### PR TITLE
AP_Relay: Add get() status function

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -133,8 +133,14 @@ void AP_Relay::set(const uint8_t instance, const bool value)
     if (_pin[instance] == -1) {
         return;
     }
+    status[instance] = value;
     hal.gpio->pinMode(_pin[instance], HAL_GPIO_OUTPUT);
     hal.gpio->write(_pin[instance], value);
+}
+
+bool AP_Relay::get(const uint8_t instance)
+{
+    return enabled(instance) && status[instance];
 }
 
 void AP_Relay::toggle(uint8_t instance)

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -38,6 +38,9 @@ public:
     // toggle the relay status
     void        toggle(uint8_t instance);
 
+    // get the current status of relay, false if off or disabled
+    bool        get(uint8_t instance);
+
     static AP_Relay *get_singleton(void) {return singleton; }
 
     static const struct AP_Param::GroupInfo        var_info[];
@@ -47,6 +50,7 @@ private:
 
     AP_Int8 _pin[AP_RELAY_NUM_RELAYS];
     AP_Int8 _default;
+    bool status[AP_RELAY_NUM_RELAYS];
 
     void set(uint8_t instance, bool value);
 };


### PR DESCRIPTION
It helps to get the current status of a switch.