### PR TITLE
Tools: Implement better scrimmage support

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -404,25 +404,31 @@ def get_user_locations_path():
     return user_locations_path
 
 
-def find_new_spawn(loc, file_path):
-    (lat, lon, alt, heading) = loc.split(",")
+def find_offsets(instances, file_path):
+    offsets = {}
     swarminit_filepath = os.path.join(autotest_dir, "swarminit.txt")
-    for path2 in [file_path, swarminit_filepath]:
-        if os.path.isfile(path2):
-            with open(path2, 'r') as swd:
-                next(swd)
-                for lines in swd:
-                    if len(lines) == 0:
+    comment_regex = re.compile("\s*#.*")
+    for path in [file_path, swarminit_filepath]:
+        if os.path.isfile(path):
+            with open(path, 'r') as fd:
+                for line in fd:
+                    line = re.sub(comment_regex, "", line)
+                    line = line.rstrip("\n")
+                    if len(line) == 0:
                         continue
-                    (instance, offset) = lines.split("=")
-                    if ((int)(instance) == (int)(cmd_opts.instance)):
-                        (x, y, z, head) = offset.split(",")
-                        g = mavextra.gps_offset((float)(lat), (float)(lon), (float)(x), (float)(y))
-                        loc = str(g[0])+","+str(g[1])+","+str(alt+z)+","+str(head)
-                        return loc
-        g = mavextra.gps_newpos((float)(lat), (float)(lon), 90, 20*(int)(cmd_opts.instance))
-        loc = str(g[0])+","+str(g[1])+","+str(alt)+","+str(heading)
-        return loc
+                    (instance, offset) = line.split("=")
+                    instance = (int)(instance)
+                    if (instance not in offsets) and (instance in instances):
+                        offsets[instance] = [ (float)(x) for x in offset.split(",") ]
+                        continue
+                    if len(offsets) == len(instances):
+                        return offsets
+        if len(offsets) == len(instances):
+            return offsets
+    for instance in instances:
+        if instance not in offsets:
+            offsets[instance] = [90.0, 20.0 * instance, 0.0, None]
+    return offsets
 
 
 def find_location_by_name(locname):
@@ -442,12 +448,22 @@ def find_location_by_name(locname):
                     continue
                 (name, loc) = line.split("=")
                 if name == locname:
-                    if cmd_opts.swarm is not None:
-                        loc = find_new_spawn(loc, cmd_opts.swarm)
-                    return loc
+                    return [ (float)(x) for x in loc.split(",") ]
 
     print("Failed to find location (%s)" % cmd_opts.location)
     sys.exit(1)
+
+
+def find_spawns(loc, offsets):
+    lat, lon, alt, heading = loc
+    spawns = {}
+    for k in offsets:
+        (x, y, z, head) = offsets[k]
+        if head is None:
+            head = heading
+        g = mavextra.gps_offset(lat, lon, x, y)
+        spawns[k] = ",".join([str(g[0]), str(g[1]), str(alt+z), str(head)])
+    return spawns
 
 
 def progress_cmd(what, cmd):
@@ -476,7 +492,7 @@ def run_cmd_blocking(what, cmd, quiet=False, check=False, **kw):
     return ret
 
 
-def run_in_terminal_window(name, cmd):
+def run_in_terminal_window(name, cmd, **kw):
 
     """Execute the run_in_terminal_window.sh command for cmd"""
     global windowID
@@ -486,7 +502,7 @@ def run_in_terminal_window(name, cmd):
 
     if under_macos() and os.environ.get('DISPLAY'):
         # on MacOS record the window IDs so we can close them later
-        out = subprocess.Popen(runme, stdout=subprocess.PIPE).communicate()[0]
+        out = subprocess.Popen(runme, stdout=subprocess.PIPE, **kw).communicate()[0]
         out = out.decode('utf-8')
         p = re.compile('tab 1 of window id (.*)')
 
@@ -505,7 +521,7 @@ def run_in_terminal_window(name, cmd):
         else:
             progress("Cannot find %s process terminal" % name)
     else:
-        subprocess.Popen(runme)
+        subprocess.Popen(runme, **kw)
 
 
 tracker_uarta = None  # blemish
@@ -536,7 +552,7 @@ def start_antenna_tracker(opts):
     os.chdir(oldpwd)
 
 
