### PR TITLE
Add startup and radio-failsafe sounds to Buzzer tones

### DIFF
--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -40,11 +40,16 @@ private:
 
     // Patterns - how many beeps will be played; read from
     // left-to-right, each bit represents 100ms
-    static const uint32_t    SINGLE_BUZZ = 0b10000000000000000000000000000000UL;
-    static const uint32_t    DOUBLE_BUZZ = 0b10100000000000000000000000000000UL;
-    static const uint32_t    ARMING_BUZZ = 0b11111111111111111111111111111100UL; // 3s
-    static const uint32_t      BARO_BUZZ = 0b10101010100000000000000000000000UL;
-    static const uint32_t        EKF_BAD = 0b11101101010000000000000000000000UL;
+    static const uint32_t     SINGLE_BUZZ = 0b10000000000000000000000000000000UL;
+    static const uint32_t     DOUBLE_BUZZ = 0b10100000000101000000010100000001UL;
+    static const uint32_t     ARMING_BUZZ = 0b11111111111111111111111111111100UL; // 3s
+    static const uint32_t   CONSTANT_BUZZ = 0b11111111111111111111111111111111UL;
+    static const uint32_t       BARO_BUZZ = 0b10101010100000000000000000000000UL;
+    static const uint32_t         EKF_BAD = 0b11101101010000000000000000000000UL;
+    static const uint32_t INITIALIZE_BUZZ = 0b10101000000000000000000000000000UL;
+    static const uint32_t  RADIOLOST_BUZZ = 0b11011111110000000000000000000000UL;
+    static const uint32_t   RADIOSOS_BUZZ = 0b00010101011101110111010101000001UL; // SOS pattern
+    static const uint32_t  RADIOBACK_BUZZ = 0b01111010000000000000000000000000UL;
 
     /// play_pattern - plays the defined buzzer pattern
     void play_pattern(const uint32_t pattern);
@@ -56,16 +61,20 @@ private:
         uint8_t armed               : 1;    // 0 = disarmed, 1 = armed
         uint8_t failsafe_battery    : 1;    // 1 if battery failsafe has triggered
         uint8_t ekf_bad             : 1;    // 1 if ekf position has gone bad
+        uint8_t initialize_started  : 1;    // 1 if system initialization started
+        uint8_t initialize_done     : 1;    // 1 if system initialization complete
+        uint8_t startup_beep        : 1;    // 1 after startup single-beep played
+        uint8_t failsafe_radio      : 1;    // 1 if radio failsafe has triggered
+        uint8_t was_armed           : 1;    // 1 if system has been armed
     } _flags;
 
+    int8_t _update_counter;      // reduce 50hz update down to 10hz for internal processing
     uint32_t _pattern;           // current pattern
+    uint8_t _pattern_pos;        // current position in pattern
     uint8_t _pin;
-    uint32_t _pattern_start_time;
-
-    // enforce minumum 100ms interval between patterns:
-    const uint16_t _pattern_start_interval_time_ms = 32*100 + 100;
 
     void update_playing_pattern();
     void update_pattern_to_play();
+    bool is_playing_pattern();
 
 };


### PR DESCRIPTION
This is for the boards that can only support a simple "active" type buzzer.

Added:

Beep at startup and then three beeps after initialization done.

Modified 'update_playing_pattern()' to stop playing
when remainder of pattern is all zeroes.

Plays beeps when radio link is lost and recovered.
If the model is or was armed then the lost-radio-link
beeps repeat indefinitely (to act as a find-lost-model sound).

I've tested this on an OmnibusNanoV6 board (with PR #12081 applied).