### PR TITLE
MatekF405-Wing: Add HAL_MINIMIZE_FEATURES to hwdef.dat

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
@@ -191,3 +191,6 @@ define HAL_BATTMON_FUEL_ENABLE 0
 # disable parachute and sprayer to save flash
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
+
+# we are low on flash on this board
+define HAL_MINIMIZE_FEATURES 1


### PR DESCRIPTION
This board is low on flash, should have this enabled. It is blocking the PR #13263