### PR TITLE
AP_Arming: Display mag field value

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -427,7 +427,7 @@ bool AP_Arming::compass_checks(bool report)
         // check for unreasonable mag field length
         const float mag_field = _compass.get_field().length();
         if (mag_field > AP_ARMING_COMPASS_MAGFIELD_MAX || mag_field < AP_ARMING_COMPASS_MAGFIELD_MIN) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Check mag field");
+            check_failed(ARMING_CHECK_COMPASS, report, "Check mag field: %4.0f, max %d, min %d", (double)mag_field, AP_ARMING_COMPASS_MAGFIELD_MAX, AP_ARMING_COMPASS_MAGFIELD_MIN);
             return false;
         }
 


### PR DESCRIPTION
I turned on the flight controller Durandal indoors.
I often see the message “PreArm: Check mag field” in Mission Planner, QgroundControl, and APM Planner2.
I put the same revision of AC4.0.1-dev in PIXRACER, PIXHAWK. I learned that this message did not appear.
I have found that it appears above 875 or below 185.
I think it is better to display the judgment value.
In this environment it is over 5000.
I checked this value while moving the aircraft.
I saw it change.

After message:
PreArm: Check mag field 5688.519