### PR TITLE
AC_Fence: relax sys-status healthy reporting

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -452,30 +452,6 @@ bool AC_Fence::sys_status_failed() const
     if (get_breaches() != 0) {
         return true;
     }
-    if (_enabled_fences & AC_FENCE_TYPE_POLYGON) {
-        if (!_poly_loader.inclusion_boundary_available()) {
-            return true;
-        }
-    }
-    if (_enabled_fences & AC_FENCE_TYPE_CIRCLE) {
-        if (_circle_radius < 0) {
-            return true;
-        }
-    }
-    if (_enabled_fences & AC_FENCE_TYPE_ALT_MAX) {
-        if (_alt_max < 0.0f) {
-            return true;
-        }
-    }
-    if ((_enabled_fences & AC_FENCE_TYPE_CIRCLE) ||
-        (_enabled_fences & AC_FENCE_TYPE_POLYGON)) {
-        Vector2f position;
-        if (!AP::ahrs().get_relative_position_NE_home(position)) {
-            // both these fence types require position
-            return true;
-        }
-    }
-
     return false;
 }
 


### PR DESCRIPTION
During 4.0.0 testing I found that "Geofence Breach" was constantly displayed on the mission planner HUD ([issue](https://github.com/ArduPilot/MissionPlanner/issues/2241)).

The cause of the issue is AC_Fence::sys_status_failed() call which is too strict in my opinion at least if it's going to be interpreted as "Breached" by the GCSs.

I understand the desire to want to warn the user of incorrect setup but I think we should do that as part of the pre-arm checks.  We risk overloading the user with errors which is unnecessarily scary and just teaches them to ignore errors.  There's no point in us telling the user "Geofence Breached" when really the issue is they don't have a GPS lock yet.

This PR changes it so this flag is really only unset if a geofence is breached.