### PR TITLE
GCS_MAVLink: Validate requested GCS channel is within range of number of channels

### DIFF
--- a/APMrover2/GCS_Rover.h
+++ b/APMrover2/GCS_Rover.h
@@ -13,9 +13,21 @@ public:
     uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
 
     // return GCS link at offset ofs
-    GCS_MAVLINK_Rover &chan(const uint8_t ofs) override { return _chan[ofs]; };
+    GCS_MAVLINK_Rover &chan(uint8_t ofs) override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
+        return _chan[ofs];
+    }
     // return GCS link at offset ofs
-    const GCS_MAVLINK_Rover &chan(const uint8_t ofs) const override { return _chan[ofs]; };
+    const GCS_MAVLINK_Rover &chan(uint8_t ofs) const override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
+        return _chan[ofs];
+    }
 
     uint32_t custom_mode() const override;
     MAV_TYPE frame_type() const override;

--- a/AntennaTracker/GCS_Tracker.h
+++ b/AntennaTracker/GCS_Tracker.h
@@ -14,8 +14,20 @@ public:
     uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
 
     // return GCS link at offset ofs
-    GCS_MAVLINK_Tracker &chan(const uint8_t ofs) override { return _chan[ofs]; };
-    const GCS_MAVLINK_Tracker &chan(const uint8_t ofs) const override { return _chan[ofs]; };
+    GCS_MAVLINK_Tracker &chan(uint8_t ofs) override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
+        return _chan[ofs];
+    }
+    const GCS_MAVLINK_Tracker &chan(uint8_t ofs) const override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
+        return _chan[ofs];
+    }
 
     void update_vehicle_sensor_status_flags() override;
 

--- a/ArduCopter/GCS_Copter.h
+++ b/ArduCopter/GCS_Copter.h
@@ -13,12 +13,20 @@ public:
     uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
 
     // return GCS link at offset ofs
-    GCS_MAVLINK_Copter &chan(const uint8_t ofs) override {
+    GCS_MAVLINK_Copter &chan(uint8_t ofs) override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
         return _chan[ofs];
-    };
-    const GCS_MAVLINK_Copter &chan(const uint8_t ofs) const override {
+    }
+    const GCS_MAVLINK_Copter &chan(uint8_t ofs) const override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
         return _chan[ofs];
-    };
+    }
 
     void update_vehicle_sensor_status_flags(void) override;
 

--- a/ArduPlane/GCS_Plane.h
+++ b/ArduPlane/GCS_Plane.h
@@ -13,12 +13,20 @@ public:
     uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
 
     // return GCS link at offset ofs
-    GCS_MAVLINK_Plane &chan(const uint8_t ofs) override {
+    GCS_MAVLINK_Plane &chan(uint8_t ofs) override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
         return _chan[ofs];
-    };
-    const GCS_MAVLINK_Plane &chan(const uint8_t ofs) const override {
+    }
+    const GCS_MAVLINK_Plane &chan(uint8_t ofs) const override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
         return _chan[ofs];
-    };
+    }
 
 protected:
 

--- a/ArduSub/GCS_Sub.h
+++ b/ArduSub/GCS_Sub.h
@@ -13,10 +13,18 @@ public:
     uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
 
     // return GCS link at offset ofs
-    GCS_MAVLINK_Sub &chan(const uint8_t ofs) override {
+    GCS_MAVLINK_Sub &chan(uint8_t ofs) override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
         return _chan[ofs];
     };
-    const GCS_MAVLINK_Sub &chan(const uint8_t ofs) const override {
+    const GCS_MAVLINK_Sub &chan(uint8_t ofs) const override {
+        if (ofs >= num_gcs()) {
+            AP::internalerror().error(AP_InternalError::error_t::gcs_offset);
+            ofs = 0;
+        }
         return _chan[ofs];
     };
 

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -51,6 +51,7 @@ public:
         main_loop_stuck             = (1U << 15),
         gcs_bad_missionprotocol_link= (1U << 16),
         bitmask_range               = (1U << 17),
+        gcs_offset                  = (1U << 18),
     };
 
     void error(const AP_InternalError::error_t error);


### PR DESCRIPTION
As discussed in devcall, sanity check to ensure requested backend exists.

At the moment we can't do any more than raise an internal error if this does happen - see the "dynamically allocate gcs backend PR" for that.
