### PR TITLE
AP_HAL_ChibiOS: remove pointless initialisations

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -69,14 +69,8 @@ adcsample_t *AnalogIn::samples;
 uint32_t AnalogIn::sample_sum[ADC_GRP1_NUM_CHANNELS];
 uint32_t AnalogIn::sample_count;
 
-AnalogSource::AnalogSource(int16_t pin, float initial_value) :
-    _pin(pin),
-    _value(initial_value),
-    _value_ratiometric(initial_value),
-    _latest_value(initial_value),
-    _sum_count(0),
-    _sum_value(0),
-    _sum_ratiometric(0)
+AnalogSource::AnalogSource(int16_t pin) :
+    _pin(pin)
 {
 }
 
@@ -351,7 +345,7 @@ AP_HAL::AnalogSource* AnalogIn::channel(int16_t pin)
 {
     for (uint8_t j=0; j<ANALOG_MAX_CHANNELS; j++) {
         if (_channels[j] == nullptr) {
-            _channels[j] = new AnalogSource(pin, 0.0f);
+            _channels[j] = new AnalogSource(pin);
             return _channels[j];
         }
     }

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.h
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.h
@@ -29,7 +29,7 @@
 class ChibiOS::AnalogSource : public AP_HAL::AnalogSource {
 public:
     friend class ChibiOS::AnalogIn;
-    AnalogSource(int16_t pin, float initial_value);
+    AnalogSource(int16_t pin);
     float read_average() override;
     float read_latest() override;
     void set_pin(uint8_t p) override;


### PR DESCRIPTION
These are never stack-allocated.

Only saves 16 bytes - but several lines