### PR TITLE
Scripting/AP_Arming: add pre-arm check that scripting has initialised successfull

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -199,9 +199,7 @@ void Rover::startup_ground(void)
 #endif
 
 #ifdef ENABLE_SCRIPTING
-    if (!g2.scripting.init()) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
-    }
+    g2.scripting.init();
 #endif // ENABLE_SCRIPTING
 
     // we don't want writes to the serial port to cause us to pause

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -60,9 +60,7 @@ void Tracker::init_tracker()
 #endif
 
 #ifdef ENABLE_SCRIPTING
-    if (!scripting.init()) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
-    }
+    scripting.init();
 #endif // ENABLE_SCRIPTING
 
     // initialise compass

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -232,9 +232,7 @@ void Copter::init_ardupilot()
     startup_INS_ground();
 
 #ifdef ENABLE_SCRIPTING
-    if (!g2.scripting.init()) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
-    }
+    g2.scripting.init();
 #endif // ENABLE_SCRIPTING
 
     // set landed flags

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -228,9 +228,7 @@ void Plane::startup_ground(void)
 #endif
 
 #ifdef ENABLE_SCRIPTING
-    if (!g2.scripting.init()) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
-    }
+    g2.scripting.init();
 #endif // ENABLE_SCRIPTING
 
     // reset last heartbeat time, so we don't trigger failsafe on slow

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -190,9 +190,7 @@ void Sub::init_ardupilot()
     startup_INS_ground();
 
 #ifdef ENABLE_SCRIPTING
-    if (!g2.scripting.init()) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
-    }
+    g2.scripting.init();
 #endif // ENABLE_SCRIPTING
 
     // we don't want writes to the serial port to cause us to pause

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -32,6 +32,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Terrain/AP_Terrain.h>
+#include <AP_Scripting/AP_Scripting.h>
 
 #if HAL_WITH_UAVCAN
   #include <AP_BoardConfig/AP_BoardConfig_CAN.h>
@@ -703,6 +704,13 @@ bool AP_Arming::system_checks(bool report)
         const AP_Terrain *terrain = AP_Terrain::get_singleton();
         if ((terrain != nullptr) && terrain->init_failed()) {
             check_failed(ARMING_CHECK_SYSTEM, report, "Terrain out of memory");
+            return false;
+        }
+#endif
+#ifdef ENABLE_SCRIPTING
+        const AP_Scripting *scripting = AP_Scripting::get_singleton();
+        if ((scripting != nullptr) && scripting->enabled() && scripting->init_failed()) {
+            check_failed(ARMING_CHECK_SYSTEM, report, "Scripting out of memory");
             return false;
         }
 #endif

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -79,19 +79,17 @@ AP_Scripting::AP_Scripting() {
     _singleton = this;
 }
 
-bool AP_Scripting::init(void) {
+void AP_Scripting::init(void) {
     if (!_enable) {
-        return true;
+        return;
     }
 
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_Scripting::thread, void),
                                       "Scripting", SCRIPTING_STACK_SIZE, AP_HAL::Scheduler::PRIORITY_SCRIPTING, 0)) {
         gcs().send_text(MAV_SEVERITY_CRITICAL, "Could not create scripting stack (%d)", SCRIPTING_STACK_SIZE);
+        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
         _init_failed = true;
-        return false;
     }
-
-    return true;
 }
 
 void AP_Scripting::thread(void) {

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -28,7 +28,7 @@ public:
     AP_Scripting(const AP_Scripting &other) = delete;
     AP_Scripting &operator=(const AP_Scripting&) = delete;
 
-    bool init(void);
+    void init(void);
     bool init_failed(void) const { return _init_failed; }
 
     bool enabled(void) const { return _enable != 0; };

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -29,6 +29,7 @@ public:
     AP_Scripting &operator=(const AP_Scripting&) = delete;
 
     bool init(void);
+    bool init_failed(void) const { return _init_failed; }
 
     bool enabled(void) const { return _enable != 0; };
 
@@ -45,6 +46,8 @@ private:
     AP_Int32 _script_vm_exec_count;
     AP_Int32 _script_heap_size;
     AP_Int8 _debug_level;
+
+    bool _init_failed;  // true if memory allocation failed
 
     static AP_Scripting *_singleton;
 

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -30,6 +30,9 @@ public:
     lua_scripts(const lua_scripts &other) = delete;
     lua_scripts &operator=(const lua_scripts&) = delete;
 
+    // return true if initialisation failed
+    bool heap_allocated() const { return _heap != nullptr; }
+
     // run scripts, does not return unless an error occured
     void run(void);
 


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/12798 by adding a pre-arm check to alert the user if scripting has failed to initialise because it has run out of memory.  In my tests a CubeBlack (and thus probably many other boards) are very close to running out of memory when using Copter in the default configuration so it is fairly likely that users will hit this issue and so we should provide protection and a decent warning.

This also removes the automatic setting of SCR_ENABLE to zero which we've recently agreed is not a good pattern because users may inadvertantly save/re-load parameter and permanently disable scripting.

This has been tested on a real board and a screen shot of the pre-arm check message is shown below.
![image](https://user-images.githubusercontent.com/1498098/69605203-dbe0be80-1062-11ea-8326-6f6123509ae2.png)

This PR also makes an unrelated change to print an initialisation failure message from the scripting library itself instead of duplicating it in each vehicle.
