### PR TITLE
Travis: Combine jobs, flake8 has been moved to semaphore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,17 +71,5 @@ matrix:
       compiler: "clang-7"
       env: CI_BUILD_TARGET="sitltest-rover sitltest-sub sitltest-balancebot"
     - if: type != cron
-      compiler: "gcc"
-      env: CI_BUILD_TARGET="unit-tests"
-    - if: type != cron
       compiler: "clang-7"
-      env: CI_BUILD_TARGET="sitl""
-    - language: python
-      python: 3.7
-      addons:  # speedup: This test does not need addons
-      compiler:
-      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-      before_install: pip install flake8
-      script:
-        - EXCLUDE=./.*,./modules/gtest,./modules/ChibiOS/test,./modules/uavcan/libuavcan,./modules/libcanard
-        - flake8 . --count --exclude=$EXCLUDE --select=E901,E999,F821,F822,F823 --show-source --statistics
+      env: CI_BUILD_TARGET="unit-tests sitl"


### PR DESCRIPTION
This does a couple of things to improve CI times:
  - The SITL and unit-test tasks are now both done with clang-7, and are done in the same instance. We spent more time spooling up/installing tooling then we did doing either of these tasks, so we can save a far amount of machine time here.
  - Flake8 is now run on SemaphoreCI instead, the only downside here is due to python versioning nightmares I ended up using Python 3.6 here instead of Python 3.7.
  - Not visible in the PR, but I also advanced the semaphore platform, which gives us a slightly newer set of dependencies to work from.

The net effect is travis should be a lot more responsive and complete it's tasks quicker/PR's should get less backlogged.