### PR TITLE
Add harmonic notch filter on accelerometer

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -243,7 +243,7 @@ void Copter::startup_INS_ground()
 // update the harmonic notch filter center frequency dynamically
 void Copter::update_dynamic_notch()
 {
-    if (!ins.gyro_harmonic_notch_enabled()) {
+    if (!ins.gyro_harmonic_notch_enabled() && !ins.accel_harmonic_notch_enabled()) {
         return;
     }
     const float ref_freq = ins.get_gyro_harmonic_notch_center_freq_hz();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -732,6 +732,14 @@ AP_InertialSensor::init(uint16_t sample_rate)
         _gyro_harmonic_notch_filter[i].init(_gyro_raw_sample_rates[i], _calculated_harmonic_notch_freq_hz,
              _harmonic_notch_filter.bandwidth_hz(), _harmonic_notch_filter.attenuation_dB());
     }
+
+    for (uint8_t i=0; i<get_accel_count(); i++) {
+    	_accel_harmonic_notch_filter[i].allocate_filters(_harmonic_notch_filter.harmonics(),
+                _harmonic_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch));
+    	// initialise default settings, these will be subsequently changed in AP_InertialSensor_Backend::update_accel()
+    	_accel_harmonic_notch_filter[i].init(_accel_raw_sample_rates[i], _calculated_harmonic_notch_freq_hz,
+    	        _harmonic_notch_filter.bandwidth_hz(), _harmonic_notch_filter.attenuation_dB());
+    }
 }
 
 bool AP_InertialSensor::_add_backend(AP_InertialSensor_Backend *backend)

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -260,7 +260,8 @@ public:
     bool is_still();
 
     // return true if harmonic notch enabled
