### PR TITLE
Correct skyviper-v2450 / toymode compilation

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -410,7 +410,7 @@ void ToyMode::update()
         const uint8_t disarm_limit = copter.flightmode->has_manual_throttle()?TOY_LAND_MANUAL_DISARM_COUNT:TOY_LAND_DISARM_COUNT;
         if (throttle_low_counter >= disarm_limit) {
             gcs().send_text(MAV_SEVERITY_INFO, "Tmode: throttle disarm");
-            copter.init_disarm_motors();
+            copter.arming.disarm();
         }
     } else {
         throttle_low_counter = 0;
@@ -569,7 +569,7 @@ void ToyMode::update()
     case ACTION_DISARM:
         if (copter.motors->armed()) {
             gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: Force disarm");
-            copter.init_disarm_motors();
+            copter.arming.disarm();
         }
         break;
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -44,7 +44,12 @@ class Board:
         self.configure_env(cfg, env)
 
         # Setup scripting, had to defer this to allow checking board size
-        if (not cfg.options.disable_scripting) and ((cfg.env.BOARD_FLASH_SIZE is None) or (cfg.env.BOARD_FLASH_SIZE == []) or (cfg.env.BOARD_FLASH_SIZE > 1024)):
+        if ((not cfg.options.disable_scripting) and
+            (not cfg.env.DISABLE_SCRIPTING) and
+            ((cfg.env.BOARD_FLASH_SIZE is None) or
+             (cfg.env.BOARD_FLASH_SIZE == []) or
+             (cfg.env.BOARD_FLASH_SIZE > 1024))):
+
             env.DEFINES.update(
                 ENABLE_SCRIPTING = 1,
                 ENABLE_HEAP = 1,

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -540,6 +540,7 @@ def write_mcu_config(f):
     else:
         f.write('#define HAL_USE_SDC FALSE\n')
         build_flags.append('USE_FATFS=no')
+        env_vars['DISABLE_SCRIPTING'] = True
     if 'OTG1' in bytype:
         f.write('#define STM32_USB_USE_OTG1                  TRUE\n')
         f.write('#define HAL_USE_USB TRUE\n')


### PR DESCRIPTION
Two fixes here.

The first is that SkyViper excludes FatFS from the build (no SD card....), so scripting breaks.

The second is a fix for toymode - missing patches from moving init_disarm_motors into AP_Arming_Copter.

This has only been tested to compile - I haven't flown it, but then, these patches shouldn't make any difference there.
