### PR TITLE
AC_Avoidance: Dijkstra's exits early if polygon fence disabled

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -37,6 +37,11 @@ bool AP_OADijkstra::update(const Location &current_loc, const Location &destinat
         return false;
     }
 
+    // no avoidance required if fence is disabled
+    if (!polygon_fence_enabled()) {
+        return false;
+    }
+
     // check for fence updates
     if (check_polygon_fence_updated()) {
         _polyfence_with_margin_ok = false;
@@ -108,6 +113,16 @@ bool AP_OADijkstra::update(const Location &current_loc, const Location &destinat
     }
 
     return false;
+}
+
+// returns true if polygon fence is enabled
+bool AP_OADijkstra::polygon_fence_enabled() const
+{
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    return ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) > 0);
 }
 
 // check if polygon fence has been updated since we created the inner fence. returns true if changed

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -31,6 +31,9 @@ public:
 
 private:
 
+    // returns true if polygon fence is enabled
+    bool polygon_fence_enabled() const;
+
     // check if polygon fence has been updated since we created the inner fence. returns true if changed
     bool check_polygon_fence_updated() const;
 


### PR DESCRIPTION
This simple change disables Dijkstra's if the polygon fence is disabled which resolves this resolves this issue https://github.com/ArduPilot/ardupilot/issues/11576

This has been tested in SITL and works as expected.  When FENCE_ENABLE = 1, the vehicle properly avoids the polygon fence, when FENCE_ENABLE is set to 0 the vehicle turns directly towards the destination.  Setting FENCE_ENABLE back to 1 re-enables Dijkstra's and the vehicle moves around the fence.