### PR TITLE
AP_RangeFinder: Change to maximum published value

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -780,7 +780,7 @@ void AP_RangeFinder_VL53L0X::update(void)
 void AP_RangeFinder_VL53L0X::timer(void)
 {
     uint16_t range_mm;
-    if (get_reading(range_mm) && range_mm < 8000) {
+    if (get_reading(range_mm) && range_mm <= 2000) {
         sum_mm += range_mm;
         counter++;
     }


### PR DESCRIPTION
I change the determination of the maximum value to the maximum published value.
This change is the same determination method as VL53L1X.

The VL53L0X is 2 meters.
The VL53L1X is 4 meters.

Data Sheet:
https://www.pololu.com/file/0J1187/VL53L0X.pdf