### PR TITLE
AP_Scripting: Stop scripts if enable is set to 0 at runtime

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -87,6 +87,7 @@ bool AP_Scripting::init(void) {
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_Scripting::thread, void),
                                       "Scripting", SCRIPTING_STACK_SIZE, AP_HAL::Scheduler::PRIORITY_SCRIPTING, 0)) {
         gcs().send_text(MAV_SEVERITY_CRITICAL, "Could not create scripting stack (%d)", SCRIPTING_STACK_SIZE);
+        _enable = 0;
         return false;
     }
 
@@ -102,7 +103,7 @@ void AP_Scripting::thread(void) {
     lua->run();
 
     // only reachable if the lua backend has died for any reason
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting has died");
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting has stopped");
 }
 
 AP_Scripting *AP_Scripting::_singleton = nullptr;

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo AP_Scripting::var_info[] = {
     // @Increment: 1024
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("HEAP_SIZE", 3, AP_Scripting, _script_heap_size, 32*1024),
+    AP_GROUPINFO("HEAP_SIZE", 3, AP_Scripting, _script_heap_size, 41*1024),
 
     AP_GROUPINFO("DEBUG_LVL", 4, AP_Scripting, _debug_level, 1),
 

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -30,6 +30,8 @@ public:
 
     bool init(void);
 
+    bool enabled(void) const { return _enable != 0; };
+
     static AP_Scripting * get_singleton(void) { return _singleton; }
 
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -16,6 +16,7 @@
 #include "lua_scripts.h"
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
+#include "AP_Scripting.h"
 #include <AP_ROMFS/AP_ROMFS.h>
 
 #include "lua_generated_bindings.h"
@@ -348,7 +349,7 @@ void lua_scripts::run(void) {
     // Scan the filesystem in an appropriate manner and autostart scripts
     load_all_scripts_in_dir(L, SCRIPTING_DIRECTORY);
 
-    while (true) {
+    while (AP_Scripting::get_singleton()->enabled()) {
 #if defined(AP_SCRIPTING_CHECKS) && AP_SCRIPTING_CHECKS >= 1
         if (lua_gettop(L) != 0) {
             AP_HAL::panic("Lua: Stack should be empty before running scripts");


### PR DESCRIPTION
This allows the GCS to terminate runaway scripts, we should add an RC option to interact with this as well for the future. Closes #11733

The increase to the heap size is simply due to the fact that 32KB doesn't work on real boards anymore either.