### PR TITLE
Correct target system id /component id in MISSION_ITEM responses

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -1140,7 +1140,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             raise NotAchievedException("Bad count received (want=%u got=%u)" %
                                        (expected_count, m.count))
 
-    def get_mission_item_on_link(self, item, mav, target_system, target_component, mission_type):
+    def get_mission_item_int_on_link(self, item, mav, target_system, target_component, mission_type):
         mav.mav.mission_request_int_send(target_system,
                                          target_component,
                                          item,
@@ -1384,9 +1384,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.progress("Assert mission count on original link")
             self.assert_mission_count_on_link(self.mav, expected_count, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             self.progress("Get first item on new link")
-            m2 = self.get_mission_item_on_link(2, mav2, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            m2 = self.get_mission_item_int_on_link(2, mav2, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             self.progress("Get first item on original link")
-            m = self.get_mission_item_on_link(2, self.mav, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            m = self.get_mission_item_int_on_link(2, self.mav, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             if m2.x != m.x:
                 raise NotAchievedException("mission items do not match (%d vs %d)" % (m2.x, m.x))
             self.start_subtest("Should enforce items come from correct GCS")

--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -1158,6 +1158,24 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                        (m.target_component, mav.mav.srcComponent))
         return m
 
+    def get_mission_item_on_link(self, item, mav, target_system, target_component, mission_type):
+        mav.mav.mission_request_send(target_system,
+                                     target_component,
+                                     item,
+                                     mission_type)
+        m = mav.recv_match(type='MISSION_ITEM',
+                           blocking=True,
+                           timeout=1)
+        if m is None:
+            raise NotAchievedException("Did not receive mission item int")
+        if m.target_system != mav.mav.srcSystem:
+            raise NotAchievedException("Unexpected target system %u want=%u" %
+                                       (m.target_system, mav.mav.srcSystem))
+        if m.target_component != mav.mav.srcComponent:
+            raise NotAchievedException("Unexpected target component %u want=%u" %
+                                       (m.target_component, mav.mav.srcComponent))
+        return m
+
     def send_clear_mission(self, mission_type, target_system, target_component):
         self.mav.mav.mission_count_send(target_system,
                                         target_component,
@@ -1389,6 +1407,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             m = self.get_mission_item_int_on_link(2, self.mav, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             if m2.x != m.x:
                 raise NotAchievedException("mission items do not match (%d vs %d)" % (m2.x, m.x))
+            m_nonint = self.get_mission_item_on_link(2, self.mav, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             self.start_subtest("Should enforce items come from correct GCS")
             self.mav.mav.mission_count_send(target_system,
                                             target_component,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -673,6 +673,9 @@ void MissionItemProtocol::handle_mission_request(const GCS_MAVLINK &_link,
     convert_MISSION_REQUEST_to_MISSION_REQUEST_INT(packet, request_int);
 
     mavlink_mission_item_int_t item_int{};
+    item_int.target_system = msg.sysid;
+    item_int.target_component = msg.compid;
+
     MAV_MISSION_RESULT ret = get_item(_link, msg, request_int, item_int);
     if (ret != MAV_MISSION_ACCEPTED) {
         return;


### PR DESCRIPTION
.... as opposed to MISSION_ITEM_INT responses.

Reported by mice5 here: https://github.com/ArduPilot/ardupilot/pull/10409
