### PR TITLE
Fixed DNA in UAVCAN

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -369,8 +369,9 @@ def build(bld):
     # implement anywhere (the FILE* functions). This allows us to get link
     # errors if we accidentially try to use one of those functions either
     # directly or via another libc call
-    wraplist = ['sscanf', 'snprintf', 'vsnprintf',
-                'fopen', 'fread', 'fprintf', 'fflush', 'fwrite', 'fread', 'fputs', 'fgets',
+    wraplist = ['sscanf', 'fprintf', 'snprintf', 'vsnprintf','vasprintf','asprintf','vprintf','scanf',
+                'fiprintf','printf',
+                'fopen', 'fread', 'fflush', 'fwrite', 'fread', 'fputs', 'fgets',
                 'clearerr', 'fseek', 'ferror', 'fclose', 'tmpfile', 'getc', 'ungetc', 'feof',
                 'ftell', 'freopen', 'remove', 'vfprintf', 'fscanf' ]
     for w in wraplist:

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -369,7 +369,7 @@ def build(bld):
     # implement anywhere (the FILE* functions). This allows us to get link
     # errors if we accidentially try to use one of those functions either
     # directly or via another libc call
-    wraplist = ['sscanf', 'snprintf',
+    wraplist = ['sscanf', 'snprintf', 'vsnprintf',
                 'fopen', 'fread', 'fprintf', 'fflush', 'fwrite', 'fread', 'fputs', 'fgets',
                 'clearerr', 'fseek', 'ferror', 'fclose', 'tmpfile', 'getc', 'ungetc', 'feof',
                 'ftell', 'freopen', 'remove', 'vfprintf', 'fscanf' ]

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
@@ -26,6 +26,7 @@ extern "C" {
 
 int vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
 int __wrap_snprintf(char *str, size_t size, const char *fmt, ...);
+int __wrap_vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
 int snprintf(char *str, size_t size, const char *fmt, ...); //undefined, only used as a placeholder, its replaced by wrap method at link time
 int vasprintf(char **strp, const char *fmt, va_list ap);
 int asprintf(char **strp, const char *fmt, ...);

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
@@ -24,19 +24,23 @@
 extern "C" {
 #endif
 
-int vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
 int __wrap_snprintf(char *str, size_t size, const char *fmt, ...);
 int __wrap_vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
+int __wrap_vasprintf(char **strp, const char *fmt, va_list ap);
+int __wrap_asprintf(char **strp, const char *fmt, ...);
+int __wrap_vprintf(const char *fmt, va_list arg);
+int __wrap_printf(const char *fmt, ...);
+int __wrap_scanf(const char *fmt, ...);
+int __wrap_sscanf(const char *buf, const char *fmt, ...);
+int __wrap_fprintf(void *f, const char *fmt, ...);
+
+int vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
 int snprintf(char *str, size_t size, const char *fmt, ...); //undefined, only used as a placeholder, its replaced by wrap method at link time
 int vasprintf(char **strp, const char *fmt, va_list ap);
 int asprintf(char **strp, const char *fmt, ...);
 int vprintf(const char *fmt, va_list arg);
 int printf(const char *fmt, ...);
 
-int scanf (const char *fmt, ...);
-int __wrap_sscanf (const char *buf, const char *fmt, ...);
-int sscanf (const char *buf, const char *fmt, ...); //undefined, only used as a placeholder, its replaced by wrap method at link time
-int vsscanf (const char *buf, const char *s, va_list ap);
 void *malloc(size_t size);
 void *calloc(size_t nmemb, size_t size);
 void free(void *ptr);

--- a/libraries/AP_HAL_ChibiOS/stdio.cpp
+++ b/libraries/AP_HAL_ChibiOS/stdio.cpp
@@ -44,6 +44,11 @@ int __wrap_snprintf(char *str, size_t size, const char *fmt, ...)
    return done;
 }
 
+int __wrap_vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
+{
+    return hal.util->vsnprintf(str, size, fmt, ap);
+}
+
 int vasprintf(char **strp, const char *fmt, va_list ap)
 {
     int len = vsnprintf(NULL, 0, fmt, ap);


### PR DESCRIPTION
Use the hal.util implementation for vsnprintf, which fixes an error with uavcan DNA, and also saves us a few k of flash
