### PR TITLE
Rover: fix sailboat heel PID

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -551,8 +551,8 @@ float AR_AttitudeControl::get_desired_pitch() const
     return _pitch_to_throttle_pid.get_pid_info().target;
 }
 
-// Sailboat heel(roll) angle contorller release sail to keep at maximum heel angle
-// But do not atempt to reach maximum heel angle, ie only let sails off do not pull them in
+// Sailboat heel(roll) angle controller release sail to keep at maximum heel angle
+// But do not attempt to reach maximum heel angle, ie only let sails off do not pull them in
 float AR_AttitudeControl::get_sail_out_from_heel(float desired_heel, float dt)
 {
     // sanity check dt
@@ -576,15 +576,15 @@ float AR_AttitudeControl::get_sail_out_from_heel(float desired_heel, float dt)
 
     // get p
     float p = _sailboat_heel_pid.get_p();
-    // constrain p to only be positive
-    if (!is_positive(p)) {
+    // constrain p to only be negative
+    if (is_positive(p)) {
         p = 0.0f;
     }
 
     // get i
     float i = _sailboat_heel_pid.get_i();
-    // constrain i to only be positive, reset integrator if negative
-    if (!is_positive(i)) {
+    // constrain i to only be negative, reset integrator if negative
+    if (is_positive(i)) {
         i = 0.0f;
         _sailboat_heel_pid.reset_I();
     }
@@ -593,7 +593,7 @@ float AR_AttitudeControl::get_sail_out_from_heel(float desired_heel, float dt)
     const float d = _sailboat_heel_pid.get_d();
 
     // constrain and return final output
-    return (ff + p + i + d );
+    return (ff + p + i + d) * -1.0f;
 }
 
 // get forward speed in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -551,8 +551,8 @@ float AR_AttitudeControl::get_desired_pitch() const
     return _pitch_to_throttle_pid.get_pid_info().target;
 }
 
-// Sailboat heel(roll) angle controller release sail to keep at maximum heel angle
-// But do not attempt to reach maximum heel angle, ie only let sails off do not pull them in
+// Sailboat heel(roll) angle controller releases sail to keep at maximum heel angle
+// but does not attempt to reach maximum heel angle, ie only lets sails out, does not pull them in
 float AR_AttitudeControl::get_sail_out_from_heel(float desired_heel, float dt)
 {
     // sanity check dt
@@ -574,16 +574,14 @@ float AR_AttitudeControl::get_sail_out_from_heel(float desired_heel, float dt)
     // get feed-forward
     const float ff = _sailboat_heel_pid.get_ff();
 
-    // get p
+    // get p, constrain to be zero or negative
     float p = _sailboat_heel_pid.get_p();
-    // constrain p to only be negative
     if (is_positive(p)) {
         p = 0.0f;
     }
 
-    // get i
+    // get i, constrain to be zero or negative
     float i = _sailboat_heel_pid.get_i();
-    // constrain i to only be negative, reset integrator if negative
     if (is_positive(i)) {
         i = 0.0f;
         _sailboat_heel_pid.reset_I();


### PR DESCRIPTION
This Sailboat fix has been extracted from this existing PR https://github.com/ArduPilot/ardupilot/pull/11423 in order to get this very necessary fix for sailboats in more quickly.

The underlying issue appears to have crept in as part of @lthall's PR to add FLTx parameters: https://github.com/ArduPilot/ardupilot/pull/11673

I don't fully understand the fix but I have tested in SITL and it's very clear that master is broken because it is leaving the sail fully out always which means the vehicle gets stuck whenever it is trying to travel upwind.  Once this patch is applied the vehicle correctly pulls in the sail when travelling upwind.

Below are screen shots of the sail position (servo output 4) before and after.
![broken](https://user-images.githubusercontent.com/1498098/62525226-fd2e5c80-b871-11e9-8788-9353269e3b87.png)
![fixed](https://user-images.githubusercontent.com/1498098/62525232-ff90b680-b871-11e9-9789-8f62224f7e16.png)

