### PR TITLE
Refactor battery current interface

### DIFF
--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -75,8 +75,10 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
     // disable cpu failsafe
     failsafe_disable();
 
+    float current;
+
     // default compensation type to use current if possible
-    if (battery.has_current()) {
+    if (battery.current_amps(current)) {
         comp_type = AP_COMPASS_MOT_COMP_CURRENT;
     } else {
         comp_type = AP_COMPASS_MOT_COMP_THROTTLE;
@@ -157,6 +159,11 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
         throttle_pct = (float)channel_throttle->get_control_in() / 1000.0f;
         throttle_pct = constrain_float(throttle_pct,0.0f,1.0f);
 
+        if (!battery.current_amps(current)) {
+            current = 0;
+        }
+        current_amps_max = MAX(current_amps_max, current);
+
         // if throttle is near zero, update base x,y,z values
         if (throttle_pct <= 0.0f) {
             for (uint8_t i=0; i<compass.get_count(); i++) {
@@ -182,11 +189,9 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
             } else {
                 // for each compass
                 for (uint8_t i=0; i<compass.get_count(); i++) {
-                    // current based compensation if more than 3amps being drawn
-                    motor_impact_scaled[i] = motor_impact[i] / battery.current_amps();
-
                     // adjust the motor compensation to negate the impact if drawing over 3amps
-                    if (battery.current_amps() >= 3.0f) {
+                    if (current >= 3.0f) {
+                        motor_impact_scaled[i] = motor_impact[i] / current;
                         motor_compensation[i] = motor_compensation[i] * 0.99f - motor_impact_scaled[i] * 0.01f;
                         updated = true;
                     }
@@ -206,16 +211,15 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
                 }
             }
 
-            // record maximum throttle and current
+            // record maximum throttle
             throttle_pct_max = MAX(throttle_pct_max, throttle_pct);
-            current_amps_max = MAX(current_amps_max, battery.current_amps());
         }
 
         if (AP_HAL::millis() - last_send_time > 500) {
             last_send_time = AP_HAL::millis();
             mavlink_msg_compassmot_status_send(gcs_chan.get_chan(),
                                                channel_throttle->get_control_in(),
-                                               battery.current_amps(),
+                                               current,
                                                interference_pct[compass.get_primary()],
                                                motor_compensation[compass.get_primary()].x,
                                                motor_compensation[compass.get_primary()].y,

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -96,14 +96,6 @@ public:
     bool healthy(uint8_t instance) const;
     bool healthy() const { return healthy(AP_BATT_PRIMARY_INSTANCE); }
 
-    /// has_consumed_energy - returns true if battery monitor instance provides consumed energy info
-    bool has_consumed_energy(uint8_t instance) const;
-    bool has_consumed_energy() const { return has_consumed_energy(AP_BATT_PRIMARY_INSTANCE); }
-
-    /// has_current - returns true if battery monitor instance provides current info
-    bool has_current(uint8_t instance) const;
-    bool has_current() const { return has_current(AP_BATT_PRIMARY_INSTANCE); }
-
     /// voltage - returns battery voltage in millivolts
     float voltage(uint8_t instance) const;
     float voltage() const { return voltage(AP_BATT_PRIMARY_INSTANCE); }
@@ -114,16 +106,13 @@ public:
     float voltage_resting_estimate() const { return voltage_resting_estimate(AP_BATT_PRIMARY_INSTANCE); }
 
     /// current_amps - returns the instantaneous current draw in amperes
-    float current_amps(uint8_t instance) const;
-    float current_amps() const { return current_amps(AP_BATT_PRIMARY_INSTANCE); }
+    bool current_amps(float &current, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
 
     /// consumed_mah - returns total current drawn since start-up in milliampere.hours
-    float consumed_mah(uint8_t instance) const;
-    float consumed_mah() const { return consumed_mah(AP_BATT_PRIMARY_INSTANCE); }
+    bool consumed_mah(float &mah, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
 
     /// consumed_wh - returns total energy drawn since start-up in watt.hours
-    float consumed_wh(uint8_t instance) const;
-    float consumed_wh() const { return consumed_wh(AP_BATT_PRIMARY_INSTANCE); }
+    bool consumed_wh(float&wh, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;
 
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     virtual uint8_t capacity_remaining_pct(uint8_t instance) const;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
@@ -37,8 +37,9 @@ AP_BattMonitor_Sum::read()
         }
         voltage_sum += _mon.voltage(i);
         voltage_count++;
-        if (_mon.has_current(i)) {
-            current_sum += _mon.current_amps(i);
+        float current;
+        if (_mon.current_amps(current, i)) {
+            current_sum += current;
             current_count++;
         }
     }

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -81,8 +81,9 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
         state.motor_offset = mot * _compass._thr;
     } else if (_compass._motor_comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
         AP_BattMonitor &battery = AP::battery();
-        if (battery.has_current()) {
-            state.motor_offset = mot * battery.current_amps();
+        float current;
+        if (battery.current_amps(current)) {
+            state.motor_offset = mot * current;
         }
     }
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -637,13 +637,13 @@ void AP_Logger::Write_Current_instance(const uint64_t time_us,
     bool has_temp = battery.get_temperature(temp, battery_instance);
     float current, consumed_mah, consumed_wh;
     if (!battery.current_amps(current)) {
-        current = 0;
+        current = quiet_nanf();
     }
     if (!battery.consumed_mah(consumed_mah, battery_instance)) {
-        consumed_mah = 0;
+        consumed_mah = quiet_nanf();
     }
     if (!battery.consumed_wh(consumed_wh, battery_instance)) {
-        consumed_wh = 0;
+        consumed_wh = quiet_nanf();
     }
 
     struct log_Current pkt = {

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -635,14 +635,25 @@ void AP_Logger::Write_Current_instance(const uint64_t time_us,
     AP_BattMonitor &battery = AP::battery();
     float temp;
     bool has_temp = battery.get_temperature(temp, battery_instance);
+    float current, consumed_mah, consumed_wh;
+    if (!battery.current_amps(current)) {
+        current = 0;
+    }
+    if (!battery.consumed_mah(consumed_mah, battery_instance)) {
+        consumed_mah = 0;
+    }
+    if (!battery.consumed_wh(consumed_wh, battery_instance)) {
+        consumed_wh = 0;
+    }
+
     struct log_Current pkt = {
         LOG_PACKET_HEADER_INIT(type),
         time_us             : time_us,
         voltage             : battery.voltage(battery_instance),
         voltage_resting     : battery.voltage_resting_estimate(battery_instance),
-        current_amps        : battery.current_amps(battery_instance),
-        current_total       : battery.consumed_mah(battery_instance),
-        consumed_wh         : battery.consumed_wh(battery_instance),
+        current_amps        : current,
+        current_total       : consumed_mah,
+        consumed_wh         : consumed_wh,
         temperature         : (int16_t)(has_temp ? (temp * 100) : 0),
         resistance          : battery.get_resistance(battery_instance)
     };

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -348,11 +348,10 @@ void AP_Motors6DOF::output_armed_stabilizing()
     const AP_BattMonitor &battery = AP::battery();
 
 	// Current limiting
-    if (_batt_current_max <= 0.0f || !battery.has_current()) {
+    float _batt_current;
+    if (_batt_current_max <= 0.0f || !battery.current_amps(_batt_current)) {
         return;
     }
-
-    float _batt_current = battery.current_amps();
 
     float _batt_current_delta = _batt_current - _batt_current_last;
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -287,9 +287,11 @@ float AP_MotorsMulticopter::get_current_limit_max_throttle()
 {
     AP_BattMonitor &battery = AP::battery();
 
+    float _batt_current;
+
     if (_batt_current_max <= 0 || // return maximum if current limiting is disabled
         !_flags.armed || // remove throttle limit if disarmed
-        !battery.has_current(_batt_idx)) { // no current monitoring is available
+        !battery.current_amps(_batt_current, _batt_idx)) { // no current monitoring is available
         _throttle_limit = 1.0f;
         return 1.0f;
     }
@@ -300,8 +302,6 @@ float AP_MotorsMulticopter::get_current_limit_max_throttle()
         _throttle_limit = 1.0f;
         return 1.0f;
     }
-
-    float _batt_current = battery.current_amps(_batt_idx);
 
     // calculate the maximum current to prevent voltage sag below _batt_voltage_min
     float batt_current_max = MIN(_batt_current_max, _batt_current + (battery.voltage(_batt_idx) - _batt_voltage_min) / _batt_resistance);

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -275,8 +275,10 @@ void AP_OSD::stats()
     max_alt_m = fmaxf(max_alt_m, alt);
     // maximum current
     AP_BattMonitor &battery = AP::battery();
-    float amps = battery.current_amps();
-    max_current_a = fmaxf(max_current_a, amps);
+    float amps;
+    if (battery.current_amps(amps)) {
+        max_current_a = fmaxf(max_current_a, amps);
+    }
 }
 
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -135,6 +135,7 @@ private:
     void draw_rssi(uint8_t x, uint8_t y);
     void draw_current(uint8_t x, uint8_t y);
     void draw_batused(uint8_t x, uint8_t y);
+    void draw_batused(uint8_t instance, uint8_t x, uint8_t y);
     void draw_sats(uint8_t x, uint8_t y);
     void draw_fltmode(uint8_t x, uint8_t y);
     void draw_message(uint8_t x, uint8_t y);

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -36,13 +36,11 @@ include AP_BattMonitor/AP_BattMonitor.h
 singleton AP_BattMonitor alias battery
 singleton AP_BattMonitor method num_instances uint8_t
 singleton AP_BattMonitor method healthy boolean uint8_t 0 ud->num_instances()
-singleton AP_BattMonitor method has_consumed_energy boolean uint8_t 0 ud->num_instances()
-singleton AP_BattMonitor method has_current boolean uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method voltage float uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method voltage_resting_estimate float uint8_t 0 ud->num_instances()
-singleton AP_BattMonitor method current_amps float uint8_t 0 ud->num_instances()
-singleton AP_BattMonitor method consumed_mah float uint8_t 0 ud->num_instances()
-singleton AP_BattMonitor method consumed_wh float uint8_t 0 ud->num_instances()
+singleton AP_BattMonitor method current_amps boolean float'Null uint8_t 0 ud->num_instances()
+singleton AP_BattMonitor method consumed_mah boolean float'Null uint8_t 0 ud->num_instances()
+singleton AP_BattMonitor method consumed_wh boolean float'Null uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method capacity_remaining_pct uint8_t uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method pack_capacity_mah int32_t uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method has_failsafed boolean

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1032,12 +1032,6 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
   fprintf(source, "static int %s_%s(lua_State *L) {\n", data->name, method->name);
   // emit comments on expected arg/type
   struct argument *arg = method->arguments;
-  while (arg != NULL) {
-    fprintf(source, "    // %d %s %d : %d\n", arg_count++, arg->type.type == TYPE_USERDATA ? arg->type.data.userdata_name :
-                                                                                             arg->type.type == TYPE_ENUM ? arg->type.data.enum_name : type_labels[arg->type.type],
-                                      arg->line_num, arg->token_num);
-    arg = arg->next;
-  }
 
   if (data->ud_type == UD_SINGLETON) {
       // fetch and check the singleton pointer
@@ -1048,7 +1042,6 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
   }
 
   // sanity check number of args called with
-  arg = method->arguments;
   arg_count = 1;
   while (arg != NULL) {
     if (!(arg->type.flags & TYPE_FLAGS_NULLABLE)) {

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -474,8 +474,8 @@ const luaL_Reg Location_meta[] = {
 };
 
 static int GCS_send_text(lua_State *L) {
-    // 1 MAV_SEVERITY 129 : 8
-    // 2 enum 129 : 9
+    // 1 MAV_SEVERITY 127 : 8
+    // 2 enum 127 : 9
     GCS * ud = GCS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 3, "gcs not supported on this firmware");
@@ -494,7 +494,7 @@ static int GCS_send_text(lua_State *L) {
 }
 
 static int AP_Relay_toggle(lua_State *L) {
-    // 1 uint8_t 125 : 8
+    // 1 uint8_t 123 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "relay not supported on this firmware");
@@ -511,7 +511,7 @@ static int AP_Relay_toggle(lua_State *L) {
 }
 
 static int AP_Relay_enabled(lua_State *L) {
-    // 1 uint8_t 124 : 8
+    // 1 uint8_t 122 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "relay not supported on this firmware");
@@ -529,7 +529,7 @@ static int AP_Relay_enabled(lua_State *L) {
 }
 
 static int AP_Relay_off(lua_State *L) {
-    // 1 uint8_t 123 : 8
+    // 1 uint8_t 121 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "relay not supported on this firmware");
@@ -546,7 +546,7 @@ static int AP_Relay_off(lua_State *L) {
 }
 
 static int AP_Relay_on(lua_State *L) {
-    // 1 uint8_t 122 : 8
+    // 1 uint8_t 120 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "relay not supported on this firmware");
@@ -563,8 +563,8 @@ static int AP_Relay_on(lua_State *L) {
 }
 
 static int AP_Terrain_height_above_terrain(lua_State *L) {
-    // 1 float 117 : 6
-    // 2 bool 117 : 7
+    // 1 float 115 : 6
+    // 2 bool 115 : 7
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 3, "terrain not supported on this firmware");
@@ -586,9 +586,9 @@ static int AP_Terrain_height_above_terrain(lua_State *L) {
 }
 
 static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
-    // 1 float 116 : 8
-    // 2 float 116 : 9
-    // 3 bool 116 : 10
+    // 1 float 114 : 8
+    // 2 float 114 : 9
+    // 3 bool 114 : 10
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 4, "terrain not supported on this firmware");
@@ -614,8 +614,8 @@ static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
 }
 
 static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
-    // 1 float 115 : 6
-    // 2 bool 115 : 7
+    // 1 float 113 : 6
+    // 2 bool 113 : 7
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 3, "terrain not supported on this firmware");
@@ -637,9 +637,9 @@ static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
 }
 
 static int AP_Terrain_height_amsl(lua_State *L) {
-    // 1 Location 114 : 6
-    // 2 float 114 : 7
-    // 3 bool 114 : 8
+    // 1 Location 112 : 6
+    // 2 float 112 : 7
+    // 3 bool 112 : 8
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 4, "terrain not supported on this firmware");
@@ -705,7 +705,7 @@ static int RangeFinder_num_sensors(lua_State *L) {
 }
 
 static int AP_Notify_play_tune(lua_State *L) {
-    // 1 enum 102 : 6
+    // 1 enum 100 : 6
     AP_Notify * ud = AP_Notify::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "AP_Notify not supported on this firmware");
@@ -748,7 +748,7 @@ static int AP_GPS_all_configured(lua_State *L) {
 }
 
 static int AP_GPS_get_antenna_offset(lua_State *L) {
-    // 1 uint8_t 73 : 8
+    // 1 uint8_t 71 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -767,7 +767,7 @@ static int AP_GPS_get_antenna_offset(lua_State *L) {
 }
 
 static int AP_GPS_have_vertical_velocity(lua_State *L) {
-    // 1 uint8_t 72 : 8
+    // 1 uint8_t 70 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -785,7 +785,7 @@ static int AP_GPS_have_vertical_velocity(lua_State *L) {
 }
 
 static int AP_GPS_last_message_time_ms(lua_State *L) {
-    // 1 uint8_t 71 : 8
+    // 1 uint8_t 69 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -804,7 +804,7 @@ static int AP_GPS_last_message_time_ms(lua_State *L) {
 }
 
 static int AP_GPS_last_fix_time_ms(lua_State *L) {
-    // 1 uint8_t 70 : 8
+    // 1 uint8_t 68 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -823,7 +823,7 @@ static int AP_GPS_last_fix_time_ms(lua_State *L) {
 }
 
 static int AP_GPS_get_vdop(lua_State *L) {
-    // 1 uint8_t 69 : 8
+    // 1 uint8_t 67 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -841,7 +841,7 @@ static int AP_GPS_get_vdop(lua_State *L) {
 }
 
 static int AP_GPS_get_hdop(lua_State *L) {
-    // 1 uint8_t 68 : 8
+    // 1 uint8_t 66 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -859,7 +859,7 @@ static int AP_GPS_get_hdop(lua_State *L) {
 }
 
 static int AP_GPS_time_week_ms(lua_State *L) {
-    // 1 uint8_t 67 : 8
+    // 1 uint8_t 65 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -878,7 +878,7 @@ static int AP_GPS_time_week_ms(lua_State *L) {
 }
 
 static int AP_GPS_time_week(lua_State *L) {
-    // 1 uint8_t 66 : 8
+    // 1 uint8_t 64 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -896,7 +896,7 @@ static int AP_GPS_time_week(lua_State *L) {
 }
 
 static int AP_GPS_num_sats(lua_State *L) {
-    // 1 uint8_t 65 : 8
+    // 1 uint8_t 63 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -914,7 +914,7 @@ static int AP_GPS_num_sats(lua_State *L) {
 }
 
 static int AP_GPS_ground_course(lua_State *L) {
-    // 1 uint8_t 64 : 8
+    // 1 uint8_t 62 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -932,7 +932,7 @@ static int AP_GPS_ground_course(lua_State *L) {
 }
 
 static int AP_GPS_ground_speed(lua_State *L) {
-    // 1 uint8_t 63 : 8
+    // 1 uint8_t 61 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -950,7 +950,7 @@ static int AP_GPS_ground_speed(lua_State *L) {
 }
 
 static int AP_GPS_velocity(lua_State *L) {
-    // 1 uint8_t 62 : 8
+    // 1 uint8_t 60 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -969,8 +969,8 @@ static int AP_GPS_velocity(lua_State *L) {
 }
 
 static int AP_GPS_vertical_accuracy(lua_State *L) {
-    // 1 uint8_t 61 : 8
-    // 2 float 61 : 9
+    // 1 uint8_t 59 : 8
+    // 2 float 59 : 9
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 3, "gps not supported on this firmware");
@@ -994,8 +994,8 @@ static int AP_GPS_vertical_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_horizontal_accuracy(lua_State *L) {
-    // 1 uint8_t 60 : 8
-    // 2 float 60 : 9
+    // 1 uint8_t 58 : 8
+    // 2 float 58 : 9
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 3, "gps not supported on this firmware");
@@ -1019,8 +1019,8 @@ static int AP_GPS_horizontal_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_speed_accuracy(lua_State *L) {
-    // 1 uint8_t 59 : 8
-    // 2 float 59 : 9
+    // 1 uint8_t 57 : 8
+    // 2 float 57 : 9
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 3, "gps not supported on this firmware");
@@ -1044,7 +1044,7 @@ static int AP_GPS_speed_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_location(lua_State *L) {
-    // 1 uint8_t 58 : 8
+    // 1 uint8_t 56 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -1063,7 +1063,7 @@ static int AP_GPS_location(lua_State *L) {
 }
 
 static int AP_GPS_status(lua_State *L) {
-    // 1 uint8_t 57 : 8
+    // 1 uint8_t 55 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "gps not supported on this firmware");
@@ -1109,8 +1109,8 @@ static int AP_GPS_num_sensors(lua_State *L) {
 }
 
 static int AP_BattMonitor_get_temperature(lua_State *L) {
-    // 1 float 50 : 6
-    // 2 uint8_t 50 : 9
+    // 1 float 48 : 6
+    // 2 uint8_t 48 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 3, "battery not supported on this firmware");
@@ -1134,7 +1134,7 @@ static int AP_BattMonitor_get_temperature(lua_State *L) {
 }
 
 static int AP_BattMonitor_overpower_detected(lua_State *L) {
-    // 1 uint8_t 49 : 8
+    // 1 uint8_t 47 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "battery not supported on this firmware");
@@ -1166,7 +1166,7 @@ static int AP_BattMonitor_has_failsafed(lua_State *L) {
 }
 
 static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
-    // 1 uint8_t 47 : 8
+    // 1 uint8_t 45 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "battery not supported on this firmware");
@@ -1184,7 +1184,7 @@ static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
 }
 
 static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
-    // 1 uint8_t 46 : 8
+    // 1 uint8_t 44 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "battery not supported on this firmware");
@@ -1202,61 +1202,82 @@ static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
 }
 
 static int AP_BattMonitor_consumed_wh(lua_State *L) {
-    // 1 uint8_t 45 : 8
+    // 1 float 43 : 6
+    // 2 uint8_t 43 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 3, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
-    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(ud->num_instances(), UINT8_MAX))), 2, "argument out of range");
-    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const float data = ud->consumed_wh(
-            data_2);
+    float data_5002 = {};
+    const lua_Integer raw_data_3 = luaL_checkinteger(L, 3);
+    luaL_argcheck(L, ((raw_data_3 >= MAX(0, 0)) && (raw_data_3 <= MIN(ud->num_instances(), UINT8_MAX))), 3, "argument out of range");
+    const uint8_t data_3 = static_cast<uint8_t>(raw_data_3);
+    const bool data = ud->consumed_wh(
+            data_5002,
+            data_3);
 
-    lua_pushnumber(L, data);
+    if (data) {
+        lua_pushnumber(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
     return 1;
 }
 
 static int AP_BattMonitor_consumed_mah(lua_State *L) {
-    // 1 uint8_t 44 : 8
+    // 1 float 42 : 6
+    // 2 uint8_t 42 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 3, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
-    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(ud->num_instances(), UINT8_MAX))), 2, "argument out of range");
-    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const float data = ud->consumed_mah(
-            data_2);
+    float data_5002 = {};
+    const lua_Integer raw_data_3 = luaL_checkinteger(L, 3);
+    luaL_argcheck(L, ((raw_data_3 >= MAX(0, 0)) && (raw_data_3 <= MIN(ud->num_instances(), UINT8_MAX))), 3, "argument out of range");
+    const uint8_t data_3 = static_cast<uint8_t>(raw_data_3);
+    const bool data = ud->consumed_mah(
+            data_5002,
+            data_3);
 
-    lua_pushnumber(L, data);
+    if (data) {
+        lua_pushnumber(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
     return 1;
 }
 
 static int AP_BattMonitor_current_amps(lua_State *L) {
-    // 1 uint8_t 43 : 8
+    // 1 float 41 : 6
+    // 2 uint8_t 41 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 3, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
-    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(ud->num_instances(), UINT8_MAX))), 2, "argument out of range");
-    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const float data = ud->current_amps(
-            data_2);
+    float data_5002 = {};
+    const lua_Integer raw_data_3 = luaL_checkinteger(L, 3);
+    luaL_argcheck(L, ((raw_data_3 >= MAX(0, 0)) && (raw_data_3 <= MIN(ud->num_instances(), UINT8_MAX))), 3, "argument out of range");
+    const uint8_t data_3 = static_cast<uint8_t>(raw_data_3);
+    const bool data = ud->current_amps(
+            data_5002,
+            data_3);
 
-    lua_pushnumber(L, data);
+    if (data) {
+        lua_pushnumber(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
     return 1;
 }
 
 static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
-    // 1 uint8_t 42 : 8
+    // 1 uint8_t 40 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "battery not supported on this firmware");
@@ -1274,7 +1295,7 @@ static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
 }
 
 static int AP_BattMonitor_voltage(lua_State *L) {
-    // 1 uint8_t 41 : 8
+    // 1 uint8_t 39 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, 2, "battery not supported on this firmware");
@@ -1288,42 +1309,6 @@ static int AP_BattMonitor_voltage(lua_State *L) {
             data_2);
 
     lua_pushnumber(L, data);
-    return 1;
-}
-
-static int AP_BattMonitor_has_current(lua_State *L) {
-    // 1 uint8_t 40 : 8
-    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
-    if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
-    }
-
-    binding_argcheck(L, 2);
-    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(ud->num_instances(), UINT8_MAX))), 2, "argument out of range");
-    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const bool data = ud->has_current(
-            data_2);
-
-    lua_pushboolean(L, data);
-    return 1;
-}
-
-static int AP_BattMonitor_has_consumed_energy(lua_State *L) {
-    // 1 uint8_t 39 : 8
-    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
-    if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
-    }
-
-    binding_argcheck(L, 2);
-    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(ud->num_instances(), UINT8_MAX))), 2, "argument out of range");
-    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const bool data = ud->has_consumed_energy(
-            data_2);
-
-    lua_pushboolean(L, data);
     return 1;
 }
 
@@ -1671,8 +1656,6 @@ const luaL_Reg AP_BattMonitor_meta[] = {
     {"current_amps", AP_BattMonitor_current_amps},
     {"voltage_resting_estimate", AP_BattMonitor_voltage_resting_estimate},
     {"voltage", AP_BattMonitor_voltage},
-    {"has_current", AP_BattMonitor_has_current},
-    {"has_consumed_energy", AP_BattMonitor_has_consumed_energy},
     {"healthy", AP_BattMonitor_healthy},
     {"num_instances", AP_BattMonitor_num_instances},
     {NULL, NULL}

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -387,7 +387,6 @@ static int Vector3f___sub(lua_State *L) {
 }
 
 static int Location_get_vector_from_origin_NEU(lua_State *L) {
-    // 1 Vector3f 14 : 6
     binding_argcheck(L, 1);
     Location * ud = check_Location(L, 1);
     Vector3f data_5002 = {};
@@ -404,8 +403,6 @@ static int Location_get_vector_from_origin_NEU(lua_State *L) {
 }
 
 static int Location_offset(lua_State *L) {
-    // 1 float 13 : 8
-    // 2 float 13 : 11
     binding_argcheck(L, 3);
     Location * ud = check_Location(L, 1);
     const float raw_data_2 = luaL_checknumber(L, 2);
@@ -422,7 +419,6 @@ static int Location_offset(lua_State *L) {
 }
 
 static int Location_get_distance(lua_State *L) {
-    // 1 Location 12 : 6
     binding_argcheck(L, 2);
     Location * ud = check_Location(L, 1);
     Location & data_2 = *check_Location(L, 2);
@@ -474,11 +470,9 @@ const luaL_Reg Location_meta[] = {
 };
 
 static int GCS_send_text(lua_State *L) {
-    // 1 MAV_SEVERITY 127 : 8
-    // 2 enum 127 : 9
     GCS * ud = GCS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "gcs not supported on this firmware");
+        return luaL_argerror(L, 1, "gcs not supported on this firmware");
     }
 
     binding_argcheck(L, 3);
@@ -494,10 +488,9 @@ static int GCS_send_text(lua_State *L) {
 }
 
 static int AP_Relay_toggle(lua_State *L) {
-    // 1 uint8_t 123 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "relay not supported on this firmware");
+        return luaL_argerror(L, 1, "relay not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -511,10 +504,9 @@ static int AP_Relay_toggle(lua_State *L) {
 }
 
 static int AP_Relay_enabled(lua_State *L) {
-    // 1 uint8_t 122 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "relay not supported on this firmware");
+        return luaL_argerror(L, 1, "relay not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -529,10 +521,9 @@ static int AP_Relay_enabled(lua_State *L) {
 }
 
 static int AP_Relay_off(lua_State *L) {
-    // 1 uint8_t 121 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "relay not supported on this firmware");
+        return luaL_argerror(L, 1, "relay not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -546,10 +537,9 @@ static int AP_Relay_off(lua_State *L) {
 }
 
 static int AP_Relay_on(lua_State *L) {
-    // 1 uint8_t 120 : 8
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "relay not supported on this firmware");
+        return luaL_argerror(L, 1, "relay not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -563,11 +553,9 @@ static int AP_Relay_on(lua_State *L) {
 }
 
 static int AP_Terrain_height_above_terrain(lua_State *L) {
-    // 1 float 115 : 6
-    // 2 bool 115 : 7
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "terrain not supported on this firmware");
+        return luaL_argerror(L, 1, "terrain not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -586,12 +574,9 @@ static int AP_Terrain_height_above_terrain(lua_State *L) {
 }
 
 static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
-    // 1 float 114 : 8
-    // 2 float 114 : 9
-    // 3 bool 114 : 10
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 4, "terrain not supported on this firmware");
+        return luaL_argerror(L, 1, "terrain not supported on this firmware");
     }
 
     binding_argcheck(L, 3);
@@ -614,11 +599,9 @@ static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
 }
 
 static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
-    // 1 float 113 : 6
-    // 2 bool 113 : 7
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "terrain not supported on this firmware");
+        return luaL_argerror(L, 1, "terrain not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -637,12 +620,9 @@ static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
 }
 
 static int AP_Terrain_height_amsl(lua_State *L) {
-    // 1 Location 112 : 6
-    // 2 float 112 : 7
-    // 3 bool 112 : 8
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 4, "terrain not supported on this firmware");
+        return luaL_argerror(L, 1, "terrain not supported on this firmware");
     }
 
     binding_argcheck(L, 3);
@@ -705,10 +685,9 @@ static int RangeFinder_num_sensors(lua_State *L) {
 }
 
 static int AP_Notify_play_tune(lua_State *L) {
-    // 1 enum 100 : 6
     AP_Notify * ud = AP_Notify::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "AP_Notify not supported on this firmware");
+        return luaL_argerror(L, 1, "AP_Notify not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -748,10 +727,9 @@ static int AP_GPS_all_configured(lua_State *L) {
 }
 
 static int AP_GPS_get_antenna_offset(lua_State *L) {
-    // 1 uint8_t 71 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -767,10 +745,9 @@ static int AP_GPS_get_antenna_offset(lua_State *L) {
 }
 
 static int AP_GPS_have_vertical_velocity(lua_State *L) {
-    // 1 uint8_t 70 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -785,10 +762,9 @@ static int AP_GPS_have_vertical_velocity(lua_State *L) {
 }
 
 static int AP_GPS_last_message_time_ms(lua_State *L) {
-    // 1 uint8_t 69 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -804,10 +780,9 @@ static int AP_GPS_last_message_time_ms(lua_State *L) {
 }
 
 static int AP_GPS_last_fix_time_ms(lua_State *L) {
-    // 1 uint8_t 68 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -823,10 +798,9 @@ static int AP_GPS_last_fix_time_ms(lua_State *L) {
 }
 
 static int AP_GPS_get_vdop(lua_State *L) {
-    // 1 uint8_t 67 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -841,10 +815,9 @@ static int AP_GPS_get_vdop(lua_State *L) {
 }
 
 static int AP_GPS_get_hdop(lua_State *L) {
-    // 1 uint8_t 66 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -859,10 +832,9 @@ static int AP_GPS_get_hdop(lua_State *L) {
 }
 
 static int AP_GPS_time_week_ms(lua_State *L) {
-    // 1 uint8_t 65 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -878,10 +850,9 @@ static int AP_GPS_time_week_ms(lua_State *L) {
 }
 
 static int AP_GPS_time_week(lua_State *L) {
-    // 1 uint8_t 64 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -896,10 +867,9 @@ static int AP_GPS_time_week(lua_State *L) {
 }
 
 static int AP_GPS_num_sats(lua_State *L) {
-    // 1 uint8_t 63 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -914,10 +884,9 @@ static int AP_GPS_num_sats(lua_State *L) {
 }
 
 static int AP_GPS_ground_course(lua_State *L) {
-    // 1 uint8_t 62 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -932,10 +901,9 @@ static int AP_GPS_ground_course(lua_State *L) {
 }
 
 static int AP_GPS_ground_speed(lua_State *L) {
-    // 1 uint8_t 61 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -950,10 +918,9 @@ static int AP_GPS_ground_speed(lua_State *L) {
 }
 
 static int AP_GPS_velocity(lua_State *L) {
-    // 1 uint8_t 60 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -969,11 +936,9 @@ static int AP_GPS_velocity(lua_State *L) {
 }
 
 static int AP_GPS_vertical_accuracy(lua_State *L) {
-    // 1 uint8_t 59 : 8
-    // 2 float 59 : 9
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -994,11 +959,9 @@ static int AP_GPS_vertical_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_horizontal_accuracy(lua_State *L) {
-    // 1 uint8_t 58 : 8
-    // 2 float 58 : 9
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1019,11 +982,9 @@ static int AP_GPS_horizontal_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_speed_accuracy(lua_State *L) {
-    // 1 uint8_t 57 : 8
-    // 2 float 57 : 9
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1044,10 +1005,9 @@ static int AP_GPS_speed_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_location(lua_State *L) {
-    // 1 uint8_t 56 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1063,10 +1023,9 @@ static int AP_GPS_location(lua_State *L) {
 }
 
 static int AP_GPS_status(lua_State *L) {
-    // 1 uint8_t 55 : 8
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1109,11 +1068,9 @@ static int AP_GPS_num_sensors(lua_State *L) {
 }
 
 static int AP_BattMonitor_get_temperature(lua_State *L) {
-    // 1 float 48 : 6
-    // 2 uint8_t 48 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1134,10 +1091,9 @@ static int AP_BattMonitor_get_temperature(lua_State *L) {
 }
 
 static int AP_BattMonitor_overpower_detected(lua_State *L) {
-    // 1 uint8_t 47 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1166,10 +1122,9 @@ static int AP_BattMonitor_has_failsafed(lua_State *L) {
 }
 
 static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
-    // 1 uint8_t 45 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1184,10 +1139,9 @@ static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
 }
 
 static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
-    // 1 uint8_t 44 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1202,11 +1156,9 @@ static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
 }
 
 static int AP_BattMonitor_consumed_wh(lua_State *L) {
-    // 1 float 43 : 6
-    // 2 uint8_t 43 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1227,11 +1179,9 @@ static int AP_BattMonitor_consumed_wh(lua_State *L) {
 }
 
 static int AP_BattMonitor_consumed_mah(lua_State *L) {
-    // 1 float 42 : 6
-    // 2 uint8_t 42 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1252,11 +1202,9 @@ static int AP_BattMonitor_consumed_mah(lua_State *L) {
 }
 
 static int AP_BattMonitor_current_amps(lua_State *L) {
-    // 1 float 41 : 6
-    // 2 uint8_t 41 : 9
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 3, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1277,10 +1225,9 @@ static int AP_BattMonitor_current_amps(lua_State *L) {
 }
 
 static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
-    // 1 uint8_t 40 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1295,10 +1242,9 @@ static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
 }
 
 static int AP_BattMonitor_voltage(lua_State *L) {
-    // 1 uint8_t 39 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1313,10 +1259,9 @@ static int AP_BattMonitor_voltage(lua_State *L) {
 }
 
 static int AP_BattMonitor_healthy(lua_State *L) {
-    // 1 uint8_t 38 : 8
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1377,10 +1322,9 @@ static int AP_AHRS_home_is_set(lua_State *L) {
 }
 
 static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
-    // 1 Vector3f 30 : 6
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     binding_argcheck(L, 1);
@@ -1400,10 +1344,9 @@ static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
 }
 
 static int AP_AHRS_get_velocity_NED(lua_State *L) {
-    // 1 Vector3f 29 : 6
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     binding_argcheck(L, 1);
@@ -1457,10 +1400,9 @@ static int AP_AHRS_wind_estimate(lua_State *L) {
 }
 
 static int AP_AHRS_get_hagl(lua_State *L) {
-    // 1 float 26 : 6
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     binding_argcheck(L, 1);
@@ -1513,10 +1455,9 @@ static int AP_AHRS_get_home(lua_State *L) {
 }
 
 static int AP_AHRS_get_position(lua_State *L) {
-    // 1 Location 23 : 6
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 2, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     binding_argcheck(L, 1);


### PR DESCRIPTION
This is a refactor I've wanted to do for awhile, but was particularly useful for scripting which is why I did it now. This removes the extra method of `has_current(void)` from the battery monitoring library. Rather then being responsible for checking if the current is available, or getting a 0 if the index is out of range this instead uses a return value on the `current_amps()` and `consumed_mah()` calls. The main advantages of this are;
  1. No need to reliably separately poll for has_current()
  1. Scripting can utilize null punning for accessing the current, which is both easier in a script, and easier to document (if null punning isn't consistently available it is a much more frustrating experience)
  1. A number of places get to skip doing work they don't need to if the current was not available
  1. The check on each backend is much tighter then the previous versions of the checks
  1. This starts to help resolve the `nullptr` dereference problem that happens if someone only enables BATT_MONITOR 2 for example

The downside, is that all the callers must select what to do now if no data was available. At the moment I've preserved the existing behavior in most cases (pass 0 out), but a good future enhancement would be to skip the rest of the work. (IE if consumed mah data isn't available, maybe we don't need to draw the label on the OSD for example).

Other things of particular note:
  - The copter motors library changed the most, but it was repeatedly polling the library for the same static data, so I think this is quite reasonable to reduce the frequency.
  - OSD had 2 different paths for drawing consumed current on the OSD. One would do rounding, one wouldn't and the only difference was which monitor was used. I've unified the methods such that they both get turned into `Ah` after the `9999 mAh` mark.