### PR TITLE
Correct send_to_components

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -4749,6 +4749,47 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.test_scripting_hello_world()
         self.test_scripting_simple_loop()
 
+    def test_send_to_components(self):
+        self.progress("Introducing ourselves to the autopilot as a component")
+        old_srcSystem = self.mav.mav.srcSystem
+        self.mav.mav.srcSystem = 1
+        self.mav.mav.heartbeat_send(
+            mavutil.mavlink.MAV_TYPE_ONBOARD_CONTROLLER,
+            mavutil.mavlink.MAV_AUTOPILOT_INVALID,
+            0,
+            0,
+            0)
+        self.progress("Sending control message")
+        self.mav.mav.digicam_control_send(
+            1, # target_system
+            1, # target_component
+            1, # start or keep it up
+            1, # zoom_pos
+            0, # zoom_step
+            0, # focus_lock
+            1, # 1 shot or start filming
+            17, # command id (de-dupe field)
+            0, # extra_param
+            0.0, # extra_value
+        )
+        self.mav.mav.srcSystem = old_srcSystem
+
+        self.progress("Expecting a command long")
+        tstart = self.get_sim_time_cached()
+        while True:
+            now = self.get_sim_time_cached()
+            if now - tstart > 2:
+                raise NotAchievedException("Did not receive digicam_control message")
+            m = self.mav.recv_match(type='COMMAND_LONG', blocking=True, timeout=0.1)
+            self.progress("Message: %s" % str(m))
+            if m is None:
+                continue
+            if m.command != mavutil.mavlink.MAV_CMD_DO_DIGICAM_CONTROL:
+                raise NotAchievedException("Did not get correct command")
+            if m.param6 != 17:
+                raise NotAchievedException("Did not get correct command_id")
+            break
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestRover, self).tests()
@@ -4898,6 +4939,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             ("PolyFenceObjectAvoidanceBendyRuler",
              "PolyFence object avoidance tests - bendy ruler",
              self.test_poly_fence_object_avoidance_bendy_ruler),
+
+            ("SendToComponents",
+             "Test ArduPilot send_to_components function",
+             self.test_send_to_components),
 
             ("PolyFenceObjectAvoidanceBendyRulerEasier",
              "PolyFence object avoidance tests - easier bendy ruler test",

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -465,12 +465,10 @@ void AP_BattMonitor::checkPoweringOff(void)
             AP_Notify::flags.powering_off = true;
 
             // Send a Mavlink broadcast announcing the shutdown
-            mavlink_message_t msg;
             mavlink_command_long_t cmd_msg{};
             cmd_msg.command = MAV_CMD_POWER_OFF_INITIATED;
             cmd_msg.param1 = i+1;
-            mavlink_msg_command_long_encode(mavlink_system.sysid, MAV_COMP_ID_ALL, &msg, &cmd_msg);
-            GCS_MAVLINK::send_to_components(msg);
+            GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&cmd_msg, sizeof(cmd_msg));
             gcs().send_text(MAV_SEVERITY_WARNING, "Vehicle %d battery %d is powering off", mavlink_system.sysid, i+1);
 
             // only send this once

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -211,7 +211,6 @@ void AP_Camera::configure(float shooting_mode, float shutter_speed, float apertu
     // we cannot process the configure command so convert to mavlink message
     // and send to all components in case they and process it
 
-    mavlink_message_t msg;
     mavlink_command_long_t mav_cmd_long = {};
 
     // convert mission command to mavlink command_long
@@ -224,11 +223,8 @@ void AP_Camera::configure(float shooting_mode, float shutter_speed, float apertu
     mav_cmd_long.param6 = cmd_id;
     mav_cmd_long.param7 = engine_cutoff_time;
 
-    // Encode Command long into MAVLINK msg
-    mavlink_msg_command_long_encode(0, 0, &msg, &mav_cmd_long);
-
     // send to all components
-    GCS_MAVLINK::send_to_components(msg);
+    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&mav_cmd_long, sizeof(mav_cmd_long));
 
     if (_type == AP_Camera::CAMERA_TYPE_BMMCC) {
         // Set a trigger for the additional functions that are flip controlled (so far just ISO and Record Start / Stop use this method, will add others if required)
@@ -261,7 +257,6 @@ void AP_Camera::control(float session, float zoom_pos, float zoom_step, float fo
         trigger_pic();
     }
 
-    mavlink_message_t msg;
     mavlink_command_long_t mav_cmd_long = {};
 
     // convert command to mavlink command long
@@ -273,11 +268,8 @@ void AP_Camera::control(float session, float zoom_pos, float zoom_step, float fo
     mav_cmd_long.param5 = shooting_cmd;
     mav_cmd_long.param6 = cmd_id;
 
-    // Encode Command long into MAVLINK msg
-    mavlink_msg_command_long_encode(0, 0, &msg, &mav_cmd_long);
-
     // send to all components
-    GCS_MAVLINK::send_to_components(msg);
+    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&mav_cmd_long, sizeof(mav_cmd_long));
 }
 
 /*
@@ -431,16 +423,12 @@ void AP_Camera::take_picture()
     trigger_pic();
 
     // tell all of our components to take a picture:
-    mavlink_command_long_t cmd_msg;
-    memset(&cmd_msg, 0, sizeof(cmd_msg));
+    mavlink_command_long_t cmd_msg {};
     cmd_msg.command = MAV_CMD_DO_DIGICAM_CONTROL;
     cmd_msg.param5 = 1;
-    // create message
-    mavlink_message_t msg;
-    mavlink_msg_command_long_encode(0, 0, &msg, &cmd_msg);
 
     // forward to all components
-    GCS_MAVLINK::send_to_components(msg);
+    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&cmd_msg, sizeof(cmd_msg));
 }
 
 /*

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -241,8 +241,8 @@ public:
       send a MAVLink message to all components with this vehicle's system id
       This is a no-op if no routes to components have been learned
     */
-    static void send_to_components(const mavlink_message_t &msg) { routing.send_to_components(msg); }
-    
+    static void send_to_components(uint32_t msgid, const char *pkt, uint8_t pkt_len) { routing.send_to_components(msgid, pkt, pkt_len); }
+
     /*
       allow forwarding of packets / heartbeats to be blocked as required by some components to reduce traffic
     */

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -32,8 +32,11 @@ public:
     /*
       send a MAVLink message to all components with this vehicle's system id
       This is a no-op if no routes to components have been learned
+
+      msgid here is the mavlink message ID, pkt is a pointer to a
+      mavlink message structure (e.g. a mavlink_command_long_t)
     */
-    void send_to_components(const mavlink_message_t &msg);
+    void send_to_components(uint32_t msgid, const char *pkt, uint8_t pkt_len);
 
     /*
       search for the first vehicle or component in the routing table with given mav_type and retrieve it's sysid, compid and channel
@@ -63,4 +66,6 @@ private:
 
     // special handling for heartbeat messages
     void handle_heartbeat(mavlink_channel_t in_channel, const mavlink_message_t &msg);
+
+    void send_to_components(const char *pkt, const mavlink_msg_entry_t *entry, uint8_t pkt_len);
 };


### PR DESCRIPTION
Attempts to solve a problem where component messages aren't send with the correct wire protocol.

Tested only as far as "it compiles".

Hopefully closes https://github.com/ArduPilot/ardupilot/issues/12567

This may cause vehicles to explode and/or turn into small mounds of granulated gelatin.  It's unlikely, however.

