### PR TITLE
ahrs log active ekf

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -587,6 +587,10 @@ public:
         return _rsem;
     }
 
+    virtual uint8_t get_active_EKF_type(void) const {
+        return 0;
+    }
+
 protected:
     void update_nmea_out();
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -965,7 +965,7 @@ uint8_t AP_AHRS_NavEKF::ekf_type(void) const
 
 AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
 {
-    EKF_TYPE ret = EKF_TYPE_NONE;
+    _active_EKF_type = EKF_TYPE_NONE;
 
     switch (ekf_type()) {
     case 0:
@@ -980,10 +980,10 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
             uint16_t ekf2_faults;
             EKF2.getFilterFaults(-1,ekf2_faults);
             if (ekf2_faults == 0) {
-                ret = EKF_TYPE2;
+                _active_EKF_type = EKF_TYPE2;
             }
         } else if (EKF2.healthy()) {
-            ret = EKF_TYPE2;
+            _active_EKF_type = EKF_TYPE2;
         }
         break;
     }
@@ -997,17 +997,17 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
             uint16_t ekf3_faults;
             EKF3.getFilterFaults(-1,ekf3_faults);
             if (ekf3_faults == 0) {
-                ret = EKF_TYPE3;
+                _active_EKF_type = EKF_TYPE3;
             }
         } else if (EKF3.healthy()) {
-            ret = EKF_TYPE3;
+            _active_EKF_type = EKF_TYPE3;
         }
         break;
     }
         
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKF_TYPE_SITL:
-        ret = EKF_TYPE_SITL;
+        _active_EKF_type = EKF_TYPE_SITL;
         break;
 #endif
     }
@@ -1020,17 +1020,17 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
       that the arming checks do wait for good GPS position on fixed
       wing and rover
      */
-    if (ret != EKF_TYPE_NONE &&
+    if (_active_EKF_type != EKF_TYPE_NONE &&
         (_vehicle_class == AHRS_VEHICLE_FIXED_WING ||
          _vehicle_class == AHRS_VEHICLE_GROUND) &&
         (_flags.fly_forward || !hal.util->get_soft_armed())) {
         nav_filter_status filt_state;
-        if (ret == EKF_TYPE2) {
+        if (_active_EKF_type == EKF_TYPE2) {
             EKF2.getFilterStatus(-1,filt_state);
-        } else if (ret == EKF_TYPE3) {
+        } else if (_active_EKF_type == EKF_TYPE3) {
             EKF3.getFilterStatus(-1,filt_state);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        } else if (ret == EKF_TYPE_SITL) {
+        } else if (_active_EKF_type == EKF_TYPE_SITL) {
             get_filter_status(filt_state);
 #endif
         }
@@ -1061,13 +1061,13 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
                   speed the EKF should get yaw alignment
                 */
                 if (filt_state.flags.gps_quality_good) {
-                    return ret;
+                    return _active_EKF_type;
                 }
             }
             return EKF_TYPE_NONE;
         }
     }
-    return ret;
+    return _active_EKF_type;
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -271,6 +271,10 @@ public:
     // check whether compass can be bypassed for arming check in case when external navigation data is available 
     bool is_ext_nav_used_for_yaw(void) const;
 
+    uint8_t get_active_EKF_type(void) const override {
+        return _active_EKF_type;
+    }
+
 private:
     enum EKF_TYPE {EKF_TYPE_NONE=0,
                    EKF_TYPE3=3,
@@ -279,6 +283,9 @@ private:
                    ,EKF_TYPE_SITL=10
 #endif
     };
+
+    mutable EKF_TYPE _active_EKF_type;
+
     EKF_TYPE active_EKF_type(void) const;
 
     bool always_use_EKF() const {

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -510,6 +510,7 @@ void AP_Logger::Write_AHRS2()
         q2    : quat.q2,
         q3    : quat.q3,
         q4    : quat.q4,
+        ekf   : ahrs.get_active_EKF_type(),
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -409,6 +409,7 @@ struct PACKED log_AHRS {
     int32_t lat;
     int32_t lng;
     float q1, q2, q3, q4;
+    uint8_t ekf;
 };
 
 struct PACKED log_POS {
@@ -1406,11 +1407,11 @@ struct PACKED log_Arm_Disarm {
     { LOG_IMU3_MSG, sizeof(log_IMU), \
       "IMU3",  IMU_FMT,     IMU_LABELS, IMU_UNITS, IMU_MULTS }, \
     { LOG_AHR2_MSG, sizeof(log_AHRS), \
-      "AHR2","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4","sddhmDU????", "FBBB0GG????" }, \
+      "AHR2","QccCfLLffffb","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4,EKF","sddhmDU????-", "FBBB0GG????-" }, \
     { LOG_POS_MSG, sizeof(log_POS), \
       "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" }, \
     { LOG_SIMSTATE_MSG, sizeof(log_AHRS), \
-      "SIM","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4", "sddhmDU????", "FBBB0GG????" }, \
+      "SIM","QccCfLLffffb","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4,EKF", "sddhmDU????-", "FBBB0GG????-" }, \
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
       "NKF1","QccCfffffffccce","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ,OH", "sddhnnnnmmmkkkm", "FBBB0000000BBBB" }, \
     { LOG_NKF2_MSG, sizeof(log_NKF2), \


### PR DESCRIPTION
Allow AHRS to log active ekf type under AHR2, make it optional.
Activate this log for arduplane.

This is very useful when EKF type is changed during flight. I really change EKF from 2 to 3 for testing and it's not easy on logs to find which one was using at this specific time.
Also useful to know when fails to DCM for any reason.