### PR TITLE
Copter: move AC_Circle navigation library into Mode object

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -461,10 +461,6 @@ private:
     AC_WPNav *wp_nav;
     AC_Loiter *loiter_nav;
 
-#if MODE_CIRCLE_ENABLED == ENABLED
-    AC_Circle *circle_nav;
-#endif
-
     // System Timers
     // --------------
     // arm_time_ms - Records when vehicle was armed. Will be Zero if we are disarmed.

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -25,6 +25,7 @@
 #define GGROUP(v, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## v, &copter.g.v, {group_info : class::var_info} }
 #define GOBJECT(v, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## v, (const void *)&copter.v, {group_info : class::var_info} }
 #define GOBJECTPTR(v, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## v, (const void *)&copter.v, {group_info : class::var_info}, AP_PARAM_FLAG_POINTER }
+#define GOBJECTNPTR(v, pname, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## pname, (const void *)&copter.v, {group_info : class::var_info}, AP_PARAM_FLAG_POINTER }
 #define GOBJECTVARPTR(v, name, var_info_ptr) { AP_PARAM_GROUP, name, Parameters::k_param_ ## v, (const void *)&copter.v, {group_info_ptr : var_info_ptr}, AP_PARAM_FLAG_POINTER | AP_PARAM_FLAG_INFO_POINTER }
 #define GOBJECTN(v, pname, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## pname, (const void *)&copter.v, {group_info : class::var_info} }
 
@@ -513,7 +514,8 @@ const AP_Param::Info Copter::var_info[] = {
 #if MODE_CIRCLE_ENABLED == ENABLED
     // @Group: CIRCLE_
     // @Path: ../libraries/AC_WPNav/AC_Circle.cpp
-    GOBJECTPTR(circle_nav, "CIRCLE_",  AC_Circle),
+    GOBJECTNPTR(mode_circle.circle_nav, circle_nav, "CIRCLE_",  AC_Circle),
+    // note that circle_nav is static in the mode base class - we just need an object here
 #endif
 
     // @Group: ATC_

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -23,7 +23,17 @@ Mode::Mode(void) :
     channel_throttle(copter.channel_throttle),
     channel_yaw(copter.channel_yaw),
     G_Dt(copter.G_Dt)
-{ };
+{
+#if MODE_CIRCLE_ENABLED == ENABLED
+    circle_nav = new AC_Circle(inertial_nav, *copter.ahrs_view, *pos_control);
+    if (circle_nav == nullptr) {
+        AP_HAL::panic("Unable to allocate CircleNav");
+    }
+    AP_Param::load_object_from_eeprom(circle_nav, circle_nav->var_info);
+#endif
+};
+
+AC_Circle *Mode::circle_nav;
 
 // return the static controller object corresponding to supplied mode
 Mode *Copter::mode_from_mode_num(const Mode::Number mode)

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -93,6 +93,12 @@ public:
         return pos_control->get_desired_velocity();
     }
 
+    // this is out here so Parameters.cpp can get an circle_nav.
+    // Should not be accessed directly outside the Mode hierachy
+#if MODE_CIRCLE_ENABLED == ENABLED
+    static AC_Circle *circle_nav;
+#endif
+
 protected:
 
     // navigation support functions

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -587,14 +587,6 @@ void Copter::allocate_motors(void)
     }
     AP_Param::load_object_from_eeprom(loiter_nav, loiter_nav->var_info);
 
-#if MODE_CIRCLE_ENABLED == ENABLED
-    circle_nav = new AC_Circle(inertial_nav, *ahrs_view, *pos_control);
-    if (circle_nav == nullptr) {
-        AP_HAL::panic("Unable to allocate CircleNav");
-    }
-    AP_Param::load_object_from_eeprom(circle_nav, circle_nav->var_info);
-#endif
-
     // reload lines from the defaults file that may now be accessible
     AP_Param::reload_defaults_file(true);
     

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -138,7 +138,7 @@ void Copter::tuning()
 
 #if MODE_CIRCLE_ENABLED == ENABLED
     case TUNING_CIRCLE_RATE:
-        circle_nav->set_rate(tuning_value);
+        flightmode->circle_nav->set_rate(tuning_value);
         break;
 #endif
 


### PR DESCRIPTION
Nothing outside the mode needs to know we even have one of these.
Methods in the flightmode object return things like the current desired
heading already.


The parameter stuff seems to work; circle parameters keep their value after applying this patch.
