### PR TITLE
Sub: rate-limit init_motor_test() calls

### DIFF
--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -197,10 +197,19 @@ bool Sub::handle_do_motor_test(mavlink_command_long_t command) {
     last_do_motor_test_ms = AP_HAL::millis();
 
     // If we are not already testing motors, initialize test
+    static uint32_t tLastInitializationFailed = 0;
     if(!ap.motor_test) {
-        if (!init_motor_test()) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "motor test initialization failed!");
-            return false; // init fail
+        // Do not allow initializations attempt under 2 seconds
+        // If one fails, we need to give the user time to fix the issue
+        // instead of spamming error messages
+        if (AP_HAL::millis() > (tLastInitializationFailed + 2000)) {
+            if (!init_motor_test()) {
+                gcs().send_text(MAV_SEVERITY_WARNING, "motor test initialization failed!");
+                tLastInitializationFailed = AP_HAL::millis();
+                return false; // init fail
+            }
+        } else {
+            return false;
         }
     }
 


### PR DESCRIPTION
This fixes https://github.com/ArduPilot/ardupilot/issues/9804
But rate-limiting the calls to init_motor_test() instead

There is still some work to be done, but that is on QGC side: https://github.com/mavlink/qgroundcontrol/issues/7585