### PR TITLE
Revert "AP_HAL_SITL: set initial PWM values to a flag value"

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -539,12 +539,9 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
 
 void SITL_State::init(int argc, char * const argv[])
 {
-    for (uint8_t i=0; i<ARRAY_SIZE(pwm_input); i++) {
-        // this is simply a magic flag value.  If you ever see this
-        // being used there is a bug as the values in this array
-        // should be overwritten before they are considered valid.
-        pwm_input[i] = 65530;
-    }
+    pwm_input[0] = pwm_input[1] = pwm_input[3] = 1500;
+    pwm_input[4] = pwm_input[7] = 1800;
+    pwm_input[2] = pwm_input[5] = pwm_input[6] = 1000;
 
     _scheduler = Scheduler::from(hal.scheduler);
     _parse_command_line(argc, argv);


### PR DESCRIPTION
This reverts commit 1735563bb790ff70b346b1bf5c5342afb34f61c2.

This commit broke RC input on high channels with sim_vehicle.py, plane
gets RC failsafe immediately
Reverts #12278 
Did anyone actually test that PR?
