### PR TITLE
AR_WPNav: add speed_min parameter

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -108,10 +108,14 @@ private:
     // returns true if vehicle should pivot immediately (because heading error is too large)
     bool use_pivot_steering(float yaw_error_cd);
 
+    // adjust speed to ensure it does not fall below value held in SPEED_MIN
+    void apply_speed_min(float &desired_speed);
+
 private:
 
     // parameters
     AP_Float _speed_max;            // target speed between waypoints in m/s
+    AP_Float _speed_min;            // target speed minimum in m/s.  Vehicle will not slow below this speed for corners
     AP_Float _radius;               // distance in meters from a waypoint when we consider the waypoint has been reached
     AP_Float _overshoot;            // maximum horizontal overshoot in meters
     AP_Int16 _pivot_angle;          // angle error that leads to pivot turn


### PR DESCRIPTION
This PR resolves this issue https://github.com/ArduPilot/ardupilot/issues/11194 by adding a new parameter called WP_SPEED_MIN that the user can set to the boat's plane speed.  If this new parameter value is left at it's default (0) then there is no change in behaviour from master.

Once this is done the target speed will not drop below this speed except in two situations:

- the vehicle is stopping
- the vehicle is planning to do a pivot turn at the next corner

Below are before and after screen shots of Desired Speed and Actual Speed from SITL of an Ackerman style steering vehicle when WP_SPEED_MIN = 3 (m/s):

![before-after-ackerman](https://user-images.githubusercontent.com/1498098/62435393-f969df80-b776-11e9-9535-2725567ad807.png)

Here's a screen shot of the mission which was just a simple square.  This mission was also tested on a skid-steering vehicle and there was no change in behaviour because the vehicle would pivot on each turn.
![speed-min-mission](https://user-images.githubusercontent.com/1498098/62435453-2d450500-b777-11e9-8fbf-fc9b4dac8e58.png)