### PR TITLE
AP_Compass: correct incorrect and misleading comment

### DIFF
--- a/libraries/AP_Compass/AP_Compass_HIL.cpp
+++ b/libraries/AP_Compass/AP_Compass_HIL.cpp
@@ -48,7 +48,7 @@ AP_Compass_Backend *AP_Compass_HIL::detect()
 bool
 AP_Compass_HIL::init(void)
 {
-    // register two compass instances
+    // register compass instances
     for (uint8_t i=0; i<HIL_NUM_COMPASSES; i++) {
         uint32_t dev_id = AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 0, DEVTYPE_SITL);
         if (!register_compass(dev_id, _compass_instance[i])) {


### PR DESCRIPTION
Good example of why making the comments be the same as the code is a bad idea.

`HIL_NUM_COMPASSES` is 1 in our current code.
