### PR TITLE
Spektrum SRXL2 support incl. telemetry

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -97,6 +97,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_ESC_Telem',
     'AP_Stats',
     'AP_GyroFFT',
+    'AP_RCTelemetry',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -32,14 +32,13 @@
 #include <AP_Common/Location.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
-#include <stdio.h>
 #include <math.h>
 
 extern const AP_HAL::HAL& hal;
 
 AP_Frsky_Telem *AP_Frsky_Telem::singleton;
 
-AP_Frsky_Telem::AP_Frsky_Telem(bool _external_data) :
+AP_Frsky_Telem::AP_Frsky_Telem(bool _external_data) : AP_RCTelemetry(TIME_SLOT_MAX),
     use_external_data(_external_data)
 {
     singleton = this;
@@ -53,35 +52,22 @@ AP_Frsky_Telem::~AP_Frsky_Telem(void)
 /*
   setup ready for passthrough telem
  */
-void AP_Frsky_Telem::setup_passthrough(void)
+void AP_Frsky_Telem::setup_wfq_scheduler(void)
 {
-#if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
-    // make frsky_telemetry available to GCS_MAVLINK (used to queue statustext messages from GCS_MAVLINK)
-    // add firmware and frame info to message queue
-    const char* _frame_string = gcs().frame_string();
-    if (_frame_string == nullptr) {
-        queue_message(MAV_SEVERITY_INFO, AP::fwversion().fw_string);
-    } else {
-        char firmware_buf[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
-        snprintf(firmware_buf, sizeof(firmware_buf), "%s %s", AP::fwversion().fw_string, _frame_string);
-        queue_message(MAV_SEVERITY_INFO, firmware_buf);
-    }
-#endif
-
     // initialize packet weights for the WFQ scheduler
-    // priority[i] = 1/_passthrough.packet_weight[i]
+    // priority[i] = 1/_scheduler.packet_weight[i]
     // rate[i] = LinkRate * ( priority[i] / (sum(priority[1-n])) )
-    _passthrough.packet_weight[0] = 35;    // 0x5000 status text (dynamic)
-    _passthrough.packet_weight[1] = 50;    // 0x5006 Attitude and range (dynamic)
-    _passthrough.packet_weight[2] = 550;   // 0x800 GPS lat (600 with 1 sensor)
-    _passthrough.packet_weight[3] = 550;   // 0x800 GPS lon (600 with 1 sensor)
-    _passthrough.packet_weight[4] = 400;   // 0x5005 Vel and Yaw
-    _passthrough.packet_weight[5] = 700;   // 0x5001 AP status
-    _passthrough.packet_weight[6] = 700;   // 0x5002 GPS Status
-    _passthrough.packet_weight[7] = 400;   // 0x5004 Home
-    _passthrough.packet_weight[8] = 1300;  // 0x5008 Battery 2 status
-    _passthrough.packet_weight[9] = 1300;  // 0x5003 Battery 1 status
-    _passthrough.packet_weight[10] = 1700; // 0x5007 parameters
+    set_scheduler_entry(TEXT, 35, 28);          // 0x5000 status text (dynamic)
+    set_scheduler_entry(ATTITUDE, 50, 38);      // 0x5006 Attitude and range (dynamic)
+    set_scheduler_entry(GPS_LAT, 550, 280);     // 0x800 GPS lat
+    set_scheduler_entry(GPS_LON, 550, 280);     // 0x800 GPS lon
+    set_scheduler_entry(VEL_YAW, 400, 250);     // 0x5005 Vel and Yaw
+    set_scheduler_entry(AP_STATUS, 700, 500);   // 0x5001 AP status
+    set_scheduler_entry(GPS_STATUS, 700, 500);  // 0x5002 GPS status
+    set_scheduler_entry(HOME, 400, 500);        // 0x5004 Home
+    set_scheduler_entry(BATT_2, 1300, 500);     // 0x5008 Battery 2 status
+    set_scheduler_entry(BATT_1, 1300, 500);     // 0x5008 Battery 1 status
+    set_scheduler_entry(PARAM, 1700, 1000);     // 0x5007 parameters
 }
 
 /*
@@ -89,6 +75,10 @@ void AP_Frsky_Telem::setup_passthrough(void)
  */
 bool AP_Frsky_Telem::init()
 {
+    if (use_external_data) {
+        return AP_RCTelemetry::init();
+    }
+
     const AP_SerialManager &serial_manager = AP::serialmanager();
 
     // check for protocol configured for a serial port - only the first serial port with one of these protocols will then run (cannot have FrSky on multiple serial ports)
@@ -98,7 +88,7 @@ bool AP_Frsky_Telem::init()
         _protocol = AP_SerialManager::SerialProtocol_FrSky_SPort; // FrSky SPort protocol (X-receivers)
     } else if ((_port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough, 0))) {
         _protocol = AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough; // FrSky SPort and SPort Passthrough (OpenTX) protocols (X-receivers)
-        setup_passthrough();
+        AP_RCTelemetry::init();
     }
 
     if (_port != nullptr) {
@@ -115,128 +105,86 @@ bool AP_Frsky_Telem::init()
     return false;
 }
 
-void AP_Frsky_Telem::update_avg_packet_rate()
+void AP_Frsky_Telem::adjust_packet_weight(bool queue_empty)
 {
-    uint32_t poll_now = AP_HAL::millis();
-
-    _passthrough.avg_packet_counter++;
-    
-    if (poll_now - _passthrough.last_poll_timer > 1000) { //average in last 1000ms
-        // initialize
-        if (_passthrough.avg_packet_rate == 0) _passthrough.avg_packet_rate = _passthrough.avg_packet_counter;
-        // moving average
-        _passthrough.avg_packet_rate = (uint8_t)_passthrough.avg_packet_rate * 0.75 + _passthrough.avg_packet_counter * 0.25;
-        // reset
-        _passthrough.last_poll_timer = poll_now;
-        _passthrough.avg_packet_counter = 0;
+    if (!queue_empty) {
+        _scheduler.packet_weight[TEXT] = 45;     // messages
+        _scheduler.packet_weight[ATTITUDE] = 80;     // attitude
+    } else {
+        _scheduler.packet_weight[TEXT] = 5000;   // messages
+        _scheduler.packet_weight[ATTITUDE] = 45;     // attitude
     }
+}
+
+// WFQ scheduler
+bool AP_Frsky_Telem::is_packet_ready(uint8_t idx, bool queue_empty)
+{
+    bool packet_ready = false;
+    switch (idx) {
+        case TEXT:
+            packet_ready = !queue_empty;
+            break;
+        case AP_STATUS:
+            packet_ready = gcs().vehicle_initialised();
+            break;
+        case BATT_2:
+            packet_ready = AP::battery().num_instances() > 1;
+            break;
+        default:
+            packet_ready = true;
+            break;
+    }
+
+    return packet_ready;
 }
 
 /*
  * WFQ scheduler
  * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
  */
-void AP_Frsky_Telem::passthrough_wfq_adaptive_scheduler(void)
+void AP_Frsky_Telem::process_packet(uint8_t idx)
 {
-    update_avg_packet_rate();
-
-    uint32_t now = AP_HAL::millis();
-    uint8_t max_delay_idx = 0;
-    
-    float max_delay = 0;
-    float delay = 0;
-    bool packet_ready = false;
-
-    // build message queue for sensor_status_flags
-    check_sensor_status_flags();
-    // build message queue for ekf_status
-    check_ekf_status();
-    
-    // dynamic priorities
-    bool queue_empty;
-    {
-        WITH_SEMAPHORE(_statustext.sem);
-        queue_empty = !_statustext.available && _statustext.queue.empty();
-    }
-    if (!queue_empty) {
-        _passthrough.packet_weight[0] = 45;     // messages
-        _passthrough.packet_weight[1] = 80;     // attitude
-    } else {
-        _passthrough.packet_weight[0] = 5000;   // messages
-        _passthrough.packet_weight[1] = 45;     // attitude
-    }
-    
-    // search the packet with the longest delay after the scheduled time
-    for (int i=0;i<TIME_SLOT_MAX;i++) {
-        //normalize packet delay relative to packet weight
-        delay = (now - _passthrough.packet_timer[i])/static_cast<float>(_passthrough.packet_weight[i]);
-        // use >= so with equal delays we choose the packet with lowest priority
-        // this is ensured by the packets being sorted by desc frequency
-        // apply the rate limiter
-        if (delay >= max_delay && ((now - _passthrough.packet_timer[i]) >= _sport_config.packet_min_period[i])) {
-            switch (i) {
-                case 0:
-                    packet_ready = !queue_empty;
-                    break;
-                case 5:
-                    packet_ready = gcs().vehicle_initialised();
-                    break;
-                case 8:
-                    packet_ready = AP::battery().num_instances() > 1;
-                    break;
-                default:
-                    packet_ready = true;
-                    break;
-            }
-
-            if (packet_ready) {
-                max_delay = delay;
-                max_delay_idx = i;
-            }
-        }
-    }
-    _passthrough.packet_timer[max_delay_idx] = AP_HAL::millis();
     // send packet
-    switch (max_delay_idx) {
-        case 0: // 0x5000 status text
+    switch (idx) {
+        case TEXT: // 0x5000 status text
             if (get_next_msg_chunk()) {
                 send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID, _msg_chunk.chunk);
             }
             break;
-        case 1: // 0x5006 Attitude and range
+        case ATTITUDE: // 0x5006 Attitude and range
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+6, calc_attiandrng());
             break;
-        case 2: // 0x800 GPS lat
+        case GPS_LAT: // 0x800 GPS lat
             // sample both lat and lon at the same time
             send_uint32(SPORT_DATA_FRAME, GPS_LONG_LATI_FIRST_ID, calc_gps_latlng(&_passthrough.send_latitude)); // gps latitude or longitude
             _passthrough.gps_lng_sample = calc_gps_latlng(&_passthrough.send_latitude);
             // force the scheduler to select GPS lon as packet that's been waiting the most
             // this guarantees that gps coords are sent at max 
-            // _passthrough.avg_polling_period*number_of_downlink_sensors time separation
-            _passthrough.packet_timer[3] = _passthrough.packet_timer[2] - 10000;
+            // _scheduler.avg_polling_period*number_of_downlink_sensors time separation
+            _scheduler.packet_timer[GPS_LON] = _scheduler.packet_timer[GPS_LAT] - 10000;
             break;
-        case 3: // 0x800 GPS lon
+        case GPS_LON: // 0x800 GPS lon
             send_uint32(SPORT_DATA_FRAME, GPS_LONG_LATI_FIRST_ID, _passthrough.gps_lng_sample); // gps longitude
             break;
-        case 4: // 0x5005 Vel and Yaw
+        case VEL_YAW: // 0x5005 Vel and Yaw
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+5, calc_velandyaw());
             break;
-        case 5: // 0x5001 AP status
+        case AP_STATUS: // 0x5001 AP status
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+1, calc_ap_status());
             break;
-        case 6: // 0x5002 GPS Status
+        case GPS_STATUS: // 0x5002 GPS Status
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+2, calc_gps_status());
             break;
-        case 7: // 0x5004 Home
+        case HOME: // 0x5004 Home
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+4, calc_home());
             break;
-        case 8: // 0x5008 Battery 2 status
+        case BATT_2: // 0x5008 Battery 2 status
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+8, calc_batt(1));
             break;
-        case 9: // 0x5003 Battery 1 status
+        case BATT_1: // 0x5003 Battery 1 status
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+3, calc_batt(0));
             break;
-        case 10: // 0x5007 parameters
+        case PARAM: // 0x5007 parameters
             send_uint32(SPORT_DATA_FRAME, DIY_FIRST_ID+7, calc_param());
             break;
     }
@@ -268,7 +216,7 @@ void AP_Frsky_Telem::send_SPort_Passthrough(void)
     }
     if (prev_byte == START_STOP_SPORT) {
         if (_passthrough.new_byte == SENSOR_ID_28) { // byte 0x7E is the header of each poll request
-            passthrough_wfq_adaptive_scheduler();
+            run_wfq_scheduler();
         }
     }
 }
@@ -603,11 +551,11 @@ bool AP_Frsky_Telem::get_next_msg_chunk(void)
     // on slow links reduce the number of duplicate chunks
     uint8_t extra_chunks = 2;
 
-    if (_passthrough.avg_packet_rate < 20) {
+    if (_scheduler.avg_packet_rate < 20) {
         // with 3 or more extra frsky sensors on the bus
         // send messages only once
         extra_chunks = 0;
-    } else if (_passthrough.avg_packet_rate < 30) {
+    } else if (_scheduler.avg_packet_rate < 30) {
         // with 1 or 2 extra frsky sensors on the bus
         // send messages twice
         extra_chunks = 1;
@@ -623,121 +571,6 @@ bool AP_Frsky_Telem::get_next_msg_chunk(void)
     return true;
 }
 
-/*
- * add message to message cue for transmission through FrSky link
- * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
- */
-void AP_Frsky_Telem::queue_message(MAV_SEVERITY severity, const char *text)
-{
-    mavlink_statustext_t statustext{};
-
-    statustext.severity = severity;
-    strncpy(statustext.text, text, sizeof(statustext.text));
-
-    // The force push will ensure comm links do not block other comm links forever if they fail.
-    // If we push to a full buffer then we overwrite the oldest entry, effectively removing the
-    // block but not until the buffer fills up.
-    WITH_SEMAPHORE(_statustext.sem);
-    _statustext.queue.push_force(statustext);
-}
-
-/*
- * add sensor_status_flags information to message cue, normally passed as sys_status mavlink messages to the GCS, for transmission through FrSky link
- * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
- */
-void AP_Frsky_Telem::check_sensor_status_flags(void)
-{
-    uint32_t now = AP_HAL::millis();
-
-    const uint32_t _sensor_status_flags = sensor_status_flags();
-
-    if ((now - check_sensor_status_timer) >= 5000) { // prevent repeating any system_status messages unless 5 seconds have passed
-        // only one error is reported at a time (in order of preference). Same setup and displayed messages as Mission Planner.
-        if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_GPS) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad GPS Health");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_GYRO) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad Gyro Health");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_ACCEL) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad Accel Health");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_MAG) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad Compass Health");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad Baro Health");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_LASER_POSITION) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad LiDAR Health");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad OptFlow Health");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_TERRAIN) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad or No Terrain Data");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_GEOFENCE) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Geofence Breach");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_AHRS) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad AHRS");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_RC_RECEIVER) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "No RC Receiver");
-            check_sensor_status_timer = now;
-        } else if ((_sensor_status_flags & MAV_SYS_STATUS_LOGGING) > 0) {
-            queue_message(MAV_SEVERITY_CRITICAL, "Bad Logging");
-            check_sensor_status_timer = now;
-        }
-    }
-}
-
-/*
- * add innovation variance information to message cue, normally passed as ekf_status_report mavlink messages to the GCS, for transmission through FrSky link
- * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
- */
-void AP_Frsky_Telem::check_ekf_status(void)
-{
-
-    // get variances
-    bool get_variance;
-    float velVar, posVar, hgtVar, tasVar;
-    Vector3f magVar;
-    Vector2f offset;
-    {
-        AP_AHRS &_ahrs = AP::ahrs();
-        WITH_SEMAPHORE(_ahrs.get_semaphore());
-        get_variance = _ahrs.get_variances(velVar, posVar, hgtVar, magVar, tasVar, offset);
-    }
-    if (get_variance) {
-        uint32_t now = AP_HAL::millis();
-        if ((now - check_ekf_status_timer) >= 10000) { // prevent repeating any ekf_status message unless 10 seconds have passed
-            // multiple errors can be reported at a time. Same setup as Mission Planner.
-            if (velVar >= 1) {
-                queue_message(MAV_SEVERITY_CRITICAL, "Error velocity variance");
-                check_ekf_status_timer = now;
-            }
-            if (posVar >= 1) {
-                queue_message(MAV_SEVERITY_CRITICAL, "Error pos horiz variance");
-                check_ekf_status_timer = now;
-            }
-            if (hgtVar >= 1) {
-                queue_message(MAV_SEVERITY_CRITICAL, "Error pos vert variance");
-                check_ekf_status_timer = now;
-            }
-            if (magVar.length() >= 1) {
-                queue_message(MAV_SEVERITY_CRITICAL, "Error compass variance");
-                check_ekf_status_timer = now;
-            }
-            if (tasVar >= 1) {
-                queue_message(MAV_SEVERITY_CRITICAL, "Error terrain alt variance");
-                check_ekf_status_timer = now;
-            }
-        }
-    }
-}
-      
 /*
  * prepare parameter data
  * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
@@ -1130,22 +963,12 @@ void AP_Frsky_Telem::calc_gps_position(void)
     _SPort_data.yaw = (uint16_t)((_ahrs.yaw_sensor / 100) % 360); // heading in degree based on AHRS and not GPS    
 }
 
-uint32_t AP_Frsky_Telem::sensor_status_flags() const
-{
-    uint32_t present;
-    uint32_t enabled;
-    uint32_t health;
-    gcs().get_sensor_status_flags(present, enabled, health);
-
-    return ~health & enabled & present;
-}
-
 /*
   fetch Sport data for an external transport, such as FPort
  */
 bool AP_Frsky_Telem::_get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data)
 {
-    passthrough_wfq_adaptive_scheduler();
+    run_wfq_scheduler();
     if (!external_data.pending) {
         return false;
     }
@@ -1167,7 +990,7 @@ bool AP_Frsky_Telem::get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &d
         new AP_Frsky_Telem(true);
         // initialize the passthrough scheduler
         if (singleton) {
-            singleton->setup_passthrough();
+            singleton->init();
         }
     }
     if (!singleton) {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -18,6 +18,7 @@
 #include <AP_Notify/AP_Notify.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AP_RCTelemetry/AP_RCTelemetry.h>
 
 #define FRSKY_TELEM_PAYLOAD_STATUS_CAPACITY          5 // size of the message buffer queue (max number of messages waiting to be sent)
 
@@ -111,7 +112,7 @@ for FrSky SPort Passthrough
 // for fair scheduler
 #define TIME_SLOT_MAX               11
 
-class AP_Frsky_Telem {
+class AP_Frsky_Telem : public AP_RCTelemetry {
 public:
     AP_Frsky_Telem(bool external_data=false);
 
@@ -122,16 +123,7 @@ public:
     AP_Frsky_Telem &operator=(const AP_Frsky_Telem&) = delete;
 
     // init - perform required initialisation
-    bool init();
-
-    // add statustext message to FrSky lib message queue
-    void queue_message(MAV_SEVERITY severity, const char *text);
-
-    // update error mask of sensors and subsystems. The mask uses the
-    // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
-    // indicates that the sensor or subsystem is present but not
-    // functioning correctly
-    uint32_t sensor_status_flags() const;
+    virtual bool init() override;
 
     static AP_Frsky_Telem *get_singleton(void) {
         return singleton;
@@ -145,17 +137,22 @@ private:
     AP_SerialManager::SerialProtocol _protocol; // protocol used - detected using SerialManager's SERIAL#_PROTOCOL parameter
     uint16_t _crc;
 
-    uint32_t check_sensor_status_timer;
-    uint32_t check_ekf_status_timer;
     uint8_t _paramID;
-
-    struct {
-        HAL_Semaphore sem;
-        ObjectBuffer<mavlink_statustext_t> queue{FRSKY_TELEM_PAYLOAD_STATUS_CAPACITY};
-        mavlink_statustext_t next;
-        bool available;
-    } _statustext;
     
+    enum PassthroughPacketType : uint8_t {
+        TEXT =          0,  // 0x5000 status text (dynamic)
+        ATTITUDE =      1,  // 0x5006 Attitude and range (dynamic)
+        GPS_LAT =       2,  // 0x800 GPS lat
+        GPS_LON =       3,  // 0x800 GPS lon
+        VEL_YAW =       4,  // 0x5005 Vel and Yaw
+        AP_STATUS =     5,  // 0x5001 AP status
+        GPS_STATUS =    6,  // 0x5002 GPS status
+        HOME =          7,  // 0x5004 Home
+        BATT_2 =        8,  // 0x5008 Battery 2 status
+        BATT_1 =        9,  // 0x5008 Battery 1 status
+        PARAM =         10  // 0x5007 parameters
+    };
+
     struct
     {
         int32_t vario_vspd;
@@ -177,31 +174,8 @@ private:
     {
         bool send_latitude; // sizeof(bool) = 4 ?
         uint32_t gps_lng_sample;
-        uint32_t last_poll_timer;
-        uint32_t avg_packet_counter;
-        uint32_t packet_timer[TIME_SLOT_MAX];
-        uint32_t packet_weight[TIME_SLOT_MAX];
-        uint8_t avg_packet_rate;
         uint8_t new_byte;
     } _passthrough;
-    
-
-    struct
-    {
-        const uint32_t packet_min_period[TIME_SLOT_MAX] = {
-            28,     //0x5000 text,      25Hz
-            38,     //0x5006 attitude   20Hz
-            280,    //0x800  GPS        3Hz
-            280,    //0x800  GPS        3Hz
-            250,    //0x5005 vel&yaw    4Hz
-            500,    //0x5001 AP status  2Hz
-            500,    //0x5002 GPS status 2Hz
-            500,    //0x5004 home       2Hz
-            500,    //0x5008 batt 2     2Hz
-            500,    //0x5003 batt 1     2Hz
-            1000    //0x5007 parameters 1Hz
-        };
-    } _sport_config;
 
     struct
     {
@@ -229,8 +203,12 @@ private:
     
     float get_vspeed_ms(void);
     // passthrough WFQ scheduler
-    void update_avg_packet_rate();
-    void passthrough_wfq_adaptive_scheduler();
+    bool is_packet_ready(uint8_t idx, bool queue_empty) override;
+    void process_packet(uint8_t idx) override;
+    void adjust_packet_weight(bool queue_empty) override;
+    // setup ready for passthrough operation
+    void setup_wfq_scheduler(void) override;
+
     // main transmission function when protocol is FrSky SPort Passthrough (OpenTX)
     void send_SPort_Passthrough(void);
     // main transmission function when protocol is FrSky SPort
@@ -247,9 +225,7 @@ private:
     void send_uint32(uint8_t frame, uint16_t id, uint32_t data);
 
     // methods to convert flight controller data to FrSky SPort Passthrough (OpenTX) format
-    bool get_next_msg_chunk(void);
-    void check_sensor_status_flags(void);
-    void check_ekf_status(void);
+    bool get_next_msg_chunk(void) override;
     uint32_t calc_param(void);
     uint32_t calc_gps_latlng(bool *send_latitude);
     uint32_t calc_gps_status(void);
@@ -264,9 +240,6 @@ private:
     void calc_nav_alt(void);
     float format_gps(float dec);
     void calc_gps_position(void);
-
-    // setup ready for passthrough operation
-    void setup_passthrough(void);
 
     // get next telemetry data for external consumers of SPort data (internal function)
     bool _get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data);

--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -22,6 +22,7 @@
 #include "AP_RCProtocol_SBUS.h"
 #include "AP_RCProtocol_SUMD.h"
 #include "AP_RCProtocol_SRXL.h"
+#include "AP_RCProtocol_SRXL2.h"
 #include "AP_RCProtocol_ST24.h"
 #include "AP_RCProtocol_FPort.h"
 #include <AP_Math/AP_Math.h>
@@ -37,6 +38,7 @@ void AP_RCProtocol::init()
     backend[AP_RCProtocol::DSM] = new AP_RCProtocol_DSM(*this);
     backend[AP_RCProtocol::SUMD] = new AP_RCProtocol_SUMD(*this);
     backend[AP_RCProtocol::SRXL] = new AP_RCProtocol_SRXL(*this);
+    backend[AP_RCProtocol::SRXL2] = new AP_RCProtocol_SRXL2(*this);
     backend[AP_RCProtocol::ST24] = new AP_RCProtocol_ST24(*this);
     backend[AP_RCProtocol::FPORT] = new AP_RCProtocol_FPort(*this, true);
 }
@@ -308,6 +310,8 @@ const char *AP_RCProtocol::protocol_name_from_protocol(rcprotocol_t protocol)
         return "SUMD";
     case SRXL:
         return "SRXL";
+    case SRXL2:
+        return "SRXL2";
     case ST24:
         return "ST24";
     case FPORT:

--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -15,6 +15,7 @@
  * Code by Andrew Tridgell and Siddharth Bharat Purohit
  */
 
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include "AP_RCProtocol.h"
 #include "AP_RCProtocol_PPMSum.h"
 #include "AP_RCProtocol_DSM.h"
@@ -22,7 +23,9 @@
 #include "AP_RCProtocol_SBUS.h"
 #include "AP_RCProtocol_SUMD.h"
 #include "AP_RCProtocol_SRXL.h"
+#if !APM_BUILD_TYPE(APM_BUILD_iofirmware)
 #include "AP_RCProtocol_SRXL2.h"
+#endif
 #include "AP_RCProtocol_ST24.h"
 #include "AP_RCProtocol_FPort.h"
 #include <AP_Math/AP_Math.h>
@@ -38,7 +41,9 @@ void AP_RCProtocol::init()
     backend[AP_RCProtocol::DSM] = new AP_RCProtocol_DSM(*this);
     backend[AP_RCProtocol::SUMD] = new AP_RCProtocol_SUMD(*this);
     backend[AP_RCProtocol::SRXL] = new AP_RCProtocol_SRXL(*this);
+#if !APM_BUILD_TYPE(APM_BUILD_iofirmware)
     backend[AP_RCProtocol::SRXL2] = new AP_RCProtocol_SRXL2(*this);
+#endif
     backend[AP_RCProtocol::ST24] = new AP_RCProtocol_ST24(*this);
     backend[AP_RCProtocol::FPORT] = new AP_RCProtocol_FPort(*this, true);
 }

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -37,6 +37,7 @@ public:
         DSM,
         SUMD,
         SRXL,
+        SRXL2,
         ST24,
         FPORT,
         NONE    //last enum always is None

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -70,11 +70,11 @@ public:
     
 protected:
     void add_input(uint8_t num_channels, uint16_t *values, bool in_failsafe, int16_t rssi=-1);
+    AP_RCProtocol &frontend;
 
     void log_data(AP_RCProtocol::rcprotocol_t prot, uint32_t timestamp, const uint8_t *data, uint8_t len) const;
 
 private:
-    AP_RCProtocol &frontend;
     uint32_t rc_input_count;
     uint32_t last_rc_input_count;
     uint32_t rc_frame_count;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -134,7 +134,7 @@ void AP_RCProtocol_SRXL2::_process_byte(uint32_t timestamp_us, uint8_t byte)
 
 void AP_RCProtocol_SRXL2::update(void)
 {
-#if 0 // it's not clear this is actually required
+    // it's not clear this is actually required, perhaps on power loss?
     if (frontend.protocol_detected() == AP_RCProtocol::SRXL2) {
         uint32_t now = AP_HAL::millis();
         // there have been no updates since we were last called
@@ -144,7 +144,6 @@ void AP_RCProtocol_SRXL2::update(void)
             _last_run_ms = now;
         }
     }
-#endif
 }
 
 void AP_RCProtocol_SRXL2::capture_scaled_input(const uint16_t *values, bool in_failsafe, int16_t new_rssi)
@@ -251,6 +250,8 @@ void AP_RCProtocol_SRXL2::_change_baud_rate(uint32_t baudrate)
 #endif
 }
 
+// SRXL2 library callbacks below
+
 // User-provided routine to change the baud rate settings on the given UART:
 // uart - the same uint8_t value as the uart parameter passed to srxlInit()
 // baudRate - the actual baud rate (currently either 115200 or 400000)
@@ -298,12 +299,10 @@ void srxlReceivedChannelData(SrxlChannelData* pChannelData, bool isFailsafe)
 // Return true if you want this bind information set automatically for all other receivers on all SRXL buses.
 bool srxlOnBind(SrxlFullID device, SrxlBindData info)
 {
-    // TODO: Add custom handling of bound data report here if needed
     return true;
 }
 
 // User-provided callback routine to handle reception of a VTX control packet.
 void srxlOnVtx(SrxlVtxData* pVtxData)
 {
-    //userProvidedHandleVtxData(pVtxData);
 }

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -1,0 +1,309 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  SRXL2 protocol decoder using Horizon Hobby's open source library https://github.com/SpektrumRC/SRXL2
+  Code by Andy Piper
+ */
+
+#include "spm_srxl.h"
+
+#include "AP_RCProtocol.h"
+#include "AP_RCProtocol_SRXL.h"
+#include "AP_RCProtocol_SRXL2.h"
+#include <AP_Math/AP_Math.h>
+#include <AP_Spektrum_Telem/AP_Spektrum_Telem.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+
+extern const AP_HAL::HAL& hal;
+//#define SRXL2_DEBUG
+#ifdef SRXL2_DEBUG
+# define debug(fmt, args...)	hal.console->printf("SRXL2:" fmt "\n", ##args)
+#else
+# define debug(fmt, args...)	do {} while(0)
+#endif
+
+AP_RCProtocol_SRXL2* AP_RCProtocol_SRXL2::_singleton;
+
+AP_RCProtocol_SRXL2::AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend)
+{
+    const uint32_t uniqueID = AP_HAL::micros();
+
+    if (_singleton != nullptr) {
+        AP_HAL::panic("Duplicate SRXL2 handler");
+    }
+
+    _singleton = this;
+    // Init the local SRXL device
+    if (!srxlInitDevice(SRXL_DEVICE_ID, SRXL_DEVICE_PRIORITY, SRXL_DEVICE_INFO, uniqueID)) {
+        AP_HAL::panic("Failed to initialize SRXL2 device");
+    }
+
+    // Init the SRXL bus: The bus index must always be < SRXL_NUM_OF_BUSES -- in this case, it can only be 0
+    if (!srxlInitBus(0, this, SRXL_SUPPORTED_BAUD_RATES)) {
+        AP_HAL::panic("Failed to initialize SRXL2 bus");
+    }
+
+}
+
+void AP_RCProtocol_SRXL2::process_pulse(uint32_t width_s0, uint32_t width_s1)
+{
+    uint8_t b;
+    if (ss.process_pulse(width_s0, width_s1, b)) {
+        _process_byte(ss.get_byte_timestamp_us(), b);
+    }
+}
+
+void AP_RCProtocol_SRXL2::_process_byte(uint32_t timestamp_us, uint8_t byte)
+{
+    if (_decode_state == STATE_IDLE) {
+        switch (byte) {
+        case SPEKTRUM_SRXL_ID:
+            _frame_len_full = 0U;
+            _decode_state = STATE_NEW;
+            break;
+        default:
+            _frame_len_full = 0U;
+            _decode_state = STATE_IDLE;
+            _buflen = 0;
+            return;
+        }
+    }
+
+    switch (_decode_state) {
+    case STATE_NEW:  // buffer header byte and prepare for frame reception and decoding
+        _buffer[0U]=byte;
+        _buflen = 1U;
+        _decode_state_next = STATE_COLLECT;
+        break;
+
+    case STATE_COLLECT: // receive all bytes. After reception decode frame and provide rc channel information to FMU
+        _buffer[_buflen] = byte;
+        _buflen++;
+
+        // need a header to get the length
+        if (_buflen < SRXL2_HEADER_LEN) {
+            return;
+        }
+
+        // parse the length
+        if (_buflen == SRXL2_HEADER_LEN) {
+            _frame_len_full = _buffer[2];
+            return;
+        }
+
+        if (_buflen > _frame_len_full) {
+            // a logic bug in the state machine, this shouldn't happen
+            _decode_state = STATE_IDLE;
+            _buflen = 0;
+            _frame_len_full = 0;
+            return;
+        }
+
+        if (_buflen == _frame_len_full) {
+            log_data(AP_RCProtocol::SRXL2, timestamp_us, _buffer, _buflen);
+            // Try to parse SRXL packet -- this internally calls srxlRun() after packet is parsed and resets timeout
+            if (srxlParsePacket(0, _buffer, _frame_len_full)) {
+                add_input(MAX_CHANNELS, _channels, _in_failsafe, _new_rssi);
+            }
+            _last_run_ms = AP_HAL::millis();
+            _decode_state_next = STATE_IDLE;
+        } else {
+            _decode_state_next = STATE_COLLECT;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    _decode_state = _decode_state_next;
+    _last_data_us = timestamp_us;
+}
+
+void AP_RCProtocol_SRXL2::update(void)
+{
+#if 0 // it's not clear this is actually required
+    if (frontend.protocol_detected() == AP_RCProtocol::SRXL2) {
+        uint32_t now = AP_HAL::millis();
+        // there have been no updates since we were last called
+        const uint32_t delay = now - _last_run_ms;
+        if (delay > 5) {
+            srxlRun(0, delay);
+            _last_run_ms = now;
+        }
+    }
+#endif
+}
+
+void AP_RCProtocol_SRXL2::capture_scaled_input(const uint16_t *values, bool in_failsafe, int16_t new_rssi)
+{
+    AP_RCProtocol_SRXL2* srxl2 = AP_RCProtocol_SRXL2::get_singleton();
+
+    if (srxl2 != nullptr) {
+        srxl2->_capture_scaled_input(values, in_failsafe, new_rssi);
+    }
+}
+
+// capture SRXL2 encoded values
+void AP_RCProtocol_SRXL2::_capture_scaled_input(const uint16_t *values, bool in_failsafe, int16_t new_rssi)
+{
+    _in_failsafe = in_failsafe;
+    // AP rssi: -1 for unknown, 0 for no link, 255 for maximum link
+    // SRXL2 rssi: -ve rssi in dBM, +ve rssi in percentage
+    if (new_rssi >= 0) {
+        _new_rssi = new_rssi * 255 / 100;
+    } else {
+        // pretty much a guess
+        _new_rssi = 255 - 255 * (-20 - new_rssi) / (-20 - 85);
+    }
+
+    for (uint8_t i = 0; i < MAX_CHANNELS; i++) {
+        /*
+         * Each channel data value is sent as an unsigned 16-bit value from 0 to 65532 (0xFFFC)
+         * with 32768 (0x8000) representing "Servo Center". The channel value must be bit-shifted
+         * to the right to match the applications's accepted resolution.
+         *
+         * So here we scale to DSMX-2048 and then use our regular Spektrum conversion.
+         */
+        _channels[i] = ((((int)(values[i] >> 5) - 1024) * 1000) / 1700) + 1500;
+    }
+}
+
+
+// start bind on DSM satellites
+void AP_RCProtocol_SRXL2::start_bind(void)
+{
+    srxlEnterBind(DSMX_11MS, true);
+}
+
+// process a byte provided by a uart
+void AP_RCProtocol_SRXL2::process_byte(uint8_t byte, uint32_t baudrate)
+{
+    if (baudrate != 115200) {
+        return;
+    }
+    _process_byte(AP_HAL::micros(), byte);
+}
+
+// send data to the uart
+void AP_RCProtocol_SRXL2::send_on_uart(uint8_t* pBuffer, uint8_t length)
+{
+    AP_RCProtocol_SRXL2* srxl2 = AP_RCProtocol_SRXL2::get_singleton();
+
+    if (srxl2 != nullptr) {
+        srxl2->_send_on_uart(pBuffer, length);
+    }
+}
+
+// send data to the uart
+void AP_RCProtocol_SRXL2::_send_on_uart(uint8_t* pBuffer, uint8_t length)
+{
+    // writing at startup locks-up the flight controller
+    if (have_UART() && AP_HAL::millis() > 3000) {
+        // check that we haven't been too slow in responding to the new
+        // UART data. If we respond too late then we will corrupt the next
+        // incoming control frame
+        uint64_t tend = get_UART()->receive_time_constraint_us(1);
+        uint64_t now = AP_HAL::micros64();
+        uint64_t tdelay = now - tend;
+        if (tdelay > 2500) {
+            // we've been too slow in responding
+            return;
+        }
+        // debug telemetry packets
+        if (pBuffer[1] == 0x80 && pBuffer[4] != 0) {
+            debug("0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x: %s",
+                pBuffer[0], pBuffer[1], pBuffer[2], pBuffer[3], pBuffer[4], pBuffer[5], pBuffer[6], pBuffer[7], pBuffer[8], pBuffer[9], &pBuffer[7]);
+        }
+        get_UART()->write(pBuffer, length);
+    }
+}
+
+// change the uart baud rate
+void AP_RCProtocol_SRXL2::change_baud_rate(uint32_t baudrate)
+{
+    AP_RCProtocol_SRXL2* srxl2 = AP_RCProtocol_SRXL2::get_singleton();
+
+    if (srxl2 != nullptr) {
+        srxl2->_change_baud_rate(baudrate);
+    }
+}
+
+// change the uart baud rate
+void AP_RCProtocol_SRXL2::_change_baud_rate(uint32_t baudrate)
+{
+#if 0
+    if (have_UART()) {
+        get_UART()->begin(baudrate);
+    }
+#endif
+}
+
+// User-provided routine to change the baud rate settings on the given UART:
+// uart - the same uint8_t value as the uart parameter passed to srxlInit()
+// baudRate - the actual baud rate (currently either 115200 or 400000)
+void srxlChangeBaudRate(void* this_ptr, uint32_t baudRate)
+{
+    AP_RCProtocol_SRXL2::change_baud_rate(baudRate);
+
+}
+
+// User-provided routine to actually transmit a packet on the given UART:
+// uart - the same uint8_t value as the uart parameter passed to srxlInit()
+// pBuffer - a pointer to an array of uint8_t values to send over the UART
+// length - the number of bytes contained in pBuffer that should be sent
+void srxlSendOnUart(void* this_ptr, uint8_t* pBuffer, uint8_t length)
+{
+    AP_RCProtocol_SRXL2::send_on_uart(pBuffer, length);
+}
+
+// User-provided callback routine to fill in the telemetry data to send to the master when requested:
+// pTelemetryData - a pointer to the 16-byte SrxlTelemetryData transmit buffer to populate
+// NOTE: srxlTelemData is available as a global variable, so the memcpy line commented out below
+// could be used if you would prefer to just populate that with the next outgoing telemetry packet.
+void srxlFillTelemetry(SrxlTelemetryData* pTelemetryData)
+{
+#if !APM_BUILD_TYPE(APM_BUILD_iofirmware)
+    AP_Spektrum_Telem::get_telem_data(pTelemetryData->raw);
+#endif
+}
+
+// User-provided callback routine that is called whenever a control data packet is received:
+// pChannelData - a pointer to the received SrxlChannelData structure for manual parsing
+// isFailsafe - true if channel data is set to failsafe values, else false.
+// this is called from within srxlParsePacket() and before the SRXL2 state machine has been run
+// so be very careful to only do local operations
+void srxlReceivedChannelData(SrxlChannelData* pChannelData, bool isFailsafe)
+{
+    if (isFailsafe) {
+        AP_RCProtocol_SRXL2::capture_scaled_input(pChannelData->values, true, pChannelData->rssi);
+    } else {
+        AP_RCProtocol_SRXL2::capture_scaled_input(srxlChData.values, false, srxlChData.rssi);
+    }
+}
+
+// User-provided callback routine to handle reception of a bound data report (either requested or unprompted).
+// Return true if you want this bind information set automatically for all other receivers on all SRXL buses.
+bool srxlOnBind(SrxlFullID device, SrxlBindData info)
+{
+    // TODO: Add custom handling of bound data report here if needed
+    return true;
+}
+
+// User-provided callback routine to handle reception of a VTX control packet.
+void srxlOnVtx(SrxlVtxData* pVtxData)
+{
+    //userProvidedHandleVtxData(pVtxData);
+}

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -1,0 +1,72 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "AP_RCProtocol.h"
+#include <AP_Math/AP_Math.h>
+#include "SoftSerial.h"
+
+#define SRXL2_MAX_CHANNELS 32U           /* Maximum number of channels from srxl2 datastream  */
+#define SRXL2_FRAMELEN_MAX   80U      /* maximum possible framelengh  */
+#define SRXL2_HEADER_LEN 3U
+
+class AP_RCProtocol_SRXL2 : public AP_RCProtocol_Backend {
+public:
+    AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend);
+    void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
+    void process_byte(uint8_t byte, uint32_t baudrate) override;
+    void start_bind(void) override;
+    void update(void) override;
+    // get singleton instance
+    static AP_RCProtocol_SRXL2* get_singleton() {
+        return _singleton;
+    }
+
+    // static functions for SRXL2 callbacks
+    static void capture_scaled_input(const uint16_t *values, bool in_failsafe, int16_t rssi);
+    static void send_on_uart(uint8_t* pBuffer, uint8_t length);
+    static void change_baud_rate(uint32_t baudrate);
+
+private:
+
+    const uint8_t MAX_CHANNELS = MIN((uint8_t)SRXL_MAX_CHANNELS, (uint8_t)MAX_RCIN_CHANNELS);
+
+    static AP_RCProtocol_SRXL2* _singleton;
+
+    void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    void _send_on_uart(uint8_t* pBuffer, uint8_t length);
+    void _change_baud_rate(uint32_t baudrate);
+    void _capture_scaled_input(const uint16_t *values, bool in_failsafe, int16_t rssi);
+
+    uint8_t _buffer[SRXL2_FRAMELEN_MAX];       /* buffer for raw srxl frame data in correct order --> buffer[0]=byte0  buffer[1]=byte1  */
+    uint8_t _buflen;                          /* length in number of bytes of received srxl dataframe in buffer  */
+    uint32_t _last_data_us;                   /* timespan since last received data in us   */
+    uint32_t _last_run_ms;                    // last time the state machine was run
+    uint16_t _channels[SRXL2_MAX_CHANNELS] = {0};    /* buffer for extracted RC channel data as pulsewidth in microseconds */
+
+    enum {
+        STATE_IDLE,                          /* do nothing */
+        STATE_NEW,                           /* get header of frame + prepare for frame reception */
+        STATE_COLLECT                        /* collect RC channel data from frame */
+    };
+    uint8_t _frame_len_full = 0U;                 /* Length in number of bytes of full srxl datastream */
+    uint8_t _decode_state = STATE_IDLE;           /* Current state of SRXL frame decoding */
+    uint8_t _decode_state_next = STATE_IDLE;      /* State of frame decoding that will be applied when the next byte from dataframe drops in  */
+    bool _in_failsafe = false;
+    int16_t _new_rssi = -1;
+
+    SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
+};

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -26,7 +26,6 @@
 class AP_RCProtocol_SRXL2 : public AP_RCProtocol_Backend {
 public:
     AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend);
-    void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
     void start_bind(void) override;
     void update(void) override;
@@ -53,7 +52,6 @@ private:
 
     uint8_t _buffer[SRXL2_FRAMELEN_MAX];       /* buffer for raw srxl frame data in correct order --> buffer[0]=byte0  buffer[1]=byte1  */
     uint8_t _buflen;                          /* length in number of bytes of received srxl dataframe in buffer  */
-    uint32_t _last_data_us;                   /* timespan since last received data in us   */
     uint32_t _last_run_ms;                    // last time the state machine was run
     uint16_t _channels[SRXL2_MAX_CHANNELS] = {0};    /* buffer for extracted RC channel data as pulsewidth in microseconds */
 
@@ -67,6 +65,4 @@ private:
     uint8_t _decode_state_next = STATE_IDLE;      /* State of frame decoding that will be applied when the next byte from dataframe drops in  */
     bool _in_failsafe = false;
     int16_t _new_rssi = -1;
-
-    SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
 };

