### PR TITLE
Compass Calibrator cleanups - enumeration for status

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -31,7 +31,7 @@ void Compass::cal_update()
 
         if (_calibrator[i].running()) {
             running = true;
-        } else if (_cal_autosave && !_cal_saved[i] && _calibrator[i].get_status() == COMPASS_CAL_SUCCESS) {
+        } else if (_cal_autosave && !_cal_saved[i] && _calibrator[i].get_status() == CompassCalibrator::Status::SUCCESS) {
             _accept_calibration(i);
         }
     }
@@ -119,7 +119,7 @@ void Compass::_cancel_calibration(uint8_t i)
 {
     AP_Notify::events.initiated_compass_cal = 0;
 
-    if (_calibrator[i].running() || _calibrator[i].get_status() == COMPASS_CAL_WAITING_TO_START) {
+    if (_calibrator[i].running() || _calibrator[i].get_status() == CompassCalibrator::Status::WAITING_TO_START) {
         AP_Notify::events.compass_cal_canceled = 1;
     }
     _cal_saved[i] = false;
@@ -143,11 +143,11 @@ void Compass::cancel_calibration_all()
 bool Compass::_accept_calibration(uint8_t i)
 {
     CompassCalibrator& cal = _calibrator[i];
-    uint8_t cal_status = cal.get_status();
+    const CompassCalibrator::Status cal_status = cal.get_status();
 
-    if (_cal_saved[i] || cal_status == COMPASS_CAL_NOT_STARTED) {
+    if (_cal_saved[i] || cal_status == CompassCalibrator::Status::NOT_STARTED) {
         return true;
-    } else if (cal_status == COMPASS_CAL_SUCCESS) {
+    } else if (cal_status == CompassCalibrator::Status::SUCCESS) {
         _cal_complete_requires_reboot = true;
         _cal_saved[i] = true;
 
@@ -202,11 +202,11 @@ bool Compass::send_mag_cal_progress(const GCS_MAVLINK& link)
         }
 
         auto& calibrator = _calibrator[compass_id];
-        uint8_t cal_status = calibrator.get_status();
+        const CompassCalibrator::Status cal_status = calibrator.get_status();
 
-        if (cal_status == COMPASS_CAL_WAITING_TO_START  ||
-            cal_status == COMPASS_CAL_RUNNING_STEP_ONE ||
-            cal_status == COMPASS_CAL_RUNNING_STEP_TWO) {
+        if (cal_status == CompassCalibrator::Status::WAITING_TO_START  ||
+            cal_status == CompassCalibrator::Status::RUNNING_STEP_ONE ||
+            cal_status == CompassCalibrator::Status::RUNNING_STEP_TWO) {
             uint8_t completion_pct = calibrator.get_completion_percent();
             const CompassCalibrator::completion_mask_t& completion_mask = calibrator.get_completion_mask();
             const Vector3f direction;
@@ -215,7 +215,7 @@ bool Compass::send_mag_cal_progress(const GCS_MAVLINK& link)
             mavlink_msg_mag_cal_progress_send(
                 link.get_chan(),
                 compass_id, cal_mask,
-                cal_status, attempt, completion_pct, completion_mask,
+                (uint8_t)cal_status, attempt, completion_pct, completion_mask,
                 direction.x, direction.y, direction.z
             );
         }
@@ -237,10 +237,10 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
             return true;
         }
 
-        uint8_t cal_status = _calibrator[compass_id].get_status();
-        if (cal_status == COMPASS_CAL_SUCCESS ||
-            cal_status == COMPASS_CAL_FAILED ||
-            cal_status == COMPASS_CAL_BAD_ORIENTATION) {
+        const CompassCalibrator::Status cal_status = _calibrator[compass_id].get_status();
+        if (cal_status == CompassCalibrator::Status::SUCCESS ||
+            cal_status == CompassCalibrator::Status::FAILED ||
+            cal_status == CompassCalibrator::Status::BAD_ORIENTATION) {
             float fitness = _calibrator[compass_id].get_fitness();
             Vector3f ofs, diag, offdiag;
             float scale_factor;
@@ -250,7 +250,7 @@ bool Compass::send_mag_cal_report(const GCS_MAVLINK& link)
             mavlink_msg_mag_cal_report_send(
                 link.get_chan(),
                 compass_id, cal_mask,
-                cal_status, autosaved,
+                (uint8_t)cal_status, autosaved,
                 fitness,
                 ofs.x, ofs.y, ofs.z,
                 diag.x, diag.y, diag.z,
@@ -269,10 +269,10 @@ bool Compass::is_calibrating() const
 {
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
         switch(_calibrator[i].get_status()) {
-            case COMPASS_CAL_NOT_STARTED:
-            case COMPASS_CAL_SUCCESS:
-            case COMPASS_CAL_FAILED:
-            case COMPASS_CAL_BAD_ORIENTATION:
+            case CompassCalibrator::Status::NOT_STARTED:
+            case CompassCalibrator::Status::SUCCESS:
+            case CompassCalibrator::Status::FAILED:
+            case CompassCalibrator::Status::BAD_ORIENTATION:
                 break;
             default:
                 return true;
@@ -285,7 +285,7 @@ uint8_t Compass::_get_cal_mask() const
 {
     uint8_t cal_mask = 0;
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
-        if (_calibrator[i].get_status() != COMPASS_CAL_NOT_STARTED) {
+        if (_calibrator[i].get_status() != CompassCalibrator::Status::NOT_STARTED) {
             cal_mask |= 1 << i;
         }
     }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -73,9 +73,7 @@ extern const AP_HAL::HAL& hal;
 ///////////////////// PUBLIC INTERFACE /////////////////////
 ////////////////////////////////////////////////////////////
 
-CompassCalibrator::CompassCalibrator():
-    _tolerance(COMPASS_CAL_DEFAULT_TOLERANCE),
-    _sample_buffer(nullptr)
+CompassCalibrator::CompassCalibrator()
 {
     stop();
 }

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -5,7 +5,6 @@
 #define COMPASS_CAL_NUM_SPHERE_PARAMS       4
 #define COMPASS_CAL_NUM_ELLIPSOID_PARAMS    9
 #define COMPASS_CAL_NUM_SAMPLES             300     // number of samples required before fitting begins
-#define COMPASS_CAL_DEFAULT_TOLERANCE       5.0f    // default RMS tolerance
 
 #define COMPASS_MIN_SCALE_FACTOR 0.85
 #define COMPASS_MAX_SCALE_FACTOR 1.3
@@ -170,7 +169,7 @@ private:
     // values provided by caller
     float _delay_start_sec;                 // seconds to delay start of calibration (provided by caller)
     bool _retry;                            // true if calibration should be restarted on failured (provided by caller)
-    float _tolerance;                       // worst acceptable tolerance (aka fitness).  see set_tolerance()
+    float _tolerance = 5.0;                 // worst acceptable RMS tolerance (aka fitness).  see set_tolerance()
     uint16_t _offset_max;                   // maximum acceptable offsets (provided by caller)
 
     // behavioral state

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -7,18 +7,6 @@
 #define COMPASS_CAL_NUM_SAMPLES             300     // number of samples required before fitting begins
 #define COMPASS_CAL_DEFAULT_TOLERANCE       5.0f    // default RMS tolerance
 
-// compass calibration states
-enum compass_cal_status_t {
-    COMPASS_CAL_NOT_STARTED = 0,
-    COMPASS_CAL_WAITING_TO_START = 1,
-    COMPASS_CAL_RUNNING_STEP_ONE = 2,
-    COMPASS_CAL_RUNNING_STEP_TWO = 3,
-    COMPASS_CAL_SUCCESS = 4,
-    COMPASS_CAL_FAILED = 5,
-    COMPASS_CAL_BAD_ORIENTATION = 6,
-    COMPASS_CAL_BAD_RADIUS = 7,
-};
-
 #define COMPASS_MIN_SCALE_FACTOR 0.85
 #define COMPASS_MAX_SCALE_FACTOR 1.3
 
@@ -45,8 +33,20 @@ public:
     // running is true if actively calculating offsets, diagonals or offdiagonals
     bool running() const;
 
+    // compass calibration states
+    enum class Status {
+        NOT_STARTED = 0,
+        WAITING_TO_START = 1,
+        RUNNING_STEP_ONE = 2,
+        RUNNING_STEP_TWO = 3,
+        SUCCESS = 4,
+        FAILED = 5,
+        BAD_ORIENTATION = 6,
+        BAD_RADIUS = 7,
+    };
+
     // get status of calibrations progress
-    enum compass_cal_status_t get_status() const { return _status; }
+    Status get_status() const { return _status; }
 
     // get calibration outputs (offsets, diagonals, offdiagonals) and fitness
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals, float &scale_factor);
@@ -111,7 +111,7 @@ private:
     };
 
     // set status including any required initialisation
-    bool set_status(compass_cal_status_t status);
+    bool set_status(Status status);
 
     // returns true if sample should be added to buffer
     bool accept_sample(const Vector3f &sample, uint16_t skip_index = UINT16_MAX);
@@ -164,7 +164,7 @@ private:
     bool fix_radius();
 
     uint8_t _compass_idx;                   // index of the compass providing data
-    enum compass_cal_status_t _status;      // current state of calibrator
+    Status _status;                         // current state of calibrator
     uint32_t _last_sample_ms;               // system time of last sample received for timeout
 
     // values provided by caller


### PR DESCRIPTION
Bizarrely, this saves 300 bytes on the MatekF405-Wing.  It's the enum-class change saving bytes.
 
Mag cal still runs on a PixRacer here, so...
