### PR TITLE
Sub: Ignore MOT_THST_HOVER parameter

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -693,9 +693,11 @@ void Sub::load_parameters()
     AP_Param::set_default_by_name("INS_GYR_CAL", 0);
     AP_Param::set_default_by_name("MNT_DEFLT_MODE", MAV_MOUNT_MODE_RC_TARGETING);
     AP_Param::set_default_by_name("MNT_JSTICK_SPD", 100);
+    AP_Param::set_default_by_name("RNGFND1_TYPE", (uint8_t)RangeFinder::Type::MAVLink);
     AP_Param::set_by_name("MNT_RC_IN_PAN", 7);
     AP_Param::set_by_name("MNT_RC_IN_TILT", 8);
-    AP_Param::set_default_by_name("RNGFND1_TYPE", (uint8_t)RangeFinder::Type::MAVLink);
+    // We should ignore this parameter since ROVs are neutral buoyancy
+    AP_Param::set_by_name("MOT_THST_HOVER", 0.5);
 }
 
 void Sub::convert_old_parameters()

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -132,6 +132,21 @@ class AutoTestSub(AutoTest):
 
         self.disarm_vehicle()
 
+    def test_mot_thst_hover_ignore(self):
+        """Test if we are ignoring MOT_THST_HOVER parameter
+        """
+
+        # Test default parameter value
+        mot_thst_hover_value = self.get_parameter("MOT_THST_HOVER")
+        if mot_thst_hover_value != 0.5:
+            raise NotAchievedException("Unexpected default MOT_THST_HOVER parameter value {}".format(mot_thst_hover_value))
+
+        # Test if parameter is being ignored
+        for value in [0.25, 0.75]:
+            self.set_parameter("MOT_THST_HOVER", value)
+            self.test_alt_hold()
+
+
     def dive_manual(self):
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -277,6 +292,8 @@ class AutoTestSub(AutoTest):
             ("GripperMission",
              "Test gripper mission items",
              self.test_gripper_mission),
+
+            ("MotorThrustHoverParameterIgnore", "Test if we are ignoring MOT_THST_HOVER", self.test_mot_thst_hover_ignore),
 
             ("SET_POSITION_TARGET_GLOBAL_INT",
              "Move vehicle using SET_POSITION_TARGET_GLOBAL_INT",


### PR DESCRIPTION
We should ignore this parameter since ROVs are neutral buoyancy

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>