### PR TITLE
AP_GPS: Remove redundant assignment of ground speed and ground course

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1494,8 +1494,6 @@ AP_GPS_UBLOX::_parse_gps(void)
         }
         _check_new_itow(_buffer.velned.itow);
         _last_vel_time         = _buffer.velned.itow;
-        state.ground_speed     = _buffer.velned.speed_2d*0.01f;          // m/s
-        state.ground_course    = wrap_360(_buffer.velned.heading_2d * 1.0e-5f);       // Heading 2D deg * 100000
         state.have_vertical_velocity = true;
         state.velocity.x = _buffer.velned.ned_north * 0.01f;
         state.velocity.y = _buffer.velned.ned_east * 0.01f;


### PR DESCRIPTION
Ground speed and ground course were set from UBLOX message, then reset
from velocity. The first assignment is immediately overwritten, so it
has been removed. Note that state.ground_speed and state.ground_course are still set right after the velocity is read in.