### PR TITLE
Copter: Set correct yaw for circle in Mode Auto

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -300,6 +300,10 @@ void ModeAuto::circle_start()
 
     // initialise circle controller
     copter.circle_nav->init(copter.circle_nav->get_center(), copter.circle_nav->center_is_terrain_alt());
+
+    if (auto_yaw.mode() != AUTO_YAW_ROI) {
+        auto_yaw.set_mode(AUTO_YAW_HOLD);
+    }
 }
 
 // auto_spline_start - initialises waypoint controller to implement flying to a particular destination using the spline controller


### PR DESCRIPTION
This is in response to #14031
I believe this is the correct fix for the bug. I have tested it in SITL, and works well. The vehicle was pointing towards the centre of the circle again.

It preserves the ROI functionality as well, but in case no ROI is setup, the yaw will be taken directly from the AC_CIRCLE library. 