### PR TITLE
Copter: fix use of WP_NAVALT_MIN 

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -171,8 +171,9 @@ protected:
     // waypoint navigation but the user can control the yaw.
     void auto_takeoff_run();
     void auto_takeoff_set_start_alt(void);
-    void auto_takeoff_attitude_run(float target_yaw_rate);
-    // altitude below which we do no navigation in auto takeoff
+
+    // altitude above-ekf-origin below which auto takeoff does not control horizontal position
+    static bool auto_takeoff_no_nav_active;
     static float auto_takeoff_no_nav_alt_cm;
 
 public:

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -2,6 +2,7 @@
 
 Mode::_TakeOff Mode::takeoff;
 
+bool Mode::auto_takeoff_no_nav_active = false;
 float Mode::auto_takeoff_no_nav_alt_cm = 0;
 
 // This file contains the high-level takeoff logic for Loiter, PosHold, AltHold, Sport modes.
@@ -149,6 +150,9 @@ void Mode::auto_takeoff_run()
         return;
     }
 
+    // set motors to full range
+    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+
     // process pilot's yaw input
     float target_yaw_rate = 0;
     if (!copter.failsafe.radio) {
@@ -163,52 +167,45 @@ void Mode::auto_takeoff_run()
         wp_nav->shift_wp_origin_to_current_pos();
     }
 
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+    // check if we are not navigating because of low altitude
+    float nav_roll = 0.0f, nav_pitch = 0.0f;
+    if (auto_takeoff_no_nav_active) {
+        // check if vehicle has reached no_nav_alt threshold
+        if (inertial_nav.get_altitude() >= auto_takeoff_no_nav_alt_cm) {
+            auto_takeoff_no_nav_active = false;
+            wp_nav->shift_wp_origin_and_destination_to_stopping_point_xy();
+        } else {
+            // shift the navigation target horizontally to our current position
+            wp_nav->shift_wp_origin_and_destination_to_current_pos_xy();
+        }
+        // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
+        pos_control->set_limit_accel_xy();
+    }
 
     // run waypoint controller
     copter.failsafe_terrain_set_status(wp_nav->update_wpnav());
 
-    // call z-axis position controller (wpnav should have already updated it's alt target)
-    copter.pos_control->update_z_controller();
-
-    // call attitude controller
-    auto_takeoff_attitude_run(target_yaw_rate);
-}
-
-void Mode::auto_takeoff_set_start_alt(void)
-{
-    // start with our current altitude
-    auto_takeoff_no_nav_alt_cm = inertial_nav.get_altitude();
-
-    if (is_disarmed_or_landed() || !motors->get_interlock()) {
-        // we are not flying, add the wp_navalt_min
-        auto_takeoff_no_nav_alt_cm += g2.wp_navalt_min * 100;
-    }
-}
-
-
-/*
-  call attitude controller for automatic takeoff, limiting roll/pitch
-  if below wp_navalt_min
- */
-void Mode::auto_takeoff_attitude_run(float target_yaw_rate)
-{
-    float nav_roll, nav_pitch;
-
-    if (g2.wp_navalt_min > 0 && inertial_nav.get_altitude() < auto_takeoff_no_nav_alt_cm) {
-        // we haven't reached the takeoff navigation altitude yet
-        nav_roll = 0;
-        nav_pitch = 0;
-        // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
-        pos_control->set_limit_accel_xy();
-    } else {
+    if (!auto_takeoff_no_nav_active) {
         nav_roll = wp_nav->get_roll();
         nav_pitch = wp_nav->get_pitch();
     }
 
+    // call z-axis position controller (wpnav should have already updated it's alt target)
+    copter.pos_control->update_z_controller();
+
     // roll & pitch from waypoint controller, yaw rate from pilot
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(nav_roll, nav_pitch, target_yaw_rate);
+}
+
+void Mode::auto_takeoff_set_start_alt(void)
+{
+    if ((g2.wp_navalt_min > 0) && (is_disarmed_or_landed() || !motors->get_interlock())) {
+        // we are not flying, climb with no navigation to current alt-above-ekf-origin + wp_navalt_min
+        auto_takeoff_no_nav_alt_cm = inertial_nav.get_altitude() + g2.wp_navalt_min * 100;
+        auto_takeoff_no_nav_active = true;
+    } else {
+        auto_takeoff_no_nav_active = false;
+    }
 }
 
 bool Mode::is_taking_off() const

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -785,6 +785,16 @@ int32_t AC_PosControl::get_bearing_to_target() const
     return get_bearing_cd(_inav.get_position(), _pos_target);
 }
 
