### PR TITLE
Correct duplicate label issue in EFI log message

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1341,7 +1341,12 @@ class AutoTest(ABC):
             if name not in docco_ids:
                 self.progress("Undocumented message: %s" % name)
                 continue
+            seen_labels = {}
             for label in code_ids[name]["labels"].split(","):
+                if label in seen_labels:
+                    raise NotAchievedException("%s.%s is duplicate label" %
+                                               (name, label))
+                seen_labels[label] = True
                 if label not in docco_ids[name]["labels"]:
                     raise NotAchievedException("%s.%s not in documented fields" %
                                                (name, label))

--- a/libraries/AP_EFI/AP_EFI.cpp
+++ b/libraries/AP_EFI/AP_EFI.cpp
@@ -114,7 +114,7 @@ void AP_EFI::log_status(void)
                        uint8_t(state.ecu_index));
 
     AP::logger().Write("EFI2",
-                       "TimeUS,Healthy,ES,GE,CSE,TS,FPS,OPS,DS,MS,DS,SPU,IDX",
+                       "TimeUS,Healthy,ES,GE,CSE,TS,FPS,OPS,DS,MS,DebS,SPU,IDX",
                        "s------------",
                        "F------------",
                        "QBBBBBBBBBBBB",


### PR DESCRIPTION
... and add a sanity check to pick these up in future.

These might be picked up if we cross the codepath in SITL with our existing sanity checks on AP_Logger - but I can't immediately spot that code.  OTOH, we may not cross these Log_Write codepaths, so adding a sanity check like this would seem to be a good idea.
