### PR TITLE
Stop using AHRS library as conduit for beacon object

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -138,9 +138,6 @@ void Rover::init_ardupilot()
      */
     hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
-    // give AHRS the range beacon sensor
-    ahrs.set_beacon(&g2.beacon);
-
     // initialize SmartRTL
     g2.smart_rtl.init();
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -128,11 +128,6 @@ void Copter::init_ardupilot()
      */
     hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
-#if BEACON_ENABLED == ENABLED
-    // give AHRS the range beacon sensor
-    ahrs.set_beacon(&g2.beacon);
-#endif
-
     // Do GPS init
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init(serial_manager);

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3366,7 +3366,9 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("BCN_ORIENT_YAW", 45)
             self.set_parameter("AVOID_ENABLE", 4)
             self.set_parameter("GPS_TYPE", 0)
-            self.set_parameter("EK2_GPS_TYPE", 3) # NOGPS
+            self.set_parameter("EK3_GPS_TYPE", 3) # NOGPS
+            self.set_parameter("EK3_ENABLE", 1)
+            self.set_parameter("EK2_ENABLE", 0)
 
             self.reboot_sitl()
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -165,16 +165,8 @@ public:
         _airspeed = airspeed;
     }
 
-    void set_beacon(AP_Beacon *beacon) {
-        _beacon = beacon;
-    }
-
     const AP_Airspeed *get_airspeed(void) const {
         return _airspeed;
-    }
-
-    const AP_Beacon *get_beacon(void) const {
-        return _beacon;
     }
 
     // get the index of the current primary accelerometer sensor
@@ -644,9 +636,6 @@ protected:
 
     // pointer to airspeed object, if available
     AP_Airspeed     * _airspeed;
-
-    // pointer to beacon object, if available
-    AP_Beacon     * _beacon;
 
     // time in microseconds of last compass update
     uint32_t _compass_last_update;

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -829,7 +829,7 @@ void AP_Logger::Write_EKF2(AP_AHRS_NavEKF &ahrs)
     }
 
     // write range beacon fusion debug packet if the range value is non-zero
-    if (ahrs.get_beacon() != nullptr) {
+    if (AP::beacon() != nullptr) {
         uint8_t ID;
         float rng;
         float innovVar;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -700,7 +700,7 @@ void NavEKF2_core::readAirSpdData()
 void NavEKF2_core::readRngBcnData()
 {
     // get the location of the beacon data
-    const AP_Beacon *beacon = _ahrs->get_beacon();
+    const AP_Beacon *beacon = AP::beacon();
 
     // exit immediately if no beacon object
     if (beacon == nullptr) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -732,7 +732,7 @@ void NavEKF3_core::readAirSpdData()
 void NavEKF3_core::readRngBcnData()
 {
     // get the location of the beacon data
-    const AP_Beacon *beacon = _ahrs->get_beacon();
+    const AP_Beacon *beacon = AP::beacon();
 
     // exit immediately if no beacon object
     if (beacon == nullptr) {


### PR DESCRIPTION
... we now have a singleton for this, so we don't need to hold this in the AHRS object.
