### PR TITLE
Handle GoPro mavlink heartbeat, shutter toggle, and capture mode toggle

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -21,7 +21,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @Description: how to trigger the camera to take a picture
     // @Values: 0:Servo,1:Relay, 2:GoPro in Solo Gimbal
     // @User: Standard
-    AP_GROUPINFO("TRIGG_TYPE",  0, AP_Camera, _trigger_type, AP_CAMERA_TRIGGER_DEFAULT_TRIGGER_TYPE),
+    AP_GROUPINFO("TRIGG_TYPE",  0, AP_Camera, _trigger_type, 0),
 
     // @Param: DURATION
     // @DisplayName: Duration that shutter is held open
@@ -146,14 +146,14 @@ void AP_Camera::trigger_pic()
     setup_feedback_callback();
 
     _image_index++;
-    switch (_trigger_type) {
-    case AP_CAMERA_TRIGGER_TYPE_SERVO:
-        servo_pic();                    // Servo operated camera
+    switch (get_trigger_type()) {
+    case CamTrigType::servo:
+        servo_pic();            // Servo operated camera
         break;
-    case AP_CAMERA_TRIGGER_TYPE_RELAY:
-        relay_pic();                    // basic relay activation
+    case CamTrigType::relay:
+        relay_pic();            // basic relay activation
         break;
-    case AP_CAMERA_TRIGGER_TYPE_GOPRO:  // gopro in Solo Gimbal
+    case CamTrigType::gopro:  // gopro in Solo Gimbal
         AP_Camera_SoloGimbal::gopro_shutter_toggle();
         break;
     }
@@ -169,11 +169,11 @@ AP_Camera::trigger_pic_cleanup()
     if (_trigger_counter) {
         _trigger_counter--;
     } else {
-        switch (_trigger_type) {
-        case AP_CAMERA_TRIGGER_TYPE_SERVO:
+        switch (get_trigger_type()) {
+        case CamTrigType::servo:
             SRV_Channels::set_output_pwm(SRV_Channel::k_cam_trigger, _servo_off_pwm);
             break;
-        case AP_CAMERA_TRIGGER_TYPE_RELAY: {
+        case CamTrigType::relay: {
             AP_Relay *_apm_relay = AP::relay();
             if (_apm_relay == nullptr) {
                 break;
@@ -185,6 +185,9 @@ AP_Camera::trigger_pic_cleanup()
             }
             break;
         }
+        case CamTrigType::gopro:
+            // nothing to do
+            break;
         }
     }
 
@@ -207,7 +210,7 @@ void AP_Camera::handle_message(mavlink_channel_t chan, const mavlink_message_t &
         break;
     case MAVLINK_MSG_ID_GOPRO_HEARTBEAT:
         // heartbeat from the Solo gimbal with a GoPro
-        if (_trigger_type == AP_CAMERA_TRIGGER_TYPE_GOPRO) {
+        if (get_trigger_type() == CamTrigType::gopro) {
             AP_Camera_SoloGimbal::handle_gopro_heartbeat(chan, msg);
             break;
         }
@@ -218,8 +221,8 @@ void AP_Camera::handle_message(mavlink_channel_t chan, const mavlink_message_t &
 /// momentary switch to cycle camera modes
 void AP_Camera::cam_mode_toggle()
 {
-    switch (_trigger_type) {
-    case AP_CAMERA_TRIGGER_TYPE_GOPRO:
+    switch (get_trigger_type()) {
+    case CamTrigType::gopro:
         AP_Camera_SoloGimbal::gopro_capture_mode_toggle();
         break;
     default:
@@ -487,6 +490,20 @@ void AP_Camera::update_trigger()
             }
         }
     }
+}
+
+AP_Camera::CamTrigType AP_Camera::get_trigger_type(void)
+{
+    uint8_t type = _trigger_type.get();
+
+    switch ((CamTrigType)type) {
+        case CamTrigType::servo:
+        case CamTrigType::relay:
+        case CamTrigType::gopro:
+            return (CamTrigType)type;
+        default:
+            return CamTrigType::servo;
+    }   
 }
 
 // singleton instance

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -7,6 +7,7 @@
 
 #define AP_CAMERA_TRIGGER_TYPE_SERVO                0
 #define AP_CAMERA_TRIGGER_TYPE_RELAY                1
+#define AP_CAMERA_TRIGGER_TYPE_GOPRO                2   // GoPro in Solo gimbal
 
 #define AP_CAMERA_TRIGGER_DEFAULT_TRIGGER_TYPE  AP_CAMERA_TRIGGER_TYPE_SERVO    // default is to use servo to trigger camera
 
@@ -41,7 +42,8 @@ public:
     }
 
     // MAVLink methods
-    void            control_msg(const mavlink_message_t &msg);
+    void            handle_message(mavlink_channel_t chan,
+                                   const mavlink_message_t &msg);
     void            send_feedback(mavlink_channel_t chan);
 
     // Command processing
@@ -54,6 +56,9 @@ public:
     {
         _trigg_dist.set(distance_m);
     }
+
+    // momentary switch to change camera modes
+    void cam_mode_toggle();
 
     void take_picture();
 
@@ -80,7 +85,9 @@ private:
 
     static AP_Camera *_singleton;
 
-    AP_Int8         _trigger_type;      // 0:Servo,1:Relay
+    void            control_msg(const mavlink_message_t &msg);
+
+    AP_Int8         _trigger_type;      // 0:Servo,1:Relay, 2:GoPro in Solo Gimbal
     AP_Int8         _trigger_duration;  // duration in 10ths of a second that the camera shutter is held open
     AP_Int8         _relay_on;          // relay value to trigger camera
     AP_Int16        _servo_on_pwm;      // PWM value to move servo to when shutter is activated

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -5,12 +5,6 @@
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS.h>
 
-#define AP_CAMERA_TRIGGER_TYPE_SERVO                0
-#define AP_CAMERA_TRIGGER_TYPE_RELAY                1
-#define AP_CAMERA_TRIGGER_TYPE_GOPRO                2   // GoPro in Solo gimbal
-
-#define AP_CAMERA_TRIGGER_DEFAULT_TRIGGER_TYPE  AP_CAMERA_TRIGGER_TYPE_SERVO    // default is to use servo to trigger camera
-
 #define AP_CAMERA_TRIGGER_DEFAULT_DURATION  10      // default duration servo or relay is held open in 10ths of a second (i.e. 10 = 1 second)
 
 #define AP_CAMERA_SERVO_ON_PWM              1300    // default PWM value to move servo to when shutter is activated
@@ -80,6 +74,14 @@ public:
         CAMERA_TYPE_STD,
         CAMERA_TYPE_BMMCC
     };
+
+    enum class CamTrigType {
+        servo   = 0,
+        relay   = 1,
+        gopro   = 2,
+    };
+
+    AP_Camera::CamTrigType get_trigger_type(void);
 
 private:
 

--- a/libraries/AP_Camera/AP_Camera_SoloGimbal.cpp
+++ b/libraries/AP_Camera/AP_Camera_SoloGimbal.cpp
@@ -1,0 +1,112 @@
+#include "AP_Camera_SoloGimbal.h"
+#include <GCS_MAVLink/GCS.h>
+
+GOPRO_CAPTURE_MODE AP_Camera_SoloGimbal::gopro_capture_mode;
+GOPRO_HEARTBEAT_STATUS AP_Camera_SoloGimbal::gopro_status;
+bool AP_Camera_SoloGimbal::gopro_is_recording;
+mavlink_channel_t AP_Camera_SoloGimbal::heartbeat_channel;
+
+// Toggle the shutter on the GoPro
+// This is so ArduPilot can toggle the shutter directly, either for mission/GCS commands, or when the
+// Solo's gimbal is installed on a vehicle other than a Solo.  The usual GoPro controls thorugh the 
+// Solo app and Solo controller do not use this, as it is done offboard on the companion computer.
+void AP_Camera_SoloGimbal::gopro_shutter_toggle()
+{
+    if (gopro_status != GOPRO_HEARTBEAT_STATUS_CONNECTED) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Not Available");
+        return;
+    }
+
+    const uint8_t gopro_shutter_start[4] = { 1, 0, 0, 0};
+    const uint8_t gopro_shutter_stop[4] = { 0, 0, 0, 0};
+
+    if (gopro_capture_mode == GOPRO_CAPTURE_MODE_PHOTO) {
+        // Trigger shutter start to take a photo
+        gcs().send_text(MAV_SEVERITY_INFO, "GoPro Photo Trigger");
+        mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_SHUTTER,gopro_shutter_start);
+
+    } else if (gopro_capture_mode == GOPRO_CAPTURE_MODE_VIDEO) {
+        if (gopro_is_recording) {
+            // GoPro is recording, so stop recording
+            gcs().send_text(MAV_SEVERITY_INFO, "GoPro Recording Stop");
+            mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_SHUTTER,gopro_shutter_stop);
+        } else {
+            // GoPro is not recording, so start recording
+            gcs().send_text(MAV_SEVERITY_INFO, "GoPro Recording Start");
+            mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_SHUTTER,gopro_shutter_start);
+        }
+    } else {
+        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Unsupported Capture Mode");    
+    }
+}
+
+// Cycle the GoPro capture mode
+// This is so ArduPilot can cycle through the capture modes of the GoPro directly, probably with an RC Aux function.
+// This is primarily for Solo's gimbal being installed on a vehicle other than a Solo. The usual GoPro controls 
+// through the Solo app and Solo controller do not use this, as it is done offboard on the companion computer.
+void AP_Camera_SoloGimbal::gopro_capture_mode_toggle()
+{
+    uint8_t gopro_capture_mode_values[4] = { };
+    
+    if (gopro_status != GOPRO_HEARTBEAT_STATUS_CONNECTED) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Not Available");
+        return;
+    }
+
+    switch(gopro_capture_mode) {
+        case GOPRO_CAPTURE_MODE_VIDEO:
+            if (gopro_is_recording) {
+                // GoPro is recording, cannot change modes
+                gcs().send_text(MAV_SEVERITY_INFO, "GoPro recording, can't change modes");
+            } else {
+                // Change to camera mode
+                gopro_capture_mode_values[0] = GOPRO_CAPTURE_MODE_PHOTO;
+                mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_CAPTURE_MODE,gopro_capture_mode_values);
+                gcs().send_text(MAV_SEVERITY_INFO, "GoPro changing to mode photo");
+            }
+            break;
+        
+        case GOPRO_CAPTURE_MODE_PHOTO:
+        default:
+            // Change to video mode
+            gopro_capture_mode_values[0] =  GOPRO_CAPTURE_MODE_VIDEO;
+            mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_CAPTURE_MODE,gopro_capture_mode_values);
+            gcs().send_text(MAV_SEVERITY_INFO, "GoPro changing to mode video");
+            break;
+    }
+}
+
+// heartbeat from the Solo gimbal GoPro
+void AP_Camera_SoloGimbal::handle_gopro_heartbeat(mavlink_channel_t chan, const mavlink_message_t &msg)
+{
+    mavlink_gopro_heartbeat_t report_msg;
+    mavlink_msg_gopro_heartbeat_decode(&msg, &report_msg);
+    gopro_is_recording = report_msg.flags & GOPRO_FLAG_RECORDING;
+    heartbeat_channel = chan;
+
+    switch((GOPRO_HEARTBEAT_STATUS)report_msg.status) {
+        case GOPRO_HEARTBEAT_STATUS_DISCONNECTED:
+        case GOPRO_HEARTBEAT_STATUS_INCOMPATIBLE:
+        case GOPRO_HEARTBEAT_STATUS_ERROR:
+        case GOPRO_HEARTBEAT_STATUS_CONNECTED:
+            gopro_status = (GOPRO_HEARTBEAT_STATUS)report_msg.status;
+            break;
+        case GOPRO_HEARTBEAT_STATUS_ENUM_END:
+            break;
+    }
+
+    switch((GOPRO_CAPTURE_MODE)report_msg.capture_mode){
+        case GOPRO_CAPTURE_MODE_VIDEO:
+        case GOPRO_CAPTURE_MODE_PHOTO:
+        case GOPRO_CAPTURE_MODE_BURST:
+        case GOPRO_CAPTURE_MODE_TIME_LAPSE:
+        case GOPRO_CAPTURE_MODE_MULTI_SHOT:
+        case GOPRO_CAPTURE_MODE_PLAYBACK:
+        case GOPRO_CAPTURE_MODE_SETUP:
+        case GOPRO_CAPTURE_MODE_UNKNOWN:
+            gopro_capture_mode = (GOPRO_CAPTURE_MODE)report_msg.capture_mode;
+            break;
+        case GOPRO_CAPTURE_MODE_ENUM_END:
+            break;
+    }
+}

