### PR TITLE
Rover: Update AP_Notify of GCS failsafe

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -278,7 +278,13 @@ void Rover::gcs_failsafe_check(void)
     }
 
     // check for updates from GCS within 2 seconds
-    failsafe_trigger(FAILSAFE_EVENT_GCS, "GCS", failsafe.last_heartbeat_ms != 0 && (millis() - failsafe.last_heartbeat_ms) > 2000);
+    bool b = failsafe.last_heartbeat_ms != 0 && (millis() - failsafe.last_heartbeat_ms) > 2000;
+
+    // update AP_Notify
+    AP_Notify::flags.failsafe_gcs = b;
+
+    // trigger gcs failsafe
+    failsafe_trigger(FAILSAFE_EVENT_GCS, "GCS", b);
 }
 
 /*


### PR DESCRIPTION
sets AP_Notify flag for GCS failsafe for Rover
AP_Notify will beep and/or flash when the GCS failsafe (aka Telemetry Failsafe) has triggered.