### PR TITLE
Copter/Rover/Scripting: add support for takeoff and velocity commands

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -150,6 +150,26 @@ bool Rover::set_target_location(const Location& target_loc)
     return control_mode->set_desired_location(target_loc);
 }
 
+// set target velocity (for use by scripting)
+bool Rover::set_target_velocity_NED(const Vector3f& vel_ned)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!control_mode->in_guided_mode()) {
+        return false;
+    }
+
+    // convert vector length into speed
+    const float target_speed_m = safe_sqrt(sq(vel_ned.x) + sq(vel_ned.y));
+
+    // convert vector direction to target yaw
+    const float target_yaw_cd = degrees(atan2f(vel_ned.y, vel_ned.x)) * 100.0f;
+
+    // send target heading and speed
+    mode_guided.set_desired_heading_and_speed(target_yaw_cd, target_speed_m);
+
+    return true;
+}
+
 #if STATS_ENABLED == ENABLED
 /*
   update AP_Stats

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -278,6 +278,7 @@ private:
 
     // Rover.cpp
     bool set_target_location(const Location& target_loc) override;
+    bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     void stats_update();
     void ahrs_update();
     void gcs_failsafe_check(void);

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -271,6 +271,21 @@ void Copter::fast_loop()
     }
 }
 
+// start takeoff to given altitude (for use by scripting)
+bool Copter::start_takeoff(float alt)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    if (mode_guided.do_user_takeoff_start(alt * 100.0f)) {
+        copter.set_auto_armed(true);
+        return true;
+    }
+    return false;
+}
+
 // set target location (for use by scripting)
 bool Copter::set_target_location(const Location& target_loc)
 {
@@ -280,6 +295,19 @@ bool Copter::set_target_location(const Location& target_loc)
     }
 
     return mode_guided.set_destination(target_loc);
+}
+
+bool Copter::set_target_velocity_NED(const Vector3f& vel_ned)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    // convert vector to neu in cm
+    const Vector3f vel_neu_cms(vel_ned.x * 100.0f, vel_ned.y * 100.0f, -vel_ned.z * 100.0f);
+    mode_guided.set_velocity(vel_neu_cms);
+    return true;
 }
 
 // rc_loops - reads user input from transmitter/receiver

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -636,7 +636,9 @@ private:
                              uint8_t &task_count,
                              uint32_t &log_bit) override;
     void fast_loop() override;
+    bool start_takeoff(float alt) override;
     bool set_target_location(const Location& target_loc) override;
+    bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     void rc_loop();
     void throttle_loop();
     void update_batt_compass(void);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -796,7 +796,7 @@ public:
 
     bool is_taking_off() const override;
 
-    bool do_user_takeoff_start(float final_alt_above_home) override;
+    bool do_user_takeoff_start(float takeoff_alt_cm) override;
 
     GuidedMode mode() const { return guided_mode; }
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -47,13 +47,13 @@ bool ModeGuided::init(bool ignore_checks)
 
 
 // do_user_takeoff_start - initialises waypoint controller to implement take-off
-bool ModeGuided::do_user_takeoff_start(float final_alt_above_home)
+bool ModeGuided::do_user_takeoff_start(float takeoff_alt_cm)
 {
     guided_mode = Guided_TakeOff;
 
     // initialise wpnav destination
     Location target_loc = copter.current_loc;
-    target_loc.set_alt_cm(final_alt_above_home, Location::AltFrame::ABOVE_HOME);
+    target_loc.set_alt_cm(takeoff_alt_cm, Location::AltFrame::ABOVE_HOME);
 
     if (!wp_nav->set_wp_destination(target_loc)) {
         // failure to set destination can only be because of missing terrain data

--- a/libraries/AP_Scripting/examples/copter-fly-vertical-circle.lua
+++ b/libraries/AP_Scripting/examples/copter-fly-vertical-circle.lua
@@ -1,0 +1,78 @@
+-- command a Copter to takeoff to 5m and fly a vertical circle in the clockwise direction
+--
+-- CAUTION: This script only works for Copter
+-- this script waits for the vehicle to be armed and RC6 input > 1800 and then:
+--    a) switches to Guided mode
+--    b) takeoff to 5m
+--    c) flies a vertical circle using the velocity controller
+--    d) switches to RTL mode
+
+local takeoff_alt_above_home = 5
+local copter_guided_mode_num = 4
+local copter_rtl_mode_num = 6
+local stage = 0
+local circle_angle = 0
+local circle_angle_increment = 1    -- increment the target angle by 1 deg every 0.1 sec (i.e. 10deg/sec)
+local circle_speed = 1              -- velocity is always 1m/s
+local yaw_cos = 0                   -- cosine of yaw at takeoff
+local yaw_sin = 0                   -- sine of yaw at takeoff
+
+-- the main update function that uses the takeoff and velocity controllers to fly a rough square pattern
+function update()
+  if not arming:is_armed() then -- reset state when disarmed
+    stage = 0
+    circle_angle = 0
+  else
+    pwm6 = rc:get_pwm(6)
+    if pwm6 and pwm6 > 1800 then    -- check if RC6 input has moved high
+      if (stage == 0) then          -- change to guided mode
+        if (vehicle:set_mode(copter_guided_mode_num)) then  -- change to Guided mode
+          local yaw_rad = ahrs:get_yaw()
+          yaw_cos = math.cos(yaw_rad)
+          yaw_sin = math.sin(yaw_rad)
+          stage = stage + 1
+        end
+      elseif (stage == 1) then      -- Stage1: takeoff
+        if (vehicle:start_takeoff(takeoff_alt_above_home)) then
+          stage = stage + 1
+        end
+      elseif (stage == 2) then      -- Stage2: check if vehicle has reached target altitude
+        local home = ahrs:get_home()
+        local curr_loc = ahrs:get_position()
+        if home and curr_loc then
+          local vec_from_home = home:get_distance_NED(curr_loc)
+          gcs:send_text(0, "alt above home: " .. tostring(math.floor(-vec_from_home:z())))
+          if (math.abs(takeoff_alt_above_home + vec_from_home:z()) < 1) then
+            stage = stage + 1
+            bottom_left_loc = curr_loc          -- record location when starting square
+          end
+        end
+      elseif (stage == 3 ) then   -- Stage3: fly a vertical circle
+
+        -- calculate velocity vector
+        circle_angle = circle_angle + circle_angle_increment
+        if (circle_angle >= 360) then
+          stage = stage + 1
+        end
+        local target_vel = Vector3f()
+        local vel_xy = math.cos(math.rad(circle_angle)) * circle_speed
+        target_vel:x(yaw_sin * vel_xy)
+        target_vel:y(yaw_cos * -vel_xy)
+        target_vel:z(-math.sin(math.rad(circle_angle)) * circle_speed)
+
+        -- send velocity request
+        if not (vehicle:set_target_velocity_NED(target_vel)) then
+          gcs:send_text(0, "failed to execute velocity command")
+        end
+      elseif (stage == 4) then  -- Stage4: change to RTL mode
+        vehicle:set_mode(copter_rtl_mode_num)
+        stage = stage + 1
+        gcs:send_text(0, "finished square, switching to RTL")
+      end
+    end
+  end
+
+  return update, 100
+end
+
+return update()

--- a/libraries/AP_Scripting/examples/set-target-location.lua
+++ b/libraries/AP_Scripting/examples/set-target-location.lua
@@ -12,7 +12,7 @@ local copter_guided_mode_num = 4
 local copter_land_mode_num = 9
 local sent_target = false
 
--- the main update function that is used to decide when we should do a failsafe
+-- the main update function that performs a simplified version of RTL
 function update()
   if not arming:is_armed() then -- reset state when disarmed
     sent_target = false

--- a/libraries/AP_Scripting/examples/set-target-velocity.lua
+++ b/libraries/AP_Scripting/examples/set-target-velocity.lua
@@ -1,0 +1,99 @@
+-- command a Copter to takeoff to 10m and fly a square pattern
+--
+-- CAUTION: This script only works for Copter
+-- this script waits for the vehicle to be armed and RC6 input > 1800 and then:
+--    a) switches to Guided mode
+--    b) takeoff to 10m
+--    c) flies a 20m x 20m square pattern using the velocity controller
+--    d) switches to RTL mode
+
+local takeoff_alt_above_home = 10
+local copter_guided_mode_num = 4
+local copter_rtl_mode_num = 6
+local stage = 0
+local bottom_left_loc   -- vehicle location when starting square
+local square_side_length = 20   -- length of each side of square
+
+-- the main update function that uses the takeoff and velocity controllers to fly a rough square pattern
+function update()
+  if not arming:is_armed() then -- reset state when disarmed
+    stage = 0
+  else
+    pwm6 = rc:get_pwm(6)
+    if pwm6 and pwm6 > 1800 then    -- check if RC7 input has moved high
+      if (stage == 0) then          -- change to guided mode
+        if (vehicle:set_mode(copter_guided_mode_num)) then     -- change to Guided mode
+          stage = stage + 1
+        end
+      elseif (stage == 1) then      -- Stage1: takeoff
+        if (vehicle:start_takeoff(takeoff_alt_above_home)) then
+          stage = stage + 1
+        end
+      elseif (stage == 2) then      -- Stage2: check if vehicle has reached target altitude
+        local home = ahrs:get_home()
+        local curr_loc = ahrs:get_position()
+        if home and curr_loc then
+          local vec_from_home = home:get_distance_NED(curr_loc)
+          gcs:send_text(0, "alt above home: " .. tostring(math.floor(-vec_from_home:z())))
+          if (math.abs(takeoff_alt_above_home + vec_from_home:z()) < 1) then
+            stage = stage + 1
+            bottom_left_loc = curr_loc          -- record location when starting square
+          end
+        end
+      elseif (stage >= 3 and stage <= 6) then   -- fly a square using velocity controller
+        local curr_loc = ahrs:get_position()
+        local target_vel = Vector3f()           -- create velocity vector
+        if (bottom_left_loc and curr_loc) then
+          local dist_NE = bottom_left_loc:get_distance_NE(curr_loc)
+
+          -- Stage3 : fly North at 2m/s
+          if (stage == 3) then
+            target_vel:x(2)
+            if (dist_NE:x() >= square_side_length) then
+              stage = stage + 1
+            end
+          end
+
+          -- Stage4 : fly East at 2m/s
+          if (stage == 4) then
+            target_vel:y(2) 
+            if (dist_NE:y() >= square_side_length) then
+              stage = stage + 1
+            end
+          end
+
+          -- Stage5 : fly South at 2m/s
+          if (stage == 5) then
+            target_vel:x(-2)
+            if (dist_NE:x() <= 2) then
+              stage = stage + 1
+            end
+          end
+
+          -- Stage6 : fly West at 2m/s
+          if (stage == 6) then
+            target_vel:y(-2)
+            if (dist_NE:y() <= 2) then
+              stage = stage + 1
+            end
+          end
+
+          -- send velocity request
+          if (vehicle:set_target_velocity_NED(target_vel)) then   -- send target velocity to vehicle
+            gcs:send_text(0, "pos:" .. tostring(math.floor(dist_NE:x())) .. "," .. tostring(math.floor(dist_NE:y())) .. " sent vel x:" .. tostring(target_vel:x()) .. " y:" .. tostring(target_vel:y()))
+          else
+            gcs:send_text(0, "failed to execute velocity command")
+          end
+        end
+      elseif (stage == 7) then  -- Stage7: change to RTL mode
+        vehicle:set_mode(copter_rtl_mode_num)
+        stage = stage + 1
+        gcs:send_text(0, "finished square, switching to RTL")
+      end
+    end
+  end
+
+  return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -154,8 +154,10 @@ singleton AP_Vehicle method set_mode boolean uint8_t 0 UINT8_MAX ModeReason::SCR
 singleton AP_Vehicle method get_mode uint8_t
 singleton AP_Vehicle method get_likely_flying boolean
 singleton AP_Vehicle method get_time_flying_ms uint32_t
+singleton AP_Vehicle method start_takeoff boolean float (-LOCATION_ALT_MAX_M*100+1) (LOCATION_ALT_MAX_M*100-1)
 singleton AP_Vehicle method set_target_location boolean Location
 singleton AP_Vehicle method get_target_location boolean Location'Null
+singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -966,6 +966,23 @@ static int AP_SerialLED_set_num_neopixel(lua_State *L) {
     return 1;
 }
 
+static int AP_Vehicle_set_target_velocity_NED(lua_State *L) {
+    AP_Vehicle * ud = AP_Vehicle::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "vehicle not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    Vector3f & data_2 = *check_Vector3f(L, 2);
+    AP::scheduler().get_semaphore().take_blocking();
+    const bool data = ud->set_target_velocity_NED(
+            data_2);
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushboolean(L, data);
+    return 1;
+}
+
 static int AP_Vehicle_get_target_location(lua_State *L) {
     AP_Vehicle * ud = AP_Vehicle::get_singleton();
     if (ud == nullptr) {
@@ -998,6 +1015,25 @@ static int AP_Vehicle_set_target_location(lua_State *L) {
     Location & data_2 = *check_Location(L, 2);
     AP::scheduler().get_semaphore().take_blocking();
     const bool data = ud->set_target_location(
+            data_2);
+
+    AP::scheduler().get_semaphore().give();
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_Vehicle_start_takeoff(lua_State *L) {
+    AP_Vehicle * ud = AP_Vehicle::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "vehicle not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const float raw_data_2 = luaL_checknumber(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX((-LOCATION_ALT_MAX_M*100+1), -INFINITY)) && (raw_data_2 <= MIN((LOCATION_ALT_MAX_M*100-1), INFINITY))), 2, "argument out of range");
+    const float data_2 = raw_data_2;
+    AP::scheduler().get_semaphore().take_blocking();
+    const bool data = ud->start_takeoff(
             data_2);
 
     AP::scheduler().get_semaphore().give();
@@ -2341,8 +2377,10 @@ const luaL_Reg AP_SerialLED_meta[] = {
 };
 
 const luaL_Reg AP_Vehicle_meta[] = {
+    {"set_target_velocity_NED", AP_Vehicle_set_target_velocity_NED},
     {"get_target_location", AP_Vehicle_get_target_location},
     {"set_target_location", AP_Vehicle_set_target_location},
+    {"start_takeoff", AP_Vehicle_start_takeoff},
     {"get_time_flying_ms", AP_Vehicle_get_time_flying_ms},
     {"get_likely_flying", AP_Vehicle_get_likely_flying},
     {"get_mode", AP_Vehicle_get_mode},

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -163,8 +163,12 @@ public:
         return AP_HAL::millis() - _last_flying_ms;
     }
 
-    // set target location (for use by scripting)
+    /*
+      methods to control vehicle for use by scripting
+    */
+    virtual bool start_takeoff(float alt) { return false; }
     virtual bool set_target_location(const Location& target_loc) { return false; }
+    virtual bool set_target_velocity_NED(const Vector3f& vel_ned) { return false; }
 
     // get target location (for use by scripting)
     virtual bool get_target_location(Location& target_loc) { return false; }


### PR DESCRIPTION
This adds Scripting support to command a Copter to takeoff and also adds velocity control to Copter and Rover.

This has been tested in SITL for both a Copter and Rover.  The example script is only implemented for Copters but a cut-down version of it was tested for Rovers as well.
![image](https://user-images.githubusercontent.com/1498098/76180510-83908f80-6201-11ea-9467-ba92bf79f09c.png)
![image](https://user-images.githubusercontent.com/1498098/76180534-8ee3bb00-6201-11ea-83aa-bc0e61c47a9f.png)
