### PR TITLE
Add common scratch variables between EK2 and EK3

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_core_common.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core_common.cpp
@@ -1,0 +1,39 @@
+/*
+  NavEKF_core_common holds scratch data shared by EKF2 and EKF3
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "AP_NavEKF_core_common.h"
+
+NavEKF_core_common::Matrix24 NavEKF_core_common::KH;
+NavEKF_core_common::Matrix24 NavEKF_core_common::KHP;
+NavEKF_core_common::Matrix24 NavEKF_core_common::nextP;
+NavEKF_core_common::Vector28 NavEKF_core_common::Kfusion;
+
+/*
+  fill common scratch variables, for detecting re-use of variables between loops in SITL
+ */
+void NavEKF_core_common::fill_scratch_variables(void)
+{
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // fill the common variables with NaN, so we catch any cases in
+    // SITL where they are used without initialisation. These are all
+    // supposed to be scratch variables that are not used between
+    // iterations
+    fill_nanf(&KH[0][0], sizeof(KH)/sizeof(float));
+    fill_nanf(&KHP[0][0], sizeof(KHP)/sizeof(float));
+    fill_nanf(&nextP[0][0], sizeof(nextP)/sizeof(float));
+    fill_nanf(&Kfusion[0], sizeof(Kfusion)/sizeof(float));
+#endif
+}

--- a/libraries/AP_NavEKF/AP_NavEKF_core_common.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core_common.h
@@ -1,0 +1,51 @@
+/*
+  NavEKF_core_common holds scratch data shared by EKF2 and EKF3
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <AP_Math/AP_Math.h>
+
+/*
+  this declares a common parent class for AP_NavEKF2 and
+  AP_NavEKF3. The purpose of this class is to hold common static
+  scratch space variables. These variables do not hold anything that
+  matters between iterations, they are only intermediate variables. By
+  placing these in a common parent class we save a lot of memory, but
+  we also save a lot of CPU (approx 10% on STM32F427) as the compiler
+  is able to resolve the address of these variables at compile time,
+  which means significantly faster code
+ */
+class NavEKF_core_common {
+public:
+    typedef float ftype;
+#if MATH_CHECK_INDEXES
+    typedef VectorN<ftype,28> Vector28;
+    typedef VectorN<VectorN<ftype,24>,24> Matrix24;
+#else
+    typedef ftype Vector28[28];
+    typedef ftype Matrix24[24][24];
+#endif
+
+protected:
+    static Matrix24 KH;                   // intermediate result used for covariance updates
+    static Matrix24 KHP;                  // intermediate result used for covariance updates
+    static Matrix24 nextP;                // Predicted covariance matrix before addition of process noise to diagonals
+    static Vector28 Kfusion;              // intermediate fusion vector
+
+    // fill all the common scratch variables with NaN on SITL
+    void fill_scratch_variables(void);
+};

--- a/libraries/AP_NavEKF/AP_NavEKF_core_common.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core_common.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Math/vectorN.h>
 
 /*
   this declares a common parent class for AP_NavEKF2 and

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -661,16 +661,6 @@ bool NavEKF2::InitialiseFilter(void)
             return false;
         }
 
-        // allocate common intermediate variable space
-        core_common = (void *)hal.util->malloc_type(NavEKF2_core::get_core_common_size(), AP_HAL::Util::MEM_FAST);
-        if (core_common == nullptr) {
-            _enable.set(0);
-            hal.util->free_type(core, sizeof(NavEKF2_core)*num_cores, AP_HAL::Util::MEM_FAST);
-            core = nullptr;
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "NavEKF2: common allocation failed");
-            return false;
-        }
-
         //Call Constructors on all cores
         for (uint8_t i = 0; i < num_cores; i++) {
             new (&core[i]) NavEKF2_core(this);

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -492,11 +492,6 @@ private:
     // time of last lane switch
     uint32_t lastLaneSwitch_ms;
 
-    /*
-      common intermediate variables used by all cores
-    */
-    void *core_common;
-
     // update the yaw reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary

--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -39,7 +39,6 @@ void NavEKF2_core::FuseAirspeed()
     float SK_TAS;
     Vector24 H_TAS;
     float VtasPred;
-    Vector28 Kfusion {};
 
     // health is set bad until test passed
     tasHealth = false;
@@ -270,7 +269,6 @@ void NavEKF2_core::FuseSideslip()
     Vector3f vel_rel_wind;
     Vector24 H_BETA;
     float innovBeta;
-    Vector28 Kfusion;
 
     // copy required states to local variable names
     q0 = stateStruct.quat[0];

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -346,7 +346,6 @@ void NavEKF2_core::FuseMagnetometer()
     Vector6 SK_MX;
     Vector6 SK_MY;
     Vector6 SK_MZ;
-    Vector28 Kfusion;
 
     hal.util->perf_end(_perf_test[1]);
     
@@ -781,7 +780,6 @@ void NavEKF2_core::fuseEulerYaw()
     float measured_yaw;
     float H_YAW[3];
     Matrix3f Tbn_zeroYaw;
