### PR TITLE
Sub (4.0): Improvements to depth hold

### DIFF
--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -338,6 +338,7 @@ private:
     // The cm/s we are moving up or down based on filtered data - Positive = UP
     int16_t climb_rate;
     float target_rangefinder_alt;      // desired altitude in cm above the ground
+    bool holding_depth;
 
     // Turn counter
     int32_t quarter_turn_count;

--- a/ArduSub/control_althold.cpp
+++ b/ArduSub/control_althold.cpp
@@ -33,20 +33,6 @@ void Sub::handle_attitude()
 {
     uint32_t tnow = AP_HAL::millis();
 
-    // initialize vertical speeds and acceleration
-    pos_control.set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
-    pos_control.set_max_accel_z(g.pilot_accel_z);
-
-    if (!motors.armed()) {
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
-        pos_control.relax_alt_hold_controllers(motors.get_throttle_hover());
-        last_pilot_heading = ahrs.yaw_sensor;
-        return;
-    }
-
     motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // get pilot desired lean angles

--- a/ArduSub/control_althold.cpp
+++ b/ArduSub/control_althold.cpp
@@ -55,14 +55,20 @@ void Sub::handle_attitude()
         // If we don't have a mavlink attitude target, we use the pilot's input instead
         get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, attitude_control.get_althold_lean_angle_max());
         target_yaw = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
-        if (abs(target_roll) > 50 || abs(target_pitch) > 50 || abs(target_yaw) > 50) {
+        if (abs(target_roll) > 50 || abs(target_pitch) > 50) {
             last_roll = ahrs.roll_sensor;
             last_pitch = ahrs.pitch_sensor;
             last_yaw = ahrs.yaw_sensor;
             last_input_ms = tnow;
             attitude_control.input_rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
+        } else if (abs(target_yaw) > 50) {
+            // if only yaw is being controlled, don't update pitch and roll
+            attitude_control.input_rate_bf_roll_pitch_yaw(0, 0, target_yaw);
+            last_yaw = ahrs.yaw_sensor;
+            last_input_ms = tnow;
         } else if (tnow < last_input_ms + 250) {
             // just brake for a few mooments so we don't bounce
+            last_yaw = ahrs.yaw_sensor;
             attitude_control.input_rate_bf_roll_pitch_yaw(0, 0, 0);
         } else {
             // Lock attitude

--- a/ArduSub/control_althold.cpp
+++ b/ArduSub/control_althold.cpp
@@ -85,7 +85,7 @@ void Sub::althold_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0.5 ,true, g.throttle_filt);
         attitude_control.relax_attitude_controllers();
         pos_control.relax_alt_hold_controllers();
         last_roll = ahrs.roll_sensor;

--- a/ArduSub/control_althold.cpp
+++ b/ArduSub/control_althold.cpp
@@ -96,7 +96,7 @@ void Sub::althold_run()
         // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
         attitude_control.set_throttle_out(0,true,g.throttle_filt);
         attitude_control.relax_attitude_controllers();
-        pos_control.relax_alt_hold_controllers(motors.get_throttle_hover());
+        pos_control.relax_alt_hold_controllers();
         last_roll = ahrs.roll_sensor;
         last_pitch = ahrs.pitch_sensor;
         last_yaw = ahrs.yaw_sensor;

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -141,6 +141,16 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
 
 void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
 {
+    // Used for trimming level in vehicle frame
+    Quaternion attitudeTarget;
+    attitudeTarget.from_euler(
+        radians(last_roll * 0.01f),
+        radians(last_pitch * 0.01f),
+        radians(last_yaw * 0.01f)
+        );
+    Vector3f localPitch = Vector3f(0, 1, 0);
+    Vector3f localRoll = Vector3f(1, 0, 0);
+
     // Act based on the function assigned to this button
     switch (get_button(button)->function(shift)) {
     case JSButton::button_function_t::k_arm_toggle:
@@ -331,16 +341,28 @@ void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
         }
         break;
     case JSButton::button_function_t::k_trim_roll_inc:
-        rollTrim = constrain_float(rollTrim+10,-200,200);
+        attitudeTarget.rotate(localRoll * radians(1));
+        last_roll = degrees(attitudeTarget.get_euler_roll()) * 100;
+        last_pitch = degrees(attitudeTarget.get_euler_pitch()) * 100;
+        last_yaw = degrees(attitudeTarget.get_euler_yaw()) * 100;
         break;
     case JSButton::button_function_t::k_trim_roll_dec:
-        rollTrim = constrain_float(rollTrim-10,-200,200);
+        attitudeTarget.rotate(localRoll * radians(-1));
+        last_roll = degrees(attitudeTarget.get_euler_roll()) * 100;
+        last_pitch = degrees(attitudeTarget.get_euler_pitch()) * 100;
+        last_yaw = degrees(attitudeTarget.get_euler_yaw()) * 100;
         break;
     case JSButton::button_function_t::k_trim_pitch_inc:
-        pitchTrim = constrain_float(pitchTrim+10,-200,200);
+        attitudeTarget.rotate(localPitch * radians(1));
+        last_roll = degrees(attitudeTarget.get_euler_roll()) * 100;
+        last_pitch = degrees(attitudeTarget.get_euler_pitch()) * 100;
+        last_yaw = degrees(attitudeTarget.get_euler_yaw()) * 100;
         break;
     case JSButton::button_function_t::k_trim_pitch_dec:
-        pitchTrim = constrain_float(pitchTrim-10,-200,200);
+        attitudeTarget.rotate(localPitch * radians(-1));
+        last_roll = degrees(attitudeTarget.get_euler_roll()) * 100;
+        last_pitch = degrees(attitudeTarget.get_euler_pitch()) * 100;
+        last_yaw = degrees(attitudeTarget.get_euler_yaw()) * 100;
         break;
     case JSButton::button_function_t::k_input_hold_set:
         if(!motors.armed()) {

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -100,7 +100,6 @@ void AC_PosControl_Sub::relax_alt_hold_controllers()
     _accel_desired.z = 0.0f;
     _accel_last_z_cms = 0.0f;
     _flags.reset_rate_to_accel_z = true;
-    _pid_accel_z.set_integrator(-_motors.get_throttle_hover() * 1000.0f);
     _accel_target.z = -(_ahrs.get_accel_ef_blended().z + GRAVITY_MSS) * 100.0f;
     _pid_accel_z.reset_filter();
 }


### PR DESCRIPTION
Updates to how the depth hold works.
 - The trimming logic is now working in vehicle frame (only noticeable in aggressive attitudes).
 - Changed to set_target_to_stopping_point_z() instead of the derivative == 0 logic we had before, which makes the controllers smoother and easier to fine tune
 - Get some fixes from master that broke Depth Hold
 - Other minor changes justified in the commit bodies