### PR TITLE
Create autotest to ensure parameters are always documented

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -284,9 +284,11 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Path: ../libraries/AP_Notify/AP_Notify.cpp
     GOBJECT(notify, "NTF_",  AP_Notify),
 
-    // @Path: RC_Channels.cpp
+    // @Group: RC
+    // @Path: ../libraries/RC_Channel/RC_Channels_VarInfo.h
     GOBJECT(rc_channels,     "RC", RC_Channels_Tracker),
 
+    // @Group: SERVO
     // @Path: ../libraries/SRV_Channel/SRV_Channels.cpp
     GOBJECT(servo_channels,     "SERVO", SRV_Channels),
     
@@ -322,6 +324,37 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Range: 0.001 0.1
     // @Increment: 0.001
     // @User: Standard
+
+    // @Param: PITCH2SRV_FF
+    // @DisplayName: Pitch axis controller feed forward
+    // @Description: Pitch axis controller feed forward
+    // @Range: 0 0.5
+    // @Increment: 0.001
+    // @User: Standard
+
+    // @Param: PITCH2SRV_FLTT
+    // @DisplayName: Pitch axis controller target frequency in Hz
+    // @Description: Pitch axis controller target frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: PITCH2SRV_FLTE
+    // @DisplayName: Pitch axis controller error frequency in Hz
+    // @Description: Pitch axis controller error frequency in Hz
+    // @Range: 1 100
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: PITCH2SRV_FLTD
+    // @DisplayName: Pitch axis controller derivative frequency in Hz
+    // @Description: Pitch axis controller derivative frequency in Hz
+    // @Range: 1 100
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
 	GGROUP(pidPitch2Srv,       "PITCH2SRV_", AC_PID),
 
     // @Param: YAW2SRV_P
@@ -351,6 +384,37 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Description: Yaw axis controller D gain.  Compensates for short-term change in desired yaw angle (heading) vs actual yaw angle
     // @Range: 0.001 0.1
     // @Increment: 0.001
+    // @User: Standard
+
+    // @Param: YAW2SRV_FF
+    // @DisplayName: Yaw axis controller feed forward
+    // @Description: Yaw axis controller feed forward
+    // @Range: 0 0.5
+    // @Increment: 0.001
+    // @User: Standard
+
+    // @Param: YAW2SRV_FLTT
+    // @DisplayName: Yaw axis controller target frequency in Hz
+    // @Description: Yaw axis controller target frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: YAW2SRV_FLTE
+    // @DisplayName: Yaw axis controller error frequency in Hz
+    // @Description: Yaw axis controller error frequency in Hz
+    // @Range: 1 100
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: YAW2SRV_FLTD
+    // @DisplayName: Yaw axis controller derivative frequency in Hz
+    // @Description: Yaw axis controller derivative frequency in Hz
+    // @Range: 1 100
+    // @Increment: 1
+    // @Units: Hz
     // @User: Standard
 	GGROUP(pidYaw2Srv,         "YAW2SRV_", AC_PID),
 
@@ -409,7 +473,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @User: Standard
     GSCALAR(disarm_pwm,              "SAFE_DISARM_PWM",        0),
 
-    // @Group: STAT_
+    // @Group: STAT
     // @Path: ../libraries/AP_Stats/AP_Stats.cpp
     GOBJECT(stats, "STAT",  AP_Stats),
 

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -384,7 +384,6 @@ def run_step(step):
         "disable_breakpoints": opts.disable_breakpoints,
         "frame": opts.frame,
         "_show_test_timings": opts.show_test_timings,
-        "validate_parameters": opts.validate_parameters,
     }
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -34,7 +34,7 @@ args = parser.parse_args()
 
 # Regular expressions for parsing the parameter metadata
 
-prog_param = re.compile(r"@Param: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: (.*))+)(?:\n\n|\n[ \t]+[A-Z])", re.MULTILINE)
+prog_param = re.compile(r"@Param: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: (.*))+)(?:\n[ \t]*\n|\n[ \t]+[A-Z])", re.MULTILINE)
 
 # match e.g @Value: 0=Unity, 1=Koala, 17=Liability
 prog_param_fields = re.compile(r"[ \t]*// @(\w+): (.*)")

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("WP_COMMS",    2, AP_AdvancedFailsafe, _wp_comms_hold, 0),
 
