### PR TITLE
fix framerate SITL

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -580,6 +580,7 @@ def start_vehicle(binary, autotest, opts, stuff, loc):
     if opts.wipe_eeprom:
         cmd.append("-w")
     cmd.extend(["--model", stuff["model"]])
+    cmd.extend(["--rate", str(opts.framerate)])
     cmd.extend(["--speedup", str(opts.speedup)])
     if opts.sitl_instance_args:
         # this could be a lot better:

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -374,7 +374,6 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             printf("Creating model %s at speed %.1f\n", model_str, speedup);
             sitl_model = model_constructors[i].constructor(home_str, model_str);
             sitl_model->set_interface_ports(simulator_address, simulator_port_in, simulator_port_out);
-            sitl_model->set_speedup(speedup);
             sitl_model->set_instance(_instance);
             sitl_model->set_autotest_dir(autotest_dir);
             sitl_model->set_config(config);
@@ -413,6 +412,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         }
     }
 
+    sitl_model->set_rate_hz (_framerate);
+    sitl_model->set_speedup(speedup);
+            
     _sitl_setup(home_str);
 }
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -164,6 +164,10 @@ void Aircraft::set_precland(SIM_Precland *_precland) {
     precland->set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(get_home_yaw()));
 }
 
+void Aircraft::set_rate_hz(float _rate_hz) {
+    rate_hz = _rate_hz;
+}
+
 /*
    return current height above ground level (metres)
 */

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -81,6 +81,9 @@ public:
     // get frame rate of model in Hz
     float get_rate_hz(void) const { return rate_hz; }
 
+    // set frame rate of model in Hz
+    void set_rate_hz(float _rate_hz);
+
     const Vector3f &get_gyro(void) const {
         return gyro;
     }


### PR DESCRIPTION
framerate in SITL_cmdline.cpp is not linked to anything.
also rate_hz in Aircraft.cpp is hardcoded initialized. I assumed this is the same variable so I linked them together.
