### PR TITLE
Copter: Disable the target system ID value less than 1

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -583,8 +583,8 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_packet(const mavlink_command_i
     case MAV_CMD_DO_FOLLOW:
 #if MODE_FOLLOW_ENABLED == ENABLED
         // param1: sysid of target to follow
-        if ((packet.param1 > 0) && (packet.param1 <= 255)) {
-            copter.g2.follow.set_target_sysid((uint8_t)packet.param1);
+        if ((static_cast<uint16_t>(packet.param1) > 0u) && (static_cast<uint16_t>(packet.param1) <= 255u)) {
+            copter.g2.follow.set_target_sysid(static_cast<uint8_t>(packet.param1));
             return MAV_RESULT_ACCEPTED;
         }
 #endif
@@ -660,8 +660,8 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 #if MODE_FOLLOW_ENABLED == ENABLED
     case MAV_CMD_DO_FOLLOW:
         // param1: sysid of target to follow
-        if ((packet.param1 > 0) && (packet.param1 <= 255)) {
-            copter.g2.follow.set_target_sysid((uint8_t)packet.param1);
+        if ((static_cast<uint16_t>(packet.param1) > 0u) && (static_cast<uint16_t>(packet.param1) <= 255u)) {
+            copter.g2.follow.set_target_sysid(static_cast<uint8_t>(packet.param1));
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_FAILED;


### PR DESCRIPTION
The individual value of the target system ID is an integer value from 1 to 255.
0 in the target system ID indicates all systems.
The target system ID is a floating value.
If this value is greater than 0 but less than 1, it is a valid value.
I think it's better to judge the floating value as an integer value.