### PR TITLE
Allow NavEKF2 and/or NavEKF3 to be compiled out of the firmware

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -334,11 +334,11 @@ const AP_Param::Info Rover::var_info[] = {
 #if AP_AHRS_NAVEKF_AVAILABLE
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
-    GOBJECTN(EKF2, NavEKF2, "EK2_", NavEKF2),
+    GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
 
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
-    GOBJECTN(EKF3, NavEKF3, "EK3_", NavEKF3),
+    GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
 #endif
 
     // @Group: RPM

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -332,13 +332,17 @@ const AP_Param::Info Rover::var_info[] = {
     GOBJECT(gps, "GPS_", AP_GPS),
 
 #if AP_AHRS_NAVEKF_AVAILABLE
+#if HAL_NAVEKF2_AVAILABLE
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
     GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
     GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
+#endif
 #endif
 
     // @Group: RPM

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -79,7 +79,7 @@ void Rover::update_wheel_encoder()
      * timeStamp_ms is the time when the rotation was last measured (msec)
      * posOffset is the XYZ body frame position of the wheel hub (m)
      */
-    EKF3.writeWheelOdom(delta_angle,
+    ahrs.EKF3.writeWheelOdom(delta_angle,
                         delta_time,
                         wheel_encoder_last_reading_ms[wheel_encoder_last_index_sent],
                         g2.wheel_encoder.get_pos_offset(wheel_encoder_last_index_sent),

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -60,7 +60,9 @@ void Rover::update_wheel_encoder()
     const uint32_t now_ms = AP_HAL::millis();
 
     // calculate angular change (in radians)
+#if HAL_NAVEKF3_AVAILABLE
     const float delta_angle = curr_angle_rad - wheel_encoder_last_angle_rad[wheel_encoder_last_index_sent];
+#endif
     wheel_encoder_last_angle_rad[wheel_encoder_last_index_sent] = curr_angle_rad;
 
     // calculate delta time using time between sensor readings or time since last send to ekf (whichever is shorter)
@@ -72,6 +74,7 @@ void Rover::update_wheel_encoder()
     } else {
         wheel_encoder_last_reading_ms[wheel_encoder_last_index_sent] = sensor_reading_ms;
     }
+#if HAL_NAVEKF3_AVAILABLE
     const float delta_time = sensor_diff_ms * 0.001f;
 
     /* delAng is the measured change in angular position from the previous measurement where a positive rotation is produced by forward motion of the vehicle (rad)
@@ -84,6 +87,7 @@ void Rover::update_wheel_encoder()
                         wheel_encoder_last_reading_ms[wheel_encoder_last_index_sent],
                         g2.wheel_encoder.get_pos_offset(wheel_encoder_last_index_sent),
                         g2.wheel_encoder.get_wheel_radius(wheel_encoder_last_index_sent));
+#endif
 }
 
 // Accel calibration

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -627,13 +627,17 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AP_RCMapper/AP_RCMapper.cpp
     GOBJECT(rcmap, "RCMAP_",        RCMapper),
 
+#if HAL_NAVEKF2_AVAILABLE
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
     GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
-    
+#endif
+
+#if HAL_NAVEKF3_AVAILABLE
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
     GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
+#endif
 
 #if MODE_AUTO_ENABLED == ENABLED
     // @Group: MIS_

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -629,11 +629,11 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
-    GOBJECTN(EKF2, NavEKF2, "EK2_", NavEKF2),
+    GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
     
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
-    GOBJECTN(EKF3, NavEKF3, "EK3_", NavEKF3),
+    GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
 
 #if MODE_AUTO_ENABLED == ENABLED
     // @Group: MIS_

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -198,7 +198,8 @@ void Copter::check_ekf_reset()
         AP::logger().Write_Event(LogEvent::EKF_YAW_RESET);
     }
 
-#if AP_AHRS_NAVEKF_AVAILABLE
+#if AP_AHRS_NAVEKF_AVAILABLE && HAL_NAVEKF2_AVAILABLE
+
     // check for change in primary EKF (log only, AC_WPNav handles position target adjustment)
     if ((ahrs.EKF2.getPrimaryCoreIndex() != ekf_primary_core) && (ahrs.EKF2.getPrimaryCoreIndex() != -1)) {
         attitude_control->inertial_frame_reset();

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -200,9 +200,9 @@ void Copter::check_ekf_reset()
 
 #if AP_AHRS_NAVEKF_AVAILABLE
     // check for change in primary EKF (log only, AC_WPNav handles position target adjustment)
-    if ((EKF2.getPrimaryCoreIndex() != ekf_primary_core) && (EKF2.getPrimaryCoreIndex() != -1)) {
+    if ((ahrs.EKF2.getPrimaryCoreIndex() != ekf_primary_core) && (ahrs.EKF2.getPrimaryCoreIndex() != -1)) {
         attitude_control->inertial_frame_reset();
-        ekf_primary_core = EKF2.getPrimaryCoreIndex();
+        ekf_primary_core = ahrs.EKF2.getPrimaryCoreIndex();
         AP::logger().Write_Error(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(ekf_primary_core));
         gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
     }

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1051,11 +1051,11 @@ const AP_Param::Info Plane::var_info[] = {
 #if AP_AHRS_NAVEKF_AVAILABLE
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
-    GOBJECTN(EKF2, NavEKF2, "EK2_", NavEKF2),
+    GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
 
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
-    GOBJECTN(EKF3, NavEKF3, "EK3_", NavEKF3),
+    GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
 #endif
 
     // @Group: RPM

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1049,13 +1049,17 @@ const AP_Param::Info Plane::var_info[] = {
     GOBJECT(rally,  "RALLY_",       AP_Rally),
 
 #if AP_AHRS_NAVEKF_AVAILABLE
+#if HAL_NAVEKF2_AVAILABLE
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
     GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
     GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
+#endif
 #endif
 
     // @Group: RPM

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -546,13 +546,17 @@ const AP_Param::Info Sub::var_info[] = {
     GOBJECT(rcmap, "RCMAP_",        RCMapper),
 #endif
 
+#if HAL_NAVEKF2_AVAILABLE
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
     GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
     GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
+#endif
 
     // @Group: MIS_
     // @Path: ../libraries/AP_Mission/AP_Mission.cpp

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -548,11 +548,11 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
-    GOBJECTN(EKF2, NavEKF2, "EK2_", NavEKF2),
+    GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
 
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
-    GOBJECTN(EKF3, NavEKF3, "EK3_", NavEKF3),
+    GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
 
     // @Group: MIS_
     // @Path: ../libraries/AP_Mission/AP_Mission.cpp

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -162,11 +162,11 @@ void Sub::init_ardupilot()
         // We only have onboard baro
         // No external underwater depth sensor detected
         barometer.set_primary_baro(0);
-        EKF2.set_baro_alt_noise(10.0f); // Readings won't correspond with rest of INS
-        EKF3.set_baro_alt_noise(10.0f);
+        ahrs.EKF2.set_baro_alt_noise(10.0f); // Readings won't correspond with rest of INS
+        ahrs.EKF3.set_baro_alt_noise(10.0f);
     } else {
-        EKF2.set_baro_alt_noise(0.1f);
-        EKF3.set_baro_alt_noise(0.1f);
+        ahrs.EKF2.set_baro_alt_noise(0.1f);
+        ahrs.EKF3.set_baro_alt_noise(0.1f);
     }
 
     leak_detector.init();

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -162,11 +162,19 @@ void Sub::init_ardupilot()
         // We only have onboard baro
         // No external underwater depth sensor detected
         barometer.set_primary_baro(0);
+#if HAL_NAVEKF2_AVAILABLE
         ahrs.EKF2.set_baro_alt_noise(10.0f); // Readings won't correspond with rest of INS
+#endif
+#if HAL_NAVEKF3_AVAILABLE
         ahrs.EKF3.set_baro_alt_noise(10.0f);
+#endif
     } else {
+#if HAL_NAVEKF2_AVAILABLE
         ahrs.EKF2.set_baro_alt_noise(0.1f);
+#endif
+#if HAL_NAVEKF3_AVAILABLE
         ahrs.EKF3.set_baro_alt_noise(0.1f);
+#endif
     }
 
     leak_detector.init();

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -69,7 +69,7 @@ const AP_Param::Info ReplayVehicle::var_info[] = {
 
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
-    GOBJECTN(EKF2, NavEKF2, "EK2_", NavEKF2),
+    GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
     
     // @Group: COMPASS_
     // @Path: ../libraries/AP_Compass/AP_Compass.cpp
@@ -81,7 +81,7 @@ const AP_Param::Info ReplayVehicle::var_info[] = {
     
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
-    GOBJECTN(EKF3, NavEKF3, "EK3_", NavEKF3),
+    GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
 
     AP_VAREND
 };
@@ -119,8 +119,8 @@ void ReplayVehicle::setup(void)
     ahrs.set_correct_centrifugal(true);
     ahrs.set_ekf_use(true);
 
-    EKF2.set_enable(true);
-    EKF3.set_enable(true);
+    ahrs.EKF2.set_enable(true);
+    ahrs.EKF3.set_enable(true);
 
     printf("Starting disarmed\n");
     hal.util->set_soft_armed(false);
@@ -731,9 +731,9 @@ void Replay::log_check_generate(void)
     Vector3f velocity;
     Location loc {};
 
-    _vehicle.EKF2.getEulerAngles(-1,euler);
-    _vehicle.EKF2.getVelNED(-1,velocity);
-    _vehicle.EKF2.getLLH(loc);
+    _vehicle.ahrs.EKF2.getEulerAngles(-1,euler);
+    _vehicle.ahrs.EKF2.getVelNED(-1,velocity);
+    _vehicle.ahrs.EKF2.getLLH(loc);
 
     _vehicle.logger.Write(
         "CHEK",
@@ -765,9 +765,9 @@ void Replay::log_check_solution(void)
     Vector3f velocity;
     Location loc {};
 
-    _vehicle.EKF2.getEulerAngles(-1,euler);
-    _vehicle.EKF2.getVelNED(-1,velocity);
-    _vehicle.EKF2.getLLH(loc);
+    _vehicle.ahrs.EKF2.getEulerAngles(-1,euler);
+    _vehicle.ahrs.EKF2.getVelNED(-1,velocity);
+    _vehicle.ahrs.EKF2.getLLH(loc);
 
     float roll_error  = degrees(fabsf(euler.x - check_state.euler.x));
     float pitch_error = degrees(fabsf(euler.y - check_state.euler.y));

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -62,6 +62,13 @@ public:
     virtual bool set_mode(const uint8_t new_mode, const ModeReason reason) override { return true; }
     virtual uint8_t get_mode() const override { return 0; }
 
+    AP_InertialSensor ins;
+    AP_Baro barometer;
+    AP_GPS gps;
+    Compass compass;
+    AP_SerialManager serial_manager;
+    RangeFinder rng;
+    AP_AHRS_NavEKF ahrs;
     AP_Vehicle::FixedWing aparm;
     AP_Airspeed airspeed;
     AP_Int32 unused; // logging is magic for Replay; this is unused

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -189,7 +189,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
 // Note that the Vector/Matrix constructors already implicitly zero
 // their values.
 //
-AC_PosControl::AC_PosControl(const AP_AHRS_View& ahrs, const AP_InertialNav& inav,
+AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
                              const AP_Motors& motors, AC_AttitudeControl& attitude_control) :
     _ahrs(ahrs),
     _inav(inav),

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -45,7 +45,7 @@ class AC_PosControl
 public:
 
     /// Constructor
-    AC_PosControl(const AP_AHRS_View& ahrs, const AP_InertialNav& inav,
+    AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
                   const AP_Motors& motors, AC_AttitudeControl& attitude_control);
 
     ///
@@ -379,7 +379,7 @@ protected:
     void check_for_ekf_z_reset();
 
     // references to inertial nav and ahrs libraries
-    const AP_AHRS_View &        _ahrs;
+    AP_AHRS_View &        _ahrs;
     const AP_InertialNav&       _inav;
     const AP_Motors&            _motors;
     AC_AttitudeControl&         _attitude_control;

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -1,6 +1,6 @@
 #include "AC_PosControl_Sub.h"
 
-AC_PosControl_Sub::AC_PosControl_Sub(const AP_AHRS_View& ahrs, const AP_InertialNav& inav,
+AC_PosControl_Sub::AC_PosControl_Sub(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
                                      const AP_Motors& motors, AC_AttitudeControl& attitude_control) :
     AC_PosControl(ahrs, inav, motors, attitude_control),
     _alt_max(0.0f),

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.h
@@ -4,7 +4,7 @@
 
 class AC_PosControl_Sub : public AC_PosControl {
 public:
-    AC_PosControl_Sub(const AP_AHRS_View & ahrs, const AP_InertialNav& inav,
+    AC_PosControl_Sub(AP_AHRS_View & ahrs, const AP_InertialNav& inav,
                       const AP_Motors& motors, AC_AttitudeControl& attitude_control);
 
     /// set_alt_max - sets maximum altitude above the ekf origin in cm

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -465,13 +465,13 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastYawResetAngle(float &yawAng) const {
+    virtual uint32_t getLastYawResetAngle(float &yawAng) {
         return 0;
     };
 
     // return the amount of NE position change in metres due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) const WARN_IF_UNUSED {
+    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) WARN_IF_UNUSED {
         return 0;
     };
 
@@ -483,7 +483,7 @@ public:
 
     // return the amount of vertical position change due to the last reset in meters
     // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastPosDownReset(float &posDelta) const WARN_IF_UNUSED {
+    virtual uint32_t getLastPosDownReset(float &posDelta) WARN_IF_UNUSED {
         return 0;
     };
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -82,8 +82,12 @@ void AP_AHRS_NavEKF::reset_gyro_drift(void)
     AP_AHRS_DCM::reset_gyro_drift();
 
     // reset the EKF gyro bias states
+#if HAL_NAVEKF2_AVAILABLE
     EKF2.resetGyroBias();
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     EKF3.resetGyroBias();
+#endif
 }
 
 void AP_AHRS_NavEKF::update(bool skip_ins_update)
@@ -109,12 +113,20 @@ void AP_AHRS_NavEKF::update(bool skip_ins_update)
     if (_ekf_type == 2) {
         // if EK2 is primary then run EKF2 first to give it CPU
         // priority
+#if HAL_NAVEKF2_AVAILABLE
         update_EKF2();
+#endif
+#if HAL_NAVEKF3_AVAILABLE
         update_EKF3();
+#endif
     } else {
         // otherwise run EKF3 first
+#if HAL_NAVEKF3_AVAILABLE
         update_EKF3();
+#endif
+#if HAL_NAVEKF2_AVAILABLE
         update_EKF2();
+#endif
     }
 
 #if AP_MODULE_SUPPORTED
@@ -155,6 +167,7 @@ void AP_AHRS_NavEKF::update_DCM(bool skip_ins_update)
     _dcm_attitude(roll, pitch, yaw);
 }
 
+#if HAL_NAVEKF2_AVAILABLE
 void AP_AHRS_NavEKF::update_EKF2(void)
 {
     if (!_ekf2_started) {
@@ -226,8 +239,9 @@ void AP_AHRS_NavEKF::update_EKF2(void)
         }
     }
 }
+#endif
 
-
+#if HAL_NAVEKF3_AVAILABLE
 void AP_AHRS_NavEKF::update_EKF3(void)
 {
     if (!_ekf3_started) {
@@ -301,6 +315,7 @@ void AP_AHRS_NavEKF::update_EKF3(void)
         }
     }
 }
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 void AP_AHRS_NavEKF::update_SITL(void)
@@ -385,12 +400,16 @@ void AP_AHRS_NavEKF::reset(bool recover_eulers)
     
     AP_AHRS_DCM::reset(recover_eulers);
     _dcm_attitude(roll, pitch, yaw);
+#if HAL_NAVEKF2_AVAILABLE
     if (_ekf2_started) {
         _ekf2_started = EKF2.InitialiseFilter();
     }
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     if (_ekf3_started) {
         _ekf3_started = EKF3.InitialiseFilter();
     }
+#endif
 }
 
 // reset the current attitude, used on new IMU calibration
@@ -401,12 +420,16 @@ void AP_AHRS_NavEKF::reset_attitude(const float &_roll, const float &_pitch, con
     
     AP_AHRS_DCM::reset_attitude(_roll, _pitch, _yaw);
     _dcm_attitude(roll, pitch, yaw);
+#if HAL_NAVEKF2_AVAILABLE
     if (_ekf2_started) {
         _ekf2_started = EKF2.InitialiseFilter();
     }
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     if (_ekf3_started) {
         _ekf3_started = EKF3.InitialiseFilter();
     }
+#endif
 }
 
 // dead-reckoning support
@@ -416,18 +439,22 @@ bool AP_AHRS_NavEKF::get_position(struct Location &loc) const
     case EKFType::NONE:
         return AP_AHRS_DCM::get_position(loc);
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         if (EKF2.getLLH(loc)) {
             return true;
         }
         break;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         if (EKF3.getLLH(loc)) {
             return true;
         }
         break;
-        
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL: {
         if (_sitl) {
@@ -471,13 +498,17 @@ Vector3f AP_AHRS_NavEKF::wind_estimate(void) const
         break;
 #endif
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getWind(-1,wind);
         break;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getWind(-1,wind);
         break;
+#endif
 
     }
     return wind;
@@ -496,11 +527,15 @@ bool AP_AHRS_NavEKF::use_compass(void)
     switch (active_EKF_type()) {
     case EKFType::NONE:
         break;
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.use_compass();
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.use_compass();
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -517,12 +552,20 @@ bool AP_AHRS_NavEKF::get_secondary_attitude(Vector3f &eulers) const
     switch (active_EKF_type()) {
     case EKFType::NONE:
         // EKF is secondary
+#if HAL_NAVEKF2_AVAILABLE
         EKF2.getEulerAngles(-1, eulers);
         return _ekf2_started;
+#else
+        return false;
+#endif
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -542,12 +585,20 @@ bool AP_AHRS_NavEKF::get_secondary_quaternion(Quaternion &quat) const
     switch (active_EKF_type()) {
     case EKFType::NONE:
         // EKF is secondary
+#if HAL_NAVEKF2_AVAILABLE
         EKF2.getQuaternion(-1, quat);
         return _ekf2_started;
+#else
+        return false;
+#endif
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -566,12 +617,20 @@ bool AP_AHRS_NavEKF::get_secondary_position(struct Location &loc) const
     switch (active_EKF_type()) {
     case EKFType::NONE:
         // EKF is secondary
+#if HAL_NAVEKF2_AVAILABLE
         EKF2.getLLH(loc);
         return _ekf2_started;
+#else
+        return false;
+#endif
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -593,13 +652,17 @@ Vector2f AP_AHRS_NavEKF::groundspeed_vector(void)
     case EKFType::NONE:
         break;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getVelNED(-1,vec);
         return Vector2f(vec.x, vec.y);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getVelNED(-1,vec);
         return Vector2f(vec.x, vec.y);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL: {
@@ -619,19 +682,27 @@ Vector2f AP_AHRS_NavEKF::groundspeed_vector(void)
 // from which to decide the origin on its own
 bool AP_AHRS_NavEKF::set_origin(const Location &loc)
 {
+#if HAL_NAVEKF2_AVAILABLE
     const bool ret2 = EKF2.setOriginLLH(loc);
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     const bool ret3 = EKF3.setOriginLLH(loc);
+#endif
 
     // return success if active EKF's origin was set
     switch (active_EKF_type()) {
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return ret2;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return ret3;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -662,13 +733,17 @@ bool AP_AHRS_NavEKF::get_velocity_NED(Vector3f &vec) const
     case EKFType::NONE:
         break;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getVelNED(-1,vec);
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getVelNED(-1,vec);
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -690,13 +765,17 @@ bool AP_AHRS_NavEKF::get_mag_field_NED(Vector3f &vec) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getMagNED(-1,vec);
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getMagNED(-1,vec);
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -713,13 +792,17 @@ bool AP_AHRS_NavEKF::get_mag_field_correction(Vector3f &vec) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getMagXYZ(-1,vec);
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getMagXYZ(-1,vec);
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -738,13 +821,17 @@ bool AP_AHRS_NavEKF::get_vert_pos_rate(float &velocity) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         velocity = EKF2.getPosDownDerivative(-1);
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         velocity = EKF3.getPosDownDerivative(-1);
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -768,11 +855,15 @@ bool AP_AHRS_NavEKF::get_hagl(float &height) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getHAGL(height);
-        
+#endif
+
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getHAGL(height);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL: {
@@ -797,6 +888,7 @@ bool AP_AHRS_NavEKF::get_relative_position_NED_origin(Vector3f &vec) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO: {
         Vector2f posNE;
         float posD;
@@ -809,7 +901,9 @@ bool AP_AHRS_NavEKF::get_relative_position_NED_origin(Vector3f &vec) const
         }
         return false;
     }
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
             Vector2f posNE;
             float posD;
@@ -822,6 +916,7 @@ bool AP_AHRS_NavEKF::get_relative_position_NED_origin(Vector3f &vec) const
             }
             return false;
         }
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL: {
@@ -869,15 +964,19 @@ bool AP_AHRS_NavEKF::get_relative_position_NE_origin(Vector2f &posNE) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO: {
         bool position_is_valid = EKF2.getPosNE(-1,posNE);
         return position_is_valid;
     }
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
         bool position_is_valid = EKF3.getPosNE(-1,posNE);
         return position_is_valid;
     }
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL: {
@@ -921,15 +1020,19 @@ bool AP_AHRS_NavEKF::get_relative_position_D_origin(float &posD) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO: {
         bool position_is_valid = EKF2.getPosD(-1,posD);
         return position_is_valid;
     }
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
         bool position_is_valid = EKF3.getPosD(-1,posD);
         return position_is_valid;
     }
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL: {
@@ -971,19 +1074,36 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::ekf_type(void) const
     switch (type) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
+        return type;
 #endif
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
+        return type;
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return type;
+#endif
     case EKFType::NONE:
         if (always_use_EKF()) {
+#if HAL_NAVEKF2_AVAILABLE
             return EKFType::TWO;
+#elif HAL_NAVEKF3_AVAILABLE
+            return EKFType::THREE;
+#endif
         }
         return EKFType::NONE;
     }
     // we can get to here if the user has mis-set AHRS_EKF_TYPE - any
-    // value above 3 will get to here.
+    // value above 3 will get to here.  TWO is returned here for no
+    // better reason than "tradition".
+#if HAL_NAVEKF2_AVAILABLE
     return EKFType::TWO;
+#elif HAL_NAVEKF3_AVAILABLE
+    return EKFType::THREE;
+#else
+    return EKFType::NONE;
+#endif
 }
 
 AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
@@ -994,6 +1114,7 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
     case EKFType::NONE:
         return EKFType::NONE;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO: {
         // do we have an EKF2 yet?
         if (!_ekf2_started) {
@@ -1010,7 +1131,9 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
         }
         break;
     }
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
         // do we have an EKF3 yet?
         if (!_ekf3_started) {
@@ -1027,7 +1150,8 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
         }
         break;
     }
-        
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
         ret = EKFType::SITL;
@@ -1048,15 +1172,21 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
          _vehicle_class == AHRS_VEHICLE_GROUND) &&
         (_flags.fly_forward || !hal.util->get_soft_armed())) {
         nav_filter_status filt_state;
+#if HAL_NAVEKF2_AVAILABLE
         if (ret == EKFType::TWO) {
             EKF2.getFilterStatus(-1,filt_state);
-        } else if (ret == EKFType::THREE) {
-            EKF3.getFilterStatus(-1,filt_state);
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        } else if (ret == EKFType::SITL) {
-            get_filter_status(filt_state);
-#endif
         }
+#endif
+#if HAL_NAVEKF3_AVAILABLE
+        if (ret == EKFType::THREE) {
+            EKF3.getFilterStatus(-1,filt_state);
+        }
+#endif
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        if (ret == EKFType::SITL) {
+            get_filter_status(filt_state);
+        }
+#endif
         if (hal.util->get_soft_armed() && !filt_state.flags.using_gps && AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D) {
             // if the EKF is not fusing GPS and we have a 3D lock, then
             // plane and rover would prefer to use the GPS position from
@@ -1105,6 +1235,7 @@ bool AP_AHRS_NavEKF::healthy(void) const
     case EKFType::NONE:
         return AP_AHRS_DCM::healthy();
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO: {
         bool ret = _ekf2_started && EKF2.healthy();
         if (!ret) {
@@ -1119,7 +1250,9 @@ bool AP_AHRS_NavEKF::healthy(void) const
         }
         return true;
     }
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
         bool ret = _ekf3_started && EKF3.healthy();
         if (!ret) {
@@ -1134,7 +1267,8 @@ bool AP_AHRS_NavEKF::healthy(void) const
         }
         return true;
     }
-        
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
         return true;
@@ -1155,17 +1289,21 @@ bool AP_AHRS_NavEKF::prearm_healthy(void) const
         prearm_health = true;
         break;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         if (_ekf2_started && EKF2.all_cores_healthy()) {
             prearm_health = true;
         }
         break;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         if (_ekf3_started && EKF3.all_cores_healthy()) {
             prearm_health = true;
         }
         break;
+#endif
     }
    return prearm_health && healthy();
 }
@@ -1182,13 +1320,17 @@ bool AP_AHRS_NavEKF::initialised(void) const
     case EKFType::NONE:
         return true;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         // initialisation complete 10sec after ekf has started
         return (_ekf2_started && (AP_HAL::millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // initialisation complete 10sec after ekf has started
         return (_ekf3_started && (AP_HAL::millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1205,13 +1347,17 @@ bool AP_AHRS_NavEKF::get_filter_status(nav_filter_status &status) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getFilterStatus(-1,status);
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getFilterStatus(-1,status);
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1235,20 +1381,28 @@ bool AP_AHRS_NavEKF::get_filter_status(nav_filter_status &status) const
 // write optical flow data to EKF
 void  AP_AHRS_NavEKF::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset)
 {
+#if HAL_NAVEKF2_AVAILABLE
     EKF2.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     EKF3.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+#endif
 }
 
 // write body frame odometry measurements to the EKF
 void  AP_AHRS_NavEKF::writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset)
 {
+#if HAL_NAVEKF3_AVAILABLE
     EKF3.writeBodyFrameOdom(quality, delPos, delAng, delTime, timeStamp_ms, posOffset);
+#endif
 }
 
 // Write position and quaternion data from an external navigation system
 void AP_AHRS_NavEKF::writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms)
 {
+#if HAL_NAVEKF2_AVAILABLE
     EKF2.writeExtNavData(sensOffset, pos, quat, posErr, angErr, timeStamp_ms, resetTime_ms);
+#endif
 }
 
 
@@ -1259,11 +1413,15 @@ uint8_t AP_AHRS_NavEKF::setInhibitGPS(void)
     case EKFType::NONE:
         return 0;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.setInhibitGPS();
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.setInhibitGPS();
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1281,13 +1439,17 @@ void AP_AHRS_NavEKF::getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVel
     case EKFType::NONE:
         break;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getEkfControlLimits(ekfGndSpdLimit,ekfNavVelGainScaler);
         break;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getEkfControlLimits(ekfGndSpdLimit,ekfNavVelGainScaler);
         break;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1307,11 +1469,15 @@ bool AP_AHRS_NavEKF::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getMagOffsets(mag_idx, magOffsets);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getMagOffsets(mag_idx, magOffsets);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1326,33 +1492,39 @@ bool AP_AHRS_NavEKF::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 // Retrieves the NED delta velocity corrected
 void AP_AHRS_NavEKF::getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const
 {
-    const EKFType type = active_EKF_type();
-    if (type == EKFType::TWO || type == EKFType::THREE) {
-        int8_t imu_idx = 0;
-        Vector3f accel_bias;
-        if (type == EKFType::TWO) {
-            accel_bias.zero();
-            imu_idx = EKF2.getPrimaryCoreIMUIndex();
-            EKF2.getAccelZBias(-1,accel_bias.z);
-        } else if (type == EKFType::THREE) {
-            imu_idx = EKF3.getPrimaryCoreIMUIndex();
-            EKF3.getAccelBias(-1,accel_bias);
-        }
-        if (imu_idx == -1) {
-            // should never happen, call parent implementation in this scenario
-            AP_AHRS::getCorrectedDeltaVelocityNED(ret, dt);
-            return;
-        }
-        ret.zero();
-        const AP_InertialSensor &_ins = AP::ins();
-        _ins.get_delta_velocity((uint8_t)imu_idx, ret);
-        dt = _ins.get_delta_velocity_dt((uint8_t)imu_idx);
-        ret -= accel_bias*dt;
-        ret = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * ret;
-        ret.z += GRAVITY_MSS*dt;
-    } else {
-        AP_AHRS::getCorrectedDeltaVelocityNED(ret, dt);
+    int8_t imu_idx = -1;
+    Vector3f accel_bias;
+    switch (active_EKF_type()) {
+    case EKFType::NONE:
+        break;
+#if HAL_NAVEKF2_AVAILABLE
+    case EKFType::TWO:
+        imu_idx = EKF2.getPrimaryCoreIMUIndex();
+        EKF2.getAccelZBias(-1,accel_bias.z);
+        break;
+#endif
+#if HAL_NAVEKF3_AVAILABLE
+    case EKFType::THREE:
+        imu_idx = EKF3.getPrimaryCoreIMUIndex();
+        EKF3.getAccelBias(-1,accel_bias);
+        break;
+#endif
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    case EKFType::SITL:
+        break;
+#endif
     }
+    if (imu_idx == -1) {
+        AP_AHRS::getCorrectedDeltaVelocityNED(ret, dt);
+        return;
+    }
+    ret.zero();
+    const AP_InertialSensor &_ins = AP::ins();
+    _ins.get_delta_velocity((uint8_t)imu_idx, ret);
+    dt = _ins.get_delta_velocity_dt((uint8_t)imu_idx);
+    ret -= accel_bias*dt;
+    ret = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * ret;
+    ret.z += GRAVITY_MSS*dt;
 }
 
 // report any reason for why the backend is refusing to initialise
@@ -1362,11 +1534,15 @@ const char *AP_AHRS_NavEKF::prearm_failure_reason(void) const
     case EKFType::NONE:
         return nullptr;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.prearm_failure_reason();
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.prearm_failure_reason();
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1386,6 +1562,7 @@ bool AP_AHRS_NavEKF::attitudes_consistent(char *failure_msg, const uint8_t failu
     // only check yaw if compasses are being used
     bool check_yaw = _compass && _compass->use_for_yaw();
 
+#if HAL_NAVEKF2_AVAILABLE
     // check primary vs ekf2
     for (uint8_t i = 0; i < EKF2.activeCores(); i++) {
         Quaternion ekf2_quat;
@@ -1403,7 +1580,9 @@ bool AP_AHRS_NavEKF::attitudes_consistent(char *failure_msg, const uint8_t failu
             return false;
         }
     }
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     // check primary vs ekf3
     for (uint8_t i = 0; i < EKF3.activeCores(); i++) {
         Quaternion ekf3_quat;
@@ -1421,6 +1600,7 @@ bool AP_AHRS_NavEKF::attitudes_consistent(char *failure_msg, const uint8_t failu
             return false;
         }
     }
+#endif
 
     // check primary vs dcm
     Quaternion dcm_quat;
@@ -1450,11 +1630,15 @@ uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng)
     case EKFType::NONE:
         return 0;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getLastYawResetAngle(yawAng);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getLastYawResetAngle(yawAng);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1473,11 +1657,15 @@ uint32_t AP_AHRS_NavEKF::getLastPosNorthEastReset(Vector2f &pos)
     case EKFType::NONE:
         return 0;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getLastPosNorthEastReset(pos);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getLastPosNorthEastReset(pos);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1496,11 +1684,15 @@ uint32_t AP_AHRS_NavEKF::getLastVelNorthEastReset(Vector2f &vel) const
     case EKFType::NONE:
         return 0;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getLastVelNorthEastReset(vel);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getLastVelNorthEastReset(vel);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1519,11 +1711,15 @@ uint32_t AP_AHRS_NavEKF::getLastPosDownReset(float &posDelta)
     case EKFType::NONE:
         return 0;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getLastPosDownReset(posDelta);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getLastPosDownReset(posDelta);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1546,17 +1742,29 @@ bool AP_AHRS_NavEKF::resetHeightDatum(void)
     switch (ekf_type()) {
 
     case EKFType::NONE:
+#if HAL_NAVEKF3_AVAILABLE
         EKF3.resetHeightDatum();
+#endif
+#if HAL_NAVEKF2_AVAILABLE
         EKF2.resetHeightDatum();
+#endif
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
+#if HAL_NAVEKF3_AVAILABLE
         EKF3.resetHeightDatum();
+#endif
         return EKF2.resetHeightDatum();
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
+#if HAL_NAVEKF2_AVAILABLE
         EKF2.resetHeightDatum();
+#endif
         return EKF3.resetHeightDatum();
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1594,12 +1802,16 @@ void AP_AHRS_NavEKF::send_ekf_status_report(mavlink_channel_t chan) const
         }
         break;
 #endif
-        
+
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.send_status_report(chan);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.send_status_report(chan);
+#endif
 
     }
 }
@@ -1613,17 +1825,21 @@ bool AP_AHRS_NavEKF::get_origin(Location &ret) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         if (!EKF2.getOriginLLH(-1,ret)) {
             return false;
         }
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         if (!EKF3.getOriginLLH(-1,ret)) {
             return false;
         }
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1649,11 +1865,15 @@ bool AP_AHRS_NavEKF::get_hgt_ctrl_limit(float& limit) const
         // We are not using an EKF so no limiting applies
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getHeightControlLimit(limit);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getHeightControlLimit(limit);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1673,11 +1893,15 @@ bool AP_AHRS_NavEKF::get_location(struct Location &loc) const
         // We are not using an EKF so no data
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.getLLH(loc);
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.getLLH(loc);
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1697,15 +1921,19 @@ bool AP_AHRS_NavEKF::get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vec
         // We are not using an EKF so no data
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         // use EKF to get innovations
         EKF2.getInnovations(-1, velInnov, posInnov, magInnov, tasInnov, yawInnov);
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // use EKF to get innovations
         EKF3.getInnovations(-1, velInnov, posInnov, magInnov, tasInnov, yawInnov);
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1732,15 +1960,19 @@ bool AP_AHRS_NavEKF::get_variances(float &velVar, float &posVar, float &hgtVar, 
         // We are not using an EKF so no data
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         // use EKF to get variance
         EKF2.getVariances(-1,velVar, posVar, hgtVar, magVar, tasVar, offset);
         return true;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // use EKF to get variance
         EKF3.getVariances(-1,velVar, posVar, hgtVar, magVar, tasVar, offset);
         return true;
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1759,14 +1991,22 @@ bool AP_AHRS_NavEKF::get_variances(float &velVar, float &posVar, float &hgtVar, 
 
 void AP_AHRS_NavEKF::setTakeoffExpected(bool val)
 {
+#if HAL_NAVEKF2_AVAILABLE
     EKF2.setTakeoffExpected(val);
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     EKF3.setTakeoffExpected(val);
+#endif
 }
 
 void AP_AHRS_NavEKF::setTouchdownExpected(bool val)
 {
+#if HAL_NAVEKF2_AVAILABLE
     EKF2.setTouchdownExpected(val);
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     EKF3.setTouchdownExpected(val);
+#endif
 }
 
 bool AP_AHRS_NavEKF::getGpsGlitchStatus() const
@@ -1785,11 +2025,15 @@ bool AP_AHRS_NavEKF::have_ekf_logging(void) const
     case EKFType::NONE:
         return false;
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.have_ekf_logging();
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         return EKF3.have_ekf_logging();
+#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
@@ -1807,14 +2051,18 @@ uint8_t AP_AHRS_NavEKF::get_primary_IMU_index() const
     switch (ekf_type()) {
     case EKFType::NONE:
         break;
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         // let EKF2 choose primary IMU
         imu = EKF2.getPrimaryCoreIMUIndex();
         break;
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // let EKF2 choose primary IMU
         imu = EKF3.getPrimaryCoreIMUIndex();
         break;
+#endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
         break;
@@ -1863,20 +2111,28 @@ void AP_AHRS_NavEKF::check_lane_switch(void)
         break;
 #endif
 
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.checkLaneSwitch();
         break;
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.checkLaneSwitch();
         break;
+#endif
     }
 }
 
 void AP_AHRS_NavEKF::Log_Write()
 {
+#if HAL_NAVEKF2_AVAILABLE
     get_NavEKF2().Log_Write();
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     get_NavEKF3().Log_Write();
+#endif
 }
 
 AP_AHRS_NavEKF &AP::ahrs_navekf()
@@ -1888,10 +2144,14 @@ AP_AHRS_NavEKF &AP::ahrs_navekf()
 bool AP_AHRS_NavEKF::is_ext_nav_used_for_yaw(void) const
 {
     switch (active_EKF_type()) {
+#if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         return EKF2.isExtNavUsedForYaw();
+#endif
     case EKFType::NONE:
+#if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
+#endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
 #endif

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -35,12 +35,8 @@
 extern const AP_HAL::HAL& hal;
 
 // constructor
-AP_AHRS_NavEKF::AP_AHRS_NavEKF(NavEKF2 &_EKF2,
-                               NavEKF3 &_EKF3,
-                               uint8_t flags) :
+AP_AHRS_NavEKF::AP_AHRS_NavEKF(uint8_t flags) :
     AP_AHRS_DCM(),
-    EKF2(_EKF2),
-    EKF3(_EKF3),
     _ekf_flags(flags)
 {
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduSub)
@@ -1447,7 +1443,7 @@ bool AP_AHRS_NavEKF::attitudes_consistent(char *failure_msg, const uint8_t failu
 
 // return the amount of yaw angle change due to the last yaw angle reset in radians
 // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng) const
+uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng)
 {
     switch (ekf_type()) {
 
@@ -1470,7 +1466,7 @@ uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng) const
 
 // return the amount of NE position change in metres due to the last reset
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t AP_AHRS_NavEKF::getLastPosNorthEastReset(Vector2f &pos) const
+uint32_t AP_AHRS_NavEKF::getLastPosNorthEastReset(Vector2f &pos)
 {
     switch (ekf_type()) {
 
@@ -1517,7 +1513,7 @@ uint32_t AP_AHRS_NavEKF::getLastVelNorthEastReset(Vector2f &vel) const
 
 // return the amount of vertical position change due to the last reset in meters
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t AP_AHRS_NavEKF::getLastPosDownReset(float &posDelta) const
+uint32_t AP_AHRS_NavEKF::getLastPosDownReset(float &posDelta)
 {
     switch (ekf_type()) {
     case EKFType::NONE:

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -23,6 +23,14 @@
 
 #include <AP_HAL/AP_HAL.h>
 
+#ifndef HAL_NAVEKF2_AVAILABLE
+#define HAL_NAVEKF2_AVAILABLE 1
+#endif
+
+#ifndef HAL_NAVEKF3_AVAILABLE
+#define HAL_NAVEKF3_AVAILABLE 1
+#endif
+
 #define AP_AHRS_NAVEKF_AVAILABLE 1
 #include "AP_AHRS.h"
 
@@ -89,19 +97,23 @@ public:
     bool use_compass() override;
 
     // we will need to remove these to fully hide which EKF we are using
+#if HAL_NAVEKF2_AVAILABLE
     NavEKF2 &get_NavEKF2(void) {
         return EKF2;
     }
     const NavEKF2 &get_NavEKF2_const(void) const {
         return EKF2;
     }
+#endif
 
+#if HAL_NAVEKF3_AVAILABLE
     NavEKF3 &get_NavEKF3(void) {
         return EKF3;
     }
     const NavEKF3 &get_NavEKF3_const(void) const {
         return EKF3;
     }
+#endif
 
     // return secondary attitude solution if available, as eulers in radians
     bool get_secondary_attitude(Vector3f &eulers) const override;
@@ -272,14 +284,22 @@ public:
     bool is_ext_nav_used_for_yaw(void) const;
 
     // these are only out here so vehicles can reference them for parameters
+#if HAL_NAVEKF2_AVAILABLE
     NavEKF2 EKF2;
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     NavEKF3 EKF3;
+#endif
 
 private:
     enum class EKFType {
         NONE = 0,
+#if HAL_NAVEKF3_AVAILABLE
         THREE = 3,
+#endif
+#if HAL_NAVEKF2_AVAILABLE
         TWO = 2
+#endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         ,SITL = 10
 #endif
@@ -290,8 +310,14 @@ private:
         return _ekf_flags & FLAG_ALWAYS_USE_EKF;
     }
 
+#if HAL_NAVEKF2_AVAILABLE
+    void update_EKF2(void);
     bool _ekf2_started;
+#endif
+#if HAL_NAVEKF3_AVAILABLE
     bool _ekf3_started;
+    void update_EKF3(void);
+#endif
     bool _force_ekf;
     
     // rotation from vehicle body to NED frame
@@ -308,8 +334,6 @@ private:
 
     EKFType ekf_type(void) const;
     void update_DCM(bool skip_ins_update);
-    void update_EKF2(void);
-    void update_EKF3(void);
 
     // get the index of the current primary IMU
     uint8_t get_primary_IMU_index(void) const;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -45,7 +45,7 @@ public:
     };
 
     // Constructor
-    AP_AHRS_NavEKF(NavEKF2 &_EKF2, NavEKF3 &_EKF3, uint8_t flags = FLAG_NONE);
+    AP_AHRS_NavEKF(uint8_t flags = FLAG_NONE);
 
     /* Do not allow copies */
     AP_AHRS_NavEKF(const AP_AHRS_NavEKF &other) = delete;
@@ -195,11 +195,11 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng) const override;
+    uint32_t getLastYawResetAngle(float &yawAng) override;
 
     // return the amount of NE position change in meters due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) const override;
+    uint32_t getLastPosNorthEastReset(Vector2f &pos) override;
 
     // return the amount of NE velocity change in meters/sec due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
@@ -207,7 +207,7 @@ public:
 
     // return the amount of vertical position change due to the last reset in meters
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosDownReset(float &posDelta) const override;
+    uint32_t getLastPosDownReset(float &posDelta) override;
 
     // Resets the baro so that it reads zero at the current height
     // Resets the EKF height to zero
@@ -271,6 +271,10 @@ public:
     // check whether compass can be bypassed for arming check in case when external navigation data is available 
     bool is_ext_nav_used_for_yaw(void) const;
 
+    // these are only out here so vehicles can reference them for parameters
+    NavEKF2 EKF2;
+    NavEKF3 EKF3;
+
 private:
     enum class EKFType {
         NONE = 0,
@@ -286,8 +290,6 @@ private:
         return _ekf_flags & FLAG_ALWAYS_USE_EKF;
     }
 
-    NavEKF2 &EKF2;
-    NavEKF3 &EKF3;
     bool _ekf2_started;
     bool _ekf3_started;
     bool _force_ekf;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -144,11 +144,11 @@ public:
         return ahrs.get_accel_ef_blended();
     }
 
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) const WARN_IF_UNUSED {
+    uint32_t getLastPosNorthEastReset(Vector2f &pos) WARN_IF_UNUSED {
         return ahrs.getLastPosNorthEastReset(pos);
     }
 
-    uint32_t getLastPosDownReset(float &posDelta) const WARN_IF_UNUSED {
+    uint32_t getLastPosDownReset(float &posDelta) WARN_IF_UNUSED {
         return ahrs.getLastPosDownReset(posDelta);
     }
 

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -30,10 +30,7 @@ static AP_Logger logger{logger_bitmask};
 
 class DummyVehicle {
 public:
-    NavEKF2 EKF2{&ahrs};
-    NavEKF3 EKF3{&ahrs};
-    AP_AHRS_NavEKF ahrs{EKF2, EKF3,
-            AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS_NavEKF ahrs{AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
@@ -191,3 +191,5 @@ define HAL_BATTMON_FUEL_ENABLE 0
 # disable parachute and sprayer to save flash
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
+
+define HAL_NAVEKF2_AVAILABLE 0

--- a/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
+++ b/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
@@ -49,9 +49,7 @@ static AP_Logger logger{logger_bitmask};
 
 class DummyVehicle {
 public:
-    NavEKF2 EKF2{&ahrs};
-    NavEKF3 EKF3{&ahrs};
-    AP_AHRS_NavEKF ahrs{EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS_NavEKF ahrs{AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -585,10 +585,10 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     AP_GROUPEND
 };
 
-NavEKF2::NavEKF2(const AP_AHRS *ahrs) :
-    _ahrs(ahrs)
+NavEKF2::NavEKF2()
 {
     AP_Param::setup_object_defaults(this, var_info);
+    _ahrs = &AP::ahrs();
 }
 
 /*

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -37,7 +37,7 @@ class NavEKF2 {
     friend class NavEKF2_core;
 
 public:
-    NavEKF2(const AP_AHRS *ahrs);
+    NavEKF2();
 
     /* Do not allow copies */
     NavEKF2(const NavEKF2 &other) = delete;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -607,10 +607,10 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     AP_GROUPEND
 };
 
-NavEKF3::NavEKF3(const AP_AHRS *ahrs) :
-    _ahrs(ahrs)
+NavEKF3::NavEKF3()
 {
     AP_Param::setup_object_defaults(this, var_info);
+   _ahrs = &AP::ahrs();
 }
 
 /*

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -34,7 +34,7 @@ class NavEKF3 {
     friend class NavEKF3_core;
 
 public:
-    NavEKF3(const AP_AHRS *ahrs);
+    NavEKF3();
 
     /* Do not allow copies */
     NavEKF3(const NavEKF3 &other) = delete;

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -27,9 +27,7 @@ public:
     AP_InertialSensor ins;
     AP_SerialManager serial_manager;
     RangeFinder sonar;
-    AP_AHRS_NavEKF ahrs{EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
-    NavEKF2 EKF2{&ahrs};
-    NavEKF3 EKF3{&ahrs};
+    AP_AHRS_NavEKF ahrs{AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
@@ -20,9 +20,7 @@ static AP_SerialManager serial_manager;
 
 class DummyVehicle {
 public:
-    NavEKF2 EKF2{&ahrs};
-    NavEKF3 EKF3{&ahrs};
-    AP_AHRS_NavEKF ahrs{EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS_NavEKF ahrs{AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -183,9 +183,7 @@ protected:
 
     // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2{&ahrs};
-    NavEKF3 EKF3{&ahrs};
-    AP_AHRS_NavEKF ahrs{EKF2, EKF3};
+    AP_AHRS_NavEKF ahrs;
 #else
     AP_AHRS_DCM ahrs;
 #endif

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -410,7 +410,8 @@ void GCS_MAVLINK::send_ahrs2()
 
 void GCS_MAVLINK::send_ahrs3()
 {
-#if AP_AHRS_NAVEKF_AVAILABLE
+#if AP_AHRS_NAVEKF_AVAILABLE && HAL_NAVEKF2_AVAILABLE
+
     const NavEKF2 &ekf2 = AP::ahrs_navekf().get_NavEKF2_const();
     if (ekf2.activeCores() > 0 &&
         HAVE_PAYLOAD_SPACE(chan, AHRS3)) {


### PR DESCRIPTION
Not much good will come of compiling both out.

~~POC only at this point.~~

This is based on another branch which moves the NavEKF objects to within AP_AHRS_NavEKF.

```
MatekF405-Wing:

define HAL_NAVEKF2_AVAILABLE 1
define HAL_NAVEKF3_AVAILABLE 1
bin/arducopter  969396  1344  129812  1100552


define HAL_NAVEKF2_AVAILABLE 0
define HAL_NAVEKF3_AVAILABLE 1
bin/arducopter  869916  1344  129812  1001072


define HAL_NAVEKF2_AVAILABLE 1
define HAL_NAVEKF3_AVAILABLE 0
bin/arducopter  837564  1344  129812  968720

define HAL_NAVEKF2_AVAILABLE 0
define HAL_NAVEKF3_AVAILABLE 0
bin/arducopter  735360  1344  129808  866512
```
