### PR TITLE
AP_Frsky_Telem: remove allocation and partial initialisation in get_t…

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -1122,15 +1122,6 @@ bool AP_Frsky_Telem::_get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &
  */
 bool AP_Frsky_Telem::get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data)
 {
-    if (!singleton && !hal.util->get_soft_armed()) {
-        // if telem data is requested when we are disarmed and don't
-        // yet have a AP_Frsky_Telem object then try to allocate one
-        new AP_Frsky_Telem(true);
-        // initialize the passthrough scheduler
-        if (singleton) {
-            singleton->setup_passthrough();
-        }
-    }
     if (!singleton) {
         return false;
     }


### PR DESCRIPTION
…elem_data

The way this is structured we will never call "init" on the object.

Callers must already handle the case that "false" is returned.

The GCS library unconditionally creates this object.