### PR TITLE
AP_Rangefinder: Dual-phase operation for LidarLite-V3

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
@@ -51,6 +51,7 @@ private:
     uint8_t hw_version;
     uint8_t check_reg_counter;
     bool v2_hardware;
+    bool v3_hardware;
     bool v3hp_hardware;
     uint16_t last_distance_cm;
     RangeFinder::RangeFinder_Type rftype;


### PR DESCRIPTION
Some LidarLite-V3 rangefinders show a constant offset of about 9 meters
in continuous mode, so use measure and collect phases instead and check
status bit to avoid bad readings.

The status check is necessary to avoid occasional false readings of zero.
This change was tested by compiling with the ArduPilot 3.6 branch and
flashing to a Pixhawk1 on a FlameWheel F450 with a LidarLite-V3.

Three plots are attached. The first shows rangefinder output when the
aircraft was initially on the table, then picked up and pointed around the room 
with the ArduPilot 3.6 branch without the change; an offset of over 9 meters
is present. The second shows the data in the same situation with the changed
code. The third plot is data from a flight in which the aircraft took off and 
landed twice, reading good rangefinder data.

![rangefinder_pull_before](https://user-images.githubusercontent.com/35647716/58441687-ccbf8a80-8098-11e9-885c-ce41dcf544a6.png)

![rangefinder_pull_after](https://user-images.githubusercontent.com/35647716/58441694-d8ab4c80-8098-11e9-97c2-6dfd32daf0bf.png)

![rangefinder_pull_flight](https://user-images.githubusercontent.com/35647716/58441710-faa4cf00-8098-11e9-8365-2065316f5c1f.png)
