### PR TITLE
AP_AHRS/Sub: set_alt_measurement_noise replaces direct calls to EKF2/EKF3

### DIFF
--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -45,8 +45,6 @@
 #include <AP_Compass/AP_Compass.h>         // ArduPilot Mega Magnetometer Library
 #include <AP_InertialSensor/AP_InertialSensor.h>  // ArduPilot Mega Inertial Sensor (accel & gyro) Library
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_NavEKF2/AP_NavEKF2.h>
-#include <AP_NavEKF3/AP_NavEKF3.h>
 #include <AP_Mission/AP_Mission.h>         // Mission command library
 #include <AC_AttitudeControl/AC_AttitudeControl_Sub.h> // Attitude control library
 #include <AC_AttitudeControl/AC_PosControl_Sub.h>      // Position control library

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -132,19 +132,9 @@ void Sub::init_ardupilot()
         // We only have onboard baro
         // No external underwater depth sensor detected
         barometer.set_primary_baro(0);
-#if HAL_NAVEKF2_AVAILABLE
-        ahrs.EKF2.set_baro_alt_noise(10.0f); // Readings won't correspond with rest of INS
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-        ahrs.EKF3.set_baro_alt_noise(10.0f);
-#endif
+        ahrs.set_alt_measurement_noise(10.0f);  // Readings won't correspond with rest of INS
     } else {
-#if HAL_NAVEKF2_AVAILABLE
-        ahrs.EKF2.set_baro_alt_noise(0.1f);
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-        ahrs.EKF3.set_baro_alt_noise(0.1f);
-#endif
+        ahrs.set_alt_measurement_noise(0.1f);
     }
 
     leak_detector.init();

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -561,7 +561,10 @@ public:
 
     // return current vibration vector for primary IMU
     Vector3f get_vibration(void) const;
-    
+
+    // set and save the alt noise parameter value
+    virtual void set_alt_measurement_noise(float noise) {};
+
     // allow threads to lock against AHRS update
     HAL_Semaphore &get_semaphore(void) {
         return _rsem;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -2285,5 +2285,16 @@ bool AP_AHRS_NavEKF::is_ext_nav_used_for_yaw(void) const
     return false;
 }
 
+// set and save the alt noise parameter value
+void AP_AHRS_NavEKF::set_alt_measurement_noise(float noise)
+{
+#if HAL_NAVEKF2_AVAILABLE
+    EKF2.set_baro_alt_noise(noise);
+#endif
+#if HAL_NAVEKF3_AVAILABLE
+    EKF3.set_baro_alt_noise(noise);
+#endif
+}
+
 #endif // AP_AHRS_NAVEKF_AVAILABLE
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -298,6 +298,9 @@ public:
     // check whether external navigation is providing yaw.  Allows compass pre-arm checks to be bypassed
     bool is_ext_nav_used_for_yaw(void) const override;
 
+    // set and save the ALT_M_NSE parameter value
+    void set_alt_measurement_noise(float noise) override;
+
     // these are only out here so vehicles can reference them for parameters
 #if HAL_NAVEKF2_AVAILABLE
     NavEKF2 EKF2;


### PR DESCRIPTION
This non-functional change replaces Sub's calls to EKF2/3's set_baro_alt_noise methods with calls to AP_AHRS::set_alt_measurement_noise.  This PR also removes Sub's include of the EKF2 and EKF3 libraries which are no longer required.

This small issue came to light as part of a [review of any dependencies we have on the EKF2](https://github.com/ArduPilot/ardupilot/issues/14148) as we move towards making EKF3 our default EKF.

This has been tested in SITL by enabling EKF2 and EKF3 and ensuring that the EK2/3_ALT_M_NSE parameters were updated.