### PR TITLE
Copter/GCS_MAVLink:  Change the component ID to be able to set it.

### DIFF
--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -7,6 +7,11 @@ uint8_t GCS_Copter::sysid_this_mav() const
     return copter.g.sysid_this_mav;
 }
 
+uint8_t GCS_Copter::compid_this_mav() const
+{
+    return copter.g.compid_this_mav;
+}
+
 const char* GCS_Copter::frame_string() const
 {
     return copter.get_frame_string();

--- a/ArduCopter/GCS_Copter.h
+++ b/ArduCopter/GCS_Copter.h
@@ -40,6 +40,7 @@ public:
 protected:
 
     uint8_t sysid_this_mav() const override;
+    uint8_t compid_this_mav() const override;
 
     // minimum amount of time (in microseconds) that must remain in
     // the main scheduler loop before we are allowed to send any

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -50,6 +50,13 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(sysid_this_mav, "SYSID_THISMAV",   MAV_SYSTEM_ID),
 
+    // @Param: COMPID_THISMAV
+    // @DisplayName: MAVLink Component ID of this vehicle
+    // @Description: Allows setting an individual MAVLink Component id for this vehicle to distinguish it
+    // @Range: 1 255
+    // @User: Advanced
+    GSCALAR(compid_this_mav, "COMPID_THISMAV",   MAV_COMPONENT_ID),
+
     // @Param: SYSID_MYGCS
     // @DisplayName: My ground station number
     // @Description: Allows restricting radio overrides to only come from my ground station

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -218,6 +218,7 @@ public:
         k_param_takeoff_trigger_dz_old,
         k_param_gcs3,
         k_param_gcs_pid_mask,    // 126
+        k_param_compid_this_mav, // 127
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -406,7 +407,9 @@ public:
 
     AP_Int16        poshold_brake_rate;         // PosHold flight mode's rotation rate during braking in deg/sec
     AP_Int16        poshold_brake_angle_max;    // PosHold flight mode's max lean angle during braking in centi-degrees
-    
+
+    AP_Int16        compid_this_mav;
+
     // Waypoints
     //
     AP_Int32        rtl_loiter_time;

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -129,6 +129,9 @@
  # define MAV_SYSTEM_ID          1
 #endif
 
+#ifndef  MAV_COMPONENT_ID
+ # define MAV_COMPONENT_ID       1
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Battery monitoring

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -36,6 +36,7 @@ const MAV_MISSION_TYPE GCS_MAVLINK::supported_mission_types[] = {
 void GCS::init()
 {
     mavlink_system.sysid = sysid_this_mav();
+    mavlink_system.compid = compid_this_mav();
 }
 
 /*

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -952,6 +952,7 @@ public:
 protected:
 
     virtual uint8_t sysid_this_mav() const = 0;
+    virtual uint8_t compid_this_mav() const = 0;
 
     virtual GCS_MAVLINK *new_gcs_mavlink_backend(GCS_MAVLINK_Parameters &params,
                                                  AP_HAL::UARTDriver &uart) = 0;


### PR DESCRIPTION
I'm considering implementing two or more FCs on a 1 airframe.
Component IDs from 25 to 75 can be defined by the user.
I have ArduPilot pegging the component ID to 1.
When I connect two FCs with UART, they get mixed up.
Therefore, I will allow you to specify the component ID.

![20200401](https://user-images.githubusercontent.com/646194/78122340-98022980-7447-11ea-9c2c-758e20ef2e8f.png)
![IMG-7519](https://user-images.githubusercontent.com/646194/78122353-9c2e4700-7447-11ea-9277-586a3d2cc561.jpg)
