### PR TITLE
AP_ToshibaCAN: consume and publish current, add arming check

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -1,5 +1,9 @@
 #include "Copter.h"
 
+#if HAL_WITH_UAVCAN
+ #include <AP_ToshibaCAN/AP_ToshibaCAN.h>
+#endif
+
 // performs pre-arm checks. expects to be called at 1hz.
 void AP_Arming_Copter::update(void)
 {
@@ -252,10 +256,12 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
     // if this is a multicopter using ToshibaCAN ESCs ensure MOT_PMW_MIN = 1000, MOT_PWM_MAX = 2000
 #if HAL_WITH_UAVCAN && (FRAME_CONFIG != HELI_FRAME)
     bool tcan_active = false;
+    uint8_t tcan_index = 0;
     const uint8_t num_drivers = AP::can().get_num_drivers();
     for (uint8_t i = 0; i < num_drivers; i++) {
         if (AP::can().get_protocol_type(i) == AP_BoardConfig_CAN::Protocol_Type_ToshibaCAN) {
             tcan_active = true;
+            tcan_index = i;
         }
     }
     if (tcan_active) {
@@ -265,6 +271,27 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
         }
         if (copter.motors->get_pwm_output_max() != 2000) {
             check_failed(display_failure, "TCAN ESCs require MOT_PWM_MAX=2000");
+            return false;
+        }
+
+        // check we have an ESC present for every SERVOx_FUNCTION = motorx
+        // find and report first missing ESC, extra ESCs are OK
+        AP_ToshibaCAN *tcan = AP_ToshibaCAN::get_tcan(tcan_index);
+        const uint16_t motors_mask = copter.motors->get_motor_mask();
+        const uint16_t esc_mask = tcan->get_present_mask();
+        uint8_t escs_missing = 0;
+        uint8_t first_missing = 0;
+        for (uint8_t i = 0; i < 16; i++) {
+            uint32_t bit = 1UL << i;
+            if (((motors_mask & bit) > 0) && ((esc_mask & bit) == 0)) {
+                escs_missing++;
+                if (first_missing == 0) {
+                    first_missing = i+1;
+                }
+            }
+        }
+        if (escs_missing > 0) {
+            check_failed(display_failure, "TCAN missing %d escs, check #%d", (int)escs_missing, (int)first_missing);
             return false;
         }
     }

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -313,7 +313,7 @@ void AP_ToshibaCAN::loop()
                     if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
                         WITH_SEMAPHORE(_telem_sem);
                         _telemetry[esc_id].rpm = be16toh(reply_data.rpm);
-                        _telemetry[esc_id].millivolts = be16toh(reply_data.millivolts);
+                        _telemetry[esc_id].voltage_mv = be16toh(reply_data.voltage_mv);
                         _telemetry[esc_id].count++;
                         _telemetry[esc_id].new_data = true;
                         _esc_present_bitmask |= ((uint32_t)1 << esc_id);
@@ -431,7 +431,7 @@ void AP_ToshibaCAN::update()
             if (_telemetry[i].new_data) {
                 logger->Write_ESC(i, time_us,
                               _telemetry[i].rpm * 100U,
-                              _telemetry[i].millivolts * 0.1f,
+                              _telemetry[i].voltage_mv * 0.1f,
                               0,
                               _telemetry[i].temperature * 100.0f,
                               0);
@@ -481,7 +481,7 @@ void AP_ToshibaCAN::send_esc_telemetry_mavlink(uint8_t mav_chan)
             for (uint8_t j = 0; j < 4; j++) {
                 uint8_t esc_id = i * 4 + j;
                 temperature[j] = _telemetry[esc_id].temperature;
-                voltage[j] = _telemetry[esc_id].millivolts * 0.1f;
+                voltage[j] = _telemetry[esc_id].voltage_mv * 0.1f;
                 rpm[j] = _telemetry[esc_id].rpm;
                 count[j] = _telemetry[esc_id].count;
             }

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -69,10 +69,10 @@ private:
     // telemetry data (rpm, voltage)
     HAL_Semaphore _telem_sem;
     struct telemetry_info_t {
-        uint16_t rpm;
-        uint16_t millivolts;
-        uint16_t temperature;
-        uint16_t count;
+        uint16_t rpm;               // rpm
+        uint16_t voltage_mv;        // voltage in millivolts
+        uint16_t temperature;       // temperature in degrees
+        uint16_t count;             // total number of packets sent
         bool new_data;
     } _telemetry[TOSHIBACAN_MAX_NUM_ESCS];
     uint32_t _telemetry_req_ms;     // system time (in milliseconds) to request data from escs (updated at 10hz)
@@ -137,7 +137,7 @@ private:
             uint8_t state:7;
             uint16_t rpm;
             uint16_t reserved;
-            uint16_t millivolts;
+            uint16_t voltage_mv;    // voltage in millivolts
             uint8_t position_est_error;
         };
         uint8_t data[8];

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -70,13 +70,17 @@ private:
     HAL_Semaphore _telem_sem;
     struct telemetry_info_t {
         uint16_t rpm;               // rpm
-        uint16_t voltage_mv;        // voltage in millivolts
+        uint16_t voltage_cv;        // voltage in centi-volts
+        uint16_t current_ca;        // current in centi-amps
         uint16_t temperature;       // temperature in degrees
         uint16_t count;             // total number of packets sent
-        bool new_data;
+        uint32_t last_update_ms;    // system time telemetry was last update (used to calc total current)
+        float current_tot_mah;      // total current in mAh
+        bool new_data;              // true if new telemetry data has been filled in but not logged yet
     } _telemetry[TOSHIBACAN_MAX_NUM_ESCS];
     uint32_t _telemetry_req_ms;     // system time (in milliseconds) to request data from escs (updated at 10hz)
     uint8_t _telemetry_temp_req_counter;    // counter used to trigger temp data requests from ESCs (10x slower than other telem data)
