### PR TITLE
AC_Avoid: active proximity avoidance

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -142,8 +142,12 @@ private:
     // convert distance (in meters) to a lean percentage (in 0~1 range) for use in manual flight modes
     float distance_to_lean_pct(float dist_m);
 
-    // returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
-    void get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
+    // returns the roll and pitch angle limits as a percentage (in -1 ~ +1 range) based on the proximity sensor
+    Vector2f get_proximity_roll_pitch_pct();
+
+    // Update min and max vectors from a given value
+    void Vector2f_min_max(Vector2f &min, Vector2f &max, const Vector2f &value);
+
 
     // parameters
     AP_Int8 _enabled;


### PR DESCRIPTION
This adds active proximity avoidance so we can 'run away' from obstacles. 

I spent quite a long time messing with various methods to do this directly in the position controller, but I ended up back using velocity. If over the proximity margin Avoid requests the velocity that would result in stopping at the margin, the idea being that this should be quite 'soft'. However in AirSim it can be quite aggressive, I think this is mostly due to AirSim.

This also removers the pilot commanded acceleration while avoiding. Previously if you were hard against a limit with full stick when you released the stick you would spring off the limit due to acceleration feed forward. Now nothing happens, I think this is more of a pilot feel improvement than anything else. I did also play with requesting acceleration without much luck.

This has only been tested in AirSim so far, I am quite limited in the real life testing I can do at the moment so it would be great to get some feedback.

There are also issues due to the proximity sensors seeing the ground when low, and when stopping and coming back level the distance changes, the solution is to correct the proximity sensors  for roll and pitch.