### PR TITLE
AP_Baro: Change Message and Deleite variable

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -232,9 +232,8 @@ void AP_Baro::calibrate(bool save)
     // now average over 5 values for the ground pressure settings
     float sum_pressure[BARO_MAX_INSTANCES] = {0};
     uint8_t count[BARO_MAX_INSTANCES] = {0};
-    const uint8_t num_samples = 5;
 
-    for (uint8_t c = 0; c < num_samples; c++) {
+    for (uint8_t c = 0; c < 5; c++) {
         uint32_t tstart = AP_HAL::millis();
         do {
             update();

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -239,7 +239,7 @@ void AP_Baro::calibrate(bool save)
         do {
             update();
             if (AP_HAL::millis() - tstart > 500) {
-                AP_BoardConfig::config_error("Baro: unable to calibrate");
+                AP_BoardConfig::config_error("Baro: unable to calibrate 2nd");
             }
         } while (!healthy());
         for (uint8_t i=0; i<_num_sensors; i++) {
@@ -273,7 +273,7 @@ void AP_Baro::calibrate(bool save)
     if (num_calibrated) {
         return;
     }
-    AP_BoardConfig::config_error("AP_Baro: all sensors uncalibrated");
+    AP_BoardConfig::config_error("Baro: all sensors uncalibrated");
 }
 
 /*


### PR DESCRIPTION
1. I output the same message in both processes. I clarify whether it was detected in the first process or the second process.
2. I think it's better to unify the title of the message to "Baro".
3. I don't need to use a variable for the number of repetitions in GDB, just rewrite the code. Therefore, it is changed to the direct value.