### PR TITLE
Proximity cleanups

### DIFF
--- a/APMrover2/GCS_Rover.cpp
+++ b/APMrover2/GCS_Rover.cpp
@@ -34,7 +34,7 @@ void GCS_Rover::update_vehicle_sensor_status_flags(void)
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_VISION_POSITION;
     }
     const AP_Proximity *proximity = AP_Proximity::get_singleton();
-    if (proximity && proximity->get_status() > AP_Proximity::Proximity_NotConnected) {
+    if (proximity && proximity->get_status() > AP_Proximity::Status::NotConnected) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
@@ -73,7 +73,7 @@ void GCS_Rover::update_vehicle_sensor_status_flags(void)
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
     }
-    if (proximity && proximity->get_status() != AP_Proximity::Proximity_NoData) {
+    if (proximity && proximity->get_status() != AP_Proximity::Status::NoData) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
 }

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -671,7 +671,7 @@ ParametersG2::ParametersG2(void)
     wheel_rate_control(wheel_encoder),
     attitude_control(rover.ahrs),
     smart_rtl(),
-    proximity(rover.serial_manager),
+    proximity(),
     avoid(),
     follow(),
     windvane(),

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -123,7 +123,6 @@ void Rover::read_rangefinders(void)
 void Rover::init_proximity(void)
 {
     g2.proximity.init();
-    g2.proximity.set_rangefinder(&rangefinder);
 }
 
 /*

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1010,7 +1010,7 @@ ParametersG2::ParametersG2(void)
     , beacon(copter.serial_manager)
 #endif
 #if PROXIMITY_ENABLED == ENABLED
-    , proximity(copter.serial_manager)
+    , proximity()
 #endif
 #if ADVANCED_FAILSAFE == ENABLED
     ,afs(copter.mode_auto.mission)

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -199,7 +199,6 @@ void Copter::init_proximity(void)
 {
 #if PROXIMITY_ENABLED == ENABLED
     g2.proximity.init();
-    g2.proximity.set_rangefinder(&rangefinder);
 #endif
 }
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -690,7 +690,7 @@ void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &d
 
     AP_Proximity &_proximity = *proximity;
 
-    if (_proximity.get_status() != AP_Proximity::Proximity_Good) {
+    if (_proximity.get_status() != AP_Proximity::Status::Good) {
         return;
     }
 
@@ -858,7 +858,7 @@ void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_ne
     AP_Proximity &_proximity = *proximity;
 
     // exit immediately if proximity sensor is not present
-    if (_proximity.get_status() != AP_Proximity::Proximity_Good) {
+    if (_proximity.get_status() != AP_Proximity::Status::Good) {
         return;
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -716,12 +716,12 @@ bool AP_Arming::proximity_checks(bool report) const
     if (proximity == nullptr) {
         return true;
     }
-    if (proximity->get_status() == AP_Proximity::Proximity_NotConnected) {
+    if (proximity->get_status() == AP_Proximity::Status::NotConnected) {
         return true;
     }
 
     // return false if proximity sensor unhealthy
-    if (proximity->get_status() < AP_Proximity::Proximity_Good) {
+    if (proximity->get_status() < AP_Proximity::Status::Good) {
         check_failed(report, "check proximity sensor");
         return false;
     }

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -928,7 +928,7 @@ void AP_Logger::Write_Beacon(AP_Beacon &beacon)
 void AP_Logger::Write_Proximity(AP_Proximity &proximity)
 {
     // exit immediately if not enabled
-    if (proximity.get_status() == AP_Proximity::Proximity_NotConnected) {
+    if (proximity.get_status() == AP_Proximity::Status::NotConnected) {
         return;
     }
 

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -206,7 +206,7 @@ void AP_Proximity::init(void)
         }
 
         // initialise status
-        state[i].status = Proximity_NotConnected;
+        state[i].status = Status::NotConnected;
     }
 }
 
@@ -222,7 +222,7 @@ void AP_Proximity::update(void)
 
     // work out primary instance - first sensor returning good data
     for (int8_t i=num_instances-1; i>=0; i--) {
-        if (drivers[i] != nullptr && (state[i].status == Proximity_Good)) {
+        if (drivers[i] != nullptr && (state[i].status == Status::Good)) {
             primary_instance = i;
         }
     }
@@ -249,17 +249,17 @@ int16_t AP_Proximity::get_yaw_correction(uint8_t instance) const
 }
 
 // return sensor health
-AP_Proximity::Proximity_Status AP_Proximity::get_status(uint8_t instance) const
+AP_Proximity::Status AP_Proximity::get_status(uint8_t instance) const
 {
     // sanity check instance number
     if (!valid_instance(instance)) {
-        return Proximity_NotConnected;
+        return Status::NotConnected;
     }
 
     return state[instance].status;
 }
 
-AP_Proximity::Proximity_Status AP_Proximity::get_status() const
+AP_Proximity::Status AP_Proximity::get_status() const
 {
     return get_status(primary_instance);
 }
@@ -458,7 +458,7 @@ AP_Proximity::Type AP_Proximity::get_type(uint8_t instance) const
 
 bool AP_Proximity::sensor_present() const
 {
-    return get_status() != Proximity_NotConnected;
+    return get_status() != Status::NotConnected;
 }
 bool AP_Proximity::sensor_enabled() const
 {
@@ -466,7 +466,7 @@ bool AP_Proximity::sensor_enabled() const
 }
 bool AP_Proximity::sensor_failed() const
 {
-    return get_status() != Proximity_Good;
+    return get_status() != Status::Good;
 }
 
 AP_Proximity *AP_Proximity::_singleton;

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -214,14 +214,10 @@ void AP_Proximity::init(void)
 void AP_Proximity::update(void)
 {
     for (uint8_t i=0; i<num_instances; i++) {
-        if (drivers[i] != nullptr) {
-            if (get_type(i) == Type::None) {
-                // allow user to disable a proximity sensor at runtime
-                state[i].status = Proximity_NotConnected;
-                continue;
-            }
-            drivers[i]->update();
+        if (!valid_instance(i)) {
+            continue;
         }
+        drivers[i]->update();
     }
 
     // work out primary instance - first sensor returning good data
@@ -235,7 +231,7 @@ void AP_Proximity::update(void)
 // return sensor orientation
 uint8_t AP_Proximity::get_orientation(uint8_t instance) const
 {
-    if (instance >= PROXIMITY_MAX_INSTANCES) {
+    if (!valid_instance(instance)) {
         return 0;
     }
 
@@ -245,7 +241,7 @@ uint8_t AP_Proximity::get_orientation(uint8_t instance) const
 // return sensor yaw correction
 int16_t AP_Proximity::get_yaw_correction(uint8_t instance) const
 {
-    if (instance >= PROXIMITY_MAX_INSTANCES) {
+    if (!valid_instance(instance)) {
         return 0;
     }
 
@@ -256,7 +252,7 @@ int16_t AP_Proximity::get_yaw_correction(uint8_t instance) const
 AP_Proximity::Proximity_Status AP_Proximity::get_status(uint8_t instance) const
 {
     // sanity check instance number
-    if (instance >= num_instances) {
+    if (!valid_instance(instance)) {
         return Proximity_NotConnected;
     }
 

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -178,8 +178,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     AP_GROUPEND
 };
 
-AP_Proximity::AP_Proximity(AP_SerialManager &_serial_manager) :
-    serial_manager(_serial_manager)
+AP_Proximity::AP_Proximity()
 {
     AP_Param::setup_object_defaults(this, var_info);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -284,16 +283,16 @@ void AP_Proximity::detect_instance(uint8_t instance)
 {
     uint8_t type = _type[instance];
     if (type == Proximity_Type_SF40C) {
-        if (AP_Proximity_LightWareSF40C::detect(serial_manager)) {
+        if (AP_Proximity_LightWareSF40C::detect()) {
             state[instance].instance = instance;
-            drivers[instance] = new AP_Proximity_LightWareSF40C(*this, state[instance], serial_manager);
+            drivers[instance] = new AP_Proximity_LightWareSF40C(*this, state[instance]);
             return;
         }
     }
     if (type == Proximity_Type_RPLidarA2) {
-        if (AP_Proximity_RPLidarA2::detect(serial_manager)) {
+        if (AP_Proximity_RPLidarA2::detect()) {
             state[instance].instance = instance;
-            drivers[instance] = new AP_Proximity_RPLidarA2(*this, state[instance], serial_manager);
+            drivers[instance] = new AP_Proximity_RPLidarA2(*this, state[instance]);
             return;
         }
     }
@@ -303,16 +302,16 @@ void AP_Proximity::detect_instance(uint8_t instance)
         return;
     }
     if (type == Proximity_Type_TRTOWER) {
-        if (AP_Proximity_TeraRangerTower::detect(serial_manager)) {
+        if (AP_Proximity_TeraRangerTower::detect()) {
             state[instance].instance = instance;
-            drivers[instance] = new AP_Proximity_TeraRangerTower(*this, state[instance], serial_manager);
+            drivers[instance] = new AP_Proximity_TeraRangerTower(*this, state[instance]);
             return;
         }
     }
     if (type == Proximity_Type_TRTOWEREVO) {
-        if (AP_Proximity_TeraRangerTowerEvo::detect(serial_manager)) {
+        if (AP_Proximity_TeraRangerTowerEvo::detect()) {
             state[instance].instance = instance;
-            drivers[instance] = new AP_Proximity_TeraRangerTowerEvo(*this, state[instance], serial_manager);
+            drivers[instance] = new AP_Proximity_TeraRangerTowerEvo(*this, state[instance]);
             return;
         }
     }

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -38,17 +38,19 @@ public:
     AP_Proximity &operator=(const AP_Proximity) = delete;
 
     // Proximity driver types
-    enum Proximity_Type {
-        Proximity_Type_None    = 0,
-        Proximity_Type_SF40C   = 1,
-        Proximity_Type_MAV     = 2,
-        Proximity_Type_TRTOWER = 3,
-        Proximity_Type_RangeFinder = 4,
-        Proximity_Type_RPLidarA2 = 5,
-        Proximity_Type_TRTOWEREVO = 6,
-        Proximity_Type_SITL    = 10,
-        Proximity_Type_MorseSITL = 11,
-        Proximity_Type_AirSimSITL = 12,
+    enum class Type {
+        None    = 0,
+        SF40C   = 1,
+        MAV     = 2,
+        TRTOWER = 3,
+        RangeFinder = 4,
+        RPLidarA2 = 5,
+        TRTOWEREVO = 6,
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        SITL    = 10,
+        MorseSITL = 11,
+        AirSimSITL = 12,
+#endif
     };
 
     enum Proximity_Status {
@@ -128,7 +130,7 @@ public:
     bool get_upward_distance(uint8_t instance, float &distance) const;
     bool get_upward_distance(float &distance) const;
 
-    Proximity_Type get_type(uint8_t instance) const;
+    Type get_type(uint8_t instance) const;
 
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
@@ -148,6 +150,13 @@ private:
     const RangeFinder *_rangefinder;
     uint8_t primary_instance;
     uint8_t num_instances;
+
+    bool valid_instance(uint8_t i) const {
+        if (drivers[i] == nullptr) {
+            return false;
+        }
+        return (Type)_type[i].get() != Type::None;
+    }
 
     // parameters for all instances
     AP_Int8  _type[PROXIMITY_MAX_INSTANCES];

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -18,7 +18,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 
 #define PROXIMITY_MAX_INSTANCES             1   // Maximum number of proximity sensor instances available on this platform
@@ -33,7 +32,7 @@ class AP_Proximity
 public:
     friend class AP_Proximity_Backend;
 
-    AP_Proximity(AP_SerialManager &_serial_manager);
+    AP_Proximity();
 
     AP_Proximity(const AP_Proximity &other) = delete;
     AP_Proximity &operator=(const AP_Proximity) = delete;
@@ -149,7 +148,6 @@ private:
     const RangeFinder *_rangefinder;
     uint8_t primary_instance;
     uint8_t num_instances;
-    AP_SerialManager &serial_manager;
 
     // parameters for all instances
     AP_Int8  _type[PROXIMITY_MAX_INSTANCES];

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -53,10 +53,10 @@ public:
 #endif
     };
 
-    enum Proximity_Status {
-        Proximity_NotConnected = 0,
-        Proximity_NoData,
-        Proximity_Good
+    enum Status {
+        NotConnected = 0,
+        NoData,
+        Good
     };
 
     // structure holding distances in PROXIMITY_MAX_DIRECTION directions. used for sending distances to ground station
@@ -80,8 +80,8 @@ public:
     int16_t get_yaw_correction(uint8_t instance) const;
 
     // return sensor health
-    Proximity_Status get_status(uint8_t instance) const;
-    Proximity_Status get_status() const;
+    Status get_status(uint8_t instance) const;
+    Status get_status() const;
 
     // Return the number of proximity sensors
     uint8_t num_sensors(void) const {
@@ -119,7 +119,7 @@ public:
     // The Proximity_State structure is filled in by the backend driver
     struct Proximity_State {
         uint8_t                 instance;   // the instance number of this proximity sensor
-        enum Proximity_Status   status;     // sensor status
+        Status   status;     // sensor status
     };
 
     //

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -18,7 +18,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_RangeFinder/AP_RangeFinder.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define PROXIMITY_MAX_INSTANCES             1   // Maximum number of proximity sensor instances available on this platform
 #define PROXIMITY_MAX_IGNORE                6   // up to six areas can be ignored
@@ -70,10 +70,6 @@ public:
 
     // update state of all proximity sensors. Should be called at high rate from main loop
     void update(void);
-
-    // set pointer to rangefinder object
-    void set_rangefinder(const class RangeFinder *rangefinder) { _rangefinder = rangefinder; }
-    const RangeFinder *get_rangefinder() const { return _rangefinder; }
 
     // return sensor orientation and yaw correction
     uint8_t get_orientation(uint8_t instance) const;
@@ -147,7 +143,6 @@ private:
     static AP_Proximity *_singleton;
     Proximity_State state[PROXIMITY_MAX_INSTANCES];
     AP_Proximity_Backend *drivers[PROXIMITY_MAX_INSTANCES];
-    const RangeFinder *_rangefinder;
     uint8_t primary_instance;
     uint8_t num_instances;
 

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -23,16 +23,6 @@ extern const AP_HAL::HAL& hal;
 #define PROXIMITY_MAX_RANGE 100.0f
 #define PROXIMITY_ACCURACY 0.1f
 
-/* 
-   The constructor also initialises the proximity sensor. 
-*/
-AP_Proximity_AirSimSITL::AP_Proximity_AirSimSITL(AP_Proximity &_frontend,
-                                     AP_Proximity::Proximity_State &_state):
-    AP_Proximity_Backend(_frontend, _state),
-    sitl(AP::sitl())
-{
-}
-
 // update the state of the sensor
 void AP_Proximity_AirSimSITL::update(void)
 {

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -38,11 +38,11 @@ void AP_Proximity_AirSimSITL::update(void)
 {
     SITL::vector3f_array &points = sitl->state.scanner.points;
     if (points.length == 0) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
         return;
     }
 
-    set_status(AP_Proximity::Proximity_Good);
+    set_status(AP_Proximity::Status::Good);
 
     memset(_distance_valid, 0, sizeof(_distance_valid));
     memset(_angle, 0, sizeof(_angle));

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
@@ -26,7 +26,7 @@ class AP_Proximity_AirSimSITL : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_AirSimSITL(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
+    using AP_Proximity_Backend::AP_Proximity_Backend;
 
     // update state
     void update(void) override;
@@ -39,6 +39,6 @@ public:
     bool get_upward_distance(float &distance) const override;
 
 private:
-    SITL::SITL *sitl;
+    SITL::SITL *sitl = AP::sitl();
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -142,7 +142,7 @@ bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Dist
 const Vector2f* AP_Proximity_Backend::get_boundary_points(uint16_t& num_points) const
 {
     // high-level status check
-    if (state.status != AP_Proximity::Proximity_Good) {
+    if (state.status != AP_Proximity::Status::Good) {
         num_points = 0;
         return nullptr;
     }
@@ -236,7 +236,7 @@ void AP_Proximity_Backend::update_boundary_for_sector(const uint8_t sector, cons
 }
 
 // set status and update valid count
-void AP_Proximity_Backend::set_status(AP_Proximity::Proximity_Status status)
+void AP_Proximity_Backend::set_status(AP_Proximity::Status status)
 {
     state.status = status;
 }

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -68,7 +68,7 @@ public:
 protected:
 
     // set status and update valid_count
-    void set_status(AP_Proximity::Proximity_Status status);
+    void set_status(AP_Proximity::Status status);
 
     // find which sector a given angle falls into
     bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -27,10 +27,10 @@ extern const AP_HAL::HAL& hal;
    already know that we should setup the proximity sensor
 */
 AP_Proximity_LightWareSF40C::AP_Proximity_LightWareSF40C(AP_Proximity &_frontend,
-                                                         AP_Proximity::Proximity_State &_state,
-                                                         AP_SerialManager &serial_manager) :
+                                                         AP_Proximity::Proximity_State &_state) :
     AP_Proximity_Backend(_frontend, _state)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
@@ -38,9 +38,9 @@ AP_Proximity_LightWareSF40C::AP_Proximity_LightWareSF40C(AP_Proximity &_frontend
 }
 
 // detect if a Lightware proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_LightWareSF40C::detect(AP_SerialManager &serial_manager)
+bool AP_Proximity_LightWareSF40C::detect()
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
 }
 
 // update the state of the sensor

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -63,9 +63,9 @@ void AP_Proximity_LightWareSF40C::update(void)
 
     // check for timeout and set health status
     if ((_last_distance_received_ms == 0) || (AP_HAL::millis() - _last_distance_received_ms > PROXIMITY_SF40C_TIMEOUT_MS)) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
     } else {
-        set_status(AP_Proximity::Proximity_Good);
+        set_status(AP_Proximity::Status::Good);
     }
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -10,10 +10,11 @@ class AP_Proximity_LightWareSF40C : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_LightWareSF40C(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_SerialManager &serial_manager);
+    AP_Proximity_LightWareSF40C(AP_Proximity &_frontend,
+                                AP_Proximity::Proximity_State &_state);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager);
+    static bool detect();
 
     // update state
     void update(void) override;

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -23,17 +23,6 @@ extern const AP_HAL::HAL& hal;
 
 #define PROXIMITY_MAV_TIMEOUT_MS    500 // distance messages must arrive within this many milliseconds
 
