### PR TITLE
Plane: reset baro_takeoff_alt while disarmed

### DIFF
--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -18,6 +18,7 @@ bool Plane::auto_takeoff_check(void)
     // reset all takeoff state if disarmed
     if (!hal.util->get_soft_armed()) {
         memset(&takeoff_state, 0, sizeof(takeoff_state));
+        auto_state.baro_takeoff_alt = barometer.get_altitude();
         return false;
     }
 


### PR DESCRIPTION
This PR will constantly reset the takeoff ground-reference altitude while disarmed.

When switching to auto with a takeoff nav cmd the baro alt is remembered at that moment. This altitude is used to limit roll during the intiial climb via [takeoff_calc_roll()](https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/takeoff.cpp#L137). However, if you move to a higher place and/or allow it to drift for a long time before you launch then that limited roll protection will be reduced and completely gone.

Consider the implications of unintentionally allowing a max roll in this video of a vehicle launch:
https://youtu.be/ICpwL1VzgHM?t=10

To reduce injury a standard practice is to keep an aircraft disarmed until it is ready to launch. This patch ensures the anticipated takeoff roll limitation is accurate.
