### PR TITLE
AP_Baro: Fix timestamp wrapping

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -318,7 +318,7 @@ bool AP_Baro_BMP085::_data_ready()
 
     // No EOC pin: use time from last read instead.
     if (_state == 0) {
-        return AP_HAL::millis() > _last_temp_read_command_time + 5;
+        return AP_HAL::millis() - _last_temp_read_command_time > 5u;
     }
 
     uint32_t conversion_time_msec;
@@ -340,5 +340,5 @@ bool AP_Baro_BMP085::_data_ready()
         break;
     }
 
-    return AP_HAL::millis() > _last_press_read_command_time + conversion_time_msec;
+    return AP_HAL::millis() - _last_press_read_command_time > conversion_time_msec;
 }


### PR DESCRIPTION
SHA f68f3558  AP_NavEKF3: Fix timestamp wrapping
I've found a process that does similar things.
I've made changes as well.