### PR TITLE
Copter: improve terrain following during RTL

### DIFF
--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -30,7 +30,6 @@ protected:
 
     bool pre_arm_checks(bool display_failure) override;
     bool pre_arm_ekf_attitude_check();
-    bool pre_arm_terrain_check(bool display_failure);
     bool proximity_checks(bool display_failure) const override;
     bool arm_checks(AP_Arming::Method method) override;
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -888,7 +888,6 @@ private:
     // terrain.cpp
     void terrain_update();
     void terrain_logging();
-    bool terrain_use();
 
     // tuning.cpp
     void tuning();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -698,14 +698,12 @@ const AP_Param::Info Copter::var_info[] = {
     GSCALAR(throw_motor_start, "THROW_MOT_START", 0),
 #endif
 
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    // @Param: TERRAIN_FOLLOW
-    // @DisplayName: Terrain Following use control
-    // @Description: This enables terrain following for RTL and LAND flight modes. To use this option TERRAIN_ENABLE must be 1 and the GCS must  support sending terrain data to the aircraft.  In RTL the RTL_ALT will be considered a height above the terrain.  In LAND mode the vehicle will slow to LAND_SPEED 10m above terrain (instead of 10m above home).  This parameter does not affect AUTO and Guided which use a per-command flag to determine if the height is above-home, absolute or above-terrain.
-    // @Values: 0:Do Not Use in RTL and Land,1:Use in RTL and Land
+    // @Param: RTL_ALT_TYPE
+    // @DisplayName: RTL mode altitude type
+    // @Description: RTL altitude type.  Set to 1 for Terrain following during RTL and then set WPNAV_RFND_USE=1 to use rangefinder or WPNAV_RFND_USE=0 to use Terrain database
+    // @Values: 0:Relative to Home, 1:Terrain
     // @User: Standard
-    GSCALAR(terrain_follow, "TERRAIN_FOLLOW", 0),
-#endif
+    GSCALAR(rtl_alt_type, "RTL_ALT_TYPE", 0),
 
 #if OSD_ENABLED == ENABLED
     // @Group: OSD

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -185,7 +185,7 @@ public:
         k_param_disarm_delay,
         k_param_fs_crash_check,
         k_param_throw_motor_start,
-        k_param_terrain_follow,    // 94
+        k_param_rtl_alt_type,
         k_param_avoid,
         k_param_avoidance_adsb,
 
@@ -451,9 +451,7 @@ public:
     AP_Int8         throw_motor_start;
 #endif
 
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    AP_Int8         terrain_follow;
-#endif
+    AP_Int8         rtl_alt_type;
 
     AP_Int16                rc_speed; // speed of fast RC Channels in Hz
 
@@ -618,6 +616,7 @@ public:
     // Autonmous autorotation
     AC_Autorotation arot;
 #endif
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -106,16 +106,6 @@ enum GuidedMode {
     Guided_Angle,
 };
 
-// RTL states
-enum RTLState {
-    RTL_Starting,
-    RTL_InitialClimb,
-    RTL_ReturnHome,
-    RTL_LoiterAtHome,
-    RTL_FinalDescent,
-    RTL_Land
-};
-
 // Safe RTL states
 enum SmartRTLState {
     SmartRTL_WaitForPathCleanup,

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -214,7 +214,6 @@ void Copter::failsafe_gcs_off_event(void)
 }
 
 // executes terrain failsafe if data is missing for longer than a few seconds
-//  missing_data should be set to true if the vehicle failed to navigate because of missing data, false if navigation is proceeding successfully
 void Copter::failsafe_terrain_check()
 {
     // trigger with 5 seconds of failures while in AUTO mode

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1019,6 +1019,15 @@ public:
     // for reporting to GCS
     bool get_wp(Location &loc) override;
 
+    // RTL states
+    enum RTLState {
+        RTL_Starting,
+        RTL_InitialClimb,
+        RTL_ReturnHome,
+        RTL_LoiterAtHome,
+        RTL_FinalDescent,
+        RTL_Land
+    };
     RTLState state() { return _state; }
 
     // this should probably not be exposed

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1038,6 +1038,13 @@ public:
 
     void restart_without_terrain();
 
+    // enum for RTL_ALT_TYPE parameter
+    enum class RTLAltType {
+        RTL_ALTTYPE_RELATIVE = 0,
+        RTL_ALTTYPE_TERRAIN = 1
+    };
+    ModeRTL::RTLAltType get_alt_type() const;
+
 protected:
 
     const char *name() const override { return "RTL"; }
@@ -1075,8 +1082,14 @@ private:
         Location return_target;
         Location descent_target;
         bool land;
-        bool terrain_used;
     } rtl_path;
+
+    // return target alt type
+    enum class ReturnTargetAltType {
+        RETURN_TARGET_ALTTYPE_RELATIVE = 0,
+        RETURN_TARGET_ALTTYPE_RANGEFINDER = 1,
+        RETURN_TARGET_ALTTYPE_TERRAINDATABASE = 2
+    };
 
     // Loiter timer - Records how long we have been in loiter
     uint32_t _loiter_start_time;

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1755,8 +1755,8 @@ bool ModeAuto::verify_loiter_to_alt()
 bool ModeAuto::verify_RTL()
 {
     return (copter.mode_rtl.state_complete() && 
-    (copter.mode_rtl.state() == RTL_FinalDescent || copter.mode_rtl.state() == RTL_Land) &&
-    (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
+            (copter.mode_rtl.state() == ModeRTL::RTL_FinalDescent || copter.mode_rtl.state() == ModeRTL::RTL_Land) &&
+            (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
 }
 
 /********************************************************************************/

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -29,12 +29,19 @@ bool ModeRTL::init(bool ignore_checks)
 void ModeRTL::restart_without_terrain()
 {
     AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::RESTARTED_RTL);
-    if (rtl_path.terrain_used) {
-        terrain_following_allowed = false;
-        _state = RTL_Starting;
-        _state_complete = true;
-        gcs().send_text(MAV_SEVERITY_CRITICAL,"Restarting RTL - Terrain data missing");
+    terrain_following_allowed = false;
+    _state = RTL_Starting;
+    _state_complete = true;
+    gcs().send_text(MAV_SEVERITY_CRITICAL,"Restarting RTL - Terrain data missing");
+}
+
+ModeRTL::RTLAltType ModeRTL::get_alt_type() const
+{
+    // sanity check parameter
+    if (g.rtl_alt_type < 0 || g.rtl_alt_type > (int)RTLAltType::RTL_ALTTYPE_TERRAIN) {
+        return RTLAltType::RTL_ALTTYPE_RELATIVE;
     }
+    return (RTLAltType)g.rtl_alt_type.get();
 }
 
 // rtl_run - runs the return-to-launch controller
@@ -118,6 +125,7 @@ void ModeRTL::climb_start()
     // set the destination
     if (!wp_nav->set_wp_destination(rtl_path.climb_target)) {
         // this should not happen because rtl_build_path will have checked terrain data was available
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"RTL: unexpected error setting climb target");
         AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         copter.set_mode(Mode::Number::LAND, ModeReason::TERRAIN_FAILSAFE);
         return;
@@ -419,7 +427,6 @@ void ModeRTL::build_path()
 }
 
 // compute the return target - home or rally point
-//   return altitude in cm above home at which vehicle should return home
 //   return target's altitude is updated to a higher altitude that the vehicle can safely return at (frame may also be set)
 void ModeRTL::compute_return_target()
 {
@@ -433,30 +440,68 @@ void ModeRTL::compute_return_target()
     // curr_alt is current altitude above home or above terrain depending upon use_terrain
     int32_t curr_alt = copter.current_loc.alt;
 
-    // decide if we should use terrain altitudes
-    rtl_path.terrain_used = copter.terrain_use() && terrain_following_allowed;
-    if (rtl_path.terrain_used) {
-        // attempt to retrieve terrain alt for current location, stopping point and origin
-        int32_t origin_terr_alt, return_target_terr_alt;
-        if (!rtl_path.origin_point.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, origin_terr_alt) ||
-            !rtl_path.return_target.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, return_target_terr_alt) ||
-            !copter.current_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, curr_alt)) {
-            rtl_path.terrain_used = false;
-            AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
+    // determine altitude type of return journey (alt-above-home, alt-above-terrain using range finder or alt-above-terrain using terrain database)
+    ReturnTargetAltType alt_type = ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RELATIVE;
+    if (terrain_following_allowed && (get_alt_type() == RTLAltType::RTL_ALTTYPE_TERRAIN)) {
+        // convert RTL_ALT_TYPE and WPNAV_RFNG_USE parameters to ReturnTargetAltType
+        switch (wp_nav->get_terrain_source()) {
+        case AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE:
+            alt_type = ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RELATIVE;
+            AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::RTL_MISSING_RNGFND);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "RTL: no terrain data, using alt-above-home");
+            break;
+        case AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER:
+            alt_type = ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RANGEFINDER;
+            break;
+        case AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE:
+            alt_type = ReturnTargetAltType::RETURN_TARGET_ALTTYPE_TERRAINDATABASE;
+            break;
         }
     }
 
-    // convert return-target alt (which is an absolute alt) to alt-above-home or alt-above-terrain
-    if (!rtl_path.terrain_used || !rtl_path.return_target.change_alt_frame(Location::AltFrame::ABOVE_TERRAIN)) {
+    // set curr_alt and return_target.alt from range finder
+    if (alt_type == ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RANGEFINDER) {
+        if (copter.rangefinder_state.alt_healthy) {
+            // set curr_alt based on rangefinder altitude
+            curr_alt = copter.rangefinder_state.alt_cm_filt.get();
+            // set return_target.alt
+            rtl_path.return_target.set_alt_cm(MAX(curr_alt + MAX(0, g.rtl_climb_min), MAX(g.rtl_altitude, RTL_ALT_MIN)), Location::AltFrame::ABOVE_TERRAIN);
+        } else {
+            // fallback to relative alt and warn user
+            alt_type = ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RELATIVE;
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "RTL: rangefinder unhealthy, using alt-above-home");
+            AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::RTL_MISSING_RNGFND);
+        }
+    }
+
+    // set curr_alt and return_target.alt from terrain database
+    if (alt_type == ReturnTargetAltType::RETURN_TARGET_ALTTYPE_TERRAINDATABASE) {
+        // set curr_alt to current altitude above terrain
+        // convert return_target.alt from an abs (above MSL) to altitude above terrain
+        //   Note: the return_target may be a rally point with the alt set above the terrain alt (like the top of a building)
+        int32_t curr_terr_alt;
+        if (copter.current_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, curr_terr_alt) &&
+            rtl_path.return_target.change_alt_frame(Location::AltFrame::ABOVE_TERRAIN)) {
+            curr_alt = curr_terr_alt;
+        } else {
+            // fallback to relative alt and warn user
+            alt_type = ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RELATIVE;
+            AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "RTL: no terrain data, using alt-above-home");
+        }
+    }
+
+    // for the default case we must convert return-target alt (which is an absolute alt) to alt-above-home
+    if (alt_type == ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RELATIVE) {
         if (!rtl_path.return_target.change_alt_frame(Location::AltFrame::ABOVE_HOME)) {
             // this should never happen but just in case
             rtl_path.return_target.set_alt_cm(0, Location::AltFrame::ABOVE_HOME);
+            gcs().send_text(MAV_SEVERITY_WARNING, "RTL: unexpected error calculating target alt");
         }
-        rtl_path.terrain_used = false;
     }
 
     // set new target altitude to return target altitude
