### PR TITLE
Copter/Sub: Loiter turns supports terrain altitude

### DIFF
--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -104,7 +104,7 @@ void ModeCircle::run()
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // run circle controller
-    copter.circle_nav->update();
+    copter.failsafe_terrain_set_status(copter.circle_nav->update());
 
     // call attitude controller
     if (pilot_yaw_override) {

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -90,10 +90,11 @@ void Copter::read_rangefinder(void)
             rf_state.last_healthy_ms = now;
         }
 
-        // send downward facing lidar altitude and health to waypoint navigation library
+        // send downward facing lidar altitude and health to waypoint and circle navigation libraries
         if (rf_orient == ROTATION_PITCH_270) {
             if (rangefinder_state.alt_healthy || timed_out) {
                 wp_nav->set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+                circle_nav->set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
             }
         }
     }

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -94,7 +94,7 @@ void Copter::read_rangefinder(void)
         if (rf_orient == ROTATION_PITCH_270) {
             if (rangefinder_state.alt_healthy || timed_out) {
                 wp_nav->set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
-                circle_nav->set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+                circle_nav->set_rangefinder_alt(rangefinder_state.enabled && wp_nav->rangefinder_used(), rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
             }
         }
     }

--- a/ArduSub/control_circle.cpp
+++ b/ArduSub/control_circle.cpp
@@ -63,7 +63,7 @@ void Sub::circle_run()
     motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // run circle controller
-    circle_nav.update();
+    failsafe_terrain_set_status(circle_nav.update());
 
     ///////////////////////
     // update xy outputs //

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -56,7 +56,7 @@ void Sub::read_rangefinder()
 
     // send rangefinder altitude and health to waypoint navigation library
     wp_nav.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
