### PR TITLE
AP_AHRS: resolve compile warning in AP_AHRS_DCM::use_compass

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -458,7 +458,7 @@ bool AP_AHRS_DCM::use_compass(void)
     // degrees and the estimated wind speed is less than 80% of the
     // ground speed, then switch to GPS navigation. This will help
     // prevent flyaways with very bad compass offsets
-    const int32_t error = abs(wrap_180_cd(yaw_sensor - AP::gps().ground_course_cd()));
+    const int32_t error = labs(wrap_180_cd(yaw_sensor - AP::gps().ground_course_cd()));
     if (error > 4500 && _wind.length() < AP::gps().ground_speed()*0.8f) {
         if (AP_HAL::millis() - _last_consistent_heading > 2000) {
             // start using the GPS for heading if the compass has been


### PR DESCRIPTION
This resolves a compiler warning that shows up in Travis but for some reason doesn't appear when I compile under Windows nor Ubuntu.  Here is the error:

 
```
 [ 31/560] Compiling libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
 ../../libraries/AP_AHRS/AP_AHRS_DCM.cpp:461:27: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
     const int32_t error = abs(wrap_180_cd(yaw_sensor - AP::gps().ground_course_cd()));
                           ^
```

This seems correct to me but feel free to close if I've misunderstood something.
I have not tested this in SITL but it's a very commonly used function so the regular tests will exercise it.  Also [here is a similar line in AP_L1_Control that uses "labs" instead of "abs"](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_L1_Control/AP_L1_Control.cpp#L187).