### PR TITLE
AP_Param: Fix failing to invalidate the cached parameter count

### DIFF
--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -444,6 +444,7 @@ public:
 
     // set frame type flags. Used to unhide frame specific parameters
     static void set_frame_type_flags(uint16_t flags_to_set) {
+        _parameter_count = 0;
         _frame_type_flags |= flags_to_set;
     }
 


### PR DESCRIPTION
This would cause a GCS to download fewer then the requested number of parameters.

Closes #13270