### PR TITLE
AP_Logger: fix extremely unlikely nullptr dereference in SITL sanity checks

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -349,7 +349,11 @@ void AP_Logger_Backend::validate_WritePrioritisedBlock(const void *pBuffer,
     }
     if (type_len != size) {
         char name[5] = {}; // get a null-terminated string
-        memcpy(name, s->name, 4);
+        if (s->name != nullptr) {
+            memcpy(name, s->name, 4);
+        } else {
+            strncpy(name, "?NM?", ARRAY_SIZE(name));
+        }
         AP_HAL::panic("Size mismatch for %u (%s) (expected=%u got=%u)\n",
                       type, name, type_len, size);
     }


### PR DESCRIPTION
To a certain extent the developer probably deserved what they got here...
