### PR TITLE
Add AP_Characterise, a KF for learning aerodynamic coefficients

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -104,6 +104,15 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
         ret = false;
     }
 
+    if (!plane.g2.characterise.prearm_healthy()) {
+        const char *reason = plane.g2.characterise.prearm_failure_reason();
+        if (reason == nullptr) {
+            reason = "AP Characterise Error";
+        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "%s", reason);
+        ret = false;
+    }
+
     return ret;
 }
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -106,6 +106,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if LANDING_GEAR_ENABLED == ENABLED
     SCHED_TASK(landing_gear_update, 5, 50),
 #endif
+    SCHED_TASK_CLASS(AP_Characterise, &plane.g2.characterise, update, 10, 100),
 };
 
 constexpr int8_t Plane::_failsafe_priorities[7];
@@ -167,6 +168,8 @@ void Plane::ahrs_update()
 
     // update inertial_nav for quadplane
     quadplane.inertial_nav.update(G_Dt);
+
+    g2.characterise.update_inputs();
 }
 
 /*

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1235,6 +1235,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DSPOILER_AILMTCH", 21, ParametersG2, crow_flap_aileron_matching, 100),
 
+    // @Group: CHAR_
+    // @Path: ../libraries/AP_Characterise/AP_Characterise.cpp
+    AP_SUBGROUPINFO(characterise, "CHAR_", 22, ParametersG2, AP_Characterise),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -564,6 +564,9 @@ public:
     AP_Int8 crow_flap_weight_inner;
     AP_Int8 crow_flap_options;
     AP_Int8 crow_flap_aileron_matching;
+
+    // Characterization library
+    AP_Characterise characterise;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -95,6 +95,7 @@
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_Landing/AP_Landing.h>
 #include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library
+#include <AP_Characterise/AP_Characterise.h>     // Aerodynamic Characterization library
 
 #include "GCS_Mavlink.h"
 #include "GCS_Plane.h"

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -33,6 +33,7 @@ def build(bld):
             'AP_OSD',
             'AC_AutoTune',
             'AP_KDECAN',
+            'AP_Characterise'
         ],
     )
 

--- a/libraries/AP_Characterise/AP_Characterise.cpp
+++ b/libraries/AP_Characterise/AP_Characterise.cpp
@@ -1,0 +1,562 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Characterise.h"
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_RPM/AP_RPM.h>
+#include <AP_Baro/AP_Baro.h>
+#include <AP_BLHeli/AP_BLHeli.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_Logger/AP_Logger.h>
+
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_Characterise::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Enable Aerodynamic Characterization
+    // @Description: Enable Aerodynamic Characterization
+    // @Values: 0:Disabled, 1:Enabled read only, 2:Enabled KF learning
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_Characterise, _enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: WING_AREA
+    // @DisplayName: Reference wing area for lift and drag coefficients
+    // @Description: reference area using in lift and drag calculation, changing this will require coefficients to be re-learned
+    // @Units: m
+    // @User: Standard
+    AP_GROUPINFO("WING_AREA", 2, AP_Characterise, _s, 1.0f),
+
+    // @Param: MASS
+    // @DisplayName: Vehicle mass
+    // @Description: vehicle mass (in KG) used to convert from force to acceleration
+    // @User: Standard
+    AP_GROUPINFO("MASS", 3, AP_Characterise, _mass, 1.0f),
+
+    // @Param: PROP_D
+    // @DisplayName: Propeller diameter
+    // @Description: propeller reference diameter, used in thrust coefficient calculations, changing this will require coefficients to be re-learned
+    // @Units: m
+    // @User: Standard
+    AP_GROUPINFO("PROP_D", 4, AP_Characterise, _d, 0.2f),
+
+    // @Param: PROP_NO
+    // @DisplayName: Number of propellers
+    // @Description: Number of propellers used in forward flight, it is assumed all propellers are identical
+    // @Increment: 1
+    // @Range: 1 2
+    // @User: Standard
+    AP_GROUPINFO("PROP_NUM", 5, AP_Characterise, _num_props, 1),
+
+    // @Param: PROP_RPM
+    // @DisplayName: propeller rpm source
+    // @Description: sensor used as source for RPM value for KF, if multiple are selected the average will be taken
+    // @Bitmask: 0:ESC1 telem, 1:ESC2 telem, 2:ESC3 telem, 3:ESC4 telem, 4:ESC5 telem, 5:ESC6 telem, 6:ESC7 telem, 7:ESC8 telem, 8:RPM1, 9:RPM2
+    // @User: Standard
+    AP_GROUPINFO("PROP_RPM", 6, AP_Characterise, _prop_rpm_bitmask, 0),
+
+    // @Param: PROP_PWR
+    // @DisplayName: propeller power source
+    // @Description: sensor used as source for power value for KF, if multiple are selected the average will be taken
+    // @Bitmask: 0:ESC1 telem, 1:ESC2 telem, 2:ESC3 telem, 3:ESC4 telem, 4:ESC5 telem, 5:ESC6 telem, 6:ESC7 telem, 7:ESC8 telem, 8:Bat mon, 9:Bat mon 1, 10:Bat mon 2, 11:Bat mon 3, 12:Bat mon 4, 13:Bat mon 5, 14:Bat mon 6, 15:Bat mon 7, 16:Bat mon 8
+    // @User: Standard
+    AP_GROUPINFO("PROP_PWR", 7, AP_Characterise, _prop_power_bitmask, 0),
+
+    // @Param: R_FORCE_X
+    // @DisplayName: Force X measurement noise
+    // @Description: measurement noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("R_FORCE_X", 8, AP_Characterise, _R_force_x, 1),
+
+    // @Param: R_FORCE_Z
+    // @DisplayName: Force Z measurement noise
+    // @Description: measurement noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("R_FORCE_Z", 9, AP_Characterise, _R_force_z, 1),
+
+    // @Param: R_POWER
+    // @DisplayName: power measurement noise
+    // @Description: measurement noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("R_POWER", 10, AP_Characterise, _R_power, 1),
+
+    // @Param: Q_CL0
+    // @DisplayName: CL0 process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CL0", 11, AP_Characterise, _Q_CL0, 1),
+
+    // @Param: Q_CLA
+    // @DisplayName: CLa process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CLA", 12, AP_Characterise, _Q_CLa, 1),
+
+    // @Param: Q_CD0
+    // @DisplayName: CD0 process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CD0", 13, AP_Characterise, _Q_CD0, 1),
+
+    // @Param: Q_CDA
+    // @DisplayName: CDa process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CDA", 14, AP_Characterise, _Q_CDa, 1),
+
+    // @Param: Q_CDAA
+    // @DisplayName: CL0 process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CDAA", 15, AP_Characterise, _Q_CDaa, 1),
+
+    // @Param: Q_CT0
+    // @DisplayName: Ct0 process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CT0", 16, AP_Characterise, _Q_Ct0, 1),
+
+    // @Param: Q_CTJ
+    // @DisplayName: Ctj process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CTJ", 17, AP_Characterise, _Q_Ctj, 1),
+
+    // @Param: Q_CTJJ
+    // @DisplayName: Ctjj process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CTJJ", 18, AP_Characterise, _Q_Ctjj, 1),
+
+    // @Param: Q_CP0
+    // @DisplayName: Cp0 process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CP0", 19, AP_Characterise, _Q_Cp0, 1),
+
+    // @Param: Q_CPJ
+    // @DisplayName: Cpj process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CPJ", 20, AP_Characterise, _Q_Cpj, 1),
+
+    // @Param: Q_CPJJ
+    // @DisplayName: Cpjj process noise
+    // @Description: process noise variance used in KF calculations
+    // @User: Standard
+    AP_GROUPINFO("Q_CPJJ", 21, AP_Characterise, _Q_Cpjj, 1),
+
+    AP_GROUPEND};
+
+// constructor
+AP_Characterise::AP_Characterise()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (_singleton) {
+        AP_HAL::panic("Too many AP_Characterise instances");
+    }
+#endif
+    _singleton = this;
+}
+
+/*
+ * Get the AP_Characterise singleton
+ */
+AP_Characterise *AP_Characterise::get_singleton()
+{
+    return _singleton;
+}
+
+// pre-arm check we have everything we need
+bool AP_Characterise::prearm_healthy()
+{
+    // reload encase we previously set it to something else
+    _enable.load();
+
+    if (_enable != 2) {
+        return true;
+    }
+
+    // if we are enabled for learning then we must have access to the appropriate inputs
+    if (!is_positive(_s)) {
+        hal.util->snprintf(prearm_fail_string,
+                           sizeof(prearm_fail_string),
+                           "Must set wing area for characterization");
+        _enable.set(1); // disable for the time being
+        return false;
+    }
+
+    if (!is_positive(_mass)) {
+        hal.util->snprintf(prearm_fail_string,
+                           sizeof(prearm_fail_string),
+                          "Must set mass for characterization");
+        _enable.set(1);
+        return false;
+    }
+
+    if (!is_positive(_d)) {
+        hal.util->snprintf(prearm_fail_string,
+                           sizeof(prearm_fail_string),
+                           "Must set prop dia for characterization");
+        _enable.set(1);
+        return false;
+    }
+
+    if (_prop_rpm_bitmask == 0) {
+        hal.util->snprintf(prearm_fail_string,
+                           sizeof(prearm_fail_string),
+                           "Must set rpm sensor characterization");
+        _enable.set(1);
+        return false;
+    }
+
+    if (_prop_power_bitmask == 0) {
+        hal.util->snprintf(prearm_fail_string,
+                           sizeof(prearm_fail_string),
+                           "Must set power sensor for characterization");
+        _enable.set(1);
+        return false;
+    }
+
+    return true;
+}
+
+// update KF inputs, this reads in values that are required for the prediction, expected to be called at 400hz
+void AP_Characterise::update_inputs()
+{
+    if (_enable != 2) {
+        return;
+    }
+
+    const float AoA = AP::ahrs().getAOA();
+    _AoA_mean = ((_AoA_mean*_samples) + AoA) / (_samples + 1);
+
+    float Airspeed;
+    const bool have_airspeed = AP::ahrs().airspeed_estimate(&Airspeed);
+    if (have_airspeed) {
+        _V_mean = ((_V_mean*_samples) + Airspeed) / (_samples + 1);
+    }
+
+    AP_Baro *baro = AP_Baro::get_singleton();
+    if (baro != nullptr) {
+        // convert from density ratio to density
+        const float rho = baro->get_air_density_ratio() * SSL_AIR_DENSITY;
+        _rho_mean = ((_rho_mean*_samples) + rho) / (_samples + 1);
+    }
+
+    // body frame accelerations
+    Vector3f bf_accel = AP::ahrs().get_accel_ef_blended();                      // read in earth frame
+    bf_accel.z += GRAVITY_MSS;                                                  // remove gravity
+    Matrix3<float> DCM_inv;
+    const bool success = AP::ahrs().get_rotation_body_to_ned().inverse(DCM_inv);
+    if (success) {
+        bf_accel = bf_accel * DCM_inv;   // convert to body frame
+        _accel_x_mean = ((_accel_x_mean*_samples) + bf_accel.x) / (_samples + 1);
+        _accel_z_mean = ((_accel_z_mean*_samples) + bf_accel.z) / (_samples + 1);
+    }
+
+    // read in power and rpm from ESC's
+    read_esc_telem();
+
+    // read RPM1 and RPM2
+    const AP_RPM *rpm = AP_RPM::get_singleton();
+    if (rpm != nullptr) {
+        for (uint8_t i=0; i<2; i++) {
+            if ((_prop_rpm_bitmask & (1 << (8+i))) != 0) {
+                _rpm_mean = ((_rpm_mean*_rpm_samples) + rpm->get_rpm(i)) / (_rpm_samples + 1);
+                _rpm_samples++;
+            }
+        }
+    }
+
+    // read in power from battery monitor's
+    read_bat_mon();
+
+    _samples++;
+}
+
+// read in power and rpm from blheli esc
+void AP_Characterise::read_esc_telem()
+{
+#ifdef HAVE_AP_BLHELI_SUPPORT
+    AP_BLHeli *blheli = AP_BLHeli::get_singleton();
+    if (!blheli) {
+        return;
+    }
+
+    for (uint8_t i=0; i<AP_BLHELI_MAX_ESCS; i++) {
+        bool use_rpm = (_prop_rpm_bitmask & (1 << i)) != 0;
+        bool use_power = (_prop_power_bitmask & (1 << i)) != 0;
+
+        if (!use_rpm && !use_power) {
+            continue;
+        }
+
+        AP_BLHeli::telem_data td;
+        if (!blheli->get_telem_data(i, td)) {
+            continue;
+        }
+
+        if (use_rpm) {
+            _rpm_mean = ((_rpm_mean*_rpm_samples) + td.rpm) / (_rpm_samples + 1);
+            _rpm_samples++;
+        }
+
+        if (use_power) {
+            // convert from cV and cI
+            _power_mean = ((_power_mean*_power_samples) + (td.voltage * td.current * 0.0001)) / (_power_samples + 1);
+            _power_samples++;
+        }
+    }
+#endif
+}
+
+// read in power from battery monitor
+void AP_Characterise::read_bat_mon()
+{
+    const AP_BattMonitor *bat = AP_BattMonitor::get_singleton();
+    if (!bat) {
+        return;
+    }
+
+    for (uint8_t i=0; i<AP_BATT_MONITOR_MAX_INSTANCES; i++) {
+        if ((_prop_power_bitmask & (1 << (8+i))) == 0){
+            continue;
+        }
+
+        _power_mean = ((_power_mean*_power_samples) + (bat->current_amps(i) * bat->voltage(i))) / (_power_samples + 1);
+        _power_samples++;
+    }
+}
+
+// update the characterization KF, expected to be called at 10hz
+void AP_Characterise::update()
+{
+    if (!hal.util->get_soft_armed() || AP::ahrs().get_time_flying_ms() < 10000) {
+        // only learn when flying and with enough time to be clear of
+        // the ground
+        return;
+    }
+
+    // define variables
+    VectorN<float,N_KF_eq>            R;
+    VectorN<float,N_KF_st>            Q;
+    MatrixRC<float,N_KF_eq,N_KF_st>   H;
+    VectorN<float,N_KF_eq>            prediction;
+    VectorN<float,N_KF_eq>            truth;
+    VectorN<float,N_KF_eq>            innovation;
+    MatrixRC<float,N_KF_eq,N_KF_st>   temp;
+    MatrixN<float,N_KF_eq>            S;
+    MatrixRC<float,N_KF_st,N_KF_eq>   KG;
+    MatrixN<float,N_KF_st>            temp1;
+    VectorN<float,N_KF_st>            delta_x;
+
+    // build R and Q from parameters
+    R[0] =  powf(_R_force_x,2);
+    R[1] =  powf(_R_force_z,2);
+    R[2] =  powf(_R_power,2);
+    Q[0] =  powf(_Q_CL0,2);
+    Q[1] =  powf(_Q_CLa,2);
+    Q[2] =  powf(_Q_CD0,2);
+    Q[3] =  powf(_Q_CDa,2);
+    Q[4] =  powf(_Q_CDaa,2);
+    Q[5] =  powf(_Q_Ct0,2);
+    Q[6] =  powf(_Q_Ctj,2);
+    Q[7] =  powf(_Q_Ctjj,2);
+    Q[8] =  powf(_Q_Cp0,2);
+    Q[9] =  powf(_Q_Cpj,2);
+    Q[10] = powf(_Q_Cpjj,2);
+
+    // temp to stop divide by zero
+    _rpm_mean = MAX(_rpm_mean,0.1f);
+
+    // calculate the known values
+    const float AoA = _AoA_mean;                             // angle of attack (deg)
+    const float q = 0.5f * _rho_mean * _V_mean * _V_mean;    // dynamic pressure (kg/m^2)
+    const float w = _rpm_mean * (1.0f/60.0f);                // prop rotation speed (Hz)
+    float       J = _V_mean / (w * _d);                      // prop advance ratio
+ 
+    int8_t effective_num_props = _num_props;
+    if (J > 4.0f) {
+        // large advance ratio means low prop rpm so assume zero
+        // thrust and don't update states related to the prop
+        effective_num_props = 0;
+        // limit J to prevent infs and nans in the matrix's
+        J = 4.0f;
+    }
+
+    // gather together some common terms to tidy equations
+    const float sin_q_s   = sinf(radians(AoA))*q*_s;
+    const float cos_q_s   = cosf(radians(AoA))*q*_s;
+    const float rho_w2_d4 = _rho_mean*powf(w,2)*powf(_d,4)*effective_num_props;
+    const float rho_w3_d5 = _rho_mean*powf(w,3)*powf(_d,5)*effective_num_props;
+
+    // X force (thrust - drag, positive forwards) is sum of..
+    H.set(0,0,sin_q_s);          // * Cl0
+    H.set(0,1,sin_q_s*AoA);      // * Cla
+    H.set(0,2,-cos_q_s);         // * Cd0
+    H.set(0,3,-cos_q_s*AoA);     // * Cda
+    H.set(0,4,-cos_q_s*AoA*AoA); // * Cdaa
+    H.set(0,5,rho_w2_d4);        // * Ct0
+    H.set(0,6,rho_w2_d4*J);      // * Ctj
+    H.set(0,7,rho_w2_d4*J*J);    // * Ctjj
+
+    // Z force (lift, positive down) is sum of..
+    H.set(1,0,-cos_q_s);         // * Cl0
+    H.set(1,1,-cos_q_s*AoA);     // * Cla
+    H.set(1,2,-sin_q_s);         // * Cd0
+    H.set(1,3,-sin_q_s*AoA);     // * Cda
+    H.set(1,4,-sin_q_s*AoA*AoA); // * Cdaa
+
+    // propeller power is sum of..
+    H.set(2,8,rho_w3_d5);        // * CP0
+    H.set(2,9,rho_w3_d5*J);      // * CPj
+    H.set(2,10,rho_w3_d5*J*J);   // * CPjj
+
+    // Calculate the predicted forces and power from the above equations
+    prediction.mult(H,_x);
+
+    // the true values as measured
+    truth[0] = (_accel_x_mean * _mass);
+    truth[1] = (_accel_z_mean * _mass);
+    truth[2] = _power_mean;
+
+    // Calculate the error between actual and predicted (this is called innovation in a KF)
+    innovation = truth - prediction;
+
+    // Calculate the Kalman gain
+    temp = H*_P;                          // H*P
+    S.mult_trans(temp,H);                 // H*P*H'
+    S.diag_add(R);                        // S = H*P*H' + R
+    KG.trans_mult(temp,S.inverse_matN()); // (P*H')/S = (H*P)'/S = (H*P)'*inv(S)
+
+    if (effective_num_props == 0){
+        // ignore prop effects
+        for (uint8_t i=5; i<11; i++) {
+            KG.set(i,0,0.0f);
+            KG.set(i,1,0.0f);
+            KG.set(i,2,0.0f);
+            Q[i] = 0.0f;
+        }
+    }
+
+    // Update the state covariance, note there is no multiplication of P as we are expecting states to be constant
+    // P = A*P*A' if A is identity, add process noise Q, ensure P remains symmetric
+    temp1.mult_trans(KG*S,KG); // KG*S*KG'
+    if (temp1.is_safe()) {     // check inf and nan before updating covariance
+        _P -= temp1;           // P = A*P*A' - KG*S*KG'
+        _P.force_symmetry();
+    }
+    _P.diag_add(Q);            // P = A*P*A' - KG*S*KG' + Q;
+
+    // Update state prediction
+    delta_x = KG*innovation;
+    // check for inf or nan before we update the states
+    if (delta_x.is_safe()) {
+        _x += delta_x;
+    }
+
+    // constrain states by assuming some facts about the aircraft
+    _x[1]  = MAX(_x[1],0.0f);  // Lift must increase with angle of attack
+    _x[2]  = MAX(_x[2],0.0f);  // Cd 0 must be greater than zero
+    _x[4]  = MAX(_x[4],0.0f);  // Drag must increase with angle of attack squared
+    _x[5]  = MAX(_x[5],0.0f);  // Must have some static thrust
+    _x[7]  = MIN(_x[7],0.0f);  // thrust must decrease with advance ratio squared
+    _x[8]  = MAX(_x[8],0.0f);  // Must use some power for static thrust
+    _x[10] = MIN(_x[10],0.0f); // Power must decrease with advance ratio squared
+
+    // do some logging
+    const uint64_t time_us = AP_HAL::micros64();
+    const struct log_aero_KF_input log1{
+        LOG_PACKET_HEADER_INIT(LOG_AERO_KF_MSG1),
+        time_us : time_us,
+        aoa     : _AoA_mean,      // Angle of attack (deg)
+        air_spd : _V_mean,        // Airspeed (m/s)
+        rho     : _rho_mean,      // pressure (kg/m^2)
+        rpm     : _rpm_mean,      // prop rpm (converted to rps in KF)
+        accel_x : _accel_x_mean,  // acceleration x (m/s^2)
+        accel_z : _accel_z_mean,  // acceleration z (m/s^2)
+        power   : _power_mean,    // power (w)
+    };
+
+    const struct log_aero_KF_innovation log2{
+        LOG_PACKET_HEADER_INIT(LOG_AERO_KF_MSG2),
+        time_us            : time_us,
+        calc_force_x       : prediction[0],  // calculated force x (N)
+        calc_force_z       : prediction[1],  // calculated force z (N)
+        calc_power         : prediction[2],  // calculated power (w)
+        true_force_x       : truth[0],       // measured force x (N)
+        true_force_z       : truth[1],       // measured force z (N)
+        true_power         : truth[2],       // measured power (w)
+        force_x_innovation : innovation[0],  // force innovation x (N)
+        force_z_innovation : innovation[1],  // force innovation Z (N)
+        power_innovation   : innovation[2],  // power innovation (w)
+    };
+
+    const struct log_aero_KF_state log3{
+        LOG_PACKET_HEADER_INIT(LOG_AERO_KF_MSG3),
+        time_us  : time_us,
+        Cl0      : _x[0],   // Cl0
+        Cla      : _x[1],   // Cla
+        Cd0      : _x[2],   // Cd0
+        Cda      : _x[3],   // Cda
+        Cdaa     : _x[4],   // Cdaa
+        Ct0      : _x[5],   // Ct0
+        Ctj      : _x[6],   // Ctj
+        Ctjj     : _x[7],   // Ctjj
+        CP0      : _x[8],   // CP0
+        CPj      : _x[9],   // CPj
+        CPjj     : _x[10],  // CPjj
+    };
+
+    const struct log_aero_KF_covariance log4{
+        LOG_PACKET_HEADER_INIT(LOG_AERO_KF_MSG4),
+        time_us      : time_us,
+        Cl0_cov      : _P.get(0,0),   // Cl0
+        Cla_cov      : _P.get(1,1),   // Cla
+        Cd0_cov      : _P.get(2,2),   // Cd0
+        Cda_cov      : _P.get(3,3),   // Cda
+        Cdaa_cov     : _P.get(4,4),   // Cdaa
+        Ct0_cov      : _P.get(5,5),   // Ct0
+        Ctj_cov      : _P.get(6,6),   // Ctj
+        Ctjj_cov     : _P.get(7,7),   // Ctjj
+        CP0_cov      : _P.get(8,8),   // CP0
+        CPj_cov      : _P.get(9,9),   // CPj
+        CPjj_cov     : _P.get(10,10), // CPjj
+    };
+
+    AP::logger().WriteBlock(&log1, sizeof(log1));
+    AP::logger().WriteBlock(&log2, sizeof(log2));
+    AP::logger().WriteBlock(&log3, sizeof(log3));
+    AP::logger().WriteBlock(&log4, sizeof(log4));
+
+    // reset number of samples for mean values
+    _samples = 0;
+    _rpm_samples = 0;
+    _power_samples = 0;
+
+}
+
+AP_Characterise *AP_Characterise::_singleton = nullptr;
+
+namespace AP {
+    AP_Characterise * characterise()
+    {
+        return AP_Characterise::get_singleton();
+    }
+};

