### PR TITLE
Correct checks for point-outside-fence

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -362,7 +362,6 @@ void AC_Avoid::adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2
     }
 
     // get polygon boundary
-    // Note: first point in list is the return-point (which copter does not use)
     uint16_t num_points;
     const Vector2f* boundary = _fence.get_boundary_points(num_points);
 
@@ -453,13 +452,7 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
         position_xy = position_xy * 100.0f;  // m to cm
     }
 
-    AC_Fence *fence = AP::fence();
-    if (fence == nullptr) {
-        return;
-    }
-    AC_Fence &_fence = *fence;
-
-    if (_fence.boundary_breached(position_xy, num_points, boundary)) {
+    if (Polygon_outside(position_xy, boundary, num_points)) {
         return;
     }
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -364,7 +364,7 @@ void AC_Avoid::adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2
     // get polygon boundary
     // Note: first point in list is the return-point (which copter does not use)
     uint16_t num_points;
-    const Vector2f* boundary = _fence.get_polygon_points(num_points);
+    const Vector2f* boundary = _fence.get_boundary_points(num_points);
 
     // adjust velocity using polygon
     adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, boundary, num_points, true, _fence.get_margin(), dt);

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -460,13 +460,22 @@ void AC_Fence::manual_recovery_start()
 }
 
 /// returns pointer to array of polygon points and num_points is filled in with the total number
-Vector2f* AC_Fence::get_polygon_points(uint16_t& num_points) const
+Vector2f* AC_Fence::get_boundary_points(uint16_t& num_points) const
 {
     // return array minus the first point which holds the return location
-    num_points = (_boundary_num_points <= 1) ? 0 : _boundary_num_points - 1;
-    if ((_boundary == nullptr) || (num_points == 0)) {
+    if (_boundary == nullptr) {
         return nullptr;
     }
+    if (!_boundary_valid) {
+        return nullptr;
+    }
+    // minus one for return point, minus one for closing point
+    // (_boundary_valid is not true unless we have a closing point AND
+    // we have a minumum number of points)
+    if (_boundary_num_points < 2) {
+        return nullptr;
+    }
+    num_points = _boundary_num_points - 2;
     return &_boundary[1];
 }
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -100,7 +100,7 @@ public:
     ///
 
     /// returns pointer to array of polygon points and num_points is filled in with the total number
-    Vector2f* get_polygon_points(uint16_t& num_points) const;
+    Vector2f* get_boundary_points(uint16_t& num_points) const;
 
     /// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object
     bool boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points) const;

--- a/libraries/AP_Beacon/AP_Beacon.cpp
+++ b/libraries/AP_Beacon/AP_Beacon.cpp
@@ -295,8 +295,10 @@ void AP_Beacon::update_boundary_points()
             }
             // if duplicate is found, remove all boundary points before the duplicate because they are inner points
             if (dup_found) {
-                uint8_t num_pts = curr_boundary_idx - dup_idx + 1;
-                if (num_pts > AP_BEACON_MINIMUM_FENCE_BEACONS) {
+                // note that the closing/duplicate point is not
+                // included in the boundary points.
+                const uint8_t num_pts = curr_boundary_idx - dup_idx;
+                if (num_pts >= AP_BEACON_MINIMUM_FENCE_BEACONS) { // we consider three points to be a polygon
                     // success, copy boundary points to boundary array and convert meters to cm
                     for (uint8_t j = 0; j < num_pts; j++) {
                         boundary[j] = boundary_points[j+dup_idx] * 100.0f;

--- a/libraries/AP_Math/polygon.cpp
+++ b/libraries/AP_Math/polygon.cpp
@@ -37,9 +37,21 @@
 template <typename T>
 bool Polygon_outside(const Vector2<T> &P, const Vector2<T> *V, unsigned n)
 {
+    const bool complete = Polygon_complete(V, n);
+    if (complete) {
+        // the last point is the same as the first point; treat as if
+        // the last point wasn't passed in
+        n--;
+    }
+
     unsigned i, j;
+    // step through each edge pair-wise looking for crossings:
     bool outside = true;
-    for (i = 0, j = n-1; i < n; j = i++) {
+    for (i=0; i<n; i++) {
+        j = i+1;
+        if (j >= n) {
+            j = 0;
+        }
         if ((V[i].y > P.y) == (V[j].y > P.y)) {
             continue;
         }

--- a/libraries/AP_Math/tests/test_polygon.cpp
+++ b/libraries/AP_Math/tests/test_polygon.cpp
@@ -75,6 +75,8 @@ TEST(Polygon, square_boundaries)
         memcpy(v, pb.boundary, sizeof(pb.boundary));
         v[4] = v[0]; // close it
         EXPECT_EQ(pb.outside, Polygon_outside(pb.point, v, 5));
+        EXPECT_EQ(Polygon_outside(pb.point, v, 4),
+                  Polygon_outside(pb.point, v, 5));
     }
 }
 
@@ -89,6 +91,8 @@ TEST(Polygon, circle_outside_triangle)
         const float x = radius * sin(radians(i)) + 0.5f;
         const float y = radius * cos(radians(i)) + 0.5f;
         EXPECT_EQ(true, Polygon_outside(Vector2f{x,y}, triangle_closed, 4));
+        EXPECT_EQ(Polygon_outside(Vector2f{x,y}, triangle_closed, 3),
+                  Polygon_outside(Vector2f{x,y}, triangle_closed, 4));
     }
 }
 
@@ -103,6 +107,8 @@ TEST(Polygon, circle_inside_triangle)
         const float x = radius * sin(radians(i)) + 0.2f;
         const float y = radius * cos(radians(i)) + 0.2f;
         EXPECT_EQ(false, Polygon_outside(Vector2f{x,y}, triangle_closed, 4));
+        EXPECT_EQ(Polygon_outside(Vector2f{x,y}, triangle_closed, 3),
+                  Polygon_outside(Vector2f{x,y}, triangle_closed, 4));
     }
 }
 
@@ -117,6 +123,8 @@ TEST(Polygon, circle_outside_square)
         const float x = radius * sin(radians(i)) + 5.0f;
         const float y = radius * cos(radians(i)) + 5.0f;
         EXPECT_EQ(true, Polygon_outside(Vector2f{x,y}, square_closed, 4));
+        EXPECT_EQ(Polygon_outside(Vector2f{x,y}, square_closed, 3),
+                  Polygon_outside(Vector2f{x,y}, square_closed, 4));
     }
 }
 

