### PR TITLE
Tools: remove build before running coverage

### DIFF
--- a/Tools/scripts/run-coverage
+++ b/Tools/scripts/run-coverage
@@ -18,6 +18,8 @@ TIMEOUT=14400
 
 OPTS="--speedup=$SPEEDUP --timeout=$TIMEOUT --debug --no-clean"
 
+rm -rf build
+
 # Run examples
 ./waf configure --board=linux --debug
 ./waf examples


### PR DESCRIPTION
Stop losing a run because a file has been removed.