### PR TITLE
Global: change to a secure sqrt

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -367,7 +367,7 @@ AP_GPS_SBF::process_message(void)
         float max_variance_squared = MAX(temp.Cov_VnVn, MAX(temp.Cov_VeVe, temp.Cov_VuVu));
         if (is_positive(max_variance_squared)) {
             state.have_speed_accuracy = true;
-            state.speed_accuracy = sqrt(max_variance_squared);
+            state.speed_accuracy = safe_sqrt(max_variance_squared);
         } else {
             state.have_speed_accuracy = false;
         }

--- a/libraries/AP_HAL_SITL/sitl_airspeed.cpp
+++ b/libraries/AP_HAL_SITL/sitl_airspeed.cpp
@@ -41,13 +41,13 @@ void SITL_State::_update_airspeed(float airspeed)
         // compute a realistic pressure report given some level of trapper air pressure in the tube and our current altitude
         // algorithm taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure
         float tube_pressure = fabsf(_sitl->arspd_fail_pressure - _barometer->get_pressure() + _sitl->arspd_fail_pitot_pressure);
-        airspeed = 340.29409348 * sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
+        airspeed = 340.29409348 * safe_sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
     }
     if (!is_zero(_sitl->arspd2_fail_pressure)) {
         // compute a realistic pressure report given some level of trapper air pressure in the tube and our current altitude
         // algorithm taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure
         float tube_pressure = fabsf(_sitl->arspd2_fail_pressure - _barometer->get_pressure() + _sitl->arspd2_fail_pitot_pressure);
-        airspeed2 = 340.29409348 * sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
+        airspeed2 = 340.29409348 * safe_sqrt(5 * (pow((tube_pressure / SSL_AIR_PRESSURE + 1), 2.0/7.0) - 1.0));
     }
 
     float airspeed_pressure = (airspeed * airspeed) / airspeed_ratio;

--- a/libraries/AP_Math/location_double.cpp
+++ b/libraries/AP_Math/location_double.cpp
@@ -31,7 +31,7 @@
  */
 void wgsllh2ecef(const Vector3d &llh, Vector3d &ecef) {
   double d = WGS84_E * sin(llh[0]);
-  double N = WGS84_A / sqrt(1 - d*d);
+  double N = WGS84_A / safe_sqrt(1 - d*d);
 
   ecef[0] = (N + llh[2]) * cos(llh[0]) * cos(llh[1]);
   ecef[1] = (N + llh[2]) * cos(llh[0]) * sin(llh[1]);
@@ -41,7 +41,7 @@ void wgsllh2ecef(const Vector3d &llh, Vector3d &ecef) {
 
 void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
   /* Distance from polar axis. */
-  const double p = sqrt(ecef[0]*ecef[0] + ecef[1]*ecef[1]);
+  const double p = safe_sqrt(ecef[0]*ecef[0] + ecef[1]*ecef[1]);
 
   /* Compute longitude first, this can be done exactly. */
   if (!is_zero(p))
@@ -59,7 +59,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
 
   /* Calculate some other constants as defined in the Fukushima paper. */
   const double P = p / WGS84_A;
-  const double e_c = sqrt(1 - WGS84_E*WGS84_E);
+  const double e_c = safe_sqrt(1 - WGS84_E*WGS84_E);
   const double Z = fabs(ecef[2]) * e_c / WGS84_A;
 
   /* Initial values for S and C correspond to a zero height solution. */
@@ -79,7 +79,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
   {
     /* Calculate some intermmediate variables used in the update step based on
      * the current state. */
-    A_n = sqrt(S*S + C*C);
+    A_n = safe_sqrt(S*S + C*C);
     D_n = Z*A_n*A_n*A_n + WGS84_E*WGS84_E*S*S*S;
     F_n = P*A_n*A_n*A_n - WGS84_E*WGS84_E*C*C*C;
     B_n = double(1.5) * WGS84_E*S*C*C*(A_n*(P*S - Z*C) - WGS84_E*S*C);
@@ -126,7 +126,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
     }
   }
 
-  A_n = sqrt(S*S + C*C);
+  A_n = safe_sqrt(S*S + C*C);
   llh[0] = copysign(1.0, ecef[2]) * atan(S / (e_c*C));
-  llh[2] = (p*e_c*C + fabs(ecef[2])*S - WGS84_A*e_c*A_n) / sqrt(e_c*e_c*C*C + S*S);
+  llh[2] = (p*e_c*C + fabs(ecef[2])*S - WGS84_A*e_c*A_n) / safe_sqrt(e_c*e_c*C*C + S*S);
 }

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -296,7 +296,7 @@ double Aircraft::rand_normal(double mean, double stddev)
             y = 2.0 * rand()/RAND_MAX - 1;
             r = x*x + y*y;
         } while (is_zero(r) || r > 1.0);
-        const double d = sqrt(-2.0 * log(r)/r);
+        const double d = safe_sqrt(-2.0 * log(r)/r);
         const double n1 = x * d;
         n2 = y * d;
         const double result = n1 * stddev + mean;


### PR DESCRIPTION
I know that sqrt has a secure sqrt.
I prefer using secure sqrt.
I can't explain why it's good to use an unsafe sqrt.