### PR TITLE
AP_Motors: Change to description(NFC)

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -137,9 +137,9 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: HOVER_LEARN
     // @DisplayName: Hover Value Learning
     // @Description: Enable/Disable automatic learning of hover throttle
-    // @Values{Copter}: 0:Disabled, 1:Learn, 2:LearnAndSave
+    // @Values{Copter}: 0:Disabled, 1:Learn, 2:Learn and Save
     // @Values{Sub}: 0:Disabled
-    // @Values{Plane}: 0:Disabled, 1:Learn, 2:LearnAndSave
+    // @Values{Plane}: 0:Disabled, 1:Learn, 2:Learn and Save
     // @User: Advanced
     AP_GROUPINFO("HOVER_LEARN", 22, AP_MotorsMulticopter, _throttle_hover_learn, HOVER_LEARN_AND_SAVE),
 


### PR DESCRIPTION
I change the description of the installation value to text.

I use it converted to Japanese.
This explanation did not become Japanese.

![Screenshot from 2019-10-06 15-16-05](https://user-images.githubusercontent.com/646194/66265148-4ee06c80-e84c-11e9-8cfa-7302efb3e114.png)
