### PR TITLE
AC_PrecLand: ignore msg in particular frame indicating report only

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -294,6 +294,15 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
 #endif
         break;
 
+    case MSG_LANDING_TARGET:
+#if PRECISION_LANDING == ENABLED
+        CHECK_PAYLOAD_SIZE(LANDING_TARGET);
+        if (copter.precland.enabled()) {
+            copter.precland.send_landing_target(chan);
+        }
+#endif
+        break;
+
     default:
         return GCS_MAVLINK::try_send_message(id);
     }
@@ -454,6 +463,7 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_VIBRATION,
     MSG_RPM,
     MSG_ESC_TELEMETRY,
+    MSG_LANDING_TARGET,
 };
 static const ap_message STREAM_PARAMS_msgs[] = {
     MSG_NEXT_PARAM

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -463,7 +463,6 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_VIBRATION,
     MSG_RPM,
     MSG_ESC_TELEMETRY,
-    MSG_LANDING_TARGET,
 };
 static const ap_message STREAM_PARAMS_msgs[] = {
     MSG_NEXT_PARAM

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -277,7 +277,7 @@ void AC_PrecLand::send_landing_target(mavlink_channel_t chan)
         chan,
         time_usec, // sensor/measurement timestamp in microseconds, either from epoch or since boot
         0, // TODO: Target ID
-        MAV_FRAME_BODY_NED, // frame
+        20, // indicate this message is sent from a drone for reporting back to GCS. TODO: add this to MAVLink protocol as MAV_FRAME_REPOR
         _angle_x, // angle_x,
         _angle_y, // angle_y,
         _dist, // distance to target, measured from rangefinder or sensor message

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -88,6 +88,9 @@ public:
     // process a LANDING_TARGET mavlink message
     void handle_msg(mavlink_message_t* msg);
 
+    // send a LANDING_TARGET mavlink message
+    void send_landing_target(mavlink_channel_t chan);
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -118,6 +121,7 @@ private:
     AP_Int8                     _type;              // precision landing sensor type
     AP_Int8                     _bus;               // which sensor bus
     AP_Int8                     _estimator_type;    // precision landing estimator type
+    AP_Float                    _dist;              // Distance to target measured from rangefinder or sensor
     AP_Float                    _lag;               // sensor lag in seconds
     AP_Float                    _yaw_align;         // Yaw angle from body x-axis to sensor x-axis.
     AP_Float                    _land_ofs_cm_x;     // Desired landing position of the camera forward of the target in vehicle body frame
@@ -128,10 +132,12 @@ private:
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently
     uint32_t                    _last_backend_los_meas_ms;  // system time target was last seen
+    uint64_t                    _last_backend_los_timestamp; // sensor time target was last seen
 
     PosVelEKF                   _ekf_x, _ekf_y;     // Kalman Filter for x and y axis
     uint32_t                    _outlier_reject_count;  // mini-EKF's outlier counter (3 consecutive outliers lead to EKF accepting updates)
-    
+
+    float                       _angle_x, _angle_y;     // target's angular offset
     Vector3f                    _target_pos_rel_meas_NED; // target's relative position as 3D vector
 
     Vector2f                    _target_pos_rel_est_NE; // target's position relative to the IMU, not compensated for lag

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -48,6 +48,10 @@ void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
     __mavlink_landing_target_t packet;
     mavlink_msg_landing_target_decode(msg, &packet);
 
+    if (packet.frame == 20) { //this msg maybe send by other drones for reporting back to GCS, ignore it. TODO: add this to MAVLink protocol as MAV_FRAME_REPORT
+        return;
+    }
+
     _timestamp_us = packet.time_usec;
     _distance_to_target = packet.distance;
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -97,6 +97,7 @@ enum ap_message : uint8_t {
     MSG_HOME,
     MSG_NAMED_FLOAT,
     MSG_EXTENDED_SYS_STATE,
+    MSG_LANDING_TARGET,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };
 


### PR DESCRIPTION
fix #3348

continue work of #9125 by @fnoop 
This PR try to solve issue mentioned by @peterbarker 

> If you have two vehicles which can see each other's traffic you may start
to get cross-pollination between the two.  There's no target fields in
this message.

It use frame field to indicate this message is reporting back to GCS. Similar to the usage of MAV_FRAME_MISSION
> MAV_FRAME_MISSION:	NOT a coordinate frame, indicates a mission command.