### PR TITLE
Rover: Fix SERVOx_REVERSED does not work as expected for ESC type "BrushedWithRelay"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ persistent.dat
 dumpstack_*out
 build.tmp.binaries/
 tasklist.json
+.vs/

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -147,9 +147,10 @@ void AP_MotorsUGV::setup_safety_output()
         // set trim to min to set duty cycle range (0 - 100%) to servo range
         // do not use function SRV_Channels::set_trim_to_min_for because this will set trim to MAX
         // when reversed is set, causing the rover motor to run full speed at minimum throttle
-        SRV_Channels::set_trim_to_min2_for(SRV_Channel::k_throttle);
-        SRV_Channels::set_trim_to_min2_for(SRV_Channel::k_throttleLeft);
-        SRV_Channels::set_trim_to_min2_for(SRV_Channel::k_throttleRight);
+        // instead use new function set_trim_to_limit_for
+        SRV_Channels::set_trim_to_limit_for(SRV_Channel::k_throttle, SRV_Channel::Limit::MIN, true);
+        SRV_Channels::set_trim_to_limit_for(SRV_Channel::k_throttleLeft, SRV_Channel::Limit::MIN, true);
+        SRV_Channels::set_trim_to_limit_for(SRV_Channel::k_throttleRight, SRV_Channel::Limit::MIN, true);
     }
 
     if (_disarm_disable_pwm) {

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -145,9 +145,11 @@ void AP_MotorsUGV::setup_safety_output()
 {
     if (_pwm_type == PWM_TYPE_BRUSHED_WITH_RELAY) {
         // set trim to min to set duty cycle range (0 - 100%) to servo range
-        SRV_Channels::set_trim_to_min_for(SRV_Channel::k_throttle);
-        SRV_Channels::set_trim_to_min_for(SRV_Channel::k_throttleLeft);
-        SRV_Channels::set_trim_to_min_for(SRV_Channel::k_throttleRight);
+        // do not use function SRV_Channels::set_trim_to_min_for because this will set trim to MAX
+        // when reversed is set, causing the rover motor to run full speed at minimum throttle
+        SRV_Channels::set_trim_to_min2_for(SRV_Channel::k_throttle);
+        SRV_Channels::set_trim_to_min2_for(SRV_Channel::k_throttleLeft);
+        SRV_Channels::set_trim_to_min2_for(SRV_Channel::k_throttleRight);
     }
 
     if (_disarm_disable_pwm) {

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -395,8 +395,11 @@ public:
     // set and save the trim for a function channel to the output value
     static void set_trim_to_servo_out_for(SRV_Channel::Aux_servo_function_t function);
 
-    // set the trim for a function channel to min of the channel
+    // set the trim for a function channel to min of the channel respectively max of the channel when reversed is set
     static void set_trim_to_min_for(SRV_Channel::Aux_servo_function_t function);
+
+    // set the trim for a function channel to min of the channel
+    static void set_trim_to_min2_for(SRV_Channel::Aux_servo_function_t function);
 
     // set the trim for a function channel to given pwm
     static void set_trim_to_pwm_for(SRV_Channel::Aux_servo_function_t function, int16_t pwm);

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -398,8 +398,9 @@ public:
     // set the trim for a function channel to min of the channel respectively max of the channel when reversed is set
     static void set_trim_to_min_for(SRV_Channel::Aux_servo_function_t function);
 
-    // set the trim for a function channel to min of the channel
-    static void set_trim_to_min2_for(SRV_Channel::Aux_servo_function_t function);
+    // set servo trim to a Limit
+    // when ignore_reversed is true the flipping of Min/Max values, that usually is done when reversed flag ist set, is not applied
+    static void set_trim_to_limit_for(SRV_Channel::Aux_servo_function_t function, SRV_Channel::Limit limit, bool ignore_reversed = false);
 
     // set the trim for a function channel to given pwm
     static void set_trim_to_pwm_for(SRV_Channel::Aux_servo_function_t function, int16_t pwm);

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -584,12 +584,22 @@ void SRV_Channels::set_trim_to_pwm_for(SRV_Channel::Aux_servo_function_t functio
     }
 }
 
-// set the trim for a function channel to min output
+// set the trim for a function channel to min output respectively max output when reversed is set
 void SRV_Channels::set_trim_to_min_for(SRV_Channel::Aux_servo_function_t function)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
             channels[i].servo_trim.set(channels[i].get_reversed()?channels[i].servo_max:channels[i].servo_min);
+        }
+    }
+}
+
+// set the trim for a function channel to min output
+void SRV_Channels::set_trim_to_min2_for(SRV_Channel::Aux_servo_function_t function)
+{
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+        if (channels[i].function == function) {
+            channels[i].servo_trim.set(channels[i].servo_min);
         }
     }
 }

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -594,12 +594,31 @@ void SRV_Channels::set_trim_to_min_for(SRV_Channel::Aux_servo_function_t functio
     }
 }
 
-// set the trim for a function channel to min output
-void SRV_Channels::set_trim_to_min2_for(SRV_Channel::Aux_servo_function_t function)
+// set servo trim to a Limit
+// when ignore_reversed is true the flipping of Min/Max values, that usually is done when reversed flag ist set, is not applied
+void SRV_Channels::set_trim_to_limit_for(SRV_Channel::Aux_servo_function_t function, SRV_Channel::Limit limit, bool ignore_reversed)
 {
-    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
-            channels[i].servo_trim.set(channels[i].servo_min);
+            if (ignore_reversed) {
+                switch (limit) {
+                case SRV_Channel::Limit::TRIM:
+                    channels[i].servo_trim.set(channels[i].get_limit_pwm(limit));
+                    break;
+                case SRV_Channel::Limit::MIN:
+                    channels[i].servo_trim.set(channels[i].servo_min);
+                    break;
+                case SRV_Channel::Limit::MAX:
+                    channels[i].servo_trim.set(channels[i].servo_max);
+                    break;
+                case SRV_Channel::Limit::ZERO_PWM:
+                    channels[i].servo_trim.set(channels[i].get_limit_pwm(limit));
+                    break;
+                }
+            }
+            else {
+                channels[i].servo_trim.set(channels[i].get_limit_pwm(limit));
+            }
         }
     }
 }


### PR DESCRIPTION
See bug report #13269

ESCs of type PWM_TYPE_BRUSHED_WITH_RELAY need to set trim to min to set duty cycle range (0 - 100%) to servo range.
The existing function "set_trim_to_min_for" does set trim to max instead when the reversed flag is set, but for ESCs of type PWM_TYPE_BRUSHED_WITH_RELAY only the relay output should be inverted when reversed is set and not the PWM range.
Setting trim to max for PWM_TYPE_BRUSHED_WITH_RELAY caused the motor to run at full speed with no throttle.

Since the existing function "set_trim_to_min_for" is also used by the Ardupilot plane code I did not modify it but introduced a new function "set_trim_to_min2_for" which is used in my modification of the Ardupilot rover code now.