### PR TITLE
Rover: Add a line-following mode [WIP]

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -632,6 +632,11 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FS_OPTIONS", 48, ParametersG2, fs_options, 0),
 
+
+    // @Group: IR_
+    // @Path: ../libraries/AR_IR/AR_IR_Sensor.cpp
+    AP_SUBGROUPINFO(ir_sensor, "IR_", 49, ParametersG2, AR_IR),
+
     AP_GROUPEND
 };
 
@@ -681,7 +686,8 @@ ParametersG2::ParametersG2(void)
     windvane(),
     airspeed(),
     wp_nav(attitude_control, rover.L1_controller),
-    sailboat()
+    sailboat(),
+    ir_sensor()
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -6,6 +6,7 @@
 #include "AC_Sprayer/AC_Sprayer.h"
 #include "AP_Gripper/AP_Gripper.h"
 #include "AP_Rally.h"
+#include "AR_IR/AR_IR_Sensor.h"
 
 // Global parameter class.
 //
@@ -400,6 +401,9 @@ public:
 
     // FS options
     AP_Int32 fs_options;
+    
+    // IR Sensors
+    AR_IR ir_sensor;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -110,6 +110,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(read_airspeed,          10,    100),
 #if OSD_ENABLED == ENABLED
     SCHED_TASK(publish_osd_info,        1,     10),
+    SCHED_TASK(read_ir,                50,    200),
 #endif
 };
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -69,6 +69,7 @@
 #include <AP_Follow/AP_Follow.h>
 #include <AP_OSD/AP_OSD.h>
 #include <AP_WindVane/AP_WindVane.h>
+#include <AR_IR/AR_IR_Sensor.h>
 
 #ifdef ENABLE_SCRIPTING
 #include <AP_Scripting/AP_Scripting.h>
@@ -118,6 +119,7 @@ public:
     friend class ModeSmartRTL;
     friend class ModeFollow;
     friend class ModeSimple;
+    friend class ModeLineFollower;
 
     friend class RC_Channel_Rover;
     friend class RC_Channels_Rover;
@@ -279,6 +281,7 @@ private:
     ModeSmartRTL mode_smartrtl;
     ModeFollow mode_follow;
     ModeSimple mode_simple;
+    ModeLineFollower mode_line_follower;
 
     // cruise throttle and speed learning
     typedef struct {
@@ -393,6 +396,7 @@ private:
     bool mavlink_set_mode(uint8_t mode);
     void startup_INS_ground(void);
     void notify_mode(const Mode *new_mode);
+    void read_ir(void);
     uint8_t check_digital_pin(uint8_t pin);
     bool should_log(uint32_t mask);
     bool is_boat() const;

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -475,6 +475,9 @@ Mode *Rover::mode_from_mode_num(const enum Mode::Number num)
     case Mode::Number::INITIALISING:
         ret = &mode_initializing;
         break;
+    case Mode::Number::LINE_FOLLOWER:
+        ret= &mode_line_follower;
+        break;
     default:
         break;
     }

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -30,7 +30,8 @@ public:
         RTL          = 11,
         SMART_RTL    = 12,
         GUIDED       = 15,
-        INITIALISING = 16
+        INITIALISING = 16,
+        LINE_FOLLOWER= 17
     };
 
     // Constructor
@@ -645,6 +646,24 @@ protected:
     void _exit() override;
 
     float _desired_speed;       // desired speed in m/s
+};
+
+class ModeLineFollower : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return LINE_FOLLOWER; }
+    const char *name4() const override { return "LNFLWR"; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+
+    // attributes for mavlink system status reporting
+    bool attitude_stabilized() const override { return false; }
+
+    //Line Follower mode does not require position or velocity estimate
+    bool requires_position() const override { return false; }
+    bool requires_velocity() const override { return true; }
 };
 
 class ModeSimple : public Mode

--- a/APMrover2/mode_line_follower.cpp
+++ b/APMrover2/mode_line_follower.cpp
@@ -1,0 +1,17 @@
+#include "mode.h"
+#include "Rover.h"
+#include <GCS_MAVLink/GCS.h>
+
+void ModeLineFollower::update()
+{
+    float desired_steering, desired_throttle,steering_out,ir_reading;
+
+    get_pilot_input(desired_steering, desired_throttle);
+    g2.motors.set_throttle(desired_throttle);
+    g2.ir_sensor.read();
+    g2.ir_sensor.calc_line_error(ir_reading); //read IR sensor values
+
+    const float target_turn_rate = ir_reading* radians(g2.acro_turn_rate);
+    steering_out = attitude_control.get_steering_out_rate(target_turn_rate, g2.motors.limit.steer_left, g2.motors.limit.steer_right, rover.G_Dt);
+    set_steering(steering_out * 4500.0f);
+}

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -127,3 +127,9 @@ void Rover::rpm_update(void)
         }
     }
 }
