### PR TITLE
AP_HAL: stop emitting extra CR before a LF as part of our printf

### DIFF
--- a/libraries/AP_HAL/utility/print_vprintf.cpp
+++ b/libraries/AP_HAL/utility/print_vprintf.cpp
@@ -89,10 +89,6 @@ void print_vprintf(AP_HAL::BetterStream *s, const char *fmt, va_list ap)
                         break;
                     }
                 }
-                /* emit cr before lf to make most terminals happy */
-                if (c == '\n') {
-                    s->write('\r');
-                }
                 s->write(c);
             }
 


### PR DESCRIPTION
This is rather surprising and unfortunate when writing serial sensor drivers.
