### PR TITLE
ChibiOS: fix I2C transactions

### DIFF
--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -269,7 +269,7 @@ bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
                                            recv, recv_len, chTimeMS2I(timeout_ms));
         }
 
-        i2cStop(I2CD[bus.busnum].i2c);
+        i2cSoftStop(I2CD[bus.busnum].i2c);
         osalDbgAssert(I2CD[bus.busnum].i2c->state == I2C_STOP, "i2cStart state");
         
         bus.dma_handle->unlock();


### PR DESCRIPTION
Since when we start calling i2cStop() after each transfer, the I2C bus was malfunctioning because we disable the device before it has time to complete the last ack (when receiving data) or the stop condition.

I caught this bug because the device I'm working with require the stop condition and doesn't work with repeated starts. I guess this is not a problem for most of other devices because they work normally with repeated starts and don't care about the NACKs  from the master controller.

Trace the bus before this change:
![tfmini-stm32-request-version](https://user-images.githubusercontent.com/31864/58314200-de1c4480-7dc3-11e9-85eb-5f08fe624bb8.png)
![tfmini-stm32-response-version](https://user-images.githubusercontent.com/31864/58314206-e1173500-7dc3-11e9-9370-98dd6ca80b8e.png)

Trace after the change:
![i2c-with-stop](https://user-images.githubusercontent.com/31864/58314226-ed9b8d80-7dc3-11e9-8f8f-559039e831e2.png)


This was tested with a CUAVv5, i.e. a stm32f7 that uses the I2Cv2 driver in ChibiOS. I also changed the I2Cv1 and I2Cv3 with similar changes to contemplate the other boards we support, but those are only compile-tested.

Thanks to Sergey who helped me debug the issue with his pixracer: https://discuss.ardupilot.org/t/pixracer-does-not-work-with-tfmini-i2c-lidar-chibios/41261/7