### PR TITLE
Copter: rewrite_get_alt_above_ground_cm for clarity

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -508,14 +508,19 @@ void Mode::make_safe_spool_down()
  */
 int32_t Mode::get_alt_above_ground_cm(void)
 {
-    int32_t alt_above_ground;
-    if (!copter.get_rangefinder_height_interpolated_cm(alt_above_ground)) {
-        bool navigating = pos_control->is_active_xy();
-        if (!navigating || !copter.current_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, alt_above_ground)) {
-            alt_above_ground = copter.current_loc.alt;
-        }
+    int32_t alt_above_ground_cm;
+    if (copter.get_rangefinder_height_interpolated_cm(alt_above_ground_cm)) {
+        return alt_above_ground_cm;
     }
-    return alt_above_ground;
+    if (!pos_control->is_active_xy()) {
+        return copter.current_loc.alt;
+    }
+    if (copter.current_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, alt_above_ground_cm)) {
+        return alt_above_ground_cm;
+    }
+
+    // Assume the Earth is flat:
+    return copter.current_loc.alt;
 }
 
 void Mode::land_run_vertical_control(bool pause_descent)


### PR DESCRIPTION
It's not entirely clear at a glance that we don't return an
uninitialised value off the stack here.

I'm actually pretty certain the original code is OK in terms of not returning an uninitialised value off a stack - it's just not clear at a glance.

This should be an NFC change as it is.  I wasn't going to PR it at this point - until @rmackay9 created https://github.com/ArduPilot/ardupilot/issues/13675

It does not seek to investigate the "why change when doing posxy control?" issue.
