### PR TITLE
Sub: backport LOIT_ and CI fix to 3.6

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -432,7 +432,7 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Group: LOIT_
     // @Path: ../libraries/AC_WPNav/AC_Loiter.cpp
-    GOBJECT(loiter_nav, "LOITER_", AC_Loiter),
+    GOBJECT(loiter_nav, "LOIT_", AC_Loiter),
 
 #if CIRCLE_NAV_ENABLED == ENABLED
     // @Group: CIRCLE_

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -152,7 +152,7 @@ def generate_DMAMUX_map_mask(peripheral_list, channel_mask, noshare_list, dma_ex
         base = idx % 16
         for i in range(16):
             found = None
-            for ii in range(base,16) + range(0,base):
+            for ii in list(range(base,16)) + list(range(0,base)):
                 if (1<<ii) & available == 0:
                     continue
 


### PR DESCRIPTION
Backporting the fix of #11769
This is needed to read the parameters correctly in QGroundControl