### PR TITLE
Add support for SDS021 particle sensor

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -308,6 +308,10 @@ void Rover::update_GPS(void)
         camera.update();
 #endif
     }
+
+#if PARTICLE_SENSOR == ENABLED
+    particlesensor.update();
+#endif
 }
 
 void Rover::update_current_mode(void)

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -44,6 +44,7 @@
 #include <AP_Navigation/AP_Navigation.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>          // Optical Flow library
 #include <AP_Param/AP_Param.h>
+#include <AP_ParticleSensor/AP_ParticleSensor.h>    // Particle Sensor library
 #include <AP_RangeFinder/AP_RangeFinder.h>          // Range finder library
 #include <AP_RCMapper/AP_RCMapper.h>                // RC input mapping library
 #include <AP_Scheduler/AP_Scheduler.h>              // main loop scheduler
@@ -191,6 +192,10 @@ private:
     // Camera
 #if CAMERA == ENABLED
     AP_Camera camera{MASK_LOG_CAMERA, current_loc};
+#endif
+
+#if PARTICLE_SENSOR == ENABLED
+    AP_ParticleSensor particlesensor;
 #endif
 
     // Camera/Antenna mount tracking and stabilisation stuff

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -142,3 +142,6 @@
  #define OSD_ENABLED DISABLED
 #endif
 
+#ifndef PARTICLE_SENSOR
+  #define PARTICLE_SENSOR ENABLED
+#endif

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -132,6 +132,10 @@ void Rover::init_ardupilot()
     camera_mount.init();
 #endif
 
+#if PARTICLE_SENSOR == ENABLED
+    particlesensor.init();
+#endif
+
     /*
       setup the 'main loop is dead' check. Note that this relies on
       the RC library being initialised.

--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -26,6 +26,7 @@ def build(bld):
             'AP_Follow',
             'AP_OSD',
             'AP_WindVane',
+            'AP_ParticleSensor',
         ],
     )
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -295,6 +295,12 @@ int SITL_State::sim_fd(const char *name, const char *arg)
         }
         nmea = new SITL::RF_NMEA();
         return nmea->fd();
+    } else if (streq(name, "sds021")) {
+        if (sds021 != nullptr) {
+            AP_HAL::panic("Only one particle sensor at a time");
+        }
+        sds021 = new SITL::ParticleSensor_SDS021();
+        return sds021->fd();
     }
 
     AP_HAL::panic("unknown simulated device: %s", name);
@@ -366,6 +372,11 @@ int SITL_State::sim_fd_write(const char *name)
             AP_HAL::panic("No nmea created");
         }
         return nmea->write_fd();
+    } else if (streq(name, "sds021")) {
+        if (sds021 == nullptr) {
+            AP_HAL::panic("No sds021 created");
+        }
+        return sds021->write_fd();
     }
     AP_HAL::panic("unknown simulated device: %s", name);
 }
@@ -538,6 +549,9 @@ void SITL_State::_fdm_input_local(void)
     }
     if (nmea != nullptr) {
         nmea->update(sitl_model->get_range());
+    }
+    if (sds021 != nullptr) {
+        sds021->update(sitl_model->get_location());
     }
 
     if (_sitl) {

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -36,6 +36,7 @@
 #include <SITL/SIM_RF_MaxsonarSerialLV.h>
 #include <SITL/SIM_RF_Wasp.h>
 #include <SITL/SIM_RF_NMEA.h>
+#include <SITL/SIM_ParticleSensor_SDS021.h>
 #include <AP_HAL/utility/Socket.h>
 
 class HAL_SITL;
@@ -261,6 +262,8 @@ private:
     SITL::RF_Wasp *wasp;
     // simulated NMEA rangefinder:
     SITL::RF_NMEA *nmea;
+    // simulated particle sensor:
+    SITL::ParticleSensor_SDS021 *sds021;
 
     // output socket for flightgear viewing
     SocketAPM fg_socket{true};

--- a/libraries/AP_ParticleSensor/AP_ParticleSensor.cpp
+++ b/libraries/AP_ParticleSensor/AP_ParticleSensor.cpp
@@ -1,0 +1,27 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ParticleSensor.h"
+
+void AP_ParticleSensor::init()
+{
+}
+
+void AP_ParticleSensor::update()
+{
+    if (backend != nullptr) {
+        backend->update();
+    }
+}

--- a/libraries/AP_ParticleSensor/AP_ParticleSensor.cpp
+++ b/libraries/AP_ParticleSensor/AP_ParticleSensor.cpp
@@ -14,9 +14,17 @@
  */
 
 #include "AP_ParticleSensor.h"
+#include "AP_ParticleSensor_SDS021.h"
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 void AP_ParticleSensor::init()
 {
+    AP_HAL::UARTDriver *port = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_SDS021, 0);
+    if (port != nullptr) {
+        backend = new AP_ParticleSensor_SDS021(*port);
+    }
 }
 
 void AP_ParticleSensor::update()