-    Vector28 Kfusion;
 
     if (fabsf(prevTnb[0][2]) < fabsf(prevTnb[1][2])) {
         // calculate observation jacobian when we are observing the first rotation in a 321 sequence
@@ -1040,7 +1038,6 @@ void NavEKF2_core::FuseDeclination(float declErr)
     float t12 = 1.0f/t11;
 
     float H_MAG[24];
-    Vector28 Kfusion {};
 
     H_MAG[16] = -magE*t5;
     H_MAG[17] = magN*t5;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -438,7 +438,6 @@ void NavEKF2_core::FuseVelPosNED()
     Vector6 R_OBS; // Measurement variances used for fusion
     Vector6 R_OBS_DATA_CHECKS; // Measurement variances used for data checks only
     float SK;
-    Vector28 Kfusion;
 
     // perform sequential fusion of GPS measurements. This assumes that the
     // errors in the different velocity and position components are

--- a/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
@@ -43,7 +43,6 @@ void NavEKF2_core::FuseRngBcn()
     float bcn_pd;
     const float R_BCN = sq(MAX(rngBcnDataDelayed.rngErr , 0.1f));
     float rngPred;
-    Vector28 Kfusion;
 
     // health is set bad until test passed
     rngBcnHealth = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -30,6 +30,7 @@
 #include "AP_NavEKF2.h"
 #include <stdio.h>
 #include <AP_Math/vectorN.h>
+#include <AP_NavEKF/AP_NavEKF_core_common.h>
 #include <AP_NavEKF2/AP_NavEKF2_Buffer.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 
@@ -58,7 +59,7 @@
 
 class AP_AHRS;
 
-class NavEKF2_core
+class NavEKF2_core : public NavEKF_core_common
 {
 public:
     // Constructor
@@ -327,9 +328,6 @@ public:
     // return true when external nav data is also being used as a yaw observation
     bool isExtNavUsedForYaw(void);
 
-    // return size of core_common for use in frontend allocation
-    static uint32_t get_core_common_size(void) { return sizeof(core_common); }
-
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;
@@ -339,7 +337,6 @@ private:
     uint8_t core_index;
     uint8_t imu_buffer_length;
 
-    typedef float ftype;
 #if MATH_CHECK_INDEXES
     typedef VectorN<ftype,2> Vector2;
     typedef VectorN<ftype,3> Vector3;
@@ -359,7 +356,6 @@ private:
     typedef VectorN<ftype,24> Vector24;
     typedef VectorN<ftype,25> Vector25;
     typedef VectorN<ftype,31> Vector31;
-    typedef VectorN<ftype,28> Vector28;
     typedef VectorN<VectorN<ftype,3>,3> Matrix3;
     typedef VectorN<VectorN<ftype,24>,24> Matrix24;
     typedef VectorN<VectorN<ftype,34>,50> Matrix34_50;
@@ -382,7 +378,6 @@ private:
     typedef ftype Vector23[23];
     typedef ftype Vector24[24];
     typedef ftype Vector25[25];
-    typedef ftype Vector28[28];
     typedef ftype Matrix3[3][3];
     typedef ftype Matrix24[24][24];
     typedef ftype Matrix34_50[34][50];
@@ -484,22 +479,6 @@ private:
         uint32_t        time_ms;    // measurement timestamp (msec)
         bool            posReset;   // true when the position measurement has been reset
     };
-
-    /*
-      common intermediate variables used by all cores. These save a
-      lot memory by avoiding allocating these arrays on every core
-      Having these as stack variables would save even more memory, but
-      would give us very high stack usage in some functions, which
-      poses a risk of stack overflow until we have infrastructure in
-      place to calculate maximum stack usage using static analysis.
-      On SITL this structure is assumed to contain only float
-      variables (for the fill_nanf())
-     */
-    struct core_common {
-        Matrix24 KH;
-        Matrix24 KHP;
-        Matrix24 nextP;
-    } *common;
 
     // bias estimates for the IMUs that are enabled but not being used
     // by this core.
@@ -818,8 +797,6 @@ private:
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
-    Matrix24 &KH;                   // intermediate result used for covariance updates
-    Matrix24 &KHP;                  // intermediate result used for covariance updates
     Matrix24 P;                     // covariance matrix
     imu_ring_buffer_t<imu_elements> storedIMU;      // IMU data buffer
     obs_ring_buffer_t<gps_elements> storedGPS;      // GPS data buffer
@@ -874,7 +851,6 @@ private:
     bool allMagSensorsFailed;       // true if all magnetometer sensors have timed out on this flight and we are no longer using magnetometer data
     uint32_t lastYawTime_ms;        // time stamp when yaw observation was last fused (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)
-    Matrix24 &nextP;                // Predicted covariance matrix before addition of process noise to diagonals
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -683,16 +683,6 @@ bool NavEKF3::InitialiseFilter(void)
             return false;
         }
 
