### PR TITLE
autotest: increase allowed time for receiving ack to compass-cal cmd

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3072,7 +3072,7 @@ class AutoTestCopter(AutoTest):
                          0,
                          0,
                          0,
-                         timeout=1)
+                         timeout=2)
             tstart = self.get_sim_time()
             last_twist_time = 0
             while True:


### PR DESCRIPTION
Saw an instance of this timeout happening on the server