### PR TITLE
Added TECS reset to end of VTOL takeoff

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2672,6 +2672,13 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
     set_alt_target_current();
 
     plane.complete_auto_takeoff();
+
+    if (plane.control_mode == &plane.mode_auto) {
+        // we reset TECS so that the target height filter is not
+        // constrained by the climb and sink rates from the initial
+        // takeoff height.
+        plane.SpdHgt_Controller->reset();
+    }
     
     return true;
 }

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -63,6 +63,9 @@ public:
 	// set path_proportion accessor
     virtual void set_path_proportion(float path_proportion) = 0;
 
+    // reset on next loop
+    virtual void reset(void) = 0;
+
 	// add new controllers to this enum. Users can then
 	// select which controller to use by setting the
 	// SPDHGT_CONTROLLER parameter

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -911,7 +911,7 @@ void AP_TECS::_update_pitch(void)
 void AP_TECS::_initialise_states(int32_t ptchMinCO_cd, float hgt_afe)
 {
     // Initialise states and variables if DT > 1 second or in climbout
-    if (_DT > 1.0f)
+    if (_DT > 1.0f || _need_reset)
     {
         _integTHR_state      = 0.0f;
         _integSEB_state      = 0.0f;
@@ -927,6 +927,7 @@ void AP_TECS::_initialise_states(int32_t ptchMinCO_cd, float hgt_afe)
         _flags.reached_speed_takeoff = false;
         _DT                = 0.1f; // when first starting TECS, use a
         // small time constant
+        _need_reset = false;
     }
     else if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND)
     {

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -116,7 +116,12 @@ public:
     void use_synthetic_airspeed(void) {
         _use_synthetic_airspeed_once = true;
     }
-    
+
+    // reset on next loop
+    void reset(void) override {
+        _need_reset = true;
+    }
+
     // this supports the TECS_* user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -319,6 +324,9 @@ private:
     float _distance_beyond_land_wp;
 
     float _land_pitch_min = -90;
+
+    // need to reset on next loop
+    bool _need_reset;
 
     // internal variables to be logged
     struct {


### PR DESCRIPTION
This fixes an issue found by SpektreWorks where the aircraft descends after a VTOL takeoff if the TECS_CLMB_MAX is set lower than the VTOL climb rate.
By resetting TECS at the end of the takeoff the climb rate filter is reset
