### PR TITLE
AP_Rangefinder: use offset param value in all drivers

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
@@ -166,6 +166,8 @@ void AP_RangeFinder_PWM::update(void)
     }
 
     if (!get_reading(state.distance_cm)) {
+        // add offset
+        state.distance_cm += params.offset;
         // failure; consider changing our state
         if (AP_HAL::millis() - state.last_reading_ms > 200) {
             set_status(RangeFinder::Status::NoData);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
 
     // @Param: OFFSET
     // @DisplayName: rangefinder offset
-    // @Description: Offset in volts for zero distance for analog rangefinders. Offset added to distance in centimeters for PWM and I2C Lidars
+    // @Description: Offset in volts for zero distance for analog rangefinders. Offset added to distance in centimeters for PWM lidars
     // @Units: V
     // @Increment: 0.001
     // @User: Standard


### PR DESCRIPTION
This PR changes all rangefinder drivers to add the RNGFNDx_OFFSET param value to distances.  This parameter's default is 0 so hopefully it will have no effect for most users.

The change to the PWM driver fixes issue https://github.com/ArduPilot/ardupilot/issues/13252 which is a regression in Copter-4.0.0 vs Copter-3.6.12.

For consistency the offset is always added at the moment the distance from the sensor is stored in the _state.distance_cm variable.  I hope this consistency will reduce the possibility of bugs being introduced in the future.

Some things to note:

- the offset is applied before the RNGFND_MIN_CM and RNGFND_MAX_CM values are used to determine the state of the rangefinder.  I think this is correct because this is consistent with how the analog driver and [Copter-3.6.x PWM driver](https://github.com/ArduPilot/ardupilot/blob/Copter-3.6/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp#L120) used it.
- the AP_RangeFinder_MAVLink driver is inconsistent with other drivers in that it [sets the distance to zero if there is NoData](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp#L71).  I have left it reporting "0" as opposed to "0+OFFSET".