### PR TITLE
AP_Mission: Add support for DO_SET_CAM_TRIGG_DIST

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -343,6 +343,8 @@ void AP_Camera::update()
     }
 
     if (is_zero(_trigg_dist)) {
+        _last_location.lat = 0;
+        _last_location.lng = 0;
         return;
     }
     if (_last_location.lat == 0 && _last_location.lng == 0) {

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -941,6 +941,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
 
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:                 // MAV ID: 206
         cmd.content.cam_trigg_dist.meters = packet.param1;  // distance between camera shots in meters
+        cmd.content.cam_trigg_dist.trigger = packet.param3; // when enabled, camera triggers once immediately
         break;
 
     case MAV_CMD_DO_FENCE_ENABLE:                       // MAV ID: 207
@@ -1380,6 +1381,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
 
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:                 // MAV ID: 206
         packet.param1 = cmd.content.cam_trigg_dist.meters;  // distance between camera shots in meters
+        packet.param3 = cmd.content.cam_trigg_dist.trigger; // when enabled, camera triggers once immediately
         break;
 
     case MAV_CMD_DO_FENCE_ENABLE:                       // MAV ID: 207

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -137,6 +137,7 @@ public:
     // set cam trigger distance command structure
     struct PACKED Cam_Trigg_Distance {
         float meters;           // distance
+        uint8_t trigger;        // triggers one image capture immediately 
     };
 
     // gripper command structure

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -102,6 +102,9 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
 
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
         camera->set_trigger_distance(cmd.content.cam_trigg_dist.meters);
+        if (cmd.content.cam_trigg_dist.trigger == 1) {
+            camera->take_picture();
+        }
         return true;
 
     default:


### PR DESCRIPTION
This PR adds support for the trigger parameter already available as the 3rd packet in DO_SET_CAM_TRIGG_DIST.

Now, if the packet 3 of DO_SET_CAM_TRIGG_DIST is set to 1, it will trigger the camera once, immediately upon recieving the command.  This is oppose to the current behaviour in which the first image is taken after the predefined distance has been covered.

This addresses the feature request raised in #13779

Tested in SITL.