-def start_vehicle(binary, opts, stuff, loc=None):
+def start_vehicle(binary, opts, stuff, spawns=None):
     """Run the ArduPilot binary"""
 
     cmd_name = opts.vehicle
@@ -586,9 +602,6 @@ def start_vehicle(binary, opts, stuff, loc=None):
 
     cmd.append(binary)
     cmd.append("-S")
-    cmd.append("-I" + str(opts.instance))
-    if loc is not None:
-        cmd.extend(["--home", loc])
     if opts.wipe_eeprom:
         cmd.append("-w")
     cmd.extend(["--model", stuff["model"]])
@@ -622,7 +635,14 @@ def start_vehicle(binary, opts, stuff, loc=None):
     if opts.mcast:
         cmd.extend(["--uartA mcast:"])
 
-    run_in_terminal_window(cmd_name, cmd)
+    old_dir = os.getcwd()
+    for i, i_dir in zip(instances, instance_dir):
+        c = ["-I" + str(i)]
+        if spawns is not None:
+            c.extend(["--home", spawns[i]])
+        os.chdir(i_dir)
+        run_in_terminal_window(cmd_name, cmd + c)
+    os.chdir(old_dir)
 
 
 def start_mavproxy(opts, stuff):
@@ -638,26 +658,6 @@ def start_mavproxy(opts, stuff):
         cmd.append("mavproxy.exe")
     else:
         cmd.append("mavproxy.py")
-
-    if opts.hil:
-        cmd.extend(["--load-module", "HIL"])
-    else:
-        if opts.mcast:
-            cmd.extend(["--master", "mcast:"])
-        else:
-            cmd.extend(["--master", mavlink_port])
-        if stuff["sitl-port"] and not opts.no_rcin:
-            cmd.extend(["--sitl", simout_port])
-
-    if not opts.no_extra_ports:
-        ports = [p + 10 * cmd_opts.instance for p in [14550, 14551]]
-        for port in ports:
-            if os.path.isfile("/ardupilot.vagrant"):
-                # We're running inside of a vagrant guest; forward our
-                # mavlink out to the containing host OS
-                cmd.extend(["--out", "10.0.2.2:" + str(port)])
-            else:
-                cmd.extend(["--out", "127.0.0.1:" + str(port)])
 
     if opts.tracker:
         cmd.extend(["--load-module", "tracker"])
@@ -739,8 +739,36 @@ def start_mavproxy(opts, stuff):
     if old is not None:
         env['PYTHONPATH'] += os.path.pathsep + old
 
-    run_cmd_blocking("Run MavProxy", cmd, env=env)
-    progress("MAVProxy exited")
+    old_dir = os.getcwd()
+    for i, i_dir in zip(instances, instance_dir):
+        c = []
+
+        if not opts.no_extra_ports:
+            ports = [p + 10 * i for p in [14550, 14551]]
+            for port in ports:
+                if os.path.isfile("/ardupilot.vagrant"):
+                    # We're running inside of a vagrant guest; forward our
+                    # mavlink out to the containing host OS
+                    c.extend(["--out", "10.0.2.2:" + str(port)])
+                else:
+                    c.extend(["--out", "127.0.0.1:" + str(port)])
+
+        if opts.hil:
+            c.extend(["--load-module", "HIL"])
+        else:
+            if opts.mcast:
+                c.extend(["--master", "mcast:"])
+            else:
+                c.extend(["--master", "tcp:127.0.0.1:" + str(5760 + 10 * i)])
+            if stuff["sitl-port"] and not opts.no_rcin:
+                c.extend(["--sitl", "127.0.0.1:" + str(5501 + 10 * i)])
+
+        os.chdir(i_dir)
+        if i == instances[-1]:
+            run_cmd_blocking("Run MavProxy", cmd + c, env=env)
+        else:
+            run_in_terminal_window("Run MavProxy", cmd + c, env=env)
+    os.chdir(old_dir)
 
 
 vehicle_options_string = '|'.join(vinfo.options.keys())
@@ -838,6 +866,14 @@ group_sim.add_option("-I", "--instance",
                      default=0,
                      type='int',
                      help="instance of simulator")
