### PR TITLE
AP_GPS: Change the setting value description

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -132,7 +132,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: SBP_LOGMASK
     // @DisplayName: Swift Binary Protocol Logging Mask
     // @Description: Masked with the SBP msg_type field to determine whether SBR1/SBR2 data is logged
-    // @Values: 0:None (0x0000),-1:All (0xFFFF),-256:External only (0xFF00)
+    // @Values: 0:None,-1:All,-256:External only
     // @User: Advanced
     AP_GROUPINFO("SBP_LOGMASK", 8, AP_GPS, _sbp_logmask, -256),
 


### PR DESCRIPTION
I don't think that C language hex notation is unnecessary for the explanation of setting values.
I will see this description in the GCS.
The display of the value that can not be set is considered unnecessary.