### PR TITLE
Build.md: Updated waf configure commands for CubeBlack and fmuv3

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -67,10 +67,10 @@ list some basic and more used commands as example.
     ```sh
     ./waf configure --board bebop --static # Bebop or Bebop2
     ./waf configure --board edge           # emlid edge
-    ./waf configure --board fmuv3          # Pixhawk2/Cube using ChibiOS
+    ./waf configure --board fmuv3          # 3DR Pixhawk 2 boards
     ./waf configure --board navio2         # emlid navio2
     ./waf configure --board Pixhawk1       # Pixhawk1
-    ./waf configure --board CubeBlack      # Pixhawk2
+    ./waf configure --board CubeBlack      # Hex/ProfiCNC Cube Black (formerly known as Pixhawk 2.1)
     ./waf configure --board Pixracer       # Pixracer
     ./waf configure --board skyviper-v2450 # SkyRocket's SkyViper GPS drone using ChibiOS
     ./waf configure --board sitl           # software-in-the-loop simulator


### PR DESCRIPTION
According to the following [forum discussion](https://discuss.cubepilot.org/t/fmuv3-vs-cubeblack-firmware/876/3), all Cubes running ChiBiOS should be configured with CubeBlack firmware.

Hence, waf configure should select CubeBlack when compiling for Pixhawk2/Cube running ChiBiOS.

According to Philip Rowse, fmuv3 is no longer suitable for Cube Black.