### PR TITLE
AP_WheelEncoder: Fix speed estimate corruption when sending position offsets to EKF3

### DIFF
--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -145,6 +145,11 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
 AP_WheelEncoder::AP_WheelEncoder(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
+
+    // initialize position offsets which will be used by EKF3
+    for (int i=0; i<WHEELENCODER_MAX_INSTANCES; ++i) {
+        wheel_pos_offset[i] = _pos_offset[i];
+    }
 }
 
 // initialise the AP_WheelEncoder class.
@@ -245,13 +250,13 @@ float AP_WheelEncoder::get_wheel_radius(uint8_t instance) const
 }
 
 // return a 3D vector defining the position offset of the center of the wheel in meters relative to the body frame origin
-const Vector3f &AP_WheelEncoder::get_pos_offset(uint8_t instance) const
+Vector3f &AP_WheelEncoder::get_pos_offset(uint8_t instance) const
 {
     // for invalid instances return zero vector
     if (instance >= WHEELENCODER_MAX_INSTANCES) {
-        return pos_offset_zero;
+        return const_cast<Vector3f &>(zero_wheel_offset);
     }
-    return _pos_offset[instance];
+    return const_cast<Vector3f &>(wheel_pos_offset[instance]);
 }
 
 // get total delta angle (in radians) measured by the wheel encoder

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -81,7 +81,7 @@ public:
     float get_wheel_radius(uint8_t instance) const;
 
     // return a 3D vector defining the position offset of the center of the wheel in meters relative to the body frame origin
-    const Vector3f &get_pos_offset(uint8_t instance) const;
+    Vector3f &get_pos_offset(uint8_t instance) const;
 
     // get total delta angle (in radians) measured by the wheel encoder
     float get_delta_angle(uint8_t instance) const;
@@ -118,5 +118,8 @@ protected:
     WheelEncoder_State state[WHEELENCODER_MAX_INSTANCES];
     AP_WheelEncoder_Backend *drivers[WHEELENCODER_MAX_INSTANCES];
     uint8_t num_instances;
-    Vector3f pos_offset_zero;   // allows returning position offsets of zero for invalid requests
+
+    Vector3f zero_wheel_offset; // allows returning position offsets of zero for invalid requests
+    // Extra variable to send _pos_offset to EKF3
+    Vector3f wheel_pos_offset[WHEELENCODER_MAX_INSTANCES];
 };


### PR DESCRIPTION
Wheel encoder position offsets were returned to EKF3  by value, from AP_WheelEncoder object until commit https://github.com/ArduPilot/ardupilot/commit/2c909cf83bf486ce28f8955228e39e752e2f4bcc#diff-6c3e0bd69602fee9de5d5b657ab44904, changed this to return by reference. But returning a reference corrupts the estimated speed. This was noticed while testing on Balance Bot. Hence reverting to return by value!

EDIT: Returns a reference now