### PR TITLE
Copter: New filtering PID controller

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -50,7 +50,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
-    AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Multi, AC_PID),
+    AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Multi, AC_PID_Filtered),
 
     // @Param: RAT_PIT_P
     // @DisplayName: Pitch axis rate controller P gain
@@ -95,7 +95,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
-    AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Multi, AC_PID),
+    AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Multi, AC_PID_Filtered),
 
     // @Param: RAT_YAW_P
     // @DisplayName: Yaw axis rate controller P gain
@@ -140,7 +140,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
-    AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Multi, AC_PID),
+    AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Multi, AC_PID_Filtered),
 
     // @Param: THR_MIX_MIN
     // @DisplayName: Throttle Mix Minimum

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -5,6 +5,7 @@
 
 #include "AC_AttitudeControl.h"
 #include <AP_Motors/AP_MotorsMulticopter.h>
+#include <AC_PID/AC_PID_Filtered.h>
 
 // default rate controller PID gains
 #ifndef AC_ATC_MULTI_RATE_RP_P
@@ -90,9 +91,9 @@ protected:
     float get_throttle_avg_max(float throttle_in);
 
     AP_MotorsMulticopter& _motors_multi;
-    AC_PID                _pid_rate_roll;
-    AC_PID                _pid_rate_pitch;
-    AC_PID                _pid_rate_yaw;
+    AC_PID_Filtered       _pid_rate_roll;
+    AC_PID_Filtered       _pid_rate_pitch;
+    AC_PID_Filtered       _pid_rate_yaw;
 
     AP_Float              _thr_mix_man;     // throttle vs attitude control prioritisation used when using manual throttle (higher values mean we prioritise attitude control over throttle)
     AP_Float              _thr_mix_min;     // throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -21,17 +21,17 @@ public:
     AC_PID(float initial_p, float initial_i, float initial_d, float initial_imax, float initial_filt_hz, float dt, float initial_ff = 0);
 
     // set_dt - set time step in seconds
-    void        set_dt(float dt);
+    virtual void        set_dt(float dt);
 
     // set_input_filter_all - set input to PID controller
     //  input is filtered before the PID controllers are run
     //  this should be called before any other calls to get_p, get_i or get_d
-    void        set_input_filter_all(float input);
+    virtual void        set_input_filter_all(float input);
 
     // set_input_filter_d - set input to PID controller
     //  only input to the D portion of the controller is filtered
     //  this should be called before any other calls to get_p, get_i or get_d
-    void        set_input_filter_d(float input);
+    virtual void        set_input_filter_d(float input);
 
     // get_pid - get results from pid controller
     float       get_pid();
@@ -48,10 +48,10 @@ public:
     void        reset_filter() { _flags._reset_filter = true; }
 
     // load gain from eeprom
-    void        load_gains();
+    virtual void        load_gains();
 
     // save gain to eeprom
-    void        save_gains();
+    virtual void        save_gains();
 
     /// operator function call for easy initialisation
     void operator() (float p, float i, float d, float imaxval, float input_filt_hz, float dt, float ffval = 0);
@@ -70,7 +70,7 @@ public:
     void        kI(const float v) { _ki.set(v); }
     void        kD(const float v) { _kd.set(v); }
     void        imax(const float v) { _imax.set(fabsf(v)); }
-    void        filt_hz(const float v);
+    virtual void    filt_hz(const float v);
     void        ff(const float v) { _ff.set(v); }
 
     float       get_integrator() const { return _integrator; }

