### PR TITLE
Drastically reduce EKF RAM consumption

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -552,12 +552,12 @@ def write_mcu_config(f):
     if get_config('PROCESS_STACK', required=False):
         env_vars['PROCESS_STACK'] = get_config('PROCESS_STACK')
     else:
-        env_vars['PROCESS_STACK'] = "0x2000"
+        env_vars['PROCESS_STACK'] = "10240"
 
     if get_config('MAIN_STACK', required=False):
         env_vars['MAIN_STACK'] = get_config('MAIN_STACK')
     else:
-        env_vars['MAIN_STACK'] = "0x400"
+        env_vars['MAIN_STACK'] = "1024"
 
     if get_config('IOMCU_FW', required=False):
         env_vars['IOMCU_FW'] = get_config('IOMCU_FW')

--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -39,6 +39,9 @@ void NavEKF2_core::FuseAirspeed()
     float SK_TAS;
     Vector24 H_TAS;
     float VtasPred;
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
 
     // health is set bad until test passed
     tasHealth = false;
@@ -269,6 +272,10 @@ void NavEKF2_core::FuseSideslip()
     Vector3f vel_rel_wind;
     Vector24 H_BETA;
     float innovBeta;
+
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
 
     // copy required states to local variable names
     q0 = stateStruct.quat[0];

--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -22,6 +22,8 @@ extern const AP_HAL::HAL& hal;
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/priseborough/InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseAirspeed()
 {
     // start performance timer
@@ -188,6 +190,7 @@ void NavEKF2_core::FuseAirspeed()
     // stop performance timer
     hal.util->perf_end(_perf_FuseAirspeed);
 }
+#pragma GCC diagnostic pop
 
 // select fusion of true airspeed measurements
 void NavEKF2_core::SelectTasFusion()
@@ -251,6 +254,8 @@ void NavEKF2_core::SelectBetaFusion()
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/priseborough/InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseSideslip()
 {
     // start performance timer
@@ -439,6 +444,7 @@ void NavEKF2_core::FuseSideslip()
     // stop the performance timer
     hal.util->perf_end(_perf_FuseSideslip);
 }
