### PR TITLE
AP_Avoidance/AP_Proximity: simplification and efficiency improvements

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -371,16 +371,10 @@ bool AP_OABendyRuler::calc_margin_from_object_database(const Location &start, co
     // check each obstacle's distance from segment
     float smallest_margin = FLT_MAX;
     for (uint16_t i=0; i<oaDb->database_count(); i++) {
-
-        // convert obstacle's location to offset (in cm) from EKF origin
-        Vector2f point;
         const AP_OADatabase::OA_DbItem& item = oaDb->get_item(i);
-        if (!item.loc.get_vector_xy_from_origin_NE(point)) {
-            continue;
-        }
-
+        const Vector2f point_cm = item.pos * 100.0f;
         // margin is distance between line segment and obstacle minus obstacle's radius
-        const float m = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, point) * 0.01f - item.radius;
+        const float m = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, point_cm) * 0.01f - item.radius;
         if (m < smallest_margin) {
             smallest_margin = m;
         }

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -374,12 +374,13 @@ bool AP_OABendyRuler::calc_margin_from_object_database(const Location &start, co
 
         // convert obstacle's location to offset (in cm) from EKF origin
         Vector2f point;
-        if (!oaDb->get_item(i).loc.get_vector_xy_from_origin_NE(point)) {
+        const AP_OADatabase::OA_DbItem& item = oaDb->get_item(i);
+        if (!item.loc.get_vector_xy_from_origin_NE(point)) {
             continue;
         }
 
         // margin is distance between line segment and obstacle minus obstacle's radius
-        const float m = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, point) * 0.01f - oaDb->get_accuracy();
+        const float m = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, point) * 0.01f - item.radius;
         if (m < smallest_margin) {
             smallest_margin = m;
         }

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -355,7 +355,6 @@ bool AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_circles(const Loc
 // on success returns true and updates margin
 bool AP_OABendyRuler::calc_margin_from_object_database(const Location &start, const Location &end, float &margin)
 {
-#if !HAL_MINIMIZE_FEATURES
     // exit immediately if db is empty
     AP_OADatabase *oaDb = AP::oadatabase();
     if (oaDb == nullptr || !oaDb->healthy()) {
@@ -386,6 +385,5 @@ bool AP_OABendyRuler::calc_margin_from_object_database(const Location &start, co
         return true;
     }
 
-#endif
     return false;
 }

--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -341,6 +341,12 @@ void AP_OADatabase::send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_
         return;
     }
 
+    // use vehicle's current altitude
+    Location current_loc;
+    if (!AP::ahrs().get_position(current_loc)) {
+        current_loc.alt = 0;
+    }
+
     const uint8_t chan_as_bitmask = 1 << chan;
     const char callsign[9] = "OA_DB";
 
@@ -381,7 +387,7 @@ void AP_OADatabase::send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_
             item_loc.lat,
             item_loc.lng,
             0,                          // altitude_type
-            0,                          // altitude is always zero
+            current_loc.alt,            // use vehicle's current altitude
             0,                          // heading
             0,                          // hor_velocity
             0,                          // ver_velocity

--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -13,8 +13,6 @@
 
 #include "AP_OADatabase.h"
 
-#if !HAL_MINIMIZE_FEATURES
-
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Math/AP_Math.h>
@@ -439,7 +437,6 @@ void AP_OADatabase::send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_
 
 // singleton instance
 AP_OADatabase *AP_OADatabase::_singleton;
-#endif //!HAL_MINIMIZE_FEATURES
 
 namespace AP {
 AP_OADatabase *oadatabase()

--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -106,7 +106,7 @@ void AP_OADatabase::update()
 }
 
 // push a location into the database
-void AP_OADatabase::queue_push(const Location &loc, const uint32_t timestamp_ms, const float distance, const float angle)
+void AP_OADatabase::queue_push(const Location &loc, uint32_t timestamp_ms, float angle, float distance)
 {
     if (!healthy()) {
         return;

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -3,8 +3,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-
-#if !HAL_MINIMIZE_FEATURES
 #include <AP_Param/AP_Param.h>
 
 class AP_OADatabase {
@@ -111,16 +109,6 @@ private:
 
     static AP_OADatabase *_singleton;
 };
-#else
-class AP_OADatabase {
-public:
-    static AP_OADatabase *get_singleton() { return nullptr; }
-    void init() {};
-    void queue_push(const Vector2f &pos, uint32_t timestamp_ms, float distance) {};
-    bool healthy() const { return false; }
-    void send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_ms) {};
-};
-#endif // #if !HAL_MINIMIZE_FEATURES
 
 namespace AP {
     AP_OADatabase *oadatabase();

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Common/Location.h>
+#include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
 #if !HAL_MINIMIZE_FEATURES
@@ -26,7 +26,7 @@ public:
     };
 
     struct OA_DbItem {
-        Location loc;           // location of object. TODO: turn this into Vector2Int to save memory
+        Vector2f pos;           // position of the object as an offset in meters from the EKF origin
         uint32_t timestamp_ms;  // system time that object was last updated
         float radius;           // objects radius in meters
         uint8_t send_to_gcs;    // bitmask of mavlink comports to which details of this object should be sent
@@ -36,8 +36,8 @@ public:
     void init();
     void update();
 
-    // push a location into the database
-    void queue_push(const Location &loc, uint32_t timestamp_ms, float angle, float distance);
+    // push an object into the database.  Pos is the offset in meters from the EKF origin, angle is in degrees, distance in meters
+    void queue_push(const Vector2f &pos, uint32_t timestamp_ms, float distance);
 
     // returns true if database is healthy
     bool healthy() const { return (_queue.items != nullptr) && (_database.items != nullptr); }
@@ -116,7 +116,7 @@ class AP_OADatabase {
 public:
     static AP_OADatabase *get_singleton() { return nullptr; }
     void init() {};
-    void queue_push(const Location &loc, uint32_t timestamp_ms, float angle, float distance) {};
+    void queue_push(const Vector2f &pos, uint32_t timestamp_ms, float distance) {};
     bool healthy() const { return false; }
     void send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_ms) {};
 };

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -37,7 +37,7 @@ public:
     void update();
 
     // push a location into the database
-    void queue_push(const Location &loc, const uint32_t timestamp_ms, const float distance, const float angle);
+    void queue_push(const Location &loc, uint32_t timestamp_ms, float angle, float distance);
 
     // returns true if database is healthy
     bool healthy() const { return (_queue.items != nullptr) && (_database.items != nullptr); }
@@ -131,7 +131,7 @@ class AP_OADatabase {
 public:
     static AP_OADatabase *get_singleton() { return nullptr; }
     void init() {};
-    void queue_push(const Location &loc, const uint32_t timestamp_ms, const float distance, const float angle) {};
+    void queue_push(const Location &loc, uint32_t timestamp_ms, float angle, float distance) {};
     bool healthy() const { return false; }
     void send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_ms) {};
 };

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -57,11 +57,9 @@ const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("MARGIN_MAX", 3, AP_OAPathPlanner, _margin_max, OA_MARGIN_MAX_DEFAULT),
 
-#if !HAL_MINIMIZE_FEATURES
     // @Group: DB_
     // @Path: AP_OADatabase.cpp
     AP_SUBGROUPINFO(_oadatabase, "DB_", 4, AP_OAPathPlanner, AP_OADatabase),
-#endif
 
     AP_GROUPEND
 };
