### PR TITLE
AP_InertialSensor: correct reboot documentation for batch logger and filters

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -258,7 +258,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
 
     // @Param: GYRO_FILTER
     // @DisplayName: Gyro filter cutoff frequency
-    // @Description: Filter cutoff frequency for gyroscopes. This can be set to a lower value to try to cope with very high vibration levels in aircraft. This option takes effect on the next reboot. A value of zero means no filtering (not recommended!)
+    // @Description: Filter cutoff frequency for gyroscopes. This can be set to a lower value to try to cope with very high vibration levels in aircraft. A value of zero means no filtering (not recommended!)
     // @Units: Hz
     // @Range: 0 256
     // @User: Advanced
@@ -266,7 +266,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
 
     // @Param: ACCEL_FILTER
     // @DisplayName: Accel filter cutoff frequency
-    // @Description: Filter cutoff frequency for accelerometers. This can be set to a lower value to try to cope with very high vibration levels in aircraft. This option takes effect on the next reboot. A value of zero means no filtering (not recommended!)
+    // @Description: Filter cutoff frequency for accelerometers. This can be set to a lower value to try to cope with very high vibration levels in aircraft. A value of zero means no filtering (not recommended!)
     // @Units: Hz
     // @Range: 0 256
     // @User: Advanced

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -6,17 +6,19 @@
 const AP_Param::GroupInfo AP_InertialSensor::BatchSampler::var_info[] = {
     // @Param: BAT_CNT
     // @DisplayName: sample count per batch
-    // @Description: Number of samples to take when logging streams of IMU sensor readings.  Will be rounded down to a multiple of 32.
+    // @Description: Number of samples to take when logging streams of IMU sensor readings.  Will be rounded down to a multiple of 32. This option takes effect on the next reboot.
     // @User: Advanced
     // @Increment: 32
+    // @RebootRequired: True
     AP_GROUPINFO("BAT_CNT",  1, AP_InertialSensor::BatchSampler, _required_count,   1024),
 
     // @Param: BAT_MASK
     // @DisplayName: Sensor Bitmask
-    // @Description: Bitmap of which IMUs to log batch data for
+    // @Description: Bitmap of which IMUs to log batch data for. This option takes effect on the next reboot.
     // @User: Advanced
     // @Values: 0:None,1:First IMU,255:All
     // @Bitmask: 0:IMU1,1:IMU2,2:IMU3
+    // @RebootRequired: True
     AP_GROUPINFO("BAT_MASK",  2, AP_InertialSensor::BatchSampler, _sensor_mask,   DEFAULT_IMU_LOG_BAT_MASK),
 
     // @Param: BAT_OPT


### PR DESCRIPTION
@peterbarker & @lthall l this corrects a couple of small documentation issues in the batch logger and accel/gyro filtering. Totally safe as affects only docs.

Remove the reboot doc statement from INS_GYRO_FILTER and INS_ACCEL_FILTER, these are both set dynamically in AP_InertialSensor_Backend::update_gyro() and AP_InertialSensor_Backend::update_accel() respectively.

Add reboot doc statement to INS_LOG_BAT_MASK and INS_LOG_BAT_CNT, both of these are set one time in AP_InertialSensor::BatchSampler::init() and cannot be changed subsequently