### PR TITLE
SITL: add basic support for visual odometry simulation

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2112,6 +2112,9 @@ class AutoTest(ABC):
     def uses_vicon(self):
         return False
 
+    def uses_viso(self):
+        return False
+
     def defaults_filepath(self):
         return None
 
@@ -2151,6 +2154,7 @@ class AutoTest(ABC):
                                     speedup=self.speedup,
                                     valgrind=self.valgrind,
                                     vicon=self.uses_vicon(),
+                                    viso=self.uses_viso(),
                                     wipe=True,
                                     )
 

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -241,6 +241,7 @@ def start_SITL(binary,
                breakpoints=[],
                disable_breakpoints=False,
                vicon=False,
+               viso=False,
                lldb=False):
     """Launch a SITL instance."""
     cmd = []
@@ -320,6 +321,8 @@ def start_SITL(binary,
         cmd.extend(['--unhide-groups'])
     if vicon:
         cmd.extend(["--uartF=sim:vicon:"])
+    if viso:
+        cmd.extend(["--uartG=sim:viso:"])
 
     if gdb and not os.getenv('DISPLAY'):
         subprocess.Popen(cmd)

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -222,6 +222,12 @@ int SITL_State::sim_fd(const char *name, const char *arg)
         }
         vicon = new SITL::Vicon();
         return vicon->fd();
+    } else if (streq(name, "viso")) {
+        if (viso != nullptr) {
+            AP_HAL::panic("Only one visual odometry system at a time");
+        }
+        viso = new SITL::VisualOdometry();
+        return viso->fd();
     }
     AP_HAL::panic("unknown simulated device: %s", name);
 }
@@ -356,6 +362,12 @@ void SITL_State::_fdm_input_local(void)
         Quaternion attitude;
         sitl_model->get_attitude(attitude);
         vicon->update(sitl_model->get_location(),
+                      sitl_model->get_position(),
+                      attitude);
+    } else if (viso != nullptr) {
+        Quaternion attitude;
+        sitl_model->get_attitude(attitude);
+        viso->update(sitl_model->get_location(),
                       sitl_model->get_position(),
                       attitude);
     }

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -24,6 +24,7 @@
 #include <SITL/SIM_Gimbal.h>
 #include <SITL/SIM_ADSB.h>
 #include <SITL/SIM_Vicon.h>
+#include <SITL/SIM_VisualOdometry.h>
 #include <AP_HAL/utility/Socket.h>
 
 class HAL_SITL;
@@ -221,6 +222,9 @@ private:
 
     // simulated vicon system:
     SITL::Vicon *vicon;
+
+    // simulated visual odometry system:
+    SITL::VisualOdometry *viso;
 
     // output socket for flightgear viewing
     SocketAPM fg_socket{true};

