### PR TITLE
Remove units from yaw estimator weights

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -291,11 +291,11 @@ void NavEKF2::Log_Write_GSF(uint8_t _core, uint64_t time_us) const
         // @Field: Y2: Yaw estimate from individual EKF filter 2 (rad)
         // @Field: Y3: Yaw estimate from individual EKF filter 3 (rad)
         // @Field: Y4: Yaw estimate from individual EKF filter 4 (rad)
-        // @Field: W0: Weighting applied to yaw estimate from individual EKF filter 0 (rad)
-        // @Field: W1: Weighting applied to yaw estimate from individual EKF filter 1 (rad)
-        // @Field: W2: Weighting applied to yaw estimate from individual EKF filter 2 (rad)
-        // @Field: W3: Weighting applied to yaw estimate from individual EKF filter 3 (rad)
-        // @Field: W4: Weighting applied to yaw estimate from individual EKF filter 4 (rad)
+        // @Field: W0: Weighting applied to yaw estimate from individual EKF filter 0
+        // @Field: W1: Weighting applied to yaw estimate from individual EKF filter 1
+        // @Field: W2: Weighting applied to yaw estimate from individual EKF filter 2
+        // @Field: W3: Weighting applied to yaw estimate from individual EKF filter 3
+        // @Field: W4: Weighting applied to yaw estimate from individual EKF filter 4
 
     if (getDataEKFGSF(_core, yaw_composite, yaw_composite_variance, yaw, ivn, ive, wgt)) {
         AP::logger().Write("NKY0",

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -353,7 +353,7 @@ void NavEKF3::Log_Write_GSF(uint8_t _core, uint64_t time_us) const
     if (getDataEKFGSF(_core, yaw_composite, yaw_composite_variance, yaw, ivn, ive, wgt)) {
 
         // @LoggerMessage: XKY0
-        // @Description: EKF2 Yaw Estimator States
+        // @Description: EKF3 Yaw Estimator States
         // @Field: TimeUS: Time since system startup
         // @Field: C: EKF3 core this data is for
         // @Field: YC: GSF yaw estimate (rad)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -363,11 +363,11 @@ void NavEKF3::Log_Write_GSF(uint8_t _core, uint64_t time_us) const
         // @Field: Y2: Yaw estimate from individual EKF filter 2 (rad)
         // @Field: Y3: Yaw estimate from individual EKF filter 3 (rad)
         // @Field: Y4: Yaw estimate from individual EKF filter 4 (rad)
-        // @Field: W0: Weighting applied to yaw estimate from individual EKF filter 0 (rad)
-        // @Field: W1: Weighting applied to yaw estimate from individual EKF filter 1 (rad)
-        // @Field: W2: Weighting applied to yaw estimate from individual EKF filter 2 (rad)
-        // @Field: W3: Weighting applied to yaw estimate from individual EKF filter 3 (rad)
-        // @Field: W4: Weighting applied to yaw estimate from individual EKF filter 4 (rad)
+        // @Field: W0: Weighting applied to yaw estimate from individual EKF filter 0
+        // @Field: W1: Weighting applied to yaw estimate from individual EKF filter 1
+        // @Field: W2: Weighting applied to yaw estimate from individual EKF filter 2
+        // @Field: W3: Weighting applied to yaw estimate from individual EKF filter 3
+        // @Field: W4: Weighting applied to yaw estimate from individual EKF filter 4
 
         AP::logger().Write("XKY0",
                         "TimeUS,C,YC,YCS,Y0,Y1,Y2,Y3,Y4,W0,W1,W2,W3,W4",


### PR DESCRIPTION
tridge said these simply sum to one and are unitless.
