### PR TITLE
AP_Compass: pull compass calibrator out into a separate thread

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4054,98 +4054,6 @@ class AutoTestCopter(AutoTest):
         if ex is not None:
             raise ex
 
-    def test_onboard_compass_calibration(self, timeout=300):
-        params = [
-            ("SIM_MAG_DIA_X", "COMPASS_DIA_X", 1.0),
-            ("SIM_MAG_DIA_Y", "COMPASS_DIA_Y", 1.1),
-            ("SIM_MAG_DIA_Z", "COMPASS_DIA_Z", 1.2),
-            ("SIM_MAG_ODI_X", "COMPASS_ODI_X", 0.004),
-            ("SIM_MAG_ODI_Y", "COMPASS_ODI_Y", 0.005),
-            ("SIM_MAG_ODI_Z", "COMPASS_ODI_Z", 0.006),
-        ]
-        twist_x = 2.1
-        twist_y = 2.2
-        twist_z = 2.3
-        ex = None
-        self.context_push()
-        try:
-            self.set_parameter("SIM_GND_BEHAV", 0)
-            self.set_parameter("AHRS_EKF_TYPE", 10)
-            for param in params:
-                (_in, _out, value) = param
-                self.set_parameter(_in, value)
-                # ensure new parameters get reversed at end of test:
-                self.set_parameter(_out, self.get_parameter(_out))
-            self.reboot_sitl()
-
-            report = self.mav.messages.get("MAG_CAL_REPORT", None)
-            if report is not None:
-                raise PreconditionFailedException("MAG_CAL_REPORT found")
-
-            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
-                         1, # bitmask of compasses to calibrate
-                         0,
-                         1, # save without user input
-                         0,
-                         0,
-                         0,
-                         0,
-                         timeout=2)
-            tstart = self.get_sim_time()
-            last_twist_time = 0
-            while True:
-                now = self.get_sim_time_cached()
-                if now - tstart > timeout:
-                    raise NotAchievedException("timeout before cal complete")
-                report = self.mav.messages.get("MAG_CAL_REPORT", None)
-                if report is not None:
-                    print("Report: %s" % str(report))
-                    # give time for things to save or whatever:
-                    self.wait_heartbeat()
-                    self.wait_heartbeat()
-                    for param in params:
-                        (_in, _out, value) = param
-                        got_value = self.get_parameter(_out)
-                        if abs(got_value - value) > value*0.15:
-                            raise NotAchievedException("%s/%s not within 15%%; got %f want=%f" % (_in, _out, got_value, value))
-                    break
-                if now - last_twist_time > 5:
-                    last_twist_time = now
-                    twist_x *= 1.1
-                    twist_y *= 1.2
-                    twist_z *= 1.3
-                    if abs(twist_x) > 10:
-                        twist_x /= -2
-                    if abs(twist_y) > 10:
-                        twist_y /= -2
-                    if abs(twist_z) > 10:
-                        twist_z /= -2
-                    self.set_parameter("SIM_TWIST_X", twist_x/10.0)
-                    self.set_parameter("SIM_TWIST_Y", twist_y/10.0)
-                    self.set_parameter("SIM_TWIST_Z", twist_z/10.0)
-                    try:
-                        self.set_parameter("SIM_TWIST_TIME", 100)
-                    except ValueError as e:
-                        # the shove resets this to zero
-                        pass
-
-                m = self.mav.recv_match(type="MAG_CAL_PROGRESS", timeout=1)
-                self.progress("progress: %s" % str(m))
-                if m is None:
-                    continue
-                att = self.mav.messages.get("ATTITUDE", None)
-                self.progress("Attitude: %f %f %f" %
-                              (math.degrees(att.roll), math.degrees(att.pitch), math.degrees(att.yaw)))
-        except Exception as e:
-            self.progress("Exception caught: %s" % (
-                self.get_exception_stacktrace(e)))
-            ex = e
-
-        self.context_pop()
-        self.reboot_sitl()
-        if ex is not None:
-            raise ex
-
     def fly_brake_mode(self):
         # test brake mode
         self.progress("Testing brake mode")
@@ -5075,10 +4983,6 @@ class AutoTestCopter(AutoTest):
             ("FOLLOW",
              "Fly follow mode",
              self.fly_follow_mode),
-
-            ("OnboardCompassCalibration",
-             "Test onboard compass calibration",
-             self.test_onboard_compass_calibration),
 
             ("RangeFinderDrivers",
              "Test rangefinder drivers",

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5121,6 +5121,10 @@ class AutoTestCopter(AutoTest):
              "Fly Gyro FFT Harmonic Matching",
              self.fly_gyro_fft_harmonic),
 
+            ("SITLCompassCalibration",
+             "Test SITL onboard compass calibration",
+             self.test_mag_calibration),
+
             ("LogUpload",
              "Log upload",
              self.log_upload),

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2495,6 +2495,33 @@ class AutoTest(ABC):
                      0,
                      timeout=timeout)
 
+    def try_arm(self, result=True, expect_msg=None, timeout=60):
+        """Send Arming command, wait for the expected result and statustext."""
+        self.progress("Try arming and wait for expected result")
+        self.drain_mav()
+        self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                     1,  # ARM
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED if result else mavutil.mavlink.MAV_RESULT_FAILED,
+                     timeout=timeout)
+        if expect_msg is not None:
+            self.wait_statustext(expect_msg, timeout=timeout, the_function=lambda: self.send_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                                                                                                 1,  # ARM
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 target_sysid=None,
+                                                                                                 target_compid=None,
+                                                                                                 ))
+
     def arm_vehicle(self, timeout=20):
         """Arm vehicle with mavlink arm message."""
         self.progress("Arm motors with MAVLink cmd")

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4680,6 +4680,14 @@ class AutoTest(ABC):
             self.set_parameter("SIM_MAG_OFS_X", MAG_OFS_X)
             self.set_parameter("SIM_MAG_OFS_Y", MAG_OFS_Y)
             self.set_parameter("SIM_MAG_OFS_Z", MAG_OFS_Z)
+
+            self.set_parameter("SIM_MAG2_OFS_X", MAG_OFS_X)
+            self.set_parameter("SIM_MAG2_OFS_Y", MAG_OFS_Y)
+            self.set_parameter("SIM_MAG2_OFS_Z", MAG_OFS_Z)
+
+            self.set_parameter("SIM_MAG3_OFS_X", MAG_OFS_X)
+            self.set_parameter("SIM_MAG3_OFS_Y", MAG_OFS_Y)
+            self.set_parameter("SIM_MAG3_OFS_Z", MAG_OFS_Z)
             # set to some sensible-ish initial values.  If your initial
             # offsets are way, way off you can get some very odd effects.
             for param in wanted:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2934,12 +2934,11 @@ class AutoTest(ABC):
                                                              m.result))
                 break
 
-    def verify_parameter_values(self, parameter_stuff):
+    def verify_parameter_values(self, parameter_stuff, max_delta=0.0):
         bad = ""
         for param in parameter_stuff:
             fetched_value = self.get_parameter(param)
             wanted_value = parameter_stuff[param]
-            max_delta = 0.0
             if type(wanted_value) == tuple:
                 max_delta = wanted_value[1]
                 wanted_value = wanted_value[0]

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4239,14 +4239,417 @@ class AutoTest(ABC):
             self.disarm_vehicle(force=True)
         self.reboot_sitl()
 
