### PR TITLE
AP_HAL_ChibiOS:  Fix waf --default-parameters

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -350,7 +350,7 @@ def configure(cfg):
 
     if cfg.options.default_parameters:
         cfg.msg('Default parameters', cfg.options.default_parameters, color='YELLOW')
-        env.DEFAULT_PARAMETERS = srcpath(cfg.options.default_parameters)
+        env.DEFAULT_PARAMETERS = cfg.options.default_parameters
 
     # we need to run chibios_hwdef.py at configure stage to generate the ldscript.ld
     # that is needed by the remaining configure checks
@@ -368,7 +368,7 @@ def configure(cfg):
         os.mkdir(hwdef_out)
     python = sys.executable
     try:
-        cmd = "{0} '{1}' -D '{2}' '{3}' {4}".format(python, hwdef_script, hwdef_out, env.HWDEF, env.BOOTLOADER_OPTION)
+        cmd = "{0} '{1}' -D '{2}' '{3}' {4} --params '{5}'".format(python, hwdef_script, hwdef_out, env.HWDEF, env.BOOTLOADER_OPTION, cfg.options.default_parameters)
         ret = subprocess.call(cmd, shell=True)
     except Exception:
         cfg.fatal("Failed to process hwdef.dat")
@@ -391,8 +391,8 @@ def build(bld):
     bld(
         # build hwdef.h from hwdef.dat. This is needed after a waf clean
         source=bld.path.ant_glob(bld.env.HWDEF),
-        rule="%s '${AP_HAL_ROOT}/hwdef/scripts/chibios_hwdef.py' -D '${BUILDROOT}' '%s' %s" % (
-            bld.env.get_flat('PYTHON'), bld.env.HWDEF, bld.env.BOOTLOADER_OPTION),
+        rule="%s '${AP_HAL_ROOT}/hwdef/scripts/chibios_hwdef.py' -D '${BUILDROOT}' '%s' %s --params '%s'" % (
+            bld.env.get_flat('PYTHON'), bld.env.HWDEF, bld.env.BOOTLOADER_OPTION, bld.env.default_parameters),
         group='dynamic_sources',
         target=[bld.bldnode.find_or_declare('hwdef.h'),
                 bld.bldnode.find_or_declare('ldscript.ld')]

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -20,6 +20,8 @@ parser.add_argument(
     '--bootloader', action='store_true', default=False, help='configure for bootloader')
 parser.add_argument(
     'hwdef', type=str, default=None, help='hardware definition file')
+parser.add_argument(
+    '--params', type=str, default=None, help='user default params path')
 
 args = parser.parse_args()
 
@@ -1774,11 +1776,19 @@ def build_peripheral_list():
 def write_env_py(filename):
     '''write out env.py for environment variables to control the build process'''
 
-    # see if board has a defaults.parm file
+    # see if board has a defaults.parm file or a --default-parameters file was specified
     defaults_filename = os.path.join(os.path.dirname(args.hwdef), 'defaults.parm')
-    if os.path.exists(defaults_filename) and not args.bootloader:
-        print("Adding defaults.parm")
-        env_vars['DEFAULT_PARAMETERS'] = os.path.abspath(defaults_filename)
+    defaults_path = os.path.join(os.path.dirname(args.hwdef), args.params)
+
+    if not args.bootloader:
+        if os.path.exists(defaults_path):
+            env_vars['DEFAULT_PARAMETERS'] = os.path.abspath(defaults_path)
+            print("Default parameters path from command line: %s" % defaults_path)
+        elif os.path.exists(defaults_filename):
+            env_vars['DEFAULT_PARAMETERS'] = os.path.abspath(defaults_filename)
+            print("Default parameters path from hwdef: %s" % defaults_filename)
+        else:
+            print("No default parameter file found")
 
     # CHIBIOS_BUILD_FLAGS is passed to the ChibiOS makefile
     env_vars['CHIBIOS_BUILD_FLAGS'] = ' '.join(build_flags)


### PR DESCRIPTION
If a defaults.parm file was present in the hwdef, waf configure ignored the `--default-parameters` command line argument.  It also treated any specified file as it's root being the repo directory, which is not very useful. It would turn an absolute path into something ridiculous like `/home/matt/github/ardupilot/home/matt/Desktop/paramfile.params` which is clearly invalid.

This PR does a few things to fix all this.
- Allow you to specify and absolute path to a parameter file that works, looking like this: `./waf configure CubeOrange --default-parameters=/home/matt/Desktop/paramfile.params`.
- A parameter file specified with the `--default-parameters` argument will take precedent over a `defaults.parm` file in the hwdef directory.
- Additional prints to tell the user what it actually is doing with what files.

It should be noted, which I didn't know until this, that this command line argument is only used in configure.  Not in the build command.