### PR TITLE
GCS_MAVLink: According to the method specification

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2074,10 +2074,8 @@ void GCS_MAVLINK::send_opticalflow()
     const Vector2f &flowRate = optflow->flowRate();
     const Vector2f &bodyRate = optflow->bodyRate();
 
-    float hagl;
-    if (!AP::ahrs().get_hagl(hagl)) {
-        hagl = 0;
-    }
+    float hagl = 0.0f;
+    AP::ahrs().get_hagl(hagl);
 
     // populate and send message
     mavlink_msg_optical_flow_send(


### PR DESCRIPTION
The get_hagl method has a function to get altitude.
Currently, since this function is not provided, false is returned as the processing result.
As the specification, set the altitude value when true.
I don't think it is necessary to judge the processing result of the method.

method spec:
// get latest altitude estimate above ground level in meters and validity flag
virtual bool get_hagl(float &height) const { return false; }
