### PR TITLE
Emit description of internal error in statustext

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -781,7 +781,9 @@ bool AP_Arming::system_checks(bool report)
 #endif
     }
     if (AP::internalerror().errors() != 0) {
-        check_failed(report, "Internal errors (0x%x) (last line:%u)", (unsigned int)AP::internalerror().errors(), AP::internalerror().last_error_line());
+        uint8_t buffer[32];
+        AP::internalerror().errors_as_string(buffer, ARRAY_SIZE(buffer));
+        check_failed(report, "Internal errors 0x%x l:%u (%s)", (unsigned int)AP::internalerror().errors(), AP::internalerror().last_error_line(), buffer);
         return false;
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -783,7 +783,7 @@ bool AP_Arming::system_checks(bool report)
     if (AP::internalerror().errors() != 0) {
         uint8_t buffer[32];
         AP::internalerror().errors_as_string(buffer, ARRAY_SIZE(buffer));
-        check_failed(report, "Internal errors 0x%x l:%u (%s)", (unsigned int)AP::internalerror().errors(), AP::internalerror().last_error_line(), buffer);
+        check_failed(report, "Internal errors 0x%x l:%u %s", (unsigned int)AP::internalerror().errors(), AP::internalerror().last_error_line(), buffer);
         return false;
     }
 

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -27,6 +27,62 @@ void AP_InternalError::error(const AP_InternalError::error_t e, uint16_t line) {
     hal.util->persistent_data.internal_error_last_line = line;
 }
 
+void AP_InternalError::errors_as_string(uint8_t *buffer, const uint16_t len) const
+{
+    static const char * const error_bit_descriptions[] {
+        "mapfailure",  // logger_mapfailure
+        "miss_struct",  // logger_missing_logstructure
+        "write_mssfmt",  // logger_logwrite_missingfmt
+        "many_deletes",  // logger_too_many_deletions
+        "bad_getfile",  // logger_bad_getfilename
+        "unused1",
+        "flush_no_sem",  // logger_flushing_without_sem
+        "bad_curr_blk",  // logger_bad_current_block
+        "blkcnt_bad",  // logger_blockcount_mismatch
+        "dq_failure",  // logger_dequeue_failure
+        "cnstring_nan",  // constraining_nan
+        "watchdog_rst",  // watchdog_reset
+        "iomcu_reset",
+        "iomcu_fail",
+        "spi_fail",
+        "main_loop_stk",  // main_loop_stuck
+        "gcs_bad_link",  // gcs_bad_missionprotocol_link
+        "bitmask_range",
+        "gcs_offset",
+        "i2c_isr",
+        "flow_of_ctrl",  // flow_of_control
+        "sfs_recursion",  // switch_full_sector_recursion
+        "bad_rotation",
+        "stack_ovrflw",  // stack_overflow
+    };
+
+    static_assert((1U<<(ARRAY_SIZE(error_bit_descriptions))) == uint32_t(AP_InternalError::error_t::__LAST__), "too few descriptions for bits");
+
+    buffer[0] = 0;
+    uint32_t buffer_used = 0;
+    for (uint8_t i=0; i<ARRAY_SIZE(error_bit_descriptions); i++) {
+        if (buffer_used >= len) {
+            break;
+        }
+        if (internal_errors & (1U<<i)) {
+            const char *format;
+            if (i == 0) {
+                format = "%s";
+            } else {
+                format = ",%s";
+            }
+            const size_t written = hal.util->snprintf((char*)&buffer[buffer_used],
+                                                      len-buffer_used,
+                                                      format,
+                                                      error_bit_descriptions[i]);
+            if (written <= 0) {
+                break;
+            }
+            buffer_used += written;
+        }
+    }
+}
+
 namespace AP {
 
 AP_InternalError &internalerror()

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -57,11 +57,22 @@ public:
         switch_full_sector_recursion= (1U << 21),  //0x200000  2097152
         bad_rotation                = (1U << 22),  //0x400000  4194304
         stack_overflow              = (1U << 23),  //0x800000  8388608
+        __LAST__                    = (1U << 24),  // used only for sanity check
     };
+
+    // if you've changed __LAST__ to be 32, then you will want to
+    // rejig the way we do sanity checks as we don't want to move to a
+    // 64-bit type for error_t:
+    static_assert(sizeof(error_t) == 4, "error_t should be 32-bit type");
 
     uint16_t last_error_line() const { return last_line; }
 
     void error(const AP_InternalError::error_t error, uint16_t line);
+
+    // fill buffer with a description of the exceptions present in
+    // internal errors.  buffer will always be null-terminated.
+    void errors_as_string(uint8_t *buffer, uint16_t len) const;
+
     uint32_t count() const { return total_error_count; }
 
     // internal_errors - return mask of internal errors seen

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -32,6 +32,10 @@ public:
     // of thing.  Examples of what NOT to put in here - sd card
     // filling up, bad input received from GCS, GPS unit was working
     // and now is not.
+
+    // note that this map is an internal ArduPilot fixture and is
+    // prone to change at regular intervals.  The meanings of these
+    // bits can change day-to-day.
     enum class error_t {                           // Hex      Decimal
         logger_mapfailure           = (1U <<  0),  // 0x00001  1
         logger_missing_logstructure = (1U <<  1),  // 0x00002  2


### PR DESCRIPTION
@meee1 

I'm hoping this will allow for the removal of the textual description of these errors that's currently in MissionPlanner.

These bits were never supposed to be an external interface.  The internal error descriptions are *supposed* to be scary - we want people to tell us whenever they receive an internal error, and @tridge has been active in squashing false-positives that have occurred.

To be clear here - any time an Internal Error occurs, a user should most definitely land and reconsider their life choices - it's that serious.  Let's not make the user any more comfortable than we need to.
