### PR TITLE
HAL_Linux: disabling input modifications on serial interface for rc r…

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput_RCProtocol.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RCProtocol.cpp
@@ -84,11 +84,12 @@ int RCInput_RCProtocol::open_115200(const char *path)
         return -1;
     }
 
-    tio.c_cflag &= ~(PARENB|CSTOPB|CSIZE);
-    tio.c_cflag |= CS8 | B115200;
+    tio.c_cflag &= ~(PARENB|CSTOPB|CSIZE|CBAUD);
+    tio.c_cflag |= CS8 | CREAD | CLOCAL | B115200;
 
     tio.c_lflag &= ~(ICANON|ECHO|ECHOE|ISIG);
     tio.c_iflag &= ~(IXON|IXOFF|IXANY);
+    tio.c_iflag &= ~(INLCR|ICRNL|IGNCR|IUCLC|BRKINT);
     tio.c_oflag &= ~OPOST;
 
     if (ioctl(fd, TCSETS2, &tio) != 0) {


### PR DESCRIPTION
…eceiver

Fix for #12162

This change removes input options that can modify the input data stream.
INLCR: map new line to carriage return
ICRNL: map carriage return to new line
IUCLC: map upper case to lower case
IGNCR: ignore carriage return
BRKINT: send SIGINT on serial break
see https://www.cmrr.umn.edu/~strupp/serial.html#3_1_3 for reference