--- a/libraries/AP_Characterise/AP_Characterise.h
+++ b/libraries/AP_Characterise/AP_Characterise.h
@@ -1,0 +1,109 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Math/matrixRC.h>
+
+#define N_KF_st 11 // number of KF states
+#define N_KF_eq 3  // number of KF equations/predictions
+
+class AP_Characterise
+{
+public:
+    AP_Characterise();
+
+    /* Do not allow copies */
+    AP_Characterise(const AP_Characterise &other) = delete;
+    AP_Characterise &operator=(const AP_Characterise&) = delete;
+
+    static AP_Characterise *get_singleton();
+
+    // return true if characterise is enabled
+    bool enabled() const;
+
+    // pre-arm check we have everything we need
+    bool prearm_healthy();
+
+    // get the reason for a prearm failure
+    char *prearm_failure_reason() {return prearm_fail_string;};
+
+    // read in and average inputs
+    void update_inputs();
+
+    // run a KF update
+    void update();
+
+    // parameter block
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+
+    // parameters
+    AP_Int8 _enable;
+    AP_Float _s;                  // wing area (m)
+    AP_Float _mass;               // vehicle mass (kg)
+    AP_Float _d;                  // propeller diameter (m)
+    AP_Int8 _num_props;           // number of propellers
+    AP_Int32 _prop_rpm_bitmask;   // bitmask of rpm sensors to use
+    AP_Int32 _prop_power_bitmask; // bitmask of power sensors to use
+    // measurement noise parameters
+    AP_Float _R_force_x;
+    AP_Float _R_force_z;
+    AP_Float _R_power;
+    // process noise paramiters
+    AP_Float _Q_CL0;
+    AP_Float _Q_CLa;
+    AP_Float _Q_CD0;
+    AP_Float _Q_CDa;
+    AP_Float _Q_CDaa;
+    AP_Float _Q_Ct0;
+    AP_Float _Q_Ctj;
+    AP_Float _Q_Ctjj;
+    AP_Float _Q_Cp0;
+    AP_Float _Q_Cpj;
+    AP_Float _Q_Cpjj;
+
+    // variables for averaging inputs
+    float _AoA_mean;
+    float _V_mean;
+    float _rho_mean;
+    float _rpm_mean;
+    float _accel_x_mean;
+    float _accel_z_mean;
+    float _power_mean;
+    uint16_t _samples;
+    uint16_t _rpm_samples;
+    uint16_t _power_samples;
+
+    // string representing last reason for prearm failure
+    char prearm_fail_string[42];
+
+    // read inputs from ESC telem and battery monitor
+    void read_esc_telem();
+    void read_bat_mon();
+
+    // KF varables
+    VectorN<float,N_KF_st>   _x;         // KF states, aerodynamic coefficients
+    MatrixN<float,N_KF_st>   _P{100.0f}; // KF state covariance matrix, initially a diagonal with values of 100
+
+    static AP_Characterise *_singleton;
+};
+
+namespace AP {
+    AP_Characterise *characterise();
+};

