### PR TITLE
Sub: Enable Visual Odometry interface

### DIFF
--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -30,6 +30,9 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
 #if OPTFLOW == ENABLED
     SCHED_TASK_CLASS(OpticalFlow,          &sub.optflow,             update,         200, 160),
 #endif
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+    SCHED_TASK_CLASS(AP_VisualOdom,       &sub.visual_odom,   update,         50,  200),
+#endif
     SCHED_TASK(update_batt_compass,   10,    120),
     SCHED_TASK(read_rangefinder,      20,    100),
     SCHED_TASK(update_altitude,       10,    100),

--- a/ArduSub/GCS_Sub.cpp
+++ b/ArduSub/GCS_Sub.cpp
@@ -36,7 +36,13 @@ void GCS_Sub::update_vehicle_sensor_status_flags()
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
     }
 #endif
-
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+    const AP_VisualOdom *visual_odom = AP::visualodom();
+    if (visual_odom && visual_odom->enabled()) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_VISION_POSITION;
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_VISION_POSITION;
+    }
+#endif
     control_sensors_present |=
         MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL |
         MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
@@ -64,6 +70,12 @@ void GCS_Sub::update_vehicle_sensor_status_flags()
 #if OPTFLOW == ENABLED
     if (optflow && optflow->healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
+    }
+#endif
+
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+    if (visual_odom && visual_odom->enabled() && visual_odom->healthy()) {
+        control_sensors_health |= MAV_SYS_STATUS_SENSOR_VISION_POSITION;
     }
 #endif
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -536,6 +536,12 @@ const AP_Param::Info Sub::var_info[] = {
     GOBJECT(rally,      "RALLY_",   AP_Rally),
 #endif
 
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+    // @Group: VISO
+    // @Path: ../libraries/AP_VisualOdom/AP_VisualOdom.cpp
+    GOBJECT(visual_odom, "VISO_", AP_VisualOdom),
+#endif
+
     // @Group: MOT_
     // @Path: ../libraries/AP_Motors/AP_Motors6DOF.cpp,../libraries/AP_Motors/AP_MotorsMulticopter.cpp
     GOBJECT(motors, "MOT_",         AP_Motors6DOF),

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -7,6 +7,9 @@
 #ifdef ENABLE_SCRIPTING
 #include <AP_Scripting/AP_Scripting.h>
 #endif
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+ # include <AP_VisualOdom/AP_VisualOdom.h>
+#endif
 
 // Global parameter class.
 //
@@ -101,7 +104,7 @@ public:
         k_param_relay, // Relay
         k_param_camera, // Camera
         k_param_camera_mount, // Camera gimbal
-
+        k_param_visual_odom,
 
         // RC_Channel settings (deprecated)
         k_param_rc_1_old = 75,
@@ -334,6 +337,11 @@ public:
 #ifdef ENABLE_SCRIPTING
     AP_Scripting scripting;
 #endif // ENABLE_SCRIPTING
+
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+    // Visual Odometry camera
+    AP_VisualOdom visual_odom;
+#endif
 
 };
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -82,6 +82,9 @@
 #if OPTFLOW == ENABLED
 #include <AP_OpticalFlow/AP_OpticalFlow.h>     // Optical Flow library
 #endif
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+ # include <AP_VisualOdom/AP_VisualOdom.h>
+#endif
 
 #if RCMAP_ENABLED == ENABLED
 #include <AP_RCMapper/AP_RCMapper.h>        // RC input mapping library
@@ -178,6 +181,11 @@ private:
     // Optical flow sensor
 #if OPTFLOW == ENABLED
     OpticalFlow optflow;
+#endif
+
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+    // Visual Odometry camera
+    AP_VisualOdom visual_odom;
 #endif
 
     // system time in milliseconds of last recorded yaw reset from ekf
@@ -557,6 +565,7 @@ private:
 #if OPTFLOW == ENABLED
     void init_optflow();
 #endif
+    void init_visual_odom();
     void terrain_update();
     void terrain_logging();
     void init_ardupilot() override;

--- a/ArduSub/config.h
+++ b/ArduSub/config.h
@@ -114,9 +114,13 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
-//  OPTICAL_FLOW
+//  OPTICAL_FLOW & VISUAL ODOMETRY
 #ifndef OPTFLOW
 # define OPTFLOW       DISABLED
+#endif
+
+#ifndef VISUAL_ODOMETRY_ENABLED
+# define VISUAL_ODOMETRY_ENABLED !HAL_MINIMIZE_FEATURES
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduSub/control_poshold.cpp
+++ b/ArduSub/control_poshold.cpp
@@ -10,7 +10,7 @@
 bool Sub::poshold_init()
 {
     // fail to initialise PosHold mode if no GPS lock
-    if (!position_ok()) {
+    if (!position_ok() && (!visual_odom.enabled() || !visual_odom.healthy())) {
         return false;
     }
 

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -94,6 +94,14 @@ void Sub::init_optflow()
 }
 #endif      // OPTFLOW == ENABLED
 
+// init visual odometry sensor
+void Sub::init_visual_odom()
+{
+#if VISUAL_ODOMETRY_ENABLED == ENABLED
+    visual_odom.init();
+#endif
+}
+
 void Sub::accel_cal_update()
 {
     if (hal.util->get_soft_armed()) {

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -66,7 +66,7 @@ void Sub::init_ardupilot()
     init_rc_in();               // sets up rc channels from radio
     init_rc_out();              // sets up motors and output to escs
     init_joystick();            // joystick initialization
-
+    init_visual_odom();
     relay.init();
 
     /*


### PR DESCRIPTION
This will enable SUB to use DVL (Doppler Velocity Logger) sensors for position control.
We have a blog post explaining it [here](https://bluerobotics.com/ardusub-research-development-dvl/).

The DVL outputs are very precise (usually < 1% error) and the output is quite compatible with the [VISION_POSITION_DELTA](https://mavlink.io/en/messages/ardupilotmega.html#VISION_POSITION_DELTA) message. They usually provides Z position, XY velocity (which we integrate) and most have a built-in IMU for attitude. 