### PR TITLE
Tools: Added semaphore ops to CPUInfo

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -27,6 +27,8 @@ static uint32_t sysclk = 0;
 
 static EKF_Maths ekf;
 
+HAL_Semaphore sem;
+HAL_Semaphore_Recursive rsem;
 
 
 void setup() {
@@ -158,6 +160,9 @@ static void show_timings(void)
     TIMEIT("memcpy128", memcpy((void*)mbuf1, (const void *)mbuf2, sizeof(mbuf1)); v_out_8 += mbuf1[0], 200);
     TIMEIT("memset128", memset((void*)mbuf1, 1, sizeof(mbuf1)); v_out_8 += mbuf1[0], 200);
     TIMEIT("delay(1)", hal.scheduler->delay(1), 5);
+
+    TIMEIT("SEM", { WITH_SEMAPHORE(sem); v_out_32 += v_32;}, 100);
+    TIMEIT("RSEM", { WITH_SEMAPHORE(rsem); v_out_32 += v_32;}, 100);
 }
 
 void loop()


### PR DESCRIPTION
taking a semaphore on F765 takes about 1.3us. About 1.5us for a
recursive semaphore

On a F405 it costs about 2.6us for semaphore, about 2.8us for
recursive semaphore