### PR TITLE
GCS_Copter: Reset VISION_POSITION flag when visual_odom is enabled but not healthy

### DIFF
--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -135,7 +135,7 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
     }
 #endif
 #if PRECISION_LANDING == ENABLED
-    if (!copter.precland.enabled() || copter.precland.healthy()) {
+    if (copter.precland.enabled() && copter.precland.healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_VISION_POSITION;
     }
 #endif


### PR DESCRIPTION
This PR will add the ability to reset the flag [`MAV_SYS_STATUS_SENSOR_VISION_POSITION`](https://mavlink.io/en/messages/common.html#MAV_SYS_STATUS_SENSOR_VISION_POSITION) whenever the status returns from `visual_odom` is not healthy.

For my [ongoing project](https://discuss.ardupilot.org/t/gsoc-2019-integration-of-ardupilot-and-vio-tracking-camera-for-gps-less-localization-and-navigation/42394), the message `VISION_POSITION_ESTIMATE` is being used to transfer pose data from the [Intel Realsense T265](https://www.intelrealsense.com/tracking-camera-t265/) to ArduPilot. The T265 also reports tracking confidence level, which is useful to investigate the performance of the SLAM during development. For a lack of a dedicated message, I am using `VISION_POSITION_DELTA` message, specifically the field [`confidence`](https://mavlink.io/en/messages/ardupilotmega.html#VISION_POSITION_DELTA), to report the confidence level to GCS. 

I notice that the `Bad Vision Position` message, which can be used as an additional indicator that the system is running without looking at the terminal, only gets set but not reset if `visual_odom` returns unhealthy. Thus, the message is only displayed once at the beginning, after which it will not show up anymore even if the SLAM stops running. This PR attempts to fix that.