### PR TITLE
AP_Motors: MatrixTS default to normal Matrix 

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
@@ -25,17 +25,6 @@ extern const AP_HAL::HAL& hal;
 
 #define SERVO_OUTPUT_RANGE  4500
 
-void AP_MotorsMatrixTS::output_to_motors()
-{
-    // calls calc_thrust_to_pwm(_thrust_rpyt_out[i]) for each enabled motor
-    AP_MotorsMatrix::output_to_motors();
-
-    // also actuate control surfaces
-    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron,  -_yaw_in * SERVO_OUTPUT_RANGE);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, _pitch_in * SERVO_OUTPUT_RANGE);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, _roll_in * SERVO_OUTPUT_RANGE);
-}
-
 // output_armed - sends commands to the motors
 // includes new scaling stability patch
 void AP_MotorsMatrixTS::output_armed_stabilizing()

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
@@ -40,7 +40,7 @@ void AP_MotorsMatrixTS::output_to_motors()
 // includes new scaling stability patch
 void AP_MotorsMatrixTS::output_armed_stabilizing()
 {
-    if (enable_yaw_torque) {
+    if (use_standard_matrix) {
         AP_MotorsMatrix::output_armed_stabilizing();
         return;
     }
@@ -105,7 +105,7 @@ void AP_MotorsMatrixTS::setup_motors(motor_frame_class frame_class, motor_frame_
     }
 
     bool success = false;
-    enable_yaw_torque = true;
+    use_standard_matrix = true;
 
     switch (frame_class) {
 
@@ -118,15 +118,6 @@ void AP_MotorsMatrixTS::setup_motors(motor_frame_class frame_class, motor_frame_
             break;
         case MOTOR_FRAME_QUAD:
             switch (frame_type) {
-                case MOTOR_FRAME_TYPE_PLUS:
-                    // differential torque for yaw: rotation directions specified below
-                    add_motor(AP_MOTORS_MOT_1,  90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
-                    add_motor(AP_MOTORS_MOT_2, -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 4);
-                    add_motor(AP_MOTORS_MOT_3,   0, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
-                    add_motor(AP_MOTORS_MOT_4, 180, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
-
-                    success = true;
-                    break;
                 case MOTOR_FRAME_TYPE_NYT_PLUS:
                     // motors 1,2 on wings, motors 3,4 on vertical tail/subfin
                     // motors 1,2 are counter-rotating, as are motors 3,4
@@ -137,19 +128,10 @@ void AP_MotorsMatrixTS::setup_motors(motor_frame_class frame_class, motor_frame_
                     add_motor(AP_MOTORS_MOT_3,   0, 0, 1);
                     add_motor(AP_MOTORS_MOT_4, 180, 0, 3);
 
-                    enable_yaw_torque = false;
+                    use_standard_matrix = false;
                     success = true;
                     break;
-                case MOTOR_FRAME_TYPE_X:
-                    // PLUS_TS layout rotated 45 degrees about X axis
-                    // differential torque for yaw: rotation directions specified below
-                    add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
-                    add_motor(AP_MOTORS_MOT_2, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
-                    add_motor(AP_MOTORS_MOT_3,  -45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  4);
-                    add_motor(AP_MOTORS_MOT_4,  135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
 
-                    success = true;
-                    break;
                 case MOTOR_FRAME_TYPE_NYT_X:
                     // PLUS_TS layout rotated 45 degrees about X axis
                     // no differential torque for yaw: wing and fin motors counter-rotating
@@ -158,17 +140,21 @@ void AP_MotorsMatrixTS::setup_motors(motor_frame_class frame_class, motor_frame_
                     add_motor(AP_MOTORS_MOT_3,  -45, 0, 4);
                     add_motor(AP_MOTORS_MOT_4,  135, 0, 2);
 
-                    enable_yaw_torque = false;
+                    use_standard_matrix = false;
                     success = true;
                     break;
                 default:
                     // matrixTS doesn't support the configured frame_type
-                    break;
+                    // try to use normal Matrix
+                    AP_MotorsMatrix::setup_motors(frame_class, frame_type);
+                    return;
             }
             break;
         default:
             // matrixTS doesn't support the configured frame_class
-            break;
+            // try to use normal Matrix
+            AP_MotorsMatrix::setup_motors(frame_class, frame_type);
+            return;
         } // switch frame_class
 
     // normalise factors to magnitude 0.5

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
@@ -25,33 +25,6 @@ extern const AP_HAL::HAL& hal;
 
 #define SERVO_OUTPUT_RANGE  4500
 
-// output a thrust to all motors that match a given motor mask. This
-// is used to control motors enabled for forward flight. Thrust is in
-// the range 0 to 1
-void AP_MotorsMatrixTS::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
-{
-    const int16_t pwm_min = get_pwm_output_min();
-    const int16_t pwm_range = get_pwm_output_max() - pwm_min;
-
-    for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-        if (motor_enabled[i]) {
-            int16_t motor_out;
-            if (mask & (1U<<i)) {
-                /*
-                    apply rudder mixing differential thrust
-                    copter frame roll is plane frame yaw (this is only
-                    used by tiltrotors and tailsitters)
-                */
-                float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
-                motor_out = pwm_min + pwm_range * constrain_float(thrust + diff_thrust, 0.0f, 1.0f);
-            } else {
-                motor_out = pwm_min;
-            }
-            rc_write(i, motor_out);
-        }
-    }
-}
-
 void AP_MotorsMatrixTS::output_to_motors()
 {
     // calls calc_thrust_to_pwm(_thrust_rpyt_out[i]) for each enabled motor

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.h
@@ -19,8 +19,6 @@ public:
 
     virtual void        output_to_motors() override;
 
-    virtual void        output_motor_mask(float thrust, uint8_t mask, float rudder_dt) override;
-
 protected:
     bool enable_yaw_torque;    // differential torque for yaw control
 

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.h
@@ -17,8 +17,6 @@ public:
         AP_Param::setup_object_defaults(this, var_info);
     };
 
-    virtual void        output_to_motors() override;
-
 protected:
     bool use_standard_matrix;    // True to use normal matrix mixers with yaw torque
 

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.h
@@ -20,7 +20,7 @@ public:
     virtual void        output_to_motors() override;
 
 protected:
-    bool enable_yaw_torque;    // differential torque for yaw control
+    bool use_standard_matrix;    // True to use normal matrix mixers with yaw torque
 
     // configures the motors for the defined frame_class and frame_type
     virtual void        setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -732,6 +732,9 @@ void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float th
 // the range 0 to 1
 void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
 {
+    const int16_t pwm_min = get_pwm_output_min();
+    const int16_t pwm_range = get_pwm_output_max() - pwm_min;
+
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             if (mask & (1U << i)) {
@@ -742,10 +745,10 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float r
                  */
                 float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
                 set_actuator_with_slew(_actuator[i], thrust_to_actuator(thrust + diff_thrust));
-                int16_t pwm_output = get_pwm_output_min() + (get_pwm_output_max() - get_pwm_output_min()) * _actuator[i];
+                int16_t pwm_output = pwm_min + pwm_range * _actuator[i];
                 rc_write(i, pwm_output);
             } else {
-                rc_write(i, get_pwm_output_min());
+                rc_write(i, pwm_min);
             }
         }
     }


### PR DESCRIPTION
This work was funded by FDrones.

There are two things in this PR. Firstly it removes matrixTS frame classes and types that are the same as the default matrix and then uses the default matrix setup. This also allows any frame type supported by copter to be used as a tailsitter. The recently added specialist no yaw frame types are retained. 

Secondly it removes the output_motor_mask function in matrixTS in favor of the [default one](https://github.com/ArduPilot/ardupilot/blob/040a1b7fbeec726fb4696a669f2c99eb85969076/libraries/AP_Motors/AP_MotorsMulticopter.cpp#L733). The default one has slew rates and thrust linearization that this one was missing. Maybe there was some reason not to have these? I have added the efficiency improvements to the default one.