### PR TITLE
AP_Vehicle: add virtual getters to access basic waypoint info

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -202,9 +202,6 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if STATS_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Stats,             &copter.g2.stats,            update,           1, 100),
 #endif
-#if OSD_ENABLED == ENABLED
-    SCHED_TASK(publish_osd_info, 1, 10),
-#endif
 };
 
 void Copter::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
@@ -617,17 +614,29 @@ void Copter::update_altitude()
     }
 }
 
-#if OSD_ENABLED == ENABLED
-void Copter::publish_osd_info()
+// vehicle specific waypoint info helpers
+bool Copter::get_wp_distance_m(float &distance) const
 {
-    AP_OSD::NavInfo nav_info;
-    nav_info.wp_distance = flightmode->wp_distance() * 1.0e-2f;
-    nav_info.wp_bearing = flightmode->wp_bearing();
-    nav_info.wp_xtrack_error = flightmode->crosstrack_error() * 1.0e-2f;
-    nav_info.wp_number = mode_auto.mission.get_current_nav_index();
-    osd.set_nav_info(nav_info);
+    // see GCS_MAVLINK_Copter::send_nav_controller_output()
+    distance = flightmode->wp_distance() * 0.01;
+    return true;
 }
-#endif
+
+// vehicle specific waypoint info helpers
+bool Copter::get_wp_bearing_deg(float &bearing) const
+{
+    // see GCS_MAVLINK_Copter::send_nav_controller_output()
+    bearing = flightmode->wp_bearing() * 0.01;
+    return true;
+}
+
+// vehicle specific waypoint info helpers
+bool Copter::get_wp_crosstrack_error_m(float &xtrack_error) const
+{
+    // see GCS_MAVLINK_Copter::send_nav_controller_output()
+    xtrack_error = flightmode->crosstrack_error() * 0.01;
+    return true;
+}
 
 /*
   constructor for main Copter class

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -887,9 +887,10 @@ private:
     void userhook_auxSwitch2(uint8_t ch_flag);
     void userhook_auxSwitch3(uint8_t ch_flag);
 
-#if OSD_ENABLED == ENABLED
-    void publish_osd_info();
-#endif
+    // vehicle specific waypoint info helpers
+    bool get_wp_distance_m(float &distance) const override;
+    bool get_wp_bearing_deg(float &bearing) const override;
+    bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
 
     Mode *flightmode;
 #if MODE_ACRO_ENABLED == ENABLED

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -977,9 +977,6 @@ private:
     void update_control_mode(void);
     void update_flight_stage();
     void set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs);
-#if OSD_ENABLED || OSD_PARAM_ENABLED
-    void publish_osd_info();
-#endif
 
     // navigation.cpp
     void set_nav_controller(void);
@@ -1081,6 +1078,11 @@ private:
 #if HAL_SOARING_ENABLED
     void update_soaring();
 #endif
+
+    // vehicle specific waypoint info helpers
+    bool get_wp_distance_m(float &distance) const override;
+    bool get_wp_bearing_deg(float &bearing) const override;
+    bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
 
     // reverse_thrust.cpp
     bool reversed_throttle;

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -326,4 +326,28 @@ bool Sub::control_check_barometer()
     return true;
 }
 
+// vehicle specific waypoint info helpers
+bool Sub::get_wp_distance_m(float &distance) const
+{
+    // see GCS_MAVLINK_Sub::send_nav_controller_output()
+    distance = sub.wp_nav.get_wp_distance_to_destination() * 0.01;
+    return true;
+}
+
+// vehicle specific waypoint info helpers
+bool Sub::get_wp_bearing_deg(float &bearing) const
+{
+    // see GCS_MAVLINK_Sub::send_nav_controller_output()
+    bearing = sub.wp_nav.get_wp_bearing_to_destination() * 0.01;
+    return true;
+}
+
+// vehicle specific waypoint info helpers
+bool Sub::get_wp_crosstrack_error_m(float &xtrack_error) const
+{
+    // no crosstrack error reported, see GCS_MAVLINK_Sub::send_nav_controller_output()
+    xtrack_error = 0;
+    return true;
+}
+
 AP_HAL_MAIN_CALLBACKS(&sub);

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -639,6 +639,11 @@ private:
 
     bool control_check_barometer();
 
+    // vehicle specific waypoint info helpers
+    bool get_wp_distance_m(float &distance) const override;
+    bool get_wp_bearing_deg(float &bearing) const override;
+    bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
+
     enum Failsafe_Action {
         Failsafe_Action_None    = 0,
         Failsafe_Action_Warn    = 1,

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -107,9 +107,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(afs_fs_check,           10,    200),
 #endif
     SCHED_TASK(read_airspeed,          10,    100),
-#if OSD_ENABLED == ENABLED
-    SCHED_TASK(publish_osd_info,        1,     10),
-#endif
 };
 
 
@@ -384,23 +381,39 @@ void Rover::update_mission(void)
     }
 }
 
-#if OSD_ENABLED == ENABLED
-void Rover::publish_osd_info()
+// vehicle specific waypoint info helpers
+bool Rover::get_wp_distance_m(float &distance) const
 {
-    AP_OSD::NavInfo nav_info {0};
-    if (control_mode == &mode_loiter) {
-        nav_info.wp_xtrack_error = control_mode->get_distance_to_destination();
-    } else {
-        nav_info.wp_xtrack_error = control_mode->crosstrack_error();
+    // see GCS_MAVLINK_Rover::send_nav_controller_output()
+    if (!rover.control_mode->is_autopilot_mode()) {
+        return false;
     }
-    nav_info.wp_distance = control_mode->get_distance_to_destination();
-    nav_info.wp_bearing = control_mode->wp_bearing() * 100.0f;
-    if (control_mode == &mode_auto) {
-         nav_info.wp_number = mode_auto.mission.get_current_nav_index();
-    }
-    osd.set_nav_info(nav_info);
+    distance = control_mode->get_distance_to_destination();
+    return true;
 }
-#endif
+
+// vehicle specific waypoint info helpers
+bool Rover::get_wp_bearing_deg(float &bearing) const
+{
+    // see GCS_MAVLINK_Rover::send_nav_controller_output()
+    if (!rover.control_mode->is_autopilot_mode()) {
+        return false;
+    }
+    bearing = control_mode->wp_bearing();
+    return true;
+}
+
+// vehicle specific waypoint info helpers
+bool Rover::get_wp_crosstrack_error_m(float &xtrack_error) const
+{
+    // see GCS_MAVLINK_Rover::send_nav_controller_output()
+    if (!rover.control_mode->is_autopilot_mode()) {
+        return false;
+    }
+    xtrack_error = control_mode->crosstrack_error();
+    return true;
+}
+
 
 Rover rover;
 AP_Vehicle& vehicle = rover;

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -390,9 +390,10 @@ private:
     bool should_log(uint32_t mask);
     bool is_boat() const;
 
-#if OSD_ENABLED || OSD_PARAM_ENABLED
-    void publish_osd_info();
-#endif
+    // vehicle specific waypoint info helpers
+    bool get_wp_distance_m(float &distance) const override;
+    bool get_wp_bearing_deg(float &bearing) const override;
+    bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
 
     enum Failsafe_Action {
         Failsafe_Action_None          = 0,

--- a/libraries/AP_Scripting/examples/wp_test.lua
+++ b/libraries/AP_Scripting/examples/wp_test.lua
@@ -1,0 +1,50 @@
+-- Example script for accessing waypoint info
+
+local wp_index
+local wp_distance
+local wp_bearing
+local wp_error
+local wp_max_distance = 0
+local last_log_ms = millis()
+
+
+function on_wp_change(index, distance)
+    wp_index = index
+    wp_distance = distance
+    wp_distance_max = distance;
+    gcs:send_text(0, string.format("NEW WP: idx=%d, dist=%.01fm", index, distance))
+end
+
+function refresh_wp_info()
+    local index = mission:get_current_nav_index()
+    local distance = vehicle:get_wp_distance_m()
+    local bearing = vehicle:get_wp_bearing_deg()
+    local error = vehicle:get_wp_crosstrack_error_m()
+
+    if index ~= nil and index ~= wp_index and distance ~= nil then
+        on_wp_change(index, distance)
+    end 
+
+    if index ~= nil and distance ~= nil and bearing ~= nil and error ~= nil then
+        wp_index = index
+        wp_bearing = bearing
+        wp_distance = distance
+        wp_error = error
+        wp_distance_max = math.max(wp_distance_max, wp_distance)
+    end
+end
+
+function log_wp_info(index, distance, bearing, error)
+    if index ~= nil and distance ~= nil and bearing ~= nil and error ~= nil then
+        local perc = wp_distance_max > 0 and 100-(100*(distance/wp_distance_max)) or 0
+        gcs:send_text(0, string.format("WP: %d, %.01fm (%.01f%%), b: %d°, xe:%.01fm", index, distance, perc, math.floor(bearing+0.5), error))
+    end
+end
+
+function update()
+    refresh_wp_info()
+    log_wp_info(wp_index, wp_distance, wp_bearing, wp_error)
+    return update, 1000 -- 1Hz
+end
+  
+return update(), 1000 -- start with a 1 sec delay

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -188,6 +188,9 @@ singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f
 singleton AP_Vehicle method set_target_angle_and_climbrate boolean float -180 180 float -90 90 float -360 360 float -FLT_MAX FLT_MAX boolean float -FLT_MAX FLT_MAX
 singleton AP_Vehicle method set_steering_and_throttle boolean float -1 1 float -1 1
+singleton AP_Vehicle method get_wp_distance_m boolean float'Null
+singleton AP_Vehicle method get_wp_bearing_deg boolean float'Null
+singleton AP_Vehicle method get_wp_crosstrack_error_m boolean float'Null
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -4,6 +4,8 @@
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Frsky_Telem/AP_Frsky_Parameters.h>
+#include <AP_Mission/AP_Mission.h>
+#include <AP_OSD/AP_OSD.h>
 
 #define SCHED_TASK(func, rate_hz, max_time_micros) SCHED_TASK_CLASS(AP_Vehicle, &vehicle, func, rate_hz, max_time_micros)
 
@@ -191,6 +193,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #if GENERATOR_ENABLED
     SCHED_TASK_CLASS(AP_Generator, &vehicle.generator,      update,                   10,  50),
 #endif
+#if OSD_ENABLED
+    SCHED_TASK(publish_osd_info, 1, 10),
+#endif
 };
 
 void AP_Vehicle::get_common_scheduler_tasks(const AP_Scheduler::Task*& tasks, uint8_t& num_tasks)
@@ -319,6 +324,34 @@ void AP_Vehicle::reboot(bool hold_in_bootloader)
 
     hal.scheduler->reboot(hold_in_bootloader);
 }
+
+#if OSD_ENABLED
+void AP_Vehicle::publish_osd_info()
+{
+    AP_Mission *mission = AP::mission();
+    if (mission == nullptr) {
+        return;
+    }
+    AP_OSD *osd = AP::osd();
+    if (osd == nullptr) {
+        return;
+    }
+    AP_OSD::NavInfo nav_info;
+    if(!get_wp_distance_m(nav_info.wp_distance)) {
+        return;
+    }
+    float wp_bearing_deg;
+    if (!get_wp_bearing_deg(wp_bearing_deg)) {
+        return;
+    }
+    nav_info.wp_bearing = (int32_t)wp_bearing_deg * 100; // OSD expects cd
+    if (!get_wp_crosstrack_error_m(nav_info.wp_xtrack_error)) {
+        return;
+    }
+    nav_info.wp_number = mission->get_current_nav_index();
+    osd->set_nav_info(nav_info);
+}
+#endif
 
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -214,6 +214,24 @@ public:
     // and flashing LEDs as appropriate
     void reboot(bool hold_in_bootloader);
 
+    /*
+      get the distance to next wp in meters
+      return false if failed or n/a
+     */
+    virtual bool get_wp_distance_m(float &distance) const { return false; }
+
+    /*
+      get the current wp bearing in degrees
+      return false if failed or n/a
+     */
+    virtual bool get_wp_bearing_deg(float &bearing) const { return false; }
+
+    /*
+      get the current wp crosstrack error in meters
+      return false if failed or n/a
+     */
+    virtual bool get_wp_crosstrack_error_m(float &xtrack_error) const { return false; }
+
 #if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
     AP_Frsky_Parameters frsky_parameters;
 #endif
@@ -293,6 +311,10 @@ protected:
 
     static const struct AP_Param::GroupInfo var_info[];
     static const struct AP_Scheduler::Task scheduler_tasks[];
+
+#if OSD_ENABLED
+    void publish_osd_info();
+#endif
 
 private:
 


### PR DESCRIPTION
This adds 3 pure virtual functions to AP_Vehicle to access:
- distance to next waypoint
- current waypoint bearing
- current waypoint crosstrack error

the implementations use the OSD code to be consistent across vehicles.

~~it's a POC to see if this approach is accepted~~

~~This also removes the need for the publish_osd_info call from the vehicle tasks~~