### PR TITLE
Rover: use oa_wp_bearing_cd for sailboat nav

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -394,7 +394,7 @@ void Mode::navigate_to_waypoint()
     desired_speed = calc_speed_nudge(desired_speed, g2.wp_nav.get_reversed());
     calc_throttle(desired_speed, true);
 
-    float desired_heading_cd = g2.wp_nav.wp_bearing_cd();
+    float desired_heading_cd = g2.wp_nav.oa_wp_bearing_cd();
     if (g2.sailboat.use_indirect_route(desired_heading_cd)) {
         // sailboats use heading controller when tacking upwind
         desired_heading_cd = g2.sailboat.calc_heading(desired_heading_cd);

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -66,6 +66,9 @@ public:
     float nav_bearing_cd() const { return _desired_heading_cd; }
     float crosstrack_error() const { return _cross_track_error; }
 
+    // return the heading (in centi-degrees) to the next waypoint accounting for OA, (used by sailboats)
+    float oa_wp_bearing_cd() const { return _oa_wp_bearing_cd; }
+
     // settor to allow vehicle code to provide turn related param values to this library (should be updated regularly)
     void set_turn_params(float turn_max_g, float turn_radius, bool pivot_possible);
 


### PR DESCRIPTION
as https://github.com/ArduPilot/ardupilot/pull/12119 turned out not to be a bug this is a new function that does the same thing