### PR TITLE
Plane: added rangefinder correction by terrain data

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -863,6 +863,7 @@ private:
     float lookahead_adjustment(void);
     float rangefinder_correction(void);
     void rangefinder_height_update(void);
+    void rangefinder_terrain_correction(float &height);
     void set_next_WP(const struct Location &loc);
     void set_guided_WP(void);
     void update_home();


### PR DESCRIPTION
allows for landing approach with terrain changes. This is useful for large planes where the landing approach may be over many hundreds of meters and the runway is on an area which isn't flat. 