+    def zero_mag_offset_parameters(self, compass_count=3):
+        self.progress("Zeroing Mag OFS parameters")
+        self.drain_mav()
+        self.get_sim_time()
+        self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
+                     2, # param1 (compass0)
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0 # param7
+                     )
+        self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
+                     5, # param1 (compass1)
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0 # param7
+                     )
+        self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
+                     6, # param1 (compass2)
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0 # param7
+                     )
+        self.progress("zeroed mag parameters")
+        params = [
+            [("SIM_MAG_OFS_X", "COMPASS_OFS_X", 0),
+             ("SIM_MAG_OFS_Y", "COMPASS_OFS_Y", 0),
+             ("SIM_MAG_OFS_Z", "COMPASS_OFS_Z", 0), ],
+        ]
+        for count in range(2, compass_count + 1):
+            params += [
+                [("SIM_MAG%d_OFS_X" % count, "COMPASS_OFS%d_X" % count, 0),
+                 ("SIM_MAG%d_OFS_Y" % count, "COMPASS_OFS%d_Y" % count, 0),
+                 ("SIM_MAG%d_OFS_Z" % count, "COMPASS_OFS%d_Z" % count, 0), ],
+                ]
+        self.check_zero_mag_parameters(params)
+
+    def forty_two_mag_dia_odi_parameters(self, compass_count=3):
+        self.progress("Forty twoing Mag DIA and ODI parameters")
+        self.drain_mav()
+        self.get_sim_time()
+        params = [
+            [("SIM_MAG_DIA_X", "COMPASS_DIA_X", 42.0),
+             ("SIM_MAG_DIA_Y", "COMPASS_DIA_Y", 42.0),
+             ("SIM_MAG_DIA_Z", "COMPASS_DIA_Z", 42.0),
+             ("SIM_MAG_ODI_X", "COMPASS_ODI_X", 42.0),
+             ("SIM_MAG_ODI_Y", "COMPASS_ODI_Y", 42.0),
+             ("SIM_MAG_ODI_Z", "COMPASS_ODI_Z", 42.0), ],
+        ]
+        for count in range(2, compass_count + 1):
+            params += [
+                [("SIM_MAG%d_DIA_X" % count, "COMPASS_DIA%d_X" % count, 42.0),
+                 ("SIM_MAG%d_DIA_Y" % count, "COMPASS_DIA%d_Y" % count, 42.0),
+                 ("SIM_MAG%d_DIA_Z" % count, "COMPASS_DIA%d_Z" % count, 42.0),
+                 ("SIM_MAG%d_ODI_X" % count, "COMPASS_ODI%d_X" % count, 42.0),
+                 ("SIM_MAG%d_ODI_Y" % count, "COMPASS_ODI%d_Y" % count, 42.0),
+                 ("SIM_MAG%d_ODI_Z" % count, "COMPASS_ODI%d_Z" % count, 42.0), ],
+            ]
+        self.wait_heartbeat()
+        for param_set in params:
+            for param in param_set:
+                (_, _out, value) = param
+                self.set_parameter(_out, value)
+        self.check_zero_mag_parameters(params)
+
+    def check_mag_parameters(self, parameter_stuff, compass_number):
+        self.progress("Checking that Mag parameter")
+        for idx in range(0, compass_number, 1):
+            for param in parameter_stuff[idx]:
+                (_in, _out, value) = param
+                got_value = self.get_parameter(_out)
+                if abs(got_value - value) > abs(value) * 0.15:
+                    raise NotAchievedException("%s/%s not within 15%%; got %f want=%f" % (_in, _out, got_value, value))
+
+    def check_zero_mag_parameters(self, parameter_stuff):
+        self.progress("Checking that Mag OFS are zero")
+        for param_set in parameter_stuff:
+            for param in param_set:
+                (_in, _out, _) = param
+                got_value = self.get_parameter(_out)
+                max = 0.15
+                if "DIA" in _out or "ODI" in _out:
+                    max += 42.0
+                if abs(got_value) > max:
+                    raise NotAchievedException("%s/%s not within 15%%; got %f want=%f" % (_in, _out, got_value, 0.0 if max > 1 else 42.0))
+
+    def check_zeros_mag_orient(self, compass_count=3):
+        self.progress("zeroed mag parameters")
+        self.verify_parameter_values({"COMPASS_ORIENT": 0})
+        for count in range(2, compass_count + 1):
+            self.verify_parameter_values({"COMPASS_ORIENT%d" % count: 0})
+
+    def test_mag_calibration(self, compass_count=3, timeout=500):
+        ex = None
+        self.set_parameter("AHRS_EKF_TYPE", 10)
+        self.set_parameter("SIM_GND_BEHAV", 0)
+
+        def reset_pos_and_start_magcal(tmask):
+            self.mavproxy.send("sitl_stop\n")
+            self.mavproxy.send("sitl_attitude 0 0 0\n")
+            self.drain_mav()
+            self.get_sim_time()
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+                         tmask, # p1: mag_mask
+                         0, # p2: retry
+                         0, # p3: autosave
+                         0, # p4: delay
+                         0, # param5
+                         0, # param6
+                         0, # param7
+                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                         timeout=20,
+                         )
+            self.mavproxy.send("sitl_magcal\n")
+
+        def do_prep_mag_cal_test(params):
+            self.progress("Preparing the vehicle for magcal")
+            MAG_OFS = 100
+            MAG_DIA = 1.0
+            MAG_ODI = 0.004
+            params += [
+                [("SIM_MAG_OFS_X", "COMPASS_OFS_X", MAG_OFS),
+                 ("SIM_MAG_OFS_Y", "COMPASS_OFS_Y", MAG_OFS + 100),
+                 ("SIM_MAG_OFS_Z", "COMPASS_OFS_Z", MAG_OFS + 200),
+                 ("SIM_MAG_DIA_X", "COMPASS_DIA_X", MAG_DIA),
+                 ("SIM_MAG_DIA_Y", "COMPASS_DIA_Y", MAG_DIA + 0.1),
+                 ("SIM_MAG_DIA_Z", "COMPASS_DIA_Z", MAG_DIA + 0.2),
+                 ("SIM_MAG_ODI_X", "COMPASS_ODI_X", MAG_ODI),
+                 ("SIM_MAG_ODI_Y", "COMPASS_ODI_Y", MAG_ODI + 0.001),
+                 ("SIM_MAG_ODI_Z", "COMPASS_ODI_Z", MAG_ODI + 0.001), ],
+            ]
+            for count in range(2, compass_count + 1):
+                params += [
+                    [("SIM_MAG%d_OFS_X" % count, "COMPASS_OFS%d_X" % count, MAG_OFS + 100 * ((count+2) % compass_count)),
+                     ("SIM_MAG%d_OFS_Y" % count, "COMPASS_OFS%d_Y" % count, MAG_OFS + 100 * ((count+3) % compass_count)),
+                     ("SIM_MAG%d_OFS_Z" % count, "COMPASS_OFS%d_Z" % count, MAG_OFS + 100 * ((count+1) % compass_count)),
+                     ("SIM_MAG%d_DIA_X" % count, "COMPASS_DIA%d_X" % count, MAG_DIA + 0.1 * ((count+2) % compass_count)),
+                     ("SIM_MAG%d_DIA_Y" % count, "COMPASS_DIA%d_Y" % count, MAG_DIA + 0.1 * ((count+3) % compass_count)),
+                     ("SIM_MAG%d_DIA_Z" % count, "COMPASS_DIA%d_Z" % count, MAG_DIA + 0.1 * ((count+1) % compass_count)),
+                     ("SIM_MAG%d_ODI_X" % count, "COMPASS_ODI%d_X" % count, MAG_ODI + 0.001 * ((count+2) % compass_count)),
+                     ("SIM_MAG%d_ODI_Y" % count, "COMPASS_ODI%d_Y" % count, MAG_ODI + 0.001 * ((count+3) % compass_count)),
+                     ("SIM_MAG%d_ODI_Z" % count, "COMPASS_ODI%d_Z" % count, MAG_ODI + 0.001 * ((count+1) % compass_count)), ],
+                ]
+            self.progress("Setting calibration mode")
+            self.wait_heartbeat()
+            self.customise_SITL_commandline(["-M", "calibration"])
+            self.mavproxy_load_module("sitl_calibration")
+            self.mavproxy_load_module("calibration")
+            self.mavproxy_load_module("relay")
+            self.mavproxy.expect("is using GPS")
+            self.mavproxy.send("accelcalsimple\n")
+            self.mavproxy.expect("Calibrated")
+            # disable it to not interfert with calibration acceptation
+            self.mavproxy_unload_module("calibration")
+            if self.is_copter():
+                # set frame class to pass arming check on copter
+                self.set_parameter("FRAME_CLASS", 1)
+            self.drain_mav()
+            self.progress("Setting SITL Magnetometer model value")
+            MAG_ORIENT = 4
+            self.set_parameter("SIM_MAG_ORIENT", MAG_ORIENT)
+            for count in range(2, compass_count + 1):
+                self.set_parameter("SIM_MAG%d_ORIENT" % count, MAG_ORIENT * (count % 41))
+                # set compass external to check that orientation is found and auto set
+                self.set_parameter("COMPASS_EXTERN%d" % count, 1)
+            for param_set in params:
+                for param in param_set:
+                    (_in, _out, value) = param
+                    self.set_parameter(_in, value)
+                    self.set_parameter(_out, value)
+            self.start_subtest("Zeroing Mag OFS parameters with Mavlink")
+            self.zero_mag_offset_parameters()
+            self.progress("=========================================")
+            # Change the default value to unexpected 42
+            self.forty_two_mag_dia_odi_parameters()
+            self.progress("Zeroing Mags orientations")
+            self.set_parameter("COMPASS_ORIENT", 0)
+            for count in range(2, compass_count + 1):
+                self.set_parameter("COMPASS_ORIENT%d" % count, 0)
+
+            # Only care about compass prearm
+            self.set_parameter("ARMING_CHECK", 4)
+
+        #################################################
+        def do_test_mag_cal(params, compass_tnumber):
+            self.start_subtest("Try magcal and make it stop around 30%")
+            self.progress("Compass mask is %s" % "{0:b}".format(target_mask))
+            reset_pos_and_start_magcal(target_mask)
+            tstart = self.get_sim_time()
+            reached_pct = [0] * compass_tnumber
+            tstop = None
+            while True:
+                if self.get_sim_time_cached() - tstart > timeout:
+                    raise NotAchievedException("Cannot receive enough MAG_CAL_PROGRESS")
+                m = self.mav.recv_match(type='MAG_CAL_PROGRESS', blocking=True, timeout=5)
+                if m is None:
+                    if tstop is not None:
+                        # wait 3 second to unsure that the calibration is well stopped
+                        if self.get_sim_time_cached() - tstop > 10:
+                            if reached_pct[0] > 33:
+                                raise NotAchievedException("Mag calibration didn't stop")
+                            else:
+                                break
+                        else:
+                            continue
+                    else:
+                        continue
+                if m is not None:
+                    cid = m.compass_id
+                    new_pct = int(m.completion_pct)
+                    if new_pct != reached_pct[cid]:
+                        if new_pct < reached_pct[cid]:
+                            raise NotAchievedException("Mag calibration restart when it shouldn't")
+                        reached_pct[cid] = new_pct
+                        self.progress("Calibration progress compass ID %d: %s" % (cid, str(reached_pct[cid])))
+                        if cid == 0 and 13 <= reached_pct[0] <= 15:
+                            self.progress("Request again to start calibration, it shouldn't restart from 0")
+                            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+                                         target_mask,
+                                         0,
+                                         0,
+                                         0,
+                                         0,
+                                         0,
+                                         0,
+                                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                                         timeout=20,
+                                         )
+
+                if reached_pct[0] > 30:
+                    self.run_cmd(mavutil.mavlink.MAV_CMD_DO_CANCEL_MAG_CAL,
+                                 target_mask,  # p1: mag_mask
+                                 0,  # param2
+                                 0,  # param3
+                                 0,  # param4
+                                 0,  # param5
+                                 0,  # param6
+                                 0,  # param7
+                                 want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                                 )
+                    if tstop is None:
+                        tstop = self.get_sim_time_cached()
+                if tstop is not None:
+                    # wait 3 second to unsure that the calibration is well stopped
+                    if self.get_sim_time_cached() - tstop > 3:
+                        raise NotAchievedException("Mag calibration didn't stop")
+            self.check_zero_mag_parameters(params)
+            self.check_zeros_mag_orient()
+
+            #################################################
+            self.start_subtest("Try magcal and make it failed")
+            self.progress("Compass mask is %s" % "{0:b}".format(target_mask))
+            old_cal_fit = self.get_parameter("COMPASS_CAL_FIT")
+            self.set_parameter("COMPASS_CAL_FIT", 0.001, add_to_context=False)
+            reset_pos_and_start_magcal(target_mask)
+            tstart = self.get_sim_time()
+            reached_pct = [0] * compass_tnumber
+            report_get = [0] * compass_tnumber
+            while True:
+                if self.get_sim_time_cached() - tstart > timeout:
+                    raise NotAchievedException("Cannot receive enough MAG_CAL_PROGRESS")
+                m = self.mav.recv_match(type=["MAG_CAL_PROGRESS", "MAG_CAL_REPORT"], blocking=True, timeout=5)
+                if m.get_type() == "MAG_CAL_REPORT":
+                    if report_get[m.compass_id] == 0:
+                        self.progress("Report: %s" % str(m))
+                        if m.cal_status == mavutil.mavlink.MAG_CAL_FAILED:
+                            report_get[m.compass_id] = 1
+                        else:
+                            raise NotAchievedException("Mag calibration didn't failed")
+                    if all(ele >= 1 for ele in report_get):
+                        self.progress("All Mag report failure")
+                        break
+                if m is not None and m.get_type() == "MAG_CAL_PROGRESS":
+                    cid = m.compass_id
+                    new_pct = int(m.completion_pct)
+                    if new_pct != reached_pct[cid]:
+                        reached_pct[cid] = new_pct
+                        self.progress("Calibration progress compass ID %d: %s" % (cid, str(reached_pct[cid])))
+                        if cid == 0 and 49 <= reached_pct[0] <= 50:
+                            self.progress("Try arming during calibration, should failed")
+                            self.try_arm(False, "Compass calibration running")
+
+            self.check_zero_mag_parameters(params)
+            self.check_zeros_mag_orient()
+            self.set_parameter("COMPASS_CAL_FIT", old_cal_fit, add_to_context=False)
+
+            #################################################
+            self.start_subtest("Try magcal and wait success")
+            self.progress("Compass mask is %s" % "{0:b}".format(target_mask))
+            reset_pos_and_start_magcal(target_mask)
+            reached_pct = [0] * compass_tnumber
+            report_get = [0] * compass_tnumber
+            tstart = self.get_sim_time()
+            while True:
+                if self.get_sim_time_cached() - tstart > timeout:
+                    raise NotAchievedException("Cannot receive enough MAG_CAL_PROGRESS")
+                m = self.mav.recv_match(type=["MAG_CAL_PROGRESS", "MAG_CAL_REPORT"], blocking=True, timeout=5)
+                if m.get_type() == "MAG_CAL_REPORT":
+                    if report_get[m.compass_id] == 0:
+                        self.progress("Report: %s" % str(m))
+                        if m.cal_status == mavutil.mavlink.MAG_CAL_SUCCESS:
+                            if reached_pct[m.compass_id] < 99:
+                                raise NotAchievedException("Mag calibration report SUCCESS without 100%% completion")
+                            report_get[m.compass_id] = 1
+                        else:
+                            raise NotAchievedException("Mag calibration didn't SUCCESS")
+                    if all(ele >= 1 for ele in report_get):
+                        self.progress("All Mag report SUCCESS")
+                        break
+                if m is not None and m.get_type() == "MAG_CAL_PROGRESS":
+                    cid = m.compass_id
+                    new_pct = int(m.completion_pct)
+                    if new_pct != reached_pct[cid]:
+                        reached_pct[cid] = new_pct
+                        self.progress("Calibration progress compass ID %d: %s" % (cid, str(reached_pct[cid])))
+            self.mavproxy.send("sitl_stop\n")
+            self.mavproxy.send("sitl_attitude 0 0 0\n")
+            self.progress("Checking that value aren't changed without acceptation")
+            self.check_zero_mag_parameters(params)
+            self.check_zeros_mag_orient()
+            self.progress("Send acceptation and check value")
+            self.wait_heartbeat()
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_ACCEPT_MAG_CAL,
+                         target_mask, # p1: mag_mask
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                         timeout=20,
+                         )
+            self.check_mag_parameters(params, compass_tnumber)
+            self.verify_parameter_values({"COMPASS_ORIENT": self.get_parameter("SIM_MAG_ORIENT")})
+            for count in range(2, compass_tnumber + 1):
+                self.verify_parameter_values({"COMPASS_ORIENT%d" % count: self.get_parameter("SIM_MAG%d_ORIENT" % count)})
+            self.try_arm(False, "Compass calibrated requires reboot")
+
+            # test buzzer/notify ?
+            self.progress("Rebooting and making sure we could arm with these values")
+            self.drain_mav()
+            self.reboot_sitl()
+            self.wait_ready_to_arm(timeout=60)
+            self.progress("Setting manually the parameter for other sensor to avoid compass consistency error")
+            for idx in range(compass_tnumber, compass_count, 1):
+                for param in params[idx]:
+                    (_in, _out, value) = param
+                    self.set_parameter(_out, value)
+            for count in range(compass_tnumber + 1, compass_count + 1):
+                self.set_parameter("COMPASS_ORIENT%d" % count, self.get_parameter("SIM_MAG%d_ORIENT" % count))
+            self.arm_vehicle()
+            self.progress("Test calibration rejection when armed")
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+                         target_mask, # p1: mag_mask
+                         0, # p2: retry
+                         0, # p3: autosave
+                         0, # p4: delay
+                         0, # param5
+                         0, # param6
+                         0, # param7
+                         want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+                         timeout=20,
+                         )
+            self.disarm_vehicle()
+            self.mavproxy_unload_module("relay")
+            self.mavproxy_unload_module("sitl_calibration")
+
+        try:
+            curr_params = []
+            target_mask = 0
+            # we test all bitmask plus 0 for all
+            for run in range(-1, compass_count, 1):
+                ntest_compass = compass_count
+                if run < 0:
+                    # use bitmask 0 for all compass
+                    target_mask = 0
+                else:
+                    target_mask |= (1 << run)
+                    ntest_compass = run + 1
+                do_prep_mag_cal_test(curr_params)
+                do_test_mag_cal(curr_params, ntest_compass)
+
+        except Exception as e:
+            self.progress("Caught exception: %s" %
+                          self.get_exception_stacktrace(e))
+            ex = e
+            self.mavproxy_unload_module("relay")
+            self.mavproxy_unload_module("sitl_calibration")
+        if ex is not None:
+            raise ex
+
     def test_fixed_yaw_calibration(self):
         self.context_push()
         ex = None
         try:
