### PR TITLE
Global: Check if @value field is in increasing order for all parameters

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -53,7 +53,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: SYSID_MYGCS
     // @DisplayName: My ground station number
     // @Description: Allows restricting radio overrides to only come from my ground station
-    // @Values: 255:Mission Planner and DroidPlanner, 252: AP Planner 2
+    // @Range: 1 255
     // @User: Advanced
     GSCALAR(sysid_my_gcs,   "SYSID_MYGCS",     255),
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -29,7 +29,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: CURR_PIN
     // @DisplayName: Battery Current sensing pin
     // @Description: Sets the analog input pin that should be used for current monitoring.
-    // @Values: -1:Disabled, 3:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 14:Pixhawk2_PM2, 15:CubeOrange, 4:CubeOrange_PM2, 17:Durandal, 101:PX4-v1
+    // @Values: -1:Disabled, 3:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 4:CubeOrange_PM2, 14:Pixhawk2_PM2, 15:CubeOrange, 17:Durandal, 101:PX4-v1
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("CURR_PIN", 3, AP_BattMonitor_Params, _curr_pin, AP_BATT_CURR_PIN),


### PR DESCRIPTION
This PR adds a check inside param_metadata to verify @value field for all parameters if the values are in increasing order.
I have fixed all the parameters that did not follow this.
I have also cherry-picked @tatsuy commit from https://github.com/ArduPilot/ardupilot/pull/14256 to confirm that all the checks pass. Before merging this in (and after that PR is merged), I can remove that commit if needed. 
@peterbarker please have a look if possible. Thanks :)