### PR TITLE
FFT bugfixes

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3652,7 +3652,7 @@ class AutoTestCopter(AutoTest):
 
         self.do_RTL()
 
-    def hover_and_check_matched_frequency(self, dblevel=-15, minhz=200, maxhz=300, peakhz=None):
+    def hover_and_check_matched_frequency(self, dblevel=-15, minhz=200, maxhz=300, peakhz=None, freqMatch=0.05):
         # find a motor peak
         self.takeoff(10, mode="ALT_HOLD")
 
@@ -3693,7 +3693,7 @@ class AutoTestCopter(AutoTest):
         self.progress("Detected motor peak at %fHz processing %d messages" % (pkAvg, nmessages))
 
         # peak within 5%
-        if abs(pkAvg - freq) / freq > 0.1:
+        if abs(pkAvg - freq) / freq > freqMatch:
             raise NotAchievedException("FFT did not detect a motor peak at %f, found %f, wanted %f" % (dblevel, pkAvg, freq))
 
         return freq
@@ -3758,7 +3758,7 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("SIM_VIB_MOT_MULT", 0.25) # halve the motor noise so that the higher harmonic dominates
             self.reboot_sitl()
 
-            self.hover_and_check_matched_frequency(-15, 100, 250)
+            self.hover_and_check_matched_frequency(-15, 100, 250, None, 0.15)
             self.set_parameter("SIM_VIB_FREQ_X", 0)
             self.set_parameter("SIM_VIB_FREQ_Y", 0)
             self.set_parameter("SIM_VIB_FREQ_Z", 0)

--- a/libraries/AP_HAL/DSP.cpp
+++ b/libraries/AP_HAL/DSP.cpp
@@ -202,7 +202,7 @@ float DSP::calculate_quinns_second_estimator(const FFTWindowState* fft, const fl
     const float am = (complex_fft[k_m1] * complex_fft[k] + complex_fft[k_m1 + 1] * complex_fft[k + 1]) / divider;
 
     // sanity check
-    if (is_zero(ap) || is_zero(am)) {
+    if (fabsf(1.0f - ap) < 0.01f || fabsf(1.0f - am) < 0.01f) {
         return 0.0f;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -65,12 +65,13 @@ void AP_InertialSensor_SITL::generate_accel()
         float noise_variation = 0.05f;
         // this smears the individual motor peaks somewhat emulating physical motors
         float freq_variation = 0.12f;
-
+        // add in sensor noise
         xAccel += accel_noise * rand_float();
         yAccel += accel_noise * rand_float();
         zAccel += accel_noise * rand_float();
 
         bool motors_on = sitl->throttle > sitl->ins_noise_throttle_min;
+
         // on a real 180mm copter gyro noise varies between 0.8-4 m/s/s for throttle 0.2-0.8
         // giving a accel noise variation of 5.33 m/s/s over the full throttle range
         if (motors_on) {
@@ -80,6 +81,14 @@ void AP_InertialSensor_SITL::generate_accel()
 
         // VIB_FREQ is a static vibration applied to each axis
         const Vector3f &vibe_freq = sitl->vibe_freq;
+
+        if (vibe_freq.is_zero() && is_zero(sitl->vibe_motor)) {
+            // no rpm noise, so add in background noise if any
+            xAccel += accel_noise * rand_float();
+            yAccel += accel_noise * rand_float();
+            zAccel += accel_noise * rand_float();
+        }
+
         if (!vibe_freq.is_zero() && motors_on) {
             xAccel += sinf(accel_time * 2 * M_PI * vibe_freq.x) * calculate_noise(accel_noise, noise_variation);
             yAccel += sinf(accel_time * 2 * M_PI * vibe_freq.y) * calculate_noise(accel_noise, noise_variation);
@@ -164,7 +173,7 @@ void AP_InertialSensor_SITL::generate_gyro()
         float noise_variation = 0.05f;
         // this smears the individual motor peaks somewhat emulating physical motors
         float freq_variation = 0.12f;
-
+        // add in sensor noise
         p += gyro_noise * rand_float();
         q += gyro_noise * rand_float();
         r += gyro_noise * rand_float();
@@ -179,6 +188,14 @@ void AP_InertialSensor_SITL::generate_gyro()
 
         // VIB_FREQ is a static vibration applied to each axis
         const Vector3f &vibe_freq = sitl->vibe_freq;
+
+        if (vibe_freq.is_zero() && is_zero(sitl->vibe_motor)) {
+            // no rpm noise, so add in background noise if any
+            p += gyro_noise * rand_float();
+            q += gyro_noise * rand_float();
+            r += gyro_noise * rand_float();
+        }
+
         if (!vibe_freq.is_zero() && motors_on) {
             p += sinf(gyro_time * 2 * M_PI * vibe_freq.x) * calculate_noise(gyro_noise, noise_variation);
             q += sinf(gyro_time * 2 * M_PI * vibe_freq.y) * calculate_noise(gyro_noise, noise_variation);


### PR DESCRIPTION
This fixes four bugs related to the FFT support:

- Check for 1 rather than 0 in Quinn's estimator to avoid a possible divide by zero
- Make sure that user specified IMU noise is present if RPM noise is not being used
- The autotest for harmonic matching is a little flaky, I have relaxed the constraints pending looking into the cause
- Changed default window size on H7 boards to 64. This is because they can easily cope and generally have BMI088 which has a backend rate of 2kHz leading to poor frequency resolution at short lengths