### PR TITLE
AP_NavEKF2: default EK2_MAG_EF_LIM to 50

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -571,7 +571,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @User: Advanced
     // @Range: 0 500
     // @Units: mGauss
-    AP_GROUPINFO("MAG_EF_LIM", 52, NavEKF2, _mag_ef_limit, 0),
+    AP_GROUPINFO("MAG_EF_LIM", 52, NavEKF2, _mag_ef_limit, 50),
     
     AP_GROUPEND
 };


### PR DESCRIPTION
this was supposed to be part of the original PR (agreed with Paul to
enable by default)