### PR TITLE
AP_Frsky_Telem: added VSpd to telemetry protocol 4

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -510,10 +510,10 @@ class FRSkySPort(FRSky):
             0x04: "Fuel",
             0x05: "Temp2",
             0x10: "Baro Alt BP",
-            0x13: "GPS_LAT_BP",
-            0x1B: "GPS_LAT_AP",
             0x21: "BARO_ALT_AP",
+            0x30: "VARIO",
             0x39: "VFAS",
+            0x800: "GPS",
         }
 
         self.sensors_to_poll = [
@@ -4532,14 +4532,14 @@ switch value'''
         # This, at least makes sure we're getting some of each
         # message.
         wants = {
-            0x02: lambda x : True,
-            0x04: lambda x : True,
-            0x05: lambda x : True,
-            0x10: lambda x : True,
-            0x13: lambda x : True,
-            0x1B: lambda x : True,
-            0x21: lambda x : True,
-            0x39: lambda x : True,
+            0x02:  lambda x : True,
+            0x04:  lambda x : True,
+            0x05:  lambda x : True,
+            0x10:  lambda x : True,
+            0x21:  lambda x : True,
+            0x30:  lambda x : True,
+            0x39:  lambda x : True,
+            0x800: lambda x : True,
         }
         tstart = self.get_sim_time_cached()
         last_wanting_print = 0

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -42,6 +42,7 @@ for FrSky D protocol (D-receivers)
 #define DATA_ID_GPS_LONG_EW         0x22
 #define DATA_ID_GPS_LAT_NS          0x23
 #define DATA_ID_CURRENT             0x28
+#define DATA_ID_VARIO               0x30
 #define DATA_ID_VFAS                0x39
 
 #define START_STOP_D                0x5E
@@ -157,6 +158,7 @@ private:
     
     struct
     {
+        int32_t vario_vspd;
         char lat_ns, lon_ew;
         uint16_t latdddmm;
         uint16_t latmmmm;
@@ -168,7 +170,8 @@ private:
         uint16_t alt_nav_cm;
         int16_t speed_in_meter;
         uint16_t speed_in_centimeter;
-    } _gps;
+        uint16_t yaw;
+    } _SPort_data;
 
     struct PACKED
     {
@@ -207,6 +210,7 @@ private:
         uint8_t gps_call;
         uint8_t vario_call;
         uint8_t various_call;
+        uint8_t next_sensor_id;
     } _SPort;
     
     struct
@@ -222,6 +226,7 @@ private:
         uint8_t char_index; // index of which character to get in the message
     } _msg_chunk;
     
+    float get_vspeed_ms(void);
     // passthrough WFQ scheduler
     void update_avg_packet_rate();
     void passthrough_wfq_adaptive_scheduler();


### PR DESCRIPTION
The Frsky vario "virtual" sensor was reporting altitude but not vertical speed.
This patch adds VSpd as a new sensor when protocol 4 is selected.

Notes:
- Just like the OSD code, if for any reason vertical speed is not available from ahrs it falls back to baro climb rate.
- this also fixes a bug in the sensors looping code

related issue
https://github.com/ArduPilot/ardupilot/issues/12245