### PR TITLE
Plane: do not set_control_channels at all when armed

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -928,7 +928,7 @@ private:
     void update_fbwb_speed_height(void);
     void setup_turn_angle(void);
     bool reached_loiter_target(void);
-    void set_control_channels(void);
+    void set_control_channels(bool ignore_armed_state = false);
     void init_rc_in();
     void init_rc_out_main();
     void init_rc_out_aux();

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -6,8 +6,14 @@
 /*
   allow for runtime change of control channel ordering
  */
-void Plane::set_control_channels(void)
+void Plane::set_control_channels(const bool ignore_armed_status)
 {
+    if (!ignore_armed_status && (arming.is_armed() || arming.arming_required() == AP_Arming::Required::NO)) {
+        // do nothing when armed.  Setting (e.g.) rcmap.roll to 76
+        // causes instant plane death.
+        return;
+    }
+
     if (g.rudder_only) {
         // in rudder only mode the roll and rudder channels are the
         // same.
@@ -40,7 +46,7 @@ void Plane::set_control_channels(void)
         SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 100);
     }
 
-    if (!arming.is_armed() && arming.arming_required() == AP_Arming::Required::YES_MIN_PWM) {
+    if (arming.arming_required() == AP_Arming::Required::YES_MIN_PWM) {
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, have_reverse_thrust()?SRV_Channel::SRV_CHANNEL_LIMIT_TRIM:SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
     }
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -49,7 +49,9 @@ void Plane::init_ardupilot()
 
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
-    set_control_channels();
+    // tell set_control_channels to ignore armed state when doing this
+    // - in case ARMING_REQUIRE=0 or we've otherwise come up armed
+    set_control_channels(true);
 
     mavlink_system.sysid = g.sysid_this_mav;
 


### PR DESCRIPTION
Resetting these parameters while the vehicle is active can cause
null-pointer dereferences in flight.

This limits it to just being disarmed.

Functional change here is that if arming is not required then a reboot
will be required for changes to take effect.

This also fixes an issue where we might change the servo output options
in the case that arming.arming_required() ==
AP_Arming::Required::YES_PWM_ZERO