### PR TITLE
AP_Scripting: add support for I2C bus

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -20,6 +20,11 @@
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_HAL/I2CDevice.h>
+
+#ifndef SCRIPTING_MAX_NUM_I2C_DEVICE
+  #define SCRIPTING_MAX_NUM_I2C_DEVICE 4
+#endif
 
 class AP_Scripting
 {
@@ -55,6 +60,10 @@ public:
         SCRIPTS = 1 << 1,
     };
     uint16_t get_disabled_dir() { return uint16_t(_dir_disable.get());}
+
+    // the number of and storage for i2c devices
+    uint8_t num_i2c_devices;
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> *_i2c_dev[SCRIPTING_MAX_NUM_I2C_DEVICE];
 
 private:
 

--- a/libraries/AP_Scripting/examples/i2c_scan.lua
+++ b/libraries/AP_Scripting/examples/i2c_scan.lua
@@ -1,0 +1,27 @@
+-- This script scans for devices on the i2c bus
+local address = 0
+local found = 0
+
+local i2c_bus = i2c.get_device(0,0)
+i2c_bus:set_retries(10)
+
+function update() -- this is the loop which periodically runs
+
+  i2c_bus:set_address(address)
+
+  if i2c_bus:read_registers(0) then
+      gcs:send_text(0, "Found I2C at " .. tostring(address))
+      found = found + 1
+  end
+
+  address = address + 1
+  if address == 127 then
+    address = 0
+    gcs:send_text(0, "Found " .. tostring(found) .. " devices")
+    found = 0
+  end
+
+  return update, 100 -- reschedules the loop
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -329,3 +329,10 @@ singleton AP_MotorsMatrix_6DoF_Scripting depends APM_BUILD_TYPE(APM_BUILD_ArduCo
 singleton AP_MotorsMatrix_6DoF_Scripting alias Motors_6DoF
 singleton AP_MotorsMatrix_6DoF_Scripting method init boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
 singleton AP_MotorsMatrix_6DoF_Scripting method add_motor void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
+
+include AP_HAL/I2CDevice.h
+ap_object AP_HAL::I2CDevice semaphore-pointer
+ap_object AP_HAL::I2CDevice method set_retries void uint8_t 0 20
+ap_object AP_HAL::I2CDevice method write_register boolean uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX
+ap_object AP_HAL::I2CDevice method read_registers boolean uint8_t 0 UINT8_MAX &uint8_t'Null 1'literal
+ap_object AP_HAL::I2CDevice method set_address void uint8_t 0 UINT8_MAX

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -519,6 +519,10 @@ int parse_type(struct type *type, const uint32_t restrictions, enum range_check_
     attribute[0] = 0;
   }
 
+  if ((type->access == ACCESS_REFERENCE) && ((type->flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) == 0)) {
+      error(ERROR_USERDATA, "Only support refences access will 'Null or 'Ref keyword");
+  }
+
   if (strcmp(data_type, keyword_boolean) == 0) {
     type->type = TYPE_BOOLEAN;
   } else if (strcmp(data_type, keyword_float) == 0) {
@@ -1578,7 +1582,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       case TYPE_ENUM:
       case TYPE_USERDATA:
       case TYPE_AP_OBJECT:
-        fprintf(source, "            data_%d", arg_count + ((arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) ? NULLABLE_ARG_COUNT_BASE : 0));
+        fprintf(source, "            %sdata_%d", (arg->type.access == ACCESS_REFERENCE)?"&":"", arg_count + ((arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) ? NULLABLE_ARG_COUNT_BASE : 0));
         break;
       case TYPE_LITERAL:
         fprintf(source, "            %s", arg->type.data.literal);

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -8,6 +8,8 @@
 #include "lua_boxed_numerics.h"
 #include <AP_Scripting/lua_generated_bindings.h>
 
+#include <AP_Scripting/AP_Scripting.h>
+
 extern const AP_HAL::HAL& hal;
 
 int check_arguments(lua_State *L, int expected_arguments, const char *fn_name);
@@ -250,9 +252,72 @@ const luaL_Reg AP_Logger_functions[] = {
     {NULL, NULL}
 };
 
+static int lua_get_i2c_device(lua_State *L) {
+
+    const int args = lua_gettop(L);
+    if (args < 2) {
+        return luaL_argerror(L, args, "require i2c bus and address");
+    }
+    if (args > 4) {
+        return luaL_argerror(L, args, "too many arguments");
+    }
+
+    const lua_Integer bus_in = luaL_checkinteger(L, 1);
+    luaL_argcheck(L, ((bus_in >= 0) && (bus_in <= 4)), 1, "bus out of range");
+    const uint8_t bus = static_cast<uint8_t>(bus_in);
+
+    const lua_Integer address_in = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((address_in >= 0) && (address_in <= 128)), 2, "address out of range");
+    const uint8_t address = static_cast<uint8_t>(address_in);
+
+    // optional arguments, use the same defaults as the hal get_device function
+    uint32_t bus_clock = 400000;
+    bool use_smbus = false;
+
+    if (args > 2) {
+        bus_clock = coerce_to_uint32_t(L, 3);
+
+        if (args > 3) {
+            use_smbus = static_cast<bool>(lua_toboolean(L, 4));
+        }
+    }
+
+    static_assert(SCRIPTING_MAX_NUM_I2C_DEVICE >= 0, "There cannot be a negative number of I2C devices");
+    if (AP::scripting()->num_i2c_devices >= SCRIPTING_MAX_NUM_I2C_DEVICE) {
+        return luaL_argerror(L, 1, "no i2c devices available");;
+    }
+
+    AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] = new AP_HAL::OwnPtr<AP_HAL::I2CDevice>;
+    if (AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] == nullptr) {
+        return luaL_argerror(L, 1, "i2c device nullptr");;
+    }
+
+    *AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] = std::move(hal.i2c_mgr->get_device(bus, address, bus_clock, use_smbus));
+
+    if (AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] == nullptr || AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices]->get() == nullptr) {
+        return luaL_argerror(L, 1, "i2c device nullptr");;
+    }
+
+    new_AP_HAL__I2CDevice(L);
+    *check_AP_HAL__I2CDevice(L, -1) = AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices]->get();
+
+    AP::scripting()->num_i2c_devices++;
+
+    return 1;
+}
+
+const luaL_Reg i2c_functions[] = {
+    {"get_device", lua_get_i2c_device},
+    {NULL, NULL}
+};
+
 void load_lua_bindings(lua_State *L) {
     lua_pushstring(L, "logger");
     luaL_newlib(L, AP_Logger_functions);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "i2c");
+    luaL_newlib(L, i2c_functions);
     lua_settable(L, -3);
 
     luaL_setfuncs(L, global_functions, 0);


### PR DESCRIPTION
This adds support for scripting to access the I2C bus. There is a device scan example that returns the address of any device found and also a 'library' for NAU7805 (sparkfun Qwiic Scale) load cell amplifier. This library is begging for 'requires' support.

I have had to add a new way to access I2C devices without using 'own pointer' (cant say I have a 100% grasp on what 'own pointer' does but I suspect we are using it more than necessary?) 

I have manually edited the generated bindings to get this to work, If the general method is approved of we can either alter the generator or move them to manual bindings. 

This only adds support for reading or writing a single byte at a time, doing more than this is much more complicated, but I think everything can still work like this just might not be the most efficient, but its in scripting anyway so I don't think its a disaster.

Only tested so far with one thing on the bus, will also test AP talking to something else at the same time.
 