### PR TITLE
Copter: Allow CH6 tuning to change loiter speed

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -323,7 +323,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Channel 6 Tuning
     // @Description: Controls which parameters (normally PID gains) are being tuned with transmitter's channel 6 knob
     // @User: Standard
-    // @Values: 0:None,1:Stab Roll/Pitch kP,4:Rate Roll/Pitch kP,5:Rate Roll/Pitch kI,21:Rate Roll/Pitch kD,3:Stab Yaw kP,6:Rate Yaw kP,26:Rate Yaw kD,56:Rate Yaw Filter,55:Motor Yaw Headroom,14:AltHold kP,7:Throttle Rate kP,34:Throttle Accel kP,35:Throttle Accel kI,36:Throttle Accel kD,12:Loiter Pos kP,22:Velocity XY kP,28:Velocity XY kI,10:WP Speed,25:Acro Roll/Pitch deg/s,40:Acro Yaw deg/s,45:RC Feel,13:Heli Ext Gyro,38:Declination,39:Circle Rate,46:Rate Pitch kP,47:Rate Pitch kI,48:Rate Pitch kD,49:Rate Roll kP,50:Rate Roll kI,51:Rate Roll kD,52:Rate Pitch FF,53:Rate Roll FF,54:Rate Yaw FF,58:SysID Magnitude,59:PSC Angle Max
+    // @Values: 0:None,1:Stab Roll/Pitch kP,4:Rate Roll/Pitch kP,5:Rate Roll/Pitch kI,21:Rate Roll/Pitch kD,3:Stab Yaw kP,6:Rate Yaw kP,26:Rate Yaw kD,56:Rate Yaw Filter,55:Motor Yaw Headroom,14:AltHold kP,7:Throttle Rate kP,34:Throttle Accel kP,35:Throttle Accel kI,36:Throttle Accel kD,12:Loiter Pos kP,22:Velocity XY kP,28:Velocity XY kI,10:WP Speed,25:Acro Roll/Pitch deg/s,40:Acro Yaw deg/s,45:RC Feel,13:Heli Ext Gyro,38:Declination,39:Circle Rate,46:Rate Pitch kP,47:Rate Pitch kI,48:Rate Pitch kD,49:Rate Roll kP,50:Rate Roll kI,51:Rate Roll kD,52:Rate Pitch FF,53:Rate Roll FF,54:Rate Yaw FF,58:SysID Magnitude,59:PSC Angle Max,60:Loiter Speed
     GSCALAR(radio_tuning, "TUNE",                   0),
 
     // @Param: FRAME_TYPE

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -51,7 +51,8 @@ enum tuning_func {
     TUNING_RATE_YAW_FILT =              56, // yaw rate input filter
     UNUSED =                            57, // was winch control
     TUNING_SYSTEM_ID_MAGNITUDE =        58, // magnitude of the system ID signal
-    TUNING_POS_CONTROL_ANGLE_MAX =      59  // position controller maximum angle
+    TUNING_POS_CONTROL_ANGLE_MAX =      59, // position controller maximum angle
+    TUNING_LOITER_MAX_XY_SPEED =        60, // maximum loiter horizontal speed
 };
 
 // Yaw behaviours during missions - possible values for WP_YAW_BEHAVIOR parameter

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -196,5 +196,9 @@ void Copter::tuning()
     case TUNING_POS_CONTROL_ANGLE_MAX:
         pos_control->set_lean_angle_max_cd(tuning_value * 100.0);
         break;
+
+    case TUNING_LOITER_MAX_XY_SPEED:
+        loiter_nav->set_max_xy_speed(tuning_value);
+        break;
     }
 }

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11802,6 +11802,36 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+    def Ch6TuningLoitMaxXYSpeed(self):
+        '''test loiter can be changed via Ch6 tuning knob'''
+        self.set_parameters({
+            "RC6_OPTION": 219,  # RC6 used for tuning
+            "TUNE": 60,  # 60 is x/y loiter speed
+            "TUNE_MIN": 0.02,  # 20cm/s
+            "TUNE_MAX": 1000,  # 10m/s
+            "AUTO_OPTIONS": 3,
+        })
+        self.set_rc(6, 2000)
+
+        self.takeoff(mode='LOITER')
+
+        self.set_rc(2, 1000)
+
+        self.wait_groundspeed(9.5, 10.5, minimum_duration=5)
+
+        self.set_rc(6, 1500)
+        self.wait_groundspeed(4.5, 5.5, minimum_duration=5)
+
+        self.set_rc(6, 2000)
+        self.wait_groundspeed(9.5, 10.5, minimum_duration=5)
+
+        self.set_rc(6, 1300)
+        self.wait_groundspeed(2.5, 3.5, minimum_duration=5)
+
+        self.set_rc(2, 1500)
+
+        self.do_RTL()
+
     def PILOT_THR_BHV(self):
         '''test the PILOT_THR_BHV parameter'''
         self.start_subtest("Test default behaviour, no disarm on land")
@@ -12771,6 +12801,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.ScriptingFlipMode,
             self.CompassLearnCopyFromEKF,
             self.AHRSAutoTrim,
+            self.Ch6TuningLoitMaxXYSpeed,
         ])
         return ret
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -192,6 +192,12 @@ void AC_Loiter::update(bool avoidance_on)
     _pos_control.update_xy_controller();
 }
 
+//set maximum horizontal speed
+void AC_Loiter::set_max_xy_speed(float max_xy_speed)
+{
+    _speed_cms.set(MAX(max_xy_speed, LOITER_SPEED_MIN));
+}
+
 // sanity check parameters
 void AC_Loiter::sanity_check_params()
 {

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -52,6 +52,9 @@ public:
     /// run the loiter controller
     void update(bool avoidance_on = true);
 
+    //set maximum horizontal speed
+    void set_max_xy_speed(float max_xy_speed);
+
     /// get desired roll, pitch which should be fed into stabilize controllers
     float get_roll() const { return _pos_control.get_roll_cd(); }
     float get_pitch() const { return _pos_control.get_pitch_cd(); }


### PR DESCRIPTION
This has been requested a few times in the past as well as in #9782.
This has been tested on SITL(incremented channel 6 by 100 every few seconds), and works well: 
![Figure_1](https://user-images.githubusercontent.com/36970042/80255976-940aa580-869b-11ea-8c63-3e12c2340901.png)
Can't test it on actual copter due to lockdown.
Looking forward to any improvements that can be suggested! 

Fixes #9782