### PR TITLE
Copter: Set the flight mode at startup to the flight SW.

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -71,10 +71,6 @@ void Copter::init_ardupilot()
     // init winch and wheel encoder
     winch_init();
 
-    // initialise notify system
-    notify.init();
-    notify_flight_mode();
-
     // initialise battery monitor
     battery.init();
 
@@ -186,6 +182,24 @@ void Copter::init_ardupilot()
     // set INS to HIL mode
     ins.set_hil_mode();
 #endif
+
+    // Setting the flight mode of the flight mode switch
+    int8_t flightCH = copter.g.flight_mode_chan.get();
+    uint16_t ch_in = rc().channel(flightCH - 1)->get_radio_in();
+    int8_t position = 0;
+    if      (ch_in < 1231) position = 0;
+    else if (ch_in < 1361) position = 1;
+    else if (ch_in < 1491) position = 2;
+    else if (ch_in < 1621) position = 3;
+    else if (ch_in < 1750) position = 4;
+    else position = 5;
+    
+    control_mode = (enum Mode::Number)flight_modes[position].get();
+    flightmode = mode_from_mode_num(control_mode);
+
+    // initialise notify system
+    notify.init();
+    notify_flight_mode();
 
     // read Baro pressure at ground
     //-----------------------------


### PR DESCRIPTION
I set flight mode 1-6 other than stabilization.
I saw a message in SITL that switches from stabilize to RTL when starting SITL.
I think it's better to start up in the flight mode of the radio's flight mode switch.

BEFORE
![Screenshot from 2020-01-19 23-55-31](https://user-images.githubusercontent.com/646194/72683351-f3e03600-3b19-11ea-8568-9b1d24d0947f.png)

AFTER
![Screenshot from 2020-01-20 00-01-52](https://user-images.githubusercontent.com/646194/72683360-08243300-3b1a-11ea-8fd7-016e61310c7f.png)