### PR TITLE
Copter: use rangefinder to takeoff altitude in guided mode

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -384,18 +384,8 @@ void ModeGuided::takeoff_run()
         copter.landinggear.retract_after_takeoff();
 
         // switch to position control mode but maintain current target
-        Location dest_loc(wp_nav->get_wp_destination());
-        Location::AltFrame frame = wp_nav->origin_and_destination_are_terrain_alt()
-                                                ? Location::AltFrame::ABOVE_TERRAIN
-                                                : Location::AltFrame::ABOVE_HOME;
-        int32_t target_alt_cm;
-        if (dest_loc.get_alt_cm(frame, target_alt_cm)) {
-            dest_loc.set_alt_cm(target_alt_cm, frame);
-            set_destination(dest_loc);
-        } else {
-            const Vector3f& target = wp_nav->get_wp_destination();
-            set_destination(target);
-        }
+        const Vector3f target = wp_nav->get_wp_destination();
+        set_destination(target, false, 0, false, 0, false, wp_nav->origin_and_destination_are_terrain_alt());
     }
 }
 


### PR DESCRIPTION
This PR allows to use rangefinder when takeoff in Guided mode if WPNAV_RFND_USE = 1 and a rangefinder is connected.
The terrain alt with RangeFinder will continue even after takeoff is over and switched to POS control.

I tested it in SITL. Specified 2m in takeoff.

**Before**
![image](https://user-images.githubusercontent.com/16643069/76226956-eb76c280-6261-11ea-8713-34ba92cc512e.png)

**After**
![image](https://user-images.githubusercontent.com/16643069/76227195-44def180-6262-11ea-8ca9-adb6411a5584.png)

We support terrain follwoing in guided mode. (#13582)
But takeoff in guided mode use relative altitude only before.

SET_POSITION_TARGET_GLOBAL_INT has the field of MAV_FRAME.
But, MAV_CMD_NAV_TAKEOFF command doesn't have it.
https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF

There is also a method of selecting relative or terrain by parameter like RTL_ALT_TYPE.
But I decided to use terrain_alt automatically if WPNAV_RFND_USE = 1 and a rangefinder is connected because I don't want to increase the number of parameters.