### PR TITLE
AP_GPS: ublox: log the first seen uptime from the reciever

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -570,6 +570,8 @@ private:
     // do we have new speed information?
     bool            _new_speed:1;
 
+    uint32_t        first_msss; // first milliseconds since startup seen
+
     uint8_t         _disable_counter;
 
     // Buffer parse & GPS state update


### PR DESCRIPTION
By logging the uptime when we first detect the instance (really it's when we get the first NAV-STATUS from the GPS), this lets us tell if later redetects of the GPS are a reboot of the receiver (IE power issues) or cabling issues that cost us communication with the receiver. This was motivated by the uncertainty we always have when reviewing logs, and came up again [here](https://discuss.cubepilot.org/t/loss-of-all-satellites-on-here-2-gnss-in-flight/1570).

The alternate logging option would be to always log the GPS uptime which would be more robust if the GPS reboot on the same configuration/baud rate, I rejected this however as it requires us to never turn off the NAV-STATUS message, which increases the bandwidth required to the receiver. If we are all fine with the extra comms to the GPS and logging we could get this information brought down as well.

EDIT: This was bench tested against a F9P as it happens to be what I have plugged in.