### PR TITLE
Copter: Make Auto and Guided mode definitions enum classes

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -123,10 +123,10 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     Vector3f target_vel;
     uint16_t type_mask;
 
-    if (guided_mode == Guided_WP) {
+    if (guided_mode == GuidedMode::WP) {
         type_mask = 0x0FF8; // ignore everything except position
         target_pos = copter.wp_nav->get_wp_destination() * 0.01f; // convert to metres
-    } else if (guided_mode == Guided_Velocity) {
+    } else if (guided_mode == GuidedMode::Velocity) {
         type_mask = 0x0FC7; // ignore everything except velocity
         target_vel = copter.flightmode->get_desired_velocity() * 0.01f; // convert to m/s
     } else {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -83,27 +83,27 @@ enum tuning_func {
 #define WP_YAW_BEHAVIOR_LOOK_AHEAD                    3   // auto pilot will look ahead during missions and rtl (primarily meant for traditional helicopters)
 
 // Auto modes
-enum AutoMode {
-    Auto_TakeOff,
-    Auto_WP,
-    Auto_Land,
-    Auto_RTL,
-    Auto_CircleMoveToEdge,
-    Auto_Circle,
-    Auto_Spline,
-    Auto_NavGuided,
-    Auto_Loiter,
-    Auto_LoiterToAlt,
-    Auto_NavPayloadPlace,
+enum class AutoMode {
+    TakeOff,
+    WP,
+    Land,
+    RTL,
+    CircleMoveToEdge,
+    Circle,
+    Spline,
+    NavGuided,
+    Loiter,
+    LoiterToAlt,
+    NavPayloadPlace,
 };
 
 // Guided modes
-enum GuidedMode {
-    Guided_TakeOff,
-    Guided_WP,
-    Guided_Velocity,
-    Guided_PosVel,
-    Guided_Angle,
+enum class GuidedMode : uint8_t {
+    TakeOff,
+    WP,
+    Velocity,
+    PosVel,
+    Angle,
 };
 
 // Safe RTL states

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -343,7 +343,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return false; };
     bool is_autopilot() const override { return true; }
-    bool in_guided_mode() const override { return mode() == Auto_NavGuided; }
+    bool in_guided_mode() const override { return mode() == AutoMode::NavGuided; }
 
     // Auto
     AutoMode mode() const { return _mode; }
@@ -418,7 +418,7 @@ private:
     void payload_place_run_descend();
     void payload_place_run_release();
 
-    AutoMode _mode = Auto_TakeOff;   // controls which auto controller is run
+    AutoMode _mode = AutoMode::TakeOff;   // controls which auto controller is run
 
     Location terrain_adjusted_location(const AP_Mission::Mission_Command& cmd) const;
 
@@ -827,7 +827,7 @@ private:
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
 
     // controls which controller is run (pos or vel):
-    GuidedMode guided_mode = Guided_TakeOff;
+    GuidedMode guided_mode = GuidedMode::TakeOff;
 
 };
 


### PR DESCRIPTION
I think it is better to classify rather than add the mode to the definition of Auto mode and the definition name of Guided mode.