### PR TITLE
AP_Logger: add more metadata for logged messages

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -453,6 +453,22 @@ const struct LogStructure Copter::log_structure[] = {
     LOG_COMMON_STRUCTURES,
     { LOG_PARAMTUNE_MSG, sizeof(log_ParameterTuning),
       "PTUN", "QBfff",         "TimeUS,Param,TunVal,TunMin,TunMax", "s----", "F----" },
+
+// @LoggerMessage: CTUN
+// @Description: Control Tuning information
+// @Field: TimeUS: microseconds since system startup
+// @Field: ThI: throttle input
+// @Field: ThO: throttle output
+// @Field: ThH: calculated hover throttle
+// @Field: DAlt: desired altitude
+// @Field: Alt: achieved altitude
+// @Field: BAlt: barometric altitude
+// @Field: DSAlt: desired rangefinder altitude
+// @Field: SAlt: achived rangefinder altitude
+// @Field: TAlt: terrain altitude
+// @Field: DCRt: desired climb rate
+// @Field: CRt: climb rate
+
     { LOG_CONTROL_TUNING_MSG, sizeof(log_Control_Tuning),
       "CTUN", "Qffffffefffhh", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DSAlt,SAlt,TAlt,DCRt,CRt", "s----mmmmmmnn", "F----00B000BB" },
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt),

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -252,6 +252,19 @@ const struct LogStructure Plane::log_structure[] = {
     LOG_COMMON_STRUCTURES,
     { LOG_STARTUP_MSG, sizeof(log_Startup),         
       "STRT", "QBH",         "TimeUS,SType,CTot", "s--", "F--" },
+
+// @LoggerMessage: CTUN
+// @Description: Control Tuning information
+// @Field: TimeUS: microseconds since system startup
+// @Field: NavRoll: desired roll
+// @Field: Roll: achieved roll
+// @Field: NavPitch: desired pitch
+// @Field: Pitch: achieved pitch
+// @Field: ThrOut: scaled output throttle
+// @Field: RdrOut: scaled output rudder
+// @Field: ThrDem: demanded speed-height-controller throttle
+// @Field: Aspd: airspeed estimate
+
     { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
       "CTUN", "Qcccchhhf",    "TimeUS,NavRoll,Roll,NavPitch,Pitch,ThrOut,RdrOut,ThrDem,Aspd", "sdddd---n", "FBBBB---0" },
 
@@ -279,10 +292,36 @@ const struct LogStructure Plane::log_structure[] = {
       "ATRP", "QBBcfff",  "TimeUS,Type,State,Servo,Demanded,Achieved,P", "s---dd-", "F---00-" },
     { LOG_STATUS_MSG, sizeof(log_Status),
       "STAT", "QBfBBBBBB",  "TimeUS,isFlying,isFlyProb,Armed,Safety,Crash,Still,Stage,Hit", "s--------", "F--------" },
+
+// @LoggerMessage: QTUN
+// @Description: QuadPlane vertical tuning message
+// @Field: TimeUS: microseconds since system startup
+// @Field: ThI: throttle input
+// @Field: ABst: angle boost
+// @Field: ThO: throttle output
+// @Field: ThH: calculated hover throttle
+// @Field: DAlt: desired altitude
+// @Field: Alt: achieved altitude
+// @Field: BAlt: barometric altitude
+// @Field: DCRt: desired climb rate
+// @Field: CRt: climb rate
+// @Field: TMix: transition throttle mix value
+// @Field: Sscl: speed scalar for surfaces
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
       "QTUN", "Qffffffeccff", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl", "s----mmmnn--", "F----00000-0" },
     { LOG_AOA_SSA_MSG, sizeof(log_AOA_SSA),
       "AOA", "Qff", "TimeUS,AOA,SSA", "sdd", "F00" },
+
+// @LoggerMessage: PIQR,PIQP,PIQY,PIQA
+// @Description: Proportional/Intergral/Derivative gain values
+// @Field: TimeUS: microseconds since system startup
+// @Field: Tar: desired value
+// @Field: Act: achieved value
+// @Field: Err: error between target and achieved
+// @Field: P: proportial part of PID
+// @Field: I: integral part of PID
+// @Field: D: integral part of PID
+// @Field: FF: controller feed-forward portion of response
     { LOG_PIQR_MSG, sizeof(log_PID), \
       "PIQR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },  \
     { LOG_PIQP_MSG, sizeof(log_PID), \

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -241,6 +241,22 @@ void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target
     logger.WriteBlock(&pkt, sizeof(pkt));
 }
 
+// @LoggerMessage: CTUN
+// @Description: Control Tuning information
+// @Field: TimeUS: microseconds since system startup
+// @Field: ThI: throttle input
+// @Field: ABst: angle boost
+// @Field: ThO: throttle output
+// @Field: ThH: calculated hover throttle
+// @Field: DAlt: desired altitude
+// @Field: Alt: achieved altitude
+// @Field: BAlt: barometric altitude
+// @Field: DSAlt: desired rangefinder altitude
+// @Field: SAlt: achived rangefinder altitude
+// @Field: TAlt: terrain altitude
+// @Field: DCRt: desired climb rate
+// @Field: CRt: climb rate
+
 // type and unit information can be found in
 // libraries/AP_Logger/Logstructure.h; search for "log_Units" for
 // units and "Format characters" for field type information

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1066,6 +1066,15 @@ class AutoTest(ABC):
                                        (length, min_length))
         self.progress("xml file length is %u" % length)
 
+        from lxml import objectify
+        xml = open(xml_filepath,'rb').read()
+        objectify.enable_recursive_str()
+        tree = objectify.fromstring(xml)
+        for thing in tree.logformat:
+            print("Got (%s)" % str(thing.get("name")))
+#        for entry in tree.children:
+#            print("Got entry (%s)" % str(entry))
+
     def initialise_after_reboot_sitl(self):
 
         # after reboot stream-rates may be zero.  Prompt MAVProxy to

--- a/Tools/autotest/logger_metadata/emit_html.py
+++ b/Tools/autotest/logger_metadata/emit_html.py
@@ -41,7 +41,7 @@ DO NOT EDIT
             print('        <table>', file=self.fh)
             print("        <tr><th>FieldName</th><th>Description</th><tr>",
                   file=self.fh)
-            for f in docco.fields:
+            for f in docco.fields_order:
                 if "description" in docco.fields[f]:
                     fdesc = docco.fields[f]["description"]
                 else:

--- a/Tools/autotest/logger_metadata/emit_rst.py
+++ b/Tools/autotest/logger_metadata/emit_rst.py
@@ -39,7 +39,7 @@ This is a list of log messages which may be present in logs produced and stored 
             print("~" * len(line), file=self.fh)
 
             rows = []
-            for f in docco.fields:
+            for f in docco.fields_order:
                 if "description" in docco.fields[f]:
                     fdesc = docco.fields[f]["description"]
                 else:

--- a/Tools/autotest/logger_metadata/emit_xml.py
+++ b/Tools/autotest/logger_metadata/emit_xml.py
@@ -27,7 +27,7 @@ class XMLEmitter(emitter.Emitter):
                 print('        <description>%s</description>' %
                       docco.description, file=self.fh)
             print('        <fields>', file=self.fh)
-            for f in docco.fields:
+            for f in docco.fields_order:
                 print('            <field name="%s">' % f, file=self.fh)
                 if "description" in docco.fields[f]:
                     print('                <description>%s</description>' %

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -1690,6 +1690,19 @@ void AC_AutoTune::get_poshold_attitude(float &roll_cd_out, float &pitch_cd_out, 
     yaw_cd_out = target_yaw_cd;
 }
 
+// @LoggerMessage: ATUN
+// @Description: Copter/QuadPlane AutoTune
+// @Vehicles: Copter, Plane
+// @Field: TimeUS: microseconds since system startup
+// @Field: TuneStep: step in autotune process
+// @Field: Targ: target angle or rate, depending on tuning step
+// @Field: Min: measured minimum target angle or rate
+// @Field: Max: measured maximum target angle or rate
+// @Field: RP: new rate gain P term
+// @Field: RD: new rate gain D term
+// @Field: SP: new angle P term
+// @Field: ddt: maximum measured twitching acceleration
+
 // Write an Autotune data packet
 void AC_AutoTune::Log_Write_AutoTune(uint8_t _axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt)
 {

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1317,6 +1317,40 @@ struct PACKED log_Arm_Disarm {
 #define ARSP_UNITS "snPOPP----"
 #define ARSP_MULTS "F00B00----"
 
+// @LoggerMessage: ATT
+// @Description: Canonical vehicle attitude
+// @Field: TimeUS: microseconds since system startup
+// @Field: DesRoll: vehicle desired roll
+// @Field: Roll: achieved vehicle roll
+// @Field: DesPitch: vehicle desired pitch
+// @Field: Pitch: achieved vehicle pitch
+// @Field: DesYaw: vehicle desired yaw
+// @Field: Yaw: achieved vehicle yaw
+// @Field: ErrRP: lowest estimated gyro drift error
+// @Field: ErrYaw: difference between measured yaw and DCM yaw estimate
+
+// @LoggerMessage: BARO
+// @Description: Gathered Barometer data
+// @Field: TimeUS: microseconds since system startup
+// @Field: Alt: calculated altitude
+// @Field: Press: measured atmospheric pressure
+// @Field: Temp: measured atmospheric temperature
+// @Field: CRt: derived climb rate from primary barometer
+// @Field: SMS: time last sample was taken
+// @Field: Offset: raw adjustment of barometer altitude, zeroed on calibration, possibly set by GCS
+// @Field: GndTemp: temperature on ground, specified by parameter or measured while on ground
+// @Field: Health: true if barometer is considered healthy
+
+// @LoggerMessage: BAT
+// @Description: Gathered battery data
+// @Field: TimeUS: microseconds since system startup
+// @Field: Volt: measured voltage
+// @Field: VoltR: estimated resting voltage
+// @Field: Curr: measured current
+// @Field: CurrTot: current * time
+// @Field: EnrgTot: energy this battery has produced
+// @Field: Temp: measured temperature
+// @Field: Res: estimated temperature resistance
 
 // @LoggerMessage: FMT
 // @Description: Message defining the format of messages in this file
@@ -1344,7 +1378,99 @@ struct PACKED log_Arm_Disarm {
 // @Field: Yaw: vehicle yaw
 // @Field: U: boolean value indicating whether this GPS is in use
 
+// @LoggerMessage: MAG,MAG2,MAG3
+// @Description: Information received from compasses
+// @Field: TimeUS: microseconds since system startup
+// @Field: MagX: magnetic field strength in body frame
+// @Field: MagY: magnetic field strength in body frame
+// @Field: MagZ: magnetic field strength in body frame
+// @Field: OfsX: magnetic field offset in body frame
+// @Field: OfsY: magnetic field offset in body frame
+// @Field: OfsZ: magnetic field offset in body frame
+// @Field: Health: true if the compass is considered healthy
+// @Field: S: time measurement was taken
 
+// @LoggerMessage: MODE
+// @Description: vehicle control mode information
+// @Field: TimeUS: microseconds since system startup
+// @Field: Mode: vehicle-specific mode number
+// @Field: ModeNum: alias for Mode
+// @Field: Rsn: reason for entering this mode; enumeration value
+
+// @LoggerMessage: PIDR,PIDP,PIDY,PIDA,PIDS
+// @Description: Proportional/Intergral/Derivative gain values
+// @Field: TimeUS: microseconds since system startup
+// @Field: Tar: desired value
+// @Field: Act: achieved value
+// @Field: Err: error between target and achieved
+// @Field: P: proportial part of PID
+// @Field: I: integral part of PID
+// @Field: D: integral part of PID
+// @Field: FF: controller feed-forward portion of response
+
+// @LoggerMessage: RATE
+// @Description: Desired and achieved vehicle attitude rates
+// @Field: TimeUS: microseconds since system startup
+// @Field: RDes: vehicle desired roll rate
+// @Field: R: achieved vehicle roll rate
+// @Field: ROut: normalised output for Roll
+// @Field: PDes: vehicle desired pitch rate
+// @Field: P: vehicle pitch rate
+// @Field: POut: normalised output for Pitch
+// @Field: YDes: vehicle desired yaw rate
+// @Field: Y: achieved vehicle yaw rate
+// @Field: YOut: normalised output for Yaw
+// @Field: YDes: vehicle desired yaw rate
+// @Field: Y: achieved vehicle yaw rate
+// @Field: ADes: desired vehicle vertical acceleration
+// @Field: A: achieived vehicle vertical acceleration
+// @Field: AOut: percentage of vertical thrust output current being used
+
+// @LoggerMessage: RCIN
+// @Description: RC input channels to vehicle
+// @Field: TimeUS: microseconds since system startup
+// @Field: C1: channel 1 input
+// @Field: C2: channel 2 input
+// @Field: C3: channel 3 input
+// @Field: C4: channel 4 input
+// @Field: C5: channel 5 input
+// @Field: C6: channel 6 input
+// @Field: C7: channel 7 input
+// @Field: C8: channel 8 input
+// @Field: C9: channel 9 input
+// @Field: C10: channel 10 input
+// @Field: C11: channel 11 input
+// @Field: C12: channel 12 input
+// @Field: C13: channel 13 input
+// @Field: C14: channel 14 input
+
+// @LoggerMessage: RCOU
+// @Description: Servo channel output values
+// @Field: TimeUS: microseconds since system startup
+// @Field: C1: channel 1 output
+// @Field: C2: channel 2 output
+// @Field: C3: channel 3 output
+// @Field: C4: channel 4 output
+// @Field: C5: channel 5 output
+// @Field: C6: channel 6 output
+// @Field: C7: channel 7 output
+// @Field: C8: channel 8 output
+// @Field: C9: channel 9 output
+// @Field: C10: channel 10 output
+// @Field: C11: channel 11 output
+// @Field: C12: channel 12 output
+// @Field: C13: channel 13 output
+// @Field: C14: channel 14 output
+
+// @LoggerMessage: VIBE
+// @Description: Processed (acceleration) vibration information
+// @Field: TimeUS: microseconds since system startup
+// @Field: VibeX: Primary accelerometer filtered vibration, x-axis
+// @Field: VibeY: Primary accelerometer filtered vibration, y-axis
+// @Field: VibeZ: Primarz accelerometer filtered vibration, z-axis
+// @Field: Clip0: Number of clipping events on 1st accelerometer
+// @Field: Clip1: Number of clipping events on 2nd accelerometer
+// @Field: Clip2: Number of clipping events on 3rd accelerometer
 
 // messages for all boards
 #define LOG_BASE_STRUCTURES \


### PR DESCRIPTION
From @Hwurzburg  (in https://github.com/ArduPilot/ardupilot/pull/11765#issuecomment-601513679):

```
@peterbarker so my list would be: ATT,ATUN,BARO,BAT,CTUN,GPS,MAG,MODE,PID/PIDQ (cant these be recursed with SUBGROUPs somehow to minimize effort?),QTUN,RAT,RCIN,RCOU,TECS,VIBE
a bit more than a dozen, but not by a lot...but @tridge and @rmackay9 should also comment...

```
