### PR TITLE
Allow the GPS to be in charge of logging itself

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -695,8 +695,7 @@ void AP_GPS::update_instance(uint8_t instance)
 
 #ifndef HAL_BUILD_AP_PERIPH
     if (data_should_be_logged &&
-        should_log() &&
-        !AP::ahrs().have_ekf_logging()) {
+        (should_log() || AP::ahrs().have_ekf_logging())) {
         AP::logger().Write_GPS(instance);
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -596,10 +596,6 @@ void NavEKF2::check_log_write(void)
         AP::logger().Write_Compass(imuSampleTime_us);
         logging.log_compass = false;
     }
-    if (logging.log_gps) {
-        AP::logger().Write_GPS(AP::gps().primary_sensor(), imuSampleTime_us);
-        logging.log_gps = false;
-    }
     if (logging.log_baro) {
         AP::logger().Write_Baro(imuSampleTime_us);
         logging.log_baro = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -457,7 +457,6 @@ private:
     struct {
         bool enabled:1;
         bool log_compass:1;
-        bool log_gps:1;
         bool log_baro:1;
         bool log_imu:1;
     } logging;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -600,8 +600,6 @@ void NavEKF2_core::readGpsData()
                 gpsNotAvailable = false;
             }
 
-            frontend->logging.log_gps = true;
-
         } else {
             // report GPS fix status
             gpsCheckStatus.bad_fix = true;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -610,10 +610,6 @@ void NavEKF3::check_log_write(void)
         AP::logger().Write_Compass(imuSampleTime_us);
         logging.log_compass = false;
     }
-    if (logging.log_gps) {
-        AP::logger().Write_GPS(AP::gps().primary_sensor(), imuSampleTime_us);
-        logging.log_gps = false;
-    }
     if (logging.log_baro) {
         AP::logger().Write_Baro(imuSampleTime_us);
         logging.log_baro = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -486,7 +486,6 @@ private:
     struct {
         bool enabled:1;
         bool log_compass:1;
-        bool log_gps:1;
         bool log_baro:1;
         bool log_imu:1;
     } logging;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -619,8 +619,6 @@ void NavEKF3_core::readGpsData()
                 gpsNotAvailable = false;
             }
 
-            frontend->logging.log_gps = true;
-
             // if the GPS has yaw data then input that as well
             float yaw_deg, yaw_accuracy_deg;
             if (AP::gps().gps_yaw_deg(yaw_deg, yaw_accuracy_deg)) {


### PR DESCRIPTION
When replay was turned on the EKF took over responsibility for logging. However due to how the EKF did the logging no GPS data was logged until you had a 3D GPS fix, anything with a lower fix quality was dropped. This leads to problems when trying to do early/poor GPS log analysis due to missing data.

The other problem this resolves is that because the EKF cores are slightly offset in time you currently are getting the primary GPS instance logged twice about 3-10 ms apart, which is increasing the logging overhead since it's the same data.

As far as I can tell this will not adversely impact replay, as the GPS code isn't being pushed into a buffer, and is instead being queried directly from the library, which this shouldn't be interfering with.

As a summary of intentional changes I'm aware of:

- GPS data will always be logged the same way regardless of if being logged because it was requested from the vehicle bitmask, or replay
- When logging GPS data all instances will be logged now, where as before when doing replay on the primary was logged. This was problematic when doing failure analysis though as when swapping GPS's it's hard to assess what your stand by GPS was doing
- Unless you are running blending this doesn't ever increase the amount of logging you do (with a 3D fix or better), and in the general case reduces logging bandwidth.