### PR TITLE
Copter: add disarm aux switch RCn_OPTION=81

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1055,7 +1055,8 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  proximity_checks(report)
         &  camera_checks(report)
         &  visodom_checks(report)
-        &  aux_auth_checks(report);
+        &  aux_auth_checks(report)
+        &  disarm_switch_checks(report);
 }
 
 bool AP_Arming::arm_checks(AP_Arming::Method method)
@@ -1212,6 +1213,20 @@ bool AP_Arming::visodom_checks(bool display_failure) const
         }
     }
 #endif
+
+    return true;
+}
+
+// check disarm switch is asserted
+bool AP_Arming::disarm_switch_checks(bool display_failure) const
+{
+    const RC_Channel *chan = rc().find_channel_for_option(RC_Channel::AUX_FUNC::DISARM);
+    if (chan != nullptr &&
+        chan->get_aux_switch_pos() == RC_Channel::aux_switch_pos_t::HIGH &&
+        (checks_to_perform & ARMING_CHECK_ALL)) {
+        check_failed(display_failure, "Disarm Switch on");
+        return false;
+    }
 
     return true;
 }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -175,6 +175,7 @@ protected:
     bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4]) const;
 
     bool visodom_checks(bool report) const;
+    bool disarm_switch_checks(bool report) const;
 
     // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced
     virtual bool mandatory_checks(bool report) { return true; }

--- a/libraries/AP_Camera/AP_RunCam.cpp
+++ b/libraries/AP_Camera/AP_RunCam.cpp
@@ -265,18 +265,6 @@ void AP_RunCam::update_osd()
     update_state_machine_disarmed();
 }
 
-// return radio values as LOW, MIDDLE, HIGH
-RC_Channel::aux_switch_pos_t AP_RunCam::get_channel_pos(uint8_t rcmapchan) const
-{
-    RC_Channel::aux_switch_pos_t position = RC_Channel::LOW;
-    const RC_Channel* chan = rc().channel(rcmapchan-1);
-    if (chan == nullptr || !chan->read_3pos_switch(position)) {
-        return RC_Channel::LOW;
-    }
-
-    return position;
-}
-
 // update the state machine when armed or flying
 void AP_RunCam::update_state_machine_armed()
 {
@@ -449,10 +437,10 @@ void AP_RunCam::handle_in_menu(Event ev)
 // map rc input to an event
 AP_RunCam::Event AP_RunCam::map_rc_input_to_event() const
 {
-    const RC_Channel::aux_switch_pos_t throttle = get_channel_pos(AP::rcmap()->throttle());
-    const RC_Channel::aux_switch_pos_t yaw = get_channel_pos(AP::rcmap()->yaw());
-    const RC_Channel::aux_switch_pos_t roll = get_channel_pos(AP::rcmap()->roll());
-    const RC_Channel::aux_switch_pos_t pitch = get_channel_pos(AP::rcmap()->pitch());
+    const RC_Channel::aux_switch_pos_t throttle = rc().get_channel_pos(AP::rcmap()->throttle());
+    const RC_Channel::aux_switch_pos_t yaw = rc().get_channel_pos(AP::rcmap()->yaw());
+    const RC_Channel::aux_switch_pos_t roll = rc().get_channel_pos(AP::rcmap()->roll());
+    const RC_Channel::aux_switch_pos_t pitch = rc().get_channel_pos(AP::rcmap()->pitch());
 
     Event result = Event::NONE;
 

--- a/libraries/AP_Camera/AP_RunCam.h
+++ b/libraries/AP_Camera/AP_RunCam.h
@@ -351,8 +351,6 @@ private:
 
     // OSD update loop
     void update_osd();
-    // return radio values as LOW, MIDDLE, HIGH
-    RC_Channel::aux_switch_pos_t get_channel_pos(uint8_t rcmapchan) const;
     // update the state machine when armed or flying
     void update_state_machine_armed();
     // update the state machine when disarmed

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -92,9 +92,9 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: OPTION
     // @DisplayName: RC input option
     // @Description: Function assigned to this RC channel
-    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5, 67:Relay6, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 80:Viso Align, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle
-    // @Values{Rover}: 0:Do Nothing, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 11:Fence, 16:Auto, 19:Gripper, 24:Auto Mission Reset, 28:Relay On/Off, 30:Lost Rover Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple Mode, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66:Relay5, 67:Relay6, 74:Sailboat motoring 3pos, 78:RunCam Control, 79:RunCam OSD Control, 80:Viso Align, 100:KillIMU1, 101:KillIMU2, 207:MainSail, 102:Camera Mode Toggle
-    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 16:ModeAuto, 24:Auto Mission Reset, 28:Relay On/Off, 29:Landing Gear, 34:Relay2 On/Off, 30:Lost Plane Sound, 31:Motor Emergency Stop, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm, 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5, 67:Relay6, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 100:KillIMU1, 101:KillIMU2, 208:Flap, 102:Camera Mode Toggle
+    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5, 67:Relay6, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 80:Viso Align, 81: Disarm, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle
+    // @Values{Rover}: 0:Do Nothing, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 11:Fence, 16:Auto, 19:Gripper, 24:Auto Mission Reset, 28:Relay On/Off, 30:Lost Rover Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple Mode, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66:Relay5, 67:Relay6, 74:Sailboat motoring 3pos, 78:RunCam Control, 79:RunCam OSD Control, 80:Viso Align, 81: Disarm, 100:KillIMU1, 101:KillIMU2, 207:MainSail, 102:Camera Mode Toggle
+    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 16:ModeAuto, 24:Auto Mission Reset, 28:Relay On/Off, 29:Landing Gear, 34:Relay2 On/Off, 30:Lost Plane Sound, 31:Motor Emergency Stop, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm, 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5, 67:Relay6, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 81: Disarm, 100:KillIMU1, 101:KillIMU2, 208:Flap, 102:Camera Mode Toggle
     // @User: Standard
     AP_GROUPINFO_FRAME("OPTION",  6, RC_Channel, option, 0, AP_PARAM_FRAME_COPTER|AP_PARAM_FRAME_ROVER|AP_PARAM_FRAME_PLANE),
 
@@ -455,6 +455,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
     case AUX_FUNC::CAMERA_TRIGGER:
     case AUX_FUNC::CLEAR_WP:
     case AUX_FUNC::COMPASS_LEARN:
+    case AUX_FUNC::DISARM:
     case AUX_FUNC::DO_NOTHING:
     case AUX_FUNC::LANDING_GEAR:
     case AUX_FUNC::LOST_VEHICLE_SOUND:
@@ -831,6 +832,12 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         do_aux_function_armdisarm(ch_flag);
         break;
 
+    case AUX_FUNC::DISARM:
+        if (ch_flag == HIGH) {
+            AP::arming().disarm(AP_Arming::Method::AUXSWITCH);
+        }
+        break;
+
     case AUX_FUNC::COMPASS_LEARN:
         if (ch_flag == HIGH) {
             Compass &compass = AP::compass();
@@ -978,6 +985,16 @@ bool RC_Channel::read_3pos_switch(RC_Channel::aux_switch_pos_t &ret) const
         ret = MIDDLE;
     }
     return true;
+}
+
+// return switch position value as LOW, MIDDLE, HIGH
+// if reading the switch fails then it returns LOW
+RC_Channel::aux_switch_pos_t RC_Channel::get_aux_switch_pos() const
+{
+    aux_switch_pos_t position = aux_switch_pos_t::LOW;
+    UNUSED_RESULT(read_3pos_switch(position));
+
+    return position;
 }
 
 RC_Channel *RC_Channels::find_channel_for_option(const RC_Channel::aux_func_t option)

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -997,6 +997,14 @@ RC_Channel::aux_switch_pos_t RC_Channel::get_aux_switch_pos() const
     return position;
 }
 
