### PR TITLE
Plane: added Q_ASSIST_DELAY parameter

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -247,7 +247,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     
     // @Param: ASSIST_ANGLE
     // @DisplayName: Quadplane assistance angle
-    // @Description: This is the angular error in attitude beyond which the quadplane VTOL motors will provide stability assistance. This will only be used if Q_ASSIST_SPEED is also non-zero. Assistance will be given if the attitude is outside the normal attitude limits by at least 5 degrees and the angular error in roll or pitch is greater than this angle for at least 1 second. Set to zero to disable angle assistance.
+    // @Description: This is the angular error in attitude beyond which the quadplane VTOL motors will provide stability assistance. This will only be used if Q_ASSIST_SPEED is also non-zero. Assistance will be given if the attitude is outside the normal attitude limits by at least 5 degrees and the angular error in roll or pitch is greater than this angle for at least Q_ASSIST_DELAY seconds. Set to zero to disable angle assistance.
     // @Units: deg
     // @Range: 0 90
     // @Increment: 1

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -484,6 +484,15 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Standard
     AP_GROUPINFO("TAILSIT_GSCMIN", 18, QuadPlane, tailsitter.gain_scaling_min, 0.4),
 
+    // @Param: ASSIST_DELAY
+    // @DisplayName: Quadplane assistance delay
+    // @Description: This is delay between the assistance thresholds being met and the assistance starting.
+    // @Units: s
+    // @Range: 0 2
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("ASSIST_DELAY", 19, QuadPlane, assist_delay, 0.5),
+    
     AP_GROUPEND
 };
 
@@ -1474,8 +1483,8 @@ bool QuadPlane::assistance_needed(float aspeed, bool have_airspeed)
             if (alt_error_start_ms == 0) {
                 alt_error_start_ms = now;
             }
-            if (now - alt_error_start_ms > 500) {
-                // we've been below assistant alt for 0.5s
+            if (now - alt_error_start_ms > assist_delay*1000) {
+                // we've been below assistant alt for Q_ASSIST_DELAY seconds
                 if (!in_alt_assist) {
                     in_alt_assist = true;
                     gcs().send_text(MAV_SEVERITY_INFO, "Alt assist %.1fm", height_above_ground);
@@ -1520,7 +1529,7 @@ bool QuadPlane::assistance_needed(float aspeed, bool have_airspeed)
     if (angle_error_start_ms == 0) {
         angle_error_start_ms = now;
     }
-    bool ret = (now - angle_error_start_ms) >= 1000U;
+    bool ret = (now - angle_error_start_ms) >= assist_delay*1000;
     if (ret && !in_angle_assist) {
         in_angle_assist = true;
         gcs().send_text(MAV_SEVERITY_INFO, "Angle assist r=%d p=%d",

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -294,6 +294,7 @@ private:
     // angular error at which quad assistance is given
     AP_Int8 assist_angle;
     uint32_t angle_error_start_ms;
+    AP_Float assist_delay;
 
     // altitude to trigger assistance
     AP_Int16 assist_alt;

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -450,10 +450,26 @@ class AutoTestQuadPlane(AutoTest):
                                       timeout=30,
                                       comparator=operator.eq)
         self.set_rc(3, 1500)
+
+        self.context_push()
+        self.progress("Rolling over hard")
+        self.set_rc(1, 1000)
+        self.wait_roll(-65, 5)
+        self.progress("Killing servo outputs to force qassist to help")
+        self.set_parameter("SERVO1_MIN", 1500)
+        self.set_parameter("SERVO1_MAX", 1500)
+        self.set_parameter("SERVO1_TRIM", 1500)
+        self.progress("Trying ot roll over hard the other way")
+        self.set_rc(1, 2000)
+        self.progress("Waiting for qassist (angle) to kick in")
+        self.wait_servo_channel_value(5, 1100, timeout=30, comparator=operator.gt)
+        self.wait_roll(85, 5)
+        self.context_pop()
+
         self.change_mode("RTL")
         self.delay_sim_time(20)
         self.change_mode("QRTL")
-        self.wait_disarmed(timeout=180)
+        self.wait_disarmed(timeout=300)
 
     def tests(self):
         '''return list of all tests'''


### PR DESCRIPTION
this allows tuning of the time between assistance thresholds being met
and assistance kicking in. It also changes the default delay from 1s
down to 0.5s based on analysis of a flight where assistance was too
slow