### PR TITLE
 UR_Atmosphere: Added Aeronautics Atmosphere Calculations library. 

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -84,6 +84,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_RobotisServo',
     'AP_ToshibaCAN',
     'AP_NMEA_Output',
+    'UR_Atmosphere',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -182,7 +182,7 @@ AP_Baro *AP_Baro::_singleton;
 AP_Baro::AP_Baro()
 {
     _singleton = this;
-	_atm = UR_Atmosphere::get_instance();
+	_atm = UR_Atmosphere::get_singleton();
     AP_Param::setup_object_defaults(this, var_info);
 }
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -777,7 +777,7 @@ void AP_Baro::update(void)
                 sensors[i].ground_pressure = sensors[i].pressure;
             }
 
-            int alt_mode = _altcalc_mode;
+            int8_t alt_mode = _altcalc_mode;
             float altitude_am = 0;
             float corrected_pressure = sensors[i].pressure + sensors[i].p_correction;
             switch (alt_mode) {
@@ -788,7 +788,7 @@ void AP_Baro::update(void)
                 altitude_am = _atm->get_altitude_amsl();
                 break;
             default:
-                ;
+                break;
             }
 
             float altitude = sensors[i].altitude;

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -4,6 +4,7 @@
 #include <AP_Param/AP_Param.h>
 #include <Filter/Filter.h>
 #include <Filter/DerivativeFilter.h>
+#include <UR_Atmosphere/UR_Atmosphere.h>
 
 // maximum number of sensor instances
 #define BARO_MAX_INSTANCES 3
@@ -16,12 +17,16 @@
 #define BARO_TIMEOUT_MS                 500     // timeout in ms since last successful read
 #define BARO_DATA_CHANGE_TIMEOUT_MS     2000    // timeout in ms since last successful read that involved temperature of pressure changing
 
+using namespace ISA_MATH_CONST;
+
 class AP_Baro_Backend;
+class UR_Atmosphere;
 
 class AP_Baro
 {
     friend class AP_Baro_Backend;
     friend class AP_Baro_SITL; // for access to sensors[]
+    friend class UR_Atmosphere;
 
 public:
     AP_Baro();
@@ -254,6 +259,9 @@ private:
 
     // semaphore for API access from threads
     HAL_Semaphore_Recursive            _rsem;
+
+    UR_Atmosphere *_atm;
+    AP_Int8 _altcalc_mode;
 };
 
 namespace AP {

--- a/libraries/UR_Atmosphere/UR_Atmosphere.cpp
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.cpp
@@ -98,7 +98,7 @@ float UR_Atmosphere::calculate_altitude_difference(float base_pressure, float pr
 
 // Calculate QNH by hPa and feet by default.
 // [1] Meteorology Specification A2669 Version 4.00 Page 100
-float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp, altitude_unit_t alt_qnh_unit)
+float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp, altitude_unit_t alt_qnh_unit) const
 {
     uint8_t pQNHUnit = PRESSURE_UNIT::HECTO_PASCAL;
     uint8_t resultQNHUnit = PRESSURE_UNIT::HECTO_PASCAL;
@@ -153,11 +153,10 @@ float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp
 
 // Calculate QFE by hPa and feet by default.
 // [1] Meteorology Specification A2669 Version 4.00 Page 100
-float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp, altitude_unit_t alt_qfe_unit)
+float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp, altitude_unit_t alt_qfe_unit) const
 {
     uint8_t pQFEUnit = PRESSURE_UNIT::HECTO_PASCAL;
     uint8_t resultQFEUnit = PRESSURE_UNIT::HECTO_PASCAL;
-    float resultQFE = 0;
     float hQNH = 0;
     float pQNH = 0;
 
@@ -203,7 +202,7 @@ float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp
         break;
     }
 
-    resultQFE = alt_qfe;
+    const float resultQFE = alt_qfe;
     return resultQFE;
 }
 
@@ -212,12 +211,12 @@ void UR_Atmosphere::consume_updated(void)
     atm_status.updated = false;
 }
 
-float UR_Atmosphere::get_altitude_amsl()
+float UR_Atmosphere::get_altitude_amsl() const
 {
     return atm_status.altitude_amsl;
 }
 
-float UR_Atmosphere::get_qnh()
+float UR_Atmosphere::get_qnh() const
 {
     return atm_status.qnh_pressure;
 }

