### PR TITLE
Copter: corrected undefined data member causing linking error

### DIFF
--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -55,6 +55,33 @@ const AP_Param::GroupInfo AP_KDECAN::var_info[] = {
 };
 
 
+const uint8_t AP_KDECAN::AUTOPILOT_NODE_ID;
+const uint8_t AP_KDECAN::BROADCAST_NODE_ID;
+const uint8_t AP_KDECAN::ESC_NODE_ID_FIRST;
+
+const uint8_t AP_KDECAN::ESC_INFO_OBJ_ADDR;
+const uint8_t AP_KDECAN::SET_PWM_OBJ_ADDR;
+const uint8_t AP_KDECAN::VOLTAGE_OBJ_ADDR;
+const uint8_t AP_KDECAN::CURRENT_OBJ_ADDR;
+const uint8_t AP_KDECAN::RPM_OBJ_ADDR;
+const uint8_t AP_KDECAN::TEMPERATURE_OBJ_ADDR;
+const uint8_t AP_KDECAN::GET_PWM_INPUT_OBJ_ADDR;
+const uint8_t AP_KDECAN::GET_PWM_OUTPUT_OBJ_ADDR;
+const uint8_t AP_KDECAN::MCU_ID_OBJ_ADDR;
+const uint8_t AP_KDECAN::UPDATE_NODE_ID_OBJ_ADDR;
+const uint8_t AP_KDECAN::ENUM_OBJ_ADDR;
+const uint8_t AP_KDECAN::TELEMETRY_OBJ_ADDR;
+
+const uint16_t AP_KDECAN::SET_PWM_MIN_INTERVAL_US;
+const uint32_t AP_KDECAN::TELEMETRY_INTERVAL_US;
+
+const uint32_t AP_KDECAN::SET_PWM_TIMEOUT_US;
+const uint16_t AP_KDECAN::TELEMETRY_TIMEOUT_US;
+const uint16_t AP_KDECAN::ENUMERATION_TIMEOUT_MS;
+
+const uint8_t AP_KDECAN::CAN_IFACE_INDEX;
+
+
 AP_KDECAN::AP_KDECAN()
 {
     AP_Param::setup_object_defaults(this, var_info);


### PR DESCRIPTION
**Problem:**

Linking arducopter : 

`/home/debian/sd_tmp/ardupilot/build/blue/../../libraries/AP_KDECAN/AP_KDECAN.cpp:419: undefined reference to 'AP_KDECAN::SET_PWM_MIN_INTERVAL_US'`

**Solution:**

The `static const uint16_t SET_PWM_MIN_INTERVAL_US = 2500` data member is only declared, but not defined.

After compiling AP_KDECAN.cpp **without the definition**:
```
nm -C libraries/AP_KDECAN/AP_KDECAN.cpp.0.o | grep SET_PWM_MIN_INTERVAL_US
         U AP_KDECAN::SET_PWM_MIN_INTERVAL_US
```
One can see that the SET_PWM_MIN_INTERVAL_US symbol is undefined in the object file and this leads to the problem mentioned here: https://github.com/ArduPilot/ardupilot/pull/12566

After compiling AP_KDECAN.cpp **with the definition**:
```
nm -C libraries/AP_KDECAN/AP_KDECAN.cpp.0.o | grep SET_PWM_MIN_INTERVAL_US
00000000 R AP_KDECAN::SET_PWM_MIN_INTERVAL_US
```
One can see that the SET_PWM_MIN_INTERVAL_US symbol is now defined in the object file and therefore arducopter builds:

![image2](https://user-images.githubusercontent.com/8594515/67152288-2be59c00-f2d3-11e9-8ac3-65d56858d1c5.png)

Reference: https://stackoverflow.com/questions/5391973/undefined-reference-to-static-const-int

Hope this helps,
Vlad