### PR TITLE
Plane: update throttle mix uses filtered accelerations

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -388,6 +388,9 @@ private:
         float vpos_start_m;
     } landing_detect;
 
+    // throttle mix acceleration filter
+    LowPassFilterVector3f throttle_mix_accel_ef_filter = LowPassFilterVector3f(1.0f);
+
     // time we last set the loiter target
     uint32_t last_loiter_ms;
 


### PR DESCRIPTION
This is the QuadPlane equivalent of this multicopter PR:https://github.com/ArduPilot/ardupilot/pull/13639 which aims to improve landing detection by placing a 1hz filter on the accelerations used in the update_throttle_mix function.  The update_throttle_mix feature's output is one of the inputs to the landing detector ([see QuadPlane::should_relax()'s call to attitude_control->is_throttle_mix_min())](https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/quadplane.cpp#L1157).

@lthall is really the expert in this area but the purpose of the "throttle_mix" feature is to decide on the priority of attitude control vs altitude control.  A example of when these two controllers conflict with each other is during a fast descent (or more accurately a fast vertical deceleration).  The **alt**itude controllers will want to pull the overall throttle low to descend while the **att**itude controllers will want to raise the overall throttle in order to give the rate controllers more "room" (i.e. a larger difference in PWM between opposite motors).

One of the inputs to the throttle_mix feature is the vehicle's acceleration.  Master currently uses the instantaneous accelerations while this PR adds a 1hz filter instead (consistent with Copter).

This has been lightly tested in SITL with multiple landings using various accelerations (I set SIM_ACC_RND to 0, 3, 5, 10, 15, 20 and even really large values).  Sadly this testing didn't expose any existing issues with QuadPlane's landing detection meaning I couldn't see any improvement by applying this PR.

In multicopter's this is the kind of accelerations we can see on large vehicles during touch down.  This is the situation where we think this type of filtering should help (actual flight testing should happen in the coming few days).
![image](https://user-images.githubusercontent.com/1498098/75851989-5709fb80-5e2e-11ea-9a82-e80dc2cb1923.png)

This PR closes this issue: https://github.com/ArduPilot/ardupilot/issues/13664
