### PR TITLE
AP_HAL_ChibiOS: eliminate EKF2 from fmuv2 build

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
@@ -11,5 +11,8 @@ FLASH_SIZE_KB 1024
 # added to the build
 define HAL_MINIMIZE_FEATURES 1
 
+#eliminate EKF2 to save flash size
+define HAL_NAVEKF2_AVAILABLE 0
+
 # we don't have a flash page spare to write parameters to:
 undef STORAGE_FLASH_PAGE


### PR DESCRIPTION
Because on plane it is right on the cusp of overflowing preventing other PR's from getting merged.