### PR TITLE
AR_WPNav: Fix issue with WP_SPEED_MIN unintentionally being applied in reverse

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -435,6 +435,6 @@ void AR_WPNav::apply_speed_min(float &desired_speed)
 
     // ensure speed does not fall below minimum
     if (fabsf(desired_speed) < speed_min) {
-        desired_speed = is_negative(desired_speed) ? -speed_min : speed_min;
+        desired_speed = is_negative(_desired_speed) ? -speed_min : speed_min;
     }
 }


### PR DESCRIPTION
Changed apply_speed_min(): desired_speed to set in the direction of global _desired_speed rather than the speed limited parameter that is passed in. Speed limiting may result in desired_speed remaining negative even when _desired_speed is positive.