### PR TITLE
Global: resolve gcs::send_text compiler warnings in 7 libraries

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -276,7 +276,7 @@ void AP_ADSB::update(void)
         }
         out_state.cfg.ICAO_id_param_prev = out_state.cfg.ICAO_id_param;
         set_callsign("PING", true);
-        gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", out_state.cfg.ICAO_id, out_state.cfg.callsign);
+        gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", (int)out_state.cfg.ICAO_id, out_state.cfg.callsign);
         out_state.last_config_ms = 0; // send now
     }
 
@@ -714,7 +714,7 @@ void AP_ADSB::handle_out_cfg(const mavlink_message_t &msg)
     // guard against string with non-null end char
     const char c = out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1];
     out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = 0;
-    gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", out_state.cfg.ICAO_id, out_state.cfg.callsign);
+    gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", (int)out_state.cfg.ICAO_id, out_state.cfg.callsign);
     out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = c;
 
     // send now

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -340,8 +340,8 @@ AP_GPS_SBF::process_message(void)
         check_new_itow(temp.TOW, sbf_msg.length);
         RxState = temp.RxState;
         if ((RxError & RX_ERROR_MASK) != (temp.RxError & RX_ERROR_MASK)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF error changed (0x%08x/0x%08x)", state.instance + 1,
-                            RxError & RX_ERROR_MASK, temp.RxError & RX_ERROR_MASK);
+            gcs().send_text(MAV_SEVERITY_INFO, "GPS %u: SBF error changed (0x%08x/0x%08x)", (unsigned int)(state.instance + 1),
+                            (unsigned int)(RxError & RX_ERROR_MASK), (unsigned int)(temp.RxError & RX_ERROR_MASK));
         }
         RxError = temp.RxError;
         break;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1380,8 +1380,8 @@ void
 AP_GPS_UBLOX::broadcast_configuration_failure_reason(void) const {
     for (uint8_t i = 0; i < ARRAY_SIZE(reasons); i++) {
         if (_unconfigured_messages & (1 << i)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: u-blox %s configuration 0x%02x",
-                state.instance +1, reasons[i], _unconfigured_messages);
+            gcs().send_text(MAV_SEVERITY_INFO, "GPS %u: u-blox %s configuration 0x%02x",
+                (unsigned int)(state.instance + 1), reasons[i], (unsigned int)_unconfigured_messages);
             break;
         }
     }

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -56,7 +56,7 @@ void AP_InertialSensor::BatchSampler::init()
     _required_count -= _required_count % 32; // round down to nearest multiple of 32
 
     const uint32_t total_allocation = 3*_required_count*sizeof(uint16_t);
-    gcs().send_text(MAV_SEVERITY_DEBUG, "INS: alloc %u bytes for ISB (free=%u)", total_allocation, hal.util->available_memory());
+    gcs().send_text(MAV_SEVERITY_DEBUG, "INS: alloc %u bytes for ISB (free=%u)", (unsigned int)total_allocation, (unsigned int)hal.util->available_memory());
 
     data_x = (int16_t*)calloc(_required_count, sizeof(int16_t));
     data_y = (int16_t*)calloc(_required_count, sizeof(int16_t));
@@ -68,7 +68,7 @@ void AP_InertialSensor::BatchSampler::init()
         data_x = nullptr;
         data_y = nullptr;
         data_z = nullptr;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to allocate %u bytes for IMU batch sampling", total_allocation);
