### PR TITLE
AP_Arming: resolve check_failed compiler warning

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -685,7 +685,7 @@ bool AP_Arming::system_checks(bool report)
         }
     }
     if (AP::internalerror().errors() != 0) {
-        check_failed(ARMING_CHECK_NONE, report, "Internal errors (0x%x)", AP::internalerror().errors());
+        check_failed(ARMING_CHECK_NONE, report, "Internal errors (0x%x)", (unsigned int)AP::internalerror().errors());
         return false;
     }
 


### PR DESCRIPTION
This resolve this compiler warning that was appearing:

[520/557] Compiling APMrover2/mode_manual.cpp
../../libraries/AP_Arming/AP_Arming.cpp: In member function 'virtual bool AP_Arming::system_checks(bool)':
../../libraries/AP_Arming/AP_Arming.cpp:688:103: warning: format '%x' expects argument of type 'unsigned int', but argument 5 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
         check_failed(ARMING_CHECK_NONE, report, "Internal errors (0x%x)", AP::internalerror().errors());