### PR TITLE
AP_Soaring: Vario improvements

### DIFF
--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -132,7 +132,7 @@ SoaringController::SoaringController(AP_AHRS &ahrs, AP_SpdHgtControl &spdHgt, co
     _ahrs(ahrs),
     _spdHgt(spdHgt),
     _vario(ahrs,parms),
-    _loiter_rad(parms.loiter_radius),
+    _aparm(parms),
     _throttle_suppressed(true)
 {
     AP_Param::setup_object_defaults(this, var_info);
@@ -177,7 +177,7 @@ bool SoaringController::check_thermal_criteria()
 
 bool SoaringController::check_cruise_criteria()
 {
-    float thermalability = (_ekf.X[0]*expf(-powf(_loiter_rad / _ekf.X[1], 2))) - EXPECTED_THERMALLING_SINK;
+    float thermalability = (_ekf.X[0]*expf(-powf(_aparm.loiter_radius / _ekf.X[1], 2))) - EXPECTED_THERMALLING_SINK;
     float alt = _vario.alt;
 
     if (soar_active && (AP_HAL::micros64() - _thermal_start_time_us) > ((unsigned)min_thermal_s * 1e6) && thermalability < McCready(alt)) {

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -30,6 +30,7 @@ class SoaringController {
     AP_AHRS &_ahrs;
     AP_SpdHgtControl &_spdHgt;
     Variometer _vario;
+    const AP_Vehicle::FixedWing &_aparm;
 
     // store aircraft location at last update
     struct Location _prev_update_location;
@@ -43,7 +44,6 @@ class SoaringController {
     // store time of last update
     unsigned long _prev_update_time;
 
-    float _loiter_rad;
     bool _throttle_suppressed;
 
     float McCready(float alt);

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -6,8 +6,7 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 
 Variometer::Variometer(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms) :
     _ahrs(ahrs),
-    _aparm(parms),
-    new_data(false)
+    _aparm(parms)
 {
 }
 
@@ -50,7 +49,6 @@ void Variometer::update(const float polar_K, const float polar_B, const float po
     displayed_reading = TE_FILT_DISPLAYED * reading + (1 - TE_FILT_DISPLAYED) * displayed_reading;
 
     _prev_update_time = AP_HAL::micros64();
-    new_data = true;
 
     AP::logger().Write("VAR", "TimeUS,aspd_raw,aspd_filt,alt,roll,raw,filt", "Qffffff",
                        AP_HAL::micros64(),

--- a/libraries/AP_Soaring/Variometer.h
+++ b/libraries/AP_Soaring/Variometer.h
@@ -40,7 +40,6 @@ public:
     float reading;
     float filtered_reading;
     float displayed_reading;
-    bool new_data;
 
     void update(const float polar_K, const float polar_CD0, const float polar_B);
     float correct_netto_rate(float climb_rate, float phi, float aspd, const float polar_K, const float polar_CD0, const float polar_B);

--- a/libraries/AP_Soaring/Variometer.h
+++ b/libraries/AP_Soaring/Variometer.h
@@ -29,6 +29,11 @@ class Variometer {
     float _last_roll;
     float _last_total_E;
 
+    // declares a 5point average filter using floats
+    AverageFilterFloat_Size5 _vdot_filter;
+
+    AverageFilterFloat_Size5 _sp_filter;
+
 public:
     Variometer(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms);
     float alt;


### PR DESCRIPTION
This updates the method of estimating the air mass vertical speed.

The previous method calculated a total energy estimate from height and airspeed, and differentiated this to get rate of change. This suffered from noise from the barometer and airspeed sensors. Filtering was needed, and the phase lags of the filters were different, causing imperfect total energy compensation.

The new method uses the analytical differential with the EKF vertical velocity estimate and the x acceleration as rates of change of height and speed. This gives lower noise and better total energy compensation.

The last commit fixes an unrelated bug that could lead soaring to stay in thermals it shouldn't have.