### PR TITLE
Fix builing bootloaders >1MB of flash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
   include:
     - if: type != cron
       compiler: "gcc"
-      env: CI_BUILD_TARGET="revo-bootloader iofirmware stm32f7 stm32h7 fmuv2-plane"
+      env: CI_BUILD_TARGET="revo-bootloader CubeOrange-bootloader iofirmware stm32f7 stm32h7 fmuv2-plane"
     - if: type != cron
       compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest-copter"

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -141,6 +141,10 @@ class Board:
                 '-O0',
             ]
 
+        if cfg.options.bootloader:
+            # don't let bootloaders try and pull scripting in
+            cfg.options.disable_scripting = True
+
         if cfg.options.enable_math_check_indexes:
             env.CXXFLAGS += ['-DMATH_CHECK_INDEXES']
 

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -93,6 +93,14 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "CubeOrange-bootloader" ]; then
+        echo "Building CubeOrange bootloader"
+        $waf configure --board CubeOrange --bootloader
+        $waf clean
+        $waf bootloader
+        continue
+    fi
+
     if [ "$t" == "stm32f7" ]; then
         echo "Building mRoX21-777/"
         $waf configure --board mRoX21-777


### PR DESCRIPTION
#11608 accidentally broke building bootloaders with > 1MB of flash, because the heap option was enabled in the bootloader, which is not something we need/want. This also includes a > 1MB bootloader as part of the CI run, to try and protect this in the future.