### PR TITLE
Added battery reset command over mavlink

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -501,10 +501,22 @@ void AP_BattMonitor::checkPoweringOff(void)
 bool AP_BattMonitor::reset_remaining(uint16_t battery_mask, float percentage)
 {
     bool ret = true;
+    BatteryFailsafe highest_failsafe = BatteryFailsafe_None;
     for (uint8_t i = 0; i < _num_instances; i++) {
         if ((1U<<i) & battery_mask) {
             ret &= drivers[i]->reset_remaining(percentage);
         }
+        if (state[i].failsafe > highest_failsafe) {
+            highest_failsafe = state[i].failsafe;
+        }
+    }
+
+    // If all backends are not in failsafe then set overall failsafe state
+    if (highest_failsafe == BatteryFailsafe_None) {
+        _highest_failsafe_priority = INT8_MAX;
+        _has_triggered_failsafe = false;
+        // and reset notify flag
+        AP_Notify::flags.failsafe_battery = false;
     }
     return ret;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -494,6 +494,21 @@ void AP_BattMonitor::checkPoweringOff(void)
     }
 }
 
+/*
+  reset battery remaining percentage for batteries that integrate to
+  calculate percentage remaining
+*/
+bool AP_BattMonitor::reset_remaining(uint16_t battery_mask, float percentage)
+{
+    bool ret = true;
+    for (uint8_t i = 0; i < _num_instances; i++) {
+        if ((1U<<i) & battery_mask) {
+            ret &= drivers[i]->reset_remaining(percentage);
+        }
+    }
+    return ret;
+}
+
 namespace AP {
 
 AP_BattMonitor &battery()

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -167,6 +167,9 @@ public:
     // sends powering off mavlink broadcasts and sets notify flag
     void checkPoweringOff(void);
 
+    // reset battery remaining percentage
+    bool reset_remaining(uint16_t battery_mask, float percentage);
+
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -232,5 +232,8 @@ bool AP_BattMonitor_Backend::reset_remaining(float percentage)
     // full charge
     _state.consumed_wh = _state.consumed_mah * 1000 * _state.voltage;
 
+    // reset failsafe state for this backend
+    _state.failsafe = update_failsafes();
+
     return true;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -215,3 +215,22 @@ void AP_BattMonitor_Backend::check_failsafe_types(bool &low_voltage, bool &low_c
         low_capacity = false;
     }
 }
+
+/*
+  default implementation for reset_remaining(). This sets consumed_wh
+  and consumed_mah based on the given percentage. Use percentage=100
+  for a full battery
+*/
+bool AP_BattMonitor_Backend::reset_remaining(float percentage)
+{
+    percentage = constrain_float(percentage, 0, 100);
+    const float used_proportion = (100 - percentage) * 0.01;
+    _state.consumed_mah = used_proportion * _params._pack_capacity;
+    // without knowing the history we can't do consumed_wh
+    // accurately. Best estimate is based on current voltage. This
+    // will be good when resetting the battery to a value close to
+    // full charge
+    _state.consumed_wh = _state.consumed_mah * 1000 * _state.voltage;
+
+    return true;
+}

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -59,6 +59,9 @@ public:
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     bool arming_checks(char * buffer, size_t buflen) const;
 
+    // reset remaining percentage to given value
+    virtual bool reset_remaining(float percentage);
+
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
@@ -40,6 +40,9 @@ public:
     // bebop provides current info
     bool has_current() const override { return true; };
 
+    // don't allow reset of remaining capacity for bebop battery
+    bool reset_remaining(float percentage) override { return false; }
+
 private:
     float _prev_vbat_raw;
     float _prev_vbat;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -42,6 +42,9 @@ public:
     // all smart batteries are expected to provide current
     bool has_current() const override { return true; }
 
+    // don't allow reset of remaining capacity for SMBus
+    bool reset_remaining(float percentage) override { return false; }
+    
     void init(void) override;
 
 protected:

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -620,6 +620,7 @@ protected:
 
     MAV_RESULT handle_command_preflight_can(const mavlink_command_long_t &packet);
 
+    MAV_RESULT handle_command_battery_reset(const mavlink_command_long_t &packet);
     void handle_command_long(mavlink_message_t* msg);
     MAV_RESULT handle_command_accelcal_vehicle_pos(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_command_mount(const mavlink_command_long_t &packet);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3729,7 +3729,15 @@ MAV_RESULT GCS_MAVLINK::handle_command_preflight_can(const mavlink_command_long_
 #endif
 }
 
-
+MAV_RESULT GCS_MAVLINK::handle_command_battery_reset(const mavlink_command_long_t &packet)
+{
+    const uint16_t battery_mask = packet.param1;
+    const float percentage = packet.param2;
+    if (AP::battery().reset_remaining(battery_mask, percentage)) {
+        return MAV_RESULT_ACCEPTED;
+    }
+    return MAV_RESULT_FAILED;
+}
 
 MAV_RESULT GCS_MAVLINK::handle_command_mag_cal(const mavlink_command_long_t &packet)
 {
@@ -3922,6 +3930,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
         result = handle_command_preflight_calibration(packet);
         break;
 
+    case MAV_CMD_BATTERY_RESET:
+        result = handle_command_battery_reset(packet);
+        break;
+        
     case MAV_CMD_PREFLIGHT_UAVCAN:
         result = handle_command_preflight_can(packet);
         break;


### PR DESCRIPTION
This adds MAV_CMD_BATTERY_RESET which allows a GCS to reset the battery remaining percentage to a specified value. This is useful for battery swap before flight, or for fuel tank swap for jets
Uses mavlink PR 
https://github.com/ArduPilot/mavlink/pull/99