### PR TITLE
Add -werror=unused-value

### DIFF
--- a/ArduSub/control_motordetect.cpp
+++ b/ArduSub/control_motordetect.cpp
@@ -82,7 +82,7 @@ void Sub::motordetect_run()
         // Force all motors to stop
         for (uint8_t i=0; i <AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motors.motor_is_enabled(i)) {
-                !motors.output_test_num(i, 1500);
+                motors.output_test_num(i, 1500);
             }
         }
         // wait until gyro product is under a certain(experimental) threshold

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -193,6 +193,7 @@ class Board:
             '-Werror=type-limits',
             '-Werror=unused-result',
             '-Werror=shadow',
+            '-Werror=unused-value',
             '-Werror=unused-variable',
             '-Werror=delete-non-virtual-dtor',
             '-Wfatal-errors',


### PR DESCRIPTION
In particular, this picks up expressions whose results are unused.
