### PR TITLE
autotest: Canonicalise on defaults_filepath (rather than defaults_file)

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -4934,7 +4934,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         defaults_filepath = vinfo.options["APMrover2"]["frames"][model]["default_params_filename"]
         self.customise_SITL_commandline([],
                                         model=model,
-                                        defaults_file=defaults_filepath)
+                                        defaults_filepath=defaults_filepath)
         self.change_mode("MANUAL")
         self.wait_ready_to_arm()
         self.arm_vehicle()

--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -4931,7 +4931,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def test_skid_steer(self):
         model = "rover-skid"
         vinfo = vehicleinfo.VehicleInfo()
-        defaults_filepath = vinfo.options["APMrover2"]["frames"][model]["default_params_filename"]
+        defaults_filepath = vinfo.options["Rover"]["frames"][model]["default_params_filename"]
         self.customise_SITL_commandline([],
                                         model=model,
                                         defaults_filepath=defaults_filepath)

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -62,7 +62,7 @@ class AutoTestPlane(AutoTest):
         return "plane-elevrev"
 
     def apply_defaultfile_parameters(self):
-        # plane passes in a defaults_file in place of applying
+        # plane passes in a defaults_filepath in place of applying
         # parameters afterwards.
         pass
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3387,8 +3387,8 @@ class AutoTest(ABC):
             "wipe": True,
         }
         start_sitl_args.update(**sitl_args)
-        if ("defaults_filepath" not in start_sitl_args or
-            start_sitl_args["defaults_filepath"] is None):
+        if ("defaults_file" not in start_sitl_args or
+            start_sitl_args["defaults_file"] is None):
             start_sitl_args["defaults_file"] = self.defaults_filepath()
 
         if "model" not in start_sitl_args or start_sitl_args["model"] is None:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1370,12 +1370,12 @@ class AutoTest(ABC):
         self.set_streamrate(self.sitl_streamrate())
         self.progress("Reboot complete")
 
-    def customise_SITL_commandline(self, customisations, model=None, defaults_file=None):
+    def customise_SITL_commandline(self, customisations, model=None, defaults_filepath=None):
         '''customisations could be "--uartF=sim:nmea" '''
         self.contexts[-1].sitl_commandline_customised = True
         self.stop_SITL()
         self.start_SITL(model=model,
-                        defaults_file=defaults_file,
+                        defaults_filepath=defaults_filepath,
                         customisations=customisations,
                         wipe=False)
         self.wait_heartbeat(drain_mav=True)
@@ -3387,9 +3387,9 @@ class AutoTest(ABC):
             "wipe": True,
         }
         start_sitl_args.update(**sitl_args)
-        if ("defaults_file" not in start_sitl_args or
-            start_sitl_args["defaults_file"] is None):
-            start_sitl_args["defaults_file"] = self.defaults_filepath()
+        if ("defaults_filepath" not in start_sitl_args or
+            start_sitl_args["defaults_filepath"] is None):
+            start_sitl_args["defaults_filepath"] = self.defaults_filepath()
 
         if "model" not in start_sitl_args or start_sitl_args["model"] is None:
             start_sitl_args["model"] = self.frame

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -235,7 +235,7 @@ def start_SITL(binary,
                home=None,
                model=None,
                speedup=1,
-               defaults_file=None,
+               defaults_filepath=None,
                unhide_parameters=False,
                gdbserver=False,
                breakpoints=[],
@@ -318,10 +318,10 @@ def start_SITL(binary,
     cmd.extend(['--model', model])
     if speedup != 1:
         cmd.extend(['--speedup', str(speedup)])
-    if defaults_file is not None:
-        if type(defaults_file) == list:
-            defaults_file = ",".join(defaults_file)
-        cmd.extend(['--defaults', defaults_file])
+    if defaults_filepath is not None:
+        if type(defaults_filepath) == list:
+            defaults_filepath = ",".join(defaults_filepath)
+        cmd.extend(['--defaults', defaults_filepath])
     if unhide_parameters:
         cmd.extend(['--unhide-groups'])
     if vicon:

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -59,17 +59,17 @@ class AutoTestQuadPlane(AutoTest):
         self.current_test_name_directory = "ArduPlane_Tests/" + name + "/"
 
     def apply_defaultfile_parameters(self):
-        # plane passes in a defaults_file in place of applying
+        # plane passes in a defaults_filepath in place of applying
         # parameters afterwards.
         pass
 
     def defaults_filepath(self):
         vinfo = vehicleinfo.VehicleInfo()
-        defaults_file = vinfo.options["ArduPlane"]["frames"][self.frame]["default_params_filename"]
-        if isinstance(defaults_file, str):
-            defaults_file = [defaults_file]
+        defaults_filepath = vinfo.options["ArduPlane"]["frames"][self.frame]["default_params_filename"]
+        if isinstance(defaults_filepath, str):
+            defaults_filepath = [defaults_filepath]
         defaults_list = []
-        for d in defaults_file:
+        for d in defaults_filepath:
             defaults_list.append(os.path.join(testdir, d))
         return ','.join(defaults_list)
 


### PR DESCRIPTION
Provoked by @andyp1per 's patch from https://github.com/ArduPilot/ardupilot/pull/14060

