### PR TITLE
AP_HAL_ChibiOS: VRUBrain-v51: reduce AP_MAX_EMBEDDED_PARAM to 1024

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
@@ -143,6 +143,8 @@ FLASH_RESERVE_START_KB 64
 # enable RAMTROM parameter storage
 #define HAL_WITH_RAMTRON 1
 
+define AP_PARAM_MAX_EMBEDDED_PARAM 1024
+
 # enable FAT filesystem
 define HAL_OS_FATFS_IO 1
 


### PR DESCRIPTION
Stops us overflowing on Copter and Plane builds