### PR TITLE
AP_HAL_ChibiOS: error if system clock not 1mhz on 16 CH_CFG_ST_RESOLU…

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
@@ -46,7 +46,7 @@ static uint32_t system_time_u32_us(void)
 {
     systime_t now = chVTGetSystemTimeX();
 #if CH_CFG_ST_FREQUENCY != 1000000U
-    now *= 1000000U/CH_CFG_ST_FREQUENCY;
+    #error "must use 32 bit timer if system clock not 1MHz"
 #endif
     static systime_t last_systime;
     static uint32_t timer_base_us32;


### PR DESCRIPTION
The problem in code:
```
#if CH_CFG_ST_RESOLUTION == 16
static uint32_t system_time_u32_us(void)
{
    systime_t now = chVTGetSystemTimeX();
#if CH_CFG_ST_FREQUENCY != 1000000U
    now *= 1000000U/CH_CFG_ST_FREQUENCY;
#endif
    static systime_t last_systime;
    static uint32_t timer_base_us32;
    uint16_t dt = now - last_systime;
    last_systime = now;
    timer_base_us32 += dt;
    return timer_base_us32;
}
```

if `CH_CFG_ST_FREQUENCY` not match `1000000U` on 16 bit `CH_CFG_ST_RESOLUTION`
we try to multiply `now *= 1000000U/CH_CFG_ST_FREQUENCY;` it may overflow 16 bit value.

It can be fixed by changing type of variables `now`, `last_systime`, `dt` to uint32_t. like this:
```
#if CH_CFG_ST_RESOLUTION == 16
static uint32_t system_time_u32_us(void)
{
    uint32_t now = chVTGetSystemTimeX();
#if CH_CFG_ST_FREQUENCY != 1000000U
    now *= 1000000U/CH_CFG_ST_FREQUENCY;
#endif
    static uint32_t last_systime;
    static uint32_t timer_base_us32;
    uint32_t dt = now - last_systime;
    last_systime = now;
    timer_base_us32 += dt;
    return timer_base_us32;
}
```
Since Ardupilot ports doesn't use settings to achieve this case we simple generate error to prevent future errors.

