### PR TITLE
Start moving bulk amounts of init_ardupilot to base class

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -115,6 +115,16 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #endif
 };
 
+
+void Rover::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                                uint8_t &task_count,
+                                uint32_t &log_bit)
+{
+    tasks = &scheduler_tasks[0];
+    task_count = ARRAY_SIZE(scheduler_tasks);
+    log_bit = MASK_LOG_PM;
+}
+
 constexpr int8_t Rover::_failsafe_priorities[7];
 
 Rover::Rover(void) :
@@ -141,19 +151,6 @@ void Rover::stats_update(void)
 }
 #endif
 
-/*
-  setup is called when the sketch starts
- */
-void Rover::setup()
-{
-    // load the default values of variables listed in var_info[]
-    AP_Param::setup_sketch_defaults();
-
-    init_ardupilot();
-
-    // initialise the main loop scheduler
-    scheduler.init(&scheduler_tasks[0], ARRAY_SIZE(scheduler_tasks), MASK_LOG_PM);
-}
 
 /*
   loop() is called rapidly while the sketch is running

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -127,7 +127,6 @@ public:
     Rover(void);
 
     // HAL::Callbacks implementation.
-    void setup(void) override;
     void loop(void) override;
 
 private:
@@ -384,8 +383,13 @@ private:
     // Steering.cpp
     void set_servos(void);
 
+    // Rover.cpp
+    void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                             uint8_t &task_count,
+                             uint32_t &log_bit) override;
+
     // system.cpp
-    void init_ardupilot();
+    void init_ardupilot() override;
     void startup_ground(void);
     void update_ahrs_flyforward();
     bool set_mode(Mode &new_mode, ModeReason reason);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -361,7 +361,7 @@ private:
     Mode *mode_from_mode_num(enum Mode::Number num);
 
     // Parameters.cpp
-    void load_parameters(void);
+    void load_parameters(void) override;
 
     // radio.cpp
     void set_control_channels(void);

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -6,7 +6,6 @@ The init_ardupilot function processes everything we need for an in - air restart
 *****************************************************************************/
 
 #include "Rover.h"
