### PR TITLE
Copter: Fix Rate expo calculation

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -10,17 +10,15 @@ float Copter::get_pilot_desired_yaw_rate(int16_t stick_angle)
     }
     float yaw_request;
 
+    // range check expo
+    g2.acro_y_expo = constrain_float(g2.acro_y_expo, 0.0f, 1.0f);
+
     // calculate yaw rate request
-    if (g2.acro_y_expo <= 0) {
+    if (is_zero(g2.acro_y_expo)) {
         yaw_request = stick_angle * g.acro_yaw_p;
     } else {
         // expo variables
         float y_in, y_in3, y_out;
-
-        // range check expo
-        if (g2.acro_y_expo > 1.0f || g2.acro_y_expo < 0.5f) {
-            g2.acro_y_expo = 1.0f;
-        }
 
         // yaw expo
         y_in = float(stick_angle)/ROLL_PITCH_YAW_INPUT_MAX;

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -82,19 +82,17 @@ void ModeAcro::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, 
         roll_in *= ratio;
         pitch_in *= ratio;
     }
+
+    // range check expo
+    g.acro_rp_p = constrain_float(g.acro_rp_p, 0.0f, 1.0f);
     
     // calculate roll, pitch rate requests
-    if (g.acro_rp_expo <= 0) {
+    if (is_zero(g.acro_rp_expo)) {
         rate_bf_request.x = roll_in * g.acro_rp_p;
         rate_bf_request.y = pitch_in * g.acro_rp_p;
     } else {
         // expo variables
         float rp_in, rp_in3, rp_out;
-
-        // range check expo
-        if (g.acro_rp_expo > 1.0f) {
-            g.acro_rp_expo = 1.0f;
-        }
 
         // roll expo
         rp_in = float(roll_in)/ROLL_PITCH_YAW_INPUT_MAX;


### PR DESCRIPTION
This fixes a bug in the yaw rate expo and makes these changes consistent with roll and pitch rate expo.

This bug was found by Nicolas Bosson:
https://discuss.ardupilot.org/t/bug-in-yaw-expo-range-check/54424

I noticed it’s currently not possible to set ACRO_Y_EXPO to any value smaller than 0.5, except 0.
The desired value (let’s say 0.3) is overwritten to 1 at next reboot.