### PR TITLE
AP_Compass: fix syntax error due to accept_sample() just fixed.

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -181,7 +181,7 @@ void CompassCalibrator::new_sample(const Vector3f& sample)
         set_status(COMPASS_CAL_RUNNING_STEP_ONE);
     }
 
-    if (running() && _samples_collected < COMPASS_CAL_NUM_SAMPLES && accept_sample(sample)) {
+    if (running() && _samples_collected < COMPASS_CAL_NUM_SAMPLES && accept_sample(sample, _samples_collected)) {
         update_completion_mask(sample);
         _sample_buffer[_samples_collected].set(sample);
         _sample_buffer[_samples_collected].att.set_from_ahrs();


### PR DESCRIPTION
I'm sooooo sorry about my mistake that I didn't explain why I just use an extra temporary variable 'temp' in this PR #12177 , about which @tridge asked before, 
And @rmackay9 quoted it and made some improvements to fix more things in this PR #12864 . While this modified version would cause build failure and I just found it in my recent test. It was totally my fault here though I don't understand why the github-online-check didn't realize it. I hope this commit would totally fix this thin_sample() issue then.