--- a/libraries/AP_Camera/AP_Camera_SoloGimbal.h
+++ b/libraries/AP_Camera/AP_Camera_SoloGimbal.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <GCS_MAVLink/GCS_MAVLink.h>
+
+class AP_Camera_SoloGimbal {
+public:
+
+    static void gopro_shutter_toggle();
+    static void gopro_capture_mode_toggle();
+    static void handle_gopro_heartbeat(mavlink_channel_t chan, const mavlink_message_t &msg);
+
+private:
+
+    static GOPRO_CAPTURE_MODE gopro_capture_mode;
+    static GOPRO_HEARTBEAT_STATUS gopro_status;
+    static bool gopro_is_recording;
+    static mavlink_channel_t heartbeat_channel;
+};

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3148,12 +3148,13 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
         break;
 
     case MAVLINK_MSG_ID_DIGICAM_CONTROL:
+    case MAVLINK_MSG_ID_GOPRO_HEARTBEAT: // heartbeat from a GoPro in Solo gimbal
         {
             AP_Camera *camera = AP::camera();
             if (camera == nullptr) {
                 return;
             }
-            camera->control_msg(msg);
+            camera->handle_message(chan, msg);
         }
         break;
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -90,9 +90,9 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: OPTION
     // @DisplayName: RC input option
     // @Description: Function assigned to this RC channel
