### PR TITLE
Scripting: static analysis cleanups

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -157,6 +157,7 @@ void AP_Scripting::thread(void) {
     lua_scripts *lua = new lua_scripts(_script_vm_exec_count, _script_heap_size, _debug_level, terminal);
     if (lua == nullptr || !lua->heap_allocated()) {
         gcs().send_text(MAV_SEVERITY_CRITICAL, "Unable to allocate scripting memory");
+        delete lua;
         _init_failed = true;
         return;
     }

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1330,7 +1330,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       // extract the userdata, it was a pointer, so we need to grab it
       fprintf(source, "    %s * ud = *check_%s(L, 1);\n", data->name, data->sanatized_name);
       fprintf(source, "    if (ud == NULL) {\n");
-      fprintf(source, "        luaL_error(L, \"Internal error, null pointer\");\n");
+      fprintf(source, "        return luaL_error(L, \"Internal error, null pointer\");\n");
       fprintf(source, "    }\n");
       break;
   }

--- a/libraries/AP_Scripting/lua/src/lua.c
+++ b/libraries/AP_Scripting/lua/src/lua.c
@@ -1,3 +1,4 @@
+#if 0
 /*
 ** $Id: lua.c,v 1.230.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Lua stand-alone interpreter
@@ -610,3 +611,4 @@ int main (int argc, char **argv) {
   return (result && status == LUA_OK) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
+#endif

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -2363,7 +2363,7 @@ static int AP_HAL__UARTDriver_set_flow_control(lua_State *L) {
     binding_argcheck(L, 2);
     AP_HAL::UARTDriver * ud = *check_AP_HAL__UARTDriver(L, 1);
     if (ud == NULL) {
-        luaL_error(L, "Internal error, null pointer");
+        return luaL_error(L, "Internal error, null pointer");
     }
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= static_cast<int32_t>(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE)) && (raw_data_2 <= static_cast<int32_t>(AP_HAL::UARTDriver::FLOW_CONTROL_AUTO))), 2, "argument out of range");
@@ -2378,7 +2378,7 @@ static int AP_HAL__UARTDriver_available(lua_State *L) {
     binding_argcheck(L, 1);
     AP_HAL::UARTDriver * ud = *check_AP_HAL__UARTDriver(L, 1);
     if (ud == NULL) {
-        luaL_error(L, "Internal error, null pointer");
+        return luaL_error(L, "Internal error, null pointer");
     }
     const uint32_t data = ud->available();
 
@@ -2391,7 +2391,7 @@ static int AP_HAL__UARTDriver_write(lua_State *L) {
     binding_argcheck(L, 2);
     AP_HAL::UARTDriver * ud = *check_AP_HAL__UARTDriver(L, 1);
     if (ud == NULL) {
-        luaL_error(L, "Internal error, null pointer");
+        return luaL_error(L, "Internal error, null pointer");
     }
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(UINT8_MAX, UINT8_MAX))), 2, "argument out of range");
@@ -2408,7 +2408,7 @@ static int AP_HAL__UARTDriver_read(lua_State *L) {
     binding_argcheck(L, 1);
     AP_HAL::UARTDriver * ud = *check_AP_HAL__UARTDriver(L, 1);
     if (ud == NULL) {
-        luaL_error(L, "Internal error, null pointer");
+        return luaL_error(L, "Internal error, null pointer");
     }
     const int16_t data = ud->read();
 
@@ -2420,7 +2420,7 @@ static int AP_HAL__UARTDriver_begin(lua_State *L) {
     binding_argcheck(L, 2);
     AP_HAL::UARTDriver * ud = *check_AP_HAL__UARTDriver(L, 1);
     if (ud == NULL) {
-        luaL_error(L, "Internal error, null pointer");
+        return luaL_error(L, "Internal error, null pointer");
     }
     const uint32_t raw_data_2 = coerce_to_uint32_t(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(1U, 0U)) && (raw_data_2 <= MIN(UINT32_MAX, UINT32_MAX))), 2, "argument out of range");

--- a/libraries/AP_Scripting/lua_repl.cpp
+++ b/libraries/AP_Scripting/lua_repl.cpp
@@ -98,7 +98,6 @@ int lua_scripts::incomplete(lua_State *L, int status) {
 */
 int lua_scripts::pushline(lua_State *L, int firstline) {
     char buffer[LUA_MAXINPUT + 1] = {};
-    ssize_t read_bytes;
     size_t l = 0;
 
     // send prompt to the user
@@ -109,15 +108,12 @@ int lua_scripts::pushline(lua_State *L, int firstline) {
         int input_fd = AP::FS().open(REPL_IN, O_RDONLY);
         if (input_fd != -1) {
             AP::FS().lseek(input_fd, terminal.input_offset, SEEK_SET);
-            read_bytes = AP::FS().read(input_fd, buffer, ARRAY_SIZE(buffer) - 1);
+            ssize_t read_bytes = AP::FS().read(input_fd, buffer, ARRAY_SIZE(buffer) - 1);
             AP::FS().close(input_fd);
             if (read_bytes > 0) {
                 // locate the first newline
                 char * newline_chr = strchr(buffer, '\n');
-                if (newline_chr == NULL) {
-                    // we don't have something that looks like a newline, just keep reading till it's longer
-                    read_bytes = 0;
-                } else {
+                if (newline_chr != NULL) {
                     newline_chr[0] = '\0';
                     // only advance to the newline
                     l = strlen(buffer);

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -373,7 +373,9 @@ void lua_scripts::run(void) {
     // Scan the filesystem in an appropriate manner and autostart scripts
     load_all_scripts_in_dir(L, SCRIPTING_DIRECTORY);
 
+#ifndef __clang_analyzer__
     succeeded_initial_load = true;
+#endif // __clang_analyzer__
 
     while (AP_Scripting::get_singleton()->enabled()) {
         // handle terminal data if we have any


### PR DESCRIPTION
This cleans up a number of things that were causing warnings in clang static analysis:
- one time memory leak if scripting couldn't be allocated
- helped the compiler understand that calling `luaL_error` gurantees you to not run any code after it (it actually longjumps away, but the return call helps the analysis tool
- hid a warning that a write had no effect (it actually does, but it only applies after longjumping back, which the analysis was missing
- remove some writes which had no effect