### PR TITLE
AP_RAMTRON: correct compilation for gcc 9

### DIFF
--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -50,36 +50,33 @@ bool AP_RAMTRON::init(void)
     }
     WITH_SEMAPHORE(dev->get_semaphore());
 
-    struct cypress_rdid {
-        uint8_t manufacturer[6];
-        uint8_t memory;
-        uint8_t id1;
-        uint8_t id2;
-    };
-    struct fujitsu_rdid {
-        uint8_t manufacturer[2];
-        uint8_t id1;
-        uint8_t id2;
-    };
-
-    uint8_t rdid[sizeof(cypress_rdid)];
-
-    if (!dev->read_registers(RAMTRON_RDID, rdid, sizeof(rdid))) {
-        return false;
-    }
-
     for (uint8_t i = 0; i < ARRAY_SIZE(ramtron_ids); i++) {
         if (ramtron_ids[i].rdid_type == RDID_type::Cypress) {
-            cypress_rdid const * const cypress = (cypress_rdid const * const)rdid;
-            if (ramtron_ids[i].id1 == cypress->id1 &&
-                ramtron_ids[i].id2 == cypress->id2) {
+            struct {
+                uint8_t manufacturer[6];
+                uint8_t memory;
+                uint8_t id1;
+                uint8_t id2;
+            } cypress;
+            if (!dev->read_registers(RAMTRON_RDID, (uint8_t*)&cypress, sizeof(cypress))) {
+                return false;
+            }
+            if (ramtron_ids[i].id1 == cypress.id1 &&
+                ramtron_ids[i].id2 == cypress.id2) {
                 id = i;
                 break;
             }
         } else if (ramtron_ids[i].rdid_type == RDID_type::Fujitsu) {
-            fujitsu_rdid const * const fujitsu = (fujitsu_rdid const * const)rdid;
-            if (ramtron_ids[i].id1 == fujitsu->id1 &&
-                ramtron_ids[i].id2 == fujitsu->id2) {
+            struct {
+                uint8_t manufacturer[2];
+                uint8_t id1;
+                uint8_t id2;
+            } fujitsu;
+            if (!dev->read_registers(RAMTRON_RDID, (uint8_t*)&fujitsu, sizeof(fujitsu))) {
+                return false;
+            }
+            if (ramtron_ids[i].id1 == fujitsu.id1 &&
+                ramtron_ids[i].id2 == fujitsu.id2) {
                 id = i;
                 break;
             }


### PR DESCRIPTION
```
../../libraries/AP_RAMTRON/AP_RAMTRON.cpp: In member function 'bool AP_RAMTRON::init()':
../../libraries/AP_RAMTRON/AP_RAMTRON.cpp:73:78: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
   73 |             cypress_rdid const * const cypress = (cypress_rdid const * const)rdid;
      |                                                                              ^~~~
compilation terminated due to -Wfatal-errors.
cc1plus: some warnings being treated as errors
```

This also has the benefit of only reading the expected number of registers
from the device.

Tested on CubeBlack.  Still finds the RAMTRON.  Still preserves parameters.

Intentionally breaking detection by putting a "break" into the relevant loop does cause the Cube to not boot (presumably it has panicked without initialising the GCS) - so this patch does appear to detect the RAMTRON appropriately.

AFAIK I only have a Cypress to test on.
