### PR TITLE
AP_Logger: Forward declare AP_AHRS and friends

### DIFF
--- a/Tools/Replay/LR_MsgHandler.h
+++ b/Tools/Replay/LR_MsgHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MsgHandler.h"
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>
 
 #include <functional>

--- a/Tools/Replay/MsgHandler.cpp
+++ b/Tools/Replay/MsgHandler.cpp
@@ -1,4 +1,5 @@
 #include "MsgHandler.h"
+#include <AP_AHRS/AP_AHRS.h>
 
 void fatal(const char *msg) {
     ::printf("%s",msg);

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -27,6 +27,8 @@
 #include <AC_Fence/AC_Fence.h>
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_Airspeed/AP_Airspeed.h>
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -45,6 +45,8 @@
 #include "AP_Baro_UAVCAN.h"
 #endif
 
+#include <AP_Airspeed/AP_Airspeed.h>
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
 #define INTERNAL_TEMPERATURE_CLAMP 35.0f

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -43,6 +43,7 @@
 #include "AP_GPS_UAVCAN.h"
 #endif
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
 #define GPS_RTK_INJECT_TO_ALL 127

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -19,6 +19,7 @@
 
 #include "AP_Landing.h"
 #include <GCS_MAVLink/GCS.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 // table of user settable parameters
 const AP_Param::GroupInfo AP_Landing::var_info[] = {

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -22,6 +22,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Common/Location.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 // table of user settable parameters for deepstall
 const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -21,6 +21,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_LandingGear/AP_LandingGear.h>
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>
 
 void AP_Landing::type_slope_do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude)

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -7,7 +7,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Logger/LogStructure.h>
@@ -22,6 +21,9 @@
 #include "LoggerMessageWriter.h"
 
 class AP_Logger_Backend;
+class AP_AHRS;
+class AP_AHRS_View;
+struct ekf_timing;
 
 // do not do anything here apart from add stuff; maintaining older
 // entries means log analysis is easier
@@ -240,9 +242,7 @@ public:
     void Write_Power(void);
     void Write_AHRS2(AP_AHRS &ahrs);
     void Write_POS(AP_AHRS &ahrs);
-#if AP_AHRS_NAVEKF_AVAILABLE
     void Write_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing);
-#endif
     void Write_Radio(const mavlink_radio_t &packet);
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -20,6 +20,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include "AP_Terrain.h"
+#include <AP_AHRS/AP_AHRS.h>
 
 #if AP_TERRAIN_AVAILABLE
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.cpp
@@ -16,6 +16,7 @@
 #include "AP_VisualOdom.h"
 #include "AP_VisualOdom_Backend.h"
 #include "AP_VisualOdom_MAV.h"
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -5,6 +5,7 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -31,6 +31,7 @@
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_Declination/AP_Declination.h>
 
 using namespace SITL;
 


### PR DESCRIPTION
This reduces the scope of places AP_AHRS (and friends) get included. By forward declaring you don't end up depending on stuff like compass/airspeed in files that have nothing to do with them and just want to log, the primary purpose is to reduce the number of things that need to be recompilied when changing headers in a library.

The most debatable part is probably that I removed the check for `AP_AHRS_NAVEKF_AVAILABLE` from the header. I decided I was okay with this as it let me reduce the scope, and I could rely on the linker to elide the function since we weren't calling it unless `AP_AHRS_NAVEKF_AVAILABLE` wasn't true. Unfortunately I couldn't find a way to test this, since you currently can't build unless `AP_AHRS_NAVEKF_AVAILABLE` is true.