### PR TITLE
AP_Logger: log dataflash-over-mavlink timestamp in micros rather than millis

### DIFF
--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -325,7 +325,7 @@ void AP_Logger_MAVLink::Write_logger_MAV(AP_Logger_MAVLink &logger_mav)
     }
     const struct log_MAV_Stats pkt{
         LOG_PACKET_HEADER_INIT(LOG_MAV_STATS),
-        timestamp         : AP_HAL::millis(),
+        timestamp         : AP_HAL::micros64(),
         seqno             : logger_mav._next_seq_num-1,
         dropped           : logger_mav._dropped,
         retries           : logger_mav._blocks_retry.sent_count,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1007,7 +1007,7 @@ struct PACKED log_GYRO {
 
 struct PACKED log_MAV_Stats {
     LOG_PACKET_HEADER;
-    uint32_t timestamp;
+    uint64_t timestamp;
     uint32_t seqno;
     uint32_t dropped;
     uint32_t retries;
@@ -1649,7 +1649,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_RFND_MSG, sizeof(log_RFND), \
       "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--" }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
-      "DMS", "IIIIIBBBBBBBBB",         "TimeMS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "C-------------" }, \
+      "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     { LOG_BEACON_MSG, sizeof(log_Beacon), \
       "BCN", "QBBfffffff",  "TimeUS,Health,Cnt,D0,D1,D2,D3,PosX,PosY,PosZ", "s--mmmmmmm", "F--BBBBBBB" }, \
     { LOG_PROXIMITY_MSG, sizeof(log_Proximity), \


### PR DESCRIPTION
... like the vast majority of our dataflash messages