### PR TITLE
Plane: Fix TECS feed forward

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -855,7 +855,7 @@ void AP_TECS::_update_pitch(void)
     // integrator has to catch up before the nose can be raised to reduce speed during climbout.
     // During flare a different damping gain is used
     float gainInv = (_TAS_state * timeConstant() * GRAVITY_MSS);
-    float temp = SEB_error + SEBdot_dem * timeConstant();
+    float temp = SEB_error + (SEBdot_dem/2.0) * timeConstant();
 
     float pitch_damp = _ptchDamp;
     if (_landing.is_flaring()) {


### PR DESCRIPTION
Hi,
My friend Martin (@MartinSollie) came across what we now believe is a bug in the scaling of the desired height rate. The error causes the TECS integrator to have to compensate for the extra feed-forward term, calling for unnecessary changes in the integrator and less than ideal performance.

The bug is well explained in [this post in the forum](https://discuss.ardupilot.org/t/tecs-climb-rate-overshoot-when-using-low-speedweight/48430), with a log from a real flight as well as two SITL bin-files (one with the code from this PR and one with TECS from master, running the same scenario). This PR is not meant as a permanent solution; it is only a quick fix to illustrate the problem in SITL, and is only valid for speed weights of 0. But we hope that submitting this PR will lure out some TECS experts, as the forum post did not get as much traction as we had hoped.

Looking forward to hear your thoughts, so that we can arrive at a complete fix for this. 