+#pragma GCC diagnostic pop
 
 /********************************************************
 *                   MISC FUNCTIONS                      *

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -347,6 +347,10 @@ void NavEKF2_core::FuseMagnetometer()
     Vector6 SK_MY;
     Vector6 SK_MZ;
 
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
+
     hal.util->perf_end(_perf_test[1]);
     
     // perform sequential fusion of magnetometer measurements.
@@ -766,6 +770,10 @@ void NavEKF2_core::FuseMagnetometer()
 */
 void NavEKF2_core::fuseEulerYaw()
 {
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
+
     float q0 = stateStruct.quat[0];
     float q1 = stateStruct.quat[1];
     float q2 = stateStruct.quat[2];
@@ -1003,6 +1011,10 @@ void NavEKF2_core::fuseEulerYaw()
 */
 void NavEKF2_core::FuseDeclination(float declErr)
 {
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
+
     // declination error variance (rad^2)
     const float R_DECL = sq(declErr);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -322,6 +322,8 @@ void NavEKF2_core::SelectMagFusion()
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/priseborough/InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseMagnetometer()
 {
     hal.util->perf_begin(_perf_test[1]);
@@ -757,6 +759,7 @@ void NavEKF2_core::FuseMagnetometer()
     hal.util->perf_end(_perf_test[5]);
 
 }
+#pragma GCC diagnostic pop
 
 
 /*
@@ -768,6 +771,8 @@ void NavEKF2_core::FuseMagnetometer()
  * It is not as robust to magnetometer failures.
  * It is not suitable for operation where the horizontal magnetic field strength is weak (within 30 degrees latitude of the magnetic poles)
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::fuseEulerYaw()
 {
     Vector28 Kfusion; // Kalman gain vector
@@ -1001,6 +1006,7 @@ void NavEKF2_core::fuseEulerYaw()
         faultStatus.bad_yaw = true;
     }
 }
+#pragma GCC diagnostic pop
 
 /*
  * Fuse declination angle using explicit algebraic equations generated with Matlab symbolic toolbox.
@@ -1009,6 +1015,8 @@ void NavEKF2_core::fuseEulerYaw()
  * This is used to prevent the declination of the EKF earth field states from drifting during operation without GPS
  * or some other absolute position or velocity reference
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseDeclination(float declErr)
 {
     Vector28 Kfusion; // Kalman gain vector
@@ -1132,6 +1140,7 @@ void NavEKF2_core::FuseDeclination(float declErr)
         faultStatus.bad_decl = true;
     }
 }
+#pragma GCC diagnostic pop
 
 /********************************************************
 *                   MISC FUNCTIONS                      *

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -279,6 +279,8 @@ void NavEKF2_core::EstimateTerrainOffset()
  * https://github.com/priseborough/InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/GenerateNavFilterEquations.m
  * Requires a valid terrain height estimate.
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseOptFlow()
 {
     Vector24 H_LOS;
@@ -732,6 +734,7 @@ void NavEKF2_core::FuseOptFlow()
         }
     }
 }
+#pragma GCC diagnostic pop
 
 /********************************************************
 *                   MISC FUNCTIONS                      *

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -286,6 +286,10 @@ void NavEKF2_core::FuseOptFlow()
     Vector14 SH_LOS;
     Vector2 losPred;
 
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
+
     // Copy required states to local variable names
     float q0  = stateStruct.quat[0];
     float q1 = stateStruct.quat[1];

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -401,6 +401,9 @@ void NavEKF2_core::SelectVelPosFusion()
 // fuse selected position, velocity and height measurements
 void NavEKF2_core::FuseVelPosNED()
 {
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KHP;     // intermediate result used for covariance updates
+
     // start performance timer
     hal.util->perf_begin(_perf_FuseVelPosNED);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -399,6 +399,8 @@ void NavEKF2_core::SelectVelPosFusion()
 }
 
 // fuse selected position, velocity and height measurements
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseVelPosNED()
 {
     Vector28 Kfusion; // Kalman gain vector
@@ -773,6 +775,7 @@ void NavEKF2_core::FuseVelPosNED()
     // stop performance timer
     hal.util->perf_end(_perf_FuseVelPosNED);
 }
+#pragma GCC diagnostic pop
 
 /********************************************************
 *                   MISC FUNCTIONS                      *

--- a/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
@@ -44,6 +44,10 @@ void NavEKF2_core::FuseRngBcn()
     const float R_BCN = sq(MAX(rngBcnDataDelayed.rngErr , 0.1f));
     float rngPred;
 
+    Vector28 Kfusion; // Kalman gain vector
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
+
     // health is set bad until test passed
     rngBcnHealth = false;
 
@@ -253,6 +257,9 @@ https://github.com/priseborough/InertialNav/blob/master/derivations/range_beacon
 */
 void NavEKF2_core::FuseRngBcnStatic()
 {
+    Matrix24 KH;      // intermediate result used for covariance updates
+    Matrix24 KHP;     // intermediate result used for covariance updates
+
     // get the estimated range measurement variance
     const float R_RNG = sq(MAX(rngBcnDataDelayed.rngErr , 0.1f));
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
@@ -32,6 +32,8 @@ void NavEKF2_core::SelectRngBcnFusion()
     }
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseRngBcn()
 {
     // declarations
@@ -249,12 +251,16 @@ void NavEKF2_core::FuseRngBcn()
         rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].testRatio = rngBcnTestRatio;
     }
 }
+#pragma GCC diagnostic pop
 
 /*
 Use range beacon measurements to calculate a static position using a 3-state EKF algorithm.
 Algorithm based on the following:
 https://github.com/priseborough/InertialNav/blob/master/derivations/range_beacon.m
 */
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::FuseRngBcnStatic()
 {
     Matrix24 KH;      // intermediate result used for covariance updates
@@ -469,6 +475,7 @@ void NavEKF2_core::FuseRngBcnStatic()
         }
     }
 }
