### PR TITLE
AP_UAVCAN: uavcan DNA range min/max, and dual-bus support for DNA

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -804,8 +804,13 @@ bool AP_Arming::can_checks(bool report)
                 }
                 case AP_BoardConfig_CAN::Protocol_Type_UAVCAN:
                 {
-                    snprintf(fail_msg, ARRAY_SIZE(fail_msg), "UAVCAN failed");
-                    if (!AP::uavcan_dna_server().prearm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
+                    snprintf(fail_msg, ARRAY_SIZE(fail_msg), "UAVCAN0 failed");
+                    if (!AP::uavcan_dna_server0().prearm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
+                        check_failed(ARMING_CHECK_SYSTEM, report, "%s", fail_msg);
+                        return false;
+                    }
+                    snprintf(fail_msg, ARRAY_SIZE(fail_msg), "UAVCAN1 failed");
+                    if (!AP::uavcan_dna_server1().prearm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
                         check_failed(ARMING_CHECK_SYSTEM, report, "%s", fail_msg);
                         return false;
                     }

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -151,8 +151,11 @@ void AP_BoardConfig_CAN::init()
             if (prot_type == Protocol_Type_UAVCAN) {
                 _drivers[i]._driver = _drivers[i]._uavcan =  new AP_UAVCAN;
 
+                printf("trying to start UAVCAN...\n\r", i + 1);
+
                 if (_drivers[i]._driver == nullptr) {
                     AP_HAL::panic("Failed to allocate uavcan %d\n\r", i + 1);
+                    printf("Failed to allocate uavcan %d\n\r", i + 1);
                     continue;
                 }
 
@@ -197,6 +200,9 @@ void AP_BoardConfig_CAN::init()
 #else
             _drivers[i]._driver->init(i, true);
 #endif
+
+            printf("... finished initing uavcan\n\r", i + 1);
+
         }
     }
 }

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.h
@@ -7,7 +7,7 @@
 #include <AP_Param/AP_Param.h>
 
 #ifndef AP_CAN_DEBUG
