### PR TITLE
Change NeoPixel Length for NTF LEDs

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -53,7 +53,7 @@ AP_Notify *AP_Notify::_singleton;
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
   #define BUILD_DEFAULT_LED_TYPE (Notify_LED_Board | I2C_LEDS)
 
-// Linux boards    
+// Linux boards
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
   #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
     #define BUILD_DEFAULT_LED_TYPE (Notify_LED_Board | I2C_LEDS |\
@@ -164,7 +164,14 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Range: 0 100
     // @Units: %
     AP_GROUPINFO("BUZZ_VOLUME", 8, AP_Notify, _buzzer_volume, 100),
-    
+
+    // @Param: NEO_LEN
+    // @DisplayName: NeoPixel String Length
+    // @Description: The number of NeoPixel LEDs to use for notifications
+    // @Range: 1 32
+    // @User: Advanced
+    AP_GROUPINFO("NEO_LEN", 9, AP_Notify, _neo_len, 1),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -51,7 +51,7 @@ public:
     static AP_Notify *get_singleton(void) {
         return _singleton;
     }
-    
+
     // Oreo LED Themes
     enum Oreo_LED_Theme {
         OreoLED_Disabled        = 0,    // Disabled the OLED driver entirely
@@ -162,6 +162,7 @@ public:
     uint8_t get_buzz_pin() const  { return _buzzer_pin; }
     uint8_t get_buzz_level() const  { return _buzzer_level; }
     uint8_t get_buzz_volume() const  { return _buzzer_volume; }
+    uint8_t get_neo_len() const {return _neo_len; }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     HAL_Semaphore sf_window_mutex;
@@ -186,6 +187,7 @@ private:
     AP_Int32 _led_type;
     AP_Int8 _buzzer_level;
     AP_Int8 _buzzer_volume;
+    AP_Int8 _neo_len;   //adding to define length of ntf neopixel string
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];
     uint32_t _send_text_updated_millis; // last time text changed

--- a/libraries/AP_Notify/NeoPixel.cpp
+++ b/libraries/AP_Notify/NeoPixel.cpp
@@ -20,10 +20,6 @@
 // This limit is from the dshot driver rcout groups limit
 #define AP_NOTIFY_NEOPIXEL_MAX_INSTANCES        4
 
-#ifndef HAL_NEOPIXEL_COUNT
-#define HAL_NEOPIXEL_COUNT 1
-#endif
-
 // Datasheet: https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf
 // 24bit msg as 3 byte GRB (not RGB) where first bit is G7, and last bit is B0
 // (first) G7|G6|G5|G4|G3|G2|G1|G0|R7|R6|R5|R4|R3|R2|R1|R0|B7|B6|B5|B4|B3|B2|B1|B0 (last)
@@ -61,7 +57,7 @@ uint16_t NeoPixel::init_ports()
     if (mask != 0) {
         for (uint16_t chan=0; chan<16; chan++) {
             if ((1U<<chan) & mask) {
-                hal.rcout->set_neopixel_num_LEDs(chan, HAL_NEOPIXEL_COUNT);
+                hal.rcout->set_neopixel_num_LEDs(chan, (pNotify->get_neo_len()));
             }
         }
     }
@@ -89,7 +85,7 @@ bool NeoPixel::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
 
     for (uint16_t chan=0; chan<16; chan++) {
         if ((1U<<chan) & enable_mask) {
-            hal.rcout->set_neopixel_rgb_data(chan, (1U<<HAL_NEOPIXEL_COUNT)-1, red, green, blue);
+            hal.rcout->set_neopixel_rgb_data(chan, (1U<<(pNotify->get_neo_len()))-1, red, green, blue);
         }
     }
     hal.rcout->neopixel_send();


### PR DESCRIPTION
This change allows more than a single NeoPixel in a chain be used for an NTF LED. In particular, I had some PCBs with 8 pixels on them, and I was able to dynamically change the number of status LEDs from 1 to 8 using parameter NTF_NEO_LEN. 

Tested using Plane master on an omnibusf4pro. 

Not sure if this has to do with my shoddy code but whenever I write a new value to NTF_NEO_LEN, mission planner disconnects from the aircraft. 

I don't really know much C++ and this is my first ArduPilot edit, so looking for any criticism you might have. 