### PR TITLE
Pre-fill SITL stack for main loop with NaN

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -339,10 +339,12 @@ bool rotation_equal(enum Rotation r1, enum Rotation r2)
 }
 
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 // fill an array of float with NaN, used to invalidate memory in SITL
 void fill_nanf(float *f, uint16_t count)
 {
     while (count--) {
-        *f++ = nanf("fill");
+        *f++ = std::numeric_limits<float>::signaling_NaN();
     }
 }
+#endif

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -277,5 +277,8 @@ Vector3f rand_vec3f(void);
 // return true if two rotations are equal
 bool rotation_equal(enum Rotation r1, enum Rotation r2) WARN_IF_UNUSED;
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 // fill an array of float with NaN, used to invalidate memory in SITL
 void fill_nanf(float *f, uint16_t count);
+#endif
+

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -285,7 +285,6 @@ void NavEKF2_core::FuseOptFlow()
     Vector3f relVelSensor;
     Vector14 SH_LOS;
     Vector2 losPred;
-    Vector28 Kfusion {};
 
     // Copy required states to local variable names
     float q0  = stateStruct.quat[0];

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -114,6 +114,18 @@ void AP_Scheduler::tick(void)
     _tick_counter++;
 }
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+/*
+  fill stack with NaN so we can catch use of uninitialised stack
+  variables in SITL
+ */
+static void fill_nanf_stack(void)
+{
+    float v[1024];
+    fill_nanf(v, ARRAY_SIZE(v));
+}
+#endif
+
 /*
   run one tick
   this will run as many scheduler tasks as we can in the specified time
@@ -173,6 +185,9 @@ void AP_Scheduler::run(uint32_t time_available)
         if (_debug > 1 && _perf_counters && _perf_counters[i]) {
             hal.util->perf_begin(_perf_counters[i]);
         }
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        fill_nanf_stack();
+#endif
         _tasks[i].function();
         if (_debug > 1 && _perf_counters && _perf_counters[i]) {
             hal.util->perf_end(_perf_counters[i]);


### PR DESCRIPTION
This allows us to catch use of uninitialised stack variables in SITL without having to run valgrind, which makes it more likely we will find bugs in CI