### PR TITLE
AP_Filesystem: use a recursive semaphore

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -24,8 +24,9 @@ static bool remount_needed;
 #define FATFS_X (S_IXUSR | S_IXGRP | S_IXOTH)	/*< FatFs Execute perms */
 
 // use a semaphore to ensure that only one filesystem operation is
-// happening at a time
-static HAL_Semaphore sem;
+// happening at a time. A recursive semaphore is used to cope with the
+// mkdir() inside sdcard_retry()
+static HAL_Semaphore_Recursive sem;
 
 typedef struct {
     FIL *fh;


### PR DESCRIPTION
this is needed to cope with the mkdir("/APM") in sdcard_retry()