### PR TITLE
Copter: add pre-arm check of PILOT_SPEED_UP param

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -172,6 +172,12 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         }
 #endif
 
+        // pilot-speed-up parameter check
+        if (copter.g.pilot_speed_up <= 0) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check PILOT_SPEED_UP");
+            return false;
+        }
+
         #if FRAME_CONFIG == HELI_FRAME
         if (copter.g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI_QUAD &&
             copter.g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI_DUAL &&


### PR DESCRIPTION
This is a very minor change to resolve this issue: https://github.com/ArduPilot/ardupilot/issues/12466

The argument for **not** adding this check is that we have hundreds of parameters, many of which can cause a crash if the user sets them incorrectly (i.e. PID gains of zero will also cause a crash).  Still, there was a real support issue where a user couldn't control their altitude so I'm adding this check.

This has been checked in SITL and works as expected (i.e. values below 0 cause a pre-arm check message to appear).