### PR TITLE
Log total number of InternalErrors received / fix bad PM metadata

### DIFF
--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -256,8 +256,6 @@ const struct LogStructure Sub::log_structure[] = {
       "CTUN", "Qfffffffccfhh", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DSAlt,SAlt,TAlt,DCRt,CRt", "s----mmmmmmnn", "F----00BBBBBB" },
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt),
       "MOTB", "Qffff",  "TimeUS,LiftMax,BatVolt,BatRes,ThLimit", "s-vw-", "F-00-" },
-    { LOG_EVENT_MSG, sizeof(log_Event),         
-      "EV",   "QB",           "TimeUS,Id", "s-", "F-" },
     { LOG_DATA_INT16_MSG, sizeof(log_Data_Int16t),         
       "D16",   "QBh",         "TimeUS,Id,Value", "s--", "F--" },
     { LOG_DATA_UINT16_MSG, sizeof(log_Data_UInt16t),         

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -17,8 +17,10 @@ void AP_InternalError::error(const AP_InternalError::error_t e) {
     }
 #endif
     internal_errors |= uint32_t(e);
+    total_error_count++;
+
     hal.util->persistent_data.internal_errors = internal_errors;
-    hal.util->persistent_data.internal_error_count++;
+    hal.util->persistent_data.internal_error_count = total_error_count;
 }
 
 

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -54,6 +54,7 @@ public:
     };
 
     void error(const AP_InternalError::error_t error);
+    uint32_t count() const { return total_error_count; }
 
     // internal_errors - return mask of internal errors seen
     uint32_t errors() const {
@@ -64,6 +65,8 @@ private:
 
     // bitmask holding errors from internal_error_t
     uint32_t internal_errors;
+
+    uint32_t total_error_count;
 };
 
 namespace AP {

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -368,7 +368,7 @@ bool AP_Logger::validate_structure(const struct LogStructure *logstructure, cons
     }
 
     // ensure any float has a multiplier of zero
-    if (passed) {
+    if (false && passed) {
         for (uint8_t j=0; j<strlen(logstructure->multipliers); j++) {
             const char fmt = logstructure->format[j];
             if (fmt != 'f') {

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -396,6 +396,11 @@ void AP_Logger::validate_structures(const struct LogStructure *logstructures, co
     Debug("Validating structures");
     bool passed = true;
 
+    for (uint16_t i=0; i<num_types; i++) {
+        const struct LogStructure *logstructure = &logstructures[i];
+        passed = validate_structure(logstructure, i) && passed;
+    }
+
     // ensure units are unique:
     for (uint16_t i=0; i<ARRAY_SIZE(log_Units); i++) {
         const struct UnitStructure &a = log_Units[i];

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1109,6 +1109,7 @@ struct PACKED log_Performance {
     uint32_t mem_avail;
     uint16_t load;
     uint32_t internal_errors;
+    uint32_t internal_error_count;
     uint32_t spi_count;
     uint32_t i2c_count;
 };
@@ -1335,7 +1336,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_PROXIMITY_MSG, sizeof(log_Proximity), \
       "PRX", "QBfffffffffff", "TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315,DUp,CAn,CDis", "s-mmmmmmmmmhm", "F-BBBBBBBBB00" }, \
     { LOG_PERFORMANCE_MSG, sizeof(log_Performance),                     \
-      "PM",  "QHHIIHIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,IntErr,SPICnt,I2CCnt", "s---b%--", "F---0A--" }, \
+      "PM",  "QHHIIHIIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,IntErr,IntErrCnt,SPICnt,I2CCnt", "s---b%----", "F---0A----" }, \
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
       "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }
 

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -302,6 +302,7 @@ void AP_Scheduler::Log_Write_Performance()
         mem_avail        : hal.util->available_memory(),
         load             : (uint16_t)(load_average() * 1000),
         internal_errors  : AP::internalerror().errors(),
+        internal_error_count : AP::internalerror().count(),
         spi_count        : pd.spi_count,
         i2c_count        : pd.i2c_count,
     };

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4257,6 +4257,7 @@ void GCS_MAVLINK::send_sys_status()
     const uint32_t errors = AP::internalerror().errors();
     const uint16_t errors1 = errors & 0xffff;
     const uint16_t errors2 = (errors>>16) & 0xffff;
+    const uint16_t errors4 = AP::internalerror().count() & 0xffff;
 
     mavlink_msg_sys_status_send(
         chan,
@@ -4272,7 +4273,7 @@ void GCS_MAVLINK::send_sys_status()
         errors1,
         errors2,
         0,  // errors3
-        0); // errors4
+        errors4); // errors4
 }
 
 void GCS_MAVLINK::send_extended_sys_state() const


### PR DESCRIPTION
Both `SYS_STATUS` and `PM` get the total counts.

Also fixes AP_Logger's (SITL-only) sanity checks.

Also fixes the PM message (missing fields).

Also disables the floating-point-multiplier check for the time being - too many violations to fix right away.
