### PR TITLE
AP_BattMonitor: SMBus batteries get cycle-count

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -115,12 +115,12 @@ AP_BattMonitor::init()
 #if HAL_BATTMON_SMBUS_ENABLE
             case AP_BattMonitor_Params::BattMonitor_TYPE_SOLO:
                 drivers[instance] = new AP_BattMonitor_SMBus_Solo(*this, state[instance], _params[instance],
-                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_SMBUS_BUS_INTERNAL, AP_BATTMONITOR_SMBUS_I2C_ADDR,
+                                                                  hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
                                                                                           100000, true, 20));
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_MAXELL:
                 drivers[instance] = new AP_BattMonitor_SMBus_Maxell(*this, state[instance], _params[instance],
-                                                                    hal.i2c_mgr->get_device(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL, AP_BATTMONITOR_SMBUS_I2C_ADDR,
+                                                                    hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
                                                                                             100000, true, 20));
                 break;
 #endif // HAL_BATTMON_SMBUS_ENABLE

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -114,11 +114,13 @@ AP_BattMonitor::init()
                 break;
 #if HAL_BATTMON_SMBUS_ENABLE
             case AP_BattMonitor_Params::BattMonitor_TYPE_SOLO:
+                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_INTERNAL);
                 drivers[instance] = new AP_BattMonitor_SMBus_Solo(*this, state[instance], _params[instance],
                                                                   hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
                                                                                           100000, true, 20));
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_MAXELL:
+                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL);
                 drivers[instance] = new AP_BattMonitor_SMBus_Maxell(*this, state[instance], _params[instance],
                                                                     hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
                                                                                             100000, true, 20));

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -446,6 +446,15 @@ bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance)
     }
 }
 
