### PR TITLE
GCS_MAVLink: don't send statustext from other than main thread

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1829,7 +1829,9 @@ void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, u
         }
 
         // try and send immediately if possible
-        service_statustext();
+        if (hal.scheduler->in_main_thread()) {
+            service_statustext();
+        }
     } while (false);
 
     // given we don't really know what these methods get up to, we


### PR DESCRIPTION
This fixes high stack usage in the RCIN thread when it notifies the
GCS of a new RCIN protocol. The problem is severe when signing is
enabled, as signing adds over 500 bytes to stack cost of sending a
mavlink msg

fixes issue #13615