### PR TITLE
AC_Avoidance: fix Dijkstra's iteration through polygon fence points

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -237,7 +237,7 @@ bool AP_OADijkstra::create_polygon_fence_visgraph()
     // calculate distance from each polygon fence point to all other points
     for (uint8_t i=0; i<_polyfence_numpoints-1; i++) {
         const Vector2f &start1 = _polyfence_pts[i];
-        for (uint8_t j=i+1; j<_polyfence_numpoints-1; j++) {
+        for (uint8_t j=i+1; j<_polyfence_numpoints; j++) {
             const Vector2f &end1 = _polyfence_pts[j];
             Vector2f intersection;
             // ToDo: calculation below could be sped up by removing unused intersection and
@@ -282,8 +282,8 @@ bool AP_OADijkstra::update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph
     // clear visibility graph
     visgraph.clear();
 
-    // calculate distance from position to all fence points
-    for (uint8_t i=0; i<_polyfence_numpoints-1; i++) {
+    // calculate distance from extra_position to all fence points
+    for (uint8_t i=0; i<_polyfence_numpoints; i++) {
         Vector2f intersection;
         if (!Polygon_intersects(boundary, num_points, position, _polyfence_pts[i], intersection)) {
             // line segment does not intersect with original fence so add to visgraph
@@ -429,8 +429,7 @@ bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &d
     _short_path_data_numpoints = 2;
 
     // add fence points to short_path_data array (node_type, id, visited, distance_from_idx, distance_cm)
-    // skip last fence point because it is the same as the first
-    for (uint8_t i=0; i<_polyfence_numpoints-1; i++) {
+    for (uint8_t i=0; i<_polyfence_numpoints; i++) {
         _short_path_data[_short_path_data_numpoints++] = {{AP_OAVisGraph::OATYPE_FENCE_POINT, i}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
     }
 


### PR DESCRIPTION
This PR fixes 3 cases where we AP_OADijkstra's algorithm was not correctly handling an "unclosed" set of fence points (i.e. a polygon fence in which the last points is **not** the same as the first).

I've tested this is SITL to confirm that there was a problem before and that it is resolved by these changes.

The image below shows a test of a simply polygon fence with only 3 points.  In the "BEFORE" image we see that the visibility graph only had one point (i.e. one distance between a pair of points) while in the "AFTER" we see that there are 3 points (i.e. point1 to point2, point1 to point3, point2 to point3).

![vis-graph-before-after](https://user-images.githubusercontent.com/1498098/60014042-02b55600-96bb-11e9-8245-82bbf852897e.png)

The image below shows a BEFORE and AFTER test in which the "safe node" that Dijkstra's should pick is near the last polygon fence point.  In the BEFORE we see Dijkstra's does not use the node and instead drives into the fence.  In the AFTER it correctly uses the node.
![dijkstra-fix-before-after](https://user-images.githubusercontent.com/1498098/60014271-8a9b6000-96bb-11e9-8690-146f7ee4be20.png)

Thanks very much to @weihli who found the issue!