--- a/libraries/AP_ParticleSensor/AP_ParticleSensor.h
+++ b/libraries/AP_ParticleSensor/AP_ParticleSensor.h
@@ -1,0 +1,27 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+class AP_ParticleSensor {
+public:
+
+    void init();
+    void update();
+
+private:
+
+    class AP_ParticleSensor_Backend *backend;
+
+};

--- a/libraries/AP_ParticleSensor/AP_ParticleSensor_Backend.h
+++ b/libraries/AP_ParticleSensor/AP_ParticleSensor_Backend.h
@@ -1,0 +1,26 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <stdint.h>
+
+class AP_ParticleSensor_Backend {
+public:
+
+    virtual void update() = 0;
+
+private:
+
+};

--- a/libraries/AP_ParticleSensor/AP_ParticleSensor_SDS021.cpp
+++ b/libraries/AP_ParticleSensor/AP_ParticleSensor_SDS021.cpp
@@ -1,0 +1,119 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ParticleSensor_SDS021.h"
+
+#include <stdio.h>
+
+#include <AP_Logger/AP_Logger.h>
+
+AP_ParticleSensor_SDS021::AP_ParticleSensor_SDS021(AP_HAL::UARTDriver &_port) :
+        port(_port)
+{
+        port.begin(9600);
+        port.set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
+}
+
+void AP_ParticleSensor_SDS021::yield_message()
+{
+    ::fprintf(stderr, "SDS021: %u: PM1.0=%0.1f PM2.5=%0.1f (bad=%u cksum fails=%u)\n", AP_HAL::millis(), reading.pm10/10.0, reading.pm25/10.0, bad_chars, checksum_failures);
+    const uint64_t now = AP_HAL::micros64();
+    AP::logger().Write(
+        "S021",
+        "TimeUS,pm10,pm25",
+        "Qhh",
+        now, reading.pm10, reading.pm25);
+}
+
+void AP_ParticleSensor_SDS021::handle_byte_read(const uint8_t byte)
+{
+    // fprintf(stderr, "Got byte (0x%02x) (state=%u)\n", byte, state);
+    switch(state) {
+    case State::WantHeader:
+        switch(byte) {
+        case 0xAA:
+            state = State::WantCommand;
+            break;
+        default:
+            bad_chars++;
+            break;
+        }
+        break;
+    case State::WantCommand:
+        switch(byte) {
+        case 0xC0:
+            state = State::WantData1;
+            break;
+        default:
+            bad_chars++;
+            state = State::WantHeader;
+            break;
+        }
+        break;
+    case State::WantData1:
+        reading.pm25 = byte;
+        state = State::WantData2;
+        checksum = byte;
+        break;
+    case State::WantData2:
+        reading.pm25 |= byte<<8;
+        state = State::WantData3;
+        checksum += byte;
+        break;
+    case State::WantData3:
+        reading.pm10 = byte;
+        state = State::WantData4;
+        checksum += byte;
+        break;
+    case State::WantData4:
+        reading.pm10 |= byte<<8;
+        state = State::WantData5;
+        checksum += byte;
+        break;
+    case State::WantData5:
+        state = State::WantData6;
+        checksum += byte;
+        break;
+    case State::WantData6:
+        state = State::WantChecksum;
+        checksum += byte;
+        break;
+    case State::WantChecksum:
+        if (byte != checksum) {
+            checksum_failures++;
+            fprintf(stderr, "checksum failure (%u) vs (%u)\n", byte, checksum);
+            state = State::WantHeader;
+            break;
+        }
+        state = State::WantTail;
+        yield_message();
+        break;
+    case State::WantTail:
+        if (byte != 0xAB) {
+            bad_chars++;
+        }
+        state = State::WantHeader;
+        break;
+    }
+}
+
+void AP_ParticleSensor_SDS021::update()
+{
+    uint8_t count = 10; // maximum characters to process per update
+    while (count-- > 0 && port.available()) {
+        const uint8_t next = port.read();
+        handle_byte_read((uint8_t)next);
+    }
+}

--- a/libraries/AP_ParticleSensor/AP_ParticleSensor_SDS021.h
+++ b/libraries/AP_ParticleSensor/AP_ParticleSensor_SDS021.h
@@ -1,0 +1,60 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "AP_ParticleSensor_Backend.h"
+#include <AP_HAL/AP_HAL.h>
+
+class AP_ParticleSensor_SDS021 : public AP_ParticleSensor_Backend {
+public:
+
+    AP_ParticleSensor_SDS021(AP_HAL::UARTDriver &port);
+
+    virtual void update() override;
+
+private:
+
+    AP_HAL::UARTDriver &port;
+
+    void yield_message();
+    void handle_byte_read(uint8_t byte);
+
+    enum class State {
+        WantHeader,
+        WantCommand,
+        WantData1,
+        WantData2,
+        WantData3,
+        WantData4,
+        WantData5,
+        WantData6,
+        WantChecksum,
+        WantTail,
+    };
+    State state = State::WantHeader;
+
+    uint32_t bad_chars;
+    uint32_t checksum_failures;
+
+    class Reading
+    {
+    public:
+        uint16_t pm25; //10ug/m^3
+        uint16_t pm10; //10ug/m^3
+    };
+
+    Reading reading;
+    uint8_t checksum;
+};

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -134,7 +134,8 @@ public:
         SerialProtocol_RCIN = 23,
         SerialProtocol_EFI_MS = 24,                   // MegaSquirt EFI serial protocol
         SerialProtocol_LTM_Telem = 25,
