### PR TITLE
Arduplane/Parachute: Little fixings

### DIFF
--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -41,7 +41,7 @@ public:
         // setup parameter defaults
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         if (_singleton != nullptr) {
-            AP_HAL::panic("Rally must be singleton");
+            AP_HAL::panic("Parachute must be singleton");
         }
 #endif
         _singleton = this;


### PR DESCRIPTION
The singleton panic message was saying "rally must be singleton" instead of "parachute must be singleton".

Also, in the function parachute_manual_release() we were setting landing gear position when it gets set before, when calling parachute_release(), so we were calling it two times when the release was manual.