### PR TITLE
Plane: Introduced separate GCS failsafe to break it out from FS_LONG

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -66,6 +66,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #endif
     SCHED_TASK(one_second_loop,         1,    400),
     SCHED_TASK(check_long_failsafe,     3,    400),
+    SCHED_TASK(check_gcs_failsafe,      1,    400),
     SCHED_TASK(rpm_update,             10,    100),
     SCHED_TASK(airspeed_ratio_update,   1,    100),
 #if MOUNT == ENABLED

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -522,12 +522,29 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     GSCALAR(fs_timeout_long,        "FS_LONG_TIMEOUT", 5),
 
+    // @Param: FS_GCS_TIMEOUT
+    // @DisplayName: GCS failsafe timeout
+    // @Description: The time in seconds that a GCS failsafe condition has to persist. This defaults to 0 seconds which means "disabled".  
+    // @Units: s
+    // @Range: 3 2147483647
+    // @Increment: 1
+    // @User: Standard
+    GSCALAR(fs_timeout_gcs,        "FS_GCS_TIMEOUT", FS_ACTION_GCS_CONTINUE),
+    
     // @Param: FS_GCS_ENABL
     // @DisplayName: GCS failsafe enable
-    // @Description: Enable ground control station telemetry failsafe. Failsafe will trigger after FS_LONG_TIMEOUT seconds of no MAVLink heartbeat messages. There are three possible enabled settings. Seeing FS_GCS_ENABL to 1 means that GCS failsafe will be triggered when the aircraft has not received a MAVLink HEARTBEAT message. Setting FS_GCS_ENABL to 2 means that GCS failsafe will be triggered on either a loss of HEARTBEAT messages, or a RADIO_STATUS message from a MAVLink enabled 3DR radio indicating that the ground station is not receiving status updates from the aircraft, which is indicated by the RADIO_STATUS.remrssi field being zero (this may happen if you have a one way link due to asymmetric noise on the ground station and aircraft radios).Setting FS_GCS_ENABL to 3 means that GCS failsafe will be triggered by Heartbeat(like option one), but only in AUTO mode. WARNING: Enabling this option opens up the possibility of your plane going into failsafe mode and running the motor on the ground it it loses contact with your ground station. If this option is enabled on an electric plane then you should enable ARMING_REQUIRED.
+    // @Description: Enable ground control station telemetry failsafe. Failsafe will trigger after FS_GCS_TIMEOUT seconds of no MAVLink heartbeat messages. There are three possible enabled settings. Seeing FS_GCS_ENABL to 1 means that GCS failsafe will be triggered when the aircraft has not received a MAVLink HEARTBEAT message. Setting FS_GCS_ENABL to 2 means that GCS failsafe will be triggered on either a loss of HEARTBEAT messages, or a RADIO_STATUS message from a MAVLink enabled 3DR radio indicating that the ground station is not receiving status updates from the aircraft, which is indicated by the RADIO_STATUS.remrssi field being zero (this may happen if you have a one way link due to asymmetric noise on the ground station and aircraft radios).Setting FS_GCS_ENABL to 3 means that GCS failsafe will be triggered by Heartbeat(like option one), but only in AUTO mode. WARNING: Enabling this option opens up the possibility of your plane going into failsafe mode and running the motor on the ground it it loses contact with your ground station. If this option is enabled on an electric plane then you should enable ARMING_REQUIRED.
     // @Values: 0:Disabled,1:Heartbeat,2:HeartbeatAndREMRSSI,3:HeartbeatAndAUTO
     // @User: Standard
     GSCALAR(gcs_heartbeat_fs_enabled, "FS_GCS_ENABL", GCS_FAILSAFE_OFF),
+
+    // @Param: FS_GCS_ACTION
+    // @DisplayName: GCS failsafe action
+    // @Description: The action to take on a GCS failsafe event. If the aircraft was in a stabilization or manual mode when failsafe started and a GCS failsafe occurs then it will change to RTL mode if FS_GCS_ACTION is 0 or 1, and will change to FBWA if FS_GCS_ACTION is set to 2. If the aircraft was in an auto mode (such as AUTO or GUIDED) when the failsafe started then it will continue in the auto mode if FS_GCS_ACTION is set to 0, will change to RTL mode if FS_GCS_ACTION is set to 1 and will change to FBWA mode if FS_GCS_ACTION is set to 2. If FS_GCS_ACTION is set to 3, the parachute will be deployed (make sure the chute is configured and enabled). 
+    // @Values: 0:Continue,1:ReturnToLaunch,2:Glide,3:Deploy Parachute
+    // @User: Standard
+    GSCALAR(fs_action_gcs, "FS_GCS_ACTION", FS_ACTION_GCS_CONTINUE),
+    
 
     // @Param: FLTMODE_CH
     // @DisplayName: Flightmode channel
