### PR TITLE
AP_Camera: send mavlink camera feedback message even if no logger

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -400,19 +400,22 @@ void AP_Camera::setup_feedback_callback(void)
 // log_picture - log picture taken and send feedback to GCS
 void AP_Camera::log_picture()
 {
+    if (!using_feedback_pin()) {
+        gcs().send_message(MSG_CAMERA_FEEDBACK);
+    }
+
     AP_Logger *logger = AP_Logger::get_singleton();
     if (logger == nullptr) {
         return;
     }
+    if (!logger->should_log(log_camera_bit)) {
+        return;
+    }
+
     if (!using_feedback_pin()) {
-        gcs().send_message(MSG_CAMERA_FEEDBACK);
-        if (logger->should_log(log_camera_bit)) {
-            logger->Write_Camera(current_loc);
-        }
+        logger->Write_Camera(current_loc);
     } else {
-        if (logger->should_log(log_camera_bit)) {
-            logger->Write_Trigger(current_loc);
-        }
+        logger->Write_Trigger(current_loc);
     }
 }
 


### PR DESCRIPTION
It's unlikely that logger will be nulltr here, but this shouldn't be behind that check.  And should possibly be in the sole caller to the method.
