### PR TITLE
AP_Frsky_Telem: fix for protocol=4 GAlt=0 and GSPd=0

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -206,11 +206,12 @@ private:
     struct
     {
         bool sport_status;
+        bool gps_refresh;
+        bool vario_refresh;
         uint8_t fas_call;
         uint8_t gps_call;
         uint8_t vario_call;
         uint8_t various_call;
-        uint8_t next_sensor_id;
     } _SPort;
     
     struct


### PR DESCRIPTION
This fixes serial_protocol 4 GPS altitude and speed error, both were reported as constant 0
for calc_gps_position() was never called.
Issue introduced after adding support for VSpd and trying to execute "slow" code when there was no serial input to process.