### PR TITLE
AP_AdvancedFailsafe: Add triggering AFS by aux input pin

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -52,7 +52,7 @@
 // features below are disabled by default on all boards
 //#define CAL_ALWAYS_REBOOT                         // flight controller will reboot after compass or accelerometer calibration completes
 //#define DISALLOW_GCS_MODE_CHANGE_DURING_RC_FAILSAFE   // disable mode changes from GCS during Radio failsafes.  Avoids a race condition for vehicle like Solo in which the RC and telemetry travel along the same link
-//#define ADVANCED_FAILSAFE     ENABLED             // enabled advanced failsafe which allows running a portion of the mission in failsafe events
+#define ADVANCED_FAILSAFE     ENABLED             // enabled advanced failsafe which allows running a portion of the mission in failsafe events
 
 // other settings
 //#define THROTTLE_IN_DEADBAND   100                // redefine size of throttle deadband in pwm (0 ~ 1000)

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -371,9 +371,7 @@ void Copter::do_failsafe_action(Failsafe_Action action, ModeReason reason){
             break;
         case Failsafe_Action_Terminate:
 #if ADVANCED_FAILSAFE == ENABLED
-            char battery_type_str[17];
-            snprintf(battery_type_str, 17, "%s battery", type_str);
-            g2.afs.gcs_terminate(true, battery_type_str);
+            g2.afs.terminate_vehicle();
 #else
             arming.disarm();
 #endif

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -131,7 +131,9 @@ protected:
     AP_Int8  _enable_RC_fs;
     AP_Int8  _rc_term_manual_only;
     AP_Int8  _enable_dual_loss;
-    AP_Int16  _max_range_km;
+    AP_Int16 _max_range_km;
+    AP_Int8  _input_pin;
+    AP_Int8  _input_pin_pol;
 
     bool _heartbeat_pin_value;
 
@@ -156,6 +158,7 @@ protected:
     Location _first_location;
     bool _have_first_location;
     uint32_t _term_range_notice_ms;
+    uint8_t  _last_afs_input_pin_state;
 
     bool check_altlimit(void);
 
@@ -164,6 +167,9 @@ private:
 
     // update maximum range check
     void max_range_update();
+
+    // update the input pin check
+    void input_pin_update(void);
 };
 
 namespace AP {


### PR DESCRIPTION
This will allow an external device to trigger the advanced failsafe termination by pulling an aux input pin high or low.  Also in this PR, I have enabled AFS in copter (maybe temporarily) since that's where a use case recently came up. However I can pull that out into a separate PR if needed. 

The most obvious use for this that recently came up is for an external parachute controller.  This will allow the external chute controller to trigger AFS cutting the motors when it pops the chute.  Any other external failsafe or deadman can utilize this to.

I still cannot figure out how to set an aux pin high or low in SITL to test this, and I don't have hardware available to test it for real with.  If someone can show me how to do that, that'd be great.