### PR TITLE
Scripting: Add a scheduler lock

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -144,6 +144,8 @@ public:
         return extra_loop_us;
     }
 
+    HAL_Semaphore &get_semaphore(void) { return _rsem; }
+
     static const struct AP_Param::GroupInfo var_info[];
 
     // loop performance monitoring:
@@ -223,6 +225,10 @@ private:
     // extra time available for each loop - used to dynamically adjust
     // the loop rate in case we are well over budget
     uint32_t extra_loop_us;
+
+
+    // semaphore that is held while not waiting for ins samples
+    HAL_Semaphore _rsem;
 };
 
 namespace AP {

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -144,6 +144,7 @@ singleton GCS method set_message_interval MAV_RESULT'enum uint8_t 0 MAVLINK_COMM
 
 include AP_Vehicle/AP_Vehicle.h
 singleton AP_Vehicle alias vehicle
+singleton AP_Vehicle scheduler-semaphore
 singleton AP_Vehicle method set_mode boolean uint8_t 0 UINT8_MAX ModeReason::SCRIPTING'literal
 singleton AP_Vehicle method get_mode uint8_t
 singleton AP_Vehicle method get_likely_flying boolean

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -710,8 +710,10 @@ static int AP_Vehicle_get_time_flying_ms(lua_State *L) {
     }
 
     binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
     const uint32_t data = ud->get_time_flying_ms();
 
+    AP::scheduler().get_semaphore().give();
         new_uint32_t(L);
         *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = data;
     return 1;
@@ -724,8 +726,10 @@ static int AP_Vehicle_get_likely_flying(lua_State *L) {
     }
 
     binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
     const bool data = ud->get_likely_flying();
 
+    AP::scheduler().get_semaphore().give();
     lua_pushboolean(L, data);
     return 1;
 }
@@ -737,8 +741,10 @@ static int AP_Vehicle_get_mode(lua_State *L) {
     }
 
     binding_argcheck(L, 1);
+    AP::scheduler().get_semaphore().take_blocking();
     const uint8_t data = ud->get_mode();
 
+    AP::scheduler().get_semaphore().give();
     lua_pushinteger(L, data);
     return 1;
 }
@@ -753,10 +759,12 @@ static int AP_Vehicle_set_mode(lua_State *L) {
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(UINT8_MAX, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    AP::scheduler().get_semaphore().take_blocking();
     const bool data = ud->set_mode(
             data_2,
             ModeReason::SCRIPTING);
 
+    AP::scheduler().get_semaphore().give();
     lua_pushboolean(L, data);
     return 1;
 }


### PR DESCRIPTION
This is the big hammer approach for locking in scripting, it allows us to only run a function call while the vehicle isn't running anything in the scheduler. Where we want to use fine grained locking (IE AHRS which already has locking around it) we don't need to change anything. However in a number of places (vehicle::set_mode and the mission work from @IamPete1) it's impractical to extremely difficult to retrofit any form of locking that prevents race conditions.

To resolve this I've introduced a lock on AP_Scheduler that the scheduler will hold any time the vehicle is running a normal flight control update. This is only released while waiting for an INS sample. This does mean that if you run at crazy fast loop rates your script may be starved from updating, but that would have been the case already as it's a low priority thread, and the vehicle stabilization matters more.

This type of lock may actually be a good utility for some of our other background threads right now, but it's definitely something to be careful with. The main point is because this blocks the main loop whatever is done while holding it must be extremely fast/hold it for the minimal amount of time necessary.

`vehicle:set_mode()` is unsafe to use on a real vehicle at this time until after this change has gone in.