### PR TITLE
AP_Mission: Fix comments for DO_CHANGE_SPEED

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -833,7 +833,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_DO_CHANGE_SPEED:                       // MAV ID: 178
         cmd.content.speed.speed_type = packet.param1;   // 0 = airspeed, 1 = ground speed
         cmd.content.speed.target_ms = packet.param2;    // target speed in m/s
-        cmd.content.speed.throttle_pct = packet.param3; // throttle as a percentage from 0 ~ 100%
+        cmd.content.speed.throttle_pct = packet.param3; // throttle as a percentage from 1 ~ 100%
         break;
 
     case MAV_CMD_DO_SET_HOME:
@@ -1268,7 +1268,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_DO_CHANGE_SPEED:                       // MAV ID: 178
         packet.param1 = cmd.content.speed.speed_type;   // 0 = airspeed, 1 = ground speed
         packet.param2 = cmd.content.speed.target_ms;    // speed in m/s
-        packet.param3 = cmd.content.speed.throttle_pct; // throttle as a percentage from 0 ~ 100%
+        packet.param3 = cmd.content.speed.throttle_pct; // throttle as a percentage from 1 ~ 100%
         break;
 
     case MAV_CMD_DO_SET_HOME:                           // MAV ID: 179

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -72,7 +72,7 @@ public:
     struct PACKED Change_Speed_Command {
         uint8_t speed_type;     // 0=airspeed, 1=ground speed
         float target_ms;        // target speed in m/s, -1 means no change
-        float throttle_pct;     // throttle as a percentage (i.e. 0 ~ 100), -1 means no change
+        float throttle_pct;     // throttle as a percentage (i.e. 1 ~ 100), 0 means no change
     };
 
     // set relay command structure


### PR DESCRIPTION
The comments were really confusing. Actual implementation in ArduPlane/commands_logic.cpp is
```
    if (cmd.content.speed.throttle_pct > 0 && cmd.content.speed.throttle_pct <= 100) {
        gcs().send_text(MAV_SEVERITY_INFO, "Set throttle %u", (unsigned)cmd.content.speed.throttle_pct);
        aparm.throttle_cruise.set(cmd.content.speed.throttle_pct);
    }
```
