### PR TITLE
AP_Windvane: fix NMEA vehicle to earth frame error

### DIFF
--- a/libraries/AP_WindVane/AP_WindVane_NMEA.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_NMEA.cpp
@@ -64,7 +64,7 @@ void AP_WindVane_NMEA::update()
         if (decode(c)) {
             // user may not have NMEA selected for both speed and direction
             if (_frontend._direction_type.get() == _frontend.WindVaneType::WINDVANE_NMEA) {
-                direction_update_frontend(wrap_PI(radians(_wind_dir_deg + _frontend._dir_analog_bearing_offset.get())));
+                direction_update_frontend(wrap_PI(radians(_wind_dir_deg + _frontend._dir_analog_bearing_offset.get()) + AP::ahrs().yaw));
             }
             if (_frontend._speed_sensor_type.get() == _frontend.Speed_type::WINDSPEED_NMEA) {
                 speed_update_frontend(_speed_ms);


### PR DESCRIPTION
This fixes a mistake I made when implementing the NMEA windvane driver. Found in on the water testing.