### PR TITLE
GCS_MAVLink: Remove redundant assignments

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1243,7 +1243,6 @@ bool GCS_MAVLINK::set_ap_message_interval(enum ap_message id, uint16_t interval_
         deferred_message_bucket[empty_bucket_id].interval_ms = interval_ms;
         deferred_message_bucket[empty_bucket_id].last_sent_ms = AP_HAL::millis16();
         closest_bucket = empty_bucket_id;
-        closest_bucket_interval_delta = 0;
     }
 
     deferred_message_bucket[closest_bucket].ap_message_ids.set(id);

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -454,14 +454,12 @@ void GCS_MAVLINK::ftp_worker(void) {
                             break;
                         }
 
-                        bool more_pending = true;
                         const uint32_t transfer_size = 100;
-                        for (uint32_t i = 0; (i < transfer_size) && more_pending; i++) {
+                        for (uint32_t i = 0; (i < transfer_size); i++) {
                             // fill the buffer
                             const ssize_t read_bytes = AP::FS().read(ftp.fd, reply.data, sizeof(reply.data));
                             if (read_bytes == -1) {
                                 ftp_error(reply, FTP_ERROR::FailErrno);
-                                more_pending = false;
                                 break;
                             }
 
@@ -472,7 +470,6 @@ void GCS_MAVLINK::ftp_worker(void) {
 
                             if (read_bytes == 0) {
                                 ftp_error(reply, FTP_ERROR::EndOfFile);
-                                more_pending = false;
                                 break;
                             }
 


### PR DESCRIPTION
From the scan-build results.
