### PR TITLE
Rover: add Hold and SmartRTL to FENCE_ACTION

### DIFF
--- a/APMrover2/fence.cpp
+++ b/APMrover2/fence.cpp
@@ -16,13 +16,36 @@ void Rover::fence_check()
 
     // if there is a new breach take action
     if (new_breaches) {
+    	gcs().send_text(MAV_SEVERITY_NOTICE,"Geofence triggered");
+
         // if the user wants some kind of response and motors are armed
-        if (g2.fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY) {
-            // if we are within 100m of the fence, RTL
+        if (g2.fence.get_action() != Failsafe_Action_None) {
+            // if we are within 100m of the fence, HOLD
             if (g2.fence.get_breach_distance(new_breaches) <= AC_FENCE_GIVE_UP_DISTANCE) {
-                if (!set_mode(mode_rtl, ModeReason::FENCE_BREACHED)) {
-                    set_mode(mode_hold, ModeReason::FENCE_BREACHED);
-                }
+            	switch (g2.fence.get_action()) {
+            	case Failsafe_Action_None:
+            		break;
+            	case Failsafe_Action_RTL:
+            		if (!set_mode(mode_rtl, ModeReason::FENCE_BREACHED)) {
+            			set_mode(mode_hold, ModeReason::FENCE_BREACHED);
+            		}
+            		break;
+            	case Failsafe_Action_Hold:
+            		set_mode(mode_hold, ModeReason::FENCE_BREACHED);
+            		break;
+            	case Failsafe_Action_SmartRTL:
+            		if (!set_mode(mode_smartrtl, ModeReason::FENCE_BREACHED)) {
+            			if (!set_mode(mode_rtl, ModeReason::FENCE_BREACHED)) {
+            				set_mode(mode_hold, ModeReason::FENCE_BREACHED);
+            			}
+            		}
+            		break;
+            	case Failsafe_Action_SmartRTL_Hold:
+            		if (!set_mode(mode_smartrtl, ModeReason::FENCE_BREACHED)) {
+            			set_mode(mode_hold, ModeReason::FENCE_BREACHED);
+            		}
+            		break;
+            	}
             } else {
                 // if more than 100m outside the fence just force to HOLD
                 set_mode(mode_hold, ModeReason::FENCE_BREACHED);

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -31,6 +31,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @DisplayName: Fence Action
     // @Description: What action should be taken when fence is breached
     // @Values{Copter}: 0:Report Only,1:RTL or Land,2:Always Land,3:SmartRTL or RTL or Land,4:Brake or Land
+    // @Values{Rover}: 0:Report Only,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold
     // @Values: 0:Report Only,1:RTL or Land
     // @User: Standard
     AP_GROUPINFO("ACTION",      2,  AC_Fence,   _action,        AC_FENCE_ACTION_RTL_AND_LAND),


### PR DESCRIPTION
This PR supports the following actions when geofence triggered.
FENCE_ACTION
 0: Report Only
 1: RTL
 2: Hold
 3: SmartRTL or RTL or Hold
 4: SmartRTL or Hold

I tested it in SITL only.