### PR TITLE
EKF: force first EKF lane when disarmed

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -766,6 +766,18 @@ void NavEKF2::UpdateFilter(void)
         }
     }
 
+    if (primary != 0 && core[0].healthy() && !hal.util->get_soft_armed()) {
+        // when on the ground and disarmed force the first lane. This
+        // avoids us ending with with a lottery for which IMU is used
+        // in each flight. Otherwise the alignment of the timing of
+        // the lane updates with the timing of GPS updates can lead to
+        // a lane other than the first one being used as primary for
+        // some flights. As different IMUs may have quite different
+        // noise characteristics this leads to inconsistent
+        // performance
+        primary = 0;
+    }
+
     check_log_write();
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -794,6 +794,18 @@ void NavEKF3::UpdateFilter(void)
         }
     }
 
+    if (primary != 0 && core[0].healthy() && !hal.util->get_soft_armed()) {
+        // when on the ground and disarmed force the first lane. This
+        // avoids us ending with with a lottery for which IMU is used
+        // in each flight. Otherwise the alignment of the timing of
+        // the lane updates with the timing of GPS updates can lead to
+        // a lane other than the first one being used as primary for
+        // some flights. As different IMUs may have quite different
+        // noise characteristics this leads to inconsistent
+        // performance
+        primary = 0;
+    }
+    
     check_log_write();
 }
 


### PR DESCRIPTION
this ensures we consistently fly with EKF lane1 if it is healthy at
the point we arm. Otherwise the choice of lane will be a lottery.

This is important as many systems have quite different filtering and
vibration characteristics on their different IMUs. We by default
enable fast sampling only on the first IMU for example, which means
the 2nd and 3rd IMUs are more vulnerable to high freq vibration causing
aliasing.