### PR TITLE
GCS_MAVLink: send optflow message even if no height estimate

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2074,12 +2074,9 @@ void GCS_MAVLINK::send_opticalflow()
     const Vector2f &flowRate = optflow->flowRate();
     const Vector2f &bodyRate = optflow->bodyRate();
 
-    const AP_AHRS &ahrs = AP::ahrs();
-    float hagl = 0;
-    if (ahrs.have_inertial_nav()) {
-        if (!ahrs.get_hagl(hagl)) {
-            return;
-        }
+    float hagl;
+    if (!AP::ahrs().get_hagl(hagl)) {
+        hagl = 0;
     }
 
     // populate and send message


### PR DESCRIPTION
This resolves an issue discovered post Copter-4.0.0 release in which a user had difficulties confirming that the optical flow sensor was working because the flow rates were not being reported to the ground station.  The values were appearing in the onboard logs however.  The discussion with firenitin is here: https://discuss.ardupilot.org/t/cheerson-cx-of-low-cost-optical-flow-sensor-testing/35598/152

This has been tested on a CubeBlack autopilot with a HereFlow sensor attached.  Before the change the flow_comp_m_x/y values were not being sent, post the change they were.
![image](https://user-images.githubusercontent.com/1498098/71789712-0cf3dc00-3070-11ea-902a-c09a7bd72254.png)
