### PR TITLE
Rover 3.5.2 release

### DIFF
--- a/APMrover2/release-notes.txt
+++ b/APMrover2/release-notes.txt
@@ -1,5 +1,9 @@
 Rover Release Notes:
 --------------------------------
+Rover 3.5.2 24-Sep-2019
+Changes from 3.5.1
+1) fixed I2C storm lockup bug on ChibiOS
+--------------------------------
 Rover 3.5.1 17-May-2019 / 3.5.1-rc1 30-Apr-2019
 Changes from 3.5.0
 1) WHEEL_DISTANCE mavlink messages sent to ground station and companion computers

--- a/APMrover2/version.h
+++ b/APMrover2/version.h
@@ -6,12 +6,12 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V3.5.1"
+#define THISFIRMWARE "ArduRover V3.5.2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 3,5,1,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 3,5,2,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 3
 #define FW_MINOR 5
-#define FW_PATCH 1
+#define FW_PATCH 2
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL


### PR DESCRIPTION
This adds a single fix for the I2C lockup bug for a new rover 3.5.2 stable release
