### PR TITLE
Rover: send POSITION_TARGET_GLOBAL_INT msg to ground stations

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -73,6 +73,30 @@ MAV_STATE GCS_MAVLINK_Rover::system_status() const
     return MAV_STATE_ACTIVE;
 }
 
+void GCS_MAVLINK_Rover::send_position_target_global_int()
+{
+    Location target;
+    if (!rover.control_mode->get_desired_location(target)) {
+        return;
+    }
+    mavlink_msg_position_target_global_int_send(
+        chan,
+        AP_HAL::millis(), // time_boot_ms
+        MAV_FRAME_GLOBAL_INT, // targets are always global altitude
+        0xFFF8, // ignore everything except the x/y/z components
+        target.lat, // latitude as 1e7
+        target.lng, // longitude as 1e7
+        target.alt * 0.01f, // altitude is sent as a float
+        0.0f, // vx
+        0.0f, // vy
+        0.0f, // vz
+        0.0f, // afx
+        0.0f, // afy
+        0.0f, // afz
+        0.0f, // yaw
+        0.0f); // yaw_rate
+}
+
 void GCS_MAVLINK_Rover::send_nav_controller_output() const
 {
     if (!rover.control_mode->is_autopilot_mode()) {
@@ -438,6 +462,7 @@ static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_GPS2_RTK,
     MSG_NAV_CONTROLLER_OUTPUT,
     MSG_FENCE_STATUS,
+    MSG_POSITION_TARGET_GLOBAL_INT,
 };
 static const ap_message STREAM_POSITION_msgs[] = {
     MSG_LOCATION,

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -21,6 +21,8 @@ protected:
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
+    void send_position_target_global_int() override;
+
     virtual bool in_hil_mode() const override;
 
     bool persist_streamrates() const override { return true; }

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -104,6 +104,10 @@ public:
     // return distance (in meters) to destination
     virtual float get_distance_to_destination() const { return 0.0f; }
 
+    // return desired location (used in Guided, Auto, RTL, etc)
+    // return true on success, false if there is no valid destination
+    virtual bool get_desired_location(Location& destination) const WARN_IF_UNUSED { return false; }
+
     // set desired location (used in Guided, Auto)
     //   next_leg_bearing_cd should be heading to the following waypoint (used to slow the vehicle in order to make the turn)
     virtual bool set_desired_location(const struct Location& destination, float next_leg_bearing_cd = AR_WPNAV_HEADING_UNKNOWN) WARN_IF_UNUSED;
@@ -252,7 +256,8 @@ public:
     // return distance (in meters) to destination
     float get_distance_to_destination() const override;
 
-    // set desired location
+    // get or set desired location
+    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
     bool set_desired_location(const struct Location& destination, float next_leg_bearing_cd = AR_WPNAV_HEADING_UNKNOWN) override WARN_IF_UNUSED;
     bool reached_destination() const override;
 
@@ -366,8 +371,11 @@ public:
     // return true if vehicle has reached destination
     bool reached_destination() const override;
 
-    // set desired location, heading and speed
+    // get or set desired location
+    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
     bool set_desired_location(const struct Location& destination, float next_leg_bearing_cd = AR_WPNAV_HEADING_UNKNOWN) override WARN_IF_UNUSED;
+
+    // set desired heading and speed
     void set_desired_heading_and_speed(float yaw_angle_cd, float target_speed) override;
 
     // set desired heading-delta, turn-rate and speed
@@ -448,6 +456,9 @@ public:
     float nav_bearing() const override { return _desired_yaw_cd * 0.01f; }
     float crosstrack_error() const override { return 0.0f; }
 
+    // return desired location
+    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
+
     // return distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
 
@@ -495,6 +506,10 @@ public:
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
 
+    // return desired location
+    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
+
+    // return distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
     bool reached_destination() const override;
 
@@ -518,6 +533,10 @@ public:
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
 
+    // return desired location
+    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
+
+    // return distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
     bool reached_destination() const override { return smart_rtl_state == SmartRTL_StopAtHome; }
 
@@ -596,6 +615,9 @@ public:
     float wp_bearing() const override;
     float nav_bearing() const override { return wp_bearing(); }
     float crosstrack_error() const override { return 0.0f; }
+
+    // return desired location
+    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED { return false; }
 
     // return distance (in meters) to destination
     float get_distance_to_destination() const override;

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -131,6 +131,31 @@ float ModeAuto::get_distance_to_destination() const
     return 0.0f;
 }
 
+// get desired location
+bool ModeAuto::get_desired_location(Location& destination) const
+{
+    switch (_submode) {
+    case Auto_WP:
+        if (g2.wp_nav.is_destination_valid()) {
+            destination = g2.wp_nav.get_destination();
+            return true;
+        }
+        return false;
+    case Auto_HeadingAndSpeed:
+        // no desired location for this submode
+        return false;
+    case Auto_RTL:
+        return rover.mode_rtl.get_desired_location(destination);
+    case Auto_Loiter:
+        return rover.mode_loiter.get_desired_location(destination);
+    case Auto_Guided:
+        return rover.mode_guided.get_desired_location(destination);\
+    }
+
+    // we should never reach here but just in case
+    return false;
+}
+
 // set desired location to drive to
 bool ModeAuto::set_desired_location(const struct Location& destination, float next_leg_bearing_cd)
 {

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -145,6 +145,29 @@ bool ModeGuided::reached_destination() const
     return true;
 }
 
+// get desired location
+bool ModeGuided::get_desired_location(Location& destination) const
+{
+    switch (_guided_mode) {
+    case Guided_WP:
+        if (g2.wp_nav.is_destination_valid()) {
+            destination = g2.wp_nav.get_destination();
+            return true;
+        }
+        return false;
+    case Guided_HeadingAndSpeed:
+    case Guided_TurnRateAndSpeed:
+        // not supported in these submodes
+        return false;
+    case Guided_Loiter:
+        // get destination from loiter
+        return rover.mode_loiter.get_desired_location(destination);
+    }
+
+    // should never get here but just in case
+    return false;
+}
+
 // set desired location
 bool ModeGuided::set_desired_location(const struct Location& destination,
                                       float next_leg_bearing_cd)

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -52,3 +52,10 @@ void ModeLoiter::update()
     calc_steering_to_heading(_desired_yaw_cd);
     calc_throttle(_desired_speed, true);
 }