-    bool gyro_harmonic_notch_enabled(void) const { return _harmonic_notch_filter.enabled(); }
+    bool gyro_harmonic_notch_enabled(void) const { return _harmonic_notch_filter.gyro_enabled(); }
+    bool accel_harmonic_notch_enabled(void) const { return _harmonic_notch_filter.accel_enabled(); }
 
     /*
       HIL set functions. The minimum for HIL is set_accel() and
@@ -448,13 +449,15 @@ private:
     bool _new_accel_data[INS_MAX_INSTANCES];
     bool _new_gyro_data[INS_MAX_INSTANCES];
 
-    // optional notch filter on gyro
+    // optional notch filter on gyro and accel
     NotchFilterParams _notch_filter;
     NotchFilterVector3f _gyro_notch_filter[INS_MAX_INSTANCES];
+    NotchFilterVector3f _accel_notch_filter[INS_MAX_INSTANCES];
 
-    // optional harmonic notch filter on gyro
+    // optional harmonic notch filter on gyro and accel
     HarmonicNotchFilterParams _harmonic_notch_filter;
     HarmonicNotchFilterVector3f _gyro_harmonic_notch_filter[INS_MAX_INSTANCES];
+    HarmonicNotchFilterVector3f _accel_harmonic_notch_filter[INS_MAX_INSTANCES];
     // the current center frequency for the notch
     float _calculated_harmonic_notch_freq_hz;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -237,26 +237,29 @@ protected:
     uint16_t get_sample_rate_hz(void) const;
 
     // return the notch filter center in Hz for the sample rate
-    float _gyro_notch_center_freq_hz(void) const { return _imu._notch_filter.center_freq_hz(); }
+    uint16_t _notch_center_freq_hz(void) const { return _imu._notch_filter.center_freq_hz(); }
 
     // return the notch filter bandwidth in Hz for the sample rate
-    float _gyro_notch_bandwidth_hz(void) const { return _imu._notch_filter.bandwidth_hz(); }
+    uint16_t _notch_bandwidth_hz(void) const { return _imu._notch_filter.bandwidth_hz(); }
 
     // return the notch filter attenuation in dB for the sample rate
-    float _gyro_notch_attenuation_dB(void) const { return _imu._notch_filter.attenuation_dB(); }
+    float _notch_attenuation_dB(void) const { return _imu._notch_filter.attenuation_dB(); }
 
-    bool _gyro_notch_enabled(void) const { return _imu._notch_filter.enabled(); }
+    bool _gyro_notch_enabled(void) const { return _imu._notch_filter.gyro_enabled(); }
+	bool _accel_notch_enabled(void) const { return _imu._notch_filter.accel_enabled(); }
 
     // return the harmonic notch filter center in Hz for the sample rate
-    float gyro_harmonic_notch_center_freq_hz() const { return _imu._calculated_harmonic_notch_freq_hz; }
+    float harmonic_notch_center_freq_hz() const { return _imu._calculated_harmonic_notch_freq_hz; }
 
     // return the harmonic notch filter bandwidth in Hz for the sample rate
-    float gyro_harmonic_notch_bandwidth_hz(void) const { return _imu._harmonic_notch_filter.bandwidth_hz(); }
+    float harmonic_notch_bandwidth_hz(void) const { return _imu._harmonic_notch_filter.bandwidth_hz(); }
 
     // return the harmonic notch filter attenuation in dB for the sample rate
-    float gyro_harmonic_notch_attenuation_dB(void) const { return _imu._harmonic_notch_filter.attenuation_dB(); }
+    float harmonic_notch_attenuation_dB(void) const { return _imu._harmonic_notch_filter.attenuation_dB(); }
 
-    bool gyro_harmonic_notch_enabled(void) const { return _imu._harmonic_notch_filter.enabled(); }
+    bool gyro_harmonic_notch_enabled(void) const { return _imu._harmonic_notch_filter.gyro_enabled(); }
+    bool accel_harmonic_notch_enabled(void) const { return _imu._harmonic_notch_filter.accel_enabled(); }
+
 
     // common gyro update function for all backends
     void update_gyro(uint8_t instance);
@@ -267,9 +270,14 @@ protected:
     // support for updating filter at runtime
     uint16_t _last_accel_filter_hz;
     uint16_t _last_gyro_filter_hz;
-    float _last_notch_center_freq_hz;
-    float _last_notch_bandwidth_hz;
-    float _last_notch_attenuation_dB;
+    //gyro notch
+    float _last_gyro_notch_center_freq_hz;
+    float _last_gyro_notch_bandwidth_hz;
+    float _last_gyro_notch_attenuation_dB;
+    //accel notch
+    float _last_accel_notch_center_freq_hz;
+	float _last_accel_notch_bandwidth_hz;
+	float _last_accel_notch_attenuation_dB;
 
     // support for updating harmonic filter at runtime
     float _last_harmonic_notch_center_freq_hz;

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -25,7 +25,7 @@ const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
     // @Param: ENABLE
     // @DisplayName: Harmonic Notch Filter enable
     // @Description: Harmonic Notch Filter enable
-    // @Values: 0:Disabled,1:Enabled
+    // @Values: 0:Disabled,1:Enabled,2:Enabled on accelerometer,3:Enabled on gyroscope and accelerometer
     // @User: Advanced
     AP_GROUPINFO_FLAGS("ENABLE", 1, HarmonicNotchFilterParams, _enable, 0, AP_PARAM_FLAG_ENABLE),
 

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -100,8 +100,8 @@ const AP_Param::GroupInfo NotchFilterParams::var_info[] = {
 
     // @Param: ENABLE
     // @DisplayName: Enable
-    // @Description: Enable notch filter
-    // @Values: 0:Disabled,1:Enabled
+    // @Description: Bitmask to enable notch filter on gyroscope and accelerometer.
+    // @Values: 0:Disabled,1:Enabled on gyroscope,2:Enabled on accelerometer,3:Enabled on gyroscope and accelerometer
     // @User: Advanced
     AP_GROUPINFO_FLAGS("ENABLE", 1, NotchFilterParams, _enable, 0, AP_PARAM_FLAG_ENABLE),
 

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -56,7 +56,8 @@ public:
     float center_freq_hz(void) const { return _center_freq_hz; }
     float bandwidth_hz(void) const { return _bandwidth_hz; }
     float attenuation_dB(void) const { return _attenuation_dB; }
-    uint8_t enabled(void) const { return _enable; }
+    bool gyro_enabled(void) const { return (_enable & 1U) != 0; }
+    bool accel_enabled(void) const { return (_enable & 1U << 1) != 0; }
     
 protected:
     AP_Int8 _enable;


### PR DESCRIPTION
In my tests adding a filter on accelerometer improved the loiter performance on the altitude.
If there's a need to use less parameters we can use the same of the gyro, maybe just adding a flag to enable also on accelerometer.