### PR TITLE
AP_GPS: Refactor first_unconfigured_gps

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -448,8 +448,8 @@ bool AP_Arming::gps_checks(bool report)
     }
 
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {
-        const uint8_t first_unconfigured = gps.first_unconfigured_gps();
-        if (first_unconfigured != AP_GPS::GPS_ALL_CONFIGURED) {
+        uint8_t first_unconfigured;
+        if (gps.first_unconfigured_gps(first_unconfigured)) {
             check_failed(ARMING_CHECK_GPS_CONFIG,
                          report,
                          "GPS %d failing configuration checks",

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -384,14 +384,9 @@ public:
 
     void send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst);
 
-    // Returns the index of the first unconfigured GPS (returns GPS_ALL_CONFIGURED if all instances report as being configured)
-    uint8_t first_unconfigured_gps(void) const;
+    // Returns true if there is an unconfigured GPS, and provides the instance number of the first non configured GPS
+    bool first_unconfigured_gps(uint8_t &instance) const WARN_IF_UNUSED;
     void broadcast_first_configuration_failure_reason(void) const;
-
-    // return true if all GPS instances have finished configuration
-    bool all_configured(void) const {
-        return first_unconfigured_gps() == GPS_ALL_CONFIGURED;
-    }
 
     // pre-arm check that all GPSs are close to each other.  farthest distance between GPSs (in meters) is returned
     bool all_consistent(float &distance) const;

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -77,8 +77,7 @@ singleton AP_GPS method last_fix_time_ms uint32_t uint8_t 0 ud->num_sensors()
 singleton AP_GPS method last_message_time_ms uint32_t uint8_t 0 ud->num_sensors()
 singleton AP_GPS method have_vertical_velocity boolean uint8_t 0 ud->num_sensors()
 singleton AP_GPS method get_antenna_offset Vector3f uint8_t 0 ud->num_sensors()
-singleton AP_GPS method all_configured boolean
-singleton AP_GPS method first_unconfigured_gps uint8_t
+singleton AP_GPS method first_unconfigured_gps boolean uint8_t'Null
 
 include AP_Math/AP_Math.h
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -700,22 +700,15 @@ static int AP_GPS_first_unconfigured_gps(lua_State *L) {
     }
 
     binding_argcheck(L, 1);
-    const uint8_t data = ud->first_unconfigured_gps();
+    uint8_t data_5002 = {};
+    const bool data = ud->first_unconfigured_gps(
+            data_5002);
 
-    lua_pushinteger(L, data);
-    return 1;
-}
-
-static int AP_GPS_all_configured(lua_State *L) {
-    AP_GPS * ud = AP_GPS::get_singleton();
-    if (ud == nullptr) {
-        return luaL_argerror(L, 1, "gps not supported on this firmware");
+    if (data) {
+        lua_pushinteger(L, data_5002);
+    } else {
+        lua_pushnil(L);
     }
-
-    binding_argcheck(L, 1);
-    const bool data = ud->all_configured();
-
-    lua_pushboolean(L, data);
     return 1;
 }
 
@@ -1582,7 +1575,6 @@ const luaL_Reg notify_meta[] = {
 
 const luaL_Reg AP_GPS_meta[] = {
     {"first_unconfigured_gps", AP_GPS_first_unconfigured_gps},
-    {"all_configured", AP_GPS_all_configured},
     {"get_antenna_offset", AP_GPS_get_antenna_offset},
     {"have_vertical_velocity", AP_GPS_have_vertical_velocity},
     {"last_message_time_ms", AP_GPS_last_message_time_ms},


### PR DESCRIPTION
This is another internal API cleanup to enable a more useful scripting API. It didn't make sense to offer both a `bool AP_GPS::all_configured(void)` and `uint8_t AP_GPS::first_unconfigured_gps(void)` which would return a define if they were all configured. Using a bool and reference version works out both because scripting can use nil punning, and we have fewer internal API's to manage.

This also fixes an our of range access if someone called `AP_GPS::broadcast_first_configuration_failure_reason(void)` when all the instances were configured. This wasn't a problem with the current structure, but it was a pending problem depending on how the code was restructured.