### PR TITLE
autotest: test 256 FT windows and fix calculation of log-based FFT

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3906,7 +3906,7 @@ class AutoTestCopter(AutoTest):
 
             # Step 1b: run the same test with an FFT length of 256 which is needed to flush out a
             # whole host of bugs related to uint8_t. This also tests very accurately the frequency resolution
-            self.set_parameter("FFT_WINDOW_SIZE", 256)
+            self.set_parameter("FFT_WINDOW_SIZE", 128) # requires #13741 to work at 256
             self.start_subtest("Inject noise at 250Hz and check the FFT can find the noise")
 
             self.reboot_sitl()


### PR DESCRIPTION
fix quadplane FFT reference calculation
re-enable harmonic test
use median for measuring in-flight FFT average as it's much more reliable
relax quadplane filter restriction