### PR TITLE
GCS_MAVLink: ensure payload space before sending message ack

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1946,8 +1946,14 @@ void GCS_MAVLINK::handle_set_mode(const mavlink_message_t &msg)
 
     const MAV_RESULT result = _set_mode_common(_base_mode, _custom_mode);
 
-    // send ACK or NAK
-    mavlink_msg_command_ack_send(chan, MAVLINK_MSG_ID_SET_MODE, result);
+    // send ACK or NAK.  Note that this is extraodinarily improper -
+    // we are sending a command-ack for a message which is not a
+    // command.  The command we are acking (ID=11) doesn't actually
+    // exist, but if it did we'd probably be acking something
+    // completely unrelated to setting modes.
+    if (HAVE_PAYLOAD_SPACE(chan, MAVLINK_MSG_ID_COMMAND_ACK)) {
+        mavlink_msg_command_ack_send(chan, MAVLINK_MSG_ID_SET_MODE, result);
+    }
 }
 
 /*


### PR DESCRIPTION
Also add comment about how we shouldn't be sending this message at all.

This message has been deprecated since late 2015, apparently.

There's at least one GCS out there that still uses it.
