### PR TITLE
Sub: Issue10844 Enforce Disarm Button

### DIFF
--- a/ArduSub/AP_Arming_Sub.h
+++ b/ArduSub/AP_Arming_Sub.h
@@ -13,6 +13,7 @@ public:
 
     bool rc_calibration_checks(bool display_failure) override;
     bool pre_arm_checks(bool display_failure) override;
+    const bool has_disarm_function();
 
     bool disarm() override;
     bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;


### PR DESCRIPTION
I guess I should also link the issue [here](https://github.com/ArduPilot/ardupilot/issues/10844)

Added a check in the sub arming method to make sure that a disarm or arm_toggle button is assigned before allowing you to arm the sub. 
I used a separate commit to add a message describing that it needs such a button before it arms.
The last commit adds a check to make sure that the assigned button is accessible (if it's a shift function, you must also have a shift button assigned).

I tested all of this in SITL with QGC.