### PR TITLE
AP_Scripting: Improve uint32_t() and add an example script

### DIFF
--- a/libraries/AP_Scripting/examples/message_interval.lua
+++ b/libraries/AP_Scripting/examples/message_interval.lua
@@ -1,0 +1,23 @@
+-- This script is an example of manipulating the message stream rates
+--
+-- It will periodically run and adjust all the messages to their desired loop rates
+-- It can be modified to only run once, however some GCS's will manipulate the rates
+-- during the initial connection, so by resetting them periodically we ensure we get
+-- the expected telemetry rate
+
+-- intervals is a table which contains a table for each entry we want to adjust
+-- each entry is arranged as {the serial link to adjust, the mavlink message ID, and the broadcast interval in Hz}
+local intervals = {{0, uint32_t(30), 2.0},  -- First serial, ATTITUDE, 2Hz
+                   {0, uint32_t(163), 5.0}} -- First serial, AHRS, 5Hz
+
+local loop_time = 5000 -- number of ms between runs
+
+function update() -- this is the loop which periodically runs
+  for i = 1, #intervals do -- we want to iterate over every specified interval
+    local channel, message, interval_hz = table.unpack(intervals[i]) -- this extracts the channel, MAVLink ID, and interval
+    gcs:set_message_interval(channel, message, math.floor(1000000 / interval_hz)) -- actually sets the interval as appropriate
+  end
+  return update, loop_time -- reschedules the loop
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -4,19 +4,6 @@
 
 extern const AP_HAL::HAL& hal;
 
-int new_uint32_t(lua_State *L) {
-    luaL_checkstack(L, 2, "Out of stack");
-    *static_cast<uint32_t *>(lua_newuserdata(L, sizeof(uint32_t))) = 0; // allocated memory is already zerod, no need to manipulate this
-    luaL_getmetatable(L, "uint32_t");
-    lua_setmetatable(L, -2);
-    return 1;
-}
-
-uint32_t * check_uint32_t(lua_State *L, int arg) {
-    void *data = luaL_checkudata(L, arg, "uint32_t");
-    return static_cast<uint32_t *>(data);
-}
-
 static uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
     { // userdata
         const uint32_t * ud = static_cast<uint32_t *>(luaL_testudata(L, arg, "uint32_t"));
@@ -45,6 +32,25 @@ static uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
     }
     // failure
     return luaL_argerror(L, arg, "Unable to coerce to uint32_t");
+}
+
+int new_uint32_t(lua_State *L) {
+    luaL_checkstack(L, 2, "Out of stack");
+
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    }
+
+    *static_cast<uint32_t *>(lua_newuserdata(L, sizeof(uint32_t))) = (args == 1) ? coerce_to_uint32_t(L, 1) : 0;
+    luaL_getmetatable(L, "uint32_t");
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+uint32_t * check_uint32_t(lua_State *L, int arg) {
+    void *data = luaL_checkudata(L, arg, "uint32_t");
+    return static_cast<uint32_t *>(data);
 }
 
 #define UINT32_T_BOX_OP(name, sym) \

--- a/libraries/AP_Scripting/scripts/sandbox.lua
+++ b/libraries/AP_Scripting/scripts/sandbox.lua
@@ -25,7 +25,7 @@ function get_sandbox_env ()
                    rad = math.rad, random = math.random, sin = math.sin, sinh = math.sinh, 
                    sqrt = math.sqrt, tan = math.tan, tanh = math.tanh },
           table = { insert = table.insert, maxn = table.maxn, remove = table.remove, 
-                    sort = table.sort },
+                    sort = table.sort, unpack = table.unpack },
           utf8 = { char = utf8.char, charpattern = utf8.charpattern, codes = utf8.codes,
                    codepoint = utf8.codepoint, len = utf8.len, offsets = utf8.offsets},
 


### PR DESCRIPTION
This does a couple of things:
1. Most importantly this adds a 1 arg version of uint32_t which will attempt to coerce input to be a `uint32_t` userdata, which means you can now do stuff like `uint32_t(30)` to create the `uint32_t` userdata and assign it an initial value of 30. The value passed must actually map to within a uint32_t's expressible range (so no negative numbers, or larger floats), but this should be a lot more intuitive.

2. This exposes `table.unpack()` inside our sandboxed environment. There wasn't any reason to have dropped it, and it is quite useful.

3. This adds an example script that does message intervals. It's a modification of #12556. I figured since I was in the process of breaking the proposed script I could present a working one here, and this shows a slightly more complex script, that is easier to add new entries to (you just extend the intervals array). We can bring the other script over that just has the copy pasted direct calls if that's thought to be easier for people. @tatsuy and @rmackay9 any preference which one comes in?