### PR TITLE
 SITL: Morse sim support for steering/throttle rover

### DIFF
--- a/libraries/SITL/SIM_Morse.h
+++ b/libraries/SITL/SIM_Morse.h
@@ -64,15 +64,17 @@ private:
     uint16_t morse_control_port = 60001;
 
     enum {
-        OUTPUT_ROVER=1,
-        OUTPUT_QUAD=2,
-        OUTPUT_PWM=3
+        OUTPUT_ROVER_REGULAR=1,
+        OUTPUT_ROVER_SKID=2,
+        OUTPUT_QUAD=3,
+        OUTPUT_PWM=4
     } output_type;
 
     bool connect_sockets(void);
     bool parse_sensors(const char *json);
     bool sensors_receive(void);
-    void output_rover(const struct sitl_input &input);
+    void output_rover_regular(const struct sitl_input &input);
+    void output_rover_skid(const struct sitl_input &input);
     void output_quad(const struct sitl_input &input);
     void output_pwm(const struct sitl_input &input);
     void report_FPS();

--- a/libraries/SITL/examples/Morse/rover.parm
+++ b/libraries/SITL/examples/Morse/rover.parm
@@ -1,4 +1,5 @@
 
-# setup rover for skid steering
-SERVO1_FUNCTION 73
-SERVO3_FUNCTION 74
+# Setup rover for steering/throttle 
+SERVO1_FUNCTION 26
+SERVO3_FUNCTION 70
+ATC_BRAKE 1

--- a/libraries/SITL/examples/Morse/rover.py
+++ b/libraries/SITL/examples/Morse/rover.py
@@ -12,16 +12,15 @@ Then connect with ArduPilot like this:
 
   sim_vehicle.py --model morse --console --map
 
-This model assumes you will setup a skid-steering rover with left throttle on
-channel 1 and right throttle on channel 2, which means you need to set:
+This model assumes you will setup a steering/throttle rover 
 
-  SERVO1_FUNCTION 73
-  SERVO3_FUNCTION 74
+  SERVO1_FUNCTION 26
+  SERVO3_FUNCTION 70
 '''
 from morse.builder import *
 
-# use the ATRV rover
-vehicle = ATRV()
+# use the Hummer
+vehicle = Hummer()
 vehicle.properties(Object = True, Graspable = False, Label = "Vehicle")
 vehicle.translate(x=0.0, z=0.0)
 
@@ -55,12 +54,9 @@ all_sensors.add_stream('socket')
 
 vehicle.append(all_sensors)
 
-# make the vehicle controllable with speed and angular velocity
+# make the vehicle controllable with steer and force 
 # this will be available on port 60001 by default
-# an example command is:
-# {"v":2, "w":1}
-# which is 2m/s fwd, and rotating left at 1 radian/second
-motion = MotionVW()
+motion = SteerForce()
 vehicle.append(motion)
 motion.add_stream('socket')
 

--- a/libraries/SITL/examples/Morse/rover_skid.parm
+++ b/libraries/SITL/examples/Morse/rover_skid.parm
@@ -1,0 +1,4 @@
+
+# Setup rover for skid setup
+SERVO1_FUNCTION 73
+SERVO3_FUNCTION 74 

--- a/libraries/SITL/examples/Morse/rover_skid.py
+++ b/libraries/SITL/examples/Morse/rover_skid.py
@@ -1,0 +1,81 @@
+'''
+This is an example builder script that sets up a rover in Morse to
+be driven by ArduPilot.
+
+The rover has the basic set of sensors that ArduPilot needs
+
+To start the simulation use this:
+
+  morse run rover_skid.py
+
+Then connect with ArduPilot like this:
+
+  sim_vehicle.py --model morse --console --map
+
+This model assumes you will setup a skid-steering rover with left throttle on
+channel 1 and right throttle on channel 2, which means you need to set:
+
+  SERVO1_FUNCTION 73
+  SERVO3_FUNCTION 74
+'''
+from morse.builder import *
+
+# use the ATRV rover
+vehicle = ATRV()
+vehicle.properties(Object = True, Graspable = False, Label = "Vehicle")
+vehicle.translate(x=0.0, z=0.0)
+
+# add a camera
+camera = SemanticCamera(name="Camera")
+camera.translate(x=0.2, y=0.3, z=0.9)
+vehicle.append(camera)
+camera.properties(cam_far=800)
+camera.properties(Vertical_Flip=True)
+
+# we could optionally stream the video to a port
+#camera.add_stream('socket')
+
+# add sensors needed for ArduPilot operation to a vehicle
+pose = Pose()
+vehicle.append(pose)
+
+imu = IMU()
+vehicle.append(imu)
+
+gps = GPS()
+gps.alter('UTM')
+vehicle.append(gps)
+
+velocity = Velocity()
+vehicle.append(velocity)
+
+# create a compound sensor of all of the individual sensors and stream it
+all_sensors = CompoundSensor([imu, gps, velocity, pose])
+all_sensors.add_stream('socket')
+
+vehicle.append(all_sensors)
+
+# make the vehicle controllable with speed and angular velocity
+# this will be available on port 60001 by default
+# an example command is:
+# {"v":2, "w":1}
+# which is 2m/s fwd, and rotating left at 1 radian/second
+motion = MotionVW()
+vehicle.append(motion)
+motion.add_stream('socket')
+
+# this would allow us to control the vehicle with a keyboard
+# we don't enable it as it causes issues with sensor consistency
+#keyboard = Keyboard()
+#keyboard.properties(Speed=3.0)
+#vehicle.append(keyboard)
+
+# Environment
+env = Environment('land-1/trees')
+env.set_camera_location([10.0, -10.0, 10.0])
+env.set_camera_rotation([1.0470, 0, 0.7854])
+env.select_display_camera(camera)
+env.set_camera_clip(clip_end=1000)
+
+# startup at CMAC. A location is needed for the magnetometer
+env.properties(longitude = 149.165230, latitude = -35.363261, altitude = 584.0)


### PR DESCRIPTION
Adds support for steering throttle rover on morse simulator

Launch Separate Steering and Throttle simulation:
> `morse run libraries/SITL/examples/Morse/rover.py` 

> `Tools/autotest/sim_vehicle.py -v APMrover2 --model morse-rover --add-param-file=libraries/SITL/examples/Morse/rover.parm --console --map`

Launch Skid Steering simulation:
> `morse run libraries/SITL/examples/Morse/rover_skid.py` 

> `Tools/autotest/sim_vehicle.py -v APMrover2 --model morse-skid --add-param-file=libraries/SITL/examples/Morse/rover_skid.parm --console --map`


