### PR TITLE
SITL: include ahrs_orientation in airspeed calculation

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -72,6 +72,12 @@ Aircraft::Aircraft(const char *frame_str) :
     // allow for orientation settings, such as with tailsitters
     enum ap_var_type ptype;
     ahrs_orientation = (AP_Int8 *)AP_Param::find("AHRS_ORIENTATION", &ptype);
+
+    enum Rotation imu_rotation = (enum Rotation)ahrs_orientation->get();
+    ahrs_rotation_inv.from_rotation(imu_rotation);
+    ahrs_rotation_inv.transpose();
+    last_imu_rotation = imu_rotation;
+
     terrain = reinterpret_cast<AP_Terrain *>(AP_Param::find_object("TERRAIN_"));
 }
 
@@ -370,11 +376,14 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
     if (ahrs_orientation != nullptr) {
         enum Rotation imu_rotation = (enum Rotation)ahrs_orientation->get();
 
+        if (imu_rotation != last_imu_rotation) {
+            ahrs_rotation_inv.from_rotation(imu_rotation);
+            ahrs_rotation_inv.transpose();
+            last_imu_rotation = imu_rotation;
+        }
         if (imu_rotation != ROTATION_NONE) {
             Matrix3f m = dcm;
-            Matrix3f rot;
-            rot.from_rotation(imu_rotation);
-            m = m * rot.transposed();
+            m = m * ahrs_rotation_inv;
 
             m.to_euler(&r, &p, &y);
             fdm.rollDeg  = degrees(r);

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -193,6 +193,8 @@ protected:
 
     // allow for AHRS_ORIENTATION
     AP_Int8 *ahrs_orientation;
+    enum Rotation last_imu_rotation;
+    Matrix3f ahrs_rotation_inv;
 
     enum GroundBehaviour {
         GROUND_BEHAVIOR_NONE = 0,

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -459,14 +459,8 @@ void FlightAxis::update(const struct sitl_input &input)
     Vector3f airspeed_3d_ef = m_wind_ef + velocity_ef;
     Vector3f airspeed3d = dcm.mul_transpose(airspeed_3d_ef);
 
-    if (ahrs_orientation != nullptr) {
-        enum Rotation imu_rotation = (enum Rotation)ahrs_orientation->get();
-
-        if (imu_rotation != ROTATION_NONE) {
-            Matrix3f rot;
-            rot.from_rotation(imu_rotation);
-            airspeed3d = airspeed3d * rot.transposed();
-        }
+    if (last_imu_rotation != ROTATION_NONE) {
+        airspeed3d = airspeed3d * ahrs_rotation_inv;
     }
     airspeed_pitot = MAX(airspeed3d.x,0);
 

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -407,7 +407,7 @@ void FlightAxis::update(const struct sitl_input &input)
     }
 
     /*
-      the queternion convention in realflight seems to have Z negative
+      the quaternion convention in realflight seems to have Z negative
      */
     Quaternion quat(state.m_orientationQuaternion_W,
                     state.m_orientationQuaternion_Y,
@@ -452,13 +452,22 @@ void FlightAxis::update(const struct sitl_input &input)
     airspeed = state.m_airspeed_MPS;
 
     /* for pitot airspeed we need the airspeed along the X axis. We
-       can't get that from m_airspeed_MPS, so instead we canculate it
+       can't get that from m_airspeed_MPS, so instead we calculate it
        from wind vector and ground speed
      */
     Vector3f m_wind_ef(-state.m_windY_MPS,-state.m_windX_MPS,-state.m_windZ_MPS);
     Vector3f airspeed_3d_ef = m_wind_ef + velocity_ef;
     Vector3f airspeed3d = dcm.mul_transpose(airspeed_3d_ef);
 
+    if (ahrs_orientation != nullptr) {
+        enum Rotation imu_rotation = (enum Rotation)ahrs_orientation->get();
+
+        if (imu_rotation != ROTATION_NONE) {
+            Matrix3f rot;
+            rot.from_rotation(imu_rotation);
+            airspeed3d = airspeed3d * rot.transposed();
+        }
+    }
     airspeed_pitot = MAX(airspeed3d.x,0);
 
 #if 0


### PR DESCRIPTION
needed if AHRS_ORIENTATION is not zero, as with tailsitters which launch vertically in RealFlight