### PR TITLE
Copter: do not speed up EKF failsafe if optflow works

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -110,7 +110,7 @@ bool Copter::ekf_over_threshold()
     if (mag_variance.length() >= g.fs_ekf_thresh) {
         over_thresh_count++;
     }
-    if (vel_variance >= (2.0f * g.fs_ekf_thresh)) {
+    if (!optflow.healthy() && (vel_variance >= (2.0f * g.fs_ekf_thresh))) {
         over_thresh_count += 2;
     } else if (vel_variance >= g.fs_ekf_thresh) {
         over_thresh_count++;


### PR DESCRIPTION
When GPS is jammed, EKF SV will rise up high very quickly. It will trigger EKF fail-safe after #10801. If a optical flow sensor is presented and functional, it would be better not to speed up EKF fail-safe and allow optical flow to work.

A GPS jammer is used in this flight
![Log Browser - 2019-10-03 10-43-51 bin 2019_10_3 下午 02_50_32](https://user-images.githubusercontent.com/19793511/66105148-358db500-e5ed-11e9-8e18-a02939365614.png)

[2019-10-03 10-43-51.bin.gz](https://github.com/ArduPilot/ardupilot/files/3684799/2019-10-03.10-43-51.bin.gz)
