### PR TITLE
AP_Scripting: Fix up uint32_t manipulation, fix AP_Notify binding

### DIFF
--- a/libraries/AP_Scripting/examples/easter-egg.lua
+++ b/libraries/AP_Scripting/examples/easter-egg.lua
@@ -1,0 +1,66 @@
+-- This script will select a random location (as defined from a lat long coordinate)
+-- and will play a set of tunes to navigate you towards that point, and select a new once
+-- once the point has been found.
+--
+-- This script primarily serves to demo how to work with Locations, as well as how to
+-- use the tonealarm to play tones, and send status text messages
+
+local ACCEPTANCE_DISTANCE = 20.0
+
+local TUNE_POINT = "MBNT255>A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8"
+local TUNE_TOWARDS = "MFT100L8>B"
+local TUNE_AWAY = "MFT100L4>A#B#"
+
+local target = Location()
+local top_left = Location()
+top_left:lat(-353622666)
+top_left:lng(1491650479)
+
+local last_distance = 1e10
+local notify_interval_ms = uint32_t(5000)
+local last_notify_time_ms = millis()
+local score = 0
+
+function find_next_point ()
+    target:lat(top_left:lat())
+    target:lng(top_left:lng())
+    target:offset(math.random()*-100, math.random()*10)
+    gcs:send_text(6, string.format("New target %d %d", target:lat(), target:lng()))
+    local current = ahrs:get_position()
+    if current then
+        last_distance = current:get_distance(target)
+    end
+    last_distance = 1e10
+    return
+end
+
+function update ()
+    local current = ahrs:get_position()
+    if current then
+        local dist = target:get_distance(current)
+        local now = millis()
+        if dist < ACCEPTANCE_DISTANCE then
+            notify:play_tune(TUNE_POINT)
+            score = score + 1
+            gcs:send_text(6, string.format("Got a point! %d total", score))
+            find_next_point()
+        elseif (now - last_notify_time_ms) > notify_interval_ms then
+            last_notify_time_ms = now
+            gcs:send_text(6, string.format("Distance: %.1f %.1f", target:get_distance(current), dist))
+            if dist < (last_distance - 1) then
+                notify:play_tune(TUNE_TOWARDS)
+            elseif dist > (last_distance + 1) then
+                notify:play_tune(TUNE_AWAY)
+            end
+        end
+        if math.abs(last_distance - dist) > 1.0 then
+            last_distance = dist;
+        end
+
+    end
+    return update, 100
+end
+
+find_next_point()
+
+return update, 100

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -103,7 +103,7 @@ userdata Vector2f operator +
 userdata Vector2f operator -
 
 include AP_Notify/AP_Notify.h
-singleton notify alias notify
+singleton AP_Notify alias notify
 singleton AP_Notify method play_tune void string
 
 include AP_RangeFinder/AP_RangeFinder.h

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -34,9 +34,18 @@ static uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
     return luaL_argerror(L, arg, "Unable to coerce to uint32_t");
 }
 
+// creates a new userdata for a uint32_t
 int new_uint32_t(lua_State *L) {
     luaL_checkstack(L, 2, "Out of stack");
 
+    *static_cast<uint32_t *>(lua_newuserdata(L, sizeof(uint32_t))) = 0;
+    luaL_getmetatable(L, "uint32_t");
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+// the exposed constructor to lua calls to create a uint32_t
+int lua_new_uint32_t(lua_State *L) {
     const int args = lua_gettop(L);
     if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
@@ -199,6 +208,6 @@ void load_boxed_numerics(lua_State *L) {
 void load_boxed_numerics_sandbox(lua_State *L) {
     // if there are ever more drivers then move to a table based solution
     lua_pushstring(L, "uint32_t");
-    lua_pushcfunction(L, new_uint32_t);
+    lua_pushcfunction(L, lua_new_uint32_t);
     lua_settable(L, -3);
 }

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -688,7 +688,7 @@ static int RangeFinder_num_sensors(lua_State *L) {
 static int AP_Notify_play_tune(lua_State *L) {
     AP_Notify * ud = AP_Notify::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, 1, "AP_Notify not supported on this firmware");
+        return luaL_argerror(L, 1, "notify not supported on this firmware");
     }
 
     binding_argcheck(L, 2);
@@ -1575,10 +1575,6 @@ const luaL_Reg AP_Notify_meta[] = {
     {NULL, NULL}
 };
 
-const luaL_Reg notify_meta[] = {
-    {NULL, NULL}
-};
-
 const luaL_Reg AP_GPS_meta[] = {
     {"first_unconfigured_gps", AP_GPS_first_unconfigured_gps},
     {"get_antenna_offset", AP_GPS_get_antenna_offset},
@@ -1681,8 +1677,7 @@ const struct userdata_meta singleton_fun[] = {
     {"relay", AP_Relay_meta, NULL},
     {"terrain", AP_Terrain_meta, AP_Terrain_enums},
     {"rangefinder", RangeFinder_meta, NULL},
-    {"AP_Notify", AP_Notify_meta, NULL},
-    {"notify", notify_meta, NULL},
+    {"notify", AP_Notify_meta, NULL},
     {"gps", AP_GPS_meta, AP_GPS_enums},
     {"battery", AP_BattMonitor_meta, NULL},
     {"arming", AP_Arming_meta, NULL},
@@ -1732,7 +1727,6 @@ const char *singletons[] = {
     "relay",
     "terrain",
     "rangefinder",
-    "AP_Notify",
     "notify",
     "gps",
     "battery",


### PR DESCRIPTION
The new uint32_t constructor accidentally caused a problem with normal math operations in some situations, which this fixes. AP_Notify also had a bad alias declaration, which resulted in not being able to usefully use the play_tune call. Finally this also adds a touched up version of the foxhunt demo that was done at the 2019 developer unconf.