### PR TITLE
Plane: improved fixed wing integrator handling

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -370,7 +370,17 @@ void Plane::stabilize()
         nav_pitch_cd = constrain_float((quadplane.tailsitter.transition_angle+5)*100, 5500, 8500),
         nav_roll_cd = 0;
     }
-    
+
+    uint32_t now = AP_HAL::millis();
+    if (now - last_stabilize_ms > 2000) {
+        // if we haven't run the rate controllers for 2 seconds then
+        // reset the integrators
+        rollController.reset_I();
+        pitchController.reset_I();
+        yawController.reset_I();
+    }
+    last_stabilize_ms = now;
+
     if (control_mode == &mode_training) {
         stabilize_training(speed_scaler);
     } else if (control_mode == &mode_acro) {

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -28,6 +28,12 @@ float Plane::get_speed_scaler(void)
             if (aspeed < threshold) {
                 float new_scaler = linear_interpolate(0, g.scaling_speed / threshold, aspeed, 0, threshold);
                 speed_scaler = MIN(speed_scaler, new_scaler);
+
+                // we also decay the integrator to prevent an integrator from before
+                // we were at low speed persistint at high speed
+                rollController.decay_I();
+                pitchController.decay_I();
+                yawController.decay_I();
             }
         }
     } else if (hal.util->get_soft_armed()) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -349,6 +349,9 @@ private:
     // This is used to enable the inverted flight feature
     bool inverted_flight;
 
+    // last time we ran roll/pitch stabilization
+    uint32_t last_stabilize_ms;
+    
     // Failsafe
     struct {
         // Used to track if the value on channel 3 (throtttle) has fallen below the failsafe threshold

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -26,6 +26,14 @@ public:
 
 	void reset_I();
 
+    /*
+      reduce the integrator, used when we have a low scale factor in a quadplane hover
+    */
+    void decay_I() {
+        // this reduces integrator by 95% over 2s
+        _pid_info.I *= 0.995f;
+    }
+    
     void autotune_start(void) { autotune.start(); }
     void autotune_restore(void) { autotune.stop(); }
 

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -26,6 +26,14 @@ public:
 
 	void reset_I();
 
+    /*
+      reduce the integrator, used when we have a low scale factor in a quadplane hover
+    */
+    void decay_I() {
+        // this reduces integrator by 95% over 2s
+        _pid_info.I *= 0.995f;
+    }
+    
     void autotune_start(void) { autotune.start(); }
     void autotune_restore(void) { autotune.stop(); }
 

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -26,6 +26,14 @@ public:
 
 	void reset_I();
 
+    /*
+      reduce the integrator, used when we have a low scale factor in a quadplane hover
+    */
+    void decay_I() {
+        // this reduces integrator by 95% over 2s
+        _pid_info.I *= 0.995f;
+    }
+    
 	const AP_Logger::PID_Info& get_pid_info(void) const {return _pid_info; }
 
 	static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
This fixes two issues seen in quadplane flights. The first is leftover integrator from previous flight modes. The 2nd is rate integrator remaining when speed scaling is zero at low airspeed in gover
