### PR TITLE
Plane: fixed a bug in LOITER_TURNS in quadplanes

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3015,6 +3015,11 @@ bool QuadPlane::guided_mode_enabled(void)
     if (plane.control_mode != &plane.mode_guided && plane.control_mode != &plane.mode_auto) {
         return false;
     }
+    if (plane.control_mode == &plane.mode_auto &&
+        plane.mission.get_current_nav_cmd().id == MAV_CMD_NAV_LOITER_TURNS) {
+        // loiter turns is a fixed wing only operation
+        return false;
+    }
     return guided_mode != 0;
 }
 


### PR DESCRIPTION
if NAV_LOITER_TURNS is used with Q_GUIDED_MODE=1 then we would orbit
forever. This ensures we do exit the loiter