### PR TITLE
SITL: add wave and tide support for sailboats

### DIFF
--- a/libraries/SITL/SIM_Sailboat.h
+++ b/libraries/SITL/SIM_Sailboat.h
@@ -62,6 +62,8 @@ private:
 
     const float mass = 2.0f;
 
+    Vector3f velocity_ef_water; // m/s
+
     // simulate basic waves / swell
     void update_wave(float delta_time);
     Vector3f wave_gyro; // rad/s

--- a/libraries/SITL/SIM_Sailboat.h
+++ b/libraries/SITL/SIM_Sailboat.h
@@ -37,6 +37,7 @@ public:
         return new Sailboat(home_str, frame_str);
     }
 
+    bool on_ground() const override {return true;};
 private:
 
     // calculate the lift and drag as values from 0 to 1 given an apparent wind speed in m/s and angle-of-attack in degrees
@@ -60,6 +61,13 @@ private:
     const float drag_curve[18] = {0.10f, 0.10f, 0.20f, 0.40f, 0.80f, 1.20f, 1.50f, 1.70f, 1.90f, 1.95f,  1.90f,  1.70f,  1.50f,  1.20f,  0.80f,  0.40f,  0.20f,  0.10f};
 
     const float mass = 2.0f;
+
+    // simulate basic waves / swell
+    void update_wave(float delta_time);
+    Vector3f wave_gyro; // rad/s
+    float wave_heave; // m/s/s
+    float wave_phase; // rads
+
 };
 
 } // namespace SITL

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -170,12 +170,14 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
 
     AP_GROUPINFO("GPS_HDG",     43, SITL,  gps_hdg_enabled, 0),
 
-    // sailboat wave simulation parameters
+    // sailboat wave and tide simulation parameters
     AP_GROUPINFO("WAVE_ENABLE", 44, SITL,  wave.enable, 0.0f),
     AP_GROUPINFO("WAVE_LENGTH", 45, SITL,  wave.length, 10.0f),
     AP_GROUPINFO("WAVE_AMP",    46, SITL,  wave.amp, 0.5f),
     AP_GROUPINFO("WAVE_DIR",    47, SITL,  wave.direction, 0.0f),
     AP_GROUPINFO("WAVE_SPEED",  48, SITL,  wave.speed, 0.5f),
+    AP_GROUPINFO("TIDE_DIR",    49, SITL,  tide.direction, 0.0f),
+    AP_GROUPINFO("TIDE_SPEED",  50, SITL,  tide.speed, 0.0f),
 
     AP_GROUPEND
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -170,10 +170,17 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
 
     AP_GROUPINFO("GPS_HDG",     43, SITL,  gps_hdg_enabled, 0),
 
+    // sailboat wave simulation parameters
+    AP_GROUPINFO("WAVE_ENABLE", 44, SITL,  wave.enable, 0.0f),
+    AP_GROUPINFO("WAVE_LENGTH", 45, SITL,  wave.length, 10.0f),
+    AP_GROUPINFO("WAVE_AMP",    46, SITL,  wave.amp, 0.5f),
+    AP_GROUPINFO("WAVE_DIR",    47, SITL,  wave.direction, 0.0f),
+    AP_GROUPINFO("WAVE_SPEED",  48, SITL,  wave.speed, 0.5f),
+
     AP_GROUPEND
 
 };
-    
+
 
 /* report SITL state via MAVLink */
 void SITL::simstate_send(mavlink_channel_t chan)

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -263,6 +263,11 @@ public:
         AP_Float speed;     // m/s
     } wave;
 
+    struct {
+        AP_Float direction; // deg (direction tide is coming from)
+        AP_Float speed;     // m/s
+    } tide;
+
     uint16_t irlock_port;
 
     void simstate_send(mavlink_channel_t chan);

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -255,6 +255,14 @@ public:
 
     AP_Int8 gnd_behav;
 
+    struct {
+        AP_Int8 enable;     // 0: disabled, 1: roll and pitch, 2: roll, pitch and heave
+        AP_Float length;    // m
+        AP_Float amp;       // m
+        AP_Float direction; // deg (direction wave is coming from)
+        AP_Float speed;     // m/s
+    } wave;
+
     uint16_t irlock_port;
 
     void simstate_send(mavlink_channel_t chan);


### PR DESCRIPTION
This is a simplified version of this PR: https://github.com/ArduPilot/ardupilot/pull/11408 including just the wave and tide changes for Sailboat.

Below are some screen shots from SITL during testing of the wave features.  The roll and pitch of the vehicle are affected as we move parallel and perpendicular to the waves.

![waves-pitch](https://user-images.githubusercontent.com/1498098/62585251-da905800-b8f2-11e9-8245-5d6e053c3077.png)

![waves-roll](https://user-images.githubusercontent.com/1498098/62585248-d7956780-b8f2-11e9-8a66-eefc52f97b3f.png)

Below is a screen shot of how the SIM_TIDE_SPEED affects the speed of the vehicle.  Different directions were tested and the vehicle seem to speed up when moving with the tide, slow down when moving against the tide.
![tide-speed](https://user-images.githubusercontent.com/1498098/62585273-fd227100-b8f2-11e9-9769-e048ed2b4cbb.png)

