### PR TITLE
Plane: update tailsitter speedscaling logic

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -263,7 +263,7 @@ const struct LogStructure Plane::log_structure[] = {
     { LOG_STATUS_MSG, sizeof(log_Status),
       "STAT", "QBfBBBBBB",  "TimeUS,isFlying,isFlyProb,Armed,Safety,Crash,Still,Stage,Hit", "s--------", "F--------" },
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
-      "QTUN", "Qffffffeccf", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix", "s----mmmnn-", "F----00000-" },
+      "QTUN", "Qffffffeccff", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl", "s----mmmnn--", "F----00000-0" },
     { LOG_AOA_SSA_MSG, sizeof(log_AOA_SSA),
       "AOA", "Qff", "TimeUS,AOA,SSA", "sdd", "F00" },
     { LOG_PIQR_MSG, sizeof(log_PID), \

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -355,10 +355,10 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
 
     // @Param: TAILSIT_THSCMX
     // @DisplayName: Maximum control throttle scaling value
-    // @Description: Maximum value of throttle scaling for tailsitter velocity scaling, reduce this value to remove low thorottle D ossilaitons 
+    // @Description: Maximum value of throttle scaling for tailsitter velocity scaling, reduce this value to remove low throttle oscillations
     // @Range: 1 5
     // @User: Standard
-    AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 5),
+    AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 2),
 
     // @Param: TRIM_PITCH
     // @DisplayName: Quadplane AHRS trim pitch
@@ -469,6 +469,20 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("ASSIST_ALT", 16, QuadPlane, assist_alt, 0),
+
+    // @Param: TAILSIT_GSCMSK
+    // @DisplayName: Tailsitter gain scaling mask
+    // @Description: Bitmask of gain scaling methods to be applied: BOOST: boost gain at low throttle, ATT_THR: reduce gain at high throttle/tilt, INTERP: interpolate between fixed-wing and copter controls
+    // @User: Standard
+    // @Bitmask: 1:BOOST,2:ATT_THR,4:INTERP
+    AP_GROUPINFO("TAILSIT_GSCMSK", 17, QuadPlane, tailsitter.gain_scaling_mask, TAILSITTER_GSCL_BOOST),
+
+    // @Param: TAILSIT_GSCMIN
+    // @DisplayName: Minimum gain scaling based on throttle and attitude
+    // @Description: Minimum gain scaling at high throttle/tilt angle
+    // @Range: 0.1 1
+    // @User: Standard
+    AP_GROUPINFO("TAILSIT_GSCMIN", 18, QuadPlane, tailsitter.gain_scaling_min, 0.4),
 
     AP_GROUPEND
 };
@@ -811,21 +825,41 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
     check_attitude_relax();
 
     // tailsitter-only bodyframe roll control options
