### PR TITLE
GCS_MAVLink: always show AHRS healthy with EKF type 10

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -169,5 +169,13 @@ void GCS::update_sensor_status_flags()
     }
     control_sensors_health |= MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS;
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (ahrs.get_ekf_type() == 10) {
+        // always show EKF type 10 as healthy. This prevents spurious error
+        // messages in xplane and other simulators that use EKF type 10
+        control_sensors_health |= MAV_SYS_STATUS_AHRS | MAV_SYS_STATUS_SENSOR_GPS | MAV_SYS_STATUS_SENSOR_3D_ACCEL | MAV_SYS_STATUS_SENSOR_3D_GYRO;
+    }
+#endif
+
     update_vehicle_sensor_status_flags();
 }


### PR DESCRIPTION
this fixes an issue noticed by Marco with xplane
ping @robustini 