-    // @Param: GPS_LOSS
+    // @Param: WP_GPS_LOSS
     // @DisplayName: GPS Loss Waypoint
     // @Description: Waypoint number to navigate to on GPS lock loss
     // @User: Advanced

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -117,7 +117,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("IDLE_RPM", 12, AP_ICEngine, idle_rpm, -1),
 
-    // @Param: ICE_IDLE_DB
+    // @Param: IDLE_DB
     // @DisplayName: Deadband for Idle Governor
     // @Description: This configures the deadband that is tolerated before adjusting the idle setpoint
     AP_GROUPINFO("IDLE_DB", 13, AP_ICEngine, idle_db, 50),

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -25,7 +25,6 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: Q1
     // @DisplayName: Process noise
     // @Description: Standard deviation of noise in process for strength
-    // @Units:
     // @Range: 0 10
     // @User: Advanced
     AP_GROUPINFO("Q1", 3, SoaringController, thermal_q1, 0.001f),
@@ -33,7 +32,6 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: Q2
     // @DisplayName: Process noise
     // @Description: Standard deviation of noise in process for position and radius
-    // @Units:
     // @Range: 0 10
     // @User: Advanced
     AP_GROUPINFO("Q2", 4, SoaringController, thermal_q2, 0.03f),
@@ -41,7 +39,6 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: R
     // @DisplayName: Measurement noise
     // @Description: Standard deviation of noise in measurement
-    // @Units:
     // @Range: 0 10
     // @User: Advanced
 
@@ -74,7 +71,6 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: POLAR_CD0
     // @DisplayName: Zero lift drag coef.
     // @Description: Zero lift drag coefficient
-    // @Units:
     // @Range: 0 0.5
     // @User: Advanced
     AP_GROUPINFO("POLAR_CD0", 9, SoaringController, polar_CD0, 0.027),
@@ -82,7 +78,6 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: POLAR_B
     // @DisplayName: Induced drag coeffient
     // @Description: Induced drag coeffient
-    // @Units:
     // @Range: 0 0.5
     // @User: Advanced
     AP_GROUPINFO("POLAR_B", 10, SoaringController, polar_B, 0.031),

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
@@ -54,6 +54,30 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Range: 1.000 100.000
     // @Units: Hz
     // @User: Standard
+
+    // @Param: _RATE_FLTT
+    // @DisplayName: Wheel rate control target frequency in Hz
+    // @Description: Wheel rate control target frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _RATE_FLTE
+    // @DisplayName: Wheel rate control error frequency in Hz
+    // @Description: Wheel rate control error frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _RATE_FLTD
+    // @DisplayName: Wheel rate control derivative frequency in Hz
+    // @Description: Wheel rate control derivative frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
     AP_SUBGROUPINFO(_rate_pid0, "_RATE_", 3, AP_WheelRateControl, AC_PID),
 
     // @Param: 2_RATE_FF
@@ -92,6 +116,31 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Range: 1.000 100.000
     // @Units: Hz
     // @User: Standard
+
+    // @Param: 2_RATE_FLTT
+    // @DisplayName: Wheel rate control target frequency in Hz
+    // @Description: Wheel rate control target frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: 2_RATE_FLTE
+    // @DisplayName: Wheel rate control error frequency in Hz
+    // @Description: Wheel rate control error frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: 2_RATE_FLTD
+    // @DisplayName: Wheel rate control derivative frequency in Hz
+    // @Description: Wheel rate control derivative frequency in Hz
+    // @Range: 1 50
+    // @Increment: 1
+    // @Units: Hz
+    // @User: Standard
+
     AP_SUBGROUPINFO(_rate_pid1, "2_RATE_", 4, AP_WheelRateControl, AC_PID),
 
     AP_GROUPEND


### PR DESCRIPTION
The following parameters are not documented and will cause this PR to fail to pass autotest ATM.

ArduPlane:
```
ICE_IDLE_DB not in XML
AFS_WP_GPS_LOSS not in XML
SOAR_POLAR_B not in XML
SOAR_Q2 not in XML
SOAR_Q1 not in XML
SOAR_POLAR_CD0 not in XML
SOAR_R not in XML
```


ArduCopter: None

Helicopter: 
```
H_SW_H3_SV3_POS not in XML
```

ArduSub: None

APMrover2:
```
WRC2_RATE_FLTD not in XML
WRC2_RATE_FLTE not in XML
WRC2_RATE_FLTT not in XML
WRC_RATE_FLTE not in XML
WRC_RATE_FLTD not in XML
WRC_RATE_FLTT not in XML
```

Tracker: too many to list