@@ -195,7 +193,6 @@ AP_OAPathPlanner::OA_RetState AP_OAPathPlanner::mission_avoidance(const Location
 void AP_OAPathPlanner::avoidance_thread()
 {
     while (true) {
-#if !HAL_MINIMIZE_FEATURES
 
         // if database queue needs attention, service it faster
         if (_oadatabase.process_queue()) {
@@ -211,10 +208,6 @@ void AP_OAPathPlanner::avoidance_thread()
         avoidance_latest_ms = now;
 
         _oadatabase.update();
-#else
-        hal.scheduler->delay(100);
-        const uint32_t now = AP_HAL::millis();
-#endif
 
         Location origin_new;
         Location destination_new;

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -27,7 +27,8 @@ extern const AP_HAL::HAL &hal;
 const float OA_LOOKAHEAD_DEFAULT = 15;
 const float OA_MARGIN_MAX_DEFAULT = 5;
 
-const int16_t OA_TIMEOUT_MS = 2000;             // avoidance results over 2 seconds old are ignored
+const int16_t OA_UPDATE_MS = 1000;      // path planning updates run at 1hz
+const int16_t OA_TIMEOUT_MS = 3000;     // results over 3 seconds old are ignored
 
 const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
 
@@ -204,7 +205,7 @@ void AP_OAPathPlanner::avoidance_thread()
         }
 
         const uint32_t now = AP_HAL::millis();
-        if (now - avoidance_latest_ms < 100) {
+        if (now - avoidance_latest_ms < OA_UPDATE_MS) {
             continue;
         }
         avoidance_latest_ms = now;

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -91,9 +91,7 @@ private:
     AP_OABendyRuler *_oabendyruler; // Bendy Ruler algorithm
     AP_OADijkstra *_oadijkstra;     // Dijkstra's algorithm
     AP_OADatabase _oadatabase;      // Database of dynamic objects to avoid
-#if !HAL_MINIMIZE_FEATURES
     uint32_t avoidance_latest_ms;   // last time Dijkstra's or BendyRuler algorithms ran
-#endif
 
     static AP_OAPathPlanner *_singleton;
 };

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -285,6 +285,14 @@ Vector2<T> Vector2<T>::projected(const Vector2<T> &v)
     return v * (*this * v)/(v*v);
 }
 
+// extrapolate position given bearing (in degrees) and distance
+template <typename T>
+void Vector2<T>::offset_bearing(float bearing, float distance)
+{
+    x += cosf(radians(bearing)) * distance;
+    y += sinf(radians(bearing)) * distance;
+}
+
 // given a position pos_delta and a velocity v1 produce a vector
 // perpendicular to v1 maximising distance from p1
 template <typename T>
@@ -435,6 +443,7 @@ template bool Vector2<float>::is_nan(void) const;
 template bool Vector2<float>::is_inf(void) const;
 template float Vector2<float>::angle(const Vector2<float> &v) const;
 template float Vector2<float>::angle(void) const;
+template void Vector2<float>::offset_bearing(float bearing, float distance);
 template bool Vector2<float>::segment_intersection(const Vector2<float>& seg1_start, const Vector2<float>& seg1_end, const Vector2<float>& seg2_start, const Vector2<float>& seg2_end, Vector2<float>& intersection);
 template bool Vector2<float>::circle_segment_intersection(const Vector2<float>& seg_start, const Vector2<float>& seg_end, const Vector2<float>& circle_center, float radius, Vector2<float>& intersection);
 template Vector2<float> Vector2<float>::perpendicular(const Vector2<float> &pos_delta, const Vector2<float> &v1);

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -155,6 +155,9 @@ struct Vector2
     // returns this vector projected onto v
     Vector2<T> projected(const Vector2<T> &v);
 
+    // adjust position by a given bearing (in degrees) and distance
+    void offset_bearing(float bearing, float distance);
+
     // given a position p1 and a velocity v1 produce a vector
     // perpendicular to v1 maximising distance from p1
     static Vector2<T> perpendicular(const Vector2<T> &pos_delta, const Vector2<T> &v1);

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -346,24 +346,6 @@ void AP_Proximity::detect_instance(uint8_t instance)
     }
 }
 
