### PR TITLE
Include LR_THD in watchdog debug

### DIFF
--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -72,6 +72,7 @@ public:
         uint8_t fault_thd_prio;
         uint32_t fault_addr;
         uint32_t fault_icsr;
+        uint32_t fault_lr;
     };
     struct PersistentData persistent_data;
 

--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -226,7 +226,7 @@ static void main_loop()
     if (hal.util->was_watchdog_reset()) {
         AP::internalerror().error(AP_InternalError::error_t::watchdog_reset);
         const AP_HAL::Util::PersistentData &pd = last_persistent_data;
-        AP::logger().WriteCritical("WDOG", "TimeUS,Task,IErr,IErrCnt,MavMsg,MavCmd,SemLine,FL,FT,FA,FP,ICSR", "QbIIHHHHHIBI",
+        AP::logger().WriteCritical("WDOG", "TimeUS,Tsk,IE,IEC,MvMsg,MvCmd,SmLn,FL,FT,FA,FP,ICSR,LR", "QbIIHHHHHIBII",
                                    AP_HAL::micros64(),
                                    pd.scheduler_task,
                                    pd.internal_errors,
@@ -238,7 +238,8 @@ static void main_loop()
                                    pd.fault_type,
                                    pd.fault_addr,
                                    pd.fault_thd_prio,
-                                   pd.fault_icsr);
+                                   pd.fault_icsr,
+                                   pd.fault_lr);
     }
 #endif // HAL_NO_LOGGING
 #endif // IOMCU_FW

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2589,14 +2589,27 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
 {
     if (is_equal(packet.param1, 42.0f) &&
         is_equal(packet.param2, 24.0f) &&
-        is_equal(packet.param3, 71.0f) &&
-        is_equal(packet.param4, 93.0f)) {
-        // this is a magic sequence to force the main loop to
-        // lockup. This is for testing the stm32 watchdog
-        // functionality
-        while (true) {
-            send_text(MAV_SEVERITY_WARNING,"entering lockup");
-            hal.scheduler->delay(250);
+        is_equal(packet.param3, 71.0f)) {
+        if (is_equal(packet.param4, 93.0f)) {
+            // this is a magic sequence to force the main loop to
+            // lockup. This is for testing the stm32 watchdog
+            // functionality
+            while (true) {
+                send_text(MAV_SEVERITY_WARNING,"entering lockup");
+                hal.scheduler->delay(250);
+            }
+        }
+        if (is_equal(packet.param4, 94.0f)) {
+            // the following text is unlikely to make it out...
+            send_text(MAV_SEVERITY_WARNING,"deferencing a bad thing");
+
+            void *foo = (void*)0xE000ED38;
+
+            typedef void (*fptr)();
+            fptr gptr = (fptr) (void *) foo;
+            gptr();
+
+            return MAV_RESULT_FAILED;
         }
     }
 


### PR DESCRIPTION
This does seem to include a correct-ish address for the error in `WDOG.LR`

The fact that the disassembly doesn't contain the expected constant is interesting, however.

```
1970-01-01 10:00:07.94: WDOG {TimeUS : 7943393, Tsk : 32, IE : 0, IEC : 0, MvMsg : 76, MvCmd : 246, SmLn : 0, FL : 102, FT : 3, FA : 3758157112, FP : 180, ICSR : 4196355, LR : 134587061}

pbarker@bluebottle:~$ i 134587061
134587061 0x805A2B5 01001321265 0b1000000001011010001010110101
pbarker@bluebottle:~$ 


pbarker@bluebottle:~/rc/ardupilot(pr/include-lr-in-wdog)$ ls -l build/CubeBlack/bin/arducopter
-rwxr-xr-x 1 pbarker pbarker 3266524 Mar 19 12:40 build/CubeBlack/bin/arducopter
pbarker@bluebottle:~/rc/ardupilot(pr/include-lr-in-wdog)$ 

pbarker@bluebottle:~/rc/ardupilot(pr/include-lr-in-wdog)$ ~/gcc-arm-none-eabi-6_2-2016q4/bin/arm-none-eabi-objdump -D build/CubeBlack/bin/arducopter | less
....
 805a2a2:       f43f af7d       beq.w   805a1a0 <_ZN11GCS_MAVLINK23handle_preflight_rebootERK24__mavlink_command_long_t+0x18>
 805a2a6:       4620            mov     r0, r4
 805a2a8:       4a18            ldr     r2, [pc, #96]   ; (805a30c <_ZN11GCS_MAVLINK23handle_preflight_rebootERK24__mavlink_command_long_t+0x184>)
 805a2aa:       2104            movs    r1, #4
 805a2ac:       f7fe f8c4       bl      8058438 <_ZNK11GCS_MAVLINK9send_textE12MAV_SEVERITYPKcz>
 805a2b0:       ab03            add     r3, sp, #12
 805a2b2:       4798            blx     r3
 805a2b4:       2004            movs    r0, #4
 805a2b6:       b005            add     sp, #20
 805a2b8:       bdf0            pop     {r4, r5, r6, r7, pc}
 805a2ba:       4620            mov     r0, r4
 805a2bc:       4798            blx     r3
 805a2be:       2800            cmp     r0, #0
 805a2c0:       d0ae            beq.n   805a220 <_ZN11GCS_MAVLINK23handle_preflight_rebootERK24__mavlink_command_long_t+0x98>
```
