### PR TITLE
HAL_ChibiOS: fixed Hott telem half duplex handling

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -817,7 +817,7 @@ void UARTDriver::write_pending_bytes_NODMA(uint32_t n)
     ByteBuffer::IoVec vec[2];
     uint16_t nwritten = 0;
 
-    if (half_duplex) {
+    if (half_duplex && n > 1) {
         half_duplex_setup_tx();
     }
 


### PR DESCRIPTION
this fixes an issue with single byte writes with half duplex. It isn't
an elegent solution, but nicely separates the different types of half
duplex operation