### PR TITLE
Rover: Pass mavlink channel reference to motor test

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -667,7 +667,7 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
         // param3 : throttle (range depends upon param2)
         // param4 : timeout (in seconds)
         return rover.mavlink_motor_test_start(*this,
-                                              static_cast<uint8_t>(packet.param1),
+                                              (AP_MotorsUGV::motor_test_order)packet.param1,
                                               static_cast<uint8_t>(packet.param2),
                                               static_cast<int16_t>(packet.param3),
                                               packet.param4);

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -666,7 +666,7 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
         // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
         // param3 : throttle (range depends upon param2)
         // param4 : timeout (in seconds)
-        return rover.mavlink_motor_test_start(chan,
+        return rover.mavlink_motor_test_start(*this,
                                               static_cast<uint8_t>(packet.param1),
                                               static_cast<uint8_t>(packet.param2),
                                               static_cast<int16_t>(packet.param3),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -476,8 +476,8 @@ public:
     void failsafe_check();
     // Motor test
     void motor_test_output();
-    bool mavlink_motor_test_check(const GCS_MAVLINK &gcs_chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value);
-    MAV_RESULT mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value, float timeout_sec);
+    bool mavlink_motor_test_check(const GCS_MAVLINK &gcs_chan, bool check_rc, AP_MotorsUGV::motor_test_order motor_instance, uint8_t throttle_type, int16_t throttle_value);
+    MAV_RESULT mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, AP_MotorsUGV::motor_test_order motor_instance, uint8_t throttle_type, int16_t throttle_value, float timeout_sec);
     void motor_test_stop();
 
     // frame type

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -476,8 +476,8 @@ public:
     void failsafe_check();
     // Motor test
     void motor_test_output();
-    bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value);
-    MAV_RESULT mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value, float timeout_sec);
+    bool mavlink_motor_test_check(const GCS_MAVLINK &gcs_chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value);
+    MAV_RESULT mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value, float timeout_sec);
     void motor_test_stop();
 
     // frame type

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -60,14 +60,8 @@ void Rover::motor_test_output()
 
 // mavlink_motor_test_check - perform checks before motor tests can begin
 // return true if tests can continue, false if not
-bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value)
+bool Rover::mavlink_motor_test_check(const GCS_MAVLINK &gcs_chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value)
 {
-    GCS_MAVLINK_Rover *gcs_chan_ptr = gcs().chan(chan-MAVLINK_COMM_0);
-    if (gcs_chan_ptr == nullptr) {
-        return false;
-    }
-    GCS_MAVLINK_Rover &gcs_chan = *gcs_chan_ptr;
-
     // check board has initialised
     if (!initialised) {
         gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Motor Test: Board initialising");
@@ -114,7 +108,7 @@ bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint
 
 // mavlink_motor_test_start - start motor test - spin a single motor at a specified pwm
 // returns MAV_RESULT_ACCEPTED on success, MAV_RESULT_FAILED on failure
-MAV_RESULT Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value, float timeout_sec)
+MAV_RESULT Rover::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value, float timeout_sec)
 {
     // if test has not started try to start it
     if (!motor_test) {
@@ -122,7 +116,7 @@ MAV_RESULT Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor
            The RC calibrated check can be skipped if direct pwm is
            supplied
         */
-        if (!mavlink_motor_test_check(chan, throttle_type != 1, motor_seq, throttle_type, throttle_value)) {
+        if (!mavlink_motor_test_check(gcs_chan, throttle_type != 1, motor_seq, throttle_type, throttle_value)) {
             return MAV_RESULT_FAILED;
         } else {
             // start test

--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -1811,6 +1811,24 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.disarm_vehicle()
 
+    def test_motor_test(self):
+        '''AKA run-rover-run'''
+        magic_throttle_value = 1812
+        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST,
+                     1, # p1 - motor instance
+                     mavutil.mavlink.MOTOR_TEST_THROTTLE_PWM, # p2 - throttle type
+                     magic_throttle_value, # p3 - throttle
+                     5, # p4 - timeout
+                     1, # p5 - motor count
+                     0, # p6 - test order (see MOTOR_TEST_ORDER)
+                     0, # p7
+        )
+        self.mav.motors_armed_wait()
+        self.progress("Waiting for magic throttle value")
+        self.wait_servo_channel_value(3, magic_throttle_value)
+        self.wait_servo_channel_value(3, self.get_parameter("RC3_TRIM", 5), timeout=10)
+        self.mav.motors_disarmed_wait()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestRover, self).tests()
@@ -1924,6 +1942,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             ("GCSRally",
              "Upload and download of rally",
              self.test_gcs_rally),
+
+            ("MotorTest",
+             "Motor Test triggered via mavlink",
+             self.test_motor_test),
 
             ("DataFlashOverMAVLink",
              "Test DataFlash over MAVLink",


### PR DESCRIPTION
Also, add a test for the same thing.  The changes made by this PR are fully tested by entry and exit to this function.

Also, rename and tighten typing on the parameter used to specify which motor to run; the packet has an "order" parameter so calling the motor instance parameter in ArduPilot "order" is bad.
