### PR TITLE
Global: Change strcmp to strncmp

### DIFF
--- a/Tools/Replay/LogReader.cpp
+++ b/Tools/Replay/LogReader.cpp
@@ -233,7 +233,7 @@ bool LogReader::save_message_type(const char *name)
 {
     bool save_message = !in_list(name, generated_names);
     save_message = save_message && !in_list(name, log_write_names);
-    if (save_chek_messages && strcmp(name, "CHEK") == 0) {
+    if (save_chek_messages && strncmp(name, "CHEK", 5) == 0) {
         save_message = true;
     }
     return save_message;

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -422,7 +422,7 @@ bool Replay::find_log_info(struct log_information &info)
             hal.console->printf("Using clock source %s\n", clock_source);
         }
         // IMT if available always overrides
-        if (streq(type, "IMT") && strcmp(clock_source, "IMT") != 0) {
+        if (streq(type, "IMT") && strncmp(clock_source, "IMT", 4) != 0) {
             strcpy(clock_source, "IMT");
             hal.console->printf("Changing clock source to %s\n", clock_source);
             samplecount = 0;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -160,7 +160,7 @@ bool AP_BattMonitor_SMBus_Maxell::check_pec_support()
     uint8_t buff[SMBUS_READ_BLOCK_MAXIMUM_TRANSFER + 1];
     if (read_block(BATTMONITOR_SMBUS_MANUFACTURE_NAME, buff, true)) {
         // Hitachi maxell batteries do not support PEC
-        if (strcmp((char*)buff, "Hitachi maxell") == 0) {
+        if (strncmp((char*)buff, "Hitachi maxell", 15) == 0) {
             _pec_supported = false;
             _pec_confirmed = true;
             return true;

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -576,7 +576,7 @@ int AP_Filesystem::stat(const char *name, struct stat *buf)
     errno = 0;
 
     // f_stat does not handle / or . as root directory
-    if (strcmp(name,"/") == 0 || strcmp(name,".") == 0) {
+    if (strncmp(name,"/", 2) == 0 || strncmp(name,".", 2) == 0) {
         buf->st_atime = 0;
         buf->st_mtime = 0;
         buf->st_ctime = 0;

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -326,15 +326,15 @@ bool AP_GPS_NMEA::_term_complete()
             return false;
         }
         const char *term_type = &_term[2];
-        if (strcmp(term_type, "RMC") == 0) {
+        if (strncmp(term_type, "RMC", 4) == 0) {
             _sentence_type = _GPS_SENTENCE_RMC;
-        } else if (strcmp(term_type, "GGA") == 0) {
+        } else if (strncmp(term_type, "GGA", 4) == 0) {
             _sentence_type = _GPS_SENTENCE_GGA;
-        } else if (strcmp(term_type, "HDT") == 0) {
+        } else if (strncmp(term_type, "HDT", 4) == 0) {
             _sentence_type = _GPS_SENTENCE_HDT;
             // HDT doesn't have a data qualifier
             _gps_data_good = true;
-        } else if (strcmp(term_type, "VTG") == 0) {
+        } else if (strncmp(term_type, "VTG", 4) == 0) {
             _sentence_type = _GPS_SENTENCE_VTG;
             // VTG may not contain a data qualifier, presume the solution is good
             // unless it tells us otherwise.

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -298,7 +298,7 @@ I2CDeviceManager::get_device(std::vector<const char *> devpaths, uint8_t address
         char *str_device, *abs_str_device;
         const char *p;
 
-        if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0) {
+        if (strncmp(de->d_name, ".", 2) == 0 || strncmp(de->d_name, "..", 3) == 0) {
             continue;
         }
 

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -185,10 +185,10 @@ AP_HAL::OwnPtr<SerialDevice> UARTDriver::_parseDevicePath(const char *arg)
 
     AP_HAL::OwnPtr<SerialDevice> device = nullptr;
 
-    if (strcmp(protocol, "udp") == 0 || strcmp(protocol, "udpin") == 0) {
-        bool bcast = (_flag && strcmp(_flag, "bcast") == 0);
+    if (strncmp(protocol, "udp", 4) == 0 || strncmp(protocol, "udpin", 6) == 0) {
+        bool bcast = (_flag && strncmp(_flag, "bcast", 6) == 0);
         _packetise = true;
-        if (strcmp(protocol, "udp") == 0) {
+        if (strncmp(protocol, "udp", 4) == 0) {
             device = new UDPDevice(_ip, _base_port, bcast, false);
         } else {
             if (bcast) {
@@ -198,7 +198,7 @@ AP_HAL::OwnPtr<SerialDevice> UARTDriver::_parseDevicePath(const char *arg)
 
         }
     } else {
-        bool wait = (_flag && strcmp(_flag, "wait") == 0);
+        bool wait = (_flag && strncmp(_flag, "wait", 5) == 0);
         device = new TCPServerDevice(_ip, _base_port, wait);
     }
 

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -146,7 +146,7 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
     // form a new argv, removing problem parameters. This is used for reboot
     uint8_t new_argv_offset = 0;
     for (uint8_t i=0; i<ARRAY_SIZE(new_argv) && i<argc; i++) {
-        if (!strcmp(argv[i], "-w")) {
+        if (!strncmp(argv[i], "-w", 3)) {
             // don't wipe params on reboot
             continue;
         }

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -401,19 +401,19 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 
     fprintf(stdout, "Starting sketch '%s'\n", SKETCH);
 
-    if (strcmp(SKETCH, "ArduCopter") == 0) {
+    if (strncmp(SKETCH, "ArduCopter", 11) == 0) {
         _vehicle = ArduCopter;
         if (_framerate == 0) {
             _framerate = 200;
         }
-    } else if (strcmp(SKETCH, "APMrover2") == 0) {
+    } else if (strncmp(SKETCH, "APMrover2", 10) == 0) {
         _vehicle = APMrover2;
         if (_framerate == 0) {
             _framerate = 50;
         }
         // set right default throttle for rover (allowing for reverse)
         pwm_input[2] = 1500;
-    } else if (strcmp(SKETCH, "ArduSub") == 0) {
+    } else if (strncmp(SKETCH, "ArduSub", 8) == 0) {
         _vehicle = ArduSub;
         for(uint8_t i = 0; i < 8; i++) {
             pwm_input[i] = 1500;

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -61,11 +61,11 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
         _uart_baudrate = baud;
     }
     
-    if (strcmp(path, "GPS1") == 0) {
+    if (strncmp(path, "GPS1", 5) == 0) {
         /* gps */
         _connected = true;
         _fd = _sitlState->gps_pipe();
-    } else if (strcmp(path, "GPS2") == 0) {
+    } else if (strncmp(path, "GPS2", 5) == 0) {
         /* 2nd gps */
         _connected = true;
         _fd = _sitlState->gps2_pipe();
@@ -87,29 +87,29 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
         char *devtype = strtok_r(s, ":", &saveptr);
         char *args1 = strtok_r(nullptr, ":", &saveptr);
         char *args2 = strtok_r(nullptr, ":", &saveptr);
-        if (strcmp(devtype, "tcp") == 0) {
+        if (strncmp(devtype, "tcp", 4) == 0) {
             uint16_t port = atoi(args1);
-            bool wait = (args2 && strcmp(args2, "wait") == 0);
+            bool wait = (args2 && strncmp(args2, "wait", 5) == 0);
             _tcp_start_connection(port, wait);
-        } else if (strcmp(devtype, "tcpclient") == 0) {
+        } else if (strncmp(devtype, "tcpclient", 10) == 0) {
             if (args2 == nullptr) {
                 AP_HAL::panic("Invalid tcp client path: %s", path);
             }
             uint16_t port = atoi(args2);
             _tcp_start_client(args1, port);
-        } else if (strcmp(devtype, "uart") == 0) {
+        } else if (strncmp(devtype, "uart", 5) == 0) {
             uint32_t baudrate = args2? atoi(args2) : baud;
             ::printf("UART connection %s:%u\n", args1, baudrate);
             _uart_path = strdup(args1);
             _uart_baudrate = baudrate;
             _uart_start_connection();
-        } else if (strcmp(devtype, "sim") == 0) {
+        } else if (strncmp(devtype, "sim", 4) == 0) {
             ::printf("SIM connection %s:%s on port %u\n", args1, args2, _portNumber);
             if (!_connected) {
                 _connected = true;
                 _fd = _sitlState->sim_fd(args1, args2);
             }
-        } else if (strcmp(devtype, "udpclient") == 0) {
+        } else if (strncmp(devtype, "udpclient", 10) == 0) {
             // udp client connection
             const char *ip = args1;
             uint16_t port = args2?atoi(args2):14550;
@@ -117,7 +117,7 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
                 ::printf("UDP connection %s:%u\n", ip, port);
                 _udp_start_client(ip, port);
             }
-        } else if (strcmp(devtype, "mcast") == 0) {
+        } else if (strncmp(devtype, "mcast", 6) == 0) {
             // udp multicast connection
             const char *ip = args1 && *args1?args1:mcast_ip_default;
             uint16_t port = args2?atoi(args2):mcast_port_default;

--- a/libraries/AP_Menu/AP_Menu.cpp
+++ b/libraries/AP_Menu/AP_Menu.cpp
@@ -141,7 +141,7 @@ Menu::_run_command(bool prompt_on_enter)
     
     // implicit commands
     if (i == _entries) {
-        if (!strcmp(_argv[0].str, "?") || (!strcasecmp(_argv[0].str, "help"))) {
+        if (!strncmp(_argv[0].str, "?", 2) || (!strcasecmp(_argv[0].str, "help"))) {
             _help();
             cmd_found=true;
         } else if (!strcasecmp(_argv[0].str, "exit")) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
@@ -157,9 +157,9 @@ bool AP_RangeFinder_NMEA::decode_latest_term()
             return false;
         }
         const char *term_type = &_term[2];
-        if (strcmp(term_type, "DBT") == 0) {
+        if (strncmp(term_type, "DBT", 4) == 0) {
             _sentence_type = SONAR_DBT;
-        } else if (strcmp(term_type, "DPT") == 0) {
+        } else if (strncmp(term_type, "DPT", 4) == 0) {
             _sentence_type = SONAR_DPT;
         } else {
             _sentence_type = SONAR_UNKNOWN;

--- a/libraries/AP_Scripting/lua/src/lauxlib.c
+++ b/libraries/AP_Scripting/lua/src/lauxlib.c
@@ -166,7 +166,7 @@ LUALIB_API int luaL_argerror (lua_State *L, int arg, const char *extramsg) {
   if (!lua_getstack(L, 0, &ar))  /* no stack frame? */
     return luaL_error(L, "bad argument #%d (%s)", arg, extramsg);
   lua_getinfo(L, "n", &ar);
-  if (strcmp(ar.namewhat, "method") == 0) {
+  if (strncmp(ar.namewhat, "method", 7) == 0) {
     arg--;  /* do not count 'self' */
     if (arg == 0)  /* error is in the self argument itself? */
       return luaL_error(L, "calling '%s' on bad self (%s)",

--- a/libraries/AP_Scripting/lua/src/ldblib.c
+++ b/libraries/AP_Scripting/lua/src/ldblib.c
@@ -404,7 +404,7 @@ static int db_debug (lua_State *L) {
     char buffer[250];
     lua_writestringerror("%s", "lua_debug> ");
     if (fgets(buffer, sizeof(buffer), stdin) == 0 ||
-        strcmp(buffer, "cont\n") == 0)
+        strncmp(buffer, "cont\n", 6) == 0)
       return 0;
     if (luaL_loadbuffer(L, buffer, strlen(buffer), "=(debug command)") ||
         lua_pcall(L, 0, 0, 0))

--- a/libraries/AP_Scripting/lua/src/loslib.c
+++ b/libraries/AP_Scripting/lua/src/loslib.c
@@ -295,7 +295,7 @@ static int os_date (lua_State *L) {
   if (stm == NULL)  /* invalid date? */
     return luaL_error(L,
                  "time result cannot be represented in this installation");
-  if (strcmp(s, "*t") == 0) {
+  if (strncmp(s, "*t", 3) == 0) {
     lua_createtable(L, 0, 9);  /* 9 = number of fields */
     setallfields(L, stm);
   }

--- a/libraries/AP_Scripting/lua/src/lua.c
+++ b/libraries/AP_Scripting/lua/src/lua.c
@@ -437,7 +437,7 @@ static int pushargs (lua_State *L) {
 static int handle_script (lua_State *L, char **argv) {
   int status;
   const char *fname = argv[0];
-  if (strcmp(fname, "-") == 0 && strcmp(argv[-1], "--") != 0)
+  if (strncmp(fname, "-", 2) == 0 && strncmp(argv[-1], "--", 3) != 0)
     fname = NULL;  /* stdin */
   status = luaL_loadfile(L, fname);
   if (status == LUA_OK) {

--- a/libraries/AP_WindVane/AP_WindVane_NMEA.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_NMEA.cpp
@@ -139,7 +139,7 @@ bool AP_WindVane_NMEA::decode_latest_term()
             return false;
         }
         const char *term_type = &_term[2];
-        if (strcmp(term_type, "MWV") == 0) {
+        if (strncmp(term_type, "MWV", 4) == 0) {
             // we found the sentence type for wind
             _sentence_valid = true;
         }

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -43,7 +43,7 @@ Sailboat::Sailboat(const char *frame_str) :
     steering_angle_max(35),
     turning_circle(1.8)
 {
-    motor_connected = (strcmp(frame_str, "sailboat-motor") == 0);
+    motor_connected = (strncmp(frame_str, "sailboat-motor", 15) == 0);
 }
 
 // calculate the lift and drag as values from 0 to 1

--- a/libraries/SITL/SIM_Scrimmage.cpp
+++ b/libraries/SITL/SIM_Scrimmage.cpp
@@ -37,7 +37,7 @@ Scrimmage::Scrimmage(const char *_frame_str) :
     frame_str(_frame_str)
 {
     // Set defaults for scrimmage-copter
-    if (strcmp(frame_str, "scrimmage-copter")== 0) {
+    if (strncmp(frame_str, "scrimmage-copter", 17)== 0) {
         mission_name = "arducopter.xml";
         motion_model = "Multirotor";
         visual_model = "iris";
@@ -57,13 +57,13 @@ void Scrimmage::set_config(const char *config)
     {
         char *end_token;
         char *token2 = strtok_r(token, "=", &end_token);
-        if (strcmp(token2, "mission")==0) {
+        if (strncmp(token2, "mission", 8)==0) {
             mission_name = strtok_r(NULL, "=", &end_token);
-        } else if (strcmp(token2, "motion_model")==0) {
+        } else if (strncmp(token2, "motion_model", 13)==0) {
             motion_model = strtok_r(NULL, "=", &end_token);
-        } else if (strcmp(token2, "visual_model")==0) {
+        } else if (strncmp(token2, "visual_model", 13)==0) {
             visual_model = strtok_r(NULL, "=", &end_token);
-        } else if (strcmp(token2, "terrain")==0) {
+        } else if (strncmp(token2, "terrain", 8)==0) {
             terrain = strtok_r(NULL, "=", &end_token);
         } else {
             printf("Invalid scrimmage param: %s", token2);


### PR DESCRIPTION
For a fixed string, I specify the length of the string, including the null character.
I thought this would be a fail safe.
For example, when NULL becomes a non-NULL code due to memory error.