### PR TITLE
Rover: remove Dodge avoidance

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -169,41 +169,6 @@ const AP_Param::Info Rover::var_info[] = {
     // @User: Advanced
     GSCALAR(fs_ekf_thresh, "FS_EKF_THRESH", 0.8f),
 
-    // @Param: RNGFND_TRIGGR_CM
-    // @DisplayName: Object avoidance trigger distance
-    // @Description: The distance from an obstacle in centimeters at which the rangefinder triggers a turn to avoid the obstacle
-    // @Units: cm
-    // @Range: 0 1000
-    // @Increment: 1
-    // @User: Standard
-    GSCALAR(rangefinder_trigger_cm,   "RNGFND_TRIGGR_CM",    100),
-
-    // @Param: RNGFND_TURN_ANGL
-    // @DisplayName: Object avoidance turn aggressiveness and direction
-    // @Description: The aggressiveness and direction of turn to avoid an obstacle.  Large positive or negative values (i.e. -450 or 450) cause turns up to the vehicle's maximum lateral acceleration (TURN_MAX_G) while values near zero cause gentle turns. Positive means to turn right, negative means turn left.
-    // @Units: deg
-    // @Range: -450 450
-    // @Increment: 1
-    // @User: Standard
-    GSCALAR(rangefinder_turn_angle,   "RNGFND_TURN_ANGL",    45),
-
-    // @Param: RNGFND_TURN_TIME
-    // @DisplayName: Object avoidance turn time
-    // @Description: The amount of time in seconds to apply the RNGFND_TURN_ANGL after detecting an obstacle.
-    // @Units: s
-    // @Range: 0 100
-    // @Increment: 0.1
-    // @User: Standard
-    GSCALAR(rangefinder_turn_time,    "RNGFND_TURN_TIME",     1.0f),
-
-    // @Param: RNGFND_DEBOUNCE
-    // @DisplayName: Object avoidance rangefinder debounce count
-    // @Description: The number of 50Hz rangefinder hits needed to trigger an obstacle avoidance event. If you get a lot of false rangefinder events then raise this number, but if you make it too large then it will cause lag in detecting obstacles, which could cause you go hit the obstacle.
-    // @Range: 1 100
-    // @Increment: 1
-    // @User: Standard
-    GSCALAR(rangefinder_debounce,   "RNGFND_DEBOUNCE",    2),
-
     // @Param: MODE_CH
     // @DisplayName: Mode channel
     // @Description: RC Channel to use for driving mode control

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -149,11 +149,11 @@ public:
         // obstacle control
         k_param_sonar_enabled = 190,  // deprecated, can be removed
         k_param_sonar_old,            // unused
-        k_param_rangefinder_trigger_cm,
-        k_param_rangefinder_turn_angle,
-        k_param_rangefinder_turn_time,
+        k_param_rangefinder_trigger_cm, // unused
+        k_param_rangefinder_turn_angle, // unused
+        k_param_rangefinder_turn_time,  // unused
         k_param_sonar2_old,           // unused
-        k_param_rangefinder_debounce,
+        k_param_rangefinder_debounce, // unused
         k_param_rangefinder,          // rangefinder object
 
         //
@@ -250,13 +250,6 @@ public:
     AP_Int8     fs_crash_check;
     AP_Int8     fs_ekf_action;
     AP_Float    fs_ekf_thresh;
-
-    // obstacle avoidance control
-    AP_Int16    rangefinder_trigger_cm;
-    AP_Float    rangefinder_turn_angle;
-    AP_Float    rangefinder_turn_time;
-    AP_Int8     rangefinder_debounce;
-
 
     // driving modes
     //

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -274,18 +274,6 @@ private:
     // true if we have a position estimate from AHRS
     bool have_position;
 
-    // obstacle detection information
-    struct {
-        // have we detected an obstacle?
-        uint8_t detected_count;
-        float turn_angle;
-        uint16_t rangefinder1_distance_cm;
-        uint16_t rangefinder2_distance_cm;
-
-        // time when we last detected an obstacle, in milliseconds
-        uint32_t detected_time_ms;
-    } obstacle;
-
     // range finder last update (used for DPTH logging)
     uint32_t rangefinder_last_reading_ms;
 
@@ -415,7 +403,6 @@ private:
     void Log_Write_Startup(uint8_t type);
     void Log_Write_Steering();
     void Log_Write_Throttle();
-    void Log_Write_Rangefinder();
     void Log_Write_RC(void);
     void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page);

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -408,13 +408,6 @@ void Mode::navigate_to_waypoint()
 // calculate steering output given a turn rate and speed
 void Mode::calc_steering_from_turn_rate(float turn_rate, float speed, bool reversed)
 {
-    // add obstacle avoidance response to lateral acceleration target
-    // ToDo: replace this type of object avoidance with path planning
-    if (!reversed) {
-        const float lat_accel_adj = (rover.obstacle.turn_angle / 45.0f) * g.turn_max_g;
-        turn_rate += attitude_control.get_turn_rate_from_lat_accel(lat_accel_adj, speed);
-    }
-
     // calculate and send final steering command to motor library
     const float steering_out = attitude_control.get_steering_out_rate(turn_rate,
                                                                       g2.motors.limit.steer_left,
@@ -428,12 +421,6 @@ void Mode::calc_steering_from_turn_rate(float turn_rate, float speed, bool rever
 */
 void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reversed)
 {
-    // add obstacle avoidance response to lateral acceleration target
-    // ToDo: replace this type of object avoidance with path planning
-    if (!reversed) {
-        lat_accel += (rover.obstacle.turn_angle / 45.0f) * g.turn_max_g;
-    }
-
     // constrain to max G force
     lat_accel = constrain_float(lat_accel, -g.turn_max_g * GRAVITY_MSS, g.turn_max_g * GRAVITY_MSS);
 


### PR DESCRIPTION
This removes the "Dodge" avoidance method ([documented here on the wiki](http://ardupilot.org/rover/docs/rover-object-avoidance.html)) now that we have the better performing BendyRuler OA Path Planning feature.

I think it's important that we get remove the old Dodge method for a few reasons:

- It never really worked very well.  It could be made to work for a very specific situation (i.e. one specific speed, objects of a particular size) after a lot of trial and error tuning but it would then fail if the situation was changed slightly (i.e. the WP_SPEED was increased)
- Removing it reduces user confusion re setup of object avoidance.  They will all be directed towards OA Path Planning which will be documented during the next beta testing period
- Removes the Rover specific range finder logging ("RGFD" message) leaving only the common "RFND" message logging
- Saves a little bit of memory and flash space although these aren't really issues on Rover

After merging, this issue can be closed: https://github.com/ArduPilot/ardupilot/issues/11946