### PR TITLE
Use AP_Arming ubiquitously in vehicles for vehicle arming

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -141,17 +141,17 @@ void Rover::loop()
     G_Dt = scheduler.get_last_loop_time_s();
 }
 
-void Rover::update_soft_armed()
+void AP_Arming_Rover::update_soft_armed()
 {
-    hal.util->set_soft_armed(arming.is_armed() &&
+    hal.util->set_soft_armed(is_armed() &&
                              hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
-    logger.set_vehicle_armed(hal.util->get_soft_armed());
+    AP::logger().set_vehicle_armed(hal.util->get_soft_armed());
 }
 
 // update AHRS system
 void Rover::ahrs_update()
 {
-    update_soft_armed();
+    arming.update_soft_armed();
 
 #if HIL_MODE != HIL_MODE_DISABLED
     // update hil before AHRS update

--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -81,6 +81,10 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
 
 bool AP_Arming_Rover::pre_arm_checks(bool report)
 {
+    //are arming checks disabled?
+    if (checks_to_perform == ARMING_CHECK_NONE) {
+        return true;
+    }
     if (SRV_Channels::get_emergency_stop()) {
         check_failed(ARMING_CHECK_NONE, report, "Motors Emergency Stopped");
         return false;
@@ -90,6 +94,15 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
             & rover.g2.motors.pre_arm_check(report)
             & fence_checks(report)
             & proximity_check(report));
+}
+
+bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
+{
+    //are arming checks disabled?
+    if (checks_to_perform == ARMING_CHECK_NONE) {
+        return true;
+    }
+    return AP_Arming::arm_checks(method);
 }
 
 // check nothing is too close to vehicle

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -17,6 +17,7 @@ public:
     AP_Arming_Rover &operator=(const AP_Arming_Rover&) = delete;
 
     bool pre_arm_checks(bool report) override;
+    bool arm_checks(AP_Arming::Method method) override;
     bool pre_arm_rc_checks(const bool display_failure);
     bool gps_checks(bool display_failure) override;
 

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -20,9 +20,15 @@ public:
     bool pre_arm_rc_checks(const bool display_failure);
     bool gps_checks(bool display_failure) override;
 
+    bool disarm() override;
+    bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;
+
+    void update_soft_armed();
+
 protected:
     bool proximity_check(bool report);
 
 private:
 
+    void change_arm_state(void);
 };

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -584,23 +584,6 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
         }
         return MAV_RESULT_FAILED;
 
-    case MAV_CMD_COMPONENT_ARM_DISARM:
-        if (is_equal(packet.param1, 1.0f)) {
-            // run pre_arm_checks and arm_checks and display failures
-            if (rover.arm_motors(AP_Arming::Method::MAVLINK)) {
-                return MAV_RESULT_ACCEPTED;
-            } else {
-                return MAV_RESULT_FAILED;
-            }
-        } else if (is_zero(packet.param1))  {
-            if (rover.disarm_motors()) {
-                return MAV_RESULT_ACCEPTED;
-            } else {
-                return MAV_RESULT_FAILED;
-            }
-        }
-        return MAV_RESULT_UNSUPPORTED;
-
     case MAV_CMD_DO_CHANGE_SPEED:
         // param1 : unused
         // param2 : new speed in m/s

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -4,24 +4,6 @@
 
 #if LOGGING_ENABLED == ENABLED
 
-struct PACKED log_Arm_Disarm {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t  arm_state;
-    uint16_t arm_checks;
-};
-
-void Rover::Log_Write_Arm_Disarm()
-{
-    struct log_Arm_Disarm pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_ARM_DISARM_MSG),
-        time_us                 : AP_HAL::micros64(),
-        arm_state               : arming.is_armed(),
-        arm_checks              : arming.get_enabled_checks()
-    };
-    logger.WriteBlock(&pkt, sizeof(pkt));
-}
-
 // Write an attitude packet
 void Rover::Log_Write_Attitude()
 {
@@ -310,8 +292,6 @@ const LogStructure Rover::log_structure[] = {
       "NTUN", "QfHHHf", "TimeUS,WpDist,WpBrg,DesYaw,Yaw,XTrack", "smdddm", "F0BBB0" },
     { LOG_RANGEFINDER_MSG, sizeof(log_Rangefinder),
       "RGFD", "QfHHHbHCb",  "TimeUS,LatAcc,R1Dist,R2Dist,DCnt,TAng,TTim,Spd,Thr", "somm-hsm-", "F0BB-0CB-" },
-    { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),
-      "ARM", "QBH", "TimeUS,ArmState,ArmChecks", "s--", "F--" },
     { LOG_STEERING_MSG, sizeof(log_Steering),
       "STER", "Qhfffff",   "TimeUS,SteerIn,SteerOut,DesLatAcc,LatAcc,DesTurnRate,TurnRate", "s--ookk", "F--0000" },
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
@@ -326,7 +306,6 @@ void Rover::log_init(void)
 #else  // LOGGING_ENABLED
 
 // dummy functions
-void Rover::Log_Write_Arm_Disarm() {}
 void Rover::Log_Write_Attitude() {}
 void Rover::Log_Write_Depth() {}
 void Rover::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}

--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -134,15 +134,6 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
         }
         break;
 
-    // arm or disarm the motors
-    case AUX_FUNC::ARMDISARM:
-        if (ch_flag == HIGH) {
-            rover.arm_motors(AP_Arming::Method::RUDDER);
-        } else if (ch_flag == LOW) {
-            rover.disarm_motors();
-        }
-        break;
-
     // set mode to Manual
     case AUX_FUNC::MANUAL:
         do_aux_function_change_mode(rover.mode_manual, ch_flag);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -420,7 +420,6 @@ private:
     void send_wheel_encoder_distance(mavlink_channel_t chan);
 
     // Log.cpp
-    void Log_Write_Arm_Disarm();
     void Log_Write_Attitude();
     void Log_Write_Depth();
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
@@ -489,9 +488,6 @@ private:
     void notify_mode(const Mode *new_mode);
     uint8_t check_digital_pin(uint8_t pin);
     bool should_log(uint32_t mask);
-    void change_arm_state(void);
-    bool arm_motors(AP_Arming::Method method);
-    bool disarm_motors(void);
     bool is_boat() const;
 
     enum Failsafe_Action {
@@ -519,7 +515,6 @@ private:
 public:
     void mavlink_delay_cb();
     void failsafe_check();
-    void update_soft_armed();
     // Motor test
     void motor_test_output();
     bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value);

--- a/APMrover2/afs_rover.cpp
+++ b/APMrover2/afs_rover.cpp
@@ -18,7 +18,7 @@ AP_AdvancedFailsafe_Rover::AP_AdvancedFailsafe_Rover(AP_Mission &_mission, const
 void AP_AdvancedFailsafe_Rover::terminate_vehicle(void)
 {
     // disarm as well
-    rover.disarm_motors();
+    AP::arming().disarm();
 
     // Set to HOLD mode
     rover.set_mode(rover.mode_hold, MODE_REASON_CRASH_FAILSAFE);

--- a/APMrover2/crash_check.cpp
+++ b/APMrover2/crash_check.cpp
@@ -51,14 +51,14 @@ void Rover::crash_check()
         if (is_balancebot()) {
             // send message to gcs
             gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash: Disarming");
-            disarm_motors();
+            arming.disarm();
         } else {
             // send message to gcs
             gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash: Going to HOLD");
             // change mode to hold and disarm
             set_mode(mode_hold, MODE_REASON_CRASH_FAILSAFE);
             if (g.fs_crash_check == FS_CRASH_HOLD_AND_DISARM) {
-                disarm_motors();
+                arming.disarm();
             }
         }
     }

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -26,7 +26,6 @@
 #define LOG_NTUN_MSG            0x02
 #define LOG_STARTUP_MSG         0x06
 #define LOG_RANGEFINDER_MSG     0x07
-#define LOG_ARM_DISARM_MSG      0x08
 #define LOG_STEERING_MSG        0x0D
 #define LOG_GUIDEDTARGET_MSG    0x0E
 
@@ -48,7 +47,7 @@
 #define MASK_LOG_CAMERA         (1<<12)
 #define MASK_LOG_STEERING       (1<<13)
 #define MASK_LOG_RC             (1<<14)
-#define MASK_LOG_ARM_DISARM     (1<<15)
+// #define MASK_LOG_ARM_DISARM     (1<<15)
 #define MASK_LOG_IMU_RAW        (1UL<<19)
 
 // for mavlink SET_POSITION_TARGET messages

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -35,7 +35,7 @@ void Rover::failsafe_check()
         // To-Do: log error
         if (arming.is_armed()) {
             // disarm motors
-            disarm_motors();
+            arming.disarm();
         }
     }
 }
