### PR TITLE
AP_Motors: convert applicable generic swashplates to H3-120

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1348,6 +1348,26 @@ void Copter::convert_tradheli_parameters(void)
         for (uint8_t i=0; i<table_size; i++) {
             AP_Param::convert_old_parameter(&singleheli_conversion_info[i], 1.0f);
         }
+
+        // convert to known swash type for setups that match
+        AP_Int16 *swash_pos_1, *swash_pos_2, *swash_pos_3, *swash_phang, *swash_type;
+        char pname[17];
+        enum ap_var_type ptype;
+        snprintf(pname, sizeof(pname), "H_SW_H3_SV1_POS");
+        swash_pos_1 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW_H3_SV2_POS");
+        swash_pos_2 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW_H3_SV3_POS");
+        swash_pos_3 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW_H3_PHANG");
+        swash_phang = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW_TYPE");
+        swash_type = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        if (swash_pos_1->get() == -60 && swash_pos_2->get() == 60 && swash_pos_3->get() == 180 && swash_phang->get() == 0 && swash_type->get() == 0) {
+            snprintf(pname, sizeof(pname), "H_SW_TYPE");
+            AP_Param::set_default_by_name(pname, SwashPlateType::SWASHPLATE_TYPE_H3_120);
+        }
+
     } else if (g2.frame_class.get() == AP_Motors::MOTOR_FRAME_HELI_DUAL) {
         // dual heli conversion info
         const AP_Param::ConversionInfo dualheli_conversion_info[] = {
@@ -1368,6 +1388,42 @@ void Copter::convert_tradheli_parameters(void)
         for (uint8_t i=0; i<table_size; i++) {
             AP_Param::convert_old_parameter(&dualheli_conversion_info[i], 1.0f);
         }
+
+        // convert swashplate 1 to known swash type for setups that match
+        AP_Int16 *swash_pos_1, *swash_pos_2, *swash_pos_3, *swash_phang, *swash_type;
+        char pname[17];
+        enum ap_var_type ptype;
+        snprintf(pname, sizeof(pname), "H_SW1_H3_SV1_POS");
+        swash_pos_1 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW1_H3_SV2_POS");
+        swash_pos_2 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW1_H3_SV3_POS");
+        swash_pos_3 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW1_H3_PHANG");
+        swash_phang = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW1_TYPE");
+        swash_type = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        if (swash_pos_1->get() == -60 && swash_pos_2->get() == 60 && swash_pos_3->get() == 180 && swash_phang->get() == 0 && swash_type->get() == 0) {
+            snprintf(pname, sizeof(pname), "H_SW1_TYPE");
+            AP_Param::set_default_by_name(pname, SwashPlateType::SWASHPLATE_TYPE_H3_120);
+        }
+
+        // convert swashplate 2 to known swash type for setups that match
+        snprintf(pname, sizeof(pname), "H_SW2_H3_SV1_POS");
+        swash_pos_1 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW2_H3_SV2_POS");
+        swash_pos_2 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW2_H3_SV3_POS");
+        swash_pos_3 = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW2_H3_PHANG");
+        swash_phang = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        snprintf(pname, sizeof(pname), "H_SW2_TYPE");
+        swash_type = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        if (swash_pos_1->get() == -60 && swash_pos_2->get() == 60 && swash_pos_3->get() == 180 && swash_phang->get() == 0 && swash_type->get() == 0) {
+            snprintf(pname, sizeof(pname), "H_SW2_TYPE");
+            AP_Param::set_default_by_name(pname, SwashPlateType::SWASHPLATE_TYPE_H3_120);
+        }
+
     }
     const AP_Param::ConversionInfo allheli_conversion_info[] = {
         { Parameters::k_param_motors, 1280, AP_PARAM_INT16, "H_RSC_CRV_000" },
@@ -1381,5 +1437,6 @@ void Copter::convert_tradheli_parameters(void)
     for (uint8_t i=0; i<table_size; i++) {
         AP_Param::convert_old_parameter(&allheli_conversion_info[i], 0.1f);
     }
+
 }
 #endif

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1351,21 +1351,14 @@ void Copter::convert_tradheli_parameters(void)
 
         // convert to known swash type for setups that match
         AP_Int16 *swash_pos_1, *swash_pos_2, *swash_pos_3, *swash_phang, *swash_type;
-        char pname[17];
         enum ap_var_type ptype;
-        snprintf(pname, sizeof(pname), "H_SW_H3_SV1_POS");
-        swash_pos_1 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW_H3_SV2_POS");
-        swash_pos_2 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW_H3_SV3_POS");
-        swash_pos_3 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW_H3_PHANG");
-        swash_phang = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW_TYPE");
-        swash_type = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        swash_pos_1 = (AP_Int16 *)AP_Param::find("H_SW_H3_SV1_POS", &ptype);
+        swash_pos_2 = (AP_Int16 *)AP_Param::find("H_SW_H3_SV2_POS", &ptype);
+        swash_pos_3 = (AP_Int16 *)AP_Param::find("H_SW_H3_SV3_POS", &ptype);
+        swash_phang = (AP_Int16 *)AP_Param::find("H_SW_H3_PHANG", &ptype);
+        swash_type = (AP_Int16 *)AP_Param::find("H_SW_TYPE", &ptype);
         if (swash_pos_1->get() == -60 && swash_pos_2->get() == 60 && swash_pos_3->get() == 180 && swash_phang->get() == 0 && swash_type->get() == 0) {
-            snprintf(pname, sizeof(pname), "H_SW_TYPE");
-            AP_Param::set_default_by_name(pname, SwashPlateType::SWASHPLATE_TYPE_H3_120);
+            AP_Param::set_default_by_name("H_SW_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3_120);
         }
 
     } else if (g2.frame_class.get() == AP_Motors::MOTOR_FRAME_HELI_DUAL) {
@@ -1391,37 +1384,24 @@ void Copter::convert_tradheli_parameters(void)
 
         // convert swashplate 1 to known swash type for setups that match
         AP_Int16 *swash_pos_1, *swash_pos_2, *swash_pos_3, *swash_phang, *swash_type;
-        char pname[17];
         enum ap_var_type ptype;
-        snprintf(pname, sizeof(pname), "H_SW1_H3_SV1_POS");
-        swash_pos_1 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW1_H3_SV2_POS");
-        swash_pos_2 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW1_H3_SV3_POS");
-        swash_pos_3 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW1_H3_PHANG");
-        swash_phang = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW1_TYPE");
-        swash_type = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        swash_pos_1 = (AP_Int16 *)AP_Param::find("H_SW1_H3_SV1_POS", &ptype);
+        swash_pos_2 = (AP_Int16 *)AP_Param::find("H_SW1_H3_SV2_POS", &ptype);
+        swash_pos_3 = (AP_Int16 *)AP_Param::find("H_SW1_H3_SV3_POS", &ptype);
+        swash_phang = (AP_Int16 *)AP_Param::find("H_SW1_H3_PHANG", &ptype);
+        swash_type = (AP_Int16 *)AP_Param::find("H_SW1_TYPE", &ptype);
         if (swash_pos_1->get() == -60 && swash_pos_2->get() == 60 && swash_pos_3->get() == 180 && swash_phang->get() == 0 && swash_type->get() == 0) {
-            snprintf(pname, sizeof(pname), "H_SW1_TYPE");
-            AP_Param::set_default_by_name(pname, SwashPlateType::SWASHPLATE_TYPE_H3_120);
+            AP_Param::set_default_by_name("H_SW1_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3_120);
         }
 
         // convert swashplate 2 to known swash type for setups that match
-        snprintf(pname, sizeof(pname), "H_SW2_H3_SV1_POS");
-        swash_pos_1 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW2_H3_SV2_POS");
-        swash_pos_2 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW2_H3_SV3_POS");
-        swash_pos_3 = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW2_H3_PHANG");
-        swash_phang = (AP_Int16 *)AP_Param::find(pname, &ptype);
-        snprintf(pname, sizeof(pname), "H_SW2_TYPE");
-        swash_type = (AP_Int16 *)AP_Param::find(pname, &ptype);
+        swash_pos_1 = (AP_Int16 *)AP_Param::find("H_SW2_H3_SV1_POS", &ptype);
+        swash_pos_2 = (AP_Int16 *)AP_Param::find("H_SW2_H3_SV2_POS", &ptype);
+        swash_pos_3 = (AP_Int16 *)AP_Param::find("H_SW2_H3_SV3_POS", &ptype);
+        swash_phang = (AP_Int16 *)AP_Param::find("H_SW2_H3_PHANG", &ptype);
+        swash_type = (AP_Int16 *)AP_Param::find("H_SW2_TYPE", &ptype);
         if (swash_pos_1->get() == -60 && swash_pos_2->get() == 60 && swash_pos_3->get() == 180 && swash_phang->get() == 0 && swash_type->get() == 0) {
-            snprintf(pname, sizeof(pname), "H_SW2_TYPE");
-            AP_Param::set_default_by_name(pname, SwashPlateType::SWASHPLATE_TYPE_H3_120);
+            AP_Param::set_default_by_name("H_SW2_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3_120);
         }
 
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     // @Description: H3 is generic, three-servo only. H3_120/H3_140 plates have Motor1 left side, Motor2 right side, Motor3 elevator in rear. HR3_120/HR3_140 have Motor1 right side, Motor2 left side, Motor3 elevator in front - use H3_120/H3_140 and reverse servo and collective directions as necessary. For all H3_90 swashplates use H4_90 and don't use servo output for the missing servo. For H4-90 Motors1&2 are left/right respectively, Motors3&4 are rear/front respectively. For H4-45 Motors1&2 are LF/RF, Motors3&4 are LR/RR 
     // @Values: 0:H3 Generic,1:H1 non-CPPM,2:H3_140,3:H3_120,4:H4_90,5:H4_45
     // @User: Standard
-    AP_GROUPINFO("TYPE", 1, AP_MotorsHeli_Swash, _swashplate_type, SWASHPLATE_TYPE_H3),
+    AP_GROUPINFO("TYPE", 1, AP_MotorsHeli_Swash, _swashplate_type, SWASHPLATE_TYPE_H3_120),
 
     // @Param: COL_DIR
     // @DisplayName: Collective Control Direction

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -25,7 +25,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Swashplate Type
     // @Description: H3 is generic, three-servo only. H3_120/H3_140 plates have Motor1 left side, Motor2 right side, Motor3 elevator in rear. HR3_120/HR3_140 have Motor1 right side, Motor2 left side, Motor3 elevator in front - use H3_120/H3_140 and reverse servo and collective directions as necessary. For all H3_90 swashplates use H4_90 and don't use servo output for the missing servo. For H4-90 Motors1&2 are left/right respectively, Motors3&4 are rear/front respectively. For H4-45 Motors1&2 are LF/RF, Motors3&4 are LR/RR 
-    // @Values: 0:H3 Generic, 1:H1 non-CPPM, 2:H3_140, 3:H3_120, 4:H4_90, 5:H4_45
+    // @Values: 0:H3 Generic,1:H1 non-CPPM,2:H3_140,3:H3_120,4:H4_90,5:H4_45
     // @User: Standard
     AP_GROUPINFO("TYPE", 1, AP_MotorsHeli_Swash, _swashplate_type, SWASHPLATE_TYPE_H3),
 


### PR DESCRIPTION
This PR automatically converts the swashplate type to the default H3-120 if the parameters meet the criteria for this swashplate type. Also the default swashplate type is set to H3-120 for new loads.   The conversion was functionally checked for all applicable heli frames.