### PR TITLE
Copter: fixed yaw handling on NAV_LAND when CONDITION_YAW active

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -872,7 +872,7 @@ void Copter::ModeAuto::land_run()
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
     
-    land_run_horizontal_control();
+    land_run_horizontal_control(auto_yaw.mode()==AUTO_YAW_FIXED, auto_yaw.yaw());
     land_run_vertical_control();
 }
 


### PR DESCRIPTION
This fixes yaw from a MAV_CMD_CONDITION_YAW being ignored in a following NAV_LAND.
This does not appear to be broken in master
