### PR TITLE
Copter: Pre-Arm Safety Check for Auto Missions

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -164,6 +164,7 @@ private:
         MIS_ITEM_CHECK_TAKEOFF       = (1 << 3),
         MIS_ITEM_CHECK_VTOL_TAKEOFF  = (1 << 4),
         MIS_ITEM_CHECK_RALLY         = (1 << 5),
+        MIS_ITEM_CHECK_NAV_DIST      = (1 << 6),
         MIS_ITEM_CHECK_MAX
     };
 };

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -31,6 +31,14 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),
 
+    // @Param: MAX_WP_DIST
+    // @DisplayName: Maximum allowed distance to first waypoint.
+    // @Description: Maximum allowed distance in meters to first waypoint for a pre-arm check. Prevents a fly away. Set param to 0, to disable the feature. 
+    // @Units: m
+    // @Range: 10 100000
+    // @User: Advanced
+    AP_GROUPINFO("MAX_WP_DIST",   3 ,  AP_Mission, _max_nav_dist, 0),
+
     AP_GROUPEND
 };
 
@@ -1968,6 +1976,19 @@ bool AP_Mission::contains_item(MAV_CMD command) const
         }
         if (tmp.id == command) {
             return true;
+        }
+    }
+    return false;
+}
+
+//get first navigation command which also has valid location
+bool AP_Mission::get_first_nav_cmd_with_loc(Mission_Command& cmd) 
+{
+    for (uint8_t i = 1; i < (unsigned)_cmd_total; i++) {
+        if (get_next_nav_cmd(i, cmd)) {
+            if (stored_in_location(cmd.id)) {
+                return true;
+            }
         }
     }
     return false;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -480,6 +480,12 @@ public:
     // returns true if the mission contains the requested items
     bool contains_item(MAV_CMD command) const;
 
+    //return maximum dist to first wp parameter
+    uint32_t get_max_arm_dist(void) const { return (uint32_t)_max_nav_dist; }
+
+    //get first navigation command which also has valid location
+    bool get_first_nav_cmd_with_loc(Mission_Command& cmd);
+
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -555,6 +561,7 @@ private:
     AP_Int16                _cmd_total;  // total number of commands in the mission
     AP_Int8                 _restart;   // controls mission starting point when entering Auto mode (either restart from beginning of mission or resume from last command run)
     AP_Int16                _options;    // bitmask options for missions, currently for mission clearing on reboot but can be expanded as required
+    AP_Int32                _max_nav_dist; //maximum allowed distance to first waypoint
 
     // pointer to main program functions
     mission_cmd_fn_t        _cmd_start_fn;  // pointer to function which will be called when a new command is started


### PR DESCRIPTION
This PR solves #1348 which prevents a **fly away** of copter. 
I have created a new param that takes in max allowed distance of the first waypoint when the user switches to mode auto. If the new param, I.e `MIS_MAX_WP_DIST` is set as '0' this feature is disabled (It is disabled by default). If the distance to first way point is greater than maximum allowed distance then copter does not switch to mode auto and raises a message alert. 


Here is what currently happens on master if a user switches to mode auto when the mission was set from some different location far away. It can easily lead to a fly away situation. 

![Screenshot from 2020-01-17 18-50-28 (copy)](https://user-images.githubusercontent.com/36970042/72616635-5fc96f80-395d-11ea-99ff-75f3a23e9fce.png)

After these commits, and setting up the param:
'MIS_MAX_WP_DIST` to any distance in meters
and 
`ARMING_MIS_ITEMS` to value: 64 (bitmask 6), the following message is raised:

![Screenshot from 2020-01-19 20-23-18](https://user-images.githubusercontent.com/36970042/72683020-a8b62b00-3af9-11ea-96f4-e9204b2e05c7.png)

I don't know if this is the best approach to solving this problem, but I feel it'll be a good safety feature to add. 
@rmackay9 @peterbarker @magicrub , if possible, please suggest any changes that can be made to make this PR better.