### PR TITLE
Copter: avoid SITL failure when changing current_loc.alt frame

### DIFF
--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -20,7 +20,7 @@ void Copter::read_inertia()
     // current_loc.alt is alt-above-home, converted from inertial nav's alt-above-ekf-origin
     const int32_t alt_above_origin_cm = inertial_nav.get_altitude();
     current_loc.set_alt_cm(alt_above_origin_cm, Location::AltFrame::ABOVE_ORIGIN);
-    if (!current_loc.change_alt_frame(Location::AltFrame::ABOVE_HOME)) {
+    if (!ahrs.home_is_set() || !current_loc.change_alt_frame(Location::AltFrame::ABOVE_HOME)) {
         // if home has not been set yet we treat alt-above-origin as alt-above-home
         current_loc.set_alt_cm(alt_above_origin_cm, Location::AltFrame::ABOVE_HOME);
     }


### PR DESCRIPTION
This change avoids a SITL failure caused by an attempt to change current_loc.alt's frame when current_loc is 0,0,0.

This has been discussed with @peterbarker.