### PR TITLE
AC_PosControl: Replace update_vel_controller_xy() with update_xy_controller()

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2243,7 +2243,7 @@ void QuadPlane::vtol_position_controller(void)
         pos_control->set_desired_accel_xy(0.0f,0.0f);
 
         // run horizontal velocity controller
-        pos_control->update_vel_controller_xy();
+        pos_control->update_xy_controller();
 
         // nav roll and pitch are controller by position controller
         plane.nav_roll_cd = pos_control->get_roll();

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -951,45 +951,13 @@ void AC_PosControl::init_vel_controller_xyz()
     init_ekf_z_reset();
 }
 
-/// update_velocity_controller_xy - run the velocity controller - should be called at 100hz or higher
-///     velocity targets should we set using set_desired_velocity_xy() method
-///     callers should use get_roll() and get_pitch() methods and sent to the attitude controller
-///     throttle targets will be sent directly to the motors
-void AC_PosControl::update_vel_controller_xy()
-{
-    // capture time since last iteration
-    const uint64_t now_us = AP_HAL::micros64();
-    float dt = (now_us - _last_update_xy_us) * 1.0e-6f;
-
-    // sanity check dt
-    if (dt >= 0.2f) {
-        dt = 0.0f;
-    }
-
-    // check for ekf xy position reset
-    check_for_ekf_xy_reset();
-
-    // check if xy leash needs to be recalculated
-    calc_leash_length_xy();
-
-    // apply desired velocity request to position target
-    // TODO: this will need to be removed and added to the calling function.
-    desired_vel_to_pos(dt);
-
-    // run position controller
-    run_xy_controller(dt);
-
-    // update xy update time
-    _last_update_xy_us = now_us;
-}
-
 /// update_velocity_controller_xyz - run the velocity controller - should be called at 100hz or higher
 ///     velocity targets should we set using set_desired_velocity_xyz() method
 ///     callers should use get_roll() and get_pitch() methods and sent to the attitude controller
 ///     throttle targets will be sent directly to the motors
 void AC_PosControl::update_vel_controller_xyz()
 {
-    update_vel_controller_xy();
+    update_xy_controller();
 
     // update altitude target
     set_alt_target_from_climb_rate_ff(_vel_desired.z, _dt, false);

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -263,12 +263,6 @@ public:
     /// init_vel_controller_xyz - initialise the velocity controller - should be called once before the caller attempts to use the controller
     void init_vel_controller_xyz();
 
-    /// update_velocity_controller_xy - run the XY velocity controller - should be called at 100hz or higher
-    ///     velocity targets should we set using set_desired_velocity_xy() method
-    ///     callers should use get_roll() and get_pitch() methods and sent to the attitude controller
-    ///     throttle targets will be sent directly to the motors
-    void update_vel_controller_xy();
-
     /// update_velocity_controller_xyz - run the velocity controller - should be called at 100hz or higher
     ///     velocity targets should we set using set_desired_velocity_xyz() method
     ///     callers should use get_roll() and get_pitch() methods and sent to the attitude controller


### PR DESCRIPTION
This is a fix for #13927.
[update_vel_controller_xy()](https://github.com/ArduPilot/ardupilot/blob/544df71fd260b91c4be43deb3b4846f77ebff967/libraries/AC_AttitudeControl/AC_PosControl.cpp#L958) is practically the same as [update_xy_controller()](https://github.com/ArduPilot/ardupilot/blob/544df71fd260b91c4be43deb3b4846f77ebff967/libraries/AC_AttitudeControl/AC_PosControl.cpp#L858), and therefore has been replaced at the relevant places.