### PR TITLE
Move sending of COLLISION message into AP_Avoidance

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1293,6 +1293,34 @@ class AutoTestPlane(AutoTest):
         self.wait_mode("CIRCLE")
         self.set_rc(9, 1000)
 
+    def test_adsb(self):
+        self.wait_ready_to_arm()
+        here = self.mav.location()
+        # message ADSB_VEHICLE 37 -353632614 1491652305 0 584070 0 0 0 "bob" 3 1 255 17
+        self.set_parameter("ADSB_ENABLE", 1)
+        self.set_parameter("AVD_ENABLE", 1)
+        self.delay_sim_time(1) # TODO: work out why this is required...
+        self.mav.mav.adsb_vehicle_send(37, # ICAO address
+                                       here.lat * 1e7,
+                                       here.lng * 1e7,
+                                       mavutil.mavlink.ADSB_ALTITUDE_TYPE_PRESSURE_QNH,
+                                       here.alt*1000 + 10000, # 10m up
+                                       0, # heading in cdeg
+                                       0, # horizontal velocity cm/s
+                                       0, # vertical velocity cm/s
+                                       "bob", # callsign
+                                       mavutil.mavlink.ADSB_EMITTER_TYPE_LIGHT,
+                                       1, # time since last communication
+                                       65535, # flags
+                                       17 # squawk
+        )
+        self.progress("Waiting for collision message")
+        m = self.mav.recv_match(type='COLLISION', blocking=True, timeout=2)
+        if m is None:
+            raise NotAchievedException("Did not get collision message")
+        if m.threat_level != 2:
+            raise NotAchievedException("Expected some threat at least")
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestPlane, self).tests()
@@ -1345,6 +1373,10 @@ class AutoTestPlane(AutoTest):
             ("FenceRTLRally",
              "Test Fence RTL Rally",
              self.test_fence_rtl_rally),
+
+            ("ADSB",
+             "Test ADSB",
+             self.test_adsb),
 
             ("LogDownLoad",
              "Log download",

--- a/libraries/AP_Avoidance/AP_Avoidance.h
+++ b/libraries/AP_Avoidance/AP_Avoidance.h
@@ -138,6 +138,8 @@ protected:
 
 private:
 
+    void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour) const;
+
     // constants
     const uint32_t MAX_OBSTACLE_AGE_MS = 5000;      // obstacles that have not been heard from for 5 seconds are removed from the list
     const static uint8_t _gcs_notify_interval = 1; // seconds

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -9,7 +9,6 @@
 #include <AP_Mission/AP_Mission.h>
 #include <stdint.h>
 #include "MAVLink_routing.h"
-#include <AP_Avoidance/AP_Avoidance.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 #include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 #include <AP_RTC/JitterCorrection.h>
@@ -435,7 +434,6 @@ public:
     virtual void send_position_target_global_int() { };
     virtual void send_position_target_local_ned() { };
     void send_servo_output_raw();
-    static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
     void send_accelcal_vehicle_position(uint32_t position);
     void send_scaled_imu(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_ms, int16_t xacc, int16_t yacc, int16_t zacc, int16_t xgyro, int16_t ygyro, int16_t zgyro, int16_t xmag, int16_t ymag, int16_t zmag));
     void send_sys_status();

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -128,7 +128,7 @@ public:
 
     // note that all of these methods are named after the packet they
     // are handling; the "mission" part just comes as part of that.
-    void handle_mission_request_list(const GCS_MAVLINK &link,
+    void handle_mission_request_list(const class GCS_MAVLINK &link,
                                      const mavlink_mission_request_list_t &packet,
                                      const mavlink_message_t &msg);
     void handle_mission_request_int(const GCS_MAVLINK &link,
@@ -830,7 +830,7 @@ private:
 
     uint8_t send_parameter_async_replies();
 
-    void send_distance_sensor(const AP_RangeFinder_Backend *sensor, const uint8_t instance) const;
+    void send_distance_sensor(const class AP_RangeFinder_Backend *sensor, const uint8_t instance) const;
 
     virtual bool handle_guided_request(AP_Mission::Mission_Command &cmd) = 0;
     virtual void handle_change_alt_request(AP_Mission::Mission_Command &cmd) = 0;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2708,27 +2708,6 @@ void GCS_MAVLINK::send_servo_output_raw()
 }
 
 
-void GCS_MAVLINK::send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour)
-{
-    for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
-        if ((1U<<i) & mavlink_active) {
-            mavlink_channel_t chan = (mavlink_channel_t)(MAVLINK_COMM_0+i);
-            if (comm_get_txspace(chan) >= MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_MSG_ID_COLLISION) {
-                mavlink_msg_collision_send(
-                    chan,
-                    MAV_COLLISION_SRC_ADSB,
-                    threat.src_id,
-                    behaviour,
-                    threat.threat_level,
-                    threat.time_to_closest_approach,
-                    threat.closest_approach_z,
-                    threat.closest_approach_xy
-                    );
-            }
-        }
-    }
-}
-
 void GCS_MAVLINK::send_accelcal_vehicle_position(uint32_t position)
 {
     if (HAVE_PAYLOAD_SPACE(chan, COMMAND_LONG)) {


### PR DESCRIPTION
Stops GCS from needing to know about Avoidance which is handy for breaking loops.

Now uses the `send_to_active_links`.

Tested to work in SITL.

autotest added.