+group_sim.add_option("-n", "--count",
+                     type='int',
+                     default=1,
+                     help="vehicle count; if this is specified, -I is used as a base-value")
+group_sim.add_option("-i", "--instances",
+                     default=None,
+                     type='string',
+                     help="a space delimited list of instances to spawn; if specified, overrides -I and -n.")
 group_sim.add_option("-V", "--valgrind",
                      action='store_true',
                      default=False,
@@ -1042,6 +1078,14 @@ if (cmd_opts.gdb or cmd_opts.gdb_stopped) and (cmd_opts.lldb or cmd_opts.lldb_st
     print("May not use lldb with gdb")
     sys.exit(1)
 
+if cmd_opts.instance < 0:
+    print("May not specify a negative instance ID")
+    sys.exit(1)
+
+if cmd_opts.count < 1:
+    print("May not specify a count less than 1")
+    sys.exit(1)
+
 if cmd_opts.strace and cmd_opts.valgrind:
     print("valgrind and strace almost certainly not a good idea")
 
@@ -1088,10 +1132,6 @@ You could also try changing directory to e.g. the ArduCopter subdirectory
 if cmd_opts.frame is None:
     cmd_opts.frame = vinfo.options[cmd_opts.vehicle]["default_frame"]
 
-# setup ports for this instance
-mavlink_port = "tcp:127.0.0.1:" + str(5760 + 10 * cmd_opts.instance)
-simout_port = "127.0.0.1:" + str(5501 + 10 * cmd_opts.instance)
-
 frame_infos = vinfo.options_for_frame(cmd_opts.frame,
                                       cmd_opts.vehicle,
                                       cmd_opts)
@@ -1101,6 +1141,18 @@ if not os.path.exists(vehicle_dir):
     print("vehicle directory (%s) does not exist" % (vehicle_dir,))
     sys.exit(1)
 
+if cmd_opts.instances is not None:
+    instances = set()
+    for i in cmd_opts.instances.split(' '):
+        i = (int)(i)
+        if i < 0:
+            print("May not specify a negative instance ID")
+            sys.exit(1)
+        instances.add(i)
+    instances = sorted(instances) # to list
+else:
+    instances = range(cmd_opts.instance, cmd_opts.instance + cmd_opts.count)
+
 if not cmd_opts.hil:
     if cmd_opts.instance == 0:
         kill_tasks()
@@ -1109,7 +1161,7 @@ if cmd_opts.tracker:
     start_antenna_tracker(cmd_opts)
 
 if cmd_opts.custom_location:
-    location = cmd_opts.custom_location
+    location = [ (float)(x) for x in cmd_opts.custom_location.split(",") ]
     progress("Starting up at %s" % (location,))
 elif cmd_opts.location is not None:
     location = find_location_by_name(cmd_opts.location)
@@ -1117,15 +1169,38 @@ elif cmd_opts.location is not None:
 else:
     progress("Starting up at SITL location")
     location = None
+if cmd_opts.swarm is not None:
+    offsets = find_offsets(instances, cmd_opts.swarm)
+else:
+    offsets = { x: [0.0, 0.0, 0.0, None] for x in instances }
+if location is not None:
+    spawns = find_spawns(location, offsets)
+else:
+    spawns = None
 
 if cmd_opts.use_dir is not None:
-    new_dir = cmd_opts.use_dir
+    base_dir = os.path.realpath(cmd_opts.use_dir)
     try:
-        os.makedirs(os.path.realpath(new_dir))
+        os.makedirs(base_dir)
     except OSError as exception:
         if exception.errno != errno.EEXIST:
             raise
-    os.chdir(new_dir)
+    os.chdir(base_dir)
+else:
+    base_dir = os.getcwd()
+instance_dir = []
+if len(instances) == 1:
+    instance_dir.append(base_dir)
+else:
+    for i in instances:
+        i_dir = os.path.join(base_dir, str(i))
+        try:
+            os.makedirs(i_dir)
+        except OSError as exception:
+            if exception.errno != errno.EEXIST:
+                raise
+        finally:
+            instance_dir.append(i_dir)
 
 if cmd_opts.hil:
     # (unlikely)
@@ -1134,10 +1209,12 @@ if cmd_opts.hil:
                      "jsb_sim/runsim.py"),
         "--speedup=" + str(cmd_opts.speedup)
     ]
