### PR TITLE
Sub 4.0: use AP_Arming_Sub to disarm in motor test and failsafe

### DIFF
--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -58,7 +58,7 @@ void Sub::mainloop_failsafe_check()
         // disarm motors every second
         failsafe_last_timestamp = tnow;
         if (motors.armed()) {
-            motors.armed(false);
+            arming.disarm();
             motors.output();
         }
     }

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -70,7 +70,7 @@ bool Sub::verify_motor_test()
 
     if (!pass) {
         ap.motor_test = false;
-        motors.armed(false); // disarm motors
+        arming.disarm(); // disarm motors
         last_do_motor_test_fail_ms = AP_HAL::millis();
         return false;
     }


### PR DESCRIPTION
Master and 4.0 cannot be armed again after disarming with `motors.armed(false)`.
Using AP_Arming_Sub to disarm fixes the issue.