### PR TITLE
Remove argument location from QuadPlane::control_auto(), not used

### DIFF
--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -57,7 +57,7 @@ void ModeAuto::update()
     uint16_t nav_cmd_id = plane.mission.get_current_nav_cmd().id;
 
     if (plane.quadplane.in_vtol_auto()) {
-        plane.quadplane.control_auto(plane.next_WP_loc);
+        plane.quadplane.control_auto();
     } else if (nav_cmd_id == MAV_CMD_NAV_TAKEOFF ||
         (nav_cmd_id == MAV_CMD_NAV_LAND && plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND)) {
         plane.takeoff_calc_roll();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2376,7 +2376,7 @@ void QuadPlane::waypoint_controller(void)
 /*
   handle auto-mode when auto_state.vtol_mode is true
  */
-void QuadPlane::control_auto(const Location &loc)
+void QuadPlane::control_auto(void)
 {
     if (!setup()) {
         return;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -44,7 +44,7 @@ public:
     static const struct AP_Param::GroupInfo var_info2[];
 
     void control_run(void);
-    void control_auto(const Location &loc);
+    void control_auto(void);
     bool init_mode(void);
     bool setup(void);
 


### PR DESCRIPTION
I think this argument was meant to be passed to the function  QuadPlane::vtol_position_controller(), invoked inside control_auto(). 

Instead, QuadPlane::vtol_position_controller() takes the location directly from plane.next_WP_loc.
