### PR TITLE
AP_InertialSensor: default fast sampling on

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #ifndef HAL_DEFAULT_INS_FAST_SAMPLE
-#define HAL_DEFAULT_INS_FAST_SAMPLE 0
+#define HAL_DEFAULT_INS_FAST_SAMPLE 1
 #endif
 
 extern const AP_HAL::HAL& hal;


### PR DESCRIPTION
if we have a first IMU capable of fast sampling then we want it
enabled by default. This affects quite a few boards. I think it is better to default for all boards rather than add it per board. If the IMU is not capable of fast sampling then this is harmless.
