### PR TITLE
HAL_ChibiOS: fixed stdout in early startup bug

### DIFF
--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -279,8 +279,8 @@ void HAL_ChibiOS::run(int argc, char * const argv[], Callbacks* callbacks) const
      *   RTOS is active.
      */
 
-#ifdef HAL_USB_PRODUCT_ID
-  setup_usb_strings();
+#if HAL_USE_SERIAL_USB == TRUE
+    usb_initialise();
 #endif
 
 #ifdef HAL_STDOUT_SERIAL

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -238,3 +238,6 @@ private:
     void thread_init();
     static void uart_thread(void *);
 };
+
+// access to usb init for stdio.cpp
+void usb_initialise(void);

--- a/libraries/AP_HAL_ChibiOS/stdio.cpp
+++ b/libraries/AP_HAL_ChibiOS/stdio.cpp
@@ -31,6 +31,7 @@
 #include <AP_HAL/AP_HAL.h>
 #if HAL_USE_SERIAL_USB == TRUE
 #include <AP_HAL_ChibiOS/hwdef/common/usbcfg.h>
+#include "UARTDriver.h"
 #endif
 
 extern const AP_HAL::HAL& hal;
@@ -85,6 +86,7 @@ int __wrap_vprintf(const char *fmt, va_list arg)
 #ifdef HAL_STDOUT_SERIAL
   return chvprintf((BaseSequentialStream*)&HAL_STDOUT_SERIAL, fmt, arg);
 #elif HAL_USE_SERIAL_USB == TRUE
+  usb_initialise();
   return chvprintf((BaseSequentialStream*)&SDU1, fmt, arg);
 #else
   (void)arg;


### PR DESCRIPTION
this caused a failure to boot on some boards if they tried to print
messages in early startup code before hal was initialised

thanks to @Shadowru for reporting the issue