### PR TITLE
AP_Scripting: Allow the bindings to descirbe any build dependencies needed

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -113,6 +113,8 @@ singleton RangeFinder method num_sensors uint8_t
 
 include AP_Terrain/AP_Terrain.h
 
+depends AP_TERRAIN_AVAILABLE 1 Scripting requires terrain to be available
+
 singleton AP_Terrain alias terrain
 singleton AP_Terrain method enabled boolean
 singleton AP_Terrain enum TerrainStatusDisabled TerrainStatusUnhealthy TerrainStatusOK

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -14,6 +14,12 @@
 #include <AP_Common/Location.h>
 
 
+#if !defined(AP_TERRAIN_AVAILABLE) || (AP_TERRAIN_AVAILABLE != 1)
+  #error Scripting requires terrain to be available
+
+#endif // !defined(AP_TERRAIN_AVAILABLE) || (AP_TERRAIN_AVAILABLE != 1)
+
+
 static int binding_argcheck(lua_State *L, int expected_arg_count) {
     const int args = lua_gettop(L);
     if (args > expected_arg_count) {

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -14,6 +14,12 @@
 #include "lua/src/lua.hpp"
 #include <new>
 
+#if !defined(AP_TERRAIN_AVAILABLE) || (AP_TERRAIN_AVAILABLE != 1)
+  #error Scripting requires terrain to be available
+
+#endif // !defined(AP_TERRAIN_AVAILABLE) || (AP_TERRAIN_AVAILABLE != 1)
+
+
 int new_Vector2f(lua_State *L);
 Vector2f * check_Vector2f(lua_State *L, int arg);
 int new_Vector3f(lua_State *L);


### PR DESCRIPTION
Scripting has a hard requirement on AP_Terrain being available, this allows us to emit a cleaner error message if you have disabled terrain but not scripting.

This replaces #12065.

If you disable terrain but not scripting you now get a message that looks like this:
```
[530/598] Compiling libraries/AP_Terrain/AP_Terrain.cpp
[531/598] Compiling libraries/AP_Scripting/lua_scripts.cpp
[532/598] Compiling libraries/AP_Scripting/lua_bindings.cpp
In file included from ../../libraries/AP_Scripting/lua_scripts.cpp:29:0:
../../libraries/AP_Scripting/lua_generated_bindings.h:18:4: error: #error Scripting requires terrain to be available
   #error Scripting requires terrain to be available
    ^~~~~
compilation terminated due to -Wfatal-errors.

In file included from ../../libraries/AP_Scripting/lua_bindings.cpp:8:0:
../../libraries/AP_Scripting/lua_generated_bindings.h:18:4: error: #error Scripting requires terrain to be available
   #error Scripting requires terrain to be available
    ^~~~~
compilation terminated due to -Wfatal-errors.
```

EDIT: This was done as a generator feature in the end, as it's where we currently tweak the dependencies, and it allows us to easily add others.