### PR TITLE
Copter: improve landing detection by using filtered acceleration

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -285,7 +285,7 @@ void Copter::rc_loop()
 void Copter::throttle_loop()
 {
     // update throttle_low_comp value (controls priority of throttle vs attitude control)
-    update_throttle_thr_mix();
+    update_throttle_mix();
 
     // check auto_armed status
     update_auto_armed();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -744,7 +744,7 @@ private:
     void update_land_detector();
     void set_land_complete(bool b);
     void set_land_complete_maybe(bool b);
-    void update_throttle_thr_mix();
+    void update_throttle_mix();
 
     // landing_gear.cpp
     void landinggear_update();

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -137,14 +137,14 @@ void Copter::set_land_complete_maybe(bool b)
     ap.land_complete_maybe = b;
 }
 
-// update_throttle_thr_mix - sets motors throttle_low_comp value depending upon vehicle state
+// sets motors throttle_low_comp value depending upon vehicle state
 //  low values favour pilot/autopilot throttle over attitude control, high values favour attitude control over throttle
 //  has no effect when throttle is above hover throttle
-void Copter::update_throttle_thr_mix()
+void Copter::update_throttle_mix()
 {
 #if FRAME_CONFIG != HELI_FRAME
     // if disarmed or landed prioritise throttle
-    if(!motors->armed() || ap.land_complete) {
+    if (!motors->armed() || ap.land_complete) {
         attitude_control->set_throttle_mix_min();
         return;
     }
@@ -175,7 +175,7 @@ void Copter::update_throttle_thr_mix()
         // check for requested decent
         bool descent_not_demanded = pos_control->get_desired_velocity().z >= 0.0f;
 
-        if ( large_angle_request || large_angle_error || accel_moving || descent_not_demanded) {
+        if (large_angle_request || large_angle_error || accel_moving || descent_not_demanded) {
             attitude_control->set_throttle_mix_max(pos_control->get_vel_z_control_ratio());
         } else {
             attitude_control->set_throttle_mix_min();

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -168,9 +168,7 @@ void Copter::update_throttle_mix()
         bool large_angle_error = (angle_error > LAND_CHECK_ANGLE_ERROR_DEG);
 
         // check for large acceleration - falling or high turbulence
-        Vector3f accel_ef = ahrs.get_accel_ef_blended();
-        accel_ef.z += GRAVITY_MSS;
-        bool accel_moving = (accel_ef.length() > LAND_CHECK_ACCEL_MOVING);
+        const bool accel_moving = (land_accel_ef_filter.get().length() > LAND_CHECK_ACCEL_MOVING);
 
         // check for requested decent
         bool descent_not_demanded = pos_control->get_desired_velocity().z >= 0.0f;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -177,7 +177,7 @@ void Plane::update_speed_height(void)
 
     if (quadplane.in_vtol_mode() ||
         quadplane.in_assisted_flight()) {
-        quadplane.update_throttle_thr_mix();
+        quadplane.update_throttle_mix();
     }
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3150,7 +3150,7 @@ float QuadPlane::stopping_distance(void)
 #define LAND_CHECK_LARGE_ANGLE_CD   1500.0f     // maximum angle target to be considered landing
 #define LAND_CHECK_ACCEL_MOVING     3.0f        // maximum acceleration after subtracting gravity
 
-void QuadPlane::update_throttle_thr_mix(void)
+void QuadPlane::update_throttle_mix(void)
 {
     // transition will directly manage the mix
     if (in_transition()) {
@@ -3158,7 +3158,7 @@ void QuadPlane::update_throttle_thr_mix(void)
     }
 
     // if disarmed or landed prioritise throttle
-    if(!motors->armed()) {
+    if (!motors->armed()) {
         attitude_control->set_throttle_mix_min();
         return;
     }
@@ -3189,7 +3189,7 @@ void QuadPlane::update_throttle_thr_mix(void)
         // check for requested decent
         bool descent_not_demanded = pos_control->get_desired_velocity().z >= 0.0f;
 
-        if ( large_angle_request || large_angle_error || accel_moving || descent_not_demanded) {
+        if (large_angle_request || large_angle_error || accel_moving || descent_not_demanded) {
             attitude_control->set_throttle_mix_max(1.0);
         } else {
             attitude_control->set_throttle_mix_min();

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -53,7 +53,7 @@ public:
     void takeoff_controller(void);
     void waypoint_controller(void);
 
-    void update_throttle_thr_mix(void);
+    void update_throttle_mix(void);
     
     // update transition handling
     void update(void);


### PR DESCRIPTION
This PR modifies the update_throttle_mix() method so that it uses filtered accelerations (filtered at 1hz) instead of the raw accelerations.  This is consistent with the update_land_detector() function and makes the landing detector more resistant to high vibrations.

High vibrations leading to a failed landing detector has been seen in the logs of at least one user.

Perhaps @lthall can say whether there's any downsides to the additional filtering.

Below is a test with this change applied to Copter-3.6.12 (see below for why I didn't use master) after setting SIM_ACC_RND = 20
![before-after](https://user-images.githubusercontent.com/1498098/75020477-2b098480-54d6-11ea-9116-d79176606fdd.png)

This PR also makes some minor formatting and function name changes to both Copter and Plane.  These are non-functional changes.

Note: we should probably make the same change in Plane but I could not immediately figure out where to introduce the change

Note2: I attempted to test with master but apparently there are no longer any vibrations in master?  @andyp1per can you check that your changes to SITL haven't disabled vibration by default?