### PR TITLE
AP_NavEKF2: ext nav will not reset yaw if compass is used

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -314,9 +314,11 @@ void NavEKF2_core::setAidingMode()
             if (canUseExtNav) {
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using external nav data",(unsigned)imu_index);
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial pos NED = %3.1f,%3.1f,%3.1f (m)",(unsigned)imu_index,(double)extNavDataDelayed.pos.x,(double)extNavDataDelayed.pos.y,(double)extNavDataDelayed.pos.z);
-                // handle yaw reset as special case
-                extNavYawResetRequest = true;
-                controlMagYawReset();
+                //handle yaw reset as special case only if compass is disabled
+                if (!use_compass()) {
+                    extNavYawResetRequest = true;
+                    controlMagYawReset();
+                }
                 // handle height reset as special case
                 hgtMea = -extNavDataDelayed.pos.z;
                 posDownObsNoise = sq(constrain_float(extNavDataDelayed.posErr, 0.1f, 10.0f));


### PR DESCRIPTION
In current code
https://github.com/ArduPilot/ardupilot/blob/adcf9c4fa45f9d8c8820417a9ff4b8ad5eb8eb37/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp#L315-L317
ext nav orientation is used only if compass is disabled 

But ext nav orientation is still used to reset yaw when it first received. even compass is enabled. It may cause problem