### PR TITLE
AP_NavEKF3: Fix double iteration of axes in SelectMagFusion

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -315,16 +315,9 @@ void NavEKF3_core::SelectMagFusion()
                 (frontend->_mag_ef_limit > 0 && have_table_earth_field)) {
                 FuseDeclination(0.34f);
             }
-            // fuse the three magnetometer componenents sequentially
+            // fuse the three magnetometer componenents using sequential fusion for each axis
             hal.util->perf_begin(_perf_test[0]);
-            for (mag_state.obsIndex = 0; mag_state.obsIndex <= 2; mag_state.obsIndex++) {
-                FuseMagnetometer();
-                // don't continue fusion if unhealthy
-                if (!magHealth) {
-                    hal.util->perf_end(_perf_test[0]);
-                    break;
-                }
-            }
+            FuseMagnetometer();
             hal.util->perf_end(_perf_test[0]);
             // zero the test ratio output from the inactive simple magnetometer yaw fusion
             yawTestRatio = 0.0f;
@@ -381,7 +374,6 @@ void NavEKF3_core::FuseMagnetometer()
     ftype &magXbias = mag_state.magXbias;
     ftype &magYbias = mag_state.magYbias;
     ftype &magZbias = mag_state.magZbias;
-    uint8_t &obsIndex = mag_state.obsIndex;
     Matrix3f &DCM = mag_state.DCM;
     Vector3f &MagPred = mag_state.MagPred;
     ftype &R_MAG = mag_state.R_MAG;
@@ -495,7 +487,7 @@ void NavEKF3_core::FuseMagnetometer()
         return;
     }
 
-    for (obsIndex = 0; obsIndex <= 2; obsIndex++) {
+    for (uint8_t obsIndex = 0; obsIndex <= 2; obsIndex++) {
 
         if (obsIndex == 0) {
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1271,7 +1271,6 @@ private:
         ftype magXbias;
         ftype magYbias;
         ftype magZbias;
-        uint8_t obsIndex;
         Matrix3f DCM;
         Vector3f MagPred;
         ftype R_MAG;


### PR DESCRIPTION
Fixes https://github.com/ArduPilot/ardupilot/issues/13905

This will reduce the rate at which mag field states 'learn' and if mag field process noise parameters  have been adjusted since this bug was introduced, this could result in a **_reduction in performance_**.

I t works OK on SITL, but U=until we get replay working again, this can only be tested with back to back flights as SITL has limited error modelling.

Flight testing TBC.

Edit: Because obsIndex was set to 3 internally upon completion, it would mean that fusion would not be repeated. There are cases where if fusion was aborted for a badly conditioned fusion operation that the fusion would have been repeated, but this is an extremely rare occurrence. Good new is no need to re-tune !!!