### PR TITLE
Dynamically update the harmonic notch using ESC Telemetry

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -172,6 +172,14 @@ enum LoggingParameters {
      LOG_SYSIDS_MSG,
 };
 
+// Harmonic notch update mode
+enum HarmonicNotchDynamicMode {
+    HarmonicNotch_Fixed,
+    HarmonicNotch_UpdateThrottle,
+    HarmonicNotch_UpdateRPM,
+    HarmonicNotch_UpdateBLHeli,
+};
+
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)
 #define MASK_LOG_ATTITUDE_MED           (1<<1)
 #define MASK_LOG_GPS                    (1<<2)

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1296,6 +1296,26 @@ bool AP_BLHeli::get_telem_data(uint8_t esc_index, struct telem_data &td)
     return true;
 }
 
+// return the average motor frequency in Hz for dynamic filtering
+float AP_BLHeli::get_average_motor_frequency_hz() const
+{
+    float motor_freq = 0.0f;
+    uint32_t now = AP_HAL::millis();
+    uint8_t valid_escs = 0;
+    // average the rpm of each motor as reported by BLHeli and convert to Hz
+    for (uint8_t i = 0; i < num_motors; i++) {
+        if (last_telem[i].timestamp_ms && (now - last_telem[i].timestamp_ms < 1000)) {
+            valid_escs++;
+            motor_freq += last_telem[i].rpm / 60.0f;
+        }
+    }
+    if (valid_escs) {
+        motor_freq /= valid_escs;
+    }
+
+    return motor_freq;
+}
+
 /*
   implement the 8 bit CRC used by the BLHeli ESC telemetry protocol
  */
@@ -1342,7 +1362,7 @@ void AP_BLHeli::read_telemetry_packet(void)
     td.voltage = (buf[1]<<8) | buf[2];
     td.current = (buf[3]<<8) | buf[4];
     td.consumption = (buf[5]<<8) | buf[6];
-    td.rpm = ((buf[7]<<8) | buf[8]) * 100 * 2 / motor_poles;
+    td.rpm = ((buf[7]<<8) | buf[8]) * 200 / motor_poles;
     td.timestamp_ms = AP_HAL::millis();
 
     last_telem[last_telem_esc] = td;

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -57,6 +57,8 @@ public:
 
     // get the most recent telemetry data packet for a motor
     bool get_telem_data(uint8_t esc_index, struct telem_data &td);
+    // return the average motor frequency in Hz for dynamic filtering
+    float get_average_motor_frequency_hz() const;
 
     static AP_BLHeli *get_singleton(void) {
         return _singleton;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -224,6 +224,9 @@ public:
     // harmonic notch reference scale factor
     float get_gyro_harmonic_notch_reference(void) const { return _harmonic_notch_filter.reference(); }
 
+    // harmonic notch tracking mode
+    uint8_t get_gyro_harmonic_notch_tracking_mode(void) const { return _harmonic_notch_filter.tracking_mode(); }
+
     // indicate which bit in LOG_BITMASK indicates raw logging enabled
     void set_log_raw_bit(uint32_t log_raw_bit) { _log_raw_bit = log_raw_bit; }
 

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -63,11 +63,19 @@ const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
 
     // @Param: REF
     // @DisplayName: Harmonic Notch Filter reference value
-    // @Description: A reference value of zero disables dynamic updates on the Harmonic Notch Filter and a positive value enables dynamic updates on the Harmonic Notch Filter.  For multicopters, this parameter is the reference value associated with the specified frequency to facilitate frequency scaling of the Harmonic Notch Filter. For helicopters, this parameter is set to 1 to enable the Harmonic Notch Filter using the RPM sensor set to measure rotor speed.  The RPM sensor data is converted to Hz automatically for use in the dynamic notch filter.  This reference value may also be used to scale the rpm sensor data, if required.  For example, rpm sensor data is required to measure motor RPM. Therefore the reference value can be used to scale the RPM sensor to the rotor RPM.
+    // @Description: A reference value of zero disables dynamic updates on the Harmonic Notch Filter and a positive value enables dynamic updates on the Harmonic Notch Filter.  For throttle-based scaling, this parameter is the reference value associated with the specified frequency to facilitate frequency scaling of the Harmonic Notch Filter. For RPM and ESC telemetry based tracking, this parameter is set to 1 to enable the Harmonic Notch Filter using the RPM sensor or ESC telemetry set to measure rotor speed.  The sensor data is converted to Hz automatically for use in the Harmonic Notch Filter.  This reference value may also be used to scale the sensor data, if required.  For example, rpm sensor data is required to measure heli motor RPM. Therefore the reference value can be used to scale the RPM sensor to the rotor RPM.
     // @User: Advanced
-    // @Range: 0.0 0.9
+    // @Range: 0.0 1.0
     // @RebootRequired: True
     AP_GROUPINFO("REF", 6, HarmonicNotchFilterParams, _reference, 0),
+
+    // @Param: MODE
+    // @DisplayName: Harmonic Notch Filter dynamic frequency tracking mode
+    // @Description: Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor or ESC telemetry based. Throttle-based updates should only be used with multicopters.
+    // @Range: 0 3
+    // @Values: 0:Disabled,1:Throttle,2:RPM Sensor,3:ESC Telemetry
+    // @User: Advanced
+    AP_GROUPINFO("MODE", 7, HarmonicNotchFilterParams, _tracking_mode, 1),
 
     AP_GROUPEND
 };

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -68,6 +68,8 @@ public:
     uint8_t harmonics(void) const { return _harmonics; }
     // reference value of the harmonic notch
     float reference(void) const { return _reference; }
+    // notch dynamic tracking mode
+    uint8_t tracking_mode(void) const { return _tracking_mode; }
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -75,6 +77,8 @@ private:
     AP_Int8 _harmonics;
     // notch reference value
     AP_Float _reference;
+    // notch dynamic tracking mode
+    AP_Int8 _tracking_mode;
 };
 
 typedef HarmonicNotchFilter<Vector3f> HarmonicNotchFilterVector3f;


### PR DESCRIPTION
I finally got my hardware working to allow me to play with this. It's incredibly simple and works incredibly well. It takes BLHeli ESC telemetry data and uses the motor rpm from that to update the harmonic notch frequency.

It is enabled by setting INS_HNTCH_MODE to 3 (1 being throttle based, 2 being rpm based and 0 being off)
This graph was generated with INS_HNTCH_REF set to 1.3, but since then I have fixed our erpm->rpm calculation and INS_HNTCH_REF can be set to 1.

![image](https://user-images.githubusercontent.com/2893260/66705648-578be380-ed21-11e9-8494-614a2f3760ca.png)

I have enabled my FFT support so you can see where the actual vibration peak is.

@rmackay9 I'm not trying to make life hard for you, honest!
