### PR TITLE
AP_Scripting: add AP_arming binding

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -31,6 +31,12 @@ singleton AP_AHRS method get_relative_position_NED_home boolean Vector3f'Null
 singleton AP_AHRS method home_is_set boolean
 singleton AP_AHRS method prearm_healthy boolean
 
+include AP_Arming/AP_Arming.h
+
+singleton AP_Arming alias arming
+singleton AP_Arming method disarm boolean
+singleton AP_Arming method is_armed boolean
+
 include AP_BattMonitor/AP_BattMonitor.h
 
 singleton AP_BattMonitor alias battery

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -9,6 +9,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_Arming/AP_Arming.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/Location.h>
 
@@ -1289,6 +1290,34 @@ static int AP_BattMonitor_num_instances(lua_State *L) {
     return 1;
 }
 
+static int AP_Arming_is_armed(lua_State *L) {
+    AP_Arming * ud = AP_Arming::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "arming not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    const bool data = ud->is_armed(
+        );
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_Arming_disarm(lua_State *L) {
+    AP_Arming * ud = AP_Arming::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "arming not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    const bool data = ud->disarm(
+        );
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
 static int AP_AHRS_prearm_healthy(lua_State *L) {
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
@@ -1602,6 +1631,12 @@ const luaL_Reg AP_BattMonitor_meta[] = {
     {NULL, NULL}
 };
 
+const luaL_Reg AP_Arming_meta[] = {
+    {"is_armed", AP_Arming_is_armed},
+    {"disarm", AP_Arming_disarm},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_AHRS_meta[] = {
     {"prearm_healthy", AP_AHRS_prearm_healthy},
     {"home_is_set", AP_AHRS_home_is_set},
@@ -1655,6 +1690,7 @@ const struct userdata_meta singleton_fun[] = {
     {"notify", notify_meta, NULL},
     {"gps", AP_GPS_meta, AP_GPS_enums},
     {"battery", AP_BattMonitor_meta, NULL},
+    {"arming", AP_Arming_meta, NULL},
     {"ahrs", AP_AHRS_meta, NULL},
 };
 
@@ -1705,6 +1741,7 @@ const char *singletons[] = {
     "notify",
     "gps",
     "battery",
+    "arming",
     "ahrs",
 };
 

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -8,6 +8,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_Arming/AP_Arming.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/Location.h>
 #include "lua/src/lua.hpp"


### PR DESCRIPTION
This PR allow lua scripts to check the armed/disarmed state and also to disarm the vehicle.

This has been tested on SITL with a rover and it worked.  The script used is below and it would check the vehicle's state at 5sec intervals and disarm it if it was armed.

```
function update()
  local res = arming:is_armed()
  gcs:send_text(0,string.format("armed:%s",tostring(res)))
  if res then arming:disarm() end
  return update, 5000
end

return update, 1000
```

It would be nice in the future to also allow the vehicle to be armed but I was unable to get the bindings to work.  This change on it's own however does resolve a user's request to be able to check the GPS state and disarm the vehicle if that state becomes too low (this user wants to only drive the vehicle using RTK).