@@ -135,7 +135,7 @@ void Rover::handle_battery_failsafe(const char* type_str, const int8_t action)
                 snprintf(battery_type_str, 17, "%s battery", type_str);
                 g2.afs.gcs_terminate(true, battery_type_str);
 #else
-                disarm_motors();
+                arming.disarm();
 #endif // ADVANCED_FAILSAFE == ENABLED
                 break;
         }

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -126,7 +126,7 @@ MAV_RESULT Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor
 
             // arm motors
             if (!arming.is_armed()) {
-                arm_motors(AP_Arming::Method::MOTORTEST);
+                arming.arm(AP_Arming::Method::MOTORTEST);
             }
 
             // disable failsafes
@@ -161,7 +161,7 @@ void Rover::motor_test_stop()
     }
 
     // disarm motors
-    disarm_motors();
+    AP::arming().disarm();
 
     // reset timeout
     motor_test_start_ms = 0;

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -72,7 +72,7 @@ void Rover::rudder_arm_disarm_check()
                 }
             } else {
                 // time to arm!
-                arm_motors(AP_Arming::Method::RUDDER);
+                arming.arm(AP_Arming::Method::RUDDER);
                 rudder_arm_timer = 0;
             }
         } else {
@@ -91,7 +91,7 @@ void Rover::rudder_arm_disarm_check()
                 }
             } else {
                 // time to disarm!
-                disarm_motors();
+                arming.disarm();
                 rudder_arm_timer = 0;
             }
         } else {

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -342,6 +342,8 @@ bool AP_Arming_Rover::arm(AP_Arming::Method method, const bool do_arming_checks)
 
     change_arm_state();
 
+    gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+
     return true;
 }
 
@@ -360,6 +362,8 @@ bool AP_Arming_Rover::disarm(void)
 
     // only log if disarming was successful
     change_arm_state();
+
+    gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
 
     return true;
 }

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -315,7 +315,7 @@ bool Rover::should_log(uint32_t mask)
 /*
   update AHRS soft arm state and log as needed
  */
