### PR TITLE
AP_HAL: Remove force_safety_no_wait

### DIFF
--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -37,7 +37,6 @@ void AP_BoardConfig::board_init_safety()
     }
     if (force_safety_off) {
         hal.rcout->force_safety_off();
-        hal.rcout->force_safety_no_wait();
         // wait until safety has been turned off
         uint8_t count = 20;
         while (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_ARMED && count--) {

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -105,11 +105,6 @@ public:
     virtual void     force_safety_off(void) {}
 
     /*
-      If we support async sends (px4), this will force it to be serviced immediately
-     */
-    virtual void     force_safety_no_wait(void) {}
-
-    /*
       setup scaling of ESC output for ESCs that can output a
       percentage of power (such as UAVCAN ESCs). The values are in
       microseconds, and represent minimum and maximum PWM values which

--- a/libraries/AP_UAVCAN/AP_UAVCAN_Servers.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_Servers.cpp
@@ -77,7 +77,6 @@ public:
         }
         // force safety on
         hal.rcout->force_safety_on();
-        hal.rcout->force_safety_no_wait();
 
         // flush pending parameter writes
         AP_Param::flush();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2475,7 +2475,6 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
     }
     // force safety on
     hal.rcout->force_safety_on();
-    hal.rcout->force_safety_no_wait();
 
     // flush pending parameter writes
     AP_Param::flush();


### PR DESCRIPTION
`force_safety_no_wait` was always an empty implementation on all boards, so calling it didn't help anywhere, and on ChibiOS (the main set of boards that use safety switches that need time to turn off) are already triggering events to wake up the sending thread.