-    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5, 67:Relay6, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 100:KillIMU1, 101:KillIMU2
-    // @Values{Rover}: 0:Do Nothing, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 11:Fence, 16:Auto, 19:Gripper, 24:Auto Mission Reset, 28:Relay On/Off, 30:Lost Rover Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple Mode, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66:Relay5, 67:Relay6, 74:Sailboat motoring 3pos, 78:RunCam Control, 79:RunCam OSD Control, 100:KillIMU1, 101:KillIMU2, 207:MainSail
-    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 16:ModeAuto, 24:Auto Mission Reset, 28:Relay On/Off, 29:Landing Gear, 34:Relay2 On/Off, 30:Lost Plane Sound, 31:Motor Emergency Stop, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm, 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5, 67:Relay6, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 100:KillIMU1, 101:KillIMU2, 208:Flap
+    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5, 67:Relay6, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle
+    // @Values{Rover}: 0:Do Nothing, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 11:Fence, 16:Auto, 19:Gripper, 24:Auto Mission Reset, 28:Relay On/Off, 30:Lost Rover Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple Mode, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66:Relay5, 67:Relay6, 74:Sailboat motoring 3pos, 78:RunCam Control, 79:RunCam OSD Control, 100:KillIMU1, 101:KillIMU2, 207:MainSail, 102:Camera Mode Toggle
+    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 16:ModeAuto, 24:Auto Mission Reset, 28:Relay On/Off, 29:Landing Gear, 34:Relay2 On/Off, 30:Lost Plane Sound, 31:Motor Emergency Stop, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm, 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5, 67:Relay6, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 100:KillIMU1, 101:KillIMU2, 208:Flap, 102:Camera Mode Toggle
     // @User: Standard
     AP_GROUPINFO_FRAME("OPTION",  6, RC_Channel, option, 0, AP_PARAM_FRAME_COPTER|AP_PARAM_FRAME_ROVER|AP_PARAM_FRAME_PLANE),
 
