### PR TITLE
AP_GPS: fixed antenna offset for blending

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -795,8 +795,10 @@ void AP_GPS::update(void)
 
 #if defined(GPS_BLENDED_INSTANCE)
     // copy the primary instance to the blended instance in case it is enabled later
-    state[GPS_BLENDED_INSTANCE] = state[primary_instance];
-    _blended_antenna_offset = _antenna_offset[primary_instance];
+    if (primary_instance != GPS_BLENDED_INSTANCE) {
+        state[GPS_BLENDED_INSTANCE] = state[primary_instance];
+        _blended_antenna_offset = _antenna_offset[primary_instance];
+    }
 #endif
     
 #ifndef HAL_BUILD_AP_PERIPH
@@ -1652,14 +1654,6 @@ void AP_GPS::calc_blended_state(void)
     for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
         _NE_pos_offset_m[i] = state[i].location.get_distance_NE(state[GPS_BLENDED_INSTANCE].location) * alpha[i] + _NE_pos_offset_m[i] * (1.0f - alpha[i]);
         _hgt_offset_cm[i] = (float)(state[GPS_BLENDED_INSTANCE].location.alt - state[i].location.alt) *  alpha[i] + _hgt_offset_cm[i] * (1.0f - alpha[i]);
-    }
-
-    // Calculate a corrected location for each GPS
-    Location corrected_location[GPS_MAX_RECEIVERS];
-    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-        corrected_location[i] = state[i].location;
-        corrected_location[i].offset(_NE_pos_offset_m[i].x, _NE_pos_offset_m[i].y);
-        corrected_location[i].alt += (int)(_hgt_offset_cm[i]);
     }
 
     // If the GPS week is the same then use a blended time_week_ms

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -587,12 +587,9 @@ private:
     void inject_data(uint8_t instance, const uint8_t *data, uint16_t len);
 
     // GPS blending and switching
-    Vector2f _NE_pos_offset_m[GPS_MAX_RECEIVERS]; // Filtered North,East position offset from GPS instance to blended solution in _output_state.location (m)
-    float _hgt_offset_cm[GPS_MAX_RECEIVERS]; // Filtered height offset from GPS instance relative to blended solution in _output_state.location (cm)
     Vector3f _blended_antenna_offset; // blended antenna offset
     float _blended_lag_sec; // blended receiver lag in seconds
     float _blend_weights[GPS_MAX_RECEIVERS]; // blend weight for each GPS. The blend weights must sum to 1.0 across all instances.
-    uint32_t _last_time_updated[GPS_MAX_RECEIVERS]; // the last value of state.last_gps_time_ms read for that GPS instance - used to detect new data.
     float _omega_lpf; // cutoff frequency in rad/sec of LPF applied to position offsets
     bool _output_is_blended; // true when a blended GPS solution being output
     uint8_t _blend_health_counter;  // 0 = perfectly health, 100 = very unhealthy


### PR DESCRIPTION
we were accessing beyond the end of the antenna_offset array. This could cause the EKF position and velocity data to be corrupted when blending
Bug introduced in 
261465ef963155bb2b30339a0fc88288ba7ac46e AP_GPS: split out update_primary() from update()
