### PR TITLE
Rover: BendyRuler and Dijkstra's path planning around obstacles

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -92,7 +92,8 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
 
     return (AP_Arming::pre_arm_checks(report)
             & rover.g2.motors.pre_arm_check(report)
-            & fence_checks(report));
+            & fence_checks(report)
+            & oa_check(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
@@ -165,4 +166,21 @@ bool AP_Arming_Rover::disarm(void)
     gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
 
     return true;
+}
+
+// check object avoidance has initialised correctly
+bool AP_Arming_Rover::oa_check(bool report)
+{
+    char failure_msg[50];
+    if (rover.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
+        return true;
+    }
+
+    // display failure
+    if (strlen(failure_msg) == 0) {
+        check_failed(ARMING_CHECK_NONE, report, "Check Object Avoidance");
+    } else {
+        check_failed(ARMING_CHECK_NONE, report, failure_msg);
+    }
+    return false;
 }

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -27,6 +27,7 @@ public:
     void update_soft_armed();
 
 protected:
+    bool oa_check(bool report);
 
 private:
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -633,6 +633,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: sailboat.cpp
     AP_SUBGROUPINFO(sailboat, "SAIL_", 44, ParametersG2, Sailboat),
 
+    // @Group: OA_
+    // @Path: ../libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+    AP_SUBGROUPINFO(oa, "OA_", 45, ParametersG2, AP_OAPathPlanner),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -392,6 +392,9 @@ public:
 
     // Sailboat functions
     Sailboat sailboat;
+
+    // object avoidance path planning
+    AP_OAPathPlanner oa;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -77,6 +77,7 @@
 #include <AC_Fence/AC_Fence.h>
 #include <AP_Proximity/AP_Proximity.h>
 #include <AC_Avoidance/AC_Avoid.h>
