### PR TITLE
AP_RangeFindar: Set default address in driver class

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -389,7 +389,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::BenewakeTFminiPlus:
         FOREACH_I2C(i) {
             if (_add_backend(AP_RangeFinder_Benewake_TFMiniPlus::detect(state[instance], params[instance],
-                                                                        hal.i2c_mgr->get_device(i, params[instance].address)))) {
+                                                                        hal.i2c_mgr->get_device(i, params[instance].address==-1?0x10:params[instance].address)))) {
                 break;
             }
         }


### PR DESCRIPTION
I read the following WIKI PR comment.
I have worked on I2C default addresses in the past.

I specify the default address of TFminiPlus in the driver class.
I know that I2C addresses are defined from 0 to 127.
I have default address set when -1 is specified.

https://github.com/ArduPilot/ardupilot_wiki/pull/2487