### PR TITLE
AP_Landing: emit DEPLOY gcs text only if not already deployed

### DIFF
--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -122,14 +122,15 @@ void AP_LandingGear::deploy()
     // set servo PWM to deployed position
     SRV_Channels::set_output_limit(SRV_Channel::k_landing_gear_control, SRV_Channel::Limit::MAX);
 
+    // send message only if output has been configured
+    if (!_deployed &&
+        SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control)) {
+        gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: DEPLOY");
+    }
+
     // set deployed flag
     _deployed = true;
     _have_changed = true;
-
-    // send message only if output has been configured
-    if (SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: DEPLOY");
-    }
 }
 
 /// retract - retract landing gear


### PR DESCRIPTION
This is a minimal fix for https://discuss.ardupilot.org/t/deploy-landing-gear-message-will-not-break-out-of-loop/49759/1

I'm not sure an early-return here in the case where we are deployed wouldn't be more appropriate - as we are also setting `_have_changed` to true, which is actually not correct!

Minimal fix as things are generally working and this should go into Copter-4.0
