### PR TITLE
AC_WPNav: reduce main load to obey wp_spd change rule.

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -137,6 +137,7 @@ void AC_WPNav::wp_and_spline_init()
 
     // initialize the desired wp speed if not already done
     _wp_desired_speed_xy_cms = _wp_speed_cms;
+    _iswpspd_done_recalc = false;
 
     // initialise position controller speed and acceleration
     _pos_control.set_max_speed_xy(_wp_speed_cms);
@@ -156,6 +157,7 @@ void AC_WPNav::set_speed_xy(float speed_cms)
     // range check target speed
     if (speed_cms >= WPNAV_WP_SPEED_MIN) {
         _wp_desired_speed_xy_cms = speed_cms;
+        _iswpspd_done_recalc = false;
     }
 }
 
@@ -1064,6 +1066,10 @@ float AC_WPNav::get_slow_down_speed(float dist_from_dest_cm, float accel_cmss)
 /// wp_speed_update - calculates how to handle speed change requests
 void AC_WPNav::wp_speed_update(float dt)
 {
+	// directly return if speed update done
+	if (_iswpspd_done_recalc){
+		return;
+	}
     // return if speed has not changed
     float curr_max_speed_xy_cms = _pos_control.get_max_speed_xy();
     if (is_equal(_wp_desired_speed_xy_cms, curr_max_speed_xy_cms)) {
@@ -1075,12 +1081,14 @@ void AC_WPNav::wp_speed_update(float dt)
         curr_max_speed_xy_cms += _wp_accel_cmss * dt;
         if (curr_max_speed_xy_cms > _wp_desired_speed_xy_cms) {
             curr_max_speed_xy_cms = _wp_desired_speed_xy_cms;
+            _iswpspd_done_recalc = true;
         }
     } else if (_wp_desired_speed_xy_cms < curr_max_speed_xy_cms) {
         // slow down is requested so reduce speed within limit set by WPNAV_ACCEL
         curr_max_speed_xy_cms -= _wp_accel_cmss * dt;
         if (curr_max_speed_xy_cms < _wp_desired_speed_xy_cms) {
             curr_max_speed_xy_cms = _wp_desired_speed_xy_cms;
+            _iswpspd_done_recalc = true;
         }
     }
 

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -299,6 +299,7 @@ protected:
 
     // waypoint controller internal variables
     uint32_t    _wp_last_update;        // time of last update_wpnav call
+    bool        _iswpspd_done_recalc;  // flag if we have reached the desired speed to reduce calculation load
     float       _wp_desired_speed_xy_cms;   // desired wp speed in cm/sec
     Vector3f    _origin;                // starting point of trip to next waypoint in cm from ekf origin
     Vector3f    _destination;           // target destination in cm from ekf origin


### PR DESCRIPTION
This Pr can improve the PR #12821 performance by add a simple flag to cast off useless calculation and reduce the main loop load.
I don't  use too much is_equal in float quantities as I personally prefer.
PR #12821 could be too expensive using "is_equal" function in main loop only to get a better speed updata state. We actually don't necesarry to  always do "float equal" check for speed update in the whole progress in main loop navigation then.  I indeed hope we can make this better.