### PR TITLE
Plane: ignore guided cmds from mavlink if we're in avoidADSB.

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1166,8 +1166,7 @@ void GCS_MAVLINK_Plane::handleMessage(const mavlink_message_t &msg)
         // in e.g., RTL, CICLE. Specifying a single mode for companion
         // computer control is more safe (even more so when using
         // FENCE_ACTION = 4 for geofence failures).
-        if ((plane.control_mode != &plane.mode_guided) &&
-            (plane.control_mode != &plane.mode_avoidADSB)) { // don't screw up failsafes
+        if (plane.control_mode != &plane.mode_guided) { // don't screw up failsafes
             break; 
         }
 
@@ -1277,7 +1276,7 @@ void GCS_MAVLINK_Plane::handleMessage(const mavlink_message_t &msg)
         // in modes such as RTL, CIRCLE, etc.  Specifying ONLY one mode
         // for companion computer control is more safe (provided
         // one uses the FENCE_ACTION = 4 (RTL) for geofence failures).
-        if (plane.control_mode != &plane.mode_guided && plane.control_mode != &plane.mode_avoidADSB) {
+        if (plane.control_mode != &plane.mode_guided) {
             //don't screw up failsafes
             break;
         }


### PR DESCRIPTION
This change makes it behave like MAVLINK_MSG_ID_SET_POSITION_TARGET_LOCAL_NED.

If a companion computer was streaming guided points, and the aircraft switches itself into avoidADSB, then two things happen:

- AvoidADSB module is asynchronously (or at least out of phase) setting the point at the same time as the companion computer so the commands will blend together and the aircraft will go back and forward trying to navigate to whichever is the most recent one.
- While we're in an emergency and/or evasive maneuver to avoid an obstacle the companion computer is still allowed to fly us right into that obstacle.


This has additional bad implications for when mode_follow gets added to plane.