### PR TITLE
AP_HAL_ChibiOS: Detect SD card error

### DIFF
--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -81,7 +81,9 @@ bool sdcard_init()
         printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
 
         // Create APM Directory if needed
-        AP::FS().mkdir("/APM");
+        if (AP::FS().mkdir("/APM") != 0 && errno != EEXIST) {
+            return false;
+        }
         sdcard_running = true;
         return true;
     }
@@ -126,7 +128,9 @@ bool sdcard_init()
         printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
 
         // Create APM Directory if needed
-        AP::FS().mkdir("/APM");
+        if (AP::FS().mkdir("/APM") != 0 && errno != EEXIST) {
+            return false;
+        }
         return true;
     }
 #endif


### PR DESCRIPTION
I think if the "APM" directory cannot be created on the SD card, there is something wrong with the SD card.
I don't know why mkdir doesn't judge the result.
I think SD cards are incomplete.