### PR TITLE
AP_OSD: distance total fix for slow vehicles

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -251,7 +251,7 @@ void AP_OSD::stats()
     AP_AHRS &ahrs = AP::ahrs();
     Vector2f v = ahrs.groundspeed_vector();
     float speed = v.length();
-    if (speed < 2.0) {
+    if (speed < 0.178) {
         speed = 0.0;
     }
     float dist_m = (speed * delta_ms)*0.001;


### PR DESCRIPTION
when I first created this panel, I  prevented accumulation unless speed was >2m/s....fine for copters and planes, but too high for rovers,especially boats....this lowers the value...

tested on a sloooow vehicle....total dist traveled now works for 1.5mph boats...