### PR TITLE
GCS_MAVLInk: Judgment of non-existence value by PARAM_SET

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -268,7 +268,7 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
     // find existing param so we can get the old value
     uint16_t parameter_flags = 0;
     vp = AP_Param::find(key, &var_type, &parameter_flags);
-    if (vp == nullptr) {
+    if (vp == nullptr || isnan(packet.param_value) || isinf(packet.param_value)) {
         return;
     }
 


### PR DESCRIPTION
I learned that ArduPilot relies on Mission Planner, Qgroundcontrol parameter checking.
ArduPilot knows that inf and nan are not enough.
I add a verdict before setting config parameters.