+#include <AC_Avoidance/AP_OAPathPlanner.h>
 #include <AP_Follow/AP_Follow.h>
 #include <AP_OSD/AP_OSD.h>
 #include <AP_WindVane/AP_WindVane.h>

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -137,7 +137,7 @@ bool ModeAuto::get_desired_location(Location& destination) const
     switch (_submode) {
     case Auto_WP:
         if (g2.wp_nav.is_destination_valid()) {
-            destination = g2.wp_nav.get_destination();
+            destination = g2.wp_nav.get_oa_destination();
             return true;
         }
         return false;

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -150,7 +150,7 @@ bool ModeGuided::get_desired_location(Location& destination) const
     switch (_guided_mode) {
     case Guided_WP:
         if (g2.wp_nav.is_destination_valid()) {
-            destination = g2.wp_nav.get_destination();
+            destination = g2.wp_nav.get_oa_destination();
             return true;
         }
         return false;

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -62,7 +62,7 @@ void ModeRTL::update()
 bool ModeRTL::get_desired_location(Location& destination) const
 {
     if (g2.wp_nav.is_destination_valid()) {
-        destination = g2.wp_nav.get_destination();
+        destination = g2.wp_nav.get_oa_destination();
         return true;
     }
     return false;

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -144,6 +144,9 @@ void Rover::init_ardupilot()
     // initialize SmartRTL
     g2.smart_rtl.init();
 
+    // initialise object avoidance
+    g2.oa.init();
+
     startup_ground();
 
     Mode *initial_mode = mode_from_mode_num((enum Mode::Number)g.initial_mode.get());

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -1,5 +1,19 @@
-#include "AC_Avoid.h"
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AC_Avoid.h"
 #include <AP_AHRS/AP_AHRS.h>     // AHRS library
 #include <AC_Fence/AC_Fence.h>         // Failsafe fence library
 #include <AP_Proximity/AP_Proximity.h>

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -1,0 +1,286 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_OABendyRuler.h"
+#include <AC_Fence/AC_Fence.h>
+
+const int16_t OA_BENDYRULER_BEARING_INC = 5;            // check every 5 degrees around vehicle
+const float OA_BENDYRULER_LOOKAHEAD_STEP2_RATIO = 1.0f; // step2's lookahead length as a ratio of step1's lookahead length
+const float OA_BENDYRULER_LOOKAHEAD_STEP2_MIN = 2.0f;   // step2 checks at least this many meters past step1's location
+const float OA_BENDYRULER_LOOKAHEAD_PAST_DEST = 2.0f;   // lookahead length will be at least this many meters past the destination
+const float OA_BENDYRULER_LOW_SPEED_SQUARED = (0.2f * 0.2f);    // when ground course is below this speed squared, vehicle's heading will be used
+
+// run background task to find best path and update avoidance_results
+// returns true and updates origin_new and destination_new if a best path has been found
+bool AP_OABendyRuler::update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new)
+{
+    // bendy ruler always sets origin to current_loc
+    origin_new = current_loc;
+
+    // calculate bearing and distance to final destination
+    const float bearing_to_dest = current_loc.get_bearing_to(destination) * 0.01f;
+    const float distance_to_dest = current_loc.get_distance(destination);
+
+    // lookahead distance is adjusted dynamically based on avoidance results
+    _current_lookahead = constrain_float(_current_lookahead, _lookahead * 0.5f, _lookahead);
+
+    // calculate lookahead dist and time for step1.  distance can be slightly longer than
+    // the distance to the destination to allow room to dodge after reaching the destination
+    const float lookahead_step1_dist = MIN(_current_lookahead, distance_to_dest + OA_BENDYRULER_LOOKAHEAD_PAST_DEST);
+
+    // calculate lookahead dist for step2
+    const float lookahead_step2_dist = _current_lookahead * OA_BENDYRULER_LOOKAHEAD_STEP2_RATIO;
+
+    // get ground course
+    float ground_course_deg;
+    if (ground_speed_vec.length_squared() < OA_BENDYRULER_LOW_SPEED_SQUARED) {
+        // with zero ground speed use vehicle's heading
+        ground_course_deg = AP::ahrs().yaw_sensor * 0.01f;
+    } else {
+        ground_course_deg = degrees(ground_speed_vec.angle());
+    }
+
+    // check OA_BEARING_INC definition allows checking in all directions
+    static_assert(360 % OA_BENDYRULER_BEARING_INC == 0, "check 360 is a multiple of OA_BEARING_INC");
+
+    // search in OA_BENDYRULER_BEARING_INC degree increments around the vehicle alternating left
+    // and right. For each direction check if vehicle would avoid all obstacles
+    float best_bearing = bearing_to_dest;
+    bool have_best_bearing = false;
+    float best_margin = -FLT_MAX;
+    float best_margin_bearing = best_bearing;
+
+    for (uint8_t i = 0; i <= (170 / OA_BENDYRULER_BEARING_INC); i++) {
+        for (uint8_t bdir = 0; bdir <= 1; bdir++) {
+            // skip duplicate check of bearing straight towards destination
+            if ((i==0) && (bdir > 0)) {
+                continue;
+            }
+            // bearing that we are probing
+            const float bearing_delta = i * OA_BENDYRULER_BEARING_INC * (bdir == 0 ? -1.0f : 1.0f);
+            const float bearing_test = wrap_180(bearing_to_dest + bearing_delta);
+
+            // ToDo: add effective groundspeed calculations using airspeed
+            // ToDo: add prediction of vehicle's position change as part of turn to desired heading
+
+            // test location is projected from current location at test bearing
+            Location test_loc = current_loc;
+            test_loc.offset_bearing(bearing_test, lookahead_step1_dist);
+
+            // calculate margin from fence for this scenario
+            float margin = calc_avoidance_margin(current_loc, test_loc);
+            if (margin > best_margin) {
+                best_margin_bearing = bearing_test;
+                best_margin = margin;
+            }
+            if (margin > _margin_max) {
+                // this bearing avoids obstacles out to the lookahead_step1_dist
+                // now check in there is a clear path in three directions towards the destination
+                if (!have_best_bearing) {
+                    best_bearing = bearing_test;
+                    have_best_bearing = true;
+                } else if (fabsf(wrap_180(ground_course_deg - bearing_test)) <
+                           fabsf(wrap_180(ground_course_deg - best_bearing))) {
+                    // replace bearing with one that is closer to our current ground course
+                    best_bearing = bearing_test;
+                }
+
+                // perform second stage test in three directions looking for obstacles
+                const float test_bearings[] { 0.0f, 45.0f, -45.0f };
+                const float bearing_to_dest2 = test_loc.get_bearing_to(destination) * 0.01f;
+                float distance2 = constrain_float(lookahead_step2_dist, OA_BENDYRULER_LOOKAHEAD_STEP2_MIN, test_loc.get_distance(destination));
+                for (uint8_t j = 0; j < ARRAY_SIZE(test_bearings); j++) {
+                    float bearing_test2 = wrap_180(bearing_to_dest2 + test_bearings[j]);
+                    Location test_loc2 = test_loc;
+                    test_loc2.offset_bearing(bearing_test2, distance2);
+
+                    // calculate minimum margin to fence and obstacles for this scenario
+                    float margin2 = calc_avoidance_margin(test_loc, test_loc2);
+                    if (margin2 > _margin_max) {
+                        // all good, now project in the chosen direction by the full distance
+                        destination_new = current_loc;
+                        destination_new.offset_bearing(bearing_test, distance_to_dest);
+                        _current_lookahead = MIN(_lookahead, _current_lookahead * 1.1f);
+                        // if the chosen direction is directly towards the destination turn off avoidance
+                        return (i != 0 || j != 0);
+                    }
+                }
+            }
+        }
+    }
+
+    float chosen_bearing;
+    if (have_best_bearing) {
+        // none of the directions tested were OK for 2-step checks. Choose the direction
+        // that was best for the first step
+        chosen_bearing = best_bearing;
+        _current_lookahead = MIN(_lookahead, _current_lookahead * 1.05f);
+    } else {
+        // none of the possible paths had a positive margin. Choose
+        // the one with the highest margin
+        chosen_bearing = best_margin_bearing;
+        _current_lookahead = MAX(_lookahead * 0.5f, _current_lookahead * 0.9f);
+    }
+
+    // calculate new target based on best effort
+    destination_new = current_loc;
+    destination_new.offset_bearing(chosen_bearing, distance_to_dest);
+
+    return true;
+}
+
+// calculate minimum distance between a segment and any obstacle
+float AP_OABendyRuler::calc_avoidance_margin(const Location &start, const Location &end)
+{
+    float circular_fence_margin;
+    if (!calc_margin_from_circular_fence(start, end, circular_fence_margin)) {
+        circular_fence_margin = FLT_MAX;
+    }
+
+    float polygon_fence_margin;
+    if (!calc_margin_from_polygon_fence(start, end, polygon_fence_margin)) {
+        polygon_fence_margin = FLT_MAX;
+    }
+
+    float proximity_margin;
+    if (!calc_margin_from_proximity_sensors(start, end, proximity_margin)) {
+        proximity_margin = FLT_MAX;
+    }
+
+    // return smallest margin from any obstacle
+    return MIN(MIN(circular_fence_margin, polygon_fence_margin), proximity_margin);
+}
+
+// calculate minimum distance between a path and the circular fence (centered on home)
+// on success returns true and updates margin
+bool AP_OABendyRuler::calc_margin_from_circular_fence(const Location &start, const Location &end, float &margin)
+{
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
+        return false;
+    }
+
+    // calculate start and end point's distance from home
+    const Location &ahrs_home = AP::ahrs().get_home();
+    const float start_dist_sq = ahrs_home.get_distance_NE(start).length_squared();
+    const float end_dist_sq = ahrs_home.get_distance_NE(end).length_squared();
+
+    // get circular fence radius
+    const float fence_radius = fence->get_radius();
+
+    // margin is fence radius minus the longer of start or end distance
+    margin = fence_radius - sqrtf(MAX(start_dist_sq, end_dist_sq));
+    return true;
+}
+
+// calculate minimum distance between a path and the polygon fence
+// on success returns true and updates margin
+bool AP_OABendyRuler::calc_margin_from_polygon_fence(const Location &start, const Location &end, float &margin)
+{
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    if (((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) || !fence->is_polygon_valid()) {
+        return false;
+    }
+
+    // get polygon boundary
+    uint16_t num_points;
+    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    if (num_points < 3) {
+        // this should have already been checked by is_polygon_valid() but just in case
+        return false;
+    }
+
+    // convert start and end to offsets from EKF origin
+    Vector2f start_NE, end_NE;
+    if (!start.get_vector_xy_from_origin_NE(start_NE) || !end.get_vector_xy_from_origin_NE(end_NE)) {
+        return false;
+    }
+
+    // calculate min distance (in meters) from line to polygon
+    margin = Polygon_closest_distance_line(boundary, num_points, start_NE, end_NE) * 0.01f;
+    return true;
+}
+
+// calculate minimum distance between a path and proximity sensor obstacles
+// on success returns true and updates margin
+bool AP_OABendyRuler::calc_margin_from_proximity_sensors(const Location &start, const Location &end, float &margin)
+{
+    AP_Proximity* prx = AP_Proximity::get_singleton();
+    if (prx == nullptr) {
+        return false;
+    }
+
+    // retrieve obstacles from proximity library
+    if (!prx->copy_locations(_prx_locs, ARRAY_SIZE(_prx_locs), _prx_loc_count)) {
+        return false;
+    }
+
+    // exit if no obstacles
+    if (_prx_loc_count == 0) {
+        return false;
+    }
+
+    // convert start and end to offsets (in cm) from EKF origin
+    Vector2f start_NE, end_NE;
+    if (!start.get_vector_xy_from_origin_NE(start_NE) || !end.get_vector_xy_from_origin_NE(end_NE)) {
+        return false;
+    }
+
+    // check each obstacle's distance from segment
+    bool valid_loc_found = false;
+    float smallest_margin = FLT_MAX;
+    uint32_t now = AP_HAL::millis();
+    for (uint16_t i=0; i<_prx_loc_count; i++) {
+
+        // check time of objects is still valid
+        if ((now - _prx_locs[i].last_update_ms) > PROXIMITY_LOCATION_TIMEOUT_MS) {
+            continue;
+        }
+        valid_loc_found = true;
+
+        // convert obstacle's location to offset (in cm) from EKF origin
+        Vector2f point;
+        if (!_prx_locs[i].loc.get_vector_xy_from_origin_NE(point)) {
+            continue;
+        }
+
+        // margin is distance between line segment and obstacle minus obstacle's radius
+        const float m = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, point) * 0.01f - _prx_locs[i].radius_m;
+        if (m < smallest_margin) {
+            smallest_margin = m;
+        }
+    }
+
+    // if no valid obstacles found then they've all expired so clear buffer
+    if (!valid_loc_found) {
+        _prx_loc_count = 0;
+    }
+
+    // return smallest margin
+    if (smallest_margin < FLT_MAX) {
+        margin = smallest_margin;
+        return true;
+    }
+
+    return false;
+}

--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Proximity/AP_Proximity.h>
+#include <AP_HAL/AP_HAL.h>
+
+/*
+ * BendyRuler avoidance algorithm for avoiding the polygon and circular fence and dynamic objects detected by the proximity sensor
+ */
+class AP_OABendyRuler {
+public:
+
+    AP_OABendyRuler() {}
+
+    /* Do not allow copies */
+    AP_OABendyRuler(const AP_OABendyRuler &other) = delete;
+    AP_OABendyRuler &operator=(const AP_OABendyRuler&) = delete;
+
+    // send configuration info stored in front end parameters
+    void set_config(float lookahead, float margin_max) { _lookahead = MAX(lookahead, 1.0f); _margin_max = MAX(margin_max, 0.0f); }
+
+    // run background task to find best path and update avoidance_results
+    bool update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new);
+
+private:
+
+    // calculate minimum distance between a path and any obstacle
+    float calc_avoidance_margin(const Location &start, const Location &end);
+
+    // calculate minimum distance between a path and the circular fence (centered on home)
+    // on success returns true and updates margin
+    bool calc_margin_from_circular_fence(const Location &start, const Location &end, float &margin);
+
+    // calculate minimum distance between a path and the polygon fence
+    // on success returns true and updates margin
+    bool calc_margin_from_polygon_fence(const Location &start, const Location &end, float &margin);
+
+    // calculate minimum distance between a path and proximity sensor obstacles
+    // on success returns true and updates margin
+    bool calc_margin_from_proximity_sensors(const Location &start, const Location &end, float &margin);
+
+    // configuration parameters
+    float _lookahead;               // object avoidance will look this many meters ahead of vehicle
+    float _margin_max;              // object avoidance will ignore objects more than this many meters from vehicle
+
+    // internal variables used by background thread
+    float _current_lookahead;       // distance (in meters) ahead of the vehicle we are looking for obstacles
+    AP_Proximity::Proximity_Location _prx_locs[PROXIMITY_MAX_DIRECTION];  // buffer of locations from proximity library
+    uint16_t _prx_loc_count;
+};

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -1,0 +1,506 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_OADijkstra.h"
+#include <AC_Fence/AC_Fence.h>
+
+#define OA_DIJKSTRA_POLYGON_VISGRAPH_PTS         (OA_DIJKSTRA_POLYGON_FENCE_PTS * OA_DIJKSTRA_POLYGON_FENCE_PTS / 2)
+#define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX 255     // index use to indicate we do not have a tentative short path for a node
+
+/// Constructor
+AP_OADijkstra::AP_OADijkstra() :
+        _polyfence_visgraph(OA_DIJKSTRA_POLYGON_VISGRAPH_PTS),
+        _source_visgraph(OA_DIJKSTRA_POLYGON_FENCE_PTS),
+        _destination_visgraph(OA_DIJKSTRA_POLYGON_FENCE_PTS)
+{
+}
+
+// calculate a destination to avoid the polygon fence
+// returns true if avoidance is required and updates origin_new and destination_new
+bool AP_OADijkstra::update(const Location &current_loc, const Location &destination, Location& origin_new, Location& destination_new)
+{
+    // require ekf origin to have been set
+    struct Location ekf_origin {};
+    if (!AP::ahrs().get_origin(ekf_origin)) {
+        return false;
+    }
+
+    // check for fence updates
+    if (check_polygon_fence_updated()) {
+        _polyfence_with_margin_ok = false;
+    }
+
+    // create inner polygon fence
+    if (!_polyfence_with_margin_ok) {
+        _polyfence_with_margin_ok = create_polygon_fence_with_margin(_polyfence_margin * 100.0f);
+        if (!_polyfence_with_margin_ok) {
+            _polyfence_visgraph_ok = false;
+            _shortest_path_ok = false;
+            return false;
+        }
+    }
+
+    // create visgraph for inner polygon fence
+    if (!_polyfence_visgraph_ok) {
+        _polyfence_visgraph_ok = create_polygon_fence_visgraph();
+        if (!_polyfence_visgraph_ok) {
+            _shortest_path_ok = false;
+            return false;
+        }
+    }
+
+    // rebuild path if destination has changed
+    if (!destination.same_latlon_as(_destination_prev)) {
+        _destination_prev = destination;
+        _shortest_path_ok = false;
+    }
+
+    // calculate shortest path from current_loc to destination
+    if (!_shortest_path_ok) {
+        _shortest_path_ok = calc_shortest_path(current_loc, destination);
+        if (!_shortest_path_ok) {
+            return false;
+        }
+        // start from 2nd point on path (first is the original origin)
+        _path_idx_returned = 1;
+    }
+
+    // path has been created, return latest point
+    Vector2f dest_pos;
+    if (get_shortest_path_point(_path_idx_returned, dest_pos)) {
+
+        // for the first point return origin as current_loc
+        Vector2f origin_pos;
+        if ((_path_idx_returned > 0) && get_shortest_path_point(_path_idx_returned-1, origin_pos)) {
+            // convert offset from ekf origin to Location
+            Location temp_loc(Vector3f(origin_pos.x, origin_pos.y, 0.0f));
+            origin_new = temp_loc;
+        } else {
+            // for first point use current loc as origin
+            origin_new = current_loc;
+        }
+
+        // convert offset from ekf origin to Location
+        Location temp_loc(Vector3f(dest_pos.x, dest_pos.y, 0.0f));
+        destination_new = destination;
+        destination_new.lat = temp_loc.lat;
+        destination_new.lng = temp_loc.lng;
+
+        // check if we should advance to next point for next iteration
+        const bool near_oa_wp = current_loc.get_distance(destination_new) <= 2.0f;
+        const bool past_oa_wp = current_loc.past_interval_finish_line(origin_new, destination_new);
+        if (near_oa_wp || past_oa_wp) {
+            _path_idx_returned++;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+// check if polygon fence has been updated since we created the inner fence. returns true if changed
+bool AP_OADijkstra::check_polygon_fence_updated() const
+{
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    return (_polyfence_update_ms != fence->get_boundary_update_ms());
+}
+
+// create a smaller polygon fence within the existing polygon fence
+// returns true on success
+bool AP_OADijkstra::create_polygon_fence_with_margin(float margin_cm)
+{
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+
+    // get polygon boundary
+    uint16_t num_points;
+    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    if ((boundary == nullptr) || (num_points < 3)) {
+        return false;
+    }
+
+    // fail if fence is too large
+    if (num_points > OA_DIJKSTRA_POLYGON_FENCE_PTS) {
+        return false;
+    }
+
+    // for each point on polygon fence
+    // Note: boundary is "unclosed" meaning the last point is *not* the same as the first
+    for (uint8_t i=0; i<num_points; i++) {
+
+        // find points before and after current point (relative to current point)
+        const uint8_t before_idx = (i == 0) ? num_points-1 : i-1;
+        const uint8_t after_idx = (i == num_points-1) ? 0 : i+1;
+        Vector2f before_pt = boundary[before_idx] - boundary[i];
+        Vector2f after_pt = boundary[after_idx] - boundary[i];
+
+        // if points are overlapping fail
+        if (before_pt.is_zero() || after_pt.is_zero() || (before_pt == after_pt)) {
+            return false;
+        }
+
+        // scale points to be unit vectors
+        before_pt.normalize();
+        after_pt.normalize();
+
+        // calculate intermediate point and scale to margin
+        Vector2f intermediate_pt = (after_pt + before_pt) * 0.5f;
+        float intermediate_len = intermediate_pt.length();
+        intermediate_pt *= (margin_cm / intermediate_len);
+
+        // find final point which is inside the original polygon
+        _polyfence_pts[i] = boundary[i] + intermediate_pt;
+        if (Polygon_outside(_polyfence_pts[i], boundary, num_points)) {
+            _polyfence_pts[i] = boundary[i] - intermediate_pt;
+            if (Polygon_outside(_polyfence_pts[i], boundary, num_points)) {
+                // could not find a point on either side that was within the fence so fail
+                // this can happen if fence lines are closer than margin_cm
+                return false;
+            }
+        }
+    }
+
+    // update number of fence points
+    _polyfence_numpoints = num_points;
+
+    // record fence update time so we don't process this exact fence again
+    _polyfence_update_ms = fence->get_boundary_update_ms();
+
+    return true;
+}
+
+// create a visibility graph of the polygon fence
+// returns true on success
+// requires create_polygon_fence_with_margin to have been run
+bool AP_OADijkstra::create_polygon_fence_visgraph()
+{
+    // exit immediately if no polygon fence (with margin)
+    if (_polyfence_numpoints == 0) {
+        return false;
+    }
+
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+
+    // get polygon boundary
+    uint16_t num_points;
+    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    if ((boundary == nullptr) || (num_points < 3)) {
+        return false;
+    }
+
+    // clear polygon visibility graph
+    _polyfence_visgraph.clear();
+
+    // calculate distance from each polygon fence point to all other points
+    for (uint8_t i=0; i<_polyfence_numpoints-1; i++) {
+        const Vector2f &start1 = _polyfence_pts[i];
+        for (uint8_t j=i+1; j<_polyfence_numpoints-1; j++) {
+            const Vector2f &end1 = _polyfence_pts[j];
+            Vector2f intersection;
+            // ToDo: calculation below could be sped up by removing unused intersection and
+            //       skipping segments we know are parallel to our fence-with-margin segments
+            if (!Polygon_intersects(boundary, num_points, start1, end1, intersection)) {
+                // line segment does not intersect with original fence so add to visgraph
+                _polyfence_visgraph.add_item({AP_OAVisGraph::OATYPE_FENCE_POINT, i},
+                                             {AP_OAVisGraph::OATYPE_FENCE_POINT, j},
+                                             (_polyfence_pts[i] - _polyfence_pts[j]).length());
+            }
+            // ToDo: store infinity when there is no clear path between points to allow faster search later
+        }
+    }
+
+    return true;
+}
+
+// updates visibility graph for a given position which is an offset (in cm) from the ekf origin
+// to add an additional position (i.e. the destination) set add_extra_position = true and provide the position in the extra_position argument
+// requires create_polygon_fence_with_margin to have been run
+// returns true on success
+bool AP_OADijkstra::update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph::OAItemID& oaid, const Vector2f &position, bool add_extra_position, Vector2f extra_position)
+{
+    // exit immediately if no polygon fence (with margin)
+    if (_polyfence_numpoints == 0) {
+        return false;
+    }
+
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+
+    // get polygon boundary
+    uint16_t num_points;
+    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    if ((boundary == nullptr) || (num_points < 3)) {
+        return false;
+    }
+
+    // clear visibility graph
+    visgraph.clear();
+
+    // calculate distance from position to all fence points
+    for (uint8_t i=0; i<_polyfence_numpoints-1; i++) {
+        Vector2f intersection;
+        if (!Polygon_intersects(boundary, num_points, position, _polyfence_pts[i], intersection)) {
+            // line segment does not intersect with original fence so add to visgraph
+            visgraph.add_item(oaid, {AP_OAVisGraph::OATYPE_FENCE_POINT, i}, (position - _polyfence_pts[i]).length());
+        }
+        // ToDo: store infinity when there is no clear path between points to allow faster search later
+    }
+
+    // add extra point to visibility graph if it doesn't intersect with polygon fence
+    if (add_extra_position) {
+        Vector2f intersection;
+        if (!Polygon_intersects(boundary, num_points, position, extra_position, intersection)) {
+            visgraph.add_item(oaid, {AP_OAVisGraph::OATYPE_DESTINATION, 0}, (position - extra_position).length());
+        }
+    }
+
+    return true;
+}
+
+// update total distance for all nodes visible from current node
+// curr_node_idx is an index into the _short_path_data array
+void AP_OADijkstra::update_visible_node_distances(node_index curr_node_idx)
+{
+    // sanity check
+    if (curr_node_idx > _short_path_data_numpoints) {
+        return;
+    }
+
+    // get current node for convenience
+    const ShortPathNode &curr_node = _short_path_data[curr_node_idx];
+
+    // for each visibility graph
+    const AP_OAVisGraph* visgraphs[] = {&_polyfence_visgraph, &_destination_visgraph};
+    for (uint8_t v=0; v<ARRAY_SIZE(visgraphs); v++) {
+
+        // skip if empty
+        const AP_OAVisGraph &curr_visgraph = *visgraphs[v];
+        if (curr_visgraph.num_items() == 0) {
+            continue;
+        }
+
+        // search visibility graph for items visible from current_node
+        for (uint8_t i=0; i<curr_visgraph.num_items(); i++) {
+            const AP_OAVisGraph::VisGraphItem &item = curr_visgraph[i];
+            // match if current node's id matches either of the id's in the graph (i.e. either end of the vector)
+            if ((curr_node.id == item.id1) || (curr_node.id == item.id2)) {
+                AP_OAVisGraph::OAItemID matching_id = (curr_node.id == item.id1) ? item.id2 : item.id1;
+                // find item's id in node array
+                node_index item_node_idx;
+                if (find_node_from_id(matching_id, item_node_idx)) {
+                    // if current node's distance + distance to item is less than item's current distance, update item's distance
+                    const float dist_to_item_via_current_node = _short_path_data[curr_node_idx].distance_cm + item.distance_cm;
+                    if (dist_to_item_via_current_node < _short_path_data[item_node_idx].distance_cm) {
+                        // update item's distance and set "distance_from_idx" to current node's index
+                        _short_path_data[item_node_idx].distance_cm = dist_to_item_via_current_node;
+                        _short_path_data[item_node_idx].distance_from_idx = curr_node_idx;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// find a node's index into _short_path_data array from it's id (i.e. id type and id number)
+// returns true if successful and node_idx is updated
+bool AP_OADijkstra::find_node_from_id(const AP_OAVisGraph::OAItemID &id, node_index &node_idx) const
+{
+    switch (id.id_type) {
+    case AP_OAVisGraph::OATYPE_SOURCE:
+        // source node is always the first node
+        if (_short_path_data_numpoints > 0) {
+            node_idx = 0;
+            return true;
+        }
+        break;
+    case AP_OAVisGraph::OATYPE_DESTINATION:
+        // destination is always the 2nd node
+        if (_short_path_data_numpoints > 1) {
+            node_idx = 1;
+            return true;
+        }
+        break;
+    case AP_OAVisGraph::OATYPE_FENCE_POINT:
+        // must be a fence node which start from 3rd node
+        if (_short_path_data_numpoints > id.id_num + 2) {
+            node_idx = id.id_num + 2;
+            return true;
+        }
+        break;
+    }
+
+    // could not find node
+    return false;
+}
+
+// find index of node with lowest tentative distance (ignore visited nodes)
+// returns true if successful and node_idx argument is updated
+bool AP_OADijkstra::find_closest_node_idx(node_index &node_idx) const
+{
+    node_index lowest_idx = 0;
+    float lowest_dist = FLT_MAX;
+
+    // scan through all nodes looking for closest
+    for (node_index i=0; i<_short_path_data_numpoints; i++) {
+        const ShortPathNode &node = _short_path_data[i];
+        if (!node.visited && (node.distance_cm < lowest_dist)) {
+            lowest_idx = i;
+            lowest_dist = node.distance_cm;
+        }
+    }
+
+    if (lowest_dist < FLT_MAX) {
+        node_idx = lowest_idx;
+        return true;
+    }
+    return false;
+}
+
+// calculate shortest path from origin to destination
+// returns true on success
+// requires create_polygon_fence_with_margin and create_polygon_fence_visgraph to have been run
+// resulting path is stored in _shortest_path array as vector offsets from EKF origin
+bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &destination)
+{
+    // convert origin and destination to offsets from EKF origin
+    Vector2f origin_NE, destination_NE;
+    if (!origin.get_vector_xy_from_origin_NE(origin_NE) || !destination.get_vector_xy_from_origin_NE(destination_NE)) {
+        return false;
+    }
+
+    // create origin and destination visgraphs of polygon points
+    update_visgraph(_source_visgraph, {AP_OAVisGraph::OATYPE_SOURCE, 0}, origin_NE, true, destination_NE);
+    update_visgraph(_destination_visgraph, {AP_OAVisGraph::OATYPE_DESTINATION, 0}, destination_NE);
+
+    // check OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX is defined correct
+    static_assert(OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX > OA_DIJKSTRA_POLYGON_FENCE_PTS, "check OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX > OA_DIJKSTRA_POLYGON_FENCE_PTS");
+
+    // add origin and destination (node_type, id, visited, distance_from_idx, distance_cm) to short_path_data array
+    _short_path_data[0] = {{AP_OAVisGraph::OATYPE_SOURCE, 0}, false, 0, 0};
+    _short_path_data[1] = {{AP_OAVisGraph::OATYPE_DESTINATION, 0}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
+    _short_path_data_numpoints = 2;
+
+    // add fence points to short_path_data array (node_type, id, visited, distance_from_idx, distance_cm)
+    // skip last fence point because it is the same as the first
+    for (uint8_t i=0; i<_polyfence_numpoints-1; i++) {
+        _short_path_data[_short_path_data_numpoints++] = {{AP_OAVisGraph::OATYPE_FENCE_POINT, i}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
+    }
+
+    // start algorithm from source point
+    node_index current_node_idx = 0;
+
+    // update nodes visible from source point
+    for (uint8_t i=0; i<_source_visgraph.num_items(); i++) {
+        node_index node_idx;
+        if (find_node_from_id(_source_visgraph[i].id2, node_idx)) {
+            _short_path_data[node_idx].distance_cm = _source_visgraph[i].distance_cm;
+            _short_path_data[node_idx].distance_from_idx = current_node_idx;
+        } else {
+            return false;
+        }
+    }
+    // mark source node as visited
+    _short_path_data[current_node_idx].visited = true;
+
+    // move current_node_idx to node with lowest distance
+    while (find_closest_node_idx(current_node_idx)) {
+        // update distances to all neighbours of current node
+        update_visible_node_distances(current_node_idx);
+
+        // mark current node as visited
+        _short_path_data[current_node_idx].visited = true;
+    }
+
+    // extract path starting from destination
+    bool success = false;
+    node_index nidx;
+    if (!find_node_from_id({AP_OAVisGraph::OATYPE_DESTINATION,0}, nidx)) {
+        return false;
+    }
+    _path_numpoints = 0;
+    while (true) {
+        // fail if out of space or newest node has invalid distance or from index
+        if ((_path_numpoints >= OA_DIJKSTRA_POLYGON_SHORTPATH_PTS) ||
+            (_short_path_data[nidx].distance_from_idx == OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) ||
+            (_short_path_data[nidx].distance_cm >= FLT_MAX)) {
+            break;
+        } else {
+            // add node's id to path array
+            _path[_path_numpoints] = _short_path_data[nidx].id;
+            _path_numpoints++;
+
+            // we are done if node is the source
+            if (_short_path_data[nidx].id.id_type == AP_OAVisGraph::OATYPE_SOURCE) {
+                success = true;
+                break;
+            } else {
+                // follow node's "distance_from_idx" to previous node on path
+                nidx = _short_path_data[nidx].distance_from_idx;
+            }
+        }
+    }
+    // update source and destination for by get_shortest_path_point
+    if (success) {
+        _path_source = origin_NE;
+        _path_destination = destination_NE;
+    }
+
+    return success;
+}
+
+// return point from final path as an offset (in cm) from the ekf origin
+bool AP_OADijkstra::get_shortest_path_point(uint8_t point_num, Vector2f& pos)
+{
+    if ((_path_numpoints == 0) || (point_num >= _path_numpoints)) {
+        return false;
+    }
+
+    // get id from path
+    AP_OAVisGraph::OAItemID id = _path[_path_numpoints - point_num - 1];
+
+    // convert id to a position offset from EKF origin
+    switch (id.id_type) {
+    case AP_OAVisGraph::OATYPE_SOURCE:
+        pos = _path_source;
+        return true;
+    case AP_OAVisGraph::OATYPE_DESTINATION:
+        pos = _path_destination;
+        return true;
+    case AP_OAVisGraph::OATYPE_FENCE_POINT:
+        // sanity check polygon fence has the point
+        if (id.id_num < _polyfence_numpoints) {
+            pos = _polyfence_pts[id.id_num];
+            return true;
+        }
+        return false;
+    }
+
+    // we should never reach here but just in case
+    return false;
+}

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AP_OAVisGraph.h"
+
+#define OA_DIJKSTRA_POLYGON_FENCE_PTS       20      // algorithm can handle up to this many polygon fence points
+#define OA_DIJKSTRA_POLYGON_SHORTPATH_PTS   OA_DIJKSTRA_POLYGON_FENCE_PTS+1 // return path can have up to this many destinations
+
+/*
+ * Dijkstra's algorithm for path planning around polygon fence
+ */
+
+class AP_OADijkstra {
+public:
+
+    AP_OADijkstra();
+
+    /* Do not allow copies */
+    AP_OADijkstra(const AP_OADijkstra &other) = delete;
+    AP_OADijkstra &operator=(const AP_OADijkstra&) = delete;
+
+    // set fence margin (in meters) used when creating "safe positions" within the polygon fence
+    void set_fence_margin(float margin) { _polyfence_margin = MAX(margin, 0.0f); }
+
+    // calculate a destination to avoid the polygon fence
+    // returns true if avoidance is required and target destination is placed in result_loc
+    bool update(const Location &current_loc, const Location &destination, Location& origin_new, Location& destination_new);
+
+private:
+
+    // check if polygon fence has been updated since we created the inner fence. returns true if changed
+    bool check_polygon_fence_updated() const;
+
+    // create a smaller polygon fence within the existing polygon fence
+    // returns true on success
+    bool create_polygon_fence_with_margin(float margin_cm);
+
+    // create a visibility graph of the polygon fence
+    // returns true on success
+    // requires create_polygon_fence_with_margin to have been run
+    bool create_polygon_fence_visgraph();
+
+    // calculate shortest path from origin to destination
+    // returns true on success
+    // requires create_polygon_fence_with_margin and create_polygon_fence_visgraph to have been run
+    // resulting path is stored in _shortest_path array as vector offsets from EKF origin
+    bool calc_shortest_path(const Location &origin, const Location &destination);
+
+    // shortest path state variables
+    bool _polyfence_with_margin_ok;
+    bool _polyfence_visgraph_ok;
+    bool _shortest_path_ok;
+
+    Location _destination_prev;     // destination of previous iterations (used to determine if path should be re-calculated)
+    uint8_t _path_idx_returned;     // index into _path array which gives location vehicle should be currently moving towards
+
+    // polygon fence (with margin) related variables
+    float _polyfence_margin = 10;
+    Vector2f _polyfence_pts[OA_DIJKSTRA_POLYGON_FENCE_PTS];
+    uint8_t _polyfence_numpoints;
+    uint32_t _polyfence_update_ms;  // system time of boundary update from AC_Fence (used to detect changes to polygon fence)
+
+    // visibility graphs
+    AP_OAVisGraph _polyfence_visgraph;
+    AP_OAVisGraph _source_visgraph;
+    AP_OAVisGraph _destination_visgraph;
+
+    // updates visibility graph for a given position which is an offset (in cm) from the ekf origin
+    // to add an additional position (i.e. the destination) set add_extra_position = true and provide the position in the extra_position argument
+    // requires create_polygon_fence_with_margin to have been run
+    // returns true on success
+    bool update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph::OAItemID& oaid, const Vector2f &position, bool add_extra_position = false, Vector2f extra_position = Vector2f(0,0));
+
+    typedef uint8_t node_index;         // indices into short path data
+    struct ShortPathNode {
+        AP_OAVisGraph::OAItemID id;     // unique id for node (combination of type and id number)
+        bool visited;                   // true if all this node's neighbour's distances have been updated
+        node_index distance_from_idx;   // index into _short_path_data from where distance was updated (or 255 if not set)
+        float distance_cm;              // distance from source (number is tentative until this node is the current node and/or visited = true)
+    } _short_path_data[OA_DIJKSTRA_POLYGON_SHORTPATH_PTS];
+    node_index _short_path_data_numpoints;  // number of elements in _short_path_data array
+
+    // update total distance for all nodes visible from current node
+    // curr_node_idx is an index into the _short_path_data array
+    void update_visible_node_distances(node_index curr_node_idx);
+
+    // find a node's index into _short_path_data array from it's id (i.e. id type and id number)
+    // returns true if successful and node_idx is updated
+    bool find_node_from_id(const AP_OAVisGraph::OAItemID &id, node_index &node_idx) const;
+
+    // find index of node with lowest tentative distance (ignore visited nodes)
+    // returns true if successful and node_idx argument is updated
+    bool find_closest_node_idx(node_index &node_idx) const;
+
+    // final path variables and functions
+    AP_OAVisGraph::OAItemID _path[OA_DIJKSTRA_POLYGON_SHORTPATH_PTS];    // ids of points on return path in reverse order (i.e. destination is first element)
+    uint8_t _path_numpoints;                                                // number of points on return path
+    Vector2f _path_source;                                                  // source point used in shortest path calculations (offset in cm from EKF origin)
+    Vector2f _path_destination;                                             // destination position used in shortest path calculations (offset in cm from EKF origin)
+
+    // return point from final path as an offset (in cm) from the ekf origin
+    bool get_shortest_path_point(uint8_t point_num, Vector2f& pos);
+};

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -1,0 +1,240 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_OAPathPlanner.h"
+#include <AP_Math/AP_Math.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AC_Fence/AC_Fence.h>
+#include <AP_Logger/AP_Logger.h>
+#include "AP_OABendyRuler.h"
+#include "AP_OADijkstra.h"
+
+extern const AP_HAL::HAL &hal;
+
+// parameter defaults
+const float OA_LOOKAHEAD_DEFAULT = 50;
+const float OA_MARGIN_MAX_DEFAULT = 10;
+
+const int16_t OA_TIMEOUT_MS = 2000;             // avoidance results over 2 seconds old are ignored
+
+const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
+
+    // @Param: TYPE
+    // @DisplayName: Object Avoidance Path Planning algorithm to use
+    // @Description: Enabled/disable path planning around obstacles
+    // @Values: 0:Disabled,1:BendyRuler,2:Dijkstra
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("TYPE", 1,  AP_OAPathPlanner, _type, OA_PATHPLAN_DISABLED, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: LOOKAHEAD
+    // @DisplayName: Object Avoidance look ahead distance maximum
+    // @Description: Object Avoidance will look this many meters ahead of vehicle
+    // @Units: m
+    // @Range: 1 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("LOOKAHEAD", 2, AP_OAPathPlanner, _lookahead, OA_LOOKAHEAD_DEFAULT),
+
+    // @Param: MARGIN_MAX
+    // @DisplayName: Object Avoidance wide margin distance
+    // @Description: Object Avoidance will ignore objects more than this many meters from vehicle
+    // @Units: m
+    // @Range: 1 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("MARGIN_MAX", 3, AP_OAPathPlanner, _margin_max, OA_MARGIN_MAX_DEFAULT),
+
+    AP_GROUPEND
+};
+
+/// Constructor
+AP_OAPathPlanner::AP_OAPathPlanner()
+{
+    _singleton = this;
+
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+// perform any required initialisation
+void AP_OAPathPlanner::init()
+{
+    // run background task looking for best alternative destination
+    switch (_type) {
+    case OA_PATHPLAN_DISABLED:
+        // do nothing
+        break;
+    case OA_PATHPLAN_BENDYRULER:
+        if (_oabendyruler == nullptr) {
+            _oabendyruler = new AP_OABendyRuler();
+        }
+        break;
+    case OA_PATHPLAN_DIJKSTRA:
+        if (_oadijkstra == nullptr) {
+            _oadijkstra = new AP_OADijkstra();
+        }
+        break;
+    }
+}
+
+// pre-arm checks that algorithms have been initialised successfully
+bool AP_OAPathPlanner::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
+{
+    // check if initialisation has succeeded
+    switch (_type) {
+    case OA_PATHPLAN_DISABLED:
+        // do nothing
+        break;
+    case OA_PATHPLAN_BENDYRULER:
+        if (_oabendyruler == nullptr) {
+            hal.util->snprintf(failure_msg, failure_msg_len, "BendyRuler OA requires reboot");
+            return false;
+        }
+        break;
+    case OA_PATHPLAN_DIJKSTRA:
+        if (_oadijkstra == nullptr) {
+            hal.util->snprintf(failure_msg, failure_msg_len, "Dijkstra OA requires reboot");
+            return false;
+        }
+        break;
+    }
+    return true;
+}
+
+// provides an alternative target location if path planning around obstacles is required
+// returns true and updates result_loc with an intermediate location
+bool AP_OAPathPlanner::mission_avoidance(const Location &current_loc,
+                                         const Location &origin,
+                                         const Location &destination,
+                                         Location &result_origin,
+                                         Location &result_destination)
+{
+    // exit immediately if disabled
+    if (_type == OA_PATHPLAN_DISABLED) {
+        return false;
+    }
+
+    WITH_SEMAPHORE(_rsem);
+
+    if (!_thread_created) {
+        // create the avoidance thread as low priority. It should soak
+        // up spare CPU cycles to fill in the avoidance_result structure based
+        // on requests in avoidance_request
+        if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_OAPathPlanner::avoidance_thread, void),
+                                          "avoidance",
+                                          8192, AP_HAL::Scheduler::PRIORITY_IO, -1)) {
+            return false;
+        }
+        _thread_created = true;
+    }
+
+    const uint32_t now = AP_HAL::millis();
+
+    // place new request for the thread to work on
+    avoidance_request.current_loc = current_loc;
+    avoidance_request.origin = origin;
+    avoidance_request.destination = destination;
+    avoidance_request.ground_speed_vec = AP::ahrs().groundspeed_vector();
+    avoidance_request.request_time_ms = now;
+
+    // return results from background thread's latest checks
+    if (destination.lat == avoidance_result.destination.lat &&
+        destination.lng == avoidance_result.destination.lng &&
+        now - avoidance_result.result_time_ms < OA_TIMEOUT_MS) {
+        // we have a result from the thread
+        result_origin = avoidance_result.origin_new;
+        result_destination = avoidance_result.destination_new;
+        // log result
+        if (avoidance_result.result_time_ms != _logged_time_ms) {
+            _logged_time_ms = avoidance_result.result_time_ms;
+            AP::logger().Write_OA(_type, destination, result_destination);
+        }
+        return avoidance_result.avoidance_needed;
+    }
+
+    // do not performance avoidance because background thread's results were
+    // run against a different destination or they are simply not required
+    return false;
+}
+
+// avoidance thread that continually updates the avoidance_result structure based on avoidance_request
+void AP_OAPathPlanner::avoidance_thread()
+{
+    while (true) {
+
+        // run at 10hz or less
+        hal.scheduler->delay(100);
+
+        Location origin_new;
+        Location destination_new;
+        {
+            WITH_SEMAPHORE(_rsem);
+            uint32_t now = AP_HAL::millis();
+            if (now - avoidance_request.request_time_ms > OA_TIMEOUT_MS) {
+                // this is a very old request, don't process it
+                continue;
+            }
+
+            // copy request to avoid conflict with main thread
+            avoidance_request2 = avoidance_request;
+
+            // store passed in origin and destination so we can return it if object avoidance is not required
+            origin_new = avoidance_request.origin;
+            destination_new = avoidance_request.destination;
+        }
+
+        // run background task looking for best alternative destination
+        bool res = false;
+        switch (_type) {
+        case OA_PATHPLAN_DISABLED:
+            continue;
+        case OA_PATHPLAN_BENDYRULER:
+            if (_oabendyruler == nullptr) {
+                continue;
+            }
+            _oabendyruler->set_config(_lookahead, _margin_max);
+            res = _oabendyruler->update(avoidance_request2.current_loc, avoidance_request2.destination, avoidance_request2.ground_speed_vec, origin_new, destination_new);
+            break;
+        case OA_PATHPLAN_DIJKSTRA:
+            if (_oadijkstra == nullptr) {
+                continue;
+            }
+            _oadijkstra->set_fence_margin(_margin_max);
+            res = _oadijkstra->update(avoidance_request2.current_loc, avoidance_request2.destination, origin_new, destination_new);
+            break;
+        }
+
+        {
+            // give the main thread the avoidance result
+            WITH_SEMAPHORE(_rsem);
+            avoidance_result.destination = avoidance_request2.destination;
+            avoidance_result.origin_new = res ? origin_new : avoidance_result.origin_new;
+            avoidance_result.destination_new = res ? destination_new : avoidance_result.destination;
+            avoidance_result.result_time_ms = AP_HAL::millis();
+            avoidance_result.avoidance_needed = res;
+        }
+    }
+}
+
+// singleton instance
+AP_OAPathPlanner *AP_OAPathPlanner::_singleton;
+
+namespace AP {
+
+AP_OAPathPlanner *ap_oapathplanner()
+{
+    return AP_OAPathPlanner::get_singleton();
+}
+
+}

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AP_OABendyRuler.h"
+#include "AP_OADijkstra.h"
+
+/*
+ * This class provides path planning around fence, stay-out zones and moving obstacles
+ */
+class AP_OAPathPlanner {
+
+public:
+    AP_OAPathPlanner();
+
+    /* Do not allow copies */
+    AP_OAPathPlanner(const AP_OAPathPlanner &other) = delete;
+    AP_OAPathPlanner &operator=(const AP_OAPathPlanner&) = delete;
+
+    // get singleton instance
+    static AP_OAPathPlanner *get_singleton() {
+        return _singleton;
+    }
+
+    // perform any required initialisation
+    void init();
+
+    /// returns true if all pre-takeoff checks have completed successfully
+    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const;
+
+    // provides an alternative target location if path planning around obstacles is required
+    // returns true and updates result_origin and result_destination with an intermediate path
+    bool mission_avoidance(const Location &current_loc,
+                           const Location &origin,
+                           const Location &destination,
+                           Location &result_origin,
+                           Location &result_destination) WARN_IF_UNUSED;
+
+    // enumerations for _TYPE parameter
+    enum OAPathPlanTypes {
+        OA_PATHPLAN_DISABLED = 0,
+        OA_PATHPLAN_BENDYRULER = 1,
+        OA_PATHPLAN_DIJKSTRA = 2
+    };
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+
+    // avoidance thread that continually updates the avoidance_result structure based on avoidance_request
+    void avoidance_thread();
+
+    // an avoidance request from the navigation code
+    struct avoidance_info {
+        Location current_loc;
+        Location origin;
+        Location destination;
+        Vector2f ground_speed_vec;
+        uint32_t request_time_ms;
+    } avoidance_request, avoidance_request2;
+
+    // an avoidance result from the avoidance thread
+    struct {
+        Location destination;       // destination vehicle is trying to get to (also used to verify the result matches a recent request)
+        Location origin_new;        // intermediate origin.  The start of line segment that vehicle should follow
+        Location destination_new;   // intermediate destination vehicle should move towards
+        uint32_t result_time_ms;    // system time the result was calculated (used to verify the result is recent)
+        bool avoidance_needed;      // true if the vehicle should move along the path from origin_new to destination_new
+    } avoidance_result;
+
+    // parameters
+    AP_Int8 _type;                  // avoidance algorith to be used
+    AP_Float _lookahead;            // object avoidance will look this many meters ahead of vehicle
+    AP_Float _margin_max;           // object avoidance will ignore objects more than this many meters from vehicle
+
+    // internal variables used by front end
+    HAL_Semaphore_Recursive _rsem;  // semaphore for multi-thread use of avoidance_request and avoidance_result
+    bool _thread_created;           // true once background thread has been created
+    AP_OABendyRuler *_oabendyruler; // Bendy Ruler algorithm
+    AP_OADijkstra *_oadijkstra;     // Dijkstra's algorithm
+    uint32_t _logged_time_ms;       // result_time_ms of last result logged (triggers logging of new results)
+
+    static AP_OAPathPlanner *_singleton;
+};
+
+namespace AP {
+    AP_OAPathPlanner *ap_oapathplanner();
+};

--- a/libraries/AC_Avoidance/AP_OAVisGraph.cpp
+++ b/libraries/AC_Avoidance/AP_OAVisGraph.cpp
@@ -1,0 +1,54 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_OAVisGraph.h"
+
+// constructor with size argument
+AP_OAVisGraph::AP_OAVisGraph(uint8_t size)
+{
+    init(size);
+}
+
+// initialise array to given size
+bool AP_OAVisGraph::init(uint8_t size)
+{
+    // only allow init once
+    if (_items != nullptr) {
+        return false;
+    }
+
+    // allocate array
+    _items = (VisGraphItem *)calloc(size, sizeof(VisGraphItem));
+    if (_items != nullptr) {
+        _num_items_max = size;
+        return true;
+    }
+
+    return false;
+}
+
+// add item to visiblity graph, returns true on success, false if graph is full
+bool AP_OAVisGraph::add_item(const OAItemID &id1, const OAItemID &id2, float distance_cm)
+{
+    // check there is space
+    if (_num_items >= _num_items_max) {
+        return false;
+    }
+
+    // add item
+    _items[_num_items] = {id1, id2, distance_cm};
+    _num_items++;
+    return true;
+}

--- a/libraries/AC_Avoidance/AP_OAVisGraph.h
+++ b/libraries/AC_Avoidance/AP_OAVisGraph.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+
+/*
+ * Visibility graph used by Dijkstra's algorithm for path planning around fence, stay-out zones and moving obstacles
+ */
+class AP_OAVisGraph {
+public:
+    AP_OAVisGraph();
+    AP_OAVisGraph(uint8_t size);
+
+    /* Do not allow copies */
+    AP_OAVisGraph(const AP_OAVisGraph &other) = delete;
+    AP_OAVisGraph &operator=(const AP_OAVisGraph&) = delete;
+
+    // types of items held in graph
+    enum OAType : uint8_t {
+        OATYPE_SOURCE = 0,
+        OATYPE_DESTINATION,
+        OATYPE_FENCE_POINT
+    };
+
+    // support up to 255 items of each type
+    typedef uint8_t oaid_num;
+
+    // id for uniquely identifying objects held in visibility graphs and paths
+    class OAItemID {
+    public:
+        OAType id_type;
+        oaid_num id_num;
+        bool operator ==(const OAItemID &i) const { return ((id_type == i.id_type) && (id_num == i.id_num)); }
+    };
+
+    struct VisGraphItem {
+        OAItemID id1;       // first item's id
+        OAItemID id2;       // second item's id
+        float distance_cm;  // distance between the items
+    };
+
+    // initialise array to given size
+    bool init(uint8_t size);
+
+    // clear all elements from graph
+    void clear() { _num_items = 0; }
+
+    // get number of items in visibility graph table
+    uint8_t num_items() const { return _num_items; }
+
+    // add item to visiblity graph, returns true on success, false if graph is full
+    bool add_item(const OAItemID &id1, const OAItemID &id2, float distance_cm);
+
+    // allow accessing graph as an array, 0 indexed
+    // Note: no protection against out-of-bounds accesses so use with num_items()
+    const VisGraphItem& operator[](uint8_t i) const { return _items[i]; }
+
+private:
+
+    VisGraphItem *_items;
+    uint8_t _num_items_max;
+    uint8_t _num_items;
+};

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -573,6 +573,7 @@ bool AC_Fence::load_polygon_from_eeprom()
         _boundary[index] = ekf_origin.get_distance_NE(temp_loc) * 100.0f;
     }
     _boundary_num_points = _total;
+    _boundary_update_ms = AP_HAL::millis();
 
     // update validity of polygon
     _boundary_valid = _poly_loader.boundary_valid(_boundary_num_points, _boundary);

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -112,6 +112,9 @@ public:
     /// handler for polygon fence messages with GCS
     void handle_msg(GCS_MAVLINK &link, mavlink_message_t* msg);
 
+    /// return system time of last update to the boundary (allows external detection of boundary changes)
+    uint32_t get_boundary_update_ms() const { return _boundary_update_ms; }
+
     static const struct AP_Param::GroupInfo var_info[];
 
     // methods for mavlink SYS_STATUS message (send_sys_status)
@@ -187,6 +190,7 @@ private:
     uint8_t         _boundary_num_points = 0;       // number of points in the boundary array (should equal _total parameter after load has completed)
     bool            _boundary_create_attempted = false; // true if we have attempted to create the boundary array
     bool            _boundary_valid = false;        // true if boundary forms a closed polygon
+    uint32_t        _boundary_update_ms;            // system time of last update to the boundary
 };
 
 namespace AP {

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -99,7 +99,11 @@ public:
     /// polygon related methods
     ///
 
+    /// returns true if polygon fence is valid (i.e. has at least 3 sides)
+    bool is_polygon_valid() const { return _boundary_valid; }
+
     /// returns pointer to array of polygon points and num_points is filled in with the total number
+    /// points are offsets from EKF origin in NE frame
     Vector2f* get_boundary_points(uint16_t& num_points) const;
 
     /// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -274,6 +274,7 @@ public:
     void Write_Beacon(AP_Beacon &beacon);
     void Write_Proximity(AP_Proximity &proximity);
     void Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& point);
+    void Write_OA(uint8_t algorithm, const Location& final_dest, const Location& oa_dest);
 
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -1694,3 +1694,17 @@ void AP_Logger::Write_SRTL(bool active, uint16_t num_points, uint16_t max_points
     };
     WriteBlock(&pkt_srtl, sizeof(pkt_srtl));
 }
+
+void AP_Logger::Write_OA(uint8_t algorithm, const Location& final_dest, const Location& oa_dest)
+{
+    struct log_OA pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_OA_MSG),
+        time_us     : AP_HAL::micros64(),
+        algorithm   : algorithm,
+        final_lat   : final_dest.lat,
+        final_lng   : final_dest.lng,
+        oa_lat      : oa_dest.lat,
+        oa_lng      : oa_dest.lng,
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1125,6 +1125,16 @@ struct PACKED log_SRTL {
     float D;
 };
 
+struct PACKED log_OA {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t algorithm;
+    int32_t final_lat;
+    int32_t final_lng;
+    int32_t oa_lat;
+    int32_t oa_lng;
+};
+
 struct PACKED log_DSTL {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1337,7 +1347,9 @@ struct PACKED log_Arm_Disarm {
     { LOG_PERFORMANCE_MSG, sizeof(log_Performance),                     \
       "PM",  "QHHIIHIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,IntErr,SPICnt,I2CCnt", "s---b%--", "F---0A--" }, \
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
-      "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }
+      "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }, \
+    { LOG_OA_MSG, sizeof(log_OA), \
+      "OA","QBLLLL","TimeUS,Algo,DLat,DLng,OALat,OALng", "s-----", "F-GGGG" }
 
 // messages for more advanced boards
 #define LOG_EXTRA_STRUCTURES \
@@ -1681,6 +1693,7 @@ enum LogMessages : uint8_t {
     LOG_ERROR_MSG,
     LOG_ADSB_MSG,
     LOG_ARM_DISARM_MSG,
+    LOG_OA_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_Math/polygon.cpp
+++ b/libraries/AP_Math/polygon.cpp
@@ -18,6 +18,8 @@
 
 #include "AP_Math.h"
 
+#pragma GCC optimize("O3")
+
 /*
  *  The point in polygon algorithm is based on:
  *  https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
@@ -121,3 +123,75 @@ template bool Polygon_outside<int32_t>(const Vector2l &P, const Vector2l *V, uns
 template bool Polygon_complete<int32_t>(const Vector2l *V, unsigned n);
 template bool Polygon_outside<float>(const Vector2f &P, const Vector2f *V, unsigned n);
 template bool Polygon_complete<float>(const Vector2f *V, unsigned n);
+
+
+/*
+  determine if the polygon of N verticies defined by points V is
+  intersected by a line from point p1 to point p2
+ */
+bool Polygon_intersects(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2)
+{
+    for (uint8_t i=0; i<N-1; i++) {
+        Vector2f tmp;
+        const Vector2f &v1 = V[i];
+        const Vector2f &v2 = V[i+1];
+        // optimisations for common cases
+        if (v1.x > p1.x && v2.x > p1.x && v1.x > p2.x && v2.x > p2.x) {
+            continue;
+        }
+        if (v1.y > p1.y && v2.y > p1.y && v1.y > p2.y && v2.y > p2.y) {
+            continue;
+        }
+        if (v1.x < p1.x && v2.x < p1.x && v1.x < p2.x && v2.x < p2.x) {
+            continue;
+        }
+        if (v1.y < p1.y && v2.y < p1.y && v1.y < p2.y && v2.y < p2.y) {
+            continue;
+        }
+        if (Vector2f::segment_intersection(v1,v2,p1,p2,tmp)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+  return the closest distance that a line from p1 to p2 comes to an
+  edge of closed polygon V, defined by N points
+ */
+float Polygon_closest_distance_line(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2)
+{
+    if (Polygon_intersects(V,N,p1,p2)) {
+        return 0;
+    }
+    float closest_sq = FLT_MAX;
+    for (uint8_t i=0; i<N-1; i++) {
+        const Vector2f &v1 = V[i];
+        const Vector2f &v2 = V[i+1];
+
+        float dist_sq = Vector2f::closest_distance_between_lines_squared(v1, v2, p1, p2);
+        if (dist_sq < closest_sq) {
+            closest_sq = dist_sq;
+        }
+    }
+    return sqrtf(closest_sq);
+}
+
+/*
+  return the closest distance that point p comes to an edge of closed
+  polygon V, defined by N points
+ */
+float Polygon_closest_distance_point(const Vector2f *V, unsigned N, const Vector2f &p)
+{
+    float closest_sq = FLT_MAX;
+    for (uint8_t i=0; i<N-1; i++) {
+        const Vector2f &v1 = V[i];
+        const Vector2f &v2 = V[i+1];
+
+        float dist_sq = Vector2f::closest_distance_between_line_and_point_squared(v1, v2, p);
+        if (dist_sq < closest_sq) {
+            closest_sq = dist_sq;
+        }
+    }
+    return sqrtf(closest_sq);
+}

--- a/libraries/AP_Math/polygon.h
+++ b/libraries/AP_Math/polygon.h
@@ -27,13 +27,15 @@ bool        Polygon_complete(const Vector2<T> *V, unsigned n);
 /*
   determine if the polygon of N verticies defined by points V is
   intersected by a line from point p1 to point p2
+  intersection argument returns the intersection closest to p1
  */
-bool Polygon_intersects(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2);
+bool Polygon_intersects(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2, Vector2f &intersection);
 
 
 /*
   return the closest distance that a line from p1 to p2 comes to an
   edge of closed polygon V, defined by N points
+  negative numbers indicate the line cross into the polygon with the negative size being the distance from p2 to the intersection point closest to p1
  */
 float Polygon_closest_distance_line(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2);
 

--- a/libraries/AP_Math/polygon.h
+++ b/libraries/AP_Math/polygon.h
@@ -24,3 +24,21 @@ bool        Polygon_outside(const Vector2<T> &P, const Vector2<T> *V, unsigned n
 template <typename T>
 bool        Polygon_complete(const Vector2<T> *V, unsigned n);
 
+/*
+  determine if the polygon of N verticies defined by points V is
+  intersected by a line from point p1 to point p2
+ */
+bool Polygon_intersects(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2);
+
+
+/*
+  return the closest distance that a line from p1 to p2 comes to an
+  edge of closed polygon V, defined by N points
+ */
+float Polygon_closest_distance_line(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2);
+
+/*
+  return the closest distance that a point p comes to an edge of
+  closed polygon V, defined by N points
+ */
+float Polygon_closest_distance_point(const Vector2f *V, unsigned N, const Vector2f &p);

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -248,9 +248,63 @@ bool Vector2<T>::circle_segment_intersection(const Vector2<T>& seg_start, const 
     return false;
 }
 
+// normalizes this vector
+template <typename T>
+void Vector2<T>::normalize()
+{
+    *this /= length();
+}
+
+// returns the normalized vector
+template <typename T>
+Vector2<T> Vector2<T>::normalized() const
+{
+    return *this/length();
+}
+
+// reflects this vector about n
+template <typename T>
+void Vector2<T>::reflect(const Vector2<T> &n)
+{
+    const Vector2<T> orig(*this);
+    project(n);
+    *this = *this*2 - orig;
+}
+
+// projects this vector onto v
+template <typename T>
+void Vector2<T>::project(const Vector2<T> &v)
+{
+    *this= v * (*this * v)/(v*v);
+}
+
+// returns this vector projected onto v
+template <typename T>
+Vector2<T> Vector2<T>::projected(const Vector2<T> &v)
+{
+    return v * (*this * v)/(v*v);
+}
+
+// given a position pos_delta and a velocity v1 produce a vector
+// perpendicular to v1 maximising distance from p1
+template <typename T>
+Vector2<T> Vector2<T>::perpendicular(const Vector2<T> &pos_delta, const Vector2<T> &v1)
+{
+    const Vector2<T> perpendicular1 = Vector2<T>(-v1[1], v1[0]);
+    const Vector2<T> perpendicular2 = Vector2<T>(v1[1], -v1[0]);
+    const T d1 = perpendicular1 * pos_delta;
+    const T d2 = perpendicular2 * pos_delta;
+    if (d1 > d2) {
+        return perpendicular1;
+    }
+    return perpendicular2;
+}
+
 // only define for float
 template float Vector2<float>::length_squared(void) const;
 template float Vector2<float>::length(void) const;
+template Vector2<float> Vector2<float>::normalized() const;
+template void Vector2<float>::normalize();
 template float Vector2<float>::operator *(const Vector2<float> &v) const;
 template float Vector2<float>::operator %(const Vector2<float> &v) const;
 template Vector2<float> &Vector2<float>::operator *=(const float num);

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -329,6 +329,30 @@ Vector2<T> Vector2<T>::closest_point(const Vector2<T> &p, const Vector2<T> &v, c
     }
 }
 
+/*
+ * Returns the point closest to p on the line segment (0,w).
+ *
+ * this is a simplification of closest point with a general segment, with v=(0,0)
+ */
+template <typename T>
+Vector2<T> Vector2<T>::closest_point(const Vector2<T> &p, const Vector2<T> &w)
+{
+    // length squared of line segment
+    const float l2 = w.length_squared();
+    if (l2 < FLT_EPSILON) {
+        // v == w case
+        return w;
+    }
+    const float t = (p * w) / l2;
+    if (t <= 0) {
+        return Vector2<T>(0,0);
+    } else if (t >= 1) {
+        return w;
+    } else {
+        return w*t;
+    }
+}
+
 // w defines a line segment from the origin
 // p is a point
 // returns the square of the closest distance between the radial and the point

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -29,9 +29,8 @@ float Vector2<T>::length_squared() const
 template <typename T>
 float Vector2<T>::length(void) const
 {
-	return norm(x, y);
+    return norm(x, y);
 }
-
 
 // dot product
 template <typename T>

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -437,6 +437,7 @@ template float Vector2<float>::angle(const Vector2<float> &v) const;
 template float Vector2<float>::angle(void) const;
 template bool Vector2<float>::segment_intersection(const Vector2<float>& seg1_start, const Vector2<float>& seg1_end, const Vector2<float>& seg2_start, const Vector2<float>& seg2_end, Vector2<float>& intersection);
 template bool Vector2<float>::circle_segment_intersection(const Vector2<float>& seg_start, const Vector2<float>& seg_end, const Vector2<float>& circle_center, float radius, Vector2<float>& intersection);
+template Vector2<float> Vector2<float>::perpendicular(const Vector2<float> &pos_delta, const Vector2<float> &v1);
 template Vector2<float> Vector2<float>::closest_point(const Vector2<float> &p, const Vector2<float> &v, const Vector2<float> &w);
 template float Vector2<float>::closest_distance_between_radial_and_point_squared(const Vector2<float> &w, const Vector2<float> &p);
 template float Vector2<float>::closest_distance_between_radial_and_point(const Vector2<float> &w, const Vector2<float> &p);

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -353,6 +353,45 @@ Vector2<T> Vector2<T>::closest_point(const Vector2<T> &p, const Vector2<T> &w)
     }
 }
 
+// closest distance between a line segment and a point
+// https://stackoverflow.com/questions/2824478/shortest-distance-between-two-line-segments
+template <typename T>
+float Vector2<T>::closest_distance_between_line_and_point_squared(const Vector2<T> &w1,
+                                                                  const Vector2<T> &w2,
+                                                                  const Vector2<T> &p)
+{
+    return closest_distance_between_radial_and_point_squared(w2-w1, p-w1);
+}
+
+// w1 and w2 define a line segment
+// p is a point
+// returns the closest distance between the line segment and the point
+template <typename T>
+float Vector2<T>::closest_distance_between_line_and_point(const Vector2<T> &w1,
+                                                          const Vector2<T> &w2,
+                                                          const Vector2<T> &p)
+{
+    return sqrtf(closest_distance_between_line_and_point_squared(w1, w2, p));
+}
+
+// a1->a2 and b2->v2 define two line segments
+// returns the square of the closest distance between the two line segments
+// see https://stackoverflow.com/questions/2824478/shortest-distance-between-two-line-segments
+template <typename T>
+float Vector2<T>::closest_distance_between_lines_squared(const Vector2<T> &a1,
+                                                         const Vector2<T> &a2,
+                                                         const Vector2<T> &b1,
+                                                         const Vector2<T> &b2)
+{
+    const float dist1 = Vector2<T>::closest_distance_between_line_and_point_squared(b1,b2,a1);
+    const float dist2 = Vector2<T>::closest_distance_between_line_and_point_squared(b1,b2,a2);
+    const float dist3 = Vector2<T>::closest_distance_between_line_and_point_squared(a1,a2,b1);
+    const float dist4 = Vector2<T>::closest_distance_between_line_and_point_squared(a1,a2,b2);
+    const float m1 = MIN(dist1,dist2);
+    const float m2 = MIN(dist3,dist4);
+    return MIN(m1,m2);
+}
+
 // w defines a line segment from the origin
 // p is a point
 // returns the square of the closest distance between the radial and the point
@@ -401,6 +440,9 @@ template bool Vector2<float>::circle_segment_intersection(const Vector2<float>& 
 template Vector2<float> Vector2<float>::closest_point(const Vector2<float> &p, const Vector2<float> &v, const Vector2<float> &w);
 template float Vector2<float>::closest_distance_between_radial_and_point_squared(const Vector2<float> &w, const Vector2<float> &p);
 template float Vector2<float>::closest_distance_between_radial_and_point(const Vector2<float> &w, const Vector2<float> &p);
+template float Vector2<float>::closest_distance_between_line_and_point(const Vector2<float> &w1, const Vector2<float> &w2, const Vector2<float> &p);
+template float Vector2<float>::closest_distance_between_line_and_point_squared(const Vector2<float> &w1, const Vector2<float> &w2, const Vector2<float> &p);
+template float Vector2<float>::closest_distance_between_lines_squared(const Vector2<float> &a1,const Vector2<float> &a2,const Vector2<float> &b1,const Vector2<float> &b2);
 
 template bool Vector2<long>::operator ==(const Vector2<long> &v) const;
 

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -140,6 +140,12 @@ float Vector2<T>::angle(const Vector2<T> &v2) const
     return acosf(cosv);
 }
 
+template <typename T>
+float Vector2<T>::angle(void) const
+{
+    return M_PI_2 + atan2f(-x, y);
+}
+
 // find the intersection between two line segments
 // returns true if they intersect, false if they do not
 // the point of intersection is returned in the intersection argument
@@ -255,6 +261,7 @@ template bool Vector2<float>::operator !=(const Vector2<float> &v) const;
 template bool Vector2<float>::is_nan(void) const;
 template bool Vector2<float>::is_inf(void) const;
 template float Vector2<float>::angle(const Vector2<float> &v) const;
+template float Vector2<float>::angle(void) const;
 template bool Vector2<float>::segment_intersection(const Vector2<float>& seg1_start, const Vector2<float>& seg1_end, const Vector2<float>& seg2_start, const Vector2<float>& seg2_end, Vector2<float>& intersection);
 template bool Vector2<float>::circle_segment_intersection(const Vector2<float>& seg_start, const Vector2<float>& seg_end, const Vector2<float>& circle_center, float radius, Vector2<float>& intersection);
 

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -300,6 +300,35 @@ Vector2<T> Vector2<T>::perpendicular(const Vector2<T> &pos_delta, const Vector2<
     return perpendicular2;
 }
 
+/*
+ * Returns the point closest to p on the line segment (v,w).
+ *
+ * Comments and implementation taken from
+ * http://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
+ */
+template <typename T>
+Vector2<T> Vector2<T>::closest_point(const Vector2<T> &p, const Vector2<T> &v, const Vector2<T> &w)
+{
+    // length squared of line segment
+    const float l2 = (v - w).length_squared();
+    if (l2 < FLT_EPSILON) {
+        // v == w case
+        return v;
+    }
+    // Consider the line extending the segment, parameterized as v + t (w - v).
+    // We find projection of point p onto the line.
+    // It falls where t = [(p-v) . (w-v)] / |w-v|^2
+    // We clamp t from [0,1] to handle points outside the segment vw.
+    const float t = ((p - v) * (w - v)) / l2;
+    if (t <= 0) {
+        return v;
+    } else if (t >= 1) {
+        return w;
+    } else {
+        return v + (w - v)*t;
+    }
+}
+
 // only define for float
 template float Vector2<float>::length_squared(void) const;
 template float Vector2<float>::length(void) const;
@@ -324,6 +353,7 @@ template float Vector2<float>::angle(const Vector2<float> &v) const;
 template float Vector2<float>::angle(void) const;
 template bool Vector2<float>::segment_intersection(const Vector2<float>& seg1_start, const Vector2<float>& seg1_end, const Vector2<float>& seg2_start, const Vector2<float>& seg2_end, Vector2<float>& intersection);
 template bool Vector2<float>::circle_segment_intersection(const Vector2<float>& seg_start, const Vector2<float>& seg_end, const Vector2<float>& circle_center, float radius, Vector2<float>& intersection);
+template Vector2<float> Vector2<float>::closest_point(const Vector2<float> &p, const Vector2<float> &v, const Vector2<float> &w);
 
 template bool Vector2<long>::operator ==(const Vector2<long> &v) const;
 

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -329,6 +329,27 @@ Vector2<T> Vector2<T>::closest_point(const Vector2<T> &p, const Vector2<T> &v, c
     }
 }
 
+// w defines a line segment from the origin
+// p is a point
+// returns the square of the closest distance between the radial and the point
+template <typename T>
+float Vector2<T>::closest_distance_between_radial_and_point_squared(const Vector2<T> &w,
+                                                                   const Vector2<T> &p)
+{
+    const Vector2<T> closest = closest_point(p, w);
+    return (closest - p).length_squared();
+}
+
+// w defines a line segment from the origin
+// p is a point
+// returns the closest distance between the radial and the point
+template <typename T>
+float Vector2<T>::closest_distance_between_radial_and_point(const Vector2<T> &w,
+                                                            const Vector2<T> &p)
+{
+    return sqrtf(closest_distance_between_radial_and_point_squared(w,p));
+}
+
 // only define for float
 template float Vector2<float>::length_squared(void) const;
 template float Vector2<float>::length(void) const;
@@ -354,6 +375,8 @@ template float Vector2<float>::angle(void) const;
 template bool Vector2<float>::segment_intersection(const Vector2<float>& seg1_start, const Vector2<float>& seg1_end, const Vector2<float>& seg2_start, const Vector2<float>& seg2_end, Vector2<float>& intersection);
 template bool Vector2<float>::circle_segment_intersection(const Vector2<float>& seg_start, const Vector2<float>& seg_end, const Vector2<float>& circle_center, float radius, Vector2<float>& intersection);
 template Vector2<float> Vector2<float>::closest_point(const Vector2<float> &p, const Vector2<float> &v, const Vector2<float> &w);
+template float Vector2<float>::closest_distance_between_radial_and_point_squared(const Vector2<float> &w, const Vector2<float> &p);
+template float Vector2<float>::closest_distance_between_radial_and_point(const Vector2<float> &w, const Vector2<float> &p);
 
 template bool Vector2<long>::operator ==(const Vector2<long> &v) const;
 

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -21,6 +21,12 @@
 #include "AP_Math.h"
 
 template <typename T>
+float Vector2<T>::length_squared() const
+{
+    return (float)(x*x + y*y);
+}
+
+template <typename T>
 float Vector2<T>::length(void) const
 {
 	return norm(x, y);
@@ -244,6 +250,7 @@ bool Vector2<T>::circle_segment_intersection(const Vector2<T>& seg_start, const 
 }
 
 // only define for float
+template float Vector2<float>::length_squared(void) const;
 template float Vector2<float>::length(void) const;
 template float Vector2<float>::operator *(const Vector2<float> &v) const;
 template float Vector2<float>::operator %(const Vector2<float> &v) const;

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -134,7 +134,7 @@ struct Vector2
     float length_squared() const;
 
     // gets the length of this vector
-    float           length(void) const;
+    float length(void) const;
 
     // normalizes this vector
     void    normalize()

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -137,50 +137,23 @@ struct Vector2
     float length(void) const;
 
     // normalizes this vector
-    void    normalize()
-    {
-        *this/=length();
-    }
+    void normalize();
 
     // returns the normalized vector
-    Vector2<T>  normalized() const
-    {
-        return *this/length();
-    }
+    Vector2<T> normalized() const;
 
     // reflects this vector about n
-    void    reflect(const Vector2<T> &n)
-    {
-        const Vector2<T>        orig(*this);
-        project(n);
-        *this= *this*2 - orig;
-    }
+    void reflect(const Vector2<T> &n);
 
     // projects this vector onto v
-    void    project(const Vector2<T> &v)
-    {
-        *this= v * (*this * v)/(v*v);
-    }
+    void project(const Vector2<T> &v);
 
     // returns this vector projected onto v
-    Vector2<T>  projected(const Vector2<T> &v)
-    {
-        return v * (*this * v)/(v*v);
-    }
+    Vector2<T> projected(const Vector2<T> &v);
 
     // given a position p1 and a velocity v1 produce a vector
     // perpendicular to v1 maximising distance from p1
-    static Vector2<T> perpendicular(const Vector2<T> &pos_delta, const Vector2<T> &v1)
-    {
-        const Vector2<T> perpendicular1 = Vector2<T>(-v1[1], v1[0]);
-        const Vector2<T> perpendicular2 = Vector2<T>(v1[1], -v1[0]);
-        const T d1 = perpendicular1 * pos_delta;
-        const T d2 = perpendicular2 * pos_delta;
-        if (d1 > d2) {
-            return perpendicular1;
-        }
-        return perpendicular2;
-    }
+    static Vector2<T> perpendicular(const Vector2<T> &pos_delta, const Vector2<T> &v1);
 
     /*
      * Returns the point closest to p on the line segment (v,w).

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -131,10 +131,7 @@ struct Vector2
     }
 
     // gets the length of this vector squared
-    T   length_squared() const
-    {
-        return (T)(*this * *this);
-    }
+    float length_squared() const;
 
     // gets the length of this vector
     float           length(void) const;

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -163,6 +163,13 @@ struct Vector2
      */
     static Vector2<T> closest_point(const Vector2<T> &p, const Vector2<T> &v, const Vector2<T> &w);
 
+    /*
+     * Returns the point closest to p on the line segment (0,w).
+     *
+     * this is a simplification of closest point with a general segment, with v=(0,0)
+     */
+    static Vector2<T> closest_point(const Vector2<T> &p, const Vector2<T> &w);
+
     // w defines a line segment from the origin
     // p is a point
     // returns the square of the closest distance between the radial and the point

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -161,27 +161,7 @@ struct Vector2
      * Comments and implementation taken from
      * http://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
      */
-    static Vector2<T> closest_point(const Vector2<T> &p, const Vector2<T> &v, const Vector2<T> &w)
-    {
-        // length squared of line segment
-        const float l2 = (v - w).length_squared();
-        if (l2 < FLT_EPSILON) {
-            // v == w case
-            return v;
-        }
-        // Consider the line extending the segment, parameterized as v + t (w - v).
-        // We find projection of point p onto the line.
-        // It falls where t = [(p-v) . (w-v)] / |w-v|^2
-        // We clamp t from [0,1] to handle points outside the segment vw.
-        const float t = ((p - v) * (w - v)) / l2;
-        if (t <= 0) {
-            return v;
-        } else if (t >= 1) {
-            return w;
-        } else {
-            return v + (w - v)*t;
-        }
-    }
+    static Vector2<T> closest_point(const Vector2<T> &p, const Vector2<T> &v, const Vector2<T> &w);
 
     // w defines a line segment from the origin
     // p is a point

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -170,6 +170,27 @@ struct Vector2
      */
     static Vector2<T> closest_point(const Vector2<T> &p, const Vector2<T> &w);
 
+    // w1 and w2 define a line segment
+    // p is a point
+    // returns the square of the closest distance between the line segment and the point
+    static float closest_distance_between_line_and_point_squared(const Vector2<T> &w1,
+                                                                 const Vector2<T> &w2,
+                                                                 const Vector2<T> &p);
+
+    // w1 and w2 define a line segment
+    // p is a point
+    // returns the closest distance between the line segment and the point
+    static float closest_distance_between_line_and_point(const Vector2<T> &w1,
+                                                         const Vector2<T> &w2,
+                                                         const Vector2<T> &p);
+
+    // a1->a2 and b2->v2 define two line segments
+    // returns the square of the closest distance between the two line segments
+    static float closest_distance_between_lines_squared(const Vector2<T> &a1,
+                                                        const Vector2<T> &a2,
+                                                        const Vector2<T> &b1,
+                                                        const Vector2<T> &b2);
+
     // w defines a line segment from the origin
     // p is a point
     // returns the square of the closest distance between the radial and the point

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -30,9 +30,6 @@
 #pragma once
 
 #include <cmath>
-#if MATH_CHECK_INDEXES
-#include <assert.h>
-#endif
 
 template <typename T>
 struct Vector2

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -98,6 +98,9 @@ struct Vector2
     // returns 0 if the vectors are parallel, and M_PI if they are antiparallel
     float angle(const Vector2<T> &v2) const;
 
+    // computes the angle of this vector in radians, from -Pi to Pi
+    float angle(void) const;
+
     // check if any elements are NAN
     bool is_nan(void) const;
 

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -165,14 +165,15 @@ struct Vector2
 
     // w defines a line segment from the origin
     // p is a point
+    // returns the square of the closest distance between the radial and the point
+    static float closest_distance_between_radial_and_point_squared(const Vector2<T> &w,
+                                                                   const Vector2<T> &p);
+
+    // w defines a line segment from the origin
+    // p is a point
     // returns the closest distance between the radial and the point
     static float closest_distance_between_radial_and_point(const Vector2<T> &w,
-                                                           const Vector2<T> &p)
-    {
-        const Vector2<T> closest = closest_point(p, Vector2<T>(0,0), w);
-        const Vector2<T> delta = closest - p;
-        return delta.length();
-    }
+                                                           const Vector2<T> &p);
 
     // find the intersection between two line segments
     // returns true if they intersect, false if they do not

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -379,76 +379,24 @@ const Vector2f* AP_Proximity::get_boundary_points(uint16_t& num_points) const
     return get_boundary_points(primary_instance, num_points);
 }
 
-const AP_Proximity::Proximity_Location* AP_Proximity::get_locations(uint16_t& location_count) const
-{
-    if (_location_count == 0) {
-        return nullptr;
-    }
-
-    location_count = _location_count;
-    return _locations;
-}
-
 // copy location points around vehicle into a buffer owned by the caller
 // caller should provide the buff_size which is the maximum number of locations the buffer can hold (normally PROXIMITY_MAX_DIRECTION)
 // num_copied is updated with the number of locations copied into the buffer
 // returns true on success, false on failure (should only happen if there is a semaphore conflict)
-bool AP_Proximity::copy_locations(Proximity_Location* buff, uint16_t buff_size, uint16_t& num_copied)
+bool AP_Proximity::copy_locations(uint8_t instance, Proximity_Location* buff, uint16_t buff_size, uint16_t& num_copied)
 {
-    // sanity check buffer
-    if (buff == nullptr) {
+    if ((drivers[instance] == nullptr) || (_type[instance] == Proximity_Type_None)) {
         num_copied = 0;
         return false;
     }
 
-    WITH_SEMAPHORE(_rsem);
-
-    // copy locations into caller's buffer
-    num_copied = MIN(_location_count, buff_size);
-    for (uint16_t i=0; i<num_copied; i++) {
-        buff[i] = _locations[i];
-    }
-
-    return true;
+    // call backend copy_locations
+    return drivers[instance]->copy_locations(buff, buff_size, num_copied);
 }
 
-void AP_Proximity::locations_update()
+bool AP_Proximity::copy_locations(Proximity_Location* buff, uint16_t buff_size, uint16_t& num_copied)
 {
-    // exit immediately if primary sensor is disabled
-    if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
-        return;
-    }
-
-    WITH_SEMAPHORE(_rsem);
-
-    // get number of objects, return early if none
-    uint8_t num_objects = get_object_count();
-    if (num_objects == 0) {
-        _location_count = 0;
-        return;
-    }
-
-    // get vehicle location and heading in degrees
-    Location my_loc;
-    if (!AP::ahrs().get_position(my_loc)) {
-        return;
-    }
-    const float veh_bearing = AP::ahrs().yaw_sensor * 0.01f;
-
-    // convert offset from vehicle position to earth frame location
-    const uint32_t now_ms = AP_HAL::millis();
-    _location_count = 0;
-    for (uint8_t i=0; i<num_objects; i++) {
-        float ang_deg, dist_m;
-        if (get_object_angle_and_distance(i, ang_deg, dist_m)) {
-            Location temp_loc = my_loc;
-            temp_loc.offset_bearing(wrap_180(veh_bearing + ang_deg), dist_m);
-            _locations[_location_count].loc = temp_loc;
-            _locations[_location_count].radius_m = 1;
-            _locations[_location_count].last_update_ms = now_ms;
-            _location_count++;
-        }
-    }
+    return copy_locations(primary_instance, buff, buff_size, num_copied);
 }
 
 // get distance and angle to closest object (used for pre-arm check)

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -26,7 +26,7 @@
 #define PROXIMITY_MAX_IGNORE                6   // up to six areas can be ignored
 #define PROXIMITY_MAX_DIRECTION 8
 #define PROXIMITY_SENSOR_ID_START 10
-#define PROXIMITY_LOCATION_TIMEOUT_MS       3000 // locations (provided by get_locations method) are valid for this many milliseconds
+#define PROXIMITY_LOCATION_TIMEOUT_MS       3000 // locations (provided by copy_locations method) are valid for this many milliseconds
 
 class AP_Proximity_Backend;
 
@@ -108,14 +108,11 @@ public:
     const Vector2f* get_boundary_points(uint8_t instance, uint16_t& num_points) const;
     const Vector2f* get_boundary_points(uint16_t& num_points) const;
 
-    // get Location points around vehicle for use by avoidance in earth-frame
-    //   returns nullptr and sets num_points to zero if no boundary can be returned
-    const Proximity_Location* get_locations(uint16_t& location_count) const;
-
     // copy location points around vehicle into a buffer owned by the caller
     // caller should provide the buff_size which is the maximum number of locations the buffer can hold (normally PROXIMITY_MAX_DIRECTION)
     // num_copied is updated with the number of locations copied into the buffer
     // returns true on success, false on failure (should only happen if there is a semaphore conflict)
+    bool copy_locations(uint8_t instance, Proximity_Location* buff, uint16_t buff_size, uint16_t& num_copied);
     bool copy_locations(Proximity_Location* buff, uint16_t buff_size, uint16_t& num_copied);
 
     // get distance and angle to closest object (used for pre-arm check)
@@ -177,12 +174,6 @@ private:
     AP_Int8 _ignore_width_deg[PROXIMITY_MAX_IGNORE];    // width of beam (in degrees) that should be ignored
 
     void detect_instance(uint8_t instance);
-
-    // earth frame objects
-    void locations_update();
-    uint16_t _location_count;                               // number of locations held in _locations buffer
-    Proximity_Location _locations[PROXIMITY_MAX_DIRECTION]; // buffer of locations
-    HAL_Semaphore_Recursive _rsem;                          // semaphore for access to _locations and _location_count
 };
 
 namespace AP {

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -14,6 +14,8 @@
  */
 
 #include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity.h"
 #include "AP_Proximity_Backend.h"
@@ -172,7 +174,7 @@ void AP_Proximity_Backend::init_boundary()
         _sector_edge_vector[sector].y = sinf(angle_rad) * 100.0f;
         _boundary_point[sector] = _sector_edge_vector[sector] * PROXIMITY_BOUNDARY_DIST_DEFAULT;
     }
-    frontend.locations_update();
+    update_locations();
 }
 
 // update boundary points used for object avoidance based on a single sector's distance changing
@@ -227,7 +229,27 @@ void AP_Proximity_Backend::update_boundary_for_sector(uint8_t sector)
     if (!_distance_valid[prev_sector_ccw]) {
         _boundary_point[prev_sector_ccw] = _sector_edge_vector[prev_sector_ccw] * shortest_distance;
     }
-    frontend.locations_update();
+    update_locations();
+}
+
+// copy location points around vehicle into a buffer owned by the caller
+// caller should provide the buff_size which is the maximum number of locations the buffer can hold (normally PROXIMITY_MAX_DIRECTION)
+// num_copied is updated with the number of locations copied into the buffer
+// returns true on success, false on failure which should only happen if buff is nullptr
+bool AP_Proximity_Backend::copy_locations(AP_Proximity::Proximity_Location* buff, uint16_t buff_size, uint16_t& num_copied)
+{
+    // sanity check buffer
+    if (buff == nullptr) {
+        num_copied = 0;
+        return false;
+    }
+
+    WITH_SEMAPHORE(_rsem);
+
+    // copy locations into caller's buffer
+    num_copied = MIN(_location_count, buff_size);
+    memcpy(buff, _locations, num_copied * sizeof(AP_Proximity::Proximity_Location));
+    return true;
 }
 
 // set status and update valid count
@@ -327,4 +349,42 @@ bool AP_Proximity_Backend::get_next_ignore_start_or_end(uint8_t start_or_end, in
         ignore_start = smallest_angle_start;
     }
     return found;
+}
+
+void AP_Proximity_Backend::update_locations()
+{
+    WITH_SEMAPHORE(_rsem);
+
+    // get number of objects, return early if none
+    const uint8_t num_objects = get_object_count();
+    if (num_objects == 0) {
+        _location_count = 0;
+        return;
+    }
+
+    // get vehicle location and heading in degrees
+    float veh_bearing;
+    Location my_loc;
+    {
+        WITH_SEMAPHORE(AP::ahrs().get_semaphore());
+        if (!AP::ahrs().get_position(my_loc)) {
+            return;
+        }
+        veh_bearing = AP::ahrs().yaw_sensor * 0.01f;
+    }
+
+    // convert offset from vehicle position to earth frame location
+    const uint32_t now_ms = AP_HAL::millis();
+    _location_count = 0;
+    for (uint8_t i=0; i<num_objects; i++) {
+        float ang_deg, dist_m;
+        if (get_object_angle_and_distance(i, ang_deg, dist_m)) {
+            Location temp_loc = my_loc;
+            temp_loc.offset_bearing(wrap_180(veh_bearing + ang_deg), dist_m);
+            _locations[_location_count].loc = temp_loc;
+            _locations[_location_count].radius_m = 1;
+            _locations[_location_count].last_update_ms = now_ms;
+            _location_count++;
+        }
+    }
 }

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -172,6 +172,7 @@ void AP_Proximity_Backend::init_boundary()
         _sector_edge_vector[sector].y = sinf(angle_rad) * 100.0f;
         _boundary_point[sector] = _sector_edge_vector[sector] * PROXIMITY_BOUNDARY_DIST_DEFAULT;
     }
