### PR TITLE
PLANE: Fix CRASH_DETECT parameter

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -852,6 +852,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: CRASH_DETECT
     // @DisplayName: Crash Detection
     // @Description: Automatically detect a crash during AUTO flight and perform the bitmask selected action(s). Disarm will turn off motor for safety and to help against burning out ESC and motor. Set to 0 to disable crash detection.
+    // @Values: 0:Disabled
     // @Bitmask: 0:Disarm
     // @User: Advanced
     ASCALAR(crash_detection_enable,         "CRASH_DETECT",   0),

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -295,23 +295,13 @@ void Plane::crash_detection_update(void)
 
     } else if ((now_ms - crash_state.debounce_timer_ms >= crash_state.debounce_time_total_ms) && !crash_state.is_crashed) {
         crash_state.is_crashed = true;
-
-        if (aparm.crash_detection_enable == CRASH_DETECT_ACTION_BITMASK_DISABLED) {
-            if (crashed_near_land_waypoint) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected. No action taken");
-            } else {
-                gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash detected. No action taken");
-            }
+        if (aparm.crash_detection_enable & CRASH_DETECT_ACTION_BITMASK_DISARM) {
+            arming.disarm(AP_Arming::Method::CRASH);
         }
-        else {
-            if (aparm.crash_detection_enable & CRASH_DETECT_ACTION_BITMASK_DISARM) {
-                arming.disarm(AP_Arming::Method::CRASH);
-            }
-            if (crashed_near_land_waypoint) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected");
-            } else {
-                gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash detected");
-            }
+        if (crashed_near_land_waypoint) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected");
+        } else {
+            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash detected");
         }
     }
 }


### PR DESCRIPTION
This is a fix for #12866

If CRASH_DETECT is set as 0, the function `void Plane::crash_detection_update(void)` will return in the beginning itself. Therefore the removed lines will never be utilized.