### PR TITLE
SITL: adding GPS_TYPE_MAV

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -146,6 +146,7 @@ private:
     void _sbp_send_message(uint16_t msg_type, uint16_t sender_id, uint8_t len, uint8_t *payload, uint8_t instance);
     void _update_gps_sbp(const struct gps_data *d, uint8_t instance);
     void _update_gps_sbp2(const struct gps_data *d, uint8_t instance);
+    void _update_gps_MAV(const struct gps_data *d, uint8_t instance);
     void _update_gps_file(uint8_t instance);
     void _update_gps_nova(const struct gps_data *d, uint8_t instance);
     void _nova_send_message(uint8_t *header, uint8_t headerlength, uint8_t *payload, uint8_t payloadlen, uint8_t instance);

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -1141,6 +1141,11 @@ void SITL_State::_nova_send_message(uint8_t *header, uint8_t headerlength, uint8
     _gps_write((uint8_t*)&crc, 4, instance);
 }
 
+void SITL_State::_update_gps_MAV (const struct gps_data *d, uint8_t instance)
+{
+    return ;
+}
+
 #define CRC32_POLYNOMIAL 0xEDB88320L
 uint32_t SITL_State::CRC32Value(uint32_t icrc)
 {
@@ -1375,6 +1380,12 @@ void SITL_State::_update_gps_instance(SITL::SITL::GPSType gps_type, const struct
         case SITL::SITL::GPS_TYPE_FILE:
             _update_gps_file(instance);
             break;
+        
+        case SITL::SITL::GPS_TYPE_MAV:
+            _update_gps_MAV(data, instance);
+            break;
+
+        
     }
 }
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -106,7 +106,8 @@ public:
         GPS_TYPE_SBP   = 6,
         GPS_TYPE_FILE  = 7,
         GPS_TYPE_NOVA  = 8,
-        GPS_TYPE_SBP2   = 9,
+        GPS_TYPE_SBP2  = 9,
+        GPS_TYPE_MAV   = 14  // Match GPS_TYPE_MAV in AP_GPS
     };
 
     struct sitl_fdm state;


### PR DESCRIPTION
This PR I added GPS_TYPE_MAV to SITL.
Now you can test  **msg_gps_input** with simulator.
GPS_TYPE = 14 "MAV"
SIM_GPS_TYPE = 14