### PR TITLE
autotest: make polyfence avoidance test more reliable

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -3501,10 +3501,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                           mavutil.location(expected_stopping_point.lat, expected_stopping_point.lng, 0, 0))
                 print("delta: %s want_delta<%f" % (str(delta), expected_distance_epsilon))
                 at_stopping_point = delta < expected_distance_epsilon
-
-            if at_stopping_point:
-                if t == "VFR_HUD":
-                    print("groundspeed: %f" % m.groundspeed)
+            elif t == "VFR_HUD":
+                print("groundspeed: %f" % m.groundspeed)
+                if at_stopping_point:
                     if m.groundspeed < 1:
                         self.progress("Seemed to have stopped at stopping point")
                         return
@@ -4466,7 +4465,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             fence_middle,
             expected_stopping_point,
             target_system=target_system,
-            target_component=target_component)
+            target_component=target_component,
+            expected_distance_epsilon=2.5)
         self.set_parameter("AVOID_ENABLE", 0)
         self.do_RTL()
 
@@ -4478,6 +4478,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.change_mode("LOITER")
         self.wait_ready_to_arm()
         self.arm_vehicle()
+        self.change_mode("MANUAL")
+        self.reach_heading_manual(180, turn_right=False)
         self.change_mode("GUIDED")
 
         self.test_poly_fence_avoidance_dont_breach_exclusion(target_system=target_system, target_component=target_component)

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1607,7 +1607,7 @@ class AutoTest(ABC):
             if m.custom_mode == custom_mode:
                 return True
 
-    def reach_heading_manual(self, heading):
+    def reach_heading_manual(self, heading, turn_right=True):
         """Manually direct the vehicle to the target heading."""
         if self.is_copter():
             self.mavproxy.send('rc 4 1580\n')
@@ -1616,7 +1616,10 @@ class AutoTest(ABC):
         if self.is_plane():
             self.progress("NOT IMPLEMENTED")
         if self.is_rover():
-            self.mavproxy.send('rc 1 1700\n')
+            steering_pwm = 1700
+            if not turn_right:
+                steering_pwm = 1300
+            self.mavproxy.send('rc 1 %u\n' % steering_pwm)
             self.mavproxy.send('rc 3 1550\n')
             self.wait_heading(heading)
             self.set_rc(3, 1500)


### PR DESCRIPTION
Amusingly, at faster speedups the car made a decision to turn North
rather than South which it does when at lower speedups.

Gave it no choice in the matter.