### PR TITLE
Copter: move RTL state definitions into ModeRTL

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -106,16 +106,6 @@ enum GuidedMode {
     Guided_Angle,
 };
 
-// RTL states
-enum RTLState {
-    RTL_Starting,
-    RTL_InitialClimb,
-    RTL_ReturnHome,
-    RTL_LoiterAtHome,
-    RTL_FinalDescent,
-    RTL_Land
-};
-
 // Safe RTL states
 enum SmartRTLState {
     SmartRTL_WaitForPathCleanup,

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1019,7 +1019,17 @@ public:
     // for reporting to GCS
     bool get_wp(Location &loc) override;
 
-    RTLState state() { return _state; }
+    // RTL states
+    enum class State {
+        Starting,
+        InitialClimb,
+        ReturnHome,
+        LoiterAtHome,
+        FinalDescent,
+        Land
+    };
+
+    State state() const { return _state; }
 
     // this should probably not be exposed
     bool state_complete() { return _state_complete; }
@@ -1056,7 +1066,7 @@ private:
     void build_path();
     void compute_return_target();
 
-    RTLState _state = RTL_InitialClimb;  // records state of rtl (initial climb, returning home, etc)
+    State _state = State::InitialClimb;  // records state of rtl (initial climb, returning home, etc)
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1755,7 +1755,7 @@ bool ModeAuto::verify_loiter_to_alt()
 bool ModeAuto::verify_RTL()
 {
     return (copter.mode_rtl.state_complete() && 
-    (copter.mode_rtl.state() == RTL_FinalDescent || copter.mode_rtl.state() == RTL_Land) &&
+            (copter.mode_rtl.state() == ModeRTL::State::FinalDescent || copter.mode_rtl.state() == ModeRTL::State::Land) &&
     (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
 }
 


### PR DESCRIPTION
Simple namespace change.

Does save 20 bytes on MatekF405-Wing, though, which is interesting.

The enum-class can't be private because ModeAuto uses it.
