### PR TITLE
Copter: correct build when AFS disabled

### DIFF
--- a/ArduCopter/afs_copter.h
+++ b/ArduCopter/afs_copter.h
@@ -30,14 +30,14 @@ public:
     AP_AdvancedFailsafe_Copter(AP_Mission &_mission);
 
     // called to set all outputs to termination state
-    void terminate_vehicle(void);
+    void terminate_vehicle(void) override;
     
 protected:
     // setup failsafe values for if FMU firmware stops running
-    void setup_IO_failsafe(void);
+    void setup_IO_failsafe(void) override;
 
     // return the AFS mapped control mode
-    enum control_mode afs_mode(void);
+    enum control_mode afs_mode(void) override;
 };
 
 #endif // ADVANCED_FAILSAFE


### PR DESCRIPTION
I have only verified that this compiles when AFS is disabled.
