### PR TITLE
Split sending of RC_CHANNELS and RC_CHANNELS_RAW

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -463,7 +463,8 @@ static const ap_message STREAM_RAW_CONTROLLER_msgs[] = {
 };
 static const ap_message STREAM_RC_CHANNELS_msgs[] = {
     MSG_SERVO_OUTPUT_RAW,
-    MSG_RADIO_IN
+    MSG_RC_CHANNELS,
+    MSG_RC_CHANNELS_RAW, // only sent on a mavlink1 connection
 };
 static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -256,7 +256,8 @@ static const ap_message STREAM_RAW_CONTROLLER_msgs[] = {
     MSG_SERVO_OUTPUT_RAW,
 };
 static const ap_message STREAM_RC_CHANNELS_msgs[] = {
-    MSG_RADIO_IN
+    MSG_RC_CHANNELS,
+    MSG_RC_CHANNELS_RAW, // only sent on a mavlink1 connection
 };
 static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -402,7 +402,8 @@ static const ap_message STREAM_POSITION_msgs[] = {
 };
 static const ap_message STREAM_RC_CHANNELS_msgs[] = {
     MSG_SERVO_OUTPUT_RAW,
-    MSG_RADIO_IN // RC_CHANNELS_RAW, RC_CHANNELS
+    MSG_RC_CHANNELS,
+    MSG_RC_CHANNELS_RAW, // only sent on a mavlink1 connection
 };
 static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -574,7 +574,8 @@ static const ap_message STREAM_RAW_CONTROLLER_msgs[] = {
 };
 static const ap_message STREAM_RC_CHANNELS_msgs[] = {
     MSG_SERVO_OUTPUT_RAW,
-    MSG_RADIO_IN
+    MSG_RC_CHANNELS,
+    MSG_RC_CHANNELS_RAW, // only sent on a mavlink1 connection
 };
 static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -343,7 +343,8 @@ static const ap_message STREAM_POSITION_msgs[] = {
 };
 static const ap_message STREAM_RC_CHANNELS_msgs[] = {
     MSG_SERVO_OUTPUT_RAW,
-    MSG_RADIO_IN
+    MSG_RC_CHANNELS,
+    MSG_RC_CHANNELS_RAW, // only sent on a mavlink1 connection
 };
 static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -42,7 +42,8 @@ enum ap_message : uint8_t {
     MSG_CURRENT_WAYPOINT,
     MSG_VFR_HUD,
     MSG_SERVO_OUTPUT_RAW,
-    MSG_RADIO_IN,
+    MSG_RC_CHANNELS,
+    MSG_RC_CHANNELS_RAW,
     MSG_RAW_IMU,
     MSG_SCALED_IMU,
     MSG_SCALED_IMU2,
@@ -407,7 +408,8 @@ public:
     void send_ahrs2();
     void send_ahrs3();
     void send_system_time();
-    void send_radio_in();
+    void send_rc_channels() const;
+    void send_rc_channels_raw() const;
     void send_raw_imu();
 
     void send_scaled_pressure_instance(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_boot_ms, float press_abs, float press_diff, int16_t temperature));

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1152,7 +1152,8 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_MISSION_CURRENT,       MSG_CURRENT_WAYPOINT},
         { MAVLINK_MSG_ID_VFR_HUD,               MSG_VFR_HUD},
         { MAVLINK_MSG_ID_SERVO_OUTPUT_RAW,      MSG_SERVO_OUTPUT_RAW},
-        { MAVLINK_MSG_ID_RC_CHANNELS,           MSG_RADIO_IN},
+        { MAVLINK_MSG_ID_RC_CHANNELS,           MSG_RC_CHANNELS},
+        { MAVLINK_MSG_ID_RC_CHANNELS_RAW,       MSG_RC_CHANNELS_RAW},
         { MAVLINK_MSG_ID_RAW_IMU,               MSG_RAW_IMU},
         { MAVLINK_MSG_ID_SCALED_IMU,            MSG_SCALED_IMU},
         { MAVLINK_MSG_ID_SCALED_IMU2,           MSG_SCALED_IMU2},
