### PR TITLE
AP_Arming: Check that sticks are neutral

### DIFF
--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -68,6 +68,11 @@ bool RC_Channels_Rover::has_valid_input() const
     return true;
 }
 
+RC_Channel * RC_Channels_Rover::get_arming_channel(void) const
+{
+    return rover.channel_steer;
+}
+
 void RC_Channel_Rover::do_aux_function_change_mode(Mode &mode,
         const aux_switch_pos_t ch_flag)
 {

--- a/APMrover2/RC_Channel.h
+++ b/APMrover2/RC_Channel.h
@@ -34,6 +34,8 @@ public:
 
     bool has_valid_input() const override;
 
+    RC_Channel *get_arming_channel(void) const override;
+
     RC_Channel_Rover obj_channels[NUM_RC_CHANNELS];
 
     RC_Channel_Rover *channel(const uint8_t chan) override {

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -57,6 +57,10 @@ bool RC_Channels_Copter::has_valid_input() const
     return true;
 }
 
+RC_Channel * RC_Channels_Copter::get_arming_channel(void) const
+{
+    return copter.channel_yaw;
+}
 
 // init_aux_switch_function - initialize aux functions
 void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)

--- a/ArduCopter/RC_Channel.h
+++ b/ArduCopter/RC_Channel.h
@@ -31,6 +31,8 @@ public:
 
     bool has_valid_input() const override;
 
