### PR TITLE
Fixed I2C errors on high bus noise

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
@@ -725,6 +725,8 @@
 #define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                               \
         extern void memory_flush_all(void); \
         memory_flush_all(); \
+        extern void system_halt_hook(void); \
+        system_halt_hook(); \
 } while(0)
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
@@ -91,6 +91,14 @@ void get_rtc_backup(uint8_t idx, uint32_t *v, uint8_t n);
 void stm32_cacheBufferInvalidate(const void *p, size_t size);
 void stm32_cacheBufferFlush(const void *p, size_t size);
 
+#ifdef HAL_GPIO_PIN_FAULT
+// printf for fault handlers
+void fault_printf(const char *fmt, ...);
+#endif
+
+// halt hook for printing panic message
+void system_halt_hook(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -20,6 +20,7 @@
 #include <AP_HAL/system.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include "hwdef/common/watchdog.h"
+#include "hwdef/common/stm32_util.h"
 
 #include <ch.h>
 #include "hal.h"
@@ -93,6 +94,25 @@ void HardFault_Handler(void) {
 
     save_fault_watchdog(__LINE__, faultType, faultAddress);
 
+#ifdef HAL_GPIO_PIN_FAULT
+    while (true) {
+        fault_printf("HARDFAULT\n");
+        fault_printf("CUR=0x%08x\n", ch.rlist.current);
+        if (ch.rlist.current) {
+            fault_printf("NAME=%s\n", ch.rlist.current->name);
+        }
+        fault_printf("FA=0x%08x\n", faultAddress);
+        fault_printf("PC=0x%08x\n", ctx.pc);
+        fault_printf("LR=0x%08x\n", ctx.lr_thd);
+        fault_printf("R0=0x%08x\n", ctx.r0);
+        fault_printf("R1=0x%08x\n", ctx.r1);
+        fault_printf("R2=0x%08x\n", ctx.r2);
+        fault_printf("R3=0x%08x\n", ctx.r3);
+        fault_printf("R12=0x%08x\n", ctx.r12);
+        fault_printf("XPSR=0x%08x\n", ctx.xpsr);
+        fault_printf("\n\n");
+    }
+#endif
     //Cause debugger to stop. Ignored if no debugger is attached
     while(1) {}
 }


### PR DESCRIPTION
This fixes issue #12862 where a cross-connected I2C and UART pin caused a watchdog by causing DMA operations to happen outside an I2C transaction context.
We previously put in a generic interrupt storm mitigation system for the last set of I2C errors, and that did work correctly, but this is a new issue where an interrupt happening outside of an I2C transaction context could trigger the re-enable of a stale DMA operation, causing a memory overwrite
The fix is a "belt and braces" approach where we guarantee we can't get any DMA operations on I2C happening outside a transaction context