### PR TITLE
Rover: Windvane: rename absolute wind direction to true

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -133,12 +133,12 @@ void Rover::Log_Write_Sail()
     float wind_speed_true = logger.quiet_nanf();
     float wind_speed_apparent = logger.quiet_nanf();
     if (rover.g2.windvane.enabled()) {
-        wind_dir_abs = degrees(g2.windvane.get_absolute_wind_direction_rad());
+        wind_dir_abs = degrees(g2.windvane.get_true_wind_direction_rad());
         wind_dir_rel = degrees(g2.windvane.get_apparent_wind_direction_rad());
         wind_speed_true = g2.windvane.get_true_wind_speed();
         wind_speed_apparent = g2.windvane.get_apparent_wind_speed();
     }
-    logger.Write("SAIL", "TimeUS,WindDirAbs,WindDirApp,WindSpdTrue,WindSpdApp,SailOut,VMG",
+    logger.Write("SAIL", "TimeUS,WindDirTrue,WindDirApp,WindSpdTrue,WindSpdApp,SailOut,VMG",
                         "shhnn%n", "F000000", "Qffffff",
                         AP_HAL::micros64(),
                         (double)wind_dir_abs,

--- a/APMrover2/sailboat.cpp
+++ b/APMrover2/sailboat.cpp
@@ -242,7 +242,7 @@ void Sailboat::handle_tack_request_acro()
     }
     // set tacking heading target to the current angle relative to the true wind but on the new tack
     currently_tacking = true;
-    tack_heading_rad = wrap_2PI(rover.ahrs.yaw + 2.0f * wrap_PI((rover.g2.windvane.get_absolute_wind_direction_rad() - rover.ahrs.yaw)));
+    tack_heading_rad = wrap_2PI(rover.ahrs.yaw + 2.0f * wrap_PI((rover.g2.windvane.get_true_wind_direction_rad() - rover.ahrs.yaw)));
 
     auto_tack_request_ms = AP_HAL::millis();
 }
@@ -290,7 +290,7 @@ bool Sailboat::use_indirect_route(float desired_heading_cd) const
     const float desired_heading_rad = radians(desired_heading_cd * 0.01f);
 
     // check if desired heading is in the no go zone, if it is we can't go direct
-    return fabsf(wrap_PI(rover.g2.windvane.get_absolute_wind_direction_rad() - desired_heading_rad)) <= radians(sail_no_go);
+    return fabsf(wrap_PI(rover.g2.windvane.get_true_wind_direction_rad() - desired_heading_rad)) <= radians(sail_no_go);
 }
 
 // if we can't sail on the desired heading then we should pick the best heading that we can sail on
@@ -312,8 +312,9 @@ float Sailboat::calc_heading(float desired_heading_cd)
     }
 
     // calculate left and right no go headings looking upwind
-    const float left_no_go_heading_rad = wrap_2PI(rover.g2.windvane.get_absolute_wind_direction_rad() + radians(sail_no_go));
-    const float right_no_go_heading_rad = wrap_2PI(rover.g2.windvane.get_absolute_wind_direction_rad() - radians(sail_no_go));
+    const float true_wind_rad = rover.g2.windvane.get_true_wind_direction_rad();
+    const float left_no_go_heading_rad = wrap_2PI(true_wind_rad + radians(sail_no_go));
+    const float right_no_go_heading_rad = wrap_2PI(true_wind_rad - radians(sail_no_go));
 
     // calculate current tack, Port if heading is left of no-go, STBD if right of no-go
     Sailboat_Tack current_tack;

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -293,7 +293,7 @@ void AP_WindVane::update()
         update_true_wind_speed_and_direction();
     } else {
         // no wind speed sensor, so can't do true wind calcs
-        _direction_absolute = _direction_apparent_ef;
+        _direction_true = _direction_apparent_ef;
         _speed_true = 0.0f;
         return;
     }
@@ -331,7 +331,7 @@ void AP_WindVane::send_wind(mavlink_channel_t chan)
     // send wind
     mavlink_msg_wind_send(
         chan,
-        wrap_360(degrees(get_absolute_wind_direction_rad())),
+        wrap_360(degrees(get_true_wind_direction_rad())),
         get_true_wind_speed(),
         0);
 }
@@ -344,7 +344,7 @@ void AP_WindVane::update_true_wind_speed_and_direction()
     Vector3f veh_velocity;
     if (!AP::ahrs().get_velocity_NED(veh_velocity)) {
         // if no vehicle speed use apparent speed and direction directly
-        _direction_absolute = _direction_apparent_ef;
+        _direction_true = _direction_apparent_ef;
         _speed_true = _speed_apparent;
         return;
     }
@@ -357,7 +357,7 @@ void AP_WindVane::update_true_wind_speed_and_direction()
     Vector2f wind_true_vec = Vector2f(wind_apparent_vec.x + veh_velocity.x, wind_apparent_vec.y + veh_velocity.y);
 
     // calculate true speed and direction
-    _direction_absolute = wrap_PI(atan2f(wind_true_vec.y, wind_true_vec.x) - radians(180));
+    _direction_true = wrap_PI(atan2f(wind_true_vec.y, wind_true_vec.x) - radians(180));
     _speed_true = wind_true_vec.length();
 }
 

--- a/libraries/AP_WindVane/AP_WindVane.h
+++ b/libraries/AP_WindVane/AP_WindVane.h
@@ -57,8 +57,8 @@ public:
         return wrap_PI(_direction_apparent_ef - AP::ahrs().yaw);
     }
 
-    // get the absolute wind direction in radians, 0 = wind coming from north
-    float get_absolute_wind_direction_rad() const { return _direction_absolute; }
+    // get the true wind direction in radians, 0 = wind coming from north
+    float get_true_wind_direction_rad() const { return _direction_true; }
 
     // Return apparent wind speed
     float get_apparent_wind_speed() const { return _speed_apparent; }
@@ -112,7 +112,7 @@ private:
 
     // wind direction variables
     float _direction_apparent_ef;                   // wind's apparent direction in radians (0 = ahead of vehicle)
-    float _direction_absolute;                      // wind's absolute direction in radians (0 = North)
+    float _direction_true;                          // wind's true direction in radians (0 = North)
 
     // wind speed variables
     float _speed_apparent;                          // wind's apparent speed in m/s


### PR DESCRIPTION
This is a no functional change to wind direction naming. We currently have wind speed true and wind direction absolute. This changes direction from absolute to true to match speed. true is the more common term in sailing. 

taken from https://github.com/ArduPilot/ardupilot/pull/11423