### PR TITLE
HAL_ChibiOS: fixed handling of 16bit timer wrap

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -102,6 +102,7 @@ static void show_timings(void)
 
     TIMEIT("micros()", AP_HAL::micros(), 200);
     TIMEIT("millis()", AP_HAL::millis(), 200);
+    TIMEIT("micros64()", AP_HAL::micros64(), 200);
 
     TIMEIT("fadd", v_out += v_f, 100);
     TIMEIT("fsub", v_out -= v_f, 100);

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
@@ -13,60 +13,84 @@
  * You should have received a copy of the GNU General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-// High Resolution Timer
+/*
+  High Resolution Timer code. This provides support for 32 and 64 bit
+  returns for micros and millis functions
+*/
 
 #include "ch.h"
 #include "hal.h"
 #include "hrt.h"
 #include <stdint.h>
 
-static uint64_t timer_base_us64;
-#if CH_CFG_ST_RESOLUTION == 16
-static uint32_t timer_base_us32;
+#pragma GCC optimize("O2")
+
+/*
+  we have 4 possible configurations of boards, made up of boards that
+  have the following properties:
+
+    CH_CFG_ST_RESOLUTION = 16 or 32
+    CH_CFG_ST_FREQUENCY  = 1000 or 1000000
+
+  To keep as much code in common as possible we create a function
+  system_time_u32_us() for all boards which gives system time since
+  boot in microseconds, and which wraps at 0xFFFFFFFF.
+
+  On top of this base function we build get_systime_us32() which has
+  the same property, but which also maintains timer_base_us64 to allow
+  for micros64()
+*/
+
+#if CH_CFG_ST_FREQUENCY != 1000000U && CH_CFG_ST_FREQUENCY != 1000U
+#error "unsupported tick frequency"
 #endif
-static uint32_t timer_base_ms;
-static volatile systime_t last_systime;
 
 #if CH_CFG_ST_RESOLUTION == 16
-static uint32_t get_systime_us32(void)
+static uint32_t system_time_u32_us(void)
 {
     systime_t now = chVTGetSystemTimeX();
-#if CH_CFG_ST_FREQUENCY != 1000000
-    now *= (1000000UL / CH_CFG_ST_FREQUENCY);
+#if CH_CFG_ST_FREQUENCY == 1000U
+    now *= 1000U;
 #endif
-    if (now < last_systime) {
-        uint32_t last_u32 = timer_base_us32;
-        timer_base_us32 += (uint32_t)TIME_MAX_SYSTIME;
-        if (timer_base_us32 < last_u32) {
-            timer_base_us64 += ((uint32_t)-1);
-            timer_base_ms += ((uint32_t)-1)/1000;
-        }
-    }
+    static systime_t last_systime;
+    static uint32_t timer_base_us32;
+    uint16_t dt = now - last_systime;
     last_systime = now;
-    return timer_base_us32 + (uint32_t)now;
+    timer_base_us32 += dt;
+    return timer_base_us32;
 }
-
 #elif CH_CFG_ST_RESOLUTION == 32
-static uint32_t get_systime_us32(void)
+static uint32_t system_time_u32_us(void)
 {
     systime_t now = chVTGetSystemTimeX();
-#if CH_CFG_ST_FREQUENCY != 1000000
-    now *= (1000000UL / CH_CFG_ST_FREQUENCY);
+#if CH_CFG_ST_FREQUENCY == 1000U
+    now *= 1000U;
 #endif
-    if (now < last_systime) {
-        timer_base_us64 += TIME_MAX_SYSTIME;
-        timer_base_ms += TIME_MAX_SYSTIME/1000;
-    }
-    last_systime = now;
     return now;
 }
 #else
 #error "unsupported timer resolution"
 #endif
 
+// offset for micros64()
+static uint64_t timer_base_us64;
+
+static uint32_t get_systime_us32(void)
+{
+    static uint32_t last_us32;
+    uint32_t now = system_time_u32_us();
+    if (now < last_us32) {
+        const uint64_t dt_us = 0x100000000ULL;
+        timer_base_us64 += dt_us;
+    }
+    last_us32 = now;
+    return now;
+}
+
 /*
-  we use chSysGetStatusAndLockX() to prevent an interrupt while
-  allowing this call from any context
+  for the exposed functions we use chSysGetStatusAndLockX() to prevent
+  an interrupt changing the globals while allowing this call from any
+  context
 */
 
 uint64_t hrt_micros64()
