### PR TITLE
Copter: fix terrain following in circle mode

### DIFF
--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -181,13 +181,21 @@ bool AC_Circle::update()
         return false;
     }
 
+    // calculate z-axis target
+    float target_z_cm;
+    if (_terrain_alt) {
+        target_z_cm = _center.z + terr_offset;
+    } else {
+        target_z_cm = _pos_control.get_alt_target();
+    }
+
     // if the circle_radius is zero we are doing panorama so no need to update loiter target
     if (!is_zero(_radius)) {
         // calculate target position
         Vector3f target;
         target.x = _center.x + _radius * cosf(-_angle);
         target.y = _center.y - _radius * sinf(-_angle);
-        target.z = _center.z + terr_offset;
+        target.z = target_z_cm;
 
         // update position controller target
         _pos_control.set_pos_target(target);
@@ -199,7 +207,7 @@ bool AC_Circle::update()
         Vector3f target;
         target.x = _center.x;
         target.y = _center.y;
-        target.z = _center.z + terr_offset;
+        target.z = target_z_cm;
 
         // update position controller target
         _pos_control.set_pos_target(target);


### PR DESCRIPTION
This PR fixes issue https://github.com/ArduPilot/ardupilot/issues/14134 by essentially reverting part of this PR https://github.com/ArduPilot/ardupilot/pull/14028.

With this fix applied AC_Circle library only updates the position controller's Z-axis target when it has been requested to do terrain following.  This means that the Circle flight mode can separately update the z-axis target to do terrain following using the sonar and the pilot's throttle input.

Below are screen shots of the desired and actual "sonar" alt before and after this change.  We can see in the before shot the vehicle was not doing terrain following (the target altitude was only using the regular baro based altitude) and afterwards it does do terrain following.

![circle-alt-fix-before-after](https://user-images.githubusercontent.com/1498098/79704780-02dbad80-82ee-11ea-8abe-b39b478df05d.png)

Thanks to Patrick Poirier for finding this issue
