### PR TITLE
Harmonic notch filter implementation

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1237,6 +1237,16 @@ void Copter::convert_pid_parameters(void)
         AP_Param::convert_old_parameters(&ff_and_filt_conversion_info[i], 1.0f);
     }
 
+    // notch filter parameter conversions (changed position and type) for Copter-3.7
+    const AP_Param::ConversionInfo notchfilt_conversion_info[] = {
+        { Parameters::k_param_ins, 165, AP_PARAM_INT16, "INS_NOTCH_FREQ" },
+        { Parameters::k_param_ins, 229, AP_PARAM_INT16, "INS_NOTCH_BW" },
+    };
+    uint8_t notchfilt_table_size = ARRAY_SIZE(notchfilt_conversion_info);
+    for (uint8_t i=0; i<notchfilt_table_size; i++) {
+        AP_Param::convert_old_parameters(&notchfilt_conversion_info[i], 1.0f);
+    }
+
     const uint8_t old_rc_keys[14] = { Parameters::k_param_rc_1_old,  Parameters::k_param_rc_2_old,
                                       Parameters::k_param_rc_3_old,  Parameters::k_param_rc_4_old,
                                       Parameters::k_param_rc_5_old,  Parameters::k_param_rc_6_old,

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -667,6 +667,9 @@ AP_InertialSensor::init(uint16_t sample_rate)
 
     for (uint8_t i=0; i<get_gyro_count(); i++) {
         _gyro_harmonic_notch_filter[i].allocate_filters(_harmonic_notch_filter.harmonics());
+        // initialise default settings, these will be subsequently changed in AP_InertialSensor_Backend::update_gyro()
+        _gyro_harmonic_notch_filter[i].init(_gyro_raw_sample_rates[i], _calculated_harmonic_notch_freq_hz,
+             _harmonic_notch_filter.bandwidth_hz(), _harmonic_notch_filter.attenuation_dB());
     }
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -453,6 +453,10 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Bitmask: 0:FirstIMU,1:SecondIMU,2:ThirdIMU
     AP_GROUPINFO("ENABLE_MASK",  40, AP_InertialSensor, _enable_mask, 0x7F),
 
+    // @Group: HNTCH_
+    // @Path: ../Filter/HarmonicNotchFilter.cpp
+    AP_SUBGROUPINFO(_harmonic_notch_filter, "HNTCH_",  41, AP_InertialSensor, HarmonicNotchFilterParams),
+
     /*
       NOTE: parameter indexes have gaps above. When adding new
       parameters check for conflicts carefully
@@ -471,6 +475,7 @@ AP_InertialSensor::AP_InertialSensor() :
     }
     _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
+
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _gyro_cal_ok[i] = true;
         _accel_max_abs_offsets[i] = 3.5f;
@@ -654,6 +659,15 @@ AP_InertialSensor::init(uint16_t sample_rate)
 
     // initialise IMU batch logging
     batchsampler.init();
+
+    // the center frequency of the harmonic notch is always taken from the calculated value so that it can be updated
+    // dynamically, the calculated value is always some multiple of the configured center frequency, so start with the
+    // configured value
+    _calculated_harmonic_notch_freq_hz = _harmonic_notch_filter.center_freq_hz();
+
+    for (uint8_t i=0; i<get_gyro_count(); i++) {
+        _gyro_harmonic_notch_filter[i].create(_harmonic_notch_filter.harmonics());
+    }
 }
 
 bool AP_InertialSensor::_add_backend(AP_InertialSensor_Backend *backend)
@@ -1748,6 +1762,14 @@ void AP_InertialSensor::acal_update()
 
     if (hal.util->get_soft_armed() && _acal->get_status() != ACCEL_CAL_NOT_STARTED) {
         _acal->cancel();
+    }
+}
+
+// Update the harmonic notch frequency
+void AP_InertialSensor::update_harmonic_notch_freq_hz(float scaled_freq) {
+    // When disarmed, throttle is zero
+    if (is_positive(scaled_freq)) {
+        _calculated_harmonic_notch_freq_hz = scaled_freq;
     }
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -666,7 +666,7 @@ AP_InertialSensor::init(uint16_t sample_rate)
     _calculated_harmonic_notch_freq_hz = _harmonic_notch_filter.center_freq_hz();
 
     for (uint8_t i=0; i<get_gyro_count(); i++) {
-        _gyro_harmonic_notch_filter[i].create(_harmonic_notch_filter.harmonics());
+        _gyro_harmonic_notch_filter[i].allocate_filters(_harmonic_notch_filter.harmonics());
     }
 }
 
@@ -1767,7 +1767,7 @@ void AP_InertialSensor::acal_update()
 
 // Update the harmonic notch frequency
 void AP_InertialSensor::update_harmonic_notch_freq_hz(float scaled_freq) {
-    // When disarmed, throttle is zero
+    // protect against zero as the scaled frequency
     if (is_positive(scaled_freq)) {
         _calculated_harmonic_notch_freq_hz = scaled_freq;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -25,6 +25,7 @@
 #include <Filter/LowPassFilter2p.h>
 #include <Filter/LowPassFilter.h>
 #include <Filter/NotchFilter.h>
+#include <Filter/HarmonicNotchFilter.h>
 
 class AP_InertialSensor_Backend;
 class AuxiliaryBus;
@@ -202,6 +203,9 @@ public:
     uint8_t get_primary_accel(void) const { return _primary_accel; }
     uint8_t get_primary_gyro(void) const { return _primary_gyro; }
 
+    // Update the harmonic notch frequency
+    void update_harmonic_notch_freq_hz(float scaled_freq);
+
     // enable HIL mode
     void set_hil_mode(void) { _hil_mode = true; }
 
@@ -210,6 +214,15 @@ public:
 
     // get the accel filter rate in Hz
     uint16_t get_accel_filter_hz(void) const { return _accel_filter_cutoff; }
+
+    // harmonic notch current center frequency
+    float get_gyro_dynamic_notch_center_freq_hz(void) const { return _calculated_harmonic_notch_freq_hz; }
+
+    // harmonic notch reference center frequency
+    float get_gyro_harmonic_notch_center_freq_hz(void) const { return _harmonic_notch_filter.center_freq_hz(); }
+
+    // harmonic notch reference scale factor
+    float get_gyro_harmonic_notch_reference(void) const { return _harmonic_notch_filter.reference(); }
 
     // indicate which bit in LOG_BITMASK indicates raw logging enabled
     void set_log_raw_bit(uint32_t log_raw_bit) { _log_raw_bit = log_raw_bit; }
@@ -410,6 +423,12 @@ private:
     // optional notch filter on gyro
     NotchFilterParams _notch_filter;
     NotchFilterVector3f _gyro_notch_filter[INS_MAX_INSTANCES];
+
+    // optional harmonic notch filter on gyro
+    HarmonicNotchFilterParams _harmonic_notch_filter;
+    HarmonicNotchFilterVector3f _gyro_harmonic_notch_filter[INS_MAX_INSTANCES];
+    // the current center frequency for the notch
+    float _calculated_harmonic_notch_freq_hz;
 
     // Most recent gyro reading
     Vector3f _gyro[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -226,6 +226,12 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
 
         // apply the low pass filter
         _imu._gyro_filtered[instance] = _imu._gyro_filter[instance].apply(gyro);
+
+        // apply the harmonic notch filter
+        if (_gyro_harmonic_notch_enabled()) {
+            _imu._gyro_filtered[instance] = _imu._gyro_harmonic_notch_filter[instance].apply(_imu._gyro_filtered[instance]);
+        }
+
         // apply the notch filter
         if (_gyro_notch_enabled()) {
             _imu._gyro_filtered[instance] = _imu._gyro_notch_filter[instance].apply(_imu._gyro_filtered[instance]);
@@ -233,6 +239,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
         if (_imu._gyro_filtered[instance].is_nan() || _imu._gyro_filtered[instance].is_inf()) {
             _imu._gyro_filter[instance].reset();
             _imu._gyro_notch_filter[instance].reset();
+            _imu._gyro_harmonic_notch_filter[instance].reset();
         }
         _imu._new_gyro_data[instance] = true;
     }
@@ -493,18 +500,31 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
     }
 
     // possibly update filter frequency
-    if (_last_gyro_filter_hz[instance] != _gyro_filter_cutoff()) {
+    if (_last_gyro_filter_hz != _gyro_filter_cutoff()) {
         _imu._gyro_filter[instance].set_cutoff_frequency(_gyro_raw_sample_rate(instance), _gyro_filter_cutoff());
-        _last_gyro_filter_hz[instance] = _gyro_filter_cutoff();
+        _last_gyro_filter_hz = _gyro_filter_cutoff();
+    }
+
+    // possily update the harmonic notch filter parameters
+    if (!is_equal(_last_harmonic_notch_bandwidth_hz, _gyro_harmonic_notch_bandwidth_hz()) ||
+        !is_equal(_last_harmonic_notch_attenuation_dB, _gyro_harmonic_notch_attenuation_dB())) {
+        _imu._gyro_harmonic_notch_filter[instance].init(_gyro_raw_sample_rate(instance), _gyro_harmonic_notch_center_freq_hz(), _gyro_harmonic_notch_bandwidth_hz(), _gyro_harmonic_notch_attenuation_dB());
+        _last_harmonic_notch_center_freq_hz = _gyro_harmonic_notch_center_freq_hz();
+        _last_harmonic_notch_bandwidth_hz = _gyro_harmonic_notch_bandwidth_hz();
+        _last_harmonic_notch_attenuation_dB = _gyro_harmonic_notch_attenuation_dB();
+    }
+    else if (!is_equal(_last_harmonic_notch_center_freq_hz, _gyro_harmonic_notch_center_freq_hz())) {
+        _imu._gyro_harmonic_notch_filter[instance].update(_gyro_harmonic_notch_center_freq_hz());
+        _last_harmonic_notch_center_freq_hz = _gyro_harmonic_notch_center_freq_hz();
     }
     // possily update the notch filter parameters
-    if (_last_notch_center_freq_hz[instance] != _gyro_notch_center_freq_hz() ||
-        _last_notch_bandwidth_hz[instance] != _gyro_notch_bandwidth_hz() ||
-        !is_equal(_last_notch_attenuation_dB[instance], _gyro_notch_attenuation_dB())) {
+    if (!is_equal(_last_notch_center_freq_hz, _gyro_notch_center_freq_hz()) ||
+        !is_equal(_last_notch_bandwidth_hz, _gyro_notch_bandwidth_hz()) ||
+        !is_equal(_last_notch_attenuation_dB, _gyro_notch_attenuation_dB())) {
         _imu._gyro_notch_filter[instance].init(_gyro_raw_sample_rate(instance), _gyro_notch_center_freq_hz(), _gyro_notch_bandwidth_hz(), _gyro_notch_attenuation_dB());
-        _last_notch_center_freq_hz[instance] = _gyro_notch_center_freq_hz();
-        _last_notch_bandwidth_hz[instance] = _gyro_notch_bandwidth_hz();
-        _last_notch_attenuation_dB[instance] = _gyro_notch_attenuation_dB();
+        _last_notch_center_freq_hz = _gyro_notch_center_freq_hz();
+        _last_notch_bandwidth_hz = _gyro_notch_bandwidth_hz();
+        _last_notch_attenuation_dB = _gyro_notch_attenuation_dB();
     }
 }
 
@@ -524,9 +544,9 @@ void AP_InertialSensor_Backend::update_accel(uint8_t instance)
     }
     
     // possibly update filter frequency
-    if (_last_accel_filter_hz[instance] != _accel_filter_cutoff()) {
+    if (_last_accel_filter_hz != _accel_filter_cutoff()) {
         _imu._accel_filter[instance].set_cutoff_frequency(_accel_raw_sample_rate(instance), _accel_filter_cutoff());
-        _last_accel_filter_hz[instance] = _accel_filter_cutoff();
+        _last_accel_filter_hz = _accel_filter_cutoff();
     }
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -242,8 +242,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
             _imu._gyro_filter[instance].reset();
             _imu._gyro_notch_filter[instance].reset();
             _imu._gyro_harmonic_notch_filter[instance].reset();
-        }
-        else {
+        } else {
             _imu._gyro_filtered[instance] = gyro_filtered;
         }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -228,7 +228,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
         _imu._gyro_filtered[instance] = _imu._gyro_filter[instance].apply(gyro);
 
         // apply the harmonic notch filter
-        if (_gyro_harmonic_notch_enabled()) {
+        if (gyro_harmonic_notch_enabled()) {
             _imu._gyro_filtered[instance] = _imu._gyro_harmonic_notch_filter[instance].apply(_imu._gyro_filtered[instance]);
         }
 
@@ -506,16 +506,15 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
     }
 
     // possily update the harmonic notch filter parameters
-    if (!is_equal(_last_harmonic_notch_bandwidth_hz, _gyro_harmonic_notch_bandwidth_hz()) ||
-        !is_equal(_last_harmonic_notch_attenuation_dB, _gyro_harmonic_notch_attenuation_dB())) {
-        _imu._gyro_harmonic_notch_filter[instance].init(_gyro_raw_sample_rate(instance), _gyro_harmonic_notch_center_freq_hz(), _gyro_harmonic_notch_bandwidth_hz(), _gyro_harmonic_notch_attenuation_dB());
-        _last_harmonic_notch_center_freq_hz = _gyro_harmonic_notch_center_freq_hz();
-        _last_harmonic_notch_bandwidth_hz = _gyro_harmonic_notch_bandwidth_hz();
-        _last_harmonic_notch_attenuation_dB = _gyro_harmonic_notch_attenuation_dB();
-    }
-    else if (!is_equal(_last_harmonic_notch_center_freq_hz, _gyro_harmonic_notch_center_freq_hz())) {
-        _imu._gyro_harmonic_notch_filter[instance].update(_gyro_harmonic_notch_center_freq_hz());
-        _last_harmonic_notch_center_freq_hz = _gyro_harmonic_notch_center_freq_hz();
+    if (!is_equal(_last_harmonic_notch_bandwidth_hz, gyro_harmonic_notch_bandwidth_hz()) ||
+        !is_equal(_last_harmonic_notch_attenuation_dB, gyro_harmonic_notch_attenuation_dB())) {
+        _imu._gyro_harmonic_notch_filter[instance].init(_gyro_raw_sample_rate(instance), gyro_harmonic_notch_center_freq_hz(), gyro_harmonic_notch_bandwidth_hz(), gyro_harmonic_notch_attenuation_dB());
+        _last_harmonic_notch_center_freq_hz = gyro_harmonic_notch_center_freq_hz();
+        _last_harmonic_notch_bandwidth_hz = gyro_harmonic_notch_bandwidth_hz();
+        _last_harmonic_notch_attenuation_dB = gyro_harmonic_notch_attenuation_dB();
+    } else if (!is_equal(_last_harmonic_notch_center_freq_hz, gyro_harmonic_notch_center_freq_hz())) {
+        _imu._gyro_harmonic_notch_filter[instance].update(gyro_harmonic_notch_center_freq_hz());
+        _last_harmonic_notch_center_freq_hz = gyro_harmonic_notch_center_freq_hz();
     }
     // possily update the notch filter parameters
     if (!is_equal(_last_notch_center_freq_hz, _gyro_notch_center_freq_hz()) ||

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -244,15 +244,15 @@ protected:
     uint8_t _gyro_notch_enabled(void) const { return _imu._notch_filter.enabled(); }
 
     // return the harmonic notch filter center in Hz for the sample rate
-    float _gyro_harmonic_notch_center_freq_hz() const { return _imu._calculated_harmonic_notch_freq_hz; }
+    float gyro_harmonic_notch_center_freq_hz() const { return _imu._calculated_harmonic_notch_freq_hz; }
 
     // return the harmonic notch filter bandwidth in Hz for the sample rate
-    float _gyro_harmonic_notch_bandwidth_hz(void) const { return _imu._harmonic_notch_filter.bandwidth_hz(); }
+    float gyro_harmonic_notch_bandwidth_hz(void) const { return _imu._harmonic_notch_filter.bandwidth_hz(); }
 
     // return the harmonic notch filter attenuation in dB for the sample rate
-    float _gyro_harmonic_notch_attenuation_dB(void) const { return _imu._harmonic_notch_filter.attenuation_dB(); }
+    float gyro_harmonic_notch_attenuation_dB(void) const { return _imu._harmonic_notch_filter.attenuation_dB(); }
 
-    uint8_t _gyro_harmonic_notch_enabled(void) const { return _imu._harmonic_notch_filter.enabled(); }
+    uint8_t gyro_harmonic_notch_enabled(void) const { return _imu._harmonic_notch_filter.enabled(); }
 
     // common gyro update function for all backends
     void update_gyro(uint8_t instance);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -180,6 +180,9 @@ protected:
     // update the sensor rate for FIFO sensors
     void _update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz) const;
 
+    // return true if the sensors are still converging and sampling rates could change significantly
+    bool sensors_converging() const { return AP_HAL::millis() < 30000; }
+
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -75,7 +75,7 @@ public:
 
     // notify of a fifo reset
     void notify_fifo_reset(void);
-    
+
     /*
       device driver IDs. These are used to fill in the devtype field
       of the device ID, which shows up as INS*ID* parameters to
@@ -179,7 +179,7 @@ protected:
 
     // update the sensor rate for FIFO sensors
     void _update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz) const;
-    
+
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 
@@ -233,15 +233,26 @@ protected:
     uint16_t get_sample_rate_hz(void) const;
 
     // return the notch filter center in Hz for the sample rate
-    uint16_t _gyro_notch_center_freq_hz(void) const { return _imu._notch_filter.center_freq_hz(); }
+    float _gyro_notch_center_freq_hz(void) const { return _imu._notch_filter.center_freq_hz(); }
 
     // return the notch filter bandwidth in Hz for the sample rate
-    uint16_t _gyro_notch_bandwidth_hz(void) const { return _imu._notch_filter.bandwidth_hz(); }
+    float _gyro_notch_bandwidth_hz(void) const { return _imu._notch_filter.bandwidth_hz(); }
 
     // return the notch filter attenuation in dB for the sample rate
     float _gyro_notch_attenuation_dB(void) const { return _imu._notch_filter.attenuation_dB(); }
 
     uint8_t _gyro_notch_enabled(void) const { return _imu._notch_filter.enabled(); }
+
+    // return the harmonic notch filter center in Hz for the sample rate
+    float _gyro_harmonic_notch_center_freq_hz() const { return _imu._calculated_harmonic_notch_freq_hz; }
+
+    // return the harmonic notch filter bandwidth in Hz for the sample rate
+    float _gyro_harmonic_notch_bandwidth_hz(void) const { return _imu._harmonic_notch_filter.bandwidth_hz(); }
+
+    // return the harmonic notch filter attenuation in dB for the sample rate
+    float _gyro_harmonic_notch_attenuation_dB(void) const { return _imu._harmonic_notch_filter.attenuation_dB(); }
+
+    uint8_t _gyro_harmonic_notch_enabled(void) const { return _imu._harmonic_notch_filter.enabled(); }
 
     // common gyro update function for all backends
     void update_gyro(uint8_t instance);
@@ -250,12 +261,17 @@ protected:
     void update_accel(uint8_t instance);
 
     // support for updating filter at runtime
-    uint16_t _last_accel_filter_hz[INS_MAX_INSTANCES];
-    uint16_t _last_gyro_filter_hz[INS_MAX_INSTANCES];
-    uint16_t _last_notch_center_freq_hz[INS_MAX_INSTANCES];
-    uint16_t _last_notch_bandwidth_hz[INS_MAX_INSTANCES];
-    float _last_notch_attenuation_dB[INS_MAX_INSTANCES];
+    uint16_t _last_accel_filter_hz;
+    uint16_t _last_gyro_filter_hz;
+    float _last_notch_center_freq_hz;
+    float _last_notch_bandwidth_hz;
+    float _last_notch_attenuation_dB;
 
+    // support for updating harmonic filter at runtime
+    float _last_harmonic_notch_center_freq_hz;
+    float _last_harmonic_notch_bandwidth_hz;
+    float _last_harmonic_notch_attenuation_dB;
+    
     void set_gyro_orientation(uint8_t instance, enum Rotation rotation) {
         _imu._gyro_orientation[instance] = rotation;
     }

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -1,0 +1,179 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "HarmonicNotchFilter.h"
+
+#define HNF_MAX_FILTERS 3
+#define HNF_MAX_HARMONICS 8
+
+// table of user settable parameters
+const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Enable
+    // @Description: Enable harmonic notch filter
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLE", 1, HarmonicNotchFilterParams, _enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: FREQ
+    // @DisplayName: Base Frequency
+    // @Description: Notch base center frequency in Hz
+    // @Range: 10 400
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("FREQ", 2, HarmonicNotchFilterParams, _center_freq_hz, 80),
+
+    // @Param: BW
+    // @DisplayName: Bandwidth
+    // @Description: Harmonic notch bandwidth in Hz
+    // @Range: 5 100
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("BW", 3, HarmonicNotchFilterParams, _bandwidth_hz, 20),
+
+    // @Param: ATT
+    // @DisplayName: Attenuation
+    // @Description: Harmonic notch attenuation in dB
+    // @Range: 5 30
+    // @Units: dB
+    // @User: Advanced
+    AP_GROUPINFO("ATT", 4, HarmonicNotchFilterParams, _attenuation_dB, 15),
+
+    // @Param: HMNCS
+    // @DisplayName: Harmonics
+    // @Description: Bitmask of harmonic frequencies to apply notches to. This option takes effect on the next reboot. A maximum of 3 harmonics can be used at any one time
+    // @Bitmask: 0:1st harmonic,1:2nd harmonic,2:3rd harmonic,3:4th hamronic,4:5th harmonic,5:6th harmonic,6:7th harmonic,7:8th harmonic
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("HMNCS", 5, HarmonicNotchFilterParams, _harmonics, 3),
+
+    // @Param: REF
+    // @DisplayName: Reference value
+    // @Description: Reference value associated with the specified frequency to facilitate frequency scaling
+    // @User: Advanced
+    // @Range: 0.1 0.9
+    // @RebootRequired: True
+    AP_GROUPINFO("REF", 6, HarmonicNotchFilterParams, _reference, 0.1f),
+
+    AP_GROUPEND
+};
+
+
+/*
+  initialise filter
+ */
+template <class T>
+void HarmonicNotchFilter<T>::init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB)
+{
+    if (_filters == nullptr) {
+        return;
+    }
+
+    _sample_freq_hz = sample_freq_hz;
+
+    // adjust the center frequency to be in the allowable range
+    center_freq_hz = constrain_float(center_freq_hz, bandwidth_hz * 0.52f, sample_freq_hz * 0.48f);
+
+    NotchFilter<T>::calculate_A_and_Q(center_freq_hz, bandwidth_hz, attenuation_dB, _A, _Q);
+
+    for (uint8_t i = 0, filt = 0; i < HNF_MAX_HARMONICS && filt < _num_filters; i++) {
+        if ((1U<<i) & _harmonics) {
+            _filters[filt++].init_with_A_and_Q(sample_freq_hz, center_freq_hz * (i+1), _A, _Q);
+        }
+    }
+    _initialised = true;
+}
+
+/*
+  initialise filter
+ */
+template <class T>
+void HarmonicNotchFilter<T>::create(uint8_t harmonics)
+{
+    for (uint8_t i = 0; i < HNF_MAX_HARMONICS && _num_filters < HNF_MAX_FILTERS; i++) {
+        if ((1U<<i) & harmonics) {
+            _num_filters++;
+        }
+    }
+    if (_num_filters > 0) {
+        _filters = new NotchFilter<T>[_num_filters];
+    }
+    _harmonics = harmonics;
+}
+
+template <class T>
+HarmonicNotchFilter<T>::~HarmonicNotchFilter() {
+    if (_num_filters > 0) {
+        delete[] _filters;
+    }
+}
+
+template <class T>
+void HarmonicNotchFilter<T>::update(float center_freq_hz)
+{
+    if (!_initialised) {
+        return;
+    }
+
+    // adjust the center frequency to be in the allowable range
+    center_freq_hz = constrain_float(center_freq_hz, 1.0f, _sample_freq_hz * 0.48f);
+
+    for (uint8_t i = 0, filt = 0; i < HNF_MAX_HARMONICS && filt < _num_filters; i++) {
+        if ((1U<<i) & _harmonics) {
+            _filters[filt++].init_with_A_and_Q(_sample_freq_hz, center_freq_hz * (i+1), _A, _Q);
+        }
+    }
+}
+
+template <class T>
+T HarmonicNotchFilter<T>::apply(const T &sample)
+{
+    if (!_initialised) {
+        return sample;
+    }
+
+    T output = sample;
+    for (uint8_t i = 0; i < _num_filters; i++) {
+        output = _filters[i].apply(output);
+    }
+    return output;
+}
+
+template <class T>
+void HarmonicNotchFilter<T>::reset()
+{
+    if (!_initialised) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < _num_filters; i++) {
+        _filters[i].reset();
+    }
+}
+
+
+/*
+  a notch filter with enable and filter parameters - constructor
+ */
+HarmonicNotchFilterParams::HarmonicNotchFilterParams(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+/* 
+   instantiate template classes
+ */
+template class HarmonicNotchFilter<Vector3f>;

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "HarmonicNotchFilter.h"
+#include <GCS_MAVLink/GCS.h>
 
 #define HNF_MAX_FILTERS 3
 #define HNF_MAX_HARMONICS 8
@@ -121,6 +122,11 @@ void HarmonicNotchFilter<T>::allocate_filters(uint8_t harmonics)
     }
     if (_num_filters > 0) {
         _filters = new NotchFilter<T>[_num_filters];
+        if (_filters == nullptr) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "Failed to allocate %lu bytes for HarmonicNotchFilter", _num_filters * sizeof(NotchFilter<T>));
+            _num_filters = 0;
+        }
+
     }
     _harmonics = harmonics;
 }

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -51,6 +51,8 @@ private:
     uint8_t _harmonics;
     // number of allocated filters
     uint8_t _num_filters;
