### PR TITLE
Call a functor in Scheduler run() function to soak up spare loop time

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -55,8 +55,10 @@ class AP_Scheduler
 public:
 
     FUNCTOR_TYPEDEF(scheduler_fastloop_fn_t, void);
+    FUNCTOR_TYPEDEF(scheduler_looptime_soak_fn_t, void);
 
-    AP_Scheduler(scheduler_fastloop_fn_t fastloop_fn = nullptr);
+    AP_Scheduler(scheduler_fastloop_fn_t fastloop_fn = nullptr,
+                 scheduler_looptime_soak_fn_t looptime_soak_fn = nullptr);
 
     /* Do not allow copies */
     AP_Scheduler(const AP_Scheduler &other) = delete;
@@ -155,6 +157,9 @@ public:
 private:
     // function that is called before anything in the scheduler table:
     scheduler_fastloop_fn_t _fastloop_fn;
+
+    // function that is called if we have lots of time left in a loop
+    scheduler_looptime_soak_fn_t _looptime_soak_fn;
 
     // used to enable scheduler debugging
     AP_Int8 _debug;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -113,6 +113,11 @@ void AP_Vehicle::loop()
     G_Dt = scheduler.get_loop_period_s();
 }
 
+void AP_Vehicle::looptime_soak_function()
+{
+    gcs().update_send();
+}
+
 /*
   common scheduler table for fast CPUs - all common vehicle tasks
   should be listed here, along with how often they should be called (in hz)

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -189,8 +189,15 @@ protected:
 #endif
 
     // main loop scheduler
-    AP_Scheduler scheduler{FUNCTOR_BIND_MEMBER(&AP_Vehicle::fast_loop, void)};
+    AP_Scheduler scheduler{
+        FUNCTOR_BIND_MEMBER(&AP_Vehicle::fast_loop, void),
+        FUNCTOR_BIND_MEMBER(&AP_Vehicle::looptime_soak_function, void)
+    };
     virtual void fast_loop() { }
+
+    // a method to soak up spare time at the end of the scheduler
+    // loop, before we go back to waiting for a sample.
+    void looptime_soak_function();
 
     // IMU variables
     // Integration time; time last loop took to run


### PR DESCRIPTION
Primarily of use to Plane and Rover running @50Hz to allow them to emit the telemetry they need to.

At higher `SCHED_LOOP_RATES` `update_send()` is called more often - so the message rates can be maintained.  This is the quick-fix workaround if you can't maintain the streamrates you desires; increase the `SCHED_LOOP_RATE`.  This has the downside that apparently Plane's performance can significantly change based on that (something that shouldn't happen but reports are...)

At 50Hz there simply isn't enough time given to `update_send()` to push out the data it needs to, instead we spend it at the top of the loop waiting-for-sample. 

We can't simply increase the time-allowed-for-task number in the scheduler table as that may lead to scheduler overruns / starving items lower down in the table when running at higher loop rates.

This patchset would constitute an interim fix for the problem.  We want to move sending of mavlink messages to a thread - see https://github.com/ArduPilot/ardupilot/pull/10325

However, that PR is likely to be quite some amount of work, and is fraught with danger.  I think this relatively short set of patches might be a reasonable interim fix, even if it will be entirely supplanted by the thread one in time.

Tests that need to be done for this primarily focus on scheduler performance.  We must ensure we don't cause (more :-( ) scheduler overruns as we soak up the extra time.  This should be performed on an stm32 board doing full fusion and "in flight".
