### PR TITLE
AP_Scripting: Add support for enums

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -25,7 +25,7 @@
 #define SCRIPTING_STACK_MIN_SIZE (8 * 1024)
 
 #if !defined(SCRIPTING_STACK_SIZE)
-  #define SCRIPTING_STACK_SIZE (16 * 1024)
+  #define SCRIPTING_STACK_SIZE (17 * 1024) // Linux experiences stack corruption at ~16.25KB when handed bad scripts
 #endif // !defined(SCRIPTING_STACK_SIZE)
 
 #if !defined(SCRIPTING_STACK_MAX_SIZE)

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -50,6 +50,7 @@ singleton AP_BattMonitor method get_temperature boolean float'Null uint8_t 0 ud-
 include AP_GPS/AP_GPS.h
 
 singleton AP_GPS alias gps
+singleton AP_GPS enum NO_GPS NO_FIX GPS_OK_FIX_2D GPS_OK_FIX_3D GPS_OK_FIX_3D_DGPS GPS_OK_FIX_3D_RTK_FLOAT GPS_OK_FIX_3D_RTK_FIXED
 singleton AP_GPS method num_sensors uint8_t
 singleton AP_GPS method primary_sensor uint8_t
 singleton AP_GPS method status uint8_t uint8_t 0 ud->num_sensors()

--- a/libraries/AP_Scripting/lua/src/lfunc.h
+++ b/libraries/AP_Scripting/lua/src/lfunc.h
@@ -26,7 +26,7 @@
 ** maximum number of upvalues in a closure (both C and Lua). (Value
 ** must fit in a VM register.)
 */
-#define MAXUPVAL	255
+#define MAXUPVAL	127
 
 
 /*

--- a/libraries/AP_Scripting/lua/src/lparser.c
+++ b/libraries/AP_Scripting/lua/src/lparser.c
@@ -31,7 +31,7 @@
 
 /* maximum number of local variables per function (must be smaller
    than 250, due to the bytecode format) */
-#define MAXVARS		200
+#define MAXVARS		100
 
 
 #define hasmultret(k)		((k) == VCALL || (k) == VVARARG)

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1619,28 +1619,43 @@ const luaL_Reg AP_AHRS_meta[] = {
     {NULL, NULL}
 };
 
-const struct userdata_fun {
+struct userdata_enum {
     const char *name;
-    const luaL_Reg *reg;
-} userdata_fun[] = {
-    {"Vector2f", Vector2f_meta},
-    {"Vector3f", Vector3f_meta},
-    {"Location", Location_meta},
+    int value;
 };
 
-const struct singleton_fun {
+struct userdata_enum AP_GPS_enums[] = {
+    {"GPS_OK_FIX_3D_RTK_FIXED", AP_GPS::GPS_OK_FIX_3D_RTK_FIXED},
+    {"GPS_OK_FIX_3D_RTK_FLOAT", AP_GPS::GPS_OK_FIX_3D_RTK_FLOAT},
+    {"GPS_OK_FIX_3D_DGPS", AP_GPS::GPS_OK_FIX_3D_DGPS},
+    {"GPS_OK_FIX_3D", AP_GPS::GPS_OK_FIX_3D},
+    {"GPS_OK_FIX_2D", AP_GPS::GPS_OK_FIX_2D},
+    {"NO_FIX", AP_GPS::NO_FIX},
+    {"NO_GPS", AP_GPS::NO_GPS},
+    {NULL, 0}};
+
+struct userdata_meta {
     const char *name;
     const luaL_Reg *reg;
-} singleton_fun[] = {
-    {"gcs", GCS_meta},
-    {"relay", AP_Relay_meta},
-    {"terrain", AP_Terrain_meta},
-    {"rangefinder", RangeFinder_meta},
-    {"AP_Notify", AP_Notify_meta},
-    {"notify", notify_meta},
-    {"gps", AP_GPS_meta},
-    {"battery", AP_BattMonitor_meta},
-    {"ahrs", AP_AHRS_meta},
+    const struct userdata_enum *enums;
+};
+
+const struct userdata_meta userdata_fun[] = {
+    {"Vector2f", Vector2f_meta, NULL},
+    {"Vector3f", Vector3f_meta, NULL},
+    {"Location", Location_meta, NULL},
+};
+
+const struct userdata_meta singleton_fun[] = {
+    {"gcs", GCS_meta, NULL},
+    {"relay", AP_Relay_meta, NULL},
+    {"terrain", AP_Terrain_meta, NULL},
+    {"rangefinder", RangeFinder_meta, NULL},
+    {"AP_Notify", AP_Notify_meta, NULL},
+    {"notify", notify_meta, NULL},
+    {"gps", AP_GPS_meta, AP_GPS_enums},
+    {"battery", AP_BattMonitor_meta, NULL},
+    {"ahrs", AP_AHRS_meta, NULL},
 };
 
 void load_generated_bindings(lua_State *L) {
@@ -1662,6 +1677,15 @@ void load_generated_bindings(lua_State *L) {
         lua_pushstring(L, "__index");
         lua_pushvalue(L, -2);
         lua_settable(L, -3);
+        if (singleton_fun[i].enums != nullptr) {
+            int j = 0;
+            while (singleton_fun[i].enums[j].name != NULL) {
+                lua_pushstring(L, singleton_fun[i].enums[j].name);
+                lua_pushinteger(L, singleton_fun[i].enums[j].value);
+                lua_settable(L, -3);
+                j++;
+            }
+        }
         lua_pop(L, 1);
         lua_newuserdata(L, 0);
         luaL_getmetatable(L, singleton_fun[i].name);

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -69,16 +69,21 @@ lua_scripts::script_info *lua_scripts::load_script(lua_State *L, char *filename)
         switch (error) {
             case LUA_ERRSYNTAX:
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: Syntax error in %s", filename);
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: Error: %s", lua_tostring(L, -1));
+                lua_pop(L, lua_gettop(L));
                 return nullptr;
             case LUA_ERRMEM:
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: Insufficent memory loading %s", filename);
+                lua_pop(L, lua_gettop(L));
                 return nullptr;
             case LUA_ERRFILE:
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: Unable to load the file: %s", lua_tostring(L, -1));
                 hal.console->printf("Lua: File error: %s\n", lua_tostring(L, -1));
+                lua_pop(L, lua_gettop(L));
                 return nullptr;
             default:
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: Unknown error (%d) loading %s", error, filename);
+                lua_pop(L, lua_gettop(L));
                 return nullptr;
         }
     }


### PR DESCRIPTION
This allows us to start wrapping enums into the exposed bindings. For example this allows us to refer to GPS fix types by name. This is not currently flexible enough to work well with the MAVLink enums for example, although it would be trivial to remap these locally in a header as a work around, it would be more appropriate to just support non namespaced enums. (In fact we could just default to all enums not being namespaced, which would result in an increased verbosity in the header, but be valid.

This also recovers from an invalid script being loaded (ie syntax error) and allows the other scripts to be loaded as per normal.

Anyways other changes that come in with this: I've had some slight oddities with a 16 KB stack in SITL that only show up as Valgrind warnings when loading an invalid script (but a massive script is correctly handled), so as a short term increasing this raises above that threshold, and reduces some of the ways that Lua can burn stack space. I'm hoping to go further with this, but I ran out of time to handle it further now.