### PR TITLE
Tools: remove trailing white spaces from output of generate_manifest

### DIFF
--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -478,7 +478,7 @@ class ManifestGenerator():
                   file=sys.stderr)
 
         structure = self.walk_directory(self.basedir)
-        return json.dumps(structure, indent=4)
+        return json.dumps(structure, indent=4, separators=(',', ': '))
 
 
 def usage():


### PR DESCRIPTION
Explicitly set the seperators of the json.dumps call. Some versions of
the library in combination with set indent parameter create output that
contains quite a lot of trailing white spaces.