### PR TITLE
Fix example compilation warnings

### DIFF
--- a/libraries/AP_GPS/examples/GPS_AUTO_test/GPS_AUTO_test.cpp
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/GPS_AUTO_test.cpp
@@ -65,6 +65,7 @@ void setup()
 /*
   print a int32_t lat/long in decimal degrees
  */
+void print_latlon(AP_HAL::BetterStream *s, int32_t lat_or_lon);
 void print_latlon(AP_HAL::BetterStream *s, int32_t lat_or_lon)
 {
     int32_t dec_portion, frac_portion;

--- a/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
+++ b/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
@@ -20,6 +20,9 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
+void setup();
+void loop();
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 #include <AP_RCProtocol/AP_RCProtocol.h>
@@ -33,10 +36,6 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 #include <termios.h>
 #include <string.h>
 #include <errno.h>
-
-void setup();
-void loop();
-
 
 static AP_RCProtocol *rcprot;
 

--- a/libraries/AP_UAVCAN/examples/UAVCAN_sniffer/UAVCAN_sniffer.cpp
+++ b/libraries/AP_UAVCAN/examples/UAVCAN_sniffer/UAVCAN_sniffer.cpp
@@ -41,6 +41,9 @@ void loop();
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 #define UAVCAN_NODE_POOL_SIZE 8192
+#ifdef UAVCAN_NODE_POOL_BLOCK_SIZE
+#undef UAVCAN_NODE_POOL_BLOCK_SIZE
+#endif
 #define UAVCAN_NODE_POOL_BLOCK_SIZE 256
 
 #define debug_uavcan(fmt, args...) do { hal.console->printf(fmt, ##args); } while (0)


### PR DESCRIPTION
I wonder if we should add `-Werror=missing-declaration`