-        // allocate common intermediate variable space
-        core_common = (void *)hal.util->malloc_type(NavEKF3_core::get_core_common_size(), AP_HAL::Util::MEM_FAST);
-        if (core_common == nullptr) {
-            _enable.set(0);
-            hal.util->free_type(core, sizeof(NavEKF3_core)*num_cores, AP_HAL::Util::MEM_FAST);
-            core = nullptr;
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "NavEKF3: common allocation failed");
-            return false;
-        }
-
         // Call constructors on all cores
         for (uint8_t i = 0; i < num_cores; i++) {
             new (&core[i]) NavEKF3_core(this);

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -496,11 +496,6 @@ private:
     // time of last lane switch
     uint32_t lastLaneSwitch_ms;
 
-    /*
-      common intermediate variables used by all cores
-    */
-    void *core_common;
-
     struct {
         uint32_t last_function_call;  // last time getLastYawYawResetAngle was called
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -27,6 +27,7 @@
 #include <AP_Math/AP_Math.h>
 #include "AP_NavEKF3.h"
 #include <AP_Math/vectorN.h>
+#include <AP_NavEKF/AP_NavEKF_core_common.h>
 #include <AP_NavEKF3/AP_NavEKF3_Buffer.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 
@@ -63,7 +64,7 @@
 
 class AP_AHRS;
 
-class NavEKF3_core
+class NavEKF3_core : public NavEKF_core_common
 {
 public:
     // Constructor
@@ -366,9 +367,6 @@ public:
     // get timing statistics structure
     void getTimingStatistics(struct ekf_timing &timing);
 
-    // return size of core_common for use in frontend allocation
-    static uint32_t get_core_common_size(void) { return sizeof(core_common); }
-
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF3 *frontend;
@@ -400,7 +398,6 @@ private:
     typedef VectorN<ftype,24> Vector24;
     typedef VectorN<ftype,25> Vector25;
     typedef VectorN<ftype,31> Vector31;
-    typedef VectorN<ftype,28> Vector28;
     typedef VectorN<VectorN<ftype,3>,3> Matrix3;
     typedef VectorN<VectorN<ftype,24>,24> Matrix24;
     typedef VectorN<VectorN<ftype,34>,50> Matrix34_50;
@@ -424,7 +421,6 @@ private:
     typedef ftype Vector23[23];
     typedef ftype Vector24[24];
     typedef ftype Vector25[25];
-    typedef ftype Vector28[28];
     typedef ftype Matrix3[3][3];
     typedef ftype Matrix24[24][24];
     typedef ftype Matrix34_50[34][50];
@@ -536,21 +532,6 @@ private:
         uint8_t     type;           // type specifiying Euler rotation order used, 1 = 312 (ZXY), 2 = 321 (ZYX)
     };
 
-    /*
-      common intermediate variables used by all cores. These save a
-      lot memory by avoiding allocating these arrays on every core
-      Having these as stack variables would save even more memory, but
-      would give us very high stack usage in some functions, which
-      poses a risk of stack overflow until we have infrastructure in
-      place to calculate maximum stack usage using static analysis.
-     */
-    struct core_common {
-        Vector28 Kfusion;
-        Matrix24 KH;
-        Matrix24 KHP;
-        Matrix24 nextP;
-    } *common;
-    
     // bias estimates for the IMUs that are enabled but not being used
     // by this core.
     struct {
@@ -873,9 +854,6 @@ private:
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
-    Vector28 &Kfusion;              // Kalman gain vector
-    Matrix24 &KH;                   // intermediate result used for covariance updates
-    Matrix24 &KHP;                  // intermediate result used for covariance updates
     Matrix24 P;                     // covariance matrix
     imu_ring_buffer_t<imu_elements> storedIMU;      // IMU data buffer
     obs_ring_buffer_t<gps_elements> storedGPS;      // GPS data buffer
@@ -929,7 +907,6 @@ private:
     bool allMagSensorsFailed;       // true if all magnetometer sensors have timed out on this flight and we are no longer using magnetometer data
     uint32_t lastSynthYawTime_ms;   // time stamp when synthetic yaw measurement was last fused to maintain covariance health (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)
-    Matrix24 &nextP;                // Predicted covariance matrix before addition of process noise to diagonals
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold


### PR DESCRIPTION
This adds a common parent class for the EK2 and EK2 core classes. That parent class holds common static intermediate variables for the two EKF implementations.

The benefits are:
 - the compiler can determine the address of the frequently accessed variables at compile time, making them faster
 - the compiler can generate much smaller code
 - by sharing between EK2 and EK3 we save a lot of memory if both EK2  and EK3 are enabled
 - we can fill all these with NaN in SITL on every loop, which allows us to catch cases where the variables are ever re-used between loops, which guarantees we aren't mixing data between EKF lanes or between EK2 and EK3

On fmuv2 the numbers are:
 - saves 10k of flash
 - saves 7k of ram when EK2 and EK3 are both enabled with 2 EKF lanes
 - saves 3% of CPU in EKF updates


