### PR TITLE
AP_Proximity: RPLidarA2 driver gets support for PRX_YAW_CORR and PRX_ORIENT params

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -50,7 +50,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Units: deg
     // @Range: -180 180
     // @User: Standard
-    AP_GROUPINFO("_YAW_CORR", 3, AP_Proximity, _yaw_correction[0], PROXIMITY_YAW_CORRECTION_DEFAULT),
+    AP_GROUPINFO("_YAW_CORR", 3, AP_Proximity, _yaw_correction[0], 0),
 
     // @Param: _IGN_ANG1
     // @DisplayName: Proximity sensor ignore angle 1
@@ -170,7 +170,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Units: deg
     // @Range: -180 180
     // @User: Standard
-    AP_GROUPINFO("2_YAW_CORR", 18, AP_Proximity, _yaw_correction[1], PROXIMITY_YAW_CORRECTION_DEFAULT),
+    AP_GROUPINFO("2_YAW_CORR", 18, AP_Proximity, _yaw_correction[1], 0),
 #endif
 
     AP_GROUPEND

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -22,7 +22,6 @@
 #include <AP_RangeFinder/AP_RangeFinder.h>
 
 #define PROXIMITY_MAX_INSTANCES             1   // Maximum number of proximity sensor instances available on this platform
-#define PROXIMITY_YAW_CORRECTION_DEFAULT    22  // default correction for sensor error in yaw
 #define PROXIMITY_MAX_IGNORE                6   // up to six areas can be ignored
 #define PROXIMITY_MAX_DIRECTION 8
 #define PROXIMITY_SENSOR_ID_START 10

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -394,7 +394,8 @@ void AP_Proximity_RPLidarA2::parse_response_data()
             Debug(2, "UART %02x %02x%02x %02x%02x", payload[0], payload[2], payload[1], payload[4], payload[3]); //show HEX values
             // check if valid SCAN packet: a valid packet starts with startbits which are complementary plus a checkbit in byte+1
             if ((payload.sensor_scan.startbit == !payload.sensor_scan.not_startbit) && payload.sensor_scan.checkbit) {
-                const float angle_deg = payload.sensor_scan.angle_q6/64.0f;
+                const float angle_sign = (frontend.get_orientation(state.instance) == 1) ? -1.0f : 1.0f;
+                const float angle_deg = wrap_360(payload.sensor_scan.angle_q6/64.0f * angle_sign + frontend.get_yaw_correction(state.instance));
                 const float distance_m = (payload.sensor_scan.distance_q2/4000.0f);
 #if RP_DEBUG_LEVEL >= 2
                 const float quality = payload.sensor_scan.quality;


### PR DESCRIPTION
This PR makes two unrelated changes to the AP_Proximity library;

- the RPLidarA2 360 deg lidar gets support for the PRX_YAW_CORR and PRX_ORIENT parameters which allow the user to mount the lidar in various ways like they can with the Lightware SF40C and mavlink enabled lidar
- change the default yaw correct to 0deg.  22deg was a good default for the SF40c (I think) but not for other lidar.

This has been tested on a real vehicle.  I think the application of the ORIENT (i.e. upside down) before the YAW_CORR is the best way to do it and is consistent with other drivers.