### PR TITLE
Support sending raw IMU data to a UART

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -296,6 +296,7 @@ BUILD_OPTIONS = [
     Feature('Sensors', 'AIRSPEED', 'AP_AIRSPEED_ENABLED', 'Enable Airspeed Sensors', 1, None),    # Default to enabled to not annoy Plane users   # NOQA: E501
     Feature('Sensors', 'BEACON', 'AP_BEACON_ENABLED', 'Enable Beacon', 0, None),
     Feature('Sensors', 'GPS_MOVING_BASELINE', 'GPS_MOVING_BASELINE', 'Enable GPS Moving Baseline', 0, None),
+    Feature('Sensors', 'IMU_ON_UART', 'AP_SERIALMANAGER_IMUOUT_ENABLED', 'Enable sending raw IMU data on a serial port', 0, None), # NOQA: E501
 
     Feature('Other', 'GyroFFT', 'HAL_GYROFFT_ENABLED', 'Enable In-Flight Gyro FFT calculations', 0, None),
     Feature('Other', 'DISPLAY', 'HAL_DISPLAY_ENABLED', 'Enable I2C Displays', 0, None),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -236,6 +236,7 @@ class ExtractFeatures(object):
             ('COMPASS_CAL_ENABLED', 'CompassCalibrator::stop'),
             ('AP_TUNING_ENABLED', 'AP_Tuning::check_input'),
             ('AP_DRONECAN_SERIAL_ENABLED', 'AP_DroneCAN_Serial::update'),
+            ('AP_SERIALMANAGER_IMUOUT_ENABLED', 'AP_InertialSensor::send_uart_data'),
         ]
 
     def progress(self, msg):

--- a/Tools/scripts/imu_uart_decode.py
+++ b/Tools/scripts/imu_uart_decode.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+'''
+script to decode IMU data on a UART
+'''
+
+import socket, struct, serial, sys
+
+import argparse
+
+parser = argparse.ArgumentParser(description='decode IMU data from ArduPilot')
+
+parser.add_argument('--set-file', type=str, default=None, help='replace parameter defaults from a file')
+parser.add_argument('--tcp', default=None, help='TCP endpoint as IP:port')
+parser.add_argument('--device', default=None, help='serial port to read from')
+parser.add_argument('--baudrate', default=921600, help='baudrate for serial port')
+
+args = parser.parse_args()
+
+if args.tcp is None and args.device is None:
+    print("Must specicy --tcp or --device")
+    sys.exit(1)
+
+if args.tcp is not None:
+    server_address = args.tcp.split(':')
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.connect((server_address[0], int(server_address[1])))
+else:
+    port = serial.Serial(args.device, baudrate=args.baudrate)
+
+def crc16_from_bytes(bytes, initial=0):
+    # CRC-16-CCITT
+    # Initial value: 0xFFFF
+    # Poly: 0x1021
+    # Reverse: no
+    # Output xor: 0
+    # Check string: '123456789'
+    # Check value: 0x29B1
+
+    try:
+        if isinstance(bytes, basestring):  # Python 2.7 compatibility
+            bytes = map(ord, bytes)
+    except NameError:
+        if isinstance(bytes, str):  # This branch will be taken on Python 3
+            bytes = map(ord, bytes)
+
+    crc = initial
+    for byte in bytes:
+        crc ^= byte << 8
+        for bit in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return crc & 0xFFFF
+
+class Packet(object):
+    def __init__(self, pkt):
+        '''parse the packet'''
+        self.pkt = pkt
+        self.delta_velocity = [0.0]*3
+        self.delta_angle = [0.0]*3
+        (self.magic,
+             self.length,
+             self.timestamp_us,
+             self.delta_velocity[0],
+             self.delta_velocity[1],
+             self.delta_velocity[2],
+             self.delta_angle[0],
+             self.delta_angle[1],
+             self.delta_angle[2],
+             self.delta_velocity_dt,
+             self.delta_angle_dt,
+             self.counter,
+             self.crc) = struct.unpack("<HHIffffffffHH", pkt)
+
+    def crc_ok(self):
+        '''check CRC is OK'''
+        return self.crc == crc16_from_bytes(bytes(self.pkt[:-2]))
+
+    def __str__(self):
+        return "%u (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f) %.3f %.3f" % (self.counter,
+                                                                       self.delta_velocity[0],
+                                                                       self.delta_velocity[1],
+                                                                       self.delta_velocity[2],
+                                                                       self.delta_angle[0],
+                                                                       self.delta_angle[1],
+                                                                       self.delta_angle[2],
+                                                                       self.delta_velocity_dt,
+                                                                       self.delta_angle_dt)
+
+
+class UARTDecoder(object):
+    def __init__(self):
+        self.buf = bytearray()
+        self.magic = [0xc4, 0x29]
+        self.full_length = 44
+        self.last_counter = 0
+
+    def add_byte(self, b):
+        '''add one byte to buffer'''
+        if len(self.buf) < len(self.magic) and b != self.magic[len(self.buf)]:
+            self.buf = bytearray()
+            return None
+        self.buf.append(b)
+        if len(self.buf) == self.full_length:
+            ret = Packet(self.buf)
+            self.buf = bytearray()
+            if ret.crc_ok():
+                if ret.counter != self.last_counter+1:
+                    print("LOST! %u %u\n", ret.counter, self.last_counter+1)
+                self.last_counter = ret.counter
+                return ret
+        return None
+
+    def add_data(self, msg):
+        '''add a block of data'''
+        ret = None
+        for b in msg:
+            r = self.add_byte(b)
+            if r is not None:
+                ret = r
+        return ret
+
+
+decoder = UARTDecoder()
+
+while True:
+    if args.tcp:
+        msg, addr = sock.recvfrom(64)
+    else:
+        msg = port.read(64)
+    pkt = decoder.add_data(msg)
+    if pkt is not None:
+        print(str(pkt))

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -19,6 +19,7 @@
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <Filter/LowPassFilter.h>
 #include <Filter/HarmonicNotchFilter.h>
