### PR TITLE
GCS_Mavlink: report sensors initialized 

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -22,6 +22,16 @@ void GCS::get_sensor_status_flags(uint32_t &present,
     health = control_sensors_health;
 }
 
+void GCS::get_sensor_status_flags(uint32_t &present,
+                                  uint32_t &enabled,
+                                  uint32_t &health,
+                                  uint32_t &initialised)
+{
+    get_sensor_status_flags(present, enabled, health);
+
+    initialised = control_sensors_initialised;
+}
+
 MissionItemProtocol_Waypoints *GCS::_missionitemprotocol_waypoints;
 MissionItemProtocol_Rally *GCS::_missionitemprotocol_rally;
 MissionItemProtocol_Fence *GCS::_missionitemprotocol_fence;
@@ -211,6 +221,8 @@ void GCS::update_sensor_status_flags()
     }
 
     update_vehicle_sensor_status_flags();
+
+    control_sensors_initialised |= control_sensors_health;
 }
 
 bool GCS::out_of_time() const

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -893,6 +893,7 @@ public:
     // update uart pass-thru
     void update_passthru();
 
+    void get_sensor_status_flags(uint32_t &present, uint32_t &enabled, uint32_t &health,  uint32_t &initialised);
     void get_sensor_status_flags(uint32_t &present, uint32_t &enabled, uint32_t &health);
     virtual bool vehicle_initialised() const { return true; }
 
@@ -913,6 +914,7 @@ protected:
     uint32_t control_sensors_present;
     uint32_t control_sensors_enabled;
     uint32_t control_sensors_health;
+    uint32_t control_sensors_initialised;
     virtual void update_vehicle_sensor_status_flags() {}
 
     GCS_MAVLINK_Parameters chan_parameters[MAVLINK_COMM_NUM_BUFFERS];

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4120,8 +4120,9 @@ void GCS_MAVLINK::send_sys_status()
     uint32_t control_sensors_present;
     uint32_t control_sensors_enabled;
     uint32_t control_sensors_health;
+    uint32_t control_sensors_initialised;
 
-    gcs().get_sensor_status_flags(control_sensors_present, control_sensors_enabled, control_sensors_health);
+    gcs().get_sensor_status_flags(control_sensors_present, control_sensors_enabled, control_sensors_health,control_sensors_initialised);
 
     const uint32_t errors = AP::internalerror().errors();
     const uint16_t errors1 = errors & 0xffff;
@@ -4142,7 +4143,8 @@ void GCS_MAVLINK::send_sys_status()
         errors1,
         errors2,
         0,  // errors3
-        errors4); // errors4
+        errors4, // errors4
+        control_sensors_initialised);
 }
 
 void GCS_MAVLINK::send_extended_sys_state() const


### PR DESCRIPTION
This uses a new sensors initialized flag extension added in https://github.com/ArduPilot/mavlink/pull/124

A possible solution to https://github.com/ArduPilot/ardupilot/issues/12456 with some MP work to report 'initializing' with a higher priority than health
