### PR TITLE
Log Space used for parameters into dataflash on log startup

### DIFF
--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -181,6 +181,13 @@ void LoggerMessageWriter_WriteSysInfo::process() {
                 return; // call me again
             }
         }
+        stage = ws_blockwriter_stage_param_space_used;
+        FALLTHROUGH;
+
+    case ws_blockwriter_stage_param_space_used:
+        if (! _logger_backend->Write_MessageF("Param space used: %u/%u", AP_Param::storage_used(), AP_Param::storage_size())) {
+            return; // call me again
+        }
         stage = ws_blockwriter_stage_rc_protocol;
         FALLTHROUGH;
 

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -31,6 +31,7 @@ private:
         ws_blockwriter_stage_firmware_string,
         ws_blockwriter_stage_git_versions,
         ws_blockwriter_stage_system_id,
+        ws_blockwriter_stage_param_space_used,
         ws_blockwriter_stage_rc_protocol
     };
     write_sysinfo_blockwriter_stage stage;

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -36,6 +36,8 @@
 
 extern const AP_HAL::HAL &hal;
 
+uint16_t AP_Param::sentinal_offset;
+
 #define ENABLE_DEBUG 1
 
 #if ENABLE_DEBUG
@@ -117,6 +119,7 @@ void AP_Param::write_sentinal(uint16_t ofs)
     set_key(phdr, _sentinal_key);
     phdr.group_element = _sentinal_group;
     eeprom_write_check(&phdr, ofs, sizeof(phdr));
+    sentinal_offset = ofs;
 }
 
 // erase all EEPROM variables by re-writing the header and adding
@@ -695,6 +698,7 @@ bool AP_Param::scan(const AP_Param::Param_header *target, uint16_t *pofs)
         if (is_sentinal(phdr)) {
             // we've reached the sentinal
             *pofs = ofs;
+            sentinal_offset = ofs;
             return false;
         }
         ofs += type_size((enum ap_var_type)phdr.type) + sizeof(phdr);
@@ -1353,6 +1357,7 @@ bool AP_Param::load_all()
         // against power off while adding a variable
         if (is_sentinal(phdr)) {
             // we've reached the sentinal
+            sentinal_offset = ofs;
             return true;
         }
 
@@ -1438,6 +1443,7 @@ void AP_Param::load_object_from_eeprom(const void *object_pointer, const struct 
             // against power off while adding a variable
             if (is_sentinal(phdr)) {
                 // we've reached the sentinal
+                sentinal_offset = ofs;
                 break;
             }
             if (get_key(phdr) == key) {

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -349,6 +349,12 @@ public:
     ///
     static bool load_all();
 
+    // returns storage space used:
+    static uint16_t storage_used() { return sentinal_offset; }
+
+    // returns storage space :
+    static uint16_t storage_size() { return _storage.size(); }
+
     /// reoad the hal.util defaults file. Called after pointer parameters have been allocated
     ///
     static void reload_defaults_file(bool last_pass);
@@ -469,6 +475,8 @@ private:
         uint8_t revision;
         uint8_t spare;
     };
+
+    static uint16_t sentinal_offset;
 
 /* This header is prepended to a variable stored in EEPROM.
  *  The meaning is as follows:


### PR DESCRIPTION
Closes #12144

On my Bixler:

```
1970-01-01 10:00:30.99: MSG {TimeUS : 30997606, Message : Param space used: 1341/3840}
```

On a quad:
```
1970-01-01 10:00:16.45: MSG {TimeUS : 16455879, Message : Param space used: 868/3840}
```

I did originally have this going to `PM` but figured it was a waste of space in that message.
