### PR TITLE
Added Quadplane option for QRTL failsafe action

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -32,7 +32,11 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, mode_reason_t re
     case Mode::Number::QACRO:
         failsafe.saved_mode_number = control_mode->mode_number();
         failsafe.saved_mode_set = true;
-        set_mode(mode_qland, reason);
+        if (quadplane.options & QuadPlane::OPTION_FS_QRTL) {
+            set_mode(mode_qrtl, reason);
+        } else {
+            set_mode(mode_qland, reason);
+        }
         break;
         
     case Mode::Number::AUTO:
@@ -94,7 +98,11 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, mode_reason_t rea
     case Mode::Number::QLOITER:
     case Mode::Number::QACRO:
     case Mode::Number::QAUTOTUNE:
-        set_mode(mode_qland, reason);
+        if (quadplane.options & QuadPlane::OPTION_FS_QRTL) {
+            set_mode(mode_qrtl, reason);
+        } else {
+            set_mode(mode_qland, reason);
+        }
         break;
         
     case Mode::Number::AUTO:

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -328,8 +328,8 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
 
     // @Param: OPTIONS
     // @DisplayName: quadplane options
-    // @Description: This provides a set of additional control options for quadplanes. LevelTransition means that the wings should be held level to within LEVEL_ROLL_LIMIT degrees during transition to fixed wing flight, and the vehicle will not use the vertical lift motors to climb during the transition. If AllowFWTakeoff bit is not set then fixed wing takeoff on quadplanes will instead perform a VTOL takeoff. If AllowFWLand bit is not set then fixed wing land on quadplanes will instead perform a VTOL land. If respect takeoff frame is not set the vehicle will interpret all takeoff waypoints as an altitude above the corrent position.
-    // @Bitmask: 0:LevelTransition,1:AllowFWTakeoff,2:AllowFWLand,3:Respect takeoff frame types,4:Use a fixed wing approach for VTOL landings
+    // @Description: This provides a set of additional control options for quadplanes. LevelTransition means that the wings should be held level to within LEVEL_ROLL_LIMIT degrees during transition to fixed wing flight, and the vehicle will not use the vertical lift motors to climb during the transition. If AllowFWTakeoff bit is not set then fixed wing takeoff on quadplanes will instead perform a VTOL takeoff. If AllowFWLand bit is not set then fixed wing land on quadplanes will instead perform a VTOL land. If respect takeoff frame is not set the vehicle will interpret all takeoff waypoints as an altitude above the corrent position. When Use QRTL is set it will replace QLAND with QRTL for failsafe actions when in VTOL modes.
+    // @Bitmask: 0:LevelTransition,1:AllowFWTakeoff,2:AllowFWLand,3:Respect takeoff frame types,4:Use a fixed wing approach for VTOL landings,5:Use QRTL instead of QLAND for failsafe when in VTOL modes.
     AP_GROUPINFO("OPTIONS", 58, QuadPlane, options, 0),
 
     AP_SUBGROUPEXTENSION("",59, QuadPlane, var_info2),

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -505,6 +505,7 @@ private:
         OPTION_ALLOW_FW_LAND=(1<<2),
         OPTION_RESPECT_TAKEOFF_FRAME=(1<<3),
         OPTION_MISSION_LAND_FW_APPROACH=(1<<4),
+        OPTION_FS_QRTL=(1<<5),
     };
 
     /*


### PR DESCRIPTION
Allows choice of QLAND (present action) or QRTL on Failsafe.