### PR TITLE
AP_Motors: Allow the user to control minimum PWM time when coming out of SAFE_DISARM

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -395,8 +395,7 @@ int16_t AP_MotorsMulticopter::output_to_pwm(float actuator)
     float pwm_output;
     if (_spool_state == SpoolState::SHUT_DOWN) {
         // in shutdown mode, use PWM 0 or minimum PWM
-        if (_disarm_disable_pwm && is_equal(_disarm_safe_timer, 0.0f) && !armed()) {
-//        if (_disarm_disable_pwm && !armed()) {
+        if (_disarm_disable_pwm && !armed()) {
             pwm_output = 0;
         } else {
             pwm_output = get_pwm_output_min();
@@ -511,8 +510,8 @@ void AP_MotorsMulticopter::output_logic()
         } else {
             _disarm_safe_timer = _safe_time;
         }
-    } else if (_disarm_safe_timer > 0.0f) {
-        _disarm_safe_timer -= 1.0f/_loop_rate;;
+    } else {
+           _disarm_safe_timer = 0.0f;
     }
 
     // force desired and current spool mode if disarmed or not interlocked

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -23,6 +23,7 @@
 #define AP_MOTORS_BAT_CURR_TC_DEFAULT   5.0f    // Time constant used to limit the maximum current
 #define AP_MOTORS_BATT_VOLT_FILT_HZ     0.5f    // battery voltage filtered at 0.5hz
 #define AP_MOTORS_SLEW_TIME_DEFAULT     0.0f    // slew rate limit for thrust output
+#define AP_MOTORS_SAFE_TIME_DEFAULT     1.0f    // Time for the esc when transitioning between zero pwm to minimum
 
 // spool definition
 #define AP_MOTORS_SPOOL_UP_TIME_DEFAULT 0.5f    // time (in seconds) for throttle to increase from zero to min throttle, and min throttle to full throttle.
@@ -148,6 +149,7 @@ protected:
     AP_Float            _thrust_curve_expo;     // curve used to linearize pwm to thrust conversion.  set to 0 for linear and 1 for second order approximation
     AP_Float            _slew_up_time;          // throttle increase slew limitting
     AP_Float            _slew_dn_time;          // throttle decrease slew limitting
+    AP_Float            _safe_time;             // Time for the esc when transitioning between zero pwm to minimum
     AP_Float            _spin_min;              // throttle out ratio which produces the minimum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
     AP_Float            _spin_max;              // throttle out ratio which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
     AP_Float            _spin_arm;              // throttle out ratio which produces the armed spin rate.  (i.e. 0 ~ 1 ) of the full throttle range
@@ -185,7 +187,7 @@ protected:
     float               _lift_max;              // maximum lift ratio from battery voltage
     float               _throttle_limit;        // ratio of throttle limit between hover and maximum
     float               _throttle_thrust_max;   // the maximum allowed throttle thrust 0.0 to 1.0 in the range throttle_min to throttle_max
-    uint16_t            _disarm_safety_timer;
+    float               _disarm_safe_timer;     // Timer for the esc when transitioning between zero pwm to minimum
 
     // vehicle supplied callback for thrust compensation. Used for tiltrotors and tiltwings
     thrust_compensation_fn_t _thrust_compensation_callback;


### PR DESCRIPTION
`M_SAFE_DISARM` allows you to ensure there are no pulses while disarmed. Depending upon the ESC you have you will need a minimum time at minimum throttle to enable the ESC to spin up. This introduces a parameter to control the ramp up time on the motor. The initial patch was done by @lthall I did the bench testing of it and had to add a patch to restore a regression around sending pulses when it shouldn't be. The main change I introduced on top of what @lthall did was that when going into the shutdown state on the motors I removed the spool down time. I think this is actually appropriate though as while I need a second of the motor being at a low throttle to start the motors, I really don't want or need a second of minimum throttle when stopping the motors. And the act of disarming the aircraft already has the same effect of cutting the throttle output so I think this is a safe path.