### PR TITLE
AP_Logger: Process _rotate_pending immediately if we're arming

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2516,6 +2516,11 @@ class AutoTest(ABC):
     def get_parameter(self, name, retry=1, timeout=60):
         """Get parameters from vehicle."""
         for i in range(0, retry):
+            # we call get_parameter while the vehicle is rebooting.
+            # We need to read out the SITL binary's STDOUT or the
+            # process blocks writing to it.
+            if self.sitl is not None:
+                util.pexpect_drain(self.sitl)
             self.mavproxy.send("param fetch %s\n" % name)
             try:
                 self.mavproxy.expect("%s = ([-0-9.]*)\r\n" % (name,), timeout=timeout/retry)

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -1596,12 +1596,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 raise NotAchievedException("Count mismatch (want=%u got=%u)" %
                                            (count, m.count))
 
-    def assert_parameter_value(self, parameter, required):
-        got = self.get_parameter(parameter)
-        if got != required:
-            raise NotAchievedException("%s has unexpected value; want=%f got=%f" %
-                                       (parameter, required, got))
-
     def send_fencepoint_expect_statustext(self, offset, count, lat, lng, statustext_fragment, target_system=1, target_component=1, timeout=10):
         self.mav.mav.fence_point_send(target_system,
                                       target_component,

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -767,6 +767,10 @@ void AP_Logger_File::stop_logging(void)
 
 void AP_Logger_File::PrepForArming()
 {
+    if (_rotate_pending) {
+        _rotate_pending = false;
+        stop_logging();
+    }
     if (logging_started()) {
         return;
     }


### PR DESCRIPTION
Without this we defy the user's `LOG_FILE_DSRMROT` setting.

Also adds new tests for logging.

Some of these tests are commented out until we get https://github.com/ArduPilot/ardupilot/pull/14331 sorted (@tatsuy )
