### PR TITLE
SRV_Channel: remove default case in get_limit_pwm

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -182,9 +182,9 @@ uint16_t SRV_Channel::get_limit_pwm(Limit limit) const
     case Limit::MAX:
         return reversed?servo_min:servo_max;
     case Limit::ZERO_PWM:
-    default:
         return 0;
     }
+    return 0;
 }
 
 // return true if function is for a multicopter motor


### PR DESCRIPTION
All cases are currently handled, and this is something people should
probably think about if they're introducing another case!