### PR TITLE
SITL: Sub: add square curve model to thruster

### DIFF
--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -82,9 +82,9 @@ void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_a
             output = (pwm - 1500) / 400.0; // range -1~1
         }
 
-        // 2.5 scalar for approximate real-life performance of T200 thruster
-        body_accel += t.linear * output * frame_property.thrust / frame_property.weight;
-        rot_accel += t.rotational * output * frame_property.thrust * frame_property.thruster_mount_radius / frame_property.moment_of_inertia;
+        float thrust = output * fabs(output) * frame_property.thrust; // approximate pwm to thrust function using a quadratic curve
+        body_accel += t.linear * thrust / frame_property.weight;
+        rot_accel += t.rotational * thrust * frame_property.thruster_mount_radius / frame_property.moment_of_inertia;
     }
 
     float floor_depth = calculate_sea_floor_depth(position);


### PR DESCRIPTION
Hopefully this is a better fix than https://github.com/ArduPilot/ardupilot/pull/12886.

This makes the pwm to thrust function a quadratic function:
![Screenshot from 2019-11-28 12-55-28](https://user-images.githubusercontent.com/4013804/69819940-ad87ee00-11de-11ea-901d-85e4d406f564.png)

This is the real vehicle's response to a 1526 us pwm in the pool:
![Screenshot from 2019-11-28 13-13-18](https://user-images.githubusercontent.com/4013804/69820893-f0e35c00-11e0-11ea-9782-b639dbd96806.png)


And this is the SITL's response:

![Screenshot from 2019-11-28 12-46-44](https://user-images.githubusercontent.com/4013804/69820036-ede76c00-11de-11ea-9a99-4db61a3c9c47.png)
