### PR TITLE
GCS_MAVLink: don't lie about bad AHRS

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -136,10 +136,12 @@ void GCS::update_sensor_status_flags()
     const AP_InertialSensor &ins = AP::ins();
 
     control_sensors_present |= MAV_SYS_STATUS_AHRS;
-    control_sensors_enabled |= MAV_SYS_STATUS_AHRS;
-    if (!ahrs.initialised() || ahrs.healthy()) {
-        if (!ahrs.have_inertial_nav() || ins.accel_calibrated_ok_all()) {
-            control_sensors_health |= MAV_SYS_STATUS_AHRS;
+    if (ahrs.initialised()) {
+        control_sensors_enabled |= MAV_SYS_STATUS_AHRS;
+        if (ahrs.healthy()) {
+            if (!ahrs.have_inertial_nav() || ins.accel_calibrated_ok_all()) {
+                control_sensors_health |= MAV_SYS_STATUS_AHRS;
+            }
         }
     }
 


### PR DESCRIPTION
This is a logic change to how the AHRS sys status bit is set. To report healthy it must now be healthy and initialized. This makes copter and plane both report Bad AHRS on boot in MP. They are now consistent so it would allow for the GCS to suppress the message.

Previously the ahrs could be not healthy and not initialised yet report healthy.

Due to plane having DCM plane the AHRS does not become healthy exactly as it its initialized as with copter, the DCM is always healthy thus resulting in the status bit going unhealthy when switched to ekf only once the ekf is initialized does it become healthy again.

This is probability a regression for copter, but i think the logic is better and will give a chance for GCS to fix. Alternately we could lie about the AHRS in a way that would work on all vehicles. such as:

```
if (ahrs.initialised()) {
    if (ahrs.healthy() && (!ahrs.have_inertial_nav() || ins.accel_calibrated_ok_all())) {
        control_sensors_health |= MAV_SYS_STATUS_AHRS;
    }
} else {
    control_sensors_health |= MAV_SYS_STATUS_AHRS;
}
```