### PR TITLE
AP_HAL_ChibiOS: fix printf error

### DIFF
--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -426,11 +426,11 @@ void SPIDevice::test_clock_freq(void)
     hal.console->printf("Waiting for USB\n");
     for (uint8_t i=0; i<3; i++) {
         hal.scheduler->delay(1000);
-        hal.console->printf("Waiting %u\n", AP_HAL::millis());
+        hal.console->printf("Waiting %u\n", (unsigned)AP_HAL::millis());
     }
     hal.console->printf("CLOCKS=\n");
     for (uint8_t i=0; i<ARRAY_SIZE(bus_clocks); i++) {
-        hal.console->printf("%u:%u ", i+1, bus_clocks[i]);
+        hal.console->printf("%u:%u ", i+1, (unsigned)bus_clocks[i]);
     }
     hal.console->printf("\n");
 


### PR DESCRIPTION
fix spi clock debug error
`../../libraries/AP_HAL_ChibiOS/SPIDevice.cpp: In static member function 'static void ChibiOS::SPIDevice::test_clock_freq()':
../../libraries/AP_HAL_ChibiOS/SPIDevice.cpp:433:61: error: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'uint32_t {aka long unsigned int}' [-Werror=format=]
         hal.console->printf("Waiting %u\n", AP_HAL::millis());
                                             ~~~~~~~~~~~~~~~~^`