### PR TITLE
Reduce compiled size of is_valid_octal

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -3,6 +3,7 @@
 #include <float.h>
 
 #include <AP_InternalError/AP_InternalError.h>
+#include <stdio.h>
 
 /*
  * is_equal(): Integer implementation, provided for convenience and
@@ -324,16 +325,15 @@ Vector3f rand_vec3f(void)
 bool is_valid_octal(uint16_t octal)
 {
     // treat "octal" as decimal and test if any decimal digit is > 7
-    if (octal > 7777) {
-        return false;
-    } else if (octal % 10 > 7) {
-        return false;
-    } else if ((octal % 100)/10 > 7) {
-        return false;
-    } else if ((octal % 1000)/100 > 7) {
-        return false;
-    } else if ((octal % 10000)/1000 > 7) {
-        return false;
+    char buffer[10];
+    snprintf(buffer, ARRAY_SIZE(buffer), "%u", octal);
+    for (uint8_t i=0; i<ARRAY_SIZE(buffer); i++) {
+        if (buffer[i] == '\0') {
+            break;
+        }
+        if (buffer[i] > '7') {
+            return false;
+        }
     }
     return true;
 }

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -322,6 +322,39 @@ TEST(MathWrapTest, Angle2PI)
     EXPECT_NEAR(0,    wrap_2PI(-M_2PI), accuracy);
 }
 
+TEST(IsValidOctal, Valid)
+{
+    EXPECT_TRUE(is_valid_octal(7777));
+    EXPECT_TRUE(is_valid_octal(777));
+    EXPECT_TRUE(is_valid_octal(77));
+    EXPECT_TRUE(is_valid_octal(7));
+    EXPECT_TRUE(is_valid_octal(0));
+    EXPECT_TRUE(is_valid_octal(1111));
+    EXPECT_TRUE(is_valid_octal(111));
+    EXPECT_TRUE(is_valid_octal(11));
+    EXPECT_TRUE(is_valid_octal(1));
+    EXPECT_TRUE(is_valid_octal(0));
+    EXPECT_TRUE(is_valid_octal(7654));
+    EXPECT_TRUE(is_valid_octal(321));
+    EXPECT_TRUE(is_valid_octal(23));
+    EXPECT_TRUE(is_valid_octal(5));
+    EXPECT_TRUE(is_valid_octal(5));
+}
+
+TEST(IsValidOctal, Invalid)
+{
+    EXPECT_FALSE(is_valid_octal(8888));
+    EXPECT_FALSE(is_valid_octal(888));
+    EXPECT_FALSE(is_valid_octal(88));
+    EXPECT_FALSE(is_valid_octal(8));
+    EXPECT_FALSE(is_valid_octal(9));
+
+    EXPECT_FALSE(is_valid_octal(7778));
+    EXPECT_FALSE(is_valid_octal(7788));
+    EXPECT_FALSE(is_valid_octal(7888));
+    EXPECT_FALSE(is_valid_octal(8888));
+}
+
 AP_GTEST_MAIN()
 
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Add tests for same function.

Saves 48 bytes.

We can save another 12 bytes with this implementation:

```
    char *outptr = ultoa_invert(octal, buffer, 10);
    for (char *s = buffer; s != outptr; s++) {
        if (*s > '7') {
             return false;
         }
     }
```

I think that's a little too much, however.
