### PR TITLE
Fix realloc method for ChibiOS

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -442,6 +442,7 @@ class chibios(Board):
         env.DEFINES.update(
             CONFIG_HAL_BOARD = 'HAL_BOARD_CHIBIOS',
             HAVE_STD_NULLPTR_T = 0,
+            USE_LIBC_REALLOC = 0,
         )
 
         env.AP_LIBRARIES += [
@@ -494,6 +495,7 @@ class chibios(Board):
             '-specs=nosys.specs',
             '-DCHIBIOS_BOARD_NAME="%s"' % self.name,
             '-D__USE_CMSIS',
+            '-Werror=deprecated-declarations'
         ]
         env.CXXFLAGS += env.CFLAGS + [
             '-fno-rtti',

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -52,7 +52,6 @@ class Board:
 
             env.DEFINES.update(
                 ENABLE_SCRIPTING = 1,
-                ENABLE_HEAP = 1,
                 LUA_32BITS = 1,
                 )
 
@@ -158,6 +157,10 @@ class Board:
         if cfg.options.bootloader:
             # don't let bootloaders try and pull scripting in
             cfg.options.disable_scripting = True
+        else:
+            env.DEFINES.update(
+                ENABLE_HEAP = 1,
+            )
 
         if cfg.options.enable_math_check_indexes:
             env.CXXFLAGS += ['-DMATH_CHECK_INDEXES']

--- a/libraries/AP_Common/AP_ExpandingArray.cpp
+++ b/libraries/AP_Common/AP_ExpandingArray.cpp
@@ -38,7 +38,7 @@ bool AP_ExpandingArrayGeneric::expand(uint16_t num_chunks)
             // fail if reallocating would leave less than 100 bytes of memory free
             return false;
         }
-        chunk_ptr_t *chunk_ptrs_new = (chunk_ptr_t*)realloc(chunk_ptrs, chunk_ptr_size * sizeof(chunk_ptr_t));
+        chunk_ptr_t *chunk_ptrs_new = (chunk_ptr_t*)hal.util->std_realloc((void*)chunk_ptrs, chunk_ptr_size * sizeof(chunk_ptr_t));
         if (chunk_ptrs_new == nullptr) {
             return false;
         }

--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -235,3 +235,7 @@
 #else
 #define AP_UAVCAN_SLCAN_ENABLED 0
 #endif
+
+#ifndef USE_LIBC_REALLOC
+#define USE_LIBC_REALLOC 1
+#endif

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -158,7 +158,9 @@ public:
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     virtual void *allocate_heap_memory(size_t size) = 0;
     virtual void *heap_realloc(void *heap, void *ptr, size_t new_size) = 0;
+    virtual void *std_realloc(void *ptr, size_t new_size) { return realloc(ptr, new_size); }
 #endif // ENABLE_HEAP
+
 
     /**
        how much free memory do we have in bytes. If unknown return 4096

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -158,7 +158,11 @@ public:
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     virtual void *allocate_heap_memory(size_t size) = 0;
     virtual void *heap_realloc(void *heap, void *ptr, size_t new_size) = 0;
+#if USE_LIBC_REALLOC
     virtual void *std_realloc(void *ptr, size_t new_size) { return realloc(ptr, new_size); }
+#else
+    virtual void *std_realloc(void *ptr, size_t new_size) = 0;
+#endif // USE_LIBC_REALLOC
 #endif // ENABLE_HEAP
 
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -86,6 +86,26 @@ void *Util::allocate_heap_memory(size_t size)
     return heap;
 }
 
+/*
+  realloc implementation thanks to wolfssl, used by AP_Scripting
+ */
+void *Util::std_realloc(void *addr, size_t size)
+{
+    if (size == 0) {
+       free(addr);
+       return nullptr;
+    }
+    if (addr == nullptr) {
+        return malloc(size);
+    }
+    void *new_mem = malloc(size);
+    if (new_mem != nullptr) {
+        memcpy(new_mem, addr, chHeapGetSize(addr) > size ? size : chHeapGetSize(addr));
+        free(addr);
+    }
+    return new_mem;
+}
+
 void *Util::heap_realloc(void *heap, void *ptr, size_t new_size)
 {
     if (heap == nullptr) {

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -38,6 +38,7 @@ public:
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     virtual void *allocate_heap_memory(size_t size) override;
     virtual void *heap_realloc(void *heap, void *ptr, size_t new_size) override;
+    virtual void *std_realloc(void *ptr, size_t new_size) override;
 #endif // ENABLE_HEAP
 
     /*

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
@@ -44,8 +44,9 @@ int printf(const char *fmt, ...);
 void *malloc(size_t size);
 void *calloc(size_t nmemb, size_t size);
 void free(void *ptr);
-
+void *realloc(void* ptr, size_t size) __attribute__((deprecated));
 extern int (*vprintf_console_hook)(const char *fmt, va_list arg);
+
 
 #define L_tmpnam 32
 

--- a/libraries/AP_Scripting/lua/src/lauxlib.c
+++ b/libraries/AP_Scripting/lua/src/lauxlib.c
@@ -1005,29 +1005,29 @@ LUALIB_API const char *luaL_gsub (lua_State *L, const char *s, const char *p,
 }
 
 
-static void *l_alloc (void *ud, void *ptr, size_t osize, size_t nsize) {
-  (void)ud; (void)osize;  /* not used */
-  if (nsize == 0) {
-    free(ptr);
-    return NULL;
-  }
-  else
-    return realloc(ptr, nsize);
-}
+// static void *l_alloc (void *ud, void *ptr, size_t osize, size_t nsize) {
+//   (void)ud; (void)osize;  /* not used */
+//   if (nsize == 0) {
+//     free(ptr);
+//     return NULL;
+//   }
+//   else
+//     return realloc(ptr, nsize);
+// }
 
 
-static int panic (lua_State *L) {
-  lua_writestringerror("PANIC: unprotected error in call to Lua API (%s)\n",
-                        lua_tostring(L, -1));
-  return 0;  /* return to Lua to abort */
-}
+// static int panic (lua_State *L) {
+//   lua_writestringerror("PANIC: unprotected error in call to Lua API (%s)\n",
+//                         lua_tostring(L, -1));
+//   return 0;  /* return to Lua to abort */
+// }
 
 
-LUALIB_API lua_State *luaL_newstate (void) {
-  lua_State *L = lua_newstate(l_alloc, NULL);
-  if (L) lua_atpanic(L, &panic);
-  return L;
-}
+// LUALIB_API lua_State *luaL_newstate (void) {
+//   lua_State *L = lua_newstate(l_alloc, NULL);
+//   if (L) lua_atpanic(L, &panic);
+//   return L;
+// }
 
 
 LUALIB_API void luaL_checkversion_ (lua_State *L, lua_Number ver, size_t sz) {


### PR DESCRIPTION
realloc method is left undefined, hence calling libc method that breaks realloc in AP_ExpandingArray used in Dijkstra Avoidance code.