### PR TITLE
AP_Scripting: add rangefinder bindings

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -121,6 +121,8 @@ include AP_RangeFinder/AP_RangeFinder.h
 
 singleton RangeFinder alias rangefinder
 singleton RangeFinder method num_sensors uint8_t
+singleton RangeFinder method has_orientation boolean Rotation'enum ROTATION_NONE ROTATION_PITCH_7
+singleton RangeFinder method distance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_PITCH_7
 
 include AP_Terrain/AP_Terrain.h
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1271,6 +1271,40 @@ static int AP_Terrain_enabled(lua_State *L) {
     return 1;
 }
 
+static int RangeFinder_distance_cm_orient(lua_State *L) {
+    RangeFinder * ud = RangeFinder::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "rangefinder not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= static_cast<int32_t>(ROTATION_NONE)) && (raw_data_2 <= static_cast<int32_t>(ROTATION_PITCH_7))), 2, "argument out of range");
+    const Rotation data_2 = static_cast<Rotation>(raw_data_2);
+    const uint16_t data = ud->distance_cm_orient(
+            data_2);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int RangeFinder_has_orientation(lua_State *L) {
+    RangeFinder * ud = RangeFinder::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, 1, "rangefinder not supported on this firmware");
+    }
+
+    binding_argcheck(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= static_cast<int32_t>(ROTATION_NONE)) && (raw_data_2 <= static_cast<int32_t>(ROTATION_PITCH_7))), 2, "argument out of range");
+    const Rotation data_2 = static_cast<Rotation>(raw_data_2);
+    const bool data = ud->has_orientation(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
 static int RangeFinder_num_sensors(lua_State *L) {
     RangeFinder * ud = RangeFinder::get_singleton();
     if (ud == nullptr) {
@@ -2374,6 +2408,8 @@ const luaL_Reg AP_Terrain_meta[] = {
 };
 
 const luaL_Reg RangeFinder_meta[] = {
+    {"distance_cm_orient", RangeFinder_distance_cm_orient},
+    {"has_orientation", RangeFinder_has_orientation},
     {"num_sensors", RangeFinder_num_sensors},
     {NULL, NULL}
 };


### PR DESCRIPTION
The rangefinder functions take a rotation as the input, I have not added the rotations enum to scripting but we could, just its rather large