### PR TITLE
AP_Scripting: RGB LED override binding

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -113,7 +113,7 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Param: LED_OVERRIDE
     // @DisplayName: Specifies colour source for the RGBLed
     // @Description: Specifies the source for the colours and brightness for the LED.  OutbackChallenge conforms to the MedicalExpress (https://uavchallenge.org/medical-express/) rules, essentially "Green" is disarmed (safe-to-approach), "Red" is armed (not safe-to-approach). Traffic light is a simplified color set, red when armed, yellow when the safety switch is not surpressing outputs (but disarmed), and green when outputs are surpressed and disarmed, the LED will blink faster if disarmed and failing arming checks.
-    // @Values: 0:Standard,1:MAVLink,2:OutbackChallenge,3:TrafficLight
+    // @Values: 0:Standard,1:MAVLink/Scripting,2:OutbackChallenge,3:TrafficLight
     // @User: Advanced
     AP_GROUPINFO("LED_OVERRIDE", 2, AP_Notify, _rgb_led_override, 0),
 
@@ -348,6 +348,16 @@ void AP_Notify::handle_led_control(const mavlink_message_t &msg)
     for (uint8_t i = 0; i < _num_devices; i++) {
         if (_devices[i] != nullptr) {
             _devices[i]->handle_led_control(msg);
+        }
+    }
+}
+
+// handle RGB from Scripting
+void AP_Notify::handle_rgb(uint8_t r, uint8_t g, uint8_t b, uint8_t rate_hz)
+{
+    for (uint8_t i = 0; i < _num_devices; i++) {
+        if (_devices[i] != nullptr) {
+            _devices[i]->rgb_control(r, g, b, rate_hz);
         }
     }
 }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -138,6 +138,9 @@ public:
     // handle a LED_CONTROL message
     static void handle_led_control(const mavlink_message_t &msg);
 
+    // handle RGB from Scripting
+    static void handle_rgb(uint8_t r, uint8_t g, uint8_t b, uint8_t rate_hz = 0);
+
     // handle a PLAY_TUNE message
     static void handle_play_tune(const mavlink_message_t &msg);
 

--- a/libraries/AP_Notify/NotifyDevice.h
+++ b/libraries/AP_Notify/NotifyDevice.h
@@ -23,6 +23,10 @@ public:
     // play a MML tune
     virtual void play_tune(const char *tune) {}
 
+    // RGB control
+    // give RGB and flash rate, used with scripting
+    virtual void rgb_control(uint8_t r, uint8_t g, uint8_t b, uint8_t rate_hz) {}
+
     // this pointer is used to read the parameters relative to devices
     const AP_Notify *pNotify;
 };

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -281,3 +281,15 @@ void RGBLed::update_override(void)
         _set_rgb(0, 0, 0);
     }
 }
+
+/*
+  RGB control
+  give RGB and flash rate, used with scripting
+*/
+void RGBLed::rgb_control(uint8_t r, uint8_t g, uint8_t b, uint8_t rate_hz)
+{
+    _led_override.rate_hz = rate_hz;
+    _led_override.r = r;
+    _led_override.g = g;
+    _led_override.b = b;
+}

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -38,7 +38,11 @@ public:
 
     // handle LED control, only used when LED_OVERRIDE=1
     virtual void handle_led_control(const mavlink_message_t &msg) override;
-    
+
+    // RGB control
+    // give RGB and flash rate, used with scripting
+    virtual void rgb_control(uint8_t r, uint8_t g, uint8_t b, uint8_t rate_hz) override;
+
 protected:
     // methods implemented in hardware specific classes
     virtual bool hw_init(void) = 0;

--- a/libraries/AP_Scripting/examples/rgb_led_test.lua
+++ b/libraries/AP_Scripting/examples/rgb_led_test.lua
@@ -1,0 +1,38 @@
+-- This script is a test of led override
+
+local count = 0
+
+function update() -- this is the loop which periodically runs
+
+  count = count + 1
+
+  if count == 1 then
+    -- solid red
+    -- red,green,blue,rate hz, duration ms
+    notify:handle_rgb(255,0,0,0)
+  elseif count == 2 then
+    -- solid green
+    notify:handle_rgb(0,255,0,0)
+  elseif count == 3 then
+    -- solid blue
+    notify:handle_rgb(0,0,255,0)
+  elseif count == 4 then
+    -- 1hz red  + green
+    notify:handle_rgb(255,255,0,1)
+  elseif count == 5 then
+    -- 1hz green + blue
+    notify:handle_rgb(0,255,255,1)
+  elseif count == 6 then
+    -- 1hz red + blue
+    notify:handle_rgb(255,0,255,1)
+  elseif count == 7 then
+    -- fast white
+    notify:handle_rgb(255,255,255,10)
+    count = 0
+  end
+
+  return update, 15000 -- reschedules the loop in 15 seconds
+
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -108,6 +108,7 @@ userdata Vector2f operator -
 include AP_Notify/AP_Notify.h
 singleton AP_Notify alias notify
 singleton AP_Notify method play_tune void string
+singleton AP_Notify method handle_rgb void uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX
 
 include AP_RangeFinder/AP_RangeFinder.h
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -832,6 +832,34 @@ static int RangeFinder_num_sensors(lua_State *L) {
     return 1;
 }
 
+static int AP_Notify_handle_rgb(lua_State *L) {
+    AP_Notify * ud = AP_Notify::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "notify not supported on this firmware");
+    }
+
+    binding_argcheck(L, 5);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(UINT8_MAX, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const lua_Integer raw_data_3 = luaL_checkinteger(L, 3);
+    luaL_argcheck(L, ((raw_data_3 >= MAX(0, 0)) && (raw_data_3 <= MIN(UINT8_MAX, UINT8_MAX))), 3, "argument out of range");
+    const uint8_t data_3 = static_cast<uint8_t>(raw_data_3);
+    const lua_Integer raw_data_4 = luaL_checkinteger(L, 4);
+    luaL_argcheck(L, ((raw_data_4 >= MAX(0, 0)) && (raw_data_4 <= MIN(UINT8_MAX, UINT8_MAX))), 4, "argument out of range");
+    const uint8_t data_4 = static_cast<uint8_t>(raw_data_4);
+    const lua_Integer raw_data_5 = luaL_checkinteger(L, 5);
+    luaL_argcheck(L, ((raw_data_5 >= MAX(0, 0)) && (raw_data_5 <= MIN(UINT8_MAX, UINT8_MAX))), 5, "argument out of range");
+    const uint8_t data_5 = static_cast<uint8_t>(raw_data_5);
+    ud->handle_rgb(
+            data_2,
+            data_3,
+            data_4,
+            data_5);
+
+    return 0;
+}
+
 static int AP_Notify_play_tune(lua_State *L) {
     AP_Notify * ud = AP_Notify::get_singleton();
     if (ud == nullptr) {
@@ -1735,6 +1763,7 @@ const luaL_Reg RangeFinder_meta[] = {
 };
 
 const luaL_Reg AP_Notify_meta[] = {
+    {"handle_rgb", AP_Notify_handle_rgb},
     {"play_tune", AP_Notify_play_tune},
     {NULL, NULL}
 };


### PR DESCRIPTION
This work was funded by 3DXR.

This adds a new method to AP_Notify to allow temporary overriding all other RGB led methods. The binding for this is then added to scripting. Along with a example to blink the lights. 

https://www.youtube.com/watch?v=TyiMCSSfkz0&feature=youtu.be