### PR TITLE
AC_Fence: turn debug messages off

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -5,7 +5,7 @@
 
 #include <stdio.h>
 
-#define POLYFENCE_LOADER_DEBUGGING 1
+#define POLYFENCE_LOADER_DEBUGGING 0
 
 #if POLYFENCE_LOADER_DEBUGGING
 #define Debug(fmt, args ...)  do { gcs().send_text(MAV_SEVERITY_INFO, fmt, ## args); } while (0)

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -185,7 +185,6 @@ MAV_MISSION_RESULT MissionItemProtocol_Fence::allocate_receive_resources(const u
     }
 
     const uint16_t allocation_size = count * sizeof(AC_PolyFenceItem);
-    gcs().send_text(MAV_SEVERITY_DEBUG, "Allocating %u bytes for fence upload", allocation_size);
     if (allocation_size != 0) {
         _new_items = (AC_PolyFenceItem*)malloc(allocation_size);
         if (_new_items == nullptr) {


### PR DESCRIPTION
This removes two places where we send messages re memory allocation to the user as part of the fence upload.

As I'm sure everyone knows I'm not a fan of these types of messages to users when things are working normally.  They're not useful to most users and will instead just make the system appear scary and/or complicated.

![image](https://user-images.githubusercontent.com/1498098/70432842-8cb77680-1ac3-11ea-8ac9-40e1de497766.png)

This has been tested on a real board and the messages don't appear anymore