### PR TITLE
Septentrio AsteRx-i S (gps with imu solution) and AsteRx-m2 (dual antenna) integration

### DIFF
--- a/README_SEPTENTRIO_INS_PRE_CONFIG.md
+++ b/README_SEPTENTRIO_INS_PRE_CONFIG.md
@@ -1,0 +1,42 @@
+# Pre-Config of the AsteRx-i or AsteRx-m2 dual antenna setup
+
+If Septentrio INS is selected (GPS_TYPE = 17) a pre-config of the AsteRx-i or AsteRx-m2 dual antenna setup is required. This can be done trough RX-tools or connecting the AsteRx with a com port and sending the commands over serial communication.
+
+The \n indicates a newline and is needed for the AsteRx to interpret a new command.
+
+## AsteRx-i
+
+The following commands has to be set:
+
+Define on which com-port the imu is connected to. For example com3
+    setIMUInput, COM3\n
+
+Define the imu orientation with respect to your drone setup. For default setup use the following command
+    setIMUOrientation, SensorDefault\n
+
+    If the imu is not placed with de x-axis pointing to the front of the drone and placed horizontally and upside up, use following command
+        setIMUOrientation, rotationAngle-x, rotationAngle-y, rotationAngel-z <CR>
+
+        for example:
+            90° rotation around the z-axis:
+                setIMUOrientation, 0, 0, 90\n
+            90° rotation around the x-axis and 270° around the z-axis:
+                setIMUOrientation, 90, 0, 270\n
+
+Define the antenna lever arm in the drone reference frame. This is the offset in x,y and z between the IMU reference point to the arp of the main GNNS antenna  
+    setINSAntLeverArm, x, y, z\n
+
+Optionally the point of interest can be defined. By default the position is calculated at the IMU reference point. If this is not the point of interest the x,y and z offset can be set to the desire point of interest (for example a camera)
+    setINSPOILeverArm, POI1, x, y, z\n
+
+Make sure the INS/GNSS integration filter is enabled (normally it is by default)
+    setINSNAvConfig, on\n
+
+## AsteRx-m2 dual antenna setup
+
+If only the AsterRx-m2 dual antenna setup is used the only command to us in pre-configuration is the attitude offset. The offset is defined in degrees
+    setAttitudeOffset, antennaOffset\n
+    for example the aux1 antenna is on the right of the main antenna (Default):
+    setAttitudeOffset, 90\n
+    Or to the left of the main antenna:
+    setAttitudeOffset, -90\n

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: TYPE
     // @DisplayName: GPS type
     // @Description: GPS type
-    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:SBFINS
+    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:SBFINS,18:SBFDUALANTENNA
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("TYPE",    0, AP_GPS, _type[0], HAL_GPS_TYPE_DEFAULT),
@@ -82,7 +82,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: TYPE2
     // @DisplayName: 2nd GPS type
     // @Description: GPS type of 2nd GPS
-    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:SBFINS
+    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:SBFINS,18:SBFDUALANTENNA
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("TYPE2",   1, AP_GPS, _type[1], 0),
@@ -478,11 +478,15 @@ void AP_GPS::detect_instance(uint8_t instance)
     switch (_type[instance]) {
     // by default the sbf/trimble gps outputs no data on its port, until configured.
     case GPS_TYPE_SBF:
-        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance], false);
+        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance], 0);
         break;
 
     case GPS_TYPE_SBFINS:
-        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance], true);
+        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance], 1);
+        break;
+
+    case GPS_TYPE_SBFDUALANTENNA:
+        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance], 2);
         break;
 
     case GPS_TYPE_GSOF:

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: TYPE
     // @DisplayName: GPS type
     // @Description: GPS type
-    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA
+    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:SBFINS
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("TYPE",    0, AP_GPS, _type[0], HAL_GPS_TYPE_DEFAULT),
@@ -82,7 +82,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: TYPE2
     // @DisplayName: 2nd GPS type
     // @Description: GPS type of 2nd GPS
-    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA
+    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:SBFINS
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("TYPE2",   1, AP_GPS, _type[1], 0),
@@ -478,7 +478,11 @@ void AP_GPS::detect_instance(uint8_t instance)
     switch (_type[instance]) {
     // by default the sbf/trimble gps outputs no data on its port, until configured.
     case GPS_TYPE_SBF:
-        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance]);
+        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance], false);
+        break;
+
+    case GPS_TYPE_SBFINS:
+        new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance], true);
         break;
 
     case GPS_TYPE_GSOF:

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -92,6 +92,7 @@ public:
         GPS_TYPE_MAV = 14,
         GPS_TYPE_NOVA = 15,
         GPS_TYPE_HEMI = 16, // hemisphere NMEA
+        GPS_TYPE_SBFINS = 17,
     };
 
     /// GPS status codes
@@ -135,9 +136,12 @@ public:
         uint32_t time_week_ms;              ///< GPS time (milliseconds from start of GPS week)
         uint16_t time_week;                 ///< GPS week number
         Location location;                  ///< last fix location
+        uint8_t atteulerMode;               ///< mode in which the Attitude is computed
         float ground_speed;                 ///< ground speed in m/sec
         float ground_course;                ///< ground course in degrees
         float gps_yaw;                      ///< GPS derived yaw information, if available (degrees)
+        float gps_pitch;                    ///< GPS derived pitch information, if available (degrees)
+        float gps_roll;                     ///< GPS derived roll information, if available (degrees)
         uint16_t hdop;                      ///< horizontal dilution of precision in cm
         uint16_t vdop;                      ///< vertical dilution of precision in cm
         uint8_t num_sats;                   ///< Number of visible satellites
