### PR TITLE
Gcc7 warning

### DIFF
--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -158,7 +158,7 @@ void AP_KDECAN::init(uint8_t driver_index, bool enable_filters)
         debug_can(2, "KDECAN: found ESC id %u\n\r", id.source_id);
     }
 
-    snprintf(_thread_name, sizeof(_thread_name), "kdecan_%u", driver_index);
+    snprintf(_thread_name, sizeof(_thread_name), "kdecan_%u", driver_index & MAX_NUMBER_OF_CAN_DRIVERS);
 
     // start thread for receiving and sending CAN frames
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_KDECAN::loop, void), _thread_name, 4096, AP_HAL::Scheduler::PRIORITY_CAN, 0)) {

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -281,7 +281,7 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     // Spin node for device discovery
     _node->spin(uavcan::MonotonicDuration::fromMSec(5000));
 
-    snprintf(_thread_name, sizeof(_thread_name), "uavcan_%u", driver_index);
+    snprintf(_thread_name, sizeof(_thread_name), "uavcan_%u", driver_index & MAX_NUMBER_OF_CAN_DRIVERS);
 
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_UAVCAN::loop, void), _thread_name, 4096, AP_HAL::Scheduler::PRIORITY_CAN, 0)) {
         _node->setModeOfflineAndPublish();

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
@@ -547,7 +547,7 @@ void trampoline_handleNodeInfo(const uavcan::ServiceCallResult<uavcan::protocol:
     uavcan::copy(resp.getResponse().hardware_version.unique_id.begin(),
                  resp.getResponse().hardware_version.unique_id.end(),
                  unique_id);
-    snprintf(name, ARRAY_SIZE(name), "%s", resp.getResponse().name.c_str());
+    snprintf(name, ARRAY_SIZE(name), "%.14s", resp.getResponse().name.c_str());
     AP::uavcan_dna_server().handleNodeInfo(node_id, unique_id, name);
 }
 


### PR DESCRIPTION
Correct GCC > 7 warning (and error) on snprintf.
error are like : 
````
../../libraries/AP_KDECAN/AP_KDECAN.cpp:75:6: error: '%u' directive output may be truncated writing between 1 and 3 bytes into a region of size 2 [-Werror=format-truncation=]
 void AP_KDECAN::init(uint8_t driver_index, bool enable_filters)
````
The fix imply to help the compiler to understand the variable max size.
I am not sure about the fix on AP_UAVCAN_DNA_Server.cpp, the max size is set to 14 when the array is of size 15 as snprintf append a \n at the end