### PR TITLE
AP_RangeFinder: LightwareSerial driver handles invalid distances

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -20,6 +20,9 @@
 
 extern const AP_HAL::HAL& hal;
 
+#define LIGHTWARE_DIST_MAX_CM           10000
+#define LIGHTWARE_OUT_OF_RANGE_ADD_CM   100
+
 /* 
    The constructor also initialises the rangefinder. Note that this
    constructor is not called until detect() returns true, so we
@@ -54,18 +57,25 @@ bool AP_RangeFinder_LightWareSerial::get_reading(uint16_t &reading_cm)
         return false;
     }
 
+    float sum = 0;              // sum of all readings taken
+    uint16_t valid_count = 0;   // number of valid readings
+    uint16_t invalid_count = 0; // number of invalid readings
+
     // read any available lines from the lidar
-    float sum = 0;
-    uint16_t count = 0;
     int16_t nbytes = uart->available();
     while (nbytes-- > 0) {
         char c = uart->read();
         if (c == '\r') {
             linebuf[linebuf_len] = 0;
-            sum += (float)atof(linebuf);
-            count++;
+            const float dist = (float)atof(linebuf);
+            if (!is_negative(dist)) {
+                sum += dist;
+                valid_count++;
+            } else {
+                invalid_count++;
+            }
             linebuf_len = 0;
-        } else if (isdigit(c) || c == '.') {
+        } else if (isdigit(c) || c == '.' || c == '-') {
             linebuf[linebuf_len++] = c;
             if (linebuf_len == sizeof(linebuf)) {
                 // too long, discard the line
@@ -87,11 +97,20 @@ bool AP_RangeFinder_LightWareSerial::get_reading(uint16_t &reading_cm)
         uart->write('d');
     }
 
-    if (count == 0) {
-        return false;
+    // return average of all valid readings
+    if (valid_count > 0) {
+        reading_cm = 100 * sum / valid_count;
+        return true;
     }
-    reading_cm = 100 * sum / count;
-    return true;
+
+    // all readings were invalid so return out-of-range-high value
+    if (invalid_count > 0) {
+        reading_cm = MIN(MAX(LIGHTWARE_DIST_MAX_CM, max_distance_cm() + LIGHTWARE_OUT_OF_RANGE_ADD_CM), UINT16_MAX);
+        return true;
+    }
+
+    // no readings so return false
+    return false;
 }
 
 /* 


### PR DESCRIPTION
The Lightware Serial driver returns -1 when it is unable to calculate a distance.  With master this results in the distance appearing as 1m.

This PR resolves the issue by enabling the driver to consume negative numbers and then, if they arrive, return a distance of RNGFNDx_MAX_CM + 100 (i.e. 1m beyond the maximum distance).  This is the same method of handling invalid readings as we have in the Benewake range finder drivers.

This has been tested on my LW20 serial lidar with Copter.
I discovered -1 was being returned using the Lightware Terminal application connected using AP's serial pass through and then pointing the vehicle's lidar up into the sky.