### PR TITLE
AP_Logger: add WriteCritical method to AP::logger()

### DIFF
--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -214,14 +214,14 @@ static void main_loop()
     if (hal.util->was_watchdog_reset()) {
         AP::internalerror().error(AP_InternalError::error_t::watchdog_reset);
         const AP_HAL::Util::PersistentData &pd = hal.util->persistent_data;
-        AP::logger().Write("WDOG", "TimeUS,Task,IErr,IErrCnt,MavMsg,MavCmd,SemLine", "QbIIHHH",
-                           AP_HAL::micros64(),
-                           pd.scheduler_task,
-                           pd.internal_errors,
-                           pd.internal_error_count,
-                           pd.last_mavlink_msgid,
-                           pd.last_mavlink_cmd,
-                           pd.semaphore_line);
+        AP::logger().WriteCritical("WDOG", "TimeUS,Task,IErr,IErrCnt,MavMsg,MavCmd,SemLine", "QbIIHHH",
+                                   AP_HAL::micros64(),
+                                   pd.scheduler_task,
+                                   pd.internal_errors,
+                                   pd.internal_error_count,
+                                   pd.last_mavlink_msgid,
+                                   pd.last_mavlink_cmd,
+                                   pd.semaphore_line);
     }
 #endif
 

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -152,6 +152,18 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
     callbacks->setup();
     scheduler->system_initialized();
 
+    if (getenv("SITL_WATCHDOG_RESET")) {
+        const AP_HAL::Util::PersistentData &pd = util->persistent_data;
+        AP::logger().WriteCritical("WDOG", "TimeUS,Task,IErr,IErrCnt,MavMsg,MavCmd,SemLine", "QbIIHHH",
+                                   AP_HAL::micros64(),
+                                   pd.scheduler_task,
+                                   pd.internal_errors,
+                                   pd.internal_error_count,
+                                   pd.last_mavlink_msgid,
+                                   pd.last_mavlink_cmd,
+                                   pd.semaphore_line);
+    }
+
     bool using_watchdog = AP_BoardConfig::watchdog_enabled();
     if (using_watchdog) {
         signal(SIGALRM, sig_alrm);

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -733,7 +733,25 @@ void AP_Logger::Write(const char *name, const char *labels, const char *units, c
     va_end(arg_list);
 }
 
-void AP_Logger::WriteV(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, va_list arg_list)
+void AP_Logger::WriteCritical(const char *name, const char *labels, const char *fmt, ...)
+{
+    va_list arg_list;
+
+    va_start(arg_list, fmt);
+    WriteV(name, labels, nullptr, nullptr, fmt, arg_list, true);
+    va_end(arg_list);
+}
+
+void AP_Logger::WriteCritical(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...)
+{
+    va_list arg_list;
+
+    va_start(arg_list, fmt);
+    WriteV(name, labels, units, mults, fmt, arg_list, true);
+    va_end(arg_list);
+}
+
+void AP_Logger::WriteV(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, va_list arg_list, bool is_critical)
 {
     struct log_write_fmt *f = msg_fmt_for_name(name, labels, units, mults, fmt);
     if (f == nullptr) {
@@ -752,7 +770,7 @@ void AP_Logger::WriteV(const char *name, const char *labels, const char *units, 
         }
         va_list arg_copy;
         va_copy(arg_copy, arg_list);
-        backends[i]->Write(f->msg_type, arg_copy);
+        backends[i]->Write(f->msg_type, arg_copy, is_critical);
         va_end(arg_copy);
     }
 }

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -276,7 +276,9 @@ public:
 
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);
-    void WriteV(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, va_list arg_list);
+    void WriteCritical(const char *name, const char *labels, const char *fmt, ...);
+    void WriteCritical(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);
+    void WriteV(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, va_list arg_list, bool is_critical=false);
 
     // This structure provides information on the internal member data of a PID for logging purposes
     struct PID_Info {

--- a/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
+++ b/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
@@ -88,11 +88,29 @@ void AP_LoggerTest::setup(void)
     hal.console->printf("Average write time %.1f usec/byte\n", 
                        (double)total_micros/((double)i*sizeof(struct log_Test)));
 
+    uint64_t now = AP_HAL::micros64();
+    hal.console->printf("Testing Write\n");
+    logger.Write("MARY",
+                 "TimeUS,GoodValue",
+                 "sm",
+                 "F0",
+                 "Qf",
+                 now,
+                 -1.5673);
+    hal.console->printf("Testing WriteCritical\n");
+    logger.WriteCritical("BOB",
+                         "TimeUS,GreatValue",
+                         "sm",
+                         "F0",
+                         "Qf",
+                         now,
+                         17.3);
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     logger.flush();
 #endif
 
-    hal.scheduler->delay(100);
+    logger.set_vehicle_armed(false);
 }
 
 void AP_LoggerTest::loop(void)


### PR DESCRIPTION
For callers who emphatically want their custom messages to be written out.

WIP as I haven't tested it works yet...
