### PR TITLE
Copter: zigzag supports arming, takeoff and landing

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1396,7 +1396,7 @@ public:
 
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
-    bool allows_arming(bool from_gcs) const override { return false; }
+    bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
 
     // save current position as A (dest_num = 0) or B (dest_num = 1).  If both A and B have been saved move to the one specified


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/13471 as part of adding support for arming, taking off and landing within ZigZag mode.

![zigzag-motor-stop-fix](https://user-images.githubusercontent.com/1498098/73902055-f8596c80-48d7-11ea-96a6-fe370e176903.png)

This PR has also been tested in SITL to ensure the vehicle can be armed in ZigZag mode and that takeoffs and landings work.  Below is a pic of the pilot's input (in blue) and the vehicle's desired alt (red) and actual altitude (green)

![image](https://user-images.githubusercontent.com/1498098/73902276-9baa8180-48d8-11ea-9015-70a74b85453e.png)


