### PR TITLE
AP_RTC: Don't allow RTC times before 2019

### DIFF
--- a/libraries/AP_RTC/AP_RTC.cpp
+++ b/libraries/AP_RTC/AP_RTC.cpp
@@ -33,6 +33,8 @@ const AP_Param::GroupInfo AP_RTC::var_info[] = {
 
 void AP_RTC::set_utc_usec(uint64_t time_utc_usec, source_type type)
 {
+    const uint64_t oldest_acceptable_date = 1546300800000; // 2019-01-01 0:00
+
     if (type >= rtc_source_type) {
         // e.g. system-time message when we've been set by the GPS
         return;
@@ -40,6 +42,11 @@ void AP_RTC::set_utc_usec(uint64_t time_utc_usec, source_type type)
 
     // check it's from an allowed sources:
     if (!(allowed_types & (1<<type))) {
+        return;
+    }
+
+    // don't allow old times
+    if (time_utc_usec < oldest_acceptable_date) {
         return;
     }
 


### PR DESCRIPTION
I've got some logs recently which had bad RTC timestamps making it into the `SYSTEM_TIME` message that couldn't be corrected. This doesn't fix the root problem (I'm still looking into that), but this prohibits setting a clearly backwards system time by accident as a general catch all/safety net. This mostly shows up when someone finds an interesting new GPS configuration.

This should also help fix some of the logs that have old/incorrect 1980 era timestamps due to getting a bad idea of the RTC time.