### PR TITLE
Log basic, relatively static information about mavlinks into MAV message

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -368,6 +368,7 @@ struct PACKED log_MAV {
     uint16_t packet_tx_count;
     uint16_t packet_rx_success_count;
     uint16_t packet_rx_drop_count;
+    uint8_t flags;
 };
 
 struct PACKED log_RSSI {
@@ -1533,7 +1534,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_RALLY_MSG, sizeof(log_Rally), \
       "RALY", "QBBLLh", "TimeUS,Tot,Seq,Lat,Lng,Alt", "s--DUm", "F--GGB" },  \
     { LOG_MAV_MSG, sizeof(log_MAV),   \
-      "MAV", "QBHHH",   "TimeUS,chan,txp,rxp,rxdp", "s#---", "F-000" },   \
+      "MAV", "QBHHHB",   "TimeUS,chan,txp,rxp,rxdp,flags", "s#----", "F-000-" },   \
     { LOG_VISUALODOM_MSG, sizeof(log_VisualOdom), \
       "VISO", "Qffffffff", "TimeUS,dt,AngDX,AngDY,AngDZ,PosDX,PosDY,PosDZ,conf", "ssrrrmmm-", "FF000000-" }, \
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1482,13 +1482,39 @@ void GCS_MAVLINK::log_mavlink_stats()
         return;
     }
 
+    enum class Flags {
+        USING_SIGNING = (1<<0),
+        ACTIVE = (1<<1),
+        STREAMING = (1<<2),
+        PRIVATE = (1<<3),
+        LOCKED = (1<<4),
+    };
+
+    uint8_t flags = 0;
+    if (signing_enabled()) {
+        flags |= (uint8_t)Flags::USING_SIGNING;
+    }
+    if (is_streaming()) {
+        flags |= (uint8_t)Flags::STREAMING;
+    }
+    if (is_active()) {
+        flags |= (uint8_t)Flags::ACTIVE;
+    }
+    if (is_private()) {
+        flags |= (uint8_t)Flags::PRIVATE;
+    }
+    if (locked()) {
+        flags |= (uint8_t)Flags::LOCKED;
+    }
+
     const struct log_MAV pkt = {
     LOG_PACKET_HEADER_INIT(LOG_MAV_MSG),
     time_us                : AP_HAL::micros64(),
     chan                   : (uint8_t)chan,
     packet_tx_count        : send_packet_count,
     packet_rx_success_count: status->packet_rx_success_count,
-    packet_rx_drop_count   : status->packet_rx_drop_count
+    packet_rx_drop_count   : status->packet_rx_drop_count,
+    flags                  : flags,
     };
 
     AP::logger().WriteBlock(&pkt, sizeof(pkt));


### PR DESCRIPTION
```
1970-01-01 10:00:04.04: MAV {TimeUS : 4047118, chan : 0, txp : 70, rxp : 2, rxdp : 0, flags : 6}
1970-01-01 10:00:04.04: MAV {TimeUS : 4047138, chan : 1, txp : 36, rxp : 0, rxdp : 0, flags : 4}
1970-01-01 10:00:04.04: MAV {TimeUS : 4047157, chan : 2, txp : 13, rxp : 0, rxdp : 0, flags : 4}
.
. [signing enabled here]
.
1970-01-01 10:01:23.58: MAV {TimeUS : 83587101, chan : 0, txp : 6941, rxp : 89, rxdp : 0, flags : 7}
1970-01-01 10:01:23.58: MAV {TimeUS : 83587121, chan : 1, txp : 3162, rxp : 0, rxdp : 0, flags : 5}
1970-01-01 10:01:23.58: MAV {TimeUS : 83587141, chan : 2, txp : 23, rxp : 0, rxdp : 0, flags : 5}
1970-01-01 10:01:24.60: MAV {TimeUS : 84607393, chan : 0, txp : 6989, rxp : 90, rxdp : 0, flags : 7}
1970-01-01 10:01:24.60: MAV {TimeUS : 84607413, chan : 1, txp : 3218, rxp : 0, rxdp : 0, flags : 5}
1970-01-01 10:01:24.60: MAV {TimeUS : 84607433, chan : 2, txp : 23, rxp : 0, rxdp : 0, flags : 5}
```

```
+    enum class Flags {
+        USING_SIGNING = (1<<0),
+        ACTIVE = (1<<1),
+        STREAMING = (1<<2),
+        PRIVATE = (1<<3),
+        LOCKED = (1<<4),
+    };
```

This is Plane which has default streamrates on all `SR?_` parameters.