@@ -1899,7 +1900,7 @@ void GCS_MAVLINK::send_system_time()
 /*
   send RC_CHANNELS messages
  */
-void GCS_MAVLINK::send_radio_in()
+void GCS_MAVLINK::send_rc_channels() const
 {
     AP_RSSI *rssi = AP::rssi();
     uint8_t receiver_rssi = 0;
@@ -1907,35 +1908,12 @@ void GCS_MAVLINK::send_radio_in()
         receiver_rssi = rssi->read_receiver_rssi_uint8();
     }
 
-    uint32_t now = AP_HAL::millis();
-    mavlink_status_t *status = mavlink_get_channel_status(chan);
-
     uint16_t values[18] = {};
     rc().get_radio_in(values, ARRAY_SIZE(values));
 
-    if (status && (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
-        // for mavlink1 send RC_CHANNELS_RAW, for compatibility with OSD implementations
-        mavlink_msg_rc_channels_raw_send(
-            chan,
-            now,
-            0,
-            values[0],
-            values[1],
-            values[2],
-            values[3],
-            values[4],
-            values[5],
-            values[6],
-            values[7],
-            receiver_rssi);
-    }
-    if (!HAVE_PAYLOAD_SPACE(chan, RC_CHANNELS)) {
-        // can't fit RC_CHANNELS
-        return;
-    }
     mavlink_msg_rc_channels_send(
         chan,
-        now,
+        AP_HAL::millis(),
         RC_Channels::get_valid_channel_count(),
         values[0],
         values[1],
@@ -1956,6 +1934,41 @@ void GCS_MAVLINK::send_radio_in()
         values[16],
         values[17],
         receiver_rssi);        
+}
+
+void GCS_MAVLINK::send_rc_channels_raw() const
+{
+    mavlink_status_t *status = mavlink_get_channel_status(chan);
+    if (status == nullptr) {
+        // should not happen
+        return;
+    }
+    // for mavlink1 send RC_CHANNELS_RAW, for compatibility with OSD
+    // implementations
+    if (!(status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
+        return;
+    }
+    AP_RSSI *rssi = AP::rssi();
+    uint8_t receiver_rssi = 0;
+    if (rssi != nullptr) {
+        receiver_rssi = rssi->read_receiver_rssi_uint8();
+    }
+    uint16_t values[8] = {};
+    rc().get_radio_in(values, ARRAY_SIZE(values));
+
+    mavlink_msg_rc_channels_raw_send(
+        chan,
+        AP_HAL::millis(),
+        0,
+        values[0],
+        values[1],
+        values[2],
+        values[3],
+        values[4],
+        values[5],
+        values[6],
+        values[7],
+        receiver_rssi);
 }
 
 void GCS_MAVLINK::send_raw_imu()
@@ -4557,9 +4570,14 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         send_power_status();
         break;
 
-    case MSG_RADIO_IN:
+    case MSG_RC_CHANNELS:
+        CHECK_PAYLOAD_SIZE(RC_CHANNELS);
+        send_rc_channels();
+        break;
+
+    case MSG_RC_CHANNELS_RAW:
         CHECK_PAYLOAD_SIZE(RC_CHANNELS_RAW);
-        send_radio_in();
+        send_rc_channels_raw();
         break;
 
     case MSG_RAW_IMU:


### PR DESCRIPTION
    Before this patch is applied we may never send the second message
    because there's not room for it in the buffer and we can't return
    failure-to-send (always interpreted as "retry") as we're in a void function.
    
    Further, if you are on a mavlink2 connection we will not send out the
    RC_CHANNELS_RAW message, depriving the user of any RC_CHANNELS messages.
    
    This patch does have the drawback of doing more work on a mavlink1
    connection - it has to fetch the data twice.  On the other hand, it also
    allows the GCS to set the message rates independently for both
    RC_CHANNELS and RC_CHANNELS_RAW so one or the other can be squelched.
    That could be handy for reducing bandwidth if you know you're not using
    more than 8 input channels.
