### PR TITLE
AP_SmartRTL: give warning buffer is about to fill and de-activate

### DIFF
--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -330,6 +330,7 @@ void AP_SmartRTL::run_background_cleanup()
     const uint16_t path_points_completed_limit = _path_points_completed_limit;
     _path_points_completed_limit = SMARTRTL_POINTS_MAX;
     _path_sem.give();
+    const uint32_t now = AP_HAL::millis();
 
     // check if thorough cleanup is required
     if (_thorough_clean_request_ms > 0) {
@@ -350,6 +351,13 @@ void AP_SmartRTL::run_background_cleanup()
 
     // perform routine cleanup which removes 10 to 50 points if possible
     routine_cleanup(path_points_count, path_points_completed_limit);
+
+    // warn if buffer is about to be filled
+    if ((path_points_count >0) && (path_points_count >= _path_points_max - 9) && (now - _last_low_space_notify_ms > 10000)) {
+        gcs().send_text(MAV_SEVERITY_INFO, "SmartRTL Low on space!");
+       _last_low_space_notify_ms = now;
+    }
+
 }
 
 // routine cleanup is called regularly from run_background_cleanup

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -173,6 +173,7 @@ private:
     uint32_t _last_position_save_ms;    // the system time a position was saved to the path (used for timeout)
     uint32_t _thorough_clean_request_ms;// the last system time the thorough cleanup was requested (set by thorough_cleanup method, used by background cleanup)
     uint32_t _thorough_clean_complete_ms; // set to _thorough_clean_request_ms when the background thread completes the thorough cleanup
+    uint32_t _last_low_space_notify_ms; //last time low on SmartRTL space was notified on Mavlink. Minimum time is required before re-notification to avoid nagging.
     ThoroughCleanupType _thorough_clean_type;   // used by example sketch to test simplify and prune separately
 
     // path variables


### PR DESCRIPTION
tested in SITL....tried 90%, 20 points....10 points seemed a good compromise letting one stop and start SmartRTL before running out of buffer, but not nagging when 50 points get pruned often....20 points was good also