### PR TITLE
AP_UAVCAN: remove unnecessary message UC Node Down

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
@@ -438,7 +438,6 @@ void AP_UAVCAN_DNA_Server::verify_nodes(AP_UAVCAN *ap_uavcan)
         /* Only report if the node was verified, otherwise ignore
         as this could be just Bootloader to Application transition. */
         if (isNodeIDVerified(curr_verifying_node)) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "UC Node %d Down!", curr_verifying_node);
             // remove verification flag for this node
             verified_mask.clear(curr_verifying_node);
         }


### PR DESCRIPTION
If the Node is really down, for instance due to collision with duplicate node, no request will be responded, hence the NodeID will never get verified.
The call can be made by the device drivers to isNodeIDVerified for some duration to check if the node is healthy and act accordingly. Hence there is no need to unnecessarily scare users with false positives.