### PR TITLE
AP_TemperatureSensor: Remove unused headers and double quotes

### DIFF
--- a/libraries/AP_TemperatureSensor/TSYS01.cpp
+++ b/libraries/AP_TemperatureSensor/TSYS01.cpp
@@ -1,8 +1,7 @@
 #include "TSYS01.h"
 
-#include <utility>
 #include <stdio.h>
-#include <AP_HAL/AP_HAL.h>
+#include <utility>
 #include <AP_HAL/I2CDevice.h>
 #include <AP_Math/AP_Math.h>
 

--- a/libraries/AP_TemperatureSensor/TSYS01.h
+++ b/libraries/AP_TemperatureSensor/TSYS01.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_HAL/Semaphores.h>
 #include <AP_HAL/Device.h>
 
 #define TSYS01_ADDR 0x77


### PR DESCRIPTION
I have found a double quote in the header file and the CPP file.
I found some unused headers.
I sorted out unused headers and double quotes.