--- a/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
+++ b/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
@@ -26,6 +26,7 @@ void loop();
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 #include <AP_RCProtocol/AP_RCProtocol.h>
+#include <RC_Channel/RC_Channel.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -38,6 +39,29 @@ void loop();
 #include <errno.h>
 
 static AP_RCProtocol *rcprot;
+
+class RC_Channel_RC : public RC_Channel
+{
+};
+
+class RC_Channels_RC : public RC_Channels
+{
+public:
+    RC_Channel *channel(uint8_t chan) override {
+        return &obj_channels[chan];
+    }
+
+    RC_Channel_RC obj_channels[NUM_RC_CHANNELS];
+private:
+    int8_t flight_mode_channel_number() const override { return -1; };
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_RC
+#define RC_CHANNEL_SUBCLASS RC_Channel_RC
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+RC_Channels_RC _rc;
 
 // change this to the device being tested.
 const char *devicename = "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A10596TP-if00-port0";

--- a/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
+++ b/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
@@ -13,7 +13,16 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-  decode RC input using SITL on command line
+ * decode RC input using SITL on command line
+ *
+ * To use this as an RC protocol decoder for SITL with a real transmitter:
+ *
+ * 1. Compile using Linux - SITL has timing that is too variable
+ * 2. Connect an RX device to an FTDI adapter
+ * 3. Set the FTDI serial port to 115k baud, 8N1
+ * 4. Set the FTDI serial BM options to 1ms latency (very important)
+ * 5. Set the tty using: stty -F <device> raw 115200
+ * 6. Run this sketch providing the serial device name as an argument. RC values will be automatically written to the SITL RC port
  */
 
 #include <AP_HAL/AP_HAL.h>
@@ -25,8 +34,10 @@ void loop();
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
+#include <AP_HAL/utility/Socket.h>
 #include <AP_RCProtocol/AP_RCProtocol.h>
 #include <RC_Channel/RC_Channel.h>
+#include <AP_Math/AP_Math.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -62,12 +73,15 @@ private:
 #include <RC_Channel/RC_Channels_VarInfo.h>
 
 RC_Channels_RC _rc;
+SocketAPM rc_socket{true};
 
 // change this to the device being tested.
 const char *devicename = "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A10596TP-if00-port0";
 const uint32_t baudrate = 115200;
 
 static int fd;
+static uint16_t chan[16];
+static uint8_t nchan = 0;
 
 // setup routine
 void setup()
@@ -106,29 +120,41 @@ void setup()
     }
     tcflush(fd, TCIOFLUSH);
 
-    rcprot = new AP_RCProtocol();
+    rcprot = &AP::RC();
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
     rcprot->init();
+#endif
+    // proxy to SITL's rcin port
+    rc_socket.connect("0.0.0.0", 5501);
 }
 
 //Main loop where the action takes place
 void loop()
 {
-    uint8_t buf[32];
+    uint8_t buf[62]; // lowest USB buffer size is 62 user bytes
+
     ssize_t ret = read(fd, buf, sizeof(buf));
-    if (ret <= 0) {
-        return;
-    }
+
     for (uint8_t i=0; i<ret; i++) {
         rcprot->process_byte(buf[i], 115200);
         if (rcprot->new_input()) {
-            uint8_t nchan = rcprot->num_channels();
+            nchan = MIN(rcprot->num_channels(), 16);
+            rcprot->read(chan, nchan);
             printf("%u: ", nchan);
             for (uint8_t j=0; j<nchan; j++) {
-                uint16_t v = rcprot->read(j);
-                printf("%04u ", v);
+                // normalize data for SITL
+                chan[j] = constrain_int16(chan[j], 1100, 1900);
+                printf("%04u ", chan[j]);
             }
             printf("\n");
+
         }
+    }
+    // SITL expects either 8 or 16 channels, send whether we got data or not
+    if (nchan <= 8) {
+        rc_socket.send(chan, 8 * 2);
+    } else {
+        rc_socket.send(chan, 16 * 2);
     }
 }
 
@@ -139,4 +165,16 @@ void loop() {}
 
 #endif // CONFIG_HAL_BOARD
 
-AP_HAL_MAIN();
+AP_HAL::HAL::FunCallbacks callbacks(setup, loop);
+extern "C" {
+int main(int argc, char* const argv[]);
+int main(int argc, char* const argv[]) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+    if (argc > 1) {
+        devicename = argv[1];
+    }
+#endif
+    hal.run(argc, argv, &callbacks);
+    return 0;
+}
+}

