### PR TITLE
CAN Parameter Server

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1710,6 +1710,35 @@ float AP_Param::cast_to_float(enum ap_var_type type) const
     }
 }
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#define assert_type(have, want) \
+        if (have != want) { AP_HAL::panic("Attempt to convert to incorrect type"); }
+#else
+#define assert_type(have, want)
+#endif
+
+int8_t AP_Param::as_int8_t(enum ap_var_type type) const
+{
+    assert_type(type, AP_PARAM_INT8);
+    return ((AP_Int8 *)this)->get();
+}
+int16_t AP_Param::as_int16_t(enum ap_var_type type) const
+{
+    assert_type(type, AP_PARAM_INT16);
+    return ((AP_Int16 *)this)->get();
+}
+int32_t AP_Param::as_int32_t(enum ap_var_type type) const
+{
+    assert_type(type, AP_PARAM_INT32);
+    return ((AP_Int32 *)this)->get();
+}
+float AP_Param::as_float(enum ap_var_type type) const
+{
+    assert_type(type, AP_PARAM_FLOAT);
+    return ((AP_Int32 *)this)->get();
+};
+#undef assert_type
+
 /*
   find an old parameter and return it.
  */

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1897,6 +1897,35 @@ void AP_Param::set_float(float value, enum ap_var_type var_type)
     }
 }
 
+void AP_Param::user_set_value(const float value, const enum ap_var_type var_type)
+{
+    const float old_value = vp->cast_to_float(var_type);
+
+    if (parameter_flags & AP_PARAM_FLAG_INTERNAL_USE_ONLY || vp->is_read_only()) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Param write denied (%s)", key);
+        // echo back the incorrect value so that we fulfull the
+        // parameter state machine requirements:
+        send_parameter_value(key, var_type, packet.param_value);
+        // and then announce what the correct value is:
+        send_parameter_value(key, var_type, old_value);
+        return;
+    }
+
+    // set the value
+    vp->set_float(value, var_type);
+
+    /*
+      we force the save if the value is not equal to the old
+      value. This copes with the use of override values in
+      constructors, such as PID elements. Otherwise a set to the
+      default value which differs from the constructor value doesn't
+      save the change
+     */
+    const bool force_save = !is_equal(value, old_value);
+
+    // save the change
+    vp->save(force_save);
+}
 
 /*
   parse a parameter file line

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -369,6 +369,13 @@ public:
     */
     void set_float(float value, enum ap_var_type var_type);
 
+    /*
+      handle the case where the user has explicity set a value for a
+      parameter.  This may force-write the parameter if required to
+      ensure value is persistent.
+    */
+    void user_set_value(float value, const enum ap_var_type var_type);
+
     // load default values for scalars in a group
     static void         setup_object_defaults(const void *object_pointer, const struct GroupInfo *group_info);
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -422,6 +422,12 @@ public:
     /// cast a variable to a float given its type
     float                   cast_to_float(enum ap_var_type type) const;
 
+    // return types value, validating in SITL as type must be appropriate
+    int8_t                 as_int8_t(enum ap_var_type type) const;
+    int16_t                as_int16_t(enum ap_var_type type) const;
+    int32_t                as_int32_t(enum ap_var_type type) const;
+    float                  as_float(enum ap_var_type type) const;
+
     // check var table for consistency
     static bool             check_var_info(void);
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN_Servers.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_Servers.h
@@ -13,6 +13,8 @@ class AP_UAVCAN_FileEventTracer;
 class AP_UAVCAN_FileStorageBackend;
 class AP_UAVCAN_CentralizedServer;
 class AP_UAVCAN_RestartRequestHandler;
+class AP_UAVCAN_ParamManager;
+class AP_UAVCAN_ParamServer;
 
 class AP_UAVCAN_Servers
 {
@@ -27,6 +29,9 @@ private:
     AP_UAVCAN_FileStorageBackend *_storage_backend;
     AP_UAVCAN_RestartRequestHandler *_restart_request_handler; // one for all nodes....
 
+
+    AP_UAVCAN_ParamManager *_param_manager;
+    AP_UAVCAN_ParamServer *_param_server;
 };
 
 #endif

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -274,32 +274,7 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
         return;
     }
 
-    float old_value = vp->cast_to_float(var_type);
-
-    if ((parameter_flags & AP_PARAM_FLAG_INTERNAL_USE_ONLY) || vp->is_read_only()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Param write denied (%s)", key);
-        // echo back the incorrect value so that we fulfull the
-        // parameter state machine requirements:
-        send_parameter_value(key, var_type, packet.param_value);
-        // and then announce what the correct value is:
-        send_parameter_value(key, var_type, old_value);
-        return;
-    }
-
-    // set the value
-    vp->set_float(packet.param_value, var_type);
-
-    /*
-      we force the save if the value is not equal to the old
-      value. This copes with the use of override values in
-      constructors, such as PID elements. Otherwise a set to the
-      default value which differs from the constructor value doesn't
-      save the change
-     */
-    bool force_save = !is_equal(packet.param_value, old_value);
-
-    // save the change
-    vp->save(force_save);
+    vp->user_set_value(packet.param_value, var_type);
 
     AP_Logger *logger = AP_Logger::get_singleton();
     if (logger != nullptr) {


### PR DESCRIPTION
```
/*
 * the ParamServer allows other CAN nodes to read and set ArduPilot parameters
 *
 * this can be tested by using uavcan_gui_tool against an SLCAN
 * adapter connected to an ArduPilot autopilot.  Use the
 * Node-Properties window to FetchAll parameters.
 */
```

with thanks to Aeronavics.
