### PR TITLE
AP_Scripting: add button binding

### DIFF
--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -41,6 +41,10 @@ public:
         return _singleton;
     }
 
+    // get state of a button
+    // used by scripting
+    bool get_button_state(uint8_t number);
+
 private:
 
     static AP_Button *_singleton;
@@ -53,6 +57,9 @@ private:
 
     // last button press mask
     uint8_t last_mask;
+
+    // debounced button press mask
+    uint8_t debounce_mask;
 
     // when the mask last changed
     uint64_t last_change_time_ms;

--- a/libraries/AP_Scripting/examples/button_test.lua.lua
+++ b/libraries/AP_Scripting/examples/button_test.lua.lua
@@ -1,0 +1,26 @@
+-- This script is an example button functionality
+
+local button_number = 1 -- the button numbber we want to read, as deffined in AP_Button
+
+local button_active_state = true -- the 'pressed' state of the button
+
+local last_button_state
+
+function update() -- this is the loop which periodically runs
+
+  local button_new_state = button:get_button_state(button_number) == button_active_state
+
+  -- the button has changes since the last loop
+  if button_new_state ~= last_button_state then
+    last_button_state = button_new_state
+    if button_new_state then
+      gcs:send_text(0, "LUA: Button pressed")
+    else
+      gcs:send_text(0, "LUA: Button released")
+    end
+  end
+
+  return update, 1000 -- reschedules the loop (1hz)
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -214,3 +214,7 @@ singleton AP_Mission method num_commands uint16_t
 include AP_RPM/AP_RPM.h
 singleton AP_RPM alias RPM
 singleton AP_RPM method get_rpm boolean uint8_t 0 RPM_MAX_INSTANCES float'Null
+
+include AP_Button/AP_Button.h
+singleton AP_Button alias button
+singleton AP_Button method get_button_state boolean uint8_t 1 AP_BUTTON_NUM_PINS

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,6 +1,7 @@
 // auto generated bindings, don't manually edit.  See README.md for details.
 #include "lua_generated_bindings.h"
 #include "lua_boxed_numerics.h"
+#include <AP_Button/AP_Button.h>
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Param/AP_Param.h>
@@ -552,6 +553,23 @@ const luaL_Reg Location_meta[] = {
     {"get_distance", Location_get_distance},
     {NULL, NULL}
 };
+
+static int AP_Button_get_button_state(lua_State *L) {
+    AP_Button * ud = AP_Button::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "button not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(1, 0)) && (raw_data_2 <= MIN(AP_BUTTON_NUM_PINS, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->get_button_state(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
 
 static int AP_RPM_get_rpm(lua_State *L) {
     AP_RPM * ud = AP_RPM::get_singleton();
@@ -2282,6 +2300,11 @@ static int AP_AHRS_get_roll(lua_State *L) {
     return 1;
 }
 
+const luaL_Reg AP_Button_meta[] = {
+    {"get_button_state", AP_Button_get_button_state},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_RPM_meta[] = {
     {"get_rpm", AP_RPM_get_rpm},
     {NULL, NULL}
@@ -2575,6 +2598,7 @@ const struct userdata_meta userdata_fun[] = {
 };
 
 const struct userdata_meta singleton_fun[] = {
+    {"button", AP_Button_meta, NULL},
     {"RPM", AP_RPM_meta, NULL},
     {"mission", AP_Mission_meta, AP_Mission_enums},
     {"param", AP_Param_meta, NULL},
@@ -2649,6 +2673,7 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
+    "button",
     "RPM",
     "mission",
     "param",

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 // auto generated bindings, don't manually edit.  See README.md for details.
+#include <AP_Button/AP_Button.h>
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Param/AP_Param.h>


### PR DESCRIPTION
This adds a binding to assess AP_Button from scripting.

I ended up having to access AP_Button via AP_Vehicle, this is because I couldn't give a AP_Button a singleton because it has multiple instances in copter and plane. I think this is probably a bug @peterbarker?. It is defined in both AP_Vehicle and the vehicle codes, if I remover either of them it works. The difference between rover and plane and copter is that the button params are not in g2 in rover. Using only the AP_Vehicle define breaks the g2 params.

My attempt to fix that is here, but I could not get quite get it working.

https://github.com/IamPete1/ardupilot/commits/button_singlton