### PR TITLE
Copter: make requires_terrain a callback on the flightmode

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -217,13 +217,9 @@ void Copter::failsafe_gcs_off_event(void)
 //  missing_data should be set to true if the vehicle failed to navigate because of missing data, false if navigation is proceeding successfully
 void Copter::failsafe_terrain_check()
 {
-    // trigger with 5 seconds of failures while in AUTO mode
-    bool valid_mode = (control_mode == Mode::Number::AUTO ||
-                       control_mode == Mode::Number::GUIDED ||
-                       control_mode == Mode::Number::GUIDED_NOGPS ||
-                       control_mode == Mode::Number::RTL);
+    // trigger within <n> milliseconds of failures while in various modes
     bool timeout = (failsafe.terrain_last_failure_ms - failsafe.terrain_first_failure_ms) > FS_TERRAIN_TIMEOUT_MS;
-    bool trigger_event = valid_mode && timeout;
+    bool trigger_event = timeout && flightmode->requires_terrain_failsafe();
 
     // check for clearing of event
     if (trigger_event != failsafe.terrain) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -69,6 +69,9 @@ public:
     virtual bool landing_gear_should_be_deployed() const { return false; }
     virtual bool is_landing() const { return false; }
 
+    // mode requires terrain to be present to be functional
+    virtual bool requires_terrain_failsafe() const { return false; }
+
     // functions for reporting to GCS
     virtual bool get_wp(Location &loc) { return false; };
     virtual int32_t wp_bearing() const { return 0; }
@@ -362,6 +365,8 @@ public:
     bool landing_gear_should_be_deployed() const override;
 
     bool is_taking_off() const override;
+
+    bool requires_terrain_failsafe() const override { return true; }
 
     // return true if this flight mode supports user takeoff
     //  must_nagivate is true if mode must also control horizontal position
@@ -772,6 +777,8 @@ public:
     bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool in_guided_mode() const override { return true; }
 
+    bool requires_terrain_failsafe() const override { return true; }
+
     void set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
     bool set_destination(const Location& dest_loc, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
@@ -1011,6 +1018,8 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return false; };
     bool is_autopilot() const override { return true; }
+
+    bool requires_terrain_failsafe() const override { return true; }
 
     // for reporting to GCS
     bool get_wp(Location &loc) override;


### PR DESCRIPTION
This will prompt new modes to consider whether failsafe should be active
for terrain.

zigzag should be enabling terrain failsafe - this should do that.
