### PR TITLE
AP_BLHeli: Update to support newer targets and protocols

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -700,6 +700,8 @@ bool AP_BLHeli::BL_ConnectEx(void)
     case 0x3306:
     case 0x3406:
     case 0x3506:
+    case 0x2B06:
+    case 0x4706:
         blheli.interface_mode[blheli.chan] = imARM_BLB;
         debug("Interface type imARM_BLB");
         break;
@@ -734,7 +736,7 @@ bool AP_BLHeli::BL_PageErase(void)
         if (!BL_SendBuf(sCMD, 2)) {
             return false;
         }
-        return BL_GetACK(1000) == brSUCCESS;
+        return BL_GetACK(3000) == brSUCCESS;
     }
     return false;
 }

--- a/libraries/AP_BLHeli/blheli_4way_protocol.h
+++ b/libraries/AP_BLHeli/blheli_4way_protocol.h
@@ -118,7 +118,7 @@
  */
 #define SERIAL_4WAY_VER_MAIN 20
 #define SERIAL_4WAY_VER_SUB_1 (uint8_t) 0
-#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 02
+#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 03
 
 #define SERIAL_4WAY_PROTOCOL_VER 107
 // *** end


### PR DESCRIPTION
This allows compatability with newer versions of BLHeli Suite 32. Tested against BLHeliSuite 32.6.1.3 with a Pixhawk, Wraith32 Metal v2, this succeeded at doing a firmware update (32.4 to 32.6), and can read/write settings.