### PR TITLE
AC_AutoTune: fix restoring of original gains

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -907,7 +907,6 @@ void AC_AutoTune::backup_gains_and_initialise()
     // no axes are complete
     axes_completed = 0;
 
-    current_gain_type = GAIN_ORIGINAL;
     positive_direction = false;
     step = WAITING_FOR_LEVEL;
     step_start_time_ms = AP_HAL::millis();
@@ -1104,9 +1103,6 @@ void AC_AutoTune::load_twitch_gains()
  */
 void AC_AutoTune::load_gains(enum GainType gain_type)
 {
-    if (current_gain_type == gain_type) {
-        return;
-    }
     switch (gain_type) {
     case GAIN_ORIGINAL:
         load_orig_gains();

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -156,7 +156,6 @@ private:
         GAIN_INTRA_TEST = 2,
         GAIN_TUNED      = 3,
     };
-    enum GainType current_gain_type;
     void load_gains(enum GainType gain_type);
 
     TuneMode mode                : 2;    // see TuneMode for what modes are allowed


### PR DESCRIPTION
This PR fixes a bug that likely contributed to two crashes reported in the Copter-4.0 discuss category [here](https://discuss.ardupilot.org/t/copter-4-0-1-released/51505/35) and [here](https://discuss.ardupilot.org/t/incomplete-autotune-copter-4-0/51544).  Thanks to @lthall for finding this!

The issue is that if the AutoTune was interrupted (for example the user switched back out of the AutoTune flight mode to Loiter, RTL, etc) the original gains were not restored so the vehicle continued to use the "Intra Test" gains.  These gains are very similar to the original gains except the I-term is 10x less.  This could lead to the vehicle being unable to maintain it's attitude properly and in very bad cases could lead to the crash-check triggering (Note: the crash check triggers when the vehicle's attitude is off from the desired for more than 2 seconds).

The bug was that the current_gain_type variable was not being set when load_gains was called meaning subsequent calls to load_gains would fail if gain_type was GAIN_ORIGINAL.

This fix has been tested in SITL using this procedure:

- armed vehicle and took off in Loiter mode
- switched to AutoTune mode for a few seconds
- switch vehicle back to Loiter mode and observed the debug code that was added to show which set of gains have been loaded

Before we see the last set of gains loaded were the "IntraTest Gains".  After this PR is applied we see the "Original Gains" are used.  Note that this is debug output added for testing.
- with some additional debug added to displasy which set of gains are being used. 

![autotune-pr-fix](https://user-images.githubusercontent.com/1498098/73415333-dc445100-4354-11ea-8b66-43fe18846ac8.png)
