### PR TITLE
SRV_Channel: allow DO_SET_SERVO, DO_REPEAT_SERVO and rc pass-thru on a single channel

### DIFF
--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -139,7 +139,7 @@ void AP_ServoRelayEvents::update_events(void)
         }
         break;
     }
-        
+
     case EVENT_TYPE_RELAY:
         relay.toggle(channel);
         break;

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -32,7 +32,13 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
     if (c == nullptr) {
         return false;
     }
-    if (c->get_function() != SRV_Channel::k_none) {
+    switch(c->get_function())
+    {
+    case SRV_Channel::k_none:
+    case SRV_Channel::k_manual:
+    case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
+        break;
+    default:
         gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
         return false;
     }
@@ -42,6 +48,7 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
         repeat = 0;
     }
     c->set_output_pwm(pwm);
+    c->ignore_small_rcin_changes();
     return true;
 }
 
@@ -72,7 +79,13 @@ bool AP_ServoRelayEvents::do_repeat_servo(uint8_t _channel, uint16_t _servo_valu
     if (c == nullptr) {
         return false;
     }
-    if (c->get_function() != SRV_Channel::k_none) {
+    switch(c->get_function())
+    {
+    case SRV_Channel::k_none:
+    case SRV_Channel::k_manual:
+    case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
+        break;
+    default:
         gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
         return false;
     }
@@ -121,6 +134,7 @@ void AP_ServoRelayEvents::update_events(void)
                 c->set_output_pwm(c->get_trim());
             } else {
                 c->set_output_pwm(servo_value);
+                c->ignore_small_rcin_changes();
             }
         }
         break;

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -217,7 +217,11 @@ public:
     bool function_configured(void) const {
         return function.configured();
     }
-    
+
+    // specify that small rc input changes should be ignored during passthrough
+    // used by DO_SET_SERVO commands
+    void ignore_small_rcin_changes() { ign_small_rcin_changes = true; }
+
 private:
     AP_Int16 servo_min;
     AP_Int16 servo_max;
@@ -268,6 +272,13 @@ private:
     // mask of channels where we have a output_pwm value. Cleared when a
     // scaled value is written. 
     static servo_mask_t have_pwm_mask;
+
+    // previous radio_in during pass-thru
+    int16_t previous_radio_in;
+
+    // specify that small rcinput changes should be ignored during passthrough
+    // used by DO_SET_SERVO commands
+    bool ign_small_rcin_changes;
 };
 
 /*

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -46,7 +46,17 @@ void SRV_Channel::output_ch(void)
             if (SRV_Channels::passthrough_disabled()) {
                 output_pwm = c->get_radio_trim();
             } else {
-                output_pwm = c->get_radio_in();
+                const int16_t radio_in = c->get_radio_in();
+                if (!ign_small_rcin_changes) {
+                    output_pwm = radio_in;
+                    previous_radio_in = radio_in;
+                } else {
+                    // check if rc input value has changed by more than the deadzone
+                    if (abs(radio_in - previous_radio_in) > c->get_dead_zone()) {
+                        output_pwm = radio_in;
+                        ign_small_rcin_changes = false;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This is a replacement for this existing PR: https://github.com/ArduPilot/ardupilot/pull/11468 and resolves this issue: https://github.com/ArduPilot/ardupilot/issues/11210

The purpose is to allow both RC pass through from a pilot's transmitter and DO_SET_SERVO and DO_REPEAT_SERVO commands on the same output channel.

This has been tested on a Cube flight controller by doing this:

- compiling for Copter and uploading to the flight controller
- set RC7_DZ = 20 (default is 0)
- set SERVO7_FUNCTION = 56 (rcinput from channel 6)
- setup MP's tuning page to show "rc6in" and "rc7out"
- used the TX's ch6 tuning knob to change the rc6 input and confirmed rc7 updated smoothly
- used MP's Flight Data screen's Servo tab to set DO_SET_SERVO commands. observed that rc7 out updated to the expected pwm value.
- moved the rc6 input slightly and confirmed the rc7 output did not changed
- moved rc6 input more than 20pwm and confirmed the rc7 output jumped to the rcinput value
- repeated the above tests with small missions containing DO_SET_SERVO and DO_REPEAT_SERVO commands