### PR TITLE
Tradheli: Aligns Dual heli Swashplate 1 with Single heli Swashplate

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1398,15 +1398,15 @@ void Copter::convert_tradheli_parameters(void)
     } else if (g2.frame_class.get() == AP_Motors::MOTOR_FRAME_HELI_DUAL) {
         // dual heli conversion info
         const AP_Param::ConversionInfo dualheli_conversion_info[] = {
-            { Parameters::k_param_motors, 1, AP_PARAM_INT16, "H_SW1_H3_SV1_POS" },
-            { Parameters::k_param_motors, 2, AP_PARAM_INT16, "H_SW1_H3_SV2_POS" },
-            { Parameters::k_param_motors, 3, AP_PARAM_INT16, "H_SW1_H3_SV3_POS" },
+            { Parameters::k_param_motors, 1, AP_PARAM_INT16, "H_SW_H3_SV1_POS" },
+            { Parameters::k_param_motors, 2, AP_PARAM_INT16, "H_SW_H3_SV2_POS" },
+            { Parameters::k_param_motors, 3, AP_PARAM_INT16, "H_SW_H3_SV3_POS" },
             { Parameters::k_param_motors, 4, AP_PARAM_INT16, "H_SW2_H3_SV1_POS" },
             { Parameters::k_param_motors, 5, AP_PARAM_INT16, "H_SW2_H3_SV2_POS" },
             { Parameters::k_param_motors, 6, AP_PARAM_INT16, "H_SW2_H3_SV3_POS" },
-            { Parameters::k_param_motors, 7, AP_PARAM_INT16, "H_SW1_H3_PHANG" },
+            { Parameters::k_param_motors, 7, AP_PARAM_INT16, "H_SW_H3_PHANG" },
             { Parameters::k_param_motors, 8, AP_PARAM_INT16, "H_SW2_H3_PHANG" },
-            { Parameters::k_param_motors, 19, AP_PARAM_INT8, "H_SW1_COL_DIR" },
+            { Parameters::k_param_motors, 19, AP_PARAM_INT8, "H_SW_COL_DIR" },
             { Parameters::k_param_motors, 19, AP_PARAM_INT8, "H_SW2_COL_DIR" },
         };
 
@@ -1435,13 +1435,13 @@ void Copter::convert_tradheli_parameters(void)
             // find the new variable in the variable structures
             enum ap_var_type ptype;
             AP_Param *ap2;
-            ap2 = AP_Param::find("H_SW1_TYPE", &ptype);
+            ap2 = AP_Param::find("H_SW_TYPE", &ptype);
             // make sure the pointer is valid
             if (ap2 != nullptr) {
                 // see if we can load it from EEPROM
                 if (!ap2->configured_in_storage()) {
                     // the new parameter is not in storage so set generic swash
-                    AP_Param::set_and_save_by_name("H_SW1_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3);            
+                    AP_Param::set_and_save_by_name("H_SW_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3);            
                 }
             }
         }

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -86,12 +86,112 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
 
     // Indice 19 was used by COL_CTRL_DIR and should not be used
 
-    // @Group: SW1_H3_
-    // @Path: AP_MotorsHeli_Swash.cpp
-    AP_SUBGROUPINFO(_swashplate1, "SW1_", 20, AP_MotorsHeli_Dual, AP_MotorsHeli_Swash),
+    // @Param: SW_TYPE
+    // @DisplayName: Swashplate 1 Type
+    // @Description: H3 is generic, three-servo only. H3_120/H3_140 plates have Motor1 left side, Motor2 right side, Motor3 elevator in rear. HR3_120/HR3_140 have Motor1 right side, Motor2 left side, Motor3 elevator in front - use H3_120/H3_140 and reverse servo and collective directions as necessary. For all H3_90 swashplates use H4_90 and don't use servo output for the missing servo. For H4-90 Motors1&2 are left/right respectively, Motors3&4 are rear/front respectively. For H4-45 Motors1&2 are LF/RF, Motors3&4 are LR/RR 
+    // @Values: 0:H3 Generic,1:H1 non-CPPM,2:H3_140,3:H3_120,4:H4_90,5:H4_45
+    // @User: Standard
 
-    // @Group: SW2_H3_
-    // @Path: AP_MotorsHeli_Swash.cpp
+    // @Param: SW_COL_DIR
+    // @DisplayName: Swashplate 1 Collective Control Direction
+    // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
+    // @Values: 0:Normal,1:Reversed
+    // @User: Standard
+
+    // @Param: SW_LIN_SVO
+    // @DisplayName: Linearize Swashplate 1 Servo Mechanical Throw
+    // @Description: This linearizes the swashplate 1 servo's mechanical output to account for nonlinear output due to arm rotation.  This requires a specific setup procedure to work properly.  The servo arm must be centered on the mechanical throw at the servo trim position and the servo trim position kept as close to 1500 as possible. Leveling the swashplate can only be done through the pitch links.  See the ardupilot wiki for more details on setup.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+
+    // @Param: SW_H3_ENABLE
+    // @DisplayName: Swashplate 1 Enable Generic H3 Settings
+    // @Description: Automatically set when H3 generic swash type is selected for swashplate 1. Do not set manually.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: SW_H3_SV1_POS
+    // @DisplayName: Swashplate 1 Servo 1 Position
+    // @Description: Azimuth position on swashplate for servo 1 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+
+    // @Param: SW_H3_SV2_POS
+    // @DisplayName: Swashplate 1 Servo 2 Position
+    // @Description: Azimuth position on swashplate 1 for servo 2 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+
+    // @Param: SW_H3_SV3_POS
+    // @DisplayName: Swashplate 1 Servo 3 Position
+    // @Description: Azimuth position on swashplate 1 for servo 3 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+    
+    // @Param: SW_H3_PHANG
+    // @DisplayName: Swashplate 1 Phase Angle Compensation
+    // @Description: Only for H3 swashplate.  If pitching the swash forward induces a roll, this can be correct the problem
+    // @Range: -30 30
+    // @Units: deg
+    // @User: Advanced
+    // @Increment: 1
+    AP_SUBGROUPINFO(_swashplate1, "SW_", 20, AP_MotorsHeli_Dual, AP_MotorsHeli_Swash),
+
+    // @Param: SW2_TYPE
+    // @DisplayName: Swashplate 2 Type
+    // @Description: H3 is generic, three-servo only. H3_120/H3_140 plates have Motor1 left side, Motor2 right side, Motor3 elevator in rear. HR3_120/HR3_140 have Motor1 right side, Motor2 left side, Motor3 elevator in front - use H3_120/H3_140 and reverse servo and collective directions as necessary. For all H3_90 swashplates use H4_90 and don't use servo output for the missing servo. For H4-90 Motors1&2 are left/right respectively, Motors3&4 are rear/front respectively. For H4-45 Motors1&2 are LF/RF, Motors3&4 are LR/RR 
+    // @Values: 0:H3 Generic,1:H1 non-CPPM,2:H3_140,3:H3_120,4:H4_90,5:H4_45
+    // @User: Standard
+
+    // @Param: SW2_COL_DIR
+    // @DisplayName: Swashplate 2 Collective Control Direction
+    // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
+    // @Values: 0:Normal,1:Reversed
+    // @User: Standard
+
+    // @Param: SW2_LIN_SVO
+    // @DisplayName: Linearize Swashplate 2 Servo Mechanical Throw
+    // @Description: This linearizes the swashplate 2 servo's mechanical output to account for nonlinear output due to arm rotation.  This requires a specific setup procedure to work properly.  The servo arm must be centered on the mechanical throw at the servo trim position and the servo trim position kept as close to 1500 as possible. Leveling the swashplate can only be done through the pitch links.  See the ardupilot wiki for more details on setup.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+
+    // @Param: SW2_H3_ENABLE
+    // @DisplayName: Swashplate 2 Enable Generic H3 Settings
+    // @Description: Automatically set when H3 generic swash type is selected for swashplate 2. Do not set manually.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: SW2_H3_SV1_POS
+    // @DisplayName: Swashplate 2 Servo 1 Position
+    // @Description: Azimuth position on swashplate for servo 1 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+
+    // @Param: SW2_H3_SV2_POS
+    // @DisplayName: Swashplate 2 Servo 2 Position
+    // @Description: Azimuth position on swashplate 2 for servo 2 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+
+    // @Param: SW2_H3_SV3_POS
+    // @DisplayName: Swashplate 2 Servo 3 Position
+    // @Description: Azimuth position on swashplate 2 for servo 3 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+    
+    // @Param: SW2_H3_PHANG
+    // @DisplayName: Swashplate 2 Phase Angle Compensation
+    // @Description: Only for H3 swashplate.  If pitching the swash forward induces a roll, this can be correct the problem
+    // @Range: -30 30
+    // @Units: deg
+    // @User: Advanced
+    // @Increment: 1
     AP_SUBGROUPINFO(_swashplate2, "SW2_", 21, AP_MotorsHeli_Dual, AP_MotorsHeli_Swash),
 
     AP_GROUPEND

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -81,8 +81,58 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
 
     // Indices 16-19 were used by RSC_PWM_MIN, RSC_PWM_MAX, RSC_PWM_REV, and COL_CTRL_DIR and should not be used
 
-    // @Group: H3_SW_
-    // @Path: AP_MotorsHeli_Swash.cpp
+    // @Param: SW_TYPE
+    // @DisplayName: Swashplate 1 Type
+    // @Description: H3 is generic, three-servo only. H3_120/H3_140 plates have Motor1 left side, Motor2 right side, Motor3 elevator in rear. HR3_120/HR3_140 have Motor1 right side, Motor2 left side, Motor3 elevator in front - use H3_120/H3_140 and reverse servo and collective directions as necessary. For all H3_90 swashplates use H4_90 and don't use servo output for the missing servo. For H4-90 Motors1&2 are left/right respectively, Motors3&4 are rear/front respectively. For H4-45 Motors1&2 are LF/RF, Motors3&4 are LR/RR 
+    // @Values: 0:H3 Generic,1:H1 non-CPPM,2:H3_140,3:H3_120,4:H4_90,5:H4_45
+    // @User: Standard
+
+    // @Param: SW_COL_DIR
+    // @DisplayName: Swashplate 1 Collective Control Direction
+    // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
+    // @Values: 0:Normal,1:Reversed
+    // @User: Standard
+
+    // @Param: SW_LIN_SVO
+    // @DisplayName: Linearize Swashplate 1 Servo Mechanical Throw
+    // @Description: This linearizes the swashplate 1 servo's mechanical output to account for nonlinear output due to arm rotation.  This requires a specific setup procedure to work properly.  The servo arm must be centered on the mechanical throw at the servo trim position and the servo trim position kept as close to 1500 as possible. Leveling the swashplate can only be done through the pitch links.  See the ardupilot wiki for more details on setup.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+
+    // @Param: SW_H3_ENABLE
+    // @DisplayName: Swashplate 1 Enable Generic H3 Settings
+    // @Description: Automatically set when H3 generic swash type is selected for swashplate 1. Do not set manually.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: SW_H3_SV1_POS
+    // @DisplayName: Swashplate 1 Servo 1 Position
+    // @Description: Azimuth position on swashplate for servo 1 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+
+    // @Param: SW_H3_SV2_POS
+    // @DisplayName: Swashplate 1 Servo 2 Position
+    // @Description: Azimuth position on swashplate 1 for servo 2 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+
+    // @Param: SW_H3_SV3_POS
+    // @DisplayName: Swashplate 1 Servo 3 Position
+    // @Description: Azimuth position on swashplate 1 for servo 3 with the front of the heli being 0 deg
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Advanced
+    
+    // @Param: SW_H3_PHANG
+    // @DisplayName: Swashplate 1 Phase Angle Compensation
+    // @Description: Only for H3 swashplate.  If pitching the swash forward induces a roll, this can be correct the problem
+    // @Range: -30 30
+    // @Units: deg
+    // @User: Advanced
+    // @Increment: 1
     AP_SUBGROUPINFO(_swashplate, "SW_", 20, AP_MotorsHeli_Single, AP_MotorsHeli_Swash),
 
     AP_GROUPEND

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -30,28 +30,28 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     AP_GROUPINFO("TYPE", 1, AP_MotorsHeli_Swash, _swashplate_type, SWASHPLATE_TYPE_H3_120),
 
     // @Param: COL_DIR
-    // @DisplayName: Collective Control Direction
+    // @DisplayName: Swashplate Collective Control Direction
     // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
     // @Values: 0:Normal,1:Reversed
     // @User: Standard
     AP_GROUPINFO("COL_DIR", 2, AP_MotorsHeli_Swash, _swash_coll_dir, COLLECTIVE_DIRECTION_NORMAL),
 
     // @Param: LIN_SVO
-    // @DisplayName: Linearize swashplate servo mechanical throw
+    // @DisplayName: Linearize Swashplate Servo Mechanical Throw
     // @Description: This linearizes the swashplate servo's mechanical output to account for nonlinear output due to arm rotation.  This requires a specific setup procedure to work properly.  The servo arm must be centered on the mechanical throw at the servo trim position and the servo trim position kept as close to 1500 as possible. Leveling the swashplate can only be done through the pitch links.  See the ardupilot wiki for more details on setup.
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
     AP_GROUPINFO("LIN_SVO", 3, AP_MotorsHeli_Swash, _linear_swash_servo, 0),
 
     // @Param: H3_ENABLE
-    // @DisplayName: Enable generic H3 swashplate settings
+    // @DisplayName: Enable Generic H3 Swashplate Settings
     // @Description: Automatically set when H3 generic swash type is selected. Do not set manually.
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
     AP_GROUPINFO_FLAGS("H3_ENABLE", 4, AP_MotorsHeli_Swash, enable, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: H3_SV1_POS
-    // @DisplayName: servo 1 position
+    // @DisplayName: Swashplate Servo 1 Position
     // @Description: Azimuth position on swashplate for servo 1 with the front of the heli being 0 deg
     // @Range: -180 180
     // @Units: deg
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     AP_GROUPINFO("H3_SV1_POS", 5, AP_MotorsHeli_Swash, _servo1_pos, -60),
 
     // @Param: H3_SV2_POS
-    // @DisplayName: servo 2 position
+    // @DisplayName: Swashplate Servo 2 Position
     // @Description: Azimuth position on swashplate for servo 2 with the front of the heli being 0 deg
     // @Range: -180 180
     // @Units: deg
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     AP_GROUPINFO("H3_SV2_POS", 6, AP_MotorsHeli_Swash, _servo2_pos, 60),
 
     // @Param: H3_SV3_POS
-    // @DisplayName: servo 3 position
+    // @DisplayName: Swashplate Servo 3 Position
     // @Description: Azimuth position on swashplate for servo 3 with the front of the heli being 0 deg
     // @Range: -180 180
     // @Units: deg


### PR DESCRIPTION
This PR makes the names and wiki display information the same between Single Heli Swashplate and Dual Heli Swashplate 1.   This follows the standard practice used for other libraries where multiple instances of the library are needed.  

@rmackay9 I have one question on how the display of the information in the wiki works.  I would like to have a different display name for the H_SW parameters based on the heli frame.  For instance I would like it to read H_SW_TYPE to read "Swashplate Type" for single heli and "Swashplate 1 Type" for dual heli for the information seen in ground control station.  I know how to change this in the code so it will do that but what will happen to the wiki listing of the parameters?  Or will I get an error on one of the PR checks?  You will see, I put a separate listing of the display information for the 2nd swashplate for dual heli.

I did a functional check on the upgrade conversion and it all checks out.