### PR TITLE
Reduce usage of InertialNav

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -989,9 +989,11 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 if (!AP::ahrs().home_is_set()) {
                     break;
                 }
-                const Location &origin = copter.inertial_nav.get_origin();
+                Location origin;
                 pos_vector.z += AP::ahrs().get_home().alt;
-                pos_vector.z -= origin.alt;
+                if (copter.ahrs.get_origin(origin)) {
+                    pos_vector.z -= origin.alt;
+                }
             }
         }
 

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -23,8 +23,8 @@ void Copter::update_home_from_EKF()
 void Copter::set_home_to_current_location_inflight() {
     // get current location from EKF
     Location temp_loc;
-    if (inertial_nav.get_location(temp_loc)) {
-        const struct Location &ekf_origin = inertial_nav.get_origin();
+    Location ekf_origin;
+    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             return;
@@ -40,7 +40,7 @@ void Copter::set_home_to_current_location_inflight() {
 bool Copter::set_home_to_current_location(bool lock) {
     // get current location from EKF
     Location temp_loc;
-    if (inertial_nav.get_location(temp_loc)) {
+    if (ahrs.get_location(temp_loc)) {
         if (!set_home(temp_loc, lock)) {
             return false;
         }
@@ -106,8 +106,8 @@ bool Copter::set_home(const Location& loc, bool lock)
 bool Copter::far_from_EKF_origin(const Location& loc)
 {
     // check distance to EKF origin
-    const struct Location &ekf_origin = inertial_nav.get_origin();
-    if (ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_M) {
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin) && (ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_M)) {
         return true;
     }
 

--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -4,11 +4,13 @@
 void Copter::read_inertia()
 {
     // inertial altitude estimates
-    inertial_nav.update(G_Dt);
+    inertial_nav.update();
 
-    // pull position from interial nav library
-    current_loc.lng = inertial_nav.get_longitude();
-    current_loc.lat = inertial_nav.get_latitude();
+    // pull position from ahrs
+    Location loc;
+    ahrs.get_position(loc);
+    current_loc.lat = loc.lat;
+    current_loc.lng = loc.lng;
 
     // exit immediately if we do not have an altitude estimate
     if (!inertial_nav.get_filter_status().flags.vert_pos) {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -166,7 +166,7 @@ void Plane::ahrs_update()
     quadplane.check_yaw_reset();
 
     // update inertial_nav for quadplane
-    quadplane.inertial_nav.update(G_Dt);
+    quadplane.inertial_nav.update();
 }
 
 /*

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2252,7 +2252,10 @@ void QuadPlane::vtol_position_controller(void)
 void QuadPlane::setup_target_position(void)
 {
     const Location &loc = plane.next_WP_loc;
-    Location origin = inertial_nav.get_origin();
+    Location origin;
+    if (!ahrs.get_origin(origin)) {
+        origin.zero();
+    }
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     const Vector2f diff2d = origin.get_distance_NE(loc);

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -24,8 +24,8 @@ void Sub::set_home_to_current_location_inflight()
 {
     // get current location from EKF
     Location temp_loc;
-    if (inertial_nav.get_location(temp_loc)) {
-        const struct Location &ekf_origin = inertial_nav.get_origin();
+    Location ekf_origin;
+    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             // ignore this failure
@@ -38,7 +38,7 @@ bool Sub::set_home_to_current_location(bool lock)
 {
     // get current location from EKF
     Location temp_loc;
-    if (inertial_nav.get_location(temp_loc)) {
+    if (ahrs.get_location(temp_loc)) {
 
         // Make home always at the water's surface.
         // This allows disarming and arming again at depth.
@@ -98,6 +98,6 @@ bool Sub::set_home(const Location& loc, bool lock)
 bool Sub::far_from_EKF_origin(const Location& loc)
 {
     // check distance to EKF origin
-    const struct Location &ekf_origin = inertial_nav.get_origin();
-    return (ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_M);
+    Location ekf_origin;
+    return ahrs.get_origin(ekf_origin) && (ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_M);
 }

--- a/ArduSub/inertia.cpp
+++ b/ArduSub/inertia.cpp
@@ -4,11 +4,13 @@
 void Sub::read_inertia()
 {
     // inertial altitude estimates
-    inertial_nav.update(G_Dt);
+    inertial_nav.update();
 
-    // pull position from interial nav library
-    current_loc.lng = inertial_nav.get_longitude();
-    current_loc.lat = inertial_nav.get_latitude();
+    // pull position from ahrs
+    Location loc;
+    ahrs.get_position(loc);
+    current_loc.lat = loc.lat;
+    current_loc.lng = loc.lng;
 
     // exit immediately if we do not have an altitude estimate
     if (!inertial_nav.get_filter_status().flags.vert_pos) {

--- a/ArduSub/position_vector.cpp
+++ b/ArduSub/position_vector.cpp
@@ -10,7 +10,10 @@
 // pv_location_to_vector - convert lat/lon coordinates to a position vector
 Vector3f Sub::pv_location_to_vector(const Location& loc)
 {
-    const struct Location &origin = inertial_nav.get_origin();
+    Location origin;
+    if (!ahrs.get_origin(origin)) {
+        origin.zero();
+    }
     float alt_above_origin = pv_alt_above_origin(loc.alt);  // convert alt-relative-to-home to alt-relative-to-origin
     return Vector3f((loc.lat-origin.lat) * LATLON_TO_CM, (loc.lng-origin.lng) * LATLON_TO_CM * scaleLongDown, alt_above_origin);
 }
@@ -18,7 +21,10 @@ Vector3f Sub::pv_location_to_vector(const Location& loc)
 // pv_alt_above_origin - convert altitude above home to altitude above EKF origin
 float Sub::pv_alt_above_origin(float alt_above_home_cm)
 {
-    const struct Location &origin = inertial_nav.get_origin();
+    Location origin;
+    if (!ahrs.get_origin(origin)) {
+        origin.zero();
+    }
     return alt_above_home_cm + (ahrs.get_home().alt - origin.alt);
 }
 

--- a/libraries/AP_InertialNav/AP_InertialNav.h
+++ b/libraries/AP_InertialNav/AP_InertialNav.h
@@ -27,22 +27,13 @@ public:
     /**
      * update - updates velocity and position estimates using latest info from accelerometers
      * augmented with gps and baro readings
-     *
-     * @param dt : time since last update in seconds
      */
-    virtual void update(float dt) = 0;
+    virtual void update(void) = 0;
 
     /**
      * get_filter_status : returns filter status as a series of flags
      */
     virtual nav_filter_status get_filter_status() const = 0;
-
-    /**
-     * get_origin - returns the inertial navigation origin in lat/lon/alt
-     *
-     * @return origin Location
-     */
-    virtual struct Location get_origin() const = 0;
 
     //
     // XY Axis specific methods
@@ -54,24 +45,6 @@ public:
      * @return
      */
     virtual const Vector3f&    get_position() const = 0;
-
-    /**
-     * get_llh - updates the provided location with the latest calculated location including absolute altitude
-     *  returns true on success (i.e. the EKF knows it's latest position), false on failure
-     */
-    virtual bool get_location(struct Location &loc) const = 0;
-
-    /**
-     * get_latitude - returns the latitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
-     * @return
-     */
-    virtual int32_t     get_latitude() const = 0;
-
-    /**
-     * get_longitude - returns the longitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
-     * @return
-     */
-    virtual int32_t     get_longitude() const = 0;
 
     /**
      * get_velocity - returns the current velocity in cm/s

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
@@ -12,7 +12,7 @@
 /**
    update internal state
 */
-void AP_InertialNav_NavEKF::update(float dt)
+void AP_InertialNav_NavEKF::update()
 {
     // get the NE position relative to the local earth frame origin
     Vector2f posNE;
@@ -26,9 +26,6 @@ void AP_InertialNav_NavEKF::update(float dt)
     if (_ahrs_ekf.get_relative_position_D_origin(posD)) {
         _relpos_cm.z = - posD * 100; // convert from m in NED to cm in NEU
     }
-
-    // get the absolute WGS-84 position
-    _haveabspos = _ahrs_ekf.get_position(_abspos);
 
     // get the velocity relative to the local earth frame
     Vector3f velNED;
@@ -49,19 +46,6 @@ nav_filter_status AP_InertialNav_NavEKF::get_filter_status() const
 }
 
 /**
- * get_origin - returns the inertial navigation origin in lat/lon/alt
- */
-struct Location AP_InertialNav_NavEKF::get_origin() const
-{
-    struct Location ret;
-     if (!_ahrs_ekf.get_origin(ret)) {
-         // initialise location to all zeros if EKF origin not yet set
-         ret.zero();
-     }
-    return ret;
-}
-
-/**
  * get_position - returns the current position relative to the home location in cm.
  *
  * @return
@@ -69,32 +53,6 @@ struct Location AP_InertialNav_NavEKF::get_origin() const
 const Vector3f &AP_InertialNav_NavEKF::get_position(void) const 
 {
     return _relpos_cm;
-}
-
-/**
- * get_location - updates the provided location with the latest calculated location
- *  returns true on success (i.e. the EKF knows it's latest position), false on failure
- */
-bool AP_InertialNav_NavEKF::get_location(struct Location &loc) const
-{
-    return _ahrs_ekf.get_location(loc);
-}
-
-/**
- * get_latitude - returns the latitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
- */
-int32_t AP_InertialNav_NavEKF::get_latitude() const
-{
-    return _abspos.lat;
-}
-
-/**
- * get_longitude - returns the longitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
- * @return
- */
-int32_t AP_InertialNav_NavEKF::get_longitude() const
-{
-    return _abspos.lng;
 }
 
 /**

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
@@ -13,26 +13,18 @@ public:
     // Constructor
     AP_InertialNav_NavEKF(AP_AHRS_NavEKF &ahrs) :
         AP_InertialNav(),
-        _haveabspos(false),
         _ahrs_ekf(ahrs)
         {}
 
     /**
        update internal state
     */
-    void        update(float dt) override;
+    void        update() override;
 
     /**
      * get_filter_status - returns filter status as a series of flags
      */
     nav_filter_status get_filter_status() const override;
-
-    /**
-     * get_origin - returns the inertial navigation origin in lat/lon/alt
-     *
-     * @return origin Location
-     */
-    struct Location get_origin() const override;
 
     /**
      * get_position - returns the current position relative to the home location in cm.
@@ -42,23 +34,6 @@ public:
      * @return
      */
     const Vector3f&    get_position() const override;
-
-    /**
-     * get_llh - updates the provided location with the latest calculated location including absolute altitude
-     *  returns true on success (i.e. the EKF knows it's latest position), false on failure
-     */
-    bool get_location(struct Location &loc) const override;
-
-    /**
-     * get_latitude - returns the latitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
-     */
-    int32_t     get_latitude() const override;
-
-    /**
-     * get_longitude - returns the longitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
-     * @return
-     */
-    int32_t     get_longitude() const override;
 
     /**
      * get_velocity - returns the current velocity in cm/s
@@ -95,7 +70,5 @@ public:
 private:
     Vector3f _relpos_cm;   // NEU
     Vector3f _velocity_cm; // NEU
-    struct Location _abspos;
-    bool _haveabspos;
     AP_AHRS_NavEKF &_ahrs_ekf;
 };


### PR DESCRIPTION
The removed methods were direct wrappers to AHRS function calls, or used immediately after the update call, and never reused so the cache wasn't helping. As well as being clearer this represents a savings across the board for flash, ram, and processing speed.

Because it isn't immediately obvious why some of these are safe transformations, I'll actually drop some inline comments on it as a review.