+// return switch position value as LOW, MIDDLE, HIGH
+// if reading the switch fails then it returns LOW
+RC_Channel::aux_switch_pos_t RC_Channels::get_channel_pos(const uint8_t rcmapchan) const
+{
+    const RC_Channel* chan = rc().channel(rcmapchan-1);
+    return chan != nullptr ? chan->get_aux_switch_pos() : RC_Channel::aux_switch_pos_t::LOW;
+}
+
 RC_Channel *RC_Channels::find_channel_for_option(const RC_Channel::aux_func_t option)
 {
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -178,6 +178,7 @@ public:
         RUNCAM_CONTROL =      78, // control RunCam device
         RUNCAM_OSD_CONTROL =  79, // control RunCam OSD
         VISODOM_CALIBRATE  =  80, // calibrate visual odometry camera's attitude
+        DISARM =              81, // disarm vehicle
         KILL_IMU1 =          100, // disable first IMU (for IMU failure testing)
         KILL_IMU2 =          101, // disable second IMU (for IMU failure testing)
         CAM_MODE_TOGGLE =    102, // Momentary switch to cycle camera modes
@@ -200,6 +201,7 @@ public:
     };
 
     bool read_3pos_switch(aux_switch_pos_t &ret) const WARN_IF_UNUSED;
+    aux_switch_pos_t get_aux_switch_pos() const;
 
 protected:
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -324,6 +324,7 @@ public:
 
     class RC_Channel *find_channel_for_option(const RC_Channel::aux_func_t option);
     bool duplicate_options_exist();
+    RC_Channel::aux_switch_pos_t get_channel_pos(const uint8_t rcmapchan) const;
 
     void init_aux_all();
     void read_aux_all();


### PR DESCRIPTION
This is similar to Estop and Arm/Disarm, but there is a slight difference.

When you set the Disarm switch to High, the copter immediately disarms.
Arming will fail if the Disarm switch is enabled.

Emergency Stop is not immediately disarmed (the timing is depends on DISARM_DELAY).
Without noticing that it has not been disarmed, it is possible to return the switch to Low and unintentionally start the motor running again.

With the Arm/Disarm option, there is a risk that the switch will be inadvertently set to High and start to rotate the motors.