+    frontend.locations_update();
 }
 
 // update boundary points used for object avoidance based on a single sector's distance changing
@@ -226,6 +227,7 @@ void AP_Proximity_Backend::update_boundary_for_sector(uint8_t sector)
     if (!_distance_valid[prev_sector_ccw]) {
         _boundary_point[prev_sector_ccw] = _sector_edge_vector[prev_sector_ccw] * shortest_distance;
     }
+    frontend.locations_update();
 }
 
 // set status and update valid count

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -64,6 +64,12 @@ public:
     // get distances in 8 directions. used for sending distances to ground station
     bool get_horizontal_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const;
 
+    // copy location points around vehicle into a buffer owned by the caller
+    // caller should provide the buff_size which is the maximum number of locations the buffer can hold (normally PROXIMITY_MAX_DIRECTION)
+    // num_copied is updated with the number of locations copied into the buffer
+    // returns true on success, false on failure which should only happen if buff is nullptr
+    bool copy_locations(AP_Proximity::Proximity_Location* buff, uint16_t buff_size, uint16_t& num_copied);
+
 protected:
 
     // set status and update valid_count
@@ -86,6 +92,9 @@ protected:
     bool get_ignore_area(uint8_t index, uint16_t &angle_deg, uint8_t &width_deg) const;
     bool get_next_ignore_start_or_end(uint8_t start_or_end, int16_t start_angle, int16_t &ignore_start) const;
 
