### PR TITLE
Make COMPASS_ENABLED a reboot-required parameter

### DIFF
--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -13,9 +13,7 @@ void Tracker::update_ahrs()
  */
 void Tracker::update_compass(void)
 {
-    if (AP::compass().enabled() && compass.read()) {
-        ahrs.set_compass(&compass);
-    }
+    UNUSED_RESULT(compass.read());
 }
 
 // Save compass offsets

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -367,12 +367,11 @@ void Copter::update_batt_compass(void)
     // read battery before compass because it may be used for motor interference compensation
     battery.read();
 
-    if(AP::compass().enabled()) {
-        // update compass with throttle value - used for compassmot
-        compass.set_throttle(motors->get_throttle());
-        compass.set_voltage(battery.voltage());
-        compass.read();
-    }
+    // update compass with throttle value - used for compassmot
+    compass.set_throttle(motors->get_throttle());
+    compass.set_voltage(battery.voltage());
+    // the compass will eventually go unhealthy.
+    UNUSED_RESULT(compass.read());
 }
 
 // Full rate logging of attitude, rate and pid loops

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -177,8 +177,10 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
     motor_test_throttle_value = throttle_value;
 
     if (motor_test_throttle_type == MOTOR_TEST_COMPASS_CAL) {
-        compass.per_motor_calibration_start();
-    }            
+        if (!compass.per_motor_calibration_start()) {
+            return MAV_RESULT_FAILED;
+        }
+    }
 
     // return success
     return MAV_RESULT_ACCEPTED;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -190,9 +190,7 @@ void Plane::update_speed_height(void)
  */
 void Plane::update_compass(void)
 {
-    if (AP::compass().enabled() && compass.read()) {
-        ahrs.set_compass(&compass);
-    }
+    UNUSED_RESULT(compass.read());
 }
 
 /*

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -163,11 +163,9 @@ void Sub::update_batt_compass()
     // read battery before compass because it may be used for motor interference compensation
     battery.read();
 
-    if (AP::compass().enabled()) {
-        // update compass with throttle value - used for compassmot
-        compass.set_throttle(motors.get_throttle());
-        compass.read();
-    }
+    // update compass with throttle value - used for compassmot
+    compass.set_throttle(motors.get_throttle());
+    UNUSED_RESULT(compass.read());
 }
 
 // ten_hz_logging_loop

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -5,9 +5,7 @@
 // check for new compass data - 10Hz
 void Rover::update_compass(void)
 {
-    if (AP::compass().enabled() && compass.read()) {
-        ahrs.set_compass(&compass);
-    }
+    UNUSED_RESULT(compass.read());
 }
 
 // Save compass offsets

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1194,7 +1194,7 @@ void AP_Periph_FW::can_mag_update(void)
     if (!compass.enabled()) {
         return;
     }
-    compass.read();
+    UNUSED_RESULT(compass.read());
 #if CAN_PROBE_CONTINUOUS
     if (compass.get_count() == 0) {
         static uint32_t last_probe_ms;

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -111,7 +111,6 @@ void ReplayVehicle::init_ardupilot(void)
     // places in the EKF, for example)
     logger.Init(log_structure, 0);
 
-    ahrs.set_compass(&compass);
     ahrs.set_fly_forward(true);
     ahrs.set_wind_estimation(true);
     ahrs.set_correct_centrifugal(true);
@@ -652,7 +651,7 @@ void Replay::read_sensors(const char *type)
             _vehicle.ahrs.estimate_wind();
         }
     } else if (streq(type,"MAG")) {
-        _vehicle.compass.read();
+        UNUSED_RESULT(_vehicle.compass.read());
     } else if (streq(type,"ARSP")) {
         _vehicle.ahrs.set_airspeed(&_vehicle.airspeed);
     } else if (streq(type,"BARO")) {

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -48,8 +48,7 @@ void setup(void)
 
     compass.init();
     if(compass.read()) {
-        hal.console->printf("Enabling compass\n");
-        ahrs.set_compass(&compass);
+        hal.console->printf("Found compass\n");
     } else {
         hal.console->printf("No compass detected\n");
     }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1477,6 +1477,9 @@ Compass::read(void)
 
     for (uint8_t i=0; i< _backend_count; i++) {
         // call read on each of the backend. This call updates field[i]
+        if (_disabled_mask & (1<<i)) {
+            continue;
+        }
         _backends[i]->read();
     }
     uint32_t time = AP_HAL::millis();

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -841,6 +841,7 @@ void Compass::mag_state::copy_from(const Compass::mag_state& state)
 //
 bool Compass::register_compass(int32_t dev_id, uint8_t& instance)
 {
+    check_initialised();
 
 #if COMPASS_MAX_INSTANCES == 1 && !COMPASS_MAX_UNREG_DEV
     // simple single compass setup for AP_Periph
@@ -935,6 +936,7 @@ Compass::StateIndex Compass::_get_state_id(Compass::Priority priority) const
 
 bool Compass::_add_backend(AP_Compass_Backend *backend)
 {
+    check_initialised();
     if (!backend) {
         return false;
     }
@@ -953,6 +955,7 @@ bool Compass::_add_backend(AP_Compass_Backend *backend)
  */
 bool Compass::_driver_enabled(enum DriverType driver_type)
 {
+    check_initialised();
     uint32_t mask = (1U<<uint8_t(driver_type));
     return (mask & uint32_t(_driver_type_mask.get())) == 0;
 }
