### PR TITLE
Copter: Add GCS failsafe arming check, tones, and lights

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -60,7 +60,8 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
         & parameter_checks(display_failure)
         & motor_checks(display_failure)
         & pilot_throttle_checks(display_failure)
-        & oa_checks(display_failure) &
+        & oa_checks(display_failure)
+        & gcs_failsafe_check(display_failure) &
         AP_Arming::pre_arm_checks(display_failure);
 }
 
@@ -563,6 +564,15 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     return true;
 }
 
+// Check GCS failsafe
+bool AP_Arming_Copter::gcs_failsafe_check(bool display_failure)
+{
+    if (copter.failsafe.gcs) {
+        check_failed(display_failure, "GCS failsafe on");
+        return false;
+    }
+    return true;
+}
 
 // arm_checks - perform final checks before arming
 //  always called just before arming.  Return true if ok to arm

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -49,6 +49,7 @@ protected:
     bool pilot_throttle_checks(bool display_failure);
     bool oa_checks(bool display_failure);
     bool mandatory_gps_checks(bool display_failure);
+    bool gcs_failsafe_check(bool display_failure);
 
     void set_pre_arm_check(bool b);
 

--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -74,6 +74,9 @@ void Copter::set_failsafe_radio(bool b)
 void Copter::set_failsafe_gcs(bool b)
 {
     failsafe.gcs = b;
+
+    // update AP_Notify
+        AP_Notify::flags.failsafe_gcs = b;
 }
 
 // ---------------------------------------------

--- a/libraries/AP_Notify/AP_BoardLED2.cpp
+++ b/libraries/AP_Notify/AP_BoardLED2.cpp
@@ -171,7 +171,7 @@ void AP_BoardLED2::update(void)
                 if ((counter2 & 0x7) == 0) {
                     hal.gpio->toggle(HAL_GPIO_A_LED_PIN);
                 }
-            }else if(AP_Notify::flags.failsafe_radio){//   blink fast (around 4Hz)
+            }else if(AP_Notify::flags.failsafe_radio || AP_Notify::flags.failsafe_gcs){//   blink fast (around 4Hz)
                 if ((counter2 & 0x3) == 0) {
                     hal.gpio->toggle(HAL_GPIO_A_LED_PIN);
                 }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -87,6 +87,7 @@ public:
         bool esc_calibration;     // true if calibrating escs
         bool failsafe_radio;      // true if radio failsafe
         bool failsafe_battery;    // true if battery failsafe
+        bool failsafe_gcs;        // true if GCS failsafe
         bool parachute_release;   // true if parachute is being released
         bool ekf_bad;             // true if ekf is reporting problems
         bool autopilot_mode;      // true if vehicle is in an autopilot flight mode (only used by OreoLEDs)

--- a/libraries/AP_Notify/ExternalLED.cpp
+++ b/libraries/AP_Notify/ExternalLED.cpp
@@ -185,7 +185,7 @@ void ExternalLED::update(void)
                 break;
         }
     }else{
-        if (AP_Notify::flags.failsafe_battery || AP_Notify::flags.failsafe_radio) {
+        if (AP_Notify::flags.failsafe_battery || AP_Notify::flags.failsafe_radio || AP_Notify::flags.failsafe_gcs) {
             // radio or battery failsafe indicated by fast flashing
             set_pattern(FAST_FLASH);
         } else {

--- a/libraries/AP_Notify/OreoLED_I2C.cpp
+++ b/libraries/AP_Notify/OreoLED_I2C.cpp
@@ -87,6 +87,10 @@ void OreoLED_I2C::update()
         return;    // don't go any further if the Pixhawk is is in radio failsafe
     }
 
+    if (mode_failsafe_gcs()) {
+        return;    // don't go any further if the Pixhawk is is in gcs failsafe
+    }
+
     set_standard_colors();
 
     if (mode_failsafe_batt()) {
@@ -156,6 +160,20 @@ bool OreoLED_I2C::mode_failsafe_radio()
         set_rgb(OREOLED_BACKRIGHT, OREOLED_PATTERN_STROBE, 255, 0, 0,0,0,0,PERIOD_SLOW,0);
     }
     return AP_Notify::flags.failsafe_radio;
+}
+
+
+// Procedure for when Pixhawk is in GCS failsafe
+// LEDs perform alternating yellow X pattern
+bool OreoLED_I2C::mode_failsafe_gcs()
+{
+    if (AP_Notify::flags.failsafe_gcs) {
+        set_rgb(OREOLED_FRONTLEFT, OREOLED_PATTERN_STROBE, 255, 50, 0,0,0,0,PERIOD_SLOW,0);
+        set_rgb(OREOLED_FRONTRIGHT, OREOLED_PATTERN_STROBE, 255, 50, 0,0,0,0,PERIOD_SLOW,PO_ALTERNATE);
+        set_rgb(OREOLED_BACKLEFT, OREOLED_PATTERN_STROBE, 255, 50, 0,0,0,0,PERIOD_SLOW,PO_ALTERNATE);
+        set_rgb(OREOLED_BACKRIGHT, OREOLED_PATTERN_STROBE, 255, 50, 0,0,0,0,PERIOD_SLOW,0);
+    }
+    return AP_Notify::flags.failsafe_gcs;
 }
 
 

--- a/libraries/AP_Notify/OreoLED_I2C.cpp
+++ b/libraries/AP_Notify/OreoLED_I2C.cpp
@@ -76,19 +76,19 @@ void OreoLED_I2C::update()
     }
 
     if (mode_firmware_update()) {
-        return;    // don't go any further if the Pixhawk is in firmware update
+        return;    // don't go any further if in firmware update
     }
 
     if (mode_init()) {
-        return;    // don't go any further if the Pixhawk is initializing
+        return;    // don't go any further if initializing
     }
 
     if (mode_failsafe_radio()) {
-        return;    // don't go any further if the Pixhawk is is in radio failsafe
+        return;    // don't go any further if in radio failsafe
     }
 
     if (mode_failsafe_gcs()) {
-        return;    // don't go any further if the Pixhawk is is in gcs failsafe
+        return;    // don't go any further if in gcs failsafe
     }
 
     set_standard_colors();
