### PR TITLE
AP_RangeFinder: Delete some description of I2C function address.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -91,7 +91,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
 
     // @Param: ADDR
     // @DisplayName: Bus address of sensor
-    // @Description: This sets the bus address of the sensor, where applicable. Used for the I2C and UAVCAN sensors to allow for multiple sensors on different addresses. A value of 0 disables the sensor.
+    // @Description: This sets the bus address of the sensor, where applicable. Used for the I2C and UAVCAN sensors to allow for multiple sensors on different addresses.
     // @Range: 0 127
     // @Increment: 1
     // @User: Standard


### PR DESCRIPTION
I2C address 0 is not prohibited.
Address 0 of I2C is a functional address in I2C.
I don't think it is necessary to describe some of the I2C functional addresses.