### PR TITLE
AP_OSD: add clock panel

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -117,6 +117,7 @@ private:
     AP_OSD_Setting atemp{false, 0, 0};
     AP_OSD_Setting bat2_vlt{false, 0, 0};
     AP_OSD_Setting bat2used{false, 0, 0};
+    AP_OSD_Setting clk{false, 0, 0};
 
     bool check_option(uint32_t option);
 
@@ -181,6 +182,7 @@ private:
     void draw_atemp(uint8_t x, uint8_t y);
     void draw_bat2_vlt(uint8_t x, uint8_t y);
     void draw_bat2used(uint8_t x, uint8_t y);
+    void draw_clk(uint8_t x, uint8_t y);
 };
 
 class AP_OSD

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -33,6 +33,7 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_RTC/AP_RTC.h>
 
 #include <ctype.h>
 #include <GCS_MAVLink/GCS.h>
@@ -688,6 +689,22 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(aspd1, "ASPD1", 42, AP_OSD_Screen, AP_OSD_Setting),
 
+    // @Param: CLK_EN
+    // @DisplayName: CLK_EN
+    // @Description: Displays a clock panel based on AP_RTC local time
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: CLK_X
+    // @DisplayName: CLK_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: CLK_Y
+    // @DisplayName: CLK_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(clk, "CLK", 43, AP_OSD_Screen, AP_OSD_Setting),
+    
     AP_GROUPEND
 };
 
@@ -782,6 +799,7 @@ AP_OSD_Screen::AP_OSD_Screen()
 #define SYM_FLY       0x9C
 #define SYM_EFF       0xF2
 #define SYM_AH        0xF3
+#define SYM_CLK       0xBC
 
 void AP_OSD_Screen::set_backend(AP_OSD_Backend *_backend)
 {
@@ -1523,6 +1541,18 @@ void AP_OSD_Screen::draw_aspd2(uint8_t x, uint8_t y)
     }
 }
 
+void AP_OSD_Screen::draw_clk(uint8_t x, uint8_t y)
+{
+    AP_RTC &rtc = AP::rtc();
+    uint8_t hour, min, sec;
+    uint16_t ms;
+    if (!rtc.get_local_time(hour, min, sec, ms)) {
+    backend->write(x, y, false, "%c--:--%", SYM_CLK);
+    } else {
+    backend->write(x, y, false, "%c%02u:%02u", SYM_CLK, hour, min);
+    }
+}
+
 #define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
 
 void AP_OSD_Screen::draw(void)
@@ -1564,6 +1594,7 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(atemp);
     DRAW_SETTING(hdop);
     DRAW_SETTING(flightime);
+    DRAW_SETTING(clk);
 
 #ifdef HAVE_AP_BLHELI_SUPPORT
     DRAW_SETTING(blh_temp);

--- a/libraries/AP_RTC/AP_RTC.h
+++ b/libraries/AP_RTC/AP_RTC.h
@@ -13,6 +13,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     AP_Int8 allowed_types;
+    AP_Int16 tz_min;
 
     // ordering is important in source_type; lower-numbered is
     // considered a better time source.  These values are documented
@@ -38,6 +39,8 @@ public:
       get time in UTC hours, minutes, seconds and milliseconds
      */
     bool get_system_clock_utc(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms);
+    
+    bool get_local_time(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms);
 
     uint32_t get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms);
 


### PR DESCRIPTION
adds a clock panel based on AP_RTC. requires https://github.com/ArduPilot/ardupilot/pull/12497 to set local time.