### PR TITLE
Extract coverage analysis into shell script

### DIFF
--- a/Tools/scripts/run-coverage
+++ b/Tools/scripts/run-coverage
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# EXECUTE enough code via the autotest tool to see coverage results
+# afterwards, but don't build/rebuild anything our aim here is to try
+# to execute as many code path/s as we have available to us, and we'll
+# afterward report on the percentage of code executed and not executed
+# etc.
+
+export GCOV_ENABLED=1 # not sure this is required
+export CCFLAGS="$CCFLAGS -fprofile-arcs -ftest-coverage"
+export CXXFLAGS="$CXXFLAGS -fprofile-arcs -ftest-coverage"
+export LINKFLAGS="$LINKFLAGS -lgcov -coverage"
+
+# Run examples
+./waf configure --board=linux
+./waf examples
+./Tools/autotest/autotest.py run.examples
+
+# Run unit tests
+./Tools/autotest/autotest.py build.unit_tests run.unit_tests
+
+# Run main vehicle tests
+SPEEDUP=5
+TIMEOUT=14400
+
+OPTS="--speedup=$SPEEDUP --timeout=$TIMEOUT --debug --no-clean"
+
+./Tools/autotest/autotest.py $OPTS build.ArduPlane fly.ArduPlane fly.QuadPlane
+./Tools/autotest/autotest.py $OPTS build.ArduSub dive.ArduSub
+./Tools/autotest/autotest.py $OPTS build.ArduCopter fly.ArduCopter
+./Tools/autotest/autotest.py $OPTS build.Helicopter fly.CopterAVC
+./Tools/autotest/autotest.py $OPTS build.AntennaTracker test.AntennaTracker
+./Tools/autotest/autotest.py $OPTS build.APMrover2 drive.APMrover2
+
+#TODO add any other execution path/s we can to maximise the actually
+# used code, can we run other tests or things?  Replay, perhaps?
+
+REPORT_DIR="reports/lcov-report"
+rm -rf "$REPORT_DIR"
+mkdir -p "$REPORT_DIR"
+
+INFO_FILE="$REPORT_DIR/lcov.info"
+
+LCOV_LOG="GCOV_lcov.log"
+GENHTML_LOG="GCOV_genhtml.log"
+
+lcov --no-external --capture --directory $PWD -o "$INFO_FILE" 2>&1 | tee $LCOV_LOG
+lcov --remove "$INFO_FILE" ".waf*" -o "$INFO_FILE" 2>&1 | tee -a $LCOV_LOG
+
+genhtml "$INFO_FILE" -o "$REPORT_DIR" 2>&1 | tee $GENHTML_LOG
+
+echo "Coverage successful. Open $REPORT_DIR/index.html"

--- a/wscript
+++ b/wscript
@@ -205,113 +205,6 @@ configuration in order to save typing.
         default=False,
         help='Force a static build')
 
