### PR TITLE
Rover: disallow arming in RTL/Smart_RTL mode

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -86,7 +86,8 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
             & rover.g2.motors.pre_arm_check(report)
             & fence_checks(report)
             & oa_check(report)
-            & parameter_checks(report));
+            & parameter_checks(report)
+            & mode_checks(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
@@ -185,3 +186,13 @@ bool AP_Arming_Rover::parameter_checks(bool report)
     return true;
 }
 
+// check if arming allowed from this mode
+bool AP_Arming_Rover::mode_checks(bool report)
+{   
+    //display failure if arming in this mode is not allowed
+    if (!rover.control_mode->allows_arming()) {
+        check_failed(report, "Mode not armable");
+        return false;
+    }
+    return true;
+}

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -30,5 +30,6 @@ protected:
     // the following check functions do not call into AP_Arming
     bool oa_check(bool report);
     bool parameter_checks(bool report);
+    bool mode_checks(bool report);
 
 };

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -72,6 +72,9 @@ public:
     // returns true if vehicle can be armed or disarmed from the transmitter in this mode
     virtual bool allows_arming_from_transmitter() { return !is_autopilot_mode(); }
 
+    // returns false if vehicle cannot be armed in this mode
+    virtual bool allows_arming() const { return true; }
+
     bool allows_stick_mixing() const { return is_autopilot_mode(); }
 
     //
@@ -510,6 +513,9 @@ public:
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
 
+    // do not allow arming from this mode
+    bool allows_arming() const override { return false; }
+
     // return desired location
     bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
 
@@ -541,6 +547,9 @@ public:
 
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
+
+    // do not allow arming from this mode
+    bool allows_arming() const override { return false; }
 
     // return desired location
     bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;

--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -31,7 +31,7 @@ SITL_START_LOCATION = mavutil.location(40.071374969556928,
 class AutoTestRover(AutoTest):
     @staticmethod
     def get_not_armable_mode_list():
-        return []
+        return ["RTL", "SMART_RTL"]
 
     @staticmethod
     def get_not_disarmed_settable_modes_list():
@@ -43,7 +43,7 @@ class AutoTestRover(AutoTest):
 
     @staticmethod
     def get_position_armable_modes_list():
-        return ["GUIDED", "LOITER", "STEERING", "AUTO", "RTL", "SMART_RTL"]
+        return ["GUIDED", "LOITER", "STEERING", "AUTO"]
 
     @staticmethod
     def get_normal_armable_modes_list():


### PR DESCRIPTION
This PR fixes #12340
The vehicle now display's a pre-arm failure if the mode is not armable, just like Copter. 