### PR TITLE
Copter: classify enum definition RTLstate and SmartRTL state

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -107,12 +107,12 @@ enum GuidedMode {
 };
 
 // Safe RTL states
-enum SmartRTLState {
-    SmartRTL_WaitForPathCleanup,
-    SmartRTL_PathFollow,
-    SmartRTL_PreLandPosition,
-    SmartRTL_Descend,
-    SmartRTL_Land
+enum  class SmartRTLState {
+    WaitForPathCleanup,
+    PathFollow,
+    PreLandPosition,
+    Descend,
+    Land
 };
 
 enum PayloadPlaceStateType {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1030,13 +1030,13 @@ public:
     bool get_wp(Location &loc) override;
 
     // RTL states
-    enum RTLState {
-        RTL_Starting,
-        RTL_InitialClimb,
-        RTL_ReturnHome,
-        RTL_LoiterAtHome,
-        RTL_FinalDescent,
-        RTL_Land
+    enum class RTLState {
+        Starting,
+        InitialClimb,
+        ReturnHome,
+        LoiterAtHome,
+        FinalDescent,
+        Land
     };
     RTLState state() { return _state; }
 
@@ -1082,7 +1082,7 @@ private:
     void build_path();
     void compute_return_target();
 
-    RTLState _state = RTL_InitialClimb;  // records state of rtl (initial climb, returning home, etc)
+    RTLState _state = RTLState::InitialClimb;  // records state of rtl (initial climb, returning home, etc)
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {
@@ -1142,7 +1142,7 @@ private:
     void path_follow_run();
     void pre_land_position_run();
     void land();
-    SmartRTLState smart_rtl_state = SmartRTL_PathFollow;
+    SmartRTLState smart_rtl_state = SmartRTLState::PathFollow;
 
 };
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1755,7 +1755,7 @@ bool ModeAuto::verify_loiter_to_alt()
 bool ModeAuto::verify_RTL()
 {
     return (copter.mode_rtl.state_complete() && 
-            (copter.mode_rtl.state() == ModeRTL::RTL_FinalDescent || copter.mode_rtl.state() == ModeRTL::RTL_Land) &&
+            (copter.mode_rtl.state() == ModeRTL::RTLState::FinalDescent || copter.mode_rtl.state() == ModeRTL::RTLState::Land) &&
             (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
 }
 

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -19,7 +19,7 @@ bool ModeRTL::init(bool ignore_checks)
     }
     // initialise waypoint and spline controller
     wp_nav->wp_and_spline_init();
-    _state = RTL_Starting;
+    _state = RTLState::Starting;
     _state_complete = true; // see run() method below
     terrain_following_allowed = !copter.failsafe.terrain;
     return true;
@@ -30,7 +30,7 @@ void ModeRTL::restart_without_terrain()
 {
     AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::RESTARTED_RTL);
     terrain_following_allowed = false;
-    _state = RTL_Starting;
+    _state = RTLState::Starting;
     _state_complete = true;
     gcs().send_text(MAV_SEVERITY_CRITICAL,"Restarting RTL - Terrain data missing");
 }
@@ -55,27 +55,27 @@ void ModeRTL::run(bool disarm_on_land)
     // check if we need to move to next state
     if (_state_complete) {
         switch (_state) {
-        case RTL_Starting:
+        case RTLState::Starting:
             build_path();
             climb_start();
             break;
-        case RTL_InitialClimb:
+        case RTLState::InitialClimb:
             return_start();
             break;
-        case RTL_ReturnHome:
+        case RTLState::ReturnHome:
             loiterathome_start();
             break;
-        case RTL_LoiterAtHome:
+        case RTLState::LoiterAtHome:
             if (rtl_path.land || copter.failsafe.radio) {
                 land_start();
             }else{
                 descent_start();
             }
             break;
-        case RTL_FinalDescent:
+        case RTLState::FinalDescent:
             // do nothing
             break;
-        case RTL_Land:
+        case RTLState::Land:
             // do nothing - rtl_land_run will take care of disarming motors
             break;
         }
@@ -84,28 +84,28 @@ void ModeRTL::run(bool disarm_on_land)
     // call the correct run function
     switch (_state) {
 
-    case RTL_Starting:
+    case RTLState::Starting:
         // should not be reached:
-        _state = RTL_InitialClimb;
+        _state = RTLState::InitialClimb;
         FALLTHROUGH;
 
-    case RTL_InitialClimb:
+    case RTLState::InitialClimb:
         climb_return_run();
         break;
 
-    case RTL_ReturnHome:
+    case RTLState::ReturnHome:
         climb_return_run();
         break;
 
-    case RTL_LoiterAtHome:
+    case RTLState::LoiterAtHome:
         loiterathome_run();
         break;
 
-    case RTL_FinalDescent:
+    case RTLState::FinalDescent:
         descent_run();
         break;
 
-    case RTL_Land:
+    case RTLState::Land:
         land_run(disarm_on_land);
         break;
     }
@@ -114,7 +114,7 @@ void ModeRTL::run(bool disarm_on_land)
 // rtl_climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
-    _state = RTL_InitialClimb;
+    _state = RTLState::InitialClimb;
     _state_complete = false;
 
     // RTL_SPEED == 0 means use WPNAV_SPEED
@@ -139,7 +139,7 @@ void ModeRTL::climb_start()
 // rtl_return_start - initialise return to home
 void ModeRTL::return_start()
 {
-    _state = RTL_ReturnHome;
+    _state = RTLState::ReturnHome;
     _state_complete = false;
 
     if (!wp_nav->set_wp_destination(rtl_path.return_target)) {
@@ -196,7 +196,7 @@ void ModeRTL::climb_return_run()
 // rtl_loiterathome_start - initialise return to home
 void ModeRTL::loiterathome_start()
 {
-    _state = RTL_LoiterAtHome;
+    _state = RTLState::LoiterAtHome;
     _state_complete = false;
     _loiter_start_time = millis();
 
@@ -263,7 +263,7 @@ void ModeRTL::loiterathome_run()
 // rtl_descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
-    _state = RTL_FinalDescent;
+    _state = RTLState::FinalDescent;
     _state_complete = false;
 
     // Set wp navigation target to above home
@@ -343,7 +343,7 @@ void ModeRTL::descent_run()
 // rtl_loiterathome_start - initialise controllers to loiter over home
 void ModeRTL::land_start()
 {
-    _state = RTL_Land;
+    _state = RTLState::Land;
     _state_complete = false;
 
     // Set wp navigation target to above home
@@ -361,15 +361,15 @@ void ModeRTL::land_start()
 
 bool ModeRTL::is_landing() const
 {
-    return _state == RTL_Land;
+    return _state == RTLState::Land;
 }
 
 bool ModeRTL::landing_gear_should_be_deployed() const
 {
     switch(_state) {
-    case RTL_LoiterAtHome:
-    case RTL_Land:
-    case RTL_FinalDescent:
+    case RTLState::LoiterAtHome:
+    case RTLState::Land:
+    case RTLState::FinalDescent:
         return true;
     default:
         return false;
@@ -545,13 +545,13 @@ bool ModeRTL::get_wp(Location& destination)
 {
     // provide target in states which use wp_nav
     switch (_state) {
-    case RTL_Starting:
-    case RTL_InitialClimb:
-    case RTL_ReturnHome:
-    case RTL_LoiterAtHome:
-    case RTL_FinalDescent:
+    case RTLState::Starting:
+    case RTLState::InitialClimb:
+    case RTLState::ReturnHome:
+    case RTLState::LoiterAtHome:
+    case RTLState::FinalDescent:
         return wp_nav->get_oa_wp_destination(destination);
-    case RTL_Land:
+    case RTLState::Land:
         return false;
     }
 


### PR DESCRIPTION
I make RTL state, enum definition of smart RTL state a class.
I thought the class enum definition was better than adding "RTL_" and "SmartRTL_" to the definition.