### PR TITLE
AP_Logger: initialise last_file value

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -264,7 +264,7 @@ void AP_Logger_Block::validate_log_structure()
     uint16_t file = GetFileNumber();
     uint16_t first_file = file;
     uint16_t next_file = file;
-    uint16_t last_file;
+    uint16_t last_file = 0;
 
     while (file != 0xFFFF && page <= df_NumPages && (file == next_file || (wrapped && file < next_file))) {
         uint32_t end_page = find_last_page_of_log(file);


### PR DESCRIPTION
../../libraries/AP_Logger/AP_Logger_Block.cpp: In member function ‘void AP_Logger_Block::validate_log_structure()’:
../../libraries/AP_Logger/AP_Logger_Block.cpp:282:16: error: ‘last_file’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         } else if (last_file < next_file) {
                ^~
compilation terminated due to -Wfatal-errors.
cc1plus: some warnings being treated as errors