### PR TITLE
EKF2/3: use EKx_RNG_USE_HGT only when EKx_ALT_SOURCE = 1 (RangeFinder)

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -829,7 +829,7 @@ void NavEKF2_core::selectHeightForFusion()
     if (extNavUsedForPos) {
         // always use external vision as the height source if using for position.
         activeHgtSource = HGT_SOURCE_EV;
-    } else if (((frontend->_useRngSwHgt > 0) || (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
+    } else if (((frontend->_useRngSwHgt > 0) && (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
         if (frontend->_altSource == 1) {
             // always use range finder
             activeHgtSource = HGT_SOURCE_RNG;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -793,7 +793,7 @@ void NavEKF3_core::selectHeightForFusion()
     baroDataToFuse = storedBaro.recall(baroDataDelayed, imuDataDelayed.time_ms);
 
     // select height source
-    if (((frontend->_useRngSwHgt > 0) || (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
+    if (((frontend->_useRngSwHgt > 0) && (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
         if (frontend->_altSource == 1) {
             // always use range finder
             activeHgtSource = HGT_SOURCE_RNG;


### PR DESCRIPTION
This small change ensures that the EKFs do not try to fuse in the range finder altitude unless EKx_RNG_USE_HGT = 1/RangeFinder.  @tridge and I think this is the intended behaviour because of the EK2_RNG_USE_HGT's parameter description:

**RNG_USE_HGT**
`Range finder can be used as the primary height source when below this percentage of its maximum range (see RNGFND_MAX_CM). Set to -1 when EK2_ALT_SOURCE is not set to range finder.  This is not for terrain following.
`

**ALT_SOURCE**
`Primary height sensor used by the EKF. If the selected option cannot be used, baro is used. 1 uses the range finder and only with optical flow navigation (EK2_GPS_TYPE = 3), Do not use "1" for terrain following. NOTE: the EK2_RNG_USE_HGT parameter can be used to switch to range-finder when close to the ground.`

This is in response to [this issue](https://github.com/ArduPilot/ardupilot/issues/7119) and [this new incident ](https://discuss.ardupilot.org/t/uncommanded-assent/46847).

I managed to reproduce an odd EKF2/3 altitude reset in SITL when descending which I think is similar to what the users have reported.  The steps to reproduce in SITL are:

- param load [../Tools/autotest/default_params/copter-rangefinder.parm](https://github.com/ArduPilot/ardupilot/blob/master/Tools/autotest/default_params/copter-rangefinder.parm)
- param set RNGFND1_MAX_CM 1500
- param set EK2_RNG_USE_HGT 70
- reboot sitl
- loiter
- arm throttle
- rc 3 1800
- rc 2 1200
- wait for the vehicle to climb to 50m
- RTL
- let the vehicle RTL home and begin descending.  Note that it will start flying forward again as it descends because the pitch stick is still pushed forward, let the vehicle continue like this until it descends to 25m
- rc 2 1500 (to flatten out the vehicle)
- when the vehicle reaches about 3m the altitude will reset

Below are screen shots of EKF2's altitude during the above test before and after this change.  Note the AFTER does not have the Altitude reset. The [before log file is here](https://www.dropbox.com/s/aw92cwb6d1cg89w/ekf2-before.bin?dl=0), [the after log file is here](https://www.dropbox.com/s/iz6ua02h9ra5649/ekf2-after.bin?dl=0) in case you would like to see more details.

![ekf2-before-after](https://user-images.githubusercontent.com/1498098/64579250-24ba9c80-d3bd-11e9-9067-eacf8dc8e693.png)


