### PR TITLE
GCS_MAVLink: don't recalculate max parameter count if not streaming p…

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -37,6 +37,12 @@ GCS_MAVLINK::queued_param_send()
     // send parameter async replies
     uint8_t async_replies_sent_count = send_parameter_async_replies();
 
+    // now send the streaming parameters (from PARAM_REQUEST_LIST)
+    if (_queued_parameter == nullptr) {
+        // .... or not....
+        return;
+    }
+
     const uint32_t tnow = AP_HAL::millis();
     const uint32_t tstart = AP_HAL::micros();
 
@@ -63,10 +69,6 @@ GCS_MAVLINK::queued_param_send()
         return;
     }
     count -= async_replies_sent_count;
-
-    if (_queued_parameter == nullptr) {
-        return;
-    }
 
     while (count && _queued_parameter != nullptr) {
         char param_name[AP_MAX_NAME_SIZE];


### PR DESCRIPTION
…arams


We went to a lot of trouble to calculate the maximum number of parameters to send.  And then didn't use it the vast majority of the time.
