### PR TITLE
GCS_MAVLink: send statustext to all GCSs until update_send is called

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -39,7 +39,14 @@ void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
 {
     char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
-    send_statustext(severity, GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask(), text);
+    uint8_t mask = GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask();
+    if (!update_send_has_been_called) {
+        // we have not yet initialised the streaming-channel-mask,
+        // which is done as part of the update() call.  So just send
+        // it to all channels:
+        mask = (1<<_num_gcs)-1;
+    }
+    send_statustext(severity, mask, text);
 }
 
 void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -949,6 +949,9 @@ private:
     // true if we have already allocated protocol objects:
     bool initialised_missionitemprotocol_objects;
 
+    // true if update_send has ever been called:
+    bool update_send_has_been_called;
+
     // handle passthru between two UARTs
     struct {
         bool enabled;


### PR DESCRIPTION
until update_send it called we don't mark channels as streaming, so
send_statustext won't send to that channel.

Calculating the streaming mask could have been done as part of the init
call, but this fix may allow for information getting to the user in the
case that the streaming parameters are all zero, too.