### PR TITLE
Write WDOG as part of log startup

### DIFF
--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -219,27 +219,6 @@ static void main_loop()
     if (AP_BoardConfig::watchdog_enabled()) {
         stm32_watchdog_init();
     }
-
-#ifndef HAL_NO_LOGGING
-    if (hal.util->was_watchdog_reset()) {
-        AP::internalerror().error(AP_InternalError::error_t::watchdog_reset);
-        const AP_HAL::Util::PersistentData &pd = hal.util->last_persistent_data;
-        AP::logger().WriteCritical("WDOG", "TimeUS,Tsk,IE,IEC,MvMsg,MvCmd,SmLn,FL,FT,FA,FP,ICSR,LR", "QbIIHHHHHIBII",
-                                   AP_HAL::micros64(),
-                                   pd.scheduler_task,
-                                   pd.internal_errors,
-                                   pd.internal_error_count,
-                                   pd.last_mavlink_msgid,
-                                   pd.last_mavlink_cmd,
-                                   pd.semaphore_line,
-                                   pd.fault_line,
-                                   pd.fault_type,
-                                   pd.fault_addr,
-                                   pd.fault_thd_prio,
-                                   pd.fault_icsr,
-                                   pd.fault_lr);
-    }
-#endif // HAL_NO_LOGGING
 #endif // IOMCU_FW
 
     schedulerInstance.watchdog_pat();

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -188,18 +188,6 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
     callbacks->setup();
     scheduler->system_initialized();
 
-    if (getenv("SITL_WATCHDOG_RESET")) {
-        const AP_HAL::Util::PersistentData &pd = util->persistent_data;
-        AP::logger().WriteCritical("WDOG", "TimeUS,Task,IErr,IErrCnt,MavMsg,MavCmd,SemLine", "QbIIHHH",
-                                   AP_HAL::micros64(),
-                                   pd.scheduler_task,
-                                   pd.internal_errors,
-                                   pd.internal_error_count,
-                                   pd.last_mavlink_msgid,
-                                   pd.last_mavlink_cmd,
-                                   pd.semaphore_line);
-    }
-
     bool using_watchdog = AP_BoardConfig::watchdog_enabled();
     if (using_watchdog) {
         signal(SIGALRM, sig_alrm);

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -446,3 +446,37 @@ void AP_Logger_Backend::Write_Rally()
     writer.set_logger_backend(this);
     writer.process();
 }
+
+bool AP_Logger_Backend::Write_WDOG(
+        uint8_t scheduler_task,
+        uint32_t internal_errors,
+        uint32_t internal_error_count,
+        uint16_t last_mavlink_msgid,
+        uint16_t last_mavlink_cmd,
+        uint16_t semaphore_line,
+        uint16_t fault_line,
+        uint16_t fault_type,
+        uint32_t fault_addr,
+        uint8_t fault_thd_prio,
+        uint32_t fault_icsr,
+        uint32_t fault_lr
+    )
+{
+    const struct log_WDOG pkt_WDOG{
+        LOG_PACKET_HEADER_INIT(LOG_WDOG_MSG),
+        time_us             : AP_HAL::micros64(),
+        scheduler_task      : scheduler_task,
+        internal_errors     : internal_errors,
+        internal_error_count: internal_error_count,
+        last_mavlink_msgid  : last_mavlink_msgid,
+        last_mavlink_cmd    : last_mavlink_cmd,
+        semaphore_line      : semaphore_line,
+        fault_line          : fault_line,
+        fault_type          : fault_type,
+        fault_addr          : fault_addr,
+        fault_thd_prio      : fault_thd_prio,
+        fault_icsr          : fault_icsr,
+        fault_lr            : fault_lr,
+    };
+    return WriteBlock(&pkt_WDOG, sizeof(pkt_WDOG));
+}

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -98,6 +98,20 @@ public:
     bool Write_Parameter(const AP_Param *ap,
                              const AP_Param::ParamToken &token,
                              enum ap_var_type type);
