### PR TITLE
SITL on ARM

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -425,6 +425,11 @@ class sitl(Board):
             env.CXXFLAGS += [
                 '-fno-slp-vectorize' # compiler bug when trying to use SLP
             ]
+class arm_sitl (sitl):
+    toolchain = 'arm-linux-gnueabihf'
+    
+    def configure_env(self, cfg, env):
+            super(arm_sitl, self).configure_env(cfg, env)
 
 class chibios(Board):
     abstract = True


### PR DESCRIPTION
It is not a big deal, but it was useful to me.
I used this to run multiple SITL on multiple Raspberry Zeros. 

**make arm_sitl**

to run use the usual commands:

 _./arducopter -S -I70 --model + --speedup 1 --gimbal --defaults ./copter.parm_
_mavproxy.py --master tcp:127.0.0.1:6460 --sitl 127.0.0.1:6201 --out 127.0.0.1:15250_
