### PR TITLE
Removes a piece of legacy script

### DIFF
--- a/Tools/scripts/build_parameters.sh
+++ b/Tools/scripts/build_parameters.sh
@@ -13,9 +13,6 @@ PARAMS_DIR="../buildlogs/Parameters"
 
 generate_parameters() {
     VEHICLE="$1"
-    URL="$2"
-    AUTHFILE="$3"
-    POST_TITLE="$4"
 
     # generate Parameters.html, Parameters.rst etc etc:
     ./Tools/autotest/param_metadata/param_parse.py --vehicle $VEHICLE
@@ -23,19 +20,19 @@ generate_parameters() {
     # stash some of the results away:
     VEHICLE_PARAMS_DIR="$PARAMS_DIR/$VEHICLE"
     mkdir -p "$VEHICLE_PARAMS_DIR"
-    /bin/cp Parameters.wiki Parameters.html *.pdef.xml "$VEHICLE_PARAMS_DIR/"
+    /bin/rm Parameters.wiki Parameters.html *.pdef.xml
     if [ -e "Parameters.rst" ]; then
 	/bin/cp Parameters.rst "$VEHICLE_PARAMS_DIR/"
     fi
 }
 
 
-generate_parameters ArduPlane http://plane.ardupilot.org plane.auth 'Plane Parameters'
+generate_parameters ArduPlane
 
-generate_parameters ArduCopter http://copter.ardupilot.org copter.auth 'Copter Parameters'
+generate_parameters ArduCopter
 
-generate_parameters APMrover2 http://rover.ardupilot.org rover.auth 'Rover Parameters'
+generate_parameters APMrover2 
 
-generate_parameters ArduSub http://sub.ardupilot.org sub.auth 'Sub Parameters'
+generate_parameters ArduSub
 
-generate_parameters AntennaTracker NONE NONE 'AntennaTracker Parameters'
+generate_parameters AntennaTracker 


### PR DESCRIPTION
I am trying to find my self around and understand the build server execution stream, and I think this code belongs as part of PR #12980.

It has Parameters files in formats that are not used by the actual wiki building scripts and not used parameters for script function.