### PR TITLE
Tools: build_autotest: install pymavlink after MAVProxy

### DIFF
--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -89,16 +89,16 @@ popd
 
 rsync -a APM/Tools/autotest/web-firmware/ buildlogs/binaries/
 
-echo "Updating pymavlink"
-pushd APM/modules/mavlink/pymavlink
-git show
-python setup.py build install --user
-popd
-
 echo "Updating MAVProxy"
 pushd MAVProxy
 git fetch origin
 git reset --hard origin/master
+git show
+python setup.py build install --user
+popd
+
+echo "Updating pymavlink"
+pushd APM/modules/mavlink/pymavlink
 git show
 python setup.py build install --user
 popd


### PR DESCRIPTION
Currently installing MAVProxy pulls pymavlink in as a dependency, so we
end up running whatever MAVProxy's master branch is pointing to
(currently pymavlink>=2.3.3).

ardupilot master can reference a pymavlink commit which is not part of
whatever MAVProxy's master branch is pointing to, so we end up with
failures like this in autotest:

```
  fly.ArduCopter:
    Mount (Test Camera/Antenna Mount) ('module' object has no attribute 'MAV_CMD_DO_SET_ROI_SYSID') (see /mnt/volume_nyc3_01/autotest/APM/buildlogs/ArduCopter-Mount.txt)
    FixedYawCalibration (Test Fixed Yaw Calibration) ('module' object has no attribute 'MAV_CMD_FIXED_MAG_CAL_YAW') (see /mnt/volume_nyc3_01/autotest/APM/buildlogs/ArduCopter-FixedYawCalibration.txt)
```

If we install pymavlink after installing MAVProxy we should end up with
the pymavlink messages generated from the messages in our mavlink
subdirectory, rather that the pymavlink messages shipped as part of the
pymavlink pip release.