### PR TITLE
Provide support for D-term logging

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -244,3 +244,9 @@ uint16_t Copter::get_pilot_speed_dn()
         return abs(g2.pilot_speed_dn);
     }
 }
+
+// Flush the logging of dterm updates to the log
+void Copter::flush_dterm_update_logs()
+{
+    attitude_control->periodic();
+}

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -156,6 +156,9 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Logger,      &copter.logger,           periodic_tasks, 400, 300),
 #endif
     SCHED_TASK_CLASS(AP_InertialSensor,    &copter.ins,                 periodic,       400,  50),
+#if FRAME_CONFIG != HELI_FRAME
+    SCHED_TASK(flush_dterm_update_logs,400,  50),
+#endif
     SCHED_TASK_CLASS(AP_Scheduler,         &copter.scheduler,           update_logging, 0.1,  75),
 #if RPM_ENABLED == ENABLED
     SCHED_TASK(rpm_update,            40,    200),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -624,6 +624,7 @@ private:
     void set_accel_throttle_I_from_pilot_throttle();
     void rotate_body_frame_to_NE(float &x, float &y);
     uint16_t get_pilot_speed_dn();
+    void flush_dterm_update_logs();
 
 #if ADSB_ENABLED == ENABLED
     // avoidance_adsb.cpp

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -144,6 +144,10 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("INPUT_TC", 20, AC_AttitudeControl, _input_tc, AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT),
 
+    // @Group: LOG_
+    // @Path: ../AC_AttitudeControl/DTermBatchSampler.cpp
+    AP_SUBGROUPINFO(batchsampler, "LOG_",  21, AC_AttitudeControl, AC_AttitudeControl::DTermBatchSampler),
+
     AP_GROUPEND
 };
 
@@ -1180,4 +1184,9 @@ bool AC_AttitudeControl::pre_arm_checks(const char *param_prefix,
         }
     }
     return true;
+}
+
+void AC_AttitudeControl::periodic()
+{
+    batchsampler.periodic();
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -256,6 +256,7 @@ void AC_AttitudeControl_Multi::rate_controller_run()
     update_throttle_rpy_mix();
 
     Vector3f gyro_latest = _ahrs.get_gyro_latest();
+
     _motors.set_roll(rate_target_to_motor_roll(gyro_latest.x, _rate_target_ang_vel.x));
     _motors.set_pitch(rate_target_to_motor_pitch(gyro_latest.y, _rate_target_ang_vel.y));
     _motors.set_yaw(rate_target_to_motor_yaw(gyro_latest.z, _rate_target_ang_vel.z));
@@ -284,4 +285,7 @@ void AC_AttitudeControl_Multi::parameter_sanity_check()
         _thr_mix_min.set_and_save(AC_ATTITUDE_CONTROL_MIN_DEFAULT);
         _thr_mix_max.set_and_save(AC_ATTITUDE_CONTROL_MAX_DEFAULT);
     }
+
+    // Initialize the batch sampler
+    batchsampler.init(_dt);
 }

--- a/libraries/AC_AttitudeControl/ControlMonitor.cpp
+++ b/libraries/AC_AttitudeControl/ControlMonitor.cpp
@@ -34,6 +34,14 @@ void AC_AttitudeControl::control_monitor_update(void)
 
     const AP_Logger::PID_Info &iyaw   = get_rate_yaw_pid().get_pid_info();
     control_monitor_filter_pid(iyaw.P + iyaw.D + iyaw.FF,  _control_monitor.rms_yaw);
