### PR TITLE
AP_Arming: allow bypassing compass healthy check when external navigation data is available for heading

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -456,11 +456,14 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     }
 
 #ifndef ALLOW_ARM_NO_COMPASS
-    const Compass &_compass = AP::compass();
-    // check compass health
-    if (!_compass.healthy()) {
-        check_failed(ARMING_CHECK_NONE, true, "Compass not healthy");
-        return false;
+    // if external source of heading is available, we can skip compass health check
+    if (!ahrs.is_ext_nav_used_for_yaw()) {
+        const Compass &_compass = AP::compass();
+        // check compass health
+        if (!_compass.healthy()) {
+            check_failed(ARMING_CHECK_NONE, true, "Compass not healthy");
+            return false;
+        }
     }
 #endif
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1821,5 +1821,17 @@ AP_AHRS_NavEKF &AP::ahrs_navekf()
     return static_cast<AP_AHRS_NavEKF&>(*AP_AHRS::get_singleton());
 }
 
+// check whether compass can be bypassed for arming check in case when external navigation data is available 
+bool AP_AHRS_NavEKF::is_ext_nav_used_for_yaw(void) const
+{
+    switch (active_EKF_type()) {
+    case EKF_TYPE2:
+        return EKF2.isExtNavUsedForYaw();
+        
+    default:
+        return false; 
+    }
+}
+
 #endif // AP_AHRS_NAVEKF_AVAILABLE
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -264,6 +264,9 @@ public:
 
     void Log_Write();
 
+    // check whether compass can be bypassed for arming check in case when external navigation data is available 
+    bool is_ext_nav_used_for_yaw(void) const;
+
 private:
     enum EKF_TYPE {EKF_TYPE_NONE=0,
                    EKF_TYPE3=3,

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1612,3 +1612,12 @@ void NavEKF2::writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, c
     }
 }
 
+// check if external navigation is being used for yaw observation
+bool NavEKF2::isExtNavUsedForYaw() const
+{
+    if (core) {
+        return core[primary].isExtNavUsedForYaw();
+    }
+    return false;
+}
+

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -352,6 +352,9 @@ public:
     // write EKF information to on-board logs
     void Log_Write();
 
+    // check if external navigation is being used for yaw observation
+    bool isExtNavUsedForYaw(void) const;
+
 private:
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -616,3 +616,9 @@ void NavEKF2_core::getOutputTrackingError(Vector3f &error) const
     error = outputTrackError;
 }
 
+// return true when external nav data is also being used as a yaw observation
+bool NavEKF2_core::isExtNavUsedForYaw()
+{
+    return extNavUsedForYaw;
+}
+

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -324,6 +324,9 @@ public:
     */
     void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms);
 
+    // return true when external nav data is also being used as a yaw observation
+    bool isExtNavUsedForYaw(void);
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;


### PR DESCRIPTION
**Problem**: an external source of heading (SLAM, mocap, vision etc.) can be used as yaw in place of the compass. As such, when compass is disabled and external navigation data is available, the arming check for compass health can be skipped completely. This PR provides a way to do this.

**Approach**:
`extNavUsedForYaw`, defined here:
https://github.com/ArduPilot/ardupilot/blob/bab31a2d61828e034a5e42440a0604f86b6b998b/libraries/AP_NavEKF2/AP_NavEKF2_core.h#L1124 seems to be the perfect candidate for the job. This variable will be set to `true` whenever the EKF core sees that external navigation data is available *and* compass is disabled.
https://github.com/ArduPilot/ardupilot/blob/634db441f885c8bff57bd98c02c2ce7c2896c1d8/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp#L317
Thus, we will check this variable of the primary EKF core. If `true`, we skip the compass health check completely. To facilitate this, we add functions to obtain the variable's value.

**Related**: issue and forum discussion:
- https://github.com/ArduPilot/ardupilot/issues/5454
- https://discuss.ardupilot.org/t/compass-not-healthy-preventing-arming-even-though-compasses-are-disabled-using-slam-instead/45011/9