### PR TITLE
AP_BLHeli: allow connection with reversible ESCs

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -360,7 +360,7 @@ void AP_BLHeli::msp_process_command(void)
     case MSP_FEATURE_CONFIG: {
         debug("MSP_FEATURE_CONFIG");
         uint8_t buf[4];
-        putU32(buf, 0); // from MSPFeatures enum
+        putU32(buf, (channel_reversible_mask.get() != 0) ? FEATURE_3D : 0); // from MSPFeatures enum
         msp_send_reply(msp.cmdMSP, buf, sizeof(buf));
         break;
     }
@@ -409,6 +409,7 @@ void AP_BLHeli::msp_process_command(void)
         for (uint8_t i = 0; i < num_motors; i++) {
             uint16_t v = hal.rcout->read(motor_map[i]);
             putU16(&buf[2*i], v);
+            debug("MOTOR %u val: %u",i,v);
         }
         msp_send_reply(msp.cmdMSP, buf, sizeof(buf));
         break;


### PR DESCRIPTION
This work was funded by DualRC (@Naterater)

This allows connection to BLHeliSuite with reversible throttle setup. Previously connection would be refused because the motors were not at idle. Reporting as 3D tells BLHeli to expect idle throttle of 1500. Small change but took ages to track down.

Note that connection will still be refused if there are a mix of reversible and normal ESC's. We can trick BLHeli into connecting by reporting all motors as having a throttle of 0. Possibly we could add this behind a magic param or we could detect a mixture and automatically report 0? Open to ideas. 

