### PR TITLE
AP_Airspeed: use send_to_active_channels for airspeed_autocal

### DIFF
--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -164,27 +164,20 @@ void AP_Airspeed::update_calibration(const Vector3f &vground, int16_t max_airspe
 
 void AP_Airspeed::send_airspeed_calibration(const Vector3f &vground)
 {
-    for (uint8_t i=0; i<gcs().num_gcs(); i++) {
-        if (!gcs().chan(i).initialised) {
-            continue;
-        }
-        const mavlink_channel_t chan = (mavlink_channel_t)i;
-        if (!HAVE_PAYLOAD_SPACE(chan, AIRSPEED_AUTOCAL)) {
-            continue;
-        }
-        mavlink_msg_airspeed_autocal_send(
-            chan,
-            vground.x,
-            vground.y,
-            vground.z,
-            get_differential_pressure(primary),
-            AP::baro().get_EAS2TAS(),
-            param[primary].ratio.get(),
-            state[primary].calibration.state.x,
-            state[primary].calibration.state.y,
-            state[primary].calibration.state.z,
-            state[primary].calibration.P.a.x,
-            state[primary].calibration.P.b.y,
-            state[primary].calibration.P.c.z);
-    }
+    const mavlink_airspeed_autocal_t packet{
+        vground.x,
+        vground.y,
+        vground.z,
+        get_differential_pressure(primary),
+        AP::baro().get_EAS2TAS(),
+        param[primary].ratio.get(),
+        state[primary].calibration.state.x,
+        state[primary].calibration.state.y,
+        state[primary].calibration.state.z,
+        state[primary].calibration.P.a.x,
+        state[primary].calibration.P.b.y,
+        state[primary].calibration.P.c.z
+    };
+    gcs().send_to_active_channels(MAVLINK_MSG_ID_AIRSPEED_AUTOCAL,
+                                  (const char *)&packet);
 }


### PR DESCRIPTION
In an effort to reduce the number of places dealing with GCS_MAVLINK backends explicitly.
