### PR TITLE
Sub: don't revert to previous attitude after a set_attitude_target_no_gps expires

### DIFF
--- a/ArduSub/control_althold.cpp
+++ b/ArduSub/control_althold.cpp
@@ -50,6 +50,10 @@ void Sub::handle_attitude()
         target_roll = 100 * degrees(target_roll);
         target_pitch = 100 * degrees(target_pitch);
         target_yaw = 100 * degrees(target_yaw);
+        last_roll = target_roll;
+        last_pitch = target_pitch;
+        last_yaw = target_yaw;
+        
         attitude_control.input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, target_yaw, true);
     } else {
         // If we don't have a mavlink attitude target, we use the pilot's input instead


### PR DESCRIPTION
In Sub 4.0, when a set_attitude_no_gps mavlink message stops being received, ardusub is reverting back to the previous attitude.
This makes the set_attitude_target_no_gps behave the same as pilot inputs and save the current attitude as the attitude setpoint for the ROV.