### PR TITLE
AP_RPM: Fix to SITL RPM driver instance

### DIFF
--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -111,7 +111,7 @@ void AP_RPM::init(void)
     }
     for (uint8_t i=0; i<RPM_MAX_INSTANCES; i++) {
         uint8_t type = _type[i];
-
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
         if (type == RPM_TYPE_PWM) {
             // PWM option same as PIN option, for upgrade
             type = RPM_TYPE_PIN;
@@ -119,6 +119,7 @@ void AP_RPM::init(void)
         if (type == RPM_TYPE_PIN) {
             drivers[i] = new AP_RPM_Pin(*this, i, state[i]);
         }
+#endif
 #if EFI_ENABLED
         if (type == RPM_TYPE_EFI) {
             drivers[i] = new AP_RPM_EFI(*this, i, state[i]);


### PR DESCRIPTION
This PR resolves this  #issue:
#12891 

This image demonstrates the issue:
![image](https://user-images.githubusercontent.com/34512430/69740998-2ed57700-1132-11ea-9513-29b951202d37.png)

I believe that because the nullptr check was added:
https://github.com/ArduPilot/ardupilot/blob/306aa5b65429eb3d3c9b60f8199d814f1cfc570e/libraries/AP_RPM/AP_RPM.cpp#L128-L130

It prevented the pointer to the SITL driver from being created as the RPM pin driver was already created.  Added ifdef statement to prevent the RPM_pin drivers from being allocated when using SITL.

I have tested this fix in SITL.  I have not tested on a board.
