### PR TITLE
Sort based on node ID when a new airspeed node is found

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
@@ -95,11 +95,24 @@ AP_Airspeed_UAVCAN* AP_Airspeed_UAVCAN::get_uavcan_backend(AP_UAVCAN* ap_uavcan,
     }
 
     if (!detected) {
+
+        AP_UAVCAN* ap_uavcan_to_fit = ap_uavcan;
+        uint8_t node_id_to_fit = node_id; 
+
         for (uint8_t i = 0; i < AIRSPEED_MAX_SENSORS; i++) {
             if (_detected_modules[i].ap_uavcan == nullptr) {
-                _detected_modules[i].ap_uavcan = ap_uavcan;
-                _detected_modules[i].node_id = node_id;
-                break;
+                _detected_modules[i].ap_uavcan = ap_uavcan_to_fit;
+                _detected_modules[i].node_id = node_id_to_fit;
+                break
+                
+            }
+            else if (_detected_modules[i].node_id > node_id_to_fit){
+                AP_UAVCAN* temp_can = ap_uavcan_to_fit;
+                uint8_t temp_node = node_id_to_fit; 
+                ap_uavcan_to_fit = _detected_modules[i].ap_uavcan;
+                node_id_to_fit = _detected_modules[i].node_id;
+                _detected_modules[i].ap_uavcan = temp_can;
+                _detected_modules[i].node_id = temp_node;
             }
         }
     }


### PR DESCRIPTION
When using multiple can airspeed sensors, mapping between Airspeed number and physical airspeed sensors was not consistent between boots. Resolved by sorting can airspeed sensors based on node ID