### PR TITLE
small TECS improvements

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -985,7 +985,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     // if TECS_PITCH_{MAX,MIN} isn't set then use
     // LIM_PITCH_{MAX,MIN}. Don't allow TECS_PITCH_{MAX,MIN} to be
     // larger than LIM_PITCH_{MAX,MIN}
-    if (_pitch_max <= 0) {
+    if (_pitch_max == 0) {
         _PITCHmaxf = aparm.pitch_limit_max_cd * 0.01f;
     } else {
         _PITCHmaxf = MIN(_pitch_max, aparm.pitch_limit_max_cd * 0.01f);

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -241,6 +241,13 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
     AP_GROUPINFO("SYNAIRSPEED", 27, AP_TECS, _use_synthetic_airspeed, 0),
+
+    // @Param: OPTIONS
+    // @DisplayName: Extra TECS options
+    // @Description: This allows the enabling of special features in the speed/height controller
+    // @Bitmask: 0:GliderOnly
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 28, AP_TECS, _options, 0),
     
     AP_GROUPEND
 };
@@ -1082,7 +1089,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     _detect_bad_descent();
 
     // when soaring is active we never trigger a bad descent
-    if (soaring_active) {
+    if (soaring_active || (_options & OPTION_GLIDER_ONLY)) {
         _flags.badDescent = false;        
     }
 

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1125,10 +1125,12 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
         (double)_TAS_rate_dem,
         (double)logging.SKE_weighting,
         _flags_byte);
-    AP::logger().Write("TEC2", "TimeUS,KErr,PErr,EDelta,LF", "Qffff",
-                                           now,
-                                           (double)logging.SKE_error,
-                                           (double)logging.SPE_error,
-                                           (double)logging.SEB_delta,
-                                           (double)load_factor);
+    AP::logger().Write("TEC2", "TimeUS,KErr,PErr,EDelta,LF,PMax,PMin", "Qffffff",
+                       now,
+                       (double)logging.SKE_error,
+                       (double)logging.SPE_error,
+                       (double)logging.SEB_delta,
+                       (double)load_factor,
+                       (double)degrees(_PITCHmaxf),
+                       (double)degrees(_PITCHminf));
 }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -988,6 +988,9 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     }
     _THRminf  = aparm.throttle_min * 0.01f;
 
+    // min of 1% throttle range to prevent a numerical error
+    _THRmaxf = MAX(_THRmaxf, _THRminf+0.01);
+
     // work out the maximum and minimum pitch
     // if TECS_PITCH_{MAX,MIN} isn't set then use
     // LIM_PITCH_{MAX,MIN}. Don't allow TECS_PITCH_{MAX,MIN} to be

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1020,7 +1020,8 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 
         // and use max pitch from TECS_LAND_PMAX
         if (_land_pitch_max != 0) {
-            _PITCHmaxf = MIN(_PITCHmaxf, _land_pitch_max);
+            // note that this allows a flare pitch outside the normal TECS auto limits
+            _PITCHmaxf = _land_pitch_max;
         }
 
         // and allow zero throttle
@@ -1057,6 +1058,9 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     // convert to radians
     _PITCHmaxf = radians(_PITCHmaxf);
     _PITCHminf = radians(_PITCHminf);
+
+    // don't allow max pitch to go below min pitch
+    _PITCHmaxf = MAX(_PITCHmaxf, _PITCHminf);
 
     // initialise selected states and variables if DT > 1 second or in climbout
     _initialise_states(ptchMinCO_cd, hgt_afe);

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -166,6 +166,11 @@ private:
     AP_Int8  _pitch_min;
     AP_Int8  _land_pitch_max;
     AP_Float _maxSinkRate_approach;
+    AP_Int32 _options;
+
+    enum {
+        OPTION_GLIDER_ONLY=(1<<0),
+    };
 
     // temporary _pitch_max_limit. Cleared on each loop. Clear when >= 90
     int8_t _pitch_max_limit = 90;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -318,6 +318,8 @@ private:
 
     float _distance_beyond_land_wp;
 
+    float _land_pitch_min = -90;
+
     // internal variables to be logged
     struct {
         float SKE_weighting;


### PR DESCRIPTION
This is a set of small TECS improvements that came out of a large glider project

 - allow for negative TECS_PITCH_MAX (suitable for some gliders)
 - added a TECS_OPTIONS flag for gliders without any motor
 - prevent a numerical error if thr max is zero
 - fixed rapidly changing pitch limits on landing approach
