### PR TITLE
Fix Aircraft::get_wall_time_us() to use monotonic clock on non-Windows

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -404,9 +404,9 @@ uint64_t Aircraft::get_wall_time_us() const
     tPrev = now;
     return last_ret_us;
 #else
-    struct timeval tp;
-    gettimeofday(&tp, nullptr);
-    return static_cast<uint64_t>(tp.tv_sec * 1.0e6 + tp.tv_usec);
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<uint64_t>(ts.tv_sec * 1.0e6 + ts.tv_nsec / 1.0e3);
 #endif
 }
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -232,7 +232,7 @@ protected:
     /* add noise based on throttle level (from 0..1) */
     void add_noise(float throttle);
 
-    /* return wall clock time in microseconds since 1970 */
+    /* return a monotonic wall clock time in microseconds */
     uint64_t get_wall_time_us(void) const;
 
     // update attitude and relative position


### PR DESCRIPTION
This fixes [Clock drift when running ArduPilot SITL in a Docker container on a Mac](https://github.com/ArduPilot/ardupilot/issues/12060)
The bug is that `get_wall_time_us` uses `gettimeofday`, which is not guaranteed to be monotonic.
The fix is to use `clock_gettime(CLOCK_MONOTONIC, ...)` instead.

Should I perhaps also rename `get_wall_time_us` to `get_system_time_us`, as it doesn't actually return wall-clock time (and hasn't returned it on Windows even before this PR)?