### PR TITLE
Copter: Enumerate A and B points of ZigZag

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -482,13 +482,13 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
             if (copter.flightmode == &copter.mode_zigzag) {
                 switch (ch_flag) {
                     case LOW:
-                        copter.mode_zigzag.save_or_move_to_destination(0);
+                        copter.mode_zigzag.save_or_move_to_destination(ModeZigZag::position::A);
                         break;
                     case MIDDLE:
                         copter.mode_zigzag.return_to_manual_control(false);
                         break;
                     case HIGH:
-                        copter.mode_zigzag.save_or_move_to_destination(1);
+                        copter.mode_zigzag.save_or_move_to_destination(ModeZigZag::position::B);
                         break;
                 }
             }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1390,6 +1390,11 @@ public:
     // Inherit constructor
     using Mode::Mode;
 
+    enum class position : uint8_t {
+        A,  // Position A
+        B,  // Position B
+    };
+
     bool init(bool ignore_checks) override;
     void run() override;
 
@@ -1398,8 +1403,8 @@ public:
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
 
-    // save current position as A (dest_num = 0) or B (dest_num = 1).  If both A and B have been saved move to the one specified
-    void save_or_move_to_destination(uint8_t dest_num);
+    // save current position as A (dest_num = position::A) or B (dest_num = position::B).  If both A and B have been saved move to the one specified
+    void save_or_move_to_destination(position dest_num);
 
     // return manual control to the pilot
     void return_to_manual_control(bool maintain_target);
@@ -1414,7 +1419,7 @@ private:
     void auto_control();
     void manual_control();
     bool reached_destination();
-    bool calculate_next_dest(uint8_t position_num, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const;
+    bool calculate_next_dest(position position_num, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const;
 
     Vector2f dest_A;    // in NEU frame in cm relative to ekf origin
     Vector2f dest_B;    // in NEU frame in cm relative to ekf origin

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -70,14 +70,9 @@ void ModeZigZag::run()
     }
 }
 
-// save current position as A (dest_num = 0) or B (dest_num = 1).  If both A and B have been saved move to the one specified
-void ModeZigZag::save_or_move_to_destination(uint8_t dest_num)
+// save current position as A (dest_num = position::A) or B (dest_num = position::B).  If both A and B have been saved move to the one specified
+void ModeZigZag::save_or_move_to_destination(position dest_num)
 {
-    // sanity check
-    if (dest_num > 1) {
-        return;
-    }
-
     // get current position as an offset from EKF origin
     const Vector3f curr_pos = inertial_nav.get_position();
 
@@ -85,7 +80,7 @@ void ModeZigZag::save_or_move_to_destination(uint8_t dest_num)
     switch (stage) {
 
         case STORING_POINTS:
-            if (dest_num == 0) {
+            if (dest_num == position::A) {
                 // store point A
                 dest_A.x = curr_pos.x;
                 dest_A.y = curr_pos.y;
@@ -120,7 +115,7 @@ void ModeZigZag::save_or_move_to_destination(uint8_t dest_num)
                     }
 #endif
                     reach_wp_time_ms = 0;
-                    if (dest_num == 0) {
+                    if (dest_num == position::A) {
                         gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to A");
                     } else {
                         gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to B");
@@ -318,15 +313,10 @@ bool ModeZigZag::reached_destination()
 // calculate next destination according to vector A-B and current position
 // use_wpnav_alt should be true if waypoint controller's altitude target should be used, false for position control or current altitude target
 // terrain_alt is returned as true if the next_dest should be considered a terrain alt
-bool ModeZigZag::calculate_next_dest(uint8_t dest_num, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const
+bool ModeZigZag::calculate_next_dest(position dest_num, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const
 {
-    // sanity check dest_num
-    if (dest_num > 1) {
-        return false;
-    }
-
     // define start_pos as either A or B depending upon dest_num
-    Vector2f start_pos = dest_num == 0 ? dest_A : dest_B;
+    Vector2f start_pos = (dest_num == position::A) ? dest_A : dest_B;
 
     // calculate vector from A to B
     Vector2f AB_diff = dest_B - dest_A;


### PR DESCRIPTION
I reflected the comment of #13648 
I decided to define points A and B by enum.