### PR TITLE
Rover: null check for unconfigured RCMAP_YAW

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -135,7 +135,7 @@ void Mode::get_pilot_desired_steering_and_speed(float &steering_out, float &spee
 void Mode::get_pilot_desired_lateral(float &lateral_out)
 {
     // no RC input means no lateral input
-    if (rover.failsafe.bits & FAILSAFE_EVENT_THROTTLE) {
+    if ((rover.failsafe.bits & FAILSAFE_EVENT_THROTTLE) || (rover.channel_lateral == nullptr)) {
         lateral_out = 0;
         return;
     }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -13,7 +13,9 @@ void Rover::set_control_channels(void)
     // set rc channel ranges
     channel_steer->set_angle(SERVO_MAX);
     channel_throttle->set_angle(100);
-    channel_lateral->set_angle(100);
+    if (channel_lateral != nullptr) {
+        channel_lateral->set_angle(100);
+    }
 
     // Allow to reconfigure output when not armed
     if (!arming.is_armed()) {
@@ -33,7 +35,9 @@ void Rover::init_rc_in()
     // set rc dead zones
     channel_steer->set_default_dead_zone(30);
     channel_throttle->set_default_dead_zone(30);
-    channel_lateral->set_default_dead_zone(30);
+    if (channel_lateral != nullptr) {
+        channel_lateral->set_default_dead_zone(30);
+    }
 }
 
 /*


### PR DESCRIPTION
This will fix vehicles configured with RCMAP_YAW = 0 which causes an insta-crash on boot due to unused channels being assigned as nullptr. Yaw (lateral) is optional for several vehicle types, however steering and throttle is universal so if those aren't configured you'll have other major problems.

Likely a different fix should be done globally for all channels and all vehicles.

This is a good candidate to backport to a Rover release.