+#pragma GCC diagnostic pop
 
 /*
 Run a single state Kalman filter to estimate the vertical position offset of the range beacon constellation

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -820,6 +820,8 @@ void NavEKF2_core::calcOutputStates()
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/priseborough/InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF2_core::CovariancePrediction()
 {
     hal.util->perf_begin(_perf_CovariancePrediction);
@@ -1338,6 +1340,7 @@ void NavEKF2_core::CovariancePrediction()
 
     hal.util->perf_end(_perf_CovariancePrediction);
 }
+#pragma GCC diagnostic pop
 
 // zero specified range of rows in the state covariance matrix
 void NavEKF2_core::zeroRows(Matrix24 &covMat, uint8_t first, uint8_t last)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -779,9 +779,6 @@ private:
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
-    Vector28 Kfusion;               // Kalman gain vector
-    Matrix24 KH;                    // intermediate result used for covariance updates
-    Matrix24 KHP;                   // intermediate result used for covariance updates
     Matrix24 P;                     // covariance matrix
     imu_ring_buffer_t<imu_elements> storedIMU;      // IMU data buffer
     obs_ring_buffer_t<gps_elements> storedGPS;      // GPS data buffer
@@ -836,12 +833,6 @@ private:
     bool allMagSensorsFailed;       // true if all magnetometer sensors have timed out on this flight and we are no longer using magnetometer data
     uint32_t lastYawTime_ms;        // time stamp when yaw observation was last fused (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)
-    Matrix24 nextP;                 // Predicted covariance matrix before addition of process noise to diagonals
-    Vector24 processNoise;          // process noise added to diagonals of predicted covariance matrix
-    Vector25 SF;                    // intermediate variables used to calculate predicted covariance matrix
-    Vector5 SG;                     // intermediate variables used to calculate predicted covariance matrix
-    Vector8 SQ;                     // intermediate variables used to calculate predicted covariance matrix
-    Vector23 SPP;                   // intermediate variables used to calculate predicted covariance matrix
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold

--- a/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
@@ -20,6 +20,8 @@ extern const AP_HAL::HAL& hal;
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseAirspeed()
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -197,6 +199,7 @@ void NavEKF3_core::FuseAirspeed()
     // stop performance timer
     hal.util->perf_end(_perf_FuseAirspeed);
 }
+#pragma GCC diagnostic pop
 
 // select fusion of true airspeed measurements
 void NavEKF3_core::SelectTasFusion()
@@ -260,6 +263,8 @@ void NavEKF3_core::SelectBetaFusion()
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseSideslip()
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -469,6 +474,7 @@ void NavEKF3_core::FuseSideslip()
     // stop the performance timer
     hal.util->perf_end(_perf_FuseSideslip);
 }
+#pragma GCC diagnostic pop
 
 /********************************************************
 *                   MISC FUNCTIONS                      *

--- a/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
@@ -22,6 +22,10 @@ extern const AP_HAL::HAL& hal;
 */
 void NavEKF3_core::FuseAirspeed()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     // start performance timer
     hal.util->perf_begin(_perf_FuseAirspeed);
 
@@ -258,6 +262,10 @@ void NavEKF3_core::SelectBetaFusion()
 */
 void NavEKF3_core::FuseSideslip()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     // start performance timer
     hal.util->perf_begin(_perf_FuseSideslip);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -312,6 +312,10 @@ void NavEKF3_core::SelectMagFusion()
 */
 void NavEKF3_core::FuseMagnetometer()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     // declarations
     ftype &q0 = mag_state.q0;
     ftype &q1 = mag_state.q1;
@@ -749,6 +753,10 @@ void NavEKF3_core::FuseMagnetometer()
 */
 void NavEKF3_core::fuseEulerYaw()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     float q0 = stateStruct.quat[0];
     float q1 = stateStruct.quat[1];
     float q2 = stateStruct.quat[2];
@@ -974,6 +982,10 @@ void NavEKF3_core::fuseEulerYaw()
 */
 void NavEKF3_core::FuseDeclination(float declErr)
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     // declination error variance (rad^2)
     const float R_DECL = sq(declErr);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -310,6 +310,8 @@ void NavEKF3_core::SelectMagFusion()
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseMagnetometer()
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -740,6 +742,7 @@ void NavEKF3_core::FuseMagnetometer()
         }
     }
 }
