### PR TITLE
Added estimation of compass scale factor

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -533,7 +533,14 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Range: 0 1.3
     AP_GROUPINFO("SCALE3", 42, Compass, _state[2].scale_factor, 0),
 #endif
-    
+
+    // @Param: OPTIONS
+    // @DisplayName: Compass options
+    // @Description: This sets options to change the behaviour of the compass
+    // @Bitmask: 0:CalRequireGPS
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 43, Compass, _options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -509,6 +509,31 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Values: 0:Disabled,1:Enabled
     AP_GROUPINFO("ENABLE", 39, Compass, _enabled, 1),
 
+    // @Param: SCALE
+    // @DisplayName: Compass1 scale factor
+    // @Description: Scaling factor for first compass to compensate for sensor scaling errors. If this is 0 then no scaling is done
+    // @User: Standard
+    // @Range: 0 1.3
+    AP_GROUPINFO("SCALE", 40, Compass, _state[0].scale_factor, 0),
+
+#if HAL_COMPASS_MAX_SENSORS > 1
+    // @Param: SCALE2
+    // @DisplayName: Compass2 scale factor
+    // @Description: Scaling factor for 2nd compass to compensate for sensor scaling errors. If this is 0 then no scaling is done
+    // @User: Standard
+    // @Range: 0 1.3
+    AP_GROUPINFO("SCALE2", 41, Compass, _state[1].scale_factor, 0),
+#endif
+
+#if HAL_COMPASS_MAX_SENSORS > 2
+    // @Param: SCALE3
+    // @DisplayName: Compass3 scale factor
+    // @Description: Scaling factor for 3rd compass to compensate for sensor scaling errors. If this is 0 then no scaling is done
+    // @User: Standard
+    // @Range: 0 1.3
+    AP_GROUPINFO("SCALE3", 42, Compass, _state[2].scale_factor, 0),
+#endif
+    
     AP_GROUPEND
 };
 
@@ -1008,6 +1033,14 @@ Compass::set_and_save_offdiagonals(uint8_t i, const Vector3f &offdiagonals)
 }
 
 void
+Compass::set_and_save_scale_factor(uint8_t i, float scale_factor)
+{
+    if (i < COMPASS_MAX_INSTANCES) {
+        _state[i].scale_factor.set_and_save(scale_factor);
+    }
+}
+
+void
 Compass::save_offsets(uint8_t i)
 {
     _state[i].offset.save();  // save offsets
@@ -1305,6 +1338,19 @@ bool Compass::consistent() const
         if (xy_len_diff > AP_COMPASS_MAX_XY_LENGTH_DIFF) {
             return false;
         }
+    }
+    return true;
+}
+
+/*
+  return true if we have a valid scale factor
+ */
+bool Compass::have_scale_factor(uint8_t i) const
+{
+    if (i >= get_count() ||
+        _state[i].scale_factor < COMPASS_MIN_SCALE_FACTOR ||
+        _state[i].scale_factor > COMPASS_MAX_SCALE_FACTOR) {
+        return false;
     }
     return true;
 }

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -472,6 +472,12 @@ private:
 
     AP_Int16 _offset_max;
 
+    // bitmask of options
+    enum class Option : uint16_t {
+        CAL_REQUIRE_GPS = (1U<<0),
+    };
+    AP_Int16 _options;
+
 #if COMPASS_CAL_ENABLED
     CompassCalibrator _calibrator[COMPASS_MAX_INSTANCES];
 #endif

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -106,6 +106,7 @@ public:
     void set_and_save_offsets(uint8_t i, const Vector3f &offsets);
     void set_and_save_diagonals(uint8_t i, const Vector3f &diagonals);
     void set_and_save_offdiagonals(uint8_t i, const Vector3f &diagonals);
+    void set_and_save_scale_factor(uint8_t i, float scale_factor);
 
     /// Saves the current offset x/y/z values for one or all compasses
     ///
@@ -123,6 +124,9 @@ public:
     /// Return the current field as a Vector3f in milligauss
     const Vector3f &get_field(uint8_t i) const { return _state[i].field; }
     const Vector3f &get_field(void) const { return get_field(get_primary()); }
+
+    /// Return true if we have set a scale factor for a compass
+    bool have_scale_factor(uint8_t i) const;
 
     // compass calibrator interface
     void cal_update();
@@ -431,6 +435,7 @@ private:
         AP_Vector3f offset;
         AP_Vector3f diagonals;
         AP_Vector3f offdiagonals;
+        AP_Float    scale_factor;
 
         // device id detected at init.
         // saved to eeprom when offsets are saved allowing ram &

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -59,6 +59,12 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
     // add in the basic offsets
     mag += offsets;
 