+
+//update IR sensor
+void Rover::read_ir(void)
+{
+   g2.ir_sensor.read();
+}

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -156,6 +156,9 @@ void Rover::init_ardupilot()
     rc().init();
 
     rover.g2.sailboat.init();
+    
+    //initialise IR Sensors
+    g2.ir_sensor.init();
 
     // disable safety if requested
     BoardConfig.init_safety();

--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -26,6 +26,7 @@ def build(bld):
             'AP_Follow',
             'AP_OSD',
             'AP_WindVane',
+            'AR_IR'
         ],
     )
 

--- a/libraries/AR_IR/AR_IR_Sensor.cpp
+++ b/libraries/AR_IR/AR_IR_Sensor.cpp
@@ -1,0 +1,57 @@
+#include <AP_HAL/AP_HAL.h>
+#include "AR_IR_Sensor.h"
+#include "AR_IR_Sensor_Analog.h"
+#include "AR_IR_Sensor_SITL_Analog.h"
+#include <AP_Math/AP_Math.h>
+
+const AP_Param::GroupInfo AR_IR::var_info[] = {
+
+    // @Param: IR_PIN_1
+    // @DisplayName: Infrared Sensor 1 pin number
+    // @Description: Analog Pin number to where the first infrared sensor is attached to the left of the rover
+    // @Range: 0 20
+    AP_GROUPINFO("PIN_1", 1, AR_IR, param._ir_1_pin_num, IR_1_PIN_NUM),
+
+    // @Param: IR_PIN_2
+    // @DisplayName: Infrared Sensor 2 pin number
+    // @Description: Analog Pin number to where the second infrared sensor is attached to the right of the rover
+    // @Range: 0 20
+    AP_GROUPINFO("PIN_2", 2, AR_IR, param._ir_2_pin_num, IR_2_PIN_NUM),
+
+    // @Param: IR_ADC_VOLTAGE
+    // @DisplayName: Infrared Sensor ADC voltage value
+    // @Description: ADV voltage value number to where the second infrared sensor is attached
+    // @Values: 3.3,5,6.6
+    AP_GROUPINFO("ADC_VOLTAGE", 3, AR_IR, param.adc_voltage, 5),
+
+    AP_GROUPEND
+};
+
+AR_IR::AR_IR()
+{
+}
+
+void AR_IR::init()
+{	
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+	drivers = new AR_IR_Analog(*this, state);
+#endif
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    drivers = new AR_IR_SITL_Analog(*this, state);
+#endif
+}
+
+
+void AR_IR::read()
+{
+    drivers->read();
+}
+
+void AR_IR:: calc_line_error(float &line_error)
+{	
+	//calculate error from the sensor
+    float sensor_error = state.voltage_ir_1 - state.voltage_ir_2; 
+    line_error = linear_interpolate(-1.0f,1.0f,sensor_error,-param.adc_voltage,param.adc_voltage);
+}
+
+

--- a/libraries/AR_IR/AR_IR_Sensor.h
+++ b/libraries/AR_IR/AR_IR_Sensor.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#define IR_1_PIN_NUM  16
+#define IR_2_PIN_NUM  17
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Param/AP_Param.h>
+
+
+class AR_IR_Backend;
+class AR_IR_Analog;
+class AR_IR_SITL_Analog;
+class AR_IR
+{
+    friend class AR_IR_Backend;
+    friend class AR_IR_Analog;
+    friend class AR_IR_SITL_Analog;
+    
+public:
+    AR_IR();
+    void read();
+    /* Do not allow copies */
+    AR_IR(const AR_IR &other) = delete;
+    AR_IR &operator=(const AR_IR&) = delete;
+    void init();
+    struct AR_IR_State {
+        float voltage_ir_1;
+        float voltage_ir_2;
+    };
+    static const struct AP_Param::GroupInfo var_info[];
+    struct {
+        AP_Int8 _ir_1_pin_num;  //set pin number for Analog Infrared Sensor 1
+        AP_Int8 _ir_2_pin_num;  //set pin number for Analog Infrared Sensor 2
+        AP_Float adc_voltage; // adc voltage
+    } param;
+    void calc_line_error(float &line_error);
+
+private:
+    AR_IR_State state;
+    AR_IR_Backend *drivers;
+};

