### PR TITLE
Copter: Arbitrary pre-arm distance

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -480,7 +480,7 @@ bool AP_Arming_Copter::proximity_checks(bool display_failure) const
     float angle_deg, distance;
     if (copter.avoid.proximity_avoidance_enabled() && copter.g2.proximity.get_closest_object(angle_deg, distance)) {
         // display error if something is within 60cm
-        if (distance <= 0.6f) {
+        if (distance <= copter.g.prearm_distance) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Proximity %d deg, %4.2fm", (int)angle_deg, (double)distance);
             return false;
         }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -605,6 +605,15 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AC_Avoidance/AC_Avoid.cpp
 #if AC_AVOID_ENABLED == ENABLED
     GOBJECT(avoid,      "AVOID_",   AC_Avoid),
+
+    // @Param: PREARM_DISTANCE
+    // @DisplayName: Pre-arm check distance
+    // @Description: Pre-arm check distance when AVOIDANCE function is enabled.
+    // @Units: m
+    // @Range: 0.1 100
+    // @Increment: 0.1
+    // @User: Advanced
+    GSCALAR(prearm_distance,     "PREARM_DISTANCE",   0.6f),
 #endif
 
 #if AC_RALLY == ENABLED

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -375,6 +375,8 @@ public:
 
         k_param_vehicle = 257, // vehicle common block of parameters
 
+        k_param_prearm_distance,
+
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -464,6 +466,8 @@ public:
     AP_Float                acro_balance_pitch;
     AP_Int8                 acro_trainer;
     AP_Float                acro_rp_expo;
+
+    AP_Float                prearm_distance;
 
     // Note: keep initializers here in the same order as they are declared
     // above.


### PR DESCRIPTION
I'm flying a multicopter of a size such as Toy Drone BUG3, F550, F890.
I want to take off from the safe area of the aircraft.
I want to change the avoidance distance when pre-arming according to the size of the aircraft.
I made it changeable.