### PR TITLE
GCS_Common: any internal error means MAV_STATE_CRITICAL

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -58,7 +58,7 @@ uint32_t GCS_Rover::custom_mode() const
     return rover.control_mode->mode_number();
 }
 
-MAV_STATE GCS_MAVLINK_Rover::system_status() const
+MAV_STATE GCS_MAVLINK_Rover::vehicle_system_status() const
 {
     if ((rover.failsafe.triggered != 0) || rover.failsafe.ekf) {
         return MAV_STATE_CRITICAL;

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -43,7 +43,7 @@ private:
     void packetReceived(const mavlink_status_t &status, const mavlink_message_t &msg) override;
 
     MAV_MODE base_mode() const override;
-    MAV_STATE system_status() const override;
+    MAV_STATE vehicle_system_status() const override;
 
     int16_t vfr_hud_throttle() const override;
 

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -68,7 +68,7 @@ uint32_t GCS_Tracker::custom_mode() const
     return (uint32_t)tracker.mode->number();
 }
 
-MAV_STATE GCS_MAVLINK_Tracker::system_status() const
+MAV_STATE GCS_MAVLINK_Tracker::vehicle_system_status() const
 {
     if (tracker.mode == &tracker.mode_initialising) {
         return MAV_STATE_CALIBRATING;

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -43,7 +43,7 @@ private:
     void send_global_position_int() override;
 
     MAV_MODE base_mode() const override;
-    MAV_STATE system_status() const override;
+    MAV_STATE vehicle_system_status() const override;
 
     bool waypoint_receiving;
 };

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -72,7 +72,7 @@ uint32_t GCS_Copter::custom_mode() const
     return (uint32_t)copter.control_mode;
 }
 
-MAV_STATE GCS_MAVLINK_Copter::system_status() const
+MAV_STATE GCS_MAVLINK_Copter::vehicle_system_status() const
 {
     // set system as critical if any failsafe have triggered
     if (copter.any_failsafe_triggered())  {

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -57,7 +57,7 @@ private:
                         const mavlink_message_t &msg) override;
 
     MAV_MODE base_mode() const override;
-    MAV_STATE system_status() const override;
+    MAV_STATE vehicle_system_status() const override;
 
     int16_t vfr_hud_throttle() const override;
     float vfr_hud_alt() const override;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -93,7 +93,7 @@ uint32_t GCS_Plane::custom_mode() const
     return plane.control_mode->mode_number();
 }
 
-MAV_STATE GCS_MAVLINK_Plane::system_status() const
+MAV_STATE GCS_MAVLINK_Plane::vehicle_system_status() const
 {
     if (plane.control_mode == &plane.mode_initializing) {
         return MAV_STATE_CALIBRATING;

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -55,7 +55,7 @@ private:
     void packetReceived(const mavlink_status_t &status, const mavlink_message_t &msg) override;
 
     MAV_MODE base_mode() const override;
-    MAV_STATE system_status() const override;
+    MAV_STATE vehicle_system_status() const override;
 
     uint8_t radio_in_rssi() const;
 

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -62,7 +62,7 @@ uint32_t GCS_Sub::custom_mode() const
     return sub.control_mode;
 }
 
-MAV_STATE GCS_MAVLINK_Sub::system_status() const
+MAV_STATE GCS_MAVLINK_Sub::vehicle_system_status() const
 {
     // set system as critical if any failsafe have triggered
     if (sub.any_failsafe_triggered())  {

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -50,7 +50,7 @@ private:
     bool send_info(void);
 
     MAV_MODE base_mode() const override;
-    MAV_STATE system_status() const override;
+    MAV_STATE vehicle_system_status() const override;
 
     int16_t vfr_hud_throttle() const override;
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -308,7 +308,8 @@ protected:
     void set_ekf_origin(const Location& loc);
 
     virtual MAV_MODE base_mode() const = 0;
-    virtual MAV_STATE system_status() const = 0;
+    MAV_STATE system_status() const;
+    virtual MAV_STATE vehicle_system_status() const = 0;
 
     virtual MAV_VTOL_STATE vtol_state() const { return MAV_VTOL_STATE_UNDEFINED; }
     virtual MAV_LANDED_STATE landed_state() const { return MAV_LANDED_STATE_UNDEFINED; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2226,6 +2226,22 @@ void GCS_MAVLINK::send_gps_global_origin() const
         AP_HAL::micros64());
 }
 
+MAV_STATE GCS_MAVLINK::system_status() const
+{
+    MAV_STATE _system_status = vehicle_system_status();
+    if (_system_status < MAV_STATE_CRITICAL) {
+        // note that POWEROFF and FLIGHT_TERMINATION are both >
+        // CRITICAL, so we will not overwrite POWEROFF and
+        // FLIGHT_TERMINATION even if we have internal errors.  If new
+        // enum entries are added then this may also not overwrite
+        // those.
+        if (AP::internalerror().errors()) {
+            _system_status = MAV_STATE_CRITICAL;
+        }
+    }
+    return _system_status;
+}
+
 /*
   Send MAVLink heartbeat
  */

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -41,7 +41,7 @@ protected:
 
     // dummy information:
     MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
-    MAV_STATE system_status() const override { return MAV_STATE_CALIBRATING; }
+    MAV_STATE vehicle_system_status() const override { return MAV_STATE_CALIBRATING; }
 
     bool set_home_to_current_location(bool _lock) override { return false; }
     bool set_home(const Location& loc, bool _lock) override { return false; }


### PR DESCRIPTION
Tested in SITL using `SITL_WATCHDOG_RESET=1 ./Tools/autotest/sim_vehicle.py -v ArduCopter`

```
STABILIZE> APM: EKF2 IMU0 origin set
APM: EKF2 IMU1 origin set
APM: PreArm: Internal errors (0x800)
APM: PreArm: check proximity sensor

STABILIZE> 
STABILIZE> status --verbose HEARTBEAT
STABILIZE> 2019-11-25 08:28:35.33: HEARTBEAT (link=None) (signed=False) (seq=95) (src=1/1)
    type: 2 (MAV_TYPE_QUADROTOR)
    autopilot: 3 (MAV_AUTOPILOT_ARDUPILOTMEGA)
    base_mode: 81
        MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
      ! MAV_MODE_FLAG_TEST_ENABLED
      ! MAV_MODE_FLAG_AUTO_ENABLED
      ! MAV_MODE_FLAG_GUIDED_ENABLED
        MAV_MODE_FLAG_STABILIZE_ENABLED
      ! MAV_MODE_FLAG_HIL_ENABLED
        MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
      ! MAV_MODE_FLAG_SAFETY_ARMED
    custom_mode: 0
    system_status: 5 (MAV_STATE_CRITICAL)
    mavlink_version: 3
```
