### PR TITLE
ChibiOS: fixed I2C BTF interrupt storm

### DIFF
--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -66,6 +66,7 @@ public:
         uint16_t semaphore_line;
         uint32_t spi_count;
         uint32_t i2c_count;
+        uint32_t i2c_isr_count;
         uint16_t fault_line;
         uint8_t fault_type;
         uint8_t fault_thd_prio;

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -280,6 +280,9 @@ bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
             break;
         }
 
+        AP_HAL::Util::PersistentData &pd = hal.util->persistent_data;
+        pd.i2c_isr_count += I2CD[bus.busnum].i2c->isr_count;
+
         if (ret == MSG_OK) {
             bus.bouncebuffer_finish(send, recv, recv_len);
             i2cReleaseBus(I2CD[bus.busnum].i2c);

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -248,7 +248,7 @@ bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
     for(uint8_t i=0 ; i <= _retries; i++) {
         int ret;
         // calculate a timeout as twice the expected transfer time, and set as min of 4ms
-        uint32_t timeout_ms = 1+2*(((8*1000000UL/bus.busclock)*MAX(send_len, recv_len))/1000);
+        uint32_t timeout_ms = 1+2*(((8*1000000UL/bus.busclock)*(send_len+recv_len))/1000);
         timeout_ms = MAX(timeout_ms, _timeout_ms);
 
         // we get the lock and start the bus inside the retry loop to

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1116,6 +1116,7 @@ struct PACKED log_Performance {
     uint32_t internal_error_count;
     uint32_t spi_count;
     uint32_t i2c_count;
+    uint32_t i2c_isr_count;
 };
 
 struct PACKED log_SRTL {
@@ -1365,7 +1366,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_PROXIMITY_MSG, sizeof(log_Proximity), \
       "PRX", "QBfffffffffff", "TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315,DUp,CAn,CDis", "s-mmmmmmmmmhm", "F-00000000000" }, \
     { LOG_PERFORMANCE_MSG, sizeof(log_Performance),                     \
-      "PM",  "QHHIIHIIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,IntErr,IntErrCnt,SPICnt,I2CCnt", "s---b%----", "F---0A----" }, \
+      "PM",  "QHHIIHIIIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,IntE,IntEC,SPIC,I2CC,I2CI", "s---b%-----", "F---0A-----" }, \
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
       "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }, \
     { LOG_OA_BENDYRULER_MSG, sizeof(log_OABendyRuler), \

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -305,6 +305,7 @@ void AP_Scheduler::Log_Write_Performance()
         internal_error_count : AP::internalerror().count(),
         spi_count        : pd.spi_count,
         i2c_count        : pd.i2c_count,
+        i2c_isr_count    : pd.i2c_isr_count,
     };
     AP::logger().WriteCriticalBlock(&pkt, sizeof(pkt));
 }


### PR DESCRIPTION
This fixes an interrupt storm that shows up on SMBus on Solo. It is caused by not properly acking BTF while waiting for an address ack.
This also adds logging of I2C interrupt counts