-#include <AP_Common/AP_FWVersion.h>
 
 static void failsafe_check_static()
 {
@@ -15,19 +14,6 @@ static void failsafe_check_static()
 
 void Rover::init_ardupilot()
 {
-    // initialise console serial port
-    serial_manager.init_console();
-
-    hal.console->printf("\n\nInit %s"
-                        "\n\nFree RAM: %u\n",
-                        AP::fwversion().fw_string,
-                        (unsigned)hal.util->available_memory());
-
-    //
-    // Check the EEPROM format version before loading any parameters from EEPROM.
-    //
-
-    load_parameters();
 #if STATS_ENABLED == ENABLED
     // initialise stats module
     g2.stats.init();

--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -55,18 +55,13 @@ const AP_Scheduler::Task Tracker::scheduler_tasks[] = {
     SCHED_TASK(accel_cal_update,       10,    100)
 };
 
-/**
-  setup the sketch - called once on startup
- */
-void Tracker::setup() 
+void Tracker::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                                uint8_t &task_count,
+                                uint32_t &log_bit)
 {
-    // load the default values of variables listed in var_info[]
-    AP_Param::setup_sketch_defaults();
-
-    init_tracker();
-
-    // initialise the main loop scheduler
-    scheduler.init(&scheduler_tasks[0], ARRAY_SIZE(scheduler_tasks), (uint32_t)-1);
+    tasks = &scheduler_tasks[0];
+    task_count = ARRAY_SIZE(scheduler_tasks);
+    log_bit = (uint32_t)-1;
 }
 
 /**

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -42,7 +42,6 @@
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Stats/AP_Stats.h>                      // statistics library
 #include <AP_BattMonitor/AP_BattMonitor.h> // Battery monitor library
-#include <AP_Common/AP_FWVersion.h>
 
 // Configuration
 #include "config.h"
@@ -73,8 +72,6 @@ public:
     friend class Mode;
 
     Tracker(void);
-
-    static const AP_FWVersion fwver;
 
     // HAL::Callbacks implementation.
     void loop() override;
@@ -192,7 +189,7 @@ private:
     void log_init(void);
 
     // Parameters.cpp
-    void load_parameters(void);
+    void load_parameters(void) override;
 
     // radio.cpp
     void read_radio();

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -77,7 +77,6 @@ public:
     static const AP_FWVersion fwver;
 
     // HAL::Callbacks implementation.
-    void setup() override;
     void loop() override;
 
 private:
@@ -174,7 +173,10 @@ private:
     // true if the compass's initial location has been set
     bool compass_init_location;
 
-    // AntennaTracker.cpp
+    // Tracker.cpp
+    void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                             uint8_t &task_count,
+                             uint32_t &log_bit) override;
     void one_second_loop();
     void ten_hz_logging_loop();
     void stats_update();
@@ -215,7 +217,7 @@ private:
     void update_yaw_cr_servo(float yaw);
 
     // system.cpp
-    void init_tracker();
+    void init_ardupilot() override;
     bool get_home_eeprom(struct Location &loc);
     bool set_home_eeprom(const Location &temp) WARN_IF_UNUSED;
     bool set_home(const Location &temp) WARN_IF_UNUSED;

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -3,7 +3,7 @@
 // mission storage
 static const StorageAccess wp_storage(StorageManager::StorageMission);
 
-void Tracker::init_tracker()
+void Tracker::init_ardupilot()
 {
     // initialise console serial port
     serial_manager.init_console();

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -5,16 +5,6 @@ static const StorageAccess wp_storage(StorageManager::StorageMission);
 
 void Tracker::init_ardupilot()
 {
-    // initialise console serial port
-    serial_manager.init_console();
-
-    hal.console->printf("\n\nInit %s\n\nFree RAM: %u\n",
-                        AP::fwversion().fw_string,
-                        (unsigned)hal.util->available_memory());
-
-    // Check the EEPROM format version before loading any parameters from EEPROM
-    load_parameters();
-
     // initialise stats module
     stats.init();
 

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -216,9 +216,6 @@ void Copter::setup()
     // Load the default values of variables listed in var_info[]s
     AP_Param::setup_sketch_defaults();
 
-    // setup storage layout for copter
-    StorageManager::set_layout_copter();
-
     init_ardupilot();
 
     // initialise the main loop scheduler

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -209,18 +209,16 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #endif
 };
 
-constexpr int8_t Copter::_failsafe_priorities[7];
-
-void Copter::setup()
+void Copter::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                                 uint8_t &task_count,
+                                 uint32_t &log_bit)
 {
-    // Load the default values of variables listed in var_info[]s
-    AP_Param::setup_sketch_defaults();
-
-    init_ardupilot();
-
-    // initialise the main loop scheduler
-    scheduler.init(&scheduler_tasks[0], ARRAY_SIZE(scheduler_tasks), MASK_LOG_PM);
+    tasks = &scheduler_tasks[0];
+    task_count = ARRAY_SIZE(scheduler_tasks);
+    log_bit = MASK_LOG_PM;
 }
+
+constexpr int8_t Copter::_failsafe_priorities[7];
 
 void Copter::loop()
 {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -66,7 +66,6 @@
 #include <AP_SmartRTL/AP_SmartRTL.h>
 #include <AP_TempCalibration/AP_TempCalibration.h>
 #include <AC_AutoTune/AC_AutoTune.h>
-#include <AP_Common/AP_FWVersion.h>
 #include <AP_Parachute/AP_Parachute.h>
 #include <AC_Sprayer/AC_Sprayer.h>
 
@@ -239,7 +238,6 @@ public:
     void loop() override;
 
 private:
-    static const AP_FWVersion fwver;
 
     // key aircraft parameters passed to multiple libraries
     AP_Vehicle::MultiCopter aparm;
@@ -818,7 +816,7 @@ private:
     uint32_t home_distance();
 
     // Parameters.cpp
-    void load_parameters(void);
+    void load_parameters(void) override;
     void convert_pid_parameters(void);
     void convert_lgr_parameters(void);
     void convert_tradheli_parameters(void);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -236,7 +236,6 @@ public:
     Copter(void);
 
     // HAL::Callbacks implementation.
-    void setup() override;
     void loop() override;
 
 private:
@@ -640,7 +639,10 @@ private:
     void set_failsafe_gcs(bool b);
     void update_using_interlock();
 
-    // ArduCopter.cpp
+    // Copter.cpp
+    void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                             uint8_t &task_count,
+                             uint32_t &log_bit) override;
     void fast_loop();
     void rc_loop();
     void throttle_loop();
@@ -859,7 +861,7 @@ private:
     void auto_trim();
 
     // system.cpp
-    void init_ardupilot();
+    void init_ardupilot() override;
     void startup_INS_ground();
     void update_dynamic_notch();
     bool position_ok() const;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -15,17 +15,6 @@ static void failsafe_check_static()
 
 void Copter::init_ardupilot()
 {
-    // initialise serial port
-    serial_manager.init_console();
-
-    hal.console->printf("\n\nInit %s"
-                        "\n\nFree RAM: %u\n",
-                        AP::fwversion().fw_string,
-                        (unsigned)hal.util->available_memory());
-
-    // load parameters from EEPROM
-    load_parameters();
-
     // time per loop - this gets updated in the main loop() based on
     // actual loop rate
     G_Dt = 1.0 / scheduler.get_loop_rate_hz();

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -112,18 +112,16 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(update_dynamic_notch,   50,    200),
 };
 
-constexpr int8_t Plane::_failsafe_priorities[7];
-
-void Plane::setup() 
+void Plane::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                                uint8_t &task_count,
+                                uint32_t &log_bit)
 {
-    // load the default values of variables listed in var_info[]
-    AP_Param::setup_sketch_defaults();
-
-    init_ardupilot();
-
-    // initialise the main loop scheduler
-    scheduler.init(&scheduler_tasks[0], ARRAY_SIZE(scheduler_tasks), MASK_LOG_PM);
+    tasks = &scheduler_tasks[0];
+    task_count = ARRAY_SIZE(scheduler_tasks);
+    log_bit = MASK_LOG_PM;
 }
+
+constexpr int8_t Plane::_failsafe_priorities[7];
 
 void Plane::loop()
 {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -119,8 +119,6 @@ void Plane::setup()
     // load the default values of variables listed in var_info[]
     AP_Param::setup_sketch_defaults();
 
-    rssi.init();
-
     init_ardupilot();
 
     // initialise the main loop scheduler

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -789,7 +789,7 @@ private:
     void Log_Write_AOA_SSA();
     void Log_Write_AETR();
 
-    void load_parameters(void);
+    void load_parameters(void) override;
     void convert_mixers(void);
     void adjust_altitude_target();
     void setup_glide_slope(void);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -161,7 +161,6 @@ public:
     Plane(void);
 
     // HAL::Callbacks implementation.
-    void setup() override;
     void loop() override;
 
 private:
@@ -896,7 +895,10 @@ private:
     void read_airspeed(void);
     void rpm_update(void);
     void efi_update(void);
-    void init_ardupilot();
+    void init_ardupilot() override;
+    void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                             uint8_t &task_count,
+                             uint32_t &log_bit) override;
     void startup_ground(void);
     bool set_mode(Mode& new_mode, const ModeReason reason);
     bool set_mode(const uint8_t mode, const ModeReason reason) override;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -85,6 +85,8 @@ void Plane::init_ardupilot()
     // initialise battery monitoring
     battery.init();
 
+    rssi.init();
+
     rpm_sensor.init();
 
     // setup telem slots with serial ports

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -1,5 +1,4 @@
 #include "Plane.h"
-#include <AP_Common/AP_FWVersion.h>
 
 /*****************************************************************************
 *   The init_ardupilot function processes everything we need for an in - air restart
@@ -15,18 +14,6 @@ static void failsafe_check_static()
 
 void Plane::init_ardupilot()
 {
-    // initialise serial port
-    serial_manager.init_console();
-
-    hal.console->printf("\n\nInit %s"
-                        "\n\nFree RAM: %u\n",
-                        AP::fwversion().fw_string,
-                        (unsigned)hal.util->available_memory());
-
-    //
-    // Check the EEPROM format version before loading any parameters from EEPROM
-    //
-    load_parameters();
 
 #if STATS_ENABLED == ENABLED
     // initialise stats module

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -80,18 +80,16 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
 #endif
 };
 
-constexpr int8_t Sub::_failsafe_priorities[5];
-
-void Sub::setup()
+void Sub::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                                 uint8_t &task_count,
+                                 uint32_t &log_bit)
 {
-    // Load the default values of variables listed in var_info[]s
-    AP_Param::setup_sketch_defaults();
-
-    init_ardupilot();
-
-    // initialise the main loop scheduler
-    scheduler.init(&scheduler_tasks[0], ARRAY_SIZE(scheduler_tasks), MASK_LOG_PM);
+    tasks = &scheduler_tasks[0];
+    task_count = ARRAY_SIZE(scheduler_tasks);
+    log_bit = MASK_LOG_PM;
 }
+
+constexpr int8_t Sub::_failsafe_priorities[5];
 
 void Sub::loop()
 {

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -132,7 +132,6 @@ public:
     Sub(void);
 
     // HAL::Callbacks implementation.
-    void setup() override;
     void loop() override;
 
 private:
@@ -573,7 +572,10 @@ private:
 #endif
     void terrain_update();
     void terrain_logging();
-    void init_ardupilot();
+    void init_ardupilot() override;
+    void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                             uint8_t &task_count,
+                             uint32_t &log_bit) override;
     void startup_INS_ground();
     bool position_ok();
     bool ekf_position_ok();

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -68,7 +68,6 @@
 #include <AP_JSButton/AP_JSButton.h>   // Joystick/gamepad button function assignment
 #include <AP_LeakDetector/AP_LeakDetector.h> // Leak detector
 #include <AP_TemperatureSensor/TSYS01.h>
-#include <AP_Common/AP_FWVersion.h>
 
 // Local modules
 #include "defines.h"
@@ -135,7 +134,6 @@ public:
     void loop() override;
 
 private:
-    static const AP_FWVersion fwver;
 
     // key aircraft parameters passed to multiple libraries
     AP_Vehicle::MultiCopter aparm;
@@ -451,7 +449,7 @@ private:
     void Log_Sensor_Health();
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
     void Log_Write_Vehicle_Startup_Messages();
-    void load_parameters(void);
+    void load_parameters(void) override;
     void userhook_init();
     void userhook_FastLoop();
     void userhook_50Hz();

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -14,17 +14,6 @@ static void failsafe_check_static()
 
 void Sub::init_ardupilot()
 {
-    // initialise serial port
-    serial_manager.init_console();
-
-    hal.console->printf("\n\nInit %s"
-                        "\n\nFree RAM: %u\n",
-                        AP::fwversion().fw_string,
-                        (unsigned)hal.util->available_memory());
-
-    // load parameters from EEPROM
-    load_parameters();
-
     BoardConfig.init();
 #if HAL_WITH_UAVCAN
     BoardConfig_CAN.init();

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -5,8 +5,6 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
-#include <AP_Common/AP_FWVersion.h>
-#include "version.h"
 #include "../AP_Bootloader/app_comms.h"
 
 #if defined(HAL_PERIPH_NEOPIXEL_COUNT) || defined(HAL_PERIPH_ENABLE_NCP5623_LED)

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -50,6 +50,7 @@
 #include <AP_HAL/I2CDevice.h>
 #include "../AP_Bootloader/app_comms.h"
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AP_Common/AP_FWVersion.h>
 
 #include "i2c.h"
 #include <utility>

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -102,10 +102,8 @@ void ReplayVehicle::load_parameters(void)
     AP_Param::set_default_by_name("LOG_FILE_BUFSIZE", 60);
 }
 
-void ReplayVehicle::setup(void) 
+void ReplayVehicle::init_ardupilot(void)
 {
-    load_parameters();
-
     // we pass an empty log structure, filling the structure in with
     // either the format present in the log (if we do not emit the
     // message as a product of Replay), or the format understood in

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -55,9 +55,11 @@ public:
 
     ReplayVehicle() { unused = -1; }
     // HAL::Callbacks implementation.
-    void setup() override;
     void loop() override;
-    void load_parameters(void);
+    void load_parameters(void) override;
+    void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                             uint8_t &task_count,
+                             uint32_t &log_bit) override { };
 
     virtual bool set_mode(const uint8_t new_mode, const ModeReason reason) override { return true; }
     virtual uint8_t get_mode() const override { return 0; }
@@ -75,6 +77,10 @@ public:
     struct LogStructure log_structure[256] = {
     };
     AP_Logger logger{unused};
+
+protected:
+
+    void init_ardupilot() override;
 
 private:
     Parameters g;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1,5 +1,7 @@
 #include "AP_Vehicle.h"
 
+#include <AP_Common/AP_FWVersion.h>
+
 #define SCHED_TASK(func, rate_hz, max_time_micros) SCHED_TASK_CLASS(AP_Vehicle, &vehicle, func, rate_hz, max_time_micros)
 
 /*

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -23,6 +23,35 @@ extern AP_Vehicle& vehicle;
 #endif
 
 /*
+  setup is called when the sketch starts
+ */
+void AP_Vehicle::setup()
+{
+    // load the default values of variables listed in var_info[]
+    AP_Param::setup_sketch_defaults();
+
+    // initialise serial port
+    serial_manager.init_console();
+
+    hal.console->printf("\n\nInit %s"
+                        "\n\nFree RAM: %u\n",
+                        AP::fwversion().fw_string,
+                        (unsigned)hal.util->available_memory());
+
+    load_parameters();
+
+    // init_ardupilot is where the vehicle does most of its initialisation.
+    init_ardupilot();
+
+    // initialise the main loop scheduler
+    const AP_Scheduler::Task *tasks;
+    uint8_t task_count;
+    uint32_t log_bit;
+    get_scheduler_tasks(tasks, task_count, log_bit);
+    AP::scheduler().init(tasks, task_count, log_bit);
+}
+
+/*
   common scheduler table for fast CPUs - all common vehicle tasks
   should be listed here, along with how often they should be called (in hz)
   and the maximum time they are expected to take (in microseconds)
@@ -112,4 +141,3 @@ AP_Vehicle *vehicle()
 }
 
 };
-

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -56,6 +56,15 @@ public:
 
     static AP_Vehicle *get_singleton();
 
+    // setup() is called once during vehicle startup to initialise the
+    // vehicle object and the objects it contains.  The
+    // AP_HAL_MAIN_CALLBACKS pragma creates a main(...) function
+    // referencing an object containing setup() and loop() functions.
+    // A vehicle is not expected to override setup(), but
+    // subclass-specific initialisation can be done in init_ardupilot
+    // which is called from setup().
+    void setup(void) override final;
+
     bool virtual set_mode(const uint8_t new_mode, const ModeReason reason) = 0;
     uint8_t virtual get_mode() const = 0;
 
@@ -117,6 +126,8 @@ public:
     // initialize the vehicle. Called from AP_BoardConfig
     void init_vehicle();
 
+    virtual void get_scheduler_tasks(const AP_Scheduler::Task *&tasks, uint8_t &task_count, uint32_t &log_bit) = 0;
+
     /*
       set the "likely flying" flag. This is not guaranteed to be
       accurate, but is the vehicle codes best guess as to the whether
@@ -150,6 +161,8 @@ public:
     }
 
 protected:
+
+    virtual void init_ardupilot() = 0;
 
     // board specific config
     AP_BoardConfig BoardConfig;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -163,6 +163,7 @@ public:
 protected:
 
     virtual void init_ardupilot() = 0;
+    virtual void load_parameters() = 0;
 
     // board specific config
     AP_BoardConfig BoardConfig;

--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -20,7 +20,10 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+
 #include "StorageManager.h"
+
 #include <stdio.h>
 
 
@@ -35,17 +38,18 @@ extern const AP_HAL::HAL& hal;
 /*
   layout for peripherals
  */
-const StorageManager::StorageArea StorageManager::layout_default[STORAGE_NUM_AREAS] = {
+const StorageManager::StorageArea StorageManager::layout[STORAGE_NUM_AREAS] = {
     { StorageParam,   0,     HAL_STORAGE_SIZE}
 };
 
-#else
+#elif !APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+
 /*
   layout for fixed wing and rovers
   On PX4v1 this gives 309 waypoints, 30 rally points and 52 fence points
   On Pixhawk this gives 724 waypoints, 50 rally points and 84 fence points
  */
-const StorageManager::StorageArea StorageManager::layout_default[STORAGE_NUM_AREAS] = {
+const StorageManager::StorageArea StorageManager::layout[STORAGE_NUM_AREAS] = {
     { StorageParam,   0,     1280}, // 0x500 parameter bytes
     { StorageMission, 1280,  2506},
     { StorageRally,   3786,   150}, // 10 rally points
@@ -71,12 +75,14 @@ const StorageManager::StorageArea StorageManager::layout_default[STORAGE_NUM_ARE
 #endif
 };
 
+#else
+
 /*
   layout for copter.
   On PX4v1 this gives 303 waypoints, 26 rally points and 38 fence points
   On Pixhawk this gives 718 waypoints, 46 rally points and 70 fence points
  */
-const StorageManager::StorageArea StorageManager::layout_copter[STORAGE_NUM_AREAS] = {
+const StorageManager::StorageArea StorageManager::layout[STORAGE_NUM_AREAS] = {
     { StorageParam,   0,     1536}, // 0x600 param bytes
     { StorageMission, 1536,  2422},
     { StorageRally,   3958,    90}, // 6 rally points
@@ -102,9 +108,6 @@ const StorageManager::StorageArea StorageManager::layout_copter[STORAGE_NUM_AREA
 #endif
 };
 #endif // STORAGE_NUM_AREAS == 1
-
-// setup default layout
-const StorageManager::StorageArea *StorageManager::layout = layout_default;
 
 /*
   erase all storage

--- a/libraries/StorageManager/StorageManager.h
+++ b/libraries/StorageManager/StorageManager.h
@@ -59,9 +59,6 @@ public:
     // erase whole of storage
     static void erase(void);
 
-    // setup for copter layout of storage
-    static void set_layout_copter(void) { layout = layout_copter; }
-
 private:
     struct StorageArea {
         StorageType type;
@@ -70,9 +67,7 @@ private:
     };
 
     // available layouts
-    static const StorageArea layout_copter[STORAGE_NUM_AREAS];
-    static const StorageArea layout_default[STORAGE_NUM_AREAS];
-    static const StorageArea *layout;
+    static const StorageArea layout[STORAGE_NUM_AREAS];
 };
 
 /*


### PR DESCRIPTION
A rather large amount of code can be moved from the `init_ardupilot` into the base-class `setup` library.  

I've restricted the movement in this PR to just a few functions as they're relatively straight-forward.

Obtaining our list of scheduled tasks might be improved in a future PR; perhaps something along the same lines as how we do the logging structures might work.
