### PR TITLE
Copter: Throttle can be operated during landing

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -547,6 +547,11 @@ void Mode::land_run_vertical_control(bool pause_descent)
             cmb_rate = MIN(-precland_min_descent_speed, -max_descent_speed+land_slowdown);
         }
 #endif
+        // If throttle operation has been performed, give priority to throttle operation
+        float throttle_cmb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+        if (throttle_cmb_rate < cmb_rate || throttle_cmb_rate > 0.55f) {
+            cmb_rate = constrain_float(throttle_cmb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
+        }
     }
 
     // update altitude target and call position controller


### PR DESCRIPTION
I can't go up or down by throttle while landing in landing mode.
I don't think safety is tied to fixed landing speed.
When I drive a car at a fixed speed, when another car interrupts or tries to interrupt, I change the speed with the accelerator.
I have a similar disturbance in Copter.
I can respond to disturbances while landing in landing mode.