### PR TITLE
AC_Fence: clear breach if breached fence is not enabled

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -317,6 +317,9 @@ uint8_t AC_Fence::check()
         return 0;
     }
 
+    // clear any breach from a non-enabled fence
+    clear_breach(~_enabled_fences);
+
     // check if pilot is attempting to recover manually
     if (_manual_recovery_start_ms != 0) {
         // we ignore any fence breaches during the manual recovery period which is about 10 seconds


### PR DESCRIPTION
To reproduce this bug in SITL (while unarmed), 
- Enable Circle Fence, set home outside the Fence radius (a pre arm error will be visible)
- Now change Fence type to not include Circle Fence ( by setting the fence to altitude or polygon) 
- The vehicle will still throw the same pre-arm error

While the vehicle is not armed, if a breach from an enabled fence is detected, the vehicle will not arm and throw a pre-arm error.
If the user now changes the fence type to NOT include the breached fence, the vehicle will still not arm. 
This PR fixes this issue. This also solves the issue #11488.
Works well in SITL