### PR TITLE
 AP_RangeFinder: Change instance to ID

### DIFF
--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -684,7 +684,7 @@ void RangeFinder::Log_RFND()
         const struct log_RFND pkt = {
                 LOG_PACKET_HEADER_INIT(LOG_RFND_MSG),
                 time_us      : AP_HAL::micros64(),
-                instance     : i,
+                instance     : (uint8_t)(i + 1),
                 dist         : s->distance_cm(),
                 status       : (uint8_t)s->status(),
                 orient       : s->orientation(),

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -377,7 +377,7 @@ void GCS_MAVLINK::send_distance_sensor() const
         enum Rotation orient = sensor->orientation();
         if (!filter_possible_proximity_sensors ||
             (orient > ROTATION_YAW_315 && orient != ROTATION_PITCH_90)) {
-            send_distance_sensor(sensor, i);
+            send_distance_sensor(sensor, i + 1);
         }
     }
 


### PR DESCRIPTION
I know that the range finder ID is 1-9, A.
The MAVLink ID is not defined as an instance.
I thought that 1-9, 10 was easier to identify range finder. 

 MAVLink spec: 
https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR

RNGFND ID:
![Screenshot from 2019-06-12 02-01-14](https://user-images.githubusercontent.com/646194/59291594-3903d600-8cb6-11e9-9964-1300cb69bf7a.png)
