### PR TITLE
waf: add -Werror=overflow

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -92,6 +92,7 @@ class Board:
             '-Werror=unused-result',
             '-Werror=narrowing',
             '-Werror=attributes',
+            '-Werror=overflow',
             '-Werror=format-extra-args',
         ]
 


### PR DESCRIPTION
Can catch some trivial errors.  This warns by default on gcc anyway