### PR TITLE
Fixed selection of EKF2/EKF3

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -290,6 +290,11 @@ class Board:
         # We always want to use PRI format macros
         cfg.define('__STDC_FORMAT_MACROS', 1)
 
+        if cfg.options.disable_ekf2:
+            env.CXXFLAGS += ['-DHAL_NAVEKF2_AVAILABLE=0']
+
+        if cfg.options.disable_ekf3:
+            env.CXXFLAGS += ['-DHAL_NAVEKF3_AVAILABLE=0']
 
     def pre_build(self, bld):
         '''pre-build hook that gets called before dynamic sources'''

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -298,6 +298,12 @@ def do_build_waf(opts, frame_options):
     if opts.flash_storage:
         cmd_configure.append("--sitl-flash-storage")
 
+    if opts.disable_ekf2:
+        cmd_configure.append("--disable-ekf2")
+
+    if opts.disable_ekf3:
+        cmd_configure.append("--disable-ekf3")
+        
     pieces = [shlex.split(x) for x in opts.waf_configure_args]
     for piece in pieces:
         cmd_configure.extend(piece)
@@ -949,6 +955,12 @@ group_sim.add_option("-Z", "--swarm",
 group_sim.add_option("--flash-storage",
                      action='store_true',
                      help="enable use of flash storage emulation")
+group_sim.add_option("--disable-ekf2",
+                     action='store_true',
+                     help="disable EKF2 in build")
+group_sim.add_option("--disable-ekf3",
+                     action='store_true',
+                     help="disable EKF3 in build")
 parser.add_option_group(group_sim)
 
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -55,6 +55,9 @@ public:
     // Constructor
     AP_AHRS_NavEKF(uint8_t flags = FLAG_NONE);
 
+    // initialise
+    void init(void) override;
+
     /* Do not allow copies */
     AP_AHRS_NavEKF(const AP_AHRS_NavEKF &other) = delete;
     AP_AHRS_NavEKF &operator=(const AP_AHRS_NavEKF&) = delete;
@@ -296,12 +299,12 @@ public:
 
 private:
     enum class EKFType {
-        NONE = 0,
+        NONE = 0
 #if HAL_NAVEKF3_AVAILABLE
-        THREE = 3,
+        ,THREE = 3
 #endif
 #if HAL_NAVEKF2_AVAILABLE
-        TWO = 2
+        ,TWO = 2
 #endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         ,SITL = 10

--- a/wscript
+++ b/wscript
@@ -199,6 +199,16 @@ configuration in order to save typing.
         action='store_true',
         default=False,
         help='Configure for building SITL with flash storage emulation.')
+
+    g.add_option('--disable-ekf2',
+        action='store_true',
+        default=False,
+        help='Configure without EKF2.')
+
+    g.add_option('--disable-ekf3',
+        action='store_true',
+        default=False,
+        help='Configure without EKF3.')
     
     g.add_option('--static',
         action='store_true',


### PR DESCRIPTION
This auto-selects the EKF that has been built into the firmware if the one in AHRS_EKF_TYPE is not built in. It also adds SITL options for building with only one EKF backend.
This fixes an issue with MatekF405-Wing which has EKF2 disabled but ended up flying on DCM as AHRS_EKF_TYPE was not being set correctly
