### PR TITLE
Tools: uploader.py: add --boot option for booting board after identify

### DIFF
--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -465,12 +465,16 @@ class uploader(object):
         ret = self.__recv(length)
         self.__getSync()
         return ret
-    
-    # send the reboot command
-    def __reboot(self):
+
+    def reboot(self):
+        '''send the reboot command'''
         self.__send(uploader.REBOOT +
                     uploader.EOC)
         self.port.flush()
+
+    def __reboot(self):
+        '''send reboot command, check for write failures'''
+        self.reboot()
 
         # v3+ can report failure if the first word flash fails
         if self.bl_rev >= 3:
@@ -864,6 +868,7 @@ def main():
     parser.add_argument('--source-component', type=int, action="store", help="Source component to send reboot mavlink packets from", default=0)
     parser.add_argument('--download', action='store_true', default=False, help='download firmware from board')
     parser.add_argument('--identify', action="store_true", help="Do not flash firmware; simply dump information about board")
+    parser.add_argument('--boot', action="store_true", help="use with --identify to boot the board after identification.")
     parser.add_argument('firmware', nargs="?", action="store", default=None, help="Firmware file to be uploaded")
     args = parser.parse_args()
 
@@ -918,6 +923,8 @@ def main():
                     # ok, we have a bootloader, try flashing it
                     if args.identify:
                         up.dump_board_info()
+                        if args.boot:
+                            up.reboot()
                     elif args.download:
                         up.download(args.firmware)
                     else:


### PR DESCRIPTION
Useful if the board is in bootloader mode and you'd like it to boot now.

Ordinarily, `--identify` leaves the board in bootloader mode, so you have to either manually cycle it or flash something to it.

```
pbarker@bluebottle:~/rc/ardupilot(pr/uploader-add-boot-option)$ ./Tools//scripts/uploader.py --identify --boot
If the board does not respond within 1-2 seconds, unplug and re-plug the USB connector.
Found board 9,0 bootloader rev 5 on /dev/serial/by-id/usb-3D_Robotics_PX4_BL_FMU_v2.x_0-if00
Bootloader Protocol: 5
OTP:
  type: ÿÿÿÿ
  idtype: =FF
  vid: ffffffff
  pid: ffffffff
  coa: //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8=
  sn: 003600273435510b38393730
ChipDes:
  family: STM32F42x
  revision: 3
Chip:
  20016419 STM32F42x_43x rev3 (no 1M flaw)
Info:
  flash size: 2080768
  board_type: 9
  board_rev: 0
Identification complete
pbarker@bluebottle:~/rc/ardupilot(pr/uploader-add-boot-option)$ ls -l /dev/serial/by-id/usb-Hex_ProfiCNC_CubeBlack_270036000B51353430373938-if00 
lrwxrwxrwx 1 root root 13 May  6 13:00 /dev/serial/by-id/usb-Hex_ProfiCNC_CubeBlack_270036000B51353430373938-if00 -> ../../ttyACM2
pbarker@bluebottle:~/rc/ardupilot(pr/uploader-add-boot-option)$ 
```
