### PR TITLE
Copter: SimpleMode variable name clarification

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -500,12 +500,12 @@ void Copter::update_simple_mode(void)
     float rollx, pitchx;
 
     // exit immediately if no new radio frame or not in simple mode
-    if (ap.simple_mode == 0 || !ap.new_radio_frame) {
+    if (ap.simple_mode == 0 || !ap.simple_mode_new_frame) {
         return;
     }
 
     // mark radio frame as consumed
-    ap.new_radio_frame = false;
+    ap.simple_mode_new_frame = false;
 
     if (ap.simple_mode == 1) {
         // rotate roll, pitch input by -initial simple heading (i.e. north facing)

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -371,7 +371,7 @@ private:
             uint8_t auto_armed              : 1; // 5       // stops auto missions from beginning until throttle is raised
             uint8_t logging_started         : 1; // 6       // true if logging has started
             uint8_t land_complete           : 1; // 7       // true if we have detected a landing
-            uint8_t new_radio_frame         : 1; // 8       // Set true if we have new PWM data to act on from the Radio
+            uint8_t simple_mode_new_frame   : 1; // 8       // Set true if we have new PWM data from the Radio to be handled by Simple Mode
             uint8_t usb_connected_unused    : 1; // 9       // UNUSED
             uint8_t rc_receiver_present     : 1; // 10      // true if we have an rc receiver present (i.e. if we've ever received an update
             uint8_t compass_mot             : 1; // 11      // true if we are currently performing compassmot calibration

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -89,7 +89,7 @@ void Copter::read_radio()
     const uint32_t tnow_ms = millis();
 
     if (rc().read_input()) {
-        ap.new_radio_frame = true;
+        ap.simple_mode_new_frame = true;
 
         set_throttle_and_failsafe(channel_throttle->get_radio_in());
         set_throttle_zero_flag(channel_throttle->get_control_in());


### PR DESCRIPTION
Minor rename to make the variable's owner and purpose clear.
