### PR TITLE
AP_RPM: check pin state in IRQ to avoid spurious interrupts

### DIFF
--- a/libraries/AP_RPM/RPM_Pin.cpp
+++ b/libraries/AP_RPM/RPM_Pin.cpp
@@ -35,14 +35,18 @@ AP_RPM_Pin::AP_RPM_Pin(AP_RPM &_ap_rpm, uint8_t instance, AP_RPM::RPM_State &_st
  */
 void AP_RPM_Pin::irq_handler(uint8_t pin, bool pin_state, uint32_t timestamp)
 {
-    const uint32_t dt = timestamp - irq_state[state.instance].last_pulse_us;
-    irq_state[state.instance].last_pulse_us = timestamp;
-    // we don't accept pulses less than 100us. Using an irq for such
-    // high RPM is too inaccurate, and it is probably just bounce of
-    // the signal which we should ignore
-    if (dt > 100 && dt < 1000*1000) {
-        irq_state[state.instance].dt_sum += dt;
-        irq_state[state.instance].dt_count++;
+    // Only trigger when pin is high. The interrupt is configured to only
+    // trigger on rising edges, but this does not seem to work right.
+    if (pin_state) {
+        const uint32_t dt = timestamp - irq_state[state.instance].last_pulse_us;
+        irq_state[state.instance].last_pulse_us = timestamp;
+        // we don't accept pulses less than 100us. Using an irq for such
+        // high RPM is too inaccurate, and it is probably just bounce of
+        // the signal which we should ignore
+        if (dt > 100 && dt < 1000*1000) {
+            irq_state[state.instance].dt_sum += dt;
+            irq_state[state.instance].dt_count++;
+        }
     }
 }
 


### PR DESCRIPTION
I have a sailboat with a cup anemometer connected to AUX6 on a Pixhawk 1. The anemometer pulls the pin low for approximately 4 ms every revolution. The rate of rising edges is used by the RPM library  to determine the wind speed.

While testing the anemometer at a nearly constant wind speed (using a fan), I noticed occasional very high wind speed measurements, usually around 250 m/s. These occur several times a minute, often in bursts.

A reading of 250 m/s corresponds to a time between pulses of approximately 4 ms, which made me suspicious that something was triggering the interrupt at the falling edge of the pulse. I used an oscilloscope to verify that no bouncing was occurring, which led me to conclude that sometime must be going wrong within ArduPilot.

I experimented with triggering the interrupt on the falling edge, or even both edges(!) and saw no change in behavior. I did find that adding a conditional on `pin_state` in the IRQ handler eliminated the spurious readings. This indicates to me that the interrupt edge parameter does not work correctly.

The solution in this PR works, but seems like it is hacking around a deeper problem with the GPIO driver.