@@ -123,7 +123,7 @@ bool OreoLED_I2C::slow_counter()
 }
 
 
-// Procedure for when Pixhawk is in FW update / bootloader
+// Procedure for when in FW update / bootloader
 // Makes all LEDs go into color cycle mode
 // Returns true if firmware update in progress. False if not
 bool OreoLED_I2C::mode_firmware_update()
@@ -149,7 +149,7 @@ bool OreoLED_I2C::mode_init()
 }
 
 
-// Procedure for when Pixhawk is in radio failsafe
+// Procedure for when in radio failsafe
 // LEDs perform alternating Red X pattern
 bool OreoLED_I2C::mode_failsafe_radio()
 {
@@ -163,7 +163,7 @@ bool OreoLED_I2C::mode_failsafe_radio()
 }
 
 
-// Procedure for when Pixhawk is in GCS failsafe
+// Procedure for when in GCS failsafe
 // LEDs perform alternating yellow X pattern
 bool OreoLED_I2C::mode_failsafe_gcs()
 {
@@ -237,7 +237,7 @@ bool OreoLED_I2C::mode_failsafe_batt()
 }
 
 
-// Procedure for when Pixhawk is in an autopilot mode
+// Procedure for when in an autopilot mode
 // Makes all LEDs strobe super fast using standard colors
 bool OreoLED_I2C::mode_auto_flight()
 {
@@ -274,7 +274,7 @@ bool OreoLED_I2C::mode_auto_flight()
 }
 
 
-// Procedure for when Pixhawk is in a pilot controlled mode
+// Procedure for when in a pilot controlled mode
 // All LEDs use standard pattern and colors
 bool OreoLED_I2C::mode_pilot_flight()
 {

--- a/libraries/AP_Notify/OreoLED_I2C.h
+++ b/libraries/AP_Notify/OreoLED_I2C.h
@@ -113,6 +113,7 @@ private:
     bool mode_firmware_update(void);
     bool mode_init(void);
     bool mode_failsafe_radio(void);
+    bool mode_failsafe_gcs(void);
     bool set_standard_colors(void);
     bool mode_failsafe_batt(void);
     bool mode_auto_flight(void);

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -118,6 +118,7 @@ uint32_t RGBLed::get_colour_sequence(void) const
     // gps failsafe pattern : flashing yellow and blue
     // ekf_bad pattern : flashing yellow and red
     if (AP_Notify::flags.failsafe_radio ||
+        AP_Notify::flags.failsafe_gcs ||
         AP_Notify::flags.failsafe_battery ||
         AP_Notify::flags.ekf_bad ||
         AP_Notify::flags.gps_glitching ||

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -299,6 +299,23 @@ void AP_ToneAlarm::update()
         }
     }
 
+    // notify the user when GCS failsafe is triggered
+    if (flags.failsafe_gcs != AP_Notify::flags.failsafe_gcs) {
+        flags.failsafe_gcs = AP_Notify::flags.failsafe_gcs;
+        if (flags.failsafe_gcs) {
+            // armed case handled by events.failsafe_mode_change
+            if (!AP_Notify::flags.armed) {
+                play_tone(AP_NOTIFY_TONE_QUIET_NEG_FEEDBACK);
+            }
+        } else {
+            if (AP_Notify::flags.armed) {
+                play_tone(AP_NOTIFY_TONE_LOUD_POS_FEEDBACK);
+            } else {
+                play_tone(AP_NOTIFY_TONE_QUIET_POS_FEEDBACK);
+            }
+        }
+    }
+
     // notify the user when pre_arm checks are passing
     if (flags.pre_arm_check != AP_Notify::flags.pre_arm_check) {
         flags.pre_arm_check = AP_Notify::flags.pre_arm_check;

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -58,6 +58,7 @@ private:
         uint16_t parachute_release     : 1;    // 1 if parachute is being released
         uint16_t pre_arm_check         : 1;    // 0 = failing checks, 1 = passed
         uint16_t failsafe_radio        : 1;    // 1 if radio failsafe
+        uint16_t failsafe_gcs          : 1;    // 1 if gcs failsafe
         uint16_t vehicle_lost          : 1;    // 1 if lost copter tone requested
         uint16_t compass_cal_running   : 1;    // 1 if compass calibration is running
         uint16_t waiting_for_throw     : 1;    // 1 if waiting for copter throw launch


### PR DESCRIPTION
This adds the GCS failsafe to the AP_Notify library tones and lights.  For the most part, it's doing the same lights as the radio failsafe. There are only so many blinks and colors, so I just has use the same thing as the radio. Open to better ideas on this.

This also adds the GCS failsafe to the AP_Arming library pre-arm checks. You will get pre-arm warnings if the failsafe is active, and it will not arm.

The GCS failsafe is disabled by default in master now, and presumably will be defaulted to disabled in Copter 4.0.1 as well.  So this shouldn't cause a major undesired annoyance now.

_As a reminder, if no GCS has ever been connected, the GCS failsafe remains inactive._

**At this time, it appears copter is the only vehicle that will utilize this**.  Other vehicle types are not setting the new notify flag yet.  The notify flag didn't exist until recently anyway. So if other vehicle types wish to do this too, they would need to start setting the new AP_Notify flag for GCS failsafe.