### PR TITLE
AP_Compass: Timeout in-flight compass learn after 10 minutes

### DIFF
--- a/libraries/AP_Compass/Compass_learn.h
+++ b/libraries/AP_Compass/Compass_learn.h
@@ -24,6 +24,7 @@ private:
     float errors[num_sectors];
     uint32_t num_samples;
 
+    uint32_t start_time;
     // earth field
     Vector3f mag_ef;
 


### PR DESCRIPTION
Timeout in-flight compass learn in case of bad mag field or other error that doesn't allow it to converge after 10 minutes

Fixes converged bool too