### PR TITLE
Enabling LIS3MDL for Cube

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -741,12 +741,6 @@ void Compass::_detect_backends(void)
         return;
     }
 
-#if AP_FEATURE_BOARD_DETECT
-    if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK2) {
-        // default to disabling LIS3MDL on pixhawk2 due to hardware issue
-        _driver_type_mask.set_default(1U<<DRIVER_LIS3MDL);
-    }
-#endif
     
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     ADD_BACKEND(DRIVER_SITL, new AP_Compass_SITL());


### PR DESCRIPTION
Can't find the purpose for disabling LIS3MDLTR compass for Pixhawk2/Cube. This make ardupilot incompatibile whith some of our hardware.