### PR TITLE
Rover: stop vehicle if object avoidance fails

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -22,6 +22,7 @@ public:
     void set_config(float lookahead, float margin_max) { _lookahead = MAX(lookahead, 1.0f); _margin_max = MAX(margin_max, 0.0f); }
 
     // run background task to find best path and update avoidance_results
+    // returns true and populates origin_new and destination_new if OA is required.  returns false if OA is not required
     bool update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new);
 
 private:

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -22,9 +22,16 @@ public:
     // set fence margin (in meters) used when creating "safe positions" within the polygon fence
     void set_fence_margin(float margin) { _polyfence_margin = MAX(margin, 0.0f); }
 
+    // update return status enum
+    enum AP_OADijkstra_State : uint8_t {
+        DIJKSTRA_STATE_NOT_REQUIRED = 0,
+        DIJKSTRA_STATE_ERROR,
+        DIJKSTRA_STATE_SUCCESS
+    };
+
     // calculate a destination to avoid the polygon fence
-    // returns true if avoidance is required and target destination is placed in result_loc
-    bool update(const Location &current_loc, const Location &destination, Location& origin_new, Location& destination_new);
+    // returns DIJKSTRA_STATE_SUCCESS and populates origin_new and destination_new if avoidance is required
+    AP_OADijkstra_State update(const Location &current_loc, const Location &destination, Location& origin_new, Location& destination_new);
 
 private:
 

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -30,9 +30,17 @@ public:
     /// returns true if all pre-takeoff checks have completed successfully
     bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const;
 
+    // object avoidance processing return status enum
+    enum OA_RetState : uint8_t {
+        OA_NOT_REQUIRED = 0,            // object avoidance is not required
+        OA_PROCESSING,                  // still calculating alternative path
+        OA_ERROR,                       // error during calculation
+        OA_SUCCESS                      // success
+    };
+
     // provides an alternative target location if path planning around obstacles is required
     // returns true and updates result_origin and result_destination with an intermediate path
-    bool mission_avoidance(const Location &current_loc,
+    OA_RetState mission_avoidance(const Location &current_loc,
                            const Location &origin,
                            const Location &destination,
                            Location &result_origin,
@@ -67,7 +75,7 @@ private:
         Location origin_new;        // intermediate origin.  The start of line segment that vehicle should follow
         Location destination_new;   // intermediate destination vehicle should move towards
         uint32_t result_time_ms;    // system time the result was calculated (used to verify the result is recent)
-        bool avoidance_needed;      // true if the vehicle should move along the path from origin_new to destination_new
+        OA_RetState ret_state;      // OA_SUCCESS if the vehicle should move along the path from origin_new to destination_new
     } avoidance_result;
 
     // parameters


### PR DESCRIPTION
This PR resolves this issue https://github.com/ArduPilot/ardupilot/issues/11600 by stopping the vehicle if object avoidance fails or before processing completes.  In the future we should send a status text or update the SYS_STATUS message's flags to inform the user that something has gone wrong this PR at least stops the vehicle from hitting things.

This has been tested in SITL.

In the test below, Dijkstra's OA was enabled (OA_TYPE = 2), the vehicle was switched into Guided mode and the target destination was set to a position outside the polygon fence.  The vehicle stopped as  excpected.
![outside-example](https://user-images.githubusercontent.com/1498098/60392164-9c0bbe80-9b38-11e9-9a6b-e2e8071a6746.png)

The image below shows a similar test but this time the target is placed within the fence and the vehicle correctly moves towards the target.
![within-example](https://user-images.githubusercontent.com/1498098/60392167-a037dc00-9b38-11e9-8120-77f3fd1d3484.png)


Another test performed was to enabled/disable both BendyRuler and Dijkstra's (by changing OA_TYPE) and the vehicle correctly stopped.
