### PR TITLE
AP_Scripting/AP_Vehicle: add set_target_position for use with Copter and Rover (at least)

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -139,6 +139,17 @@ Rover::Rover(void) :
 {
 }
 
+// set target location (for use by scripting)
+bool Rover::set_target_location(const Location& target_loc)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!control_mode->in_guided_mode()) {
+        return false;
+    }
+
+    return control_mode->set_desired_location(target_loc);
+}
+
 #if STATS_ENABLED == ENABLED
 /*
   update AP_Stats

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -276,7 +276,8 @@ private:
 
 private:
 
-    // APMrover2.cpp
+    // Rover.cpp
+    bool set_target_location(const Location& target_loc) override;
     void stats_update();
     void ahrs_update();
     void gcs_failsafe_check(void);

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -271,6 +271,17 @@ void Copter::fast_loop()
     }
 }
 
+// set target location (for use by scripting)
+bool Copter::set_target_location(const Location& target_loc)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    return mode_guided.set_destination(target_loc);
+}
+
 // rc_loops - reads user input from transmitter/receiver
 // called at 100hz
 void Copter::rc_loop()

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -636,6 +636,7 @@ private:
                              uint8_t &task_count,
                              uint32_t &log_bit) override;
     void fast_loop() override;
+    bool set_target_location(const Location& target_loc) override;
     void rc_loop();
     void throttle_loop();
     void update_batt_compass(void);

--- a/libraries/AP_Scripting/examples/set-target-location.lua
+++ b/libraries/AP_Scripting/examples/set-target-location.lua
@@ -1,0 +1,53 @@
+-- performs the equivalent of a simple RTL in Guided mode using set_target_location
+--
+-- CAUTION: This script only works for Copter
+-- this script checks for RC input > 1800 and then:
+--    a) switches to Guided mode
+--    b) sets the target location to be 10m above home
+--    c) switches the vehicle to land once it is within a couple of meters of home
+
+local wp_radius = 2
+local target_alt_above_home = 10
+local copter_guided_mode_num = 4
+local copter_land_mode_num = 9
+local sent_target = false
+
+-- the main update function that is used to decide when we should do a failsafe
+function update()
+  if not arming:is_armed() then -- reset state when disarmed
+    sent_target = false
+  else
+    pwm7 = rc:get_pwm(7)
+    if pwm7 and pwm7 > 1800 then                        -- check if RC input 7 has moved high
+      local mode = vehicle:get_mode()                   -- get current mode
+      if not sent_target then                           -- if we haven't sent the target yet
+        if not (mode == copter_guided_mode_num) then    -- change to guided mode
+          vehicle:set_mode(copter_guided_mode_num)
+        else
+          local above_home = ahrs:get_home()            -- get home location
+          if above_home then
+            above_home:alt(above_home:alt() + (target_alt_above_home * 100))
+            sent_target = vehicle:set_target_location(above_home)   -- set target above home
+          end
+        end
+      else
+
+        -- change to land mode when within 2m of home
+        if not (mode == copter_land_mode_num) then
+          local home = ahrs:get_home()
+          local curr_loc = ahrs:get_position()
+          if home and curr_loc then
+            local home_dist = curr_loc:get_distance(home)   -- get horizontal distance to home
+            if (home_dist < wp_radius) then                 -- change to land mode if close
+              vehicle:set_mode(copter_land_mode_num)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -152,6 +152,7 @@ singleton AP_Vehicle method set_mode boolean uint8_t 0 UINT8_MAX ModeReason::SCR
 singleton AP_Vehicle method get_mode uint8_t
 singleton AP_Vehicle method get_likely_flying boolean
 singleton AP_Vehicle method get_time_flying_ms uint32_t
+singleton AP_Vehicle method set_target_location boolean Location
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -4,6 +4,7 @@ include AP_Common/Location.h
 
 userdata Location field lat int32_t read write -900000000 900000000
 userdata Location field lng int32_t read write -1800000000 1800000000
+userdata Location field alt int32_t read write -INT32_MAX INT32_MAX
 userdata Location field relative_alt boolean read write
 userdata Location field terrain_alt boolean read write
 userdata Location field origin_alt boolean read write

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -4,7 +4,7 @@ include AP_Common/Location.h
 
 userdata Location field lat int32_t read write -900000000 900000000
 userdata Location field lng int32_t read write -1800000000 1800000000
-userdata Location field alt int32_t read write -INT32_MAX INT32_MAX
+userdata Location field alt int32_t read write (-LOCATION_ALT_MAX_M*100+1) (LOCATION_ALT_MAX_M*100-1)
 userdata Location field relative_alt boolean read write
 userdata Location field terrain_alt boolean read write
 userdata Location field origin_alt boolean read write

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -161,6 +161,9 @@ public:
         return AP_HAL::millis() - _last_flying_ms;
     }
 
+    // set target location (for use by scripting)
+    virtual bool set_target_location(const Location& target_loc) { return false; }
+
 protected:
 
     virtual void init_ardupilot() = 0;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -229,14 +229,13 @@ protected:
 
 private:
 
-    static AP_Vehicle *_singleton;
-
+    // delay() callback that processing MAVLink packets
     static void scheduler_delay_callback();
 
-    // true if vehicle is probably flying
-    bool likely_flying;
-    // time when likely_flying last went true
-    uint32_t _last_flying_ms;
+    bool likely_flying;         // true if vehicle is probably flying
+    uint32_t _last_flying_ms;   // time when likely_flying last went true
+
+    static AP_Vehicle *_singleton;
 };
 
 namespace AP {


### PR DESCRIPTION
This PR allows a script to request a Copter or Rover fly/drive to a specified location in Guided mode.

The more detailed changes are:

- AP_Vehicle gets a new set_target_position virtual method
- Copter and Rover override the above method and then call the existing guided mode methods
- AP_Scripting is given bindings for the new function and Location's alt field is also exposed
- A new example script, set-target-location.lua is added and has been tested succesfully on Copter.  It also works on Rover if the copter_guided_mode_num is set to "15" and copter_land_mode_num is set to "4" (for Hold mode)

This is a first step for adding the ability to control the vehicle's movement from a script, future steps probably include:

- add takeoff(target_alt)
- add reached_destination()?
- implement for Plane and Sub?
- add velocity controller for Copter/Rover