### PR TITLE
fixed build warnings and add --Werror configure option

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -122,6 +122,7 @@ class Board:
             '-Werror=parentheses',
             '-Werror=format-extra-args',
             '-Werror=ignored-qualifiers',
+            '-DARDUPILOT_BUILD',
         ]
 
         if cfg.options.scripting_checks:
@@ -205,6 +206,7 @@ class Board:
             '-Wfatal-errors',
             '-Wno-trigraphs',
             '-Werror=parentheses',
+            '-DARDUPILOT_BUILD',
         ]
 
         if 'clang++' in cfg.env.COMPILER_CXX:
@@ -248,6 +250,15 @@ class Board:
                 env.CXXFLAGS += [
                     '-Werror=implicit-fallthrough',
                 ]
+
+        if cfg.options.Werror:
+            errors = ['-Werror',
+                      '-Werror=missing-declarations',
+                      '-Werror=float-equal',
+                      '-Werror=undef',
+                    ]
+            env.CFLAGS += errors
+            env.CXXFLAGS += errors
 
         if cfg.env.DEBUG:
             env.CXXFLAGS += [
@@ -481,11 +492,6 @@ class chibios(Board):
             '-Wframe-larger-than=1300',
             '-fsingle-precision-constant',
             '-Wno-attributes',
-            '-Wno-error=double-promotion',
-            '-Wno-error=missing-declarations',
-            '-Wno-error=float-equal',
-            '-Wno-error=undef',
-            '-Wno-error=cpp',
             '-fno-exceptions',
             '-Wall',
             '-Wextra',
@@ -521,6 +527,15 @@ class chibios(Board):
             '-D__USE_CMSIS',
             '-Werror=deprecated-declarations'
         ]
+        if not cfg.options.Werror:
+            env.CFLAGS += [
+            '-Wno-error=double-promotion',
+            '-Wno-error=missing-declarations',
+            '-Wno-error=float-equal',
+            '-Wno-error=undef',
+            '-Wno-error=cpp',
+            ]
+
         env.CXXFLAGS += env.CFLAGS + [
             '-fno-rtti',
             '-fno-threadsafe-statics',

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -152,6 +152,7 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
     return v == value;
 }
 
+#if defined(HAL_VALIDATE_BOARD)
 static bool check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
     if (!dev) {
@@ -210,6 +211,7 @@ static bool check_ms5611(const char* devname) {
 
     return true;
 }
+#endif // HAL_VALIDATE_BOARD
 
 #define MPUREG_WHOAMI 0x75
 #define MPU_WHOAMI_MPU60X0  0x68

--- a/libraries/AP_Filesystem/posix_compat.h
+++ b/libraries/AP_Filesystem/posix_compat.h
@@ -49,6 +49,8 @@ int apfs_feof(APFS_FILE *stream);
 long apfs_ftell(APFS_FILE *stream);
 APFS_FILE *apfs_freopen(const char *pathname, const char *mode, APFS_FILE *stream);
 int apfs_remove(const char *pathname);
+int apfs_rename(const char *oldpath, const char *newpath);
+char *tmpnam(char *s);
 
 #undef stdin
 #undef stdout
@@ -87,6 +89,7 @@ int apfs_remove(const char *pathname);
 #define ftell(stream) apfs_ftell(stream)
 #define freopen(pathname, mode, stream) apfs_freopen(pathname, mode, stream)
 #define remove(pathname) apfs_remove(pathname)
+#define rename(oldpath, newpath) apfs_rename(oldpath, newpath)
 #if !defined(__APPLE__)
 int sprintf(char *str, const char *format, ...);
 #endif

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -769,7 +769,10 @@ public:
     /// value separately, as otherwise the value in EEPROM won't be
     /// updated correctly.
     void set_and_save_ifchanged(const T &v) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
         if (v == _value) {
+#pragma GCC diagnostic pop
             return;
         }
         set(v);

--- a/libraries/AP_Scripting/lua/src/lauxlib.c
+++ b/libraries/AP_Scripting/lua/src/lauxlib.c
@@ -26,6 +26,9 @@
 
 #include "lauxlib.h"
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
 
 /*
 ** {======================================================

--- a/libraries/AP_Scripting/lua/src/lbaselib.c
+++ b/libraries/AP_Scripting/lua/src/lbaselib.c
@@ -20,6 +20,9 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 
 static int luaB_print (lua_State *L) {
   int n = lua_gettop(L);  /* number of arguments */

--- a/libraries/AP_Scripting/lua/src/lcode.c
+++ b/libraries/AP_Scripting/lua/src/lcode.c
@@ -7,6 +7,10 @@
 #define lcode_c
 #define LUA_CORE
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 #include "lprefix.h"
 
 

--- a/libraries/AP_Scripting/lua/src/liolib.c
+++ b/libraries/AP_Scripting/lua/src/liolib.c
@@ -22,7 +22,9 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
-
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 
 
 /*

--- a/libraries/AP_Scripting/lua/src/lmathlib.c
+++ b/libraries/AP_Scripting/lua/src/lmathlib.c
@@ -18,6 +18,10 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 
 #undef PI
 #define PI	(l_mathop(3.141592653589793238462643383279502884))

--- a/libraries/AP_Scripting/lua/src/lstrlib.c
+++ b/libraries/AP_Scripting/lua/src/lstrlib.c
@@ -24,6 +24,10 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
 
 /*
 ** maximum number of captures that a pattern can do during

--- a/libraries/AP_Scripting/lua/src/ltable.c
+++ b/libraries/AP_Scripting/lua/src/ltable.c
@@ -7,6 +7,10 @@
 #define ltable_c
 #define LUA_CORE
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 #include "lprefix.h"
 
 

--- a/libraries/AP_Scripting/lua/src/lundump.c
+++ b/libraries/AP_Scripting/lua/src/lundump.c
@@ -4,6 +4,10 @@
 ** See Copyright Notice in lua.h
 */
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 #define lundump_c
 #define LUA_CORE
 

--- a/libraries/AP_Scripting/lua/src/lvm.c
+++ b/libraries/AP_Scripting/lua/src/lvm.c
@@ -7,6 +7,10 @@
 #define lvm_c
 #define LUA_CORE
 
+#if defined(ARDUPILOT_BUILD)
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 #include "lprefix.h"
 
 #include <float.h>
@@ -1319,4 +1323,5 @@ void luaV_execute (lua_State *L) {
 }
 
 /* }================================================================== */
+
 

--- a/wscript
+++ b/wscript
@@ -76,6 +76,11 @@ def options(opt):
         default=False,
         help='Configure as debug variant.')
 
+    g.add_option('--Werror',
+        action='store_true',
+        default=False,
+        help='build with -Werror.')
+    
     g.add_option('--toolchain',
         action='store',
         default=None,


### PR DESCRIPTION
This allows us to configure with a --Werror option to more easily catch build warnings.
It fixes existing build warnings for STM32 boards in several subsystems