### PR TITLE
ArduPlane: Reset baro and home until soft_armed

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -282,7 +282,7 @@ void Plane::one_second_loop()
 
     // update home position if NOT armed and gps position has
     // changed. Update every 5s at most
-    if (!arming.is_armed() &&
+    if (!hal.util->get_soft_armed() &&
         gps.last_message_time_ms() - last_home_update_ms > 5000 &&
         gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
             last_home_update_ms = gps.last_message_time_ms();


### PR DESCRIPTION
This should solve a problem when ahrs relative alt starts getting
higher when armed but not yet soft_armed for several minutes,
which causes much trouble on auto take-off; such as:
Uneffective LEVEL_ROLL_LIMIT
No Takeoff procedure as it has already achieved the takeoff alt
This is specially true if ARMING_CHECKS doesn't include safety switch