### PR TITLE
GCS_MAVLink: Remove unused headers

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -30,11 +30,10 @@ extern AP_IOMCU iomcu;
 #include "hwdef/common/stm32_util.h"
 
 #ifndef CHIBIOS_ADC_MAVLINK_DEBUG
+#include <GCS_MAVLink/GCS_MAVLink.h>
 // this allows the first 6 analog channels to be reported by mavlink for debugging purposes
 #define CHIBIOS_ADC_MAVLINK_DEBUG 0
 #endif
-
-#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define ANLOGIN_DEBUGGING 0
 

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -23,7 +23,6 @@ This provides some support code and variables for MAVLink enabled sketches
 #include "GCS_MAVLink.h"
 
 #include <AP_Common/AP_Common.h>
-#include <AP_GPS/AP_GPS.h>
 #include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -14,10 +14,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 
-#include "AP_Common/AP_FWVersion.h"
 #include "GCS.h"
 #include <AP_Logger/AP_Logger.h>
 

--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -20,7 +20,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "GCS.h"
-#include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
 
 extern const AP_HAL::HAL& hal;


### PR DESCRIPTION
More headers we didn't need to include triggering more things to be recompiled that didn't need to be.