### PR TITLE
AP_Arming/AP_Scripting: allow scripts for pre-arm checks

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -112,10 +112,10 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: CHECK
     // @DisplayName: Arm Checks to Perform (bitmask)
     // @Description: Checks prior to arming motor. This is a bitmask of checks that will be performed before allowing arming. The default is no checks, allowing arming at any time. You can select whatever checks you prefer by adding together the values of each check type to set this parameter. For example, to only allow arming when you have GPS lock and no RC failsafe you would set ARMING_CHECK to 72. For most users it is recommended that you set this to 1 to enable all checks.
-    // @Values: 0:None,1:All,2:Barometer,4:Compass,8:GPS Lock,16:INS(INertial Sensors - accels & gyros),32:Parameters(unused),64:RC Channels,128:Board voltage,256:Battery Level,1024:LoggingAvailable,2048:Hardware safety switch,4096:GPS configuration,8192:System,16384:Mission,32768:RangeFinder,65536:Camera
-    // @Values{Plane}: 0:None,1:All,2:Barometer,4:Compass,8:GPS Lock,16:INS(INertial Sensors - accels & gyros),32:Parameters(unused),64:RC Channels,128:Board voltage,256:Battery Level,512:Airspeed,1024:LoggingAvailable,2048:Hardware safety switch,4096:GPS configuration,8192:System,16384:Mission,32768:RangeFinder,65536:Camera
-    // @Bitmask: 0:All,1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera
-    // @Bitmask{Plane}: 0:All,1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera
+    // @Values: 0:None,1:All,2:Barometer,4:Compass,8:GPS Lock,16:INS(INertial Sensors - accels & gyros),32:Parameters(unused),64:RC Channels,128:Board voltage,256:Battery Level,1024:LoggingAvailable,2048:Hardware safety switch,4096:GPS configuration,8192:System,16384:Mission,32768:RangeFinder,65536:Camera,131072:AuxAuth
+    // @Values{Plane}: 0:None,1:All,2:Barometer,4:Compass,8:GPS Lock,16:INS(INertial Sensors - accels & gyros),32:Parameters(unused),64:RC Channels,128:Board voltage,256:Battery Level,512:Airspeed,1024:LoggingAvailable,2048:Hardware safety switch,4096:GPS configuration,8192:System,16384:Mission,32768:RangeFinder,65536:Camera,131072:AuxAuth
+    // @Bitmask: 0:All,1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth
+    // @Bitmask{Plane}: 0:All,1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth
     // @User: Standard
     AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
@@ -863,6 +863,121 @@ bool AP_Arming::camera_checks(bool display_failure)
     return true;
 }
 
