### PR TITLE
AP_Logger: fix examples

### DIFF
--- a/libraries/AP_Logger/examples/AP_Logger_AllTypes/AP_Logger_AllTypes.cpp
+++ b/libraries/AP_Logger/examples/AP_Logger_AllTypes/AP_Logger_AllTypes.cpp
@@ -4,6 +4,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Scheduler/AP_Scheduler.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <stdio.h>
 
@@ -106,6 +107,7 @@ private:
 
     AP_Int32 log_bitmask;
     AP_Logger logger{log_bitmask};
+    AP_Scheduler scheduler;
 
     void Log_Write_TypeMessages();
     void Log_Write_TypeMessages_Log_Write();

--- a/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
+++ b/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <stdio.h>
@@ -41,6 +42,7 @@ private:
 
     AP_Int32 log_bitmask;
     AP_Logger logger{log_bitmask};
+    AP_Scheduler scheduler;
 
 };
 


### PR DESCRIPTION
Having a valid AP_Scheduler is now a requirement