### PR TITLE
Copter: inhibit heartbeat until finished booting

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -4,6 +4,9 @@
 
 void Copter::gcs_send_heartbeat(void)
 {
+    if (!ap.initialised) {
+        return;
+    }
     gcs().send_message(MSG_HEARTBEAT);
 }
 


### PR DESCRIPTION
Closes https://github.com/ArduPilot/ardupilot/issues/11591 where first heartbeat always has type QUADCOPTER and following heartbeats have correct Copter frame type configured