### PR TITLE
AP_GPS: Remove unprocessed SBP messages

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -208,11 +208,6 @@ AP_GPS_SBP::_sbp_process_message() {
             check_new_itow(last_dops.tow, parser_state.msg_len);
             break;
 
-        case SBP_TRACKING_STATE_MSGTYPE:
-            //INTENTIONALLY BLANK
-            //Currently unhandled, but logged after switch statement.
-            break;
-
         case SBP_IAR_STATE_MSGTYPE: {
             sbp_iar_state_t *iar = (struct sbp_iar_state_t*)parser_state.msg_buff;
             last_iar_num_hypotheses = iar->num_hypotheses;

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -68,17 +68,11 @@ private:
     static const uint8_t SBP_PREAMBLE = 0x55;
 
     //Message types supported by this driver
-    static const uint16_t SBP_STARTUP_MSGTYPE        = 0xFF00;
     static const uint16_t SBP_HEARTBEAT_MSGTYPE      = 0xFFFF;
     static const uint16_t SBP_GPS_TIME_MSGTYPE       = 0x0100;
     static const uint16_t SBP_DOPS_MSGTYPE           = 0x0206;
-    static const uint16_t SBP_POS_ECEF_MSGTYPE       = 0x0200;
     static const uint16_t SBP_POS_LLH_MSGTYPE        = 0x0201;
-    static const uint16_t SBP_BASELINE_ECEF_MSGTYPE  = 0x0202;
-    static const uint16_t SBP_BASELINE_NED_MSGTYPE   = 0x0203;
-    static const uint16_t SBP_VEL_ECEF_MSGTYPE       = 0x0204;
     static const uint16_t SBP_VEL_NED_MSGTYPE        = 0x0205;
-    static const uint16_t SBP_TRACKING_STATE_MSGTYPE = 0x0016;
     static const uint16_t SBP_IAR_STATE_MSGTYPE      = 0x0019;
 
     // Heartbeat
@@ -137,13 +131,6 @@ private:
         uint8_t n_sats;        //< Number of satellites used in solution
         uint8_t flags;         //< Status flags (reserved)
     }; // 22 bytes
-
-    // Activity and Signal-to-Noise data of a tracking channel on the GPS.
-    struct PACKED sbp_tracking_state_t {
-        uint8_t state;         //< 0 if disabled, 1 if running
-        uint8_t prn;           //< PRN identifier of tracked satellite
-        float cn0;             //< carrier to noise power ratio.
-    };
 
     // Integer Ambiguity Resolution state - how is the RTK resolution doing?
     struct PACKED sbp_iar_state_t {

--- a/libraries/AP_GPS/AP_GPS_SBP2.h
+++ b/libraries/AP_GPS/AP_GPS_SBP2.h
@@ -66,18 +66,11 @@ private:
     static const uint8_t SBP_PREAMBLE = 0x55;
 
     // Message types supported by this driver
-    static const uint16_t SBP_STARTUP_MSGTYPE        = 0xFF00;
     static const uint16_t SBP_HEARTBEAT_MSGTYPE      = 0xFFFF;
     static const uint16_t SBP_GPS_TIME_MSGTYPE       = 0x0102;
     static const uint16_t SBP_DOPS_MSGTYPE           = 0x0208;
-    static const uint16_t SBP_POS_ECEF_MSGTYPE       = 0x0209;
     static const uint16_t SBP_POS_LLH_MSGTYPE        = 0x020A;
-    static const uint16_t SBP_BASELINE_ECEF_MSGTYPE  = 0x020B;
-    static const uint16_t SBP_BASELINE_NED_MSGTYPE   = 0x020C;
-    static const uint16_t SBP_VEL_ECEF_MSGTYPE       = 0x020D;
     static const uint16_t SBP_VEL_NED_MSGTYPE        = 0x020E;
-    static const uint16_t SBP_TRACKING_STATE_MSGTYPE = 0x0013;
-    static const uint16_t SBP_IAR_STATE_MSGTYPE      = 0x0019;
     static const uint16_t SBP_EXT_EVENT_MSGTYPE      = 0x0101;
 
     // Heartbeat


### PR DESCRIPTION
The SBP drivers define a bunch of messages, but some of those messages are never handled. These unprocessed messages have been removed. This shouldn't affect functionality at all. It has been tested with a Rover build on a Pixhawk 4. Behavior is identical before and after the change.

Note that all messages are still logged regardless of whether or not they are recognized.