### PR TITLE
AP_Logger: regain some logging IDs

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1583,9 +1583,6 @@ enum LogMessages : uint8_t {
     LOG_XKFD_MSG,
     LOG_XKV1_MSG,
     LOG_XKV2_MSG,
-
-    LOG_FORMAT_MSG = 128, // this must remain #128
-
     LOG_PARAMETER_MSG,
     LOG_GPS_MSG,
     LOG_GPS2_MSG,
@@ -1631,7 +1628,12 @@ enum LogMessages : uint8_t {
     LOG_COMPASS3_MSG,
     LOG_MODE_MSG,
     LOG_GPS_RAW_MSG,
+
+    // LOG_GPS_RAWH_MSG is used as a check for duplicates. Do not add between this and LOG_FORMAT_MSG
     LOG_GPS_RAWH_MSG,
+
+    LOG_FORMAT_MSG = 128, // this must remain #128
+
     LOG_GPS_RAWS_MSG,
 	LOG_GPS_SBF_EVENT_MSG,
     LOG_ACC1_MSG,
@@ -1702,6 +1704,7 @@ enum LogMessages : uint8_t {
 };
 
 static_assert(_LOG_LAST_MSG_ <= 255, "Too many message formats");
+static_assert(LOG_GPS_RAWH_MSG < 128, "Duplicate message format IDs");
 
 enum LogOriginType {
     ekf_origin = 0,


### PR DESCRIPTION
this gains a lot of logging ID slots by moving elements before LOG_FORMAT_MSG