### PR TITLE
Rover: on completion of mission Hold or Loiter within Auto

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -558,8 +558,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: MIS_DONE_BEHAVE
     // @DisplayName: Mission done behave
-    // @Description: Mode to become after mission done
-    // @Values: 0:Hold,1:Loiter, 2:Acro
+    // @Description: Behaviour after mission completes
+    // @Values: 0:Hold,1:Loiter,2:Acro
     // @User: Standard
     AP_GROUPINFO("MIS_DONE_BEHAVE", 38, ParametersG2, mis_done_behave, 0),
 

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -437,7 +437,7 @@ void ModeAuto::exit_mission()
     // send message
     gcs().send_text(MAV_SEVERITY_NOTICE, "Mission Complete");
 
-    if (g2.mis_done_behave == MIS_DONE_BEHAVE_LOITER && rover.set_mode(rover.mode_loiter, MODE_REASON_MISSION_END)) {
+    if (g2.mis_done_behave == MIS_DONE_BEHAVE_LOITER && start_loiter()) {
         return;
     }
 
@@ -445,7 +445,7 @@ void ModeAuto::exit_mission()
         return;
     }
 
-    rover.set_mode(rover.mode_hold, MODE_REASON_MISSION_END);
+    start_stop();
 }
 
 // verify_command_callback - callback function called from ap-mission at 10hz or higher when a command is being run


### PR DESCRIPTION
This PR slightly changes how Rover's behaves when an Auto mission is completed.  Previously the vehicle would switch out of Auto to Hold, Loiter or Acro mode (see MIS_DONE_BEHAVE parameter) but this PR uses Hold-within-Auto and Loiter-within-Auto instead (for Acro it still switches modes).

The advantage of this is that the vehicle will stay in Auto mode which can impact failsafe behaviours. In particular we currently suppress Radio failsafes while the vehicle is in Hold mode but we wouldn't want to do that if the vehicle was in Hold-within-Auto.

This PR closes this issue: https://github.com/ArduPilot/ardupilot/issues/12304

This has been successfully tested in SITL