### PR TITLE
AP_HAL_SITL: Fix build with --sitl-flash-storage option

### DIFF
--- a/libraries/AP_HAL_SITL/Storage.cpp
+++ b/libraries/AP_HAL_SITL/Storage.cpp
@@ -7,6 +7,8 @@
 #include <unistd.h>
 #include "Storage.h"
 
+#include <stdio.h>
+
 using namespace HALSITL;
 
 extern const AP_HAL::HAL& hal;


### PR DESCRIPTION
Fixing error:

../../libraries/AP_HAL_SITL/Storage.cpp:229:5: fatal error: use of undeclared identifier 'printf'
    printf("erase %u -> %u\n", page, ret);