+    // number of enabled filters
+    uint8_t _num_enabled_filters;
     bool _initialised;
 };
 

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -16,44 +16,62 @@
 
 #include <AP_Math/AP_Math.h>
 #include <cmath>
-#include <inttypes.h>
 #include <AP_Param/AP_Param.h>
 #include "NotchFilter.h"
 
+/*
+  a filter that manages a set of notch filters targetted at a fundamental center frequency
+  and multiples of that fundamental frequency
+ */
 template <class T>
 class HarmonicNotchFilter {
 public:
-    // set parameters
-    void create(uint8_t harmonics);
-    void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
-    T apply(const T &sample);
-    void reset();
-    void update(float center_freq_hz);
     ~HarmonicNotchFilter();
+    // allocate a bank of notch filters for this harmonic notch filter
+    void allocate_filters(uint8_t harmonics);
+    // initialize the underlying filters using the provided filter parameters
+    void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
+    // update the underlying filters' center frequencies using center_freq_hz as the fundamental
+    void update(float center_freq_hz);
+    // apply a sample to each of the underlying filters in turn
+    T apply(const T &sample);
+    // reset each of the underlying filters
+    void reset();
 
 private:
+    // underlying bank of notch filters
     NotchFilter<T>*  _filters;
+    // sample frequency for each filter
     float _sample_freq_hz;
+    // attenuation for each filter
     float _A;
+    // quality factor of each filter
     float _Q;
+    // a bitmask of the harmonics to use
     uint8_t _harmonics;
+    // number of allocated filters
     uint8_t _num_filters;
     bool _initialised;
 };
 
 /*
-  notch filter enable and filter parameters
+  harmonic notch filter configuration parameters
  */
 class HarmonicNotchFilterParams : public NotchFilterParams {
 public:
     HarmonicNotchFilterParams(void);
+    // set the fundamental center frequency of the harmonic notch
     void set_center_freq_hz(float center_freq) { _center_freq_hz.set(center_freq); }
+    // harmonics enabled on the harmonic notch
     uint8_t harmonics(void) const { return _harmonics; }
+    // reference value of the harmonic notch
     float reference(void) const { return _reference; }
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
+    // notch harmonics
     AP_Int8 _harmonics;
+    // notch reference value
     AP_Float _reference;
 };
 

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -14,57 +14,48 @@
  */
 #pragma once
 
