### PR TITLE
AP_Scripting: Reduce the sleep time with no scripts

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -72,10 +72,10 @@ const AP_Param::GroupInfo AP_Scripting::var_info[] = {
     AP_GROUPINFO("HEAP_SIZE", 3, AP_Scripting, _script_heap_size, SCRIPTING_HEAP_SIZE),
 
     // @Param: DEBUG_LVL
-    // @DisplayName: Enable Scripting Debug
-    // @Description: Enable scripting debug.
+    // @DisplayName: Scripting Debug Level
+    // @Description: The higher the number the more verbose builtin scripting debug will be.
     // @User: Advanced
-    AP_GROUPINFO("DEBUG_LVL", 4, AP_Scripting, _debug_level, 1),
+    AP_GROUPINFO("DEBUG_LVL", 4, AP_Scripting, _debug_level, 0),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -368,8 +368,6 @@ void lua_scripts::run(void) {
         return;
     }
     lua_atpanic(L, atpanic);
-//    luaL_openlibs(L);
-//    load_lua_bindings(L);
     load_generated_bindings(L);
 
     // Scan the filesystem in an appropriate manner and autostart scripts
@@ -430,8 +428,10 @@ void lua_scripts::run(void) {
             lua_gc(L, LUA_GCCOLLECT, 0);
 
         } else {
-            gcs().send_text(MAV_SEVERITY_DEBUG, "Lua: No scripts to run");
-            hal.scheduler->delay(10000);
+            if (_debug_level > 0) {
+                gcs().send_text(MAV_SEVERITY_DEBUG, "Lua: No scripts to run");
+            }
+            hal.scheduler->delay(1000);
         }
 
     }


### PR DESCRIPTION
Lowering the sleep time when no scripts are pending, causes starting a
REPL session to respond much faster (this cuts the latency from up to 10
seconds to 1 second before the session is ready to start).

Also lowers the default scripting debug level to hide the statustext
from users, as in the general case this is just a spammy message if it
occurs, and we should be finding better reporting bits to get this to
the user.