-// get distance in meters in a particular direction in degrees (0 is forward, clockwise)
-// returns true on successful read and places distance in distance
-bool AP_Proximity::get_horizontal_distance(uint8_t instance, float angle_deg, float &distance) const
-{
-    if (!valid_instance(instance)) {
-        return false;
-    }
-    // get distance from backend
-    return drivers[instance]->get_horizontal_distance(angle_deg, distance);
-}
-
-// get distance in meters in a particular direction in degrees (0 is forward, clockwise)
-// returns true on successful read and places distance in distance
-bool AP_Proximity::get_horizontal_distance(float angle_deg, float &distance) const
-{
-    return get_horizontal_distance(primary_instance, angle_deg, distance);
-}
-
 // get distances in 8 directions. used for sending distances to ground station
 bool AP_Proximity::get_horizontal_distances(Proximity_Distance_Array &prx_dist_array) const
 {

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -85,11 +85,6 @@ public:
         return num_instances;
     }
 
-    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
-    // returns true on successful read and places distance in distance
-    bool get_horizontal_distance(uint8_t instance, float angle_deg, float &distance) const;
-    bool get_horizontal_distance(float angle_deg, float &distance) const;
-
     // get distances in PROXIMITY_MAX_DIRECTION directions. used for sending distances to ground station
     bool get_horizontal_distances(Proximity_Distance_Array &prx_dist_array) const;
 

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -38,10 +38,6 @@ void AP_Proximity_AirSimSITL::update(void)
     memset(_angle, 0, sizeof(_angle));
     memset(_distance, 0, sizeof(_distance));
 
