### PR TITLE
Copter: remove unused prev_control_mode

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -402,9 +402,6 @@ private:
     Mode::Number control_mode;
     mode_reason_t control_mode_reason = MODE_REASON_UNKNOWN;
 
-    Mode::Number prev_control_mode;
-    mode_reason_t prev_control_mode_reason = MODE_REASON_UNKNOWN;
-
     RCMapper rcmap;
 
     // intertial nav alt when we armed


### PR DESCRIPTION
Does seem to be any consumers of these variables so should be fine to delete them.

Note: this PR will likely cause merge issues in @Gone4Dirt's PR: https://github.com/ArduPilot/ardupilot/pull/12108.  We might not want to merge this until the other PR has gone in.