### PR TITLE
Copter: use check_failed function for ESTOP arming check

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -632,7 +632,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     if (!rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_ESTOP)){
         SRV_Channels::set_emergency_stop(false);
         // if we are using motor Estop switch, it must not be in Estop position
-    } else if (rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_ESTOP) && SRV_Channels::get_emergency_stop()){
+    } else if (SRV_Channels::get_emergency_stop()){
         check_failed(true, "Motor Emergency Stopped");
         return false;
     }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -633,7 +633,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         SRV_Channels::set_emergency_stop(false);
         // if we are using motor Estop switch, it must not be in Estop position
     } else if (rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_ESTOP) && SRV_Channels::get_emergency_stop()){
-        gcs().send_text(MAV_SEVERITY_CRITICAL,"Arm: Motor Emergency Stopped");
+        check_failed(true, "Motor Emergency Stopped");
         return false;
     }
 


### PR DESCRIPTION
See this #6709