### PR TITLE
AR_WPNav: bug fix

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -327,7 +327,7 @@ void AR_WPNav::update_distance_and_bearing_to_destination()
     // update OA adjusted values
     if (_oa_active) {
         _oa_distance_to_destination = current_loc.get_distance(_oa_destination);
-        _oa_wp_bearing_cd = _oa_origin.get_bearing_to(_oa_destination);
+        _oa_wp_bearing_cd = current_loc.get_bearing_to(_oa_destination);
     } else {
         _oa_distance_to_destination = _distance_to_destination;
         _oa_wp_bearing_cd = _wp_bearing_cd;

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -62,7 +62,7 @@ public:
     const Location &get_oa_destination() { return _oa_destination; }
 
     // return heading (in degrees) and cross track error (in meters) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
-    float wp_bearing_cd() const { return _wp_bearing_cd; }
+    float wp_bearing_cd() const { return _oa_wp_bearing_cd; }
     float nav_bearing_cd() const { return _desired_heading_cd; }
     float crosstrack_error() const { return _cross_track_error; }
 


### PR DESCRIPTION
This is small bug (I think) fix that in combination with https://github.com/ArduPilot/ardupilot/pull/12117 allows sailboats to work with the avoidance path planner, this is a example with Dijkstra's. 

https://youtu.be/UzJ66stWt98

a small improvement could be made to make the Dijkstra's code work better for sailboats, It should be possible to skip intermediate points in some cases, for example [here ](https://youtu.be/UzJ66stWt98?t=15) it could have jumped onto the next point and saved some tacks.

but all in all it basically 'just works'