### PR TITLE
manual speed input for quadplanes

### DIFF
--- a/ArduPlane/mode_qacro.cpp
+++ b/ArduPlane/mode_qacro.cpp
@@ -21,6 +21,9 @@ void ModeQAcro::update()
     Vector3f att_target = plane.quadplane.attitude_control->get_att_target_euler_cd();
     plane.nav_pitch_cd = att_target.y;
     plane.nav_roll_cd = att_target.x;
+
+    // set rudder using stick
+    plane.steering_control.rudder = plane.channel_rudder->get_control_in();
     return;
 }
 

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -42,5 +42,8 @@ void ModeQStabilize::update()
 
     plane.nav_roll_cd = (plane.channel_roll->get_control_in() / 4500.0) * roll_limit;
     plane.nav_roll_cd = constrain_int32(plane.nav_roll_cd, -roll_limit, roll_limit);
+
+    // set rudder using copter controller
+    plane.steering_control.rudder = plane.quadplane.motors->get_yaw() * SERVO_MAX;
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2680,6 +2680,16 @@ int8_t QuadPlane::forward_throttle_pct(void)
         return 0;
     }
 
+    // in QACRO and QSTABILIZE modes, control throttle directly from RC.
+    // QHOVER mode will get manual speed bias applied below.
+    if (rc_bias_ch != nullptr &&
+        (plane.control_mode == &plane.mode_qacro ||
+         plane.control_mode == &plane.mode_qstabilize)) {
+
+        float speed_bias = constrain_float((1.0f + rc_bias_ch->norm_input()) / 2, 0, 1);
+        return 100.0f * speed_bias;
+    }
+
     float deltat = (AP_HAL::millis() - vel_forward.last_ms) * 0.001f;
     if (deltat > 1 || deltat < 0) {
         vel_forward.integrator = 0;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -315,6 +315,10 @@ private:
     // manual throttle curve expo strength
     AP_Float throttle_expo;
 
+    // manual speed bias input
+    AP_Int8  spd_bias_chan;
+    RC_Channel *rc_bias_ch;
+
     // QACRO mode max roll/pitch/yaw rates
     AP_Float acro_roll_rate;
     AP_Float acro_pitch_rate;

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -96,10 +96,9 @@ void QuadPlane::tiltrotor_continuous_update(void)
       needed. There are 4 strategies we will use:
 
       1a) In QAUTOTUNE mode the angle will be set to zero.
-      1b) In QHOVER, QSTABILIZE and QACRO modes with rc_bias_ch null, the angle will be set to zero.
-            This enables these modes to be used as a safe recovery mode.
+      1b) In QACRO mode with rc_bias_ch null, the angle will be set to zero.
 
-      2) In QHOVER, QSTABILIZE and QACRO modes with rc_bias_ch assigned to a valid RC channel:
+      2) In QACRO mode with rc_bias_ch assigned to a valid RC channel:
            The tilt angle is determined by RC input.
 
       3) In fixed wing assisted flight or velocity controlled modes we
@@ -117,12 +116,12 @@ void QuadPlane::tiltrotor_continuous_update(void)
         return;
     }
     if (plane.control_mode == &plane.mode_qacro) {
-        if (tilt.rc_bias_ch == nullptr) {
+        if (rc_bias_ch == nullptr) {
             // case 1b
             tiltrotor_slew(0);
         } else {
             // case 2) manual control of motor tilt
-            float settilt = constrain_float((1.0f + tilt.rc_bias_ch->norm_input()) / 2, 0, 1);
+            float settilt = constrain_float((1.0f + rc_bias_ch->norm_input()) / 2, 0, 1);
             settilt *= tilt.max_angle_deg / 90.0f;
             tiltrotor_slew(settilt);
         }

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -90,26 +90,42 @@ void QuadPlane::tiltrotor_continuous_update(void)
     tilt.current_throttle = constrain_float(motors_throttle,
                                             tilt.current_throttle-max_change,
                                             tilt.current_throttle+max_change);
-    
+
     /*
       we are in a VTOL mode. We need to work out how much tilt is
-      needed. There are 3 strategies we will use:
+      needed. There are 4 strategies we will use:
 
-      1) in QSTABILIZE or QHOVER the angle will be set to zero. This
-         enables these modes to be used as a safe recovery mode.
+      1a) In QAUTOTUNE mode the angle will be set to zero.
+      1b) In QHOVER, QSTABILIZE and QACRO modes with rc_bias_ch null, the angle will be set to zero.
+            This enables these modes to be used as a safe recovery mode.
 
-      2) in fixed wing assisted flight or velocity controlled modes we
+      2) In QHOVER, QSTABILIZE and QACRO modes with rc_bias_ch assigned to a valid RC channel:
+           The tilt angle is determined by RC input.
+
+      3) In fixed wing assisted flight or velocity controlled modes we
          will set the angle based on the demanded forward throttle,
          with a maximum tilt given by Q_TILT_MAX. This relies on
-         Q_VFWD_GAIN being set
+         Q_VFWD_GAIN being set.
 
-      3) if we are in TRANSITION_TIMER mode then we are transitioning
+      4) if we are in TRANSITION_TIMER mode then we are transitioning
          to forward flight and should put the rotors all the way forward
     */
-    if (plane.control_mode == &plane.mode_qstabilize ||
-        plane.control_mode == &plane.mode_qhover ||
-        plane.control_mode == &plane.mode_qautotune) {
+
+    if (plane.control_mode == &plane.mode_qautotune) {
+        // case 1a
         tiltrotor_slew(0);
+        return;
+    }
+    if (plane.control_mode == &plane.mode_qacro) {
+        if (tilt.rc_bias_ch == nullptr) {
+            // case 1b
+            tiltrotor_slew(0);
+        } else {
+            // case 2) manual control of motor tilt
+            float settilt = constrain_float((1.0f + tilt.rc_bias_ch->norm_input()) / 2, 0, 1);
+            settilt *= tilt.max_angle_deg / 90.0f;
+            tiltrotor_slew(settilt);
+        }
         return;
     }
 
@@ -138,6 +154,7 @@ void QuadPlane::tiltrotor_binary_slew(bool forward)
     SRV_Channels::set_output_scaled(SRV_Channel::k_motor_tilt, forward?1000:0);
 
     // rate limiting current_tilt has the effect of delaying throttle in tiltrotor_binary_update
+    // The rate used here is (tilt.max_rate_down_dps > 0) ? tilt.max_rate_down_dps, tilt.max_rate_up_dps
     float max_change = tilt_max_change(!forward);
     if (forward) {
         tilt.current_tilt = constrain_float(tilt.current_tilt+max_change, 0, 1);


### PR DESCRIPTION
Allows using an RC input channel to control the forward speed in QHOVER mode and forward throttle directly in QACRO and QSTABILIZE modes.
Also adds manual rudder control in QACRO and QSTABILIZE
supersedes #11378