### PR TITLE
HAL_ChibiOS: support LEDs with a wider range of frequencies

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -348,7 +348,7 @@ private:
     static void dma_irq_callback(void *p, uint32_t flags);
     static void dma_unlock(void *p);
     bool mode_requires_dma(enum output_mode mode) const;
-    bool setup_group_DMA(pwm_group &group, uint32_t bitrate, uint32_t bit_width, bool active_high, const uint16_t buffer_length);
+    bool setup_group_DMA(pwm_group &group, uint32_t bitrate, uint32_t bit_width, bool active_high, const uint16_t buffer_length, bool choose_high);
     void send_pulses_DMAR(pwm_group &group, uint32_t buffer_length);
     void set_group_mode(pwm_group &group);
     bool is_dshot_protocol(const enum output_mode mode) const;


### PR DESCRIPTION
this fixed LEDs on FMUv5 boards on first 4 aux channels. We need to
round up not round down in the resulting bitrate