### PR TITLE
autotest: make scripts directory relative to CWD

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -4689,7 +4689,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         return os.path.join(self.rootdir(), "libraries", "AP_Scripting", "examples", scriptname)
 
     def installed_script_path(self, scriptname):
-        return os.path.join(self.rootdir(), "scripts", scriptname)
+        return os.path.join("scripts", scriptname)
 
     def install_example_script(self, scriptname):
         source = self.script_source_path(scriptname)


### PR DESCRIPTION
This is where the library is expecting to find the scripts directory.

The existing setup assumes that autotest has been run from the root
directory - that's not always the case.  For example, the autotest
server starts everything one-up from the root directory.