### PR TITLE
AP_Rangefinder: use offset param value in pwm driver (attempt 2)

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
@@ -166,14 +166,14 @@ void AP_RangeFinder_PWM::update(void)
     }
 
     if (!get_reading(state.distance_cm)) {
-        // add offset
-        state.distance_cm += params.offset;
         // failure; consider changing our state
         if (AP_HAL::millis() - state.last_reading_ms > 200) {
             set_status(RangeFinder::Status::NoData);
         }
         return;
     }
+    // add offset
+    state.distance_cm += params.offset;
 
     // update range_valid state based on distance measured
     state.last_reading_ms = AP_HAL::millis();


### PR DESCRIPTION
This is a second attempt at resolving issue https://github.com/ArduPilot/ardupilot/issues/13252 after the previous PR https://github.com/ArduPilot/ardupilot/pull/13293 contained a bug that made it not work.

I have properly tested the fix this time and the screen shot below shows the RNGFND1_OFFSET parameter being changed from 0 to +20, back to 0, then -50 and then finally back to zero again.
![rngfnd-pwm-offset-testing](https://user-images.githubusercontent.com/1498098/73620355-d3b18a80-4674-11ea-85f6-cb615a7eed9f.png)

As a side note the direction that the offset applies appears to be reversed compared to the analog driver but this seems to be the case in Copter-3.6.12 as well ([Copter-3.6.12's pwm driver](https://github.com/ArduPilot/ardupilot/blob/Copter-3.6/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp#L120) and [analog driver](https://github.com/ArduPilot/ardupilot/blob/Copter-3.6/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp#L97)) 

I've asked mbtsteve to test this fix as well ([discussion](https://discuss.ardupilot.org/t/copter-4-0-2-rc3-available-for-beta-testing/51790/17))