### PR TITLE
AP_Scripting: add mission bindings and example

### DIFF
--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -397,6 +397,9 @@ public:
     uint16_t get_current_nav_index() const { 
         return _nav_cmd.index==AP_MISSION_CMD_INDEX_NONE?0:_nav_cmd.index; }
 
+    /// get_current_nav_id - return the id of the current nav command
+    uint16_t get_current_nav_id() const { return _nav_cmd.id; }
+
     /// get_prev_nav_cmd_id - returns the previous "navigation" command id
     ///     if there was no previous nav command it returns AP_MISSION_CMD_ID_NONE
     ///     we do not return the entire command to save on RAM
@@ -424,6 +427,9 @@ public:
 
     /// get_current_do_cmd - returns active "do" command
     const Mission_Command& get_current_do_cmd() const { return _do_cmd; }
+
+    /// get_current_do_cmd_id - returns id of the active "do" command
+    uint16_t get_current_do_cmd_id() const { return _do_cmd.id; }
 
     // set_current_cmd - jumps to command specified by index
     bool set_current_cmd(uint16_t index);

--- a/libraries/AP_Scripting/examples/Mission_test.lua
+++ b/libraries/AP_Scripting/examples/Mission_test.lua
@@ -1,0 +1,49 @@
+-- This script is a test for AP_Mission bindings
+
+local last_mission_index = mission:get_current_nav_index()
+
+function update() -- this is the loop which periodically runs
+
+  local mission_state = mission:state()
+
+  -- make sure the mission is running
+  if mission_state == mission.MISSION_COMPLETE then
+    gcs:send_text(0, "LUA: Mission Complete")
+    return update, 1000 -- reschedules the loop
+  elseif mission_state == mission.MISSION_STOPPED then
+    gcs:send_text(0, "LUA: Mission stopped")
+    return update, 1000 -- reschedules the loop
+  end
+
+  local mission_index = mission:get_current_nav_index()
+
+  -- see if we have changed since we last checked
+  if mission_index ~= last_mission_index then
+
+    gcs:send_text(0, "LUA: New Mission Item") -- we spotted a change
+
+    -- print the current and previous nav commands
+    gcs:send_text(0, string.format("Prev: %d, Current: %d",mission:get_prev_nav_cmd_id(),mission:get_current_nav_id()))
+
+    last_mission_index = mission_index;
+
+    -- num commands includes home so - 1
+    local mission_length = mission:num_commands() - 1
+    if mission_length > 1 and mission_index == mission_length then
+      local jump_to = 1
+      if mission_length > 2 then
+        -- jump back to a random mission item
+        jump_to = math.random(mission_length - 1)  -- no point jump to the end so - 1
+      end
+      if mission:set_current_cmd(jump_to) then
+        gcs:send_text(0, string.format("LUA: jumped to mission item %d",jump_to))
+      else
+        gcs:send_text(0, "LUA: mission item jump failed")
+      end
+    end
+  end
+
+  return update, 1000 -- reschedules the loop
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -193,3 +193,15 @@ singleton AP_Param alias param
 singleton AP_Param method get boolean string float'Null
 singleton AP_Param method set boolean string float -FLT_MAX FLT_MAX
 singleton AP_Param method set_and_save boolean string float -FLT_MAX FLT_MAX
+
+include AP_Mission/AP_Mission.h
+singleton AP_Mission alias mission
+singleton AP_Mission scheduler-semaphore
+singleton AP_Mission enum MISSION_STOPPED MISSION_RUNNING MISSION_COMPLETE
+singleton AP_Mission method state uint8_t
+singleton AP_Mission method get_current_nav_index uint16_t
+singleton AP_Mission method set_current_cmd boolean uint16_t 0 UINT16_MAX
+singleton AP_Mission method get_prev_nav_cmd_id uint16_t
+singleton AP_Mission method get_current_nav_id uint16_t
+singleton AP_Mission method get_current_do_cmd_id uint16_t
+singleton AP_Mission method num_commands uint16_t

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -200,7 +200,7 @@ singleton AP_Mission scheduler-semaphore
 singleton AP_Mission enum MISSION_STOPPED MISSION_RUNNING MISSION_COMPLETE
 singleton AP_Mission method state uint8_t
 singleton AP_Mission method get_current_nav_index uint16_t
-singleton AP_Mission method set_current_cmd boolean uint16_t 0 UINT16_MAX
+singleton AP_Mission method set_current_cmd boolean uint16_t 0 (ud->num_commands()-1) 
 singleton AP_Mission method get_prev_nav_cmd_id uint16_t
 singleton AP_Mission method get_current_nav_id uint16_t
 singleton AP_Mission method get_current_do_cmd_id uint16_t

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,6 +1,7 @@
 // auto generated bindings, don't manually edit.  See README.md for details.
 #include "lua_generated_bindings.h"
 #include "lua_boxed_numerics.h"
