### PR TITLE
AP_NAVEKF3: change plane check_scaler value to match EKF2 value

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -85,7 +85,7 @@
 #define FLOW_MEAS_DELAY         10
 #define FLOW_M_NSE_DEFAULT      0.15f
 #define FLOW_I_GATE_DEFAULT     500
-#define CHECK_SCALER_DEFAULT    100
+#define CHECK_SCALER_DEFAULT    150
 #define FLOW_USE_DEFAULT        2
 
 #else


### PR DESCRIPTION
recent change to EKF highlited that for plane EKF2 consistency checking is a little looser than EKF3....when moving planes with mini gps over to master and EKF3, some take a very long time to settle and pass arming checks (>10min) when it was a minute or so on EKF2...this change to same defaults makes plane GPS warm up behaviour consistent...