### PR TITLE
Remove unneeded CI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ addons:
       - python-pip
       - python-dev
       - zlib1g-dev
-      - gcc-4.9
-      - g++-4.9
       - gdb
       - cmake
       - cmake-data

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -52,8 +52,6 @@ popd
 mkdir -p $HOME/bin
 
 # symlink to compiler versions
-ln -s /usr/bin/gcc-4.9 ~/bin/gcc
-ln -s /usr/bin/g++-4.9 ~/bin/g++
 ln -s /usr/bin/clang-7 ~/bin/clang
 ln -s /usr/bin/clang++-7 ~/bin/clang++
 ln -s /usr/bin/llvm-ar-7 ~/bin/llvm-ar

--- a/Tools/scripts/install-apt-ci.sh
+++ b/Tools/scripts/install-apt-ci.sh
@@ -13,8 +13,6 @@ PKGS=" \
     python-pip \
     python-dev \
     zlib1g-dev \
-    gcc-4.9 \
-    g++-4.9 \
     cmake3 \
     cmake3-data \
     "


### PR DESCRIPTION
As far as I can tell thus far, we aren't actually using these in CI at all, and can remove it, as this is just causing us to take longer to setup the CI instance.