### PR TITLE
GCS_MAVLink: mission item support more mav frames

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -64,7 +64,11 @@ uint16_t MissionItemProtocol_Fence::item_count() const
 static MAV_MISSION_RESULT convert_MISSION_ITEM_INT_to_AC_PolyFenceItem(const mavlink_mission_item_int_t &mission_item_int, AC_PolyFenceItem &ret)
 {
     if (mission_item_int.frame != MAV_FRAME_GLOBAL &&
-        mission_item_int.frame != MAV_FRAME_GLOBAL_INT) {
+        mission_item_int.frame != MAV_FRAME_GLOBAL_INT &&
+        mission_item_int.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT &&
+        mission_item_int.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT_INT &&
+        mission_item_int.frame != MAV_FRAME_GLOBAL_TERRAIN_ALT &&
+        mission_item_int.frame != MAV_FRAME_GLOBAL_TERRAIN_ALT_INT) {
         return MAV_MISSION_UNSUPPORTED_FRAME;
     }
 


### PR DESCRIPTION
This resolves this issue found while testing uploading of fences from QGC: https://github.com/ArduPilot/ardupilot/issues/12664 by allow two more mavtypes be used when uploading fences.

- MAV_FRAME_GLOBAL_RELATIVE_ALT
- MAV_FRAME_GLOBAL_RELATIVE_ALT_INT

Because fences are essentially 2D (no altitude) I don't think there should be any problem with accepting these additional frames.

This has been tested on Copter-4.0.0-rc1 including a test flight and seems to work