--- a/libraries/SITL/SIM_VisualOdometry.cpp
+++ b/libraries/SITL/SIM_VisualOdometry.cpp
@@ -1,0 +1,195 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  visual odometry simulator class
+*/
+
+#include "SIM_VisualOdometry.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+using namespace SITL;
+
+VisualOdometry::VisualOdometry()
+{
+    int tmp[2];
+    if (pipe(tmp) == -1) {
+        AP_HAL::panic("pipe() failed");
+    }
+    fd_my_end    = tmp[1];
+    fd_their_end = tmp[0];
+
+    // close file descriptors on exec:
+    fcntl(fd_my_end, F_SETFD, FD_CLOEXEC);
+    fcntl(fd_their_end, F_SETFD, FD_CLOEXEC);
+
+    // make sure we don't screw the simulation up by blocking:
+    fcntl(fd_my_end, F_SETFL, fcntl(fd_my_end, F_GETFL, 0) | O_NONBLOCK);
+    fcntl(fd_their_end, F_SETFL, fcntl(fd_their_end, F_GETFL, 0) | O_NONBLOCK);
+
+    if (!valid_channel(mavlink_ch)) {
+        AP_HAL::panic("Invalid mavlink channel");
+    }
+}
+
+void VisualOdometry::maybe_send_heartbeat()
+{
+    const uint32_t now = AP_HAL::millis();
+
+    if (now - last_heartbeat_ms < 100) {
+        // we only provide a heartbeat every so often
+        return;
+    }
+    last_heartbeat_ms = now;
+
+    mavlink_message_t msg;
+    mavlink_msg_heartbeat_pack(system_id,
+                               component_id,
+                               &msg,
+                               MAV_TYPE_GCS,
+                               MAV_AUTOPILOT_INVALID,
+                               0,
+                               0,
+                               0);
+}
+
+void VisualOdometry::update_vision_position_estimate(Vector3f &position, Quaternion &attitude)
+{
+    const uint64_t now_us = AP_HAL::micros64();
+
+    if (time_offset_us == 0) {
+        time_offset_us = (unsigned(random()) % 7000) * 1000000ULL;
+        printf("time_offset_us %llu\n", (long long unsigned)time_offset_us);
+    }
+    
+    if (time_send_us && now_us >= time_send_us) {
+        uint8_t msgbuf[300];
+        uint16_t msgbuf_len = mavlink_msg_to_send_buffer(msgbuf, &obs_msg);
+
+        if (::write(fd_my_end, (void*)&msgbuf, msgbuf_len) != msgbuf_len) {
+            ::fprintf(stderr, "VisualOdometry: write failure\n");
+        }
+        time_send_us = 0;
+    }
+    if (time_send_us != 0) {
+        // waiting for the last msg to go out
+        return;
+    }
+
+    if (now_us - last_observation_usec < 70000) {
+        // create observations at 70ms intervals (matches EK2 max rate)
+        return;
+    }
+
+    float roll;
+    float pitch;
+    float yaw;
+    attitude.to_euler(roll, pitch, yaw);
+
+    // VISION_POSITION_ESTIMATE message
+    mavlink_msg_vision_position_estimate_pack_chan(
+        system_id,
+        component_id,
+        mavlink_ch,
+        &obs_msg,
+        now_us + time_offset_us,
+        position.x,
+        position.y,
+        position.z,
+        roll,
+        pitch,
+        yaw,
+        NULL, 0);
+
+    uint32_t delay_ms = 25 + unsigned(random()) % 300;
+    time_send_us = now_us + delay_ms * 1000UL;
+}
+
+bool VisualOdometry::init_sitl_pointer()
+{
+    if (_sitl == nullptr) {
+        _sitl = AP::sitl();
+        if (_sitl == nullptr) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void VisualOdometry::save_original_state(const Vector3f &position, const Quaternion &attitude)
+{
+    original_position = position;
+    original_attitude = attitude;
+}
+/*
+ * simulate the normal behaviour of visual odometry
+ */
+void VisualOdometry::simulate_normal_behaviour(Vector3f &simulated_position,
+                                        Quaternion &simulated_attitude,
+                                        const Vector3f &true_position,
+                                        const Quaternion &true_attitude,
+                                        float scale_factor)
+{
+    // apply offsets so that the origin is (0,0,0) and heading is 0
+    simulated_position = true_position - original_position;
+    simulated_attitude = true_attitude * original_attitude.inverse();
+
+    // position from visual odometry might be off from ground truth by a scale factor
+    const Vector3f scale(scale_factor, scale_factor, scale_factor);
+    simulated_position *= scale;
+}
+
+/*
+  update simulated visual odometry state based on true state
+ */
+void VisualOdometry::update(const Location &true_loc, const Vector3f &true_position, const Quaternion &true_attitude)
+{
+    if (!init_sitl_pointer()) {
+        return;
+    }
+
+    // use SIM_VISO_ENABLE param to start and stop sending visual odometry messages
+    if (_sitl->viso_enable) {
+        Vector3f simulated_position;
+        Quaternion simulated_attitude;
+
+        maybe_send_heartbeat();
+
+        simulate_normal_behaviour(simulated_position, simulated_attitude, true_position, true_attitude, _sitl->viso_scale_factor);
+
+        // different scenarios that might happen during operation
+        // for now, we only handle position-related cases
+        if (_sitl->viso_error_type == SITL::SITL::SITL_VISOFail_Diverge) {
+            // when divergence happens, position will gradually move to infinity from last good position
+            static Vector3f diverged_position = simulated_position;
+
+            diverged_position *= _sitl->viso_divergence_rate;
+
+            simulated_position = diverged_position;
+        } else if (_sitl->viso_error_type == SITL::SITL::SITL_VISOFail_Jump) {
+            // when loop closure or relocalization occur, position will suddenly jump erratically in any direction
+            // after which the position will resume normal behavior.
+            static Vector3f jump_vector(1, 1, 1); // an example jump of 1m in all directions
+
+            simulated_position += jump_vector;
+        }
+
+        update_vision_position_estimate(simulated_position, simulated_attitude);
+    } else {
+        // original position and heading of visual odometry are reset everytime viso is enabled
+        save_original_state(true_position, true_attitude);
+    }
+}

--- a/libraries/SITL/SIM_VisualOdometry.h
+++ b/libraries/SITL/SIM_VisualOdometry.h
@@ -1,0 +1,79 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  visual odometry simulator class
+*/
+
+#pragma once
+
+#include "SIM_Aircraft.h"
+
+#include <SITL/SITL.h>
+
+#include <AP_HAL/utility/RingBuffer.h>
+
+namespace SITL {
+
+class VisualOdometry {
+public:
+
+    VisualOdometry();
+
+    // update state
+    void update(const Location &true_loc, const Vector3f &true_position, const Quaternion &true_attitude);
+
+    // return fd on which data from the device can be read, and data
+    // to the device can be written
+    int fd() { return fd_their_end; }
+
+private:
+
+    SITL *_sitl;
+
+    // TODO: make these parameters:
+    const uint8_t system_id = 17;
+    const uint8_t component_id = 18;
+
+    // we share channels with the ArduPilot binary!
+    const mavlink_channel_t mavlink_ch = (mavlink_channel_t)(MAVLINK_COMM_0+5);
+
+    int fd_their_end;
+    int fd_my_end;
+
+    uint32_t last_heartbeat_ms;
+    uint64_t last_observation_usec;
+    uint64_t time_send_us;
+    uint64_t time_offset_us;
+    mavlink_message_t obs_msg;
+    
+    Vector3f original_position;
+    Quaternion original_attitude;
+
+    void save_original_state(const Vector3f &position, const Quaternion &attitude);
+
+    void simulate_normal_behaviour(Vector3f &simulated_position, 
+                              Quaternion &simulated_attitude, 
+                              const Vector3f &true_position, 
+                              const Quaternion &true_attitude,
+                              float scale_factor);
+
+    void update_vision_position_estimate(Vector3f &true_position, Quaternion &true_attitude);
+
+    void maybe_send_heartbeat();
+
+    bool init_sitl_pointer();
+};
+
+}

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -189,6 +189,12 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     // extra delay per main loop
     AP_GROUPINFO("LOOP_DELAY",  55, SITL,  loop_delay, 0),
 
+    // parameters for visual odometry 
+    AP_GROUPINFO("VISO_ENABLE", 56, SITL,  viso_enable, 0),
+    AP_GROUPINFO("VISO_SCALE",  57, SITL,  viso_scale_factor, 1.0f),
+    AP_GROUPINFO("VISO_ERROR",  58, SITL,  viso_error_type, 0),
+    AP_GROUPINFO("VISO_DIVRATE",  59, SITL,  viso_divergence_rate, 1.01f),
+
     AP_GROUPEND
 
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -236,6 +236,18 @@ public:
     AP_Int8 gyro_fail_mask;
     AP_Int8 accel_fail_mask;
 
+    // visual odometry: scale factor and error types
+    AP_Int8 viso_enable;
+    AP_Int8 viso_error_type;
+    AP_Float viso_scale_factor;
+    AP_Float viso_divergence_rate;
+
+    enum SITL_VISOFail {
+        SITL_VISOFail_None = 0,
+        SITL_VISOFail_Diverge = 1,
+        SITL_VISOFail_Jump = 2,
+    };
+
     struct {
         AP_Float x;
         AP_Float y;


### PR DESCRIPTION
With many new developments for visual odometry (VO), it would be very helpful to have SITL support so that we can replicate and investigate issues that happen in various scenarios. This PR attempts to provide a simulated VO system onboard the vehicle. 

The normal operation of the simulated VO system is:
- Start the simulation with VO system attached to UARTB (similar to Vicon):
```
./Tools/autotest/sim_vehicle.py -v ArduCopter --gdb --debug -A "--uartB=sim:viso:" --map --console
```
- **Enable** with `param set SIM_VISO_ENABLE 1`. VO system always starts at `(0, 0, 0)` and have a heading of `0`. Upon enabling the simulated VO will start sending `VISION_POSITION_ESTIMATE` message to the vehicle.
- **Disable** with `param set SIM_VISO_ENABLE 0`, which would stop sending the message immediately. When the system is enabled again, the original position and heading are reset.

In this first PR, 3 of the most frequent kinds of issues encountered with VO is simulated:
1. **Scale**. The position from odometry might be off, in some cases up to 20-30%, of the true value. 
  -- **Usage**: scale can be modified with `SIM_VISO_SCALE`. For example, `param set SIM_VISO_SCALE 0.9` will make moving 1m in any axis into 0.9m in reported position in the message.
2. **Divergence**. When divergence occurs, the position will exponentially or gradually increase to infinity. In this PR we shall implement the former.
  -- **Usage**: first define divergence rate, e.g. `param set SIM_VISO_DIVRATE 1.01` is 1% increase of position in each step. Start the divergence with `param set SIM_VISO_ERROR 1`.
3. **Jumping**: In most SLAM systems, when loop closure / relocalization function is enabled, the position might jump erratically at certain locations in the map. For now, we simulate this as a jump of 1m in all xyz directions. 
 -- **Usage**: start the jump with `param set SIM_VISO_ERROR 1`. Set the param to 0 then 1 to jump again.

This is by no means a thorough simulation of VO, but I hope this can be a stepping stone for upcoming developments in the codebase.

------
Some observations:
- Compared with the current ``SIM_Vicon``, which also utilizes the `VISION_POSITION_ESTIMATE` message, some of the most noticable differences are:

| Feature | SIM_Vicon | SIM_VisualOdometry  |
| ------------- |:-------------:|:-----:|
| Position type | Absolute (fixed world frame) | Relative (world frame is set at first camera frame)|
| Possible MAVLink messages | [VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE), [VICON_POSITION_ESTIMATE ](https://mavlink.io/en/messages/common.html#VICON_POSITION_ESTIMATE) | [VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE), [VISION_SPEED_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_SPEED_ESTIMATE), [ODOMETRY](https://mavlink.io/en/messages/common.html#ODOMETRY), [VISION_POSITION_DELTA](https://mavlink.io/en/messages/ardupilotmega.html#VISION_POSITION_DELTA) |
| Potential issues | Occlusion (temporarily lost of data)      | Scale offset, divergence, tracking lost, jumping (due to loop closure or relocalizatoin), drift, etc. each with different variations |

Thus, I believe there would be more room for future developments by separating the two types instead of building on top of the existing `SIM_Vicon`.

- In my SITL tests, most of the times when divergence occurs the copter would keep moving a bit before `EKF Variance` error appears, subsequently it would switch to `land`. 

- Jumping of 1m when the vehicle is moving does not seem to have any effect, but when the vehicle is stationary in some cases I encounter `EKF variance error`.

- With `COMPASS_USE` enable, the heading will start at some direction of compass, then slowly moves to 0, similar to what I observe with real copter. In my tests, I usually disable all compass with `param set COMPASS_USE 0` as well as `COMPASS_USE2` and `COMPASS_USE3`.