### PR TITLE
SITL: Airspeed fault options

### DIFF
--- a/grep.txt
+++ b/grep.txt
@@ -1,0 +1,2789 @@
+.git/logs/HEAD:f69be707720d4dc96c05180ea6d4986bbaee3247 f69be707720d4dc96c05180ea6d4986bbaee3247 ivan <ivan@ivan-computer.(none)> 1572857500 +0200	checkout: moving from master to airspeed-blend-branch
+.git/logs/HEAD:5336c4ccb48aae46ec28f24039592ae9a90cd935 f69be707720d4dc96c05180ea6d4986bbaee3247 Ivan <ivanpugachardupilot@gmail.com> 1573045535 +0200	checkout: moving from airspeed-blend-branch to master
+.git/logs/HEAD:82c85de4694fbd759fde529fb7d3d6c37ad7ac6b 5336c4ccb48aae46ec28f24039592ae9a90cd935 Ivan <ivanpugachardupilot@gmail.com> 1574244609 +0200	checkout: moving from ArduPlane-release to airspeed-blend-branch
+Binary file .git/index matches
+Binary file .git/modules/modules/PX4Firmware/index matches
+Binary file .git/modules/modules/PX4Firmware/objects/pack/pack-87f855ca7ba6f5947a1a77090c7f66f08956bad5.pack matches
+Binary file .git/modules/modules/mavlink/modules/pymavlink/objects/pack/pack-0719b66b4e4d4da9ec8ab9c0118575563310c9d0.pack matches
+Binary file .git/objects/pack/pack-1902aa50dd6ae012d21c15c3bbd671a4cddcb76a.pack matches
+.git/HEAD:ref: refs/heads/airspeed-blend-branch
+ArduPlane/mode_fbwa.cpp:            if (plane.auto_state.highest_airspeed < plane.g.takeoff_tdrag_speed1) {
+ArduPlane/quadplane.cpp:    // @Description: Transition time in milliseconds after minimum airspeed is reached
+ArduPlane/quadplane.cpp:    // @DisplayName: Takeoff airspeed limit
+ArduPlane/quadplane.cpp:    // @Description: Airspeed limit during takeoff. If the airspeed exceeds this level the vehicle will switch to QLAND. This is useful for ensuring that you don't takeoff into excessively strong wind. If set to 0 there is no limit on airspeed during takeoff.
+ArduPlane/quadplane.cpp:    AP_GROUPINFO("TKOFF_ARSP_LIM", 15, QuadPlane, maximum_takeoff_airspeed, 0),
+ArduPlane/quadplane.cpp:    if (!ahrs.airspeed_estimate(&aspeed) || aspeed < plane.aparm.airspeed_min) {
+ArduPlane/quadplane.cpp:        aspeed = plane.aparm.airspeed_min;
+ArduPlane/quadplane.cpp:        transition_low_airspeed_ms = 0;
+ArduPlane/quadplane.cpp:    bool have_airspeed = ahrs.airspeed_estimate(&aspeed);
+ArduPlane/quadplane.cpp:    // tailsitters use angle wait, not airspeed wait
+ArduPlane/quadplane.cpp:    if (have_airspeed &&
+ArduPlane/quadplane.cpp:            gcs().send_text(MAV_SEVERITY_INFO, "Transition started airspeed %.1f", (double)aspeed);
+ArduPlane/quadplane.cpp:            transition_low_airspeed_ms = 0;
+ArduPlane/quadplane.cpp:    // unless we are waiting for airspeed to increase (in which case
+ArduPlane/quadplane.cpp:        transition_low_airspeed_ms = 0;
+ArduPlane/quadplane.cpp:        // airspeed. Otherwise the pitch limits will throw off the
+ArduPlane/quadplane.cpp:        plane.TECS_controller.use_synthetic_airspeed();
+ArduPlane/quadplane.cpp:        // we hold in hover until the required airspeed is reached
+ArduPlane/quadplane.cpp:            gcs().send_text(MAV_SEVERITY_INFO, "Transition airspeed wait");
+ArduPlane/quadplane.cpp:        transition_low_airspeed_ms = now;
+ArduPlane/quadplane.cpp:        if (have_airspeed && aspeed > plane.aparm.airspeed_min && !assisted_flight) {
+ArduPlane/quadplane.cpp:            gcs().send_text(MAV_SEVERITY_INFO, "Transition airspeed reached %.1f", (double)aspeed);
+ArduPlane/quadplane.cpp:        // reset integrators while we are below target airspeed as we
+ArduPlane/quadplane.cpp:        // after airspeed is reached we degrade throttle over the
+ArduPlane/quadplane.cpp:        const uint32_t transition_timer_ms = now - transition_low_airspeed_ms;
+ArduPlane/quadplane.cpp:            transition_low_airspeed_ms = 0;
+ArduPlane/quadplane.cpp:            transition_low_airspeed_ms = 0;
+ArduPlane/quadplane.cpp:                  setup for airspeed wait for later
+ArduPlane/quadplane.cpp:    // calc average throttle if we are in a level hover and low airspeed
+ArduPlane/quadplane.cpp:        ahrs.airspeed_estimate(&aspeed) && aspeed < plane.aparm.airspeed_min*0.3) {
+ArduPlane/quadplane.cpp:    if (is_positive(maximum_takeoff_airspeed) && (plane.airspeed.get_airspeed() > maximum_takeoff_airspeed)) {
+ArduPlane/quadplane.cpp:        // reload target airspeed which could have been modified by the mission
+ArduPlane/quadplane.cpp:        plane.aparm.airspeed_cruise_cm.load();
+ArduPlane/quadplane.cpp:    // scale forward velocity error by maximum airspeed
+ArduPlane/quadplane.cpp:    fwd_vel_error /= MAX(plane.aparm.airspeed_max, 5);
+ArduPlane/AP_Arming.cpp:    // Check airspeed sensor
+ArduPlane/AP_Arming.cpp:    ret &= AP_Arming::airspeed_checks(display_failure);
+ArduPlane/AP_Arming.cpp:    // reload target airspeed which could have been modified by a mission
+ArduPlane/AP_Arming.cpp:    plane.aparm.airspeed_cruise_cm.load();
+ArduPlane/GCS_Mavlink.cpp:            plane.airspeed_error * 100,
+ArduPlane/GCS_Mavlink.cpp:            plane.airspeed_error * 100,
+ArduPlane/GCS_Mavlink.cpp:float GCS_MAVLINK_Plane::vfr_hud_airspeed() const
+ArduPlane/GCS_Mavlink.cpp:    // airspeed sensors are best.  While the AHRS airspeed_estimate
+ArduPlane/GCS_Mavlink.cpp:    // will use an airspeed sensor, that value is constrained by the
+ArduPlane/GCS_Mavlink.cpp:    // ground speed.  When reporting we should send the true airspeed
+ArduPlane/GCS_Mavlink.cpp:    if (plane.airspeed.enabled() && plane.airspeed.healthy()) {
+ArduPlane/GCS_Mavlink.cpp:        return plane.airspeed.get_airspeed();
+ArduPlane/GCS_Mavlink.cpp:    // airspeed estimates are OK:
+ArduPlane/GCS_Mavlink.cpp:    if (AP::ahrs().airspeed_estimate(&aspeed)) {
+ArduPlane/GCS_Mavlink.cpp:        // setup airspeed pressure based on 3D speed, no wind
+ArduPlane/GCS_Mavlink.cpp:        plane.airspeed.setHIL(sq(vel.length()) / 2.0f + 2013);
+ArduPlane/Parameters.cpp:    // @Description: Degrees of down pitch added when throttle is below TRIM_THROTTLE in FBWA and AUTOTUNE modes. Scales linearly so full value is added when THR_MIN is reached. Helps to keep airspeed higher in glides or landing approaches and prevents accidental stalls. 2 degrees recommended for most planes.
+ArduPlane/Parameters.cpp:    // @Description: This parameter sets the airspeed at which to stop holding the tail down and transition to rudder control of steering on the ground. When TKOFF_TDRAG_SPD1 is reached the pitch of the aircraft will be held level until TKOFF_ROTATE_SPD is reached, at which point the takeoff pitch specified in the mission will be used to "rotate" the pitch for takeoff climb. Set TKOFF_TDRAG_SPD1 to zero to go straight to rotation. This should be set to zero for hand launch and catapult launch. It should also be set to zero for tricycle undercarriages unless you are using the method above to genetly hold the nose wheel down. For tail dragger aircraft it should be set just below the stall speed.
+ArduPlane/Parameters.cpp:    // @Description: This parameter sets the airspeed at which the aircraft will "rotate", setting climb pitch specified in the mission. If TKOFF_ROTATE_SPD is zero then the climb pitch will be used as soon as takeoff is started. For hand launch and catapult launches a TKOFF_ROTATE_SPD of zero should be set. For all ground launches TKOFF_ROTATE_SPD should be set above the stall speed, usually by about 10 to 30 percent
+ArduPlane/Parameters.cpp:    // @Description: This is a RC input channel which when it goes above 1700 enables FBWA taildragger takeoff mode. It should be assigned to a momentary switch. Once this feature is enabled it will stay enabled until the aircraft goes above TKOFF_TDRAG_SPD1 airspeed, changes mode, or the pitch goes above the initial pitch when this is engaged or goes below 0 pitch. When enabled the elevator will be forced to TKOFF_TDRAG_ELEV. This option allows for easier takeoffs on taildraggers in FBWA mode, and also makes it easier to test auto-takeoff steering handling in FBWA. Setting it to 0 disables this option.
+ArduPlane/Parameters.cpp:    // @Description: Enables roll limits at low airspeed in roll limiting flight modes. Roll limits based on aerodynamic load factor in turns and scale on ARSPD_FBW_MIN that must be set correctly. Without airspeed sensor, uses synthetic airspeed from wind speed estimate that may both be inaccurate.
+ArduPlane/Parameters.cpp:    // @Description: Minimum airspeed demanded in automatic throttle modes. Should be set to 20% higher than level flight stall speed.
+ArduPlane/Parameters.cpp:    ASCALAR(airspeed_min, "ARSPD_FBW_MIN",  AIRSPEED_FBW_MIN),
+ArduPlane/Parameters.cpp:    // @Description: Maximum airspeed demanded in automatic throttle modes. Should be set slightly less than level flight speed at THR_MAX and also at least 50% above ARSPD_FBW_MAX to allow for accurate TECS altitude control.
+ArduPlane/Parameters.cpp:    ASCALAR(airspeed_max, "ARSPD_FBW_MAX",  AIRSPEED_FBW_MAX),
+ArduPlane/Parameters.cpp:    // @Description: This sets the rate in m/s at which FBWB and CRUISE modes will change its target altitude for full elevator deflection. Note that the actual climb rate of the aircraft can be lower than this, depending on your airspeed and throttle control settings. If you have this parameter set to the default value of 2.0, then holding the elevator at maximum deflection for 10 seconds would change the target altitude by 20 meters.
+ArduPlane/Parameters.cpp:    // @Description: Target percentage of throttle to apply for flight in automatic throttle modes and throttle percentage that maintains TRIM_ARSPD_CM. Caution: low battery voltages at the end of flights may require higher throttle to maintain airspeed.
+ArduPlane/Parameters.cpp:    // @Description: When enabled, this uses the throttle input in auto-throttle modes to 'nudge' the throttle or airspeed to higher or lower values. When you have an airspeed sensor the nudge affects the target airspeed, so that throttle inputs above 50% will increase the target airspeed from TRIM_ARSPD_CM up to a maximum of ARSPD_FBW_MAX. When no airspeed sensor is enabled the throttle nudge will push up the target throttle for throttle inputs above 50%.
+ArduPlane/Parameters.cpp:    // @DisplayName: Target airspeed
+ArduPlane/Parameters.cpp:    // @Description: Target airspeed in cm/s in automatic throttle modes. Value is as an indicated (calibrated/apparent) airspeed.
+ArduPlane/Parameters.cpp:    ASCALAR(airspeed_cruise_cm,     "TRIM_ARSPD_CM",  AIRSPEED_CRUISE_CM),
+ArduPlane/Parameters.cpp:    // @Description: Minimum ground speed in cm/s when under airspeed control
+ArduPlane/Parameters.cpp:    GOBJECT(airspeed,                               "ARSPD",   AP_Airspeed),
+ArduPlane/Parameters.cpp:    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB
+ArduPlane/Parameters.cpp:    { Parameters::k_param_land_pre_flare_airspeed, 0, AP_PARAM_FLOAT, "LAND_PF_ARSPD" },
+ArduPlane/takeoff.cpp:    if (auto_state.highest_airspeed < g.takeoff_rotate_speed) {
+ArduPlane/takeoff.cpp:    if (ahrs.airspeed_sensor_enabled()) {
+ArduPlane/takeoff.cpp:        nav_pitch_cd = ((gps.ground_speed()*100) / (float)aparm.airspeed_cruise_cm) * auto_state.takeoff_pitch_cd;
+ArduPlane/takeoff.cpp:    if (auto_state.highest_airspeed >= g.takeoff_tdrag_speed1) {
+ArduPlane/mode.cpp:    // zero initial pitch and highest airspeed on mode change
+ArduPlane/mode.cpp:    plane.auto_state.highest_airspeed = 0;
+ArduPlane/GCS_Mavlink.h:    float vfr_hud_airspeed() const override;
+ArduPlane/config.h:// FLY_BY_WIRE_B airspeed control
+ArduPlane/release-notes.txt: - fixed time race in airspeed driver (thanks to liang)
+ArduPlane/release-notes.txt: - added check for airspeed and Z controller active for hover throttle learning
+ArduPlane/release-notes.txt: - support DLVR I2C airspeed sensors
+ArduPlane/release-notes.txt: - support UAVCAN buzzers, safety switch, safety LED and airspeed
+ArduPlane/release-notes.txt: - it skips baromoter, gyro and airspeed calibration, allowing for
+ArduPlane/release-notes.txt:airspeed demand resulting in a large negative pitch integrator.
+ArduPlane/release-notes.txt:for the cause of the transient in airspeed demand affecting the TECS
+ArduPlane/release-notes.txt:demanded airspeed.
+ArduPlane/release-notes.txt:   airspeeds
+ArduPlane/release-notes.txt:   airspeeds
+ArduPlane/release-notes.txt: - added speed scaler reduction in Q modes when at low airspeed
+ArduPlane/release-notes.txt: - fixed synthetic airspeed estimation to be along +ve X axis
+ArduPlane/release-notes.txt: - fixed airspeed reporting for unhealthy sensors
+ArduPlane/release-notes.txt: - added support for dual airspeed sensors
+ArduPlane/release-notes.txt: - added support for the SDP33 airspeed sensor. This is still
+ArduPlane/release-notes.txt: - add support for the MS5525 airspeed sensor on multiple I2C
+ArduPlane/release-notes.txt:The first change is to fix a timing bug in the MS5525 airspeed sensor
+ArduPlane/release-notes.txt:driver. That bug was causing unreliable airspeed sensing. Thanks to
+ArduPlane/release-notes.txt: - eliminate airspeed positive bias after offset zero
+ArduPlane/release-notes.txt: - support for MS5525 airspeed sensor
+ArduPlane/release-notes.txt: - large improvements in airspeed noise handling
+ArduPlane/release-notes.txt: - fixed quadplane transition without airspeed sensor
+ArduPlane/release-notes.txt:fixed wing modes when the aircraft airspeed dropped below
+ArduPlane/release-notes.txt:Q_ASSIST_SPEED. Some stalls can occur with higher airspeed however,
+ArduPlane/release-notes.txt: - reload airspeed after VTOL landing
+ArduPlane/release-notes.txt: - prevent EKF blocking during baro and airspeed cal
+ArduPlane/release-notes.txt: - reload airspeed after VTOL landing
+ArduPlane/release-notes.txt:   as the airspeed has risen sufficiently past the minimum airspeed
+ArduPlane/release-notes.txt:   for a sufficient period of time (by 15% above minimum airspeed for
+ArduPlane/release-notes.txt:  - fixed airspeed handling in SITL simulators
+ArduPlane/release-notes.txt: - fixed landing approach without an airspeed sensor
+ArduPlane/release-notes.txt:maximum roll angle and the minimum airspeed. You can enable/disable
+ArduPlane/release-notes.txt:configured minimum airspeed (from ARSPD_FBW_MIN). That means when in
+ArduPlane/release-notes.txt:maneuverability if the airspeed estimate is incorrect.
+ArduPlane/release-notes.txt:additionally raise the minimum airspeed in proportion to the
+ArduPlane/release-notes.txt:controller will add power to bring the airspeed up to a level that can
+ArduPlane/release-notes.txt:airspeed will drop back to the normal level.
+ArduPlane/release-notes.txt: - use airspeed temperature for baro calibration if possible
+ArduPlane/release-notes.txt:  - added airspeed sensor support in HIL
+ArduPlane/release-notes.txt: - fixed EKF wind estimation with no airspeed sensor (thanks to Paul
+ArduPlane/release-notes.txt:    wind reporting with EKF enabled and no airspeed sensor
+ArduPlane/release-notes.txt:sensors we don't support two of now are the barometer and the airspeed
+ArduPlane/release-notes.txt:sensor. I fully expect we will support dual baro and dual airspeed in
+ArduPlane/release-notes.txt:TECS_LAND_ARSPD and TECS_LAND_THR parameters to control airspeed and
+ArduPlane/release-notes.txt:  - fixed accelerometer launch detection with no airspeed sensor
+ArduPlane/release-notes.txt:  - added MS4525 I2C airspeed sensor voltage compensation
+ArduPlane/tiltrotor.cpp:  transitioning to fixed wing flight, in order to gain airspeed,
+ArduPlane/sensors.cpp:  ask airspeed sensor for a new value
+ArduPlane/sensors.cpp:void Plane::read_airspeed(void)
+ArduPlane/sensors.cpp:    airspeed.update(should_log(MASK_LOG_IMU));
+ArduPlane/sensors.cpp:    // we calculate airspeed errors (and thus target_airspeed_cm) even
+ArduPlane/sensors.cpp:    // when airspeed is disabled as TECS may be using synthetic
+ArduPlane/sensors.cpp:    // airspeed for a quadplane transition
+ArduPlane/sensors.cpp:    calc_airspeed_errors();
+ArduPlane/sensors.cpp:    // update smoothed airspeed estimate
+ArduPlane/sensors.cpp:    if (ahrs.airspeed_estimate(&aspeed)) {
+ArduPlane/sensors.cpp:        smoothed_airspeed = smoothed_airspeed * 0.8f + aspeed * 0.2f;
+ArduPlane/servos.cpp:        // if we have an airspeed sensor, then check it too, and
+ArduPlane/servos.cpp:        if ((!ahrs.airspeed_sensor_enabled()) || airspeed.get_airspeed() >= 5) {
+ArduPlane/servos.cpp:        if (ahrs.airspeed_sensor_enabled()) {
+ArduPlane/servos.cpp:            flapSpeedSource = target_airspeed_cm * 0.01f;
+ArduPlane/servos.cpp:    if (ahrs.groundspeed() < 8 || smoothed_airspeed < 8) {
+ArduPlane/radio.cpp:        if (ahrs.airspeed_sensor_enabled()) {
+ArduPlane/radio.cpp:            airspeed_nudge_cm = (aparm.airspeed_max * 100 - aparm.airspeed_cruise_cm) * nudge;
+ArduPlane/radio.cpp:        airspeed_nudge_cm = 0;
+ArduPlane/Parameters.h:        k_param_airspeed_min = 120,
+ArduPlane/Parameters.h:        k_param_airspeed_max,
+ArduPlane/Parameters.h:        k_param_airspeed,  // AP_Airspeed parameters
+ArduPlane/Parameters.h:        k_param_land_pre_flare_airspeed = 149,  // unused - moved to AP_Landing
+ArduPlane/Parameters.h:        k_param_airspeed_cruise_cm,
+ArduPlane/system.cpp:    // initialise airspeed sensor
+ArduPlane/system.cpp:    airspeed.init();
+ArduPlane/system.cpp:    // give AHRS the airspeed sensor
+ArduPlane/system.cpp:    ahrs.set_airspeed(&airspeed);
+ArduPlane/system.cpp:    if (airspeed.enabled()) {
+ArduPlane/system.cpp:        // initialize airspeed sensor
+ArduPlane/system.cpp:        airspeed.calibrate(true);
+ArduPlane/system.cpp:        gcs().send_text(MAV_SEVERITY_WARNING,"No airspeed");
+ArduPlane/commands_logic.cpp:    // pitch in deg, airspeed  m/s, throttle %, track WP 1 or 0
+ArduPlane/commands_logic.cpp:            aparm.airspeed_cruise_cm.set(cmd.content.speed.target_ms * 100);
+ArduPlane/commands_logic.cpp:            gcs().send_text(MAV_SEVERITY_INFO, "Set airspeed %u m/s", (unsigned)cmd.content.speed.target_ms);
+ArduPlane/navigation.cpp:void Plane::calc_airspeed_errors()
+ArduPlane/navigation.cpp:    float airspeed_measured = 0;
+ArduPlane/navigation.cpp:    // we use the airspeed estimate function not direct sensor as TECS
+ArduPlane/navigation.cpp:    // may be using synthetic airspeed
+ArduPlane/navigation.cpp:    ahrs.airspeed_estimate(&airspeed_measured);
+ArduPlane/navigation.cpp:    // FBW_B/cruise airspeed target
+ArduPlane/navigation.cpp:            target_airspeed_cm = aparm.airspeed_cruise_cm;
+ArduPlane/navigation.cpp:                target_airspeed_cm = linear_interpolate(aparm.airspeed_min * 100, aparm.airspeed_cruise_cm,
+ArduPlane/navigation.cpp:                target_airspeed_cm = linear_interpolate(aparm.airspeed_cruise_cm, aparm.airspeed_max * 100,
+ArduPlane/navigation.cpp:            target_airspeed_cm = ((int32_t)(aparm.airspeed_max - aparm.airspeed_min) *
+ArduPlane/navigation.cpp:                                  get_throttle_input()) + ((int32_t)aparm.airspeed_min * 100);
+ArduPlane/navigation.cpp:        // Landing airspeed target
+ArduPlane/navigation.cpp:        target_airspeed_cm = landing.get_target_airspeed_cm();
+ArduPlane/navigation.cpp:        float land_airspeed = SpdHgt_Controller->get_land_airspeed();
+ArduPlane/navigation.cpp:        if (is_positive(land_airspeed)) {
+ArduPlane/navigation.cpp:            target_airspeed_cm = SpdHgt_Controller->get_land_airspeed() * 100;
+ArduPlane/navigation.cpp:            // fallover to normal airspeed
+ArduPlane/navigation.cpp:            target_airspeed_cm = aparm.airspeed_cruise_cm;
+ArduPlane/navigation.cpp:        // Normal airspeed target
+ArduPlane/navigation.cpp:        target_airspeed_cm = aparm.airspeed_cruise_cm;
+ArduPlane/navigation.cpp:    // Set target to current airspeed + ground speed undershoot,
+ArduPlane/navigation.cpp:    // but only when this is faster than the target airspeed commanded
+ArduPlane/navigation.cpp:        int32_t min_gnd_target_airspeed = airspeed_measured*100 + groundspeed_undershoot;
+ArduPlane/navigation.cpp:        if (min_gnd_target_airspeed > target_airspeed_cm) {
+ArduPlane/navigation.cpp:            target_airspeed_cm = min_gnd_target_airspeed;
+ArduPlane/navigation.cpp:    // Bump up the target airspeed based on throttle nudging
+ArduPlane/navigation.cpp:    if (throttle_allows_nudging && airspeed_nudge_cm > 0) {
+ArduPlane/navigation.cpp:        target_airspeed_cm += airspeed_nudge_cm;
+ArduPlane/navigation.cpp:    // Apply airspeed limit
+ArduPlane/navigation.cpp:    if (target_airspeed_cm > (aparm.airspeed_max * 100))
+ArduPlane/navigation.cpp:        target_airspeed_cm = (aparm.airspeed_max * 100);
+ArduPlane/navigation.cpp:    // use the TECS view of the target airspeed for reporting, to take
+ArduPlane/navigation.cpp:    airspeed_error = SpdHgt_Controller->get_target_airspeed() - airspeed_measured;
+ArduPlane/navigation.cpp:  throttle is used to change target airspeed or throttle
+ArduPlane/Plane.h:    // external failsafe boards during baro and airspeed calibration
+ArduPlane/Plane.h:    // The calculated airspeed to use in FBW-B.  Also used in higher modes for insuring min ground speed is met.
+ArduPlane/Plane.h:    int32_t target_airspeed_cm;
+ArduPlane/Plane.h:    // The difference between current and desired airspeed.  Used in the pitch controller.  Meters per second.
+ArduPlane/Plane.h:    float airspeed_error;
+ArduPlane/Plane.h:    // An amount that the airspeed should be increased in auto modes based on the user positioning the
+ArduPlane/Plane.h:    int16_t airspeed_nudge_cm;
+ArduPlane/Plane.h:    // Similar to airspeed_nudge, but used when no airspeed sensor.
+ArduPlane/Plane.h:    AP_Airspeed airspeed;
+ArduPlane/Plane.h:        // the highest airspeed we have reached since entering AUTO. Used
+ArduPlane/Plane.h:        float highest_airspeed;
+ArduPlane/Plane.h:    // this allows certain flight modes to mix RC input with throttle depending on airspeed_nudge_cm
+ArduPlane/Plane.h:    // a smoothed airspeed estimate, used for limiting roll angle
+ArduPlane/Plane.h:    float smoothed_airspeed;
+ArduPlane/Plane.h:    void calc_airspeed_errors();
+ArduPlane/Plane.h:    void read_airspeed(void);
+ArduPlane/Plane.h:    void airspeed_ratio_update(void);
+ArduPlane/ArduPlane.cpp:    SCHED_TASK(read_airspeed,          10,    100),
+ArduPlane/ArduPlane.cpp:    SCHED_TASK(airspeed_ratio_update,   1,    100),
+ArduPlane/ArduPlane.cpp:    adsb.set_stall_speed_cm(aparm.airspeed_min);
+ArduPlane/ArduPlane.cpp:    adsb.set_max_speed(aparm.airspeed_max);
+ArduPlane/ArduPlane.cpp:  once a second update the airspeed calibration ratio
+ArduPlane/ArduPlane.cpp:void Plane::airspeed_ratio_update(void)
+ArduPlane/ArduPlane.cpp:    if (!airspeed.enabled() ||
+ArduPlane/ArduPlane.cpp:    if (airspeed.get_airspeed() < aparm.airspeed_min && 
+ArduPlane/ArduPlane.cpp:        gps.ground_speed() < (uint32_t)aparm.airspeed_min) {
+ArduPlane/ArduPlane.cpp:        // don't calibrate when flying below the minimum airspeed. We
+ArduPlane/ArduPlane.cpp:        // check both airspeed and ground speed to catch cases where
+ArduPlane/ArduPlane.cpp:        // the airspeed ratio is way too low, which could lead to it
+ArduPlane/ArduPlane.cpp:    airspeed.update_calibration(vg, aparm.airspeed_max);
+ArduPlane/ArduPlane.cpp:                                                 target_airspeed_cm,
+ArduPlane/tailsitter.cpp:        bool airspeed_enabled = ahrs.airspeed_sensor_enabled();
+ArduPlane/tailsitter.cpp:        // If there is an airspeed sensor use the measured airspeed
+ArduPlane/tailsitter.cpp:        // The airspeed estimate based only on GPS and (estimated) wind is
+ArduPlane/tailsitter.cpp:        if (airspeed_enabled && ahrs.airspeed_estimate(&aspeed)) {
+ArduPlane/tailsitter.cpp:            // ramp down from 1 to max_atten as speed increases to airspeed_max
+ArduPlane/tailsitter.cpp:            spd_scaler = constrain_float(1 - (aspeed / plane.aparm.airspeed_max), max_atten, 1.0f);
+ArduPlane/tailsitter.cpp:            // if no airspeed sensor reduce control surface throws at large tilt
+ArduPlane/tailsitter.cpp:            // angles (assuming high airspeed)
+ArduPlane/is_flying.cpp:    // airspeed at least 75% of stall speed?
+ArduPlane/is_flying.cpp:    const float airspeed_threshold = MAX(aparm.airspeed_min,2)*0.75f;
+ArduPlane/is_flying.cpp:    bool airspeed_movement = ahrs.airspeed_estimate(&aspeed) && (aspeed >= airspeed_threshold);
+ArduPlane/is_flying.cpp:    if (gps.status() < AP_GPS::GPS_OK_FIX_2D && arming.is_armed() && !airspeed_movement && isFlyingProbability > 0.3) {
+ArduPlane/is_flying.cpp:        // when flying with no GPS, use the last airspeed estimate to
+ArduPlane/is_flying.cpp:        // determine if we think we have airspeed movement. This
+ArduPlane/is_flying.cpp:        airspeed_movement = aspeed >= airspeed_threshold;
+ArduPlane/is_flying.cpp:            // we've flown before, remove GPS constraints temporarily and only use airspeed
+ArduPlane/is_flying.cpp:            is_flying_bool = airspeed_movement; // moving through the air
+ArduPlane/is_flying.cpp:            is_flying_bool = airspeed_movement || // moving through the air
+ArduPlane/is_flying.cpp:                    // while on the ground, an uncalibrated airspeed sensor can drift to 7m/s so
+ArduPlane/is_flying.cpp:        is_flying_bool = airspeed_movement && gps_confirmed_movement;
+ArduPlane/is_flying.cpp:    // if we have no GPS lock and we don't have a functional airspeed
+ArduPlane/is_flying.cpp:    if (gps.status() < AP_GPS::GPS_OK_FIX_3D && (!airspeed.use() || !airspeed.healthy())) {
+ArduPlane/Attitude.cpp:    if (ahrs.airspeed_estimate(&aspeed)) {
+ArduPlane/Attitude.cpp:        if (aspeed > auto_state.highest_airspeed) {
+ArduPlane/Attitude.cpp:            auto_state.highest_airspeed = aspeed;
+ArduPlane/Attitude.cpp:        // ensure we have scaling over the full configured airspeed
+ArduPlane/Attitude.cpp:        float scale_min = MIN(0.5, (0.5 * aparm.airspeed_min) / g.scaling_speed);
+ArduPlane/Attitude.cpp:        float scale_max = MAX(2.0, (1.5 * aparm.airspeed_max) / g.scaling_speed);
+ArduPlane/Attitude.cpp:            float threshold = aparm.airspeed_min * 0.5;
+ArduPlane/Attitude.cpp:  keeping up good airspeed in FBWA mode easier, as the plane will
+ArduPlane/Attitude.cpp:  airspeed
+ArduPlane/Attitude.cpp:    float max_load_factor = smoothed_airspeed / MAX(aparm.airspeed_min, 1);
+ArduPlane/Attitude.cpp:        // our airspeed is below the minimum airspeed. Limit roll to
+ArduPlane/Attitude.cpp:        // aircraft can be maneuvered with a bad airspeed estimate. At
+ArduPlane/GCS_Plane.cpp:    const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+ArduPlane/GCS_Plane.cpp:    if (airspeed && airspeed->enabled()) {
+ArduPlane/GCS_Plane.cpp:    if (airspeed && airspeed->enabled() && airspeed->use()) {
+ArduPlane/GCS_Plane.cpp:    if (airspeed && airspeed->all_healthy()) {
+ArduPlane/quadplane.h:    uint32_t transition_low_airspeed_ms;
+ArduPlane/quadplane.h:    // true if we have reached the airspeed threshold for transition
+ArduPlane/quadplane.h:    AP_Float maximum_takeoff_airspeed;
+ArduPlane/Log.cpp:    float airspeed_estimate;
+ArduPlane/Log.cpp:    float est_airspeed = 0;
+ArduPlane/Log.cpp:    ahrs.airspeed_estimate(&est_airspeed);
+ArduPlane/Log.cpp:        airspeed_estimate : est_airspeed
+ArduPlane/Log.cpp:    float   airspeed_error;
+ArduPlane/Log.cpp:    int32_t target_airspeed;
+ArduPlane/Log.cpp:        airspeed_error      : airspeed_error,
+ArduPlane/Log.cpp:        target_airspeed     : target_airspeed_cm,
+libraries/AP_Mission/AP_Mission.h:        uint8_t speed_type;     // 0=airspeed, 1=ground speed
+libraries/AP_Mission/AP_Mission.cpp:        cmd.content.speed.speed_type = packet.param1;   // 0 = airspeed, 1 = ground speed
+libraries/AP_Mission/AP_Mission.cpp:        packet.param1 = cmd.content.speed.speed_type;   // 0 = airspeed, 1 = ground speed
+libraries/AP_Baro/AP_Baro.h:    // get scale factor required to convert equivalent to true airspeed
+libraries/AP_Baro/AP_Baro.h:    // airspeed sensor) to be used as the temperature source
+libraries/AP_Baro/AP_Baro.cpp:// return current scale factor that converts from equivalent to true airspeed
+libraries/AP_Baro/AP_Baro.cpp:    // from the airspeed sensor
+libraries/AP_Baro/AP_Baro.cpp:    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/AP_Baro/AP_Baro.cpp:    if (airspeed != nullptr) {
+libraries/AP_Baro/AP_Baro.cpp:        if (airspeed->healthy() && airspeed->get_temperature(temperature)) {
+libraries/AP_Baro/AP_Baro.cpp:    // if we don't have an external temperature and airspeed temperature
+libraries/AP_OSD/AP_OSD_Screen.cpp:    // @Description: Displays airspeed value being used by TECS (fused value)
+libraries/AP_OSD/AP_OSD_Screen.cpp:    // @Description: Displays temperature reported by primary airspeed sensor
+libraries/AP_OSD/AP_OSD_Screen.cpp:    // @Description: Displays airspeed reported directly from secondary airspeed sensor
+libraries/AP_OSD/AP_OSD_Screen.cpp:    // @Description: Displays airspeed reported directly from primary airspeed sensor
+libraries/AP_OSD/AP_OSD_Screen.cpp:    bool have_estimate = ahrs.airspeed_estimate(&aspd);
+libraries/AP_OSD/AP_OSD_Screen.cpp:    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/AP_OSD/AP_OSD_Screen.cpp:    if (!airspeed) {
+libraries/AP_OSD/AP_OSD_Screen.cpp:    airspeed->get_temperature(temperature);
+libraries/AP_OSD/AP_OSD_Screen.cpp:    if (airspeed->healthy()) {
+libraries/AP_OSD/AP_OSD_Screen.cpp:    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/AP_OSD/AP_OSD_Screen.cpp:    if (!airspeed) {
+libraries/AP_OSD/AP_OSD_Screen.cpp:    float asp1 = airspeed->get_airspeed();
+libraries/AP_OSD/AP_OSD_Screen.cpp:    if (airspeed != nullptr && airspeed->healthy()) {
+libraries/AP_OSD/AP_OSD_Screen.cpp:    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/AP_OSD/AP_OSD_Screen.cpp:    if (!airspeed) {
+libraries/AP_OSD/AP_OSD_Screen.cpp:    float asp2 = airspeed->get_airspeed(1);
+libraries/AP_OSD/AP_OSD_Screen.cpp:    if (airspeed != nullptr && airspeed->healthy(1)) {
+libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp:// return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp: 6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp:              faultStatus.bad_airspeed<<5 |
+libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp: 4 = true airspeed measurement timeout
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    // return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:     6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    // fuse true airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    // store true airspeed data
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    // recall true airspeed data at the fusion time horizon
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    // check for new airspeed data and update stored measurements if available
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    // determine when to perform fusion of true airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    // return true if we should use the airspeed sensor
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    bool tasHealth;                 // boolean true if true airspeed has passed innovation consistency check
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    bool tasTimeout;                // boolean true if true airspeed measurements have failed for too long and have timed out
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    ftype innovVtas;                // innovation output from fusion of airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    ftype varInnovVtas;             // innovation variance output from fusion of airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    bool tasDataToFuse;             // true when new airspeed data is waiting to be fused
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    uint32_t lastTasPassTime_ms;    // time stamp when airspeed measurement last passed innovation consistency check (msec)
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:    float tasTestRatio;             // sum of squares of true airspeed innovation divided by fail threshold
+libraries/AP_NavEKF2/AP_NavEKF2_core.h:        bool bad_airspeed:1;
+libraries/AP_NavEKF2/AP_NavEKF2.h:     6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF2/AP_NavEKF2.h:    AP_Float _easNoise;             // equivalent airspeed measurement noise : m/s
+libraries/AP_NavEKF2/AP_NavEKF2.h:    AP_Int16  _tasInnovGate;        // Percentage number of standard deviations applied to true airspeed innovation consistency check
+libraries/AP_NavEKF2/AP_NavEKF2.h:    const uint16_t tasRetryTime_ms = 5000;         // True airspeed timeout and retry interval (msec)
+libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp:// check for new airspeed data and update stored measurements if available
+libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp:    // if airspeed reading is valid and is set by the user to be used and has been updated then
+libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp:    const AP_Airspeed *aspeed = _ahrs->get_airspeed();
+libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp:        tasDataNew.tas = aspeed->get_airspeed() * AP::ahrs().get_EAS2TAS();
+libraries/AP_NavEKF2/AP_NavEKF2_core.cpp:        // Update states using airspeed data
+libraries/AP_NavEKF2/AP_NavEKF2_core.cpp:    // velocity limit 500 m/sec (could set this based on some multiple of max airspeed * EAS2TAS)
+libraries/AP_NavEKF2/AP_NavEKF2_core.cpp:    // wind velocity limit 100 m/s (could be based on some multiple of max airspeed * EAS2TAS) - TODO apply circular limit
+libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp:            // if we have airspeed and a valid heading, set the wind states to the reciprocal of the vehicle heading
+libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp:        // Check if airspeed data is being used
+libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp:// return true if we should use the airspeed sensor
+libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp:    return _ahrs->airspeed_sensor_enabled();
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp: * Fuse true airspeed measurements using explicit algebraic equations generated with Matlab symbolic toolbox.
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp:    // calculate the predicted airspeed
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp:            faultStatus.bad_airspeed = false;
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp:            faultStatus.bad_airspeed = true;
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp:        // test the ratio before fusing data, forcing fusion if airspeed and position are timed out as we have no choice but to try and use airspeed to constrain error growth
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp:// select fusion of true airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp:    // get true airspeed measurement
+libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp:    // If we haven't received airspeed data for a while, then declare the airspeed data as being timed out
+libraries/AP_NavEKF2/AP_NavEKF2.cpp:    // @DisplayName: Equivalent airspeed measurement noise (m/s)
+libraries/AP_NavEKF2/AP_NavEKF2.cpp:    // @Description: This is the RMS value of noise in equivalent airspeed measurements used by planes. Increasing it reduces the weighting of airspeed measurements and will make wind speed estimates less noisy and slower to converge. Increasing also increases navigation errors when dead-reckoning without GPS measurements.
+libraries/AP_NavEKF2/AP_NavEKF2.cpp:    // @Description: This sets the percentage number of standard deviations applied to the airspeed measurement innovation consistency check. Decreasing it makes it more likely that good measurements will be rejected. Increasing it makes it more likely that bad measurements will be accepted.
+libraries/AP_NavEKF2/AP_NavEKF2.cpp:// return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
+libraries/AP_NavEKF2/AP_NavEKF2.cpp:  6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp:        // To be confident we are in the air we use a criteria which combines arm status, ground speed, airspeed and height change
+libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp:        // trigger at 8 m/s airspeed
+libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp:        if (_ahrs->airspeed_sensor_enabled()) {
+libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp:            const AP_Airspeed *airspeed = _ahrs->get_airspeed();
+libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp:            if (airspeed->get_airspeed() * AP::ahrs().get_EAS2TAS() > 10.0f) {
+libraries/AP_Airspeed/AP_Airspeed.cpp: *   AP_Airspeed.cpp - airspeed (pitot) driver
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Type of airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Enables airspeed use for automatic throttle modes and replaces control from THR_TRIM. Continues to display and log airspeed if set to 0. Uses airspeed for control if set to 1. Only uses airspeed when throttle = 0 if set to 2 (useful for gliders with airspeed sensors behind propellers).
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Calibrates pitot tube pressure to velocity. Increasing this value will indicate a higher airspeed at any given dynamic pressure.
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: The pin number that the airspeed sensor is connected to for analog sensors. Set to 15 on the Pixhawk for the analog airspeed port. 
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Automatic airspeed ratio calibration
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Enables automatic adjustment of ARSPD_RATIO during a calibration flight based on estimation of ground speed and true airspeed. New ratio saved every 2 minutes if change is > 5%. Should not be left enabled.
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Changes the pitot tube order to specify the dynamic pressure side of the sensor. Accepts either if set to 2. Accepts only one side if set to 0 or 1 and can help detect excessive pressure on the static port without indicating positive airspeed.
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Skip airspeed calibration on startup
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: This parameter allows you to skip airspeed offset calibration on startup, instead using the offset from the last calibration. This may be desirable if the offset variance between flights for your sensor is low and you want to avoid having to cover the pitot tube on each boot.
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Bus number of the I2C bus where the airspeed sensor is connected
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Primary airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: This selects which airspeed sensor will be the primary if multiple sensors are found
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Bitmask of options to use with airspeed.
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Type of 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Enable use of 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: use airspeed for flight control. When set to 0 airspeed sensor can be logged and displayed on a GCS but won't be used for flight. When set to 1 it will be logged and used. When set to 2 it will be only used when the throttle is zero, which can be useful in gliders with airspeed sensors behind a propeller
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Airspeed offset for 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Airspeed ratio for 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Airspeed pin for 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: Pin number indicating location of analog airspeed sensors. Pixhawk/Cube if set to 15. 
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Automatic airspeed ratio calibration for 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: If this is enabled then the autopilot will automatically adjust the ARSPD_RATIO during flight, based upon an estimation filter using ground speed and true airspeed. The automatic calibration will save the new ratio to EEPROM every 2 minutes if it changes by more than 5%. This option should be enabled for a calibration flight then disabled again when calibration is complete. Leaving it enabled all the time is not recommended.
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Control pitot tube order of 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: This parameter allows you to control whether the order in which the tubes are attached to your pitot tube matters. If you set this to 0 then the top connector on the sensor needs to be the dynamic pressure. If set to 1 then the bottom connector needs to be the dynamic pressure. If set to 2 (the default) then the airspeed driver will accept either order. The reason you may wish to specify the order is it will allow your airspeed sensor to detect if the aircraft it receiving excessive pressure on the static port, which would otherwise be seen as a positive airspeed.
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @DisplayName: Skip airspeed calibration on startup for 2nd sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // @Description: This parameter allows you to skip airspeed offset calibration on startup, instead using the offset from the last calibration. This may be desirable if the offset variance between flights for your sensor is low and you want to avoid having to cover the pitot tube on each boot.
+libraries/AP_Airspeed/AP_Airspeed.cpp:        // Set the enable automatically to false and set the probability that the airspeed is healhy to start with
+libraries/AP_Airspeed/AP_Airspeed.cpp:        switch ((enum airspeed_type)param[i].type.get()) {
+libraries/AP_Airspeed/AP_Airspeed.cpp:// read the airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:// calibrate the zero offset for the airspeed. This must be called at
+libraries/AP_Airspeed/AP_Airspeed.cpp:// least once before the get_airspeed() interface can be used
+libraries/AP_Airspeed/AP_Airspeed.cpp:  update async airspeed zero offset calibration
+libraries/AP_Airspeed/AP_Airspeed.cpp:// read one airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:    float airspeed_pressure;
+libraries/AP_Airspeed/AP_Airspeed.cpp:    airspeed_pressure = raw_pressure - param[i].offset;
+libraries/AP_Airspeed/AP_Airspeed.cpp:    state[i].corrected_pressure = airspeed_pressure;
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].filtered_pressure = airspeed_pressure;
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].filtered_pressure = 0.7f * state[i].filtered_pressure + 0.3f * airspeed_pressure;
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].last_pressure  = -airspeed_pressure;
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].raw_airspeed   = sqrtf(MAX(-airspeed_pressure, 0) * param[i].ratio);
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].airspeed       = sqrtf(MAX(-state[i].filtered_pressure, 0) * param[i].ratio);
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].last_pressure  = airspeed_pressure;
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].raw_airspeed   = sqrtf(MAX(airspeed_pressure, 0) * param[i].ratio);
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].airspeed       = sqrtf(MAX(state[i].filtered_pressure, 0) * param[i].ratio);
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].last_pressure  = fabsf(airspeed_pressure);
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].raw_airspeed   = sqrtf(fabsf(airspeed_pressure) * param[i].ratio);
+libraries/AP_Airspeed/AP_Airspeed.cpp:        state[i].airspeed       = sqrtf(fabsf(state[i].filtered_pressure) * param[i].ratio);
+libraries/AP_Airspeed/AP_Airspeed.cpp:// read all airspeed sensors
+libraries/AP_Airspeed/AP_Airspeed.cpp:    // debugging until we get MAVLink support for 2nd airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed.cpp:        gcs().send_named_float("AS2", get_airspeed(1));
+libraries/AP_Airspeed/AP_Airspeed.cpp:            airspeed      : get_raw_airspeed(i),
+libraries/AP_Airspeed/AP_Airspeed.cpp:void AP_Airspeed::setHIL(float airspeed, float diff_pressure, float temperature)
+libraries/AP_Airspeed/AP_Airspeed.cpp:    state[0].raw_airspeed = airspeed;
+libraries/AP_Airspeed/AP_Airspeed.cpp:    state[0].airspeed = airspeed;
+libraries/AP_Airspeed/AP_Airspeed.cpp:        // special case for gliders with airspeed sensors behind the
+libraries/AP_Airspeed/AP_Airspeed.cpp:        // propeller. Allow airspeed to be disabled when throttle is
+libraries/AP_Airspeed/AP_Airspeed.cpp:AP_Airspeed *airspeed()
+libraries/AP_Airspeed/models/ADS_cal_EKF.m:% factor that needs to be applied to a true airspeed measurement
+libraries/AP_Airspeed/models/ADS_cal_EKF.m:% Define airspeed scale factor used for truth model
+libraries/AP_Airspeed/models/ADS_cal_EKF.m:    % circular path of of 60m radius and 16 m/s airspeed
+libraries/AP_Airspeed/models/ADS_cal_EKF.m:    % calculate measured ground velocity and airspeed, adding some noise and
+libraries/AP_Airspeed/models/ADS_cal_EKF.m:    % adding a scale factor to the airspeed measurement.
+libraries/AP_Airspeed/AP_Airspeed_Health.cpp:    const float aspeed = get_airspeed();
+libraries/AP_Airspeed/AP_Airspeed.h:    // take current airspeed in m/s and ground speed vector and return
+libraries/AP_Airspeed/AP_Airspeed.h:    float update(float airspeed, const Vector3f &vg, int16_t max_airspeed_allowed_during_cal);
+libraries/AP_Airspeed/AP_Airspeed.h:    // state of kalman filter for airspeed ratio estimation
+libraries/AP_Airspeed/AP_Airspeed.h:    // read the analog source and update airspeed
+libraries/AP_Airspeed/AP_Airspeed.h:    // calibrate the airspeed. This must be called on startup if the
+libraries/AP_Airspeed/AP_Airspeed.h:    // return the current airspeed in m/s
+libraries/AP_Airspeed/AP_Airspeed.h:    float get_airspeed(uint8_t i) const {
+libraries/AP_Airspeed/AP_Airspeed.h:        return state[i].airspeed;
+libraries/AP_Airspeed/AP_Airspeed.h:    float get_airspeed(void) const { return get_airspeed(primary); }
+libraries/AP_Airspeed/AP_Airspeed.h:    // return the unfiltered airspeed in m/s
+libraries/AP_Airspeed/AP_Airspeed.h:    float get_raw_airspeed(uint8_t i) const {
+libraries/AP_Airspeed/AP_Airspeed.h:        return state[i].raw_airspeed;
+libraries/AP_Airspeed/AP_Airspeed.h:    float get_raw_airspeed(void) const { return get_raw_airspeed(primary); }
+libraries/AP_Airspeed/AP_Airspeed.h:    // return the current airspeed ratio (dimensionless)
+libraries/AP_Airspeed/AP_Airspeed.h:    float get_airspeed_ratio(uint8_t i) const {
+libraries/AP_Airspeed/AP_Airspeed.h:    float get_airspeed_ratio(void) const { return get_airspeed_ratio(primary); }
+libraries/AP_Airspeed/AP_Airspeed.h:    // set the airspeed ratio (dimensionless)
+libraries/AP_Airspeed/AP_Airspeed.h:    void set_airspeed_ratio(uint8_t i, float ratio) {
+libraries/AP_Airspeed/AP_Airspeed.h:    void set_airspeed_ratio(float ratio) { set_airspeed_ratio(primary, ratio); }
+libraries/AP_Airspeed/AP_Airspeed.h:    // return true if airspeed is enabled, and airspeed use is set
+libraries/AP_Airspeed/AP_Airspeed.h:    // return true if airspeed is enabled
+libraries/AP_Airspeed/AP_Airspeed.h:    // used by HIL to set the airspeed
+libraries/AP_Airspeed/AP_Airspeed.h:    void set_HIL(float airspeed) {
+libraries/AP_Airspeed/AP_Airspeed.h:        state[primary].airspeed = airspeed;
+libraries/AP_Airspeed/AP_Airspeed.h:    // return the differential pressure in Pascal for the last airspeed reading
+libraries/AP_Airspeed/AP_Airspeed.h:    // update airspeed ratio calibration
+libraries/AP_Airspeed/AP_Airspeed.h:    void update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
+libraries/AP_Airspeed/AP_Airspeed.h:    void setHIL(float airspeed, float diff_pressure, float temperature);
+libraries/AP_Airspeed/AP_Airspeed.h:        ON_FAILURE_AHRS_WIND_MAX_DO_DISABLE                   = (1<<0),   // If set then use airspeed failure check
+libraries/AP_Airspeed/AP_Airspeed.h:        ON_FAILURE_AHRS_WIND_MAX_RECOVERY_DO_REENABLE         = (1<<1),   // If set then automatically enable the airspeed sensor use when healthy again.
+libraries/AP_Airspeed/AP_Airspeed.h:    enum airspeed_type {
+libraries/AP_Airspeed/AP_Airspeed.h:    AP_Int32 _options;    // bitmask options for airspeed
+libraries/AP_Airspeed/AP_Airspeed.h:    struct airspeed_state {
+libraries/AP_Airspeed/AP_Airspeed.h:        float   raw_airspeed;
+libraries/AP_Airspeed/AP_Airspeed.h:        float   airspeed;
+libraries/AP_Airspeed/AP_Airspeed.h:    // return the differential pressure in Pascal for the last airspeed reading for the requested instance
+libraries/AP_Airspeed/AP_Airspeed.h:    void update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
+libraries/AP_Airspeed/AP_Airspeed.h:    void send_airspeed_calibration(const Vector3f &vg);
+libraries/AP_Airspeed/AP_Airspeed.h:    AP_Airspeed *airspeed();
+libraries/AP_Airspeed/AP_Airspeed_SDP3X.h:  backend driver for airspeed from I2C
+libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp:  backend driver for airspeed from a I2C SDP3X sensor
+libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp:  with thanks to https://github.com/PX4/Firmware/blob/master/src/drivers/sdp3x_airspeed
+libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp:    // airspeed ratio
+libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp:    float ratio = get_airspeed_ratio();
+libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp:    // pressure correction. We need to do this so the airspeed ratio
+libraries/AP_Airspeed/Airspeed_Calibration.cpp: *   auto_calibration.cpp - airspeed auto calibration
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:  update the state of the airspeed calibration - needs to be called
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:float Airspeed_Calibration::update(float airspeed, const Vector3f &vg, int16_t max_airspeed_allowed_during_cal)
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    float TAS_mea  = airspeed;
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    state.x = constrain_float(state.x, -max_airspeed_allowed_during_cal, max_airspeed_allowed_during_cal);
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    state.y = constrain_float(state.y, -max_airspeed_allowed_during_cal, max_airspeed_allowed_during_cal);
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:void AP_Airspeed::update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal)
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    // calculate true airspeed, assuming a airspeed ratio of 1.0
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    float true_airspeed = sqrtf(dpress) * AP::baro().get_EAS2TAS();
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    float zratio = state[i].calibration.update(true_airspeed, vground, max_airspeed_allowed_during_cal);
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:void AP_Airspeed::update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal)
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:        update_calibration(i, vground, max_airspeed_allowed_during_cal);
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    send_airspeed_calibration(vground);
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:void AP_Airspeed::send_airspeed_calibration(const Vector3f &vground)
+libraries/AP_Airspeed/Airspeed_Calibration.cpp:    const mavlink_airspeed_autocal_t packet{
+libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp:  driver for DLVR differential airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed_Backend.cpp:  backend driver class for airspeed
+libraries/AP_Airspeed/AP_Airspeed_Backend.h:  backend driver class for airspeed
+libraries/AP_Airspeed/AP_Airspeed_Backend.h:    float get_airspeed_ratio(void) const {
+libraries/AP_Airspeed/AP_Airspeed_Backend.h:        return frontend.get_airspeed_ratio(instance);
+libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp:  backend driver for airspeed from a I2C MS4525D0 sensor
+libraries/AP_Airspeed/AP_Airspeed_analog.cpp: *   analog airspeed driver
+libraries/AP_Airspeed/AP_Airspeed_analog.cpp:// scaling for 3DR analog airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed_analog.cpp:// read the airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h:    static void handle_airspeed(AP_UAVCAN* ap_uavcan, uint8_t node_id, const AirspeedCb &cb);
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h:    HAL_Semaphore _sem_airspeed;
+libraries/AP_Airspeed/AP_Airspeed_DLVR.h:// backend driver for AllSensors DLVR differential airspeed sensor
+libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp:  backend driver for airspeed from a I2C MS5525D0 sensor
+libraries/AP_Airspeed/AP_Airspeed_MS4525.h:  backend driver for airspeed from I2C
+libraries/AP_Airspeed/AP_Airspeed_MS5525.h:  backend driver for airspeed from I2C
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp: *   Airspeed.cpp - airspeed example sketch
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:// create airspeed object
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:AP_Airspeed airspeed;
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:    // set airspeed pin to 65, enable and use to true
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:    set_object_value(&airspeed, airspeed.var_info, "PIN", 65);
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:    set_object_value(&airspeed, airspeed.var_info, "ENABLE", 1);
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:    set_object_value(&airspeed, airspeed.var_info, "USE", 1);
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:    // initialize airspeed
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:    airspeed.init();
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:    airspeed.calibrate(false);
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:        airspeed.update(false);
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:        airspeed.get_temperature(temperature);
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:        // print temperature and airspeed to console
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:        hal.console->printf("airspeed %5.2f temperature %6.2f healthy = %u\n",
+libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp:                            (double)airspeed.get_airspeed(), (double)temperature, airspeed.healthy());
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:#define debug_airspeed_uavcan(level_debug, can_driver, fmt, args...) do { if ((level_debug) <= AP::can().get_debug_level_driver(can_driver)) { printf(fmt, ##args); }} while (0)
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:    uavcan::Subscriber<uavcan::equipment::air_data::RawAirData, AirspeedCb> *airspeed_listener;
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:    airspeed_listener = new uavcan::Subscriber<uavcan::equipment::air_data::RawAirData, AirspeedCb>(*node);
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:    const int airspeed_listener_res = airspeed_listener->start(AirspeedCb(ap_uavcan, &handle_airspeed));
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:    if (airspeed_listener_res < 0) {
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:                debug_airspeed_uavcan(2,
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:                debug_airspeed_uavcan(2,
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:void AP_Airspeed_UAVCAN::handle_airspeed(AP_UAVCAN* ap_uavcan, uint8_t node_id, const AirspeedCb &cb)
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:        WITH_SEMAPHORE(driver->_sem_airspeed);
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:    WITH_SEMAPHORE(_sem_airspeed);
+libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:    WITH_SEMAPHORE(_sem_airspeed);
+libraries/AP_Arming/AP_Arming.cpp:bool AP_Arming::airspeed_checks(bool report)
+libraries/AP_Arming/AP_Arming.cpp:        const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/AP_Arming/AP_Arming.cpp:        if (airspeed == nullptr) {
+libraries/AP_Arming/AP_Arming.cpp:            // not an airspeed capable vehicle
+libraries/AP_Arming/AP_Arming.cpp:            if (airspeed->enabled(i) && airspeed->use(i) && !airspeed->healthy(i)) {
+libraries/AP_Arming/AP_Arming.h:    bool airspeed_checks(bool report);
+libraries/AP_WindVane/AP_WindVane_Airspeed.cpp:    const AP_Airspeed* airspeed = AP_Airspeed::get_singleton();
+libraries/AP_WindVane/AP_WindVane_Airspeed.cpp:    if (airspeed != nullptr) {
+libraries/AP_WindVane/AP_WindVane_Airspeed.cpp:        speed_update_frontend(airspeed->get_airspeed());
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp: * Fuse true airspeed measurements using explicit algebraic equations generated with Matlab symbolic toolbox.
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp:    // calculate the predicted airspeed
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp:            faultStatus.bad_airspeed = false;
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp:            faultStatus.bad_airspeed = true;
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp:        // test the ratio before fusing data, forcing fusion if airspeed and position are timed out as we have no choice but to try and use airspeed to constrain error growth
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp:// select fusion of true airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp:    // get true airspeed measurement
+libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp:    // If we haven't received airspeed data for a while, then declare the airspeed data as being timed out
+libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp:            // if we have airspeed and a valid heading, set the wind states to the reciprocal of the vehicle heading
+libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp:            // Check if airspeed data is being used
+libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp:// return true if we should use the airspeed sensor
+libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp:    return _ahrs->airspeed_sensor_enabled();
+libraries/AP_NavEKF3/AP_NavEKF3_core.cpp:    // airspeed sensing can have large delays and should not be included if disabled
+libraries/AP_NavEKF3/AP_NavEKF3_core.cpp:    if (_ahrs->airspeed_sensor_enabled()) {
+libraries/AP_NavEKF3/AP_NavEKF3_core.cpp:        // Update states using airspeed data
+libraries/AP_NavEKF3/AP_NavEKF3_core.cpp:    // velocity limit 500 m/sec (could set this based on some multiple of max airspeed * EAS2TAS)
+libraries/AP_NavEKF3/AP_NavEKF3_core.cpp:    // wind velocity limit 100 m/s (could be based on some multiple of max airspeed * EAS2TAS) - TODO apply circular limit
+libraries/AP_NavEKF3/AP_NavEKF3.h:     6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF3/AP_NavEKF3.h:    AP_Float _easNoise;             // equivalent airspeed measurement noise : m/s
+libraries/AP_NavEKF3/AP_NavEKF3.h:    AP_Int16  _tasInnovGate;        // Percentage number of standard deviations applied to true airspeed innovation consistency check
+libraries/AP_NavEKF3/AP_NavEKF3.h:    const uint16_t tasRetryTime_ms = 5000;         // True airspeed timeout and retry interval (msec)
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    // return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:     6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:        float       tas;            // true airspeed measurement (m/sec)
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    // fuse true airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    // store true airspeed data
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    // recall true airspeed data at the fusion time horizon
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    // check for new airspeed data and update stored measurements if available
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    // determine when to perform fusion of true airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    // return true if we should use the airspeed sensor
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    bool tasHealth;                 // boolean true if true airspeed has passed innovation consistency check
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    bool tasTimeout;                // boolean true if true airspeed measurements have failed for too long and have timed out
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    ftype innovVtas;                // innovation output from fusion of airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    ftype varInnovVtas;             // innovation variance output from fusion of airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    bool tasDataToFuse;             // true when new airspeed data is waiting to be fused
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    uint32_t lastTasPassTime_ms;    // time stamp when airspeed measurement last passed innovation consistency check (msec)
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:    float tasTestRatio;             // sum of squares of true airspeed innovation divided by fail threshold
+libraries/AP_NavEKF3/AP_NavEKF3_core.h:        bool bad_airspeed:1;
+libraries/AP_NavEKF3/AP_NavEKF3.cpp:    // @DisplayName: Equivalent airspeed measurement noise (m/s)
+libraries/AP_NavEKF3/AP_NavEKF3.cpp:    // @Description: This is the RMS value of noise in equivalent airspeed measurements used by planes. Increasing it reduces the weighting of airspeed measurements and will make wind speed estimates less noisy and slower to converge. Increasing also increases navigation errors when dead-reckoning without GPS measurements.
+libraries/AP_NavEKF3/AP_NavEKF3.cpp:    // @Description: This sets the percentage number of standard deviations applied to the airspeed measurement innovation consistency check. Decreasing it makes it more likely that good measurements will be rejected. Increasing it makes it more likely that bad measurements will be accepted.
+libraries/AP_NavEKF3/AP_NavEKF3.cpp:// return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3.cpp:  6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp:// check for new airspeed data and update stored measurements if available
+libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp:    // if airspeed reading is valid and is set by the user to be used and has been updated then
+libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp:    const AP_Airspeed *aspeed = _ahrs->get_airspeed();
+libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp:        tasDataNew.tas = aspeed->get_raw_airspeed() * AP::ahrs().get_EAS2TAS();
+libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp:        // To be confident we are in the air we use a criteria which combines arm status, ground speed, airspeed and height change
+libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp:        // trigger at 8 m/s airspeed
+libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp:        if (_ahrs->airspeed_sensor_enabled()) {
+libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp:            const AP_Airspeed *airspeed = _ahrs->get_airspeed();
+libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp:            if (airspeed->get_airspeed() * AP::ahrs().get_EAS2TAS() > 10.0f) {
+libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp:// return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
+libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp: 6 = badly conditioned airspeed fusion
+libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp:              faultStatus.bad_airspeed<<5 |
+libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp: 4 = true airspeed measurement timeout
+libraries/APM_Control/AP_RollController.cpp:	// Get an airspeed estimate - default to zero if none available
+libraries/APM_Control/AP_RollController.cpp:	if (!_ahrs.airspeed_estimate(&aspeed)) {
+libraries/APM_Control/AP_RollController.cpp:	// This means aileron trim offset doesn't change as the value of scaler changes with airspeed
+libraries/APM_Control/AP_RollController.cpp:		//only integrate if gain and time step are positive and airspeed above min value.
+libraries/APM_Control/AP_RollController.cpp:		if (dt > 0 && aspeed > float(aparm.airspeed_min)) {
+libraries/APM_Control/AP_RollController.cpp:    if (autotune.running && aspeed > aparm.airspeed_min) {
+libraries/APM_Control/AP_RollController.cpp: 4) minimum FBW airspeed (metres/sec)
+libraries/APM_Control/AP_YawController.cpp:	// @Description: Gain to the yaw rate required to keep it consistent with the turn rate in a coordinated turn. Corrects for yaw tendencies after the turn is established. Increase yaw into the turn by raising. Increase yaw out of the turn by decreasing. Values outside of 0.9-1.1 range indicate airspeed calibration problems.
+libraries/APM_Control/AP_YawController.cpp:    int16_t aspd_min = aparm.airspeed_min;
+libraries/APM_Control/AP_YawController.cpp:	if (!_ahrs.airspeed_estimate(&aspeed)) {
+libraries/APM_Control/AP_YawController.cpp:	    // If no airspeed available use average of min and max
+libraries/APM_Control/AP_YawController.cpp:        aspeed = 0.5f*(float(aspd_min) + float(aparm.airspeed_max));
+libraries/APM_Control/AP_YawController.cpp:		//only integrate if airspeed above min value
+libraries/APM_Control/TuningGuide.txt:c) you have calibrated your airspeed sensor
+libraries/APM_Control/TuningGuide.txt:6) If you have an airspeed sensor enabled then blow air towards the
+libraries/APM_Control/TuningGuide.txt:   airspeed reading increase
+libraries/APM_Control/TuningGuide.txt:   of your pitch loop, your airspeed calibration or you APM's bank
+libraries/APM_Control/TuningGuide.txt:   and you should check step 2), the airspeed calibration and accuracy
+libraries/APM_Control/TuningGuide.txt:with the airspeed calibration.
+libraries/APM_Control/AP_PitchController.cpp: 4) minimum FBW airspeed (metres/sec)
+libraries/APM_Control/AP_PitchController.cpp: 5) maximum FBW airspeed (metres/sec)
+libraries/APM_Control/AP_PitchController.cpp:	// This means elevator trim offset doesn't change as the value of scaler changes with airspeed
+libraries/APM_Control/AP_PitchController.cpp:		//only integrate if gain and time step are positive and airspeed above min value.
+libraries/APM_Control/AP_PitchController.cpp:		if (dt > 0 && aspeed > 0.5f*float(aparm.airspeed_min)) {
+libraries/APM_Control/AP_PitchController.cpp:    if (autotune.running && aspeed > aparm.airspeed_min) {
+libraries/APM_Control/AP_PitchController.cpp: 4) minimum FBW airspeed (metres/sec)
+libraries/APM_Control/AP_PitchController.cpp: 5) maximum FBW airspeed (metres/sec)
+libraries/APM_Control/AP_PitchController.cpp:	if (!_ahrs.airspeed_estimate(&aspeed)) {
+libraries/APM_Control/AP_PitchController.cpp:	    // If no airspeed available use average of min and max
+libraries/APM_Control/AP_PitchController.cpp:        aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
+libraries/APM_Control/AP_PitchController.cpp:  Also returns the inverted flag and the estimated airspeed in m/s for
+libraries/APM_Control/AP_PitchController.cpp:	if (!_ahrs.airspeed_estimate(&aspeed)) {
+libraries/APM_Control/AP_PitchController.cpp:	    // If no airspeed available use average of min and max
+libraries/APM_Control/AP_PitchController.cpp:        aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
+libraries/APM_Control/AP_PitchController.cpp:        rate_offset = cosf(_ahrs.pitch)*fabsf(ToDeg((GRAVITY_MSS / MAX((aspeed * _ahrs.get_EAS2TAS()) , float(aparm.airspeed_min))) * tanf(bank_angle) * sinf(bank_angle))) * _roll_ff;
+libraries/APM_Control/AP_PitchController.cpp:// 4) minimum FBW airspeed (metres/sec)
+libraries/APM_Control/AP_PitchController.cpp:// 5) maximum FBW airspeed (metres/sec)
+libraries/APM_Control/AP_PitchController.cpp:	// Calculate ideal turn rate from bank angle and airspeed assuming a level coordinated turn
+libraries/AP_AHRS/AP_AHRS_NavEKF.cpp:// return an airspeed estimate if available. return true
+libraries/AP_AHRS/AP_AHRS_NavEKF.cpp:bool AP_AHRS_NavEKF::airspeed_estimate(float *airspeed_ret) const
+libraries/AP_AHRS/AP_AHRS_NavEKF.cpp:    return AP_AHRS_DCM::airspeed_estimate(airspeed_ret);
+libraries/AP_AHRS/AP_AHRS.h:    void set_airspeed(AP_Airspeed *airspeed) {
+libraries/AP_AHRS/AP_AHRS.h:        _airspeed = airspeed;
+libraries/AP_AHRS/AP_AHRS.h:    const AP_Airspeed *get_airspeed(void) const {
+libraries/AP_AHRS/AP_AHRS.h:        return _airspeed;
+libraries/AP_AHRS/AP_AHRS.h:    // return an airspeed estimate if available. return true
+libraries/AP_AHRS/AP_AHRS.h:    virtual bool airspeed_estimate(float *airspeed_ret) const WARN_IF_UNUSED;
+libraries/AP_AHRS/AP_AHRS.h:    // return a true airspeed estimate (navigation airspeed) if
+libraries/AP_AHRS/AP_AHRS.h:    bool airspeed_estimate_true(float *airspeed_ret) const WARN_IF_UNUSED {
+libraries/AP_AHRS/AP_AHRS.h:        if (!airspeed_estimate(airspeed_ret)) {
+libraries/AP_AHRS/AP_AHRS.h:        *airspeed_ret *= get_EAS2TAS();
+libraries/AP_AHRS/AP_AHRS.h:    // get apparent to true airspeed ratio
+libraries/AP_AHRS/AP_AHRS.h:    // return true if airspeed comes from an airspeed sensor, as
+libraries/AP_AHRS/AP_AHRS.h:    bool airspeed_sensor_enabled(void) const {
+libraries/AP_AHRS/AP_AHRS.h:        return _airspeed != nullptr && _airspeed->use() && _airspeed->healthy();
+libraries/AP_AHRS/AP_AHRS.h:    // pointer to airspeed object, if available
+libraries/AP_AHRS/AP_AHRS.h:    AP_Airspeed     * _airspeed;
+libraries/AP_AHRS/AP_AHRS_DCM.h:    // return an airspeed estimate if available. return true
+libraries/AP_AHRS/AP_AHRS_DCM.h:    bool airspeed_estimate(float *airspeed_ret) const override;
+libraries/AP_AHRS/AP_AHRS_DCM.h:    float _last_airspeed;
+libraries/AP_AHRS/AP_AHRS.cpp:    // @Description: This sets the maximum allowable difference between ground speed and airspeed. This allows the plane to cope with a failing airspeed sensor. A value of zero means to use the airspeed as is.
+libraries/AP_AHRS/AP_AHRS.cpp:    // @Description: This controls the time constant for the cross-over frequency used to fuse AHRS (airspeed and heading) and GPS data to estimate ground velocity. Time constant is 0.1/beta. A larger time constant will use GPS data less and a small time constant will use air data less.
+libraries/AP_AHRS/AP_AHRS.cpp:// return airspeed estimate if available
+libraries/AP_AHRS/AP_AHRS.cpp:bool AP_AHRS::airspeed_estimate(float *airspeed_ret) const
+libraries/AP_AHRS/AP_AHRS.cpp:    if (airspeed_sensor_enabled()) {
+libraries/AP_AHRS/AP_AHRS.cpp:        *airspeed_ret = _airspeed->get_airspeed();
+libraries/AP_AHRS/AP_AHRS.cpp:            // constrain the airspeed by the ground speed
+libraries/AP_AHRS/AP_AHRS.cpp:            float true_airspeed = *airspeed_ret * get_EAS2TAS();
+libraries/AP_AHRS/AP_AHRS.cpp:            true_airspeed = constrain_float(true_airspeed,
+libraries/AP_AHRS/AP_AHRS.cpp:            *airspeed_ret = true_airspeed / get_EAS2TAS();
+libraries/AP_AHRS/AP_AHRS.cpp:    float airspeed = 0;
+libraries/AP_AHRS/AP_AHRS.cpp:    const bool gotAirspeed = airspeed_estimate_true(&airspeed);
+libraries/AP_AHRS/AP_AHRS.cpp:        const Vector2f airspeed_vector(_cos_yaw * airspeed, _sin_yaw * airspeed);
+libraries/AP_AHRS/AP_AHRS.cpp:        gndVelADS = airspeed_vector + wind2d;
+libraries/AP_AHRS/AP_AHRS.cpp:    if (airspeed > 0) {
+libraries/AP_AHRS/AP_AHRS.cpp:        // we have a rough airspeed, and we have a yaw. For
+libraries/AP_AHRS/AP_AHRS.cpp:        ret *= airspeed;
+libraries/AP_AHRS/AP_AHRS.cpp: * Update AOA and SSA estimation based on airspeed, velocity vector and wind vector
+libraries/AP_AHRS/AP_AHRS.cpp:// get apparent to true airspeed ratio
+libraries/AP_AHRS/AP_AHRS_View.h:    bool airspeed_estimate(float *airspeed_ret) const WARN_IF_UNUSED {
+libraries/AP_AHRS/AP_AHRS_View.h:        return ahrs.airspeed_estimate(airspeed_ret);
+libraries/AP_AHRS/AP_AHRS_View.h:    bool airspeed_estimate_true(float *airspeed_ret) const WARN_IF_UNUSED {
+libraries/AP_AHRS/AP_AHRS_View.h:        return ahrs.airspeed_estimate_true(airspeed_ret);
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        // if we have an airspeed estimate (which we only have if
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        float airspeed;
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        if (airspeed_sensor_enabled()) {
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:            airspeed = _airspeed->get_airspeed();
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:            airspeed = _last_airspeed;
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        // use airspeed to estimate our ground velocity in
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        velocity = _dcm_matrix.colx() * airspeed;
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        // keep last airspeed estimate for dead-reckoning purposes
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        Vector3f airspeed = velocity - _wind;
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        airspeed = rot.mul_transpose(airspeed);
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        _last_airspeed = MAX(airspeed.x, 0);
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        // estimate airspeed it using equation 6
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:    } else if (now - _last_wind_time > 2000 && airspeed_sensor_enabled()) {
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        // when flying straight use airspeed to get wind estimate if available
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        const Vector3f airspeed = _dcm_matrix.colx() * _airspeed->get_airspeed();
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        const Vector3f wind = velocity - (airspeed * get_EAS2TAS());
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:// return an airspeed estimate if available
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:bool AP_AHRS_DCM::airspeed_estimate(float *airspeed_ret) const
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:    if (airspeed_sensor_enabled()) {
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        *airspeed_ret = _airspeed->get_airspeed();
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        *airspeed_ret = _last_airspeed;
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        // constrain the airspeed by the ground speed
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        float true_airspeed = *airspeed_ret * get_EAS2TAS();
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        true_airspeed = constrain_float(true_airspeed,
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        *airspeed_ret = true_airspeed / get_EAS2TAS();
+libraries/AP_AHRS/AP_AHRS_DCM.cpp:        *airspeed_ret = _last_airspeed;
+libraries/AP_AHRS/AP_AHRS_NavEKF.h:    // return an airspeed estimate if available. return true
+libraries/AP_AHRS/AP_AHRS_NavEKF.h:    bool airspeed_estimate(float *airspeed_ret) const override;
+libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat:# And the analog input for airspeed (rarely used these days).
+libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat:#analog rssi pin (also could be used as analog airspeed input)
+libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat:#analog rssi pin (also could be used as analog airspeed input)
+libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat:# and the analog input for airspeed (rarely used these days)
+libraries/AP_HAL_ChibiOS/hwdef/omnibusf4v6/hwdef.dat:#analog rssi pin (also could be used as analog airspeed input)
+libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat:# also could be used as analog airspeed input
+libraries/AP_HAL_ChibiOS/hwdef/speedybeef4/hwdef.dat:#analog rssi pin (also could be used as analog airspeed input)
+libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat:#analog rssi pin (also could be used as analog airspeed input)
+libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat:#analog rssi pin (also could be used as analog airspeed input)
+libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat:# And the analog input for airspeed (rarely used these days).
+libraries/AP_HAL_ChibiOS/hwdef/mRoX21-777/hwdef.dat:# and the analog input for airspeed (rarely used these days)
+libraries/AP_L1_Control/AP_L1_Control.cpp:        nominal_velocity_sea_level =  _spdHgtControl->get_target_airspeed();
+libraries/AP_Logger/LogStructure.h:    float   airspeed;
+libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp:    // horizontal velocity in dm/s (use airspeed if available and enabled - even if not used - otherwise use groundspeed)
+libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp:    const AP_Airspeed *aspeed = _ahrs.get_airspeed();
+libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp:        velandyaw |= prep_number(roundf(aspeed->get_airspeed() * 10), 2, 1)<<VELANDYAW_XYVEL_OFFSET;
+libraries/AP_SpdHgtControl/AP_SpdHgtControl.h:	// return current target airspeed
+libraries/AP_SpdHgtControl/AP_SpdHgtControl.h:	virtual float get_target_airspeed(void) const = 0;
+libraries/AP_SpdHgtControl/AP_SpdHgtControl.h:    // return landing airspeed
+libraries/AP_SpdHgtControl/AP_SpdHgtControl.h:    virtual float get_land_airspeed(void) const = 0;
+libraries/SITL/SIM_XPlane.cpp:            airspeed = data[2] * KNOTS_TO_METERS_PER_SECOND;
+libraries/SITL/SIM_XPlane.cpp:            airspeed_pitot = airspeed;
+libraries/SITL/SIM_SilentWings.cpp:    airspeed = pkt.v_eas;
+libraries/SITL/SIM_SilentWings.cpp:    airspeed_pitot = pkt.v_eas;
+libraries/SITL/SIM_Plane.cpp:    float effective_airspeed = airspeed;
+libraries/SITL/SIM_Plane.cpp:          tailsitters get airspeed from prop-wash
+libraries/SITL/SIM_Plane.cpp:        effective_airspeed += inputThrust * 20;
+libraries/SITL/SIM_Plane.cpp:	double qbar = 1.0/2.0*rho*pow(effective_airspeed,2)*s; //Calculate dynamic pressure
+libraries/SITL/SIM_Plane.cpp:	if (is_zero(effective_airspeed))
+libraries/SITL/SIM_Plane.cpp:		la = qbar*b*(c_l_0 + c_l_b*beta + c_l_p*b*p/(2*effective_airspeed) + c_l_r*b*r/(2*effective_airspeed) + c_l_deltaa*inputAileron + c_l_deltar*inputRudder);
+libraries/SITL/SIM_Plane.cpp:		ma = qbar*c*(c_m_0 + c_m_a*alpha + c_m_q*c*q/(2*effective_airspeed) + c_m_deltae*inputElevator);
+libraries/SITL/SIM_Plane.cpp:		na = qbar*b*(c_n_0 + c_n_b*beta + c_n_p*b*p/(2*effective_airspeed) + c_n_r*b*r/(2*effective_airspeed) + c_n_deltaa*inputAileron + c_n_deltar*inputRudder);
+libraries/SITL/SIM_Plane.cpp:	double qbar = 1.0/2.0*rho*pow(airspeed,2)*s; //Calculate dynamic pressure
+libraries/SITL/SIM_Plane.cpp:	if (is_zero(airspeed))
+libraries/SITL/SIM_Plane.cpp:		ax = qbar*(c_x_a + c_x_q*c*q/(2*airspeed) - c_drag_deltae*cos(alpha)*fabs(inputElevator) + c_lift_deltae*sin(alpha)*inputElevator);
+libraries/SITL/SIM_Plane.cpp:		ay = qbar*(c_y_0 + c_y_b*beta + c_y_p*b*p/(2*airspeed) + c_y_r*b*r/(2*airspeed) + c_y_deltaa*inputAileron + c_y_deltar*inputRudder);
+libraries/SITL/SIM_Plane.cpp:		az = qbar*(c_z_a + c_z_q*c*q/(2*airspeed) - c_drag_deltae*sin(alpha)*fabs(inputElevator) - c_lift_deltae*cos(alpha)*inputElevator);
+libraries/SITL/SIM_Aircraft.h:    float airspeed;                      // m/s, apparent airspeed
+libraries/SITL/SIM_Aircraft.h:    float airspeed_pitot;                // m/s, apparent airspeed, as seen by fwd pitot tube
+libraries/SITL/SIM_Scrimmage.h:        double airspeed;
+libraries/SITL/SIM_Scrimmage.cpp:    airspeed = pkt.airspeed;
+libraries/SITL/SIM_Scrimmage.cpp:    airspeed_pitot = pkt.airspeed;
+libraries/SITL/SIM_Sailboat.cpp:    // set RPM and airspeed from wind speed, allows to test RPM and Airspeed wind vane back end in SITL
+libraries/SITL/SIM_Sailboat.cpp:    airspeed_pitot = wind_apparent_speed;
+libraries/SITL/SIM_FlightAxis.cpp:    airspeed = state.m_airspeed_MPS;
+libraries/SITL/SIM_FlightAxis.cpp:    /* for pitot airspeed we need the airspeed along the X axis. We
+libraries/SITL/SIM_FlightAxis.cpp:       can't get that from m_airspeed_MPS, so instead we canculate it
+libraries/SITL/SIM_FlightAxis.cpp:    Vector3f airspeed_3d_ef = m_wind_ef + velocity_ef;
+libraries/SITL/SIM_FlightAxis.cpp:    Vector3f airspeed3d = dcm.mul_transpose(airspeed_3d_ef);
+libraries/SITL/SIM_FlightAxis.cpp:    airspeed_pitot = MAX(airspeed3d.x,0);
+libraries/SITL/SIM_FlightAxis.cpp:           airspeed3d.x,
+libraries/SITL/SIM_FlightAxis.cpp:           airspeed3d.y,
+libraries/SITL/SIM_FlightAxis.cpp:           airspeed3d.z);
+libraries/SITL/SIM_CRRCSim.cpp:    airspeed = pkt.airspeed;
+libraries/SITL/SIM_CRRCSim.cpp:    airspeed_pitot = pkt.airspeed;
+libraries/SITL/SIM_JSBSim.h:    float vcas;          // calibrated airspeed
+libraries/SITL/SITL.h:    double airspeed; // m/s
+libraries/SITL/SITL.h:    // airspeed fault control
+libraries/SITL/SITL.h:    //airspeed fault
+libraries/SITL/SIM_Aircraft.cpp:    fdm.airspeed = airspeed_pitot;
+libraries/SITL/SIM_Aircraft.cpp:    // airspeed
+libraries/SITL/SIM_Aircraft.cpp:    airspeed = velocity_air_ef.length();
+libraries/SITL/SIM_Aircraft.cpp:    // airspeed as seen by a fwd pitot tube (limited to 120m/s)
+libraries/SITL/SIM_Aircraft.cpp:    airspeed_pitot = constrain_float(velocity_air_bf * Vector3f(1.0f, 0.0f, 0.0f), 0.0f, 120.0f);
+libraries/SITL/SIM_FlightAxis.h:        double m_airspeed_MPS;
+libraries/SITL/SIM_FlightAxis.h:        { "m-airspeed-MPS", state.m_airspeed_MPS },
+libraries/SITL/SIM_last_letter.cpp:    airspeed = pkt.airspeed;
+libraries/SITL/SIM_last_letter.cpp:    airspeed_pitot = pkt.airspeed;
+libraries/SITL/SIM_last_letter.h:        double airspeed;
+libraries/SITL/SIM_CRRCSim.h:        double airspeed;
+libraries/SITL/SIM_JSBSim.cpp:    airspeed = fdm.vcas * KNOTS_TO_METERS_PER_SECOND;
+libraries/SITL/SIM_JSBSim.cpp:    airspeed_pitot = airspeed;
+libraries/AP_Landing/AP_Landing.h:    int32_t get_target_airspeed_cm(void);
+libraries/AP_Landing/AP_Landing.h:    AP_Float pre_flare_airspeed;
+libraries/AP_Landing/AP_Landing.h:    int32_t type_slope_get_target_airspeed_cm(void);
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    // @DisplayName: Deepstall enabled airspeed
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    AP_GROUPINFO("ARSP_MAX", 8, AP_Landing_Deepstall, handoff_airspeed, 15.0),
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    // @DisplayName: Deepstall minimum derating airspeed
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    // @Description: Deepstall lowest airspeed where the deepstall controller isn't allowed full control
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    AP_GROUPINFO("ARSP_MIN", 9, AP_Landing_Deepstall, handoff_lower_limit_airspeed, 10.0),
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    // use the current airspeed to dictate the travel limits
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    float airspeed;
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    if (!landing.ahrs.airspeed_estimate(&airspeed)) {
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:        airspeed = 0; // safely forces control to the deepstall steering since we don't have an estimate
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    // only allow the deepstall steering controller to run below the handoff airspeed
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:    if (slew_progress >= 1.0f || airspeed <= handoff_airspeed) {
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:        float travel_limit = constrain_float((handoff_airspeed - airspeed) /
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:                                             (handoff_airspeed - handoff_lower_limit_airspeed) *
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:int32_t AP_Landing_Deepstall::get_target_airspeed_cm(void) const
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:        return landing.pre_flare_airspeed * 100;
+libraries/AP_Landing/AP_Landing_Deepstall.cpp:        return landing.aparm.airspeed_cruise_cm;
+libraries/AP_Landing/AP_Landing_Deepstall.h:    AP_Float handoff_airspeed;
+libraries/AP_Landing/AP_Landing_Deepstall.h:    AP_Float handoff_lower_limit_airspeed;
+libraries/AP_Landing/AP_Landing_Deepstall.h:    int32_t get_target_airspeed_cm(void) const;
+libraries/AP_Landing/AP_Landing_Slope.cpp:            // reload any airspeed or groundspeed parameters that may have
+libraries/AP_Landing/AP_Landing_Slope.cpp:            aparm.airspeed_cruise_cm.load();
+libraries/AP_Landing/AP_Landing_Slope.cpp:    } else if (type_slope_stage == SLOPE_STAGE_APPROACH && pre_flare_airspeed > 0) {
+libraries/AP_Landing/AP_Landing_Slope.cpp:int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
+libraries/AP_Landing/AP_Landing_Slope.cpp:    // pre-flare airspeeds. Also increase for head-winds
+libraries/AP_Landing/AP_Landing_Slope.cpp:    const float land_airspeed = SpdHgt_Controller->get_land_airspeed();
+libraries/AP_Landing/AP_Landing_Slope.cpp:    int32_t target_airspeed_cm = aparm.airspeed_cruise_cm;
+libraries/AP_Landing/AP_Landing_Slope.cpp:        if (land_airspeed >= 0) {
+libraries/AP_Landing/AP_Landing_Slope.cpp:            target_airspeed_cm = land_airspeed * 100;
+libraries/AP_Landing/AP_Landing_Slope.cpp:        if (pre_flare_airspeed > 0) {
+libraries/AP_Landing/AP_Landing_Slope.cpp:            // if we just preflared then continue using the pre-flare airspeed during final flare
+libraries/AP_Landing/AP_Landing_Slope.cpp:            target_airspeed_cm = pre_flare_airspeed * 100;
+libraries/AP_Landing/AP_Landing_Slope.cpp:        } else if (land_airspeed >= 0) {
+libraries/AP_Landing/AP_Landing_Slope.cpp:            target_airspeed_cm = land_airspeed * 100;
+libraries/AP_Landing/AP_Landing_Slope.cpp:    return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_cruise_cm);
+libraries/AP_Landing/AP_Landing.cpp:    // @Description: This parameter is used when using a rangefinder during landing for altitude correction from baro drift (RNGFND_LANDING=1) and the altitude correction indicates your actual altitude is higher than the intended slope path. Normally it would pitch down steeply but that can result in a crash with high airspeed so this allows remembering the baro offset and self-abort the landing and come around for another landing with the correct baro offset applied for a perfect slope. An auto-abort go-around will only happen once, next attempt will not auto-abort again. This operation happens entirely automatically in AUTO mode. This value is the delta degrees threshold to trigger the go-around compared to the original slope. Example: if set to 5 deg and the mission planned slope is 15 deg then if the new slope is 21 then it will go-around. Set to 0 to disable. Requires LAND_SLOPE_RCALC > 0.
+libraries/AP_Landing/AP_Landing.cpp:    // @Description: Altitude to trigger pre-flare flight stage where LAND_PF_ARSPD controls airspeed. The pre-flare flight stage trigger works just like LAND_FLARE_ALT but higher. Disabled when LAND_PF_ARSPD is 0.
+libraries/AP_Landing/AP_Landing.cpp:    // @Description: Vertical time to ground to trigger pre-flare flight stage where LAND_PF_ARSPD controls airspeed. This pre-flare flight stage trigger works just like LAND_FLARE_SEC but earlier. Disabled when LAND_PF_ARSPD is 0.
+libraries/AP_Landing/AP_Landing.cpp:    // @DisplayName: Landing pre-flare airspeed
+libraries/AP_Landing/AP_Landing.cpp:    // @Description: Desired airspeed during pre-flare flight stage. This is useful to reduce airspeed just before the flare. Use 0 to disable.
+libraries/AP_Landing/AP_Landing.cpp:    AP_GROUPINFO("PF_ARSPD", 8, AP_Landing, pre_flare_airspeed, 0),
+libraries/AP_Landing/AP_Landing.cpp:    // @Description: This parameter sets the slew rate for the throttle during auto landing. When this is zero the THR_SLEWRATE parameter is used during landing. The value is a percentage throttle change per second, so a value of 20 means to advance the throttle over 5 seconds on landing. Values below 50 are not recommended as it may cause a stall when airspeed is low and you can not throttle up fast enough.
+libraries/AP_Landing/AP_Landing.cpp: * returns target airspeed in cm/s depending on flight stage
+libraries/AP_Landing/AP_Landing.cpp:int32_t AP_Landing::get_target_airspeed_cm(void)
+libraries/AP_Landing/AP_Landing.cpp:        // not landing, use regular cruise airspeed
+libraries/AP_Landing/AP_Landing.cpp:        return aparm.airspeed_cruise_cm;
+libraries/AP_Landing/AP_Landing.cpp:        return type_slope_get_target_airspeed_cm();
+libraries/AP_Landing/AP_Landing.cpp:        return deepstall.get_target_airspeed_cm();
+libraries/AP_Landing/AP_Landing.cpp:        // don't return the landing airspeed, because if type is invalid we have
+libraries/AP_Landing/AP_Landing.cpp:        // no postive indication that the land airspeed has been configured or
+libraries/AP_Landing/AP_Landing.cpp:        return SpdHgt_Controller->get_target_airspeed();
+libraries/AC_Avoidance/AP_OABendyRuler.cpp:            // ToDo: add effective groundspeed calculations using airspeed
+libraries/AP_HAL_SITL/SITL_State.cpp:        _update_airspeed(0);
+libraries/AP_HAL_SITL/SITL_State.cpp:        _update_airspeed(_sitl->state.airspeed);
+libraries/AP_HAL_SITL/SITL_State.cpp:    // give 5 seconds to calibrate airspeed sensor at 0 wind speed
+libraries/AP_HAL_SITL/AnalogIn.cpp:        return _sitlState->airspeed_pin_value;
+libraries/AP_HAL_SITL/AnalogIn.cpp:        return _sitlState->airspeed_2_pin_value;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:  This simulates an analog airspeed sensor
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:  convert airspeed in m/s to an airspeed sensor value
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:void SITL_State::_update_airspeed(float airspeed)
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    const float airspeed_ratio = 1.9936f;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    const float airspeed_offset = 2013.0f;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    float airspeed2 = airspeed;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        if (airspeed2 > 0)
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    airspeed2 += _sitl->arspd_fault_value;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    airspeed = is_zero(_sitl->arspd_fail) ? airspeed : _sitl->arspd_fail;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    airspeed2 = is_zero(_sitl->arspd2_fail) ? airspeed2 : _sitl->arspd2_fail;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    cout<<"ARSPD = "<<airspeed<<endl;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    cout<<"ARSPD2 = "<<airspeed2<<endl;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    cout<<"ARSPD state  = "<<_sitl->state.airspeed<<endl;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    airspeed = airspeed + (_sitl->arspd_noise * rand_float());
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    airspeed2 = airspeed2 + (_sitl->arspd_noise * rand_float());
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        // algorithm taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        airspeed = 340.29409348 * sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        // algorithm taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        airspeed2 = 340.29409348 * sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    float airspeed_pressure = (airspeed * airspeed) / airspeed_ratio;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    float airspeed2_pressure = (airspeed2 * airspeed2) / airspeed_ratio;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    if (_sitl->arspd_signflip) airspeed_pressure *= -1;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    if (_sitl->arspd_signflip) airspeed2_pressure *= -1;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    float airspeed_raw = airspeed_pressure + airspeed_offset;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    float airspeed2_raw = airspeed2_pressure + airspeed_offset;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    if (airspeed_raw / 4 > 0xFFFF) {
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        airspeed_pin_value = 0xFFFF;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    if (airspeed2_raw / 4 > 0xFFFF) {
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        airspeed_2_pin_value = 0xFFFF;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        buffer_wind[store_index_wind].data = airspeed_raw;  // add data to current index
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        buffer_wind_2[store_index_wind].data = airspeed2_raw;  // add data to current index
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        airspeed_raw = buffer_wind[best_index_wind].data;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:        airspeed2_raw = buffer_wind_2[best_index_wind].data;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    airspeed_pin_value = airspeed_raw / 4;
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:    airspeed_2_pin_value = airspeed2_raw / 4;
+libraries/AP_HAL_SITL/SITL_State.h:    // simulated airspeed, sonar and battery monitor
+libraries/AP_HAL_SITL/SITL_State.h:    uint16_t airspeed_pin_value; // pin 1
+libraries/AP_HAL_SITL/SITL_State.h:    uint16_t airspeed_2_pin_value; // pin 2
+libraries/AP_HAL_SITL/SITL_State.h:    void _update_airspeed(float airspeed);
+libraries/AP_HAL_SITL/SITL_State.h:    uint16_t _airspeed_sensor(float airspeed);
+libraries/AP_HAL_SITL/SITL_State.h:    // airspeed sensor delay buffer variables
+libraries/GCS_MAVLink/GCS.h:    virtual float vfr_hud_airspeed() const;
+libraries/GCS_MAVLink/GCS_Common.cpp:// send data for barometer and airspeed sensors instances.  In the
+libraries/GCS_MAVLink/GCS_Common.cpp:    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/GCS_MAVLink/GCS_Common.cpp:    if (airspeed != nullptr &&
+libraries/GCS_MAVLink/GCS_Common.cpp:        airspeed->enabled(instance)) {
+libraries/GCS_MAVLink/GCS_Common.cpp:        press_diff = airspeed->get_differential_pressure(instance) * 0.01f;
+libraries/GCS_MAVLink/GCS_Common.cpp:float GCS_MAVLINK::vfr_hud_airspeed() const
+libraries/GCS_MAVLink/GCS_Common.cpp:    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/GCS_MAVLink/GCS_Common.cpp:    if (airspeed != nullptr && airspeed->healthy()) {
+libraries/GCS_MAVLink/GCS_Common.cpp:        return airspeed->get_airspeed();
+libraries/GCS_MAVLink/GCS_Common.cpp:    // because most vehicles don't have airspeed sensors, we return a
+libraries/GCS_MAVLink/GCS_Common.cpp:        vfr_hud_airspeed(),
+libraries/GCS_MAVLink/GCS_Common.cpp:    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+libraries/GCS_MAVLink/GCS_Common.cpp:    if (airspeed != nullptr) {
+libraries/GCS_MAVLink/GCS_Common.cpp:        airspeed->calibrate(false);
+libraries/AP_TECS/AP_TECS.h: *  - Fallback mode when no airspeed measurement is available that
+libraries/AP_TECS/AP_TECS.h:    // return current target airspeed
+libraries/AP_TECS/AP_TECS.h:    float get_target_airspeed(void) const override {
+libraries/AP_TECS/AP_TECS.h:    // return landing airspeed
+libraries/AP_TECS/AP_TECS.h:    float get_land_airspeed(void) const override {
+libraries/AP_TECS/AP_TECS.h:    // force use of synthetic airspeed for one loop
+libraries/AP_TECS/AP_TECS.h:    void use_synthetic_airspeed(void) {
+libraries/AP_TECS/AP_TECS.h:        _use_synthetic_airspeed_once = true;
+libraries/AP_TECS/AP_TECS.h:    // Integrator state 4 - airspeed filter first derivative
+libraries/AP_TECS/AP_TECS.h:    // Integrator state 5 - true airspeed
+libraries/AP_TECS/AP_TECS.h:    // Equivalent airspeed
+libraries/AP_TECS/AP_TECS.h:    // True airspeed limits
+libraries/AP_TECS/AP_TECS.h:    // Current true airspeed demand
+libraries/AP_TECS/AP_TECS.h:    // Equivalent airspeed demand
+libraries/AP_TECS/AP_TECS.h:        // Bad descent condition caused by unachievable airspeed demand
+libraries/AP_TECS/AP_TECS.h:    AP_Int8 _use_synthetic_airspeed;
+libraries/AP_TECS/AP_TECS.h:    // use synthetic airspeed for next loop
+libraries/AP_TECS/AP_TECS.h:    bool _use_synthetic_airspeed_once;
+libraries/AP_TECS/AP_TECS.h:    // Update the airspeed internal state using a second order complementary filter
+libraries/AP_TECS/AP_TECS.h:    // Update the demanded airspeed
+libraries/AP_TECS/AP_TECS.h:    void _update_throttle_with_airspeed(void);
+libraries/AP_TECS/AP_TECS.h:    void _update_throttle_without_airspeed(int16_t throttle_nudge);
+libraries/AP_TECS/AP_TECS.cpp:    // @Description: Maximum demanded climb rate. Do not set higher than the climb speed at THR_MAX at TRIM_ARSPD_CM when the battery is at low voltage. Reduce value if airspeed cannot be maintained on ascent. Increase value if throttle does not increase significantly to ascend.
+libraries/AP_TECS/AP_TECS.cpp:    // @Description: This is the cross-over frequency of the complementary filter used to fuse longitudinal acceleration and airspeed to obtain a lower noise and lag estimate of airspeed.
+libraries/AP_TECS/AP_TECS.cpp:    // @Description: Gain from bank angle to throttle to compensate for loss of airspeed from drag in turns. Set to approximately 10x the sink rate in m/s caused by a 45-degree turn. High efficiency models may need less while less efficient aircraft may need more. Should be tuned in an automatic mission with waypoints and turns greater than 90 degrees. Tune with PTCH2SV_RLL and KFF_RDDRMIX to achieve constant airspeed, constant altitude turns.
+libraries/AP_TECS/AP_TECS.cpp:    // @Description: Mixing of pitch and throttle correction for height and airspeed errors. Pitch controls altitude and throttle controls airspeed if set to 0. Pitch controls airspeed and throttle controls altitude if set to 2 (good for gliders). Blended if set to 1.
+libraries/AP_TECS/AP_TECS.cpp:    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is not used during landing.
+libraries/AP_TECS/AP_TECS.cpp:    // @Description: Use this parameter instead of LAND_ARSPD if your platform does not have an airspeed sensor.  It is the cruise throttle during landing approach.  If this value is negative then it is disabled and TECS_LAND_ARSPD is used instead.
+libraries/AP_TECS/AP_TECS.cpp:    // @DisplayName: Enable the use of synthetic airspeed
+libraries/AP_TECS/AP_TECS.cpp:    // @Description: This enable the use of synthetic airspeed for aircraft that don't have a real airspeed sensor. This is useful for development testing where the user is aware of the considerable limitations of the synthetic airspeed system, such as very poor estimates when a wind estimate is not accurate. Do not enable this option unless you fully understand the limitations of a synthetic airspeed estimate.
+libraries/AP_TECS/AP_TECS.cpp:    AP_GROUPINFO("SYNAIRSPEED", 27, AP_TECS, _use_synthetic_airspeed, 0),
+libraries/AP_TECS/AP_TECS.cpp: *  - Fallback mode when no airspeed measurement is available that
+libraries/AP_TECS/AP_TECS.cpp:    // Convert equivalent airspeeds to true airspeeds
+libraries/AP_TECS/AP_TECS.cpp:    _TASmax   = aparm.airspeed_max * EAS2TAS;
+libraries/AP_TECS/AP_TECS.cpp:    _TASmin   = aparm.airspeed_min * EAS2TAS;
+libraries/AP_TECS/AP_TECS.cpp:        // airspeed based on aerodynamic load factor
+libraries/AP_TECS/AP_TECS.cpp:    // Get airspeed or default to halfway between min and max if
+libraries/AP_TECS/AP_TECS.cpp:    // airspeed is not being used and set speed rate to zero
+libraries/AP_TECS/AP_TECS.cpp:    bool use_airspeed = _use_synthetic_airspeed_once || _use_synthetic_airspeed.get() || _ahrs.airspeed_sensor_enabled();
+libraries/AP_TECS/AP_TECS.cpp:    if (!use_airspeed || !_ahrs.airspeed_estimate(&_EAS)) {
+libraries/AP_TECS/AP_TECS.cpp:        // If no airspeed available use average of min and max
+libraries/AP_TECS/AP_TECS.cpp:        _EAS = 0.5f * (aparm.airspeed_min.get() + (float)aparm.airspeed_max.get());
+libraries/AP_TECS/AP_TECS.cpp:    // smoothed airspeed estimate
+libraries/AP_TECS/AP_TECS.cpp:    // airspeed estimate is held in _TAS_state
+libraries/AP_TECS/AP_TECS.cpp:    // limit the airspeed to a minimum of 3 m/s
+libraries/AP_TECS/AP_TECS.cpp:    // Set the airspeed demand to the minimum value if an underspeed condition exists
+libraries/AP_TECS/AP_TECS.cpp:    // into the ground due to an unachievable airspeed value
+libraries/AP_TECS/AP_TECS.cpp:        // airspeed
+libraries/AP_TECS/AP_TECS.cpp:  calculate throttle demand - airspeed enabled case
+libraries/AP_TECS/AP_TECS.cpp:void AP_TECS::_update_throttle_with_airspeed(void)
+libraries/AP_TECS/AP_TECS.cpp:                // ensure we run at full throttle until we reach the target airspeed
+libraries/AP_TECS/AP_TECS.cpp:  calculate throttle, non-airspeed case
+libraries/AP_TECS/AP_TECS.cpp:void AP_TECS::_update_throttle_without_airspeed(int16_t throttle_nudge)
+libraries/AP_TECS/AP_TECS.cpp:    //If landing and we don't have an airspeed sensor and we have a non-zero
+libraries/AP_TECS/AP_TECS.cpp:    // Detect a demanded airspeed too high for the aircraft to achieve. This will be
+libraries/AP_TECS/AP_TECS.cpp:    // A SKE_weighting of 0 provides 100% priority to height control. This is used when no airspeed measurement is available
+libraries/AP_TECS/AP_TECS.cpp:    // A SKE_weighting of 2 provides 100% priority to speed control. This is used when an underspeed condition is detected. In this instance, if airspeed
+libraries/AP_TECS/AP_TECS.cpp:    if (!_ahrs.airspeed_sensor_enabled()) {
+libraries/AP_TECS/AP_TECS.cpp:    // airspeed sensor.
+libraries/AP_TECS/AP_TECS.cpp:    // synthetic airspeed for one loop if needed. This is required
+libraries/AP_TECS/AP_TECS.cpp:    if (_ahrs.airspeed_sensor_enabled() || _use_synthetic_airspeed || _use_synthetic_airspeed_once) {
+libraries/AP_TECS/AP_TECS.cpp:        _update_throttle_with_airspeed();
+libraries/AP_TECS/AP_TECS.cpp:        _use_synthetic_airspeed_once = false;
+libraries/AP_TECS/AP_TECS.cpp:        _update_throttle_without_airspeed(throttle_nudge);
+libraries/AP_TECS/AP_TECS.cpp:    // Detect bad descent due to demanded airspeed being too high
+libraries/AP_Vehicle/AP_Vehicle.h:        AP_Int16 airspeed_min;
+libraries/AP_Vehicle/AP_Vehicle.h:        AP_Int16 airspeed_max;
+libraries/AP_Vehicle/AP_Vehicle.h:        AP_Int32 airspeed_cruise_cm;
+libraries/AP_Soaring/Variometer.cpp:        if (!_ahrs.airspeed_estimate(&aspd)) {
+libraries/AP_Soaring/Variometer.cpp:            aspd = _aparm.airspeed_cruise_cm / 100.0f;
+libraries/AP_Soaring/AP_Soaring.cpp:    // for example, calculation of optimal airspeed and flap angle.
+libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp:    // @Description: Analog pin that rangefinder is connected to. Set to 11 on PX4 for the analog 'airspeed' port. Set to 15 on the Pixhawk for the analog 'airspeed' port.
+libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp:    // @Values: -1:Not Used, 11:PX4-airspeed port, 15:Pixhawk-airspeed port
+Tools/AP_Periph/Parameters.cpp:    GOBJECT(airspeed, "ARSP", AP_Airspeed),
+Tools/AP_Periph/can.cpp:        AP_Param::setup_object_defaults(&periph.airspeed, periph.airspeed.var_info);
+Tools/AP_Periph/can.cpp:    can_airspeed_update();
+Tools/AP_Periph/can.cpp:  update CAN airspeed
+Tools/AP_Periph/can.cpp:void AP_Periph_FW::can_airspeed_update(void)
+Tools/AP_Periph/can.cpp:    if (!airspeed.healthy()) {
+Tools/AP_Periph/can.cpp:            airspeed.init();
+Tools/AP_Periph/can.cpp:    if (now - last_airspeed_update_ms < 50) {
+Tools/AP_Periph/can.cpp:    last_airspeed_update_ms = now;
+Tools/AP_Periph/can.cpp:    airspeed.update(false);
+Tools/AP_Periph/can.cpp:    if (!airspeed.healthy()) {
+Tools/AP_Periph/can.cpp:    const float press = airspeed.get_differential_pressure();
+Tools/AP_Periph/can.cpp:    if (!airspeed.get_temperature(temp)) {
+Tools/AP_Periph/AP_Periph.cpp:    airspeed.init();
+Tools/AP_Periph/Parameters.h:        k_param_airspeed,
+Tools/AP_Periph/AP_Periph.h:    void can_airspeed_update();
+Tools/AP_Periph/AP_Periph.h:    AP_Airspeed airspeed;
+Tools/AP_Periph/AP_Periph.h:    uint32_t last_airspeed_update_ms;
+Tools/autotest/arduplane.py:        # ensure we know what the airspeed is:
+Tools/autotest/arduplane.py:        self.progress("Setting airspeed")
+Tools/autotest/arduplane.py:        new_target_airspeed = initial_speed + 5
+Tools/autotest/arduplane.py:            0, # airspeed
+Tools/autotest/arduplane.py:            new_target_airspeed,
+Tools/autotest/arduplane.py:        self.wait_groundspeed(new_target_airspeed-0.5, new_target_airspeed+0.5)
+Tools/autotest/arduplane.py:            delta = abs(m.airspeed - m.groundspeed)
+Tools/autotest/arduplane.py:            self.progress("groundspeed and airspeed should be different (have=%f want=%f)" % (delta, want_delta))
+Tools/autotest/arduplane.py:    def airspeed_autocal(self):
+Tools/autotest/arduplane.py:            ("AIRSPEED_AUTOCAL", "Test AIRSPEED_AUTOCAL", self.airspeed_autocal),
+Tools/autotest/aircraft/arducopter/arducopter-set.xml:             right.add("/apm/airspeed");
+Tools/autotest/aircraft/arducopter/quad.nas:    # airspeed-kt is actually in feet per second (FDM NET bug)
+Tools/autotest/aircraft/arducopter/quad.nas:    setprop("/apm/airspeed", round10(0.3048*getprop("/velocities/airspeed-kt")));
+Tools/autotest/aircraft/Rascal/Systems/airdata.nas:var compute_airspeed_accel = func( speed_filt, dt ) {
+Tools/autotest/aircraft/Rascal/Systems/airdata.nas:    sensed_speed = getprop("/velocities/airspeed-kt");
+Tools/autotest/aircraft/Rascal/Systems/airdata.nas:	sensed_accel = compute_airspeed_accel( speed_filt, dt );
+Tools/autotest/aircraft/Rascal/Systems/airdata.nas:    setprop("/accelerations/airspeed-ktps", accel_filt);
+Tools/autotest/aircraft/Rascal/Systems/airdata.nas:    # airspeed-kt is actually in feet per second (FDM NET bug)
+Tools/autotest/aircraft/Rascal/Systems/airdata.nas:    setprop("/apm/airspeed", round10(0.3048*getprop("/velocities/airspeed-kt")));
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <!-- <prop>/autopilot/internal/lookahead-5-sec-airspeed-kt</prop> -->
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <prop>/velocities/airspeed-kt</prop>
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <!-- <prop>/autopilot/internal/lookahead-5-sec-airspeed-kt</prop> -->
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <prop>/velocities/airspeed-kt</prop>
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <prop>/velocities/airspeed-kt</prop>
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <prop>/accelerations/airspeed-ktps</prop>
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <!-- <prop>/autopilot/internal/lookahead-5-sec-airspeed-kt</prop> -->
+Tools/autotest/aircraft/Rascal/Systems/110-autopilot.xml:      <prop>/velocities/airspeed-kt</prop>
+Tools/autotest/aircraft/Rascal/Rascal110-JSBSim-set.xml:             right.add("/apm/airspeed");
+Tools/autotest/fakepos.py:airspeed = 0
+Tools/autotest/fakepos.py:                            airspeed, magic)
+Tools/vagrant/mavinit.scr:@alias add gspeed g VFR_HUD.airspeed VFR_HUD.groundspeed
+Tools/vagrant/mavinit.scr:@alias add gtakeoff graph VFR_HUD.airspeed NAV_CONTROLLER_OUTPUT.nav_pitch NAV_CONTROLLER_OUTPUT.alt_error NAV_CONTROLLER_OUTPUT.aspd_error*0.01
+Tools/Replay/Replay.h:    AP_Airspeed airspeed;
+Tools/Replay/Replay.h:            _vehicle.airspeed,
+Tools/Replay/Replay.cpp:    GOBJECT(airspeed,                               "ARSP_",   AP_Airspeed),
+Tools/Replay/Replay.cpp:        _vehicle.ahrs.set_airspeed(&_vehicle.airspeed);
+Tools/Replay/LogReader.h:              AP_Airspeed &_airspeed,
+Tools/Replay/LogReader.h:    AP_Airspeed &airspeed;
+Tools/Replay/Parameters.h:        k_param_airspeed,
+Tools/Replay/LR_MsgHandler.cpp:    airspeed.setHIL(require_field_float(msg, "Airspeed"),
+Tools/Replay/LogReader.cpp:                     AP_Airspeed &_airspeed,
+Tools/Replay/LogReader.cpp:    airspeed(_airspeed),
+Tools/Replay/LogReader.cpp:                                                    airspeed);
+Tools/Replay/LR_MsgHandler.h:		    uint64_t &_last_timestamp_usec, AP_Airspeed &_airspeed) :
+Tools/Replay/LR_MsgHandler.h:	LR_MsgHandler(_f, _logger, _last_timestamp_usec), airspeed(_airspeed) { };
+Tools/Replay/LR_MsgHandler.h:    AP_Airspeed &airspeed;
+Binary file build/sitl/lib/libArduPlane_libs.a matches
+build/sitl/ArduPlane/mode_qland.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/afs_plane.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_fbwa.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/system.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/is_flying.cpp.27.o matches
+build/sitl/ArduPlane/soaring.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/control_modes.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/version.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_fbwb.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/commands_logic.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/sensors.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/parachute.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_autotune.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_acro.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_rtl.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/events.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_training.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/navigation.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/AP_Arming.cpp.27.o matches
+build/sitl/ArduPlane/mode_auto.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_guided.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/RC_Channel.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/quadplane.cpp.27.o matches
+build/sitl/ArduPlane/servos.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/ArduPlane.cpp.27.o matches
+build/sitl/ArduPlane/mode_cruise.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/is_flying.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/Log.cpp.27.o matches
+build/sitl/ArduPlane/motor_test.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_initializing.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/radio.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_qautotune.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_manual.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_qloiter.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/system.cpp.27.o matches
+build/sitl/ArduPlane/GCS_Plane.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/failsafe.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_qstabilize.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/tailsitter.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/navigation.cpp.27.o matches
+build/sitl/ArduPlane/geofence.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/Log.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/quadplane.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/Parameters.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/tiltrotor.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/Attitude.cpp.27.o matches
+build/sitl/ArduPlane/AP_Arming.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_circle.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_stabilize.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/Plane.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/altitude.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/qautotune.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/Attitude.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/reverse_thrust.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/takeoff.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/commands.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_loiter.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/avoidance_adsb.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/commands_logic.cpp.27.o matches
+Binary file build/sitl/ArduPlane/GCS_Mavlink.cpp.27.o matches
+build/sitl/ArduPlane/mode_takeoff.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/GCS_Mavlink.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_qhover.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_qacro.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/tuning.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/ArduPlane/sensors.cpp.27.o matches
+build/sitl/ArduPlane/mode_avoidADSB.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/ArduPlane.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/ArduPlane/mode_qrtl.cpp.27.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BoardConfig/AP_BoardConfig.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BoardConfig/board_drivers.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Avoidance/AP_Avoidance.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mission/AP_Mission.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mission/AP_Mission_Commands.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AttitudeControl/AC_PosControl.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AttitudeControl/ControlMonitor.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Button/AP_Button.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_LandingGear/AP_LandingGear.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RobotisServo/AP_RobotisServo.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Rally/AP_Rally.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Baro/AP_Baro.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Baro/AP_Baro_ICM20789.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Baro/AP_Baro_SITL.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OSD/AP_OSD_Screen.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OSD/AP_OSD.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Scheduler/PerfInfo.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Scheduler/AP_Scheduler.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/Filter/HarmonicNotchFilter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Parachute/AP_Parachute.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_PID/AC_PID.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_PID/AC_HELI_PID.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Gripper/AP_Gripper.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Gripper/AP_Gripper_Servo.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Gripper/AP_Gripper_EPM.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_AccelCal/AP_AccelCal.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Tuning/AP_Tuning.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF_GyroBias.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Terrain/TerrainIO.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Terrain/TerrainUtil.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Terrain/AP_Terrain.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Terrain/TerrainGCS.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Terrain/TerrainMission.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_VisualOdom/AP_VisualOdom_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_VisualOdom/AP_VisualOdom.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Radio/AP_Radio_backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_WPNav/AC_Loiter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_WPNav/AC_WPNav_OA.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_WPNav/AC_WPNav.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_WPNav/AC_Circle.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/AP_Mount_Alexmos.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/AP_Mount_SToRM32.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/AP_Mount_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/SoloGimbalEKF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/SoloGimbal_Parameters.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/AP_Mount.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/SoloGimbal.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Mount/AP_Mount_Servo.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_ADSB/AP_ADSB.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SRV_Channel/SRV_Channel_aux.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SRV_Channel/SRV_Channels.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SRV_Channel/SRV_Channel.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Airspeed/AP_Airspeed_analog.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Airspeed/Airspeed_Calibration.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Airspeed/AP_Airspeed.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_Airspeed/AP_Airspeed.cpp.5.o matches
+build/sitl/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_Airspeed/Airspeed_Calibration.cpp.0.o matches
+build/sitl/libraries/AP_Airspeed/AP_Airspeed_Health.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/RC_Channel/RC_Channel.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/RC_Channel/RC_Channels.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_TempCalibration/AP_TempCalibration.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF/AP_Nav_Common.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Arming/AP_Arming.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_Arming/AP_Arming.cpp.5.o matches
+build/sitl/libraries/AP_Motors/AP_MotorsMatrixTS.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsTri.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsMatrix.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsHeli_Single.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_Motors6DOF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsMulticopter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsCoax.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_Motors_Class.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsSingle.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsHeli.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsTailsitter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_SerialManager/AP_SerialManager.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/PID/PID.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL/utility/packetise.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_Sprayer/AC_Sprayer.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/Display_SH1106_I2C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/NCP5623.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/ExternalLED.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/Buzzer.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/AP_BoardLED.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/RGBLed.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/Display_SSD1306_I2C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/Display.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/ToshibaLED_I2C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/MMLPlayer.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/PCA9685LED_I2C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/OreoLED_I2C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/RCOutputRGBLed.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/SITL_SFML_LED.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/VRBoard_LED.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/DiscreteRGBLed.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/AP_Notify.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/PixRacerLED.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/ToneAlarm.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/AP_BoardLED2.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Notify/NeoPixel.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RSSI/AP_RSSI.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RTC/AP_RTC.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/OpticalFlow_backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_OpticalFlow/OpticalFlow.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_Fence/AC_PolyFence_loader.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_Fence/AC_Fence.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_SBP.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_GSOF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_UBLOX.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_SBF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_MTK19.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_NMEA.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_SIRF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/GPS_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_MAV.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_MTK.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_NOVA.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_SBP2.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_GPS/AP_GPS_ERB.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Scripting/lua_bindings.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Scripting/lua_scripts.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Scripting/AP_Scripting.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Scripting/lua_generated_bindings.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/APM_Control/AR_AttitudeControl.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/APM_Control/AP_RollController.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/APM_Control/AP_SteerController.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/APM_Control/AP_AutoTune.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/APM_Control/AP_PitchController.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/APM_Control/AP_YawController.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_HIL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/BatchSampler.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_AK09916.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_LSM303D.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_MAG3110.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_QMC5883L.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/Compass_PerMotor.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/Compass_learn.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_AK8963.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_HMC5843.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_IST8310.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_IST8308.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_BMM150.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/CompassCalibrator.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_HIL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_RM3100.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_MMC3416.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_Calibration.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Compass/AP_Compass_SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_AHRS/AP_AHRS_DCM.cpp.0.o matches
+build/sitl/libraries/AP_AHRS/AP_AHRS_DCM.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_AHRS/AP_AHRS_View.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp.0.o matches
+build/sitl/libraries/AP_AHRS/AP_AHRS.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_AHRS/AP_AHRS.cpp.5.o matches
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_L1_Control/AP_L1_Control.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/AP_Logger_MAVLink.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/AP_Logger_Backend.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/AP_Logger_File.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/AP_Logger_SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/AP_Logger_Block.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/LoggerMessageWriter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/LogFile.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Logger/AP_Logger.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Calibration.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_SingleCopter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Frame.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_FlightAxis.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_XPlane.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Webots.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Morse.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_ADSB.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Plane.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_CRRCSim.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Vicon.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_last_letter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Buzzer.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Helicopter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Multicopter.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_QuadPlane.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Submarine.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Gazebo.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Aircraft.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Motor.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_ToneAlarm.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Balloon.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_ICEngine.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_SilentWings.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/SITL/SIM_FlightAxis.cpp.0.o matches
+build/sitl/libraries/SITL/SIM_Sailboat.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Tracker.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_JSBSim.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_BalanceBot.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Scrimmage.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Parachute.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_AirSim.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Rover.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/SITL/SIM_Gimbal.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_AutoTune/AC_AutoTune.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Param/AP_Param.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Landing/AP_Landing_Slope.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_Landing/AP_Landing_Slope.cpp.0.o matches
+build/sitl/libraries/AP_Landing/AP_Landing.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Landing/AP_Landing_Deepstall.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_Landing/AP_Landing_Deepstall.cpp.0.o matches
+Binary file build/sitl/libraries/AP_Landing/AP_Landing.cpp.0.o matches
+build/sitl/libraries/AC_Avoidance/AC_Avoid.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_Avoidance/AP_OAPathPlanner.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_Avoidance/AP_OABendyRuler.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_Avoidance/AP_OADijkstra.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AC_Avoidance/AP_OADatabase.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_SBusOut/AP_SBusOut.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Beacon/AP_Beacon_SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Beacon/AP_Beacon_Marvelmind.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Beacon/AP_Beacon_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Beacon/AP_Beacon.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_MAV.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/RCInput.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_HAL_SITL/SITL_State.cpp.0.o matches
+build/sitl/libraries/AP_HAL_SITL/sitl_airspeed.cpp.0.d:libraries/AP_HAL_SITL/sitl_airspeed.cpp.0.o: \
+build/sitl/libraries/AP_HAL_SITL/sitl_airspeed.cpp.0.d: ../../libraries/AP_HAL_SITL/sitl_airspeed.cpp ap_config.h \
+build/sitl/libraries/AP_HAL_SITL/sitl_airspeed.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/RCOutput.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/SITL_State.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/AnalogIn.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/Scheduler.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/sitl_rangefinder.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/SITL_cmdline.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/Util.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/sitl_gps.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/UARTDriver.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_HAL_SITL/sitl_airspeed.cpp.0.o matches
+build/sitl/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_HAL_SITL/GPIO.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_MAVLink.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_Signing.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_ServoRelay.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/MAVLink_routing.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_DeviceOp.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/MissionItemProtocol.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_Fence.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_serial_control.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_Param.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/GCS_Rally.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/GCS_MAVLink/GCS_Common.cpp.5.o matches
+build/sitl/libraries/GCS_MAVLink/GCS_Common.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/ardupilotmega.h:   MAV_CMD_NAV_TAKEOFF=22, /* Takeoff from ground / hand |Minimum pitch (if airspeed sensor present), desired pitch without sensor| Empty| Empty| Yaw angle (if magnetometer present), ignored without magnetometer. NaN for unchanged.| Latitude| Longitude| Altitude|  */
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/ardupilotmega.h:   MAV_CMD_NAV_TAKEOFF_LOCAL=24, /* Takeoff from local position (local frame only) |Minimum pitch (if airspeed sensor present), desired pitch without sensor| Empty| Takeoff ascend rate| Yaw angle (if magnetometer or another yaw estimation source present), ignored without one of these| Y-axis position| X-axis position| Z-axis position|  */
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/ardupilotmega.h:   MAV_CMD_PREFLIGHT_CALIBRATION=241, /* Trigger calibration. This command will be only accepted if in pre-flight mode. Except for Temperature Calibration, only one sensor should be set in a single message and all others should be zero. |1: gyro calibration, 3: gyro temperature calibration| 1: magnetometer calibration| 1: ground pressure calibration| 1: radio RC calibration, 2: RC trim calibration| 1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration| 1: APM: compass/motor interference calibration (PX4: airspeed calibration, deprecated), 2: airspeed calibration| 1: ESC calibration, 3: barometer temperature calibration|  */
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/ardupilotmega.h:   MAV_CMD_PAYLOAD_PREPARE_DEPLOY=30001, /* Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity. |Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.| Desired approach vector in compass heading. A negative value indicates the system can define the approach vector at will.| Desired ground speed at release time. This can be overridden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.| Minimum altitude clearance to the release position. A negative value indicates the system can define the clearance at will.| Latitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT| Longitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT| Altitude (MSL), in meters|  */
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/ardupilotmega.h:#include "./mavlink_msg_airspeed_autocal.h"
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:static void mavlink_test_airspeed_autocal(uint8_t system_id, uint8_t component_id, mavlink_message_t *last_msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_airspeed_autocal_t packet_in = {
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_airspeed_autocal_t packet1, packet2;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_encode(system_id, component_id, &msg, &packet1);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_decode(&msg, &packet2);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_pack(system_id, component_id, &msg , packet1.vx , packet1.vy , packet1.vz , packet1.diff_pressure , packet1.EAS2TAS , packet1.ratio , packet1.state_x , packet1.state_y , packet1.state_z , packet1.Pax , packet1.Pby , packet1.Pcz );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_decode(&msg, &packet2);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_pack_chan(system_id, component_id, MAVLINK_COMM_0, &msg , packet1.vx , packet1.vy , packet1.vz , packet1.diff_pressure , packet1.EAS2TAS , packet1.ratio , packet1.state_x , packet1.state_y , packet1.state_z , packet1.Pax , packet1.Pby , packet1.Pcz );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_decode(&msg, &packet2);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_decode(last_msg, &packet2);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_send(MAVLINK_COMM_1 , packet1.vx , packet1.vy , packet1.vz , packet1.diff_pressure , packet1.EAS2TAS , packet1.ratio , packet1.state_x , packet1.state_y , packet1.state_z , packet1.Pax , packet1.Pby , packet1.Pcz );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_airspeed_autocal_decode(last_msg, &packet2);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:        packet1.airspeed_variance = packet_in.airspeed_variance;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_ekf_status_report_pack(system_id, component_id, &msg , packet1.flags , packet1.velocity_variance , packet1.pos_horiz_variance , packet1.pos_vert_variance , packet1.compass_variance , packet1.terrain_alt_variance , packet1.airspeed_variance );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_ekf_status_report_pack_chan(system_id, component_id, MAVLINK_COMM_0, &msg , packet1.flags , packet1.velocity_variance , packet1.pos_horiz_variance , packet1.pos_vert_variance , packet1.compass_variance , packet1.terrain_alt_variance , packet1.airspeed_variance );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_msg_ekf_status_report_send(MAVLINK_COMM_1 , packet1.flags , packet1.velocity_variance , packet1.pos_horiz_variance , packet1.pos_vert_variance , packet1.compass_variance , packet1.terrain_alt_variance , packet1.airspeed_variance );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/testsuite.h:    mavlink_test_airspeed_autocal(system_id, component_id, last_msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:typedef struct __mavlink_airspeed_autocal_t {
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: float EAS2TAS; /*<  Estimated to true airspeed ratio.*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:}) mavlink_airspeed_autocal_t;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    {  { "vx", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_airspeed_autocal_t, vx) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "vy", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_airspeed_autocal_t, vy) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "vz", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_airspeed_autocal_t, vz) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "diff_pressure", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_airspeed_autocal_t, diff_pressure) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "EAS2TAS", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_airspeed_autocal_t, EAS2TAS) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "ratio", NULL, MAVLINK_TYPE_FLOAT, 0, 20, offsetof(mavlink_airspeed_autocal_t, ratio) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "state_x", NULL, MAVLINK_TYPE_FLOAT, 0, 24, offsetof(mavlink_airspeed_autocal_t, state_x) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "state_y", NULL, MAVLINK_TYPE_FLOAT, 0, 28, offsetof(mavlink_airspeed_autocal_t, state_y) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "state_z", NULL, MAVLINK_TYPE_FLOAT, 0, 32, offsetof(mavlink_airspeed_autocal_t, state_z) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "Pax", NULL, MAVLINK_TYPE_FLOAT, 0, 36, offsetof(mavlink_airspeed_autocal_t, Pax) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "Pby", NULL, MAVLINK_TYPE_FLOAT, 0, 40, offsetof(mavlink_airspeed_autocal_t, Pby) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "Pcz", NULL, MAVLINK_TYPE_FLOAT, 0, 44, offsetof(mavlink_airspeed_autocal_t, Pcz) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    {  { "vx", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_airspeed_autocal_t, vx) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "vy", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_airspeed_autocal_t, vy) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "vz", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_airspeed_autocal_t, vz) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "diff_pressure", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_airspeed_autocal_t, diff_pressure) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "EAS2TAS", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_airspeed_autocal_t, EAS2TAS) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "ratio", NULL, MAVLINK_TYPE_FLOAT, 0, 20, offsetof(mavlink_airspeed_autocal_t, ratio) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "state_x", NULL, MAVLINK_TYPE_FLOAT, 0, 24, offsetof(mavlink_airspeed_autocal_t, state_x) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "state_y", NULL, MAVLINK_TYPE_FLOAT, 0, 28, offsetof(mavlink_airspeed_autocal_t, state_y) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "state_z", NULL, MAVLINK_TYPE_FLOAT, 0, 32, offsetof(mavlink_airspeed_autocal_t, state_z) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "Pax", NULL, MAVLINK_TYPE_FLOAT, 0, 36, offsetof(mavlink_airspeed_autocal_t, Pax) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "Pby", NULL, MAVLINK_TYPE_FLOAT, 0, 40, offsetof(mavlink_airspeed_autocal_t, Pby) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:         { "Pcz", NULL, MAVLINK_TYPE_FLOAT, 0, 44, offsetof(mavlink_airspeed_autocal_t, Pcz) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Pack a airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @param EAS2TAS  Estimated to true airspeed ratio.
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline uint16_t mavlink_msg_airspeed_autocal_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    mavlink_airspeed_autocal_t packet;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Pack a airspeed_autocal message on a channel
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @param EAS2TAS  Estimated to true airspeed ratio.
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline uint16_t mavlink_msg_airspeed_autocal_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    mavlink_airspeed_autocal_t packet;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Encode a airspeed_autocal struct
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @param airspeed_autocal C-struct to read the message contents from
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline uint16_t mavlink_msg_airspeed_autocal_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_airspeed_autocal_t* airspeed_autocal)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    return mavlink_msg_airspeed_autocal_pack(system_id, component_id, msg, airspeed_autocal->vx, airspeed_autocal->vy, airspeed_autocal->vz, airspeed_autocal->diff_pressure, airspeed_autocal->EAS2TAS, airspeed_autocal->ratio, airspeed_autocal->state_x, airspeed_autocal->state_y, airspeed_autocal->state_z, airspeed_autocal->Pax, airspeed_autocal->Pby, airspeed_autocal->Pcz);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Encode a airspeed_autocal struct on a channel
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @param airspeed_autocal C-struct to read the message contents from
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline uint16_t mavlink_msg_airspeed_autocal_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_airspeed_autocal_t* airspeed_autocal)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    return mavlink_msg_airspeed_autocal_pack_chan(system_id, component_id, chan, msg, airspeed_autocal->vx, airspeed_autocal->vy, airspeed_autocal->vz, airspeed_autocal->diff_pressure, airspeed_autocal->EAS2TAS, airspeed_autocal->ratio, airspeed_autocal->state_x, airspeed_autocal->state_y, airspeed_autocal->state_z, airspeed_autocal->Pax, airspeed_autocal->Pby, airspeed_autocal->Pcz);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Send a airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @param EAS2TAS  Estimated to true airspeed ratio.
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline void mavlink_msg_airspeed_autocal_send(mavlink_channel_t chan, float vx, float vy, float vz, float diff_pressure, float EAS2TAS, float ratio, float state_x, float state_y, float state_z, float Pax, float Pby, float Pcz)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    mavlink_airspeed_autocal_t packet;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Send a airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline void mavlink_msg_airspeed_autocal_send_struct(mavlink_channel_t chan, const mavlink_airspeed_autocal_t* airspeed_autocal)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    mavlink_msg_airspeed_autocal_send(chan, airspeed_autocal->vx, airspeed_autocal->vy, airspeed_autocal->vz, airspeed_autocal->diff_pressure, airspeed_autocal->EAS2TAS, airspeed_autocal->ratio, airspeed_autocal->state_x, airspeed_autocal->state_y, airspeed_autocal->state_z, airspeed_autocal->Pax, airspeed_autocal->Pby, airspeed_autocal->Pcz);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AIRSPEED_AUTOCAL, (const char *)airspeed_autocal, MAVLINK_MSG_ID_AIRSPEED_AUTOCAL_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_AUTOCAL_LEN, MAVLINK_MSG_ID_AIRSPEED_AUTOCAL_CRC);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline void mavlink_msg_airspeed_autocal_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  float vx, float vy, float vz, float diff_pressure, float EAS2TAS, float ratio, float state_x, float state_y, float state_z, float Pax, float Pby, float Pcz)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    mavlink_airspeed_autocal_t *packet = (mavlink_airspeed_autocal_t *)msgbuf;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field vx from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_vx(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field vy from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_vy(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field vz from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_vz(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field diff_pressure from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_diff_pressure(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field EAS2TAS from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @return  Estimated to true airspeed ratio.
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_EAS2TAS(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field ratio from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_ratio(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field state_x from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_state_x(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field state_y from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_state_y(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field state_z from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_state_z(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field Pax from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_Pax(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field Pby from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_Pby(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Get field Pcz from airspeed_autocal message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline float mavlink_msg_airspeed_autocal_get_Pcz(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @brief Decode a airspeed_autocal message into a struct
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h: * @param airspeed_autocal C-struct to decode the message contents into
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:static inline void mavlink_msg_airspeed_autocal_decode(const mavlink_message_t* msg, mavlink_airspeed_autocal_t* airspeed_autocal)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->vx = mavlink_msg_airspeed_autocal_get_vx(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->vy = mavlink_msg_airspeed_autocal_get_vy(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->vz = mavlink_msg_airspeed_autocal_get_vz(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->diff_pressure = mavlink_msg_airspeed_autocal_get_diff_pressure(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->EAS2TAS = mavlink_msg_airspeed_autocal_get_EAS2TAS(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->ratio = mavlink_msg_airspeed_autocal_get_ratio(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->state_x = mavlink_msg_airspeed_autocal_get_state_x(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->state_y = mavlink_msg_airspeed_autocal_get_state_y(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->state_z = mavlink_msg_airspeed_autocal_get_state_z(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->Pax = mavlink_msg_airspeed_autocal_get_Pax(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->Pby = mavlink_msg_airspeed_autocal_get_Pby(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    airspeed_autocal->Pcz = mavlink_msg_airspeed_autocal_get_Pcz(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:        memset(airspeed_autocal, 0, MAVLINK_MSG_ID_AIRSPEED_AUTOCAL_LEN);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_airspeed_autocal.h:    memcpy(airspeed_autocal, _MAV_PAYLOAD(msg), len);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h: float airspeed_variance; /*<  Airspeed variance.*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:         { "airspeed_variance", NULL, MAVLINK_TYPE_FLOAT, 0, 22, offsetof(mavlink_ekf_status_report_t, airspeed_variance) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:         { "airspeed_variance", NULL, MAVLINK_TYPE_FLOAT, 0, 22, offsetof(mavlink_ekf_status_report_t, airspeed_variance) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h: * @param airspeed_variance  Airspeed variance.
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:                               uint16_t flags, float velocity_variance, float pos_horiz_variance, float pos_vert_variance, float compass_variance, float terrain_alt_variance, float airspeed_variance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    _mav_put_float(buf, 22, airspeed_variance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    packet.airspeed_variance = airspeed_variance;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h: * @param airspeed_variance  Airspeed variance.
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:                                   uint16_t flags,float velocity_variance,float pos_horiz_variance,float pos_vert_variance,float compass_variance,float terrain_alt_variance,float airspeed_variance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    _mav_put_float(buf, 22, airspeed_variance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    packet.airspeed_variance = airspeed_variance;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    return mavlink_msg_ekf_status_report_pack(system_id, component_id, msg, ekf_status_report->flags, ekf_status_report->velocity_variance, ekf_status_report->pos_horiz_variance, ekf_status_report->pos_vert_variance, ekf_status_report->compass_variance, ekf_status_report->terrain_alt_variance, ekf_status_report->airspeed_variance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    return mavlink_msg_ekf_status_report_pack_chan(system_id, component_id, chan, msg, ekf_status_report->flags, ekf_status_report->velocity_variance, ekf_status_report->pos_horiz_variance, ekf_status_report->pos_vert_variance, ekf_status_report->compass_variance, ekf_status_report->terrain_alt_variance, ekf_status_report->airspeed_variance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h: * @param airspeed_variance  Airspeed variance.
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:static inline void mavlink_msg_ekf_status_report_send(mavlink_channel_t chan, uint16_t flags, float velocity_variance, float pos_horiz_variance, float pos_vert_variance, float compass_variance, float terrain_alt_variance, float airspeed_variance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    _mav_put_float(buf, 22, airspeed_variance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    packet.airspeed_variance = airspeed_variance;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    mavlink_msg_ekf_status_report_send(chan, ekf_status_report->flags, ekf_status_report->velocity_variance, ekf_status_report->pos_horiz_variance, ekf_status_report->pos_vert_variance, ekf_status_report->compass_variance, ekf_status_report->terrain_alt_variance, ekf_status_report->airspeed_variance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:static inline void mavlink_msg_ekf_status_report_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint16_t flags, float velocity_variance, float pos_horiz_variance, float pos_vert_variance, float compass_variance, float terrain_alt_variance, float airspeed_variance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    _mav_put_float(buf, 22, airspeed_variance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    packet->airspeed_variance = airspeed_variance;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h: * @brief Get field airspeed_variance from ekf_status_report message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:static inline float mavlink_msg_ekf_status_report_get_airspeed_variance(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink_msg_ekf_status_report.h:    ekf_status_report->airspeed_variance = mavlink_msg_ekf_status_report_get_airspeed_variance(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h: float airspeed; /*< [m/s] Current indicated airspeed (IAS).*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    {  { "airspeed", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_vfr_hud_t, airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    {  { "airspeed", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_vfr_hud_t, airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h: * @param airspeed [m/s] Current indicated airspeed (IAS).
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:                               float airspeed, float groundspeed, int16_t heading, uint16_t throttle, float alt, float climb)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    _mav_put_float(buf, 0, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h: * @param airspeed [m/s] Current indicated airspeed (IAS).
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:                                   float airspeed,float groundspeed,int16_t heading,uint16_t throttle,float alt,float climb)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    _mav_put_float(buf, 0, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    return mavlink_msg_vfr_hud_pack(system_id, component_id, msg, vfr_hud->airspeed, vfr_hud->groundspeed, vfr_hud->heading, vfr_hud->throttle, vfr_hud->alt, vfr_hud->climb);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    return mavlink_msg_vfr_hud_pack_chan(system_id, component_id, chan, msg, vfr_hud->airspeed, vfr_hud->groundspeed, vfr_hud->heading, vfr_hud->throttle, vfr_hud->alt, vfr_hud->climb);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h: * @param airspeed [m/s] Current indicated airspeed (IAS).
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:static inline void mavlink_msg_vfr_hud_send(mavlink_channel_t chan, float airspeed, float groundspeed, int16_t heading, uint16_t throttle, float alt, float climb)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    _mav_put_float(buf, 0, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    mavlink_msg_vfr_hud_send(chan, vfr_hud->airspeed, vfr_hud->groundspeed, vfr_hud->heading, vfr_hud->throttle, vfr_hud->alt, vfr_hud->climb);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:static inline void mavlink_msg_vfr_hud_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  float airspeed, float groundspeed, int16_t heading, uint16_t throttle, float alt, float climb)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    _mav_put_float(buf, 0, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    packet->airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h: * @brief Get field airspeed from vfr_hud message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h: * @return [m/s] Current indicated airspeed (IAS).
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:static inline float mavlink_msg_vfr_hud_get_airspeed(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_vfr_hud.h:    vfr_hud->airspeed = mavlink_msg_vfr_hud_get_airspeed(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:        packet1.airspeed = packet_in.airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_vfr_hud_pack(system_id, component_id, &msg , packet1.airspeed , packet1.groundspeed , packet1.heading , packet1.throttle , packet1.alt , packet1.climb );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_vfr_hud_pack_chan(system_id, component_id, MAVLINK_COMM_0, &msg , packet1.airspeed , packet1.groundspeed , packet1.heading , packet1.throttle , packet1.alt , packet1.climb );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_vfr_hud_send(MAVLINK_COMM_1 , packet1.airspeed , packet1.groundspeed , packet1.heading , packet1.throttle , packet1.alt , packet1.climb );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:        packet1.ind_airspeed = packet_in.ind_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:        packet1.true_airspeed = packet_in.true_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_hil_state_quaternion_pack(system_id, component_id, &msg , packet1.time_usec , packet1.attitude_quaternion , packet1.rollspeed , packet1.pitchspeed , packet1.yawspeed , packet1.lat , packet1.lon , packet1.alt , packet1.vx , packet1.vy , packet1.vz , packet1.ind_airspeed , packet1.true_airspeed , packet1.xacc , packet1.yacc , packet1.zacc );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_hil_state_quaternion_pack_chan(system_id, component_id, MAVLINK_COMM_0, &msg , packet1.time_usec , packet1.attitude_quaternion , packet1.rollspeed , packet1.pitchspeed , packet1.yawspeed , packet1.lat , packet1.lon , packet1.alt , packet1.vx , packet1.vy , packet1.vz , packet1.ind_airspeed , packet1.true_airspeed , packet1.xacc , packet1.yacc , packet1.zacc );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_hil_state_quaternion_send(MAVLINK_COMM_1 , packet1.time_usec , packet1.attitude_quaternion , packet1.rollspeed , packet1.pitchspeed , packet1.yawspeed , packet1.lat , packet1.lon , packet1.alt , packet1.vx , packet1.vy , packet1.vz , packet1.ind_airspeed , packet1.true_airspeed , packet1.xacc , packet1.yacc , packet1.zacc );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:        packet1.airspeed = packet_in.airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_control_system_state_pack(system_id, component_id, &msg , packet1.time_usec , packet1.x_acc , packet1.y_acc , packet1.z_acc , packet1.x_vel , packet1.y_vel , packet1.z_vel , packet1.x_pos , packet1.y_pos , packet1.z_pos , packet1.airspeed , packet1.vel_variance , packet1.pos_variance , packet1.q , packet1.roll_rate , packet1.pitch_rate , packet1.yaw_rate );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_control_system_state_pack_chan(system_id, component_id, MAVLINK_COMM_0, &msg , packet1.time_usec , packet1.x_acc , packet1.y_acc , packet1.z_acc , packet1.x_vel , packet1.y_vel , packet1.z_vel , packet1.x_pos , packet1.y_pos , packet1.z_pos , packet1.airspeed , packet1.vel_variance , packet1.pos_variance , packet1.q , packet1.roll_rate , packet1.pitch_rate , packet1.yaw_rate );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_control_system_state_send(MAVLINK_COMM_1 , packet1.time_usec , packet1.x_acc , packet1.y_acc , packet1.z_acc , packet1.x_vel , packet1.y_vel , packet1.z_vel , packet1.x_pos , packet1.y_pos , packet1.z_pos , packet1.airspeed , packet1.vel_variance , packet1.pos_variance , packet1.q , packet1.roll_rate , packet1.pitch_rate , packet1.yaw_rate );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:        packet1.airspeed = packet_in.airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:        packet1.airspeed_sp = packet_in.airspeed_sp;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_high_latency_pack(system_id, component_id, &msg , packet1.base_mode , packet1.custom_mode , packet1.landed_state , packet1.roll , packet1.pitch , packet1.heading , packet1.throttle , packet1.heading_sp , packet1.latitude , packet1.longitude , packet1.altitude_amsl , packet1.altitude_sp , packet1.airspeed , packet1.airspeed_sp , packet1.groundspeed , packet1.climb_rate , packet1.gps_nsat , packet1.gps_fix_type , packet1.battery_remaining , packet1.temperature , packet1.temperature_air , packet1.failsafe , packet1.wp_num , packet1.wp_distance );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_high_latency_pack_chan(system_id, component_id, MAVLINK_COMM_0, &msg , packet1.base_mode , packet1.custom_mode , packet1.landed_state , packet1.roll , packet1.pitch , packet1.heading , packet1.throttle , packet1.heading_sp , packet1.latitude , packet1.longitude , packet1.altitude_amsl , packet1.altitude_sp , packet1.airspeed , packet1.airspeed_sp , packet1.groundspeed , packet1.climb_rate , packet1.gps_nsat , packet1.gps_fix_type , packet1.battery_remaining , packet1.temperature , packet1.temperature_air , packet1.failsafe , packet1.wp_num , packet1.wp_distance );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/testsuite.h:    mavlink_msg_high_latency_send(MAVLINK_COMM_1 , packet1.base_mode , packet1.custom_mode , packet1.landed_state , packet1.roll , packet1.pitch , packet1.heading , packet1.throttle , packet1.heading_sp , packet1.latitude , packet1.longitude , packet1.altitude_amsl , packet1.altitude_sp , packet1.airspeed , packet1.airspeed_sp , packet1.groundspeed , packet1.climb_rate , packet1.gps_nsat , packet1.gps_fix_type , packet1.battery_remaining , packet1.temperature , packet1.temperature_air , packet1.failsafe , packet1.wp_num , packet1.wp_distance );
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_estimator_status.h: float tas_ratio; /*<  True airspeed innovation test ratio*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_estimator_status.h: * @param tas_ratio  True airspeed innovation test ratio
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_estimator_status.h: * @param tas_ratio  True airspeed innovation test ratio
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_estimator_status.h: * @param tas_ratio  True airspeed innovation test ratio
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_estimator_status.h: * @return  True airspeed innovation test ratio
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: uint16_t ind_airspeed; /*< [cm/s] Indicated airspeed*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: uint16_t true_airspeed; /*< [cm/s] True airspeed*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:         { "ind_airspeed", NULL, MAVLINK_TYPE_UINT16_T, 0, 54, offsetof(mavlink_hil_state_quaternion_t, ind_airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:         { "true_airspeed", NULL, MAVLINK_TYPE_UINT16_T, 0, 56, offsetof(mavlink_hil_state_quaternion_t, true_airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:         { "ind_airspeed", NULL, MAVLINK_TYPE_UINT16_T, 0, 54, offsetof(mavlink_hil_state_quaternion_t, ind_airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:         { "true_airspeed", NULL, MAVLINK_TYPE_UINT16_T, 0, 56, offsetof(mavlink_hil_state_quaternion_t, true_airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @param ind_airspeed [cm/s] Indicated airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @param true_airspeed [cm/s] True airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:                               uint64_t time_usec, const float *attitude_quaternion, float rollspeed, float pitchspeed, float yawspeed, int32_t lat, int32_t lon, int32_t alt, int16_t vx, int16_t vy, int16_t vz, uint16_t ind_airspeed, uint16_t true_airspeed, int16_t xacc, int16_t yacc, int16_t zacc)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 54, ind_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 56, true_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet.ind_airspeed = ind_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet.true_airspeed = true_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @param ind_airspeed [cm/s] Indicated airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @param true_airspeed [cm/s] True airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:                                   uint64_t time_usec,const float *attitude_quaternion,float rollspeed,float pitchspeed,float yawspeed,int32_t lat,int32_t lon,int32_t alt,int16_t vx,int16_t vy,int16_t vz,uint16_t ind_airspeed,uint16_t true_airspeed,int16_t xacc,int16_t yacc,int16_t zacc)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 54, ind_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 56, true_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet.ind_airspeed = ind_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet.true_airspeed = true_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    return mavlink_msg_hil_state_quaternion_pack(system_id, component_id, msg, hil_state_quaternion->time_usec, hil_state_quaternion->attitude_quaternion, hil_state_quaternion->rollspeed, hil_state_quaternion->pitchspeed, hil_state_quaternion->yawspeed, hil_state_quaternion->lat, hil_state_quaternion->lon, hil_state_quaternion->alt, hil_state_quaternion->vx, hil_state_quaternion->vy, hil_state_quaternion->vz, hil_state_quaternion->ind_airspeed, hil_state_quaternion->true_airspeed, hil_state_quaternion->xacc, hil_state_quaternion->yacc, hil_state_quaternion->zacc);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    return mavlink_msg_hil_state_quaternion_pack_chan(system_id, component_id, chan, msg, hil_state_quaternion->time_usec, hil_state_quaternion->attitude_quaternion, hil_state_quaternion->rollspeed, hil_state_quaternion->pitchspeed, hil_state_quaternion->yawspeed, hil_state_quaternion->lat, hil_state_quaternion->lon, hil_state_quaternion->alt, hil_state_quaternion->vx, hil_state_quaternion->vy, hil_state_quaternion->vz, hil_state_quaternion->ind_airspeed, hil_state_quaternion->true_airspeed, hil_state_quaternion->xacc, hil_state_quaternion->yacc, hil_state_quaternion->zacc);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @param ind_airspeed [cm/s] Indicated airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @param true_airspeed [cm/s] True airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:static inline void mavlink_msg_hil_state_quaternion_send(mavlink_channel_t chan, uint64_t time_usec, const float *attitude_quaternion, float rollspeed, float pitchspeed, float yawspeed, int32_t lat, int32_t lon, int32_t alt, int16_t vx, int16_t vy, int16_t vz, uint16_t ind_airspeed, uint16_t true_airspeed, int16_t xacc, int16_t yacc, int16_t zacc)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 54, ind_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 56, true_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet.ind_airspeed = ind_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet.true_airspeed = true_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    mavlink_msg_hil_state_quaternion_send(chan, hil_state_quaternion->time_usec, hil_state_quaternion->attitude_quaternion, hil_state_quaternion->rollspeed, hil_state_quaternion->pitchspeed, hil_state_quaternion->yawspeed, hil_state_quaternion->lat, hil_state_quaternion->lon, hil_state_quaternion->alt, hil_state_quaternion->vx, hil_state_quaternion->vy, hil_state_quaternion->vz, hil_state_quaternion->ind_airspeed, hil_state_quaternion->true_airspeed, hil_state_quaternion->xacc, hil_state_quaternion->yacc, hil_state_quaternion->zacc);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:static inline void mavlink_msg_hil_state_quaternion_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint64_t time_usec, const float *attitude_quaternion, float rollspeed, float pitchspeed, float yawspeed, int32_t lat, int32_t lon, int32_t alt, int16_t vx, int16_t vy, int16_t vz, uint16_t ind_airspeed, uint16_t true_airspeed, int16_t xacc, int16_t yacc, int16_t zacc)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 54, ind_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    _mav_put_uint16_t(buf, 56, true_airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet->ind_airspeed = ind_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    packet->true_airspeed = true_airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @brief Get field ind_airspeed from hil_state_quaternion message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @return [cm/s] Indicated airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:static inline uint16_t mavlink_msg_hil_state_quaternion_get_ind_airspeed(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @brief Get field true_airspeed from hil_state_quaternion message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h: * @return [cm/s] True airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:static inline uint16_t mavlink_msg_hil_state_quaternion_get_true_airspeed(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    hil_state_quaternion->ind_airspeed = mavlink_msg_hil_state_quaternion_get_ind_airspeed(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_state_quaternion.h:    hil_state_quaternion->true_airspeed = mavlink_msg_hil_state_quaternion_get_true_airspeed(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_nav_controller_output.h: float aspd_error; /*< [m/s] Current airspeed error*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_nav_controller_output.h: * @param aspd_error [m/s] Current airspeed error
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_nav_controller_output.h: * @param aspd_error [m/s] Current airspeed error
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_nav_controller_output.h: * @param aspd_error [m/s] Current airspeed error
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_nav_controller_output.h: * @return [m/s] Current airspeed error
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: uint8_t airspeed; /*< [m/s] airspeed*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: uint8_t airspeed_sp; /*< [m/s] airspeed setpoint*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: int8_t temperature_air; /*< [degC] Air temperature (degrees C) from airspeed sensor*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:         { "airspeed", NULL, MAVLINK_TYPE_UINT8_T, 0, 29, offsetof(mavlink_high_latency_t, airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:         { "airspeed_sp", NULL, MAVLINK_TYPE_UINT8_T, 0, 30, offsetof(mavlink_high_latency_t, airspeed_sp) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:         { "airspeed", NULL, MAVLINK_TYPE_UINT8_T, 0, 29, offsetof(mavlink_high_latency_t, airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:         { "airspeed_sp", NULL, MAVLINK_TYPE_UINT8_T, 0, 30, offsetof(mavlink_high_latency_t, airspeed_sp) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param airspeed [m/s] airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param airspeed_sp [m/s] airspeed setpoint
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param temperature_air [degC] Air temperature (degrees C) from airspeed sensor
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:                               uint8_t base_mode, uint32_t custom_mode, uint8_t landed_state, int16_t roll, int16_t pitch, uint16_t heading, int8_t throttle, int16_t heading_sp, int32_t latitude, int32_t longitude, int16_t altitude_amsl, int16_t altitude_sp, uint8_t airspeed, uint8_t airspeed_sp, uint8_t groundspeed, int8_t climb_rate, uint8_t gps_nsat, uint8_t gps_fix_type, uint8_t battery_remaining, int8_t temperature, int8_t temperature_air, uint8_t failsafe, uint8_t wp_num, uint16_t wp_distance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 29, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 30, airspeed_sp);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet.airspeed_sp = airspeed_sp;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param airspeed [m/s] airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param airspeed_sp [m/s] airspeed setpoint
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param temperature_air [degC] Air temperature (degrees C) from airspeed sensor
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:                                   uint8_t base_mode,uint32_t custom_mode,uint8_t landed_state,int16_t roll,int16_t pitch,uint16_t heading,int8_t throttle,int16_t heading_sp,int32_t latitude,int32_t longitude,int16_t altitude_amsl,int16_t altitude_sp,uint8_t airspeed,uint8_t airspeed_sp,uint8_t groundspeed,int8_t climb_rate,uint8_t gps_nsat,uint8_t gps_fix_type,uint8_t battery_remaining,int8_t temperature,int8_t temperature_air,uint8_t failsafe,uint8_t wp_num,uint16_t wp_distance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 29, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 30, airspeed_sp);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet.airspeed_sp = airspeed_sp;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    return mavlink_msg_high_latency_pack(system_id, component_id, msg, high_latency->base_mode, high_latency->custom_mode, high_latency->landed_state, high_latency->roll, high_latency->pitch, high_latency->heading, high_latency->throttle, high_latency->heading_sp, high_latency->latitude, high_latency->longitude, high_latency->altitude_amsl, high_latency->altitude_sp, high_latency->airspeed, high_latency->airspeed_sp, high_latency->groundspeed, high_latency->climb_rate, high_latency->gps_nsat, high_latency->gps_fix_type, high_latency->battery_remaining, high_latency->temperature, high_latency->temperature_air, high_latency->failsafe, high_latency->wp_num, high_latency->wp_distance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    return mavlink_msg_high_latency_pack_chan(system_id, component_id, chan, msg, high_latency->base_mode, high_latency->custom_mode, high_latency->landed_state, high_latency->roll, high_latency->pitch, high_latency->heading, high_latency->throttle, high_latency->heading_sp, high_latency->latitude, high_latency->longitude, high_latency->altitude_amsl, high_latency->altitude_sp, high_latency->airspeed, high_latency->airspeed_sp, high_latency->groundspeed, high_latency->climb_rate, high_latency->gps_nsat, high_latency->gps_fix_type, high_latency->battery_remaining, high_latency->temperature, high_latency->temperature_air, high_latency->failsafe, high_latency->wp_num, high_latency->wp_distance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param airspeed [m/s] airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param airspeed_sp [m/s] airspeed setpoint
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @param temperature_air [degC] Air temperature (degrees C) from airspeed sensor
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:static inline void mavlink_msg_high_latency_send(mavlink_channel_t chan, uint8_t base_mode, uint32_t custom_mode, uint8_t landed_state, int16_t roll, int16_t pitch, uint16_t heading, int8_t throttle, int16_t heading_sp, int32_t latitude, int32_t longitude, int16_t altitude_amsl, int16_t altitude_sp, uint8_t airspeed, uint8_t airspeed_sp, uint8_t groundspeed, int8_t climb_rate, uint8_t gps_nsat, uint8_t gps_fix_type, uint8_t battery_remaining, int8_t temperature, int8_t temperature_air, uint8_t failsafe, uint8_t wp_num, uint16_t wp_distance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 29, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 30, airspeed_sp);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet.airspeed_sp = airspeed_sp;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    mavlink_msg_high_latency_send(chan, high_latency->base_mode, high_latency->custom_mode, high_latency->landed_state, high_latency->roll, high_latency->pitch, high_latency->heading, high_latency->throttle, high_latency->heading_sp, high_latency->latitude, high_latency->longitude, high_latency->altitude_amsl, high_latency->altitude_sp, high_latency->airspeed, high_latency->airspeed_sp, high_latency->groundspeed, high_latency->climb_rate, high_latency->gps_nsat, high_latency->gps_fix_type, high_latency->battery_remaining, high_latency->temperature, high_latency->temperature_air, high_latency->failsafe, high_latency->wp_num, high_latency->wp_distance);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:static inline void mavlink_msg_high_latency_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t base_mode, uint32_t custom_mode, uint8_t landed_state, int16_t roll, int16_t pitch, uint16_t heading, int8_t throttle, int16_t heading_sp, int32_t latitude, int32_t longitude, int16_t altitude_amsl, int16_t altitude_sp, uint8_t airspeed, uint8_t airspeed_sp, uint8_t groundspeed, int8_t climb_rate, uint8_t gps_nsat, uint8_t gps_fix_type, uint8_t battery_remaining, int8_t temperature, int8_t temperature_air, uint8_t failsafe, uint8_t wp_num, uint16_t wp_distance)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 29, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    _mav_put_uint8_t(buf, 30, airspeed_sp);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet->airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    packet->airspeed_sp = airspeed_sp;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @brief Get field airspeed from high_latency message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @return [m/s] airspeed
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:static inline uint8_t mavlink_msg_high_latency_get_airspeed(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @brief Get field airspeed_sp from high_latency message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @return [m/s] airspeed setpoint
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:static inline uint8_t mavlink_msg_high_latency_get_airspeed_sp(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h: * @return [degC] Air temperature (degrees C) from airspeed sensor
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    high_latency->airspeed = mavlink_msg_high_latency_get_airspeed(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_high_latency.h:    high_latency->airspeed_sp = mavlink_msg_high_latency_get_airspeed_sp(msg);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_sensor.h: float diff_pressure; /*< [mbar] Differential pressure (airspeed)*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_sensor.h: * @param diff_pressure [mbar] Differential pressure (airspeed)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_sensor.h: * @param diff_pressure [mbar] Differential pressure (airspeed)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_sensor.h: * @param diff_pressure [mbar] Differential pressure (airspeed)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_hil_sensor.h: * @return [mbar] Differential pressure (airspeed)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h: float airspeed; /*< [m/s] Airspeed, set to -1 if unknown*/
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:         { "airspeed", NULL, MAVLINK_TYPE_FLOAT, 0, 44, offsetof(mavlink_control_system_state_t, airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:         { "airspeed", NULL, MAVLINK_TYPE_FLOAT, 0, 44, offsetof(mavlink_control_system_state_t, airspeed) }, \
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h: * @param airspeed [m/s] Airspeed, set to -1 if unknown
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:                               uint64_t time_usec, float x_acc, float y_acc, float z_acc, float x_vel, float y_vel, float z_vel, float x_pos, float y_pos, float z_pos, float airspeed, const float *vel_variance, const float *pos_variance, const float *q, float roll_rate, float pitch_rate, float yaw_rate)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    _mav_put_float(buf, 44, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h: * @param airspeed [m/s] Airspeed, set to -1 if unknown
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:                                   uint64_t time_usec,float x_acc,float y_acc,float z_acc,float x_vel,float y_vel,float z_vel,float x_pos,float y_pos,float z_pos,float airspeed,const float *vel_variance,const float *pos_variance,const float *q,float roll_rate,float pitch_rate,float yaw_rate)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    _mav_put_float(buf, 44, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    return mavlink_msg_control_system_state_pack(system_id, component_id, msg, control_system_state->time_usec, control_system_state->x_acc, control_system_state->y_acc, control_system_state->z_acc, control_system_state->x_vel, control_system_state->y_vel, control_system_state->z_vel, control_system_state->x_pos, control_system_state->y_pos, control_system_state->z_pos, control_system_state->airspeed, control_system_state->vel_variance, control_system_state->pos_variance, control_system_state->q, control_system_state->roll_rate, control_system_state->pitch_rate, control_system_state->yaw_rate);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    return mavlink_msg_control_system_state_pack_chan(system_id, component_id, chan, msg, control_system_state->time_usec, control_system_state->x_acc, control_system_state->y_acc, control_system_state->z_acc, control_system_state->x_vel, control_system_state->y_vel, control_system_state->z_vel, control_system_state->x_pos, control_system_state->y_pos, control_system_state->z_pos, control_system_state->airspeed, control_system_state->vel_variance, control_system_state->pos_variance, control_system_state->q, control_system_state->roll_rate, control_system_state->pitch_rate, control_system_state->yaw_rate);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h: * @param airspeed [m/s] Airspeed, set to -1 if unknown
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:static inline void mavlink_msg_control_system_state_send(mavlink_channel_t chan, uint64_t time_usec, float x_acc, float y_acc, float z_acc, float x_vel, float y_vel, float z_vel, float x_pos, float y_pos, float z_pos, float airspeed, const float *vel_variance, const float *pos_variance, const float *q, float roll_rate, float pitch_rate, float yaw_rate)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    _mav_put_float(buf, 44, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    packet.airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    mavlink_msg_control_system_state_send(chan, control_system_state->time_usec, control_system_state->x_acc, control_system_state->y_acc, control_system_state->z_acc, control_system_state->x_vel, control_system_state->y_vel, control_system_state->z_vel, control_system_state->x_pos, control_system_state->y_pos, control_system_state->z_pos, control_system_state->airspeed, control_system_state->vel_variance, control_system_state->pos_variance, control_system_state->q, control_system_state->roll_rate, control_system_state->pitch_rate, control_system_state->yaw_rate);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:static inline void mavlink_msg_control_system_state_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint64_t time_usec, float x_acc, float y_acc, float z_acc, float x_vel, float y_vel, float z_vel, float x_pos, float y_pos, float z_pos, float airspeed, const float *vel_variance, const float *pos_variance, const float *q, float roll_rate, float pitch_rate, float yaw_rate)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    _mav_put_float(buf, 44, airspeed);
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    packet->airspeed = airspeed;
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h: * @brief Get field airspeed from control_system_state message
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:static inline float mavlink_msg_control_system_state_get_airspeed(const mavlink_message_t* msg)
+build/sitl/libraries/GCS_MAVLink/include/mavlink/v2.0/common/mavlink_msg_control_system_state.h:    control_system_state->airspeed = mavlink_msg_control_system_state_get_airspeed(msg);
+build/sitl/libraries/AP_Common/AP_FWVersion.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Common/Location.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_TECS/AP_TECS.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/libraries/AP_TECS/AP_TECS.cpp.0.o matches
+build/sitl/libraries/AP_ICEngine/AP_ICEngine.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Camera/AP_Camera.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Vehicle/AP_Vehicle.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Soaring/AP_Soaring.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_Soaring/Variometer.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/RangeFinder_Backend.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/RangeFinder.cpp.5.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_Lanbao.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RPM/RPM_SITL.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RPM/AP_RPM.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+build/sitl/libraries/AP_RPM/RPM_Pin.cpp.0.d: libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/./mavlink_msg_airspeed_autocal.h \
+Binary file build/sitl/bin/arduplane matches
+build/sitl/compile_commands.json:      "../../libraries/AP_HAL_SITL/sitl_airspeed.cpp", 
+build/sitl/compile_commands.json:      "-olibraries/AP_HAL_SITL/sitl_airspeed.cpp.0.o"
+build/sitl/compile_commands.json:    "file": "../../libraries/AP_HAL_SITL/sitl_airspeed.cpp"
+Binary file build/sitl/.wafpickle-linux2-34017264-20 matches
+modules/libcanard/dsdl_compiler/pyuavcan/uavcan/dsdl_files/uavcan/equipment/air_data/1021.IndicatedAirspeed.uavcan:float16 indicated_airspeed              # m/s
+modules/libcanard/dsdl_compiler/pyuavcan/uavcan/dsdl_files/uavcan/equipment/air_data/1021.IndicatedAirspeed.uavcan:float16 indicated_airspeed_variance     # (m/s)^2
+modules/libcanard/dsdl_compiler/pyuavcan/uavcan/dsdl_files/uavcan/equipment/air_data/1020.TrueAirspeed.uavcan:float16 true_airspeed           # m/s
+modules/libcanard/dsdl_compiler/pyuavcan/uavcan/dsdl_files/uavcan/equipment/air_data/1020.TrueAirspeed.uavcan:float16 true_airspeed_variance  # (m/s)^2
+modules/uavcan/dsdl/uavcan/equipment/air_data/1021.IndicatedAirspeed.uavcan:float16 indicated_airspeed              # m/s
+modules/uavcan/dsdl/uavcan/equipment/air_data/1021.IndicatedAirspeed.uavcan:float16 indicated_airspeed_variance     # (m/s)^2
+modules/uavcan/dsdl/uavcan/equipment/air_data/1020.TrueAirspeed.uavcan:float16 true_airspeed           # m/s
+modules/uavcan/dsdl/uavcan/equipment/air_data/1020.TrueAirspeed.uavcan:float16 true_airspeed_variance  # (m/s)^2
+modules/uavcan/libuavcan/dsdl_compiler/pyuavcan/dsdl/uavcan/equipment/air_data/1021.IndicatedAirspeed.uavcan:float16 indicated_airspeed              # m/s
+modules/uavcan/libuavcan/dsdl_compiler/pyuavcan/dsdl/uavcan/equipment/air_data/1021.IndicatedAirspeed.uavcan:float16 indicated_airspeed_variance     # (m/s)^2
+modules/uavcan/libuavcan/dsdl_compiler/pyuavcan/dsdl/uavcan/equipment/air_data/1020.TrueAirspeed.uavcan:float16 true_airspeed           # m/s
+modules/uavcan/libuavcan/dsdl_compiler/pyuavcan/dsdl/uavcan/equipment/air_data/1020.TrueAirspeed.uavcan:float16 true_airspeed_variance  # (m/s)^2
+modules/PX4Firmware/src/lib/runway_takeoff/runway_takeoff_params.c: * Pitch setpoint during taxi / before takeoff airspeed is reached.
+modules/PX4Firmware/src/lib/runway_takeoff/runway_takeoff_params.c: * a little to keep it's wheel on the ground before airspeed
+modules/PX4Firmware/src/lib/runway_takeoff/runway_takeoff_params.c: * Min. airspeed scaling factor for takeoff.
+modules/PX4Firmware/src/lib/runway_takeoff/runway_takeoff_params.c: * Pitch up will be commanded when the following airspeed is reached:
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.h:	void update(float airspeed, float alt_agl, double current_lat, double current_lon, orb_advert_t *mavlink_log_pub);
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.h:	float getMinAirspeedScaling() { return _min_airspeed_scaling.get(); };
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.h:	control::BlockParamFloat _min_airspeed_scaling;
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.h:	control::BlockParamFloat _airspeed_min;
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.cpp:	_min_airspeed_scaling(this, "AIRSPD_SCL"),
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.cpp:	_airspeed_min(this, "FW_AIRSPD_MIN", false),
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.cpp:void RunwayTakeoff::update(float airspeed, float alt_agl,
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.cpp:		if (airspeed > _airspeed_min.get() * _min_airspeed_scaling.get()) {
+modules/PX4Firmware/src/lib/runway_takeoff/RunwayTakeoff.cpp:			mavlink_log_info(mavlink_log_pub, "#Takeoff airspeed reached");
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h: *  - Fallback mode when no airspeed measurement is available that
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		_airspeed_enabled(false),
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		_indicated_airspeed_min(3.0f),
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		_indicated_airspeed_max(30.0f)
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	bool airspeed_sensor_enabled() {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		return _airspeed_enabled;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	void enable_airspeed(bool enabled) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		_airspeed_enabled = enabled;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	void update_state(float baro_altitude, float airspeed, const math::Matrix<3,3> &rotMat,
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	void update_pitch_throttle(const math::Matrix<3,3> &rotMat, float pitch, float baro_altitude, float hgt_dem, float EAS_dem, float indicated_airspeed, float EAS2TAS, bool climbOutDem, float ptchMinCO,
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		float airspeed_filtered;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		float airspeed_sp;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		float airspeed_rate;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		float airspeed_rate_sp;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	void set_indicated_airspeed_min(float airspeed) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		_indicated_airspeed_min = airspeed;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	void set_indicated_airspeed_max(float airspeed) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:		_indicated_airspeed_max = airspeed;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Integrator state 4 - airspeed filter first derivative
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Integrator state 5 - true airspeed
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Equivalent airspeed
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// True airspeed limits
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Current and last true airspeed demand
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Equivalent airspeed demand
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Bad descent condition caused by unachievable airspeed demand
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	bool _airspeed_enabled;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	float _indicated_airspeed_min;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	float _indicated_airspeed_max;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Update the airspeed internal state using a second order complementary filter
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	void _update_speed(float airspeed_demand, float indicated_airspeed,
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:			   float indicated_airspeed_min, float indicated_airspeed_max, float EAS2TAS);
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.h:	// Update the demanded airspeed
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp: *  - Fallback mode when no airspeed measurement is available that
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:void TECS::update_state(float baro_altitude, float airspeed, const math::Matrix<3,3> &rotMat,
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// 	DT, baro_altitude, airspeed, rotMat(0, 0), rotMat(1, 1), accel_body(0), accel_body(1), accel_body(2),
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_EAS = airspeed;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// Only required if airspeed is being measured and controlled
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	if (PX4_ISFINITE(airspeed) && airspeed_sensor_enabled()) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:void TECS::_update_speed(float airspeed_demand, float indicated_airspeed,
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:			 float indicated_airspeed_min, float indicated_airspeed_max, float EAS2TAS)
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// Convert equivalent airspeeds to true airspeeds
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_EAS_dem = airspeed_demand;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_TASmax   = indicated_airspeed_max * EAS2TAS;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_TASmin   = indicated_airspeed_min * EAS2TAS;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// Get airspeed or default to halfway between min and max if
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// airspeed is not being used and set speed rate to zero
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	if (!PX4_ISFINITE(indicated_airspeed) || !airspeed_sensor_enabled()) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:		// If no airspeed available use average of min and max
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:		_EAS = 0.5f * (indicated_airspeed_min + indicated_airspeed_max);
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:		_EAS = indicated_airspeed;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// smoothed airspeed estimate
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// airspeed estimate is held in _integ5_state
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// limit the airspeed to a minimum of 3 m/s
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// Set the airspeed demand to the minimum value if an underspeed condition exists
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// into the ground due to an unachievable airspeed value
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:		// Only use feed-forward component if airspeed is not being used
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:		if (airspeed_sensor_enabled()) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// Detect a demanded airspeed too high for the aircraft to achieve. This will be
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// A SKE_weighting of 0 provides 100% priority to height control. This is used when no airspeed measurement is available
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// or during takeoff/climbout where a minimum pitch angle is set to ensure height is gained. In this instance, if airspeed
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	if ((_underspeed || _climbOutDem) && airspeed_sensor_enabled()) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	} else if (!airspeed_sensor_enabled()) {
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:void TECS::update_pitch_throttle(const math::Matrix<3,3> &rotMat, float pitch, float baro_altitude, float hgt_dem, float EAS_dem, float indicated_airspeed, float EAS2TAS, bool climbOutDem, float ptchMinCO,
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// 	_DT, pitch, baro_altitude, hgt_dem, EAS_dem, indicated_airspeed, EAS2TAS, (climbOutDem) ? "climb" : "level", ptchMinCO, throttle_min, throttle_max, throttle_cruise, pitch_limit_min, pitch_limit_max);
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_update_speed(EAS_dem, indicated_airspeed, _indicated_airspeed_min, _indicated_airspeed_max, EAS2TAS);
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	// Detect bad descent due to demanded airspeed being too high
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_tecs_state.airspeed_sp = _TAS_dem_adj;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_tecs_state.airspeed_rate_sp = _TAS_rate_dem;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_tecs_state.airspeed_filtered = _integ5_state;
+modules/PX4Firmware/src/lib/external_lgpl/tecs/tecs.cpp:	_tecs_state.airspeed_rate = _vel_dot;
+modules/PX4Firmware/src/drivers/hott/messages.cpp:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/drivers/hott/messages.cpp:static int _airspeed_sub = -1;
+modules/PX4Firmware/src/drivers/hott/messages.cpp:	_airspeed_sub = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/drivers/hott/messages.cpp:	/* get a local copy of the airspeed data */
+modules/PX4Firmware/src/drivers/hott/messages.cpp:	struct airspeed_s airspeed;
+modules/PX4Firmware/src/drivers/hott/messages.cpp:	memset(&airspeed, 0, sizeof(airspeed));
+modules/PX4Firmware/src/drivers/hott/messages.cpp:	orb_copy(ORB_ID(airspeed), _airspeed_sub, &airspeed);
+modules/PX4Firmware/src/drivers/hott/messages.cpp:	uint16_t speed = (uint16_t)(airspeed.indicated_airspeed_m_s * 3.6f);
+modules/PX4Firmware/src/drivers/ets_airspeed/CMakeLists.txt:	MODULE drivers__ets_airspeed
+modules/PX4Firmware/src/drivers/ets_airspeed/CMakeLists.txt:	MAIN ets_airspeed
+modules/PX4Firmware/src/drivers/ets_airspeed/CMakeLists.txt:		ets_airspeed.cpp
+modules/PX4Firmware/src/drivers/ets_airspeed/module.mk:MODULE_COMMAND		= ets_airspeed
+modules/PX4Firmware/src/drivers/ets_airspeed/module.mk:SRCS			= ets_airspeed.cpp
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp: * @file ets_airspeed.cpp
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:#include <drivers/airspeed/airspeed.h>
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:#define ETS_PATH	"/dev/ets_airspeed"
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:extern "C" __EXPORT int ets_airspeed_main(int argc, char *argv[]);
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:	if (_airspeed_pub != nullptr && !(_pub_blocked)) {
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:		orb_publish(ORB_ID(differential_pressure), _airspeed_pub, &report);
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:namespace ets_airspeed
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:	errx(1, "no ETS airspeed sensor connected");
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:		err(1, "%s open failed (try 'ets_airspeed start' if the driver is not running", ETS_PATH);
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:ets_airspeed_usage()
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:	warnx("usage: ets_airspeed command [options]");
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:ets_airspeed_main(int argc, char *argv[])
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:		ets_airspeed::start(i2c_bus);
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:		ets_airspeed::stop();
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:		ets_airspeed::test();
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:		ets_airspeed::reset();
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:		ets_airspeed::info();
+modules/PX4Firmware/src/drivers/ets_airspeed/ets_airspeed.cpp:	ets_airspeed_usage();
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp: * @file meas_airspeed.cpp
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:#include <drivers/airspeed/airspeed.h>
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:extern "C" __EXPORT int meas_airspeed_main(int argc, char *argv[]);
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:	if (_airspeed_pub != nullptr && !(_pub_blocked)) {
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:		orb_publish(ORB_ID(differential_pressure), _airspeed_pub, &report);
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:namespace meas_airspeed
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:	errx(1, "no MS4525 airspeed sensor connected");
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:		err(1, "%s open failed (try 'meas_airspeed start' if the driver is not running", PATH_MS4525);
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:meas_airspeed_usage()
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:	warnx("usage: meas_airspeed command [options]");
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:meas_airspeed_main(int argc, char *argv[])
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:		meas_airspeed::start(i2c_bus);
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:		meas_airspeed::stop();
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:		meas_airspeed::test();
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:		meas_airspeed::reset();
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:		meas_airspeed::info();
+modules/PX4Firmware/src/drivers/meas_airspeed/meas_airspeed.cpp:	meas_airspeed_usage();
+modules/PX4Firmware/src/drivers/meas_airspeed/CMakeLists.txt:	MODULE drivers__meas_airspeed
+modules/PX4Firmware/src/drivers/meas_airspeed/CMakeLists.txt:	MAIN meas_airspeed
+modules/PX4Firmware/src/drivers/meas_airspeed/CMakeLists.txt:		meas_airspeed.cpp
+modules/PX4Firmware/src/drivers/meas_airspeed/module.mk:# Makefile to build the MEAS Spec airspeed sensor driver.
+modules/PX4Firmware/src/drivers/meas_airspeed/module.mk:MODULE_COMMAND		= meas_airspeed
+modules/PX4Firmware/src/drivers/meas_airspeed/module.mk:SRCS			= meas_airspeed.cpp
+modules/PX4Firmware/src/drivers/drv_airspeed.h: * @file drv_airspeed.h
+modules/PX4Firmware/src/drivers/drv_airspeed.h:#define AIRSPEED_BASE_DEVICE_PATH "/dev/airspeed"
+modules/PX4Firmware/src/drivers/drv_airspeed.h:#define AIRSPEED0_DEVICE_PATH	"/dev/airspeed0"
+modules/PX4Firmware/src/drivers/drv_airspeed.h:/** airspeed scaling factors; out = (in * Vscale) + offset */
+modules/PX4Firmware/src/drivers/drv_airspeed.h:struct airspeed_scale {
+modules/PX4Firmware/src/drivers/airspeed/airspeed.h: * @file airspeed.h
+modules/PX4Firmware/src/drivers/airspeed/airspeed.h: * Generic driver for airspeed sensors connected via I2C.
+modules/PX4Firmware/src/drivers/airspeed/airspeed.h:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/drivers/airspeed/airspeed.h:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/drivers/airspeed/airspeed.h:	orb_advert_t		_airspeed_pub;
+modules/PX4Firmware/src/drivers/airspeed/CMakeLists.txt:	MODULE drivers__airspeed
+modules/PX4Firmware/src/drivers/airspeed/CMakeLists.txt:		airspeed.cpp
+modules/PX4Firmware/src/drivers/airspeed/module.mk:# Makefile to build the generic airspeed driver.
+modules/PX4Firmware/src/drivers/airspeed/module.mk:SRCS			= airspeed.cpp
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp: * @file airspeed.cpp
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:#include <drivers/airspeed/airspeed.h>
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:	_airspeed_pub(nullptr),
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:		_airspeed_pub = orb_advertise(ORB_ID(differential_pressure), &arp);
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:		if (_airspeed_pub == nullptr) {
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:			struct airspeed_scale *s = (struct airspeed_scale *)arg;
+modules/PX4Firmware/src/drivers/airspeed/airspeed.cpp:			struct airspeed_scale *s = (struct airspeed_scale *)arg;
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp: * @file meas_airspeed_sim.cpp
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp: * Driver for a simulated airspeed sensor.
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:#include "airspeedsim.h"
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:extern "C" __EXPORT int measairspeedsim_main(int argc, char *argv[]);
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	} airspeed_report;
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	ret = transfer(nullptr, 0, (uint8_t *)&airspeed_report, sizeof(airspeed_report));
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	float temperature = airspeed_report.temperature;
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	float diff_press_pa_raw = airspeed_report.diff_pressure * 100.0f; // convert from millibar to bar
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	if (_airspeed_pub != nullptr && !(_pub_blocked)) {
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:		orb_publish(ORB_ID(differential_pressure), _airspeed_pub, &report);
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:namespace meas_airspeed_sim
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	PX4_ERR("no MS4525 airspeedSim sensor connected");
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:		PX4_ERR("%s open failed (try 'meas_airspeed_sim start' if the driver is not running", PATH_MS4525);
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:meas_airspeed_usage()
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	PX4_WARN("usage: measairspeedsim command [options]");
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:measairspeedsim_main(int argc, char *argv[])
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:		return meas_airspeed_sim::start(i2c_bus);
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:		return meas_airspeed_sim::stop();
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:		return meas_airspeed_sim::test();
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:		return meas_airspeed_sim::reset();
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:		return meas_airspeed_sim::info();
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp:	meas_airspeed_usage();
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt:	MODULE platforms__posix__drivers__airspeedsim
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt:	MAIN measairspeedsim
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt:		airspeedsim.cpp
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt:		meas_airspeed_sim.cpp
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/module.mk:# Makefile to build the generic airspeed driver.
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/module.mk:MODULE_COMMAND	= measairspeedsim
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/module.mk:SRCS			= airspeedsim.cpp meas_airspeed_sim.cpp
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.h: * @file airspeed.h
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.h: * Generic driver for airspeed sensors connected via I2C.
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.h:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.h:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.h:	orb_advert_t		_airspeed_pub;
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp: * @file ets_airspeed.cpp
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:#include "airspeedsim.h"
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:	_buffer_overflows(perf_alloc(PC_COUNT, "airspeed_buffer_overflows")),
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:	_airspeed_pub(nullptr),
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:	_sample_perf(perf_alloc(PC_ELAPSED, "airspeed_read")),
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:	_comms_errors(perf_alloc(PC_COUNT, "airspeed_comms_errors"))
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:		_airspeed_pub = orb_advertise(ORB_ID(differential_pressure), &arp);
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:		if (_airspeed_pub == nullptr) {
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:			struct airspeed_scale *s = (struct airspeed_scale *)arg;
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp:			struct airspeed_scale *s = (struct airspeed_scale *)arg;
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * @file airspeed.h
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * Calculate indicated airspeed.
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * Note that the indicated airspeed is not the true airspeed because it
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * lacks the air density compensation. Use the calc_true_airspeed functions to get
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * the true airspeed.
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * @return indicated airspeed in m/s
+modules/PX4Firmware/src/modules/systemlib/airspeed.h:__EXPORT float calc_indicated_airspeed(float differential_pressure);
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * Calculate true airspeed from indicated airspeed.
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * Note that the true airspeed is NOT the groundspeed, because of the effects of wind
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * @param speed_indicated current indicated airspeed
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * @return true airspeed in m/s
+modules/PX4Firmware/src/modules/systemlib/airspeed.h:__EXPORT float calc_true_airspeed_from_indicated(float speed_indicated, float pressure_ambient,
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * Directly calculate true airspeed
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * Note that the true airspeed is NOT the groundspeed, because of the effects of wind
+modules/PX4Firmware/src/modules/systemlib/airspeed.h: * @return true airspeed in m/s
+modules/PX4Firmware/src/modules/systemlib/airspeed.h:__EXPORT float calc_true_airspeed(float total_pressure, float static_pressure, float temperature_celsius);
+modules/PX4Firmware/src/modules/systemlib/otp.h://__EXPORT float calc_indicated_airspeed(float differential_pressure);
+modules/PX4Firmware/src/modules/systemlib/CMakeLists.txt:	airspeed.c
+modules/PX4Firmware/src/modules/systemlib/circuit_breaker_params.c: * Circuit breaker for airspeed sensor
+modules/PX4Firmware/src/modules/systemlib/circuit_breaker_params.c: * Setting this parameter to 162128 will disable the check for an airspeed sensor.
+modules/PX4Firmware/src/modules/systemlib/module.mk:		   airspeed.c \
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * @file airspeed.c
+modules/PX4Firmware/src/modules/systemlib/airspeed.c:#include "airspeed.h"
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * Calculate indicated airspeed.
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * Note that the indicated airspeed is not the true airspeed because it
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * lacks the air density compensation. Use the calc_true_airspeed functions to get
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * the true airspeed.
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * @return indicated airspeed in m/s
+modules/PX4Firmware/src/modules/systemlib/airspeed.c:float calc_indicated_airspeed(float differential_pressure)
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * Calculate true airspeed from indicated airspeed.
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * Note that the true airspeed is NOT the groundspeed, because of the effects of wind
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * @param speed_indicated current indicated airspeed
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * @return true airspeed in m/s
+modules/PX4Firmware/src/modules/systemlib/airspeed.c:float calc_true_airspeed_from_indicated(float speed_indicated, float pressure_ambient, float temperature_celsius)
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * Directly calculate true airspeed
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * Note that the true airspeed is NOT the groundspeed, because of the effects of wind
+modules/PX4Firmware/src/modules/systemlib/airspeed.c: * @return true airspeed in m/s
+modules/PX4Firmware/src/modules/systemlib/airspeed.c:float calc_true_airspeed(float total_pressure, float static_pressure, float temperature_celsius)
+modules/PX4Firmware/src/modules/ekf2_replay/ekf2_replay_main.cpp:		log_message.body.control_state.airspeed = control_state.airspeed;
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.cpp:	_airspeedSub(-1),
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.cpp:	_airspeed{},
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.cpp:	_airspeed_filtered(0.0f),
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.cpp:	_airspeedSub = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.cpp:	orb_update(ORB_ID(airspeed), _airspeedSub, &_airspeed);
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.cpp:		_airspeed_filtered = 0.95f * _airspeed_filtered + 0.05f * _airspeed.true_airspeed_m_s;
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.cpp:		    && _airspeed_filtered < _params.maxAirSpeed
+modules/PX4Firmware/src/modules/land_detector/land_detector_params.c: * Maximum airspeed allowed in the landed state (m/s)
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.h:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.h:	int _airspeedSub;
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.h:	struct airspeed_s _airspeed;
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.h:	float _airspeed_filtered; /**< low pass filtered airspeed */
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	_airspeedSub(-1),
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	_airspeed{},
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	_airspeed_filtered(0)
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	_airspeedSub = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	orb_update(ORB_ID(airspeed), _airspeedSub, &_airspeed);
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	// for vtol we additionally consider airspeed
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	if (hrt_elapsed_time(&_airspeed.timestamp) < 500 * 1000) {
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:		_airspeed_filtered = 0.95f * _airspeed_filtered + 0.05f * _airspeed.true_airspeed_m_s;
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:		// if airspeed does not update, set it to zero and rely on multicopter land detector
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:		_airspeed_filtered = 0.0f;
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	// only consider airspeed if we have been in air before to avoid false
+modules/PX4Firmware/src/modules/land_detector/VtolLandDetector.cpp:	if (_was_in_air && _airspeed_filtered > _params.maxAirSpeed) {
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.h:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.h:	int					_airspeedSub;
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.h:	struct airspeed_s			_airspeed;
+modules/PX4Firmware/src/modules/land_detector/FixedwingLandDetector.h:	float _airspeed_filtered;
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:	int		_airspeed_sub = -1;
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:	airspeed_s _airspeed = {};
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:	_airspeed_sub = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:		// Update airspeed
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:		bool airspeed_updated = false;
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:		orb_check(_airspeed_sub, &airspeed_updated);
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:		if (airspeed_updated) {
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:			orb_copy(ORB_ID(airspeed), _airspeed_sub, &_airspeed);
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:			/* Airspeed - take airspeed measurement directly here as no wind is estimated */
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:			if (PX4_ISFINITE(_airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - _airspeed.timestamp < 1e6
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:			    && _airspeed.timestamp > 0) {
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:				ctrl_state.airspeed = _airspeed.indicated_airspeed_m_s;
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:				ctrl_state.airspeed_valid = true;
+modules/PX4Firmware/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp:				ctrl_state.airspeed_valid = false;
+modules/PX4Firmware/src/modules/commander/state_machine_helper.cpp:	/* Perform airspeed check only if circuit breaker is not
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool report_fail)
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:	int fd = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:	struct airspeed_s airspeed;
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:	if ((ret = orb_copy(ORB_ID(airspeed), fd, &airspeed)) ||
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:	    (hrt_elapsed_time(&airspeed.timestamp) > (500 * 1000))) {
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:	if (fabsf(airspeed.confidence) < 0.99f) {
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:	if (fabsf(airspeed.indicated_airspeed_m_s) > 6.0f) {
+modules/PX4Firmware/src/modules/commander/PreflightCheck.cpp:		if (!airspeedCheck(mavlink_log_pub, true, reportFailures)) {
+modules/PX4Firmware/src/modules/commander/CMakeLists.txt:		airspeed_calibration.cpp
+modules/PX4Firmware/src/modules/commander/module.mk:			airspeed_calibration.cpp \
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp: * @file airspeed_calibration.cpp
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:#include "airspeed_calibration.h"
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:	struct airspeed_scale airscale = {
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:			calibration_log_critical(mavlink_log_pub, "[cal] airspeed offset zero failed");
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:			calibration_log_critical(mavlink_log_pub, "[cal] No airspeed sensor, see http://px4.io/help/aspd");
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.cpp:				calibration_log_critical(mavlink_log_pub, "[cal] airspeed offset update failed");
+modules/PX4Firmware/src/modules/commander/commander.cpp:#include "airspeed_calibration.h"
+modules/PX4Firmware/src/modules/commander/commander.cpp:			} else if (!strcmp(argv[2], "airspeed")) {
+modules/PX4Firmware/src/modules/commander/commander.cpp:				calib_ret = do_airspeed_calibration(&mavlink_log_pub);
+modules/PX4Firmware/src/modules/commander/commander.cpp:	/* Perform airspeed check only if circuit breaker is not
+modules/PX4Firmware/src/modules/commander/commander.cpp:					/* Perform airspeed check only if circuit breaker is not
+modules/PX4Firmware/src/modules/commander/commander.cpp:		check_valid(diff_pres.timestamp, DIFFPRESS_TIMEOUT, true, &(status.condition_airspeed_valid), &status_changed);
+modules/PX4Firmware/src/modules/commander/commander.cpp:						/* airspeed calibration */
+modules/PX4Firmware/src/modules/commander/commander.cpp:						calib_ret = do_airspeed_calibration(&mavlink_log_pub);
+modules/PX4Firmware/src/modules/commander/commander.cpp:						/* Perform airspeed check only if circuit breaker is not
+modules/PX4Firmware/src/modules/commander/PreflightCheck.h:*   true if the airspeed sensor should be checked
+modules/PX4Firmware/src/modules/commander/airspeed_calibration.h:int do_airspeed_calibration(orb_advert_t *mavlink_log_pub);
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:#include <drivers/drv_airspeed.h>
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:	orb_advert_t	_airspeed_pub;			/**< airspeed */
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:	DataValidator	_airspeed_validator;		/**< data validator to monitor airspeed */
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:	struct airspeed_s _airspeed;
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:	_airspeed_pub(nullptr),
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:	_airspeed_validator(),
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed.timestamp = _diff_pres.timestamp;
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed_validator.put(_airspeed.timestamp, _diff_pres.differential_pressure_raw_pa, _diff_pres.error_count, 100);
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed.confidence = 1.0f;
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed.confidence = _airspeed_validator.confidence(hrt_absolute_time());
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		/* don't risk to feed negative airspeed into the system */
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed.indicated_airspeed_m_s = math::max(0.0f,
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:						   calc_indicated_airspeed(_diff_pres.differential_pressure_filtered_pa));
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed.true_airspeed_m_s = math::max(0.0f,
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:							calc_true_airspeed(_diff_pres.differential_pressure_filtered_pa + raw.baro_pres_mbar[0] * 1e2f,
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed.true_airspeed_unfiltered_m_s = math::max(0.0f,
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:				calc_true_airspeed(_diff_pres.differential_pressure_raw_pa + raw.baro_pres_mbar[0] * 1e2f,
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		_airspeed.air_temperature_celsius = air_temperature_celsius;
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		/* announce the airspeed if needed, just publish else */
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:		if (_airspeed_pub != nullptr) {
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:			orb_publish(ORB_ID(airspeed), _airspeed_pub, &_airspeed);
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &_airspeed);
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:			struct airspeed_scale airscale = {
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:				warn("WARNING: failed to set scale / offsets for airspeed sensor");
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:					/* calculate airspeed, raw is the difference from */
+modules/PX4Firmware/src/modules/sensors/sensors.cpp:						/* announce the airspeed if needed, just publish else */
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:	MavlinkOrbSubscription *_airspeed_sub;
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:	uint64_t _airspeed_time;
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:		_airspeed_sub(_mavlink->add_orb_subscription(ORB_ID(airspeed))),
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:		_airspeed_time(0),
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:		struct airspeed_s airspeed = {};
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:		updated |= _airspeed_sub->update(&_airspeed_time, &airspeed);
+modules/PX4Firmware/src/modules/mavlink/mavlink_messages.cpp:			msg.airspeed = airspeed.indicated_airspeed_m_s;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.h:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.h:	orb_advert_t _airspeed_pub;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:#include <systemlib/airspeed.h>
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:	_airspeed_pub(nullptr),
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:	/* airspeed */
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		struct airspeed_s airspeed = {};
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		float ias = calc_indicated_airspeed(imu.diff_pressure * 1e2f);
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		float tas = calc_true_airspeed_from_indicated(ias, imu.abs_pressure * 100, imu.temperature);
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		airspeed.timestamp = timestamp;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		airspeed.indicated_airspeed_m_s = ias;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		airspeed.true_airspeed_m_s = tas;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		if (_airspeed_pub == nullptr) {
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &airspeed);
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:			orb_publish(ORB_ID(airspeed), _airspeed_pub, &airspeed);
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:	/* airspeed */
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		struct airspeed_s airspeed;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		memset(&airspeed, 0, sizeof(airspeed));
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		airspeed.timestamp = timestamp;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		airspeed.indicated_airspeed_m_s = hil_state.ind_airspeed * 1e-2f;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		airspeed.true_airspeed_m_s = hil_state.true_airspeed * 1e-2f;
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:		if (_airspeed_pub == nullptr) {
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &airspeed);
+modules/PX4Firmware/src/modules/mavlink/mavlink_receiver.cpp:			orb_publish(ORB_ID(airspeed), _airspeed_pub, &airspeed);
+modules/PX4Firmware/src/modules/navigator/mission_block.cpp:			// XXX not differentiating ground and airspeed yet
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:	int		_airspeed_sub = -1;
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:	control::BlockParamFloat *_airspeed_delay_ms;
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:	control::BlockParamFloat *_eas_noise;			// measurement noise used for airspeed fusion (std m/s)
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:	_airspeed_delay_ms(new control::BlockParamFloat(this, "EKF2_ASP_DELAY", false, &_params->airspeed_delay_ms)),
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:	_airspeed_sub = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:	airspeed_s airspeed = {};
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:		bool airspeed_updated = false;
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:		orb_check(_airspeed_sub, &airspeed_updated);
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:		if (airspeed_updated) {
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:			orb_copy(ORB_ID(airspeed), _airspeed_sub, &airspeed);
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:		// read airspeed data if available
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:		if (airspeed_updated) {
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:			_ekf->setAirspeedData(airspeed.timestamp, &airspeed.true_airspeed_m_s); // Only TAS is now fed into the estimator
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:			// Airspeed - take airspeed measurement directly here as no wind is estimated
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:			if (PX4_ISFINITE(airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - airspeed.timestamp < 1e6
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:			    && airspeed.timestamp > 0) {
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:				ctrl_state.airspeed = airspeed.indicated_airspeed_m_s;
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:				ctrl_state.airspeed_valid = true;
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:				ctrl_state.airspeed_valid = false;
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:		_ekf->get_airspeed_innov(&innovations.airspeed_innov);
+modules/PX4Firmware/src/modules/ekf2/ekf2_main.cpp:		_ekf->get_airspeed_innov_var(&innovations.airspeed_innov_var);
+modules/PX4Firmware/src/modules/ekf2/ekf2_params.c: * Measurement noise for airspeed fusion.
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:		struct airspeed_s airspeed;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:		int airspeed_sub;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:	subs.airspeed_sub = -1;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_VTOL.airspeed_tot = buf.vtol_status.airspeed_tot;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:			if (copy_if_updated(ORB_ID(airspeed), &subs.airspeed_sub, &buf.airspeed)) {
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_AIRS.indicated_airspeed = buf.airspeed.indicated_airspeed_m_s;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_AIRS.true_airspeed = buf.airspeed.true_airspeed_m_s;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_AIRS.air_temperature_celsius = buf.airspeed.air_temperature_celsius;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_INO2.s[8] = buf.innovations.airspeed_innov;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_INO2.s[9] = buf.innovations.airspeed_innov_var;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_TECS.airspeedSp = buf.tecs_status.airspeedSp;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_TECS.airspeedFiltered = buf.tecs_status.airspeed_filtered;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_TECS.airspeedDerivativeSp = buf.tecs_status.airspeedDerivativeSp;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_TECS.airspeedDerivative = buf.tecs_status.airspeedDerivative;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2.c:				log_msg.body.log_CTS.airspeed = buf.ctrl_state.airspeed;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float indicated_airspeed;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float true_airspeed;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float airspeedSp;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float airspeedFiltered;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float airspeedDerivativeSp;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float airspeedDerivative;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float airspeed_tot;
+modules/PX4Firmware/src/modules/sdlog2/sdlog2_messages.h:	float airspeed;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:		float airspeed_min;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:		float airspeed_trim;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:		float airspeed_max;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:		param_t airspeed_min;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:		param_t airspeed_trim;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:		param_t airspeed_max;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:	_parameter_handles.airspeed_min = param_find("FW_AIRSPD_MIN");
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:	_parameter_handles.airspeed_trim = param_find("FW_AIRSPD_TRIM");
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:	_parameter_handles.airspeed_max = param_find("FW_AIRSPD_MAX");
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:	param_get(_parameter_handles.airspeed_min, &(_parameters.airspeed_min));
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:	param_get(_parameter_handles.airspeed_trim, &(_parameters.airspeed_trim));
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:	param_get(_parameter_handles.airspeed_max, &(_parameters.airspeed_max));
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				/* scale around tuning airspeed */
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				float airspeed;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				/* if airspeed is not updating, we assume the normal average speed */
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				if (bool nonfinite = !PX4_ISFINITE(_ctrl_state.airspeed) || !_ctrl_state.airspeed_valid) {
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:					airspeed = _parameters.airspeed_trim;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:					airspeed = math::max(0.5f, _ctrl_state.airspeed);
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				float airspeed_scaling = _parameters.airspeed_trim / ((airspeed < _parameters.airspeed_min) ? _parameters.airspeed_min :
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:							 airspeed);
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				/* Use min airspeed to calculate ground speed scaling region.
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				float gspd_scaling_trim = (_parameters.airspeed_min * 0.6f);
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				control_input.airspeed_min = _parameters.airspeed_min;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				control_input.airspeed_max = _parameters.airspeed_max;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				control_input.airspeed = airspeed;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:				control_input.scaler = airspeed_scaling;
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:							      " airspeed %.4f, airspeed_scaling %.4f,"
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_main.cpp:							      (double)airspeed, (double)airspeed_scaling,
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_params.c: * For airspeeds above this value, the yaw rate is calculated for a coordinated
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_params.c: * The following parameters about airspeed are used by the attitude and the
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_params.c: * If the airspeed falls below this value, the TECS controller will try to
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_params.c: * increase airspeed more aggressively.
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_params.c: * The TECS controller tries to fly at this airspeed.
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_params.c: * If the airspeed is above this value, the TECS controller will try to decrease
+modules/PX4Firmware/src/modules/fw_att_control/fw_att_control_params.c: * airspeed more aggressively.
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs_params.c: * Lowpass (cutoff freq.) for airspeed
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs_params.c: * P gain for the airspeed control
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs_params.c: * Maps the airspeed error to the acceleration setpoint
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs_params.c: * D gain for the airspeed control
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs_params.c: * Maps the change of airspeed error to the acceleration setpoint
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	int updateAltitudeSpeed(float flightPathAngle, float altitude, float altitudeSp, float airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:				float airspeedSp, unsigned mode, LimitOverride limitOverride);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	int updateFlightPathAngleSpeed(float flightPathAngle, float flightPathAngleSp, float airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:				       float airspeedSp, unsigned mode, LimitOverride limitOverride);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	int updateFlightPathAngleAcceleration(float flightPathAngle, float flightPathAngleSp, float airspeedFiltered,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	void resetDerivatives(float airspeed);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	float airspeedLowpassUpdate(float input) { return _airspeedLowpass.update(input); }
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	float getAirspeedLowpassState() { return _airspeedLowpass.getState(); }
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	float getAirspeedDerivativeLowpassState() { return _airspeedDerivative.getO(); }
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	control::BlockParamFloat _airspeedMin;		/**< minimal airspeed */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	BlockPDLimited	_controlAirSpeed;			/**< PD controller for airspeed: output is acceleration
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	control::BlockLowPass2 _airspeedLowpass;		/**< low pass filter for airspeed */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.h:	control::BlockDerivative _airspeedDerivative;	/**< airspeed derivative calulation */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	_airspeedMin(this, "FW_AIRSPD_MIN", false),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	_airspeedLowpass(this, "A_LP", 50),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	_airspeedDerivative(this, "AD"),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:int mTecs::updateAltitudeSpeed(float flightPathAngle, float altitude, float altitudeSp, float airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:		float airspeedSp, unsigned mode, LimitOverride limitOverride)
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:			!PX4_ISFINITE(altitudeSp) || !PX4_ISFINITE(airspeed) || !PX4_ISFINITE(airspeedSp) || !PX4_ISFINITE(mode)) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	return updateFlightPathAngleSpeed(flightPathAngle, flightPathAngleSp, airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:			airspeedSp, mode, limitOverride);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:int mTecs::updateFlightPathAngleSpeed(float flightPathAngle, float flightPathAngleSp, float airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:		float airspeedSp, unsigned mode, LimitOverride limitOverride)
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:			!PX4_ISFINITE(airspeed) || !PX4_ISFINITE(airspeedSp) || !PX4_ISFINITE(mode)) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	/* Filter airspeed */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float airspeedFiltered = _airspeedLowpass.update(airspeed);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	/* calculate longitudinal acceleration setpoint from airspeed setpoint*/
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float accelerationLongitudinalSp = _controlAirSpeed.update(airspeedSp - airspeedFiltered);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:		debug("updateFlightPathAngleSpeed airspeedSp %.4f, airspeed %.4f airspeedFiltered %.4f,"
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:				(double)airspeedSp, (double)airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:				(double)airspeedFiltered, (double)accelerationLongitudinalSp);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	_status.get().airspeedSp = airspeedSp;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	_status.get().airspeed_filtered = airspeedFiltered;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	return updateFlightPathAngleAcceleration(flightPathAngle, flightPathAngleSp, airspeedFiltered,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:int mTecs::updateFlightPathAngleAcceleration(float flightPathAngle, float flightPathAngleSp, float airspeedFiltered,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:			!PX4_ISFINITE(airspeedFiltered) || !PX4_ISFINITE(accelerationLongitudinalSp) || !PX4_ISFINITE(mode)) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float airspeedDerivative = 0.0f;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	if(_airspeedDerivative.getDt() > 0.0f) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:		airspeedDerivative = _airspeedDerivative.update(airspeedFiltered);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float airspeedDerivativeNorm = airspeedDerivative / CONSTANTS_ONE_G;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float airspeedDerivativeSp = accelerationLongitudinalSp;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float airspeedDerivativeNormSp = airspeedDerivativeSp / CONSTANTS_ONE_G;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float airspeedDerivativeNormError = airspeedDerivativeNormSp - airspeedDerivativeNorm;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float totalEnergyRate = flightPathAngleFiltered + airspeedDerivativeNorm;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float totalEnergyRateError = flightPathAngleError + airspeedDerivativeNormError;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float totalEnergyRateSp = flightPathAngleSp + airspeedDerivativeNormSp;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float energyDistributionRate = flightPathAngleFiltered - airspeedDerivativeNorm;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float energyDistributionRateError = flightPathAngleError - airspeedDerivativeNormError;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	float energyDistributionRateSp = flightPathAngleSp - airspeedDerivativeNormSp;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:		debug("totalEnergyRateSp %.2f, totalEnergyRate %.2f, totalEnergyRateError %.2f totalEnergyRateError2 %.2f airspeedDerivativeNorm %.4f",
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:				(double)totalEnergyRateSp, (double)totalEnergyRate, (double)totalEnergyRateError, (double)totalEnergyRateError2, (double)airspeedDerivativeNorm);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	/* Check airspeed: if below safe value switch to underspeed mode (if not in land or takeoff mode) */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	if (mode != MTECS_MODE_LAND && mode != MTECS_MODE_TAKEOFF && airspeedFiltered < _airspeedMin.get()) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	// _status.airspeedDerivativeSp = airspeedDerivativeSp;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	// _status.airspeedDerivative = airspeedDerivative;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:		debug("_throttleSp %.1f, _pitchSp %.1f, flightPathAngleSp %.1f, flightPathAngle %.1f accelerationLongitudinalSp %.1f, airspeedDerivative %.1f",
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:				(double)accelerationLongitudinalSp, (double)airspeedDerivative);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:void mTecs::resetDerivatives(float airspeed)
+modules/PX4Firmware/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp:	_airspeedDerivative.setU(airspeed);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	/* throttle and airspeed states */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	float _airspeed_error;				///< airspeed error to setpoint in m/s
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	bool _airspeed_valid;				///< flag if a valid airspeed estimate exists
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	uint64_t _airspeed_last_received;			///< last time airspeed was received. Used to detect timeouts.
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float airspeed_min;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float airspeed_trim;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float airspeed_max;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float land_airspeed_scale;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		param_t airspeed_min;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		param_t airspeed_trim;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		param_t airspeed_max;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		param_t land_airspeed_scale;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	 * @return true if climbout mode was requested by user (climb with max rate and min airspeed)
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	float		get_demanded_airspeed();
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	float		calculate_target_airspeed(float airspeed_demand);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_airspeed_error(0.0f),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_airspeed_valid(false),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_airspeed_last_received(0),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_parameter_handles.airspeed_min = param_find("FW_AIRSPD_MIN");
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_parameter_handles.airspeed_trim = param_find("FW_AIRSPD_TRIM");
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_parameter_handles.airspeed_max = param_find("FW_AIRSPD_MAX");
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_parameter_handles.land_airspeed_scale = param_find("FW_LND_AIRSPD_SC");
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	param_get(_parameter_handles.airspeed_min, &(_parameters.airspeed_min));
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	param_get(_parameter_handles.airspeed_trim, &(_parameters.airspeed_trim));
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	param_get(_parameter_handles.airspeed_max, &(_parameters.airspeed_max));
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	param_get(_parameter_handles.land_airspeed_scale, &(_parameters.land_airspeed_scale));
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_tecs.set_indicated_airspeed_min(_parameters.airspeed_min);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_tecs.set_indicated_airspeed_max(_parameters.airspeed_max);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	if (_parameters.airspeed_max < _parameters.airspeed_min ||
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	    _parameters.airspeed_max < 5.0f ||
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	    _parameters.airspeed_min > 100.0f ||
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	    _parameters.airspeed_trim < _parameters.airspeed_min ||
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	    _parameters.airspeed_trim > _parameters.airspeed_max) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		warnx("error: airspeed parameters invalid");
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		_airspeed_valid = _ctrl_state.airspeed_valid;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		_airspeed_last_received = hrt_absolute_time();
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		/* no airspeed updates for one second */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		if (_airspeed_valid && (hrt_absolute_time() - _airspeed_last_received) > 1e6) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:			_airspeed_valid = false;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_tecs.enable_airspeed(_airspeed_valid);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:FixedwingPositionControl::get_demanded_airspeed()
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	float altctrl_airspeed = 0;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	// neutral throttle corresponds to trim airspeed
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		// lower half of throttle is min to trim airspeed
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		altctrl_airspeed = _parameters.airspeed_min +
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:							(_parameters.airspeed_trim - _parameters.airspeed_min) *
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		// upper half of throttle is trim to max airspeed
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		altctrl_airspeed = _parameters.airspeed_trim +
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:							(_parameters.airspeed_max - _parameters.airspeed_trim) *
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	return altctrl_airspeed;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:FixedwingPositionControl::calculate_target_airspeed(float airspeed_demand)
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	float airspeed;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	if (_airspeed_valid) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		airspeed = _ctrl_state.airspeed;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		airspeed = _parameters.airspeed_min + (_parameters.airspeed_max - _parameters.airspeed_min) / 2.0f;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	/* cruise airspeed for all modes unless modified below */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	float target_airspeed = airspeed_demand;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	target_airspeed += _groundspeed_undershoot;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		//target_airspeed += nudge term.
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	target_airspeed = math::constrain(target_airspeed, _parameters.airspeed_min, _parameters.airspeed_max);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	/* plain airspeed error */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	_airspeed_error = target_airspeed - airspeed;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	return target_airspeed;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		/* The minimum desired ground speed is the minimum airspeed projected on to the ground using the altitude and horizontal difference between the waypoints if available*/
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float ground_speed_desired = _parameters.airspeed_min * cosf(atan2f(delta_altitude, distance));
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		 * by the plane. Consequently it is zero if airspeed is >= min ground speed
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		 * and positive if airspeed < min ground speed.
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		_tecs.update_state(_global_pos.alt, _ctrl_state.airspeed, _R_nb,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:				_mTecs.resetDerivatives(_ctrl_state.airspeed);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float mission_airspeed = _parameters.airspeed_trim;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:			mission_airspeed = _pos_sp_triplet.current.cruising_speed;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:			tecs_update_pitch_throttle(pos_sp_triplet.current.alt, calculate_target_airspeed(mission_airspeed), eas2tas,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:			tecs_update_pitch_throttle(alt_sp, calculate_target_airspeed(mission_airspeed), eas2tas,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:			float airspeed_land = _parameters.land_airspeed_scale * _parameters.airspeed_min;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:			float airspeed_approach = _parameters.land_airspeed_scale * _parameters.airspeed_min;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:							   calculate_target_airspeed(airspeed_land), eas2tas,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:							   calculate_target_airspeed(airspeed_approach), eas2tas,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:					_ctrl_state.airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:							   calculate_target_airspeed(
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:								   _runway_takeoff.getMinAirspeedScaling() * _parameters.airspeed_min),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:									   calculate_target_airspeed(1.3f * _parameters.airspeed_min),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:									   calculate_target_airspeed(mission_airspeed),
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		/* POSITION CONTROL: pitch stick moves altitude setpoint, throttle stick sets airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:				_mTecs.resetDerivatives(_ctrl_state.airspeed);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float altctrl_airspeed = get_demanded_airspeed();
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:					   altctrl_airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		/* ALTITUDE CONTROL: pitch stick moves altitude setpoint, throttle stick sets airspeed */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:				_mTecs.resetDerivatives(_ctrl_state.airspeed);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		/* Get demanded airspeed */
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		float altctrl_airspeed = get_demanded_airspeed();
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:					   altctrl_airspeed,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	// (it should also not run during VTOL blending because airspeed is too low still)
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		_asp_after_transition = _ctrl_state.airspeed;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:	// after transition we ramp up desired airspeed from the speed we had coming out of the transition
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		if (_asp_after_transition < v_sp && _ctrl_state.airspeed < v_sp) {
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:			v_sp = fmaxf(_asp_after_transition, _ctrl_state.airspeed);
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		_mTecs.updateAltitudeSpeed(flightPathAngle, altitude, alt_sp, _ctrl_state.airspeed, v_sp, mode,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:					    _ctrl_state.airspeed, eas2tas,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		t.airspeedSp 		= s.airspeed_sp;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		t.airspeed_filtered = s.airspeed_filtered;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		t.airspeedDerivativeSp 	= s.airspeed_rate_sp;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:		t.airspeedDerivative 	= s.airspeed_rate;
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * with maximum throttle and minimum airspeed until it is closer than this
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * the throttle set to THR_MAX and the airspeed set to the
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * airspeed, then this parameter is set correctly. If the airspeed starts
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * set to THR_MIN and flown at the same airspeed as used
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * filter used to fuse longitudinal acceleration and airspeed to obtain an
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * improved airspeed estimate. Increasing this frequency weights the solution
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * normally improve height accuracy but give larger airspeed errors.
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * and ignore height errors. This will normally reduce airspeed errors,
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * adjust its pitch angle to maintain airspeed, ignoring changes in height).
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * Landing airspeed scale factor
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * Multiplying this factor with the minimum airspeed of the plane
+modules/PX4Firmware/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c: * gives the target airspeed the landing approach.
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h:    int     _airspeed_sub;          /**< airspeed subscription */
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h:    struct airspeed_s                   _airspeed;      /**< airspeed */
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h:    perf_counter_t  _perf_airspeed;     ///<local performance counter for airspeed updates
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.h:    float airspeedMeasurementSigma;
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.h:    float EAS2TAS; // ratio f true to equivalent airspeed
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.h:    float VtasMeas; // true airspeed measurement (m/s)
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.h:    bool fuseVtasData; // boolean true when airspeed data is to be fused
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.h:    bool useAirspeed;    ///< boolean true if airspeed data is being used
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_params.c: * The delay in milliseconds of the airspeed estimate.
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	_airspeed_sub(-1),
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	_airspeed{},
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	_perf_airspeed(perf_alloc(PC_INTERVAL, "ekf_att_pos_aspd_upd")),
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:		_ekf->airspeedMeasurementSigma = _parameters.eas_noise;
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	_airspeed_sub = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	//_ctrl_state.airspeed = sqrt(pow(_ekf->states[4] -  _ekf->states[14], 2) + pow(_ekf->states[5] - _ekf->states[15], 2) + pow(_ekf->states[6], 2));
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	// the line above was introduced by the control state PR. The airspeed it gives is totally wrong and leads to horrible flight performance in SITL
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	if (PX4_ISFINITE(_airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - _airspeed.timestamp < 1e6
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	    && _airspeed.timestamp > 0) {
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:		_ctrl_state.airspeed = _airspeed.indicated_airspeed_m_s;
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:		_ctrl_state.airspeed_valid = true;
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:		_ctrl_state.airspeed_valid = false;
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	if (fuseAirSpeed && _airspeed.true_airspeed_m_s > 5.0f) {
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:				   (getMillis() - _parameters.tas_delay_ms)); // assume 100 msec avg delay for airspeed data
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:	orb_check(_airspeed_sub, &_newAdsData);
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:		orb_copy(ORB_ID(airspeed), _airspeed_sub, &_airspeed);
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:		perf_count(_perf_airspeed);
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp:		_ekf->VtasMeas = _airspeed.true_airspeed_unfiltered_m_s;
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.cpp:    airspeedMeasurementSigma(0.0f),
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.cpp:    airspeedMeasurementSigma = 1.4f;
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.cpp:        // set the GPS data timeout depending on whether airspeed data is present
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.cpp:    float R_TAS = sq(airspeedMeasurementSigma);
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.cpp:    // Need to check that it is flying before fusing airspeed data
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.cpp:    // Calculate the predicted airspeed
+modules/PX4Firmware/src/modules/ekf_att_pos_estimator/estimator_22states.cpp:    // don't update wind states if there is no airspeed measurement
+modules/PX4Firmware/src/modules/simulator/simulator.cpp:	return _airspeed.copyData(buf, len);
+modules/PX4Firmware/src/modules/simulator/simulator.cpp:void Simulator::write_airspeed_data(void *buf)
+modules/PX4Firmware/src/modules/simulator/simulator.cpp:	_airspeed.writeData(buf);
+modules/PX4Firmware/src/modules/simulator/simulator.h:	void write_airspeed_data(void *buf);
+modules/PX4Firmware/src/modules/simulator/simulator.h:		_airspeed(1),
+modules/PX4Firmware/src/modules/simulator/simulator.h:		_perf_airspeed(perf_alloc_once(PC_ELAPSED, "sim_airspeed_delay")),
+modules/PX4Firmware/src/modules/simulator/simulator.h:	simulator::Report<simulator::RawAirspeedData> _airspeed;
+modules/PX4Firmware/src/modules/simulator/simulator.h:	perf_counter_t _perf_airspeed;
+modules/PX4Firmware/src/modules/simulator/simulator_mavlink.cpp:	RawAirspeedData airspeed = {};
+modules/PX4Firmware/src/modules/simulator/simulator_mavlink.cpp:	airspeed.temperature = imu->temperature;
+modules/PX4Firmware/src/modules/simulator/simulator_mavlink.cpp:	airspeed.diff_pressure = imu->diff_pressure;
+modules/PX4Firmware/src/modules/simulator/simulator_mavlink.cpp:	write_airspeed_data(&airspeed);
+modules/PX4Firmware/src/modules/simulator/simulator_mavlink.cpp:	RawAirspeedData airspeed {};
+modules/PX4Firmware/src/modules/simulator/simulator_mavlink.cpp:	write_airspeed_data(&airspeed);
+modules/PX4Firmware/src/modules/uORB/objects_common.cpp:#include "topics/airspeed.h"
+modules/PX4Firmware/src/modules/uORB/objects_common.cpp:ORB_DEFINE(airspeed, struct airspeed_s);
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter_params.c: * when the plane has picked up enough airspeed and is ready to go into fixed wind mode.
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_airspeed_sub(-1),
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	memset(&_airspeed, 0, sizeof(_airspeed));
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_params_handles.mc_airspeed_min = param_find("VT_MC_ARSPD_MIN");
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_params_handles.mc_airspeed_max = param_find("VT_MC_ARSPD_MAX");
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_params_handles.mc_airspeed_trim = param_find("VT_MC_ARSPD_TRIM");
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:* Check for airspeed updates.
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:VtolAttitudeControl::vehicle_airspeed_poll()
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	orb_check(_airspeed_sub, &updated);
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:		orb_copy(ORB_ID(airspeed), _airspeed_sub , &_airspeed);
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	/* vtol mc mode min airspeed */
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	param_get(_params_handles.mc_airspeed_min, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_params.mc_airspeed_min = v;
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	/* vtol mc mode max airspeed */
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	param_get(_params_handles.mc_airspeed_max, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_params.mc_airspeed_max = v;
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	/* vtol mc mode trim airspeed */
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	param_get(_params_handles.mc_airspeed_trim, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_params.mc_airspeed_trim = v;
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	/* vtol total airspeed estimate low pass gain */
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:	_airspeed_sub          = orb_subscribe(ORB_ID(airspeed));
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:		vehicle_airspeed_poll();
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_type.h:	float mc_airspeed_min;		// min airspeed in multicoper mode (including prop-wash)
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_type.h:	float mc_airspeed_trim;		// trim airspeed in multicopter mode
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_type.h:	float mc_airspeed_max;		// max airpseed in multicopter mode
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_type.h:	float arsp_lp_gain;			// total airspeed estimate low pass gain
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_type.h:	struct airspeed_s 				*_airspeed;					// airspeed
+modules/PX4Firmware/src/modules/vtol_att_control/standard.h:		float airspeed_blend;
+modules/PX4Firmware/src/modules/vtol_att_control/standard.h:		float airspeed_trans;
+modules/PX4Firmware/src/modules/vtol_att_control/standard.h:		param_t airspeed_blend;
+modules/PX4Firmware/src/modules/vtol_att_control/standard.h:		param_t airspeed_trans;
+modules/PX4Firmware/src/modules/vtol_att_control/standard.h:	float _airspeed_trans_blend_margin;
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	_airspeed_trans_blend_margin(0.0f)
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	_params_handles_standard.airspeed_blend = param_find("VT_ARSP_BLEND");
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	_params_handles_standard.airspeed_trans = param_find("VT_ARSP_TRANS");
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	/* airspeed at which we should switch to fw mode */
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	param_get(_params_handles_standard.airspeed_trans, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	_params_standard.airspeed_trans = math::constrain(v, 1.0f, 20.0f);
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	/* airspeed at which we start blending mc/fw controls */
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	param_get(_params_handles_standard.airspeed_blend, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	_params_standard.airspeed_blend = math::constrain(v, 0.0f, 20.0f);
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:	_airspeed_trans_blend_margin = _params_standard.airspeed_trans - _params_standard.airspeed_blend;
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:			if ((_airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans &&
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:		if (_airspeed_trans_blend_margin > 0.0f &&
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:		    _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_blend &&
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:			float weight = 1.0f - fabsf(_airspeed->indicated_airspeed_m_s - _params_standard.airspeed_blend) /
+modules/PX4Firmware/src/modules/vtol_att_control/standard.cpp:				       _airspeed_trans_blend_margin;
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_type.cpp:	_airspeed = _attc->get_airspeed();
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:#include <uORB/topics/airspeed.h>
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:	struct airspeed_s 				*get_airspeed() {return &_airspeed;}
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:	int 	_airspeed_sub;			// airspeed subscription
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:	struct airspeed_s 				_airspeed;			// airspeed
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:		param_t mc_airspeed_min;
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:		param_t mc_airspeed_trim;
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:		param_t mc_airspeed_max;
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:	void 		vehicle_airspeed_poll();		// Check for changes in airspeed
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * Minimum airspeed in multicopter mode
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * Maximum airspeed in multicopter mode
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * Trim airspeed when in multicopter mode
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * This is the airflow over the control surfaces for which no airspeed scaling is applied in multicopter mode.
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * Total airspeed estimate low-pass filter gain
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * Gain for tuning the low-pass filter for the total airspeed estimate
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * Transition blending airspeed
+modules/PX4Firmware/src/modules/vtol_att_control/vtol_att_control_params.c: * Transition airspeed
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor_params.c: * when the plane has picked up enough airspeed and is ready to go into fixed wind mode.
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:#define ARSP_YAW_CTRL_DISABLE 7.0f	// airspeed at which we stop controlling yaw during a front transition
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	_params_handles_tiltrotor.airspeed_trans = param_find("VT_ARSP_TRANS");
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	_params_handles_tiltrotor.airspeed_blend_start = param_find("VT_ARSP_BLEND");
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	/* vtol airspeed at which it is ok to switch to fw mode */
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	param_get(_params_handles_tiltrotor.airspeed_trans, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	_params_tiltrotor.airspeed_trans = v;
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	/* vtol airspeed at which we start blending mc/fw controls */
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	param_get(_params_handles_tiltrotor.airspeed_blend_start, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	_params_tiltrotor.airspeed_blend_start = v;
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:	if (_params_tiltrotor.airspeed_trans < _params_tiltrotor.airspeed_blend_start + 1.0f) {
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:		_params_tiltrotor.airspeed_trans = _params_tiltrotor.airspeed_blend_start + 1.0f;
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:			// check if we have reached airspeed to switch to fw mode
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:			if (_airspeed->indicated_airspeed_m_s >= _params_tiltrotor.airspeed_trans || !_armed->armed) {
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:		if (_airspeed->indicated_airspeed_m_s >= _params_tiltrotor.airspeed_blend_start) {
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.cpp:		if (_airspeed->indicated_airspeed_m_s > ARSP_YAW_CTRL_DISABLE) {
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:#define ARSP_YAW_CTRL_DISABLE 7.0f	// airspeed at which we stop controlling yaw during a front transition
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_airspeed_tot(0.0f),
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_params_handles_tailsitter.airspeed_trans = param_find("VT_ARSP_TRANS");
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_params_handles_tailsitter.airspeed_blend_start = param_find("VT_ARSP_BLEND");
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	/* vtol airspeed at which it is ok to switch to fw mode */
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	param_get(_params_handles_tailsitter.airspeed_trans, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_params_tailsitter.airspeed_trans = v;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	/* vtol airspeed at which we start blending mc/fw controls */
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	param_get(_params_handles_tailsitter.airspeed_blend_start, &v);
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_params_tailsitter.airspeed_blend_start = v;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	if (_params_tailsitter.airspeed_trans < _params_tailsitter.airspeed_blend_start + 1.0f) {
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:		_params_tailsitter.airspeed_trans = _params_tailsitter.airspeed_blend_start + 1.0f;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:			// check if we have reached airspeed  and pitch angle to switch to TRANSITION P2 mode
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:			if ((_airspeed->indicated_airspeed_m_s >= _params_tailsitter.airspeed_trans
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:		if (_airspeed->indicated_airspeed_m_s <= _params_tailsitter.airspeed_trans) {
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:		if (_airspeed->indicated_airspeed_m_s > ARSP_YAW_CTRL_DISABLE) {
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:void Tailsitter::calc_tot_airspeed()
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	float airspeed = math::max(1.0f, _airspeed->indicated_airspeed_m_s);	// prevent numerical drama
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	float eta = (1.0f / (1 + expf(-0.4f * power_factor * airspeed)) - 0.5f) * 2.0f;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	// calculate induced airspeed by propeller
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	float v_ind = (airspeed / eta - airspeed) * 2.0f;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	// calculate total airspeed
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	float airspeed_raw = airspeed + v_ind;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_airspeed_tot = _params->arsp_lp_gain * (_airspeed_tot - airspeed_raw) + airspeed_raw;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	// scale around tuning airspeed
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	float airspeed;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	calc_tot_airspeed();	// estimate air velocity seen by elevons
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	// if airspeed is not updating, we assume the normal average speed
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	if (bool nonfinite = !PX4_ISFINITE(_airspeed->indicated_airspeed_m_s) ||
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:			     hrt_elapsed_time(&_airspeed->timestamp) > 1e6) {
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:		airspeed = _params->mc_airspeed_trim;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:		airspeed = _airspeed_tot;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:		airspeed = math::constrain(airspeed, _params->mc_airspeed_min, _params->mc_airspeed_max);
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_vtol_vehicle_status->airspeed_tot = airspeed;	// save value for logging
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	float airspeed_scaling = _params->mc_airspeed_trim / ((airspeed < _params->mc_airspeed_min) ? _params->mc_airspeed_min :
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:				 airspeed);
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.cpp:	_actuators_mc_in->control[1] = math::constrain(_actuators_mc_in->control[1] * airspeed_scaling * airspeed_scaling,
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.h:		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.h:		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.h:		param_t airspeed_trans;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.h:		param_t airspeed_blend_start;
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.h:	float _airspeed_tot; 		/** speed estimation for propwash controlled surfaces */
+modules/PX4Firmware/src/modules/vtol_att_control/tailsitter.h:	void calc_tot_airspeed();
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.h:		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.h:		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.h:		param_t airspeed_trans;
+modules/PX4Firmware/src/modules/vtol_att_control/tiltrotor.h:		param_t airspeed_blend_start;
+modules/PX4Firmware/posix-configs/SITL/init/rcS_gazebo_plane:measairspeedsim start
+modules/PX4Firmware/posix-configs/SITL/init/rcS_gazebo_standard_vtol:measairspeedsim start
+modules/PX4Firmware/posix-configs/SITL/init/rcS_gazebo_tailsitter:measairspeedsim start
+modules/PX4Firmware/posix-configs/SITL/init/rc.fixed_wing:measairspeedsim start
+modules/PX4Firmware/Tools/mavlink_px4.py:        def __init__(self, airspeed, groundspeed, heading, throttle, alt, climb):
+modules/PX4Firmware/Tools/mavlink_px4.py:                self._fieldnames = ['airspeed', 'groundspeed', 'heading', 'throttle', 'alt', 'climb']
+modules/PX4Firmware/Tools/mavlink_px4.py:                self.airspeed = airspeed
+modules/PX4Firmware/Tools/mavlink_px4.py:                return MAVLink_message.pack(self, mav, 20, struct.pack('<ffffhH', self.airspeed, self.groundspeed, self.alt, self.climb, self.heading, self.throttle))
+modules/PX4Firmware/Tools/mavlink_px4.py:                aspd_error                : Current airspeed error in meters/second (float)
+modules/PX4Firmware/Tools/mavlink_px4.py:                aspd_error                : Current airspeed error in meters/second (float)
+modules/PX4Firmware/Tools/mavlink_px4.py:        def vfr_hud_encode(self, airspeed, groundspeed, heading, throttle, alt, climb):
+modules/PX4Firmware/Tools/mavlink_px4.py:                airspeed                  : Current airspeed in m/s (float)
+modules/PX4Firmware/Tools/mavlink_px4.py:                msg = MAVLink_vfr_hud_message(airspeed, groundspeed, heading, throttle, alt, climb)
+modules/PX4Firmware/Tools/mavlink_px4.py:        def vfr_hud_send(self, airspeed, groundspeed, heading, throttle, alt, climb):
+modules/PX4Firmware/Tools/mavlink_px4.py:                airspeed                  : Current airspeed in m/s (float)
+modules/PX4Firmware/Tools/mavlink_px4.py:                return self.send(self.vfr_hud_encode(airspeed, groundspeed, heading, throttle, alt, climb))
+modules/PX4Firmware/Tools/sdlog2/logconv.m:    %add GPS total airspeed here
+modules/PX4Firmware/msg/airspeed.msg:float32 indicated_airspeed_m_s		# indicated airspeed in meters per second, -1 if unknown
+modules/PX4Firmware/msg/airspeed.msg:float32 true_airspeed_m_s		# true filtered airspeed in meters per second, -1 if unknown
+modules/PX4Firmware/msg/airspeed.msg:float32 true_airspeed_unfiltered_m_s	# true airspeed in meters per second, -1 if unknown
+modules/PX4Firmware/msg/control_state.msg:float32 airspeed		# Airspeed, estimated
+modules/PX4Firmware/msg/control_state.msg:bool airspeed_valid		# False: Non-finite values or non-updating sensor
+modules/PX4Firmware/msg/vehicle_status.msg:bool condition_airspeed_valid			# set to true by the commander app if there is a valid airspeed measurement available
+modules/PX4Firmware/msg/tecs_status.msg:float32 airspeedSp
+modules/PX4Firmware/msg/tecs_status.msg:float32 airspeed_filtered
+modules/PX4Firmware/msg/tecs_status.msg:float32 airspeedDerivativeSp
+modules/PX4Firmware/msg/tecs_status.msg:float32 airspeedDerivative
+modules/PX4Firmware/msg/hil_sensor.msg:float32 differential_pressure_filtered_pa	# Low pass filtered airspeed sensor differential pressure reading
+modules/PX4Firmware/msg/hil_sensor.msg:float32 differential_pressure1_filtered_pa	# Low pass filtered airspeed sensor differential pressure reading
+modules/PX4Firmware/msg/vtol_vehicle_status.msg:float32 airspeed_tot			# Estimated airspeed over control surfaces
+modules/PX4Firmware/msg/sensor_combined.msg:float32[3] differential_pressure_filtered_pa	# Low pass filtered airspeed sensor differential pressure reading
+modules/PX4Firmware/msg/ekf2_innovations.msg:float32 airspeed_innov	# airspeed innovation
+modules/PX4Firmware/msg/ekf2_innovations.msg:float32 airspeed_innov_var	# Airspeed innovation variance
+modules/PX4Firmware/msg/vehicle_command.msg:uint32 VEHICLE_CMD_NAV_TAKEOFF = 22			# Takeoff from ground / hand |Minimum pitch (if airspeed sensor present), desired pitch without sensor| Empty| Empty| Yaw angle (if magnetometer present), ignored without magnetometer| Latitude| Longitude| Altitude| 
+modules/PX4Firmware/msg/vehicle_command.msg:uint32 VEHICLE_CMD_NAV_VTOL_TAKEOFF = 84		# Takeoff from ground / hand and transition to fixed wing |Minimum pitch (if airspeed sensor present), desired pitch without sensor| Empty| Empty| Yaw angle (if magnetometer present), ignored without magnetometer| Latitude| Longitude| Altitude|
+modules/PX4Firmware/ROMFS/px4fmu_test/init.d/rcS:if meas_airspeed start
+modules/PX4Firmware/ROMFS/px4fmu_test/init.d/rcS:	if ets_airspeed start
+modules/PX4Firmware/ROMFS/px4fmu_test/init.d/rcS:		if ets_airspeed start -b 1
+modules/PX4Firmware/ROMFS/px4fmu_common/init.d/rc.sensors:		if meas_airspeed start -b 2
+modules/PX4Firmware/ROMFS/px4fmu_common/init.d/rc.sensors:if meas_airspeed start
+modules/PX4Firmware/ROMFS/px4fmu_common/init.d/rc.sensors:	if ets_airspeed start
+modules/PX4Firmware/ROMFS/px4fmu_common/init.d/rc.sensors:		if ets_airspeed start -b 1
+modules/PX4Firmware/makefiles/posix/config_posix_default.mk:MODULES		+= platforms/posix/drivers/airspeedsim
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_multiplatform.mk:MODULES		+= drivers/airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_multiplatform.mk:MODULES		+= drivers/ets_airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_multiplatform.mk:MODULES		+= drivers/meas_airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_test.mk:MODULES		+= drivers/airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_test.mk:MODULES		+= drivers/ets_airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_test.mk:MODULES		+= drivers/meas_airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_default.mk:MODULES		+= drivers/airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_default.mk:MODULES		+= drivers/ets_airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v2_default.mk:MODULES		+= drivers/meas_airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v1_default.mk:MODULES		+= drivers/airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v1_default.mk:MODULES		+= drivers/ets_airspeed
+modules/PX4Firmware/makefiles/nuttx/config_px4fmu-v1_default.mk:MODULES		+= drivers/meas_airspeed
+modules/PX4Firmware/cmake/configs/posix_sitl_default.cmake:	platforms/posix/drivers/airspeedsim
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v1_default.cmake:	drivers/airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v1_default.cmake:	drivers/ets_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v1_default.cmake:	drivers/meas_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v4_default.cmake:	drivers/airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v4_default.cmake:	drivers/ets_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v4_default.cmake:	drivers/meas_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_mindpx-v2_default.cmake:	drivers/airspeed
+modules/PX4Firmware/cmake/configs/nuttx_mindpx-v2_default.cmake:	drivers/ets_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_mindpx-v2_default.cmake:	drivers/meas_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v4pro_default.cmake:	drivers/airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v4pro_default.cmake:	drivers/ets_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v4pro_default.cmake:	drivers/meas_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake:	drivers/airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake:	drivers/ets_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake:	drivers/meas_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v2_default.cmake:	drivers/airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v2_default.cmake:	drivers/ets_airspeed
+modules/PX4Firmware/cmake/configs/nuttx_px4fmu-v2_default.cmake:	drivers/meas_airspeed
+modules/PX4Firmware/cmake/configs/posix_sitl_ekf2.cmake:	platforms/posix/drivers/airspeedsim
+modules/mavlink/pymavlink/tools/mavplayback.py:            self.fdm.set('vcas', msg.airspeed, units='mps')
+Binary file modules/mavlink/pymavlink/generator/javascript/test/capture.mavlink matches
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/ardupilotmega.xml:      <field name="EAS2TAS" type="float">Estimated to true airspeed ratio</field>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:        <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:        <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor [rad]</param>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:        <param index="3">Desired ground speed at release time. This can be overriden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.</param>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <field type="float" name="aspd_error">Current airspeed error in meters/second</field>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <field type="float" name="airspeed">Current airspeed in m/s</field>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <description>DEPRECATED PACKET! Suffers from missing airspeed fields and singularities due to Euler angles. Please use HIL_STATE_QUATERNION instead. Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <field type="float" name="diff_pressure">Differential pressure (airspeed) in millibar</field>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <field type="uint16_t" name="ind_airspeed">Indicated airspeed, expressed as m/s * 100</field>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <field type="uint16_t" name="true_airspeed">True airspeed, expressed as m/s * 100</field>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <field type="float" name="airspeed">Airspeed, set to -1 if unknown</field>
+modules/mavlink/pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml:      <field name="tas_ratio" type="float">True airspeed innovation test ratio</field>
+modules/mavlink/pymavlink/mavextra.py:def airspeed(VFR_HUD, ratio=None, used_ratio=None, offset=None):
+modules/mavlink/pymavlink/mavextra.py:    '''recompute airspeed with a different ARSPD_RATIO'''
+modules/mavlink/pymavlink/mavextra.py:    if hasattr(VFR_HUD,'airspeed'):
+modules/mavlink/pymavlink/mavextra.py:        airspeed = VFR_HUD.airspeed
+modules/mavlink/pymavlink/mavextra.py:        airspeed = VFR_HUD.Airspeed
+modules/mavlink/pymavlink/mavextra.py:    airspeed_pressure = (airspeed**2) / used_ratio
+modules/mavlink/pymavlink/mavextra.py:        airspeed_pressure += offset
+modules/mavlink/pymavlink/mavextra.py:        if airspeed_pressure < 0:
+modules/mavlink/pymavlink/mavextra.py:            airspeed_pressure = 0
+modules/mavlink/pymavlink/mavextra.py:    airspeed = sqrt(airspeed_pressure * ratio)
+modules/mavlink/pymavlink/mavextra.py:    return airspeed
+modules/mavlink/pymavlink/mavextra.py:def airspeed_ratio(VFR_HUD):
+modules/mavlink/pymavlink/mavextra.py:    '''recompute airspeed with a different ARSPD_RATIO'''
+modules/mavlink/pymavlink/mavextra.py:    airspeed_pressure = (VFR_HUD.airspeed**2) / ratio
+modules/mavlink/pymavlink/mavextra.py:    airspeed = sqrt(airspeed_pressure * ratio)
+modules/mavlink/pymavlink/mavextra.py:    return airspeed
+modules/mavlink/pymavlink/mavextra.py:def airspeed_voltage(VFR_HUD, ratio=None):
+modules/mavlink/pymavlink/mavextra.py:    '''back-calculate the voltage the airspeed sensor must have seen'''
+modules/mavlink/pymavlink/mavextra.py:    airspeed_pressure = (pow(VFR_HUD.airspeed,2)) / used_ratio
+modules/mavlink/pymavlink/mavextra.py:    raw = airspeed_pressure + offset
+modules/mavlink/pymavlink/mavextra.py:def airspeed_energy_error(NAV_CONTROLLER_OUTPUT, VFR_HUD):
+modules/mavlink/pymavlink/mavextra.py:    '''return airspeed energy error matching APM internals
+modules/mavlink/pymavlink/mavextra.py:    aspeed_cm = VFR_HUD.airspeed*100
+modules/mavlink/pymavlink/mavextra.py:    target_airspeed = NAV_CONTROLLER_OUTPUT.aspd_error + aspeed_cm
+modules/mavlink/pymavlink/mavextra.py:    airspeed_energy_error = ((target_airspeed*target_airspeed) - (aspeed_cm*aspeed_cm))*0.00005
+modules/mavlink/pymavlink/mavextra.py:    return airspeed_energy_error
+modules/mavlink/pymavlink/mavextra.py:    aspeed_energy_error = airspeed_energy_error(NAV_CONTROLLER_OUTPUT, VFR_HUD)
+modules/mavlink/pymavlink/mavextra.py:def airspeed_estimate(GLOBAL_POSITION_INT,WIND):
+modules/mavlink/pymavlink/mavextra.py:    '''estimate airspeed'''
+modules/mavlink/pymavlink/mavextra.py:    airspeed = (ground + wind3d).length()
+modules/mavlink/pymavlink/mavextra.py:    return airspeed
+modules/mavlink/pymavlink/fgFDM.py:        self.mapping.add('vcas', units='fps')               # calibrated airspeed
+modules/mavlink/message_definitions/v1.0/matrixpilot.xml:      <description>The airspeed measured by sensors and IMU</description>
+modules/mavlink/message_definitions/v1.0/matrixpilot.xml:      <field type="int16_t" name="airspeed_imu">Airspeed estimate from IMU, cm/s</field>
+modules/mavlink/message_definitions/v1.0/matrixpilot.xml:      <field type="int16_t" name="airspeed_pitot">Pitot measured forward airpseed, cm/s</field>
+modules/mavlink/message_definitions/v1.0/matrixpilot.xml:      <field type="int16_t" name="airspeed_hot_wire">Hot wire anenometer measured airspeed, cm/s</field>
+modules/mavlink/message_definitions/v1.0/matrixpilot.xml:      <field type="int16_t" name="airspeed_ultrasonic">Ultrasonic measured airspeed, cm/s</field>
+modules/mavlink/message_definitions/v1.0/ASLUAV.xml:      <field type="float" name="vSinkExp" units="m/s">Expected sink rate at current airspeed, roll and throttle</field>
+modules/mavlink/message_definitions/v1.0/ardupilotmega.xml:      <field type="float" name="EAS2TAS">Estimated to true airspeed ratio.</field>
+modules/mavlink/message_definitions/v1.0/ardupilotmega.xml:      <field type="float" name="airspeed_variance">Airspeed variance.</field>
+modules/mavlink/message_definitions/v1.0/common.xml:        <param index="1" label="Pitch">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
+modules/mavlink/message_definitions/v1.0/common.xml:        <param index="1" label="Pitch" units="rad">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
+modules/mavlink/message_definitions/v1.0/common.xml:        <param index="6" label="Compmot or Airspeed" minValue="0" maxValue="2" increment="1">1: APM: compass/motor interference calibration (PX4: airspeed calibration, deprecated), 2: airspeed calibration</param>
+modules/mavlink/message_definitions/v1.0/common.xml:        <param index="3" label="Ground Speed" minValue="-1">Desired ground speed at release time. This can be overridden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.</param>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="float" name="aspd_error" units="m/s">Current airspeed error</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="float" name="airspeed" units="m/s">Current indicated airspeed (IAS).</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <deprecated since="2013-07" replaced_by="HIL_STATE_QUATERNION">Suffers from missing airspeed fields and singularities due to Euler angles</deprecated>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="float" name="diff_pressure" units="mbar">Differential pressure (airspeed)</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="uint16_t" name="ind_airspeed" units="cm/s">Indicated airspeed</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="uint16_t" name="true_airspeed" units="cm/s">True airspeed</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="float" name="airspeed" units="m/s">Airspeed, set to -1 if unknown</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="float" name="tas_ratio">True airspeed innovation test ratio</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="uint8_t" name="airspeed" units="m/s">airspeed</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="uint8_t" name="airspeed_sp" units="m/s">airspeed setpoint</field>
+modules/mavlink/message_definitions/v1.0/common.xml:      <field type="int8_t" name="temperature_air" units="degC">Air temperature (degrees C) from airspeed sensor</field>
+APMrover2/Parameters.cpp:    AP_SUBGROUPINFO(airspeed, "ARSPD", 37, ParametersG2, AP_Airspeed),
+APMrover2/Parameters.cpp:    airspeed(),
+APMrover2/Rover.cpp:    SCHED_TASK(read_airspeed,          10,    100),
+APMrover2/Rover.h:    void read_airspeed();
+APMrover2/sensors.cpp:  ask airspeed sensor for a new value, duplicated from plane
+APMrover2/sensors.cpp:void Rover::read_airspeed(void)
+APMrover2/sensors.cpp:    g2.airspeed.update(should_log(MASK_LOG_IMU));
+APMrover2/Parameters.h:    AP_Airspeed airspeed;
+APMrover2/system.cpp:    g2.airspeed.init();
+
+libraries/AP_HAL_SITL/sitl_airspeed.cpp:  This simulates an analog airspeed sensor
+libraries/AP_HAL_SITL/SITL_State.h:    // simulated airspeed, sonar and battery monitor
+modules/PX4Firmware/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp: * Driver for a simulated airspeed sensor.

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -5,6 +5,7 @@
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Math/AP_Math.h>
+#include <iostream>
 
 class AP_Airspeed_Backend;
 
@@ -63,6 +64,7 @@ public:
 
     // return the unfiltered airspeed in m/s
     float get_raw_airspeed(uint8_t i) const {
+        //std::cout<<"unfiltered airspeed in m/s = "<<state[i].raw_airspeed<<std::endl;
         return state[i].raw_airspeed;
     }
     float get_raw_airspeed(void) const { return get_raw_airspeed(primary); }

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -5,7 +5,6 @@
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Math/AP_Math.h>
-#include <iostream>
 
 class AP_Airspeed_Backend;
 
@@ -64,7 +63,6 @@ public:
 
     // return the unfiltered airspeed in m/s
     float get_raw_airspeed(uint8_t i) const {
-        //std::cout<<"unfiltered airspeed in m/s = "<<state[i].raw_airspeed<<std::endl;
         return state[i].raw_airspeed;
     }
     float get_raw_airspeed(void) const { return get_raw_airspeed(primary); }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -1,8 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#include <iostream>
-using namespace std;
 
 #include "AP_HAL_SITL.h"
 #include "AP_HAL_SITL_Namespace.h"
@@ -437,7 +435,6 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
 
         case SITL::SITL::WIND_TYPE_NO_LIMIT:
         default:
-            cout<<"wind_test"<<_sitl->wind_type_test<<endl;
             break;
         }
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -1,6 +1,8 @@
 #include <AP_HAL/AP_HAL.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <iostream>
+using namespace std;
 
 #include "AP_HAL_SITL.h"
 #include "AP_HAL_SITL_Namespace.h"
@@ -435,6 +437,7 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
 
         case SITL::SITL::WIND_TYPE_NO_LIMIT:
         default:
+            cout<<"wind_test"<<_sitl->wind_type_test<<endl;
             break;
         }
 

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -90,10 +90,7 @@ public:
     static float add_clogged(float airspeed, float fault);
     static float add_sum(float airspeed, float fault);
     static float add_multiply(float airspeed, float fault);
-    static float _add_fault (float airspeed, float fault, float(*func)(float, float))
-    {
-        return func(airspeed, fault);
-    }
+    static float add_fault (float airspeed, float fault, float(*func)(float, float));
 
 private:
     void _parse_command_line(int argc, char * const argv[]);
@@ -147,9 +144,9 @@ private:
                      double yaw, bool have_lock);
     void _update_airspeed(float airspeed);
     //arspd fault
-    void _get_arspd_fault();
+    //void _get_arspd_fault();
     //float _get_arspd_fault(float airspeed);
-    void _get_arspd_fault(float airspeed);
+
     float _get_arspd_fault(float airspeed, int fault_type, float fault);
 
     void _update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *d, uint8_t instance);

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -4,6 +4,10 @@
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
+#ifndef AIRSPEED_MAX_SENSORS
+#define AIRSPEED_MAX_SENSORS 2
+#endif
+
 #include "AP_HAL_SITL.h"
 #include "AP_HAL_SITL_Namespace.h"
 #include "HAL_SITL_Class.h"
@@ -41,7 +45,7 @@ public:
         ArduPlane,
         ArduSub
     };
-
+    
     int gps_pipe(void);
     int gps2_pipe(void);
     ssize_t gps_read(int fd, void *buf, size_t count);
@@ -71,6 +75,8 @@ public:
     uint16_t voltage2_pin_value;  // pin 15
     uint16_t current2_pin_value;  // pin 14
 
+    SITL::arspd_data sensors[AIRSPEED_MAX_SENSORS];
+
     // paths for UART devices
     const char *_uart_path[7] {
         "tcp:0:wait",
@@ -86,11 +92,6 @@ public:
     static bool parse_home(const char *home_str,
                            Location &loc,
                            float &yaw_degrees);
-
-    static float add_clogged(float airspeed, float fault);
-    static float add_sum(float airspeed, float fault);
-    static float add_multiply(float airspeed, float fault);
-    static float add_fault (float airspeed, float fault, float(*func)(float, float));
 
 private:
     void _parse_command_line(int argc, char * const argv[]);
@@ -143,11 +144,9 @@ private:
                      double speedN, double speedE, double speedD,
                      double yaw, bool have_lock);
     void _update_airspeed(float airspeed);
-    //arspd fault
-    //void _get_arspd_fault();
-    //float _get_arspd_fault(float airspeed);
-
-    float _get_arspd_fault(float airspeed, int fault_type, float fault);
+    //airspeed fault
+    float _get_arspd_fault(SITL::arspd_data& sensor, float airspeed);
+    void _arspd_data_init(SITL::arspd_data& sensor, int fault_type, float fault);
 
     void _update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *d, uint8_t instance);
     void _check_rc_input(void);

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -87,6 +87,14 @@ public:
                            Location &loc,
                            float &yaw_degrees);
 
+    static float add_clogged(float airspeed, float fault);
+    static float add_sum(float airspeed, float fault);
+    static float add_multiply(float airspeed, float fault);
+    static float _add_fault (float airspeed, float fault, float(*func)(float, float))
+    {
+        return func(airspeed, fault);
+    }
+
 private:
     void _parse_command_line(int argc, char * const argv[]);
     void _set_param_default(const char *parm);
@@ -140,6 +148,9 @@ private:
     void _update_airspeed(float airspeed);
     //arspd fault
     void _get_arspd_fault();
+    //float _get_arspd_fault(float airspeed);
+    void _get_arspd_fault(float airspeed);
+    float _get_arspd_fault(float airspeed, int fault_type, float fault);
 
     void _update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *d, uint8_t instance);
     void _check_rc_input(void);

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -138,6 +138,9 @@ private:
                      double speedN, double speedE, double speedD,
                      double yaw, bool have_lock);
     void _update_airspeed(float airspeed);
+    //arspd fault
+    void _get_arspd_fault();
+
     void _update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *d, uint8_t instance);
     void _check_rc_input(void);
     bool _read_rc_sitl_input();

--- a/libraries/AP_HAL_SITL/sitl_airspeed.cpp
+++ b/libraries/AP_HAL_SITL/sitl_airspeed.cpp
@@ -33,254 +33,80 @@ extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
 
-class test
+void SITL_State::_arspd_data_init(SITL::arspd_data& sensor, int fault_type, float fault)
 {
-public:
-    static test * getInstance()
-    {
-        if (!p_instance) {
-            p_instance = new test();
-        }
-        return p_instance;
-    }
-
-    void update_time()
-    {
-        first_prev_call_time = current_time();
-        second_prev_call_time = current_time();
-    }
-
-
-    float get_fault_clogged(float fault)
-    {
-        if (first_prev_call_time == 0) {
-            update_time();
-        }
-        first_arspd_fault += ((current_time() - first_prev_call_time)/1000.f)*(fault);
-        update_time();
-        return first_arspd_fault;
-    }
-
-private:
-    test()
-    {
-        first_arspd_fault = 0;
-        second_arspd_fault = 0;
-        first_prev_call_time = 0;
-        second_prev_call_time = 0;
-        is_first_call = true;
-        isSecondWasCalled = true;
-    };
-    static test * p_instance;
-    float first_arspd_fault;
-    float second_arspd_fault;
-    uint32_t first_prev_call_time;
-    uint32_t second_prev_call_time;
-    bool is_first_call;
-    bool isSecondWasCalled;
-};
-
-static uint32_t previos_call_time;
-static float fault_static = 0;
-static bool isFirstCall = true;
-
-/*static uint32_t previos_call_time2;
-static float fault_static2 = 0;
-static bool isFirstCall2 = true;*/
-
-float SITL_State::add_clogged(float airspeed, float fault)
-{
-    fault_static += ((current_time() - previos_call_time)/1000.f)*(fault);
-    return add_sum(airspeed, fault_static);
-}
-
-float SITL_State::add_sum(float airspeed, float fault)
-{
-    return airspeed + fault;
-}
-
-float SITL_State::add_multiply(float airspeed, float fault)
-{
-    return airspeed * fault;
-}
-
-float SITL_State::add_fault(float airspeed, float fault, float(*func)(float, float))
-{
-    return func(airspeed, fault);
-}
-
-typedef float(*func_fault)(float, float);
-
-func_fault func_type_fault[] =
-{
-    HALSITL::SITL_State::add_sum, HALSITL::SITL_State::add_multiply, HALSITL::SITL_State::add_clogged
-};
-
-float SITL_State::_get_arspd_fault(float airspeed, int fault_type, float fault)
-{
-    switch (fault_type) {
-
-        case MULTIPLY:
-            cout<<"ARSPD_FAULT_MULTIPLY"<<endl;
-            airspeed = SITL_State::add_fault(airspeed, fault, func_type_fault[fault_type - 1]);
-            break;
-
-        case CLOGGED:
-            cout<<"ARSPD_FAULT_CLOGGED"<<endl;
-
-            if (isFirstCall == true) {
-                previos_call_time = current_time();
-                isFirstCall = false;
-            }
-
-            airspeed = SITL_State::add_fault(airspeed, fault, func_type_fault[fault_type - 1]);
-            //previos_call_time = current_time();
-            break;
-
-        case CONST:
-            cout<<"ARPSD CONST"<<endl;
-            
-            break;
-            airspeed = SITL_State::add_fault(airspeed, fault, func_type_fault[fault_type - 1]);
-
-        default:
-            break;
-        }
-        if (fault_type != CLOGGED)
-            fault_static = 0;
-        previos_call_time = current_time();
-    return airspeed;
-}
-typedef struct
-{
-    int type;
-    float fault;
-    float clogged_fault;
-    uint32_t time_prev;
-} arspd_data;
-void arspd_data_init(arspd_data& sensor, int fault_type, float fault)
-{
-    if (sensor.type != fault_type) {
-        if (sensor.type == CLOGGED) {
+    if (sensor.fault_type != fault_type) {
+        if (sensor.fault_type == CLOGGED) {
             sensor.clogged_fault = 0;
-            sensor.time_prev = 0;
+            sensor.time_previos_call = 0;
         }
-            
-        sensor.type = fault_type;
+        sensor.fault_type = fault_type;
     }
 
     sensor.fault = fault;
 }
-void arspd_clogged(arspd_data& sensor);
-float get_arspd_fault(arspd_data& sensor, float airspeed)
-{
-    switch (sensor.type) {
+
+float SITL_State::_get_arspd_fault(SITL::arspd_data& sensor, float airspeed) {
+    
+    switch (sensor.fault_type) {
+
         case CONST:
             airspeed += sensor.fault;
             break;
+
         case MULTIPLY:
             airspeed *= sensor.fault;
             break;
+
         case CLOGGED:
-            arspd_clogged(sensor);
+            if (sensor.time_previos_call == 0)
+                sensor.time_previos_call = current_time();
+
+            sensor.clogged_fault += ((current_time() - sensor.time_previos_call)/1000.0f) * sensor.fault;
+            sensor.time_previos_call = current_time();
+
             airspeed += sensor.clogged_fault;
             break;
+
         default:
             break;
     }
     return airspeed;
 }
-
-void arspd_clogged(arspd_data& sensor)
-{
-    if (sensor.time_prev == 0)
-        sensor.time_prev = current_time();
-    sensor.clogged_fault += ((current_time() - sensor.time_prev)/1000.f)*(sensor.fault);
-    sensor.time_prev = current_time();
-}
-test* test::p_instance = nullptr;
-test* t = test::getInstance();
-static arspd_data first_sensor;
-//static arspd_data second_sensor;
 
 /*
   convert airspeed in m/s to an airspeed sensor value
  */
 void SITL_State::_update_airspeed(float airspeed)
 {
-    cout<<"CURRENT TIME= "<<current_time()<<"\n";
     const float airspeed_ratio = 1.9936f;
     const float airspeed_offset = 2013.0f;
 
+    _arspd_data_init(sensors[0], _sitl->arspd_fault_type, _sitl->arspd_fault_value);
+    _arspd_data_init(sensors[1], _sitl->arspd2_fault_type, _sitl->arspd2_fault_value);
 
-    arspd_data_init(first_sensor, _sitl->arspd_fault_type, _sitl->arspd_fault_value);
-    //arspd_clogged(p_arspd_data);
-    //cout<<"FROM ARSTRUCT type = "<<p_arspd_data.type<<endl;
-    cout<<"\nFROM STRUCT fault = "<<get_arspd_fault(first_sensor, airspeed)<<endl;
-    cout<<"\n"<<endl;
-
-    float true_airspeed = airspeed;
-    float airspeed2 = airspeed;
-    
-    //t->set(current_time());
-    cout<<"FAULT CLOGGED FROM TEST = "<<t->get_fault_clogged(_sitl->arspd_fault_value)<<endl;
-
-    //if (isFirstCall == false && _sitl->arspd_fault_type != CLOGGED)
-    //    previos_call_time = current_time();
-
-    /*if (isFirstCall2 == false && _sitl->arspd2_fault_type != CLOGGED)
-        previos_call_time2 = current_time();*/
-        
-    //if (_sitl->arspd_fault_type != 0)
-    //{
-        airspeed = _get_arspd_fault(airspeed, _sitl->arspd_fault_type , _sitl->arspd_fault_value);
-        cout<<"ARSPD2 VALUE FAULT TESTING = "<<airspeed<<endl;
-        cout<<"ARSPD CLEAR TESTING = "<<airspeed<<endl;
-    //}
-
-    /*if (_sitl->arspd2_fault_type != 0)
-    {
-        airspeed2 = _get_arspd_fault(airspeed2, _sitl->arspd2_fault_type , _sitl->arspd2_fault_value);
-        cout<<"ARSPD2 VALUE FAULT TESTING = "<<airspeed2<<endl;
-        cout<<"ARSPD CLEAR TESTING = "<<airspeed<<endl;
-    }*/
-    //previos_call_time = current_time();
-
-    
-
-
-    // switch for adding fault airspeed or airspeed2
-    /*if (_sitl->arspd_fault_type == 2)
-    {
-        //airspeed += _sitl->arspd_fault_value;
-        fault_static += SITL_State::add_fault(airspeed, _sitl->arspd_fault_value, func_type_fault[_sitl->arspd_fault_type]); //((current_time - previos_call_time)/1000)*(_sitl->arspd_fault_value);
-        previos_call_time = current_time;
-    }*/
-    //airspeed2 += _sitl->arspd_fault_value;
-
-    cout<<"PREVIOS FAULT VALUE = "<<fault_static<<endl;
-    //cout<<"CURR_TIME VALUE = "<<current_time<<endl;
+    float
+    airspeed2 = _get_arspd_fault(sensors[1], airspeed);
+    airspeed  = _get_arspd_fault(sensors[0], airspeed);
 
     // Check sensor failure
     airspeed = is_zero(_sitl->arspd_fail) ? airspeed : _sitl->arspd_fail;
     airspeed2 = is_zero(_sitl->arspd2_fail) ? airspeed2 : _sitl->arspd2_fail;
+    cout<<"\n";
     cout<<"arspd_fault_type ="<<(int)_sitl->arspd_fault_type<<endl;
     cout<<"arspd2_fault_type  = "<<(int)_sitl->arspd2_fault_type<<endl;
-    cout<<"ARSPD        = "<<airspeed<<endl;
-    cout<<"ARSPD2       = "<<airspeed2<<endl;
-    cout<<"ARSPD state  = "<<_sitl->state.airspeed<<endl;
-    cout<<"ARSPD true value ="<<true_airspeed<<endl;
+    cout<<"ARSPD VALUE  = "<<airspeed<<endl;
+    cout<<"ARSPD2 VALUE = "<<airspeed2<<endl;
     cout<<"ARSPD fault value ="<<_sitl->arspd_fault_value<<endl;
     cout<<"ARSPD2 fault value = "<<_sitl->arspd2_fault_value<<endl;
+    cout<<"ARSPD SENSOR FAULT ="<<sensors[0].clogged_fault<<endl;
+    cout<<"ARSPD2 SENSOR FAULT = "<<sensors[1].clogged_fault<<endl;
+    cout<<"\n";
 
-    //cout<<"ARSPD POLIMORF = "<<SITL_State::add_fault(true_airspeed, _sitl->arspd_fault_value, func_type_fault[_sitl->arspd_fault_type])<<endl;
-    
     // Add noise
     airspeed = airspeed + (_sitl->arspd_noise * rand_float());
     airspeed2 = airspeed2 + (_sitl->arspd_noise * rand_float());
     
-
-
     if (!is_zero(_sitl->arspd_fail_pressure)) {
         // compute a realistic pressure report given some level of trapper air pressure in the tube and our current altitude
         // algorithm taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure

--- a/libraries/AP_HAL_SITL/sitl_airspeed.cpp
+++ b/libraries/AP_HAL_SITL/sitl_airspeed.cpp
@@ -15,9 +15,6 @@
 #include "SITL_State.h"
 #include <SITL/SITL.h>
 #include <AP_Math/AP_Math.h>
-#include <iostream>
-#include <cstdlib>
-#include <ctime>
 
 #ifndef ENABLE
     #define ENABLE   0
@@ -92,16 +89,6 @@ void SITL_State::_update_airspeed(float airspeed)
     // Check sensor failure
     airspeed = is_zero(_sitl->arspd_fail) ? airspeed : _sitl->arspd_fail;
     airspeed2 = is_zero(_sitl->arspd2_fail) ? airspeed2 : _sitl->arspd2_fail;
-    cout<<"\n";
-    cout<<"arspd_fault_type ="<<(int)_sitl->arspd_fault_type<<endl;
-    cout<<"arspd2_fault_type  = "<<(int)_sitl->arspd2_fault_type<<endl;
-    cout<<"ARSPD VALUE  = "<<airspeed<<endl;
-    cout<<"ARSPD2 VALUE = "<<airspeed2<<endl;
-    cout<<"ARSPD fault value ="<<_sitl->arspd_fault_value<<endl;
-    cout<<"ARSPD2 fault value = "<<_sitl->arspd2_fault_value<<endl;
-    cout<<"ARSPD SENSOR FAULT ="<<sensors[0].clogged_fault<<endl;
-    cout<<"ARSPD2 SENSOR FAULT = "<<sensors[1].clogged_fault<<endl;
-    cout<<"\n";
 
     // Add noise
     airspeed = airspeed + (_sitl->arspd_noise * rand_float());
@@ -123,15 +110,13 @@ void SITL_State::_update_airspeed(float airspeed)
     float airspeed_pressure = (airspeed * airspeed) / airspeed_ratio;
     float airspeed2_pressure = (airspeed2 * airspeed2) / airspeed_ratio;
 
-    cout<<"pressure = "<<airspeed_pressure<<endl; cout<<"pressure = "<<airspeed2_pressure<<endl;
-
     // flip sign here for simulating reversed pitot/static connections
     if (_sitl->arspd_signflip) airspeed_pressure *= -1;
     if (_sitl->arspd_signflip) airspeed2_pressure *= -1;
 
     float airspeed_raw = airspeed_pressure + airspeed_offset;
     float airspeed2_raw = airspeed2_pressure + airspeed_offset;
-    cout<<"airspeed raw "<<airspeed_raw<<endl;
+
     if (airspeed_raw / 4 > 0xFFFF) {
         airspeed_pin_value = 0xFFFF;
         return;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -119,9 +119,11 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
     AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
     
-    AP_GROUPINFO("WIND_T_TEST", 58, SITL, wind_type_test, 0),
-    AP_GROUPINFO("TEST_ARSPD", 59, SITL, arspd_fault_value, 0),
-    AP_GROUPINFO("ARSPD_FT", 60, SITL, arspd_fault_type, 0),
+    AP_GROUPINFO("ARSPD_FT", 58, SITL, arspd_fault_type, SITL::ARSPD_FAULT_ENABLE),
+    AP_GROUPINFO("ARSPD2_FT", 59, SITL, arspd2_fault_type, SITL::ARSPD_FAULT_ENABLE),
+    AP_GROUPINFO("ARSPD_FV", 60, SITL, arspd_fault_value, 0),
+    AP_GROUPINFO("ARSPD2_FV", 61, SITL, arspd2_fault_value, 0),
+    
     
 
     AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag, 0),

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -112,7 +112,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD_SIGN",   9, SITL,  arspd_signflip, 0),
     AP_GROUPINFO("WIND_DIR_Z",  10, SITL,  wind_dir_z,     0),
     AP_GROUPINFO("ARSPD2_FAIL", 11, SITL,  arspd2_fail, 0),
-    AP_GROUPINFO("ARSPD2_FAILP",12, SITL,  arspd2_fail_pressure, 0),
+    AP_GROUPINFO("ARSPD2_FAIL_P",12, SITL,  arspd2_fail_pressure, 0),
     AP_GROUPINFO("ARSPD2_PITOT",13, SITL,  arspd2_fail_pitot_pressure, 0),
     AP_GROUPINFO("VICON_HSTLEN",14, SITL,  vicon_observation_history_length, 0),
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -112,7 +112,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD_SIGN",   9, SITL,  arspd_signflip, 0),
     AP_GROUPINFO("WIND_DIR_Z",  10, SITL,  wind_dir_z,     0),
     AP_GROUPINFO("ARSPD2_FAIL", 11, SITL,  arspd2_fail, 0),
-    AP_GROUPINFO("ARSPD2_FAIL_P",12, SITL,  arspd2_fail_pressure, 0),
+    AP_GROUPINFO("ARSPD2_FAILP",12, SITL,  arspd2_fail_pressure, 0),
     AP_GROUPINFO("ARSPD2_PITOT",13, SITL,  arspd2_fail_pitot_pressure, 0),
     AP_GROUPINFO("VICON_HSTLEN",14, SITL,  vicon_observation_history_length, 0),
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -118,6 +118,12 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),
     AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
     AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
+    
+    AP_GROUPINFO("WIND_T_TEST", 58, SITL, wind_type_test, 0),
+    AP_GROUPINFO("TEST_ARSPD", 59, SITL, arspd_fault_value, 0),
+    AP_GROUPINFO("ARSPD_FT", 60, SITL, arspd_fault_type, 0),
+    
+
     AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag, 0),
     AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag, 0),
     AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient, 0),

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -118,14 +118,6 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),
     AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
     AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
-    
-    AP_GROUPINFO("ARSPD_FT", 58, SITL, arspd_fault_type, SITL::ARSPD_FAULT_ENABLE),
-    AP_GROUPINFO("ARSPD2_FT", 59, SITL, arspd2_fault_type, SITL::ARSPD_FAULT_ENABLE),
-    AP_GROUPINFO("ARSPD_FV", 60, SITL, arspd_fault_value, 0),
-    AP_GROUPINFO("ARSPD2_FV", 61, SITL, arspd2_fault_value, 0),
-    
-    
-
     AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag, 0),
     AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag, 0),
     AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient, 0),
@@ -202,6 +194,11 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
 
     // @Path: ./SIM_ToneAlarm.cpp
     AP_SUBGROUPINFO(tonealarm_sim, "TA_", 57, SITL, ToneAlarm),
+    
+    AP_GROUPINFO("ARSPD_FT", 58, SITL, arspd_fault_type, SITL::ARSPD_FAULT_ENABLE),
+    AP_GROUPINFO("ARSPD2_FT", 59, SITL, arspd2_fault_type, SITL::ARSPD_FAULT_ENABLE),
+    AP_GROUPINFO("ARSPD_FV", 60, SITL, arspd_fault_value, 0),
+    AP_GROUPINFO("ARSPD2_FV", 61, SITL, arspd2_fault_value, 0),
 
     AP_GROUPEND
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -191,8 +191,9 @@ public:
     // airspeed fault control
     enum AirspeedFault {
         ARSPD_FAULT_ENABLE = 0,
+        ARSPD_FAULT_REMOVE,
+        ARSPD_FAULT_MULTIPLY,
         ARSPD_FAULT_CLOGGED,
-        ARSPD_FAULT_SMOOTHY,
         ARSPD_FAULT_CONST,
     };
     
@@ -210,8 +211,10 @@ public:
 
     AP_Float wind_type_test;
     //airspeed fault
-    AP_Int8  arspd_fault_type;
+    AP_Int8 arspd_fault_type;
     AP_Float arspd_fault_value;
+    AP_Int8 arspd2_fault_type;
+    AP_Float arspd2_fault_value;
 
     AP_Int16  baro_delay; // barometer data delay in ms
     AP_Int16  mag_delay; // magnetometer data delay in ms

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -23,6 +23,14 @@ struct float_array {
     uint16_t length;
     float *data;
 };
+
+
+struct arspd_data {
+    int fault_type;
+    float fault;
+    float clogged_fault;
+    uint32_t time_previos_call;
+};
     
 
 struct sitl_fdm {

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -191,10 +191,9 @@ public:
     // airspeed fault control
     enum AirspeedFault {
         ARSPD_FAULT_ENABLE = 0,
-        ARSPD_FAULT_REMOVE,
-        ARSPD_FAULT_MULTIPLY,
-        ARSPD_FAULT_CLOGGED,
         ARSPD_FAULT_CONST,
+        ARSPD_FAULT_MULTIPLY,
+        ARSPD_FAULT_CLOGGED
     };
     
     float wind_speed_active;

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -185,6 +185,15 @@ public:
         WIND_TYPE_SQRT = 0,
         WIND_TYPE_NO_LIMIT = 1,
         WIND_TYPE_COEF = 2,
+        WIND_TYPE_TEST = 3,
+    };
+
+    // airspeed fault control
+    enum AirspeedFault {
+        ARSPD_FAULT_ENABLE = 0,
+        ARSPD_FAULT_CLOGGED,
+        ARSPD_FAULT_SMOOTHY,
+        ARSPD_FAULT_CONST,
     };
     
     float wind_speed_active;
@@ -198,6 +207,11 @@ public:
     AP_Int8  wind_type; // enum WindLimitType
     AP_Float wind_type_alt;
     AP_Float wind_type_coef;
+
+    AP_Float wind_type_test;
+    //airspeed fault
+    AP_Int8  arspd_fault_type;
+    AP_Float arspd_fault_value;
 
     AP_Int16  baro_delay; // barometer data delay in ms
     AP_Int16  mag_delay; // magnetometer data delay in ms


### PR DESCRIPTION
Added features for simulating airspeed errors for two sensors
0. mode when the error is turned off.
1. constant displacement, that is, the real airspeed changes to a constant, a call with the sign - or + is possible.
2. air speed is multiplied by a constant
3. smoothly increasing error witch increasing with the time

simulator options:
ARPSD_FT [0,1,2,3] option number for the first sensor (primary)
ARPSD_FV value used to calculate airspeed error
ARPSD2_FT [0,1,2,3] option number for the second sensor
ARPSD2_FV value used to calculate airspeed error