### PR TITLE
AP_Proximity: reduce distance message

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -61,6 +61,7 @@ public:
     struct Proximity_Distance_Array {
         uint8_t orientation[PROXIMITY_MAX_DIRECTION]; // orientation (i.e. rough direction) of the distance (see MAV_SENSOR_ORIENTATION)
         float distance[PROXIMITY_MAX_DIRECTION];      // distance in meters
+        bool dist_set[PROXIMITY_MAX_DIRECTION];       // distance is set or not
     };
 
     // detect and initialise any available proximity sensors

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -103,7 +103,6 @@ bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Dist
     // initialise orientations and directions
     //  see MAV_SENSOR_ORIENTATION for orientations (0 = forward, 1 = 45 degree clockwise from north, etc)
     //  distances initialised to maximum distances
-    bool dist_set[PROXIMITY_MAX_DIRECTION]{};
     for (uint8_t i=0; i<PROXIMITY_MAX_DIRECTION; i++) {
         prx_dist_array.orientation[i] = i;
         prx_dist_array.distance[i] = distance_max();
@@ -116,17 +115,17 @@ bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Dist
             int16_t orientation = static_cast<int16_t>(_angle[i] * (PROXIMITY_MAX_DIRECTION / 360.0f));
             if ((orientation >= 0) && (orientation < PROXIMITY_MAX_DIRECTION) && (_distance[i] < prx_dist_array.distance[orientation])) {
                 prx_dist_array.distance[orientation] = _distance[i];
-                dist_set[orientation] = true;
+                prx_dist_array.dist_set[orientation] = true;
             }
         }
     }
 
     // fill in missing orientations with average of adjacent orientations if necessary and possible
     for (uint8_t i=0; i<PROXIMITY_MAX_DIRECTION; i++) {
-        if (!dist_set[i]) {
+        if (!prx_dist_array.dist_set[i]) {
             uint8_t orient_before = (i==0) ? (PROXIMITY_MAX_DIRECTION - 1) : (i-1);
             uint8_t orient_after = (i==(PROXIMITY_MAX_DIRECTION - 1)) ? 0 : (i+1);
-            if (dist_set[orient_before] && dist_set[orient_after]) {
+            if (prx_dist_array.dist_set[orient_before] && prx_dist_array.dist_set[orient_after]) {
                 prx_dist_array.distance[i] = (prx_dist_array.distance[orient_before] + prx_dist_array.distance[orient_after]) / 2.0f;
             }
         }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -416,6 +416,10 @@ void GCS_MAVLINK::send_proximity() const
             if (!HAVE_PAYLOAD_SPACE(chan, DISTANCE_SENSOR)) {
                 return;
             }
+            // don't send if distance is not set
+            if (!dist_array.dist_set[i]) {
+                continue;
+            }
             mavlink_msg_distance_sensor_send(
                     chan,
                     AP_HAL::millis(),                               // time since system boot


### PR DESCRIPTION
I have put a rangefinder lidar toward front to front of vehicle to use as proximity sensor[PRX_TYPE=4]. 
It got timeout on loading parameter with Mission Planner through XBee as a telemetry. I found that it send 8 sectors distance message even it only use 3 sectors. I think it don't need to send if distance was not set.