### PR TITLE
AP_Mount: ignore RCx_TRIM when calculating desired angle

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -138,7 +138,7 @@ void AP_Mount_Backend::update_targets_from_rc()
 // returns the angle (radians) that the RC_Channel input is receiving
 float AP_Mount_Backend::angle_input_rad(const RC_Channel* rc, int16_t angle_min, int16_t angle_max)
 {
-    return radians(((rc->norm_input() + 1.0f) * 0.5f * (angle_max - angle_min) + angle_min)*0.01f);
+    return radians(((rc->norm_input_ignore_trim() + 1.0f) * 0.5f * (angle_max - angle_min) + angle_min)*0.01f);
 }
 
 bool AP_Mount_Backend::calc_angle_to_roi_target(Vector3f& angles_to_target_rad,

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -106,35 +106,30 @@ RC_Channel::RC_Channel(void)
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-void
-RC_Channel::set_range(uint16_t high)
+void RC_Channel::set_range(uint16_t high)
 {
     type_in = RC_CHANNEL_TYPE_RANGE;
     high_in = high;
 }
 
-void
-RC_Channel::set_angle(uint16_t angle)
+void RC_Channel::set_angle(uint16_t angle)
 {
     type_in = RC_CHANNEL_TYPE_ANGLE;
     high_in = angle;
 }
 
-void
-RC_Channel::set_default_dead_zone(int16_t dzone)
+void RC_Channel::set_default_dead_zone(int16_t dzone)
 {
     dead_zone.set_default(abs(dzone));
 }
 
-bool
-RC_Channel::get_reverse(void) const
+bool RC_Channel::get_reverse(void) const
 {
     return bool(reversed.get());
 }
 
 // read input from hal.rcin or overrides
-bool
-RC_Channel::update(void)
+bool RC_Channel::update(void)
 {
     if (has_override() && !rc().ignore_overrides()) {
         radio_in = override_value;
@@ -157,8 +152,7 @@ RC_Channel::update(void)
 // recompute control values with no deadzone
 // When done this way the control_in value can be used as servo_out
 // to give the same output as input
-void
-RC_Channel::recompute_pwm_no_deadzone()
+void RC_Channel::recompute_pwm_no_deadzone()
 {
     if (type_in == RC_CHANNEL_TYPE_RANGE) {
         control_in = pwm_to_range_dz(0);
@@ -193,8 +187,7 @@ int16_t RC_Channel::get_control_mid() const
   return an "angle in centidegrees" (normally -4500 to 4500) from
   the current radio_in value using the specified dead_zone
  */
-int16_t
-RC_Channel::pwm_to_angle_dz_trim(uint16_t _dead_zone, uint16_t _trim) const
+int16_t RC_Channel::pwm_to_angle_dz_trim(uint16_t _dead_zone, uint16_t _trim) const
 {
     int16_t radio_trim_high = _trim + _dead_zone;
     int16_t radio_trim_low  = _trim - _dead_zone;
@@ -213,8 +206,7 @@ RC_Channel::pwm_to_angle_dz_trim(uint16_t _dead_zone, uint16_t _trim) const
   return an "angle in centidegrees" (normally -4500 to 4500) from
   the current radio_in value using the specified dead_zone
  */
-int16_t
-RC_Channel::pwm_to_angle_dz(uint16_t _dead_zone) const
+int16_t RC_Channel::pwm_to_angle_dz(uint16_t _dead_zone) const
 {
     return pwm_to_angle_dz_trim(_dead_zone, radio_trim);
 }
@@ -223,8 +215,7 @@ RC_Channel::pwm_to_angle_dz(uint16_t _dead_zone) const
   return an "angle in centidegrees" (normally -4500 to 4500) from
   the current radio_in value
  */
-int16_t
-RC_Channel::pwm_to_angle() const
+int16_t RC_Channel::pwm_to_angle() const
 {
 	return pwm_to_angle_dz(dead_zone);
 }
@@ -234,8 +225,7 @@ RC_Channel::pwm_to_angle() const
   convert a pulse width modulation value to a value in the configured
   range, using the specified deadzone
  */
-int16_t
-RC_Channel::pwm_to_range_dz(uint16_t _dead_zone) const
+int16_t RC_Channel::pwm_to_range_dz(uint16_t _dead_zone) const
 {
     int16_t r_in = constrain_int16(radio_in, radio_min.get(), radio_max.get());
 
@@ -255,8 +245,7 @@ RC_Channel::pwm_to_range_dz(uint16_t _dead_zone) const
   convert a pulse width modulation value to a value in the configured
   range
  */
-int16_t
-RC_Channel::pwm_to_range() const
+int16_t RC_Channel::pwm_to_range() const
 {
     return pwm_to_range_dz(dead_zone);
 }
@@ -272,8 +261,7 @@ int16_t RC_Channel::get_control_in_zero_dz(void) const
 
 // ------------------------------------------
 
-float
-RC_Channel::norm_input() const
+float RC_Channel::norm_input() const
 {
     float ret;
     int16_t reverse_mul = (reversed?-1:1);
@@ -291,8 +279,7 @@ RC_Channel::norm_input() const
     return constrain_float(ret, -1.0f, 1.0f);
 }
 
-float
-RC_Channel::norm_input_dz() const
+float RC_Channel::norm_input_dz() const
 {
     int16_t dz_min = radio_trim - dead_zone;
     int16_t dz_max = radio_trim + dead_zone;
@@ -323,8 +310,7 @@ float RC_Channel::norm_input_ignore_trim() const
 /*
   get percentage input from 0 to 100. This ignores the trim value.
  */
-uint8_t
-RC_Channel::percent_input() const
+uint8_t RC_Channel::percent_input() const
 {
     if (radio_in <= radio_min) {
         return reversed?100:0;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -308,6 +308,18 @@ RC_Channel::norm_input_dz() const
     return constrain_float(ret, -1.0f, 1.0f);
 }
 
+// return a normalised input for a channel, in range -1 to 1,
+// ignores trim and deadzone
+float RC_Channel::norm_input_ignore_trim() const
+{
+    // sanity check min and max to avoid divide by zero
+    if (radio_max <= radio_min) {
+        return 0.0f;
+    }
+    const float ret = (reversed ? -2.0f : 2.0f) * (((float)(radio_in - radio_min) / (float)(radio_max - radio_min)) - 0.5f);
+    return constrain_float(ret, -1.0f, 1.0f);
+}
+
 /*
   get percentage input from 0 to 100. This ignores the trim value.
  */

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -52,6 +52,10 @@ public:
     */
     float       norm_input_dz() const;
 
+    // return a normalised input for a channel, in range -1 to 1,
+    // ignores trim and deadzone
+    float       norm_input_ignore_trim() const;
+
     uint8_t     percent_input() const;
     int16_t     pwm_to_range() const;
     int16_t     pwm_to_range_dz(uint16_t dead_zone) const;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -40,16 +40,12 @@ public:
     // for hover throttle
     int16_t     pwm_to_angle_dz_trim(uint16_t dead_zone, uint16_t trim) const;
 
-    /*
-      return a normalised input for a channel, in range -1 to 1,
-      centered around the channel trim. Ignore deadzone.
-     */
+    // return a normalised input for a channel, in range -1 to 1,
+    // centered around the channel trim. Ignore deadzone.
     float       norm_input() const;
 
-    /*
-      return a normalised input for a channel, in range -1 to 1,
-      centered around the channel trim. Take into account the deadzone
-    */
+    // return a normalised input for a channel, in range -1 to 1,
+    // centered around the channel trim. Take into account the deadzone
     float       norm_input_dz() const;
 
     // return a normalised input for a channel, in range -1 to 1,
@@ -99,7 +95,7 @@ public:
 
     AP_Int16    option; // e.g. activate EPM gripper / enable fence
 
-    // auxillary switch support:
+    // auxiliary switch support
     void init_aux();
     bool read_aux();
 


### PR DESCRIPTION
This PR resolves [this user issue raised in the Copter-4.0 category on discuss](https://discuss.ardupilot.org/t/gimbal-limits-with-storm32-backend-mavlink-not-applied-correctly/51438).

The report was that the camera gimbal was not able to move all the way to the min/max configured angles.  The user had specified the min and max tilt angles as -90 and +10 deg respectively but the gimbal was only moving between -90 and -40 degrees.  The issue was the RC7_TRIM was the same as the RC7_MAX meaning only 1/2 the output range was possible.

This change has been successfully tested on a real board.  The two main tests were:

1. confirmed that the before-and-after output was the same if the RCx_TRIM was set to be precisely half way between RCx_MIN and RCx_MAX (see image below).  This was checked twice, once with RCx_REVERSED = 0, and once more with RCx_REVERSED = 1.
![image](https://user-images.githubusercontent.com/1498098/75086929-614e0f00-557d-11ea-968c-34b177e8f539.png)

2. confirmed that with the user's specified parameters the issue could be reproduced with master but was resolved with this PR.

This PR also makes some formatting changes but happy to remove these if there are any objections.

Just FYI, this change in behaviour comes from this PR:https://github.com/ArduPilot/ardupilot/pull/9953 which introduced a reliance on the RCx_TRIM values when calculating the pilot desired target angle.