### PR TITLE
AP_Scripting: Fix apparent memory leak

### DIFF
--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -257,15 +257,15 @@ void *Util::heap_realloc(void *h, void *ptr, size_t new_size)
         old_size = old_header->allocation_size;
     }
 
+    if ((heapp->current_heap_usage + new_size - old_size) > heapp->max_heap_size) {
+        // fail the allocation as we don't have the memory. Note that we don't simulate fragmentation
+        return nullptr;
+    }
+
     heapp->current_heap_usage -= old_size;
     if (new_size == 0) {
        free(old_header);
        return nullptr;
-    }
-
-    if ((heapp->current_heap_usage + new_size - old_size) > heapp->max_heap_size) {
-        // fail the allocation as we don't have the memory. Note that we don't simulate fragmentation
-        return nullptr;
     }
 
     heap_allocation_header *new_header = (heap_allocation_header *)malloc(new_size + sizeof(heap_allocation_header));

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -95,15 +95,15 @@ void *HALSITL::Util::heap_realloc(void *heap_ptr, void *ptr, size_t new_size)
         old_size = old_header->allocation_size;
     }
 
+    if ((heapp->current_heap_usage + new_size - old_size) > heapp->scripting_max_heap_size) {
+        // fail the allocation as we don't have the memory. Note that we don't simulate fragmentation
+        return nullptr;
+    }
+
     heapp->current_heap_usage -= old_size;
     if (new_size == 0) {
        free(old_header);
        return nullptr;
-    }
-
-    if ((heapp->current_heap_usage + new_size - old_size) > heapp->scripting_max_heap_size) {
-        // fail the allocation as we don't have the memory. Note that we don't simulate fragmentation
-        return nullptr;
     }
 
     heap_allocation_header *new_header = (heap_allocation_header *)malloc(new_size + sizeof(heap_allocation_header));

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -393,8 +393,14 @@ void lua_scripts::run(void) {
             const uint32_t runEnd = AP_HAL::micros();
             const int endMem = lua_gc(L, LUA_GCCOUNT, 0) * 1024 + lua_gc(L, LUA_GCCOUNTB, 0);
             if (_debug_level > 1) {
-                gcs().send_text(MAV_SEVERITY_DEBUG, "Lua: Time: %u Mem: %d", (unsigned int)(runEnd - loadEnd), (int)(endMem - startMem));
+                gcs().send_text(MAV_SEVERITY_DEBUG, "Lua: Time: %u Mem: %d + %d",
+                                                    (unsigned int)(runEnd - loadEnd),
+                                                    (int)endMem,
+                                                    (int)(endMem - startMem));
             }
+
+            // garbage collect after each script, this shouldn't matter, but seems to resolve a memory leak
+            lua_gc(L, LUA_GCCOLLECT, 0);
 
         } else {
             gcs().send_text(MAV_SEVERITY_DEBUG, "Lua: No scripts to run");


### PR DESCRIPTION
This resolves an apparent memory leak from the following loop in a script:
```
function loop ()
  local file = io.open("test.lua", "r")
  file:close()
  return loop, 10
end
return loop, 10
```

No individual part of this leaks, and this is fine if we GC after each run of the loop, when we don't call this though both SITL and a ChibiOS board eventually run out of memory. (If you use a small heap (say 40-65k) this is quick to get to in both real boards and SITL to reproduce.) This deserves a more thorough investigation of why in the future, but it appears to be something related to Lua.

This also tweaks the scripting memory debug print to be more useful, it now prints the current used memory after the script was run, and the delta amount of memory allocated during the run of the script (if your script doesn't allocate a lot this is how much memory was totally allocated).

Finally this corrects a small implementation issue with the `heap_realloc` function in SITL which is supposed to behave the same as `realloc`. It was accidentally double subtracting the old_size when doing reallocs which allowed it to overuse it's memory by accident (it is relatively rare to use realloc, and on these boards you generally have the memory to get away with it, but it was still a bug).