### PR TITLE
AP_OpticalFlow: Correct Comment for CX-OF Data Format Sequence

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -19,10 +19,10 @@
    CXOF serial packet description
    byte0: header (0xFE)
    byte1: reserved
-   byte2: x-motion high byte;
-   byte3: x-motion low byte;
-   byte4: y-motion high byte;
-   byte5: y-motion low byte;
+   byte2: x-motion low byte;
+   byte3: x-motion high byte;
+   byte4: y-motion low byte;
+   byte5: y-motion high byte;
    byte6: t-motion
    byte7: surface quality
    byte8: footer (0xAA)


### PR DESCRIPTION
Correct CX-OF (a.k.a. UART Version PMW3901) Data Format Sequence
![image](https://user-images.githubusercontent.com/4748411/58482845-c19c5580-8191-11e9-9123-35ddd4010bf7.png)

