### PR TITLE
Add radio-failsafe sounds to Buzzer tones

### DIFF
--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -56,6 +56,10 @@ bool Buzzer::init()
     // warning in plane and rover on every boot
     _flags.armed = AP_Notify::flags.armed;
     _flags.failsafe_battery = AP_Notify::flags.failsafe_battery;
+
+    // play a quick beep at startup
+    play_pattern(SINGLE_BUZZ);
+
     return true;
 }
 
@@ -68,6 +72,19 @@ void Buzzer::update()
 
 void Buzzer::update_pattern_to_play()
 {
+    if (!_flags.initialise_done) {
+        // play beeps when system initialization complete
+        if (!_flags.initialise_started) {
+            if (AP_Notify::flags.initialising) {
+                _flags.initialise_started = true;
+            }
+        } else if (!AP_Notify::flags.initialising) {
+            _flags.initialise_done = true;
+            play_pattern(INITIALISE_BUZZ);
+            return;
+        }
+    }
+
     // check for arming failed event
     if (AP_Notify::events.arming_failed) {
         // arming failed buzz

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -97,6 +97,16 @@ void Buzzer::update_pattern_to_play()
         return;
     }
 
+    // check if radio failsafe status has changed
+    if (_flags.failsafe_radio != AP_Notify::flags.failsafe_radio) {
+        _flags.failsafe_radio = AP_Notify::flags.failsafe_radio;
+        // play beeps to indicate radio status (if init completed)
+        if (_flags.initialise_done) {
+            play_pattern(_flags.failsafe_radio ? RADIOLOST_BUZZ : RADIOBACK_BUZZ);
+            return;
+        }
+    }
+
     // check if armed status has changed
     if (_flags.armed != AP_Notify::flags.armed) {
         _flags.armed = AP_Notify::flags.armed;

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -47,6 +47,8 @@ private:
     static const uint32_t         EKF_BAD = 0b11101101010000000000000000000000UL;
     static const uint32_t MODEL_LOST_BUZZ = 0b00010100000000000000000000000000UL;
     static const uint32_t INITIALISE_BUZZ = 0b10101100000000000000000000000000UL;
+    static const uint32_t  RADIOLOST_BUZZ = 0b11011111110000000000000000000000UL;
+    static const uint32_t  RADIOBACK_BUZZ = 0b01111010000000000000000000000000UL;
 
     /// play_pattern - plays the defined buzzer pattern
     void play_pattern(const uint32_t pattern);
@@ -60,6 +62,7 @@ private:
         uint8_t ekf_bad             : 1;    // 1 if ekf position has gone bad
         uint8_t initialise_started  : 1;    // 1 if system initialization started
         uint8_t initialise_done     : 1;    // 1 if system initialization complete
+        uint8_t failsafe_radio      : 1;    // 1 if radio failsafe has triggered
     } _flags;
 
     uint32_t _pattern;           // current pattern

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -46,6 +46,7 @@ private:
     static const uint32_t       BARO_BUZZ = 0b10101010100000000000000000000000UL;
     static const uint32_t         EKF_BAD = 0b11101101010000000000000000000000UL;
     static const uint32_t MODEL_LOST_BUZZ = 0b00010100000000000000000000000000UL;
+    static const uint32_t INITIALISE_BUZZ = 0b10101100000000000000000000000000UL;
 
     /// play_pattern - plays the defined buzzer pattern
     void play_pattern(const uint32_t pattern);
@@ -57,6 +58,8 @@ private:
         uint8_t armed               : 1;    // 0 = disarmed, 1 = armed
         uint8_t failsafe_battery    : 1;    // 1 if battery failsafe has triggered
         uint8_t ekf_bad             : 1;    // 1 if ekf position has gone bad
+        uint8_t initialise_started  : 1;    // 1 if system initialization started
+        uint8_t initialise_done     : 1;    // 1 if system initialization complete
     } _flags;
 
     uint32_t _pattern;           // current pattern

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -40,11 +40,12 @@ private:
 
     // Patterns - how many beeps will be played; read from
     // left-to-right, each bit represents 100ms
-    static const uint32_t    SINGLE_BUZZ = 0b10000000000000000000000000000000UL;
-    static const uint32_t    DOUBLE_BUZZ = 0b10100000000000000000000000000000UL;
-    static const uint32_t    ARMING_BUZZ = 0b11111111111111111111111111111100UL; // 3s
-    static const uint32_t      BARO_BUZZ = 0b10101010100000000000000000000000UL;
-    static const uint32_t        EKF_BAD = 0b11101101010000000000000000000000UL;
+    static const uint32_t     SINGLE_BUZZ = 0b10000000000000000000000000000000UL;
+    static const uint32_t     DOUBLE_BUZZ = 0b10100000000000000000000000000000UL;
+    static const uint32_t     ARMING_BUZZ = 0b11111111111111111111111111111100UL; // 3s
+    static const uint32_t       BARO_BUZZ = 0b10101010100000000000000000000000UL;
+    static const uint32_t         EKF_BAD = 0b11101101010000000000000000000000UL;
+    static const uint32_t MODEL_LOST_BUZZ = 0b00010100000000000000000000000000UL;
 
     /// play_pattern - plays the defined buzzer pattern
     void play_pattern(const uint32_t pattern);
@@ -61,9 +62,7 @@ private:
     uint32_t _pattern;           // current pattern
     uint8_t _pin;
     uint32_t _pattern_start_time;
-
-    // enforce minumum 100ms interval between patterns:
-    const uint16_t _pattern_start_interval_time_ms = 32*100 + 100;
+    int _current_bit_pos;
 
     void update_playing_pattern();
     void update_pattern_to_play();


### PR DESCRIPTION
This is for the boards that can only support a simple "active" type buzzer.

Plays beeps when radio link is lost and recovered.

Builds on PR #12190