### PR TITLE
RC_Channel: don't enter the config error loop on unknown options

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -478,8 +478,10 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
     default:
         gcs().send_text(MAV_SEVERITY_WARNING, "Failed to init: RC%u_OPTION: %u\n",
                            (unsigned)(this->ch_in+1), (unsigned)ch_option);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_BoardConfig::config_error("Failed to init: RC%u_OPTION: %u",
                            (unsigned)(this->ch_in+1), (unsigned)ch_option);
+#endif
         break;
     }
 }


### PR DESCRIPTION
... unless we are in SITL

Users moving backwards and forwards between versions can hit this case
too easily.

We probably need a better story around this error loop so it's less
confusing to the user about what's going on.