### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 - Github repository: <https://github.com/ArduPilot/ardupilot>
 
-- Main developer wiki: <https://dev.ardupilot.org>
+- Main developer wiki: <https://ardupilot.org/dev/>
 
 - Developer discussion: <https://discuss.ardupilot.org>
 


### PR DESCRIPTION
In the README https://dev.ardupilot.org has an invalid ssl cert, but it actually redirects to https://ardupilot.org/dev/ which has a valid certificate. This patch just updates the link to point to https://ardupilot.org/dev/.