### PR TITLE
AP_RangeFinder: Add TF03-180

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
@@ -10,7 +10,8 @@ public:
 
     enum benewake_model_type {
         BENEWAKE_TF02 = 0,
-        BENEWAKE_TFmini = 1
+        BENEWAKE_TFmini = 1,
+        BENEWAKE_TF03 = 2,
     };
 
     // constructor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -6,7 +6,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:BenewakeTFmini,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFMiniPlus
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:BenewakeTFmini,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFMiniPlus,27:BenewakeTF03
     // @User: Standard
     AP_GROUPINFO("TYPE",    1, AP_RangeFinder_Params, type, 0),
 

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -503,6 +503,11 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
             drivers[instance] = new AP_RangeFinder_Benewake(state[instance], params[instance], serial_instance++, AP_RangeFinder_Benewake::BENEWAKE_TFmini);
         }
         break;
+    case RangeFinder_TYPE_BenewakeTF03:
+        if (AP_RangeFinder_Benewake::detect(serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_Benewake(state[instance], params[instance], serial_instance++, AP_RangeFinder_Benewake::BENEWAKE_TF03);
+        }
+        break;
     case RangeFinder_TYPE_PWM:
         if (AP_RangeFinder_PWM::detect()) {
             drivers[instance] = new AP_RangeFinder_PWM(state[instance], params[instance], estimated_terrain_height);

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -73,6 +73,7 @@ public:
         RangeFinder_TYPE_UAVCAN = 24,
         RangeFinder_TYPE_BenewakeTFminiPlus = 25,
         RangeFinder_TYPE_Lanbao = 26,
+        RangeFinder_TYPE_BenewakeTF03 = 27,
     };
 
     enum RangeFinder_Function {


### PR DESCRIPTION
I connected TF03-180 to Pixhawk.
In WIKI, TF02 was specified.
However, it could not be used because the message was different from TF02.
Also different from TFmini.
However, TF03-180 uses only distance.
The maximum distance with TF03-180 is 180 meters.
Therefore, the range finder type was added and the default was 180 meters.

TF03-180 spec
![Screenshot from 2019-10-14 18-34-06](https://user-images.githubusercontent.com/646194/66742191-17a83600-eeb2-11e9-928a-35dcd79c3691.png)

TF03 serial message format:
![Screenshot from 2019-10-14 18-42-06](https://user-images.githubusercontent.com/646194/66742322-5a6a0e00-eeb2-11e9-9e6d-270481ed9ac7.png)

This PR was tested in the following environment.
![IMG-7077](https://user-images.githubusercontent.com/646194/66742596-fa279c00-eeb2-11e9-8182-385bab37f0bd.JPG)

test results: I tested in the room. I checked the distance by moving the device.
![Screenshot from 2019-10-14 18-25-20](https://user-images.githubusercontent.com/646194/66742706-3bb84700-eeb3-11e9-835e-cf3fb7d48ecb.png)