### PR TITLE
AC_Avoidance: fix stopping at circular fence

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -304,25 +304,39 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
     const float fence_radius = _fence.get_radius() * 100.0f;
     // get the margin to the fence in cm
     const float margin_cm = _fence.get_margin() * 100.0f;
-
-    if (!is_zero(speed) && position_xy.length() <= fence_radius) {
-        // Currently inside circular fence
-        Vector2f stopping_point = position_xy + desired_vel_cms*(get_stopping_distance(kP, accel_cmss, speed)/speed);
-        float stopping_point_length = stopping_point.length();
-        if (stopping_point_length > fence_radius - margin_cm) {
-            // Unsafe desired velocity - will not be able to stop before fence breach
-            if ((AC_Avoid::BehaviourType)_behavior.get() == BEHAVIOR_SLIDE) {
+    // get vehicle distance from home
+    const float dist_from_home = position_xy.length();
+    if (!is_zero(speed) && (dist_from_home <= fence_radius)) {
+        // vehicle is inside the circular fence
+        if ((AC_Avoid::BehaviourType)_behavior.get() == BEHAVIOR_SLIDE) {
+            // implement sliding behaviour
+            const Vector2f stopping_point = position_xy + desired_vel_cms*(get_stopping_distance(kP, accel_cmss, speed)/speed);
+            const float stopping_point_dist_from_home = stopping_point.length();
+            if (stopping_point_dist_from_home > fence_radius - margin_cm) {
+                // unsafe desired velocity - will not be able to stop before reaching margin from fence
                 // Project stopping point radially onto fence boundary
                 // Adjusted velocity will point towards this projected point at a safe speed
-                const Vector2f target = stopping_point * ((fence_radius - margin_cm) / stopping_point_length);
+                const Vector2f target = stopping_point * ((fence_radius - margin_cm) / stopping_point_dist_from_home);
                 const Vector2f target_direction = target - position_xy;
                 const float distance_to_target = target_direction.length();
                 const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
                 desired_vel_cms = target_direction * (MIN(speed,max_speed) / distance_to_target);
+            }
+        } else {
+            // implement stopping behaviour
+            const Vector2f stopping_point_plus_margin = position_xy + desired_vel_cms*((2.0f + margin_cm + get_stopping_distance(kP, accel_cmss, speed))/speed);
+            const float stopping_point_plus_margin_dist_from_home = stopping_point_plus_margin.length();
+            if (dist_from_home >= fence_radius - margin_cm) {
+                // if vehicle has already breached margin around fence
+                // if stopping point is even further from home (i.e. in wrong direction) then adjust speed to zero
+                // otherwise user is backing away from fence so do not apply limits
+                if (stopping_point_plus_margin_dist_from_home >= dist_from_home) {
+                    desired_vel_cms.zero();
+                }
             } else {
                 // shorten vector without adjusting its direction
                 Vector2f intersection;
-                if (Vector2f::circle_segment_intersection(position_xy, stopping_point, Vector2f(0.0f,0.0f), fence_radius, intersection)) {
+                if (Vector2f::circle_segment_intersection(position_xy, stopping_point_plus_margin, Vector2f(0.0f,0.0f), fence_radius - margin_cm, intersection)) {
                     const float distance_to_target = MAX((intersection - position_xy).length() - margin_cm, 0.0f);
                     const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
                     if (max_speed < speed) {

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -289,6 +289,13 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
         return;
     }
 
+    // get desired speed
+    const float desired_speed = desired_vel_cms.length();
+    if (is_zero(desired_speed)) {
+        // no avoidance necessary when desired speed is zero
+        return;
+    }
+
     const AP_AHRS &_ahrs = AP::ahrs();
 
     // get position as a 2D offset from ahrs home
@@ -299,49 +306,55 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
     }
     position_xy *= 100.0f; // m -> cm
 
-    const float speed = desired_vel_cms.length();
     // get the fence radius in cm
     const float fence_radius = _fence.get_radius() * 100.0f;
     // get the margin to the fence in cm
     const float margin_cm = _fence.get_margin() * 100.0f;
+
     // get vehicle distance from home
     const float dist_from_home = position_xy.length();
-    if (!is_zero(speed) && (dist_from_home <= fence_radius)) {
-        // vehicle is inside the circular fence
-        if ((AC_Avoid::BehaviourType)_behavior.get() == BEHAVIOR_SLIDE) {
-            // implement sliding behaviour
-            const Vector2f stopping_point = position_xy + desired_vel_cms*(get_stopping_distance(kP, accel_cmss, speed)/speed);
-            const float stopping_point_dist_from_home = stopping_point.length();
-            if (stopping_point_dist_from_home > fence_radius - margin_cm) {
-                // unsafe desired velocity - will not be able to stop before reaching margin from fence
-                // Project stopping point radially onto fence boundary
-                // Adjusted velocity will point towards this projected point at a safe speed
-                const Vector2f target = stopping_point * ((fence_radius - margin_cm) / stopping_point_dist_from_home);
-                const Vector2f target_direction = target - position_xy;
-                const float distance_to_target = target_direction.length();
-                const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
-                desired_vel_cms = target_direction * (MIN(speed,max_speed) / distance_to_target);
+    if (dist_from_home > fence_radius) {
+        // outside of circular fence, no velocity adjustments
+        return;
+    }
+
+    // vehicle is inside the circular fence
+    if ((AC_Avoid::BehaviourType)_behavior.get() == BEHAVIOR_SLIDE) {
+        // implement sliding behaviour
+        const Vector2f stopping_point = position_xy + desired_vel_cms*(get_stopping_distance(kP, accel_cmss, desired_speed)/desired_speed);
+        const float stopping_point_dist_from_home = stopping_point.length();
+        if (stopping_point_dist_from_home <= fence_radius - margin_cm) {
+            // stopping before before fence so no need to adjust
+            return;
+        }
+        // unsafe desired velocity - will not be able to stop before reaching margin from fence
+        // Project stopping point radially onto fence boundary
+        // Adjusted velocity will point towards this projected point at a safe speed
+        const Vector2f target_offset = stopping_point * ((fence_radius - margin_cm) / stopping_point_dist_from_home);
+        const Vector2f target_direction = target_offset - position_xy;
+        const float distance_to_target = target_direction.length();
+        const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
+        desired_vel_cms = target_direction * (MIN(desired_speed,max_speed) / distance_to_target);
+    } else {
+        // implement stopping behaviour
+        // calculate stopping point plus a margin so we look forward far enough to intersect with circular fence
+        const Vector2f stopping_point_plus_margin = position_xy + desired_vel_cms*((2.0f + margin_cm + get_stopping_distance(kP, accel_cmss, desired_speed))/desired_speed);
+        const float stopping_point_plus_margin_dist_from_home = stopping_point_plus_margin.length();
+        if (dist_from_home >= fence_radius - margin_cm) {
+            // if vehicle has already breached margin around fence
+            // if stopping point is even further from home (i.e. in wrong direction) then adjust speed to zero
+            // otherwise user is backing away from fence so do not apply limits
+            if (stopping_point_plus_margin_dist_from_home >= dist_from_home) {
+                desired_vel_cms.zero();
             }
         } else {
-            // implement stopping behaviour
-            const Vector2f stopping_point_plus_margin = position_xy + desired_vel_cms*((2.0f + margin_cm + get_stopping_distance(kP, accel_cmss, speed))/speed);
-            const float stopping_point_plus_margin_dist_from_home = stopping_point_plus_margin.length();
-            if (dist_from_home >= fence_radius - margin_cm) {
-                // if vehicle has already breached margin around fence
-                // if stopping point is even further from home (i.e. in wrong direction) then adjust speed to zero
-                // otherwise user is backing away from fence so do not apply limits
-                if (stopping_point_plus_margin_dist_from_home >= dist_from_home) {
-                    desired_vel_cms.zero();
-                }
-            } else {
-                // shorten vector without adjusting its direction
-                Vector2f intersection;
-                if (Vector2f::circle_segment_intersection(position_xy, stopping_point_plus_margin, Vector2f(0.0f,0.0f), fence_radius - margin_cm, intersection)) {
-                    const float distance_to_target = MAX((intersection - position_xy).length() - margin_cm, 0.0f);
-                    const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
-                    if (max_speed < speed) {
-                        desired_vel_cms *= MAX(max_speed, 0.0f) / speed;
-                    }
+            // shorten vector without adjusting its direction
+            Vector2f intersection;
+            if (Vector2f::circle_segment_intersection(position_xy, stopping_point_plus_margin, Vector2f(0.0f,0.0f), fence_radius - margin_cm, intersection)) {
+                const float distance_to_target = MAX((intersection - position_xy).length() - margin_cm, 0.0f);
+                const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
+                if (max_speed < desired_speed) {
+                    desired_vel_cms *= MAX(max_speed, 0.0f) / desired_speed;
                 }
             }
         }

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -543,6 +543,8 @@ float AR_AttitudeControl::get_throttle_out_stop(bool motor_limit_low, bool motor
     if (stopped) {
         // update last time we thought we were stopped
         _stop_last_ms = now;
+        // set last time speed controller was run so accelerations are limited
+        _speed_last_ms = now;
         return 0.0f;
     }
 


### PR DESCRIPTION
This PR resolves https://github.com/ArduPilot/ardupilot/issues/11483 and another that I found while fixing the issue :-).

Both Copter and Rover use AC_Avoid/AC_Avoidance to avoid breaching the circular fence in pilot controlled modes (i.e. Loiter for Copter, Acro for Rover).  This PR resolves an issue in which the vehicle's forward velocity was oscillating as it approached the circular fence.

Below is from a SITL test of the "Stop" behaviour.  The graph shows the target and actual velocity (red and green) and the pilot's pitch input.  The pilot is pushing the pitch stick fully forward but the vehicle's velocity reduces to zero (as it reaches the circular fence).  In the BEFORE shot we see how that slow down is very rough while in the AFTER it is perfectly smooth.
![copter-stop-before-and-after](https://user-images.githubusercontent.com/1498098/58930051-d9c53380-8794-11e9-8b8e-be0b6e6ffb15.png)

The underlying issue was that the slowdown code was projecting forward from the vehicle using exactly it's stopping distance.  While slowing down, if the vehicle slowed down a little more than expected (i.e. it's actual speed dropped below the desired) then the stopping distance would fall short of the fence.  In these cases we were not limiting the maximum velocity at all so the velocity would increase.  The next iteration the stopping point would likely be on the far side of the fence and we would then limit it, etc, etc.

Below is the equivalent for the "Slide" behaviour.  The Before and After are unchanged because there's really no change in this part of the code.
![copter-slide-before-and-after](https://user-images.githubusercontent.com/1498098/58930158-493b2300-8795-11e9-9d76-3d860dfcb989.png)

This PR also includes a small (mostly unrelated) change to Rover's stopping controller which could lead to the acceleration limiting not being applied (i.e. the target speed was allowed to jump immediately to the pilot's input).  I'm having a hard time reproducing it today in SITL but the issue was that if the vehicle came to a complete stop (as detected in AR_AttitudeControl::get_throttle_out_stop) it would return early (see line 547). This meant that the get_throttle_out_speed() function was not being run and once this stops running we turn off acceleration limiting.