### PR TITLE
Implement and use txspace() on GCS_MAVLink objects

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -586,11 +586,11 @@ MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlin
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
 }
 
-bool GCS_MAVLINK_Rover::set_home_to_current_location(bool lock) {
-    return rover.set_home_to_current_location(lock);
+bool GCS_MAVLINK_Rover::set_home_to_current_location(bool _lock) {
+    return rover.set_home_to_current_location(_lock);
 }
-bool GCS_MAVLINK_Rover::set_home(const Location& loc, bool lock) {
-    return rover.set_home(loc, lock);
+bool GCS_MAVLINK_Rover::set_home(const Location& loc, bool _lock) {
+    return rover.set_home(loc, _lock);
 }
 
 MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_int_t &packet)

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -458,10 +458,10 @@ MAV_RESULT GCS_MAVLINK_Tracker::handle_command_long_packet(const mavlink_command
     }
 }
 
-bool GCS_MAVLINK_Tracker::set_home_to_current_location(bool lock) {
+bool GCS_MAVLINK_Tracker::set_home_to_current_location(bool _lock) {
     return tracker.set_home(AP::gps().location());
 }
-bool GCS_MAVLINK_Tracker::set_home(const Location& loc, bool lock) {
+bool GCS_MAVLINK_Tracker::set_home(const Location& loc, bool _lock) {
     return tracker.set_home(loc);
 }
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -570,11 +570,11 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_preflight_reboot(const mavlink_command_lon
     return GCS_MAVLINK::handle_preflight_reboot(packet);
 }
 
-bool GCS_MAVLINK_Copter::set_home_to_current_location(bool lock) {
-    return copter.set_home_to_current_location(lock);
+bool GCS_MAVLINK_Copter::set_home_to_current_location(bool _lock) {
+    return copter.set_home_to_current_location(_lock);
 }
-bool GCS_MAVLINK_Copter::set_home(const Location& loc, bool lock) {
-    return copter.set_home(loc, lock);
+bool GCS_MAVLINK_Copter::set_home(const Location& loc, bool _lock) {
+    return copter.set_home(loc, _lock);
 }
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_packet(const mavlink_command_int_t &packet)

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -709,22 +709,22 @@ void GCS_MAVLINK_Plane::packetReceived(const mavlink_status_t &status,
 }
 
 
-bool GCS_MAVLINK_Plane::set_home_to_current_location(bool lock)
+bool GCS_MAVLINK_Plane::set_home_to_current_location(bool _lock)
 {
     if (!plane.set_home_persistently(AP::gps().location())) {
         return false;
     }
-    if (lock) {
+    if (_lock) {
         AP::ahrs().lock_home();
     }
     return true;
 }
-bool GCS_MAVLINK_Plane::set_home(const Location& loc, bool lock)
+bool GCS_MAVLINK_Plane::set_home(const Location& loc, bool _lock)
 {
     if (!AP::ahrs().set_home(loc)) {
         return false;
     }
-    if (lock) {
+    if (_lock) {
         AP::ahrs().lock_home();
     }
     return true;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -446,11 +446,11 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi(const Location &roi_loc)
     return MAV_RESULT_ACCEPTED;
 }
 
-bool GCS_MAVLINK_Sub::set_home_to_current_location(bool lock) {
-    return sub.set_home_to_current_location(lock);
+bool GCS_MAVLINK_Sub::set_home_to_current_location(bool _lock) {
+    return sub.set_home_to_current_location(_lock);
 }
-bool GCS_MAVLINK_Sub::set_home(const Location& loc, bool lock) {
-    return sub.set_home(loc, lock);
+bool GCS_MAVLINK_Sub::set_home(const Location& loc, bool _lock) {
+    return sub.set_home(loc, _lock);
 }
 
 

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -60,7 +60,7 @@ void GCS::send_to_active_channels(uint32_t msgid, const char *pkt)
         if (!c.is_active()) {
             continue;
         }
-        if (entry->max_msg_len + c.packet_overhead() > c.get_uart()->txspace()) {
+        if (entry->max_msg_len + c.packet_overhead() > c.txspace()) {
             // no room on this channel
             continue;
         }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2329,7 +2329,7 @@ bool GCS_MAVLINK::get_ap_message_interval(ap_message id, uint16_t &interval_ms) 
 
 MAV_RESULT GCS_MAVLINK::handle_command_get_message_interval(const mavlink_command_long_t &packet)
 {
-    if (comm_get_txspace(chan) < PAYLOAD_SIZE(chan, MESSAGE_INTERVAL) + PAYLOAD_SIZE(chan, COMMAND_ACK)) {
+    if (txspace() < PAYLOAD_SIZE(chan, MESSAGE_INTERVAL) + PAYLOAD_SIZE(chan, COMMAND_ACK)) {
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
 

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -43,8 +43,8 @@ protected:
     MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
     MAV_STATE system_status() const override { return MAV_STATE_CALIBRATING; }
 
-    bool set_home_to_current_location(bool lock) override { return false; }
-    bool set_home(const Location& loc, bool lock) override { return false; }
+    bool set_home_to_current_location(bool _lock) override { return false; }
+    bool set_home(const Location& loc, bool _lock) override { return false; }
 
     void send_nav_controller_output() const override {};
     void send_pid_tuning() override {};

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -49,8 +49,8 @@ GCS_MAVLINK::queued_param_send()
     if (bytes_allowed < size_for_one_param_value_msg) {
         bytes_allowed = size_for_one_param_value_msg;
     }
-    if (bytes_allowed > comm_get_txspace(chan)) {
-        bytes_allowed = comm_get_txspace(chan);
+    if (bytes_allowed > txspace()) {
+        bytes_allowed = txspace();
     }
     uint32_t count = bytes_allowed / size_for_one_param_value_msg;
 

--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -43,14 +43,24 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
     bool exclusive = (packet.flags & SERIAL_CONTROL_FLAG_EXCLUSIVE) != 0;
 
     switch (packet.device) {
-    case SERIAL_CONTROL_DEV_TELEM1:
-        stream = port = hal.uartC;
-        lock_channel(MAVLINK_COMM_1, exclusive);
+    case SERIAL_CONTROL_DEV_TELEM1: {
+        GCS_MAVLINK *link = gcs().chan(1);
+        if (link == nullptr) {
+            break;
+        }
+        stream = port = link->get_uart();
+        link->lock(exclusive);
         break;
-    case SERIAL_CONTROL_DEV_TELEM2:
-        stream = port = hal.uartD;
-        lock_channel(MAVLINK_COMM_2, exclusive);
+    }
+    case SERIAL_CONTROL_DEV_TELEM2: {
+        GCS_MAVLINK *link = gcs().chan(2);
+        if (link == nullptr) {
+            break;
+        }
+        stream = port = link->get_uart();
+        link->lock(exclusive);
         break;
+    }
     case SERIAL_CONTROL_DEV_GPS1:
         stream = port = hal.uartB;
         AP::gps().lock_port(0, exclusive);


### PR DESCRIPTION
Solves a pair of bugs:

 - checking of space in send_to_active_channels was incorrect - did not
take into account locked status of the channel

 - corrected return value on comm_get_txspace - took a uint32_t, cast it
to int16_t, checked it for zero, then cast it to uint16_t on return.
That's just... odd.

I do want to kill `comm_get_txspace` - that's a little harder.
