### PR TITLE
Copter: makes the pump on while moving to destination A or B in ZigZag mode

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -967,6 +967,16 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(arot, "AROT_", 37, ParametersG2, AC_Autorotation),
 #endif
 
+#if MODE_ZIGZAG_ENABLED == ENABLED && SPRAYER_ENABLED == ENABLED
+    // @Param: ZIGZAG_AUTO_PUMP
+    // @DisplayName: Auto pump in ZigZag
+    // @Description: Enable the auto pump in ZigZag mode. SERVOx_FUNCTION = 22 (SprayerPump) and SPRAY_ENABLE = 1 also must be set. This makes the pump on while moving to destination A or B. The pump will stop if the vehicle reaches destination or the flight mode is changed from ZigZag to other.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("ZIGZAG_AUTO_PUMP", 38, ParametersG2, zigzag_auto_pump_enabled, ZIGZAG_AUTO_PUMP_ENABLED),
+#endif
+
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -619,6 +619,11 @@ public:
     AC_Autorotation arot;
 #endif
 
+#if MODE_ZIGZAG_ENABLED == ENABLED && SPRAYER_ENABLED == ENABLED
+    // auto pump enable/disable
+    AP_Int8 zigzag_auto_pump_enabled;
+#endif
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -370,6 +370,9 @@
 #ifndef MODE_ZIGZAG_ENABLED
 # define MODE_ZIGZAG_ENABLED !HAL_MINIMIZE_FEATURES
 #endif
+#if MODE_ZIGZAG_ENABLED == ENABLED && HAL_SPRAYER_ENABLED
+# define ZIGZAG_AUTO_PUMP_ENABLED DISABLED
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -256,6 +256,13 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
         return false;
     }
 
+#if MODE_ZIGZAG_ENABLED == ENABLED && SPRAYER_ENABLED == ENABLED
+    // The pump will stop if the flight mode is changed from ZigZag to other
+    if (control_mode == Mode::Number::ZIGZAG && g2.zigzag_auto_pump_enabled) {
+        copter.sprayer.run(false);
+    }
+#endif
+
     // perform any cleanup required by previous flight mode
     exit_mode(flightmode, new_flightmode);
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -113,6 +113,12 @@ void ModeZigZag::save_or_move_to_destination(uint8_t dest_num)
                 wp_nav->wp_and_spline_init();
                 if (wp_nav->set_wp_destination(next_dest, terr_alt)) {
                     stage = AUTO;
+#if SPRAYER_ENABLED == ENABLED
+                    // spray on while moving to A or B
+                    if (g2.zigzag_auto_pump_enabled) {
+                        copter.sprayer.run(true);
+                    }
+#endif
                     reach_wp_time_ms = 0;
                     if (dest_num == 0) {
                         gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to A");
@@ -130,6 +136,12 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
 {
     if (stage == AUTO) {
         stage = MANUAL_REGAIN;
+#if SPRAYER_ENABLED == ENABLED
+        // spray off
+        if (g2.zigzag_auto_pump_enabled) {
+            copter.sprayer.run(false);
+        }
+#endif
         loiter_nav->clear_pilot_desired_acceleration();
         if (maintain_target) {
             const Vector3f& wp_dest = wp_nav->get_wp_destination();


### PR DESCRIPTION
This automatically turns on spraying in ZigZag mode.
And the pump will stop if the vehicle reaches destination or the flight mode is changed from ZigZag to other.

The features are the followings:
	1. A user can control the pump using only one aux switch (ZigZag SaveWP)
	2. The pump does not operate while manual control or recording the AB point
	3. The pump will stop if a failsafe happens (i.e. battery and radio failsafe)
	4. The pump will also stop if the pilot changes the flight mode
	5. Control the rate of flow of liquid fertilizer based on the vehicle speed (It's a crop sprayer's feature)

These must be set:
	SERVOx_FUNCTION = 22 (SprayerPump)
	SPRAY_ENABLE = 1
