### PR TITLE
Copter: fix takeoff from getting stuck (rarely)

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -370,7 +370,7 @@ bool ModeAuto::is_landing() const
 
 bool ModeAuto::is_taking_off() const
 {
-    return _mode == Auto_TakeOff;
+    return ((_mode == Auto_TakeOff) && !wp_nav->reached_wp_destination());
 }
 
 bool ModeAuto::landing_gear_should_be_deployed() const
@@ -741,10 +741,6 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 void ModeAuto::takeoff_run()
 {
     auto_takeoff_run();
-    if (wp_nav->reached_wp_destination()) {
-        const Vector3f target = wp_nav->get_wp_destination();
-        wp_start(target, wp_nav->origin_and_destination_are_terrain_alt());
-    }
 }
 
 // auto_wp_run - runs the auto waypoint controller

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1524,7 +1524,7 @@ bool ModeAuto::verify_land()
             // check if we've reached the location
             if (copter.wp_nav->reached_wp_destination()) {
                 // get destination so we can use it for loiter target
-                Vector3f dest = copter.wp_nav->get_wp_destination();
+                const Vector3f& dest = copter.wp_nav->get_wp_destination();
 
                 // initialise landing controller
                 land_start(dest);

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -370,7 +370,7 @@ void ModeGuided::takeoff_run()
 {
     auto_takeoff_run();
     if (wp_nav->reached_wp_destination()) {
-        const Vector3f target = wp_nav->get_wp_destination();
+        const Vector3f& target = wp_nav->get_wp_destination();
         set_destination(target);
     }
 }

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -123,7 +123,7 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
         stage = MANUAL_REGAIN;
         loiter_nav->clear_pilot_desired_acceleration();
         if (maintain_target) {
-            const Vector3f wp_dest = wp_nav->get_wp_destination();
+            const Vector3f& wp_dest = wp_nav->get_wp_destination();
             loiter_nav->init_target(wp_dest);
             if (wp_nav->origin_and_destination_are_terrain_alt()) {
                 copter.surface_tracking.set_target_alt_cm(wp_dest.z);


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/12818 in which Copter would not progress past the takeoff command in some very rare situations.

The copter was getting stuck when the [ModeAuto::verify_takeoff()](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_auto.cpp#L1508) was returning false.  This was happening not because the vehicle hadn't reached it's target altitude but rather because ModeAuto::takeoff_run() had gotten in there first and used wp_start() to set a new position target which set the wp_nav->reached_destination() back to false.

I'm actually not sure why wp_nav was failing to get the vehicle to the destination but in any case, the call to wp_start() is unnecessary.  The Auto_TakeOff sub mode is perfectly capable of keeping the vehicle at the target altitude.

The ModeAuto::is_taking_off() command which is used for reporting to the GCS has also been updated to return false once the vehicle reaches the takeoff altitude.

This is the original PR https://github.com/ArduPilot/ardupilot/pull/9010 which caused auto to change submodes after it reached the takeoff altitude.  I have not determined if the bug was created at that time or if it came later when I added some terrrain altitude changes.