### PR TITLE
Copter: Auto Loiter-Turns accepts pilot yaw input

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -94,6 +94,10 @@ void Mode::AutoYaw::set_mode(autopilot_yaw_mode yaw_mode)
         // initialise target yaw rate to zero
         _rate_cds = 0.0f;
         break;
+
+    case AUTO_YAW_CIRCLE:
+        // no initialisation required
+        break;
     }
 }
 
@@ -196,6 +200,13 @@ float Mode::AutoYaw::yaw()
     case AUTO_YAW_RESETTOARMEDYAW:
         // changes yaw to be same as when quad was armed
         return copter.initial_armed_bearing;
+
+    case AUTO_YAW_CIRCLE:
+        if (copter.circle_nav->is_active()) {
+            return copter.circle_nav->get_yaw();
+        }
+        // return the current attitude target
+        return wrap_360_cd(copter.attitude_control->get_att_target_euler_cd().z);
 
     case AUTO_YAW_LOOK_AT_NEXT_WP:
     default:

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -19,6 +19,7 @@ enum autopilot_yaw_mode {
     AUTO_YAW_LOOK_AHEAD =       4,  // point in the direction the copter is moving
     AUTO_YAW_RESETTOARMEDYAW =  5,  // point towards heading at time motors were armed
     AUTO_YAW_RATE =             6,  // turn at a specified rate (held in auto_yaw_rate)
+    AUTO_YAW_CIRCLE =           7,  // use AC_Circle's provided yaw (used during Loiter-Turns commands)
 };
 
 // Frame types

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -476,6 +476,3 @@ public:
     float control_monitor_rms_output_pitch(void) const;
     float control_monitor_rms_output_yaw(void) const;
 };
-
-#define AC_ATTITUDE_CONTROL_LOG_FORMAT(msg) { msg, sizeof(AC_AttitudeControl::log_Attitude),	\
-                            "ATT", "cccccCC",      "RollIn,Roll,PitchIn,Pitch,YawIn,Yaw,NavYaw" }

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -150,6 +150,13 @@ void AC_Circle::set_radius(float radius_cm)
     calc_velocities(false);
 }
 
+/// returns true if update has been run recently
+/// used by vehicle code to determine if get_yaw() is valid
+bool AC_Circle::is_active() const
+{
+    return (AP_HAL::millis() - _last_update_ms < 200);
+}
+
 /// update - update circle controller
 bool AC_Circle::update()
 {
@@ -218,6 +225,9 @@ bool AC_Circle::update()
 
     // update position controller
     _pos_control.update_xy_controller();
+
+    // set update time
+    _last_update_ms = AP_HAL::millis();
 
     return true;
 }

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -68,6 +68,10 @@ public:
     float get_pitch() const { return _pos_control.get_pitch(); }
     float get_yaw() const { return _yaw; }
 
+    /// returns true if update has been run recently
+    /// used by vehicle code to determine if get_yaw() is valid
+    bool is_active() const;
+
     // get_closest_point_on_circle - returns closest point on the circle
     //  circle's center should already have been set
     //  closest point on the circle will be placed in result
@@ -136,6 +140,7 @@ private:
     float       _angular_vel;   // angular velocity in radians/sec
     float       _angular_vel_max;   // maximum velocity in radians/sec
     float       _angular_accel; // angular acceleration in radians/sec/sec
+    uint32_t    _last_update_ms;    // system time of last update
 
     // terrain following variables
     bool        _terrain_alt;           // true if _center.z is alt-above-terrain, false if alt-above-ekf-origin


### PR DESCRIPTION
This change allows pilots to control the yaw of the vehicle during LOITER_TURNS commands which is possible in every other auto command.

It also resolves a bug in how the vehicle's heading was pointing while the vehicle was moving out to the edge of the circle.  The vehicle's heading was meant to be held still during this move, as mentioned in this comment, "// vehicle is within circle so hold yaw to avoid spinning as we move to edge of circle" but it was not because AUTO_YAW_HOLD was being incorrectly used to mean point-the-vehicle-towards-center-of-circle.

This has been tested in SITL

P.S. I've also removed an unused macro that I happened to notice while writing this PR