### PR TITLE
AP_HAL_ChibiOS: correct include of mavlink header for analog debug

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -30,10 +30,13 @@ extern AP_IOMCU iomcu;
 #include "hwdef/common/stm32_util.h"
 
 #ifndef CHIBIOS_ADC_MAVLINK_DEBUG
-#include <GCS_MAVLink/GCS_MAVLink.h>
 // this allows the first 6 analog channels to be reported by mavlink for debugging purposes
 #define CHIBIOS_ADC_MAVLINK_DEBUG 0
 #endif
+
+// MAVLink is included as we send a mavlink message as part of debug,
+// and also use the MAV_POWER flags below in update_power_flags
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define ANLOGIN_DEBUGGING 0
 


### PR DESCRIPTION
This fixes the SkyViper Journey build.
