### PR TITLE
Make GPS_DISABLE prevent last_fix_time_ms updates

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -810,7 +810,8 @@ void AP_GPS::update_instance(uint8_t instance)
         // delta will only be correct after parsing two messages
         timing[instance].delta_time_ms = tnow - timing[instance].last_message_time_ms;
         timing[instance].last_message_time_ms = tnow;
-        if (state[instance].status >= GPS_OK_FIX_2D) {
+        // if GPS disabled for flight testing then don't update fix timing value
+        if (state[instance].status >= GPS_OK_FIX_2D && !_force_disable_gps) {
             timing[instance].last_fix_time_ms = tnow;
         }
 


### PR DESCRIPTION
While using the RC_OPTION "GPS Disable" (65) to test how the Advanced-Failsafe system responds to GPS issues, I found that it would not detect this type of simulated failure.  The issue is that it's using GPS 'last_fix_time_ms' to determine the GPS health, and the 'force_disable_gps' mode does not affect it; so this mod addresses that.