### PR TITLE
RC_Channel: put options in numerical order and add missing options for Rover

### DIFF
--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -33,20 +33,23 @@ void RC_Channel_Rover::init_aux_function(const aux_func_t ch_option, const aux_s
     // init channel options
     switch (ch_option) {
     // the following functions do not need initialising:
+    case AUX_FUNC::ACRO:
+    case AUX_FUNC::ARMDISARM:
+    case AUX_FUNC::AUTO:
+    case AUX_FUNC::FOLLOW:
+    case AUX_FUNC::GUIDED:
+    case AUX_FUNC::HOLD:
+    case AUX_FUNC::LEARN_CRUISE:
+    case AUX_FUNC::LOITER:
+    case AUX_FUNC::MAINSAIL:
+    case AUX_FUNC::MANUAL:
+    case AUX_FUNC::RTL:
+    case AUX_FUNC::SAILBOAT_TACK:
     case AUX_FUNC::SAVE_TRIM:
     case AUX_FUNC::SAVE_WP:
-    case AUX_FUNC::LEARN_CRUISE:
-    case AUX_FUNC::ARMDISARM:
-    case AUX_FUNC::MANUAL:
-    case AUX_FUNC::ACRO:
+    case AUX_FUNC::SIMPLE:
+    case AUX_FUNC::SMART_RTL:
     case AUX_FUNC::STEERING:
-    case AUX_FUNC::HOLD:
-    case AUX_FUNC::AUTO:
-    case AUX_FUNC::GUIDED:
-    case AUX_FUNC::LOITER:
-    case AUX_FUNC::FOLLOW:
-    case AUX_FUNC::SAILBOAT_TACK:
-    case AUX_FUNC::MAINSAIL:
         break;
     case AUX_FUNC::SAILBOAT_MOTOR_3POS:
         do_aux_function_sailboat_motor_3pos(ch_flag);

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -63,52 +63,52 @@ void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_
 {
     // init channel options
     switch(ch_option) {
-    case AUX_FUNC::SIMPLE_MODE:
-    case AUX_FUNC::RANGEFINDER:
-    case AUX_FUNC::SUPERSIMPLE_MODE:
-    case AUX_FUNC::ACRO_TRAINER:
-    case AUX_FUNC::PARACHUTE_ENABLE:
-    case AUX_FUNC::PARACHUTE_3POS:      // we trust the vehicle will be disarmed so even if switch is in release position the chute will not release
-    case AUX_FUNC::RETRACT_MOUNT:
-    case AUX_FUNC::ATTCON_FEEDFWD:
-    case AUX_FUNC::ATTCON_ACCEL_LIM:
-    case AUX_FUNC::MOTOR_INTERLOCK:
-    case AUX_FUNC::PRECISION_LOITER:
-    case AUX_FUNC::INVERTED:
-    case AUX_FUNC::WINCH_ENABLE:
-    case AUX_FUNC::STANDBY:
-    case AUX_FUNC::SURFACE_TRACKING:
-        do_aux_function(ch_option, ch_flag);
-        break;
     // the following functions do not need to be initialised:
+    case AUX_FUNC::ALTHOLD:
+    case AUX_FUNC::ARMDISARM:
+    case AUX_FUNC::AUTO:
+    case AUX_FUNC::AUTOTUNE:
+    case AUX_FUNC::BRAKE:
+    case AUX_FUNC::CIRCLE:
+    case AUX_FUNC::DRIFT:
     case AUX_FUNC::FLIP:
+    case AUX_FUNC::FLOWHOLD:
+    case AUX_FUNC::FOLLOW:
+    case AUX_FUNC::GUIDED:
+    case AUX_FUNC::LAND:
+    case AUX_FUNC::LOITER:
+    case AUX_FUNC::PARACHUTE_RELEASE:
+    case AUX_FUNC::POSHOLD:
+    case AUX_FUNC::RESETTOARMEDYAW:
     case AUX_FUNC::RTL:
     case AUX_FUNC::SAVE_TRIM:
     case AUX_FUNC::SAVE_WP:
-    case AUX_FUNC::RESETTOARMEDYAW:
-    case AUX_FUNC::AUTO:
-    case AUX_FUNC::AUTOTUNE:
-    case AUX_FUNC::LAND:
-    case AUX_FUNC::BRAKE:
-    case AUX_FUNC::THROW:
     case AUX_FUNC::SMART_RTL:
-    case AUX_FUNC::GUIDED:
-    case AUX_FUNC::LOITER:
-    case AUX_FUNC::FOLLOW:
-    case AUX_FUNC::PARACHUTE_RELEASE:
-    case AUX_FUNC::ARMDISARM:
-    case AUX_FUNC::WINCH_CONTROL:
+    case AUX_FUNC::STABILIZE:
+    case AUX_FUNC::THROW:
     case AUX_FUNC::USER_FUNC1:
     case AUX_FUNC::USER_FUNC2:
     case AUX_FUNC::USER_FUNC3:
+    case AUX_FUNC::WINCH_CONTROL:
     case AUX_FUNC::ZIGZAG:
     case AUX_FUNC::ZIGZAG_SaveWP:
-    case AUX_FUNC::STABILIZE:
-    case AUX_FUNC::POSHOLD:
-    case AUX_FUNC::ALTHOLD:
-    case AUX_FUNC::FLOWHOLD:
-    case AUX_FUNC::CIRCLE:
-    case AUX_FUNC::DRIFT:
+        break;
+    case AUX_FUNC::ACRO_TRAINER:
+    case AUX_FUNC::ATTCON_ACCEL_LIM:
+    case AUX_FUNC::ATTCON_FEEDFWD:
+    case AUX_FUNC::INVERTED:
+    case AUX_FUNC::MOTOR_INTERLOCK:
+    case AUX_FUNC::PARACHUTE_3POS:      // we trust the vehicle will be disarmed so even if switch is in release position the chute will not release
+    case AUX_FUNC::PARACHUTE_ENABLE:
+    case AUX_FUNC::PRECISION_LOITER:
+    case AUX_FUNC::RANGEFINDER:
+    case AUX_FUNC::RETRACT_MOUNT:
+    case AUX_FUNC::SIMPLE_MODE:
+    case AUX_FUNC::STANDBY:
+    case AUX_FUNC::SUPERSIMPLE_MODE:
+    case AUX_FUNC::SURFACE_TRACKING:
+    case AUX_FUNC::WINCH_ENABLE:
+        do_aux_function(ch_option, ch_flag);
         break;
     default:
         RC_Channel::init_aux_function(ch_option, ch_flag);

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -59,10 +59,10 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
     switch(ch_option) {
     // the following functions do not need to be initialised:
     case AUX_FUNC::ARMDISARM:
-    case AUX_FUNC::INVERTED:
     case AUX_FUNC::AUTO:
     case AUX_FUNC::CIRCLE:
     case AUX_FUNC::GUIDED:
+    case AUX_FUNC::INVERTED:
     case AUX_FUNC::MANUAL:
     case AUX_FUNC::RTL:
     case AUX_FUNC::TAKEOFF:

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -449,33 +449,31 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
 {
     // init channel options
     switch(ch_option) {
-    case AUX_FUNC::FENCE:  
-    case AUX_FUNC::RC_OVERRIDE_ENABLE:
-    case AUX_FUNC::AVOID_ADSB:
-    case AUX_FUNC::AVOID_PROXIMITY:
-    case AUX_FUNC::MISSION_RESET:
-        do_aux_function(ch_option, ch_flag);
-        break;
     // the following functions do not need to be initialised:
+    case AUX_FUNC::CAMERA_TRIGGER:
+    case AUX_FUNC::CLEAR_WP:
+    case AUX_FUNC::COMPASS_LEARN:
+    case AUX_FUNC::DO_NOTHING:
+    case AUX_FUNC::LANDING_GEAR:
+    case AUX_FUNC::LOST_VEHICLE_SOUND:
     case AUX_FUNC::RELAY:
     case AUX_FUNC::RELAY2:
     case AUX_FUNC::RELAY3:
     case AUX_FUNC::RELAY4:
     case AUX_FUNC::RELAY5:
     case AUX_FUNC::RELAY6:
-    case AUX_FUNC::CAMERA_TRIGGER:
-    case AUX_FUNC::LOST_VEHICLE_SOUND:
-    case AUX_FUNC::DO_NOTHING:
-    case AUX_FUNC::CLEAR_WP:
-    case AUX_FUNC::COMPASS_LEARN:
-    case AUX_FUNC::LANDING_GEAR:
         break;
-    case AUX_FUNC::MOTOR_ESTOP:
-    case AUX_FUNC::GRIPPER:
-    case AUX_FUNC::SPRAYER:
+    case AUX_FUNC::AVOID_ADSB:
+    case AUX_FUNC::AVOID_PROXIMITY:
+    case AUX_FUNC::FENCE:
     case AUX_FUNC::GPS_DISABLE:
+    case AUX_FUNC::GRIPPER:
     case AUX_FUNC::KILL_IMU1:
     case AUX_FUNC::KILL_IMU2:
+    case AUX_FUNC::MISSION_RESET:
+    case AUX_FUNC::MOTOR_ESTOP:
+    case AUX_FUNC::RC_OVERRIDE_ENABLE:
+    case AUX_FUNC::SPRAYER:
         do_aux_function(ch_option, ch_flag);
         break;
     default:


### PR DESCRIPTION
This PR includes two changes:

- a non-functional reorder of the case statement in each of the RC_Channel::init_aux_function() methods for the RC_Channel library and each vehicle.  This re-order may cause some annoyance as we try to backport options to the stable branches but long lists (of functions, cases, etc) in seemingly random order make spotting errors difficult.  Let's try and use either numerical or alphabetical ordering.
- add 3 missing options to the RC_Channel_Rover::init_aux_function() handler.  This error was discovered as part of Rover-4.0 testing ([discussion](https://discuss.ardupilot.org/t/rover-4-0-0-rc3-available-for-beta-testing/49003/5))

This has been tested on a CubeOrange:

- set RC6_OPTION = 4 (RTL), 42 (SmartRTL) and 59 (Simple)
- loaded Rover-4.0.0-rc3 and checked that the, "Config Error: failed to init" message appeared
- loaded this PR and checked that the message no longer appeared, then used the channel to set the mode to each of the 3 listed

