### PR TITLE
move TECS airspeed filter to AP_Airspeed

### DIFF
--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -37,7 +37,7 @@ bool Plane::auto_takeoff_check(void)
 
     if (!takeoff_state.launchTimerStarted && !is_zero(g.takeoff_throttle_min_accel)) {
         // we are requiring an X acceleration event to launch
-        float xaccel = SpdHgt_Controller->get_VXdot();
+        float xaccel = AP::ahrs().get_VXdot();
         if (g2.takeoff_throttle_accel_count <= 1) {
             if (xaccel < g.takeoff_throttle_min_accel) {
                 goto no_launch;
@@ -65,7 +65,7 @@ bool Plane::auto_takeoff_check(void)
         takeoff_state.last_tkoff_arm_time = now;
         if (now - takeoff_state.last_report_ms > 2000) {
             gcs().send_text(MAV_SEVERITY_INFO, "Armed AUTO, xaccel = %.1f m/s/s, waiting %.1f sec",
-                              (double)SpdHgt_Controller->get_VXdot(), (double)(wait_time_ms*0.001f));
+                              (double)AP::ahrs().get_VXdot(), (double)(wait_time_ms*0.001f));
             takeoff_state.last_report_ms = now;
         }
     }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -253,6 +253,15 @@ public:
     // if we have an estimate
     virtual bool airspeed_estimate(float &airspeed_ret) const WARN_IF_UNUSED;
 
+    // maintain estimate of velocity rate of change; used by EAS_estimate()
+    void update_vel_dot(void);
+
+    // Rate of change of velocity along X body axis in m/s^2
+    float get_VXdot(void) { return vel_dot; }
+
+    // return a filtered airspeed estimate. return true if estimate was available
+    virtual bool EAS_estimate(float *airspeed_ret) const WARN_IF_UNUSED;
+
     // return a true airspeed estimate (navigation airspeed) if
     // available. return true if we have an estimate
     bool airspeed_estimate_true(float &airspeed_ret) const WARN_IF_UNUSED {
@@ -629,6 +638,13 @@ protected:
     // accelerometer values in the earth frame in m/s/s
     Vector3f        _accel_ef[INS_MAX_INSTANCES];
     Vector3f        _accel_ef_blended;
+
+    // Rate of change of speed along body frame X axis
+    float vel_dot;
+
+    // declares a 5point average filter using floats
+    AverageFilterFloat_Size5 vdot_filter;
+    uint64_t _update_vdot_last_msec;
 
     // Declare filter states for HPF and LPF used by complementary
     // filter in AP_AHRS::groundspeed_vector

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -28,6 +28,7 @@
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/Location.h>
+#include <Filter/AverageFilter.h>
 
 class AP_NMEA_Output;
 class OpticalFlow;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -117,6 +117,9 @@ AP_AHRS_DCM::update(bool skip_ins_update)
     // update AOA and SSA
     update_AOA_SSA();
 
+    // update vel_dot
+    update_vel_dot();
+
     backup_attitude();
 }
 

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -51,6 +51,10 @@ public:
     // read the analog source and update airspeed
     void update(bool log);
 
+    // filtered equivalent airspeed used by TECS
+    void update_EAS(void);
+    float get_EAS(void) const { return _EAS_state; }
+
     // calibrate the airspeed. This must be called on startup if the
     // altitude/climb_rate/acceleration interfaces are ever used
     void calibrate(bool in_startup);
@@ -216,6 +220,10 @@ private:
     // current primary sensor
     uint8_t primary;
     
+    float   _EAS_state;   // TECS airspeed
+    float   _integETAS_state;
+    uint64_t _update_speed_last_usec;
+
     void read(uint8_t i);
     // return the differential pressure in Pascal for the last airspeed reading for the requested instance
     // returns 0 if the sensor is not enabled

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -61,19 +61,28 @@ public:
 
     // return the current airspeed in m/s
     float get_airspeed(uint8_t i) const {
-        return state[i].airspeed;
+        if (i < AIRSPEED_MAX_SENSORS) {
+            return state[i].airspeed;
+        }
+        return 0;
     }
     float get_airspeed(void) const { return get_airspeed(primary); }
 
     // return the unfiltered airspeed in m/s
     float get_raw_airspeed(uint8_t i) const {
-        return state[i].raw_airspeed;
+        if (i < AIRSPEED_MAX_SENSORS) {
+            return state[i].raw_airspeed;
+        }
+        return 0;
     }
     float get_raw_airspeed(void) const { return get_raw_airspeed(primary); }
 
     // return the current airspeed ratio (dimensionless)
     float get_airspeed_ratio(uint8_t i) const {
-        return param[i].ratio;
+        if (i < AIRSPEED_MAX_SENSORS) {
+            return param[i].ratio;
+        }
+        return 0;
     }
     float get_airspeed_ratio(void) const { return get_airspeed_ratio(primary); }
 
@@ -83,7 +92,9 @@ public:
 
     // set the airspeed ratio (dimensionless)
     void set_airspeed_ratio(uint8_t i, float ratio) {
-        param[i].ratio.set(ratio);
+        if (i < AIRSPEED_MAX_SENSORS) {
+           param[i].ratio.set(ratio);
+        }
     }
     void set_airspeed_ratio(float ratio) { set_airspeed_ratio(primary, ratio); }
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -979,7 +979,9 @@ struct PACKED log_CESC {
 struct PACKED log_AIRSPEED {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    float   raw_airspeed;
     float   airspeed;
+    float   eas;
     float   diffpressure;
     int16_t temperature;
     float   rawpressure;
@@ -1312,10 +1314,10 @@ struct PACKED log_Arm_Disarm {
 #define QUAT_UNITS  "s#????"
 #define QUAT_MULTS  "F-????"
 
-#define ARSP_LABELS "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U,Health,Hfp,Pri"
-#define ARSP_FMT "QffcffBBfB"
-#define ARSP_UNITS "snPOPP----"
-#define ARSP_MULTS "F00B00----"
+#define ARSP_LABELS "TimeUS,RawArsp,Arsp,EAS,DiffP,Temp,RawP,Offset,U,Health,Hfp,Pri"
+#define ARSP_FMT "QffffcffBBfB"
+#define ARSP_UNITS "snnnPOPP----"
+#define ARSP_MULTS "F0000B00----"
 
 // messages for all boards
 #define LOG_BASE_STRUCTURES \

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -42,9 +42,6 @@ public:
 	// should return -9000 to +9000
 	virtual int32_t get_pitch_demand(void)=0;
 	
-	// Rate of change of velocity along X body axis in m/s^2
-    virtual float get_VXdot(void)=0;
-	
 	// return current target airspeed
 	virtual float get_target_airspeed(void) const = 0;
 

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -328,15 +328,6 @@ void AP_TECS::update_50hz(void)
             _height_filter.height += integ3_input*DT;
         }
     }
-
-    // Update and average speed rate of change
-    // Get DCM
-    const Matrix3f &rotMat = _ahrs.get_rotation_body_to_ned();
-    // Calculate speed rate of change
-    float temp = rotMat.c.x * GRAVITY_MSS + AP::ins().get_accel().x;
-    // take 5 point moving average
-    _vel_dot = _vdot_filter.apply(temp);
-
 }
 
 void AP_TECS::_update_speed(float load_factor)
@@ -369,7 +360,6 @@ void AP_TECS::_update_speed(float load_factor)
     // Reset states of time since last update is too large
     if (DT > 1.0f) {
         _TAS_state = (_EAS * EAS2TAS);
-        _integDTAS_state = 0.0f;
         DT            = 0.1f; // when first starting TECS, use a
         // small time constant
     }

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -67,11 +67,6 @@ public:
         return int32_t(_pitch_dem * 5729.5781f);
     }
 
