### PR TITLE
Disable EK2 by default on all 1M boards

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -24,7 +24,8 @@
 #include <AP_HAL/AP_HAL.h>
 
 #ifndef HAL_NAVEKF2_AVAILABLE
-#define HAL_NAVEKF2_AVAILABLE 1
+// only default to EK2 enabled on boards with over 1M flash
+#define HAL_NAVEKF2_AVAILABLE (BOARD_FLASH_SIZE>1024)
 #endif
 
 #ifndef HAL_NAVEKF3_AVAILABLE

--- a/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
@@ -155,9 +155,6 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 define HAL_STORAGE_SIZE 15360
 define STORAGE_FLASH_PAGE 1
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 # defaults for battery monitoring
 define HAL_BATT_MONITOR_DEFAULT 4
 define HAL_BATT_VOLT_PIN 11

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/hwdef.dat
@@ -149,9 +149,6 @@ define OSD_ENABLED 1
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 # 8 PWM available by default
 define BOARD_PWM_COUNT_DEFAULT 8
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
@@ -189,8 +189,6 @@ define HAL_BATTMON_FUEL_ENABLE 0
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-define HAL_NAVEKF2_AVAILABLE 0
-
 # reduce max size of embedded params for apj_tool.py
 define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 define HAL_WITH_DSP FALSE

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
@@ -169,8 +169,5 @@ define HAL_BATTMON_FUEL_ENABLE 0
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 # reduce max size of embedded params for apj_tool.py
 define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
@@ -136,9 +136,6 @@ define HAL_OSD_TYPE_DEFAULT 1
 #To complementary channels work we define this
 define STM32_PWM_USE_ADVANCED TRUE
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 define BOARD_PWM_COUNT_DEFAULT 4
 
 #font for the osd

--- a/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
@@ -132,8 +132,5 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 # reduce max size of embedded params for apj_tool.py
 define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/airbotf4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/airbotf4/hwdef.dat
@@ -104,7 +104,4 @@ define HAL_GPIO_A_LED_PIN 57
 #To complementary channels work we define this
 define STM32_PWM_USE_ADVANCED TRUE
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 define BOARD_PWM_COUNT_DEFAULT 6

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
@@ -11,8 +11,5 @@ FLASH_SIZE_KB 1024
 # added to the build
 define HAL_MINIMIZE_FEATURES 1
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 # we don't have a flash page spare to write parameters to:
 undef STORAGE_FLASH_PAGE

--- a/libraries/AP_HAL_ChibiOS/hwdef/mini-pix/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mini-pix/hwdef.dat
@@ -153,6 +153,3 @@ define HAL_GPIO_C_LED_PIN 2
 define HAL_GPIO_LED_ON  0
 define HAL_GPIO_LED_OFF 1
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
@@ -148,7 +148,5 @@ define HAL_BATTMON_FUEL_ENABLE 0
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-define HAL_NAVEKF2_AVAILABLE 0
-
 # reduce max size of embedded params for apj_tool.py
 define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4v6/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4v6/hwdef.dat
@@ -147,9 +147,6 @@ define HAL_GPIO_A_LED_PIN 41
 #To have complementary channels work we define this
 define STM32_PWM_USE_ADVANCED TRUE
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 define BOARD_PWM_COUNT_DEFAULT 6
 
 define OSD_ENABLED 1

--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini/hwdef.dat
@@ -131,9 +131,6 @@ SPIDEV dataflash SPI3 DEVID1 FLASH_CS MODE3 32*MHZ 32*MHZ
 # enable logging to dataflash
 define HAL_LOGGING_DATAFLASH
 
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0
-
 # 8 PWM available by default
 define BOARD_PWM_COUNT_DEFAULT 8
 define HAL_WITH_DSP FALSE

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4/hwdef.dat
@@ -150,6 +150,3 @@ define BOARD_PWM_COUNT_DEFAULT 8
 define OSD_ENABLED 1
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
-
-#eliminate EKF2 to save flash size
-define HAL_NAVEKF2_AVAILABLE 0


### PR DESCRIPTION
This is in response to Pixhawk1-1M not building any more with EK2
