### PR TITLE
AP_NavEKF3: shorten EKF3 initialisation send-text string

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -146,7 +146,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedOutput.init(imu_buffer_length)) {
         return false;
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u buffers, IMU=%u, OBS=%u, OF=%u, dt=%6.4f",
+    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u buffers IMU=%u OBS=%u OF=%u, dt=%.4f",
                     (unsigned)imu_index,
                     (unsigned)imu_buffer_length,
                     (unsigned)obs_buffer_length,


### PR DESCRIPTION
Now:
```
pbarker@bluebottle:~/rc/ardupilot(master)$ echo -n "EKF3 IMU1 buffers IMU=11 OBS=4 OF=10, dt=0.0120" | wc
      0       7      47
pbarker@bluebottle:~/rc/ardupilot(master)$
```

Closes #11952