### PR TITLE
Fix count of fence boundary points

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -364,7 +364,7 @@ void AC_Avoid::adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2
     // get polygon boundary
     // Note: first point in list is the return-point (which copter does not use)
     uint16_t num_points;
-    const Vector2f* boundary = _fence.get_polygon_points(num_points);
+    const Vector2f* boundary = _fence.get_boundary_points(num_points);
 
     // adjust velocity using polygon
     adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, boundary, num_points, true, _fence.get_margin(), dt);

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -460,13 +460,19 @@ void AC_Fence::manual_recovery_start()
 }
 
 /// returns pointer to array of polygon points and num_points is filled in with the total number
-Vector2f* AC_Fence::get_polygon_points(uint16_t& num_points) const
+Vector2f* AC_Fence::get_boundary_points(uint16_t& num_points) const
 {
     // return array minus the first point which holds the return location
-    num_points = (_boundary_num_points <= 1) ? 0 : _boundary_num_points - 1;
-    if ((_boundary == nullptr) || (num_points == 0)) {
+    if (_boundary == nullptr) {
         return nullptr;
     }
+    if (!_boundary_valid) {
+        return nullptr;
+    }
+    // minus one for return point, minus one for closing point
+    // (_boundary_valid is not true unless we have a closing point AND
+    // we have a minumum number of points)
+    num_points = _boundary_num_points - 2;
     return &_boundary[1];
 }
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -100,7 +100,7 @@ public:
     ///
 
     /// returns pointer to array of polygon points and num_points is filled in with the total number
-    Vector2f* get_polygon_points(uint16_t& num_points) const;
+    Vector2f* get_boundary_points(uint16_t& num_points) const;
 
     /// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object
     bool boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points) const;


### PR DESCRIPTION
This simply caused the closing point to be counted as a point.  Since it's the same as the first polygon point, this is pointless.

This also says that the fence must be valid to be used for avoidance - e.g. minimum point count and closing point.  adjust_velocity_polygon shouldn't be called if you're not passing it a polygon...

Also rename get_polygon_points to get_boundary_points to be in-line with Proximity and Beacon equivalent methods.
