### PR TITLE
Rover: resolve send_text compiler warnings

### DIFF
--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -68,7 +68,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
         control_mode != &mode_rtl &&
         control_mode != &mode_hold) {
         failsafe.triggered = failsafe.bits;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", static_cast<uint32_t>(failsafe.triggered));
+        gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", (unsigned int)failsafe.triggered);
 
         // clear rc overrides
         RC_Channels::clear_overrides();

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -583,13 +583,13 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
         if (loiter_duration > 0) {
             // send message including loiter time
             gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u. Loiter for %u seconds",
-                    static_cast<uint32_t>(cmd.index),
-                    static_cast<uint32_t>(loiter_duration));
+                            (unsigned int)cmd.index,
+                            (unsigned int)loiter_duration);
             // record the current time i.e. start timer
             loiter_start_time = millis();
         } else {
             // send simpler message to GCS
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u", static_cast<uint32_t>(cmd.index));
+            gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u", (unsigned int)cmd.index);
         }
     }
 

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -150,7 +150,7 @@ void Rover::read_rangefinders(void)
             }
             if (obstacle.detected_count == g.rangefinder_debounce) {
                 gcs().send_text(MAV_SEVERITY_INFO, "Rangefinder1 obstacle %u cm",
-                        static_cast<uint32_t>(obstacle.rangefinder1_distance_cm));
+                                (unsigned int)obstacle.rangefinder1_distance_cm);
             }
             obstacle.detected_time_ms = AP_HAL::millis();
             obstacle.turn_angle = g.rangefinder_turn_angle;
@@ -161,7 +161,7 @@ void Rover::read_rangefinders(void)
             }
             if (obstacle.detected_count == g.rangefinder_debounce) {
                 gcs().send_text(MAV_SEVERITY_INFO, "Rangefinder2 obstacle %u cm",
-                        static_cast<uint32_t>(obstacle.rangefinder2_distance_cm));
+                                (unsigned int)obstacle.rangefinder2_distance_cm);
             }
             obstacle.detected_time_ms = AP_HAL::millis();
             obstacle.turn_angle = -g.rangefinder_turn_angle;
@@ -177,7 +177,7 @@ void Rover::read_rangefinders(void)
             }
             if (obstacle.detected_count == g.rangefinder_debounce) {
                 gcs().send_text(MAV_SEVERITY_INFO, "Rangefinder obstacle %u cm",
-                        static_cast<uint32_t>(obstacle.rangefinder1_distance_cm));
+                                (unsigned int)obstacle.rangefinder1_distance_cm);
             }
             obstacle.detected_time_ms = AP_HAL::millis();
             obstacle.turn_angle = g.rangefinder_turn_angle;


### PR DESCRIPTION
Some more fixes to resolve compiler warnings when using send_text.  The exact messages that were appearing (now gone) are below.

../../APMrover2/failsafe.cpp: In member function 'void Rover::failsafe_trigger(uint8_t, bool)':
../../APMrover2/failsafe.cpp:71:113: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
         gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", static_cast<uint32_t>(failsafe.triggered));
                                                                                                                 ^

../../APMrover2/mode_auto.cpp: In member function 'bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command&)':
../../APMrover2/mode_auto.cpp:587:59: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
                     static_cast<uint32_t>(loiter_duration));
                                                           ^
../../APMrover2/mode_auto.cpp:587:59: warning: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
../../APMrover2/mode_auto.cpp:592:104: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
             gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u", static_cast<uint32_t>(cmd.index));
                                                                                                        ^

../../APMrover2/sensors.cpp: In member function 'void Rover::read_rangefinders()':
../../APMrover2/sensors.cpp:153:81: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
                         static_cast<uint32_t>(obstacle.rangefinder1_distance_cm));
                                                                                 ^
../../APMrover2/sensors.cpp:164:81: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
                         static_cast<uint32_t>(obstacle.rangefinder2_distance_cm));
                                                                                 ^
../../APMrover2/sensors.cpp:180:81: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
                         static_cast<uint32_t>(obstacle.rangefinder1_distance_cm));