### PR TITLE
waf: do not -Werror=suggest-override on uavcan-enabled boards

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -226,7 +226,7 @@ class Board:
                 '-Werror=unused-but-set-variable'
             ]
             (major, minor, patchlevel) = cfg.env.CC_VERSION
-            if int(major) >= 5 and int(minor) > 1:
+            if int(major) >= 5 and int(minor) > 1 and not self.with_uavcan:
                 env.CXXFLAGS += [
                     '-Werror=suggest-override',
                 ]

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -190,6 +190,12 @@ def setup_can_build(cfg):
         '-DUAVCAN_STM32_NUM_IFACES=2'
         ]
 
+    (major, minor, patchlevel) = cfg.env.CC_VERSION
+    if int(major) >= 5 and int(minor) > 1:
+        env.CXXFLAGS += [
+            '-Wno-error=suggest-override',
+        ]
+
     env.DEFINES += [
         'UAVCAN_CPP_VERSION=UAVCAN_CPP03',
         'UAVCAN_NO_ASSERTIONS=1',


### PR DESCRIPTION
uavcan doesn't have all of the required override keywords

SITL will still die without the keyword