### PR TITLE
Added scripting interface for RPM

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -167,7 +167,9 @@ void Copter::heli_update_rotor_speed_targets()
             // set rpm from rotor speed sensor
             if (motors->get_interlock()) {
 #if RPM_ENABLED == ENABLED
-                motors->set_rpm(rpm_sensor.get_rpm(0));
+                float rpm = -1;
+                rpm_sensor.get_rpm(0, rpm);
+                motors->set_rpm(rpm);
 #endif
                 motors->set_desired_rotor_speed(motors->get_rsc_setpoint());
             }else{

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -265,9 +265,10 @@ void Copter::update_dynamic_notch()
 
 #if RPM_ENABLED == ENABLED
         case HarmonicNotchDynamicMode::UpdateRPM: // rpm sensor based tracking
-            if (rpm_sensor.healthy(0)) {
+            float rpm;
+            if (rpm_sensor.get_rpm(0, rpm)) {
                 // set the harmonic notch filter frequency from the main rotor rpm
-                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, rpm_sensor.get_rpm(0) * ref / 60.0f));
+                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, rpm * ref / 60.0f));
             } else {
                 ins.update_harmonic_notch_freq_hz(ref_freq);
             }

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -699,4 +699,42 @@ void Plane::publish_osd_info()
 }
 #endif
 
+// set target location (for use by scripting)
+bool Plane::set_target_location(const Location& target_loc)
+{
+    if (plane.control_mode != &plane.mode_guided) {
+        // only accept position updates when in GUIDED mode
+        return false;
+    }
+    plane.guided_WP_loc = target_loc;
+    // add home alt if needed
+    if (plane.guided_WP_loc.relative_alt) {
+        plane.guided_WP_loc.alt += plane.home.alt;
+        plane.guided_WP_loc.relative_alt = 0;
+    }
+    plane.set_guided_WP();
+    return true;
+}
+
+// set target location (for use by scripting)
+bool Plane::get_target_location(Location& target_loc)
+{
+    switch (control_mode->mode_number()) {
+    case Mode::Number::RTL:
+    case Mode::Number::AVOID_ADSB:
+    case Mode::Number::GUIDED:
+    case Mode::Number::AUTO:
+    case Mode::Number::LOITER:
+    case Mode::Number::QLOITER:
+    case Mode::Number::QLAND:
+    case Mode::Number::QRTL:
+        target_loc = next_WP_loc;
+        return true;
+        break;
+    default:
+        break;
+    }
+    return false;
+}
+
 AP_HAL_MAIN_CALLBACKS(&plane);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1040,6 +1040,8 @@ private:
 
 public:
     void failsafe_check(void);
+    bool set_target_location(const Location& target_loc) override;
+    bool get_target_location(Location& target_loc) override;
 };
 
 extern Plane plane;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -466,9 +466,10 @@ void Plane::update_dynamic_notch()
             break;
 
         case HarmonicNotchDynamicMode::UpdateRPM: // rpm sensor based tracking
-            if (rpm_sensor.healthy(0)) {
+            float rpm;
+            if (rpm_sensor.get_rpm(0, rpm)) {
                 // set the harmonic notch filter frequency from the main rotor rpm
-                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, rpm_sensor.get_rpm(0) * ref / 60.0f));
+                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, rpm * ref / 60.0f));
             } else {
                 ins.update_harmonic_notch_freq_hz(ref_freq);
             }

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -219,10 +219,9 @@ float AC_Autorotation::get_rpm(bool update_counter)
 
         //Get RPM value
         uint8_t instance = _param_rpm_instance;
-        current_rpm = rpm->get_rpm(instance);
 
         //Check RPM sesnor is returning a healthy status
-        if (current_rpm <= -1) {
+        if (!rpm->get_rpm(instance, current_rpm) || current_rpm <= -1) {
             //unhealthy, rpm unreliable
             _flags.bad_rpm = true;
         }

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -518,6 +518,12 @@ void AP_AHRS::update_nmea_out()
 #endif
 }
 
+// return current vibration vector for primary IMU
+Vector3f AP_AHRS::get_vibration(void) const
+{
+    return AP::ins().get_vibration_levels();
+}
+
 // singleton instance
 AP_AHRS *AP_AHRS::_singleton;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -550,6 +550,9 @@ public:
     // Write position and quaternion data from an external navigation system
     virtual void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms) { }
 
