### PR TITLE
Copter: smoothing land on auto and update navigation report

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -611,6 +611,10 @@ bool ModeAuto::get_wp(Location& destination)
     case Auto_NavGuided:
         return copter.mode_guided.get_wp(destination);
     case Auto_WP:
+    case Auto_TakeOff:
+    case Auto_Loiter:
+    case Auto_LoiterToAlt:
+    case Auto_Land:
         return wp_nav->get_oa_wp_destination(destination);
     case Auto_RTL:
         return copter.mode_rtl.get_wp(destination);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1173,21 +1173,20 @@ void ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
 void ModeAuto::do_land(const AP_Mission::Mission_Command& cmd)
 {
     // To-Do: check if we have already landed
-
+    // set state to fly to location
+    state = State::FlyToLocation;
     // if location provided we fly to that location at current altitude
     if (cmd.content.location.lat != 0 || cmd.content.location.lng != 0) {
-        // set state to fly to location
-        state = State::FlyToLocation;
-
         const Location target_loc = terrain_adjusted_location(cmd);
 
         wp_start(target_loc);
     } else {
-        // set landing state
-        state = State::Descending;
+        // calculate stopping point
+        Vector3f stopping_point;
+        wp_nav->get_wp_stopping_point(stopping_point);
+        const Location target_loc(stopping_point);
 
-        // initialise landing controller
-        land_start();
+        wp_start(target_loc);
     }
 }
 


### PR DESCRIPTION
this correct the report of the land position on auto mode.
It also allow smoother transition on land, indeed, if we need to land on spot, we will start by using the loiter_controler that is more raw that the wp_controler. This patch will now start using the wp controler before the loiter_controler ensuring a smooth transition