### PR TITLE
Create AP_Proximity intermediate Serial backend

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
@@ -1,0 +1,43 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Proximity_Backend_Serial.h"
+
+#include <AP_SerialManager/AP_SerialManager.h>
+
+/*
+   The constructor also initialises the proximity sensor. Note that this
+   constructor is not called until detect() returns true, so we
+   already know that we should setup the proximity sensor
+*/
+AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial(AP_Proximity &_frontend,
+                                                         AP_Proximity::Proximity_State &_state) :
+    AP_Proximity_Backend(_frontend, _state)
+{
+    const AP_SerialManager &serial_manager = AP::serialmanager();
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
+    if (_uart != nullptr) {
+        // start uart with larger receive buffer
+        _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0), rxspace(), 0);
+    }
+}
+
+// detect if a proximity sensor is connected by looking for a
+// configured serial port
+bool AP_Proximity_Backend_Serial::detect()
+{
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
+}
+

--- a/libraries/AP_Proximity/AP_Proximity_Backend_Serial.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend_Serial.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "AP_Proximity.h"
+#include "AP_Proximity_Backend.h"
+
+class AP_Proximity_Backend_Serial : public AP_Proximity_Backend
+{
+public:
+    AP_Proximity_Backend_Serial(AP_Proximity &_frontend,
+                                AP_Proximity::Proximity_State &_state);
+    // static detection function
+    static bool detect();
+
+protected:
+    virtual uint16_t rxspace() const { return 0; };
+
+    AP_HAL::UARTDriver *_uart;              // uart for communicating with sensor
+};

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -16,7 +16,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Math/crc.h>
 #include "AP_Proximity_LightWareSF40C.h"
 
@@ -24,30 +23,6 @@ extern const AP_HAL::HAL& hal;
 
 #define PROXIMITY_SF40C_HEADER                  0xAA
 #define PROXIMITY_SF40C_DESIRED_OUTPUT_RATE     3
-#define PROXIMITY_SF40C_UART_RX_SPACE           1280
-
-/* 
-   The constructor also initialises the proximity sensor. Note that this
-   constructor is not called until detect() returns true, so we
-   already know that we should setup the proximity sensor
-*/
-AP_Proximity_LightWareSF40C::AP_Proximity_LightWareSF40C(AP_Proximity &_frontend,
-                                                         AP_Proximity::Proximity_State &_state) :
-    AP_Proximity_Backend(_frontend, _state)
-{
-    const AP_SerialManager &serial_manager = AP::serialmanager();
-    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
-    if (_uart != nullptr) {
-        // start uart with larger receive buffer
-        _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0), PROXIMITY_SF40C_UART_RX_SPACE, 0);
-    }
-}
-
-// detect if a Lightware proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_LightWareSF40C::detect()
-{
-    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
-}
 
 // update the state of the sensor
 void AP_Proximity_LightWareSF40C::update(void)

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -1,22 +1,22 @@
 #pragma once
 
 #include "AP_Proximity.h"
-#include "AP_Proximity_Backend.h"
+#include "AP_Proximity_Backend_Serial.h"
 
 #define PROXIMITY_SF40C_TIMEOUT_MS            200   // requests timeout after 0.2 seconds
 #define PROXIMITY_SF40C_PAYLOAD_LEN_MAX       256   // maximum payload size we can accept (in some configurations sensor may send as large as 1023)
 #define PROXIMITY_SF40C_COMBINE_READINGS        7   // combine this many readings together to improve efficiency
 
