### PR TITLE
UBSan fixes

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -35,7 +35,7 @@ uint8_t AP_BattMonitor_Backend::capacity_remaining_pct() const
 {
     float mah_remaining = _params._pack_capacity - _state.consumed_mah;
     if ( _params._pack_capacity > 10 ) { // a very very small battery
-        return (100 * (mah_remaining) / _params._pack_capacity);
+        return MIN(MAX((100 * (mah_remaining) / _params._pack_capacity), 0), UINT8_MAX);
     } else {
         return 0;
     }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -134,7 +134,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Description: Masked with the SBP msg_type field to determine whether SBR1/SBR2 data is logged
     // @Values: 0:None (0x0000),-1:All (0xFFFF),-256:External only (0xFF00)
     // @User: Advanced
-    AP_GROUPINFO("SBP_LOGMASK", 8, AP_GPS, _sbp_logmask, 0xFF00),
+    AP_GROUPINFO("SBP_LOGMASK", 8, AP_GPS, _sbp_logmask, -256),
 
     // @Param: RAW_DATA
     // @DisplayName: Raw data logging

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -42,17 +42,6 @@ private:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    // deepstall members
-    enum deepstall_stage {
-        DEEPSTALL_STAGE_FLY_TO_LANDING,    // fly to the deepstall landing point
-        DEEPSTALL_STAGE_ESTIMATE_WIND,     // loiter until we have a decent estimate of the wind for the target altitude
-        DEEPSTALL_STAGE_WAIT_FOR_BREAKOUT, // wait until the aircraft is aligned for the optimal breakout
-        DEEPSTALL_STAGE_FLY_TO_ARC,        // fly to the start of the arc
-        DEEPSTALL_STAGE_ARC,               // fly the arc
-        DEEPSTALL_STAGE_APPROACH,          // fly the approach in, and prepare to deepstall when close 
-        DEEPSTALL_STAGE_LAND,              // the aircraft will stall torwards the ground while targeting a given point
-    };
-
     AP_Float forward_speed;
     AP_Float slope_a;
     AP_Float slope_b;
@@ -69,7 +58,7 @@ private:
     AP_Float min_abort_alt;
     AP_Float aileron_scalar;
     int32_t loiter_sum_cd;         // used for tracking the progress on loitering
-    deepstall_stage stage;
+    DEEPSTALL_STAGE stage;
     Location landing_point;
     Location extended_approach;
     Location breakout_location;


### PR DESCRIPTION
This is a couple of UBSan found/inspired fixups. I've only run it against plane thus far, I started on Copter and it has lots of shadowing warnings I decided to not chase:

```
In file included from ../../ArduCopter/events.cpp:1:
In file included from ../../ArduCopter/Copter.h:856:
../../ArduCopter/mode.h:1278:9: fatal error: declaration shadows a variable in the global namespace [-Wshadow]
        AUTO,           // after A and B defined, pilot toggle the switch from one side to the other, vehicle flies autonomously
        ^
../../ArduCopter/defines.h:38:5: note: previous declaration is here
    AUTO =          3,  // fully automatic waypoint control using mission commands
    ^
1 error generated.
```