### PR TITLE
AP_RangeFinder: TeraRanger a to close reading is not the minimum distance

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -143,8 +143,7 @@ bool AP_RangeFinder_TeraRangerI2C::process_raw_measure(uint16_t raw_distance, ui
       return false;
   } else if (raw_distance == 0x0000) {
       // Too close
-      output_distance_cm =  params.min_distance_cm;
-      return true;
+      return false;
   } else if (raw_distance == 0x0001) {
       // Unable to measure
       return false;


### PR DESCRIPTION
This is a bit of a drive by change, but as far as I can tell using the minimum distance here is unsafe. The problem with copying the minimum distance in, is that if we are to close to get a reading we could be any distance less then the minimum distance. However the logic for determing if a rangefinder is good or not only considers the driver to be out of range low, if the distance is less then the minimum distance.  Logic can be seen [here.](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp#L56)

This could be combined with the following case, I kept them separate just to ensure that the meanings are preserved, and to make it easier to directly flag something like OutOfRangeLow in the future.

I don't actually have one of these units, so I can't test (or even verify) if this is a real problem (and solution). Does anyone have the hardware to actually do the test?