### PR TITLE
Plane: Resore old default behaviour for throttle curves

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -983,12 +983,16 @@ float QuadPlane::get_pilot_throttle()
     // normalize to [0,1]
     throttle_in /= plane.channel_throttle->get_range();
 
-    // get hover throttle level [0,1]
-    float thr_mid = motors->get_throttle_hover();
-    float thrust_curve_expo = constrain_float(throttle_expo, 0.0f, 1.0f);
+    if (is_positive(throttle_expo)) {
+        // get hover throttle level [0,1]
+        float thr_mid = motors->get_throttle_hover();
+        float thrust_curve_expo = constrain_float(throttle_expo, 0.0f, 1.0f);
 
-    // this puts mid stick at hover throttle
-    return throttle_curve(thr_mid, thrust_curve_expo, throttle_in);;
+        // this puts mid stick at hover throttle
+        return throttle_curve(thr_mid, thrust_curve_expo, throttle_in);;
+    } else {
+        return throttle_in;
+    }
 }
 
 /*


### PR DESCRIPTION
The change in this made QStabilize behave very differently then it had, which is quite shocking in a test flight.

![Figure_1](https://user-images.githubusercontent.com/567688/66092373-b5aa1100-e540-11e9-9f87-340a05032e96.png)
The first part shows the effect of 0.2 our default, the second restores the old behaviour with a value of 0, which leads to the expected behavior we had. This was particularly painful when upgrading firmware as it was a surprise to hit it.