### PR TITLE
GPS: add enum GPS_AUTO_SWITCH=4 choose WORST receiver

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -101,7 +101,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Description: Automatic switchover to GPS reporting best lock
     // @Values: 0:Disabled,1:UseBest,2:Blend,3:UseSecond
     // @User: Advanced
-    AP_GROUPINFO("AUTO_SWITCH", 3, AP_GPS, _auto_switch, 1),
+    AP_GROUPINFO("AUTO_SWITCH", 3, AP_GPS, _auto_switch, GPS_AUTO_SWITCH_USE_BEST),
 #endif
 
     // @Param: MIN_DGPS
@@ -837,7 +837,7 @@ void AP_GPS::update_primary(void)
 {
 #if defined(GPS_BLENDED_INSTANCE)
     // if blending is requested, attempt to calculate weighting for each GPS
-    if (_auto_switch == 2) {
+    if (_auto_switch == GPS_AUTO_SWITCH_BLEND) {
         _output_is_blended = calc_blend_weights();
         // adjust blend health counter
         if (!_output_is_blended) {
@@ -862,13 +862,13 @@ void AP_GPS::update_primary(void)
         return;
     }
 
-    if (_auto_switch == 0) {
+    if (_auto_switch == GPS_AUTO_SWITCH_DISABLED) {
         // AUTO_SWITCH is 0 so no switching of GPSs, always use first instance
         primary_instance = 0;
         return;
     }
 
-    if (_auto_switch == 3) {
+    if (_auto_switch == GPS_AUTO_SWITCH_USE_SECOND) {
         // always select the second GPS instance
         primary_instance = 1;
         return;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -627,6 +627,13 @@ private:
         GPS_AUTO_CONFIG_ENABLE  = 1
     };
 
+    enum GPS_AUTO_SWITCH {
+        GPS_AUTO_SWITCH_DISABLED     = 0,
+        GPS_AUTO_SWITCH_USE_BEST     = 1,
+        GPS_AUTO_SWITCH_BLEND        = 2,
+        GPS_AUTO_SWITCH_USE_SECOND   = 3,
+    };
+
     // used for flight testing with GPS loss
     bool _force_disable_gps;
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -632,6 +632,7 @@ private:
         GPS_AUTO_SWITCH_USE_BEST     = 1,
         GPS_AUTO_SWITCH_BLEND        = 2,
         GPS_AUTO_SWITCH_USE_SECOND   = 3,
+        GPS_AUTO_SWITCH_USE_WORST    = 4,
     };
 
     // used for flight testing with GPS loss


### PR DESCRIPTION
add enum GPS_AUTO_SWITCH=4 choose WORST receiver. That includes status=0.

This is useful when you want to be able "disable" the gps in-flight and feed that inferior, or absent, value into the system but still want to log true gps values for later analysis. Helpful to show behavior of actual aircraft gps loss during flight and easier to see improvements when adding additional sensors like airspeed, flow and SLAM.

This should give a similar effect as SIM_GPS_DISABLE but with the added benefit that it will also work on real vehicles. To test in SITL:

SIM_GPS2_ENABLE 1
GPS_TYPE2 1
AUTO_SWITCH 4

(arm, takeoff, fly around)

SIM_GPS2_ENABLE 0

(things go nuts)

SIM_GPS2_ENABLE 1

(aircraft resumes whatever it was doing)

