### PR TITLE
Plane: Fix RTL behaviour when MIS_RESTART = 1 and DO_LAND_START present.

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -467,6 +467,7 @@ void Plane::update_navigation()
             // we've reached the RTL point, see if we have a landing sequence
             if (mission.jump_to_landing_sequence()) {
                 // switch from RTL -> AUTO
+                mission.set_force_resume(true);
                 set_mode(mode_auto, ModeReason::UNKNOWN);
             }
 
@@ -479,6 +480,7 @@ void Plane::update_navigation()
             // Go directly to the landing sequence
             if (mission.jump_to_landing_sequence()) {
                 // switch from RTL -> AUTO
+                mission.set_force_resume(true);
                 set_mode(mode_auto, ModeReason::UNKNOWN);
             }
 

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -163,10 +163,11 @@ bool AP_Mission::starts_with_takeoff_cmd()
 /// start_or_resume - if MIS_AUTORESTART=0 this will call resume(), otherwise it will call start()
 void AP_Mission::start_or_resume()
 {
-    if (_restart) {
+    if (_restart == 1 && !_force_resume) {
         start();
     } else {
         resume();
+        _force_resume = false;
     }
 }
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -305,6 +305,7 @@ public:
         _flags.nav_cmd_loaded = false;
         _flags.do_cmd_loaded = false;
         _flags.in_landing_sequence = false;
+        _force_resume = false;
     }
 
     // get singleton instance
@@ -479,6 +480,9 @@ public:
     // set in_landing_sequence flag
     void set_in_landing_sequence_flag(bool flag) { _flags.in_landing_sequence = flag; }
 
+    // force mission to resume when start_or_resume() is called
+    void set_force_resume(bool force_resume) { _force_resume = force_resume; }
+
     // get a reference to the AP_Mission semaphore, allowing an external caller to lock the
     // storage while working with multiple waypoints
     HAL_Semaphore &get_semaphore(void) {
@@ -582,6 +586,7 @@ private:
     uint16_t                _prev_nav_cmd_id;       // id of the previous "navigation" command. (WAYPOINT, LOITER_TO_ALT, ect etc)
     uint16_t                _prev_nav_cmd_index;    // index of the previous "navigation" command.  Rarely used which is why we don't store the whole command
     uint16_t                _prev_nav_cmd_wp_index; // index of the previous "navigation" command that contains a waypoint.  Rarely used which is why we don't store the whole command
+    bool                    _force_resume;  // when set true it forces mission to resume irrespective of MIS_RESTART param.
 
     // jump related variables
     struct jump_tracking_struct {


### PR DESCRIPTION
I have found what I believe to be incorrect behaviour given the following combination:

- Mission contains DO_LAND_START flag.
- RTL_AUTOLAND is set to either 1 or 2 (to land via a DO_LAND_START).
- MIS_RESTART = 1 (to reset mission on restart).
- RTL is initiated by any method other than by failsafe (e.g. via RC switch or GCS).

This series of circumstances leads to the mission always being reset.  Thus, instead of RTL causing the aircraft to land via a DO_LAND_START, it causes the mission to begin again from command 1.

This PR fixes this behaviour by adding a _force_resume bool in the mission library.  Allowing the invoking mode change back to RTL to effectively ignore the MIS_RESTART parameter in this niche case.

Tested in SITL