### PR TITLE
Rover: pre-arm check that WP_SPEED is positive

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -85,7 +85,8 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
     return (AP_Arming::pre_arm_checks(report)
             & rover.g2.motors.pre_arm_check(report)
             & fence_checks(report)
-            & oa_check(report));
+            & oa_check(report)
+            & parameter_checks(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
@@ -176,3 +177,21 @@ bool AP_Arming_Rover::oa_check(bool report)
     }
     return false;
 }
+
+// perform parameter checks
+bool AP_Arming_Rover::parameter_checks(bool report)
+{
+    // success if parameter checks are disabled
+    if ((checks_to_perform != ARMING_CHECK_ALL) && !(checks_to_perform & ARMING_CHECK_PARAMETERS)) {
+        return true;
+    }
+
+    // check waypoint speed is positive
+    if (!is_positive(rover.g2.wp_nav.get_default_speed())) {
+        check_failed(ARMING_CHECK_PARAMETERS, report, "WP_SPEED too low");
+        return false;
+    }
+
+    return true;
+}
+

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -27,7 +27,9 @@ public:
     void update_soft_armed();
 
 protected:
+    // the following check functions do not call into AP_Arming
     bool oa_check(bool report);
+    bool parameter_checks(bool report);
 
 private:
 


### PR DESCRIPTION
This adds a pre-arm check that Rover's WP_SPEED parameter is positive.  This is important for the upcoming Rover-4.0.0 releases because in the new version the vehicle's speed in Auto, Guided, etc comes from the WP_SPEED parameter and we no longer fall back to the CRUISE_SPEED if WP_SPEED is zero.

Although WP_SPEED now defaults to 2m/s (it defaulted to zero in 3.5.1 and earlier) there have been two reported cases (from @Hwurzburg and @magicrub) where WP_SPEED was set to zero after loading a parameter file from an earlier version of the firmware.

This has been bench tested on a flight controller with ARMING_CHECKS = 1 and ARMING_CHECKS = 64990 (all arming checks on except "Parameters" ).

This PR replaces the most critical part of this PR from @magicrub: https://github.com/ArduPilot/ardupilot/pull/11958