-/*
-  notch filter with settable sample rate, center frequency, bandwidth and attenuation
-
-  Design by Leonard Hall
- */
-
 #include <AP_Math/AP_Math.h>
 #include <cmath>
 #include <inttypes.h>
 #include <AP_Param/AP_Param.h>
-
+#include "NotchFilter.h"
 
 template <class T>
-class NotchFilter {
+class HarmonicNotchFilter {
 public:
     // set parameters
+    void create(uint8_t harmonics);
     void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
-    void init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q);
     T apply(const T &sample);
     void reset();
-
-    // calculate attenuation and quality from provided center frequency and bandwidth
-    static void calculate_A_and_Q(float center_freq_hz, float bandwidth_hz, float attenuation_dB, float& A, float& Q); 
+    void update(float center_freq_hz);
+    ~HarmonicNotchFilter();
 
 private:
-
-    bool initialised;
-    float b0, b1, b2, a1, a2, a0_inv;
-    T ntchsig, ntchsig1, ntchsig2, signal2, signal1;
+    NotchFilter<T>*  _filters;
+    float _sample_freq_hz;
+    float _A;
+    float _Q;
+    uint8_t _harmonics;
+    uint8_t _num_filters;
+    bool _initialised;
 };
 
 /*
   notch filter enable and filter parameters
  */
