### PR TITLE
Copter: auto's wp_start accepts terrain alts

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -313,7 +313,7 @@ public:
     bool loiter_start();
     void rtl_start();
     void takeoff_start(const Location& dest_loc);
-    void wp_start(const Vector3f& destination);
+    void wp_start(const Vector3f& destination, bool terrain_alt);
     void wp_start(const Location& dest_loc);
     void land_start();
     void land_start(const Vector3f& destination);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -189,12 +189,12 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
 }
 
 // auto_wp_start - initialises waypoint controller to implement flying to a particular destination
-void ModeAuto::wp_start(const Vector3f& destination)
+void ModeAuto::wp_start(const Vector3f& destination, bool terrain_alt)
 {
     _mode = Auto_WP;
 
     // initialise wpnav (no need to check return status because terrain data is not used)
-    wp_nav->set_wp_destination(destination, false);
+    wp_nav->set_wp_destination(destination, terrain_alt);
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
@@ -741,7 +741,7 @@ void ModeAuto::takeoff_run()
     auto_takeoff_run();
     if (wp_nav->reached_wp_destination()) {
         const Vector3f target = wp_nav->get_wp_destination();
-        wp_start(target);
+        wp_start(target, wp_nav->origin_and_destination_are_terrain_alt());
     }
 }
 


### PR DESCRIPTION
This fixes a bug when a takeoff command is specified using a terrain altitude.

To recreate the original problem by doing this:

- create a mission with a simple takeoff command and altitude type of Terrain (aka AGL)
![mission-with-takeoff2](https://user-images.githubusercontent.com/1498098/61017763-54eeba80-a3cf-11e9-88eb-2fcbfb261231.png)
- param set GND_ALT_OFFSET 3 (this creates a difference between the altitude above EKF origin and terrain altitude)
- arm in Loiter, switch to Auto mode and raise throttle
- vehicle will climb correctly to the specified height above terrain but will then descend 3m

The underlying issue is that when takeoff_run() notices it has reached the target it was using wp_start to set WPNav's target position but this ignored the terrain altitude.  The fix is to enhance wp_start to accept either alt-above-ekf-origin (as it does now) OR alt-above-terrain.

Before and after graphs of the altitude are shown below
![before](https://user-images.githubusercontent.com/1498098/61017726-3be60980-a3cf-11e9-9565-ba379f658bd6.png)
![after](https://user-images.githubusercontent.com/1498098/61017732-3ee0fa00-a3cf-11e9-9153-4d4b61fc22e4.png)