-    // only use 8 sectors to match RPLidar
-    const uint8_t nsectors = MIN(8, PROXIMITY_SECTORS_MAX);
-    const uint16_t degrees_per_sector = 360 / nsectors;
-
     for (uint16_t i=0; i<points.length; i++) {
         Vector3f &point = points.data[i];
         if (point.is_zero()) {
@@ -49,7 +45,7 @@ void AP_Proximity_AirSimSITL::update(void)
         }
         float angle_deg = wrap_360(degrees(atan2f(-point.y, point.x)));
         uint16_t angle_rounded = uint16_t(angle_deg+0.5);
-        uint8_t sector = wrap_360(angle_rounded + 22.5f) / degrees_per_sector;
+        const uint8_t sector = convert_angle_to_sector(angle_rounded);
         if (!_distance_valid[sector] || PROXIMITY_MAX_RANGE < _distance[sector]) {
             _distance_valid[sector] = true;
             const Vector2f v = Vector2f(point.x, point.y);
@@ -61,7 +57,7 @@ void AP_Proximity_AirSimSITL::update(void)
 
 #if 0
     printf("npoints=%u\n", points.length);
-    for (uint16_t i=0; i<nsectors; i++) {
+    for (uint16_t i=0; i<PROXIMITY_NUM_SECTORS; i++) {
         printf("sector[%u] ang=%.1f dist=%.1f\n", i, _angle[i], _distance[i]);
     }
 #endif

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -335,7 +335,7 @@ bool AP_Proximity_Backend::get_next_ignore_start_or_end(uint8_t start_or_end, in
 }
 
 // returns true if database is ready to be pushed to and all cached data is ready
-bool AP_Proximity_Backend::database_prepare_for_push(Location &current_loc, float &current_vehicle_bearing)
+bool AP_Proximity_Backend::database_prepare_for_push(Location &current_loc, float &current_heading)
 {
     AP_OADatabase *oaDb = AP::oadatabase();
     if (oaDb == nullptr || !oaDb->healthy()) {
@@ -346,22 +346,22 @@ bool AP_Proximity_Backend::database_prepare_for_push(Location &current_loc, floa
         return false;
     }
 
-    current_vehicle_bearing = AP::ahrs().yaw_sensor * 0.01f;
+    current_heading = AP::ahrs().yaw_sensor * 0.01f;
     return true;
 }
 
 // update Object Avoidance database with Earth-frame point
-void AP_Proximity_Backend::database_push(const float angle, const float distance)
+void AP_Proximity_Backend::database_push(float angle, float distance)
 {
     Location current_loc;
-    float current_vehicle_bearing;
-    if (database_prepare_for_push(current_loc, current_vehicle_bearing) == true) {
-        database_push(angle, distance, AP_HAL::millis(), current_loc, current_vehicle_bearing);
+    float current_heading;
+    if (database_prepare_for_push(current_loc, current_heading)) {
+        database_push(angle, distance, AP_HAL::millis(), current_loc, current_heading);
     }
 }
 
 // update Object Avoidance database with Earth-frame point
-void AP_Proximity_Backend::database_push(const float angle, const float distance, const uint32_t timestamp_ms, const Location &current_loc, const float current_vehicle_bearing)
+void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t timestamp_ms, const Location &current_loc, float current_heading)
 {
     AP_OADatabase *oaDb = AP::oadatabase();
     if (oaDb == nullptr || !oaDb->healthy()) {
@@ -369,6 +369,6 @@ void AP_Proximity_Backend::database_push(const float angle, const float distance
     }
 
     Location temp_loc = current_loc;
-    temp_loc.offset_bearing(wrap_180(current_vehicle_bearing + angle), distance);
+    temp_loc.offset_bearing(wrap_180(current_heading + angle), distance);
     oaDb->queue_push(temp_loc, timestamp_ms, distance, angle);
 }

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -33,17 +33,6 @@ AP_Proximity_Backend::AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity
     init_boundary();
 }
 
-// get distance in meters in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
-bool AP_Proximity_Backend::get_horizontal_distance(float angle_deg, float &distance) const
-{
-    const uint8_t sector = convert_angle_to_sector(angle_deg);
-    if (_distance_valid[sector]) {
-        distance = _distance[sector];
-        return true;
-    }
-    return false;
-}
-
 // get distance and angle to closest object (used for pre-arm check)
 //   returns true on success, false if no valid readings
 bool AP_Proximity_Backend::get_closest_object(float& angle_deg, float &distance) const

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -248,14 +248,14 @@ bool AP_Proximity_Backend::ignore_reading(uint16_t angle_deg) const
 }
 
 // returns true if database is ready to be pushed to and all cached data is ready
-bool AP_Proximity_Backend::database_prepare_for_push(Location &current_loc, float &current_heading)
+bool AP_Proximity_Backend::database_prepare_for_push(Vector2f &current_pos, float &current_heading)
 {
     AP_OADatabase *oaDb = AP::oadatabase();
     if (oaDb == nullptr || !oaDb->healthy()) {
         return false;
     }
 
-    if (!AP::ahrs().get_position(current_loc)) {
+    if (!AP::ahrs().get_relative_position_NE_origin(current_pos)) {
         return false;
     }
 
@@ -266,22 +266,22 @@ bool AP_Proximity_Backend::database_prepare_for_push(Location &current_loc, floa
 // update Object Avoidance database with Earth-frame point
 void AP_Proximity_Backend::database_push(float angle, float distance)
 {
-    Location current_loc;
+    Vector2f current_pos;
     float current_heading;
-    if (database_prepare_for_push(current_loc, current_heading)) {
-        database_push(angle, distance, AP_HAL::millis(), current_loc, current_heading);
+    if (database_prepare_for_push(current_pos, current_heading)) {
+        database_push(angle, distance, AP_HAL::millis(), current_pos, current_heading);
     }
 }
 
 // update Object Avoidance database with Earth-frame point
-void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t timestamp_ms, const Location &current_loc, float current_heading)
+void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t timestamp_ms, const Vector2f &current_pos, float current_heading)
 {
     AP_OADatabase *oaDb = AP::oadatabase();
     if (oaDb == nullptr || !oaDb->healthy()) {
         return;
     }
 
-    Location temp_loc = current_loc;
-    temp_loc.offset_bearing(wrap_180(current_heading + angle), distance);
-    oaDb->queue_push(temp_loc, timestamp_ms, angle, distance);
+    Vector2f temp_pos = current_pos;
+    temp_pos.offset_bearing(wrap_180(current_heading + angle), distance);
+    oaDb->queue_push(temp_pos, timestamp_ms, distance);
 }

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -370,5 +370,5 @@ void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t t
 
     Location temp_loc = current_loc;
     temp_loc.offset_bearing(wrap_180(current_heading + angle), distance);
-    oaDb->queue_push(temp_loc, timestamp_ms, distance, angle);
+    oaDb->queue_push(temp_loc, timestamp_ms, angle, distance);
 }

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -84,9 +84,9 @@ protected:
     bool ignore_reading(uint16_t angle_deg) const;
 
     // database helpers.  all angles are in degrees
-    bool database_prepare_for_push(Location &current_loc, float &current_heading);
+    bool database_prepare_for_push(Vector2f &current_pos, float &current_heading);
     void database_push(float angle, float distance);
-    void database_push(float angle, float distance, uint32_t timestamp_ms, const Location &current_loc, float current_heading);
+    void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector2f &current_pos, float current_heading);
 
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -47,10 +47,6 @@ public:
     // handle mavlink DISTANCE_SENSOR messages
     virtual void handle_msg(const mavlink_message_t &msg) {}
 
-    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
-    // returns true on successful read and places distance in distance
-    bool get_horizontal_distance(float angle_deg, float &distance) const;
-
     // get boundary points around vehicle for use by avoidance
     //   returns nullptr and sets num_points to zero if no boundary can be returned
     const Vector2f* get_boundary_points(uint16_t& num_points) const;

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -87,10 +87,10 @@ protected:
     bool get_ignore_area(uint8_t index, uint16_t &angle_deg, uint8_t &width_deg) const;
     bool get_next_ignore_start_or_end(uint8_t start_or_end, int16_t start_angle, int16_t &ignore_start) const;
 
-    // database helpers
-    bool database_prepare_for_push(Location &current_loc, float &current_vehicle_bearing);
-    void database_push(const float angle, const float distance);
-    void database_push(const float angle, const float distance, const uint32_t timestamp_ms, const Location &current_loc, const float current_vehicle_bearing);
+    // database helpers.  all angles are in degrees
+    bool database_prepare_for_push(Location &current_loc, float &current_heading);
+    void database_push(float angle, float distance);
+    void database_push(float angle, float distance, uint32_t timestamp_ms, const Location &current_loc, float current_heading);
 
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -73,10 +73,8 @@ void AP_Proximity_LightWareSF40C::update(void)
 // initialise sensor
 void AP_Proximity_LightWareSF40C::initialise()
 {
-    // initialise sectors
-    if (!_sector_initialised) {
-        init_sectors();
-    }
+    // initialise boundary
+    init_boundary();
 
     // exit immediately if we've sent initialisation requests in the last second
     uint32_t now_ms = AP_HAL::millis();
@@ -135,66 +133,6 @@ void AP_Proximity_LightWareSF40C::restart_sensor()
     _sensor_state.motor_state = MotorState::UNKNOWN;
     _sensor_state.streaming = false;
     _sensor_state.output_rate = 0;
-}
-
-// initialise sector angles using user defined ignore areas
-void AP_Proximity_LightWareSF40C::init_sectors()
-{
-    // use defaults if no ignore areas defined
-    uint8_t ignore_area_count = get_ignore_area_count();
-    if (ignore_area_count == 0) {
-        _sector_initialised = true;
-        return;
-    }
-
-    uint8_t sector = 0;
-
-    for (uint8_t i=0; i<ignore_area_count; i++) {
-
-        // get ignore area info
-        uint16_t ign_area_angle;
-        uint8_t ign_area_width;
-        if (get_ignore_area(i, ign_area_angle, ign_area_width)) {
-
-            // calculate how many degrees of space we have between this end of this ignore area and the start of the end
-            int16_t start_angle, end_angle;
-            get_next_ignore_start_or_end(1, ign_area_angle, start_angle);
-            get_next_ignore_start_or_end(0, start_angle, end_angle);
-            int16_t degrees_to_fill = wrap_360(end_angle - start_angle);
-
-            // divide up the area into sectors
-            while ((degrees_to_fill > 0) && (sector < PROXIMITY_SECTORS_MAX)) {
-                uint16_t sector_size;
-                if (degrees_to_fill >= 90) {
-                    // set sector to maximum of 45 degrees
-                    sector_size = 45;
-                } else if (degrees_to_fill > 45) {
-                    // use half the remaining area to optimise size of this sector and the next
-                    sector_size = degrees_to_fill / 2.0f;
-                } else  {
-                    // 45 degrees or less are left so put it all into the next sector
-                    sector_size = degrees_to_fill;
-                }
-                // record the sector middle and width
-                _sector_middle_deg[sector] = wrap_360(start_angle + sector_size / 2.0f);
-                _sector_width_deg[sector] = sector_size;
-
-                // move onto next sector
-                start_angle += sector_size;
-                sector++;
-                degrees_to_fill -= sector_size;
-            }
-        }
-    }
-
-    // set num sectors
-    _num_sectors = sector;
-
-    // re-initialise boundary because sector locations have changed
-    init_boundary();
-
-    // record success
-    _sector_initialised = true;
 }
 
 // send message to sensor
@@ -404,8 +342,8 @@ void AP_Proximity_LightWareSF40C::process_message()
             const uint16_t idx = 14 + (i * 2);
             const int16_t dist_cm = (int16_t)buff_to_uint16(_msg.payload[idx], _msg.payload[idx+1]);
             const float angle_deg = wrap_360((point_start_index + i) * angle_inc_deg * angle_sign + angle_correction);
-            uint8_t sector;
-            if (convert_angle_to_sector(angle_deg, sector)) {
+            if (!ignore_reading(angle_deg)) {
+                const uint8_t sector = convert_angle_to_sector(angle_deg);
                 if (sector != _last_sector) {
                     // update boundary used for avoidance
                     if (_last_sector != UINT8_MAX) {

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -391,8 +391,8 @@ void AP_Proximity_LightWareSF40C::process_message()
 
         // prepare to push to object database
         Location current_loc;
-        float current_vehicle_bearing;
-        const bool database_ready = database_prepare_for_push(current_loc, current_vehicle_bearing);
+        float current_heading;
+        const bool database_ready = database_prepare_for_push(current_loc, current_heading);
 
         // process each point
         const float angle_inc_deg = (1.0f / point_total) * 360.0f;
@@ -426,7 +426,7 @@ void AP_Proximity_LightWareSF40C::process_message()
                     }
                     // send point to object avoidance database
                     if (database_ready) {
-                        database_push(angle_deg, dist_m, _last_distance_received_ms, current_loc, current_vehicle_bearing);
+                        database_push(angle_deg, dist_m, _last_distance_received_ms, current_loc, current_heading);
                     }
                 }
             }

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -328,9 +328,9 @@ void AP_Proximity_LightWareSF40C::process_message()
         }
 
         // prepare to push to object database
-        Location current_loc;
+        Vector2f current_pos;
         float current_heading;
-        const bool database_ready = database_prepare_for_push(current_loc, current_heading);
+        const bool database_ready = database_prepare_for_push(current_pos, current_heading);
 
         // process each point
         const float angle_inc_deg = (1.0f / point_total) * 360.0f;
@@ -386,7 +386,7 @@ void AP_Proximity_LightWareSF40C::process_message()
             // send combined distance to object database
             if ((i+1 >= point_count) || (combined_count >= PROXIMITY_SF40C_COMBINE_READINGS)) {
                 if ((combined_dist_m < INT16_MAX) && database_ready) {
-                    database_push(combined_angle_deg, combined_dist_m, _last_distance_received_ms, current_loc, current_heading);
+                    database_push(combined_angle_deg, combined_dist_m, _last_distance_received_ms, current_pos, current_heading);
                 }
                 combined_count = 0;
                 combined_dist_m = INT16_MAX;

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -5,6 +5,7 @@
 
 #define PROXIMITY_SF40C_TIMEOUT_MS            200   // requests timeout after 0.2 seconds
 #define PROXIMITY_SF40C_PAYLOAD_LEN_MAX       256   // maximum payload size we can accept (in some configurations sensor may send as large as 1023)
+#define PROXIMITY_SF40C_COMBINE_READINGS        7   // combine this many readings together to improve efficiency
 
 class AP_Proximity_LightWareSF40C : public AP_Proximity_Backend
 {

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -28,7 +28,6 @@ private:
 
     // initialise sensor
     void initialise();
-    void init_sectors();
 
     // restart sensor and re-init our state
     void restart_sensor();
@@ -106,7 +105,6 @@ private:
 
     // internal variables
     AP_HAL::UARTDriver *_uart;              // uart for communicating with sensor
-    bool _sector_initialised;               // true if sectors have been initialised
     uint32_t _last_request_ms;              // system time of last request
     uint32_t _last_reply_ms;                // system time of last valid reply
     uint32_t _last_restart_ms;              // system time we restarted the sensor

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
@@ -101,72 +101,11 @@ bool AP_Proximity_LightWareSF40C_v09::initialise()
         }
         return false;
     }
+
     // initialise sectors
-    if (!_sector_initialised) {
-        init_sectors();
-        return false;
-    }
-    return true;
-}
-
-// initialise sector angles using user defined ignore areas
-void AP_Proximity_LightWareSF40C_v09::init_sectors()
-{
-    // use defaults if no ignore areas defined
-    uint8_t ignore_area_count = get_ignore_area_count();
-    if (ignore_area_count == 0) {
-        _sector_initialised = true;
-        return;
-    }
-
-    uint8_t sector = 0;
-
-    for (uint8_t i=0; i<ignore_area_count; i++) {
-
-        // get ignore area info
-        uint16_t ign_area_angle;
-        uint8_t ign_area_width;
-        if (get_ignore_area(i, ign_area_angle, ign_area_width)) {
-
-            // calculate how many degrees of space we have between this end of this ignore area and the start of the end
-            int16_t start_angle, end_angle;
-            get_next_ignore_start_or_end(1, ign_area_angle, start_angle);
-            get_next_ignore_start_or_end(0, start_angle, end_angle);
-            int16_t degrees_to_fill = wrap_360(end_angle - start_angle);
-
-            // divide up the area into sectors
-            while ((degrees_to_fill > 0) && (sector < PROXIMITY_SECTORS_MAX)) {
-                uint16_t sector_size;
-                if (degrees_to_fill >= 90) {
-                    // set sector to maximum of 45 degrees
-                    sector_size = 45;
-                } else if (degrees_to_fill > 45) {
-                    // use half the remaining area to optimise size of this sector and the next
-                    sector_size = degrees_to_fill / 2.0f;
-                } else  {
-                    // 45 degrees or less are left so put it all into the next sector
-                    sector_size = degrees_to_fill;
-                }
-                // record the sector middle and width
-                _sector_middle_deg[sector] = wrap_360(start_angle + sector_size / 2.0f);
-                _sector_width_deg[sector] = sector_size;
-
-                // move onto next sector
-                start_angle += sector_size;
-                sector++;
-                degrees_to_fill -= sector_size;
-            }
-        }
-    }
-
-    // set num sectors
-    _num_sectors = sector;
-
-    // re-initialise boundary because sector locations have changed
     init_boundary();
 
-    // record success
-    _sector_initialised = true;
+    return true;
 }
 
 // set speed of rotating motor
@@ -281,15 +220,15 @@ bool AP_Proximity_LightWareSF40C_v09::send_request_for_distance()
 
     // increment sector
     _last_sector++;
-    if (_last_sector >= _num_sectors) {
+    if (_last_sector >= PROXIMITY_NUM_SECTORS) {
         _last_sector = 0;
     }
 
     // prepare request
     char request_str[16];
     snprintf(request_str, sizeof(request_str), "?TS,%u,%u\r\n",
-             MIN(_sector_width_deg[_last_sector], 999),
-             MIN(_sector_middle_deg[_last_sector], 999));
+             (unsigned int)PROXIMITY_SECTOR_WIDTH_DEG,
+             _sector_middle_deg[_last_sector]);
     uart->write(request_str);
 
 
@@ -410,8 +349,8 @@ bool AP_Proximity_LightWareSF40C_v09::process_reply()
         {
             float angle_deg = strtof(element_buf[0], NULL);
             float distance_m = strtof(element_buf[1], NULL);
-            uint8_t sector;
-            if (convert_angle_to_sector(angle_deg, sector)) {
+            if (!ignore_reading(angle_deg)) {
+                const uint8_t sector = convert_angle_to_sector(angle_deg);
                 _angle[sector] = angle_deg;
                 _distance[sector] = distance_m;
                 _distance_valid[sector] = is_positive(distance_m);

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.h
@@ -36,7 +36,6 @@ private:
 
     // initialise sensor (returns true if sensor is successfully initialised)
     bool initialise();
-    void init_sectors();
     void set_motor_speed(bool on_off);
     void set_motor_direction();
     void set_forward_direction();
@@ -93,5 +92,4 @@ private:
     uint8_t _motor_speed;               // motor speed as reported by lidar
     uint8_t _motor_direction = 99;      // motor direction as reported by lidar
     int16_t _forward_direction = 999;   // forward direction as reported by lidar
-    bool _sector_initialised = false;
 };

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -104,8 +104,8 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
         }
 
         Location current_loc;
-        float current_vehicle_bearing;
-        const bool database_ready = database_prepare_for_push(current_loc, current_vehicle_bearing);
+        float current_heading;
+        const bool database_ready = database_prepare_for_push(current_loc, current_heading);
 
         // initialise updated array and proximity sector angles (to closest object) and distances
         bool sector_updated[_num_sectors];
@@ -145,7 +145,7 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
 
             // update Object Avoidance database with Earth-frame point
             if (database_ready) {
-                database_push(mid_angle, packet_distance_m, _last_update_ms, current_loc, current_vehicle_bearing);
+                database_push(mid_angle, packet_distance_m, _last_update_ms, current_loc, current_heading);
             }
         }
 

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -103,9 +103,9 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
             increment *= -1;
         }
 
-        Location current_loc;
+        Vector2f current_pos;
         float current_heading;
-        const bool database_ready = database_prepare_for_push(current_loc, current_heading);
+        const bool database_ready = database_prepare_for_push(current_pos, current_heading);
 
         // initialise updated array and proximity sector angles (to closest object) and distances
         bool sector_updated[PROXIMITY_NUM_SECTORS];
@@ -143,7 +143,7 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
 
             // update Object Avoidance database with Earth-frame point
             if (database_ready) {
-                database_push(mid_angle, packet_distance_m, _last_update_ms, current_loc, current_heading);
+                database_push(mid_angle, packet_distance_m, _last_update_ms, current_pos, current_heading);
             }
         }
 

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -108,11 +108,9 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
         const bool database_ready = database_prepare_for_push(current_loc, current_heading);
 
         // initialise updated array and proximity sector angles (to closest object) and distances