+// request an auxiliary authorisation id.  This id should be used in subsequent calls to set_aux_auth_passed/failed
+// returns true on success
+bool AP_Arming::get_aux_auth_id(uint8_t& auth_id)
+{
+    WITH_SEMAPHORE(aux_auth_sem);
+
+    // check we have enough room to allocate another id
+    if (aux_auth_count >= aux_auth_count_max) {
+        aux_auth_error = true;
+        return false;
+    }
+
+    // allocate buffer for failure message
+    if (aux_auth_fail_msg == nullptr) {
+        aux_auth_fail_msg = (char *)calloc(aux_auth_str_len, sizeof(char));
+        if (aux_auth_fail_msg == nullptr) {
+            aux_auth_error = true;
+            return false;
+        }
+    }
+    auth_id = aux_auth_count;
+    aux_auth_count++;
+    return true;
+}
+
+// set auxiliary authorisation passed
+void AP_Arming::set_aux_auth_passed(uint8_t auth_id)
+{
+    WITH_SEMAPHORE(aux_auth_sem);
+
+    // sanity check auth_id
+    if (auth_id >= aux_auth_count) {
+        return;
+    }
+
+    aux_auth_state[auth_id] = AuxAuthStates::AUTH_PASSED;
+}
+
+// set auxiliary authorisation failed and provide failure message
+void AP_Arming::set_aux_auth_failed(uint8_t auth_id, const char* fail_msg)
+{
+    WITH_SEMAPHORE(aux_auth_sem);
+
+    // sanity check auth_id
+    if (auth_id >= aux_auth_count) {
+        return;
+    }
+
+    // update state
+    aux_auth_state[auth_id] = AuxAuthStates::AUTH_FAILED;
+
+    // store failure message if this authoriser has the lowest auth_id
+    for (uint8_t i = 0; i < auth_id; i++) {
+        if (aux_auth_state[i] == AuxAuthStates::AUTH_FAILED) {
+            return;
+        }
+    }
+    if (aux_auth_fail_msg != nullptr) {
+        if (fail_msg == nullptr) {
+            strncpy(aux_auth_fail_msg, "Auxiliary authorisation refused", aux_auth_str_len);
+        } else {
+            strncpy(aux_auth_fail_msg, fail_msg, aux_auth_str_len);
+        }
+        aux_auth_fail_msg_source = auth_id;
+    }
+}
+
+bool AP_Arming::aux_auth_checks(bool display_failure)
+{
+    // handle error cases
+    if (aux_auth_error) {
+        if (aux_auth_fail_msg == nullptr) {
+            check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "memory low for auxiliary authorisation");
+        } else {
+            check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "Too many auxiliary authorisers");
+        }
+        return false;
+    }
+
+    WITH_SEMAPHORE(aux_auth_sem);
+
+    // check results for each auxiliary authorisation id
+    bool some_failures = false;
+    bool failure_msg_sent = false;
+    bool waiting_for_responses = false;
+    for (uint8_t i = 0; i < aux_auth_count; i++) {
+        switch (aux_auth_state[i]) {
+        case AuxAuthStates::NO_RESPONSE:
+            waiting_for_responses = true;
+            break;
+        case AuxAuthStates::AUTH_FAILED:
+            some_failures = true;
+            if (i == aux_auth_fail_msg_source) {
+                check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "%s", aux_auth_fail_msg);
+                failure_msg_sent = true;
+            }
+            break;
+        case AuxAuthStates::AUTH_PASSED:
+            break;
+        }
+    }
+
+    // send failure or waiting message
+    if (some_failures && !failure_msg_sent) {
+        check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "Auxiliary authorisation refused");
+        return false;
+    } else if (waiting_for_responses) {
+        check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "Waiting for auxiliary authorisation");
+        return false;
+    }
+
+    // if we got this far all auxiliary checks must have passed
+    return true;
+}
+
 bool AP_Arming::pre_arm_checks(bool report)
 {
 #if !APM_BUILD_TYPE(APM_BUILD_ArduCopter)
@@ -888,7 +1003,8 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  system_checks(report)
         &  can_checks(report)
         &  proximity_checks(report)
-        &  camera_checks(report);
+        &  camera_checks(report)
+        &  aux_auth_checks(report);
 }
 
 bool AP_Arming::arm_checks(AP_Arming::Method method)

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -147,7 +147,7 @@ bool AP_Arming::is_armed()
     return (Required)require.get() == Required::NO || armed;
 }
 
-uint16_t AP_Arming::get_enabled_checks()
+uint32_t AP_Arming::get_enabled_checks() const
 {
     return checks_to_perform;
 }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -84,7 +84,7 @@ public:
     bool is_armed();
 
     // get bitmask of enabled checks
-    uint16_t get_enabled_checks();
+    uint32_t get_enabled_checks() const;
 
     // pre_arm_checks() is virtual so it can be modified in a vehicle specific subclass
     virtual bool pre_arm_checks(bool report);

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1236,7 +1236,7 @@ struct PACKED log_Arm_Disarm {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint8_t  arm_state;
-    uint16_t arm_checks;
+    uint32_t arm_checks;
     uint8_t forced;
     uint8_t method;
 };
@@ -1546,7 +1546,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_EVENT_MSG, sizeof(log_Event), \
       "EV",   "QB",           "TimeUS,Id", "s-", "F-" }, \
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm), \
-      "ARM", "QBHBB", "TimeUS,ArmState,ArmChecks,Forced,Method", "s----", "F----" }, \
+      "ARM", "QBIBB", "TimeUS,ArmState,ArmChecks,Forced,Method", "s----", "F----" }, \
     { LOG_ERROR_MSG, sizeof(log_Error), \
       "ERR",   "QBB",         "TimeUS,Subsys,ECode", "s--", "F--" }
 

