### PR TITLE
Move PolyFence-related functions into the polyfence loader

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -399,7 +399,7 @@ void AC_Avoid::adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2
 
     // get polygon boundary
     uint16_t num_points;
-    const Vector2f* boundary = _fence.get_boundary_points(num_points);
+    const Vector2f* boundary = _fence.polyfence().get_boundary_points(num_points);
 
     // adjust velocity using polygon
     adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, boundary, num_points, true, _fence.get_margin(), dt);

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -200,13 +200,13 @@ bool AP_OABendyRuler::calc_margin_from_polygon_fence(const Location &start, cons
     if (fence == nullptr) {
         return false;
     }
-    if (((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) || !fence->is_polygon_valid()) {
+    if (((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) || !fence->polyfence_const().valid()) {
         return false;
     }
 
     // get polygon boundary
     uint16_t num_points;
-    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    const Vector2f* boundary = fence->polyfence_const().get_boundary_points(num_points);
     if (num_points < 3) {
         // this should have already been checked by is_polygon_valid() but just in case
         return false;

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -124,7 +124,7 @@ bool AP_OADijkstra::polygon_fence_enabled() const
     if (fence == nullptr) {
         return false;
     }
-    if (!fence->is_polygon_valid()) {
+    if (!fence->polyfence_const().valid()) {
         return false;
     }
     return ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) > 0);
@@ -138,7 +138,7 @@ bool AP_OADijkstra::check_polygon_fence_updated() const
     if (fence == nullptr) {
         return false;
     }
-    return (_polyfence_update_ms != fence->get_boundary_update_ms());
+    return (_polyfence_update_ms != fence->polyfence_const().update_ms());
 }
 
 // create a smaller polygon fence within the existing polygon fence
@@ -153,7 +153,7 @@ bool AP_OADijkstra::create_polygon_fence_with_margin(float margin_cm)
 
     // get polygon boundary
     uint16_t num_points;
-    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    const Vector2f* boundary = fence->polyfence_const().get_boundary_points(num_points);
     if ((boundary == nullptr) || (num_points < 3)) {
         return false;
     }
@@ -203,7 +203,7 @@ bool AP_OADijkstra::create_polygon_fence_with_margin(float margin_cm)
     _polyfence_numpoints = num_points;
 
     // record fence update time so we don't process this exact fence again
-    _polyfence_update_ms = fence->get_boundary_update_ms();
+    _polyfence_update_ms = fence->polyfence_const().update_ms();
 
     return true;
 }
@@ -226,7 +226,7 @@ bool AP_OADijkstra::create_polygon_fence_visgraph()
 
     // get polygon boundary
     uint16_t num_points;
-    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    const Vector2f* boundary = fence->polyfence_const().get_boundary_points(num_points);
     if ((boundary == nullptr) || (num_points < 3)) {
         return false;
     }
@@ -278,7 +278,7 @@ bool AP_OADijkstra::update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph
 
     // get polygon boundary
     uint16_t num_points;
-    const Vector2f* boundary = fence->get_boundary_points(num_points);
+    const Vector2f* boundary = fence->polyfence_const().get_boundary_points(num_points);
     if ((boundary == nullptr) || (num_points < 3)) {
         return false;
     }

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -116,7 +116,7 @@ bool AC_Fence::pre_arm_check_polygon(const char* &fail_msg) const
         return true;
     }
 
-    if (!_boundary_valid) {
+    if (!_poly_loader.valid()) {
         fail_msg = "Polygon boundary invalid";
         return false;
     }
@@ -258,27 +258,9 @@ bool AC_Fence::polygon_fence_is_breached()
         return false;
     }
 
-    // check consistency of number of points
-    if (_boundary_num_points != _total) {
-        // Fence is currently not completely loaded.  Can't breach it?!
-        load_polygon_from_eeprom();
-        return false;
-    }
-    if (!_boundary_valid) {
-        // fence isn't valid - can't breach it?!
-        return false;
-    }
-
-    // check if vehicle is outside the polygon fence
-    Vector2f position;
-    if (!AP::ahrs().get_relative_position_NE_origin(position)) {
-        // we have no idea where we are; can't breach the fence
-        return false;
-    }
-
-    position = position * 100.0f;  // m to cm
-    return _poly_loader.boundary_breached(position, _boundary_num_points, _boundary);
+    return _poly_loader.breached();
 }
