### PR TITLE
Fix missing parameter / add autotest.py validation of parameter documentation

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -384,6 +384,7 @@ def run_step(step):
         "disable_breakpoints": opts.disable_breakpoints,
         "frame": opts.frame,
         "_show_test_timings": opts.show_test_timings,
+        "validate_parameters": opts.validate_parameters,
     }
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup
@@ -682,6 +683,10 @@ if __name__ == "__main__":
                       action="store_true",
                       default=False,
                       help="show how long each test took to run")
+    parser.add_option("--validate-parameters",
+                      action="store_true",
+                      default=False,
+                      help="validate vehicle parameter files")
 
     group_build = optparse.OptionGroup(parser, "Build options")
     group_build.add_option("--no-configure",

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4141,7 +4141,8 @@ switch value'''
         while True:
             now = self.get_sim_time_cached()
             if now - tstart > 10:
-                raise AutoTestTimeoutException("Failed to download parameters")
+                raise AutoTestTimeoutException("Failed to download parameters  (have %s/%s)" %
+                                               (str(count), str(expected_count)))
             m = self.mav.recv_match(type='PARAM_VALUE', blocking=True, timeout=1)
             if m is None:
                 raise AutoTestTimeoutException("tardy PARAM_VALUE (have %s/%s)" % (

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -54,6 +54,12 @@ vehicle_paths.sort(reverse=True)
 vehicles = []
 libraries = []
 
+# AP_Vehicle also has parameters rooted at "", but isn't referenced
+# from the vehicle in any way:
+ap_vehicle_lib = Library("") # the "" is tacked onto the front of param name
+setattr(ap_vehicle_lib, "Path", os.path.join('..', 'libraries', 'AP_Vehicle', 'AP_Vehicle.cpp'))
+libraries.append(ap_vehicle_lib)
+
 error_count = 0
 current_param = None
 current_file = None
@@ -166,7 +172,7 @@ def process_library(vehicle, library, pathprefix=None):
             p_text = f.read()
             f.close()
         else:
-            error("Path %s not found for library %s" % (path, library.name))
+            error("Path %s not found for library %s (fname=%s)" % (path, library.name, libraryfname))
             continue
 
         param_matches = prog_param.findall(p_text)


### PR DESCRIPTION
This is an option (not used on our autotest server) to validate that any parameter we download from the vehicle directly after a reboot is present in the generated documentation.

Also adds the runcam documentation to the xml....
