### PR TITLE
AP_Compass: fixed compass ordering bug with AP_Periph

### DIFF
--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -87,4 +87,5 @@ fi
 pip install --user -U argparse empy pyserial pexpect future lxml
 pip install --user -U intelhex
 pip install --user -U numpy
-pip install --user -U edn_format
+pip install --user -U edn_format || true
+

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -344,7 +344,7 @@ public:
 private:
     static Compass *_singleton;
 
-    // Use Priority and StateIndex typesafe index types 
+    // Use Priority and StateIndex typesafe index types
     // to distinguish between two different type of indexing
     // We use StateIndex for access by Backend
     // and Priority for access by Frontend
@@ -518,8 +518,10 @@ private:
     
     //Create Arrays to be accessible by Priority only
     RestrictIDTypeArray<AP_Int8, COMPASS_MAX_INSTANCES, Priority> _use_for_yaw;
+#if COMPASS_MAX_INSTANCES > 1
     RestrictIDTypeArray<AP_Int32, COMPASS_MAX_INSTANCES, Priority> _priority_did_stored_list;
     RestrictIDTypeArray<int32_t, COMPASS_MAX_INSTANCES, Priority> _priority_did_list;
+#endif
 
     AP_Int16 _offset_max;
 


### PR DESCRIPTION
when a user swaps compasses on AP_Periph we want to immediately
replace it. The compass ordering code was rejecting the new compass
and calling panic as it was out of slots. This changes the AP_Compass
ordering so that when we only have a single compass we operate in a
very simple manner where we always accept the first compass found