### PR TITLE
Copter: set Heli frame default at compile-time

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -172,6 +172,13 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
 #endif
 
         #if FRAME_CONFIG == HELI_FRAME
+        if (copter.g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI_QUAD &&
+            copter.g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI_DUAL &&
+            copter.g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Invalid Heli FRAME_CLASS");
+            return false;
+        }
+
         // check helicopter parameters
         if (!copter.motors->parameter_check(display_failure)) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Heli motors checks failed");
@@ -189,6 +196,13 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
             return false;
         }
 
+        #else
+        if (copter.g2.frame_class.get() == AP_Motors::MOTOR_FRAME_HELI_QUAD ||
+            copter.g2.frame_class.get() == AP_Motors::MOTOR_FRAME_HELI_DUAL ||
+            copter.g2.frame_class.get() == AP_Motors::MOTOR_FRAME_HELI) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Invalid MultiCopter FRAME_CLASS");
+            return false;
+        }
         #endif // HELI_FRAME
 
         // check for missing terrain data

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -844,7 +844,6 @@ private:
     bool optflow_position_ok();
     void update_auto_armed();
     bool should_log(uint32_t mask);
-    void set_default_frame_class();
     MAV_TYPE get_frame_mav_type();
     const char* get_frame_string();
     void allocate_motors(void);

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -28,6 +28,13 @@
 #define GOBJECTVARPTR(v, name, var_info_ptr) { AP_PARAM_GROUP, name, Parameters::k_param_ ## v, (const void *)&copter.v, {group_info_ptr : var_info_ptr}, AP_PARAM_FLAG_POINTER | AP_PARAM_FLAG_INFO_POINTER }
 #define GOBJECTN(v, pname, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## pname, (const void *)&copter.v, {group_info : class::var_info} }
 
+#if FRAME_CONFIG == HELI_FRAME
+// 6 here is AP_Motors::MOTOR_FRAME_HELI
+#define DEFAULT_FRAME_CLASS 6
+#else
+#define DEFAULT_FRAME_CLASS 0
+#endif
+
 const AP_Param::Info Copter::var_info[] = {
     // @Param: SYSID_SW_MREV
     // @DisplayName: Eeprom format version number
@@ -819,7 +826,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad
     // @User: Standard
     // @RebootRequired: True
-    AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, 0),
+    AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, DEFAULT_FRAME_CLASS),
 
     // @Group: SERVO
     // @Path: ../libraries/SRV_Channel/SRV_Channels.cpp

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -108,9 +108,6 @@ void Copter::init_ardupilot()
 
     init_rc_in();               // sets up rc channels from radio
 
-    // default frame class to match firmware if possible
-    set_default_frame_class();
-
     // allocate the motors class
     allocate_motors();
 
@@ -393,16 +390,6 @@ bool Copter::should_log(uint32_t mask)
 #else
     return false;
 #endif
-}
-
-// default frame_class to match firmware if possible
-void Copter::set_default_frame_class()
-{
-    if (FRAME_CONFIG == HELI_FRAME &&
-        g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI_DUAL &&
-        g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI_QUAD) {
-        g2.frame_class.set(AP_Motors::MOTOR_FRAME_HELI);
-    }
 }
 
 // return MAV_TYPE corresponding to frame class


### PR DESCRIPTION
This should avoid us sending heartbeats out with the incorrect frame type.

Our run-time defaulting of the frame happened really, really late in the boot process - no wonder we were sending multicopter....

Note that this is very much a functional change.  This allows someone to explicitly set their frame class to any value and have that persist across reboots.  But then, they could already set it to heli-dual or heli-quad and have that persist.  We could add a pre-arm check that the frame class chosen makes sense for this build (would also save the multicopter users who have heli aspirations and decide to start with setting frame_class).

OTOH.  Better to unify the builds anyway.

This was tested by flashing onto PixHawk.  Note that since FRAME_CLASS is usually explicitly set, you do need to reset the stored parameters to test this.
