### PR TITLE
Create and use AP_Vehicle  - a base class for all vehicle types

### DIFF
--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -4,6 +4,7 @@
 
 #include "RC_Channel.h"
 #include "AC_Sprayer/AC_Sprayer.h"
+#include "AP_Gripper/AP_Gripper.h"
 #include "AP_Rally.h"
 
 // Global parameter class.

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -35,6 +35,8 @@
 #include "version.h"
 #undef FORCE_VERSION_H_INCLUDE
 
+#include "AP_Gripper/AP_Gripper.h"
+
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 #define SCHED_TASK(func, _interval_ticks, _max_time_micros) SCHED_TASK_CLASS(Rover, &rover, func, _interval_ticks, _max_time_micros)
@@ -114,6 +116,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 constexpr int8_t Rover::_failsafe_priorities[7];
 
 Rover::Rover(void) :
+    AP_Vehicle(),
     param_loader(var_info),
     channel_steer(nullptr),
     channel_throttle(nullptr),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -107,7 +107,7 @@
 #include "AP_Rally.h"
 #include "RC_Channel.h"                  // RC Channel Library
 
-class Rover : public AP_HAL::HAL::Callbacks {
+class Rover : public AP_Vehicle {
 public:
     friend class GCS_MAVLINK_Rover;
     friend class Parameters;

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -31,13 +31,9 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>          // Battery monitor library
 #include <AP_Beacon/AP_Beacon.h>
-#include <AP_BoardConfig/AP_BoardConfig.h>
-#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
-#include <AP_Button/AP_Button.h>
 #include <AP_Camera/AP_Camera.h>                    // Camera triggering
 #include <AP_Compass/AP_Compass.h>                  // ArduPilot Mega Magnetometer Library
 #include <AP_Declination/AP_Declination.h>          // Compass declination library
-#include <AP_GPS/AP_GPS.h>                          // ArduPilot GPS library
 #include <AP_InertialSensor/AP_InertialSensor.h>    // Inertial Sensor (uncalibated IMU) Library
 #include <AP_L1_Control/AP_L1_Control.h>
 #include <AP_Math/AP_Math.h>                        // ArduPilot Mega Vector/Matrix math Library
@@ -46,18 +42,11 @@
 #include <AP_NavEKF2/AP_NavEKF2.h>
 #include <AP_NavEKF3/AP_NavEKF3.h>
 #include <AP_Navigation/AP_Navigation.h>
-#include <AP_Notify/AP_Notify.h>                    // Notify library
 #include <AP_OpticalFlow/AP_OpticalFlow.h>          // Optical Flow library
 #include <AP_Param/AP_Param.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>          // Range finder library
 #include <AP_RCMapper/AP_RCMapper.h>                // RC input mapping library
-#include <AP_Relay/AP_Relay.h>                      // APM relay
-#include <AP_RPM/AP_RPM.h>
-#include <AP_RSSI/AP_RSSI.h>                        // RSSI Library
 #include <AP_Scheduler/AP_Scheduler.h>              // main loop scheduler
-#include <AP_SerialManager/AP_SerialManager.h>      // Serial manager library
-#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
-#include <AP_Gripper/AP_Gripper.h>
 #include <AP_Stats/AP_Stats.h>                      // statistics library
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_Vehicle/AP_Vehicle.h>                  // needed for AHRS build
@@ -73,7 +62,6 @@
 #include <Filter/Filter.h>                          // Filter library
 #include <Filter/LowPassFilter.h>
 #include <Filter/ModeFilter.h>                      // Mode Filter from Filter library
-#include <StorageManager/StorageManager.h>
 #include <AC_Fence/AC_Fence.h>
 #include <AP_Proximity/AP_Proximity.h>
 #include <AC_Avoidance/AC_Avoid.h>
@@ -159,28 +147,12 @@ private:
     // mapping between input channels
     RCMapper rcmap;
 
-    // board specific config
-    AP_BoardConfig BoardConfig;
-
-#if HAL_WITH_UAVCAN
-    // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN;
-#endif
-
     // primary control channels
     RC_Channel *channel_steer;
     RC_Channel *channel_throttle;
     RC_Channel *channel_lateral;
 
     AP_Logger logger;
-
-    // sensor drivers
-    AP_GPS gps;
-    AP_Baro barometer;
-    Compass compass;
-    AP_InertialSensor ins;
-    RangeFinder rangefinder;
-    AP_Button button;
 
     // flight modes convenience array
     AP_Int8 *modes;
@@ -207,9 +179,6 @@ private:
     OpticalFlow optflow;
 #endif
 
-    // RSSI
-    AP_RSSI rssi;
-
 #if OSD_ENABLED == ENABLED
     AP_OSD osd;
 #endif
@@ -218,19 +187,12 @@ private:
     SITL::SITL sitl;
 #endif
 
-    AP_SerialManager serial_manager;
-
     // GCS handling
     GCS_Rover _gcs;  // avoid using this; use gcs()
     GCS_Rover &gcs() { return _gcs; }
 
     // RC Channels:
     RC_Channels_Rover &rc() { return g2.rc_channels; }
-
-    // relay support
-    AP_Relay relay;
-
-    AP_ServoRelayEvents ServoRelayEvents;
 
     // The rover's current location
     struct Location current_loc;
@@ -267,9 +229,6 @@ private:
         uint32_t last_heartbeat_ms; // system time of most recent heartbeat from ground station
         bool ekf;
     } failsafe;
-
-    // notification object for LEDs, buzzers etc (parameter set to false disables external leds)
-    AP_Notify notify;
 
     // true if we have a position estimate from AHRS
     bool have_position;
@@ -492,7 +451,6 @@ public:
     float simple_sin_yaw;
 };
 
