### PR TITLE
AC_AutoTune: fix backup of yaw acceleration

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -1210,7 +1210,7 @@ void AC_AutoTune::save_tuning_gains()
         orig_yaw_rff = attitude_control->get_rate_yaw_pid().ff();
         orig_yaw_rLPF = attitude_control->get_rate_yaw_pid().filt_E_hz();
         orig_yaw_sp = attitude_control->get_angle_yaw_p().kP();
-        orig_yaw_accel = attitude_control->get_accel_pitch_max();
+        orig_yaw_accel = attitude_control->get_accel_yaw_max();
     }
 
     // update GCS and log save gains event


### PR DESCRIPTION
This PR fixes a bug when AC_AutoTune goes to save the gains after AutoTune has completed successfully.  The issue was not with the actual gains being saved but rather the backup yaw acceleration was being set incorrectly.  This could lead to the wrong yaw acceleration being used if autotune was stopped by the user (for example if the pilot took over control with the stick).

This resolves this issue: https://github.com/ArduPilot/ardupilot/issues/13344