### PR TITLE
AP_OSD: add current averaging filter to reduce jitter (~3 sample time constant)

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -283,4 +283,5 @@ private:
     float max_alt_m;
     float max_speed_mps;
     float max_current_a;
+    float avg_current_a;
 };

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -935,13 +935,15 @@ void AP_OSD_Screen::draw_current(uint8_t x, uint8_t y)
     AP_BattMonitor &battery = AP::battery();
     float amps;
     if (!battery.current_amps(amps)) {
-        amps = 0;
+        osd->avg_current_a = 0;
     }
-    if (amps < 10.0) {
-        backend->write(x, y, false, "%2.2f%c", amps, SYM_AMP);
+    //filter current and display with autoranging for low values
+    osd->avg_current_a= osd->avg_current_a + (amps - osd->avg_current_a) * 0.33;
+    if (osd->avg_current_a < 10.0) {
+        backend->write(x, y, false, "%2.2f%c", osd->avg_current_a, SYM_AMP);
     }
     else {
-        backend->write(x, y, false, "%2.1f%c", amps, SYM_AMP);
+        backend->write(x, y, false, "%2.1f%c", osd->avg_current_a, SYM_AMP);
     }
 }
 


### PR DESCRIPTION
because current can be displayed now down to 1/100 of amp, noise, especially in brushed motor setups, produces very jittery display.....this smooths it, but is still very responsive...
looks much better in the OSD display...takes only about 5 samples to respond  90%+ to full on to off step function, but reduces jitter to the point its almost unnoticeable..