### PR TITLE
AP_Logger: remove non-error init messages

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -111,7 +111,6 @@ AP_Logger::AP_Logger(const AP_Int32 &log_bitmask)
 
 void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "Preparing log system");
     if (hal.util->was_watchdog_armed()) {
         gcs().send_text(MAV_SEVERITY_INFO, "Forcing logging for watchdog reset");
         _params.log_disarmed.set(1);
@@ -209,8 +208,6 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
     Prep();
 
     EnableWrites(true);
-
-    gcs().send_text(MAV_SEVERITY_INFO, "Prepared log system");
 }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL


### PR DESCRIPTION
This removes two logging related messages, "Preparing log system" and "Prepared log system", from the stream of startup messages AP displays.  I've confirmed with @peterbarker that he's happy with removing these.

I don't think these two messages add any real value to the user and in general I think we should try and reduce the send_text messages we send to the user when the system is operating correctly.

Here's a picture before and after this change is applied to Copter.
![log-init-message-before-after](https://user-images.githubusercontent.com/1498098/72489520-a765d380-3857-11ea-969a-953b0e3bb5c1.png)


