### PR TITLE
Fixed RM3100 scale factor

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -56,7 +56,8 @@ compass_types = {
     0x0E : "DEVTYPE_MAG3110",
     0x0F : "DEVTYPE_SITL",
     0x10 : "DEVTYPE_IST8308",
-    0x11 : "DEVTYPE_RM3100",
+    0x11 : "DEVTYPE_RM3100_OLD",
+    0x12 : "DEVTYPE_RM3100",
 }
 
 imu_types = {

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -58,7 +58,8 @@ public:
         DEVTYPE_MAG3110  = 0x0E,
         DEVTYPE_SITL  = 0x0F,
         DEVTYPE_IST8308 = 0x10,
-		DEVTYPE_RM3100 = 0x11,
+        DEVTYPE_RM3100_OLD = 0x11,
+        DEVTYPE_RM3100 = 0x12,
     };
 
 

--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -135,7 +135,7 @@ bool AP_Compass_RM3100::init()
     dev->write_register(RM3100_CCZ1_REG, CCP1, true); // cycle count z
     dev->write_register(RM3100_CCZ0_REG, CCP0, true); // cycle count z
 
-    _scaler = (1 / GAIN_CC200) * UTESLA_TO_MGAUSS; // has to be changed if using a different cycle count
+    _scaler = (1 / GAIN_CC200) * UTESLA_TO_MGAUSS / 200.0; // has to be changed if using a different cycle count
 
     // lower retries for run
     dev->set_retries(3);
@@ -203,11 +203,6 @@ void AP_Compass_RM3100::timer()
     magx = ((uint32_t)data.magx_2 << 24) | ((uint32_t)data.magx_1 << 16) | ((uint32_t)data.magx_0 << 8);
     magy = ((uint32_t)data.magy_2 << 24) | ((uint32_t)data.magy_1 << 16) | ((uint32_t)data.magy_0 << 8);
     magz = ((uint32_t)data.magz_2 << 24) | ((uint32_t)data.magz_1 << 16) | ((uint32_t)data.magz_0 << 8);
-
-    // right-shift signed integer back to get correct measurement value
-    magx >>= 8;
-    magy >>= 8;
-    magz >>= 8;
 
     // apply scaler and store in field vector
     field(magx * _scaler, magy * _scaler, magz * _scaler);


### PR DESCRIPTION
The RM3100 driver uses the wrong scale factor, resulting in COMPASS_SCALE values of around 1.28. This fixes that issue, and switches to a new device ID which will force a recal
The PR is WIP as we need to work out what to do for users of CAN compasses that use the RM3100, such as the CUAV_GPS, which is AP_Periph based
The simple approach is to tell users who update their CAN compass to recalibrate. An alternative would be to check the git hash via the NODE_INFO message for the version that had the wrong scaling and auto-compensate
