### PR TITLE
Copter: always store prev_control_mode

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -396,9 +396,7 @@ private:
     // There are multiple states defined such as STABILIZE, ACRO,
     Mode::Number control_mode;
     ModeReason control_mode_reason = ModeReason::UNKNOWN;
-
     Mode::Number prev_control_mode;
-    ModeReason prev_control_mode_reason = ModeReason::UNKNOWN;
 
     RCMapper rcmap;
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -202,9 +202,8 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to enter a non-manual throttle mode if the
     // rotor runup is not complete
-    if (!ignore_checks && 
-    !new_flightmode->has_manual_throttle() && 
-    (motors->get_spool_state() == AP_Motors::SpoolState::SPOOLING_UP || motors->get_spool_state() == AP_Motors::SpoolState::SPOOLING_DOWN)) {
+    if (!ignore_checks && !new_flightmode->has_manual_throttle() &&
+        (motors->get_spool_state() == AP_Motors::SpoolState::SPOOLING_UP || motors->get_spool_state() == AP_Motors::SpoolState::SPOOLING_DOWN)) {
         #if MODE_AUTOROTATE_ENABLED == ENABLED
             //if the mode being exited is the autorotation mode allow mode change despite rotor not being at
             //full speed.  This will reduce altitude loss on bail-outs back to non-manual throttle modes
@@ -219,12 +218,6 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
             return false;
         }
     }
-
-    #if MODE_AUTOROTATE_ENABLED == ENABLED
-        // If changing to autorotate flight mode from a non-manual throttle mode, store the previous flight mode
-        // to exit back to it when interlock is re-engaged
-        prev_control_mode = control_mode;
-    #endif
 #endif
 
 #if FRAME_CONFIG != HELI_FRAME
@@ -265,6 +258,9 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 
     // perform any cleanup required by previous flight mode
     exit_mode(flightmode, new_flightmode);
+
+    // store previous flight mode (only used by tradeheli's autorotation)
+    prev_control_mode = control_mode;
 
     // update flight mode
     flightmode = new_flightmode;


### PR DESCRIPTION
This PR makes two minor non-functional changes:

- always updates the prev_control_mode variable to the previous flight mode.  I figure if we're going to have this variable in both Copter and TradHeli then it should be updated in both vehicles otherwise we future developers will be confused I think
- remove unused prev_control_mode_reason
- minor formatting fix for TradHeli's set_mode checks