### PR TITLE
AP_Scripting: add set_message_interval binding

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -134,3 +134,4 @@ singleton AP_Relay method toggle void uint8_t 0 AP_RELAY_NUM_RELAYS
 include GCS_MAVLink/GCS.h
 singleton GCS alias gcs
 singleton GCS method send_text void MAV_SEVERITY'enum MAV_SEVERITY_EMERGENCY MAV_SEVERITY_DEBUG "%s"'literal string
+singleton GCS method set_message_interval MAV_RESULT uint8_t 0 MAVLINK_COMM_NUM_BUFFERS uint32_t 0 UINT32_MAX int32_t -1 INT32_MAX

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -491,6 +491,32 @@ static int GCS_send_text(lua_State *L) {
     return 0;
 }
 
+static int GCS_set_message_interval(lua_State *L) {
+    GCS * ud = GCS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "gcs not supported on this firmware");
+    }
+
+    binding_argcheck(L, 4);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && raw_data_2 <= MIN(MAVLINK_COMM_NUM_BUFFERS, UINT8_MAX)), 2, "argument out of range");
+    const uint32_t data_2 = static_cast<uint32_t>(raw_data_2);
+    const lua_Unsigned raw_data_3 = luaL_checkinteger(L, 3);
+    luaL_argcheck(L, (raw_data_3 <= UINT32_MAX), 3, "argument out of range");
+    const uint32_t data_3 = static_cast<uint32_t>(raw_data_3);
+    const lua_Integer raw_data_4 = luaL_checkinteger(L, 4);
+    luaL_argcheck(L, ((raw_data_4 >= -1) && (raw_data_4 <= INT32_MAX)), 4, "argument out of range");
+    const int32_t data_4 = static_cast<int32_t>(raw_data_4);
+    const MAV_RESULT data = ud->set_message_interval(
+            data_2,
+            data_3,
+            data_4);
+
+    lua_pushinteger(L, data);
+
+    return 1;
+}
+
 static int AP_Relay_toggle(lua_State *L) {
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
@@ -1519,6 +1545,7 @@ static int AP_AHRS_get_roll(lua_State *L) {
 
 const luaL_Reg GCS_meta[] = {
     {"send_text", GCS_send_text},
+    {"set_message_interval", GCS_set_message_interval},
     {NULL, NULL}
 };
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -273,6 +273,8 @@ public:
     virtual uint64_t capabilities() const;
     uint8_t get_stream_slowdown_ms() const { return stream_slowdown_ms; }
 
+    MAV_RESULT set_message_interval(uint32_t msg_id, int32_t interval_us);
+
 protected:
 
     virtual bool in_hil_mode() const { return false; }
@@ -783,6 +785,9 @@ public:
 
     virtual bool simple_input_active() const { return false; }
     virtual bool supersimple_input_active() const { return false; }
+
+    MAV_RESULT set_message_interval(uint8_t port_num, uint32_t msg_id, int32_t interval_us);
+    uint8_t get_channel_from_port_number(uint8_t port_num);
 
 protected:
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2265,9 +2265,9 @@ MAV_RESULT GCS::set_message_interval(uint8_t port_num, uint32_t msg_id, int32_t 
 {
     uint8_t channel = get_channel_from_port_number(port_num);
 
-    if (channel < MAVLINK_COMM_NUM_BUFFERS && chan(channel) != nullptr)
-    {
+    if ((channel < MAVLINK_COMM_NUM_BUFFERS) && (chan(channel) != nullptr)) {
         chan(channel)->set_message_interval(msg_id, interval_us);
+        return MAV_RESULT_ACCEPTED;
     }
 
     return MAV_RESULT_FAILED;
@@ -2275,8 +2275,9 @@ MAV_RESULT GCS::set_message_interval(uint8_t port_num, uint32_t msg_id, int32_t 
 
 uint8_t GCS::get_channel_from_port_number(uint8_t port_num)
 {
+    const AP_HAL::UARTDriver *u = AP::serialmanager().get_serial_by_id(port_num);
     for (uint8_t i=0; i<num_gcs(); i++) {
-        if (chan(i)->get_uart() == AP::serialmanager().get_serial_by_id(port_num)) {
+        if (chan(i)->get_uart() == u) {
             return i;
         }
     }


### PR DESCRIPTION
This PR allows lua scripts to set message interval.

This has been tested on SITL with a copter and it worked. The script used is below and it would set ATTITUDE message to 5Hz and AHRS message to 2Hz.

``` lua
function update ()
  gcs_mavlink:set_message_interval(30, 200000) -- ATTITUDE
  gcs_mavlink:set_message_interval(163, 500000) -- AHRS

  return update, 1000
end

return update, 1000
```