### PR TITLE
Copter: add support for BendyRuler and Dijkstra's object avoidance

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -13,6 +13,7 @@
 //#define PROXIMITY_ENABLED     DISABLED            // disable proximity sensors
 //#define AC_RALLY              DISABLED            // disable rally points library (must also disable terrain which relies on rally)
 //#define AC_AVOID_ENABLED      DISABLED            // disable stop-at-fence library
+//#define AC_OAPATHPLANNER_ENABLED DISABLED         // disable path planning around obstacles
 //#define AC_TERRAIN            DISABLED            // disable terrain library
 //#define PARACHUTE             DISABLED            // disable parachute release to save 1k of flash
 //#define NAV_GUIDED            DISABLED            // disable external navigation computer ability to control vehicle through MAV_CMD_NAV_GUIDED mission commands

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -55,7 +55,8 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
     return fence_checks(display_failure)
         & parameter_checks(display_failure)
         & motor_checks(display_failure)
-        & pilot_throttle_checks(display_failure) &
+        & pilot_throttle_checks(display_failure)
+        & oa_checks(display_failure) &
         AP_Arming::pre_arm_checks(display_failure);
 }
 
@@ -261,6 +262,25 @@ bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
     }
 
     return true;
+}
+
+bool AP_Arming_Copter::oa_checks(bool display_failure)
+{
+#if AC_OAPATHPLANNER_ENABLED == ENABLED
+    char failure_msg[50];
+    if (copter.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
+        return true;
+    }
+    // display failure
+    if (strlen(failure_msg) == 0) {
+        check_failed(ARMING_CHECK_NONE, display_failure, "%s", "Check Object Avoidance");
+    } else {
+        check_failed(ARMING_CHECK_NONE, display_failure, "%s", failure_msg);
+    }
+    return false;
+#else
+    return true;
+#endif
 }
 
 bool AP_Arming_Copter::rc_calibration_checks(bool display_failure)

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -45,6 +45,7 @@ protected:
     bool parameter_checks(bool display_failure);
     bool motor_checks(bool display_failure);
     bool pilot_throttle_checks(bool display_failure);
+    bool oa_checks(bool display_failure);
 
     void set_pre_arm_check(bool b);
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -97,6 +97,10 @@
 #if AC_AVOID_ENABLED == ENABLED
  #include <AC_Avoidance/AC_Avoid.h>
 #endif
+#if AC_OAPATHPLANNER_ENABLED == ENABLED
+ #include <AC_WPNav/AC_WPNav_OA.h>
+ #include <AC_Avoidance/AP_OAPathPlanner.h>
+#endif
 #if SPRAYER_ENABLED == ENABLED
  # include <AC_Sprayer/AC_Sprayer.h>
 #endif

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -270,12 +270,23 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
         // unused
         break;
 
-    case MSG_ADSB_VEHICLE:
+    case MSG_ADSB_VEHICLE: {
 #if ADSB_ENABLED == ENABLED
         CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);
         copter.adsb.send_adsb_vehicle(chan);
 #endif
+#if AC_OAPATHPLANNER_ENABLED == ENABLED
+        AP_OADatabase *oadb = AP_OADatabase::get_singleton();
+        if (oadb != nullptr) {
+            CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);
+            uint16_t interval_ms = 0;
+            if (get_ap_message_interval(id, interval_ms)) {
+                oadb->send_adsb_vehicle(chan, interval_ms);
+            }
+        }
+#endif
         break;
+    }
 
     default:
         return GCS_MAVLINK::try_send_message(id);

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -926,6 +926,12 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("TUNE_MAX", 32, ParametersG2, tuning_max, 0),
 
+#if AC_OAPATHPLANNER_ENABLED == ENABLED
+    // @Group: OA_
+    // @Path: ../libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+    AP_SUBGROUPINFO(oa, "OA_", 33, ParametersG2, AP_OAPathPlanner),
+#endif
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -596,6 +596,11 @@ public:
 
     AP_Float tuning_min;
     AP_Float tuning_max;
+
+#if AC_OAPATHPLANNER_ENABLED == ENABLED
+    // object avoidance path planning
+    AP_OAPathPlanner oa;
+#endif
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -677,6 +677,10 @@
  #define AC_AVOID_ENABLED   ENABLED
 #endif
 
+#ifndef AC_OAPATHPLANNER_ENABLED
+ #define AC_OAPATHPLANNER_ENABLED   !HAL_MINIMIZE_FEATURES
+#endif
+
 #if AC_AVOID_ENABLED && !PROXIMITY_ENABLED
   #error AC_Avoidance relies on PROXIMITY_ENABLED which is disabled
 #endif

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -36,10 +36,12 @@ public:
     virtual bool landing_gear_should_be_deployed() const { return false; }
     virtual bool is_landing() const { return false; }
 
