### PR TITLE
Global: Change the unit of barometric pressure from mbar to hPa.

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -84,7 +84,7 @@ known_units = {
              'mGauss'  : 'milligauss'            , # Gauss is not an SI unit, but 1 tesla = 10000 gauss so a simple replacement is not possible here
 # pressure
              'Pa'      : 'pascal'                ,
-             'mbar'    : 'millibar'              ,
+             'hPa'     : 'hectopascal'           ,
 # ratio
              '%'       : 'percent'               ,
              '%/s'     : 'percent per second'    ,

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -98,7 +98,7 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @Param: QNH_PRESSURE
     // @DisplayName: QNH pressure
     // @Description: This sets the QNH pressure in millibars to be used for pressure altitude in the altitude limit. A value of zero disables the altitude limit.
-    // @Units: mbar
+    // @Units: hPa
     // @User: Advanced
     AP_GROUPINFO("QNH_PRESSURE", 10, AP_AdvancedFailsafe, _qnh_pressure,    0),
 


### PR DESCRIPTION
I think the unit of pressure is internationally from mbar to hPa.
I think it's better to change to an international unit.

I also made a pull request to MAVLINK.
https://github.com/ArduPilot/mavlink/pull/107