### PR TITLE
AP_Rangefinder: Dual-phase operation for LidarLiteV3-I2C

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
@@ -51,6 +51,7 @@ private:
     uint8_t hw_version;
     uint8_t check_reg_counter;
     bool v2_hardware;
+    bool v3_hardware;
     bool v3hp_hardware;
     uint16_t last_distance_cm;
     RangeFinder::RangeFinder_Type rftype;


### PR DESCRIPTION
Some LidarLite-V3 rangefinders show a constant offset of about 9 meters
in continuous mode with I2C, so use measure and collect phases instead
and check hardware status register to avoid bad readings. Only changes
operation when rangefinder type 15 (LidarLiteV3-I2C) is selected.

The status check is necessary to avoid occasional false readings of zero. 

This change was tested by compiling both the master branch and this branch and flashing to a Pixhawk1 on a FlameWheel F450 with a LidarLite-V3. The change was also tested in flight with the same aircraft by merging to the ArduPilot 3.6 branch.

Three plots are attached. The first shows rangefinder output when the aircraft was initially on the table, then picked up and pointed around the room with the master branch without the change; an offset of over 9 meters is present. 

![rangefinder_v3_master](https://user-images.githubusercontent.com/35647716/59005957-722ed880-87d4-11e9-820e-8c1c3a20ec8c.png)

The second shows the data in the same bench test situation with the changed code, and there is no offset.

![rangefinder_v3_dev](https://user-images.githubusercontent.com/35647716/59005966-7eb33100-87d4-11e9-8f2a-2fee00baebdd.png)

The third plot is data from a flight in which the aircraft took off, flew an automated path, hovered at 2 meters, and landed, reading good rangefinder data.

![rangefinder_v3_flight](https://user-images.githubusercontent.com/35647716/59005979-8bd02000-87d4-11e9-858c-dc607350e5ac.png)

There is more information about the problem addressed by this change on the discussion board: https://discuss.ardupilot.org/t/lidar-lite-v3-offset-value-issue/34793?u=huttonsoftware

