### PR TITLE
Plane: Use AHRS for heading in mode loiter

### DIFF
--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -52,7 +52,7 @@ bool ModeLoiter::isHeadingLinedUp_cd(const int32_t bearing_cd)
     // Tolerance is initially 10 degrees and grows at 10 degrees for each loiter circle completed.
 
     // get current heading.
-    const int32_t heading_cd = plane.gps.ground_course_cd();
+    const int32_t heading_cd = (wrap_360(degrees(plane.ahrs.groundspeed_vector().angle())))*100;
 
     const int32_t heading_err_cd = wrap_180_cd(bearing_cd - heading_cd);
 


### PR DESCRIPTION
This is a fix for #14018.
@WickedShell is this fine? Please let me know if there is something wrong here! Thanks. 