### PR TITLE
AP_FrSky_Telem: Don't retain the object if no ports were found

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -38,7 +38,7 @@ ObjectArray<mavlink_statustext_t> AP_Frsky_Telem::_statustext_queue(FRSKY_TELEM_
 /*
  * init - perform required initialisation
  */
-void AP_Frsky_Telem::init()
+bool AP_Frsky_Telem::init()
 {
     const AP_SerialManager &serial_manager = AP::serialmanager();
 
@@ -65,7 +65,11 @@ void AP_Frsky_Telem::init()
         hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&AP_Frsky_Telem::tick, void));
         // we don't want flow control for either protocol
         _port->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
+
+        return true;
     }
+
+    return false;
 }
 
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -33,7 +33,10 @@
 
 extern const AP_HAL::HAL& hal;
 
-ObjectArray<mavlink_statustext_t> AP_Frsky_Telem::_statustext_queue(FRSKY_TELEM_PAYLOAD_STATUS_CAPACITY);
+AP_Frsky_Telem::AP_Frsky_Telem(void) :
+  _statustext_queue(FRSKY_TELEM_PAYLOAD_STATUS_CAPACITY)
+{
+}
 
 /*
  * init - perform required initialisation

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -112,7 +112,7 @@ for FrSky SPort Passthrough
 
 class AP_Frsky_Telem {
 public:
-    AP_Frsky_Telem() {}
+    AP_Frsky_Telem();
 
     /* Do not allow copies */
     AP_Frsky_Telem(const AP_Frsky_Telem &other) = delete;
@@ -130,8 +130,6 @@ public:
     // functioning correctly
     uint32_t sensor_status_flags() const;
 
-    static ObjectArray<mavlink_statustext_t> _statustext_queue;
-
 private:
     AP_HAL::UARTDriver *_port;                  // UART used to send data to FrSky receiver
     AP_SerialManager::SerialProtocol _protocol; // protocol used - detected using SerialManager's SERIAL#_PROTOCOL parameter
@@ -141,6 +139,9 @@ private:
     uint32_t check_sensor_status_timer;
     uint32_t check_ekf_status_timer;
     uint8_t _paramID;
+
+    ObjectArray<mavlink_statustext_t> _statustext_queue;
+
     
     struct
     {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -119,7 +119,7 @@ public:
     AP_Frsky_Telem &operator=(const AP_Frsky_Telem&) = delete;
 
     // init - perform required initialisation
-    void init();
+    bool init();
 
     // add statustext message to FrSky lib message queue
     void queue_message(MAV_SEVERITY severity, const char *text);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -976,7 +976,7 @@ public:
     }
 
     // frsky backend
-    AP_Frsky_Telem frsky;
+    AP_Frsky_Telem *frsky;
 
     // Devo backend
     AP_DEVO_Telem devo_telemetry;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2136,8 +2136,9 @@ void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const cha
         logger->Write_Message(text);
     }
 
-    // add statustext message to FrSky lib queue
-    frsky.queue_message(severity, text);
+    if (frsky != nullptr) {
+        frsky->queue_message(severity, text);
+    }
 
     AP_Notify *notify = AP_Notify::get_singleton();
     if (notify) {
@@ -2279,7 +2280,13 @@ void GCS::setup_uarts(AP_SerialManager &serial_manager)
         chan(i).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
     }
 
-    frsky.init();
+    if (frsky == nullptr) {
+        frsky = new AP_Frsky_Telem();
+        if (frsky == nullptr || !frsky->init()) {
+            delete frsky;
+            frsky = nullptr;
+        }
+    }
 
     devo_telemetry.init();
 }


### PR DESCRIPTION
This is something I've wanted to mess with for awhile now. The basic idea is that if we don't have a serial port for it, we can't possibly have a useful instance of the FrSky telem, so skipping updating it saves time and memory.

The overall RAM savings is 376 bytes, it's split between two commits:
  - First just to delete the instance if we didn't find a port, this only saved 96 bytes
  - Second we were storing the statustext_queue as a static for some reason, which was another 280 bytes, and was generally a bad idea (particularly if we ever wanted to run 2 instances at once).

I've tested this on a Cube (running Plane is where the numbers came from) without any FrSky setup, I have the hardware in a box to test with FrSky, but I've never actually gotten to setting it up, so if someone can help with validating that it would be appreciated.

Are there any objections to this path of removing stuff on startup that we don't need? ~I'd like to extend this to also cover Devo, but only did FrSky as proof of concept.~ EDIT: Devo is maybe not worth the effort, it holds a uint32_t and pointer... For  the 8 bytes of RAM I'd spend more in flash...