### PR TITLE
Autotest correction

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2486,6 +2486,7 @@ class AutoTest(ABC):
                 self.progress("Armable mode : %s" % mode)
                 self.change_mode(mode)
                 self.arm_vehicle()
+                self.wait_heartbeat()
                 if not self.disarm_vehicle():
                     raise NotAchievedException("Failed to DISARM")
                 self.progress("PASS arm mode : %s" % mode)

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -335,6 +335,7 @@ def start_MAVProxy_SITL(atype, aircraft=None, setup=False, master='tcp:127.0.0.1
         aircraft = 'test.%s' % atype
     cmd += ' --aircraft=%s' % aircraft
     cmd += ' ' + ' '.join(options)
+    cmd += ' --default-modules log,wp,rally,fence,param,arm,mode,rc,cmdlong,output'
     ret = pexpect.spawn(cmd, logfile=logfile, encoding=ENCODING, timeout=60)
     ret.delaybeforesend = 0
     pexpect_autoclose(ret)


### PR DESCRIPTION
Reduce mavproxy consumtion by removing unnecessary modules for tests.
add a wait before disarming to try to catch the instant arm disarm bug on test ...