### PR TITLE
AP_Scripting: add support for dataflash logging

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -929,8 +929,7 @@ AP_Logger::log_write_fmt *AP_Logger::msg_fmt_for_name(const char *name, const ch
             }
         } else {
             // direct comparison used from scripting where pointer is not maintained
-            char *test_name = strdup(f->name);
-            if (strcmp(test_name,name) == 0) {
+            if (strcmp(f->name,name) == 0) {
                 // already have an ID for this name:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
                 assert_same_fmt_for_name(f, name, labels, units, mults, fmt);

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -373,6 +373,31 @@ public:
     // returns true if msg_type is associated with a message
     bool msg_type_in_use(uint8_t msg_type) const;
 
+    // calculate the length of a message using fields specified in
+    // fmt; includes the message header
+    int16_t Write_calc_msg_len(const char *fmt) const;
+
+    // this structure looks much like struct LogStructure in
+    // LogStructure.h, however we need to remember a pointer value for
+    // efficiency of finding message types
+    struct log_write_fmt {
+        struct log_write_fmt *next;
+        uint8_t msg_type;
+        uint8_t msg_len;
+        uint8_t sent_mask; // bitmask of backends sent to
+        const char *name;
+        const char *fmt;
+        const char *labels;
+        const char *units;
+        const char *mults;
+    } *log_write_fmts;
+
+    // return (possibly allocating) a log_write_fmt for a name
+    struct log_write_fmt *msg_fmt_for_name(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, const bool direct_comp = false);
+
+    // output a FMT message for each backend if not already done so
+    void Safe_Write_Emit_FMT(log_write_fmt *f);
+
 protected:
 
     const struct LogStructure *_structures;
@@ -405,25 +430,9 @@ private:
      * support for dynamic Write; user-supplies name, format,
      * labels and values in a single function call.
      */
-
-    // this structure looks much like struct LogStructure in
-    // LogStructure.h, however we need to remember a pointer value for
-    // efficiency of finding message types
-    struct log_write_fmt {
-        struct log_write_fmt *next;
-        uint8_t msg_type;
-        uint8_t msg_len;
-        uint8_t sent_mask; // bitmask of backends sent to
-        const char *name;
-        const char *fmt;
-        const char *labels;
-        const char *units;
-        const char *mults;
-    } *log_write_fmts;
     HAL_Semaphore log_write_fmts_sem;
 
     // return (possibly allocating) a log_write_fmt for a name
-    struct log_write_fmt *msg_fmt_for_name(const char *name, const char *labels, const char *units, const char *mults, const char *fmt);
     const struct log_write_fmt *log_write_fmt_for_msg_type(uint8_t msg_type) const;
 
     const struct LogStructure *structure_for_msg_type(uint8_t msg_type);
@@ -433,10 +442,6 @@ private:
 
     // fill LogStructure with information about msg_type
     bool fill_log_write_logstructure(struct LogStructure &logstruct, const uint8_t msg_type) const;
-
-    // calculate the length of a message using fields specified in
-    // fmt; includes the message header
-    int16_t Write_calc_msg_len(const char *fmt) const;
 
     bool _armed;
 

--- a/libraries/AP_Scripting/examples/UART_log.lua
+++ b/libraries/AP_Scripting/examples/UART_log.lua
@@ -1,0 +1,114 @@
+-- Reads data in from UART and logs to dataflash
+
+-- find the serial first (0) scripting serial port instance
+local port = serial:find_serial(0)
+
+if not port or baud == 0 then
+    gcs:send_text(0, "No Scripting Serial Port")
+    return
+end
+
+-- begin the serial port
+port:begin(9600)
+port:set_flow_control(0)
+
+-- table for strings used in decoding
+local log_data = {}
+local term_number = 1
+local valid = true
+local term
+
+-- number of terms we expect in the message
+local num_terms = 3
+-- maximum length of terms each term we expect
+local max_length = 20
+
+-- decode a basic string
+local function decode(byte)
+    local char = string.char(byte)
+    if char == '\r' or char == '\n' or char == ',' then
+
+        -- decode the term, note this assumes it is a number
+        log_data[term_number] = tonumber(term)
+        if not log_data[term_number] then
+            -- could not convert to a number, discard this message
+            valid = false
+        end
+        term = nil
+
+        -- not got to the end yet
+        if char == ',' then
+            -- move onto next term
+            if term_number < num_terms then
+                term_number = term_number + 1
+            end
+            return false
+        end
+
+        -- make sure we have the correct number of terms
+        if #log_data ~= num_terms then
+            valid = false
+        end
+
+        if not valid then
+            log_data = {}
+        end
+
+        -- reset for the next message
+        local is_valid = valid
+        term_number = 1
+        valid = true
+
+        return is_valid
+    end
+
+    -- ordinary characters are added to term
+    -- if we have too many terms or they are too long then don't add to them
+    if term_number <= num_terms then
+        if term then
+            if string.len(term) < max_length then
+                term = term .. char
+            else
+                valid = false
+            end
+        else
+            term = char
+        end
+    else
+        valid = false
+    end
+
+    return false
+end
+
+-- the main update function that is used to read in data from serial port
+function update()
+
+    if not port then
+        gcs:send_text(0, "no Scripting Serial Port")
+        return update, 100
+    end
+
+    local n_bytes = port:available()
+    while n_bytes > 0 do
+        local byte = port:read()
+        if decode(byte) then
+            -- we have got a full line
+            -- save to data flash
+
+            -- care must be taken when selecting a name, must be less than four characters and not clash with an existing log type
+            -- format characters specify the type of variable to be logged, see AP_Logger/README.md
+            -- not all format types are supported by scripting only: i, L, e, f, n, M, B, I, E, and N
+            -- Note that Lua automatically adds a timestamp in micro seconds
+            logger.write('SCR','Sensor1, Sensor2, Sensor3','fff',table.unpack(log_data))
+
+            -- reset for the next message
+            log_data = {}
+        end
+        n_bytes = n_bytes - 1
+    end
+
+    return update, 100
+end
+
+return update, 100

--- a/libraries/AP_Scripting/examples/logging.lua
+++ b/libraries/AP_Scripting/examples/logging.lua
@@ -1,0 +1,64 @@
+-- example of logging to a file on the SD card and to data flash
+local file_name = "AHRS_DATA.csv"
+local file
+
+-- index for the data and table
+local roll = 1
+local pitch = 2
+local yaw = 3
+local interesting_data = {}
+
+local function write_to_file()
+
+  if not file then
+    error("Could not open file")
+  end
+
+  -- write data
+  -- separate with comas and add a carriage return
+  file:write(tostring(millis()) .. ", " .. table.concat(interesting_data,", ") .. "\n")
+
+  -- make sure file is upto date
+  file:flush()
+
+end
+
+local function write_to_dataflash()
+
+  -- care must be taken when selecting a name, must be less than four characters and not clash with an existing log type
+  -- format characters specify the type of variable to be logged, see AP_Logger/README.md
+  -- not all format types are supported by scripting only: i, L, e, f, n, M, B, I, E, and N
+  -- lua automatically adds a timestamp in micro seconds
+  logger.write('SCR','roll(deg),pitch(deg),yaw(deg)','fff',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
+
+end
+
+function update()
+
+  -- get some interesting data
+  interesting_data[roll] = math.deg(ahrs:get_roll())
+  interesting_data[pitch] = math.deg(ahrs:get_pitch())
+  interesting_data[yaw] = math.deg(ahrs:get_yaw())
+
+  -- write to then new file the SD card
+  write_to_file()
+
+  -- write to a new log in the data flash log
+  write_to_dataflash()
+
+  return update, 1000 -- reschedules the loop
+end
+
+-- make a file
+-- note that this appends to the same the file each time, you will end up with a very big file
+-- you may want to make a new file each time using a unique name
+file = io.open(file_name, "a")
+if not file then
+  error("Could not make file")
+end
+
+-- write the CSV header
+file:write('Time Stamp(ms), roll(deg), pitch(deg), yaw(deg)\n')
+file:flush()
+
+return update, 10000

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -1,6 +1,7 @@
 #include <AP_Common/AP_Common.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_HAL/HAL.h>
+#include <AP_Logger/AP_Logger.h>
 
 #include "lua_bindings.h"
 
@@ -40,7 +41,171 @@ static const luaL_Reg global_functions[] =
     {NULL, NULL}
 };
 
+static int AP_Logger_Write(lua_State *L) {
+    AP_Logger * AP_logger = AP_Logger::get_singleton();
+    if (AP_logger == nullptr) {
+        return luaL_argerror(L, 1, "logger not supported on this firmware");
+    }
+
+    // check we have at least 4 arguments passed in
+    const int args = lua_gettop(L);
+    if (args < 4) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    const char * name = luaL_checkstring(L, 1);
+    const char * labels = luaL_checkstring(L, 2);
+    const char * fmt = luaL_checkstring(L, 3);
+
+    // cheack the name, labels and format are not too long
+    if (strlen(name) >= LS_NAME_SIZE) {
+        return luaL_error(L, "Name must be 4 or less chars long");
+    }
+    int length = strlen(labels);
+    if (length >= (LS_LABELS_SIZE - 7)) { // need 7 chars to add 'TimeUS,'
+        return luaL_error(L, "labels must be less than 58 chars long");
+    }
+    // Count the number of commas
+    uint8_t commas = 1;
+    for (uint8_t i=0; i<length; i++) {
+        if (labels[i] == ',') {
+            commas++;
+        }
+    }
+    // check the number of arguments matches the number of values in the label
+    if (args - 3 != commas) {
+        return luaL_argerror(L, args, "label does not match No. of arguments");
+    }
+
+    length = strlen(fmt);
+    if (length >= (LS_FORMAT_SIZE - 1)) { // need 1 char to add timestamp
+        return luaL_error(L, "format must be less than 15 chars long");
+    }
+
+    // check the number of arguments matches the length of the foramt string
+    if (args - 3 != length) {
+        return luaL_argerror(L, args, "format does not match No. of arguments");
+    }
+
+    // prepend timestamp to format and labels
+    char label_cat[LS_LABELS_SIZE];
+    strcpy(label_cat,"TimeUS,");
+    strcat(label_cat,labels);
+    char fmt_cat[LS_FORMAT_SIZE];
+    strcpy(fmt_cat,"Q");
+    strcat(fmt_cat,fmt);
+
+    // ask for a mesage type
+    struct AP_Logger::log_write_fmt *f = AP_logger->msg_fmt_for_name(name, label_cat, nullptr, nullptr, fmt_cat, true);
+    if (f == nullptr) {
+        // unable to map name to a messagetype; could be out of
+        // msgtypes, could be out of slots, ...
+        return luaL_argerror(L, args, "could not map message type");
+    }
+
+    // work out how long the block will be
+    int16_t msg_len = AP_logger->Write_calc_msg_len(fmt_cat);
+    if (msg_len == -1) {
+        return luaL_argerror(L, args, "unknown format");
+    }
+
+    luaL_Buffer buffer;
+    luaL_buffinit(L, &buffer);
+
+    // add logging headers
+    const char header[2] = {(char)HEAD_BYTE1, (char)HEAD_BYTE2};
+    luaL_addlstring(&buffer, header, sizeof(header));
+    luaL_addlstring(&buffer, (char *)&f->msg_type, sizeof(f->msg_type));
+
+    // timestamp is always first value
+    const uint64_t now = AP_HAL::micros64();
+    luaL_addlstring(&buffer, (char *)&now, sizeof(uint64_t));
+
+    for (uint8_t i=4; i<=args; i++) {
+        uint8_t charlen = 0;
+        switch(fmt_cat[i-3]) {
+            // logger varable types not available to scripting
+            // 'b': int8_t
+            // 'h': int16_t
+            // 'c': int16_t
+            // 'd': double
+            // 'H': uint16_t
+            // 'C': uint16_t
+            // 'Q': uint64_t
+            // 'q': int64_t
+            // 'a': arrays
+            case 'i':
+            case 'L':
+            case 'e': {
+                const lua_Integer tmp1 = luaL_checkinteger(L, i);
+                luaL_argcheck(L, ((tmp1 >= INT32_MIN) && (tmp1 <= INT32_MAX)), i, "argument out of range");
+                int32_t tmp = tmp1;
+                luaL_addlstring(&buffer, (char *)&tmp, sizeof(int32_t));
+                break;
+            }
+            case 'f': {
+                float tmp = luaL_checknumber(L, i);
+                luaL_argcheck(L, ((tmp >= -INFINITY) && (tmp <= INFINITY)), i, "argument out of range");
+                luaL_addlstring(&buffer, (char *)&tmp, sizeof(float));
+                break;
+            }
+            case 'n': {
+                charlen = 4;
+                break;
+            }
+            case 'M':
+            case 'B': {
+                const lua_Integer tmp1 = luaL_checkinteger(L, i);
+                luaL_argcheck(L, ((tmp1 >= 0) && (tmp1 <= UINT8_MAX)), i, "argument out of range");
+                uint8_t tmp = static_cast<uint8_t>(tmp1);
+                luaL_addlstring(&buffer, (char *)&tmp, sizeof(uint8_t));
+                break;
+            }
+            case 'I':
+            case 'E': {
+                const uint32_t tmp = coerce_to_uint32_t(L, i);
+                luaL_addlstring(&buffer, (char *)&tmp, sizeof(uint32_t));
+                break;
+            }
+            case 'N': {
+                charlen = 16;
+                break;
+            }
+            case 'Z': {
+                charlen = 64;
+                break;
+            }
+            default: {
+                return luaL_error(L, "%c unsupported format",fmt_cat[i-3]);
+            }
+        }
+        if (charlen != 0) {
+            const char *tmp = luaL_checkstring(L, i);
+            if (strlen(tmp) > charlen) {
+                return luaL_error(L, "arg %i too long for %c format",i,fmt_cat[i-3]);
+            }
+            luaL_addlstring(&buffer, (char *)&tmp, charlen);
+        }
+    }
+
+    AP_logger->Safe_Write_Emit_FMT(f);
+
+    luaL_pushresult(&buffer);
+    AP_logger->WriteBlock(buffer.b,msg_len);
+
+    return 0;
+}
+
+const luaL_Reg AP_Logger_functions[] = {
+    {"write", AP_Logger_Write},
+    {NULL, NULL}
+};
+
 void load_lua_bindings(lua_State *L) {
+    lua_pushstring(L, "logger");
+    luaL_newlib(L, AP_Logger_functions);
+    lua_settable(L, -3);
+
     luaL_setfuncs(L, global_functions, 0);
 }
 


### PR DESCRIPTION
This add support for writing to dataflash logs from scripting. This also adds a example writing to both dataflash logs and a file on the SD card. There is also a second example that reads in data over serial and writes to dataflash closing https://github.com/ArduPilot/ardupilot/pull/12801. The examples use find_baudrate() and tabel.concat from https://github.com/ArduPilot/ardupilot/pull/13268. Tested both in SITL and on real hardware.

This generally works OK, not all the the formats are supported for lua so I added a helper to auto fill the timestamp for a 'Q' character in the format string. 

Is there a nicer way to give the binding access to AP_logger? I had to make a couple of functions public to get this working. Possibly we may have also bypassed some checking that gets done by logger before logging. 

Many thanks to @WickedShell for helping me out when I got stuck (more than once) 