### PR TITLE
Fixed EKF height innovation gate on the ground

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -564,10 +564,17 @@ void NavEKF3_core::FuseVelPosNED()
             varInnovVelPos[5] = P[9][9] + R_OBS_DATA_CHECKS[5];
             // calculate the innovation consistency test ratio
             hgtTestRatio = sq(innovVelPos[5]) / (sq(MAX(0.01f * (float)frontend->_hgtInnovGate, 1.0f)) * varInnovVelPos[5]);
+
+            // when on ground we accept a larger test ratio to allow
+            // the filter to handle large switch on IMU bias errors
+            // without rejecting the height sensor
+            const float maxTestRatio = (PV_AidingMode == AID_NONE && onGround)? 3.0 : 1.0;
+
             // fail if the ratio is > 1, but don't fail if bad IMU data
-            hgtHealth = ((hgtTestRatio < 1.0f) || badIMUdata);
+            hgtHealth = ((hgtTestRatio < maxTestRatio) || badIMUdata);
+
             // Fuse height data if healthy or timed out or in constant position mode
-            if (hgtHealth || hgtTimeout || (PV_AidingMode == AID_NONE && onGround)) {
+            if (hgtHealth || hgtTimeout) {
                 // Calculate a filtered value to be used by pre-flight health checks
                 // We need to filter because wind gusts can generate significant baro noise and we want to be able to detect bias errors in the inertial solution
                 if (onGround) {


### PR DESCRIPTION
The height innovation gate when on the ground without GPS was unlimited, as the innovation limit check was skipped with AID_NONE and onGround.
This meant that a single extreme baro reading (due for example to a brief SPI bus error) could completely destabilise the filter as it fused in a value beyond what the EKF can cope with.
This change increases the test ratio limit to 3.0 from 1.0 when onGround with AIDING_NONE, which still gives us increased chance to fuse the baro without allowing the filter to destabilise.
Note that the value of 3.0 is pretty arbitrary. I'm hoping Paul can suggest a suitable value.
Fixes #11903 