### PR TITLE
Tracker: add arming library to avoid segmentation fault

### DIFF
--- a/AntennaTracker/AP_Arming.h
+++ b/AntennaTracker/AP_Arming.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <AP_Arming/AP_Arming.h>
+
+// this class isn't actually used by Tracker; it's really just here so
+// the singleton doesn't come back as nullptr
+class AP_Arming_Tracker : public AP_Arming
+{
+public:
+    friend class Tracker;
+
+private:
+
+};

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -52,6 +52,8 @@
 #include "GCS_Mavlink.h"
 #include "GCS_Tracker.h"
 
+#include "AP_Arming.h"
+
 #ifdef ENABLE_SCRIPTING
 #include <AP_Scripting/AP_Scripting.h>
 #endif
@@ -229,6 +231,9 @@ private:
     void tracking_update_pressure(const mavlink_scaled_pressure_t &msg);
     void tracking_manual_control(const mavlink_manual_control_t &msg);
     void update_armed_disarmed();
+
+    // Arming/Disarming management class
+    AP_Arming_Tracker arming;
 
     // Mission library
     AP_Mission mission{


### PR DESCRIPTION
Places make assumptions that the AP_Arming singleton is non-null

```
Program received signal SIGSEGV, Segmentation fault.
0x0000555555616afa in AP_Arming::get_enabled_checks (this=0x0)
    at ../../libraries/AP_Arming/AP_Arming.cpp:151
151         return checks_to_perform;
(gdb) print this
$1 = (AP_Arming * const) 0x0
(gdb) bt
#0  0x0000555555616afa in AP_Arming::get_enabled_checks (this=0x0)
    at ../../libraries/AP_Arming/AP_Arming.cpp:151
#1  0x00005555555ec25d in GCS::update_sensor_status_flags (this=
    0x555555966b90 <tracker+13040>) at ../../libraries/GCS_MAVLink/GCS.cpp:215
#2  0x00005555555eb9e0 in GCS::get_sensor_status_flags (
    this=0x555555966b90 <tracker+13040>, present=@0x7fffffffd630: 4294956640, 
    enabled=@0x7fffffffd634: 32767, health=@0x7fffffffd638: 1432291740)
    at ../../libraries/GCS_MAVLink/GCS.cpp:19
#3  0x00005555555fe225 in GCS_MAVLINK::send_sys_status (this=0x5555559c8f90)
    at ../../libraries/GCS_MAVLink/GCS_Common.cpp:4181
#4  0x00005555555ff2f3 in GCS_MAVLINK::try_send_message (this=0x5555559c8f90, 
    id=MSG_SYS_STATUS) at ../../libraries/GCS_MAVLink/GCS_Common.cpp:4530
#5  0x00005555555f64f3 in GCS_MAVLINK::do_try_send_message (
    this=0x5555559c8f90, id=MSG_SYS_STATUS)
    at ../../libraries/GCS_MAVLink/GCS_Common.cpp:946
#6  0x00005555555f68f0 in GCS_MAVLINK::update_send (this=0x5555559c8f90)
    at ../../libraries/GCS_MAVLink/GCS_Common.cpp:1092
#7  0x00005555555f8ccd in GCS::update_send (
    this=0x555555966b90 <tracker+13040>)
    at ../../libraries/GCS_MAVLink/GCS_Common.cpp:1936
#8  0x0000555555579d89 in Functor<void>::method_wrapper<GCS, &GCS::update_send>
    (obj=0x555555966b90 <tracker+13040>)
    at ../../libraries/AP_HAL/utility/functor.h:88
#9  0x00005555555c2844 in Functor<void>::operator() (
    this=0x555555953920 <Tracker::scheduler_tasks+288>)
    at ../../libraries/AP_HAL/utility/functor.h:54
#10 0x00005555555d6c5e in AP_Scheduler::run (
    this=0x555555963918 <tracker+120>, time_available=20000)
    at ../../libraries/AP_Scheduler/AP_Scheduler.cpp:205
#11 0x00005555555d7125 in AP_Scheduler::loop (
    this=0x555555963918 <tracker+120>)
    at ../../libraries/AP_Scheduler/AP_Scheduler.cpp:326
#12 0x00005555555d9aac in AP_Vehicle::loop (this=0x5555559638a0 <tracker>)
    at ../../libraries/AP_Vehicle/AP_Vehicle.cpp:62
#13 0x0000555555618192 in HAL_SITL::run (
    this=0x555555971940 <AP_HAL::get_HAL()::hal>, argc=9, argv=0x7fffffffda48, 
    callbacks=0x5555559638a0 <tracker>)
    at ../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:213
#14 0x00005555555799e2 in main (argc=9, argv=0x7fffffffda48)
    at ../../AntennaTracker/Tracker.cpp:162
(gdb)
```