-    circle_nav.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+    circle_nav.set_rangefinder_alt(rangefinder_state.enabled && wp_nav.rangefinder_used(), rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 
 #else
     rangefinder_state.enabled = false;

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -56,6 +56,7 @@ void Sub::read_rangefinder()
 
     // send rangefinder altitude and health to waypoint navigation library
     wp_nav.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+    circle_nav.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 
 #else
     rangefinder_state.enabled = false;

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -312,7 +312,7 @@ void AC_Circle::init_start_angle(bool use_heading)
 AC_Circle::TerrainSource AC_Circle::get_terrain_source() const
 {
     // use range finder if connected
-    if (_rangefinder_available && _rangefinder_use) {
+    if (_rangefinder_available) {
         return AC_Circle::TerrainSource::TERRAIN_FROM_RANGEFINDER;
     }
 #if AP_TERRAIN_AVAILABLE

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -20,18 +20,26 @@ public:
     AC_Circle(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosControl& pos_control);
 
     /// init - initialise circle controller setting center specifically
+    ///     set terrain_alt to true if center.z should be interpreted as an alt-above-terrain
     ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
-    void init(const Vector3f& center);
+    void init(const Vector3f& center, bool terrain_alt);
 
     /// init - initialise circle controller setting center using stopping point and projecting out based on the copter's heading
     ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
     void init();
 
-    /// set_circle_center in cm from home
-    void set_center(const Vector3f& center) { _center = center; }
+    /// set circle center to a Location
+    void set_center(const Location& center);
+
+    /// set_circle_center as a vector from ekf origin
+    ///     terrain_alt should be true if center.z is alt is above terrain
+    void set_center(const Vector3f& center, bool terrain_alt) { _center = center; _terrain_alt = terrain_alt; }
 
     /// get_circle_center in cm from home
     const Vector3f& get_center() const { return _center; }
+
+    /// returns true if using terrain altitudes
+    bool center_is_terrain_alt() const { return _terrain_alt; }
 
     /// get_radius - returns radius of circle in cm
     float get_radius() const { return _radius; }
@@ -52,7 +60,8 @@ public:
     float get_angle_total() const { return _angle_total; }
 
     /// update - update circle controller
-    void update();
+    ///     returns false on failure which indicates a terrain failsafe
+    bool update() WARN_IF_UNUSED;
 
     /// get desired roll, pitch which should be fed into stabilize controllers
     float get_roll() const { return _pos_control.get_roll(); }
@@ -75,6 +84,9 @@ public:
     /// true if pilot control of radius and turn rate is enabled
     bool pilot_control_enabled() const { return _control > 0; }
 
+    /// provide rangefinder altitude
+    void set_rangefinder_alt(bool use, bool healthy, float alt_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_alt_cm = alt_cm; }
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -89,6 +101,17 @@ private:
     //  if use_heading is true the vehicle's heading will be used to init the angle causing minimum yaw movement
     //  if use_heading is false the vehicle's position from the center will be used to initialise the angle
     void init_start_angle(bool use_heading);
+
+    // get expected source of terrain data
+    enum class TerrainSource {
+        TERRAIN_UNAVAILABLE,
+        TERRAIN_FROM_RANGEFINDER,
+        TERRAIN_FROM_TERRAINDATABASE,
+    };
+    AC_Circle::TerrainSource get_terrain_source() const;
+
+    // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
+    bool get_terrain_offset(float& offset_cm);
 
     // flags structure
     struct circle_flags {
@@ -113,4 +136,11 @@ private:
     float       _angular_vel;   // angular velocity in radians/sec
     float       _angular_vel_max;   // maximum velocity in radians/sec
     float       _angular_accel; // angular acceleration in radians/sec/sec
+
+    // terrain following variables
+    bool        _terrain_alt;           // true if _center.z is alt-above-terrain, false if alt-above-ekf-origin
+    bool        _rangefinder_available; // true if range finder could be used
+    AP_Int8     _rangefinder_use;       // true if caller has requested rangefinder be used for terrain altitude
+    bool        _rangefinder_healthy;   // true if range finder is healthy
+    float       _rangefinder_alt_cm;    // latest rangefinder altitude
 };

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -140,7 +140,6 @@ private:
     // terrain following variables
     bool        _terrain_alt;           // true if _center.z is alt-above-terrain, false if alt-above-ekf-origin
     bool        _rangefinder_available; // true if range finder could be used
-    AP_Int8     _rangefinder_use;       // true if caller has requested rangefinder be used for terrain altitude
     bool        _rangefinder_healthy;   // true if range finder is healthy
     float       _rangefinder_alt_cm;    // latest rangefinder altitude
 };

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -55,6 +55,7 @@ public:
     void set_rangefinder_alt(bool use, bool healthy, float alt_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_alt_cm = alt_cm; }
 
     // return true if range finder may be used for terrain following
+    bool rangefinder_used() const { return _rangefinder_use; }
     bool rangefinder_used_and_healthy() const { return _rangefinder_use && _rangefinder_healthy; }
 
     // get expected source of terrain data if alt-above-terrain command is executed (used by Copter's ModeRTL)


### PR DESCRIPTION
This is a minimalist change to add support for Auto mode's Loiter-Turn command to support terrain altitudes (either rangefinder or SRTM data).  Loiter-Turns is essentially circle mode within Auto.  The changes include:

- AC_Circle::set_center(const Location&) is added allowing Copter and Sub to more directly provide the Location from the command directly to AC_Circle.  AC_Circle then converts this to a Vector3f which is an offset from the EKF origin unless _terrain_alt = true in which case the Z-axis component is interpreted as an altitude above terrain.  This is slightly messy but is consistent with how AC_WPNav works.
- AC_Circle::set_rangefinder_alt() added to allow the vehicle code to pass in the range finder altitude
- AC_Circle::update() calculates a terr_offset which is added to the target position's z-axis (an alt-above-ekf-origin) so that the vehicle stays at the desired alt-above-terrain.  This function also returns a boolean which is false if the terrain altitude cannot be retrieved.
- AC_Circle::get_terrain_source() and get_terrain_offset() methods added which are basically copy-paste versions of what is in AC_WPNav.  This is slightly messy but I wanted to keep it simple so as not to interfere with Leonard's S-curve work.

I will post testing results for Copter and Sub shortly.


