### PR TITLE
Rover: notify users when WP_SPEED == 0

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -485,7 +485,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: RTL_SPEED
     // @DisplayName: Return-to-Launch speed default
-    // @Description: Return-to-Launch speed default.  If zero use WP_SPEED or CRUISE_SPEED.
+    // @Description: Return-to-Launch speed default.  If zero use WP_SPEED.
     // @Units: m/s
     // @Range: 0 100
     // @Increment: 0.1
@@ -681,7 +681,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
 // @Param: WP_SPEED
 // @DisplayName: Waypoint speed default
-// @Description: Waypoint speed default.  If zero use CRUISE_SPEED.
+// @Description: Waypoint speed default.
 // @Units: m/s
 // @Range: 0 100
 // @Increment: 0.1

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -46,6 +46,10 @@ bool Mode::enter()
 
         // clear sailboat tacking flags
         rover.g2.sailboat.clear_tack();
+
+        if (is_autopilot_mode() && !is_positive(g2.wp_nav.get_default_speed())) {
+            gcs().send_text(MAV_SEVERITY_NOTICE, "Bad desired speed, check param WP_SPEED.");
+        }
     }
 
     return ret;

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -257,6 +257,10 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     // update notify object
     notify_flight_mode();
 
+    if (flightmode->is_autopilot() && !is_positive(wp_nav->get_default_speed_xy())) {
+        gcs().send_text(MAV_SEVERITY_NOTICE, "Bad desired speed, check param WP_SPEED.");
+    }
+
     // return success
     return true;
 }

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -582,7 +582,7 @@ private:
     bool mode_requires_GPS(control_mode_t mode);
     bool mode_has_manual_throttle(control_mode_t mode);
     bool mode_allows_arming(control_mode_t mode, bool arming_from_gcs);
-    void notify_flight_mode(control_mode_t mode);
+    bool mode_is_autopilot(control_mode_t mode);
     void read_inertia();
     void update_surface_and_bottom_detector();
     void set_surfaced(bool at_surface);

--- a/ArduSub/flight_mode.cpp
+++ b/ArduSub/flight_mode.cpp
@@ -76,6 +76,10 @@ bool Sub::set_mode(control_mode_t mode, mode_reason_t reason)
         // update notify object
         AP_Notify::flags.autopilot_mode = mode_is_autopilot(control_mode);
 
+        if (mode_is_autopilot(control_mode) && !is_positive(wp_nav.get_default_speed_xy())) {
+            gcs().send_text(MAV_SEVERITY_NOTICE, "Bad desired speed, check param WP_SPEED.");
+        }
+
 #if CAMERA == ENABLED
         camera.set_is_auto_mode(control_mode == AUTO);
 #endif

--- a/ArduSub/flight_mode.cpp
+++ b/ArduSub/flight_mode.cpp
@@ -74,7 +74,7 @@ bool Sub::set_mode(control_mode_t mode, mode_reason_t reason)
         gcs().send_message(MSG_HEARTBEAT);
 
         // update notify object
-        notify_flight_mode(control_mode);
+        AP_Notify::flags.autopilot_mode = mode_is_autopilot(control_mode);
 
 #if CAMERA == ENABLED
         camera.set_is_auto_mode(control_mode == AUTO);
@@ -199,8 +199,8 @@ bool Sub::mode_allows_arming(control_mode_t mode, bool arming_from_gcs)
     );
 }
 
-// notify_flight_mode - sets notify object based on flight mode.  Only used for OreoLED notify device
-void Sub::notify_flight_mode(control_mode_t mode)
+// returns true when mode is an autopilot navigation mode
+bool Sub::mode_is_autopilot(control_mode_t mode)
 {
     switch (mode) {
     case AUTO:
@@ -208,11 +208,9 @@ void Sub::notify_flight_mode(control_mode_t mode)
     case CIRCLE:
     case SURFACE:
         // autopilot modes
-        AP_Notify::flags.autopilot_mode = true;
-        break;
+        return true;
     default:
         // all other are manual flight modes
-        AP_Notify::flags.autopilot_mode = false;
-        break;
+        return false;
     }
 }


### PR DESCRIPTION
Rover: regression fix: reinstate WP_SPEED == 0 means use CRUISE_SPEED which matches the [param description for Rover](http://ardupilot.org/rover/docs/parameters.html#wp-speed-waypoint-speed-default). 

Current behavior of WP_SPEED=0 means you don't move in AUTO mode unless the first command is a set speed.