### PR TITLE
AC_Fence: Change the minimum value of the circle radius to 0

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @DisplayName: Circular Fence Radius
     // @Description: Circle fence radius which when breached will cause an RTL
     // @Units: m
-    // @Range: 30 10000
+    // @Range: 0 10000
     // @User: Standard
     AP_GROUPINFO("RADIUS",      4,  AC_Fence,   _circle_radius, AC_FENCE_CIRCLE_RADIUS_DEFAULT),
 


### PR DESCRIPTION
I learned that the circle radius check was performed at 0m.
I adjust the parameter range specification to the judgment value.