### PR TITLE
AP_NavEKF2: switch to optflow if gps is jammed

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -250,6 +250,9 @@ void NavEKF2_core::setAidingMode()
             tasTimeout = true;
             gpsNotAvailable = true;
         } else if (posAidLossCritical) {
+            if ((frontend->_flowUse & FLOW_USE_NAV) && optFlowDataPresent()) {
+                PV_AidingMode = AID_NONE;
+            }
             // if the loss of position is critical, declare all sources of position aiding as being timed out
             posTimeout = true;
             velTimeout = true;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -250,7 +250,7 @@ void NavEKF2_core::setAidingMode()
             tasTimeout = true;
             gpsNotAvailable = true;
         } else if (posAidLossCritical) {
-            if ((frontend->_flowUse & FLOW_USE_NAV) && optFlowDataPresent()) {
+            if ((frontend->_flowUse & FLOW_USE_NAV) && optFlowDataPresent() && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
                 PV_AidingMode = AID_NONE;
             }
             // if the loss of position is critical, declare all sources of position aiding as being timed out


### PR DESCRIPTION
fix #9919 and fix #11156

When GPS is jammed, EKF fail-safe will be triggered even a optical flow sensor is functional and ek2_flow_use = 1.  In following flight, a GSP jammer is used, SV did not go above 2x FS_EKF_THRESH and neither SP or SM go above FS_EKF_THRESH. But EKF fail-safe is still triggered even optical flow is working well. EKF did not switch to optical flow.

Copter is f450 frame with pixhawk4, hereflow and sf20. This is the GPS jammer used in following test
![Picture 3](https://user-images.githubusercontent.com/19793511/66177475-26ae0d80-e694-11e9-8ef6-94fa56e89268.jpg)

![Log Browser - 2019-10-03 11-04-34 bin 2019_10_3 下午 03_13_17](https://user-images.githubusercontent.com/19793511/66106521-a8e4f600-e5f0-11e9-9d57-e3fa68de1e8a.png)
[2019-10-03 11-04-34.bin.gz](https://github.com/ArduPilot/ardupilot/files/3684921/2019-10-03.11-04-34.bin.gz)

After apply this PR. In following flight, a GSP jammer is used and EKF switch to optical flow. Copter loiter well. EKF switch back to GPS after GPS jammer is turned off.

![Log Browser - 2019-10-03 10-52-48 bin 2019_10_3 下午 03_28_06](https://user-images.githubusercontent.com/19793511/66107287-6de3c200-e5f2-11e9-940c-de03862ab8c1.png)
[2019-10-03 10-52-48.bin.gz](https://github.com/ArduPilot/ardupilot/files/3684913/2019-10-03.10-52-48.bin.gz)

this PR may need #12481
