### PR TITLE
AP_ToshibaCAN/AP_Scripting: retrieve ESC usage time and make available to lua scripts

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -94,6 +94,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_SerialLED',
     'AP_EFI',
     'AP_Hott_Telem',
+    'AP_ESC_Telem',
     'AP_Stats',
 ]
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -1,0 +1,74 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ESC_Telem.h"
+#include <AP_HAL/AP_HAL.h>
+
+#if HAL_WITH_UAVCAN
+  #include <AP_BoardConfig/AP_BoardConfig_CAN.h>
+  #include <AP_Common/AP_Common.h>
+  #include <AP_Vehicle/AP_Vehicle.h>
+  #include <AP_UAVCAN/AP_UAVCAN.h>
+  #include <AP_KDECAN/AP_KDECAN.h>
+  #include <AP_ToshibaCAN/AP_ToshibaCAN.h>
+#endif
+
+extern const AP_HAL::HAL& hal;
+
+AP_ESC_Telem::AP_ESC_Telem()
+{
+    if (_singleton) {
+        AP_HAL::panic("Too many AP_ESC_Telem instances");
+    }
+    _singleton = this;
+}
+
+// get an individual ESC's usage time in seconds if available, returns true on success
+bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_id, uint32_t& usage_sec) const
+{
+#if HAL_WITH_UAVCAN
+    const uint8_t num_drivers = AP::can().get_num_drivers();
+    for (uint8_t i = 0; i < num_drivers; i++) {
+        if (AP::can().get_protocol_type(i) == AP_BoardConfig_CAN::Protocol_Type_ToshibaCAN) {
+            AP_ToshibaCAN *tcan = AP_ToshibaCAN::get_tcan(i);
+            if (tcan != nullptr) {
+                usage_sec = tcan->get_usage_seconds(esc_id);
+                return true;
+            }
+            return true;
+        }
+    }
+#endif
+    return false;
+}
+
+AP_ESC_Telem *AP_ESC_Telem::_singleton = nullptr;
+
+/*
+ * Get the AP_InertialSensor singleton
+ */
+AP_ESC_Telem *AP_ESC_Telem::get_singleton()
+{
+    return AP_ESC_Telem::_singleton;
+}
+
+namespace AP {
+
+AP_ESC_Telem &esc_telem()
+{
+    return *AP_ESC_Telem::get_singleton();
+}
+
+};

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+class AP_ESC_Telem {
+public:
+
+    AP_ESC_Telem();
+
+    /* Do not allow copies */
+    AP_ESC_Telem(const AP_ESC_Telem &other) = delete;
+    AP_ESC_Telem &operator=(const AP_ESC_Telem&) = delete;
+
+    static AP_ESC_Telem *get_singleton();
+
+    // get an individual ESC's usage time in seconds if available, returns true on success
+    bool get_usage_seconds(uint8_t esc_id, uint32_t& usage_sec) const;
+
+private:
+
+    static AP_ESC_Telem *_singleton;
+
+};
+
+namespace AP {
+    AP_ESC_Telem &esc_telem();
+};

--- a/libraries/AP_Scripting/examples/esc-usage.lua
+++ b/libraries/AP_Scripting/examples/esc-usage.lua
@@ -1,0 +1,31 @@
+-- This script displays ESC usage time (supported only by ToshibaCAN ESCs)
+
+local usage_hours_max = 100 -- maximum safe usage for these ESCs in hours
+local usage_sec_max = usage_hours_max*60*60
+
+function update() -- this is the loop which periodically runs
+  if not arming:is_armed() then -- only run check when disarmed
+    local got_esc_usage = false
+    local esc_over_max = false
+    for i = 0, 3 do -- check first four ESCs
+      local usage_sec = esc_telem:get_usage_seconds(i)
+      if usage_sec > 0 then
+        got_esc_usage = true
+      end
+      if usage_sec > usage_sec_max then
+          esc_over_max = true
+          local usage_hours = usage_sec / 3600
+          local usage_minutes = (usage_sec / 60) % 60
+          gcs:send_text(0, string.format("ESC" .. tostring(i) .. ": " .. tostring(usage_hours) .. "hrs " .. tostring(usage_minutes) .. "min (limit is " .. tostring(usage_hours_max) .. "hrs)"))
+      end
+    end
+    if not got_esc_usage then
+      gcs:send_text(0, "Could not retrieve ESC usage time")
+    elseif not esc_over_max then
+      gcs:send_text(0, string.format("ESC usage time OK (under " .. tostring(usage_hours_max) .. "hrs limit)"))
+    end
+  end
+  return update, 5000 -- reschedules the loop in 5 seconds
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -179,3 +179,7 @@ singleton AP_Baro alias baro
 singleton AP_Baro method get_pressure float
 singleton AP_Baro method get_temperature float
 singleton AP_Baro method get_external_temperature float