--- a/libraries/AP_Characterise/AP_Characterise.h
+++ b/libraries/AP_Characterise/AP_Characterise.h
@@ -94,7 +94,7 @@ private:
     char prearm_fail_string[42];
 
     // read inputs from ESC telem and battery monitor
-    void read_esc_telem();
+    void read_esc_telem(const bool have_throttle);
     void read_bat_mon();
 
     // KF varables

--- a/libraries/AP_Math/matrixN.cpp
+++ b/libraries/AP_Math/matrixN.cpp
@@ -54,7 +54,118 @@ void MatrixN<T,N>::force_symmetry(void)
     }
 }
 
+// get a element from the matrix
+template <typename T, uint8_t N>
+float MatrixN<T,N>::get(const uint8_t i, const uint8_t j) const
+{
+    return v[i][j];
+}
+
+// set a element to the matrix
+template <typename T, uint8_t N>
+void MatrixN<T,N>::set(const uint8_t i, const uint8_t j, const float value)
+{
+    v[i][j] = value;
+}
+
+// multiply rectangular matrix A by the transpose of rectangular matrix B to give a square matrix, in-place
+template <typename T, uint8_t N>
+void MatrixN<T,N>::mult_trans(const MatrixRC<T,N,11> &A, const MatrixRC<T,N,11> &B)
+{
+    for (uint8_t i=0; i<N; i++) {
+        for (uint8_t n=0; n<N; n++) {
+            for (uint8_t j=0; j<11; j++) {
+                v[i][n] += A.get(i,j) * B.get(n,j);
+            }
+        }
+    }
+}
+
+// multiply rectangular matrix A by the transpose of rectangular matrix B to give a square matrix, in-place
+template <typename T, uint8_t N>
+void MatrixN<T,N>::mult_trans(const MatrixRC<T,N,3> &A, const MatrixRC<T,N,3> &B)
+{
+    for (uint8_t i=0; i<N; i++) {
+        for (uint8_t n=0; n<N; n++) {
+            for (uint8_t j=0; j<3; j++) {
+                v[i][n] += A.get(i,j) * B.get(n,j);
+            }
+        }
+    }
+}
+
+// add a vector to the diagonals of the matrix, in-place
+template <typename T, uint8_t N>
+void MatrixN<T,N>::diag_add(const VectorN<T,N> &A)
+{
+    for (uint8_t i = 0; i < N; i++) {
+        v[i][i] += A[i];
+    }
+}
+
+// invert, note no error checking!
+template <typename T, uint8_t N>
+MatrixN<T,N> MatrixN<T,N>::inverse_matN()
+{
+    MatrixN<T,N> ret;
+    float input[N*N];
+
+    // convert to array
+    uint16_t index = 0;
+    for (uint8_t i = 0; i < N; i++) {
+        for (uint8_t j = 0; j < N; j++) {
+            input[index] = v[i][j];
+            index++;
+        }
+    }
+
+    float output[N*N];
+    inverse(input,output,(uint16_t)N);
+
+    // convert back again
+    index = 0;
+    for (uint8_t i = 0; i < N; i++) {
+        for (uint8_t j = 0; j < N; j++) {
+            ret.v[i][j] = output[index];
+            index++;
+        }
+    }
+    return ret;
+}
+
+// Check if it is safe to use this matrix
+template <typename T, uint8_t N>
+bool MatrixN<T,N>::is_safe(void)
+{
+    for (uint8_t i = 0; i < N; i++) {
+        for (uint8_t j = 0; j < N; j++) {
+            if (isinf(v[i][j]) || isnan(v[i][j])) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 template void MatrixN<float,4>::mult(const VectorN<float,4> &A, const VectorN<float,4> &B);
+
 template MatrixN<float,4> &MatrixN<float,4>::operator -=(const MatrixN<float,4> &B);
+template MatrixN<float,11> &MatrixN<float,11>::operator -=(const MatrixN<float,11> &B);
+
 template MatrixN<float,4> &MatrixN<float,4>::operator +=(const MatrixN<float,4> &B);
+
+template float MatrixN<float,3>::get(const uint8_t i, const uint8_t j) const;
+template float MatrixN<float,11>::get(const uint8_t i, const uint8_t j) const;
+
 template void MatrixN<float,4>::force_symmetry(void);
+template void MatrixN<float,11>::force_symmetry(void);
+
+template void MatrixN<float,3>::mult_trans(const MatrixRC<float,3,11> &A, const MatrixRC<float,3,11> &B);
+template void MatrixN<float,11>::mult_trans(const MatrixRC<float,11,3> &A, const MatrixRC<float,11,3> &B);
+
+template void MatrixN<float,3>::diag_add(const VectorN<float,3> &A);
+template void MatrixN<float,11>::diag_add(const VectorN<float,11> &A);
+
+template MatrixN<float,3> MatrixN<float,3>::inverse_matN();
+
+template bool MatrixN<float,11>::is_safe();

--- a/libraries/AP_Math/matrixN.h
+++ b/libraries/AP_Math/matrixN.h
@@ -7,20 +7,24 @@
 #include "math.h"
 #include <stdint.h>
 #include "vectorN.h"
+#include "matrixRC.h"
+#include <AP_Math/AP_Math.h>
 
 template <typename T, uint8_t N>
 class VectorN;
 
+template <typename T, uint8_t R, uint8_t C>
+class MatrixRC;
 
 template <typename T, uint8_t N>
 class MatrixN {
-  
+
     friend class VectorN<T,N>;
 
 public:
     // constructor from zeros
     MatrixN<T,N>(void) {
-        memset(v, 0, sizeof(v));        
+        memset(v, 0, sizeof(v));
     }
 
     // constructor from 4 diagonals
@@ -28,6 +32,14 @@ public:
         memset(v, 0, sizeof(v));
         for (uint8_t i = 0; i < N; i++) {
             v[i][i] = d[i];
+        }
+    }
+
+    // constructor constant diagonal
+    MatrixN<T,N>(const float d) {
+        memset(v, 0, sizeof(v));
+        for (uint8_t i = 0; i < N; i++) {
+            v[i][i] = d;
         }
     }
 
@@ -39,9 +51,27 @@ public:
 
     // add B to the matrix
     MatrixN<T,N> &operator +=(const MatrixN<T,N> &B);
-    
+
     // Matrix symmetry routine
     void force_symmetry(void);
+
+    // get a element from the matrix
+    float get(const uint8_t i, const uint8_t j) const;
+
+    // set a element to the matrix
+    void set(const uint8_t i, const uint8_t j, const float value);
+
+    // multiply rectangular matrix A by the transpose of rectangular matrix B to give a square matrix, in-place
+    void mult_trans(const MatrixRC<T,N,11> &A, const MatrixRC<T,N,11> &B);
+    void mult_trans(const MatrixRC<T,N,3> &A, const MatrixRC<T,N,3> &B);
+
+    // add a vector to the diagonals of the matrix, in-place
+    void diag_add(const VectorN<T,N> &A);
+
+    // invert, note no error checking!
+    MatrixN<T,N> inverse_matN();
+
+    bool is_safe();
 
 private:
     T v[N][N];

--- a/libraries/AP_Math/matrixRC.cpp
+++ b/libraries/AP_Math/matrixRC.cpp
@@ -1,0 +1,90 @@
+/*
+ *  R by C rectangular matrix operations
+ */
+
+#pragma GCC optimize("O3")
+
+#include "matrixRC.h"
+
+
+// multiply two vectors to give a matrix, in-place
+template <typename T, uint8_t R, uint8_t C>
+void MatrixRC<T,R,C>::mult(const VectorN<T,R> &A, const VectorN<T,C> &B)
+{
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            v[i][j] = A[i] * B[j];
+        }
+    }
+}
+
+// set a element in the matrix
+template <typename T, uint8_t R, uint8_t C>
+void MatrixRC<T,R,C>::set(const uint8_t i, const uint8_t j, const float value)
+{
+    v[i][j] = value;
+}
+
+// get a element from the matrix
+template <typename T, uint8_t R, uint8_t C>
+float MatrixRC<T,R,C>::get(const uint8_t i, const uint8_t j) const
+{
+    return v[i][j];
+}
+
+// multiply a rectangular matrix A of dimensions [dim1, dim2] by square matrix B of [dim2 dim2]
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::operator *(const MatrixN<T,C> &B)
+{
+    MatrixRC<T,R,C> ret;
+
+    for (uint8_t i=0; i<R; i++) {
+        for (uint8_t n=0; n<C; n++) {
+            for (uint8_t j=0; j<C; j++) {
+                ret.v[i][n] = ret.v[i][n] + v[i][j] * B.get(j,n);
+            }
+        }
+    }
+    return ret;
+}
+
+// multiply a rectangular matrix A of dimensions [dim1, dim2] by vector B of [dim2]
+template <typename T, uint8_t R, uint8_t C>
+VectorN<T,R> MatrixRC<T,R,C>::operator *(const VectorN<T,C> &B)
+{
+    VectorN<T,R> ret;
+
+    for (uint8_t i=0; i<R; i++) {
+        for (uint8_t j=0; j<C; j++) {
+            ret[i] = ret[i] + v[i][j] * B[j];
+        }
+    }
+    return ret;
+}
+
+// multiply the transpose of rectangular matrix A by square matrix B to give a rectangular matrix, in-place
+template <typename T, uint8_t R, uint8_t C>
+void MatrixRC<T,R,C>::trans_mult(const MatrixRC<T,C,R> &A, const MatrixN<T,C> &B)
+{
+    for (uint8_t i=0; i<R; i++) {
+        for (uint8_t n=0; n<C; n++) {
+            for (uint8_t j=0; j<C; j++) {
+                v[i][n] = v[i][n] + A.get(j,i) * B.get(j,n);
+            }
+        }
+    }
+}
+
+template void MatrixRC<float,3,11> ::set(const uint8_t i, const uint8_t j, const float value);
+template void MatrixRC<float,11,3> ::set(const uint8_t i, const uint8_t j, const float value);
+
+template float MatrixRC<float,3,11> ::get(const uint8_t i, const uint8_t j) const;
+template float MatrixRC<float,11,3> ::get(const uint8_t i, const uint8_t j) const;
+
+template MatrixRC<float,3,11> MatrixRC<float,3,11>::operator *(const MatrixN<float,11> &B);
+template MatrixRC<float,11,3> MatrixRC<float,11,3>::operator *(const MatrixN<float,3> &B);
+
+template VectorN<float,11> MatrixRC<float,11,3>::operator *(const VectorN<float,3> &B);
+
+
+template void MatrixRC<float,11,3>::trans_mult(const MatrixRC<float,3,11> &A, const MatrixN<float,3> &B);

--- a/libraries/AP_Math/matrixRC.h
+++ b/libraries/AP_Math/matrixRC.h
@@ -1,0 +1,46 @@
+/*
+ *  R by C rectangular matrix operations
+ */
+
+#pragma once
+
+#include "math.h"
+#include <stdint.h>
+#include "vectorN.h"
+#include "matrixN.h"
+
+template <typename T, uint8_t N>
+class VectorN;
+
+template <typename T, uint8_t N>
+class MatrixN;
+
+template <typename T, uint8_t R, uint8_t C>
+class MatrixRC {
+public:
+    // constructor from zeros
+    MatrixRC<T,R,C>(void) {
+        memset(v, 0, sizeof(v));
+    }
+
+    // multiply two vectors to give a matrix, in-place
+    void mult(const VectorN<T,R> &A, const VectorN<T,C> &B);
+
+    // set a element in the matrix
+    void set(const uint8_t i, const uint8_t j, const float value);
+
+    // get a element from the matrix
+    float get(const uint8_t i, const uint8_t j) const;
+
+    // multiply a rectangular matrix A of dimensions [dim1, dim2] by square matrix B of [dim2 dim2]
+    MatrixRC<T,R,C> operator *(const MatrixN<T,C> &B);
+
+    // multiply a rectangular matrix A of dimensions [dim1, dim2] by vector B of [dim2]
+    VectorN<T,R> operator *(const VectorN<T,C> &B);
+
+    // multiply the transpose of rectangular matrix A by square matrix B to give a rectangular matrix, in-place
+    void trans_mult(const MatrixRC<T,C,R> &A, const MatrixN<T,C> &B);
+
+private:
+    T v[R][C];
+};

--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <string.h>
 #include "matrixN.h"
+#include "matrixRC.h"
 
 #ifndef MATH_CHECK_INDEXES
 # define MATH_CHECK_INDEXES 0
@@ -29,6 +30,8 @@
 template <typename T, uint8_t N>
 class MatrixN;
 
+template <typename T, uint8_t R, uint8_t C>
+class MatrixRC;
 
 template <typename T, uint8_t N>
 class VectorN
@@ -158,7 +161,7 @@ public:
         return ret;
     }
     
