### PR TITLE
Prevent loop rate tasks from slipping all the time

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -269,6 +269,8 @@ void Copter::fast_loop()
     if (should_log(MASK_LOG_ANY)) {
         Log_Sensor_Health();
     }
+
+    AP_Vehicle::fast_loop();
 }
 
 // start takeoff to given altitude (for use by scripting)

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -135,6 +135,8 @@ void Sub::fast_loop()
     if (should_log(MASK_LOG_ANY)) {
         Log_Sensor_Health();
     }
+
+    AP_Vehicle::fast_loop();
 }
 
 // 50 Hz tasks

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -103,6 +103,16 @@ void AP_Vehicle::loop()
 }
 
 /*
+ fast loop callback for all vehicles. This will get called at the end of any vehicle-specific fast loop.
+ */
+void AP_Vehicle::fast_loop()
+{
+#if HAL_GYROFFT_ENABLED
+    gyro_fft.sample_gyros();
+#endif
+}
+
+/*
   common scheduler table for fast CPUs - all common vehicle tasks
   should be listed here, along with how often they should be called (in hz)
   and the maximum time they are expected to take (in microseconds)
@@ -112,7 +122,6 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_RunCam,    &vehicle.runcam,         update,                   50, 50),
 #endif
 #if HAL_GYROFFT_ENABLED
-    SCHED_TASK_CLASS(AP_GyroFFT,   &vehicle.gyro_fft,       sample_gyros,      LOOP_RATE, 50),
     SCHED_TASK_CLASS(AP_GyroFFT,   &vehicle.gyro_fft,       update_parameters,         1, 50),
 #endif
 };

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -189,7 +189,7 @@ protected:
 
     // main loop scheduler
     AP_Scheduler scheduler{FUNCTOR_BIND_MEMBER(&AP_Vehicle::fast_loop, void)};
-    virtual void fast_loop() { }
+    virtual void fast_loop();
 
     // IMU variables
     // Integration time; time last loop took to run


### PR DESCRIPTION
The AP_Vehicle scheduler table comes after the vehicle specific tables. This means that loop rate tasks will almost always get penalized by slower tasks in the vehicle specific tables especially on slower processors. For FFT this is a problem as we need to reliably increment the gyro sample counters, but in general I believe this is the right thing to do.