### PR TITLE
Add simple test for scripting

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import copy
 import os
+import shutil
 import sys
 import time
 
@@ -4621,6 +4622,93 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             target_component=target_component,
         )
 
+    def script_source_path(self, scriptname):
+        return os.path.join(self.rootdir(), "libraries", "AP_Scripting", "examples", scriptname)
+
+    def installed_script_path(self, scriptname):
+        return os.path.join(self.rootdir(), "scripts", scriptname)
+
+    def install_example_script(self, scriptname):
+        source = self.script_source_path(scriptname)
+        dest = self.installed_script_path(scriptname)
+        destdir = os.path.dirname(dest)
+        if not os.path.exists(destdir):
+            os.mkdir(destdir)
+        shutil.copy(source, dest)
+
+    def remove_example_script(self, scriptname):
+        dest = self.installed_script_path(scriptname)
+        try:
+            os.unlink(dest)
+        except IOError:
+            pass
+        except OSError:
+            pass
+
+    def test_scripting_simple_loop(self):
+        ex = None
+        example_script = "simple_loop.lua"
+        messages = []
+        def my_message_hook(mav, m):
+            if m.get_type() != 'STATUSTEXT':
+                return
+            messages.append(m)
+        self.install_message_hook(my_message_hook)
+        try:
+            self.set_parameter("SCR_ENABLE", 1)
+            self.install_example_script(example_script)
+            self.reboot_sitl()
+        except Exception as e:
+            ex = e
+        self.remove_example_script(example_script)
+        self.reboot_sitl()
+
+        self.remove_message_hook(my_message_hook)
+
+        if ex is not None:
+            raise ex
+
+        # check all messages to see if we got our message
+        count = 0
+        for m in messages:
+            if "hello, world" in m.text:
+                count += 1
+        self.progress("Got %u hellos" % count)
+        if count < 3:
+            raise NotAchievedException("Expected at least three hellos")
+
+    def test_scripting_hello_world(self):
+        ex = None
+        example_script = "hello_world.lua"
+        messages = []
+        def my_message_hook(mav, m):
+            if m.get_type() != 'STATUSTEXT':
+                return
+            messages.append(m)
+        self.install_message_hook(my_message_hook)
+        try:
+            self.set_parameter("SCR_ENABLE", 1)
+            self.install_example_script(example_script)
+            self.reboot_sitl()
+        except Exception as e:
+            ex = e
+        self.remove_example_script(example_script)
+        self.reboot_sitl()
+
+        self.remove_message_hook(my_message_hook)
+
+        if ex is not None:
+            raise ex
+
+        # check all messages to see if we got our message
+        for m in messages:
+            if "hello, world" in m.text:
+                return # success!
+        raise NotAchievedException("Did not get expected text")
+
+    def test_scripting(self):
+        self.test_scripting_hello_world()
+        self.test_scripting_simple_loop()
 
     def tests(self):
         '''return list of all tests'''
@@ -4775,6 +4863,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             ("PolyFenceObjectAvoidanceBendyRulerEasier",
              "PolyFence object avoidance tests - easier bendy ruler test",
              self.test_poly_fence_object_avoidance_bendy_ruler_easier),
+
+            ("Scripting",
+             "Scripting test",
+             self.test_scripting),
 
             ("DownLoadLogs", "Download logs", lambda:
              self.log_download(

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -647,6 +647,20 @@ class AutoTest(ABC):
         wploader.load(filename)
         return wploader.count()
 
+    def install_message_hook(self, hook):
+        self.mav.message_hooks.append(hook)
+
+    def remove_message_hook(self, hook):
+        oldlen = len(self.mav.message_hooks)
+        self.mav.message_hooks = list(filter(lambda x : x != hook,
+                                        self.mav.message_hooks))
+        if len(self.mav.message_hooks) == oldlen:
+            raise NotAchievedException("Failed to remove hook")
+
+    def rootdir(self):
+        this_dir = os.path.dirname(__file__)
+        return os.path.realpath(os.path.join(this_dir, "../.."))
+
     def mission_directory(self):
         return testdir
 

--- a/libraries/AP_Scripting/examples/hello_world.lua
+++ b/libraries/AP_Scripting/examples/hello_world.lua
@@ -1,0 +1,3 @@
+-- This script is an example of saying hello
+
+gcs:send_text(0, "hello, world") -- send the traditional message

--- a/libraries/AP_Scripting/examples/simple_loop.lua
+++ b/libraries/AP_Scripting/examples/simple_loop.lua
@@ -1,0 +1,8 @@
+-- This script is an example of saying hello.  A lot.
+
+function update() -- this is the loop which periodically runs
+  gcs:send_text(0, "hello, world") -- send the traditional message
+  return update, 1000 -- reschedules the loop
+end
+
+return update() -- run immediately before starting to reschedule


### PR DESCRIPTION
I was cordially informed that appropriate extended descriptions of Pull Requests were desired.

It was, however, unclear as to whether they should actually relate to the subject of the Pull Request, so perhaps it would be wise to talk for a while about dolphins.

Or endorphins.

Or possible Dolph Lundgren.

MdB was unclear on that matter.

More complex tests will follow.

Testing a simple hello world script turns out to be complicated by our reboot swallowing messages, thus the creation of a simple loop example.

Tests for the cabbage-hunt script will follow in the future; MdB seemed to be suggesting some sort of frontend/backend split for the simulated tonealarm device so we can capture the tones being emitted.

I can't help but think the looping script sounds a bit needy.

We could choose to clear the scripts directory before running script tests.  That may cause people to lose work - perhaps we rename the scripts in there, or introduce an overriding environment variable?  (future work.... in the meantime pre-existing scripts may cause tests to fail for e.g. out-of-memory reasons).