-    if location is not None:
-        jsbsim_opts.extend(["--home", location])
+    for i in instances:
+        c = []
+        if spawns is not None:
+            c = ["--home", spawns[i]]
+        run_in_terminal_window("JSBSim", jsbsim_opts + c)
 
-    run_in_terminal_window("JSBSim", jsbsim_opts)
 else:
     if not cmd_opts.no_rebuild:  # i.e. we should rebuild
         do_build(vehicle_dir, cmd_opts, frame_infos)
@@ -1160,7 +1237,7 @@ else:
     start_vehicle(vehicle_binary,
                   cmd_opts,
                   frame_infos,
-                  loc=location)
+                  spawns=spawns)
 
 if cmd_opts.delay_start:
     progress("Sleeping for %f seconds" % (cmd_opts.delay_start,))

--- a/Tools/autotest/template/scrimmage.xml
+++ b/Tools/autotest/template/scrimmage.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="Straight flying">
+
+  <!--  <run start="0.0" end="100" dt="0.00833333" -->
+  <run start="0.0" end="10000000" dt="0.001"
+       {% if plane %}
+       motion_multiplier="1"
+       {% endif %}
+       time_warp="1"
+       enable_gui="true"
+       network_gui="false"
+       start_paused="false"/>
+
+  <stream_port>50051</stream_port>
+  <stream_ip>localhost</stream_ip>
+
+  <end_condition>all_dead</end_condition> <!-- time, one_team, none-->
+
+  <grid_spacing>10</grid_spacing>
+  <grid_size>1000</grid_size>
+
+  <terrain>{% if terrain %}{{ terrain }}{% else %}mcmillan{% endif %}</terrain>
+  <background_color>191 191 191</background_color> <!-- Red Green Blue -->
+  <gui_update_period>10</gui_update_period> <!-- milliseconds -->
+
+  <plot_tracks>false</plot_tracks>
+  <output_type>all</output_type>
+  <show_plugins>false</show_plugins>
+
+  <metrics>SimpleCollisionMetrics</metrics>
+
+  <log_dir>~/.scrimmage/logs</log_dir>
+
+  {% if plane %}
+  <latitude_origin>{% if lat %}{{ lat }}{% else %}32.42553{% endif %}</latitude_origin>
+  <longitude_origin>{% if lon %}{{ lon }}{% else %}-84.79109{% endif %}</longitude_origin>
+  <altitude_origin>{% if alt %}{{ alt }}{% else %}75{% endif %}</altitude_origin>
+  {% else %}
+  <latitude_origin>{% if lat %}{{ lat }}{% else %}34.458281{% endif %}</latitude_origin>
+  <longitude_origin>{% if lon %}{{ lon }}{% else %}-84.180209{% endif %}</longitude_origin>
+  <altitude_origin>{% if alt %}{{ alt }}{% else %}450{% endif %}</altitude_origin>
+  {% endif %}
+
+  <show_origin>true</show_origin>
+  <origin_length>10</origin_length>
+
+  <network>LocalNetwork</network>
+  <network>GlobalNetwork</network>
+
+  <entity_interaction>SimpleCollision</entity_interaction>
+  <entity_interaction enable_startup_collisions="false"
+                      remove_on_collision="false">GroundCollision</entity_interaction>
+
+  <!-- uncomment "seed" and use integer for deterministic results -->
+  <!--<seed>2147483648</seed>-->
+
+  <!-- ========================== TEAM 1 ========================= -->
+  {% for e in entities %}
+  <entity>
+    <team_id>1</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <x>{% if e.x %}{{ e.x }}{% else %}0{% endif %}</x>
+    <y>{% if e.y %}{{ e.y }}{% else %}0{% endif %}</y>
+    <z>{% if e.z %}{{ e.z }}{% else %}0{% endif %}</z>
+    {% if plane %}<pitch>-20</pitch>{% endif %}
+    <heading>{% if e.heading %}{{ e.heading }}{% else %}0{% endif %}</heading>
+
+
+    <sensor>RigidBody6DOFStateSensor</sensor>
+    <controller>DirectController</controller>
+
+    <!-- Use this settings in SITL -->
+    <autonomy to_ardupilot_port="{% if e.to_ardupilot_port %}{{ e.to_ardupilot_port }}{% else %}9003{% endif %}"
+              from_ardupilot_port="{% if e.from_ardupilot_port %}{{ e.from_ardupilot_port }}{% else %}9002{% endif %}"
+              to_ardupilot_ip="{% if e.to_ardupilot_ip %}{{ e.to_ardupilot_ip }}{% else %}127.0.0.1{% endif %}"
+    {% if plane %}
+        >ArduPilot</autonomy>
+    <!-- Use this settings in HIL through mavproxy -->
+    <!-- <autonomy to_ardupilot_port="5501" from_ardupilot_port="5502" mavproxy_mode="true">ArduPilot</autonomy> -->
+    <!-- <motion_model drawVel="0" drawAngVel="0" drawAcc="0" use_launcher="1" launch_time="60" launch_accel="200">${motion_model=JSBSimControl}</motion_model> -->
+    <motion_model drawVel="0" drawAngVel="0" drawAcc="0">{% if e.motion_model %}{{ e.motion_model }}{% else %}JSBSimControl{% endif %}</motion_model>
+    <script_name>rascal_no_autopilot.xml</script_name>
+    <visual_model>{% if e.visual_model %}{{ e.visual_model }}{% else %}zephyr-blue{% endif %}</visual_model>
+    {% else %}
+    servo_map="[ motor_0 0 1000 +2000    346.41 1200.0 +1 ]
+               [ motor_1 1 1000 +2000    346.41 1200.0 +1 ]
+               [ motor_2 2 1000 +2000    346.41 1200.0 +1 ]
+               [ motor_3 3 1000 +2000    346.41 1200.0 +1 ]"
+        >ArduPilot</autonomy>
+    <motion_model write_csv="true">{% if e.motion_model %}{{ e.motion_model }}{% else %}Multirotor{% endif %}</motion_model>
+    <visual_model>{% if e.visual_model %}{{ e.visual_model }}{% else %}iris{% endif %}</visual_model>
+    {% endif %}
+  </entity>
+  {% endfor %}
+</runscript>

