### PR TITLE
AP_Scripting: Send lua errors to the console before status_text

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -184,8 +184,8 @@ void lua_scripts::run_next_script(lua_State *L) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: %s exceeded time limit (%d)", script->name,  (int)vm_steps);
             remove_script(L, script);
         } else {
-            gcs().send_text(MAV_SEVERITY_INFO, "Lua: %s", lua_tostring(L, -1));
             hal.console->printf("Lua: Error: %s\n", lua_tostring(L, -1));
+            gcs().send_text(MAV_SEVERITY_INFO, "Lua: %s", lua_tostring(L, -1));
             remove_script(L, script);
         }
         lua_pop(L, 1);


### PR DESCRIPTION
This helps SITL where we frequently panic about to long a statustext,
which means a user never sees the intresting part unless they comment
out the sanity check, or run on a real board.