### PR TITLE
AP_Airspeed: switched to recursive semaphore

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -46,7 +46,7 @@ protected:
     }
     
     // semaphore for access to shared frontend data
-    HAL_Semaphore sem;
+    HAL_Semaphore_Recursive sem;
 
     float get_airspeed_ratio(void) const {
         return frontend.get_airspeed_ratio(instance);


### PR DESCRIPTION
this is needed by the SDP3X driver. It is the simplest fix for the
issue
alternative to #12807