### PR TITLE
Sub 4.0: Do not report battery levels

### DIFF
--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -40,6 +40,8 @@ protected:
 
     uint64_t capabilities() const override;
 
+    uint8_t get_battery_remaining_percentage() override { return -1; };
+
 private:
 
     void handleMessage(const mavlink_message_t &msg) override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -431,6 +431,7 @@ protected:
     virtual float vfr_hud_airspeed() const;
     virtual int16_t vfr_hud_throttle() const { return 0; }
     virtual float vfr_hud_alt() const;
+    virtual uint8_t get_battery_remaining_percentage();
 
     static constexpr const float magic_force_arm_value = 2989.0f;
     static constexpr const float magic_force_disarm_value = 21196.0f;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3931,7 +3931,7 @@ void GCS_MAVLINK::send_sys_status()
     int8_t battery_remaining;
 
     if (battery.healthy() && battery.current_amps(battery_current)) {
-        battery_remaining = battery.capacity_remaining_pct();
+        battery_remaining = get_battery_remaining_percentage();
         battery_current *= 100;
     } else {
         battery_current = -1;
@@ -4659,6 +4659,11 @@ void GCS_MAVLINK::manual_override(RC_Channel *c, int16_t value_in, const uint16_
         override_value = radio_min + (radio_max - radio_min) * (value_in + offset) / scaler;
     }
     c->set_override(override_value, tnow);
+}
+
+uint8_t GCS_MAVLINK::get_battery_remaining_percentage() {
+    const AP_BattMonitor &battery = AP::battery();
+    return battery.capacity_remaining_pct();
 }
 
 GCS &gcs()


### PR DESCRIPTION
This is a sub4.0-only alternative for https://github.com/ArduPilot/ardupilot/pull/13712.
This makes Sub ALWAYS return -1 for battery levels.