+    const float centiamp_ms_to_mah = 1.0f / 360000.0f;  // for converting centi-amps milliseconds to mAh
 
     // bitmask of which escs seem to be present
     uint16_t _esc_present_bitmask;
@@ -136,7 +140,7 @@ private:
             uint8_t rxng:1;
             uint8_t state:7;
             uint16_t rpm;
-            uint16_t reserved;
+            uint16_t current_ma;    // current in milliamps
             uint16_t voltage_mv;    // voltage in millivolts
             uint8_t position_est_error;
         };

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -41,6 +41,9 @@ public:
     // send ESC telemetry messages over MAVLink
     void send_esc_telemetry_mavlink(uint8_t mav_chan);
 
+    // return a bitmask of escs that are "present" which means they are responding to requests.  Bitmask matches RC outputs
+    uint16_t get_present_mask() const { return _esc_present_bitmask; }
+
 private:
 
     // loop to send output to ESCs in background thread
@@ -51,6 +54,9 @@ private:
 
     // read frame on CAN bus, returns true on success
     bool read_frame(uavcan::CanFrame &recv_frame, uavcan::MonotonicTime timeout);
+
+    // update esc_present_bitmask
+    void update_esc_present_bitmask();
 
     bool _initialized;
     char _thread_name[9];
@@ -82,8 +88,10 @@ private:
     uint8_t _telemetry_temp_req_counter;    // counter used to trigger temp data requests from ESCs (10x slower than other telem data)
     const float centiamp_ms_to_mah = 1.0f / 360000.0f;  // for converting centi-amps milliseconds to mAh
 
-    // bitmask of which escs seem to be present
-    uint16_t _esc_present_bitmask;
+    // variables for updating bitmask of responsive escs
+    uint16_t _esc_present_bitmask;      // bitmask of which escs seem to be present
+    uint16_t _esc_present_bitmask_recent;   // bitmask of escs that have responded in the last second
+    uint32_t _esc_present_update_ms;    // system time _esc_present_bitmask was last updated
 
     // structure for sending motor lock command to ESC
     union motor_lock_cmd_t {


### PR DESCRIPTION
This PR adds two enhancements to our ToshibaCAN ESC support:

- consume the instantaneous current reported by the ESC and calculate the total current (since boot)
- log the above to the dataflash and publish to the GCS using the [ESC_TELEMETRY_xxx](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_1_TO_4) messages
- add a pre-arm check that an ESC is present (i.e. providing data back to the flight controller) for each Motor controlled by the AP_Motors library.

This has been bench tested using a single ESC and screen shots of the results are below:

- MP's mavlink inspector showing the current and totalcurrent for the first ESC is updating
![toshibacan-esc-telem](https://user-images.githubusercontent.com/1498098/67853285-8ee7f600-fb51-11e9-9a1b-dd598b51d802.png)

- Dataflash log shows the ESC's instantaneous current.  The total current is zero but this is perhaps just because the total is still very small
![toshibacan-curr-logging](https://user-images.githubusercontent.com/1498098/67853385-cc4c8380-fb51-11e9-84bb-0da54668e91d.png)

- Pre-Arm check that 3 motors are missing (was testing with a Quad frame) starting from motor 2
![toshibacan-prearm](https://user-images.githubusercontent.com/1498098/67853445-e8e8bb80-fb51-11e9-8ffd-046740d0ff78.png)

More testing at EAMS Lab will be done before we merge this.  All feedback welcome!



