### PR TITLE
Plane: prevent failsafe from changing mode during landing

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -40,6 +40,13 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
         break;
         
     case Mode::Number::AUTO:
+        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND ||
+            quadplane.in_vtol_land_sequence()) {
+            // don't failsafe in a landing sequence
+            break;
+        }
+        FALLTHROUGH;
+
     case Mode::Number::AVOID_ADSB:
     case Mode::Number::GUIDED:
     case Mode::Number::LOITER:
@@ -107,6 +114,13 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
         break;
         
     case Mode::Number::AUTO:
+        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND ||
+            quadplane.in_vtol_land_sequence()) {
+            // don't failsafe in a landing sequence
+            break;
+        }
+        FALLTHROUGH;
+
     case Mode::Number::AVOID_ADSB:
     case Mode::Number::GUIDED:
     case Mode::Number::LOITER:


### PR DESCRIPTION
this prevents RC or GCS failsafe from triggering a mode change during
a landing