-/* 
-   The constructor also initialises the proximity sensor. Note that this
-   constructor is not called until detect() returns true, so we
-   already know that we should setup the proximity sensor
-*/
-AP_Proximity_MAV::AP_Proximity_MAV(AP_Proximity &_frontend,
-                                   AP_Proximity::Proximity_State &_state) :
-    AP_Proximity_Backend(_frontend, _state)
-{
-}
-
 // update the state of the sensor
 void AP_Proximity_MAV::update(void)
 {

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -40,9 +40,9 @@ void AP_Proximity_MAV::update(void)
     // check for timeout and set health status
     if ((_last_update_ms == 0 || (AP_HAL::millis() - _last_update_ms > PROXIMITY_MAV_TIMEOUT_MS)) &&
         (_last_upward_update_ms == 0 || (AP_HAL::millis() - _last_upward_update_ms > PROXIMITY_MAV_TIMEOUT_MS))) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
     } else {
-        set_status(AP_Proximity::Proximity_Good);
+        set_status(AP_Proximity::Status::Good);
     }
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -8,7 +8,7 @@ class AP_Proximity_MAV : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_MAV(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
+    using AP_Proximity_Backend::AP_Proximity_Backend;
 
     // update state
     void update(void) override;

--- a/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
@@ -24,16 +24,6 @@ extern const AP_HAL::HAL& hal;
 #define PROXIMITY_MAX_RANGE 200.0f
 #define PROXIMITY_ACCURACY 0.1f
 
-/* 
-   The constructor also initialises the proximity sensor. 
-*/
-AP_Proximity_MorseSITL::AP_Proximity_MorseSITL(AP_Proximity &_frontend,
-                                     AP_Proximity::Proximity_State &_state):
-    AP_Proximity_Backend(_frontend, _state),
-    sitl(AP::sitl())
-{
-}
-
 // update the state of the sensor
 void AP_Proximity_MorseSITL::update(void)
 {

--- a/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
@@ -41,11 +41,11 @@ void AP_Proximity_MorseSITL::update(void)
     SITL::float_array &ranges = sitl->state.scanner.ranges;
     if (points.length != ranges.length ||
         points.length == 0) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
         return;
     }
 
-    set_status(AP_Proximity::Proximity_Good);
+    set_status(AP_Proximity::Status::Good);
 
     memset(_distance_valid, 0, sizeof(_distance_valid));
     memset(_angle, 0, sizeof(_angle));

--- a/libraries/AP_Proximity/AP_Proximity_MorseSITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_MorseSITL.h
@@ -11,7 +11,7 @@ class AP_Proximity_MorseSITL : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_MorseSITL(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
+    using AP_Proximity_Backend::AP_Proximity_Backend;
 
     // update state
     void update(void) override;
@@ -24,7 +24,7 @@ public:
     bool get_upward_distance(float &distance) const override;
 
 private:
-    SITL::SITL *sitl;
+    SITL::SITL *sitl = AP::sitl();
     float distance_maximum;
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -69,11 +69,12 @@ extern const AP_HAL::HAL& hal;
    constructor is not called until detect() returns true, so we
    already know that we should setup the proximity sensor
  */
-AP_Proximity_RPLidarA2::AP_Proximity_RPLidarA2(AP_Proximity &_frontend,
-                                               AP_Proximity::Proximity_State &_state,
-                                               AP_SerialManager &serial_manager) :
-                                               AP_Proximity_Backend(_frontend, _state)
+AP_Proximity_RPLidarA2::AP_Proximity_RPLidarA2(
+    AP_Proximity &_frontend,
+    AP_Proximity::Proximity_State &_state) :
+    AP_Proximity_Backend(_frontend, _state)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
     _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
     if (_uart != nullptr) {
         _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
@@ -84,9 +85,9 @@ AP_Proximity_RPLidarA2::AP_Proximity_RPLidarA2(AP_Proximity &_frontend,
 }
 
 // detect if a RPLidarA2 proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_RPLidarA2::detect(AP_SerialManager &serial_manager)
+bool AP_Proximity_RPLidarA2::detect()
 {
-    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
 }
 
 // update the _rp_state of the sensor

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -109,10 +109,10 @@ void AP_Proximity_RPLidarA2::update(void)
 
     // check for timeout and set health status
     if ((_last_distance_received_ms == 0) || (AP_HAL::millis() - _last_distance_received_ms > COMM_ACTIVITY_TIMEOUT_MS)) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
         Debug(1, "LIDAR NO DATA");
     } else {
-        set_status(AP_Proximity::Proximity_Good);
+        set_status(AP_Proximity::Status::Good);
     }
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -39,10 +39,10 @@ class AP_Proximity_RPLidarA2 : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_RPLidarA2(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_SerialManager &serial_manager);
+    AP_Proximity_RPLidarA2(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager);
+    static bool detect();
 
     // update state
     void update(void) override;

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -20,15 +20,6 @@
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_RangeFinder/RangeFinder_Backend.h>
 
-extern const AP_HAL::HAL& hal;
-
-AP_Proximity_RangeFinder::AP_Proximity_RangeFinder(AP_Proximity &_frontend,
-                                   AP_Proximity::Proximity_State &_state) :
-    AP_Proximity_Backend(_frontend, _state),
-    _distance_upward(-1)
-{
-}
-
 // update the state of the sensor
 void AP_Proximity_RangeFinder::update(void)
 {

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -15,9 +15,9 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_RangeFinder.h"
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_RangeFinder/RangeFinder_Backend.h>
 
 extern const AP_HAL::HAL& hal;
@@ -33,7 +33,7 @@ AP_Proximity_RangeFinder::AP_Proximity_RangeFinder(AP_Proximity &_frontend,
 void AP_Proximity_RangeFinder::update(void)
 {
     // exit immediately if no rangefinder object
-    const RangeFinder *rngfnd = frontend.get_rangefinder();
+    const RangeFinder *rngfnd = AP::rangefinder();
     if (rngfnd == nullptr) {
         set_status(AP_Proximity::Status::NoData);
         return;

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -35,7 +35,7 @@ void AP_Proximity_RangeFinder::update(void)
     // exit immediately if no rangefinder object
     const RangeFinder *rngfnd = frontend.get_rangefinder();
     if (rngfnd == nullptr) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
         return;
     }
 
@@ -76,9 +76,9 @@ void AP_Proximity_RangeFinder::update(void)
 
     // check for timeout and set health status
     if ((_last_update_ms == 0) || (now - _last_update_ms > PROXIMITY_RANGEFIDER_TIMEOUT_MS)) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
     } else {
-        set_status(AP_Proximity::Proximity_Good);
+        set_status(AP_Proximity::Status::Good);
     }
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
@@ -10,7 +10,7 @@ class AP_Proximity_RangeFinder : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_RangeFinder(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
+    using AP_Proximity_Backend::AP_Proximity_Backend;
 
     // update state
     void update(void) override;
@@ -31,5 +31,5 @@ private:
 
     // upward distance support
     uint32_t _last_upward_update_ms;    // system time of last update distance
-    float _distance_upward;             // upward distance in meters, negative if the last reading was out of range
+    float _distance_upward = -1;        // upward distance in meters, negative if the last reading was out of range
 };

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -54,7 +54,7 @@ void AP_Proximity_SITL::update(void)
     if (AP::fence()->polyfence().inclusion_boundary_available()) {
         // update distance in one sector
         if (get_distance_to_fence(_sector_middle_deg[last_sector], _distance[last_sector])) {
-            set_status(AP_Proximity::Proximity_Good);
+            set_status(AP_Proximity::Status::Good);
             _distance_valid[last_sector] = true;
             _angle[last_sector] = _sector_middle_deg[last_sector];
             update_boundary_for_sector(last_sector, true);
@@ -66,7 +66,7 @@ void AP_Proximity_SITL::update(void)
             last_sector = 0;
         }
     } else {
-        set_status(AP_Proximity::Proximity_NoData);        
+        set_status(AP_Proximity::Status::NoData);
     }
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -60,9 +60,9 @@ void AP_Proximity_TeraRangerTower::update(void)
 
     // check for timeout and set health status
     if ((_last_distance_received_ms == 0) || (AP_HAL::millis() - _last_distance_received_ms > PROXIMITY_TRTOWER_TIMEOUT_MS)) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
     } else {
-        set_status(AP_Proximity::Proximity_Good);
+        set_status(AP_Proximity::Status::Good);
     }
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -27,11 +27,13 @@ extern const AP_HAL::HAL& hal;
    constructor is not called until detect() returns true, so we
    already know that we should setup the proximity sensor
 */
-AP_Proximity_TeraRangerTower::AP_Proximity_TeraRangerTower(AP_Proximity &_frontend,
-                                                         AP_Proximity::Proximity_State &_state,
-                                                         AP_SerialManager &serial_manager) :
+AP_Proximity_TeraRangerTower::AP_Proximity_TeraRangerTower(
+    AP_Proximity &_frontend,
+    AP_Proximity::Proximity_State &_state) :
     AP_Proximity_Backend(_frontend, _state)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
+
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
@@ -39,10 +41,10 @@ AP_Proximity_TeraRangerTower::AP_Proximity_TeraRangerTower(AP_Proximity &_fronte
 }
 
 // detect if a TeraRanger Tower proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_TeraRangerTower::detect(AP_SerialManager &serial_manager)
+bool AP_Proximity_TeraRangerTower::detect()
 {
     AP_HAL::UARTDriver *uart = nullptr;
-    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
+    uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
     return uart != nullptr;
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
@@ -10,10 +10,10 @@ class AP_Proximity_TeraRangerTower : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_TeraRangerTower(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_SerialManager &serial_manager);
+    AP_Proximity_TeraRangerTower(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager);
+    static bool detect();
 
     // update state
     void update(void) override;

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -28,10 +28,11 @@ extern const AP_HAL::HAL& hal;
    already know that we should setup the proximity sensor
 */
 AP_Proximity_TeraRangerTowerEvo::AP_Proximity_TeraRangerTowerEvo(AP_Proximity &_frontend,
-                                                         AP_Proximity::Proximity_State &_state,
-                                                         AP_SerialManager &serial_manager) :
+                                                         AP_Proximity::Proximity_State &_state) :
     AP_Proximity_Backend(_frontend, _state)
 {
+    const AP_SerialManager &serial_manager = AP::serialmanager();
+
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
     if (uart != nullptr) {
         uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
@@ -40,11 +41,9 @@ AP_Proximity_TeraRangerTowerEvo::AP_Proximity_TeraRangerTowerEvo(AP_Proximity &_
 }
 
 // detect if a TeraRanger Tower proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_TeraRangerTowerEvo::detect(AP_SerialManager &serial_manager)
+bool AP_Proximity_TeraRangerTowerEvo::detect()
 {
-    AP_HAL::UARTDriver *uart = nullptr;
-    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
-    return uart != nullptr;
+    return (AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr);
 }
 
 // update the state of the sensor

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -64,9 +64,9 @@ void AP_Proximity_TeraRangerTowerEvo::update(void)
 
     // check for timeout and set health status
     if ((_last_distance_received_ms == 0) || (AP_HAL::millis() - _last_distance_received_ms > PROXIMITY_TRTOWER_TIMEOUT_MS)) {
-        set_status(AP_Proximity::Proximity_NoData);
+        set_status(AP_Proximity::Status::NoData);
     } else {
-        set_status(AP_Proximity::Proximity_Good);
+        set_status(AP_Proximity::Status::Good);
     }
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
@@ -9,10 +9,10 @@ class AP_Proximity_TeraRangerTowerEvo : public AP_Proximity_Backend {
 
 public:
     // constructor
-    AP_Proximity_TeraRangerTowerEvo(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_SerialManager &serial_manager);
+    AP_Proximity_TeraRangerTowerEvo(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
     // static detection function
-    static bool detect(AP_SerialManager &serial_manager);
+    static bool detect();
 
     // update state
     void update(void) override;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -290,7 +290,7 @@ void GCS_MAVLINK::send_distance_sensor() const
     AP_Proximity *proximity = AP_Proximity::get_singleton();
     if (proximity != nullptr) {
         for (uint8_t i = 0; i < proximity->num_sensors(); i++) {
-            if (proximity->get_type(i) == AP_Proximity::Proximity_Type_RangeFinder) {
+            if (proximity->get_type(i) == AP_Proximity::Type::RangeFinder) {
                 filter_possible_proximity_sensors = true;
             }
         }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -342,7 +342,7 @@ void GCS_MAVLINK::send_proximity() const
     const uint16_t dist_max = (uint16_t)(proximity->distance_max() * 100.0f); // maximum distance the sensor can measure in centimeters
 
     // send horizontal distances
-    if (proximity->get_status() == AP_Proximity::Proximity_Good) {
+    if (proximity->get_status() == AP_Proximity::Status::Good) {
         AP_Proximity::Proximity_Distance_Array dist_array;
         if (proximity->get_horizontal_distances(dist_array)) {
             for (uint8_t i = 0; i < PROXIMITY_MAX_DIRECTION; i++) {


### PR DESCRIPTION
Use singletons in place of passing objects around.

Factor some valid instance code out.


Testing:
 - We test SITL Proximity backend as part of autotest.
 - Morse backend tested.
 - Real RPILidar A2 tested from SITL.
