### PR TITLE
SITL: JSBSim: Fix comments

### DIFF
--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -13,7 +13,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-  simulator connector for ardupilot version of JSBSim
+  simulator connector for JSBSim
 */
 
 #include "SIM_JSBSim.h"

--- a/libraries/SITL/SIM_JSBSim.h
+++ b/libraries/SITL/SIM_JSBSim.h
@@ -13,7 +13,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-  simulator connection for ardupilot version of JSBSim
+  simulator connection for JSBSim - https://github.com/JSBSim-Team/jsbsim
 */
 
 #pragma once
@@ -155,8 +155,7 @@ public:
     float gear_compression[FG_MAX_WHEELS];
 
     // Environment
-    uint32_t cur_time;           // current unix time
-                                 // FIXME: make this uint64_t before 2038
+    uint32_t cur_time;           // current simulation time of JSBSim
     int32_t warp;                // offset in seconds to unix time
     float visibility;            // visibility in meters (for env. effects)
 


### PR DESCRIPTION
We are now compatible with the latest JSBSim master
The usage of the `cur_time` variable changed in PR https://github.com/ArduPilot/ardupilot/pull/11217, specifically commit https://github.com/ArduPilot/ardupilot/pull/11217/commits/552644845402bd42151eb028a6d66226a7853d36 which tells JSBSim to send the current simulation time instead of unix time