### PR TITLE
AP_Param: correct flags returned from find(...)

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3084,6 +3084,11 @@ switch value'''
         if old_mt != self.get_parameter("MIS_TOTAL"):
             raise NotAchievedException("Total has changed")
 
+        self.start_subtest("Ensure GCS is able to set other MIS_ parameters")
+        self.set_parameter("MIS_OPTIONS", 1)
+        if self.get_parameter("MIS_OPTIONS") != 1:
+            raise NotAchievedException("Failed to set MIS_OPTIONS")
+
     def disabled_tests(self):
         return {}
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -849,7 +849,14 @@ AP_Param::find(const char *name, enum ap_var_type *ptype, uint16_t *flags)
             AP_Param *ap = find_group(name + len, i, 0, group_info, ptype);
             if (ap != nullptr) {
                 if (flags != nullptr) {
-                    *flags = group_info->flags;
+                    uint32_t group_element = 0;
+                    const struct GroupInfo *ginfo;
+                    struct GroupNesting group_nesting {};
+                    uint8_t idx;
+                    ap->find_var_info(&group_element, ginfo, group_nesting, &idx);
+                    if (ginfo != nullptr) {
+                        *flags = ginfo->flags;
+                    }
                 }
                 return ap;
             }


### PR DESCRIPTION
We were returning the flags for the group the parameter is in rather than for the parameter.

Added test for bug caused by this.
