### PR TITLE
Fix pixhawk1 gyro orientation

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/hwdef.dat
@@ -17,7 +17,7 @@ include ../fmuv3/hwdef.dat
 # and two SPIDEV endpoints, one for gyro, one for accel/mag
 
 IMU Invensense SPI:mpu6000 ROTATION_ROLL_180
-IMU LSM9DS0 SPI:lsm9ds0_g SPI:lsm9ds0_am ROTATION_ROLL_180
+IMU LSM9DS0 SPI:lsm9ds0_g SPI:lsm9ds0_am ROTATION_ROLL_180 ROTATION_ROLL_180_YAW_270 ROTATION_PITCH_180
 
 # define the barometers to probe with BARO lines. These follow the
 # same format as IMU lines

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -860,12 +860,6 @@ AP_InertialSensor::detect_backends(void)
 #elif HAL_INS_DEFAULT == HAL_INS_EDGE
     ADD_BACKEND(AP_InertialSensor_Invensense::probe(*this, hal.spi->get_device(HAL_INS_MPU60x0_NAME), ROTATION_YAW_90));
     ADD_BACKEND(AP_InertialSensor_Invensense::probe(*this, hal.spi->get_device(HAL_INS_MPU60x0_NAME_EXT), ROTATION_YAW_90));
-#elif HAL_INS_DEFAULT == HAL_INS_LSM9DS1
-    ADD_BACKEND(AP_InertialSensor_LSM9DS1::probe(*this, hal.spi->get_device(HAL_INS_LSM9DS1_NAME)));
-#elif HAL_INS_DEFAULT == HAL_INS_LSM9DS0
-    ADD_BACKEND(AP_InertialSensor_LSM9DS0::probe(*this,
-                 hal.spi->get_device(HAL_INS_LSM9DS0_G_NAME),
-                 hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME)));
 #elif HAL_INS_DEFAULT == HAL_INS_L3G4200D
     ADD_BACKEND(AP_InertialSensor_L3G4200D::probe(*this, hal.i2c_mgr->get_device(HAL_INS_L3G4200D_I2C_BUS, HAL_INS_L3G4200D_I2C_ADDR)));
 #elif HAL_INS_DEFAULT == HAL_INS_MPU9250_I2C

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
@@ -18,9 +18,9 @@ public:
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
                                             AP_HAL::OwnPtr<AP_HAL::Device> dev_gyro,
                                             AP_HAL::OwnPtr<AP_HAL::Device> dev_accel,
-                                            enum Rotation rotation_a = ROTATION_NONE,
-                                            enum Rotation rotation_g = ROTATION_NONE,
-                                            enum Rotation rotation_gH = ROTATION_NONE);
+                                            enum Rotation rotation_a,
+                                            enum Rotation rotation_g,
+                                            enum Rotation rotation_gH);
 
 private:
     AP_InertialSensor_LSM9DS0(AP_InertialSensor &imu,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.h
@@ -18,7 +18,7 @@ public:
 
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
                                             AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev,
-                                            enum Rotation rotation = ROTATION_NONE);
+                                            enum Rotation rotation);
 private:
     AP_InertialSensor_LSM9DS1(AP_InertialSensor &imu,
                               AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev,


### PR DESCRIPTION
This was broken by the recent switch to hwdef.dat orientations, and was caused by having default values in the headers. fixes #12143 
many thanks to @Jaaaky for spotting this!
I'll do a follow-up PR to remove the defaults for other drivers
