### PR TITLE
Rover: Add loiter gain control and maximum vehicle speed params

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -603,6 +603,23 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AC_Avoidance/AP_OAPathPlanner.cpp
     AP_SUBGROUPINFO(oa, "OA_", 45, ParametersG2, AP_OAPathPlanner),
 
+    // @Param: SPEED_MAX
+    // @DisplayName: Maximum obtainable vehicle speed
+    // @Description: Maximum speed vehicle can obtain at full throttle. If 0, it will be estimated based on CRUISE_SPEED and CRUISE_THROTTLE.
+    // @Units: m/s
+    // @Range: 0 100
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("SPEED_MAX", 46, ParametersG2, speed_max, 0.0f),
+
+    // @Param: LOIT_SPEED_GAIN
+    // @DisplayName: Loiter speed gain
+    // @Description: Determines how agressively LOITER tries to correct for drift from loiter point. Higher is faster but default should be acceptable.
+    // @Range: 0 5
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("LOIT_SPEED_GAIN", 47, ParametersG2, loiter_speed_gain, 0.5f),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -320,6 +320,12 @@ public:
     // default speed for rtl
     AP_Float rtl_speed;
 
+    // gain for speed of correction in loiter
+    AP_Float loiter_speed_gain;
+
+    // maximum speed for vehicle
+    AP_Float speed_max;
+
     // frame class for vehicle
     AP_Int8 frame_class;
 

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -337,7 +337,11 @@ float Mode::calc_speed_max(float cruise_speed, float cruise_throttle) const
         speed_max = cruise_speed;
     } else {
         // project vehicle's maximum speed
-        speed_max = (1.0f / cruise_throttle) * cruise_speed;
+        if (g2.speed_max > 0.0f ) {
+             speed_max = g2.speed_max;
+        } else {
+             speed_max = (1.0f / cruise_throttle) * cruise_speed;
+        }
     }
 
     // constrain to 30m/s (108km/h) and return

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -28,10 +28,8 @@ void ModeLoiter::update()
         const float desired_speed_within_radius = rover.g2.sailboat.tack_enabled() ? 0.1f : 0.0f;
         _desired_speed = attitude_control.get_desired_speed_accel_limited(desired_speed_within_radius, rover.G_Dt);
     } else {
-        // P controller with hard-coded gain to convert distance to desired speed
-        // To-Do: make gain configurable or calculate from attitude controller's maximum accelearation
-        _desired_speed = MIN((_distance_to_destination - g2.loit_radius) * 0.5f, g2.wp_nav.get_default_speed());
-
+        // P controller with hard-coded gain to convert distance to desired speed       
+        _desired_speed = MIN((_distance_to_destination - g2.loit_radius) * g2.loiter_speed_gain, g2.wp_nav.get_default_speed());
         // calculate bearing to destination
         _desired_yaw_cd = rover.current_loc.get_bearing_to(_destination);
         float yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);


### PR DESCRIPTION
Adds a param to control aggression on corrections in loiter mode(boat only mode)
Adds a param to set maximum expected vehicle speed, default is present estimation, changing it allows actual max speed to be used to linearize ACRO speed control vs stick and Throttle Nudge (all vehicles)

Boat tested 