### PR TITLE
AP_Common: Include altitude in the init check for a location

### DIFF
--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -112,7 +112,7 @@ public:
      */
     float line_path_proportion(const Location &point1, const Location &point2) const;
 
-    bool initialised() const { return (lat !=0 || lng != 0); }
+    bool initialised() const { return (lat !=0 || lng != 0 || alt != 0); }
 
 private:
     static AP_Terrain *_terrain;


### PR DESCRIPTION
There are location objects which are used for takeoffs which have a lat/lng of 0,0 but do provide an altitude which we want to do frame conversions on. This currently results in a panic in SITL. Vehicles aren't suffering from this as they aren't using the method to do the conversion, and are instead directly doing it.