### PR TITLE
Clean up and extend RAMTRON driver

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -739,10 +739,16 @@ void Rover::load_parameters(void)
         AP_HAL::panic("Bad var table");
     }
 
-    if (!g.format_version.load() ||
-         g.format_version != Parameters::k_format_version) {
+    uint8_t loadErr = !g.format_version.load();
+    bool isNewFirmware = g.format_version != Parameters::k_format_version;
+    if (loadErr || isNewFirmware) {
+
         // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        if (loadErr) {
+            hal.console->printf("Couldn't load params: erasing params...\n");
+        } else {
+            hal.console->printf("Firmware change: erasing params...\n");
+        }
         StorageManager::erase();
         AP_Param::erase_all();
 

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -487,11 +487,16 @@ const AP_Param::Info Tracker::var_info[] = {
 
 void Tracker::load_parameters(void)
 {
-    if (!g.format_version.load() ||
-        g.format_version != Parameters::k_format_version) {
+    uint8_t loadErr = !g.format_version.load();
+    bool isNewFirmware = g.format_version != Parameters::k_format_version;
+    if (loadErr || isNewFirmware) {
 
         // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        if (loadErr) {
+            hal.console->printf("Couldn't load params: erasing params...\n");
+        } else {
+            hal.console->printf("Firmware change: erasing params...\n");
+        }
         StorageManager::erase();
         AP_Param::erase_all();
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1065,11 +1065,16 @@ void Copter::load_parameters(void)
     ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
-    if (!g.format_version.load() ||
-        g.format_version != Parameters::k_format_version) {
+    uint8_t loadErr = !g.format_version.load();
+    bool isNewFirmware = g.format_version != Parameters::k_format_version;
+    if (loadErr || isNewFirmware) {
 
         // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        if (loadErr) {
+            hal.console->printf("Couldn't load params: erasing params...\n");
+        } else {
+            hal.console->printf("Firmware change: erasing params...\n");
+        }
         StorageManager::erase();
         AP_Param::erase_all();
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1326,11 +1326,16 @@ void Plane::load_parameters(void)
         hal.console->printf("Bad parameter table\n");
         AP_HAL::panic("Bad parameter table");
     }
-    if (!g.format_version.load() ||
-        g.format_version != Parameters::k_format_version) {
+    uint8_t loadErr = !g.format_version.load();
+    bool isNewFirmware = g.format_version != Parameters::k_format_version;
+    if (loadErr || isNewFirmware) {
 
         // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        if (loadErr) {
+            hal.console->printf("Couldn't load params: erasing params...\n");
+        } else {
+            hal.console->printf("Firmware change: erasing params...\n");
+        }
         StorageManager::erase();
         AP_Param::erase_all();
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -662,17 +662,22 @@ void Sub::load_parameters()
     ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
-    if (!g.format_version.load() ||
-            g.format_version != Parameters::k_format_version) {
+    uint8_t loadErr = !g.format_version.load();
+    bool isNewFirmware = g.format_version != Parameters::k_format_version;
+    if (loadErr || isNewFirmware) {
 
         // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        if (loadErr) {
+            hal.console->printf("Couldn't load params: erasing params...\n");
+        } else {
+            hal.console->printf("Firmware change: erasing params...\n");
+        }
         StorageManager::erase();
         AP_Param::erase_all();
 
         // save the current format version
         g.format_version.set_and_save(Parameters::k_format_version);
-        hal.console->println("done.");
+        hal.console->printf("done.\n");
     }
 
     uint32_t before = AP_HAL::micros();

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -55,7 +55,7 @@ void Storage::_storage_open(void)
         if (fram.read(0, _buffer, CH_STORAGE_SIZE) == CH_STORAGE_SIZE) {
             _save_backup();
             _initialisedType = StorageBackend::FRAM;
-            hal.console->printf("Initialised Storage type=%d\n", _initialisedType);
+            ::printf("Initialised Storage type=%d\n", _initialisedType);
             return;
         }
     }
@@ -82,12 +82,12 @@ void Storage::_storage_open(void)
         if (sdcard_retry()) {
             log_fd = AP::FS().open(HAL_STORAGE_FILE, O_RDWR|O_CREAT);
             if (log_fd == -1) {
-                hal.console->printf("open failed of " HAL_STORAGE_FILE "\n");
+                ::printf("open failed of " HAL_STORAGE_FILE "\n");
                 return;
             }
             int ret = AP::FS().read(log_fd, _buffer, CH_STORAGE_SIZE);
             if (ret < 0) {
-                hal.console->printf("read failed for " HAL_STORAGE_FILE "\n");
+                ::printf("read failed for " HAL_STORAGE_FILE "\n");
                 AP::FS().close(log_fd);
                 log_fd = -1;
                 return;
@@ -95,7 +95,7 @@ void Storage::_storage_open(void)
             // pre-fill to full size
             if (AP::FS().lseek(log_fd, ret, SEEK_SET) != ret ||
                 AP::FS().write(log_fd, &_buffer[ret], CH_STORAGE_SIZE-ret) != CH_STORAGE_SIZE-ret) {
-                hal.console->printf("setup failed for " HAL_STORAGE_FILE "\n");
+                ::printf("setup failed for " HAL_STORAGE_FILE "\n");
                 AP::FS().close(log_fd);
                 log_fd = -1;
                 return;
@@ -106,7 +106,7 @@ void Storage::_storage_open(void)
 #endif
 
     if (_initialisedType != StorageBackend::None) {
-        hal.console->printf("Initialised Storage type=%d\n", _initialisedType);
+        ::printf("Initialised Storage type=%d\n", _initialisedType);
     } else {
         AP_HAL::panic("Unable to init Storage backend");
     }
@@ -237,7 +237,7 @@ void Storage::_flash_load(void)
 #ifdef STORAGE_FLASH_PAGE
     _flash_page = STORAGE_FLASH_PAGE;
 
-    hal.console->printf("Storage: Using flash pages %u and %u\n", _flash_page, _flash_page+1);
+    ::printf("Storage: Using flash pages %u and %u\n", _flash_page, _flash_page+1);
 
     if (!_flash.init()) {
         AP_HAL::panic("Unable to init flash storage");
@@ -280,8 +280,8 @@ bool Storage::_flash_write_data(uint8_t sector, uint32_t offset, const uint8_t *
         if (now - _last_re_init_ms > 5000) {
             _last_re_init_ms = now;
             bool ok = _flash.re_initialise();
-            hal.console->printf("Storage: failed at %u:%u for %u - re-init %u\n",
-                                (unsigned)sector, (unsigned)offset, (unsigned)length, (unsigned)ok);
+            ::printf("Storage: failed at %u:%u for %u - re-init %u\n",
+                     (unsigned)sector, (unsigned)offset, (unsigned)length, (unsigned)ok);
         }
     }
     return false;

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -66,6 +66,10 @@ void Storage::_storage_open(void)
         }
     }
 
+    #if defined(HAL_RAMTRON_NO_FALLBACK) && HAL_RAMTRON_NO_FALLBACK
+        AP_HAL::panic("Unable to init RAMTRON storage");
+    #endif
+
     // allow for FMUv3 with no FRAM chip, fall through to flash storage
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -60,9 +60,9 @@ void Storage::_storage_open(void)
         }
     }
 
-    #if defined(HAL_RAMTRON_NO_FALLBACK) && HAL_RAMTRON_NO_FALLBACK
-        AP_HAL::panic("Unable to init RAMTRON storage");
-    #endif
+#if defined(HAL_RAMTRON_ALLOW_FALLBACK) && !HAL_RAMTRON_ALLOW_FALLBACK
+    AP_HAL::panic("Unable to init RAMTRON storage");
+#endif
 
 #endif // HAL_WITH_RAMTRON
 

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -103,8 +103,6 @@ void Storage::_storage_open(void)
             _save_backup();
             _initialisedType = StorageBackend::SDCard;
         }
-#elif !HAL_WITH_RAMTRON
-        #error No Storage Backend defined!
 #endif
 
     if (_initialisedType != StorageBackend::None) {

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -52,7 +52,7 @@ void Storage::_storage_open(void)
 
 #if HAL_WITH_RAMTRON
     if (fram.init()) {
-        if (fram.read(0, _buffer, CH_STORAGE_SIZE) == CH_STORAGE_SIZE) {
+        if (fram.read(0, _buffer, CH_STORAGE_SIZE)) {
             _save_backup();
             _initialisedType = StorageBackend::FRAM;
             ::printf("Initialised Storage type=%d\n", _initialisedType);
@@ -197,7 +197,7 @@ void Storage::_timer_tick(void)
 
 #if HAL_WITH_RAMTRON
     if (_initialisedType == StorageBackend::FRAM) {
-        if (fram.write(CH_STORAGE_LINE_SIZE*i, &_buffer[CH_STORAGE_LINE_SIZE*i], CH_STORAGE_LINE_SIZE) == CH_STORAGE_LINE_SIZE) {
+        if (fram.write(CH_STORAGE_LINE_SIZE*i, &_buffer[CH_STORAGE_LINE_SIZE*i], CH_STORAGE_LINE_SIZE)) {
             _dirty_mask.clear(i);
         }
         return;

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -60,7 +60,7 @@ void Storage::_storage_open(void)
 #if HAL_WITH_RAMTRON
     using_fram = fram.init();
     if (using_fram) {
-        if (!fram.read(0, _buffer, CH_STORAGE_SIZE)) {
+        if (fram.read(0, _buffer, CH_STORAGE_SIZE) != CH_STORAGE_SIZE) {
             return;
         }
         _save_backup();
@@ -144,7 +144,7 @@ void Storage::_mark_dirty(uint16_t loc, uint16_t length)
 
 void Storage::read_block(void *dst, uint16_t loc, size_t n)
 {
-    if (loc >= sizeof(_buffer)-(n-1)) {
+    if ((n > sizeof(_buffer)) || (loc > (sizeof(_buffer) - n))) {
         return;
     }
     _storage_open();
@@ -153,7 +153,7 @@ void Storage::read_block(void *dst, uint16_t loc, size_t n)
 
 void Storage::write_block(uint16_t loc, const void *src, size_t n)
 {
-    if (loc >= sizeof(_buffer)-(n-1)) {
+    if ((n > sizeof(_buffer)) || (loc > (sizeof(_buffer) - n))) {
         return;
     }
     if (memcmp(src, &_buffer[loc], n) != 0) {
@@ -188,7 +188,7 @@ void Storage::_timer_tick(void)
 
 #if HAL_WITH_RAMTRON
     if (using_fram) {
-        if (fram.write(CH_STORAGE_LINE_SIZE*i, &_buffer[CH_STORAGE_LINE_SIZE*i], CH_STORAGE_LINE_SIZE)) {
+        if (fram.write(CH_STORAGE_LINE_SIZE*i, &_buffer[CH_STORAGE_LINE_SIZE*i], CH_STORAGE_LINE_SIZE) == CH_STORAGE_LINE_SIZE) {
             _dirty_mask.clear(i);
         }
         return;

--- a/libraries/AP_HAL_ChibiOS/Storage.h
+++ b/libraries/AP_HAL_ChibiOS/Storage.h
@@ -48,7 +48,13 @@ public:
     bool healthy(void) override;
 
 private:
-    volatile bool _initialised;
+    enum class StorageBackend: uint8_t {
+        None,
+        FRAM,
+        Flash,
+        SDCard,
+    };
+    volatile StorageBackend _initialisedType = StorageBackend::None;
     void _storage_create(void);
     void _storage_open(void);
     void _save_backup(void);
@@ -79,10 +85,8 @@ private:
 
 #if HAL_WITH_RAMTRON
     AP_RAMTRON fram;
-    bool using_fram;
 #endif
 #ifdef USE_POSIX
-    bool using_filesystem;
     int log_fd;
 #endif
 };

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -326,7 +326,7 @@ bool AP_Param::setup(void)
         hdr.revision != k_EEPROM_revision) {
         // header doesn't match. We can't recover any variables. Wipe
         // the header and setup the sentinal directly after the header
-        Debug("bad header in setup - erasing");
+        Debug("bad header (%u %u %u) in setup - erasing", hdr.magic[0], hdr.magic[1], hdr.revision);
         erase_all();
     }
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -518,6 +518,7 @@ private:
         uint8_t revision;
         uint8_t spare;
     };
+    static_assert(sizeof(struct EEPROM_header) == 4, "Bad EEPROM_header size!");
 
     static uint16_t sentinal_offset;
 
@@ -540,6 +541,7 @@ private:
         uint32_t key_high : 1;
         uint32_t group_element : 18;
     };
+    static_assert(sizeof(struct Param_header) == 4, "Bad Param_header size!");
 
     // number of bits in each level of nesting of groups
     static const uint8_t        _group_level_shift = 6;

--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -21,21 +21,21 @@ static const uint8_t RAMTRON_WRITE = 0x02;
   list of supported devices. Thanks to NuttX ramtron driver
  */
 const AP_RAMTRON::ramtron_id AP_RAMTRON::ramtron_ids[] = {
-    { 0x21, 0x00,  16, 2, CYPRESS_RDID, }, // FM25V01
-    { 0x21, 0x08,  16, 2, CYPRESS_RDID, }, // FM25V01A
-    { 0x22, 0x00,  32, 2, CYPRESS_RDID, }, // FM25V02
-    { 0x22, 0x08,  32, 2, CYPRESS_RDID, }, // FM25V02A
-    { 0x22, 0x01,  32, 2, CYPRESS_RDID, }, // FM25VN02
-    { 0x23, 0x00,  64, 2, CYPRESS_RDID, }, // FM25V05
-    { 0x23, 0x01,  64, 2, CYPRESS_RDID, }, // FM25VN05
-    { 0x24, 0x00, 128, 3, CYPRESS_RDID, }, // FM25V10
-    { 0x24, 0x01, 128, 3, CYPRESS_RDID, }, // FM25VN10
-    { 0x25, 0x08, 256, 3, CYPRESS_RDID, }, // FM25V20A
-    { 0x26, 0x08, 512, 3, CYPRESS_RDID, }, // CY15B104Q
+    { 0x21, 0x00,  16, 2, RDID_type::Cypress, }, // FM25V01
+    { 0x21, 0x08,  16, 2, RDID_type::Cypress, }, // FM25V01A
+    { 0x22, 0x00,  32, 2, RDID_type::Cypress, }, // FM25V02
+    { 0x22, 0x08,  32, 2, RDID_type::Cypress, }, // FM25V02A
+    { 0x22, 0x01,  32, 2, RDID_type::Cypress, }, // FM25VN02
+    { 0x23, 0x00,  64, 2, RDID_type::Cypress, }, // FM25V05
+    { 0x23, 0x01,  64, 2, RDID_type::Cypress, }, // FM25VN05
+    { 0x24, 0x00, 128, 3, RDID_type::Cypress, }, // FM25V10
+    { 0x24, 0x01, 128, 3, RDID_type::Cypress, }, // FM25VN10
+    { 0x25, 0x08, 256, 3, RDID_type::Cypress, }, // FM25V20A
+    { 0x26, 0x08, 512, 3, RDID_type::Cypress, }, // CY15B104Q
 
-    { 0x27, 0x03, 128, 3, FUJITSU_RDID, }, // MB85RS1MT
-    { 0x05, 0x09,  32, 2, FUJITSU_RDID, }, // MB85RS256B
-    { 0x24, 0x03,  16, 2, FUJITSU_RDID, }, // MB85RS128TY
+    { 0x27, 0x03, 128, 3, RDID_type::Fujitsu, }, // MB85RS1MT
+    { 0x05, 0x09,  32, 2, RDID_type::Fujitsu, }, // MB85RS256B
+    { 0x24, 0x03,  16, 2, RDID_type::Fujitsu, }, // MB85RS128TY
 };
 
 // initialise the driver
@@ -70,14 +70,14 @@ bool AP_RAMTRON::init(void)
     }
 
     for (uint8_t i = 0; i < ARRAY_SIZE(ramtron_ids); i++) {
-        if (ramtron_ids[i].rdid_type == CYPRESS_RDID) {
+        if (ramtron_ids[i].rdid_type == RDID_type::Cypress) {
             cypress_rdid const * const cypress = (cypress_rdid const * const)rdid;
             if (ramtron_ids[i].id1 == cypress->id1 &&
                 ramtron_ids[i].id2 == cypress->id2) {
                 id = i;
                 break;
             }
-        } else if (ramtron_ids[i].rdid_type == FUJITSU_RDID) {
+        } else if (ramtron_ids[i].rdid_type == RDID_type::Fujitsu) {
             fujitsu_rdid const * const fujitsu = (fujitsu_rdid const * const)rdid;
             if (ramtron_ids[i].id1 == fujitsu->id1 &&
                 ramtron_ids[i].id2 == fujitsu->id2) {
@@ -99,7 +99,7 @@ bool AP_RAMTRON::init(void)
         return false;
     }
 
-    char const * const manufacturer = (ramtron_ids[id].rdid_type == FUJITSU_RDID) ? "Fujitsu" : "Cypress";
+    char const * const manufacturer = (ramtron_ids[id].rdid_type == RDID_type::Fujitsu) ? "Fujitsu" : "Cypress";
     hal.console->printf("Found %s RAMTRON idx=%u sr=0x%02x\n", manufacturer, id, status_register);
 
     uint8_t const kWriteEnableLatch   = (1 << 1);

--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -128,7 +128,8 @@ bool AP_RAMTRON::init(void)
     return true;
 }
 
-bool AP_RAMTRON::_populate_addr(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz, uint32_t addr) {
+bool AP_RAMTRON::_fill_cmd_buffer(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz, uint8_t const cmd, uint32_t addr)
+{
     if (kCmdBufferSz == 4) {
         cmdBuffer[1] = uint8_t((addr >> 16) & 0xFF);
         cmdBuffer[2] = uint8_t((addr >>  8) & 0xFF);
@@ -139,6 +140,7 @@ bool AP_RAMTRON::_populate_addr(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz
     } else {
         return false;
     }
+    cmdBuffer[0] = cmd;
     return true;
 }
 
@@ -159,8 +161,8 @@ uint32_t AP_RAMTRON::read(uint32_t offset, uint8_t * const buf, uint32_t size)
 
     while (size > 0) {
         uint32_t const kCmdBufferSz = ramtron_ids[id].addrlen + 1;
-        uint8_t cmdBuffer[kCmdBufferSz] = { RAMTRON_READ, };
-        if (!_populate_addr(cmdBuffer, kCmdBufferSz, (offset + numRead))) {
+        uint8_t cmdBuffer[kCmdBufferSz];
+        if (!_fill_cmd_buffer(cmdBuffer, kCmdBufferSz, RAMTRON_READ, (offset + numRead))) {
             break;
         } else {
             WITH_SEMAPHORE(dev->get_semaphore());
@@ -191,8 +193,8 @@ uint32_t AP_RAMTRON::write(uint32_t offset, uint8_t const * const buf, uint32_t 
     }
 
     uint32_t const kCmdBufferSz = ramtron_ids[id].addrlen + 1;
-    uint8_t cmdBuffer[kCmdBufferSz] = { RAMTRON_WRITE, };
-    if (!_populate_addr(cmdBuffer, kCmdBufferSz, offset)) {
+    uint8_t cmdBuffer[kCmdBufferSz];
+    if (!_fill_cmd_buffer(cmdBuffer, kCmdBufferSz, RAMTRON_WRITE, offset)) {
         return 0;
     }
 

--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -118,6 +118,7 @@ bool AP_RAMTRON::init(void)
     // Ensure Block Protect is disabled
     if ((status_register & kBlockProtect) != 0x00) {
         status_register &= ~kBlockProtect;
+        status_register |= kWriteEnableLatch; // Ensure Write Enable is not overwritten
         if (!dev->write_register(RAMTRON_WRSR, status_register)) {
             hal.console->printf("Failed to disable RAMTRON BlockProtect!");
             return false;

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -15,10 +15,10 @@ public:
     uint32_t get_size(void) const { return (id == UINT8_MAX) ? 0 : ramtron_ids[id].size_kbyte * 1024UL; }
 
     // read from device
-    bool read(uint32_t offset, uint8_t *buf, uint32_t size);
+    uint32_t read(uint32_t offset, uint8_t *buf, uint32_t size);
 
     // write to device
-    bool write(uint32_t offset, const uint8_t *buf, uint32_t size);
+    uint32_t write(uint32_t offset, const uint8_t *buf, uint32_t size);
 
 private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;
@@ -38,6 +38,5 @@ private:
     static const struct ramtron_id ramtron_ids[];
     uint8_t id = UINT8_MAX;
 
-    // send offset of transfer
-    void send_offset(uint8_t cmd, uint32_t offset);
+    bool _populate_addr(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz, uint32_t addr);
 };

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -15,10 +15,10 @@ public:
     uint32_t get_size(void) const { return (id == UINT8_MAX) ? 0 : ramtron_ids[id].size_kbyte * 1024UL; }
 
     // read from device
-    uint32_t read(uint32_t offset, uint8_t *buf, uint32_t size);
+    uint32_t read(uint32_t offset, uint8_t * const buf, uint32_t size);
 
     // write to device
-    uint32_t write(uint32_t offset, const uint8_t *buf, uint32_t size);
+    uint32_t write(uint32_t offset, uint8_t const * const buf, uint32_t size);
 
 private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -9,6 +9,7 @@
 class AP_RAMTRON {
 public:
     // initialise the driver
+    // this will retry RAMTRON_RETRIES times until successful
     bool init(void);
 
     // get size in bytes
@@ -38,5 +39,7 @@ private:
     static const struct ramtron_id ramtron_ids[];
     uint8_t id = UINT8_MAX;
 
+    // perform a single device initialisation
+    bool _init(void);
     bool _fill_cmd_buffer(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz, uint8_t const cmd, uint32_t addr);
 };

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -38,5 +38,5 @@ private:
     static const struct ramtron_id ramtron_ids[];
     uint8_t id = UINT8_MAX;
 
-    bool _populate_addr(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz, uint32_t addr);
+    bool _fill_cmd_buffer(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz, uint8_t const cmd, uint32_t addr);
 };

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -12,7 +12,7 @@ public:
     bool init(void);
 
     // get size in bytes
-    uint32_t get_size(void) const { return ramtron_ids[id].size_kbyte*1024UL; }
+    uint32_t get_size(void) const { return (id == UINT8_MAX) ? 0 : ramtron_ids[id].size_kbyte * 1024UL; }
 
     // read from device
     bool read(uint32_t offset, uint8_t *buf, uint32_t size);
@@ -23,13 +23,20 @@ public:
 private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;
 
+    enum rdid_type {
+        CYPRESS_RDID,
+        FUJITSU_RDID,
+    };
+
     struct ramtron_id {
-        uint8_t id1, id2;
+        uint8_t id1;
+        uint8_t id2;
         uint16_t size_kbyte;
         uint8_t addrlen;
+        enum rdid_type rdid_type;
     };
     static const struct ramtron_id ramtron_ids[];
-    uint8_t id;
+    uint8_t id = UINT8_MAX;
 
     // send offset of transfer
     void send_offset(uint8_t cmd, uint32_t offset);

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -23,9 +23,9 @@ public:
 private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;
 
-    enum rdid_type {
-        CYPRESS_RDID,
-        FUJITSU_RDID,
+    enum class RDID_type :uint8_t {
+        Cypress,
+        Fujitsu,
     };
 
     struct ramtron_id {
@@ -33,7 +33,7 @@ private:
         uint8_t id2;
         uint16_t size_kbyte;
         uint8_t addrlen;
-        enum rdid_type rdid_type;
+        RDID_type rdid_type;
     };
     static const struct ramtron_id ramtron_ids[];
     uint8_t id = UINT8_MAX;

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -16,6 +16,7 @@ public:
     uint32_t get_size(void) const { return (id == UINT8_MAX) ? 0 : ramtron_ids[id].size_kbyte * 1024UL; }
 
     // read from device
+    // this will retry RAMTRON_RETRIES times until two successive reads return the same data
     bool read(uint32_t offset, uint8_t * const buf, uint32_t size);
 
     // write to device
@@ -41,5 +42,7 @@ private:
 
     // perform a single device initialisation
     bool _init(void);
+    // perform a single device read
+    bool _read(uint32_t offset, uint8_t * const buf, uint32_t size);
     bool _fill_cmd_buffer(uint8_t cmdBuffer[], uint32_t const kCmdBufferSz, uint8_t const cmd, uint32_t addr);
 };

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -15,10 +15,10 @@ public:
     uint32_t get_size(void) const { return (id == UINT8_MAX) ? 0 : ramtron_ids[id].size_kbyte * 1024UL; }
 
     // read from device
-    uint32_t read(uint32_t offset, uint8_t * const buf, uint32_t size);
+    bool read(uint32_t offset, uint8_t * const buf, uint32_t size);
 
     // write to device
-    uint32_t write(uint32_t offset, uint8_t const * const buf, uint32_t size);
+    bool write(uint32_t offset, uint8_t const * const buf, uint32_t size);
 
 private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;


### PR DESCRIPTION
We experienced an issue where parameters were being unexpectedly erased during development. The sequence of events that caused this was:
1. The RAMTRON driver fails to initialise;
2. The Storage driver silently falls back to using the SD card;
3. The SD card was not fitted, so the Storage drive falls back to using Flash;
4. A new program image was written to the device over JTAG, erasing the params in Flash;
5. Developer tests the new image, and finds unexpected params.

This behaviour was observed on both a Pixracer and custom hardware. 

The root cause of the the RAMTRON driver failing to initialise (step 1. above) was different data returned by different manufacturers. Fujitsu and Cypress make FRAM chips that are both pin and register compatible, but each manufacturer returns different data when the `RDID` register is read.

This pull request contains the following key changes to address the issues discovered during this investigation:
- RAMTRON:
    - Updated the struct that defines the supported FRAM devices to include the `RDID` format. This was then used to properly parse the read of the `RDID` register.
    - Updated the `init` function to ensure the `WriteEnable` and `BlockProtect` bits of the status register are properly set.
    - Updated the `read` and `write` functions so that the SPI read and write calls were inside the same chip select activation. This prevents spurious data being returned if the FRAM chip resets it's read registers on deselect.
    - Updated the `read` and `write` functions to fail if we attempt to access more data than the FRAM chip can hold. Previously these would silently wrap back to address `0x0000`, which would cause unexpected behaviour.
- AP_HAL_ChibiOS/Storage:
    - Added a field and extra logging to capture what physical device is being used by the Storage driver.
    - Added a panic if no suitable backend device can be initialised by the Storage driver.
    - Added an optional panic (intended to be controlled by a define in the `hwdef.dat` file) that prevents falling back to another device if the FRAM can't be initialised. 

Please let me know if you need test evidence and/or test cases for this.
