### PR TITLE
Rover: resolve compiler warning for delay time

### DIFF
--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -579,7 +579,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         // absolute delay to utc time
         nav_delay_time_max_ms = AP::rtc().get_time_utc(cmd.content.nav_delay.hour_utc, cmd.content.nav_delay.min_utc, cmd.content.nav_delay.sec_utc, 0);
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %lu sec", nav_delay_time_max_ms/1000);
+    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
 }
 
 // start guided within auto to allow external navigation system to control vehicle


### PR DESCRIPTION
The current code raises a warning here on 64-bit SITL as `nav_delay_time_max_ms/1000` isn't a long integer, just an integer.

We can safely cast to `(unsigned)` here because the range of what we're including is constrained to be within a day of seconds.

This compiles without warning on SITL and for fmuv3 - that's the extent of the testing I've done.
