### PR TITLE
AP_NavEKF2: initialise Kfusion stack variable to fix compilation

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -39,7 +39,7 @@ void NavEKF2_core::FuseAirspeed()
     float SK_TAS;
     Vector24 H_TAS;
     float VtasPred;
-    Vector28 Kfusion;
+    Vector28 Kfusion {};
 
     // health is set bad until test passed
     tasHealth = false;


### PR DESCRIPTION
This fixes the compilation, as previous patches have done.

Whether it's the right thing to do is another matter.
