### PR TITLE
Rover: fix set-desired-speed in Auto

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -648,16 +648,21 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
     {
         // param1 : yaw angle to adjust direction by in centidegress
         // param2 : Speed - normalized to 0 .. 1
+        // param3 : 0 = absolute, 1 = relative
 
         // exit if vehicle is not in Guided mode
         if (!rover.control_mode->in_guided_mode()) {
             return MAV_RESULT_FAILED;
         }
 
-        // send yaw change and target speed to guided mode controller
-        const float speed_max = rover.control_mode->get_speed_default();
-        const float target_speed = constrain_float(packet.param2 * speed_max, -speed_max, speed_max);
-        rover.mode_guided.set_desired_heading_delta_and_speed(packet.param1, target_speed);
+        // get final angle, 1 = Relative, 0 = Absolute
+        if (packet.param3 > 0) {
+            // relative angle
+            rover.mode_guided.set_desired_heading_delta_and_speed(packet.param1 * 100.0f, packet.param2);
+        } else {
+            // absolute angle
+            rover.mode_guided.set_desired_heading_and_speed(packet.param1 * 100.0f, packet.param2);
+        }
         return MAV_RESULT_ACCEPTED;
     }
 

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -209,17 +209,6 @@ bool Mode::set_desired_location(const struct Location& destination, float next_l
     return true;
 }
 
-// set desired heading and speed
-void Mode::set_desired_heading_and_speed(float yaw_angle_cd, float target_speed)
-{
-    // handle initialisation
-    _reached_destination = false;
-
-    // record targets
-    _desired_yaw_cd = yaw_angle_cd;
-    _desired_speed = target_speed;
-}
-
 // get default speed for this mode (held in WP_SPEED or RTL_SPEED)
 float Mode::get_speed_default(bool rtl) const
 {
@@ -228,22 +217,6 @@ float Mode::get_speed_default(bool rtl) const
     }
 
     return g2.wp_nav.get_default_speed();
-}
-
-// restore desired speed to default from parameter values (WP_SPEED)
-void Mode::set_desired_speed_to_default(bool rtl)
-{
-    _desired_speed = get_speed_default(rtl);
-}
-
-// set desired speed in m/s
-bool Mode::set_desired_speed(float speed)
-{
-    if (!is_negative(speed)) {
-        _desired_speed = speed;
-        return true;
-    }
-    return false;
 }
 
 // execute the mission in reverse (i.e. backing up)

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -202,24 +202,28 @@ bool ModeAuto::reached_destination() const
     return true;
 }
 
-// set desired heading in centidegrees (vehicle will turn to this heading)
-void ModeAuto::set_desired_heading_and_speed(float yaw_angle_cd, float target_speed)
+// set desired speed in m/s
+bool ModeAuto::set_desired_speed(float speed)
 {
-    // call parent
-    Mode::set_desired_heading_and_speed(yaw_angle_cd, target_speed);
-
-    _submode = Auto_HeadingAndSpeed;
-    _reached_heading = false;
-}
-
-// return true if vehicle has reached desired heading
-bool ModeAuto::reached_heading()
-{
-    if (_submode == Auto_HeadingAndSpeed) {
-        return _reached_heading;
+    switch (_submode) {
+    case Auto_WP:
+    case Auto_Stop:
+        if (!is_negative(speed)) {
+            g2.wp_nav.set_desired_speed(speed);
+            return true;
+        }
+        return false;
+    case Auto_HeadingAndSpeed:
+        _desired_speed = speed;
+        return true;
+    case Auto_RTL:
+        return rover.mode_rtl.set_desired_speed(speed);
+    case Auto_Loiter:
+        return rover.mode_loiter.set_desired_speed(speed);
+    case Auto_Guided:
+        return rover.mode_guided.set_desired_speed(speed);
     }
-    // we should never reach here but just in case, return true to allow missions to continue
-    return true;
+    return false;
 }
 
 // start RTL (within auto)
@@ -604,9 +608,13 @@ void ModeAuto::do_nav_set_yaw_speed(const AP_Mission::Mission_Command& cmd)
         desired_heading_cd = cmd.content.set_yaw_speed.angle_deg * 100.0f;
     }
 
-    // set auto target
+    // set targets
     const float speed_max = g2.wp_nav.get_default_speed();
-    set_desired_heading_and_speed(desired_heading_cd, constrain_float(cmd.content.set_yaw_speed.speed, -speed_max, speed_max));
+    _desired_speed = constrain_float(cmd.content.set_yaw_speed.speed, -speed_max, speed_max);
+    _desired_yaw_cd = desired_heading_cd;
+    _reached_heading = false;
+    _reached_destination = false;
+    _submode = Auto_HeadingAndSpeed;
 }
 
 /********************************************************************************/
@@ -700,7 +708,11 @@ bool ModeAuto::verify_nav_guided_enable(const AP_Mission::Mission_Command& cmd)
 // verify_yaw - return true if we have reached the desired heading
 bool ModeAuto::verify_nav_set_yaw_speed()
 {
-    return reached_heading();
+    if (_submode == Auto_HeadingAndSpeed) {
+        return _reached_heading;
+    }
+    // we should never reach here but just in case, return true to allow missions to continue
+    return true;
 }
 
 /********************************************************************************/

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -590,7 +590,7 @@ void ModeAuto::do_nav_guided_enable(const AP_Mission::Mission_Command& cmd)
     }
 }
 
