### PR TITLE
Make Compass Calibration calculations to run on a thread

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Namespace.h
+++ b/libraries/AP_HAL/AP_HAL_Namespace.h
@@ -49,6 +49,7 @@ namespace AP_HAL {
      */
     typedef void(*Proc)(void);
     FUNCTOR_TYPEDEF(MemberProc, void);
+    typedef void* ThreadHandle;
 
     /**
      * Global names for all of the existing SPI devices on all platforms.

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -116,9 +116,17 @@ public:
     /*
       create a new thread
      */
-    virtual bool thread_create(AP_HAL::MemberProc proc, const char *name,
+    virtual ThreadHandle thread_create(AP_HAL::MemberProc proc, const char *name,
                                uint32_t stack_size, priority_base base, int8_t priority) {
-        return false;
+        return nullptr;
+    }
+    
+    /*
+      destroys a thread
+     */
+    //NOTE: use with CAUTION, can block on some platforms
+    virtual bool thread_destroyed(ThreadHandle) {
+        return true;  
     }
 
 private:

--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -126,7 +126,10 @@ public:
     /*
       create a new thread
      */
-    bool thread_create(AP_HAL::MemberProc, const char *name, uint32_t stack_size, priority_base base, int8_t priority) override;
+    AP_HAL::ThreadHandle thread_create(AP_HAL::MemberProc, const char *name, uint32_t stack_size, priority_base base, int8_t priority) override;
+    
+    bool thread_destroyed(AP_HAL::ThreadHandle) override;
+
 
     // pat the watchdog
     void watchdog_pat(void);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -50,8 +50,10 @@ public:
     /*
       create a new thread
      */
-    bool thread_create(AP_HAL::MemberProc, const char *name, uint32_t stack_size, priority_base base, int8_t priority) override;
-    
+    AP_HAL::ThreadHandle thread_create(AP_HAL::MemberProc, const char *name, uint32_t stack_size, priority_base base, int8_t priority) override;
+
+    bool thread_destroyed(AP_HAL::ThreadHandle) override;
+
 private:
     class SchedulerThread : public PeriodicThread {
     public:

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -45,6 +45,7 @@ void *Thread::_run_trampoline(void *arg)
         delete thread;
     }
 
+    thread->_finished = true;
     return nullptr;
 }
 
@@ -226,6 +227,13 @@ bool Thread::join()
     return true;
 }
 
+bool Thread::stop() {
+    if (_finished) {
+        join();
+        return true;
+    }
+    return false;
+}
 
 bool PeriodicThread::set_rate(uint32_t rate_hz)
 {

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -47,7 +47,7 @@ public:
 
     void set_auto_free(bool auto_free) { _auto_free = auto_free; }
 
-    virtual bool stop() { return false; }
+    virtual bool stop();
 
     bool join();
 
@@ -62,7 +62,7 @@ protected:
     virtual bool _run();
 
     void _poison_stack();
-
+    bool _finished = false;
     task_t _task;
     bool _started = false;
     bool _should_exit = false;

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -291,7 +291,7 @@ void *Scheduler::thread_create_trampoline(void *ctx)
 /*
   create a new thread
 */
-bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_t stack_size, priority_base base, int8_t priority)
+AP_HAL::ThreadHandle Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_t stack_size, priority_base base, int8_t priority)
 {
     WITH_SEMAPHORE(_thread_sem);
 
@@ -304,7 +304,7 @@ bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_
 
     struct thread_attr *a = new struct thread_attr;
     if (!a) {
-        return false;
+        return nullptr;
     }
     // take a copy of the MemberProc, it is freed after thread exits
     a->f = (AP_HAL::MemberProc *)malloc(sizeof(proc));
@@ -337,7 +337,7 @@ bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_
     }
     a->next = threads;
     threads = a;
-    return true;
+    return a;
 
 failed:
     if (a->stack) {
@@ -347,7 +347,7 @@ failed:
         free(a->f);
     }
     delete a;
-    return false;
+    return nullptr;
 }
 
 /*

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -55,7 +55,7 @@ public:
     /*
       create a new thread
      */
-    bool thread_create(AP_HAL::MemberProc, const char *name,
+    AP_HAL::ThreadHandle thread_create(AP_HAL::MemberProc, const char *name,
                        uint32_t stack_size, priority_base base, int8_t priority) override;
 
     void set_in_semaphore_take_wait(bool value) { _in_semaphore_take_wait = value; }


### PR DESCRIPTION
* Runs only the calculations on a thread, which always happen after all the samples are collected.
* Threads are killed after they have done their job.
* Needs testing on Linux boards.
