### PR TITLE
include replace.h in SIM_AirSim.cpp to fix missing memrchr() on MacOS

### DIFF
--- a/libraries/SITL/SIM_AirSim.cpp
+++ b/libraries/SITL/SIM_AirSim.cpp
@@ -10,6 +10,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_HAL/utility/replace.h>
 
 extern const AP_HAL::HAL& hal;
 


### PR DESCRIPTION
Related to this PR: https://github.com/ArduPilot/ardupilot/pull/9957
replace.h also needs to be included in SIM_AirSim.cpp when building on MacOS using SITL following these build steps: https://github.com/ArduPilot/ardupilot_wiki/blob/master/dev/source/docs/sitl-with-xplane.rst