@@ -1433,6 +1436,7 @@ void Compass::_reset_compass_id()
 void
 Compass::_detect_runtime(void)
 {
+    check_initialised();
 #if HAL_WITH_UAVCAN
     //Don't try to add device while armed
     if (hal.util->get_soft_armed()) {
@@ -1676,12 +1680,14 @@ uint8_t Compass::get_num_enabled(void) const
 void
 Compass::set_use_for_yaw(uint8_t i, bool use)
 {
+    check_initialised();
     _use_for_yaw[Priority(i)].set(use);
 }
 
 void
 Compass::set_declination(float radians, bool save_to_eeprom)
 {
+    check_initialised();
     if (save_to_eeprom) {
         _declination.set_and_save(radians);
     } else {
@@ -1692,6 +1698,7 @@ Compass::set_declination(float radians, bool save_to_eeprom)
 float
 Compass::get_declination() const
 {
+    check_initialised();
     return _declination.get();
 }
 
@@ -1876,6 +1883,8 @@ void Compass::motor_compensation_type(const uint8_t comp_type)
 
 bool Compass::consistent() const
 {
+    check_initialised();
+
     const Vector3f &primary_mag_field = get_field();
     const Vector2f primary_mag_field_xy = Vector2f(primary_mag_field.x,primary_mag_field.y);
 
@@ -1930,6 +1939,8 @@ bool Compass::consistent() const
  */
 bool Compass::have_scale_factor(uint8_t i) const
 {
+    check_initialised();
+
     StateIndex id = _get_state_id(Priority(i));
     if (id >= COMPASS_MAX_INSTANCES ||
         _state[id].scale_factor < COMPASS_MIN_SCALE_FACTOR ||

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1643,14 +1643,14 @@ void Compass::try_set_initial_location()
 bool
 Compass::use_for_yaw(void) const
 {
-    return _initialised && healthy(0) && use_for_yaw(0);
+    return _initialised && _enabled && healthy(0) && use_for_yaw(0);
 }
 
 /// return true if the specified compass can be used for yaw calculations
 bool
 Compass::use_for_yaw(uint8_t i) const
 {
-    if (!_initialised) {
+    if (!_initialised || !_enabled) {
         return false;
     }
     // when we are doing in-flight compass learning the state

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -103,6 +103,11 @@ public:
     // as we don't want it to have an effect at run-time.
     bool enabled() const { return initialised(); }
 
+    // used to disable Compass for Compass failure testing in flight
+    void set_disabled_mask(uint8_t mask) {
+        _disabled_mask = mask;
+    }
+
     // many methods in here should not be called unless the
     // magnetometer has been initialised and is currently enabled
     void check_initialised() const {
@@ -637,6 +642,9 @@ private:
     bool _initial_location_set;
 
     bool _cal_thread_started;
+
+    // used for flight testing with Compass loss
+    bool _disabled_mask;
 };
 
 namespace AP {

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -8,6 +8,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_InternalError/AP_InternalError.h>
 
 #include "AP_Compass_Backend.h"
 #include "Compass_PerMotor.h"
@@ -102,6 +103,14 @@ public:
     // as we don't want it to have an effect at run-time.
     bool enabled() const { return initialised(); }
 
+    // many methods in here should not be called unless the
+    // magnetometer has been initialised and is currently enabled
+    void check_initialised() const {
+        if (!_initialised) {
+            AP::internalerror().error(AP_InternalError::error_t::flow_of_control);
+        }
+    }
+
     /// Calculate the tilt-compensated heading_ variables.
     ///
     /// @param dcm_matrix			The current orientation rotation matrix
@@ -109,6 +118,7 @@ public:
     /// @returns heading in radians
     ///
     float calculate_heading(const Matrix3f &dcm_matrix) const {
+        check_initialised();
         return calculate_heading(dcm_matrix, 0);
     }
     float calculate_heading(const Matrix3f &dcm_matrix, uint8_t i) const;
@@ -148,8 +158,14 @@ public:
     uint8_t get_num_enabled(void) const;
     
     /// Return the current field as a Vector3f in milligauss
-    const Vector3f &get_field(uint8_t i) const { return _get_state(Priority(i)).field; }
-    const Vector3f &get_field(void) const { return get_field(0); }
+    const Vector3f &get_field(uint8_t i) const {
+        check_initialised();
+        return _get_state(Priority(i)).field;
+    }
+    const Vector3f &get_field(void) const {
+        check_initialised();
+        return get_field(0);
+    }
 
     /// Return true if we have set a scale factor for a compass
     bool have_scale_factor(uint8_t i) const;
@@ -160,6 +176,7 @@ public:
 #if COMPASS_MOT_ENABLED
     // per-motor calibration access
     bool per_motor_calibration_start(void) WARN_IF_UNUSED {
+        check_initialised();
         return _per_motor.calibration_start();
     }
     void per_motor_calibration_update(void) {
@@ -200,8 +217,14 @@ public:
     ///
     /// @returns                    The current compass offsets in milligauss.
     ///
-    const Vector3f &get_offsets(uint8_t i) const { return _get_state(Priority(i)).offset; }
-    const Vector3f &get_offsets(void) const { return get_offsets(0); }
+    const Vector3f &get_offsets(uint8_t i) const {
+        check_initialised();
+        return _get_state(Priority(i)).offset;
+    }
+    const Vector3f &get_offsets(void) const {
+        check_initialised();
+        return get_offsets(0);
+    }
 
     const Vector3f &get_diagonals(uint8_t i) const { return _get_state(Priority(i)).diagonals; }
     const Vector3f &get_diagonals(void) const { return get_diagonals(0); }
@@ -242,6 +265,7 @@ public:
 
     /// get the motor compensation value.
     uint8_t get_motor_compensation_type() const {
+        check_initialised();
         return _motor_comp_type;
     }
 
@@ -253,8 +277,14 @@ public:
     void set_motor_compensation(uint8_t i, const Vector3f &motor_comp_factor);
 
     /// get motor compensation factors as a vector
-    const Vector3f& get_motor_compensation(uint8_t i) const { return _get_state(Priority(i)).motor_compensation; }
-    const Vector3f& get_motor_compensation(void) const { return get_motor_compensation(0); }
+    const Vector3f& get_motor_compensation(uint8_t i) const {
+        check_initialised();
+        return _get_state(Priority(i)).motor_compensation;
+    }
+    const Vector3f& get_motor_compensation(void) const {
+        check_initialised();
+        return get_motor_compensation(0);
+    }
 
     /// Saves the current motor compensation x/y/z values.
     ///

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -153,8 +153,8 @@ public:
 
 #if COMPASS_MOT_ENABLED
     // per-motor calibration access
-    void per_motor_calibration_start(void) {
-        _per_motor.calibration_start();
+    bool per_motor_calibration_start(void) WARN_IF_UNUSED {
+        return _per_motor.calibration_start();
     }
     void per_motor_calibration_update(void) {
         _per_motor.calibration_update();

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -92,9 +92,15 @@ public:
 
     /// Read the compass and update the mag_ variables.
     ///
-    bool read();
+    bool read() WARN_IF_UNUSED;
 
-    bool enabled() const { return _enabled; }
+    // _enabled is a parameter.  _initialised is set if we
+    // successfully initialise Compass at boot
+    bool initialised() const { return _initialised; }
+    // enabled is just an alias for initialised for now - to avoid
+    // code churn.  Note that we do NOT check the _enabled flag here
+    // as we don't want it to have an effect at run-time.
+    bool enabled() const { return initialised(); }
 
     /// Calculate the tilt-compensated heading_ variables.
     ///
@@ -136,7 +142,7 @@ public:
     void save_offsets(void);
 
     // return the number of compass instances
-    uint8_t get_count(void) const { return _compass_count; }
+    uint8_t get_count(void) const { return _initialised ? _compass_count : 0; }
 
     // return the number of enabled sensors
     uint8_t get_num_enabled(void) const;
@@ -348,6 +354,8 @@ public:
 private:
     static Compass *_singleton;
 
+    bool _initialised;
+
     // Use Priority and StateIndex typesafe index types
     // to distinguish between two different type of indexing
     // We use StateIndex for access by Backend
@@ -426,7 +434,11 @@ private:
     AP_Compass_Backend *_backends[COMPASS_MAX_BACKEND];
     uint8_t     _backend_count;
 
-    // whether to enable the compass drivers at all
+    // Parameter to indicate whether to enable the compass drivers at
+    // all.  Do NOT use this - use the initialised() method which checks
+    // the Compass class was initialised rather than whether it was
+    // enabled.  The driver may not be initialised it was disabled
+    // at boot.
     AP_Int8     _enabled;
 
     // number of registered compasses.

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -350,8 +350,11 @@ uint8_t Compass::_get_cal_mask()
  */
 MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_long_t &packet)
 {
-    MAV_RESULT result = MAV_RESULT_FAILED;
+    if (!_initialised) {
+        return MAV_RESULT_FAILED;
+    }
 
+    MAV_RESULT result = MAV_RESULT_FAILED;
     switch (packet.command) {
     case MAV_CMD_DO_START_MAG_CAL: {
         result = MAV_RESULT_ACCEPTED;
@@ -473,6 +476,10 @@ bool Compass::get_uncorrected_field(uint8_t instance, Vector3f &field)
 MAV_RESULT Compass::mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
                                       float lat_deg, float lon_deg)
 {
+    if (!_initialised) {
+        return MAV_RESULT_FAILED;
+    }
+
     _reset_compass_id();
     if (is_zero(lat_deg) && is_zero(lon_deg)) {
         Location loc;

--- a/libraries/AP_Compass/Compass_PerMotor.cpp
+++ b/libraries/AP_Compass/Compass_PerMotor.cpp
@@ -132,7 +132,7 @@ float Compass_PerMotor::scaled_output(uint8_t motor)
 }
 
 // per-motor calibration update
-void Compass_PerMotor::calibration_start(void)
+bool Compass_PerMotor::calibration_start(void)
 {
     for (uint8_t i=0; i<4; i++) {
         field_sum[i].zero();
@@ -145,12 +145,15 @@ void Compass_PerMotor::calibration_start(void)
     // samples. The offsets may have just changed from an offset
     // calibration
     for (uint8_t i=0; i<4; i++) {
-        compass.read();
+        if (!compass.read()) {
+            return false;
+        }
         hal.scheduler->delay(50);
     }
     
     base_field = compass.get_field(0);
     running = true;
+    return true;
 }
 
 // per-motor calibration update

--- a/libraries/AP_Compass/Compass_PerMotor.h
+++ b/libraries/AP_Compass/Compass_PerMotor.h
@@ -24,7 +24,7 @@ public:
         voltage = 0.9f * voltage + 0.1f * _voltage;
     }
 
-    void calibration_start(void);
+    bool calibration_start(void) WARN_IF_UNUSED;
     void calibration_update(void);
     void calibration_end(void);
     void compensate(Vector3f &offset);

--- a/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
+++ b/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
@@ -71,7 +71,9 @@ static void loop()
     // run read() at 10Hz
     if ((AP_HAL::micros() - timer) > 100000L) {
         timer = AP_HAL::micros();
-        compass.read();
+        if (!compass.read()) {
+            hal.console->printf("Compass read failed");
+        }
         const uint32_t read_time = AP_HAL::micros() - timer;
 
         for (uint8_t i = 0; i < compass_count; i++) {

--- a/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
+++ b/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
@@ -72,8 +72,7 @@ void setup(void)
 
     compass.init();
     if(compass.read()) {
-        hal.console->printf("Enabling compass\n");
-        vehicle.ahrs.set_compass(&compass);
+        hal.console->printf("Found compass\n");
     } else {
         hal.console->printf("No compass detected\n");
     }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1787,7 +1787,12 @@ void GCS_MAVLINK::send_sensor_offsets()
     }
     counter = 0;
 
-    const Vector3f &mag_offsets = compass.get_offsets(0);
+    Vector3f mag_offsets;
+    float declination = 0.0f;
+    if (compass.initialised()) {
+        mag_offsets = compass.get_offsets(0);
+        declination = compass.get_declination();
+    }
     const Vector3f &accel_offsets = ins.get_accel_offsets(0);
     const Vector3f &gyro_offsets = ins.get_gyro_offsets(0);
 
@@ -1797,7 +1802,7 @@ void GCS_MAVLINK::send_sensor_offsets()
                                     mag_offsets.x,
                                     mag_offsets.y,
                                     mag_offsets.z,
-                                    compass.get_declination(),
+                                    declination,
                                     barometer.get_pressure(),
                                     barometer.get_temperature()*100,
                                     gyro_offsets.x,

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -34,6 +34,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_Camera/AP_Camera.h>
 #include <AP_Camera/AP_RunCam.h>
 #include <AP_Generator/AP_Generator_RichenPower.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_ADSB/AP_ADSB.h>
 #include <AP_LandingGear/AP_LandingGear.h>
@@ -486,6 +487,9 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
         break;
     case AUX_FUNC::AVOID_ADSB:
     case AUX_FUNC::AVOID_PROXIMITY:
+    case AUX_FUNC::KILL_MAGS:
+    case AUX_FUNC::KILL_MAG1:
+    case AUX_FUNC::KILL_MAG2:
     case AUX_FUNC::FENCE:
     case AUX_FUNC::GPS_DISABLE:
     case AUX_FUNC::GPS_DISABLE_YAW:
@@ -975,6 +979,18 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
 
     case AUX_FUNC::GPS_DISABLE_YAW:
         AP::gps().set_force_disable_yaw(ch_flag == AuxSwitchPos::HIGH);
+        break;
+
+    case AUX_FUNC::KILL_MAGS:
+        AP::compass().set_disabled_mask(ch_flag == HIGH ? 0xff : 0);
+        break;
+
+    case AUX_FUNC::KILL_MAG1:
+        AP::compass().set_disabled_mask(ch_flag == HIGH ? (1 << 0) : 0);
+        break;
+
+    case AUX_FUNC::KILL_MAG2:
+        AP::compass().set_disabled_mask(ch_flag == HIGH ? (1 << 1) : 0);
         break;
 
     case AUX_FUNC::MOTOR_ESTOP:

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -191,6 +191,9 @@ public:
         // options used for testing
         KILL_IMU1 =          100, // disable first IMU (for IMU failure testing)
         KILL_IMU2 =          101, // disable second IMU (for IMU failure testing)
+        KILL_MAGS =          103, // disable all magnetometers
+        KILL_MAG1 =          104, // disable first magnetometer
+        KILL_MAG2 =          105, // disable second magnetometer
         CAM_MODE_TOGGLE =    102, // Momentary switch to cycle camera modes
         EKF_LANE_SWITCH =    103, // trigger lane switch attempt
         EKF_YAW_RESET =      104, // trigger yaw reset attempt


### PR DESCRIPTION
We're crossing too many codepaths without crossing the init() method if this is enabled at runtime as we've been checking to see if the library is *enabled* rather than if it is *initialised*.

Make entry to functions depend on whether the library was initialised rather than whether it was enabled.

Add more places where we check for intiialisation; it is safe to call read if the library isn't initialised - it will simply return false.

As discussed last devcall.
