### PR TITLE
AP_Logger: GPA/GPA2 Change the unit of DELTA.

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1204,7 +1204,7 @@ struct PACKED log_Arm_Disarm {
 #define GPA_LABELS "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS,Delta"
 #define GPA_FMT   "QCCCCBIH"
 #define GPA_UNITS "smmmn-ss"
-#define GPA_MULTS "FBBBB-CF"
+#define GPA_MULTS "FBBBB-CC"
 
 // see "struct GPS_State" and "Write_GPS":
 #define GPS_LABELS "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,Yaw,U"


### PR DESCRIPTION
GPA / GPA2 delta value is milliseconds.
However, the log unit is micro.
I change the unit.

BEFORE:
![Screenshot from 2019-08-26 12-18-05](https://user-images.githubusercontent.com/646194/63663357-040b1800-c7fd-11e9-85b8-6807277bf8d8.png)

AFTER:
![Screenshot from 2019-08-26 12-16-51](https://user-images.githubusercontent.com/646194/63663388-200eb980-c7fd-11e9-8720-8e8fb3db56f6.png)
