### PR TITLE
Tools: add --upload-port option to waf

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -507,6 +507,13 @@ platforms may support this. Example: `waf copter --upload` means "build
 arducopter and upload it to my board".
 ''')
 
+    g.add_option('--upload-port',
+        action='store',
+        dest='upload_port',
+        default=None,
+        help='''Specify the port to be used with the --upload option. For example a port of /dev/ttyS10 indicates that serial port 10 shuld be used.
+''')
+
     g = opt.ap_groups['check']
 
     g.add_option('--check-verbose',

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -53,8 +53,12 @@ class upload_fw(Task.Task):
     always_run = True
     def run(self):
         upload_tools = self.env.get_flat('UPLOAD_TOOLS')
+        upload_port = self.generator.bld.options.upload_port
         src = self.inputs[0]
-        return self.exec_command("{} '{}/uploader.py' '{}'".format(self.env.get_flat('PYTHON'), upload_tools, src))
+        cmd = "{} '{}/uploader.py' '{}'".format(self.env.get_flat('PYTHON'), upload_tools, src)
+        if upload_port is not None:
+            cmd += " '--port' '%s'" % upload_port
+        return self.exec_command(cmd)
 
     def exec_command(self, cmd, **kw):
         kw['stdout'] = sys.stdout


### PR DESCRIPTION
On windows WSL at least, autodetect on upload does not work well and specifying a port is necessary. This allows this be done from the waf command-line

@peterbarker FYI