### PR TITLE
Plane: limit forward throttle during auto transition

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -412,8 +412,11 @@ void Plane::set_servos_controlled(void)
         min_throttle = 0;
     }
     
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
-        if(aparm.takeoff_throttle_max != 0) {
+    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || 
+        flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND ||
+        quadplane.in_transition()) {
+
+        if (aparm.takeoff_throttle_max != 0) {
             max_throttle = aparm.takeoff_throttle_max;
         } else {
             max_throttle = aparm.throttle_max;


### PR DESCRIPTION
@Hwurzburg I think this would be worth testing. We can make the throttle management more sophisticated if this does what I expect: force throttle to the value spec'd by the TRIM_THROTTLE parameter until the forward transition is complete.