### PR TITLE
AP_AccelCal: remove wrapper around send_text

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -19,6 +19,13 @@
 
 #define AP_ACCELCAL_POSITION_REQUEST_INTERVAL_MS 1000
 
+#define _printf(fmt, args ...) do {                                     \
+        if (_gcs != nullptr) {                                          \
+            _gcs->send_text(MAV_SEVERITY_CRITICAL, fmt, ## args);       \
+        }                                                               \
+    } while (0)
+
+
 const extern AP_HAL::HAL& hal;
 static bool _start_collect_sample;
 
@@ -374,29 +381,4 @@ bool AP_AccelCal::gcs_vehicle_position(float position)
     }
 
     return false;
-}
-
-void AP_AccelCal::_printf(const char* fmt, ...)
-{
-    if (!_gcs) {
-        return;
-    }
-    char msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
-    va_list ap;
-    va_start(ap, fmt);
-    hal.util->vsnprintf(msg, sizeof(msg), fmt, ap);
-    va_end(ap);
-
-    AP_HAL::UARTDriver *uart = _gcs->get_uart();
-    /*
-     *     to ensure these messages get to the user we need to wait for the
-     *     port send buffer to have enough room
-     */
-    while (uart->txspace() < MAVLINK_NUM_NON_PAYLOAD_BYTES+MAVLINK_MSG_ID_STATUSTEXT_LEN) {
-        hal.scheduler->delay(1);
-    }
-
-#if !APM_BUILD_TYPE(APM_BUILD_Replay)
-    _gcs->send_text(MAV_SEVERITY_CRITICAL, "%s", msg);
-#endif
 }

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -74,7 +74,6 @@ private:
     uint8_t _num_active_calibrators;
 
     AccelCalibrator* get_calibrator(uint8_t i);
-    void _printf(const char*, ...);
 };
 
 class AP_AccelCal_Client {


### PR DESCRIPTION
With our statustext queueing system this check is not just wrong but
redundant.


We still get the accel pose requests when flashed to a CubeBlack.