+// relax velocity controller by clearing velocity error and setting velocity target to current velocity
+void AC_PosControl::relax_velocity_controller_xy()
+{
+    const Vector3f& curr_vel = _inav.get_velocity();
+    _vel_target.x = curr_vel.x;
+    _vel_target.y = curr_vel.y;
+    _vel_error.x = 0.0f;
+    _vel_error.y = 0.0f;
+}
+
 // is_active_xy - returns true if the xy position controller has been run very recently
 bool AC_PosControl::is_active_xy() const
 {

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -233,6 +233,9 @@ public:
     /// freeze_ff_z - used to stop the feed forward being calculated during a known discontinuity
     void freeze_ff_z() { _flags.freeze_ff_z = true; }
 
+    // relax velocity controller by clearing velocity error and setting velocity target to current velocity
+    void relax_velocity_controller_xy();
+
     // is_active_xy - returns true if the xy position controller has been run very recently
     bool is_active_xy() const;
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -154,6 +154,9 @@ public:
     float get_leash_down_z() const { return _leash_down_z; }
     float get_leash_up_z() const { return _leash_up_z; }
 
+    /// freeze_ff_z - used to stop the feed forward being calculated during a known discontinuity
+    void freeze_ff_z() { _flags.freeze_ff_z = true; }
+
     ///
     /// xy position controller
     ///
@@ -230,9 +233,6 @@ public:
     // overrides the velocity process variable for one timestep
     void override_vehicle_velocity_xy(const Vector2f& vel_xy) { _vehicle_horiz_vel = vel_xy; _flags.vehicle_horiz_vel_override = true; }
 
-    /// freeze_ff_z - used to stop the feed forward being calculated during a known discontinuity
-    void freeze_ff_z() { _flags.freeze_ff_z = true; }
-
     // relax velocity controller by clearing velocity error and setting velocity target to current velocity
     void relax_velocity_controller_xy();
 
@@ -247,7 +247,6 @@ public:
     void set_target_to_stopping_point_xy();
 
     /// get_stopping_point_xy - calculates stopping point based on current position, velocity, vehicle acceleration
-    ///     distance_max allows limiting distance to stopping point
     ///     results placed in stopping_position vector
     ///     set_accel_xy() should be called before this method to set vehicle acceleration
     ///     set_leash_length() should have been called before this method

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -317,6 +317,47 @@ void AC_WPNav::shift_wp_origin_to_current_pos()
     _pos_control.freeze_ff_z();
 }
 