@@ -1300,10 +1317,6 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_land_then_servos_neutral,0, AP_PARAM_INT8,  "LAND_THEN_NEUTRAL" },
     { Parameters::k_param_land_abort_throttle_enable,0,AP_PARAM_INT8, "LAND_ABORT_THR" },
     { Parameters::k_param_land_flap_percent,  0,      AP_PARAM_INT8,  "LAND_FLAP_PERCENT" },
-
-    // battery failsafes
-    { Parameters::k_param_fs_batt_voltage,    0,      AP_PARAM_FLOAT, "BATT_LOW_VOLT" },
-    { Parameters::k_param_fs_batt_mah,        0,      AP_PARAM_FLOAT, "BATT_LOW_MAH" },
 
     { Parameters::k_param_arming,             3,      AP_PARAM_INT8,  "ARMING_RUDDER" },
     { Parameters::k_param_compass_enabled_deprecated,       0,      AP_PARAM_INT8, "COMPASS_ENABLE" },

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -245,12 +245,12 @@ public:
         k_param_rc_2_old,
         k_param_rc_3_old,
         k_param_rc_4_old,
-        k_param_rc_5_old,
+        k_param_rc_5_old, 
         k_param_rc_6_old,
         k_param_rc_7_old,
         k_param_rc_8_old,
         k_param_rc_9_old,
-        k_param_rc_10_old,
+        k_param_rc_10_old, 
         k_param_rc_11_old,
 
         k_param_throttle_min,
@@ -266,8 +266,8 @@ public:
         k_param_throttle_suppress_manual,
         k_param_throttle_passthru_stabilize,
         k_param_rc_12_old,
-        k_param_fs_batt_voltage, // unused - moved to AP_BattMonitor
-        k_param_fs_batt_mah,     // unused - moved to AP_BattMonitor
+        k_param_fs_action_gcs,
+        k_param_fs_timeout_gcs,     
         k_param_fs_timeout_short,
         k_param_fs_timeout_long,
         k_param_rc_13_old,
@@ -422,6 +422,8 @@ public:
     AP_Int8 fs_action_long;
     AP_Float fs_timeout_short;
     AP_Float fs_timeout_long;
+    AP_Int32 fs_timeout_gcs;
+    AP_Int16 fs_action_gcs;
     AP_Int8 gcs_heartbeat_fs_enabled;
 
     // Flight modes

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -857,8 +857,10 @@ private:
     bool fly_inverted(void);
     void failsafe_short_on_event(enum failsafe_state fstype, mode_reason_t reason);
     void failsafe_long_on_event(enum failsafe_state fstype, mode_reason_t reason);
+    void failsafe_gcs_on_event(enum failsafe_state fstype, mode_reason_t reason);
     void failsafe_short_off_event(mode_reason_t reason);
     void failsafe_long_off_event(mode_reason_t reason);
+    void failsafe_gcs_off_event(mode_reason_t reason);
     void handle_battery_failsafe(const char* type_str, const int8_t action);
     uint8_t max_fencepoints(void) const;
     Vector2l get_fence_point_with_index(uint8_t i) const;
@@ -909,8 +911,9 @@ private:
     bool set_mode(Mode& new_mode, const mode_reason_t reason);
     bool set_mode_by_number(const Mode::Number new_mode_number, const mode_reason_t reason);
     Mode *mode_from_mode_num(const enum Mode::Number num);
-    void check_long_failsafe();
+    void check_long_failsafe();  
     void check_short_failsafe();
+    void check_gcs_failsafe();
     void startup_INS_ground(void);
     bool should_log(uint32_t mask);
     int8_t throttle_percentage(void);

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -31,6 +31,14 @@ enum gcs_failsafe {
                                  // while in AUTO mode
 };
 
+// GCS failsafe actions
+enum failsafe_action_gcs {
+    FS_ACTION_GCS_CONTINUE = 0,
+    FS_ACTION_GCS_RTL = 1,
+    FS_ACTION_GCS_GLIDE = 2,
+    FS_ACTION_GCS_PARACHUTE = 3,
+};
+
 enum failsafe_action_short {
     FS_ACTION_SHORT_BESTGUESS = 0,      // CIRCLE/no change(if already in AUTO|GUIDED|LOITER)
     FS_ACTION_SHORT_CIRCLE = 1,
@@ -65,6 +73,9 @@ enum mode_reason_t {
     MODE_REASON_VTOL_FAILED_TRANSITION,
     MODE_REASON_UNAVAILABLE,
     MODE_REASON_VTOL_FAILED_TAKEOFF,
+    MODE_REASON_GCS_FAILSAFE_HEARTBEAT,
+    MODE_REASON_GCS_FAILSAFE_HEARTBEAT_AND_REM_RSSI,
+    MODE_REASON_GCS_FAILSAFE_HEARTBEAT_AND_AUTO,
 };
 
 // type of stick mixing enabled

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -318,13 +318,13 @@ bool Plane::set_mode_by_number(const Mode::Number new_mode_number, const mode_re
     }
     return set_mode(*new_mode, reason);
 }
