### PR TITLE
Plane: Fix VTOL yaw for STICK_MIXING 0

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1314,7 +1314,11 @@ float QuadPlane::get_pilot_input_yaw_rate_cds(void) const
         return 0;
     }
 
-    if (plane.g.stick_mixing == STICK_MIXING_DISABLED) {
+    if ((plane.g.stick_mixing == STICK_MIXING_DISABLED) &&
+        (plane.control_mode == &plane.mode_qrtl ||
+         plane.control_mode == &plane.mode_guided ||
+         plane.control_mode == &plane.mode_avoidADSB ||
+         in_vtol_auto())) {
         return 0;
     }
 


### PR DESCRIPTION
STICK_MIXING 0 was recently patched to disallow yaw inputs while in quadplane auto modes, however I hadn't realized that the same path was used for modes like `QSTABILIZE` which meant QStab/QLoiter/QLand were all not seeing any pilot commanded yaw. This patch currently takes the blacklist of what modes are not allowed to have pilot input when stick mixing is disabled, but we could invert it to be a whitelist if preferred.

I'll be taking this out and flight testing this today.