+
+    // Pre-fiter sample
+    const Vector3f sample(get_rate_roll_pid().get_raw_derivative(), get_rate_pitch_pid().get_raw_derivative(), get_rate_yaw_pid().get_raw_derivative());
+    batchsampler.sample(AC_AttitudeControl::DTERM_PRE_FILTER_CONTROL_POINT, AP_HAL::micros64(), sample);
+
+    // Post-filter sample
+    const Vector3f sample2(get_rate_roll_pid().get_derivative(), get_rate_pitch_pid().get_derivative(), get_rate_yaw_pid().get_derivative());
+    batchsampler.sample(AC_AttitudeControl::DTERM_POST_FILTER_CONTROL_POINT, AP_HAL::micros64(), sample2);
 }
 
 /*

--- a/libraries/AC_AttitudeControl/DTermBatchSampler.cpp
+++ b/libraries/AC_AttitudeControl/DTermBatchSampler.cpp
@@ -1,0 +1,228 @@
+#include "AC_AttitudeControl.h"
+#include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
+
+// Class level parameters
+const AP_Param::GroupInfo AC_AttitudeControl::DTermBatchSampler::var_info[] = {
+    // @Param: BAT_CNT
+    // @DisplayName: sample count per batch
+    // @Description: Number of samples to take when logging streams of IMU sensor readings.  Will be rounded down to a multiple of 32.
+    // @User: Advanced
+    // @Increment: 32
+    AP_GROUPINFO("BAT_CNT",  1, AC_AttitudeControl::DTermBatchSampler, _required_count,   1024),
+
+    // @Param: BAT_MASK
+    // @DisplayName: Control Term Bitmask
+    // @Description: Bitmap of which control terms to log batch data for
+    // @User: Advanced
+    // @Values: 0:None,1:Raw D-Term input,2:Post-filter D-Term output,255:All
+    // @Bitmask: 0:Raw-DTerm,1:Filter-DTerm
+    AP_GROUPINFO("BAT_MASK",  2, AC_AttitudeControl::DTermBatchSampler, _control_mask,   DEFAULT_AC_ATTITUDE_LOG_BAT_MASK),
+
+    // @Param: BAT_OPT
+    // @DisplayName: Batch Logging Options Mask
+    // @Description: Options for the BatchSampler
+    // @User: Advanced
+    AP_GROUPINFO("BAT_OPT",  3, AC_AttitudeControl::DTermBatchSampler, _batch_options_mask, 0),
+
+    // @Param: BAT_LGIN
+    // @DisplayName: logging interval
+    // @Description: Interval between pushing samples to the DataFlash log
+    // @Units: ms
+    // @Increment: 10
+    AP_GROUPINFO("BAT_LGIN", 4, AC_AttitudeControl::DTermBatchSampler, push_interval_ms,   20),
+
+    // @Param: BAT_LGCT
+    // @DisplayName: logging count
+    // @Description: Number of samples to push to count every @PREFIX@BAT_LGIN
+    // @Increment: 1
+    AP_GROUPINFO("BAT_LGCT", 5, AC_AttitudeControl::DTermBatchSampler, samples_per_msg,   32),
+
+    AP_GROUPEND
+};
+
+
+extern const AP_HAL::HAL& hal;
+void AC_AttitudeControl::DTermBatchSampler::init(float dt)
+{
+    if (_control_mask == 0) {
+        return;
+    }
+    if (_required_count <= 0) {
+        return;
+    }
+
+    // MPU-6000 can measure +/- 2000 deg/s, so multiplier should be maximum change in dt
+    // This works well in SITL, but saturates in actual flight
+    // multiplier = INT16_MAX/(radians(2000)*dt);
+    multiplier = INT16_MAX/(radians(2000)/dt);
+    _required_count -= _required_count % 32; // round down to nearest multiple of 32
+
+    const uint32_t total_allocation = 3*_required_count*sizeof(uint16_t);
+    gcs().send_text(MAV_SEVERITY_DEBUG, "ATC: alloc %u bytes for ISB (free=%u)", total_allocation, hal.util->available_memory());
+
+    data_x = (int16_t*)calloc(_required_count, sizeof(int16_t));
+    data_y = (int16_t*)calloc(_required_count, sizeof(int16_t));
+    data_z = (int16_t*)calloc(_required_count, sizeof(int16_t));
+    if (data_x == nullptr || data_y == nullptr || data_z == nullptr) {
+        free(data_x);
+        free(data_y);
+        free(data_z);
+        data_x = nullptr;
+        data_y = nullptr;
+        data_z = nullptr;
+        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to allocate %u bytes for ATC batch sampling", total_allocation);
+        return;
+    }
+
+    rotate_to_next_control_point();
+
+    initialised = true;
+}
+
+void AC_AttitudeControl::DTermBatchSampler::periodic()
+{
+    if (_control_mask == 0) {
+        return;
+    }
+    push_data_to_log();
+}
+
+void AC_AttitudeControl::DTermBatchSampler::rotate_to_next_control_point()
+{
+    if (_control_mask == 0) {
+        // should not have been called
+        return;
+    }
+    if ((1U<<control_point) > (uint8_t)_control_mask) {
+        // should only ever happen if user resets _control_mask
+        control_point = 0;
+    }
+
+    // find next control point to log:
+    bool haveinstance = false;
+    for (uint8_t i=control_point+1; i<AC_ATTITUDE_LOG_MAX_CONTROL_POINTS; i++) {
+        if (_control_mask & (1U<<i)) {
+            control_point = i;
+            haveinstance = true;
+            break;
+        }
+    }
+    if (!haveinstance) {
+        for (uint8_t i=0; i<=control_point; i++) {
+            if (_control_mask & (1U<<i)) {
+                control_point = i;
+                haveinstance = true;
+                break;
+            }
+        }
+    }
+    if (!haveinstance) {
+        // should not happen!
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        abort();
+#endif
+        control_point = 0;
+        return;
+    }
+}
+
+void AC_AttitudeControl::DTermBatchSampler::push_data_to_log()
+{
+    if (!initialised) {
+        return;
+    }
+    if (_control_mask == 0) {
+        return;
+    }
+    if (data_write_offset - data_read_offset < samples_per_msg) {
+        // insuffucient data to pack a packet
+        return;
+    }
+    if (AP_HAL::millis() - last_sent_ms < (uint16_t)push_interval_ms) {
+        // avoid flooding DataFlash's buffer
+        return;
+    }
+    AP_Logger *dataflash = AP_Logger::get_singleton();
+    if (dataflash == nullptr) {
+        // should not have been called
+        return;
+    }
+
+    // possibly send isb header:
+    if (!isbh_sent && data_read_offset == 0) {
+        float sample_rate = 1.0 / _controller._dt;
+        if (!dataflash->Write_ISBH(isb_seqnum,
+                                   AP_InertialSensor::DTERM_CONTROL_POINT,
+                                   control_point,
+                                   multiplier,
+                                   _required_count,
+                                   measurement_started_us,
+                                   sample_rate)) {
+            // buffer full?
+            return;
+        }
+        isbh_sent = true;
+    }
+    // pack and send a data packet:
+    if (!dataflash->Write_ISBD(isb_seqnum,
+                               data_read_offset/samples_per_msg,
+                               &data_x[data_read_offset],
+                               &data_y[data_read_offset],
+                               &data_z[data_read_offset])) {
+        // maybe later?!
+        return;
+    }
+    data_read_offset += samples_per_msg;
+    last_sent_ms = AP_HAL::millis();
+    if (data_read_offset >= _required_count) {
+        // that was the last one.  Clean up:
+        data_read_offset = 0;
+        isb_seqnum++;
+        isbh_sent = false;
+        // rotate to next instance:
+        rotate_to_next_control_point();
+        data_write_offset = 0; // unlocks writing process
+    }
+}
+
+bool AC_AttitudeControl::DTermBatchSampler::should_log(uint8_t _control_point)
+{
+    if (_control_mask == 0) {
+        return false;
+    }
+    if (!initialised) {
+        return false;
+    }
+    if (_control_point != control_point) {
+        return false;
+    }
+    if (data_write_offset >= _required_count) {
+        return false;
+    }
+    AP_Logger *dataflash = AP_Logger::get_singleton();
+    if (dataflash == nullptr) {
+        return false;
+    }
+#define MASK_LOG_ANY                    0xFFFF
+    if (!dataflash->should_log(MASK_LOG_ANY)) {
+        return false;
+    }
+    return true;
+}
+
+void AC_AttitudeControl::DTermBatchSampler::sample(AC_AttitudeControl::DTERM_CONTROL_POINT_TYPE _control_point, uint64_t sample_us, const Vector3f &_sample)
+{
+    if (!should_log(_control_point)) {
+        return;
+    }
+    if (data_write_offset == 0) {
+        measurement_started_us = sample_us;
+    }
+
+    data_x[data_write_offset] = multiplier*_sample.x;
+    data_y[data_write_offset] = multiplier*_sample.y;
+    data_z[data_write_offset] = multiplier*_sample.z;
+
+    data_write_offset++; // may unblock the reading process
+}

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -47,7 +47,8 @@ AC_PID::AC_PID(float initial_p, float initial_i, float initial_d, float initial_
     _dt(dt),
     _integrator(0.0f),
     _input(0.0f),
-    _derivative(0.0f)
+    _derivative(0.0f),
+    _raw_derivative(0.0f)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
@@ -96,6 +97,7 @@ void AC_PID::set_input_filter_all(float input)
         _flags._reset_filter = false;
         _input = input;
         _derivative = 0.0f;
+        _raw_derivative = 0.0f;
     }
 
     // update filter and calculate derivative
@@ -103,6 +105,7 @@ void AC_PID::set_input_filter_all(float input)
     _input = _input + input_filt_change;
     if (_dt > 0.0f) {
         _derivative = input_filt_change / _dt;
+        _raw_derivative = (input - _input) / _dt;
     }
 }
 
@@ -121,12 +124,13 @@ void AC_PID::set_input_filter_d(float input)
         _flags._reset_filter = false;
         _input = input;
         _derivative = 0.0f;
+        _raw_derivative = 0.0f;
     }
 
     // update filter and calculate derivative
     if (_dt > 0.0f) {
-        float derivative = (input - _input) / _dt;
-        _derivative = _derivative + get_filt_alpha() * (derivative-_derivative);
+        _raw_derivative = (input - _input) / _dt;
+        _derivative = _derivative + get_filt_alpha() * (_raw_derivative -_derivative);
     }
 
     _input = input;

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -75,6 +75,8 @@ public:
 
     float       get_integrator() const { return _integrator; }
     void        set_integrator(float i) { _integrator = i; }
+    float       get_derivative() const { return _derivative; }
+    float       get_raw_derivative() const { return _raw_derivative; }
 
     // set the desired and actual rates (for logging purposes)
     void        set_desired_rate(float desired) { _pid_info.desired = desired; }
@@ -104,6 +106,7 @@ protected:
     float           _dt;                    // timestep in seconds
     float           _integrator;            // integrator value
     float           _input;                 // last input for derivative
+    float           _raw_derivative;        // last raw input derivative
     float           _derivative;            // last derivative for low-pass filter
 
     AP_Logger::PID_Info        _pid_info;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -277,6 +277,7 @@ public:
     enum IMU_SENSOR_TYPE {
         IMU_SENSOR_TYPE_ACCEL = 0,
         IMU_SENSOR_TYPE_GYRO = 1,
+        DTERM_CONTROL_POINT = 2
     };
 
     class BatchSampler {
@@ -337,7 +338,7 @@ public:
         bool _doing_sensor_rate_logging : 1;
         bool _doing_post_filter_logging : 1;
         uint8_t instance : 3; // instance we are sending data for
-        AP_InertialSensor::IMU_SENSOR_TYPE type : 1;
+        AP_InertialSensor::IMU_SENSOR_TYPE type : 2;
         uint16_t isb_seqnum;
         int16_t *data_x;
         int16_t *data_y;

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -104,6 +104,7 @@ void AP_InertialSensor::BatchSampler::update_doing_sensor_rate_logging()
         _doing_sensor_rate_logging = _imu._gyro_sensor_rate_sampling_enabled & bit;
         break;
     case IMU_SENSOR_TYPE_ACCEL:
+    default:
         _doing_sensor_rate_logging = _imu._accel_sensor_rate_sampling_enabled & bit;
         break;
     }
@@ -201,6 +202,7 @@ void AP_InertialSensor::BatchSampler::push_data_to_log()
             }
             break;
         case IMU_SENSOR_TYPE_ACCEL:
+        default:
             sample_rate = _imu._accel_raw_sample_rates[instance];
             if (_doing_sensor_rate_logging) {
                 sample_rate *= _imu._accel_over_sampling[instance];


### PR DESCRIPTION
Provides support for analyzing the frequency characteristics and noise of the D-term, both pre- and post-filter. Betaflight allows this and it's quite key in tuning the D-term filters for small quads.

Fixes #11421 

Configuration options are similar to INS_LOG_BAT_* but named ATC_LOG_BAT*. The key difference is ATC_LOG_BAT_MASK which allows you to set the "control point" as pre-filter (bit 1) and post-filter (bit 2) or both.

In order to aid support for mission planner I have reused the ISDB and ISDH log types, however mission planner doesn't currently understand the type "2" so in order to see the effect you have to log as a gyro. An example trace is shown below.

![image](https://user-images.githubusercontent.com/2893260/58427070-69ccf400-8096-11e9-805b-cd9070dc639c.png)

"Gyro 0" is pre-filter, "Gyro 1" is post-filter

