### PR TITLE
EKF ram reduction using common variables

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -303,3 +303,11 @@ bool rotation_equal(enum Rotation r1, enum Rotation r2)
     return (v1 - v2).length() < 0.001;
 }
 
+
+// fill an array of float with NaN, used to invalidate memory in SITL
+void fill_nanf(float *f, uint16_t count)
+{
+    while (count--) {
+        *f++ = nanf("fill");
+    }
+}

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -281,3 +281,6 @@ bool is_valid_octal(uint16_t octal) WARN_IF_UNUSED;
 
 // return true if two rotations are equal
 bool rotation_equal(enum Rotation r1, enum Rotation r2) WARN_IF_UNUSED;
+
+// fill an array of float with NaN, used to invalidate memory in SITL
+void fill_nanf(float *f, uint16_t count);

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -660,16 +660,27 @@ bool NavEKF2::InitialiseFilter(void)
             gcs().send_text(MAV_SEVERITY_CRITICAL, "NavEKF2: allocation failed");
             return false;
         }
+
+        // allocate common intermediate variable space
+        core_common = (struct CoreCommon *)hal.util->malloc_type(NavEKF2_core::get_core_common_size(), AP_HAL::Util::MEM_FAST);
+        if (core_common == nullptr) {
+            _enable.set(0);
+            hal.util->free_type(core, sizeof(NavEKF2_core)*num_cores, AP_HAL::Util::MEM_FAST);
+            core = nullptr;
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "NavEKF2: common allocation failed");
+            return false;
+        }
+
+        //Call Constructors on all cores
         for (uint8_t i = 0; i < num_cores; i++) {
-            //Call Constructors
-            new (&core[i]) NavEKF2_core();
+            new (&core[i]) NavEKF2_core(this);
         }
 
         // set the IMU index for the cores
         num_cores = 0;
         for (uint8_t i=0; i<7; i++) {
             if (_imuMask & (1U<<i)) {
-                if(!core[num_cores].setup_core(this, i, num_cores)) {
+                if(!core[num_cores].setup_core(i, num_cores)) {
                     return false;
                 }
                 num_cores++;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -662,7 +662,7 @@ bool NavEKF2::InitialiseFilter(void)
         }
 
         // allocate common intermediate variable space
-        core_common = (struct CoreCommon *)hal.util->malloc_type(NavEKF2_core::get_core_common_size(), AP_HAL::Util::MEM_FAST);
+        core_common = (void *)hal.util->malloc_type(NavEKF2_core::get_core_common_size(), AP_HAL::Util::MEM_FAST);
         if (core_common == nullptr) {
             _enable.set(0);
             hal.util->free_type(core, sizeof(NavEKF2_core)*num_cores, AP_HAL::Util::MEM_FAST);

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -492,6 +492,11 @@ private:
     // time of last lane switch
     uint32_t lastLaneSwitch_ms;
 
+    /*
+      common intermediate variables used by all cores
+    */
+    void *core_common;
+
     // update the yaw reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary

--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -39,6 +39,7 @@ void NavEKF2_core::FuseAirspeed()
     float SK_TAS;
     Vector24 H_TAS;
     float VtasPred;
+    Vector28 Kfusion;
 
     // health is set bad until test passed
     tasHealth = false;
@@ -269,6 +270,7 @@ void NavEKF2_core::FuseSideslip()
     Vector3f vel_rel_wind;
     Vector24 H_BETA;
     float innovBeta;
+    Vector28 Kfusion;
 
     // copy required states to local variable names
     q0 = stateStruct.quat[0];

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -346,6 +346,7 @@ void NavEKF2_core::FuseMagnetometer()
     Vector6 SK_MX;
     Vector6 SK_MY;
     Vector6 SK_MZ;
+    Vector28 Kfusion;
 
     hal.util->perf_end(_perf_test[1]);
     
@@ -780,6 +781,8 @@ void NavEKF2_core::fuseEulerYaw()
     float measured_yaw;
     float H_YAW[3];
     Matrix3f Tbn_zeroYaw;
+    Vector28 Kfusion;
+
     if (fabsf(prevTnb[0][2]) < fabsf(prevTnb[1][2])) {
         // calculate observation jacobian when we are observing the first rotation in a 321 sequence
         float t2 = q0*q0;
@@ -1037,6 +1040,8 @@ void NavEKF2_core::FuseDeclination(float declErr)
     float t12 = 1.0f/t11;
 
     float H_MAG[24];
+    Vector28 Kfusion;
+
     H_MAG[16] = -magE*t5;
     H_MAG[17] = magN*t5;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -285,6 +285,7 @@ void NavEKF2_core::FuseOptFlow()
     Vector3f relVelSensor;
     Vector14 SH_LOS;
     Vector2 losPred;
+    Vector28 Kfusion;
 
     // Copy required states to local variable names
     float q0  = stateStruct.quat[0];

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -438,6 +438,7 @@ void NavEKF2_core::FuseVelPosNED()
     Vector6 R_OBS; // Measurement variances used for fusion
     Vector6 R_OBS_DATA_CHECKS; // Measurement variances used for data checks only
     float SK;
+    Vector28 Kfusion;
 
     // perform sequential fusion of GPS measurements. This assumes that the
     // errors in the different velocity and position components are

--- a/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
@@ -43,6 +43,7 @@ void NavEKF2_core::FuseRngBcn()
     float bcn_pd;
     const float R_BCN = sq(MAX(rngBcnDataDelayed.rngErr , 0.1f));
     float rngPred;
+    Vector28 Kfusion;
 
     // health is set bad until test passed
     rngBcnHealth = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -32,15 +32,9 @@ NavEKF2_core::NavEKF2_core(NavEKF2 *_frontend) :
     frontend(_frontend),
     // setup the intermediate variables shared by all cores (to save memory)
     common((struct core_common *)_frontend->core_common),
-    Kfusion(common->Kfusion),
     KH(common->KH),
     KHP(common->KHP),
-    nextP(common->nextP),
-    processNoise(common->processNoise),
-    SF(common->SF),
-    SG(common->SG),
-    SQ(common->SQ),
-    SPP(common->SPP)
+    nextP(common->nextP)
 {
     _perf_test[0] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test0");
     _perf_test[1] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test1");
@@ -882,6 +876,10 @@ void NavEKF2_core::CovariancePrediction()
     float day_s;        // Y axis delta angle measurement scale factor
     float daz_s;        // Z axis delta angle measurement scale factor
     float dvz_b;        // Z axis delta velocity measurement bias (rad)
+    Vector25 SF;
+    Vector5 SG;
+    Vector8 SQ;
+    Vector24 processNoise;
 
     // calculate covariance prediction process noise
     // use filtered height rate to increase wind process noise when climbing or descending
@@ -979,6 +977,7 @@ void NavEKF2_core::CovariancePrediction()
     SQ[6] = 2*q1*q2;
     SQ[7] = SG[4];
 
+    Vector23 SPP;
     SPP[0] = SF[17]*(2*q0*q1 + 2*q2*q3) + SF[18]*(2*q0*q2 - 2*q1*q3);
     SPP[1] = SF[18]*(2*q0*q2 + 2*q1*q3) + SF[16]*(SF[24] - 2*q0*q3);
     SPP[2] = 2*q3*SF[8] + 2*q1*SF[11] - 2*q0*SF[14] - 2*q2*SF[13];

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -494,15 +494,9 @@ private:
       place to calculate maximum stack usage using static analysis.
      */
     struct core_common {
-        Vector28 Kfusion;
         Matrix24 KH;
         Matrix24 KHP;
         Matrix24 nextP;
-        Vector24 processNoise;
-        Vector25 SF;
-        Vector5 SG;
-        Vector8 SQ;
-        Vector23 SPP;
     } *common;
 
     // bias estimates for the IMUs that are enabled but not being used
@@ -822,7 +816,6 @@ private:
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
-    Vector28 &Kfusion;              // Kalman gain vector
     Matrix24 &KH;                   // intermediate result used for covariance updates
     Matrix24 &KHP;                  // intermediate result used for covariance updates
     Matrix24 P;                     // covariance matrix
@@ -880,11 +873,6 @@ private:
     uint32_t lastYawTime_ms;        // time stamp when yaw observation was last fused (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)
     Matrix24 &nextP;                // Predicted covariance matrix before addition of process noise to diagonals
-    Vector24 &processNoise;         // process noise added to diagonals of predicted covariance matrix
-    Vector25 &SF;                   // intermediate variables used to calculate predicted covariance matrix
-    Vector5 &SG;                    // intermediate variables used to calculate predicted covariance matrix
-    Vector8 &SQ;                    // intermediate variables used to calculate predicted covariance matrix
-    Vector23 &SPP;                  // intermediate variables used to calculate predicted covariance matrix
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -62,10 +62,10 @@ class NavEKF2_core
 {
 public:
     // Constructor
-    NavEKF2_core(void);
+    NavEKF2_core(NavEKF2 *_frontend);
 
     // setup this core backend
-    bool setup_core(NavEKF2 *_frontend, uint8_t _imu_index, uint8_t _core_index);
+    bool setup_core(uint8_t _imu_index, uint8_t _core_index);
     
     // Initialise the states from accelerometer and magnetometer data (if present)
     // This method can only be used when the vehicle is static
@@ -327,6 +327,9 @@ public:
     // return true when external nav data is also being used as a yaw observation
     bool isExtNavUsedForYaw(void);
 
+    // return size of core_common for use in frontend allocation
+    static uint32_t get_core_common_size(void) { return sizeof(core_common); }
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;
@@ -481,6 +484,26 @@ private:
         uint32_t        time_ms;    // measurement timestamp (msec)
         bool            posReset;   // true when the position measurement has been reset
     };
+
+    /*
+      common intermediate variables used by all cores. These save a
+      lot memory by avoiding allocating these arrays on every core
+      Having these as stack variables would save even more memory, but
+      would give us very high stack usage in some functions, which
+      poses a risk of stack overflow until we have infrastructure in
+      place to calculate maximum stack usage using static analysis.
+     */
+    struct core_common {
+        Vector28 Kfusion;
+        Matrix24 KH;
+        Matrix24 KHP;
+        Matrix24 nextP;
+        Vector24 processNoise;
+        Vector25 SF;
+        Vector5 SG;
+        Vector8 SQ;
+        Vector23 SPP;
+    } *common;
 
     // bias estimates for the IMUs that are enabled but not being used
     // by this core.
@@ -799,9 +822,9 @@ private:
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
-    Vector28 Kfusion;               // Kalman gain vector
-    Matrix24 KH;                    // intermediate result used for covariance updates
-    Matrix24 KHP;                   // intermediate result used for covariance updates
+    Vector28 &Kfusion;              // Kalman gain vector
+    Matrix24 &KH;                   // intermediate result used for covariance updates
+    Matrix24 &KHP;                  // intermediate result used for covariance updates
     Matrix24 P;                     // covariance matrix
     imu_ring_buffer_t<imu_elements> storedIMU;      // IMU data buffer
     obs_ring_buffer_t<gps_elements> storedGPS;      // GPS data buffer
@@ -856,12 +879,12 @@ private:
     bool allMagSensorsFailed;       // true if all magnetometer sensors have timed out on this flight and we are no longer using magnetometer data
     uint32_t lastYawTime_ms;        // time stamp when yaw observation was last fused (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)
-    Matrix24 nextP;                 // Predicted covariance matrix before addition of process noise to diagonals
-    Vector24 processNoise;          // process noise added to diagonals of predicted covariance matrix
-    Vector25 SF;                    // intermediate variables used to calculate predicted covariance matrix
-    Vector5 SG;                     // intermediate variables used to calculate predicted covariance matrix
-    Vector8 SQ;                     // intermediate variables used to calculate predicted covariance matrix
-    Vector23 SPP;                   // intermediate variables used to calculate predicted covariance matrix
+    Matrix24 &nextP;                // Predicted covariance matrix before addition of process noise to diagonals
+    Vector24 &processNoise;         // process noise added to diagonals of predicted covariance matrix
+    Vector25 &SF;                   // intermediate variables used to calculate predicted covariance matrix
+    Vector5 &SG;                    // intermediate variables used to calculate predicted covariance matrix
+    Vector8 &SQ;                    // intermediate variables used to calculate predicted covariance matrix
+    Vector23 &SPP;                  // intermediate variables used to calculate predicted covariance matrix
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -492,6 +492,8 @@ private:
       would give us very high stack usage in some functions, which
       poses a risk of stack overflow until we have infrastructure in
       place to calculate maximum stack usage using static analysis.
+      On SITL this structure is assumed to contain only float
+      variables (for the fill_nanf())
      */
     struct core_common {
         Matrix24 KH;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -495,7 +495,12 @@ private:
 
     // time of last lane switch
     uint32_t lastLaneSwitch_ms;
-    
+
+    /*
+      common intermediate variables used by all cores
+    */
+    void *core_common;
+
     struct {
         uint32_t last_function_call;  // last time getLastYawYawResetAngle was called
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -10,7 +10,7 @@
 extern const AP_HAL::HAL& hal;
 
 // constructor
-NavEKF3_core::NavEKF3_core(void) :
+NavEKF3_core::NavEKF3_core(NavEKF3 *_frontend) :
     _perf_UpdateFilter(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_UpdateFilter")),
     _perf_CovariancePrediction(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_CovariancePrediction")),
     _perf_FuseVelPosNED(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseVelPosNED")),
@@ -19,7 +19,14 @@ NavEKF3_core::NavEKF3_core(void) :
     _perf_FuseSideslip(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseSideslip")),
     _perf_TerrainOffset(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_TerrainOffset")),
     _perf_FuseOptFlow(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseOptFlow")),
-    _perf_FuseBodyOdom(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseBodyOdom"))
+    _perf_FuseBodyOdom(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseBodyOdom")),
+    frontend(_frontend),
+    // setup the intermediate variables shared by all cores (to save memory)
+    common((struct core_common *)_frontend->core_common),
+    Kfusion(common->Kfusion),
+    KH(common->KH),
+    KHP(common->KHP),
+    nextP(common->nextP)
 {
     _perf_test[0] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test0");
     _perf_test[1] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test1");
@@ -36,9 +43,8 @@ NavEKF3_core::NavEKF3_core(void) :
 }
 
 // setup this core backend
-bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _core_index)
+bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
 {
-    frontend = _frontend;
     imu_index = _imu_index;
     gyro_index_active = imu_index;
     accel_index_active = imu_index;
@@ -59,15 +65,15 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     }
 
     // find the maximum time delay for all potential sensors
-    uint16_t maxTimeDelay_ms = MAX(_frontend->_hgtDelay_ms ,
-            MAX(_frontend->_flowDelay_ms ,
-                MAX(_frontend->_rngBcnDelay_ms ,
-                    MAX(_frontend->magDelay_ms ,
+    uint16_t maxTimeDelay_ms = MAX(frontend->_hgtDelay_ms ,
+            MAX(frontend->_flowDelay_ms ,
+                MAX(frontend->_rngBcnDelay_ms ,
+                    MAX(frontend->magDelay_ms ,
                         (uint16_t)(EKF_TARGET_DT_MS)
                                   ))));
 
     // GPS sensing can have large delays and should not be included if disabled
-    if (_frontend->_fusionModeGPS != 3) {
+    if (frontend->_fusionModeGPS != 3) {
         // Wait for the configuration of all GPS units to be confirmed. Until this has occurred the GPS driver cannot provide a correct time delay
         float gps_delay_sec = 0;
         if (!AP::gps().get_lag(gps_delay_sec)) {
@@ -90,7 +96,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
 
     // airspeed sensing can have large delays and should not be included if disabled
     if (_ahrs->airspeed_sensor_enabled()) {
-        maxTimeDelay_ms = MAX(maxTimeDelay_ms , _frontend->tasDelay_ms);
+        maxTimeDelay_ms = MAX(maxTimeDelay_ms , frontend->tasDelay_ms);
     }
 
     // calculate the IMU buffer length required to accommodate the maximum delay with some allowance for jitter
@@ -100,13 +106,13 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     // with the worst case delay from current time to ekf fusion time
     // allow for worst case 50% extension of the ekf fusion time horizon delay due to timing jitter
     uint16_t ekf_delay_ms = maxTimeDelay_ms + (int)(ceilf((float)maxTimeDelay_ms * 0.5f));
-    obs_buffer_length = (ekf_delay_ms / _frontend->sensorIntervalMin_ms) + 1;
+    obs_buffer_length = (ekf_delay_ms / frontend->sensorIntervalMin_ms) + 1;
 
     // limit to be no longer than the IMU buffer (we can't process data faster than the EKF prediction rate)
     obs_buffer_length = MIN(obs_buffer_length,imu_buffer_length);
 
     // calculate buffer size for optical flow data
-    const uint8_t flow_buffer_length = MIN((ekf_delay_ms / _frontend->flowIntervalMin_ms) + 1, imu_buffer_length);
+    const uint8_t flow_buffer_length = MIN((ekf_delay_ms / frontend->flowIntervalMin_ms) + 1, imu_buffer_length);
 
     if(!storedGPS.init(obs_buffer_length)) {
         return false;
@@ -211,7 +217,7 @@ void NavEKF3_core::InitialiseVariables()
     lastKnownPositionNE.zero();
     prevTnb.zero();
     memset(&P[0][0], 0, sizeof(P));
-    memset(&nextP[0][0], 0, sizeof(nextP));
+    memset(common, 0, sizeof(*common));
     flowDataValid = false;
     rangeDataToFuse  = false;
     Popt = 0.0f;
@@ -567,6 +573,12 @@ void NavEKF3_core::CovarianceInit()
 // Update Filter States - this should be called whenever new IMU data is available
 void NavEKF3_core::UpdateFilter(bool predict)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // fill the common variables with NaN, so we catch any cases in
+    // SITL where they are used without initialisation
+    fill_nanf((float *)common, sizeof(*common)/sizeof(float));
+#endif
+
     // Set the flag to indicate to the filter that the front-end has given permission for a new state prediction cycle to be started
     startPredictEnabled = predict;
 


### PR DESCRIPTION
This is an alternative to #11717. Instead of moving variables to the stack it moves them to a common structure shared between cores. This doesn't save as much memory as #11717, but it avoids the large stack frames. I tried to build a static analyser to allow us to have large stack frames safely, but haven't had the time to finish that work, so this is an alternative that gives us most of the memory saving now.
This patch also adds code in SITL to fill the common variables with NaN on each filter update. This allows SITL to catch any cases where these intermediate variables are carrying over values from a previous iteration, which they should not do.