### PR TITLE
Support SRXL2 listen-only devices

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -52,6 +52,7 @@ public:
     void process_pulse(uint32_t width_s0, uint32_t width_s1);
     void process_pulse_list(const uint32_t *widths, uint16_t n, bool need_swap);
     bool process_byte(uint8_t byte, uint32_t baudrate);
+    void process_handshake(uint32_t baudrate);
     void update(void);
 
     void disable_for_pulses(enum rcprotocol_t protocol) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -28,6 +28,7 @@ public:
     virtual ~AP_RCProtocol_Backend() {}
     virtual void process_pulse(uint32_t width_s0, uint32_t width_s1) {}
     virtual void process_byte(uint8_t byte, uint32_t baudrate) {}
+    virtual void process_handshake(uint32_t baudrate) {}
     uint16_t read(uint8_t chan);
     void read(uint16_t *pwm, uint8_t n);
     bool new_input();
@@ -56,6 +57,10 @@ public:
     // get number of frames, honoring failsafe
     uint32_t get_rc_input_count(void) const {
         return rc_input_count;
+    }
+
+    uint32_t get_rc_protocols_mask(void) const {
+        return frontend.rc_protocols_mask;
     }
 
     // get RSSI

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -29,6 +29,7 @@ public:
     AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend);
     virtual ~AP_RCProtocol_SRXL2();
     void process_byte(uint8_t byte, uint32_t baudrate) override;
+    void process_handshake(uint32_t baudrate) override;
     void start_bind(void) override;
     void update(void) override;
     // get singleton instance
@@ -53,20 +54,26 @@ private:
     void _send_on_uart(uint8_t* pBuffer, uint8_t length);
     void _change_baud_rate(uint32_t baudrate);
     void _capture_scaled_input(const uint8_t *values_p, bool in_failsafe, int16_t rssi);
+    void _bootstrap(uint8_t device_id);
+    bool is_bootstrapped() const { return _device_id != 0; }
 
     uint8_t _buffer[SRXL2_FRAMELEN_MAX];       /* buffer for raw srxl frame data in correct order --> buffer[0]=byte0  buffer[1]=byte1  */
     uint8_t _buflen;                          /* length in number of bytes of received srxl dataframe in buffer  */
     uint32_t _last_run_ms;                    // last time the state machine was run
-    uint16_t _channels[SRXL2_MAX_CHANNELS] = {0};    /* buffer for extracted RC channel data as pulsewidth in microseconds */
+    uint16_t _channels[SRXL2_MAX_CHANNELS];    /* buffer for extracted RC channel data as pulsewidth in microseconds */
+    bool _in_bootstrap_or_failsafe;         // controls whether we allow UART sends outside a receive time constraint
+    uint8_t _device_id;
 
     enum {
         STATE_IDLE,                          /* do nothing */
         STATE_NEW,                           /* get header of frame + prepare for frame reception */
         STATE_COLLECT                        /* collect RC channel data from frame */
     };
-    uint8_t _frame_len_full = 0U;                 /* Length in number of bytes of full srxl datastream */
-    uint8_t _decode_state = STATE_IDLE;           /* Current state of SRXL frame decoding */
-    uint8_t _decode_state_next = STATE_IDLE;      /* State of frame decoding that will be applied when the next byte from dataframe drops in  */
+    uint8_t _frame_len_full;                 /* Length in number of bytes of full srxl datastream */
+    uint8_t _decode_state;           /* Current state of SRXL frame decoding */
+    uint8_t _decode_state_next;      /* State of frame decoding that will be applied when the next byte from dataframe drops in  */
     bool _in_failsafe = false;
     int16_t _new_rssi = -1;
+    uint32_t _last_handshake_ms;
+    uint32_t _handshake_start_ms;
 };

--- a/libraries/AP_RCProtocol/spm_srxl_config.h
+++ b/libraries/AP_RCProtocol/spm_srxl_config.h
@@ -50,6 +50,7 @@ extern "C++" {
 //    VTX = 0x81
 // NOTE: This value is not used internally -- it is passed as a parameter to srxlInit() in the example app
 #define SRXL_DEVICE_ID              0x31
+#define SRXL_DEVICE_ID_BASE_RX      0x30
 
 // Set this to the desired priority level for sending telemetry, ranging from 0 to 100.
 // Generally, this number should be 10 times the number of different telemetry packets to regularly send.


### PR DESCRIPTION
Certain SRXL2 RXs (e.g. AR620) are "listen-only" - they require the flight controller to initiate a handshake in order to switch to SRXL2 mode. This requires that we send data on the UART even if we have not decoded SRXL2 (recently).

Furthermore, the switch to "SRXL2 mode" must be initiated within 200ms of the transmitter being active, otherwise the RX will fall back to PWM.

This PR introduces a "handshake" uart step to the AP_RCProtocol detector, that can be used to initiate this protocol. This is only initiated if RC_OPTIONS bit 8 is set. It is not possible to make this auto-detect in the same way as the time spent reading for other protocols can cause the bootstrap to fail.

This has been tested on an AR620 and SPM4651T