### PR TITLE
Added check for correct system clock on STM32 boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f3_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f3_mcuconf.h
@@ -32,7 +32,7 @@
  * HAL driver system settings.
  */
 #define STM32_NO_INIT                       FALSE
-#define STM32_HSI_ENABLED                   TRUE
+#define STM32_HSI_ENABLED                   FALSE
 #define STM32_LSI_ENABLED                   FALSE
 #define STM32_HSE_ENABLED                   TRUE
 #define STM32_LSE_ENABLED                   FALSE
@@ -42,6 +42,15 @@
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
 #define STM32_PLLXTPRE                      STM32_PLLXTPRE_DIV1
 #define STM32_PLLMUL_VALUE                  9
+#define STM32_PPRE1                         STM32_PPRE1_DIV2
+#define STM32_PPRE2                         STM32_PPRE2_DIV2
+#define STM32_ADCPRE                        STM32_ADCPRE_DIV4
+#define STM32_HPRE                          STM32_HPRE_DIV1
+#elif STM32_HSECLK == 24000000U
+#define STM32_SW                            STM32_SW_PLL
+#define STM32_PLLSRC                        STM32_PLLSRC_HSE
+#define STM32_PLLXTPRE                      STM32_PLLXTPRE_DIV1
+#define STM32_PLLMUL_VALUE                  3
 #define STM32_PPRE1                         STM32_PPRE1_DIV2
 #define STM32_PPRE2                         STM32_PPRE2_DIV2
 #define STM32_ADCPRE                        STM32_ADCPRE_DIV4

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F100xB.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F100xB.py
@@ -30,7 +30,9 @@ mcu = {
     # flags of 2 means faster memory for CPU intensive work
     'RAM_MAP' : [
         (0x20000000, 8, 1), # main memory, DMA safe
-    ]
+    ],
+
+    'EXPECTED_CLOCK' : 24000000
 }
 
 ADC1_map = {

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F103xB.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F103xB.py
@@ -27,7 +27,9 @@ mcu = {
 
     'RAM_MAP' : [
         (0x20000000, 20, 1), # main memory, DMA safe
-    ]
+    ],
+
+    'EXPECTED_CLOCK' : 72000000
 }
 
 ADC1_map = {

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F303xC.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F303xC.py
@@ -21,7 +21,9 @@ mcu = {
     'RAM_MAP' : [
         (0x20000000,  40, 1), # main memory, DMA safe
         (0x10000000,   8, 2), # CCM memory, faster, but not DMA safe
-    ]
+    ],
+
+    'EXPECTED_CLOCK' : 72000000
 }
 
 AltFunction_map = {

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F405xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F405xx.py
@@ -21,7 +21,9 @@ mcu = {
     'RAM_MAP' : [
         (0x20000000, 128, 1), # main memory, DMA safe
         (0x10000000,  64, 2), # CCM memory, faster, but not DMA safe
-    ]
+    ],
+
+    'EXPECTED_CLOCK' : 168000000
 }
 
 AltFunction_map = {

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F427xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F427xx.py
@@ -21,7 +21,9 @@ mcu = {
     'RAM_MAP' : [
         (0x20000000, 192, 1), # main memory, DMA safe
         (0x10000000,  64, 2), # CCM memory, faster, but not DMA safe
-    ]
+    ],
+
+    'EXPECTED_CLOCK' : 168000000
 }
 
 DMA_Map = {

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F745xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F745xx.py
@@ -23,6 +23,8 @@ mcu = {
         (0x20000000,  64, 1), # DTCM memory, DMA safe
     ],
 
+    'EXPECTED_CLOCK' : 216000000,
+
     # this board has M7 instructions, but single precision only FPU
     # we build as m4 as it makes for a smaller build, and given the 1M
     # flash limit we care more about size

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F767xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F767xx.py
@@ -40,6 +40,8 @@ mcu = {
         (0x20010000,  64, 2), # DTCM, 2nd half, used as fast memory. This lowers memory contention in the EKF code
     ],
 
+    'EXPECTED_CLOCK' : 216000000,
+
     # this MCU has M7 instructions and hardware double precision
     'CORTEX'    : 'cortex-m7',
     'CPU_FLAGS' : '-mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F777xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F777xx.py
@@ -37,6 +37,8 @@ mcu = {
         (0x20000000, 128, 1), # DTCM, DMA
     ],
 
+    'EXPECTED_CLOCK' : 216000000,
+
     # this MCU has M7 instructions and hardware double precision
     'CORTEX'    : 'cortex-m7',
     'CPU_FLAGS' : '-mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
@@ -26,6 +26,8 @@ mcu = {
         (0x00000400,  63, 2), # ITCM (first 1k removed, to keep address 0 unused)
     ],
 
+    'EXPECTED_CLOCK' : 400000000,
+
     # this MCU has M7 instructions and hardware double precision
     'CORTEX'    : 'cortex-m7',
     'CPU_FLAGS' : '-mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -727,6 +727,9 @@ def write_mcu_config(f):
         env_vars['CPU_FLAGS'] = ["-mcpu=%s" % cortex, "-mfpu=fpv4-sp-d16", "-mfloat-abi=hard"]
         build_info['MCU'] = cortex
 
+    if get_mcu_config('EXPECTED_CLOCK'):
+        f.write('#define HAL_EXPECTED_SYSCLOCK %u\n' % get_mcu_config('EXPECTED_CLOCK'))
+
     env_vars['CORTEX'] = cortex
 
     if not args.bootloader:

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -32,6 +32,16 @@ static_assert(sizeof(systime_t) == 2, "expected 16 bit systime_t");
 static_assert(sizeof(systime_t) == 4, "expected 32 bit systime_t");
 #endif
 
+#if defined(HAL_EXPECTED_SYSCLOCK)
+#ifdef STM32_SYS_CK
+static_assert(HAL_EXPECTED_SYSCLOCK == STM32_SYS_CK, "unexpected STM32_SYS_CK value");
+#elif defined(STM32_HCLK)
+static_assert(HAL_EXPECTED_SYSCLOCK == STM32_HCLK, "unexpected STM32_HCLK value");
+#else
+#error "unknown system clock"
+#endif
+#endif
+
 extern const AP_HAL::HAL& hal;
 extern "C"
 {


### PR DESCRIPTION
This prevents bad defines from resulting in a slow system clock
Also adds support for 24MHz crystals on F3 boards