### PR TITLE
AP_Arming: PreArm: baro & arspd validity checks and more

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -835,14 +835,14 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
     //are arming checks disabled?
     if (!do_arming_checks || checks_to_perform == ARMING_CHECK_NONE) {
         armed = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+        gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed without checks");
         return true;
     }
 
     if (pre_arm_checks(true) && arm_checks(method)) {
         armed = true;
 
-        gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+        gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed checks succeeded");
 
         //TODO: Log motor arming
         //Can't do this from this class until there is a unified logging library

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -85,6 +85,7 @@ protected:
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
     AP_Int32                 _required_mission_items;
+    AP_Int8                 _baro2gps;
 
     // internal members
     bool                    armed;

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -86,6 +86,7 @@ protected:
     AP_Int8                 _rudder_arming;
     AP_Int32                 _required_mission_items;
     AP_Int8                 _baro2gps;
+    AP_Float                _arspd_max;
 
     // internal members
     bool                    armed;

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -342,6 +342,7 @@ void AP_Baro_MS56XX::update()
     }
 }
 
+static bool first_calc{true};
 // Calculate Temperature and compensated Pressure in real units (Celsius degrees*100, mbar*100).
 void AP_Baro_MS56XX::_calculate_5611()
 {
@@ -374,6 +375,17 @@ void AP_Baro_MS56XX::_calculate_5611()
 
     float pressure = (_D1*SENS/2097152 - OFF)/32768;
     float temperature = (TEMP + 2000) * 0.01f;
+
+    if (first_calc) {
+        first_calc = false;
+        if (pressure < 51000 && temperature > 0) {
+            hal.console->printf("TEMP5611=%f, Press=%f\n", temperature, pressure);
+            hal.console->printf("Switching to MS5607\n");
+            _ms56xx_type = BARO_MS5607;
+            _calculate_5607();
+            return;
+        }
+    }
     _copy_to_frontend(_instance, pressure, temperature);
 }
 


### PR DESCRIPTION
I've added some PreArm checks for barometer and airspeed to make sure it's working fine before takeoff.

Barometer:
Compare baro alt with GPS alt. I know about one case where barometer sensor hole was contaminated and caused vehicle crash on takeoff as it gave very wrong altitude readings.

AirSpeed:

1. Always enable checks if airspeed is enabled. Other sensors checks works like this. Otherwise user can knowingly disable airspeed. Also, airspeed is used on crash detection and dead-reckoning on GPS loss even if not 'used'.
2.  Check very high airspeed readings. Usually due to tight airspeed cover. Or not covering at all on startup. Which should be re-calibrated.
3. Check very low airspeed usually due to bad TYPE or PIN config. Also can occur on some blockage cases.


One more change in "Throttle Armed" messages to make it more useful and informative. To distinguish forced arming without checks and proper arming. Which can also help on diagnosis on case of failure.