### PR TITLE
Plane: fix floating outputs and allow motor test for tailsitters and tiltrotors 

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -54,7 +54,8 @@ bool QuadPlane::tailsitter_active(void)
  */
 void QuadPlane::tailsitter_output(void)
 {
-    if (!is_tailsitter()) {
+    if (!is_tailsitter() || motor_test.running) {
+        // if motor test is running we don't want to overwrite it with output_motor_mask or motors_output
         return;
     }
 
@@ -88,18 +89,14 @@ void QuadPlane::tailsitter_output(void)
                 SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
                 pos_control->get_accel_z_pid().set_integrator(throttle*10);
 
-                if (mask == 0) {
-                    // override AP_MotorsTailsitter throttles during back transition
-                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
-                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
-                }
-            }
-            if (mask != 0) {
-                // set AP_MotorsMatrix throttles enabled for forward flight
-                motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
+                // override AP_MotorsTailsitter throttles during back transition
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
             }
         }
+        // set AP_MotorsMatrix throttles for forward flight
+        motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
         return;
     }
 

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -75,11 +75,13 @@ void QuadPlane::tiltrotor_continuous_update(void)
         if (!hal.util->get_soft_armed()) {
             tilt.current_throttle = 0;
         } else {
+            // prevent motor shutdown
+            tilt.motors_active = true;
+        }
+        if (!motor_test.running) {
             // the motors are all the way forward, start using them for fwd thrust
             uint8_t mask = is_zero(tilt.current_throttle)?0:(uint8_t)tilt.tilt_mask.get();
             motors->output_motor_mask(tilt.current_throttle, mask, plane.rudder_dt);
-            // prevent motor shutdown
-            tilt.motors_active = true;
         }
         return;
     }
@@ -373,7 +375,8 @@ void QuadPlane::tiltrotor_vectored_yaw(void)
  */
 void QuadPlane::tiltrotor_bicopter(void)
 {
-    if (tilt.tilt_type != TILT_TYPE_BICOPTER) {
+    if (tilt.tilt_type != TILT_TYPE_BICOPTER || motor_test.running) {
+        // don't override motor test with motors_output
         return;
     }
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -737,7 +737,7 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float r
 
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
-            if (mask & (1U << i)) {
+            if ((mask & (1U << i)) && armed()) {
                 /*
                  apply rudder mixing differential thrust
                  copter frame roll is plane frame yaw as this only


### PR DESCRIPTION
This moves both tailsitter and tiltrottors to always output motor mask and leaves AP_Motors to zero the throttle if not armed. This fixes the outputs being left with no pwm if you boot into a forward flight mode. It also fixes the output just being left at whatever they were previously, for example if you were to disarm with half throttle in a forward flight mode the outputs would remain at half until you re-arm and change it or switch to a Q mode.

This also adds a check for a active motor test before call either output_motor_mask or motors_output. There were both overwriting the motor test PWM back to min.