### PR TITLE
Correct coverage analysis by handling SIGTERM

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -6,6 +6,7 @@ import os
 import random
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import tempfile
@@ -165,6 +166,19 @@ def pexpect_close(p):
     """Close a pexpect child."""
     global close_list
 
+    ex = None
+    try:
+        p.kill(signal.SIGTERM)
+    except IOError as e:
+        print("Caught exception: %s" % str(e))
+        ex = e
+        pass
+    if ex is None:
+        # give the process some time to go away
+        for i in range(20):
+            if not p.isalive():
+                break
+            time.sleep(0.05)
     try:
         p.close()
     except Exception:

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -16,6 +16,9 @@ public:
 
 private:
     HALSITL::SITL_State *_sitl_state;
+
+    void setup_signal_handlers() const;
+    static void exit_signal_handler(int);
 };
 
 #endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -28,6 +28,7 @@ AP_HAL::MemberProc Scheduler::_io_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {nullpt
 uint8_t Scheduler::_num_io_procs = 0;
 bool Scheduler::_in_io_proc = false;
 bool Scheduler::_should_reboot = false;
+bool Scheduler::_should_exit = false;
 
 bool Scheduler::_in_semaphore_take_wait = false;
 

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -50,6 +50,7 @@ public:
 
     static void _run_io_procs();
     static bool _should_reboot;
+    static bool _should_exit;
 
     /*
       create a new thread


### PR DESCRIPTION
Coverage depends on atexit functionality which doesn't run if we just kill the SITL binaries.

Send a SIGTERM to the SITL binary and have it exit gracefully.

The reason we were getting any coverage at all is that the exit handlers are also called when you exec another binary, which is what we do when we reboot  SITL.