+#pragma GCC diagnostic pop
 
 
 /*
@@ -751,6 +754,8 @@ void NavEKF3_core::FuseMagnetometer()
  * It is not as robust to magnetometer failures.
  * It is not suitable for operation where the horizontal magnetic field strength is weak (within 30 degrees latitude of the magnetic poles)
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::fuseEulerYaw()
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -972,6 +977,7 @@ void NavEKF3_core::fuseEulerYaw()
         faultStatus.bad_yaw = true;
     }
 }
+#pragma GCC diagnostic pop
 
 /*
  * Fuse declination angle using explicit algebraic equations generated with Matlab symbolic toolbox.
@@ -980,6 +986,8 @@ void NavEKF3_core::fuseEulerYaw()
  * This is used to prevent the declination of the EKF earth field states from drifting during operation without GPS
  * or some other absolute position or velocity reference
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseDeclination(float declErr)
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -1153,6 +1161,7 @@ void NavEKF3_core::FuseDeclination(float declErr)
         faultStatus.bad_decl = true;
     }
 }
+#pragma GCC diagnostic pop
 
 /********************************************************
 *                   MISC FUNCTIONS                      *

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -282,6 +282,8 @@ void NavEKF3_core::EstimateTerrainOffset()
  * https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
  * Requires a valid terrain height estimate.
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseOptFlow()
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -763,7 +765,7 @@ void NavEKF3_core::FuseOptFlow()
         }
     }
 }
-
+#pragma GCC diagnostic pop
 /********************************************************
 *                   MISC FUNCTIONS                      *
 ********************************************************/

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -284,6 +284,10 @@ void NavEKF3_core::EstimateTerrainOffset()
 */
 void NavEKF3_core::FuseOptFlow()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     Vector24 H_LOS;
     Vector3f relVelSensor;
     Vector14 SH_LOS;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -357,6 +357,9 @@ void NavEKF3_core::SelectVelPosFusion()
 // fuse selected position, velocity and height measurements
 void NavEKF3_core::FuseVelPosNED()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     // start performance timer
     hal.util->perf_begin(_perf_FuseVelPosNED);
 
@@ -920,6 +923,10 @@ void NavEKF3_core::selectHeightForFusion()
 */
 void NavEKF3_core::FuseBodyVel()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     Vector24 H_VEL;
     Vector3f bodyVelPred;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -355,6 +355,8 @@ void NavEKF3_core::SelectVelPosFusion()
 }
 
 // fuse selected position, velocity and height measurements
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseVelPosNED()
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -740,7 +742,7 @@ void NavEKF3_core::FuseVelPosNED()
     // stop performance timer
     hal.util->perf_end(_perf_FuseVelPosNED);
 }
-
+#pragma GCC diagnostic pop
 /********************************************************
 *                   MISC FUNCTIONS                      *
 ********************************************************/

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -46,6 +46,8 @@ void NavEKF3_core::SelectRngBcnFusion()
     }
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseRngBcn()
 {
     Vector28 Kfusion;               // Kalman gain vector
@@ -278,12 +280,15 @@ void NavEKF3_core::FuseRngBcn()
         rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].testRatio = rngBcnTestRatio;
     }
 }
