### PR TITLE
Tools: fix the switch-to-uart function in TFMiniPlus script

### DIFF
--- a/Tools/scripts/tfminiplus.py
+++ b/Tools/scripts/tfminiplus.py
@@ -45,9 +45,9 @@ def parse_args(proc_args):
     p.add_argument('uart', help="UART device the sensor is currently using (e.g. /dev/ttyUSB0, /dev/ttyS1, etc)")
     p.set_defaults(func=cmd_switch_to_i2c)
 
-    p = subparsers.add_parser('switch-to-uart', help="Switch sensor to I2C mode")
-    p.add_argument('i2c_dev', help="I2C-device the sensor is currently using (e.g. /dev/i2c-1, /dev/i2c-2, etc)")
-    p.add_argument('addr', type=lambda x: int(x, 0), help="I2C-device's address the sensor is currently using (e.g. 0x10, 0x11, etc)")
+    p = subparsers.add_parser('switch-to-uart', help="Switch sensor to UART mode")
+    p.add_argument('i2c_dev', help="I2C device the sensor is currently using (e.g. /dev/i2c-1, /dev/i2c-2, etc)")
+    p.add_argument('addr', type=lambda x: int(x, 0), help="I2C device's address the sensor is currently using (e.g. 0x10, 0x11, etc)")
     p.set_defaults(func=cmd_switch_to_uart)
 
     try:

--- a/Tools/scripts/tfminiplus.py
+++ b/Tools/scripts/tfminiplus.py
@@ -46,8 +46,8 @@ def parse_args(proc_args):
     p.set_defaults(func=cmd_switch_to_i2c)
 
     p = subparsers.add_parser('switch-to-uart', help="Switch sensor to I2C mode")
-    p.add_argument('i2c-dev', help="I2C-device the sensor is currently using (e.g. /dev/i2c-1, /dev/i2c-2, etc)")
-    p.add_argument('addr', help="I2C-device's address the sensor is currently using (e.g. 0x10, 0x11, etc)")
+    p.add_argument('i2c_dev', help="I2C-device the sensor is currently using (e.g. /dev/i2c-1, /dev/i2c-2, etc)")
+    p.add_argument('addr', type=lambda x: int(x, 0), help="I2C-device's address the sensor is currently using (e.g. 0x10, 0x11, etc)")
     p.set_defaults(func=cmd_switch_to_uart)
 
     try:


### PR DESCRIPTION
I changed these.
- fix the typo
- Allows the argument of the i2c address to input hexadecimal values