### PR TITLE
GCS_MAVLink: raise ftp stack size to 3072 from 1024

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -42,7 +42,7 @@ bool GCS_MAVLINK::ftp_init(void) {
     }
 
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&GCS_MAVLINK::ftp_worker, void),
-                                      "FTP", 1024, AP_HAL::Scheduler::PRIORITY_IO, 0)) {
+                                      "FTP", 3072, AP_HAL::Scheduler::PRIORITY_IO, 0)) {
         goto failed;
     }
 


### PR DESCRIPTION
this prevents memory corruption on directory listing