### PR TITLE
Fixed build warnings in SITL

### DIFF
--- a/libraries/AP_Math/tests/test_perpendicular.cpp
+++ b/libraries/AP_Math/tests/test_perpendicular.cpp
@@ -37,7 +37,8 @@
         EXPECT_VECTOR3F_EQ(expected, result);           \
     } while (false)
 
-void foo() { } 
+void foo();
+void foo() { }
 TEST(ThreatTests, Distance)
 {
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -950,6 +950,8 @@ void NavEKF3_core::writeExtNavData(const Vector3f &pos, const Quaternion &quat, 
         extNavMeasTime_ms = timeStamp_ms;
     }
 
+    ext_nav_elements extNavDataNew {};
+
     if (resetTime_ms != extNavLastPosResetTime_ms) {
         extNavDataNew.posReset = true;
         extNavLastPosResetTime_ms = resetTime_ms;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -395,8 +395,7 @@ void NavEKF3_core::InitialiseVariables()
     memset(&yawAngDataDelayed, 0, sizeof(yawAngDataDelayed));
 
     // external nav data fusion
-    memset(&extNavDataNew, 0, sizeof(extNavDataNew));
-    memset(&extNavDataDelayed, 0, sizeof(extNavDataDelayed));
+    extNavDataDelayed = {};
     extNavMeasTime_ms = 0;
     extNavLastPosResetTime_ms = 0;
     lastExtNavPassTime_ms = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1329,7 +1329,6 @@ private:
 
     // external navigation fusion
     obs_ring_buffer_t<ext_nav_elements> storedExtNav; // external navigation data buffer
-    ext_nav_elements extNavDataNew;     // External nav data at the current time horizon
     ext_nav_elements extNavDataDelayed; // External nav at the fusion time horizon
     uint32_t extNavMeasTime_ms;         // time external measurements were accepted for input to the data buffer (msec)
     uint32_t extNavLastPosResetTime_ms; // last time the external nav systen performed a position reset (msec)

--- a/libraries/RC_Channel/examples/RC_UART/RC_UART.cpp
+++ b/libraries/RC_Channel/examples/RC_UART/RC_UART.cpp
@@ -110,7 +110,9 @@ void RC_UART::loop()
             uint16_t rcin[8];
             uint16_t crc;
         } rcin;
-        if (hal.rcin->new_input() && hal.rcin->read(rcin.rcin, 8) == 8) {
+        uint16_t rcval[8];
+        if (hal.rcin->new_input() && hal.rcin->read(rcval, 8) == 8) {
+            memcpy(rcin.rcin, rcval, sizeof(rcval));
             rcin.crc = crc_calculate((uint8_t*)&rcin.rcin[0], 16);
             hal.UART->write((uint8_t*)&rcin, sizeof(rcin));
         }

--- a/tests/AP_gtest.h
+++ b/tests/AP_gtest.h
@@ -1,10 +1,14 @@
 /*
  * Utility header for unit tests with gtest.
  */
+
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #include <gtest/gtest.h>
 
 
 #define AP_GTEST_PRINTATBLE_PARAM_MEMBER(class_name_, printable_member_) \
+::std::ostream& operator<<(::std::ostream& os, const class_name_& param); \
 ::std::ostream& operator<<(::std::ostream& os, const class_name_& param) \
 { \
     return os << param.printable_member_; \


### PR DESCRIPTION
This fixes several build warnings in SITL, bringing us closer to full --Werror support
With these changes sitl builds with g++ 9.3.0 with no warnings, with "./waf all"
