### PR TITLE
SITL: Indicates that the message is SIM only

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -502,7 +502,7 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
     // constrain height to the ground
     if (on_ground()) {
         if (!was_on_ground && AP_HAL::millis() - last_ground_contact_ms > 1000) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Hit ground at %f m/s", velocity_ef.z);
+            gcs().send_text(MAV_SEVERITY_INFO, "SIM Hit ground at %f m/s", velocity_ef.z);
             last_ground_contact_ms = AP_HAL::millis();
         }
         position.z = -(ground_level + frame_height - home.alt * 0.01f + ground_height_difference());


### PR DESCRIPTION
I debug with SITL.
I confirm the operation in the message.
I learned that there was no distinction between SITL messages and regular messages.
I think it would be better to have a key "SIM" to indicate that it is a SIM message.

AFTER:
![Screenshot from 2020-01-12 09-34-21](https://user-images.githubusercontent.com/646194/72212600-399d6d00-3522-11ea-9a70-2341ed825f98.png)
