### PR TITLE
AP_Logger: Add DataFlash log AHRS ground speed & vertical speed on AHR2

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -17,6 +17,7 @@ void Rover::Log_Write_Attitude()
     logger.Write_AHRS2(ahrs);
 #endif
     logger.Write_POS(ahrs);
+    logger.Write_VEL();
 
     // log steering rate controller
     logger.Write_PID(LOG_PIDS_MSG, g2.attitude_control.get_steering_rate_pid().get_pid_info());

--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -17,6 +17,7 @@ void Tracker::Log_Write_Attitude()
     sitl.Log_Write_SIMSTATE();
 #endif
     logger.Write_POS(ahrs);
+    logger.Write_VEL();
 }
 
 struct PACKED log_Vehicle_Baro {

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -88,6 +88,7 @@ void Copter::Log_Write_EKF_POS()
     sitl.Log_Write_SIMSTATE();
 #endif
     logger.Write_POS(ahrs);
+    logger.Write_VEL();
 }
 
 struct PACKED log_MotBatt {

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -50,6 +50,7 @@ void Plane::Log_Write_Attitude(void)
     sitl.Log_Write_SIMSTATE();
 #endif
     logger.Write_POS(ahrs);
+    logger.Write_VEL();
 }
 
 // do logging at loop rate

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -63,6 +63,7 @@ void Sub::Log_Write_Attitude()
     sitl.Log_Write_SIMSTATE();
 #endif
     logger.Write_POS(ahrs);
+    logger.Write_VEL();
 }
 
 struct PACKED log_MotBatt {

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -624,6 +624,9 @@ void Replay::write_ekf_logs(void)
     if (!LogReader::in_list("POS", nottypes)) {
         _vehicle.logger.Write_POS(_vehicle.ahrs);
     }
+    if (!LogReader::in_list("VEL", nottypes)) {
+        _vehicle.logger.Write_VEL();
+    }
 }
 
 void Replay::read_sensors(const char *type)

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -240,6 +240,7 @@ public:
     void Write_Power(void);
     void Write_AHRS2(AP_AHRS &ahrs);
     void Write_POS(AP_AHRS &ahrs);
+    void Write_VEL();
 #if AP_AHRS_NAVEKF_AVAILABLE
     void Write_EKF(AP_AHRS_NavEKF &ahrs);
 #endif

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -501,6 +501,25 @@ void AP_Logger::Write_POS(AP_AHRS &ahrs)
     WriteBlock(&pkt, sizeof(pkt));
 }
 
+// Write a VEL packet
+void AP_Logger::Write_VEL()
+{
+    AP_AHRS &ahrs = AP::ahrs();
+    Vector3f vel;
+    Vector2f gs {ahrs.groundspeed_vector()};
+    bool have_vel {ahrs.get_velocity_NED(vel)};
+    struct log_VEL pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_VEL_MSG),
+        time_us : AP_HAL::micros64(),
+        vx      : have_vel ? vel.x : quiet_nanf(),
+        vy      : have_vel ? vel.y : quiet_nanf(),
+        vz      : have_vel ? vel.z : quiet_nanf(),
+        gx      : gs.x,
+        gy      : gs.y,
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}
+
 #if AP_AHRS_NAVEKF_AVAILABLE
 void AP_Logger::Write_EKF(AP_AHRS_NavEKF &ahrs)
 {

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -417,6 +417,16 @@ struct PACKED log_POS {
     float rel_origin_alt;
 };
 
+struct PACKED log_VEL {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float vx;
+    float vy;
+    float vz;
+    float gx;
+    float gy;
+};
+
 struct PACKED log_POWR {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1362,6 +1372,8 @@ struct PACKED log_Arm_Disarm {
       "AHR2","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4","sddhmDU????", "FBBB0GG????" }, \
     { LOG_POS_MSG, sizeof(log_POS), \
       "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" }, \
+    { LOG_VEL_MSG, sizeof(log_VEL), \
+      "VEL","Qfffff","TimeUS,Vx,Vy,Vz,Gx,Gy", "snnnnn", "F00000" }, \
     { LOG_SIMSTATE_MSG, sizeof(log_AHRS), \
       "SIM","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4", "sddhmDU????", "FBBB0GG????" }, \
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
@@ -1640,6 +1652,7 @@ enum LogMessages : uint8_t {
     LOG_GYR2_MSG,
     LOG_GYR3_MSG,
     LOG_POS_MSG,
+    LOG_VEL_MSG,
     LOG_PIDR_MSG,
     LOG_PIDP_MSG,
     LOG_PIDY_MSG,


### PR DESCRIPTION
Log AHRS ground speed aka ahrs.groundspeed() and  vertical speed aka -ahrs.get_velocity_NED(vel).z to DataFlash logs.
Very useful to debug non-GPS navigation or dead-reckoning.