+            MAG_OFS_X = 100
+            MAG_OFS_Y = 200
+            MAG_OFS_Z = 300
             wanted = {
-                "COMPASS_OFS_X": (100, 3.0),
-                "COMPASS_OFS_Y": (200, 3.0),
-                "COMPASS_OFS_Z": (300, 3.0),
+                "COMPASS_OFS_X": (MAG_OFS_X, 3.0),
+                "COMPASS_OFS_Y": (MAG_OFS_Y, 3.0),
+                "COMPASS_OFS_Z": (MAG_OFS_Z, 3.0),
                 "COMPASS_DIA_X": 1,
                 "COMPASS_DIA_Y": 1,
                 "COMPASS_DIA_Z": 1,
@@ -4254,9 +4657,9 @@ class AutoTest(ABC):
                 "COMPASS_ODI_Y": 0,
                 "COMPASS_ODI_Z": 0,
 
-                "COMPASS_OFS2_X": (100, 3.0),
-                "COMPASS_OFS2_Y": (200, 3.0),
-                "COMPASS_OFS2_Z": (300, 3.0),
+                "COMPASS_OFS2_X": (MAG_OFS_X, 3.0),
+                "COMPASS_OFS2_Y": (MAG_OFS_Y, 3.0),
+                "COMPASS_OFS2_Z": (MAG_OFS_Z, 3.0),
                 "COMPASS_DIA2_X": 1,
                 "COMPASS_DIA2_Y": 1,
                 "COMPASS_DIA2_Z": 1,
@@ -4264,20 +4667,19 @@ class AutoTest(ABC):
                 "COMPASS_ODI2_Y": 0,
                 "COMPASS_ODI2_Z": 0,
 
-                "COMPASS_OFS3_X": (100, 3.0),
-                "COMPASS_OFS3_Y": (200, 3.0),
-                "COMPASS_OFS3_Z": (300, 3.0),
+                "COMPASS_OFS3_X": (MAG_OFS_X, 3.0),
+                "COMPASS_OFS3_Y": (MAG_OFS_Y, 3.0),
+                "COMPASS_OFS3_Z": (MAG_OFS_Z, 3.0),
                 "COMPASS_DIA3_X": 1,
                 "COMPASS_DIA3_Y": 1,
                 "COMPASS_DIA3_Z": 1,
-                "COMPASS_ODI2_X": 0,
-                "COMPASS_ODI2_Y": 0,
-                "COMPASS_ODI2_Z": 0,
+                "COMPASS_ODI3_X": 0,
+                "COMPASS_ODI3_Y": 0,
+                "COMPASS_ODI3_Z": 0,
             }
