### PR TITLE
Copter: move brake from AC_WPNav to mode_brake

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -532,6 +532,8 @@ protected:
 
 private:
 
+    void init_target();
+
     uint32_t _timeout_start;
     uint32_t _timeout_ms;
 

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -10,7 +10,7 @@
 bool ModeBrake::init(bool ignore_checks)
 {
     // set target to current position
-    wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
+    init_target();
 
     // initialize vertical speed and acceleration
     pos_control->set_max_speed_z(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z);
@@ -34,7 +34,7 @@ void ModeBrake::run()
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_spool_down();
-        wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
+        init_target();
         return;
     }
 
@@ -46,8 +46,9 @@ void ModeBrake::run()
         loiter_nav->soften_for_landing();
     }
 
-    // run brake controller
-    wp_nav->update_brake();
+    // use position controller to stop
+    pos_control->set_desired_velocity_xy(0.0f, 0.0f);
+    pos_control->update_xy_controller();
 
     // call attitude controller
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), 0.0f);
@@ -72,6 +73,24 @@ void ModeBrake::timeout_to_loiter_ms(uint32_t timeout_ms)
 {
     _timeout_start = millis();
     _timeout_ms = timeout_ms;
+}
+
+void ModeBrake::init_target()
+{
+    // initialise position controller
+    pos_control->set_desired_velocity_xy(0.0f,0.0f);
+    pos_control->set_desired_accel_xy(0.0f,0.0f);
+    pos_control->init_xy_controller();
+
+    // initialise pos controller speed and acceleration
+    pos_control->set_max_speed_xy(inertial_nav.get_velocity().length());
+    pos_control->set_max_accel_xy(BRAKE_MODE_DECEL_RATE);
+    pos_control->calc_leash_length_xy();
+
+    // set target position
+    Vector3f stopping_point;
+    pos_control->get_stopping_point_xy(stopping_point);
+    pos_control->set_xy_target(stopping_point.x, stopping_point.y);
 }
 
 #endif

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -96,35 +96,6 @@ AC_WPNav::AC_WPNav(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosC
 }
 
 
-/// init_brake_target - initializes stop position from current position and velocity
-void AC_WPNav::init_brake_target(float accel_cmss)
-{
-    const Vector3f& curr_vel = _inav.get_velocity();
-    Vector3f stopping_point;
-
-    // initialise position controller
-    _pos_control.set_desired_velocity_xy(0.0f,0.0f);
-    _pos_control.set_desired_accel_xy(0.0f,0.0f);
-    _pos_control.init_xy_controller();
-
-    // initialise pos controller speed and acceleration
-    _pos_control.set_max_speed_xy(curr_vel.length());
-    _pos_control.set_max_accel_xy(accel_cmss);
-    _pos_control.calc_leash_length_xy();
-
-    // set target position
-    _pos_control.get_stopping_point_xy(stopping_point);
-    _pos_control.set_xy_target(stopping_point.x, stopping_point.y);
-}
-
-// update_brake - run the stop controller - gets called at 400hz
-void AC_WPNav::update_brake()
-{
-    // send adjusted feed forward velocity back to position controller
-    _pos_control.set_desired_velocity_xy(0.0f, 0.0f);
-    _pos_control.update_xy_controller();
-}
-
 ///
 /// waypoint navigation
 ///

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -58,15 +58,6 @@ public:
     bool rangefinder_used() const { return _rangefinder_use && _rangefinder_healthy; }
 
     ///
-    /// brake controller
-    ///
-    /// init_brake_target - initialize's position and feed-forward velocity from current pos and velocity
-    void init_brake_target(float accel_cmss);
-    ///
-    /// update_brake - run the brake controller - should be called at 400hz
-    void update_brake();
-
-    ///
     /// waypoint controller
     ///
 


### PR DESCRIPTION
This PR is a replacement for this existing PR https://github.com/ArduPilot/ardupilot/pull/11518 and resolves this issue: https://github.com/ArduPilot/ardupilot/issues/11504

This is a non-functional change which slightly reduces the complexity of the AC_WPNav library by moving the brake feature into the Brake mode class.

This has been lightly tested in SITL and brake mode appears to work OK.