### PR TITLE
Copter: add support for BendyRuler and Dijkstra's object avoidance - WIP

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -55,7 +55,8 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
     return fence_checks(display_failure)
         & parameter_checks(display_failure)
         & motor_checks(display_failure)
-        & pilot_throttle_checks(display_failure) &
+        & pilot_throttle_checks(display_failure)
+        & oa_checks(display_failure) &
         AP_Arming::pre_arm_checks(display_failure);
 }
 
@@ -261,6 +262,25 @@ bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
     }
 
     return true;
+}
+
+bool AP_Arming_Copter::oa_checks(bool display_failure)
+{
+#ifdef AC_AVOID_ENABLED
+    char failure_msg[50];
+    if (copter.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
+        return true;
+    }
+    // display failure
+    if (strlen(failure_msg) == 0) {
+        check_failed(ARMING_CHECK_NONE, display_failure, "Check Object Avoidance");
+    } else {
+        check_failed(ARMING_CHECK_NONE, display_failure, failure_msg);
+    }
+    return false;
+#else
+    return true;
+#endif
 }
 
 bool AP_Arming_Copter::rc_calibration_checks(bool display_failure)

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -45,6 +45,7 @@ protected:
     bool parameter_checks(bool display_failure);
     bool motor_checks(bool display_failure);
     bool pilot_throttle_checks(bool display_failure);
+    bool oa_checks(bool display_failure);
 
     void set_pre_arm_check(bool b);
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -96,6 +96,7 @@
 #endif
 #if AC_AVOID_ENABLED == ENABLED
  #include <AC_Avoidance/AC_Avoid.h>
+ #include <AC_Avoidance/AP_OAPathPlanner.h>
 #endif
 #if SPRAYER_ENABLED == ENABLED
  # include <AC_Sprayer/AC_Sprayer.h>

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -926,6 +926,12 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("TUNE_MAX", 32, ParametersG2, tuning_max, 0),
 
+#ifdef AC_AVOID_ENABLED
+    // @Group: OA_
+    // @Path: ../libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+    AP_SUBGROUPINFO(oa, "OA_", 33, ParametersG2, AP_OAPathPlanner),
+#endif
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -596,6 +596,11 @@ public:
 
     AP_Float tuning_min;
     AP_Float tuning_max;
+
+#ifdef AC_AVOID_ENABLED
+    // object avoidance path planning
+    AP_OAPathPlanner oa;
+#endif
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -980,6 +980,9 @@ public:
     bool allows_arming(bool from_gcs) const override { return false; };
     bool is_autopilot() const override { return true; }
 
+    // for reporting to GCS
+    bool get_wp(Location &loc) override;
+
     RTLState state() { return _state; }
 
     // this should probably not be exposed
@@ -995,6 +998,7 @@ protected:
     const char *name() const override { return "RTL"; }
     const char *name4() const override { return "RTL "; }
 
+    // for reporting to GCS
     uint32_t wp_distance() const override;
     int32_t wp_bearing() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
@@ -1058,6 +1062,8 @@ protected:
     const char *name() const override { return "SMARTRTL"; }
     const char *name4() const override { return "SRTL"; }
 
+    // for reporting to GCS
+    bool get_wp(Location &loc) override;
     uint32_t wp_distance() const override;
     int32_t wp_bearing() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
@@ -1235,9 +1241,11 @@ protected:
 
     const char *name() const override { return "FOLLOW"; }
     const char *name4() const override { return "FOLL"; }
+
+    // for reporting to GCS
+    bool get_wp(Location &loc) override;
     uint32_t wp_distance() const override;
     int32_t wp_bearing() const override;
-    bool get_wp(Location &loc) override;
 
     uint32_t last_log_ms;   // system time of last time desired velocity was logging
 };

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -36,10 +36,12 @@ public:
     virtual bool landing_gear_should_be_deployed() const { return false; }
     virtual bool is_landing() const { return false; }
 
+    // functions for reporting to GCS
     virtual bool get_wp(Location &loc) { return false; };
     virtual int32_t wp_bearing() const { return 0; }
     virtual uint32_t wp_distance() const { return 0; }
     virtual float crosstrack_error() const { return 0.0f;}
+
     void update_navigation();
 
     int32_t get_alt_above_ground_cm(void);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -608,6 +608,8 @@ bool ModeAuto::get_wp(Location& destination)
         return copter.mode_guided.get_wp(destination);
     case Auto_WP:
         return wp_nav->get_oa_wp_destination(destination);
+    case Auto_RTL:
+        return copter.mode_rtl.get_wp(destination);
     default:
         return false;
     }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -607,7 +607,7 @@ bool ModeAuto::get_wp(Location& destination)
     case Auto_NavGuided:
         return copter.mode_guided.get_wp(destination);
     case Auto_WP:
