### PR TITLE
AP_Radio: expect delay whil resetting radios

### DIFF
--- a/libraries/AP_Radio/AP_Radio_cypress.cpp
+++ b/libraries/AP_Radio/AP_Radio_cypress.cpp
@@ -290,6 +290,7 @@ bool AP_Radio_cypress::reset(void)
       to reset radio hold reset high for 0.5s, then low for 0.5s
      */
 #if defined(HAL_GPIO_RADIO_RESET)
+    hal.scheduler->expect_delay_ms(2000); // avoid main-loop-delay internal error
     hal.gpio->write(HAL_GPIO_RADIO_RESET, 1);
     hal.scheduler->delay(500);
     hal.gpio->write(HAL_GPIO_RADIO_RESET, 0);


### PR DESCRIPTION
@hsteinhaus would you be able to test this patch?

(ref: https://discuss.ardupilot.org/t/arducopter-4-0-on-v2450-internal-error-0x8000/49570/4)
