### PR TITLE
Move EKF timing logging out into AP_NavEKF

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -34,6 +34,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_InertialSensor',
     'AP_Math',
     'AP_Mission',
+    'AP_NavEKF',
     'AP_NavEKF2',
     'AP_NavEKF3',
     'AP_Notify',

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -23,7 +23,6 @@
 class AP_Logger_Backend;
 class AP_AHRS;
 class AP_AHRS_View;
-struct ekf_timing;
 
 // do not do anything here apart from add stuff; maintaining older
 // entries means log analysis is easier
@@ -242,7 +241,6 @@ public:
     void Write_Power(void);
     void Write_AHRS2(AP_AHRS &ahrs);
     void Write_POS(AP_AHRS &ahrs);
-    void Write_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing);
     void Write_Radio(const mavlink_radio_t &packet);
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -533,31 +533,6 @@ void AP_Logger::Write_POS(AP_AHRS &ahrs)
     WriteBlock(&pkt, sizeof(pkt));
 }
 
-#if AP_AHRS_NAVEKF_AVAILABLE
-
-
-/*
-  write an EKF timing message
- */
-void AP_Logger::Write_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing)
-{
-    Write(name,
-              "TimeUS,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax",
-              "QIffffffff",
-              time_us,
-              timing.count,
-              (double)timing.dtIMUavg_min,
-              (double)timing.dtIMUavg_max,
-              (double)timing.dtEKFavg_min,
-              (double)timing.dtEKFavg_max,
-              (double)timing.delAngDT_min,
-              (double)timing.delAngDT_max,
-              (double)timing.delVelDT_min,
-              (double)timing.delVelDT_max);
-}
-
-#endif
-
 void AP_Logger::Write_Radio(const mavlink_radio_t &packet)
 {
     const struct log_Radio pkt{

--- a/libraries/AP_NavEKF/AP_Nav_Common.cpp
+++ b/libraries/AP_NavEKF/AP_Nav_Common.cpp
@@ -1,0 +1,25 @@
+#include "AP_Nav_Common.h"
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Logger/AP_Logger.h>
+
+/*
+  write an EKF timing message
+ */
+void Log_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing)
+{
+    AP::logger().Write(
+        name,
+        "TimeUS,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax",
+        "QIffffffff",
+        time_us,
+        timing.count,
+        (double)timing.dtIMUavg_min,
+        (double)timing.dtIMUavg_max,
+        (double)timing.dtEKFavg_min,
+        (double)timing.dtEKFavg_max,
+        (double)timing.delAngDT_min,
+        (double)timing.delAngDT_max,
+        (double)timing.delVelDT_min,
+        (double)timing.delVelDT_max);
+}

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -16,6 +16,8 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 union nav_filter_status {
     struct {
         bool attitude           : 1; // 0 - true if attitude estimate is valid
@@ -73,3 +75,4 @@ struct ekf_timing {
     float delVelDT_max;
     float delVelDT_min;
 };
+void Log_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -276,12 +276,12 @@ void NavEKF2::Log_Write()
         for (uint8_t i=0; i<activeCores(); i++) {
             getTimingStatistics(i, timing);
             if (i == 0) {
-                AP::logger().Write_EKF_Timing("NKT1", time_us, timing);
+                Log_EKF_Timing("NKT1", time_us, timing);
             } else if (i == 1) {
-                AP::logger().Write_EKF_Timing("NKT2", time_us, timing);
+                Log_EKF_Timing("NKT2", time_us, timing);
             } else if (i == 2) {
-                AP::logger().Write_EKF_Timing("NKT3", time_us, timing);
-            }            
+                Log_EKF_Timing("NKT3", time_us, timing);
+            }
         }
     }
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -347,11 +347,11 @@ void NavEKF3::Log_Write()
         for (uint8_t i=0; i<activeCores(); i++) {
             getTimingStatistics(i, timing);
             if (i == 0) {
-                AP::logger().Write_EKF_Timing("XKT1", time_us, timing);
+                Log_EKF_Timing("XKT1", time_us, timing);
             } else if (i == 1) {
-                AP::logger().Write_EKF_Timing("XKT2", time_us, timing);
+                Log_EKF_Timing("XKT2", time_us, timing);
             } else if (i == 2) {
-                AP::logger().Write_EKF_Timing("XKT3", time_us, timing);
+                Log_EKF_Timing("XKT3", time_us, timing);
             }
         }
     }


### PR DESCRIPTION
This will help fix the build when EKF is disabled.

```
pbarker@bluebottle:~/rc/ardupilot(pr/move-ekf-timing-logging)$ mavlogdump.py --t NKT1 ../buildlogs/APMrover2-00000001.BIN 
2019-08-28 13:49:06.90: NKT1 {TimeUS : 22121148, Cnt : 927, IMUMin : 0.019999999553, IMUMax : 0.019999999553, EKFMin : 0.0102000208572, EKFMax : 0.0200147274882, AngMin : 0.00102000206243, AngMax : 0.0210016183555, VMin : 0.00102000206243, VMax : 0.0210016183555}
pbarker@bluebottle:~/rc/ardupilot(pr/move-ekf-timing-logging)$ 
```

Testing limited to running in SITL and ensuring we still get messages.
