### PR TITLE
Rover: remove redundant check for arming-required-is-no

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -299,7 +299,7 @@ void Rover::one_second_loop(void)
     // update notify flags
     AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);
     AP_Notify::flags.pre_arm_gps_check = true;
-    AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::Required::NO;
+    AP_Notify::flags.armed = arming.is_armed();
     AP_Notify::flags.flying = hal.util->get_soft_armed();
 
     // cope with changes to mavlink system ID


### PR DESCRIPTION
AP_Arming takes this into account in its is_armed method