### PR TITLE
SR4 params

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -243,6 +243,10 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Path: GCS_Mavlink.cpp
     GOBJECTN(_gcs.chan_parameters[3],  gcs3,       "SR3_",     GCS_MAVLINK_Parameters),
 
+    // @Group: SR4_
+    // @Path: GCS_Mavlink.cpp
+    GOBJECTN(_gcs.chan_parameters[4],  gcs4,       "SR4_",     GCS_MAVLINK_Parameters),
+
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: 4 byte bitmap of log types to enable

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -88,6 +88,7 @@ public:
         k_param_notify,
         k_param_BoardConfig_CAN,
         k_param_battery,
+        k_param_gcs4,
 
         //
         // 150: Telemetry control

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -544,6 +544,10 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: GCS_Mavlink.cpp
     GOBJECTN(_gcs.chan_parameters[3],  gcs3,       "SR3_",     GCS_MAVLINK_Parameters),
 
+    // @Group: SR4_
+    // @Path: GCS_Mavlink.cpp
+    GOBJECTN(_gcs.chan_parameters[4],  gcs4,       "SR4_",     GCS_MAVLINK_Parameters),
+
     // @Group: AHRS_
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp
     GOBJECT(ahrs,                   "AHRS_",    AP_AHRS),

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -218,6 +218,7 @@ public:
         k_param_takeoff_trigger_dz_old,
         k_param_gcs3,
         k_param_gcs_pid_mask,    // 126
+        k_param_gcs4,
 
         //
         // 135 : reserved for Solo until features merged with master

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -979,6 +979,10 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: GCS_Mavlink.cpp
     GOBJECTN(_gcs.chan_parameters[3],  gcs3,       "SR3_",     GCS_MAVLINK_Parameters),
 
+    // @Group: SR4_
+    // @Path: GCS_Mavlink.cpp
+    GOBJECTN(_gcs.chan_parameters[4],  gcs4,       "SR4_",     GCS_MAVLINK_Parameters),
+
     // @Group: INS_
     // @Path: ../libraries/AP_InertialSensor/AP_InertialSensor.cpp
     GOBJECT(ins,                    "INS_", AP_InertialSensor),

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -341,6 +341,7 @@ public:
 
         k_param_mixing_offset,
         k_param_dspoiler_rud_rate,
+        k_param_gcs4,
 
         k_param_logger = 253, // Logging Group
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -464,6 +464,10 @@ const AP_Param::Info Sub::var_info[] = {
     // @Path: GCS_Mavlink.cpp
     GOBJECTN(_gcs.chan_parameters[3],  gcs3,       "SR3_",     GCS_MAVLINK_Parameters),
 
+    // @Group: SR4_
+    // @Path: GCS_Mavlink.cpp
+    GOBJECTN(_gcs.chan_parameters[4],  gcs4,       "SR4_",     GCS_MAVLINK_Parameters),
+
     // @Group: AHRS_
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp
     GOBJECT(ahrs,                   "AHRS_",    AP_AHRS),

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -58,6 +58,7 @@ public:
         k_param_gcs3,
         k_param_sysid_this_mav,
         k_param_sysid_my_gcs,
+        k_param_gcs4,
 
         // Hardware/Software configuration
         k_param_BoardConfig = 20, // Board configuration (Pixhawk/Linux/etc)

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -266,6 +266,10 @@ const AP_Param::Info Rover::var_info[] = {
     // @Path: GCS_Mavlink.cpp
     GOBJECTN(_gcs.chan_parameters[3],  gcs3,       "SR3_",     GCS_MAVLINK_Parameters),
 
+    // @Group: SR4_
+    // @Path: GCS_Mavlink.cpp
+    GOBJECTN(_gcs.chan_parameters[4],  gcs4,       "SR4_",     GCS_MAVLINK_Parameters),
+
     // @Group: SERIAL
     // @Path: ../libraries/AP_SerialManager/AP_SerialManager.cpp
     GOBJECT(serial_manager,         "SERIAL",   AP_SerialManager),

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -81,6 +81,7 @@ public:
         k_param_cli_enabled_old,    // unused
         k_param_gcs3,
         k_param_gcs_pid_mask,
+        k_param_gcs4,
 
         //
         // 130: Sensor parameters


### PR DESCRIPTION
This PR adds the stream rate parameters for the fifth MAVLink serial communication (SR4_* parameters), as discussed here: https://github.com/ArduPilot/ardupilot/issues/7036#issuecomment-599049094.

I tested this in SITL (launched with `-A "--uartC=udpclient:127.0.0.1:14552 --uartD=udpclient:127.0.0.1:14553 --uartF=udpclient:127.0.0.1:14554 --uartG=udpclient:127.0.0.1:14556"`) for Plane, Copter and Rover and checked that the stream rate of ATTITUDE messages changes in my GCS when I modify SR4_EXTRA1. I don't have access to a vehicle I can test on.