+    RC_Channel *get_arming_channel(void) const override;
+
     RC_Channel_Copter obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Copter *channel(const uint8_t chan) override {
         if (chan >= NUM_RC_CHANNELS) {

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -27,6 +27,11 @@ bool RC_Channels_Plane::has_valid_input() const
     return true;
 }
 
+RC_Channel * RC_Channels_Plane::get_arming_channel(void) const
+{
+    return plane.channel_rudder;
+}
+
 void RC_Channel_Plane::do_aux_function_change_mode(const Mode::Number number,
                                                    const aux_switch_pos_t ch_flag)
 {

--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -33,6 +33,8 @@ public:
 
     bool has_valid_input() const override;
 
+    RC_Channel *get_arming_channel(void) const override;
+
 protected:
 
     // note that these callbacks are not presently used on Plane:

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -35,6 +35,7 @@
 #include <AP_Scripting/AP_Scripting.h>
 #include <AP_Camera/AP_RunCam.h>
 #include <AP_GyroFFT/AP_GyroFFT.h>
+#include <AP_RCMapper/AP_RCMapper.h>
 
 #if HAL_WITH_UAVCAN
   #include <AP_BoardConfig/AP_BoardConfig_CAN.h>
@@ -529,6 +530,53 @@ bool AP_Arming::hardware_safety_check(bool report)
     return true;
 }
 
+bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
+{
+    // don't check the trims if we are in a failsafe
+    if (!rc().has_valid_input()) {
+        return true;
+    }
+
+    // only check if we've recieved some form of input within the last second
+    // this is a protection against a vehicle having never enabled an input
+    uint32_t last_input_ms = rc().last_input_ms();
+    if ((last_input_ms == 0) || ((AP_HAL::millis() - last_input_ms) > 1000)) {
+        return true;
+    }
+
+    bool check_passed = true;
+    const RCMapper * rcmap = AP::rcmap();
+    if (rcmap != nullptr) {
+        if (!rc().arming_skip_checks_rpy()) {
+            const char *names[3] = {"Roll", "Pitch", "Yaw"};
+            const uint8_t channels[3] = {rcmap->roll(), rcmap->pitch(), rcmap->yaw()};
+            for (uint8_t i = 0; i < ARRAY_SIZE(channels); i++) {
+                const RC_Channel *c = rc().channel(channels[i] - 1);
+                if (c == nullptr) {
+                    continue;
+                }
+                if (!c->in_trim_dz()) {
+                    if ((method != Method::RUDDER) || (c != rc().get_arming_channel())) { // ignore the yaw input channel if rudder arming
+                        check_failed(ARMING_CHECK_RC, true, "%s (RC%d) is not neutral", names[i], channels[i]);
+                        check_passed = false;
+                    }
+                }
+            }
+        }
+
+        if (rc().arming_check_throttle()) {
+            const RC_Channel *c = rc().channel(rcmap->throttle() - 1);
+            if (c != nullptr) {
+                if (c->get_control_in() != 0) {
+                    check_failed(ARMING_CHECK_RC, true, "Throttle (RC%d) is not neutral", rcmap->throttle());
+                    check_passed = false;
+                }
+            }
+        }
+    }
+    return check_passed;
+}
+
 bool AP_Arming::rc_calibration_checks(bool report)
 {
     bool check_passed = true;
@@ -1009,6 +1057,13 @@ bool AP_Arming::pre_arm_checks(bool report)
 
 bool AP_Arming::arm_checks(AP_Arming::Method method)
 {
+    if ((checks_to_perform & ARMING_CHECK_ALL) ||
+        (checks_to_perform & ARMING_CHECK_RC)) {
+        if (!rc_arm_checks(method)) {
+            return false;
+        }
+    }
+
     // ensure the GPS drivers are ready on any final changes
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -150,6 +150,8 @@ protected:
 
     virtual bool rc_calibration_checks(bool report);
 
+    bool rc_arm_checks(AP_Arming::Method method);
+
     bool manual_transmitter_checks(bool report);
 
     bool mission_checks(bool report);

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -330,6 +330,8 @@ public:
     // has_valid_input should be pure-virtual when Plane is converted
     virtual bool has_valid_input() const { return false; };
 
+    virtual RC_Channel *get_arming_channel(void) const { return nullptr; };
+
     bool gcs_overrides_enabled() const { return _gcs_overrides_enabled; }
     void set_gcs_overrides_enabled(bool enable) {
         _gcs_overrides_enabled = enable;
@@ -360,6 +362,14 @@ public:
         return _options & uint32_t(Option::LOG_DATA);
     }
     
+    bool arming_check_throttle() const {
+        return _options & uint32_t(Option::ARMING_CHECK_THROTTLE);
+    }
+
+    bool arming_skip_checks_rpy() const {
+        return _options & uint32_t(Option::ARMING_SKIP_CHECK_RPY);
+    }
+
     float override_timeout_ms() const {
         return _override_timeout.get() * 1e3f;
     }
@@ -371,14 +381,18 @@ public:
     */
     bool get_pwm(uint8_t channel, uint16_t &pwm) const;
 
+    uint32_t last_input_ms() const { return last_update_ms; };
+
 protected:
 
     enum class Option {
-        IGNORE_RECEIVER  = (1 << 0), // RC receiver modules
-        IGNORE_OVERRIDES = (1 << 1), // MAVLink overrides
-        IGNORE_FAILSAFE  = (1 << 2), // ignore RC failsafe bits
-        FPORT_PAD        = (1 << 3), // pad fport telem output
-        LOG_DATA         = (1 << 4), // log rc input bytes
+        IGNORE_RECEIVER       = (1 << 0), // RC receiver modules
+        IGNORE_OVERRIDES      = (1 << 1), // MAVLink overrides
+        IGNORE_FAILSAFE       = (1 << 2), // ignore RC failsafe bits
+        FPORT_PAD             = (1 << 3), // pad fport telem output
+        LOG_DATA              = (1 << 4), // log rc input bytes
+        ARMING_CHECK_THROTTLE = (1 << 5), // run an arming check for neutral throttle
+        ARMING_SKIP_CHECK_RPY = (1 << 6), // skip the an arming checks for the roll/pitch/yaw channels
     };
 
     void new_override_received() {
@@ -390,6 +404,7 @@ private:
     // this static arrangement is to avoid static pointers in AP_Param tables
     static RC_Channel *channels;
 
+    uint32_t last_update_ms;
     bool has_new_overrides;
 
     AP_Float _override_timeout;

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -74,6 +74,8 @@ bool RC_Channels::read_input(void)
 
     has_new_overrides = false;
 
+    last_update_ms = AP_HAL::millis();
+
     bool success = false;
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
         success |= channel(i)->update();

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -86,7 +86,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe, 3:FPort Pad
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, 0),
 
     AP_GROUPEND


### PR DESCRIPTION
This is designed to catch the situation where someone has slowly nudged the trim sticks over by accident and has not noticed it. The problem with this is that they will be taking off and can be commanding a large input when they think they are neutral, which leads to erratic (and scary) flights.

This checks that the roll/pitch/throttle/yaw channels are inside of their deadzone before allowing arming. It's done as an `arm` rather then `prearm` check because I needed access to the method to check if the user was attempting to rudder arm or not.

This was bench tested with real hardware and behaved as expected.