-    g.add_option("--enable-gcov",
-        help=("Enable gcov code coverage analysis."
-             " WARNING: this option only has effect "
-             "with the configure command. "
-             "You should also add --lcov-report to your build command."),
-        action="store_true", default=False,
-        dest="enable_gcov")
-
-    g.add_option("--lcov-report",
-        help=("Generates a lcov code coverage report "
-             "(use this option at build time, not in configure)"),
-        action="store_true", default=False,
-        dest="lcov_report")
-
-
-
-# EXECUTE enough code via the autotest tool to see coverage results afterwards, but don't build/rebuild anything
-# our aim here is to try to execute as many code path/s as we have available to us, and we'll afterward report
-# on the percentage of code executed and not executed etc.
-def	run_coverage_tests(bld):
-
-    FNULL = open(os.devnull, 'w')
-
-    #tests = ['fly.ArduPlane']
-    #tests = ['fly.ArduCopter','fly.ArduPlane']
-    #tests = ['fly.ArduCopter','fly.ArduPlane', 'fly.QuadPlane', 'drive.APMrover2', 'dive.ArduSub']
-    tests = ['build.examples','build.unit_tests','run.examples','run.unit_tests',
-             'fly.ArduCopter','fly.ArduPlane', 'fly.QuadPlane', 'drive.APMrover2', 'dive.ArduSub', 
-             'test.AntennaTracker', 'fly.CopterAVC' ]
-
-    for test in tests:
-        print("LCOV/GCOV -> "+test+" started.... this will take quite some time...")
-        testcmd = '( ./Tools/autotest/autotest.py --speedup=5 --timeout=14400 --debug --no-configure '+test+' ) '
-        print("Coverage Tests Executing:"+testcmd+" > ./GCOV_"+test+".log")
-        FLOG = open("./GCOV_"+test+".log", 'w')
-        if subprocess.Popen(testcmd, shell=True , stdout=FLOG, stderr=FNULL).wait():
-	        print("LCOV/GCOV -> "+test+" see ./GCOV_"+test+".log for log of activity)")
-	        raise SystemExit(1)
-        print("LCOV/GCOV -> "+test+" succeeded")
-        FLOG.close()
-
-    #TODO add any other execution path/s we can to maximise the actually used code, can we run other tests or things?
-    # eg run.unit_tests, run.examples , test.AntennaTracker or other things?
-
-
-def lcov_report(bld):
-    """
-    Generates the coverage report
-    :param bld: temporal options context
-    :type bld: wscript.tmp
-    """
-    env = bld.env
-    REPORTS = "reports"
-
-    if not env.GCOV_ENABLED:
-        raise WafError("project not configured for code coverage;"
-                       " reconfigure with --enable-gcov")
-
-    run_coverage_tests(bld)
-    lcov_report_dir = os.path.join(REPORTS, "lcov-report")
-    try:
-        if not os.path.exists(REPORTS):
-            os.mkdir(REPORTS)
-
-        create_dir_command = "rm -rf " + lcov_report_dir
-        create_dir_command += " && mkdir " + lcov_report_dir
-
-        print (create_dir_command );
-        if subprocess.Popen(create_dir_command, shell=True).wait():
-            raise SystemExit(1)
-
-        info_file = os.path.join(lcov_report_dir, "lcov.info")
-
-        FLOG = open("GCOV_lcov.log", 'w')
-        FNULL = open(os.devnull, 'w')
-
-        lcov_command =\
-            "lcov --no-external --capture --directory . -o " + info_file
-        lcov_command +=\
-            " && lcov --remove " + info_file + " \".waf*\" -o " + info_file
-
-        print("LCOV/GCOV executing lcov -> ")
-        print ("\t"+lcov_command + " > ./GCOV_lcov.log")
-        if subprocess.Popen(lcov_command, shell=True, stdout=FLOG, stderr=FNULL).wait():
-            raise SystemExit(1)
-        FLOG.close()
-
-
-        FLOG = open("GCOV_genhtml.log", 'w')
-        genhtml_command = "genhtml " + info_file
-        genhtml_command += " -o " + lcov_report_dir
-        print("LCOV/GCOV building html report -> ")
-        print ("\t"+genhtml_command + " > ./GCOV_genhtml.log")
-        if subprocess.Popen(genhtml_command, shell=True, stdout=FLOG, stderr=FNULL).wait():
-            raise SystemExit(1)
-        FLOG.close()
-
-    except:
-        print (\
-            "LCOV/GCOV -> Problems running coverage. Try manually" );
-
-    finally:
-        print (\
-            "LCOV/GCOV -> Coverage successful. Open " + lcov_report_dir +\
-            "/index.html" );
-
-
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():
         paths = []
@@ -332,10 +225,6 @@ def _collect_autoconfig_files(cfg):
 
 def configure(cfg):
 	# we need to enable debug mode when building for gconv, and force it to sitl
-    if cfg.options.enable_gcov:
-        cfg.options.debug = True
-        cfg.options.board = 'sitl'
-
     if cfg.options.board is None:
         cfg.options.board = 'sitl'
 
@@ -364,21 +253,6 @@ def configure(cfg):
     cfg.define('WAF_BUILD', 1)
 
     cfg.msg('Autoconfiguration', 'enabled' if cfg.options.autoconfig else 'disabled')
-
-    #Sets the lcov flag if is configurated
-    if cfg.options.enable_gcov:
-        cfg.start_msg("GCOV code coverage analysis")
-        cfg.env.GCOV_ENABLED = True
-        cfg.env.append_value('CCFLAGS', '-fprofile-arcs')
-        cfg.env.append_value('CCFLAGS', '-ftest-coverage')
-        cfg.env.append_value('CXXFLAGS', '-fprofile-arcs')
-        cfg.env.append_value('CXXFLAGS', '-ftest-coverage')
-        cfg.env.append_value('LINKFLAGS', '-lgcov')
-        cfg.env.append_value('LINKFLAGS', '-coverage')
-        cfg.end_msg('yes' , color='RED')
-    else:
-        cfg.start_msg("GCOV code coverage analysis")
-        cfg.end_msg('no' , color='GREEN')
 
     if cfg.options.static:
         cfg.msg('Using static linking', 'yes', color='YELLOW')


### PR DESCRIPTION
We broke coverage recently in waf and I took the opportunity to move it out to a separate shell script (after chatting with @davidbuzz briefly)

This has the small advantage that it stops a loop where waf is calling autotest is calling waf.
