### PR TITLE
AP_HAL_Linux: Add missing wscript for GPIOTest

### DIFF
--- a/libraries/AP_HAL_Linux/examples/GPIOTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/GPIOTest/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>