+    // Angle mode attitude control for pitch and body-frame roll, rate control for euler yaw.
     if (is_tailsitter()) {
+        const float euler_pitch = plane.nav_pitch_cd * .01f;
+
+        int16_t roll_limit = MIN(plane.roll_limit_cd, plane.quadplane.aparm.angle_max);
+        // separate limit for tailsitter roll, if set
+        if (plane.quadplane.tailsitter.max_roll_angle > 0) {
+            roll_limit = plane.quadplane.tailsitter.max_roll_angle * 100.0f;
+        }
+        float roll_rate_limit_cds = plane.quadplane.yaw_rate_max * 100.0f;
+
+        float bf_yaw_cds = constrain_float(plane.nav_roll_cd, -roll_rate_limit_cds, roll_rate_limit_cds);
+        float bf_roll_cd = constrain_float(yaw_rate_cds, -roll_limit, roll_limit);
         if (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M) {
-            // Angle mode attitude control for pitch and body-frame roll, rate control for yaw.
-            // this version interprets the first argument as yaw rate and the third as roll angle
-            // because it is intended to be used with Q_TAILSIT_INPUT=1 where the roll and yaw sticks
-            // act in the tailsitter's body frame (i.e. roll is MC/earth frame yaw and
-            // yaw is MC/earth frame roll)
-            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(plane.nav_roll_cd,
+            // If pitch is  small (nose vertical) use roll rate limit for MC yaw rate and roll limit for MC roll angle
+            if (fabsf(euler_pitch) < 30.0f) {
+                float yaw_input_scale = roll_rate_limit_cds / roll_limit;
+                bf_yaw_cds = constrain_float(yaw_input_scale * plane.nav_roll_cd, -roll_rate_limit_cds, roll_rate_limit_cds);
+                bf_roll_cd = constrain_float(yaw_rate_cds, -roll_limit, roll_limit);
+            }
+            // multicopter style: rudder stick controls bodyframe roll when hovering
+            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(bf_yaw_cds,
                                                                                plane.nav_pitch_cd,
-                                                                               yaw_rate_cds);
+                                                                               bf_roll_cd);
             return;
         } else if (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P) {
-            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(plane.nav_roll_cd,
+            // If pitch is  small (nose vertical) use roll rate limit for roll rate and roll limit for bf yaw angle
+            if (fabsf(euler_pitch) < 30.0f) {
+                bf_yaw_cds = constrain_float(plane.nav_roll_cd, -roll_limit, roll_limit);
+                bf_roll_cd = constrain_float(yaw_rate_cds, -roll_rate_limit_cds, roll_rate_limit_cds);
+            }
+            // plane style: rudder stick controls bodyframe yaw when hovering
+            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(bf_yaw_cds,
                                                                                plane.nav_pitch_cd,
-                                                                               yaw_rate_cds);
+                                                                               bf_roll_cd);
             return;
         }
     }
@@ -1023,9 +1057,8 @@ void QuadPlane::control_qacro(void)
         float target_yaw = 0;
         if (is_tailsitter()) {
             // Note that the 90 degree Y rotation for copter mode swaps body-frame roll and yaw
-            // acro_roll_rate param applies to yaw in copter frame
-            target_roll =  plane.channel_rudder->norm_input() * acro_roll_rate * 100.0f;
-            target_yaw  = -plane.channel_roll->norm_input() * acro_yaw_rate * 100.0f;
+            target_roll =  plane.channel_rudder->norm_input() * acro_yaw_rate * 100.0f;
+            target_yaw  = -plane.channel_roll->norm_input() * acro_roll_rate * 100.0f;
         } else {
             target_roll = plane.channel_roll->norm_input() * acro_roll_rate * 100.0f;
             target_yaw  = plane.channel_rudder->norm_input() * acro_yaw_rate * 100.0;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -443,24 +443,23 @@ private:
         bool motors_active:1;
     } tilt;
 
+    // bit 0 enables plane mode and bit 1 enables body-frame roll mode
     enum tailsitter_input {
-        TAILSITTER_INPUT_MULTICOPTER = 0,
-        TAILSITTER_INPUT_PLANE       = 1,
-        TAILSITTER_INPUT_BF_ROLL_M   = 2,
-        TAILSITTER_INPUT_BF_ROLL_P   = 3,
+        TAILSITTER_INPUT_PLANE   = (1U<<0),
+        TAILSITTER_INPUT_BF_ROLL = (1U<<1)
     };
 
     enum tailsitter_mask {
-        TAILSITTER_MASK_AILERON  = 1,
-        TAILSITTER_MASK_ELEVATOR = 2,
-        TAILSITTER_MASK_THROTTLE = 4,
-        TAILSITTER_MASK_RUDDER   = 8,
+        TAILSITTER_MASK_AILERON  = (1U<<0),
+        TAILSITTER_MASK_ELEVATOR = (1U<<1),
+        TAILSITTER_MASK_THROTTLE = (1U<<2),
+        TAILSITTER_MASK_RUDDER   = (1U<<3),
     };
 
     enum tailsitter_gscl_mask {
-        TAILSITTER_GSCL_BOOST  = 1,
-        TAILSITTER_GSCL_ATT_THR = 2,
-        TAILSITTER_GSCL_INTERP = 4,
+        TAILSITTER_GSCL_BOOST   = (1U<<0),
+        TAILSITTER_GSCL_ATT_THR = (1U<<1),
+        TAILSITTER_GSCL_INTERP  = (1U<<2),
     };
 
     // tailsitter control variables

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -124,9 +124,9 @@ public:
     // check if we have completed transition to vtol
     bool tailsitter_transition_vtol_complete(void) const;
 
