### PR TITLE
AP_HAL_SITL: Fix writing out of a buffer range when dumping the stack trace

### DIFF
--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -72,6 +72,9 @@ void dump_stack_trace()
         strncpy(progname, "unknown", sizeof(progname));
         n = strlen(progname);
 	}
+    if (n >= (int)sizeof(progname)) {
+        n = sizeof(progname) - 1;
+    }
 	progname[n] = 0;
 
 	p = strrchr(progname, '/');


### PR DESCRIPTION
Resolves CID 343302. Root cause is `readlink` simply returns how many bytes are read, and there is no prevision for null terminating, so if we read in the entire possible buffer we would terminate at `buffer_length + 1` which was out of bounds.