### PR TITLE
Allow scripts to get modes

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -390,6 +390,7 @@ private:
     void update_ahrs_flyforward();
     bool set_mode(Mode &new_mode, ModeReason reason);
     bool set_mode(const uint8_t new_mode, ModeReason reason) override;
+    uint8_t get_mode() const override { return (uint8_t)control_mode->mode_number(); }
     bool mavlink_set_mode(uint8_t mode);
     void startup_INS_ground(void);
     void notify_mode(const Mode *new_mode);

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -224,6 +224,7 @@ private:
     void prepare_servos();
     void set_mode(Mode &newmode, ModeReason reason);
     bool set_mode(uint8_t new_mode, ModeReason reason) override;
+    uint8_t get_mode() const override { return (uint8_t)mode->number(); }
     bool should_log(uint32_t mask);
     bool start_command_callback(const AP_Mission::Mission_Command& cmd) { return false; }
     void exit_mission_callback() { return; }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -796,6 +796,7 @@ private:
     // mode.cpp
     bool set_mode(Mode::Number mode, ModeReason reason);
     bool set_mode(const uint8_t new_mode, const ModeReason reason) override;
+    uint8_t get_mode() const override { return (uint8_t)control_mode; }
     void update_flight_mode();
     void notify_flight_mode();
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -901,6 +901,7 @@ private:
     bool set_mode(Mode& new_mode, const ModeReason reason);
     bool set_mode(const uint8_t mode, const ModeReason reason) override;
     bool set_mode_by_number(const Mode::Number new_mode_number, const ModeReason reason);
+    uint8_t get_mode() const override { return (uint8_t)control_mode->mode_number(); }
     Mode *mode_from_mode_num(const enum Mode::Number num);
     void check_long_failsafe();
     void check_short_failsafe();

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -540,6 +540,7 @@ private:
     void fence_check();
     bool set_mode(control_mode_t mode, ModeReason reason);
     bool set_mode(const uint8_t mode, const ModeReason reason) override;
+    uint8_t get_mode() const override { return (uint8_t)control_mode; }
     void update_flight_mode();
     void exit_mode(control_mode_t old_control_mode, control_mode_t new_control_mode);
     bool mode_requires_GPS(control_mode_t mode);

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -60,6 +60,7 @@ public:
     void load_parameters(void);
 
     virtual bool set_mode(const uint8_t new_mode, const ModeReason reason) override { return true; }
+    virtual uint8_t get_mode() const override { return 0; }
 
     AP_Vehicle::FixedWing aparm;
     AP_Airspeed airspeed;

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -144,6 +144,7 @@ singleton GCS method set_message_interval MAV_RESULT'enum uint8_t 0 MAVLINK_COMM
 include AP_Vehicle/AP_Vehicle.h
 singleton AP_Vehicle alias vehicle
 singleton AP_Vehicle method set_mode boolean uint8_t 0 UINT8_MAX ModeReason::SCRIPTING'literal
+singleton AP_Vehicle method get_mode uint8_t
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,4 +1,4 @@
-// auto generated bindings, don't manually edit
+// auto generated bindings, don't manually edit.  See README.md for details.
 #include "lua_generated_bindings.h"
 #include "lua_boxed_numerics.h"
 #include <RC_Channel/RC_Channel.h>
@@ -622,6 +622,19 @@ static int AP_SerialLED_set_num_LEDs(lua_State *L) {
             data_3);
 
     lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_Vehicle_get_mode(lua_State *L) {
+    AP_Vehicle * ud = AP_Vehicle::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "vehicle not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    const uint8_t data = ud->get_mode();
+
+    lua_pushinteger(L, data);
     return 1;
 }
 
@@ -1782,6 +1795,7 @@ const luaL_Reg AP_SerialLED_meta[] = {
 };
 
 const luaL_Reg AP_Vehicle_meta[] = {
+    {"get_mode", AP_Vehicle_get_mode},
     {"set_mode", AP_Vehicle_set_mode},
     {NULL, NULL}
 };

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,5 @@
 #pragma once
-// auto generated bindings, don't manually edit
+// auto generated bindings, don't manually edit.  See README.md for details.
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_SerialLED/AP_SerialLED.h>

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -56,6 +56,7 @@ public:
     static AP_Vehicle *get_singleton();
 
     bool virtual set_mode(const uint8_t new_mode, const ModeReason reason) = 0;
+    uint8_t virtual get_mode() const = 0;
 
     /*
       common parameters for fixed wing aircraft


### PR DESCRIPTION
This PR allow LUA scripting change the flight mode.
I referenced #12575

I checked this in SITL (Plane, Copter, Sub, Rover, AntennaTracker) and Cube (with Copter) using the following script

```lua
function update()
  mode = vehicle:get_mode()
  gcs:send_text(0, mode)
  return update, 2000
end

return update()
```
