### PR TITLE
Plane: Prevent FS action overiding VTOL land cmd

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -171,7 +171,7 @@ void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)
             }
             FALLTHROUGH;
         case Failsafe_Action_RTL:
-            if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND && control_mode != &mode_qland ) {
+            if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND && control_mode != &mode_qland && !quadplane.in_vtol_land_sequence()) {
                 // never stop a landing if we were already committed
                 set_mode(mode_rtl, ModeReason::BATTERY_FAILSAFE);
                 aparm.throttle_cruise.load();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3172,3 +3172,11 @@ bool QuadPlane::in_vtol_land_final(void) const
 {
     return in_vtol_land_descent() && poscontrol.state == QPOS_LAND_FINAL;
 }
+
+/*
+  see if we are in any of the phases of a VTOL landing
+ */
+bool QuadPlane::in_vtol_land_sequence(void) const
+{
+    return in_vtol_land_approach() || in_vtol_land_descent() || in_vtol_land_final();
+}

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -554,6 +554,11 @@ private:
       are we in the final landing phase of a VTOL landing?
      */
     bool in_vtol_land_final(void) const;
+
+    /*
+      are we in any of the phases of a VTOL landing?
+     */
+    bool in_vtol_land_sequence(void) const;
     
 public:
     void motor_test_output();


### PR DESCRIPTION
This PR has been commissioned by DUALRC.

This provides a fix for the issue on ArduPlane raised here #10320.  The issue was closed due to a Copter fix.  The behaviour in plane was not fixed.

This video demonstrates the original fault and the behaviours with the fix.

https://youtu.be/m8qYRzTnE9M

This PR is 1 of 3 that aims to address failsafe behaviour on landing.  The PRs have been split across three as they address different conditions and I anticipate that there will be a lot of discussion around each behaviour.  My hope is that by separating them, it will highlight the issues in isolation.

