### PR TITLE
Fix SkyViper build

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -936,7 +936,7 @@ void ToyMode::handle_message(const mavlink_message_t &msg)
         return;
     }
     mavlink_named_value_int_t m;
-    mavlink_msg_named_value_int_decode(msg, &m);
+    mavlink_msg_named_value_int_decode(&msg, &m);
     if (strncmp(m.name, "BLINKR", 10) == 0) {
         red_blink_pattern = (uint16_t)m.value;
         red_blink_count = m.value >> 16;

--- a/libraries/AP_Radio/AP_Radio_cc2500.h
+++ b/libraries/AP_Radio/AP_Radio_cc2500.h
@@ -70,7 +70,7 @@ public:
     const AP_Radio::stats &get_stats(void) override;
 
     // set the 2.4GHz wifi channel used by companion computer, so it can be avoided
-    void set_wifi_channel(uint8_t channel) {
+    void set_wifi_channel(uint8_t channel) override {
         // t_status.wifi_chan = channel;
     }
     

--- a/libraries/AP_Radio/AP_Radio_cypress.h
+++ b/libraries/AP_Radio/AP_Radio_cypress.h
@@ -71,7 +71,7 @@ public:
     const AP_Radio::stats &get_stats(void) override;
 
     // set the 2.4GHz wifi channel used by companion computer, so it can be avoided
-    void set_wifi_channel(uint8_t channel) {
+    void set_wifi_channel(uint8_t channel) override {
         t_status.wifi_chan = channel;
     }
     


### PR DESCRIPTION
Missing override keywords and an incomplete signature change on handle_message.

Compilation fails before these patches and passes afterwards - that's the limit of the testing done on this PR.