-
+    
 void Plane::check_long_failsafe()
 {
     uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if (failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    if (failsafe.state != FAILSAFE_LONG && flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
         uint32_t radio_timeout_ms = failsafe.last_valid_rc_ms;
         if (failsafe.state == FAILSAFE_SHORT) {
             // time is relative to when short failsafe enabled
@@ -333,34 +333,19 @@ void Plane::check_long_failsafe()
         if (failsafe.rc_failsafe &&
             (tnow - radio_timeout_ms) > g.fs_timeout_long*1000) {
             failsafe_long_on_event(FAILSAFE_LONG, MODE_REASON_RADIO_FAILSAFE);
-        } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_AUTO && control_mode == &mode_auto &&
-                   failsafe.last_heartbeat_ms != 0 &&
-                   (tnow - failsafe.last_heartbeat_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE);
-        } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HEARTBEAT &&
-                   failsafe.last_heartbeat_ms != 0 &&
-                   (tnow - failsafe.last_heartbeat_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE);
-        } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI && 
-                   gcs().chan(0) != nullptr &&
-                   gcs().chan(0)->last_radio_status_remrssi_ms != 0 &&
-                   (tnow - gcs().chan(0)->last_radio_status_remrssi_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE);
-        }
+        } 
     } else {
         uint32_t timeout_seconds = g.fs_timeout_long;
-        if (g.fs_action_short != FS_ACTION_SHORT_DISABLED) {
+        if (g.fs_action_short != FS_ACTION_SHORT_DISABLED) {            
             // avoid dropping back into short timeout
             timeout_seconds = g.fs_timeout_short;
         }
         // We do not change state but allow for user to change mode
-        if (failsafe.state == FAILSAFE_GCS && 
-            (tnow - failsafe.last_heartbeat_ms) < timeout_seconds*1000) {
-            failsafe_long_off_event(MODE_REASON_GCS_FAILSAFE);
-        } else if (failsafe.state == FAILSAFE_LONG && 
+        if (failsafe.state == FAILSAFE_LONG && 
                    !failsafe.rc_failsafe) {
             failsafe_long_off_event(MODE_REASON_RADIO_FAILSAFE);
         }
+        timeout_seconds = timeout_seconds;
     }
 }
 
@@ -384,6 +369,41 @@ void Plane::check_short_failsafe()
     }
 }
 
+void Plane::check_gcs_failsafe()
+{
+    uint32_t tnow = millis();
+
+    // only act on changes
+    // -------------------   
+    if (g.fs_timeout_gcs !=  0 && g.gcs_heartbeat_fs_enabled != 0
+        && failsafe.state != FAILSAFE_GCS && flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {      
+        if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_AUTO &&
+            control_mode == &mode_auto && failsafe.last_heartbeat_ms != 0 &&
+            (tnow - failsafe.last_heartbeat_ms) > (uint32_t) g.fs_timeout_gcs*1000) {
+            failsafe_gcs_on_event(FAILSAFE_GCS,
+                                  MODE_REASON_GCS_FAILSAFE_HEARTBEAT_AND_AUTO);
+        } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HEARTBEAT &&
+                   failsafe.last_heartbeat_ms != 0 &&
+                   (tnow - failsafe.last_heartbeat_ms) > (uint32_t) g.fs_timeout_gcs*1000) {
+            failsafe_gcs_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE_HEARTBEAT);
+        } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI && 
+                   gcs().chan(0) != nullptr &&
+                   gcs().chan(0)->last_radio_status_remrssi_ms != 0 &&
+                   (tnow - gcs().chan(0)->last_radio_status_remrssi_ms)
+                      > (uint32_t) g.fs_timeout_gcs*1000) {
+            failsafe_gcs_on_event(FAILSAFE_GCS,
+                                  MODE_REASON_GCS_FAILSAFE_HEARTBEAT_AND_REM_RSSI);
+        }
+    } else {
+        uint32_t timeout_seconds = g.fs_timeout_gcs;
+        
+        // We do not change state but allow for user to change mode
+        if (failsafe.state == FAILSAFE_GCS && 
+            (tnow - failsafe.last_heartbeat_ms) < timeout_seconds*1000) {
+            failsafe_gcs_off_event(MODE_REASON_GCS_FAILSAFE);
+        }
+    } 
+}    
 
 void Plane::startup_INS_ground(void)
 {


### PR DESCRIPTION
Broke the GCS failsafe out into its own failure mode.  This keeps it separate from FS_LONG.  Future pull requests might consider not glomming all failure modes together into FS_LONG and FS_SHORT.  Rather keep throttle, battery, GCS, GPS, companion computer, engine RPMs, etc. all in their own failure modes.