### PR TITLE
AP_WheelEncoder: get_delta_angle() should also return get_last_update_ms()

### DIFF
--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -42,8 +42,7 @@ void Rover::update_wheel_encoder()
     if (!wheel_encoder_initialised) {
         wheel_encoder_initialised = true;
         for (uint8_t i = 0; i < g2.wheel_encoder.num_sensors(); i++) {
-            wheel_encoder_last_angle_rad[i] = g2.wheel_encoder.get_delta_angle(i);
-            wheel_encoder_last_reading_ms[i] = g2.wheel_encoder.get_last_reading_ms(i);
+            g2.wheel_encoder.get_delta_angle_and_last_reading_ms(i,wheel_encoder_last_angle_rad[i],wheel_encoder_last_reading_ms[i]);
         }
         return;
     }
@@ -55,8 +54,9 @@ void Rover::update_wheel_encoder()
     }
 
     // get current time, total delta angle (since startup) and update time from sensor
-    const float curr_angle_rad = g2.wheel_encoder.get_delta_angle(wheel_encoder_last_index_sent);
-    const uint32_t sensor_reading_ms = g2.wheel_encoder.get_last_reading_ms(wheel_encoder_last_index_sent);
+    float curr_angle_rad;
+    uint32_t sensor_reading_ms;
+    g2.wheel_encoder.get_delta_angle_and_last_reading_ms(wheel_encoder_last_index_sent,curr_angle_rad,sensor_reading_ms);
     const uint32_t now_ms = AP_HAL::millis();
 
     // calculate angular change (in radians)

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -102,9 +102,9 @@ public:
 
     // get the signal quality for a sensor (0 = extremely poor quality, 100 = extremely good quality)
     float get_signal_quality(uint8_t instance) const;
-
-    // get the system time (in milliseconds) of the last update
-    uint32_t get_last_reading_ms(uint8_t instance) const;
+        
+    // get total delta angle (in radians) measured by the wheel encoder and system time (in milliseconds) of the last update to avoid race condition
+    void get_delta_angle_and_last_reading_ms(uint8_t instance,float &delta_angle,uint32_t &sensor_reading_ms) const;
 
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
This is in response to #12613.
I defined a completely new function that would return both delta_angle and get_last_update_ms simultaneously. 
I deleted the function [get_last_reading_ms()](https://github.com/ArduPilot/ardupilot/blob/0986ed0a81096c43ae1db1c0ea833828c5b83dc6/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp#L336) all together since my new function would automatically return it and it was not needed anymore. However, I did not delete [get_delta_angle()](https://github.com/ArduPilot/ardupilot/blob/0986ed0a81096c43ae1db1c0ea833828c5b83dc6/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp#L268) because it is being used [here](https://github.com/ArduPilot/ardupilot/blob/0986ed0a81096c43ae1db1c0ea833828c5b83dc6/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp#L285).
We can, however, get rid of the function entirely after discussion. 