### PR TITLE
Rover: Sailboat tacking improvements

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -402,7 +402,9 @@ void Mode::navigate_to_waypoint()
     if (g2.sailboat.use_indirect_route(desired_heading_cd)) {
         // sailboats use heading controller when tacking upwind
         desired_heading_cd = g2.sailboat.calc_heading(desired_heading_cd);
-        calc_steering_to_heading(desired_heading_cd, g2.wp_nav.get_pivot_rate());
+        // use pivot turn rate for tacks
+        const float turn_rate = g2.sailboat.tacking() ? g2.wp_nav.get_pivot_rate() : 0.0f;
+        calc_steering_to_heading(desired_heading_cd, turn_rate);
     } else {
         // call turn rate steering controller
         calc_steering_from_turn_rate(g2.wp_nav.get_turn_rate_rads(), desired_speed, g2.wp_nav.get_reversed());

--- a/APMrover2/sailboat.h
+++ b/APMrover2/sailboat.h
@@ -49,7 +49,7 @@ public:
     void handle_tack_request_acro();
 
     // return target heading in radians when tacking (only used in acro)
-    float get_tack_heading_rad() const;
+    float get_tack_heading_rad();
 
     // handle user initiated tack while in autonomous modes (Auto, Guided, RTL, SmartRTL, etc)
     void handle_tack_request_auto();
@@ -97,16 +97,12 @@ private:
     AP_Float sail_no_go;
     AP_Float sail_windspeed_min;
 
-    enum Sailboat_Tack {
-        TACK_PORT,
-        TACK_STARBOARD
-    };
-
     RC_Channel *channel_mainsail;   // rc input channel for controlling mainsail
     bool currently_tacking;         // true when sailboat is in the process of tacking to a new heading
     float tack_heading_rad;         // target heading in radians while tacking in either acro or autonomous modes
-    uint32_t auto_tack_request_ms;  // system time user requested tack in autonomous modes
+    uint32_t tack_request_ms;       // system time user requested tack
     uint32_t auto_tack_start_ms;    // system time when tack was started in autonomous mode
+    uint32_t tack_clear_ms;         // system time when tack was cleared
     bool tack_assist;               // true if we should use some throttle to assist tack
     UseMotor motor_state;           // current state of motor output
 };

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -23,11 +23,6 @@
 #include "AP_WindVane_SITL.h"
 #include "AP_WindVane_NMEA.h"
 
-#define WINDVANE_DEFAULT_PIN 15                     // default wind vane sensor analog pin
-#define WINDSPEED_DEFAULT_SPEED_PIN 14              // default pin for reading speed from ModernDevice rev p wind sensor
-#define WINDSPEED_DEFAULT_TEMP_PIN 13               // default pin for reading temperature from ModernDevice rev p wind sensor
-#define WINDSPEED_DEFAULT_VOLT_OFFSET 1.346         // default voltage offset between speed and temp pins from ModernDevice rev p wind sensor
-
 const AP_Param::GroupInfo AP_WindVane::var_info[] = {
 
     // @Param: TYPE

--- a/libraries/AP_WindVane/AP_WindVane.h
+++ b/libraries/AP_WindVane/AP_WindVane.h
@@ -18,6 +18,12 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
+#define WINDVANE_DEFAULT_PIN 15                     // default wind vane sensor analog pin
+#define WINDSPEED_DEFAULT_SPEED_PIN 14              // default pin for reading speed from ModernDevice rev p wind sensor
+#define WINDSPEED_DEFAULT_TEMP_PIN 13               // default pin for reading temperature from ModernDevice rev p wind sensor
+#define WINDSPEED_DEFAULT_VOLT_OFFSET 1.346f        // default voltage offset between speed and temp pins from ModernDevice rev p wind sensor
+#define TACK_FILT_CUTOFF 0.1f                       // cutoff frequency in Hz used in low pass filter to determine the current tack
+
 class AP_WindVane_Backend;
 
 class AP_WindVane
@@ -66,6 +72,15 @@ public:
     // Return true wind speed
     float get_true_wind_speed() const { return _speed_true; }
 
+    // enum defining current tack
+    enum Sailboat_Tack {
+        TACK_PORT,
+        TACK_STARBOARD
+    };
+
+    // return the current tack
+    Sailboat_Tack get_current_tack() const { return _current_tack; }
+
     // record home heading for use as wind direction if no sensor is fitted
     void record_home_heading() { _home_heading = AP::ahrs().yaw; }
 
@@ -111,12 +126,15 @@ private:
     void update_true_wind_speed_and_direction();
 
     // wind direction variables
-    float _direction_apparent_ef;                   // wind's apparent direction in radians (0 = ahead of vehicle)
+    float _direction_apparent_ef;                   // wind's apparent direction in radians (0 = ahead of vehicle) in earth frame
     float _direction_true;                          // wind's true direction in radians (0 = North)
 
     // wind speed variables
     float _speed_apparent;                          // wind's apparent speed in m/s
     float _speed_true;                              // wind's true estimated speed in m/s
+
+    // current tack
+    Sailboat_Tack _current_tack;
 
     // heading in radians recorded when vehicle was armed
     float _home_heading;

--- a/libraries/AP_WindVane/AP_WindVane_Backend.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Backend.cpp
@@ -44,13 +44,14 @@ void AP_WindVane_Backend::direction_update_frontend(float apparent_angle_ef)
         // https://en.wikipedia.org/wiki/Mean_of_circular_quantities
         const float filtered_sin = _dir_sin_filt.apply(sinf(apparent_angle_ef), 0.05f);
         const float filtered_cos = _dir_cos_filt.apply(cosf(apparent_angle_ef), 0.05f);
-        _frontend._direction_apparent_ef = atan2f(filtered_sin, filtered_cos);
+        _frontend._direction_apparent_ef = wrap_PI(atan2f(filtered_sin, filtered_cos));
     } else {
-        _frontend._direction_apparent_ef = apparent_angle_ef;
+        _frontend._direction_apparent_ef = wrap_PI(apparent_angle_ef);
     }
 
