### PR TITLE
Tools: scripts: dumpstack: do not run any gdbinit scripts

### DIFF
--- a/Tools/scripts/dumpstack
+++ b/Tools/scripts/dumpstack
@@ -11,5 +11,5 @@ bt full
 thread apply all bt full
 quit
 EOF
-gdb -batch -x $TMPFILE --pid $PID < /dev/null 2>&1
+gdb -n -batch -x $TMPFILE --pid $PID < /dev/null 2>&1
 /bin/rm -f $TMPFILE


### PR DESCRIPTION
Often these scripts look for hardware dongles that may not exist