--- a/libraries/AC_PID/AC_PID_Filtered.cpp
+++ b/libraries/AC_PID/AC_PID_Filtered.cpp
@@ -1,0 +1,237 @@
+/// @file	AC_PID_Filtered.cpp
+/// @brief	Generic PID algorithm
+
+#include <AP_Math/AP_Math.h>
+#include "AC_PID_Filtered.h"
+
+const AP_Param::GroupInfo AC_PID_Filtered::var_info[] = {
+    // parameters from parent PID
+    AP_NESTEDGROUPINFO(AC_PID, 0),
+
+    // @Param: FLT2
+    // @DisplayName: Second PID Input filter frequency in Hz
+    // @Description: Second Input filter frequency in Hz. Filter is applied before the main filter. For small copters a frequency double that of FILT is a good starting point. This filter can be set at most to half the loop frequency.
+    // @Range: 0 200
+    // @Units: Hz
+    AP_GROUPINFO("FLT2", 1, AC_PID_Filtered, filt_hz2, 0.0f),
+
+    // @Param: NTCH
+    // @DisplayName: Enable
+    // @Description: Enable notch filter
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("NTCH", 2, AC_PID_Filtered, notch_enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: NTHZ
+    // @DisplayName: Frequency
+    // @Description: Notch center frequency in Hz
+    // @Range: 10 200
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("NTHZ", 3, AC_PID_Filtered, notch_center_freq_hz, 80),
+
+    // @Param: NTBW
+    // @DisplayName: Bandwidth
+    // @Description: Notch bandwidth in Hz
+    // @Range: 5 50
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("NTBW", 4, AC_PID_Filtered, notch_bandwidth_hz, 20),
+
+    // @Param: NTAT
+    // @DisplayName: Attenuation
+    // @Description: Notch attenuation in dB
+    // @Range: 5 30
+    // @Units: dB
+    // @User: Advanced
+    AP_GROUPINFO("NTAT", 5, AC_PID_Filtered, notch_attenuation_dB, 15),
+
+
+    AP_GROUPEND
+};
+
+// Constructor
+AC_PID_Filtered::AC_PID_Filtered(float initial_p, float initial_i, float initial_d, float initial_imax, float initial_filt_hz, float dt, float initial_ff) :
+    AC_PID(initial_p, initial_i, initial_d, initial_imax, initial_filt_hz, dt, initial_ff),
+    _raw_input(0.0f),
+    _raw_derivative(0.0f)
+{
+    // By default 2nd filter tracks the first
+    filt_hz2.set(0.0f);
+
+    AP_Param::setup_object_defaults(this, var_info);
+    set_dt(dt); // Initializes all the filters as well
+}
+
+// update the notch parameters
+void AC_PID_Filtered::notch_update_params()
+{
+    _pid_notch_filter.init(1.0/_dt, notch_center_freq_hz, notch_bandwidth_hz, notch_attenuation_dB);
+    _last_notch_center_freq_hz = notch_center_freq_hz;
+    _last_notch_bandwidth_hz = notch_bandwidth_hz;
+    _last_notch_attenuation_dB = notch_attenuation_dB;
+}
+
+// set_dt - set time step in seconds
+void AC_PID_Filtered::set_dt(float dt)
+{
+    // set dt and calculate the input filter alpha
+    AC_PID::set_dt(dt);
+    _pid_filter.set_cutoff_frequency(1.0/dt, _filt_hz);
+    if (is_zero(filt_hz2.get())) {
+        _pid_filter2.set_cutoff_frequency(1.0/dt, _filt_hz);
+    }
+    else {
+        _pid_filter2.set_cutoff_frequency(1.0/dt, filt_hz2);
+    }
+    notch_update_params();
+}
+
+// filt_hz - set input filter hz, used by autotune, does not affect _pid_filter2
+void AC_PID_Filtered::filt_hz(float hz)
+{
+    AC_PID::filt_hz(hz);
+    _pid_filter.set_cutoff_frequency(1.0/_dt, _filt_hz);
+    if (is_zero(filt_hz2.get())) {
+        _pid_filter2.set_cutoff_frequency(1.0/_dt, _filt_hz);
+    }
+}
+
+// set_input_filter_all - set input to PID controller
+//  input is filtered before the PID controllers are run
+//  this should be called before any other calls to get_p, get_i or get_d
+void AC_PID_Filtered::set_input_filter_all(float input)
+{
+    // don't process inf or NaN
+    if (!isfinite(input)) {
+        return;
+    }
+
+    // update notch parameters if necessary
+    if (notch_requires_update()) {
+        notch_update_params();
+        _flags._reset_filter = true;
+    }
+
+    if (!is_equal(_filt_hz.get(), _pid_filter.get_cutoff_freq())) {
+        _pid_filter.set_cutoff_frequency(1.0/_dt, _filt_hz);
+        // FILT2 may track FILT
+        if (is_zero(filt_hz2.get())) {
+            _pid_filter2.set_cutoff_frequency(1.0/_dt, _filt_hz);
+        }
+        _flags._reset_filter = true;
+    }
+
+    if (!is_zero(filt_hz2.get()) && !is_equal(filt_hz2.get(), _pid_filter2.get_cutoff_freq())) {
+        _pid_filter2.set_cutoff_frequency(1.0/_dt, filt_hz2);
+        _flags._reset_filter = true;
+    }
+
+    // reset input filter to value received
+    if (_flags._reset_filter) {
+        _pid_filter.reset();
+        _pid_filter2.reset();
+        _pid_notch_filter.reset();
+        _flags._reset_filter = false;
+        _input = input;
+        _raw_input = input;
+        _derivative = 0.0f;
+        _raw_derivative = 0.0f;
+    }
+
+    // update filter and calculate derivative
+    float next_input = _pid_filter2.apply(input);
+    next_input = _pid_filter.apply(next_input);
+    if (notch_enable.get()) {
+        next_input = _pid_notch_filter.apply(next_input);
+    }
+    if (_dt > 0.0f) {
+        _derivative = (next_input - _input) / _dt;
+        _raw_derivative = (input - _raw_input) / _dt;        
+    }
+    _input = next_input;
+    _raw_input = input;
+}
+
+// set_input_filter_d - set input to PID controller
+// only input to the D portion of the controller is filtered
+// this should be called before any other calls to get_p, get_i or get_d
+void AC_PID_Filtered::set_input_filter_d(float input)
+{
+    // don't process inf or NaN
+    if (!isfinite(input)) {
+        return;
+    }
+
+    // update notch parameters if necessary
+    if (notch_requires_update()) {
+        notch_update_params();
+        _flags._reset_filter = true;
+    }
+
+    if (!is_equal(_filt_hz.get(), _pid_filter.get_cutoff_freq())) {
+        _pid_filter.set_cutoff_frequency(1.0/_dt, _filt_hz);
+        // FILT2 may track FILT
+        if (is_zero(filt_hz2.get())) {
+            _pid_filter2.set_cutoff_frequency(1.0/_dt, _filt_hz);
+        }
+        _flags._reset_filter = true;
+    }
+
+    if (!is_zero(filt_hz2.get()) && !is_equal(filt_hz2.get(), _pid_filter2.get_cutoff_freq())) {
+        _pid_filter2.set_cutoff_frequency(1.0/_dt, filt_hz2);
+        _flags._reset_filter = true;
+    }
+
+    // reset input filter to value received
+    if (_flags._reset_filter) {
+        _pid_filter.reset();
+        _pid_filter2.reset();
+        _pid_notch_filter.reset();
+        _flags._reset_filter = false;
+        _input = input;
+        _derivative = 0.0f;
+        _raw_input = input;
+        _raw_derivative = 0.0f;
+    }
+
+    // update filter and calculate derivative
+    if (_dt > 0.0f) {
+        _raw_derivative = (input - _input) / _dt;
+        _derivative = _pid_filter2.apply(_raw_derivative);
+        _derivative = _pid_filter.apply(_derivative);
+        if (notch_enable.get()) {
+            _derivative = _pid_notch_filter.apply(_derivative);
+       }
+    }
+
+    _raw_input = input;
+    _input = input;
+}
+
+void AC_PID_Filtered::load_gains()
+{
+    AC_PID::load_gains();
+    // not sure these are really necessary, but filt frequency is important to yaw autotune
+    filt_hz2.load();
+    notch_attenuation_dB.load();
+    notch_bandwidth_hz.load();
+    notch_center_freq_hz.load();
+    _pid_filter.set_cutoff_frequency(1.0/_dt, _filt_hz);
+    _pid_filter2.set_cutoff_frequency(1.0/_dt, filt_hz2);
+}
+
+// save_gains - save gains to eeprom
+void AC_PID_Filtered::save_gains()
+{
+    AC_PID::save_gains();
+    // not sure these are really necessary, but filt frequency is important to yaw autotune
+    filt_hz2.save();
+    notch_attenuation_dB.save();
+    notch_bandwidth_hz.save();
+    notch_center_freq_hz.save();
+}
+
+
+
+

--- a/libraries/AC_PID/AC_PID_Filtered.h
+++ b/libraries/AC_PID/AC_PID_Filtered.h
@@ -1,0 +1,76 @@
+#pragma once
+
+/// @file	AC_PID_Filtered.h
+/// @brief	Multicopter Specific Rate PID algorithm with advanced filtering, with EEPROM-backed storage of constants.
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+#include <Filter/LowPassFilter2p.h>
+#include <Filter/NotchFilter.h>
+#include "AC_PID.h"
+
+#define AC_PID_FILT_HZ_DEFAULT  20.0f   // default input filter frequency
+#define AC_PID_FILT_HZ_MIN      0.01f   // minimum input filter frequency
+
+/// @class	AC_PID_Fiteredd
+/// @brief	PID control class with D-term notch filter
+class AC_PID_Filtered : public AC_PID {
+public:
+
+    /// Constructor for PID
+    AC_PID_Filtered(float initial_p, float initial_i, float initial_d, float initial_imax, float initial_filt_hz, float dt, float initial_ff=0);
+
+   // set_dt - set time step in seconds
+    void        set_dt(float dt);
+
+    // set_input_filter_all - set input to PID controller
+    //  input is filtered before the PID controllers are run
+    //  this should be called before any other calls to get_p, get_i or get_d
+    void        set_input_filter_all(float input);
+
+    // set_input_filter_d - set input to PID controller
+    //  only input to the D portion of the controller is filtered
+    //  this should be called before any other calls to get_p, get_i or get_d
+    void        set_input_filter_d(float input);
+
+    // set accessors
+    void        filt_hz(const float v);
+
+    // load gain from eeprom
+    virtual void        load_gains();
+
+    // save gain to eeprom
+    virtual void        save_gains();
+
+    float       get_derivative() const { return _derivative; }
+    float       get_raw_derivative() const { return _raw_derivative; }
+    bool        notch_requires_update() const {
+        return !is_equal(notch_center_freq_hz.get(), _last_notch_center_freq_hz) ||
+            !is_equal(notch_bandwidth_hz.get(), _last_notch_bandwidth_hz) ||
+            !is_equal(notch_attenuation_dB.get(), _last_notch_attenuation_dB);
+    }
+    void        notch_update_params();
+
+    // parameter var table
+    static const struct AP_Param::GroupInfo        var_info[];
+
+    AP_Int8     notch_enable;
+    AP_Int16    notch_center_freq_hz;
+    AP_Int16    notch_bandwidth_hz;
+    AP_Float    notch_attenuation_dB;
+    AP_Float    filt_hz2;                   // 2nd PID Input filter frequency in Hz
+
+private:
+    // internal variables
+    float           _raw_input;             // last filtered output value
+    float           _raw_derivative;        // last raw input derivative
+    int16_t         _last_notch_center_freq_hz;
+    int16_t         _last_notch_bandwidth_hz;
+    float           _last_notch_attenuation_dB;
+
+private:
+    LowPassFilterFloat _pid_filter;
+    LowPassFilterFloat _pid_filter2;
+    NotchFilterFloat _pid_notch_filter;
+};


### PR DESCRIPTION
New filtering PID controller, AC_PID_Filtered.
Use the filter library for the PID controller allowing 2-pass LPF and notch filters on the D-term.
Add configuration items for the notch filter. Apply biquad and notch to d-term.

Here is the D-term FFT graph for the PID using a single pass LPF
![image](https://user-images.githubusercontent.com/2893260/58575468-054a9a00-823a-11e9-9b01-3e0e7482ccd8.png)

Here is the D-term FFT graph for the PID using a biquad LPF
![image](https://user-images.githubusercontent.com/2893260/58575508-1dbab480-823a-11e9-83a7-cb5d94fb4ab8.png)

Here is the D-term FFT graph for the PID using a biquad LPF and Notch on 180Hz
![image](https://user-images.githubusercontent.com/2893260/58575567-3c20b000-823a-11e9-9549-86c868832766.png)

Copter flies smoother with the notch applied.
