### PR TITLE
Improve Gyro Inconsistency Check

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -242,6 +242,9 @@ public:
     // return the current estimate of the gyro drift
     virtual const Vector3f &get_gyro_drift(void) const = 0;
 
+    // return the current estimated bias for IMU instance
+    virtual const Vector3f get_gyro_bias(uint8_t i) const { return Vector3f(0.0f, 0.0f, 0.0f); }
+
     // reset the current gyro drift estimate
     //  should be called if gyro offsets are recalculated
     virtual void reset_gyro_drift(void) = 0;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -69,6 +69,36 @@ const Vector3f &AP_AHRS_NavEKF::get_gyro_drift(void) const
     return _gyro_drift;
 }
 
+// return the current estimated bias for IMU instance
+const Vector3f AP_AHRS_NavEKF::get_gyro_bias(uint8_t i) const
+{
+    Vector3f gyro_bias;
+    gyro_bias.zero();
+    if (!active_EKF_type()) {
+        return gyro_bias;
+    }
+    int8_t imu_index = -1;
+    if (_ekf2_started) {
+        for (uint8_t core = 0; core < EKF2.activeCores(); core++) {
+            imu_index = EKF2.getCoreIMUIndex(core);
+            if (imu_index != -1 && i == imu_index) {
+                EKF2.getGyroBias(core, gyro_bias);
+                return gyro_bias;
+            }
+        }
+    }
+    if (_ekf3_started) {
+        for (uint8_t core = 0; core < EKF3.activeCores(); core++) {
+            imu_index = EKF3.getCoreIMUIndex(core);
+            if (imu_index != -1 && i == imu_index) {
+                EKF3.getGyroBias(core, gyro_bias);
+                return gyro_bias;
+            }
+        }
+    }
+    return gyro_bias;
+}
+
 // reset the current gyro drift estimate
 //  should be called if gyro offsets are recalculated
 void AP_AHRS_NavEKF::reset_gyro_drift(void)

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -58,6 +58,9 @@ public:
     // return the current drift correction integrator value
     const Vector3f &get_gyro_drift(void) const override;
 
+    // return the current estimated bias for IMU instance
+    const Vector3f get_gyro_bias(uint8_t i) const override;
+
     // reset the current gyro drift estimate
     //  should be called if gyro offsets are recalculated
     void reset_gyro_drift() override;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -265,15 +265,15 @@ bool AP_Arming::ins_gyros_consistent(const AP_InertialSensor &ins)
         return true;
     }
 
-    const Vector3f &prime_gyro_vec = ins.get_gyro();
+    Vector3f prime_gyro_vec = ins.get_gyro_corrected();
     const uint32_t now = AP_HAL::millis();
     for(uint8_t i=0; i<gyro_count; i++) {
         if (!ins.use_gyro(i)) {
             continue;
         }
         // get next gyro vector
-        const Vector3f &gyro_vec = ins.get_gyro(i);
-        const Vector3f vec_diff = gyro_vec - prime_gyro_vec;
+        Vector3f gyro_vec = ins.get_gyro_corrected(i);
+        Vector3f vec_diff = gyro_vec - prime_gyro_vec;
         // allow for up to 5 degrees/s difference. Pass if it has
         // been OK in last 10 seconds
         if (vec_diff.length() <= radians(5)) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -2018,6 +2018,17 @@ AP_InertialSensor::Gyro_Calibration_Timing AP_InertialSensor::gyro_calibration_t
     return (Gyro_Calibration_Timing)_gyro_cal_timing.get();
 }
 
+/*
+    Get corrected gyro data, with corrections from biases learnt by EKF
+*/
+const Vector3f AP_InertialSensor::get_gyro_corrected(uint8_t i) const
+{
+    if (i >= INS_MAX_INSTANCES) {
+        return Vector3f(0.0f, 0.0f, 0.0f);
+    }
+    return (_gyro[i] - AP::ahrs().get_gyro_bias(i));
+}
+
 
 namespace AP {
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -97,7 +97,9 @@ public:
     ///
     const Vector3f     &get_gyro(uint8_t i) const { return _gyro[i]; }
     const Vector3f     &get_gyro(void) const { return get_gyro(_primary_gyro); }
-
+    const Vector3f     get_gyro_corrected(uint8_t i) const;
+    const Vector3f     get_gyro_corrected(void) const { return get_gyro_corrected(_primary_gyro); }
+    
     // set gyro offsets in radians/sec
     const Vector3f &get_gyro_offsets(uint8_t i) const { return _gyro_offset[i]; }
     const Vector3f &get_gyro_offsets(void) const { return get_gyro_offsets(_primary_gyro); }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -801,6 +801,16 @@ int8_t NavEKF2::getPrimaryCoreIMUIndex(void) const
     return core[primary].getIMUIndex();
 }
 
+// returns the index of the IMU of the core instance
+// return -1 if invalid core selected
+int8_t NavEKF2::getCoreIMUIndex(uint8_t i) const
+{
+    if (!core || i >= num_cores) {
+        return -1;
+    }
+    return core[i].getIMUIndex();
+}
+
 // Write the last calculated NE position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -72,7 +72,11 @@ public:
     // returns the index of the IMU of the primary core
     // return -1 if no primary core selected
     int8_t getPrimaryCoreIMUIndex(void) const;
-    
+
+    // returns the index of the IMU of the core instance
+    // return -1 if invalid core selected
+    int8_t getCoreIMUIndex(uint8_t i) const;
+
     // Write the last calculated NE position relative to the reference point (m) for the specified instance.
     // An out of range instance (eg -1) returns data for the primary instance
     // If a calculated solution is not available, use the best available data and return false

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -837,6 +837,16 @@ int8_t NavEKF3::getPrimaryCoreIMUIndex(void) const
     return core[primary].getIMUIndex();
 }
 
+// returns the index of the IMU of the core instance
+// return -1 if invalid core selected
+int8_t NavEKF3::getCoreIMUIndex(uint8_t i) const
+{
+    if (!core || i >= num_cores) {
+        return -1;
+    }
+    return core[i].getIMUIndex();
+}
+
 // Write the last calculated NE position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -70,6 +70,10 @@ public:
     // return -1 if no primary core selected
     int8_t getPrimaryCoreIMUIndex(void) const;
 
+    // returns the index of the IMU of the core instance
+    // return -1 if invalid core selected
+    int8_t getCoreIMUIndex(uint8_t i) const;
+
     // Write the last calculated NE position relative to the reference point (m) for the specified instance.
     // An out of range instance (eg -1) returns data for the primary instance
     // If a calculated solution is not available, use the best available data and return false


### PR DESCRIPTION
Current implementation doesn't remove bias learnt by EKF before consistency check, leading to false positive for Inconsistency check. Especially for heated IMUs, where the IMU heating leads to a drift which is not corrected since we do calibration on boot time only.

With this PR the need to reboot systems where the Gyros have drifted off due to heating is fixed..