### PR TITLE
AP_Motors: tricopter: use rc_write_angle

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -157,6 +157,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Units: deg
     // @Increment: 1
     // @User: Standard
+    // @RebootRequired: True
     AP_GROUPINFO_FRAME("YAW_SV_ANGLE", 35, AP_MotorsMulticopter, _yaw_servo_angle_max_deg, 30, AP_PARAM_FRAME_TRICOPTER),
 
     // @Param: SPOOL_TIME

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -56,6 +56,9 @@ void AP_MotorsTri::init(motor_frame_class frame_class, motor_frame_type frame_ty
         _pitch_reversed = true;
     }
 
+    // init the yaw servo
+    SRV_Channels::set_angle(SRV_Channel::k_motor7, _yaw_servo_angle_max_deg * 10);
+
     // record successful initialisation if what we setup was the desired frame_class
     _flags.initialised_ok = (frame_class == MOTOR_FRAME_TRI);
 }
@@ -95,7 +98,7 @@ void AP_MotorsTri::output_to_motors()
             rc_write(AP_MOTORS_MOT_1, output_to_pwm(0));
             rc_write(AP_MOTORS_MOT_2, output_to_pwm(0));
             rc_write(AP_MOTORS_MOT_4, output_to_pwm(0));
-            rc_write(AP_MOTORS_CH_TRI_YAW, _yaw_servo->get_trim());
+            rc_write_angle(AP_MOTORS_CH_TRI_YAW, 0);
             break;
         case SpoolState::GROUND_IDLE:
             // sends output to motors when armed but not flying
@@ -105,7 +108,7 @@ void AP_MotorsTri::output_to_motors()
             rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[1]));
             rc_write(AP_MOTORS_MOT_2, output_to_pwm(_actuator[2]));
             rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[4]));
-            rc_write(AP_MOTORS_CH_TRI_YAW, _yaw_servo->get_trim());
+            rc_write_angle(AP_MOTORS_CH_TRI_YAW, 0);
             break;
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
@@ -117,7 +120,7 @@ void AP_MotorsTri::output_to_motors()
             rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[1]));
             rc_write(AP_MOTORS_MOT_2, output_to_pwm(_actuator[2]));
             rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[4]));
-            rc_write(AP_MOTORS_CH_TRI_YAW, calc_yaw_radio_output(_pivot_angle, radians(_yaw_servo_angle_max_deg)));
+            rc_write_angle(AP_MOTORS_CH_TRI_YAW, degrees(_pivot_angle) * 10);
             break;
     }
 }
@@ -308,24 +311,6 @@ void AP_MotorsTri::output_test_seq(uint8_t motor_seq, int16_t pwm)
             // do nothing
             break;
     }
-}
-
-// calc_yaw_radio_output - calculate final radio output for yaw channel
-int16_t AP_MotorsTri::calc_yaw_radio_output(float yaw_input, float yaw_input_max)
-{
-    int16_t ret;
-
-    if (_yaw_servo->get_reversed()) {
-        yaw_input = -yaw_input;
-    }
-
-    if (yaw_input >= 0) {
-        ret = (_yaw_servo->get_trim() + (yaw_input / yaw_input_max * (_yaw_servo->get_output_max() - _yaw_servo->get_trim())));
-    } else {
-        ret = (_yaw_servo->get_trim() + (yaw_input / yaw_input_max * (_yaw_servo->get_trim() - _yaw_servo->get_output_min())));
-    }
-
-    return ret;
 }
 
 /*

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -61,9 +61,6 @@ protected:
     // call vehicle supplied thrust compensation if set
     void                thrust_compensation(void) override;
     
-    // calc_yaw_radio_output - calculate final radio output for yaw channel
-    int16_t             calc_yaw_radio_output(float yaw_input, float yaw_input_max);        // calculate radio output for yaw servo, typically in range of 1100-1900
-
     // parameters
 
     SRV_Channel     *_yaw_servo; // yaw output channel


### PR DESCRIPTION
This is a no functional change to tricopter yaw servo handling, tested in RealFlight. This moves from using  calc_yaw_radio_output and rc_write to using rc_write angle. 

This fix is due to a bug found by Rolf with his Quadplane testing. All yaw servo outputs would use the trim set for the first output, this change allows each yaw servo to be setup individually.

https://discuss.ardupilot.org/t/reverse-tricopter-vtol-plane/39829/75?u=iampete