### PR TITLE
Rover: HEARTBEAT timeout 4 or 5 not received.

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -226,6 +226,15 @@ const AP_Param::Info Rover::var_info[] = {
     // @User: Standard
     GSCALAR(turn_max_g,             "TURN_MAX_G",      0.6f),
 
+    // @Param: HEARTBEAT_TMOUT
+    // @DisplayName: Heartbeat timeout time
+    // @Description: MAVLink HEARTBEAT reception timeout time
+    // @Units: s
+    // @Range: 1 10
+    // @Increment: 1
+    // @User: Standard
+    GSCALAR(heartbeat_timeout,      "HEARTBEAT_TMOUT",    2),
+
     // variables not in the g class which contain EEPROM saved variables
 
     // @Group: COMPASS_

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -115,6 +115,7 @@ public:
         k_param_auto_kickstart,
         k_param_turn_circle,  // unused
         k_param_turn_max_g,
+        k_param_heartbeat_timeout,
 
         //
         // 160: Radio settings
@@ -238,6 +239,7 @@ public:
     AP_Float    auto_kickstart;
     AP_Float    turn_max_g;
     AP_Int16    gcs_pid_mask;
+    AP_Int8     heartbeat_timeout;
 
     // Throttle
     //

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -204,8 +204,8 @@ void Rover::gcs_failsafe_check(void)
         return;
     }
 
-    // check for updates from GCS within 2 seconds
-    failsafe_trigger(FAILSAFE_EVENT_GCS, "GCS", failsafe.last_heartbeat_ms != 0 && (millis() - failsafe.last_heartbeat_ms) > 2000);
+    // check for updates from GCS within 2(default) seconds.
+    failsafe_trigger(FAILSAFE_EVENT_GCS, "GCS", failsafe.last_heartbeat_ms != 0 && (millis() - failsafe.last_heartbeat_ms) > (g.k_param_heartbeat_timeout * 1000));
 }
 
 /*


### PR DESCRIPTION
I think it's better to match the heartbeat timeout to the MAVLink specification.

https://mavlink.io/en/services/heartbeat.html#heartbeat-broadcast-frequency

The rate at which the HEARTBEAT message must be broadcast, and how many messages may be "missed" before a system is considered to have timed out / disconnected from the network, depends on the channel (it is not defined by MAVLink) .On RF telemetry links, components typically publish their heartbeat at 1 Hz and consider another system to have disconnected if four or five messages are not received.