### PR TITLE
Removed Microseconds from TimeUS field in logger documentaion

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -257,7 +257,7 @@ const LogStructure Rover::log_structure[] = {
 // @LoggerMessage: NTUN
 // @Description: Navigation Tuning information - e.g. vehicle destination
 // @URL: http://ardupilot.org/rover/docs/navigation.html
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: WpDist: distance to the current navigation waypoint
 // @Field: WpBrg: bearing to the current navigation waypoint
 // @Field: DesYaw: the vehicle's desired heading

--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -67,13 +67,13 @@ void Tracker::Log_Write_Vehicle_Pos(int32_t lat, int32_t lng, int32_t alt, const
 
 // @LoggerMessage: VBAR
 // @Description: Information received from tracked vehicle; barometer data
-// @Field: TimeUS: microseconds since system startup
-// @Field: Press: vehicle baromettric pressure
+// @Field: TimeUS: Time since system startup
+// @Field: Press: vehicle barometric pressure
 // @Field: AltDiff: altitude difference based on difference on barometric pressure
 
 // @LoggerMessage: VPOS
 // @Description: Information received from tracked vehicle; barometer position data
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Lat: tracked vehicle latitude
 // @Field: Lng: tracked vehicle longitude
 // @Field: Alt: tracked vehicle altitude

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -455,7 +455,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @LoggerMessage: PTUN
 // @Description: Parameter Tuning information
 // @URL: https://ardupilot.org/copter/docs/tuning.html#in-flight-tuning
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Param: Parameter being tuned
 // @Field: TunVal: Normalized value used inside tuning() function
 // @Field: TunMin: Tuning minimum limit
@@ -466,7 +466,7 @@ const struct LogStructure Copter::log_structure[] = {
 
 // @LoggerMessage: CTUN
 // @Description: Control Tuning information
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: ThI: throttle input
 // @Field: ABst: angle boost
 // @Field: ThO: throttle output
@@ -509,7 +509,7 @@ const struct LogStructure Copter::log_structure[] = {
     
 // @LoggerMessage: MOTB
 // @Description: Battery information
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: LiftMax: Maximum motor compensation gain
 // @Field: BatVolt: Ratio betwen detected battery voltage and maximum battery voltage
 // @Field: BatRes: Estimated battery resistance
@@ -530,7 +530,7 @@ const struct LogStructure Copter::log_structure[] = {
     
 // @LoggerMessage: HELI
 // @Description: Helicopter related messages 
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: DRRPM: Desired rotor speed
 // @Field: ERRPM: Estimated rotor speed
 // @Field: Gov: Governor Output
@@ -542,7 +542,7 @@ const struct LogStructure Copter::log_structure[] = {
 
 // @LoggerMessage: PL
 // @Description: Precision Landing messages
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Heal: True if Precision Landing is healthy
 // @Field: TAcq: True if landing target is detected
 // @Field: pX: Target position relative to vehicle, X-Axis (0 if target not found)
@@ -563,7 +563,7 @@ const struct LogStructure Copter::log_structure[] = {
 
 // @LoggerMessage: SIDD
 // @Description: System ID data
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Time: Time reference for waveform
 // @Field: Targ: Current waveform sample
 // @Field: F: Instantaneous waveform frequency
@@ -579,7 +579,7 @@ const struct LogStructure Copter::log_structure[] = {
    
 // @LoggerMessage: SIDS
 // @Description: System ID settings
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Ax: The axis which is being excited
 // @Field: Mag: Magnitude of the chirp waveform
 // @Field: FSt: Frequency at the start of chirp
@@ -594,7 +594,7 @@ const struct LogStructure Copter::log_structure[] = {
     
 // @LoggerMessage: GUID
 // @Description: Guided mode target information
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Type: Type of guided mode
 // @Field: pX: Target position, X-Axis
 // @Field: pY: Target position, Y-Axis

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -226,7 +226,7 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: CTUN
 // @Description: Control Tuning information
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: NavRoll: desired roll
 // @Field: Roll: achieved roll
 // @Field: NavPitch: desired pitch
@@ -242,7 +242,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @LoggerMessage: NTUN
 // @Description: Navigation Tuning information - e.g. vehicle destination
 // @URL: http://ardupilot.org/rover/docs/navigation.html
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Dist: distance to the current navigation waypoint
 // @Field: TBrg: bearing to the current navigation waypoint
 // @Field: NavBrg: the vehicle's desired heading
@@ -260,7 +260,7 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: ATRP
 // @Description: Pitch/Roll AutoTune messages for Plane 
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Type: Type of autotune (0 = Roll/ 1 = Pitch)
 // @Field: State: AutoTune state
 // @Field: Servo: Normalised control surface output (between -4500 to 4500)
@@ -272,7 +272,7 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: STAT
 // @Description: Current status of the aircraft
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: isFlying: True if aircraft is probably flying
 // @Field: isFlyProb: Probabilty that the aircraft is flying
 // @Field: Armed: Arm status of the aircraft
@@ -286,7 +286,7 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: QTUN
 // @Description: QuadPlane vertical tuning message
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: ThI: throttle input
 // @Field: ABst: angle boost
 // @Field: ThO: throttle output
@@ -303,7 +303,7 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: AOA
 // @Description: Angle of attack and Side Slip Angle values
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: AOA: Angle of Attack calculated from airspeed, wind vector,velocity vector 
 // @Field: SSA: Side Slip Angle calculated from airspeed, wind vector,velocity vector
     { LOG_AOA_SSA_MSG, sizeof(log_AOA_SSA),
@@ -311,7 +311,7 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: PIQR,PIQP,PIQY,PIQA
 // @Description: QuadPlane Proportional/Integral/Derivative gain values for Roll/Pitch/Yaw/Z
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Tar: desired value
 // @Field: Act: achieved value
 // @Field: Err: error between target and achieved
@@ -330,7 +330,7 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: AETR
 // @Description: Normalised pre-mixer control surface outputs
-// @Field: TimeUS: Microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Ail: Pre-mixer value for aileron output (between -4500 to 4500)
 // @Field: Elev: Pre-mixer value for elevator output (between -4500 to 4500)
 // @Field: Thr: Pre-mixer value for throttle output (between -4500 to 4500)

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -243,7 +243,7 @@ void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target
 
 // @LoggerMessage: CTUN
 // @Description: Control Tuning information
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: ThI: throttle input
 // @Field: ABst: angle boost
 // @Field: ThO: throttle output
@@ -252,7 +252,7 @@ void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target
 // @Field: Alt: achieved altitude
 // @Field: BAlt: barometric altitude
 // @Field: DSAlt: desired rangefinder altitude
-// @Field: SAlt: achived rangefinder altitude
+// @Field: SAlt: achieved rangefinder altitude
 // @Field: TAlt: terrain altitude
 // @Field: DCRt: desired climb rate
 // @Field: CRt: climb rate

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -1693,7 +1693,7 @@ void AC_AutoTune::get_poshold_attitude(float &roll_cd_out, float &pitch_cd_out, 
 // @LoggerMessage: ATUN
 // @Description: Copter/QuadPlane AutoTune
 // @Vehicles: Copter, Plane
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Axis: which axis is currently being tuned
 // @Field: TuneStep: step in autotune process
 // @Field: Targ: target angle or rate, depending on tuning step

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1358,12 +1358,12 @@ struct PACKED log_Arm_Disarm {
 // @Field: Offset: Offset from parameter
 // @Field: U: True if sensor is being used
 // @Field: Health: True if sensor is healthy
-// @Field: Hfp: Probablilty sensor has failed
+// @Field: Hfp: Probability sensor has failed
 // @Field: Pri: True if sensor is the primary sensor
 
 // @LoggerMessage: ATT
 // @Description: Canonical vehicle attitude
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: DesRoll: vehicle desired roll
 // @Field: Roll: achieved vehicle roll
 // @Field: DesPitch: vehicle desired pitch
@@ -1375,7 +1375,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: BARO,BAR2,BAR3
 // @Description: Gathered Barometer data
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Alt: calculated altitude
 // @Field: Press: measured atmospheric pressure
 // @Field: Temp: measured atmospheric temperature
@@ -1387,7 +1387,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: BAT
 // @Description: Gathered battery data
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Instance: battery instance number
 // @Field: Volt: measured voltage
 // @Field: VoltR: estimated resting voltage
@@ -1431,7 +1431,7 @@ struct PACKED log_Arm_Disarm {
 // @Field: TimeUS: Time since system startup
 // @Field: Id: Servo number this data relates to
 // @Field: Pos: Current servo position
-// @Field: Force: Force being appiled
+// @Field: Force: Force being applied
 // @Field: Speed: Current servo movement speed
 // @Field: Pow: Amount of rated power being applied
 
@@ -1465,7 +1465,7 @@ struct PACKED log_Arm_Disarm {
 // @LoggerMessage: ERR
 // @Description: Specifically coded error messages
 // @Field: TimeUS: Time since system startup
-// @Field: Subsys: Subsystem in which the error occured
+// @Field: Subsys: Subsystem in which the error occurred
 // @Field: ECode: Subsystem-specific error code
 
 // @LoggerMessage: EV
@@ -1484,14 +1484,14 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: FMTU
 // @Description: Message defining units and multipliers used for fields of other messages
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: FmtType: numeric reference to associated FMT message
 // @Field: UnitIds: each character refers to a UNIT message.  The unit at an offset corresponds to the field at the same offset in FMT.Format
 // @Field: MultIds: each character refers to a MULT message.  The multiplier at an offset corresponds to the field at the same offset in FMT.Format
 
 // @LoggerMessage: GPA,GPA2
 // @Description: GPS accuracy information
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: VDop: vertical degree of procession
 // @Field: HAcc: horizontal position accuracy
 // @Field: VAcc: vertical position accuracy
@@ -1503,7 +1503,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: GPS,GPS2
 // @Description: Information received from GNSS systems attached to the autopilot
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Status: GPS Fix type; 2D fix, 3D fix etc.
 // @Field: GMS: milliseconds since start of GPS Week
 // @Field: GWk: weeks since 5 Jan 1980
@@ -1564,7 +1564,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: MAG,MAG2,MAG3
 // @Description: Information received from compasses
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: MagX: magnetic field strength in body frame
 // @Field: MagY: magnetic field strength in body frame
 // @Field: MagZ: magnetic field strength in body frame
@@ -1579,7 +1579,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: MAV
 // @Description: GCS MAVLink link statistics
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: chan: mavlink channel number
 // @Field: txp: transmitted packet count
 // @Field: rxp: received packet count
@@ -1589,7 +1589,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: MAVC
 // @Description: MAVLink command we have just executed
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: TS: target system for command
 // @Field: TC: target component for command
 // @Field: Fr: command frame
@@ -1608,14 +1608,14 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: MODE
 // @Description: vehicle control mode information
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Mode: vehicle-specific mode number
 // @Field: ModeNum: alias for Mode
 // @Field: Rsn: reason for entering this mode; enumeration value
 
 // @LoggerMessage: MON
 // @Description: Main loop stuck data
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: LDelay: Time main loop has been stuck for
 // @Field: Task: Current scheduler task number
 // @Field: IErr: Internal error mask; which internal errors have been detected
@@ -1628,12 +1628,12 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: MSG
 // @Description: Textual messages
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Message: message text
 
 // @LoggerMessage: MULT
 // @Description: Message mapping from single character to numeric multiplier
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Id: character referenced by FMTU
 // @Field: Mult: numeric multiplier
 
@@ -1656,13 +1656,13 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: PARM
 // @Description: parameter value
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Name: parameter name
 // @Field: Value: parameter vlaue
 
 // @LoggerMessage: PIDR,PIDP,PIDY,PIDA,PIDS
 // @Description: Proportional/Integral/Derivative gain values for Roll/Pitch/Yaw/Z/Steering
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Tar: desired value
 // @Field: Act: achieved value
 // @Field: Err: error between target and achieved
@@ -1673,7 +1673,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: PM
 // @Description: autopilot system performance and general data dumping ground
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: NLon: Number of long loops detected
 // @Field: NLoop: Number of measurement loops for this message
 // @Field: MaxT: Maximum loop time
@@ -1725,7 +1725,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: RATE
 // @Description: Desired and achieved vehicle attitude rates
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: RDes: vehicle desired roll rate
 // @Field: R: achieved vehicle roll rate
 // @Field: ROut: normalized output for Roll
@@ -1743,7 +1743,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: RCIN
 // @Description: RC input channels to vehicle
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: C1: channel 1 input
 // @Field: C2: channel 2 input
 // @Field: C3: channel 3 input
@@ -1761,7 +1761,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: RCOU
 // @Description: Servo channel output values
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: C1: channel 1 output
 // @Field: C2: channel 2 output
 // @Field: C3: channel 3 output
@@ -1812,7 +1812,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: SRTL
 // @Description: SmartRTL statistics
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Active: true if SmartRTL could be used right now
 // @Field: NumPts: number of points currently in use
 // @Field: MaxPts: maximum number of points that could be used
@@ -1841,7 +1841,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: UBX1
 // @Description: uBlox-specific GPS information (part 1)
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Instance: GPS instance number
 // @Field: noisePerMS: noise level as measured by GPS
 // @Field: jamInd: jamming indicator; higher is more likely jammed
@@ -1851,7 +1851,7 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: UBX2
 // @Description: uBlox-specific GPS information (part 2)
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Instance: GPS instance number
 // @Field: ofsI: imbalance of I part of complex signal
 // @Field: magI: magnitude of I part of complex signal
@@ -1860,13 +1860,13 @@ struct PACKED log_Arm_Disarm {
 
 // @LoggerMessage: UNIT
 // @Description: Message mapping from single character to SI unit
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: Id: character referenced by FMTU
 // @Field: Label: Unit - SI where available
 
 // @LoggerMessage: VIBE
 // @Description: Processed (acceleration) vibration information
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: VibeX: Primary accelerometer filtered vibration, x-axis
 // @Field: VibeY: Primary accelerometer filtered vibration, y-axis
 // @Field: VibeZ: Primary accelerometer filtered vibration, z-axis

--- a/libraries/AP_NavEKF/AP_Nav_Common.cpp
+++ b/libraries/AP_NavEKF/AP_Nav_Common.cpp
@@ -9,7 +9,7 @@
 
 // @LoggerMessage: NKT,XKT
 // @Description: EKF timing information
-// @Field: TimeUS: microseconds since system startup
+// @Field: TimeUS: Time since system startup
 // @Field: C: EKF core this message instance applies to
 // @Field: Cnt: count of samples used to create this message
 // @Field: IMUMin: smallest IMU sample interval

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1136,7 +1136,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     // @Vehicles: Plane
     // @Description: Information about the Total Energy Control System
     // @URL: http://ardupilot.org/plane/docs/tecs-total-energy-control-system-for-speed-height-tuning-guide.html
-    // @Field: TimeUS: microseconds since system startup
+    // @Field: TimeUS: Time since system startup
     // @Field: h: height estimate (UP) currently in use by TECS
     // @Field: dh: current climb rate ("delta-height")
     // @Field: hdem: height TECS is currently trying to achieve
@@ -1177,7 +1177,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     // @Vehicles: Plane
     // @Description: Additional Information about the Total Energy Control System
     // @URL: http://ardupilot.org/plane/docs/tecs-total-energy-control-system-for-speed-height-tuning-guide.html
-    // @Field: TimeUS: microseconds since system startup
+    // @Field: TimeUS: Time since system startup
     // @Field: pmax: maximum allowed pitch from parameter
     // @Field: pmin: minimum allowed pitch from parameter
     // @Field: KErr: difference between estimated kinetic energy and desired kinetic energy


### PR DESCRIPTION
The list was getting quite big.... Thought I should fix it up before we document more of these logs.
Additionally, I have fixed a few typos that my built-in spell checker found.