@@ -903,6 +903,26 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         }
         break;
 #endif // HAL_MINIMIZE_FEATURES
+
+    case AUX_FUNC::CAM_MODE_TOGGLE: {
+        // Momentary switch to for cycling camera modes
+        AP_Camera *camera = AP_Camera::get_singleton();
+        if (camera == nullptr) {
+            break;
+        }
+        switch (ch_flag) {
+        case LOW:
+            // nothing
+            break;
+        case MIDDLE:
+            // nothing
+            break;
+        case HIGH:
+            camera->cam_mode_toggle();
+            break;
+        }
+        break;
+    }
 
     default:
         gcs().send_text(MAV_SEVERITY_INFO, "Invalid channel option (%u)", (unsigned int)ch_option);

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -179,6 +179,7 @@ public:
         RUNCAM_OSD_CONTROL =  79, // control RunCam OSD
         KILL_IMU1 =          100, // disable first IMU (for IMU failure testing)
         KILL_IMU2 =          101, // disable second IMU (for IMU failure testing)
+        CAM_MODE_TOGGLE =    102, // Momentary switch to cycle camera modes
         // if you add something here, make sure to update the documentation of the parameter in RC_Channel.cpp!
         // also, if you add an option >255, you will need to fix duplicate_options_exist
 


### PR DESCRIPTION
This enables the use of a Solo gimbal on a vehicle other than a Solo.  Also has some use on the Solo itself to allow mission/gcs camera triggers to work out of the box.

_**Updated 2/11/2020 after much debate over library location**_

**GCS_Mavlink:**
- Routing of the GoPro/Gimbal heartbeat to the AP_Camera library.
- This gives us the camera's status, mode, and recording flag to be consumed by other new functions.
- This was not previously handled or consumed, but has always been there going nowhere.

**AP_Camera:**
- Creates AP_Camera/AP_Camera_SoloGimbal to handle the camera on the gimbal.
- Parse the gimbal's heartbeat for status, mode, and recording state.
- Added function to toggle the shutter command. This will take a photo, or start/stop video depending on what mode you're in.
- Added a function to toggle the capture mode between photo and video.
- GCS text tells the operator what it's doing.
- Added option 2 for parameter `CAM_TRIGG_TYPE`. Will trigger the GoPro shutter toggle rather than servo or relay shutters.
- This also ends up getting called by anything using `mav_cmd_do_digicam_control`, such as auto mode missions and GCS camera trigger buttons. So those functions will now work on the Solo as well.

**RC_Channel:**
- Added RC aux switch option 102 to toggle the GoPro mode. So for example a momentary switch on RC8 could be set with `RC8_OPTION`=102
- Momentary switch calls into the mount library to toggle modes between photo and video.

Tested and working on my quad with a solo gimbal strapped to the bottom of it.
