### PR TITLE
Move filling of SYS_STATUS bits for Fence up

### DIFF
--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -70,11 +70,6 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_PROXIMITY;
     }
 #endif
-#if AC_FENCE == ENABLED
-    if (copter.fence.sys_status_present()) {
-        control_sensors_present |= MAV_SYS_STATUS_GEOFENCE;
-    }
-#endif
 #if RANGEFINDER_ENABLED == ENABLED
     const RangeFinder *rangefinder = RangeFinder::get_singleton();
     if (rangefinder && rangefinder->has_orientation(ROTATION_PITCH_270)) {
@@ -112,11 +107,6 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         break;
     }
 
-#if AC_FENCE == ENABLED
-    if (copter.fence.sys_status_enabled()) {
-        control_sensors_enabled |= MAV_SYS_STATUS_GEOFENCE;
-    }
-#endif
 #if PROXIMITY_ENABLED == ENABLED
     if (copter.g2.proximity.sensor_enabled()) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_PROXIMITY;
@@ -174,12 +164,6 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         if (rangefinder && rangefinder->has_data_orient(ROTATION_PITCH_270)) {
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
-    }
-#endif
-
-#if AC_FENCE == ENABLED
-    if (!copter.fence.sys_status_failed()) {
-        control_sensors_health |= MAV_SYS_STATUS_GEOFENCE;
     }
 #endif
 }

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -1,5 +1,6 @@
 #include "GCS.h"
 
+#include <AC_Fence/AC_Fence.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
@@ -176,6 +177,19 @@ void GCS::update_sensor_status_flags()
         control_sensors_health |= MAV_SYS_STATUS_AHRS | MAV_SYS_STATUS_SENSOR_GPS | MAV_SYS_STATUS_SENSOR_3D_ACCEL | MAV_SYS_STATUS_SENSOR_3D_GYRO;
     }
 #endif
+
+    const AC_Fence *fence = AP::fence();
+    if (fence != nullptr) {
+        if (fence->sys_status_enabled()) {
+            control_sensors_enabled |= MAV_SYS_STATUS_GEOFENCE;
+        }
+        if (fence->sys_status_present()) {
+            control_sensors_present |= MAV_SYS_STATUS_GEOFENCE;
+        }
+        if (!fence->sys_status_failed()) {
+            control_sensors_health |= MAV_SYS_STATUS_GEOFENCE;
+        }
+    }
 
     update_vehicle_sensor_status_flags();
 }


### PR DESCRIPTION
This makes Rover fill these bits in so the GCS can show the current fence status.

Tested in SITL for both Copter and Rover, and Plane to ensure its overriding of these bits still works.

Notionally this also makes the bits work in Sub...
