### PR TITLE
Rover: do not set_control_channels at all when armed

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -273,7 +273,7 @@ void Rover::one_second_loop(void)
     // allow orientation change at runtime to aid config
     ahrs.update_orientation();
 
-    set_control_channels();
+    update_control_channels();
 
     // cope with changes to aux functions
     SRV_Channels::enable_aux_servos();

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -366,6 +366,7 @@ private:
 
     // radio.cpp
     void set_control_channels(void);
+    void update_control_channels();
     void init_rc_in();
     void rudder_arm_disarm_check();
     void read_radio();

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -3,6 +3,16 @@
 /*
   allow for runtime change of control channel ordering
  */
+void Rover::update_control_channels()
+{
+    if (arming.is_armed()) {
+        // do nothing when armed.  Setting (e.g.) rcmap.roll to 76
+        // causes instant rover malfunction.
+        return;
+    }
+    set_control_channels();
+}
+
 void Rover::set_control_channels(void)
 {
     // check change on RCMAP
@@ -26,7 +36,8 @@ void Rover::set_control_channels(void)
         // For a rover safety is TRIM throttle
         g2.motors.setup_safety_output();
     }
-    // setup correct scaling for ESCs like the UAVCAN ESCs which
+
+    // setup correct scaling for ESCs like the UAVCAN PX4ESC which
     // take a proportion of speed. Default to 1000 to 2000 for systems without
     // a k_throttle output
     hal.rcout->set_esc_scaling(1000, 2000);

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -31,11 +31,9 @@ void Rover::set_control_channels(void)
     g2.sailboat.init_rc_in();
 
     // Allow to reconfigure output when not armed
-    if (!arming.is_armed()) {
-        g2.motors.setup_servo_output();
-        // For a rover safety is TRIM throttle
-        g2.motors.setup_safety_output();
-    }
+    g2.motors.setup_servo_output();
+    // For a rover safety is TRIM throttle
+    g2.motors.setup_safety_output();
 
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
     // take a proportion of speed. Default to 1000 to 2000 for systems without


### PR DESCRIPTION
Resetting these parameters while the vehicle is active can cause
null-pointer references in flight.

This limits it to only making changes when the vehicle is disarmed.