+    // functions for reporting to GCS
     virtual bool get_wp(Location &loc) { return false; };
     virtual int32_t wp_bearing() const { return 0; }
     virtual uint32_t wp_distance() const { return 0; }
     virtual float crosstrack_error() const { return 0.0f;}
+
     void update_navigation();
 
     int32_t get_alt_above_ground_cm(void);
@@ -978,6 +980,9 @@ public:
     bool allows_arming(bool from_gcs) const override { return false; };
     bool is_autopilot() const override { return true; }
 
+    // for reporting to GCS
+    bool get_wp(Location &loc) override;
+
     RTLState state() { return _state; }
 
     // this should probably not be exposed
@@ -993,6 +998,7 @@ protected:
     const char *name() const override { return "RTL"; }
     const char *name4() const override { return "RTL "; }
 
+    // for reporting to GCS
     uint32_t wp_distance() const override;
     int32_t wp_bearing() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
@@ -1056,6 +1062,8 @@ protected:
     const char *name() const override { return "SMARTRTL"; }
     const char *name4() const override { return "SRTL"; }
 
+    // for reporting to GCS
+    bool get_wp(Location &loc) override;
     uint32_t wp_distance() const override;
     int32_t wp_bearing() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
@@ -1233,9 +1241,11 @@ protected:
 
     const char *name() const override { return "FOLLOW"; }
     const char *name4() const override { return "FOLL"; }
+
+    // for reporting to GCS
+    bool get_wp(Location &loc) override;
     uint32_t wp_distance() const override;
     int32_t wp_bearing() const override;
-    bool get_wp(Location &loc) override;
 
     uint32_t last_log_ms;   // system time of last time desired velocity was logging
 };

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -607,7 +607,9 @@ bool ModeAuto::get_wp(Location& destination)
     case Auto_NavGuided:
         return copter.mode_guided.get_wp(destination);
     case Auto_WP:
-        return wp_nav->get_wp_destination(destination);
+        return wp_nav->get_oa_wp_destination(destination);
+    case Auto_RTL:
+        return copter.mode_rtl.get_wp(destination);
     default:
         return false;
     }

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -209,7 +209,7 @@ bool ModeGuided::get_wp(Location& destination)
     if (guided_mode != Guided_WP) {
         return false;
     }
-    return wp_nav->get_wp_destination(destination);
+    return wp_nav->get_oa_wp_destination(destination);
 }
 
 // sets guided mode's target from a Location object

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -496,6 +496,24 @@ void ModeRTL::compute_return_target()
     rtl_path.return_target.alt = MAX(rtl_path.return_target.alt, curr_alt);
 }
 
+bool ModeRTL::get_wp(Location& destination)
+{
+    // provide target in states which use wp_nav
+    switch (_state) {
+    case RTL_Starting:
+    case RTL_InitialClimb:
+    case RTL_ReturnHome:
+    case RTL_LoiterAtHome:
+    case RTL_FinalDescent:
+        return wp_nav->get_oa_wp_destination(destination);
+    case RTL_Land:
+        return false;
+    }
+
+    // we should never get here but just in case
+    return false;
+}
+
 uint32_t ModeRTL::wp_distance() const
 {
     return wp_nav->get_wp_distance_to_destination();

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -149,6 +149,23 @@ void ModeSmartRTL::save_position()
     copter.g2.smart_rtl.update(copter.position_ok(), should_save_position);
 }
 
+bool ModeSmartRTL::get_wp(Location& destination)
+{
+    // provide target in states which use wp_nav
+    switch (smart_rtl_state) {
+    case SmartRTL_WaitForPathCleanup:
+    case SmartRTL_PathFollow:
+    case SmartRTL_PreLandPosition:
+    case SmartRTL_Descend:
+        return wp_nav->get_wp_destination(destination);
+    case SmartRTL_Land:
+        return false;
+    }
+
+    // we should never get here but just in case
+    return false;
+}
+
 uint32_t ModeSmartRTL::wp_distance() const
 {
     return wp_nav->get_wp_distance_to_destination();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -149,6 +149,10 @@ void Copter::init_ardupilot()
     wp_nav->set_terrain(&terrain);
 #endif
 
+#if AC_OAPATHPLANNER_ENABLED == ENABLED
+    g2.oa.init();
+#endif
+
     attitude_control->parameter_sanity_check();
     pos_control->set_dt(scheduler.get_loop_period_s());
 
@@ -550,7 +554,11 @@ void Copter::allocate_motors(void)
     }
     AP_Param::load_object_from_eeprom(pos_control, pos_control->var_info);
 
