### PR TITLE
AP_ToshibaCAN: consume and log motor temperature

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -253,6 +253,11 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
         return false;
     }
 
+    // further checks enabled with parameters
+    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
+        return true;
+    }
+
     // if this is a multicopter using ToshibaCAN ESCs ensure MOT_PMW_MIN = 1000, MOT_PWM_MAX = 2000
 #if HAL_WITH_UAVCAN && (FRAME_CONFIG != HELI_FRAME)
     bool tcan_active = false;
@@ -265,6 +270,7 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
         }
     }
     if (tcan_active) {
+        // check motor range parameters
         if (copter.motors->get_pwm_output_min() != 1000) {
             check_failed(display_failure, "TCAN ESCs require MOT_PWM_MIN=1000");
             return false;

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1381,7 +1381,8 @@ void AP_BLHeli::read_telemetry_packet(void)
                       td.voltage,
                       td.current,
                       td.temperature * 100U,
-                      td.consumption);
+                      td.consumption,
+                      0);
     }
     if (debug_level >= 2) {
         hal.console->printf("ESC[%u] T=%u V=%u C=%u con=%u RPM=%u t=%u\n",

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -633,7 +633,7 @@ void AP_KDECAN::update()
                           int32_t(telem_buffer[i].rpm * 60UL * 2 / num_poles * 100),
                           telem_buffer[i].voltage,
                           telem_buffer[i].current,
-                          int16_t(telem_buffer[i].temp * 100U), 0);
+                          int16_t(telem_buffer[i].temp * 100U), 0, 0);
         }
     }
 }

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -257,7 +257,7 @@ public:
     void Write_CameraInfo(enum LogMessages msg, const Location &current_loc, uint64_t timestamp_us=0);
     void Write_Camera(const Location &current_loc, uint64_t timestamp_us=0);
     void Write_Trigger(const Location &current_loc);
-    void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t temperature, uint16_t current_tot);
+    void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t esc_temp, uint16_t current_tot, int16_t motor_temp);
     void Write_Attitude(const Vector3f &targets);
     void Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);
     void Write_Current();

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -780,7 +780,7 @@ bool AP_Logger_Backend::Write_Mode(uint8_t mode, const ModeReason reason)
 //   current is in centi-amps
 //   temperature is in centi-degrees Celsius
 //   current_tot is in centi-amp hours
-void AP_Logger::Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t temperature, uint16_t current_tot)
+void AP_Logger::Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t esc_temp, uint16_t current_tot, int16_t motor_temp)
 {
     // sanity check id
     if (id >= 8) {
@@ -792,8 +792,9 @@ void AP_Logger::Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t vo
         rpm         : rpm,
         voltage     : voltage,
         current     : current,
-        temperature : temperature,
-        current_tot : current_tot
+        esc_temp    : esc_temp,
+        current_tot : current_tot,
+        motor_temp  : motor_temp
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -937,8 +937,9 @@ struct PACKED log_Esc {
     int32_t rpm;
     uint16_t voltage;
     uint16_t current;
-    int16_t temperature;
+    int16_t esc_temp;
     uint16_t current_tot;
+    int16_t motor_temp;
 };
 
 struct PACKED log_AIRSPEED {
@@ -1219,10 +1220,10 @@ struct PACKED log_Arm_Disarm {
 #define BARO_UNITS "smPOnsmO-"
 #define BARO_MULTS "F00B0C?0-"
 
-#define ESC_LABELS "TimeUS,RPM,Volt,Curr,Temp,CTot"
-#define ESC_FMT   "QeCCcH"
-#define ESC_UNITS "sqvAO-"
-#define ESC_MULTS "FBBBB-"
+#define ESC_LABELS "TimeUS,RPM,Volt,Curr,Temp,CTot,MotTemp"
+#define ESC_FMT   "QeCCcHc"
+#define ESC_UNITS "sqvAO-O"
+#define ESC_MULTS "FBBBB-B"
 
 #define GPA_LABELS "TimeUS,VDop,HAcc,VAcc,SAcc,YAcc,VV,SMS,Delta"
 #define GPA_FMT   "QCCCCfBIH"

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -78,7 +78,8 @@ private:
         uint16_t rpm;               // rpm
         uint16_t voltage_cv;        // voltage in centi-volts
         uint16_t current_ca;        // current in centi-amps
-        uint16_t temperature;       // temperature in degrees
+        uint16_t esc_temp;          // esc temperature in degrees
+        uint16_t motor_temp;        // motor temperature in degrees
         uint16_t count;             // total number of packets sent
         uint32_t last_update_ms;    // system time telemetry was last update (used to calc total current)
         float current_tot_mah;      // total current in mAh


### PR DESCRIPTION
The latest firmware version of the ToshibaCAN ESCs can report the motor temperature as well (they come with a little external sensor board that can be attached to the motor).  This PR consumes this motor temperature and adds it to the ESC logs.

The PR also fixes two issues/bugs to do with ToshibaCAN ESCs:

- allows disabling the pre-arm check that all motors are present
- fixes the existing esc temperature consumption so that it doesn't show massive numbers when the temperature is very low

The only downside of this PR is that it slightly increases the size of the ESCx dataflash logs because we log motor temperature (as zero) for the BLHeli and KDE CAN ESCs even though they can't provide it.

This has been tested on real hardware