### PR TITLE
Dual GPS SwitchOnHigherStatus

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -85,7 +85,7 @@ void SITL_State::_sitl_setup(const char *home_str)
         // setup some initial values
 #ifndef HIL_MODE
         _update_airspeed(0);
-        _update_gps(0, 0, 0, 0, 0, 0, false);
+        _update_gps(0, 0, 0, 0, 0, 0);
         _update_rangefinder(0);
 #endif
         if (enable_gimbal) {
@@ -170,7 +170,7 @@ void SITL_State::_fdm_input_step(void)
     _scheduler->sitl_begin_atomic();
 
     if (_update_count == 0 && _sitl != nullptr) {
-        _update_gps(0, 0, 0, 0, 0, 0, false);
+        _update_gps(0, 0, 0, 0, 0, 0);
         _scheduler->timer_event();
         _scheduler->sitl_end_atomic();
         return;
@@ -179,8 +179,7 @@ void SITL_State::_fdm_input_step(void)
     if (_sitl != nullptr) {
         _update_gps(_sitl->state.latitude, _sitl->state.longitude,
                     _sitl->state.altitude,
-                    _sitl->state.speedN, _sitl->state.speedE, _sitl->state.speedD,
-                    !_sitl->gps_disable);
+                    _sitl->state.speedN, _sitl->state.speedE, _sitl->state.speedD);
         _update_airspeed(_sitl->state.airspeed);
         _update_rangefinder(_sitl->state.range);
 

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -129,7 +129,7 @@ private:
     uint32_t CalculateBlockCRC32(uint32_t length, uint8_t *buffer, uint32_t crc);
 
     void _update_gps(double latitude, double longitude, float altitude,
-                     double speedN, double speedE, double speedD, bool have_lock);
+                     double speedN, double speedE, double speedD);
     void _update_airspeed(float airspeed);
     void _update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *d, uint8_t instance);
     void _check_rc_input(void);

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -1151,11 +1151,11 @@ void SITL_State::_update_gps_file(uint8_t instance)
   possibly send a new GPS packet
  */
 void SITL_State::_update_gps(double latitude, double longitude, float altitude,
-                             double speedN, double speedE, double speedD, bool have_lock)
+                             double speedN, double speedE, double speedD)
 {
     struct gps_data d;
     char c;
-
+    bool have_lock;
     // simulate delayed lock times
     if (AP_HAL::millis() < _sitl->gps_lock_time*1000UL) {
         have_lock = false;
@@ -1202,7 +1202,7 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
     d.speedN = speedN;
     d.speedE = speedE;
     d.speedD = speedD;
-    d.have_lock = have_lock;
+    d.have_lock = !_sitl->gps_disable;
 
     // correct the latitude, longitude, hiehgt and NED velocity for the offset between
     // the vehicle c.g. and GPs antenna
@@ -1274,6 +1274,7 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
     d2.latitude += glitch_offsets.x;
     d2.longitude += glitch_offsets.y;
     d2.altitude += glitch_offsets.z;
+    d2.have_lock = !_sitl->gps2_disable;
 
     if (gps_state.gps_fd != 0) {
         _update_gps_instance((SITL::SITL::GPSType)_sitl->gps_type.get(), &d, 0);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -166,6 +166,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("TWIST_TIME",  40, SITL,  twist.t, 0),
 
     AP_GROUPINFO("GND_BEHAV",   41, SITL,  gnd_behav, -1),
+    AP_GROUPINFO("GPS2_DISABLE",  42, SITL,  gps2_disable, 0),
 
     AP_GROUPEND
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -152,6 +152,7 @@ public:
     AP_Float engine_mul;  // engine multiplier
     AP_Int8  engine_fail; // engine servo to fail (0-7)
     AP_Int8  gps_disable; // disable simulated GPS
+    AP_Int8  gps2_disable; // disable simulated GPS
     AP_Int8  gps2_enable; // enable 2nd simulated GPS
     AP_Int8  gps_delay;   // delay in samples
     AP_Int8  gps_type;    // see enum GPSType


### PR DESCRIPTION
Add GPS_AUTO_SWITCH 4 option.
SwitchOnHigherStatus swtiches to GPS reporting higher lock status, so less swtiching than UseBest. SwitchOnHigherStatus also helps to switch if primary lost GPS.

Also, added SIM_GPS2_DISABLE parameter for SITL to allow disable GPS1 or GPS2 separately which helps testing different GPS_AUTO_SWITCH options.
It helped me test the switchonhigherstatus commit. I've also done real flight test for switchonhigherstatus and it worked so fine.
I've discussed the idea of adding an option for SwitchOnPrimaryLoss on gitter with @WickedShell  but on implementation I've found that SwitchOnHigherStatus maybe more useful and also implicitly does SwitchOnPrimaryLoss.

Here is my original post on gitter for explanation;
```
For GPS_AUTO_SWITCH, I've done some testing using 2 gps receivers of from different manufacturers. Actually due to accuracy variation, I've found that all GPS_AUTO_SWITCH options are not suitable: for following reasons;
0 disable switch? What of the primary got no_fix?
1 use best? It keeps jumping all the time causing fight instability
2 blend? too bad if one of them have bad glitches, even worse than using the glitching one alone
3 use second? same as 0

So I'm thinking about adding option 4 that is switch if no 3D fix. So it only switches to other one if the currently used one lost 3D fix.
```

