### PR TITLE
AP_FOLLOW: Reset offsets every time Follow mode is entered.

### DIFF
--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -630,6 +630,7 @@ public:
 protected:
 
     bool _enter() override;
+    void _exit() override;
 };
 
 class ModeSimple : public Mode

--- a/APMrover2/mode_follow.cpp
+++ b/APMrover2/mode_follow.cpp
@@ -14,6 +14,12 @@ bool ModeFollow::_enter()
     return true;
 }
 
+// exit handling
+void ModeFollow::_exit()
+{
+    g2.follow.clear_offsets_if_required();
+}
+
 void ModeFollow::update()
 {
     // stop vehicle if no speed estimate

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -314,6 +314,12 @@ void Copter::exit_mode(Mode *&old_flightmode,
     }
 #endif
 
+#if MODE_FOLLOW_ENABLED == ENABLED
+    if (old_flightmode == &mode_follow) {
+        mode_follow.exit();
+    }
+#endif
+
 #if FRAME_CONFIG == HELI_FRAME
     // firmly reset the flybar passthrough to false when exiting acro mode.
     if (old_flightmode == &mode_acro) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1256,6 +1256,7 @@ public:
     using ModeGuided::Mode;
 
     bool init(bool ignore_checks) override;
+    void exit();
     void run() override;
 
     bool requires_GPS() const override { return true; }

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -24,6 +24,12 @@ bool ModeFollow::init(const bool ignore_checks)
     return ModeGuided::init(ignore_checks);
 }
 
+// perform cleanup required when leaving follow mode
+void ModeFollow::exit()
+{
+    g2.follow.clear_offsets_if_required();
+}
+
 void ModeFollow::run()
 {
     // if not armed set throttle to zero and exit immediately

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -44,6 +44,9 @@ public:
     // set which target to follow
     void set_target_sysid(uint8_t sysid) { _sysid = sysid; }
 
+    // restore offsets to zero if necessary, should be called when vehicle exits follow mode
+    void clear_offsets_if_required();
+
     //
     // position tracking related methods
     //
@@ -122,8 +125,9 @@ private:
     uint32_t _last_heading_update_ms;   // system time of last heading update
     float _target_heading;          // heading in degrees
     bool _automatic_sysid;          // did we lock onto a sysid automatically?
-    float   _dist_to_target;        // latest distance to target in meters (for reporting purposes)
-    float   _bearing_to_target;     // latest bearing to target in degrees (for reporting purposes)
+    float _dist_to_target;          // latest distance to target in meters (for reporting purposes)
+    float _bearing_to_target;       // latest bearing to target in degrees (for reporting purposes)
+    bool _offsets_were_zero;        // true if offsets were originally zero and then initialised to the offset from lead vehicle
 
     // setup jitter correction with max transport lag of 3s
     JitterCorrection _jitter{3000};


### PR DESCRIPTION
Probably all wrong...no way to SITL test it....no FOLLOW or SIMPLE mode in SITL yet for Rover...
but this is my attempt to allow vehicles switching to FOLLOW mode, to reset the offsets to the parameter value....including current vehicle positions offset...

currently the library uses the param variable itself to store the calculated offsets so, once computed and stored in the param vector, they never can be changed until reboot, or a new offset is loaded via mavlink....

it compiles fine and I think it does the job by using something other than the param var as storage,leaving it intact, but again, no way to test....let me know what I need to change....

PS will add to copter follow mode once its okay and tested for Rover...