### PR TITLE
AP_VisualOdom: Support logging VISION_POSITION_DELTA message even when VISO_TYPE is not enabled

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.cpp
@@ -107,7 +107,7 @@ void AP_VisualOdom::update()
                                          time_delta_sec,
                                          get_last_update_ms(),
                                          get_pos_offset());
-    // log sensor data
+    // log sensor data (when enabled)
     AP::logger().Write_VisualOdom(time_delta_sec,
                                   get_angle_delta(),
                                   get_position_delta(),
@@ -128,8 +128,17 @@ bool AP_VisualOdom::healthy() const
 // consume VISION_POSITION_DELTA MAVLink message
 void AP_VisualOdom::handle_msg(const mavlink_message_t &msg)
 {
-    // exit immediately if not enabled
+    // log sensor data then exit immediately if not enabled
     if (!enabled()) {
+        // log sensor data (when not enabled)
+        mavlink_vision_position_delta_t packet;
+        mavlink_msg_vision_position_delta_decode(&msg, &packet);
+        const Vector3f angle_delta(packet.angle_delta[0], packet.angle_delta[1], packet.angle_delta[2]);
+        const Vector3f position_delta(packet.position_delta[0], packet.position_delta[1], packet.position_delta[2]);
+        AP::logger().Write_VisualOdom(packet.time_delta_usec,
+                                    angle_delta,
+                                    position_delta,
+                                    packet.confidence);
         return;
     }
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp
@@ -25,7 +25,7 @@ AP_VisualOdom_MAV::AP_VisualOdom_MAV(AP_VisualOdom &frontend) :
 {
 }
 
-// consume VISIOIN_POSITION_DELTA MAVLink message
+// consume VISION_POSITION_DELTA MAVLink message
 void AP_VisualOdom_MAV::handle_msg(const mavlink_message_t &msg)
 {
     // decode message


### PR DESCRIPTION
This PR attempts to let the [`VISION_POSITION_DELTA`](https://mavlink.io/en/messages/ardupilotmega.html#VISION_POSITION_DELTA)  message be logged whenever the FCU receives it.

Currently, the MAVLink message [`VISION_POSITION_DELTA`](https://mavlink.io/en/messages/ardupilotmega.html#VISION_POSITION_DELTA) will only be logged when param `VISO_TYPE = 1` (visual odometry enabled), as can be seen [here](https://github.com/ArduPilot/ardupilot/blob/c56acb49d6a992dff109d599c9133ade4d19d928/libraries/AP_VisualOdom/AP_VisualOdom.cpp#L111). 

My understanding from reading [GCS_Common.cpp](https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_Common.cpp) is that for other vision-related messages, they will be logged whenever the messages are present. Thus, doing the same for `VISION_POSITION_DELTA` would be consistent. 