-extern const AP_HAL::HAL& hal;
 extern Rover rover;
 
 using AP_HAL::millis;

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -52,13 +52,9 @@
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_Rally/AP_Rally.h>
 #include <AP_Stats/AP_Stats.h>                      // statistics library
-#include <AP_Notify/AP_Notify.h>      // Notify library
 #include <AP_BattMonitor/AP_BattMonitor.h> // Battery monitor library
 #include <AP_Airspeed/AP_Airspeed.h>
-#include <AP_BoardConfig/AP_BoardConfig.h>
-#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
-#include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Beacon/AP_Beacon.h>
 #include <AP_Common/AP_FWVersion.h>
 
@@ -99,27 +95,14 @@ private:
     // main loop scheduler
     AP_Scheduler scheduler;
 
-    // notification object for LEDs, buzzers etc
-    AP_Notify notify;
-
     uint32_t start_time_ms = 0;
 
     AP_Logger logger;
 
-    AP_GPS gps;
-
-    AP_Baro barometer;
-
-    Compass compass;
-
-    AP_InertialSensor ins;
-
-    RangeFinder rng;
-
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2{&ahrs, rng};
-    NavEKF3 EKF3{&ahrs, rng};
+    NavEKF2 EKF2{&ahrs, rangefinder};
+    NavEKF3 EKF3{&ahrs, rangefinder};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3};
 #else
     AP_AHRS_DCM ahrs;
@@ -141,24 +124,15 @@ private:
     bool yaw_servo_out_filt_init = false;
     bool pitch_servo_out_filt_init = false;
 
-    AP_SerialManager serial_manager;
     GCS_Tracker _gcs; // avoid using this; use gcs()
     GCS_Tracker &gcs() { return _gcs; }
 
     AP_Stats stats;
 
-    AP_BoardConfig BoardConfig;
-
-#if HAL_WITH_UAVCAN
-    // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN;
-#endif
-
     // Battery Sensors
     AP_BattMonitor battery{MASK_LOG_CURRENT,
                            FUNCTOR_BIND_MEMBER(&Tracker::handle_battery_failsafe, void, const char*, const int8_t),
                            nullptr};
-
     struct Location current_loc;
 
     enum ControlMode control_mode  = INITIALISING;
@@ -297,5 +271,4 @@ public:
     void mavlink_delay_cb();
 };
 
-extern const AP_HAL::HAL& hal;
 extern Tracker tracker;

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -79,7 +79,7 @@
 #include <SITL/SITL.h>
 #endif
 