-class AP_Proximity_LightWareSF40C : public AP_Proximity_Backend
+class AP_Proximity_LightWareSF40C : public AP_Proximity_Backend_Serial
 {
 
 public:
     // constructor
-    AP_Proximity_LightWareSF40C(AP_Proximity &_frontend,
-                                AP_Proximity::Proximity_State &_state);
+    using AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial;
 
-    // static detection function
-    static bool detect();
+    uint16_t rxspace() const override {
+        return 1280;
+    };
 
     // update state
     void update(void) override;
@@ -105,7 +105,6 @@ private:
     void process_message();
 
     // internal variables
-    AP_HAL::UARTDriver *_uart;              // uart for communicating with sensor
     uint32_t _last_request_ms;              // system time of last request
     uint32_t _last_reply_ms;                // system time of last valid reply
     uint32_t _last_restart_ms;              // system time we restarted the sensor

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.h
@@ -1,20 +1,16 @@
 #pragma once
 
 #include "AP_Proximity.h"
-#include "AP_Proximity_Backend.h"
+#include "AP_Proximity_Backend_Serial.h"
 
 #define PROXIMITY_SF40C_TIMEOUT_MS            200                               // requests timeout after 0.2 seconds
 
-class AP_Proximity_LightWareSF40C_v09 : public AP_Proximity_Backend
+class AP_Proximity_LightWareSF40C_v09 : public AP_Proximity_Backend_Serial
 {
 
 public:
-    // constructor
-    AP_Proximity_LightWareSF40C_v09(AP_Proximity &_frontend,
-                                AP_Proximity::Proximity_State &_state);
 
-    // static detection function
-    static bool detect();
+    using AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial;
 
     // update state
     void update(void) override;
@@ -51,7 +47,6 @@ private:
     void clear_buffers();
 
     // reply related variables
-    AP_HAL::UARTDriver *uart = nullptr;
     char element_buf[2][10];
     uint8_t element_len[2];
     uint8_t element_num;

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -28,7 +28,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_RPLidarA2.h"
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <ctype.h>
 #include <stdio.h>
 
@@ -63,32 +62,6 @@
 #define RPLIDAR_CMD_EXPRESS_SCAN       0x82
 
 extern const AP_HAL::HAL& hal;
-
-/*
-   The constructor also initialises the proximity sensor. Note that this
-   constructor is not called until detect() returns true, so we
-   already know that we should setup the proximity sensor
- */
-AP_Proximity_RPLidarA2::AP_Proximity_RPLidarA2(
-    AP_Proximity &_frontend,
-    AP_Proximity::Proximity_State &_state) :
-    AP_Proximity_Backend(_frontend, _state)
-{
-    const AP_SerialManager &serial_manager = AP::serialmanager();
-    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
-    if (_uart != nullptr) {
-        _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
-    }
-    _cnt = 0 ;
-    _sync_error = 0 ;
-    _byte_count = 0;
-}
-
-// detect if a RPLidarA2 proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_RPLidarA2::detect()
-{
-    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
-}
 
 // update the _rp_state of the sensor
 void AP_Proximity_RPLidarA2::update(void)

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -30,19 +30,16 @@
 #pragma once
 
 #include "AP_Proximity.h"
-#include "AP_Proximity_Backend.h"
+#include "AP_Proximity_Backend_Serial.h"
 #include <AP_HAL/AP_HAL.h>                   ///< for UARTDriver
 
 
-class AP_Proximity_RPLidarA2 : public AP_Proximity_Backend
+class AP_Proximity_RPLidarA2 : public AP_Proximity_Backend_Serial
 {
 
 public:
-    // constructor
-    AP_Proximity_RPLidarA2(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
-    // static detection function
-    static bool detect();
+    using AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial;
 
     // update state
     void update(void) override;
@@ -79,7 +76,6 @@ private:
     void reset_rplidar();
 
     // reply related variables
-    AP_HAL::UARTDriver *_uart;
     uint8_t _descriptor[7];
     char _rp_systeminfo[63];
     bool _descriptor_data;

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -15,43 +15,16 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_TeraRangerTower.h"
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Math/crc.h>
 #include <ctype.h>
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
 
-/*
-   The constructor also initialises the proximity sensor. Note that this
-   constructor is not called until detect() returns true, so we
-   already know that we should setup the proximity sensor
-*/
-AP_Proximity_TeraRangerTower::AP_Proximity_TeraRangerTower(
-    AP_Proximity &_frontend,
-    AP_Proximity::Proximity_State &_state) :
-    AP_Proximity_Backend(_frontend, _state)
-{
-    const AP_SerialManager &serial_manager = AP::serialmanager();
-
-    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
-    if (uart != nullptr) {
-        uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
-    }
-}
-
-// detect if a TeraRanger Tower proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_TeraRangerTower::detect()
-{
-    AP_HAL::UARTDriver *uart = nullptr;
-    uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
-    return uart != nullptr;
-}
-
 // update the state of the sensor
 void AP_Proximity_TeraRangerTower::update(void)
 {
-    if (uart == nullptr) {
+    if (_uart == nullptr) {
         return;
     }
 
@@ -79,15 +52,15 @@ float AP_Proximity_TeraRangerTower::distance_min() const
 // check for replies from sensor, returns true if at least one message was processed
 bool AP_Proximity_TeraRangerTower::read_sensor_data()
 {
-    if (uart == nullptr) {
+    if (_uart == nullptr) {
         return false;
     }
 
     uint16_t message_count = 0;
-    int16_t nbytes = uart->available();
+    int16_t nbytes = _uart->available();
 
     while (nbytes-- > 0) {
-        char c = uart->read();
+        char c = _uart->read();
         if (c == 'T' ) {
             buffer_count = 0;
         }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
@@ -1,19 +1,16 @@
 #pragma once
 
 #include "AP_Proximity.h"
-#include "AP_Proximity_Backend.h"
+#include "AP_Proximity_Backend_Serial.h"
 
 #define PROXIMITY_TRTOWER_TIMEOUT_MS            300                               // requests timeout after 0.3 seconds
 
-class AP_Proximity_TeraRangerTower : public AP_Proximity_Backend
+class AP_Proximity_TeraRangerTower : public AP_Proximity_Backend_Serial
 {
 
 public:
-    // constructor
-    AP_Proximity_TeraRangerTower(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
-    // static detection function
-    static bool detect();
+    using AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial;
 
     // update state
     void update(void) override;
@@ -29,7 +26,6 @@ private:
     void update_sector_data(int16_t angle_deg, uint16_t distance_cm);
 
     // reply related variables
-    AP_HAL::UARTDriver *uart = nullptr;
     uint8_t buffer[20]; // buffer where to store data from serial
     uint8_t buffer_count;
 

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -15,44 +15,21 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_TeraRangerTowerEvo.h"
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Math/crc.h>
 #include <ctype.h>
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
 
-/*
-   The constructor also initialises the proximity sensor. Note that this
-   constructor is not called until detect() returns true, so we
-   already know that we should setup the proximity sensor
-*/
-AP_Proximity_TeraRangerTowerEvo::AP_Proximity_TeraRangerTowerEvo(AP_Proximity &_frontend,
-                                                         AP_Proximity::Proximity_State &_state) :
-    AP_Proximity_Backend(_frontend, _state)
-{
-    const AP_SerialManager &serial_manager = AP::serialmanager();
-
-    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
-    if (uart != nullptr) {
-        uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
-    }
-    _last_request_sent_ms = AP_HAL::millis();
-}
-
-// detect if a TeraRanger Tower proximity sensor is connected by looking for a configured serial port
-bool AP_Proximity_TeraRangerTowerEvo::detect()
-{
-    return (AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr);
-}
-
 // update the state of the sensor
 void AP_Proximity_TeraRangerTowerEvo::update(void)
 {
-    if (uart == nullptr) {
+    if (_uart == nullptr) {
         return;
     }
-
+    if (_last_request_sent_ms == 0) {
+        _last_request_sent_ms = AP_HAL::millis();
+    }
     //initialize the sensor
     if(_current_init_state != InitState::InitState_Finished)
     {
@@ -101,19 +78,19 @@ void AP_Proximity_TeraRangerTowerEvo::initialise_modes()
 
 void AP_Proximity_TeraRangerTowerEvo::set_mode(const uint8_t *c, int length)
 {
-    uart->write(c, length);
+    _uart->write(c, length);
     _last_request_sent_ms = AP_HAL::millis();
 }
 
 // check for replies from sensor, returns true if at least one message was processed
 bool AP_Proximity_TeraRangerTowerEvo::read_sensor_data()
 {
-    if (uart == nullptr) {
+    if (_uart == nullptr) {
         return false;
     }
 
     uint16_t message_count = 0;
-    int16_t nbytes = uart->available();
+    int16_t nbytes = _uart->available();
 
     if(_current_init_state != InitState_Finished && nbytes == 4) {
 
@@ -137,7 +114,7 @@ bool AP_Proximity_TeraRangerTowerEvo::read_sensor_data()
     }
 
     while (nbytes-- > 0) {
-        char c = uart->read();
+        char c = _uart->read();
         if (c == 'T' ) {
             buffer_count = 0;
         }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
@@ -1,18 +1,15 @@
 #pragma once
 
 #include "AP_Proximity.h"
-#include "AP_Proximity_Backend.h"
+#include "AP_Proximity_Backend_Serial.h"
 
 #define PROXIMITY_TRTOWER_TIMEOUT_MS            300                               // requests timeout after 0.3 seconds
 
-class AP_Proximity_TeraRangerTowerEvo : public AP_Proximity_Backend {
+class AP_Proximity_TeraRangerTowerEvo : public AP_Proximity_Backend_Serial {
 
 public:
-    // constructor
-    AP_Proximity_TeraRangerTowerEvo(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
-    // static detection function
-    static bool detect();
+    using AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial;
 
     // update state
     void update(void) override;
@@ -38,7 +35,6 @@ private:
     };
     
     // reply related variables
-    AP_HAL::UARTDriver *uart = nullptr;
     uint8_t buffer[21]; // buffer where to store data from serial
     uint8_t buffer_count;
 


### PR DESCRIPTION
Saves 264 bytes on MatekF405-Wing.

I only have a physical RPLidarA2 to test this on.

I do have a simulation for the RPLidarA2, but it's not ready to go yet.
