### PR TITLE
AP_Math: must not error on ROTATION_CUSTOM

### DIFF
--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -252,9 +252,9 @@ void Vector3<T>::rotate(enum Rotation rotation)
         return;
     }
     case ROTATION_CUSTOM: 
-        // Error: caller must perform custom rotations via matrix multiplication
-        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+        // Caller must perform custom rotations via matrix multiplication
         return;
+
     case ROTATION_MAX:
         break;
     }


### PR DESCRIPTION
My PR for custom compass rotation was broken by making CUSTOM_ROTATION an internal error. Currently you get an internal error if you try configuring a compass with CUSTOM_ROTATION. This fixes that.

Sorry @kd0aij ☹️ 