### PR TITLE
Compass Ordering Improvement

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -96,8 +96,9 @@ bool AP_Arming_Copter::compass_checks(bool display_failure)
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_COMPASS)) {
         // check compass offsets have been set.  AP_Arming only checks
         // this if learning is off; Copter *always* checks.
-        if (!AP::compass().configured()) {
-            check_failed(ARMING_CHECK_COMPASS, display_failure, "Compass not calibrated");
+        char failure_msg[50] = {};
+        if (!AP::compass().configured(failure_msg, ARRAY_SIZE(failure_msg))) {
+            check_failed(ARMING_CHECK_COMPASS, display_failure, "%s", failure_msg);
             ret = false;
         }
     }

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -221,10 +221,10 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
             mavlink_msg_compassmot_status_send(gcs_chan.get_chan(),
                                                channel_throttle->get_control_in(),
                                                current,
-                                               interference_pct[compass.get_primary()],
-                                               motor_compensation[compass.get_primary()].x,
-                                               motor_compensation[compass.get_primary()].y,
-                                               motor_compensation[compass.get_primary()].z);
+                                               interference_pct[0],
+                                               motor_compensation[0].x,
+                                               motor_compensation[0].y,
+                                               motor_compensation[0].z);
         }
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -389,7 +389,7 @@ bool AP_Arming::compass_checks(bool report)
 
         // avoid Compass::use_for_yaw(void) as it implicitly calls healthy() which can
         // incorrectly skip the remaining checks, pass the primary instance directly
-        if (!_compass.use_for_yaw(_compass.get_primary())) {
+        if (!_compass.use_for_yaw(0)) {
             // compass use is disabled
             return true;
         }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -399,9 +399,12 @@ bool AP_Arming::compass_checks(bool report)
             return false;
         }
         // check compass learning is on or offsets have been set
-        if (!_compass.learn_offsets_enabled() && !_compass.configured()) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Compass not calibrated");
-            return false;
+        if (!_compass.learn_offsets_enabled()) {
+            char failure_msg[50] = {};
+            if (!_compass.configured(failure_msg, ARRAY_SIZE(failure_msg))) {
+                check_failed(ARMING_CHECK_COMPASS, report, "%s", failure_msg);
+                return false;
+            }
         }
 
         // check for unreasonable compass offsets

--- a/libraries/AP_Common/TSIndex.h
+++ b/libraries/AP_Common/TSIndex.h
@@ -1,0 +1,113 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define DECLARE_TYPESAFE_INDEX(NAME, TYPE) typedef typesafe_index<TYPE, class TAG_##NAME> NAME
+
+/// This template allows for indexing with compile time check and generating
+/// error for using one index variable for another array that is to be indexed
+/// with different variable.
+/// base_type specifies
+///
+/// @param  base_type      Base integral type
+///
+/// @param tag             Tag Name to prevent copy from one type to other
+///
+template <class base_type, class tag> class typesafe_index
+{
+public:
+    explicit typesafe_index(base_type i = base_type()) : p(i) {}
+
+    void operator=(const base_type& val)
+    {
+        p = val;
+    }
+
+    constexpr base_type get_int() const
+    {
+        return p;
+    }
+
+    typesafe_index operator++()
+    {
+        return typesafe_index(++p);
+    }
+
+    typesafe_index operator++(int)
+    {
+        return typesafe_index(p++);
+    }
+
+    bool operator<(const base_type& val) const
+    {
+        return (p<val);
+    }
+
+    bool operator<=(const base_type& val) const
+    {
+        return (p<=val);
+    }
+
+    bool operator>=(const base_type& val) const
+    {
+        return (p>=val);
+    }
+
+
+    bool operator>(const base_type& val) const
+    {
+        return (p>val);
+    }
+
+    bool operator!=(const base_type& val) const
+    {
+        return (p!=val);
+    }
+
+    bool operator==(const base_type& val) const
+    {
+        return (p==val);
+    }
+
+    explicit constexpr operator base_type() const
+    {
+        return p;
+    }
+
+    typesafe_index operator+(const base_type& val) const
+    {
+        return typesafe_index(p+val);
+    }
+private:
+    base_type p;
+};
+
+/// This template associates the the base_type array with accessor_type(index).
+/// So the elements can be accessed using [] only using accessor_type index
+/// _priv_instance is kept public for use in Parameter declaration.
+///
+template <class base_type, uint32_t num_instances, typename accessor_type> class RestrictIDTypeArray
+{
+public:
+    base_type _priv_instance[num_instances];
+    base_type& operator[](const accessor_type& index)
+    {
+        return _priv_instance[index.get_int()];
+    }
+
+    constexpr const base_type& operator[](const accessor_type& index) const
+    {
+        return _priv_instance[index.get_int()];
+    }
+};

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -218,12 +218,6 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Calibration: 1
     AP_GROUPINFO("MOT2",    11, Compass, _state[1].motor_compensation, 0),
 
-    // @Param: PRIMARY
-    // @DisplayName: Choose primary compass
-    // @Description: If more than one compass is available, this selects which compass is the primary. When external compasses are connected, they will be ordered first. NOTE: If no external compass is attached, this parameter is ignored.
-    // @Values: 0:FirstCompass,1:SecondCompass,2:ThirdCompass
-    // @User: Advanced
-    AP_GROUPINFO("PRIMARY", 12, Compass, _primary, 0),
 #endif // HAL_COMPASS_MAX_SENSORS
 
 #if HAL_COMPASS_MAX_SENSORS > 2
@@ -292,7 +286,6 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Calibration: 1
     AP_GROUPINFO("DEV_ID",  15, Compass, _state[0].dev_id, 0),
 
-#if HAL_COMPASS_MAX_SENSORS > 1
     // @Param: DEV_ID2
     // @DisplayName: Compass2 device id
     // @Description: Second compass's device id.  Automatically detected, do not set manually
@@ -300,9 +293,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @User: Advanced
     // @Calibration: 1
     AP_GROUPINFO("DEV_ID2", 16, Compass, _state[1].dev_id, 0),
-#endif // HAL_COMPASS_MAX_SENSORS
 
-#if HAL_COMPASS_MAX_SENSORS > 2
     // @Param: DEV_ID3
     // @DisplayName: Compass3 device id
     // @Description: Third compass's device id.  Automatically detected, do not set manually
@@ -310,7 +301,6 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @User: Advanced
     // @Calibration: 1
     AP_GROUPINFO("DEV_ID3", 17, Compass, _state[2].dev_id, 0),
-#endif // HAL_COMPASS_MAX_SENSORS
 
 #if HAL_COMPASS_MAX_SENSORS > 1
     // @Param: USE2
@@ -520,26 +510,26 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Values: 0:Disabled,1:CheckOnly,2:CheckAndFix
     AP_GROUPINFO("AUTO_ROT", 35, Compass, _rotate_auto, HAL_COMPASS_AUTO_ROT_DEFAULT),
 
-    // @Param: EXP_DID
-    // @DisplayName: Compass device id expected
-    // @Description: The expected value of COMPASS_DEV_ID, used by arming checks. Setting this to -1 means "don't care."
+    // @Param: PRI_DEVID
+    // @DisplayName: Primary Compass device id
+    // @Description: Primary Compass device id, set automatically if 0. Reboot required after change.
     // @User: Advanced
-    AP_GROUPINFO("EXP_DID",  36, Compass, _state[0].expected_dev_id, -1),
+    AP_GROUPINFO("PRI_DEV",  36, Compass, _priority_did_stored_list[0], 0),
 
 #if HAL_COMPASS_MAX_SENSORS > 1
-    // @Param: EXP_DID2
-    // @DisplayName: Compass2 device id expected
-    // @Description: The expected value of COMPASS_DEV_ID2, used by arming checks. Setting this to -1 means "don't care."
+    // @Param: SEC_DID
+    // @DisplayName: Secondary Compass device id
+    // @Description: Secondary Compass device id, set automatically if 0. Reboot required after change.
     // @User: Advanced
-    AP_GROUPINFO("EXP_DID2", 37, Compass, _state[1].expected_dev_id, -1),
+    AP_GROUPINFO("SEC_DEV", 37, Compass, _priority_did_stored_list[1], 0),
 #endif // HAL_COMPASS_MAX_SENSORS
 
 #if HAL_COMPASS_MAX_SENSORS > 2
-    // @Param: EXP_DID3
-    // @DisplayName: Compass3 device id expected
-    // @Description: The expected value of COMPASS_DEV_ID3, used by arming checks. Setting this to -1 means "don't care."
+    // @Param: TER_DID
+    // @DisplayName: Tertiary Compass device id
+    // @Description: Tertiary Compass device id, set automatically if 0. Reboot required after change.
     // @User: Advanced
-    AP_GROUPINFO("EXP_DID3", 38, Compass, _state[2].expected_dev_id, -1),
+    AP_GROUPINFO("TER_DEV", 38, Compass, _priority_did_stored_list[2], 0),
 #endif // HAL_COMPASS_MAX_SENSORS
 
     // @Param: ENABLE
@@ -580,6 +570,44 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Bitmask: 0:CalRequireGPS
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 43, Compass, _options, 0),
+
+    // @Param: DEV_ID4
+    // @DisplayName: Compass4 device id
+    // @Description: Extra 4th compass's device id.  Automatically detected, do not set manually
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("DEV_ID4", 44, Compass, extra_dev_id[0], 0),
+
+
+    // @Param: DEV_ID5
+    // @DisplayName: Compass5 device id
+    // @Description: Extra 5th compass's device id.  Automatically detected, do not set manually
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("DEV_ID5", 45, Compass, extra_dev_id[1], 0),
+
+
+    // @Param: DEV_ID6
+    // @DisplayName: Compass6 device id
+    // @Description: Extra 6th compass's device id.  Automatically detected, do not set manually
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("DEV_ID6", 46, Compass, extra_dev_id[2], 0),
+
+    // @Param: DEV_ID7
+    // @DisplayName: Compass7 device id
+    // @Description: Extra 7th compass's device id.  Automatically detected, do not set manually
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("DEV_ID7", 47, Compass, extra_dev_id[3], 0),
+
+
+    // @Param: DEV_ID8
+    // @DisplayName: Compass8 device id
+    // @Description: Extra 8th compass's device id.  Automatically detected, do not set manually
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("DEV_ID8", 48, Compass, extra_dev_id[4], 0),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -41,7 +41,7 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 #ifndef HAL_COMPASS_FILTER_DEFAULT
- #define HAL_COMPASS_FILTER_DEFAULT 0 // turned off by default
+#define HAL_COMPASS_FILTER_DEFAULT 0 // turned off by default
 #endif
 
 #ifndef HAL_COMPASS_AUTO_ROT_DEFAULT
