### PR TITLE
AP_NavEKF2/3: fix getLLH provided location when no GPS fix

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -349,6 +349,8 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
             } else {
                 // if no GPS fix, provide last known position before entering the mode
                 // correct for IMU offset (EKF calculations are at the IMU position)
+                loc.lat = EKF_origin.lat;
+                loc.lng = EKF_origin.lng;
                 loc.offset((lastKnownPositionNE.x + posOffsetNED.x), (lastKnownPositionNE.y + posOffsetNED.y));
                 return false;
             }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -345,6 +345,8 @@ bool NavEKF3_core::getLLH(struct Location &loc) const
                 return true;
             } else {
                 // if no GPS fix, provide last known position before entering the mode
+                loc.lat = EKF_origin.lat;
+                loc.lng = EKF_origin.lng;
                 loc.offset(lastKnownPositionNE.x, lastKnownPositionNE.y);
                 return false;
             }


### PR DESCRIPTION
This fixes a bug in EKF2 and EKF3's getLLH function when there is no GPS (or the GPS has no fix).  This was uncovered during testing of external navigation.

Below is a screen shot of before/after tests of Copter using a simulated VICON system which was failed.  The output is some debug output to show what the getLLH functions were returning.

![image](https://user-images.githubusercontent.com/1498098/80195758-4bc99400-8657-11ea-9369-aae4601735a4.png)

The reason this was never noticed is because AP_AHRS_NavEKF falls back to DCM if the EKF::getLLH() method returns zero ([see code here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp#L492)).