### PR TITLE
AP_OADijkstra: re-do visgraphs if polyfence is changed

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -47,14 +47,14 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     // check for fence updates
     if (check_polygon_fence_updated()) {
         _polyfence_with_margin_ok = false;
+        _polyfence_visgraph_ok = false;
+        _shortest_path_ok = false;
     }
 
     // create inner polygon fence
     if (!_polyfence_with_margin_ok) {
         _polyfence_with_margin_ok = create_polygon_fence_with_margin(_polyfence_margin * 100.0f);
         if (!_polyfence_with_margin_ok) {
-            _polyfence_visgraph_ok = false;
-            _shortest_path_ok = false;
             return DIJKSTRA_STATE_ERROR;
         }
     }


### PR DESCRIPTION
This resolves a small (unlikely) bug in the OA Dijkstra's algorithm.

The issue is that the visgraphs and shortest-path calculations might not have been re-done if the polygon fence was changed.

I have actually never seen the bug happen probably because when the fence is changed it takes more than 0.1seconds to be uploaded and then the building of the inner fence fails which was then triggering the recalculation of the visgraphs and shortest-path.