### PR TITLE
Sub: Issue11018 Don't announce 'motor test timed out'

### DIFF
--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -60,7 +60,7 @@ bool Sub::verify_motor_test()
 
     // Require at least 2 Hz incoming do_set_motor requests
     if (AP_HAL::millis() > last_do_motor_test_ms + 500) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Motor test timed out!");
+        gcs().send_text(MAV_SEVERITY_INFO, "Motor test timed out!");
         pass = false;
     }
 


### PR DESCRIPTION
Changed the MAV_SEVERITY of the motor test timed out message from WARNING to INFO so that it wont be read out loud everytime the user ends the motor test. 

Note that the issue suggests using a prefix to make it so that QGC will not read it out loud; however, BlueRobotics version of QGC does not support any such prefix. 

I could easily add one to QGC and make a PR for that, but I'm unsure what the proper procedure would be since they are independent projects.

Lastly, I've tested with SITL and this does prevent it from saying the message out loud.

EDIT: Linking to the issue [here](https://github.com/ArduPilot/ardupilot/issues/11018)
