### PR TITLE
AP_RangeFinder: update minimum fw version of TFMiniPlus

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -99,8 +99,8 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::init()
         goto fail;
     }
 
-    if (val[5] * 10000 + val[4] * 100 + val[3] < 10706) {
-        hal.console->printf(DRIVER ": minimum required FW version 1.7.6, but version %u.%u.%u found\n",
+    if (val[5] * 10000 + val[4] * 100 + val[3] < 20003) {
+        hal.console->printf(DRIVER ": minimum required FW version 2.0.3, but version %u.%u.%u found\n",
                             val[5], val[4], val[3]);
         goto fail;
     }


### PR DESCRIPTION
Version 2.0.3 has important fixes to avoid having the sensor to lock up.
Let's make sure we check for it and warn on console.

@rmackay9 could you check if this still works for you?