### PR TITLE
Tools: waf: add -Werror=delete-non-virtual-dtor

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -123,6 +123,7 @@ class Board:
             '-Werror=overflow',
             '-Werror=parentheses',
             '-Werror=format-extra-args',
+            '-Werror=delete-non-virtual-dtor',
         ]
 
         if cfg.options.scripting_checks:


### PR DESCRIPTION
This is just a warning on some platforms meaning we catch things later than we should.
