### PR TITLE
Copter: fix compilation when drift mode is disabled

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -204,9 +204,15 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     // into a manual throttle mode from a non-manual-throttle mode
     // (e.g. user arms in guided, raises throttle to 1300 (not enough to
     // trigger auto takeoff), then switches into manual):
+    bool user_throttle = new_flightmode->has_manual_throttle();
+#if MODE_DRIFT_ENABLED == ENABLED
+    if (new_flightmode == &mode_drift) {
+        user_throttle = true;
+    }
+#endif
     if (!ignore_checks &&
         ap.land_complete &&
-        (new_flightmode->has_manual_throttle() || new_flightmode == &mode_drift) &&
+        user_throttle &&
         !copter.flightmode->has_manual_throttle() &&
         new_flightmode->get_pilot_desired_throttle() > copter.get_non_takeoff_throttle()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: throttle too high");


### PR DESCRIPTION
I have only validated that this compiles.

This should be NFC (apart from actually compiling...).

I think there's a wider discussion to be had on when we should allow these mode switches.  Depending on how aggressively it is tuned, popping the vehicle into several other modes may cause it to leap off the ground here.

e.g.:
```
STABILIZE> mode guided
STABILIZE> Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
GUIDED> Mode GUIDED
rc 3 2000
GUIDED> param set FS_GCS_ENABLE 0
GUIDED> arm throttle
GUIDED> APM: Arming motors
Got MAVLink msg: COMMAND_ACK {command : 400, result : 0}
ARMED

GUIDED> mode loiter
GUIDED> Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
LOITER> Mode LOITER
APM: EKF2 IMU0 in-flight yaw alignment complete
APM: EKF2 IMU1 in-flight yaw alignment complete
height 15
height 25
SIM_VEHICLE: Keyboard Interrupt received ...
SIM_VEHICLE: Killing tasks
```
