### PR TITLE
AP_GPS: allow autobaud detect of 460800 for uBlox F9

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -60,7 +60,7 @@
 extern const AP_HAL::HAL &hal;
 
 // baudrates to try to detect GPSes with
-const uint32_t AP_GPS::_baudrates[] = {9600U, 115200U, 4800U, 19200U, 38400U, 57600U, 230400U};
+const uint32_t AP_GPS::_baudrates[] = {9600U, 115200U, 4800U, 19200U, 38400U, 57600U, 460800U, 230400U};
 
 // initialisation blobs to send to the GPS to try to get it into the
 // right mode


### PR DESCRIPTION
The new uBlox F9 can send more/faster data so faster bauds are needed. This adds a GPS autodetect of 460800.