### PR TITLE
Fixed build with g++ 7.3.1 for stm32

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -425,7 +425,6 @@ class chibios(Board):
 
         env.DEFINES.update(
             CONFIG_HAL_BOARD = 'HAL_BOARD_CHIBIOS',
-            HAVE_OCLOEXEC = 0,
             HAVE_STD_NULLPTR_T = 0,
         )
 

--- a/libraries/AP_Common/missing/fcntl.h
+++ b/libraries/AP_Common/missing/fcntl.h
@@ -1,9 +1,0 @@
-#include_next <fcntl.h>
-
-/*
- * we only want to define as 0 for those targets in which it doesn't make
- * sense
- */
-#if defined(HAVE_OCLOEXEC) && HAVE_OCLOEXEC == 0
-#define O_CLOEXEC 0
-#endif

--- a/libraries/AP_HAL/AP_HAL_Macros.h
+++ b/libraries/AP_HAL/AP_HAL_Macros.h
@@ -13,6 +13,9 @@
 #define ALLOW_DOUBLE_MATH_FUNCTIONS
 #endif
 
+// we need to include math.h here for newer compilers (eg. g++ 7.3.1 for stm32)
+#include <math.h>
+
 #if !defined(ALLOW_DOUBLE_MATH_FUNCTIONS)
 /* give warnings if we use double precision maths functions without
    specifying ALLOW_DOUBLE_TRIG_FUNCTIONS. Code should use the


### PR DESCRIPTION
This allows us to build with the standard compiler for Ubuntu 19.04
Also tested with g++ 8.3.1 20190703
Added NeedsTesting as we need to test fly this to ensure we are fully functional with newer compiler. UAVCAN also needs testing