### PR TITLE
CI: Update Azure Pipelines to use Python3

### DIFF
--- a/.azure/autotest_template.yml
+++ b/.azure/autotest_template.yml
@@ -10,13 +10,13 @@ jobs:
   steps:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
-  - script: choco install gcc-g++ python2 python27 python27-devel python27-future python27-lxml python27-pip python27-pexpect python27-numpy git gettext libcrypt-devel --source cygwin
+  - script: choco install gcc-g++ python36 python36-devel python36-future python36-lxml python36-pip python36-pexpect python36-numpy git gettext libcrypt-devel --source cygwin
     displayName: 'Install Cygwin packages'
   - script: git submodule update --recursive --init modules/mavlink
     displayName: Initialize MAVLink submodule
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%')/modules/mavlink/pymavlink && python setup.py build install --user"
     displayName: 'Install pymavlink from submodule'
-  - script: C:\Cygwin\bin\bash --login -c "pip2 install MAVProxy"
+  - script: C:\Cygwin\bin\bash --login -c "pip install MAVProxy"
     displayName: 'Install MAVProxy in Cygwin'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && Tools/autotest/autotest.py ${{ format('build.{0} {1}.{2}', parameters.build_target, parameters.action, parameters.action_target) }}"
     displayName: ${{ format('Run {0} autotest', parameters.name) }}

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -8,8 +8,11 @@ jobs:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
 
-  - script: choco install cygwin32-gcc-g++ python2 python27 python27-future python27-lxml git gettext --source cygwin
+  - script: choco install cygwin32-gcc-g++ python36 python36-future python36-lxml git gettext --source cygwin
     displayName: 'Install Cygwin packages'
+
+  - script: C:\Cygwin\bin\bash --login -c "ln -s /usr/bin/python3.6 /usr/bin/python && ln -s /usr/bin/pip3.6 /usr/bin/pip"
+    displayName: 'Make Python 3.6 the default Python'
 
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') &&
                                            mkdir artifacts &&


### PR DESCRIPTION
Leading on from the Cygwin updates in https://github.com/ArduPilot/ardupilot/pull/14095, I've updated the Azure Pipelines Cygwin build to use Python3

Are we still using Appveyor? If so, I'll update that too.