### PR TITLE
AP_BattMonitor: add a voltage full and empty volt for percent

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -162,6 +162,22 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ARM_MAH", 19, AP_BattMonitor_Params, _arming_minimum_capacity, 0),
 
+    // @Param: VOLT_FULL
+    // @DisplayName: Full battery voltage
+    // @Description: Battery voltage that is considered fully charged. Used to compute a percent if no current sensor is available. Accuracy is better with current sensor.
+    // @Units: V
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("VOLT_FULL", 20, AP_BattMonitor_Params, _voltage_full, 0),
+
+    // @Param: VOLT_EMPTY
+    // @DisplayName: Empty battery voltage
+    // @Description: Battery voltage that is considered completely empty with 0% remaining. Used to compute a percent if no current sensor is available. Accuracy is better with current sensor.
+    // @Units: V
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("VOLT_EMPTY", 21, AP_BattMonitor_Params, _voltage_empty, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -54,5 +54,6 @@ public:
     AP_Int8  _failsafe_critical_action; /// action to preform on a critical battery failsafe
     AP_Int32 _arming_minimum_capacity;  /// capacity level required to arm
     AP_Float _arming_minimum_voltage;   /// voltage level required to arm
-
+    AP_Float _voltage_full;             /// voltage level considered "100%". Only used when no current is available
+    AP_Float _voltage_empty;            /// voltage level considered "0%".   Only used when no current is available
 };


### PR DESCRIPTION
Adds two params to battery to determine a voltage percent if there is no current sensor available. Also allows for inverted analog signals by gracefully handling the percent and failsafes low/crit values for voltage sensors that are inverted, such as analog potentiometer based fuel systems where a higher voltage means "empty".

// @Param: VOLT_FULL
// @Description: Battery voltage that is considered fully charged. Used to compute a percent if no current sensor is available. Accuracy is better with current sensor.

// @Param: VOLT_EMPTY
// @Description: Battery voltage that is considered completely empty with 0% remaining. Used to 