### PR TITLE
AP_Compass: format cleanup and minor bug fixes

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -116,7 +116,7 @@ void Compass::_cancel_calibration(uint8_t i)
         AP_Notify::events.compass_cal_canceled = 1;
     }
     _cal_saved[i] = false;
-    _calibrator[i].clear();
+    _calibrator[i].stop();
 }
 
 void Compass::_cancel_calibration_mask(uint8_t mask)
@@ -172,7 +172,7 @@ bool Compass::_accept_calibration_mask(uint8_t mask)
             if (!_accept_calibration(i)) {
                 success = false;
             }
-            _calibrator[i].clear();
+            _calibrator[i].stop();
         }
     }
 

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -208,7 +208,7 @@ bool Compass::send_mag_cal_progress(const GCS_MAVLINK& link)
             cal_status == COMPASS_CAL_RUNNING_STEP_ONE ||
             cal_status == COMPASS_CAL_RUNNING_STEP_TWO) {
             uint8_t completion_pct = calibrator.get_completion_percent();
-            auto& completion_mask = calibrator.get_completion_mask();
+            const CompassCalibrator::completion_mask_t& completion_mask = calibrator.get_completion_mask();
             const Vector3f direction;
             uint8_t attempt = _calibrator[compass_id].get_attempt();
 

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -8,8 +8,7 @@ extern AP_HAL::HAL& hal;
 
 #if COMPASS_CAL_ENABLED
 
-void
-Compass::cal_update()
+void Compass::cal_update()
 {
     if (hal.util->get_soft_armed()) {
         return;
@@ -47,8 +46,7 @@ Compass::cal_update()
     }
 }
 
-bool
-Compass::_start_calibration(uint8_t i, bool retry, float delay)
+bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
 {
     if (!healthy(i)) {
         return false;
@@ -82,8 +80,7 @@ Compass::_start_calibration(uint8_t i, bool retry, float delay)
     return true;
 }
 
-bool
-Compass::_start_calibration_mask(uint8_t mask, bool retry, bool autosave, float delay, bool autoreboot)
+bool Compass::_start_calibration_mask(uint8_t mask, bool retry, bool autosave, float delay, bool autoreboot)
 {
     _cal_autosave = autosave;
     _compass_cal_autoreboot = autoreboot;
@@ -99,8 +96,7 @@ Compass::_start_calibration_mask(uint8_t mask, bool retry, bool autosave, float 
     return true;
 }
 
-void
-Compass::start_calibration_all(bool retry, bool autosave, float delay, bool autoreboot)
+void Compass::start_calibration_all(bool retry, bool autosave, float delay, bool autoreboot)
 {
     _cal_autosave = autosave;
     _compass_cal_autoreboot = autoreboot;
@@ -112,8 +108,7 @@ Compass::start_calibration_all(bool retry, bool autosave, float delay, bool auto
     }
 }
 
-void
-Compass::_cancel_calibration(uint8_t i)
+void Compass::_cancel_calibration(uint8_t i)
 {
     AP_Notify::events.initiated_compass_cal = 0;
 
@@ -124,24 +119,21 @@ Compass::_cancel_calibration(uint8_t i)
     _calibrator[i].clear();
 }
 
-void
-Compass::_cancel_calibration_mask(uint8_t mask)
+void Compass::_cancel_calibration_mask(uint8_t mask)
 {
-    for(uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
-        if((1<<i) & mask) {
+    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+        if ((1<<i) & mask) {
             _cancel_calibration(i);
         }
     }
 }
 
-void
-Compass::cancel_calibration_all()
+void Compass::cancel_calibration_all()
 {
     _cancel_calibration_mask(0xFF);
 }
 
-bool
-Compass::_accept_calibration(uint8_t i)
+bool Compass::_accept_calibration(uint8_t i)
 {
     CompassCalibrator& cal = _calibrator[i];
     uint8_t cal_status = cal.get_status();
@@ -172,8 +164,7 @@ Compass::_accept_calibration(uint8_t i)
     }
 }
 
-bool
-Compass::_accept_calibration_mask(uint8_t mask)
+bool Compass::_accept_calibration_mask(uint8_t mask)
 {
     bool success = true;
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
@@ -263,8 +254,7 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
     return true;
 }
 
-bool
-Compass::is_calibrating() const
+bool Compass::is_calibrating() const
 {
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
         switch(_calibrator[i].get_status()) {
@@ -280,8 +270,7 @@ Compass::is_calibrating() const
     return false;
 }
 
-uint8_t
-Compass::_get_cal_mask() const
+uint8_t Compass::_get_cal_mask() const
 {
     uint8_t cal_mask = 0;
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
@@ -291,7 +280,6 @@ Compass::_get_cal_mask() const
     }
     return cal_mask;
 }
-
 
 /*
   handle an incoming MAG_CAL command
@@ -326,32 +314,32 @@ MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_long_t &packet)
                 result = MAV_RESULT_FAILED;
             }
         }
-        
+
         break;
     }
 
     case MAV_CMD_DO_ACCEPT_MAG_CAL: {
         result = MAV_RESULT_ACCEPTED;
-        if(packet.param1 < 0 || packet.param1 > 255) {
+        if (packet.param1 < 0 || packet.param1 > 255) {
             result = MAV_RESULT_FAILED;
             break;
         }
-        
+
         uint8_t mag_mask = packet.param1;
-        
+
         if (mag_mask == 0) { // 0 means all
             mag_mask = 0xFF;
         }
-        
-        if(!_accept_calibration_mask(mag_mask)) {
+
+        if (!_accept_calibration_mask(mag_mask)) {
             result = MAV_RESULT_FAILED;
         }
         break;
     }
-        
+
     case MAV_CMD_DO_CANCEL_MAG_CAL: {
         result = MAV_RESULT_ACCEPTED;
-        if(packet.param1 < 0 || packet.param1 > 255) {
+        if (packet.param1 < 0 || packet.param1 > 255) {
             result = MAV_RESULT_FAILED;
             break;
         }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -461,11 +461,6 @@ float CompassCalibrator::calc_residual(const Vector3f& sample, const param_t& pa
     return params.radius - (softiron*(sample+params.offset)).length();
 }
 
-float CompassCalibrator::calc_mean_squared_residuals() const
-{
-    return calc_mean_squared_residuals(_params);
-}
-
 // calc the fitness given a set of parameters (offsets, diagonals, off diagonals)
 float CompassCalibrator::calc_mean_squared_residuals(const param_t& params) const
 {

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -73,10 +73,10 @@ CompassCalibrator::CompassCalibrator():
     _tolerance(COMPASS_CAL_DEFAULT_TOLERANCE),
     _sample_buffer(nullptr)
 {
-    clear();
+    stop();
 }
 
-void CompassCalibrator::clear()
+void CompassCalibrator::stop()
 {
     set_status(COMPASS_CAL_NOT_STARTED);
 }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -203,8 +203,9 @@ void CompassCalibrator::update(bool &failure)
             if (is_equal(_fitness, _initial_fitness) || isnan(_fitness)) {  // if true, means that fitness is diverging instead of converging
                 set_status(COMPASS_CAL_FAILED);
                 failure = true;
+            } else {
+                set_status(COMPASS_CAL_RUNNING_STEP_TWO);
             }
-            set_status(COMPASS_CAL_RUNNING_STEP_TWO);
         } else {
             if (_fit_step == 0) {
                 calc_initial_offset();

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -153,7 +153,7 @@ void CompassCalibrator::update_completion_mask(const Vector3f& v)
     _completion_mask[section / 8] |= 1 << (section % 8);
 }
 
-// reset and updated the completion mask using all samples in the sample buffer
+// reset and update the completion mask using all samples in the sample buffer
 void CompassCalibrator::update_completion_mask()
 {
     memset(_completion_mask, 0, sizeof(_completion_mask));

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -147,11 +147,6 @@ void CompassCalibrator::update_completion_mask()
     }
 }
 
-CompassCalibrator::completion_mask_t& CompassCalibrator::get_completion_mask()
-{
-    return _completion_mask;
-}
-
 bool CompassCalibrator::check_for_timeout() {
     uint32_t tnow = AP_HAL::millis();
     if(running() && tnow - _last_sample_ms > 1000) {

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -50,7 +50,7 @@ public:
     enum Rotation get_original_orientation() const { return _orig_orientation; }
 
     float get_completion_percent() const;
-    completion_mask_t& get_completion_mask();
+    const completion_mask_t& get_completion_mask() const { return _completion_mask; }
     enum compass_cal_status_t get_status() const { return _status; }
     float get_fitness() const { return sqrtf(_fitness); }
     float get_orientation_confidence() const { return _orientation_confidence; }

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -109,8 +109,8 @@ private:
     bool set_status(compass_cal_status_t status);
 
     // returns true if sample should be added to buffer
-    bool accept_sample(const Vector3f &sample);
-    bool accept_sample(const CompassSample &sample);
+    bool accept_sample(const Vector3f &sample, uint16_t skip_index = UINT16_MAX);
+    bool accept_sample(const CompassSample &sample, uint16_t skip_index = UINT16_MAX);
 
     // returns true if fit is acceptable
     bool fit_acceptable();

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -10,13 +10,13 @@
 #define COMPASS_CAL_DEFAULT_TOLERANCE 5.0f
 
 enum compass_cal_status_t {
-    COMPASS_CAL_NOT_STARTED=0,
-    COMPASS_CAL_WAITING_TO_START=1,
-    COMPASS_CAL_RUNNING_STEP_ONE=2,
-    COMPASS_CAL_RUNNING_STEP_TWO=3,
-    COMPASS_CAL_SUCCESS=4,
-    COMPASS_CAL_FAILED=5,
-    COMPASS_CAL_BAD_ORIENTATION=6,
+    COMPASS_CAL_NOT_STARTED = 0,
+    COMPASS_CAL_WAITING_TO_START = 1,
+    COMPASS_CAL_RUNNING_STEP_ONE = 2,
+    COMPASS_CAL_RUNNING_STEP_TWO = 3,
+    COMPASS_CAL_SUCCESS = 4,
+    COMPASS_CAL_FAILED = 5,
+    COMPASS_CAL_BAD_ORIENTATION = 6,
 };
 
 class CompassCalibrator {
@@ -42,7 +42,7 @@ public:
         _is_external = is_external;
         _fix_orientation = fix_orientation;
     }
-    
+
     void set_tolerance(float tolerance) { _tolerance = tolerance; }
 
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -46,8 +46,8 @@ public:
     void set_tolerance(float tolerance) { _tolerance = tolerance; }
 
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);
-    enum Rotation get_orientation(void) { return _orientation; }
-    enum Rotation get_original_orientation(void) { return _orig_orientation; }
+    enum Rotation get_orientation() const { return _orientation; }
+    enum Rotation get_original_orientation() const { return _orig_orientation; }
 
     float get_completion_percent() const;
     completion_mask_t& get_completion_mask();

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -133,7 +133,6 @@ private:
     // calc the fitness of the parameters (offsets, diagonals, off diagonals) vs all the samples collected
     // returns 1.0e30f if the sample buffer is empty
     float calc_mean_squared_residuals(const param_t& params) const;
-    float calc_mean_squared_residuals() const;
 
     // calculate initial offsets by simply taking the average values of the samples
     void calc_initial_offset();

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -30,7 +30,7 @@ public:
 
     // start or stop the calibration
     void start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx);
-    void clear();
+    void stop();
 
     // update the state machine and calculate offsets, diagonals and offdiagonals
     void update(bool &failure);

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -2,13 +2,12 @@
 
 #include <AP_Math/AP_Math.h>
 
-#define COMPASS_CAL_NUM_SPHERE_PARAMS 4
-#define COMPASS_CAL_NUM_ELLIPSOID_PARAMS 9
-#define COMPASS_CAL_NUM_SAMPLES 300
+#define COMPASS_CAL_NUM_SPHERE_PARAMS       4
+#define COMPASS_CAL_NUM_ELLIPSOID_PARAMS    9
+#define COMPASS_CAL_NUM_SAMPLES             300     // number of samples required before fitting begins
+#define COMPASS_CAL_DEFAULT_TOLERANCE       5.0f    // default RMS tolerance
 
-//RMS tolerance
-#define COMPASS_CAL_DEFAULT_TOLERANCE 5.0f
-
+// compass calibration states
 enum compass_cal_status_t {
     COMPASS_CAL_NOT_STARTED = 0,
     COMPASS_CAL_WAITING_TO_START = 1,
@@ -21,42 +20,52 @@ enum compass_cal_status_t {
 
 class CompassCalibrator {
 public:
-    typedef uint8_t completion_mask_t[10];
-
     CompassCalibrator();
 
+    // set tolerance of calibration (aka fitness)
+    void set_tolerance(float tolerance) { _tolerance = tolerance; }
+
+    // set compass's initial orientation and whether it should be automatically fixed (if required)
+    void set_orientation(enum Rotation orientation, bool is_external, bool fix_orientation);
+
+    // start or stop the calibration
     void start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx);
     void clear();
 
+    // update the state machine and calculate offsets, diagonals and offdiagonals
     void update(bool &failure);
     void new_sample(const Vector3f &sample);
 
     bool check_for_timeout();
 
+    // running is true if actively calculating offsets, diagonals or offdiagonals
     bool running() const;
 
-    void set_orientation(enum Rotation orientation, bool is_external, bool fix_orientation) {
-        _check_orientation = true;
-        _orientation = orientation;
-        _orig_orientation = orientation;
-        _is_external = is_external;
-        _fix_orientation = fix_orientation;
-    }
+    // get status of calibrations progress
+    enum compass_cal_status_t get_status() const { return _status; }
 
-    void set_tolerance(float tolerance) { _tolerance = tolerance; }
-
+    // get calibration outputs (offsets, diagonals, offdiagonals) and fitness
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);
+    float get_fitness() const { return sqrtf(_fitness); }
+
+    // get corrected (and original) orientation
     enum Rotation get_orientation() const { return _orientation; }
     enum Rotation get_original_orientation() const { return _orig_orientation; }
-
-    float get_completion_percent() const;
-    const completion_mask_t& get_completion_mask() const { return _completion_mask; }
-    enum compass_cal_status_t get_status() const { return _status; }
-    float get_fitness() const { return sqrtf(_fitness); }
     float get_orientation_confidence() const { return _orientation_confidence; }
+
+    // get completion percentage (0 to 100) for reporting to GCS
+    float get_completion_percent() const;
+
+    // get how many attempts have been made to calibrate for reporting to GCS
     uint8_t get_attempt() const { return _attempt; }
 
+    // get completion mask for mavlink reporting (a bitmask of faces/directions for which we have compass samples)
+    typedef uint8_t completion_mask_t[10];
+    const completion_mask_t& get_completion_mask() const { return _completion_mask; }
+
 private:
+
+    // results
     class param_t {
     public:
         float* get_sphere_params() {
@@ -67,10 +76,10 @@ private:
             return &offset.x;
         }
 
-        float radius;
-        Vector3f offset;
-        Vector3f diag;
-        Vector3f offdiag;
+        float radius;       // magnetic field strength calculated from samples
+        Vector3f offset;    // offsets
+        Vector3f diag;      // diagonal scaling
+        Vector3f offdiag;   // off diagonal scaling
     };
 
     // compact class for approximate attitude, to save memory
@@ -84,6 +93,7 @@ private:
         int8_t yaw;
     };
 
+    // compact class to hold compass samples, to save memory
     class CompassSample {
     public:
         Vector3f get() const;
@@ -95,40 +105,7 @@ private:
         int16_t z;
     };
 
-    enum Rotation _orientation;
-    enum Rotation _orig_orientation;
-    bool _is_external;
-    bool _check_orientation;
-    bool _fix_orientation;
-    uint8_t _compass_idx;
-
-    enum compass_cal_status_t _status;
-
-    // timeout watchdog state
-    uint32_t _last_sample_ms;
-
-    // behavioral state
-    float _delay_start_sec;
-    uint32_t _start_time_ms;
-    bool _retry;
-    float _tolerance;
-    uint8_t _attempt;
-    uint16_t _offset_max;
-
-    completion_mask_t _completion_mask;
-
-    //fit state
-    class param_t _params;
-    uint16_t _fit_step;
-    CompassSample *_sample_buffer;
-    float _fitness; // mean squared residuals
-    float _initial_fitness;
-    float _sphere_lambda;
-    float _ellipsoid_lambda;
-    uint16_t _samples_collected;
-    uint16_t _samples_thinned;
-    float _orientation_confidence;
-
+    // set status including any required initialisation
     bool set_status(compass_cal_status_t status);
 
     // returns true if sample should be added to buffer
@@ -138,37 +115,78 @@ private:
     // returns true if fit is acceptable
     bool fit_acceptable();
 
+    // clear sample buffer and reset offsets and scaling to their defaults
     void reset_state();
+
+    // initialize fitness before starting a fit
     void initialize_fit();
 
+    // true if enough samples have been collected and fitting has begun (aka runniong())
     bool fitting() const;
 
     // thins out samples between step one and step two
     void thin_samples();
 
+    // calc the fitness of a single sample vs a set of parameters (offsets, diagonals, off diagonals)
     float calc_residual(const Vector3f& sample, const param_t& params) const;
+
+    // calc the fitness of the parameters (offsets, diagonals, off diagonals) vs all the samples collected
+    // returns 1.0e30f if the sample buffer is empty
     float calc_mean_squared_residuals(const param_t& params) const;
     float calc_mean_squared_residuals() const;
 
+    // calculate initial offsets by simply taking the average values of the samples
     void calc_initial_offset();
+
+    // run sphere fit to calculate diagonals and offdiagonals
     void calc_sphere_jacob(const Vector3f& sample, const param_t& params, float* ret) const;
     void run_sphere_fit();
 
+    // run ellipsoid fit to calculate diagonals and offdiagonals
     void calc_ellipsoid_jacob(const Vector3f& sample, const param_t& params, float* ret) const;
     void run_ellipsoid_fit();
 
-    /**
-     * Update #_completion_mask for the geodesic section of \p v. Corrections
-     * are applied to \p v with #_params.
-     *
-     * @param v[in] A vector representing one calibration sample.
-     */
-    void update_completion_mask(const Vector3f& v);
-    /**
-     * Reset and update #_completion_mask with the current samples.
-     */
+    // update the completion mask based on a single sample
+    void update_completion_mask(const Vector3f& sample);
+
+    // reset and updated the completion mask using all samples in the sample buffer
     void update_completion_mask();
 
+    // calculate compass orientation
     Vector3f calculate_earth_field(CompassSample &sample, enum Rotation r);
     bool calculate_orientation();
+
+    uint8_t _compass_idx;                   // index of the compass providing data
+    enum compass_cal_status_t _status;      // current state of calibrator
+    uint32_t _last_sample_ms;               // system time of last sample received for timeout
+
+    // values provided by caller
+    float _delay_start_sec;                 // seconds to delay start of calibration (provided by caller)
+    bool _retry;                            // true if calibration should be restarted on failured (provided by caller)
+    float _tolerance;                       // worst acceptable tolerance (aka fitness).  see set_tolerance()
+    uint16_t _offset_max;                   // maximum acceptable offsets (provided by caller)
+
+    // behavioral state
+    uint32_t _start_time_ms;                // system time start() function was last called
+    uint8_t _attempt;                       // number of attempts have been made to calibrate
+    completion_mask_t _completion_mask;     // bitmask of directions in which we have samples
+    CompassSample *_sample_buffer;          // buffer of sensor values
+    uint16_t _samples_collected;            // number of samples in buffer
+    uint16_t _samples_thinned;              // number of samples removed by the thin_samples() call (called before step 2 begins)
+
+    // fit state
+    class param_t _params;                  // latest calibration outputs
+    uint16_t _fit_step;                     // step during RUNNING_STEP_ONE/TWO which performs sphere fit and ellipsoid fit
+    float _fitness;                         // fitness (mean squared residuals) of current parameters
+    float _initial_fitness;                 // fitness before latest "fit" was attempted (used to determine if fit was an improvement)
+    float _sphere_lambda;                   // sphere fit's lambda
+    float _ellipsoid_lambda;                // ellipsoid fit's lambda
+
+    // variables for orientation checking
+    enum Rotation _orientation;             // latest detected orientation
+    enum Rotation _orig_orientation;        // original orientation provided by caller
+    bool _is_external;                      // true if compass is external (provided by caller)
+    bool _check_orientation;                // true if orientation should be automatically checked
+    bool _fix_orientation;                  // true if orientation should be fixed if necessary
+    float _orientation_confidence;          // measure of confidence in automatic orientation detection
 };


### PR DESCRIPTION
This PR is the result of investigations into issue: https://github.com/ArduPilot/ardupilot/issues/12838.  In the end we think that the diagonals and off-diagonals are not being saved because they would not improve the fit (i.e. there is no error).

This PR includes the following:

- bug fix in the thin_samples method.  This function re-checked if any sensor samples in the buffer are close together (after offsets and diagonals have been updated).  The bug meant each sample to itself and always being removed which led to exactly 1/2 the samples being removed each time.  In one test, after this fix, 127 samples were removed instead of 150.  This is a modified version of the fix in this PR: https://github.com/ArduPilot/ardupilot/pull/12177
- minor bug fix in CompassCalibrator::update's where it would set_status(RUNNING_STEP_TWO) immediately after the compass cal failed although in practice this has no impact because set_status has checks that would the state changing from CAL_FAILED to RUNNING_STEP_TWO.
- get_orientation, get_original_orientation and get_completion_mask are made const
- unused calc_mean_squared_residuals method (the one that took no arguments) is removed
- renamed the "clear" method to "stop" which is a more intuitive name
- significant formatting improvements and comments added


The code in this PR has been extensively tested in SITL and some [results can be seen in this spreadsheet](https://www.dropbox.com/s/ombuyid7612jobj/compass-cal-results.xlsx?dl=0).  It should be clear from inspection that the actual changes are pretty minor.

Thanks very much to @peterbarker, @bugobliterator and @tridge for contributing to the investigation.