--- a/libraries/AP_Math/tests/test_polygon.cpp
+++ b/libraries/AP_Math/tests/test_polygon.cpp
@@ -1,7 +1,7 @@
 #include <AP_gtest.h>
 #include <AP_Common/AP_Common.h>
 
-#include <AP_Math/polygon.h>
+#include <AP_Math/AP_Math.h>
 
 struct PB {
     Vector2f point;
@@ -53,6 +53,72 @@ TEST(Polygon, outside)
     }
 }
 
+struct SquareBoundary {
+    Vector2f point;
+    Vector2f boundary[4];
+    bool outside;
+};
+static const SquareBoundary square_boundaries[] = {
+    { {1.0f,1.0f}, {{0.0f,0.0f}, {0.0f,10.0f}, {10.0, 10.0}, {10.0f,0.0f}}, false },
+    { {9.0f,9.0f}, {{0.0f,0.0f}, {0.0f,10.0f}, {10.0, 10.0}, {10.0f,0.0f}}, false },
+    { {1.0f,9.0f}, {{0.0f,0.0f}, {0.0f,10.0f}, {10.0, 10.0}, {10.0f,0.0f}}, false },
+    { {9.0f,1.0f}, {{0.0f,0.0f}, {0.0f,10.0f}, {10.0, 10.0}, {10.0f,0.0f}}, false },
+
+};
+
+TEST(Polygon, square_boundaries)
+{
+    // uint8_t count = 0;
+    for (const auto &pb : square_boundaries) {
+        // ::fprintf(stderr, "count=%u\n", count++);
+        Vector2f v[5];
+        memcpy(v, pb.boundary, sizeof(pb.boundary));
+        v[4] = v[0]; // close it
+        EXPECT_EQ(pb.outside, Polygon_outside(pb.point, v, 5));
+    }
+}
+
+TEST(Polygon, circle_outside_triangle)
+{
+    const Vector2f triangle[] = {{0.0f,0.0f}, {1.0f,0.0f}, {0.0f,1.0f}};
+    Vector2f triangle_closed[4];
+    memcpy(triangle_closed, triangle, sizeof(triangle));
+    triangle_closed[3] = triangle_closed[0];
+    const float radius = 0.8f;
+    for (uint16_t i=0; i<360; i++) {
+        const float x = radius * sin(radians(i)) + 0.5f;
+        const float y = radius * cos(radians(i)) + 0.5f;
+        EXPECT_EQ(true, Polygon_outside(Vector2f{x,y}, triangle_closed, 4));
+    }
+}
+
+TEST(Polygon, circle_inside_triangle)
+{
+    const Vector2f triangle[] = {{0.0f,0.0f}, {1.0f,0.0f}, {0.0f,1.0f}};
+    Vector2f triangle_closed[4];
+    memcpy(triangle_closed, triangle, sizeof(triangle));
+    triangle_closed[3] = triangle_closed[0];
+    const float radius = 0.2f;
+    for (uint16_t i=0; i<360; i++) {
+        const float x = radius * sin(radians(i)) + 0.2f;
+        const float y = radius * cos(radians(i)) + 0.2f;
+        EXPECT_EQ(false, Polygon_outside(Vector2f{x,y}, triangle_closed, 4));
+    }
+}
+
+TEST(Polygon, circle_outside_square)
+{
+    const Vector2f square[] = {{0.0f,0.0f}, {0.0f,10.0f}, {10.0, 10.0}, {10.0f,0.0f}};
+    Vector2f square_closed[5];
+    memcpy(square_closed, square, sizeof(square));
+    square_closed[4] = square_closed[0];
+    const float radius = 8.0f;
+    for (uint16_t i=0; i<360; i++) {
+        const float x = radius * sin(radians(i)) + 5.0f;
+        const float y = radius * cos(radians(i)) + 5.0f;
+        EXPECT_EQ(true, Polygon_outside(Vector2f{x,y}, square_closed, 4));
+    }
+}
 
 struct PB_long {
     Vector2l point;

--- a/libraries/AP_Math/tests/test_polygon.cpp
+++ b/libraries/AP_Math/tests/test_polygon.cpp
@@ -104,6 +104,19 @@ TEST(Polygon, outside_long)
     }
 }
 