-    // Note: this is alt-above-home or terrain-alt depending upon use_terrain
+    // Note: this is alt-above-home or terrain-alt depending upon rtl_alt_type
     // Note: ignore negative altitudes which could happen if user enters negative altitude for rally point or terrain is higher at rally point compared to home
     int32_t target_alt = MAX(rtl_path.return_target.alt, 0);
 
@@ -471,8 +516,8 @@ void ModeRTL::compute_return_target()
         target_alt = MAX(curr_alt, MIN(target_alt, MAX(rtl_return_dist_cm*g.rtl_cone_slope, curr_alt+RTL_ABS_MIN_CLIMB)));
     }
 
-    // set returned target alt to new target_alt
-    rtl_path.return_target.set_alt_cm(target_alt, rtl_path.terrain_used ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_HOME);
+    // set returned target alt to new target_alt (don't change altitude type)
+    rtl_path.return_target.set_alt_cm(target_alt, (alt_type == ReturnTargetAltType::RETURN_TARGET_ALTTYPE_RELATIVE) ? Location::AltFrame::ABOVE_HOME : Location::AltFrame::ABOVE_TERRAIN);
 
 #if AC_FENCE == ENABLED
     // ensure not above fence altitude if alt fence is enabled

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -285,7 +285,7 @@ bool ModeZigZag::calculate_next_dest(uint8_t dest_num, bool use_wpnav_alt, Vecto
         next_dest.z = wp_nav->get_wp_destination().z;
     } else {
         // if we have a downward facing range finder then use terrain altitude targets
-        terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used();
+        terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
         if (terrain_alt) {
             if (!copter.surface_tracking.get_target_alt_cm(next_dest.z)) {
                 next_dest.z = copter.rangefinder_state.alt_cm_filt.get();

--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -15,13 +15,9 @@ void Copter::update_precland()
 {
     int32_t height_above_ground_cm = current_loc.alt;
 
-    // use range finder altitude if it is valid, else try to get terrain alt
+    // use range finder altitude if it is valid, otherwise use home alt
     if (rangefinder_alt_ok()) {
         height_above_ground_cm = rangefinder_state.alt_cm;
-    } else if (terrain_use() && !current_loc.is_zero()) {
-        if (!current_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, height_above_ground_cm)) {
-            height_above_ground_cm = current_loc.alt;
-        }
     }
 
     precland.update(height_above_ground_cm, rangefinder_alt_ok());

--- a/ArduCopter/terrain.cpp
+++ b/ArduCopter/terrain.cpp
@@ -26,13 +26,3 @@ void Copter::terrain_logging()
     }
 #endif
 }
-
-// should we use terrain data for things including the home altitude
-bool Copter::terrain_use()
-{
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    return (g.terrain_follow > 0);
-#else
-    return false;
-#endif
-}

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -586,15 +586,6 @@ const AP_Param::Info Sub::var_info[] = {
     // @Path: ../libraries/AP_Notify/AP_Notify.cpp
     GOBJECT(notify, "NTF_",  AP_Notify),
 
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    // @Param: TERRAIN_FOLLOW
-    // @DisplayName: Terrain Following use control
-    // @Description: This enables terrain following for RTL and SURFACE flight modes. To use this option TERRAIN_ENABLE must be 1 and the GCS must  support sending terrain data to the aircraft.  In RTL the RTL_ALT will be considered a height above the terrain.  In LAND mode the vehicle will slow to LAND_SPEED 10m above terrain (instead of 10m above home).  This parameter does not affect AUTO and Guided which use a per-command flag to determine if the height is above-home, absolute or above-terrain.
-    // @Values: 0:Do Not Use in RTL and SURFACE,1:Use in RTL and SURFACE
-    // @User: Standard
-    GSCALAR(terrain_follow, "TERRAIN_FOLLOW", 0),
-#endif
-
     // @Group:
     // @Path: Parameters.cpp
     GOBJECT(g2, "",  ParametersG2),

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -186,7 +186,7 @@ public:
         k_param_gcs_pid_mask = 178,
         k_param_throttle_filt,
         k_param_throttle_deadzone, // Used in auto-throttle modes
-        k_param_terrain_follow = 182,
+        k_param_terrain_follow = 182,   // deprecated
         k_param_rc_feel_rp,
         k_param_throttle_gain,
         k_param_cam_tilt_center, // deprecated
@@ -258,10 +258,6 @@ public:
     AP_Int8         fs_crash_check;
     AP_Float        fs_ekf_thresh;
     AP_Int16        gcs_pid_mask;
-
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    AP_Int8         terrain_follow;
-#endif
 
     AP_Int16        rc_speed; // speed of fast RC Channels in Hz
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -572,7 +572,6 @@ private:
 #endif
     void terrain_update();
     void terrain_logging();
-    bool terrain_use();
     void init_ardupilot();
     void startup_INS_ground();
     bool position_ok();

--- a/ArduSub/terrain.cpp
+++ b/ArduSub/terrain.cpp
@@ -27,12 +27,3 @@ void Sub::terrain_logging()
 #endif
 }
 
-// should we use terrain data for things including the home altitude
-bool Sub::terrain_use()
-{
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    return (g.terrain_follow > 0);
-#else
-    return false;
-#endif
-}

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4153,7 +4153,7 @@ class AutoTestCopter(AutoTest):
 
     def fly_rangefinder_drivers(self):
         self.set_parameter("RTL_ALT", 500)
-        self.set_parameter("TERRAIN_FOLLOW", 1)
+        self.set_parameter("RTL_ALT_TYPE", 1)
         drivers = [
             ("lightwareserial",8),
             ("ulanding_v0", 11),

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -95,6 +95,23 @@ AC_WPNav::AC_WPNav(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosC
     _wp_radius_cm = MAX(_wp_radius_cm, WPNAV_WP_RADIUS_MIN);
 }
 
+// get expected source of terrain data if alt-above-terrain command is executed (used by Copter's ModeRTL)
+AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
+{
+    // use range finder if connected
+    if (_rangefinder_available && _rangefinder_use) {
+        return AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER;
+    }
+#if AP_TERRAIN_AVAILABLE
+    if ((_terrain != nullptr) && _terrain->enabled()) {
+        return AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE;
+    } else {
+        return AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE;
+    }
+#else
+    return AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE;
+#endif
+}
 
 ///
 /// waypoint navigation
@@ -941,23 +958,28 @@ void AC_WPNav::calc_spline_pos_vel(float spline_time, Vector3f& position, Vector
 // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
 bool AC_WPNav::get_terrain_offset(float& offset_cm)
 {
-    // use range finder if connected
-    if (_rangefinder_available && _rangefinder_use) {
+    // calculate offset based on source (rangefinder or terrain database)
+    switch (get_terrain_source()) {
+    case AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE:
+        return false;
+    case AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER:
         if (_rangefinder_healthy) {
             offset_cm = _inav.get_altitude() - _rangefinder_alt_cm;
             return true;
         }
         return false;
+    case AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE:
+#if AP_TERRAIN_AVAILABLE
+        float terr_alt = 0.0f;
+        if (_terrain != nullptr && _terrain->height_above_terrain(terr_alt, true)) {
+            offset_cm = _inav.get_altitude() - (terr_alt * 100.0f);
+            return true;
+        }
+#endif
+        return false;
     }
 
-#if AP_TERRAIN_AVAILABLE
-    // use terrain database
-    float terr_alt = 0.0f;
-    if (_terrain != nullptr && _terrain->height_above_terrain(terr_alt, true)) {
-        offset_cm = _inav.get_altitude() - (terr_alt * 100.0f);
-        return true;
-    }
-#endif
+    // we should never get here but just in case
     return false;
 }
 

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -55,7 +55,15 @@ public:
     void set_rangefinder_alt(bool use, bool healthy, float alt_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_alt_cm = alt_cm; }
 
     // return true if range finder may be used for terrain following
-    bool rangefinder_used() const { return _rangefinder_use && _rangefinder_healthy; }
+    bool rangefinder_used_and_healthy() const { return _rangefinder_use && _rangefinder_healthy; }
+
+    // get expected source of terrain data if alt-above-terrain command is executed (used by Copter's ModeRTL)
+    enum class TerrainSource {
+        TERRAIN_UNAVAILABLE,
+        TERRAIN_FROM_RANGEFINDER,
+        TERRAIN_FROM_TERRAINDATABASE,
+    };
+    AC_WPNav::TerrainSource get_terrain_source() const;
 
     ///
     /// waypoint controller

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -159,6 +159,7 @@ enum class LogErrorCode : uint8_t {
     RESTARTED_RTL = 3,
     FAILED_CIRCLE_INIT = 4,
     DEST_OUTSIDE_FENCE = 5,
+    RTL_MISSING_RNGFND = 6,
 
 // parachute failed to deploy because of low altitude or landed
     PARACHUTE_TOO_LOW = 2,


### PR DESCRIPTION
This PR slightly improves the accuracy and usability of terrain following in RTL:

- Fixes a bug in how the return altitude was calculated.  The altitude was always being calculated using the terrain database even when the vehicle would use the rangefinder.  I.e. if WPNAV_RFND_USE = 1 and a rangefinder is connected then AC_WPNav uses the rangefinder for terrain following home.
- The TERRAIN_FOLLOW parameter is renamed to RTL_ALT_TYPE and is available on all frames, not just those that support the terrain database (because users can do terrain-following in RTL with just a rangefinder).
- Pre-arm checks to ensure that either a rangefinder or the terrain database is available if the user selects RTL_ALT_TYPE = 1 (Terrain)
- Slightly improved reporting to the user if the RTL falls back to alt-above-home because the rangefinder or terrain database are not available.
- PrecisionLanding no longer tries to use the terrain database.  In fact, it never did because the precland.update() only consumes the altitude is rangefinder_alt_ok is true.  We could actually simplify the function further.

This has been extensively tested in SITL including these tests:

- Terrain following worked with both range finder and terrain database both for the RTL flight mode and RTL-within-Auto
- Fall back to alt-above-home worked when rangefinder or terrain database failed
- RTL_CLIMB_MIN, RTL_ALT, RTL_CONE_SLOPE, RTL_ALT_FINAL params were used correctly
- Pre-arm checks fired correctly including warnings that RNGFNDx_MAX_CM is below RTL_ALT if RTL_ALT_TYPE = 1 (Terrain) and WPNAV_RFND_USE = 1 and a range finder is attached

Below is a flight from a real vehicle using Copter-4.0.0-dev in which the return altitude was calculated incorrectly.  RTL_ALT was 500 so it should have only climbed to 5m above terrain.
![bad-rtl-alt](https://user-images.githubusercontent.com/1498098/70773165-05ffe380-1dba-11ea-8147-4a868b5162ce.png)

Below is a picture from SITL in which the return altitude was calculated correctly when flying to a rally point.  The RTL_ALT was set to 1500 (15m).
![good-rtl-alt](https://user-images.githubusercontent.com/1498098/70773184-12843c00-1dba-11ea-99e3-86f4bdaed0bb.png)

Some improvements that would improve RTL further (not covered by this PR):

- if the range finder failed during RTL, it would be nice if it fell back to use the terrain database.  I tried to implement this but it is slightly tricky because AC_WPNav must be enhanced to fall back from using the rangefinder to instead using the terrain database
- some users would prefer if the vehicle did not terrain follow but instead took the shortest path home while avoiding terrain (probably using the terrain database)
