### PR TITLE
SITL: fix ADSB home location

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -188,7 +188,7 @@ void SITL_State::_fdm_input_step(void)
 
         if (_sitl->adsb_plane_count >= 0 &&
             adsb == nullptr) {
-            adsb = new SITL::ADSB(_sitl->state, _home_str);
+            adsb = new SITL::ADSB(_sitl->state, sitl_model->get_home());
         } else if (_sitl->adsb_plane_count == -1 &&
                    adsb != nullptr) {
             delete adsb;

--- a/libraries/SITL/SIM_ADSB.cpp
+++ b/libraries/SITL/SIM_ADSB.cpp
@@ -28,13 +28,6 @@ namespace SITL {
 
 SITL *_sitl;
 
-ADSB::ADSB(const struct sitl_fdm &_fdm, const char *_home_str)
-{
-    float yaw_degrees;
-    HALSITL::SITL_State::parse_home(_home_str, home, yaw_degrees);
-}
-
-
 /*
   update a simulated vehicle
  */

--- a/libraries/SITL/SIM_ADSB.h
+++ b/libraries/SITL/SIM_ADSB.h
@@ -42,14 +42,14 @@ private:
         
 class ADSB {
 public:
-    ADSB(const struct sitl_fdm &_fdm, const char *home_str);
+    ADSB(const struct sitl_fdm &_fdm, const Location& _home) : home(_home) {};
     void update(void);
 
 private:
     const char *target_address = "127.0.0.1";
     const uint16_t target_port = 5762;
 
-    Location home;
+    const Location& home;
     uint8_t num_vehicles = 0;
     static const uint8_t num_vehicles_MAX = 200;
     ADSB_Vehicle vehicles[num_vehicles_MAX];


### PR DESCRIPTION
This passes ADSB a home location rather than a home string. The home string was null and thus SITL would crash. Thanks to @OXINARF for this fix and help figuring it out on gitter.