### PR TITLE
Tools: Adding a default value definition

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -32,6 +32,7 @@ known_param_fields = [
              'Volatile',
              'ReadOnly',
              'Calibration',
+             'Default'
                       ]
 
 # Follow SI units conventions from:


### PR DESCRIPTION
I'd like to know the default value of the config parameter.
I will refer to the source code to know the default values.
I can know the default values in the list by adding "Default" to the config parameter definition item.

Sample:
![Screenshot from 2020-04-30 10-04-56](https://user-images.githubusercontent.com/646194/80663406-db939600-8ace-11ea-908e-ff5db3b79a9e.png)