--- a/libraries/UR_Atmosphere/UR_Atmosphere.cpp
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.cpp
@@ -69,7 +69,7 @@ void UR_Atmosphere::update(uint8_t sensor)
 {
     if (!atm_status.updated) {
         atm_status.updated = true;
-        atm_status.altitude_amsl = calculate_altitude_difference(p0, _barometer->sensors[sensor].pressure, _barometer->sensors[sensor].temperature);
+        atm_status.altitude_amsl = calculate_altitude_difference(press0, _barometer->sensors[sensor].pressure, _barometer->sensors[sensor].temperature);
         atm_status.qnh_pressure = calculate_qnh(atm_status.altitude_amsl, (_barometer->sensors[sensor].pressure / 100), _barometer->sensors[sensor].temperature, ALTITUDE_UNIT::METER);
         atm_status.qfe_pressure = calculate_qfe(atm_status.altitude_amsl, atm_status.qnh_pressure, _barometer->sensors[sensor].temperature, ALTITUDE_UNIT::METER) * 100;
     }

--- a/libraries/UR_Atmosphere/UR_Atmosphere.cpp
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.cpp
@@ -79,7 +79,7 @@ void UR_Atmosphere::update(uint8_t sensor)
 float UR_Atmosphere::calculate_altitude_difference(float base_pressure, float pressure, float temp, altitude_unit_t alt_diff_unit) const
 {
     float result;
-    float tempcorrected  = T0 + temp - 15;
+    float tempcorrected  = Temp0 + temp - 15;
     float unit_result = 1;
 
     switch (alt_diff_unit) {
@@ -133,7 +133,7 @@ float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp
     }
 
     // Calculation(s)
-    pressure_qnh = p0hPa * powf(powf((pQFE / p0hPa), (-1 * (CRGasSI * dTdh0SI)) / CgSI) - (hQFE * dTdh0SI) / (T0 + temp - 15), (-1 * CgSI) / (CRGasSI * dTdh0SI));
+    pressure_qnh = p0hPa * powf(powf((pQFE / p0hPa), (-1 * (CRGasSI * dTdh0SI)) / CgSI) - (hQFE * dTdh0SI) / (Temp0 + temp - 15), (-1 * CgSI) / (CRGasSI * dTdh0SI));
 
     // Unit Conversion(s)
     switch (resultQNHUnit) {
@@ -189,7 +189,7 @@ float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp
     }
 
     // Calculations
-    alt_qfe = p0hPa * powf(powf((pQNH / p0hPa), (-1 * (CRGasSI * dTdh0SI)) / CgSI) + ((hQNH * dTdh0SI) / (T0 + temp - 15)), (-1 * CgSI) / (CRGasSI * dTdh0SI));
+    alt_qfe = p0hPa * powf(powf((pQNH / p0hPa), (-1 * (CRGasSI * dTdh0SI)) / CgSI) + ((hQNH * dTdh0SI) / (Temp0 + temp - 15)), (-1 * CgSI) / (CRGasSI * dTdh0SI));
 
     // Unit Conversions
     switch (resultQFEUnit) {

--- a/libraries/UR_Atmosphere/UR_Atmosphere.cpp
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.cpp
@@ -1,0 +1,225 @@
+/*
+   Aeronautics Atmosphere Calculations.
+   Copyright (c) 2019 Hiroshi Takey <htakey@gmail.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+   UPDATE 05072019:
+
+   The improvements about QNH, QFE, Namespace ISA_MATH_CONST Definitions constants and
+   Altitude_difference calculations was based on the AviationCalculator 1.8.2 05/10/2017
+   revision application from Ph.D. Aerospace Engineering, Joachim K. Hochwarth (GE Principal
+   Engineer/System Architect), published on this URL:
+
+   http://www.hochwarth.com/misc/AviationCalculator.html
+   http://www.hochwarth.com/script/AviationCalculator.js
+
+   Thanks Hochwarth!
+
+   These functions was tested on the Encoder & Altimeter Benchtest Hardware and Application
+   development in cooperation and support with Fenix Aeronautics Academy under the supervision
+   and technical support with the FAA Licensed Fixed and Rotor Wing Aircraft Engineer
+   Maintenance Service, Rudy Averanga <raveranga@fenixaeronautica.com>.
+
+   Thanks a lot Rudy!
+*/
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Baro/AP_Baro.h>
+#include "UR_Atmosphere.h"
+
+extern const AP_HAL::HAL& hal;
+bool UR_Atmosphere::_initialized = false;
+UR_Atmosphere *UR_Atmosphere::_instance = nullptr;
+
+UR_Atmosphere::UR_Atmosphere()
+{
+    _barometer = AP_Baro::get_singleton();
+}
+
+void UR_Atmosphere::init(void)
+{
+    if (_initialized) {
+        return;
+    }
+
+    _initialized = true;
+    _instance = this;
+
+    if (!_barometer) {
+        _barometer = new AP_Baro;
+        _barometer->init();
+    }
+}
+
+void UR_Atmosphere::update(uint8_t sensor)
+{
+    if (!atm_status.updated) {
+        atm_status.updated = true;
+        atm_status.altitude_amsl = calculate_altitude_difference(p0, _barometer->sensors[sensor].pressure, _barometer->sensors[sensor].temperature);
+        atm_status.qnh_pressure = calculate_qnh(atm_status.altitude_amsl, (_barometer->sensors[sensor].pressure / 100), _barometer->sensors[sensor].temperature, ALTITUDE_UNIT::METER);
+        atm_status.qfe_pressure = calculate_qfe(atm_status.altitude_amsl, atm_status.qnh_pressure, _barometer->sensors[sensor].temperature, ALTITUDE_UNIT::METER) * 100;
+    }
+}
+
+// Get the calculation altitude difference based on th Layer 0 > Troposphere.
+float UR_Atmosphere::calculate_altitude_difference(float base_pressure, float pressure, float temp, altitude_unit_t alt_diff_unit) const
+{
+    float result;
+    float tempcorrected  = T0 + temp - 15;
+    float unit_result = 1;
+
+    switch (alt_diff_unit) {
+    case FEET:
+        break;
+    case METER:
+        unit_result = CftTOm;
+        break;
+    default:
+        ;
+    }
+
+    result = unit_result * (tempcorrected * (powf((base_pressure / pressure), (dTdh0SI / CgRGasSI)) - 1.0f) / dTdh0);
+
+    return result;
+}
+
+// Calculate QNH by hPa and feet by default.
+// [1] Meteorology Specification A2669 Version 4.00 Page 100
+float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp, altitude_unit_t alt_qnh_unit)
+{
+    uint8_t pQNHUnit = 0;
+    uint8_t resultQNHUnit = 0;
+    float resultQNH = 0;
+    float hQFE = 0;
+    float pQFE = 0;
+
+    switch (alt_qnh_unit) {
+    case FEET:                         // [ft] feet
+        hQFE = alt_qnh * CftTOm;
+        break;
+    case METER:                         // [m]  meters
+        hQFE = alt_qnh;
+        break;
+    default:
+        ;
+    }
+
+    switch (pQNHUnit) {
+    case 0:                                 // [hPa]    hectoPascal
+        pQFE = pressure_qnh;
+        break;
+    case 1:                                 // [inHg]   inches mercury
+        pQFE = pressure_qnh / ChPaTOinHG;
+        break;
+    case 2:                                 // [mmHg]   millimiters mercury
+        pQFE = pressure_qnh / ChPaTOmmHG;
+        break;
+    default:
+        ;
+    }
+
+    // Calculation(s)
+    pressure_qnh = p0hPa * powf(powf((pQFE / p0hPa), (-1 * (CRGasSI * dTdh0SI)) / CgSI) - (hQFE * dTdh0SI) / (T0 + temp - 15), (-1 * CgSI) / (CRGasSI * dTdh0SI));
+
+    // Unit Conversion(s)
+    switch (resultQNHUnit) {
+    case 0:                                         // [hPa]    hectoPascal
+        break;
+    case 1:                                         // [inHg]   inches mercury
+        pressure_qnh = pressure_qnh * ChPaTOinHG;
+        break;
+    case 2:                                         // [mmHg]   millimiters mercury
+        pressure_qnh = pressure_qnh * ChPaTOmmHG;
+        break;
+    default:
+        ;
+    }
+
+    resultQNH = pressure_qnh;
+    return resultQNH;
+}
+
+// Calculate QFE by hPa and feet by default.
+// [1] Meteorology Specification A2669 Version 4.00 Page 100
+float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp, altitude_unit_t alt_qfe_unit)
+{
+    uint8_t pQFEUnit = 0;
+    uint8_t resultQFEUnit = 0;
+    float resultQFE = 0;
+    float hQNH = 0;
+    float pQNH = 0;
+
+    switch (alt_qfe_unit) {
+    case FEET:                                 // [ft] feet
+        hQNH = alt_qfe * CftTOm;
+        break;
+    case METER:                                 // [m]  meters
+        hQNH = alt_qfe;
+        break;
+    default:
+        ;
+    }
+
+    switch (pQFEUnit) {
+    case 0:                                 // [hPa]    hectoPascal
+        pQNH = pressure_qfe;
+        break;
+    case 1:                                 // [inHg]   inches mercury
+        pQNH = pressure_qfe / ChPaTOinHG;
+        break;
+    case 2:                                 // [mmHg]   millimiters mercury
+        pQNH = pressure_qfe / ChPaTOmmHG;
+        break;
+    default:
+        ;
+    }
+
+    // Calculations
+    alt_qfe = p0hPa * powf(powf((pQNH / p0hPa), (-1 * (CRGasSI * dTdh0SI)) / CgSI) + ((hQNH * dTdh0SI) / (T0 + temp - 15)), (-1 * CgSI) / (CRGasSI * dTdh0SI));
+
+    // Unit Conversions
+    switch (resultQFEUnit) {
+    case 0:                                 // [hPa]    hectoPascal
+        break;
+    case 1:                                 // [inHg]   inches mercury
+        alt_qfe = alt_qfe * ChPaTOinHG;
+        break;
+    case 2:                                 // [mmHg]   millimiters mercury
+        alt_qfe = alt_qfe * ChPaTOmmHG;
+        break;
+    default:
+        ;
+    }
+
+    resultQFE = alt_qfe;
+    return resultQFE;
+}
+
+void UR_Atmosphere::consume_updated(void)
+{
+    atm_status.updated = false;
+}
+
+float UR_Atmosphere::get_altitude_amsl()
+{
+    return atm_status.altitude_amsl;
+}
+
+float UR_Atmosphere::get_qnh()
+{
+    return atm_status.qnh_pressure;
+}

--- a/libraries/UR_Atmosphere/UR_Atmosphere.cpp
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.cpp
@@ -78,8 +78,7 @@ void UR_Atmosphere::update(uint8_t sensor)
 // Get the calculation altitude difference based on th Layer 0 > Troposphere.
 float UR_Atmosphere::calculate_altitude_difference(float base_pressure, float pressure, float temp, altitude_unit_t alt_diff_unit) const
 {
-    float result;
-    float tempcorrected  = Temp0 + temp - 15;
+    const float tempcorrected  = Temp0 + temp - 15;
     float unit_result = 1;
 
     switch (alt_diff_unit) {
@@ -89,10 +88,10 @@ float UR_Atmosphere::calculate_altitude_difference(float base_pressure, float pr
         unit_result = CftTOm;
         break;
     default:
-        ;
+        break;
     }
 
-    result = unit_result * (tempcorrected * (powf((base_pressure / pressure), (dTdh0SI / CgRGasSI)) - 1.0f) / dTdh0);
+    const float result = unit_result * (tempcorrected * (powf((base_pressure / pressure), (dTdh0SI / CgRGasSI)) - 1.0f) / dTdh0);
 
     return result;
 }
@@ -101,9 +100,8 @@ float UR_Atmosphere::calculate_altitude_difference(float base_pressure, float pr
 // [1] Meteorology Specification A2669 Version 4.00 Page 100
 float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp, altitude_unit_t alt_qnh_unit)
 {
-    uint8_t pQNHUnit = 0;
-    uint8_t resultQNHUnit = 0;
-    float resultQNH = 0;
+    uint8_t pQNHUnit = PRESSURE_UNIT::HECTO_PASCAL;
+    uint8_t resultQNHUnit = PRESSURE_UNIT::HECTO_PASCAL;
     float hQFE = 0;
     float pQFE = 0;
 
@@ -115,21 +113,21 @@ float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp
         hQFE = alt_qnh;
         break;
     default:
-        ;
+        break;
     }
 
     switch (pQNHUnit) {
-    case 0:                                 // [hPa]    hectoPascal
+    case HECTO_PASCAL:                      // [hPa]    hectoPascal
         pQFE = pressure_qnh;
         break;
-    case 1:                                 // [inHg]   inches mercury
+    case INCH_MERCURY:                      // [inHg]   inches mercury
         pQFE = pressure_qnh / ChPaTOinHG;
         break;
-    case 2:                                 // [mmHg]   millimiters mercury
+    case MILLIMETER_MERCURY:                // [mmHg]   millimiters mercury
         pQFE = pressure_qnh / ChPaTOmmHG;
         break;
     default:
-        ;
+        break;
     }
 
     // Calculation(s)
@@ -137,19 +135,19 @@ float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp
 
     // Unit Conversion(s)
     switch (resultQNHUnit) {
-    case 0:                                         // [hPa]    hectoPascal
+    case HECTO_PASCAL:                              // [hPa]    hectoPascal
         break;
-    case 1:                                         // [inHg]   inches mercury
+    case INCH_MERCURY:                              // [inHg]   inches mercury
         pressure_qnh = pressure_qnh * ChPaTOinHG;
         break;
-    case 2:                                         // [mmHg]   millimiters mercury
+    case MILLIMETER_MERCURY:                        // [mmHg]   millimiters mercury
         pressure_qnh = pressure_qnh * ChPaTOmmHG;
         break;
     default:
-        ;
+        break;
     }
 
-    resultQNH = pressure_qnh;
+    const float resultQNH = pressure_qnh;
     return resultQNH;
 }
 
@@ -157,8 +155,8 @@ float UR_Atmosphere::calculate_qnh(float alt_qnh, float pressure_qnh, float temp
 // [1] Meteorology Specification A2669 Version 4.00 Page 100
 float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp, altitude_unit_t alt_qfe_unit)
 {
-    uint8_t pQFEUnit = 0;
-    uint8_t resultQFEUnit = 0;
+    uint8_t pQFEUnit = PRESSURE_UNIT::HECTO_PASCAL;
+    uint8_t resultQFEUnit = PRESSURE_UNIT::HECTO_PASCAL;
     float resultQFE = 0;
     float hQNH = 0;
     float pQNH = 0;
@@ -171,21 +169,21 @@ float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp
         hQNH = alt_qfe;
         break;
     default:
-        ;
+        break;
     }
 
     switch (pQFEUnit) {
-    case 0:                                 // [hPa]    hectoPascal
+    case HECTO_PASCAL:                      // [hPa]    hectoPascal
         pQNH = pressure_qfe;
         break;
-    case 1:                                 // [inHg]   inches mercury
+    case INCH_MERCURY:                      // [inHg]   inches mercury
         pQNH = pressure_qfe / ChPaTOinHG;
         break;
-    case 2:                                 // [mmHg]   millimiters mercury
+    case MILLIMETER_MERCURY:                // [mmHg]   millimiters mercury
         pQNH = pressure_qfe / ChPaTOmmHG;
         break;
     default:
-        ;
+        break;
     }
 
     // Calculations
@@ -193,16 +191,16 @@ float UR_Atmosphere::calculate_qfe(float alt_qfe, float pressure_qfe, float temp
 
     // Unit Conversions
     switch (resultQFEUnit) {
-    case 0:                                 // [hPa]    hectoPascal
+    case HECTO_PASCAL:                      // [hPa]    hectoPascal
         break;
-    case 1:                                 // [inHg]   inches mercury
+    case INCH_MERCURY:                      // [inHg]   inches mercury
         alt_qfe = alt_qfe * ChPaTOinHG;
         break;
-    case 2:                                 // [mmHg]   millimiters mercury
+    case MILLIMETER_MERCURY:                // [mmHg]   millimiters mercury
         alt_qfe = alt_qfe * ChPaTOmmHG;
         break;
     default:
-        ;
+        break;
     }
 
     resultQFE = alt_qfe;

--- a/libraries/UR_Atmosphere/UR_Atmosphere.h
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.h
@@ -48,7 +48,7 @@ public:
     float get_altitude_amsl();
     float get_qnh();
 
-    static UR_Atmosphere *get_instance() {
+    static UR_Atmosphere *get_singleton() {
         return _instance;
     }
 

--- a/libraries/UR_Atmosphere/UR_Atmosphere.h
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.h
@@ -36,8 +36,8 @@ public:
     void update(uint8_t sensor);
 
     float calculate_altitude_difference(float base_pressure, float pressure, float temp, altitude_unit_t alt_diff_unit = METER) const;
-    float calculate_qnh(float alt_qnh, float pressure_qnh, float temp, altitude_unit_t alt_qnh_unit);
-    float calculate_qfe(float alt_qfe, float pressure_qfe, float temp, altitude_unit_t alt_qfe_unit);
+    float calculate_qnh(float alt_qnh, float pressure_qnh, float temp, altitude_unit_t alt_qnh_unit) const;
+    float calculate_qfe(float alt_qfe, float pressure_qfe, float temp, altitude_unit_t alt_qfe_unit) const;
 
     static bool initialized(void) {
         return _initialized;
@@ -45,8 +45,8 @@ public:
 
     void consume_updated(void);
 
-    float get_altitude_amsl();
-    float get_qnh();
+    float get_altitude_amsl() const;
+    float get_qnh() const;
 
     static UR_Atmosphere *get_singleton() {
         return _instance;

--- a/libraries/UR_Atmosphere/UR_Atmosphere.h
+++ b/libraries/UR_Atmosphere/UR_Atmosphere.h
@@ -1,0 +1,69 @@
+/*
+   Aeronautics Atmosphere Calculations.
+   Copyright (c) 2019 Hiroshi Takey <htakey@gmail.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Baro/AP_Baro.h>
+#include "UR_Atmosphere/atmosphere_definitions.h"
+
+using namespace ISA_MATH_CONST;
+
+class AP_Baro;
+
+class UR_Atmosphere
+{
+public:
+    UR_Atmosphere();
+    ~UR_Atmosphere(void) {};
+
+    void init(void);
+    void update(uint8_t sensor);
+
+    float calculate_altitude_difference(float base_pressure, float pressure, float temp, altitude_unit_t alt_diff_unit = METER) const;
+    float calculate_qnh(float alt_qnh, float pressure_qnh, float temp, altitude_unit_t alt_qnh_unit);
+    float calculate_qfe(float alt_qfe, float pressure_qfe, float temp, altitude_unit_t alt_qfe_unit);
+
+    static bool initialized(void) {
+        return _initialized;
+    }
+
+    void consume_updated(void);
+
+    float get_altitude_amsl();
+    float get_qnh();
+
+    static UR_Atmosphere *get_instance() {
+        return _instance;
+    }
+
+private:
+
+    struct atm_status_s {
+        float altitude_amsl;
+        float qfe_pressure;
+        float qnh_pressure;
+        bool updated;
+    } atm_status;
+
+    AP_Baro *_barometer;
+    static UR_Atmosphere *_instance;
+
+    static bool _initialized;
+
+};

--- a/libraries/UR_Atmosphere/atmosphere_definitions.h
+++ b/libraries/UR_Atmosphere/atmosphere_definitions.h
@@ -27,6 +27,8 @@
 
 namespace ISA_MATH_CONST {
 
+using namespace std;
+
     const float p0      = 101325.0f;                    // [N/m^2] = [Pa]
     const float p1      = 22632.05545875171f;           // [N/m^2] = [Pa] Calculated @ 11000.0000000000001 [ft]
     const float p2      = 5474.884659730908f;           // [N/m^2] = [Pa] Calculated @ 20000.000000000001  [ft]
@@ -80,7 +82,7 @@ namespace ISA_MATH_CONST {
     const float CGamma     = 1.4f;    // [-]
     const float CGammaRGas = (CGamma * CRGasSI) / (CftTOm * CftTOm);    // [ft^2/(s^2*K)]
 
-    const float CaSLSI         = sqrt(CGamma * CRGasSI * T0);
+    const float CaSLSI         = sqrtf(CGamma * CRGasSI * T0);
     const float CPressureSLSI  = 101325.0f;                             // [Pa] = [N/m^2]
     const float CaSLNU         = CaSLSI * CmPsTOkn;                     // [kts] Nautical Unit
     const float CRhoSLSI       = 1.225f;                                // [kg/m^3]

--- a/libraries/UR_Atmosphere/atmosphere_definitions.h
+++ b/libraries/UR_Atmosphere/atmosphere_definitions.h
@@ -1,0 +1,109 @@
+/*
+   Aeronautics Atmosphere Calculations.
+   Copyright (c) 2019 Hiroshi Takey <htakey@gmail.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#include <cmath>
+
+#define INHG_TO_PA      3386.383613f
+#define METERS_TO_FEET  3.280839895f
+
+namespace ISA_MATH_CONST {
+
+    const float p0      = 101325.0f;                    // [N/m^2] = [Pa]
+    const float p1      = 22632.05545875171f;           // [N/m^2] = [Pa] Calculated @ 11000.0000000000001 [ft]
+    const float p2      = 5474.884659730908f;           // [N/m^2] = [Pa] Calculated @ 20000.000000000001  [ft]
+    const float p3      = 868.0176477556424f;           // [N/m^2] = [Pa] Calculated @ 32000.000000000001  [ft]
+
+    const float p0hPa   = 1013.25f;                     // [hPa]
+    const float p0inHG  = 29.9213f;                     // [inHG] Truncated 29.9213
+    const float p0mmHG  = p0inHG * 25.4f;               // [mmHG] w/ 25.4 [mm] = 1.0 [in]
+
+    const float T0      = 288.15f;                      // [K]
+    const float T1      = 216.65f;                      // [K]
+    const float T2      = 216.65f;                      // [K]
+
+    const float h1      = 36089.238845144355f;          // [ft] = 11000 [m] w/ CftTOm
+    const float h2      = 65616.79790026246f;           // [ft] = 20000 [m] w/ CftTOm
+    const float h3      = 104986.87664041994f;          // [ft] = 32000 [m] w/ CftTOm
+
+    const float dTdh0   = -0.0019812f;                  // [K/ft] w/ CftTOm
+    const float dTdh0SI = -0.0065f;                     // [K/m]
+
+    const float dTdh2   = 0.0003048f;                   // [K/ft] w/ CftTOm
+    const float dTdh2SI = 0.001f;                       // [K/m]
+
+    const float CPascalTOPSI   = 1.45037737730209e-04f;
+    const float ChPaTOinHG     = p0inHG / p0hPa;
+    const float ChPaTOmmHG     = p0mmHG / p0hPa;
+    const float CPaTOinHG     = p0inHG / p0;
+
+    const float ClbPft3TOkgPm3 = 16.0184633739601f;     // [lb/ft^3] to [kg/m^3]
+
+    const float CftTOm     = 0.3048f;
+    const float CftTOnm    = 1.64578833693305e-04f;
+
+    const float CnmTOm     = 1852.0f;
+
+    const float CftPsTOkn  = CftTOnm * 3600.0f;
+    const float CftPsTOmph = 3600.0f / 5280.0f;
+    const float CftPsTOkph = CftTOm * 3600.0f / 1000.0f;
+
+    const float CmPsTOkn   = 3600.0f / CnmTOm;
+
+    const float CknTOftPs  = 1.0f / (CftTOnm * 3600.0f);
+
+    const float CRGasSI    = 287.053f;                  // [m^2/(s^2*K)] = [J/(kg*K)]
+
+    const float CgSI       = 9.80665f;                  // [m/s^2]
+
+    const float CgRGas     = (CgSI * CftTOm) / CRGasSI;
+    const float CgRGasSI   = CgSI / CRGasSI;
+
+    const float CGamma     = 1.4f;    // [-]
+    const float CGammaRGas = (CGamma * CRGasSI) / (CftTOm * CftTOm);    // [ft^2/(s^2*K)]
+
+    const float CaSLSI         = sqrt(CGamma * CRGasSI * T0);
+    const float CPressureSLSI  = 101325.0f;                             // [Pa] = [N/m^2]
+    const float CaSLNU         = CaSLSI * CmPsTOkn;                     // [kts] Nautical Unit
+    const float CRhoSLSI       = 1.225f;                                // [kg/m^3]
+
+    const float CKelvinTOCelsius   = 273.15f;
+    const float CKelvinTORankine   = 1.8f;
+
+    const float CCelsiusTOFahrenheitLinear       =  32.0f;
+    const float CCelsiusTOFahrenheitProportional =  1.8f;
+
+    typedef enum ALTITUDE_UNIT {
+        INCH = 0,
+        FEET,
+        MILLIMETER,
+        CENTIMETER,
+        METER
+    } altitude_unit_t;
+
+    typedef enum PRESSURE_UNIT {
+        PASCAL = 0,
+        HECTO_PASCAL,
+        INCH_MERCURY,
+        MILLIMETER_MERCURY
+    } pressure_unit_t;
+
+};

--- a/libraries/UR_Atmosphere/atmosphere_definitions.h
+++ b/libraries/UR_Atmosphere/atmosphere_definitions.h
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-
 #include <cmath>
 
 #define INHG_TO_PA      3386.383613f
@@ -29,22 +27,22 @@ namespace ISA_MATH_CONST {
 
 using namespace std;
 
-    const float p0      = 101325.0f;                    // [N/m^2] = [Pa]
-    const float p1      = 22632.05545875171f;           // [N/m^2] = [Pa] Calculated @ 11000.0000000000001 [ft]
-    const float p2      = 5474.884659730908f;           // [N/m^2] = [Pa] Calculated @ 20000.000000000001  [ft]
-    const float p3      = 868.0176477556424f;           // [N/m^2] = [Pa] Calculated @ 32000.000000000001  [ft]
+    const float press0      = 101325.0f;               // [N/m^2] = [Pa]
+    const float press1      = 22632.05545875171f;      // [N/m^2] = [Pa] Calculated @ 11000.0000000000001 [ft]
+    const float press2      = 5474.884659730908f;      // [N/m^2] = [Pa] Calculated @ 20000.000000000001  [ft]
+    const float press3      = 868.0176477556424f;      // [N/m^2] = [Pa] Calculated @ 32000.000000000001  [ft]
 
     const float p0hPa   = 1013.25f;                     // [hPa]
     const float p0inHG  = 29.9213f;                     // [inHG] Truncated 29.9213
     const float p0mmHG  = p0inHG * 25.4f;               // [mmHG] w/ 25.4 [mm] = 1.0 [in]
 
-    const float Temp0      = 288.15f;                      // [K]
-    const float Temp1      = 216.65f;                      // [K]
-    const float Temp2      = 216.65f;                      // [K]
+    const float Temp0      = 288.15f;                   // [K]
+    const float Temp1      = 216.65f;                   // [K]
+    const float Temp2      = 216.65f;                   // [K]
 
-    const float h1      = 36089.238845144355f;          // [ft] = 11000 [m] w/ CftTOm
-    const float h2      = 65616.79790026246f;           // [ft] = 20000 [m] w/ CftTOm
-    const float h3      = 104986.87664041994f;          // [ft] = 32000 [m] w/ CftTOm
+    const float hgt1      = 36089.238845144355f;        // [ft] = 11000 [m] w/ CftTOm
+    const float hgt2      = 65616.79790026246f;         // [ft] = 20000 [m] w/ CftTOm
+    const float hgt3      = 104986.87664041994f;        // [ft] = 32000 [m] w/ CftTOm
 
     const float dTdh0   = -0.0019812f;                  // [K/ft] w/ CftTOm
     const float dTdh0SI = -0.0065f;                     // [K/m]
@@ -55,7 +53,7 @@ using namespace std;
     const float CPascalTOPSI   = 1.45037737730209e-04f;
     const float ChPaTOinHG     = p0inHG / p0hPa;
     const float ChPaTOmmHG     = p0mmHG / p0hPa;
-    const float CPaTOinHG     = p0inHG / p0;
+    const float CPaTOinHG     = p0inHG / press0;
 
     const float ClbPft3TOkgPm3 = 16.0184633739601f;     // [lb/ft^3] to [kg/m^3]
 

--- a/libraries/UR_Atmosphere/atmosphere_definitions.h
+++ b/libraries/UR_Atmosphere/atmosphere_definitions.h
@@ -38,9 +38,9 @@ using namespace std;
     const float p0inHG  = 29.9213f;                     // [inHG] Truncated 29.9213
     const float p0mmHG  = p0inHG * 25.4f;               // [mmHG] w/ 25.4 [mm] = 1.0 [in]
 
-    const float T0      = 288.15f;                      // [K]
-    const float T1      = 216.65f;                      // [K]
-    const float T2      = 216.65f;                      // [K]
+    const float Temp0      = 288.15f;                      // [K]
+    const float Temp1      = 216.65f;                      // [K]
+    const float Temp2      = 216.65f;                      // [K]
 
     const float h1      = 36089.238845144355f;          // [ft] = 11000 [m] w/ CftTOm
     const float h2      = 65616.79790026246f;           // [ft] = 20000 [m] w/ CftTOm
@@ -82,7 +82,7 @@ using namespace std;
     const float CGamma     = 1.4f;    // [-]
     const float CGammaRGas = (CGamma * CRGasSI) / (CftTOm * CftTOm);    // [ft^2/(s^2*K)]
 
-    const float CaSLSI         = sqrtf(CGamma * CRGasSI * T0);
+    const float CaSLSI         = sqrtf(CGamma * CRGasSI * Temp0);
     const float CPressureSLSI  = 101325.0f;                             // [Pa] = [N/m^2]
     const float CaSLNU         = CaSLSI * CmPsTOkn;                     // [kts] Nautical Unit
     const float CRhoSLSI       = 1.225f;                                // [kg/m^3]


### PR DESCRIPTION
It's an implementation about Atmospheric calculation for precise pressure altitude on avionics instruments.

These functions was tested on the Encoder & Altimeter Benchtest Hardware and Application development in cooperation and support with Fenix Aeronautics Academy under the supervision and technical support with the FAA Licensed Fixed and Rotor Wing Aircraft Engineer Maintenance Service, Rudy Averanga <raveranga@fenixaeronautica.com>.

This library use the ICAO and ISA definitions with dynamic temperature corrections and calculations improvements, this was also tested rigorously in about 3 months with Garmin GTX327 transponder in MODE C interfaced with the Narco AR850 calibrated altitude encoder and DIY URUS Encoder on two Cessna C152 running this library inside too. The altitude calibration was constantly performed monitoring with local airport METAR data report from Viru Viru (ICAO airport code: SLVR) via MODE C.

The library has the correct QNH and QFE implementations following the ICAO and ISA formulas with +/-0 error and in real world about 3 feets (+/- 1meters).

A ALTCALC_MODE parameter var was added in to AP_Baro to switch between native pressure calculation (ground level) and the Atmosphere _atm var for ASL (Troposphere pressure rel.) calculations. With Atm implementation on the Baro driver side, Ardupilot can flight without worried with the OAT correction calculation and Ground Level reference.

This video demonstrate the bench test procedure with the Narco AR850.

[![](http://img.youtube.com/vi/ta2P-0agYXY/0.jpg)](http://www.youtube.com/watch?v=ta2P-0agYXY "Barometric pressure and altitude bench test application")

The image show in flight Cessna C152 altitude at 2390 feets on the Garmin GTX327 and 2500 feets on the altimeter with 30.01 inHg QNH.

![Atm_cessna](https://user-images.githubusercontent.com/6075116/62864275-40a52280-bcd9-11e9-830d-3c1275358f90.jpg)
