### PR TITLE
AP_Math: Polygon_intersects handles unclosed polygons

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -122,6 +122,9 @@ bool AP_OADijkstra::polygon_fence_enabled() const
     if (fence == nullptr) {
         return false;
     }
+    if (!fence->is_polygon_valid()) {
+        return false;
+    }
     return ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) > 0);
 }
 

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -251,7 +251,6 @@ bool AP_OADijkstra::create_polygon_fence_visgraph()
                                              {AP_OAVisGraph::OATYPE_FENCE_POINT, j},
                                              (_polyfence_pts[i] - _polyfence_pts[j]).length());
             }
-            // ToDo: store infinity when there is no clear path between points to allow faster search later
         }
     }
 

--- a/libraries/AP_Math/polygon.cpp
+++ b/libraries/AP_Math/polygon.cpp
@@ -132,10 +132,21 @@ template bool Polygon_complete<float>(const Vector2f *V, unsigned n);
  */
 bool Polygon_intersects(const Vector2f *V, unsigned N, const Vector2f &p1, const Vector2f &p2, Vector2f &intersection)
 {
+    const bool complete = Polygon_complete(V, N);
+    if (complete) {
+        // if the last point is the same as the first point
+        // treat as if the last point wasn't passed in
+        N--;
+    }
+
     float intersect_dist_sq = FLT_MAX;
-    for (uint8_t i=0; i<N-1; i++) {
+    for (uint8_t i=0; i<N; i++) {
+        uint8_t j = i+1;
+        if (j >= N) {
+            j = 0;
+        }
         const Vector2f &v1 = V[i];
-        const Vector2f &v2 = V[i+1];
+        const Vector2f &v2 = V[j];
         // optimisations for common cases
         if (v1.x > p1.x && v2.x > p1.x && v1.x > p2.x && v2.x > p2.x) {
             continue;


### PR DESCRIPTION
This PR resolves two problems affecting avoidance in Rover:

- AP_Math's Polygon_intersects is enhanced to handle unclosed polygons which resolves this issue: https://github.com/ArduPilot/ardupilot/issues/11687.  This function is only used by AP_OADijkstra's and would lead to vehicle's attempting to drive through the polygon fence in some cases.  The before-and-after picture below shows a test in SITL in which a target is placed outside the fence (in Guided mode).  "Before" the vehicle attempts to drive through the fence, "After" it correctly stops.
![polygon-intersect-fix-before-after](https://user-images.githubusercontent.com/1498098/60761857-7c225080-a08c-11e9-9d50-2703760940c7.png)
- The second small fix is to cause Dijkstra's to turn off avoidance and just drive straight to the point if the polygon fence is cleared (i.e. no points).
- Finally there's a small commit to remove an out-of-date comment

