### PR TITLE
Rover: Add param FS_THR_TIMEOUT for tighter control of RC loss

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -603,6 +603,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AC_Avoidance/AP_OAPathPlanner.cpp
     AP_SUBGROUPINFO(oa, "OA_", 45, ParametersG2, AP_OAPathPlanner),
 
+    // @Param: FS_THR_TIMEOUT
+    // @DisplayName: Throttle Failsafe Timeout
+    // @Description: The throttle failsafe timeout time in seconds. If no RC update occurs for this amount of time then throttle and steering demands are set to zero but no other action is taken. If this condition continues for another FS_TIMEOUT then a throttle failsafe will occur. This is useful for system failures where the RC input disappears or your are controlled only by MAVLink commands.
+    // @Units: s
+    // @User: Standard
+    AP_GROUPINFO("FS_THR_TIMEOUT", 46, ParametersG2, fs_throttle_timeout, 0.5f),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -388,6 +388,8 @@ public:
 
     // object avoidance path planning
     AP_OAPathPlanner oa;
+
+    AP_Float    fs_throttle_timeout;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -129,7 +129,7 @@ void Rover::radio_failsafe_check(uint16_t pwm)
     }
 
     bool failed = pwm < static_cast<uint16_t>(g.fs_throttle_value);
-    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 500) {
+    if (is_positive(g2.fs_throttle_timeout) && AP_HAL::millis() - failsafe.last_valid_rc_ms > (uint32_t)(g2.fs_throttle_timeout * 1000)) {
         failed = true;
     }
     failsafe_trigger(FAILSAFE_EVENT_THROTTLE, failed);


### PR DESCRIPTION
Rover: Add param FS_THR_TIMEOUT for tighter control of RC loss