### PR TITLE
Tools: Add edn_format to CI

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1221,7 +1221,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: DSPOILER_OPTS
     // @DisplayName: Differential spoiler and crow flaps options
     // @Description: Differential spoiler and crow flaps options
-    // @Values: 0: none, 1: D spoilers have pitch input, 2: use both control surfaces on each wing for roll, 4: Progressive crow, flaps only first (0-50% flap in) then crow flaps (50 - 100% flap in)
+    // @Values: 0: none, 1: D spoilers have pitch input, 2: use both control surfaces on each wing for roll, 4: Progressive crow flaps only first (0-50% flap in) then crow flaps (50 - 100% flap in)
     // @Bitmask: 0:pitch control, 1:full span, 2:Progressive crow
     // @User: Advanced
     AP_GROUPINFO("DSPOILER_OPTS", 20, ParametersG2, crow_flap_options, 3),

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -156,11 +156,11 @@ for t in $CI_BUILD_TARGET; do
     fi
 done
 
-python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle APMrover2
-python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle AntennaTracker
-python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduCopter
-python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduPlane
-python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduSub
+python Tools/autotest/param_metadata/param_parse.py --vehicle APMrover2
+python Tools/autotest/param_metadata/param_parse.py --vehicle AntennaTracker
+python Tools/autotest/param_metadata/param_parse.py --vehicle ArduCopter
+python Tools/autotest/param_metadata/param_parse.py --vehicle ArduPlane
+python Tools/autotest/param_metadata/param_parse.py --vehicle ArduSub
 
 echo build OK
 exit 0

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -90,3 +90,4 @@ pip install --user -U argparse empy pyserial pexpect future lxml
 pip install --user -U mavproxy
 pip install --user -U intelhex
 pip install --user -U numpy
+pip install --user -U edn_format

--- a/libraries/AP_RCMapper/AP_RCMapper.cpp
+++ b/libraries/AP_RCMapper/AP_RCMapper.cpp
@@ -45,7 +45,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
-    // @Values{Sub}: 1-8
+    // @Values{Sub}: 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8
     AP_GROUPINFO_FRAME("FORWARD",    4, RCMapper, _ch_forward, 6, AP_PARAM_FRAME_SUB),
 
     // @Param: LATERAL
@@ -55,7 +55,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
-    // @Values{Sub}: 1-8
+    // @Values{Sub}: 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8
     AP_GROUPINFO_FRAME("LATERAL",    5, RCMapper, _ch_lateral, 7, AP_PARAM_FRAME_SUB),
 
     AP_GROUPEND


### PR DESCRIPTION
This adds the edn_format dependency to CI, which allows us to run the edn parameter emitter as part of CI. The rational for this is that the EDN parser is stricter then the general param_parse.py script, and it catches more errors in our documentation, that we currently push to be GCS's problems.

Tagged WIP as the first push of this is missing the commits to make the parser work correctly, the target is to prove CI would actually catch the error first.