### PR TITLE
AP_NMEA_Output: 10hz rate limiting uses uint32_t

### DIFF
--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -67,13 +67,13 @@ uint8_t AP_NMEA_Output::_nmea_checksum(const char *str)
 
 void AP_NMEA_Output::update()
 {
-    const uint16_t now = AP_HAL::millis16();
+    const uint32_t now_ms = AP_HAL::millis();
 
     // only send at 10Hz
-    if (uint16_t(now - _last_run) < 100) {
+    if ((now_ms - _last_run_ms) < 100) {
         return;
     }
-    _last_run = now;
+    _last_run_ms = now_ms;
 
     // get time and date
     uint64_t time_usec;

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.h
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.h
@@ -47,7 +47,7 @@ private:
     uint8_t _num_outputs;
     AP_HAL::UARTDriver* _uart[SERIALMANAGER_NUM_PORTS];
 
-    uint16_t _last_run;
+    uint32_t _last_run_ms;
 };
 
 #endif  // !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE


### PR DESCRIPTION
This is a small follow-up to this PR: https://github.com/ArduPilot/ardupilot/pull/12915

This is a non-functional change that uses uint32_t instead of uint16_t.  A bit pointless now perhaps but I think this is a bit more consistent with how we normally do this sort of thing and I'd already done the work including testing.