### PR TITLE
Enable Scripting on all builds

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -614,7 +614,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_GROUPINFO("BAL_PITCH_TRIM", 40, ParametersG2, bal_pitch_trim, 0),
 
 #ifdef ENABLE_SCRIPTING
-    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    // @Group: SCR_
+    // @Path: ../libraries/AP_Scripting/AP_Scripting.cpp
     AP_SUBGROUPINFO(scripting, "SCR_", 41, ParametersG2, AP_Scripting),
 #endif
 

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -355,7 +355,8 @@ const AP_Param::Info Tracker::var_info[] = {
 	GGROUP(pidYaw2Srv,         "YAW2SRV_", AC_PID),
 
 #ifdef ENABLE_SCRIPTING
-    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    // @Group: SCR_
+    // @Path: ../libraries/AP_Scripting/AP_Scripting.cpp
     GOBJECT(scripting, "SCR_", AP_Scripting),
 #endif
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -902,7 +902,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 #endif
 
 #ifdef ENABLE_SCRIPTING
-    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    // @Group: SCR_
+    // @Path: ../libraries/AP_Scripting/AP_Scripting.cpp
     AP_SUBGROUPINFO(scripting, "SCR_", 30, ParametersG2, AP_Scripting),
 #endif
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1173,7 +1173,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 
 #ifdef ENABLE_SCRIPTING
-    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    // @Group: SCR_
+    // @Path: ../libraries/AP_Scripting/AP_Scripting.cpp
     AP_SUBGROUPINFO(scripting, "SCR_", 14, ParametersG2, AP_Scripting),
 #endif
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -628,7 +628,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(rc_channels, "RC", 17, ParametersG2, RC_Channels),
 
 #ifdef ENABLE_SCRIPTING
-    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    // @Group: SCR_
+    // @Path: ../libraries/AP_Scripting/AP_Scripting.cpp
     AP_SUBGROUPINFO(scripting, "SCR_", 18, ParametersG2, AP_Scripting),
 #endif
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -43,6 +43,29 @@ class Board:
         env = waflib.ConfigSet.ConfigSet()
         self.configure_env(cfg, env)
 
+        # Setup scripting, had to defer this to allow checking board size
+        if (not cfg.options.disable_scripting) and ((cfg.env.BOARD_FLASH_SIZE is None) or (cfg.env.BOARD_FLASH_SIZE == []) or (cfg.env.BOARD_FLASH_SIZE > 1024)):
+            env.DEFINES.update(
+                ENABLE_SCRIPTING = 1,
+                ENABLE_HEAP = 1,
+                LUA_32BITS = 1,
+                )
+
+            env.ROMFS_FILES += [
+                ('sandbox.lua', 'libraries/AP_Scripting/scripts/sandbox.lua'),
+                ]
+
+            env.AP_LIBRARIES += [
+                'AP_Scripting',
+                'AP_Scripting/lua/src',
+                ]
+
+            env.CXXFLAGS += [
+                '-DHAL_HAVE_AP_ROMFS_EMBEDDED_H'
+                ]
+        else:
+            cfg.options.disable_scripting = True;
+
         d = env.get_merged_dict()
         # Always prepend so that arguments passed in the command line get
         # the priority.
@@ -96,26 +119,6 @@ class Board:
             '-Werror=parentheses',
             '-Werror=format-extra-args',
         ]
