### PR TITLE
AP_Proximity: fix rangefinder backends cm to m conversion

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -65,7 +65,7 @@ void AP_Proximity_RangeFinder::update(void)
                 int16_t up_distance_min = sensor->min_distance_cm();
                 int16_t up_distance_max = sensor->max_distance_cm();
                 if ((distance_upward >= up_distance_min) && (distance_upward <= up_distance_max)) {
-                    _distance_upward = distance_upward * 1e2;
+                    _distance_upward = distance_upward * 0.01f;
                 } else {
                     _distance_upward = -1.0; // mark an valid reading
                 }


### PR DESCRIPTION
This fixes a cm to meters conversion in the AP_Proximity library's RangeFinder backend (i.e. the proximity library's backend that takes distances from 1D lidar).

Below are screen shots of the before and after distances.  During this test object avoidance (of the ceiling) was not working in the "Before" but was working "After".
![prx-logs-before-after](https://user-images.githubusercontent.com/1498098/65038638-5ddda880-d98b-11e9-9acb-e24dcb70923e.png)

