### PR TITLE
AP_RangeFinder: clarify _TYPE param descriptions for Benewake lidar

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -6,7 +6,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:BenewakeTFmini,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFMiniPlus,27:BenewakeTF03
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:BenewakeTFmini/Plus-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFmini/Plus-I2C,27:BenewakeTF03
     // @User: Standard
     AP_GROUPINFO("TYPE",    1, AP_RangeFinder_Params, type, 0),
 


### PR DESCRIPTION
Some users have reported troubles setting up their Benewake lidar and the root cause has been that they had simply selected the wrong driver.  This PR attempts to clarify the RNGFNDx_TYPE parameter description for the TFMini and TFMiniPlus lidar by adding "-Serial" or "-I2C".

19 :BenewakeTF02 is unchanged
20: BenewakeTFMini becomes BenewakeTFMiniPlus-Serial
25: BenewakeTFMiniPlus becomes BenewakeTFMiniPlus-I2C
27: BenewakeTF03 is unchanged

This is a non-functional change so it's not dangerous change but I'd like to hear feedback from @peterbarker, @lucasdemarchi  and @Hwurzburg before we merge.