+TEST(Polygon, outside_long_closed_equal_to_unclosed)
+{
+    // uint8_t count = 0;
+    for (const struct PB_long &pb : points_boundaries_long) {
+        // ::fprintf(stderr, "count=%u\n", count++);
+        Vector2l v[4];
+        memcpy(v, pb.boundary, sizeof(pb.boundary));
+        v[3] = v[0]; // close it
+        EXPECT_EQ(Polygon_outside(pb.point, v, 3),
+                  Polygon_outside(pb.point, v, 4));
+    }
+}
+
 
 #define TEST_POLYGON_POINTS(POLYGON, TEST_POINTS)                       \
     do {                                                                \

--- a/libraries/AP_Math/tests/test_polygon.cpp
+++ b/libraries/AP_Math/tests/test_polygon.cpp
@@ -112,6 +112,55 @@ TEST(Polygon, circle_inside_triangle)
     }
 }
 
+TEST(Polygon, complex)
+{
+    const Vector2f poly[] = {
+        {0.0f,0.0f},
+        {0.0f,10.0f},
+        {5.0, 10.0f},
+        {5.0f,5.0f},
+        {3.0f,5.0f},
+        {3.0f,6.0f},
+        {4.0f,6.0f},
+        {4.0f,9.0f},
+        {4.0f,9.0f},
+        {1.0f,9.0f},
+        {1.0f,6.0f},
+        {2.0f,6.0f},
+        {2.0f,5.0f},
+        {1.0f,5.0f},
+        {1.0f,0.0f},
+    };
+    const Vector2f inside_points[] = {
+        {0.1f, 0.1f},
+        {4.5f, 9.5f},
+        {0.5f, 9.5f},
+    };
+    const Vector2f outside_points[] = {
+        {3.0f, 8.0f},
+        {5.5f, 10.0f},
+        {2.0f, 2.0f},
+        {2.5f, 5.5f},
+        {1.5f, 6.5f},
+    };
+
+    Vector2f closed_poly[sizeof(poly) + sizeof(Vector2f)];
+    memcpy(closed_poly, poly, sizeof(poly));
+    const uint16_t n = ARRAY_SIZE(closed_poly);
+    closed_poly[n-1] = closed_poly[0];
+
+    for (const auto &point : inside_points) {
+        EXPECT_EQ(false, Polygon_outside(point, closed_poly, n));
+        EXPECT_EQ(Polygon_outside(point, closed_poly, n-1),
+                  Polygon_outside(point, closed_poly, n));
+    }
+    for (const auto &point : outside_points) {
+        EXPECT_EQ(true, Polygon_outside(point, closed_poly, n));
+        EXPECT_EQ(Polygon_outside(point, closed_poly, n-1),
+                  Polygon_outside(point, closed_poly, n));
+    }
+}
+
 TEST(Polygon, circle_outside_square)
 {
     const Vector2f square[] = {{0.0f,0.0f}, {0.0f,10.0f}, {10.0, 10.0}, {10.0f,0.0f}};


### PR DESCRIPTION
`_fence.boundary_breached` strictly ignores the first point in the list returned.  That's OK if your first point is the fence return point - but AC_Avoid's boundaries don't include that!

The boundary returned by the proximity sensor also doesn't include the closing (duplicate) point, and the new fence storage code will not include it in storage - i.e. the polygon will come along with a count of the number of points in the polygon and not rely on the duplicate-point method.  So this PR also changes the fence and beacon code to not include the closing point in the boundary polygon.

The Polygon_outside code has been duplicated to Polygon_outside_unclosed so the Plane code doesn't change behaviour, and to show in the tests that the new function provides the same answers as the original.  If tridge is satisfied they have the same behaviour then we could remove the "closed" version and rename the "unclosed" version.
