### PR TITLE
Copter: fix format-string compilation warning

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1369,7 +1369,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         // absolute delay to utc time
         nav_delay_time_max_ms = AP::rtc().get_time_utc(cmd.content.nav_delay.hour_utc, cmd.content.nav_delay.min_utc, cmd.content.nav_delay.sec_utc, 0);
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec",nav_delay_time_max_ms/1000);
+    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
 }
 
 /********************************************************************************/


### PR DESCRIPTION
Only ensured this compiled in SITL and with mini-pix.

```
../../ArduCopter/mode_auto.cpp: In member function 'void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command&)':
../../ArduCopter/mode_auto.cpp:1372:84: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'long unsigned int' [-Wformat=]
     gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec",nav_delay_time_max_ms/1000);
                                                                                    ^
```

This is with a mini-pix build.