+
+include AP_ESC_Telem/AP_ESC_Telem.h
+singleton AP_ESC_Telem alias esc_telem
+singleton AP_ESC_Telem method get_usage_seconds boolean uint8_t 0 NUM_SERVO_CHANNELS uint32_t'Null

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,6 +1,7 @@
 // auto generated bindings, don't manually edit.  See README.md for details.
 #include "lua_generated_bindings.h"
 #include "lua_boxed_numerics.h"
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <RC_Channel/RC_Channel.h>
@@ -529,6 +530,30 @@ const luaL_Reg Location_meta[] = {
     {"get_distance", Location_get_distance},
     {NULL, NULL}
 };
+
+static int AP_ESC_Telem_get_usage_seconds(lua_State *L) {
+    AP_ESC_Telem * ud = AP_ESC_Telem::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "esc_telem not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(NUM_SERVO_CHANNELS, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    uint32_t data_5003 = {};
+    const bool data = ud->get_usage_seconds(
+            data_2,
+            data_5003);
+
+    if (data) {
+        new_uint32_t(L);
+        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = data_5003;
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
 
 static int AP_Baro_get_external_temperature(lua_State *L) {
     AP_Baro * ud = AP_Baro::get_singleton();
@@ -1903,6 +1928,11 @@ static int AP_AHRS_get_roll(lua_State *L) {
     return 1;
 }
 
+const luaL_Reg AP_ESC_Telem_meta[] = {
+    {"get_usage_seconds", AP_ESC_Telem_get_usage_seconds},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_Baro_meta[] = {
     {"get_external_temperature", AP_Baro_get_external_temperature},
     {"get_temperature", AP_Baro_get_temperature},
@@ -2155,6 +2185,7 @@ const struct userdata_meta userdata_fun[] = {
 };
 
 const struct userdata_meta singleton_fun[] = {
+    {"esc_telem", AP_ESC_Telem_meta, NULL},
     {"baro", AP_Baro_meta, NULL},
     {"serial", AP_SerialManager_meta, NULL},
     {"rc", RC_Channels_meta, NULL},
@@ -2225,6 +2256,7 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
+    "esc_telem",
     "baro",
     "serial",
     "rc",

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 // auto generated bindings, don't manually edit.  See README.md for details.
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <RC_Channel/RC_Channel.h>

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -552,6 +552,15 @@ void AP_ToshibaCAN::send_esc_telemetry_mavlink(uint8_t mav_chan)
     }
 }
 
+// return total usage time in seconds
+uint32_t AP_ToshibaCAN::get_usage_seconds(uint8_t esc_id) const
+{
+    if (esc_id >= TOSHIBACAN_MAX_NUM_ESCS) {
+        return 0;
+    }
+    return _telemetry[esc_id].usage_sec;
+}
+
 // helper function to create motor_request_data_cmd_t
 AP_ToshibaCAN::motor_request_data_cmd_t AP_ToshibaCAN::get_motor_request_data_cmd(uint8_t request_id) const
 {

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -238,19 +238,7 @@ void AP_ToshibaCAN::loop()
                 }
 
                 // prepare command to request data1 (rpm and voltage) from all ESCs
-                motor_request_data_cmd_t request_data_cmd = {};
-                request_data_cmd.motor1 = 1;
-                request_data_cmd.motor2 = 1;
-                request_data_cmd.motor3 = 1;
-                request_data_cmd.motor4 = 1;
-                request_data_cmd.motor5 = 1;
-                request_data_cmd.motor6 = 1;
-                request_data_cmd.motor7 = 1;
-                request_data_cmd.motor8 = 1;
-                request_data_cmd.motor9 = 1;
-                request_data_cmd.motor10 = 1;
-                request_data_cmd.motor11 = 1;
-                request_data_cmd.motor12 = 1;
+                motor_request_data_cmd_t request_data_cmd = get_motor_request_data_cmd(1);
                 uavcan::CanFrame request_data_frame;
                 request_data_frame = {(uint8_t)COMMAND_REQUEST_DATA, request_data_cmd.data, sizeof(request_data_cmd.data)};
 
@@ -273,19 +261,7 @@ void AP_ToshibaCAN::loop()
                 _telemetry_temp_req_counter = 0;
 
                 // prepare command to request data2 (temperature) from all ESCs
-                motor_request_data_cmd_t request_data_cmd = {};
-                request_data_cmd.motor1 = 2;
-                request_data_cmd.motor2 = 2;
-                request_data_cmd.motor3 = 2;
-                request_data_cmd.motor4 = 2;
-                request_data_cmd.motor5 = 2;
-                request_data_cmd.motor6 = 2;
-                request_data_cmd.motor7 = 2;
-                request_data_cmd.motor8 = 2;
-                request_data_cmd.motor9 = 2;
-                request_data_cmd.motor10 = 2;
-                request_data_cmd.motor11 = 2;
-                request_data_cmd.motor12 = 2;
+                motor_request_data_cmd_t request_data_cmd = get_motor_request_data_cmd(2);
                 uavcan::CanFrame request_data_frame;
                 request_data_frame = {(uint8_t)COMMAND_REQUEST_DATA, request_data_cmd.data, sizeof(request_data_cmd.data)};
 
@@ -343,7 +319,7 @@ void AP_ToshibaCAN::loop()
                     const uint16_t motor_temp = (((uint16_t)recv_frame.data[3] & (uint16_t)0x03) << 8) | ((uint16_t)recv_frame.data[4]);
                     const uint16_t temp_max = MAX(u_temp, MAX(v_temp, w_temp));
 
-                    // store repose in telemetry array
+                    // store response in telemetry array
                     uint8_t esc_id = recv_frame.id - MOTOR_DATA2;
                     if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
                         WITH_SEMAPHORE(_telem_sem);
@@ -537,6 +513,25 @@ void AP_ToshibaCAN::send_esc_telemetry_mavlink(uint8_t mav_chan)
             }
         }
     }
+}
+
+// helper function to create motor_request_data_cmd_t
+AP_ToshibaCAN::motor_request_data_cmd_t AP_ToshibaCAN::get_motor_request_data_cmd(uint8_t request_id) const
+{
+    motor_request_data_cmd_t req_data_cmd = {};
+    req_data_cmd.motor1 = request_id;
+    req_data_cmd.motor2 = request_id;
+    req_data_cmd.motor3 = request_id;
+    req_data_cmd.motor4 = request_id;
+    req_data_cmd.motor5 = request_id;
+    req_data_cmd.motor6 = request_id;
+    req_data_cmd.motor7 = request_id;
+    req_data_cmd.motor8 = request_id;
+    req_data_cmd.motor9 = request_id;
+    req_data_cmd.motor10 = request_id;
+    req_data_cmd.motor11 = request_id;
+    req_data_cmd.motor12 = request_id;
+    return req_data_cmd;
 }
 
 #endif // HAL_WITH_UAVCAN

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -248,8 +248,9 @@ void AP_ToshibaCAN::loop()
                     continue;
                 }
 
