### PR TITLE
Rover: Enter Auto mode if no mission is defined while unarmed

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -194,5 +194,11 @@ bool AP_Arming_Rover::mode_checks(bool report)
         check_failed(report, "Mode not armable");
         return false;
     }
+
+    //check if mission commands exists before arming in mode auto
+    if (rover.control_mode == &rover.mode_auto && rover.mode_auto.mission.num_commands() <= 1) {
+        check_failed(report, "Mode AUTO not armable without mission");
+        return false;
+    }
     return true;
 }

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -6,7 +6,7 @@
 bool ModeAuto::_enter()
 {
     // fail to enter auto if no mission commands
-    if (mission.num_commands() <= 1) {
+    if (mission.num_commands() <= 1 && hal.util->get_soft_armed()) {
         gcs().send_text(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
         return false;
     }


### PR DESCRIPTION
This is a fix for #12662
Currently, we do not allow switching to mode auto at all If no mission is set. This PR adds a new pre arm condition and does not allow arming if we are in mode auto AND no mission is defined.
However, the user is now free to change into mode auto while the vehicle is unarmed. 