### PR TITLE
Send messages using MAV_FRAME_GLOBAL rather than MAV_FRAME_GLOBAL_INT

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -82,7 +82,7 @@ void GCS_MAVLINK_Rover::send_position_target_global_int()
     mavlink_msg_position_target_global_int_send(
         chan,
         AP_HAL::millis(), // time_boot_ms
-        MAV_FRAME_GLOBAL_INT, // targets are always global altitude
+        MAV_FRAME_GLOBAL, // targets are always global altitude
         0xFFF8, // ignore everything except the x/y/z components
         target.lat, // latitude as 1e7
         target.lng, // longitude as 1e7

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -96,7 +96,7 @@ void GCS_MAVLINK_Copter::send_position_target_global_int()
     mavlink_msg_position_target_global_int_send(
         chan,
         AP_HAL::millis(), // time_boot_ms
-        MAV_FRAME_GLOBAL_INT, // targets are always global altitude
+        MAV_FRAME_GLOBAL, // targets are always global altitude
         0xFFF8, // ignore everything except the x/y/z components
         target.lat, // latitude as 1e7
         target.lng, // longitude as 1e7

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -198,7 +198,7 @@ void GCS_MAVLINK_Plane::send_position_target_global_int()
     mavlink_msg_position_target_global_int_send(
         chan,
         AP_HAL::millis(), // time_boot_ms
-        MAV_FRAME_GLOBAL_INT, // targets are always global altitude
+        MAV_FRAME_GLOBAL, // targets are always global altitude
         0xFFF8, // ignore everything except the x/y/z components
         next_WP_loc.lat, // latitude as 1e7
         next_WP_loc.lng, // longitude as 1e7

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -756,7 +756,8 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_packet(const mavlink_command_in
         else if (packet.frame == MAV_FRAME_GLOBAL_TERRAIN_ALT_INT) {
             requested_position.terrain_alt = 1;
         }
-        else if (packet.frame != MAV_FRAME_GLOBAL_INT) {
+        else if (packet.frame != MAV_FRAME_GLOBAL_INT &&
+                 packet.frame != MAV_FRAME_GLOBAL) {
             // not a supported frame
             return MAV_RESULT_FAILED;
         }
@@ -1295,6 +1296,7 @@ void GCS_MAVLINK_Plane::handleMessage(const mavlink_message_t &msg)
             cmd.content.location.terrain_alt = false;
             switch (pos_target.coordinate_frame) 
             {
+                case MAV_FRAME_GLOBAL:
                 case MAV_FRAME_GLOBAL_INT:
                     break; //default to MSL altitude
                 case MAV_FRAME_GLOBAL_RELATIVE_ALT_INT:


### PR DESCRIPTION
Also accept messages using `MAV_FRAME_GLOBAL` where we were only accepting GLOBAL_INT

After this we shouldn't be sending anything in global_int frame.

We don't accept the `global_int` frame everywhere - but at least after this we accept `global` whereever we were only accepting `global_int`.
