### PR TITLE
AP_SerialManager: ensure users can't break SERIAL0_PROTOCOL

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -355,6 +355,18 @@ void AP_SerialManager::init()
     state[7].uart = hal.uartH;  // serial7
 #endif
 
+#ifdef HAL_OTG1_CONFIG
+    /*
+      prevent users from changing USB protocol to other than
+      MAVLink. This fixes an issue where users trying to get SLCAN
+      change SERIAL0_PROTOCOL to 22 and find they can no longer connect
+     */
+    if (state[0].protocol != SerialProtocol_MAVLink &&
+        state[0].protocol != SerialProtocol_MAVLink2) {
+        state[0].protocol.set(SerialProtocol_MAVLink2);
+    }
+#endif
+
 #if SERIALMANAGER_NUM_PORTS > 0
     if (state[0].uart == nullptr) {
         init_console();


### PR DESCRIPTION
this prevents users from setting SERIAL0_PROTOCOL to something that
prevents them accessing the board. This can happen when users are
trying to setup SLCAN