### PR TITLE
Pr add gnu backtrace

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -398,7 +398,7 @@ class sitl(Board):
         cfg.check_librt(env)
         cfg.check_feenableexcept()
 
-        env.LINKFLAGS += ['-pthread',]
+        env.LINKFLAGS += ['-pthread','-rdynamic']
 
         if cfg.env.DEBUG and 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
              env.LINKFLAGS += ['-fsanitize=address']

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <execinfo.h>
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/system.h>
@@ -34,6 +35,15 @@ void panic(const char *errormsg, ...)
     vprintf(errormsg, ap);
     va_end(ap);
     printf("\n");
+
+    void *array[10];
+    size_t size;
+
+    // get void*'s for all entries on the stack
+    size = backtrace(array, 10);
+
+    // print out all the frames to stdout
+    backtrace_symbols_fd(array, size, STDOUT_FILENO);
 
     dump_stack_trace();
 


### PR DESCRIPTION
Use the gnu library function "backtrace" to print a backtrace in AP_HAL::panic()