### PR TITLE
AP_Periph: Fixed airspeed to use corrected pressure

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1518,7 +1518,7 @@ void AP_Periph_FW::can_airspeed_update(void)
         // don't send any data
         return;
     }
-    const float press = airspeed.get_differential_pressure();
+    const float press = airspeed.get_corrected_pressure();
     float temp;
     if (!airspeed.get_temperature(temp)) {
         temp = nanf("");

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -159,6 +159,14 @@ public:
     uint8_t get_primary(void) const { return primary; }
 
     static AP_Airspeed *get_singleton() { return _singleton; }
+
+    // return the current corrected pressure, public for AP_Periph
+    float get_corrected_pressure(uint8_t i) const {
+        return state[i].corrected_pressure;
+    }
+    float get_corrected_pressure(void) const {
+        return get_corrected_pressure(primary);
+    }
     
 private:
     static AP_Airspeed *_singleton;
@@ -220,13 +228,7 @@ private:
     // return the differential pressure in Pascal for the last airspeed reading for the requested instance
     // returns 0 if the sensor is not enabled
     float get_pressure(uint8_t i);
-    // return the current corrected pressure
-    float get_corrected_pressure(uint8_t i) const {
-        return state[i].corrected_pressure;
-    }
-    float get_corrected_pressure(void) const {
-        return get_corrected_pressure(primary);
-    }
+
     // get the failure health probability
     float get_health_failure_probability(uint8_t i) const {
         return state[i].failures.health_probability;


### PR DESCRIPTION
this avoids the fabsf() inside the node, which causes an error when used by the main airspeed driver