-class Tracker : public AP_HAL::HAL::Callbacks {
+class Tracker : public AP_Vehicle {
 public:
     friend class GCS_MAVLINK_Tracker;
     friend class GCS_Tracker;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -194,7 +194,7 @@
 
 #include "mode.h"
 
-class Copter : public AP_HAL::HAL::Callbacks {
+class Copter : public AP_Vehicle {
 public:
     friend class GCS_MAVLINK_Copter;
     friend class GCS_Copter;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -35,11 +35,7 @@
 
 // Application dependencies
 #include <GCS_MAVLink/GCS.h>
-#include <AP_SerialManager/AP_SerialManager.h>   // Serial manager library
-#include <AP_GPS/AP_GPS.h>             // ArduPilot GPS library
 #include <AP_Logger/AP_Logger.h>          // ArduPilot Mega Flash Memory Library
-#include <AP_Baro/AP_Baro.h>
-#include <AP_Compass/AP_Compass.h>         // ArduPilot Mega Magnetometer Library
 #include <AP_Math/AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
 #include <AP_InertialSensor/AP_InertialSensor.h>  // ArduPilot Mega Inertial Sensor (accel & gyro) Library
@@ -52,10 +48,7 @@
 #include <AC_AttitudeControl/AC_PosControl.h>      // Position control library
 #include <AP_Motors/AP_Motors.h>          // AP Motors library
 #include <AP_Stats/AP_Stats.h>     // statistics library
-#include <AP_RSSI/AP_RSSI.h>                   // RSSI Library
 #include <Filter/Filter.h>             // Filter library
-#include <AP_Relay/AP_Relay.h>           // APM relay
-#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AP_Airspeed/AP_Airspeed.h>        // needed for AHRS build
 #include <AP_Vehicle/AP_Vehicle.h>         // needed for AHRS build
 #include <AP_InertialNav/AP_InertialNav.h>     // ArduPilot Mega inertial navigation library
@@ -65,14 +58,10 @@
 #include <AP_Declination/AP_Declination.h>     // ArduPilot Mega Declination Helper Library
 #include <AP_Scheduler/AP_Scheduler.h>       // main loop scheduler
 #include <AP_RCMapper/AP_RCMapper.h>        // RC input mapping library
-#include <AP_Notify/AP_Notify.h>          // Notify library
 #include <AP_BattMonitor/AP_BattMonitor.h>     // Battery monitor library
-#include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
-#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library
 #include <AC_InputManager/AC_InputManager.h>        // Pilot input handling library
 #include <AC_InputManager/AC_InputManager_Heli.h>   // Heli specific pilot input handling library
-#include <AP_Button/AP_Button.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_SmartRTL/AP_SmartRTL.h>
 #include <AP_TempCalibration/AP_TempCalibration.h>
@@ -257,9 +246,6 @@ private:
     // main loop scheduler
     AP_Scheduler scheduler{FUNCTOR_BIND_MEMBER(&Copter::fast_loop, void)};
 
-    // AP_Notify instance
-    AP_Notify notify;
-
     // used to detect MAVLink acks from GCS to stop compassmot
     uint8_t command_ack_counter;
 
@@ -271,17 +257,10 @@ private:
 
     AP_Logger logger;
 
-    AP_GPS gps;
-
     // flight modes convenience array
     AP_Int8 *flight_modes;
     const uint8_t num_flight_modes = 6;
 
-    AP_Baro barometer;
-    Compass compass;
-    AP_InertialSensor ins;
-
-    RangeFinder rangefinder;
     struct RangeFinderState {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder
@@ -350,8 +329,6 @@ private:
     uint32_t ekfYawReset_ms;
     int8_t ekf_primary_core;
 
-    AP_SerialManager serial_manager;
-
     // GCS selection
     GCS_Copter _gcs; // avoid using this; use gcs()
     GCS_Copter &gcs() { return _gcs; }
@@ -409,14 +386,6 @@ private:
 
     // intertial nav alt when we armed
     float arming_altitude_m;
-
-    // board specific config
-    AP_BoardConfig BoardConfig;
-
-#if HAL_WITH_UAVCAN
-    // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN;
-#endif
 
     // Failsafe
     struct {
@@ -509,12 +478,6 @@ private:
     // Used to exit the roll and pitch auto trim function
     uint8_t auto_trim_counter;
 
-    // Reference to the relay object
-    AP_Relay relay;
-
-    // handle repeated servo and relay events
-    AP_ServoRelayEvents ServoRelayEvents;
-
     // Camera
 #if CAMERA == ENABLED
     AP_Camera camera{MASK_LOG_CAMERA, current_loc};
@@ -539,9 +502,6 @@ private:
 #if AC_RALLY == ENABLED
     AP_Rally_Copter rally;
 #endif
-
-    // RSSI
-    AP_RSSI rssi;
 
     // Crop Sprayer
 #if SPRAYER_ENABLED == ENABLED
@@ -980,7 +940,6 @@ public:
     void failsafe_check();      // failsafe.cpp
 };
 
-extern const AP_HAL::HAL& hal;
 extern Copter copter;
 
 using AP_HAL::millis;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -128,7 +128,7 @@
 /*
   main APM:Plane class
  */
-class Plane : public AP_HAL::HAL::Callbacks {
+class Plane : public AP_Vehicle {
 public:
     friend class GCS_MAVLINK_Plane;
     friend class Parameters;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -33,9 +33,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <StorageManager/StorageManager.h>
-#include <AP_GPS/AP_GPS.h>         // ArduPilot GPS library
-#include <AP_Baro/AP_Baro.h>        // ArduPilot barometer library
-#include <AP_Compass/AP_Compass.h>     // ArduPilot Mega Magnetometer Library
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
 #include <AP_InertialSensor/AP_InertialSensor.h> // Inertial Sensor Library
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
@@ -43,7 +40,6 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>     // Range finder library
 #include <Filter/Filter.h>                     // Filter library
-#include <AP_Relay/AP_Relay.h>       // APM relay
 #include <AP_Camera/AP_Camera.h>          // Photo or video camera
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Terrain/AP_Terrain.h>
@@ -55,7 +51,6 @@
 #include <APM_Control/APM_Control.h>
 #include <APM_Control/AP_AutoTune.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>    // MAVLink GCS definitions
-#include <AP_SerialManager/AP_SerialManager.h>   // Serial manager library
 #include <AP_Mount/AP_Mount.h>           // Camera/Antenna mount
 #include <AP_Declination/AP_Declination.h> // ArduPilot Mega Declination Helper Library
 #include <AP_Logger/AP_Logger.h>
@@ -74,23 +69,17 @@
 #include <AP_Mission/AP_Mission.h>     // Mission command library
 
 #include <AP_Soaring/AP_Soaring.h>
-#include <AP_Notify/AP_Notify.h>      // Notify library
 #include <AP_BattMonitor/AP_BattMonitor.h> // Battery monitor library
 
 #include <AP_Arming/AP_Arming.h>
-#include <AP_BoardConfig/AP_BoardConfig.h>
-#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 #include <AP_OSD/AP_OSD.h>
-#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 
 #include <AP_Rally/AP_Rally.h>
 
 #include <AP_OpticalFlow/AP_OpticalFlow.h>     // Optical Flow library
-#include <AP_RSSI/AP_RSSI.h>                   // RSSI Library
 #include <AP_Parachute/AP_Parachute.h>
 #include <AP_ADSB/AP_ADSB.h>
-#include <AP_Button/AP_Button.h>
 #include <AP_ICEngine/AP_ICEngine.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_Landing/AP_Landing.h>
@@ -188,22 +177,11 @@ private:
     // mapping between input channels
     RCMapper rcmap;
 
-    // board specific config
-    AP_BoardConfig BoardConfig;
-
-    // board specific config for CAN bus
-#if HAL_WITH_UAVCAN
-    AP_BoardConfig_CAN BoardConfig_CAN;
-#endif
-
     // primary input channels
     RC_Channel *channel_roll;
     RC_Channel *channel_pitch;
     RC_Channel *channel_throttle;
     RC_Channel *channel_rudder;
-
-    // notification object for LEDs, buzzers etc (parameter set to false disables external leds)
-    AP_Notify notify;
 
     AP_Logger logger;
 
@@ -211,18 +189,8 @@ private:
     int32_t roll_limit_cd;
     int32_t pitch_limit_min_cd;
 
-    // Sensors
-    AP_GPS gps;
-
     // flight modes convenience array
     AP_Int8 *flight_modes = &g.flight_mode1;
-
-    AP_Baro barometer;
-    Compass compass;
-
-    AP_InertialSensor ins;
-
-    RangeFinder rangefinder;
 
     AP_Vehicle::FixedWing::Rangefinder_State rangefinder_state;
 
@@ -271,8 +239,6 @@ private:
     // external failsafe boards during baro and airspeed calibration
     bool in_calibration;
 
-    AP_SerialManager serial_manager;
-
     // GCS selection
     GCS_Plane _gcs; // avoid using this; use gcs()
     GCS_Plane &gcs() { return _gcs; }
@@ -282,12 +248,6 @@ private:
 
     // selected navigation controller
     AP_SpdHgtControl *SpdHgt_Controller = &TECS_controller;
-
-    // Relay
-    AP_Relay relay;
-
-    // handle servo and relay events
-    AP_ServoRelayEvents ServoRelayEvents;
 
     // Camera
 #if CAMERA == ENABLED
@@ -301,9 +261,6 @@ private:
 
     // Rally Ponints
     AP_Rally rally;
-
-    // RSSI
-    AP_RSSI rssi;
 
 #if OSD_ENABLED == ENABLED
     AP_OSD osd;
@@ -1098,7 +1055,6 @@ public:
     void failsafe_check(void);
 };
 
-extern const AP_HAL::HAL& hal;
 extern Plane plane;
 
 using AP_HAL::millis;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -128,7 +128,7 @@
 #include <SITL/SITL.h>
 #endif
 
-class Sub : public AP_HAL::HAL::Callbacks {
+class Sub : public AP_Vehicle {
 public:
     friend class GCS_MAVLINK_Sub;
     friend class GCS_Sub;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -55,10 +55,8 @@
 #include <AC_AttitudeControl/AC_AttitudeControl_Sub.h> // Attitude control library
 #include <AC_AttitudeControl/AC_PosControl_Sub.h>      // Position control library
 #include <AP_Motors/AP_Motors.h>          // AP Motors library
-#include <AP_RangeFinder/AP_RangeFinder.h>     // Range finder library
 #include <Filter/Filter.h>             // Filter library
 #include <AP_Relay/AP_Relay.h>           // APM relay
-#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AP_Mount/AP_Mount.h>           // Camera/Antenna mount
 #include <AP_Vehicle/AP_Vehicle.h>         // needed for AHRS build
 #include <AP_InertialNav/AP_InertialNav.h>     // ArduPilot Mega inertial navigation library
@@ -70,8 +68,6 @@
 #include <AP_Scheduler/PerfInfo.h>       // loop perf monitoring
 #include <AP_Notify/AP_Notify.h>          // Notify library
 #include <AP_BattMonitor/AP_BattMonitor.h>     // Battery monitor library
-#include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
-#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_JSButton/AP_JSButton.h>   // Joystick/gamepad button function assignment
 #include <AP_LeakDetector/AP_LeakDetector.h> // Leak detector
@@ -156,9 +152,6 @@ private:
     // main loop scheduler
     AP_Scheduler scheduler{FUNCTOR_BIND_MEMBER(&Sub::fast_loop, void)};
 
-    // AP_Notify instance
-    AP_Notify notify;
-
     // primary input control channels
     RC_Channel *channel_roll;
     RC_Channel *channel_pitch;
@@ -169,16 +162,10 @@ private:
 
     AP_Logger logger;
 
-    AP_GPS gps;
-
     AP_LeakDetector leak_detector;
 
     TSYS01 celsius;
-    AP_Baro barometer;
-    Compass compass;
-    AP_InertialSensor ins;
 
-    RangeFinder rangefinder;
     struct {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder
@@ -213,8 +200,6 @@ private:
 
     // system time in milliseconds of last recorded yaw reset from ekf
     uint32_t ekfYawReset_ms = 0;
-
-    AP_SerialManager serial_manager;
 
     // GCS selection
     GCS_Sub _gcs; // avoid using this; use gcs()
@@ -252,14 +237,6 @@ private:
 
 #if RCMAP_ENABLED == ENABLED
     RCMapper rcmap;
-#endif
-
-    // board specific config
-    AP_BoardConfig BoardConfig;
-
-#if HAL_WITH_UAVCAN
-    // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN;
 #endif
 
     // Failsafe
@@ -397,12 +374,6 @@ private:
     AC_WPNav wp_nav;
     AC_Loiter loiter_nav;
     AC_Circle circle_nav;
-
-    // Reference to the relay object
-    AP_Relay relay;
-
-    // handle repeated servo and relay events
-    AP_ServoRelayEvents ServoRelayEvents;
 
     // Camera
 #if CAMERA == ENABLED

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -139,10 +139,10 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
     z_last = z;
 }
 
-void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
+void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
 {
     // Act based on the function assigned to this button
-    switch (get_button(button)->function(shift)) {
+    switch (get_button(_button)->function(shift)) {
     case JSButton::button_function_t::k_arm_toggle:
         if (motors.armed()) {
             arming.disarm();
@@ -586,10 +586,10 @@ void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
     }
 }
 
-void Sub::handle_jsbutton_release(uint8_t button, bool shift) {
+void Sub::handle_jsbutton_release(uint8_t _button, bool shift) {
 
     // Act based on the function assigned to this button
-    switch (get_button(button)->function(shift)) {
+    switch (get_button(_button)->function(shift)) {
     case JSButton::button_function_t::k_relay_1_momentary:
         relay.off(0);
         break;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -6,6 +6,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_AHRS/AP_AHRS_View.h>
 #include <AP_Motors/AP_Motors.h>
 #include <AC_PID/AC_PID.h>

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -2,6 +2,7 @@
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include "AccelCalibrator.h"
+#include "AP_Vehicle/AP_Vehicle_Type.h"
 
 #define AP_ACCELCAL_MAX_NUM_CLIENTS 4
 class GCS_MAVLINK;

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -16,12 +16,13 @@
  *   AP_BoardConfig - board specific configuration
  */
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Common/AP_Common.h>
-#include <GCS_MAVLink/GCS.h>
 #include "AP_BoardConfig.h"
-#include <stdio.h>
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
 #include <AP_RTC/AP_RTC.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <GCS_MAVLink/GCS.h>
 
 #if HAL_WITH_UAVCAN
 #include <AP_UAVCAN/AP_UAVCAN.h>
@@ -29,6 +30,8 @@
 #include <AP_HAL_Linux/CAN.h>
 #endif
 #endif
+
+#include <stdio.h>
 
 #ifndef BOARD_TYPE_DEFAULT
 #define BOARD_TYPE_DEFAULT PX4_BOARD_AUTO

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -28,7 +28,7 @@
 #include "AP_Compass.h"
 #include "Compass_learn.h"
 
-extern AP_HAL::HAL& hal;
+extern const AP_HAL::HAL& hal;
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduSub)
 #define COMPASS_LEARN_DEFAULT Compass::LEARN_NONE

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -4,6 +4,9 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_AHRS/AP_AHRS_DCM.h>
+#include <AP_AHRS/AP_AHRS_NavEKF.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -71,7 +71,7 @@ public:
     void update(void);
 
     // set pointer to rangefinder object
-    void set_rangefinder(const RangeFinder *rangefinder) { _rangefinder = rangefinder; }
+    void set_rangefinder(const class RangeFinder *rangefinder) { _rangefinder = rangefinder; }
     const RangeFinder *get_rangefinder() const { return _rangefinder; }
 
     // return sensor orientation and yaw correction

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -19,11 +19,25 @@
   parameters needed by multiple libraries
  */
 
+#include <AP_Baro/AP_Baro.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
+#include <AP_Button/AP_Button.h>
+#include <AP_GPS/AP_GPS.h>
+#include <AP_Logger/AP_Logger.h>
+#include <AP_Notify/AP_Notify.h>                    // Notify library
 #include <AP_Param/AP_Param.h>
+#include <AP_Relay/AP_Relay.h>                      // APM relay
+#include <AP_RSSI/AP_RSSI.h>                        // RSSI Library
+#include <AP_SerialManager/AP_SerialManager.h>      // Serial manager library
+#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 
-class AP_Vehicle {
+class AP_Vehicle : public AP_HAL::HAL::Callbacks {
 
 public:
+
+    AP_Vehicle() {}
+
     /*
       common parameters for fixed wing aircraft
      */
@@ -76,7 +90,39 @@ public:
     struct MultiCopter {
         AP_Int16 angle_max;
     };
+
+protected:
+
+    // board specific config
+    AP_BoardConfig BoardConfig;
+
+#if HAL_WITH_UAVCAN
+    // board specific config for CAN bus
+    AP_BoardConfig_CAN BoardConfig_CAN;
+#endif
+
+    // sensor drivers
+    AP_GPS gps;
+    AP_Baro barometer;
+    Compass compass;
+    AP_InertialSensor ins;
+    AP_Button button;
+    RangeFinder rangefinder;
+
+    AP_RSSI rssi;
+
+    AP_SerialManager serial_manager;
+
+    AP_Relay relay;
+
+    AP_ServoRelayEvents ServoRelayEvents;
+
+    // notification object for LEDs, buzzers etc (parameter set to
+    // false disables external leds)
+    AP_Notify notify;
+
 };
 
+extern const AP_HAL::HAL& hal;
 
 #include "AP_Vehicle_Type.h"


### PR DESCRIPTION
```
Michael, 12:55
Anyways yes

So we can have the discusion

Because it would make the mode stuff a lot better for scripting

and I suspect would let you narrow down a lot of MAVLink interfaces to common code that then get called on a vehicle singleton

WHich would let scrippting use the same singleton/interface

Which would give a very pleasing similiarity in behaviour
```

(IOW Michael made me do it)
