### PR TITLE
Save 7k of flash on boards that are low on flash

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/hwdef.dat
@@ -167,3 +167,6 @@ define HAL_BATTMON_FUEL_ENABLE 0
 # disable parachute and sprayer to save flash
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
+
+# reduce max size of embedded params for apj_tool.py
+define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
@@ -193,3 +193,6 @@ define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
 define HAL_NAVEKF2_AVAILABLE 0
+
+# reduce max size of embedded params for apj_tool.py
+define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
@@ -181,3 +181,6 @@ define HAL_BATTMON_FUEL_ENABLE 0
 # disable parachute and sprayer to save flash
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
+
+# reduce max size of embedded params for apj_tool.py
+define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
@@ -155,3 +155,6 @@ define HAL_BATTMON_FUEL_ENABLE 0
 # disable parachute and sprayer to save flash
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
+
+# reduce max size of embedded params for apj_tool.py
+define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -39,7 +39,11 @@
   maximum size of embedded parameter file
  */
 #ifndef AP_PARAM_MAX_EMBEDDED_PARAM
-#define AP_PARAM_MAX_EMBEDDED_PARAM 8192
+#if HAL_MINIMIZE_FEATURES
+# define AP_PARAM_MAX_EMBEDDED_PARAM 1024
+#else
+# define AP_PARAM_MAX_EMBEDDED_PARAM 8192
+#endif
 #endif
 
 /*


### PR DESCRIPTION
This reduces the size of the parameter area available for apj_tool.py