+    // return current vibration vector for primary IMU
+    Vector3f get_vibration(void) const;
+    
     // allow threads to lock against AHRS update
     HAL_Semaphore &get_semaphore(void) {
         return _rsem;

--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -147,8 +147,9 @@ void AP_Hott_Telem::send_EAM(void)
     msg.climbrate3s = 120 + vel.z * -3;
 
     const AP_RPM *rpm = AP::rpm();
-    if (rpm && rpm->enabled(0)) {
-        msg.rpm = rpm->get_rpm(0) / 10;
+    float rpm_value;
+    if (rpm && rpm->get_rpm(0, rpm_value)) {
+        msg.rpm = rpm_value * 0.1;
     }
 
     AP_Stats *stats = AP::stats();

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -229,8 +229,9 @@ void AP_ICEngine::update(void)
             gcs().send_text(MAV_SEVERITY_INFO, "Stopped engine");
         } else if (rpm_instance > 0) {
             // check RPM to see if still running
-            if (!rpm.healthy(rpm_instance-1) ||
-                rpm.get_rpm(rpm_instance-1) < rpm_threshold) {
+            float rpm_value;
+            if (!rpm.get_rpm(rpm_instance-1, rpm_value) ||
+                rpm_value < rpm_threshold) {
                 // engine has stopped when it should be running
                 state = ICE_START_DELAY;
             }
@@ -365,10 +366,10 @@ void AP_ICEngine::update_idle_governor(int8_t &min_throttle)
     }
 
     // get current RPM feedback
-    uint32_t rpmv = ap_rpm->get_rpm(rpm_instance-1);
+    float rpmv;
 
     // Double Check to make sure engine is really running
-    if (rpmv < 1) {
+    if (!ap_rpm->get_rpm(rpm_instance-1, rpmv) || rpmv < 1) {
         // Reset idle point to the default value when the engine is stopped
         idle_governor_integrator = min_throttle;
         return;

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -855,11 +855,16 @@ void AP_Logger::Write_Origin(uint8_t origin_type, const Location &loc)
 
 void AP_Logger::Write_RPM(const AP_RPM &rpm_sensor)
 {
+    float rpm1 = -1, rpm2 = -1;
+
+    rpm_sensor.get_rpm(0, rpm1);
+    rpm_sensor.get_rpm(1, rpm2);
+
     const struct log_RPM pkt{
         LOG_PACKET_HEADER_INIT(LOG_RPM_MSG),
         time_us     : AP_HAL::micros64(),
-        rpm1        : rpm_sensor.get_rpm(0),
-        rpm2        : rpm_sensor.get_rpm(1)
+        rpm1        : rpm1,
+        rpm2        : rpm2
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -188,6 +188,18 @@ bool AP_RPM::enabled(uint8_t instance) const
     return true;
 }
 
+/*
+  get RPM value, return true on success
+ */
+bool AP_RPM::get_rpm(uint8_t instance, float &rpm_value) const
+{
+    if (!healthy(instance)) {
+        return false;
+    }
+    rpm_value = state[instance].rate_rpm;
+    return true;
+}
+
 // singleton instance
 AP_RPM *AP_RPM::_singleton;
 

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -75,12 +75,7 @@ public:
     /*
       return RPM for a sensor. Return -1 if not healthy
      */
-    float get_rpm(uint8_t instance) const {
-        if (!healthy(instance)) {
-            return -1;
-        }
-        return state[instance].rate_rpm;
-    }
+    bool get_rpm(uint8_t instance, float &rpm_value) const;
 
     /*
       return signal quality for a sensor.

--- a/libraries/AP_RPM/examples/RPM_generic/RPM_generic.cpp
+++ b/libraries/AP_RPM/examples/RPM_generic/RPM_generic.cpp
@@ -56,9 +56,11 @@ void loop(void)
             sensor_state = '-';
         }
 
+        float rpm = -1;
+        RPM.get_rpm(ii, rpm);
         hal.console->printf("%u - (%c) RPM: %8.2f  Quality: %.2f  ",
                             ii, sensor_state,
-                            (double)RPM.get_rpm(ii),
+                            (double)rpm,
                             (double)RPM.get_signal_quality(ii));
 
         if (ii+1 < RPM.num_sensors()) {

--- a/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
+++ b/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
@@ -1,0 +1,141 @@
+-- This script allows for best effort return for quadplanes
+-- on loss of forward motor
+
+-- When an engine failure is detected (RPM and Vibration values drop below a certain threshold), the aircraft will:
+-- Send a warning ground station
+-- Start prioritizing airspeed completely
+-- Glide back towards the home location or rally point, monitoring the distance away from the point as well as Altitude.
+-- If the aircraft drops below a predetermined minimum altitude, QLAND mode is engaged and the aircraft lands at its current position.
+-- If the aircraft arrives within Q_FW_LND_APR_RAD of the return point before dropping below the minimum altitude, it should loiter down to the minimum altitude before switching to QRTL and landing.
+
+-- consider engine stopped when vibe is low and RPM low for more than 4s
+local ENGINE_STOPPED_MS = 4000
+
+-- RPM threshold below which engine may be stopped
+local RPM_LOW_THRESH = 500
+
+-- vibration threshold below which engine may be stopped
+local VIBE_LOW_THRESH = 2
+
+-- altitude threshold for QLAND
+local LOW_ALT_THRESH = 70
+
+-- when below MIN_AIRSPEED assume we are not in forward flight
+local MIN_AIRSPEED = 5
+
+-- time when engine stopped
+local engine_stop_ms = -1
+local engine_stopped = false
+
+-- have we triggered failsafe? Only trigger once
+local triggered_failsafe = false
+
+-- flight mode numbers for plane
+local MODE_AUTO = 10
+local MODE_RTL = 11
+local MODE_QLAND = 20
+local MODE_QRTL = 21
+
+-- update engine running status
+function check_engine()
+  if not arming:is_armed() then
+     engine_stopped = false
+     engine_stop_ms = -1
+     return true
+  end
+
+  local rpm = RPM:get_rpm(0)
+  local vibe = ahrs:get_vibration():length()
+
+  -- if either RPM is high or vibe is high then assume engine is running
+  if (rpm and (rpm > RPM_LOW_THRESH)) or (vibe > VIBE_LOW_THRESH) then
+     -- engine is definately running
+     engine_stop_ms = -1
+     if engine_stopped then
+        -- notify user engine has started
+        gcs:send_text(0, "Engine: STARTED")
+        engine_stopped = false
+     end
+     return true
+  end
+  local now = millis()
+
+  if engine_stop_ms == -1 then
+     -- start timeout period
+     engine_stop_ms = now
+     return true
+  end
+  if now - engine_stop_ms < ENGINE_STOPPED_MS then
+     return false
+  end
+  -- engine has been stopped for ENGINE_STOPPED_MS milliseconds, notify user
+  if not engine_stopped then
+     engine_stopped = true
+     gcs:send_text(0, "Engine: STOPPED")
+  end
+  return engine_stopped
+end
+
+-- trigger failsafe function
+function trigger_failsafe()
+  if param:get('RTL_AUTOLAND') == 2 then
+     -- we don't want to do the mission based autoland, so disable
+     -- RTL_AUTOLAND
+     param:set('RTL_AUTOLAND', 0)
+  end
+  if param:get('TECS_SPDWEIGHT') < 2 then
+     -- force airspeed priority
+     param:set('TECS_SPDWEIGHT', 2)
+  end
+  -- trigger an RTL to start bringing the vehicle home
+  -- it will automatically go to the nearest rally point if set or go to home
+  -- if no rally point available within the RALLY_LIMIT_KM
+  vehicle:set_mode(MODE_RTL)
+end
+
+-- check if we should switch to QLAND
+function check_qland()
+  local target = vehicle:get_target_location()
+  local pos = ahrs:get_position()
+  if not target or not pos then
+    -- we can't estimate distance
+    return
+  end
+  local dist = target:get_distance(pos)
+  local terrain_height = terrain:height_above_terrain(true)
+  local threshold = param:get('Q_FW_LND_APR_RAD')
+  if dist < threshold and (terrain_height and (terrain_height < LOW_ALT_THRESH)) then
+    gcs:send_text(0, "Failsafe: LANDING QRTL")
+    vehicle:set_mode(MODE_QRTL)
+  elseif terrain_height and terrain_height < LOW_ALT_THRESH then
+    gcs:send_text(0, "Failsafe: LANDING QLAND")
+    vehicle:set_mode(MODE_QLAND)
+  end
+end
+
+function update()
+  -- check engine status
+  check_engine()
+
+  -- if armed and in AUTO mode then consider triggering failsafe
+  if engine_stopped and vehicle:get_mode() == MODE_AUTO and arming:is_armed() and not triggered_failsafe then
+    triggered_failsafe = true
+    trigger_failsafe()
+    gcs:send_text(0, "Failsafe: TRIGGERED")
+  end
+
+  if not engine_stopped and triggered_failsafe then
+    triggered_failsafe = false
+    gcs:send_text(0, "Failsafe: RECOVERED")
+  end
+
+  if triggered_failsafe and vehicle:get_mode() == MODE_RTL then
+    check_qland()
+  end
+
+  -- run at 5Hz
+  return update, 200
+end
+
+-- start running update loop
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -35,6 +35,7 @@ singleton AP_AHRS method get_relative_position_NED_home boolean Vector3f'Null
 singleton AP_AHRS method home_is_set boolean
 singleton AP_AHRS method prearm_healthy boolean
 singleton AP_AHRS method airspeed_estimate boolean float'Null
+singleton AP_AHRS method get_vibration Vector3f
 
 include AP_Arming/AP_Arming.h
 
@@ -154,6 +155,7 @@ singleton AP_Vehicle method get_mode uint8_t
 singleton AP_Vehicle method get_likely_flying boolean
 singleton AP_Vehicle method get_time_flying_ms uint32_t
 singleton AP_Vehicle method set_target_location boolean Location
+singleton AP_Vehicle method get_target_location boolean Location'Null
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -208,3 +208,7 @@ singleton AP_Mission method get_prev_nav_cmd_id uint16_t
 singleton AP_Mission method get_current_nav_id uint16_t
 singleton AP_Mission method get_current_do_cmd_id uint16_t
 singleton AP_Mission method num_commands uint16_t
+
+include AP_RPM/AP_RPM.h
+singleton AP_RPM alias RPM
+singleton AP_RPM method get_rpm boolean uint8_t 0 RPM_MAX_INSTANCES float'Null

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,6 +1,7 @@
 // auto generated bindings, don't manually edit.  See README.md for details.
 #include "lua_generated_bindings.h"
 #include "lua_boxed_numerics.h"
+#include <AP_RPM/AP_RPM.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
@@ -551,6 +552,29 @@ const luaL_Reg Location_meta[] = {
     {"get_distance", Location_get_distance},
     {NULL, NULL}
 };
+
+static int AP_RPM_get_rpm(lua_State *L) {
+    AP_RPM * ud = AP_RPM::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "RPM not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(RPM_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    float data_5003 = {};
+    const bool data = ud->get_rpm(
+            data_2,
+            data_5003);
+
+    if (data) {
+        lua_pushnumber(L, data_5003);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
 
 static int AP_Mission_num_commands(lua_State *L) {
     AP_Mission * ud = AP_Mission::get_singleton();
@@ -2220,6 +2244,11 @@ static int AP_AHRS_get_roll(lua_State *L) {
     return 1;
 }
 
+const luaL_Reg AP_RPM_meta[] = {
+    {"get_rpm", AP_RPM_get_rpm},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_Mission_meta[] = {
     {"num_commands", AP_Mission_num_commands},
     {"get_current_do_cmd_id", AP_Mission_get_current_do_cmd_id},
@@ -2506,6 +2535,7 @@ const struct userdata_meta userdata_fun[] = {
 };
 
 const struct userdata_meta singleton_fun[] = {
+    {"RPM", AP_RPM_meta, NULL},
     {"mission", AP_Mission_meta, AP_Mission_enums},
     {"param", AP_Param_meta, NULL},
     {"esc_telem", AP_ESC_Telem_meta, NULL},
@@ -2579,6 +2609,7 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
+    "RPM",
     "mission",
     "param",
     "esc_telem",

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 // auto generated bindings, don't manually edit.  See README.md for details.
+#include <AP_RPM/AP_RPM.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -164,6 +164,9 @@ public:
     // set target location (for use by scripting)
     virtual bool set_target_location(const Location& target_loc) { return false; }
 
+    // get target location (for use by scripting)
+    virtual bool get_target_location(Location& target_loc) { return false; }
+    
 protected:
 
     virtual void init_ardupilot() = 0;

--- a/libraries/AP_WindVane/AP_WindVane_RPM.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_RPM.cpp
@@ -25,8 +25,9 @@ void AP_WindVane_RPM::update_speed()
 {
     const AP_RPM* rpm = AP_RPM::get_singleton();
     if (rpm != nullptr) {
-        const float temp_speed = rpm->get_rpm(0);
-        if (!is_negative(temp_speed)) {
+        float temp_speed;
+        if (rpm->get_rpm(0, temp_speed) &&
+            !is_negative(temp_speed)) {
             speed_update_frontend(temp_speed);
         }
     }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4200,10 +4200,15 @@ void GCS_MAVLINK::send_rpm() const
         return;
     }
 
+    float rpm1 = -1, rpm2 = -1;
+
+    rpm->get_rpm(0, rpm1);
+    rpm->get_rpm(1, rpm2);
+
     mavlink_msg_rpm_send(
         chan,
-        rpm->get_rpm(0),
-        rpm->get_rpm(1));
+        rpm1,
+        rpm2);
 }
 
 void GCS_MAVLINK::send_sys_status()


### PR DESCRIPTION
This allows scripts to make decisions based on engine RPM, which is useful for detecting failure of an ICE engine and triggering a failsafe behaviour
This also adds APIs for get_vibration and get_target_location

