### PR TITLE
AP_HAL_ChibiOS: fix voltage sensor connected to fmu adc

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -298,6 +298,11 @@ void AnalogIn::_timer_tick(void)
             _board_voltage = buf_adc[i] * pin_config[i].scaling;
         }
 #endif
+#ifdef FMU_SERVORAIL_ADC_CHAN
+        if (pin_config[i].channel == FMU_SERVORAIL_ADC_CHAN) {
+           _servorail_voltage = buf_adc[i] * pin_config[i].scaling;
+        }
+#endif
     }
 
 #if HAL_WITH_IO_MCU

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1204,6 +1204,9 @@ def write_ADC_config(f):
         if p.label == 'VDD_5V_SENS':
             f.write('#define ANALOG_VCC_5V_PIN %u\n' % chan)
             f.write('#define HAL_HAVE_BOARD_VOLTAGE 1\n')
+        if p.label == 'FMU_SERVORAIL_VCC_SENS':
+            f.write('#define FMU_SERVORAIL_ADC_CHAN %u\n' % chan)
+            f.write('#define HAL_HAVE_SERVO_VOLTAGE 1\n')
         adc_chans.append((chan, scale, p.label, p.portpin))
     adc_chans = sorted(adc_chans)
     vdd = get_config('STM32_VDD')


### PR DESCRIPTION
fix  issue "The FlightController "F4BY" don‘t have SERVORAIL_VCC_SENS #11409"
https://github.com/ArduPilot/ardupilot/issues/11409

use FMU adc for measure servo rail voltage for chibios boards

Example  of configuration 
https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/F4BY/hwdef.dat#L163

tests: compiled, uploaded to board, checked servo voltage mavlink data