### PR TITLE
AP_NavEKF3: Fix GPS < 3D empty PreArm: msg-as EKF2

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -401,6 +401,9 @@ bool NavEKF3_core::InitialiseFilterBootstrap(void)
 {
     // If we are a plane and don't have GPS lock then don't initialise
     if (assume_zero_sideslip() && AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
+        hal.util->snprintf(prearm_fail_string,
+                    sizeof(prearm_fail_string),
+                    "EKF3 init failure: No GPS lock");
         statesInitialised = false;
         return false;
     }


### PR DESCRIPTION
It fixes Prearm: empty message when AHRS_EKF_TYPE is set to 3 and there is no GPS fix yet.
Same as EKF2 commit 1b4705242c2578ed0