### PR TITLE
AP_Airspeed: support both 5inH2O and 10inH2O versions of DLVR sensor

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Airspeed type
     // @Description: Type of airspeed sensor
-    // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X,7:I2C-DLVR,8:UAVCAN
+    // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X,7:I2C-DLVR-5in,8:UAVCAN,9:I2C-DLVR-10in
     // @User: Standard
     AP_GROUPINFO_FLAGS("_TYPE", 0, AP_Airspeed, param[0].type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
 
@@ -146,7 +146,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Param: 2_TYPE
     // @DisplayName: Second Airspeed type
     // @Description: Type of 2nd airspeed sensor
-    // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X,7:I2C-DLVR,8:UAVCAN
+    // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X,7:I2C-DLVR-5in,8:UAVCAN,9:I2C-DLVR-10in
     // @User: Standard
     AP_GROUPINFO_FLAGS("2_TYPE", 11, AP_Airspeed, param[1].type, 0, AP_PARAM_FLAG_ENABLE),
 
@@ -267,9 +267,14 @@ void AP_Airspeed::init()
         case TYPE_I2C_SDP3X:
             sensor[i] = new AP_Airspeed_SDP3X(*this, i);
             break;
-        case TYPE_I2C_DLVR:
+        case TYPE_I2C_DLVR_5IN:
 #if !HAL_MINIMIZE_FEATURES
-            sensor[i] = new AP_Airspeed_DLVR(*this, i);
+            sensor[i] = new AP_Airspeed_DLVR(*this, i, 5);
+#endif // !HAL_MINIMIZE_FEATURES
+            break;
+        case TYPE_I2C_DLVR_10IN:
+#if !HAL_MINIMIZE_FEATURES
+            sensor[i] = new AP_Airspeed_DLVR(*this, i, 10);
 #endif // !HAL_MINIMIZE_FEATURES
             break;
         case TYPE_UAVCAN:

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -140,8 +140,9 @@ public:
         TYPE_I2C_MS5525_ADDRESS_1=4,
         TYPE_I2C_MS5525_ADDRESS_2=5,
         TYPE_I2C_SDP3X=6,
-        TYPE_I2C_DLVR=7,
+        TYPE_I2C_DLVR_5IN=7,
         TYPE_UAVCAN=8,
+        TYPE_I2C_DLVR_10IN=9,
     };
 
     // get current primary sensor

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
@@ -12,6 +12,10 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+/*
+  driver for DLVR differential airspeed sensor
+  https://www.allsensors.com/products/DLVR-L01D
+ */
 
 #include "AP_Airspeed_DLVR.h"
 #include <AP_Math/AP_Math.h>
@@ -27,8 +31,9 @@ extern const AP_HAL::HAL &hal;
 #endif
 
 
-AP_Airspeed_DLVR::AP_Airspeed_DLVR(AP_Airspeed &_frontend, uint8_t _instance) :
-    AP_Airspeed_Backend(_frontend, _instance)
+AP_Airspeed_DLVR::AP_Airspeed_DLVR(AP_Airspeed &_frontend, uint8_t _instance, const float _range_inH2O) :
+    AP_Airspeed_Backend(_frontend, _instance),
+    range_inH2O(_range_inH2O)
 {}
 
 // probe and initialise the sensor
@@ -53,7 +58,6 @@ bool AP_Airspeed_DLVR::init()
 #define PRESSURE_SHIFT 16
 #define PRESSURE_MASK ((1 << 14) - 1)
 
-#define DLVR_FSS       5.0f // assumes 5 inch H2O sensor
 #define DLVR_OFFSET 8192.0f
 #define DLVR_SCALE 16384.0f
 
@@ -79,7 +83,7 @@ void AP_Airspeed_DLVR::timer()
     uint32_t pres_raw = (data >> PRESSURE_SHIFT)    & PRESSURE_MASK;
     uint32_t temp_raw = (data >> TEMPERATURE_SHIFT) & TEMPERATURE_MASK;
 
-    float press_h2o = 1.25f * 2.0f * DLVR_FSS * ((pres_raw - DLVR_OFFSET) / DLVR_SCALE);
+    float press_h2o = 1.25f * 2.0f * range_inH2O * ((pres_raw - DLVR_OFFSET) / DLVR_SCALE);
     float temp = temp_raw * (200.0f / 2047.0f) - 50.0f;
 
     WITH_SEMAPHORE(sem);

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
@@ -28,7 +28,7 @@ class AP_Airspeed_DLVR : public AP_Airspeed_Backend
 {
 public:
 
-    AP_Airspeed_DLVR(AP_Airspeed &frontend, uint8_t _instance);
+    AP_Airspeed_DLVR(AP_Airspeed &frontend, uint8_t _instance, const float _range_inH2O);
     ~AP_Airspeed_DLVR(void) {}
     
     // probe and initialise the sensor
@@ -51,6 +51,7 @@ private:
     uint32_t press_count;
     
     uint32_t last_sample_time_ms;
+    const float range_inH2O;
 
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
 };


### PR DESCRIPTION
useful for faster aircraft