### PR TITLE
AP_HAL_Linux: do not create ConsoleDevices for Replay or examples

### DIFF
--- a/libraries/AP_HAL_Linux/ConsoleDevice.cpp
+++ b/libraries/AP_HAL_Linux/ConsoleDevice.cpp
@@ -8,6 +8,7 @@
 
 #include "ConsoleDevice.h"
 
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 ConsoleDevice::ConsoleDevice()
 {
@@ -27,6 +28,13 @@ bool ConsoleDevice::close()
 
 bool ConsoleDevice::open()
 {
+#if APM_BUILD_TYPE(APM_BUILD_Replay) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+    // we do not want a ConsoleDevice for Replay or any examples.  It
+    // screws up the terminal settings and creates all sorts of
+    // weirdnesses in Replay's output.
+    return false;
+#endif
+
     _rd_fd = STDIN_FILENO;
     _wr_fd = STDOUT_FILENO;
 

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -79,7 +79,9 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
 
     if (!_connected) {
         _connected = _device->open();
-        _device->set_blocking(false);
+        if (_connected) {
+            _device->set_blocking(false);
+        }
     }
     _initialised = false;
 


### PR DESCRIPTION
Uusally problems evidence themsleves with stdin not working correctly -
for example, "git add -p" skipping through all queries as if the
user was just pressing enter.