-void Rover::change_arm_state(void)
+void AP_Arming_Rover::change_arm_state(void)
 {
     Log_Write_Arm_Disarm();
     update_soft_armed();
@@ -324,15 +324,15 @@ void Rover::change_arm_state(void)
 /*
   arm motors
  */
-bool Rover::arm_motors(AP_Arming::Method method)
+bool AP_Arming_Rover::arm(AP_Arming::Method method, const bool do_arming_checks)
 {
-    if (!arming.arm(method)) {
+    if (!AP_Arming::arm(method, do_arming_checks)) {
         AP_Notify::events.arming_failed = true;
         return false;
     }
 
     // Set the SmartRTL home location. If activated, SmartRTL will ultimately try to land at this point
-    g2.smart_rtl.set_home(true);
+    rover.g2.smart_rtl.set_home(true);
 
     // initialize simple mode heading
     rover.mode_simple.init_heading();
@@ -341,20 +341,21 @@ bool Rover::arm_motors(AP_Arming::Method method)
     rover.g2.windvane.record_home_heading();
 
     change_arm_state();
+
     return true;
 }
 
 /*
   disarm motors
  */
-bool Rover::disarm_motors(void)
+bool AP_Arming_Rover::disarm(void)
 {
-    if (!arming.disarm()) {
+    if (!AP_Arming::disarm()) {
         return false;
     }
-    if (control_mode != &mode_auto) {
+    if (rover.control_mode != &rover.mode_auto) {
         // reset the mission on disarm if we are not in auto
-        mode_auto.mission.reset();
+        rover.mode_auto.mission.reset();
     }
 
     // only log if disarming was successful

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -9,6 +9,7 @@ def build(bld):
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AC_PID',
             'AP_Beacon',
+            'AP_Arming',
         ],
     )
 

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -12,20 +12,19 @@ void AP_Arming_Copter::update(void)
         pre_arm_display_counter = 0;
     }
 
-    set_pre_arm_check(pre_arm_checks(display_fail));
+    pre_arm_checks(display_fail);
 }
 
-// performs pre-arm checks and arming checks
-bool AP_Arming_Copter::all_checks_passing(AP_Arming::Method method)
+bool AP_Arming_Copter::pre_arm_checks(bool display_failure)
 {
-    set_pre_arm_check(pre_arm_checks(true));
-
-    return copter.ap.pre_arm_check && arm_checks(method);
+    const bool passed = run_pre_arm_checks(display_failure);
+    set_pre_arm_check(passed);
+    return passed;
 }
 
 // perform pre-arm checks
 //  return true if the checks pass successfully
-bool AP_Arming_Copter::pre_arm_checks(bool display_failure)
+bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
 {
     // exit immediately if already armed
     if (copter.motors->armed()) {

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -20,9 +20,11 @@ public:
     AP_Arming_Copter &operator=(const AP_Arming_Copter&) = delete;
 
     void update(void);
-    bool all_checks_passing(AP_Arming::Method method);
 
     bool rc_calibration_checks(bool display_failure) override;
+
+    bool disarm() override;
+    bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;
 
 protected:
 
@@ -47,5 +49,9 @@ protected:
     void set_pre_arm_check(bool b);
 
 private:
+
+    // actually contains the pre-arm checks.  This is wrapped so that
+    // we can store away success/failure of the checks.
+    bool run_pre_arm_checks(bool display_failure);
 
 };

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -756,8 +756,6 @@ private:
     // motors.cpp
     void arm_motors_check();
     void auto_disarm_check();
-    bool init_arm_motors(AP_Arming::Method method, bool do_arming_checks=true);
-    void init_disarm_motors();
     void motors_output();
     void lost_vehicle_check();
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -606,6 +606,11 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
     return GCS_MAVLINK::handle_command_mount(packet);
 }
 
+bool GCS_MAVLINK_Copter::allow_disarm() const
+{
+    return copter.ap.land_complete;
+}
+
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_long_t &packet)
 {
     switch(packet.command) {
@@ -698,26 +703,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         }
         return MAV_RESULT_FAILED;
 #endif
-
-    case MAV_CMD_COMPONENT_ARM_DISARM:
-        if (is_equal(packet.param1,1.0f)) {
-            // attempt to arm and return success or failure
-            const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
-            if (copter.init_arm_motors(AP_Arming::Method::MAVLINK, do_arming_checks)) {
-                return MAV_RESULT_ACCEPTED;
-            }
-        } else if (is_zero(packet.param1))  {
-            if (copter.ap.land_complete || is_equal(packet.param2,magic_force_disarm_value)) {
-                // force disarming by setting param2 = 21196 is deprecated
-                copter.init_disarm_motors();
-                return MAV_RESULT_ACCEPTED;
-            } else {
-                return MAV_RESULT_FAILED;
-            }
-        } else {
-            return MAV_RESULT_UNSUPPORTED;
-        }
-        return MAV_RESULT_FAILED;
 
 #if PARACHUTE == ENABLED
     case MAV_CMD_DO_PARACHUTE:
@@ -819,7 +804,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 
         if (!copter.motors->armed()) {
             // if disarmed, arm motors
-            copter.init_arm_motors(AP_Arming::Method::MAVLINK);
+            copter.arming.arm(AP_Arming::Method::MAVLINK);
         } else if (copter.ap.land_complete) {
             // if armed and landed, takeoff
             if (copter.set_mode(LOITER, MODE_REASON_GCS_COMMAND)) {
@@ -841,7 +826,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         if (copter.motors->armed()) {
             if (copter.ap.land_complete) {
                 // if landed, disarm motors
-                copter.init_disarm_motors();
+                copter.arming.disarm();
             } else {
                 // assume that shots modes are all done in guided.
                 // NOTE: this may need to change if we add a non-guided shot mode
@@ -1309,7 +1294,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_flight_termination(const mavlink_command_l
     if (GCS_MAVLINK::handle_flight_termination(packet) != MAV_RESULT_ACCEPTED) {
 #endif
         if (packet.param1 > 0.5f) {
-            copter.init_disarm_motors();
+            copter.arming.disarm();
             result = MAV_RESULT_ACCEPTED;
         }
 #if ADVANCED_FAILSAFE == ENABLED

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -43,6 +43,8 @@ protected:
     virtual MAV_VTOL_STATE vtol_state() const override { return MAV_VTOL_STATE_MC; };
     virtual MAV_LANDED_STATE landed_state() const override;
 
+    bool allow_disarm() const override;
+
 private:
 
     void handleMessage(mavlink_message_t * msg) override;

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -420,7 +420,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
             // arm or disarm the vehicle
             switch (ch_flag) {
             case HIGH:
-                copter.init_arm_motors(AP_Arming::Method::AUXSWITCH);
+                copter.arming.arm(AP_Arming::Method::AUXSWITCH);
                 // remember that we are using an arming switch, for use by set_throttle_zero_flag
                 copter.ap.armed_with_switch = true;
                 break;
@@ -428,7 +428,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
                 // nothing
                 break;
             case LOW:
-                copter.init_disarm_motors();
+                copter.arming.disarm();
                 break;
             }
             break;

--- a/ArduCopter/afs_copter.cpp
+++ b/ArduCopter/afs_copter.cpp
@@ -25,7 +25,7 @@ void AP_AdvancedFailsafe_Copter::terminate_vehicle(void)
         copter.motors->output();
 
         // disarm as well
-        copter.init_disarm_motors();
+        copter.arming.disarm();
     
         // and set all aux channels
         SRV_Channels::set_output_limit(SRV_Channel::k_heli_rsc, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);

--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -34,7 +34,7 @@ MAV_COLLISION_ACTION AP_Avoidance_Copter::handle_avoidance(const AP_Avoidance::O
 
     // if landed and we will take some kind of action, just disarm
     if ((actual_action > MAV_COLLISION_ACTION_REPORT) && copter.should_disarm_on_failsafe()) {
-        copter.init_disarm_motors();
+        copter.arming.disarm();
         actual_action = MAV_COLLISION_ACTION_NONE;
     } else {
 

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -53,7 +53,7 @@ void Copter::crash_check()
         // send message to gcs
         gcs().send_text(MAV_SEVERITY_EMERGENCY,"Crash: Disarming");
         // disarm motors
-        init_disarm_motors();
+        copter.arming.disarm();
     }
 }
 
@@ -210,7 +210,7 @@ void Copter::parachute_check()
 void Copter::parachute_release()
 {
     // disarm motors
-    init_disarm_motors();
+    arming.disarm();
 
     // release parachute
     parachute.release();

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -12,7 +12,7 @@ void Copter::failsafe_radio_on_event()
     }
 
     if (should_disarm_on_failsafe()) {
-        init_disarm_motors();
+        arming.disarm();
     } else {
         if (control_mode == AUTO && g.failsafe_throttle == FS_THR_ENABLED_CONTINUE_MISSION) {
             // continue mission
@@ -55,7 +55,7 @@ void Copter::handle_battery_failsafe(const char *type_str, const int8_t action)
 
     // failsafe check
     if (should_disarm_on_failsafe()) {
-        init_disarm_motors();
+        arming.disarm();
     } else {
         switch ((Failsafe_Action)action) {
             case Failsafe_Action_None:
@@ -78,7 +78,7 @@ void Copter::handle_battery_failsafe(const char *type_str, const int8_t action)
                 snprintf(battery_type_str, 17, "%s battery", type_str);
                 g2.afs.gcs_terminate(true, battery_type_str);
 #else
-                init_disarm_motors();
+                arming.disarm();
 #endif
         }
     }
@@ -122,7 +122,7 @@ void Copter::failsafe_gcs_check()
     RC_Channels::clear_overrides();
 
     if (should_disarm_on_failsafe()) {
-        init_disarm_motors();
+        arming.disarm();
     } else {
         if (control_mode == AUTO && g.failsafe_gcs == FS_GCS_ENABLED_CONTINUE_MISSION) {
             // continue mission
@@ -190,7 +190,7 @@ void Copter::failsafe_terrain_on_event()
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_TERRAIN, LogErrorCode::FAILSAFE_OCCURRED);
 
     if (should_disarm_on_failsafe()) {
-        init_disarm_motors();
+        arming.disarm();
 #if MODE_RTL_ENABLED == ENABLED
     } else if (control_mode == RTL) {
         mode_rtl.restart_without_terrain();

--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -30,7 +30,7 @@ void Copter::fence_check()
             // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down
             if (ap.land_complete || (flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & AC_FENCE_TYPE_ALT_MAX)== 0))){
-                init_disarm_motors();
+                arming.disarm();
 
             } else {
 

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -117,7 +117,7 @@ void Copter::set_land_complete(bool b)
     const bool mode_disarms_on_land = flightmode->allows_arming(false) && !flightmode->has_manual_throttle();
 
     if (ap.land_complete && motors->armed() && disarm_on_land_configured && mode_disarms_on_land) {
-        init_disarm_motors();
+        arming.disarm();
     }
 }
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -537,7 +537,7 @@ void Copter::ModeAuto::exit_mission()
         }
     } else {
         // if we've landed it's safe to disarm
-        copter.init_disarm_motors();
+        copter.arming.disarm();
     }
 }
 

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -55,7 +55,7 @@ void Copter::ModeLand::gps_run()
 {
     // disarm when the landing detector says we've landed
     if (ap.land_complete && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE) {
-        copter.init_disarm_motors();
+        copter.arming.disarm();
     }
 
     // Land State Machine Determination
@@ -109,7 +109,7 @@ void Copter::ModeLand::nogps_run()
 
     // disarm when the landing detector says we've landed
     if (ap.land_complete && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE) {
-        copter.init_disarm_motors();
+        copter.arming.disarm();
     }
 
     // Land State Machine Determination

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -358,7 +358,7 @@ void Copter::ModeRTL::land_run(bool disarm_on_land)
 
     // disarm when the landing detector says we've landed
     if (disarm_on_land && ap.land_complete && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE) {
-        copter.init_disarm_motors();
+        copter.arming.disarm();
     }
 
     // if not armed set throttle to zero and exit immediately

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -424,7 +424,7 @@ void ToyMode::update()
         if (throttle_high_counter >= TOY_LAND_ARM_COUNT) {
             gcs().send_text(MAV_SEVERITY_INFO, "Tmode: throttle arm");
             arm_check_compass();
-            if (!copter.init_arm_motors(AP_Arming::Method::MAVLINK) && (flags & FLAG_UPGRADE_LOITER) && copter.control_mode == LOITER) {
+            if (!copter.arming.arm(AP_Arming::Method::MAVLINK) && (flags & FLAG_UPGRADE_LOITER) && copter.control_mode == LOITER) {
                 /*
                   support auto-switching to ALT_HOLD, then upgrade to LOITER once GPS available
                  */
@@ -433,7 +433,7 @@ void ToyMode::update()
 #if AC_FENCE == ENABLED
                     copter.fence.enable(false);
 #endif
-                    if (!copter.init_arm_motors(AP_Arming::Method::MAVLINK)) {
+                    if (!copter.arming.arm(AP_Arming::Method::MAVLINK)) {
                         // go back to LOITER
                         gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: ALT_HOLD arm failed");
                         set_and_remember_mode(LOITER, MODE_REASON_TMODE);
@@ -625,7 +625,7 @@ void ToyMode::update()
 #if AC_FENCE == ENABLED
             copter.fence.enable(false);
 #endif
-            if (copter.init_arm_motors(AP_Arming::Method::MAVLINK)) {
+            if (copter.arming.arm(AP_Arming::Method::MAVLINK)) {
                 load_test.running = true;
                 gcs().send_text(MAV_SEVERITY_INFO, "Tmode: load_test on");
             } else {
@@ -803,7 +803,7 @@ void ToyMode::action_arm(void)
         // we want GPS and checks are passing, arm and enable fence
         copter.fence.enable(true);
 #endif
-        copter.init_arm_motors(AP_Arming::Method::RUDDER);
+        copter.arming.arm(AP_Arming::Method::RUDDER);
         if (!copter.motors->armed()) {
             AP_Notify::events.arming_failed = true;
             gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: GPS arming failed");
@@ -819,7 +819,7 @@ void ToyMode::action_arm(void)
         // non-GPS mode
         copter.fence.enable(false);
 #endif
-        copter.init_arm_motors(AP_Arming::Method::RUDDER);
+        copter.arming.arm(AP_Arming::Method::RUDDER);
         if (!copter.motors->armed()) {
             AP_Notify::events.arming_failed = true;
             gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: non-GPS arming failed");

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -19,6 +19,10 @@ const AP_Param::GroupInfo AP_Arming_Plane::var_info[] = {
  */
 bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
 {
+    //are arming checks disabled?
+    if (checks_to_perform == ARMING_CHECK_NONE) {
+        return true;
+    }
     if (hal.util->was_watchdog_armed()) {
         // on watchdog reset bypass arming checks to allow for
         // in-flight arming if we were armed before the reset. This
@@ -128,6 +132,11 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
 
 bool AP_Arming_Plane::arm_checks(AP_Arming::Method method)
 {
+    //are arming checks disabled?
+    if (checks_to_perform == ARMING_CHECK_NONE) {
+        return true;
+    }
+
     if (hal.util->was_watchdog_armed()) {
         // on watchdog reset bypass arming checks to allow for
         // in-flight arming if we were armed before the reset. This

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -24,7 +24,14 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
+    bool disarm() override;
+    bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;
+
+    void update_soft_armed();
+
 protected:
     bool ins_checks(bool report) override;
 
+private:
+    void change_arm_state(void);
 };

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -129,17 +129,17 @@ void Plane::loop()
     G_Dt = scheduler.get_loop_period_s();
 }
 
-void Plane::update_soft_armed()
+void AP_Arming_Plane::update_soft_armed()
 {
-    hal.util->set_soft_armed(arming.is_armed() &&
+    hal.util->set_soft_armed(is_armed() &&
                              hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
-    logger.set_vehicle_armed(hal.util->get_soft_armed());
+    AP::logger().set_vehicle_armed(hal.util->get_soft_armed());
 }
 
 // update AHRS system
 void Plane::ahrs_update()
 {
-    update_soft_armed();
+    arming.update_soft_armed();
 
 #if HIL_SUPPORT
     if (g.hil_mode == 1) {
@@ -671,7 +671,7 @@ void Plane::disarm_if_autoland_complete()
         arming.is_armed()) {
         /* we have auto disarm enabled. See if enough time has passed */
         if (millis() - auto_state.last_flying_ms >= landing.get_disarm_delay()*1000UL) {
-            if (disarm_motors()) {
+            if (arming.disarm()) {
                 gcs().send_text(MAV_SEVERITY_INFO,"Auto disarmed");
             }
         }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -851,22 +851,6 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
         plane.set_mode(plane.mode_auto, MODE_REASON_GCS_COMMAND);
         return MAV_RESULT_ACCEPTED;
 
-    case MAV_CMD_COMPONENT_ARM_DISARM:
-        if (is_equal(packet.param1,1.0f)) {
-            // run pre_arm_checks and arm_checks and display failures
-            const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
-            if (plane.arm_motors(AP_Arming::Method::MAVLINK, do_arming_checks)) {
-                return MAV_RESULT_ACCEPTED;
-            }
-            return MAV_RESULT_FAILED;
-        } else if (is_zero(packet.param1))  {
-            if (plane.disarm_motors()) {
-                return MAV_RESULT_ACCEPTED;
-            }
-            return MAV_RESULT_FAILED;
-        }
-        return MAV_RESULT_UNSUPPORTED;
-
     case MAV_CMD_DO_LAND_START:
         // attempt to switch to next DO_LAND_START command in the mission
         if (plane.mission.jump_to_landing_sequence()) {

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -210,24 +210,6 @@ void Plane::Log_Write_Sonar()
     logger.WriteBlock(&pkt, sizeof(pkt));
 }
 
-struct PACKED log_Arm_Disarm {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t  arm_state;
-    uint16_t arm_checks;
-};
-
-void Plane::Log_Arm_Disarm() {
-    struct log_Arm_Disarm pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_ARM_DISARM_MSG),
-        time_us                 : AP_HAL::micros64(),
-        arm_state               : arming.is_armed(),
-        arm_checks              : arming.get_enabled_checks()      
-    };
-    logger.WriteCriticalBlock(&pkt, sizeof(pkt));
-}
-
-
 struct PACKED log_AETR {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -276,8 +258,6 @@ const struct LogStructure Plane::log_structure[] = {
       "NTUN", "QfcccfffLLii",  "TimeUS,Dist,TBrg,NavBrg,AltErr,XT,XTi,AspdE,TLat,TLng,TAlt,TAspd", "smddmmmnDUmn", "F0BBB0B0GGBB" },
     { LOG_SONAR_MSG, sizeof(log_Sonar),             
       "SONR", "QffBf",   "TimeUS,Dist,Volt,Cnt,Corr", "smv--", "FB0--" },
-    { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),
-      "ARM", "QBH", "TimeUS,ArmState,ArmChecks", "s--", "F--" },
     { LOG_ATRP_MSG, sizeof(AP_AutoTune::log_ATRP),
       "ATRP", "QBBcfff",  "TimeUS,Type,State,Servo,Demanded,Achieved,P", "s---dd-", "F---00-" },
     { LOG_STATUS_MSG, sizeof(log_Status),
@@ -326,7 +306,6 @@ void Plane::Log_Write_Nav_Tuning() {}
 void Plane::Log_Write_Status() {}
 void Plane::Log_Write_Sonar() {}
 
-void Plane::Log_Arm_Disarm() {}
 void Plane::Log_Write_RC(void) {}
 void Plane::Log_Write_Vehicle_Startup_Messages() {}
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -829,7 +829,6 @@ private:
     void Log_Write_Nav_Tuning();
     void Log_Write_Status();
     void Log_Write_Sonar();
-    void Log_Arm_Disarm();
     void Log_Write_RC(void);
     void Log_Write_Vehicle_Startup_Messages();
     void Log_Write_AOA_SSA();
@@ -947,9 +946,6 @@ private:
     void startup_INS_ground(void);
     bool should_log(uint32_t mask);
     int8_t throttle_percentage(void);
-    void change_arm_state(void);
-    bool disarm_motors(void);
-    bool arm_motors(AP_Arming::Method method, bool do_arming_checks=true);
     bool auto_takeoff_check(void);
     void takeoff_calc_roll(void);
     void takeoff_calc_pitch(void);
@@ -1052,7 +1048,6 @@ private:
     void publish_osd_info();
 #endif
     void accel_cal_update(void);
-    void update_soft_armed();
 #if SOARING_ENABLED == ENABLED
     void update_soaring();
 #endif

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -58,20 +58,6 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
 void RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
 {
     switch(ch_option) {
-    case AUX_FUNC::ARMDISARM:
-        // arm or disarm the vehicle
-        switch (ch_flag) {
-        case HIGH:
-            plane.arm_motors(AP_Arming::Method::AUXSWITCH, true);
-            break;
-        case MIDDLE:
-            // nothing
-            break;
-        case LOW:
-            plane.disarm_motors();
-            break;
-        }
-        break;
     case AUX_FUNC::INVERTED:
         plane.inverted_flight = (ch_flag == HIGH);
         break;

--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -47,7 +47,7 @@ void AP_AdvancedFailsafe_Plane::terminate_vehicle(void)
     plane.quadplane.afs_terminate();
     
     // also disarm to ensure that ignition is cut
-    plane.disarm_motors();
+    plane.arming.disarm();
 }
 
 void AP_AdvancedFailsafe_Plane::setup_IO_failsafe(void)

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -555,7 +555,7 @@ bool Plane::verify_takeoff()
             uint32_t now = AP_HAL::millis();
             if (now - takeoff_state.start_time_ms > (uint32_t)(1000U * g2.takeoff_timeout)) {
                 gcs().send_text(MAV_SEVERITY_INFO, "Takeoff timeout at %.1f m/s", ground_speed);
-                plane.disarm_motors();
+                plane.arming.disarm();
                 mission.reset();
             }
         }

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -117,7 +117,6 @@ enum log_messages {
     TYPE_GROUNDSTART_MSG,
     LOG_RC_MSG,
     LOG_SONAR_MSG,
-    LOG_ARM_DISARM_MSG,
     LOG_STATUS_MSG,
     LOG_QTUN_MSG,
     LOG_PARAMTUNE_MSG,
@@ -145,7 +144,7 @@ enum log_messages {
 #define MASK_LOG_CAMERA                 (1<<12)
 #define MASK_LOG_RC                     (1<<13)
 #define MASK_LOG_SONAR                  (1<<14)
-#define MASK_LOG_ARM_DISARM             (1<<15)
+// #define MASK_LOG_ARM_DISARM             (1<<15)
 #define MASK_LOG_IMU_RAW                (1UL<<19)
 
 // altitude control algorithms

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -174,7 +174,7 @@ void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)
             snprintf(battery_type_str, 17, "%s battery", type_str);
             afs.gcs_terminate(true, battery_type_str);
 #else
-            disarm_motors();
+            arming.disarm();
 #endif
             break;
 

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -305,7 +305,7 @@ void Plane::crash_detection_update(void)
         }
         else {
             if (aparm.crash_detection_enable & CRASH_DETECT_ACTION_BITMASK_DISARM) {
-                disarm_motors();
+                arming.disarm();
             }
             if (crashed_near_land_waypoint) {
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected");

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2543,7 +2543,7 @@ void QuadPlane::check_land_complete(void)
         return;
     }
     if (land_detector(4000)) {
-        plane.disarm_motors();
+        plane.arming.disarm();
         poscontrol.state = QPOS_LAND_COMPLETE;
         gcs().send_text(MAV_SEVERITY_INFO,"Land complete");
         // reload target airspeed which could have been modified by the mission

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -146,7 +146,7 @@ void Plane::rudder_arm_disarm_check()
                 }
 			} else {
 				//time to arm!
-				arm_motors(AP_Arming::Method::RUDDER);
+				arming.arm(AP_Arming::Method::RUDDER);
 				rudder_arm_timer = 0;
 			}
 		} else {
@@ -165,7 +165,7 @@ void Plane::rudder_arm_disarm_check()
                 }
 			} else {
 				//time to disarm!
-				disarm_motors();
+				arming.disarm();
 				rudder_arm_timer = 0;
 			}
 		} else {

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -456,21 +456,18 @@ int8_t Plane::throttle_percentage(void)
 }
 
 /*
-  update AHRS soft arm state and log as needed
- */
-void Plane::change_arm_state(void)
+  update HAL soft arm state and log as needed
+*/
+void AP_Arming_Plane::change_arm_state(void)
 {
-    Log_Arm_Disarm();
+    Log_Write_Arm_Disarm();
     update_soft_armed();
-    quadplane.set_armed(hal.util->get_soft_armed());
+    plane.quadplane.set_armed(hal.util->get_soft_armed());
 }
 
-/*
-  arm motors
- */
-bool Plane::arm_motors(const AP_Arming::Method method, const bool do_arming_checks)
+bool AP_Arming_Plane::arm(const AP_Arming::Method method, const bool do_arming_checks)
 {
-    if (!arming.arm(method, do_arming_checks)) {
+    if (!AP_Arming::arm(method, do_arming_checks)) {
         return false;
     }
 
@@ -481,18 +478,18 @@ bool Plane::arm_motors(const AP_Arming::Method method, const bool do_arming_chec
 /*
   disarm motors
  */
-bool Plane::disarm_motors(void)
+bool AP_Arming_Plane::disarm(void)
 {
-    if (!arming.disarm()) {
+    if (!AP_Arming::disarm()) {
         return false;
     }
-    if (control_mode != &mode_auto) {
+    if (plane.control_mode != &plane.mode_auto) {
         // reset the mission on disarm if we are not in auto
-        mission.reset();
+        plane.mission.reset();
     }
 
     // suppress the throttle in auto-throttle modes
-    throttle_suppressed = auto_throttle_mode;
+    plane.throttle_suppressed = plane.auto_throttle_mode;
     
     //only log if disarming was successful
     change_arm_state();
@@ -502,10 +499,10 @@ bool Plane::disarm_motors(void)
     
 #if QAUTOTUNE_ENABLED
     //save qautotune gains if enabled and success
-    if (control_mode == &mode_qautotune) {
-        quadplane.qautotune.save_tuning_gains();
+    if (plane.control_mode == &plane.mode_qautotune) {
+        plane.quadplane.qautotune.save_tuning_gains();
     } else {
-        quadplane.qautotune.reset();
+        plane.quadplane.qautotune.reset();
     }
 #endif
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -472,6 +472,9 @@ bool AP_Arming_Plane::arm(const AP_Arming::Method method, const bool do_arming_c
     }
 
     change_arm_state();
+
+    gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+
     return true;
 }
 
@@ -505,6 +508,8 @@ bool AP_Arming_Plane::disarm(void)
         plane.quadplane.qautotune.reset();
     }
 #endif
+
+    gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
 
     return true;
 }

--- a/ArduSub/AP_Arming_Sub.h
+++ b/ArduSub/AP_Arming_Sub.h
@@ -14,6 +14,9 @@ public:
     bool rc_calibration_checks(bool display_failure) override;
     bool pre_arm_checks(bool display_failure) override;
 
+    bool disarm() override;
+    bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;
+
 protected:
     bool ins_checks(bool display_failure) override;
 };

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -511,22 +511,6 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_long_packet(const mavlink_command_lon
         }
         return MAV_RESULT_FAILED;
 
-    case MAV_CMD_COMPONENT_ARM_DISARM:
-        if (is_equal(packet.param1,1.0f)) {
-            // attempt to arm and return success or failure
-            if (sub.init_arm_motors(AP_Arming::Method::MAVLINK)) {
-                return MAV_RESULT_ACCEPTED;
-            }
-        } else if (is_zero(packet.param1))  {
-            // force disarming by setting param2 = 21196 is deprecated
-            // see COMMAND_LONG DO_FLIGHTTERMINATION
-            sub.init_disarm_motors();
-            return MAV_RESULT_ACCEPTED;
-        } else {
-            return MAV_RESULT_UNSUPPORTED;
-        }
-        return MAV_RESULT_FAILED;
-
     case MAV_CMD_DO_MOTOR_TEST:
         // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
         // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
@@ -850,7 +834,7 @@ void Sub::mavlink_delay_cb()
 
 MAV_RESULT GCS_MAVLINK_Sub::handle_flight_termination(const mavlink_command_long_t &packet) {
     if (packet.param1 > 0.5f) {
-        sub.init_disarm_motors();
+        sub.arming.disarm();
         return MAV_RESULT_ACCEPTED;
     }
     return MAV_RESULT_FAILED;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -588,8 +588,6 @@ private:
     void update_surface_and_bottom_detector();
     void set_surfaced(bool at_surface);
     void set_bottomed(bool at_bottom);
-    bool init_arm_motors(AP_Arming::Method method);
-    void init_disarm_motors();
     void motors_output();
     Vector3f pv_location_to_vector(const Location& loc);
     float pv_alt_above_origin(float alt_above_home_cm);

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -92,7 +92,7 @@ void Sub::failsafe_sensors_check()
         // This should always succeed
         if (!set_mode(MANUAL, MODE_REASON_BAD_DEPTH)) {
             // We should never get here
-            init_disarm_motors();
+            arming.disarm();
         }
     }
 }
@@ -146,7 +146,7 @@ void Sub::failsafe_ekf_check()
     }
 
     if (g.fs_ekf_action == FS_EKF_ACTION_DISARM) {
-        init_disarm_motors();
+        arming.disarm();
     }
 }
 
@@ -160,7 +160,7 @@ void Sub::handle_battery_failsafe(const char* type_str, const int8_t action)
             set_mode(SURFACE, MODE_REASON_BATTERY_FAILSAFE);
             break;
         case Failsafe_Action_Disarm:
-            init_disarm_motors();
+            arming.disarm();
             break;
         case Failsafe_Action_Warn:
         case Failsafe_Action_None:
@@ -194,7 +194,7 @@ void Sub::failsafe_pilot_input_check()
     set_neutral_controls();
 
     if(g.failsafe_pilot_input == FS_PILOT_INPUT_DISARM) {
-        init_disarm_motors();
+        arming.disarm();
     }
 #endif
 }
@@ -345,14 +345,14 @@ void Sub::failsafe_gcs_check()
 
     // handle failsafe action
     if (g.failsafe_gcs == FS_GCS_DISARM) {
-        init_disarm_motors();
+        arming.disarm();
     } else if (g.failsafe_gcs == FS_GCS_HOLD && motors.armed()) {
         if (!set_mode(ALT_HOLD, MODE_REASON_GCS_FAILSAFE)) {
-            init_disarm_motors();
+            arming.disarm();
         }
     } else if (g.failsafe_gcs == FS_GCS_SURFACE && motors.armed()) {
         if (!set_mode(SURFACE, MODE_REASON_GCS_FAILSAFE)) {
-            init_disarm_motors();
+            arming.disarm();
         }
     }
 }
@@ -411,7 +411,7 @@ void Sub::failsafe_crash_check()
 
     // disarm motors
     if (g.fs_crash_check == FS_CRASH_DISARM) {
-        init_disarm_motors();
+        arming.disarm();
     }
 }
 
@@ -490,6 +490,6 @@ void Sub::failsafe_terrain_act()
 
     case FS_TERRAIN_DISARM:
     default:
-        init_disarm_motors();
+        arming.disarm();
     }
 }

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -128,16 +128,16 @@ void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
     switch (get_button(button)->function(shift)) {
     case JSButton::button_function_t::k_arm_toggle:
         if (motors.armed()) {
-            init_disarm_motors();
+            arming.disarm();
         } else {
-            init_arm_motors(AP_Arming::Method::MAVLINK);
+            arming.arm(AP_Arming::Method::MAVLINK);
         }
         break;
     case JSButton::button_function_t::k_arm:
-        init_arm_motors(AP_Arming::Method::MAVLINK);
+        arming.arm(AP_Arming::Method::MAVLINK);
         break;
     case JSButton::button_function_t::k_disarm:
-        init_disarm_motors();
+        arming.disarm();
         break;
 
     case JSButton::button_function_t::k_mode_manual:

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -6,9 +6,7 @@ void Sub::enable_motor_output()
     motors.output_min();
 }
 
-// init_arm_motors - performs arming process including initialisation of barometer and gyros
-//  returns false if arming failed because of pre-arm checks, arming checks or a gyro calibration failure
-bool Sub::init_arm_motors(AP_Arming::Method method)
+bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
 {
     static bool in_arm_motors = false;
 
@@ -19,7 +17,7 @@ bool Sub::init_arm_motors(AP_Arming::Method method)
 
     in_arm_motors = true;
 
-    if (!arming.pre_arm_checks(true)) {
+    if (!AP_Arming::arm(method, do_arming_checks)) {
         AP_Notify::events.arming_failed = true;
         in_arm_motors = false;
         return false;
@@ -29,20 +27,22 @@ bool Sub::init_arm_motors(AP_Arming::Method method)
     AP::logger().set_vehicle_armed(true);
 
     // disable cpu failsafe because initialising everything takes a while
-    mainloop_failsafe_disable();
+    sub.mainloop_failsafe_disable();
 
     // notify that arming will occur (we do this early to give plenty of warning)
     AP_Notify::flags.armed = true;
     // call notify update a few times to ensure the message gets out
     for (uint8_t i=0; i<=10; i++) {
-        notify.update();
+        AP::notify().update();
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     gcs().send_text(MAV_SEVERITY_INFO, "Arming motors");
 #endif
 
-    initial_armed_bearing = ahrs.yaw_sensor;
+    AP_AHRS &ahrs = AP::ahrs();
+
+    sub.initial_armed_bearing = ahrs.yaw_sensor;
 
     if (!ahrs.home_is_set()) {
         // Reset EKF altitude if home hasn't been set yet (we use EKF altitude as substitute for alt above home)
@@ -52,7 +52,7 @@ bool Sub::init_arm_motors(AP_Arming::Method method)
         // Log_Write_Event(DATA_EKF_ALT_RESET);
     } else if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         // Reset home position if it has already been set before (but not locked)
-        if (!set_home_to_current_location(false)) {
+        if (!sub.set_home_to_current_location(false)) {
             // ignore this failure
         }
     }
@@ -62,21 +62,21 @@ bool Sub::init_arm_motors(AP_Arming::Method method)
     hal.util->set_soft_armed(true);
 
     // enable output to motors
-    enable_motor_output();
+    sub.enable_motor_output();
 
     // finally actually arm the motors
-    motors.armed(true);
+    sub.motors.armed(true);
 
-    Log_Write_Event(DATA_ARMED);
+    AP::logger().Write_Event(DATA_ARMED);
 
     // log flight mode in case it was changed while vehicle was disarmed
-    logger.Write_Mode(control_mode, control_mode_reason);
+    AP::logger().Write_Mode(sub.control_mode, sub.control_mode_reason);
 
     // reenable failsafe
-    mainloop_failsafe_enable();
+    sub.mainloop_failsafe_enable();
 
     // perf monitor ignores delay due to arming
-    scheduler.perf_info.ignore_this_loop();
+    AP::scheduler().perf_info.ignore_this_loop();
 
     // flag exiting this function
     in_arm_motors = false;
@@ -85,35 +85,40 @@ bool Sub::init_arm_motors(AP_Arming::Method method)
     return true;
 }
 
-// init_disarm_motors - disarm motors
-void Sub::init_disarm_motors()
+bool AP_Arming_Sub::disarm()
 {
     // return immediately if we are already disarmed
-    if (!motors.armed()) {
-        return;
+    if (!sub.motors.armed()) {
+        return false;
+    }
+
+    if (!AP_Arming::disarm()) {
+        return false;
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     gcs().send_text(MAV_SEVERITY_INFO, "Disarming motors");
 #endif
 
+    AP_AHRS_NavEKF &ahrs = AP::ahrs_navekf();
+
     // save compass offsets learned by the EKF if enabled
-    if (ahrs.use_compass() && compass.get_learn_type() == Compass::LEARN_EKF) {
+    if (ahrs.use_compass() && AP::compass().get_learn_type() == Compass::LEARN_EKF) {
         for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
             Vector3f magOffsets;
             if (ahrs.getMagOffsets(i, magOffsets)) {
-                compass.set_and_save_offsets(i, magOffsets);
+                AP::compass().set_and_save_offsets(i, magOffsets);
             }
         }
     }
 
-    Log_Write_Event(DATA_DISARMED);
+    AP::logger().Write_Event(DATA_DISARMED);
 
     // send disarm command to motors
-    motors.armed(false);
+    sub.motors.armed(false);
 
     // reset the mission
-    mission.reset();
+    sub.mission.reset();
 
     AP::logger().set_vehicle_armed(false);
 
@@ -122,7 +127,9 @@ void Sub::init_disarm_motors()
     hal.util->set_soft_armed(false);
 
     // clear input holds
-    clear_input_hold();
+    sub.clear_input_hold();
+
+    return true;
 }
 
 // motors_output - send output to motors library which will adjust and send to ESCs and servos

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -14,6 +14,7 @@ def build(bld):
         ap_vehicle=vehicle,
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AP_Beacon',
+            'AP_Arming',
         ],
     )
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -115,6 +115,11 @@ extern AP_IOMCU iomcu;
 
 AP_Arming::AP_Arming()
 {
+    if (_singleton) {
+        AP_HAL::panic("Too many AP_Arming instances");
+    }
+    _singleton = this;
+
     AP_Param::setup_object_defaults(this, var_info);
 }
 
@@ -894,3 +899,22 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
     }
     return ret;
 }
+
+AP_Arming *AP_Arming::_singleton = nullptr;
+
+/*
+ * Get the AP_InertialSensor singleton
+ */
+AP_Arming *AP_Arming::get_singleton()
+{
+    return AP_Arming::_singleton;
+}
+
+namespace AP {
+
+AP_Arming &arming()
+{
+    return *AP_Arming::get_singleton();
+}
+
+};

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -796,8 +796,6 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
     if (!do_arming_checks || (pre_arm_checks(true) && arm_checks(method))) {
         armed = true;
 
-        gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
-
         //TODO: Log motor arming
         //Can't do this from this class until there is a unified logging library
 
@@ -815,8 +813,6 @@ bool AP_Arming::disarm()
         return false;
     }
     armed = false;
-
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
 
 #if HAL_HAVE_SAFETY_SWITCH
     AP_BoardConfig *board_cfg = AP_BoardConfig::get_singleton();

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -797,14 +797,7 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         return false;
     }
 
-    //are arming checks disabled?
-    if (!do_arming_checks || checks_to_perform == ARMING_CHECK_NONE) {
-        armed = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
-        return true;
-    }
-
-    if (pre_arm_checks(true) && arm_checks(method)) {
+    if (!do_arming_checks || (pre_arm_checks(true) && arm_checks(method))) {
         armed = true;
 
         gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -789,10 +789,6 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
 //returns true if arming occurred successfully
 bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
 {
-#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
-    // Copter should never use this function
-    return false;
-#else
     if (armed) { //already armed
         return false;
     }
@@ -810,16 +806,11 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
     }
 
     return armed;
-#endif
 }
 
 //returns true if disarming occurred successfully
 bool AP_Arming::disarm() 
 {
-#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
-    // Copter should never use this function
-    return false;
-#else
     if (!armed) { // already disarmed
         return false;
     }
@@ -839,7 +830,6 @@ bool AP_Arming::disarm()
     //Can't do this from this class until there is a unified logging library.
 
     return true;
-#endif
 }
 
 AP_Arming::Required AP_Arming::arming_required() 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -900,6 +900,17 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
     return ret;
 }
 
+void AP_Arming::Log_Write_Arm_Disarm()
+{
+    struct log_Arm_Disarm pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_ARM_DISARM_MSG),
+        time_us                 : AP_HAL::micros64(),
+        arm_state               : is_armed(),
+        arm_checks              : get_enabled_checks()
+    };
+    AP::logger().WriteCriticalBlock(&pkt, sizeof(pkt));
+}
+
 AP_Arming *AP_Arming::_singleton = nullptr;
 
 /*

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -14,6 +14,8 @@ public:
     AP_Arming(const AP_Arming &other) = delete;
     AP_Arming &operator=(const AP_Arming&) = delete;
 
+    static AP_Arming *get_singleton();
+
     enum ArmingChecks {
         ARMING_CHECK_NONE       = 0x0000,
         ARMING_CHECK_ALL        = 0x0001,
@@ -133,6 +135,8 @@ protected:
 
 private:
 
+    static AP_Arming *_singleton;
+
     bool ins_accels_consistent(const AP_InertialSensor &ins);
     bool ins_gyros_consistent(const AP_InertialSensor &ins);
 
@@ -145,4 +149,8 @@ private:
         MIS_ITEM_CHECK_RALLY         = (1 << 5),
         MIS_ITEM_CHECK_MAX
     };
+};
+
+namespace AP {
+    AP_Arming &arming();
 };

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -51,7 +51,7 @@ public:
     // these functions should not be used by Copter which holds the armed state in the motors library
     Required arming_required();
     virtual bool arm(AP_Arming::Method method, bool do_arming_checks=true);
-    bool disarm();
+    virtual bool disarm();
     bool is_armed();
 
     // get bitmask of enabled checks
@@ -132,6 +132,8 @@ protected:
     MAV_SEVERITY check_severity(const enum AP_Arming::ArmingChecks check) const;
     // handle the case where a check fails
     void check_failed(const enum AP_Arming::ArmingChecks check, bool report, const char *fmt, ...) const;
+
+    void Log_Write_Arm_Disarm();
 
 private:
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -974,8 +974,6 @@ struct PACKED log_Rate {
     float   accel_out;
 };
 
-// #if SBP_HW_LOGGING
-
 struct PACKED log_SbpLLH {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1119,7 +1117,12 @@ struct PACKED log_DSTL {
     float D;
 };
 
-// #endif // SBP_HW_LOGGING
+struct PACKED log_Arm_Disarm {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t  arm_state;
+    uint16_t arm_checks;
+};
 
 // FMT messages define all message formats other than FMT
 // UNIT messages define units which can be referenced by FMTU messages
@@ -1502,7 +1505,6 @@ Format characters in the format string for binary log messages
       "ADSB",  "QIiiiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }
 
 
-// #if SBP_HW_LOGGING
 #define LOG_SBP_STRUCTURES \
     { LOG_MSG_SBPHEALTH, sizeof(log_SbpHealth), \
       "SBPH", "QIII", "TimeUS,CrcError,LastInject,IARhyp", "s---", "F---" }, \
@@ -1514,10 +1516,10 @@ Format characters in the format string for binary log messages
       "EV",   "QB",           "TimeUS,Id", "s-", "F-" }, \
     { LOG_MSG_SBPEVENT, sizeof(log_SbpEvent), \
       "SBRE", "QHIiBB", "TimeUS,GWk,GMS,ns_residual,level,quality", "s?????", "F?????" }, \
+    { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm), \
+      "ARM", "QBH", "TimeUS,ArmState,ArmChecks", "s--", "F--" }, \
     { LOG_ERROR_MSG, sizeof(log_Error), \
       "ERR",   "QBB",         "TimeUS,Subsys,ECode", "s--", "F--" }
-
-// #endif
 
 #define LOG_COMMON_STRUCTURES LOG_BASE_STRUCTURES, LOG_EXTRA_STRUCTURES, LOG_SBP_STRUCTURES
 
@@ -1676,6 +1678,7 @@ enum LogMessages : uint8_t {
     LOG_MAV_MSG,
     LOG_ERROR_MSG,
     LOG_ADSB_MSG,
+    LOG_ARM_DISARM_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -451,6 +451,8 @@ protected:
     static constexpr const float magic_force_arm_value = 2989.0f;
     static constexpr const float magic_force_disarm_value = 21196.0f;
 
+    virtual bool allow_disarm() const { return true; }
+
     void manual_override(RC_Channel *c, int16_t value_in, uint16_t offset, float scaler, const uint32_t tnow, bool reversed = false);
 
 private:

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3730,6 +3730,12 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
             if (!AP::arming().is_armed()) {
                 return MAV_RESULT_ACCEPTED;
             }
+            // allow vehicle to disallow disarm.  Copter does this if
+            // the vehicle isn't considered landed.
+            if (!allow_disarm() &&
+                !is_equal(packet.param2, magic_force_disarm_value)) {
+                return MAV_RESULT_FAILED;
+            }
             if (AP::arming().disarm()) {
                 return MAV_RESULT_ACCEPTED;
             }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3720,12 +3720,16 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
         if (is_equal(packet.param1,1.0f)) {
             // run pre_arm_checks and arm_checks and display failures
             const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
-            if (AP::arming().arm(AP_Arming::Method::MAVLINK, do_arming_checks)) {
+            if (AP::arming().is_armed() ||
+                AP::arming().arm(AP_Arming::Method::MAVLINK, do_arming_checks)) {
                 return MAV_RESULT_ACCEPTED;
             }
             return MAV_RESULT_FAILED;
         }
         if (is_zero(packet.param1))  {
+            if (!AP::arming().is_armed()) {
+                return MAV_RESULT_ACCEPTED;
+            }
             if (AP::arming().disarm()) {
                 return MAV_RESULT_ACCEPTED;
             }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -16,6 +16,7 @@
  */
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Arming/AP_Arming.h>
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
@@ -3714,6 +3715,24 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     case MAV_CMD_DO_FLIGHTTERMINATION:
         result = handle_flight_termination(packet);
         break;
+
+    case MAV_CMD_COMPONENT_ARM_DISARM:
+        if (is_equal(packet.param1,1.0f)) {
+            // run pre_arm_checks and arm_checks and display failures
+            const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
+            if (AP::arming().arm(AP_Arming::Method::MAVLINK, do_arming_checks)) {
+                return MAV_RESULT_ACCEPTED;
+            }
+            return MAV_RESULT_FAILED;
+        }
+        if (is_zero(packet.param1))  {
+            if (AP::arming().disarm()) {
+                return MAV_RESULT_ACCEPTED;
+            }
+            return MAV_RESULT_FAILED;
+        }
+
+        return MAV_RESULT_UNSUPPORTED;
 
     default:
         result = MAV_RESULT_UNSUPPORTED;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -35,6 +35,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_LandingGear/AP_LandingGear.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
+#include <AP_Arming/AP_Arming.h>
 
 const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: MIN
@@ -678,6 +679,21 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
 
     case AUX_FUNC::LOST_VEHICLE_SOUND:
         do_aux_function_lost_vehicle_sound(ch_flag);
+        break;
+
+    case AUX_FUNC::ARMDISARM:
+        // arm or disarm the vehicle
+        switch (ch_flag) {
+        case HIGH:
+            AP::arming().arm(AP_Arming::Method::AUXSWITCH, true);
+            break;
+        case MIDDLE:
+            // nothing
+            break;
+        case LOW:
+            AP::arming().disarm();
+            break;
+        }
         break;
 
     case AUX_FUNC::COMPASS_LEARN:


### PR DESCRIPTION
Mostly just namespace changes from (e.g.) `Copter::init_arm_motors` to `copter.arming.arm()`, but brings the vehicles a lot closer together in terms of their arming.

Some of these commits could possibly be squashed.  Several of them are there to preserve behaviour - e.g. Plane emitting "Throttle armed" as a statustext but Copter not.

Changes in behaviour:

- MAVLink: Rover gets force-disarm and force-arm via mavlink
- MAVLink: Sub gets force-disarm and force-arm via mavlink
- MAVLink: Plane gets force-disarm
- Canonicalise on "if you try to arm via mavlink when armed then return success", similarly for disarm
- arming method for Rover's aux-channel arming corrected from rudder to auxswitch
 - BOARD_SAFETY_OPTION_SAFETY_ON_DISARM honoured on all vehicles as it is in the base class method

Allows future cleanups:
 - AP_Arming singleton allows access to vehicle arm state - at least this concept of armed
 - remove set_soft_armed in favour of AP_HAL checking AP_Arming::is_armed and hal.util->safety_switch_state
   - this will require a behavioural change from some vehicles so hal.util's concept of armed is common between our vehicles
   - elimination of update_soft_armed methods
 - moving of proximity prearm check up (so Rover can use it)
 - Copter's AUX_FUNC::ARMDISARM should move up and the AP_Arming::Method stored
 - rudder arm/disarm can possibly move up
 - vehicle arm/disarm logging can become common (probably log both an even and something into the ARM message as the ARM message contains more information)
 - reduce the number of "armed" states we have in the code
 - make reset-mission-on-disarm a common option between vehicles
 - moving of arming-related methods into AP_Arming files
 - have the parachute library itself disarm the vehicle rather than doing that in the vehicles
 - move manipulation of logger armed status into base class (AP::logger().set_vehicle_armed())
 - move AP_Notify manipulation up to base class (so Rover and Plane get arming tones)
 - move AP_Scheduler manipulation up to base class
 - could consider storing armed-bearing in AP_Arming
 - canonicalise home position / baro reset / EKF height datum reset handling
 - make resetting EKF height datum an arming check rather than something we do once armed (as it is bool and is kinda-sorta MUST_CHECK)
 - move sprayer-pump-testing-disabling up to base arm method
 - canonicalise return value of AP_Arming::arm() when we are armed to return false
 - canonicalise return value of AP_Arming::disarm() when we are disarmed to return false
  - very few places actually check the return value
 - consider making in_arming_delay something in the base class and/or renaming it to in_post_arming_delay
 - try to work out of motor estop functionality can be made common in AP_Arming
 - make safety switch behaviour common between vehicles for whether you can arm or not
 - create AP_Arming::update() and continuously do prearms on Plane, Sub and Rover as they are in Copter
 - move inertial-nav vs baro check up to base class(?)
 - remove defaulting in "bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;"
 - consider not allowing arm() to be overridden but have hooks for post-arm actions
