### PR TITLE
autotest: make sub altitude test more reliable

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -125,6 +125,9 @@ class AutoTestSub(AutoTest):
         self.wait_altitude(alt_min=-5, alt_max=-4)
         self.set_rc(Joystick.Throttle, 1500)
 
+        # let the vehicle settle (momentum / stopping point shenanigans....)
+        self.delay_sim_time(2)
+
         self.watch_altitude_maintained()
 
         self.disarm_vehicle()


### PR DESCRIPTION
momentum + stopping point could both explain unreliability