### PR TITLE
AP_NavEKF3: ensure extnav angle error is at least 5deg

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -978,7 +978,10 @@ void NavEKF3_core::writeExtNavData(const Vector3f &pos, const Quaternion &quat, 
     // extract yaw from the attitude
     float roll_rad, pitch_rad, yaw_rad;
     quat.to_euler(roll_rad, pitch_rad, yaw_rad);
-    writeEulerYawAngle(yaw_rad, angErr, timeStamp_ms, 2);
+
+    // ensure yaw accuracy is no better than 5 degrees (some callers may send zero)
+    const float yaw_accuracy_rad = MAX(angErr, radians(5.0f));
+    writeEulerYawAngle(yaw_rad, yaw_accuracy_rad, timeStamp_ms, 2);
 
     storedExtNav.push(extNavDataNew);
 }


### PR DESCRIPTION
This PR ensures that when external nav is used as the yaw source, the minimum angle error is 5deg.  This minimum error was taken from the "moving baseline" code (aka GPS for yaw) but I'm very happy to change this to a different value if there are better suggestions.  Alternatively we could only apply this minimum if the incoming angle error is zero (or negative).

This change resolves two issues:

- The EKF was ignoring changes in the external nav yaw.  I.e. if the external nav's yaw changed the EKF's estimate would not follow it
- The EKF's attitude and position estimate could become wildly inaccurate after large changes in the external nav yaw (see issue https://github.com/ArduPilot/ardupilot/issues/14356)

This has been tested in SITL (using PR https://github.com/ArduPilot/ardupilot/pull/14357) by introducing a sudden external yaw change of 45 degrees.  Below are screen shots before and after.  

In the Before image we see the external yaw (in red) is adjusted up by 45deg.  The EKF yaw estimate jumps to match it but the position estimate (shown in orange and blue) moves by over 60m.  The yaw estimate (in green) also eventually becomes unstable.

In the After image we see the expected behaviour.  After the external yaw (in red) jump, the EKF's estimate (in green) moves towards it.  The position changes are also just a few cm (scale is on the right).
![ekf3-yaw-fix-before-after](https://user-images.githubusercontent.com/1498098/81802043-54bfce00-9550-11ea-921e-406922d77f1d.png)