+/// shifts the origin and destination horizontally to the current position
+///     used to reset the track when taking off without horizontal position control
+///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
+void AC_WPNav::shift_wp_origin_and_destination_to_current_pos_xy()
+{
+    // get current and target locations
+    const Vector3f& curr_pos = _inav.get_position();
+
+    // shift origin and destination horizontally
+    _origin.x = curr_pos.x;
+    _origin.y = curr_pos.y;
+    _destination.x = curr_pos.x;
+    _destination.y = curr_pos.y;
+
+    // move pos controller target horizontally
+    _pos_control.set_xy_target(curr_pos.x, curr_pos.y);
+}
+
+/// shifts the origin and destination horizontally to the achievable stopping point
+///     used to reset the track when horizontal navigation is enabled after having been disabled (see Copter's wp_navalt_min)
+///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
+void AC_WPNav::shift_wp_origin_and_destination_to_stopping_point_xy()
+{
+    // relax position control in xy axis
+    // removing velocity error also impacts stopping point calculation
+    _pos_control.relax_velocity_controller_xy();
+
+    // get current and target locations
+    Vector3f stopping_point;
+    get_wp_stopping_point_xy(stopping_point);
+
+    // shift origin and destination horizontally
+    _origin.x = stopping_point.x;
+    _origin.y = stopping_point.y;
+    _destination.x = stopping_point.x;
+    _destination.y = stopping_point.y;
+
+    // move pos controller target horizontally
+    _pos_control.set_xy_target(stopping_point.x, stopping_point.y);
+}
+
 /// get_wp_stopping_point_xy - returns vector to stopping point based on a horizontal position and velocity
 void AC_WPNav::get_wp_stopping_point_xy(Vector3f& stopping_point) const
 {

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -135,6 +135,16 @@ public:
     ///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
     void shift_wp_origin_to_current_pos();
 
+    /// shifts the origin and destination horizontally to the current position
+    ///     used to reset the track when taking off without horizontal position control
+    ///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
+    void shift_wp_origin_and_destination_to_current_pos_xy();
+
+    /// shifts the origin and destination horizontally to the achievable stopping point
+    ///     used to reset the track when horizontal navigation is enabled after having been disabled (see Copter's wp_navalt_min)
+    ///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
+    void shift_wp_origin_and_destination_to_stopping_point_xy();
+
     /// get_wp_stopping_point_xy - calculates stopping point based on current position, velocity, waypoint acceleration
     ///		results placed in stopping_position vector
     void get_wp_stopping_point_xy(Vector3f& stopping_point) const;


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/12888 which can lead to the vehicle drifting away if the wind is too strong and WP_NAVALT_MIN is set too high.

The underlying cause of the issue is:

- that the current method does not use the WPNav's get_roll() and get_pitch outputs until the vehicle passes the WP_NAVALT_MIN altitude meaning the vehicle could drift horizontally a significant distance
- WPNav will stop advancing the intermediate point if the vehicle is more than the leash length from the track

These two put together mean the vehicle is not trying to move back towards the track nor is it trying to climb to the WP_NAVALT_MIN and it drifts away.

This PR resolves the problem by constantly shifting the track horizontally so that it is where the vehicle is horizontally.  Then at the last iteration just before horizontal control is enabled we move the track to be at the vehicle's "stopping point".

It might seem that we should always just reset the track to the vehicle's stopping point but if the wind was extremely high, the vehicle could end up flying horizontally quite quickly, so quickly that it's stopping point might be longer than the leash and we would be back in the position where the WPNav controller would not advance the intermediate point.

This has been tested in SITL and below are some screen shots.

Below is a picture of the vehicle's track at the moment it starts towards the first waypoint.  The wind was set to 3m/s north so the vehicle has drifted about 30m north before horizontal navigation began.
![image](https://user-images.githubusercontent.com/1498098/75599695-ab3d7480-5aea-11ea-9478-c1d8d1a11349.png)

Here's a before image of the PSC.TPX (target North-South position) vs PX (actual North-South position) showing the vehicle drifts 200m before it passes the WP_NAVALT_MIN altitude and retakes horizontal control (i.e. the altitude climbed very slowly)
![before-image](https://user-images.githubusercontent.com/1498098/75599905-96fa7700-5aec-11ea-842e-f2a20332c4f2.png)

Here's an after image showing the vehicle drifts only 28m horizontally before re-taking horizontal control at the moment it passes the WP_NAVALT_MIN altitude.
![after-image](https://user-images.githubusercontent.com/1498098/75599951-1daf5400-5aed-11ea-948c-e3ab8db74c3d.png)

Here's an after image of the roll, pitch and altitude.  We see the roll and pitch angles are relatively smooth (i.e. no sudden twitches).  Throttle output (not shown) is also smooth during the transition
![after-roll-pitch](https://user-images.githubusercontent.com/1498098/75600036-0e7cd600-5aee-11ea-958b-ad6ed93ee442.png)
