### PR TITLE
GCS_Mavlink: constrain battery current to avoid wrap

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -217,7 +217,7 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
 
     float current, consumed_mah, consumed_wh;
     if (battery.current_amps(current, instance)) {
-         current *= 100;
+         current = constrain_float(current * 100,-INT16_MAX,INT16_MAX);
     } else {
         current = -1;
     }
@@ -2031,7 +2031,7 @@ void GCS_MAVLINK::send_battery2()
     if (battery.num_instances() > 1) {
         float current;
         if (battery.current_amps(current, 1)) {
-            current *= 100; // 10*mA
+            current = constrain_float(current * 100,-INT16_MAX,INT16_MAX); // 10*mA
         } else {
             current = -1;
         }
@@ -4167,7 +4167,7 @@ void GCS_MAVLINK::send_sys_status()
 
     if (battery.healthy() && battery.current_amps(battery_current)) {
         battery_remaining = battery.capacity_remaining_pct();
-        battery_current *= 100;
+        battery_current = constrain_float(battery_current * 100,-INT16_MAX,INT16_MAX);
     } else {
         battery_current = -1;
         battery_remaining = -1;


### PR DESCRIPTION
This is a potential fix for wrapping int16 current values in cA. The max we can currently send is 327.7A. This prevents values larger than that wrapping to negative numbers, this does not actually fix the underlying issue, I guess we could change the MAVLink message. This might also trick people into thinking its a valid reading when a negative number is clearly incorrect. Maybe the GCS could display >328A or similar  when it gets a INT16_MAX value.

https://discuss.ardupilot.org/t/maximum-current-on-mission-planner/52185/3?u=iampete
