### PR TITLE
AP_Frsky_Telem: prevent SPort frame fragmentation

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -480,6 +480,7 @@ void  AP_Frsky_Telem::send_sport_frame(uint8_t frame, uint16_t appid, uint32_t d
             buf2[len++] = c;
         }
     }
+#ifndef HAL_BOARD_SITL
     /*
       check that we haven't been too slow in responding to the new
       UART data. If we respond too late then we will overwrite the next
@@ -495,6 +496,7 @@ void  AP_Frsky_Telem::send_sport_frame(uint8_t frame, uint16_t appid, uint32_t d
         // we've been too slow in responding
         return;
     }
+#endif
     _port->write(buf2, len);
 }
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -57,14 +57,16 @@ for FrSky SPort and SPort Passthrough (OpenTX) protocols (X-receivers)
 #define SENSOR_ID_FAS               0x22 // Sensor ID  2
 #define SENSOR_ID_GPS               0x83 // Sensor ID  3
 #define SENSOR_ID_SP2UR             0xC6 // Sensor ID  6
-#define SENSOR_ID_28                0x1B // Sensor ID 28
+#define SENSOR_ID_27                0x1B // Sensor ID 27
 
 // FrSky data IDs
 #define GPS_LONG_LATI_FIRST_ID      0x0800
 #define DIY_FIRST_ID                0x5000
 
-#define START_STOP_SPORT            0x7E
-#define BYTESTUFF_SPORT             0x7D
+#define FRAME_HEAD                  0x7E
+#define FRAME_DLE                   0x7D
+#define FRAME_XOR                   0x20
+
 #define SPORT_DATA_FRAME            0x10
 /* 
 for FrSky SPort Passthrough
@@ -218,11 +220,9 @@ private:
     // tick - main call to send updates to transmitter (called by scheduler at 1kHz)
     void loop(void);
     // methods related to the nuts-and-bolts of sending data
-    void calc_crc(uint8_t byte);
-    void send_crc(void);
     void send_byte(uint8_t value);
     void send_uint16(uint16_t id, uint16_t data);
-    void send_uint32(uint8_t frame, uint16_t id, uint32_t data);
+    void send_sport_frame(uint8_t frame, uint16_t appid, uint32_t data);
 
     // methods to convert flight controller data to FrSky SPort Passthrough (OpenTX) format
     bool get_next_msg_chunk(void) override;


### PR DESCRIPTION
general scheduler delays could introduce small delays when writing SPort frames to the uart one byte
at the time potentially leading to rx desyncs on the SPort bus.
This fix replaces single byte writes with full frame writes.

The library has around 10ms to respond to polling so to guarantee frame integrity responses taking
longer than 7500us are discarded