### PR TITLE
AP_HAL_SITL: prevent dump_stack_trace() blowing up on macOS

### DIFF
--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -75,7 +75,11 @@ void dump_stack_trace()
 	progname[n] = 0;
 
 	p = strrchr(progname, '/');
-	*p = 0;
+    if (p != nullptr) {
+	    *p = 0;
+    } else {
+        p = progname;
+    }
 
     char output_filepath[30];
     snprintf(output_filepath,


### PR DESCRIPTION
We get a write to memory location 0 currently