--- a/libraries/SITL/SIM_Scrimmage.cpp
+++ b/libraries/SITL/SIM_Scrimmage.cpp
@@ -36,44 +36,6 @@ Scrimmage::Scrimmage(const char *_frame_str) :
     send_sock(true),
     frame_str(_frame_str)
 {
-    // Set defaults for scrimmage-copter
-    if (strcmp(frame_str, "scrimmage-copter")== 0) {
-        mission_name = "arducopter.xml";
-        motion_model = "Multirotor";
-        visual_model = "iris";
-    }
-}
-
-void Scrimmage::set_config(const char *config)
-{
-    // The configuration string is a comma-separated sequence of key:value
-    // pairs
-
-    // Iterate over comma-separated strings and store parameters
-    char *end_str;
-    char* copy_config = strdup(config);
-    char *token = strtok_r(copy_config, ",", &end_str);
-    while (token != NULL)
-    {
-        char *end_token;
-        char *token2 = strtok_r(token, "=", &end_token);
-        if (strcmp(token2, "mission")==0) {
-            mission_name = strtok_r(NULL, "=", &end_token);
-        } else if (strcmp(token2, "motion_model")==0) {
-            motion_model = strtok_r(NULL, "=", &end_token);
-        } else if (strcmp(token2, "visual_model")==0) {
-            visual_model = strtok_r(NULL, "=", &end_token);
-        } else if (strcmp(token2, "terrain")==0) {
-            terrain = strtok_r(NULL, "=", &end_token);
-        } else {
-            printf("Invalid scrimmage param: %s", token2);
-        }
-        token = strtok_r(NULL, ",", &end_str);
-    }
-    free(copy_config);
-
-    // start scrimmage after parsing simulation configuration
-    start_scrimmage();
 }
 
 void Scrimmage::set_interface_ports(const char* address, const int port_in, const int port_out)
