### PR TITLE
ArduCopter: allow logging of both IMU and IMU_RAW

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -382,8 +382,7 @@ void Copter::twentyfive_hz_logging()
         Log_Write_EKF_POS();
     }
 
-    // log IMU data if we're not already logging at the higher rate
-    if (should_log(MASK_LOG_IMU) && !should_log(MASK_LOG_IMU_RAW)) {
+    if (should_log(MASK_LOG_IMU)) {
         logger.Write_IMU();
     }
 #endif


### PR DESCRIPTION
Currently we disable regular IMU logging when IMU_RAW is enabled. This is wrong as IMU_RAW is unfiltered and IMU is filtered and we want to be able to see the differences. In addition IMU errors are only shown on the regular IMU logging and are therefore not available if IMU_RAW is enabled. This PR allows both if so configured.

We allow regular IMU logging together with batch logging already, so there can be no issue with data rates to the SD card and the current state is inconsistent.

Totally safe patch!

@rmackay9 any opinions?