### PR TITLE
Copter: land detector allows larger lean angle request in land mode

### DIFF
--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -173,7 +173,10 @@ void Copter::update_throttle_mix()
         // check for requested decent
         bool descent_not_demanded = pos_control->get_desired_velocity().z >= 0.0f;
 
-        if (large_angle_request || large_angle_error || accel_moving || descent_not_demanded) {
+        // check if landing
+        const bool landing = flightmode->is_landing();
+
+        if ((large_angle_request && !landing) || large_angle_error || accel_moving || descent_not_demanded) {
             attitude_control->set_throttle_mix_max(pos_control->get_vel_z_control_ratio());
         } else {
             attitude_control->set_throttle_mix_min();


### PR DESCRIPTION
This PR removes the "throttle-mix" feature's desired lean angle check when the vehicle is in Land mode (or Auto-Land).  This means the vehicle is more likely to prioritise altitude while landing especially if the user has repositioned the vehicle (causing a desired lean angle > 15deg) just before landing.

To provide some background, the "throttle-mix" feature is responsible for prioritisation of attitude control vs altitude control.  The land detector also uses the output of the throttle-mix in it's heuristics to decide if the vehicle is landed.  In particular **altitude** must be prioritised over attitude

This has been discussed with @lthall and we think this is a safe change and should slightly improve the reliability of the landing detector.