### PR TITLE
Tools: exclude build-linux-libraries and gtest from coverage analysis

### DIFF
--- a/Tools/scripts/run-coverage
+++ b/Tools/scripts/run-coverage
@@ -49,7 +49,10 @@ LCOV_LOG="GCOV_lcov.log"
 GENHTML_LOG="GCOV_genhtml.log"
 
 lcov --no-external --capture --directory $PWD -o "$INFO_FILE" 2>&1 | tee $LCOV_LOG
+# remove files we do not intentionally test:
 lcov --remove "$INFO_FILE" ".waf*" -o "$INFO_FILE" 2>&1 | tee -a $LCOV_LOG
+lcov --remove "$INFO_FILE" "$PWD/modules/gtest/*" -o "$INFO_FILE" 2>&1 | tee -a $LCOV_LOG
+lcov --remove "$INFO_FILE" "$PWD/build/linux/libraries/*" -o "$INFO_FILE" 2>&1 | tee -a $LCOV_LOG
 
 genhtml "$INFO_FILE" -o "$REPORT_DIR" 2>&1 | tee $GENHTML_LOG
 


### PR DESCRIPTION
The build-linux-libraries were mavlink-generated headers created when we
build the examples.  We don't intentionally try to test anything in
there at the moment, so it's noise.


Also... the removal of the .waf stuff seems to do nothing....
