### PR TITLE
Plane: Remove redundant if

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,10 @@ cmake-build-*/
 way.txt
 *.wbproj
 *.wbproj
+segv_*out
+/scripts/
+/APMrover2/scripts/
+/AntennaTracker/scripts/
+/ArduCopter/scripts/
+/ArduPlane/scripts/
+/ArduSub/scripts/

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -278,36 +278,34 @@ void Plane::control_failsafe()
         }
     }
 
-    if(g.throttle_fs_enabled == 0)
+    if(g.throttle_fs_enabled == 0) {
         return;
+    }
 
-    if (g.throttle_fs_enabled) {
-        if (rc_failsafe_active()) {
-            // we detect a failsafe from radio
-            // throttle has dropped below the mark
-            failsafe.throttle_counter++;
-            if (failsafe.throttle_counter == 10) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe on");
-                failsafe.rc_failsafe = true;
-                AP_Notify::flags.failsafe_radio = true;
-            }
-            if (failsafe.throttle_counter > 10) {
-                failsafe.throttle_counter = 10;
-            }
-
-        }else if(failsafe.throttle_counter > 0) {
-            // we are no longer in failsafe condition
-            // but we need to recover quickly
-            failsafe.throttle_counter--;
-            if (failsafe.throttle_counter > 3) {
-                failsafe.throttle_counter = 3;
-            }
-            if (failsafe.throttle_counter == 1) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe off");
-            } else if(failsafe.throttle_counter == 0) {
-                failsafe.rc_failsafe = false;
-                AP_Notify::flags.failsafe_radio = false;
-            }
+    if (rc_failsafe_active()) {
+        // we detect a failsafe from radio
+        // throttle has dropped below the mark
+        failsafe.throttle_counter++;
+        if (failsafe.throttle_counter == 10) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe on");
+            failsafe.rc_failsafe = true;
+            AP_Notify::flags.failsafe_radio = true;
+        }
+        if (failsafe.throttle_counter > 10) {
+            failsafe.throttle_counter = 10;
+        }
+    } else if(failsafe.throttle_counter > 0) {
+        // we are no longer in failsafe condition
+        // but we need to recover quickly
+        failsafe.throttle_counter--;
+        if (failsafe.throttle_counter > 3) {
+            failsafe.throttle_counter = 3;
+        }
+        if (failsafe.throttle_counter == 1) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe off");
+        } else if(failsafe.throttle_counter == 0) {
+            failsafe.rc_failsafe = false;
+            AP_Notify::flags.failsafe_radio = false;
         }
     }
 }


### PR DESCRIPTION
There is no need to check `g.throttle_fs_enabled` twice in a row here. I retained the early return (and added brackets around it), but I can keep the if block if people don't like it.

The additions to `.gitignore` allow git to ignore any stack traces from crashes, as well as scripts that we were using in SITL.