### PR TITLE
Hide MIS_TOTAL parameter by specifying NONE frame

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -15,7 +15,7 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     // @ReadOnly: True
-    AP_GROUPINFO_FLAGS("TOTAL",  0, AP_Mission, _cmd_total, 0, AP_PARAM_FLAG_INTERNAL_USE_ONLY),
+AP_GROUPINFO_FLAGS_FRAME("TOTAL",  0, AP_Mission, _cmd_total, 0, AP_PARAM_FLAG_INTERNAL_USE_ONLY, AP_PARAM_FRAME_NONE),
 
     // @Param: RESTART
     // @DisplayName: Mission Restart when entering Auto mode

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -83,6 +83,7 @@
 #define AP_PARAM_FRAME_SUB          (1<<3)
 #define AP_PARAM_FRAME_TRICOPTER    (1<<4)
 #define AP_PARAM_FRAME_HELI         (1<<5)
+#define AP_PARAM_FRAME_NONE         (1<<6) // should not be visible to the user
 
 // a variant of offsetof() to work around C++ restrictions.
 // this can only be used when the offset of a variable in a object


### PR DESCRIPTION
There's no particular reason we need to show this to anybody.  Hiding it means GCSs are less likely to fall afoul of our new ReadOnly stuff, too.

