### PR TITLE
AP_HAL_ChibiOS: Add mkdir processing result judgment

### DIFF
--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -79,9 +79,10 @@ bool sdcard_init()
         printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
 
         // Create APM Directory if needed
-        AP::FS().mkdir("/APM");
-        sdcard_running = true;
-        return true;
+        if (AP::FS().mkdir("/APM") == 0) {
+            sdcard_running = true;
+            return true;
+        }
     }
 #elif HAL_USE_MMC_SPI
     if (sdcard_running) {
@@ -124,8 +125,9 @@ bool sdcard_init()
         printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
 
         // Create APM Directory if needed
-        AP::FS().mkdir("/APM");
-        return true;
+        if (AP::FS().mkdir("/APM") == 0) {
+            return true;
+        }
     }
 #endif
     sdcard_running = false;


### PR DESCRIPTION
I found that mkdir processing results were not judged.
I think this process is NG.
I think it's better to detect the folder when it is created than to find it in other processes.