### PR TITLE
Rover: allow user to set pivot turn exit angle

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -119,6 +119,7 @@ private:
     AP_Float _overshoot;            // maximum horizontal overshoot in meters
     AP_Int16 _pivot_angle;          // angle error that leads to pivot turn
     AP_Int16 _pivot_rate;           // desired turn rate during pivot turns in deg/sec
+    AP_Int16 _pivot_exit_angle;     // angle error that exits the pivot turn
 
     // references
     AR_AttitudeControl& _atc;       // rover attitude control library


### PR DESCRIPTION
This PR fixes #11973.
Currently, 10 degrees has been hardcoded as the angle error, below which the rover exits its pivot turn. I have converted this angle into a user-settable param and sets its default to 10. I feel this is a good feature to have. 
A minor description typo was also fixed for PIVOT_ANGLE param.