-                // increment count to request temperature
+                // increment count to request temperature and usage
                 _telemetry_temp_req_counter++;
+                _telemetry_usage_req_counter++;
             }
 
             send_stage++;
@@ -275,8 +276,27 @@ void AP_ToshibaCAN::loop()
             send_stage++;
         }
 
-        // check for replies from ESCs
+        // check if we should request usage from ESCs
         if (send_stage == 7) {
+            if (_telemetry_usage_req_counter > 100) {
+                _telemetry_usage_req_counter = 0;
+
+                // prepare command to request data2 (temperature) from all ESCs
+                motor_request_data_cmd_t request_data_cmd = get_motor_request_data_cmd(3);
+                uavcan::CanFrame request_data_frame;
+                request_data_frame = {(uint8_t)COMMAND_REQUEST_DATA, request_data_cmd.data, sizeof(request_data_cmd.data)};
+
+                // send request data command
+                timeout = uavcan::MonotonicTime::fromUSec(AP_HAL::micros64() + timeout_us);
+                if (!write_frame(request_data_frame, timeout)) {
+                    continue;
+                }
+            }
+            send_stage++;
+        }
+
+        // check for replies from ESCs
+        if (send_stage == 8) {
             uavcan::CanFrame recv_frame;
             while (read_frame(recv_frame, timeout)) {
                 // decode rpm and voltage data
@@ -325,6 +345,23 @@ void AP_ToshibaCAN::loop()
                         WITH_SEMAPHORE(_telem_sem);
                         _telemetry[esc_id].esc_temp = temp_max < 100 ? 0 : temp_max / 5 - 20;
                         _telemetry[esc_id].motor_temp = motor_temp < 100 ? 0 : motor_temp / 5 - 20;
+                        _esc_present_bitmask_recent |= ((uint32_t)1 << esc_id);
+                    }
+                }
+
+                // decode cumulative usage data
+                if ((recv_frame.id >= MOTOR_DATA3) && (recv_frame.id <= MOTOR_DATA3 + 12)) {
+                    // motor data3 data format is 8 bytes (64 bits)
+                    //    3 bytes: usage in seconds
+                    //    2 bytes: number of times rotors started and stopped
+                    //    3 bytes: reserved
+                    const uint32_t usage_sec = ((uint32_t)recv_frame.data[0] << 16) | ((uint32_t)recv_frame.data[1] << 8) | (uint32_t)recv_frame.data[2];
+
+                    // store response in telemetry array
+                    uint8_t esc_id = recv_frame.id - MOTOR_DATA3;
+                    if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
+                        WITH_SEMAPHORE(_telem_sem);
+                        _telemetry[esc_id].usage_sec = usage_sec;
                         _esc_present_bitmask_recent |= ((uint32_t)1 << esc_id);
                     }
                 }

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -44,6 +44,9 @@ public:
     // return a bitmask of escs that are "present" which means they are responding to requests.  Bitmask matches RC outputs
     uint16_t get_present_mask() const { return _esc_present_bitmask; }
 