@@ -88,9 +112,5 @@ uint32_t hrt_micros32()
 
 uint32_t hrt_millis32()
 {
-    syssts_t sts = chSysGetStatusAndLockX();
-    uint32_t now = get_systime_us32();
-    uint32_t ret = (now / 1000U) + timer_base_ms;
-    chSysRestoreStatusX(sts);
-    return ret;
+    return (uint32_t)(hrt_micros64() / 1000U);
 }

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -26,6 +26,12 @@
 #include "hal.h"
 #include <hrt.h>
 
+#if CH_CFG_ST_RESOLUTION == 16
+static_assert(sizeof(systime_t) == 2, "expected 16 bit systime_t");
+#elif CH_CFG_ST_RESOLUTION == 32
+static_assert(sizeof(systime_t) == 4, "expected 32 bit systime_t");
+#endif
+
 extern const AP_HAL::HAL& hal;
 extern "C"
 {

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -32,27 +32,27 @@ public:
     // of thing.  Examples of what NOT to put in here - sd card
     // filling up, bad input received from GCS, GPS unit was working
     // and now is not.
-    enum class error_t {
-        logger_mapfailure           = (1U <<  0),
-        logger_missing_logstructure = (1U <<  1),
-        logger_logwrite_missingfmt  = (1U <<  2),
-        logger_too_many_deletions   = (1U <<  3),
-        logger_bad_getfilename      = (1U <<  4),
-        unused1                     = (1U <<  5), // was logger_stopping_without_sem
-        logger_flushing_without_sem = (1U <<  6),
-        logger_bad_current_block    = (1U <<  7),
-        logger_blockcount_mismatch  = (1U <<  8),
-        logger_dequeue_failure      = (1U <<  9),
-        constraining_nan            = (1U << 10),
-        watchdog_reset              = (1U << 11),
-        iomcu_reset                 = (1U << 12),
-        iomcu_fail                  = (1U << 13),
-        spi_fail                    = (1U << 14),
-        main_loop_stuck             = (1U << 15),
-        gcs_bad_missionprotocol_link= (1U << 16),
-        bitmask_range               = (1U << 17),
-        gcs_offset                  = (1U << 18),
-        i2c_isr                     = (1U << 19),
+    enum class error_t {                           // Hex      Decimal
+        logger_mapfailure           = (1U <<  0),  // 0x00001  1
+        logger_missing_logstructure = (1U <<  1),  // 0x00002  2
+        logger_logwrite_missingfmt  = (1U <<  2),  // 0x00004  4
+        logger_too_many_deletions   = (1U <<  3),  // 0x00008  8
+        logger_bad_getfilename      = (1U <<  4),  // 0x00010  16
+        unused1                     = (1U <<  5),  // 0x00020  32
+        logger_flushing_without_sem = (1U <<  6),  // 0x00040  64
+        logger_bad_current_block    = (1U <<  7),  // 0x00080  128
+        logger_blockcount_mismatch  = (1U <<  8),  // 0x00100  256
+        logger_dequeue_failure      = (1U <<  9),  // 0x00200  512
+        constraining_nan            = (1U << 10),  // 0x00400  1024
+        watchdog_reset              = (1U << 11),  // 0x00800  2048
+        iomcu_reset                 = (1U << 12),  // 0x01000  4096
+        iomcu_fail                  = (1U << 13),  // 0x02000  8192
+        spi_fail                    = (1U << 14),  // 0x04000  16384
+        main_loop_stuck             = (1U << 15),  // 0x08000  32768
+        gcs_bad_missionprotocol_link= (1U << 16),  // 0x10000  65536
+        bitmask_range               = (1U << 17),  // 0x20000  131072
+        gcs_offset                  = (1U << 18),  // 0x40000  262144
+        i2c_isr                     = (1U << 19),  // 0x80000  524288
         flow_of_control             = (1U << 20), // for generic we-should-never-get-here situations
     };
 


### PR DESCRIPTION
this fixes #12948
This is a critical fix for MatekF765 and MatekF405, which use 16 bit timers
This adds a common system_time_u32_us() so 16 bit and 32 bit systems have identical behaviour