### PR TITLE
AC_AttitudeControl: update param ranges

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -92,7 +92,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Param: ANG_YAW_P
     // @DisplayName: Yaw axis angle controller P gain
     // @Description: Yaw axis angle controller P gain.  Converts the error between the desired yaw angle and actual angle to a desired yaw rate
-    // @Range: 3.000 6.000
+    // @Range: 3.000 12.000
     // @Range{Sub}: 0.0 6.000
     // @User: Standard
     AP_SUBGROUPINFO(_p_angle_yaw, "ANG_YAW_", 15, AC_AttitudeControl, AC_P),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_RLL_FLTT
     // @DisplayName: Roll axis rate controller target frequency in Hz
     // @Description: Roll axis rate controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_RLL_FLTE
     // @DisplayName: Roll axis rate controller error frequency in Hz
     // @Description: Roll axis rate controller error frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_RLL_FLTD
     // @DisplayName: Roll axis rate controller derivative frequency in Hz
     // @Description: Roll axis rate controller derivative frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_PIT_FLTT
     // @DisplayName: Pitch axis rate controller target frequency in Hz
     // @Description: Pitch axis rate controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -132,7 +132,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_PIT_FLTE
     // @DisplayName: Pitch axis rate controller error frequency in Hz
     // @Description: Pitch axis rate controller error frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -140,7 +140,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_PIT_FLTD
     // @DisplayName: Pitch axis rate controller derivative frequency in Hz
     // @Description: Pitch axis rate controller derivative frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -190,7 +190,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_YAW_FLTT
     // @DisplayName: Yaw axis rate controller target frequency in Hz
     // @Description: Yaw axis rate controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -198,7 +198,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_YAW_FLTE
     // @DisplayName: Yaw axis rate controller error frequency in Hz
     // @Description: Yaw axis rate controller error frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -206,7 +206,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_YAW_FLTD
     // @DisplayName: Yaw axis rate controller derivative frequency in Hz
     // @Description: Yaw axis rate controller derivative frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -46,7 +46,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_RLL_FLTT
     // @DisplayName: Roll axis rate controller target frequency in Hz
     // @Description: Roll axis rate controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -54,7 +54,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_RLL_FLTE
     // @DisplayName: Roll axis rate controller error frequency in Hz
     // @Description: Roll axis rate controller error frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -62,7 +62,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_RLL_FLTD
     // @DisplayName: Roll axis rate controller derivative frequency in Hz
     // @Description: Roll axis rate controller derivative frequency in Hz
-    // @Range: 1 100
+    // @Range: 5 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -107,7 +107,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_PIT_FLTT
     // @DisplayName: Pitch axis rate controller target frequency in Hz
     // @Description: Pitch axis rate controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 5 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -115,7 +115,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_PIT_FLTE
     // @DisplayName: Pitch axis rate controller error frequency in Hz
     // @Description: Pitch axis rate controller error frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -123,7 +123,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_PIT_FLTD
     // @DisplayName: Pitch axis rate controller derivative frequency in Hz
     // @Description: Pitch axis rate controller derivative frequency in Hz
-    // @Range: 1 100
+    // @Range: 5 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -168,7 +168,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_YAW_FLTT
     // @DisplayName: Yaw axis rate controller target frequency in Hz
     // @Description: Yaw axis rate controller target frequency in Hz
-    // @Range: 1 5
+    // @Range: 1 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -176,7 +176,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_YAW_FLTE
     // @DisplayName: Yaw axis rate controller error frequency in Hz
     // @Description: Yaw axis rate controller error frequency in Hz
-    // @Range: 1 10
+    // @Range: 0 20
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -184,7 +184,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_YAW_FLTD
     // @DisplayName: Yaw axis rate controller derivative frequency in Hz
     // @Description: Yaw axis rate controller derivative frequency in Hz
-    // @Range: 1 20
+    // @Range: 5 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard


### PR DESCRIPTION
This is a small update to the min and max values for some of the attitude control gain parameters.

I've run over these suggested limits with @lthall but I haven't updated the equivalent tradheli limits.  Maybe @bnsgeyer can confirm he's happy with the tradheli limits?

I noticed the limits were a bit too strict because my [Hexsoon EDU450](https://ardupilot.org/copter/docs/reference-frames-hexsoon-edu450.html) params were triggering little pop-ups from MP.