### PR TITLE
Write AutoTune events directly from AC_AutoTune

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -509,7 +509,6 @@ protected:
     float get_pilot_desired_climb_rate_cms(void) const override;
     void get_pilot_desired_rp_yrate_cd(float &roll_cd, float &pitch_cd, float &yaw_rate_cds) override;
     void init_z_limits() override;
-    void Log_Write_Event(enum at_event id) override;
     void log_pids() override;
 };
 

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -115,34 +115,6 @@ void AutoTune::log_pids()
     copter.logger.Write_PID(LOG_PIDY_MSG, copter.attitude_control->get_rate_yaw_pid().get_pid_info());
 }
 
-
-/*
-  Write an event packet. This maps from AC_AutoTune event IDs to
-  copter event IDs
-*/
-void AutoTune::Log_Write_Event(enum at_event id)
-{
-    const struct {
-        enum at_event eid;
-        Log_Event id;
-    } map[] = {
-        { EVENT_AUTOTUNE_INITIALISED, DATA_AUTOTUNE_INITIALISED },
-        { EVENT_AUTOTUNE_OFF, DATA_AUTOTUNE_OFF },
-        { EVENT_AUTOTUNE_RESTART, DATA_AUTOTUNE_RESTART },
-        { EVENT_AUTOTUNE_SUCCESS, DATA_AUTOTUNE_SUCCESS },
-        { EVENT_AUTOTUNE_FAILED, DATA_AUTOTUNE_FAILED },
-        { EVENT_AUTOTUNE_REACHED_LIMIT, DATA_AUTOTUNE_REACHED_LIMIT },
-        { EVENT_AUTOTUNE_PILOT_TESTING, DATA_AUTOTUNE_PILOT_TESTING },
-        { EVENT_AUTOTUNE_SAVEDGAINS, DATA_AUTOTUNE_SAVEDGAINS },
-    };
-    for (uint8_t i=0; i<ARRAY_SIZE(map); i++) {
-        if (id == map[i].eid) {
-            copter.Log_Write_Event(map[i].id);
-            break;
-        }
-    }
-}
-
 /*
   check if we have a good position estimate
  */

--- a/ArduPlane/qautotune.cpp
+++ b/ArduPlane/qautotune.cpp
@@ -46,21 +46,6 @@ void QAutoTune::init_z_limits()
 }
 
 
-// Wrote an event packet
-void QAutoTune::Log_Write_Event(enum at_event id)
-{
-    // offset of 30 aligned with ArduCopter autotune events
-    uint8_t ev_id = 30 + (uint8_t)id;
-    AP::logger().Write(
-        "EVT",
-        "TimeUS,Id",
-        "s-",
-        "F-",
-        "QB",
-        AP_HAL::micros64(),
-        ev_id);
-}
-
 // log VTOL PIDs for during twitch
 void QAutoTune::log_pids(void)
 {

--- a/ArduPlane/qautotune.h
+++ b/ArduPlane/qautotune.h
@@ -23,7 +23,6 @@ protected:
     float get_pilot_desired_climb_rate_cms(void) const override;
     void get_pilot_desired_rp_yrate_cd(float &roll_cd, float &pitch_cd, float &yaw_rate_cds) override;
     void init_z_limits() override;
-    void Log_Write_Event(enum at_event id) override;
     void log_pids() override;
 };
 

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -168,7 +168,7 @@ bool AC_AutoTune::init_internals(bool _use_poshold,
         if (success) {
             // reset gains to tuning-start gains (i.e. low I term)
             load_gains(GAIN_INTRA_TEST);
-            Log_Write_Event(EVENT_AUTOTUNE_RESTART);
+            AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_RESTART);
             update_gcs(AUTOTUNE_MESSAGE_STARTED);
         }
         break;
@@ -177,7 +177,7 @@ bool AC_AutoTune::init_internals(bool _use_poshold,
         // we have completed a tune and the pilot wishes to test the new gains in the current flight mode
         // so simply apply tuning gains (i.e. do not change flight mode)
         load_gains(GAIN_TUNED);
-        Log_Write_Event(EVENT_AUTOTUNE_PILOT_TESTING);
+        AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_PILOT_TESTING);
         break;
     }
 
@@ -196,7 +196,7 @@ void AC_AutoTune::stop()
     attitude_control->use_sqrt_controller(true);
 
     update_gcs(AUTOTUNE_MESSAGE_STOPPED);
-    Log_Write_Event(EVENT_AUTOTUNE_OFF);
+    AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_OFF);
 
     // Note: we leave the mode as it was so that we know how the autotune ended
     // we expect the caller will change the flight mode back to the flight mode indicated by the flight mode switch
@@ -862,7 +862,7 @@ void AC_AutoTune::control_attitude()
                 if (complete) {
                     mode = SUCCESS;
                     update_gcs(AUTOTUNE_MESSAGE_SUCCESS);
-                    Log_Write_Event(EVENT_AUTOTUNE_SUCCESS);
+                    AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_SUCCESS);
                     AP_Notify::events.autotune_complete = true;
                 } else {
                     AP_Notify::events.autotune_next_axis = true;
@@ -954,7 +954,7 @@ void AC_AutoTune::backup_gains_and_initialise()
     tune_yaw_sp = attitude_control->get_angle_yaw_p().kP();
     tune_yaw_accel = attitude_control->get_accel_yaw_max();
 
-    Log_Write_Event(EVENT_AUTOTUNE_INITIALISED);
+    AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_INITIALISED);
 }
 
 // load_orig_gains - set gains to their original values
@@ -1213,7 +1213,7 @@ void AC_AutoTune::save_tuning_gains()
 
     // update GCS and log save gains event
     update_gcs(AUTOTUNE_MESSAGE_SAVED_GAINS);