+    // earth frame objects
+    void update_locations();
+
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
 
@@ -102,4 +111,9 @@ protected:
     // fence boundary
     Vector2f _sector_edge_vector[PROXIMITY_SECTORS_MAX];    // vector for right-edge of each sector, used to speed up calculation of boundary
     Vector2f _boundary_point[PROXIMITY_SECTORS_MAX];        // bounding polygon around the vehicle calculated conservatively for object avoidance
+
+    // earth frame locations (i.e. detected obstacles stored as lat/lon points)
+    uint16_t _location_count;                               // number of locations held in _locations buffer
+    AP_Proximity::Proximity_Location _locations[PROXIMITY_SECTORS_MAX];   // buffer of locations
+    HAL_Semaphore_Recursive _rsem;                          // semaphore for access to _locations and _location_count
 };

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -3,6 +3,7 @@
 #include <AP_Common/AP_Common.h>
 #include <APM_Control/AR_AttitudeControl.h>
 #include <AP_Navigation/AP_Navigation.h>
+#include <AC_Avoidance/AP_OAPathPlanner.h>
 
 const float AR_WPNAV_HEADING_UNKNOWN = 99999.0f; // used to indicate to set_desired_location method that next leg's heading is unknown
 
@@ -56,6 +57,9 @@ public:
 
     // get current destination. Note: this is not guaranteed to be valid (i.e. _orig_and_dest_valid is not checked)
     const Location &get_destination() { return _destination; }