-    // Rate of change of velocity along X body axis in m/s^2
-    float get_VXdot(void) override {
-        return AP::ahrs().get_VXdot();
-    }
-
     // return current target airspeed
     float get_target_airspeed(void) const override {
         return _TAS_dem / _ahrs.get_EAS2TAS();

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -69,7 +69,7 @@ public:
 
     // Rate of change of velocity along X body axis in m/s^2
     float get_VXdot(void) override {
-        return _vel_dot;
+        return AP::ahrs().get_VXdot();
     }
 
     // return current target airspeed
@@ -203,9 +203,6 @@ private:
         float height;
     } _height_filter;
 
-    // Integrator state 4 - airspeed filter first derivative
-    float _integDTAS_state;
-
     // Integrator state 5 - true airspeed
     float _TAS_state;
 
@@ -221,8 +218,8 @@ private:
     // pitch demand rate limiter state
     float _last_pitch_dem;
 
-    // Rate of change of speed along X axis
-    float _vel_dot;
+//    // Rate of change of speed along X axis
+//    float _vel_dot;
 
     // Equivalent airspeed
     float _EAS;


### PR DESCRIPTION
move airspeed filtering code from update_speed() to AP_Airspeed::update_EAS 
move vel_dot code from update_50_Hz to AP_AHRS::get_VXdot
add AP_AHRS::EAS_estimate() and call it from TECS (instead of airspeed_estimate)

add filtered airspeed (get_airspeed() and EAS to ARSP/ASP2 log records
change airspeed field of ARSP/ASP2 records to get_airspeed instead of get_raw_airspeed (get_raw_airspeed is not used anywhere except Log_Airspeed())

TODO:
- [x] eliminate get_VXdot() in AP_SpdHgtControl (no need to override AP_AHRS?)
- [ ] rename EAS_xxx to filtered_airspeed_xxx (but value returned by airspeed_estimateO is also filtered...)