--- a/libraries/AP_RCProtocol/spm_srxl.c
+++ b/libraries/AP_RCProtocol/spm_srxl.c
@@ -1,0 +1,1425 @@
+/*
+MIT License
+
+Copyright (c) 2019 Horizon Hobby, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <string.h>
+#include <stdint.h>
+
+#include "spm_srxl.h"
+
+/// LOCAL TYPES AND CONSTANTS ///
+
+#if(SRXL_CRC_OPTIMIZE_MODE == SRXL_CRC_OPTIMIZE_SPEED)
+const uint16_t srxlCRCTable[] =
+{
+    0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,
+    0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
+    0x1231, 0x0210, 0x3273, 0x2252, 0x52B5, 0x4294, 0x72F7, 0x62D6,
+    0x9339, 0x8318, 0xB37B, 0xA35A, 0xD3BD, 0xC39C, 0xF3FF, 0xE3DE,
+    0x2462, 0x3443, 0x0420, 0x1401, 0x64E6, 0x74C7, 0x44A4, 0x5485,
+    0xA56A, 0xB54B, 0x8528, 0x9509, 0xE5EE, 0xF5CF, 0xC5AC, 0xD58D,
+    0x3653, 0x2672, 0x1611, 0x0630, 0x76D7, 0x66F6, 0x5695, 0x46B4,
+    0xB75B, 0xA77A, 0x9719, 0x8738, 0xF7DF, 0xE7FE, 0xD79D, 0xC7BC,
+
+    0x48C4, 0x58E5, 0x6886, 0x78A7, 0x0840, 0x1861, 0x2802, 0x3823,
+    0xC9CC, 0xD9ED, 0xE98E, 0xF9AF, 0x8948, 0x9969, 0xA90A, 0xB92B,
+    0x5AF5, 0x4AD4, 0x7AB7, 0x6A96, 0x1A71, 0x0A50, 0x3A33, 0x2A12,
+    0xDBFD, 0xCBDC, 0xFBBF, 0xEB9E, 0x9B79, 0x8B58, 0xBB3B, 0xAB1A,
+    0x6CA6, 0x7C87, 0x4CE4, 0x5CC5, 0x2C22, 0x3C03, 0x0C60, 0x1C41,
+    0xEDAE, 0xFD8F, 0xCDEC, 0xDDCD, 0xAD2A, 0xBD0B, 0x8D68, 0x9D49,
+    0x7E97, 0x6EB6, 0x5ED5, 0x4EF4, 0x3E13, 0x2E32, 0x1E51, 0x0E70,
+    0xFF9F, 0xEFBE, 0xDFDD, 0xCFFC, 0xBF1B, 0xAF3A, 0x9F59, 0x8F78,
+
+    0x9188, 0x81A9, 0xB1CA, 0xA1EB, 0xD10C, 0xC12D, 0xF14E, 0xE16F,
+    0x1080, 0x00A1, 0x30C2, 0x20E3, 0x5004, 0x4025, 0x7046, 0x6067,
+    0x83B9, 0x9398, 0xA3FB, 0xB3DA, 0xC33D, 0xD31C, 0xE37F, 0xF35E,
+    0x02B1, 0x1290, 0x22F3, 0x32D2, 0x4235, 0x5214, 0x6277, 0x7256,
+    0xB5EA, 0xA5CB, 0x95A8, 0x8589, 0xF56E, 0xE54F, 0xD52C, 0xC50D,
+    0x34E2, 0x24C3, 0x14A0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+    0xA7DB, 0xB7FA, 0x8799, 0x97B8, 0xE75F, 0xF77E, 0xC71D, 0xD73C,
+    0x26D3, 0x36F2, 0x0691, 0x16B0, 0x6657, 0x7676, 0x4615, 0x5634,
+
+    0xD94C, 0xC96D, 0xF90E, 0xE92F, 0x99C8, 0x89E9, 0xB98A, 0xA9AB,
+    0x5844, 0x4865, 0x7806, 0x6827, 0x18C0, 0x08E1, 0x3882, 0x28A3,
+    0xCB7D, 0xDB5C, 0xEB3F, 0xFB1E, 0x8BF9, 0x9BD8, 0xABBB, 0xBB9A,
+    0x4A75, 0x5A54, 0x6A37, 0x7A16, 0x0AF1, 0x1AD0, 0x2AB3, 0x3A92,
+    0xFD2E, 0xED0F, 0xDD6C, 0xCD4D, 0xBDAA, 0xAD8B, 0x9DE8, 0x8DC9,
+    0x7C26, 0x6C07, 0x5C64, 0x4C45, 0x3CA2, 0x2C83, 0x1CE0, 0x0CC1,
+    0xEF1F, 0xFF3E, 0xCF5D, 0xDF7C, 0xAF9B, 0xBFBA, 0x8FD9, 0x9FF8,
+    0x6E17, 0x7E36, 0x4E55, 0x5E74, 0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
+};
+#endif
+
+#define SRXL_TELEM_SUPPRESS_MAX (100)
+
+/// PUBLIC VARIABLES ///
+
+SrxlChannelData srxlChData = {0, 0, 0, {0}};
+SrxlTelemetryData srxlTelemData = {0};
+SrxlVtxData srxlVtxData = {0, 0, 1, 0, 0, 1};
+
+/// LOCAL VARIABLES ///
+
+SrxlDevice srxlThisDev = {0};
+SrxlBus srxlBus[SRXL_NUM_OF_BUSES];
+bool srxlChDataIsFailsafe = false;
+bool srxlTelemetryPhase = false;
+uint32_t srxlFailsafeChMask = 0;  // Tracks all active channels for use during failsafe transmission
+SrxlBindData srxlBindInfo = {0, 0, 0, 0};
+SrxlReceiverStats srxlRx = {0};
+uint16_t srxlTelemSuppressCount = 0;
+
+#ifdef SRXL_INCLUDE_FWD_PGM_CODE
+SrxlFullID srxlFwdPgmDevice = {0, 0};  // Device that should accept Forward Programming connection by default
+uint8_t srxlFwdPgmBuffer[FWD_PGM_MAX_DATA_SIZE] = {0};
+uint8_t srxlFwdPgmBufferLength = 0;
+#endif
+
+// Include additional header and externs if using STM32 hardware acceleration
+#if(SRXL_CRC_OPTIMIZE_MODE > SRXL_CRC_OPTIMIZE_SIZE)
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#if(SRXL_CRC_OPTIMIZE_MODE == SRXL_CRC_OPTIMIZE_STM_HAL)
+#if(SRXL_STM_TARGET_FAMILY == SRXL_STM_TARGET_F7)
+#include "stm32f7xx_hal.h"
+#else
+#include "stm32f3xx_hal.h"  // Default to F3 if not given
+#endif
+    extern CRC_HandleTypeDef hcrc;
+#else
+#if(SRXL_STM_TARGET_FAMILY == SRXL_STM_TARGET_F7)
+#error "STM32F7 targets not yet supported for register-based STM HW optimization"
+#else
+#include "stm32f30x.h"  // Default to F3 if not given
+#endif
+#endif
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+/// LOCAL HELPER FUNCTIONS ///
+
+// Compute SRXL CRC over packet buffer (assumes length is correctly set)
+static uint16_t srxlCrc16(uint8_t* packet)
+{
+    uint16_t crc = 0;                // Seed with 0
+    uint8_t length = packet[2] - 2;  // Exclude 2 CRC bytes at end of packet from the length
+
+    if(length <= SRXL_MAX_BUFFER_SIZE - 2)
+    {
+#if(SRXL_CRC_OPTIMIZE_MODE == SRXL_CRC_OPTIMIZE_SIZE)
+        // Use bitwise method
+        for(uint8_t i = 0; i < length; ++i)
+        {
+            crc = crc ^ ((uint16_t)packet[i] << 8);
+            for(int b = 0; b < 8; b++)
+            {
+                if(crc & 0x8000)
+                    crc = (crc << 1) ^ 0x1021;
+                else
+                    crc = crc << 1;
+            }
+        }
+#elif(SRXL_CRC_OPTIMIZE_MODE == SRXL_CRC_OPTIMIZE_STM_HW)
+        // Use direct STM32 HW CRC register access
+        uint8_t* pEnd = &packet[length];
+        srxlEnterCriticalSection();
+#ifdef SRXL_SAVE_HW_CRC_CONTEXT
+        uint32 savedPOL = CRC->POL;
+        uint32 savedINIT = CRC->INIT;
+        uint32 savedCR = CRC->CR;
+        uint32 savedDR = CRC->DR;
+#endif
+        CRC->POL = 0x1021;
+        CRC->INIT = 0;
+        CRC->CR = 0x09;  // 16-bit polynomial, no input or output reversal, reset to init of 0
+        while(packet < pEnd)
+            *(uint8_t*)(CRC_BASE) = *(packet++);
+        crc = (uint16_t)CRC->DR;
+#ifdef SRXL_SAVE_HW_CRC_CONTEXT
+        // We have to use this convoluted method to restore things because writing INIT sets DR too
+        CRC->CR = 0;
+        CRC->POL = 0x04C11DB7;
+        CRC->INIT = savedINIT;
+        CRC->DR = savedINIT;
+        CRC->POL = savedDR;
+        CRC->DR = 1;
+        CRC->CR = savedCR;
+        CRC->POL = savedPOL;
+#endif
+        srxlExitCriticalSection();
+#elif(SRXL_CRC_OPTIMIZE_MODE == SRXL_CRC_OPTIMIZE_STM_HAL)
+        // STM32f3/f7 hardware optimization using the STM32Cube libraries in HAL mode requires the following
+        // configuration, set in the STM32CubeMX "Pinout & Configuration" tab under "Computing > CRC":
+        //  Basic Parameters
+        //    Default Polynomial State        = Disable
+        //    CRC Length                      = 16-bit
+        //    CRC Generating Polynomial       = X12+X5+X0
+        //    Default Init Value State        = Disable
+        //    Init Value For CRC Computation  = 0
+        //  Advanced Parameters
+        //    Input Data Inversion Mode       = None
+        //    Output Data Inversion Mode      = Disable
+        //    Input Data Format               = Bytes
+        crc = (uint16_t)HAL_CRC_Calculate(&hcrc, (uint32_t*)packet, length);
+#elif(SRXL_CRC_OPTIMIZE_MODE == SRXL_CRC_EXTERNAL)
+        crc = SRXL_CRC_EXTERNAL(packet, length, crc);
+#else
+        // Default to table-lookup method
+        uint8_t i;
+        for(i = 0; i < length; ++i)
+        {
+            // Get indexed position in lookup table using XOR of current CRC hi byte
+            uint8_t pos = (uint8_t)((crc >> 8) ^ packet[i]);
+            // Shift LSB up and XOR with the resulting lookup table entry
+            crc = (uint16_t)((crc << 8) ^ (uint16_t)(srxlCRCTable[pos]));
+        }
+#endif
+    }
+    return crc;
+}
+
+// Get the receiver entry for the requested bus and device ID
+static inline SrxlRcvrEntry* srxlGetReceiverEntry(uint8_t busIndex, uint8_t deviceID)
+{
+    SrxlRcvrEntry* pRcvr = 0;
+    uint8_t i;
+    for(i = 0; i < srxlRx.rcvrCount; ++i)
+    {
+        if((srxlRx.rcvr[i].busBits & (1u << busIndex)) && (srxlRx.rcvr[i].deviceID == deviceID))
+        {
+            pRcvr = &srxlRx.rcvr[i];
+            break;
+        }
+    }
+    return pRcvr;
+}
+
+// Add a new receiver entry for the given device
+static inline SrxlRcvrEntry* srxlAddReceiverEntry(SrxlBus* pBus, SrxlDevEntry devEntry)
+{
+    // Only allow receivers (or flight controllers in certain circumstances) to be added
+    if(!pBus || devEntry.deviceID < 0x10 || devEntry.deviceID >= 0x40)
+        return 0;
+
+    // If we didn't previously add this receiver, add it now if we have room
+    SrxlRcvrEntry* pRcvr = srxlGetReceiverEntry(pBus->fullID.busIndex, devEntry.deviceID);
+    if(!pRcvr)
+    {
+        if(srxlRx.rcvrCount >= SRXL_MAX_RCVRS)
+            return 0;
+
+        uint8_t i = srxlRx.rcvrCount++;
+        pRcvr = &srxlRx.rcvr[i];
+        pRcvr->deviceID = devEntry.deviceID;
+        pRcvr->busBits = (1u << pBus->fullID.busIndex);
+        pRcvr->info = devEntry.info;
+
+        // If this receiver is full-range, insert into our sorted list after the other full-range telemetry receivers
+        if(pRcvr->info & SRXL_DEVINFO_TELEM_FULL_RANGE)
+        {
+            uint8_t n;
+            for(n = i; n > srxlRx.rcvrSortInsert; --n)
+                srxlRx.rcvrSorted[n] = srxlRx.rcvrSorted[n - 1];
+            srxlRx.rcvrSorted[(srxlRx.rcvrSortInsert)++] = pRcvr;
+        }
+        // Else just tack onto the end
+        else
+        {
+            srxlRx.rcvrSorted[i] = pRcvr;
+        }
+    }
+
+    // If this new receiver is a base receiver that supports telemetry or we haven't set a default active telemetry receiver, set it
+    if(!srxlRx.pTelemRcvr || (pRcvr->deviceID >= 0x20 && pRcvr->deviceID < 0x30 && (pRcvr->info & SRXL_DEVINFO_TELEM_TX_ENABLED)))
+    {
+        srxlRx.pTelemRcvr = pRcvr;
+    }
+
+    return pRcvr;
+}
+
+// Pick the best receiver to send telemetry on
+static inline SrxlRcvrEntry* srxlChooseTelemRcvr(void)
+{
+    // If we only know about one receiver, set it to that
+    if(srxlRx.rcvrCount == 1)
+        return srxlRx.rcvrSorted[0];
+
+    // If we were previously sending telemetry
+    if(srxlRx.pTelemRcvr && srxlRx.pTelemRcvr->channelMask)
+    {
+        // If the current choice is not full-range
+        if((srxlRx.pTelemRcvr->info & SRXL_DEVINFO_TELEM_FULL_RANGE) == 0)
+        {
+            // Then see if there is a full-range choice that received channel data to switch to
+            uint8_t i;
+            for(i = 0; i < srxlRx.rcvrSortInsert; ++i)
+            {
+                if(srxlRx.rcvrSorted[i]->channelMask)
+                    return srxlRx.rcvrSorted[i];
+            }
+        }
+
+        // Else keep using the current receiver
+        return srxlRx.pTelemRcvr;
+    }
+    // Else just pick the first one that got channel data this past frame
+    else
+    {
+        uint8_t i;
+        for(i = 0; i < srxlRx.rcvrCount; ++i)
+        {
+            if(srxlRx.rcvrSorted[i]->channelMask)
+                return srxlRx.rcvrSorted[i];
+        }
+    }
+
+    return 0;
+}
+
+// Return pointer to device entry matching the given ID, or NULL if not found
+SrxlDevEntry* srxlGetDeviceEntry(SrxlBus* pBus, uint8_t deviceID)
+{
+    if(pBus)
+    {
+        uint8_t i;
+        for(i = 0; i < pBus->rxDevCount; ++i)
+        {
+            if(pBus->rxDev[i].deviceID == deviceID)
+                return &(pBus->rxDev[i]);
+        }
+    }
+    return 0;
+}
+
+// Add an entry to our list of devices found on the SRXL bus (or update an entry if it already exists)
+SrxlDevEntry* srxlAddDeviceEntry(SrxlBus* pBus, SrxlDevEntry devEntry)
+{
+    // Don't allow broadcast or unknown device types to be added
+    if(!pBus || devEntry.deviceID < 0x10 || devEntry.deviceID > 0xEF)
+        return 0;
+
+    // Limit device priority
+    if(devEntry.priority > 100)
+        devEntry.priority = 100;
+
+    // Update device entry if it already exists
+    SrxlDevEntry* retVal = srxlGetDeviceEntry(pBus, devEntry.deviceID);
+    if(retVal)
+    {
+        pBus->rxDevPrioritySum -= retVal->priority;
+        *retVal = devEntry;
+        pBus->rxDevPrioritySum += retVal->priority;
+    }
+    // Else add to the list if we have room
+    else if(pBus->rxDevCount < SRXL_MAX_DEVICES)
+    {
+        retVal = &(pBus->rxDev[pBus->rxDevCount++]);
+        *retVal = devEntry;
+        pBus->rxDevPrioritySum += retVal->priority;
+
+#ifdef SRXL_INCLUDE_FWD_PGM_CODE
+        // If the new device supports Forward Programming and is a base receiver or flight controller, choose as the default
+        if(devEntry.info & SRXL_DEVINFO_FWD_PROG_SUPPORT)
+        {
+            uint8_t devType = devEntry.deviceID >> 4;
+            if(devType > (srxlFwdPgmDevice.deviceID >> 4) && devType < SrxlDevType_ESC)
+            {
+                srxlFwdPgmDevice.deviceID = devEntry.deviceID;
+                srxlFwdPgmDevice.busIndex = pBus->fullID.busIndex;
+            }
+        }
+#endif
+
+        // If the new device is a receiver, add to our receiver list
+        if(retVal->deviceID < 0x30)
+        {
+            srxlAddReceiverEntry(pBus, *retVal);
+        }
+    }
+
+    return retVal;
+}
+
+/// PUBLIC FUNCTIONS ///
+
+/**
+    @brief  Initialize common SRXL info for this device
+
+    @param  deviceID:   SRXL Device ID (see section 7.1.1 of SRXL2 Spec)
+    @param  priority:   Requested telemetry priority (1-100; typical is 10 per unique message type)
+    @param  info:       Device info bits (see SRXL_DEVINFO_XXX bits in spm_srxl.h)
+    @param  uid:        Unique 32-bit id to avoid device ID collision during handshake
+    @return bool:       True if device info was successfully initialized
+*/
+bool srxlInitDevice(uint8_t deviceID, uint8_t priority, uint8_t info, uint32_t uid)
+{
+    if(deviceID < 0x10 || deviceID > 0xEF)
+        return false;
+
+    srxlThisDev.devEntry.deviceID = deviceID;
+    srxlThisDev.devEntry.info = info;
+    srxlThisDev.devEntry.priority = priority;
+    srxlThisDev.devEntry.rfu = 0;
+    srxlThisDev.uid = uid;
+    srxlThisDev.vtxProxy = false;
+
+#ifdef SRXL_INCLUDE_MASTER_CODE
+    // If this device is a receiver, add to our receiver info
+    if(deviceID < 0x30)
+    {
+        srxlInitReceiver(deviceID, info);
+    }
+#endif
+
+#ifdef SRXL_INCLUDE_FWD_PGM_CODE
+    // If this device is a receiver or flight controller that supports Forward Programming, set as default
+    if((info & SRXL_DEVINFO_FWD_PROG_SUPPORT) && deviceID < 0x40)
+    {
+        srxlFwdPgmDevice.deviceID = deviceID;
+        srxlFwdPgmDevice.busIndex = 0;
+    }
+#endif
+
+#if(SRXL_CRC_OPTIMIZE_MODE == SRXL_CRC_OPTIMIZE_STM_HW)
+    // Enable the peripheral clock for the HW CRC engine
+    RCC->AHBENR |= RCC_AHBENR_CRCEN;
+#endif
+
+    return true;
+}
+
+/**
+    @brief  Initialize bus settings for the given SRXL bus
+
+    @param  busIndex:       Index into srxlBus array of bus entries
+    @param  uart:           Number to identify UART to which this SRXL bus should be connected
+    @param  baudSupported:  0 = 115200 baud, 1 = 400000 baud
+    @return bool:           True if SRXL bus was successfully initialized
+*/
+bool srxlInitBus(uint8_t busIndex, void* uart, uint8_t baudSupported)
+{
+    if(busIndex >= SRXL_NUM_OF_BUSES || !srxlThisDev.devEntry.deviceID)
+        return false;
+
+    SrxlBus* pBus = &srxlBus[busIndex];
+    pBus->state = SrxlState_ListenOnStartup;
+    pBus->fullID.deviceID = srxlThisDev.devEntry.deviceID;
+    pBus->fullID.busIndex = busIndex;
+    pBus->rxDevCount = 0;
+    pBus->rxDevPrioritySum = 0;
+    pBus->requestID = (srxlThisDev.devEntry.deviceID == 0x10) ? 0x11 : 0;
+    pBus->baudSupported = baudSupported;
+    pBus->baudRate = SRXL_BAUD_115200;
+    pBus->frameErrCount = 0;
+    pBus->uart = uart;
+    // Default remote receiver is automatically master -- everyone else figures it out during handshake
+    pBus->master = (srxlThisDev.devEntry.deviceID == 0x10);
+    pBus->pMasterRcvr = (srxlThisDev.devEntry.deviceID == 0x10) ? &srxlRx.rcvr[0] : 0;
+    pBus->initialized = true;
+
+    return true;
+}
+
+/**
+    @brief  See if this device is the bus master on the given bus
+
+    @param  busIndex:   Index into srxlBus array for the desired SRXL bus
+    @return bool:       True if this device is the bus master on the given SRXL bus
+*/
+bool srxlIsBusMaster(uint8_t busIndex)
+{
+    return (busIndex < SRXL_NUM_OF_BUSES && srxlBus[busIndex].master);
+}
+
+/**
+    @brief  Get the current SRXL state machine timeout count for the given bus
+
+    @param  busIndex:   Index into srxlBus array for the desired SRXL bus
+    @return uint16_t:    Timeout count in ms for the given SRXL bus
+*/
+uint16_t srxlGetTimeoutCount_ms(uint8_t busIndex)
+{
+    return (busIndex < SRXL_NUM_OF_BUSES) ? srxlBus[busIndex].timeoutCount_ms : 0;
+}
+
+/**
+    @brief  Get the Device ID of this device on the given bus
+
+    @param  busIndex:   Index into srxlBus array for the desired SRXL bus
+    @return uint8_t:    Device ID of this device on the given SRXL bus
+*/
+uint8_t srxlGetDeviceID(uint8_t busIndex)
+{
+    return (busIndex < SRXL_NUM_OF_BUSES) ? srxlBus[busIndex].fullID.deviceID : 0;
+}
+
+/**
+    @brief  Internal send function called by srxlRun() -- do not call in user code
+
+    @param  pBus:       Pointer to SRXL bus entry for the desired SRXL bus
+    @param  srxlCmd:    Specific type of packet to send
+    @param  replyID:    Device ID of the device this Send command is targeting
+*/
+void srxlSend(SrxlBus* pBus, SRXL_CMD srxlCmd, uint8_t replyID)
+{
+    if(!pBus || !pBus->initialized)
+        return;
+
+    memset(pBus->srxlOut.raw, 0, SRXL_MAX_BUFFER_SIZE);
+    pBus->srxlOut.header.srxlID = SPEKTRUM_SRXL_ID;
+
+    // VTX Data
+    if(srxlCmd == SRXL_CMD_VTX)
+    {
+        pBus->srxlOut.header.packetType = SRXL_CTRL_ID;
+        pBus->srxlOut.header.length = SRXL_CTRL_BASE_LENGTH + sizeof(SrxlVtxData);
+        pBus->srxlOut.control.payload.cmd = SRXL_CTRL_CMD_VTX;
+        pBus->srxlOut.control.payload.replyID = replyID;
+        pBus->srxlOut.control.payload.vtxData = srxlVtxData;
+    }
+#ifdef SRXL_INCLUDE_MASTER_CODE
+    // Channel Data
+    else if(srxlCmd == SRXL_CMD_CHANNEL || srxlCmd == SRXL_CMD_CHANNEL_FS)
+    {
+        pBus->srxlOut.header.packetType = SRXL_CTRL_ID;
+        uint32_t channelMask;
+        if(srxlCmd == SRXL_CMD_CHANNEL)
+        {
+            pBus->srxlOut.control.payload.cmd = SRXL_CTRL_CMD_CHANNEL;
+            pBus->srxlOut.control.payload.replyID = replyID;
+
+            channelMask = srxlChData.mask;
+        }
+        else // == SRXL_CMD_CHANNEL_FS
+        {
+            // In failsafe mode, we dont want a telemetry reply
+            pBus->srxlOut.control.payload.cmd = SRXL_CTRL_CMD_CHANNEL_FS;
+            pBus->srxlOut.control.payload.replyID = 0;
+
+            channelMask = srxlFailsafeChMask;
+        }
+
+        // Set signal quality info (only a bus master sends this, so assume srxlChData contains the latest values)
+        pBus->srxlOut.control.payload.channelData.rssi = srxlChData.rssi;
+#ifdef SRXL_IS_HUB
+        pBus->srxlOut.control.payload.channelData.frameLosses = srxlRx.frameLosses;
+#else
+        pBus->srxlOut.control.payload.channelData.frameLosses = srxlRx.rcvr[0].fades;
+#endif
+
+        uint8_t channelIndex = 0;
+        uint32_t channelMaskBit = 1;
+        for(uint8_t i = 0; i < 32; ++i, channelMaskBit <<= 1)
+        {
+            if(channelMask & channelMaskBit)
+            {
+                pBus->srxlOut.control.payload.channelData.values[channelIndex++] = srxlChData.values[i];
+            }
+        }
+
+        // Set bits in packet for channels we populated, and clear those mask bits if it was part of a normal channel data command
+        pBus->srxlOut.control.payload.channelData.mask = channelMask;
+        if(srxlCmd == SRXL_CMD_CHANNEL)
+            srxlChData.mask &= ~channelMask;
+
+        pBus->srxlOut.header.length = SRXL_CTRL_BASE_LENGTH + 7 + (2 * channelIndex);
+    }
+#ifdef SRXL_INCLUDE_FWD_PGM_CODE
+    // Forward Programming Pass-thru
+    else if(srxlCmd == SRXL_CMD_FWDPGM)
+    {
+        pBus->srxlOut.header.packetType = SRXL_CTRL_ID;
+        pBus->srxlOut.header.length = SRXL_CTRL_BASE_LENGTH + 3 + srxlFwdPgmBufferLength;
+        pBus->srxlOut.control.payload.cmd = SRXL_CTRL_CMD_FWDPGM;
+        pBus->srxlOut.control.payload.replyID = replyID;
+        memcpy(pBus->srxlOut.control.payload.fpData.data, srxlFwdPgmBuffer, srxlFwdPgmBufferLength);
+    }
+#endif  // SRXL_INCLUDE_FWD_PGM_CODE
+#endif  // SRXL_INCLUDE_MASTER_CODE
+    // RSSI Data
+    else if(srxlCmd == SRXL_CMD_RSSI)
+    {
+        pBus->srxlOut.header.packetType = SRXL_RSSI_ID;
+        pBus->srxlOut.header.length = sizeof(SrxlRssiPacket);
+        pBus->srxlOut.rssi.request = SRXL_RSSI_REQ_REQUEST;  // TODO: Needs to handle both directions!
+        pBus->srxlOut.rssi.antennaA = 0;                     // TODO: Fill in actual data later
+        pBus->srxlOut.rssi.antennaB = 0;
+        pBus->srxlOut.rssi.antennaC = 0;
+        pBus->srxlOut.rssi.antennaD = 0;
+    }
+    else if(srxlCmd == SRXL_CMD_HANDSHAKE)
+    {
+        pBus->srxlOut.header.packetType = SRXL_HANDSHAKE_ID;
+        pBus->srxlOut.header.length = sizeof(SrxlHandshakePacket);
+        pBus->srxlOut.handshake.payload.srcDevID = srxlThisDev.devEntry.deviceID;
+        pBus->srxlOut.handshake.payload.destDevID = replyID;
+        pBus->srxlOut.handshake.payload.priority = srxlThisDev.devEntry.priority;
+        pBus->srxlOut.handshake.payload.baudSupported = pBus->baudSupported;
+        pBus->srxlOut.handshake.payload.info = srxlThisDev.devEntry.info;
+        pBus->srxlOut.handshake.payload.uid = srxlThisDev.uid;
+    }
+    else if(srxlCmd == SRXL_CMD_TELEMETRY)
+    {
+        srxlFillTelemetry(&pBus->srxlOut.telemetry.payload);
+        pBus->srxlOut.header.packetType = SRXL_TELEM_ID;
+        pBus->srxlOut.header.length = sizeof(SrxlTelemetryPacket);
+        // If we successfully received a handshake from the bus master
+        if(pBus->pMasterRcvr)
+        {
+            // If we know that a device on this bus should send it, then target that device
+            if(srxlRx.pTelemRcvr && (srxlRx.pTelemRcvr->busBits & (1u << pBus->fullID.busIndex)))
+                pBus->srxlOut.telemetry.destDevID = srxlRx.pTelemRcvr->deviceID;
+            else
+                pBus->srxlOut.telemetry.destDevID = 0;
+        }
+        else
+        {
+            // Send 0xFF to tell bus master to re-send the handshake so we know where to direct telemetry in the future
+            pBus->srxlOut.telemetry.destDevID = 0xFF;
+        }
+
+#ifdef SRXL_INCLUDE_MASTER_CODE
+        if(srxlRx.pTelemRcvr && (pBus->srxlOut.telemetry.destDevID == srxlRx.pTelemRcvr->deviceID))
+        {
+            // Don't mark telemetry as having been sent if we are sending it ourself over RF
+            if(pBus->srxlOut.telemetry.destDevID != srxlThisDev.pRcvr->deviceID)
+            {
+                srxlTelemetrySent();
+                // Clear telemetry buffer after sending so we don't repeatedly display old data
+//                srxlTelemData.sensorID = srxlTelemData.secondaryID = 0;
+            }
+        }
+#endif
+    }
+    else if(srxlCmd == SRXL_CMD_ENTER_BIND)
+    {
+        pBus->srxlOut.header.packetType = SRXL_BIND_ID;
+        pBus->srxlOut.header.length = sizeof(SrxlBindPacket);
+        pBus->srxlOut.bind.request = SRXL_BIND_REQ_ENTER;
+        pBus->srxlOut.bind.deviceID = replyID;
+        pBus->srxlOut.bind.data.type = DSMX_11MS;
+        pBus->srxlOut.bind.data.options = (replyID != 0xFF) ? SRXL_BIND_OPT_TELEM_TX_ENABLE | SRXL_BIND_OPT_BIND_TX_ENABLE : 0;
+        pBus->srxlOut.bind.data.guid = 0;
+        pBus->srxlOut.bind.data.uid = 0;
+    }
+    else if(srxlCmd == SRXL_CMD_REQ_BIND)
+    {
+        pBus->srxlOut.header.packetType = SRXL_BIND_ID;
+        pBus->srxlOut.header.length = sizeof(SrxlBindPacket);
+        pBus->srxlOut.bind.request = SRXL_BIND_REQ_STATUS;
+        pBus->srxlOut.bind.deviceID = replyID;
+        memset(&(pBus->srxlOut.bind.data), 0, sizeof(SrxlBindData));
+    }
+    else if(srxlCmd == SRXL_CMD_SET_BIND)
+    {
+        pBus->srxlOut.header.packetType = SRXL_BIND_ID;
+        pBus->srxlOut.header.length = sizeof(SrxlBindPacket);
+        pBus->srxlOut.bind.request = SRXL_BIND_REQ_SET_BIND;
+        pBus->srxlOut.bind.deviceID = replyID;
+        pBus->srxlOut.bind.data = srxlBindInfo;
+    }
+    else if(srxlCmd == SRXL_CMD_BIND_INFO)
+    {
+        pBus->srxlOut.header.packetType = SRXL_BIND_ID;
+        pBus->srxlOut.header.length = sizeof(SrxlBindPacket);
+        pBus->srxlOut.bind.request = SRXL_BIND_REQ_BOUND_DATA;
+        pBus->srxlOut.bind.deviceID = replyID;
+        pBus->srxlOut.bind.data = srxlBindInfo;
+    }
+
+    // Compute CRC over entire SRXL packet (excluding the 2 CRC bytes at the end)
+    uint16_t crc = srxlCrc16(pBus->srxlOut.raw);
+
+    // Add CRC to packet in big-endian byte order
+    pBus->srxlOut.raw[pBus->srxlOut.header.length - 2] = (crc >> 8) & 0xFF;
+    pBus->srxlOut.raw[pBus->srxlOut.header.length - 1] = crc & 0xFF;
+
+    // Send the packet out over the assigned UART
+    srxlSendOnUart(pBus->uart, pBus->srxlOut.raw, pBus->srxlOut.header.length);
+}
+
+/**
+    @brief  Parse an SRXL packet received on the given SRXL bus UART
+
+    @param  busIndex:   Index of SRXL bus state information entry in the srxlBus array
+    @param  packet:     Pointer to received packet data
+    @param  length:     Length in bytes of received packet data
+    @return bool:       True if a valid packet was received, else false
+*/
+bool srxlParsePacket(uint8_t busIndex, uint8_t* packet, uint8_t length)
+{
+    // Validate parameters
+    if(busIndex >= SRXL_NUM_OF_BUSES || !packet || length < 5 || length > SRXL_MAX_BUFFER_SIZE)
+        return false;
+
+    // Validate SRXL ID and length
+    if(packet[0] != SPEKTRUM_SRXL_ID || packet[2] != length)
+        return false;
+
+    // Validate checksum
+    uint16_t crc = srxlCrc16(packet);
+    if((((uint16_t)packet[length - 2] << 8) | packet[length - 1]) != crc)
+        return false;
+
+    // Copy packet into our unioned buffer to avoid "strict aliasing" violations
+    SrxlBus* pBus = &srxlBus[busIndex];
+    SrxlPacket* pRx = &(pBus->srxlIn);
+    memcpy(pRx, packet, length);
+
+    // Handle restart with ongoing communications -- bump to run state
+    pBus->timeoutCount_ms = 0;  // TODO: Should we clear this even if packet isn't valid?
+    if(pBus->state < SrxlState_Running && pRx->header.packetType != SRXL_HANDSHAKE_ID)
+        pBus->state = SrxlState_Running;
+
+    // Parse the specific data
+    switch(pRx->header.packetType)
+    {
+    case SRXL_CTRL_ID:  // 0xCD
+    {
+        SrxlControlData* pCtrlData = &(pRx->control.payload);
+
+        // Validate command
+        if(pCtrlData->cmd > SRXL_CTRL_CMD_FWDPGM)
+            break;
+
+        // VTX
+        if(pCtrlData->cmd == SRXL_CTRL_CMD_VTX)
+        {
+            if(srxlSetVtxData(&pCtrlData->vtxData))
+                srxlOnVtx(&srxlVtxData);
+            if(pCtrlData->replyID == pBus->fullID.deviceID || pCtrlData->replyID == 0xFF || srxlThisDev.vtxProxy)
+            {
+                // TODO: Should we ack this somehow
+            }
+        }
+#ifdef SRXL_INCLUDE_FWD_PGM_CODE
+        // Forward Programming
+        else if(pCtrlData->cmd == SRXL_CTRL_CMD_FWDPGM)
+        {
+            if(pCtrlData->replyID == pBus->fullID.deviceID)
+            {
+                memcpy(srxlFwdPgmBuffer, pCtrlData->fpData.data, pRx->header.length - 3 - SRXL_CTRL_BASE_LENGTH);
+                srxlFwdPgmBufferLength = length;
+                if(pCtrlData->replyID == srxlFwdPgmDevice.deviceID)
+                {
+                    // Handle Forward Programming command locally
+                    srxlOnFwdPgm(srxlFwdPgmBuffer, srxlFwdPgmBufferLength);
+                }
+                else if(srxlFwdPgmDevice.deviceID && srxlBus[srxlFwdPgmDevice.busIndex].master)
+                {
+                    // Pass it on through to the next target
+                    srxlBus[srxlFwdPgmDevice.busIndex].txFlags.sendFwdPgmData = 1;
+                }
+            }
+        }
+#endif
+        // Channel Data or Failsafe Data
+        else
+        {
+            bool isFailsafe = (pCtrlData->cmd == SRXL_CTRL_CMD_CHANNEL_FS);
+            srxlChData.rssi = pCtrlData->channelData.rssi;
+            srxlChData.frameLosses = pCtrlData->channelData.frameLosses;
+            if(pBus->pMasterRcvr)
+            {
+                if(pCtrlData->channelData.rssi < 0)
+                {
+                    pBus->pMasterRcvr->rssi_dBm = pCtrlData->channelData.rssi;
+                    pBus->pMasterRcvr->rssiRcvd |= RSSI_RCVD_DBM;
+                }
+                else
+                {
+                    pBus->pMasterRcvr->rssi_Pct = pCtrlData->channelData.rssi;
+                    pBus->pMasterRcvr->rssiRcvd |= RSSI_RCVD_PCT;
+                }
+                // If the receiver is sending alternating dBm/%, then use that as phase
+                if(pBus->pMasterRcvr->rssiRcvd == RSSI_RCVD_BOTH)
+                {
+                    srxlTelemetryPhase = pCtrlData->channelData.rssi >= 0;
+                }
+                pBus->pMasterRcvr->fades = pCtrlData->channelData.frameLosses;
+                pBus->pMasterRcvr->channelMask = isFailsafe ? 0 : pCtrlData->channelData.mask;
+                srxlRx.rxBusBits |= pBus->pMasterRcvr->busBits;
+            }
+
+            // Only save received channel values to srxlChData if it's normal channel data or we're in a hold condition
+            if(!isFailsafe || !srxlRx.lossCountdown)
+            {
+                uint8_t channelIndex = 0;
+                uint32_t channelMaskBit = 1;
+                uint8_t i;
+                for(i = 0; i < 32 && channelMaskBit <= pCtrlData->channelData.mask; ++i, channelMaskBit <<= 1)
+                {
+                    if(pCtrlData->channelData.mask & channelMaskBit)
+                    {
+                        srxlChData.values[i] = pCtrlData->channelData.values[channelIndex++];
+                        srxlChData.mask |= channelMaskBit;
+                    }
+                }
+            }
+
+            srxlChDataIsFailsafe = isFailsafe;  // TODO: Can we still assume this???
+            srxlReceivedChannelData(&(pCtrlData->channelData), isFailsafe);
+
+            // Figure out what type of reply packet to send, if any
+            if(pCtrlData->replyID == 0)
+            {
+                if(pBus->txFlags.enterBind)
+                {
+                    pBus->state = SrxlState_SendEnterBind;
+                    pBus->txFlags.enterBind = 0;
+                }
+                else if(pBus->txFlags.setBindInfo)
+                {
+                    if(srxlRx.pBindRcvr)  // TODO: Double-check this logic
+                    {
+                        pBus->requestID = srxlRx.pBindRcvr->deviceID;
+                        pBus->state = SrxlState_SendSetBindInfo;
+                    }
+                    pBus->txFlags.setBindInfo = 0;
+                }
+                else if(pBus->txFlags.broadcastBindInfo)
+                {
+                    pBus->requestID = 0xFF;
+                    pBus->state = SrxlState_SendSetBindInfo;
+                    pBus->txFlags.broadcastBindInfo = 0;
+                }
+            }
+            else if(pCtrlData->replyID == pBus->fullID.deviceID)
+            {
+                pBus->state = SrxlState_SendTelemetry;
+            }
+        }
+        break;
+    }
+    case SRXL_HANDSHAKE_ID:  // 0x21
+    {
+        if(length < sizeof(SrxlHandshakePacket))
+            return false;
+
+        // If this is an unprompted handshake (dest == 0) from a higher device ID, then we're the master
+        SrxlHandshakeData* pHandshake = &(pRx->handshake.payload);
+        if((pHandshake->destDevID == 0) && (pHandshake->srcDevID > pBus->fullID.deviceID))
+        {
+            // Send a reply immediately to get the slave to shut up
+            pBus->state = SrxlState_SendHandshake;
+            pBus->requestID = pHandshake->srcDevID;
+            pBus->baudSupported = SRXL_SUPPORTED_BAUD_RATES;
+            srxlRun(busIndex, 0);
+            pBus->requestID = pBus->fullID.deviceID;
+            pBus->state = SrxlState_SendHandshake;
+            pBus->master = true;
+            pBus->pMasterRcvr = &srxlRx.rcvr[0];
+        }
+
+        // Add this device to our list of discovered devices
+        SrxlDevEntry newDev = {.deviceID = pHandshake->srcDevID, .priority = pHandshake->priority, .info = pHandshake->info};
+        srxlAddDeviceEntry(pBus, newDev);
+
+        // Bus master needs to track responses and poll next device
+        if(pBus->master)
+        {
+            // Keep track of baud rates supported
+            pBus->baudSupported &= pHandshake->baudSupported;
+
+            // Make sure the state machine is set to poll -- this will eventually reach broadcast address (0xFF)
+            pBus->state = SrxlState_SendHandshake;
+        }
+        // Broadcast handshake sets the agreed upon baud rate for this bus
+        else if(pHandshake->destDevID == 0xFF)
+        {
+            // Get bus master receiver entry (if it's a flight controller, add it now as a receiver on this bus)
+            if(newDev.deviceID >= 0x30 && newDev.deviceID < 0x40)
+            {
+                pBus->pMasterRcvr = srxlAddReceiverEntry(pBus, newDev);
+            }
+            else
+            {
+                pBus->pMasterRcvr = srxlGetReceiverEntry(busIndex, newDev.deviceID);
+            }
+
+            // Set baud rate and advance to run state
+            pBus->baudRate = pHandshake->baudSupported;
+            if(pBus->baudRate & SRXL_BAUD_400000)
+            {
+                srxlChangeBaudRate(pBus->uart, 400000);  // Only alternate rate supported for now...
+            }
+            pBus->state = SrxlState_Running;
+        }
+        // Normal Handshake destined for this device should be replied to -- else ignore
+        else
+        {
+            if(pHandshake->destDevID == pBus->fullID.deviceID && pBus->state != SrxlState_SendHandshake)
+            {
+                pBus->requestID = pHandshake->srcDevID;
+                pBus->state = SrxlState_SendHandshake;
+            }
+            else
+            {
+                pBus->state = SrxlState_ListenForHandshake;
+            }
+        }
+
+        break;
+    }
+    case SRXL_PARAM_ID:  // 0x50
+    {
+        // TODO: Add later
+        break;
+    }
+    case SRXL_RSSI_ID:  // 0x55
+    {
+        // TODO: Add later
+        break;
+    }
+    case SRXL_BIND_ID:  // 0x41
+    {
+        if(length < sizeof(SrxlBindPacket))
+            return false;
+
+        SrxlBindPacket* pBindInfo = &(pRx->bind);
+
+        // If this is a bound data report
+        if(pBindInfo->request == SRXL_BIND_REQ_BOUND_DATA)
+        {
+            // Call the user-defined callback -- if returns true, bind all other receivers
+            SrxlFullID boundID = {.deviceID = pBindInfo->deviceID, .busIndex = busIndex};
+            if(srxlOnBind(boundID, pBindInfo->data))
+            {
+                // Update the bind info
+                srxlBindInfo.type = pBindInfo->data.type;
+                if(pBindInfo->data.options & SRXL_BIND_OPT_TELEM_TX_ENABLE)
+                {
+                    SrxlRcvrEntry* pNewTelem = srxlGetReceiverEntry(busIndex, pBindInfo->deviceID);
+                    if(pNewTelem || !srxlRx.pTelemRcvr)
+                        srxlRx.pTelemRcvr = pNewTelem;
+                }
+                srxlBindInfo.options = 0;  // Disable telemetry and Discovery reply when setting other receivers
+                srxlBindInfo.guid = pBindInfo->data.guid;
+                srxlBindInfo.uid = pBindInfo->data.uid;
+
+                // Try to set bind info for all other receivers on other buses to match it
+                uint8_t b;
+                for(b = 0; b < SRXL_NUM_OF_BUSES; ++b)
+                {
+                    if(b == busIndex)
+                        continue;
+                    srxlBus[b].txFlags.broadcastBindInfo = 1;
+                }
+            }
+        }
+        // If this bind packet is directed at us
+        else if(pBindInfo->deviceID == pBus->fullID.deviceID || pBindInfo->deviceID == 0xFF)
+        {
+            // Check for Enter Bind Mode (only valid if sent to a specific receiver)
+            if(pBindInfo->request == SRXL_BIND_REQ_ENTER)
+            {
+#ifdef SRXL_INCLUDE_MASTER_CODE
+                srxlBindInfo.type = pBindInfo->data.type;
+                srxlBindInfo.options = pBindInfo->data.options;
+                srxlBindInfo.guid = 0;
+                srxlBindInfo.uid = 0;
+                srxlTryToBind(srxlBindInfo);
+#endif
+            }
+            else if(pBindInfo->request == SRXL_BIND_REQ_STATUS && srxlThisDev.pRcvr)
+            {
+                // TODO: Fill in data if we didn't just bind?
+                pBus->txFlags.reportBindInfo = 1;
+            }
+            // Handle set bind info request
+            else if(pBindInfo->request == SRXL_BIND_REQ_SET_BIND)
+            {
+                srxlBindInfo = pBindInfo->data;
+#ifdef SRXL_INCLUDE_MASTER_CODE
+                if(pBus->fullID.deviceID < 0x30)
+                    srxlTryToBind(srxlBindInfo);
+#endif
+            }
+        }
+
+        break;
+    }
+    case SRXL_TELEM_ID:  // 0x80
+    {
+        if(length < sizeof(SrxlTelemetryPacket))
+            return false;
+
+        // NOTE: This data should be sent by exactly one telemetry device in response to a bus master request,
+        //       so it is safe to update the global pTelemRcvr here even though this is a bus-specific function.
+
+        SrxlTelemetryPacket* pTelem = &(pRx->telemetry);
+        memcpy(&srxlTelemData, &pTelem->payload, sizeof(srxlTelemData));
+        // If the telemetry destination is set to broadcast, that indicates a request to re-handshake
+        if(pBus->master && pTelem->destDevID == 0xFF)
+        {
+            // If the master only found one device, don't poll again -- just tell the requesting device who we are
+            pBus->requestID = pBus->rxDevCount > 1 ? pBus->fullID.deviceID : 0xFF;
+            pBus->state = SrxlState_SendHandshake;
+        }
+        // If the incoming telemetry is destined for us, then we need to figure out who should send it over RF
+        else if(pTelem->destDevID == pBus->fullID.deviceID)
+        {
+            // This needs different logic for hubs versus endpoints
+#ifdef SRXL_IS_HUB
+            if(srxlRx.pTelemRcvr == 0)
+            {
+                srxlRx.pTelemRcvr = srxlChooseTelemRcvr();
+            }
+#else
+            srxlRx.pTelemRcvr = srxlThisDev.pRcvr;
+#endif
+            // Enable this device's telemetry tx based on whether we are the chosen telemetry receiver
+#ifdef SRXL_INCLUDE_MASTER_CODE
+            srxlSetTelemetryTxEnable(srxlRx.pTelemRcvr && (srxlRx.pTelemRcvr == srxlThisDev.pRcvr));
+#endif
+        }
+        // Else turn off our telemetry and that of any receivers we might reply to via our own telemetry
+        else
+        {
+            srxlRx.pTelemRcvr = 0;
+#ifdef SRXL_INCLUDE_MASTER_CODE
+            srxlSetTelemetryTxEnable(false);
+#endif
+        }
+
+        srxlTelemSuppressCount = 0;
+#ifdef SRXL_INCLUDE_MASTER_CODE
+        srxlSuppressInternalTelemetry(&pTelem->payload);
+#endif
+        break;
+    }
+    default:
+    {
+        break;
+    }
+    }
+
+    // Run state machine for slave devices after each received packet
+    if(!pBus->master)
+    {
+        srxlRun(busIndex, 0);
+    }
+
+    return true;
+}
+
+/**
+    @brief  Run the SRXL state machine after each receive or rx timeout
+
+    @param  busIndex:           Index of SRXL bus state information entry in the srxlBus array
+    @param  timeoutDelta_ms:    Number of milliseconds to increment receive timeout if a timeout
+                                occured, or <= 0 to clear timeout count upon packet receive.
+*/
+void srxlRun(uint8_t busIndex, int16_t timeoutDelta_ms)
+{
+    SrxlBus* pBus = &srxlBus[busIndex];
+    if(busIndex >= SRXL_NUM_OF_BUSES || !pBus->initialized || pBus->state == SrxlState_Disabled)
+        return;
+
+    // Check receive timeout and advance state if needed
+    if(timeoutDelta_ms > 0)
+    {
+        pBus->timeoutCount_ms += timeoutDelta_ms;
+        if(pBus->timeoutCount_ms >= 30000)
+            pBus->timeoutCount_ms = 30000;
+
+        if(pBus->timeoutCount_ms >= 50)
+        {
+            // After startup delay of 50ms, switch to handshake send or listen based on device unit ID
+            if(pBus->state == SrxlState_ListenOnStartup)
+            {
+                pBus->state = (pBus->fullID.deviceID & 0x0F) ? SrxlState_ListenForHandshake : SrxlState_SendHandshake;
+            }
+            // Reset non-master device back to startup conditions if 50ms elapses with no communications
+            else if(!pBus->master && pBus->state >= SrxlState_Running)
+            {
+                srxlChangeBaudRate(pBus->uart, 115200);
+                pBus->baudRate = SRXL_BAUD_115200;
+                pBus->timeoutCount_ms = 0;
+                pBus->requestID = 0;  // Change back to 0 to indicate unprompted handshake from slave device
+                if(pBus->pMasterRcvr)
+                {
+                    pBus->pMasterRcvr->channelMask = 0;
+                    pBus->pMasterRcvr->fades = 0xFFFF;
+                    pBus->pMasterRcvr->rssi_Pct = 0;
+                    pBus->pMasterRcvr->rssi_dBm = -1;
+                }
+                pBus->state = SrxlState_ListenOnStartup;
+            }
+        }
+    }
+    else
+    {
+        pBus->timeoutCount_ms = 0;
+    }
+
+    if(!pBus->master)
+    {
+        // Non-master actions for the given state
+        switch(pBus->state)
+        {
+        case SrxlState_SendHandshake:
+        {
+            srxlSend(pBus, SRXL_CMD_HANDSHAKE, pBus->requestID);
+            break;
+        }
+        case SrxlState_SendTelemetry:
+        {
+            srxlSend(pBus, SRXL_CMD_TELEMETRY, pBus->requestID);
+            pBus->state = SrxlState_Running;
+            break;
+        }
+        case SrxlState_SendVTX:
+        {
+            srxlSend(pBus, SRXL_CMD_VTX, pBus->requestID);
+            pBus->state = SrxlState_Running;
+            break;
+        }
+        case SrxlState_SendEnterBind:
+        {
+            if(srxlRx.pBindRcvr && (srxlRx.pBindRcvr != srxlThisDev.pRcvr))
+            {
+                srxlSend(pBus, SRXL_CMD_ENTER_BIND, srxlRx.pBindRcvr->deviceID);
+            }
+            else
+            {
+                srxlBindInfo.options = 0;
+                srxlSend(pBus, SRXL_CMD_ENTER_BIND, 0xFF);
+            }
+            pBus->state = SrxlState_Running;
+            break;
+        }
+        case SrxlState_SendSetBindInfo:
+        {
+            srxlSend(pBus, SRXL_CMD_SET_BIND, pBus->requestID);
+            pBus->state = SrxlState_Running;
+            break;
+        }
+        case SrxlState_SendBoundDataReport:
+        {
+            srxlSend(pBus, SRXL_CMD_BIND_INFO, pBus->fullID.deviceID);
+            pBus->state = SrxlState_Running;
+            break;
+        }
+        case SrxlState_Running:
+        default:
+        {
+            return;
+        }
+        }
+    }
+#ifdef SRXL_INCLUDE_MASTER_CODE
+    else
+    {
+        srxlRunMaster(pBus);
+    }
+#endif  // SRXL_INCLUDE_MASTER_CODE
+}
+
+/**
+    @brief  Tell the "best" receiver to enter bind mode, either locally or via SRXL command
+
+    @param  bindType: One of the possible bind status types to use when binding -- NOTE: The transmitter may ignore this
+    @param  broadcast: True if this is a local request that should tell all connected receivers to enter bind
+    @return bool: True if a receiver was told to enter bind mode; else false
+*/
+bool srxlEnterBind(uint8_t bindType, bool broadcast)
+{
+    srxlRx.pBindRcvr = 0;
+    if(broadcast && srxlThisDev.pRcvr)
+    {
+        srxlRx.pBindRcvr = srxlThisDev.pRcvr;
+    }
+    else if(srxlRx.pTelemRcvr)
+    {
+        srxlRx.pBindRcvr = srxlRx.pTelemRcvr;
+    }
+    else if(srxlRx.rcvrCount > 0 && srxlRx.rcvrSorted[0]->deviceID < 0x30)
+    {
+        srxlRx.pBindRcvr = srxlRx.rcvrSorted[0];
+    }
+
+    if(srxlRx.pBindRcvr)
+    {
+#ifdef SRXL_INCLUDE_MASTER_CODE
+        // Local bind
+        if(srxlRx.pBindRcvr == srxlThisDev.pRcvr)
+        {
+            srxlBindInfo.type = bindType;
+            srxlBindInfo.options = SRXL_BIND_OPT_BIND_TX_ENABLE;
+            srxlBindInfo.guid = 0;
+            srxlBindInfo.uid = 0;
+            if(srxlRx.pBindRcvr == srxlRx.pTelemRcvr)
+                srxlBindInfo.options |= SRXL_BIND_OPT_TELEM_TX_ENABLE;
+            srxlTryToBind(srxlBindInfo);
+            if(broadcast)
+            {
+                uint8_t b;
+                for(b = 0; b < SRXL_NUM_OF_BUSES; ++b)
+                {
+                    srxlBus[b].txFlags.enterBind = 1;
+                }
+            }
+            return true;
+        }
+#endif // SRXL_INCLUDE_MASTER_CODE
+
+        // Remote bind
+        uint8_t i;
+        for(i = 0; i < SRXL_NUM_OF_BUSES; ++i)
+        {
+            if((1u << i) & srxlRx.pBindRcvr->busBits)
+            {
+                srxlBus[i].txFlags.enterBind = 1;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+    @brief  Public function to set bind info for the system, either locally or via SRXL commands
+
+    @param  bindType: Type of bind requested for this receiver or all receivers
+    @param  guid: Transmitter GUID to bind the receiver to
+    @param  uid: Unique ID provided by transmitter upon initial bind (can be 0 if unknown)
+    @return bool: True if bind info was successfully set for the destination device; else false
+*/
+bool srxlSetBindInfo(uint8_t bindType, uint64_t guid, uint32_t uid)
+{
+    if(guid == 0)
+        return false;
+
+    // Set bind info, with options defaulted to 0
+    srxlBindInfo.type = bindType;
+    srxlBindInfo.options = SRXL_BIND_OPT_US_POWER; // Request US power, with no guarantee it's supported
+    srxlBindInfo.guid = guid;
+    srxlBindInfo.uid = uid ? uid : srxlThisDev.uid;
+
+#ifdef SRXL_INCLUDE_MASTER_CODE
+    // If we are a receiver
+    if(srxlThisDev.pRcvr)
+    {
+        // Bind locally, which will result in no further packets since options == 0
+        srxlTryToBind(srxlBindInfo);
+    }
+#endif
+
+    // Broadcast this bind info on all SRXL buses
+    uint8_t b;
+    for(b = 0; b < SRXL_NUM_OF_BUSES; ++b)
+    {
+        srxlBus[b].txFlags.broadcastBindInfo = 1;
+    }
+
+    return true;
+}
+
+/**
+    @brief  Public function to call from the user UART code when a UART frame error occurs
+
+    @param  busIndex: Index of SRXL bus state information entry in the srxlBus array
+*/
+void srxlOnFrameError(uint8_t busIndex)
+{
+    SrxlBus* pBus = &srxlBus[busIndex];
+    if(busIndex >= SRXL_NUM_OF_BUSES || !pBus->initialized)
+        return;
+
+    ++(pBus->frameErrCount);
+    if(pBus->master)
+    {
+        // TODO: If master (i.e. remote receiver 0x10), cause break condition to force reset?
+        return;
+    }
+
+    if(pBus->state == SrxlState_ListenOnStartup || pBus->state == SrxlState_ListenForHandshake)
+    {
+        // Wait for multiple frame breaks before trying to change baud rate
+        if(pBus->frameErrCount < 3)
+            return;
+
+        // Try the next higher baud rate
+        switch(pBus->baudRate)
+        {
+        case SRXL_BAUD_115200:
+        {
+            if(pBus->baudSupported & SRXL_BAUD_400000)
+            {
+                srxlChangeBaudRate(pBus->uart, 400000);
+                pBus->baudRate = SRXL_BAUD_400000;
+                break;
+            }
+            // else fall thru...
+        }
+        case SRXL_BAUD_400000:
+        default:
+        {
+            // TODO: Cause break condition to force reset of everyone? Or just keep cycling?
+
+            srxlChangeBaudRate(pBus->uart, 115200);
+            pBus->baudRate = SRXL_BAUD_115200;
+            break;
+        }
+        }
+        pBus->frameErrCount = 0;
+    }
+    else
+    {
+        // TODO: Handle frame error during normal comm -- probably caused by collision on bus?
+    }
+}
+
+SrxlFullID srxlGetTelemetryEndpoint(void)
+{
+    SrxlFullID retVal = {0};
+    if(srxlRx.pTelemRcvr)
+    {
+        retVal.deviceID = srxlRx.pTelemRcvr->deviceID;
+        retVal.busIndex = srxlRx.pTelemRcvr->busBits;
+    }
+    return retVal;
+}
+
+bool srxlSetVtxData(SrxlVtxData* pVtxData)
+{
+    if(!pVtxData)
+        return false;
+
+    // Update VTX data, ignoring values marked as unchanged
+    if(pVtxData->band != 0xFF)
+        srxlVtxData.band = pVtxData->band;
+    if(pVtxData->channel != 0xFF)
+        srxlVtxData.channel = pVtxData->channel;
+    if(pVtxData->pit != 0xFF)
+        srxlVtxData.pit = pVtxData->pit;
+    if(pVtxData->power != 0xFF || pVtxData->powerDec != 0xFFFF)
+        srxlVtxData.power = pVtxData->power;
+    if(pVtxData->powerDec != 0xFFFF)
+        srxlVtxData.powerDec = pVtxData->powerDec;
+    if(pVtxData->region != 0xFF)
+        srxlVtxData.region = pVtxData->region;
+
+    uint8_t b;
+    for(b = 0; b < SRXL_NUM_OF_BUSES; ++b)
+    {
+        srxlBus[b].txFlags.sendVtxData = 1;
+    }
+
+    return true;
+}
+
+void srxlSetHoldThreshold(uint8_t countdownReset)
+{
+    srxlRx.lossHoldCount = (countdownReset > 1) ? countdownReset : 45;
+}
+
+void srxlClearCommStats(void)
+{
+    srxlRx.holds = 0;
+    srxlRx.frameLosses = 0;
+    srxlRx.lossCountdown = srxlRx.lossHoldCount + 1;
+}
+
+// Return true on failsafe hold
+bool srxlUpdateCommStats(bool isFade)
+{
+    srxlRx.rxBusBits = 0;
+    if(srxlTelemetryPhase)
+    {
+        srxlRx.bestRssi_dBm = -128;
+        srxlRx.bestRssi_Pct = 0;
+    }
+
+    uint8_t i;
+    for(i = 0; i < srxlRx.rcvrCount; ++i)
+    {
+        if(srxlRx.rcvr[i].channelMask)
+        {
+            srxlRx.lossCountdown = srxlRx.lossHoldCount + 1;
+
+            if((srxlRx.rcvr[i].rssiRcvd & RSSI_RCVD_DBM) && srxlRx.bestRssi_dBm < srxlRx.rcvr[i].rssi_dBm)
+                srxlRx.bestRssi_dBm = srxlRx.rcvr[i].rssi_dBm;
+            if((srxlRx.rcvr[i].rssiRcvd & RSSI_RCVD_PCT) && srxlRx.bestRssi_dBm < srxlRx.rcvr[i].rssi_Pct)
+                srxlRx.bestRssi_Pct = srxlRx.rcvr[i].rssi_Pct;
+        }
+    }
+
+    // Set RSSI based on telemetry phase and type of telemetry received
+    srxlChData.rssi = (srxlTelemetryPhase || srxlChDataIsFailsafe) ? srxlRx.bestRssi_Pct : srxlRx.bestRssi_dBm;
+
+    // Update flight log frame losses and holds
+    if(isFade && srxlRx.lossCountdown)
+    {
+        if(--srxlRx.lossCountdown == 0)
+        {
+            ++srxlRx.holds;
+            srxlRx.frameLosses -= srxlRx.lossHoldCount;
+        }
+        else
+        {
+            ++srxlRx.frameLosses;
+        }
+    }
+
+    static uint8_t telemFadeCount = 0;
+    // If we are allowed to send telemetry by the device downstream (i.e. any slave device)
+    if(srxlRx.pTelemRcvr)
+    {
+        if(srxlRx.pTelemRcvr->channelMask == 0 || (srxlRx.pTelemRcvr->info & SRXL_DEVINFO_TELEM_FULL_RANGE) == 0)
+        {
+            // If our telemetry receiver missed channel data 3 frames in a row, switch
+            if(++telemFadeCount > 3)
+            {
+                srxlRx.pTelemRcvr = srxlChooseTelemRcvr();
+#ifdef SRXL_INCLUDE_MASTER_CODE
+                srxlSetTelemetryTxEnable(srxlRx.pTelemRcvr && (srxlRx.pTelemRcvr == srxlThisDev.pRcvr));
+#endif
+                telemFadeCount = 0;
+            }
+        }
+        else
+        {
+            telemFadeCount = 0;
+        }
+    }
+#ifdef SRXL_INCLUDE_MASTER_CODE
+    // Else check to make sure we're still supposed to suppress telemetry (reset countdown when slave tells us not to send again)
+    else if(++srxlTelemSuppressCount > SRXL_TELEM_SUPPRESS_MAX)
+    {
+        // Enable this device's telemetry tx since we stopped being told not to
+        srxlRx.pTelemRcvr = srxlThisDev.pRcvr;
+        srxlSetTelemetryTxEnable(srxlRx.pTelemRcvr);
+    }
+#endif
+
+    // Return true while we're in hold condition (failsafe)
+    return srxlRx.lossCountdown == 0;
+}

--- a/libraries/AP_RCProtocol/spm_srxl.h
+++ b/libraries/AP_RCProtocol/spm_srxl.h
@@ -1,0 +1,533 @@
+/*
+MIT License
+
+Copyright (c) 2019 Horizon Hobby, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef __SRXL_H__
+#define __SRXL_H__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// Standard C Libraries
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+
+//      7.1 General Overview
+#define SPEKTRUM_SRXL_ID        (0xA6)
+#define SRXL_MAX_BUFFER_SIZE    (80)
+#define SRXL_MAX_DEVICES        (16)
+
+// Supported SRXL device types (upper nibble of device ID)
+typedef enum
+{
+    SrxlDevType_None                = 0,
+    SrxlDevType_RemoteReceiver      = 1,
+    SrxlDevType_Receiver            = 2,
+    SrxlDevType_FlightController    = 3,
+    SrxlDevType_ESC                 = 4,
+    SrxlDevType_SRXLServo1          = 6,
+    SrxlDevType_SRXLServo2          = 7,
+    SrxlDevType_VTX                 = 8,
+    SrxlDevType_Broadcast           = 15
+} SrxlDevType;
+
+// Default device ID list used by master when polling
+static const uint8_t SRXL_DEFAULT_ID_OF_TYPE[16] =
+{
+    [SrxlDevType_None]              = 0x00,
+    [SrxlDevType_RemoteReceiver]    = 0x10,
+    [SrxlDevType_Receiver]          = 0x21,
+    [SrxlDevType_FlightController]  = 0x30,
+    [SrxlDevType_ESC]               = 0x40,
+    [5]                             = 0x60,
+    [SrxlDevType_SRXLServo1]        = 0x60,
+    [SrxlDevType_SRXLServo2]        = 0x70,
+    [SrxlDevType_VTX]               = 0x81,
+    [9]                             = 0xFF,
+    [10]                            = 0xFF,
+    [11]                            = 0xFF,
+    [12]                            = 0xFF,
+    [13]                            = 0xFF,
+    [14]                            = 0xFF,
+    [SrxlDevType_Broadcast]         = 0xFF,
+};
+
+// Set SRXL_CRC_OPTIMIZE_MODE in spm_srxl_config.h to one of the following values
+#define SRXL_CRC_OPTIMIZE_SPEED     (1)  // Uses table lookup for CRC computation (requires 512 const bytes for CRC table)
+#define SRXL_CRC_OPTIMIZE_SIZE      (2)  // Uses bitwise operations
+#define SRXL_CRC_OPTIMIZE_STM_HW    (3)  // Uses STM32 register-level hardware acceleration (only available on STM32F30x devices for now)
+#define SRXL_CRC_OPTIMIZE_STM_HAL   (4)  // Uses STM32Cube HAL driver for hardware acceleration (only available on STM32F3/F7) -- see srxlCrc16() for details on HAL config
+
+// Set SRXL_STM_TARGET_FAMILY in spm_srxl_config.h to one of the following values when using one of the STM HW-optimized modes
+#define SRXL_STM_TARGET_F3          (3)
+#define SRXL_STM_TARGET_F7          (7)
+
+//      7.2 Handshake Packet
+#define SRXL_HANDSHAKE_ID       (0x21)
+
+// Supported additional baud rates besides default 115200
+// NOTE: Treated as bitmask, ANDed with baud rates from slaves
+#define SRXL_BAUD_115200        (0x00)
+#define SRXL_BAUD_400000        (0x01)
+//#define SRXL_BAUD_NEXT_RATE   (0x02)
+//#define SRXL_BAUD_ANOTHER     (0x04)
+
+// Bit masks for Device Info byte sent via Handshake
+#define SRXL_DEVINFO_NO_RF              (0x00)  // This is the base for non-RF devices
+#define SRXL_DEVINFO_TELEM_TX_ENABLED   (0x01)  // This bit is set if the device is actively configured to transmit telemetry over RF
+#define SRXL_DEVINFO_TELEM_FULL_RANGE   (0x02)  // This bit is set if the device can send full-range telemetry over RF
+#define SRXL_DEVINFO_FWD_PROG_SUPPORT   (0x04)  // This bit is set if the device supports Forward Programming via RF or SRXL
+
+//      7.3 Bind Info Packet
+#define SRXL_BIND_ID                    (0x41)
+#define SRXL_BIND_REQ_ENTER             (0xEB)
+#define SRXL_BIND_REQ_STATUS            (0xB5)
+#define SRXL_BIND_REQ_BOUND_DATA        (0xDB)
+#define SRXL_BIND_REQ_SET_BIND          (0x5B)
+
+// Bit masks for Options byte
+#define SRXL_BIND_OPT_NONE              (0x00)
+#define SRXL_BIND_OPT_TELEM_TX_ENABLE   (0x01)  // Set if this device should be enabled as the current telemetry device to tx over RF
+#define SRXL_BIND_OPT_BIND_TX_ENABLE    (0x02)  // Set if this device should reply to a bind request with a Discover packet over RF
+#define SRXL_BIND_OPT_US_POWER          (0x04)  // Set if this device should request US transmit power levels instead of EU
+
+// Current Bind Status
+typedef enum
+{
+    NOT_BOUND           = 0x00,
+    // Air types
+    DSM2_1024_22MS      = 0x01,
+    DSM2_1024_MC24      = 0x02,
+    DSM2_2048_11MS      = 0x12,
+    DSMX_22MS           = 0xA2,
+    DSMX_11MS           = 0xB2,
+    // Surface types (corresponding Air type bitwise OR'd with 0x40)
+    SURFACE_DSM1        = 0x40,
+    SURFACE_DSM2_16p5MS = 0x63,
+    DSMR_11MS_22MS      = 0xE2,
+    DSMR_5p5MS          = 0xE4,
+} BIND_STATUS;
+
+//      7.4 Parameter Configuration
+#define SRXL_PARAM_ID           (0x50)
+#define SRXL_PARAM_REQ_QUERY    (0x50)
+#define SRXL_PARAM_REQ_WRITE    (0x57)
+
+//      7.5 Signal Quality Packet
+#define SRXL_RSSI_ID            (0x55)
+#define SRXL_RSSI_REQ_REQUEST   (0x52)
+#define SRXL_RSSI_REQ_SEND      (0x53)
+
+//      7.6 Telemetry Sensor Data Packet
+#define SRXL_TELEM_ID           (0x80)
+
+//      7.7 Control Data Packet
+#define SRXL_CTRL_ID                (0xCD)
+#define SRXL_CTRL_BASE_LENGTH       (3 + 2 + 2) // header + cmd/replyID + crc
+#define SRXL_CTRL_CMD_CHANNEL       (0x00)
+#define SRXL_CTRL_CMD_CHANNEL_FS    (0x01)
+#define SRXL_CTRL_CMD_VTX           (0x02)
+#define SRXL_CTRL_CMD_FWDPGM        (0x03)
+
+typedef enum
+{
+    SRXL_CMD_NONE,
+    SRXL_CMD_CHANNEL,
+    SRXL_CMD_CHANNEL_FS,
+    SRXL_CMD_VTX,
+    SRXL_CMD_FWDPGM,
+    SRXL_CMD_RSSI,
+    SRXL_CMD_HANDSHAKE,
+    SRXL_CMD_TELEMETRY,
+    SRXL_CMD_ENTER_BIND,
+    SRXL_CMD_REQ_BIND,
+    SRXL_CMD_SET_BIND,
+    SRXL_CMD_BIND_INFO,
+} SRXL_CMD;
+
+// VTX Band
+#define VTX_BAND_FATSHARK   (0)
+#define VTX_BAND_RACEBAND   (1)
+#define VTX_BAND_E_BAND     (2)
+#define VTX_BAND_B_BAND     (3)
+#define VTX_BAND_A_BAND     (4)
+
+// VTX Pit Mode
+#define VTX_MODE_RACE   (0)
+#define VTX_MODE_PIT    (1)
+
+// VTX Power
+#define VTX_POWER_OFF           (0)
+#define VTX_POWER_1MW_14MW      (1)
+#define VTX_POWER_15MW_25MW     (2)
+#define VTX_POWER_26MW_99MW     (3)
+#define VTX_POWER_100MW_299MW   (4)
+#define VTX_POWER_300MW_600MW   (5)
+#define VTX_POWER_601_PLUS      (6)
+#define VTX_POWER_MANUAL        (7)
+
+// VTX Region
+#define VTX_REGION_US   (0)
+#define VTX_REGION_EU   (1)
+
+// Forward Programming Pass-Thru
+#define FWD_PGM_MAX_DATA_SIZE   (64)
+
+
+// Enable byte packing for all structs defined here!
+#ifdef PACKED
+#error "preprocessor definition PACKED is already defined -- this could be bad"
+#endif
+#ifdef __GNUC__
+#define PACKED __attribute__((packed))
+#else
+#pragma pack(push, 1)
+#define PACKED
+#endif
+
+// Spektrum SRXL header
+typedef struct SrxlHeader
+{
+    uint8_t srxlID;     // Always 0xA6 for SRXL2
+    uint8_t packetType;
+    uint8_t length;
+} PACKED SrxlHeader;
+
+// Handshake
+typedef struct SrxlHandshakeData
+{
+    uint8_t     srcDevID;
+    uint8_t     destDevID;
+    uint8_t     priority;
+    uint8_t     baudSupported;  // 0 = 115200, 1 = 400000 (See SRXL_BAUD_xxx definitions above)
+    uint8_t     info;           // See SRXL_DEVINFO_xxx definitions above for defined bits
+    uint32_t    uid;            // Unique/random id to allow detection of two devices on bus with same deviceID
+} PACKED SrxlHandshakeData;
+
+typedef struct SrxlHandshakePacket
+{
+    SrxlHeader          hdr;
+    SrxlHandshakeData   payload;
+    uint16_t            crc;
+} PACKED SrxlHandshakePacket;
+
+// Bind
+typedef struct SrxlBindData
+{
+    uint8_t     type;
+    uint8_t     options;
+    uint64_t    guid;
+    uint32_t    uid;
+} PACKED SrxlBindData;
+
+typedef struct SrxlBindPacket
+{
+    SrxlHeader      hdr;
+    uint8_t         request;
+    uint8_t         deviceID;
+    SrxlBindData    data;
+    uint16_t        crc;
+} PACKED SrxlBindPacket;
+
+// Telemetry
+typedef struct SrxlTelemetryData
+{
+    union
+    {
+        struct
+        {
+            uint8_t sensorID;
+            uint8_t secondaryID;
+            uint8_t data[14];
+        };
+        uint8_t raw[16];
+    };
+} PACKED SrxlTelemetryData;
+
+typedef struct SrxlTelemetryPacket
+{
+    SrxlHeader          hdr;
+    uint8_t             destDevID;
+    SrxlTelemetryData   payload;
+    uint16_t            crc;
+} PACKED SrxlTelemetryPacket;
+
+// Signal Quality
+typedef struct SrxlRssiPacket
+{
+    SrxlHeader  hdr;
+    uint8_t     request;
+    int8_t      antennaA;
+    int8_t      antennaB;
+    int8_t      antennaC;
+    int8_t      antennaD;
+    uint16_t    crc;
+} PACKED SrxlRssiPacket;
+
+// Parameter Config
+typedef struct SrxlParamPacket
+{
+    SrxlHeader  hdr;
+    uint8_t     request;
+    uint8_t     destDevID;
+    uint32_t    paramID;
+    uint32_t    paramVal;
+    uint16_t    crc;
+} PACKED SrxlParamPacket;
+
+// VTX Data
+typedef struct SrxlVtxData
+{
+    uint8_t band;       // VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A)
+    uint8_t channel;    // VTX Channel (0-7)
+    uint8_t pit;        // Pit/Race mode (0 = Race, 1 = Pit). Race = normal power, Pit = reduced power
+    uint8_t power;      // VTX Power (0 = Off, 1 = 1mw to 14mW, 2 = 15mW to 25mW, 3 = 26mW to 99mW,
+                        // 4 = 100mW to 299mW, 5 = 300mW to 600mW, 6 = 601mW+, 7 = manual control)
+    uint16_t powerDec;  // VTX Power as a decimal 1mw/unit
+    uint8_t region;     // Region (0 = USA, 1 = EU)
+} PACKED SrxlVtxData;
+
+// Forward Programming Data
+typedef struct SrxlFwdPgmData
+{
+    uint8_t rfu[3];     // 0 for now -- used to word-align data
+    uint8_t data[FWD_PGM_MAX_DATA_SIZE];
+} PACKED SrxlFwdPgmData;
+
+// Channel Data
+typedef struct SrxlChannelData
+{
+    int8_t    rssi;         // Best RSSI when sending channel data, or dropout RSSI when sending failsafe data
+    uint16_t  frameLosses;  // Total lost frames (or fade count when sent from Remote Rx to main Receiver)
+    uint32_t  mask;         // Set bits indicate that channel data with the corresponding index is present
+    uint16_t  values[32];   // Channel values, shifted to full 16-bit range (32768 = mid-scale); lowest 2 bits RFU
+} PACKED SrxlChannelData;
+
+// Control Data
+typedef struct SrxlControlData
+{
+    uint8_t cmd;
+    uint8_t replyID;
+    union
+    {
+        SrxlChannelData channelData;    // Used for Channel Data and Failsafe Channel Data commands
+        SrxlVtxData     vtxData;        // Used for VTX commands
+        SrxlFwdPgmData  fpData;         // Used to pass forward programming data to an SRXL device
+    };
+} PACKED SrxlControlData;
+
+typedef struct SrxlControlPacket
+{
+    SrxlHeader      hdr;
+    SrxlControlData payload;
+//  uint16_t        crc;    // NOTE: Since this packet is variable-length, we can't use this value anyway
+} PACKED SrxlControlPacket;
+
+// SRXL Packets
+typedef union
+{
+    SrxlHeader          header;
+    SrxlBindPacket      bind;
+    SrxlHandshakePacket handshake;
+    SrxlTelemetryPacket telemetry;
+    SrxlRssiPacket      rssi;
+    SrxlParamPacket     parameter;
+    SrxlControlPacket   control;
+    uint8_t             raw[SRXL_MAX_BUFFER_SIZE];
+} SrxlPacket;
+
+// SRXL full device identifier -- SRXL Device ID with bus number
+typedef union
+{
+    struct
+    {
+        uint8_t deviceID;
+        uint8_t busIndex;
+    };
+    uint16_t word;
+} PACKED SrxlFullID;
+
+// Restore packing back to default
+#undef PACKED
+#ifndef __GNUC__
+#pragma pack(pop)
+#endif
+
+// Global vars
+extern SrxlChannelData srxlChData;
+extern SrxlTelemetryData srxlTelemData;
+extern SrxlVtxData srxlVtxData;
+
+// Include config here, after all typedefs that might be needed within it
+#include "spm_srxl_config.h"
+
+#if !defined(SRXL_NUM_OF_BUSES)
+#error "SRXL_NUM_OF_BUSES must be defined in spm_srxl_config.h!"
+#elif SRXL_NUM_OF_BUSES <= 0
+#error "SRXL_NUM_OF_BUSES must be defined in spm_srxl_config.h!"
+#elif SRXL_NUM_OF_BUSES > 1
+#define SRXL_IS_HUB
+#endif
+#define SRXL_ALL_BUSES          ((1u << SRXL_NUM_OF_BUSES) - 1)
+#define SRXL_MAX_RCVRS          (2 * SRXL_NUM_OF_BUSES)
+#ifndef SRXL_CRC_OPTIMIZE_MODE  // NOTE: This should be set in spm_srxl_config.h
+#define SRXL_CRC_OPTIMIZE_MODE  SRXL_CRC_OPTIMIZE_SPEED
+#endif
+
+#define RSSI_RCVD_NONE  (0)
+#define RSSI_RCVD_DBM   (1)
+#define RSSI_RCVD_PCT   (2)
+#define RSSI_RCVD_BOTH  (3)
+
+// Internal types
+typedef enum
+{
+    SrxlState_Disabled,             // Default state before initialized or if bus is subsequently disabled
+    SrxlState_ListenOnStartup,      // Wait 50ms to see if anything is already talking (i.e. we probably browned out)
+    SrxlState_SendHandshake,        // Call when handshake should be sent every 50ms
+    SrxlState_ListenForHandshake,   // Wait at least 150ms more for handshake request
+    SrxlState_Running,              // Normal run state
+    SrxlState_SendTelemetry,        // Send telemetry reply when requested
+    SrxlState_SendVTX,              // Send VTX packet when needed
+    SrxlState_SendEnterBind,
+    SrxlState_SendBoundDataReport,
+    SrxlState_SendSetBindInfo,
+} SrxlState;
+
+//#ifdef SRXL_IS_HUB
+typedef struct SrxlRcvrEntry
+{
+    uint8_t     deviceID;       // SRXL device ID of the receiver
+    uint8_t     busBits;        // Supports 8 buses, with each bit corresponding to busIndex (bit 0 = bus 0, bit 7 = bus 7)
+    uint8_t     info;           // Info bits reported during handshake - See SRXL_DEVINFO_XXX mask bits in header
+    uint8_t     rssiRcvd;       // 0 = none, 1 = dBm, 2 = percent, 3 = both dBm and percent
+    int8_t      rssi_dBm;       // Latest RSSI dBm value reported by receiver (negative, varies with receiver type)
+    int8_t      rssi_Pct;       // Latest RSSI percent range estimate reported by receiver (0-100)
+    uint16_t    fades;          // Latest number of fades reported for a given receiver
+    uint32_t    channelMask;    // Latest channel mask for channels provided in channel data packet (0 during fade)
+} SrxlRcvrEntry;
+
+typedef struct SrxlReceiverInfo
+{
+    SrxlRcvrEntry   rcvr[SRXL_MAX_RCVRS];       // Stats for each receiver, filled when ch data is received
+    SrxlRcvrEntry*  rcvrSorted[SRXL_MAX_RCVRS]; // Pointers to receiver entries sorted in telemetry range order
+    uint8_t         rcvrSortInsert;             // Index into rcvrSorted where full-range telem rcvrs should be inserted
+    uint8_t         rcvrCount;                  // Number of entries in rcvr[] and rcvrSorted[]
+    uint8_t         rxBusBits;
+    int8_t          bestRssi_dBm;
+    int8_t          bestRssi_Pct;
+    uint8_t         lossCountdown;  // Reset to lossHoldCount when frame is good, and decrement for each consecutive
+                                    // frame loss -- when we get to 0, convert lossHoldCount frame losses to a hold
+    uint8_t         lossHoldCount;  // Consecutive frame losses required to count as hold
+    uint16_t        frameLosses;    // Increment each time all receivers are in frame loss -- if 45
+                                    // consecutive, subtract those and increment holds
+    uint16_t        holds;          // Increment each time 45 or more consecutive frames are lost (but don't keep
+                                    // incrementing once in that state)
+    SrxlRcvrEntry*  pTelemRcvr;     // Pointer to current assigned telemetry receiver (used for checking
+                                    // for fade to know when to switch)
+    SrxlRcvrEntry*  pBindRcvr;      // Pointer to receiver that we told to Enter Bind Mode (used to
+                                    // process Bound Data Report and send Set Bind Info)
+} SrxlReceiverStats;
+//#endif
+
+typedef struct SrxlDevEntry
+{
+    uint8_t deviceID;
+    uint8_t priority;   // Requested telemetry priority of this device
+    uint8_t info;       // Refer to SRXL_DEVINFO_XXX mask bits in header
+    uint8_t rfu;
+} SrxlDevEntry;
+
+typedef struct SrxlTxFlags
+{
+    unsigned int enterBind : 1;
+    unsigned int getBindInfo : 1;
+    unsigned int setBindInfo : 1;
+    unsigned int broadcastBindInfo : 1;
+    unsigned int reportBindInfo : 1;
+    unsigned int sendVtxData : 1;
+    unsigned int sendFwdPgmData : 1;
+} SrxlTxFlags;
+
+typedef struct SrxlBus
+{
+    SrxlPacket      srxlOut;            // Transmit packet buffer
+    SrxlPacket      srxlIn;             // Receive packet buffer
+
+    SrxlState       state;              // Current state of SRXL state machine
+    SrxlFullID      fullID;             // Device ID and Bus Index of this device, set during init
+    uint8_t         rxDevCount;         // Number of other SRXL devices discovered via handshake
+    SrxlDevEntry    rxDev[SRXL_MAX_DEVICES];    // Device entries for tracking SRXL telemetry priorities
+#ifdef SRXL_INCLUDE_MASTER_CODE
+    uint16_t        rxDevAge[SRXL_MAX_DEVICES]; // Telemetry age value for the associated device
+#endif
+    uint16_t        rxDevPrioritySum;   // Sum of priorities requested for each discovered SRXL device
+    uint16_t        timeoutCount_ms;    // Milliseconds since SRXL packet was received (incremented in srxlRun)
+    uint8_t         requestID;          // Device ID to poll
+    uint8_t         baudSupported;      // Baud rates this device can do: 0 = 115200, 1 = 400000
+    uint8_t         baudRate;           // Current baud rate: 0 = 115200, 1 = 400000
+    uint8_t         frameErrCount;      // Number of consecutive missed frames
+    SrxlTxFlags     txFlags;            // Pending outgoing packet types
+    void*           uart;               // Index number of UART tied to this SRXL bus
+    SrxlRcvrEntry*  pMasterRcvr;        // Receiver entry for the bus master, if one exists
+    bool            master;             // True if this device is the bus master on this bus
+    bool            initialized;        // True when this SRXL bus is initialized
+} SrxlBus;
+
+typedef struct SrxlDevice
+{
+    SrxlDevEntry    devEntry;   // Device info for this local device, shared across all buses.
+    uint32_t        uid;        // ID statistically likely to be unique (Random, hash of serial, etc.)
+    SrxlRcvrEntry*  pRcvr;      // Pointer to our receiver entry, if we're a receiver (don't set for
+                                // flight controller acting as hub -- only true receiver)
+    bool vtxProxy;              // Set true if this device can and should respond to VTX commands
+} SrxlDevice;
+
+
+// Function prototypes
+bool srxlInitDevice(uint8_t deviceID, uint8_t priority, uint8_t info, uint32_t uid);
+bool srxlInitBus(uint8_t busIndex, void* uart, uint8_t baudSupported);
+bool srxlIsBusMaster(uint8_t busIndex);
+uint16_t srxlGetTimeoutCount_ms(uint8_t busIndex);
+uint8_t srxlGetDeviceID(uint8_t busIndex);
+bool srxlParsePacket(uint8_t busIndex, uint8_t *packet, uint8_t length);
+void srxlRun(uint8_t busIndex, int16_t timeoutDelta_ms);
+bool srxlEnterBind(uint8_t bindType, bool broadcast);
+bool srxlSetBindInfo(uint8_t bindType, uint64_t guid, uint32_t uid);
+void srxlOnFrameError(uint8_t busIndex);
+SrxlFullID srxlGetTelemetryEndpoint(void);
+bool srxlSetVtxData(SrxlVtxData *pVtxData);
+bool srxlPassThruFwdPgm(uint8_t *pData, uint8_t length);
+void srxlSetHoldThreshold(uint8_t countdownReset);
+void srxlClearCommStats(void);
+bool srxlUpdateCommStats(bool isFade);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif //__SRXL_H__

--- a/libraries/AP_RCProtocol/spm_srxl_config.h
+++ b/libraries/AP_RCProtocol/spm_srxl_config.h
@@ -32,9 +32,11 @@ SOFTWARE.
 // User included headers/declarations to access interface functions required below
 //#include <AP_HAL/AP_HAL.h>
 
-//void userProvidedFillSrxlTelemetry(SrxlTelemetryData* pTelemetry);
-//void userProvidedReceivedChannelData(SrxlChannelData* pChannelData);
-//void userProvidedHandleVtxData(SrxlVtxData* pVtxData);
+extern "C++" {
+#include <AP_Math/crc.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+}
 
 //### USER CONFIGURATION ###
 
@@ -72,10 +74,9 @@ SOFTWARE.
 //    SRXL_CRC_OPTIMIZE_STM_HW  -- Uses STM32 register-level hardware acceleration (only available on STM32F30x devices for now)
 //    SRXL_CRC_OPTIMIZE_STM_HAL -- Uses STM32Cube HAL driver for hardware acceleration (only available on STM32F3/F7) -- see srxlCrc16() for details on HAL config
 
-#define SRXL_CRC_EXTERNAL(packet, length, crc) crc16_ccitt(packet, length, crc)
+#define SRXL_CRC_CALCULATE(packet, length, crc) crc16_ccitt(packet, length, crc)
 
-extern uint16_t crc16_ccitt(const uint8_t *buf, uint32_t len, uint16_t crc);
-#define SRXL_CRC_OPTIMIZE_MODE      SRXL_CRC_EXTERNAL
+#define SRXL_CRC_OPTIMIZE_MODE      SRXL_CRC_OPTIMIZE_EXTERNAL
 
 // If using STM32 hardware CRC acceleration above, set this flag to the target family. Choices are:
 //    SRXL_STM_TARGET_F3
@@ -94,13 +95,13 @@ extern uint16_t crc16_ccitt(const uint8_t *buf, uint32_t len, uint16_t crc);
 // User-provided routine to change the baud rate settings on the given UART:
 // uart - the same uint8_t value as the uart parameter passed to srxlInit()
 // baudRate - the actual baud rate (currently either 115200 or 400000)
-void srxlChangeBaudRate(void* uart, uint32_t baudRate);
+void srxlChangeBaudRate(uint8_t uart, uint32_t baudRate);
 
 // User-provided routine to actually transmit a packet on the given UART:
 // uart - the same uint8_t value as the uart parameter passed to srxlInit()
 // pBuffer - a pointer to an array of uint8_t values to send over the UART
 // length - the number of bytes contained in pBuffer that should be sent
-void srxlSendOnUart(void* uart, uint8_t* pBuffer, uint8_t length);
+void srxlSendOnUart(uint8_t uart, uint8_t* pBuffer, uint8_t length);
 
 // User-provided callback routine to fill in the telemetry data to send to the master when requested:
 // pTelemetryData - a pointer to the 16-byte SrxlTelemetryData transmit buffer to populate

--- a/libraries/AP_RCProtocol/spm_srxl_config.h
+++ b/libraries/AP_RCProtocol/spm_srxl_config.h
@@ -1,0 +1,144 @@
+/*
+MIT License
+
+Copyright (c) 2019 Horizon Hobby, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// This file is automatically included within spm_srxl.h -- do not include elsewhere!
+
+#ifndef _SRXL_CONFIG_H_
+#define _SRXL_CONFIG_H_
+
+//### USER PROVIDED HEADER FUNCTIONS AND FORWARD DECLARATIONS ###
+
+// User included headers/declarations to access interface functions required below
+//#include <AP_HAL/AP_HAL.h>
+
+//void userProvidedFillSrxlTelemetry(SrxlTelemetryData* pTelemetry);
+//void userProvidedReceivedChannelData(SrxlChannelData* pChannelData);
+//void userProvidedHandleVtxData(SrxlVtxData* pVtxData);
+
+//### USER CONFIGURATION ###
+
+// Set this value to the number of physically separate SRXL buses on the device
+#define SRXL_NUM_OF_BUSES           1
+
+// Set this to the appropriate device ID (See Section 7.1.1 in Spektrum Bi-Directional SRXL Documentation).
+// Typical values are:
+//    Flight Controller = 0x31 (or possibly 0x30 if connected to Base Receiver instead of Remote Receiver)
+//    Smart ESC = 0x40
+//    VTX = 0x81
+// NOTE: This value is not used internally -- it is passed as a parameter to srxlInit() in the example app
+#define SRXL_DEVICE_ID              0x31
+
+// Set this to the desired priority level for sending telemetry, ranging from 0 to 100.
+// Generally, this number should be 10 times the number of different telemetry packets to regularly send.
+// If there are telemetry messages that should be sent more often, increase this value.
+// If there are messages that are rarely sent, add less than 10 for those.
+// For example, if you had two normal priority messages and one that you plan to send twice as often as those,
+// you could set the priority to 40 (10 + 10 + 2*10)
+// NOTE: This value is not used internally -- it is passed as a parameter to srxlInit() in the example app
+#define SRXL_DEVICE_PRIORITY        20
+
+// Set these information bits based on the capabilities of the device.
+// The only bit currently applicable to third-party devices is the SRXL_DEVINFO_FWD_PROG_SUPPORT flag,
+// which should be set if you would like to allow Forward Programming of the device via SRXL pass-through.
+#define SRXL_DEVICE_INFO            (SRXL_DEVINFO_NO_RF)
+
+// Set this value to 0 for 115200 baud only, or 1 for 400000 baud support
+#define SRXL_SUPPORTED_BAUD_RATES   0
+
+// Set this value to choose which code to include for CRC computation. Choices are:
+//    SRXL_CRC_OPTIMIZE_SPEED   -- Uses table lookup for CRC computation (requires 512 const bytes for CRC table)
+//    SRXL_CRC_OPTIMIZE_SIZE    -- Uses bitwise operations for smaller code size but slower execution
+//    SRXL_CRC_OPTIMIZE_STM_HW  -- Uses STM32 register-level hardware acceleration (only available on STM32F30x devices for now)
+//    SRXL_CRC_OPTIMIZE_STM_HAL -- Uses STM32Cube HAL driver for hardware acceleration (only available on STM32F3/F7) -- see srxlCrc16() for details on HAL config
+
+#define SRXL_CRC_EXTERNAL(packet, length, crc) crc16_ccitt(packet, length, crc)
+
+extern uint16_t crc16_ccitt(const uint8_t *buf, uint32_t len, uint16_t crc);
+#define SRXL_CRC_OPTIMIZE_MODE      SRXL_CRC_EXTERNAL
+
+// If using STM32 hardware CRC acceleration above, set this flag to the target family. Choices are:
+//    SRXL_STM_TARGET_F3
+//    SRXL_STM_TARGET_F7
+#define SRXL_STM_TARGET_FAMILY      SRXL_STM_TARGET_F3
+
+// If using SRXL_CRC_OPTIMIZE_STM_HW and the CRC hardware is shared with non-SRXL code, then
+// uncomment the following flag to save and restore the CRC registers after use by SRXL:
+//#define SRXL_SAVE_HW_CRC_CONTEXT
+
+// Uncomment the following flag if your code must support Forward Programming received via SRXL
+//#define SRXL_INCLUDE_FWD_PGM_CODE
+
+//### USER PROVIDED INTERFACE FUNCTIONS ###
+
+// User-provided routine to change the baud rate settings on the given UART:
+// uart - the same uint8_t value as the uart parameter passed to srxlInit()
+// baudRate - the actual baud rate (currently either 115200 or 400000)
+void srxlChangeBaudRate(void* uart, uint32_t baudRate);
+
+// User-provided routine to actually transmit a packet on the given UART:
+// uart - the same uint8_t value as the uart parameter passed to srxlInit()
+// pBuffer - a pointer to an array of uint8_t values to send over the UART
+// length - the number of bytes contained in pBuffer that should be sent
+void srxlSendOnUart(void* uart, uint8_t* pBuffer, uint8_t length);
+
+// User-provided callback routine to fill in the telemetry data to send to the master when requested:
+// pTelemetryData - a pointer to the 16-byte SrxlTelemetryData transmit buffer to populate
+// NOTE: srxlTelemData is available as a global variable, so the memcpy line commented out below
+// could be used if you would prefer to just populate that with the next outgoing telemetry packet.
+void srxlFillTelemetry(SrxlTelemetryData* pTelemetryData);
+
+// User-provided callback routine that is called whenever a control data packet is received:
+// pChannelData - a pointer to the received SrxlChannelData structure for manual parsing
+// isFailsafe - true if channel data is set to failsafe values, else false.
+// NOTE: srxlChData is available as a global variable that contains all of the latest values
+// for channel data, so this callback is intended to be used if more control is desired.
+// It might make sense to only use this to trigger your own handling of the received servo values.
+void srxlReceivedChannelData(SrxlChannelData* pChannelData, bool isFailsafe);
+
+// User-provided callback routine to handle reception of a bound data report (either requested or unprompted).
+// Return true if you want this bind information set automatically for all other receivers on all SRXL buses.
+bool srxlOnBind(SrxlFullID device, SrxlBindData info);
+
+// User-provided callback routine to handle reception of a VTX control packet.
+void srxlOnVtx(SrxlVtxData* pVtxData);
+
+// Optional user-provided callback routine to handle Forward Programming command locally if supported
+#ifdef SRXL_INCLUDE_FWD_PGM_CODE
+static inline void srxlOnFwdPgm(uint8_t* pData, uint8_t dataLength)
+{
+    // TODO: Pass data to Forward Programming library
+}
+#endif // SRXL_INCLUDE_FWD_PGM_CODE
+
+// User-provided routine to enter a critical section (only needed with multiple buses or if HW CRC is used externally)
+static inline void srxlEnterCriticalSection(void)
+{
+}
+
+// User-provided routine to exit a critical section (only needed with multiple buses or if HW CRC is used externally)
+static inline void srxlExitCriticalSection(void)
+{
+}
+
+#endif // _SRXL_CONFIG_H_

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
@@ -1,0 +1,258 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* 
+   Abstract Telemetry library
+*/
+
+#include "AP_RCTelemetry.h"
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Common/AP_FWVersion.h>
+#include <GCS_MAVLink/GCS.h>
+#include <stdio.h>
+#include <math.h>
+
+#ifdef TELEM_DEBUG
+# define debug(fmt, args...)	hal.console->printf("Telem: " fmt "\n", ##args)
+#else
+# define debug(fmt, args...)	do {} while(0)
+#endif
+
+extern const AP_HAL::HAL& hal;
+
+/*
+  setup ready for passthrough telem
+ */
+bool AP_RCTelemetry::init(void)
+{
+#if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+    // make telemetry available to GCS_MAVLINK (used to queue statustext messages from GCS_MAVLINK)
+    // add firmware and frame info to message queue
+    const char* _frame_string = gcs().frame_string();
+    if (_frame_string == nullptr) {
+        queue_message(MAV_SEVERITY_INFO, AP::fwversion().fw_string);
+    } else {
+        char firmware_buf[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+        snprintf(firmware_buf, sizeof(firmware_buf), "%s %s", AP::fwversion().fw_string, _frame_string);
+        queue_message(MAV_SEVERITY_INFO, firmware_buf);
+    }
+#endif
+    setup_wfq_scheduler();
+
+    return true;
+}
+
+void AP_RCTelemetry::update_avg_packet_rate()
+{
+    uint32_t poll_now = AP_HAL::millis();
+
+    _scheduler.avg_packet_counter++;
+    
+    if (poll_now - _scheduler.last_poll_timer > 1000) { //average in last 1000ms
+        // initialize
+        if (_scheduler.avg_packet_rate == 0) _scheduler.avg_packet_rate = _scheduler.avg_packet_counter;
+        // moving average
+        _scheduler.avg_packet_rate = (uint8_t)_scheduler.avg_packet_rate * 0.75f + _scheduler.avg_packet_counter * 0.25f;
+        // reset
+        _scheduler.last_poll_timer = poll_now;
+        _scheduler.avg_packet_counter = 0;
+        debug("avg packet rate %dHz, rates(Hz) %d %d %d %d %d %d %d %d", _scheduler.avg_packet_rate,
+             _scheduler.packet_rate[0],
+             _scheduler.packet_rate[1],
+             _scheduler.packet_rate[2],
+             _scheduler.packet_rate[3],
+             _scheduler.packet_rate[4],
+             _scheduler.packet_rate[5],
+             _scheduler.packet_rate[6],
+             _scheduler.packet_rate[7]);
+    }
+}
+
+/*
+ * WFQ scheduler
+ */
+void AP_RCTelemetry::run_wfq_scheduler(void)
+{
+    update_avg_packet_rate();
+
+    uint32_t now = AP_HAL::millis();
+    uint8_t max_delay_idx = 0;
+    
+    float max_delay = 0;
+    float delay = 0;
+    bool packet_ready = false;
+
+    // build message queue for sensor_status_flags
+    check_sensor_status_flags();
+    // build message queue for ekf_status
+    check_ekf_status();
+    
+    // dynamic priorities
+    bool queue_empty;
+    {
+        WITH_SEMAPHORE(_statustext.sem);
+        queue_empty = !_statustext.available && _statustext.queue.empty();
+    }
+
+    adjust_packet_weight(queue_empty);
+    
+    // search the packet with the longest delay after the scheduled time
+    for (int i=0; i<_time_slots; i++) {
+        // normalize packet delay relative to packet weight
+        delay = (now - _scheduler.packet_timer[i])/static_cast<float>(_scheduler.packet_weight[i]);
+        // use >= so with equal delays we choose the packet with lowest priority
+        // this is ensured by the packets being sorted by desc frequency
+        // apply the rate limiter
+        if (delay >= max_delay && ((now - _scheduler.packet_timer[i]) >= _scheduler.packet_min_period[i])) {
+            packet_ready = is_packet_ready(i, queue_empty);
+
+            if (packet_ready) {
+                max_delay = delay;
+                max_delay_idx = i;
+            }
+        }
+    }
+    now = AP_HAL::millis();
+#ifdef TELEM_DEBUG
+    _scheduler.packet_rate[max_delay_idx] = (_scheduler.packet_rate[max_delay_idx] + 1000 / (now - _scheduler.packet_timer[max_delay_idx])) / 2;
+#endif
+    _scheduler.packet_timer[max_delay_idx] = now;
+    //debug("process_packet(%d): %f", max_delay_idx, max_delay);
+    // send packet
+    process_packet(max_delay_idx);
+}
+
+/*
+ * add message to message cue for transmission through link
+ */
+void AP_RCTelemetry::queue_message(MAV_SEVERITY severity, const char *text)
+{
+    mavlink_statustext_t statustext{};
+
+    statustext.severity = severity;
+    strncpy(statustext.text, text, sizeof(statustext.text));
+
+    // The force push will ensure comm links do not block other comm links forever if they fail.
+    // If we push to a full buffer then we overwrite the oldest entry, effectively removing the
+    // block but not until the buffer fills up.
+    WITH_SEMAPHORE(_statustext.sem);
+    _statustext.queue.push_force(statustext);
+}
+
+/*
+ * add sensor_status_flags information to message cue, normally passed as sys_status mavlink messages to the GCS, for transmission through FrSky link
+ */
+void AP_RCTelemetry::check_sensor_status_flags(void)
+{
+    uint32_t now = AP_HAL::millis();
+
+    const uint32_t _sensor_status_flags = sensor_status_flags();
+
+    if ((now - check_sensor_status_timer) >= 5000) { // prevent repeating any system_status messages unless 5 seconds have passed
+        // only one error is reported at a time (in order of preference). Same setup and displayed messages as Mission Planner.
+        if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_GPS) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad GPS Health");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_GYRO) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad Gyro Health");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_ACCEL) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad Accel Health");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_MAG) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad Compass Health");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad Baro Health");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_LASER_POSITION) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad LiDAR Health");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad OptFlow Health");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_TERRAIN) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad or No Terrain Data");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_GEOFENCE) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Geofence Breach");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_AHRS) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad AHRS");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_RC_RECEIVER) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "No RC Receiver");
+            check_sensor_status_timer = now;
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_LOGGING) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad Logging");
+            check_sensor_status_timer = now;
+        }
+    }
+}
+
+/*
+ * add innovation variance information to message cue, normally passed as ekf_status_report mavlink messages to the GCS, for transmission through FrSky link
+ */
+void AP_RCTelemetry::check_ekf_status(void)
+{
+    // get variances
+    bool get_variance;
+    float velVar, posVar, hgtVar, tasVar;
+    Vector3f magVar;
+    Vector2f offset;
+    {
+        AP_AHRS &_ahrs = AP::ahrs();
+        WITH_SEMAPHORE(_ahrs.get_semaphore());
+        get_variance = _ahrs.get_variances(velVar, posVar, hgtVar, magVar, tasVar, offset);
+    }
+    if (get_variance) {
+        uint32_t now = AP_HAL::millis();
+        if ((now - check_ekf_status_timer) >= 10000) { // prevent repeating any ekf_status message unless 10 seconds have passed
+            // multiple errors can be reported at a time. Same setup as Mission Planner.
+            if (velVar >= 1) {
+                queue_message(MAV_SEVERITY_CRITICAL, "Error velocity variance");
+                check_ekf_status_timer = now;
+            }
+            if (posVar >= 1) {
+                queue_message(MAV_SEVERITY_CRITICAL, "Error pos horiz variance");
+                check_ekf_status_timer = now;
+            }
+            if (hgtVar >= 1) {
+                queue_message(MAV_SEVERITY_CRITICAL, "Error pos vert variance");
+                check_ekf_status_timer = now;
+            }
+            if (magVar.length() >= 1) {
+                queue_message(MAV_SEVERITY_CRITICAL, "Error compass variance");
+                check_ekf_status_timer = now;
+            }
+            if (tasVar >= 1) {
+                queue_message(MAV_SEVERITY_CRITICAL, "Error terrain alt variance");
+                check_ekf_status_timer = now;
+            }
+        }
+    }
+}
+      
+uint32_t AP_RCTelemetry::sensor_status_flags() const
+{
+    uint32_t present;
+    uint32_t enabled;
+    uint32_t health;
+    gcs().get_sensor_status_flags(present, enabled, health);
+
+    return ~health & enabled & present;
+}
+

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.h
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.h
@@ -1,0 +1,97 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Notify/AP_Notify.h>
+#include <AP_HAL/utility/RingBuffer.h>
+
+#define TELEM_PAYLOAD_STATUS_CAPACITY          5 // size of the message buffer queue (max number of messages waiting to be sent)
+
+// for fair scheduler
+#define TELEM_TIME_SLOT_MAX               15
+//#define TELEM_DEBUG
+
+class AP_RCTelemetry {
+public:
+    AP_RCTelemetry(uint8_t time_slots) : _time_slots(time_slots) {}
+    virtual ~AP_RCTelemetry() {};
+
+    /* Do not allow copies */
+    AP_RCTelemetry(const AP_RCTelemetry &other) = delete;
+    AP_RCTelemetry &operator=(const AP_RCTelemetry&) = delete;
+
+    // add statustext message to message queue
+    void queue_message(MAV_SEVERITY severity, const char *text);
+
+    // update error mask of sensors and subsystems. The mask uses the
+    // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
+    // indicates that the sensor or subsystem is present but not
+    // functioning correctly
+    uint32_t sensor_status_flags() const;
+
+protected:
+    void run_wfq_scheduler();
+    // set an entry in the scheduler table
+    void set_scheduler_entry(uint8_t slot, uint32_t weight, uint32_t min_period_ms) {
+        _scheduler.packet_weight[slot] = weight;
+        _scheduler.packet_min_period[slot] = min_period_ms;
+    }
+    // add an entry to the scheduler table
+    void add_scheduler_entry(uint32_t weight, uint32_t min_period_ms) {
+        set_scheduler_entry(_time_slots++, weight, min_period_ms);
+    }
+    // setup ready for passthrough operation
+    virtual bool init(void);
+
+    uint8_t _time_slots;
+
+    struct
+    {
+        uint32_t last_poll_timer;
+        uint32_t avg_packet_counter;
+        uint32_t packet_timer[TELEM_TIME_SLOT_MAX];
+        uint32_t packet_weight[TELEM_TIME_SLOT_MAX];
+        uint32_t packet_min_period[TELEM_TIME_SLOT_MAX];
+        uint8_t avg_packet_rate;
+#ifdef TELEM_DEBUG
+        uint8_t packet_rate[TELEM_TIME_SLOT_MAX];
+#endif
+    } _scheduler;
+
+    struct {
+        HAL_Semaphore sem;
+        ObjectBuffer<mavlink_statustext_t> queue{TELEM_PAYLOAD_STATUS_CAPACITY};
+        mavlink_statustext_t next;
+        bool available;
+    } _statustext;
+
+private:
+    uint32_t check_sensor_status_timer;
+    uint32_t check_ekf_status_timer;
+
+    // passthrough WFQ scheduler
+    virtual void setup_wfq_scheduler() = 0;
+    virtual bool get_next_msg_chunk(void) = 0;
+    virtual bool is_packet_ready(uint8_t idx, bool queue_empty) = 0;
+    virtual void process_packet(uint8_t idx) = 0;
+    virtual void adjust_packet_weight(bool queue_empty) = 0;
+
+    void update_avg_packet_rate();
+
+    // methods to convert flight controller data to FrSky SPort Passthrough (OpenTX) format
+    void check_sensor_status_flags(void);
+    void check_ekf_status(void);
+};

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
@@ -1,0 +1,622 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+   Spektrum Telemetry library, based on AP_Frsky_Telem.cpp
+   See https://www.spektrumrc.com/ProdInfo/Files/SPM_Telemetry_Developers_Specs.pdf
+*/
+
+#include "AP_Spektrum_Telem.h"
+#include <AP_HAL/utility/sparse-endian.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_RPM/AP_RPM.h>
+#include <AP_Airspeed/AP_Airspeed.h>
+#include <AP_Compass/AP_Compass.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_Common/AP_FWVersion.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Common/Location.h>
+#include <AP_GPS/AP_GPS.h>
+#include <AP_Baro/AP_Baro.h>
+#include <AP_GPS/AP_GPS.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_RTC/AP_RTC.h>
+#ifdef HAVE_AP_BLHELI_SUPPORT
+#include <AP_BLheli/AP_BLHeli.h>
+#endif
+#include <math.h>
+
+#if HAL_SPEKTRUM_TELEM_ENABLED
+
+#define MICROSEC_PER_MINUTE 60000000
+#define MAX_TEXTGEN_LEN     13
+
+//#define SPKT_DEBUG
+#ifdef SPKT_DEBUG
+# define debug(fmt, args...)	hal.console->printf("SPKT:" fmt "\n", ##args)
+#else
+# define debug(fmt, args...)	do {} while(0)
+#endif
+
+extern const AP_HAL::HAL& hal;
+
+AP_Spektrum_Telem *AP_Spektrum_Telem::singleton;
+
+AP_Spektrum_Telem::AP_Spektrum_Telem() : AP_RCTelemetry(0)
+{
+    singleton = this;
+}
+
+AP_Spektrum_Telem::~AP_Spektrum_Telem(void)
+{
+    singleton = nullptr;
+}
+
+bool AP_Spektrum_Telem::init(void)
+{
+    // sanity check that we are using a UART for RC input
+    if (!AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_RCIN, 0)) {
+        return false;
+    }
+    return AP_RCTelemetry::init();
+}
+
+/*
+  setup ready for passthrough telem
+ */
+void AP_Spektrum_Telem::setup_wfq_scheduler(void)
+{
+    // initialize packet weights for the WFQ scheduler
+    // priority[i] = 1/_scheduler.packet_weight[i]
+    // rate[i] = LinkRate * ( priority[i] / (sum(priority[1-n])) )
+
+    // Spektrum telemetry rate is 46Hz, so these rates must fit
+    add_scheduler_entry(50, 100);   // qos        10Hz
+    add_scheduler_entry(50, 100);   // rpm        10Hz
+    add_scheduler_entry(50, 100);   // text,      10Hz
+    add_scheduler_entry(50, 120);   // Attitude and compass 8Hz
+    add_scheduler_entry(550, 280);  // GPS        3Hz
+    add_scheduler_entry(550, 280);  // ESC        3Hz
+    add_scheduler_entry(400, 250);  // altitude   4Hz
+    add_scheduler_entry(400, 250);  // airspeed   4Hz
+    add_scheduler_entry(700, 500);  // GPS status 2Hz
+    add_scheduler_entry(1300, 500); // batt volt  2Hz
+    add_scheduler_entry(1300, 500); // batt curr  2Hz
+    add_scheduler_entry(1300, 500); // batt mah   2Hz
+    add_scheduler_entry(1300, 500); // temp       2Hz
+}
+
+void AP_Spektrum_Telem::adjust_packet_weight(bool queue_empty)
+{
+    if (!queue_empty) {
+        _scheduler.packet_weight[TEXT] = 50;         // messages
+    } else {
+        _scheduler.packet_weight[TEXT] = 5000;        // messages
+    }
+}
+
+// WFQ scheduler
+bool AP_Spektrum_Telem::is_packet_ready(uint8_t idx, bool queue_empty)
+{
+    bool packet_ready = false;
+    switch (idx) {
+    case TEXT:
+        packet_ready = !queue_empty;
+        break;
+    default:
+        packet_ready = true;
+        break;
+    }
+
+    return packet_ready;
+}
+
+// WFQ scheduler
+void AP_Spektrum_Telem::process_packet(uint8_t idx)
+{
+    // send packet
+    switch (idx) {
+        case QOS: // QOS
+            calc_qos();
+            break;
+        case RPM: // RPM
+            calc_rpm();
+            break;
+        case TEXT: // status text
+            if (repeat_msg_chunk() || get_next_msg_chunk()) {
+                send_msg_chunk(_msg_chunk);
+            }
+            break;
+        case ATTITUDE: // Attitude and compass
+            calc_attandmag();
+            break;
+        case GPS_LOC: // GPS location
+            calc_gps_location();
+            break;
+        case ESC: // ESC
+            calc_esc();
+            break;
+        case ALTITUDE: // altitude
+            calc_altitude();
+            break;
+        case AIRSPEED: // airspeed
+            calc_airspeed();
+            break;
+        case GPS_STATUS: // GPS status
+            calc_gps_status();
+            break;
+        case VOLTAGE: // Battery volts
+            calc_batt_volts(0);
+            break;
+        case AMPS: // Battery current
+            calc_batt_amps(0);
+            break;
+        case MAH: // Battery current & mah
+            calc_batt_mah();
+            break;
+        case TEMP: // temperature
+            calc_temperature(0);
+            break;
+        default:
+            break;
+    }
+}
+
+// whether to repeat the last texgen output
+bool AP_Spektrum_Telem::repeat_msg_chunk(void)
+{
+    if (_msg_chunk.repeats == 0) {
+        return false;
+    }
+
+    // repeat each message chunk 3 times to ensure transmission
+    // on slow links reduce the number of duplicate chunks
+    uint8_t extra_chunks = 2;
+
+    if (_scheduler.avg_packet_rate < 20) {
+        extra_chunks = 0;
+    } else if (_scheduler.avg_packet_rate < 30) {
+        extra_chunks = 1;
+    }
+
+    if (_msg_chunk.repeats++ > extra_chunks) {
+        _msg_chunk.repeats = 0;
+        return false;
+    }
+    return true;
+}
+
+
+// grabs one "chunk" (13 bytes) of the queued message to be transmitted
+bool AP_Spektrum_Telem::get_next_msg_chunk(void)
+{
+    _msg_chunk.repeats++;
+
+    if (!_statustext.available) {
+        WITH_SEMAPHORE(_statustext.sem);
+        if (!_statustext.queue.pop(_statustext.next)) {
+            return false;
+        }
+
+        _statustext.available = true;
+
+        // We're going to display a new message so first clear the screen
+        _msg_chunk.linenumber = 0xFF;
+        _msg_chunk.char_index = 0;
+        return true;
+    }
+
+    uint8_t character = 0;
+    memset(_msg_chunk.chunk, 0, MAX_TEXTGEN_LEN);
+
+    const uint8_t message_len = sizeof(_statustext.next.text);
+    // the message fits in an entire line of text
+    if (message_len < MAX_TEXTGEN_LEN) {
+        memcpy(_msg_chunk.chunk, _statustext.next.text, message_len);
+        _msg_chunk.linenumber = 0;
+        _statustext.available = false;
+        return true;
+    }
+
+    // a following part of multi-line text
+    if (_msg_chunk.linenumber == 0xFF) {
+        _msg_chunk.linenumber = 0;
+    } else if (_msg_chunk.char_index > 0) {
+        _msg_chunk.linenumber++;
+    }
+
+    // skip leading whitespace
+    while (_statustext.next.text[_msg_chunk.char_index] == ' ' && _msg_chunk.char_index < message_len) {
+        _msg_chunk.char_index++;
+    }
+
+    uint8_t space_idx = 0;
+    const uint8_t begin_idx = _msg_chunk.char_index;
+    // can't fit it all on one line so wrap at an appropriate place
+    for (int i = 0; i < MAX_TEXTGEN_LEN && _msg_chunk.char_index < message_len; i++) {
+        character = _statustext.next.text[_msg_chunk.char_index++];
+        // split at the first ':'
+        if (character == ':') {
+            _msg_chunk.chunk[i] = 0;
+            break;
+        }
+        // record the last space if we need to go back there
+        if (character == ' ') {
+            space_idx = _msg_chunk.char_index;
+        }
+
+        _msg_chunk.chunk[i] = character;
+
+        if (!character) {
+            break;
+        }
+    }
+    // still not done, can we break at a word boundary?
+    if (character != 0 && _msg_chunk.char_index < message_len && space_idx > 0) {
+        _msg_chunk.char_index = space_idx;
+        _msg_chunk.chunk[space_idx - begin_idx - 1] = 0;
+    }
+
+    // we've reached the end of the message (string terminated by '\0' or last character of the string has been processed)
+    if (character == 0 || _msg_chunk.char_index == message_len) {
+        _msg_chunk.char_index = 0; // reset index to get ready to process the next message
+        _statustext.available = false;
+    }
+
+    return true;
+}
+
+// prepare qos data - mandatory frame that must be sent periodically
+void AP_Spektrum_Telem::calc_qos()
+{
+    _telem.qos.identifier = TELE_DEVICE_QOS;
+    _telem.qos.sID = 0;
+    _telem.qos.A = 0xFFFF;
+    _telem.qos.B = 0xFFFF;
+    _telem.qos.L = 0xFFFF;
+    _telem.qos.R = 0xFFFF;
+    _telem.qos.F = 0xFFFF;
+    _telem.qos.H = 0xFFFF;
+    _telem.qos.rxVoltage = 0xFFFF;
+    _telem_pending = true;
+}
+
+// prepare rpm data - B/E mandatory frame that must be sent periodically
+void AP_Spektrum_Telem::calc_rpm()
+{
+    const AP_BattMonitor &_battery = AP::battery();
+
+    _telem.rpm.identifier = TELE_DEVICE_RPM;
+    _telem.rpm.sID = 0;
+    // battery voltage in centivolts, can have up to a 12S battery (4.25Vx12S = 51.0V)
+    _telem.rpm.volts = htobe16(((uint16_t)roundf(_battery.voltage(0) * 100.0f)));
+    _telem.rpm.temperature = htobe16(int16_t(roundf(32.0f + AP::baro().get_temperature(0) * 9.0f / 5.0f)));
+    const AP_RPM *rpm = AP::rpm();
+    float rpm_value;
+    if (!rpm || !rpm->get_rpm(0, rpm_value) || rpm_value < 999.0f) {
+        rpm_value = 999.0f;
+    }
+    _telem.rpm.microseconds = htobe16(uint16_t(roundf(MICROSEC_PER_MINUTE / rpm_value)));
+    _telem.rpm.dBm_A = 0x7F;
+    _telem.rpm.dBm_B = 0x7F;
+    _telem_pending = true;
+}
+
+void AP_Spektrum_Telem::send_msg_chunk(const MessageChunk& chunk)
+{
+    memcpy(_telem.textgen.text, chunk.chunk, 13);
+    _telem.textgen.identifier = TELE_DEVICE_TEXTGEN;
+    _telem.textgen.lineNumber = chunk.linenumber;
+    _telem.textgen.sID = 0;
+    _telem_pending = true;
+}
+
+// prepare battery data - B/E but not supported by Spektrum
+void AP_Spektrum_Telem::calc_batt_volts(uint8_t instance)
+{
+    const AP_BattMonitor &_battery = AP::battery();
+
+    // battery voltage in centivolts, can have up to a 12S battery (4.25Vx12S = 51.0V)
+    _telem.hv.volts = htobe16(uint16_t(roundf(_battery.voltage(instance) * 100.0f)));
+    _telem.hv.identifier = TELE_DEVICE_VOLTAGE;
+    _telem.hv.sID = 0;
+    _telem_pending = true;
+}
+
+// prepare battery data - B/E but not supported by Spektrum
+void AP_Spektrum_Telem::calc_batt_amps(uint8_t instance)
+{
+    const AP_BattMonitor &_battery = AP::battery();
+
+    float current;
+    if (!_battery.current_amps(current, instance)) {
+        current = 0;
+    }
+
+    // Range: +/- 150A     Resolution: 300A / 2048 = 0.196791 A/count
+    _telem.amps.current = htobe16(int16_t(roundf(current * 2048.0f / 300.0f)));
+    _telem.amps.identifier = TELE_DEVICE_AMPS;
+    _telem.amps.sID = 0;
+    _telem_pending = true;
+}
+
+// prepare battery data - L/E
+void AP_Spektrum_Telem::calc_batt_mah()
+{
+    const AP_BattMonitor &_battery = AP::battery();
+
+    _telem.fpMAH.identifier = TELE_DEVICE_FP_MAH;
+    _telem.fpMAH.sID = 0;
+
+    float current;
+    if (!_battery.current_amps(current, 0)) {
+        current = 0;
+    }
+    _telem.fpMAH.current_A = int16_t(roundf(current * 10.0f));     // Instantaneous current, 0.1A (0-3276.6A)
+
+    float used_mah;
+    if (!_battery.consumed_mah(used_mah, 0)) {
+        used_mah = 0;
+    }
+    _telem.fpMAH.chargeUsed_A = int16_t(roundf(used_mah));         // Integrated mAh used, 1mAh (0-32.766Ah)
+
+    float temp;
+    if (_battery.get_temperature(temp, 0)) {
+         _telem.fpMAH.temp_A = uint16_t(roundf(temp * 10.0f));     // Temperature, 0.1C (0-150C, 0x7FFF indicates not populated)
+    } else {
+        _telem.fpMAH.temp_A = 0x7FFF;
+    }
+
+    if (!_battery.current_amps(current, 1)) {
+        current = 0;
+    }
+    _telem.fpMAH.current_B = int16_t(roundf(current * 10.0f));     // Instantaneous current, 0.1A (0-3276.6A)
+
+    if (!_battery.consumed_mah(used_mah, 1)) {
+        used_mah = 0;
+    }
+    _telem.fpMAH.chargeUsed_B = int16_t(roundf(used_mah));         // Integrated mAh used, 1mAh (0-32.766Ah)
+
+    if (_battery.get_temperature(temp, 1)) {
+         _telem.fpMAH.temp_B = uint16_t(roundf(temp * 10.0f));     // Temperature, 0.1C (0-150C, 0x7FFF indicates not populated)
+    } else {
+        _telem.fpMAH.temp_B = 0x7FFF;
+    }
+
+    _telem_pending = true;
+}
+
+// prepare temperature data - B/E but not supported by Spektrum
+void AP_Spektrum_Telem::calc_temperature(uint8_t instance)
+{
+    _telem.temp.temperature = htobe16(int16_t(roundf(32.0f + AP::baro().get_temperature(instance) * 9.0f / 5.0f)));
+    _telem.temp.identifier = TELE_DEVICE_TEMPERATURE;
+    _telem.temp.sID = 0;
+    _telem_pending = true;
+}
+
+// prepare altitude data - B/E
+void AP_Spektrum_Telem::calc_altitude()
+{
+    _telem.alt.identifier = TELE_DEVICE_ALTITUDE;
+    _telem.alt.sID = 0;
+
+    AP_AHRS &ahrs = AP::ahrs();
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+
+    float alt = 0;
+    ahrs.get_relative_position_D_home(alt);
+    alt = roundf(-alt * 10.0f);
+    _telem.alt.altitude = htobe16(uint16_t(alt));            // .1m increments
+    _max_alt = MAX(alt, _max_alt);
+    _telem.alt.maxAltitude = htobe16(uint16_t(_max_alt));    // .1m increments
+    _telem_pending = true;
+}
+
+// prepare airspeed data - B/E
+void AP_Spektrum_Telem::calc_airspeed()
+{
+    _telem.speed.identifier = TELE_DEVICE_AIRSPEED;
+    _telem.speed.sID = 0;
+
+    AP_AHRS &ahrs = AP::ahrs();
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+
+    const AP_Airspeed *airspeed = ahrs.get_airspeed();
+    float speed = 0.0f;
+    if (airspeed && airspeed->healthy()) {
+        speed = roundf(airspeed->get_airspeed() * 3.6);
+    } else {
+        speed = roundf(AP::ahrs().groundspeed() * 3.6);
+    }
+    _telem.speed.airspeed = htobe16(uint16_t(speed));           // 1 km/h increments
+    _max_speed = MAX(speed, _max_speed);
+    _telem.speed.maxAirspeed = htobe16(uint16_t(_max_speed));   // 1 km/h increments
+    _telem_pending = true;
+}
+
+// prepare attitude and compass data - L/E
+void AP_Spektrum_Telem::calc_attandmag(void)
+{
+    _telem.attMag.identifier = TELE_DEVICE_ATTMAG;
+    _telem.attMag.sID = 0;
+
+    AP_AHRS &_ahrs = AP::ahrs();
+    WITH_SEMAPHORE(_ahrs.get_semaphore());
+
+    // Attitude, 3 axes.  Roll is a rotation about the X Axis of the vehicle using the RHR.
+    // Units are 0.1 deg - Pitch is a rotation about the Y Axis of the vehicle using the RHR.
+    // Yaw is a rotation about the Z Axis of the vehicle using the RHR.
+    _telem.attMag.attRoll = _ahrs.roll_sensor / 10;
+    _telem.attMag.attPitch = _ahrs.pitch_sensor / 10;
+    _telem.attMag.attYaw = _ahrs.yaw_sensor / 10;
+    _telem.attMag.heading = (_ahrs.yaw_sensor / 10) % 3600;  // Heading, 0.1deg
+
+    const Vector3f& field = AP::compass().get_field();
+
+    _telem.attMag.magX = int16_t(roundf(field.x * 10.0f));             // Units are 0.1mG
+    _telem.attMag.magY = int16_t(roundf(field.y * 10.0f));
+    _telem.attMag.magZ = int16_t(roundf(field.z * 10.0f));
+    _telem_pending = true;
+}
+
+// prepare gps location - L/E
+void AP_Spektrum_Telem::calc_gps_location()
+{
+    const Location &loc = AP::gps().location(0); // use the first gps instance (same as in send_mavlink_gps_raw)
+    const uint32_t u1e8 = 100000000, u1e7 = 10000000, u1e6 = 1000000, u1e5 = 100000, u1e4 = 10000;
+
+    _telem.gpsloc.identifier = TELE_DEVICE_GPS_LOC;                 // Source device = 0x16
+    _telem.gpsloc.sID = 0;                                          // Secondary ID
+    uint32_t alt = (abs(loc.alt) / 10) % u1e6;
+    _telem.gpsloc.altitudeLow = ((alt % u1e4 / 1000) << 12) | ((alt % 1000 / 100) << 8)
+        | ((alt % 100 / 10) << 4) | (alt % 100); // BCD, meters, format 3.1 (Low order of altitude)
+
+    const float lat = fabsf(loc.lat / 1.0e7f);                       // BCD, format 4.4, Degrees * 100 + minutes, less than 100 degrees
+    const float lng = fabsf(loc.lng / 1.0e7f);                       // BCD, format 4.4 , Degrees * 100 + minutes, flag indicates > 99 degrees
+
+    const uint32_t ulat = roundf((int32_t(lat) * 100.0f + (lat - int32_t(lat)) * 60.0f) * 10000.0f);
+    const uint32_t ulng = roundf((int32_t(lng) * 100.0f + (lng - int32_t(lng)) * 60.0f) * 10000.0f);
+
+    _telem.gpsloc.latitude = ((ulat % u1e8 / u1e7) << 28) | ((ulat % u1e7 / u1e6) << 24) | ((ulat % u1e6 / u1e5) << 20) | ((ulat % u1e5 / u1e4) << 16)
+        | ((ulat % u1e4 / 1000) << 12) | ((ulat % 1000 / 100) << 8) | ((ulat % 100 / 10) << 4) | (ulat % 10);
+    _telem.gpsloc.longitude = ((ulng % u1e8 / u1e7) << 28) | ((ulng % u1e7 / u1e6) << 24) | ((ulng % u1e6 / u1e5) << 20) | ((ulng % u1e5 / u1e4) << 16)
+        | ((ulng % u1e4 / 1000) << 12) | ((ulng % 1000 / 100) << 8) | ((ulng % 100 / 10) << 4) | (ulng % 10);
+
+    uint16_t course = uint16_t(roundf(AP::gps().ground_course() * 10.0f));
+    _telem.gpsloc.course = ((course % u1e5 / u1e4) << 12) | ((course % u1e4 / 1000) << 8)  | ((course % 1000 / 100) << 4) | (course % 100 / 10);  // BCD, 3.1
+    uint16_t hdop = AP::gps().get_hdop(0);
+    _telem.gpsloc.HDOP = ((hdop % 1000 / 100) << 4) | (hdop % 100 / 10); // BCD, format 1.1
+    _telem.gpsloc.GPSflags = 0;
+
+    if (AP::gps().status(0) >= AP_GPS::GPS_OK_FIX_3D) {
+        _telem.gpsloc.GPSflags |= GPS_INFO_FLAGS_3D_FIX;
+    }
+    if (loc.alt < 0) {
+        _telem.gpsloc.GPSflags |= GPS_INFO_FLAGS_NEGATIVE_ALT;
+    }
+    if ((loc.lng / 1e7) > 99) {
+        _telem.gpsloc.GPSflags |= GPS_INFO_FLAGS_LONGITUDE_GREATER_99;
+    }
+    if (loc.lat >= 0) {
+        _telem.gpsloc.GPSflags |= GPS_INFO_FLAGS_IS_NORTH;
+    }
+    if (loc.lng >= 0) {
+        _telem.gpsloc.GPSflags |= GPS_INFO_FLAGS_IS_EAST;
+    }
+    if (AP::gps().status(0) > AP_GPS::NO_FIX) {
+        _telem.gpsloc.GPSflags |= GPS_INFO_FLAGS_GPS_FIX_VALID;
+    }
+    if (AP::gps().status(0) >= AP_GPS::NO_FIX) {
+        _telem.gpsloc.GPSflags |= GPS_INFO_FLAGS_GPS_DATA_RECEIVED;
+    }
+    _telem_pending = true;
+}
+
+// prepare gps status - L/E
+void AP_Spektrum_Telem::calc_gps_status()
+{
+    const Location &loc = AP::gps().location(0);
+
+    _telem.gpsstat.identifier = TELE_DEVICE_GPS_STATS;              // Source device = 0x17
+    _telem.gpsstat.sID = 0;                                         // Secondary ID
+
+    uint16_t knots = roundf(AP::gps().ground_speed() * 1.94384f * 10.0f);
+    _telem.gpsstat.speed = ((knots % 10000 / 1000) << 12) | ((knots % 1000 / 100) << 8) | ((knots % 100 / 10) << 4) | (knots % 10); // BCD, knots, format 3.1
+    uint16_t ms;
+    uint8_t h, m, s;
+    AP::rtc().get_system_clock_utc(h, m, s, ms);                    // BCD, format HH:MM:SS.S, format 6.1
+    _telem.gpsstat.UTC = ((((h / 10) << 4) | (h % 10)) << 20) | ((((m / 10) << 4) | (m % 10)) << 12) | ((((s / 10) << 4) | (s % 10)) << 4) | (ms / 100) ;
+    uint8_t nsats =  AP::gps().num_sats();
+    _telem.gpsstat.numSats = ((nsats / 10) << 4) | (nsats % 10);    // BCD, 0-99
+    uint32_t alt = (abs(loc.alt) / 100000);
+    _telem.gpsstat.altitudeHigh = ((alt / 10) << 4) | (alt % 10); // BCD, meters, format 2.0 (High order of altitude)
+    _telem_pending = true;
+}
+
+// prepare ESC information - B/E
+void AP_Spektrum_Telem::calc_esc()
+{
+#ifdef HAVE_AP_BLHELI_SUPPORT
+    AP_BLHeli* blh = AP_BLHeli::get_singleton();
+
+    if (blh == nullptr) {
+        return;
+    }
+
+    AP_BLHeli::telem_data td;
+
+    if (!blh->get_telem_data(0, td)) {
+        return;
+    }
+
+	_telem.esc.identifier = TELE_DEVICE_ESC;	    // Source device = 0x20
+	_telem.esc.sID = 0;									// Secondary ID
+	_telem.esc.RPM = htobe16(uint16_t(roundf(blh->get_average_motor_frequency_hz() * 60)));	// Electrical RPM, 10RPM (0-655340 RPM)  0xFFFF --> "No data"
+	_telem.esc.voltsInput = htobe16(td.voltage);	    // Volts, 0.01v (0-655.34V)       0xFFFF --> "No data"
+	_telem.esc.tempFET = htobe16(td.temperature * 10);	// Temperature, 0.1C (0-6553.4C)  0xFFFF --> "No data"
+	_telem.esc.currentMotor = htobe16(td.current);		// Current, 10mA (0-655.34A)      0xFFFF --> "No data"
+	_telem.esc.tempBEC = 0xFFFF;						// Temperature, 0.1C (0-6553.4C)  0xFFFF --> "No data"
+	_telem.esc.currentBEC = 0xFF;						// BEC Current, 100mA (0-25.4A)   0xFF ----> "No data"
+	_telem.esc.voltsBEC = 0xFF;							// BEC Volts, 0.05V (0-12.70V)    0xFF ----> "No data"
+	_telem.esc.throttle = 0xFF;							// 0.5% (0-100%)                  0xFF ----> "No data"
+	_telem.esc.powerOut = 0xFF;							// Power Output, 0.5% (0-127%)    0xFF ----> "No data"
+    _telem_pending = true;
+#endif
+}
+
+/*
+  fetch Spektrum data for an external transport, such as SRXL2
+ */
+bool AP_Spektrum_Telem::_get_telem_data(uint8_t* data)
+{
+    memset(&_telem, 0, 16);
+    run_wfq_scheduler();
+    if (!_telem_pending) {
+        return false;
+    }
+    memcpy(data, &_telem, 16);
+    _telem_pending = false;
+    return true;
+}
+
+/*
+  fetch data for an external transport, such as SRXL2
+ */
+bool AP_Spektrum_Telem::get_telem_data(uint8_t* data)
+{
+    if (!singleton && !hal.util->get_soft_armed()) {
+        // if telem data is requested when we are disarmed and don't
+        // yet have a AP_Spektrum_Telem object then try to allocate one
+        new AP_Spektrum_Telem();
+        // initialize the passthrough scheduler
+        if (singleton) {
+            singleton->init();
+        }
+    }
+    if (!singleton) {
+        return false;
+    }
+    return singleton->_get_telem_data(data);
+}
+
+namespace AP {
+    AP_Spektrum_Telem *spektrum_telem() {
+        return AP_Spektrum_Telem::get_singleton();
+    }
+};
+
+#endif

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.h
@@ -1,0 +1,147 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#ifndef HAL_SPEKTRUM_TELEM_ENABLED
+#define HAL_SPEKTRUM_TELEM_ENABLED !HAL_MINIMIZE_FEATURES
+#endif
+
+#if HAL_SPEKTRUM_TELEM_ENABLED
+
+#include <AP_Notify/AP_Notify.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_HAL/utility/RingBuffer.h>
+#include "AP_RCTelemetry.h"
+
+#define UINT8 uint8_t
+#define UINT16 uint16_t
+#define UINT32 uint32_t
+#define UINT64 uint64_t
+#define INT8 int8_t
+#define INT16 int16_t
+#define INT32 int32_t
+extern "C" {
+#include "spektrumTelemetrySensors.h"
+}
+#undef UINT8
+#undef UINT16
+#undef UINT32
+#undef UINT64
+#undef INT8
+#undef INT16
+#undef INT32
+
+class AP_Spektrum_Telem : public AP_RCTelemetry {
+public:
+    AP_Spektrum_Telem();
+    ~AP_Spektrum_Telem() override;
+
+    /* Do not allow copies */
+    AP_Spektrum_Telem(const AP_Spektrum_Telem &other) = delete;
+    AP_Spektrum_Telem &operator=(const AP_Spektrum_Telem&) = delete;
+
+    // init - perform required initialisation
+    virtual bool init() override;
+
+    static AP_Spektrum_Telem *get_singleton(void) {
+        return singleton;
+    }
+
+    // get next telemetry data for external consumers of SPort data
+    static bool get_telem_data(uint8_t* data);
+
+private:
+
+    enum SensorType {
+        QOS,
+        RPM,
+        TEXT,
+        ATTITUDE,
+        GPS_LOC,
+        ESC,
+        ALTITUDE,
+        AIRSPEED,
+        GPS_STATUS,
+        VOLTAGE,
+        AMPS,
+        MAH,
+        TEMP,
+        NUM_SENSORS
+    };
+
+    struct MessageChunk
+    {
+        uint8_t chunk[13]; // a "chunk" (13 characters/bytes) at a time of the queued message to be sent
+        uint8_t linenumber;
+        uint8_t char_index; // index of which character to get in the message
+        uint8_t repeats;
+    } _msg_chunk;
+
+    float _max_speed = 0.0f;
+    float _max_alt = 0.0f;
+
+    // passthrough WFQ scheduler
+    // Text Generator
+    bool get_next_msg_chunk(void) override;
+    bool repeat_msg_chunk(void);
+    void send_msg_chunk(const MessageChunk& message);
+    bool is_packet_ready(uint8_t idx, bool queue_empty) override;
+    void process_packet(uint8_t idx) override;
+    void adjust_packet_weight(bool queue_empty) override;
+    // RxV + flight log data
+    void calc_qos();
+    // High-Voltage sensor
+    void calc_batt_volts(uint8_t instance);
+    // Temperature Sensor
+    void calc_temperature(uint8_t instance);
+    // Amps
+    void calc_batt_amps(uint8_t instance);
+    // Flight Battery Capacity (Dual)
+    void calc_batt_mah();
+    // Altitude (Eagle Tree Sensor)
+    void calc_altitude();
+    // Air Speed (Eagle Tree Sensor)
+    void calc_airspeed();
+    // Attitude and Magnetic Compass
+    void calc_attandmag();
+    // GPS Location Data (Eagle Tree)
+    void calc_gps_location();
+    // GPS Status (Eagle Tree)
+    void calc_gps_status();
+    // Electronic Speed Control
+    void calc_esc();
+    // RPM sensor
+    void calc_rpm();
+
+     // setup ready for passthrough operation
+    void setup_wfq_scheduler(void) override;
+
+     // get next telemetry data for external consumers of SPort data (internal function)
+    bool _get_telem_data(uint8_t* data);
+
+    // all Spektrum telemtry packets are big-endian!
+    PACKED UN_TELEMETRY _telem;
+    bool _telem_pending;
+
+    static AP_Spektrum_Telem *singleton;
+};
+
+namespace AP {
+    AP_Spektrum_Telem *spektrum_telem();
+};
+
+#endif

