### PR TITLE
Plane: Geofence reduce state, speed up common paths

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -148,11 +148,11 @@ bool AP_Arming_Plane::arm_checks(AP_Arming::Method method)
 
 #if GEOFENCE_ENABLED == ENABLED
     if (plane.g.fence_autoenable == 3) {
-        if (!plane.geofence_set_enabled(true, AUTO_TOGGLED)) {
+        if (!plane.geofence_set_enabled(true)) {
             gcs().send_text(MAV_SEVERITY_WARNING, "Fence: cannot enable for arming");
             return false;
         } else if (!plane.geofence_prearm_check()) {
-            plane.geofence_set_enabled(false, AUTO_TOGGLED);
+            plane.geofence_set_enabled(false);
             return false;
         } else {
             gcs().send_text(MAV_SEVERITY_WARNING, "Fence: auto-enabled for arming");
@@ -222,7 +222,7 @@ bool AP_Arming_Plane::disarm(void)
 
 #if GEOFENCE_ENABLED == ENABLED
     if (plane.g.fence_autoenable == 3) {
-        plane.geofence_set_enabled(false, AUTO_TOGGLED);
+        plane.geofence_set_enabled(false);
     }
 #endif
     

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -899,12 +899,12 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
         }
         switch((uint16_t)packet.param1) {
         case 0:
-            if (! plane.geofence_set_enabled(false, GCS_TOGGLED)) {
+            if (! plane.geofence_set_enabled(false)) {
                 return MAV_RESULT_FAILED;
             }
             return MAV_RESULT_ACCEPTED;
         case 1:
-            if (! plane.geofence_set_enabled(true, GCS_TOGGLED)) {
+            if (! plane.geofence_set_enabled(true)) {
                 return MAV_RESULT_FAILED;
             }
             return MAV_RESULT_ACCEPTED;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -904,7 +904,7 @@ private:
     void geofence_load(void);
     bool geofence_present(void);
     void geofence_update_pwm_enabled_state();
-    bool geofence_set_enabled(bool enable, GeofenceEnableReason r);
+    bool geofence_set_enabled(bool enable);
     bool geofence_enabled(void);
     bool geofence_set_floor_enabled(bool floor_enable);
     bool geofence_check_minalt(void);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -898,8 +898,8 @@ private:
     void failsafe_short_off_event(mode_reason_t reason);
     void failsafe_long_off_event(mode_reason_t reason);
     void handle_battery_failsafe(const char* type_str, const int8_t action);
-    uint8_t max_fencepoints(void);
-    Vector2l get_fence_point_with_index(unsigned i);
+    uint8_t max_fencepoints(void) const;
+    Vector2l get_fence_point_with_index(uint8_t i) const;
     void set_fence_point_with_index(const Vector2l &point, unsigned i);
     void geofence_load(void);
     bool geofence_present(void);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -136,7 +136,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_FENCE_ENABLE:
 #if GEOFENCE_ENABLED == ENABLED
         if (cmd.p1 != 2) {
-            if (!geofence_set_enabled((bool) cmd.p1, AUTO_TOGGLED)) {
+            if (!geofence_set_enabled((bool) cmd.p1)) {
                 gcs().send_text(MAV_SEVERITY_WARNING, "Unable to set fence. Enabled state to %u", cmd.p1);
             } else {
                 gcs().send_text(MAV_SEVERITY_INFO, "Set fence enabled state to %u", cmd.p1);
@@ -385,7 +385,7 @@ void Plane::do_land(const AP_Mission::Mission_Command& cmd)
 
 #if GEOFENCE_ENABLED == ENABLED 
     if (g.fence_autoenable == 1) {
-        if (! geofence_set_enabled(false, AUTO_TOGGLED)) {
+        if (! geofence_set_enabled(false)) {
             gcs().send_text(MAV_SEVERITY_NOTICE, "Disable fence failed (autodisable)");
         } else {
             gcs().send_text(MAV_SEVERITY_NOTICE, "Fence disabled (autodisable)");

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -86,16 +86,6 @@ enum ChannelMixing {
     MIXING_DNDN_SWP = 8,
 };
 
-/*
- * The cause for the most recent fence enable
- */
-typedef enum GeofenceEnableReason {
-    NOT_ENABLED = 0,     //The fence is not enabled
-    PWM_TOGGLED,         //Fence enabled/disabled by PWM signal
-    AUTO_TOGGLED,        //Fence auto enabled/disabled at takeoff.
-    GCS_TOGGLED          //Fence enabled/disabled by the GCS via Mavlink
-} GeofenceEnableReason;
-
 // PID broadcast bitmask
 enum tuning_pid_bits {
     TUNING_BITS_ROLL  = (1 <<  0),

--- a/ArduPlane/geofence.cpp
+++ b/ArduPlane/geofence.cpp
@@ -207,14 +207,20 @@ bool Plane::geofence_set_enabled(bool enable)
  */
 bool Plane::geofence_enabled(void)
 {
+    if (g.fence_action == FENCE_ACTION_NONE) {
+        if (geofence_state != nullptr) {
+            geofence_state->fence_triggered = false;
+        }
+        return false;
+    }
+
     geofence_update_pwm_enabled_state();
 
     if (geofence_state == nullptr) {
         return false;
     }
 
-    if (g.fence_action == FENCE_ACTION_NONE ||
-        !geofence_present() ||
+    if (!geofence_present() ||
         (g.fence_action != FENCE_ACTION_REPORT && !geofence_state->is_enabled)) {
         // geo-fencing is disabled
         // re-arm for when the channel trigger is switched on

--- a/ArduPlane/geofence.cpp
+++ b/ArduPlane/geofence.cpp
@@ -27,7 +27,6 @@ static struct GeofenceState {
     int32_t guided_lng;
     uint16_t breach_count;
     uint8_t breach_type;
-    GeofenceEnableReason enable_reason;
     uint8_t old_switch_position;
     uint8_t num_points;
     bool boundary_uptodate;
@@ -179,13 +178,13 @@ void Plane::geofence_update_pwm_enabled_state()
     }
 
     if (geofence_state->is_pwm_enabled != is_pwm_enabled) {
-        geofence_set_enabled(is_pwm_enabled, PWM_TOGGLED);
+        geofence_set_enabled(is_pwm_enabled);
         geofence_state->is_pwm_enabled = is_pwm_enabled;
     }    
 }
 
 //return true on success, false on failure
-bool Plane::geofence_set_enabled(bool enable, GeofenceEnableReason r) 
+bool Plane::geofence_set_enabled(bool enable) 
 {
     if (geofence_state == nullptr && enable) {
         geofence_load();
@@ -199,7 +198,6 @@ bool Plane::geofence_set_enabled(bool enable, GeofenceEnableReason r)
         //turn the floor back on if it had been off
         geofence_set_floor_enabled(true);
     }
-    geofence_state->enable_reason = r;
     
     return true;
 }
@@ -518,7 +516,7 @@ bool Plane::geofence_present(void) {
     return false;
 }
 
-bool Plane::geofence_set_enabled(bool enable, GeofenceEnableReason r) {
+bool Plane::geofence_set_enabled(bool enable) {
     return false;
 }
 

--- a/ArduPlane/geofence.cpp
+++ b/ArduPlane/geofence.cpp
@@ -21,23 +21,21 @@
  *  very quickly at runtime
  */
 static struct GeofenceState {
+    Vector2l *boundary;   // point 0 is the return point
+    uint32_t breach_time;
+    int32_t guided_lat;
+    int32_t guided_lng;
+    uint16_t breach_count;
+    uint8_t breach_type;
+    GeofenceEnableReason enable_reason;
+    uint8_t old_switch_position;
     uint8_t num_points;
     bool boundary_uptodate;
     bool fence_triggered;
     bool is_pwm_enabled;          //true if above FENCE_ENABLE_PWM threshold
     bool is_enabled;
-    GeofenceEnableReason enable_reason;
     bool floor_enabled;          //typically used for landing
-    uint16_t breach_count;
-    uint8_t breach_type;
-    uint32_t breach_time;
-    uint8_t old_switch_position;
-    int32_t guided_lat;
-    int32_t guided_lng;
-    /* point 0 is the return point */
-    Vector2l *boundary;
 } *geofence_state;
-
 
 static const StorageAccess fence_storage(StorageManager::StorageFence);
 

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -269,7 +269,7 @@ void Plane::complete_auto_takeoff(void)
 {
 #if GEOFENCE_ENABLED == ENABLED
     if (g.fence_autoenable > 0) {
-        if (! geofence_set_enabled(true, AUTO_TOGGLED)) {
+        if (! geofence_set_enabled(true)) {
             gcs().send_text(MAV_SEVERITY_NOTICE, "Enable fence failed (cannot autoenable");
         } else {
             gcs().send_text(MAV_SEVERITY_INFO, "Fence enabled (autoenabled)");


### PR DESCRIPTION
This is split into a couple of commits, (and is easier to review in that order).

The first commit removes us stashing the previous pwm_enable state, when we only need it locally in a function (and more critically don't even need a temporary, and can run faster without adding it).

The second commit simply does the header rearrangement on GeofenceState which shrinks the size by 4 bytes. (As a note, the whole thing only weighs 28 bytes after this, we should consider just making it a member of the plane class and deleting the nullptr checks everywhere).

The third commit remove the geofence enable reason. We currently only write to this, and never read it so this doesn't change behaviour, while reducing code. If someone actually wants to make us use this then we can keep it, but as is it's dead weight.

The fourth commit makes the `geofence_enabled()` check have an early return if the action isn't specified. This is advantageous if you aren't using the fence as it speeds up the calls to geofence stick mixing which gets called every loop (particularly noticeable on a quadplane), and speeds up the normal update call. This does introduce a slight behaviour change in that we would previously allocate/load the fence if there was a RC channel assigned to enable the fence and it was high. (It also used to set the state to disabled if the switch was around and we had allocated a state) However since the action was set to none I think this is an acceptable change in behavior. Surprisingly on a CubeBlack build this saves 60 bytes of flash.

In other note I can't see the reason for `FENCE_RET_RALLY`. If you want to return to a rally point just specify the action to be RTL. I think we can lose the parameter without any loss of functionality, and simplify the code internally (and one less parameter for GCS's to deal with). (There is some really messy code with handling the actions I'd like to rework).