### PR TITLE
AC_Avoidance: fix BendyRuler when outside polygon fence

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -216,8 +216,11 @@ bool AP_OABendyRuler::calc_margin_from_polygon_fence(const Location &start, cons
         return false;
     }
 
+    // if outside the fence margin is the closest distance but with negative sign
+    const float sign = Polygon_outside(start_NE, boundary, num_points) ? -1.0f : 1.0f;
+
     // calculate min distance (in meters) from line to polygon
-    margin = Polygon_closest_distance_line(boundary, num_points, start_NE, end_NE) * 0.01f;
+    margin = sign * Polygon_closest_distance_line(boundary, num_points, start_NE, end_NE) * 0.01f;
     return true;
 }
 


### PR DESCRIPTION
This PR resolves this issue: https://github.com/ArduPilot/ardupilot/issues/11543 in which the vehicle would actively stay outside the polygon fence if for some reason it managed to get outside of it.

This fix modifies the calculation of the margin from the polygon fence to be the **negative** of the closest point (from the fence) on the line being probed.  Below is an image which helps to show why this is the correct way to calculate the margin.
![bendy-ruler-margin-calc-pic](https://user-images.githubusercontent.com/1498098/59320202-6f6a4100-8d08-11e9-98e5-b782a66b15d9.png)

Here are a few screen shots of the vehicle's behaviour when BendyRuler is activated outside the fence.  
![bendy-ruler-fix](https://user-images.githubusercontent.com/1498098/59320224-8872f200-8d08-11e9-95ff-337a03289009.png)
- The left image shows the vehicle outside the fence.
- The middle image shows the vehicle's final destination is waypoint 1 (see the red line) but it first moves in the direction that most quickly gets it back within the fence (the green line)
- the right image shows how the vehicle turns back towards waypoint 1 once it has moved back inside the fence

By the way, this issue could be recreated in SITL by doing the following:

- start SITL rover
- enable BendyRuler by setting OA_TYPE = 1
- enable the Polygon fence by setting FENCE_ENABLE = 1, FENCE_TYPE = 6, FENCE_ACTION = 0 (we don't want it switching to Hold mode) and then create a polygon fence with the mavproxy gui
- temporarily disable the fence by setting FENCE_ENABLE = 0
- arm the vehicle in MANUAL mode and drive outside the fence
- re-enable the fence by setting FENCE_ENABLE 1
- RTL, the vehicle would start home but would then weave as it approached the polygon fence and never cross back within the fence.

The same issue does not exist for the circular fence nor when using Dijksta's.
