### PR TITLE
Plane: limit reverse speed in QLOITER

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -319,6 +319,9 @@ private:
     AP_Float acro_roll_rate;
     AP_Float acro_pitch_rate;
     AP_Float acro_yaw_rate;
+    
+    // QLOITER mode max reverse speed
+    AP_Float loit_rev_aspd;
 
     // time we last got an EKF yaw reset
     uint32_t ekfYawReset_ms;

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -55,6 +55,13 @@ public:
     }
     float get_airspeed(void) const { return get_airspeed(primary); }
 
+    // return the filtered indicated airspeed in m/s
+    float get_filtered_IAS(uint8_t i) const {
+        float ias = state[i].filtered_IAS;
+        return (ias > 0) ? ias : 0;
+    }
+    float get_filtered_IAS(void) const { return get_filtered_IAS(primary); }
+
     // return the unfiltered airspeed in m/s
     float get_raw_airspeed(uint8_t i) const {
         return state[i].raw_airspeed;
@@ -183,8 +190,11 @@ private:
     struct airspeed_state {
         float   raw_airspeed;
         float   airspeed;
+        float   filtered_IAS;   // filtered Indicated Airspeed
         float	last_pressure;
         float   filtered_pressure;
+        float   IAS_filtered_pressure;
+//        float   IAS_integ;
         float	corrected_pressure;
         float   EAS2TAS;
         bool	healthy:1;


### PR DESCRIPTION
Makes flying a quadplane backwards a bit safer.
Adds parameter Q_LOIT_REV_SPD to set maximum reverse airspeed and relies on AHRS estimated airspeed and NED velocity.