### PR TITLE
EKF2/3: fix getLLH when GPS is disabled

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -351,7 +351,11 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
                 // correct for IMU offset (EKF calculations are at the IMU position)
                 loc.lat = EKF_origin.lat;
                 loc.lng = EKF_origin.lng;
-                loc.offset((lastKnownPositionNE.x + posOffsetNED.x), (lastKnownPositionNE.y + posOffsetNED.y));
+                if (PV_AidingMode == AID_NONE) {
+                    loc.offset((lastKnownPositionNE.x + posOffsetNED.x), (lastKnownPositionNE.y + posOffsetNED.y));
+                } else {
+                    loc.offset((outputDataNew.position.x + posOffsetNED.x), (outputDataNew.position.y + posOffsetNED.y));
+                }
                 return false;
             }
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -347,7 +347,11 @@ bool NavEKF3_core::getLLH(struct Location &loc) const
                 // if no GPS fix, provide last known position before entering the mode
                 loc.lat = EKF_origin.lat;
                 loc.lng = EKF_origin.lng;
-                loc.offset(lastKnownPositionNE.x, lastKnownPositionNE.y);
+                if (PV_AidingMode == AID_NONE) {
+                    loc.offset(lastKnownPositionNE.x, lastKnownPositionNE.y);
+                } else {
+                    loc.offset(outputDataNew.position.x, outputDataNew.position.y);
+                }
                 return false;
             }
         }


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/14236 in which the vehicle would momentarily jump back to the origin when the GPS is disabled by setting GPS_TYPE = 0.

The core issue is that lastKnownPositionNE is only set once aiding has stopped ([see code here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp#L334)).  I'm actually not sure that this is the ideal solution, another solution might be to always update the lastKnownPositionNE after fusion is done but I couldn't immediately figure out where to do this because lastKnownPositionNE is also used for position resets.

This has been tested in SITL for both EKF2 and EKF3.  Below is a screen shot of what we see in SITL during the itermediate time after GPS_TYPE = 1 but before aiding has stopped.  Note that after aiding stops the vehicle appears in the same place with or without this change

![before-after](https://user-images.githubusercontent.com/1498098/80930458-a51b8b00-8dee-11ea-9278-378618407daa.png)
