### PR TITLE
GCS_MAVLink/AP_HAL: banner to display RCOutput modes

### DIFF
--- a/libraries/AP_HAL/RCOutput.cpp
+++ b/libraries/AP_HAL/RCOutput.cpp
@@ -1,0 +1,52 @@
+#include "AP_HAL.h"
+
+extern const AP_HAL::HAL &hal;
+
+// helper function for implementation of get_output_mode_banner
+const char* AP_HAL::RCOutput::get_output_mode_string(enum output_mode out_mode) const
+{
+    // convert mode to string
+    switch (out_mode) {
+    case MODE_PWM_NONE:
+        return "None";
+    case MODE_PWM_NORMAL:
+        return "PWM";
+    case MODE_PWM_ONESHOT:
+        return "OneS";
+    case MODE_PWM_ONESHOT125:
+        return "OS125";
+    case MODE_PWM_BRUSHED:
+        return "Brush";
+    case MODE_PWM_DSHOT150:
+        return "DS150";
+    case MODE_PWM_DSHOT300:
+        return "DS300";
+    case MODE_PWM_DSHOT600:
+        return "DS600";
+    case MODE_PWM_DSHOT1200:
+        return "DS1200";
+    case MODE_NEOPIXEL:
+        return "NeoP";
+    }
+
+    // we should never reach here but just in case
+    return "Unknown";
+}
+
+// convert output mode to string.  helper function for implementation of get_output_mode_banner
+void AP_HAL::RCOutput::append_to_banner(char banner_msg[], uint8_t banner_msg_len, output_mode out_mode, uint8_t low_ch, uint8_t high_ch) const
+{
+    const char* mode_str = get_output_mode_string(out_mode);
+
+    // make copy of banner_msg
+    char banner_msg_temp[banner_msg_len];
+    memcpy(banner_msg_temp, banner_msg, banner_msg_len);
+
+    if (low_ch == high_ch) {
+        // handle single channel case
+        hal.util->snprintf(banner_msg, banner_msg_len, "%s %s:%u", banner_msg_temp, mode_str, (unsigned)low_ch);
+    } else {
+        // the general case
+        hal.util->snprintf(banner_msg, banner_msg_len, "%s %s:%u-%u", banner_msg_temp, mode_str, (unsigned)low_ch, (unsigned)high_ch);
+    }
+}

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -183,6 +183,11 @@ public:
     virtual void    set_output_mode(uint16_t mask, enum output_mode mode) {}
 
     /*
+     * get output mode banner to inform user of how outputs are configured
+     */
+    virtual bool get_output_mode_banner(char banner_msg[], uint8_t banner_msg_len) const { return false; }
+
+    /*
       set default update rate
      */
     virtual void    set_default_rate(uint16_t rate_hz) {}
@@ -209,4 +214,10 @@ public:
       trigger send of neopixel data
      */
     virtual void neopixel_send(void) {}
+
+protected:
+
+    // helper functions for implementation of get_output_mode_banner
+    void append_to_banner(char banner_msg[], uint8_t banner_msg_len, output_mode out_mode, uint8_t low_ch, uint8_t high_ch) const;
+    const char* get_output_mode_string(enum output_mode out_mode) const;
 };

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -49,6 +49,7 @@ public:
         return true;
     }
     void set_output_mode(uint16_t mask, enum output_mode mode) override;
+    bool get_output_mode_banner(char banner_msg[], uint8_t banner_msg_len) const override;
 
     float scale_esc_to_unity(uint16_t pwm) override {
         return 2.0 * ((float) pwm - _esc_pwm_min) / (_esc_pwm_max - _esc_pwm_min) - 1.0;
@@ -294,8 +295,8 @@ private:
     // widest pulse for oneshot triggering
     uint16_t trigger_widest_pulse;
 
-    // are we using oneshot125 for the iomcu?
-    bool iomcu_oneshot125;
+    // iomcu output mode (pwm, oneshot or oneshot125)
+    enum output_mode iomcu_mode = MODE_PWM_NORMAL;
 
     // find a channel group given a channel number
     struct pwm_group *find_chan(uint8_t chan, uint8_t &group_idx);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3372,6 +3372,12 @@ void GCS_MAVLINK::send_banner()
     if (hal.util->get_system_id(sysid)) {
         send_text(MAV_SEVERITY_INFO, "%s", sysid);
     }
+
+    // send RC output mode info if available
+    char banner_msg[50];
+    if (hal.rcout->get_output_mode_banner(banner_msg, sizeof(banner_msg))) {
+        send_text(MAV_SEVERITY_INFO, "%s", banner_msg);
+    }
 }
 
 


### PR DESCRIPTION
This PR attempts to help users determine if they've setup the servo outputs correctly by displaying a banner (aka a send_text that appears during the parameter download) of the form, "RCOut: OneS:1-4 PWM:5-6".

![image](https://user-images.githubusercontent.com/1498098/73319467-d0d32600-427f-11ea-9acd-dc56123f082c.png)

This comes from this discussion in which some users were struggling to setup oneshot and/or dshot: https://discuss.ardupilot.org/t/oneshot125-42-blhelis/51462

This has been tested on a pixracer and a CubeBlack