### PR TITLE
Add UART stats to MAV dataflash message

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -367,6 +367,12 @@ struct PACKED log_MAV {
     uint16_t packet_tx_count;
     uint16_t packet_rx_success_count;
     uint16_t packet_rx_drop_count;
+    uint16_t rxq_min;
+    uint16_t rxq_max;
+    uint16_t rxq_avg;
+    uint16_t txq_min;
+    uint16_t txq_max;
+    uint16_t txq_avg;
 };
 
 struct PACKED log_RSSI {
@@ -1548,7 +1554,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_RALLY_MSG, sizeof(log_Rally), \
       "RALY", "QBBLLh", "TimeUS,Tot,Seq,Lat,Lng,Alt", "s--DUm", "F--GGB" },  \
     { LOG_MAV_MSG, sizeof(log_MAV),   \
-      "MAV", "QBHHH",   "TimeUS,chan,txp,rxp,rxdp", "s#---", "F-000" },   \
+      "MAV", "QBHHHHHHHHH",   "TimeUS,chan,txp,rxp,rxdp,rmn,rmx,rav,tmn,tmx,tav", "s#---------", "F-000000000" },   \
     { LOG_VISUALODOM_MSG, sizeof(log_VisualOdom), \
       "VISO", "Qffffffff", "TimeUS,dt,AngDX,AngDY,AngDZ,PosDX,PosDY,PosDZ,conf", "ssrrrmmm-", "FF000000-" }, \
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -666,6 +666,16 @@ private:
 
     uint8_t last_tx_seq;
     uint16_t send_packet_count;