--- a/libraries/AP_RCTelemetry/spektrumTelemetrySensors.h
+++ b/libraries/AP_RCTelemetry/spektrumTelemetrySensors.h
@@ -1,0 +1,1354 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Copyright 2013 by Horizon Hobby, Inc.
+//	All Rights Reserved Worldwide.
+//
+//	Released to Public Domain
+//
+//	This header file may be incorporated into non-Horizon
+//	products.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Author:		AK
+//	Date:		2017-02-24
+//	Mods:		Sync to Spektrum internal version by matching sequence of
+//				structs, formatting, etc.  Also changed some structs from
+//				having "id" to "identifier."  Also redefined "spare" in Rx MAH
+//				to provide more bits for "chargeUsed" fields.
+//
+#ifndef TELEMETRY_H
+#define	TELEMETRY_H
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//				TELEMETRY SENSOR I2C ADDRESSES & DEVICE TYPES
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#define	TELE_DEVICE_NODATA			(0x00)										// No data in packet, but telemetry is alive
+#define	TELE_DEVICE_VOLTAGE			(0x01)										// High-Voltage sensor (INTERNAL)
+#define	TELE_DEVICE_TEMPERATURE		(0x02)										// Temperature Sensor (INTERNAL)
+#define	TELE_DEVICE_AMPS			(0x03)										// Amps (INTERNAL)
+#define	TELE_DEVICE_RSV_04			(0x04)										// Reserved
+#define	TELE_DEVICE_FLITECTRL		(0x05)										// Flight Controller Status Report
+#define	TELE_DEVICE_RSV_06			(0x06)										// Reserved
+#define	TELE_DEVICE_RSV_07			(0x07)										// Reserved
+#define	TELE_DEVICE_RSV_08			(0x08)										// Reserved
+//#define	DO_NOT_USE				(0x09)										// DO NOT USE!
+#define	TELE_DEVICE_PBOX			(0x0A)										// PowerBox
+#define	TELE_DEVICE_LAPTIMER		(0x0B)										// Lap Timer
+#define	TELE_DEVICE_TEXTGEN			(0x0C)										// Text Generator
+#define	TELE_DEVICE_VTX				(0x0D)										// Video Transmitter Feedback
+#define	TELE_DEVICE_RSV_0E			(0x0E)										// Reserved
+#define	TELE_DEVICE_RSV_0F			(0x0F)										// Reserved
+#define	TELE_DEVICE_RSV_10			(0x10)										// Reserved
+#define	TELE_DEVICE_AIRSPEED		(0x11)										// Air Speed (Eagle Tree Sensor)
+#define	TELE_DEVICE_ALTITUDE		(0x12)										// Altitude (Eagle Tree Sensor)
+#define	TELE_DEVICE_RSV_13			(0x13)										// Reserved
+#define	TELE_DEVICE_GMETER			(0x14)										// G-Force (Eagle Tree Sensor)
+#define	TELE_DEVICE_JETCAT			(0x15)										// Turbine interface (Eagle Tree)
+#define	TELE_DEVICE_GPS_LOC			(0x16)										// GPS Location Data (Eagle Tree)
+#define	TELE_DEVICE_GPS_STATS		(0x17)										// GPS Status (Eagle Tree)
+#define	TELE_DEVICE_RX_MAH			(0x18)										// Receiver Pack Capacity (Dual)
+#define	TELE_DEVICE_JETCAT_2		(0x19)										// Turbine interface, message 2 format (Eagle Tree)
+#define	TELE_DEVICE_GYRO			(0x1A)										// 3-axis gyro
+#define	TELE_DEVICE_ATTMAG			(0x1B)										// Attitude and Magnetic Compass
+#define	TELE_DEVICE_TILT			(0x1C)										// Surface Tilt Sensor
+#define	TELE_DEVICE_RSV_1D			(0x1D)										// Reserved
+#define	TELE_DEVICE_AS6X_GAIN		(0x1E)										// Active AS6X Gains (new mode)
+#define	TELE_DEVICE_AS3X_LEGACYGAIN	(0x1F)										// Active AS3X Gains for legacy mode
+#define	TELE_DEVICE_ESC				(0x20)										// Electronic Speed Control
+#define	TELE_DEVICE_RSV_21			(0x21)										// Reserved
+#define	TELE_DEVICE_FUEL			(0x22)										// Fuel Flow Meter
+#define	TELE_DEVICE_RSV_23			(0x23)										// Reserved
+#define	TELE_DEVICE_ALPHA6			(0x24)										// Alpha6 Stabilizer
+#define	TELE_DEVICE_RSV_25			(0x25)										// Reserved
+#define	TELE_DEVICE_GPS_BINARY		(0x26)										// GPS, binary format
+#define	TELE_DEVICE_RSV_27			(0x27)										// Reserved
+#define	TELE_DEVICE_RSV_28			(0x28)										// Reserved
+#define	TELE_DEVICE_RSV_29			(0x29)										// Reserved
+#define	TELE_DEVICE_RSV_2A			(0x2A)										// Reserved
+#define	TELE_DEVICE_RSV_2B			(0x2B)										// Reserved
+#define	TELE_DEVICE_RSV_2C			(0x2C)										// Reserved
+#define	TELE_DEVICE_RSV_2D			(0x2D)										// Reserved
+#define	TELE_DEVICE_RSV_2E			(0x2E)										// Reserved
+#define	TELE_DEVICE_RSV_2F			(0x2F)										// Reserved
+//#define	DO_NOT_USE				(0x30)										// Internal ST sensor
+//#define	DO_NOT_USE				(0x32)										// Internal ST sensor
+#define	TELE_DEVICE_RSV_33			(0x33)										// Reserved
+#define	TELE_DEVICE_FP_MAH			(0x34)										// Flight Battery Capacity (Dual)
+#define	TELE_DEVICE_RSV_35			(0x35)										// Reserved
+#define	TELE_DEVICE_DIGITAL_AIR		(0x36)										// Digital Inputs & Tank Pressure
+#define	TELE_DEVICE_RSV_37			(0x37)										// Reserved
+#define	TELE_DEVICE_STRAIN			(0x38)										// Thrust/Strain Gauge
+#define	TELE_DEVICE_RSV_39			(0x39)										// Reserved
+#define	TELE_DEVICE_LIPOMON			(0x3A)										// 6S Cell Monitor (LiPo taps)
+#define	TELE_DEVICE_RSV_3B			(0x3B)										// Reserved
+#define	TELE_DEVICE_RSV_3C			(0x3C)										// Reserved
+#define	TELE_DEVICE_RSV_3D			(0x3D)										// Reserved
+#define	TELE_DEVICE_RSV_3E			(0x3E)										// Reserved
+#define	TELE_DEVICE_LIPOMON_14		(0x3F)										// 14S Cell Monitor (LiPo taps)
+#define	TELE_DEVICE_VARIO_S			(0x40)										// Vario
+#define	TELE_DEVICE_RSV_41			(0x41)										// Reserved
+#define	TELE_DEVICE_SMARTBATT		(0x42)										// Spektrum SMART Battery (multiple structs)
+#define	TELE_DEVICE_RSV_43			(0x43)										// Reserved
+#define	TELE_DEVICE_RSV_44			(0x44)										// Reserved
+#define	TELE_DEVICE_RSV_45			(0x45)										// Reserved
+#define	TELE_DEVICE_RSV_46			(0x46)										// Reserved
+#define	TELE_DEVICE_RSV_47			(0x47)										// Reserved
+#define	TELE_DEVICE_RSV_48			(0x48)										// Reserved
+#define	TELE_DEVICE_RSV_49			(0x49)										// Reserved
+#define	TELE_DEVICE_RSV_4A			(0x4A)										// Reserved
+#define	TELE_DEVICE_RSV_4B			(0x4B)										// Reserved
+#define	TELE_DEVICE_RSV_4C			(0x4C)										// Reserved
+#define	TELE_DEVICE_RSV_4D			(0x4D)										// Reserved
+#define	TELE_DEVICE_RSV_4E			(0x4E)										// Reserved
+#define	TELE_DEVICE_RSV_4F			(0x4F)										// Reserved
+#define	TELE_DEVICE_USER_16SU		(0x50)										// User-Defined, STRU_TELE_USER_16SU
+#define	TELE_DEVICE_RSV_51			(0x51)										// Reserved
+#define	TELE_DEVICE_USER_16SU32U	(0x52)										// User-Defined, STRU_TELE_USER_16SU32U
+#define	TELE_DEVICE_RSV_53			(0x53)										// Reserved
+#define	TELE_DEVICE_USER_16SU32S	(0x54)										// User-Defined, STRU_TELE_USER_16SU32S
+#define	TELE_DEVICE_RSV_55			(0x55)										// Reserved
+#define	TELE_DEVICE_USER_16U32SU	(0x56)										// User-Defined, STRU_TELE_USER_16U32SU
+#define	TELE_DEVICE_RSV_57			(0x57)										// Reserved
+#define	TELE_DEVICE_RSV_58			(0x58)										// Reserved
+#define	TELE_DEVICE_MULTICYLINDER	(0x59)										// Multi-cylinder temp sensor
+#define	TELE_DEVICE_RSV_5A			(0x5A)										// Reserved
+#define	TELE_DEVICE_RSV_5B			(0x5B)										// Reserved
+#define	TELE_DEVICE_RSV_5C			(0x5C)										// Reserved
+#define	TELE_DEVICE_RSV_5D			(0x5D)										// Reserved
+#define	TELE_DEVICE_RSV_5E			(0x5E)										// Reserved
+#define	TELE_DEVICE_RSV_5F			(0x5F)										// Reserved
+#define	TELE_DEVICE_VSPEAK			(0x60)										// Reserved for V-Speak
+#define	TELE_DEVICE_SMOKE_EL		(0x61)										// Reserved for Smoke-EL.de
+#define	TELE_DEVICE_CROSSFIRE		(0x62)										// Reserved for Crossfire devices
+#define	TELE_DEVICE_RSV_63			(0x63)										// Reserved
+#define	TELE_DEVICE_RSV_64			(0x64)										// Reserved
+#define	TELE_DEVICE_RSV_65			(0x65)										// Reserved
+#define	TELE_DEVICE_EXTRF			(0x66)										// Reserved for Generic External RF sources
+#define	TELE_DEVICE_RSV_67			(0x67)										// Reserved
+#define	TELE_DEVICE_RSV_68			(0x68)										// Reserved
+#define	TELE_DEVICE_RSV_69			(0x69)										// Reserved
+#define	TELE_DEVICE_RSV_6A			(0x6A)										// Reserved
+//#define	DO_NOT_USE				(0x6B)										// DO NOT USE!
+#define	TELE_DEVICE_RSV_6C			(0x6C)										// Reserved
+#define	TELE_DEVICE_RSV_6D			(0x6D)										// Reserved
+#define	TELE_DEVICE_RSV_6E			(0x6E)										// Reserved
+#define	TELE_DEVICE_RSV_6F			(0x6F)										// Reserved
+#define	TELE_DEVICE_RSV_70			(0x70)										// Reserved
+#define	TELE_XRF_LINKSTATUS			(0x71)										// External RF Link Status
+#define	TELE_DEVICE_RSV_72			(0x72)										// Reserved
+#define	TELE_DEVICE_RSV_73			(0x73)										// Reserved
+#define	TELE_DEVICE_RSV_74			(0x74)										// Reserved
+#define	TELE_DEVICE_RSV_75			(0x75)										// Reserved
+#define	TELE_DEVICE_RSV_76			(0x76)										// Reserved
+#define	TELE_DEVICE_RSV_77			(0x77)										// Reserved
+#define	TELE_DEVICE_RSV_78			(0x78)										// Reserved
+#define	TELE_DEVICE_RSV_79			(0x79)										// Reserved
+#define	TELE_DEVICE_RSV_7A			(0x7A)										// Reserved
+#define	TELE_DEVICE_ALT_ZERO		(0x7B)										// Pseudo-device setting Altitude "zero"
+#define	TELE_DEVICE_RTC				(0x7C)										// Pseudo-device giving timestamp
+#define	TELE_DEVICE_RPM				(0x7E)										// RPM sensor
+#define	TELE_DEVICE_QOS				(0x7F)										// RxV + flight log data
+#define	TELE_DEVICE_MAX				(0x7F)										// Last address available
+
+#define	TELE_DEVICE_SHORTRANGE		(0x80)										// OR this bit to indicate data is from a short-range telemetry device (e.g. TM1100)
+
+#define	TELE_DEVICE_MAX_PROGRAM		(0x70)										// Last programmable address when using sID
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							TELEMETRY
+//					DEVICE-SPECIFIC STRUCTURES
+//
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+//
+//		THIRD-PARTY 16-BIT DATA SIGNED/UNSIGNED
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8	identifier;															// Source device = 0x50
+	UINT8	sID;																// Secondary ID
+	INT16	sField1,															// Signed 16-bit data fields
+			sField2,
+			sField3;
+	UINT16	uField1, 															// Unsigned 16-bit data fields
+			uField2,
+			uField3,
+			uField4;
+} STRU_TELE_USER_16SU;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//		THIRD-PARTY 16-BIT SIGNED/UNSIGNED AND 32-BIT UNSIGNED
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8	identifier;															// Source device = 0x52
+	UINT8	sID;																// Secondary ID
+	INT16	sField1,															// Signed 16-bit data fields
+			sField2;
+	UINT16	uField1, 															// Unsigned 16-bit data fields
+			uField2,
+			uField3;
+	UINT32	u32Field; 															// Unsigned 32-bit data field
+} STRU_TELE_USER_16SU32U;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//		THIRD-PARTY 16-BIT SIGNED/UNSIGNED AND 32-BIT SIGNED
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8	identifier;															// Source device = 0x54
+	UINT8	sID;																// Secondary ID
+	INT16	sField1,															// Signed 16-bit data fields
+			sField2;
+	UINT16	uField1, 															// Unsigned 16-bit data fields
+			uField2,
+			uField3;
+	INT32	s32Field; 															// Signed 32-bit data field
+} STRU_TELE_USER_16SU32S;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//		THIRD-PARTY 16-BIT UNSIGNED AND 32-BIT SIGNED/UNSIGNED
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8	identifier;															// Source device = 0x56
+	UINT8	sID;																// Secondary ID
+	UINT16	uField1; 															// Unsigned 16-bit data field
+	INT32	s32Field; 															// Signed 32-bit data field
+	UINT32	u32Field1, 															// Unsigned 32-bit data fields
+			u32Field2;
+} STRU_TELE_USER_16U32SU;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							POWERBOX
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8	identifier;															// Source device = 0x0A
+	UINT8	sID;																// Secondary ID
+	UINT16	volt1;																// Volts, 0.01v
+	UINT16	volt2;																// Volts, 0.01v
+	UINT16	capacity1;															// mAh, 1mAh
+	UINT16	capacity2;															// mAh, 1mAh
+	UINT16	spare16_1;
+	UINT16	spare16_2;
+	UINT8	spare;
+	UINT8	alarms;																// Alarm bitmask (see below)
+} STRU_TELE_POWERBOX;
+
+#define	TELE_PBOX_ALARM_VOLTAGE_1			(0x01)
+#define	TELE_PBOX_ALARM_VOLTAGE_2			(0x02)
+#define	TELE_PBOX_ALARM_CAPACITY_1			(0x04)
+#define	TELE_PBOX_ALARM_CAPACITY_2			(0x08)
+//#define	TELE_PBOX_ALARM_RPM					(0x10)
+//#define	TELE_PBOX_ALARM_TEMPERATURE			(0x20)
+#define	TELE_PBOX_ALARM_RESERVED_1			(0x40)
+#define	TELE_PBOX_ALARM_RESERVED_2			(0x80)
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							VOLTAGE
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x01
+	UINT8		sID;															// Secondary ID
+	UINT16		volts;															// 0.01V increments
+} STRU_TELE_HV;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							TEMPERATURE
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x02
+	UINT8		sID;															// Secondary ID
+	INT16		temperature;													// Temperature in degrees Fahrenheit
+} STRU_TELE_TEMP;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						RX CAPACITY METER
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x18
+	UINT8		sID;															// Secondary ID
+	INT16		current_A;														// Instantaneous current, 0.01A (0-328.7A)		7FFF-> no data
+	UINT16		chargeUsed_A;													// Integrated mAh used, 0.1mAh (0-3276.6mAh)
+	UINT16		volts_A;														// Volts, 0.01V increments (0-16.00V)
+	INT16		current_B;														// Instantaneous current, 0.01A (0-328.7A)		7FFF-> no data/sensor B
+	UINT16		chargeUsed_B;													// Integrated mAh used, 0.1mAh (0-3276.6mAh)
+	UINT16		volts_B;														// Volts, 0.01V increments (0-16.00V)
+	UINT8		alerts,															// Bit mapped alert conditions (see below)
+				highCharge;														// High nybble is extra bits for chargeUsed_B, Low is for chargeUsed_A
+} STRU_TELE_RX_MAH;
+
+#define	RXMAH_PS_ALERT_NONE			(0)											// No alarms
+#define	RXMAH_PS_ALERT_RF_INT		(1 << 0)									// A or internal Remote failure
+#define	RXMAH_PS_ALERT_RF_ANT1		(1 << 1)									// B remote power fault
+#define	RXMAH_PS_ALERT_RF_ANT2		(1 << 2)									// L remote power fault
+#define	RXMAH_PS_ALERT_RF_ANT3		(1 << 3)									// R remote power fault
+#define	RXMAH_PS_ALERT_OVERVOLT_A	(1 << 4) 									// Battery A is over voltage
+#define	RXMAH_PS_ALERT_OVERVOLT_B	(1 << 5) 									// Battery A is over voltage
+#define	RXMAH_PS_ALERT_RFU1			(1 << 6)
+#define	RXMAH_PS_ALERT_RFU2			(1 << 7)
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							HIGH-CURRENT
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x03
+	UINT8		sID;															// Secondary ID
+	INT16		current,														// Range: +/- 150A     Resolution: 300A / 2048 = 0.196791 A/count
+				dummy;															// TBD
+} STRU_TELE_IHIGH;
+
+#define	IHIGH_RESOLUTION_FACTOR						((FP32)(0.196791))
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							SIMPLE VARIO
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x40
+	UINT8		sID;															// Secondary ID
+	INT16		altitude;														// .1m increments
+	INT16		delta_0250ms,													// change in altitude last 250ms, 0.1m/s increments
+				delta_0500ms,													// change in altitude last 500ms, 0.1m/s increments
+				delta_1000ms,													// change in altitude last 1.0 seconds, 0.1m/s increments
+				delta_1500ms,													// change in altitude last 1.5 seconds, 0.1m/s increments
+				delta_2000ms,													// change in altitude last 2.0 seconds, 0.1m/s increments
+				delta_3000ms;													// change in altitude last 3.0 seconds, 0.1m/s increments
+} STRU_TELE_VARIO_S;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							ALTIMETER
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;
+	UINT8		sID;															// Secondary ID
+	INT16		altitude;														// .1m increments
+	INT16		maxAltitude;													// .1m increments
+} STRU_TELE_ALT;																// Eagle Tree Sensor
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							AIRSPEED
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;
+	UINT8		sID;															// Secondary ID
+	UINT16		airspeed;														// 1 km/h increments
+	UINT16		maxAirspeed;													// 1 km/h increments
+} STRU_TELE_SPEED;																// Eagle Tree Sensor
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							LAP TIMER
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;
+	UINT8		sID;															// Secondary ID
+	UINT8		lapNumber;														// Lap last finished
+	UINT8		gateNumber;														// Last gate passed
+	UINT32		lastLapTime;													// Time of lap in 1ms increments (NOT duration)
+	UINT32		gateTime;														// Duration between last 2 gates
+	UINT8		unused[4];
+} STRU_TELE_LAPTIMER;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							TEXT GENERATOR
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;
+	UINT8		sID;															// Secondary ID
+	UINT8		lineNumber;														// Line number to display (0 = title, 1-8 for general, 254 = Refresh backlight, 255 = Erase all text on screen)
+	char		text[13];														// 0-terminated text when < 13 chars
+} STRU_TELE_TEXTGEN;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							VIDEO TRANSMITTER (VTX)
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	VTX spec subject to change. Refer to Spektrum VTX Interfacing document for latest info
+//
+typedef struct
+{
+	UINT8		identifier;
+	UINT8		sID;															// Secondary ID
+	UINT8		band;															// VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A, 5-7 = Reserved)
+	UINT8		channel;														// VTX Channel (0-7)
+	UINT8		pit;															// Pit/Race mode (0 = Race, 1 = Pit). Race = (normal operating) mode. Pit = (reduced power) mode. When PIT is set, it overrides all other power settings.
+	UINT8		power;															// VTX Power (0 = Off, 1 = 1mw to 14mW, 2 = 15mW to 25mW, 3 = 26mW to 99mW, 4 = 100mW to 299mW, 5 = 300mW to 600mW, 6 = 601mW+, 7 = manual control)
+	UINT16		powerDec;														// VTX Power as a decimal 1mw/unit
+	UINT8		region;															// Region (0 = USA, 1 = EU, 0xFF = Not Provided)
+	UINT8		unused[7];														// reserved
+} STRU_TELE_VTX;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							ESC
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Uses big-endian byte order
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x20
+	UINT8		sID;															// Secondary ID
+	UINT16		RPM;															// Electrical RPM, 10RPM (0-655340 RPM)  0xFFFF --> "No data"
+	UINT16		voltsInput;														// Volts, 0.01v (0-655.34V)       0xFFFF --> "No data"
+	UINT16		tempFET;														// Temperature, 0.1C (0-6553.4C)  0xFFFF --> "No data"
+	UINT16		currentMotor;													// Current, 10mA (0-655.34A)      0xFFFF --> "No data"
+	UINT16		tempBEC;														// Temperature, 0.1C (0-6553.4C)  0xFFFF --> "No data"
+	UINT8		currentBEC;														// BEC Current, 100mA (0-25.4A)   0xFF ----> "No data"
+	UINT8		voltsBEC;														// BEC Volts, 0.05V (0-12.70V)    0xFF ----> "No data"
+	UINT8		throttle;														// 0.5% (0-100%)                  0xFF ----> "No data"
+	UINT8		powerOut;														// Power Output, 0.5% (0-127%)    0xFF ----> "No data"
+} STRU_TELE_ESC;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//		(Liquid) Fuel Flow/Capacity (Two Tanks/Engines)
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x22
+	UINT8		sID;															// Secondary ID
+	UINT16		fuelConsumed_A;													// Integrated fuel consumption, 0.1mL
+	UINT16		flowRate_A;														// Instantaneous consumption, 0.01mL/min
+	UINT16		temp_A;															// Temperature, 0.1C (0-655.34C)
+	UINT16		fuelConsumed_B;													// Integrated fuel consumption, 0.1mL
+	UINT16		flowRate_B;														// Instantaneous consumption, 0.01mL/min
+	UINT16		temp_B;															// Temperature, 0.1C (0-655.34C)
+	UINT16		spare;															// Not used
+} STRU_TELE_FUEL;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//		Battery Current/Capacity (Flight Pack Capacity)
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+// AK 2013-11-19 make struct align with 0x03 device
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x34
+	UINT8		sID;															// Secondary ID
+	INT16		current_A;														// Instantaneous current, 0.1A (0-3276.6A)
+	INT16		chargeUsed_A;													// Integrated mAh used, 1mAh (0-32.766Ah)
+	UINT16		temp_A;															// Temperature, 0.1C (0-150C, 0x7FFF indicates not populated)
+	INT16		current_B;														// Instantaneous current, 0.1A (0-3276.6A)
+	INT16		chargeUsed_B;													// Integrated mAh used, 1mAh (0-32.766Ah)
+	UINT16		temp_B;															// Temperature, 0.1C (0-150C, 0x7FFF indicates not populated)
+	UINT16		spare;															// Not used
+} STRU_TELE_FP_MAH;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//		Digital Input Status (Retract Status) and Tank Pressure
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = TELE_DEVICE_DIGITAL_AIR
+	UINT8		sID;															// Secondary ID
+	UINT16		digital;														// Digital inputs (bit per input)
+	UINT16		spare1;
+	UINT16		pressure[4];													// Tank pressure, 0.1PSI (0-6553.4PSI), 0xFFFF = Not Installed
+	UINT16		spare2;
+} STRU_TELE_DIGITAL_AIR;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//		Thrust/Strain Gauge
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x38
+	UINT8		sID;															// Secondary ID
+	UINT16		strain_A,														// Strain sensor A
+				strain_B,														// Strain sensor B
+				strain_C,														// Strain sensor D
+				strain_D;														// Strain sensor C
+} STRU_TELE_STRAIN;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						6S LiPo Cell Monitor
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x3A
+	UINT8		sID;															// Secondary ID
+	UINT16		cell[6];														// Voltage across cell 1, .01V steps
+																				// 0x7FFF --> cell not present
+	UINT16		temp;															// Temperature, 0.1C (0-655.34C)
+} STRU_TELE_LIPOMON;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						14S LiPo Cell Monitor
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x3F
+	UINT8		sID;															// Secondary ID
+	UINT8		cell[14];														// Voltage across cell 1, .01V steps, excess of 2.56V
+																				// (ie, 3.00V would report 300-256 = 44)
+																				// 0xFF --> cell not present
+} STRU_TELE_LIPOMON_14;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//								Smart Battery
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//			Uses little-endian byte order for all multi-byte fields
+//
+typedef struct
+{
+	UINT8	identifier;															// Source device = 0x42
+	UINT8	sID;																// Secondary ID
+	UINT8	typeChannel;														// Upper nybble = Message type; Lower nybble = Battery number (0 or 1)
+	UINT8	msgData[13];														// Message-specific data, determined by upper nybble of typeChannel (see defs below)
+} STRU_SMARTBATT_HEADER;
+
+#define	SMARTBATT_MSG_TYPE_MASK_BATTNUMBER		(0x0F)
+#define	SMARTBATT_MSG_TYPE_MASK_MSGTYPE			(0xF0)
+
+#define SMARTBATT_MSG_TYPE_REALTIME				(0x00)
+#define SMARTBATT_MSG_TYPE_CELLS_1_6			(0x10)
+#define SMARTBATT_MSG_TYPE_CELLS_7_12			(0x20)
+#define SMARTBATT_MSG_TYPE_CELLS_13_18			(0x30)
+#define SMARTBATT_MSG_TYPE_ID					(0x80)
+#define SMARTBATT_MSG_TYPE_LIMITS				(0x90)
+
+//...........................................................................
+// Real-time battery data when current sense is available
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x42
+	UINT8		sID;															// Secondary ID
+	UINT8		typeChannel;													// Msg type = SMARTBATT_MSG_TYPE_REALTIME | Battery number (0 or 1)
+	INT8		temperature_C;													// Temperature in degrees C, 1 degree increments (-128 = unavailable)
+	UINT32		dischargeCurrent_mA;											// Amount of current being drawn from battery, in mA steps (0xFFFFFFFF = unavailable)
+	UINT16		batteryCapacityUsage_mAh;										// Approximate battery capacity usage, in mAh (0xFFFF = unavailable)
+	UINT16		minCellVoltage_mV;												// Minimum cell voltage of pack, in mV
+	UINT16		maxCellVoltage_mV;												// Maximum cell voltage of pack, in mV
+	UINT8		rfu[2];
+} STRU_SMARTBATT_REALTIME;
+
+//...........................................................................
+// Real-time cell voltage
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x42
+	UINT8		sID;															// Secondary ID
+	UINT8		typeChannel;													// Msg type = SMARTBATT_MSG_TYPE_CELLS_X_Y | Battery number (0 or 1)
+	INT8		temperature_C;													// Temperature in degrees C, 1 degree increments (-128 = unavailable)
+	UINT16		cellVoltage_mV[6];												// Cell voltage of first 6 cells, in mV (0xFFFF = unavailable)
+} STRU_SMARTBATT_CELLS;
+
+//...........................................................................
+// Smart Battery ID and general info
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x42
+	UINT8		sID;															// Secondary ID
+	UINT8		typeChannel;													// Msg type = SMARTBATT_MSG_TYPE_ID | Battery number (0 or 1)
+	UINT8		chemistry;														// 0:LiHv, 1:LiPo, 2:LiIon, 3:LiFe, 4:Pb, 5:Ni-MH/Cd
+	UINT8		numOfCells;														// Number of cells in the battery
+	UINT8		manufacturer;													// 0:BattGo
+	UINT16		cycles;															// Number of charge/discharge cycles recorded (0 = unavailable)
+	UINT8		uniqueID[8];													// Unique battery ID, manufacturer-specific
+																				// 0: [0]   = lower (first) byte of "Customer ID"
+																				//    [1-3] = lower 3 bytes of "Special Mark of Battery"
+																				//    [4-7] = 4-byte "Manufacturing Date"
+} STRU_SMARTBATT_ID;
+
+//...........................................................................
+// Smart Battery Limits
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x42
+	UINT8		sID;															// Secondary ID
+	UINT8		typeChannel;													// Msg type = SMARTBATT_MSG_TYPE_LIMITS | Battery number (0 or 1)
+	UINT8		rfu;
+	UINT16		fullCapacity_mAh;												// Fully charged battery capacity, in mAh
+	UINT16		dischargeCurrentRating;											// Rated discharge current, in 0.1C
+	UINT16		overDischarge_mV;												// Limit below which battery is likely damaged, in mV
+	UINT16		zeroCapacity_mV;												// Voltage at which LVC protection should activate, in mV
+	UINT16		fullyCharged_mV;												// Voltage reading expected when fully charged, in mV
+	INT8		minWorkingTemp;													// Minimum working temperature in degrees C, 1 degree steps
+	INT8		maxWorkingTemp;													// Maximum working temperature in degrees C, 1 degree steps
+} STRU_SMARTBATT_LIMITS;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							ACCELEROMETER
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x14
+	UINT8		sID;															// Secondary ID
+	INT16		GForceX;														// force is reported as .01G increments
+	INT16		GForceY;														// 		Range = +/-4000 (+/- 40G) in Pro model
+	INT16		GForceZ;														// 		Range = +/-800 (+/- 8G) in Standard model
+	INT16		maxGForceX;														// abs(max G X-axis)   FORE/AFT
+	INT16		maxGForceY;														// abs (max G Y-axis)  LEFT/RIGHT
+	INT16		maxGForceZ;														// max G Z-axis        WING SPAR LOAD
+	INT16		minGForceZ;														// min G Z-axis        WING SPAR LOAD
+} STRU_TELE_G_METER;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						SURFACE TILT (ATTITUDE) SENSOR
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x1C TELE_DEVICE_TILT
+	UINT8		sID;															// Secondary ID
+	INT16		attQuatX;														// Quaternion representing attitude using RHR. X component in Q14.
+	INT16		attQuatY;														// Y component in Q14.
+	INT16		attQuatZ;														// Z component in Q14.
+	INT16		attQuatW;														// W component in Q14.
+	UINT16		spare[3];
+} STRU_TELE_TILT;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//								TURBINE
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x15
+	UINT8		sID;															// Secondary ID
+	UINT8		status;															// Table below
+	UINT8		throttle;														// (BCD) xx Percent
+	UINT16		packVoltage;													// (BCD) xx.yy
+	UINT16		pumpVoltage;													// (BCD) xx.yy
+	UINT32		RPM;															// (BCD)
+	UINT16		EGT;															// (BCD) Temperature, Celsius
+	UINT8		offCondition;													// Table below
+	UINT8		spare;
+} STRU_TELE_JETCAT;
+
+enum JETCAT_ECU_TURBINE_STATE {							// ECU Status definitions
+		JETCAT_ECU_STATE_OFF = 0x00,
+		JETCAT_ECU_STATE_WAIT_for_RPM = 0x01, // (Stby/Start)
+		JETCAT_ECU_STATE_Ignite = 0x02,
+		JETCAT_ECU_STATE_Accelerate = 0x03,
+		JETCAT_ECU_STATE_Stabilise = 0x04,
+		JETCAT_ECU_STATE_Learn_HI = 0x05,
+		JETCAT_ECU_STATE_Learn_LO = 0x06,
+		JETCAT_ECU_STATE_UNDEFINED = 0x07,
+		JETCAT_ECU_STATE_Slow_Down = 0x08,
+		JETCAT_ECU_STATE_Manual = 0x09,
+		JETCAT_ECU_STATE_AutoOff = 0x10,
+		JETCAT_ECU_STATE_Run = 0x11, // (reg.)
+		JETCAT_ECU_STATE_Accleleration_delay = 0x12,
+		JETCAT_ECU_STATE_SpeedReg = 0x13, // (Speed Ctrl)
+		JETCAT_ECU_STATE_Two_Shaft_Regulate = 0x14, // (only for secondary shaft)
+		JETCAT_ECU_STATE_PreHeat1 = 0x15,
+		JETCAT_ECU_STATE_PreHeat2 = 0x16,
+		JETCAT_ECU_STATE_MainFStart = 0x17,
+		JETCAT_ECU_STATE_NotUsed = 0x18,
+		JETCAT_ECU_STATE_KeroFullOn = 0x19,
+		// undefined states 0x1A-0x1F
+		EVOJET_ECU_STATE_off = 0x20,
+		EVOJET_ECU_STATE_ignt = 0x21,
+		EVOJET_ECU_STATE_acce = 0x22,
+		EVOJET_ECU_STATE_run = 0x23,
+		EVOJET_ECU_STATE_cal = 0x24,
+		EVOJET_ECU_STATE_cool = 0x25,
+		EVOJET_ECU_STATE_fire = 0x26,
+		EVOJET_ECU_STATE_glow = 0x27,
+		EVOJET_ECU_STATE_heat = 0x28,
+		EVOJET_ECU_STATE_idle = 0x29,
+		EVOJET_ECU_STATE_lock = 0x2A,
+		EVOJET_ECU_STATE_rel = 0x2B,
+		EVOJET_ECU_STATE_spin = 0x2C,
+		EVOJET_ECU_STATE_stop = 0x2D,
+		// undefined states 0x2E-0x2F
+		HORNET_ECU_STATE_OFF = 0x30,
+		HORNET_ECU_STATE_SLOWDOWN = 0x31,
+		HORNET_ECU_STATE_COOL_DOWN = 0x32,
+		HORNET_ECU_STATE_AUTO = 0x33,
+		HORNET_ECU_STATE_AUTO_HC = 0x34,
+		HORNET_ECU_STATE_BURNER_ON = 0x35,
+		HORNET_ECU_STATE_CAL_IDLE = 0x36,
+		HORNET_ECU_STATE_CALIBRATE = 0x37,
+		HORNET_ECU_STATE_DEV_DELAY = 0x38,
+		HORNET_ECU_STATE_EMERGENCY = 0x39,
+		HORNET_ECU_STATE_FUEL_HEAT = 0x3A,
+		HORNET_ECU_STATE_FUEL_IGNITE = 0x3B,
+		HORNET_ECU_STATE_GO_IDLE = 0x3C,
+		HORNET_ECU_STATE_PROP_IGNITE = 0x3D,
+		HORNET_ECU_STATE_RAMP_DELAY = 0x3E,
+		HORNET_ECU_STATE_RAMP_UP = 0x3F,
+		HORNET_ECU_STATE_STANDBY = 0x40,
+		HORNET_ECU_STATE_STEADY = 0x41,
+		HORNET_ECU_STATE_WAIT_ACC = 0x42,
+		HORNET_ECU_STATE_ERROR = 0x43,
+		// undefined states 0x44-0x4F
+		XICOY_ECU_STATE_Temp_High = 0x50,
+		XICOY_ECU_STATE_Trim_Low = 0x51,
+		XICOY_ECU_STATE_Set_Idle = 0x52,
+		XICOY_ECU_STATE_Ready = 0x53,
+		XICOY_ECU_STATE_Ignition = 0x54,
+		XICOY_ECU_STATE_Fuel_Ramp = 0x55,
+		XICOY_ECU_STATE_Glow_Test = 0x56,
+		XICOY_ECU_STATE_Running = 0x57,
+		XICOY_ECU_STATE_Stop = 0x58,
+		XICOY_ECU_STATE_Flameout = 0x59,
+		XICOY_ECU_STATE_Speed_Low = 0x5A,
+		XICOY_ECU_STATE_Cooling = 0x5B,
+		XICOY_ECU_STATE_Igniter_Bad = 0x5C,
+		XICOY_ECU_STATE_Starter_F = 0x5D,
+		XICOY_ECU_STATE_Weak_Fuel = 0x5E,
+		XICOY_ECU_STATE_Start_On = 0x5F,
+		XICOY_ECU_STATE_Pre_Heat = 0x60,
+		XICOY_ECU_STATE_Battery = 0x61,
+		XICOY_ECU_STATE_Time_Out = 0x62,
+		XICOY_ECU_STATE_Overload = 0x63,
+		XICOY_ECU_STATE_Igniter_Fail = 0x64,
+		XICOY_ECU_STATE_Burner_On = 0x65,
+		XICOY_ECU_STATE_Starting = 0x66,
+		XICOY_ECU_STATE_SwitchOver = 0x67,
+		XICOY_ECU_STATE_Cal_Pump = 0x68,
+		XICOY_ECU_STATE_Pump_Limit = 0x69,
+		XICOY_ECU_STATE_No_Engine = 0x6A,
+		XICOY_ECU_STATE_Pwr_Boost = 0x6B,
+		XICOY_ECU_STATE_Run_Idle = 0x6C,
+		XICOY_ECU_STATE_Run_Max = 0x6D,
+		// undefined states 0x6e-0x73
+		JETCENT_ECU_STATE_STOP = 0x74,
+		JETCENT_ECU_STATE_GLOW_TEST = 0x75,
+		JETCENT_ECU_STATE_STARTER_TEST = 0x76,
+		JETCENT_ECU_STATE_PRIME_FUEL = 0x77,
+		JETCENT_ECU_STATE_PRIME_BURNER = 0x78,
+		JETCENT_ECU_STATE_MAN_COOL = 0x79,
+		JETCENT_ECU_STATE_AUTO_COOL = 0x7A,
+		JETCENT_ECU_STATE_IGN_HEAT = 0x7B,
+		JETCENT_ECU_STATE_IGNITION = 0x7C,
+		JETCENT_ECU_STATE_PREHEAT = 0x7D,
+		JETCENT_ECU_STATE_SWITCHOVER = 0x7E,
+		JETCENT_ECU_STATE_TO_IDLE = 0x7F,
+		JETCENT_ECU_STATE_RUNNING = 0x80,
+		JETCENT_ECU_STATE_STOP_ERROR = 0x81,
+		// undefined states 0x82-0x8F
+		SWIWIN_ECU_STATE_STOP = 0x90,
+		SWIWIN_ECU_STATE_READY = 0x91,
+		SWIWIN_ECU_STATE_IGNITION = 0x92,
+		SWIWIN_ECU_STATE_PREHEAT = 0x93,
+		SWIWIN_ECU_STATE_FUEL_RAMP = 0x94,
+		SWIWIN_ECU_STATE_RUNNING = 0x95,
+		SWIWIN_ECU_STATE_COOLING = 0x96,
+		SWIWIN_ECU_STATE_RESTART_SWOVER = 0x97,
+		SWIWIN_ECU_STATE_NOTUSED = 0x98,
+		// undefined states 0x99-0x9F
+
+		TURBINE_ECU_MAX_STATE = 0x9F
+};
+
+enum JETCAT_ECU_OFF_CONDITIONS {					// ECU off conditions. Valid only when the ECUStatus = JETCAT_ECU_STATE_OFF
+		JETCAT_ECU_OFF_No_Off_Condition_defined = 0,
+		JETCAT_ECU_OFF_Shut_down_via_RC,
+		JETCAT_ECU_OFF_Overtemperature,
+		JETCAT_ECU_OFF_Ignition_timeout,
+		JETCAT_ECU_OFF_Acceleration_time_out,
+		JETCAT_ECU_OFF_Acceleration_too_slow,
+		JETCAT_ECU_OFF_Over_RPM,
+		JETCAT_ECU_OFF_Low_Rpm_Off,
+		JETCAT_ECU_OFF_Low_Battery,
+		JETCAT_ECU_OFF_Auto_Off,
+		JETCAT_ECU_OFF_Low_temperature_Off,
+		JETCAT_ECU_OFF_Hi_Temp_Off,
+		JETCAT_ECU_OFF_Glow_Plug_defective,
+		JETCAT_ECU_OFF_Watch_Dog_Timer,
+		JETCAT_ECU_OFF_Fail_Safe_Off,
+		JETCAT_ECU_OFF_Manual_Off, // (via GSU)
+		JETCAT_ECU_OFF_Power_fail, // (Battery fail)
+		JETCAT_ECU_OFF_Temp_Sensor_fail, // (only during startup)
+		JETCAT_ECU_OFF_Fuel_fail,
+		JETCAT_ECU_OFF_Prop_fail,
+		JETCAT_ECU_OFF_2nd_Engine_fail,
+		JETCAT_ECU_OFF_2nd_Engine_Diff_Too_High,
+		JETCAT_ECU_OFF_2nd_Engine_No_Comm,
+		JETCAT_ECU_MAX_OFF_COND,
+		// Jet Central
+		JETCENT_ECU_OFF_No_Off_Condition_defined = 24,		// ECU off conditions. Valid only when the ECUStatus = JETCENT_ECU_STATE_STOP or JETCENT_ECU_STATE_STOP_ERROR or JETCENT_ECU_STATE_RUNNING
+		JETCENT_ECU_OFF_IGNITION_ERROR,
+		JETCENT_ECU_OFF_PREHEAT_ERROR,
+		JETCENT_ECU_OFF_SWITCHOVER_ERROR,
+		JETCENT_ECU_OFF_STARTER_MOTOR_ERROR,
+		JETCENT_ECU_OFF_TO_IDLE_ERROR,
+		JETCENT_ECU_OFF_ACCELERATION_ERROR,
+		JETCENT_ECU_OFF_IGNITER_BAD,
+		JETCENT_ECU_OFF_MIN_PUMP_OK,
+		JETCENT_ECU_OFF_MAX_PUMP_OK,
+		JETCENT_ECU_OFF_LOW_RX_BATTERY,
+		JETCENT_ECU_OFF_LOW_ECU_BATTERY,
+		JETCENT_ECU_OFF_NO_RX,
+		JETCENT_ECU_OFF_TRIM_DOWN,
+		JETCENT_ECU_OFF_TRIM_UP,
+		JETCENT_ECU_OFF_FAILSAFE,
+		JETCENT_ECU_OFF_FULL,
+		JETCENT_ECU_OFF_RX_SETUP_ERROR,
+		JETCENT_ECU_OFF_TEMP_SENSOR_ERROR,
+		JETCENT_ECU_OFF_COM_TURBINE_ERROR,
+		JETCENT_ECU_OFF_MAX_TEMP,
+		JETCENT_ECU_OFF_MAX_AMPS,
+		JETCENT_ECU_OFF_LOW_RPM,
+		JETCENT_ECU_OFF_ERROR_RPM_SENSOR,
+		JETCENT_ECU_OFF_MAX_PUMP,
+		JETCENT_ECU_MAX_OFF_COND
+};
+
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x19
+	UINT8		sID;															// Secondary ID
+	UINT16		FuelFlowRateMLMin;												// (BCD) mL per Minute
+	UINT32		RestFuelVolumeInTankML;											// (BCD) mL remaining in tank
+	UINT8		ECUbatteryPercent;												// (BCD) % battery pack capacity remaining
+	// 7 bytes left
+} STRU_TELE_JETCAT2;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//								GPS
+//						  Packed-BCD Type
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x16
+	UINT8		sID;															// Secondary ID
+	UINT16		altitudeLow;													// BCD, meters, format 3.1 (Low order of altitude)
+	UINT32		latitude;														// BCD, format 4.4, Degrees * 100 + minutes, less than 100 degrees
+	UINT32		longitude;														// BCD, format 4.4 , Degrees * 100 + minutes, flag indicates > 99 degrees
+	UINT16		course;															// BCD, 3.1
+	UINT8		HDOP;															// BCD, format 1.1
+	UINT8		GPSflags;														// see definitions below
+} STRU_TELE_GPS_LOC;
+
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x17
+	UINT8		sID;															// Secondary ID
+	UINT16		speed;															// BCD, knots, format 3.1
+	UINT32		UTC;															// BCD, format HH:MM:SS.S, format 6.1
+	UINT8		numSats;														// BCD, 0-99
+	UINT8		altitudeHigh;													// BCD, meters, format 2.0 (High order of altitude)
+} STRU_TELE_GPS_STAT;
+
+// GPS flags definitions:
+#define	GPS_INFO_FLAGS_IS_NORTH_BIT					(0)
+#define	GPS_INFO_FLAGS_IS_NORTH						(1 << GPS_INFO_FLAGS_IS_NORTH_BIT)
+#define	GPS_INFO_FLAGS_IS_EAST_BIT					(1)
+#define	GPS_INFO_FLAGS_IS_EAST						(1 << GPS_INFO_FLAGS_IS_EAST_BIT)
+#define	GPS_INFO_FLAGS_LONGITUDE_GREATER_99_BIT		(2)
+#define	GPS_INFO_FLAGS_LONGITUDE_GREATER_99			(1 << GPS_INFO_FLAGS_LONGITUDE_GREATER_99_BIT)
+#define	GPS_INFO_FLAGS_GPS_FIX_VALID_BIT			(3)
+#define	GPS_INFO_FLAGS_GPS_FIX_VALID				(1 << GPS_INFO_FLAGS_GPS_FIX_VALID_BIT)
+#define	GPS_INFO_FLAGS_GPS_DATA_RECEIVED_BIT		(4)
+#define	GPS_INFO_FLAGS_GPS_DATA_RECEIVED			(1 << GPS_INFO_FLAGS_GPS_DATA_RECEIVED_BIT)
+#define	GPS_INFO_FLAGS_3D_FIX_BIT					(5)
+#define	GPS_INFO_FLAGS_3D_FIX						(1 << GPS_INFO_FLAGS_3D_FIX_BIT)
+#define GPS_INFO_FLAGS_NEGATIVE_ALT_BIT				(7)
+#define GPS_INFO_FLAGS_NEGATIVE_ALT					(1 << GPS_INFO_FLAGS_NEGATIVE_ALT_BIT)
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//								GPS
+//							Binary Type
+//
+//		NOTE:	Data resolution for all fields matches Crossfire EXCEPT speed.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x26
+	UINT8		sID;															// Secondary ID
+	UINT16		altitude;														// m, 1000m offset
+	INT32		latitude;														// degree / 10,000,000
+	INT32		longitude;														// degree / 10,000,000
+	UINT16		heading;														// degree / 10
+	UINT8		groundSpeed;													// km/h
+	UINT8		numSats;														// count
+} STRU_TELE_GPS_BINARY;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//					AS3X Legacy Gain Report
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = TELE_DEVICE_AS3X_LEGACYGAIN
+	UINT8		sID;															// Secondary ID
+	UINT8		gainRoll;														// Configured normal gains per axis
+	UINT8		gainPitch;
+	UINT8		gainYaw;
+	UINT8		headRoll;														// Configured heading hold gains per axis
+	UINT8		headPitch;
+	UINT8		headYaw;
+	UINT8		activeRoll;														// Active gains per axis (as affected by FM channel)
+	UINT8		activePitch;
+	UINT8		activeYaw;
+	UINT8		flightMode;														// bit 7 1 --> FM present in bits 0,1 except 0xFF --> not present
+	UINT8		unused[4];
+} STRU_TELE_AS3X_LEGACY;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//					AS6X Gain Report (AS3X Legacy + more fields)
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = TELE_DEVICE_AS6X_GAIN
+	UINT8		sID;															// Secondary ID
+	UINT8		gainRoll;														// Configured normal gains per axis
+	UINT8		gainPitch;
+	UINT8		gainYaw;
+	UINT8		headRoll;														// Configured heading hold gains per axis
+	UINT8		headPitch;
+	UINT8		headYaw;
+	UINT8		activeRoll;														// Active gains per axis (as affected by FM channel)
+	UINT8		activePitch;
+	UINT8		activeYaw;
+	UINT8		flightMode;														// bit 7 1 --> FM present in bits 0,1 except 0xFF --> not present
+	// new fields go here:
+	UINT8		unused[4];
+} STRU_TELE_AS6X_GAIN;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							GYRO
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x1A
+	UINT8		sID;															// Secondary ID
+	INT16		gyroX;															// Rotation rates of the body - Rate is about the X Axis which is defined out the nose of the vehicle.
+	INT16		gyroY;															// Units are 0.1 deg/sec  - Rate is about the Y Axis which is define out the right wing of the vehicle.
+	INT16		gyroZ;															// Rate is about the Z axis which is defined down from the vehicle.
+	INT16		maxGyroX;														// Max rates (absolute value)
+	INT16		maxGyroY;
+	INT16		maxGyroZ;
+} STRU_TELE_GYRO;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						Alpha6 Stabilizer
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x24
+	UINT8		sID;															// Secondary ID
+	UINT16		volts;															// 0.01V increments
+	UINT8		state_FM;														// Flight Mode and System State (see below)
+	UINT8		gainRoll,														// Roll Gain,  high bit --> Heading Hold
+				gainPitch,														// Pitch Gain
+				gainYaw;														// Yaw Gain
+	INT16		attRoll,														// Roll Attitude, 0.1degree, RHR
+				attPitch,														// Pitch Attitude
+				attYaw;															// Yaw Attitude
+	UINT16		spare;
+} STRU_TELE_ALPHA6;
+
+#define	GBOX_STATE_BOOT							(0x00)							// Alpha6 State - Boot
+#define	GBOX_STATE_INIT							(0x01)							// Init
+#define	GBOX_STATE_READY						(0x02)							// Ready
+#define	GBOX_STATE_SENSORFAULT					(0x03)							// Sensor Fault
+#define	GBOX_STATE_POWERFAULT					(0x04)							// Power Fault
+#define	GBOX_STATE_MASK							(0x0F)
+
+#define	GBOX_FMODE_FM0							(0x00)							// FM0 through FM4
+#define	GBOX_FMODE_FM1							(0x10)
+#define	GBOX_FMODE_FM2							(0x20)
+#define	GBOX_FMODE_FM3							(0x30)
+#define	GBOX_FMODE_FM4							(0x40)
+#define	GBOX_FMODE_PANIC						(0x50)
+#define	GBOX_FMODE_MASK							(0xF0)
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						ATTITUDE & MAG COMPASS
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x1B
+	UINT8		sID;															// Secondary ID
+	INT16		attRoll;														// Attitude, 3 axes.  Roll is a rotation about the X Axis of the vehicle using the RHR.
+	INT16		attPitch;														// Units are 0.1 deg - Pitch is a rotation about the Y Axis of the vehicle using the RHR.
+	INT16		attYaw;															// Yaw is a rotation about the Z Axis of the vehicle using the RHR.
+	INT16		magX;															// Magnetic Compass, 3 axes
+	INT16		magY;															// Units are 0.1mG
+	INT16		magZ;															//
+	UINT16		heading;														// Heading, 0.1deg
+} STRU_TELE_ATTMAG;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						Altitude "Zero" Message
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x7B
+	UINT8		sID;															// Secondary ID
+	UINT8		spare[2];
+	UINT32		altOffset;														// Altitude "zero" log
+} STRU_TELE_ALT_ZERO;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						Real-Time Clock
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x7C
+	UINT8		sID;															// Secondary ID
+	UINT8		spare[6];
+	UINT64		UTC64;															// Linux 64-bit time_t for post-2038 date compatibility
+} STRU_TELE_RTC;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						V-Speak (Placeholder)
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x61
+	UINT8		sID;															// Secondary ID
+	UINT8		spare[14];														// Format TBD by V-Speak
+} STRU_TELE_V_SPEAK;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						www.Smoke-EL.de
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x61
+	UINT8		sID;															// Secondary ID
+	UINT16		batteryV;														// 0.01V, Range 0.00-70.00V
+	UINT16		countdown;														// 0.01s, Range 0.00-30.00s
+	INT16		GForce;															// 0.01g, Range = +/-8.00g
+	UINT8		cutoff;															// 1 count, Range 0-9
+	UINT8		connected;														// 0=not connected, 1=connected, x = TBD
+	UINT16		spare[3];
+} STRU_TELE_SMOKE_EL;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							MULTI-CYLINDER SENSOR
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = TELE_DEVICE_MULTICYLINDER
+	UINT8		sID;															// Secondary ID
+	UINT8		temperature[9];													// Temperature, 1C increments, Offset = 30C, 0xFF = NO DATA
+				// 0x00 = 30C		(86F)
+				// 0x01 = 31C ...	(88F)
+				// 0xFE = 284C		(543F)
+				// 0xFF = NO SENSOR ATTACHED.  Note that sensors must be installed cylinder 1-9 in sequence!
+	UINT8		throttlePct;													// Throttle percent (0-100% typical, 0xFF = NO DATA)
+	UINT16		RPM;															// 4 RPM increments, Offset = 400RPM, range 404-16776.
+				// 0x000 = 0 RPM
+				// 0x001 = 404 RPM
+				// 0x002 = 408 RPM
+				// 0xFFE = 16776 RPM
+				// 0xFFF = NO SENSOR ATTACHED
+				// NOTE:  HI NYBBLE RESERVED, set to 0xF to mark "NO DATA" for now
+	UINT8		batteryV;														// Voltage, 0.1V increments, Offset = 3.5V, 0xFF = NO DATA
+				// 0x00 = 3.5V
+				// 0x01 = 3.6V
+				// 0xFE = 28.9V
+				// 0xFF = NO SENSOR ATTACHED
+	UINT8		spare;															// 0xFF --> no data
+} STRU_TELE_MULTI_TEMP;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						Transmitter Frame Data
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x7D
+	UINT8		sID;															// Secondary ID
+	UINT16		chanData[7];													// Channel Data array
+} STRU_TELE_FRAMEDATA;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							AHRS Monitor
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = TELE_DEVICE_AHRS
+	UINT8		sID;															// Secondary ID
+	INT16		attRoll;														// Attitude, 3 axes.  Roll is a rotation about the X Axis of the vehicle using the RHR.
+	INT16		attPitch;														// Units are 0.1 deg - Pitch is a rotation about the Y Axis of the vehicle using the RHR.
+	INT16		attYaw;															// Roll is a rotation about the Z Axis of the vehicle using the RHR.
+	INT16		altitude;														// .1m increments
+	UINT8		waypoint;														// Waypoint number
+	UINT8		spare8;
+	UINT16		spare16[2];
+} STRU_TELE_AHRS;																// AHRS data from rx
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							FLIGHT MODE
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x05 TELE_DEVICE_FLITECTRL
+	UINT8		sID;															// Secondary ID
+	UINT8		fMode,															// Current flight mode (low nybble)
+				spare8;
+	UINT16		spare[6];														// Growth
+	// Ideas -
+	//		arming status in a bitmap
+	//		time in state
+} STRU_TELE_FLITECTRL;
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							Crossfire QOS
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = TELE_XRF_LINKSTATUS
+	UINT8		sID;															// Secondary ID
+	UINT8		ant1,					// dBm * -1
+				ant2,
+				quality;				// %
+	INT8		SNR;					// dB
+	UINT8		activeAnt,				// ant1=0, ant2=1
+				RFmode,					// 4fps=0, 50fps, 150Hz
+				upPower,				// 0mW=0, 10mW, 25mW, 100mW, 500mW, 1000mW, 2000mW
+				downlink,				// dBm * -1
+				qualityDown;			// %
+	INT8		SNRdown;				// dB
+} STRU_TELE_XF_QOS;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//						RPM/Volts/Temperature
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Uses big-endian byte order
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x7E
+	UINT8		sID;															// Secondary ID
+	UINT16		microseconds;													// microseconds between pulse leading edges
+	UINT16		volts;															// 0.01V increments (typically flight pack voltage)
+	INT16		temperature;													// Temperature in degrees F.  0x7FFF = "No Data"
+	INT8		dBm_A,															// Avg RSSI in dBm (<-1 = dBm, 0 = no data, >0 = % range) -- (legacy)antenna A in dBm
+				dBm_B;															// Avg RSSI in % (<-1 = dBm, 0 = no data, >0 = % range)   -- (legacy)antenna B in dBm
+																				// Note: Legacy use as antenna A/B dBm values is still supported. If only 1 antenna, set B = A.
+																				//       The "no data" value is 0, but -1 (0xFF) is treated the same for backwards compatibility
+	UINT16		spare[2];
+} STRU_TELE_RPM;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//							QoS DATA
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	NOTE:  AR6410-series send:
+//			id = 7F
+//			sID = 0
+//			A = 0
+//			B = 0
+//			L = 0
+//			R = 0
+//			F = fades
+//			H = holds
+//			rxV = 0xFFFF
+//
+typedef struct
+{
+	UINT8		identifier;														// Source device = 0x7F
+	UINT8		sID;															// Secondary ID
+	UINT16		A;																// Internal/base receiver fades. 0xFFFF = "No data"
+	UINT16		B;																// Remote receiver fades. 0xFFFF = "No data"
+	UINT16		L;																// Third receiver fades. 0xFFFF = "No data"
+	UINT16		R;																// Fourth receiver fades. 0xFFFF = "No data"
+	UINT16		F;																// Frame losses. 0xFFFF = "No data"
+	UINT16		H;																// Holds. 0xFFFF = "No data"
+	UINT16		rxVoltage;														// Volts, .01V increment. 0xFFFF = "No data"
+} STRU_TELE_QOS;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//					UNION OF ALL DEVICE MESSAGES
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+typedef union
+{
+	UINT16					raw[8];
+	STRU_TELE_QOS			qos;
+	STRU_TELE_RPM			rpm;
+	STRU_TELE_HV			hv;
+	STRU_TELE_TEMP			temp;
+	STRU_TELE_IHIGH			amps;
+	STRU_TELE_ALT			alt;
+	STRU_TELE_SPEED			speed;
+	STRU_TELE_ESC			escSPM;
+	STRU_TELE_VARIO_S		varioSimple;
+	STRU_TELE_G_METER		accel;
+	STRU_TELE_JETCAT		jetcat;
+	STRU_TELE_JETCAT2		jetcat2;
+	STRU_TELE_GPS_LOC		gpsloc;
+	STRU_TELE_GPS_STAT		gpsstat;
+	STRU_TELE_GPS_BINARY	gpsbin;
+	STRU_TELE_AS3X_LEGACY	as3x;
+	STRU_TELE_AS6X_GAIN		as6x;
+	STRU_TELE_GYRO			gyro;
+	STRU_TELE_ALPHA6		alpha6;
+	STRU_TELE_ATTMAG		attMag;
+	STRU_TELE_POWERBOX		powerBox;
+	STRU_TELE_RX_MAH		rxMAH;
+	STRU_TELE_FP_MAH		fpMAH;
+	STRU_TELE_ESC			esc;
+	STRU_TELE_FUEL			fuel;
+	STRU_TELE_DIGITAL_AIR	digAir;
+	STRU_TELE_STRAIN		strain;
+	STRU_TELE_LIPOMON		lipomon;
+	STRU_TELE_LIPOMON_14	lipomon14;
+	STRU_SMARTBATT_HEADER	smartBatt_header;
+	STRU_SMARTBATT_REALTIME	smartBatt_realtime;
+	STRU_SMARTBATT_CELLS	smartBatt_cells;
+	STRU_SMARTBATT_ID		smartBatt_ID;
+	STRU_SMARTBATT_LIMITS	smartBatt_limits;
+	STRU_TELE_USER_16SU		user_16SU;
+	STRU_TELE_USER_16SU32U	user_16SU32U;
+	STRU_TELE_USER_16SU32S	user_16SU32S;
+	STRU_TELE_USER_16U32SU	user_16U32SU;
+	STRU_TELE_TEXTGEN		textgen;
+	STRU_TELE_VTX			vtx;
+	STRU_TELE_V_SPEAK		vSpeak;
+	STRU_TELE_SMOKE_EL		smoke_el;
+	STRU_TELE_MULTI_TEMP	multiCylinder;
+	STRU_TELE_FLITECTRL		fControl;
+	STRU_TELE_TILT			tilt;
+	STRU_TELE_XF_QOS		xfire;
+} UN_TELEMETRY;																	// All telemetry messages
+
+//////////////////////////////////////////////////////////////////
+//
+//					sID Field Functionality
+//
+//////////////////////////////////////////////////////////////////
+//
+//		if .sID == 0x00 then .identifier = device type (TELE_DEVICE_xxx) and address I2C bus
+//		if .sID != 0x00 then .sID = device type and .identifer = address on I2C bus
+
+#endif

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -34,6 +34,7 @@
 #include <AP_RTC/AP_RTC.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_RCTelemetry/AP_Spektrum_Telem.h>
 #include <AP_Mount/AP_Mount.h>
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
@@ -1878,7 +1879,12 @@ void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, u
     if (frsky != nullptr) {
         frsky->queue_message(severity, first_piece_of_text);
     }
-
+#if HAL_SPEKTRUM_TELEM_ENABLED
+    AP_Spektrum_Telem* spektrum = AP::spektrum_telem();
+    if (spektrum != nullptr) {
+        spektrum->queue_message(severity, first_piece_of_text);
+    }
+#endif
     AP_Notify *notify = AP_Notify::get_singleton();
     if (notify) {
         notify->send_text(first_piece_of_text);
@@ -2062,7 +2068,6 @@ void GCS::setup_uarts()
             frsky = nullptr;
         }
     }
-
 #if !HAL_MINIMIZE_FEATURES
     ltm_telemetry.init();
     devo_telemetry.init();


### PR DESCRIPTION
Full support for SRXL2 and Spektrum Telemetry when using SRXL2.

Protocol is half-duplex, non-inverted. Setup is identical to that for FrSky passthrough.
The protocol *requires* half-duplex and therefore will not work on the IOMCU or with soft serial.

Flight test on a KakuteF7 Mini with these options:
```
BRD_ALT_CONFIG=1
SERIAL6_PROTOCOL=23
SERIAL6_OPTIONS=12
RSSI_TYPE=3
```
