### PR TITLE
Copter: check if only one of MOT_PWM_MIN or MOT_PWM_MAX is set

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -148,6 +148,14 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
     // check various parameter values
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_PARAMETERS)) {
 
+	    // checks MOT_PWM_MIN/MAX for acceptable values
+#if (FRAME_CONFIG != HELI_FRAME)
+        if (copter.motors->check_mot_pwm_params()) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check MOT_PWM_MAX/MIN");
+            return false;
+        } 
+#endif
+
         // ensure all rc channels have different functions
         if (rc().duplicate_options_exist()) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Duplicate Aux Switch Options");

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -483,6 +483,17 @@ int16_t AP_MotorsMulticopter::get_pwm_output_max() const
     return _throttle_radio_max;
 }
 
+// parameter checks for MOT_PWM_MIN/MAX
+bool AP_MotorsMulticopter::check_mot_pwm_params() 
+{
+    if ((_pwm_min == 0 && _pwm_max !=0) || (_pwm_min != 0 && _pwm_max == 0) ||
+     (_pwm_min < 0 || _pwm_min < 0) || (_pwm_min > _pwm_max))
+    {
+        return true;
+    }
+    return false;
+}
+
 // set_throttle_range - sets the minimum throttle that will be sent to the engines when they're not off (i.e. to prevents issues with some motors spinning and some not at very low throttle)
 // also sets throttle channel minimum and maximum pwm
 void AP_MotorsMulticopter::set_throttle_range(int16_t radio_min, int16_t radio_max)

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -84,6 +84,9 @@ public:
     int16_t             get_pwm_output_min() const;
     int16_t             get_pwm_output_max() const;
     
+    // parameter check for MOT_PWM_MIN/MAX
+    bool check_mot_pwm_params();
+
     // set thrust compensation callback
     FUNCTOR_TYPEDEF(thrust_compensation_fn_t, void, float *, uint8_t);
     void                set_thrust_compensation_callback(thrust_compensation_fn_t callback) {


### PR DESCRIPTION
fixes #13242 

Pre-arm check to ensure that both MOT_PWM_MIN and MOT_PWM_MAX values are either zero or non-zero. When only one of them is non-zerol trigger a pre-arm failure.
![Screenshot from 2020-01-22 00-59-51](https://user-images.githubusercontent.com/35897713/72976565-d7cde480-3df8-11ea-9990-cc86cfa1933b.png)
![Screenshot from 2020-01-22 01-00-29](https://user-images.githubusercontent.com/35897713/72976574-db616b80-3df8-11ea-9f76-e8b7e918afdd.png)

