### PR TITLE
Added BRD_BOOT_DELAY parameter

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -76,6 +76,10 @@
 #endif
 #endif
 
+#ifndef HAL_DEFAULT_BOOT_DELAY
+#define HAL_DEFAULT_BOOT_DELAY 0
+#endif
+
 extern const AP_HAL::HAL& hal;
 AP_BoardConfig *AP_BoardConfig::_singleton;
 
@@ -245,6 +249,14 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 19, AP_BoardConfig, _options, HAL_BRD_OPTIONS_DEFAULT),
 
+    // @Param: BOOT_DELAY
+    // @DisplayName: Boot delay
+    // @Description: This adds a delay in milliseconds to boot to ensure peripherals initialise fully
+    // @Range: 0 10000
+    // @Units: ms
+    // @User: Advanced
+    AP_GROUPINFO("BOOT_DELAY", 20, AP_BoardConfig, _boot_delay_ms, HAL_DEFAULT_BOOT_DELAY),
+    
     AP_GROUPEND
 };
 
@@ -261,6 +273,16 @@ void AP_BoardConfig::init()
 
     AP::rtc().set_utc_usec(hal.util->get_hw_rtc(), AP_RTC::SOURCE_HW);
 
+    if (_boot_delay_ms > 0) {
+        uint16_t delay_ms = uint16_t(_boot_delay_ms.get());
+        if (hal.util->was_watchdog_armed() && delay_ms > 200) {
+            // don't delay a long time on watchdog reset, the pilot
+            // may be able to save the vehicle
+            delay_ms = 200;
+        }
+        hal.scheduler->delay(delay_ms);
+    }
+    
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS && defined(USE_POSIX)
     uint8_t slowdown = constrain_int16(_sdcard_slowdown.get(), 0, 32);
     const uint8_t max_slowdown = 8;

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -234,5 +234,7 @@ private:
     AP_Int8 _sdcard_slowdown;
 #endif
 
+    AP_Int16 _boot_delay_ms;
+
     AP_Int32 _options;
 };

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -380,6 +380,10 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         break;
     case RangeFinder_TYPE_LWI2C:
         if (params[instance].address) {
+            // the LW20 needs a long time to boot up, so we delay 1.5s here
+            if (!hal.util->was_watchdog_armed()) {
+                hal.scheduler->delay(1500);
+            }
 #ifdef HAL_RANGEFINDER_LIGHTWARE_I2C_BUS
             _add_backend(AP_RangeFinder_LightWareI2C::detect(state[instance], params[instance],
                 hal.i2c_mgr->get_device(HAL_RANGEFINDER_LIGHTWARE_I2C_BUS, params[instance].address)));


### PR DESCRIPTION
This allows for slower boots if the user has peripherals that need time to settle before being probed
