### PR TITLE
Missing include pthread.h in Scheduler.h breaking SITL build on OSX

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -4,6 +4,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_HAL_SITL_Namespace.h"
 #include <sys/time.h>
+#include <pthread.h>
 
 #define SITL_SCHEDULER_MAX_TIMER_PROCS 4
 


### PR DESCRIPTION
Seems to be same as PR 11281 from July last year, was discussing with Peter Barker who suggested submitting against plane-stable. This is my first PR, I've tried to follow guidelines but my git skills are not particularly refined. Hope this helps.