### PR TITLE
AP_Motors:Heli - Throttle metadata and default

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1341,11 +1341,14 @@ void Copter::convert_tradheli_parameters(void)
         }
     }
     const AP_Param::ConversionInfo allheli_conversion_info[] = {
-        { Parameters::k_param_motors, 1280, AP_PARAM_INT16, "H_RSC_CRV_000" },
-        { Parameters::k_param_motors, 1344, AP_PARAM_INT16, "H_RSC_CRV_025" },
-        { Parameters::k_param_motors, 1408, AP_PARAM_INT16, "H_RSC_CRV_050" },
-        { Parameters::k_param_motors, 1472, AP_PARAM_INT16, "H_RSC_CRV_075" },
-        { Parameters::k_param_motors, 1536, AP_PARAM_INT16, "H_RSC_CRV_100" },
+        { Parameters::k_param_motors, 1280, AP_PARAM_INT16, "H_RSC_THRCRV_0" },
+        { Parameters::k_param_motors, 1344, AP_PARAM_INT16, "H_RSC_THRCRV_25" },
+        { Parameters::k_param_motors, 1408, AP_PARAM_INT16, "H_RSC_THRCRV_50" },
+        { Parameters::k_param_motors, 1472, AP_PARAM_INT16, "H_RSC_THRCRV_75" },
+        { Parameters::k_param_motors, 1536, AP_PARAM_INT16, "H_RSC_THRCRV_100" },
+        { Parameters::k_param_motors, 448, AP_PARAM_INT16, "H_RSC_SETPOINT" },
+        { Parameters::k_param_motors, 768, AP_PARAM_INT16, "H_RSC_CRITICAL" },
+        { Parameters::k_param_motors, 832, AP_PARAM_INT16, "H_RSC_IDLE" },
     };
     // convert dual heli parameters without scaling
     uint8_t table_size = ARRAY_SIZE(allheli_conversion_info);

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -498,18 +498,3 @@ void AP_MotorsHeli::rc_write_swash(uint8_t chan, float swash_in)
     SRV_Channels::set_output_pwm_trimmed(function, pwm);
 }
 
-// enable_parameters - enables the rsc parameters for the rsc mode
-void AP_MotorsHeli::enable_rsc_parameters(void)
-{
-    if (_rsc_mode == (int8_t)ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT || _rsc_mode == (int8_t)ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
-        _rsc_thrcrv.set_thrcrv_enable(1);
-    } else {
-        _rsc_thrcrv.set_thrcrv_enable(0);
-    }
-    if (_rsc_mode == (int8_t)ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
-        _rsc_gov.set_gov_enable(1);
-    } else {
-        _rsc_gov.set_gov_enable(0);
-    }
-}
-

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -150,9 +150,9 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // indices 20 to 25 was throttle curve. Do not use this index in the future.
 
-    // @Group: RSC_CRV_
+    // @Group: RSC_THRCRV_
     // @Path: AP_MotorsHeli_RSC.cpp
-    AP_SUBGROUPINFO(_rsc_thrcrv, "RSC_CRV_", 27, AP_MotorsHeli, RSCThrCrvParam),
+    AP_SUBGROUPINFO(_rsc_thrcrv, "RSC_THRCRV_", 27, AP_MotorsHeli, RSCThrCrvParam),
 
     // @Group: RSC_GOV_
     // @Path: AP_MotorsHeli_RSC.cpp

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -20,15 +20,6 @@
 #define AP_MOTORS_HELI_COLLECTIVE_MAX           1750
 #define AP_MOTORS_HELI_COLLECTIVE_MID           1500
 
-// default main rotor speed (ch8 out) as a number from 0 ~ 1000
-#define AP_MOTORS_HELI_RSC_SETPOINT             70
-
-// default main rotor critical speed
-#define AP_MOTORS_HELI_RSC_CRITICAL             50
-
-// RSC output defaults
-#define AP_MOTORS_HELI_RSC_IDLE_DEFAULT         0
-
 // default main rotor ramp up time in seconds
 #define AP_MOTORS_HELI_RSC_RAMP_TIME            1       // 1 second to ramp output to main rotor ESC to setpoint
 #define AP_MOTORS_HELI_RSC_RUNUP_TIME           10      // 10 seconds for rotor to reach full speed
@@ -87,7 +78,7 @@ public:
     uint8_t get_rsc_mode() const { return _rsc_mode; }
 
     // get_rsc_setpoint - gets contents of _rsc_setpoint parameter (0~1)
-    float get_rsc_setpoint() const { return _rsc_setpoint * 0.01f; }
+    float get_rsc_setpoint() const { return _rsc.get_setpoint() * 0.01f; }
     
     // set_rpm - for rotor speed governor
     virtual void set_rpm(float rotor_rpm) = 0;
@@ -150,6 +141,7 @@ protected:
 
     RSCThrCrvParam   _rsc_thrcrv;
     RSCGovParam      _rsc_gov;
+    RSCParam         _rsc;
 
     // output - sends commands to the motors
     void output_armed_stabilizing() override;
