### PR TITLE
SITL: support SITL_PANIC_EXIT

### DIFF
--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -107,8 +107,6 @@ popd
 githash=$(cd APM && git rev-parse HEAD)
 hdate=$(date +"%Y-%m-%d-%H:%m")
 
-mkdir -p "buildlogs/history/$hdate"
-
 (cd APM && Tools/scripts/build_parameters.sh)
 
 (cd APM && Tools/scripts/build_docs.sh)
@@ -121,7 +119,12 @@ ulimit -c 10000000
 # build in home dir, as on faster storage
 export BUILD_BINARIES_PATH=$HOME/build/tmp
 
+# exit on panic so we don't waste time waiting around
+export SITL_PANIC_EXIT=1
+
 timelimit 32000 APM/Tools/autotest/autotest.py --timeout=30000 > buildlogs/autotest-output.txt 2>&1
+
+mkdir -p "buildlogs/history/$hdate"
 
 (cd buildlogs && cp -f *.txt *.flashlog *.tlog *.km[lz] *.gpx *.html *.png *.bin *.BIN *.elf "history/$hdate/")
 echo $githash > "buildlogs/history/$hdate/githash.txt"

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -31,6 +31,11 @@ void panic(const char *errormsg, ...)
     va_end(ap);
     printf("\n");
 
+    if (getenv("SITL_PANIC_EXIT")) {
+        // this is used on the autotest server to prevent us waiting
+        // 10 hours for a timeout
+        exit(1);
+    }
     for(;;);
 }
 


### PR DESCRIPTION
used in autotest server to stop us waiting 10 hours for a failure