-    // account for surface speed scaling in hover
+    // account for control surface speed scaling in VTOL modes
     void tailsitter_speed_scaling(void);
-    
+
     // user initiated takeoff for guided mode
     bool do_user_takeoff(float takeoff_altitude);
 
@@ -455,7 +455,13 @@ private:
         TAILSITTER_MASK_THROTTLE = 4,
         TAILSITTER_MASK_RUDDER   = 8,
     };
-    
+
+    enum tailsitter_gscl_mask {
+        TAILSITTER_GSCL_BOOST  = 1,
+        TAILSITTER_GSCL_ATT_THR = 2,
+        TAILSITTER_GSCL_INTERP = 4,
+    };
+
     // tailsitter control variables
     struct {
         AP_Int8 transition_angle;
@@ -466,9 +472,16 @@ private:
         AP_Float vectored_hover_gain;
         AP_Float vectored_hover_power;
         AP_Float throttle_scale_max;
+        AP_Float gain_scaling_min;
         AP_Float max_roll_angle;
         AP_Int16 motor_mask;
+        AP_Float scaling_speed_min;
+        AP_Float scaling_speed_max;
+        AP_Int8 gain_scaling_mask;
     } tailsitter;
+
+    // tailsitter speed scaler
+    float last_spd_scaler = 1.0f;
 
     // the attitude view of the VTOL attitude controller
     AP_AHRS_View *ahrs_view;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -149,6 +149,7 @@ public:
         int16_t  target_climb_rate;
         int16_t  climb_rate;
         float    throttle_mix;
+        float    speed_scaler;
     };
 
     MAV_TYPE get_mav_type(void) const;
@@ -477,7 +478,7 @@ private:
         AP_Int16 motor_mask;
         AP_Float scaling_speed_min;
         AP_Float scaling_speed_max;