+#pragma GCC diagnostic pop
 
 /*
 Use range beacon measurements to calculate a static position using a 3-state EKF algorithm.
 Algorithm based on the following:
 https://github.com/priseborough/InertialNav/blob/master/derivations/range_beacon.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::FuseRngBcnStatic()
 {
     Matrix24 KH;                    // intermediate result used for covariance updates
@@ -517,6 +522,7 @@ void NavEKF3_core::FuseRngBcnStatic()
         rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].testRatio = rngBcnTestRatio;
     }
 }
+#pragma GCC diagnostic pop
 
 /*
 Run a single state Kalman filter to estimate the vertical position offset of the range beacon constellation

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -48,6 +48,10 @@ void NavEKF3_core::SelectRngBcnFusion()
 
 void NavEKF3_core::FuseRngBcn()
 {
+    Vector28 Kfusion;               // Kalman gain vector
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     // declarations
     float pn;
     float pe;
@@ -282,6 +286,9 @@ https://github.com/priseborough/InertialNav/blob/master/derivations/range_beacon
 */
 void NavEKF3_core::FuseRngBcnStatic()
 {
+    Matrix24 KH;                    // intermediate result used for covariance updates
+    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     // get the estimated range measurement variance
     const float R_RNG = sq(MAX(rngBcnDataDelayed.rngErr , 0.1f));
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -207,7 +207,6 @@ void NavEKF3_core::InitialiseVariables()
     lastKnownPositionNE.zero();
     prevTnb.zero();
     memset(&P[0][0], 0, sizeof(P));
-    memset(&nextP[0][0], 0, sizeof(nextP));
     flowDataValid = false;
     rangeDataToFuse  = false;
     Popt = 0.0f;
@@ -872,6 +871,8 @@ void NavEKF3_core::CovariancePrediction()
     float dvx_b;        // X axis delta velocity measurement bias (rad)
     float dvy_b;        // Y axis delta velocity measurement bias (rad)
     float dvz_b;        // Z axis delta velocity measurement bias (rad)
+    Matrix24 nextP;     // Predicted covariance matrix before addition of process noise to diagonals
+
 
     // Calculate the time step used by the covariance prediction as an average of the gyro and accel integration period
     // Constrain to prevent bad timing jitter causing numerical conditioning problems with the covariance prediction

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -846,6 +846,8 @@ void NavEKF3_core::calcOutputStates()
  * The script file used to generate these and other equations in this filter can be found here:
  * https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wframe-larger-than=5300"
 void NavEKF3_core::CovariancePrediction()
 {
     hal.util->perf_begin(_perf_CovariancePrediction);
@@ -1354,6 +1356,7 @@ void NavEKF3_core::CovariancePrediction()
 
     hal.util->perf_end(_perf_CovariancePrediction);
 }
+#pragma GCC diagnostic pop
 
 // zero specified range of rows in the state covariance matrix
 void NavEKF3_core::zeroRows(Matrix24 &covMat, uint8_t first, uint8_t last)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -814,9 +814,7 @@ private:
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
-    Vector28 Kfusion;               // Kalman gain vector
-    Matrix24 KH;                    // intermediate result used for covariance updates
-    Matrix24 KHP;                   // intermediate result used for covariance updates
+
     Matrix24 P;                     // covariance matrix
     imu_ring_buffer_t<imu_elements> storedIMU;      // IMU data buffer
     obs_ring_buffer_t<gps_elements> storedGPS;      // GPS data buffer
@@ -870,7 +868,6 @@ private:
     bool allMagSensorsFailed;       // true if all magnetometer sensors have timed out on this flight and we are no longer using magnetometer data
     uint32_t lastSynthYawTime_ms;   // time stamp when synthetic yaw measurement was last fused to maintain covariance health (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)
-    Matrix24 nextP;                 // Predicted covariance matrix before addition of process noise to diagonals
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold


### PR DESCRIPTION
This reduces EKF RAM consumption by moving intermediate variables onto the stack. Since the stack is allocated on CCM RAM, this should keep these intermediate variables in CCM RAM while allowing the 3rd EKF to fit into CCM RAM, freeing ~16k of main RAM.

Tested on CubeBlack. Other platforms could potentially have stack depth issues.

2 EKF2s before patch: 76176 bytes free
3 EKF2s before patch: 59744 bytes free
2 EKF2s after patch: 90912 bytes free
3 EKF2s after patch: 81848 bytes free

2 EKF3s before patch: 76992 bytes free
3 EKF3s before patch: 60968 bytes free
2 EKF3s after patch: 91040 bytes free
3 EKF3s after patch: 82040 bytes free

Free stack after change (EKF2): 2608

This does introduce some warnings along the lines of "warning: the frame size of 5128 bytes is larger than 1024 bytes [-Wframe-larger-than=]" - perhaps that could be eliminated with a preprocessor statement or something.