### PR TITLE
Global: Change to mav link message length definition

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -96,7 +96,7 @@ bool AP_Arming_Copter::compass_checks(bool display_failure)
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_COMPASS)) {
         // check compass offsets have been set.  AP_Arming only checks
         // this if learning is off; Copter *always* checks.
-        char failure_msg[50] = {};
+        char failure_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = {};
         if (!AP::compass().configured(failure_msg, ARRAY_SIZE(failure_msg))) {
             check_failed(ARMING_CHECK_COMPASS, display_failure, "%s", failure_msg);
             ret = false;
@@ -198,7 +198,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
             return false;
         }
 
-        char fail_msg[50];
+        char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN];
         // check input mangager parameters
         if (!copter.input_manager.parameter_check(fail_msg, ARRAY_SIZE(fail_msg))) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "%s", fail_msg);
@@ -281,7 +281,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
 #endif
 
         // ensure controllers are OK with us arming:
-        char failure_msg[50];
+        char failure_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN];
         if (!copter.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;
@@ -379,7 +379,7 @@ bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
 bool AP_Arming_Copter::oa_checks(bool display_failure)
 {
 #if AC_OAPATHPLANNER_ENABLED == ENABLED
-    char failure_msg[50];
+    char failure_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN];
     if (copter.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
         return true;
     }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -77,7 +77,7 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
 
     if (plane.quadplane.enabled() && plane.quadplane.available()) {
         // ensure controllers are OK with us arming:
-        char failure_msg[50];
+        char failure_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN];
         if (!plane.quadplane.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -155,7 +155,7 @@ bool AP_Arming_Rover::disarm(const AP_Arming::Method method)
 // check object avoidance has initialised correctly
 bool AP_Arming_Rover::oa_check(bool report)
 {
-    char failure_msg[50];
+    char failure_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN];
     if (rover.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
         return true;
     }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -175,7 +175,7 @@ void AP_Arming::check_failed(const enum AP_Arming::ArmingChecks check, bool repo
     if (!report) {
         return;
     }
-    char taggedfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    char taggedfmt[MAVLINK_MSG_ID_STATUSTEXT_LEN];
     hal.util->snprintf(taggedfmt, sizeof(taggedfmt), "PreArm: %s", fmt);
     MAV_SEVERITY severity = check_severity(check);
     va_list arg_list;
@@ -189,7 +189,7 @@ void AP_Arming::check_failed(bool report, const char *fmt, ...) const
     if (!report) {
         return;
     }
-    char taggedfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    char taggedfmt[MAVLINK_MSG_ID_STATUSTEXT_LEN];
     hal.util->snprintf(taggedfmt, sizeof(taggedfmt), "PreArm: %s", fmt);
     va_list arg_list;
     va_start(arg_list, fmt);
@@ -361,7 +361,7 @@ bool AP_Arming::ins_checks(bool report)
         }
 
         // check AHRS attitudes are consistent
-        char failure_msg[50] = {};
+        char failure_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = {};
         if (!AP::ahrs().attitudes_consistent(failure_msg, ARRAY_SIZE(failure_msg))) {
             check_failed(ARMING_CHECK_INS, report, "%s", failure_msg);
             return false;
@@ -412,7 +412,7 @@ bool AP_Arming::compass_checks(bool report)
         }
         // check compass learning is on or offsets have been set
         if (!_compass.learn_offsets_enabled()) {
-            char failure_msg[50] = {};
+            char failure_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = {};
             if (!_compass.configured(failure_msg, ARRAY_SIZE(failure_msg))) {
                 check_failed(ARMING_CHECK_COMPASS, report, "%s", failure_msg);
                 return false;
@@ -507,7 +507,7 @@ bool AP_Arming::battery_checks(bool report)
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_BATTERY)) {
 
-        char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
+        char buffer[MAVLINK_MSG_ID_STATUSTEXT_LEN] {};
         if (!AP::battery().arming_checks(sizeof(buffer), buffer)) {
             check_failed(ARMING_CHECK_BATTERY, report, "%s", buffer);
             return false;
@@ -687,7 +687,7 @@ bool AP_Arming::rangefinder_checks(bool report)
             return true;
         }
 
-        char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+        char buffer[MAVLINK_MSG_ID_STATUSTEXT_LEN];
         if (!range->prearm_healthy(buffer, ARRAY_SIZE(buffer))) {
             check_failed(ARMING_CHECK_RANGEFINDER, report, "%s", buffer);
             return false;
@@ -814,7 +814,7 @@ bool AP_Arming::can_checks(bool report)
 {
 #if HAL_WITH_UAVCAN
     if (check_enabled(ARMING_CHECK_SYSTEM)) {
-        char fail_msg[50] = {};
+        char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = {};
         uint8_t num_drivers = AP::can().get_num_drivers();
 
         for (uint8_t i = 0; i < num_drivers; i++) {
@@ -903,7 +903,7 @@ bool AP_Arming::camera_checks(bool display_failure)
         }
 
         // check camera is ready
-        char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+        char fail_msg[MAVLINK_MSG_ID_STATUSTEXT_LEN];
         if (!runcam->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
             check_failed(ARMING_CHECK_CAMERA, display_failure, "%s", fail_msg);
             return false;
@@ -1205,7 +1205,7 @@ bool AP_Arming::visodom_checks(bool display_failure) const
 #if HAL_VISUALODOM_ENABLED
     AP_VisualOdom *visual_odom = AP::visualodom();
     if (visual_odom != nullptr) {
-        char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+        char fail_msg[MAVLINK_MSG_ID_STATUSTEXT_LEN];
         if (!visual_odom->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
             check_failed(ARMING_CHECK_VISION, display_failure, "VisualOdom: %s", fail_msg);
             return false;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -479,7 +479,7 @@ bool AP_BattMonitor::get_cycle_count(uint8_t instance, uint16_t &cycles) const
 
 bool AP_BattMonitor::arming_checks(size_t buflen, char *buffer) const
 {
-    char temp_buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
+    char temp_buffer[MAVLINK_MSG_ID_STATUSTEXT_LEN] {};
 
     for (uint8_t i = 0; i < AP_BATT_MONITOR_MAX_INSTANCES; i++) {
         if (drivers[i] != nullptr && !(drivers[i]->arming_checks(temp_buffer, sizeof(temp_buffer)))) {

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -363,7 +363,7 @@ void AP_BoardConfig::config_error(const char *fmt, ...)
             vprintf(printfmt, arg_list);
             va_end(arg_list);
 #if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN) && !defined(HAL_BUILD_AP_PERIPH)
-            char taggedfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+            char taggedfmt[MAVLINK_MSG_ID_STATUSTEXT_LEN];
             hal.util->snprintf(taggedfmt, sizeof(taggedfmt), "Config error: %s", fmt);
             va_start(arg_list, fmt);
             gcs().send_textv(MAV_SEVERITY_CRITICAL, taggedfmt, arg_list);

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -62,7 +62,7 @@ void AP_Frsky_Telem::setup_passthrough(void)
     if (_frame_string == nullptr) {
         queue_message(MAV_SEVERITY_INFO, AP::fwversion().fw_string);
     } else {
-        char firmware_buf[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+        char firmware_buf[MAVLINK_MSG_ID_STATUSTEXT_LEN];
         snprintf(firmware_buf, sizeof(firmware_buf), "%s %s", AP::fwversion().fw_string, _frame_string);
         queue_message(MAV_SEVERITY_INFO, firmware_buf);
     }

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -160,7 +160,7 @@ void AP_GPS_Backend::_detection_message(char *buffer, const uint8_t buflen) cons
 void AP_GPS_Backend::broadcast_gps_type() const
 {
 #ifndef HAL_NO_GCS
-    char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    char buffer[MAVLINK_MSG_ID_STATUSTEXT_LEN];
     _detection_message(buffer, sizeof(buffer));
     gcs().send_text(MAV_SEVERITY_INFO, "%s", buffer);
 #endif
@@ -169,7 +169,7 @@ void AP_GPS_Backend::broadcast_gps_type() const
 void AP_GPS_Backend::Write_AP_Logger_Log_Startup_messages() const
 {
 #ifndef HAL_NO_LOGGING
-    char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    char buffer[MAVLINK_MSG_ID_STATUSTEXT_LEN];
     _detection_message(buffer, sizeof(buffer));
     AP::logger().Write_Message(buffer);
 #endif

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1769,7 +1769,7 @@ void GCS_MAVLINK::send_ahrs()
 */
 void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t dest_bitmask)
 {
-    char first_piece_of_text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1]{};
+    char first_piece_of_text[MAVLINK_MSG_ID_STATUSTEXT_LEN]{};
 
     do {
         WITH_SEMAPHORE(_statustext_sem);
@@ -2760,7 +2760,7 @@ void GCS_MAVLINK::handle_statustext(const mavlink_message_t &msg)
     mavlink_statustext_t packet;
     mavlink_msg_statustext_decode(&msg, &packet);
     const uint8_t max_prefix_len = 20;
-    const uint8_t text_len = MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1+max_prefix_len;
+    const uint8_t text_len = MAVLINK_MSG_ID_STATUSTEXT_LEN+max_prefix_len;
     char text[text_len] = { 'G','C','S',':'};
     uint8_t offset = strlen(text);
 
@@ -3349,7 +3349,7 @@ void GCS_MAVLINK::send_banner()
     }
 
     // send RC output mode info if available
-    char banner_msg[50];
+    char banner_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN];
     if (hal.rcout->get_output_mode_banner(banner_msg, sizeof(banner_msg))) {
         send_text(MAV_SEVERITY_INFO, "%s", banner_msg);
     }


### PR DESCRIPTION
I learned that the message length and message area of the MAVLink message notification has been defined.
I defined the maximum message length as 50 and the message area as 51.
I think it is better to use this defined name.
I wasn't sure about the number 50.

https://github.com/mavlink/c_library_v1/blob/master/common/mavlink_msg_statustext.h