### PR TITLE
AP_InternalError: move include of BoardConfig to cpp

### DIFF
--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -20,6 +20,7 @@
 #include "SITL_State.h"
 #include "Util.h"
 
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_HAL_Empty/AP_HAL_Empty.h>
 #include <AP_HAL_Empty/AP_HAL_Empty_Private.h>
 #include <AP_InternalError/AP_InternalError.h>

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -1,5 +1,7 @@
 #include "AP_InternalError.h"
 
+#include <AP_BoardConfig/AP_BoardConfig.h>
+
 extern const AP_HAL::HAL &hal;
 
 // actually create the instance:

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <stdint.h>
 
 class AP_InternalError {
 public:

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -17,6 +17,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_InternalError/AP_InternalError.h>
+#include <AP_RTC/AP_RTC.h>
 
 #if HAL_OS_POSIX_IO
 #include <unistd.h>

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -27,6 +27,7 @@
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_BLHeli/AP_BLHeli.h>
 #include <AP_RSSI/AP_RSSI.h>
+#include <AP_RTC/AP_RTC.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Mount/AP_Mount.h>


### PR DESCRIPTION
This breaks an include loop when building for skyviper-v2450