### PR TITLE
do not forward MAVLINK_MSG_ID_LANDING_TARGET

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -100,7 +100,7 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     // learn new routes
     learn_route(in_channel, msg);
 
-    if (msg->msgid == MAVLINK_MSG_ID_LANDING_TARGET) {
+    if (msg.msgid == MAVLINK_MSG_ID_LANDING_TARGET) {
         // don't forward LANDING_TARGET packets, just process locally
         return true;
     }

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -100,6 +100,11 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     // learn new routes
     learn_route(in_channel, msg);
 
+    if (msg->msgid == MAVLINK_MSG_ID_LANDING_TARGET) {
+        // don't forward LANDING_TARGET packets, just process locally
+        return true;
+    }
+
     if (msg.msgid == MAVLINK_MSG_ID_RADIO ||
         msg.msgid == MAVLINK_MSG_ID_RADIO_STATUS) {
         // don't forward RADIO packets


### PR DESCRIPTION
We precland from a companion computer which sends MAVLINK_MSG_ID_LANDING_TARGET messages over serial to the Pixhawk. We have had problems that during precland, the FC would then forward those messages to everywhere in the MAVLink network, causing telemetry issues. This commit solves this issue.