### PR TITLE
Copter: compassmot and motor_test set set_soft_armed

### DIFF
--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -125,6 +125,7 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
     init_rc_out();
     enable_motor_output();
     motors->armed(true);
+    hal.util->set_soft_armed(true);
 
     // initialise run time
     last_run_time = millis();
@@ -230,6 +231,7 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
     // stop motors
     motors->output_min();
     motors->armed(false);
+    hal.util->set_soft_armed(false);
 
     // set and save motor compensation
     if (updated) {

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -41,6 +41,7 @@ void Copter::motor_test_output()
                 motor_test_start_ms = now;
                 if (!motors->armed()) {
                     motors->armed(true);
+                    hal.util->set_soft_armed(true);
                 }
             }
             return;
@@ -152,6 +153,7 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
                 init_rc_out();
                 enable_motor_output();
                 motors->armed(true);
+                hal.util->set_soft_armed(true);
             }
 
             // disable throttle and gps failsafe
@@ -197,6 +199,7 @@ void Copter::motor_test_stop()
 
     // disarm motors
     motors->armed(false);
+    hal.util->set_soft_armed(false);
 
     // reset timeout
     motor_test_start_ms = 0;


### PR DESCRIPTION
This PR resolves an issue in which the [ToshibaCAN ESCs](http://ardupilot.org/copter/docs/common-toshiba-can-escs.html) do not spin during the motor test.

The underlying cause of the problem is that the [ToshibaCAN ESC driver uses the AP_HAL::Util::soft_armed state to determine whether the motors should be enabled](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp#L404) but Copter's motor test (and also compassmot) features never set the soft_armed state to true (they only set the AP_Motor's armed state to true).

The solution in this PR is to set the AP_HAL::Util::set_soft_armed() state at the same time AP_Motors::armed() is set.

To provide additional background, due to historic reasons Copter maintains it's armed state in two places:

- [AP_Motor's library's armed() flag](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Motors/AP_Motors_Class.h#L74)
- [AP_HAL::Util's soft_armed() flag](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL/Util.h#L14)

Copter mostly relies on the AP_Motor's armed/state to determine if it is armed or not (there are a few exceptions to this including in [ToyMode's trim_update() function](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/toy_mode.cpp#L696)).

Most of the time the vehicle is armed using AP_Arming_Copter::arm() or AP_Arming_Copter::disarm() functions which update both the AP_Motors and AP_HAL state.  We apparently do not use these two functions in the motor-test, compassmot and esc calibration functions probably because we don't want to risk other features (like saving AutoTune parameters, updating compass offsets, etc) to trigger.  Instead these three functions directly arm/disarm the motors.

Longer-term we should probably remove the AP_Motor's armed state and use only the AP_HAL::Util::soft_armed state.
