### PR TITLE
GCS_MAVLink: GCS_Dummy: add missing CR to console output of statustexts

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -90,6 +90,7 @@ private:
     void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t dest_bitmask) override {
         hal.console->printf("TOGCS: ");
         hal.console->vprintf(fmt, arg_list);
+        hal.console->printf("\n");
     }
 
     MAV_TYPE frame_type() const override { return MAV_TYPE_FIXED_WING; }


### PR DESCRIPTION
send_text and friends don't expect the caller to add the CR; the GCS
will add one.  Since we're jsut emitting to console, add one ourselves.