### PR TITLE
AP_BLHeli: allow mixed type connection and stop motors if connection lost

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1136,15 +1136,15 @@ bool AP_BLHeli::protocol_handler(uint8_t b, AP_HAL::UARTDriver *_uart)
 */
 void AP_BLHeli::run_connection_test(uint8_t chan)
 {
+    run_test.set_and_notify(0);
     debug_uart = hal.console;
     uint8_t saved_chan = blheli.chan;
     if (chan >= num_motors) {
-        debug("bad channel %u", chan);
+        gcs().send_text(MAV_SEVERITY_INFO, "ESC: bad channel %u", chan);
         return;
     }
     blheli.chan = chan;
-    debug("Running test on channel %u", blheli.chan);
-    run_test.set_and_notify(0);
+    gcs().send_text(MAV_SEVERITY_INFO, "ESC: Running test on channel %u",  blheli.chan);
     bool passed = false;
     for (uint8_t tries=0; tries<5; tries++) {
         EXPECT_DELAY_MS(3000);
@@ -1172,11 +1172,11 @@ void AP_BLHeli::run_connection_test(uint8_t chan)
         }
     }
     hal.rcout->serial_end();
-    SRV_Channels::set_disabled_channel_mask(0);            
+    SRV_Channels::set_disabled_channel_mask(0);
     motors_disabled = false;
     serial_start_ms = 0;
     blheli.chan = saved_chan;
-    debug("Test %s", passed?"PASSED":"FAILED");
+    gcs().send_text(MAV_SEVERITY_INFO, "ESC: Test %s", passed?"PASSED":"FAILED");
     debug_uart = nullptr;
 }
 

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -239,6 +239,9 @@ private:
     // have we locked the UART?
     bool uart_locked;
 
+    // true if we have a mix of reversable and normal ESC
+    bool mixed_type;
+
     // mapping from BLHeli motor numbers to RC output channels
     uint8_t motor_map[max_motors];
     uint16_t motor_mask;


### PR DESCRIPTION
This is two bug fixes for BLHeli suite connection following up from https://github.com/ArduPilot/ardupilot/pull/13058

If a mix of reversible and normal motors are connected it now reports 0 pwm allowing BLHeli suite to connect, and disables motor test functionality. This is because in this situation BLHeli suite is expecting all reversible ESC's so will output 1500 on all channels, this will be 50% throttle on normal motors. (I have not tested if motor test would work in this situation in anycase)

This also implements a 1 second connection time out when motors are active, currently if you pull the usb during a motor test it just leaves the motor at whatever pwm it was at, this now writes 1000 for normal and 1500 for reversible to the outputs on time out.

