### PR TITLE
Manifest generation fix

### DIFF
--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -285,7 +285,7 @@ class ManifestGenerator():
             platform_frame_regex = re.compile("(?P<board>.+)(-(?P<frame>heli)$)")
             m = platform_frame_regex.match(platformdir)
             if m is not None:
-		# This is a heli build
+                # This is a heli build
                 platform = m.group("board")  # e.g. navio
                 frame = "heli"
             else:

--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -10,7 +10,7 @@ import fnmatch
 import gen_stable
 
 FIRMWARE_TYPES = ["AntennaTracker", "Copter", "Plane", "Rover", "Sub"]
-RELEASE_TYPES = ["beta", "latest", "stable", "stable-*"]
+RELEASE_TYPES = ["beta", "latest", "stable", "stable-*", "dirty"]
 
 # mapping for board names to brand name and manufacturer
 brand_map = {
@@ -236,8 +236,6 @@ class ManifestGenerator():
                                    vehicletype,
                                    releasetype="dev"):
         '''accumulate additional information about firmwares from directory'''
-        platform_frame_regex = re.compile(
-            "(?P<board>PX4|navio|pxf)(-(?P<frame>.+))?")
         variant_firmware_regex = re.compile("[^-]+-(?P<variant>v\d+)[.px4]")
         if not os.path.isdir(dir):
             return
@@ -283,16 +281,15 @@ class ManifestGenerator():
                 # is incomplete.
                 continue
 
+            # Directory names for heli builds end in -heli
+            platform_frame_regex = re.compile("(?P<board>.+)(-(?P<frame>heli)$)")
             m = platform_frame_regex.match(platformdir)
             if m is not None:
-                # the model type (quad/tri) is
-                # encoded in the platform name
-                # (e.g. navio-octa)
+		# This is a heli build
                 platform = m.group("board")  # e.g. navio
-                frame = m.group("frame")  # e.g. octa
-                if frame is None:
-                    frame = vehicletype
+                frame = "heli"
             else:
+                # Non-heli build
                 frame = vehicletype  # e.g. Plane
                 platform = platformdir  # e.g. apm2
 


### PR DESCRIPTION
Fix for #11632. The parsing of heli directory names was incorrect causing the platform to be set incorrectly which then caused all sorts of other downstream problems with the parser.

@peterbarker I left eh addition of "dirty" into release types in the pull. Not sure of that's ok.