### PR TITLE
Tools: autotest: fix process kill in sim_vehicle.py

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -196,9 +196,10 @@ def kill_tasks_psutil(victims):
     use this routine"""
     import psutil
     for proc in psutil.process_iter():
-        if proc.status == psutil.STATUS_ZOMBIE:
+        pdict = proc.as_dict(attrs=['name', 'status'])
+        if pdict['status'] == psutil.STATUS_ZOMBIE:
             continue
-        if proc.name in victims:
+        if pdict['name'] in victims:
             proc.kill()
 
 


### PR DESCRIPTION
Problem discovered while looking into issue https://github.com/ArduPilot/ardupilot/issues/11320
Has been tested and this method should potentially avoid changes in the `psutil` API 

@peterbarker I'm not sure if would work on older pythons as well but I think it should. Would be great if someone can confirm this. 