### PR TITLE
Avoid setting radio channel values when in throttle failsafe

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -184,6 +184,8 @@ private:
     RC_Channel *channel_throttle;
     RC_Channel *channel_rudder;
 
+    bool throttle_at_failsafe_level() const;
+
     AP_Logger logger;
 
     // scaled roll limit based on pitch

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -27,6 +27,11 @@ bool RC_Channels_Plane::has_valid_input() const
     return true;
 }
 
+bool RC_Channel_Plane::throttle_at_failsafe_level() const
+{
+    return plane.throttle_at_failsafe_level();
+}
+
 void RC_Channel_Plane::do_aux_function_change_mode(const Mode::Number number,
                                                    const aux_switch_pos_t ch_flag)
 {

--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -13,6 +13,8 @@ protected:
                            aux_switch_pos_t ch_flag) override;
     void do_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
 
+    bool throttle_at_failsafe_level() const override;
+
 private:
 
     void do_aux_function_change_mode(Mode::Number number,

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -376,10 +376,15 @@ bool Plane::rc_throttle_value_ok(void) const
     if (!g.throttle_fs_enabled) {
         return true;
     }
+    return !throttle_at_failsafe_level();
+}
+
+bool Plane::throttle_at_failsafe_level() const
+{
     if (channel_throttle->get_reverse()) {
-        return channel_throttle->get_radio_in() < g.throttle_fs_value;
+        return channel_throttle->get_radio_in_underlying() < g.throttle_fs_value;
     }
-    return channel_throttle->get_radio_in() > g.throttle_fs_value;
+    return channel_throttle->get_radio_in_underlying() <= g.throttle_fs_value;
 }
 
 /*

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -930,6 +930,45 @@ class AutoTestPlane(AutoTest):
         if ex is not None:
             raise ex
 
+    def test_throttle_failsafe_fence(self):
+        fence_bit = mavutil.mavlink.MAV_SYS_STATUS_GEOFENCE
+
+        self.progress("Checking fence is not present before being configured")
+        m = self.mav.recv_match(type='SYS_STATUS', blocking=True)
+        print("%s" % str(m))
+        if (m.onboard_control_sensors_enabled & fence_bit):
+            raise NotAchievedException("Fence enabled before being configured")
+
+        self.change_mode('MANUAL')
+        self.wait_ready_to_arm()
+
+        self.load_fence("CMAC-fence.txt")
+
+        self.set_parameter("FENCE_CHANNEL", 7)
+        self.set_parameter("FENCE_ACTION", 4)
+        self.set_rc(3, 1000)
+        self.set_rc(7, 2000)
+
+        self.progress("Checking fence is initially OK")
+        m = self.mav.recv_match(type='SYS_STATUS', blocking=True)
+        print("%s" % str(m))
+        if (not (m.onboard_control_sensors_enabled & fence_bit)):
+            raise NotAchievedException("Fence not initially enabled")
+
+        self.set_parameter("THR_FS_VALUE", 960)
+        self.progress("Failing receiver (throttle-to-950)")
+        self.set_parameter("SIM_RC_FAIL", 2) # throttle-to-950
+        self.wait_mode("CIRCLE")
+        self.delay_sim_time(1) # give
+        self.drain_mav_unparsed()
+
+        self.progress("Checking fence is OK after receiver failure (bind-values)")
+        fence_bit = mavutil.mavlink.MAV_SYS_STATUS_GEOFENCE
+        m = self.mav.recv_match(type='SYS_STATUS', blocking=True)
+        print("%s" % str(m))
+        if (not (m.onboard_control_sensors_enabled & fence_bit)):
+            raise NotAchievedException("Fence not enabled after RC fail")
+
     def test_gripper_mission(self):
         self.context_push()
         ex = None
@@ -1421,6 +1460,10 @@ class AutoTestPlane(AutoTest):
             ("ThrottleFailsafe",
              "Fly throttle failsafe",
              self.test_throttle_failsafe),
+
+            ("ThrottleFailsafeFence",
+             "Fly fence survives throttle failsafe",
+             self.test_throttle_failsafe_fence),
 
             ("TestFlaps", "Flaps", self.fly_flaps),
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -136,7 +136,12 @@ RC_Channel::update(void)
     if (has_override() && !rc().ignore_overrides()) {
         radio_in = override_value;
     } else if (!rc().ignore_receiver()) {
-        radio_in = hal.rcin->read(ch_in);
+        const uint16_t read_value = hal.rcin->read(ch_in);
+        if (!throttle_at_failsafe_level()) {
+            radio_in = read_value;
+        }
+        // store the underlying value for the 
+        radio_in_underlying = read_value;
     } else {
         return false;
     }

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -64,6 +64,8 @@ public:
     int16_t    get_radio_in() const { return radio_in;}
     void       set_radio_in(int16_t val) {radio_in = val;}
 
+    int16_t    get_radio_in_underlying() const { return radio_in_underlying;}
+
     int16_t    get_control_in() const { return control_in;}
     void       set_control_in(int16_t val) { control_in = val;}
 
@@ -196,6 +198,7 @@ protected:
 
     virtual void init_aux_function(aux_func_t ch_option, aux_switch_pos_t);
     virtual void do_aux_function(aux_func_t ch_option, aux_switch_pos_t);
+    virtual bool throttle_at_failsafe_level() const = 0;
 
     void do_aux_function_avoid_proximity(const aux_switch_pos_t ch_flag);
     void do_aux_function_camera_trigger(const aux_switch_pos_t ch_flag);
@@ -216,8 +219,12 @@ protected:
 
 private:
 
-    // pwm is stored here
-    int16_t     radio_in;
+    // pwm is stored here - but only if we think it is a good value to
+    // process.  So if we seem to be in throttle failsafe we shouldn't
+    // use any other values from the packet...
+    int16_t     radio_in;  // values from receiver that code should act on
+
+    int16_t     radio_in_underlying; // actual values from receiver
 
     // value generated from PWM normalised to configured scale
     int16_t    control_in;


### PR DESCRIPTION
This is supposed to be a global fix for the many issues in the code where we use radio values when the throttle level is at a value indicating the receiver is in failsafe - and all the other channels have probably gone to their bind values.
