### PR TITLE
AP_Arming: reduce length of internal errors errorstring prefix

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -664,7 +664,7 @@ bool AP_Arming::system_checks(bool report)
         }
     }
     if (AP::internalerror().errors() != 0) {
-        check_failed(ARMING_CHECK_NONE, report, "Internal errors detected (0x%x)", AP::internalerror().errors());
+        check_failed(ARMING_CHECK_NONE, report, "Internal errors (0x%x)", AP::internalerror().errors());
         return false;
     }
 


### PR DESCRIPTION
MissionPlanner's HUD requires a short string for this to be useful