-            self.set_parameter("SIM_MAG_OFS_X", 100)
-            self.set_parameter("SIM_MAG_OFS_Y", 200)
-            self.set_parameter("SIM_MAG_OFS_Z", 300)
-
+            self.set_parameter("SIM_MAG_OFS_X", MAG_OFS_X)
+            self.set_parameter("SIM_MAG_OFS_Y", MAG_OFS_Y)
+            self.set_parameter("SIM_MAG_OFS_Z", MAG_OFS_Z)
             # set to some sensible-ish initial values.  If your initial
             # offsets are way, way off you can get some very odd effects.
             for param in wanted:
@@ -4287,28 +4689,9 @@ class AutoTest(ABC):
                 elif "ODI" in param:
                     value = 0.001
                 self.set_parameter(param, value)
-            # zero the parameters:
-            self.progress("zeroing parameters")
-            self.drain_mav()  # these two lines are odd....
-            self.get_sim_time()
-            self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
-                         2, # param1 (compass0)
-                         0, # param2
-                         0, # param3
-                         0, # param4
-                         0, # param5
-                         0, # param6
-                         0 # param7
-            )
-            self.progress("zeroed parameters")
-            # ensure these are all zero; note that we don't set the DIA or
-            # ODI in SET_SENSOR_OFFSETS...
-            for axis in "X", "Y", "Z":
-                name = "COMPASS_OFS_%s" % axis
-                value = self.get_parameter(name)
-                if value != 0.0:
-                    raise NotAchievedException("Failed to zero %s; got %f" %
-                                               (name, value))
+
+            self.zero_mag_offset_parameters()
+
             self.change_mode('LOITER')
             self.wait_ready_to_arm() # so we definitely have position
             ss = self.mav.recv_match(type='SIMSTATE', blocking=True, timeout=1)

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -9,7 +9,6 @@
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-#include "CompassCalibrator.h"
 #include "AP_Compass_Backend.h"
 #include "Compass_PerMotor.h"
 #include <AP_Common/TSIndex.h>
