### PR TITLE
Copter: Crash check delay time

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -466,6 +466,15 @@ const AP_Param::Info Copter::var_info[] = {
     GSCALAR(acro_rp_expo,  "ACRO_RP_EXPO",    ACRO_RP_EXPO_DEFAULT),
 #endif
 
+    // @Param: CRACHK_DELAY
+    // @DisplayName: Crash check delay
+    // @Description: Crash check delay time
+    // @Units: s
+    // @Range: 0.1 2.0
+    // @Increment: 0.1
+    // @User: Advanced
+    GSCALAR(crachk_delay, "CRACHK_DELAY", CRASH_CHECK_TRIGGER_SEC),
+
     // variables not in the g class which contain EEPROM saved variables
 
 #if CAMERA == ENABLED

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -373,6 +373,8 @@ public:
 
         // 254,255: reserved
 
+        k_param_crachk_delay = 256,
+
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -464,6 +466,8 @@ public:
     AP_Float                acro_balance_pitch;
     AP_Int8                 acro_trainer;
     AP_Float                acro_rp_expo;
+
+    AP_Float crachk_delay;  // Crash check delay
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -776,3 +776,7 @@
 #ifndef HAL_FRAME_TYPE_DEFAULT
 #define HAL_FRAME_TYPE_DEFAULT AP_Motors::MOTOR_FRAME_TYPE_X
 #endif
+
+#ifndef CRASH_CHECK_TRIGGER_SEC
+#define CRASH_CHECK_TRIGGER_SEC  2.0f  // 2 seconds inverted indicates a crash
+#endif

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -1,7 +1,6 @@
 #include "Copter.h"
 
-// Code to detect a crash main ArduCopter code
-#define CRASH_CHECK_TRIGGER_SEC         2       // 2 seconds inverted indicates a crash
+// Code to detect a crash main ArduCopter code    // 2 seconds inverted indicates a crash
 #define CRASH_CHECK_ANGLE_DEVIATION_DEG 30.0f   // 30 degrees beyond angle max is signal we are inverted
 #define CRASH_CHECK_ACCEL_MAX           3.0f    // vehicle must be accelerating less than 3m/s/s to be considered crashed
 
@@ -51,8 +50,8 @@ void Copter::crash_check()
     // we may be crashing
     crash_counter++;
 
-    // check if crashing for 2 seconds
-    if (crash_counter >= (CRASH_CHECK_TRIGGER_SEC * scheduler.get_loop_rate_hz())) {
+    // check if crashing for range from 0.1 to 2.0 seconds
+    if (crash_counter >= (g.crachk_delay * scheduler.get_loop_rate_hz())) {
         AP::logger().Write_Error(LogErrorSubsystem::CRASH_CHECK, LogErrorCode::CRASH_CHECK_CRASH);
         // keep logging even if disarmed:
         AP::logger().set_force_log_disarmed(true);


### PR DESCRIPTION
I feel a long time before crashing and disarming.
The aircraft is rampant until it is disarmed.
I thought it would be better for the aircraft owner to be able to set it arbitrarily.