### PR TITLE
autotest: Add method to get default params for model.

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1644,12 +1644,12 @@ class AutoTestPlane(AutoTest):
 
     def fly_soaring(self):
 
-        self.customise_SITL_commandline([],
-                                        model="plane-soaring",
-                                        defaults_filepath=os.path.join(testdir, "default_params/plane.parm"))
+        model="plane-soaring"
 
-        self.set_parameter("SOAR_ENABLE", 1)
-        self.repeatedly_apply_parameter_file(os.path.join(testdir, 'default_params/plane-soaring.parm'))
+        self.customise_SITL_commandline([],
+                                        model=model,
+                                        defaults_filepath=self.model_defaults_filepath("ArduPlane",model))
+
         self.load_mission('CMAC-soar.txt')
 
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5551,3 +5551,14 @@ switch value'''
         psd["F"] = freqmap
 
         return psd
+
+    def model_defaults_filepath(self, vehicle, model):
+
+        vinfo = vehicleinfo.VehicleInfo()
+        defaults_filepath = vinfo.options[vehicle]["frames"][model]["default_params_filename"]
+        if isinstance(defaults_filepath, str):
+            defaults_filepath = [defaults_filepath]
+        defaults_list = []
+        for d in defaults_filepath:
+            defaults_list.append(os.path.join(testdir, d))
+        return ','.join(defaults_list)

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -64,14 +64,7 @@ class AutoTestQuadPlane(AutoTest):
         pass
 
     def defaults_filepath(self):
-        vinfo = vehicleinfo.VehicleInfo()
-        defaults_filepath = vinfo.options["ArduPlane"]["frames"][self.frame]["default_params_filename"]
-        if isinstance(defaults_filepath, str):
-            defaults_filepath = [defaults_filepath]
-        defaults_list = []
-        for d in defaults_filepath:
-            defaults_list.append(os.path.join(testdir, d))
-        return ','.join(defaults_list)
+        return self.model_defaults_filepath("ArduPlane",self.frame)
 
     def is_plane(self):
         return True

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -4930,12 +4930,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def test_skid_steer(self):
         model = "rover-skid"
-        vinfo = vehicleinfo.VehicleInfo()
-        defaults_filepath = vinfo.options["Rover"]["frames"][model]["default_params_filename"]
-        defaults_filepath = [os.path.join(testdir, x) for x in defaults_filepath]
+
         self.customise_SITL_commandline([],
                                         model=model,
-                                        defaults_filepath=defaults_filepath)
+                                        defaults_filepath=self.model_defaults_filepath("Rover",model))
+
         self.change_mode("MANUAL")
         self.wait_ready_to_arm()
         self.arm_vehicle()


### PR DESCRIPTION
Replaces duplicate code in rover and quadplane tests, and simplifies soaring test.