### PR TITLE
AP_Common/AP_Avoidance: create AP_ExpandingArray class and use for avoidance

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -16,7 +16,7 @@
 #include "AP_OADijkstra.h"
 #include <AC_Fence/AC_Fence.h>
 
-#define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  20      // expanding arrays for inner polygon fence and paths to destination will grow in increments of 20 elements
+#define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  32      // expanding arrays for inner polygon fence and paths to destination will grow in increments of 20 elements
 #define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX        255     // index use to indicate we do not have a tentative short path for a node
 
 /// Constructor

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -138,8 +138,8 @@ bool AP_OADijkstra::create_polygon_fence_with_margin(float margin_cm)
         return false;
     }
 
-    // fail if fence is too large
-    if (num_points > OA_DIJKSTRA_POLYGON_FENCE_PTS) {
+    // expand fence point array if required
+    if (!_polyfence_pts.expand_to_hold(num_points)) {
         return false;
     }
 
@@ -401,6 +401,11 @@ bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &d
     // check OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX is defined correct
     static_assert(OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX > OA_DIJKSTRA_POLYGON_FENCE_PTS, "check OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX > OA_DIJKSTRA_POLYGON_FENCE_PTS");
 
+    // expand _short_path_data if necessary
+    if (!_short_path_data.expand_to_hold(2 + _polyfence_numpoints)) {
+        return false;
+    }
+
     // add origin and destination (node_type, id, visited, distance_from_idx, distance_cm) to short_path_data array
     _short_path_data[0] = {{AP_OAVisGraph::OATYPE_SOURCE, 0}, false, 0, 0};
     _short_path_data[1] = {{AP_OAVisGraph::OATYPE_DESTINATION, 0}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
@@ -445,9 +450,14 @@ bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &d
     }
     _path_numpoints = 0;
     while (true) {
-        // fail if out of space or newest node has invalid distance or from index
-        if ((_path_numpoints >= OA_DIJKSTRA_POLYGON_SHORTPATH_PTS) ||
-            (_short_path_data[nidx].distance_from_idx == OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) ||
+        // fail if out of space
+        if (_path_numpoints >= _path.max_items()) {
+            if (!_path.expand()) {
+                break;
+            }
+        }
+        // fail if newest node has invalid distance_from_index
+        if ((_short_path_data[nidx].distance_from_idx == OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) ||
             (_short_path_data[nidx].distance_cm >= FLT_MAX)) {
             break;
         } else {

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -16,14 +16,14 @@
 #include "AP_OADijkstra.h"
 #include <AC_Fence/AC_Fence.h>
 
-#define OA_DIJKSTRA_POLYGON_VISGRAPH_PTS         (OA_DIJKSTRA_POLYGON_FENCE_PTS * OA_DIJKSTRA_POLYGON_FENCE_PTS / 2)
-#define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX 255     // index use to indicate we do not have a tentative short path for a node
+#define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  20      // expanding arrays for inner polygon fence and paths to destination will grow in increments of 20 elements
+#define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX        255     // index use to indicate we do not have a tentative short path for a node
 
 /// Constructor
 AP_OADijkstra::AP_OADijkstra() :
-        _polyfence_visgraph(OA_DIJKSTRA_POLYGON_VISGRAPH_PTS),
-        _source_visgraph(OA_DIJKSTRA_POLYGON_FENCE_PTS),
-        _destination_visgraph(OA_DIJKSTRA_POLYGON_FENCE_PTS)
+        _polyfence_pts(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
+        _short_path_data(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
+        _path(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK)
 {
 }
 
@@ -208,6 +208,11 @@ bool AP_OADijkstra::create_polygon_fence_visgraph()
     uint16_t num_points;
     const Vector2f* boundary = fence->get_boundary_points(num_points);
     if ((boundary == nullptr) || (num_points < 3)) {
+        return false;
+    }
+
+    // fail if more than number of polygon points algorithm can handle
+    if (num_points >= OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) {
         return false;
     }
 
@@ -397,9 +402,6 @@ bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &d
     // create origin and destination visgraphs of polygon points
     update_visgraph(_source_visgraph, {AP_OAVisGraph::OATYPE_SOURCE, 0}, origin_NE, true, destination_NE);
     update_visgraph(_destination_visgraph, {AP_OAVisGraph::OATYPE_DESTINATION, 0}, destination_NE);
-
-    // check OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX is defined correct
-    static_assert(OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX > OA_DIJKSTRA_POLYGON_FENCE_PTS, "check OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX > OA_DIJKSTRA_POLYGON_FENCE_PTS");
 
     // expand _short_path_data if necessary
     if (!_short_path_data.expand_to_hold(2 + _polyfence_numpoints)) {

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -6,9 +6,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_OAVisGraph.h"
 
-#define OA_DIJKSTRA_POLYGON_FENCE_PTS       20      // algorithm can handle up to this many polygon fence points
-#define OA_DIJKSTRA_POLYGON_SHORTPATH_PTS   OA_DIJKSTRA_POLYGON_FENCE_PTS+1 // return path can have up to this many destinations
-
 /*
  * Dijkstra's algorithm for path planning around polygon fence
  */

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -59,7 +59,7 @@ private:
 
     // polygon fence (with margin) related variables
     float _polyfence_margin = 10;
-    Vector2f _polyfence_pts[OA_DIJKSTRA_POLYGON_FENCE_PTS];
+    AP_ExpandingArray<Vector2f> _polyfence_pts;
     uint8_t _polyfence_numpoints;
     uint32_t _polyfence_update_ms;  // system time of boundary update from AC_Fence (used to detect changes to polygon fence)
 
@@ -80,7 +80,8 @@ private:
         bool visited;                   // true if all this node's neighbour's distances have been updated
         node_index distance_from_idx;   // index into _short_path_data from where distance was updated (or 255 if not set)
         float distance_cm;              // distance from source (number is tentative until this node is the current node and/or visited = true)
-    } _short_path_data[OA_DIJKSTRA_POLYGON_SHORTPATH_PTS];
+    };
+    AP_ExpandingArray<ShortPathNode> _short_path_data;
     node_index _short_path_data_numpoints;  // number of elements in _short_path_data array
 
     // update total distance for all nodes visible from current node
@@ -96,10 +97,10 @@ private:
     bool find_closest_node_idx(node_index &node_idx) const;
 
     // final path variables and functions
-    AP_OAVisGraph::OAItemID _path[OA_DIJKSTRA_POLYGON_SHORTPATH_PTS];    // ids of points on return path in reverse order (i.e. destination is first element)
-    uint8_t _path_numpoints;                                                // number of points on return path
-    Vector2f _path_source;                                                  // source point used in shortest path calculations (offset in cm from EKF origin)
-    Vector2f _path_destination;                                             // destination position used in shortest path calculations (offset in cm from EKF origin)
+    AP_ExpandingArray<AP_OAVisGraph::OAItemID> _path;   // ids of points on return path in reverse order (i.e. destination is first element)
+    uint8_t _path_numpoints;                            // number of points on return path
+    Vector2f _path_source;                              // source point used in shortest path calculations (offset in cm from EKF origin)
+    Vector2f _path_destination;                         // destination position used in shortest path calculations (offset in cm from EKF origin)
 
     // return point from final path as an offset (in cm) from the ekf origin
     bool get_shortest_path_point(uint8_t point_num, Vector2f& pos);

--- a/libraries/AC_Avoidance/AP_OAVisGraph.cpp
+++ b/libraries/AC_Avoidance/AP_OAVisGraph.cpp
@@ -15,26 +15,18 @@
 
 #include "AP_OAVisGraph.h"
 
-// constructor with size argument
-AP_OAVisGraph::AP_OAVisGraph(uint8_t size)
+// constructor initialises expanding array to use 20 elements per chunk
+AP_OAVisGraph::AP_OAVisGraph() :
+    _items(20)
 {
-    init(size);
-}
-
-// initialise array to given size
-bool AP_OAVisGraph::init(uint8_t size)
-{
-    return _items.expand_to_hold(size);
 }
 
 // add item to visiblity graph, returns true on success, false if graph is full
 bool AP_OAVisGraph::add_item(const OAItemID &id1, const OAItemID &id2, float distance_cm)
 {
-    // check there is space
-    if (_num_items >= _items.max_items()) {
-        if (!_items.expand(1)) {
-            return false;
-        }
+    // ensure there is space in the array
+    if (!_items.expand_to_hold(_num_items+1)) {
+        return false;
     }
 
     // add item

--- a/libraries/AC_Avoidance/AP_OAVisGraph.cpp
+++ b/libraries/AC_Avoidance/AP_OAVisGraph.cpp
@@ -24,27 +24,17 @@ AP_OAVisGraph::AP_OAVisGraph(uint8_t size)
 // initialise array to given size
 bool AP_OAVisGraph::init(uint8_t size)
 {
-    // only allow init once
-    if (_items != nullptr) {
-        return false;
-    }
-
-    // allocate array
-    _items = (VisGraphItem *)calloc(size, sizeof(VisGraphItem));
-    if (_items != nullptr) {
-        _num_items_max = size;
-        return true;
-    }
-
-    return false;
+    return _items.expand_to_hold(size);
 }
 
 // add item to visiblity graph, returns true on success, false if graph is full
 bool AP_OAVisGraph::add_item(const OAItemID &id1, const OAItemID &id2, float distance_cm)
 {
     // check there is space
-    if (_num_items >= _num_items_max) {
-        return false;
+    if (_num_items >= _items.max_items()) {
+        if (!_items.expand(1)) {
+            return false;
+        }
     }
 
     // add item

--- a/libraries/AC_Avoidance/AP_OAVisGraph.h
+++ b/libraries/AC_Avoidance/AP_OAVisGraph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
+#include <AP_Common/AP_ExpandingArray.h>
 #include <AP_HAL/AP_HAL.h>
 
 /*
@@ -57,7 +58,6 @@ public:
 
 private:
 
-    VisGraphItem *_items;
-    uint8_t _num_items_max;
+    AP_ExpandingArray<VisGraphItem> _items;
     uint8_t _num_items;
 };

--- a/libraries/AC_Avoidance/AP_OAVisGraph.h
+++ b/libraries/AC_Avoidance/AP_OAVisGraph.h
@@ -10,7 +10,6 @@
 class AP_OAVisGraph {
 public:
     AP_OAVisGraph();
-    AP_OAVisGraph(uint8_t size);
 
     /* Do not allow copies */
     AP_OAVisGraph(const AP_OAVisGraph &other) = delete;
@@ -39,9 +38,6 @@ public:
         OAItemID id2;       // second item's id
         float distance_cm;  // distance between the items
     };
-
-    // initialise array to given size
-    bool init(uint8_t size);
 
     // clear all elements from graph
     void clear() { _num_items = 0; }

--- a/libraries/AP_Common/AP_ExpandingArray.cpp
+++ b/libraries/AP_Common/AP_ExpandingArray.cpp
@@ -1,0 +1,66 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ExpandingArray.h"
+
+AP_ExpandingArrayGeneric::~AP_ExpandingArrayGeneric(void)
+{
+    // free chunks
+    for (uint16_t i=0; i<chunk_count; i++) {
+        free(chunk_ptrs[i]);
+    }
+    // free chunks_ptrs array
+    free(chunk_ptrs);
+}
+
+// expand the array by specified number of chunks, returns true on success
+bool AP_ExpandingArrayGeneric::expand(uint16_t num_chunks)
+{
+    // expand chunk_ptrs array if necessary
+    if (chunk_count + num_chunks >= chunk_count_max) {
+        uint16_t chunk_ptr_size = chunk_count + num_chunks + chunk_ptr_increment;
+        chunk_ptr_t *chunk_ptrs_new = (chunk_ptr_t*)realloc(chunk_ptrs, chunk_ptr_size * sizeof(chunk_ptr_t));
+        if (chunk_ptrs_new == nullptr) {
+            return false;
+        }
+
+        // use new pointers array
+        chunk_ptrs = chunk_ptrs_new;
+        chunk_count_max = chunk_ptr_size;
+    }
+
+    // allocate new chunks
+    for (uint16_t i = 0; i < num_chunks; i++) {
+        uint8_t *new_chunk = (uint8_t *)calloc(chunk_size, elem_size);
+        if (new_chunk == nullptr) {
+            // failed to allocate new chunk
+            return false;
+        }
+        chunk_ptrs[chunk_count] = new_chunk;
+        chunk_count++;
+    }
+    return true;
+}
+
+// expand to hold at least num_items
+bool AP_ExpandingArrayGeneric::expand_to_hold(uint16_t num_items)
+{
+    // check if already big enough
+    if (num_items <= max_items()) {
+        return true;
+    }
+    uint16_t chunks_required = ((num_items - max_items()) / chunk_size) + 1;
+    return expand(chunks_required);
+}

--- a/libraries/AP_Common/AP_ExpandingArray.h
+++ b/libraries/AP_Common/AP_ExpandingArray.h
@@ -16,6 +16,9 @@
 /*
  * ExpandingArray class description
  *
+ * ExpandingArrayGeneric implements most of the required functionality and is type agnostic allowing smaller overall code size
+ * ExpandingArray<T> is the template and implements the small number of type specific methods
+ *
  * Elements are organised into "chunks" with each chunk holding "chunk_size" elements
  * The "chunk_ptrs" array holds pointers to all allocated chunks
  *
@@ -38,96 +41,69 @@
 
 #include <AP_Common/AP_Common.h>
 
+class AP_ExpandingArrayGeneric
+{
+public:
+
+    AP_ExpandingArrayGeneric(uint16_t element_size, uint16_t elements_per_chunk) :
+        elem_size(element_size),
+        chunk_size(elements_per_chunk)
+    {}
+
+    ~AP_ExpandingArrayGeneric(void);
+
+    /* Do not allow copies */
+    AP_ExpandingArrayGeneric(const AP_ExpandingArrayGeneric &other) = delete;
+    AP_ExpandingArrayGeneric &operator=(const AP_ExpandingArrayGeneric&) = delete;
+
+    // current maximum number of items (using expand may increase this)
+    uint16_t max_items() const { return chunk_size * chunk_count; }
+
+    // expand the array by specified number of chunks, returns true on success
+    bool expand(uint16_t num_chunks = 1);
+
+    // expand to hold at least num_items
+    bool expand_to_hold(uint16_t num_items);
+
+protected:
+
+    const uint16_t elem_size;   // number of bytes for each element
+    const uint16_t chunk_size;  // the number of T elements in each chunk
+    const uint16_t chunk_ptr_increment = 32;    // chunk_ptrs array is grown by this many elements each time it fills
+
+    typedef uint8_t* chunk_ptr_t;   // pointer to a chunk
+
+    chunk_ptr_t *chunk_ptrs;    // array of pointers to allocated chunks
+    uint16_t chunk_count_max;   // number of elements in chunk_ptrs array
+    uint16_t chunk_count;       // number of allocated chunks
+};
+
 template <typename T>
-class AP_ExpandingArray
+class AP_ExpandingArray : public AP_ExpandingArrayGeneric
 {
 public:
 
     AP_ExpandingArray<T>(uint16_t elements_per_chunk) :
-        chunk_size(elements_per_chunk)
+        AP_ExpandingArrayGeneric(sizeof(T), elements_per_chunk)
     {}
-
-    ~AP_ExpandingArray(void)
-    {
-        // free chunks
-        for (uint16_t i=0; i<chunk_count; i++) {
-            free(chunk_ptrs[i]);
-        }
-        // free chunks_ptrs array
-        free(chunk_ptrs);
-    }
 
     /* Do not allow copies */
     AP_ExpandingArray<T>(const AP_ExpandingArray<T> &other) = delete;
     AP_ExpandingArray<T> &operator=(const AP_ExpandingArray<T>&) = delete;
 
-    // current maximum number of items (using expand may increase this)
-    uint16_t max_items() const { return chunk_size * chunk_count; }
-
     // allow use as an array for assigning to elements. no bounds checking is performed
     T &operator[](uint16_t i)
     {
         const uint16_t chunk_num = i / chunk_size;
-        const uint16_t chunk_index = i % chunk_size;
-        return chunk_ptrs[chunk_num][chunk_index];
+        const uint16_t chunk_index = (i % chunk_size) * elem_size;
+        return (T &)(chunk_ptrs[chunk_num][chunk_index]);
     }
 
     // allow use as an array for accessing elements. no bounds checking is performed
     const T &operator[](uint16_t i) const
     {
         const uint16_t chunk_num = i / chunk_size;
-        const uint16_t chunk_index = i % chunk_size;
-        return chunk_ptrs[chunk_num][chunk_index];
+        const uint16_t chunk_index = (i % chunk_size) * elem_size;
+        return (const T &)(chunk_ptrs[chunk_num][chunk_index]);
     }
-
-    // expand the array by specified number of chunks, returns true on success
-    bool expand(uint16_t num_chunks = 1)
-    {
-        // expand chunk_ptrs array if necessary
-        if (chunk_count + num_chunks >= chunk_count_max) {
-            uint16_t chunk_ptr_size = chunk_count + num_chunks + chunk_ptr_increment;
-            chunk_ptr_t *chunk_ptrs_new = (chunk_ptr_t*)realloc(chunk_ptrs, chunk_ptr_size * sizeof(T*));
-            if (chunk_ptrs_new == nullptr) {
-                return false;
-            }
-
-            // use new pointers array
-            chunk_ptrs = chunk_ptrs_new;
-            chunk_count_max = chunk_ptr_size;
-        }
-
-        // allocate new chunks
-        for (uint16_t i = 0; i < num_chunks; i++) {
-            T *new_chunk = (T *)calloc(chunk_size, sizeof(T));
-            if (new_chunk == nullptr) {
-                // failed to allocate new chunk
-                return false;
-            }
-            chunk_ptrs[chunk_count] = new_chunk;
-            chunk_count++;
-        }
-        return true;
-    }
-
-    // expand to hold at least num_items
-    bool expand_to_hold(uint16_t num_items)
-    {
-        // check if already big enough
-        if (num_items <= max_items()) {
-            return true;
-        }
-        uint16_t chunks_required = ((num_items - max_items()) / chunk_size) + 1;
-        return expand(chunks_required);
-    }
-
-private:
-
-    const uint16_t chunk_size;  // the number of T elements in each chunk
-    const uint16_t chunk_ptr_increment = 32;    // chunk_ptrs array is grown by this many elements each time it fills
-
-    typedef T* chunk_ptr_t;     // pointer to a chunk
-
-    chunk_ptr_t *chunk_ptrs;    // array of pointers to allocated chunks
-    uint16_t chunk_count_max;   // number of elements in chunk_ptrs array
-    uint16_t chunk_count;       // number of allocated chunks
 };

--- a/libraries/AP_Common/AP_ExpandingArray.h
+++ b/libraries/AP_Common/AP_ExpandingArray.h
@@ -47,6 +47,16 @@ public:
         chunk_size(elements_per_chunk)
     {}
 
+    ~AP_ExpandingArray(void)
+    {
+        // free chunks
+        for (uint16_t i=0; i<chunk_count; i++) {
+            free(chunk_ptrs[i]);
+        }
+        // free chunks_ptrs array
+        free(chunk_ptrs);
+    }
+
     /* Do not allow copies */
     AP_ExpandingArray<T>(const AP_ExpandingArray<T> &other) = delete;
     AP_ExpandingArray<T> &operator=(const AP_ExpandingArray<T>&) = delete;

--- a/libraries/AP_Common/AP_ExpandingArray.h
+++ b/libraries/AP_Common/AP_ExpandingArray.h
@@ -1,0 +1,115 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+
+template <typename T>
+class AP_ExpandingArray
+{
+public:
+
+    AP_ExpandingArray<T>() :
+        chunk_size(50)
+    {   // create one chunk
+        expand(1);
+    }
+
+    AP_ExpandingArray<T>(uint16_t num_chunks, uint16_t elements_per_chunk) :
+        chunk_size(elements_per_chunk)
+    {   // create requested number of chunks
+        expand(num_chunks);
+    }
+
+    /* Do not allow copies */
+    AP_ExpandingArray<T>(const AP_ExpandingArray<T> &other) = delete;
+    AP_ExpandingArray<T> &operator=(const AP_ExpandingArray<T>&) = delete;
+
+    // current maximum number of items (using expand may increase this)
+    uint16_t max_items() const { return chunk_size * chunk_count; }
+
+    // allow use as an array for assigning to elements. no bounds checking is performed
+    T &operator[](uint16_t i)
+    {
+        const uint16_t chunk_num = i / chunk_size;
+        const uint16_t chunk_index = i % chunk_size;
+        return chunk_ptrs[chunk_num][chunk_index];
+    }
+
+    // allow use as an array for accessing elements. no bounds checking is performed
+    const T &operator[](uint16_t i) const
+    {
+        const uint16_t chunk_num = i / chunk_size;
+        const uint16_t chunk_index = i % chunk_size;
+        return chunk_ptrs[chunk_num][chunk_index];
+    }
+
+    // expand the array by specified number of chunks, returns true on success
+    bool expand(uint16_t num_chunks = 1)
+    {
+        // expand chunk_ptrs array if necessary
+        if (chunk_count + num_chunks >= chunk_count_max) {
+            uint16_t chunk_ptr_size = chunk_count + num_chunks + chunk_ptr_increment;
+            chunk_ptr *chunk_ptrs_new = (chunk_ptr*)calloc(chunk_ptr_size, sizeof(T*));
+            if (chunk_ptrs_new == nullptr) {
+                return false;
+            }
+            // copy pointers to new points array
+            memcpy(chunk_ptrs_new, chunk_ptrs, chunk_count_max * sizeof(T*));
+
+            // free old pointers array
+            delete chunk_ptrs;
+
+            // use new pointers array
+            chunk_ptrs = chunk_ptrs_new;
+            chunk_count_max = chunk_ptr_size;
+        }
+
+        // allocate new chunks
+        for (uint16_t i = 0; i < num_chunks; i++) {
+            T *new_chunk = (T *)calloc(chunk_size, sizeof(T));
+            if (new_chunk == nullptr) {
+                // failed to allocate new chunk
+                return false;
+            }
+            chunk_ptrs[chunk_count] = new_chunk;
+            chunk_count++;
+        }
+        return true;
+    }
+
+    // expand to hold at least num_items
+    bool expand_to_hold(uint16_t num_items)
+    {
+        // check if already big enough
+        if (num_items <= max_items()) {
+            return true;
+        }
+        uint16_t chunks_required = ((num_items - max_items()) / chunk_size) + 1;
+        return expand(chunks_required);
+    }
+
+private:
+
+    // chunk_ptrs array is grown by this many elements each time it fills
+    const uint16_t chunk_ptr_increment = 50;
+
+    typedef T* chunk_ptr;
+    uint16_t chunk_size;        // the number of T elements in each chunk
+    chunk_ptr* chunk_ptrs;      // array of pointers to allocated chunks
+    uint16_t chunk_count_max;   // number of elements in chunk_ptrs array
+    uint16_t chunk_count;       // number of allocated chunks
+};


### PR DESCRIPTION
This PR allows the AP_Avoidance/AP_OADijkstra class to find the shortest path to a destination even if there are many more than 20 polygon fence points.  This is accomplished by making use of a new AP_ExpandingArray template class to hold various bits of required data including:

- the inner polygon fence points (the inner polygon fence is 10m within the regular polygon fence)
- the visibility graphs which hold the distances between all "nodes" (aka safe positions) which includes the waypoint origin, waypoint destination and the inner polygon fence points
- the resulting shortest path from origin to destination

This has been tested in SITL using a polygon fence of about 40 points (see image below) but probably needs a bit more testing to ensure we completely handle the case where we run out of memory.  Perhaps we should also add limits on how big the arrays can get.

It's possible that I've pushed this PR a little prematurely (i.e. I should do more testing) but in any case, all feedback is appreciated!

![rover-snake-fence](https://user-images.githubusercontent.com/1498098/59547760-fe808e80-8f7e-11e9-8a2d-534f727a5cc3.png)

This PR resolves this issue https://github.com/ArduPilot/ardupilot/issues/11572.