### PR TITLE
Correct vagrant boot of boxes

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -9,6 +9,18 @@ if [ $EUID == 0 ]; then
 fi
 
 OPT="/opt"
+RELEASE_CODENAME=$(lsb_release -c -s)
+if [ ${RELEASE_CODENAME} == 'xenial' ]; then
+    SITLFML_VERSION="2.3v5"
+    SITLCFML_VERSION="2.3"
+elif [ ${RELEASE_CODENAME} == 'disco' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
+else
+    SITLFML_VERSION="2.4"
+    SITLCFML_VERSION="2.4"
+fi
+
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
 PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"
 # add some Python packages required for commonly-used MAVProxy modules:
@@ -20,7 +32,7 @@ ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 # python-wxgtk packages are added to SITL_PKGS below
 SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing xterm lcov gcovr"
 # add some packages required for commonly-used MAVProxy modules:
-SITL_PKGS="$SITL_PKGS libcsfml-dev libcsfml-audio2.4 libcsfml-dev libcsfml-graphics2.4 libcsfml-network2.4 libcsfml-system2.4 libcsfml-window2.4 libsfml-audio2.4 libsfml-dev libsfml-graphics2.4 libsfml-network2.4 libsfml-system2.4 libsfml-window2.4 python-yaml python3-yaml"
+SITL_PKGS="$SITL_PKGS libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION} python-yaml python3-yaml"
 
 ASSUME_YES=false
 QUIET=false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,18 +45,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # LTS, EOL April, 2019:
   config.vm.define "trusty32", autostart: false do |trusty32|
-    config.vm.box = "ubuntu/trusty32"
-    config.vm.provision "trusty32", type: "shell", path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    trusty32.vm.box = "ubuntu/trusty32"
+    trusty32.vm.provision "trusty32", type: "shell", path: "Tools/vagrant/initvagrant.sh"
+    trusty32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (trusty32)"
     end
   end
 
   # 14.04.5 LTS, EOL April, 2019:
   config.vm.define "trusty64", autostart: false do |trusty64|
-    config.vm.box = "ubuntu/trusty64"
-    config.vm.provision "trusty64", type: "shell", path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    trusty64.vm.box = "ubuntu/trusty64"
+    trusty64.vm.provision "trusty64", type: "shell", path: "Tools/vagrant/initvagrant.sh"
+    trusty64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (trusty64)"
     end
   end
@@ -64,16 +64,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # LTS, EOL April 2021
   # this VM is useful for running valgrind on!
   config.vm.define "xenial32", autostart: false do |xenial32|
-    config.vm.box = "ubuntu/xenial32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    xenial32.vm.box = "ubuntu/xenial32"
+    xenial32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    xenial32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (xenial32)"
     end
   end
+
   config.vm.define "xenial64", autostart: false do |xenial64|
-    config.vm.box = "ubuntu/xenial64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    xenial64.vm.box = "ubuntu/xenial64"
+    xenial64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    xenial64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (xenial64)"
     end
   end
@@ -82,9 +83,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # EOL January 2018
   # Only kept around for those few dev's who have already got this image and continue to use it.
   config.vm.define "zesty32", autostart: false do |zesty32|
-    config.vm.box = "ubuntu/zesty32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    zesty32.vm.box = "ubuntu/zesty32"
+    zesty32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    zesty32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (zesty32)"
     end
   end
@@ -92,55 +93,55 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # 17.10, EOL July 2018
   # Only kept around for those few dev's who have already got this image and continue to use it; not available for download
   config.vm.define "artful32", autostart: false do |artful32|
-    config.vm.box = "ubuntu/artful32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    artful32.vm.box = "ubuntu/artful32"
+    artful32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    artful32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (artful32)"
     end
   end
 
   # 18.04 LTS
+  # Only kept around for those few dev's who have already got this image and continue to use it; not available for download
   config.vm.define "bionic32", autostart: false do |bionic32|
-    config.vm.box = "ubuntu/bionic32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    bionic32.vm.box = "ubuntu/bionic32"
+    bionic32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    bionic32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (bionic32)"
     end
   end
 
   # 18.04 LTS
   config.vm.define "bionic64", primary: true do |bionic64|
-    config.vm.box = "ubuntu/bionic64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    bionic64.vm.box = "ubuntu/bionic64"
+    bionic64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    bionic64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (bionic64)"
     end
   end
 
-
   # 18.10
   config.vm.define "cosmic32", autostart: false do |cosmic32|
-    config.vm.box = "ubuntu/cosmic32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    cosmic32.vm.box = "ubuntu/cosmic32"
+    cosmic32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    cosmic32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (cosmic32)"
     end
   end
 
   # 18.10
   config.vm.define "cosmic64", autostart: false do |cosmic64|
-    config.vm.box = "ubuntu/cosmic64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    cosmic64.vm.box = "ubuntu/cosmic64"
+    cosmic64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    cosmic64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (cosmic64)"
     end
   end
 
   # 19.04 bleeding edge
   config.vm.define "disco64", autostart: false do |disco64|
-    config.vm.box = "ubuntu/disco64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    disco64.vm.box = "ubuntu/disco64"
+    disco64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    disco64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (disco64)"
       vb.gui = true
     end


### PR DESCRIPTION
Our Vagrant file is incorrectly configuring the box to boot in that it is not configuring it at all and we always pick up disco64 as the default. This PR fixes this. It also makes some attempt to make sure that we install available pre-requisites for different ubuntu editions as these vary. I have corrected this for xenial, bionic and disco only.
