### PR TITLE
GCS_Param: correct sending of parameters of length 16

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -304,8 +304,9 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg)
  */
 void GCS::send_parameter_value(const char *param_name, ap_var_type param_type, float param_value)
 {
-    mavlink_param_value_t packet;
-    strncpy(packet.param_id, param_name, ARRAY_SIZE(packet.param_id));
+    mavlink_param_value_t packet{};
+    const uint8_t to_copy = MIN(ARRAY_SIZE(packet.param_id), strlen(param_name));
+    memcpy(packet.param_id, param_name, to_copy);
     packet.param_value = param_value;
     packet.param_type = mav_param_type(param_type);
     packet.param_count = AP_Param::count_parameters();


### PR DESCRIPTION
This stops relying on any null-termination behaviour strncpy may have.

At least in SITL this change seems to be a no-op for me - i.e. strncpy is leaving he buffer non-null-terminated.
