### PR TITLE
GCS_MAVLink: make servicing statustext more efficient

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -890,16 +890,20 @@ public:
 
     struct statustext_t {
         mavlink_statustext_t    msg;
+        uint16_t                entry_created_ms;
         uint8_t                 bitmask;
     };
     class StatusTextQueue : public ObjectArray<statustext_t> {
     public:
         using ObjectArray::ObjectArray;
         HAL_Semaphore &semaphore() { return _sem; }
+        void prune();
     private:
         // a lock for the statustext queue, to make it safe to use send_text()
         // from multiple threads
         HAL_Semaphore _sem;
+
+        uint32_t last_prune_ms;
     };
 
     StatusTextQueue &statustext_queue() {


### PR DESCRIPTION
We should only need to do a single PAYLOAD_SIZE check for each mavlink
backend now.

 - stop iterating over all channels, only do instantiated mavlink
backends
 - if we don't have space for a statustext on a channel, break
immediately and don't do remaining texts
 - resposibility is now on the GCS_MAVLINK backend for sending texts
   - that's a timing change

 - only iterate over entries actually in the queue rather than maximum
queue size
   - it's likely to be the full length anyway as we don't expire things
from the queue and most setups will have full channels