### PR TITLE
Experimental ICM filtering

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -493,6 +493,15 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Path: ../Filter/HarmonicNotchFilter.cpp
     AP_SUBGROUPINFO(_harmonic_notch_filter, "HNTCH_",  41, AP_InertialSensor, HarmonicNotchFilterParams),
 
+    // options for ICM IMUs
+    AP_GROUPINFO("ICM_OPTIONS", 42, AP_InertialSensor, _icm_options, 0),
+
+    // optional LPF on accels
+    AP_GROUPINFO("ACCEL_LPF", 43, AP_InertialSensor, _icm_accel_lpf_hz, 188),
+
+    // optional LPF on gyros
+    AP_GROUPINFO("GYRO_LPF", 44, AP_InertialSensor, _icm_gyro_lpf_hz, 188),
+
     /*
       NOTE: parameter indexes have gaps above. When adding new
       parameters check for conflicts carefully

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -51,6 +51,7 @@ class AP_Logger;
 class AP_InertialSensor : AP_AccelCal_Client
 {
     friend class AP_InertialSensor_Backend;
+    friend class AP_InertialSensor_Invensense;
 
 public:
     AP_InertialSensor();
@@ -452,6 +453,10 @@ private:
 #endif
     bool _new_accel_data[INS_MAX_INSTANCES];
     bool _new_gyro_data[INS_MAX_INSTANCES];
+
+    AP_Int16 _icm_options;
+    AP_Float _icm_accel_lpf_hz;
+    AP_Float _icm_gyro_lpf_hz;
 
     // optional notch filter on gyro
     NotchFilterParams _notch_filter;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -155,8 +155,8 @@ private:
         Vector3f accel;
         Vector3f gyro;
         uint8_t count;
-        LowPassFilterVector3f accel_filter{4000, 188};
-        LowPassFilterVector3f gyro_filter{8000, 188};
+        LowPassFilterVector3f accel_filter;
+        LowPassFilterVector3f gyro_filter;
     } _accum;
 };
 


### PR DESCRIPTION
This PR is not designed to be merged it introduces 3 new settings that can be played with to see if there are better ICM20689 settings that reduce sensor noise.

```INS_ACCEL_LPF = 188``` is the default fast sampling pre-filter. For more aggressive filtering this can be reduced to a lower cutoff frequency. For less agressive filtering it can be raised.
```INS_GYRO_LPF = 188``` is the same but for gyros
```INS_ICM_OPTIONS``` is a bitmask that allows the ICM low power and filtering options to be set. Bits 0-2 set DLPF_CFG, the default is 0 which sets a HW LPF of 250 at sample rate of 8k.
Bit 6 sets GYRO_CYCLE, which if set turns on low power mode
Bit 3-5 sets G_AVGCFG, which is the averaging filter configuration. 0 is no averaging, 1 is 2x, 3 is 4x averaging and so on. Can only be used if GYRO_CYCLE is set.
See http://www.invensense.com/wp-content/uploads/2017/08/ICM-20689-v2.2-002.pdf for more details