### PR TITLE
autotest: param_parse.py: allow cr to exist on empty lines in prog_param

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -34,7 +34,7 @@ args = parser.parse_args()
 
 # Regular expressions for parsing the parameter metadata
 
-prog_param = re.compile(r"@Param: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: (.*))+)(?:\n[ \t]*\n|\n[ \t]+[A-Z])", re.MULTILINE)
+prog_param = re.compile(r"@Param: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: (.*))+)(?:\n[ \t\r]*\n|\n[ \t]+[A-Z])", re.MULTILINE)
 
 # match e.g @Value: 0=Unity, 1=Koala, 17=Liability
 prog_param_fields = re.compile(r"[ \t]*// @(\w+): ([^\r\n]*)")


### PR DESCRIPTION
This should fix parameter building on the Windows CI autotest.

We allow empty lines between @Param blocks and the parameter (and, in
fact, require it before multi-entry @GROUPINFOs like vectors).

The regex wasn't taking into account Windows will have \r\n on that empty
line rather than just \n