### PR TITLE
Rover: wheel encoder fixes

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -289,7 +289,7 @@ void Rover::send_wheel_encoder_distance(const mavlink_channel_t chan)
         for (uint8_t i = 0; i < g2.wheel_encoder.num_sensors(); i++) {
             distances[i] = wheel_encoder_last_distance_m[i];
         }
-        mavlink_msg_wheel_distance_send(chan, 1000UL * wheel_encoder_last_ekf_update_ms, g2.wheel_encoder.num_sensors(), distances);
+        mavlink_msg_wheel_distance_send(chan, 1000UL * AP_HAL::millis(), g2.wheel_encoder.num_sensors(), distances);
     }
 }
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -267,11 +267,12 @@ private:
     // Store the time the last GPS message was received.
     uint32_t last_gps_msg_ms{0};
 
-    // last wheel encoder update times
+    // latest wheel encoder values
+    float wheel_encoder_last_distance_m[WHEELENCODER_MAX_INSTANCES];    // total distance recorded by wheel encoder (for reporting to GCS)
+    bool wheel_encoder_initialised;                                     // true once arrays below have been initialised to sensors initial values
     float wheel_encoder_last_angle_rad[WHEELENCODER_MAX_INSTANCES];     // distance in radians at time of last update to EKF
-    float wheel_encoder_last_distance_m[WHEELENCODER_MAX_INSTANCES];    // distance in meters at time of last update to EKF (for reporting to GCS)
-    uint32_t wheel_encoder_last_update_ms[WHEELENCODER_MAX_INSTANCES];  // system time of last ping from each encoder
-    uint32_t wheel_encoder_last_ekf_update_ms;                          // system time of last encoder data push to EKF
+    uint32_t wheel_encoder_last_reading_ms[WHEELENCODER_MAX_INSTANCES]; // system time of last ping from each encoder
+    uint8_t wheel_encoder_last_index_sent;                              // index of the last wheel encoder sent to the EKF
 
     // True when we are doing motor test
     bool motor_test;

--- a/APMrover2/ekf_check.cpp
+++ b/APMrover2/ekf_check.cpp
@@ -132,12 +132,12 @@ bool Rover::ekf_position_ok()
     nav_filter_status filt_status;
     rover.ahrs.get_filter_status(filt_status);
 
-    // if disarmed we accept a predicted horizontal position
+    // if disarmed we accept a predicted horizontal absolute or relative position
     if (!arming.is_armed()) {
-        return ((filt_status.flags.horiz_pos_abs || filt_status.flags.pred_horiz_pos_abs));
+        return (filt_status.flags.horiz_pos_abs || filt_status.flags.pred_horiz_pos_abs || filt_status.flags.horiz_pos_rel || filt_status.flags.pred_horiz_pos_rel);
     } else {
-        // once armed we require a good absolute position and EKF must not be in const_pos_mode
-        return (filt_status.flags.horiz_pos_abs && !filt_status.flags.const_pos_mode);
+        // once armed we require a good absolute or relative position and EKF must not be in const_pos_mode
+        return ((filt_status.flags.horiz_pos_abs || filt_status.flags.horiz_pos_rel) && !filt_status.flags.const_pos_mode);
     }
 }
 

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -26,7 +26,7 @@ void Rover::set_control_channels(void)
         // For a rover safety is TRIM throttle
         g2.motors.setup_safety_output();
     }
