### PR TITLE
Copter: disable gcs failsafe by default

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -175,7 +175,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: Controls whether failsafe will be invoked (and what action to take) when connection with Ground station is lost for at least 5 seconds. NB. The GCS Failsafe is only active when RC_OVERRIDE is being used to control the vehicle.
     // @Values: 0:Disabled,1:Enabled always RTL,2:Enabled Continue with Mission in Auto Mode (Deprecated in 4.0+),3:Enabled always SmartRTL or RTL,4:Enabled always SmartRTL or Land,5:Enabled always land (4.0+ Only)
     // @User: Standard
-    GSCALAR(failsafe_gcs, "FS_GCS_ENABLE", FS_GCS_ENABLED_ALWAYS_RTL),
+    GSCALAR(failsafe_gcs, "FS_GCS_ENABLE", FS_GCS_DISABLED),
 
     // @Param: GPS_HDOP_GOOD
     // @DisplayName: GPS Hdop Good


### PR DESCRIPTION
This disables Copter's GCS failsafe by default.  This change is being made in response to beta testers' reports that it has been triggering unexpectly or causing pre-arm failures (I've noticed this myself).

I think it is safe to disable the GCS failsafe by default (it was enabled by default in 3.6.x and earlier) because nobody has been relying on it because it was not actually function.  It didn't do anything that the regular RC failsafe didn't already do.

FYI to @Pedals2Paddles