### PR TITLE
AP_HAL_Linux: check return value of system command

### DIFF
--- a/libraries/AP_HAL_Linux/GPIO_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Sysfs.cpp
@@ -287,7 +287,10 @@ void GPIO_Sysfs::_gpio_script_thread(void)
             char cmd[100];
             snprintf(cmd, sizeof(cmd)-1, "/bin/sh %s %u %u", HAL_GPIO_SCRIPT, pv.pin, pv.value);
             hal.console->printf("Running: %s\n", cmd);
-            system(cmd);
+            const int system_ret = system(cmd);
+            if (system_ret != 0) {
+                hal.console->printf("Unexpected return value (%d)\n", system_ret);
+            }
         }
     }
 }


### PR DESCRIPTION
Compilation fails on disco without this patch as system is declared with
attribute warn_unused_result