### PR TITLE
AP_Proximity: AirSimSITL: fix left right swap

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -41,7 +41,7 @@ void AP_Proximity_AirSimSITL::update(void)
         if (point.is_zero()) {
             continue;
         }
-        const float angle_deg = wrap_360(degrees(atan2f(-point.y, point.x)));
+        const float angle_deg = wrap_360(degrees(atan2f(point.y, point.x)));
         const uint8_t sector = convert_angle_to_sector(angle_deg);
 
         const Vector2f v = Vector2f(point.x, point.y);


### PR DESCRIPTION
This fixes a left and right swap of lidar data I was seeing in AirSim @rajat2004 

https://discuss.ardupilot.org/t/gsoc-2019-airsim-simulator-support-for-ardupilot-sitl-part-ii/46395/12?u=iampete

