### PR TITLE
Copter: Pilot RC stick control of Circle mode radius, rate, & direction

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -609,6 +609,7 @@ private:
 
     // Circle
     bool pilot_yaw_override = false; // true if pilot is overriding yaw
+    bool speed_changing = false;     // true when the roll stick is being held to facilitate stopping at 0 rate
 };
 
 

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -10,6 +10,7 @@
 bool ModeCircle::init(bool ignore_checks)
 {
     pilot_yaw_override = false;
+    speed_changing = false;
 
     // initialize speeds and accelerations
     pos_control->set_max_speed_xy(wp_nav->get_default_speed_xy());
@@ -37,6 +38,52 @@ void ModeCircle::run()
     float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     if (!is_zero(target_yaw_rate)) {
         pilot_yaw_override = true;
+    }
+
+    // pilot changes to circle rate and radius
+    // skip if in radio failsafe
+    if (!copter.failsafe.radio && copter.circle_nav->pilot_control_enabled()) {
+        // update the circle controller's radius target based on pilot pitch stick inputs
+        const float radius_current = copter.circle_nav->get_radius();           // circle controller's radius target, which begins as the circle_radius parameter
+        const float pitch_stick = channel_pitch->norm_input_dz();               // pitch stick normalized -1 to 1
+        const float nav_speed = copter.wp_nav->get_default_speed_xy();          // copter WP_NAV parameter speed
+        const float radius_pilot_change = (pitch_stick * nav_speed) * G_Dt;     // rate of change
+        const float radius_new = MAX(radius_current + radius_pilot_change,0);   // new radius target
+
+        if (!is_equal(radius_current, radius_new)) {
+            copter.circle_nav->set_radius(radius_new);
+        }
+
+        // update the orbicular rate target based on pilot roll stick inputs
+        // skip if using CH6 tuning knob for circle rate
+        if (g.radio_tuning != TUNING_CIRCLE_RATE) {
+            const float roll_stick = channel_roll->norm_input_dz();         // roll stick normalized -1 to 1
+
+            if (is_zero(roll_stick)) {
+                // no speed change, so reset speed changing flag
+                speed_changing = false;
+            } else {
+                const float rate = copter.circle_nav->get_rate();           // circle controller's rate target, which begins as the circle_rate parameter
+                const float rate_current = copter.circle_nav->get_rate_current(); // current adjusted rate target, which is probably different from _rate
+                const float rate_pilot_change = (roll_stick * G_Dt);        // rate of change from 0 to 1 degrees per second
+                float rate_new = rate_current;                              // new rate target
+                if (is_positive(rate)) {
+                    // currently moving clockwise, constrain 0 to 90
+                    rate_new = constrain_float(rate_current + rate_pilot_change, 0, 90);
+
+                } else if (is_negative(rate)) {
+                    // currently moving counterclockwise, constrain -90 to 0
+                    rate_new = constrain_float(rate_current + rate_pilot_change, -90, 0);
+
+                } else if (is_zero(rate) && !speed_changing) {
+                    // Stopped, pilot has released the roll stick, and pilot now wants to begin moving with the roll stick
+                    rate_new = rate_pilot_change;
+                }
+
+                speed_changing = true;
+                copter.circle_nav->set_rate(rate_new);
+            }
+        }
     }
 
     // get pilot desired climb rate (or zero if in radio failsafe)

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -9,7 +9,7 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
     // @DisplayName: Circle Radius
     // @Description: Defines the radius of the circle the vehicle will fly when in Circle flight mode
     // @Units: cm
-    // @Range: 0 10000
+    // @Range: 0 200000
     // @Increment: 100
     // @User: Standard
     AP_GROUPINFO("RADIUS",  0,  AC_Circle, _radius, AC_CIRCLE_RADIUS_DEFAULT),
@@ -22,6 +22,13 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("RATE",    1, AC_Circle, _rate,    AC_CIRCLE_RATE_DEFAULT),
+
+    // @Param: CONTROL
+    // @DisplayName: Circle control
+    // @Description: Enable or disable using the pitch/roll stick control circle mode's radius and rate
+    // @Values: 0:Disable,1:Enable
+    // @User: Standard
+    AP_GROUPINFO("CONTROL", 2, AC_Circle, _control, 1),
 
     AP_GROUPEND
 };
@@ -106,6 +113,13 @@ void AC_Circle::set_rate(float deg_per_sec)
     }
 }
 
