### PR TITLE
AP_BLHeli: fix eRPM conversion

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1342,7 +1342,7 @@ void AP_BLHeli::read_telemetry_packet(void)
     td.voltage = (buf[1]<<8) | buf[2];
     td.current = (buf[3]<<8) | buf[4];
     td.consumption = (buf[5]<<8) | buf[6];
-    td.rpm = ((buf[7]<<8) | buf[8]) * motor_poles;
+    td.rpm = ((buf[7]<<8) | buf[8]) * 100 * 2 / motor_poles;
     td.timestamp_ms = AP_HAL::millis();
 
     last_telem[last_telem_esc] = td;


### PR DESCRIPTION
i got the conversion wrong in my initial commit https://github.com/ArduPilot/ardupilot/pull/9590
the error happens to be only 2% for a standard 14 pole motor, that's why i didn't notice. it increases drastically for different motor pole counts though.
thanks @andyp1per for noticing. fixing this is part of https://github.com/ArduPilot/ardupilot/pull/12544 too, however i thought it might be usefull to get this fixed independently of the harmonic notch filter complex.