### PR TITLE
AP_NavEKF2: provide reasons for init failures: alternate implementation

### DIFF
--- a/libraries/AP_NavEKF/AP_Nav_Common.cpp
+++ b/libraries/AP_NavEKF/AP_Nav_Common.cpp
@@ -3,6 +3,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
 
+extern const AP_HAL::HAL& hal;
+
 /*
   write an EKF timing message
  */
@@ -23,3 +25,8 @@ void Log_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing 
         (double)timing.delVelDT_min,
         (double)timing.delVelDT_max);
 }
+
+const char* EKF_Init_Failure::getFailureReason(const char* prefix) const {
+    hal.util->snprintf(const_cast<char*>(prearm_fail_string), sizeof(prearm_fail_string), "%s: %s", prefix, initFailureReason[int(failure_reason)]);
+    return prearm_fail_string;
+};

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -76,3 +76,35 @@ struct ekf_timing {
     float delVelDT_min;
 };
 void Log_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing);
+
+class EKF_Init_Failure {
+public:
+    enum class InitFailures {
+        UNKNOWN,
+        NO_ENABLE, 
+        NO_IMUS, 
+        NO_MASK, 
+        NO_MEM, 
+        NO_SETUP,
+        NUM_INIT_FAILURES
+    };
+    // initialization failure reasons
+    const char* initFailureReason[int(InitFailures::NUM_INIT_FAILURES)] {
+        "unknown initialization failure",
+        "EKn_enable is false",
+        "no IMUs available",
+        "EKn_IMU_MASK is zero",
+        "insufficient memory available",
+        "core setup failed"
+    };
+
+    const char* getFailureReason(const char* prefix) const;
+    
+    void set_failure_reason(InitFailures v) {
+        failure_reason = v;
+    }
+
+private:
+    InitFailures failure_reason;
+    char prearm_fail_string[41];
+};

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -361,6 +361,8 @@ private:
     NavEKF2_core *core = nullptr;
     const AP_AHRS *_ahrs;
     const RangeFinder &_rng;
+    
+    EKF_Init_Failure initFailure;
 
     uint32_t _frameTimeUsec;        // time per IMU frame
     uint8_t  _framesPerPrediction;  // expected number of IMU frames per prediction


### PR DESCRIPTION
alternate implementation of #12710
moves the enum and strings into a new class in AP_Nav_common to be shared by EK2 and EK3

@rmackay9 attempting to reduce duplication of code