### PR TITLE
Prevent internal error from compass custom rotation

### DIFF
--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -221,7 +221,9 @@ public:
     // set overall board orientation
     void set_board_orientation(enum Rotation orientation, Matrix3f* custom_rotation = nullptr) {
         _board_orientation = orientation;
-        _custom_rotation = custom_rotation;
+        if (custom_rotation) {
+            _custom_rotation = custom_rotation;
+        }
     }
 
     /// Set the motor compensation type

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -24,6 +24,7 @@ AP_Compass_SITL::AP_Compass_SITL()
 
                 // save so the compass always comes up configured in SITL
                 save_dev_id(_compass_instance[_num_compass]);
+                set_rotation(instance, ROTATION_NONE);
                 _num_compass++;
             }
         }


### PR DESCRIPTION
Custom rotation didn't work in SITL.

Setting a custom rotation provoked an internal error.