### PR TITLE
AP_Vehicle: User code handler for scripting

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -889,6 +889,7 @@ private:
     void userhook_auxSwitch1(uint8_t ch_flag);
     void userhook_auxSwitch2(uint8_t ch_flag);
     void userhook_auxSwitch3(uint8_t ch_flag);
+    bool userhook_script(uint8_t i, float f) override;
 
 #if OSD_ENABLED == ENABLED
     void publish_osd_info();

--- a/ArduCopter/UserCode.cpp
+++ b/ArduCopter/UserCode.cpp
@@ -59,3 +59,8 @@ void Copter::userhook_auxSwitch3(uint8_t ch_flag)
     // put your aux switch #3 handler here (CHx_OPT = 49)
 }
 #endif
+
+bool Copter::userhook_script(uint8_t i, float f)
+{
+    return false;
+}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -148,6 +148,7 @@ singleton AP_Vehicle method set_mode boolean uint8_t 0 UINT8_MAX ModeReason::SCR
 singleton AP_Vehicle method get_mode uint8_t
 singleton AP_Vehicle method get_likely_flying boolean
 singleton AP_Vehicle method get_time_flying_ms uint32_t
+singleton AP_Vehicle method userhook_script boolean uint8_t 0 UINT8_MAX float -FLT_MAX FLT_MAX
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -159,6 +159,8 @@ public:
         }
         return AP_HAL::millis() - _last_flying_ms;
     }
+    
+    virtual bool userhook_script(uint8_t i, float f) { return false; }
 
 protected:
 


### PR DESCRIPTION
UserCode extension for developers, same as Copter have for aux switches.
Adding a direct script binding to a concrete method can be non trivial. Especially if object is not singleton or something vehicle-specific. This allows to call vehicle usercode from script.