### PR TITLE
Copter: remove redundant SurfaceTracking enumeration namespacing

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -289,17 +289,17 @@ private:
         bool get_dist_for_logging(float &target_dist, float &actual_dist) const;
         void invalidate_for_logging() { valid_for_logging = false; }
 
-        // surface tracking states
-        enum class SurfaceTrackingState {
-            SURFACE_TRACKING_DISABLED = 0,
-            SURFACE_TRACKING_GROUND = 1,
-            SURFACE_TRACKING_CEILING = 2
+        // surface tracking surface
+        enum class Surface {
+            NONE = 0,
+            GROUND = 1,
+            CEILING = 2
         };
-        // set direction
-        void set_state(SurfaceTrackingState state);
+        // set surface to track
+        void set_surface(Surface new_surface);
 
     private:
-        SurfaceTrackingState tracking_state = SurfaceTrackingState::SURFACE_TRACKING_GROUND;
+        Surface surface = Surface::GROUND;
         float target_dist_cm;       // desired distance in cm from ground or ceiling
         uint32_t last_update_ms;    // system time of last update to target_alt_cm
         uint32_t last_glitch_cleared_ms;    // system time of last handle glitch recovery

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -562,13 +562,13 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
         case AUX_FUNC::SURFACE_TRACKING:
             switch (ch_flag) {
             case LOW:
-                copter.surface_tracking.set_state(Copter::SurfaceTracking::SurfaceTrackingState::SURFACE_TRACKING_GROUND);
+                copter.surface_tracking.set_surface(Copter::SurfaceTracking::Surface::GROUND);
                 break;
             case MIDDLE:
-                copter.surface_tracking.set_state(Copter::SurfaceTracking::SurfaceTrackingState::SURFACE_TRACKING_DISABLED);
+                copter.surface_tracking.set_surface(Copter::SurfaceTracking::Surface::NONE);
                 break;
             case HIGH:
-                copter.surface_tracking.set_state(Copter::SurfaceTracking::SurfaceTrackingState::SURFACE_TRACKING_CEILING);
+                copter.surface_tracking.set_surface(Copter::SurfaceTracking::Surface::CEILING);
                 break;
             }
             break;


### PR DESCRIPTION
Also rename State to Surface to be more specific about what is being
set/tracked.

This halves the length of a lot of lines.

This was a mechanical rename.  It has been tested in SITL.