-class NotchFilterParams {
+class HarmonicNotchFilterParams : public NotchFilterParams {
 public:
-    NotchFilterParams(void);
+    HarmonicNotchFilterParams(void);
+    void set_center_freq_hz(float center_freq) { _center_freq_hz.set(center_freq); }
+    uint8_t harmonics(void) const { return _harmonics; }
+    float reference(void) const { return _reference; }
     static const struct AP_Param::GroupInfo var_info[];
 
-    float center_freq_hz(void) const { return _center_freq_hz; }
-    float bandwidth_hz(void) const { return _bandwidth_hz; }
-    float attenuation_dB(void) const { return _attenuation_dB; }
-    uint8_t enabled(void) const { return _enable; }
-    
-protected:
-    AP_Int8 _enable;
-    AP_Float _center_freq_hz;
-    AP_Float _bandwidth_hz;
-    AP_Float _attenuation_dB;
+private:
+    AP_Int8 _harmonics;
+    AP_Float _reference;
 };
 
-typedef NotchFilter<float> NotchFilterFloat;
-typedef NotchFilter<Vector3f> NotchFilterVector3f;
+typedef HarmonicNotchFilter<Vector3f> HarmonicNotchFilterVector3f;
 

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -16,15 +16,33 @@
 #include "NotchFilter.h"
 
 /*
+   calculate the attenuation and quality factors of the filter
+ */
+template <class T>
+void NotchFilter<T>::calculate_A_and_Q(float center_freq_hz, float bandwidth_hz, float attenuation_dB, float& A, float& Q) {
+    const float octaves = log2f(center_freq_hz / (center_freq_hz - bandwidth_hz / 2.0f)) * 2.0f;
+    A = powf(10, -attenuation_dB / 40.0f);
+    Q = sqrtf(powf(2, octaves)) / (powf(2, octaves) - 1.0f);
+}
+
+/*
   initialise filter
  */
 template <class T>
 void NotchFilter<T>::init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB)
 {
+    // adjust the center frequency to be in the allowable range
+    center_freq_hz = constrain_float(center_freq_hz, bandwidth_hz * 0.52f, sample_freq_hz * 0.48f);
+
+    float A, Q;
+    calculate_A_and_Q(center_freq_hz, bandwidth_hz, attenuation_dB, A, Q);
+    init_with_A_and_Q(sample_freq_hz, center_freq_hz, A, Q);
+}
+
+template <class T>
+void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q)
+{
     float omega = 2.0 * M_PI * center_freq_hz / sample_freq_hz;
-    float octaves = log2f(center_freq_hz  / (center_freq_hz - bandwidth_hz/2)) * 2;
-    float A = powf(10, -attenuation_dB/40);
-    float Q = sqrtf(powf(2, octaves)) / (powf(2,octaves) - 1);
     float alpha = sinf(omega) / (2 * Q/A);
     b0 =  1.0 + alpha*A;
     b1 = -2.0 * cosf(omega);
@@ -72,22 +90,6 @@ const AP_Param::GroupInfo NotchFilterParams::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO_FLAGS("ENABLE", 1, NotchFilterParams, _enable, 0, AP_PARAM_FLAG_ENABLE),
 
-    // @Param: FREQ
-    // @DisplayName: Frequency
-    // @Description: Notch center frequency in Hz
-    // @Range: 10 400
-    // @Units: Hz
-    // @User: Advanced
-    AP_GROUPINFO("FREQ", 2, NotchFilterParams, _center_freq_hz, 80),
-
-    // @Param: BW
-    // @DisplayName: Bandwidth
-    // @Description: Notch bandwidth in Hz
-    // @Range: 5 100
-    // @Units: Hz
-    // @User: Advanced
-    AP_GROUPINFO("BW", 3, NotchFilterParams, _bandwidth_hz, 20),
-
     // @Param: ATT
     // @DisplayName: Attenuation
     // @Description: Notch attenuation in dB
@@ -95,7 +97,23 @@ const AP_Param::GroupInfo NotchFilterParams::var_info[] = {
     // @Units: dB
     // @User: Advanced
     AP_GROUPINFO("ATT", 4, NotchFilterParams, _attenuation_dB, 15),
-    
+
+    // @Param: FREQ
+    // @DisplayName: Frequency
+    // @Description: Notch center frequency in Hz
+    // @Range: 10 400
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("FREQ", 5, NotchFilterParams, _center_freq_hz, 80),
+
+    // @Param: BW
+    // @DisplayName: Bandwidth
+    // @Description: Notch bandwidth in Hz
+    // @Range: 5 100
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("BW", 6, NotchFilterParams, _bandwidth_hz, 20),
+
     AP_GROUPEND
 };
 

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -90,6 +90,8 @@ const AP_Param::GroupInfo NotchFilterParams::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO_FLAGS("ENABLE", 1, NotchFilterParams, _enable, 0, AP_PARAM_FLAG_ENABLE),
 
+    // Slots 2 and 3 are reserved - they were integer versions of FREQ and BW which have since been converted to float
+
     // @Param: ATT
     // @DisplayName: Attenuation
     // @Description: Notch attenuation in dB

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -20,9 +20,13 @@
  */
 template <class T>
 void NotchFilter<T>::calculate_A_and_Q(float center_freq_hz, float bandwidth_hz, float attenuation_dB, float& A, float& Q) {
-    const float octaves = log2f(center_freq_hz / (center_freq_hz - bandwidth_hz / 2.0f)) * 2.0f;
     A = powf(10, -attenuation_dB / 40.0f);
-    Q = sqrtf(powf(2, octaves)) / (powf(2, octaves) - 1.0f);
+    if (center_freq_hz > 0.5 * bandwidth_hz) {
+        const float octaves = log2f(center_freq_hz / (center_freq_hz - bandwidth_hz / 2.0f)) * 2.0f;
+        Q = sqrtf(powf(2, octaves)) / (powf(2, octaves) - 1.0f);
+    } else {
+        Q = 0.0;
+    }
 }
 
 /*
@@ -31,26 +35,32 @@ void NotchFilter<T>::calculate_A_and_Q(float center_freq_hz, float bandwidth_hz,
 template <class T>
 void NotchFilter<T>::init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB)
 {
-    // adjust the center frequency to be in the allowable range
-    center_freq_hz = constrain_float(center_freq_hz, bandwidth_hz * 0.52f, sample_freq_hz * 0.48f);
-
-    float A, Q;
-    calculate_A_and_Q(center_freq_hz, bandwidth_hz, attenuation_dB, A, Q);
-    init_with_A_and_Q(sample_freq_hz, center_freq_hz, A, Q);
+    // check center frequency is in the allowable range
+    if ((center_freq_hz > 0.5 * bandwidth_hz) && (center_freq_hz < 0.5 * sample_freq_hz)) {
+        float A, Q;
+        calculate_A_and_Q(center_freq_hz, bandwidth_hz, attenuation_dB, A, Q);
+        init_with_A_and_Q(sample_freq_hz, center_freq_hz, A, Q);
+    } else {
+        initialised = false;
+    }
 }
 
 template <class T>
 void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q)
 {
-    float omega = 2.0 * M_PI * center_freq_hz / sample_freq_hz;
-    float alpha = sinf(omega) / (2 * Q/A);
-    b0 =  1.0 + alpha*A;
-    b1 = -2.0 * cosf(omega);
-    b2 =  1.0 - alpha*A;
-    a0_inv =  1.0/(1.0 + alpha/A);
-    a1 = -2.0 * cosf(omega);
-    a2 =  1.0 - alpha/A;
-    initialised = true;
+    if ((center_freq_hz > 0.0) && (center_freq_hz < 0.5 * sample_freq_hz) && (Q > 0.0)) {
+        float omega = 2.0 * M_PI * center_freq_hz / sample_freq_hz;
+        float alpha = sinf(omega) / (2 * Q);
+        b0 =  1.0 + alpha*sq(A);
+        b1 = -2.0 * cosf(omega);
+        b2 =  1.0 - alpha*sq(A);
+        a0_inv =  1.0/(1.0 + alpha);
+        a1 = b1;
+        a2 =  1.0 - alpha;
+        initialised = true;
+    } else {
+        initialised = false;
+    }
 }
 
 /*
@@ -61,7 +71,12 @@ T NotchFilter<T>::apply(const T &sample)
 {
     if (!initialised) {
         // if we have not been initialised when return the input
-        // sample as output
+        // sample as output and update delayed samples
+        ntchsig2 = ntchsig1;
+        ntchsig1 = ntchsig;
+        ntchsig = sample;
+        signal2 = signal1;
+        signal1 = sample;
         return sample;
     }
     ntchsig2 = ntchsig1;


### PR DESCRIPTION
New HarmonicNotchFilter that delegates updates to a bank of NotchFilters located at an rpm frequency and harmonics. Center frequency can be updated dynamically. Notch parameters are configurable, including the number of harmonics to filter on. Updates to the filter parameters are optimized across the notch bank.

Example configuration is as follows:

INS_HNTCH_ATT    15.000000
INS_HNTCH_FREQ 80.000000
INS_HNTCH_BW     20.000000
INS_HNTCH_ENABLE 1.000000
INS_HNTCH_HMNCS  1.000000

