### PR TITLE
AP_Compass: Skip rotating the mag data when the board orientation is none

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -15,7 +15,9 @@ AP_Compass_Backend::AP_Compass_Backend()
 void AP_Compass_Backend::rotate_field(Vector3f &mag, uint8_t instance)
 {
     Compass::mag_state &state = _compass._state[Compass::StateIndex(instance)];
-    mag.rotate(MAG_BOARD_ORIENTATION);
+    if (MAG_BOARD_ORIENTATION != ROTATION_NONE) {
+        mag.rotate(MAG_BOARD_ORIENTATION);
+    }
     mag.rotate(state.rotation);
 
     if (!state.external) {


### PR DESCRIPTION
The general case is that `MAG_BOARD_ORIENTATION` is `ROTATION_NONE` which means we aren't benefiting by calling rotate. On CubeBlack (and similiar boards) this shrinks the build by 8 bytes (and more significantly saves us from actually stepping into the function/switch), on CrazyFlie2 (which does actually define an orientation) it doesn't change the build product.