### PR TITLE
Copter 4.0 rc override timeout fix

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -356,7 +356,7 @@ bool RC_Channel::has_override() const
     }
 
     const float override_timeout_ms = rc().override_timeout_ms();
-    return is_positive(override_timeout_ms) && ((AP_HAL::millis() - last_override_time) < (uint32_t)override_timeout_ms);
+    return override_timeout_ms == -1 || (is_positive(override_timeout_ms) && ((AP_HAL::millis() - last_override_time) < (uint32_t)override_timeout_ms));
 }
 
 /*

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -356,7 +356,7 @@ bool RC_Channel::has_override() const
     }
 
     const float override_timeout_ms = rc().override_timeout_ms();
-    return override_timeout_ms == -1 || (is_positive(override_timeout_ms) && ((AP_HAL::millis() - last_override_time) < (uint32_t)override_timeout_ms));
+    return override_timeout_ms < 0 || (is_positive(override_timeout_ms) && ((AP_HAL::millis() - last_override_time) < (uint32_t)override_timeout_ms));
 }
 
 /*


### PR DESCRIPTION
Small fix to handle the rc_override_time=-1 case.  This addresses why the RC overrides were not being respected as discussed here:
https://discuss.ardupilot.org/t/copter-4-0-1-rc3-available-for-beta-testing/51295/26

@rmackay9 