### PR TITLE
waf: squash expansion-to-defined warnings

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -175,6 +175,7 @@ class Board:
             '-Wno-reorder',
             '-Wno-redundant-decls',
             '-Wno-unknown-pragmas',
+            '-Wno-expansion-to-defined',
             '-Werror=attributes',
             '-Werror=format-security',
             '-Werror=enum-compare',


### PR DESCRIPTION
We use these a lot in our code and we're not particularly fussed with
portability.