@@ -62,6 +61,8 @@
 #define COMPASS_MAX_BACKEND   HAL_COMPASS_MAX_SENSORS
 
 #define MAX_CONNECTED_MAGS (COMPASS_MAX_UNREG_DEV+COMPASS_MAX_INSTANCES)
+
+#include "CompassCalibrator.h"
 
 class CompassLearn;
 
@@ -167,8 +168,8 @@ public:
 
     void cancel_calibration_all();
 
-    bool compass_cal_requires_reboot() const { return _cal_complete_requires_reboot; }
-    bool is_calibrating() const;
+    bool compass_cal_requires_reboot() const { return _cal_requires_reboot; }
+    bool is_calibrating();
 
     // indicate which bit in LOG_BITMASK indicates we should log compass readings
     void set_log_bit(uint32_t log_bit) { _log_bit = log_bit; }
@@ -367,11 +368,12 @@ private:
     void _detect_backends(void);
 
     // compass cal
+    void _update_calibration_trampoline();
     bool _accept_calibration(uint8_t i);
     bool _accept_calibration_mask(uint8_t mask);
     void _cancel_calibration(uint8_t i);
     void _cancel_calibration_mask(uint8_t mask);
-    uint8_t _get_cal_mask() const;
+    uint8_t _get_cal_mask();
     bool _start_calibration(uint8_t i, bool retry=false, float delay_sec=0.0f);
     bool _start_calibration_mask(uint8_t mask, bool retry=false, bool autosave=false, float delay_sec=0.0f, bool autoreboot=false);
     bool _auto_reboot() { return _compass_cal_autoreboot; }
@@ -393,7 +395,7 @@ private:
 
     //autoreboot after compass calibration
     bool _compass_cal_autoreboot;
-    bool _cal_complete_requires_reboot;
+    bool _cal_requires_reboot;
     bool _cal_has_run;
 
     // enum of drivers for COMPASS_TYPEMASK
@@ -545,7 +547,7 @@ private:
     AP_Int16 _options;
 
 #if COMPASS_CAL_ENABLED
-    RestrictIDTypeArray<CompassCalibrator, COMPASS_MAX_INSTANCES, Priority> _calibrator;
+    RestrictIDTypeArray<CompassCalibrator*, COMPASS_MAX_INSTANCES, Priority> _calibrator;
 #endif
 
 #if COMPASS_MOT_ENABLED
@@ -578,6 +580,8 @@ private:
     ///
     void try_set_initial_location();
     bool _initial_location_set;