-        AP_Int8 gain_scaling_mask;
+        AP_Int16 gain_scaling_mask;
     } tailsitter;
 
     // tailsitter speed scaler

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -217,8 +217,7 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
 void QuadPlane::tailsitter_check_input(void)
 {
     if (tailsitter_active() &&
-        (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P ||
-         tailsitter.input_type == TAILSITTER_INPUT_PLANE)) {
+        (tailsitter.input_type & TAILSITTER_INPUT_PLANE)) {
         // the user has asked for body frame controls when tailsitter
         // is active. We switch around the control_in value for the
         // channels to do this, as that ensures the value is

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -217,8 +217,8 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
 void QuadPlane::tailsitter_check_input(void)
 {
     if (tailsitter_active() &&
-        (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M ||
-         tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P ||
+        (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P ||
+         tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M ||
          tailsitter.input_type == TAILSITTER_INPUT_PLANE)) {
         // the user has asked for body frame controls when tailsitter
         // is active. We switch around the control_in value for the

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -218,7 +218,6 @@ void QuadPlane::tailsitter_check_input(void)
 {
     if (tailsitter_active() &&
         (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P ||
-         tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M ||
          tailsitter.input_type == TAILSITTER_INPUT_PLANE)) {
         // the user has asked for body frame controls when tailsitter
         // is active. We switch around the control_in value for the

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -18,6 +18,7 @@
   to a configuration supported by AP_MotorsMatrix
  */
 
+#include <math.h>
 #include "Plane.h"
 
 /*
@@ -103,7 +104,7 @@ void QuadPlane::tailsitter_output(void)
     }
 
     // handle VTOL modes
-    // the MultiCopter rate controller has already been run in an earlier call 
+    // the MultiCopter rate controller has already been run in an earlier call
     // to motors_output() from quadplane.update()
     motors_output(false);
     plane.pitchController.reset_I();
@@ -129,11 +130,12 @@ void QuadPlane::tailsitter_output(void)
           power law. This allows the motors to point straight up for
           takeoff without integrator windup
          */
-        int32_t pitch_error_cd = (plane.nav_pitch_cd - ahrs_view->pitch_sensor) * 0.5;
+        float des_pitch_cd = attitude_control->get_att_target_euler_cd().y;
+        int32_t pitch_error_cd = (des_pitch_cd - ahrs_view->pitch_sensor) * 0.5;
         float extra_pitch = constrain_float(pitch_error_cd, -SERVO_MAX, SERVO_MAX) / SERVO_MAX;
         float extra_sign = extra_pitch > 0?1:-1;
         float extra_elevator = 0;
-        if (!is_zero(extra_pitch)) {
+        if (!is_zero(extra_pitch) && in_vtol_mode()) {
             extra_elevator = extra_sign * powf(fabsf(extra_pitch), tailsitter.vectored_hover_power) * SERVO_MAX;
         }
         tilt_left  = extra_elevator + tilt_left * tailsitter.vectored_hover_gain;
@@ -215,8 +217,8 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
 void QuadPlane::tailsitter_check_input(void)
 {
     if (tailsitter_active() &&
-        (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P ||
-         tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M ||
+        (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M ||
+         tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P ||
          tailsitter.input_type == TAILSITTER_INPUT_PLANE)) {
         // the user has asked for body frame controls when tailsitter
         // is active. We switch around the control_in value for the
@@ -244,95 +246,70 @@ void QuadPlane::tailsitter_speed_scaling(void)
 {
     const float hover_throttle = motors->get_throttle_hover();
     const float throttle = motors->get_throttle();
-    float spd_scaler = 1;
+    float spd_scaler = 1.0f;
 
-    // If throttle_scale_max is > 1, boost gains at low throttle
-    if (tailsitter.throttle_scale_max > 1) {
-        if (is_zero(throttle)) {
-            spd_scaler = tailsitter.throttle_scale_max;
-        } else {
-            spd_scaler = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
-        }
-    } else {
+    if (tailsitter.gain_scaling_mask & TAILSITTER_GSCL_ATT_THR) {
         // reduce gains when flying at high speed in Q modes:
 
         // critical parameter: violent oscillations if too high
         // sudden loss of attitude control if too low
-        constexpr float max_atten = 0.2f;
+        const float min_scale = tailsitter.gain_scaling_min;
         float tthr = 1.25f * hover_throttle;
-        float aspeed;
-        bool airspeed_enabled = ahrs.airspeed_sensor_enabled();
 
-        // If there is an airspeed sensor use the measured airspeed
-        // The airspeed estimate based only on GPS and (estimated) wind is
-        // not sufficiently accurate for tailsitters.
-        // (based on tests in RealFlight 8 with 10kph wind)
-        if (airspeed_enabled && ahrs.airspeed_estimate(&aspeed)) {
-            // plane.get_speed_scaler() doesn't work well for copter tailsitters
-            // ramp down from 1 to max_atten as speed increases to airspeed_max
-            spd_scaler = constrain_float(1 - (aspeed / plane.aparm.airspeed_max), max_atten, 1.0f);
-        } else {
-            // if no airspeed sensor reduce control surface throws at large tilt
-            // angles (assuming high airspeed)
-            // ramp down from 1 to max_atten at tilt angles over trans_angle
-            // (angles here are represented by their cosines)
+        // reduce control surface throws at large tilt
+        // angles (assuming high airspeed)
+        // ramp down from 1 to max_atten at tilt angles over trans_angle
+        // (angles here are represented by their cosines)
 
-            // Note that the cosf call will be necessary if trans_angle becomes a parameter
-            // but the C language spec does not guarantee that trig functions can be used
-            // in constant expressions, even though gcc currently allows it.
-            constexpr float c_trans_angle = 0.9238795; // cosf(.125f * M_PI)
+        // Note that the cosf call will be necessary if trans_angle becomes a parameter
+        // but the C language spec does not guarantee that trig functions can be used
+        // in constant expressions, even though gcc currently allows it.
+        constexpr float c_trans_angle = 0.9238795; // cosf(.125f * M_PI)
 
-            // alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(90)));
-            constexpr float alpha = (1 - max_atten) / c_trans_angle;
-            constexpr float beta = 1 - alpha * c_trans_angle;
+        // alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(90)));
+        const float alpha = (1 - min_scale) / c_trans_angle;
+        const float beta = 1 - alpha * c_trans_angle;
 
-            const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
-            if (c_tilt < c_trans_angle) {
-                spd_scaler = constrain_float(beta + alpha * c_tilt, max_atten, 1.0f);
-                // reduce throttle attenuation threshold too
-                tthr = 0.5f * hover_throttle;
-            }
+        const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
+        if (c_tilt < c_trans_angle) {
+            spd_scaler = constrain_float(beta + alpha * c_tilt, min_scale, 1.0f);
+            // reduce throttle attenuation threshold too
+            tthr = 0.5f * hover_throttle;
         }
         // if throttle is above hover thrust, apply additional attenuation
         if (throttle > tthr) {
             const float throttle_atten = 1 - (throttle - tthr) / (1 - tthr);
             spd_scaler *= throttle_atten;
-            spd_scaler = constrain_float(spd_scaler, max_atten, 1.0f);
+            spd_scaler = constrain_float(spd_scaler, min_scale, 1.0f);
         }
-    }
-    // limit positive and negative slew rates of applied speed scaling
-    constexpr float posTC = 5.0f;   // seconds
-    constexpr float negTC = 2.0f;   // seconds
-    const float posdelta = plane.G_Dt / posTC;
-    const float negdelta = plane.G_Dt / negTC;
-    static float last_scale = 0;
-    static float scale = 0;
-    if ((spd_scaler - last_scale) > 0) {
-        if ((spd_scaler - last_scale) > posdelta) {
-            scale += posdelta;
-        } else {
-            scale = spd_scaler;
-        }
-    } else {
-        if ((spd_scaler - last_scale) < -negdelta) {
-            scale -= negdelta;
-        } else {
-            scale = spd_scaler;
-        }
-    }
-    last_scale = scale;
 
-    const SRV_Channel::Aux_servo_function_t functions[5] = {
+        // limit positive and negative slew rates of applied speed scaling
+        constexpr float posTC = 2.0f;   // seconds
+        constexpr float negTC = 1.0f;   // seconds
+        const float posdelta = plane.G_Dt / posTC;
+        const float negdelta = plane.G_Dt / negTC;
+        spd_scaler = constrain_float(spd_scaler, last_spd_scaler - negdelta, last_spd_scaler + posdelta);
+        last_spd_scaler = spd_scaler;
+    }
+
+    // if gain attenuation isn't active and boost is enabled
+    if ((spd_scaler >= 1.0f) && (tailsitter.gain_scaling_mask & TAILSITTER_GSCL_BOOST)) {
+        // boost gains at low throttle
+        if (is_zero(throttle)) {
+            spd_scaler = tailsitter.throttle_scale_max;
+        } else {
+            spd_scaler = constrain_float(hover_throttle / throttle, 1.0f, tailsitter.throttle_scale_max);
+        }
+    }
+
+    const SRV_Channel::Aux_servo_function_t functions[] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,
-        SRV_Channel::Aux_servo_function_t::k_rudder,
-        SRV_Channel::Aux_servo_function_t::k_tiltMotorLeft,
-        SRV_Channel::Aux_servo_function_t::k_tiltMotorRight};
+        SRV_Channel::Aux_servo_function_t::k_rudder};
     for (uint8_t i=0; i<ARRAY_SIZE(functions); i++) {
         int32_t v = SRV_Channels::get_output_scaled(functions[i]);
-        v *= scale;
+        v *= spd_scaler;
         v = constrain_int32(v, -SERVO_MAX, SERVO_MAX);
         SRV_Channels::set_output_scaled(functions[i], v);
     }
 }
-

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -344,14 +344,18 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw(float euler_roll_angle
     attitude_controller_run_quat();
 }
 
-// Command euler pitch and yaw angles and roll rate (used only by tailsitter quadplanes)
-// Multicopter style controls: roll stick is tailsitter bodyframe yaw in hover
-void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float euler_yaw_rate_cds, float euler_pitch_cd, float body_roll_cd)
+// Command euler yaw rate and pitch angle with roll angle specified in body frame
+// (used only by tailsitter quadplanes)
+// If plane_controls is true, swap the effects of roll and yaw as euler pitch approaches 90 degrees
+void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float euler_yaw_rate_cds, float euler_pitch_cd, float body_roll_cd)
 {
     // Convert from centidegrees on public interface to radians
     float euler_yaw_rate = radians(euler_yaw_rate_cds*0.01f);
     float euler_pitch = radians(constrain_float(euler_pitch_cd * 0.01f, -90.0f, 90.0f));
     float body_roll   = radians(constrain_float(body_roll_cd   * 0.01f, -90.0f, 90.0f));
+
+    const float cpitch = cosf(euler_pitch);
+    const float spitch = fabsf(sinf(euler_pitch));
 
     // Compute attitude error
     Quaternion attitude_vehicle_quat;
@@ -362,16 +366,18 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float 
     error_quat.to_axis_angle(att_error);
 
     // limit yaw error
-    if (fabsf(att_error.z) < AC_ATTITUDE_THRUST_ERROR_ANGLE) {
+    if (fabsf(att_error.z) < 2*AC_ATTITUDE_THRUST_ERROR_ANGLE) {
         // update heading
-        _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + euler_yaw_rate * _dt);
+        if (plane_controls) {
+            float yaw_rate = euler_yaw_rate * spitch + body_roll * cpitch;
+            _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + yaw_rate * _dt);
+        } else {
+            _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + euler_yaw_rate * _dt);
+        }
     }
 
     // init attitude target to desired euler yaw and pitch with zero roll
     _attitude_target_quat.from_euler(0, euler_pitch, _attitude_target_euler_angle.z);
-
-    const float cpitch = cosf(euler_pitch);
-    const float spitch = fabsf(sinf(euler_pitch));
 
     // apply body-frame yaw/roll (this is roll/yaw for a tailsitter in forward flight)
     // rotate body_roll axis by |sin(pitch angle)|
@@ -380,70 +386,15 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float 
 
     // rotate body_yaw axis by cos(pitch angle)
     Quaternion bf_yaw_Q;
-    bf_yaw_Q.from_axis_angle(Vector3f(-cpitch * body_roll, 0, 0));
+    if (plane_controls) {
+        bf_yaw_Q.from_axis_angle(Vector3f(cpitch, 0, 0), euler_yaw_rate);
+    } else {
+        bf_yaw_Q.from_axis_angle(Vector3f(-cpitch * body_roll, 0, 0));
+    }
     _attitude_target_quat = _attitude_target_quat * bf_roll_Q * bf_yaw_Q;
 
     // _attitude_target_euler_angle roll and pitch: Note: roll/yaw will be indeterminate when pitch is near +/-90
     // These should be used only for logging target eulers, with the caveat noted above.
-    // Also note that _attitude_target_quat.from_euler() should only be used in special circumstances
-    // such as when attitude is specified directly in terms of Euler angles.
-    //    _attitude_target_euler_angle.x = _attitude_target_quat.get_euler_roll();
-    //    _attitude_target_euler_angle.y = euler_pitch;
-
-    // Set rate feedforward requests to zero
-    _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-    _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
-
-    // Compute attitude error
-    error_quat = attitude_vehicle_quat.inverse() * _attitude_target_quat;
-    error_quat.to_axis_angle(att_error);
-
-    // Compute the angular velocity target from the attitude error
-    _rate_target_ang_vel = update_ang_vel_target_from_att_error(att_error);
-}
-
-// Command euler pitch and yaw angles and roll rate (used only by tailsitter quadplanes)
-// Plane style controls: yaw stick is tailsitter bodyframe yaw in hover
-void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(float euler_yaw_rate_cds, float euler_pitch_cd, float body_roll_cd)
-{
-    // Convert from centidegrees on public interface to radians
-    float euler_yaw_rate = radians(euler_yaw_rate_cds*0.01f);
-    float euler_pitch = radians(constrain_float(euler_pitch_cd * 0.01f, -90.0f, 90.0f));
-    float body_roll   = radians(constrain_float(body_roll_cd   * 0.01f, -90.0f, 90.0f));
-
-    const float cpitch = cosf(euler_pitch);
-    const float spitch = fabsf(sinf(euler_pitch));
-
-    // Compute attitude error
-    Quaternion attitude_vehicle_quat;
-    Quaternion error_quat;
-    attitude_vehicle_quat.from_rotation_matrix(_ahrs.get_rotation_body_to_ned());
-    error_quat = attitude_vehicle_quat.inverse() * _attitude_target_quat;
-    Vector3f att_error;
-    error_quat.to_axis_angle(att_error);
-
-    // limit yaw error
-    if (fabsf(att_error.z) < AC_ATTITUDE_THRUST_ERROR_ANGLE) {
-        // update heading
-        float yaw_rate = euler_yaw_rate * spitch + body_roll * cpitch;
-        _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + yaw_rate * _dt);
-    }
-
-    // init attitude target to desired euler yaw and pitch with zero roll
-    _attitude_target_quat.from_euler(0, euler_pitch, _attitude_target_euler_angle.z);
-
-    // apply body-frame yaw/roll (this is roll/yaw for a tailsitter in forward flight)
-    // rotate body_roll axis by |sin(pitch angle)|
-    Quaternion bf_roll_Q;
-    bf_roll_Q.from_axis_angle(Vector3f(0, 0, spitch * body_roll));
-
-    // rotate body_yaw axis by cos(pitch angle)
-    Quaternion bf_yaw_Q;
-    bf_yaw_Q.from_axis_angle(Vector3f(cpitch, 0, 0), euler_yaw_rate);
-    _attitude_target_quat = _attitude_target_quat * bf_roll_Q * bf_yaw_Q;
-
-    // _attitude_target_euler_angle roll and pitch: Note: roll/yaw will be indeterminate when pitch is near +/-90
-    // These should be used only for logging target eulers, with the caveat noted above
     // Also note that _attitude_target_quat.from_euler() should only be used in special circumstances
     // such as when attitude is specified directly in terms of Euler angles.
     //    _attitude_target_euler_angle.x = _attitude_target_quat.get_euler_roll();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -347,12 +347,12 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw(float euler_roll_angle
 // Command euler yaw rate and pitch angle with roll angle specified in body frame
 // (used only by tailsitter quadplanes)
 // If plane_controls is true, swap the effects of roll and yaw as euler pitch approaches 90 degrees
-void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float euler_yaw_rate_cds, float euler_pitch_cd, float body_roll_cd)
+void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float body_roll_cd, float euler_pitch_cd, float euler_yaw_rate_cds)
 {
     // Convert from centidegrees on public interface to radians
     float euler_yaw_rate = radians(euler_yaw_rate_cds*0.01f);
-    float euler_pitch = radians(constrain_float(euler_pitch_cd * 0.01f, -90.0f, 90.0f));
-    float body_roll   = radians(constrain_float(body_roll_cd   * 0.01f, -90.0f, 90.0f));
+    float euler_pitch    = radians(constrain_float(euler_pitch_cd * 0.01f, -90.0f, 90.0f));
+    float body_roll      = radians(-body_roll_cd * 0.01f);
 
     const float cpitch = cosf(euler_pitch);
     const float spitch = fabsf(sinf(euler_pitch));
@@ -365,16 +365,18 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool pla
     Vector3f att_error;
     error_quat.to_axis_angle(att_error);
 
-    // limit yaw error
-    if (fabsf(att_error.z) < 2*AC_ATTITUDE_THRUST_ERROR_ANGLE) {
-        // update heading
-        if (plane_controls) {
-            float yaw_rate = euler_yaw_rate * spitch + body_roll * cpitch;
-            _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + yaw_rate * _dt);
-        } else {
-            _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + euler_yaw_rate * _dt);
-        }
+    // update heading
+    float yaw_rate = euler_yaw_rate;
+    if (plane_controls) {
+        yaw_rate = (euler_yaw_rate * spitch) + (body_roll * cpitch);
     }
+    // limit yaw error
+    float yaw_error = fabsf(att_error.z);
+    float error_ratio = yaw_error / M_PI_2;
+    if (error_ratio > 1) {
+        yaw_rate /= (error_ratio * error_ratio);
+    }
+    _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + yaw_rate * _dt);
 
     // init attitude target to desired euler yaw and pitch with zero roll
     _attitude_target_quat.from_euler(0, euler_pitch, _attitude_target_euler_angle.z);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -135,13 +135,9 @@ public:
     // Command an euler roll, pitch and yaw angle with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, bool slew_yaw);
 
-    // Command euler yaw rate and pitch angle with roll angle specified in body frame with multicopter style controls
+    // Command euler yaw rate and pitch angle with roll angle specified in body frame
     // (used only by tailsitter quadplanes)
-    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
-
-    // Command euler yaw rate and pitch angle with roll angle specified in body frame with plane style controls
-    // (used only by tailsitter quadplanes)
-    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
+    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float euler_yaw_rate_cds, float euler_pitch_angle_cd, float euler_roll_angle_cd);
 
     // Command an euler roll, pitch, and yaw rate with angular velocity feedforward and smoothing
     void input_euler_rate_roll_pitch_yaw(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -137,7 +137,7 @@ public:
 
     // Command euler yaw rate and pitch angle with roll angle specified in body frame
     // (used only by tailsitter quadplanes)
-    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float euler_yaw_rate_cds, float euler_pitch_angle_cd, float euler_roll_angle_cd);
+    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
 
     // Command an euler roll, pitch, and yaw rate with angular velocity feedforward and smoothing
     void input_euler_rate_roll_pitch_yaw(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds);

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.h
@@ -22,6 +22,8 @@ public:
     virtual void        output_motor_mask(float thrust, uint8_t mask, float rudder_dt) override;
 
 protected:
+    bool enable_yaw_torque;    // differential torque for yaw control
+
     // configures the motors for the defined frame_class and frame_type
     virtual void        setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -59,6 +59,8 @@ public:
         MOTOR_FRAME_TYPE_DJI_X = 13, // X frame, DJI ordering
         MOTOR_FRAME_TYPE_CW_X = 14, // X frame, clockwise ordering
         MOTOR_FRAME_TYPE_I = 15, // (sideways H) octo only
+        MOTOR_FRAME_TYPE_NYT_PLUS = 16, // plus frame, no differential torque for yaw
+        MOTOR_FRAME_TYPE_NYT_X = 17, // X frame, no differential torque for yaw
     };
 
     // Constructor


### PR DESCRIPTION
add tailsitter gain scaling option mask and logging
apply roll limit in tailsitter bodyframe roll control
add define for future exclusion of tailsitter gainscaling debug code/logging
tailsitter bodyframe roll and qacro input scaling bugfixes:
  respect Q_TAILSIT_RLL_MX and roll/yaw scale parameters in bodyframe roll modes
  fix unintended swap of Q_ACRO_RLL/YAW_RATE params in QACRO mode

This is a subset of flight test code (https://github.com/ArduPilot/ardupilot/pull/12869)
It contains the speed scaling method which has been flight tested by @losawing on both dual-motor tailsitter (frame class 10) and quad (frame class 1 with Q_TAILSIT_MOTMX=0xF) "copter" tailsitter vehicles. It omits the gain interpolation method and other non-tailsitter related changes in order to simplify this PR and limit it to flight tested code. 

log of SITL test of rebased PR with both (legacy) BOOST (THSCMX=2) and ATT_THR (GSCMIN=.2) scaling methods enabled (note that scale factor ranges from 0.2 to 2.0 depending on throttle and attitude) "unknown" flight mode is QACRO:
![image](https://user-images.githubusercontent.com/2300221/69486730-fbca7500-0e0b-11ea-935e-6d8b1ff8b524.png)