-    // make sure between -pi and pi
-    _frontend._direction_apparent_ef = wrap_PI(_frontend._direction_apparent_ef);
+    // apply low pass filter for current tack, this is at a hard coded cutoff frequency
+    const float tack_direction_apparent = _tack_filt.apply(wrap_PI(apparent_angle_ef - AP::ahrs().yaw), 0.05f);
+    _frontend._current_tack = is_negative(tack_direction_apparent) ? _frontend.Sailboat_Tack::TACK_PORT : _frontend.Sailboat_Tack::TACK_STARBOARD;
 }
 
 // calibrate WindVane

--- a/libraries/AP_WindVane/AP_WindVane_Backend.h
+++ b/libraries/AP_WindVane/AP_WindVane_Backend.h
@@ -49,4 +49,5 @@ private:
     LowPassFilterFloat _dir_sin_filt = LowPassFilterFloat(2.0f);
     LowPassFilterFloat _dir_cos_filt = LowPassFilterFloat(2.0f);
     LowPassFilterFloat _speed_filt = LowPassFilterFloat(2.0f);
+    LowPassFilterFloat _tack_filt = LowPassFilterFloat(TACK_FILT_CUTOFF);
 };


### PR DESCRIPTION
This is some sailboat tacking improvements broken out from https://github.com/ArduPilot/ardupilot/pull/11423

- Sailboats only use pivot turn rate for tacking, previously it was used all the time upwind for some reason

- Sailboats constantly (previously only in auto modes) monitor the tack they are on using a low pass filter on the apparent wind angle, the low pass filter is a 'upgrade' from the dead-zone used in the previous PR. This helps especially when switching to auto, the sailboat will now carry on with its current tack rather than sometimes doing a 180.

- tacks can now also timeout in acro mode

- must have some gap between tacks, currently hard coded to 5 seconds

- the no-go zone is padded by a hard-coded 10 deg, in this region the boat will head directly for the destination but not switch back to L1 controller, this saves lost of switching back and forth between controllers, especially when getting close to up-wind waypoints.

- tacking logic is now use for all tacks, previously the tacking logic was only used when a tack was requested. Tacks due to waypoint navigation for example were just done like a standard rover. Now tacking logic is used on all tacks so we can benefit from the motor assist and different turn rate.

Most of this has been tested on the water, although there are some changes since then, all tested in SITL. 

will probably need a re-base on https://github.com/ArduPilot/ardupilot/pull/12236
