### PR TITLE
EKF2:set origin for all core

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1044,7 +1044,12 @@ bool NavEKF2::setOriginLLH(const Location &loc)
     if (!core) {
         return false;
     }
-    return core[primary].setOriginLLH(loc);
+    for (uint8_t i = 0; i < num_cores; i++) {
+        if (!core[i].setOriginLLH(loc)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // return estimated height above ground level

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1061,7 +1061,12 @@ bool NavEKF3::setOriginLLH(const Location &loc)
     if (!core) {
         return false;
     }
-    return core[primary].setOriginLLH(loc);
+    for (uint8_t i = 0; i < num_cores; i++) {
+        if (!core[i].setOriginLLH(loc)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // return estimated height above ground level


### PR DESCRIPTION
When using non-gps navigation.,We set the home position from the ground station map(from MP's Flight Data screen,select "Set EKF Origin Here"). It only setOriginLLH for primary core. If the ardupilot change EKF core, We will lose global position. 