### PR TITLE
GCS_MAVLink: manual_override should ignore INT16_MAX, not treat as zero

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4654,15 +4654,18 @@ void GCS_MAVLINK::manual_override(RC_Channel *c, int16_t value_in, const uint16_
     if (c == nullptr) {
         return;
     }
-    int16_t override_value = 0;
-    if (value_in != INT16_MAX) {
-        const int16_t radio_min = c->get_radio_min();
-        const int16_t radio_max = c->get_radio_max();
-        if (reversed) {
-            value_in *= -1;
-        }
-        override_value = radio_min + (radio_max - radio_min) * (value_in + offset) / scaler;
+
+    if (value_in == INT16_MAX) {
+        return;
     }
+
+    const int16_t radio_min = c->get_radio_min();
+    const int16_t radio_max = c->get_radio_max();
+    if (reversed) {
+        value_in *= -1;
+    }
+
+    const int16_t override_value = radio_min + (radio_max - radio_min) * (value_in + offset) / scaler;
     c->set_override(override_value, tnow);
 }
 


### PR DESCRIPTION
Spec for the mavlink packet MANUAL_CONTROL (69) for an axis is:
      <field type="int16_t" name="x">X-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to forward(1000)-backward(-1000) movement on a joystick and the pitch of a vehicle.</field>

We were treating INT16_MAX as zero pwm instead of ignoring it like we do correctly on the [RC_CHANNELS_OVERRIDE](https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_Common.cpp#L3034).

This PR now correctly ignores INT16_MAX.