-    // setup correct scaling for ESCs like the UAVCAN PX4ESC which
+    // setup correct scaling for ESCs like the UAVCAN ESCs which
     // take a proportion of speed. Default to 1000 to 2000 for systems without
     // a k_throttle output
     hal.rcout->set_esc_scaling(1000, 2000);

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -59,7 +59,7 @@ void Copter::init_rc_out()
 #if FRAME_CONFIG != HELI_FRAME
     motors->set_throttle_range(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 #else
-    // setup correct scaling for ESCs like the UAVCAN PX4ESC which
+    // setup correct scaling for ESCs like the UAVCAN ESCs which
     // take a proportion of speed.
     hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 #endif

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -707,7 +707,7 @@ bool QuadPlane::setup(void)
     pos_control->set_dt(loop_delta_t);
     attitude_control->parameter_sanity_check();
 
-    // setup the trim of any motors used by AP_Motors so px4io
+    // setup the trim of any motors used by AP_Motors so I/O board
     // failsafe will disable motors
     for (uint8_t i=0; i<8; i++) {
         SRV_Channel::Aux_servo_function_t func = SRV_Channels::get_motor_function(i);

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -45,7 +45,7 @@ void Plane::set_control_channels(void)
     }
 
     if (!quadplane.enable) {
-        // setup correct scaling for ESCs like the UAVCAN PX4ESC which
+        // setup correct scaling for ESCs like the UAVCAN ESCs which
         // take a proportion of speed. For quadplanes we use AP_Motors
         // scaling
         g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_throttle);
@@ -84,7 +84,7 @@ void Plane::init_rc_out_main()
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_rudder, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
     
-    // setup PX4 to output the min throttle when safety off if arming
+    // setup flight controller to output the min throttle when safety off if arming
     // is setup for min on disarm
     if (arming.arming_required() == AP_Arming::Required::YES_MIN_PWM) {
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, have_reverse_thrust()?SRV_Channel::SRV_CHANNEL_LIMIT_TRIM:SRV_Channel::SRV_CHANNEL_LIMIT_MIN);

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -60,7 +60,7 @@ public:
         k_param_sysid_my_gcs,
 
         // Hardware/Software configuration
-        k_param_BoardConfig = 20, // Board configuration (PX4/Linux/etc)
+        k_param_BoardConfig = 20, // Board configuration (Pixhawk/Linux/etc)
         k_param_scheduler, // Scheduler (for debugging/perf_info)
         k_param_logger, // AP_Logger Logging
         k_param_serial_manager, // Serial ports, AP_SerialManager

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1104,14 +1104,14 @@ bool NavEKF2::getOriginLLH(int8_t instance, struct Location &loc) const
 // Returns false if the filter has rejected the attempt to set the origin
 bool NavEKF2::setOriginLLH(const Location &loc)
 {
+    if (!core) {
+        return false;
+    }
     if (_fusionModeGPS != 3) {
         // we don't allow setting of the EKF origin unless we are
         // flying in non-GPS mode. This is to prevent accidental set
         // of EKF origin with invalid position or height
         gcs().send_text(MAV_SEVERITY_WARNING, "EKF2 refusing set origin");
-        return false;
-    }
-    if (!core) {
         return false;
     }
     bool ret = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1127,14 +1127,14 @@ bool NavEKF3::getOriginLLH(int8_t instance, struct Location &loc) const
 // Returns false if the filter has rejected the attempt to set the origin
 bool NavEKF3::setOriginLLH(const Location &loc)
 {
+    if (!core) {
+        return false;
+    }
     if (_fusionModeGPS != 3) {
         // we don't allow setting of the EKF origin unless we are
         // flying in non-GPS mode. This is to prevent accidental set
         // of EKF origin with invalid position or height
         gcs().send_text(MAV_SEVERITY_WARNING, "EKF3 refusing set origin");
-        return false;
-    }
-    if (!core) {
         return false;
     }
     bool ret = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -233,6 +233,7 @@ public:
      * timeStamp_ms is the time when the rotation was last measured (msec)
      * posOffset is the XYZ body frame position of the wheel hub (m)
      * radius is the effective rolling radius of the wheel (m)
+     * this should not be called at more than the EKF's update rate (50hz or 100hz)
     */
     void writeWheelOdom(float delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset, float radius);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -140,9 +140,10 @@ void NavEKF3_core::writeWheelOdom(float delAng, float delTime, uint32_t timeStam
     // It uses the exisiting body frame velocity fusion.
     // TODO implement a dedicated wheel odometry observation model
 
+    // rate limiting to 50hz should be done by the caller
     // limit update rate to maximum allowed by sensor buffers and fusion process
     // don't try to write to buffer until the filter has been initialised
-    if (((timeStamp_ms - wheelOdmMeasTime_ms) < frontend->sensorIntervalMin_ms) || (delTime < dtEkfAvg) || !statesInitialised) {
+    if ((delTime < dtEkfAvg) || !statesInitialised) {
         return;
     }
 

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo AP_RPM::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: RPM type
     // @Description: What type of RPM sensor is connected
-    // @Values: 0:None,1:PX4-PWM,2:AUXPIN
+    // @Values: 0:None,1:PWM,2:AUXPIN
     // @User: Standard
     AP_GROUPINFO("_TYPE",    0, AP_RPM, _type[0], 0),
 
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AP_RPM::var_info[] = {
     // @Param: 2_TYPE
     // @DisplayName: Second RPM type
     // @Description: What type of RPM sensor is connected
-    // @Values: 0:None,1:PX4-PWM,2:AUXPIN
+    // @Values: 0:None,1:PWM,2:AUXPIN
     // @User: Advanced
     AP_GROUPINFO("2_TYPE",    10, AP_RPM, _type[1], 0),
 
@@ -111,8 +111,8 @@ void AP_RPM::init(void)
     for (uint8_t i=0; i<RPM_MAX_INSTANCES; i++) {
         uint8_t type = _type[i];
 
-        if (type == RPM_TYPE_PX4_PWM) {
-            // on non-PX4 treat PX4-pin as AUXPIN option, for upgrade
+        if (type == RPM_TYPE_PWM) {
+            // PWM option same as PIN option, for upgrade
             type = RPM_TYPE_PIN;
         }
         if (type == RPM_TYPE_PIN) {

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -38,7 +38,7 @@ public:
     // RPM driver types
     enum RPM_Type {
         RPM_TYPE_NONE    = 0,
-        RPM_TYPE_PX4_PWM = 1,
+        RPM_TYPE_PWM     = 1,
         RPM_TYPE_PIN     = 2
     };
 


### PR DESCRIPTION
This PR resolves a few issues with Rover's wheel encoder support:

- Rover/EKF: only one wheel encoder info is used (https://github.com/ArduPilot/ardupilot/issues/7139)
- Rover: fix non-GPS wheel encoder feature (https://github.com/ArduPilot/ardupilot/issues/9303)
- Rover: Cannot enter Guided mode with only wheel-encoders (https://github.com/ArduPilot/ardupilot/issues/10752)

The changes are:

- EKF3 allows the writeWheelOdom() method to be called at more than 20hz.  The EKF3 has the memory to allow updates at the EKF update rate (50hz to 100hz depending upon the vehicle's main loop rate).  We limit the updates to 50hz in the Rover update_wheel_encoder method.
- Rover sends data from only 1 wheel encoder on each iteration of the update_wheel_encoder method (which updates at 50hz).  Previously data from all wheel encoders was sent which would lead to the EKF only using the 1st.
- Rover's EKF check (used to stop the vehicle from a drive-away if it loses it's position estimate) is modified to work with relative position estimates (this is what the EKF uses when using only wheel encoders or optical flow sensors)
- EKF2/EKF3 will only display the "refusing set origin" only if it's enabled.  Previously the message would appear from the EKF2 when users set the EKF origin from the GCS (which they must do when using only wheel encoders) even though the EKF2 was disabled (wheel encoders only work with the EKF3).

This PR also includes these unrelated non-functional changes:

- minor comment changes to remove some historical NuttX-ish names from Rover, Copter, Plane, Sub and the AP_RPM library

This has been lightly tested on a real vehicle