### PR TITLE
Avoid acting on first RC input from receiver

### DIFF
--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -27,11 +27,10 @@ void RC_Channel_Rover::mode_switch_changed(modeswitch_pos_t new_pos)
     }
 }
 
-// init_aux_switch_function - initialize aux functions
-void RC_Channel_Rover::init_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+// init_aux - initialize aux functions
+void RC_Channel_Rover::init_aux()
 {
-    // init channel options
-    switch (ch_option) {
+    switch ((aux_func_t)option.get()) {
     // the following functions do not need initialising:
     case AUX_FUNC::ACRO:
     case AUX_FUNC::AUTO:
@@ -51,10 +50,10 @@ void RC_Channel_Rover::init_aux_function(const aux_func_t ch_option, const aux_s
     case AUX_FUNC::STEERING:
         break;
     case AUX_FUNC::SAILBOAT_MOTOR_3POS:
-        do_aux_function_sailboat_motor_3pos(ch_flag);
+        do_aux_function_sailboat_motor_3pos(aux_switch_pos_t::LOW);
         break;
     default:
-        RC_Channel::init_aux_function(ch_option, ch_flag);
+        RC_Channel::init_aux();
         break;
     }
 }

--- a/APMrover2/RC_Channel.h
+++ b/APMrover2/RC_Channel.h
@@ -11,7 +11,7 @@ public:
 
 protected:
 
-    void init_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
+    void init_aux() override;
     void do_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
 
     // called when the mode switch changes position:

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -59,8 +59,10 @@ bool RC_Channels_Copter::has_valid_input() const
 
 
 // init_aux_switch_function - initialize aux functions
-void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+void RC_Channel_Copter::init_aux()
 {
+    const aux_func_t ch_option = (aux_func_t)option.get();
+
     // init channel options
     switch(ch_option) {
     // the following functions do not need to be initialised:
@@ -107,10 +109,12 @@ void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_
     case AUX_FUNC::SUPERSIMPLE_MODE:
     case AUX_FUNC::SURFACE_TRACKING:
     case AUX_FUNC::WINCH_ENABLE:
-        do_aux_function(ch_option, ch_flag);
+        // all of these functions assume the switch is in the LOW
+        // position for initialisation the function
+        do_aux_function(ch_option, aux_switch_pos_t::LOW);
         break;
     default:
-        RC_Channel::init_aux_function(ch_option, ch_flag);
+        RC_Channel::init_aux();
         break;
     }
 }

--- a/ArduCopter/RC_Channel.h
+++ b/ArduCopter/RC_Channel.h
@@ -11,7 +11,7 @@ public:
 
 protected:
 
-    void init_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
+    void init_aux() override;
     void do_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
 
 private:

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -53,10 +53,9 @@ void RC_Channel_Plane::do_aux_function_change_mode(const Mode::Number number,
     }
 }
 
-void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
-                                         const RC_Channel::aux_switch_pos_t ch_flag)
+void RC_Channel_Plane::init_aux()
 {
-    switch(ch_option) {
+    switch ((aux_func_t)option.get()) {
     // the following functions do not need to be initialised:
     case AUX_FUNC::AUTO:
     case AUX_FUNC::CIRCLE:
@@ -71,7 +70,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
 
     case AUX_FUNC::REVERSE_THROTTLE:
         plane.have_reverse_throttle_rc_option = true;
-        // setup input throttle as a range. This is needed as init_aux_function is called
+        // setup input throttle as a range. This is needed as init_aux is called
         // after set_control_channels()
         if (plane.channel_throttle) {
             plane.channel_throttle->set_range(100);
@@ -82,7 +81,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
 
     default:
         // handle in parent class
-        RC_Channel::init_aux_function(ch_option, ch_flag);
+        RC_Channel::init_aux();
         break;
 }
 }

--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -9,8 +9,7 @@ public:
 
 protected:
 
-    void init_aux_function(aux_func_t ch_option,
-                           aux_switch_pos_t ch_flag) override;
+    void init_aux() override;
     void do_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
 
 private:

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -448,8 +448,12 @@ bool RC_Channel::debounce_completed(int8_t position)
 //
 
 // init_aux_switch_function - initialize aux functions
-void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+void RC_Channel::init_aux()
 {
+    const aux_func_t ch_option = (aux_func_t)option.get();
+
+    aux_switch_pos_t assumed_switch_position = aux_switch_pos_t::LOW;
+
     // init channel options
     switch(ch_option) {
     // the following functions do not need to be initialised:
@@ -466,7 +470,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
     case AUX_FUNC::RELAY4:
     case AUX_FUNC::RELAY5:
     case AUX_FUNC::RELAY6:
-        break;
+        return;
     case AUX_FUNC::AVOID_ADSB:
     case AUX_FUNC::AVOID_PROXIMITY:
     case AUX_FUNC::FENCE:
@@ -480,7 +484,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
     case AUX_FUNC::RUNCAM_CONTROL:
     case AUX_FUNC::RUNCAM_OSD_CONTROL:
     case AUX_FUNC::SPRAYER:
-        do_aux_function(ch_option, ch_flag);
+        do_aux_function(ch_option, assumed_switch_position);
         break;
     default:
         gcs().send_text(MAV_SEVERITY_WARNING, "Failed to init: RC%u_OPTION: %u\n",
@@ -949,15 +953,6 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         gcs().send_text(MAV_SEVERITY_INFO, "Invalid channel option (%u)", (unsigned int)ch_option);
         break;
     }
-}
-
-void RC_Channel::init_aux()
-{
-    aux_switch_pos_t position;
-    if (!read_3pos_switch(position)) {
-        position = aux_switch_pos_t::LOW;
-    }
-    init_aux_function((aux_func_t)option.get(), position);
 }
 
 // read_3pos_switch

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -195,6 +195,7 @@ public:
         MIDDLE,    // indicates auxiliary switch is in the middle position (pwm >1200, <1800)
         HIGH       // indicates auxiliary switch is in the high position (pwm >1800)
     };
+    bool aux_switch_pos_initialised;
 
     bool read_3pos_switch(aux_switch_pos_t &ret) const WARN_IF_UNUSED;
 
@@ -223,11 +224,16 @@ protected:
         // no action by default (e.g. Tracker, Sub, who do their own thing)
     };
 
+    // returns true if we should act on the very first level we see on
+    // a switch.  If it returns false then we need to see a transition
+    // from the first value we see for the function to trigger.
+    bool should_react_to_first_rc_input();
 
 private:
 
     // pwm is stored here
     int16_t     radio_in;
+    bool        using_override; // true if radio_in was last set from an override
 
     // value generated from PWM normalised to configured scale
     int16_t    control_in;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -96,7 +96,7 @@ public:
     AP_Int16    option; // e.g. activate EPM gripper / enable fence
 
     // auxillary switch support:
-    void init_aux();
+    virtual void init_aux();
     bool read_aux();
 
     // Aux Switch enumeration
@@ -201,7 +201,6 @@ public:
 
 protected:
 
-    virtual void init_aux_function(aux_func_t ch_option, aux_switch_pos_t);
     virtual void do_aux_function(aux_func_t ch_option, aux_switch_pos_t);
 
     virtual void do_aux_function_armdisarm(const aux_switch_pos_t ch_flag);


### PR DESCRIPTION
This should be considered unbelievably-wip at this point.

I said I'd reopen the old PR, but the old branch was long gone, so I recreated from scratch.  Old PR is here: https://github.com/ArduPilot/ardupilot/pull/10166/files

Initiating issue is here: https://discuss.ardupilot.org/t/crash-following-rcinput-decoding-sbus/52290/7

There are two separate but related changes here.

The first is that we do not assume that we have radio input when initialising any auxillary functions.

The practical effect of that is that if you start with your transmitter off then when you turn it on we will no longer react to some inputs - so if you vehicle is armed we will not disarm it.  If you have a mode-on-aux-switch switch asserted then we will not act on that (so if you are trying to recover a vehicle by turning the transmitter on and your signal is marginal you may have to hammer that switch until the vehicle sees a transition!  OTOH, you might not want the vehicle to (e.g.) RTL the first time it sees the transmitter, so this may be intended behaviour).


Notes:
 - interesting interactions with RC overrides!
