### PR TITLE
GCS_MAVLink: Remove redundant assignment to the command

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
@@ -94,8 +94,6 @@ MAV_MISSION_RESULT MissionItemProtocol_Waypoints::get_item(const GCS_MAVLINK &_l
     // set auto continue to 1
     ret_packet.autocontinue = 1;     // 1 (true), 0 (false)
 
-    ret_packet.command = cmd.id;
-
     return MAV_MISSION_ACCEPTED;
 }
 


### PR DESCRIPTION
This is done internally by the conversion to `mission_item_int_t`