### PR TITLE
Send heartbeat on mode change

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -268,6 +268,7 @@ bool Rover::set_mode(Mode &new_mode, mode_reason_t reason)
 
     control_mode_reason = reason;
     logger.Write_Mode(control_mode->mode_number(), control_mode_reason);
+    gcs().send_message(MSG_HEARTBEAT);
 
     notify_mode(control_mode);
     return true;

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -235,6 +235,7 @@ void Tracker::set_mode(enum ControlMode mode, mode_reason_t reason)
 
 	// log mode change
 	logger.Write_Mode(control_mode, reason);
+  gcs().send_message(MSG_HEARTBEAT);
 
     nav_status.bearing = ahrs.yaw_sensor * 0.01f;
 }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -237,6 +237,7 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     control_mode = mode;
     control_mode_reason = reason;
     logger.Write_Mode(control_mode, reason);
+    gcs().send_message(MSG_HEARTBEAT);
 
 #if ADSB_ENABLED == ENABLED
     adsb.set_is_auto_mode((mode == AUTO) || (mode == RTL) || (mode == GUIDED));

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -301,6 +301,7 @@ bool Plane::set_mode(Mode &new_mode, const mode_reason_t reason)
     // log and notify mode change
     logger.Write_Mode(control_mode->mode_number(), control_mode_reason);
     notify_mode(*control_mode);
+    gcs().send_message(MSG_HEARTBEAT);
 
     return true;
 }

--- a/ArduSub/flight_mode.cpp
+++ b/ArduSub/flight_mode.cpp
@@ -71,6 +71,7 @@ bool Sub::set_mode(control_mode_t mode, mode_reason_t reason)
         control_mode = mode;
         control_mode_reason = reason;
         logger.Write_Mode(control_mode, control_mode_reason);
+        gcs().send_message(MSG_HEARTBEAT);
 
         // update notify object
         notify_flight_mode(control_mode);


### PR DESCRIPTION
I should have done this patch a long time ago. There are 2 primary reasons for this:
  1. The GCS gets a much prompter notification when the vehicles mode changes, rather then at a 1 Hz beat. This means the GCS operator gets a much more upto date report of the mode, and fixes the delay of up to 1 second between sending a mode change (or the safety pilot reporting they changed modes) before you see it on the GCS.
  1. This significantly improves log analysis on tlogs when trying to couple the vehicles change in behavior/motors to flight modes. The current tlog makes it hard to tell when the mode change actually happened, unless it prompted a statustext, and that's not something we can actually rely on. This is particularly when things go bad the moment you switch into a mode, and you are using a cropped log file based on flight modes (a common use case with MAVExplorer)

The only real downside I can see to this is that it can reset when we send the heartbeat interval, but given the advantages I think it's well worth it.

EDIT: I've only SITL tested plane, but it works well and the other vehicles are seeing just a copy paste of the same functionality, so I was comfortable with relying on auto test for them.