+
 
 bool AC_Fence::check_fence_circle()
 {
@@ -385,13 +367,9 @@ bool AC_Fence::check_destination_within_fence(const Location& loc)
     }
 
     // polygon fence check
-    if ((get_enabled_fences() & AC_FENCE_TYPE_POLYGON) && _boundary_num_points > 0) {
-        // check ekf has a good location
-        Vector2f posNE;
-        if (loc.get_vector_xy_from_origin_NE(posNE)) {
-            if (_poly_loader.boundary_breached(posNE, _boundary_num_points, _boundary)) {
-                return false;
-            }
+    if ((get_enabled_fences() & AC_FENCE_TYPE_POLYGON)) {
+        if (_poly_loader.breached(loc)) {
+            return false;
         }
     }
 
@@ -459,17 +437,17 @@ void AC_Fence::manual_recovery_start()
 }
 
 /// returns pointer to array of polygon points and num_points is filled in with the total number
-Vector2f* AC_Fence::get_boundary_points(uint16_t& num_points) const
+Vector2f* AC_PolyFence_loader::get_boundary_points(uint16_t& num_points) const
 {
     // return array minus the first point which holds the return location
     if (_boundary == nullptr) {
         return nullptr;
     }
-    if (!_boundary_valid) {
+    if (!valid()) {
         return nullptr;
     }
     // minus one for return point, minus one for closing point
-    // (_boundary_valid is not true unless we have a closing point AND
+    // (polygon().valid() is not true unless we have a closing point AND
     // we have a minumum number of points)
     if (_boundary_num_points < 2) {
         return nullptr;
@@ -478,14 +456,8 @@ Vector2f* AC_Fence::get_boundary_points(uint16_t& num_points) const
     return &_boundary[1];
 }
 
-/// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object
-bool AC_Fence::boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points) const
-{
-    return _poly_loader.boundary_breached(location, num_points, points);
-}
-
 /// handler for polygon fence messages with GCS
-void AC_Fence::handle_msg(GCS_MAVLINK &link, const mavlink_message_t &msg)
+void AC_PolyFence_loader::handle_msg(conts GCS_MAVLINK &link, const mavlink_message_t &msg)
 {
     switch (msg.msgid) {
         // receive a fence point from GCS and store in EEPROM
@@ -498,7 +470,7 @@ void AC_Fence::handle_msg(GCS_MAVLINK &link, const mavlink_message_t &msg)
                 Vector2l point;
                 point.x = packet.lat*1.0e7f;
                 point.y = packet.lng*1.0e7f;
-                if (!_poly_loader.save_point_to_eeprom(packet.idx, point)) {
+                if (!save_point_to_eeprom(packet.idx, point)) {
                     link.send_text(MAV_SEVERITY_WARNING, "Failed to save polygon point, too many points?");
                 } else {
                     // trigger reload of points
@@ -514,8 +486,13 @@ void AC_Fence::handle_msg(GCS_MAVLINK &link, const mavlink_message_t &msg)
             mavlink_msg_fence_fetch_point_decode(&msg, &packet);
             // attempt to retrieve from eeprom
             Vector2l point;
+<<<<<<< HEAD
             if (_poly_loader.load_point_from_eeprom(packet.idx, point)) {
                 mavlink_msg_fence_point_send(link.get_chan(), msg.sysid, msg.compid, packet.idx, _total, point.x*1.0e-7f, point.y*1.0e-7f);
+=======
+            if (load_point_from_eeprom(packet.idx, point)) {
+                mavlink_msg_fence_point_send(link.get_chan(), msg->sysid, msg->compid, packet.idx, _total, point.x*1.0e-7f, point.y*1.0e-7f);
+>>>>>>> AC_Fence: move polygon points into AC_Fence_Polygon
             } else {
                 link.send_text(MAV_SEVERITY_WARNING, "Bad fence point");
             }
@@ -529,12 +506,12 @@ void AC_Fence::handle_msg(GCS_MAVLINK &link, const mavlink_message_t &msg)
 }
 
 /// load polygon points stored in eeprom into boundary array and perform validation
-bool AC_Fence::load_polygon_from_eeprom()
+bool AC_PolyFence_loader::load_from_eeprom()
 {
     // check if we need to create array
-    if (!_boundary_create_attempted) {
-        _boundary = (Vector2f *)_poly_loader.create_point_array(sizeof(Vector2f));
-        _boundary_create_attempted = true;
+    if (!_create_attempted) {
+        _boundary = (Vector2f *)create_point_array(sizeof(Vector2f));
+        _create_attempted = true;
     }
 
     // exit if we could not allocate RAM for the boundary
@@ -553,13 +530,13 @@ bool AC_Fence::load_polygon_from_eeprom()
     }
 
     // sanity check total
-    _total = constrain_int16(_total, 0, _poly_loader.max_points());
+    _total = constrain_int16(_total, 0, max_points());
 
     // load each point from eeprom
     Vector2l temp_latlon;
     for (uint16_t index=0; index<_total; index++) {
         // load boundary point as lat/lon point
-        if (!_poly_loader.load_point_from_eeprom(index, temp_latlon)) {
+        if (!load_point_from_eeprom(index, temp_latlon)) {
             return false;
         }
         // move into location structure and convert to offset from ekf origin
@@ -568,10 +545,10 @@ bool AC_Fence::load_polygon_from_eeprom()
         _boundary[index] = ekf_origin.get_distance_NE(temp_loc) * 100.0f;
     }
     _boundary_num_points = _total;
-    _boundary_update_ms = AP_HAL::millis();
+    _update_ms = AP_HAL::millis();
 
     // update validity of polygon
-    _boundary_valid = _poly_loader.boundary_valid(_boundary_num_points, _boundary);
+    _valid = calculate_boundary_valid();
 
     return true;
 }
@@ -603,7 +580,7 @@ bool AC_Fence::sys_status_failed() const
         return true;
     }
     if (_enabled_fences & AC_FENCE_TYPE_POLYGON) {
-        if (!_boundary_valid) {
+        if (!_poly_loader.valid()) {
             return true;
         }
     }

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -95,26 +95,6 @@ public:
     ///     has no effect if no breaches have occurred
     void manual_recovery_start();
 
-    ///
-    /// polygon related methods
-    ///
-
-    /// returns true if polygon fence is valid (i.e. has at least 3 sides)
-    bool is_polygon_valid() const { return _boundary_valid; }
-
-    /// returns pointer to array of polygon points and num_points is filled in with the total number
-    /// points are offsets from EKF origin in NE frame
-    Vector2f* get_boundary_points(uint16_t& num_points) const;
-
-    /// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object
-    bool boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points) const;
-
-    /// handler for polygon fence messages with GCS
-    void handle_msg(GCS_MAVLINK &link, const mavlink_message_t &msg);
-
-    /// return system time of last update to the boundary (allows external detection of boundary changes)
-    uint32_t get_boundary_update_ms() const { return _boundary_update_ms; }
-
     static const struct AP_Param::GroupInfo var_info[];
 
     // methods for mavlink SYS_STATUS message (send_sys_status)
@@ -124,6 +104,9 @@ public:
 
     // get singleton instance
     static AC_Fence *get_singleton() { return _singleton; }
+
+    AC_PolyFence_loader &polyfence() { return _poly_loader; }
+    const AC_PolyFence_loader &polyfence_const() const { return _poly_loader; }
 
 private:
     static AC_Fence *_singleton;
@@ -147,9 +130,6 @@ private:
     bool pre_arm_check_polygon(const char* &fail_msg) const;
     bool pre_arm_check_circle(const char* &fail_msg) const;
     bool pre_arm_check_alt(const char* &fail_msg) const;
-
-    /// load polygon points stored in eeprom into boundary array and perform validation.  returns true if load successfully completed
-    bool load_polygon_from_eeprom();
 
     // returns true if we have breached the fence:
     bool polygon_fence_is_breached();
@@ -184,13 +164,8 @@ private:
 
     uint32_t        _manual_recovery_start_ms;  // system time in milliseconds that pilot re-took manual control
 
-    // polygon fence variables
-    AC_PolyFence_loader _poly_loader;               // helper for loading/saving polygon points
-    Vector2f        *_boundary = nullptr;           // array of boundary points.  Note: point 0 is the return point
-    uint8_t         _boundary_num_points = 0;       // number of points in the boundary array (should equal _total parameter after load has completed)
-    bool            _boundary_create_attempted = false; // true if we have attempted to create the boundary array
-    bool            _boundary_valid = false;        // true if boundary forms a closed polygon
-    uint32_t        _boundary_update_ms;            // system time of last update to the boundary
+    AC_PolyFence_loader _poly_loader{_total}; // polygon fence
+
 };
 
 namespace AP {

--- a/libraries/AC_Fence/AC_PolyFence_loader.h
+++ b/libraries/AC_Fence/AC_PolyFence_loader.h
@@ -2,11 +2,48 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
 
 class AC_PolyFence_loader
 {
 
 public:
+
+    AC_PolyFence_loader(AP_Int8 &total) :
+        _total(total) {}
+
+    AC_PolyFence_loader(const AC_PolyFence_loader &other) = delete;
+    AC_PolyFence_loader &operator=(const AC_PolyFence_loader&) = delete;
+
+    /// returns pointer to array of polygon points and num_points is
+    /// filled in with the total number.  This does not include the
+    /// return point or the closing point.
+    Vector2f* get_boundary_points(uint16_t& num_points) const;
+
+    /// handler for polygon fence messages with GCS
+    void handle_msg(const GCS_MAVLINK &link, const mavlink_message_t &msg);
+
+    bool breached();
+    //   returns true if location is outside the boundary
+    bool breached(const Location& loc);
+
+    //   returns true if boundary is valid
+    bool valid() const {
+        return _valid;
+    }
+
+    // returns the system in in millis when the boundary was last updated
+    uint32_t update_ms() const {
+        return _update_ms;
+    }
+
+private:
+
+    bool breached(const Vector2f& location);
+    /// load polygon points stored in eeprom into boundary array and
+    /// perform validation.  returns true if load successfully
+    /// completed
+    bool load_from_eeprom();
 
     // maximum number of fence points we can store in eeprom
     uint8_t max_points() const;
@@ -21,16 +58,15 @@ public:
     // save a fence point to eeprom, returns true on successful save
     bool save_point_to_eeprom(uint16_t i, const Vector2l& point);
 
+    // update the validity flag:
+    bool calculate_boundary_valid() const;
 
-    // validate array of boundary points (expressed as either floats or long ints)
-    //   returns true if boundary is valid
-    template <typename T>
-    bool boundary_valid(uint16_t num_points, const Vector2<T>* points) const;
+    Vector2f *_boundary;          // array of boundary points.  Note: point 0 is the return point
+    uint8_t _boundary_num_points; // number of points in the boundary array (should equal _total parameter after load has completed)
+    bool   _create_attempted;     // true if we have attempted to create the boundary array
+    bool   _valid;                // true if boundary forms a closed polygon
+    uint32_t        _update_ms;   // system time of last update to the boundary
 
-    // check if a location (expressed as either floats or long ints) is within the boundary
-    //   returns true if location is outside the boundary
-    template <typename T>
-    bool boundary_breached(const Vector2<T>& location, uint16_t num_points, const Vector2<T>* points) const;
-
+    AP_Int8 &_total;
 };
 

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -18,6 +18,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <AP_Param/AP_Param.h>
 #include "AP_Proximity_SITL.h"
+#include <AC_Fence/AC_Fence.h>
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
@@ -34,10 +35,6 @@ AP_Proximity_SITL::AP_Proximity_SITL(AP_Proximity &_frontend,
     sitl(AP::sitl())
 {
     ap_var_type ptype;
-    fence_count = (AP_Int8 *)AP_Param::find("FENCE_TOTAL", &ptype);
-    if (fence_count == nullptr || ptype != AP_PARAM_INT8) {
-        AP_HAL::panic("Proximity_SITL: Failed to find FENCE_TOTAL");
-    }
     fence_alt_max = (AP_Float *)AP_Param::find("FENCE_ALT_MAX", &ptype);
     if (fence_alt_max == nullptr || ptype != AP_PARAM_FLOAT) {
         AP_HAL::panic("Proximity_SITL: Failed to find FENCE_ALT_MAX");
@@ -47,11 +44,12 @@ AP_Proximity_SITL::AP_Proximity_SITL(AP_Proximity &_frontend,
 // update the state of the sensor
 void AP_Proximity_SITL::update(void)
 {
-    load_fence();
     current_loc.lat = sitl->state.latitude * 1.0e7;
     current_loc.lng = sitl->state.longitude * 1.0e7;
     current_loc.alt = sitl->state.altitude * 1.0e2;
-    if (fence && fence_loader.boundary_valid(fence_count->get(), fence)) {
+
+    (void)AP::fence()->polyfence().breached(); // prompt polyfence to reload fence if required
+    if (AP::fence()->polyfence().valid()) {
         // update distance in one sector
         if (get_distance_to_fence(_sector_middle_deg[last_sector], _distance[last_sector])) {
             set_status(AP_Proximity::Proximity_Good);
@@ -70,29 +68,10 @@ void AP_Proximity_SITL::update(void)
     }
 }
 
-void AP_Proximity_SITL::load_fence(void)
-{
-    uint32_t now = AP_HAL::millis();
-    if (now - last_load_ms < 1000) {
-        return;
-    }
-    last_load_ms = now;
-    
-    if (fence == nullptr) {
-        fence = (Vector2l *)fence_loader.create_point_array(sizeof(Vector2l));
-    }
-    if (fence == nullptr) {
-        return;
-    }
-    for (uint8_t i=0; i<fence_count->get(); i++) {
-        fence_loader.load_point_from_eeprom(i, fence[i]);
-    }
-}
-
 // get distance in meters to fence in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
 bool AP_Proximity_SITL::get_distance_to_fence(float angle_deg, float &distance) const
 {
-    if (!fence_loader.boundary_valid(fence_count->get(), fence)) {
+    if (!AP::fence()->polyfence().valid()) {
         return false;
     }
 
@@ -106,10 +85,10 @@ bool AP_Proximity_SITL::get_distance_to_fence(float angle_deg, float &distance) 
     float min_dist = 0, max_dist = PROXIMITY_MAX_RANGE;
     while (max_dist - min_dist > PROXIMITY_ACCURACY) {
         float test_dist = (max_dist+min_dist)*0.5f;
+
         Location loc = current_loc;
         loc.offset_bearing(angle_deg, test_dist);
-        Vector2l vecloc(loc.lat, loc.lng);
-        if (fence_loader.boundary_breached(vecloc, fence_count->get(), fence)) {
+        if (AP::fence()->polyfence().breached(loc)) {
             max_dist = test_dist;
         } else {
             min_dist = test_dist;

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -26,17 +26,11 @@ public:
 
 private:
     SITL::SITL *sitl;
-    Vector2l *fence;
-    AP_Int8 *fence_count;
     AP_Float *fence_alt_max;
-    uint32_t last_load_ms;
-    AC_PolyFence_loader fence_loader;
     Location current_loc;
 
     // latest sector updated
     uint8_t last_sector;
-
-    void load_fence(void);
 
     // get distance in meters to fence in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
     bool get_distance_to_fence(float angle_deg, float &distance) const;

--- a/libraries/GCS_MAVLink/GCS_Fence.cpp
+++ b/libraries/GCS_MAVLink/GCS_Fence.cpp
@@ -31,7 +31,7 @@ void GCS_MAVLINK::handle_fence_message(const mavlink_message_t &msg)
     switch (msg.msgid) {
     case MAVLINK_MSG_ID_FENCE_POINT:
     case MAVLINK_MSG_ID_FENCE_FETCH_POINT:
-        fence->handle_msg(*this, msg);
+        fence->polyfence().handle_msg(*this, msg);
         break;
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL


### PR DESCRIPTION
PolyfenceLoader becomes just PolyFence, a self-contained piece of functionality that can be used by AC_Fence.

I have another branch which seems to be showing it can also be used by Plane for its PolyFence requirements.
