### PR TITLE
SITL: Airspeed fault modes

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -4,6 +4,10 @@
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
+#ifndef AIRSPEED_MAX_SENSORS
+#define AIRSPEED_MAX_SENSORS 2
+#endif
+
 #include "AP_HAL_SITL.h"
 #include "AP_HAL_SITL_Namespace.h"
 #include "HAL_SITL_Class.h"
@@ -70,6 +74,8 @@ public:
     uint16_t current_pin_value;  // pin 12
     uint16_t voltage2_pin_value;  // pin 15
     uint16_t current2_pin_value;  // pin 14
+
+    SITL::arspd_data sensors[AIRSPEED_MAX_SENSORS];
 
     // paths for UART devices
     const char *_uart_path[7] {
@@ -138,6 +144,9 @@ private:
                      double speedN, double speedE, double speedD,
                      double yaw, bool have_lock);
     void _update_airspeed(float airspeed);
+    //airspeed fault
+    float _get_arspd_fault(SITL::arspd_data& sensor, float airspeed);
+    void _arspd_data_init(SITL::arspd_data& sensor, int fault_type, float fault);
     void _update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *d, uint8_t instance);
     void _check_rc_input(void);
     bool _read_rc_sitl_input();

--- a/libraries/AP_HAL_SITL/sitl_airspeed.cpp
+++ b/libraries/AP_HAL_SITL/sitl_airspeed.cpp
@@ -19,7 +19,49 @@
 extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
+void SITL_State::_arspd_data_init(SITL::arspd_data& sensor, int fault_type, float fault)
+{
+    if (sensor.fault_type != fault_type) {
+        if (sensor.fault_type == SITL::SITL::ARSPD_FAULT_CLOGGED) {
+            sensor.clogged_fault = 0;
+            sensor.time_previos_call = 0;
+        }
+        sensor.fault_type = fault_type;
+    }
 
+    sensor.fault = fault;
+}
+
+float SITL_State::_get_arspd_fault(SITL::arspd_data& sensor, float airspeed)
+{
+    switch (sensor.fault_type) {
+
+        case SITL::SITL::ARSPD_FAULT_ADD:
+            airspeed += sensor.fault;
+            break;
+
+        case SITL::SITL::ARSPD_FAULT_MULTIPLY:
+            airspeed *= sensor.fault;
+            break;
+
+        case SITL::SITL::ARSPD_FAULT_CLOGGED:
+            if (sensor.time_previos_call == 0)
+                sensor.time_previos_call = AP_HAL::millis();
+
+            sensor.clogged_fault += ((AP_HAL::millis() - sensor.time_previos_call)/1000.0f) * sensor.fault;
+            sensor.time_previos_call = AP_HAL::millis();
+
+            airspeed += sensor.clogged_fault;
+            break;
+
+        case SITL::SITL::ARSPD_FAULT_CONST:
+            airspeed = sensor.fault;
+
+        default:
+            break;
+    }
+    return airspeed;
+}
 /*
   convert airspeed in m/s to an airspeed sensor value
  */
@@ -28,11 +70,13 @@ void SITL_State::_update_airspeed(float airspeed)
     const float airspeed_ratio = 1.9936f;
     const float airspeed_offset = 2013.0f;
     
-    float airspeed2 = airspeed;
-
-    // Check sensor failure
-    airspeed = is_zero(_sitl->arspd_fail) ? airspeed : _sitl->arspd_fail;
-    airspeed2 = is_zero(_sitl->arspd2_fail) ? airspeed2 : _sitl->arspd2_fail;
+    _arspd_data_init(sensors[0], _sitl->arspd_fault_type, _sitl->arspd_fault_value);
+    _arspd_data_init(sensors[1], _sitl->arspd2_fault_type, _sitl->arspd2_fault_value);
+	
+    float
+    airspeed2 = _get_arspd_fault(sensors[1], airspeed);
+    airspeed  = _get_arspd_fault(sensors[0], airspeed);
+    
     // Add noise
     airspeed = airspeed + (_sitl->arspd_noise * rand_float());
     airspeed2 = airspeed2 + (_sitl->arspd_noise * rand_float());

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -75,7 +75,7 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("WIND_DELAY",    40, SITL,  wind_delay, 0),
     AP_GROUPINFO("MAG_OFS",       41, SITL,  mag_ofs, 0),
     AP_GROUPINFO("ACC2_RND",      42, SITL,  accel2_noise, 0),
-    AP_GROUPINFO("ARSPD_FAIL",    43, SITL,  arspd_fail, 0),
+    AP_GROUPINFO("ARSPD_FAULT",   43, SITL,  arspd_fault_value, 0),
     AP_GROUPINFO("GYR_SCALE",     44, SITL,  gyro_scale, 0),
     AP_GROUPINFO("ADSB_COUNT",    45, SITL,  adsb_plane_count, -1),
     AP_GROUPINFO("ADSB_RADIUS",   46, SITL,  adsb_radius_m, 10000),
