### PR TITLE
Sub: default RNGFNDR1_TYPE to mavlink

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -703,6 +703,7 @@ void Sub::load_parameters()
     AP_Param::set_default_by_name("MNT_JSTICK_SPD", 100);
     AP_Param::set_by_name("MNT_RC_IN_PAN", 7);
     AP_Param::set_by_name("MNT_RC_IN_TILT", 8);
+    AP_Param::set_default_by_name("RNGFND1_TYPE", RangeFinder::RangeFinder_TYPE_MAVLink);
 }
 
 void Sub::convert_old_parameters()


### PR DESCRIPTION
Fix #9821