### PR TITLE
Fixed learning of EKF body mag biases after in-flight yaw reset

### DIFF
--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -12,7 +12,9 @@ AP_Compass_SITL::AP_Compass_SITL()
         _compass._setup_earth_field();
         for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
             // default offsets to correct value
-            _compass.set_offsets(i, _sitl->mag_ofs);
+            if (_compass.get_offsets(i).is_zero()) {
+                _compass.set_offsets(i, _sitl->mag_ofs);
+            }
             
             _compass_instance[i] = register_compass();
             set_dev_id(_compass_instance[i], AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 0, DEVTYPE_SITL));

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -127,6 +127,9 @@ void NavEKF3_core::controlMagYawReset()
                 gcs().send_text(MAV_SEVERITY_WARNING, "EKF3 IMU%u ground mag anomaly, yaw re-aligned",(unsigned)imu_index);
             }
 
+            // prevent reset of variances in ConstrainVariances()
+            inhibitMagStates = false;
+
             // update the yaw reset completed status
             recordYawReset();
 


### PR DESCRIPTION
This fixes a bug where the variances of the mag bias states are reset to zero by a ConstrainVariances() immediately after a in-flight yaw reset
The end result is extremely slow body mag field learning when EK3_MAG_CAL=3
This doesn't affect EKF2 as it does the zero of the variances inside NavEKF2_core::CovariancePrediction() whereas EKF3 does it in NavEKF3_core::ConstrainVariances(). 
