### PR TITLE
Copter: Set the landing waiting time at fail safe to the set value

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -723,6 +723,15 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AP_Vehicle/AP_Vehicle.cpp
     { AP_PARAM_GROUP, "", Parameters::k_param_vehicle, (const void *)&copter, {group_info : AP_Vehicle::var_info} },
 
+    // @Param: LAND_DELAY_TIME
+    // @DisplayName: Waiting time to land
+    // @Description: Waiting time to land
+    // @Range: 0 30000
+    // @Increment: 1
+    // @Units: ms
+    // @User: Standard
+    GSCALAR(land_delay_time, "LAND_DELAY_TIME", LAND_WITH_DELAY_MS),
+
     AP_VAREND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -375,6 +375,8 @@ public:
 
         k_param_vehicle = 257, // vehicle common block of parameters
 
+        k_param_land_delay_time,
+
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -464,6 +466,8 @@ public:
     AP_Float                acro_balance_pitch;
     AP_Int8                 acro_trainer;
     AP_Float                acro_rp_expo;
+
+    AP_Int16                land_delay_time;
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -74,7 +74,7 @@ void ModeLand::gps_run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // pause before beginning land descent
-        if(land_pause && millis()-land_start_time >= LAND_WITH_DELAY_MS) {
+        if(land_pause && millis()-land_start_time >= static_cast<uint32_t>(copter.g.land_delay_time)) {
             land_pause = false;
         }
 
@@ -127,7 +127,7 @@ void ModeLand::nogps_run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // pause before beginning land descent
-        if(land_pause && millis()-land_start_time >= LAND_WITH_DELAY_MS) {
+        if(land_pause && millis()-land_start_time >= static_cast<uint32_t>(copter.g.land_delay_time)) {
             land_pause = false;
         }
 


### PR DESCRIPTION
I don't know why failsafe is fixed at 4 seconds.
I think it would be better to be able to change 4 seconds.