### PR TITLE
Copter: Match the option specification of the function with others

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -48,6 +48,7 @@
 //#define MODE_ZIGZAG_ENABLED   DISABLED            // disable zigzag mode support
 //#define OSD_ENABLED           DISABLED            // disable on-screen-display support
 //#define BUTTON_ENABLED        DISABLED            // disable button support
+#define MODE_AUTOROTATE_ENABLED DISABLED            // disable autorotate support(helicopters only ENABLED)
 
 // features below are disabled by default on all boards
 //#define CAL_ALWAYS_REBOOT                         // flight controller will reboot after compass or accelerometer calibration completes

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -380,8 +380,6 @@
         #ifndef MODE_AUTOROTATE_ENABLED
         # define MODE_AUTOROTATE_ENABLED !HAL_MINIMIZE_FEATURES
         #endif
-    #else
-        # define MODE_AUTOROTATE_ENABLED DISABLED
     #endif
 #else
     # define MODE_AUTOROTATE_ENABLED DISABLED


### PR DESCRIPTION
I match the option specification of the auto-rotate function with others.