+#if AC_OAPATHPLANNER_ENABLED == ENABLED
+    wp_nav = new AC_WPNav_OA(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
+#else
     wp_nav = new AC_WPNav(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
+#endif
     if (wp_nav == nullptr) {
         AP_HAL::panic("Unable to allocate WPNav");
     }

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -47,6 +47,11 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         return DIJKSTRA_STATE_NOT_REQUIRED;
     }
 
+    // no avoidance required if destination is same as current location
+    if (current_loc.same_latlon_as(destination)) {
+        return DIJKSTRA_STATE_NOT_REQUIRED;
+    }
+
     // check for fence updates
     if (check_polygon_fence_updated()) {
         _polyfence_with_margin_ok = false;

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -88,6 +88,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     if (!_shortest_path_ok) {
         _shortest_path_ok = calc_shortest_path(current_loc, destination);
         if (!_shortest_path_ok) {
+            AP::logger().Write_OADijkstra(DIJKSTRA_STATE_ERROR, 0, 0, destination, destination);
             return DIJKSTRA_STATE_ERROR;
         }
         // start from 2nd point on path (first is the original origin)
@@ -126,9 +127,9 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         return DIJKSTRA_STATE_SUCCESS;
     }
 
-    // log failure
-    AP::logger().Write_OADijkstra(DIJKSTRA_STATE_ERROR, 0, 0, destination, destination);
-    return DIJKSTRA_STATE_ERROR;
+    // we have reached the destination so avoidance is no longer required
+    AP::logger().Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, destination, destination);
+    return DIJKSTRA_STATE_NOT_REQUIRED;
 }
 
 // returns true if polygon fence is enabled

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -271,8 +271,8 @@ void AP_OAPathPlanner::avoidance_thread()
             // give the main thread the avoidance result
             WITH_SEMAPHORE(_rsem);
             avoidance_result.destination = avoidance_request2.destination;
-            avoidance_result.origin_new = res ? origin_new : avoidance_result.origin_new;
-            avoidance_result.destination_new = res ? destination_new : avoidance_result.destination;
+            avoidance_result.origin_new = (res == OA_SUCCESS) ? origin_new : avoidance_result.origin_new;
+            avoidance_result.destination_new = (res == OA_SUCCESS) ? destination_new : avoidance_result.destination;
             avoidance_result.result_time_ms = AP_HAL::millis();
             avoidance_result.ret_state = res;
         }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -173,7 +173,8 @@ bool AC_WPNav::set_wp_destination(const Location& destination)
     return set_wp_destination(dest_neu, terr_alt);
 }
 