@@ -651,7 +651,7 @@ void Compass::init()
         }
     }
 
-    // Load priority list from storage, the changes to priority list 
+    // Load priority list from storage, the changes to priority list
     // by user only take effect post reboot, after this
     for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_priority_did_stored_list[i] != 0) {
@@ -719,7 +719,7 @@ void Compass::init()
 Compass::Priority Compass::_update_priority_list(int32_t dev_id)
 {
     // Check if already in priority list
-    for(Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_priority_did_list[i] == dev_id) {
             if (i >= _compass_count) {
                 _compass_count = uint8_t(i)+1;
@@ -729,7 +729,7 @@ Compass::Priority Compass::_update_priority_list(int32_t dev_id)
     }
 
     // We are not in priority list, let's add at first empty
-    for(Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_priority_did_stored_list[i] == 0) {
             _priority_did_stored_list[i].set_and_save(dev_id);
             _priority_did_list[i] = dev_id;
@@ -748,7 +748,7 @@ void Compass::_reorder_compass_params()
 {
     mag_state swap_state;
     StateIndex curr_state_id;
-    for(Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         curr_state_id = _get_state_id(i);
         if (curr_state_id != COMPASS_MAX_INSTANCES && uint8_t(curr_state_id) != uint8_t(i)) {
             //let's swap
@@ -839,7 +839,7 @@ bool Compass::register_compass(int32_t dev_id, uint8_t& instance)
 
 Compass::StateIndex Compass::_get_state_id(Compass::Priority priority) const
 {
-    for(StateIndex i(0); i<COMPASS_MAX_INSTANCES; i++) {
+    for (StateIndex i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_priority_did_list[priority] == _state[i].expected_dev_id) {
             return i;
         }
@@ -911,7 +911,7 @@ void Compass::_probe_external_i2c_compasses(void)
     // external i2c bus
     FOREACH_I2C_EXTERNAL(i) {
         ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(i, HAL_COMPASS_HMC5843_I2C_ADDR),
-                                                              true, ROTATION_ROLL_180));
+                    true, ROTATION_ROLL_180));
     }
 
     if (AP_BoardConfig::get_board_type() != AP_BoardConfig::PX4_BOARD_MINDPXV2 &&
@@ -919,14 +919,14 @@ void Compass::_probe_external_i2c_compasses(void)
         // internal i2c bus
         FOREACH_I2C_INTERNAL(i) {
             ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(i, HAL_COMPASS_HMC5843_I2C_ADDR),
-                                                                  all_external, all_external?ROTATION_ROLL_180:ROTATION_YAW_270));
+                        all_external, all_external?ROTATION_ROLL_180:ROTATION_YAW_270));
         }
     }
 
     //external i2c bus
     FOREACH_I2C_EXTERNAL(i) {
         ADD_BACKEND(DRIVER_QMC5883L, AP_Compass_QMC5883L::probe(GET_I2C_DEVICE(i, HAL_COMPASS_QMC5883L_I2C_ADDR),
-                                                               true, HAL_COMPASS_QMC5883L_ORIENTATION_EXTERNAL));
+                    true, HAL_COMPASS_QMC5883L_ORIENTATION_EXTERNAL));
     }
 
     // internal i2c bus
@@ -934,8 +934,8 @@ void Compass::_probe_external_i2c_compasses(void)
         // only probe QMC5883L on internal if we are treating internals as externals
         FOREACH_I2C_INTERNAL(i) {
             ADD_BACKEND(DRIVER_QMC5883L, AP_Compass_QMC5883L::probe(GET_I2C_DEVICE(i, HAL_COMPASS_QMC5883L_I2C_ADDR),
-                                                                    all_external,
-                                                                    all_external?HAL_COMPASS_QMC5883L_ORIENTATION_EXTERNAL:HAL_COMPASS_QMC5883L_ORIENTATION_INTERNAL));
+                        all_external,
+                        all_external?HAL_COMPASS_QMC5883L_ORIENTATION_EXTERNAL:HAL_COMPASS_QMC5883L_ORIENTATION_INTERNAL));
         }
     }
 
@@ -944,49 +944,49 @@ void Compass::_probe_external_i2c_compasses(void)
     // AK09916 on ICM20948
     FOREACH_I2C_EXTERNAL(i) {
         ADD_BACKEND(DRIVER_ICM20948, AP_Compass_AK09916::probe_ICM20948(GET_I2C_DEVICE(i, HAL_COMPASS_AK09916_I2C_ADDR),
-                                                                        GET_I2C_DEVICE(i, HAL_COMPASS_ICM20948_I2C_ADDR),
-                                                                        true, ROTATION_PITCH_180_YAW_90));
+                    GET_I2C_DEVICE(i, HAL_COMPASS_ICM20948_I2C_ADDR),
+                    true, ROTATION_PITCH_180_YAW_90));
     }
 
     FOREACH_I2C_INTERNAL(i) {
         ADD_BACKEND(DRIVER_ICM20948, AP_Compass_AK09916::probe_ICM20948(GET_I2C_DEVICE(i, HAL_COMPASS_AK09916_I2C_ADDR),
-                                                                        GET_I2C_DEVICE(i, HAL_COMPASS_ICM20948_I2C_ADDR),
-                                                                        all_external, ROTATION_PITCH_180_YAW_90));
+                    GET_I2C_DEVICE(i, HAL_COMPASS_ICM20948_I2C_ADDR),
+                    all_external, ROTATION_PITCH_180_YAW_90));
     }
 #endif // HAL_BUILD_AP_PERIPH
 
     // lis3mdl on bus 0 with default address
     FOREACH_I2C_INTERNAL(i) {
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(GET_I2C_DEVICE(i, HAL_COMPASS_LIS3MDL_I2C_ADDR),
-                                                              all_external, all_external?ROTATION_YAW_90:ROTATION_NONE));
+                    all_external, all_external?ROTATION_YAW_90:ROTATION_NONE));
     }
 
     // lis3mdl on bus 0 with alternate address
     FOREACH_I2C_INTERNAL(i) {
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(GET_I2C_DEVICE(i, HAL_COMPASS_LIS3MDL_I2C_ADDR2),
-                                                              all_external, all_external?ROTATION_YAW_90:ROTATION_NONE));
+                    all_external, all_external?ROTATION_YAW_90:ROTATION_NONE));
     }
 
     // external lis3mdl on bus 1 with default address
     FOREACH_I2C_EXTERNAL(i) {
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(GET_I2C_DEVICE(i, HAL_COMPASS_LIS3MDL_I2C_ADDR),
-                                                              true, ROTATION_YAW_90));
+                    true, ROTATION_YAW_90));
     }
 
     // external lis3mdl on bus 1 with alternate address
     FOREACH_I2C_EXTERNAL(i) {
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(GET_I2C_DEVICE(i, HAL_COMPASS_LIS3MDL_I2C_ADDR2),
-                                                              true, ROTATION_YAW_90));
+                    true, ROTATION_YAW_90));
     }
 
     // AK09916. This can be found twice, due to the ICM20948 i2c bus pass-thru, so we need to be careful to avoid that
     FOREACH_I2C_EXTERNAL(i) {
         ADD_BACKEND(DRIVER_AK09916, AP_Compass_AK09916::probe(GET_I2C_DEVICE(i, HAL_COMPASS_AK09916_I2C_ADDR),
-                                                              true, ROTATION_YAW_270));
+                    true, ROTATION_YAW_270));
     }
     FOREACH_I2C_INTERNAL(i) {
         ADD_BACKEND(DRIVER_AK09916, AP_Compass_AK09916::probe(GET_I2C_DEVICE(i, HAL_COMPASS_AK09916_I2C_ADDR),
-                                                              all_external, all_external?ROTATION_YAW_270:ROTATION_NONE));
+                    all_external, all_external?ROTATION_YAW_270:ROTATION_NONE));
     }
 
     // IST8310 on external and internal bus
@@ -1005,11 +1005,11 @@ void Compass::_probe_external_i2c_compasses(void)
         for (uint8_t a=0; a<ARRAY_SIZE(ist8310_addr); a++) {
             FOREACH_I2C_EXTERNAL(i) {
                 ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(GET_I2C_DEVICE(i, ist8310_addr[a]),
-                                                                      true, default_rotation));
+                            true, default_rotation));
             }
             FOREACH_I2C_INTERNAL(i) {
                 ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(GET_I2C_DEVICE(i, ist8310_addr[a]),
-                                                                      all_external, default_rotation));
+                            all_external, default_rotation));
             }
         }
     }
@@ -1017,17 +1017,17 @@ void Compass::_probe_external_i2c_compasses(void)
     // external i2c bus
     FOREACH_I2C_EXTERNAL(i) {
         ADD_BACKEND(DRIVER_IST8308, AP_Compass_IST8308::probe(GET_I2C_DEVICE(i, HAL_COMPASS_IST8308_I2C_ADDR),
-                                                              true, ROTATION_NONE));
+                    true, ROTATION_NONE));
     }
 
     // external i2c bus
     FOREACH_I2C_EXTERNAL(i) {
-            ADD_BACKEND(DRIVER_RM3100, AP_Compass_RM3100::probe(GET_I2C_DEVICE(i, HAL_COMPASS_RM3100_I2C_ADDR),
-                                                                true, ROTATION_NONE));
+        ADD_BACKEND(DRIVER_RM3100, AP_Compass_RM3100::probe(GET_I2C_DEVICE(i, HAL_COMPASS_RM3100_I2C_ADDR),
+                    true, ROTATION_NONE));
     }
     FOREACH_I2C_INTERNAL(i) {
-            ADD_BACKEND(DRIVER_RM3100, AP_Compass_RM3100::probe(GET_I2C_DEVICE(i, HAL_COMPASS_RM3100_I2C_ADDR),
-                                                                all_external, ROTATION_NONE));
+        ADD_BACKEND(DRIVER_RM3100, AP_Compass_RM3100::probe(GET_I2C_DEVICE(i, HAL_COMPASS_RM3100_I2C_ADDR),
+                    all_external, ROTATION_NONE));
     }
 
 #endif // HAL_MINIMIZE_FEATURES
