### PR TITLE
fix error with python3.7 and gcc 7.3.1

### DIFF
--- a/wscript
+++ b/wscript
@@ -157,7 +157,7 @@ def _collect_autoconfig_files(cfg):
                 paths.append(p)
 
         for p in paths:
-            if p in cfg.files or not os.path.isfile(p):
+            if p in cfg.files or not (p and os.path.isfile(p)):
                 continue
 
             with open(p, 'rb') as f:


### PR DESCRIPTION
fix waf error TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType with python3.7 and gcc 7.3.1 math.h error