### PR TITLE
AC_PosControl_Sub: do not reset accel_z integrator when relaxing

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -100,7 +100,6 @@ void AC_PosControl_Sub::relax_alt_hold_controllers()
     _accel_desired.z = 0.0f;
     _accel_last_z_cms = 0.0f;
     _flags.reset_rate_to_accel_z = true;
-    _pid_accel_z.set_integrator(-_motors.get_throttle_hover() * 1000.0f);
     _accel_target.z = -(_ahrs.get_accel_ef_blended().z + GRAVITY_MSS) * 100.0f;
     _pid_accel_z.reset_filter();
 }


### PR DESCRIPTION
Doing so caused the ROV to dive and slowly go back to the altitude
setpoint everytime it tried to relax the controllers.

This is the depth-hold mode with the reset, notice that it bounces down every time the throttle stick is centered:
![Screenshot from 2019-12-02 12-41-03](https://user-images.githubusercontent.com/4013804/69972800-13d38000-1501-11ea-9a47-9392b34c29d4.png)

And this is without resetting, working as expected (and how it currently works in ArduSub stable):
![Screenshot from 2019-12-02 12-38-48](https://user-images.githubusercontent.com/4013804/69972838-29e14080-1501-11ea-86e0-0ee18a938171.png)

Tested in SITL.