@@ -207,12 +199,9 @@ protected:
     AP_Int16        _collective_max;            // Highest possible servo position for the swashplate
     AP_Int16        _collective_mid;            // Swash servo position corresponding to zero collective pitch (or zero lift for Asymmetrical blades)
     AP_Int8         _servo_mode;                // Pass radio inputs directly to servos during set-up through mission planner
-    AP_Int16        _rsc_setpoint;              // Electric ESC governor throttle setting
     AP_Int8         _rsc_mode;                  // Method of throttle control used
     AP_Int8         _rsc_ramp_time;             // Time in seconds to ramp throttle from ground idle to flight idle
     AP_Int8         _rsc_runup_time;            // Time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
-    AP_Int16        _rsc_critical;              // Rotor speed below which autorotation is no longer possible
-    AP_Int16        _rsc_idle_output;           // Combustion engine idle speed setting
     AP_Int16        _rsc_slewrate;              // throttle slew rate (percentage per second)
     AP_Int8         _servo_test;                // sets number of cycles to test servo movement on bootup
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -21,10 +21,10 @@
 #define AP_MOTORS_HELI_COLLECTIVE_MID           1500
 
 // default main rotor speed (ch8 out) as a number from 0 ~ 1000
-#define AP_MOTORS_HELI_RSC_SETPOINT             700
+#define AP_MOTORS_HELI_RSC_SETPOINT             70
 
 // default main rotor critical speed
-#define AP_MOTORS_HELI_RSC_CRITICAL             500
+#define AP_MOTORS_HELI_RSC_CRITICAL             50
 
 // RSC output defaults
 #define AP_MOTORS_HELI_RSC_IDLE_DEFAULT         0
@@ -87,7 +87,7 @@ public:
     uint8_t get_rsc_mode() const { return _rsc_mode; }
 
     // get_rsc_setpoint - gets contents of _rsc_setpoint parameter (0~1)
-    float get_rsc_setpoint() const { return _rsc_setpoint * 0.001f; }
+    float get_rsc_setpoint() const { return _rsc_setpoint * 0.01f; }
     
     // set_rpm - for rotor speed governor
     virtual void set_rpm(float rotor_rpm) = 0;
@@ -210,12 +210,12 @@ protected:
     AP_Int16        _collective_max;            // Highest possible servo position for the swashplate
     AP_Int16        _collective_mid;            // Swash servo position corresponding to zero collective pitch (or zero lift for Asymmetrical blades)
     AP_Int8         _servo_mode;                // Pass radio inputs directly to servos during set-up through mission planner
-    AP_Int16        _rsc_setpoint;              // rotor speed when RSC mode is set to is enabled
-    AP_Int8         _rsc_mode;                  // Which main rotor ESC control mode is active
-    AP_Int8         _rsc_ramp_time;             // Time in seconds for the output to the main rotor's ESC to reach setpoint
+    AP_Int16        _rsc_setpoint;              // Electric ESC governor throttle setting
+    AP_Int8         _rsc_mode;                  // Method of throttle control used
+    AP_Int8         _rsc_ramp_time;             // Time in seconds to ramp throttle from ground idle to flight idle
     AP_Int8         _rsc_runup_time;            // Time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
-    AP_Int16        _rsc_critical;              // Rotor speed below which flight is not possible
-    AP_Int16        _rsc_idle_output;           // Rotor control output while at idle
+    AP_Int16        _rsc_critical;              // Rotor speed below which autorotation is no longer possible
+    AP_Int16        _rsc_idle_output;           // Combustion engine idle speed setting
     AP_Int16        _rsc_slewrate;              // throttle slew rate (percentage per second)
     AP_Int8         _servo_test;                // sets number of cycles to test servo movement on bootup
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -133,9 +133,6 @@ public:
     // support passing init_targets_on_arming flag to greater code
     bool init_targets_on_arming() const { return _heliflags.init_targets_on_arming; }
 
-    void enable_rsc_parameters(void);
-
-
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -221,6 +221,7 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
     _rotor.set_critical_speed(_rsc.get_critical()*0.01f);
     _rotor.set_idle_output(_rsc.get_idle_output()*0.01f);
     _rotor.set_slewrate(_rsc_slewrate);
