### PR TITLE
AC_Avoid: support circle fence in poshold and althold

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -876,14 +876,12 @@ bool AC_Avoid::get_fence_roll_pitch_pct(float &roll_positive, float &roll_negati
         return false;
     }
     const float fence_radius = fence->get_radius();
-    const float margin = fence->get_margin();
-
     bool adjusted = false;
     const AP_AHRS &_ahrs = AP::ahrs();
     Vector2f pos; 
     if (_ahrs.get_relative_position_NE_home(pos)) {
         float dist = fence_radius - pos.length();
-        if (dist < margin) {
+        if (dist < _dist_max) {
             const float lean_pct = distance_to_lean_pct(dist);
             const float angle_rad = pos.angle() - _ahrs.yaw;
             const float roll_pct = -sinf(angle_rad) * lean_pct;

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -880,9 +880,9 @@ bool AC_Avoid::get_fence_roll_pitch_pct(float &roll_positive, float &roll_negati
     const AP_AHRS &_ahrs = AP::ahrs();
     Vector2f pos; 
     if (_ahrs.get_relative_position_NE_home(pos)) {
-        float dist = fence_radius - pos.length();
-        if (dist < _dist_max) {
-            const float lean_pct = distance_to_lean_pct(dist);
+        float dist_squared = pos.length_squared();
+        if (dist_squared > ((fence_radius - _dist_max) * (fence_radius - _dist_max))) {
+            const float lean_pct = distance_to_lean_pct(sqrtf(dist_squared));
             const float angle_rad = pos.angle() - _ahrs.yaw;
             const float roll_pct = -sinf(angle_rad) * lean_pct;
             const float pitch_pct = cosf(angle_rad) * lean_pct;

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -211,10 +211,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
 // roll and pitch value are in centi-degrees
 void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float veh_angle_max)
 {
-    // exit immediately if proximity based avoidance is disabled
-    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) == 0 || !_proximity_enabled) {
-        return;
-    }
+    bool adjusted = false;
 
     // exit immediately if angle max is zero
     if (_angle_max <= 0.0f || veh_angle_max <= 0.0f) {
@@ -226,8 +223,16 @@ void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float veh_angle_max)
     float pitch_positive = 0.0f;   // maximum positive pitch value
     float pitch_negative = 0.0f;   // minimum negative pitch value
 
-    // get maximum positive and negative roll and pitch percentages from proximity sensor
-    get_proximity_roll_pitch_pct(roll_positive, roll_negative, pitch_positive, pitch_negative);
+    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) && _proximity_enabled) {
+        // get maximum positive and negative roll and pitch percentages from proximity sensor
+        adjusted |= get_proximity_roll_pitch_pct(roll_positive, roll_negative, pitch_positive, pitch_negative);
+    }
+
+    if (_enabled & AC_AVOID_STOP_AT_FENCE) {
+        adjusted |= get_fence_roll_pitch_pct(roll_positive, roll_negative, pitch_positive, pitch_negative);
+    }
+
+    if (!adjusted) return;
 
     // add maximum positive and negative percentages together for roll and pitch, convert to centi-degrees
     Vector2f rp_out((roll_positive + roll_negative) * 4500.0f, (pitch_positive + pitch_negative) * 4500.0f);
@@ -853,27 +858,74 @@ float AC_Avoid::distance_to_lean_pct(float dist_m)
     return 1.0f - (dist_m / _dist_max);
 }
 
+bool AC_Avoid::get_fence_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative)
+{    
+    AC_Fence *fence = AP::fence();
+    if (fence == nullptr) {
+        return false;
+    }
+
+    // exit if circular fence is not enabled
+    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
+        return false;
+    }
+
+    // exit if the circular fence has already been breached
+    if ((fence->get_breaches() & AC_FENCE_TYPE_CIRCLE) != 0) {
+        return false;
+    }
+    const float fence_radius = fence->get_radius();
+    const float margin = fence->get_margin();
+
+    bool adjusted = false;
+    const AP_AHRS &_ahrs = AP::ahrs();
+    Vector2f pos; 
+    if (_ahrs.get_relative_position_NE_home(pos)) {
+        float dist = fence_radius - pos.length();
+        if (dist < margin) {
+            const float lean_pct = distance_to_lean_pct(dist);
+            const float angle_rad = pos.angle() - _ahrs.yaw;
+            const float roll_pct = -sinf(angle_rad) * lean_pct;
+            const float pitch_pct = cosf(angle_rad) * lean_pct;
+            // update roll, pitch maximums
+            if (roll_pct > 0.0f) {
+                roll_positive = MAX(roll_positive, roll_pct);
+            } else if (roll_pct < 0.0f) {
+                roll_negative = MIN(roll_negative, roll_pct);
+            }
+            if (pitch_pct > 0.0f) {
+                pitch_positive = MAX(pitch_positive, pitch_pct);
+            } else if (pitch_pct < 0.0f) {
+                pitch_negative = MIN(pitch_negative, pitch_pct);
+            }
+            adjusted = true;
+        }
+    }
+    return adjusted;
+}
+
 // returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
