### PR TITLE
Rover: fix sailboat without motors moving backwards in SITL

### DIFF
--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -43,6 +43,7 @@ Sailboat::Sailboat(const char *frame_str) :
     steering_angle_max(35),
     turning_circle(1.8)
 {
+    motor_connected = (strcmp(frame_str, "sailboat-motor") == 0);
 }
 
 // calculate the lift and drag as values from 0 to 1
@@ -222,9 +223,9 @@ void Sailboat::update(const struct sitl_input &input)
     // throttle force (for motor sailing)
     // gives throttle force == hull drag at 10m/s
     float throttle_force = 0.0f;
-    uint16_t throttle_in = input.servos[THROTTLE_SERVO_CH];
-    if (throttle_in > 900 && throttle_in < 2100) {
-        throttle_force = (throttle_in-1500) * 0.1f;
+    if (motor_connected) {
+        const uint16_t throttle_out = constrain_int16(input.servos[THROTTLE_SERVO_CH], 1000, 2000);
+        throttle_force = (throttle_out-1500) * 0.1f;
     }
 
     // accel in body frame due acceleration from sail and deceleration from hull friction

--- a/libraries/SITL/SIM_Sailboat.h
+++ b/libraries/SITL/SIM_Sailboat.h
@@ -69,6 +69,7 @@ private:
     Vector3f wave_gyro;         // rad/s
     float wave_heave;           // m/s/s
     float wave_phase;           // rads
+    bool motor_connected;       // true if this frame has a motor
 };
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Sailboat.h
+++ b/libraries/SITL/SIM_Sailboat.h
@@ -52,6 +52,9 @@ private:
     // return lateral acceleration in m/s/s given a steering input (in the range -1 to +1) and speed in m/s
     float get_lat_accel(float steering, float speed) const;
 
+    // simulate waves and swell
+    void update_wave(float delta_time);
+
     float steering_angle_max;   // vehicle steering mechanism's max angle in degrees
     float turning_circle;       // vehicle minimum turning circle diameter in meters
 
@@ -63,13 +66,9 @@ private:
     const float mass = 2.0f;
 
     Vector3f velocity_ef_water; // m/s
-
-    // simulate basic waves / swell
-    void update_wave(float delta_time);
-    Vector3f wave_gyro; // rad/s
-    float wave_heave; // m/s/s
-    float wave_phase; // rads
-
+    Vector3f wave_gyro;         // rad/s
+    float wave_heave;           // m/s/s
+    float wave_phase;           // rads
 };
 
 } // namespace SITL


### PR DESCRIPTION
This PR resolves this issue: https://github.com/ArduPilot/ardupilot/issues/12096

The underlying issue is the [SITL sailboat frame](https://github.com/ArduPilot/ardupilot/blob/master/libraries/SITL/SIM_Sailboat.cpp) is meant to support sailboats both with and without a motor.  The virtual motor is attached to servo output channel 3.  When we use the regular sailboat frame this output immediately goes to 1000 which means the motor goes into full reverse and the vehicle moves backwards.

This PR adds a new "motor_connected" variable to the SITL Sailboat class which is only set to true if the name of the frame is "sailboat-motor".

This has been tested in SITL using both the "sailboat" and "sailboat-motor" frames and works as expected.  With the "sailboat" frame the vehicle doesn't move backwards at startup.  When using "sailboat-motor" frame the simulated sailboat moves when the motor is turned on.

As a side note, I suspect there is an issue in SITL's code to populate the input.servos[] array.  Below is a picture showing a discrepancy between SERVO_OUTPUT_RAW.servo3_raw and input.servos[2].  Note that SERVO_OUTPUT_xxx shows "0" while input.servos[2] shows 1000.
![sailboat-sitl-servo3-output](https://user-images.githubusercontent.com/1498098/63425031-9ea8d700-c44a-11e9-9350-8aed90419419.png)
