### PR TITLE
Correct retry times on mission item fetch retries

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -292,7 +292,7 @@ public:
     static const struct stream_entries all_stream_entries[];
 
     virtual uint64_t capabilities() const;
-    uint8_t get_stream_slowdown_ms() const { return stream_slowdown_ms; }
+    uint16_t get_stream_slowdown_ms() const { return stream_slowdown_ms; }
 
     MAV_RESULT set_message_interval(uint32_t msg_id, int32_t interval_us);
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -349,7 +349,7 @@ void MissionItemProtocol::update()
         return;
     }
     // resend request if we haven't gotten one:
-    const uint32_t wp_recv_timeout_ms = 1000U + (link->get_stream_slowdown_ms()*20);
+    const uint32_t wp_recv_timeout_ms = 1000U + link->get_stream_slowdown_ms();
     if (tnow - timelast_request_ms > wp_recv_timeout_ms) {
         timelast_request_ms = tnow;
         link->send_message(next_item_ap_message_id());


### PR DESCRIPTION
One case of wrong-return-type, one case of failing to remove a multiplication.

Both probably hanging over from when we moved from delaying in multiples of 20ms to delaying a number of ms.

Tested on a 900MHz radio and setting streamrates high.
