### PR TITLE
ardupilotwaf: -Werror=delete-non-virtual-dtor is a C++ flag not a C flag

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -124,7 +124,6 @@ class Board:
             '-Werror=overflow',
             '-Werror=parentheses',
             '-Werror=format-extra-args',
-            '-Werror=delete-non-virtual-dtor',
             '-Werror=ignored-qualifiers',
         ]
 
@@ -191,6 +190,7 @@ class Board:
             '-Werror=unused-result',
             '-Werror=shadow',
             '-Werror=unused-variable',
+            '-Werror=delete-non-virtual-dtor',
             '-Wfatal-errors',
             '-Wno-trigraphs',
             '-Werror=parentheses',


### PR DESCRIPTION
This was in CFLAGS, and destructors are a C++ feature, not a C feature, and it was throwing warnings.

```
[508/603] Compiling libraries/AP_Scripting/lua/src/lua.c
cc1: warning: ‘-Werror=’ argument ‘-Werror=delete-non-virtual-dtor’ is not valid for C
```

Tagged @peterbarker because git blame