@@ -1051,7 +1051,7 @@ void Compass::_detect_backends(void)
         _driver_type_mask.set_default(1U<<DRIVER_LIS3MDL);
     }
 #endif
-    
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     ADD_BACKEND(DRIVER_SITL, new AP_Compass_SITL());
     return;
@@ -1096,12 +1096,12 @@ void Compass::_detect_backends(void)
     case AP_BoardConfig::VRX_BOARD_BRAIN54: {
         // external i2c bus
         ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(1, HAL_COMPASS_HMC5843_I2C_ADDR),
-                                                              true, ROTATION_ROLL_180));
-        }
+                    true, ROTATION_ROLL_180));
+    }
         // internal i2c bus
-        ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(0, HAL_COMPASS_HMC5843_I2C_ADDR),
-                                                              false, ROTATION_YAW_270));
-        break;
+    ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(0, HAL_COMPASS_HMC5843_I2C_ADDR),
+                false, ROTATION_YAW_270));
+    break;
 
     case AP_BoardConfig::VRX_BOARD_BRAIN51:
     case AP_BoardConfig::VRX_BOARD_BRAIN52:
@@ -1111,9 +1111,9 @@ void Compass::_detect_backends(void)
     case AP_BoardConfig::VRX_BOARD_UBRAIN52: {
         // external i2c bus
         ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(1, HAL_COMPASS_HMC5843_I2C_ADDR),
-                                                              true, ROTATION_ROLL_180));
-        }
-        break;
+                    true, ROTATION_ROLL_180));
+    }
+    break;
 
     default:
         break;
@@ -1121,7 +1121,7 @@ void Compass::_detect_backends(void)
     switch (AP_BoardConfig::get_board_type()) {
     case AP_BoardConfig::PX4_BOARD_PIXHAWK:
         ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(hal.spi->get_device(HAL_COMPASS_HMC5843_NAME),
-                                                              false, ROTATION_PITCH_180));
+                    false, ROTATION_PITCH_180));
         ADD_BACKEND(DRIVER_LSM303D, AP_Compass_LSM303D::probe(hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME), ROTATION_NONE));
         break;
 
@@ -1137,22 +1137,22 @@ void Compass::_detect_backends(void)
     case AP_BoardConfig::PX4_BOARD_FMUV6:
         FOREACH_I2C_EXTERNAL(i) {
             ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(GET_I2C_DEVICE(i, HAL_COMPASS_IST8310_I2C_ADDR),
-                                                                  true, ROTATION_ROLL_180_YAW_90));
+                        true, ROTATION_ROLL_180_YAW_90));
         }
         FOREACH_I2C_INTERNAL(i) {
             ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(GET_I2C_DEVICE(i, HAL_COMPASS_IST8310_I2C_ADDR),
-                                                                  false, ROTATION_ROLL_180_YAW_90));
+                        false, ROTATION_ROLL_180_YAW_90));
         }
         break;
-        
+
     case AP_BoardConfig::PX4_BOARD_SP01:
         ADD_BACKEND(DRIVER_AK8963, AP_Compass_AK8963::probe_mpu9250(1, ROTATION_NONE));
         break;
-        
+
     case AP_BoardConfig::PX4_BOARD_PIXHAWK_PRO:
         ADD_BACKEND(DRIVER_AK8963, AP_Compass_AK8963::probe_mpu9250(0, ROTATION_ROLL_180_YAW_90));
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(hal.spi->get_device(HAL_COMPASS_LIS3MDL_NAME),
-                                                              false, ROTATION_NONE));
+                    false, ROTATION_NONE));
         break;
 
     case AP_BoardConfig::PX4_BOARD_PHMINI:
@@ -1162,17 +1162,17 @@ void Compass::_detect_backends(void)
     case AP_BoardConfig::PX4_BOARD_AUAV21:
         ADD_BACKEND(DRIVER_AK8963, AP_Compass_AK8963::probe_mpu9250(0, ROTATION_ROLL_180_YAW_90));
         break;
-        
+
     case AP_BoardConfig::PX4_BOARD_PH2SLIM:
         ADD_BACKEND(DRIVER_AK8963, AP_Compass_AK8963::probe_mpu9250(0, ROTATION_YAW_270));
         break;
 
     case AP_BoardConfig::PX4_BOARD_MINDPXV2:
         ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(0, HAL_COMPASS_HMC5843_I2C_ADDR),
-                                                              false, ROTATION_YAW_90));
+                    false, ROTATION_YAW_90));
         ADD_BACKEND(DRIVER_LSM303D, AP_Compass_LSM303D::probe(hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME), ROTATION_PITCH_180_YAW_270));
         break;
-        
+
     default:
         break;
     }
@@ -1180,14 +1180,14 @@ void Compass::_detect_backends(void)
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_NONE
     // no compass, or only external probe
 #else
-    #error Unrecognised HAL_COMPASS_TYPE setting
+#error Unrecognised HAL_COMPASS_TYPE setting
 #endif
 
 
-/* for chibios external board coniguration */
+    /* for chibios external board coniguration */
 #ifdef HAL_EXT_COMPASS_HMC5843_I2C_BUS
     ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(HAL_EXT_COMPASS_HMC5843_I2C_BUS, HAL_COMPASS_HMC5843_I2C_ADDR),
-                                                          true, ROTATION_ROLL_180));
+                true, ROTATION_ROLL_180));
 #endif
 
 #if HAL_WITH_UAVCAN
@@ -1197,7 +1197,7 @@ void Compass::_detect_backends(void)
             if (_uavcan_backend) {
                 _add_backend(_uavcan_backend);
             }
-            if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV) { 
+            if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV) {
                 return;
             }
         }
@@ -1231,7 +1231,7 @@ Compass::_detect_runtime(void)
             if (_uavcan_backend) {
                 _add_backend(_uavcan_backend);
             }
-            if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV) { 
+            if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV) {
                 return;
             }
         }