-    // multiplication of a matrix by a vector, in-place
+    // multiplication of a square matrix by a vector, in-place
     // C = A * B
     void mult(const MatrixN<T,N> &A, const VectorN<T,N> &B) {
         for (uint8_t i = 0; i < N; i++) {
@@ -167,6 +170,26 @@ public:
                 _v[i] += A.v[i][k] * B[k];
             }
         }
+    }
+
+    // multiplication of a rectangular matrix by a vector, in-place
+    void mult(MatrixRC<T,3,11> &A, VectorN<T,11> &B) {
+        for (uint8_t i = 0; i < N; i++) {
+            _v[i] = 0;
+            for (uint8_t k = 0; k < 11; k++) {
+                _v[i] += A.get(i,k) * B[k];
+            }
+        }
+    }
+
+    // check if it is safe to use this vector
+    bool is_safe() {
+        for (uint8_t i=0; i<N; i++) {
+            if (isinf( _v[i]) || isnan(_v[i])) {
+                return false;
+            }
+        }
+        return true;
     }
 
 private:


### PR DESCRIPTION
This adds a Kalman filter that learns the aerodynamic coefficients of the air-frame and propeller. These can then then be used to estimate the battery drain to travel a certain distance, this would allow a dynamic RTL battery fail-safe that would always get you back home with x% battery remaining no mater how far you were from home when the fail-safe triggered. (this is yet to be implemented).