-// do_set_yaw_speed - turn to a specified heading and achieve and given speed
+// do_set_yaw_speed - turn to a specified heading and achieve a given speed
 void ModeAuto::do_nav_set_yaw_speed(const AP_Mission::Mission_Command& cmd)
 {
     float desired_heading_cd;

--- a/APMrover2/mode_follow.cpp
+++ b/APMrover2/mode_follow.cpp
@@ -8,8 +8,8 @@ bool ModeFollow::_enter()
         return false;
     }
 
-    // initialise waypoint speed
-    set_desired_speed_to_default();
+    // initialise speed to waypoint speed
+    _desired_speed = g2.wp_nav.get_default_speed();
 
     return true;
 }
@@ -84,4 +84,14 @@ float ModeFollow::wp_bearing() const
 float ModeFollow::get_distance_to_destination() const
 {
     return g2.follow.get_distance_to_target();
+}
+
+// set desired speed in m/s
+bool ModeFollow::set_desired_speed(float speed)
+{
+    if (is_negative(speed)) {
+        return false;
+    }
+    _desired_speed = speed;
+    return true;
 }

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -144,6 +144,26 @@ bool ModeGuided::reached_destination() const
     return true;
 }
 
+// set desired speed in m/s
+bool ModeGuided::set_desired_speed(float speed)
+{
+    switch (_guided_mode) {
+    case Guided_WP:
+        if (!is_negative(speed)) {
+            g2.wp_nav.set_desired_speed(speed);
+            return true;
+        }
+        return false;
+    case Guided_HeadingAndSpeed:
+    case Guided_TurnRateAndSpeed:
+        // speed is set from mavlink message
+        return false;
+    case Guided_Loiter:
+        return rover.mode_loiter.set_desired_speed(speed);
+    }
+    return false;
+}
+
 // get desired location
 bool ModeGuided::get_desired_location(Location& destination) const
 {
@@ -185,10 +205,7 @@ bool ModeGuided::set_desired_location(const struct Location& destination,
 // set desired attitude
 void ModeGuided::set_desired_heading_and_speed(float yaw_angle_cd, float target_speed)
 {
-    // call parent
-    Mode::set_desired_heading_and_speed(yaw_angle_cd, target_speed);
-
-    // handle guided specific initialisation and logging
+    // initialisation and logging
     _guided_mode = ModeGuided::Guided_HeadingAndSpeed;
     _des_att_time_ms = AP_HAL::millis();
     _reached_destination = false;

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -81,3 +81,13 @@ bool ModeRTL::reached_destination() const
 {
     return g2.wp_nav.reached_destination();
 }
+
+// set desired speed in m/s
+bool ModeRTL::set_desired_speed(float speed)
+{
+    if (is_negative(speed)) {
+        return false;
+    }
+    g2.wp_nav.set_desired_speed(speed);
+    return true;
+}

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -115,6 +115,16 @@ bool ModeSmartRTL::get_desired_location(Location& destination) const
     return false;
 }
 
+// set desired speed in m/s
+bool ModeSmartRTL::set_desired_speed(float speed)
+{
+    if (is_negative(speed)) {
+        return false;
+    }
+    g2.wp_nav.set_desired_speed(speed);
+    return true;
+}
+
 // save current position for use by the smart_rtl flight mode
 void ModeSmartRTL::save_position()
 {


### PR DESCRIPTION
This PR resolves three issues.  The first is a regression since 3.5.x so we must be fixed before we can release Rover-4.0.

- Rover: ignores DO_CHANGE_SPEED: https://github.com/ArduPilot/ardupilot/issues/12753

  - This bug crept in when we create the [AR_WPNav library](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AR_WPNav/AR_WPNav.h).  The AR_WPNav library maintains it's own target speed but we weren't updating this when we received a DO_CHANGE_SPEED command
  - The Mode classes's default implementation of set_desired_speed() is removed and instead Auto, Guided, Follow, RTL and SmartRTL modes override the function because they support external callers adjusting the speed.
  - Mode class's _desired_speed variable is removed because it is no longer required
  - The functionality in the Mode class's set_desired_speed_to_default(), set_desired_heading_and_speed() and reached_heading() functions are moved to the few modes that require them (Auto, Guided, Follow)

- Rover: NAV_SET_YAW_SPEED handling is inconsistent between mission command and command-long: https://github.com/ArduPilot/ardupilot/issues/10803

  - Guided mode's interpretation of the SET_YAW_SPEED command is modified to match Auto's

     - parameter 3 allows selecting between relative and absolute heading
     - yaw is expected to be in degrees (was centi-degrees)
     - speed is expected to be a speed in m/s instead of a percentage of the WP_SPEED

- Rover: ignores DO_CHANGE_SPEED command if before first nav command: https://github.com/ArduPilot/ardupilot/issues/8619.  This problem is fixed as a side-effect of the changes above

This has been successfully tested in SITL by performing the following tests:

- Created a mission with waypoints, do-change-speed and RTL commands and confirmed the speeds changed appropriately.
- One issue was found: the RTL returned home at the default speed (5m/s) even though there was a DO_CHANGE_SPEED command immediately before it.  This was found to be because the DO_CHANGE_SPEED was executed before the RTL.  A work around is to add an extra CONDITION_DELAY before the do-change-speed.
![test1](https://user-images.githubusercontent.com/1498098/68179558-b288c180-ffd3-11e9-93d0-63e4d5dcdd57.png)
- DO_CHANGE_SPEED commands were also sent from the SITL command line and took effect immediately
- NAV_YAW_SPEED commands were tested in both Auto and Guided and found to be working