@@ -1280,8 +1280,8 @@ uint8_t
 Compass::get_healthy_mask() const
 {
     uint8_t healthy_mask = 0;
-    for(Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
-        if(healthy(uint8_t(i))) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
+        if (healthy(uint8_t(i))) {
             healthy_mask |= 1 << uint8_t(i);
         }
     }
@@ -1293,7 +1293,7 @@ Compass::set_offsets(uint8_t i, const Vector3f &offsets)
 {
     // sanity check compass instance provided
     StateIndex id = _get_state_id(Priority(i));
-    if (id < COMPASS_MAX_INSTANCES){
+    if (id < COMPASS_MAX_INSTANCES) {
         _state[id].offset.set(offsets);
     }
 }
@@ -1303,7 +1303,7 @@ Compass::set_and_save_offsets(uint8_t i, const Vector3f &offsets)
 {
     // sanity check compass instance provided
     StateIndex id = _get_state_id(Priority(i));
-    if (id < COMPASS_MAX_INSTANCES){
+    if (id < COMPASS_MAX_INSTANCES) {
         _state[id].offset.set(offsets);
         save_offsets(i);
     }
@@ -1314,7 +1314,7 @@ Compass::set_and_save_diagonals(uint8_t i, const Vector3f &diagonals)
 {
     // sanity check compass instance provided
     StateIndex id = _get_state_id(Priority(i));
-    if (id < COMPASS_MAX_INSTANCES){
+    if (id < COMPASS_MAX_INSTANCES) {
         _state[id].diagonals.set_and_save(diagonals);
     }
 }
@@ -1324,7 +1324,7 @@ Compass::set_and_save_offdiagonals(uint8_t i, const Vector3f &offdiagonals)
 {
     // sanity check compass instance provided
     StateIndex id = _get_state_id(Priority(i));
-    if (id < COMPASS_MAX_INSTANCES){
+    if (id < COMPASS_MAX_INSTANCES) {
         _state[id].offdiagonals.set_and_save(offdiagonals);
     }
 }
@@ -1342,7 +1342,7 @@ void
 Compass::save_offsets(uint8_t i)
 {
     StateIndex id = _get_state_id(Priority(i));
-    if (id < COMPASS_MAX_INSTANCES){
+    if (id < COMPASS_MAX_INSTANCES) {
         _state[id].offset.save();  // save offsets
         _state[id].dev_id.set_and_save(_state[id].detected_dev_id);
     }
@@ -1352,7 +1352,7 @@ void
 Compass::set_and_save_orientation(uint8_t i, Rotation orientation)
 {
     StateIndex id = _get_state_id(Priority(i));
-    if (id < COMPASS_MAX_INSTANCES){
+    if (id < COMPASS_MAX_INSTANCES) {
         _state[id].orientation.set_and_save_ifchanged(orientation);
     }
 }
@@ -1369,7 +1369,7 @@ void
 Compass::set_motor_compensation(uint8_t i, const Vector3f &motor_comp_factor)
 {
     StateIndex id = _get_state_id(Priority(i));
-    if (id < COMPASS_MAX_INSTANCES){
+    if (id < COMPASS_MAX_INSTANCES) {
         _state[id].motor_compensation.set(motor_comp_factor);
     }
 }
@@ -1381,7 +1381,7 @@ Compass::save_motor_compensation()
     _motor_comp_type.save();
     for (Priority k(0); k<COMPASS_MAX_INSTANCES; k++) {
         id = _get_state_id(k);
-        if (id<COMPASS_MAX_INSTANCES){
+        if (id<COMPASS_MAX_INSTANCES) {
             _state[id].motor_compensation.save();
         }
     }
@@ -1439,7 +1439,7 @@ Compass::set_declination(float radians, bool save_to_eeprom)
 {
     if (save_to_eeprom) {
         _declination.set_and_save(radians);
-    }else{
+    } else {
         _declination.set(radians);
     }
 }
@@ -1471,13 +1471,13 @@ Compass::calculate_heading(const Matrix3f &dcm_matrix, uint8_t i) const
     float heading = constrain_float(atan2f(-headY,headX), -3.15f, 3.15f);
 
     // Declination correction (if supplied)
-    if( fabsf(_declination) > 0.0f )
-    {
+    if ( fabsf(_declination) > 0.0f ) {
         heading = heading + _declination;
-        if (heading > M_PI)    // Angle normalization (-180 deg, 180 deg)
+        if (heading > M_PI) {  // Angle normalization (-180 deg, 180 deg)
             heading -= (2.0f * M_PI);
-        else if (heading < -M_PI)
+        } else if (heading < -M_PI) {
             heading += (2.0f * M_PI);
+        }
     }
 
     return heading;
@@ -1540,7 +1540,7 @@ bool Compass::configured(char *failure_msg, uint8_t failure_msg_len)
     }
 
     bool all_configured = true;
-    for(uint8_t i=0; i<get_count(); i++) {
+    for (uint8_t i=0; i<get_count(); i++) {
         all_configured = all_configured && (!use_for_yaw(i) || configured(i));
     }
     if (!all_configured) {
@@ -1695,7 +1695,8 @@ bool Compass::have_scale_factor(uint8_t i) const
 // singleton instance
 Compass *Compass::_singleton;
 
-namespace AP {
+namespace AP
+{
 
 Compass &compass()
 {

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -12,6 +12,7 @@
 #include "CompassCalibrator.h"
 #include "AP_Compass_Backend.h"
 #include "Compass_PerMotor.h"
+#include <AP_Common/TSIndex.h>
 
 // motor compensation types (for use with motor_comp_enabled)
 #define AP_COMPASS_MOT_COMP_DISABLED    0x00
@@ -45,8 +46,17 @@
    maximum number of compass instances available on this platform. If more
    than 1 then redundant sensors may be available
  */
+#ifndef HAL_BUILD_AP_PERIPH
 #define COMPASS_MAX_INSTANCES 3
 #define COMPASS_MAX_BACKEND   3
+#define COMPASS_MAX_UNREG_DEV 5
+#else
+#define COMPASS_MAX_INSTANCES 1
+#define COMPASS_MAX_BACKEND   1
+#define COMPASS_MAX_UNREG_DEV 0
+#endif
+
+#define MAX_CONNECTED_MAGS (COMPASS_MAX_UNREG_DEV+COMPASS_MAX_INSTANCES)
 
 class CompassLearn;
 
@@ -87,7 +97,7 @@ public:
     /// @returns heading in radians
     ///
     float calculate_heading(const Matrix3f &dcm_matrix) const {
-        return calculate_heading(dcm_matrix, get_primary());
+        return calculate_heading(dcm_matrix, 0);
     }
     float calculate_heading(const Matrix3f &dcm_matrix, uint8_t i) const;
 
@@ -107,6 +117,7 @@ public:
     void set_and_save_diagonals(uint8_t i, const Vector3f &diagonals);
     void set_and_save_offdiagonals(uint8_t i, const Vector3f &diagonals);
     void set_and_save_scale_factor(uint8_t i, float scale_factor);
+    void set_and_save_orientation(uint8_t i, Rotation orientation);
 
     /// Saves the current offset x/y/z values for one or all compasses
     ///
@@ -122,8 +133,8 @@ public:
     uint8_t get_count(void) const { return _compass_count; }
 
     /// Return the current field as a Vector3f in milligauss
-    const Vector3f &get_field(uint8_t i) const { return _state[i].field; }
-    const Vector3f &get_field(void) const { return get_field(get_primary()); }
+    const Vector3f &get_field(uint8_t i) const { return _get_state(Priority(i)).field; }
+    const Vector3f &get_field(void) const { return get_field(0); }
 
     /// Return true if we have set a scale factor for a compass
     bool have_scale_factor(uint8_t i) const;
@@ -166,22 +177,22 @@ public:
     bool consistent() const;
 
     /// Return the health of a compass
-    bool healthy(uint8_t i) const { return _state[i].healthy; }
-    bool healthy(void) const { return healthy(get_primary()); }
+    bool healthy(uint8_t i) const { return _get_state(Priority(i)).healthy; }
+    bool healthy(void) const { return healthy(0); }
     uint8_t get_healthy_mask() const;
 
     /// Returns the current offset values
     ///
     /// @returns                    The current compass offsets in milligauss.
     ///
-    const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset; }
-    const Vector3f &get_offsets(void) const { return get_offsets(get_primary()); }
+    const Vector3f &get_offsets(uint8_t i) const { return _get_state(Priority(i)).offset; }
+    const Vector3f &get_offsets(void) const { return get_offsets(0); }
 
-    const Vector3f &get_diagonals(uint8_t i) const { return _state[i].diagonals; }
-    const Vector3f &get_diagonals(void) const { return get_diagonals(get_primary()); }
+    const Vector3f &get_diagonals(uint8_t i) const { return _get_state(Priority(i)).diagonals; }
+    const Vector3f &get_diagonals(void) const { return get_diagonals(0); }
 
-    const Vector3f &get_offdiagonals(uint8_t i) const { return _state[i].offdiagonals; }
-    const Vector3f &get_offdiagonals(void) const { return get_offdiagonals(get_primary()); }
+    const Vector3f &get_offdiagonals(uint8_t i) const { return _get_state(Priority(i)).offdiagonals; }
+    const Vector3f &get_offdiagonals(void) const { return get_offdiagonals(0); }
 
     // learn offsets accessor
     bool learn_offsets_enabled() const { return _learn == LEARN_INFLIGHT; }
@@ -190,9 +201,7 @@ public:
     bool use_for_yaw(uint8_t i) const;
     bool use_for_yaw(void) const;
 
-    void set_use_for_yaw(uint8_t i, bool use) {
-        _state[i].use_for_yaw.set(use);
-    }
+    void set_use_for_yaw(uint8_t i, bool use);
 
     /// Sets the local magnetic field declination.
     ///
@@ -227,8 +236,8 @@ public:
     void set_motor_compensation(uint8_t i, const Vector3f &motor_comp_factor);
 
     /// get motor compensation factors as a vector
-    const Vector3f& get_motor_compensation(uint8_t i) const { return _state[i].motor_compensation; }
-    const Vector3f& get_motor_compensation(void) const { return get_motor_compensation(get_primary()); }
+    const Vector3f& get_motor_compensation(uint8_t i) const { return _get_state(Priority(i)).motor_compensation; }
+    const Vector3f& get_motor_compensation(void) const { return get_motor_compensation(0); }
 
     /// Saves the current motor compensation x/y/z values.
     ///
@@ -240,8 +249,8 @@ public:
     ///
     /// @returns                    The current compass offsets in milligauss.
     ///
-    const Vector3f &get_motor_offsets(uint8_t i) const { return _state[i].motor_offset; }
-    const Vector3f &get_motor_offsets(void) const { return get_motor_offsets(get_primary()); }
+    const Vector3f &get_motor_offsets(uint8_t i) const { return _get_state(Priority(i)).motor_offset; }
+    const Vector3f &get_motor_offsets(void) const { return get_motor_offsets(0); }
 
     /// Set the throttle as a percentage from 0.0 to 1.0
     /// @param thr_pct              throttle expressed as a percentage from 0 to 1.0
@@ -263,13 +272,7 @@ public:
     /// @returns                    True if compass has been configured
     ///
     bool configured(uint8_t i);
-    bool configured(void);
-
-    /// Returns the instance of the primary compass
-    ///
-    /// @returns                    the instance number of the primary compass
-    ///
-    uint8_t get_primary(void) const { return _primary; }
+    bool configured(char *failure_msg, uint8_t failure_msg_len);
 
     // HIL methods
     void        setHIL(uint8_t instance, float roll, float pitch, float yaw);
@@ -281,11 +284,11 @@ public:
     void        set_hil_mode(void) { _hil_mode = true; }
 
     // return last update time in microseconds
-    uint32_t last_update_usec(void) const { return _state[get_primary()].last_update_usec; }
-    uint32_t last_update_usec(uint8_t i) const { return _state[i].last_update_usec; }
+    uint32_t last_update_usec(void) const { return last_update_usec(0); }
+    uint32_t last_update_usec(uint8_t i) const { return _get_state(Priority(i)).last_update_usec; }
 
-    uint32_t last_update_ms(void) const { return _state[get_primary()].last_update_ms; }
-    uint32_t last_update_ms(uint8_t i) const { return _state[i].last_update_ms; }
+    uint32_t last_update_ms(void) const { return last_update_ms(0); }
+    uint32_t last_update_ms(uint8_t i) const { return _get_state(Priority(i)).last_update_ms; }
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -333,10 +336,20 @@ public:
 
 private:
     static Compass *_singleton;
+
+    // Use Priority and StateIndex typesafe index types 
+    // to distinguish between two different type of indexing
+    // We use StateIndex for access by Backend
+    // and Priority for access by Frontend
+    DECLARE_TYPESAFE_INDEX(Priority, uint8_t);
+    DECLARE_TYPESAFE_INDEX(StateIndex, uint8_t);
+
     /// Register a new compas driver, allocating an instance number
     ///
-    /// @return number of compass instances
-    uint8_t register_compass(void);
+    /// @param  dev_id                   Dev ID of compass to register against
+    ///
+    /// @return instance number saved against the dev id or first available empty instance number
+    bool register_compass(int32_t dev_id, uint8_t& instance);
 
     // load backend drivers
     bool _add_backend(AP_Compass_Backend *backend);
@@ -364,7 +377,7 @@ private:
     
 #if COMPASS_CAL_ENABLED
     //keep track of which calibrators have been saved
-    bool _cal_saved[COMPASS_MAX_INSTANCES];
+    RestrictIDTypeArray<bool, COMPASS_MAX_INSTANCES, Priority> _cal_saved;
     bool _cal_autosave;
 #endif
 
@@ -405,15 +418,15 @@ private:
     // number of registered compasses.
     uint8_t     _compass_count;
 
+    // number of unregistered compasses.
+    uint8_t     _unreg_compass_count;
+
     // settable parameters
     AP_Int8 _learn;
 
     // board orientation from AHRS
     enum Rotation _board_orientation = ROTATION_NONE;
     Matrix3f* _custom_rotation;
-
-    // primary instance
-    AP_Int8     _primary;
 
     // declination in radians
     AP_Float    _declination;
@@ -426,9 +439,6 @@ private:
 
     // stores which bit is used to indicate we should log compass readings
     uint32_t _log_bit = -1;
-
-    // used by offset correction
-    static const uint8_t _mag_history_size = 20;
 
     // motor compensation type
     // 0 = disabled, 1 = enabled for throttle, 2 = enabled for current
@@ -443,6 +453,8 @@ private:
     struct mag_state {
         AP_Int8     external;
         bool        healthy;
+        bool        registered;
+        Compass::Priority priority;
         AP_Int8     orientation;
         AP_Vector3f offset;
         AP_Vector3f diagonals;
@@ -453,13 +465,8 @@ private:
         // saved to eeprom when offsets are saved allowing ram &
         // eeprom values to be compared as consistency check
         AP_Int32    dev_id;
-        AP_Int32    expected_dev_id;
         int32_t detected_dev_id;
-
-        AP_Int8     use_for_yaw;
-
-        uint8_t     mag_history_index;
-        Vector3i    mag_history[_mag_history_size];
+        int32_t expected_dev_id;
 
         // factors multiplied by throttle and added to compass outputs
         AP_Vector3f motor_compensation;
@@ -480,7 +487,32 @@ private:
         // accumulated samples, protected by _sem, used by AP_Compass_Backend
         Vector3f accum;
         uint32_t accum_count;
-    } _state[COMPASS_MAX_INSTANCES];
+        // We only copy persistent params
+        void copy_from(const mag_state& state);
+    };
+
+    //Create an Array of mag_state to be accessible by StateIndex only
+    RestrictIDTypeArray<mag_state, COMPASS_MAX_INSTANCES+1, StateIndex> _state;
+
+    //Convert Priority to StateIndex
+    StateIndex _get_state_id(Priority priority) const;
+    //Get State Struct by Priority
+    const struct mag_state& _get_state(Priority priority) const { return _state[_get_state_id(priority)]; }
+    //Convert StateIndex to Priority
+    Priority _get_priority(StateIndex state_id) { return _state[state_id].priority; }
+    //Method to detect compass beyond initialisation stage
+    void _detect_runtime(void);
+    // This method reorganises devid list to match
+    // priority list, only call before detection at boot
+    void _reorder_compass_params();
+    // Update Priority List for Mags, by default, we just
+    // load them as they come up the first time
+    Priority _update_priority_list(int32_t dev_id);
+    
+    //Create Arrays to be accessible by Priority only
+    RestrictIDTypeArray<AP_Int8, COMPASS_MAX_INSTANCES, Priority> _use_for_yaw;
+    RestrictIDTypeArray<AP_Int32, COMPASS_MAX_INSTANCES, Priority> _priority_did_stored_list;
+    RestrictIDTypeArray<int32_t, COMPASS_MAX_INSTANCES, Priority> _priority_did_list;
 
     AP_Int16 _offset_max;
 
@@ -491,7 +523,7 @@ private:
     AP_Int16 _options;
 
 #if COMPASS_CAL_ENABLED
-    CompassCalibrator _calibrator[COMPASS_MAX_INSTANCES];
+    RestrictIDTypeArray<CompassCalibrator, COMPASS_MAX_INSTANCES, Priority> _calibrator;
 #endif
 
 #if COMPASS_MOT_ENABLED
@@ -506,7 +538,12 @@ private:
 
     // mask of driver types to not load. Bit positions match DEVTYPE_ in backend
     AP_Int32 _driver_type_mask;
-    
+
+#if COMPASS_MAX_UNREG_DEV
+    // Put extra dev ids detected
+    AP_Int32 extra_dev_id[COMPASS_MAX_UNREG_DEV];
+#endif
+
     AP_Int8 _filter_range;
 
     CompassLearn *learn;

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -222,7 +222,11 @@ bool AP_Compass_AK09916::init()
     _initialized = true;
 
     /* register the compass instance in the frontend */
-    _compass_instance = register_compass();
+    _bus->set_device_type(DEVTYPE_AK09916);
+    if (!register_compass(_bus->get_bus_id(), _compass_instance)) {
+        goto fail;
+    }
+    set_dev_id(_compass_instance, _bus->get_bus_id());
 
     if (_force_external) {
         set_external(_compass_instance, true);
@@ -230,9 +234,6 @@ bool AP_Compass_AK09916::init()
 
     set_rotation(_compass_instance, _rotation);
     
-    _bus->set_device_type(DEVTYPE_AK09916);
-    set_dev_id(_compass_instance, _bus->get_bus_id());
-
     bus_sem->give();
 
     _bus->register_periodic_callback(10000, FUNCTOR_BIND_MEMBER(&AP_Compass_AK09916::_update, void));

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -155,13 +155,13 @@ bool AP_Compass_AK8963::init()
     _initialized = true;
 
     /* register the compass instance in the frontend */
-    _compass_instance = register_compass();
-
-    set_rotation(_compass_instance, _rotation);
-    
     _bus->set_device_type(DEVTYPE_AK8963);
+    if (!register_compass(_bus->get_bus_id(), _compass_instance)) {
+        goto fail;
+    }
     set_dev_id(_compass_instance, _bus->get_bus_id());
 
+    set_rotation(_compass_instance, _rotation);
     bus_sem->give();
 
     _bus->register_periodic_callback(10000, FUNCTOR_BIND_MEMBER(&AP_Compass_AK8963::_update, void));

--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -211,12 +211,14 @@ bool AP_Compass_BMM150::init()
     _dev->get_semaphore()->give();
 
     /* register the compass instance in the frontend */
-    _compass_instance = register_compass();
+    _dev->set_device_type(DEVTYPE_BMM150);
+    if (!register_compass(_dev->get_bus_id(), _compass_instance)) {
+        return false;
+    }
+    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     set_rotation(_compass_instance, _rotation);
 
-    _dev->set_device_type(DEVTYPE_BMM150);
-    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     _perf_err = hal.util->perf_alloc(AP_HAL::Util::PC_COUNT, "BMM150_err");
 

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -14,7 +14,7 @@ AP_Compass_Backend::AP_Compass_Backend()
 
 void AP_Compass_Backend::rotate_field(Vector3f &mag, uint8_t instance)
 {
-    Compass::mag_state &state = _compass._state[instance];
+    Compass::mag_state &state = _compass._state[Compass::StateIndex(instance)];
     mag.rotate(MAG_BOARD_ORIENTATION);
     mag.rotate(state.rotation);
 
@@ -33,20 +33,20 @@ void AP_Compass_Backend::rotate_field(Vector3f &mag, uint8_t instance)
 
 void AP_Compass_Backend::publish_raw_field(const Vector3f &mag, uint8_t instance)
 {
-    Compass::mag_state &state = _compass._state[instance];
+    Compass::mag_state &state = _compass._state[Compass::StateIndex(instance)];
 
     // note that we do not set last_update_usec here as otherwise the
     // EKF and DCM would end up consuming compass data at the full
     // sensor rate. We want them to consume only the filtered fields
     state.last_update_ms = AP_HAL::millis();
 #if COMPASS_CAL_ENABLED
-    _compass._calibrator[instance].new_sample(mag);
+    _compass._calibrator[_compass._get_priority(Compass::StateIndex(instance))].new_sample(mag);
 #endif
 }
 
 void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
 {
-    Compass::mag_state &state = _compass._state[i];
+    Compass::mag_state &state = _compass._state[Compass::StateIndex(i)];
 
     if (state.diagonals.get().is_zero()) {
         state.diagonals.set(Vector3f(1.0f,1.0f,1.0f));
@@ -123,7 +123,7 @@ void AP_Compass_Backend::accumulate_sample(Vector3f &field, uint8_t instance,
 
     WITH_SEMAPHORE(_sem);
 
-    Compass::mag_state &state = _compass._state[instance];
+    Compass::mag_state &state = _compass._state[Compass::StateIndex(instance)];
     state.accum += field;
     state.accum_count++;
     if (max_samples && state.accum_count >= max_samples) {
@@ -137,7 +137,7 @@ void AP_Compass_Backend::drain_accumulated_samples(uint8_t instance,
 {
     WITH_SEMAPHORE(_sem);
 
-    Compass::mag_state &state = _compass._state[instance];
+    Compass::mag_state &state = _compass._state[Compass::StateIndex(instance)];
 
     if (state.accum_count == 0) {
         return;
@@ -159,7 +159,7 @@ void AP_Compass_Backend::drain_accumulated_samples(uint8_t instance,
  */
 void AP_Compass_Backend::publish_filtered_field(const Vector3f &mag, uint8_t instance)
 {
-    Compass::mag_state &state = _compass._state[instance];
+    Compass::mag_state &state = _compass._state[Compass::StateIndex(instance)];
 
     state.field = mag;
 
@@ -169,7 +169,7 @@ void AP_Compass_Backend::publish_filtered_field(const Vector3f &mag, uint8_t ins
 
 void AP_Compass_Backend::set_last_update_usec(uint32_t last_update, uint8_t instance)
 {
-    Compass::mag_state &state = _compass._state[instance];
+    Compass::mag_state &state = _compass._state[Compass::StateIndex(instance)];
     state.last_update_usec = last_update;
 }
 
@@ -177,9 +177,9 @@ void AP_Compass_Backend::set_last_update_usec(uint32_t last_update, uint8_t inst
   register a new backend with frontend, returning instance which
   should be used in publish_field()
  */
-uint8_t AP_Compass_Backend::register_compass(void) const
+bool AP_Compass_Backend::register_compass(int32_t dev_id, uint8_t& instance) const
 { 
-    return _compass.register_compass(); 
+    return _compass.register_compass(dev_id, instance);
 }
 
 
@@ -188,8 +188,9 @@ uint8_t AP_Compass_Backend::register_compass(void) const
 */
 void AP_Compass_Backend::set_dev_id(uint8_t instance, uint32_t dev_id)
 {
-    _compass._state[instance].dev_id.set_and_notify(dev_id);
-    _compass._state[instance].detected_dev_id = dev_id;
+    _compass._state[Compass::StateIndex(instance)].dev_id.set_and_notify(dev_id);
+    _compass._state[Compass::StateIndex(instance)].detected_dev_id = dev_id;
+    _compass._state[Compass::StateIndex(instance)].expected_dev_id = dev_id;
 }
 
 /*
@@ -197,7 +198,7 @@ void AP_Compass_Backend::set_dev_id(uint8_t instance, uint32_t dev_id)
 */
 void AP_Compass_Backend::save_dev_id(uint8_t instance)
 {
-    _compass._state[instance].dev_id.save();
+    _compass._state[Compass::StateIndex(instance)].dev_id.save();
 }
 
 /*
@@ -205,20 +206,20 @@ void AP_Compass_Backend::save_dev_id(uint8_t instance)
 */
 void AP_Compass_Backend::set_external(uint8_t instance, bool external)
 {
-    if (_compass._state[instance].external != 2) {
-        _compass._state[instance].external.set_and_notify(external);
+    if (_compass._state[Compass::StateIndex(instance)].external != 2) {
+        _compass._state[Compass::StateIndex(instance)].external.set_and_notify(external);
     }
 }
 
 bool AP_Compass_Backend::is_external(uint8_t instance)
 {
-    return _compass._state[instance].external;
+    return _compass._state[Compass::StateIndex(instance)].external;
 }
 
 // set rotation of an instance
 void AP_Compass_Backend::set_rotation(uint8_t instance, enum Rotation rotation)
 {
-    _compass._state[instance].rotation = rotation;
+    _compass._state[Compass::StateIndex(instance)].rotation = rotation;
 }
 
 static constexpr float FILTER_KOEF = 0.1f;

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -88,7 +88,7 @@ protected:
     void drain_accumulated_samples(uint8_t instance, const Vector3f *scale = NULL);
 
     // register a new compass instance with the frontend
-    uint8_t register_compass(void) const;
+    bool register_compass(int32_t dev_id, uint8_t& instance) const;
 
     // set dev_id for an instance
     void set_dev_id(uint8_t instance, uint32_t dev_id);

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -19,7 +19,7 @@ void Compass::cal_update()
 
     bool running = false;
 
-    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         bool failure;
         _calibrator[i].update(failure);
         if (failure) {
@@ -34,7 +34,7 @@ void Compass::cal_update()
         if (_calibrator[i].running()) {
             running = true;
         } else if (_cal_autosave && !_cal_saved[i] && _calibrator[i].get_status() == CompassCalibrator::Status::SUCCESS) {
-            _accept_calibration(i);
+            _accept_calibration(uint8_t(i));
         }
     }
 
@@ -57,6 +57,11 @@ bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
     if (!use_for_yaw(i)) {
         return false;
     }
+    Priority prio = Priority(i);
+    if (_priority_did_list[prio] != _priority_did_stored_list[prio]) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "Compass cal requires reboot after priority change");
+        return false;
+    }
     if (_options.get() & uint16_t(Option::CAL_REQUIRE_GPS)) {
         if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
             gcs().send_text(MAV_SEVERITY_ERROR, "Compass cal requires GPS lock");
@@ -66,22 +71,22 @@ bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
     if (!is_calibrating()) {
         AP_Notify::events.initiated_compass_cal = 1;
     }
-    if (i == get_primary() && _state[i].external != 0) {
-        _calibrator[i].set_tolerance(_calibration_threshold);
+    if (i == 0 && _get_state(prio).external != 0) {
+        _calibrator[prio].set_tolerance(_calibration_threshold);
     } else {
         // internal compasses or secondary compasses get twice the
         // threshold. This is because internal compasses tend to be a
         // lot noisier
-        _calibrator[i].set_tolerance(_calibration_threshold*2);
+        _calibrator[prio].set_tolerance(_calibration_threshold*2);
     }
     if (_rotate_auto) {
-        enum Rotation r = _state[i].external?(enum Rotation)_state[i].orientation.get():ROTATION_NONE;
+        enum Rotation r = _get_state(prio).external?(enum Rotation)_get_state(prio).orientation.get():ROTATION_NONE;
         if (r != ROTATION_CUSTOM) {
-            _calibrator[i].set_orientation(r, _state[i].external, _rotate_auto>=2);
+            _calibrator[prio].set_orientation(r, _get_state(prio).external, _rotate_auto>=2);
         }
     }
-    _cal_saved[i] = false;
-    _calibrator[i].start(retry, delay, get_offsets_max(), i);
+    _cal_saved[prio] = false;
+    _calibrator[prio].start(retry, delay, get_offsets_max(), i);
 
     // disable compass learning both for calibration and after completion
     _learn.set_and_save(0);
@@ -120,12 +125,13 @@ void Compass::start_calibration_all(bool retry, bool autosave, float delay, bool
 void Compass::_cancel_calibration(uint8_t i)
 {
     AP_Notify::events.initiated_compass_cal = 0;
+    Priority prio = Priority(i);
 
-    if (_calibrator[i].running() || _calibrator[i].get_status() == CompassCalibrator::Status::WAITING_TO_START) {
+    if (_calibrator[prio].running() || _calibrator[prio].get_status() == CompassCalibrator::Status::WAITING_TO_START) {
         AP_Notify::events.compass_cal_canceled = 1;
     }
-    _cal_saved[i] = false;
-    _calibrator[i].stop();
+    _cal_saved[prio] = false;
+    _calibrator[prio].stop();
 }
 
 void Compass::_cancel_calibration_mask(uint8_t mask)
@@ -144,14 +150,16 @@ void Compass::cancel_calibration_all()
 
 bool Compass::_accept_calibration(uint8_t i)
 {
-    CompassCalibrator& cal = _calibrator[i];
+    Priority prio = Priority(i);
+
+    CompassCalibrator& cal = _calibrator[prio];
     const CompassCalibrator::Status cal_status = cal.get_status();
 
-    if (_cal_saved[i] || cal_status == CompassCalibrator::Status::NOT_STARTED) {
+    if (_cal_saved[prio] || cal_status == CompassCalibrator::Status::NOT_STARTED) {
         return true;
     } else if (cal_status == CompassCalibrator::Status::SUCCESS) {
         _cal_complete_requires_reboot = true;
-        _cal_saved[i] = true;
+        _cal_saved[prio] = true;
 
         Vector3f ofs, diag, offdiag;
         float scale_factor;
@@ -162,8 +170,8 @@ bool Compass::_accept_calibration(uint8_t i)
         set_and_save_offdiagonals(i,offdiag);
         set_and_save_scale_factor(i,scale_factor);
 
-        if (_state[i].external && _rotate_auto >= 2) {
-            _state[i].orientation.set_and_save_ifchanged(cal.get_orientation());
+        if (_get_state(prio).external && _rotate_auto >= 2) {
+            set_and_save_orientation(i, cal.get_orientation());
         }
 
         if (!is_calibrating()) {
@@ -178,9 +186,9 @@ bool Compass::_accept_calibration(uint8_t i)
 bool Compass::_accept_calibration_mask(uint8_t mask)
 {
     bool success = true;
-    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
-        if ((1<<i) & mask) {
-            if (!_accept_calibration(i)) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
+        if ((1<<uint8_t(i)) & mask) {
+            if (!_accept_calibration(uint8_t(i))) {
                 success = false;
             }
             _calibrator[i].stop();
@@ -194,7 +202,7 @@ bool Compass::send_mag_cal_progress(const GCS_MAVLINK& link)
 {
     uint8_t cal_mask = _get_cal_mask();
 
-    for (uint8_t compass_id=0; compass_id<COMPASS_MAX_INSTANCES; compass_id++) {
+    for (Priority compass_id(0); compass_id<COMPASS_MAX_INSTANCES; compass_id++) {
         // ensure we don't try to send with no space available
         if (!HAVE_PAYLOAD_SPACE(link.get_chan(), MAG_CAL_PROGRESS)) {
             // ideally we would only send one progress message per
@@ -216,7 +224,7 @@ bool Compass::send_mag_cal_progress(const GCS_MAVLINK& link)
 
             mavlink_msg_mag_cal_progress_send(
                 link.get_chan(),
-                compass_id, cal_mask,
+                uint8_t(compass_id), cal_mask,
                 (uint8_t)cal_status, attempt, completion_pct, completion_mask,
                 direction.x, direction.y, direction.z
             );
@@ -230,7 +238,7 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
 {
     uint8_t cal_mask = _get_cal_mask();
 
-    for (uint8_t compass_id=0; compass_id<COMPASS_MAX_INSTANCES; compass_id++) {
+    for (Priority compass_id(0); compass_id<COMPASS_MAX_INSTANCES; compass_id++) {
         // ensure we don't try to send with no space available
         if (!HAVE_PAYLOAD_SPACE(link.get_chan(), MAG_CAL_REPORT)) {
             // ideally we would only send one progress message per
@@ -251,7 +259,7 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
 
             mavlink_msg_mag_cal_report_send(
                 link.get_chan(),
-                compass_id, cal_mask,
+                uint8_t(compass_id), cal_mask,
                 (uint8_t)cal_status, autosaved,
                 fitness,
                 ofs.x, ofs.y, ofs.z,
@@ -269,7 +277,7 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
 
 bool Compass::is_calibrating() const
 {
-    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         switch(_calibrator[i].get_status()) {
             case CompassCalibrator::Status::NOT_STARTED:
             case CompassCalibrator::Status::SUCCESS:
@@ -286,9 +294,9 @@ bool Compass::is_calibrating() const
 uint8_t Compass::_get_cal_mask() const
 {
     uint8_t cal_mask = 0;
-    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+    for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_calibrator[i].get_status() != CompassCalibrator::Status::NOT_STARTED) {
-            cal_mask |= 1 << i;
+            cal_mask |= 1 << uint8_t(i);
         }
     }
     return cal_mask;

--- a/libraries/AP_Compass/AP_Compass_HIL.cpp
+++ b/libraries/AP_Compass/AP_Compass_HIL.cpp
@@ -50,7 +50,10 @@ AP_Compass_HIL::init(void)
 {
     // register two compass instances
     for (uint8_t i=0; i<HIL_NUM_COMPASSES; i++) {
-        _compass_instance[i] = register_compass();
+        uint32_t dev_id = AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 0, DEVTYPE_SITL);
+        if (!register_compass(dev_id, _compass_instance[i])) {
+            return false;
+        }
     }
     return true;
 }

--- a/libraries/AP_Compass/AP_Compass_HIL.h
+++ b/libraries/AP_Compass/AP_Compass_HIL.h
@@ -2,7 +2,7 @@
 
 #include "AP_Compass.h"
 
-#define HIL_NUM_COMPASSES 2
+#define HIL_NUM_COMPASSES 1
 
 class AP_Compass_HIL : public AP_Compass_Backend
 {

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -194,13 +194,15 @@ bool AP_Compass_HMC5843::init()
     // perform an initial read
     read();
 
-    _compass_instance = register_compass();
+    //register compass instance
+    _bus->set_device_type(DEVTYPE_HMC5883);
+    if (!register_compass(_bus->get_bus_id(), _compass_instance)) {
+        return false;
+    }
+    set_dev_id(_compass_instance, _bus->get_bus_id());
 
     set_rotation(_compass_instance, _rotation);
     
-    _bus->set_device_type(DEVTYPE_HMC5883);
-    set_dev_id(_compass_instance, _bus->get_bus_id());
-
     if (_force_external) {
         set_external(_compass_instance, true);
     }

--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -158,15 +158,17 @@ bool AP_Compass_IST8308::init()
 
     _dev->get_semaphore()->give();
 
-    _instance = register_compass();
+    //register compass instance
+    _dev->set_device_type(DEVTYPE_IST8308);
+    if (!register_compass(_dev->get_bus_id(), _instance)) {
+        return false;
+    }
+    set_dev_id(_instance, _dev->get_bus_id());
 
     printf("%s found on bus %u id %u address 0x%02x\n", name,
            _dev->bus_num(), _dev->get_bus_id(), _dev->get_bus_address());
 
     set_rotation(_instance, _rotation);
-
-    _dev->set_device_type(DEVTYPE_IST8308);
-    set_dev_id(_instance, _dev->get_bus_id());
 
     if (_force_external) {
         set_external(_instance, true);

--- a/libraries/AP_Compass/AP_Compass_IST8310.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8310.cpp
@@ -151,15 +151,17 @@ bool AP_Compass_IST8310::init()
 
     _dev->get_semaphore()->give();
 
-    _instance = register_compass();
+    // register compass instance
+    _dev->set_device_type(DEVTYPE_IST8310);
+    if (!register_compass(_dev->get_bus_id(), _instance)) {
+        return false;
+    }
+    set_dev_id(_instance, _dev->get_bus_id());
 
     printf("%s found on bus %u id %u address 0x%02x\n", name,
            _dev->bus_num(), _dev->get_bus_id(), _dev->get_bus_address());
 
     set_rotation(_instance, _rotation);
-
-    _dev->set_device_type(DEVTYPE_IST8310);
-    set_dev_id(_instance, _dev->get_bus_id());
 
     if (_force_external) {
         set_external(_instance, true);

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -105,7 +105,11 @@ bool AP_Compass_LIS3MDL::init()
     dev->get_semaphore()->give();
 
     /* register the compass instance in the frontend */
-    compass_instance = register_compass();
+    dev->set_device_type(DEVTYPE_LIS3MDL);
+    if (!register_compass(dev->get_bus_id(), compass_instance)) {
+        return false;
+    }
+    set_dev_id(compass_instance, dev->get_bus_id());
 
     printf("Found a LIS3MDL on 0x%x as compass %u\n", dev->get_bus_id(), compass_instance);
     
@@ -115,9 +119,6 @@ bool AP_Compass_LIS3MDL::init()
         set_external(compass_instance, true);
     }
     
-    dev->set_device_type(DEVTYPE_LIS3MDL);
-    set_dev_id(compass_instance, dev->get_bus_id());
-
     // call timer() at 80Hz
     dev->register_periodic_callback(1000000U/80U,
                                     FUNCTOR_BIND_MEMBER(&AP_Compass_LIS3MDL::timer, void));

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -266,12 +266,13 @@ bool AP_Compass_LSM303D::init(enum Rotation rotation)
     _initialised = true;
 
     /* register the compass instance in the frontend */
-    _compass_instance = register_compass();
+    _dev->set_device_type(DEVTYPE_LSM303D);
+    if (!register_compass(_dev->get_bus_id(), _compass_instance)) {
+        return false;
+    }
+    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     set_rotation(_compass_instance, rotation);
-
-    _dev->set_device_type(DEVTYPE_LSM303D);
-    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     // read at 91Hz. We don't run at 100Hz as fetching data too fast can cause some very
     // odd periodic changes in the output data

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -104,12 +104,15 @@ bool AP_Compass_LSM9DS1::init()
         goto errout;
     }
 
-    _compass_instance = register_compass();
+    //register compass instance
+    _dev->set_device_type(DEVTYPE_LSM9DS1);
+    if (!register_compass(_dev->get_bus_id(), _compass_instance)) {
+        goto errout;
+    }
+    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     set_rotation(_compass_instance, _rotation);
 
-    _dev->set_device_type(DEVTYPE_LSM9DS1);
-    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     _dev->register_periodic_callback(10000, FUNCTOR_BIND_MEMBER(&AP_Compass_LSM9DS1::_update, void));
 

--- a/libraries/AP_Compass/AP_Compass_MAG3110.cpp
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.cpp
@@ -116,12 +116,13 @@ bool AP_Compass_MAG3110::init(enum Rotation rotation)
     read();
     
     /* register the compass instance in the frontend */
-    _compass_instance = register_compass();
+    _dev->set_device_type(DEVTYPE_MAG3110);
+    if (!register_compass(_dev->get_bus_id(), _compass_instance)) {
+        return false;
+    }
+    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     set_rotation(_compass_instance, rotation);
-
-    _dev->set_device_type(DEVTYPE_MAG3110);
-    set_dev_id(_compass_instance, _dev->get_bus_id());
 
     set_external(_compass_instance, true);
 

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -90,7 +90,12 @@ bool AP_Compass_MMC3416::init()
     dev->get_semaphore()->give();
 
     /* register the compass instance in the frontend */
-    compass_instance = register_compass();
+    dev->set_device_type(DEVTYPE_MMC3416);
+    if (!register_compass(dev->get_bus_id(), compass_instance)) {
+        return false;
+    }
+    
+    set_dev_id(compass_instance, dev->get_bus_id());
 
     printf("Found a MMC3416 on 0x%x as compass %u\n", dev->get_bus_id(), compass_instance);
     
@@ -100,9 +105,6 @@ bool AP_Compass_MMC3416::init()
         set_external(compass_instance, true);
     }
     
-    dev->set_device_type(DEVTYPE_MMC3416);
-    set_dev_id(compass_instance, dev->get_bus_id());
-
     dev->set_retries(1);
     
     // call timer() at 100Hz

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -113,15 +113,17 @@ bool AP_Compass_QMC5883L::init()
 
     _dev->get_semaphore()->give();
 
-    _instance = register_compass();
+    //register compass instance
+    _dev->set_device_type(DEVTYPE_QMC5883L);
+    if (!register_compass(_dev->get_bus_id(), _instance)) {
+        return false;
+    }
+    set_dev_id(_instance, _dev->get_bus_id());
 
     printf("%s found on bus %u id %u address 0x%02x\n", name,
            _dev->bus_num(), _dev->get_bus_id(), _dev->get_bus_address());
 
     set_rotation(_instance, _rotation);
-
-    _dev->set_device_type(DEVTYPE_QMC5883L);
-    set_dev_id(_instance, _dev->get_bus_id());
 
     if (_force_external) {
         set_external(_instance, true);

--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -143,19 +143,20 @@ bool AP_Compass_RM3100::init()
     dev->get_semaphore()->give();
 
     /* register the compass instance in the frontend */
-    compass_instance = register_compass();
+    dev->set_device_type(DEVTYPE_RM3100);
+    if (!register_compass(dev->get_bus_id(), compass_instance)) {
+        return false;
+    }
+    set_dev_id(compass_instance, dev->get_bus_id());
 
     hal.console->printf("RM3100: Found at address 0x%x as compass %u\n", dev->get_bus_address(), compass_instance);
-
+    
     set_rotation(compass_instance, rotation);
 
     if (force_external) {
         set_external(compass_instance, true);
     }
-
-    dev->set_device_type(DEVTYPE_RM3100);
-    set_dev_id(compass_instance, dev->get_bus_id());
-
+    
     // call timer() at 80Hz
     dev->register_periodic_callback(1000000U/80U,
                                     FUNCTOR_BIND_MEMBER(&AP_Compass_RM3100::timer, void));

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -9,7 +9,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Declination/AP_Declination.h>
 
-#define SITL_NUM_COMPASSES 3
+#define MAX_SITL_COMPASSES 3
 
 class AP_Compass_SITL : public AP_Compass_Backend {
 public:
@@ -18,7 +18,8 @@ public:
     void read(void) override;
 
 private:
-    uint8_t _compass_instance[SITL_NUM_COMPASSES];
+    uint8_t _compass_instance[MAX_SITL_COMPASSES];
+    uint8_t _num_compass;
     SITL::SITL *_sitl;
 
     // delay buffer variables

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.h
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.h
@@ -15,13 +15,13 @@ public:
     void        read(void) override;
 
     static void subscribe_msgs(AP_UAVCAN* ap_uavcan);
-    static AP_Compass_Backend* probe();
+    static AP_Compass_Backend* probe(uint8_t index);
 
     static void handle_magnetic_field(AP_UAVCAN* ap_uavcan, uint8_t node_id, const MagCb &cb);
     static void handle_magnetic_field_2(AP_UAVCAN* ap_uavcan, uint8_t node_id, const Mag2Cb &cb);
 
 private:
-    void init();
+    bool init();
 
     // callback for UAVCAN messages
     void handle_mag_msg(const Vector3f &mag);

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -20,11 +20,11 @@ CompassLearn::CompassLearn(Compass &_compass) :
     compass(_compass)
 {
     gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: Initialised");
-    for (uint8_t i=0; i<compass.get_count(); i++) {
-        if (compass._state[i].use_for_yaw) {
+    for (Compass::Priority i(0); i<compass.get_count(); i++) {
+        if (compass._use_for_yaw[i]) {
             // reset scale factors, we can't learn scale factors in
             // flight
-            compass.set_and_save_scale_factor(i, 0.0);
+            compass.set_and_save_scale_factor(uint8_t(i), 0.0);
         }
     }
 }
@@ -50,9 +50,6 @@ void CompassLearn::update(void)
             return;
         }
 
-        // remember primary mag
-        primary_mag = compass.get_primary();
-
         // setup the expected earth field in mGauss at this location
         mag_ef = AP_Declination::get_earth_field_ga(loc) * 1000;
         have_earth_field = true;
@@ -60,8 +57,8 @@ void CompassLearn::update(void)
         // form eliptical correction matrix and invert it. This is
         // needed to remove the effects of the eliptical correction
         // when calculating new offsets
-        const Vector3f &diagonals = compass.get_diagonals(primary_mag);
-        const Vector3f &offdiagonals = compass.get_offdiagonals(primary_mag);
+        const Vector3f &diagonals = compass.get_diagonals(0);
+        const Vector3f &offdiagonals = compass.get_offdiagonals(0);
         mat = Matrix3f(
             diagonals.x, offdiagonals.x, offdiagonals.y,
             offdiagonals.x,    diagonals.y, offdiagonals.z,
@@ -89,7 +86,7 @@ void CompassLearn::update(void)
         return;
     }
 
-    Vector3f field = compass.get_field(primary_mag);
+    Vector3f field = compass.get_field(0);
     Vector3f field_change = field - last_field;
     if (field_change.length() < min_field_change) {
         return;
@@ -99,7 +96,7 @@ void CompassLearn::update(void)
         WITH_SEMAPHORE(sem);
         // give a sample to the backend to process
         new_sample.field = field;
-        new_sample.offsets = compass.get_offsets(primary_mag);
+        new_sample.offsets = compass.get_offsets(0);
         new_sample.attitude = Vector3f(ahrs.roll, ahrs.pitch, ahrs.yaw);
         sample_available = true;
         last_field = field;
@@ -122,12 +119,12 @@ void CompassLearn::update(void)
         WITH_SEMAPHORE(sem);
 
         // set offsets to current best guess
-        compass.set_offsets(primary_mag, best_offsets);
+        compass.set_offsets(0, best_offsets);
 
         // set non-primary offsets to match primary
-        Vector3f field_primary = compass.get_field(primary_mag);
-        for (uint8_t i=0; i<compass.get_count(); i++) {
-            if (i == primary_mag || !compass._state[i].use_for_yaw) {
+        Vector3f field_primary = compass.get_field(0);
+        for (uint8_t i=1; i<compass.get_count(); i++) {
+            if (!compass.use_for_yaw(i)) {
                 continue;
             }
             Vector3f field2 = compass.get_field(i);
@@ -140,7 +137,7 @@ void CompassLearn::update(void)
             // set the offsets and enable compass for EKF use. Let the
             // EKF learn the remaining compass offset error
             for (uint8_t i=0; i<compass.get_count(); i++) {
-                if (compass._state[i].use_for_yaw) {
+                if (compass.use_for_yaw(i)) {
                     compass.save_offsets(i);
                     compass.set_and_save_scale_factor(i, 0.0);
                     compass.set_use_for_yaw(i, true);

--- a/libraries/AP_Compass/Compass_learn.h
+++ b/libraries/AP_Compass/Compass_learn.h
@@ -51,7 +51,6 @@ private:
     float best_yaw_deg;
     float worst_error;
     bool converged;
-    uint8_t primary_mag;
 
     void io_timer(void);
     void process_sample(const struct sample &s);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -359,9 +359,7 @@ void NavEKF2_core::InitialiseVariablesMag()
 
     inhibitMagStates = true;
 
-    if (_ahrs->get_compass()) {
-        magSelectIndex = _ahrs->get_compass()->get_primary();
-    }
+    magSelectIndex = 0;
     lastMagOffsetsValid = false;
     magStateResetRequest = false;
     magStateInitComplete = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -406,9 +406,7 @@ void NavEKF3_core::InitialiseVariablesMag()
     mag_state.DCM.identity();
     inhibitMagStates = true;
     magStoreIndex = 0;
-    if (_ahrs->get_compass()) {
-        magSelectIndex = _ahrs->get_compass()->get_primary();
-    }
+    magSelectIndex = 0;
     lastMagOffsetsValid = false;
     magStateResetRequest = false;
     magStateInitComplete = false;

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -962,6 +962,23 @@ bool AP_Param::find_key_by_pointer(const void *ptr, uint16_t &key)
     return false;
 }
 
+/*
+  Find key to top level group parameters by pointer
+*/
+bool AP_Param::find_top_level_key_by_pointer(const void *ptr, uint16_t &key)
+{
+    for (uint16_t i=0; i<_num_vars; i++) {
+        if (_var_info[i].type != AP_PARAM_GROUP) {
+            continue;
+        }
+        if (ptr == (void **)_var_info[i].ptr) {
+            key = _var_info[i].key;
+            return true;
+        }
+    }
+    return false;
+}
+
 
 // Find a object by name.
 //

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -307,6 +307,14 @@ public:
                                           ptrdiff_t offset, uint16_t &key);
     static bool find_key_by_pointer(const void *ptr, uint16_t &key);
 
+    /// Find key of top level group variable by pointer
+    ///
+    ///
+    /// @param  p               Pointer to variable
+    /// @return                 key for variable
+    static bool find_top_level_key_by_pointer(const void *ptr, uint16_t &key);
+
+
     /// Find a object in the top level var_info table
     ///
     /// If the variable has no name, it cannot be found by this interface.

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -217,10 +217,19 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
 const AP_Param::GroupInfo SITL::var_info3[] = {
     AP_GROUPINFO("ODOM_ENABLE",   1, SITL,  odom_enable, 0),
     AP_GROUPINFO("GPS2_POS",      2, SITL,  gps_pos_offset[1], 0),
+    AP_GROUPINFO("MAG1_DEVID",    3, SITL,  mag_devid[0], 97539),    
+    AP_GROUPINFO("MAG2_DEVID",    4, SITL,  mag_devid[1], 131874),
+    AP_GROUPINFO("MAG3_DEVID",    5, SITL,  mag_devid[2], 263178),
+    AP_GROUPINFO("MAG4_DEVID",    6, SITL,  mag_devid[3], 97283),    
+    AP_GROUPINFO("MAG5_DEVID",    7, SITL,  mag_devid[4], 97795),
+    AP_GROUPINFO("MAG6_DEVID",    8, SITL,  mag_devid[5], 98051),
+    AP_GROUPINFO("MAG7_DEVID",    9, SITL,  mag_devid[6], 0),
+    AP_GROUPINFO("MAG8_DEVID",    10, SITL,  mag_devid[7], 0),
+
     AP_GROUPEND
+
 };
     
-
 /* report SITL state via MAVLink */
 void SITL::simstate_send(mavlink_channel_t chan)
 {

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -7,7 +7,7 @@
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Common/Location.h>
-
+#include <AP_Compass/AP_Compass.h>
 #include "SIM_Buzzer.h"
 #include "SIM_Gripper_EPM.h"
 #include "SIM_Gripper_Servo.h"
@@ -185,6 +185,7 @@ public:
     AP_Int8 gps_hdg_enabled; // enable the output of a NMEA heading HDT sentence
     AP_Int32 loop_delay; // extra delay to add to every loop
     AP_Float mag_scaling; // scaling factor on first compasses
+    AP_Int32 mag_devid[MAX_CONNECTED_MAGS]; // Mag devid
 
     // EFI type
     enum EFIType {


### PR DESCRIPTION
This PR is targeted towards making compasses show up in a consistent order.

**AP_Compass**:
* Enables registration to frontend based on device id, instead of auto incrementing compass_count. This ensure whatever order of compass was reached in first boot is retained in following boots.
* Registration process involves, first looking if device id was already detected and recorded in previous boot, if so, return the instance id.
* If above fails, we look for free instance, i.e. the one that has never been linked with in previous boots.
* If all fails, we replace the first unregistered compass. This is most likely going to happen in case the compass was replaced by user with a different one.
* Compass_UAVCAN driver is modified to reorder the detected devices, so that the compass with larger node id is sent for registration first. This ensures two things incase we are overflowing number of CAN Instances: We give older compasses priority, they can replace the newer one if connected again alongside, also makes it consistent that same uavcan compass appears as one of the instances.

**AP_Logger, GCS_MAVLink, ArduCopter**
* We use new method `instance_available` to select whether to record/send/use the respective values for compass instance.

**AP_NavEKF2, AP_NavEKF3**
* We scroll through list of available instances when needed to select different Compass, the changes are made to accommodate behaviour change in Compass library, where devices may appear in an order with missing instance in between.