### PR TITLE
Copter: ensure we have a position estimate before arming in Loiter, PosHold, etc

### DIFF
--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -34,6 +34,9 @@ protected:
     bool proximity_checks(bool display_failure) const override;
     bool arm_checks(AP_Arming::Method method) override;
 
+    // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced
+    bool mandatory_checks(bool display_failure) override;
+
     // NOTE! the following check functions *DO* call into AP_Arming:
     bool ins_checks(bool display_failure) override;
     bool compass_checks(bool display_failure) override;
@@ -46,6 +49,7 @@ protected:
     bool motor_checks(bool display_failure);
     bool pilot_throttle_checks(bool display_failure);
     bool oa_checks(bool display_failure);
+    bool mandatory_gps_checks(bool display_failure);
 
     void set_pre_arm_check(bool b);
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -864,7 +864,7 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         return false;
     }
 
-    if (!do_arming_checks || (pre_arm_checks(true) && arm_checks(method))) {
+    if ((!do_arming_checks && mandatory_checks(true)) || (pre_arm_checks(true) && arm_checks(method))) {
         armed = true;
 
         //TODO: Log motor arming

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -133,6 +133,9 @@ protected:
     bool servo_checks(bool report) const;
     bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4]) const;
 
+    // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced
+    virtual bool mandatory_checks(bool report) { return true; }
+
     // returns true if a particular check is enabled
     bool check_enabled(const enum AP_Arming::ArmingChecks check) const;
     // returns a mavlink severity which should be used if a specific check fails


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/11435 which was a serious safety hazard because users could attempt to fly in a mode that requires a position estimate without actually having one by either setting ARMING_CHECK = 0 or using the new "arm throttle force" feature.

To highlight the danger, in SITL I was able set GPS_TYPE = 0 and then arm and fly in Loiter mode.  The result was the vehicle pitched over at 45degrees and would barely respond to user input.

This has been tested in SITL by doing the following:

- param set GPS_TYPE 0
- LOITER
- arm throttle force

The vehicle refused to arm and instead displayed the message "PreArm: EKF2 still initialising".  This is not a great message but compared to Copter-3.6 which simply displays, "PreArm:" (with no message) this is an improvement.

The same behaviour was observed with this similar test:

- param set ARMING_CHECK 0
- LOITER
- arm throttle

Also to ensure the vehicle could still be armed in non-GPS modes the following test was done:

- STABILIZE
- arm throttle

As expected the vehicle could be armed.