### PR TITLE
Use EAS2TAS for all airspeed backend calibrations

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -640,9 +640,6 @@ void Plane::update_flight_stage(void)
     } else {
         set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_NORMAL);
     }
-
-    // tell AHRS the airspeed to true airspeed ratio
-    airspeed.set_EAS2TAS(barometer.get_EAS2TAS());
 }
 
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -299,10 +299,7 @@ public:
 
     // get apparent to true airspeed ratio
     float get_EAS2TAS(void) const {
-        if (_airspeed) {
-            return _airspeed->get_EAS2TAS();
-        }
-        return 1.0f;
+        return AP::baro().get_EAS2TAS();
     }
 
     // return true if airspeed comes from an airspeed sensor, as

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -219,9 +219,6 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
 AP_Airspeed::AP_Airspeed()
 {
-    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
-        state[i].EAS2TAS = 1;
-    }
     AP_Param::setup_object_defaults(this, var_info);
 
     if (_singleton != nullptr) {

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -101,18 +101,6 @@ public:
     }
     float get_differential_pressure(void) const { return get_differential_pressure(primary); }
 
-    // set the apparent to true airspeed ratio
-    void set_EAS2TAS(uint8_t i, float v) {
-        state[i].EAS2TAS = v;
-    }
-    void set_EAS2TAS(float v) { set_EAS2TAS(primary, v); }
-
-    // get the apparent to true airspeed ratio
-    float get_EAS2TAS(uint8_t i) const {
-        return state[i].EAS2TAS;
-    }
-    float get_EAS2TAS(void) const { return get_EAS2TAS(primary); }
-
     // update airspeed ratio calibration
     void update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
 
@@ -186,7 +174,6 @@ private:
         float	last_pressure;
         float   filtered_pressure;
         float	corrected_pressure;
-        float   EAS2TAS;
         bool	healthy:1;
         bool	hil_set:1;
         float   hil_pressure;

--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -127,7 +127,7 @@ void AP_Airspeed::update_calibration(uint8_t i, const Vector3f &vground, int16_t
 
     // calculate true airspeed, assuming a airspeed ratio of 1.0
     float dpress = MAX(get_differential_pressure(), 0);
-    float true_airspeed = sqrtf(dpress) * state[i].EAS2TAS;
+    float true_airspeed = sqrtf(dpress) * AP::baro().get_EAS2TAS();
 
     float zratio = state[i].calibration.update(true_airspeed, vground, max_airspeed_allowed_during_cal);
 
@@ -178,7 +178,7 @@ void AP_Airspeed::send_airspeed_calibration(const Vector3f &vground)
             vground.y,
             vground.z,
             get_differential_pressure(primary),
-            state[primary].EAS2TAS,
+            AP::baro().get_EAS2TAS(),
             param[primary].ratio.get(),
             state[primary].calibration.state.x,
             state[primary].calibration.state.y,

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -676,7 +676,7 @@ void NavEKF2_core::readAirSpdData()
     if (aspeed &&
             aspeed->use() &&
             aspeed->last_update_ms() != timeTasReceived_ms) {
-        tasDataNew.tas = aspeed->get_airspeed() * aspeed->get_EAS2TAS();
+        tasDataNew.tas = aspeed->get_airspeed() * AP::ahrs().get_EAS2TAS();
         timeTasReceived_ms = aspeed->last_update_ms();
         tasDataNew.time_ms = timeTasReceived_ms - frontend->tasDelay_ms;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -313,7 +313,7 @@ void NavEKF2_core::detectFlight()
         // trigger at 8 m/s airspeed
         if (_ahrs->airspeed_sensor_enabled()) {
             const AP_Airspeed *airspeed = _ahrs->get_airspeed();
-            if (airspeed->get_airspeed() * airspeed->get_EAS2TAS() > 10.0f) {
+            if (airspeed->get_airspeed() * AP::ahrs().get_EAS2TAS() > 10.0f) {
                 highAirSpd = true;
             }
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -708,7 +708,7 @@ void NavEKF3_core::readAirSpdData()
     if (aspeed &&
             aspeed->use() &&
             (aspeed->last_update_ms() - timeTasReceived_ms) > frontend->sensorIntervalMin_ms) {
-        tasDataNew.tas = aspeed->get_raw_airspeed() * aspeed->get_EAS2TAS();
+        tasDataNew.tas = aspeed->get_raw_airspeed() * AP::ahrs().get_EAS2TAS();
         timeTasReceived_ms = aspeed->last_update_ms();
         tasDataNew.time_ms = timeTasReceived_ms - frontend->tasDelay_ms;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -312,7 +312,7 @@ void NavEKF3_core::detectFlight()
         // trigger at 8 m/s airspeed
         if (_ahrs->airspeed_sensor_enabled()) {
             const AP_Airspeed *airspeed = _ahrs->get_airspeed();
-            if (airspeed->get_airspeed() * airspeed->get_EAS2TAS() > 10.0f) {
+            if (airspeed->get_airspeed() * AP::ahrs().get_EAS2TAS() > 10.0f) {
                 highAirSpd = true;
             }
         }


### PR DESCRIPTION
Plane was only setting this for the primary airspeed instance.  All instances used their own EAS2TAS state to calibrate with.