+        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to allocate %u bytes for IMU batch sampling", (unsigned int)total_allocation);
         return;
     }
 

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -219,7 +219,7 @@ void AP_RSSI::check_pwm_pin_rssi()
         // failed to attach interrupt
         gcs().send_text(MAV_SEVERITY_WARNING,
                         "RSSI: Failed to attach to pin %u",
-                        rssi_analog_pin);
+                        (unsigned int)rssi_analog_pin);
         return;
     }
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
@@ -109,7 +109,7 @@ void AP_RangeFinder_PWM::check_pin()
         // failed to attach interrupt
         gcs().send_text(MAV_SEVERITY_WARNING,
                         "RangeFinder_PWM: Failed to attach to pin %u",
-                        params.pin);
+                        (unsigned int)params.pin);
         return;
     }
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -812,7 +812,7 @@ bool GCS_MAVLINK::set_mavlink_message_id_interval(const uint32_t mavlink_id,
 {
     const ap_message id = mavlink_id_to_ap_message_id(mavlink_id);
     if (id == MSG_LAST) {
-        gcs().send_text(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", mavlink_id);
+        gcs().send_text(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", (unsigned int)mavlink_id);
         return false;
     }
     return set_ap_message_interval(id, interval_ms);

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -791,7 +791,7 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
 #endif // HAL_MINIMIZE_FEATURES
 
     default:
-        gcs().send_text(MAV_SEVERITY_INFO, "Invalid channel option (%u)", ch_option);
+        gcs().send_text(MAV_SEVERITY_INFO, "Invalid channel option (%u)", (unsigned int)ch_option);
         break;
     }
 }


### PR DESCRIPTION
This PR resolves some slightly distracting compiler warnings.  The warnings that appeared for each are written below. I've tested that post these changes the warnings do not appear.

**AP_ADSB**
../../libraries/AP_ADSB/AP_ADSB.cpp: In member function 'void AP_ADSB::update()':
../../libraries/AP_ADSB/AP_ADSB.cpp:279:131: warning: format '%d' expects argument of type 'int', but argument 4 has type 'int32_t {aka long int}' [-Wformat=]
         gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", out_state.cfg.ICAO_id, out_state.cfg.callsign);
                                                                                                                                   ^
../../libraries/AP_ADSB/AP_ADSB.cpp: In member function 'void AP_ADSB::handle_out_cfg(const mavlink_message_t&)':
../../libraries/AP_ADSB/AP_ADSB.cpp:717:127: warning: format '%d' expects argument of type 'int', but argument 4 has type 'int32_t {aka long int}' [-Wformat=]
     gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", out_state.cfg.ICAO_id, out_state.cfg.callsign);
     
     
**GCS_MAVLink**
../../libraries/GCS_MAVLink/GCS_Common.cpp: In member function 'bool GCS_MAVLINK::set_mavlink_message_id_interval(uint32_t, uint16_t)':
../../libraries/GCS_MAVLink/GCS_Common.cpp:815:91: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
         gcs().send_text(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", mavlink_id);

**AP_GPS_SBP2**
[132/605] Compiling libraries/AP_GPS/AP_GPS_SBP2.cpp
../../libraries/AP_GPS/AP_GPS_SBF.cpp: In member function 'bool AP_GPS_SBF::process_message()':
../../libraries/AP_GPS/AP_GPS_SBF.cpp:344:82: warning: format '%x' expects argument of type 'unsigned int', but argument 5 has type 'long unsigned int' [-Wformat=]
                             RxError & RX_ERROR_MASK, temp.RxError & RX_ERROR_MASK);
                                                                                  ^
../../libraries/AP_GPS/AP_GPS_SBF.cpp:344:82: warning: format '%x' expects argument of type 'unsigned int', but argument 6 has type 'long unsigned int' [-Wformat=]

**AP_GPS_UBLOX**
../../libraries/AP_GPS/AP_GPS_UBLOX.cpp: In member function 'virtual void AP_GPS_UBLOX::broadcast_configuration_failure_reason() const':
../../libraries/AP_GPS/AP_GPS_UBLOX.cpp:1384:70: warning: format '%x' expects argument of type 'unsigned int', but argument 6 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
                 state.instance +1, reasons[i], _unconfigured_messages);
                                                                      ^
**AP_RSSI**
../../libraries/AP_RSSI/AP_RSSI.cpp: In member function 'void AP_RSSI::check_pwm_pin_rssi()':
../../libraries/AP_RSSI/AP_RSSI.cpp:222:40: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'AP_Int8 {aka AP_ParamT<signed char, (ap_var_type)1u>}' [-Wformat=]
                         rssi_analog_pin);
                                        ^

**AP_InertialSensor**
../../libraries/AP_InertialSensor/BatchSampler.cpp: In member function 'void AP_InertialSensor::BatchSampler::init()':
../../libraries/AP_InertialSensor/BatchSampler.cpp:59:128: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
     gcs().send_text(MAV_SEVERITY_DEBUG, "INS: alloc %u bytes for ISB (free=%u)", total_allocation, hal.util->available_memory());
                                                                                                                                ^
../../libraries/AP_InertialSensor/BatchSampler.cpp:59:128: warning: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
../../libraries/AP_InertialSensor/BatchSampler.cpp:71:117: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
         gcs().send_text(MAV_SEVERITY_WARNING, "Failed to allocate %u bytes for IMU batch sampling", total_allocation);
                                                                                                                     ^
**AP_RangeFinder**
libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
../../libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp: In member function 'void AP_RangeFinder_PWM::check_pin()':
../../libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp:112:35: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'AP_Int8 {aka AP_ParamT<signed char, (ap_var_type)1u>}' [-Wformat=]
                         params.pin);
                                   ^

**RC_Channel**
../../libraries/RC_Channel/RC_Channel.cpp: In member function 'virtual void RC_Channel::do_aux_function(RC_Channel::aux_func_t, RC_Channel::aux_switch_pos_t)':
../../libraries/RC_Channel/RC_Channel.cpp:794:84: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'RC_Channel::aux_func_t {aka RC_Channel::AUX_FUNC}' [-Wformat=]
         gcs().send_text(MAV_SEVERITY_INFO, "Invalid channel option (%u)", ch_option);
