### PR TITLE
Added bouncebuffer allocation checks

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -3,6 +3,7 @@
  */
 #include "AP_Filesystem.h"
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include <stdio.h>
 
 #if HAVE_FILESYSTEM_SUPPORT && CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
@@ -22,6 +23,10 @@ static bool remount_needed;
 #define FATFS_R (S_IRUSR | S_IRGRP | S_IROTH)	/*< FatFs Read perms */
 #define FATFS_W (S_IWUSR | S_IWGRP | S_IWOTH)	/*< FatFs Write perms */
 #define FATFS_X (S_IXUSR | S_IXGRP | S_IXOTH)	/*< FatFs Execute perms */
+
+// don't write more than 4k at a time to prevent needing too much
+// DMAable memory
+#define MAX_IO_SIZE 4096
 
 // use a semaphore to ensure that only one filesystem operation is
 // happening at a time. A recursive semaphore is used to cope with the
@@ -379,7 +384,6 @@ int AP_Filesystem::close(int fileno)
 
 ssize_t AP_Filesystem::read(int fd, void *buf, size_t count)
 {
-    UINT size;
     UINT bytes = count;
     int res;
     FIL *fh;
@@ -401,17 +405,31 @@ ssize_t AP_Filesystem::read(int fd, void *buf, size_t count)
         return -1;
     }
 
-    res = f_read(fh, (void *) buf, bytes, &size);
-    if (res != FR_OK) {
-        errno = fatfs_to_errno((FRESULT)res);
-        return -1;
-    }
-    return (ssize_t)size;
+    UINT total = 0;
+    do {
+        UINT size = 0;
+        UINT n = MIN(bytes, MAX_IO_SIZE);
+        res = f_read(fh, (void *)buf, n, &size);
+        if (res != FR_OK) {
+            errno = fatfs_to_errno((FRESULT)res);
+            return -1;
+        }
+        if (size > n || size == 0) {
+            errno = EIO;
+            return -1;
+        }
+        total += size;
+        buf = (void *)(((uint8_t *)buf)+size);
+        bytes -= size;
+        if (size < n) {
+            break;
+        }
+    } while (bytes > 0);
+    return (ssize_t)total;
 }
 
 ssize_t AP_Filesystem::write(int fd, const void *buf, size_t count)
 {
-    UINT size;
     UINT bytes = count;
     FRESULT res;
     FIL *fh;
@@ -428,19 +446,34 @@ ssize_t AP_Filesystem::write(int fd, const void *buf, size_t count)
         return -1;
     }
 
-    res = f_write(fh, buf, bytes, &size);
-    if (res == FR_DISK_ERR && RETRY_ALLOWED()) {
-        // one retry on disk error
-        hal.scheduler->delay(100);
-        if (remount_file_system()) {
-            res = f_write(fh, buf, bytes, &size);
+    UINT total = 0;
+    do {
+        UINT n = MIN(bytes, MAX_IO_SIZE);
+        UINT size = 0;
+        res = f_write(fh, buf, n, &size);
+        if (res == FR_DISK_ERR && RETRY_ALLOWED()) {
+            // one retry on disk error
+            hal.scheduler->delay(100);
+            if (remount_file_system()) {
+                res = f_write(fh, buf, n, &size);
+            }
         }
-    }
-    if (res != FR_OK) {
-        errno = fatfs_to_errno(res);
-        return -1;
-    }
-    return (ssize_t)size;
+        if (size > n || size == 0) {
+            errno = EIO;
+            return -1;
+        }
+        if (res != FR_OK || size > n) {
+            errno = fatfs_to_errno(res);
+            return -1;
+        }
+        total += size;
+        buf = (void *)(((uint8_t *)buf)+size);
+        bytes -= size;
+        if (size < n) {
+            break;
+        }
+    } while (bytes > 0);
+    return (ssize_t)total;
 }
 
 int AP_Filesystem::fsync(int fileno)

