### PR TITLE
Limit auto rotations to ROTATION_MAX_AUTO_ROTATION

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -823,9 +823,9 @@ bool CompassCalibrator::calculate_orientation(void)
     // this function is very slow
     EXPECT_DELAY_MS(1000);
 
-    float variance[ROTATION_MAX] {};
+    float variance[ROTATION_MAX_AUTO_ROTATION+1] {};
 
-    for (enum Rotation r = ROTATION_NONE; r<ROTATION_MAX; r = (enum Rotation)(r+1)) {
+    for (enum Rotation r = ROTATION_NONE; r <= ROTATION_MAX_AUTO_ROTATION; r = (enum Rotation)(r+1)) {
         // calculate the average implied earth field across all samples
         Vector3f total_ef {};
         for (uint32_t i=0; i<_samples_collected; i++) {
@@ -846,7 +846,7 @@ bool CompassCalibrator::calculate_orientation(void)
     // find the rotation with the lowest variance
     enum Rotation besti = ROTATION_NONE;
     float bestv = variance[0];
-    for (enum Rotation r = ROTATION_NONE; r<ROTATION_MAX; r = (enum Rotation)(r+1)) {
+    for (enum Rotation r = ROTATION_NONE; r <= ROTATION_MAX_AUTO_ROTATION; r = (enum Rotation)(r+1)) {
         if (variance[r] < bestv) {
             bestv = variance[r];
             besti = r;
@@ -859,7 +859,7 @@ bool CompassCalibrator::calculate_orientation(void)
 
     float second_best = besti==ROTATION_NONE?variance[1]:variance[0];
     enum Rotation besti2 = ROTATION_NONE;
-    for (enum Rotation r = ROTATION_NONE; r<ROTATION_MAX; r = (enum Rotation)(r+1)) {
+    for (enum Rotation r = ROTATION_NONE; r <= ROTATION_MAX_AUTO_ROTATION; r = (enum Rotation)(r+1)) {
         if (!rotation_equal(besti, r)) {
             if (variance[r] < second_best) {
                 second_best = variance[r];

--- a/libraries/AP_Math/rotations.h
+++ b/libraries/AP_Math/rotations.h
@@ -76,6 +76,10 @@ enum Rotation : uint8_t {
     ROTATION_MAX,
     ROTATION_CUSTOM              = 100,
 };
+
+// maximum rotation that will be used for auto-detection
+#define ROTATION_MAX_AUTO_ROTATION ROTATION_ROLL_90_PITCH_315
+
 /*
 Here are the same values in a form sutable for a @Values attribute in
 auto documentation:


### PR DESCRIPTION
This fixes a problem where users are getting a higher likelihood of failed compass calibration. The problem is the addition of ROTATION_PITCH_7, which is just 7 degrees off from ROTATION_NONE. The automatic rotation code is not always accurate enough to distinguish these two rotations, and ends up failing the calibration as the confidence in the rotation is below the minimum threshold.
