### PR TITLE
AC_Avoidance: add OABR and OADJ log messages

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -17,6 +17,7 @@
 #include <AC_Avoidance/AP_OADatabase.h>
 #include <AC_Fence/AC_Fence.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Logger/AP_Logger.h>
 
 const int16_t OA_BENDYRULER_BEARING_INC = 5;            // check every 5 degrees around vehicle
 const float OA_BENDYRULER_LOOKAHEAD_STEP2_RATIO = 1.0f; // step2's lookahead length as a ratio of step1's lookahead length
@@ -116,7 +117,9 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
                         destination_new.offset_bearing(bearing_test, distance_to_dest);
                         _current_lookahead = MIN(_lookahead, _current_lookahead * 1.1f);
                         // if the chosen direction is directly towards the destination turn off avoidance
-                        return (i != 0 || j != 0);
+                        const bool active = (i != 0 || j != 0);
+                        AP::logger().Write_OABendyRuler(active, bearing_to_dest, margin, destination, destination_new);
+                        return active;
                     }
                 }
             }
@@ -139,6 +142,9 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
     // calculate new target based on best effort
     destination_new = current_loc;
     destination_new.offset_bearing(chosen_bearing, distance_to_dest);
+
+    // log results
+    AP::logger().Write_OABendyRuler(true, chosen_bearing, best_margin, destination, destination_new);
 
     return true;
 }

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -178,11 +178,6 @@ AP_OAPathPlanner::OA_RetState AP_OAPathPlanner::mission_avoidance(const Location
         // we have a result from the thread
         result_origin = avoidance_result.origin_new;
         result_destination = avoidance_result.destination_new;
-        // log result
-        if (avoidance_result.result_time_ms != _logged_time_ms) {
-            _logged_time_ms = avoidance_result.result_time_ms;
-            AP::logger().Write_OA(_type, destination, result_destination);
-        }
         return avoidance_result.ret_state;
     }
 

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -91,7 +91,6 @@ private:
     AP_OABendyRuler *_oabendyruler; // Bendy Ruler algorithm
     AP_OADijkstra *_oadijkstra;     // Dijkstra's algorithm
     AP_OADatabase _oadatabase;      // Database of dynamic objects to avoid
-    uint32_t _logged_time_ms;       // result_time_ms of last result logged (triggers logging of new results)
 #if !HAL_MINIMIZE_FEATURES
     uint32_t avoidance_latest_ms;   // last time Dijkstra's or BendyRuler algorithms ran
 #endif

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -273,7 +273,8 @@ public:
     void Write_Beacon(AP_Beacon &beacon);
     void Write_Proximity(AP_Proximity &proximity);
     void Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& point);
-    void Write_OA(uint8_t algorithm, const Location& final_dest, const Location& oa_dest);
+    void Write_OABendyRuler(bool active, float target_yaw, float margin, const Location &final_dest, const Location &oa_dest);
+    void Write_OADijkstra(uint8_t state, uint8_t curr_point, uint8_t tot_points, const Location &final_dest, const Location &oa_dest);
 
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -971,16 +971,35 @@ void AP_Logger::Write_SRTL(bool active, uint16_t num_points, uint16_t max_points
     WriteBlock(&pkt_srtl, sizeof(pkt_srtl));
 }
 
-void AP_Logger::Write_OA(uint8_t algorithm, const Location& final_dest, const Location& oa_dest)
+void AP_Logger::Write_OABendyRuler(bool active, float target_yaw, float margin, const Location &final_dest, const Location &oa_dest)
 {
-    struct log_OA pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_OA_MSG),
+    struct log_OABendyRuler pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_OA_BENDYRULER_MSG),
         time_us     : AP_HAL::micros64(),
-        algorithm   : algorithm,
+        active      : active,
+        target_yaw  : (uint16_t)wrap_360(target_yaw),
+        yaw         : (uint16_t)wrap_360(AP::ahrs().yaw_sensor * 0.01f),
+        margin      : margin,
         final_lat   : final_dest.lat,
         final_lng   : final_dest.lng,
         oa_lat      : oa_dest.lat,