-        SerialProtocol_RunCam = 26
+        SerialProtocol_RunCam = 26,
+        SerialProtocol_SDS021 = 27,
     };
 
     // get singleton instance

--- a/libraries/SITL/SIM_ParticleSensor_SDS021.cpp
+++ b/libraries/SITL/SIM_ParticleSensor_SDS021.cpp
@@ -1,0 +1,108 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple particle sensor simulator class
+*/
+
+#include "SIM_ParticleSensor_SDS021.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+using namespace SITL;
+
+ParticleSensor_SDS021::ParticleSensor_SDS021() :
+    SerialDevice()
+{
+}
+
+/*
+  update particle sensor state
+ */
+void ParticleSensor_SDS021::update(const Location &loc)
+{
+    const uint64_t now = AP_HAL::millis();
+
+    if (now - last_update_ms < 1000) {
+        // we only provide a reading every second
+        return;
+    }
+    last_update_ms = now;
+
+    // push a reading into the socket...
+    const float value10 = 8.7;
+    const float value25 = 3.9;
+    const bool should_corrupt = false;
+    push_reading(value10, value25, should_corrupt);
+}
+
+
+bool ParticleSensor_SDS021::push_byte(const uint8_t byte)
+{
+    if (write_to_autopilot((char*)&byte, 1) != 1) {
+        return false;
+    }
+    checksum += byte;
+    return true;
+}
+
+void ParticleSensor_SDS021::push_reading(const float value10, const float value25, const bool should_corrupt)
+{
+    const char header_byte = 0xAA;
+    if (!push_byte(header_byte)) {
+        return;
+    }
+
+    const char commander_no = 0xC0;
+    if (!push_byte(commander_no)) {
+        return;
+    }
+    checksum = 0;
+    const uint16_t pm25 = (uint16_t)(value25*10);
+    const uint8_t pm25_low = (pm25 & 0xff);
+    if (!push_byte(pm25_low)) {
+        return;
+    }
+    const uint8_t pm25_high = ((pm25>>8) & 0xff);
+    if (!push_byte(pm25_high)) {
+        return;
+    }
+    const uint16_t pm10 = (uint16_t)(value10*10);
+    const uint8_t pm10_low = (pm10 & 0xff);
+    if (!push_byte(pm10_low)) {
+        return;
+    }
+    const uint8_t pm10_high = ((pm10>>8) & 0xff);
+    if (!push_byte(pm10_high)) {
+        return;
+    }
+    const uint8_t id1 = 1;
+    if (!push_byte(id1)) {
+        return;
+    }
+    const uint8_t id2 = 0;
+    if (!push_byte(id2)) {
+        return;
+    }
+
+    if (!push_byte(checksum)) {
+        return;
+    }
+
+    const char footer_byte = 0xAB; // Message Tail
+    if (!push_byte(footer_byte)) {
+        return;
+    }
+}

--- a/libraries/SITL/SIM_ParticleSensor_SDS021.h
+++ b/libraries/SITL/SIM_ParticleSensor_SDS021.h
@@ -1,0 +1,49 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple particle sensor simulation
+
+./Tools/autotest/sim_vehicle.py --gdb --debug -v APMrover2 -A --uartF=sim:sds021 --speedup=1
+
+param set SERIAL5_PROTOCOL 24
+reboot
+
+*/
+
+#pragma once
+
+#include "SIM_SerialDevice.h"
+
+namespace SITL {
+
+class ParticleSensor_SDS021 : public SerialDevice {
+public:
+
+    ParticleSensor_SDS021();
+
+    // update state
+    void update(const Location &loc);
+
+private:
+
+    uint32_t last_update_ms;
+
+    uint8_t checksum;
+
+    bool push_byte(const uint8_t byte);
+    void push_reading(const float value10, const float value25, const bool should_corrupt);
+};
+
+}


### PR DESCRIPTION
This is a serially-connected sensor which gives readings for both 1 and 2.5 micron particles.

I initially wrote this as an "example" driver which people might model their UART drivers on, however it's been suggested I push this ahead for merging.

If nothing else it might prompt a discussion on supporting this sort of sensor.  Perhaps this would be better left to scripting in the modern day-and-age?

TODO:

 - [ ] protect compilation with `#ifdef`s
