### PR TITLE
AP_HAL_Linux: avoid segfaults during early panics

### DIFF
--- a/libraries/AP_HAL_Linux/system.cpp
+++ b/libraries/AP_HAL_Linux/system.cpp
@@ -30,8 +30,12 @@ void panic(const char *errormsg, ...)
     va_end(ap);
     UNUSED_RESULT(write(1, "\n", 1));
 
-    hal.rcin->teardown();
-    hal.scheduler->delay_microseconds(10000);
+    if (hal.rcin != nullptr) {
+        hal.rcin->teardown();
+    }
+    if (hal.scheduler != nullptr) {
+        hal.scheduler->delay_microseconds(10000);
+    }
     exit(1);
 }
 


### PR DESCRIPTION
singletons failing to be singleton can cause the segfaults.  This is
more a tidiness thing - but better not to have cascading failures.