### PR TITLE
Allow range finder to be used

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -85,7 +85,7 @@ void NavEKF2_core::EstimateTerrainOffset()
 
     // don't fuse flow data if LOS rate is misaligned, without GPS, or insufficient velocity, as it is poorly observable
     // don't fuse flow data if it exceeds validity limits
-    // don't update terrain offset if grpund is being used as the zero height datum in the main filter
+    // don't update terrain offset if ground is being used as the zero height datum in the main filter
     bool cantFuseFlowData = ((frontend->_flowUse != FLOW_USE_TERRAIN)
     || gpsNotAvailable 
     || PV_AidingMode == AID_RELATIVE 
@@ -159,9 +159,7 @@ void NavEKF2_core::EstimateTerrainOffset()
 
             }
         }
-
         if (!cantFuseFlowData) {
-
             Vector3f relVelSensor;          // velocity of sensor relative to ground in sensor axes
             Vector2f losPred;               // predicted optical flow angular rate measurement
             float q0 = stateStruct.quat[0]; // quaternion at optical flow measurement time

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -942,7 +942,7 @@ void NavEKF2_core::selectHeightForFusion()
     if (extNavUsedForPos) {
         // always use external vision as the height source if using for position.
         activeHgtSource = HGT_SOURCE_EXTNAV;
-    } else if (_rng && ((frontend->_useRngSwHgt > 0) && (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
+    } else if (_rng && (frontend->_useRngSwHgt > 0 || frontend->_altSource == 1) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
         if (frontend->_altSource == 1) {
             // always use range finder
             activeHgtSource = HGT_SOURCE_RNG;
@@ -1031,6 +1031,7 @@ void NavEKF2_core::selectHeightForFusion()
             hgtMea  = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd);
             // correct for terrain position relative to datum
             hgtMea -= terrainState;
+
             // enable fusion
             fuseHgtData = true;
             velPosObs[5] = -hgtMea;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -932,7 +932,7 @@ void NavEKF3_core::selectHeightForFusion()
     if (extNavUsedForPos && (frontend->_altSource == 4)) {
         // always use external navigation as the height source if using for position.
         activeHgtSource = HGT_SOURCE_EXTNAV;
-    } else if (_rng && ((frontend->_useRngSwHgt > 0) && (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
+    } else if (_rng && ((frontend->_useRngSwHgt > 0) || (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
         if (frontend->_altSource == 1) {
             // always use range finder
             activeHgtSource = HGT_SOURCE_RNG;


### PR DESCRIPTION
Currently ```EK2_RNG_USE_HGT``` will not use the rangefinder for height calculations - we always use the barometer. This change re-enables the use of the rangefinder close to the ground.

This fix survives @rmackay9 's test in https://github.com/ArduPilot/ardupilot/pull/12250