--- a/libraries/AR_IR/AR_IR_Sensor_Analog.cpp
+++ b/libraries/AR_IR/AR_IR_Sensor_Analog.cpp
@@ -1,0 +1,22 @@
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+#include "AR_IR_Sensor_Analog.h"
+#include "AR_IR_Sensor.h"
+
+AR_IR_Analog::AR_IR_Analog(AR_IR &val, AR_IR::AR_IR_State &val_state):
+    AR_IR_Backend(val,val_state)
+{
+    _IR_pin_analog_source_1= hal.analogin->channel(ANALOG_INPUT_NONE);
+    _IR_pin_analog_source_2= hal.analogin->channel(ANALOG_INPUT_NONE);
+}
+
+void AR_IR_Analog::read()
+{
+    _IR_pin_analog_source_1->set_pin(_val.param._ir_1_pin_num);
+    float pin_1_reading = _IR_pin_analog_source_1->voltage_average();
+
+    _IR_pin_analog_source_2->set_pin(_val.param._ir_2_pin_num);
+    float pin_2_reading = _IR_pin_analog_source_2->voltage_average();
+    
+    copy_state_to_frontend(pin_1_reading,pin_2_reading);
+}

--- a/libraries/AR_IR/AR_IR_Sensor_Analog.h
+++ b/libraries/AR_IR/AR_IR_Sensor_Analog.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "AR_IR_Sensor.h"
+#include "AR_IR_Sensor_Backend.h"
+
+extern const AP_HAL::HAL& hal ;
+
+class AR_IR_Analog: public AR_IR_Backend
+{
+public:
+    AR_IR_Analog(AR_IR &val, AR_IR::AR_IR_State &val_state);
+    void read() override;
+
+private:
+    AP_HAL::AnalogSource *_IR_pin_analog_source_1;
+    AP_HAL::AnalogSource *_IR_pin_analog_source_2;
+};

--- a/libraries/AR_IR/AR_IR_Sensor_Backend.cpp
+++ b/libraries/AR_IR/AR_IR_Sensor_Backend.cpp
@@ -1,0 +1,17 @@
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AR_IR_Sensor.h"
+#include "AR_IR_Sensor_Backend.h"
+
+AR_IR_Backend:: AR_IR_Backend(AR_IR &val, AR_IR::AR_IR_State &val_state) :
+    _val(val),
+    _state(val_state)
+{
+}
+
+// copy state to front end helper function
+void AR_IR_Backend:: copy_state_to_frontend(float IR_Reading_1, float IR_Reading_2)
+{
+     _state.voltage_ir_1 = IR_Reading_1;
+     _state.voltage_ir_2 = IR_Reading_2;
+}

--- a/libraries/AR_IR/AR_IR_Sensor_Backend.h
+++ b/libraries/AR_IR/AR_IR_Sensor_Backend.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AR_IR_Sensor.h"
+class AR_IR_Backend
+{
+public:
+    AR_IR_Backend(AR_IR &val, AR_IR::AR_IR_State &val_state);
+    virtual void read()=0;
+
+protected:
+    void copy_state_to_frontend(float IR_Reading_1, float IR_Reading_2); // copy state to front end helper function
+    AR_IR &_val;
+    AR_IR::AR_IR_State &_state;
+};

--- a/libraries/AR_IR/AR_IR_Sensor_SITL_Analog.cpp
+++ b/libraries/AR_IR/AR_IR_Sensor_SITL_Analog.cpp
@@ -1,0 +1,69 @@
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Common/Location.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include "AR_IR_Sensor_SITL_Analog.h"
+#include "AR_IR_Sensor.h"
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+extern const AP_HAL::HAL& hal;
+
+AR_IR_SITL_Analog::AR_IR_SITL_Analog(AR_IR &val, AR_IR::AR_IR_State &val_state):
+    AR_IR_Backend(val,val_state)
+{
+    _sitl = AP::sitl();
+}
+
+void AR_IR_SITL_Analog::read()
+{
+    const Location &home_loc = AP::ahrs().get_home();
+    Location projected_home_line; 
+    //location of sensors
+    Location sensor_1; 
+    Location sensor_2;
+
+    float current_heading =  AP::ahrs().yaw_sensor * 0.01f;
+    float max_sensor_range = 300.0f; // maximum range of the sensor (cm)
+    projected_home_line.lat = home_loc.lat;
+    projected_home_line.lng = home_loc.lng;
+    projected_home_line.offset_bearing(0,1000); //1km line projected from home
+
+    sensor_1.lat = _sitl->state.latitude*1.0e7;
+    sensor_1.lng = _sitl->state.longitude*1.0e7;
+    sensor_1.offset_bearing(wrap_360(current_heading+90),0.25f); //First sensor offset is set at 25cm
+
+    sensor_2.lat = _sitl->state.latitude*1.0e7;
+    sensor_2.lng = _sitl->state.longitude*1.0e7;
+    sensor_2.offset_bearing(wrap_360(current_heading-90),0.25f); //Second sensor offset is set at -25cm
+
+    //get vectors from origin to the points
+    Vector2f start_NE, end_NE,sensor_1_offset_NE,sensor_2_offset_NE; 
+    bool home_loc_vector = home_loc.get_vector_xy_from_origin_NE(start_NE);
+    bool projected_line_vector = projected_home_line.get_vector_xy_from_origin_NE(end_NE);
+    bool sensor_1_vector = sensor_1.get_vector_xy_from_origin_NE(sensor_1_offset_NE);
+    bool sensor_2_vector = sensor_2.get_vector_xy_from_origin_NE(sensor_2_offset_NE);
+
+    float crosstrack_error_1 = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, sensor_1_offset_NE); // distance between individual sensors and the virtual line
+    float crosstrack_error_2 = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, sensor_2_offset_NE);
+    
+    //force sensor to stay in range limit
+    if (crosstrack_error_1>= max_sensor_range) { 
+        crosstrack_error_1 = max_sensor_range;
+    } if (crosstrack_error_2>= max_sensor_range) {
+        crosstrack_error_2 = max_sensor_range;
+    }
+    //convert the distance to voltage
+    float voltage_sensor_1 = linear_interpolate(5.0f,0.0f,crosstrack_error_1,0.0f,max_sensor_range); 
+    float voltage_sensor_2 = linear_interpolate(5.0f,0.0f,crosstrack_error_2,0.0f,max_sensor_range);
+
+    //check for valid origin
+    if (home_loc_vector&projected_line_vector&sensor_1_vector&sensor_2_vector) { 
+        copy_state_to_frontend(voltage_sensor_1, voltage_sensor_2);
+    } else {
+         copy_state_to_frontend(0.0f, 0.0f); //set voltage 0 if valid origin is not available
+    }
+}
+
+#endif

