### PR TITLE
Move handling of AP_PARAM_KEY_DUMP up

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -130,10 +130,6 @@ void Rover::init_ardupilot()
 
     // flag that initialisation has completed
     initialised = true;
-
-#if AP_PARAM_KEY_DUMP
-    AP_Param::show_all(hal.console, true);
-#endif
 }
 
 //*********************************************************************************

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -224,10 +224,6 @@ void Copter::init_ardupilot()
 
     // flag that initialisation has completed
     ap.initialised = true;
-
-#if AP_PARAM_KEY_DUMP
-    AP_Param::show_all(hal.console, true);
-#endif
 }
 
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -160,10 +160,6 @@ void Plane::init_ardupilot()
 
     // disable safety if requested
     BoardConfig.init_safety();
-
-#if AP_PARAM_KEY_DUMP
-    AP_Param::show_all(hal.console, true);
-#endif
 }
 
 //********************************************************************************

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -192,10 +192,6 @@ void Sub::init_ardupilot()
 
     // flag that initialisation has completed
     ap.initialised = true;
-
-#if AP_PARAM_KEY_DUMP
-    AP_Param::show_all(hal.console, true);
-#endif
 }
 
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -79,6 +79,7 @@ void AP_Vehicle::setup()
 
     // init_ardupilot is where the vehicle does most of its initialisation.
     init_ardupilot();
+
     // gyro FFT needs to be initialized really late
 #if HAL_GYROFFT_ENABLED
     gyro_fft.init(AP::scheduler().get_loop_period_us());
@@ -88,6 +89,10 @@ void AP_Vehicle::setup()
 #endif
 #if HAL_HOTT_TELEM_ENABLED
     hott_telem.init();
+#endif
+
+#if AP_PARAM_KEY_DUMP
+    AP_Param::show_all(hal.console, true);
 #endif
 }
 


### PR DESCRIPTION
This is a diagnostic thing used for debugging parameter stuff.

Better one copy than 4.
