### PR TITLE
Add erase() method to hal.storage

### DIFF
--- a/libraries/AP_FlashStorage/AP_FlashStorage.h
+++ b/libraries/AP_FlashStorage/AP_FlashStorage.h
@@ -82,6 +82,11 @@ public:
     // initialise storage, filling mem_buffer with current contents
     bool init(void);
 
+    // erase sectors and re-initialise
+    bool erase(void) {
+        return erase_all();
+    }
+    
     // re-initialise storage, using current mem_buffer
     bool re_initialise(void);
     

--- a/libraries/AP_HAL/Storage.cpp
+++ b/libraries/AP_HAL/Storage.cpp
@@ -1,0 +1,17 @@
+#include "AP_HAL.h"
+#include "Storage.h"
+#include <AP_Math/AP_Math.h>
+
+/*
+  default erase method
+ */
+bool AP_HAL::Storage::erase(void)
+{
+    uint8_t blk[16] {};
+    uint32_t ofs;
+    for (ofs=0; ofs<HAL_STORAGE_SIZE; ofs += sizeof(blk)) {
+        uint32_t n = MIN(sizeof(blk), HAL_STORAGE_SIZE - ofs);
+        write_block(ofs, blk, n);
+    }
+    return true;
+}

--- a/libraries/AP_HAL/Storage.h
+++ b/libraries/AP_HAL/Storage.h
@@ -6,6 +6,7 @@
 class AP_HAL::Storage {
 public:
     virtual void init() = 0;
+    virtual bool erase();
     virtual void read_block(void *dst, uint16_t src, size_t n) = 0;
     virtual void write_block(uint16_t dst, const void* src, size_t n) = 0;
     virtual void _timer_tick(void) {};

--- a/libraries/AP_HAL_ChibiOS/Storage.h
+++ b/libraries/AP_HAL_ChibiOS/Storage.h
@@ -37,6 +37,7 @@
 class ChibiOS::Storage : public AP_HAL::Storage {
 public:
     void init() override {}
+    bool erase() override;
     void read_block(void *dst, uint16_t src, size_t n) override;
     void write_block(uint16_t dst, const void* src, size_t n) override;
 

--- a/libraries/AP_HAL_ChibiOS/stdio.cpp
+++ b/libraries/AP_HAL_ChibiOS/stdio.cpp
@@ -29,6 +29,9 @@
 #include <ctype.h>
 #include "hwdef/common/stdio.h"
 #include <AP_HAL/AP_HAL.h>
+#if HAL_USE_SERIAL_USB == TRUE
+#include <AP_HAL_ChibiOS/hwdef/common/usbcfg.h>
+#endif
 
 extern const AP_HAL::HAL& hal;
 
@@ -80,7 +83,9 @@ int __wrap_asprintf(char **strp, const char *fmt, ...)
 int __wrap_vprintf(const char *fmt, va_list arg)
 {
 #ifdef HAL_STDOUT_SERIAL
-  return chvprintf ((BaseSequentialStream*)&HAL_STDOUT_SERIAL, fmt, arg);
+  return chvprintf((BaseSequentialStream*)&HAL_STDOUT_SERIAL, fmt, arg);
+#elif HAL_USE_SERIAL_USB == TRUE
+  return chvprintf((BaseSequentialStream*)&SDU1, fmt, arg);
 #else
   (void)arg;
   return strlen(fmt);

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -203,7 +203,10 @@ void panic(const char *errormsg, ...)
     va_end(ap);
 
     hal.scheduler->delay_microseconds(10000);
-    while(1) {}
+    while (1) {
+        vprintf(errormsg, ap);
+        hal.scheduler->delay(500);
+    }
 }
 
 uint32_t micros()

--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -21,6 +21,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "StorageManager.h"
+#include <stdio.h>
 
 
 extern const AP_HAL::HAL& hal;
@@ -110,21 +111,9 @@ const StorageManager::StorageArea *StorageManager::layout = layout_default;
  */
 void StorageManager::erase(void)
 {
-    uint8_t blk[16];
-    memset(blk, 0, sizeof(blk));
-    for (uint8_t i=0; i<STORAGE_NUM_AREAS; i++) {
-        const StorageManager::StorageArea &area = StorageManager::layout[i];
-        uint16_t length = area.length;
-        uint16_t offset = area.offset;
-        for (uint16_t ofs=0; ofs<length; ofs += sizeof(blk)) {
-            uint8_t n = 16;
-            if (ofs + n > length) {
-                n = length - ofs;
-            }
-            hal.storage->write_block(offset + ofs, blk, n);
-        }
+    if (!hal.storage->erase()) {
+        ::printf("StorageManager: erase failed\n");
     }
-    
 }
 
 /*


### PR DESCRIPTION
This fixes an issue where the flash based storage gets sufficiently corrupted that it can't be fixed by writing zero bytes. The usual method of setting FORMAT_VERSION to zero or loading a different vehicle firmware also doesn't work. We need to erase the sectors, which means we need a separate erase call
