### PR TITLE
AP_Mount: Slow down Solo gimbal tilt

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -98,7 +98,7 @@ void AP_Mount_Backend::update_targets_from_rc()
 
     // if joystick_speed is defined then pilot input defines a rate of change of the angle
     if (_frontend._joystick_speed) {
-        // allow pilot position input to come directly from an RC_Channel
+        // allow pilot rate input to come directly from an RC_Channel
         rate_input_rad(_angle_ef_target_rad.x,
                        roll_ch,
                        _state._roll_angle_min,
@@ -112,7 +112,7 @@ void AP_Mount_Backend::update_targets_from_rc()
                        _state._pan_angle_min,
                        _state._pan_angle_max);
     } else {
-        // allow pilot rate input to come directly from an RC_Channel
+        // allow pilot position input to come directly from an RC_Channel
         if ((roll_ch != nullptr) && (roll_ch->get_radio_in() != 0)) {
             _angle_ef_target_rad.x = angle_input_rad(roll_ch, _state._roll_angle_min, _state._roll_angle_max);
         }

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -130,7 +130,7 @@ void SoloGimbal::send_controls(mavlink_channel_t chan)
                 }
                 if (HAVE_PAYLOAD_SPACE(chan, GIMBAL_CONTROL)) {
                     mavlink_msg_gimbal_control_send(chan, mavlink_system.sysid, _compid,
-                                                    _ang_vel_dem_rads.x, _ang_vel_dem_rads.y, _ang_vel_dem_rads.z);
+                                                    _ang_vel_dem_rads.x, (_ang_vel_dem_rads.y)*0.25, _ang_vel_dem_rads.z);
                 }
                 break;
             }


### PR DESCRIPTION
In ChibiOS, the pilot gimbal tilt operates dramatically faster than it ever did under Nuttx. I'm not sure why. But it isn't the first time that ChibiOS performing so much better than Nuttx has caused something like this. The result of this highly responsive tilt velocity is that the gimbal tilt massively overshoots its upper and lower limits.  Reducing the tilt velocity demand by 75% brings it back under proper/expected control.  **I am open to a better way to do this if anyone has some suggestions.**  This method seems like a bit of a hack, but it definitely works.

Also, fixed a backwards comment in the mount backend.