### PR TITLE
AP_RangeFinder: Multiple I2C VL53L1X can be used with a multiplexer

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -380,6 +380,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
                 }
                 if (_add_backend(AP_RangeFinder_VL53L1X::detect(state[instance], params[instance],
                                                                 hal.i2c_mgr->get_device(i, params[instance].address),
+                                                                hal.i2c_mgr->get_device(i, params[instance].multiplexer_unit!=-1?0x70:-1),
                                                                 _type == Type::VL53L1X_Short ?  AP_RangeFinder_VL53L1X::DistanceMode::Short :
                                                                                                 AP_RangeFinder_VL53L1X::DistanceMode::Long))) {
                     break;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -42,6 +42,7 @@ public:
     MAV_DISTANCE_SENSOR get_mav_distance_sensor_type() const;
     RangeFinder::Status status() const;
     RangeFinder::Type type() const { return (RangeFinder::Type)params.type.get(); }
+    int8_t get_multiUnit() const { return params.multiplexer_unit; }
 
     // true if sensor is returning data
     bool has_data() const;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -129,6 +129,14 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ORIENT", 53, AP_RangeFinder_Params, orientation, ROTATION_PITCH_270),
 
+    // @Param: MULUNIT
+    // @DisplayName: Multiplexer unit number
+    // @Description: Multiplexer unit number
+    // @Range: -1 7
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("MULUNIT", 17, AP_RangeFinder_Params, multiplexer_unit, -1),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -27,4 +27,5 @@ public:
     AP_Int8  address;
     AP_Vector3f pos_offset; // position offset in body frame
     AP_Int8  orientation;
+    AP_Int8  multiplexer_unit;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
@@ -11,7 +11,7 @@ public:
     enum class DistanceMode { Short, Medium, Long, Unknown };
 
     // static detection function
-    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev, DistanceMode mode);
+    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _multiUnit, DistanceMode mode);
 
     // update state
     void update(void) override;
@@ -1242,7 +1242,7 @@ private:
     };
 
     // constructor
-    AP_RangeFinder_VL53L1X(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+    AP_RangeFinder_VL53L1X(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev, AP_HAL::OwnPtr<AP_HAL::I2CDevice> multiUnit);
 
     bool init(DistanceMode mode);
     void timer();
@@ -1253,6 +1253,7 @@ private:
     // get a reading
     bool get_reading(uint16_t &reading_cm);
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> multiUnit;
 
     // value used in measurement timing budget calculations
     // assumes PresetMode is LOWPOWER_AUTONOMOUS


### PR DESCRIPTION
I want to achieve obstacle avoidance using multiple VL53L1Xs.
I did it using a multiplexer "Qwiic MUX".
I added the designated port of the multiplexer to the range finder item.
I have added multiplexer processing to the VL53L1X.

Qwiic MUX: PCA9548A
https://learn.sparkfun.com/tutorials/qwiic-mux-hookup-guide?_ga=2.87071256.1479520225.1580447771-633117466.1568220924

![IMG-7449](https://user-images.githubusercontent.com/646194/73589968-3cd3b980-4520-11ea-926b-a3af45d56a5e.jpg)

![Screenshot from 2020-02-01 18-33-20](https://user-images.githubusercontent.com/646194/73590060-5a555300-4521-11ea-8467-5acae22270fc.png)
