### PR TITLE
AP_NavEKF2: clean up init failure handling

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -359,6 +359,7 @@ private:
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core
     NavEKF2_core *core = nullptr;
+    bool core_malloc_failed;
     const AP_AHRS *_ahrs;
     const RangeFinder &_rng;
 


### PR DESCRIPTION
If I am right, _enable was being cleared only to reduce noise from the gcs().sendtext messages which are deleted by this PR.
_enable is used nowhere else, except for being forced true for replay.

There is now only one sendtext remaining in InitialiseFilter(): "NavEKF2: core %d setup failed"
and it is also redundant to an initFailure message, although it does provide additional info as to which core setup failed.