+// return true if cycle count can be provided and fills in cycles argument
+bool AP_BattMonitor::get_cycle_count(uint8_t instance, uint16_t &cycles) const
+{
+    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES || (drivers[instance] == nullptr)) {
+        return false;
+    }
+    return drivers[instance]->get_cycle_count(cycles);
+}
+
 bool AP_BattMonitor::arming_checks(size_t buflen, char *buffer) const
 {
     char temp_buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -152,8 +152,11 @@ public:
     const cells & get_cell_voltages(const uint8_t instance) const;
 
     // temperature
-    bool get_temperature(float &temperature) const { return get_temperature(temperature, AP_BATT_PRIMARY_INSTANCE); };
+    bool get_temperature(float &temperature) const { return get_temperature(temperature, AP_BATT_PRIMARY_INSTANCE); }
     bool get_temperature(float &temperature, const uint8_t instance) const;
+
+    // cycle count
+    bool get_cycle_count(uint8_t instance, uint16_t &cycles) const;
 
     // get battery resistance estimate in ohms
     float get_resistance() const { return get_resistance(AP_BATT_PRIMARY_INSTANCE); }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -46,6 +46,9 @@ public:
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     uint8_t capacity_remaining_pct() const;
 
+    // return true if cycle count can be provided and fills in cycles argument
+    virtual bool get_cycle_count(uint16_t &cycles) const { return false; }
+
     /// get voltage with sag removed (based on battery current draw and resistance)
     /// this will always be greater than or equal to the raw voltage
     float voltage_resting_estimate() const;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -162,6 +162,13 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ARM_MAH", 19, AP_BattMonitor_Params, _arming_minimum_capacity, 0),
 
+    // @Param: BUS
+    // @DisplayName: Battery monitor I2C bus number
+    // @Description: Battery monitor I2C bus number
+    // @Range: 0 3
+    // @User: Standard
+    AP_GROUPINFO("BUS", 20, AP_BattMonitor_Params, _i2c_bus, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -55,5 +55,5 @@ public:
     AP_Int8  _failsafe_critical_action; /// action to preform on a critical battery failsafe
     AP_Int32 _arming_minimum_capacity;  /// capacity level required to arm
     AP_Float _arming_minimum_voltage;   /// voltage level required to arm
-
+    AP_Int8  _i2c_bus;                  /// I2C bus number
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -13,10 +13,21 @@ AP_BattMonitor_SMBus::AP_BattMonitor_SMBus(AP_BattMonitor &mon,
     _params._pack_capacity = 0;
 }
 
-void AP_BattMonitor_SMBus::init(void) {
+void AP_BattMonitor_SMBus::init(void)
+{
     if (_dev) {
         _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus::timer, void));
     }
+}
+
+// return true if cycle count can be provided and fills in cycles argument
+bool AP_BattMonitor_SMBus::get_cycle_count(uint16_t &cycles) const
+{
+    if (!_has_cycle_count) {
+        return false;
+    }
+    cycles = _cycle_count;
+    return true;
 }
 
 /// read the battery_voltage and current, should be called at 10hz
@@ -83,7 +94,8 @@ bool AP_BattMonitor_SMBus::read_temp(void)
 
 // reads the serial number if it's not already known
 // returns true if the read was successful or the number was already known
-bool AP_BattMonitor_SMBus::read_serial_number(void) {
+bool AP_BattMonitor_SMBus::read_serial_number(void)
+{
     uint16_t data;
 
     // don't recheck the serial number if we already have it
@@ -95,6 +107,16 @@ bool AP_BattMonitor_SMBus::read_serial_number(void) {
     }
 
     return false;
+}
+
+// reads the battery's cycle count
+void AP_BattMonitor_SMBus::read_cycle_count()
+{
+    // only read cycle count once
+    if (_has_cycle_count) {
+        return;
+    }
+    _has_cycle_count = read_word(BATTMONITOR_SMBUS_CYCLE_COUNT, _cycle_count);
 }
 
 // read word from register

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -22,6 +22,7 @@ public:
         BATTMONITOR_SMBUS_CURRENT = 0x0A,              // Current
         BATTMONITOR_SMBUS_REMAINING_CAPACITY = 0x0F,   // Remaining Capacity
         BATTMONITOR_SMBUS_FULL_CHARGE_CAPACITY = 0x10, // Full Charge Capacity
+        BATTMONITOR_SMBUS_CYCLE_COUNT = 0x17,          // Cycle Count
         BATTMONITOR_SMBUS_SPECIFICATION_INFO = 0x1A,   // Specification Info
         BATTMONITOR_SMBUS_SERIAL = 0x1C,               // Serial Number
         BATTMONITOR_SMBUS_MANUFACTURE_NAME = 0x20,     // Manufacture Name
@@ -44,7 +45,10 @@ public:
 
     // don't allow reset of remaining capacity for SMBus
     bool reset_remaining(float percentage) override { return false; }
-    
+
+    // return true if cycle count can be provided and fills in cycles argument
+    bool get_cycle_count(uint16_t &cycles) const override;
+
     void init(void) override;
 
 protected:
@@ -68,6 +72,9 @@ protected:
     // returns true if the read was successful, or the number was already known
     bool read_serial_number(void);
 
+    // reads the battery's cycle count
+    void read_cycle_count();
+
      // read word from register
      // returns true if read was successful, false if failed
     bool read_word(uint8_t reg, uint16_t& data) const;
@@ -81,8 +88,9 @@ protected:
 
     int32_t _serial_number = -1;    // battery serial number
     uint16_t _full_charge_capacity; // full charge capacity, used to stash the value before setting the parameter
-
-    bool _has_cell_voltages;        // smbus backends flag this as true once they have recieved a valid cell voltage report
+    bool _has_cell_voltages;        // smbus backends flag this as true once they have received a valid cell voltage report
+    uint16_t _cycle_count = 0;      // number of cycles the battery has experienced. An amount of discharge approximately equal to the value of DesignCapacity.
+    bool _has_cycle_count;          // true if cycle count has been retrieved from the battery
 
     virtual void timer(void) = 0;   // timer function to read from the battery
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -85,6 +85,8 @@ void AP_BattMonitor_SMBus_Maxell::timer()
     read_temp();
 
     read_serial_number();
+
+    read_cycle_count();
 }
 
 // read_block - returns number of characters read if successful, zero if unsuccessful

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -5,7 +5,6 @@
 #include "AP_BattMonitor_SMBus_Maxell.h"
 #include <utility>
 
-#define BATTMONITOR_SMBUS_MAXELL_NUM_CELLS 6
 uint8_t maxell_cell_ids[] = { 0x3f,  // cell 1
                               0x3e,  // cell 2
                               0x3d,  // cell 3
@@ -60,7 +59,8 @@ void AP_BattMonitor_SMBus_Maxell::timer()
         if (read_word(maxell_cell_ids[i], data)) {
             _has_cell_voltages = true;
             _state.cell_voltages.cells[i] = data;
-        } else {
+            _last_cell_update_ms[i] = tnow;
+        } else if ((tnow - _last_cell_update_ms[i]) > AP_BATTMONITOR_SMBUS_TIMEOUT_MICROS) {
             _state.cell_voltages.cells[i] = UINT16_MAX;
         }
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
@@ -6,6 +6,8 @@
 #include "AP_BattMonitor_SMBus.h"
 #include <AP_HAL/I2CDevice.h>
 
+#define BATTMONITOR_SMBUS_MAXELL_NUM_CELLS 6
+
 class AP_BattMonitor_SMBus_Maxell : public AP_BattMonitor_SMBus
 {
 public:
@@ -28,4 +30,5 @@ private:
     uint8_t read_block(uint8_t reg, uint8_t* data, bool append_zero) const;
 
     uint8_t _pec_confirmed; // count of the number of times PEC has been confirmed as working
+    uint32_t _last_cell_update_ms[BATTMONITOR_SMBUS_MAXELL_NUM_CELLS];  // system time of last successful read of cell voltage
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -93,6 +93,8 @@ void AP_BattMonitor_SMBus_Solo::timer()
     read_temp();
 
     read_serial_number();
+
+    read_cycle_count();
 }
 
 // read_block - returns number of characters read if successful, zero if unsuccessful

--- a/libraries/AP_Scripting/examples/smbus-check-cycles.lua
+++ b/libraries/AP_Scripting/examples/smbus-check-cycles.lua
@@ -1,0 +1,21 @@
+-- This script checks SMBus battery cycle count
+
+local warning_cycles = 100
+local battery_instance = 0
+
+function update()
+  if not arming:is_armed() then -- only run check when disarmed
+    local cycle_count = battery:get_cycle_count(battery_instance)
+    if cycle_count then
+      if cycle_count >= warning_cycles then
+        gcs:send_text(0, string.format("Battery needs replacing (%d cycles)", cycle_count))
+      end
+    else
+      gcs:send_text(0, "failed to get battery cycles")
+    end
+  end
+
+  return update, 15000 -- check again in 15 seconds
+end
+
+return update(), 15000 -- first message may be displayed 15 seconds after start-up

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -56,6 +56,7 @@ singleton AP_BattMonitor method pack_capacity_mah int32_t uint8_t 0 ud->num_inst
 singleton AP_BattMonitor method has_failsafed boolean
 singleton AP_BattMonitor method overpower_detected boolean uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method get_temperature boolean float'Null uint8_t 0 ud->num_instances()
+singleton AP_BattMonitor method get_cycle_count boolean uint8_t 0 ud->num_instances() uint16_t'Null
 
 include AP_GPS/AP_GPS.h
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1232,6 +1232,29 @@ static int AP_GPS_num_sensors(lua_State *L) {
     return 1;
 }
 
+static int AP_BattMonitor_get_cycle_count(lua_State *L) {
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(ud->num_instances(), UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    uint16_t data_5003 = {};
+    const bool data = ud->get_cycle_count(
+            data_2,
+            data_5003);
+
+    if (data) {
+        lua_pushinteger(L, data_5003);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
 static int AP_BattMonitor_get_temperature(lua_State *L) {
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
@@ -1793,6 +1816,7 @@ const luaL_Reg AP_GPS_meta[] = {
 };
 
 const luaL_Reg AP_BattMonitor_meta[] = {
+    {"get_cycle_count", AP_BattMonitor_get_cycle_count},
     {"get_temperature", AP_BattMonitor_get_temperature},
     {"overpower_detected", AP_BattMonitor_overpower_detected},
     {"has_failsafed", AP_BattMonitor_has_failsafed},


### PR DESCRIPTION
This PR enhances the SMBus battery drivers for Solo and Maxell to allow the cycle count to be retrieved using a Lua script.  The intention is that the included Lua script is installed and used to warning the user once they should replace their battery.

I considered sending the cycle count to the GCS after first extending the [BATTERY_STATUS mavlink message](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) but have left this for a potential future enhancement.

This has been successfully tested on one Solo battery and multiple Maxell batteries.  The example below shows a slightly modified script (set "warning_cycles = -1" so it always displays the warning).  This particular battery is new so it always shows "0" cycles.
![image](https://user-images.githubusercontent.com/1498098/70595854-bc7f8f00-1c27-11ea-87c2-d4c79d535784.png)



This also includes a slightly modified version of PR https://github.com/ArduPilot/ardupilot/pull/7943 to allow the Maxell batteries to be used on any I2C bus