### PR TITLE
ADSB: copy vehicle updates to Object Avoidance Database

### DIFF
--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -142,6 +142,23 @@ void AP_OADatabase::update()
 }
 
 // push a location into the database
+void AP_OADatabase::queue_push(const Location &loc, uint32_t timestamp_ms)
+{
+    if (!healthy()) {
+        return;
+    }
+
+    Location ekf_origin;
+    if (!AP::ahrs().get_origin(ekf_origin)) {
+        return;
+    }
+
+    const Vector3f pos = loc.get_distance_NED(ekf_origin);
+    const float distance = loc.get_distance(ekf_origin);
+    queue_push(pos, timestamp_ms, distance);
+}
+
+// push a location into the database
 void AP_OADatabase::queue_push(const Vector3f &pos, uint32_t timestamp_ms, float distance)
 {
     if (!healthy()) {

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -4,6 +4,7 @@
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_Common/Location.h>
 
 class AP_OADatabase {
 public:
@@ -36,6 +37,9 @@ public:
 
     // push an object into the database.  Pos is the offset in meters from the EKF origin, angle is in degrees, distance in meters
     void queue_push(const Vector3f &pos, uint32_t timestamp_ms, float distance);
+
+    // push an object into the database in world frame
+    void queue_push(const Location &loc, uint32_t timestamp_ms);
 
     // returns true if database is healthy
     bool healthy() const { return (_queue.items != nullptr) && (_database.items != nullptr); }

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -157,6 +157,9 @@ private:
 
     AP_Int8     _enabled;
 
+    // copy adsb targets into OADB
+    AP_Int8     _use_oadb;
+
     Location  _my_loc;
 
     bool _init_failed;


### PR DESCRIPTION
This needs testing.

copy vehicle updates to Object Avoidance Database

New param: ADSB_USE_OADB

Simply injects the vehicle into the OADB.

Things to consider:

1. OA_DB_DIST_MAX > 0 and ADSB_LIST_RADIUS will both filter out distances in the OADB.
2. ADSB values that are moving will pretty much always be larger than OA_DB_RADIUS_MIN so objects in the database will be a trail of the same object and we have to rely on OA_DB_EXPIRE to remove them. Possible solution to this is to add a metadata value to OA_DbItem that could hold the ADSB ICAO number. Then in queue_process() we can change is_close_to_item_in_database() to also check for matching non-zero meta data values which would signify the same object has moved, that handles removing the trail but at the cost of increasing struct OA_DbItem by 4 bytes.
3. ADSB altitudes are ignored in OA_DB because it's only a 2D vector. However, the ADSB_LIST_ALT can be used to filter the alt.