### PR TITLE
AP_Landing_Deepstall: Corrected description of parameters

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
 
     // @Param: APP_EXT
     // @DisplayName: Deepstall approach extension
-    // @Description: The forward velocity of the aircraft while stalled
+    // @Description: The horizontal distance from which the aircraft will approach before the stall
     // @Range: 10 200
     // @Units: m
     // @User: Advanced
@@ -99,7 +99,7 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
     // @DisplayName: Deepstall L1 period
     // @Description: Deepstall L1 navigational controller period
     // @Range: 5 50
-    // @Units: m
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("L1", 10, AP_Landing_Deepstall, L1_period, 30.0),
 


### PR DESCRIPTION
I notice some errors in the description and units of two parameters in the Deepstall landing:

- **APP_EXT** (Deepstall approach extension)
Wrong description, probably copy and paste from V_FWD.

- **L1** (Deepstall L1 period)
Should be seconds, not meters, right?.