### PR TITLE
 AP_RangeFinder: Remove a unit from a parameter name

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -366,8 +366,8 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("PLND_TYPE", 4)
 
             self.set_parameter("RNGFND1_TYPE", 1)
-            self.set_parameter("RNGFND1_MIN_CM", 0)
-            self.set_parameter("RNGFND1_MAX_CM", 4000)
+            self.set_parameter("RNGFND1_MIN", 0)
+            self.set_parameter("RNGFND1_MAX", 4000)
             self.set_parameter("RNGFND1_PIN", 0)
             self.set_parameter("RNGFND1_SCALING", 12.12)
 
@@ -1202,8 +1202,8 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("FLOW_TYPE", 10)
 
             self.set_parameter("RNGFND1_TYPE", 1)
-            self.set_parameter("RNGFND1_MIN_CM", 0)
-            self.set_parameter("RNGFND1_MAX_CM", 4000)
+            self.set_parameter("RNGFND1_MIN", 0)
+            self.set_parameter("RNGFND1_MAX", 4000)
             self.set_parameter("RNGFND1_PIN", 0)
             self.set_parameter("RNGFND1_SCALING", 12.12, epsilon=0.01)
 
@@ -1607,8 +1607,8 @@ class AutoTestCopter(AutoTest):
 
         try:
             self.set_parameter("RNGFND1_TYPE", 1)
-            self.set_parameter("RNGFND1_MIN_CM", 0)
-            self.set_parameter("RNGFND1_MAX_CM", 4000)
+            self.set_parameter("RNGFND1_MIN", 0)
+            self.set_parameter("RNGFND1_MAX", 4000)
             self.set_parameter("RNGFND1_PIN", 0)
             self.set_parameter("RNGFND1_SCALING", 12.12)
             self.set_parameter("RC9_OPTION", 10) # rangefinder
@@ -1757,8 +1757,8 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("PLND_TYPE", 4)
 
             self.set_parameter("RNGFND1_TYPE", 1)
-            self.set_parameter("RNGFND1_MIN_CM", 0)
-            self.set_parameter("RNGFND1_MAX_CM", 4000)
+            self.set_parameter("RNGFND1_MIN", 0)
+            self.set_parameter("RNGFND1_MAX", 4000)
             self.set_parameter("RNGFND1_PIN", 0)
             self.set_parameter("RNGFND1_SCALING", 12)
             self.set_parameter("SIM_SONAR_SCALE", 12)
@@ -2454,8 +2454,8 @@ class AutoTestCopter(AutoTest):
         ex = None
         try:
             self.set_parameter("RNGFND1_TYPE", 1)
-            self.set_parameter("RNGFND1_MIN_CM", 0)
-            self.set_parameter("RNGFND1_MAX_CM", 4000)
+            self.set_parameter("RNGFND1_MIN", 0)
+            self.set_parameter("RNGFND1_MAX", 4000)
             self.set_parameter("RNGFND1_PIN", 0)
             self.set_parameter("RNGFND1_SCALING", 12.12)
             self.set_parameter("GRIP_ENABLE", 1)
@@ -3023,8 +3023,8 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("PLND_TYPE", 1)
 
             self.set_parameter("RNGFND1_TYPE", 1)
-            self.set_parameter("RNGFND1_MIN_CM", 0)
-            self.set_parameter("RNGFND1_MAX_CM", 4000)
+            self.set_parameter("RNGFND1_MIN", 0)
+            self.set_parameter("RNGFND1_MAX", 4000)
             self.set_parameter("RNGFND1_PIN", 0)
             self.set_parameter("RNGFND1_SCALING", 12.12)
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1199,8 +1199,8 @@ class AutoTestPlane(AutoTest):
 
         try:
             self.set_parameter("RNGFND1_TYPE", 1)
-            self.set_parameter("RNGFND1_MIN_CM", 0)
-            self.set_parameter("RNGFND1_MAX_CM", 4000)
+            self.set_parameter("RNGFND1_MIN", 0)
+            self.set_parameter("RNGFND1_MAX", 4000)
             self.set_parameter("RNGFND1_PIN", 0)
             self.set_parameter("RNGFND1_SCALING", 12.12)
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -40,21 +40,21 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("FUNCTION", 5, AP_RangeFinder_Params, function, 0),
 
-    // @Param: MIN_CM
+    // @Param: MIN
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
     // @Units: cm
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("MIN_CM",  6, AP_RangeFinder_Params, min_distance_cm, 20),
+    AP_GROUPINFO("MIN",  6, AP_RangeFinder_Params, min_distance_cm, 20),
 
-    // @Param: MAX_CM
+    // @Param: MAX
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
     // @Units: cm
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("MAX_CM",  7, AP_RangeFinder_Params, max_distance_cm, 700),
+    AP_GROUPINFO("MAX",  7, AP_RangeFinder_Params, max_distance_cm, 700),
 
     // @Param: STOP_PIN
     // @DisplayName: Rangefinder stop pin


### PR DESCRIPTION
I saw a unit added to the parameter name.
I think it is unnecessary because it is described in the parameter description even if the unit is not added to the parameter name.
It is only this parameter that adds CM and centimeter to the parameter name.

![Screenshot from 2019-06-09 22-20-00](https://user-images.githubusercontent.com/646194/59159659-0a47fd00-8b08-11e9-8b4b-acc2ffba3daa.png)
