### PR TITLE
Copter: Ensure ToshibaCAN ESCs shutdown when vehicle is disarmed

### DIFF
--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -309,7 +309,7 @@ void AP_ToshibaCAN::loop()
                     motor_reply_data1_t reply_data;
                     memcpy(reply_data.data, recv_frame.data, sizeof(reply_data.data));
                     // store response in telemetry array
-                    uint8_t esc_id = recv_frame.id - MOTOR_DATA1;
+                    const uint8_t esc_id = recv_frame.id - MOTOR_DATA1;
                     if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
                         WITH_SEMAPHORE(_telem_sem);
                         _telemetry[esc_id].rpm = be16toh(reply_data.rpm);
@@ -328,10 +328,10 @@ void AP_ToshibaCAN::loop()
                     //    10 bits: W temperature
                     //    10 bits: motor temperature
                     //    remaining 24 bits: reserved
-                    uint16_t u_temp = ((uint16_t)recv_frame.data[0] << 2) | ((uint16_t)recv_frame.data[1] >> 6);
-                    uint16_t v_temp = (((uint16_t)recv_frame.data[1] & (uint16_t)0x3F) << 4) | (((uint16_t)recv_frame.data[2] & (uint16_t)0xF0) >> 4);
-                    uint16_t w_temp = (((uint16_t)recv_frame.data[2] & (uint16_t)0x0F) << 6) | (((uint16_t)recv_frame.data[3] & (uint16_t)0xFC) >> 2);
-                    uint16_t temp_max = MAX(u_temp, MAX(v_temp, w_temp));
+                    const uint16_t u_temp = ((uint16_t)recv_frame.data[0] << 2) | ((uint16_t)recv_frame.data[1] >> 6);
+                    const uint16_t v_temp = (((uint16_t)recv_frame.data[1] & (uint16_t)0x3F) << 4) | (((uint16_t)recv_frame.data[2] & (uint16_t)0xF0) >> 4);
+                    const uint16_t w_temp = (((uint16_t)recv_frame.data[2] & (uint16_t)0x0F) << 6) | (((uint16_t)recv_frame.data[3] & (uint16_t)0xFC) >> 2);
+                    const uint16_t temp_max = MAX(u_temp, MAX(v_temp, w_temp));
 
                     // store repose in telemetry array
                     uint8_t esc_id = recv_frame.id - MOTOR_DATA2;
@@ -403,12 +403,11 @@ void AP_ToshibaCAN::update()
         WITH_SEMAPHORE(_rc_out_sem);
         const bool armed = hal.util->get_soft_armed();
         for (uint8_t i = 0; i < MIN(TOSHIBACAN_MAX_NUM_ESCS, 16); i++) {
-            SRV_Channel *c = SRV_Channels::srv_channel(i);
-            if (c == nullptr) {
+            const SRV_Channel *c = SRV_Channels::srv_channel(i);
             if (!armed || (c == nullptr)) {
                 _scaled_output[i] = 0;
             } else {
-                uint16_t pwm_out = c->get_output_pwm();
+                const uint16_t pwm_out = c->get_output_pwm();
                 if (pwm_out <= 1000) {
                     _scaled_output[i] = 0;
                 } else if (pwm_out >= 2000) {
@@ -427,7 +426,7 @@ void AP_ToshibaCAN::update()
         WITH_SEMAPHORE(_telem_sem);
 
         // log if any new data received.  Logging only supports up to 8 ESCs
-        uint64_t time_us = AP_HAL::micros64();
+        const uint64_t time_us = AP_HAL::micros64();
         for (uint8_t i = 0; i < MIN(TOSHIBACAN_MAX_NUM_ESCS, 8); i++) {
             if (_telemetry[i].new_data) {
                 logger->Write_ESC(i, time_us,

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -401,9 +401,11 @@ void AP_ToshibaCAN::update()
     // take semaphore and update outputs
     {
         WITH_SEMAPHORE(_rc_out_sem);
+        const bool armed = hal.util->get_soft_armed();
         for (uint8_t i = 0; i < MIN(TOSHIBACAN_MAX_NUM_ESCS, 16); i++) {
             SRV_Channel *c = SRV_Channels::srv_channel(i);
             if (c == nullptr) {
+            if (!armed || (c == nullptr)) {
                 _scaled_output[i] = 0;
             } else {
                 uint16_t pwm_out = c->get_output_pwm();


### PR DESCRIPTION
This PR improves the safety of using ToshibaCAN ESCs in two ways:

- specifically check the vehicle's armed state and if disarmed send a shutdown command to all ESCs
- add a pre-arm check to copter that the MOT_PWM_MIN = 1000, MOT_PWM_MAX = 2000

The second item is important because the ToshibaCAN ESC driver assumes that pwm output sent to the corresponding servo output will be in the range 1000 to 2000 when converting the pwm output to an RPM that the ESCs understand.

In master this means that (for multicopters) the MOT_PWM_MIN/MOT_PWM_MAX must be set to 1000 and 2000 respectively.  [This is specified on the wiki](http://ardupilot.org/copter/docs/common-toshiba-can-escs.html) but invariably even experienced users sometimes forget leading to a scary situation where the ESCS/motors spin-up (normally to a low speed) even if the vehicle is disarmed because we output 1100 when disarmed to keep regular ESCs from beeping.

This has not yet been tested on actual ESCs but will be in the coming days.