### PR TITLE
Tools: add toolchain version validator function

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -36,6 +36,7 @@ class Board:
 
     def configure(self, cfg):
         cfg.env.TOOLCHAIN = cfg.options.toolchain or self.toolchain
+        cfg.env.AP_MIN_CC_VERSION = [4, 9]
         cfg.env.ROMFS_FILES = []
         cfg.load('toolchain')
         cfg.load('cxx_checks')


### PR DESCRIPTION
Add a validation on Waf.
By default it will only check that the minimun version is used : aka gcc > 4.9
I also add an option to enforce the use of one specific version !