### PR TITLE
AP_GPS: use jitter correction on GPS_INPUT data

### DIFF
--- a/libraries/AP_GPS/AP_GPS_MAV.h
+++ b/libraries/AP_GPS/AP_GPS_MAV.h
@@ -39,4 +39,6 @@ public:
 
 private:
     bool _new_data;
+    uint32_t first_week;
+    JitterCorrection jitter{2000};
 };


### PR DESCRIPTION
this allows for more accurate timing when using GPS_INPUT for indoor
positioning systems