### PR TITLE
Rover: add fence enable RC_Option

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -65,7 +65,6 @@ void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_
     switch(ch_option) {
     case AUX_FUNC::SIMPLE_MODE:
     case AUX_FUNC::RANGEFINDER:
-    case AUX_FUNC::FENCE:
     case AUX_FUNC::SUPERSIMPLE_MODE:
     case AUX_FUNC::ACRO_TRAINER:
     case AUX_FUNC::PARACHUTE_ENABLE:
@@ -241,19 +240,6 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
                 copter.rangefinder_state.enabled = true;
             } else {
                 copter.rangefinder_state.enabled = false;
-            }
-#endif
-            break;
-
-        case AUX_FUNC::FENCE:
-#if AC_FENCE == ENABLED
-            // enable or disable the fence
-            if (ch_flag == HIGH) {
-                copter.fence.enable(true);
-                copter.Log_Write_Event(DATA_FENCE_ENABLE);
-            } else {
-                copter.fence.enable(false);
-                copter.Log_Write_Event(DATA_FENCE_DISABLE);
             }
 #endif
             break;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -196,6 +196,7 @@ protected:
 
     void do_aux_function_avoid_proximity(const aux_switch_pos_t ch_flag);
     void do_aux_function_camera_trigger(const aux_switch_pos_t ch_flag);
+    void do_aux_function_fence(const aux_switch_pos_t ch_flag);
     void do_aux_function_clear_wp(const aux_switch_pos_t ch_flag);
     void do_aux_function_gripper(const aux_switch_pos_t ch_flag);
     void do_aux_function_lost_vehicle_sound(const aux_switch_pos_t ch_flag);


### PR DESCRIPTION
This brings the fence enable RC_Option from copter to rover. Unfortunately we don't have log_write_event on rover, other than that this works identically to copter. Tested in SITL that fence, avoidance and path planning can all be disabled. 

The use case is a boat that you want to sail on one bit of water inside a fence, but you want to be able to get it to come back to the shore in a mode other than manual.