### PR TITLE
RC_Channel: don't panic on unsupported RCn_OPTION in SITL

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -509,7 +509,7 @@ void GCS_MAVLINK_Copter::packetReceived(const mavlink_status_t &status,
 
 bool GCS_MAVLINK_Copter::params_ready() const
 {
-    if (AP_BoardConfig::in_sensor_config_error()) {
+    if (AP_BoardConfig::in_config_error()) {
         // we may never have parameters "initialised" in this case
         return true;
     }

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -197,7 +197,7 @@ class AutoTestSub(AutoTest):
     def disabled_tests(self):
         ret = super(AutoTestSub, self).disabled_tests()
         ret.update({
-            "SensorConfigErrorLoop": "Sub does not instantiate AP_Stats.  Also see https://github.com/ArduPilot/ardupilot/issues/10247",
+            "ConfigErrorLoop": "Sub does not instantiate AP_Stats.  Also see https://github.com/ArduPilot/ardupilot/issues/10247",
         })
         return ret
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3146,7 +3146,7 @@ class AutoTest(ABC):
             raise NotAchievedException("Failed to clear mission")
         self.last_wp_load = time.time()
 
-    def test_sensor_config_error_loop(self):
+    def test_config_error_loop(self):
         '''test the sensor config error loop works and that parameter sets are persistent'''
         parameter_name = "SERVO8_MIN"
         old_parameter_value = self.get_parameter(parameter_name)
@@ -3163,8 +3163,8 @@ class AutoTest(ABC):
                 self.disarm_vehicle(force=True)
 
             self.reboot_sitl(required_bootcount=1);
-            self.progress("Waiting for 'Check BRD_TYPE'")
-            self.mavproxy.expect("Check BRD_TYPE");
+            self.progress("Waiting for 'Config error'")
+            self.mavproxy.expect("Config error");
             self.progress("Setting %s to %f" % (parameter_name, new_parameter_value))
             self.set_parameter(parameter_name, new_parameter_value)
         except Exception as e:
@@ -3610,9 +3610,9 @@ switch value'''
             "Test Set Home",
              self.fly_test_set_home),
 
-            ("SensorConfigErrorLoop",
-             "Test Sensor Config Error Loop",
-             self.test_sensor_config_error_loop),
+            ("ConfigErrorLoop",
+             "Test Config Error Loop",
+             self.test_config_error_loop),
 
             ("Parameters",
              "Test Parameter Set/Get",

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -216,7 +216,7 @@ void AP_Baro::calibrate(bool save)
         do {
             update();
             if (AP_HAL::millis() - tstart > 500) {
-                AP_BoardConfig::sensor_config_error("Baro: unable to calibrate");
+                AP_BoardConfig::config_error("Baro: unable to calibrate");
             }
             hal.scheduler->delay(10);
         } while (!healthy());
@@ -233,7 +233,7 @@ void AP_Baro::calibrate(bool save)
         do {
             update();
             if (AP_HAL::millis() - tstart > 500) {
-                AP_BoardConfig::sensor_config_error("Baro: unable to calibrate");
+                AP_BoardConfig::config_error("Baro: unable to calibrate");
             }
         } while (!healthy());
         for (uint8_t i=0; i<_num_sensors; i++) {
@@ -267,7 +267,7 @@ void AP_Baro::calibrate(bool save)
     if (num_calibrated) {
         return;
     }
-    AP_BoardConfig::sensor_config_error("AP_Baro: all sensors uncalibrated");
+    AP_BoardConfig::config_error("AP_Baro: all sensors uncalibrated");
 }
 
 /*
@@ -603,7 +603,7 @@ void AP_Baro::init(void)
 #if !defined(HAL_BARO_ALLOW_INIT_NO_BARO) // most boards requires external baro
 
     if (_num_drivers == 0 || _num_sensors == 0 || drivers[0] == nullptr) {
-        AP_BoardConfig::sensor_config_error("Baro: unable to initialise driver");
+        AP_BoardConfig::config_error("Baro: unable to initialise driver");
     }
 #endif
 }

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -58,11 +58,11 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     // notify user of a fatal startup error related to available sensors. 
-    static void sensor_config_error(const char *reason);
+    static void config_error(const char *reason, ...);
 
     // permit other libraries (in particular, GCS_MAVLink) to detect
     // that we're never going to boot properly:
-    static bool in_sensor_config_error(void) { return _in_sensor_config_error; }
+    static bool in_config_error(void) { return _in_sensor_config_error; }
 
     // valid types for BRD_TYPE: these values need to be in sync with the
     // values from the param description

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -171,7 +171,7 @@ void AP_BoardConfig_CAN::init()
                 _drivers[i]._driver = _drivers[i]._tcan = new AP_ToshibaCAN;
 
                 if (_drivers[i]._driver == nullptr) {
-                    AP_BoardConfig::sensor_config_error("ToshibaCAN init failed");
+                    AP_BoardConfig::config_error("ToshibaCAN init failed");
                     continue;
                 }
             } else {

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -116,7 +116,7 @@ void AP_BoardConfig::board_setup_drivers(void)
     case PX4_BOARD_MINDPXV2:
         break;
     default:
-        sensor_config_error("Unknown board type");
+        config_error("Unknown board type");
         break;
     }
 }
@@ -251,7 +251,7 @@ void AP_BoardConfig::validate_board_type(void)
         // configured for PIXHAWK1
 #if !defined(CONFIG_ARCH_BOARD_PX4FMU_V3) && !defined(HAL_CHIBIOS_ARCH_FMUV3)
         // force user to load the right firmware
-        sensor_config_error("Pixhawk2 requires FMUv3 firmware");        
+        config_error("Pixhawk2 requires FMUv3 firmware");        
 #endif
         state.board_type.set(PX4_BOARD_PIXHAWK2);
         hal.console->printf("Forced PIXHAWK2\n");
@@ -282,7 +282,7 @@ void AP_BoardConfig::check_cubeblack(void)
     if (!check_ms5611("ms5611_ext")) { success = false; }
 
     if (!success) {
-        sensor_config_error("Failed to init CubeBlack - sensor mismatch");
+        config_error("Failed to init CubeBlack - sensor mismatch");
     }
 #endif
 }
@@ -338,7 +338,7 @@ void AP_BoardConfig::board_autodetect(void)
         state.board_type.set(PX4_BOARD_PIXHAWK);
         hal.console->printf("Detected Pixhawk\n");
     } else {
-        sensor_config_error("Unable to detect board type");
+        config_error("Unable to detect board type");
     }
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4) || defined(HAL_CHIBIOS_ARCH_FMUV4)
     // only one choice

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -163,7 +163,7 @@ void Scheduler::sitl_end_atomic() {
 
 void Scheduler::reboot(bool hold_in_bootloader)
 {
-    if (AP_BoardConfig::in_sensor_config_error()) {
+    if (AP_BoardConfig::in_config_error()) {
         // the _should_reboot flag set below is not checked by the
         // sensor-config-error loop, so force the reboot here:
         HAL_SITL::actually_reboot();

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -798,7 +798,7 @@ bool AP_IOMCU::check_crc(void)
     if (!upload_fw()) {
         AP_ROMFS::free(fw);
         fw = nullptr;
-        AP_BoardConfig::sensor_config_error("Failed to update IO firmware");
+        AP_BoardConfig::config_error("Failed to update IO firmware");
     }
 
     AP_ROMFS::free(fw);

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -867,7 +867,7 @@ AP_InertialSensor::detect_backends(void)
 #endif
 
     if (_backend_count == 0) {
-        AP_BoardConfig::sensor_config_error("INS: unable to initialise driver");
+        AP_BoardConfig::config_error("INS: unable to initialise driver");
     }
 }
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2293,7 +2293,7 @@ void AP_Param::set_defaults_from_table(const struct defaults_table_struct *table
         if (!AP_Param::set_default_by_name(table[i].name, table[i].value)) {
             char *buf = nullptr;
             if (asprintf(&buf, "param deflt fail:%s", table[i].name) > 0) {
-                AP_BoardConfig::sensor_config_error(buf);
+                AP_BoardConfig::config_error(buf);
             }
         }
     }

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -204,7 +204,7 @@ bool GCS::out_of_time() const
     }
 
     // we always want to be able to send messages out while in the error loop:
-    if (AP_BoardConfig::in_sensor_config_error()) {
+    if (AP_BoardConfig::in_config_error()) {
         return false;
     }
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -476,10 +476,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
         do_aux_function(ch_option, ch_flag);
         break;
     default:
-        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to initialise RC function (%u)", (unsigned)ch_option);
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        AP_HAL::panic("RC function (%u) initialisation not handled", (unsigned)ch_option);
-#endif
+        gcs().send_text(MAV_SEVERITY_WARNING, "Unsupported RC function (%u)", (unsigned)ch_option);
         break;
     }
 }

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -476,11 +476,10 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
         do_aux_function(ch_option, ch_flag);
         break;
     default:
-        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to initialise RC function (%u)", (unsigned)ch_option);
-        char errorMsg[51];
-        hal.util->snprintf(errorMsg, sizeof(errorMsg), "Failed to initialise RC function %u for channel %u",
-                           (unsigned)ch_option, (unsigned)(this->ch_in+1));
-        AP_BoardConfig::rc_option_error(errorMsg);
+        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to init: RC%u_OPTION: %u\n",
+                           (unsigned)(this->ch_in+1), (unsigned)ch_option);
+        AP_BoardConfig::config_error("Failed to init: RC%u_OPTION: %u",
+                           (unsigned)(this->ch_in+1), (unsigned)ch_option);
         break;
     }
 }

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -476,7 +476,11 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
         do_aux_function(ch_option, ch_flag);
         break;
     default:
-        gcs().send_text(MAV_SEVERITY_WARNING, "Unsupported RC function (%u)", (unsigned)ch_option);
+        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to initialise RC function (%u)", (unsigned)ch_option);
+        char errorMsg[51];
+        hal.util->snprintf(errorMsg, sizeof(errorMsg), "Failed to initialise RC function %u for channel %u",
+                           (unsigned)ch_option, (unsigned)(this->ch_in+1));
+        AP_BoardConfig::rc_option_error(errorMsg);
         break;
     }
 }


### PR DESCRIPTION
there is no known risk of failure due to an RCn_OPTION parameter having an invalid or unsupported value 

Eliminating the panic leaves only the 
gcs().send_text(MAV_SEVERITY_WARNING, "Unsupported RC function (%u)", (unsigned)ch_option);
to indicate the problem in SITL