### PR TITLE
AP_HAL_SITL: Scheduler skip set stack on Cygwin

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -289,9 +289,11 @@ bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_
     a->name = name;
     
     pthread_attr_init(&a->attr);
+#if !defined(__CYGWIN__) && !defined(__CYGWIN64__)
     if (pthread_attr_setstack(&a->attr, a->stack, alloc_stack) != 0) {
         AP_HAL::panic("Failed to set stack of size %u for thread %s", alloc_stack, name);
     }
+#endif
     if (pthread_create(&thread, &a->attr, thread_create_trampoline, a) != 0) {
         goto failed;
     }


### PR DESCRIPTION
This skips setting the thread size on Cygwin builds, this allows OA to run on Cygwin, although it seems to get get stuck some times and need a disarm and re-arm to carry on, I guess this is not expected behavior?

Possibly needs some further work

fix for https://github.com/ArduPilot/ardupilot/issues/12041 (on Cygwin)