+
+    bool _cal_thread_started;
 };
 
 namespace AP {

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -52,7 +52,10 @@ void AP_Compass_Backend::publish_raw_field(const Vector3f &mag, uint8_t instance
     // sensor rate. We want them to consume only the filtered fields
     state.last_update_ms = AP_HAL::millis();
 #if COMPASS_CAL_ENABLED
-    _compass._calibrator[_compass._get_priority(Compass::StateIndex(instance))].new_sample(mag);
+    auto& cal = _compass._calibrator[_compass._get_priority(Compass::StateIndex(instance))];
+    if (cal != nullptr) {
+        cal->new_sample(mag);
+    }
 #endif
 }
 

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -35,7 +35,7 @@ private:
     void _timer();
     uint32_t _last_sample_time;
 
-    void _setup_eliptical_correcion();
+    void _setup_eliptical_correcion(uint8_t i);
     
     Matrix3f _eliptical_corr;
     Vector3f _last_dia;

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -57,6 +57,7 @@
  * http://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
  */
 
+#include "AP_Compass.h"
 #include "CompassCalibrator.h"
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_GeodesicGrid.h>
@@ -75,70 +76,181 @@ extern const AP_HAL::HAL& hal;
 
 CompassCalibrator::CompassCalibrator()
 {
-    stop();
+    set_status(Status::NOT_STARTED);
 }
 
+// Request to cancel calibration 
 void CompassCalibrator::stop()
 {
-    set_status(Status::NOT_STARTED);
+    WITH_SEMAPHORE(state_sem);
+    _requested_status = Status::NOT_STARTED;
+    _status_set_requested = true;
 }
 
 void CompassCalibrator::set_orientation(enum Rotation orientation, bool is_external, bool fix_orientation)
 {
-    _check_orientation = true;
-    _orientation = orientation;
-    _orig_orientation = orientation;
-    _is_external = is_external;
-    _fix_orientation = fix_orientation;
+    WITH_SEMAPHORE(state_sem);
+    cal_settings.check_orientation = true;
+    cal_settings.orientation = orientation;
+    cal_settings.orig_orientation = orientation;
+    cal_settings.is_external = is_external;
+    cal_settings.fix_orientation = fix_orientation;
 }
 
-void CompassCalibrator::start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx)
+void CompassCalibrator::start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx, float tolerance)
 {
-    if (running()) {
-        return;
-    }
-    _offset_max = offset_max;
-    _attempt = 1;
-    _retry = retry;
-    _delay_start_sec = delay;
-    _start_time_ms = AP_HAL::millis();
-    _compass_idx = compass_idx;
-    set_status(Status::WAITING_TO_START);
-}
-
-void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals, float &scale_factor)
-{
-    if (_status != Status::SUCCESS) {
+    if (compass_idx > COMPASS_MAX_INSTANCES) {
         return;
     }
 
-    offsets = _params.offset;
-    diagonals = _params.diag;
-    offdiagonals = _params.offdiag;
-    scale_factor = _params.scale_factor;
+    WITH_SEMAPHORE(state_sem);
+    // Don't do this while we are already started
+    if (_running()) {
+        return;
+    }
+    cal_settings.offset_max = offset_max;
+    cal_settings.attempt = 1;
+    cal_settings.retry = retry;
+    cal_settings.delay_start_sec = delay;
+    cal_settings.start_time_ms = AP_HAL::millis();
+    cal_settings.compass_idx = compass_idx;
+    cal_settings.tolerance = tolerance;
+
+    // Request status change to Waiting to start
+    _requested_status = Status::WAITING_TO_START;
+    _status_set_requested = true;
 }
 
-float CompassCalibrator::get_completion_percent() const
+// Record point mag sample and associated attitude sample to intermediate struct
+void CompassCalibrator::new_sample(const Vector3f& sample)
 {
-    // first sampling step is 1/3rd of the progress bar
-    // never return more than 99% unless _status is Status::SUCCESS
-    switch (_status) {
-        case Status::NOT_STARTED:
-        case Status::WAITING_TO_START:
-            return 0.0f;
-        case Status::RUNNING_STEP_ONE:
-            return 33.3f * _samples_collected/COMPASS_CAL_NUM_SAMPLES;
-        case Status::RUNNING_STEP_TWO:
-            return 33.3f + 65.7f*((float)(_samples_collected-_samples_thinned)/(COMPASS_CAL_NUM_SAMPLES-_samples_thinned));
-        case Status::SUCCESS:
-            return 100.0f;
-        case Status::FAILED:
-        case Status::BAD_ORIENTATION:
-        case Status::BAD_RADIUS:
-            return 0.0f;
-    };
-    // will not get here if the compiler is doing its job (no default clause)
-    return 0.0f;
+    WITH_SEMAPHORE(sample_sem);
+    _last_sample.set(sample);
+    _last_sample.att.set_from_ahrs();
+    _new_sample = true;
+}
+
+bool CompassCalibrator::failed() {
+    WITH_SEMAPHORE(state_sem);
+    return (cal_state.status == Status::FAILED ||
+            cal_state.status == Status::BAD_ORIENTATION || 
+            cal_state.status == Status::BAD_RADIUS);
+}
+
+
+bool CompassCalibrator::running() {
+    WITH_SEMAPHORE(state_sem); 
+    return (cal_state.status == Status::RUNNING_STEP_ONE || cal_state.status == Status::RUNNING_STEP_TWO);
+}
+
+const CompassCalibrator::Report CompassCalibrator::get_report() {
+    WITH_SEMAPHORE(state_sem);
+    return cal_report;
+}
+
+const CompassCalibrator::State CompassCalibrator::get_state() {
+    WITH_SEMAPHORE(state_sem);
+    return cal_state;
+}
+/////////////////////////////////////////////////////////////
+////////////////////// PRIVATE METHODS //////////////////////
+/////////////////////////////////////////////////////////////
+
+void CompassCalibrator::update()
+{
+
+    //pickup samples from intermediate struct
+    pull_sample();
+
+    {
+        WITH_SEMAPHORE(state_sem);
+        //update_settings
+        if (!running()) {
+            update_cal_settings();
+        }
+
+        //update requested state
+        if (_status_set_requested) {
+            _status_set_requested = false;
+            set_status(_requested_status);
+        }
+        //update report and status
+        update_cal_status();
+        update_cal_report();
+    }
+
+    // collect the minimum number of samples
+    if (!_fitting()) {
+        return;
+    }
+
+    if (_status == Status::RUNNING_STEP_ONE) {
+        if (_fit_step >= 10) {
+            if (is_equal(_fitness, _initial_fitness) || isnan(_fitness)) {  // if true, means that fitness is diverging instead of converging
+                set_status(Status::FAILED);
+            } else {
+                set_status(Status::RUNNING_STEP_TWO);
+            }
+        } else {
+            if (_fit_step == 0) {
+                calc_initial_offset();
+            }
+            run_sphere_fit();
+            _fit_step++;
+        }
+    } else if (_status == Status::RUNNING_STEP_TWO) {
+        if (_fit_step >= 35) {
+            if (fit_acceptable() && fix_radius() && calculate_orientation()) {
+                set_status(Status::SUCCESS);
+            } else {
+                set_status(Status::FAILED);
+            }
+        } else if (_fit_step < 15) {
+            run_sphere_fit();
+            _fit_step++;
+        } else {
+            run_ellipsoid_fit();
+            _fit_step++;
+        }
+    }
+}
+
+void CompassCalibrator::pull_sample()
+{
+    CompassSample mag_sample;
+    {
+        WITH_SEMAPHORE(sample_sem);
+        if (!_new_sample) {
+            return;
+        }
+        if (_status == Status::WAITING_TO_START) {
+            set_status(Status::RUNNING_STEP_ONE);
+        }
+        _new_sample = false;
+        mag_sample = _last_sample;
+    }
+    if (_running() && _samples_collected < COMPASS_CAL_NUM_SAMPLES && accept_sample(mag_sample.get())) {
+        update_completion_mask(mag_sample.get());
+        _sample_buffer[_samples_collected] = mag_sample;
+        _samples_collected++;
+    }
+}
+
+
+void CompassCalibrator::update_cal_settings()
+{
+    _tolerance = cal_settings.tolerance;
+    _check_orientation = cal_settings.check_orientation;
+    _orientation = cal_settings.orientation;
+    _orig_orientation = cal_settings.orig_orientation;
+    _is_external = cal_settings.is_external;
+    _fix_orientation = cal_settings.fix_orientation;
+    _offset_max = cal_settings.offset_max;
+    _attempt = cal_settings.attempt;
+    _retry = cal_settings.retry;
+    _delay_start_sec = cal_settings.delay_start_sec;
+    _start_time_ms = cal_settings.start_time_ms;
+    _compass_idx = cal_settings.compass_idx;
 }
 
 // update completion mask based on latest sample
@@ -167,86 +279,60 @@ void CompassCalibrator::update_completion_mask()
     }
 }
 
-bool CompassCalibrator::check_for_timeout()
+void CompassCalibrator::update_cal_status()
 {
-    uint32_t tnow = AP_HAL::millis();
-    if (running() && tnow - _last_sample_ms > 1000) {
-        _retry = false;
-        set_status(Status::FAILED);
-        return true;
-    }
-    return false;
+    cal_state.status = _status;
+    cal_state.attempt = _attempt;
+    memcpy(cal_state.completion_mask, _completion_mask, sizeof(completion_mask_t));
+    cal_state.completion_pct = 0.0f;
+    // first sampling step is 1/3rd of the progress bar
+    // never return more than 99% unless _status is Status::SUCCESS
+    switch (_status) {
+        case Status::NOT_STARTED:
+        case Status::WAITING_TO_START:
+            cal_state.completion_pct = 0.0f;
+            break;
+        case Status::RUNNING_STEP_ONE:
+            cal_state.completion_pct = 33.3f * _samples_collected/COMPASS_CAL_NUM_SAMPLES;
+            break;
+        case Status::RUNNING_STEP_TWO:
+            cal_state.completion_pct = 33.3f + 65.7f*((float)(_samples_collected-_samples_thinned)/(COMPASS_CAL_NUM_SAMPLES-_samples_thinned));
+            break;
+        case Status::SUCCESS:
+            cal_state.completion_pct = 100.0f;
+            break;
+        case Status::FAILED:
+        case Status::BAD_ORIENTATION:
+        case Status::BAD_RADIUS:
+            cal_state.completion_pct = 0.0f;
+            break;
+    };
 }
 
