### PR TITLE
AP_HAL: added GCC_VERSION for macro control optimization on libraries

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Macros.h
+++ b/libraries/AP_HAL/AP_HAL_Macros.h
@@ -13,6 +13,14 @@
 #define ALLOW_DOUBLE_MATH_FUNCTIONS
 #endif
 
+#ifdef __GNUC__
+
+ #define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#endif
+
 #if !defined(ALLOW_DOUBLE_MATH_FUNCTIONS)
 /* give warnings if we use double precision maths functions without
    specifying ALLOW_DOUBLE_TRIG_FUNCTIONS. Code should use the

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -20,7 +20,9 @@
  */
 #pragma once
 
+#if (GCC_VERSION >= 40900)
 #pragma GCC optimize("O3")
+#endif
 
 #define EK2_DISABLE_INTERRUPTS 0
 
@@ -66,7 +68,7 @@ public:
 
     // setup this core backend
     bool setup_core(NavEKF2 *_frontend, uint8_t _imu_index, uint8_t _core_index);
-    
+
     // Initialise the states from accelerometer and magnetometer data (if present)
     // This method can only be used when the vehicle is static
     bool InitialiseFilterBootstrap(void);
@@ -309,7 +311,7 @@ public:
 
     // get timing statistics structure
     void getTimingStatistics(struct ekf_timing &timing);
-    
+
     /*
      * Write position and quaternion data from an external navigation system
      *
@@ -777,7 +779,7 @@ private:
 
     // update timing statistics structure
     void updateTimingStatistics(void);
-    
+
     // Length of FIFO buffers used for non-IMU sensor data.
     // Must be larger than the time period defined by IMU_BUFFER_LENGTH
     static const uint32_t OBS_BUFFER_LENGTH = 5;
@@ -1208,7 +1210,7 @@ private:
 
     // when was attitude filter status last non-zero?
     uint32_t last_filter_ok_ms;
-    
+
     // should we assume zero sideslip?
     bool assume_zero_sideslip(void) const;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -19,7 +19,9 @@
  */
 #pragma once
 
+#if (GCC_VERSION >= 40900)
 #pragma GCC optimize("O3")
+#endif
 
 #define EK3_DISABLE_INTERRUPTS 0
 
@@ -71,7 +73,7 @@ public:
 
     // setup this core backend
     bool setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _core_index);
-    
+
     // Initialise the states from accelerometer and magnetometer data (if present)
     // This method can only be used when the vehicle is static
     bool InitialiseFilterBootstrap(void);
@@ -365,7 +367,7 @@ public:
 
     // get timing statistics structure
     void getTimingStatistics(struct ekf_timing &timing);
-    
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF3 *frontend;
@@ -829,7 +831,7 @@ private:
 
     // calculate the variances for the rotation vector equivalent
     Vector3f calcRotVecVariances(void);
-    
+
     // initialise the quaternion covariances using rotation vector variances
     void initialiseQuatCovariances(const Vector3f &rotVarVec);
 
@@ -838,7 +840,7 @@ private:
 
     // Update the state index limit based on which states are active
     void updateStateIndexLim(void);
-    
+
     // Variables
     bool statesInitialised;         // boolean true when filter states have been initialised
     bool velHealth;                 // boolean true if velocity measurements have passed innovation consistency check
@@ -1288,7 +1290,7 @@ private:
 
     // timing statistics
     struct ekf_timing timing;
-    
+
     // should we assume zero sideslip?
     bool assume_zero_sideslip(void) const;
 


### PR DESCRIPTION
This helps to control optimization on libraries.

GCC 4.8.4 preprocessor break with out of memory on some headers like AP_NavEKF2 and AP_NavEKF3.