+    struct {
+        uint16_t rx_min;
+        uint16_t rx_max;
+        uint32_t rx_sum;
+        uint16_t rx_count;
+        uint16_t tx_min;
+        uint16_t tx_max;
+        uint32_t tx_sum;
+        uint16_t tx_count;
+    } qstats;
 
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS
     struct {


### PR DESCRIPTION
We discussed this on the call yesterday.  This may not be suitable for running all the time - we just want to know what the statistics are like on the UART being used for the gimbal on Solo (trying to explain gimbal overshoots).  (@Pedals2Paddles)

Tested both in SITL and on an stm-32 board running Plane (@300Hz, 4Hz streamrates).

```pbarker@bluebottle:~/rc/ardupilot(master)$ mavlogdump.py ../log2.bin --t 'MAV' --condition "MAV.chan==0"
2019-08-21 11:22:56.84: MAV {TimeUS : 53183859, chan : 0, txp : 3567, rxp : 32, rxdp : 0, rmn : 0, rmx : 48, rav : 0, tmn : 3880, tmx : 4095, tav : 4077}
2019-08-21 11:22:57.84: MAV {TimeUS : 54187054, chan : 0, txp : 3668, rxp : 33, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3930, tmx : 4095, tav : 4080}
2019-08-21 11:22:58.84: MAV {TimeUS : 55190177, chan : 0, txp : 3769, rxp : 34, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3930, tmx : 4095, tav : 4080}
2019-08-21 11:22:59.85: MAV {TimeUS : 56193420, chan : 0, txp : 3871, rxp : 36, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3933, tmx : 4095, tav : 4080}
2019-08-21 11:23:00.85: MAV {TimeUS : 57196832, chan : 0, txp : 3973, rxp : 37, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3930, tmx : 4095, tav : 4080}
2019-08-21 11:23:01.85: MAV {TimeUS : 58199943, chan : 0, txp : 4074, rxp : 38, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3930, tmx : 4095, tav : 4080}
2019-08-21 11:23:02.86: MAV {TimeUS : 59203113, chan : 0, txp : 4175, rxp : 39, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3914, tmx : 4095, tav : 4080}
2019-08-21 11:23:03.86: MAV {TimeUS : 60206352, chan : 0, txp : 4277, rxp : 40, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3930, tmx : 4095, tav : 4080}
2019-08-21 11:23:04.86: MAV {TimeUS : 61209703, chan : 0, txp : 4381, rxp : 41, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3949, tmx : 4095, tav : 4080}
2019-08-21 11:23:05.87: MAV {TimeUS : 62212914, chan : 0, txp : 4486, rxp : 42, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3942, tmx : 4095, tav : 4080}
2019-08-21 11:23:06.87: MAV {TimeUS : 63213695, chan : 0, txp : 4588, rxp : 43, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3914, tmx : 4095, tav : 4080}
2019-08-21 11:23:07.87: MAV {TimeUS : 64216845, chan : 0, txp : 4692, rxp : 44, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3933, tmx : 4095, tav : 4080}
2019-08-21 11:23:08.87: MAV {TimeUS : 65219968, chan : 0, txp : 4796, rxp : 45, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3933, tmx : 4095, tav : 4080}
2019-08-21 11:23:09.88: MAV {TimeUS : 66223165, chan : 0, txp : 4898, rxp : 46, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3930, tmx : 4095, tav : 4080}
2019-08-21 11:23:10.88: MAV {TimeUS : 67226375, chan : 0, txp : 5004, rxp : 47, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3919, tmx : 4095, tav : 4079}
2019-08-21 11:23:11.88: MAV {TimeUS : 68229737, chan : 0, txp : 5107, rxp : 48, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 3930, tmx : 4095, tav : 4080}
pbarker@bluebottle:~/rc/ardupilot(master)$ 
```

The Plane also has an esp8266 on the second channel:

```
pbarker@bluebottle:~/rc/ardupilot(pr/logger-MAV-uart-stats)$ mavlogdump.py ../log2.bin --t 'MAV' --condition "MAV.chan==1"
2019-08-21 11:22:56.84: MAV {TimeUS : 53183883, chan : 1, txp : 4589, rxp : 70, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 7, tmx : 1023, tav : 754}
2019-08-21 11:22:57.84: MAV {TimeUS : 54187075, chan : 1, txp : 4661, rxp : 72, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 46, tmx : 1023, tav : 567}
2019-08-21 11:22:58.84: MAV {TimeUS : 55190202, chan : 1, txp : 4714, rxp : 74, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 30, tmx : 1023, tav : 783}
2019-08-21 11:22:59.85: MAV {TimeUS : 56193445, chan : 1, txp : 4787, rxp : 76, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 21, tmx : 1023, tav : 741}
2019-08-21 11:23:00.85: MAV {TimeUS : 57196852, chan : 1, txp : 4860, rxp : 78, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 1, tmx : 1023, tav : 715}
2019-08-21 11:23:01.85: MAV {TimeUS : 58199967, chan : 1, txp : 4931, rxp : 80, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 46, tmx : 1023, tav : 726}
2019-08-21 11:23:02.86: MAV {TimeUS : 59203138, chan : 1, txp : 4994, rxp : 82, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 21, tmx : 1023, tav : 779}
2019-08-21 11:23:03.86: MAV {TimeUS : 60206381, chan : 1, txp : 5055, rxp : 84, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 36, tmx : 1023, tav : 784}
2019-08-21 11:23:04.86: MAV {TimeUS : 61209727, chan : 1, txp : 5111, rxp : 86, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 36, tmx : 1023, tav : 810}
2019-08-21 11:23:05.87: MAV {TimeUS : 62212938, chan : 1, txp : 5166, rxp : 88, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 6, tmx : 1023, tav : 808}
2019-08-21 11:23:06.87: MAV {TimeUS : 63213719, chan : 1, txp : 5216, rxp : 90, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 51, tmx : 1023, tav : 816}
2019-08-21 11:23:07.87: MAV {TimeUS : 64216865, chan : 1, txp : 5265, rxp : 92, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 6, tmx : 1023, tav : 823}
2019-08-21 11:23:08.87: MAV {TimeUS : 65219995, chan : 1, txp : 5360, rxp : 94, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 1, tmx : 1023, tav : 522}
2019-08-21 11:23:09.88: MAV {TimeUS : 66223190, chan : 1, txp : 5465, rxp : 100, rxdp : 0, rmn : 0, rmx : 112, rav : 0, tmn : 0, tmx : 207, tav : 43}
2019-08-21 11:23:10.88: MAV {TimeUS : 67226399, chan : 1, txp : 5565, rxp : 102, rxdp : 0, rmn : 0, rmx : 34, rav : 0, tmn : 0, tmx : 208, tav : 49}
2019-08-21 11:23:11.88: MAV {TimeUS : 68229761, chan : 1, txp : 5666, rxp : 103, rxdp : 0, rmn : 0, rmx : 19, rav : 0, tmn : 0, tmx : 185, tav : 45}
pbarker@bluebottle:~/rc/ardupilot(pr/logger-MAV-uart-stats)$ 
```