+    bool Write_WDOG(
+        uint8_t scheduler_task,
+        uint32_t internal_errors,
+        uint32_t internal_error_count,
+        uint16_t last_mavlink_msgid,
+        uint16_t last_mavlink_cmd,
+        uint16_t semaphore_line,
+        uint16_t fault_line,
+        uint16_t fault_type,
+        uint32_t fault_addr,
+        uint8_t fault_thd_prio,
+        uint32_t fault_icsr,
+        uint32_t fault_lr
+    );
 
     uint32_t num_dropped(void) const {
         return _dropped;

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1136,6 +1136,23 @@ struct PACKED log_Rally {
     int16_t altitude;
 };
 
+struct PACKED log_WDOG {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t scheduler_task;
+    uint32_t internal_errors;
+    uint32_t internal_error_count;
+    uint16_t last_mavlink_msgid;
+    uint16_t last_mavlink_cmd;
+    uint16_t semaphore_line;
+    uint16_t fault_line;
+    uint16_t fault_type;
+    uint32_t fault_addr;
+    uint8_t fault_thd_prio;
+    uint32_t fault_icsr;
+    uint32_t fault_lr;
+};
+
 struct PACKED log_AOA_SSA {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -2144,6 +2161,8 @@ struct PACKED log_Arm_Disarm {
       "EV",   "QB",           "TimeUS,Id", "s-", "F-" }, \
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm), \
       "ARM", "QBIBB", "TimeUS,ArmState,ArmChecks,Forced,Method", "s----", "F----" }, \
+    { LOG_WDOG_MSG, sizeof(log_WDOG), \
+      "WDOG", "QbIIHHHHHIBII", "TimeUS,Tsk,IE,IEC,MvMsg,MvCmd,SmLn,FL,FT,FA,FP,ICSR,LR", "s------------", "F------------" }, \
     { LOG_ERROR_MSG, sizeof(log_Error), \
       "ERR",   "QBB",         "TimeUS,Subsys,ECode", "s--", "F--" }
 
@@ -2298,6 +2317,7 @@ enum LogMessages : uint8_t {
     LOG_ARM_DISARM_MSG,
     LOG_OA_BENDYRULER_MSG,
     LOG_OA_DIJKSTRA_MSG,
+    LOG_WDOG_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -198,6 +198,29 @@ void LoggerMessageWriter_WriteSysInfo::process() {
                 return; // call me again
             }
         }
+        stage = Stage::WATCHDOG_RESET;
+        FALLTHROUGH;
+
+    case Stage::WATCHDOG_RESET:
+        if (hal.util->was_watchdog_reset()) {
+            AP::internalerror().error(AP_InternalError::error_t::watchdog_reset);
+            const AP_HAL::Util::PersistentData &pd = hal.util->last_persistent_data;
+            if (!_logger_backend->Write_WDOG(
+                    pd.scheduler_task,
+                    pd.internal_errors,
+                    pd.internal_error_count,
+                    pd.last_mavlink_msgid,
+                    pd.last_mavlink_cmd,
+                    pd.semaphore_line,
+                    pd.fault_line,
+                    pd.fault_type,
+                    pd.fault_addr,
+                    pd.fault_thd_prio,
+                    pd.fault_icsr,
+                    pd.fault_lr)) {
+                return; // call me again
+            }
+        }
         stage = Stage::SYSTEM_ID;
         FALLTHROUGH;
 

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -30,6 +30,7 @@ private:
         FORMATS = 0,
         FIRMWARE_STRING,
         GIT_VERSIONS,
+        WATCHDOG_RESET,
         SYSTEM_ID,
         PARAM_SPACE_USED,
         RC_PROTOCOL


### PR DESCRIPTION
See https://github.com/ArduPilot/ardupilot/issues/14054

If logging doesn't work immediately at boot we should still get the message out this way.

This does not fix the referenced issue; logs are not being forced-open on watchdog reset for some reason?
