### PR TITLE
Copter: esc cal startup check moved outside rc output initialisation

### DIFF
--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -44,7 +44,7 @@ void Copter::init_rc_in()
     ap.throttle_zero = true;
 }
 
- // init_rc_out -- initialise motors and check if pilot wants to perform ESC calibration
+ // init_rc_out -- initialise motors
 void Copter::init_rc_out()
 {
     motors->set_loop_rate(scheduler.get_loop_rate_hz());
@@ -74,9 +74,6 @@ void Copter::init_rc_out()
     uint16_t safety_ignore_mask = (~copter.motors->get_motor_mask()) & 0x3FFF;
     BoardConfig.set_default_safety_ignore_mask(safety_ignore_mask);
 #endif
-
-    // check if we should enter esc calibration mode
-    esc_calibration_startup_check();
 }
 
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -117,6 +117,9 @@ void Copter::init_ardupilot()
     // sets up motors and output to escs
     init_rc_out();
 
+    // check if we should enter esc calibration mode
+    esc_calibration_startup_check();
+
     // motors initialised so parameters can be sent
     ap.initialised_params = true;
 


### PR DESCRIPTION
This PR resolves this issue:https://github.com/ArduPilot/ardupilot/issues/11816 in which the EKF was being upset each time the motor test was run.

The cause of the problem was the main loop was being slowed down during the motor test because we call rc_init_out() when starting the test.  This function includes a call to the esc_calibration_startup_check() function which [includes some delays to ensure we've received radio packets from the user](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/esc_calibration.cpp#L30).

We definitely **do not** want to be running the esc calibration check when we're running the motors test because it could falsely trigger entry to the esc calibration if the user happens to have the transmitter's throttle stick held high so I've moved esc_calibration_startup_check to only run as part of the vehicle startup initialisation (aka "init_ardupilot").  Note this change also affects compassmot but we don't want to run the esc-calibration-startup-check before compassmot either.

I've re-tested the motor test and the esc calibration on my IRIS and they work fine.  The EKF reporting to the GCS shows the EKF is happy now when the motor test is run