--- a/libraries/AP_Scripting/examples/arming-check-batt-temp .lua
+++ b/libraries/AP_Scripting/examples/arming-check-batt-temp .lua
@@ -1,0 +1,21 @@
+-- This script runs a custom arming check of the battery temperature
+
+auth_id = arming:get_aux_auth_id()
+batt_temp_max = 35
+
+function update() -- this is the loop which periodically runs
+  if auth_id then
+    now = millis()
+    batt_temp = battery:get_temperature(0)
+    if not batt_temp then
+      arming:set_aux_auth_failed(auth_id, "Could not retrieve battery temperature")
+    elseif (batt_temp >= batt_temp_max) then
+      arming:set_aux_auth_failed(auth_id, "Batt temp too high (" .. tostring(batt_temp) .. "C > " .. tostring(batt_temp_max) .. "C)")
+    else
+      arming:set_aux_auth_passed(auth_id)
+    end
+  end
+  return update, 5000 -- reschedules the loop in 5 seconds
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -41,6 +41,9 @@ singleton AP_Arming alias arming
 singleton AP_Arming method disarm boolean AP_Arming::Method::SCRIPTING'literal
 singleton AP_Arming method is_armed boolean
 singleton AP_Arming method arm boolean AP_Arming::Method::SCRIPTING'literal
+singleton AP_Arming method get_aux_auth_id boolean uint8_t'Null
+singleton AP_Arming method set_aux_auth_passed void uint8_t 0 UINT8_MAX
+singleton AP_Arming method set_aux_auth_failed void uint8_t 0 UINT8_MAX string
 
 include AP_BattMonitor/AP_BattMonitor.h
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1710,6 +1710,59 @@ static int AP_BattMonitor_num_instances(lua_State *L) {
     return 1;
 }
 
+static int AP_Arming_set_aux_auth_failed(lua_State *L) {
+    AP_Arming * ud = AP_Arming::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "arming not supported on this firmware");
+    }
+
+    binding_argcheck(L, 3);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(UINT8_MAX, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const char * data_3 = luaL_checkstring(L, 3);
+    ud->set_aux_auth_failed(
+            data_2,
+            data_3);
+
+    return 0;
+}
+
+static int AP_Arming_set_aux_auth_passed(lua_State *L) {
+    AP_Arming * ud = AP_Arming::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "arming not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(UINT8_MAX, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    ud->set_aux_auth_passed(
+            data_2);
+
+    return 0;
+}
+
+static int AP_Arming_get_aux_auth_id(lua_State *L) {
+    AP_Arming * ud = AP_Arming::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "arming not supported on this firmware");
+    }
+
+    binding_argcheck(L, 1);
+    uint8_t data_5002 = {};
+    const bool data = ud->get_aux_auth_id(
+            data_5002);
+
+    if (data) {
+        lua_pushinteger(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
 static int AP_Arming_arm(lua_State *L) {
     AP_Arming * ud = AP_Arming::get_singleton();
     if (ud == nullptr) {
@@ -2121,6 +2174,9 @@ const luaL_Reg AP_BattMonitor_meta[] = {
 };
 
 const luaL_Reg AP_Arming_meta[] = {
+    {"set_aux_auth_failed", AP_Arming_set_aux_auth_failed},
+    {"set_aux_auth_passed", AP_Arming_set_aux_auth_passed},
+    {"get_aux_auth_id", AP_Arming_get_aux_auth_id},
     {"arm", AP_Arming_arm},
     {"is_armed", AP_Arming_is_armed},
     {"disarm", AP_Arming_disarm},


### PR DESCRIPTION
This PR makes two somewhat unrelated changes:

- Resolves an issue with the onboard LOG message's "ArmChecks" field not displaying all the bits for the enabled checks.  No big deal of course but just so we know, it was this PR that introduced the issue: https://github.com/ArduPilot/ardupilot/pull/12810
- Add the ability for Scripts to stop the vehicle from arming

Below is a screen shot from a bench test where the example script was run on a CubeBlack.  This example script simply disallows arming the vehicle within 60 seconds of boot

![scripting-pre-arm](https://user-images.githubusercontent.com/1498098/74319116-c22d5880-4dc1-11ea-82e7-a624ae9ec55e.png)

Some known issues and thoughts on this change:

- In a follow-up PR I plan to extend support for companion computers to prevent arming using the [MAV_CMD_ARM_AUTHORIZATION_REQUEST](https://mavlink.io/en/messages/common.html#MAV_CMD_ARM_AUTHORIZATION_REQUEST) command
- Only 3 external "authorisers" are supported.  This low number is pretty arbitrary and could be increased easily with only minimal impact on RAM usage.  Each additional authoriser consumes about 42 bytes of RAM most of which is for the string to hold failure messages.
- We could modify the logic so that if there are any failed calls to get_external_auth_id() we disallow arming.  This would protect against cases where there are more than 3 scripts attempting to restrict arming
- There is a slight loophole in that we only protect against arming after the script has made a call to get_external_auth_id().  Theoretically it might be possible for a vehicle to become armed before the script has made the call to get_external_auth_id() although I think in practice this is not possible.