-void CompassCalibrator::new_sample(const Vector3f& sample)
+
+void CompassCalibrator::update_cal_report()
 {
-    _last_sample_ms = AP_HAL::millis();
-
-    if (_status == Status::WAITING_TO_START) {
-        set_status(Status::RUNNING_STEP_ONE);
-    }
-
-    if (running() && _samples_collected < COMPASS_CAL_NUM_SAMPLES && accept_sample(sample)) {
-        update_completion_mask(sample);
-        _sample_buffer[_samples_collected].set(sample);
-        _sample_buffer[_samples_collected].att.set_from_ahrs();
-        _samples_collected++;
-    }
+    cal_report.status = _status;
+    cal_report.fitness = sqrtf(_fitness);
+    cal_report.ofs = _params.offset;
+    cal_report.diag = _params.diag;
+    cal_report.offdiag = _params.offdiag;
+    cal_report.scale_factor = _params.scale_factor;
+    cal_report.orientation_confidence = _orientation_confidence;
+    cal_report.original_orientation = _orig_orientation;
+    cal_report.orientation = _orientation_solution;
 }
 
-void CompassCalibrator::update(bool &failure)
-{
-    failure = false;
-
-    // collect the minimum number of samples
-    if (!fitting()) {
-        return;
-    }
-
-    if (_status == Status::RUNNING_STEP_ONE) {
-        if (_fit_step >= 10) {
-            if (is_equal(_fitness, _initial_fitness) || isnan(_fitness)) {  // if true, means that fitness is diverging instead of converging
-                set_status(Status::FAILED);
-                failure = true;
-            } else {
-                set_status(Status::RUNNING_STEP_TWO);
-            }
-        } else {
-            if (_fit_step == 0) {
-                calc_initial_offset();
-            }
-            run_sphere_fit();
-            _fit_step++;
-        }
-    } else if (_status == Status::RUNNING_STEP_TWO) {
-        if (_fit_step >= 35) {
-            if (fit_acceptable() && fix_radius() && calculate_orientation()) {
-                set_status(Status::SUCCESS);
-            } else {
-                set_status(Status::FAILED);
-                failure = true;
-            }
-        } else if (_fit_step < 15) {
-            run_sphere_fit();
-            _fit_step++;
-        } else {
-            run_ellipsoid_fit();
-            _fit_step++;
-        }
-    }
-}
-
-/////////////////////////////////////////////////////////////
-////////////////////// PRIVATE METHODS //////////////////////
-/////////////////////////////////////////////////////////////
-bool CompassCalibrator::running() const
+// running method for use in thread
+bool CompassCalibrator::_running() const
 {
     return _status == Status::RUNNING_STEP_ONE || _status == Status::RUNNING_STEP_TWO;
 }
 
-bool CompassCalibrator::fitting() const
+// fitting method for use in thread
+bool CompassCalibrator::_fitting() const
 {
-    return running() && (_samples_collected == COMPASS_CAL_NUM_SAMPLES);
+    return _running() && (_samples_collected == COMPASS_CAL_NUM_SAMPLES);
 }
 
 // initialize fitness before starting a fit
@@ -825,6 +911,8 @@ bool CompassCalibrator::calculate_orientation(void)
 
     float variance[ROTATION_MAX_AUTO_ROTATION+1] {};
 
+    _orientation_solution = _orientation;
+    
     for (enum Rotation r = ROTATION_NONE; r <= ROTATION_MAX_AUTO_ROTATION; r = (enum Rotation)(r+1)) {
         // calculate the average implied earth field across all samples
         Vector3f total_ef {};
@@ -904,6 +992,7 @@ bool CompassCalibrator::calculate_orientation(void)
         // we won't change the orientation, but we set _orientation
         // for reporting purposes
         _orientation = besti;
+        _orientation_solution = besti;
         set_status(Status::BAD_ORIENTATION);
         return false;
     }
@@ -923,6 +1012,7 @@ bool CompassCalibrator::calculate_orientation(void)
     }
 
     _orientation = besti;
+    _orientation_solution = besti;
 
     // re-run the fit to get the diagonals and off-diagonals for the
     // new orientation

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -13,24 +13,25 @@ class CompassCalibrator {
 public:
     CompassCalibrator();
 
-    // set tolerance of calibration (aka fitness)
-    void set_tolerance(float tolerance) { _tolerance = tolerance; }
+    // start or stop the calibration
+    void start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx, float tolerance);
+    void stop();
+
+    // Update point sample
+    void new_sample(const Vector3f& sample);
 
     // set compass's initial orientation and whether it should be automatically fixed (if required)
     void set_orientation(enum Rotation orientation, bool is_external, bool fix_orientation);
 
-    // start or stop the calibration
-    void start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx);
-    void stop();
+    // running is true if actively calculating offsets, diagonals or offdiagonals
+    bool running();
+
+    // failed is true if either of the failure states are hit
+    bool failed();
+
 
     // update the state machine and calculate offsets, diagonals and offdiagonals
-    void update(bool &failure);
-    void new_sample(const Vector3f &sample);
-
-    bool check_for_timeout();
-
-    // running is true if actively calculating offsets, diagonals or offdiagonals
-    bool running() const;
+    void update();
 
     // compass calibration states
     enum class Status {
@@ -44,27 +45,51 @@ public:
         BAD_RADIUS = 7,
     };
 
-    // get status of calibrations progress
-    Status get_status() const { return _status; }
-
-    // get calibration outputs (offsets, diagonals, offdiagonals) and fitness
-    void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals, float &scale_factor);
-    float get_fitness() const { return sqrtf(_fitness); }
-
-    // get corrected (and original) orientation
-    enum Rotation get_orientation() const { return _orientation; }
-    enum Rotation get_original_orientation() const { return _orig_orientation; }
-    float get_orientation_confidence() const { return _orientation_confidence; }
-
-    // get completion percentage (0 to 100) for reporting to GCS
-    float get_completion_percent() const;
-
-    // get how many attempts have been made to calibrate for reporting to GCS
-    uint8_t get_attempt() const { return _attempt; }
-
     // get completion mask for mavlink reporting (a bitmask of faces/directions for which we have compass samples)
     typedef uint8_t completion_mask_t[10];
