### PR TITLE
Plane: Add TERMINATE_ACTION_DISARM (44) value for AFS_TERM_ACTION

### DIFF
--- a/ArduPlane/failsafe.cpp
+++ b/ArduPlane/failsafe.cpp
@@ -86,7 +86,8 @@ void Plane::failsafe_check(void)
 #if ADVANCED_FAILSAFE == ENABLED
         if (afs.should_crash_vehicle()) {
             afs.terminate_vehicle();
-            if (!afs.terminating_vehicle_via_landing()) {
+            // terminate via landing or disarm needs servo output to stay active
+            if ((!afs.terminating_vehicle_via_landing()) && (!afs.terminating_vehicle_via_disarm())) {
                 return;
             }
         }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -672,7 +672,8 @@ void Plane::set_servos(void)
 #if ADVANCED_FAILSAFE == ENABLED
     if (afs.should_crash_vehicle()) {
         afs.terminate_vehicle();
-        if (!afs.terminating_vehicle_via_landing()) {
+        // terminate via landing or disarm needs servo output to stay active
+        if ((!afs.terminating_vehicle_via_landing()) && (!afs.terminating_vehicle_via_disarm())) {
             return;
         }
     }

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -380,6 +380,7 @@ bool AP_AdvancedFailsafe::should_crash_vehicle(void)
     // _terminate may be set via parameters, or a mavlink command
     if (_terminate &&
         (_terminate_action == TERMINATE_ACTION_TERMINATE ||
+         _terminate_action == TERMINATE_ACTION_DISARM ||
          _terminate_action == TERMINATE_ACTION_LAND)) {
         // we are terminating
         return true;
@@ -409,7 +410,8 @@ bool AP_AdvancedFailsafe::gcs_terminate(bool should_terminate, const char *reaso
             gcs().send_text(MAV_SEVERITY_INFO, "Aborting termination due to %s", reason);
         }
         return true;
-    } else if (should_terminate && _terminate_action != TERMINATE_ACTION_TERMINATE) {
+    } else if (should_terminate && _terminate_action != TERMINATE_ACTION_TERMINATE &&
+               _terminate_action != TERMINATE_ACTION_DISARM) {
         gcs().send_text(MAV_SEVERITY_INFO, "Unable to terminate, termination is not configured");
     }
     return false;

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -45,7 +45,8 @@ public:
 
     enum terminate_action {
         TERMINATE_ACTION_TERMINATE = 42,
-        TERMINATE_ACTION_LAND      = 43
+        TERMINATE_ACTION_LAND      = 43,
+        TERMINATE_ACTION_DISARM    = 44
     };
 
     // Constructor
@@ -83,6 +84,10 @@ public:
 
     bool terminating_vehicle_via_landing() const {
         return _terminate_action == TERMINATE_ACTION_LAND;
+    };
+
+    bool terminating_vehicle_via_disarm() const {
+        return _terminate_action == TERMINATE_ACTION_DISARM;
     };
 
 protected:


### PR DESCRIPTION
This adds an Advanced-Failsafe option for "soft" flight termination (for Plane), where the motor is disarmed and 'stabilized' mode is activated.  The option is selected by setting AFS_TERM_ACTION to 44, similar to the currently-supported values 42 (TERMINATE_ACTION_TERMINATE) and 43 (TERMINATE_ACTION_LAND).

My application is a small, lightweight foam airplane flying AUTO missions, and this provides a good way to prevent potential fly-aways (via geofence) -- without the hard-crash result of a standard termination.

I implemented something like this a while back using new parameter options (#3385), but doing it this way requires fewer code changes.