### PR TITLE
GCS_Mavlink: Correct format specifier in UART panic message

### DIFF
--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -148,7 +148,7 @@ void comm_send_buffer(mavlink_channel_t chan, const uint8_t *buf, uint8_t len)
     const size_t written = mavlink_comm_port[chan]->write(buf, len);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (written < len) {
-        AP_HAL::panic("Short write on UART: %d < %u", written, len);
+        AP_HAL::panic("Short write on UART: %lu < %u", written, len);
     }
 #else
     (void)written;


### PR DESCRIPTION
While compiling the latest master, following warning is there
```
../../libraries/GCS_MAVLink/GCS_MAVLink.cpp: In function ‘void comm_send_buffer(mavlink_channel_t, const uint8_t*, uint8_t)’:
../../libraries/GCS_MAVLink/GCS_MAVLink.cpp:151:67: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
         AP_HAL::panic("Short write on UART: %d < %u", written, len);
```