### PR TITLE
gitignore: add way.txt for MAVPorxy waypoint missions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,5 @@ parameters.edn
 cmake-build-*/
 /reports/
 /GCOV_*.log
+way.txt
 


### PR DESCRIPTION
This is already ignored on other vehicles when launching sim_vehicle from the directory but not if you launch sim_vehicle from root