### PR TITLE
GCS_MAVLink: add mask to send_textv, use it for the GCS_MAVLINK send_…

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -35,11 +35,11 @@ const MAV_MISSION_TYPE GCS_MAVLINK::supported_mission_types[] = {
 /*
   send a text message to all GCS
  */
-void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
+void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t mask)
 {
     char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
-    send_statustext(severity, GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask(), text);
+    send_statustext(severity, mask, text);
 }
 
 void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -832,7 +832,11 @@ public:
     void send_to_active_channels(uint32_t msgid, const char *pkt);
 
     void send_text(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(3, 4);
-    void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
+    void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t mask);
+    void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list) {
+        // if no mask is supplied we send to active and streaming channels
+        send_textv(severity, fmt, arg_list, uint8_t(GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask()));
+    }
     virtual void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
     void service_statustext(void);
     virtual GCS_MAVLINK *chan(const uint8_t ofs) = 0;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -597,12 +597,10 @@ void GCS_MAVLINK::handle_param_value(const mavlink_message_t &msg)
 
 void GCS_MAVLINK::send_text(MAV_SEVERITY severity, const char *fmt, ...) const
 {
-    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     va_list arg_list;
     va_start(arg_list, fmt);
-    hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
+    gcs().send_textv(severity, fmt, arg_list, (1<<chan));
     va_end(arg_list);
-    gcs().send_statustext(severity, (1<<chan), text);
 }
 
 void GCS_MAVLINK::handle_radio_status(const mavlink_message_t &msg, bool log_radio)


### PR DESCRIPTION
…text

This reduces the places where we put the statustext string onto the
stack when doing the vsnprintf thing.