### PR TITLE
Copter: correct current_loc.alt to be above home instead of above ekf origin

### DIFF
--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -17,12 +17,11 @@ void Copter::read_inertia()
         return;
     }
 
-    if (ahrs.home_is_set()) {
-        current_loc.set_alt_cm(inertial_nav.get_altitude(),
-                               Location::AltFrame::ABOVE_HOME);
-    } else {
-        // without home use alt above the EKF origin
-        current_loc.set_alt_cm(inertial_nav.get_altitude(),
-                               Location::AltFrame::ABOVE_ORIGIN);
+    // current_loc.alt is alt-above-home, converted from inertial nav's alt-above-ekf-origin
+    const int32_t alt_above_origin_cm = inertial_nav.get_altitude();
+    current_loc.set_alt_cm(alt_above_origin_cm, Location::AltFrame::ABOVE_ORIGIN);
+    if (!current_loc.change_alt_frame(Location::AltFrame::ABOVE_HOME)) {
+        // if home has not been set yet we treat alt-above-origin as alt-above-home
+        current_loc.set_alt_cm(alt_above_origin_cm, Location::AltFrame::ABOVE_HOME);
     }
 }


### PR DESCRIPTION
This fixes this issue https://github.com/ArduPilot/ardupilot/issues/13441 which was caused by Copter's current_loc.alt being an altitude above EKF origin instead of an altitude above home.  The issue becomes especially obvious when we force the EKF origin and Home altitude to be different by changing the GND_ALT_OFFSET parameter before arming the vehicle.

Below are screen shots of the vehicle's altitude and we can see in the 2nd image (After) that the vehicle does not decend after being switched to RTL.

![rtl-alt-bug-before](https://user-images.githubusercontent.com/1498098/73589373-e7e07500-4518-11ea-8b7c-35d8c0137e93.png)

![rtl-alt-bug-after](https://user-images.githubusercontent.com/1498098/73589374-eadb6580-4518-11ea-9188-179d962e5113.png)

This fix should be fine but we need to carefully review everywhere else we use current_loc.alt before merging.