+/// set_circle_rate - set circle rate in degrees per second
+void AC_Circle::set_radius(float radius_cm)
+{
+    _radius = constrain_float(radius_cm, 0, AC_CIRCLE_RADIUS_MAX);
+    calc_velocities(false);
+}
+
 /// update - update circle controller
 void AC_Circle::update()
 {
@@ -167,7 +181,7 @@ void AC_Circle::update()
 //  closest point on the circle will be placed in result
 //  result's altitude (i.e. z) will be set to the circle_center's altitude
 //  if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
-void AC_Circle::get_closest_point_on_circle(Vector3f &result)
+void AC_Circle::get_closest_point_on_circle(Vector3f &result) const
 {
     // return center if radius is zero
     if (_radius <= 0) {

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -10,6 +10,7 @@
 #define AC_CIRCLE_RADIUS_DEFAULT    1000.0f     // radius of the circle in cm that the vehicle will fly
 #define AC_CIRCLE_RATE_DEFAULT      20.0f       // turn rate in deg/sec.  Positive to turn clockwise, negative for counter clockwise
 #define AC_CIRCLE_ANGULAR_ACCEL_MIN 2.0f        // angular acceleration should never be less than 2deg/sec
+#define AC_CIRCLE_RADIUS_MAX        200000.0f   // maximum allowed circle radius of 2km
 
 class AC_Circle
 {
@@ -33,11 +34,18 @@ public:
     const Vector3f& get_center() const { return _center; }
 
     /// get_radius - returns radius of circle in cm
-    float get_radius() { return _radius; }
-    /// set_radius - sets circle radius in cm
-    void set_radius(float radius_cm) { _radius = radius_cm; }
+    float get_radius() const { return _radius; }
 
-    /// set_circle_rate - set circle rate in degrees per second
+    /// set_radius - sets circle radius in cm
+    void set_radius(float radius_cm);
+
+    /// get_rate - returns target rate in deg/sec held in RATE parameter
+    float get_rate() const { return _rate; }
+
+    /// get_rate_current - returns actual calculated rate target in deg/sec, which may be less than _rate
+    float get_rate_current() const { return ToDeg(_angular_vel); }
+
+    /// set_rate - set circle rate in degrees per second
     void set_rate(float deg_per_sec);
 
     /// get_angle_total - return total angle in radians that vehicle has circled
@@ -56,13 +64,16 @@ public:
     //  closest point on the circle will be placed in result
     //  result's altitude (i.e. z) will be set to the circle_center's altitude
     //  if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
-    void get_closest_point_on_circle(Vector3f &result);
+    void get_closest_point_on_circle(Vector3f &result) const;
 
     /// get horizontal distance to loiter target in cm
     float get_distance_to_target() const { return _pos_control.get_distance_to_target(); }
 
     /// get bearing to target in centi-degrees
     int32_t get_bearing_to_target() const { return _pos_control.get_bearing_to_target(); }
+
+    /// true if pilot control of radius and turn rate is enabled
+    bool pilot_control_enabled() const { return _control > 0; }
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -92,6 +103,7 @@ private:
     // parameters
     AP_Float    _radius;        // maximum horizontal speed in cm/s during missions
     AP_Float    _rate;          // rotation speed in deg/sec
+    AP_Int16    _control;       // stick control enable/disable
 
     // internal variables
     Vector3f    _center;        // center of circle in cm from home


### PR DESCRIPTION
This allows the pilot to change the circle mode radius, rate, and direction using the RC pitch and roll sticks.  This does not change the circle center point.  Tested in SITL and working quite nicely.  This would probably be a nice feature add for Copter 4 as well.  There are a number of open issues that this will close.

- Pitch stick down (negative) reduces the radius until it reaches zero.
- Pitch stick up (positive) increases the radius
- Roll stick right (think clockwise) will increase the speed while moving clockwise, or decrease the speed while moving counterclockwise until reaching zero, at which point it will stop.
- Roll stick left (think counterclockwise) will increase the speed while moving counterclockwise, or decrease the speed while moving clockwise until reaching zero, at which point it will stop.
- Once stopped (rate 0), releasing the roll stick and pushing it again in either direction will begin moving again in the desired direction. So yes, this allows you to completely change the direction on the fly.
- Roll stick rate changes are inhibited when CH6 tuning knob is set for circle rate.
- All stick changes are inhibited in radio failsafe.
- Does not actually change the stored `circle_rate` or `circle_radius` parameter. Upon rebooting, any stick changes to rate and radius are gone and it will use the parameter values.  So users should not have any surprises with every new flight.

**To Do:**
- [x] The radius change should have a maximum limit. What should it be? Maximum float? Or something more sane?  It doesn't appear the `circle_radius` parameter has any sanity checking now.
- [x] The rate has a constrained max of 90 degrees per second since that's what the `circle_rate` parameter doc suggests.  Is this a sane limit?  I can't think of a use case where one would desire to spin that fast or faster.  There is no current sanity checking on this in the code to begin with.
- [ ] Wiki update for [Circle Mode](http://ardupilot.org/copter/docs/circle-mode.html).
- [ ] Copter 4 backport?