### PR TITLE
autotest: fixes for quadplane fft test

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -267,8 +267,13 @@ class AutoTestQuadPlane(AutoTest):
         mlog = self.dfreader_for_current_onboard_log()
         pkAvg = freq
 
-        for m in mlog.recv_match(type='FTN1', blocking=True,
-                                condition="FTN1.TimeUS>%u and FTN1.TimeUS<%u" % (tstart * 1.0e6, tend * 1.0e6)):
+        while True:
+            m = mlog.recv_match(
+                type='FTN1',
+                blocking=True,
+                condition="FTN1.TimeUS>%u and FTN1.TimeUS<%u" % (tstart * 1.0e6, tend * 1.0e6))
+            if m is None:
+                break
             pkAvg = pkAvg + (0.1 * (m.PkAvg - pkAvg))
         # peak within 5%
         if abs(pkAvg - freq) / freq > 0.05:
@@ -371,9 +376,13 @@ class AutoTestQuadPlane(AutoTest):
             self.reboot_sitl()
 
         except Exception as e:
+            self.progress("Exception caught: %s" % (
+                self.get_exception_stacktrace(e)))
             ex = e
 
         self.context_pop()
+
+        self.reboot_sitl()
 
         if ex is not None:
             raise ex

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -23,6 +23,7 @@ FENCE = 'ArduPlane-Missions/Dalby-OBC2016-fence.txt'
 WIND = "0,180,0.2"  # speed,direction,variance
 SITL_START_LOCATION = mavutil.location(-27.274439, 151.290064, 343, 8.7)
 
+
 class AutoTestQuadPlane(AutoTest):
 
     @staticmethod
@@ -247,7 +248,7 @@ class AutoTestQuadPlane(AutoTest):
         tstart = self.get_sim_time()
         self.progress("Hovering for %u seconds" % hover_time)
         while self.get_sim_time_cached() < tstart + hover_time:
-            attitude = self.mav.recv_match(type='ATTITUDE', blocking=True)
+            self.mav.recv_match(type='ATTITUDE', blocking=True)
         vfr_hud = self.mav.recv_match(type='VFR_HUD', blocking=True)
         tend = self.get_sim_time()
 
@@ -348,7 +349,7 @@ class AutoTestQuadPlane(AutoTest):
             self.progress("Hovering for %u seconds" % hover_time)
             tstart = self.get_sim_time()
             while self.get_sim_time_cached() < tstart + hover_time:
-                attitude = self.mav.recv_match(type='ATTITUDE', blocking=True)
+                self.mav.recv_match(type='ATTITUDE', blocking=True)
             tend = self.get_sim_time()
 
             self.do_RTL()


### PR DESCRIPTION
recv_match's result is not iterable; it just gives you a single message.

printing the stacktrace when assigning to ex is tradition - we tend to
lose the stack traces otherwise

rebooting sitl is usually required if the context we've just popped had
a reboot in it (usually indicating a reboot-required parameter was set).
So I added a reboot after the context pop.