### PR TITLE
Rover: remove pointless library init wrappers

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -384,12 +384,9 @@ private:
     // sensors.cpp
     void update_compass(void);
     void compass_save(void);
-    void init_beacon();
-    void init_visual_odom();
     void update_wheel_encoder();
     void accel_cal_update(void);
     void read_rangefinders(void);
-    void init_proximity();
     void read_airspeed();
     void rpm_update(void);
 

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -20,18 +20,6 @@ void Rover::compass_save() {
     }
 }
 
-// init beacons used for non-gps position estimates
-void Rover::init_beacon()
-{
-    g2.beacon.init();
-}
-
-// init visual odometry sensor
-void Rover::init_visual_odom()
-{
-    g2.visual_odom.init();
-}
-
 // update wheel encoders
 void Rover::update_wheel_encoder()
 {
@@ -117,12 +105,6 @@ void Rover::read_rangefinders(void)
 {
     rangefinder.update();
     Log_Write_Depth();
-}
-
-// initialise proximity sensor
-void Rover::init_proximity(void)
-{
-    g2.proximity.init();
 }
 
 /*

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -99,13 +99,13 @@ void Rover::init_ardupilot()
     rangefinder.init(ROTATION_NONE);
 
     // init proximity sensor
-    init_proximity();
+    g2.proximity.init();
 
     // init beacons used for non-gps position estimation
-    init_beacon();
+    g2.beacon.init();
 
-    // init visual odometry
-    init_visual_odom();
+    // init library used for visual position estimation
+    g2.visual_odom.init();
 
     // and baro for EKF
     barometer.set_log_baro_bit(MASK_LOG_IMU);


### PR DESCRIPTION
The vast majority of calls in init_ardupilot already follow this
convention