Further to this it is hoped that the coefficients maybe able to give some insight into aircraft setup and design. For example prop X is more efficient at airspeed Y. 

So far this has only be tested in Realflight, it would be great to get as many logs as possible so we can select the optimal parameters for the KF, in particular if you have a idea what the aerodynamic parameters for your airfraime should be.  

The KF learns 11 states and then uses these states to predict the X(trust - drag) and Z(lift) body frame accelerations and the power draw. In order to converge to a correct solution some states are subject to constants. The states are:

1. Cl0 - the zero angle of attack lift coefficient
2. Cla - the change in lift coefficient with angle of attack - this must be positive, lift must increase with angle of attack 
3. Cd0 - the zero angle of attack drag coefficient - this must be positive
4. Cda - the change in drag coefficient with angle of attack
5. Cdaa - the change in drag coefficient with angle of attack squared - this must be positive, drag must increase with angle of attack squared 
6. Ct0 - the zero advance ratio propeller thrust coefficient - this must be positive, must be some static thrust
7.Ctj - the change in thrust coefficient with advance ratio
8. Ctjj - the change in thrust coefficient with advance ratio squared - this must be negative, thrust must decrease as the airspeed increases
9. Cp0 - the zero advance ratio propeller power coefficient - this must be positive, must use some power at zero airspeed 
10. Cpj - the change in power coefficient with advance ratio
11. Cpjj - the change in power coefficient with advance ratio squared, this must be negative, power must decrease at the airspeed increases

