### PR TITLE
Plane: tiltrotors: allow vectored yaw motor tilt when disarmed

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -187,6 +187,7 @@ bool AP_Arming_Plane::arm(const AP_Arming::Method method, const bool do_arming_c
     }
 
     change_arm_state();
+    plane.quadplane.delay_arming = true;
 
     gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
 

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -28,10 +28,15 @@ public:
     bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;
 
     void update_soft_armed();
+    bool get_delay_arming() { return delay_arming; };
 
 protected:
     bool ins_checks(bool report) override;
 
 private:
     void change_arm_state(void);
+
+    // oneshot with duration AP_ARMING_DELAY_MS used by quadplane to delay spoolup after arming:
+    // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
+    bool delay_arming;
 };

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -483,6 +483,7 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Range: 0.1 1
     // @User: Standard
     AP_GROUPINFO("TAILSIT_GSCMIN", 18, QuadPlane, tailsitter.gain_scaling_min, 0.4),
+
     // @Param: ASSIST_DELAY
     // @DisplayName: Quadplane assistance delay
     // @Description: This is delay between the assistance thresholds being met and the assistance starting.
@@ -2010,16 +2011,11 @@ void QuadPlane::motors_output(bool run_rate_controller)
        2) to allow motors to return to vertical (OPTION_DISARMED_TILT)
      */
     if ((options & OPTION_DISARMED_TILT) || (options & OPTION_DELAY_ARMING)) {
-        constexpr uint32_t ARMING_DELAY_MS = 2000;
-        if (delay_arming) {
-            if (AP_HAL::millis() - hal.util->get_last_armed_change() < ARMING_DELAY_MS) {
-                // delay motor start after arming
-                motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
-                motors->output();
-                return;
-            } else {
-                delay_arming = false;
-            }
+        if (plane.arming.get_delay_arming()) {
+            // delay motor start after arming
+            motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
+            motors->output();
+            return;
         }
     }
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -575,6 +575,7 @@ private:
 
     float last_land_final_agl;
 
+
     // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:
     // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
     bool delay_arming;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -195,7 +195,7 @@ private:
      // air mode state: OFF, ON
     AirMode air_mode;
 
-   // check for quadplane assistance needed
+    // check for quadplane assistance needed
     bool assistance_needed(float aspeed, bool have_airspeed);
 
     // check if it is safe to provide assistance
@@ -564,6 +564,8 @@ private:
         OPTION_Q_ASSIST_FORCE_ENABLE=(1<<7),
         OPTION_TAILSIT_Q_ASSIST_MOTORS_ONLY=(1<<8),
         OPTION_AIRMODE=(1<<9),
+        OPTION_DISARMED_TILT=(1<<10),
+        OPTION_DELAY_ARMING=(1<<11),
     };
 
     AP_Float takeoff_failure_scalar;
@@ -572,6 +574,10 @@ private:
     uint32_t takeoff_time_limit_ms;
 
     float last_land_final_agl;
+
+    // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:
+    // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
+    bool delay_arming;
 
     /*
       return true if current mission item is a vtol takeoff


### PR DESCRIPTION
Useful for checking the vectored yaw tilt direction and range when setting up tilt SERVO MAX/MIN and  Q_TILT_YAW_ANGLE