### PR TITLE
Add CI sanity checking code for onboard log message documentation

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -259,7 +259,7 @@ const LogStructure Rover::log_structure[] = {
 // @URL: http://ardupilot.org/rover/docs/navigation.html
 // @Field: TimeUS: Microseconds since system startup
 // @Field: WpDist: distance to the current navigation waypoint
-// @Field: Wpbrg: bearing to the current navigation waypoint
+// @Field: WpBrg: bearing to the current navigation waypoint
 // @Field: DesYaw: the vehicle's desired heading
 // @Field: Yaw: the vehicle's current heading
 // @Field: XTrack: the vehicle's current distance from the current travel segment

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -458,6 +458,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @Description: Control Tuning information
 // @Field: TimeUS: microseconds since system startup
 // @Field: ThI: throttle input
+// @Field: ABst: angle boost
 // @Field: ThO: throttle output
 // @Field: ThH: calculated hover throttle
 // @Field: DAlt: desired altitude

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -322,16 +322,16 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: I: integral part of PID
 // @Field: D: derivative part of PID
 // @Field: FF: controller feed-forward portion of response
-    { LOG_PIQR_MSG, sizeof(log_PID), \
-      "PIQR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },  \
-    { LOG_PIQP_MSG, sizeof(log_PID), \
-      "PIQP", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
-    { LOG_PIQY_MSG, sizeof(log_PID), \
-      "PIQY", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
-    { LOG_PIQA_MSG, sizeof(log_PID), \
-      "PIQA", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
-    { LOG_AETR_MSG, sizeof(log_AETR), \
-      "AETR", "Qhhhhh",  "TimeUS,Ail,Elev,Thr,Rudd,Flap", "s-----", "F-----" },  \
+    { LOG_PIQR_MSG, sizeof(log_PID),
+      "PIQR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
+    { LOG_PIQP_MSG, sizeof(log_PID),
+      "PIQP", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
+    { LOG_PIQY_MSG, sizeof(log_PID),
+      "PIQY", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
+    { LOG_PIQA_MSG, sizeof(log_PID),
+      "PIQA", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
+    { LOG_AETR_MSG, sizeof(log_AETR),
+      "AETR", "Qhhhhh",  "TimeUS,Ail,Elev,Thr,Rudd,Flap", "s-----", "F-----" },
 };
 
 void Plane::Log_Write_Vehicle_Startup_Messages()

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -1694,6 +1694,7 @@ void AC_AutoTune::get_poshold_attitude(float &roll_cd_out, float &pitch_cd_out, 
 // @Description: Copter/QuadPlane AutoTune
 // @Vehicles: Copter, Plane
 // @Field: TimeUS: microseconds since system startup
+// @Field: Axis: which axis is currently being tuned
 // @Field: TuneStep: step in autotune process
 // @Field: Targ: target angle or rate, depending on tuning step
 // @Field: Min: measured minimum target angle or rate

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -518,18 +518,6 @@ float AP_GyroFFT::get_weighted_noise_center_freq_hz()
     }
 }
 
-static const char* LOG_FTN1_NAME = "FTN1";
-static const char* LOG_FTN1_LABELS = "TimeUS,PkAvg,PkX,PkY,PkZ,BwAvg,BwX,BwY,BwZ,DnF";
-static const char* LOG_FTN1_UNITS = "szzzzzzzzz";
-static const char* LOG_FTN1_SCALE = "F---------";
-static const char* LOG_FTN1_FORMAT = "Qfffffffff";
-
-static const char* LOG_FTN2_NAME = "FTN2";
-static const char* LOG_FTN2_LABELS = "TimeUS,FtX,FtY,FtZ,EnX,EnY,EnZ,SnX,SnY,SnZ,Bin";
-static const char* LOG_FTN2_UNITS = "s%%%-------";
-static const char* LOG_FTN2_SCALE = "F----------";
-static const char* LOG_FTN2_FORMAT = "QfffffffffB";
-
 // log gyro fft messages
 void AP_GyroFFT::write_log_messages()
 {
@@ -537,7 +525,12 @@ void AP_GyroFFT::write_log_messages()
         return;
     }
 
-    AP::logger().Write(LOG_FTN1_NAME, LOG_FTN1_LABELS, LOG_FTN1_UNITS, LOG_FTN1_SCALE, LOG_FTN1_FORMAT,
+    AP::logger().Write(
+        "FTN1",
+        "TimeUS,PkAvg,PkX,PkY,PkZ,BwAvg,BwX,BwY,BwZ,DnF",
+        "szzzzzzzzz",
+        "F---------",
+        "Qfffffffff",
         AP_HAL::micros64(),
         get_weighted_noise_center_freq_hz(),
         get_noise_center_freq_hz().x,
@@ -549,7 +542,12 @@ void AP_GyroFFT::write_log_messages()
         get_noise_center_bandwidth_hz().z,
         _ins->get_gyro_dynamic_notch_center_freq_hz());
 
-    AP::logger().Write(LOG_FTN2_NAME, LOG_FTN2_LABELS, LOG_FTN2_UNITS, LOG_FTN2_SCALE, LOG_FTN2_FORMAT,
+    AP::logger().Write(
+        "FTN2",
+        "TimeUS,FtX,FtY,FtZ,EnX,EnY,EnZ,SnX,SnY,SnZ,Bin",
+        "s%%%-------",
+        "F----------",
+        "QfffffffffB",
         AP_HAL::micros64(),
         get_raw_noise_harmonic_fit().x,
         get_raw_noise_harmonic_fit().y,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1344,6 +1344,7 @@ struct PACKED log_Arm_Disarm {
 // @LoggerMessage: BAT
 // @Description: Gathered battery data
 // @Field: TimeUS: microseconds since system startup
+// @Field: Instance: battery instance number
 // @Field: Volt: measured voltage
 // @Field: VoltR: estimated resting voltage
 // @Field: Curr: measured current
@@ -1355,11 +1356,11 @@ struct PACKED log_Arm_Disarm {
 // @LoggerMessage: FMT
 // @Description: Message defining the format of messages in this file
 // @URL: https://ardupilot.org/dev/docs/code-overview-adding-a-new-log-message.html
-// @Field: type: unique-to-this-log identifier for message being defined
-// @Field: length: the number of bytes taken up by this message (including all headers)
-// @Field: name: name of the message being defined
-// @Field: format: character string defining the C-storage-type of the fields in this message
-// @Field: labels: the labels of the message being defined
+// @Field: Type: unique-to-this-log identifier for message being defined
+// @Field: Length: the number of bytes taken up by this message (including all headers)
+// @Field: Name: name of the message being defined
+// @Field: Format: character string defining the C-storage-type of the fields in this message
+// @Field: Columns: the labels of the message being defined
 
 // @LoggerMessage: GPS
 // @Description: Information received from GNSS systems attached to the autopilot
@@ -1387,6 +1388,9 @@ struct PACKED log_Arm_Disarm {
 // @Field: OfsX: magnetic field offset in body frame
 // @Field: OfsY: magnetic field offset in body frame
 // @Field: OfsZ: magnetic field offset in body frame
+// @Field: MOfsX: motor interference magnetic field offset in body frame
+// @Field: MOfsY: motor interference magnetic field offset in body frame
+// @Field: MOfsZ: motor interference magnetic field offset in body frame
 // @Field: Health: true if the compass is considered healthy
 // @Field: S: time measurement was taken
 

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1136,6 +1136,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     // @Vehicles: Plane
     // @Description: Information about the Total Energy Control System
     // @URL: http://ardupilot.org/plane/docs/tecs-total-energy-control-system-for-speed-height-tuning-guide.html
+    // @Field: TimeUS: microseconds since system startup
     // @Field: h: height estimate (UP) currently in use by TECS
     // @Field: dh: current climb rate ("delta-height")
     // @Field: hdem: height TECS is currently trying to achieve
@@ -1176,6 +1177,9 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     // @Vehicles: Plane
     // @Description: Additional Information about the Total Energy Control System
     // @URL: http://ardupilot.org/plane/docs/tecs-total-energy-control-system-for-speed-height-tuning-guide.html
+    // @Field: TimeUS: microseconds since system startup
+    // @Field: pmax: maximum allowed pitch from parameter
+    // @Field: pmin: minimum allowed pitch from parameter
     // @Field: KErr: difference between estimated kinetic energy and desired kinetic energy
     // @Field: PErr: difference between estimated potential energy and desired potential energy
     // @Field: EDelta: current error in speed/balance weighting

--- a/libraries/AP_Tuning/AP_Tuning.cpp
+++ b/libraries/AP_Tuning/AP_Tuning.cpp
@@ -233,7 +233,7 @@ void AP_Tuning::check_input(uint8_t flightmode)
  */
 void AP_Tuning::Log_Write_Parameter_Tuning(float value)
 {
-    AP::logger().Write("PTUN", "TimeUS,Set,Parm,Value,CenterValue", "QBBff",
+    AP::logger().Write("PRTN", "TimeUS,Set,Parm,Value,CenterValue", "QBBff",
                                            AP_HAL::micros64(),
                                            parmset,
                                            current_parm,


### PR DESCRIPTION
 - checks to make sure we're not documenting a message we don't emit
 - checks everything is documented (but only whinges about this, doesn't fail at the moment)
 - checks all of the documented fields are present in the emitted message list
 - checks all of the emitted messages are in the documented fields

Also fixes all of the failures in the existing documented fields, of which there were an embarrassing number.

@Hwurzburg 

@andyp1per I've consolidated the logging code in the GyroFFT code - I hope you don't mind!  It would have been more custom parsing or something to cope with what you had, and it seemed like you'd taken the structure we have in LogStructure for reusing fields, where you really didn't need it in there.
