### PR TITLE
AP_Arming: remove bogus ARMING_CHECK_NONE 'bitmask value'

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -47,13 +47,13 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
         if (reason == nullptr) {
             reason = "AHRS not healthy";
         }
-        check_failed(ARMING_CHECK_NONE, display_failure, "%s", reason);
+        check_failed(display_failure, "%s", reason);
         return false;
     }
 
     // check for ekf failsafe
     if (rover.failsafe.ekf) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "EKF failsafe");
+        check_failed(display_failure, "EKF failsafe");
         return false;
     }
 
@@ -63,7 +63,7 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
         if (reason == nullptr) {
             reason = "Need Position Estimate";
         }
-        check_failed(ARMING_CHECK_NONE, display_failure, "%s", reason);
+        check_failed(display_failure, "%s", reason);
         return false;
     }
 
@@ -74,11 +74,11 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
 bool AP_Arming_Rover::pre_arm_checks(bool report)
 {
     //are arming checks disabled?
-    if (checks_to_perform == ARMING_CHECK_NONE) {
+    if (checks_to_perform == 0) {
         return true;
     }
     if (SRV_Channels::get_emergency_stop()) {
-        check_failed(ARMING_CHECK_NONE, report, "Motors Emergency Stopped");
+        check_failed(report, "Motors Emergency Stopped");
         return false;
     }
 
@@ -92,7 +92,7 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
 {
     //are arming checks disabled?
-    if (checks_to_perform == ARMING_CHECK_NONE) {
+    if (checks_to_perform == 0) {
         return true;
     }
     return AP_Arming::arm_checks(method);
@@ -171,9 +171,9 @@ bool AP_Arming_Rover::oa_check(bool report)
 
     // display failure
     if (strlen(failure_msg) == 0) {
-        check_failed(ARMING_CHECK_NONE, report, "Check Object Avoidance");
+        check_failed(report, "Check Object Avoidance");
     } else {
-        check_failed(ARMING_CHECK_NONE, report, "%s", failure_msg);
+        check_failed(report, "%s", failure_msg);
     }
     return false;
 }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -20,7 +20,7 @@ const AP_Param::GroupInfo AP_Arming_Plane::var_info[] = {
 bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
 {
     //are arming checks disabled?
-    if (checks_to_perform == ARMING_CHECK_NONE) {
+    if (checks_to_perform == 0) {
         return true;
     }
     if (hal.util->was_watchdog_armed()) {
@@ -38,22 +38,22 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
     ret &= AP_Arming::airspeed_checks(display_failure);
 
     if (plane.g.fs_timeout_long < plane.g.fs_timeout_short && plane.g.fs_action_short != FS_ACTION_SHORT_DISABLED) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "FS_LONG_TIMEOUT < FS_SHORT_TIMEOUT");
+        check_failed(display_failure, "FS_LONG_TIMEOUT < FS_SHORT_TIMEOUT");
         ret = false;
     }
 
     if (plane.aparm.roll_limit_cd < 300) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "LIM_ROLL_CD too small (%u)", (unsigned)plane.aparm.roll_limit_cd);
+        check_failed(display_failure, "LIM_ROLL_CD too small (%u)", (unsigned)plane.aparm.roll_limit_cd);
         ret = false;
     }
 
     if (plane.aparm.pitch_limit_max_cd < 300) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "LIM_PITCH_MAX too small (%u)", (unsigned)plane.aparm.pitch_limit_max_cd);
+        check_failed(display_failure, "LIM_PITCH_MAX too small (%u)", (unsigned)plane.aparm.pitch_limit_max_cd);
         ret = false;
     }
 
     if (plane.aparm.pitch_limit_min_cd > -300) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "LIM_PITCH_MIN too large (%u)", (unsigned)plane.aparm.pitch_limit_min_cd);
+        check_failed(display_failure, "LIM_PITCH_MIN too large (%u)", (unsigned)plane.aparm.pitch_limit_min_cd);
         ret = false;
     }
 
@@ -61,17 +61,17 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
         plane.g.throttle_fs_enabled &&
         plane.g.throttle_fs_value < 
         plane.channel_throttle->get_radio_max()) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "Invalid THR_FS_VALUE for rev throttle");
+        check_failed(display_failure, "Invalid THR_FS_VALUE for rev throttle");
         ret = false;
     }
 
     if (plane.quadplane.enabled() && !plane.quadplane.available()) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "Quadplane enabled but not running");
+        check_failed(display_failure, "Quadplane enabled but not running");
         ret = false;
     }
 
     if (plane.quadplane.available() && plane.scheduler.get_loop_rate_hz() < 100) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "quadplane needs SCHED_LOOP_RATE >= 100");
+        check_failed(display_failure, "quadplane needs SCHED_LOOP_RATE >= 100");
         ret = false;
     }
 
@@ -89,18 +89,18 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
     }
 
     if (plane.control_mode == &plane.mode_auto && plane.mission.num_commands() <= 1) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "No mission loaded");
+        check_failed(display_failure, "No mission loaded");
         ret = false;
     }
 
     // check adsb avoidance failsafe
     if (plane.failsafe.adsb) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "ADSB threat detected");
+        check_failed(display_failure, "ADSB threat detected");
         ret = false;
     }
 
     if (SRV_Channels::get_emergency_stop()) {
-        check_failed(ARMING_CHECK_NONE, display_failure,"Motors Emergency Stopped");
+        check_failed(display_failure,"Motors Emergency Stopped");
         ret = false;
     }
 
@@ -133,7 +133,7 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
 bool AP_Arming_Plane::arm_checks(AP_Arming::Method method)
 {
     //are arming checks disabled?
-    if (checks_to_perform == ARMING_CHECK_NONE) {
+    if (checks_to_perform == 0) {
         return true;
     }
 

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -48,7 +48,7 @@ bool AP_Arming_Sub::pre_arm_checks(bool display_failure)
     }
     // don't allow arming unless there is a disarm button configured
     if (!has_disarm_function()) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "Must assign a disarm or arm_toggle button");
+        check_failed(display_failure, "Must assign a disarm or arm_toggle button");
         return false;
     }
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -17,7 +17,6 @@ public:
     static AP_Arming *get_singleton();
 
     enum ArmingChecks {
-        ARMING_CHECK_NONE        = 0x0000,
         ARMING_CHECK_ALL         = (1U << 0),
         ARMING_CHECK_BARO        = (1U << 1),
         ARMING_CHECK_COMPASS     = (1U << 2),
@@ -140,6 +139,7 @@ protected:
     MAV_SEVERITY check_severity(const enum AP_Arming::ArmingChecks check) const;
     // handle the case where a check fails
     void check_failed(const enum AP_Arming::ArmingChecks check, bool report, const char *fmt, ...) const FMT_PRINTF(4, 5);
+    void check_failed(bool report, const char *fmt, ...) const FMT_PRINTF(3, 4);
 
     void Log_Write_Arm_Disarm();
 


### PR DESCRIPTION
This looks like a bitmask value, but if you treat it like one (and
people have in the past!) by using logical operations then you get the
incorrect result.

Places which were checking for equivalence to ARMING_CHECK_NONE now
simply check the bitmask to see if it is all-empty.
