### PR TITLE
SITL fixs for alpine linux

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -360,6 +360,7 @@ class sitl(Board):
         ]
 
         cfg.check_librt(env)
+        cfg.check_feenableexcept()
 
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES += [

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -170,6 +170,22 @@ def check_librt(cfg, env):
     return ret
 
 @conf
+def check_feenableexcept(cfg):
+
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <fenv.h>
+
+        int main() {
+            return feenableexcept(FE_OVERFLOW | FE_DIVBYZERO);
+        }''',
+        msg="Checking for feenableexcept",
+        define_name="HAVE_FEENABLEEXCEPT",
+        mandatory=False,
+    )
+
+@conf
 def check_package(cfg, env, libname):
     '''use pkg-config to look for an installed library that has a LIBNAME.pc file'''
     capsname = libname.upper()

--- a/libraries/AP_Common/missing/fenv.h
+++ b/libraries/AP_Common/missing/fenv.h
@@ -2,6 +2,7 @@
 
 #include_next <fenv.h>
 
+#ifndef HAVE_FEENABLEEXCEPT
 #if defined(__APPLE__) && defined(__MACH__)
 
 // Public domain polyfill for feenableexcept on OS X
@@ -45,4 +46,29 @@ inline int fedisableexcept(unsigned int excepts)
     return fesetenv(&fenv) ? -1 : old_excepts;
 }
 
+#else
+inline int feenableexcept(unsigned int excepts)
+{
+    #pragma STDC FENV_ACCESS ON
+    fexcept_t flags;
+    /* Save current exception flags. */
+    fegetexceptflag(&flags, FE_ALL_EXCEPT);
+
+    feclearexcept(FE_ALL_EXCEPT);   /* clear all fp exception conditions */
+    return fesetexceptflag(&flags, excepts) != 0 ? -1 : flags; /* set new flags */
+
+}
+
+inline int fedisableexcept(unsigned int excepts)
+{
+    #pragma STDC FENV_ACCESS ON
+    fexcept_t flags;
+    /* Save current exception flags. */
+    fegetexceptflag(&flags, FE_ALL_EXCEPT);
+
+    feclearexcept(FE_ALL_EXCEPT);   /* clear all fp exception conditions */
+    return fesetexceptflag(&flags, ~excepts) != 0 ? -1 : flags; /* set new flags */
+}
+
+#endif
 #endif

--- a/libraries/AP_HAL_SITL/UART_utils.cpp
+++ b/libraries/AP_HAL_SITL/UART_utils.cpp
@@ -26,6 +26,7 @@
 #ifdef USE_TERMIOS
 #include <termios.h>
 #else
+#include <asm/ioctls.h>
 #include <asm/termbits.h>
 #endif
 


### PR DESCRIPTION
This fix two error when building SITL on Alpine linux, mainly use on docker.
First fix is for feenableexcept that is only present on glibc, as alpine is using musl, I made a workaround with c++11 standard library.

The second fix a missing header.

I will provide the alpine image later. Using alpine allow to shrink docker container with SITL from 68Mo on ubuntu to 10Mo ! That save some trees !