### PR TITLE
autotest: fixed MISSION_ITEM_INT receive to be reliable

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -2128,7 +2128,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                          mission_type)
         m = mav.recv_match(type='MISSION_ITEM_INT',
                            blocking=True,
-                           timeout=1)
+                           timeout=1,
+                           condition='MISSION_ITEM_INT.mission_type==%u' % mission_type)
         if m is None:
             raise NotAchievedException("Did not receive mission item int")
         if m.mission_type != mission_type:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2423,7 +2423,8 @@ class AutoTest(ABC):
                                                   mission_type)
             m = self.mav.recv_match(type='MISSION_ITEM_INT',
                                     blocking=True,
-                                    timeout=5)
+                                    timeout=5,
+                                    condition='MISSION_ITEM_INT.mission_type==%u' % mission_type)
             self.progress("Got (%s)" % str(m))
             if m is None:
                 raise NotAchievedException("Did not receive MISSION_ITEM_INT")


### PR DESCRIPTION
use a condition in recv_match() to ensure we don't mix up msgs from
other protocols