### PR TITLE
Plane: Quadplane tailsit transition to FW throttle level change

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1708,7 +1708,8 @@ void QuadPlane::update_transition(void)
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                       plane.nav_pitch_cd,
                                                                       0);
-        attitude_control->set_throttle_out(motors->get_throttle_hover(), true, 0);
+        // set throttle at either hover throttle or current throttle, whichever is higher, through the transition
+        attitude_control->set_throttle_out(MAX(motors->get_throttle_hover(),motors->get_throttle()), true, 0);
         break;
     }
 


### PR DESCRIPTION
currently fixed at hover throttle...this change allows pilot input above that level to station keep in wind while transitioning....companion to #14039 