### PR TITLE
AP_ChibiOS/AP_HAL_SITL: Send panic message as telemetry message

### DIFF
--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -19,6 +19,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/system.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <GCS_MAVLink/GCS.h>
 #include "hwdef/common/watchdog.h"
 #include "hwdef/common/stm32_util.h"
 
@@ -202,6 +203,9 @@ void panic(const char *errormsg, ...)
     va_start(ap, errormsg);
     vprintf(errormsg, ap);
     va_end(ap);
+
+    gcs().send_text(MAV_SEVERITY_ALERT, errormsg, ap);
+    hal.scheduler->delay(1000);  // Wait for the time when the message will be sent
 
     hal.scheduler->delay_microseconds(10000);
     while (1) {

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -7,7 +7,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/system.h>
-
+#include <GCS_MAVLink/GCS.h>
 #include "Scheduler.h"
 
 extern const AP_HAL::HAL& hal;
@@ -34,6 +34,9 @@ void panic(const char *errormsg, ...)
     vprintf(errormsg, ap);
     va_end(ap);
     printf("\n");
+    
+    gcs().send_text(MAV_SEVERITY_ALERT, errormsg, ap);
+    hal.scheduler->delay(1000);  // Wait for the time when the message will be sent
 
     dump_stack_trace();
 


### PR DESCRIPTION
I need to connect my PC to FC USB to see the panic message.
I don't think WIKI mentions connecting a UART communicator to the FC USB when flying.
I think you can know that FC has panicked by sending a panic message by telemetry.