### PR TITLE
SRV_Channel: allow DO_SET_SERVO commands while rc pass-thru

### DIFF
--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -32,7 +32,13 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
     if (c == nullptr) {
         return false;
     }
-    if (c->get_function() != SRV_Channel::k_none) {
+    switch(c->get_function())
+    {
+    case SRV_Channel::k_none:
+    case SRV_Channel::k_manual:
+    case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
+        break;
+    default:
         gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
         return false;
     }
@@ -42,6 +48,7 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
         repeat = 0;
     }
     c->set_output_pwm(pwm);
+    c->set_do_set_servo(true);
     return true;
 }
 
@@ -72,7 +79,13 @@ bool AP_ServoRelayEvents::do_repeat_servo(uint8_t _channel, uint16_t _servo_valu
     if (c == nullptr) {
         return false;
     }
-    if (c->get_function() != SRV_Channel::k_none) {
+    switch(c->get_function())
+    {
+    case SRV_Channel::k_none:
+    case SRV_Channel::k_manual:
+    case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
+        break;
+    default:
         gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
         return false;
     }
@@ -121,6 +134,7 @@ void AP_ServoRelayEvents::update_events(void)
                 c->set_output_pwm(c->get_trim());
             } else {
                 c->set_output_pwm(servo_value);
+                c->set_do_set_servo(true);
             }
         }
         break;

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -203,3 +203,8 @@ bool SRV_Channel::should_e_stop(SRV_Channel::Aux_servo_function_t function)
             (function >= SRV_Channel::k_boost_throttle && function <= SRV_Channel::k_motor12) ||
             function == k_engine_run_enable);
 }
+
+void SRV_Channel::set_do_set_servo(bool b)
+{
+    use_do_set_servo = b;
+}

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -217,7 +217,10 @@ public:
     bool function_configured(void) const {
         return function.configured();
     }
-    
+
+    // set the flag
+    void set_do_set_servo(bool b);
+
 private:
     AP_Int16 servo_min;
     AP_Int16 servo_max;
@@ -268,6 +271,12 @@ private:
     // mask of channels where we have a output_pwm value. Cleared when a
     // scaled value is written. 
     static servo_mask_t have_pwm_mask;
+
+    // a previous output_pwm value for pass-thru
+    uint16_t previous_pwm;
+
+    // specify that DO_SET_SERVO has been used
+    bool use_do_set_servo:1;
 };
 
 /*

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -46,7 +46,19 @@ void SRV_Channel::output_ch(void)
             if (SRV_Channels::passthrough_disabled()) {
                 output_pwm = c->get_radio_trim();
             } else {
-                output_pwm = c->get_radio_in();
+                if (use_do_set_servo == false) {
+                    output_pwm = c->get_radio_in();
+                } else {
+                    // if the input value has not been changed, do nothing
+                    uint16_t radio_in = c->get_radio_in();
+                    if (radio_in >= c->get_dead_zone() &&
+                            (previous_pwm < radio_in - c->get_dead_zone() ||
+                            radio_in + c->get_dead_zone() < previous_pwm)) {
+                        output_pwm = radio_in;
+                        previous_pwm = radio_in;
+                        use_do_set_servo = false;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR allows DO_SET_SERVO commands when RC pass-thru is enabled.
It stores the transmitter's previous value and uses the transmitter's signal if changed.

Related issue is #11210
