### PR TITLE
GCS_MAVLink: remove stray undef of undefined macro

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -97,8 +97,6 @@ bool GCS::install_alternative_protocol(mavlink_channel_t c, GCS_MAVLINK::protoco
     return true;
 }
 
-#undef FOR_EACH_ACTIVE_CHANNEL
-
 void GCS::update_sensor_status_flags()
 {
     control_sensors_present = 0;


### PR DESCRIPTION
nobody ever defines this one any more