--- a/libraries/AR_IR/AR_IR_Sensor_SITL_Analog.h
+++ b/libraries/AR_IR/AR_IR_Sensor_SITL_Analog.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "AR_IR_Sensor.h"
+#include "AR_IR_Sensor_Backend.h"
+#include <SITL/SITL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+extern const AP_HAL::HAL& hal ;
+
+class AR_IR_SITL_Analog: public AR_IR_Backend
+{
+public:
+    AR_IR_SITL_Analog(AR_IR &val, AR_IR::AR_IR_State &val_state);
+    void read() override;
+
+private:
+    SITL::SITL *_sitl; // pointer to SITL singleton
+};
+
+#endif // CONFIG_HAL_BOARD


### PR DESCRIPTION
This PR is in response to #7590.

- I have attempted to simulate Analog IR Sensor's [https://www.sparkfun.com/products/9453]. These sensors are widely used in line following robots - white surfaces reflect much more light than black, so, when directed towards a white surface, the voltage output will be lower than that on a black surface. A minimum of two of these sensors are required on the far edges of the robot to determine where the vehicle is with respect to the black line.  
![image](https://user-images.githubusercontent.com/36970042/71436639-58bf9080-2714-11ea-956f-aaa6cdcfb37e.png)


- A new IR Sensor library is created which is divided into front-end, back-end, and an analog driver similar to other standard Ardupilot sensor libraries. This will make it easier to add other line following sensors to the library. Certain parameters are also defined which need to be specified by the user. Using the values that are picked up from the sensors, an error is generated to approximate the position of the vehicle with respect to the line. **The first 8 commits include these additions**

- A new "Line Follower" mode is created in the **last 10 commits**. The IR sensors are read periodically and the generated error is directly fed to ` AR_AttitudeControl::get_steering_out_rate()`.
The following image explains the theory behind how this mode works. 

![image](https://user-images.githubusercontent.com/36970042/71437234-afc66500-2716-11ea-9a4d-3cd783828564.png)

- **TESTING:**

1. The simulation in SITL works well. To simulate, first change the param's :
 `param set IR_PIN_1 16`
`param set IR_PIN_2 17`
`param set IR_ADC_VOLTAGE 5`

Then write the commands: 
`mode 17`
`arm throttle`
`rc 3 1700`

The GIF of a simulation is posted below:
![Line_Follower_SITL](https://user-images.githubusercontent.com/36970042/71438414-b4414c80-271b-11ea-9fa3-d29cb8ac206d.gif)

2. `Tools/scripts/build_all.sh` script was run. All systems were built successfully. 

3. I had attached the analog sensors to the 3.3V ADC of my Pixhawk, The values were read correctly. 

4. Unfortunately, I do not have a compatible motor driver (ESC) to build the rover, therefore I **can not test the mode on an actual vehicle** but this PR should at least give a good start to this age-long issue. I had tested a similar algorithm on an Arduino Uno based vehicle with a cheap motor driver and the mode worked well.

- @peterbarker please tell me the modifications required in this PR, if they are needed. I realize there are a lot of commits! Hopefully, this will be a start to Ardupilot's Line Follower vehicles and other developers can contribute to this.