### PR TITLE
ChibiOS: Added ISR limit on I2C

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
@@ -382,3 +382,8 @@
  * WDG driver system settings.
  */
 #define STM32_WDG_USE_IWDG                  FALSE
+
+// limit ISR count per byte
+#define STM32_I2C_ISR_LIMIT                 6
+
+

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -439,3 +439,6 @@
 #define STM32_WDG_USE_IWDG                  FALSE
 
 #define STM32_EXTI_ENHANCED
+
+// limit ISR count per byte
+#define STM32_I2C_ISR_LIMIT                 6

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -52,6 +52,7 @@ public:
         gcs_bad_missionprotocol_link= (1U << 16),
         bitmask_range               = (1U << 17),
         gcs_offset                  = (1U << 18),
+        i2c_isr                     = (1U << 19),
     };
 
     void error(const AP_InternalError::error_t error);


### PR DESCRIPTION
this adds a limit on the number of interrupts allowed per transaction  for I2C peripherals on STM32. It is meant to prevent any possibility of an interrupt storm due to a badly behaving peripheral which generates an interrupt which isn't properly acknowledged or cannot be acknowledged

This is meant to fix the most likely cause of #11642. If it does happen then we will reset the I2C peripheral and will report an internal error