+    // return total usage time in seconds
+    uint32_t get_usage_seconds(uint8_t esc_id) const;
+
 private:
 
     // loop to send output to ESCs in background thread

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -80,6 +80,7 @@ private:
         uint16_t current_ca;        // current in centi-amps
         uint16_t esc_temp;          // esc temperature in degrees
         uint16_t motor_temp;        // motor temperature in degrees
+        uint32_t usage_sec;         // motor's total usage in seconds
         uint16_t count;             // total number of packets sent
         uint32_t last_update_ms;    // system time telemetry was last update (used to calc total current)
         float current_tot_mah;      // total current in mAh
@@ -87,6 +88,7 @@ private:
     } _telemetry[TOSHIBACAN_MAX_NUM_ESCS];
     uint32_t _telemetry_req_ms;     // system time (in milliseconds) to request data from escs (updated at 10hz)
     uint8_t _telemetry_temp_req_counter;    // counter used to trigger temp data requests from ESCs (10x slower than other telem data)
+    uint8_t _telemetry_usage_req_counter;   // counter used to trigger usage data requests from ESCs (100x slower than other telem data)
     const float centiamp_ms_to_mah = 1.0f / 360000.0f;  // for converting centi-amps milliseconds to mAh
 
     // variables for updating bitmask of responsive escs

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -143,6 +143,9 @@ private:
         uint8_t data[6];
     };
 
+    // helper function to create motor_request_data_cmd_t
+    motor_request_data_cmd_t get_motor_request_data_cmd(uint8_t request_id) const;
+
     // structure for replies from ESC of data1 (rpm and voltage)
     union motor_reply_data1_t {
         struct PACKED {

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -83,8 +83,8 @@ private:
         uint16_t current_ca;        // current in centi-amps
         uint16_t esc_temp;          // esc temperature in degrees
         uint16_t motor_temp;        // motor temperature in degrees
-        uint32_t usage_sec;         // motor's total usage in seconds
         uint16_t count;             // total number of packets sent
+        uint32_t usage_sec;         // motor's total usage in seconds
         uint32_t last_update_ms;    // system time telemetry was last update (used to calc total current)
         float current_tot_mah;      // total current in mAh
         bool new_data;              // true if new telemetry data has been filled in but not logged yet

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -37,6 +37,7 @@
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AP_Camera/AP_RunCam.h>
 #include <AP_Hott_Telem/AP_Hott_Telem.h>
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
 
 class AP_Vehicle : public AP_HAL::HAL::Callbacks {
 
@@ -216,6 +217,8 @@ protected:
 #if HAL_HOTT_TELEM_ENABLED
     AP_Hott_Telem hott_telem;
 #endif
+
+    AP_ESC_Telem esc_telem;
 
     static const struct AP_Param::GroupInfo var_info[];
     static const struct AP_Scheduler::Task scheduler_tasks[];


### PR DESCRIPTION
This PR adds the following features:

- AP_ToshibaCAN is enhance to retrieve the ESC's usage time in seconds (i.e. how many seconds it has spun in it's life).  This is intended to help with proactive maintenance so older ESCs can be swapped out in the hopes of reducing failures
- AP_ESC_Telem library is added as a first step towards consolidating the interface for our various ESCs with feedback (ToshibaCAN, KDECAN, UAVCAN, PiccoloCAN and maybe BLHeli).  For the moment it doesn't do much except expose the AP_ToshibaCAN ESCs get_usage accessor.
- AP_Scripting gets access to the AP_ESC library and an example script, "get_usage.lua" is added to show how to retrieve the ESCs usage time.

The previously known issues have been resolved now (the list can be seen by checking the previous version of this description)