### PR TITLE
waf: fixed --build-dates option

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -268,7 +268,7 @@ class Board:
                 cfg.srcnode.find_dir('modules/uavcan/libuavcan/include').abspath()
             ]
 
-        if cfg.env.build_dates:
+        if cfg.options.build_dates:
             env.build_dates = True
 
         # We always want to use PRI format macros

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -103,13 +103,16 @@ class generate_apj(Task.Task):
             "magic": "APJFWv1",
             "description": "Firmware for a %s board" % self.env.APJ_BOARD_TYPE,
             "image": base64.b64encode(zlib.compress(img,9)).decode('utf-8'),
-            "build_time": int(time.time()),
             "summary": self.env.BOARD,
             "version": "0.1",
             "image_size": len(img),
             "git_identity": self.generator.bld.git_head_hash(short=True),
             "board_revision": 0
         }
+        if self.env.build_dates:
+            # we omit build_time when we don't have build_dates so that apj
+            # file is idential for same git hash and compiler
+            d["build_time"] = int(time.time())
         apj_file = self.outputs[0].abspath()
         f = open(apj_file, "w")
         f.write(json.dumps(d, indent=4))


### PR DESCRIPTION
and remove build_time from apj when --build-dates not used to avoid
changing apj file