-bool AC_WPNav::get_wp_destination(Location& destination) {
+bool AC_WPNav::get_wp_destination(Location& destination) const
+{
     Vector3f dest = get_wp_destination();
     if (!AP::ahrs().get_origin(destination)) {
         return false;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -104,7 +104,7 @@ public:
     // returns wp location using location class.
     // returns false if unable to convert from target vector to global
     // coordinates
-    bool get_wp_destination(Location& destination);
+    bool get_wp_destination(Location& destination) const;
 
     /// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
     ///     terrain_alt should be true if destination.z is a desired altitude above terrain

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -106,6 +106,10 @@ public:
     // coordinates
     bool get_wp_destination(Location& destination) const;
 
+    // returns object avoidance adjusted destination which is always the same as get_wp_destination
+    // having this function unifies the AC_WPNav_OA and AC_WPNav interfaces making vehicle code simpler
+    virtual bool get_oa_wp_destination(Location& destination) const { return get_wp_destination(destination); }
+
     /// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
     ///     terrain_alt should be true if destination.z is a desired altitude above terrain
     bool set_wp_destination(const Vector3f& destination, bool terrain_alt = false);
@@ -116,7 +120,7 @@ public:
     /// set_wp_origin_and_destination - set origin and destination waypoints using position vectors (distance from ekf origin in cm)
     ///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if these are alt-above-ekf-origin)
     ///     returns false on failure (likely caused by missing terrain data)
-    bool set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt = false);
+    virtual bool set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt = false);
 
     /// shift_wp_origin_to_current_pos - shifts the origin and destination so the origin starts at the current position
     ///     used to reset the position just before takeoff
@@ -129,13 +133,13 @@ public:
     void get_wp_stopping_point(Vector3f& stopping_point) const;
 
     /// get_wp_distance_to_destination - get horizontal distance to destination in cm
-    float get_wp_distance_to_destination() const;
+    virtual float get_wp_distance_to_destination() const;
 
     /// get_bearing_to_destination - get bearing to next waypoint in centi-degrees
-    int32_t get_wp_bearing_to_destination() const;
+    virtual int32_t get_wp_bearing_to_destination() const;
 
     /// reached_destination - true when we have come within RADIUS cm of the waypoint
-    bool reached_wp_destination() const { return _flags.reached_destination; }
+    virtual bool reached_wp_destination() const { return _flags.reached_destination; }
 
     // reached_wp_destination_xy - true if within RADIUS_CM of waypoint in x/y
     bool reached_wp_destination_xy() const {
@@ -146,7 +150,7 @@ public:
     void set_fast_waypoint(bool fast) { _flags.fast_waypoint = fast; }
 
     /// update_wpnav - run the wp controller - should be called at 100hz or higher
-    bool update_wpnav();
+    virtual bool update_wpnav();
 
     // check_wp_leash_length - check recalc_wp_leash flag and calls calculate_wp_leash_length() if necessary
     //  should be called after _pos_control.update_xy_controller which may have changed the position controller leash lengths

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -1,0 +1,130 @@
+#include "AC_WPNav_OA.h"
+
+AC_WPNav_OA::AC_WPNav_OA(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control) :
+    AC_WPNav(inav, ahrs, pos_control, attitude_control)
+{
+}
+
+// returns object avoidance adjusted wp location using location class
+// returns false if unable to convert from target vector to global coordinates
+bool AC_WPNav_OA::get_oa_wp_destination(Location& destination) const
+{
+    // if oa inactive return unadjusted location
+    if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
+        return get_wp_destination(destination);
+    }
+
+    // return latest destination provided by oa path planner
+    destination = _oa_destination;
+    return true;
+}
+
+/// set_origin_and_destination - set origin and destination waypoints using position vectors (distance from home in cm)
+///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if these are alt-above-ekf-origin)
+///     returns false on failure (likely caused by missing terrain data)
+bool AC_WPNav_OA::set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt)
+{
+    const bool ret = AC_WPNav::set_wp_origin_and_destination(origin, destination, terrain_alt);
+
+    if (ret) {
+        // reset object avoidance state
+        _oa_state = AP_OAPathPlanner::OA_NOT_REQUIRED;
+    }
+
+    return ret;
+}
+
+/// get_wp_distance_to_destination - get horizontal distance to destination in cm
+/// always returns distance to final destination (i.e. does not use oa adjusted destination)
+float AC_WPNav_OA::get_wp_distance_to_destination() const
+{
+    if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
+        return AC_WPNav::get_wp_distance_to_destination();
+    }
+
+    // get current location
+    const Vector3f &curr = _inav.get_position();
+    return norm(_destination_oabak.x-curr.x, _destination_oabak.y-curr.y);
+}
+
+/// get_wp_bearing_to_destination - get bearing to next waypoint in centi-degrees
+/// always returns bearing to final destination (i.e. does not use oa adjusted destination)
+int32_t AC_WPNav_OA::get_wp_bearing_to_destination() const
+{
+    if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
+        return AC_WPNav::get_wp_bearing_to_destination();
+    }
+
+    return get_bearing_cd(_inav.get_position(), _destination_oabak);
+}
+
+/// true when we have come within RADIUS cm of the waypoint
+bool AC_WPNav_OA::reached_wp_destination() const
+{
+    return (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) && AC_WPNav::reached_wp_destination();
+}
+
+/// update_wpnav - run the wp controller - should be called at 100hz or higher
+bool AC_WPNav_OA::update_wpnav()
+{
+    // run path planning around obstacles
+    AP_OAPathPlanner *oa_ptr = AP_OAPathPlanner::get_singleton();
+    Location current_loc;
+    if ((oa_ptr != nullptr) && AP::ahrs().get_position(current_loc)) {
+
+        // backup _origin and _destination when not doing oa
+        if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
+            _origin_oabak = _origin;
+            _destination_oabak = _destination;
+        }
+
+        // convert origin and destination to Locations and pass into oa
+        const Location origin_loc(_origin_oabak);
+        const Location destination_loc(_destination_oabak);
+        Location oa_origin_new, oa_destination_new;
+        const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc, origin_loc, destination_loc, oa_origin_new, oa_destination_new);
+        switch (oa_retstate) {
+        case AP_OAPathPlanner::OA_NOT_REQUIRED:
+            if (_oa_state != oa_retstate) {
+                // object avoidance has become inactive so reset target to original destination
+                set_wp_destination(_destination_oabak, _terrain_alt);
+                _oa_state = oa_retstate;
+            }
+            break;
+        case AP_OAPathPlanner::OA_PROCESSING:
+        case AP_OAPathPlanner::OA_ERROR:
+            // during processing or in case of error stop the vehicle
+            // by setting the oa_destination to a stopping point
+            if ((_oa_state != AP_OAPathPlanner::OA_PROCESSING) && (_oa_state != AP_OAPathPlanner::OA_ERROR)) {
+                // calculate stopping point
+                Vector3f stopping_point;
+                get_wp_stopping_point(stopping_point);
+                _oa_destination = Location(stopping_point);
+                if (set_wp_destination(stopping_point, false)) {
+                    _oa_state = oa_retstate;
+                }
+            }
+            break;
+        case AP_OAPathPlanner::OA_SUCCESS:
+            // if oa destination has become active or destination has changed update wpnav
+            if ((_oa_state != AP_OAPathPlanner::OA_SUCCESS) || !oa_destination_new.same_latlon_as(_oa_destination)) {
+                _oa_destination = oa_destination_new;
+                // convert Location to offset from EKF origin
+                Vector3f dest_NEU;
+                if (_oa_destination.get_vector_from_origin_NEU(dest_NEU)) {
+                    // calculate target altitude by calculating OA adjusted destination's distance along the original track
+                    // and then linear interpolate using the original track's origin and destination altitude
+                    const float dist_along_path = constrain_float(oa_destination_new.line_path_proportion(origin_loc, destination_loc), 0.0f, 1.0f);
+                    dest_NEU.z = linear_interpolate(_origin_oabak.z, _destination_oabak.z, dist_along_path, 0.0f, 1.0f);
+                    if (set_wp_destination(dest_NEU, _terrain_alt)) {
+                        _oa_state = oa_retstate;
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    // run the non-OA update
+    return AC_WPNav::update_wpnav();
+}

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <AC_WPNav/AC_WPNav.h>
+#include <AC_Avoidance/AP_OAPathPlanner.h>
+
+class AC_WPNav_OA : public AC_WPNav
+{
+
+public:
+    /// Constructor
+    AC_WPNav_OA(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
+
+    // returns object avoidance adjusted wp location using location class
+    // returns false if unable to convert from target vector to global coordinates
+    bool get_oa_wp_destination(Location& destination) const override;
+
+    /// set origin and destination waypoints using position vectors (distance from ekf origin in cm)
+    ///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if these are alt-above-ekf-origin)
+    ///     returns false on failure (likely caused by missing terrain data)
+    bool set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt = false) override;
+
+    /// get horizontal distance to destination in cm
+    /// always returns distance to final destination (i.e. does not use oa adjusted destination)
+    float get_wp_distance_to_destination() const override;
+
+    /// get bearing to next waypoint in centi-degrees
+    /// always returns bearing to final destination (i.e. does not use oa adjusted destination)
+    int32_t get_wp_bearing_to_destination() const override;
+
+    /// true when we have come within RADIUS cm of the final destination
+    bool reached_wp_destination() const override;
+
+    /// run the wp controller
+    bool update_wpnav() override;
+
+protected:
+
+    // oa path planning variables
+    AP_OAPathPlanner::OA_RetState _oa_state;    // state of object avoidance, if OA_SUCCESS we use _oa_destination to avoid obstacles
+    Vector3f    _origin_oabak;          // backup of _origin so it can be restored when oa completes
+    Vector3f    _destination_oabak;     // backup of _destination so it can be restored when oa completes
+    Location    _oa_destination;        // intermediate destination during avoidance
+};


### PR DESCRIPTION
This is a replacement for PR https://github.com/ArduPilot/ardupilot/pull/11566

This PR adds support for Copter to use AC_Avoidance's BendyRuler and Dijkstra's path planning algorithms.  This has been successfully tested in SITL ([video](https://www.youtube.com/watch?v=GAmNaDTzy3Q)) and on a real vehicle.

There is one known issue but this is not serious enough that we need to resolve it before merging:

- the vehicle accelerates very slowly while BendyRuler is actively avoiding objects. Users could perhaps think this is on purpose to improve safety but I think that the real issue is caused by the path planning constantly changing the origin and destination.

EDIT: I think this is ready for merging now so any feedback from the likes of @peterbarker, @OXINARF or anyone else would be very welcome!