### PR TITLE
Tricopter: yaw servo feedback

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -206,6 +206,47 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SAFE_TIME", 42, AP_MotorsMulticopter, _safe_time, AP_MOTORS_SAFE_TIME_DEFAULT),
 
+    // @Param: YAW_SV_PIN
+    // @DisplayName: Tricopter Yaw Servo analogue feedback pin
+    // @Description: Tricopter Yaw Servo analogue feedback pin
+    // @User: Standard
+    // @Values: 11:Pixracer,13:Pixhawk ADC4,14:Pixhawk ADC3,15:Pixhawk ADC6/Pixhawk2 ADC,50:PixhawkAUX1,51:PixhawkAUX2,52:PixhawkAUX3,53:PixhawkAUX4,54:PixhawkAUX5,55:PixhawkAUX6,103:Pixhawk SBUS
+    AP_GROUPINFO_FRAME("YAW_SV_PIN", 43, AP_MotorsMulticopter, _yaw_servo_pin, 0, AP_PARAM_FRAME_TRICOPTER),
+
+    // @Param: YAW_SV_MIN_V
+    // @DisplayName: Tricopter Yaw Servo analogue feedback min voltage
+    // @Description: The Voltage measured when the yaw servo is at is min position
+    // @Units: V
+    // @Increment: 0.01
+    // @Range: 0 5.0
+    // @User: Standard
+    AP_GROUPINFO_FRAME("YAW_SV_MIN_V", 44, AP_MotorsMulticopter, _yaw_servo_min_voltage, 0, AP_PARAM_FRAME_TRICOPTER),
+
+    // @Param: YAW_SV_MID_V
+    // @DisplayName: Tricopter Yaw Servo analogue feedback trim voltage
+    // @Description: The Voltage measured when the yaw servo is at is trim position
+    // @Units: V
+    // @Increment: 0.01
+    // @Range: 0 5.0
+    // @User: Standard
+    AP_GROUPINFO_FRAME("YAW_SV_MID_V", 45, AP_MotorsMulticopter, _yaw_servo_mid_voltage, 0, AP_PARAM_FRAME_TRICOPTER),
+
+    // @Param: YAW_SV_MAX_V
+    // @DisplayName: Tricopter Yaw Servo analogue feedback max voltage
+    // @Description: The Voltage measured when the yaw servo is at is max position
+    // @Units: V
+    // @Increment: 0.01
+    // @Range: 0 5.0
+    // @User: Standard
+    AP_GROUPINFO_FRAME("YAW_SV_MAX_V", 46, AP_MotorsMulticopter, _yaw_servo_max_voltage, 0, AP_PARAM_FRAME_TRICOPTER),
+
+    // @Param: YAW_SV_SPEED
+    // @DisplayName: Tricopter Yaw Servo analogue feedback pin
+    // @Description: The speed the yaw servo moves at, set to -1 to calibrate speed and voltages
+    // @User: Standard
+    // @Units: deg/s
+    AP_GROUPINFO_FRAME("YAW_SV_SPEED", 47, AP_MotorsMulticopter, _yaw_servo_speed, 0, AP_PARAM_FRAME_TRICOPTER),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -183,6 +183,11 @@ protected:
     AP_Float            _throttle_hover;        // estimated throttle required to hover throttle in the range 0 ~ 1
     AP_Int8             _throttle_hover_learn;  // enable/disabled hover thrust learning
     AP_Int8             _disarm_disable_pwm;    // disable PWM output while disarmed
+    AP_Int8             _yaw_servo_pin;         // Tricopter Yaw Servo analogue feedback pin
+    AP_Float            _yaw_servo_min_voltage; // Tricopter Yaw Servo analogue feedback min voltage
+    AP_Float            _yaw_servo_mid_voltage; // Tricopter Yaw Servo analogue feedback trim voltage
+    AP_Float            _yaw_servo_max_voltage; // Tricopter Yaw Servo analogue feedback max voltage
+    AP_Int16            _yaw_servo_speed;       // Tricopter Yaw Servo speed
 
     // Maximum lean angle of yaw servo in degrees. This is specific to tricopter
     AP_Float            _yaw_servo_angle_max_deg;

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -62,14 +62,41 @@ protected:
 
     // call vehicle supplied thrust compensation if set
     void                thrust_compensation(void) override;
-    
-    // parameters
 
-    float           _pivot_angle;                       // Angle of yaw pivot
+    // parameters
+    float           _desired_pivot_angle;   // the desired angle of yaw pivot
     float           _thrust_right;
     float           _thrust_rear;
     float           _thrust_left;
 
     // reverse pitch
     bool _pitch_reversed;
+
+    // servo feedback and speed tracking
+    float calculate_new_pivot(float desired_pivot_angle);
+    float measure_pivot_angle();
+    float calibrate_yaw();
+    float _last_pivot_angle;
+    AP_HAL::AnalogSource *_yaw_feedback;
+
+private:
+
+    // varables for yaw servo paramiter calibration
+    enum Calibration_state{
+        CAL_NONE = 0,
+        CAL_MIN = 1,
+        CAL_MID = 2,
+        CAL_MAX = 3,
+        CAL_SPEED = 4,
+        CAL_FAILED = 5,
+    };
+    Calibration_state _cal_state;
+    uint32_t _cal_start_ms;
+    uint16_t _count;
+    float _reading_sum;
+    float _voltage_min_temp;
+    float _voltage_mid_temp;
+    float _voltage_max_temp;
+    float _cal_last_angle;
+
 };


### PR DESCRIPTION
This adds analogue voltage servo position feedback to tricopter. The idea is that this decouples pitch and yaw. Currently the code calculates the rear motor throttle based on the angle it asked the yaw servo to be at, if the servo is not at this angle there is a error. This changes uses the actual servo angle to calculate the rear motor throttle. 

This has been reported to improve tricopter handling quite abit in Triflight/cleanflight/betaflight. 

This is achieved in two ways:

Firstly given the estimated max rotation speed of the yaw servo a 'virtual servo' is updated to estimate the position of the true servo. This essentially removes the assumption that the yaw servo moves instantly replaces it with a assumption that the servo moves at a fixed maximum speed. This requires no additional hardware, but one parameter.

Secondly a [servo with a feedback wire](https://rcexplorer.se/product/blue-bird-bms-210dmh-servo/) can be used to measure the position directly. This requires the addition of four parameters. A calibration routine has also been implemented such that the servo min, mid and max voltages and rotation speed are automatically found. If this calculated angle is found to disagree with the virtual angle too much the feedback is disabled.

I have tested the calibration and that tricopters still fly irl. However more testing is need to make sure we're getting the promised improvements in handling. If the new params are left at default there should be no functional change.

Fixes #4294