### PR TITLE
Stop passing SerialManager through to RangeFinder constructors

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -179,7 +179,7 @@ private:
     AP_Baro barometer;
     Compass compass;
     AP_InertialSensor ins;
-    RangeFinder rangefinder{serial_manager};
+    RangeFinder rangefinder;
     AP_Button button;
 
     // flight modes convenience array

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -113,7 +113,7 @@ private:
 
     AP_InertialSensor ins;
 
-    RangeFinder rng{serial_manager};
+    RangeFinder rng;
 
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -277,7 +277,7 @@ private:
     Compass compass;
     AP_InertialSensor ins;
 
-    RangeFinder rangefinder{serial_manager};
+    RangeFinder rangefinder;
     struct {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -545,7 +545,7 @@ private:
     AP_ADSB adsb;
 
     // avoidance of adsb enabled vehicles (normally manned vehicles)
-    AP_Avoidance_Copter avoidance_adsb{ahrs, adsb};
+    AP_Avoidance_Copter avoidance_adsb{adsb};
 #endif
 
     // last valid RC input time

--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -169,7 +169,7 @@ bool AP_Avoidance_Copter::handle_avoidance_vertical(const AP_Avoidance::Obstacle
     // decide on whether we should climb or descend
     bool should_climb = false;
     Location my_loc;
-    if (_ahrs.get_position(my_loc)) {
+    if (AP::ahrs().get_position(my_loc)) {
         should_climb = my_loc.alt > obstacle->_location.alt;
     }
 

--- a/ArduCopter/avoidance_adsb.h
+++ b/ArduCopter/avoidance_adsb.h
@@ -8,10 +8,8 @@
 // functionality - for example, not doing anything while landed.
 class AP_Avoidance_Copter : public AP_Avoidance {
 public:
-    AP_Avoidance_Copter(AP_AHRS &ahrs, class AP_ADSB &adsb)
-        : AP_Avoidance(ahrs, adsb)
-    {
-    }
+
+    using AP_Avoidance::AP_Avoidance;
 
     /* Do not allow copies */
     AP_Avoidance_Copter(const AP_Avoidance_Copter &other) = delete;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -673,7 +673,7 @@ private:
     AP_ADSB adsb;
 
     // avoidance of adsb enabled vehicles (normally manned vheicles)
-    AP_Avoidance_Plane avoidance_adsb{ahrs, adsb};
+    AP_Avoidance_Plane avoidance_adsb{adsb};
 
     // Outback Challenge Failsafe Support
 #if ADVANCED_FAILSAFE == ENABLED

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -222,7 +222,7 @@ private:
 
     AP_InertialSensor ins;
 
-    RangeFinder rangefinder{serial_manager};
+    RangeFinder rangefinder;
 
     AP_Vehicle::FixedWing::Rangefinder_State rangefinder_state;
 

--- a/ArduPlane/avoidance_adsb.h
+++ b/ArduPlane/avoidance_adsb.h
@@ -8,10 +8,8 @@
 // functionality - for example, not doing anything while landed.
 class AP_Avoidance_Plane : public AP_Avoidance {
 public:
-    AP_Avoidance_Plane(AP_AHRS &ahrs, class AP_ADSB &adsb)
-        : AP_Avoidance(ahrs, adsb)
-    {
-    }
+
+    using AP_Avoidance::AP_Avoidance;
 
     /* Do not allow copies */
     AP_Avoidance_Plane(const AP_Avoidance_Plane &other) = delete;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -178,7 +178,7 @@ private:
     Compass compass;
     AP_InertialSensor ins;
 
-    RangeFinder rangefinder{serial_manager};
+    RangeFinder rangefinder;
     struct {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -60,7 +60,7 @@ public:
     AP_GPS gps;
     Compass compass;
     AP_SerialManager serial_manager;
-    RangeFinder rng{serial_manager};
+    RangeFinder rng;
     NavEKF2 EKF2{&ahrs, rng};
     NavEKF3 EKF3{&ahrs, rng};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3};

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -30,6 +30,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 
 #define VEHICLE_TIMEOUT_MS              5000   // if no updates in this time, drop it from the list

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -25,7 +25,6 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/Location.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AP_AHRS/AP_AHRS.h>
 
 #include <AP_Buffer/AP_Buffer.h>
 

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -30,7 +30,7 @@ static AP_Logger logger{logger_bitmask};
 
 class DummyVehicle {
 public:
-    RangeFinder sonar{serial_manager};
+    RangeFinder sonar;
     NavEKF2 EKF2{&ahrs, sonar};
     NavEKF3 EKF3{&ahrs, sonar};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3,

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -3,6 +3,7 @@
 extern const AP_HAL::HAL& hal;
 
 #include <limits>
+#include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 
 #define AVOIDANCE_DEBUGGING 0
@@ -125,8 +126,7 @@ const AP_Param::GroupInfo AP_Avoidance::var_info[] = {
     AP_GROUPEND
 };
 
-AP_Avoidance::AP_Avoidance(AP_AHRS &ahrs, AP_ADSB &adsb) :
-    _ahrs(ahrs),
+AP_Avoidance::AP_Avoidance(AP_ADSB &adsb) :
     _adsb(adsb)
 {
     AP_Param::setup_object_defaults(this, var_info);
@@ -436,6 +436,8 @@ bool AP_Avoidance::obstacle_is_more_serious_threat(const AP_Avoidance::Obstacle 
 
 void AP_Avoidance::check_for_threats()
 {
+    const AP_AHRS &_ahrs = AP::ahrs();
+
     Location my_loc;
     if (!_ahrs.get_position(my_loc)) {
         // if we don't know our own location we can't determine any threat level
@@ -522,7 +524,7 @@ void AP_Avoidance::handle_avoidance_local(AP_Avoidance::Obstacle *threat)
             action = (MAV_COLLISION_ACTION)_fail_action.get();
             Location my_loc;
             if (action != MAV_COLLISION_ACTION_NONE && _fail_altitude_minimum > 0 &&
-             _ahrs.get_position(my_loc) && ((my_loc.alt*0.01f) < _fail_altitude_minimum)) {
+                AP::ahrs().get_position(my_loc) && ((my_loc.alt*0.01f) < _fail_altitude_minimum)) {
                 // disable avoidance when close to ground, report only
                 action = MAV_COLLISION_ACTION_REPORT;
 			}
@@ -597,7 +599,7 @@ bool AP_Avoidance::get_vector_perpendicular(const AP_Avoidance::Obstacle *obstac
     }
 
     Location my_abs_pos;
-    if (!_ahrs.get_position(my_abs_pos)) {
+    if (!AP::ahrs().get_position(my_abs_pos)) {
         // we should not get to here!  If we don't know our position
         // we can't know if there are any threats, for starters!
         return false;

--- a/libraries/AP_Avoidance/AP_Avoidance.h
+++ b/libraries/AP_Avoidance/AP_Avoidance.h
@@ -25,7 +25,6 @@
   based on AP_ADSB,  Tom Pittenger, November 2015
 */
 
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_ADSB/AP_ADSB.h>
 
 // F_RCVRY possible parameter values
@@ -40,6 +39,10 @@
 
 class AP_Avoidance {
 public:
+
+    // constructor
+    AP_Avoidance(class AP_ADSB &adsb);
+
     // obstacle class to hold latest information for a known obstacles
     class Obstacle {
     public:
@@ -92,8 +95,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:
-    // constructor
-    AP_Avoidance(AP_AHRS &ahrs, class AP_ADSB &adsb);
 
     // top level avoidance handler.  This calls the vehicle specific handle_avoidance with requested action
     void handle_avoidance_local(AP_Avoidance::Obstacle *threat);
@@ -132,9 +133,6 @@ protected:
     // Note: v1 is NED
     static Vector3f perpendicular_xyz(const Location &p1, const Vector3f &v1, const Location &p2);
     static Vector2f perpendicular_xy(const Location &p1, const Vector3f &v1, const Location &p2);
-
-    // reference to AHRS, so we can ask for our position, heading and speed
-    const AP_AHRS &_ahrs;
 
 private:
 

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -26,7 +26,7 @@ public:
     Compass compass;
     AP_InertialSensor ins;
     AP_SerialManager serial_manager;
-    RangeFinder sonar{serial_manager};
+    RangeFinder sonar;
     AP_AHRS_NavEKF ahrs{EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
     NavEKF2 EKF2{&ahrs, sonar};
     NavEKF3 EKF3{&ahrs, sonar};

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
@@ -53,10 +53,10 @@
 */
 AP_RangeFinder_BLPing::AP_RangeFinder_BLPing(RangeFinder::RangeFinder_State &_state,
                                              AP_RangeFinder_Params &_params,
-                                             AP_SerialManager &serial_manager,
                                              uint8_t serial_instance) :
     AP_RangeFinder_Backend(_state, _params)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance));
@@ -64,9 +64,9 @@ AP_RangeFinder_BLPing::AP_RangeFinder_BLPing(RangeFinder::RangeFinder_State &_st
 }
 
 // detect if a serial port has been setup to accept rangefinder input
-bool AP_RangeFinder_BLPing::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+bool AP_RangeFinder_BLPing::detect(uint8_t serial_instance)
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.h
@@ -11,11 +11,10 @@ public:
     // constructor
     AP_RangeFinder_BLPing(RangeFinder::RangeFinder_State &_state,
                           AP_RangeFinder_Params &_params,
-                          AP_SerialManager &serial_manager,
                           uint8_t serial_instance);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     // update state
     void update(void) override;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
@@ -50,12 +50,12 @@ extern const AP_HAL::HAL& hal;
 */
 AP_RangeFinder_Benewake::AP_RangeFinder_Benewake(RangeFinder::RangeFinder_State &_state,
                                                              AP_RangeFinder_Params &_params,
-                                                             AP_SerialManager &serial_manager,
                                                              uint8_t serial_instance,
                                                              benewake_model_type model) :
     AP_RangeFinder_Backend(_state, _params),
     model_type(model)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance));
@@ -67,9 +67,9 @@ AP_RangeFinder_Benewake::AP_RangeFinder_Benewake(RangeFinder::RangeFinder_State 
    trying to take a reading on Serial. If we get a result the sensor is
    there.
 */
-bool AP_RangeFinder_Benewake::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+bool AP_RangeFinder_Benewake::detect(uint8_t serial_instance)
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 // distance returned in reading_cm, signal_ok is set to true if sensor reports a strong signal

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
@@ -16,12 +16,11 @@ public:
     // constructor
     AP_RangeFinder_Benewake(RangeFinder::RangeFinder_State &_state,
                             AP_RangeFinder_Params &_params,
-                            AP_SerialManager &serial_manager,
                             uint8_t serial_instance,
                             benewake_model_type model);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     // update state
     void update(void) override;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -27,10 +27,10 @@ extern const AP_HAL::HAL& hal;
 */
 AP_RangeFinder_LeddarOne::AP_RangeFinder_LeddarOne(RangeFinder::RangeFinder_State &_state,
                                                    AP_RangeFinder_Params &_params,
-                                                   AP_SerialManager &serial_manager,
                                                    uint8_t serial_instance) :
     AP_RangeFinder_Backend(_state, _params)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance));
@@ -42,9 +42,9 @@ AP_RangeFinder_LeddarOne::AP_RangeFinder_LeddarOne(RangeFinder::RangeFinder_Stat
    trying to take a reading on Serial. If we get a result the sensor is
    there.
 */
-bool AP_RangeFinder_LeddarOne::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+bool AP_RangeFinder_LeddarOne::detect(uint8_t serial_instance)
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 // read - return last value measured by sensor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -44,11 +44,10 @@ public:
     // constructor
     AP_RangeFinder_LeddarOne(RangeFinder::RangeFinder_State &_state,
                              AP_RangeFinder_Params &_params,
-                             AP_SerialManager &serial_manager,
                              uint8_t serial_instance);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     // update state
     void update(void) override;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -27,10 +27,10 @@ extern const AP_HAL::HAL& hal;
 */
 AP_RangeFinder_LightWareSerial::AP_RangeFinder_LightWareSerial(RangeFinder::RangeFinder_State &_state,
                                                                AP_RangeFinder_Params &_params,
-                                                               AP_SerialManager &serial_manager,
                                                                uint8_t serial_instance) :
     AP_RangeFinder_Backend(_state, _params)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance));
@@ -42,9 +42,9 @@ AP_RangeFinder_LightWareSerial::AP_RangeFinder_LightWareSerial(RangeFinder::Rang
    trying to take a reading on Serial. If we get a result the sensor is
    there.
 */
-bool AP_RangeFinder_LightWareSerial::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+bool AP_RangeFinder_LightWareSerial::detect(uint8_t serial_instance)
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 // read - return last value measured by sensor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -10,11 +10,10 @@ public:
     // constructor
     AP_RangeFinder_LightWareSerial(RangeFinder::RangeFinder_State &_state,
                                    AP_RangeFinder_Params &_params,
-                                   AP_SerialManager &serial_manager,
                                    uint8_t serial_instance);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     // update state
     void update(void) override;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
@@ -31,10 +31,10 @@ extern const AP_HAL::HAL& hal;
 */
 AP_RangeFinder_MaxsonarSerialLV::AP_RangeFinder_MaxsonarSerialLV(RangeFinder::RangeFinder_State &_state,
                                                                  AP_RangeFinder_Params &_params,
-                                                                 AP_SerialManager &serial_manager,
                                                                  uint8_t serial_instance) :
     AP_RangeFinder_Backend(_state, _params)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance));
@@ -46,9 +46,9 @@ AP_RangeFinder_MaxsonarSerialLV::AP_RangeFinder_MaxsonarSerialLV(RangeFinder::Ra
    trying to take a reading on Serial. If we get a result the sensor is
    there.
 */
-bool AP_RangeFinder_MaxsonarSerialLV::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+bool AP_RangeFinder_MaxsonarSerialLV::detect(uint8_t serial_instance)
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 // read - return last value measured by sensor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
@@ -10,11 +10,10 @@ public:
     // constructor
     AP_RangeFinder_MaxsonarSerialLV(RangeFinder::RangeFinder_State &_state,
                                    AP_RangeFinder_Params &_params,
-                                   AP_SerialManager &serial_manager,
                                    uint8_t serial_instance);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     // update state
     void update(void) override;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
@@ -26,11 +26,11 @@ extern const AP_HAL::HAL& hal;
 // already know that we should setup the rangefinder
 AP_RangeFinder_NMEA::AP_RangeFinder_NMEA(RangeFinder::RangeFinder_State &_state,
                                          AP_RangeFinder_Params &_params,
-                                         AP_SerialManager &serial_manager,
                                          uint8_t serial_instance) :
     AP_RangeFinder_Backend(_state, _params),
     _distance_m(-1.0f)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance));
@@ -38,9 +38,9 @@ AP_RangeFinder_NMEA::AP_RangeFinder_NMEA(RangeFinder::RangeFinder_State &_state,
 }
 
 // detect if a NMEA rangefinder by looking to see if the user has configured it
-bool AP_RangeFinder_NMEA::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+bool AP_RangeFinder_NMEA::detect(uint8_t serial_instance)
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 // update the state of the sensor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
@@ -25,11 +25,10 @@ public:
     // constructor
     AP_RangeFinder_NMEA(RangeFinder::RangeFinder_State &_state,
                         AP_RangeFinder_Params &_params,
-                        AP_SerialManager &serial_manager,
                         uint8_t serial_instance);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     // update state
     void update(void) override;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.cpp
@@ -68,11 +68,11 @@ const AP_Param::GroupInfo AP_RangeFinder_Wasp::var_info[] = {
 
 AP_RangeFinder_Wasp::AP_RangeFinder_Wasp(RangeFinder::RangeFinder_State &_state,
                                          AP_RangeFinder_Params &_params,
-                                         AP_SerialManager &serial_manager,
                                          uint8_t serial_instance) :
     AP_RangeFinder_Backend(_state, _params) {
     AP_Param::setup_object_defaults(this, var_info);
 
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(115200);
@@ -85,8 +85,8 @@ AP_RangeFinder_Wasp::AP_RangeFinder_Wasp(RangeFinder::RangeFinder_State &_state,
 }
 
 // detection is considered as locating a serial port
-bool AP_RangeFinder_Wasp::detect(AP_SerialManager &serial_manager, uint8_t serial_instance) {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+bool AP_RangeFinder_Wasp::detect(uint8_t serial_instance) {
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 // read - return last value measured by sensor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.h
@@ -11,10 +11,9 @@ class AP_RangeFinder_Wasp : public AP_RangeFinder_Backend {
 public:
     AP_RangeFinder_Wasp(RangeFinder::RangeFinder_State &_state,
                         AP_RangeFinder_Params &_params,
-                        AP_SerialManager &serial_manager,
                         uint8_t serial_instance);
 
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     void update(void) override;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
@@ -34,11 +34,10 @@ extern const AP_HAL::HAL& hal;
 */
 AP_RangeFinder_uLanding::AP_RangeFinder_uLanding(RangeFinder::RangeFinder_State &_state,
                                                  AP_RangeFinder_Params &_params,
-                                                 AP_SerialManager &serial_manager,
                                                  uint8_t serial_instance) :
     AP_RangeFinder_Backend(_state, _params)
 {
-    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
+    uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
         uart->begin(ULANDING_BAUD, ULANDING_BUFSIZE_RX, ULANDING_BUFSIZE_TX);
     }
@@ -49,9 +48,9 @@ AP_RangeFinder_uLanding::AP_RangeFinder_uLanding(RangeFinder::RangeFinder_State 
    trying to take a reading on Serial. If we get a result the sensor is
    there.
 */
-bool AP_RangeFinder_uLanding::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+bool AP_RangeFinder_uLanding::detect(uint8_t serial_instance)
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
@@ -10,11 +10,10 @@ public:
     // constructor
 	AP_RangeFinder_uLanding(RangeFinder::RangeFinder_State &_state,
                             AP_RangeFinder_Params &_params,
-                            AP_SerialManager &serial_manager,
                             uint8_t serial_instance);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+    static bool detect(uint8_t serial_instance);
 
     // update state
     void update(void) override;

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -39,10 +39,11 @@
 #include "AP_RangeFinder_PWM.h"
 #include "AP_RangeFinder_BLPing.h"
 #include "AP_RangeFinder_UAVCAN.h"
-#include <AP_BoardConfig/AP_BoardConfig.h>
-#include <AP_Vehicle/AP_Vehicle_Type.h>
 
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -152,8 +153,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
 
 const AP_Param::GroupInfo *RangeFinder::backend_var_info[RANGEFINDER_MAX_INSTANCES];
 
-RangeFinder::RangeFinder(AP_SerialManager &_serial_manager) :
-    serial_manager(_serial_manager)
+RangeFinder::RangeFinder()
 {
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -440,18 +440,18 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         break;
 #endif
     case RangeFinder_TYPE_LWSER:
-        if (AP_RangeFinder_LightWareSerial::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_LightWareSerial(state[instance], params[instance], serial_manager, serial_instance++);
+        if (AP_RangeFinder_LightWareSerial::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_LightWareSerial(state[instance], params[instance], serial_instance++);
         }
         break;
     case RangeFinder_TYPE_LEDDARONE:
-        if (AP_RangeFinder_LeddarOne::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_LeddarOne(state[instance], params[instance], serial_manager, serial_instance++);
+        if (AP_RangeFinder_LeddarOne::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_LeddarOne(state[instance], params[instance], serial_instance++);
         }
         break;
     case RangeFinder_TYPE_ULANDING:
-        if (AP_RangeFinder_uLanding::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_uLanding(state[instance], params[instance], serial_manager, serial_instance++);
+        if (AP_RangeFinder_uLanding::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_uLanding(state[instance], params[instance], serial_instance++);
         }
         break;
 #if (CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP || \
@@ -468,8 +468,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         }
         break;
     case RangeFinder_TYPE_MBSER:
-        if (AP_RangeFinder_MaxsonarSerialLV::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_MaxsonarSerialLV(state[instance], params[instance], serial_manager, serial_instance++);
+        if (AP_RangeFinder_MaxsonarSerialLV::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_MaxsonarSerialLV(state[instance], params[instance], serial_instance++);
         }
         break;
     case RangeFinder_TYPE_ANALOG:
@@ -479,23 +479,23 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         }
         break;
     case RangeFinder_TYPE_NMEA:
-        if (AP_RangeFinder_NMEA::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_NMEA(state[instance], params[instance], serial_manager, serial_instance++);
+        if (AP_RangeFinder_NMEA::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_NMEA(state[instance], params[instance], serial_instance++);
         }
         break;
     case RangeFinder_TYPE_WASP:
-        if (AP_RangeFinder_Wasp::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Wasp(state[instance], params[instance], serial_manager, serial_instance++);
+        if (AP_RangeFinder_Wasp::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_Wasp(state[instance], params[instance], serial_instance++);
         }
         break;
     case RangeFinder_TYPE_BenewakeTF02:
-        if (AP_RangeFinder_Benewake::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Benewake(state[instance], params[instance], serial_manager, serial_instance++, AP_RangeFinder_Benewake::BENEWAKE_TF02);
+        if (AP_RangeFinder_Benewake::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_Benewake(state[instance], params[instance], serial_instance++, AP_RangeFinder_Benewake::BENEWAKE_TF02);
         }
         break;
     case RangeFinder_TYPE_BenewakeTFmini:
-        if (AP_RangeFinder_Benewake::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Benewake(state[instance], params[instance], serial_manager, serial_instance++, AP_RangeFinder_Benewake::BENEWAKE_TFmini);
+        if (AP_RangeFinder_Benewake::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_Benewake(state[instance], params[instance], serial_instance++, AP_RangeFinder_Benewake::BENEWAKE_TFmini);
         }
         break;
     case RangeFinder_TYPE_PWM:
@@ -504,8 +504,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         }
         break;
     case RangeFinder_TYPE_BLPing:
-        if (AP_RangeFinder_BLPing::detect(serial_manager, serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_BLPing(state[instance], params[instance], serial_manager, serial_instance++);
+        if (AP_RangeFinder_BLPing::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_BLPing(state[instance], params[instance], serial_instance++);
         }
         break;
     default:

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -17,7 +17,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_SerialManager/AP_SerialManager.h>
+#include <GCS_MAVLink/GCS.h>
 #include "AP_RangeFinder_Params.h"
 
 // Maximum number of range finder instances available on this platform
@@ -38,7 +38,7 @@ class RangeFinder
     //UAVCAN drivers are initialised in the Backend, hence list of drivers is needed there.
     friend class AP_RangeFinder_UAVCAN;
 public:
-    RangeFinder(AP_SerialManager &_serial_manager);
+    RangeFinder();
 
     /* Do not allow copies */
     RangeFinder(const RangeFinder &other) = delete;
@@ -166,7 +166,6 @@ private:
     AP_RangeFinder_Backend *drivers[RANGEFINDER_MAX_INSTANCES];
     uint8_t num_instances;
     float estimated_terrain_height;
-    AP_SerialManager &serial_manager;
     Vector3f pos_offset_zero;   // allows returning position offsets of zero for invalid requests
 
     void convert_params(void);

--- a/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
@@ -11,7 +11,7 @@ void loop();
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 static AP_SerialManager serial_manager;
-static RangeFinder sonar{serial_manager};
+static RangeFinder sonar;
 
 void setup()
 {

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
@@ -20,7 +20,7 @@ static AP_SerialManager serial_manager;
 
 class DummyVehicle {
 public:
-    RangeFinder rangefinder{serial_manager};
+    RangeFinder rangefinder;
     NavEKF2 EKF2{&ahrs, rangefinder};
     NavEKF3 EKF3{&ahrs, rangefinder};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -129,7 +129,7 @@ public:
 
     // note that all of these methods are named after the packet they
     // are handling; the "mission" part just comes as part of that.
-    void handle_mission_request_list(const GCS_MAVLINK &link,
+    void handle_mission_request_list(const class GCS_MAVLINK &link,
                                      const mavlink_mission_request_list_t &packet,
                                      const mavlink_message_t &msg);
     void handle_mission_request_int(const GCS_MAVLINK &link,
@@ -832,7 +832,7 @@ private:
 
     uint8_t send_parameter_async_replies();
 
-    void send_distance_sensor(const AP_RangeFinder_Backend *sensor, const uint8_t instance) const;
+    void send_distance_sensor(const class AP_RangeFinder_Backend *sensor, const uint8_t instance) const;
 
     virtual bool handle_guided_request(AP_Mission::Mission_Command &cmd) = 0;
     virtual void handle_change_alt_request(AP_Mission::Mission_Command &cmd) = 0;


### PR DESCRIPTION
```
master
  bin/arduplane  1156500  1192  195604  1353296
pr/avoidance-ahrs-constructor
  bin/arduplane  1156468  1192  195604  1353264
pr/rangefinder-constructor
  bin/arduplane  1156408  1192  195600  1353200
```