-        return wp_nav->get_wp_destination(destination);
+        return wp_nav->get_oa_wp_destination(destination);
     default:
         return false;
     }

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -209,7 +209,7 @@ bool ModeGuided::get_wp(Location& destination)
     if (guided_mode != Guided_WP) {
         return false;
     }
-    return wp_nav->get_wp_destination(destination);
+    return wp_nav->get_oa_wp_destination(destination);
 }
 
 // sets guided mode's target from a Location object

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -496,6 +496,24 @@ void ModeRTL::compute_return_target()
     rtl_path.return_target.alt = MAX(rtl_path.return_target.alt, curr_alt);
 }
 
+bool ModeRTL::get_wp(Location& destination)
+{
+    // provide target in states which use wp_nav
+    switch (_state) {
+    case RTL_Starting:
+    case RTL_InitialClimb:
+    case RTL_ReturnHome:
+    case RTL_LoiterAtHome:
+    case RTL_FinalDescent:
+        return wp_nav->get_oa_wp_destination(destination);
+    case RTL_Land:
+        return false;
+    }
+
+    // we should never get here but just in case
+    return false;
+}
+
 uint32_t ModeRTL::wp_distance() const
 {
     return wp_nav->get_wp_distance_to_destination();

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -149,6 +149,23 @@ void ModeSmartRTL::save_position()
     copter.g2.smart_rtl.update(copter.position_ok(), should_save_position);
 }
 
+bool ModeSmartRTL::get_wp(Location& destination)
+{
+    // provide target in states which use wp_nav
+    switch (smart_rtl_state) {
+    case SmartRTL_WaitForPathCleanup:
+    case SmartRTL_PathFollow:
+    case SmartRTL_PreLandPosition:
+    case SmartRTL_Descend:
+        return wp_nav->get_wp_destination(destination);
+    case SmartRTL_Land:
+        return false;
+    }
+
+    // we should never get here but just in case
+    return false;
+}
+
 uint32_t ModeSmartRTL::wp_distance() const
 {
     return wp_nav->get_wp_distance_to_destination();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -149,6 +149,10 @@ void Copter::init_ardupilot()
     wp_nav->set_terrain(&terrain);
 #endif
 
+#if AC_AVOID_ENABLED == ENABLED
+    g2.oa.init();
+#endif
+
     attitude_control->parameter_sanity_check();
     pos_control->set_dt(scheduler.get_loop_period_s());
 

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -119,7 +119,8 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         return DIJKSTRA_STATE_SUCCESS;
     }
 
-    return DIJKSTRA_STATE_ERROR;
+    // we have reached the destination so avoidance is no longer required
+    return DIJKSTRA_STATE_NOT_REQUIRED;
 }
 
 // returns true if polygon fence is enabled

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -44,6 +44,11 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         return DIJKSTRA_STATE_NOT_REQUIRED;
     }
 
+    // no avoidance required if destination is same as current location
+    if (current_loc.same_latlon_as(destination)) {
+        return DIJKSTRA_STATE_NOT_REQUIRED;
+    }
+
     // check for fence updates
     if (check_polygon_fence_updated()) {
         _polyfence_with_margin_ok = false;

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -240,8 +240,8 @@ void AP_OAPathPlanner::avoidance_thread()
             // give the main thread the avoidance result
             WITH_SEMAPHORE(_rsem);
             avoidance_result.destination = avoidance_request2.destination;
-            avoidance_result.origin_new = res ? origin_new : avoidance_result.origin_new;
-            avoidance_result.destination_new = res ? destination_new : avoidance_result.destination;
+            avoidance_result.origin_new = (res == OA_SUCCESS) ? origin_new : avoidance_result.origin_new;
+            avoidance_result.destination_new = (res == OA_SUCCESS) ? destination_new : avoidance_result.destination;
             avoidance_result.result_time_ms = AP_HAL::millis();
             avoidance_result.ret_state = res;
         }


### PR DESCRIPTION
This PR adds initial support for Copter to use AC_Avoidance's BendyRuler and Dijkstra's path planning algorithms.

This has been tested in SITL (video) but there are three known issues.  The 1st one at least should probably be resolved before we merge this to master which is why I've marked this as WIP.

- the vehicle accelerates very slowly while BendyRuler is actively avoiding objects.  Users could perhaps think this is on purpose to improve safety but I think that the real issue is caused by the path planning constantly changing the origin and destination.
- If moving to the waypoint causes an altitude change, when Dijkstra's is used the vehicle will climb or descend to the final waypoint's altitude as part of reaching the first intermediate waypoint.
- AC_WPNav or AC_PosControl should be enhanced to use AC_Avoidance's velocity based slide or stopping behaviour.  This lower level obstacle avoidance is already implemented for Loiter mode but we've never enabled it for Auto, Guided, etc for fear that vehicles would get stuck behind obstacles.  With these BendyRuler/Dijkstra's available it is now safe to implement these lower level obstacle avoidance features as well.

This has not yet been tested on a real vehicle.