### PR TITLE
regularise CAN pre-arm failure messages

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -823,9 +823,8 @@ bool AP_Arming::can_checks(bool report)
 // To be replaced with macro saying if KDECAN library is included
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_ArduSub)
                     AP_KDECAN *ap_kdecan = AP_KDECAN::get_kdecan(i);
-                    snprintf(fail_msg, ARRAY_SIZE(fail_msg), "KDECAN failed");
                     if (ap_kdecan != nullptr && !ap_kdecan->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-                        check_failed(ARMING_CHECK_SYSTEM, report, "%s", fail_msg);
+                        check_failed(ARMING_CHECK_SYSTEM, report, "KDECAN: %s", fail_msg);
                         return false;
                     }
 #endif
@@ -836,12 +835,7 @@ bool AP_Arming::can_checks(bool report)
                     AP_PiccoloCAN *ap_pcan = AP_PiccoloCAN::get_pcan(i);
 
                     if (ap_pcan != nullptr && !ap_pcan->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-                        if (fail_msg == nullptr) {
-                            check_failed(ARMING_CHECK_SYSTEM, report, "PiccoloCAN failed");
-                        } else {
-                            check_failed(ARMING_CHECK_SYSTEM, report, "%s", fail_msg);
-                        }
-
+                        check_failed(ARMING_CHECK_SYSTEM, report, "PiccoloCAN: %s", fail_msg);
                         return false;
                     }
 
@@ -853,15 +847,20 @@ bool AP_Arming::can_checks(bool report)
                 }
                 case AP_BoardConfig_CAN::Protocol_Type_UAVCAN:
                 {
-                    snprintf(fail_msg, ARRAY_SIZE(fail_msg), "UAVCAN failed");
                     if (!AP::uavcan_dna_server().prearm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-                        check_failed(ARMING_CHECK_SYSTEM, report, "%s", fail_msg);
+                        check_failed(ARMING_CHECK_SYSTEM, report, "UAVCAN: %s", fail_msg);
                         return false;
                     }
                     break;
                 }
+                case AP_BoardConfig_CAN::Protocol_Type_ToshibaCAN:
+                {
+                    // toshibacan doesn't currently have any prearm
+                    // checks.  Theres scope for adding a "not
+                    // initialised" prearm check.
+                    break;
+                }
                 case AP_BoardConfig_CAN::Protocol_Type_None:
-                default:
                     break;
             }
         }

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -642,12 +642,12 @@ bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
 {
     if (!_enum_sem.take(1)) {
         debug_can(2, "KDECAN: failed to get enumeration semaphore on read\n\r");
-        snprintf(reason, reason_len ,"KDECAN enumeration state unknown");
+        snprintf(reason, reason_len ,"Enumeration state unknown");
         return false;
     }
 
     if (_enumeration_state != ENUMERATION_STOPPED) {
-        snprintf(reason, reason_len ,"KDECAN enumeration running");
+        snprintf(reason, reason_len ,"Enumeration running");
         _enum_sem.give();
         return false;
     }
@@ -665,17 +665,17 @@ bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
     uint8_t num_present_escs = __builtin_popcount(_esc_present_bitmask);
 
     if (num_present_escs < num_expected_motors) {
-        snprintf(reason, reason_len ,"Not enough KDECAN ESCs detected");
+        snprintf(reason, reason_len, "Too few ESCs detected");
         return false;
     }
 
     if (num_present_escs > num_expected_motors) {
-        snprintf(reason, reason_len ,"Too many KDECAN ESCs detected");
+        snprintf(reason, reason_len, "Too many ESCs detected");
         return false;
     }
 
     if (_esc_max_node_id != num_expected_motors) {
-        snprintf(reason, reason_len ,"Wrong KDECAN node IDs, run enumeration");
+        snprintf(reason, reason_len, "Wrong node IDs, run enumeration");
         return false;
     }
 

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -536,14 +536,14 @@ bool AP_PiccoloCAN::pre_arm_check(char* reason, uint8_t reason_len)
         if (SRV_Channels::function_assigned(motor_function)) {
 
             if (!is_esc_present(ii)) {
-                snprintf(reason, reason_len, "PiccoloCAN: ESC %u not detected", ii + 1);
+                snprintf(reason, reason_len, "ESC %u not detected", ii + 1);
                 return false;
             }
 
             PiccoloESC_Info_t &esc = _esc_info[ii];
 
             if (esc.statusA.status.hwInhibit) {
-                snprintf(reason, reason_len, "PiccoloCAN: ESC %u is hardware inhibited", (ii + 1));
+                snprintf(reason, reason_len, "ESC %u is hardware inhibited", (ii + 1));
                 return false;
             }
         }

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
@@ -646,25 +646,23 @@ void trampoline_handleAllocation(AP_UAVCAN* ap_uavcan, uint8_t node_id, const Al
 //report the server state, along with failure message if any
 bool AP_UAVCAN_DNA_Server::prearm_check(char* fail_msg, uint8_t fail_msg_len) const
 {
-    if (server_state == HEALTHY) {
-        return true;
-    }
     switch (server_state) {
+    case HEALTHY:
+        return true;
     case STORAGE_FAILURE: {
-        snprintf(fail_msg, fail_msg_len, "UC: Failed to access storage!");
+        snprintf(fail_msg, fail_msg_len, "Failed to access storage!");
         return false;
     }
     case DUPLICATE_NODES: {
-        snprintf(fail_msg, fail_msg_len, "UC: Duplicate Node %s../%d!", fault_node_name, fault_node_id);
+        snprintf(fail_msg, fail_msg_len, "Duplicate Node %s../%d!", fault_node_name, fault_node_id);
         return false;
     }
     case FAILED_TO_ADD_NODE: {
-        snprintf(fail_msg, fail_msg_len, "UC: Failed to add Node %d!", fault_node_id);
+        snprintf(fail_msg, fail_msg_len, "Failed to add Node %d!", fault_node_id);
         return false;
     }
-    default:
-        break;
     }
+    // should never get; compiler should enforce all server_states are covered
     return false;
 }
 


### PR DESCRIPTION
AP_Arming tacks on the sub-system bit.

Remove PiccoloCAN's silly nullptr check

Require the library to supply the failure message (no default message)

Remove default cases so authors know to think about places they should
add things.


Tested this by flashing it onto a CubeBlack, returning messages like this:

```
APM: PreArm: KDECAN: Too few ESCs detected
```

and

```
APM: PreArm: PiccoloCAN: ESC 1 not detected
``
