### PR TITLE
Move initialisation of compass location into Compass class itself

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -283,9 +283,6 @@ void Rover::one_second_loop(void)
         update_home();
     }
 
-    // init compass location for declination
-    init_compass_location();
-
     // update error mask of sensors and subsystems. The mask uses the
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
     // indicates that the sensor or subsystem is present but not

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -423,7 +423,6 @@ private:
     bool trim_radio();
 
     // sensors.cpp
-    void init_compass_location(void);
     void update_compass(void);
     void compass_save(void);
     void init_beacon();

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -3,21 +3,6 @@
 #include <AP_RangeFinder/RangeFinder_Backend.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
 
-/*
-  initialise compass's location used for declination
- */
-void Rover::init_compass_location(void)
-{
-    // update initial location used for declination
-    if (!compass_init_location) {
-        Location loc;
-        if (ahrs.get_position(loc)) {
-            compass.set_initial_location(loc.lat, loc.lng);
-            compass_init_location = true;
-        }
-    }
-}
-
 // check for new compass data - 10Hz
 void Rover::update_compass(void)
 {

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -97,9 +97,6 @@ void Tracker::one_second_loop()
     // updated armed/disarmed status LEDs
     update_armed_disarmed();
 
-    // init compass location for declination
-    init_compass_location();
-
     if (!ahrs.home_is_set()) {
         // set home to current location
         Location temp_loc;

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -248,7 +248,6 @@ private:
     // sensors.cpp
     void update_ahrs();
     void compass_save();
-    void init_compass_location();
     void update_compass(void);
     void accel_cal_update(void);
     void update_GPS(void);

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -9,21 +9,6 @@ void Tracker::update_ahrs()
 }
 
 /*
-  initialise compass's location used for declination
- */
-void Tracker::init_compass_location(void)
-{
-    // update initial location used for declination
-    if (!compass_init_location) {
-        Location loc;
-        if (ahrs.get_position(loc)) {
-            compass.set_initial_location(loc.lat, loc.lng);
-            compass_init_location = true;
-        }
-    }
-}
-
-/*
   read and update compass
  */
 void Tracker::update_compass(void)
@@ -84,11 +69,6 @@ void Tracker::update_GPS(void)
                 current_loc = gps.location();
                 if (!set_home(current_loc)) {
                     // silently ignored
-                }
-
-                if (AP::compass().enabled()) {
-                    // Set compass declination automatically
-                    compass.set_initial_location(gps.location().lat, gps.location().lng);
                 }
                 ground_start_count = 0;
             }

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -454,9 +454,6 @@ void Copter::one_hz_loop()
     // indicates that the sensor or subsystem is present but not
     // functioning correctly
     gcs().update_sensor_status_flags();
-
-    // init compass location for declination
-    init_compass_location();
 }
 
 // called at 50hz

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -825,7 +825,6 @@ private:
     void read_rangefinder(void);
     bool rangefinder_alt_ok();
     void rpm_update();
-    void init_compass_location();
     void init_optflow();
     void update_optical_flow(void);
     void compass_cal_update(void);

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -85,21 +85,6 @@ void Copter::rpm_update(void)
 #endif
 }
 
-/*
-  initialise compass's location used for declination
- */
-void Copter::init_compass_location()
-{
-    // update initial location used for declination
-    if (!ap.compass_init_location) {
-        Location loc;
-        if (ahrs.get_position(loc)) {
-            compass.set_initial_location(loc.lat, loc.lng);
-            ap.compass_init_location = true;
-        }
-    }
-}
-
 // initialise optical flow sensor
 void Copter::init_optflow()
 {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -379,11 +379,6 @@ void Plane::update_GPS_10Hz(void)
 
                 next_WP_loc = prev_WP_loc = home;
 
-                if (AP::compass().enabled()) {
-                    // Set compass declination automatically
-                    const Location &loc = gps.location();
-                    compass.set_initial_location(loc.lat, loc.lng);
-                }
                 ground_start_count = 0;
             }
         }

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -284,9 +284,6 @@ void Sub::one_hz_loop()
     // log terrain data
     terrain_logging();
 
-    // init compass location for declination
-    init_compass_location();
-
     // need to set "likely flying" when armed to allow for compass
     // learning to run
     ahrs.set_likely_flying(hal.util->get_soft_armed());

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -454,7 +454,6 @@ private:
     static const AP_Param::Info var_info[];
     static const struct LogStructure log_structure[];
 
-    void init_compass_location();
     void fast_loop();
     void fifty_hz_loop();
     void update_batt_compass(void);

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -80,21 +80,6 @@ void Sub::rpm_update(void)
 }
 #endif
 
-/*
-  initialise compass's location used for declination
- */
-void Sub::init_compass_location()
-{
-    // update initial location used for declination
-    if (!ap.compass_init_location) {
-        Location loc;
-        if (ahrs.get_position(loc)) {
-            compass.set_initial_location(loc.lat, loc.lng);
-            ap.compass_init_location = true;
-        }
-    }
-}
-
 // initialise optical flow sensor
 #if OPTFLOW == ENABLED
 void Sub::init_optflow()

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -644,7 +644,6 @@ void Replay::read_sensors(const char *type)
             if (!_vehicle.ahrs.set_home(loc)) {
                 ::printf("Failed to set home to that location!");
             }
-            _vehicle.compass.set_initial_location(loc.lat, loc.lng);
             done_home_init = true;
         }
     }

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -173,13 +173,6 @@ public:
 
     const Vector3f &get_offdiagonals(uint8_t i) const { return _state[i].offdiagonals; }
     const Vector3f &get_offdiagonals(void) const { return get_offdiagonals(get_primary()); }
-    
-    /// Sets the initial location used to get declination
-    ///
-    /// @param  latitude             GPS Latitude.
-    /// @param  longitude            GPS Longitude.
-    ///
-    void set_initial_location(int32_t latitude, int32_t longitude);
 
     // learn offsets accessor
     bool learn_offsets_enabled() const { return _learn == LEARN_INFLIGHT; }
@@ -482,6 +475,14 @@ private:
 
     CompassLearn *learn;
     bool learn_allocated;
+
+    /// Sets the initial location used to get declination
+    ///
+    /// @param  latitude             GPS Latitude.
+    /// @param  longitude            GPS Longitude.
+    ///
+    void try_set_initial_location();
+    bool _initial_location_set;
 };
 
 namespace AP {


### PR DESCRIPTION
The Compass class has access to the AHRS, so it can do the same checks each vehicle is  doing.

Tested with breakpoints in SITL.
