### PR TITLE
Wp_Nav: an easy way to correct speed reduce issue to avoid twitch

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -221,6 +221,7 @@ AC_PosControl::AC_PosControl(const AP_AHRS_View& ahrs, const AP_InertialNav& ina
     _flags.reset_rate_to_accel_z = true;
     _flags.freeze_ff_z = true;
     _flags.use_desvel_ff_z = true;
+    _flags.rqwpspd_reduced = false;
     _limit.pos_up = true;
     _limit.pos_down = true;
     _limit.vel_up = true;
@@ -1030,9 +1031,13 @@ void AC_PosControl::run_xy_controller(float dt)
         // Constrain _pos_error and target position
         // Constrain the maximum length of _vel_target to the maximum position correction velocity
         // TODO: replace the leash length with a user definable maximum position correction
-        if (limit_vector_length(_pos_error.x, _pos_error.y, _leash)) {
-            _pos_target.x = curr_pos.x + _pos_error.x;
-            _pos_target.y = curr_pos.y + _pos_error.y;
+        if (!_flags.rqwpspd_reduced) {
+        	// we just won't do this check when we try to reduce speed
+        	// in fact, I didn't find a better elegant idea yet
+            if (limit_vector_length(_pos_error.x, _pos_error.y, _leash)) {
+                _pos_target.x = curr_pos.x + _pos_error.x;
+                _pos_target.y = curr_pos.y + _pos_error.y;
+            }
         }
 
         _vel_target = sqrt_controller(_pos_error, kP, _accel_cms);

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1038,6 +1038,9 @@ void AC_PosControl::run_xy_controller(float dt)
                 _pos_target.x = curr_pos.x + _pos_error.x;
                 _pos_target.y = curr_pos.y + _pos_error.y;
             }
+        }else{
+        	// check if we have reduced to the target speed and clear the flag once we reached it
+        	if (_inav.get_speed_xy() < _speed_cms) _flags.rqwpspd_reduced =false;
         }
 
         _vel_target = sqrt_controller(_pos_error, kP, _accel_cms);

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -215,6 +215,10 @@ public:
     // clear desired velocity feed-forward in z axis
     void clear_desired_velocity_ff_z() { _flags.use_desvel_ff_z = false; }
 
+    // get and set function for the requested speed changed to reduced flag status
+    void set_rqwpspd_reduced(bool rqspd) { _flags.rqwpspd_reduced = rqspd; }
+    bool get_rqwpspd_reduced() { return _flags.rqwpspd_reduced; }
+
     // set desired acceleration in cm/s in xy axis
     void set_desired_accel_xy(float accel_lat_cms, float accel_lon_cms) { _accel_desired.x = accel_lat_cms; _accel_desired.y = accel_lon_cms; }
 
@@ -324,6 +328,7 @@ protected:
             uint16_t freeze_ff_z        : 1;    // 1 used to freeze velocity to accel feed forward for one iteration
             uint16_t use_desvel_ff_z    : 1;    // 1 to use z-axis desired velocity as feed forward into velocity step
             uint16_t vehicle_horiz_vel_override : 1; // 1 if we should use _vehicle_horiz_vel as our velocity process variable for one timestep
+            uint8_t  rqwpspd_reduced    : 1;    // true if the requested speed change to reduced in the nav control mission planning
     } _flags;
 
     // limit flags structure

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -215,9 +215,8 @@ public:
     // clear desired velocity feed-forward in z axis
     void clear_desired_velocity_ff_z() { _flags.use_desvel_ff_z = false; }
 
-    // get and set function for the requested speed changed to reduced flag status
+    // set function for the requested speed changed to reduced flag status
     void set_rqwpspd_reduced(bool rqspd) { _flags.rqwpspd_reduced = rqspd; }
-    bool get_rqwpspd_reduced() { return _flags.rqwpspd_reduced; }
 
     // set desired acceleration in cm/s in xy axis
     void set_desired_accel_xy(float accel_lat_cms, float accel_lon_cms) { _accel_desired.x = accel_lat_cms; _accel_desired.y = accel_lon_cms; }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -401,24 +401,12 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         // we are traveling fast in the opposite direction of travel to the waypoint so do not move the intermediate point
         _limited_speed_xy_cms = 0;
     }else{
-    	if(_pos_control.get_rqwpspd_reduced()){
-    		// reduced speed according to the mission requested
-    		if(dt > 0 && !reached_leash_limit) {
-                _limited_speed_xy_cms -= 2.0f * _track_accel * dt;
-    		}
-    		// clear this flag only when we get close to the track speed term limitation
-    		if(_limited_speed_xy_cms < _track_speed) {
-    			_limited_speed_xy_cms = _track_speed;
-    			_pos_control.set_rqwpspd_reduced(false);
-    		}
-    	} else {
-            // increase intermediate target point's velocity if not yet at the leash limit
-            if(dt > 0 && !reached_leash_limit) {
-                _limited_speed_xy_cms += 2.0f * _track_accel * dt;
-            }
-            // do not allow speed to be below zero or over top speed
-            _limited_speed_xy_cms = constrain_float(_limited_speed_xy_cms, 0.0f, _track_speed);
-    	}
+        // increase intermediate target point's velocity if not yet at the leash limit
+        if(dt > 0 && !reached_leash_limit) {
+            _limited_speed_xy_cms += 2.0f * _track_accel * dt;
+        }
+        // do not allow speed to be below zero or over top speed
+        _limited_speed_xy_cms = constrain_float(_limited_speed_xy_cms, 0.0f, _track_speed);
 
         // check if we should begin slowing down
         if (!_flags.fast_waypoint) {


### PR DESCRIPTION
Bug report and fix:

This is an easy way to avoid attitude discontinuity which I believe it's for all kind of vehicles in this project. I would show you more about this wp_nav speed control issue I found and met in the real fight below. All I mentioned later are tested in the latest master branch and all the released tag versions still have this problem definatly.

 You guys would easily met this issue if you change one of your waypoint speed and reduce the request speed in the mission. Then after this do_cmd waypoint take effect in SITL or real filght, the vehicle would definitely make a sudden brake just like the following figure shows.
![2019-12-23_193311](https://user-images.githubusercontent.com/26009293/71394975-e769da00-264e-11ea-91c9-fc9ae42cf81e.PNG)

I konw it's better to try to update the '_leash' in pos_control.cpp but I actually haven't find a proper way yet. Now, my method may not look elegant enough but it can indeed avoid this waypoint change to reduce speed issue from distance limitation check of '_leash' once we update the speed request from the mission planned.

I would attache two log files here if you guys would like to check what I met. Both are using a same simple waypoint planned from MissionPlanner. Please help me solve this issue if you have more elegant ways.

