### PR TITLE
DO_WAIT_LOCATION

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -289,6 +289,7 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
     case MAV_CMD_DO_GRIPPER:
         return start_command_do_gripper(cmd);
     case MAV_CMD_DO_WAIT_LOCATION:
+        drop_min_dist = 9999999999;
         return true;
     case MAV_CMD_DO_SET_SERVO:
     case MAV_CMD_DO_SET_RELAY:

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -264,6 +264,8 @@ void AP_Mission::update()
 bool AP_Mission::verify_command(const Mission_Command& cmd)
 {
     switch (cmd.id) {
+    case MAV_CMD_DO_WAIT_LOCATION:
+        return verify_command_wait_location(cmd);
         // do-commands always return true for verify:
     case MAV_CMD_DO_GRIPPER:
     case MAV_CMD_DO_SET_SERVO:
@@ -286,6 +288,8 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
     switch (cmd.id) {
     case MAV_CMD_DO_GRIPPER:
         return start_command_do_gripper(cmd);
+    case MAV_CMD_DO_WAIT_LOCATION:
+        return true;
     case MAV_CMD_DO_SET_SERVO:
     case MAV_CMD_DO_SET_RELAY:
     case MAV_CMD_DO_REPEAT_SERVO:
@@ -577,6 +581,7 @@ bool AP_Mission::stored_in_location(uint16_t id)
     case MAV_CMD_NAV_GUIDED_ENABLE:
     case MAV_CMD_DO_SET_HOME:
     case MAV_CMD_DO_LAND_START:
+    case MAV_CMD_DO_WAIT_LOCATION:
     case MAV_CMD_DO_GO_AROUND:
     case MAV_CMD_DO_SET_ROI:
     case MAV_CMD_NAV_VTOL_TAKEOFF:
@@ -856,6 +861,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_DO_LAND_START:                         // MAV ID: 189
+        break;
+
+    case MAV_CMD_DO_WAIT_LOCATION:
+        cmd.p1 = packet.param1;                         // acceptance radius in metres
         break;
 
     case MAV_CMD_DO_GO_AROUND:                          // MAV ID: 191
@@ -1288,6 +1297,10 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         break;
 
     case MAV_CMD_DO_LAND_START:                         // MAV ID: 189
+        break;
+
+    case MAV_CMD_DO_WAIT_LOCATION:
+        packet.param1 = cmd.p1;                         // acceptance radius in metres
         break;
 
     case MAV_CMD_DO_GO_AROUND:                          // MAV ID: 191
@@ -1929,6 +1942,8 @@ const char *AP_Mission::Mission_Command::type() const {
         return "CondYaw";
     case MAV_CMD_DO_LAND_START:
         return "LandStart";
+    case MAV_CMD_DO_WAIT_LOCATION:
+        return "DropAt";
     case MAV_CMD_NAV_DELAY:
         return "Delay";
     case MAV_CMD_DO_GRIPPER:

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -586,6 +586,9 @@ private:
     bool start_command_do_servorelayevents(const AP_Mission::Mission_Command& cmd);
     bool start_command_camera(const AP_Mission::Mission_Command& cmd);
     bool start_command_parachute(const AP_Mission::Mission_Command& cmd);
+
+    bool verify_command_wait_location(const AP_Mission::Mission_Command& cmd);
+
 };
 
 namespace AP {

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -589,6 +589,8 @@ private:
 
     bool verify_command_wait_location(const AP_Mission::Mission_Command& cmd);
 
+    float drop_min_dist = 9999999999;
+
 };
 
 namespace AP {

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -17,20 +17,19 @@ bool AP_Mission::verify_command_wait_location(const AP_Mission::Mission_Command&
     }
     const float dist = loc.get_distance(cmd.content.location);
     static uint32_t last_print;
-    static float min_dist = 9999999999;
-    if (dist < min_dist) {
-        min_dist = dist;
+    if (dist < drop_min_dist) {
+        drop_min_dist = dist;
     }
     const uint32_t now = AP_HAL::millis();
     if (now - last_print > 200) { // 5Hz
-        gcs().send_text(MAV_SEVERITY_INFO, "distance: %.02f (min=%.02f)", dist, min_dist);
+        gcs().send_text(MAV_SEVERITY_INFO, "distance: %.02f (min=%.02f)", dist, drop_min_dist);
     }
 
     if (dist <= cmd.p1) {
         gcs().send_text(MAV_SEVERITY_INFO, "Drop");
         return true;
     }
-    // if (dist > min_dist+1) {
+    // if (dist > drop_min_dist+1) {
     //     gcs().send_text(MAV_SEVERITY_INFO, "Drop (missed!)");
     //     return true;
     // }

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -30,10 +30,10 @@ bool AP_Mission::verify_command_wait_location(const AP_Mission::Mission_Command&
         gcs().send_text(MAV_SEVERITY_INFO, "Drop");
         return true;
     }
-    if (dist > min_dist+1) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Drop (missed!)");
-        return true;
-    }
+    // if (dist > min_dist+1) {
+    //     gcs().send_text(MAV_SEVERITY_INFO, "Drop (missed!)");
+    //     return true;
+    // }
 
     return false;
 }

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -22,11 +22,20 @@ bool AP_Mission::verify_command_wait_location(const AP_Mission::Mission_Command&
         min_dist = dist;
     }
     const uint32_t now = AP_HAL::millis();
-    if (now - last_print > 100) { // 10Hz
-        gcs().send_text(MAV_SEVERITY_INFO, "distance: %f (min=%f) %s", dist, min_dist, (dist <= cmd.p1) ? "Y" : "N");
+    if (now - last_print > 200) { // 5Hz
+        gcs().send_text(MAV_SEVERITY_INFO, "distance: %.02f (min=%.02f)", dist, min_dist);
     }
 
-    return dist <= cmd.p1;
+    if (dist <= cmd.p1) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Drop");
+        return true;
+    }
+    if (dist > min_dist+1) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Drop (missed!)");
+        return true;
+    }
+
+    return false;
 }
 
 bool AP_Mission::start_command_do_gripper(const AP_Mission::Mission_Command& cmd)


### PR DESCRIPTION
This is a PR which adds a new DO waypoint type, which triggers when a location is reached. 

I'm not sure this is generally useful, but my daughter and I worked on this for a project she's working on.

The reason this is *currently* useful is that Copter's fast-waypoint logic makes it difficult to achieve doing things at specific coordinates without coming to rest first.

Scripting may be a better way of accomplishing this goal.

S-Curve navigation will almost certainly be a better option.

Is this a useful thing or should I keep this out-of-tree?
