### PR TITLE
[NFC]AP_Vehicle: add warning about get_scheduler_task implementations

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -127,6 +127,8 @@ public:
     };
 
     void get_common_scheduler_tasks(const AP_Scheduler::Task*& tasks, uint8_t& num_tasks);
+    // implementations *MUST* fill in all passed-in fields or we get
+    // Valgrind errors
     virtual void get_scheduler_tasks(const AP_Scheduler::Task *&tasks, uint8_t &task_count, uint32_t &log_bit) = 0;
 
     /*


### PR DESCRIPTION
We don't initialise these values we pass in.  Considering how few times
we need to get this right, requiring it of the implementation would seem
to make sense and save a few bytes.