### PR TITLE
AP_Logger: constraints time spend in header writing

### DIFF
--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -1,5 +1,6 @@
 #include "AP_Common/AP_FWVersion.h"
 #include "LoggerMessageWriter.h"
+#include <AP_Scheduler/AP_Scheduler.h>
 
 #define FORCE_VERSION_H_INCLUDE
 #include "ap_version.h"
@@ -35,6 +36,9 @@ void LoggerMessageWriter_DFLogStart::reset()
 
 void LoggerMessageWriter_DFLogStart::process()
 {
+    if (AP::scheduler().time_available_usec() < 200) {
+        return;
+    }
     switch(stage) {
     case Stage::FORMATS:
         // write log formats so the log is self-describing


### PR DESCRIPTION
fix #11304 and #13882

Start logging in first arm (log_disarm=0) seems make EKF altitude incorrectly climbing for a few seconds while copter still on the ground. It is not happened if you disarm and then arm again. 
[ekf_alt_climbing_high_1st_arm.zip](https://github.com/ArduPilot/ardupilot/files/4453727/ekf_alt_climbing_high_1st_arm.zip)

@JamesMegariotis also report 

> Seems to definitely be related to dataflash logging since arming using log while disarmed feature leads to much smaller errors

related [discussion](https://discuss.ardupilot.org/t/copter-ekf-altitude-estimation-error-due-to-heavy-uart-communication-load/41625)

Thanks @peterbarker very much for very useful [suggestions](https://discuss.ardupilot.org/t/copter-ekf-altitude-estimation-error-due-to-heavy-uart-communication-load/41625/41?u=chobitsfan)

flight tests log
[sd_log_fix.zip](https://github.com/ArduPilot/ardupilot/files/4453757/sd_log_fix.zip)