-        bool sector_updated[_num_sectors];
-        float sector_width_half[_num_sectors];
-        for (uint8_t i = 0; i < _num_sectors; i++) {
+        bool sector_updated[PROXIMITY_NUM_SECTORS];
+        for (uint8_t i = 0; i < PROXIMITY_NUM_SECTORS; i++) {
             sector_updated[i] = false;
-            sector_width_half[i] = _sector_width_deg[i] * 0.5f;
             _angle[i] = _sector_middle_deg[i];
             _distance[i] = MAX_DISTANCE;
         }
@@ -133,10 +131,10 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
             const float mid_angle = wrap_360((float)j * increment + yaw_correction);
 
             // iterate over proximity sectors
-            for (uint8_t i = 0; i < _num_sectors; i++) {
+            for (uint8_t i = 0; i < PROXIMITY_NUM_SECTORS; i++) {
                 float angle_diff = fabsf(wrap_180(_sector_middle_deg[i] - mid_angle));
                 // update distance array sector with shortest distance from message
-                if ((angle_diff <= sector_width_half[i]) && (packet_distance_m < _distance[i])) {
+                if ((angle_diff <= (PROXIMITY_SECTOR_WIDTH_DEG * 0.5f)) && (packet_distance_m < _distance[i])) {
                     _distance[i] = packet_distance_m;
                     _angle[i] = mid_angle;
                     sector_updated[i] = true;
@@ -150,7 +148,7 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
         }
 
         // update proximity sectors validity and boundary point
-        for (uint8_t i = 0; i < _num_sectors; i++) {
+        for (uint8_t i = 0; i < PROXIMITY_NUM_SECTORS; i++) {
             _distance_valid[i] = (_distance[i] >= _distance_min) && (_distance[i] <= _distance_max);
             if (sector_updated[i]) {
                 update_boundary_for_sector(i, false);

--- a/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
@@ -41,10 +41,6 @@ void AP_Proximity_MorseSITL::update(void)
     memset(_angle, 0, sizeof(_angle));
     memset(_distance, 0, sizeof(_distance));
 
-    // only use 8 sectors to match RPLidar
-    const uint8_t nsectors = MIN(8, PROXIMITY_SECTORS_MAX);
-    const uint16_t degrees_per_sector = 360 / nsectors;
-
     for (uint16_t i=0; i<points.length; i++) {
         Vector3f &point = points.data[i];
         float &range = ranges.data[i];
@@ -54,7 +50,7 @@ void AP_Proximity_MorseSITL::update(void)
         }
         float angle_deg = wrap_360(degrees(atan2f(-point.y, point.x)));
         uint16_t angle_rounded = uint16_t(angle_deg+0.5);
-        uint8_t sector = wrap_360(angle_rounded + 22.5f) / degrees_per_sector;
+        const uint8_t sector = convert_angle_to_sector(angle_rounded);
         if (!_distance_valid[sector] || range < _distance[sector]) {
             _distance_valid[sector] = true;
             _distance[sector] = range;
@@ -65,7 +61,7 @@ void AP_Proximity_MorseSITL::update(void)
 
 #if 0
     printf("npoints=%u\n", points.length);
-    for (uint16_t i=0; i<nsectors; i++) {
+    for (uint16_t i=0; i<PROXIMITY_NUM_SECTORS; i++) {
         printf("sector[%u] ang=%.1f dist=%.1f\n", i, _angle[i], _distance[i]);
     }
 #endif

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -69,7 +69,6 @@ private:
 
     // initialise sensor (returns true if sensor is successfully initialised)
     bool initialise();
-    void init_sectors();
     void set_scan_mode();
 
     // send request for something from sensor
@@ -87,7 +86,6 @@ private:
     bool _information_data;
     bool _resetted;
     bool _initialised;
-    bool _sector_initialised;
 
     uint8_t _payload_length;
     uint8_t _cnt;

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -62,7 +62,7 @@ void AP_Proximity_SITL::update(void)
             _distance_valid[last_sector] = false;
         }
         last_sector++;
-        if (last_sector >= _num_sectors) {
+        if (last_sector >= PROXIMITY_NUM_SECTORS) {
             last_sector = 0;
         }
     } else {

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -119,13 +119,11 @@ bool AP_Proximity_TeraRangerTower::read_sensor_data()
 // process reply
 void AP_Proximity_TeraRangerTower::update_sector_data(int16_t angle_deg, uint16_t distance_cm)
 {
-    uint8_t sector;
-    if (convert_angle_to_sector(angle_deg, sector)) {
-        _angle[sector] = angle_deg;
-        _distance[sector] = ((float) distance_cm) / 1000;
-        _distance_valid[sector] = distance_cm != 0xffff;
-        _last_distance_received_ms = AP_HAL::millis();
-        // update boundary used for avoidance
-        update_boundary_for_sector(sector, true);
-    }
+    const uint8_t sector = convert_angle_to_sector(angle_deg);
+    _angle[sector] = angle_deg;
+    _distance[sector] = ((float) distance_cm) / 1000;
+    _distance_valid[sector] = distance_cm != 0xffff;
+    _last_distance_received_ms = AP_HAL::millis();
+    // update boundary used for avoidance
+    update_boundary_for_sector(sector, true);
 }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -168,15 +168,13 @@ bool AP_Proximity_TeraRangerTowerEvo::read_sensor_data()
 // process reply
 void AP_Proximity_TeraRangerTowerEvo::update_sector_data(int16_t angle_deg, uint16_t distance_cm)
 {
-    uint8_t sector;
-    if (convert_angle_to_sector(angle_deg, sector)) {
-        _angle[sector] = angle_deg;
-        _distance[sector] = ((float) distance_cm) / 1000;
+    const uint8_t sector = convert_angle_to_sector(angle_deg);
+    _angle[sector] = angle_deg;
+    _distance[sector] = ((float) distance_cm) / 1000;
 
-        //check for target too far, target too close and sensor not connected
-        _distance_valid[sector] = distance_cm != 0xffff && distance_cm != 0x0000 && distance_cm != 0x0001;
-        _last_distance_received_ms = AP_HAL::millis();
-        // update boundary used for avoidance
-        update_boundary_for_sector(sector, true);
-    }
+    //check for target too far, target too close and sensor not connected
+    _distance_valid[sector] = distance_cm != 0xffff && distance_cm != 0x0000 && distance_cm != 0x0001;
+    _last_distance_received_ms = AP_HAL::millis();
+    // update boundary used for avoidance
+    update_boundary_for_sector(sector, true);
 }


### PR DESCRIPTION
This PR resolves a few issues that affect Copter's BendyRuler object avoidance:

- Object Database and Proximity libraries lose some unnecessary const on arguments passed by value
- Object Database's object's radii are calculated based on their distance from the vehicle (and beam width) rather than based on their direction compared to the vehicle's heading.  Resolves https://github.com/ArduPilot/ardupilot/issues/12661 and makes the circles around objects on the map look more like the users would expect.
- Object Database stores locations as offsets from the EKF origin (in meters) instead of as locations.  This saves on memory (because it uses Vector2f) and CPU (because there are less conversions between locations and offsets-from-origin)
- AP_Proximity's Lightware SF40c driver combines 7 readings together (choosing the shortest) before sending to the Object Database to improve efficiency (both CPU and memory).  7deg is accurate enough and was chosen because normally the sensor sends packets holding 21 readings.
- AP_Proximity library gets simplified handling of ignore zones to improve efficiency.  Previously it would create up to 12 sectors between ignore zones, now it always uses 8 and simply ignores readings if they fall within the ignore zone.
- BendyRuler updates at 1hz instead of 10hz.  This gives enough time for the Copter position controller to get the vehicle moving before another new target arrives.
- Object Database is available regardless of the HAL_MINIMIZE_FEATURES setting.  Removing the database when hal-minimized-features was set was a half measure and is no longer required because the entire PathPlanning class (including the database) are not compiled in when hal-minimize-featuers is set on Copter.  On Rover PathPlanning including the database is always available because it fits within 1MB

This has been tested on a real vehicle using a Cube Orange and SF40c Lidar.

![bendyruler-sf40c](https://user-images.githubusercontent.com/1498098/70503739-706d1580-1b67-11ea-8220-5be207b3f96d.png)