-  #define AP_CAN_DEBUG 0
+  #define AP_CAN_DEBUG 1
 #endif
 
 class AP_BoardConfig_CAN {

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -58,8 +58,8 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define debug_uavcan(level_debug, fmt, args...) do { if ((level_debug) <= AP::can().get_debug_level_driver(_driver_index)) { printf(fmt, ##args); }} while (0)
-//#define debug_uavcan(level_debug, fmt, args...) do { gcs().send_text(MAV_SEVERITY_WARNING, fmt, ##args); } while (0)
+//#define debug_uavcan(level_debug, fmt, args...) do { if ((level_debug) <= AP::can().get_debug_level_driver(_driver_index)) { printf(fmt, ##args); }} while (0)
+#define debug_uavcan(level_debug, fmt, args...) do { gcs().send_text(MAV_SEVERITY_WARNING, fmt, ##args); } while (0)
 
 // Translation of all messages from UAVCAN structures into AP structures is done
 // in AP_UAVCAN and not in corresponding drivers.
@@ -249,12 +249,27 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
         return;
     }
 
-    //Start Servers
-    AP::uavcan_dna_server().set_min_max(_dna_min_id,_dna_max_id); 
-    if (!AP::uavcan_dna_server().init(this)) {
-        debug_uavcan(1, "UAVCAN: Failed to start DNA Server\n\r");
-        return;
+    //Start Server/s
+
+    if (driver_index == 0) {
+    AP::uavcan_dna_server0().set_min_max(_dna_min_id,_dna_max_id); 
+        if (!AP::uavcan_dna_server0().init(this)) {
+            debug_uavcan(1, "UAVCAN0: Failed to start DNA Server\n\r");
+            //return;
+        } else {
+            debug_uavcan(1, "UAVCAN0: OK starting DNA Server\n\r");
+        }
     }
+    if (driver_index == 1) {
+    AP::uavcan_dna_server1().set_min_max(_dna_min_id,_dna_max_id); 
+        if (!AP::uavcan_dna_server1().init(this)) {
+            debug_uavcan(1, "UAVCAN1: Failed to start DNA Server\n\r");
+            //return;
+        } else {
+            debug_uavcan(1, "UAVCAN1: OK starting DNA Server\n\r");
+        }
+    }
+
 
     // Roundup all subscribers from supported drivers
     AP_UAVCAN_DNA_Server::subscribe_msgs(this);
@@ -382,7 +397,8 @@ void AP_UAVCAN::loop(void)
         buzzer_send();
         rtcm_stream_send();
         safety_state_send();
-        AP::uavcan_dna_server().verify_nodes(this);
+        AP::uavcan_dna_server0().verify_nodes(this);
+        AP::uavcan_dna_server1().verify_nodes(this);
     }
 }
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -59,6 +59,7 @@
 extern const AP_HAL::HAL& hal;
 
 #define debug_uavcan(level_debug, fmt, args...) do { if ((level_debug) <= AP::can().get_debug_level_driver(_driver_index)) { printf(fmt, ##args); }} while (0)
+//#define debug_uavcan(level_debug, fmt, args...) do { gcs().send_text(MAV_SEVERITY_WARNING, fmt, ##args); } while (0)
 
 // Translation of all messages from UAVCAN structures into AP structures is done
 // in AP_UAVCAN and not in corresponding drivers.
@@ -95,6 +96,21 @@ const AP_Param::GroupInfo AP_UAVCAN::var_info[] = {
     // @Units: Hz
     // @User: Advanced
     AP_GROUPINFO("SRV_RT", 4, AP_UAVCAN, _servo_rate_hz, 50),
+
+
+    // these two are file to leave at their defaults unless u have multiple DNA devices on the same networtk, or you have multiple pixhawk/canbus combos and don't want client node/s to conflict.
+    // @Param: DYNAMIC NODE ALLOCATOR MIN
+    // @DisplayName: UAVCAN Dynamic Node Allocator MINIMUM NodeID
+    // @Description: UAVCAN Dynamic Node Allocator MINIMUM NodeID
+    // @Range: 1 254
+    // @User: Advanced
+    AP_GROUPINFO("AL_MIN", 5, AP_UAVCAN, _dna_min_id, 1),
+    // @Param: DYNAMIC NODE ALLOCATOR MAX
+    // @DisplayName: UAVCAN Dynamic Node Allocator MAXIMUM NodeID
+    // @Description: UAVCAN Dynamic Node Allocator MAXIMUM NodeID
+    // @Range: 1 254
+    // @User: Advanced
+    AP_GROUPINFO("AL_MAX", 6, AP_UAVCAN, _dna_max_id, 125), // aka MAX_NODE_ID
 
     AP_GROUPEND
 };
@@ -234,6 +250,7 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     }
 
     //Start Servers
+    AP::uavcan_dna_server().set_min_max(_dna_min_id,_dna_max_id); 
     if (!AP::uavcan_dna_server().init(this)) {
         debug_uavcan(1, "UAVCAN: Failed to start DNA Server\n\r");
         return;

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -170,7 +170,9 @@ private:
     uavcan::PoolAllocator<UAVCAN_NODE_POOL_SIZE, UAVCAN_NODE_POOL_BLOCK_SIZE, AP_UAVCAN::RaiiSynchronizer> _node_allocator;
 
     // UAVCAN parameters
-    AP_Int8 _uavcan_node;
+    AP_Int8 _uavcan_node; // if stored in a AP_Int8, the range is -127-127
+    AP_Int8 _dna_min_id;  //  1-126 is fine in this.
+    AP_Int8 _dna_max_id;  //  1-126 is fine in this.
     AP_Int32 _servo_bm;
     AP_Int32 _esc_bm;
     AP_Int16 _servo_rate_hz;

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
@@ -49,6 +49,10 @@ class AP_UAVCAN_DNA_Server
     uint8_t current_driver_index;
     uint32_t last_activity_ms;
 
+    // this servers min and max ids, 
+    uint8_t _this_dna_min_id = 1;
+    uint8_t _this_dna_max_id = 125;
+
     //Methods to handle and report Node IDs seen on the bus
     void addToSeenNodeMask(uint8_t node_id);
     bool isNodeSeen(uint8_t node_id);
@@ -90,6 +94,9 @@ public:
     // Do not allow copies
     AP_UAVCAN_DNA_Server(const AP_UAVCAN_DNA_Server &other) = delete;
     AP_UAVCAN_DNA_Server &operator=(const AP_UAVCAN_DNA_Server&) = delete;
+
+    // defines range of nodes assignable by DNA server before we start it.
+    bool set_min_max(uint8_t min, uint8_t max);
 
     //Initialises publisher and Server Record for specified uavcan driver
     bool init(AP_UAVCAN *ap_uavcan);

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
@@ -47,6 +47,9 @@ class AP_UAVCAN_DNA_Server
     uint8_t rcvd_unique_id[16];
     uint8_t rcvd_unique_id_offset;
     uint8_t current_driver_index;
+
+    uint8_t driver_index;
+
     uint32_t last_activity_ms;
 
     // this servers min and max ids, 
@@ -64,7 +67,7 @@ class AP_UAVCAN_DNA_Server
     bool readNodeData(NodeData &data, uint8_t node_id);
 
     //Writes the Server Record from storage for specified node id
-    bool writeNodeData(const NodeData &data, uint8_t node_id);
+    bool writeNodeData(const NodeData &data, uint8_t node_id, bool verbose);
 
     //Methods to set, clear and report NodeIDs allocated/registered so far
     bool setOccupationMask(uint8_t node_id);
@@ -75,7 +78,7 @@ class AP_UAVCAN_DNA_Server
     void setVerificationMask(uint8_t node_id);
 
     //Go through List to find node id for specified unique id
-    uint8_t getNodeIDForUniqueID(const uint8_t unique_id[], uint8_t size);
+    uint8_t getNodeIDForUniqueID(const uint8_t unique_id[], uint8_t size, bool self);
 
     //Add Node ID info to the record and setup necessary mask fields
     bool addNodeIDForUniqueID(uint8_t node_id, const uint8_t unique_id[], uint8_t size);
@@ -84,7 +87,7 @@ class AP_UAVCAN_DNA_Server
     uint8_t findFreeNodeID(uint8_t preferred);
 
     //Look in the storage and check if there's a valid Server Record there
-    bool isValidNodeDataAvailable(uint8_t node_id);
+    bool isValidNodeDataAvailable(uint8_t node_id,bool verbose);
 
     HAL_Semaphore sem;
 
@@ -128,6 +131,8 @@ public:
 
 namespace AP
 {
-AP_UAVCAN_DNA_Server& uavcan_dna_server();
+AP_UAVCAN_DNA_Server& uavcan_dna_server0();
+AP_UAVCAN_DNA_Server& uavcan_dna_server1();
+
 }
 #endif


### PR DESCRIPTION
 - suitable for multiple pixhawks on the same CAN bus
 - or co-existing with an other DNA server.
 - or multi-bus setups where you don't want id's on the different bus to conflict for other reasons.
 - if a node from a previous setup is found in persistent storage that is outside of the defined range, it's removed and the node treated as a new one, and assigned a new id inside the range.
eg: this will cause the DNA server to only assign CAN node id's in the 40-80 range, inclusive.
>param set CAN_D1_UC_AL_MIN 40
>param set CAN_D1_UC_AL_MAX 80
reboot required after changing these.