### PR TITLE
Rover: Fix  bug in  failsafe initiation while in HOLD mode

### DIFF
--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -68,7 +68,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
         failsafe.bits != 0 &&
         millis() - failsafe.start_time > g.fs_timeout * 1000 &&
         control_mode != &mode_rtl &&
-        control_mode != &mode_hold) {
+        control_mode != &mode_smartrtl && (control_mode != &mode_hold || (enum frame_class)g2.frame_class.get() == FRAME_BOAT)  ) {
         failsafe.triggered = failsafe.bits;
         gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", (unsigned int)failsafe.triggered);
 


### PR DESCRIPTION
fixes a bug that prevents failsafes from being executed anytime Rover is in HOLD mode....particularly troublesome when HOLD comes at end of mission (its the default mission end) and FS happens in the middle of a lake! ask me how I know!

Pierre says this bug is intended behavior...I  disagree, but perhaps this should be limited to boat frames and not ground vehicles...discuss in DEVCALL

tested on vehicle....easily tested on bench