### PR TITLE
Stop passing serial manager through to mount init()

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -129,7 +129,7 @@ void Rover::init_ardupilot()
 
 #if MOUNT == ENABLED
     // initialise camera mount
-    camera_mount.init(serial_manager);
+    camera_mount.init();
 #endif
 
     /*

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -160,7 +160,7 @@ void Copter::init_ardupilot()
 
 #if MOUNT == ENABLED
     // initialise camera mount
-    camera_mount.init(serial_manager);
+    camera_mount.init();
 #endif
 
 #if PRECISION_LANDING == ENABLED

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -129,7 +129,7 @@ void Plane::init_ardupilot()
 
 #if MOUNT == ENABLED
     // initialise camera mount
-    camera_mount.init(serial_manager);
+    camera_mount.init();
 #endif
 
 #if LANDING_GEAR_ENABLED == ENABLED

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -127,7 +127,7 @@ void Sub::init_ardupilot()
 
 #if MOUNT == ENABLED
     // initialise camera mount
-    camera_mount.init(serial_manager);
+    camera_mount.init();
 #endif
 
 #ifdef USERHOOK_INIT

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -408,7 +408,7 @@ AP_Mount::AP_Mount(const struct Location &current_loc) :
 }
 
 // init - detect and initialise all mounts
-void AP_Mount::init(const AP_SerialManager& serial_manager)
+void AP_Mount::init()
 {
     // check init has not been called before
     if (_num_instances != 0) {
@@ -466,7 +466,7 @@ void AP_Mount::init(const AP_SerialManager& serial_manager)
 
         // init new instance
         if (_backends[instance] != nullptr) {
-            _backends[instance]->init(serial_manager);
+            _backends[instance]->init();
             if (!primary_set) {
                 _primary = instance;
                 primary_set = true;

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -23,7 +23,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 
 // maximum number of mounts
 #define AP_MOUNT_MAX_INSTANCES          1
@@ -74,7 +73,7 @@ public:
     };
 
     // init - detect and initialise all mounts
-    void init(const AP_SerialManager& serial_manager);
+    void init();
 
     // update - give mount opportunity to update servos.  should be called at 10hz or higher
     void update();

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -1,10 +1,13 @@
 #include "AP_Mount_Alexmos.h"
 #include <AP_GPS/AP_GPS.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 extern const AP_HAL::HAL& hal;
 
-void AP_Mount_Alexmos::init(const AP_SerialManager& serial_manager)
+void AP_Mount_Alexmos::init()
 {
+    const AP_SerialManager& serial_manager = AP::serialmanager();
+
     // check for alexmos protcol
     if ((_port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_AlexMos, 0))) {
         _initialised = true;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -70,7 +70,7 @@ public:
     {}
 
     // init - performs any required initialisation for this instance
-    void init(const AP_SerialManager& serial_manager) override;
+    void init() override;
 
     // update mount position - should be called periodically
     void update() override;

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -37,7 +37,7 @@ public:
     virtual ~AP_Mount_Backend(void) {}
 
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager) = 0;
+    virtual void init() = 0;
 
     // update mount position - should be called periodically
     virtual void update() = 0;

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -22,7 +22,7 @@ public:
     AP_Mount_SToRM32(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
     // init - performs any required initialisation for this instance
-    void init(const AP_SerialManager& serial_manager) override {}
+    void init() override {}
 
     // update mount position - should be called periodically
     void update() override;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -3,6 +3,7 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -12,8 +13,10 @@ AP_Mount_SToRM32_serial::AP_Mount_SToRM32_serial(AP_Mount &frontend, AP_Mount::m
 {}
 
 // init - performs any required initialisation for this instance
-void AP_Mount_SToRM32_serial::init(const AP_SerialManager& serial_manager)
+void AP_Mount_SToRM32_serial::init()
 {
+    const AP_SerialManager& serial_manager = AP::serialmanager();
+
     _port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_SToRM32, 0);
     if (_port) {
         _initialised = true;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -21,7 +21,7 @@ public:
     AP_Mount_SToRM32_serial(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
     // init - performs any required initialisation for this instance
-    void init(const AP_SerialManager& serial_manager) override;
+    void init() override;
 
     // update mount position - should be called periodically
     void update() override;

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -4,7 +4,7 @@
 extern const AP_HAL::HAL& hal;
 
 // init - performs any required initialisation for this instance
-void AP_Mount_Servo::init(const AP_SerialManager& serial_manager)
+void AP_Mount_Servo::init()
 {
     if (_instance == 0) {
         _roll_idx = SRV_Channel::k_mount_roll;

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -24,7 +24,7 @@ public:
     }
 
     // init - performs any required initialisation for this instance
-    void init(const AP_SerialManager& serial_manager) override;
+    void init() override;
 
     // update mount position - should be called periodically
     void update() override;

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -17,7 +17,7 @@ AP_Mount_SoloGimbal::AP_Mount_SoloGimbal(AP_Mount &frontend, AP_Mount::mount_sta
 {}
 
 // init - performs any required initialisation for this instance
-void AP_Mount_SoloGimbal::init(const AP_SerialManager& serial_manager)
+void AP_Mount_SoloGimbal::init()
 {
     _initialised = true;
     set_mode((enum MAV_MOUNT_MODE)_state._default_mode.get());

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -24,7 +24,7 @@ public:
     AP_Mount_SoloGimbal(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
     // init - performs any required initialisation for this instance
-    void init(const AP_SerialManager& serial_manager) override;
+    void init() override;
 
     // update mount position - should be called periodically
     void update() override;


### PR DESCRIPTION
The two backends that need it can go and get it themselves.
