### PR TITLE
Make common Proximity arming checks...common

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -92,8 +92,7 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
 
     return (AP_Arming::pre_arm_checks(report)
             & rover.g2.motors.pre_arm_check(report)
-            & fence_checks(report)
-            & proximity_check(report));
+            & fence_checks(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
@@ -103,23 +102,6 @@ bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
         return true;
     }
     return AP_Arming::arm_checks(method);
-}
-
-// check nothing is too close to vehicle
-bool AP_Arming_Rover::proximity_check(bool report)
-{
-    // return true immediately if no sensor present
-    if (rover.g2.proximity.get_status() == AP_Proximity::Proximity_NotConnected) {
-        return true;
-    }
-
-    // return false if proximity sensor unhealthy
-    if (rover.g2.proximity.get_status() < AP_Proximity::Proximity_Good) {
-        check_failed(ARMING_CHECK_NONE, report, "check proximity sensor");
-        return false;
-    }
-
-    return true;
 }
 
 void AP_Arming_Rover::update_soft_armed()

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -27,7 +27,6 @@ public:
     void update_soft_armed();
 
 protected:
-    bool proximity_check(bool report);
 
 private:
 

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -204,11 +204,6 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         }
 #endif
 
-        // check for something close to vehicle
-        if (!pre_arm_proximity_check(display_failure)) {
-            return false;
-        }
-
         // ensure controllers are OK with us arming:
         char failure_msg[50];
         if (!copter.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
@@ -404,19 +399,17 @@ bool AP_Arming_Copter::pre_arm_terrain_check(bool display_failure)
 }
 
 // check nothing is too close to vehicle
-bool AP_Arming_Copter::pre_arm_proximity_check(bool display_failure)
+bool AP_Arming_Copter::proximity_checks(bool display_failure) const
 {
 #if PROXIMITY_ENABLED == ENABLED
 
-    // return true immediately if no sensor present
-    if (copter.g2.proximity.get_status() == AP_Proximity::Proximity_NotConnected) {
-        return true;
+    if (!AP_Arming::proximity_checks(display_failure)) {
+        return false;
     }
 
-    // return false if proximity sensor unhealthy
-    if (copter.g2.proximity.get_status() < AP_Proximity::Proximity_Good) {
-        check_failed(ARMING_CHECK_PARAMETERS, display_failure, "check proximity sensor");
-        return false;
+    if (!((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_PARAMETERS))) {
+        // check is disabled
+        return true;
     }
 
     // get closest object if we might use it for avoidance

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -31,7 +31,7 @@ protected:
     bool pre_arm_checks(bool display_failure) override;
     bool pre_arm_ekf_attitude_check();
     bool pre_arm_terrain_check(bool display_failure);
-    bool pre_arm_proximity_check(bool display_failure);
+    bool proximity_checks(bool display_failure) const override;
     bool arm_checks(AP_Arming::Method method) override;
 
     // NOTE! the following check functions *DO* call into AP_Arming:

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -122,7 +122,9 @@ protected:
     virtual bool system_checks(bool report);
 
     bool can_checks(bool report);
-    
+
+    virtual bool proximity_checks(bool report) const;
+
     bool servo_checks(bool report) const;
     bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4]) const;
 


### PR DESCRIPTION
This is a behavioural change for Copter; if you have a proximity sensor configured it's going to have to be working for you to arm.