+    _rotor.set_rpm_reference(_rsc.get_rpm_reference());
 
     // Set rsc mode specific parameters
     if (_rsc_mode == ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT) {
@@ -229,7 +230,6 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
         _rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
         _rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
         _rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
-        _rotor.set_governor_reference(_rsc_gov.get_reference());
         _rotor.set_governor_range(_rsc_gov.get_range());
         _rotor.set_governor_tcgain(_rsc_gov.get_tcgain()*0.01f);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -218,8 +218,8 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
     // Set common RSC variables
     _rotor.set_ramp_time(_rsc_ramp_time);
     _rotor.set_runup_time(_rsc_runup_time);
-    _rotor.set_critical_speed(_rsc_critical*0.01f);
-    _rotor.set_idle_output(_rsc_idle_output*0.01f);
+    _rotor.set_critical_speed(_rsc.get_critical()*0.01f);
+    _rotor.set_idle_output(_rsc.get_idle_output()*0.01f);
     _rotor.set_slewrate(_rsc_slewrate);
 
     // Set rsc mode specific parameters

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -218,8 +218,8 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
     // Set common RSC variables
     _rotor.set_ramp_time(_rsc_ramp_time);
     _rotor.set_runup_time(_rsc_runup_time);
-    _rotor.set_critical_speed(_rsc_critical*0.001f);
-    _rotor.set_idle_output(_rsc_idle_output*0.001f);
+    _rotor.set_critical_speed(_rsc_critical*0.01f);
+    _rotor.set_idle_output(_rsc_idle_output*0.01f);
     _rotor.set_slewrate(_rsc_slewrate);
 
     // Set rsc mode specific parameters

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -268,7 +268,6 @@ void AP_MotorsHeli_Dual::calculate_scalars()
 
     // set mode of main rotor controller and trigger recalculation of scalars
     _rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
-    enable_rsc_parameters();
     calculate_armed_scalars();
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -231,7 +231,7 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
         _rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
         _rotor.set_governor_reference(_rsc_gov.get_reference());
         _rotor.set_governor_range(_rsc_gov.get_range());
-        _rotor.set_governor_thrcurve(_rsc_gov.get_thrcurve()*0.01f);
+        _rotor.set_governor_tcgain(_rsc_gov.get_tcgain()*0.01f);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -111,6 +111,7 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
     _rotor.set_critical_speed(_rsc.get_critical()*0.01f);
     _rotor.set_idle_output(_rsc.get_idle_output()*0.01f);
     _rotor.set_slewrate(_rsc_slewrate);
+    _rotor.set_rpm_reference(_rsc.get_rpm_reference());
 
     // Set rsc mode specific parameters
     if (_rsc_mode == ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT) {
@@ -119,7 +120,6 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
         _rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
         _rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
         _rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
-        _rotor.set_governor_reference(_rsc_gov.get_reference());
         _rotor.set_governor_range(_rsc_gov.get_range());
         _rotor.set_governor_tcgain(_rsc_gov.get_tcgain()*0.01f);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -108,8 +108,8 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
     // Set common RSC variables
     _rotor.set_ramp_time(_rsc_ramp_time);
     _rotor.set_runup_time(_rsc_runup_time);
-    _rotor.set_critical_speed(_rsc_critical*0.01f);
-    _rotor.set_idle_output(_rsc_idle_output*0.01f);
+    _rotor.set_critical_speed(_rsc.get_critical()*0.01f);
+    _rotor.set_idle_output(_rsc.get_idle_output()*0.01f);
     _rotor.set_slewrate(_rsc_slewrate);
 
     // Set rsc mode specific parameters

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -121,7 +121,7 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
         _rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
         _rotor.set_governor_reference(_rsc_gov.get_reference());
         _rotor.set_governor_range(_rsc_gov.get_range());
-        _rotor.set_governor_thrcurve(_rsc_gov.get_thrcurve()*0.01f);
+        _rotor.set_governor_tcgain(_rsc_gov.get_tcgain()*0.01f);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -108,8 +108,8 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
     // Set common RSC variables
     _rotor.set_ramp_time(_rsc_ramp_time);
     _rotor.set_runup_time(_rsc_runup_time);
-    _rotor.set_critical_speed(_rsc_critical*0.001f);
-    _rotor.set_idle_output(_rsc_idle_output*0.001f);
+    _rotor.set_critical_speed(_rsc_critical*0.01f);
+    _rotor.set_idle_output(_rsc_idle_output*0.01f);
     _rotor.set_slewrate(_rsc_slewrate);
 
     // Set rsc mode specific parameters

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -144,7 +144,6 @@ void AP_MotorsHeli_Quad::calculate_scalars()
 
     // set mode of main rotor controller and trigger recalculation of scalars
     _rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
-    enable_rsc_parameters();
     calculate_armed_scalars();
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -20,6 +20,38 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_Param::GroupInfo RSCParam::var_info[] = {
+
+    // @Param: SETPOINT
+    // @DisplayName: Electric ESC Throttle Setting
+    // @Description: Throttle signal percent for electric helicopters when a governor is used in the ESC
+    // @Range: 0 100
+    // @Units: %
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("SETPOINT", 1, RSCParam, setpoint, AP_MOTORS_HELI_RSC_SETPOINT),
+
+    // @Param: CRITICAL
+    // @DisplayName: Critical Rotor Speed
+    // @Description: Percentage of normal rotor speed where entry to autorotation becomes dangerous. For helicopters with rotor speed sensor should be set to the percentage of the governor rpm setting used. Even if governor is not used when a speed sensor is installed, set the governor rpm to normal headspeed then set critical to a percentage of normal rpm (usually 90%). This can be considered the bottom of the green arc for autorotation. For helicopters without speed sensor should be set to the throttle percentage where flight is no longer possible. With no speed sensor critical should be lower than electric ESC throttle setting for ESC's with governor, or lower than normal in-flight throttle percentage when the throttle curve or RC Passthru is used.
+    // @Range: 0 100
+    // @Units: %
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("CRITICAL", 2, RSCParam, critical, AP_MOTORS_HELI_RSC_CRITICAL),
+
+    // @Param: IDLE
+    // @DisplayName: Engine Ground Idle Setting
+    // @Description: FOR COMBUSTION ENGINES. Sets the engine ground idle throttle percentage with clutch disengaged. This must be set to zero for electric helicopters under most situations. If the ESC has an autorotation window this can be set to keep the autorotation window open in the ESC. Consult the operating manual for your ESC to set it properly for this purpose
+    // @Range: 0 50
+    // @Units: %
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("IDLE", 3, RSCParam, idle_output, AP_MOTORS_HELI_RSC_IDLE_DEFAULT),
+
+    AP_GROUPEND
+};
+
 const AP_Param::GroupInfo RSCThrCrvParam::var_info[] = {
 
 // enable param removed
@@ -116,6 +148,11 @@ const AP_Param::GroupInfo RSCGovParam::var_info[] = {
 
     AP_GROUPEND
 };
+
+RSCParam::RSCParam(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
 
 RSCThrCrvParam::RSCThrCrvParam(void)
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -351,7 +351,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     // runup complete based on actual measured rotor speed or runup scalar
     if (!_runup_complete) {
         // if rotor speed sensor is present runup is complete when rotor reaches actual critical speed
-        if ((_rpm_sensor = true) && (_rotor_rpm > (_governor_reference * _critical_speed))) {
+        if (_rpm_sensor && (_rotor_rpm > (_governor_reference * _critical_speed))) {
             _runup_complete = true;
         // if no rotor speed sensor installed _runup_complete is determined by runup timer
         } else if ((_rotor_ramp_output >= 1.0f) && (_rotor_runup_output >= 1.0f)) {
@@ -360,7 +360,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     }
     // if rotor speed is less than critical speed, then run-up is not complete
     if (_runup_complete) {
-        if ((_rpm_sensor = true) && (_rotor_rpm <= (_governor_reference * _critical_speed))) {
+        if (_rpm_sensor && (_rotor_rpm <= (_governor_reference * _critical_speed))) {
             _runup_complete = false;
         } else if (get_rotor_speed() <= _critical_speed) {
             _runup_complete = false;

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -25,40 +25,40 @@ const AP_Param::GroupInfo RSCThrCrvParam::var_info[] = {
 // enable param removed
 
     // @Param: 0
-    // @DisplayName: Throttle Servo Position in percent for 0 percent collective
-    // @Description: Throttle Servo Position in percent for 0 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @DisplayName: Throttle at 0% collective
+    // @Description: Sets the engine's throttle percent for the throttle curve with the swashplate all the way to its maximum negative collective pitch position
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("0", 2, RSCThrCrvParam, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
 
     // @Param: 25
-    // @DisplayName: Throttle Servo Position in percent for 25 percent collective
-    // @Description: Throttle Servo Position in percent for 25 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @DisplayName: Throttle at 25% collective
+    // @Description: Sets the engine's throttle percent for the throttle curve with the swashplate at 25% of it's full collective travel.This may or may not correspond to 25% position of the collective stick, depending on the range of negative pitch in the setup. Example: if the setup has -2 degree to +10 degree collective pitch setup, the total range is 12 degrees. 25% of 12 degrees is 3 degrees, so this setting would correspond to +1 degree of positive pitch.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("25", 3, RSCThrCrvParam, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
 
     // @Param: 50
-    // @DisplayName: Throttle Servo Position in percent for 50 percent collective
-    // @Description: Throttle Servo Position in percent for 50 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @DisplayName: Throttle at 50% collective
+    // @Description: Sets the engine's throttle percent for the throttle curve with the swashplate at 50% of it's full collective travel.This may or may not correspond to 50% position of the collective stick, depending on the range of negative pitch in the setup. Example: if the setup has -2 degree to +10 degree collective pitch setup, the total range is 12 degrees. 50% of 12 degrees is 6 degrees, so this setting would correspond to +4 degrees of positive pitch.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("50", 4, RSCThrCrvParam, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
 
     // @Param: 75
-    // @DisplayName: Throttle Servo Position in percent for 75 percent collective
-    // @Description: Throttle Servo Position in percent for 75 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @DisplayName: Throttle at 75% collective
+    // @Description: Sets the engine's throttle percent for the throttle curve with the swashplate at 75% of it's full collective travel.This may or may not correspond to 75% position of the collective stick, depending on the range of negative pitch in the setup. Example: if the setup has -2 degree to +10 degree collective pitch setup, the total range is 12 degrees. 75% of 12 degrees is 9 degrees, so this setting would correspond to +7 degrees of positive pitch.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("75", 5, RSCThrCrvParam, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
 
     // @Param: 100
-    // @DisplayName: Throttle Servo Position in percent for 100 percent collective
-    // @Description: Throttle Servo Position in percent for 100 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @DisplayName: Throttle at 100% collective
+    // @Description: Sets the engine's throttle percent for the throttle curve with the swashplate at 100% of it's full collective travel, which is maximum positive pitch.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -81,7 +81,7 @@ const AP_Param::GroupInfo RSCGovParam::var_info[] = {
 
     // @Param: DISGAG
     // @DisplayName: Throttle Percentage for Governor Disengage
-    // @Description: Percentage of throttle where the governor will disenage to allow return to flight idle power. Typically should be set to a value slightly below flight idle throttle. The governor disengage can be disabled by setting this value to zero, requiring throttle hold to shut down the governor
+    // @Description: Percentage of throttle where the governor will disengage to allow return to flight idle power. Typically should be set to the same value as flight idle throttle (the very lowest throttle setting on your throttle curve). The governor disengage can be disabled by setting this value to zero and using the pull-down from the governor TCGAIN to reduce power to flight idle with the collective at it's lowest throttle setting on the throttle curve.
     // @Range: 0 50
     // @Units: %
     // @Increment: 1
@@ -99,7 +99,7 @@ const AP_Param::GroupInfo RSCGovParam::var_info[] = {
 
     // @Param: TCGAIN
     // @DisplayName: Governor Throttle Curve Gain
-    // @Description: Percentage of throttle curve gain in governor output. This provides a type of feedforward response to sudden loading or unloading of the engine. If headspeed drops excessively during sudden heavy load, increase the throttle curve gain. If the governor runs with excessive droop more than 15 rpm lower than the speed setting, increase this setting until the governor runs at 8-10 rpm droop from the speed setting. The throttle curve must be properly tuned to fly the helicopter without the governor for this setting will work properly
+    // @Description: Percentage of throttle curve gain in governor output. This provides a type of feedforward response to sudden loading or unloading of the engine. If headspeed drops excessively during sudden heavy load, increase the throttle curve gain. If the governor runs with excessive droop more than 15 rpm lower than the speed setting, increase this setting until the governor runs at 8-10 rpm droop from the speed setting. The throttle curve must be properly tuned to fly the helicopter without the governor for this setting to work properly
     // @Range: 50 100
     // @Units: %
     // @Increment: 1

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -24,37 +24,37 @@ const AP_Param::GroupInfo RSCThrCrvParam::var_info[] = {
 
 // enable param removed
 
-    // @Param: 000
+    // @Param: 0
     // @DisplayName: Throttle Servo Position in percent for 0 percent collective
     // @Description: Throttle Servo Position in percent for 0 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("000", 2, RSCThrCrvParam, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
+    AP_GROUPINFO("0", 2, RSCThrCrvParam, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
 
-    // @Param: 025
+    // @Param: 25
     // @DisplayName: Throttle Servo Position in percent for 25 percent collective
     // @Description: Throttle Servo Position in percent for 25 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("025", 3, RSCThrCrvParam, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
+    AP_GROUPINFO("25", 3, RSCThrCrvParam, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
 
-    // @Param: 050
+    // @Param: 50
     // @DisplayName: Throttle Servo Position in percent for 50 percent collective
     // @Description: Throttle Servo Position in percent for 50 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("050", 4, RSCThrCrvParam, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
+    AP_GROUPINFO("50", 4, RSCThrCrvParam, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
 
-    // @Param: 075
+    // @Param: 75
     // @DisplayName: Throttle Servo Position in percent for 75 percent collective
     // @Description: Throttle Servo Position in percent for 75 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("075", 5, RSCThrCrvParam, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
+    AP_GROUPINFO("75", 5, RSCThrCrvParam, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
 
     // @Param: 100
     // @DisplayName: Throttle Servo Position in percent for 100 percent collective

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -22,12 +22,7 @@ extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo RSCThrCrvParam::var_info[] = {
 
-    // @Param: ENABLE
-    // @DisplayName: Enable settings for RSC Setpoint
-    // @Description: Automatically set when RSC Setpoint mode is selected. Should not be set manually.
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCThrCrvParam, enable, 0, AP_PARAM_FLAG_ENABLE),
+// enable param removed
 
     // @Param: 000
     // @DisplayName: Throttle Servo Position in percent for 0 percent collective
@@ -74,12 +69,7 @@ const AP_Param::GroupInfo RSCThrCrvParam::var_info[] = {
 
 const AP_Param::GroupInfo RSCGovParam::var_info[] = {
 
-    // @Param: ENABLE
-    // @DisplayName: Enable settings for RSC Governor
-    // @Description: Automatically set when RSC Governor mode is selected. Should not be set manually.
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCGovParam, enable, 0, AP_PARAM_FLAG_ENABLE),
+// enable parameter removed
 
     // @Param: SETPNT
     // @DisplayName: Governor RPM Reference Setting

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -5,14 +5,11 @@
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
 
-// default main rotor speed (ch8 out) as a number from 0 ~ 100
+// General RSC Defaults
 #define AP_MOTORS_HELI_RSC_SETPOINT             70
-
-// default main rotor critical speed
 #define AP_MOTORS_HELI_RSC_CRITICAL             50
-
-// RSC output defaults
 #define AP_MOTORS_HELI_RSC_IDLE_DEFAULT         0
+#define AP_MOTORS_HELI_RSC_HEADSPEED_DEFAULT    1500
 
 // Throttle Curve Defaults
 #define AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT     25
@@ -22,7 +19,6 @@
 #define AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT   100
 
 // RSC governor defaults
-#define AP_MOTORS_HELI_RSC_GOVERNOR_SETPNT_DEFAULT    1500
 #define AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE_DEFAULT 25
 #define AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT     30
 #define AP_MOTORS_HELI_RSC_GOVERNOR_TCGAIN_DEFAULT    90
@@ -76,7 +72,7 @@ public:
     void        set_governor_disengage(float governor_disengage) {_governor_disengage = governor_disengage; }
     void        set_governor_droop_response(float governor_droop_response) { _governor_droop_response = governor_droop_response; }
     void        set_governor_output(float governor_output) {_governor_output = governor_output; }
-    void        set_governor_reference(float governor_reference) { _governor_reference = governor_reference; }
+    void        set_rpm_reference(float rpm_reference) { _rpm_reference = rpm_reference; }
     void        set_governor_range(float governor_range) { _governor_range = governor_range; }
     void        set_governor_tcgain(float governor_tcgain) {_governor_tcgain = governor_tcgain; }
 
@@ -134,6 +130,7 @@ private:
     float           _control_output;              // latest logic controlled output
     float           _rotor_ramp_output;           // scalar used to ramp rotor speed between _rsc_idle_output and full speed (0.0-1.0f)
     float           _rotor_runup_output;          // scalar used to store status of rotor run-up time (0.0-1.0f)
+    float           _rpm_reference;               // sets rotor rpm reference for governor, runup_complete, autorotation
     bool            _rpm_sensor;                  // flag to determine if rpm sensor is used
     int8_t          _ramp_time;                   // time in seconds for the output to the main rotor's ESC to reach full speed
     int8_t          _runup_time;                  // time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
@@ -145,7 +142,6 @@ private:
     float           _governor_disengage;          // throttle percentage where governor disenages to allow return to flight idle
     float           _governor_output;             // governor output for rotor speed control
     float           _governor_range;              // RPM range +/- governor rpm reference setting where governor is operational
-    float           _governor_reference;          // sets rotor speed for governor
     float           _governor_droop_response;     // governor response to droop under load
     bool            _governor_engage;             // RSC governor status flag for soft-start
     float           _governor_tcgain;             // governor throttle curve gain, range 50-100%
@@ -173,11 +169,13 @@ public:
     float get_setpoint() const { return setpoint; }
     float get_critical() const { return critical; }
     float get_idle_output() const { return idle_output; }
+    int16_t get_rpm_reference() { return rpm_reference; }
 
 private:
     AP_Int16        setpoint;              // Electric ESC governor throttle setting
     AP_Int16        critical;              // Rotor speed below which autorotation is no longer possible
     AP_Int16        idle_output;           // Combustion engine idle speed setting
+    AP_Int16        rpm_reference;         // sets the headspeed reference for governor, runup_complete, autorotation
 
 };
 
@@ -206,14 +204,12 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    int16_t get_reference() { return reference; }
     float get_range() { return range; }
     float get_disengage() { return disengage; }
     float get_droop_response() { return droop_response; }
     float get_tcgain() { return tcgain; }
 
 private:
-    AP_Int16  reference;      // sets rotor speed for governor
     AP_Float  range;          // RPM range +/- governor rpm reference setting where governor is operational
     AP_Float  disengage;      // sets the throttle percent where the governor disengages for return to flight idle
     AP_Float  droop_response; // governor response to droop under load

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -5,6 +5,15 @@
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
 
+// default main rotor speed (ch8 out) as a number from 0 ~ 100
+#define AP_MOTORS_HELI_RSC_SETPOINT             70
+
+// default main rotor critical speed
+#define AP_MOTORS_HELI_RSC_CRITICAL             50
+
+// RSC output defaults
+#define AP_MOTORS_HELI_RSC_IDLE_DEFAULT         0
+
 // Throttle Curve Defaults
 #define AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT     25
 #define AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT    32
@@ -152,6 +161,24 @@ private:
 
     // calculate_desired_throttle - uses throttle curve and collective input to determine throttle setting
     float           calculate_desired_throttle(float collective_in);
+};
+
+
+class RSCParam {
+public:
+    RSCParam(void);
+
+    static struct AP_Param::GroupInfo var_info[];
+
+    float get_setpoint() const { return setpoint; }
+    float get_critical() const { return critical; }
+    float get_idle_output() const { return idle_output; }
+
+private:
+    AP_Int16        setpoint;              // Electric ESC governor throttle setting
+    AP_Int16        critical;              // Rotor speed below which autorotation is no longer possible
+    AP_Int16        idle_output;           // Combustion engine idle speed setting
+
 };
 
 class RSCThrCrvParam {

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -160,7 +160,6 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    void set_thrcrv_enable(int8_t setenable) {enable = setenable; }
     float * get_thrcrv() {
         static float throttlecurve[5];
         for (uint8_t i = 0; i < 5; i++) {
@@ -170,7 +169,6 @@ public:
     }
 
 private:
-    AP_Int8   enable;
     AP_Int16  thrcrv[5]; // throttle value sent to throttle servo at 0, 25, 50, 75 and 100 percent collective
 
 };
@@ -181,7 +179,6 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    void set_gov_enable(int8_t setenable) {enable = setenable; }
     int16_t get_reference() { return reference; }
     float get_range() { return range; }
     float get_disengage() { return disengage; }
@@ -189,7 +186,6 @@ public:
     float get_thrcurve() { return thrcurve; }
 
 private:
-    AP_Int8   enable;
     AP_Int16  reference;      // sets rotor speed for governor
     AP_Float  range;          // RPM range +/- governor rpm reference setting where governor is operational
     AP_Float  disengage;      // sets the throttle percent where the governor disengages for return to flight idle

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -125,6 +125,7 @@ private:
     float           _control_output;              // latest logic controlled output
     float           _rotor_ramp_output;           // scalar used to ramp rotor speed between _rsc_idle_output and full speed (0.0-1.0f)
     float           _rotor_runup_output;          // scalar used to store status of rotor run-up time (0.0-1.0f)
+    bool            _rpm_sensor;                  // flag to determine if rpm sensor is used
     int8_t          _ramp_time;                   // time in seconds for the output to the main rotor's ESC to reach full speed
     int8_t          _runup_time;                  // time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
     bool            _runup_complete;              // flag for determining if runup is complete

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -16,7 +16,7 @@
 #define AP_MOTORS_HELI_RSC_GOVERNOR_SETPNT_DEFAULT    1500
 #define AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE_DEFAULT 25
 #define AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT     30
-#define AP_MOTORS_HELI_RSC_GOVERNOR_THRCURVE_DEFAULT  90
+#define AP_MOTORS_HELI_RSC_GOVERNOR_TCGAIN_DEFAULT    90
 #define AP_MOTORS_HELI_RSC_GOVERNOR_RANGE_DEFAULT     100
 
 // rotor controller states
@@ -69,7 +69,7 @@ public:
     void        set_governor_output(float governor_output) {_governor_output = governor_output; }
     void        set_governor_reference(float governor_reference) { _governor_reference = governor_reference; }
     void        set_governor_range(float governor_range) { _governor_range = governor_range; }
-    void        set_governor_thrcurve(float governor_thrcurve) {_governor_thrcurve = governor_thrcurve; }
+    void        set_governor_tcgain(float governor_tcgain) {_governor_tcgain = governor_tcgain; }
 
     // get_desired_speed
     float       get_desired_speed() const { return _desired_speed; }
@@ -139,7 +139,7 @@ private:
     float           _governor_reference;          // sets rotor speed for governor
     float           _governor_droop_response;     // governor response to droop under load
     bool            _governor_engage;             // RSC governor status flag for soft-start
-    float           _governor_thrcurve;           // governor throttle curve gain, range 50-100%
+    float           _governor_tcgain;             // governor throttle curve gain, range 50-100%
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);
@@ -183,13 +183,13 @@ public:
     float get_range() { return range; }
     float get_disengage() { return disengage; }
     float get_droop_response() { return droop_response; }
-    float get_thrcurve() { return thrcurve; }
+    float get_tcgain() { return tcgain; }
 
 private:
     AP_Int16  reference;      // sets rotor speed for governor
     AP_Float  range;          // RPM range +/- governor rpm reference setting where governor is operational
     AP_Float  disengage;      // sets the throttle percent where the governor disengages for return to flight idle
     AP_Float  droop_response; // governor response to droop under load
-    AP_Float  thrcurve;       // governor throttle curve weighting, range 50-100%
+    AP_Float  tcgain;       // governor throttle curve weighting, range 50-100%
 
 };

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -224,6 +224,7 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
     _main_rotor.set_critical_speed(_rsc.get_critical()*0.01f);
     _main_rotor.set_idle_output(_rsc.get_idle_output()*0.01f);
     _main_rotor.set_slewrate(_rsc_slewrate);
+    _main_rotor.set_rpm_reference(_rsc.get_rpm_reference());
 
     // Set rsc mode specific parameters
     if (_rsc_mode == ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT) {
@@ -232,7 +233,6 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
         _main_rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
         _main_rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
         _main_rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
-        _main_rotor.set_governor_reference(_rsc_gov.get_reference());
         _main_rotor.set_governor_range(_rsc_gov.get_range());
         _main_rotor.set_governor_tcgain(_rsc_gov.get_tcgain()*0.01f);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -221,8 +221,8 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
     // Set common RSC variables
     _main_rotor.set_ramp_time(_rsc_ramp_time);
     _main_rotor.set_runup_time(_rsc_runup_time);
-    _main_rotor.set_critical_speed(_rsc_critical*0.01f);
-    _main_rotor.set_idle_output(_rsc_idle_output*0.01f);
+    _main_rotor.set_critical_speed(_rsc.get_critical()*0.01f);
+    _main_rotor.set_idle_output(_rsc.get_idle_output()*0.01f);
     _main_rotor.set_slewrate(_rsc_slewrate);
 
     // Set rsc mode specific parameters
@@ -264,8 +264,8 @@ void AP_MotorsHeli_Single::calculate_scalars()
         _tail_rotor.set_control_mode(ROTOR_CONTROL_MODE_SPEED_SETPOINT);
         _tail_rotor.set_ramp_time(_rsc_ramp_time);
         _tail_rotor.set_runup_time(_rsc_runup_time);
-        _tail_rotor.set_critical_speed(_rsc_critical*0.01f);
-        _tail_rotor.set_idle_output(_rsc_idle_output*0.01f);
+        _tail_rotor.set_critical_speed(_rsc.get_critical()*0.01f);
+        _tail_rotor.set_idle_output(_rsc.get_idle_output()*0.01f);
     } else {
         _tail_rotor.set_control_mode(ROTOR_CONTROL_MODE_DISABLED);
         _tail_rotor.set_ramp_time(0);

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -257,7 +257,6 @@ void AP_MotorsHeli_Single::calculate_scalars()
 
     // send setpoints to main rotor controller and trigger recalculation of scalars
     _main_rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
-    enable_rsc_parameters();
     calculate_armed_scalars();
 
     // send setpoints to DDVP rotor controller and trigger recalculation of scalars

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -234,7 +234,7 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
         _main_rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
         _main_rotor.set_governor_reference(_rsc_gov.get_reference());
         _main_rotor.set_governor_range(_rsc_gov.get_range());
-        _main_rotor.set_governor_thrcurve(_rsc_gov.get_thrcurve()*0.01f);
+        _main_rotor.set_governor_tcgain(_rsc_gov.get_tcgain()*0.01f);
     }
 }
 
@@ -539,7 +539,7 @@ bool AP_MotorsHeli_Single::parameter_check(bool display_msg) const
     // returns false if DDVP tail throttle setting is over 100%
     if (_direct_drive_tailspeed > 100.0f){
         if (display_msg) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Tail throttle setting over 100 percent");
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: DDVP throttle over 100 percent");
         }
         return false;
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -21,7 +21,7 @@
 #define AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_FIXEDPITCH  3
 
 // direct-drive variable pitch defaults
-#define AP_MOTORS_HELI_SINGLE_DDVP_SPEED_DEFAULT               500
+#define AP_MOTORS_HELI_SINGLE_DDVP_SPEED_DEFAULT               50
 
 // default external gyro gain
 #define AP_MOTORS_HELI_SINGLE_EXT_GYRO_GAIN                    350
@@ -146,7 +146,7 @@ protected:
     AP_Int16        _ext_gyro_gain_acro;        // PWM sent to external gyro on ch7 when tail type is Servo w/ ExtGyro in ACRO
     AP_Float        _collective_yaw_effect;     // Feed-forward compensation to automatically add rudder input when collective pitch is increased. Can be positive or negative depending on mechanics.
     AP_Int8         _flybar_mode;               // Flybar present or not.  Affects attitude controller used during ACRO flight mode
-    AP_Int16        _direct_drive_tailspeed;    // Direct Drive VarPitch Tail ESC speed (0 ~ 1000)
+    AP_Int16        _direct_drive_tailspeed;    // Direct Drive VarPitch tail throttle setting, 0-100%
 
     bool            _acro_tail = false;
 };

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -25,7 +25,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Swashplate Type
     // @Description: H3 is generic, three-servo only. H3_120/H3_140 plates have Motor1 left side, Motor2 right side, Motor3 elevator in rear. HR3_120/HR3_140 have Motor1 right side, Motor2 left side, Motor3 elevator in front - use H3_120/H3_140 and reverse servo and collective directions as necessary. For all H3_90 swashplates use H4_90 and don't use servo output for the missing servo. For H4-90 Motors1&2 are left/right respectively, Motors3&4 are rear/front respectively. For H4-45 Motors1&2 are LF/RF, Motors3&4 are LR/RR 
-    // @Values: 0:H3 Generic, 1:H1 non-CPPM, 2:H3_140, 3:H3_120, 4:H4_90, 5:H4_45
+    // @Values: 0:H3 Generic,1:H1 non-CPPM,2:H3_140,3:H3_120,4:H4_90,5:H4_45
     // @User: Standard
     AP_GROUPINFO("TYPE", 1, AP_MotorsHeli_Swash, _swashplate_type, SWASHPLATE_TYPE_H3),
 


### PR DESCRIPTION
1) This changes all throttle related settings to 0-100% to be consistent with the throttle curve.
2) Improves metadata descriptions and throttle control default for next-gen heli setup page in GCS.
3) Adjusts description and prepares function of RSC_CRITICAL for use with or without rotor speed sensor to determine runup_complete, and to reflect function of upcoming autorotation code.

