### PR TITLE
Rover: sailboats tack on fence

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -242,6 +242,12 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
     // apply object avoidance to desired speed using half vehicle's maximum deceleration
     if (avoidance_enabled) {
         g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_decel_max(), ahrs.yaw, target_speed, rover.G_Dt);
+        if (g2.sailboat.tack_enabled() && g2.avoid.limits_active()) {
+            // we are a sailboat trying to avoid fence, try a tack
+            if (rover.control_mode != &rover.mode_acro) {
+                rover.control_mode->handle_tack_request();
+            }
+        }
     }
 
     // call throttle controller and convert output to -100 to +100 range


### PR DESCRIPTION
This adds a method to track if AC_Avodance is actively avoiding, if it is a sailboat will try a tack. 

https://youtu.be/AAhHa9Nh3mU

This shows a sailboat sailing upwind between two wayponints parallel to a fence boundary. The sailboat tacks on the fence boundary, at the other it tacks on a cross track error of 100m. This would benefit from the tacking improvements from https://github.com/ArduPilot/ardupilot/pull/11423. Tacking may not always result in traveling away from the fence but in 95% of cases it is a improvement over stopping.  I think this should also allow tacking on avoidance data from a rangefinder...... 

This also lays the ground work for reporting if fence limiting is active, see https://github.com/mavlink/mavlink/pull/1215