### PR TITLE
Copter: Change the bit value of log mask ANY to 32 bits.

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -238,7 +238,7 @@ enum LoggingParameters {
 #define MASK_LOG_MOTBATT                (1UL<<17)
 #define MASK_LOG_IMU_FAST               (1UL<<18)
 #define MASK_LOG_IMU_RAW                (1UL<<19)
-#define MASK_LOG_ANY                    0xFFFF
+#define MASK_LOG_ANY                    0xFFFFFFFF
 
 // Radio failsafe definitions (FS_THR parameter)
 #define FS_THR_DISABLED                            0


### PR DESCRIPTION
I change the bit value of log mask ANY to 32 bits.
The log mask bit being defined exceeds 16 bits.
The mask bits are up to 32 bits.