### PR TITLE
Tools: configure_all.py: parallelise it

### DIFF
--- a/Tools/scripts/configure_all.py
+++ b/Tools/scripts/configure_all.py
@@ -11,16 +11,36 @@ import sys
 import fnmatch
 
 import argparse
+import threading
+
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
 
 parser = argparse.ArgumentParser(description='configure all ChibiOS boards')
 parser.add_argument('--build', action='store_true', default=False, help='build as well as configure')
 parser.add_argument('--stop', action='store_true', default=False, help='stop on build fail')
 parser.add_argument('--pattern', default='*')
+parser.add_argument('--workers', type=int, default=4)
 args = parser.parse_args()
 
 os.environ['PYTHONUNBUFFERED'] = '1'
 
-failures = []
+worker_failures = Queue.Queue()
+
+workqueue = Queue.Queue()
+
+def worker_thread():
+    global workqueue
+    while True:
+        try:
+            job = workqueue.get(block=False)
+        except Queue.Empty:
+            break
+        (cmd_list, build) = job
+        print("Processing %s" % build)
+        run_program(cmd_list, build)
 
 def get_board_list():
     '''add boards based on existance of hwdef-bl.dat in subdirectories for ChibiOS'''
@@ -37,8 +57,8 @@ def run_program(cmd_list, build):
     retcode = subprocess.call(cmd_list)
     if retcode != 0:
         print("Build failed: %s %s" % (build, ' '.join(cmd_list)))
-        global failures
-        failures.append(build)
+        global worker_failures
+        worker_failures.put(build)
         if args.stop:
             sys.exit(1)
 
@@ -46,20 +66,40 @@ for board in get_board_list():
     if not fnmatch.fnmatch(board, args.pattern):
         continue
     print("Configuring for %s" % board)
-    run_program(["./waf", "configure", "--board", board], "configure: " + board)
+    workqueue.put( (["./waf", "configure", "--board", board], "configure: " + board) )
     if args.build:
         if board == "iomcu":
             target = "iofirmware"
         else:
             target = "copter"
-        run_program(["./waf", target], "build: " + board)
+        workqueue.put( (["./waf", target], "build: " + board) )
     # check for bootloader def
     hwdef_bl = os.path.join('libraries/AP_HAL_ChibiOS/hwdef/%s/hwdef-bl.dat' % board)
     if os.path.exists(hwdef_bl):
         print("Configuring bootloader for %s" % board)
-        run_program(["./waf", "configure", "--board", board, "--bootloader"], "configure: " + board + "-bl")
+        workqueue.put( (["./waf", "configure", "--board", board, "--bootloader"], "configure: " + board + "-bl") )
         if args.build:
-            run_program(["./waf", "bootloader"], "build: " + board + "-bl")
+            workqueue.put( (["./waf", "bootloader"], "build: " + board + "-bl") )
+
+# start workers:
+workers = []
+for i in range(0, args.workers):
+    t = threading.Thread(target=worker_thread, name='worker_thread %u' % i)
+    t.start()
+    workers.append(t)
+
+# wait for workers to finish:
+for worker in workers:
+    print("Waiting for %s to finish" % str(worker))
+    worker.join()
+
+failures = []
+while True:
+    try:
+        failure = worker_failures.get(block=False)
+        failures.append(failure)
+    except Queue.Empty:
+        break
 
 if len(failures) > 0:
     print("Failed builds:")


### PR DESCRIPTION
Saves about half the wall-clock time (saving ~50 seconds) at the cost of complication and pretty-much useless output.

On my laptop:
```
master:
real	1m36.491s
user	0m40.134s
sys	0m8.098s

1 worker:
real	1m36.672s
user	0m40.512s
sys	0m7.995s

2 workers:
real	0m56.943s
user	0m47.507s
sys	0m9.101s

3 workers:
real	0m46.817s
user	0m56.734s
sys	0m9.576s

4 workers:
real	0m41.307s
user	1m3.697s
sys	0m10.037s
pbarker@bluebottle:~/rc/ardupilot(master)$ 

5 workers:
real	0m40.421s
user	1m4.190s
sys	0m9.978s

10 workers:
real	0m42.897s
user	1m7.022s
sys	0m10.489s

20 workers:
real	0m43.256s
user	1m8.282s
sys	0m10.075s
```
