### PR TITLE
Copter: Add invalid value judgment

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -573,7 +573,7 @@ void Copter::update_simple_mode(void)
 void Copter::update_super_simple_bearing(bool force_update)
 {
     if (!force_update) {
-        if (ap.simple_mode != 2) {
+        if (ap.simple_mode < 2) {
             return;
         }
         if (home_distance() < SUPER_SIMPLE_RADIUS) {

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -19,7 +19,7 @@ bool GCS_Copter::simple_input_active() const
 
 bool GCS_Copter::supersimple_input_active() const
 {
-    return copter.ap.simple_mode == 2;
+    return copter.ap.simple_mode >= 2;
 }
 
 void GCS_Copter::update_vehicle_sensor_status_flags(void)


### PR DESCRIPTION
I found out that super simple mode and illegal value 3 are treated the same.
I change the processing determined in 2 according to this specification.