### PR TITLE
Copter: Match cyclic rate to scheduler rate

### DIFF
--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -8,7 +8,7 @@
 
 void Copter::init_precland()
 {
-    copter.precland.init(scheduler.get_loop_rate_hz());
+    copter.precland.init();
 }
 
 void Copter::update_precland()

--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -8,7 +8,7 @@
 
 void Copter::init_precland()
 {
-    copter.precland.init(400);
+    copter.precland.init(scheduler.get_loop_rate_hz());
 }
 
 void Copter::update_precland()

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -124,7 +124,6 @@ AC_PrecLand::AC_PrecLand()
 }
 
 // perform any required initialisation of landing controllers
-// update_rate_hz should be the rate at which the update method will be called in hz
 void AC_PrecLand::init()
 {
     // exit immediately if init has already been run

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -125,7 +125,7 @@ AC_PrecLand::AC_PrecLand()
 
 // perform any required initialisation of landing controllers
 // update_rate_hz should be the rate at which the update method will be called in hz
-void AC_PrecLand::init(uint16_t update_rate_hz)
+void AC_PrecLand::init()
 {
     // exit immediately if init has already been run
     if (_backend != nullptr) {
@@ -140,8 +140,8 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
     // constrain lag parameter to be within bounds
     _lag = constrain_float(_lag, 0.02f, 0.25f);
 
-    // calculate inertial buffer size from lag and minimum of main loop rate and update_rate_hz argument
-    const uint16_t inertial_buffer_size = MAX((uint16_t)roundf(_lag * MIN(update_rate_hz, AP::scheduler().get_loop_rate_hz())), 1);
+    // calculate inertial buffer size from lag and minimum of main loop rate and 400Hz(maximum)
+    const uint16_t inertial_buffer_size = MAX((uint16_t)roundf(_lag * MIN(400, AP::scheduler().get_loop_rate_hz())), 1);
 
     // instantiate ring buffer to hold inertial history, return on failure so no backends are created
     _inertial_history = new ObjectArray<inertial_data_frame_s>(inertial_buffer_size);

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -46,8 +46,7 @@ public:
     };
 
     // perform any required initialisation of landing controllers
-    // update_rate_hz should be the rate at which the update method will be called in hz
-    void init(uint16_t update_rate_hz);
+    void init(void);
 
     // returns true if precision landing is healthy
     bool healthy() const { return _backend_state.healthy; }


### PR DESCRIPTION
I'm testing flight with a Copter scheduler rate other than 400.
I think it's better to adjust from 400 fixed to scheduler rate.