### PR TITLE
Fixed critical FPort bug

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -929,12 +929,10 @@ void UARTDriver::half_duplex_setup_tx(void)
     if (!hd_tx_active) {
         chEvtGetAndClearFlags(&hd_listener);
         hd_tx_active = true;
-        if (_last_options & (OPTION_RXINV | OPTION_TXINV)) {
-            SerialDriver *sd = (SerialDriver*)(sdef.serial);
-            sdStop(sd);
-            sercfg.cr3 &= ~USART_CR3_HDSEL;
-            sdStart(sd, &sercfg);
-        }
+        SerialDriver *sd = (SerialDriver*)(sdef.serial);
+        sdStop(sd);
+        sercfg.cr3 &= ~USART_CR3_HDSEL;
+        sdStart(sd, &sercfg);
     }
 #endif
 }
@@ -955,12 +953,10 @@ void UARTDriver::_timer_tick(void)
           half-duplex transmit has finished. We now re-enable the
           HDSEL bit for receive
          */
-        if (_last_options & (OPTION_RXINV | OPTION_TXINV)) {
-            SerialDriver *sd = (SerialDriver*)(sdef.serial);
-            sdStop(sd);
-            sercfg.cr3 |= USART_CR3_HDSEL;
-            sdStart(sd, &sercfg);
-        }
+        SerialDriver *sd = (SerialDriver*)(sdef.serial);
+        sdStop(sd);
+        sercfg.cr3 |= USART_CR3_HDSEL;
+        sdStart(sd, &sercfg);
         hd_tx_active = false;
     }
 #endif

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -322,6 +322,10 @@ void AP_RCProtocol_FPort::_process_byte(uint32_t timestamp_us, uint8_t b)
             (frame->type == FPORT_TYPE_DOWNLINK && frame->len != FRAME_LEN_DOWNLINK)) {
             goto reset;
         }
+        if (frame->type != FPORT_TYPE_CONTROL && frame->type != FPORT_TYPE_DOWNLINK) {
+            // invalid type
+            goto reset;
+        }
     }
 
     if (frame->type == FPORT_TYPE_CONTROL && byte_input.ofs == FRAME_LEN_CONTROL + 4) {
@@ -333,6 +337,9 @@ void AP_RCProtocol_FPort::_process_byte(uint32_t timestamp_us, uint8_t b)
         if (check_checksum()) {
             decode_downlink(*frame);
         }
+        goto reset;
+    }
+    if (byte_input.ofs == sizeof(byte_input.buf)) {
         goto reset;
     }
     return;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -86,18 +86,6 @@ struct PACKED FPort_Frame {
     };
 };
 
-struct {
-    bool available = false;
-    uint32_t data;
-    uint16_t appid;
-    uint8_t frame;
-} telem_data;
-
-// receiver sends 0x10 when ready to receive telemetry frames (R-XSR)
-bool rx_driven_frame_rate = false;
-// if the receiver is not controlling frame rate apply a constraint on consecutive frames
-uint8_t consecutive_telemetry_frame_count;
-
 static_assert(sizeof(FPort_Frame) == FPORT_CONTROL_FRAME_SIZE, "FPort_Frame incorrect size");
 
 // constructor

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
@@ -47,4 +47,17 @@ private:
     } byte_input;
 
     const bool inverted;
+
+    struct {
+        bool available = false;
+        uint32_t data;
+        uint16_t appid;
+        uint8_t frame;
+    } telem_data;
+
+    // receiver sends 0x10 when ready to receive telemetry frames (R-XSR)
+    bool rx_driven_frame_rate = false;
+
+    // if the receiver is not controlling frame rate apply a constraint on consecutive frames
+    uint8_t consecutive_telemetry_frame_count;
 };


### PR DESCRIPTION
This fixes a bug in FPort parsing that led to memory corruption and a watchdog. Many thanks to polarijet for patiently testing firmwares to help peter and I narrow down this bug.
