### PR TITLE
Azure: fix builds

### DIFF
--- a/.azure/autotest_template.yml
+++ b/.azure/autotest_template.yml
@@ -10,7 +10,7 @@ jobs:
   steps:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
-  - script: choco install gcc-g++ python27 python27-devel python2-future python27-lxml python27-pip python27-pexpect python27-numpy git gettext libcrypt-devel --source cygwin
+  - script: choco install gcc-g++ python2 python27 python27-devel python27-future python27-lxml python27-pip python27-pexpect python27-numpy git gettext libcrypt-devel --source cygwin
     displayName: 'Install Cygwin packages'
   - script: git submodule update --recursive --init modules/mavlink
     displayName: Initialize MAVLink submodule

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
 
-  - script: choco install cygwin32-gcc-g++ python27 python2-future python27-lxml git gettext --source cygwin
+  - script: choco install cygwin32-gcc-g++ python2 python27 python27-future python27-lxml git gettext --source cygwin
     displayName: 'Install Cygwin packages'
 
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') &&


### PR DESCRIPTION
Cygwin keeps changing Python packages names and unfortunately their virtual packages with the old name don't work. This fixes it.

@ArduPilot/ardupilot-maintainers It's the second time that Azure is failing and stuff continues to be merged without anyone warning me that it is failing. If we aren't going to care when Azure fails then there is no point in me wasting time to maintain it.