### PR TITLE
Send GPS logging status as part of SYS_STATUS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1639,6 +1639,20 @@ bool AP_GPS::prepare_for_arming(void) {
     return all_passed;
 }
 
+bool AP_GPS::logging_failed(void) const {
+    if (!logging_enabled()) {
+        return false;
+    }
+
+    for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
+        if ((drivers[i] != nullptr) && !(drivers[i]->logging_healthy())) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 namespace AP {
 
 AP_GPS &gps()

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -431,6 +431,12 @@ public:
     // returns true if all GPS instances have passed all final arming checks/state changes
     bool prepare_for_arming(void);
 
+    // returns false if any GPS drivers are not performing their logging appropriately
+    bool logging_failed(void) const;
+
+    bool logging_present(void) const { return _raw_data != 0; }
+    bool logging_enabled(void) const { return _raw_data != 0; }
+
     // used to disable GPS for GPS failure testing in flight
     void force_disable(bool disable) {
         _force_disable_gps = disable;

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -106,6 +106,17 @@ AP_GPS_SBF::read(void)
     return ret;
 }
 
+bool AP_GPS_SBF::logging_healthy(void) const
+{
+    switch (gps._raw_data) {
+        case 1:
+        default:
+            return (RxState & SBF_DISK_MOUNTED) && (RxState & SBF_DISK_ACTIVITY);
+        case 2:
+            return ((RxState & SBF_DISK_MOUNTED) && (RxState & SBF_DISK_ACTIVITY)) || (!hal.util->get_soft_armed() && _has_been_armed);
+    }
+}
+
 bool
 AP_GPS_SBF::parse(uint8_t temp)
 {

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -404,7 +404,7 @@ void AP_GPS_SBF::mount_disk (void) const {
 
 void AP_GPS_SBF::unmount_disk (void) const {
     const char* command = "emd, DSK1, Unmount\n";
-    Debug("Unmounting disk");
+    gcs().send_text(MAV_SEVERITY_DEBUG, "SBF unmounting disk");
     port->write((const uint8_t*)command, strlen(command));
 }
 

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -47,6 +47,8 @@ public:
 
     bool is_healthy(void) const override;
 
+    bool logging_healthy(void) const override;
+
     bool prepare_for_arming(void) override;
 
 

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -57,6 +57,8 @@ public:
 
     // driver specific health, returns true if the driver is healthy
     virtual bool is_healthy(void) const { return true; }
+    // returns true if the GPS is doing any logging it is expected to
+    virtual bool logging_healthy(void) const { return true; }
 
     virtual const char *name() const = 0;
 

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -7,6 +7,7 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_GPS/AP_GPS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -155,13 +156,14 @@ void GCS::update_sensor_status_flags()
     }
 
     const AP_Logger &logger = AP::logger();
-    if (logger.logging_present()) {  // primary logging only (usually File)
+    const AP_GPS &gps = AP::gps();
+    if (logger.logging_present() || gps.logging_present()) {  // primary logging only (usually File)
         control_sensors_present |= MAV_SYS_STATUS_LOGGING;
     }
-    if (logger.logging_enabled()) {
+    if (logger.logging_enabled() || gps.logging_enabled()) {
         control_sensors_enabled |= MAV_SYS_STATUS_LOGGING;
     }
-    if (!logger.logging_failed()) {
+    if (!logger.logging_failed() && !gps.logging_failed()) {
         control_sensors_health |= MAV_SYS_STATUS_LOGGING;
     }
 


### PR DESCRIPTION
This allows a GPS which is responsible for logging to flag to a GCS when logging has failed. We will only send this down if the `GPS_RAW_DATA` parameter is not 0, so the user must have opted into it. This allows you to assess when a GPS has lost access to it's SD card for some reason.

This shows up as the logging bit to the GCS, which I think is consistent with the way we already use logging bits. IE a bad accelerometer health warning just tells us any one of our accelerometers has a problem, it doesn't refer to the primary one.