### PR TITLE
AP_HAL_ChibiOS: retry neopixel until successful send

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -337,8 +337,9 @@ private:
 
     /*
       NeoPixel handling. Max of 32 LEDs uses max 12k of memory per group
+      return true if send was successful
     */
-    void neopixel_send(pwm_group &group);
+    bool neopixel_send(pwm_group &group);
     bool neopixel_pending;
 
     void dma_allocate(Shared_DMA *ctx);


### PR DESCRIPTION
Fixes #13563 This retrys sending neopixel until all groups get through. Tested on CubeOrange with lots of serial stuff , fixes sync loss.

Possibly more elegant to only retry failed groups, but this seems to work and is a small change.