### PR TITLE
Sub: do not initialize channels 6 and higher

### DIFF
--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -704,10 +704,6 @@ void Sub::set_neutral_controls()
         RC_Channels::set_override(i, 1500, tnow);
     }
 
-    for (uint8_t i = 6; i < 11; i++) {
-        RC_Channels::set_override(i, 0xffff, tnow);
-    }
-
     // Clear pitch/roll trim settings
     pitchTrim = 0;
     rollTrim  = 0;


### PR DESCRIPTION
~~This brings back the behavior we had in Sub 3.5, [where invalid PWM signals were ignored](https://github.com/ArduPilot/ardupilot/blob/Sub-3.5/libraries/AP_HAL_Linux/RCInput.cpp#L85).~~

~~This check was removed when the [RC overrides where moved out of the hal](https://github.com/ArduPilot/ardupilot/commit/737c4ac36f43496385da1a10faf5cce255fd70f4) and didn't make it to the [new implementation](https://github.com/ArduPilot/ardupilot/commit/4253c7f74d6aa0f63b0eacb8c2286e7a6b8fed62).~~

Without this, when running in a linux board, ArduSub actually tries to write the invalid value to the PWM driver and this causes erratic behavior of some of our peripherals (lights flickering when there is no joystick connected).

~~I'm not sure this is the right fix, so feel free to point to me in the right direction if it isn't.~~

This fixes an issue with Sub where the lights would turn on both at boot and after manual control was lost.