### PR TITLE
AP_Logger: fix logging on 256Mbit flash chips

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -11,7 +11,7 @@ extern AP_HAL::HAL& hal;
 
 // the last page holds the log format in first 4 bytes. Please change
 // this if (and only if!) the low level format changes
-#define DF_LOGGING_FORMAT    0x19012019
+#define DF_LOGGING_FORMAT    0x1901201A
 
 AP_Logger_Block::AP_Logger_Block(AP_Logger &front, LoggerMessageWriter_DFLogStart *writer) :
     writebuf(0),
@@ -464,20 +464,20 @@ uint32_t AP_Logger_Block::find_last_page(void)
     uint32_t look;
     uint32_t bottom = 1;
     uint32_t top = df_NumPages;
-    uint32_t look_hash;
-    uint32_t bottom_hash;
-    uint32_t top_hash;
+    uint64_t look_hash;
+    uint64_t bottom_hash;
+    uint64_t top_hash;
 
     WITH_SEMAPHORE(sem);
 
     StartRead(bottom);
-    bottom_hash = ((int32_t)GetFileNumber()<<16) | df_FilePage;
+    bottom_hash = ((int64_t)GetFileNumber()<<32) | df_FilePage;
 
     while (top-bottom > 1) {
         look = (top+bottom)/2;
         StartRead(look);
-        look_hash = (int32_t)GetFileNumber()<<16 | df_FilePage;
-        if (look_hash >= 0xFFFF0000) {
+        look_hash = (int64_t)GetFileNumber()<<32 | df_FilePage;
+        if (look_hash >= 0xFFFF00000000) {
             look_hash = 0;
         }
 
@@ -492,8 +492,8 @@ uint32_t AP_Logger_Block::find_last_page(void)
     }
 
     StartRead(top);
-    top_hash = ((int32_t)GetFileNumber()<<16) | df_FilePage;
-    if (top_hash >= 0xFFFF0000) {
+    top_hash = ((int64_t)GetFileNumber()<<32) | df_FilePage;
+    if (top_hash >= 0xFFFF00000000) {
         top_hash = 0;
     }
     if (top_hash > bottom_hash) {
@@ -509,8 +509,8 @@ uint32_t AP_Logger_Block::find_last_page_of_log(uint16_t log_number)
     uint32_t look;
     uint32_t bottom;
     uint32_t top;
-    uint32_t look_hash;
-    uint32_t check_hash;
+    uint64_t look_hash;
+    uint64_t check_hash;
 
     WITH_SEMAPHORE(sem);
 
@@ -529,13 +529,13 @@ uint32_t AP_Logger_Block::find_last_page_of_log(uint16_t log_number)
         top = find_last_page();
     }
 
-    check_hash = (int32_t)log_number<<16 | 0xFFFF;
+    check_hash = (int64_t)log_number<<32 | 0xFFFFFFFF;
 
     while (top-bottom > 1) {
         look = (top+bottom)/2;
         StartRead(look);
-        look_hash = (int32_t)GetFileNumber()<<16 | df_FilePage;
-        if (look_hash >= 0xFFFF0000) {
+        look_hash = (int64_t)GetFileNumber()<<32 | df_FilePage;
+        if (look_hash >= 0xFFFF00000000) {
             look_hash = 0;
         }
 

--- a/libraries/AP_Logger/AP_Logger_Block.h
+++ b/libraries/AP_Logger/AP_Logger_Block.h
@@ -46,9 +46,9 @@ private:
     virtual void StartErase() = 0;
     virtual bool InErase() = 0;
 
-    struct PageHeader {
+    struct PACKED PageHeader {
+        uint32_t FilePage;
         uint16_t FileNumber;
-        uint16_t FilePage;
     };
 
     HAL_Semaphore_Recursive sem;

--- a/libraries/AP_Logger/AP_Logger_DataFlash.cpp
+++ b/libraries/AP_Logger/AP_Logger_DataFlash.cpp
@@ -68,6 +68,10 @@ void AP_Logger_DataFlash::Init()
         return;
     }
 
+    if (use_32bit_address) {
+        Enter4ByteAddressMode();
+    }
+
     flash_died = false;
 
     AP_Logger_Block::Init();
@@ -174,6 +178,13 @@ bool AP_Logger_DataFlash::Busy()
     return (status & JEDEC_STATUS_BUSY) != 0;
 }
 
+void AP_Logger_DataFlash::Enter4ByteAddressMode(void)
+{
+    WITH_SEMAPHORE(dev_sem);
+
+    const uint8_t cmd = 0xB7;
+    dev->transfer(&cmd, 1, NULL, 0);
+}
 
 /*
   send a command with an address

--- a/libraries/AP_Logger/AP_Logger_DataFlash.h
+++ b/libraries/AP_Logger/AP_Logger_DataFlash.h
@@ -27,7 +27,8 @@ private:
     void              WaitReady();
     bool              Busy();
     uint8_t           ReadStatusReg();
-    
+    void              Enter4ByteAddressMode(void);
+
     void              WriteEnable();
     bool              getSectorCount(void);
     void              flash_test(void);


### PR DESCRIPTION
256Mbit flash chips :
* have more than 65535 pages so the page number doesn't fit into an unsigned 16bit integer
* need the addressing mode to be changed to be able to use 32bit addresses