### PR TITLE
Generate internalError for invalid Rotation

### DIFF
--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -55,6 +55,7 @@ public:
         i2c_isr                     = (1U << 19),  // 0x80000  524288
         flow_of_control             = (1U << 20),  //0x100000  1048576 for generic we-should-never-get-here situations
         switch_full_sector_recursion= (1U << 21),  //0x200000  2097152
+        bad_rotation                = (1U << 22),  //0x400000  4194304
     };
 
     void error(const AP_InternalError::error_t error);

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -366,12 +366,16 @@ void Quaternion::from_rotation(enum Rotation rotation)
         q3 = 0.06104854f;
         return;
 
-    case ROTATION_MAX:
     case ROTATION_CUSTOM:
-        // no-op; custom rotations not supported
+        // Error; custom rotations not supported
         AP::internalerror().error(AP_InternalError::error_t::flow_of_control);
         return;
+
+    case ROTATION_MAX:
+        break;
     }
+    // rotation invalid
+    AP::internalerror().error(AP_InternalError::error_t::bad_rotation);
 }
 
 // rotate this quaternion by the given rotation

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -19,6 +19,7 @@
 #pragma GCC optimize("O2")
 
 #include "AP_Math.h"
+#include <AP_InternalError/AP_InternalError.h>
 
 // rotate a vector by a standard rotation, attempting
 // to use the minimum number of floating point operations
@@ -28,7 +29,6 @@ void Vector3<T>::rotate(enum Rotation rotation)
     T tmp;
     switch (rotation) {
     case ROTATION_NONE:
-    case ROTATION_MAX:
         return;
     case ROTATION_YAW_45: {
         tmp = HALF_SQRT_2*(float)(x - y);
@@ -251,9 +251,15 @@ void Vector3<T>::rotate(enum Rotation rotation)
         z = -sin_pitch * tmpx + cos_pitch * tmpz;
         return;
     }
-    case ROTATION_CUSTOM: // no-op; caller should perform custom rotations via matrix multiplication
+    case ROTATION_CUSTOM: 
+        // Error: caller must perform custom rotations via matrix multiplication
+        AP::internalerror().error(AP_InternalError::error_t::flow_of_control);
         return;
+    case ROTATION_MAX:
+        break;
     }
+    // rotation invalid
+    AP::internalerror().error(AP_InternalError::error_t::bad_rotation);
 }
 
 template <typename T>


### PR DESCRIPTION
Instead of no-op, report bad_rotation internalError for unsupported Rotation values.
SITL will now panic if AHRS_ORIENTATION=ROTATION_CUSTOM (or if the parameter is set to any value not in the Rotation enum)

https://github.com/ArduPilot/ardupilot/pull/13256 adds SITL support for ROTATION_CUSTOM 
