### PR TITLE
AP_HAL_Linux: release mutex lock before calling write(c)

### DIFF
--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -328,12 +328,12 @@ size_t UARTDriver::write(const uint8_t *buffer, size_t size)
         /*
           use the per-byte delay loop in write() above for blocking writes
          */
+        _write_mutex.give();
         size_t ret = 0;
         while (size--) {
             if (write(*buffer++) != 1) break;
             ret++;
         }
-        _write_mutex.give();
         return ret;
     }
 


### PR DESCRIPTION
It instantly tries to take it, but we're still holding it, leading to
instant failure.

This mirrors the same code in AP_HAL_ChibiOS.