### PR TITLE
Rover: sailboat relax heel controller when not in use

### DIFF
--- a/APMrover2/mode_hold.cpp
+++ b/APMrover2/mode_hold.cpp
@@ -10,8 +10,9 @@ void ModeHold::update()
         rover.balancebot_pitch_control(throttle);
     }
 
-    // relax mainsail
+    // relax mainsail and controller
     g2.motors.set_mainsail(100.0f);
+    g2.attitude_control.get_sailboat_heel_pid().reset_I();
 
     // hold position - stop motors and center steering
     g2.motors.set_throttle(throttle);

--- a/APMrover2/mode_manual.cpp
+++ b/APMrover2/mode_manual.cpp
@@ -18,10 +18,11 @@ void ModeManual::update()
         rover.balancebot_pitch_control(desired_throttle);
     }
 
-    // set sailboat mainsail
+    // set sailboat mainsail and relax controller
     float desired_mainsail;
     g2.sailboat.get_pilot_desired_mainsail(desired_mainsail);
     g2.motors.set_mainsail(desired_mainsail);
+    g2.attitude_control.get_sailboat_heel_pid().reset_I();
 
     // copy RC scaled inputs to outputs
     g2.motors.set_throttle(desired_throttle);

--- a/APMrover2/sailboat.cpp
+++ b/APMrover2/sailboat.cpp
@@ -195,6 +195,7 @@ void Sailboat::get_throttle_and_mainsail_out(float desired_speed, float &throttl
     // if we are motoring or attempting to reverse relax the sail
     if (motor_state == UseMotor::USE_MOTOR_ALWAYS || !is_positive(desired_speed)) {
         mainsail_out = 100.0f;
+        rover.g2.attitude_control.get_sailboat_heel_pid().reset_I();
     } else {
         // + is wind over starboard side, - is wind over port side, but as the sails are sheeted the same on each side it makes no difference so take abs
         float wind_dir_apparent = fabsf(rover.g2.windvane.get_apparent_wind_direction_rad());


### PR DESCRIPTION
I found this small change forgotten in https://github.com/ArduPilot/ardupilot/pull/11034

It simply resets the I term of the sailboat heel controller when it is not in use in manual mode, hold mode or when using the motor