### PR TITLE
AP_Scripting: add declaration for lua_new_uint32_t

### DIFF
--- a/libraries/AP_Scripting/lua_boxed_numerics.h
+++ b/libraries/AP_Scripting/lua_boxed_numerics.h
@@ -3,6 +3,7 @@
 #include "lua/src/lua.hpp"
 
 int new_uint32_t(lua_State *L);
+int lua_new_uint32_t(lua_State *L);
 uint32_t *check_uint32_t(lua_State *L, int arg);
 
 void load_boxed_numerics(lua_State *L);


### PR DESCRIPTION
This PR adds a missing declaration which resolve this (innocuous) compiler warning https://github.com/ArduPilot/ardupilot/issues/13180