### PR TITLE
AP_Scheduler: print the classname on slips/overruns to make debugging easier

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -37,6 +37,12 @@
 #define SCHEDULER_DEFAULT_LOOP_RATE  50
 #endif
 
+#if HAL_MINIMIZE_FEATURES
+#define DEBUG_FORMAT_LENGTH "15"
+#else
+#define DEBUG_FORMAT_LENGTH "30"
+#endif
+
 #define debug(level, fmt, args...)   do { if ((level) <= _debug.get()) { hal.console->printf(fmt, ##args); }} while (0)
 
 extern const AP_HAL::HAL& hal;
@@ -174,7 +180,7 @@ void AP_Scheduler::run(uint32_t time_available)
 
         if (dt >= interval_ticks*2) {
             // we've slipped a whole run of this task!
-            debug(2, "Scheduler slip task[%u-%s] (%u/%u/%u)\n",
+            debug(2, "Scheduler slip task[%u-%-" DEBUG_FORMAT_LENGTH "s] (%u/%u/%u)\n",
                   (unsigned)i,
                   task.name,
                   (unsigned)dt,
@@ -219,7 +225,7 @@ void AP_Scheduler::run(uint32_t time_available)
 
         if (time_taken > _task_time_allowed) {
             // the event overran!
-            debug(3, "Scheduler overrun task[%u-%s] (%u/%u)\n",
+            debug(3, "Scheduler overrun task[%u-%-" DEBUG_FORMAT_LENGTH "s] (%u/%u)\n",
                   (unsigned)i,
                   task.name,
                   (unsigned)time_taken,

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -25,7 +25,11 @@
 #include <AP_Math/AP_Math.h>
 #include "PerfInfo.h"       // loop perf monitoring
 
-#define AP_SCHEDULER_NAME_INITIALIZER(_name) .name = #_name,
+#if HAL_MINIMIZE_FEATURES
+#define AP_SCHEDULER_NAME_INITIALIZER(_class, _name) .name = #_name,
+#else
+#define AP_SCHEDULER_NAME_INITIALIZER(_class, _name) .name = #_class "::" #_name,
+#endif
 #define LOOP_RATE 0
 
 /*
@@ -33,7 +37,7 @@
  */
 #define SCHED_TASK_CLASS(classname, classptr, func, _rate_hz, _max_time_micros) { \
     .function = FUNCTOR_BIND(classptr, &classname::func, void),\
-    AP_SCHEDULER_NAME_INITIALIZER(func)\
+    AP_SCHEDULER_NAME_INITIALIZER(classname, func)\
     .rate_hz = _rate_hz,\
     .max_time_micros = _max_time_micros\
 }


### PR DESCRIPTION
Non-functional change that makes the output a little clearer:

```
Scheduler overrun task[37-AP_Logger::periodic_tasks     ] (397/300)
Scheduler slip task[50-AP_GyroFFT::push_gyro_frame   ] (6/2/200)
Scheduler overrun task[50-AP_GyroFFT::push_gyro_frame   ] (397/200)
Scheduler overrun task[32-GCS::update_send              ] (1285/550)
Scheduler overrun task[11-AP_Beacon::update             ] (96/50)
Scheduler overrun task[14-Copter::update_throttle_hover ] (340/90)
Scheduler overrun task[31-GCS::update_receive           ] (607/180)
Scheduler overrun task[38-AP_InertialSensor::periodic   ] (107/50)
Scheduler overrun task[41-Copter::compass_cal_update    ] (484/100)
Scheduler overrun task[49-AP_RunCam::update             ] (56/50)
Scheduler overrun task[18-AP_ServoRelayEvents::update_events] (115/75)
Scheduler overrun task[19-AP_Baro::accumulate           ] (404/90)
Scheduler overrun task[31-GCS::update_receive           ] (432/180)
Scheduler overrun task[22-Copter::fourhundred_hz_logging] (110/50)
Scheduler overrun task[21-Copter::update_precland       ] (202/50)
Scheduler overrun task[22-Copter::fourhundred_hz_logging] (340/50)
```