### PR TITLE
GCS_MAVLink: do not push statustext queue on statustext send

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1860,11 +1860,6 @@ void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, u
                 break;
             }
         }
-
-        // try and send immediately if possible
-        if (hal.scheduler->in_main_thread()) {
-            service_statustext();
-        }
     } while (false);
 
     // given we don't really know what these methods get up to, we


### PR DESCRIPTION
This prevents sending of statustexts consuming all telemetry bandwidth.


This may mean we never send statustexts out on oversubscribed links as the remaining `service_statustext`  call comes after all of the other periodic sends on a link.  Perhaps that call should move up?
