### PR TITLE
AP_AHRS: get_position obeys always_use_EKF

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -489,7 +489,12 @@ bool AP_AHRS_NavEKF::get_position(struct Location &loc) const
     }
 #endif
     }
-    return AP_AHRS_DCM::get_position(loc);
+
+    // fall back to position from DCM
+    if (!always_use_EKF()) {
+        return AP_AHRS_DCM::get_position(loc);
+    }
+    return false;
 }
 
 // status reporting of estimated errors
@@ -2286,4 +2291,3 @@ bool AP_AHRS_NavEKF::is_ext_nav_used_for_yaw(void) const
 }
 
 #endif // AP_AHRS_NAVEKF_AVAILABLE
-


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/14181 by ensuring that AP_AHRS_NavEKF::get_position() method will obey the "always_use_EKF" flag and return the response from EKF2 or EKF3.

I believe this is a good change because:

1. If external navigation fails, the EKF is no longer able to return a position estimate good enough for navigation (so the getLLH returns false) but it can provide the last known location.  DCM on the otherhand just returns false with no lat/lon.  This means that in Copter, when external navigation fails, the vehicle disappears from the map.  This is inconsistent with what happens when GPS is lost (the vehicle remains on the map in its last known location).
2. this (probably) restores the behaviour to what it was before PR https://github.com/ArduPilot/ardupilot/pull/11681 went in in July 2019

This is a relatively small change but with a potentially large impact for Copter because DCM's position won't be used during startup and some failures.

Note1:  [Copter's read_inertia() method](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/inertia.cpp#L10) is odd in that it uses the Location even if get_position() returns false.  This could also potentially be changed although that could lead to current_loc being inconsistent with ahrs.get_position().

Note2: PR https://github.com/ArduPilot/ardupilot/pull/14183 which fixes EKF's getLLH() should go in before this PR is merged.
