### PR TITLE
AP_NavEKF2/3: replace blank prearm failure message with "EKF2/3 still initialising"

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -336,6 +336,9 @@ void NavEKF2_core::InitialiseVariables()
     yawAlignComplete = false;
     have_table_earth_field = false;
 
+    // initialise pre-arm message
+    hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "EKF2 still initialising");
+
     InitialiseVariablesMag();
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -385,6 +385,9 @@ void NavEKF3_core::InitialiseVariables()
     storedBodyOdm.reset();
     storedWheelOdm.reset();
 
+    // initialise pre-arm message
+    hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "EKF3 still initialising");
+
     InitialiseVariablesMag();
 }
 


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/11800 found during Copter-4.0 testing in which a blank "PreArm:" pre-arm failure message was appearing.

The issue had a similar symptom to the one fixed in this PR but is actually separate: https://github.com/ArduPilot/ardupilot/pull/12651

This has been tested on a CubeBlack flight controller with a wiped eeprom (the best way to make the issue appear is to clear all parameters) using EKF2 and EKF3.

EKF2 testing:
![ekf-prearm-msg](https://user-images.githubusercontent.com/1498098/67736909-aa1d0d80-fa4c-11e9-9e59-ace3be477c6a.png)

EKF3 testing:
![ekf3-prearm-msg](https://user-images.githubusercontent.com/1498098/67737025-21eb3800-fa4d-11e9-999b-727c81ac4812.png)

If @priseborough or someone else has a better idea for the string then I'm very happy to change it

