### PR TITLE
AP_HAL: correct include ordering in srxl.h

### DIFF
--- a/libraries/AP_HAL/utility/srxl.cpp
+++ b/libraries/AP_HAL/utility/srxl.cpp
@@ -20,13 +20,13 @@
    - 2016.10.23: SRXL variant V1 sucessfully (Testbench and Pixhawk/MissionPlanner) tested with RX-9-DR M-LINK (SW v1.26)
  */
 
+#include "srxl.h"
+
+#include <AP_Math/crc.h>
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <AP_Math/crc.h>
-#include "srxl.h"
-
-
 
 /* SRXL datastream characteristics for all variants */
 #define SRXL_MIN_FRAMESPACE_US 8000U    /* Minumum space between srxl frames in us (applies to all variants)  */

--- a/libraries/AP_HAL/utility/srxl.h
+++ b/libraries/AP_HAL/utility/srxl.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 /*
  * Decoder for SRXL protocol
  *


### PR DESCRIPTION
The header needs stdint.h which it was only getting because it was
included after stdint.h in the cpp file.

Stop including standard headers before other ArduPilot headers