### PR TITLE
AP_Logger: fix locking issues, log wrapping and status messages

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Block.h
+++ b/libraries/AP_Logger/AP_Logger_Block.h
@@ -112,9 +112,14 @@ protected:
     uint32_t df_NumPages;
     bool log_write_started;
 
-    // get the next sector from the current page
+    // get the current sector from the current page
     uint32_t get_sector(uint32_t current_page) {
         return ((current_page - 1) / df_PagePerSector);
+    }
+
+    // get the current block from the current page
+    uint32_t get_block(uint32_t current_page) {
+        return ((current_page - 1) / df_PagePerBlock);
     }
 
     static const uint16_t page_size_max = 256;


### PR DESCRIPTION
This is a follow-up to https://github.com/ArduPilot/ardupilot/pull/13130
I was getting hangs in chip erase which lead to corrupted logs. This PR fixes this problem.
It also shortens some of the status messages so that they can be seen. 

Tests done:
- [x] Start and stop logs using LOG_DISARMED, check logs list ok
- [x] Allow logs to wrap so that indexing no longer starts at 1, check logs list ok
- [x] Allow a single log to wrap itself, check listing works ok and log can be downloaded
- [x] Chip erase works and logging will work again afterwards
- [x] Pull the power during chip erase and make sure it restarts
- [ ] Chip erase and then check that logs can be written once again without rebooting

All pass except the last one. So if you erase the chip you need to reboot to get logging to work again. This seems like a small inconvenience and nothing actually breaks in all these tests