+#include <AP_SerialManager/AP_SerialManager_config.h>
 #include "AP_InertialSensor_Params.h"
 #include "AP_InertialSensor_tempcal.h"
 
@@ -301,6 +302,17 @@ public:
 
     // for killing an IMU for testing purposes
     void kill_imu(uint8_t imu_idx, bool kill_it);
+
+#if AP_SERIALMANAGER_IMUOUT_ENABLED
+    // optional UART for sending IMU data to an external process
+    void set_imu_out_uart(AP_HAL::UARTDriver *uart);
+    void send_uart_data(void);
+
+    struct {
+        uint16_t counter;
+        AP_HAL::UARTDriver *imu_out_uart;
+    } uart;
+#endif // AP_SERIALMANAGER_IMUOUT_ENABLED
 
     enum IMU_SENSOR_TYPE {
         IMU_SENSOR_TYPE_ACCEL = 0,

--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -117,7 +117,7 @@ static const char* SERIAL_PROTOCOL_VALUES[] = {
     "FSKY_TX", "LID360", "", "BEACN", "VOLZ", "SBUS", "ESC_TLM", "DEV_TLM", "OPTFLW", "RBTSRV",
     "NMEA", "WNDVNE", "SLCAN", "RCIN", "MGSQRT", "LTM", "RUNCAM", "HOT_TLM", "SCRIPT", "CRSF",
     "GEN", "WNCH", "MSP", "DJI", "AIRSPD", "ADSB", "AHRS", "AUDIO", "FETTEC", "TORQ",
-    "AIS", "CD_ESC", "MSP_DP", "MAV_HL", "TRAMP", "DDS"
+    "AIS", "CD_ESC", "MSP_DP", "MAV_HL", "TRAMP", "DDS", "IMUOUT",
 };
 static_assert(AP_SerialManager::SerialProtocol_NumProtocols == ARRAY_SIZE(SERIAL_PROTOCOL_VALUES), "Wrong size SerialProtocol_NumProtocols");
 

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -24,6 +24,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_RCProtocol/AP_RCProtocol.h>
 #include <AP_MSP/AP_MSP.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include "AP_SerialManager.h"
 #include <GCS_MAVLink/GCS.h>
 
@@ -209,7 +210,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:Gimbal, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp, 45:DDS XRCE
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:Gimbal, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp, 45:DDS XRCE, 46:IMUDATA
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, DEFAULT_SERIAL1_PROTOCOL),
@@ -600,6 +601,17 @@ void AP_SerialManager::init()
                     // Note init is handled by AP_MSP
                     break;
 #endif
+
+#if AP_SERIALMANAGER_IMUOUT_ENABLED
+                case SerialProtocol_IMUOUT:
+                    uart->begin(state[i].baudrate(),
+                                AP_SERIALMANAGER_IMUOUT_BUFSIZE_RX,
+                                AP_SERIALMANAGER_IMUOUT_BUFSIZE_TX);
+                    AP::ins().set_imu_out_uart(uart);
+                    uart->set_unbuffered_writes(true);
+                    break;
+#endif
+
                 default:
                     uart->begin(state[i].baudrate());
             }

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -79,6 +79,7 @@ public:
         SerialProtocol_MAVLinkHL = 43,
         SerialProtocol_Tramp = 44,
         SerialProtocol_DDS_XRCE = 45,
+        SerialProtocol_IMUOUT = 46,
         SerialProtocol_NumProtocols                    // must be the last value
     };
 

--- a/libraries/AP_SerialManager/AP_SerialManager_config.h
+++ b/libraries/AP_SerialManager/AP_SerialManager_config.h
@@ -21,6 +21,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Networking/AP_Networking_Config.h>
+#include <AP_InertialSensor/AP_InertialSensor_config.h>
 
 #ifdef HAL_UART_NUM_SERIAL_PORTS
 #if HAL_UART_NUM_SERIAL_PORTS >= 4
@@ -54,6 +55,10 @@
 
 #ifndef AP_SERIALMANAGER_REGISTER_ENABLED
 #define AP_SERIALMANAGER_REGISTER_ENABLED BOARD_FLASH_SIZE > 1024 && (AP_NETWORKING_ENABLED || HAL_ENABLE_DRONECAN_DRIVERS)
+#endif
+
+#ifndef AP_SERIALMANAGER_IMUOUT_ENABLED
+#define AP_SERIALMANAGER_IMUOUT_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL) && AP_INERTIALSENSOR_ENABLED
 #endif
 
 // serial ports registered by AP_Networking will use IDs starting at 21 for the first port
@@ -127,3 +132,8 @@
 #define AP_SERIALMANAGER_MSP_BUFSIZE_RX     128
 #define AP_SERIALMANAGER_MSP_BUFSIZE_TX     256
 #define AP_SERIALMANAGER_MSP_BAUD           115200
+
+// IMU OUT protocol
+#define AP_SERIALMANAGER_IMUOUT_BAUD           921600
+#define AP_SERIALMANAGER_IMUOUT_BUFSIZE_RX     128
+#define AP_SERIALMANAGER_IMUOUT_BUFSIZE_TX     2048


### PR DESCRIPTION
This allows unfiltered IMU data to be sent at the main loop rate to a UART. This is for supporting external visual odomotry systems that need to augment image data with the autopilots IMU data

was used for this ANU research project: https://github.com/STR-ANU/eqf_vio