### PR TITLE
AP_Scripting: Remove readline link dependency

### DIFF
--- a/libraries/AP_Scripting/generator/Makefile
+++ b/libraries/AP_Scripting/generator/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -Werror -Wextra -g -std=c99
-LDFLAGS = -lreadline
+LDFLAGS =
 
 OBJ_DIR = build/obj
 SRC_DIR = src


### PR DESCRIPTION
We don't use `readline` anymore, and the including of the flag breaks building for some people if they don't have it installed. Deleting the generator and running `make run` still produces the same output, there's no difference in any of the generated files.