-void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative)
+bool AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative)
 {
     AP_Proximity *proximity = AP::proximity();
     if (proximity == nullptr) {
-        return;
+        return false;
     }
     AP_Proximity &_proximity = *proximity;
 
     // exit immediately if proximity sensor is not present
     if (_proximity.get_status() != AP_Proximity::Status::Good) {
-        return;
+        return false;
     }
 
     const uint8_t obj_count = _proximity.get_object_count();
 
     // if no objects return
     if (obj_count == 0) {
-        return;
+        return false;
     }
 
+    bool adjusted = false;
     // calculate maximum roll, pitch values from objects
     for (uint8_t i=0; i<obj_count; i++) {
         float ang_deg, dist_m;
@@ -896,9 +948,11 @@ void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_ne
                 } else if (pitch_pct < 0.0f) {
                     pitch_negative = MIN(pitch_negative, pitch_pct);
                 }
+                adjusted = true;
             }
         }
     }
+    return adjusted;
 }
 
 // singleton instance

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -211,8 +211,6 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
 // roll and pitch value are in centi-degrees
 void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float veh_angle_max)
 {
-    bool adjusted = false;
-
     // exit immediately if angle max is zero
     if (_angle_max <= 0.0f || veh_angle_max <= 0.0f) {
         return;
@@ -222,7 +220,8 @@ void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float veh_angle_max)
     float roll_negative = 0.0f;    // minimum negative roll value
     float pitch_positive = 0.0f;   // maximum positive pitch value
     float pitch_negative = 0.0f;   // minimum negative pitch value
-
+    bool adjusted = false;
+    
     if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) && _proximity_enabled) {
         // get maximum positive and negative roll and pitch percentages from proximity sensor
         adjusted |= get_proximity_roll_pitch_pct(roll_positive, roll_negative, pitch_positive, pitch_negative);
@@ -232,7 +231,9 @@ void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float veh_angle_max)
         adjusted |= get_fence_roll_pitch_pct(roll_positive, roll_negative, pitch_positive, pitch_negative);
     }
 
-    if (!adjusted) return;
+    if (!adjusted) {
+        return;
+    }
 
     // add maximum positive and negative percentages together for roll and pitch, convert to centi-degrees
     Vector2f rp_out((roll_positive + roll_negative) * 4500.0f, (pitch_positive + pitch_negative) * 4500.0f);
@@ -860,7 +861,7 @@ float AC_Avoid::distance_to_lean_pct(float dist_m)
 
 bool AC_Avoid::get_fence_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative)
 {    
-    AC_Fence *fence = AP::fence();
+    const AC_Fence *fence = AP::fence();
     if (fence == nullptr) {
         return false;
     }

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -143,7 +143,9 @@ private:
     float distance_to_lean_pct(float dist_m);
 
     // returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
-    void get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
+    bool get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
+
+    bool get_fence_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
 
     // parameters
     AP_Int8 _enabled;


### PR DESCRIPTION
It acts the same as object avoidance. Copter will be pushed away from fence toward center for circle

https://youtu.be/AxCrv2yEofU

It is tested on CubeBlack (outdoor, GPS) and Kakute F7 (indoor, motion capture system)