@@ -91,43 +53,6 @@ void Scrimmage::set_interface_ports(const char* address, const int port_in, cons
 
     send_sock.reuseaddress();
     send_sock.set_blocking(false);
-}
-
-// Start Scrimmage child
-void Scrimmage::start_scrimmage(void)
-{
-    pid_t child_pid = fork();
-    if (child_pid == 0) {
-        // In child
-
-        // Construct the scrimmage command string with overrides for initial
-        // position and heading.
-        char* full_exec_str;
-        int len;
-        // Get required string length
-        len = snprintf(NULL, 0, "xterm +hold -T SCRIMMAGE -e 'scrimmage %s -o \"latitude_origin=%f,"
-        "longitude_origin=%f,altitude_origin=%f,heading=%f,motion_model=%s,visual_model=%s,terrain=%s,"
-        "to_ardupilot_port=%d,from_ardupilot_port=%d,to_ardupilot_ip=%s\"'", mission_name, home.lat*1.0e-7f,home.lng*1.0e-7f,
-        home.alt*1.0e-2f, home_yaw, motion_model, visual_model, terrain, fdm_port_in, fdm_port_out, fdm_address);
-
-        full_exec_str = (char *)malloc(len+1);
-        snprintf(full_exec_str, len+1, "xterm +hold -T SCRIMMAGE -e 'scrimmage %s -o \"latitude_origin=%f,"
-        "longitude_origin=%f,altitude_origin=%f,heading=%f,motion_model=%s,visual_model=%s,terrain=%s,"
-        "to_ardupilot_port=%d,from_ardupilot_port=%d,to_ardupilot_ip=%s\"'", mission_name, home.lat*1.0e-7f,home.lng*1.0e-7f,
-        home.alt*1.0e-2f, home_yaw, motion_model, visual_model, terrain, fdm_port_in, fdm_port_out, fdm_address);
-
-        printf("%s\n", full_exec_str);
-
-        // system call worked
-        int ret = system(full_exec_str);
-
-        if (ret != 0) {
-            ::fprintf(stderr, "scrimmage didn't open.\n");
-            perror("scrimmage");
-        }
-
-        free(full_exec_str);
-    }
 }
 
 void Scrimmage::send_servos(const struct sitl_input &input)

--- a/libraries/SITL/SIM_Scrimmage.h
+++ b/libraries/SITL/SIM_Scrimmage.h
@@ -41,8 +41,6 @@ public:
         return new Scrimmage(frame_str);
     }
 
-    void set_config(const char *config) override;
-
     /*  Create and set in/out socket for extenal simulator */
     void set_interface_ports(const char* address, const int port_in, const int port_out) override;
 
@@ -76,19 +74,12 @@ private:
 
     void recv_fdm(const struct sitl_input &input);
     void send_servos(const struct sitl_input &input);
-    void start_scrimmage(void);
 
     uint64_t prev_timestamp_us;
     SocketAPM recv_sock;
     SocketAPM send_sock;
 
     const char *frame_str;
-
-    // Use ArduPlane by default
-    const char *mission_name = "arduplane.xml";
-    const char *motion_model = "JSBSimControl";
-    const char *visual_model = "zephyr-blue";
-    const char *terrain = "mcmillan";
 };
 
 } // namespace SITL


### PR DESCRIPTION
This change provides better scrimmage support by allowing a single scrimmage process to connect to multiple ArduPilot processes.

- sim_vehicle.py can now spawn multiple vehicles at once (prior behavior
  is maintained if the user decides not to use this feature)
- Users can specify multiple instances to spawn through either the -n or -i
  flags. Each instance executes in its own directory (<use_dir>/<instance_id>)
- The responsibility of spawning scrimmage has now been delegated to
  sim_vehicle.py instead of libraries/SITL/SIM_Scrimmage.cpp
- The mission.xml file which scrimmage expects is generated from a template,
  wherein each ardupilot instance corresponds to a scrimmage entity.
- All together, this allows for a single scrimmage simulator to connect to
  multiple instances of ardupilot, which in turn allows multiple ardupilot
  entities to interact with one another in scrimmage. Prior to this change,
  each ardupilot process was connected to its own scrimmage process.
- Misc. changes:
  * find_location_by_name() and find_new_spawn() have been rewritten such that a
    base location and coordinate offsets (specified by swarminit.txt) are
    maintained separately. This is necessary because scrimmage expects these
    values separately ({latitude,longitude,altitude}_origin vs {x,y,z})
  * find_autotest_dir() and find_root_dir() are now calculated only once. Issues
    were encountered when calling find_autotest_dir() after calling os.chdir()

Also, this change addresses some of the concerns presented in: https://github.com/ArduPilot/ardupilot/pull/11887