### PR TITLE
AC_Avoidance, SITL: resolve various compiler warnings

### DIFF
--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -382,7 +382,7 @@ void AP_OADatabase::send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_
     static_assert(MAVLINK_COMM_NUM_BUFFERS <= sizeof(OA_DbItem::send_to_gcs) * 8,
                   "AP_OADatabase's OA_DBItem.send_to_gcs bitmask must be large enough to hold MAVLINK_COMM_NUM_BUFFERS");
 
-    if ((_output_level.get() <= (int8_t)OA_DbOutputLevel::OUTPUT_LEVEL_DISABLED) || !healthy() || (chan >= MAVLINK_COMM_NUM_BUFFERS)) {
+    if ((_output_level.get() <= (int8_t)OA_DbOutputLevel::OUTPUT_LEVEL_DISABLED) || !healthy()) {
         return;
     }
 

--- a/libraries/AP_HAL_SITL/sitl_airspeed.cpp
+++ b/libraries/AP_HAL_SITL/sitl_airspeed.cpp
@@ -40,13 +40,13 @@ void SITL_State::_update_airspeed(float airspeed)
     if (!is_zero(_sitl->arspd_fail_pressure)) {
         // compute a realistic pressure report given some level of trapper air pressure in the tube and our current altitude
         // algorithm taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure
-        float tube_pressure = abs(_sitl->arspd_fail_pressure - _barometer->get_pressure() + _sitl->arspd_fail_pitot_pressure);
+        float tube_pressure = fabsf(_sitl->arspd_fail_pressure - _barometer->get_pressure() + _sitl->arspd_fail_pitot_pressure);
         airspeed = 340.29409348 * sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
     }
     if (!is_zero(_sitl->arspd2_fail_pressure)) {
         // compute a realistic pressure report given some level of trapper air pressure in the tube and our current altitude
         // algorithm taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure
-        float tube_pressure = abs(_sitl->arspd2_fail_pressure - _barometer->get_pressure() + _sitl->arspd2_fail_pitot_pressure);
+        float tube_pressure = fabsf(_sitl->arspd2_fail_pressure - _barometer->get_pressure() + _sitl->arspd2_fail_pitot_pressure);
         airspeed2 = 340.29409348 * sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
     }
 

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
@@ -40,6 +40,5 @@ public:
 
 private:
     SITL::SITL *sitl;
-    float distance_maximum;
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/SITL/SIM_Gripper_EPM.cpp
+++ b/libraries/SITL/SIM_Gripper_EPM.cpp
@@ -107,7 +107,7 @@ bool Gripper_EPM::should_report()
         return false;
     }
 
-    if (abs(reported_field_strength - field_strength) > 10.0) {
+    if (fabsf(reported_field_strength - field_strength) > 10.0) {
         return true;
     }
 

--- a/libraries/SITL/SIM_Gripper_EPM.h
+++ b/libraries/SITL/SIM_Gripper_EPM.h
@@ -48,8 +48,8 @@ private:
 
     bool servo_based = true;
 
-    double field_strength; // percentage
-    double reported_field_strength = -1; // unlikely
+    float field_strength;   // percentage
+    float reported_field_strength = -1; // unlikely
 
     // I've a feeling these are probably a higher order than this:
     const float field_strength_slew_rate = 400; // (percentage of delta between field strength and 100)/second

--- a/libraries/SITL/SIM_Webots.h
+++ b/libraries/SITL/SIM_Webots.h
@@ -73,7 +73,6 @@ private:
     uint32_t connect_counter;
 
     double initial_time_s;
-    double time_diff;
     double extrapolated_s;
     double average_frame_time_s;
 


### PR DESCRIPTION
Similar to this earlier PR, these compiler warnings appear in travis but not during regular builds for some reason.  These warnings can be see by looking at a recent run of Travis for "sitl-test-rover" ([example](https://travis-ci.org/ArduPilot/ardupilot/jobs/580980396))

Here are the original errors:
```
[427/560] Compiling libraries/SITL/SIM_SilentWings.cpp
In file included from ../../libraries/SITL/SIM_Webots.cpp:19:
../../libraries/SITL/SIM_Webots.h:76:12: warning: private field 'time_diff' is not used [-Wunused-private-field]
    double time_diff;
           ^
1 warning generated.

```
```
[440/560] Compiling libraries/SITL/SIM_Gripper_EPM.cpp
../../libraries/SITL/SIM_Gripper_EPM.cpp:110:9: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
    if (abs(reported_field_strength - field_strength) > 10.0) {
        ^
../../libraries/SITL/SIM_Gripper_EPM.cpp:110:9: note: use function 'std::abs' instead
    if (abs(reported_field_strength - field_strength) > 10.0) {
        ^~~
        std::abs
1 warning generated.
```


```
[254/560] Compiling libraries/AP_Proximity/AP_Proximity.cpp
In file included from ../../libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp:18:
../../libraries/AP_Proximity/AP_Proximity_AirSimSITL.h:43:11: warning: private field 'distance_maximum' is not used [-Wunused-private-field]
    float distance_maximum;
          ^
1 warning generated.
```

```
../../libraries/AP_HAL_SITL/sitl_airspeed.cpp:43:31: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        float tube_pressure = abs(_sitl->arspd_fail_pressure - _barometer->get_pressure() + _sitl->arspd_fail_pitot_pressure);
                              ^`
`../../libraries/AP_HAL_SITL/sitl_airspeed.cpp:49:31: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        float tube_pressure = abs(_sitl->arspd2_fail_pressure - _barometer->get_pressure() + _sitl->arspd2_fail_pitot_pressure);
                              ^
2 warnings generated.
```

```
../../libraries/AC_Avoidance/AP_OADatabase.cpp:385:105: warning: result of comparison of constant 6 with expression of type 'mavlink_channel_t' is always false [-Wtautological-constant-out-of-range-compare]
    if ((_output_level.get() <= (int8_t)OA_DbOutputLevel::OUTPUT_LEVEL_DISABLED) || !healthy() || (chan >= MAVLINK_COMM_NUM_BUFFERS)) {
                                                                                                   ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```