@@ -106,12 +106,12 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("TEMP_TCONST",  3, SITL,  temp_tconst, 30),
     AP_GROUPINFO("TEMP_BFACTOR", 4, SITL,  temp_baro_factor, 0),
     AP_GROUPINFO("GPS_LOCKTIME", 5, SITL,  gps_lock_time, 0),
-    AP_GROUPINFO("ARSPD_FAIL_P", 6, SITL,  arspd_fail_pressure, 0),
+    AP_GROUPINFO("ARSPD_FAILP", 6, SITL,  arspd_fail_pressure, 0),
     AP_GROUPINFO("ARSPD_PITOT",  7, SITL,  arspd_fail_pitot_pressure, 0),
     AP_GROUPINFO("GPS_ALT_OFS",  8, SITL,  gps_alt_offset, 0),
     AP_GROUPINFO("ARSPD_SIGN",   9, SITL,  arspd_signflip, 0),
     AP_GROUPINFO("WIND_DIR_Z",  10, SITL,  wind_dir_z,     0),
-    AP_GROUPINFO("ARSPD2_FAIL", 11, SITL,  arspd2_fail, 0),
+    AP_GROUPINFO("ARSPD2_FAULT",11, SITL,  arspd2_fault_value, 0),
     AP_GROUPINFO("ARSPD2_FAILP",12, SITL,  arspd2_fail_pressure, 0),
     AP_GROUPINFO("ARSPD2_PITOT",13, SITL,  arspd2_fail_pitot_pressure, 0),
     AP_GROUPINFO("VICON_HSTLEN",14, SITL,  vicon_observation_history_length, 0),
@@ -194,6 +194,8 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
 
     // @Path: ./SIM_ToneAlarm.cpp
     AP_SUBGROUPINFO(tonealarm_sim, "TA_", 57, SITL, ToneAlarm),
+    AP_GROUPINFO("ARSPD_FT", 58, SITL, arspd_fault_type, SITL::ARSPD_FAULT_ENABLE),
+    AP_GROUPINFO("ARSPD2_FT", 59, SITL, arspd2_fault_type, SITL::ARSPD_FAULT_ENABLE),
 
     AP_GROUPEND
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -23,7 +23,14 @@ struct float_array {
     uint16_t length;
     float *data;
 };
-    
+
+// struct for calculated airspeed fault
+struct arspd_data {
+    int fault_type;
+    float fault;
+    float clogged_fault;
+    uint32_t time_previos_call;
+};   
 
 struct sitl_fdm {
     // this is the structure passed between FDM models and the main SITL code
@@ -187,6 +194,15 @@ public:
         WIND_TYPE_COEF = 2,
     };
     
+    // airspeed fault control
+    enum AirspeedFault {
+        ARSPD_FAULT_ENABLE = 0,
+        ARSPD_FAULT_CONST,
+        ARSPD_FAULT_ADD,
+        ARSPD_FAULT_CLOGGED,
+        ARSPD_FAULT_MULTIPLY,
+    };
+
     float wind_speed_active;
     float wind_direction_active;
     float wind_dir_z_active;
@@ -195,9 +211,16 @@ public:
     AP_Float wind_turbulance;
     AP_Float gps_drift_alt;
     AP_Float wind_dir_z;
+
     AP_Int8  wind_type; // enum WindLimitType
     AP_Float wind_type_alt;
     AP_Float wind_type_coef;
+
+    //airspeed fault
+    AP_Int8 arspd_fault_type; // enum AirspeedFault
+    AP_Float arspd_fault_value;
+    AP_Int8 arspd2_fault_type;
+    AP_Float arspd2_fault_value;
 
     AP_Int16  baro_delay; // barometer data delay in ms
     AP_Int16  mag_delay; // magnetometer data delay in ms


### PR DESCRIPTION
- ARSPD_FAULT_ENABLE 
- ARSPD_FAULT_CONST,
- ARSPD_FAULT_ADD,
- ARSPD_FAULT_CLOGGED,
- ARSPD_FAULT_MULTIPLY

control occurs by setting the parameters of the simulator
SIM_ARSPD_FAIL etermines the value of the airspeed error for the main sensor
SIM_ARSPD_FT etermines the mode by which airspeed will change
the same is true for the second sensor with the addition
SIM_ARSPD2_FAIL
SIM_ARSPD2_FT

New streamlined modes for managing airspeed errors. At the moment, it is designed for 2 sensors but can be easily scaled for a larger number.

the existing version of the error that allowed to set the constant value of the airspeed error is included in the mode ARSPD_FAULT_CONST

It will be useful to further improve the detection of malfunction of the airspeed sensor.