### PR TITLE
GCS_MAVLink: correct increment of out-of-space in HAVE_PAYLOAD_SPACE

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -44,7 +44,7 @@ void gcs_out_of_space_to_send_count(mavlink_channel_t chan);
 // anywhere in the code to determine if the mavlink message with ID id
 // can currently fit in the output of _chan.  Note the use of the ","
 // operator here to increment a counter.
-#define HAVE_PAYLOAD_SPACE(_chan, id) (comm_get_txspace(_chan) >= PAYLOAD_SIZE(_chan, id) ? (gcs_out_of_space_to_send_count(_chan), true) : false)
+#define HAVE_PAYLOAD_SPACE(_chan, id) (comm_get_txspace(_chan) >= PAYLOAD_SIZE(_chan, id) ? true : (gcs_out_of_space_to_send_count(_chan), false))
 
 // CHECK_PAYLOAD_SIZE - macro which may only be used within a
 // GCS_MAVLink object's methods.  It inserts code which will

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2079,7 +2079,7 @@ void GCS_MAVLINK::handle_set_mode(const mavlink_message_t &msg)
     // command.  The command we are acking (ID=11) doesn't actually
     // exist, but if it did we'd probably be acking something
     // completely unrelated to setting modes.
-    if (HAVE_PAYLOAD_SPACE(chan, MAVLINK_MSG_ID_COMMAND_ACK)) {
+    if (HAVE_PAYLOAD_SPACE(chan, COMMAND_ACK)) {
         mavlink_msg_command_ack_send(chan, MAVLINK_MSG_ID_SET_MODE, result);
     }
 }

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -85,7 +85,7 @@ void GCS_MAVLINK::handle_file_transfer_protocol(const mavlink_message_t &msg) {
 }
 
 void GCS_MAVLINK::send_ftp_replies(void) {
-    if (ftp.replies == nullptr) {
+    if (ftp.replies == nullptr || ftp.replies->empty()) {
         return;
     }
 


### PR DESCRIPTION
Close.... but we should probably increment when we don't have space rather than when we do.

Minor patch to mavlink-ftp to avoid unnecessary work.  It also tended to blow out the times-full count as we call this rapidly.

Also regularise the check for space for `COMMAND_ACK`.  This only worked because we're double-evaluating `id` - and we provide a `MAVLINK_MSG_ID_77_LEN` as well as a `MAVLINK_MSG_ID_COMMAND_ACK_LEN`.
