### PR TITLE
AP_RangeFinder: Maxbotix sonar I2C multi devices

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -337,7 +337,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::MBI2C:
         FOREACH_I2C(i) {
             if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
-                                                                  hal.i2c_mgr->get_device(i, AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR)))) {
+                                                                     hal.i2c_mgr->get_device(i, params[instance].address)))) {
                 break;
             }
         }

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -335,10 +335,12 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         }
         break;
     case Type::MBI2C:
-        FOREACH_I2C(i) {
-            if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
-                                                                     hal.i2c_mgr->get_device(i, params[instance].address)))) {
-                break;
+        if (params[instance].address){
+            FOREACH_I2C(i) {
+                if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
+                                                                        hal.i2c_mgr->get_device(i, params[instance].address)))) {
+                    break;
+                }
             }
         }
         break;


### PR DESCRIPTION
Add a backend driver for each maxbotix I2C rangefinder as different address.

Tested with two gy-us42 sonar , one of default address 0x70 and the second with 0x68 address
 
![Maxbotix_i2c](https://user-images.githubusercontent.com/6493675/79151888-916e9d00-7dcb-11ea-8248-b061a8963b9f.png)
  