### PR TITLE
AP_Arming: make RC check message clearer

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -592,11 +592,11 @@ bool AP_Arming::rc_calibration_checks(bool report)
         }
         const uint16_t trim = c->get_radio_trim();
         if (c->get_radio_min() > trim) {
-            check_failed(ARMING_CHECK_RC, report, "RC%d minimum is greater than trim", i + 1);
+            check_failed(ARMING_CHECK_RC, report, "RC%d_MIN is greater than RC%d_TRIM", i + 1, i + 1);
             check_passed = false;
         }
         if (c->get_radio_max() < trim) {
-            check_failed(ARMING_CHECK_RC, report, "RC%d maximum is less than trim", i + 1);
+            check_failed(ARMING_CHECK_RC, report, "RC%d_MAX is less than RC%d_TRIM", i + 1, i + 1);
             check_passed = false;
         }
     }
@@ -708,11 +708,11 @@ bool AP_Arming::servo_checks(bool report) const
 
         const uint16_t trim = c->get_trim();
         if (c->get_output_min() > trim) {
-            check_failed(report, "SERVO%d minimum is greater than trim", i + 1);
+            check_failed(report, "SERVO%d_MIN is greater than SERVO%d_TRIM", i + 1, i + 1);
             check_passed = false;
         }
         if (c->get_output_max() < trim) {
-            check_failed(report, "SERVO%d maximum is less than trim", i + 1);
+            check_failed(report, "SERVO%d_MAX is less than SERVO%d_TRIM", i + 1, i + 1);
             check_passed = false;
         }
     }


### PR DESCRIPTION
Some users don't aware that RCx maximum is RCx_MAX parameter.
Including the parameter name in the error message helps users.

https://discuss.ardupilot.org/t/problem-with-prearm-rc12-13-14-15-16-minimum-is-greater-than-trim/37707
https://discuss.ardupilot.org/t/prearm-trim-error/37311

I also saw two questions this month (April) in a Facebook group.