### PR TITLE
AP_BLHeli: fix watchdog resets with telemetry active from non-multirotor motors

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1274,7 +1274,7 @@ void AP_BLHeli::update(void)
     motor_mask = mask;
     debug("ESC: %u motors mask=0x%04x", num_motors, mask);
 
-    if (telem_rate > 0) {
+    if (num_motors != 0 && telem_rate > 0) {
         AP_SerialManager *serial_manager = AP_SerialManager::get_singleton();
         if (serial_manager) {
             telem_uart = serial_manager->find_serial(AP_SerialManager::SerialProtocol_ESCTelemetry,0);


### PR DESCRIPTION
This fixes a corner case issue when setting up BLH telemetry from non-multirotor motors on traditional fixed wing setups (SERVOn_FUNCTION = throttle [left/right]).
if BLH_AUTO is enabled, plus an ESC is actively sending telemetry data to the specified serial port, but no multirotor motor is found, serial manager gets unhappy and triggers infinite watchdog resets.