+
+    // get object avoidance adjusted destination. Note: this is not guaranteed to be valid (i.e. _orig_and_dest_valid is not checked)
+    const Location &get_oa_destination() { return _oa_destination; }
 
     // return heading (in degrees) and cross track error (in meters) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
     float wp_bearing_cd() const { return _wp_bearing_cd; }
@@ -143,4 +147,11 @@ private:
     // variables for reporting
     float _distance_to_destination; // distance from vehicle to final destination in meters
     bool _reached_destination;      // true once the vehicle has reached the destination
+
+    // object avoidance variables
+    bool _oa_active;                // true if we should use alternative destination to avoid obstacles
+    Location _oa_origin;            // intermediate origin during avoidance
+    Location _oa_destination;       // intermediate destination during avoidance
+    float _oa_distance_to_destination; // OA (object avoidance) distance from vehicle to _oa_destination in meters
+    float _oa_wp_bearing_cd;        // OA adjusted heading to _oa_destination in centi-degrees
 };

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2498,7 +2498,7 @@ void GCS_MAVLINK::send_home_position() const
         return;
     }
 
-    Location home = AP::ahrs().get_home();
+    const Location &home = AP::ahrs().get_home();
 
     const float q[4] = {1.0f, 0.0f, 0.0f, 0.0f};
     mavlink_msg_home_position_send(


### PR DESCRIPTION
This PR adds two new methods of obstacle avoidance (BendyRuler and [Dijkstra's](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm)) to the AC_Avoid and Rover.

I've marked this PR as a WIP but I think it is close-ish to being ready (once the "known issues" mentioned below are resolved).  I'd really like some feedback on the structure and anything else really to help me get it over the line.

[Tridge described BendyRuler in this video](https://www.youtube.com/watch?v=DZE_sl456dA) from the recent Developer's Unconference in Canberra but in short, it probes around the vehicle in 5deg increments and checks how far the probe point (or more accurately the line between the vehicle and the probe point) come to obstacles including the circular and polygon fences and barriers detected by the proximity sensor.

[Dijkstra's algorithm is descrbied to some degree here on Wikipedia](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm) but in short does this:

- creates a list of safe nodes which are a few meters inside the polygon fence
- calculates the distances between all the nodes and puts these into "visibility graphs"
- iterates through the nodes (starting at the "source" and ending at the "destination") updating each nodes distance from the source.  After updating all the distances the shortest path is clear by iterating backwards from destination to source and making use of the "distance_from_idx" held for each node.

Both methods have also been tested on a real vehicle (my AION Robotics R1 rover).  Some videos from testing:

- [SITL video of Dijkstra's](https://www.youtube.com/watch?v=JKxQGt6XW60)
- [SITL video of BendyRuler](https://www.youtube.com/watch?v=KuJLxMEcPnU)