### PR TITLE
AP_Arming: remove stray comment on removed parameter

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -106,7 +106,6 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("MIS_ITEMS",    7,     AP_Arming, _required_mission_items, 0),
 
-    // index 4 was VOLT_MIN, moved to AP_BattMonitor
     AP_GROUPEND
 };
 


### PR DESCRIPTION
Almost certainly a rebase issue

this comment is repeated further up in the appropriate spot
