### PR TITLE
Added support for ROMFS scripts

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -394,12 +394,21 @@ class sitl(Board):
             if not cfg.check_SFML(env):
                 cfg.fatal("Failed to find SFML libraries")
 
+        import fnmatch
         if cfg.options.sitl_osd:
-            env.CXXFLAGS += ['-DWITH_SITL_OSD','-DOSD_ENABLED=ENABLED','-DHAL_HAVE_AP_ROMFS_EMBEDDED_H']
-            import fnmatch
+            env.CXXFLAGS += ['-DWITH_SITL_OSD','-DOSD_ENABLED=ENABLED']
             for f in os.listdir('libraries/AP_OSD/fonts'):
                 if fnmatch.fnmatch(f, "font*bin"):
                     env.ROMFS_FILES += [(f,'libraries/AP_OSD/fonts/'+f)]
+
+        # embed any scripts from ROMFS/scripts
+        if os.path.exists('ROMFS/scripts'):
+            for f in os.listdir('ROMFS/scripts'):
+                if fnmatch.fnmatch(f, "*.lua"):
+                    env.ROMFS_FILES += [('scripts/'+f,'ROMFS/scripts/'+f)]
+
+        if len(env.ROMFS_FILES) > 0:
+            env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_H']
 
         if cfg.options.sitl_rgbled:
             env.CXXFLAGS += ['-DWITH_SITL_RGBLED']

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1815,6 +1815,18 @@ def romfs_wildcard(pattern):
         if fnmatch.fnmatch(f, pattern):
             romfs[f] = os.path.join(pattern_dir, f)
 
+def romfs_add_dir(dirname):
+    '''add a filesystem directory to ROMFS'''
+    romfs_dir = os.path.join(os.path.dirname(args.hwdef), dirname)
+    if not args.bootloader and os.path.exists(romfs_dir):
+        for root, d, files in os.walk(romfs_dir):
+            for f in files:
+                if fnmatch.fnmatch(f, '*~'):
+                    # skip editor backup files
+                    continue
+                fullpath = os.path.join(root, f)
+                relpath = os.path.join(os.path.relpath(root, romfs_dir), f)
+                romfs[relpath] = fullpath
 
 def process_line(line):
     '''process one line of pin definition file'''
@@ -1965,6 +1977,8 @@ write_hwdef_header(os.path.join(outdir, "hwdef.h"))
 
 # write out ldscript.ld
 write_ldscript(os.path.join(outdir, "ldscript.ld"))
+
+romfs_add_dir('ROMFS')
 
 write_ROMFS(outdir)
 

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -113,3 +113,21 @@ void AP_ROMFS::free(const uint8_t *data)
     ::free(const_cast<uint8_t *>(data));
 #endif
 }
+
+/*
+  directory listing interface. Start with ofs=0. Returns pathnames
+  that match dirname prefix. Ends with nullptr return when no more
+  files found
+*/
+const char *AP_ROMFS::dir_list(const char *dirname, uint16_t &ofs)
+{
+    const size_t dlen = strlen(dirname);
+    for ( ; ofs < ARRAY_SIZE(files); ofs++) {
+        if (strncmp(dirname, files[ofs].filename, dlen) == 0 &&
+            files[ofs].filename[dlen] == '/') {
+            // found one
+            return files[ofs++].filename;
+        }
+    }
+    return nullptr;
+}

--- a/libraries/AP_ROMFS/AP_ROMFS.h
+++ b/libraries/AP_ROMFS/AP_ROMFS.h
@@ -16,6 +16,13 @@ public:
     // free returned data
     static void free(const uint8_t *data);
 
+    /*
+      directory listing interface. Start with ofs=0. Returns pathnames
+      that match dirname prefix. Ends with nullptr return when no more
+      files found
+    */
+    static const char *dir_list(const char *dirname, uint16_t &ofs);
+
 private:
     // find an embedded file
     static const uint8_t *find_file(const char *name, uint32_t &size);

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -71,6 +71,7 @@ private:
 
     void reset_loop_overtime(lua_State *L);
 
+    void load_all_scripts_in_romfs(lua_State *L, const char *dirname);
     void load_all_scripts_in_dir(lua_State *L, const char *dirname);
 
     void run_next_script(lua_State *L);


### PR DESCRIPTION
This allows for scripts to be embedded in ROMFS, which removes the dependency on a microSD card for flight critical scripts.
The PR is WIP as the code to load the lua script in AP_Scripting is just a placeholder ready for @WickedShell 
files are embedded from two places:
 - scripts/ directory at top level of build for SITL
 - ROMFS/ directory inside hwdef directory for ChibiOS builds
