### PR TITLE
Fixed UAVCAN/AP_Periph zero timestamp bug

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1245,7 +1245,11 @@ void AP_Periph_FW::can_gps_update(void)
 
         pkt.timestamp.usec = AP_HAL::micros64();
         pkt.gnss_timestamp.usec = gps.time_epoch_usec();
-        pkt.gnss_time_standard = UAVCAN_EQUIPMENT_GNSS_FIX_GNSS_TIME_STANDARD_UTC;
+        if (pkt.gnss_timestamp.usec == 0) {
+            pkt.gnss_time_standard = UAVCAN_EQUIPMENT_GNSS_FIX_GNSS_TIME_STANDARD_NONE;
+        } else {
+            pkt.gnss_time_standard = UAVCAN_EQUIPMENT_GNSS_FIX_GNSS_TIME_STANDARD_UTC;
+        }
         pkt.longitude_deg_1e8 = uint64_t(loc.lng) * 10ULL;
         pkt.latitude_deg_1e8 = uint64_t(loc.lat) * 10ULL;
         pkt.height_ellipsoid_mm = loc.alt * 10;
@@ -1324,7 +1328,11 @@ void AP_Periph_FW::can_gps_update(void)
 
         pkt.timestamp.usec = AP_HAL::micros64();
         pkt.gnss_timestamp.usec = gps.time_epoch_usec();
-        pkt.gnss_time_standard = UAVCAN_EQUIPMENT_GNSS_FIX2_GNSS_TIME_STANDARD_UTC;
+        if (pkt.gnss_timestamp.usec == 0) {
+            pkt.gnss_time_standard = UAVCAN_EQUIPMENT_GNSS_FIX_GNSS_TIME_STANDARD_NONE;
+        } else {
+            pkt.gnss_time_standard = UAVCAN_EQUIPMENT_GNSS_FIX_GNSS_TIME_STANDARD_UTC;
+        }
         pkt.longitude_deg_1e8 = uint64_t(loc.lng) * 10ULL;
         pkt.latitude_deg_1e8 = uint64_t(loc.lat) * 10ULL;
         pkt.height_ellipsoid_mm = loc.alt * 10;

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -173,10 +173,12 @@ void AP_GPS_UAVCAN::handle_fix_msg(const FixCb &cb)
 
         if (cb.msg->gnss_time_standard == uavcan::equipment::gnss::Fix::GNSS_TIME_STANDARD_UTC) {
             uint64_t epoch_ms = uavcan::UtcTime(cb.msg->gnss_timestamp).toUSec();
-            epoch_ms /= 1000;
-            uint64_t gps_ms = epoch_ms - UNIX_OFFSET_MSEC;
-            interim_state.time_week = (uint16_t)(gps_ms / AP_MSEC_PER_WEEK);
-            interim_state.time_week_ms = (uint32_t)(gps_ms - (interim_state.time_week) * AP_MSEC_PER_WEEK);
+            if (epoch_ms != 0) {
+                epoch_ms /= 1000;
+                uint64_t gps_ms = epoch_ms - UNIX_OFFSET_MSEC;
+                interim_state.time_week = (uint16_t)(gps_ms / AP_MSEC_PER_WEEK);
+                interim_state.time_week_ms = (uint32_t)(gps_ms - (interim_state.time_week) * AP_MSEC_PER_WEEK);
+            }
         }
     }
 
@@ -283,10 +285,12 @@ void AP_GPS_UAVCAN::handle_fix2_msg(const Fix2Cb &cb)
 
         if (cb.msg->gnss_time_standard == uavcan::equipment::gnss::Fix2::GNSS_TIME_STANDARD_UTC) {
             uint64_t epoch_ms = uavcan::UtcTime(cb.msg->gnss_timestamp).toUSec();
-            epoch_ms /= 1000;
-            uint64_t gps_ms = epoch_ms - UNIX_OFFSET_MSEC;
-            interim_state.time_week = (uint16_t)(gps_ms / AP_MSEC_PER_WEEK);
-            interim_state.time_week_ms = (uint32_t)(gps_ms - (interim_state.time_week) * AP_MSEC_PER_WEEK);
+            if (epoch_ms != 0) {
+                epoch_ms /= 1000;
+                uint64_t gps_ms = epoch_ms - UNIX_OFFSET_MSEC;
+                interim_state.time_week = (uint16_t)(gps_ms / AP_MSEC_PER_WEEK);
+                interim_state.time_week_ms = (uint32_t)(gps_ms - (interim_state.time_week) * AP_MSEC_PER_WEEK);
+            }
         }
 
         if (interim_state.status == AP_GPS::GPS_Status::GPS_OK_FIX_3D) {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
@@ -735,7 +735,7 @@
  * @details This hook is invoked when we have a stack overflow on task switch
  */
 #define CH_CFG_STACK_OVERFLOW_HOOK(tp) {                                         \
-  extern void stack_overflow_hook(thread_t *tp); \
+  extern void stack_overflow(thread_t *tp); \
   stack_overflow(tp); \
 }
 


### PR DESCRIPTION
AP_Periph was sending a zero timestamp marked as UTC time on first fix, this prevents that from being used as the RTC time
