### PR TITLE
Copter/Rover: reset follow mode's offsets when exiting follow mode

### DIFF
--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -630,6 +630,7 @@ public:
 protected:
 
     bool _enter() override;
+    void _exit() override;
 };
 
 class ModeSimple : public Mode

--- a/APMrover2/mode_follow.cpp
+++ b/APMrover2/mode_follow.cpp
@@ -14,6 +14,12 @@ bool ModeFollow::_enter()
     return true;
 }
 
+// exit handling
+void ModeFollow::_exit()
+{
+    g2.follow.clear_offsets_if_required();
+}
+
 void ModeFollow::update()
 {
     // stop vehicle if no speed estimate

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -314,6 +314,12 @@ void Copter::exit_mode(Mode *&old_flightmode,
     }
 #endif
 
+#if MODE_FOLLOW_ENABLED == ENABLED
+    if (old_flightmode == &mode_follow) {
+        mode_follow.exit();
+    }
+#endif
+
 #if FRAME_CONFIG == HELI_FRAME
     // firmly reset the flybar passthrough to false when exiting acro mode.
     if (old_flightmode == &mode_acro) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1256,6 +1256,7 @@ public:
     using ModeGuided::Mode;
 
     bool init(bool ignore_checks) override;
+    void exit();
     void run() override;
 
     bool requires_GPS() const override { return true; }

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -24,6 +24,12 @@ bool ModeFollow::init(const bool ignore_checks)
     return ModeGuided::init(ignore_checks);
 }
 
+// perform cleanup required when leaving follow mode
+void ModeFollow::exit()
+{
+    g2.follow.clear_offsets_if_required();
+}
+
 void ModeFollow::run()
 {
     // if not armed set throttle to zero and exit immediately

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -134,6 +134,15 @@ AP_Follow::AP_Follow() :
     AP_Param::setup_object_defaults(this, var_info);
 }
 
+// restore offsets to zero if necessary, should be called when vehicle exits follow mode
+void AP_Follow::clear_offsets_if_required()
+{
+    if (_offsets_were_zero) {
+        _offset = Vector3f();
+    }
+    _offsets_were_zero = false;
+}
+
 // get target's estimated location
 bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ned) const
 {
@@ -346,6 +355,7 @@ void AP_Follow::init_offsets_if_required(const Vector3f &dist_vec_ned)
     if (!_offset.get().is_zero()) {
         return;
     }
+    _offsets_were_zero = true;
 
     float target_heading_deg;
     if ((_offset_type == AP_FOLLOW_OFFSET_TYPE_RELATIVE) && get_target_heading_deg(target_heading_deg)) {

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -44,6 +44,9 @@ public:
     // set which target to follow
     void set_target_sysid(uint8_t sysid) { _sysid = sysid; }
 
+    // restore offsets to zero if necessary, should be called when vehicle exits follow mode
+    void clear_offsets_if_required();
+
     //
     // position tracking related methods
     //
@@ -122,8 +125,9 @@ private:
     uint32_t _last_heading_update_ms;   // system time of last heading update
     float _target_heading;          // heading in degrees
     bool _automatic_sysid;          // did we lock onto a sysid automatically?
-    float   _dist_to_target;        // latest distance to target in meters (for reporting purposes)
-    float   _bearing_to_target;     // latest bearing to target in degrees (for reporting purposes)
+    float _dist_to_target;          // latest distance to target in meters (for reporting purposes)
+    float _bearing_to_target;       // latest bearing to target in degrees (for reporting purposes)
+    bool _offsets_were_zero;        // true if offsets were originally zero and then initialised to the offset from lead vehicle
 
     // setup jitter correction with max transport lag of 3s
     JitterCorrection _jitter{3000};


### PR DESCRIPTION
This is an alternative to this PR: https://github.com/ArduPilot/ardupilot/pull/12464 and resolves this issue: https://github.com/ArduPilot/ardupilot/issues/12460

The issue is that Follow mode only initialises the offsets (if they are zero) to the distance from the lead vehicle the first time the vehicle enters Follow mode.  Imagine this sequence:

- lead vehicle is 3m away, vehicle is switched into Follow mode: offsets are set to 3m, vehicle follows lead at 3m (all good!)
- vehicle is switched to another mode, user drives/flies the vehicle to 5m from lead vehicle.
- vehicle is switched back to Follow mode: vehicle returns to 3m from lead vehicle (unintuitive!)

With this change we record whether the offsets were initialised to the distance from the leader (which can only happen if they were zero) and if "yes" then we reset the offsets back to zero when exiting follow mode.

This hasn't been tested in SITL yet nor on a real vehicle.

As a side note, while making this change it's become very clear to me that Copter needs an exit() method like Rover has.