### PR TITLE
Copter: Change the version patch number

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -9,7 +9,7 @@
 #define THISFIRMWARE "ArduCopter V4.0.1-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,0,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,0,1,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
 #define FW_MINOR 0


### PR DESCRIPTION
I discovered that the patch numbers for FIRMWARE_VERSION were different.
I change the version patch number.