### PR TITLE
AP_RangeFinder: make LightWare I2C native work with more hw versions

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -36,10 +36,10 @@ private:
                                 AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     bool write_bytes(uint8_t *write_buf_u8, uint32_t len_u8);
-    bool sf20_disable_address_tagging();
-    bool sf20_product_name_check();
+    void sf20_disable_address_tagging();
     bool sf20_send_and_expect(const char* send, const char* expected_reply);
     bool sf20_set_lost_signal_confirmations();
+    void sf20_get_version(const char* send_msg, const char *reply_prefix, char reply[5]);
     bool sf20_wait_on_reply(uint8_t *rx_two_bytes);
     bool init();
     bool legacy_init();


### PR DESCRIPTION
this allows the native i2c lightware driver to work with a wide range
of lidars from LightWare, removing the specific version check, and the
version specific config commands