+    // add in scale factor, use a wide sanity check. The calibrator
+    // uses a narrower check.
+    if (_compass.have_scale_factor(i)) {
+        mag *= state.scale_factor;
+    }
+
     // apply eliptical correction
     Matrix3f mat(
         diagonals.x, offdiagonals.x, offdiagonals.y,

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -1,5 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Notify/AP_Notify.h>
+#include <AP_GPS/AP_GPS.h>
 #include <GCS_MAVLink/GCS.h>
 
 #include "AP_Compass.h"
@@ -53,6 +54,12 @@ bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
     }
     if (!use_for_yaw(i)) {
         return false;
+    }
+    if (_options.get() & uint16_t(Option::CAL_REQUIRE_GPS)) {
+        if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Compass cal requires GPS lock");
+            return false;
+        }
     }
     if (!is_calibrating()) {
         AP_Notify::events.initiated_compass_cal = 1;

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -145,11 +145,13 @@ bool Compass::_accept_calibration(uint8_t i)
         _cal_saved[i] = true;
 
         Vector3f ofs, diag, offdiag;
-        cal.get_calibration(ofs, diag, offdiag);
+        float scale_factor;
+        cal.get_calibration(ofs, diag, offdiag, scale_factor);
 
         set_and_save_offsets(i, ofs);
         set_and_save_diagonals(i,diag);
         set_and_save_offdiagonals(i,offdiag);
+        set_and_save_scale_factor(i,scale_factor);
 
         if (_state[i].external && _rotate_auto >= 2) {
             _state[i].orientation.set_and_save_ifchanged(cal.get_orientation());
@@ -234,7 +236,8 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
             cal_status == COMPASS_CAL_BAD_ORIENTATION) {
             float fitness = _calibrator[compass_id].get_fitness();
             Vector3f ofs, diag, offdiag;
-            _calibrator[compass_id].get_calibration(ofs, diag, offdiag);
+            float scale_factor;
+            _calibrator[compass_id].get_calibration(ofs, diag, offdiag, scale_factor);
             uint8_t autosaved = _cal_saved[compass_id];
 
             mavlink_msg_mag_cal_report_send(
@@ -247,7 +250,8 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
                 offdiag.x, offdiag.y, offdiag.z,
                 _calibrator[compass_id].get_orientation_confidence(),
                 _calibrator[compass_id].get_original_orientation(),
-                _calibrator[compass_id].get_orientation()
+                _calibrator[compass_id].get_orientation(),
+                scale_factor
             );
         }
     }

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -115,6 +115,9 @@ void AP_Compass_SITL::_timer()
             // rotate the first compass, allowing for testing of external compass rotation
             f.rotate_inverse((enum Rotation)_sitl->mag_orient.get());
             f.rotate(get_board_orientation());
+
+            // scale the first compass to simulate sensor scale factor errors
+            f *= _sitl->mag_scaling;
         }
         
         accumulate_sample(f, _compass_instance[i], 10);

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -16,7 +16,11 @@ enum compass_cal_status_t {
     COMPASS_CAL_SUCCESS = 4,
     COMPASS_CAL_FAILED = 5,
     COMPASS_CAL_BAD_ORIENTATION = 6,
+    COMPASS_CAL_BAD_RADIUS = 7,
 };
+
+#define COMPASS_MIN_SCALE_FACTOR 0.3
+#define COMPASS_MAX_SCALE_FACTOR 1.6
 
 class CompassCalibrator {
 public:
@@ -45,7 +49,7 @@ public:
     enum compass_cal_status_t get_status() const { return _status; }
 
     // get calibration outputs (offsets, diagonals, offdiagonals) and fitness
-    void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);
+    void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals, float &scale_factor);
     float get_fitness() const { return sqrtf(_fitness); }
 
     // get corrected (and original) orientation
@@ -80,6 +84,7 @@ private:
         Vector3f offset;    // offsets
         Vector3f diag;      // diagonal scaling
         Vector3f offdiag;   // off diagonal scaling
+        float scale_factor; // scaling factor to compensate for radius error
     };
 
     // compact class for approximate attitude, to save memory
@@ -154,6 +159,9 @@ private:
     // calculate compass orientation
     Vector3f calculate_earth_field(CompassSample &sample, enum Rotation r);
     bool calculate_orientation();
+
+    // fix radius to compensate for sensor scaling errors
+    bool fix_radius();
 
     uint8_t _compass_idx;                   // index of the compass providing data
     enum compass_cal_status_t _status;      // current state of calibrator

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -19,8 +19,8 @@ enum compass_cal_status_t {
     COMPASS_CAL_BAD_RADIUS = 7,
 };
 
