### PR TITLE
AP_Baro: Add I2C Access

### DIFF
--- a/libraries/AP_Baro/AP_Baro_DPS280.cpp
+++ b/libraries/AP_Baro/AP_Baro_DPS280.cpp
@@ -135,7 +135,11 @@ bool AP_Baro_DPS280::init()
         return false;
     }
 
-    dev->set_read_flag(0x80);
+    // setup to allow reads on SPI
+    if (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
+        dev->set_read_flag(0x80);
+    }
+
     dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     uint8_t whoami=0;


### PR DESCRIPTION
I want to use DPS310 with I2C.
I couldn't use this driver.
I learned that this driver is fixed to SPI.
I added a bus verdict.