### PR TITLE
AP_Common: Remove extra comparison from longitude_scale()

### DIFF
--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -271,7 +271,7 @@ void Location::offset_bearing(float bearing, float distance)
 float Location::longitude_scale() const
 {
     float scale = cosf(lat * (1.0e-7f * DEG_TO_RAD));
-    return constrain_float(scale, 0.01f, 1.0f);
+    return MAX(scale, 0.01f);
 }
 
 /*


### PR DESCRIPTION
`lat` is an integer value, so we won't be inducing any NaN's or infinities to the cos function. That implies that the range of scale is [-1, 1]. This means we can skip the comparison against `1.0f`. We keep the 0.1f check as we are trying to prevent later divide by 0's, and even the negative values won't happen with a valid in range latitude, but it's worth keeping that check. Anyways this just saves us a bit of time when computing locations :)