### PR TITLE
Tools: Require edn_format again

### DIFF
--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -87,5 +87,5 @@ fi
 pip install --user -U argparse empy pyserial pexpect future lxml
 pip install --user -U intelhex
 pip install --user -U numpy
-pip install --user -U edn_format || true
+pip install --user -U edn_format
 


### PR DESCRIPTION
This was a PIP problem with edn_format which was fixed in https://github.com/swaroopch/edn_format/pull/75 so lets reenable the requirement, as the edn emitter has stricter rules then the others.