### PR TITLE
AP_ADSB: Add Health Checks

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -808,6 +808,31 @@ void AP_ADSB::handle_transceiver_report(const mavlink_channel_t chan, const mavl
     out_state.chan_last_ms = AP_HAL::millis();
     out_state.chan = chan;
     out_state.status = (UAVIONIX_ADSB_RF_HEALTH)packet.rfHealth;
+
+    gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Health Status %d", out_state.status);
+
+    // record the health status for checksS
+    switch(out_state.status) {
+        case UAVIONIX_ADSB_RF_HEALTH_OK:
+            _adsb_healthy = true;
+            gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Health OK");
+            break;
+        case UAVIONIX_ADSB_RF_HEALTH_INITIALIZING:
+            gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Health Initializing");
+            _adsb_healthy = false;
+            break;
+        case UAVIONIX_ADSB_RF_HEALTH_FAIL_TX:
+            gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Health TX Fail");
+            _adsb_healthy = false;
+            break;
+        case UAVIONIX_ADSB_RF_HEALTH_FAIL_RX:
+            gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Health RX Fail");
+            _adsb_healthy = false;
+            break;
+        default:
+            gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Health Unknown");
+            _adsb_healthy = false;
+    }
 }
 
 /*

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -94,6 +94,10 @@ public:
         return _singleton;
     }
 
+    bool get_adsb_health(void) {
+         return _adsb_healthy;
+     }
+
 private:
     static AP_ADSB *_singleton;
 
@@ -140,6 +144,7 @@ private:
 
     Location  _my_loc;
 
+    bool _adsb_healthy = false;
 
     // ADSB-IN state. Maintains list of external vehicles
     struct {

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -34,6 +34,7 @@ public:
         ARMING_CHECK_MISSION     = (1U << 14),
         ARMING_CHECK_RANGEFINDER = (1U << 15),
         ARMING_CHECK_CAMERA      = (1U << 16),
+        ARMING_CHECK_ADSB        = (1U << 17),
     };
 
     enum class Method {
@@ -135,6 +136,7 @@ protected:
 
     bool servo_checks(bool report) const;
     bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4]) const;
+    bool adsb_checks(bool display_failure);
 
     // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced
     virtual bool mandatory_checks(bool report) { return true; }


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/issues/4633

Attempting to do something with the UAVIONIX health status message. According to the documentation, we should be getting `UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT` every 10 seconds.  This is in the documentation for the PingRX and mavlink.  I've enabled mavlink 2, since this is a mavlink 2 message.  Still nothing.  Tested on my Solo and a cube ADS-B Carrier.

So best I can think of for now is to call them on Monday and ask what's up.  If I were to guess, I would guess that the ADS-B in only units like the PingRX don't send anything but received vehicles.  In which case, we cannot do any health checks.