In order  to learn these states accurately you must give the KF some information about your aircraft, its mass, wing area, propeller diameter and number of props. Note that if you don't care about the values of the learned coefficients but just want to get the battery percentage predictions they can be left at the default but all the coefficients will be none-dimensionalised wrong.  

You must however have a battery power sensor(s) and a prop rpm sensor(s). The code can use both battery and rpm feedback from BlHeli-telem. If you have multiple props the average of the rpm sensors will be taken, the KF assumes that all the props are identical. The KF also relys on knowing the airspeed so a airspeed sensor is a good idea too. 

This is data from a example flight using a beaver model in realflight. More testing is required to see if this is something that could be left running all the time or if it would be better to tune it up once with a plane autotune type flight. This is me flying a autotune style flight, i had to remove the last bit of the data as the KF got abit confused once it had landed.  
![inputs](https://user-images.githubusercontent.com/33176108/60931972-bc174c80-a2b3-11e9-92e7-e994ef5530ad.png)
These are the inputs to the KF

![states](https://user-images.githubusercontent.com/33176108/60932005-e832cd80-a2b3-11e9-8064-1f4f65ddfcff.png)
This is the KF states over time, the red lines are the average values used for plotting the later graphs. This is abit wired, sort of like filtering a filter, any better ideas?

![cov](https://user-images.githubusercontent.com/33176108/60932064-33e57700-a2b4-11e9-86da-8c7d2f1177ff.png)
This is the state covariances, note the thrust J and JJ are more or less continually increasing, this may be a problem if the KF were to run for a longer period of time. 

![lift and drag](https://user-images.githubusercontent.com/33176108/60932129-86bf2e80-a2b4-11e9-928e-06c1d5f05412.png)
This is the lift and drag coefficients vs angle of attack. The black shows the predictions over time, red is the average. Note that we only consider the linear lift region, no stall effects. 

![prop](https://user-images.githubusercontent.com/33176108/60932211-d69df580-a2b4-11e9-9c22-b560c2ddd5bc.png)
Propeller thrust and power coefficient vs advance ratio. (airspeed / (prop rotation rate * diameter))

![eff](https://user-images.githubusercontent.com/33176108/60932257-106efc00-a2b5-11e9-95c2-d4da16fc6b9e.png)
From these curves we can then plot some more insightful things. The lift over drag ratio, this shows that this air-frame is most efficient at a angle of attack of ~3 deg with a best L/D ratio of 0.77. The propeller efficiency gives a peek efficiency of 51% at a advance ratio of 0.2. Note that this is actually the whole power system efficient as we measure in input electrical power rather than shaft power to the propeller. This is the efficiency of the prop * motor efficiency * esc efficiency.

![drag](https://user-images.githubusercontent.com/33176108/60932396-c20e2d00-a2b5-11e9-94ec-8692db83f61c.png)
This is the drag vs airspeed, for this aircraft minimum drag is achieved at ~18m/s.

If we assume straight level un-accelerated flight (SLUF) we can go further. 

![power](https://user-images.githubusercontent.com/33176108/60932487-23360080-a2b6-11e9-8ff5-b8c30a0bb077.png)

Power draw vs airspeed, if you want to use little power fly slowly. Note that this assume small angles, that is that the propeller does not contribute to lift, no prop hanging. To do a dynamic battery fail safe we only need to get the power correct at the RLT airspeed.


So all in all for this example the graphs look quite plausible but it would be nice to do some tests to try and find out how much we can really trust these graphs.

If they seem quite trust worthy we could do some more things such as automatically choosing the airspeed to give the best flight time or minimum (power / ground speed) in a particular direction. (this depends on the wind speed)