-#define COMPASS_MIN_SCALE_FACTOR 0.3
-#define COMPASS_MAX_SCALE_FACTOR 1.6
+#define COMPASS_MIN_SCALE_FACTOR 0.85
+#define COMPASS_MAX_SCALE_FACTOR 1.3
 
 class CompassCalibrator {
 public:

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -19,6 +19,13 @@ CompassLearn::CompassLearn(Compass &_compass) :
     compass(_compass)
 {
     gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: Initialised");
+    for (uint8_t i=0; i<compass.get_count(); i++) {
+        if (compass._state[i].use_for_yaw) {
+            // reset scale factors, we can't learn scale factors in
+            // flight
+            compass.set_and_save_scale_factor(i, 0.0);
+        }
+    }
 }
 
 /*
@@ -133,6 +140,7 @@ void CompassLearn::update(void)
             for (uint8_t i=0; i<compass.get_count(); i++) {
                 if (compass._state[i].use_for_yaw) {
                     compass.save_offsets(i);
+                    compass.set_and_save_scale_factor(i, 0.0);
                     compass.set_use_for_yaw(i, true);
                 }
             }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -577,13 +577,16 @@ void NavEKF2_core::readGpsData()
             }
 
             if (gpsGoodToAlign && !have_table_earth_field) {
-                table_earth_field_ga = AP_Declination::get_earth_field_ga(gpsloc);
-                table_declination = radians(AP_Declination::get_declination(gpsloc.lat*1.0e-7,
-                                                                            gpsloc.lng*1.0e-7));
-                have_table_earth_field = true;
-                if (frontend->_mag_ef_limit > 0) {
-                    // initialise earth field from tables
-                    stateStruct.earth_magfield = table_earth_field_ga;
+                const Compass *compass = _ahrs->get_compass();
+                if (compass && compass->have_scale_factor(magSelectIndex)) {
+                    table_earth_field_ga = AP_Declination::get_earth_field_ga(gpsloc);
+                    table_declination = radians(AP_Declination::get_declination(gpsloc.lat*1.0e-7,
+                                                                                gpsloc.lng*1.0e-7));
+                    have_table_earth_field = true;
+                    if (frontend->_mag_ef_limit > 0) {
+                        // initialise earth field from tables
+                        stateStruct.earth_magfield = table_earth_field_ga;
+                    }
                 }
             }
             

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -608,13 +608,16 @@ void NavEKF3_core::readGpsData()
             }
 
             if (gpsGoodToAlign && !have_table_earth_field) {
-                table_earth_field_ga = AP_Declination::get_earth_field_ga(gpsloc);
-                table_declination = radians(AP_Declination::get_declination(gpsloc.lat*1.0e-7,
+                const Compass *compass = _ahrs->get_compass();
+                if (compass && compass->have_scale_factor(magSelectIndex)) {
+                    table_earth_field_ga = AP_Declination::get_earth_field_ga(gpsloc);
+                    table_declination = radians(AP_Declination::get_declination(gpsloc.lat*1.0e-7,
                                                                             gpsloc.lng*1.0e-7));
-                have_table_earth_field = true;
-                if (frontend->_mag_ef_limit > 0) {
-                    // initialise earth field from tables
-                    stateStruct.earth_magfield = table_earth_field_ga;
+                    have_table_earth_field = true;
+                    if (frontend->_mag_ef_limit > 0) {
+                        // initialise earth field from tables
+                        stateStruct.earth_magfield = table_earth_field_ga;
+                    }
                 }
             }
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -202,6 +202,8 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
 
     AP_GROUPINFO("SAFETY_STATE",    59, SITL,  _safety_switch_state, 0),
 
+    AP_GROUPINFO("MAG_SCALING",    60, SITL,  mag_scaling, 1),
+
     AP_GROUPEND
 
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -184,6 +184,7 @@ public:
     AP_Int8  baro_count; // number of simulated baros to create
     AP_Int8 gps_hdg_enabled; // enable the output of a NMEA heading HDT sentence
     AP_Int32 loop_delay; // extra delay to add to every loop
+    AP_Float mag_scaling; // scaling factor on first compasses
 
     // EFI type
     enum EFIType {


### PR DESCRIPTION
This adds new COMPASS_SCALE, COMPASS_SCALE2 and COMPASS_SCALE3  parameters, which give the sensor scaling factor. It is used to compensate for an incorrect scaling in a compass.
The 3D compass calibration process will set the correct value automatically, otherwise users can set the value to a known value for an existing compass.
If the scale factor is not set then the EKF will not use the WMM tables for field constraint

