### PR TITLE
HAL_ChibiOS: default OTG2 protocol to mavlink2 on most boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6/hwdef.dat
@@ -30,6 +30,9 @@ STM32_VDD 330U
 # order of UARTs (and USB)
 UART_ORDER OTG1 USART1 USART2 USART3 UART4 USART6 UART7 OTG2
 
+# default the 2nd interface to MAVLink2 until MissionPlanner updates drivers
+define HAL_OTG2_PROTOCOL SerialProtocol_MAVLink2
+
 define HAL_STORAGE_SIZE 16384
 
 define CONFIG_HAL_BOARD_SUBTYPE HAL_BOARD_SUBTYPE_CHIBIOS_FMUV5

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv5/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv5/hwdef.dat
@@ -35,6 +35,9 @@ env OPTIMIZE -O3
 # order of UARTs (and USB)
 UART_ORDER OTG1 USART1 USART2 USART3 UART4 USART6 UART7 OTG2
 
+# default the 2nd interface to MAVLink2 until MissionPlanner updates drivers
+define HAL_OTG2_PROTOCOL SerialProtocol_MAVLink2
+
 # now we define the pins that USB is connected on
 PA11 OTG_FS_DM OTG1
 PA12 OTG_FS_DP OTG1

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroF7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroF7/hwdef.dat
@@ -75,6 +75,9 @@ I2C_ORDER I2C1
 
 UART_ORDER OTG1 UART4 USART2 USART3 UART8 USART6 UART7 OTG2
 
+# default the 2nd interface to MAVLink2 until MissionPlanner updates drivers
+define HAL_OTG2_PROTOCOL SerialProtocol_MAVLink2
+
 # Another USART, this one for telem1. This one has RTS and CTS lines.
 # USART2 telem1
 PD3 USART2_CTS USART2

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoX21-777/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoX21-777/hwdef.dat
@@ -118,6 +118,9 @@ I2C_ORDER I2C1
 # order of UARTs (and USB)
 UART_ORDER OTG1 UART4 USART2 USART3 UART8 UART7 OTG2
 
+# default the 2nd interface to MAVLink2 until MissionPlanner updates drivers
+define HAL_OTG2_PROTOCOL SerialProtocol_MAVLink2
+
 # if the board has an IOMCU connected via a UART then this defines the
 # UART to talk to that MCU. Leave it out for boards with no IOMCU
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -957,7 +957,10 @@ def write_UART_config(f):
         f.write('#define HAL_OTG2_UART_INDEX %d\n' % OTG2_index)
         f.write('''
 #if HAL_WITH_UAVCAN
-#define HAL_SERIAL%d_PROTOCOL SerialProtocol_SLCAN
+#ifndef HAL_OTG2_PROTOCOL
+#define HAL_OTG2_PROTOCOL SerialProtocol_SLCAN
+#endif
+#define HAL_SERIAL%d_PROTOCOL HAL_OTG2_PROTOCOL
 #define HAL_SERIAL%d_BAUD 115200
 #endif
 ''' % (OTG2_index, OTG2_index))


### PR DESCRIPTION
For boards that haven't yet had a driver update in MissionPlanner to
cope with the 2nd OTG interface this change makes both interfaces work
as MAVLink

This also fixes an issue with connecting under a windows VM within
vmware