### PR TITLE
AP_Scripting: Fix generation of uint32_t arguments

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -134,4 +134,4 @@ singleton AP_Relay method toggle void uint8_t 0 AP_RELAY_NUM_RELAYS
 include GCS_MAVLink/GCS.h
 singleton GCS alias gcs
 singleton GCS method send_text void MAV_SEVERITY'enum MAV_SEVERITY_EMERGENCY MAV_SEVERITY_DEBUG "%s"'literal string
-singleton GCS method set_message_interval MAV_RESULT uint8_t 0 MAVLINK_COMM_NUM_BUFFERS uint32_t 0 UINT32_MAX int32_t -1 INT32_MAX
+singleton GCS method set_message_interval MAV_RESULT'enum uint8_t 0 MAVLINK_COMM_NUM_BUFFERS uint32_t 0U UINT32_MAX int32_t -1 INT32_MAX

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -944,8 +944,8 @@ void emit_checker(const struct type t, int arg_number, const char *indentation, 
         forced_max = "UINT16_MAX";
         break;
       case TYPE_UINT32_T:
-        forced_min = "0";
-        forced_max = "UINT16_MAX";
+        forced_min = "0U";
+        forced_max = "UINT32_MAX";
         break;
       case TYPE_ENUM:
         forced_min = forced_max = NULL;
@@ -975,7 +975,7 @@ void emit_checker(const struct type t, int arg_number, const char *indentation, 
         fprintf(source, "%sconst lua_Integer raw_data_%d = luaL_checkinteger(L, %d);\n", indentation, arg_number, arg_number);
         break;
       case TYPE_UINT32_T:
-        fprintf(source, "%sconst uint32_t raw_data_%d = coerce_to_uint32_t(L, %d);\n", indentation, arg_number, arg_number);
+        fprintf(source, "%sconst uint32_t raw_data_%d = *check_uint32_t(L, %d);\n", indentation, arg_number, arg_number);
         break;
       case TYPE_NONE:
       case TYPE_STRING:

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -472,6 +472,31 @@ const luaL_Reg Location_meta[] = {
     {NULL, NULL}
 };
 
+static int GCS_set_message_interval(lua_State *L) {
+    GCS * ud = GCS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "gcs not supported on this firmware");
+    }
+
+    binding_argcheck(L, 4);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(MAVLINK_COMM_NUM_BUFFERS, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint32_t raw_data_3 = *check_uint32_t(L, 3);
+    luaL_argcheck(L, ((raw_data_3 >= MAX(0U, 0U)) && (raw_data_3 <= MIN(UINT32_MAX, UINT32_MAX))), 3, "argument out of range");
+    const uint32_t data_3 = static_cast<uint32_t>(raw_data_3);
+    const lua_Integer raw_data_4 = luaL_checkinteger(L, 4);
+    luaL_argcheck(L, ((raw_data_4 >= MAX(-1, INT32_MIN)) && (raw_data_4 <= MIN(INT32_MAX, INT32_MAX))), 4, "argument out of range");
+    const int32_t data_4 = raw_data_4;
+    const MAV_RESULT &data = ud->set_message_interval(
+            data_2,
+            data_3,
+            data_4);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
 static int GCS_send_text(lua_State *L) {
     GCS * ud = GCS::get_singleton();
     if (ud == nullptr) {
@@ -489,32 +514,6 @@ static int GCS_send_text(lua_State *L) {
             data_3);
 
     return 0;
-}
-
-static int GCS_set_message_interval(lua_State *L) {
-    GCS * ud = GCS::get_singleton();
-    if (ud == nullptr) {
-        return luaL_argerror(L, 1, "gcs not supported on this firmware");
-    }
-
-    binding_argcheck(L, 4);
-    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && raw_data_2 <= MIN(MAVLINK_COMM_NUM_BUFFERS, UINT8_MAX)), 2, "argument out of range");
-    const uint32_t data_2 = static_cast<uint32_t>(raw_data_2);
-    const lua_Unsigned raw_data_3 = luaL_checkinteger(L, 3);
-    luaL_argcheck(L, (raw_data_3 <= UINT32_MAX), 3, "argument out of range");
-    const uint32_t data_3 = static_cast<uint32_t>(raw_data_3);
-    const lua_Integer raw_data_4 = luaL_checkinteger(L, 4);
-    luaL_argcheck(L, ((raw_data_4 >= -1) && (raw_data_4 <= INT32_MAX)), 4, "argument out of range");
-    const int32_t data_4 = static_cast<int32_t>(raw_data_4);
-    const MAV_RESULT data = ud->set_message_interval(
-            data_2,
-            data_3,
-            data_4);
-
-    lua_pushinteger(L, data);
-
-    return 1;
 }
 
 static int AP_Relay_toggle(lua_State *L) {
@@ -1544,8 +1543,8 @@ static int AP_AHRS_get_roll(lua_State *L) {
 }
 
 const luaL_Reg GCS_meta[] = {
-    {"send_text", GCS_send_text},
     {"set_message_interval", GCS_set_message_interval},
+    {"send_text", GCS_send_text},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
This also fixes the message interval description not generating correctly, it must have been manually edited before.

When merging PR's for scripting the mergerer needs to check that if they checkout the branch and generated the bindings nothing changes. Until we get some WAF expert to make this generate automatically for us this will be a bit of a pain point.

I haven't locally tested that the message interval stuff works with the changes, but it at least compiles again, and preforms the strict type checking it was intended to do. @tatsuy @rmackay9 if you have a chance to test this that would be great. As a note your script may need to be modified now to ensure that it's argument to the function was actually uint32_t, where as before a lua int or float would have been accepted.