### PR TITLE
AP_Periph: update to new NeoPixel API

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -111,7 +111,7 @@ void AP_Periph_FW::init()
 
 #ifdef HAL_PERIPH_NEOPIXEL_COUNT
     hal.rcout->init();
-    hal.rcout->set_neopixel_num_LEDs(HAL_PERIPH_NEOPIXEL_CHAN, HAL_PERIPH_NEOPIXEL_COUNT);
+    hal.rcout->set_serial_led_num_LEDs(HAL_PERIPH_NEOPIXEL_CHAN, AP_HAL::RCOutput::MODE_NEOPIXEL);
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_ADSB
@@ -157,8 +157,8 @@ static void update_rainbow()
     uint32_t now = AP_HAL::millis();
     if (now-start_ms > 1500) {
         rainbow_done = true;
-        hal.rcout->set_neopixel_rgb_data(HAL_PERIPH_NEOPIXEL_CHAN, -1, 0, 0, 0);
-        hal.rcout->neopixel_send();
+        hal.rcout->set_serial_led_rgb_data(HAL_PERIPH_NEOPIXEL_CHAN, -1, 0, 0, 0);
+        hal.rcout->serial_led_send(HAL_PERIPH_NEOPIXEL_CHAN);
         return;
     }
     static uint32_t last_update_ms;
@@ -186,13 +186,13 @@ static void update_rainbow()
     float brightness = 0.3;
     for (uint8_t n=0; n<8; n++) {
         uint8_t i = (step + n) % nsteps;
-        hal.rcout->set_neopixel_rgb_data(HAL_PERIPH_NEOPIXEL_CHAN, n,
+        hal.rcout->set_serial_led_rgb_data(HAL_PERIPH_NEOPIXEL_CHAN, n,
                                          rgb_rainbow[i].red*brightness,
                                          rgb_rainbow[i].green*brightness,
                                          rgb_rainbow[i].blue*brightness);
     }
     step++;
-    hal.rcout->neopixel_send();
+    hal.rcout->serial_led_send(HAL_PERIPH_NEOPIXEL_CHAN);
 }
 #endif
 
@@ -223,7 +223,7 @@ void AP_Periph_FW::update()
         show_stack_usage();
 #endif
 #ifdef HAL_PERIPH_NEOPIXEL_COUNT
-        hal.rcout->set_neopixel_num_LEDs(HAL_PERIPH_NEOPIXEL_CHAN, HAL_PERIPH_NEOPIXEL_COUNT);
+        hal.rcout->set_serial_led_num_LEDs(HAL_PERIPH_NEOPIXEL_CHAN, HAL_PERIPH_NEOPIXEL_COUNT, AP_HAL::RCOutput::MODE_NEOPIXEL);
 #endif
     }
     can_update();

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -507,8 +507,8 @@ static void handle_RTCMStream(CanardInstance* ins, CanardRxTransfer* transfer)
 static void set_rgb_led(uint8_t red, uint8_t green, uint8_t blue)
 {
 #ifdef HAL_PERIPH_NEOPIXEL_COUNT
-    hal.rcout->set_neopixel_rgb_data(HAL_PERIPH_NEOPIXEL_CHAN, -1, red, green, blue);
-    hal.rcout->neopixel_send();
+    hal.rcout->set_serial_led_rgb_data(HAL_PERIPH_NEOPIXEL_CHAN, -1, red, green, blue);
+    hal.rcout->serial_led_send(HAL_PERIPH_NEOPIXEL_CHAN);
 #endif // HAL_PERIPH_NEOPIXEL_COUNT
 #ifdef HAL_PERIPH_ENABLE_NCP5623_LED
     {


### PR DESCRIPTION
This fixes AP_Periph for the new led API changes that went in with https://github.com/ArduPilot/ardupilot/pull/13658

This is not included in autotest and I didn't think to check. Interestingly I cannot build AP_Periph locally on Cygwin due to some uavcan module errors. So I would be greatfull if someone could confirm this builds.

 ./waf configure --board=CUAV_GPS
./waf build --target=bin/AP_Periph

Fixes #13781