### PR TITLE
Rover: have GCS_MAVLink_Rover unfriend Rover

### DIFF
--- a/APMrover2/GCS_Rover.h
+++ b/APMrover2/GCS_Rover.h
@@ -5,9 +5,8 @@
 
 class GCS_Rover : public GCS
 {
-    friend class Rover; // for access to _chan in parameter declarations
 
-public:
+protected:
 
     // return GCS link at offset ofs
     GCS_MAVLINK_Rover *chan(const uint8_t ofs) override {
@@ -35,8 +34,6 @@ public:
 
     bool simple_input_active() const override;
     bool supersimple_input_active() const override;
-
-protected:
 
     GCS_MAVLINK_Rover *new_gcs_mavlink_backend(GCS_MAVLINK_Parameters &params,
                                                AP_HAL::UARTDriver &uart) override {

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -252,19 +252,19 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(_gcs.chan_parameters[0], gcs0,        "SR0_",     GCS_MAVLINK_Parameters),
+    GOBJECTN(_gcs.chan_params_ref(0), gcs0,        "SR0_",     GCS_MAVLINK_Parameters),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(_gcs.chan_parameters[1],  gcs1,       "SR1_",     GCS_MAVLINK_Parameters),
+    GOBJECTN(_gcs.chan_params_ref(1),  gcs1,       "SR1_",     GCS_MAVLINK_Parameters),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(_gcs.chan_parameters[2],  gcs2,       "SR2_",     GCS_MAVLINK_Parameters),
+    GOBJECTN(_gcs.chan_params_ref(2),  gcs2,       "SR2_",     GCS_MAVLINK_Parameters),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(_gcs.chan_parameters[3],  gcs3,       "SR3_",     GCS_MAVLINK_Parameters),
+    GOBJECTN(_gcs.chan_params_ref(3),  gcs3,       "SR3_",     GCS_MAVLINK_Parameters),
 
     // @Group: SERIAL
     // @Path: ../libraries/AP_SerialManager/AP_SerialManager.cpp

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -719,6 +719,10 @@ public:
     void service_statustext(void);
     virtual GCS_MAVLINK *chan(const uint8_t ofs) = 0;
     virtual const GCS_MAVLINK *chan(const uint8_t ofs) const = 0;
+
+    const GCS_MAVLINK_Parameters &chan_params_ref(const uint8_t ofs) const {
+        return chan_parameters[ofs];
+    };
     // return the number of valid GCS objects
     uint8_t num_gcs() const { return _num_gcs; };
     void send_message(enum ap_message id);
@@ -782,6 +786,12 @@ protected:
     virtual void update_vehicle_sensor_status_flags() {}
 
     GCS_MAVLINK_Parameters chan_parameters[MAVLINK_COMM_NUM_BUFFERS];
+    // The Parameters.cpp files call _gcs.chan_params_ref which
+    // returns a reference with no bounds checking.  So do some
+    // checking here.
+    static_assert(ARRAY_SIZE(chan_parameters) >= 4,
+                  "chan_parameters safe to accomodate up to SR3_");
+
     uint8_t _num_gcs;
     GCS_MAVLINK *_chan[MAVLINK_COMM_NUM_BUFFERS];
 


### PR DESCRIPTION
This helps clearly define the interface to the `GCS_Rover` class.  Rover has no reason to poke at the innards of the GCS subclass.


