### PR TITLE
Enable active buzzer output on OmnibusNanoV6

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
@@ -73,7 +73,15 @@ PC11 SPI3_MISO SPI3
 PC10 SPI3_SCK SPI3
 
 PA8 LED OUTPUT HIGH GPIO(41)
+
+# passive buzzer disabled, timer 3 used for PWM(4) output
 #PB4 TIM3_CH1 TIM3 GPIO(70) ALARM
+
+# use active buzzer instead
+PB4 BUZZER OUTPUT GPIO(80) LOW
+define HAL_BUZZER_PIN 80
+define HAL_BUZZER_ON 1
+define HAL_BUZZER_OFF 0
 
 PA11 OTG_FS_DM OTG1
 PA12 OTG_FS_DP OTG1


### PR DESCRIPTION
Verified on OmnibusNanoV6 board; active-style buzzer connected to "BZ-" pad (and +5V).