-    Log_Write_Event(EVENT_AUTOTUNE_SAVEDGAINS);
+    AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_SAVEDGAINS);
 
     reset();
 }
@@ -1398,7 +1398,7 @@ void AC_AutoTune::updating_rate_d_up(float &tune_d, float tune_d_min, float tune
                 // We have reached minimum D gain so stop tuning
                 tune_d = tune_d_min;
                 counter = AUTOTUNE_SUCCESS_COUNT;
-                Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+                AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
             }
         }
     } else if ((meas_rate_max < rate_target*(1.0f-AUTOTUNE_D_UP_DOWN_MARGIN)) && (tune_p <= tune_p_max)) {
@@ -1407,7 +1407,7 @@ void AC_AutoTune::updating_rate_d_up(float &tune_d, float tune_d_min, float tune
         tune_p += tune_p*tune_p_step_ratio;
         if (tune_p >= tune_p_max) {
             tune_p = tune_p_max;
-            Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+            AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
         }
     } else {
         // we have a good measurement of bounce back
@@ -1428,7 +1428,7 @@ void AC_AutoTune::updating_rate_d_up(float &tune_d, float tune_d_min, float tune
                 if (tune_d >= tune_d_max) {
                     tune_d = tune_d_max;
                     counter = AUTOTUNE_SUCCESS_COUNT;
-                    Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+                    AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
                 }
             } else {
                 ignore_next = false;
@@ -1453,7 +1453,7 @@ void AC_AutoTune::updating_rate_d_down(float &tune_d, float tune_d_min, float tu
                 // We have reached minimum D so stop tuning
                 tune_d = tune_d_min;
                 counter = AUTOTUNE_SUCCESS_COUNT;
-                Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+                AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
             }
         }
     } else if ((meas_rate_max < rate_target*(1.0f-AUTOTUNE_D_UP_DOWN_MARGIN)) && (tune_p <= tune_p_max)) {
@@ -1462,7 +1462,7 @@ void AC_AutoTune::updating_rate_d_down(float &tune_d, float tune_d_min, float tu
         tune_p += tune_p*tune_p_step_ratio;
         if (tune_p >= tune_p_max) {
             tune_p = tune_p_max;
-            Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+            AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
         }
     } else {
         // we have a good measurement of bounce back
@@ -1486,7 +1486,7 @@ void AC_AutoTune::updating_rate_d_down(float &tune_d, float tune_d_min, float tu
             if (tune_d <= tune_d_min) {
                 tune_d = tune_d_min;
                 counter = AUTOTUNE_SUCCESS_COUNT;
-                Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+                AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
             }
         }
     }
@@ -1511,14 +1511,14 @@ void AC_AutoTune::updating_rate_p_up_d_down(float &tune_d, float tune_d_min, flo
         // do not decrease the D term past the minimum
         if (tune_d <= tune_d_min) {
             tune_d = tune_d_min;
-            Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+            AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
         }
         // decrease P gain to match D gain reduction
         tune_p -= tune_p*tune_p_step_ratio;
         // do not decrease the P term past the minimum
         if (tune_p <= tune_p_min) {
             tune_p = tune_p_min;
-            Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+            AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
         }
         // cancel change in direction
         positive_direction = !positive_direction;
@@ -1534,7 +1534,7 @@ void AC_AutoTune::updating_rate_p_up_d_down(float &tune_d, float tune_d_min, flo
             if (tune_p >= tune_p_max) {
                 tune_p = tune_p_max;
                 counter = AUTOTUNE_SUCCESS_COUNT;
-                Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+                AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
             }
         } else {
             ignore_next = false;
@@ -1566,7 +1566,7 @@ void AC_AutoTune::updating_angle_p_down(float &tune_p, float tune_p_min, float t
         if (tune_p <= tune_p_min) {
             tune_p = tune_p_min;
             counter = AUTOTUNE_SUCCESS_COUNT;
-            Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+            AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
         }
     }
 }
@@ -1593,7 +1593,7 @@ void AC_AutoTune::updating_angle_p_up(float &tune_p, float tune_p_max, float tun
             if (tune_p >= tune_p_max) {
                 tune_p = tune_p_max;
                 counter = AUTOTUNE_SUCCESS_COUNT;
-                Log_Write_Event(EVENT_AUTOTUNE_REACHED_LIMIT);
+                AP::logger().Write_Event(Log_Event::DATA_AUTOTUNE_REACHED_LIMIT);
             }
         } else {
             ignore_next = false;

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -68,20 +68,6 @@ protected:
     // return true if we have a good position estimate
     virtual bool position_ok();
 
-    enum at_event {
-        EVENT_AUTOTUNE_INITIALISED   =  0,
-        EVENT_AUTOTUNE_OFF           =  1,
-        EVENT_AUTOTUNE_RESTART       =  2,
-        EVENT_AUTOTUNE_SUCCESS       =  3,
-        EVENT_AUTOTUNE_FAILED        =  4,
-        EVENT_AUTOTUNE_REACHED_LIMIT =  5,
-        EVENT_AUTOTUNE_PILOT_TESTING =  6,
-        EVENT_AUTOTUNE_SAVEDGAINS    =  7
-    };
-
-    // write a log event
-    virtual void Log_Write_Event(enum at_event id) = 0;
-
     // internal init function, should be called from init()
     bool init_internals(bool use_poshold,
                         AC_AttitudeControl_Multi *attitude_control,


### PR DESCRIPTION
No need to have a 1-1 conversion from the `ATEvent` enum to the `Log_Event` enum.

The original code was probably written before `Write_Event` moved to `AP_Logger`.
