### PR TITLE
HAL_ChibiOS: fixed issue with I2C4 on H743

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -204,7 +204,11 @@ def generate_DMAMUX_map(peripheral_list, noshare_list, dma_exclude):
         else:
             dmamux1_peripherals.append(p)
     map1 = generate_DMAMUX_map_mask(dmamux1_peripherals, 0xFFFF, noshare_list, dma_exclude)
-    map2 = generate_DMAMUX_map_mask(dmamux2_peripherals, 0xFF, noshare_list, dma_exclude)
+    # there are 8 BDMA channels, but an issue has been found where if I2C4 and SPI6
+    # use neighboring channels then we sometimes lose a BDMA completion interrupt. To
+    # avoid this we set the BDMA available mask to 0x33, which forces the channels not to be
+    # adjacent. This issue was found on a CUAV-X7, with H743 RevV.
+    map2 = generate_DMAMUX_map_mask(dmamux2_peripherals, 0x33, noshare_list, dma_exclude)
     # translate entries from map2 to "DMA controller 3", which is used for BDMA
     for p in map2.keys():
         streams = []


### PR DESCRIPTION
when both I2C4 and SPI6 are active on a H743 I found that some BDMA
completion interrupts were lost, which resulted in SPI transfer
timeouts. Close inspection of the ChibiOS BDMA, I2Cv3 and SPIv3
drivers did not reveal any issues, but I found that the issue only
happened when the first 4 BDMA streams were used. This change splits
the 4 streams across the first and 2nd half of the BDMA controller,
and that fixes the problem.

This works as there are only 2 peripherals (I2C4 and SPI6) that want
to use BDMA with our current setup. If we ever wish to enable ADC3
(which also uses BDMA) we will need to revisit this issue