### PR TITLE
AP_InertialSensor: prevent gyro overflow on invensense sensors

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -500,6 +500,16 @@ bool AP_InertialSensor_Invensense::_accumulate_sensor_rate_sampling(uint8_t *sam
         Vector3f g2 = g * _gyro_scale;
         _notify_new_gyro_sensor_rate_sample(_gyro_instance, g2);
 
+        const int16_t overflowValue = 0x7C00; // 1937 dps
+        if (g.x > overflowValue || g.x < -overflowValue
+            || g.y > overflowValue || g.y < -overflowValue
+            || g.z > overflowValue || g.z < -overflowValue) {
+            g = _accum.prev_gyro;
+            _inc_gyro_error_count(_gyro_instance);
+        }
+        else {
+            _accum.prev_gyro = g;
+        }
         _accum.gyro += _accum.gyro_filter.apply(g);
         _accum.count++;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -154,6 +154,7 @@ private:
     struct {
         Vector3f accel;
         Vector3f gyro;
+        Vector3f prev_gyro;
         uint8_t count;
         LowPassFilterVector3f accel_filter{4000, 188};
         LowPassFilterVector3f gyro_filter{8000, 188};


### PR DESCRIPTION
Invensense ICM206xx sensors have a bug which means that if they get close to the sensor limit the output can invert. The betaflight team refer to this as the "yaw of death" since it is most likely to happen on yaw. This PR applies the simplistic BF fix to prevent the inversion. The betaflight team have a more complicated setup now which attempts to deal with yaw requests close to the trigger point - I don't think that AP is quite at that stage yet!