### PR TITLE
Use extensions to allow amalgamation of statustext messages

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -37,7 +37,7 @@ const MAV_MISSION_TYPE GCS_MAVLINK::supported_mission_types[] = {
  */
 void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
 {
-    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    char text[256+1]; // eep!  Stack!  Eeep!
     hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
     send_statustext(severity, GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask(), text);
 }

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -35,11 +35,11 @@ const MAV_MISSION_TYPE GCS_MAVLINK::supported_mission_types[] = {
 /*
   send a text message to all GCS
  */
-void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
+void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t mask)
 {
     char text[256+1]; // eep!  Stack!  Eeep!
     hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
-    send_statustext(severity, GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask(), text);
+    send_statustext(severity, mask, text);
 }
 
 void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -934,9 +934,9 @@ private:
     void update_sensor_status_flags();
 
 #if HAL_MEM_CLASS <= HAL_MEM_CLASS_192 || CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    static const uint8_t _status_capacity = 5;
+    const uint8_t _status_capacity = 5;
 #else
-    static const uint8_t _status_capacity = 30;
+    const uint8_t _status_capacity = 30;
 #endif
 
     // a lock for the statustext queue, to make it safe to use send_text()

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -832,7 +832,11 @@ public:
     void send_to_active_channels(uint32_t msgid, const char *pkt);
 
     void send_text(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(3, 4);
-    void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
+    void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t mask);
+    void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list) {
+        // if no mask is supplied we send to active and streaming channels
+        send_textv(severity, fmt, arg_list, uint8_t(GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask()));
+    }
     virtual void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
     void service_statustext(void);
     virtual GCS_MAVLINK *chan(const uint8_t ofs) = 0;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1870,6 +1870,31 @@ void GCS::send_message(enum ap_message id)
 
 void GCS::update_send()
 {
+    static uint32_t last_send;
+    const uint32_t now = AP_HAL::millis();
+    static uint32_t count = 0;
+    if (now - last_send > 100) {
+        gcs().send_text(MAV_SEVERITY_INFO, "%u", count);
+
+        char buffer[300];
+        uint16_t i;
+        for (i=0; i<count;i++) {
+            const uint8_t x = i % 16;
+            if (x > 9) {
+                buffer[i] = 'A' + x - 10;
+            } else {
+                buffer[i] = '0' + x;
+            }
+        }
+        buffer[i] = '\0';
+        gcs().send_text(MAV_SEVERITY_INFO, "%s", buffer);
+        last_send = now;
+        count++;
+        if (count == sizeof(buffer)) {
+            count = 0;
+        }
+    }
+
     if (!initialised_missionitemprotocol_objects) {
         initialised_missionitemprotocol_objects = true;
         // once-only initialisation of MissionItemProtocol objects:

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -597,12 +597,10 @@ void GCS_MAVLINK::handle_param_value(const mavlink_message_t &msg)
 
 void GCS_MAVLINK::send_text(MAV_SEVERITY severity, const char *fmt, ...) const
 {
-    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     va_list arg_list;
     va_start(arg_list, fmt);
-    hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
+    gcs().send_textv(severity, fmt, arg_list, (1<<chan));
     va_end(arg_list);
-    gcs().send_statustext(severity, (1<<chan), text);
 }
 
 void GCS_MAVLINK::handle_radio_status(const mavlink_message_t &msg, bool log_radio)


### PR DESCRIPTION
... and split long strings into multiple statustext messages.

Sample output from MAVProxy for long text messages:

```
APM: 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123
APM: 229
APM: 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF01234
APM: 230
APM: 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF012345
APM: 231
APM: 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456
```
