### PR TITLE
GCS_Common: whitelist AUTOPILOT_VERSION for in_delay_callback sending

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -814,10 +814,6 @@ bool GCS_MAVLINK::should_send_message_in_delay_callback(const ap_message id) con
     // No ID we return true for may take more than a few hundred
     // microseconds to return!
 
-    if (id == MSG_HEARTBEAT || id == MSG_NEXT_PARAM) {
-        return true;
-    }
-
     if (in_hil_mode()) {
         // in HIL we need to keep sending servo values to ensure
         // the simulator doesn't pause, otherwise our sensor
@@ -826,6 +822,15 @@ bool GCS_MAVLINK::should_send_message_in_delay_callback(const ap_message id) con
             id == MSG_SERVO_OUTPUT_RAW) {
             return true;
         }
+    }
+
+    switch (id) {
+    case MSG_HEARTBEAT:
+    case MSG_NEXT_PARAM:
+    case MSG_AUTOPILOT_VERSION:
+        return true;
+    default:
+        return false;
     }
 
     return false;


### PR DESCRIPTION
GCSs may request this very early on in the boot process, particularly
for SITL.

If we try to send it during a delay callback then we end up dropping it
at the moment - but we'd already sent the ack in response to the
request.

The sequence here is that we receive the request for the message from the GCS, and put that into the pushed_ap_message_ids bitmask.  Something then calls `delay_ms(...)` for some period of time, and we start to push messages out.  We choose this one to go out - but in `try_send_message` we discover that we're not allowed to send it.  We return true, saying we sent it - lying - if we don't do this then at the moment we would effectively have "blocker" messages which stop any of the in-delay-callback-whitelisted-messages (e.g. heartbeat) getting out.

The more elaborate fix for this is probably to have `try_send_message` return an enumeration value instead of true/false.  There are three callers, however, and things sending from a queue might have problems moving onto the next entry while preserving the need to send the first.  An alternate fix might be for the caller to check if we're in a delay callback itself and change its behaviour appropriately - so, for example:

```
            if (!do_try_send_message(next)) {
                break;
            }
            pushed_ap_message_ids.clear(next);
```

would become more elaborate.

Another option might be to whitelist virtually all of the messages - that requires an audit of the message sending to see how long they could possibly take and/or modifying the existing timing code to ensure the deadlines are not exceeded.
