### PR TITLE
Azure: fix build with uavcan support

### DIFF
--- a/.azure/autotest_template.yml
+++ b/.azure/autotest_template.yml
@@ -14,6 +14,8 @@ jobs:
     displayName: 'Install Cygwin packages'
   - script: git submodule update --recursive --init modules/mavlink
     displayName: Initialize MAVLink submodule
+  - script: git submodule update --recursive --init modules/uavcan
+    displayName: 'Initialize UAVCAN submodule'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%')/modules/mavlink/pymavlink && python setup.py build install --user"
     displayName: 'Install pymavlink from submodule'
   - script: C:\Cygwin\bin\bash --login -c "pip install MAVProxy"

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -8,8 +8,10 @@ jobs:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
 
-  - script: choco install cygwin32-gcc-g++ python36 python36-future python36-lxml git gettext --source cygwin
+  - script: choco install cygwin32-gcc-g++ python36 python36-future python36-lxml python36-pip python-setuptools git libexpat procps gettext --source cygwin
     displayName: 'Install Cygwin packages'
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && git submodule update --recursive --init --depth 2"
+    displayName: Initialize submodules
 
   - script: C:\Cygwin\bin\bash --login -c "ln -s /usr/bin/python3.6 /usr/bin/python && ln -s /usr/bin/pip3.6 /usr/bin/pip"
     displayName: 'Make Python 3.6 the default Python'


### PR DESCRIPTION
This adds modifications to Azure build server that allows for build with UAVCAN.

Results can be reviewed here: https://github.com/bugobliterator/ardupilot/runs/604668088