--- a/libraries/AP_HAL_ChibiOS/Device.cpp
+++ b/libraries/AP_HAL_ChibiOS/Device.cpp
@@ -164,15 +164,23 @@ bool DeviceBus::adjust_timer(AP_HAL::Device::PeriodicHandle h, uint32_t period_u
 /*
   setup to use DMA-safe bouncebuffers for device transfers
  */
-void DeviceBus::bouncebuffer_setup(const uint8_t *&buf_tx, uint16_t tx_len,
+bool DeviceBus::bouncebuffer_setup(const uint8_t *&buf_tx, uint16_t tx_len,
                                    uint8_t *&buf_rx, uint16_t rx_len)
 {
     if (buf_rx) {
-        bouncebuffer_setup_read(bounce_buffer_rx, &buf_rx, rx_len);
+        if (!bouncebuffer_setup_read(bounce_buffer_rx, &buf_rx, rx_len)) {
+            return false;
+        }
     }
     if (buf_tx) {
-        bouncebuffer_setup_write(bounce_buffer_tx, &buf_tx, tx_len);
+        if (!bouncebuffer_setup_write(bounce_buffer_tx, &buf_tx, tx_len)) {
+            if (buf_rx) {
+                bouncebuffer_abort(bounce_buffer_rx);
+            }
+            return false;
+        }
     }
+    return true;
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/Device.h
+++ b/libraries/AP_HAL_ChibiOS/Device.h
@@ -39,8 +39,8 @@ public:
     bool adjust_timer(AP_HAL::Device::PeriodicHandle h, uint32_t period_usec);
     static void bus_thread(void *arg);
 
-    void bouncebuffer_setup(const uint8_t *&buf_tx, uint16_t tx_len,
-                            uint8_t *&buf_rx, uint16_t rx_len);
+    bool bouncebuffer_setup(const uint8_t *&buf_tx, uint16_t tx_len,
+                            uint8_t *&buf_rx, uint16_t rx_len) WARN_IF_UNUSED;
     void bouncebuffer_finish(const uint8_t *buf_tx, uint8_t *buf_rx, uint16_t rx_len);
 
 private:

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -258,7 +258,10 @@ bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
 {
     i2cAcquireBus(I2CD[bus.busnum].i2c);
 
-    bus.bouncebuffer_setup(send, send_len, recv, recv_len);
+    if (!bus.bouncebuffer_setup(send, send_len, recv, recv_len)) {
+        i2cReleaseBus(I2CD[bus.busnum].i2c);
+        return false;
+    }
 
     for(uint8_t i=0 ; i <= _retries; i++) {
         int ret;

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -185,7 +185,10 @@ bool SPIDevice::do_transfer(const uint8_t *send, uint8_t *recv, uint32_t len)
         }
     }
 #else
-    bus.bouncebuffer_setup(send, len, recv, len);
+    if (!bus.bouncebuffer_setup(send, len, recv, len)) {
+        set_chip_select(old_cs_forced);
+        return false;
+    }
     osalSysLock();
     hal.util->persistent_data.spi_count++;
     if (send == nullptr) {

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -156,7 +156,18 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
       of data. Assumes 10 bits per byte, which is normal for most
       protocols
      */
-    min_rx_buffer = MAX(min_rx_buffer, b/(40*10));
+    bool rx_size_by_baudrate = true;
+#if HAL_WITH_IO_MCU
+    if (this == &uart_io) {
+        // iomcu doesn't need extra space, just speed
+        rx_size_by_baudrate = false;
+        min_tx_buffer = 0;
+        min_rx_buffer = 0;
+    }
+#endif
+    if (rx_size_by_baudrate) {
+        min_rx_buffer = MAX(min_rx_buffer, b/(40*10));
+    }
 
     if (sdef.is_usb) {
         // give more buffer space for log download on USB

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -445,12 +445,12 @@ void UARTDriver::rx_irq_cb(void* self)
     if (!uart_drv->rx_dma_enabled) {
         return;
     }
-    dmaStreamDisable(uart_drv->rxdma);
 #if defined(STM32F7) || defined(STM32H7)
     //disable dma, triggering DMA transfer complete interrupt
     uart_drv->rxdma->stream->CR &= ~STM32_DMA_CR_EN;
 #elif defined(STM32F3)
     //disable dma, triggering DMA transfer complete interrupt
+    dmaStreamDisable(uart_drv->rxdma);
     uart_drv->rxdma->channel->CCR &= ~STM32_DMA_CR_EN;
 #else
     volatile uint16_t sr = ((SerialDriver*)(uart_drv->sdef.serial))->usart->SR;

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.c
@@ -45,8 +45,9 @@ void bouncebuffer_init(struct bouncebuffer_t **bouncebuffer, uint32_t prealloc_b
     (*bouncebuffer)->is_sdcard = sdcard;
     if (prealloc_bytes) {
         (*bouncebuffer)->dma_buf = sdcard?malloc_sdcard_dma(prealloc_bytes):malloc_dma(prealloc_bytes);
-        osalDbgAssert(((*bouncebuffer)->dma_buf != NULL), "bouncebuffer preallocate");
-        (*bouncebuffer)->size = prealloc_bytes;
+        if ((*bouncebuffer)->dma_buf) {
+            (*bouncebuffer)->size = prealloc_bytes;
+        }
     }
 }
 
@@ -55,11 +56,11 @@ void bouncebuffer_init(struct bouncebuffer_t **bouncebuffer, uint32_t prealloc_b
   Note that *buf can be NULL, in which case we allocate DMA capable memory, but don't
   copy to it in bouncebuffer_finish_read(). This avoids DMA failures in dummyrx in the SPI LLD
  */
-void bouncebuffer_setup_read(struct bouncebuffer_t *bouncebuffer, uint8_t **buf, uint32_t size)
+bool bouncebuffer_setup_read(struct bouncebuffer_t *bouncebuffer, uint8_t **buf, uint32_t size)
 {
     if (!bouncebuffer || IS_DMA_SAFE(*buf)) {
         // nothing needs to be done
-        return;
+        return true;
     }
     osalDbgAssert((bouncebuffer->busy == false), "bouncebuffer read");        
     bouncebuffer->orig_buf = *buf;
@@ -68,7 +69,10 @@ void bouncebuffer_setup_read(struct bouncebuffer_t *bouncebuffer, uint8_t **buf,
             free(bouncebuffer->dma_buf);
         }
         bouncebuffer->dma_buf = bouncebuffer->is_sdcard?malloc_sdcard_dma(size):malloc_dma(size);
-        osalDbgAssert((bouncebuffer->dma_buf != NULL), "bouncebuffer read allocate");
+        if (!bouncebuffer->dma_buf) {
+            bouncebuffer->size = 0;
+            return false;
+        }
         bouncebuffer->size = size;
     }
     *buf = bouncebuffer->dma_buf;
@@ -77,6 +81,7 @@ void bouncebuffer_setup_read(struct bouncebuffer_t *bouncebuffer, uint8_t **buf,
     stm32_cacheBufferInvalidate(*buf, (size+31)&~31);
 #endif
     bouncebuffer->busy = true;
+    return true;
 }
 
 /*
@@ -97,11 +102,11 @@ void bouncebuffer_finish_read(struct bouncebuffer_t *bouncebuffer, const uint8_t
 /*
   setup for reading from memory to a device, allocating a bouncebuffer if needed
  */
-void bouncebuffer_setup_write(struct bouncebuffer_t *bouncebuffer, const uint8_t **buf, uint32_t size)
+bool bouncebuffer_setup_write(struct bouncebuffer_t *bouncebuffer, const uint8_t **buf, uint32_t size)
 {
     if (!bouncebuffer || IS_DMA_SAFE(*buf)) {
         // nothing needs to be done
-        return;
+        return true;
     }
     osalDbgAssert((bouncebuffer->busy == false), "bouncebuffer write");        
     if (bouncebuffer->size < size) {
@@ -109,7 +114,10 @@ void bouncebuffer_setup_write(struct bouncebuffer_t *bouncebuffer, const uint8_t
             free(bouncebuffer->dma_buf);
         }
         bouncebuffer->dma_buf = bouncebuffer->is_sdcard?malloc_sdcard_dma(size):malloc_dma(size);
-        osalDbgAssert((bouncebuffer->dma_buf != NULL), "bouncebuffer write allocate");
+        if (!bouncebuffer->dma_buf) {
+            bouncebuffer->size = 0;
+            return false;
+        }
         bouncebuffer->size = size;
     }
     if (*buf) {
@@ -121,6 +129,7 @@ void bouncebuffer_setup_write(struct bouncebuffer_t *bouncebuffer, const uint8_t
     stm32_cacheBufferFlush(*buf, (size+31)&~31);
 #endif
     bouncebuffer->busy = true;
+    return true;
 }
 
 
@@ -131,6 +140,16 @@ void bouncebuffer_finish_write(struct bouncebuffer_t *bouncebuffer, const uint8_
 {
     if (bouncebuffer && buf == bouncebuffer->dma_buf) {
         osalDbgAssert((bouncebuffer->busy == true), "bouncebuffer finish_wite");        
+        bouncebuffer->busy = false;
+    }
+}
+
+/*
+  abort an operation
+ */
+void bouncebuffer_abort(struct bouncebuffer_t *bouncebuffer)
+{
+    if (bouncebuffer) {
         bouncebuffer->busy = false;
     }
 }

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.h
@@ -27,7 +27,7 @@ void bouncebuffer_init(struct bouncebuffer_t **bouncebuffer, uint32_t prealloc_b
 /*
   setup for reading from a device into memory, allocating a bouncebuffer if needed
  */
-void bouncebuffer_setup_read(struct bouncebuffer_t *bouncebuffer, uint8_t **buf, uint32_t size);
+bool bouncebuffer_setup_read(struct bouncebuffer_t *bouncebuffer, uint8_t **buf, uint32_t size);
     
 /*
   finish a read operation
@@ -37,12 +37,17 @@ void bouncebuffer_finish_read(struct bouncebuffer_t *bouncebuffer, const uint8_t
 /*
   setup for reading from memory to a device, allocating a bouncebuffer if needed
  */
-void bouncebuffer_setup_write(struct bouncebuffer_t *bouncebuffer, const uint8_t **buf, uint32_t size);
+bool bouncebuffer_setup_write(struct bouncebuffer_t *bouncebuffer, const uint8_t **buf, uint32_t size);
     
 /*
   finish a write operation
  */
 void bouncebuffer_finish_write(struct bouncebuffer_t *bouncebuffer, const uint8_t *buf);
+
+/*
+  abort an operation
+ */
+void bouncebuffer_abort(struct bouncebuffer_t *bouncebuffer);
 
 #ifdef __cplusplus
 }

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -59,7 +59,7 @@ static memory_heap_t heaps[NUM_MEMORY_REGIONS];
 
 // size of memory reserved for dma-capable alloc
 #ifndef DMA_RESERVE_SIZE
-#define DMA_RESERVE_SIZE 4096
+#define DMA_RESERVE_SIZE 6144
 #endif
 
 #if DMA_RESERVE_SIZE != 0
@@ -81,9 +81,15 @@ void malloc_init(void)
       create a DMA reserve heap, to ensure we keep some memory for DMA
       safe memory allocations
      */
-    void *dma_reserve = malloc_dma(DMA_RESERVE_SIZE);
-    osalDbgAssert(dma_reserve != NULL, "DMA reserve");
-    chHeapObjectInit(&dma_reserve_heap, dma_reserve, DMA_RESERVE_SIZE);
+    uint32_t reserve_size = DMA_RESERVE_SIZE;
+    while (reserve_size > 0) {
+        void *dma_reserve = malloc_dma(reserve_size);
+        if (dma_reserve != NULL) {
+            chHeapObjectInit(&dma_reserve_heap, dma_reserve, reserve_size);
+            break;
+        }
+        reserve_size = (reserve_size * 7) / 8;
+    }
 #endif
 }
 

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -56,7 +56,9 @@ bool sdcard_init()
 #if HAL_USE_SDC
 
     if (SDCD1.bouncebuffer == nullptr) {
-        bouncebuffer_init(&SDCD1.bouncebuffer, 512, true);
+        // allocate 4k bouncebuffer for microSD to match size in
+        // AP_Logger
+        bouncebuffer_init(&SDCD1.bouncebuffer, 4096, true);
     }
 
     if (sdcard_running) {

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -300,8 +300,14 @@ void AP_IOMCU::read_status()
 {
     uint16_t *r = (uint16_t *)&reg_status;
     if (!read_registers(PAGE_STATUS, 0, sizeof(reg_status)/2, r)) {
+        read_status_errors++;
         return;
     }
+    if (read_status_ok == 0) {
+        // reset error count on first good read
+        read_status_errors = 0;
+    }
+    read_status_ok++;
 
     check_iomcu_reset();
 
@@ -449,6 +455,7 @@ bool AP_IOMCU::read_registers(uint8_t page, uint8_t offset, uint8_t count, uint1
     if (!uart.wait_timeout(count*2+4, 10)) {
         debug("t=%u timeout read page=%u offset=%u count=%u\n",
               AP_HAL::millis(), page, offset, count);
+        protocol_fail_count++;
         return false;
     }
 
@@ -861,7 +868,7 @@ void AP_IOMCU::set_safety_mask(uint16_t chmask)
  */
 bool AP_IOMCU::healthy(void)
 {
-    return crc_is_ok && protocol_fail_count == 0 && !detected_io_reset;
+    return crc_is_ok && protocol_fail_count == 0 && !detected_io_reset && read_status_errors < read_status_ok/128U;
 }
 
 /*

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -64,7 +64,7 @@ AP_IOMCU *AP_IOMCU::singleton;
 void AP_IOMCU::init(void)
 {
     // uart runs at 1.5MBit
-    uart.begin(1500*1000, 256, 256);
+    uart.begin(1500*1000, 128, 128);
     uart.set_blocking_writes(true);
     uart.set_unbuffered_writes(true);
 
@@ -100,7 +100,7 @@ void AP_IOMCU::thread_main(void)
     thread_ctx = chThdGetSelfX();
     chEvtSignal(thread_ctx, initial_event_mask);
 
-    uart.begin(1500*1000, 256, 256);
+    uart.begin(1500*1000, 128, 128);
     uart.set_blocking_writes(true);
     uart.set_unbuffered_writes(true);
 

--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -221,6 +221,8 @@ private:
     uint32_t total_errors;
     uint32_t num_delayed;
     uint32_t last_iocmu_timestamp_ms;
+    uint32_t read_status_errors;
+    uint32_t read_status_ok;
 
     // firmware upload
     const char *fw_name = "io_firmware.bin";


### PR DESCRIPTION
This fixes an issue found in Copter-4.0.1rc2 where high memory usage led to a DMA bouncebuffer allocating failing in the SDIO code. This also fixes two other issues with AP_IOMCU and the UART driver that were discovered while debugging