-        oa_lng      : oa_dest.lng,
+        oa_lng      : oa_dest.lng
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}
+
+void AP_Logger::Write_OADijkstra(uint8_t state, uint8_t curr_point, uint8_t tot_points, const Location &final_dest, const Location &oa_dest)
+{
+    struct log_OADijkstra pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_OA_DIJKSTRA_MSG),
+        time_us     : AP_HAL::micros64(),
+        state       : state,
+        curr_point  : curr_point,
+        tot_points  : tot_points,
+        final_lat   : final_dest.lat,
+        final_lng   : final_dest.lng,
+        oa_lat      : oa_dest.lat,
+        oa_lng      : oa_dest.lng
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1130,10 +1130,25 @@ struct PACKED log_SRTL {
     float D;
 };
 
-struct PACKED log_OA {
+struct PACKED log_OABendyRuler {
     LOG_PACKET_HEADER;
     uint64_t time_us;
-    uint8_t algorithm;
+    uint8_t active;
+    uint16_t target_yaw;
+    uint16_t yaw;
+    float margin;
+    int32_t final_lat;
+    int32_t final_lng;
+    int32_t oa_lat;
+    int32_t oa_lng;
+};
+
+struct PACKED log_OADijkstra {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t state;
+    uint8_t curr_point;
+    uint8_t tot_points;
     int32_t final_lat;
     int32_t final_lng;
     int32_t oa_lat;
@@ -1353,8 +1368,10 @@ struct PACKED log_Arm_Disarm {
       "PM",  "QHHIIHIIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,IntErr,IntErrCnt,SPICnt,I2CCnt", "s---b%----", "F---0A----" }, \
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
       "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }, \
-    { LOG_OA_MSG, sizeof(log_OA), \
-      "OA","QBLLLL","TimeUS,Algo,DLat,DLng,OALat,OALng", "s-----", "F-GGGG" }
+    { LOG_OA_BENDYRULER_MSG, sizeof(log_OABendyRuler), \
+      "OABR","QBHHfLLLL","TimeUS,Active,DesYaw,Yaw,Mar,DLat,DLng,OALat,OALng", "sbddmDUDU", "F----GGGG" }, \
+    { LOG_OA_DIJKSTRA_MSG, sizeof(log_OADijkstra), \
+      "OADJ","QBBBLLLL","TimeUS,State,CurrPoint,TotPoints,DLat,DLng,OALat,OALng", "sbbbDUDU", "F---GGGG" }
 
 // messages for more advanced boards
 #define LOG_EXTRA_STRUCTURES \
@@ -1726,7 +1743,8 @@ enum LogMessages : uint8_t {
     LOG_ERROR_MSG,
     LOG_ADSB_MSG,
     LOG_ARM_DISARM_MSG,
-    LOG_OA_MSG,
+    LOG_OA_BENDYRULER_MSG,
+    LOG_OA_DIJKSTRA_MSG,
 
     _LOG_LAST_MSG_
 };


### PR DESCRIPTION
This PR resolves this issue https://github.com/ArduPilot/ardupilot/issues/11944 by improving the logging for AC_Avoidance's BendyRuler and Dijkstra's object avoidance path planning algorithms.

Instead of a general purpose "OA" logging message there are two, OABR and OADJ.  Both messages return the target Lat,Lon points (both original destination and object avoidance adjusted destination) but then include these extra bits tailored for each algorithm:

- BendyRuler essentially returns a safe direction so the DesiredYaw and ActualYaw is logged along with active/inactive status
![bendyruler-log](https://user-images.githubusercontent.com/1498098/62452390-099bb200-b7ab-11e9-9c06-06d47f07ff62.png)

- Dijkstra's produces a safe return path so the currently active path point number and the total number of points in the path are logged.  A status (inactive, active, error) is also logged.
![dijkstra-log](https://user-images.githubusercontent.com/1498098/62452397-0c96a280-b7ab-11e9-85a2-93a93ecfe50e.png)

