### PR TITLE
Stop passing AHRS and relay objects to Camera object

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -237,7 +237,7 @@ private:
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
+    AP_Camera camera{MASK_LOG_CAMERA, current_loc};
 #endif
 
     // Camera/Antenna mount tracking and stabilisation stuff

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -486,7 +486,7 @@ private:
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
+    AP_Camera camera{MASK_LOG_CAMERA, current_loc};
 #endif
 
     // Camera/Antenna mount tracking and stabilisation stuff

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -291,7 +291,7 @@ private:
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
+    AP_Camera camera{MASK_LOG_CAMERA, current_loc};
 #endif
 
 #if OPTFLOW == ENABLED

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -406,7 +406,7 @@ private:
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
+    AP_Camera camera{MASK_LOG_CAMERA, current_loc};
 #endif
 
     // Camera/Antenna mount tracking and stabilisation stuff

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -5,7 +5,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Relay/AP_Relay.h>
-#include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
 
 #define AP_CAMERA_TRIGGER_TYPE_SERVO                0
 #define AP_CAMERA_TRIGGER_TYPE_RELAY                1
@@ -24,13 +24,11 @@
 class AP_Camera {
 
 public:
-    AP_Camera(AP_Relay *obj_relay, uint32_t _log_camera_bit, const struct Location &_loc, const AP_AHRS &_ahrs)
+    AP_Camera(uint32_t _log_camera_bit, const struct Location &_loc)
         : log_camera_bit(_log_camera_bit)
         , current_loc(_loc)
-        , ahrs(_ahrs)
     {
         AP_Param::setup_object_defaults(this, var_info);
-        _apm_relay = obj_relay;
         _singleton = this;
     }
 
@@ -91,7 +89,6 @@ private:
     AP_Int16        _servo_off_pwm;     // PWM value to move servo to when shutter is deactivated
     uint8_t         _trigger_counter;   // count of number of cycles shutter has been held open
     uint8_t         _trigger_counter_cam_function;   // count of number of cycles alternative camera function has been held open
-    AP_Relay       *_apm_relay;         // pointer to relay object from the base class Relay.
     AP_Int8         _auto_mode_only;    // if 1: trigger by distance only if in AUTO mode.
     AP_Int8         _type;              // Set the type of camera in use, will open additional parameters if set
     bool            _is_in_auto_mode;   // true if in AUTO mode
@@ -124,7 +121,6 @@ private:
 
     uint32_t log_camera_bit;
     const struct Location &current_loc;
-    const AP_AHRS &ahrs;
 
     // entry point to trip local shutter (e.g. by relay or servo)
     void trigger_pic();

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -246,9 +246,9 @@ public:
     void Write_Radio(const mavlink_radio_t &packet);
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);
-    void Write_CameraInfo(enum LogMessages msg, const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us=0);
-    void Write_Camera(const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us=0);
-    void Write_Trigger(const AP_AHRS &ahrs, const Location &current_loc);
+    void Write_CameraInfo(enum LogMessages msg, const Location &current_loc, uint64_t timestamp_us=0);
+    void Write_Camera(const Location &current_loc, uint64_t timestamp_us=0);
+    void Write_Trigger(const Location &current_loc);
     void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t temperature, uint16_t current_tot);
     void Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
     void Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -543,8 +543,10 @@ void AP_Logger::Write_Radio(const mavlink_radio_t &packet)
 }
 
 // Write a Camera packet
-void AP_Logger::Write_CameraInfo(enum LogMessages msg, const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us)
+void AP_Logger::Write_CameraInfo(enum LogMessages msg, const Location &current_loc, uint64_t timestamp_us)
 {
+    const AP_AHRS &ahrs = AP::ahrs();
+
     int32_t altitude, altitude_rel, altitude_gps;
     if (current_loc.relative_alt) {
         altitude = current_loc.alt+ahrs.get_home().alt;
@@ -578,15 +580,15 @@ void AP_Logger::Write_CameraInfo(enum LogMessages msg, const AP_AHRS &ahrs, cons
 }
 
 // Write a Camera packet
-void AP_Logger::Write_Camera(const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us)
+void AP_Logger::Write_Camera(const Location &current_loc, uint64_t timestamp_us)
 {
-    Write_CameraInfo(LOG_CAMERA_MSG, ahrs, current_loc, timestamp_us);
+    Write_CameraInfo(LOG_CAMERA_MSG, current_loc, timestamp_us);
 }
 
 // Write a Trigger packet
-void AP_Logger::Write_Trigger(const AP_AHRS &ahrs, const Location &current_loc)
+void AP_Logger::Write_Trigger(const Location &current_loc)
 {
-    Write_CameraInfo(LOG_TRIGGER_MSG, ahrs, current_loc, 0);
+    Write_CameraInfo(LOG_TRIGGER_MSG, current_loc, 0);
 }
 
 // Write an attitude packet


### PR DESCRIPTION
... it can use singletons.

~~Also add AP:: singleton getter for `AP_Relay`~~ (already merged separately)
