### PR TITLE
libraries: Deletes the 0-bit left shift process.

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -485,7 +485,7 @@ return the filter fault status as a bitmasked integer
 */
 void  NavEKF2_core::getFilterFaults(uint16_t &faults) const
 {
-    faults = (stateStruct.quat.is_nan()<<0 |
+    faults = (stateStruct.quat.is_nan() |
               stateStruct.velocity.is_nan()<<1 |
               faultStatus.bad_xmag<<2 |
               faultStatus.bad_ymag<<3 |
@@ -508,7 +508,7 @@ return filter timeout status as a bitmasked integer
 */
 void  NavEKF2_core::getFilterTimeouts(uint8_t &timeouts) const
 {
-    timeouts = (posTimeout<<0 |
+    timeouts = (posTimeout |
                 velTimeout<<1 |
                 hgtTimeout<<2 |
                 magTimeout<<3 |

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -493,7 +493,7 @@ return the filter fault status as a bitmasked integer
 */
 void  NavEKF3_core::getFilterFaults(uint16_t &faults) const
 {
-    faults = (stateStruct.quat.is_nan()<<0 |
+    faults = (stateStruct.quat.is_nan() |
               stateStruct.velocity.is_nan()<<1 |
               faultStatus.bad_xmag<<2 |
               faultStatus.bad_ymag<<3 |
@@ -516,7 +516,7 @@ return filter timeout status as a bitmasked integer
 */
 void  NavEKF3_core::getFilterTimeouts(uint8_t &timeouts) const
 {
-    timeouts = (posTimeout<<0 |
+    timeouts = (posTimeout |
                 velTimeout<<1 |
                 hgtTimeout<<2 |
                 magTimeout<<3 |

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1488,7 +1488,7 @@ void GCS_MAVLINK::log_mavlink_stats()
     }
 
     enum class Flags {
-        USING_SIGNING = (1<<0),
+        USING_SIGNING = (1),
         ACTIVE = (1<<1),
         STREAMING = (1<<2),
         PRIVATE = (1<<3),


### PR DESCRIPTION
I don't see the need for a meaningless left 0-bit number shift.
I don't think this statement makes it any easier to understand.
I think the processing is better on the edge.