+#include <AP_Mission/AP_Mission.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <AP_Baro/AP_Baro.h>
@@ -531,6 +532,115 @@ const luaL_Reg Location_meta[] = {
     {"get_distance", Location_get_distance},
     {NULL, NULL}
 };
+
+static int AP_Mission_num_commands(lua_State *L) {
+    AP_Mission * ud = AP_Mission::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "mission not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
+    const uint16_t data = ud->num_commands();
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_Mission_get_current_do_cmd_id(lua_State *L) {
+    AP_Mission * ud = AP_Mission::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "mission not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
+    const uint16_t data = ud->get_current_do_cmd_id();
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_Mission_get_current_nav_id(lua_State *L) {
+    AP_Mission * ud = AP_Mission::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "mission not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
+    const uint16_t data = ud->get_current_nav_id();
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_Mission_get_prev_nav_cmd_id(lua_State *L) {
+    AP_Mission * ud = AP_Mission::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "mission not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
+    const uint16_t data = ud->get_prev_nav_cmd_id();
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_Mission_set_current_cmd(lua_State *L) {
+    AP_Mission * ud = AP_Mission::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "mission not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN((ud->num_commands()-1), UINT16_MAX))), 2, "argument out of range");
+    const uint16_t data_2 = static_cast<uint16_t>(raw_data_2);
+    AP::scheduler().get_semaphore().take_blocking();
+    const bool data = ud->set_current_cmd(
+            data_2);
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_Mission_get_current_nav_index(lua_State *L) {
+    AP_Mission * ud = AP_Mission::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "mission not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
+    const uint16_t data = ud->get_current_nav_index();
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_Mission_state(lua_State *L) {
+    AP_Mission * ud = AP_Mission::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "mission not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
+    const uint8_t data = ud->state();
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushinteger(L, data);
+    return 1;
+}
 
 static int AP_Param_set_and_save(lua_State *L) {
     AP_Param * ud = AP_Param::get_singleton();
@@ -2049,6 +2159,17 @@ static int AP_AHRS_get_roll(lua_State *L) {
     return 1;
 }
 
+const luaL_Reg AP_Mission_meta[] = {
+    {"num_commands", AP_Mission_num_commands},
+    {"get_current_do_cmd_id", AP_Mission_get_current_do_cmd_id},
+    {"get_current_nav_id", AP_Mission_get_current_nav_id},
+    {"get_prev_nav_cmd_id", AP_Mission_get_prev_nav_cmd_id},
+    {"set_current_cmd", AP_Mission_set_current_cmd},
+    {"get_current_nav_index", AP_Mission_get_current_nav_index},
+    {"state", AP_Mission_state},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_Param_meta[] = {
     {"set_and_save", AP_Param_set_and_save},
     {"set", AP_Param_set},
@@ -2287,6 +2408,12 @@ struct userdata_enum {
     int value;
 };
 
+struct userdata_enum AP_Mission_enums[] = {
+    {"MISSION_COMPLETE", AP_Mission::MISSION_COMPLETE},
+    {"MISSION_RUNNING", AP_Mission::MISSION_RUNNING},
+    {"MISSION_STOPPED", AP_Mission::MISSION_STOPPED},
+    {NULL, 0}};
+
 struct userdata_enum AP_Terrain_enums[] = {
     {"TerrainStatusOK", AP_Terrain::TerrainStatusOK},
     {"TerrainStatusUnhealthy", AP_Terrain::TerrainStatusUnhealthy},
@@ -2316,6 +2443,7 @@ const struct userdata_meta userdata_fun[] = {
 };
 
 const struct userdata_meta singleton_fun[] = {
+    {"mission", AP_Mission_meta, AP_Mission_enums},
     {"param", AP_Param_meta, NULL},
     {"esc_telem", AP_ESC_Telem_meta, NULL},
     {"baro", AP_Baro_meta, NULL},
@@ -2388,6 +2516,7 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
+    "mission",
     "param",
     "esc_telem",
     "baro",

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 // auto generated bindings, don't manually edit.  See README.md for details.
+#include <AP_Mission/AP_Mission.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <AP_Baro/AP_Baro.h>


### PR DESCRIPTION
This work was funded by 3DXR.

This adds bindings for missions to scripting and a fun example that randomly resets the mission item once the end of a mission is reached.

The only thing I'm having an issue with is the mission status. If I use the enum it doesn't work as expected, I couldn't find a enum example so its quite possible its a PEBKAC.

 

