### PR TITLE
Tools: install ardupilot deps as non-root in Docker 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-instal
     lsb-release \
     sudo \
     software-properties-common \
-    python-software-properties && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    python-software-properties
 
 ENV USER=ardupilot
 ADD . /ardupilot
-RUN chown -R ardupilot:ardupilot /ardupilot && \
-    bash -c "Tools/environment_install/install-prereqs-ubuntu.sh -y && apt-get install gcc-arm-none-eabi -y" && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN echo "ardupilot ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ardupilot
+RUN chmod 0440 /etc/sudoers.d/ardupilot
+
+RUN chown -R ardupilot:ardupilot /ardupilot
 
 USER ardupilot
+RUN bash -c "Tools/environment_install/install-prereqs-ubuntu.sh -y"
+RUN sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 ENV CCACHE_MAXSIZE=1G
 ENV PATH /usr/lib/ccache:/ardupilot/Tools:${PATH}
+ENV PATH /ardupilot/Tools/autotest:${PATH}
+ENV PATH /ardupilot/.local/bin:$PATH


### PR DESCRIPTION
Fixes: https://github.com/ArduPilot/ardupilot/issues/12513

* Install python packages for `$USER`, set home directory (`~`) based on `$USER` environment variable so that `.profile` gets written in the right place.
* Adds correct paths to the Dockerfile for autotest and mavproxy.