### PR TITLE
Rover: remove duplicate get stopping location code

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -451,31 +451,6 @@ void Mode::calc_steering_to_heading(float desired_heading_cd, float rate_max_deg
     set_steering(steering_out * 4500.0f);
 }
 
-// calculate vehicle stopping point using current location, velocity and maximum acceleration
-void Mode::calc_stopping_location(Location& stopping_loc)
-{
-    // default stopping location
-    stopping_loc = rover.current_loc;
-
-    // get current velocity vector and speed
-    const Vector2f velocity = ahrs.groundspeed_vector();
-    const float speed = velocity.length();
-
-    // avoid divide by zero
-    if (!is_positive(speed)) {
-        stopping_loc = rover.current_loc;
-        return;
-    }
-
-    // get stopping distance in meters
-    const float stopping_dist = attitude_control.get_stopping_distance(speed);
-
-    // calculate stopping position from current location in meters
-    const Vector2f stopping_offset = velocity.normalized() * stopping_dist;
-
-    stopping_loc.offset(stopping_offset.x, stopping_offset.y);
-}
-
 void Mode::set_steering(float steering_value)
 {
     if (allows_stick_mixing() && g2.stick_mixing > 0) {

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -186,9 +186,6 @@ protected:
     //  reversed should be true if the vehicle is intentionally backing up which allows the pilot to increase the backing up speed by pulling the throttle stick down
     float calc_speed_nudge(float target_speed, bool reversed);
 
-    // calculate vehicle stopping location using current location, velocity and maximum acceleration
-    void calc_stopping_location(Location& stopping_loc);
-
 protected:
 
     // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -4,7 +4,9 @@
 bool ModeLoiter::_enter()
 {
     // set _destination to reasonable stopping point
-    calc_stopping_location(_destination);
+    if (!g2.wp_nav.get_stopping_location(_destination)) {
+        return false;
+    }
 
     // initialise desired speed to current speed
     if (!attitude_control.get_forward_speed(_desired_speed)) {

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -81,6 +81,10 @@ public:
     float get_overshoot() const { return _overshoot; }
     float get_pivot_rate() const { return _pivot_rate; }
 
+    // calculate stopping location using current position and attitude controller provided maximum deceleration
+    // returns true on success, false on failure
+    bool get_stopping_location(Location& stopping_loc) WARN_IF_UNUSED;
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -100,10 +104,6 @@ private:
     // relies on update_distance_and_bearing_to_destination and update_steering being run so these internal members
     // have been updated: _wp_bearing_cd, _cross_track_error, _distance_to_destination
     void update_desired_speed(float dt);
-
-    // calculate stopping location using current position and attitude controller provided maximum deceleration
-    // returns true on success, false on failure
-    bool get_stopping_location(Location& stopping_loc) WARN_IF_UNUSED;
 
     // returns true if vehicle should pivot turn at next waypoint
     bool use_pivot_steering_at_next_WP(float yaw_error_cd) const;


### PR DESCRIPTION
while poking about in rover I noticed this functionality is duplicated in mode.cpp and AR_WPNav.cpp. This removes the mode.ccp version in favor of the AR_WPNav function that is now public.

should be no functional change, I have tested loiter still works in SITL.