### PR TITLE
AP_Baro: Fix scope of HAL_INS_MPU60x0_NAME

### DIFF
--- a/libraries/AP_Baro/examples/ICM20789/ICM20789.cpp
+++ b/libraries/AP_Baro/examples/ICM20789/ICM20789.cpp
@@ -193,6 +193,7 @@ static bool send_cmd16(uint16_t cmd)
     return i2c_dev->transfer(cmd_b, 2, nullptr, 0);
 }
 
+#ifdef HAL_INS_MPU60x0_NAME
 /*
   read baro calibration data
  */
@@ -217,7 +218,6 @@ static bool read_calibration_data(void)
     return true;
 }
 
-#ifdef HAL_INS_MPU60x0_NAME
 // initialise baro on i2c
 static void i2c_init(void)
 {


### PR DESCRIPTION
`read_calibration_data` is defined but only used inside the
HAL_INS_MPU60x0_NAME scope.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>