### PR TITLE
AP_LandingGear: send-text only if servo output has been configured

### DIFF
--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -126,7 +126,10 @@ void AP_LandingGear::deploy()
     _deployed = true;
     _have_changed = true;
 
-    gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: DEPLOY");
+    // send message only if output has been configured
+    if (SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control)) {
+        gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: DEPLOY");
+    }
 }
 
 /// retract - retract landing gear
@@ -139,7 +142,10 @@ void AP_LandingGear::retract()
     _deployed = false;
     _have_changed = true;
 
-    gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: RETRACT");
+    // send message only if output has been configured
+    if (SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control)) {
+        gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: RETRACT");
+    }
 }
 
 bool AP_LandingGear::deployed()


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/12815 in which "LandingGear: RETRACT" messages were being sent to the ground station even if the user hadn't setup landing.  This is the minimum change which simply turns off the send-text if there's no SERVOx_FUNCTION = 29 (for Landing Gear).

This has been tested in SITL to confirm that messages are still sent if SERVOx_FUNCTION = 29 but not sent if no servo output has been set to 28
![lgear-send-text-fix](https://user-images.githubusercontent.com/1498098/68561795-6aade280-048a-11ea-9d69-484cc91c6591.png)
