### PR TITLE
Global: Match with other class quotes

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -7,7 +7,7 @@
 
 #include "AP_Compass.h"
 
-extern AP_HAL::HAL& hal;
+const extern AP_HAL::HAL& hal;
 
 #if COMPASS_CAL_ENABLED
 

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <GCS_MAVLink/GCS.h>
 
-extern AP_HAL::HAL& hal;
+const extern AP_HAL::HAL& hal;
 
 // the last page holds the log format in first 4 bytes. Please change
 // this if (and only if!) the low level format changes


### PR DESCRIPTION
I had a file that was recently merged into the master that changed the type of the external reference.
I learned that there are others.
I changed that file.

SHA：
8e412d0885496e91119976dc6bcce0abd596c5eb