### PR TITLE
Copter: land mode initialises yaw

### DIFF
--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -34,6 +34,9 @@ bool ModeLand::init(bool ignore_checks)
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     copter.ap.land_repo_active = false;
 
+    // initialise yaw
+    auto_yaw.set_mode(AUTO_YAW_HOLD);
+
     return true;
 }
 


### PR DESCRIPTION
This resolves an issue with the vehicle's heading changing as it is switched into Land mode because the AutoYaw's mode is not being set as Land mode starts.

Note that this change only affect the Land flight mode.  It does not affect Land-within-Auto or Land-within-RTL.

The sudden change in yaw is most easily reproduced when switching from ZigZag mode to Land mode.  Steps to reproduce in SITL are:

- param set RC8_OPTION 61  (allows setting the zigzag "waypoints")
- take off in Loiter and climb to 5m
- rc8 2000 (to set first zigzag point)
- rc 1 1000 (to fly left 10m)
- rc 1 1500 (to stop)
- rc 8 1000 (to save second zigzag point
- rc 8 2000 (to fly to the first waypoint)
- rc 8 1000 (to fly to the 2nd waypoint)
- LAND (at this point the vehicle will yaw normally to the west)

Below are screen shots of the SITL test (as described above).  Note the desired yaw before and after this PR's change:

![land-yaw-init-fix-before-after](https://user-images.githubusercontent.com/1498098/64585528-0318df80-d3d4-11e9-9dc0-42a6975aaefe.png)


