### PR TITLE
COPTER: fix CTUN.ThI logging

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -49,7 +49,7 @@ void Copter::Log_Write_Control_Tuning()
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CONTROL_TUNING_MSG),
         time_us             : AP_HAL::micros64(),
-        throttle_in         : attitude_control->get_throttle_in(),
+        throttle_in         : ((float)channel_throttle->get_control_in())/1000.0f,
         angle_boost         : attitude_control->angle_boost(),
         throttle_out        : motors->get_throttle(),
         throttle_hover      : motors->get_throttle_hover(),


### PR DESCRIPTION
Fixed a bug (presumably in 76a8de8a) - CTUN.ThI logs not pilot's input throttle, but almost the same as ThO (in althold for example).