### PR TITLE
ArduPlane: Fix long failsafe never working if FS_SHORT_ACTN=3

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -937,6 +937,7 @@ private:
     int16_t rudder_input(void);
     void control_failsafe();
     bool trim_radio();
+    bool rc_throttle_value_ok(void) const;
     bool rc_failsafe_active(void) const;
     void read_rangefinder(void);
     void read_airspeed(void);


### PR DESCRIPTION
This solves an issue when FS_SHORT_ACTN=3 aka Disabled, which caused to never trigger long_failsafe.