### PR TITLE
AP_OpticalFlow: check for px4flow on all I2C ports

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
@@ -28,6 +28,9 @@ STM32_VDD 330U
 
 define HAL_STORAGE_SIZE 16384
 
+// no internal I2C bus
+#undef HAL_I2C_INTERNAL_MASK
+
 # order of I2C buses
 I2C_ORDER I2C2 I2C1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -94,6 +94,9 @@ USB_STRING_SERIAL  "%SERIAL%"
 # followed by I2C1 in order to achieve the conventional order that
 # drivers expect
 
+// no internal I2C bus
+#undef HAL_I2C_INTERNAL_MASK
+
 # order of I2C buses
 I2C_ORDER I2C2 I2C1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -127,6 +127,9 @@ USB_STRING_SERIAL  "%SERIAL%"
 # followed by I2C1 in order to achieve the conventional order that
 # drivers expect.
 
+// no internal I2C bus
+#undef HAL_I2C_INTERNAL_MASK
+
 # order of I2C buses
 I2C_ORDER I2C2 I2C1
 


### PR DESCRIPTION
This resolves [this issue reported in the Copter-4.0 forums](https://discuss.ardupilot.org/t/px4flow-not-working-with-copter-4-0/51018) in which Cube autopilots cannot connect to the px4flow optical flow sensor using the I2C2 port.  This is a regression from Copter-3.6.12 probably caused by [this commit](https://github.com/ArduPilot/ardupilot/commit/8b7b5f0db90019efa2447c75bb7aaaaf65d1bf61#diff-0bf777403bbb55fabc7f7dd6e6dd54d2).

This has been bench tested tested on a CubeBlack and before the change, the flow_comp_m_x values do not appear in the GCS, afterwards they do.