### PR TITLE
Tools: FilterTestTool fix open .BIN files on case sensitive systems

### DIFF
--- a/Tools/FilterTestTool/run_filter_test.py
+++ b/Tools/FilterTestTool/run_filter_test.py
@@ -51,7 +51,7 @@ if not log_file:
     root = Tk()
     root.withdraw()
     root.focus_force()
-    log_file = askopenfilename(title="Select log file", filetypes=(("log files", ".bin .log"), ("all files", "*.*")))
+    log_file = askopenfilename(title="Select log file", filetypes=(("log files", ".BIN .bin .log"), ("all files", "*.*")))
     root.update()
     root.destroy()
 


### PR DESCRIPTION
As the default name is capital .BIN, on my linux system it was not shown with small .bin