### PR TITLE
AP_OpticalFlow: Deleted parameter descriptions without variables

### DIFF
--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -83,13 +83,6 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_ADDR", 5,  OpticalFlow, _address,   0),
 
-    // the parameter description below is for GCSs (like MP) that use master for the parameter descriptions.  This should be removed when Copter-3.7 is released
-    // @Param: _ENABLE
-    // @DisplayName: Optical flow enable/disable
-    // @Description: Setting this to Enabled(1) will enable optical flow. Setting this to Disabled(0) will disable optical flow
-    // @Values: 0:Disabled, 1:Enabled
-    // @User: Standard
-
     AP_GROUPEND
 };
 


### PR DESCRIPTION
I set the OPTICAL FLOW setting by looking at WIKI.
I could not find FLOW_ENABLE from the config parameters.
I know that the description of the WIKI config parameters is created from the source.
I don't think a description without parameters is necessary.

WIKI:
https://ardupilot.org/copter/docs/parameters.html#flow-enable
EX:
https://ardupilot.org/copter/docs/common-cheerson-cxof.html