### PR TITLE
Use EKF core as instance number when logging EKF timings

### DIFF
--- a/libraries/AP_NavEKF/AP_Nav_Common.cpp
+++ b/libraries/AP_NavEKF/AP_Nav_Common.cpp
@@ -6,13 +6,16 @@
 /*
   write an EKF timing message
  */
-void Log_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing)
+void Log_EKF_Timing(const char * name, const uint8_t core, uint64_t time_us, const struct ekf_timing &timing)
 {
     AP::logger().Write(
         name,
-        "TimeUS,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax",
-        "QIffffffff",
+        "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax",
+        "s#sssssssss", // Units
+        "F-000000000", // Mults
+        "QBIffffffff", // Format
         time_us,
+        core,
         timing.count,
         (double)timing.dtIMUavg_min,
         (double)timing.dtIMUavg_max,

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -75,4 +75,4 @@ struct ekf_timing {
     float delVelDT_max;
     float delVelDT_min;
 };
-void Log_EKF_Timing(const char *name, uint64_t time_us, const struct ekf_timing &timing);
+void Log_EKF_Timing(const char *name, const uint8_t core, uint64_t time_us, const struct ekf_timing &timing);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -275,13 +275,7 @@ void NavEKF2::Log_Write()
         struct ekf_timing timing;
         for (uint8_t i=0; i<activeCores(); i++) {
             getTimingStatistics(i, timing);
-            if (i == 0) {
-                Log_EKF_Timing("NKT1", time_us, timing);
-            } else if (i == 1) {
-                Log_EKF_Timing("NKT2", time_us, timing);
-            } else if (i == 2) {
-                Log_EKF_Timing("NKT3", time_us, timing);
-            }
+            Log_EKF_Timing("NKT", i, time_us, timing);
         }
     }
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -346,13 +346,7 @@ void NavEKF3::Log_Write()
         struct ekf_timing timing;
         for (uint8_t i=0; i<activeCores(); i++) {
             getTimingStatistics(i, timing);
-            if (i == 0) {
-                Log_EKF_Timing("XKT1", time_us, timing);
-            } else if (i == 1) {
-                Log_EKF_Timing("XKT2", time_us, timing);
-            } else if (i == 2) {
-                Log_EKF_Timing("XKT3", time_us, timing);
-            }
+            Log_EKF_Timing("XKT", i, time_us, timing);
         }
     }
 }


### PR DESCRIPTION
Also adds units to this message.

May make things slightly faster as we won't be creating as many dynamic log messages this way.