@@ -150,6 +154,8 @@ public:
         bool have_horizontal_accuracy;    ///< does GPS give horizontal position accuracy? Set to true only once available.
         bool have_vertical_accuracy;      ///< does GPS give vertical position accuracy? Set to true only once available.
         bool have_gps_yaw;                ///< does GPS give yaw? Set to true only once available.
+        bool have_gps_roll;               ///< does GPS give roll? Set to true only once available.  
+        bool have_gps_pitch;              ///< does GPS give pitch? Set to true only once available. 
         uint32_t last_gps_time_ms;          ///< the system time we got the last GPS timestamp, milliseconds
         uint32_t uart_timestamp_ms;         ///< optional timestamp from set_uart_timestamp()
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -92,7 +92,8 @@ public:
         GPS_TYPE_MAV = 14,
         GPS_TYPE_NOVA = 15,
         GPS_TYPE_HEMI = 16, // hemisphere NMEA
-        GPS_TYPE_SBFINS = 17,
+        GPS_TYPE_SBFINS = 17, // Septentrio gps with imu corrections (AsterRx-i S)
+        GPS_TYPE_SBFDUALANTENNA = 18, // Septentrio with dual antenna (AsteRx-m2)
     };
 
     /// GPS status codes

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -29,7 +29,7 @@
 class AP_GPS_SBF : public AP_GPS_Backend
 {
 public:
-    AP_GPS_SBF(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port, bool _asterx_i);
+    AP_GPS_SBF(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port, uint8_t _asterx_setup);
 
     AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
@@ -58,8 +58,6 @@ private:
     static const uint8_t SBF_PREAMBLE1 = '$';
     static const uint8_t SBF_PREAMBLE2 = '@';
 
-    sso, Stream1, COM1, PVTGeodetic+VelCovGeodetic, msec200
-
     uint8_t _init_blob_index = 0;
     uint32_t _init_blob_time = 0;
     const char* _initialisation_blob[5] = {
@@ -69,11 +67,17 @@ private:
     "spm, Rover, all\n",
     "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, msec100\n"};
     const char* _initialisation_blob_i[5] = {
-    "sso, Stream1, COM1, INSNavGeod+DOP+ReceiverStatus+VelCovGeodetic,sec1\n",
+    "sso, Stream1, COM1, PVTGeodetic+INSNavGeod+DOP+ReceiverStatus+VelCovGeodetic, msec100\n",
     "srd, Moderate, UAV\n",
     "sem, PVT, 5\n",
     "spm, Rover, all\n",
-    "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, sec1\n"};
+    "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, msec100\n"};
+    const char* _initialisation_blob_dualantenna[5] = {
+    "sso, Stream1, COM1, PVTGeodetic+AttEuler+DOP+ReceiverStatus+VelCovGeodetic, msec100\n",
+    "srd, Moderate, UAV\n",
+    "sem, PVT, 5\n",
+    "spm, Rover, all\n",
+    "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, msec100\n"};
     uint32_t _config_last_ack_time;
 
     const char* _port_enable = "\nSSSSSSSSSS\n";
@@ -85,7 +89,9 @@ private:
     void mount_disk(void) const;
     void unmount_disk(void) const;
     bool _has_been_armed;
+    bool _asterx_type_is_singleantenna;
     bool _asterx_type_is_i;
+    bool _asterx_type_is_dualantenna;
 
     enum sbf_ids {
         DOP = 4001,
@@ -189,27 +195,28 @@ private:
         uint16_t Accuracy;
         uint16_t Latency;
         uint8_t Datum;
+        uint8_t Reserved;
         uint16_t SBList;
         // INSNavGeodPosStdDev sub-block
-        double LatitudeStdDev;
-        double LongitudeStdDev;
-        double HeightStdDev;
+        float LatitudeStdDev;
+        float LongitudeStdDev;
+        float HeightStdDev;
         // INSNavGeodAtt sub-block
-        double Heading;
-        double Pitch;
-        double Roll;
+        float Heading;
+        float Pitch;
+        float Roll;
         // INSNavGeodAttStdDev sub-block
-        double HeadingStdDev;
-        double PitchStdDev;
-        double RollStdDev;
+        float HeadingStdDev;
+        float PitchStdDev;
+        float RollStdDev;
         // INSNavGeodVel sub-block
-        double Ve;
-        double Vn;
-        double Vu;
+        float Ve;
+        float Vn;
+        float Vu;
         // INSNavGeodVelStdDev sub-block
-        double VestdDev;
-        double VnStdDev;
-        double VuStdDev;
+        float VestdDev;
+        float VnStdDev;
+        float VuStdDev;
     };
 
     struct PACKED msg5938 // AttEuler 


### PR DESCRIPTION
This pull request is to add the Septentrio AsteRx-i S and the AsteRx-m2 receivers support in Arducopter.
 
The AsteRx-i S is a gps receiver with an imu integration. This receiver generates a sbf messages called INSNAvGeod and includes the position information enhanced by the imu and the attitude of the imu. This message is included in this branche and the yaw, roll and pitch are parsed but the roll and pitch is only stored in a variable. Roll and Pitch are not included in the ekf3 like yaw is (something to consider?). 

The AsteRx-m2 is a gps receiver capable of using 2 gps antennas so it also gives the heading and pitch (or roll if the antenna setup is configured accordingly). This receiver generates the sbf message AttEuler and delivers the heading, roll and pitch. Only the pitch and heading can be used because the roll can not be calculated by dual antennas. Septentrio has included the roll in the AttEuler message for future use. 

We have added two new gps types under parameter GPS_TYPE and GPS_TYPE2. number 17 for SBFINS (AsteRx-i S) and 18 for SBFDUALANTENNA (AsteRx-m2).

Also we added a readme for the optional pre-configuration of the antennas and/or imu of the receivers.

This addition to the code is written by Airobot N.V. Belgium  