### PR TITLE
Copter: zigzag stops more smoothly on terrain data failure

### DIFF
--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -122,10 +122,14 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
     if (stage == AUTO) {
         stage = MANUAL_REGAIN;
         loiter_nav->clear_pilot_desired_acceleration();
-        const Vector3f wp_dest = wp_nav->get_wp_destination();
-        loiter_nav->init_target(wp_dest);
-        if (maintain_target && wp_nav->origin_and_destination_are_terrain_alt()) {
-            copter.surface_tracking.set_target_alt_cm(wp_dest.z);
+        if (maintain_target) {
+            const Vector3f wp_dest = wp_nav->get_wp_destination();
+            loiter_nav->init_target(wp_dest);
+            if (wp_nav->origin_and_destination_are_terrain_alt()) {
+                copter.surface_tracking.set_target_alt_cm(wp_dest.z);
+            }
+        } else {
+            loiter_nav->init_target();
         }
         gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: manual control");
     }


### PR DESCRIPTION
This reduces the aggressiveness of the stops in zigzag mode when the vehicle is returned to manual control either because of a terrain data failure (i.e. sonar data failure) or because the ZigZag_SaveWP auxiliary switch is moved to the central position.

ZigZag mode itself is a relatively recent addition (created after Copter-3.6 was released) so it is likely that this was a small oversight in the original implementation.

Here are screen shots of the before and after roll angle when returning to manual control.
![before-after-comparison](https://user-images.githubusercontent.com/1498098/63487624-f7c64880-c4e6-11e9-92c8-d72b75a8b9da.png)

This has been tested in SITL and will be tested on a real vehicle in the next few days.