### PR TITLE
Plane: add option to use boost motor in forward flight, tiltrotors and tailsitters only

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -329,7 +329,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: quadplane options
     // @Description: This provides a set of additional control options for quadplanes. LevelTransition means that the wings should be held level to within LEVEL_ROLL_LIMIT degrees during transition to fixed wing flight, and the vehicle will not use the vertical lift motors to climb during the transition. If AllowFWTakeoff bit is not set then fixed wing takeoff on quadplanes will instead perform a VTOL takeoff. If AllowFWLand bit is not set then fixed wing land on quadplanes will instead perform a VTOL land. If respect takeoff frame is not set the vehicle will interpret all takeoff waypoints as an altitude above the corrent position. When Use QRTL is set it will replace QLAND with QRTL for failsafe actions when in VTOL modes.
-    // @Bitmask: 0:LevelTransition,1:AllowFWTakeoff,2:AllowFWLand,3:Respect takeoff frame types,4:Use a fixed wing approach for VTOL landings,5:Use QRTL instead of QLAND for failsafe when in VTOL modes,6:Use idle governor in MANUAL
+    // @Bitmask: 0:LevelTransition,1:AllowFWTakeoff,2:AllowFWLand,3:Respect takeoff frame types,4:Use a fixed wing approach for VTOL landings,5:Use QRTL instead of QLAND for failsafe when in VTOL modes,6:Use idle governor in MANUAL,7:Use boost motor in forward flight (tiltrotors and tailsitters only)
     AP_GROUPINFO("OPTIONS", 58, QuadPlane, options, 0),
 
     AP_SUBGROUPEXTENSION("",59, QuadPlane, var_info2),

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -531,6 +531,7 @@ private:
         OPTION_MISSION_LAND_FW_APPROACH=(1<<4),
         OPTION_FS_QRTL=(1<<5),
         OPTION_IDLE_GOV_MANUAL=(1<<6),
+        OPTION_BOOST_FORWARD_FLIGHT=(1<<7),
     };
 
     AP_Float takeoff_failure_scalar;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -96,7 +96,8 @@ void QuadPlane::tailsitter_output(void)
             }
         }
         // set AP_MotorsMatrix throttles for forward flight
-        motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
+        const bool use_boost = (options & OPTION_BOOST_FORWARD_FLIGHT) != 0;
+        motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt, use_boost);
         return;
     }
 

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -80,8 +80,11 @@ void QuadPlane::tiltrotor_continuous_update(void)
         }
         if (!motor_test.running) {
             // the motors are all the way forward, start using them for fwd thrust
-            uint8_t mask = is_zero(tilt.current_throttle)?0:(uint8_t)tilt.tilt_mask.get();
-            motors->output_motor_mask(tilt.current_throttle, mask, plane.rudder_dt);
+            const uint8_t mask = is_zero(tilt.current_throttle)?0:(uint8_t)tilt.tilt_mask.get();
+            const bool use_boost = (options & OPTION_BOOST_FORWARD_FLIGHT) != 0;
+            motors->output_motor_mask(tilt.current_throttle, mask, plane.rudder_dt, use_boost);
+            // prevent motor shutdown
+            tilt.motors_active = true;
         }
         return;
     }
@@ -163,9 +166,10 @@ void QuadPlane::tiltrotor_binary_update(void)
 
         float new_throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)*0.01f;
         if (tilt.current_tilt >= 1) {
-            uint8_t mask = is_zero(new_throttle)?0:(uint8_t)tilt.tilt_mask.get();
+            const uint8_t mask = is_zero(new_throttle)?0:(uint8_t)tilt.tilt_mask.get();
             // the motors are all the way forward, start using them for fwd thrust
-            motors->output_motor_mask(new_throttle, mask, plane.rudder_dt);
+            const bool use_boost = (options & OPTION_BOOST_FORWARD_FLIGHT) != 0;
+            motors->output_motor_mask(new_throttle, mask, plane.rudder_dt, use_boost);
         }
     } else {
         tiltrotor_binary_slew(false);

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -751,7 +751,7 @@ void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float th
 // output a thrust to all motors that match a given motor mask. This
 // is used to control tiltrotor motors in forward flight. Thrust is in
 // the range 0 to 1
-void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
+void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float rudder_dt, bool use_boost)
 {
     const int16_t pwm_min = get_pwm_output_min();
     const int16_t pwm_range = get_pwm_output_max() - pwm_min;
@@ -772,6 +772,14 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float r
                 rc_write(i, pwm_min);
             }
         }
+    }
+
+    // Output to boost motor
+    if (use_boost) {
+        // boost throttle is in the range 0 to 1000
+        SRV_Channels::set_output_scaled(SRV_Channel::k_boost_throttle, thrust * 1000);
+    } else {
+        SRV_Channels::set_output_scaled(SRV_Channel::k_boost_throttle, 0);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -74,7 +74,7 @@ public:
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
-    virtual void        output_motor_mask(float thrust, uint8_t mask, float rudder_dt);
+    virtual void        output_motor_mask(float thrust, uint8_t mask, float rudder_dt, bool use_boost);
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -338,10 +338,10 @@ void AP_MotorsTri::thrust_compensation(void)
 /*
   override tricopter tail servo output in output_motor_mask
  */
-void AP_MotorsTri::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
+void AP_MotorsTri::output_motor_mask(float thrust, uint8_t mask, float rudder_dt, bool use_boost)
 {
     // normal multicopter output
-    AP_MotorsMulticopter::output_motor_mask(thrust, mask, rudder_dt);
+    AP_MotorsMulticopter::output_motor_mask(thrust, mask, rudder_dt, use_boost);
 
     // and override yaw servo
     rc_write_angle(AP_MOTORS_CH_TRI_YAW, 0);

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -48,7 +48,7 @@ public:
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
     // rudder_dt applys diffential thrust for yaw in the range 0 to 1
-    void                output_motor_mask(float thrust, uint8_t mask, float rudder_dt) override;
+    void                output_motor_mask(float thrust, uint8_t mask, float rudder_dt, bool use_boost) override;
 
     // return the roll factor of any motor, this is used for tilt rotors and tail sitters
     // using copter motors for forward flight


### PR DESCRIPTION
This gives the option to use the boost motor in forward flight, this is actually an improvement because currently the boost motor can be used in Q modes but just stays at its last value in forward flight. This fixes that. 

Tested with a Realflight [model](https://github.com/Fanman74/RealFlight9) from Fanman

https://discuss.ardupilot.org/t/new-tricopter-quadplane-concept/47469?u=iampete