### PR TITLE
Tools: create log of build_binaries.py builds

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -100,23 +100,15 @@ def build_all():
 def build_binaries():
     """Run the build_binaries.py script."""
     print("Running build_binaries.py")
-    # copy the script as it changes git branch, which can change the
-    # script while running
-    orig = util.reltopdir('Tools/scripts/build_binaries.py')
-    copy = util.reltopdir('./build_binaries.py')
-    shutil.copy2(orig, copy)
 
-    # also copy generate_manifest library:
-    orig_gm = util.reltopdir('Tools/scripts/generate_manifest.py')
-    copy_gm = util.reltopdir('./generate_manifest.py')
-    shutil.copy2(orig_gm, copy_gm)
-
-    # and gen_stable.py
-    orig_gs = util.reltopdir('Tools/scripts/gen_stable.py')
-    copy_gs = util.reltopdir('./gen_stable.py')
-    shutil.copy2(orig_gs, copy_gs)
+    # copy the script (and various libraries used by the script) as it
+    # changes git branch, which can change the script while running
+    for thing in "build_binaries.py", "generate_manifest.py", "gen_stable.py", "build_binaries_history.py":
+        orig = util.reltopdir('Tools/scripts/%s' % thing)
+        copy = util.reltopdir('./%s' % thing)
+        shutil.copy2(orig, copy)
     
-    if util.run_cmd(copy, directory=util.reltopdir('.')) != 0:
+    if util.run_cmd("./build_binaries.py", directory=util.reltopdir('.')) != 0:
         print("Failed build_binaries.py")
         return False
     return True

--- a/Tools/scripts/build_binaries_history.py
+++ b/Tools/scripts/build_binaries_history.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+
+import os
+import sqlite3
+
+
+class BuildBinariesHistory():
+    def __init__(self, db_filepath):
+        self.db_filepath = db_filepath
+        self.assure_db_present()
+
+    def progress(self, msg):
+        print("BBHIST: %s" % msg)
+
+    def conn(self):
+        return sqlite3.connect(self.db_filepath)
+
+    def create_schema(self, c):
+        '''create our tables and whatnot'''
+        schema_version = 1
+        c.execute("create table version (version integer)")
+        c.execute("insert into version (version) values (?)", (schema_version,))
+        # at some stage we should probably directly associate build with runs....
+        c.execute("create table build (hash text, tag text, vehicle text, board text, "
+                  "frame text, text integer, data integer, bss integer, start_time real, duration real)")
+        c.execute("create table run (hash text, tag text, start_time real, duration real)")
+
+    def sizes_for_file(self, filepath):
+        cmd = "size %s" % (filepath,)
+        stuff = os.popen(cmd).read()
+        lines = stuff.split("\n")
+        sizes = lines[1].split("\t")
+        text = int(sizes[0])
+        data = int(sizes[1])
+        bss = int(sizes[2])
+        print("text=%u" % text)
+        print("data=%u" % data)
+        print("bss=%u" % bss)
+        return (text, data, bss)
+
+    def assure_db_present(self):
+        c = self.conn()
+        need_schema_create = False
+        try:
+            version_cursor = c.execute("select version from version")
+        except sqlite3.OperationalError as e:
+            if "no such table" in str(e): # FIXME: do better here?  what's in "e"?
+                print("need schema create")
+                need_schema_create = True
+
+        if need_schema_create:
+            self.create_schema(c)
+            version_cursor = c.execute("select version from version")
+
+        version_results = version_cursor.fetchall()
+
+        if len(version_results) == 0:
+            raise IOError("No version number?")
+        if len(version_results) > 1:
+            raise IOError("More than one version result?")
+        first = version_results[0]
+        want_version = 1
+        got_version = first[0]
+        if got_version != want_version:
+            raise IOError("Bad version number (want=%u got=%u" %
+                          (want_version, got_version))
+        self.progress("Got history version %u" % got_version)
+
+    def record_build(self, hash, tag, vehicle, board, frame, bare_path, start_time, duration):
+        if bare_path is None:
+            (text, data, bss) = (None, None, None)
+        else:
+            (text, data, bss) = self.sizes_for_file(bare_path)
+        c = self.conn()
+        c.execute("replace into build (hash, tag, vehicle, board, frame, text, data, bss, start_time, duration) "
+                  "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                  (hash, tag, vehicle, board, frame, text, data, bss, start_time, duration))
+        c.commit()
+
+    def record_run(self, hash, tag, start_time, duration):
+        c = self.conn()
+        c.execute("replace into run (hash, tag, start_time, duration) "
+                  "values (?, ?, ?, ?)",
+                  (hash, tag, start_time, duration))
+        c.commit()


### PR DESCRIPTION
Created a sqlite database to store information about build durations and binary sizes.

```
pbarker@recursion:~/rc/ardupilot(pr/build-log-sqlite3)$ sqlite3 /mnt/storage/buildlogs/build_binaries_history.sqlite 
SQLite version 3.22.0 2018-01-22 18:45:57
Enter ".help" for usage hints.
sqlite> .schema
CREATE TABLE version (version integer);
CREATE TABLE build (hash text, tag text, vehicle text, board text, frame text, text integer, data integer, bss integer, start_time real, duration real);
CREATE TABLE run (hash text, tag text, start_time real, duration real);
sqlite> select * from build;
380c610e8b1eab4c5bd9788fd0ad3452905ba1a2|dirty|AP_Periph|f103-GPS||104357|544|19720|1583550495.24132|12.1772360801697
380c610e8b1eab4c5bd9788fd0ad3452905ba1a2|dirty|AP_Periph|ZubaxGNSS|||||1583550508.3356|10.9900178909302
sqlite> select * from run;
380c610e8b1eab4c5bd9788fd0ad3452905ba1a2|dirty|1583550494.39211|25.1293199062347
sqlite> 
```

(that was obviously a cut-down set of things to build, hacked into build_binaries.py while I was testing the script)

It's a crappy schema.  But it is better than what we have now, which is nothing.