+
+// get desired location
+bool ModeLoiter::get_desired_location(Location& destination) const
+{
+    destination = _destination;
+    return true;
+}

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -58,6 +58,16 @@ void ModeRTL::update()
     }
 }
 
+// get desired location
+bool ModeRTL::get_desired_location(Location& destination) const
+{
+    if (g2.wp_nav.is_destination_valid()) {
+        destination = g2.wp_nav.get_destination();
+        return true;
+    }
+    return false;
+}
+
 bool ModeRTL::reached_destination() const
 {
     return g2.wp_nav.reached_destination();

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -86,6 +86,26 @@ void ModeSmartRTL::update()
     }
 }
 
+// get desired location
+bool ModeSmartRTL::get_desired_location(Location& destination) const
+{
+    switch (smart_rtl_state) {
+    case SmartRTL_WaitForPathCleanup:
+        return false;
+    case SmartRTL_PathFollow:
+        if (g2.wp_nav.is_destination_valid()) {
+            destination = g2.wp_nav.get_destination();
+            return true;
+        }
+        return false;
+    case SmartRTL_StopAtHome:
+    case SmartRTL_Failure:
+        return false;
+    }
+    // should never reach here but just in case
+    return false;
+}
+
 // save current position for use by the smart_rtl flight mode
 void ModeSmartRTL::save_position()
 {

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -51,6 +51,9 @@ public:
     // return distance (in meters) to destination
     float get_distance_to_destination() const { return _distance_to_destination; }
 
+    // return true if destination is valid
+    bool is_destination_valid() const { return _orig_and_dest_valid; }
+
     // get current destination. Note: this is not guaranteed to be valid (i.e. _orig_and_dest_valid is not checked)
     const Location &get_destination() { return _destination; }
 


### PR DESCRIPTION
This PR modifies Rover to send the POSITION_TARGET_GLOBAL_INT message in line with Copter and Plane.

This is useful because it means the ground stations can plot the exact target location on the map instead of having to calculate the target position using the vehicle's latest position and the contents of the NAV_CONTROLLER_OUTPUT message which can introduce some error because the messages are unlikely to arrive at exactly the same time.

Each flight mode is responsible for providing the position target it is heading for by overriding the new "get_desired_location()" method.  The equivalent method in Copter mode's is get_wp().

This has been tested in SITL and with MAVProxy at least it leads to an additional line appearing on the map as shown below.

![rover-send-global-pos-target-int](https://user-images.githubusercontent.com/1498098/58403558-ee6f4080-809d-11e9-8e78-346e66cd5e49.png)


