### PR TITLE
AP_BoardConfig: Define a method class

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -257,6 +257,15 @@ private:
     AP_Int32 _options;
 
     AP_Int8  _alt_config;
+
+private:
+#if AP_FEATURE_BOARD_DETECT
+
+    bool check_ms5611(const char* devname);
+
+#endif // AP_FEATURE_BOARD_DETECT
+
+
 };
 
 namespace AP {

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -152,7 +152,7 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
     return v == value;
 }
 
-static bool check_ms5611(const char* devname) {
+bool AP_BoardConfig::check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
     if (!dev) {
 #if SPI_PROBE_DEBUG


### PR DESCRIPTION
I saw a warning for the check_ms5611 method.
I have found that there is no class, no prototype definition, that doesn't belong to a class.
I've added a class definition and a prototype definition.