### PR TITLE
Implement AFS_MAX_RANGE option

### DIFF
--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -16,6 +16,12 @@ AP_AdvancedFailsafe_Plane::AP_AdvancedFailsafe_Plane(AP_Mission &_mission) :
  */
 void AP_AdvancedFailsafe_Plane::terminate_vehicle(void)
 {
+    if (plane.quadplane.available() && _terminate_action == TERMINATE_ACTION_LAND) {
+        // perform a VTOL landing
+        plane.set_mode(plane.mode_qland, MODE_REASON_FENCE_BREACH);
+        return;
+    }
+
     plane.g2.servo_channels.disable_passthrough(true);
     
     if (_terminate_action == TERMINATE_ACTION_LAND) {

--- a/ArduPlane/failsafe.cpp
+++ b/ArduPlane/failsafe.cpp
@@ -86,7 +86,9 @@ void Plane::failsafe_check(void)
 #if ADVANCED_FAILSAFE == ENABLED
         if (afs.should_crash_vehicle()) {
             afs.terminate_vehicle();
-            return;
+            if (!afs.terminating_vehicle_via_landing()) {
+                return;
+            }
         }
 #endif
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1634,7 +1634,7 @@ void QuadPlane::update(void)
     }
 
 #if ADVANCED_FAILSAFE == ENABLED
-    if (plane.afs.should_crash_vehicle()) {
+    if (plane.afs.should_crash_vehicle() && !plane.afs.terminating_vehicle_via_landing()) {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
         motors->output();
         return;
@@ -1826,7 +1826,9 @@ void QuadPlane::motors_output(bool run_rate_controller)
     }
 
 #if ADVANCED_FAILSAFE == ENABLED
-    if (!hal.util->get_soft_armed() || plane.afs.should_crash_vehicle() || SRV_Channels::get_emergency_stop()) {
+    if (!hal.util->get_soft_armed() ||
+        (plane.afs.should_crash_vehicle() && !plane.afs.terminating_vehicle_via_landing()) ||
+         SRV_Channels::get_emergency_stop()) {
 #else
     if (!hal.util->get_soft_armed() || SRV_Channels::get_emergency_stop()) {
 #endif

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -672,7 +672,9 @@ void Plane::set_servos(void)
 #if ADVANCED_FAILSAFE == ENABLED
     if (afs.should_crash_vehicle()) {
         afs.terminate_vehicle();
-        return;
+        if (!afs.terminating_vehicle_via_landing()) {
+            return;
+        }
     }
 #endif
 

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -149,6 +149,13 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @Units: s
     AP_GROUPINFO("RC_FAIL_TIME",   19, AP_AdvancedFailsafe, _rc_fail_time_seconds,    0),
 
+    // @Param: MAX_RANGE
+    // @DisplayName: Max allowed range
+    // @Description: This is the maximum range of the vehicle in kilometers from first arming. If the vehicle goes beyond this range then the TERM_ACTION is performed. A value of zero disables this feature.
+    // @User: Advanced
+    // @Units: km
+    AP_GROUPINFO("MAX_RANGE",   20, AP_AdvancedFailsafe, _max_range_km,    0),
+    
     AP_GROUPEND
 };
 
@@ -170,6 +177,9 @@ AP_AdvancedFailsafe::check(uint32_t last_heartbeat_ms, bool geofence_breached, u
             }
         }
     }
+
+    // update max range check
+    max_range_update();
 
     enum control_mode mode = afs_mode();
     
@@ -403,4 +413,43 @@ bool AP_AdvancedFailsafe::gcs_terminate(bool should_terminate, const char *reaso
         gcs().send_text(MAV_SEVERITY_INFO, "Unable to terminate, termination is not configured");
     }
     return false;
+}
+
+/*
+  update check of maximum range
+ */
+void AP_AdvancedFailsafe::max_range_update(void)
+{
+    if (_max_range_km <= 0) {
+        return;
+    }
+
+    if (!_have_first_location) {
+        if (AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
+            // wait for 3D fix
+            return;
+        }
+        if (!hal.util->get_soft_armed()) {
+            // wait for arming
+            return;
+        }
+        _first_location = AP::gps().location();
+        _have_first_location = true;
+    }
+
+    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
+        // don't trigger when dead-reckoning
+        return;
+    }
+    
+    // check distance from first location
+    float distance_km = _first_location.get_distance(AP::gps().location()) * 0.001;
+    if (distance_km > _max_range_km) {
+        uint32_t now = AP_HAL::millis();
+        if (now - _term_range_notice_ms > 5000) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Terminating due to range %.1fkm", distance_km);
+            _term_range_notice_ms = now;
+        }
+        _terminate.set_and_notify(1);
+    }
 }

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -118,6 +118,7 @@ protected:
     AP_Int8  _enable_RC_fs;
     AP_Int8  _rc_term_manual_only;
     AP_Int8  _enable_dual_loss;
+    AP_Int16  _max_range_km;
 
     bool _heartbeat_pin_value;
 
@@ -139,5 +140,13 @@ protected:
     // have the failsafe values been setup?
     bool _failsafe_setup:1;
 
+    Location _first_location;
+    bool _have_first_location;
+    uint32_t _term_range_notice_ms;
+
     bool check_altlimit(void);
+
+private:
+    // update maximum range check
+    void max_range_update();
 };


### PR DESCRIPTION
this allows a maximum range since first arm to be set in AFS_MAX_RANGE. This value (in km) will trigger the configuredtermination type if the GPS location shows that it has been breached.
    
This feature, in combination with the @READONLY apj parameter feature, is intended to be used to meet regulatory restrictions on a vehicles maximum range
