### PR TITLE
AP_RangeFinder: Benewake-TFminiP driver outputs init failure to ground station 

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -18,6 +18,8 @@
 
 #include <utility>
 
+#include <GCS_MAVLink/GCS.h>
+
 #include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;
@@ -100,8 +102,8 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::init()
     }
 
     if (val[5] * 10000 + val[4] * 100 + val[3] < 20003) {
-        hal.console->printf(DRIVER ": minimum required FW version 2.0.3, but version %u.%u.%u found\n",
-                            val[5], val[4], val[3]);
+        gcs().send_text(MAV_SEVERITY_ERROR, "TFMini: FW ver %u.%u.%u (need>=2.0.3)",
+                            (unsigned)val[5],(unsigned)val[4],(unsigned)val[3]);
         goto fail;
     }
 


### PR DESCRIPTION
Fixes #12396
checks the version of the lidar and if it's too low, outputs a text string to the user. 