-    const completion_mask_t& get_completion_mask() const { return _completion_mask; }
+
+    // Structure accessed for cal status update via mavlink 
+    struct State {
+        Status status;
+        uint8_t attempt;
+        float completion_pct;
+        completion_mask_t completion_mask;
+    } cal_state;
+
+    // Structure accessed after calibration is finished/failed
+    struct Report {
+        Status status;
+        float fitness;
+        Vector3f ofs;
+        Vector3f diag;
+        Vector3f offdiag;
+        float orientation_confidence;
+        Rotation original_orientation;
+        Rotation orientation;
+        float scale_factor;
+    } cal_report;
+
+    // Structure setup to set calibration run settings
+    struct Settings {
+        float tolerance;
+        bool check_orientation;
+        enum Rotation orientation;
+        enum Rotation orig_orientation;
+        bool is_external;
+        bool fix_orientation;
+        uint16_t offset_max;
+        uint8_t attempt;
+        bool retry;
+        float delay_start_sec;
+        uint32_t start_time_ms;
+        uint8_t compass_idx;
+    } cal_settings;
+
+    // Get calibration result
+    const Report get_report();
+    
+    // Get current Calibration state
+    const State get_state();
 
 private:
 
@@ -112,6 +137,9 @@ private:
     // set status including any required initialisation
     bool set_status(Status status);
 
+    // consume point raw sample from intermediate structure
+    void pull_sample();
+
     // returns true if sample should be added to buffer
     bool accept_sample(const Vector3f &sample, uint16_t skip_index = UINT16_MAX);
     bool accept_sample(const CompassSample &sample, uint16_t skip_index = UINT16_MAX);
@@ -126,7 +154,7 @@ private:
     void initialize_fit();
 
     // true if enough samples have been collected and fitting has begun (aka runniong())
-    bool fitting() const;
+    bool _fitting() const;
 
     // thins out samples between step one and step two
     void thin_samples();
@@ -162,9 +190,16 @@ private:
     // fix radius to compensate for sensor scaling errors
     bool fix_radius();
 
+    // update methods to read write intermediate structures, called inside thread
+    inline void update_cal_status();
+    inline void update_cal_report();
+    inline void update_cal_settings();
+
+    // running method for use in thread
+    bool _running() const;
+
     uint8_t _compass_idx;                   // index of the compass providing data
     Status _status;                         // current state of calibrator
-    uint32_t _last_sample_ms;               // system time of last sample received for timeout
 
     // values provided by caller
     float _delay_start_sec;                 // seconds to delay start of calibration (provided by caller)
@@ -191,8 +226,21 @@ private:
     // variables for orientation checking
     enum Rotation _orientation;             // latest detected orientation
     enum Rotation _orig_orientation;        // original orientation provided by caller
+    enum Rotation _orientation_solution;    // latest solution
     bool _is_external;                      // true if compass is external (provided by caller)
     bool _check_orientation;                // true if orientation should be automatically checked
     bool _fix_orientation;                  // true if orientation should be fixed if necessary
     float _orientation_confidence;          // measure of confidence in automatic orientation detection
+    CompassSample _last_sample;
+
+    Status _requested_status;
+    bool   _status_set_requested;
+
+    bool _new_sample;
+
+    // Semaphore for state related intermediate structures
+    HAL_Semaphore state_sem;
+
+    // Semaphore for intermediate structure for point sample collection
+    HAL_Semaphore sample_sem;
 };

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -75,7 +75,7 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("BARO_DELAY",    38, SITL,  baro_delay, 0),
     AP_GROUPINFO("MAG_DELAY",     39, SITL,  mag_delay, 0),
     AP_GROUPINFO("WIND_DELAY",    40, SITL,  wind_delay, 0),
-    AP_GROUPINFO("MAG_OFS",       41, SITL,  mag_ofs, 0),
+    AP_GROUPINFO("MAG_OFS",       41, SITL,  mag_ofs[0], 0),
     AP_GROUPINFO("ACC2_RND",      42, SITL,  accel2_noise, 0),
     AP_GROUPINFO("ARSPD_FAIL",    43, SITL,  arspd_fail, 0),
     AP_GROUPINFO("GYR_SCALE",     44, SITL,  gyro_scale, 0),
@@ -119,9 +119,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),
     AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
     AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
-    AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag, 0),
-    AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag, 0),
-    AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient, 0),
+    AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag[0], 0),
+    AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag[0], 0),
+    AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient[0], 0),
     AP_GROUPINFO("RC_CHANCOUNT",21, SITL,  rc_chancount, 16),
     // @Group: SPR_
     // @Path: ./SIM_Sprayer.cpp
@@ -258,6 +258,20 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     AP_GROUPINFO("VICON_VGLI",    21, SITL,  vicon_vel_glitch, 0),
 
     AP_GROUPINFO("RATE_HZ",  22, SITL,  loop_rate_hz, 1200),
+
+#if HAL_COMPASS_MAX_SENSORS > 1
+    AP_GROUPINFO("MAG2_OFS",     23, SITL,  mag_ofs[1], 0),
+    AP_GROUPINFO("MAG2_DIA",     24, SITL,  mag_diag[1], 0),
+    AP_GROUPINFO("MAG2_ODI",     25, SITL,  mag_offdiag[1], 0),
+    AP_GROUPINFO("MAG2_ORIENT",  26, SITL,  mag_orient[1], 0),
+#endif
+
+#if HAL_COMPASS_MAX_SENSORS > 2
+    AP_GROUPINFO("MAG3_OFS",     27, SITL,  mag_ofs[2], 0),
+    AP_GROUPINFO("MAG3_DIA",     28, SITL,  mag_diag[2], 0),
+    AP_GROUPINFO("MAG3_ODI",     29, SITL,  mag_offdiag[2], 0),
+    AP_GROUPINFO("MAG3_ORIENT",  30, SITL,  mag_orient[2], 0),
+#endif
 
     AP_GROUPEND
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -73,7 +73,9 @@ public:
 
     SITL() {
         // set a default compass offset
-        mag_ofs.set(Vector3f(5, 13, -18));
+        for (uint8_t i = 0; i < HAL_COMPASS_MAX_SENSORS; i++) {
+            mag_ofs[i].set(Vector3f(5, 13, -18));
+        }
         AP_Param::setup_object_defaults(this, var_info);
         AP_Param::setup_object_defaults(this, var_info2);
         AP_Param::setup_object_defaults(this, var_info3);
@@ -151,10 +153,10 @@ public:
 
     AP_Float mag_noise;   // in mag units (earth field is 818)
     AP_Vector3f mag_mot;  // in mag units per amp
-    AP_Vector3f mag_ofs;  // in mag units
-    AP_Vector3f mag_diag;  // diagonal corrections
-    AP_Vector3f mag_offdiag;  // off-diagonal corrections
-    AP_Int8 mag_orient;   // external compass orientation
+    AP_Vector3f mag_ofs[HAL_COMPASS_MAX_SENSORS];  // in mag units
+    AP_Vector3f mag_diag[HAL_COMPASS_MAX_SENSORS];  // diagonal corrections
+    AP_Vector3f mag_offdiag[HAL_COMPASS_MAX_SENSORS];  // off-diagonal corrections
+    AP_Int8 mag_orient[HAL_COMPASS_MAX_SENSORS];   // external compass orientation
     AP_Float servo_speed; // servo speed in seconds
 
     AP_Float sonar_glitch;// probablility between 0-1 that any given sonar sample will read as max distance


### PR DESCRIPTION
* Pulls the entire compass calibrator into a separate thread.
* Requires further review on stack allocation. Currently set arbitrarily to 1024B
* All read write accesses to calibrator are done via intermediate structures with locks, to avoid race conditions.
