### PR TITLE
Copter: Acro_Balance update

### DIFF
--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -124,15 +124,15 @@ void ModeAcro::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, 
         if (g.acro_trainer == ACRO_TRAINER_LIMITED) {
             const float angle_max = copter.aparm.angle_max;
             if (roll_angle > angle_max){
-                rate_ef_level.x -=  g.acro_balance_roll*(roll_angle-angle_max);
+                rate_ef_level.x +=  AC_AttitudeControl::sqrt_controller(angle_max - roll_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_roll_max(), G_Dt);
             }else if (roll_angle < -angle_max) {
-                rate_ef_level.x -=  g.acro_balance_roll*(roll_angle+angle_max);
+                rate_ef_level.x +=  AC_AttitudeControl::sqrt_controller(-angle_max - roll_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_roll_max(), G_Dt);
             }
 
             if (pitch_angle > angle_max){
-                rate_ef_level.y -=  g.acro_balance_pitch*(pitch_angle-angle_max);
+                rate_ef_level.y +=  AC_AttitudeControl::sqrt_controller(angle_max - pitch_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_pitch_max(), G_Dt);
             }else if (pitch_angle < -angle_max) {
-                rate_ef_level.y -=  g.acro_balance_pitch*(pitch_angle+angle_max);
+                rate_ef_level.y +=  AC_AttitudeControl::sqrt_controller(-angle_max - pitch_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_pitch_max(), G_Dt);
             }
         }
 

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -54,15 +54,15 @@ void ModeSport::run()
 
     const float angle_max = copter.aparm.angle_max;
     if (roll_angle > angle_max){
-        target_roll_rate -=  g.acro_rp_p*(roll_angle-angle_max);
+        target_roll_rate +=  AC_AttitudeControl::sqrt_controller(angle_max - roll_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_roll_max(), G_Dt);
     }else if (roll_angle < -angle_max) {
-        target_roll_rate -=  g.acro_rp_p*(roll_angle+angle_max);
+        target_roll_rate +=  AC_AttitudeControl::sqrt_controller(-angle_max - roll_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_roll_max(), G_Dt);
     }
 
     if (pitch_angle > angle_max){
-        target_pitch_rate -=  g.acro_rp_p*(pitch_angle-angle_max);
+        target_pitch_rate +=  AC_AttitudeControl::sqrt_controller(angle_max - pitch_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_pitch_max(), G_Dt);
     }else if (pitch_angle < -angle_max) {
-        target_pitch_rate -=  g.acro_rp_p*(pitch_angle+angle_max);
+        target_pitch_rate +=  AC_AttitudeControl::sqrt_controller(-angle_max - pitch_angle, g.acro_rp_p * 4.5, attitude_control->get_accel_pitch_max(), G_Dt);
     }
 
     // get pilot's desired yaw rate


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/issues/11888

Is your feature request related to a problem? Please describe.
I would like to be able to use only the angle limiting option of ACRO_TRAINER, so it works the same as Acro Trainer in Betaflight. In this mode, no self-leveling would occur and the copter would not lean further than ANGLE_MAX.

Describe the solution you'd like
I would like to split self leveling rate and angle limiting rate parameters, so I can set one of them to zero. It would bring consistency between Acro mode and Sport mode, too.

In Acro mode, around mode_acro.cpp#L124 you use acro_balance_roll and acro_balance_pitch for both angle limiting and self leveling.

On the other hand, in Sport mode (mode_sport.cpp#L57), you use acro_balance_roll for self-leveling and acro_rp_p for angle limiting.

I propose you add two new parameters (for example acro_anglimit_rate_pitch and acro_anglimit_rate_roll) and use these consistently for both Acro mode and Sport mode.

Describe alternatives you've considered
I've studied the code and there is no way to get my desired behaviour without firmware modification.

This also adds an acceleration limited approach.