### PR TITLE
SITL: Be strict about presence of defaults files

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -4932,6 +4932,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         model = "rover-skid"
         vinfo = vehicleinfo.VehicleInfo()
         defaults_filepath = vinfo.options["Rover"]["frames"][model]["default_params_filename"]
+        defaults_filepath = [os.path.join(testdir, x) for x in defaults_filepath]
         self.customise_SITL_commandline([],
                                         model=model,
                                         defaults_filepath=defaults_filepath)

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1459,7 +1459,7 @@ void AP_Param::reload_defaults_file(bool last_pass)
         if (load_defaults_file(default_file, last_pass)) {
             printf("Loaded defaults from %s\n", default_file);
         } else {
-            printf("Failed to load defaults from %s\n", default_file);
+            AP_HAL::panic("Failed to load defaults from %s\n", default_file);
         }
     }
 #endif


### PR DESCRIPTION
This can avoid subtle testing problems where config files aren't being found and used.