-
-        if cfg.options.enable_scripting:
-            env.DEFINES.update(
-                ENABLE_SCRIPTING = 1,
-                ENABLE_HEAP = 1,
-                LUA_32BITS = 1,
-                )
-
-            env.ROMFS_FILES += [
-                ('sandbox.lua', 'libraries/AP_Scripting/scripts/sandbox.lua'),
-                ]
-
-            env.AP_LIBRARIES += [
-                'AP_Scripting',
-                'AP_Scripting/lua/src',
-                ]
-
-            env.CXXFLAGS += [
-                '-DHAL_HAVE_AP_ROMFS_EMBEDDED_H'
-                ]
 
         if cfg.options.scripting_checks:
             env.DEFINES.update(

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -85,14 +85,6 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
-    if [ "$t" == "sitl-scripting" ]; then
-        echo "Building scripting"
-        $waf configure --enable-scripting
-        $waf clean
-        $waf all
-        continue
-    fi
-
     if [ "$t" == "revo-bootloader" ]; then
         echo "Building revo bootloader"
         $waf configure --board revo-mini --bootloader

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -236,10 +236,10 @@ public:
     int32_t pitch_sensor;
     int32_t yaw_sensor;
 
-    // return a smoothed and corrected gyro vector
+    // return a smoothed and corrected gyro vector in radians/second
     virtual const Vector3f &get_gyro(void) const = 0;
 
-    // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
+    // return a smoothed and corrected gyro vector in radians/second using the latest ins data (which may not have been consumed by the EKF yet)
     Vector3f get_gyro_latest(void) const;
 
     // return the current estimate of the gyro drift
@@ -281,6 +281,7 @@ public:
     // otherwise false. This call fills in lat, lng and alt
     virtual bool get_position(struct Location &loc) const = 0;
 
+    // get latest altitude estimate above ground level in meters and validity flag
     virtual bool get_hagl(float &height) const { return false; }
 
     // return a wind estimation vector, in m/s

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -572,6 +572,7 @@ def write_mcu_config(f):
             f.write('#define %s\n' % d[7:])
     flash_size = get_config('FLASH_SIZE_KB', type=int)
     f.write('#define BOARD_FLASH_SIZE %u\n' % flash_size)
+    env_vars['BOARD_FLASH_SIZE'] = flash_size
     f.write('#define CRT1_AREAS_NUMBER 1\n')
 
     flash_reserve_start = get_config(

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -36,8 +36,8 @@ public:
 
 #ifdef ENABLE_HEAP
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
-    virtual void *allocate_heap_memory(size_t size);
-    virtual void *heap_realloc(void *heap, void *ptr, size_t new_size);
+    void *allocate_heap_memory(size_t size) override;
+    void *heap_realloc(void *heap, void *ptr, size_t new_size) override;
 #endif // ENABLE_HEAP
 
 #ifdef WITH_SITL_TONEALARM

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -44,7 +44,7 @@ const AP_Param::GroupInfo AP_Scripting::var_info[] = {
     // @Values: 0:None,1:Lua Scripts
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_Scripting, _enable, 1, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_Scripting, _enable, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: VM_I_COUNT
     // @DisplayName: Scripting Virtual Machine Instruction Count

--- a/libraries/AP_Scripting/README.md
+++ b/libraries/AP_Scripting/README.md
@@ -2,13 +2,15 @@
 
 ## Enabling Scripting Support in Builds
 
-To enable scripting the `--enable-scripting` flag must be passed to waf.
-The following example enables scripting and builds the ArduPlane firmware for the Cube.
+Scripting is automatically enabled on all boards with at least 1MB of flash space.
+The following example enables scripting, builds the ArduPlane firmware for the Cube, and uploads it.
 
 ```
-$ waf configure --enable-scripting --board=CubeBlack
+$ waf configure --board=CubeBlack
 
 $ waf plane
+
+$ waf plane --upload
 ```
 
 To run SITL you can simply use the `sim_vehicle.py` script which will wrap the configuration, compilation,
@@ -16,8 +18,10 @@ and launching of the simulation into one command for you.
 
 
 ```
-$ Tools/autotest/sim_vehicle.py --waf-configure-arg --enable-scripting -v ArduPlane
+$ Tools/autotest/sim_vehicle.py -v ArduPlane
 ```
+
+Once you have a vehicle flashed with scripting you need to set the `SCR_ENABLE` parameter to 1 to enable scripting and reboot.
 
 ## Adding Scripts
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -11,7 +11,7 @@ userdata Location field loiter_xtrack boolean read write
 
 userdata Location method get_distance float Location
 userdata Location method offset void float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX
-userdata Location method get_vector_from_origin_NEU boolean Vector3f
+userdata Location method get_vector_from_origin_NEU boolean Vector3f'Null
 
 include AP_AHRS/AP_AHRS.h
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -388,13 +388,18 @@ static int Vector3f___sub(lua_State *L) {
 
 static int Location_get_vector_from_origin_NEU(lua_State *L) {
     // 1 Vector3f 14 : 6
-    binding_argcheck(L, 2);
+    binding_argcheck(L, 1);
     Location * ud = check_Location(L, 1);
-    Vector3f & data_2 = *check_Vector3f(L, 2);
+    Vector3f data_5002 = {};
     const bool data = ud->get_vector_from_origin_NEU(
-            data_2);
+            data_5002);
 
-    lua_pushboolean(L, data);
+    if (data) {
+        new_Vector3f(L);
+        *check_Vector3f(L, -1) = data_5002;
+    } else {
+        lua_pushnil(L);
+    }
     return 1;
 }
 

--- a/wscript
+++ b/wscript
@@ -131,9 +131,9 @@ submodules at specific revisions.
                  default=False,
                  help="Enable checking of math indexes")
 
-    g.add_option('--enable-scripting', action='store_true',
+    g.add_option('--disable-scripting', action='store_true',
                  default=False,
-                 help="Enable onboard scripting engine")
+                 help="Disable onboard scripting engine")
 
     g.add_option('--scripting-checks', action='store_true',
                  default=True,
@@ -424,10 +424,10 @@ def configure(cfg):
         cfg.end_msg('disabled', color='YELLOW')
 
     cfg.start_msg('Scripting')
-    if cfg.options.enable_scripting:
-        cfg.end_msg('enabled')
-    else:
+    if cfg.options.disable_scripting:
         cfg.end_msg('disabled', color='YELLOW')
+    else:
+        cfg.end_msg('enabled')
 
     cfg.start_msg('Scripting runtime checks')
     if cfg.options.scripting_checks:


### PR DESCRIPTION
This enables scripting automatically on all builds that have more then 1MB of flash. Scripting can be forced off by passing `--disable-scripting` to waf. SCR_ENABLE must be set to 1 before we actually allocate/run scripts, so this should be safe to enable on all builds and let users starting opting in as they want.

The other minor commits:
  - Fixed missing comments saying what units an AHRS function returned
  - Fixed a scripting method that was meant to be nil punning