### PR TITLE
Tools: improve compass calibration testing

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5068,6 +5068,10 @@ class AutoTestCopter(AutoTest):
              "Fly Gyro FFT Harmonic Matching",
              self.fly_gyro_fft_harmonic),
 
+            ("SITLCompassCalibration",
+             "Test SITL onboard compass calibration",
+             self.test_mag_calibration),
+
             ("LogDownLoad",
              "Log download",
              lambda: self.log_download(

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2684,12 +2684,11 @@ class AutoTest(ABC):
                                                              m.result))
                 break
 
-    def verify_parameter_values(self, parameter_stuff):
+    def verify_parameter_values(self, parameter_stuff, max_delta=0.0):
         bad = ""
         for param in parameter_stuff:
             fetched_value = self.get_parameter(param)
             wanted_value = parameter_stuff[param]
-            max_delta = 0.0
             if type(wanted_value) == tuple:
                 max_delta = wanted_value[1]
                 wanted_value = wanted_value[0]

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2251,6 +2251,33 @@ class AutoTest(ABC):
                      0,
                      timeout=timeout)
 
+    def try_arm(self, result=True, expect_msg=None, timeout=60):
+        """Send Arming command, wait for the expected result and statustext."""
+        self.progress("Try arming and wait for expected result")
+        self.drain_mav()
+        self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                     1,  # ARM
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED if result else mavutil.mavlink.MAV_RESULT_FAILED,
+                     timeout=timeout)
+        if expect_msg is not None:
+            self.wait_statustext(expect_msg, timeout=timeout, the_function=lambda: self.send_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                                                                                                 1,  # ARM
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 0,
+                                                                                                 target_sysid=None,
+                                                                                                 target_compid=None,
+                                                                                                 ))
+
     def arm_vehicle(self, timeout=20):
         """Arm vehicle with mavlink arm message."""
         self.progress("Arm motors with MAVLink cmd")

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3987,14 +3987,417 @@ class AutoTest(ABC):
             self.disarm_vehicle(force=True)
         self.reboot_sitl()
 
+    def zero_mag_offset_parameters(self, compass_count=3):
+        self.progress("Zeroing Mag OFS parameters")
+        self.drain_mav()
+        self.get_sim_time()
+        self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
+                     2, # param1 (compass0)
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0 # param7
+                     )
+        self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
+                     5, # param1 (compass1)
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0 # param7
+                     )
+        self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
+                     6, # param1 (compass2)
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0 # param7
+                     )
+        self.progress("zeroed mag parameters")
+        params = [
+            [("SIM_MAG_OFS_X", "COMPASS_OFS_X", 0),
+             ("SIM_MAG_OFS_Y", "COMPASS_OFS_Y", 0),
+             ("SIM_MAG_OFS_Z", "COMPASS_OFS_Z", 0), ],
+        ]
+        for count in range(2, compass_count + 1):
+            params += [
+                [("SIM_MAG%d_OFS_X" % count, "COMPASS_OFS%d_X" % count, 0),
+                 ("SIM_MAG%d_OFS_Y" % count, "COMPASS_OFS%d_Y" % count, 0),
+                 ("SIM_MAG%d_OFS_Z" % count, "COMPASS_OFS%d_Z" % count, 0), ],
+                ]
+        self.check_zero_mag_parameters(params)
+
+    def forty_two_mag_dia_odi_parameters(self, compass_count=3):
+        self.progress("Forty twoing Mag DIA and ODI parameters")
+        self.drain_mav()
+        self.get_sim_time()
+        params = [
+            [("SIM_MAG_DIA_X", "COMPASS_DIA_X", 42.0),
+             ("SIM_MAG_DIA_Y", "COMPASS_DIA_Y", 42.0),
+             ("SIM_MAG_DIA_Z", "COMPASS_DIA_Z", 42.0),
+             ("SIM_MAG_ODI_X", "COMPASS_ODI_X", 42.0),
+             ("SIM_MAG_ODI_Y", "COMPASS_ODI_Y", 42.0),
+             ("SIM_MAG_ODI_Z", "COMPASS_ODI_Z", 42.0), ],
+        ]
+        for count in range(2, compass_count + 1):
+            params += [
+                [("SIM_MAG%d_DIA_X" % count, "COMPASS_DIA%d_X" % count, 42.0),
+                 ("SIM_MAG%d_DIA_Y" % count, "COMPASS_DIA%d_Y" % count, 42.0),
+                 ("SIM_MAG%d_DIA_Z" % count, "COMPASS_DIA%d_Z" % count, 42.0),
+                 ("SIM_MAG%d_ODI_X" % count, "COMPASS_ODI%d_X" % count, 42.0),
+                 ("SIM_MAG%d_ODI_Y" % count, "COMPASS_ODI%d_Y" % count, 42.0),
+                 ("SIM_MAG%d_ODI_Z" % count, "COMPASS_ODI%d_Z" % count, 42.0), ],
+            ]
+        self.wait_heartbeat()
+        for param_set in params:
+            for param in param_set:
+                (_, _out, value) = param
+                self.set_parameter(_out, value)
+        self.check_zero_mag_parameters(params)
+
+    def check_mag_parameters(self, parameter_stuff, compass_number):
+        self.progress("Checking that Mag parameter")
+        for idx in range(0, compass_number, 1):
+            for param in parameter_stuff[idx]:
+                (_in, _out, value) = param
+                got_value = self.get_parameter(_out)
+                if abs(got_value - value) > abs(value) * 0.15:
+                    raise NotAchievedException("%s/%s not within 15%%; got %f want=%f" % (_in, _out, got_value, value))
+
+    def check_zero_mag_parameters(self, parameter_stuff):
+        self.progress("Checking that Mag OFS are zero")
+        for param_set in parameter_stuff:
+            for param in param_set:
+                (_in, _out, _) = param
+                got_value = self.get_parameter(_out)
+                max = 0.15
+                if "DIA" in _out or "ODI" in _out:
+                    max += 42.0
+                if abs(got_value) > max:
+                    raise NotAchievedException("%s/%s not within 15%%; got %f want=%f" % (_in, _out, got_value, 0.0 if max > 1 else 42.0))
+
+    def check_zeros_mag_orient(self, compass_count=3):
+        self.progress("zeroed mag parameters")
+        self.verify_parameter_values({"COMPASS_ORIENT": 0})
+        for count in range(2, compass_count + 1):
+            self.verify_parameter_values({"COMPASS_ORIENT%d" % count: 0})
+
+    def test_mag_calibration(self, compass_count=3, timeout=500):
+        ex = None
+        self.set_parameter("AHRS_EKF_TYPE", 10)
+        self.set_parameter("SIM_GND_BEHAV", 0)
+
+        def reset_pos_and_start_magcal(tmask):
+            self.mavproxy.send("sitl_stop\n")
+            self.mavproxy.send("sitl_attitude 0 0 0\n")
+            self.drain_mav()
+            self.get_sim_time()
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+                         tmask, # p1: mag_mask
+                         0, # p2: retry
+                         0, # p3: autosave
+                         0, # p4: delay
+                         0, # param5
+                         0, # param6
+                         0, # param7
+                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                         timeout=20,
+                         )
+            self.mavproxy.send("sitl_magcal\n")
+
+        def do_prep_mag_cal_test(params):
+            self.progress("Preparing the vehicle for magcal")
+            MAG_OFS = 100
+            MAG_DIA = 1.0
+            MAG_ODI = 0.004
+            params += [
+                [("SIM_MAG_OFS_X", "COMPASS_OFS_X", MAG_OFS),
+                 ("SIM_MAG_OFS_Y", "COMPASS_OFS_Y", MAG_OFS + 100),
+                 ("SIM_MAG_OFS_Z", "COMPASS_OFS_Z", MAG_OFS + 200),
+                 ("SIM_MAG_DIA_X", "COMPASS_DIA_X", MAG_DIA),
+                 ("SIM_MAG_DIA_Y", "COMPASS_DIA_Y", MAG_DIA + 0.1),
+                 ("SIM_MAG_DIA_Z", "COMPASS_DIA_Z", MAG_DIA + 0.2),
+                 ("SIM_MAG_ODI_X", "COMPASS_ODI_X", MAG_ODI),
+                 ("SIM_MAG_ODI_Y", "COMPASS_ODI_Y", MAG_ODI + 0.001),
+                 ("SIM_MAG_ODI_Z", "COMPASS_ODI_Z", MAG_ODI + 0.001), ],
+            ]
+            for count in range(2, compass_count + 1):
+                params += [
+                    [("SIM_MAG%d_OFS_X" % count, "COMPASS_OFS%d_X" % count, MAG_OFS + 100 * ((count+2) % compass_count)),
+                     ("SIM_MAG%d_OFS_Y" % count, "COMPASS_OFS%d_Y" % count, MAG_OFS + 100 * ((count+3) % compass_count)),
+                     ("SIM_MAG%d_OFS_Z" % count, "COMPASS_OFS%d_Z" % count, MAG_OFS + 100 * ((count+1) % compass_count)),
+                     ("SIM_MAG%d_DIA_X" % count, "COMPASS_DIA%d_X" % count, MAG_DIA + 0.1 * ((count+2) % compass_count)),
+                     ("SIM_MAG%d_DIA_Y" % count, "COMPASS_DIA%d_Y" % count, MAG_DIA + 0.1 * ((count+3) % compass_count)),
+                     ("SIM_MAG%d_DIA_Z" % count, "COMPASS_DIA%d_Z" % count, MAG_DIA + 0.1 * ((count+1) % compass_count)),
+                     ("SIM_MAG%d_ODI_X" % count, "COMPASS_ODI%d_X" % count, MAG_ODI + 0.001 * ((count+2) % compass_count)),
+                     ("SIM_MAG%d_ODI_Y" % count, "COMPASS_ODI%d_Y" % count, MAG_ODI + 0.001 * ((count+3) % compass_count)),
+                     ("SIM_MAG%d_ODI_Z" % count, "COMPASS_ODI%d_Z" % count, MAG_ODI + 0.001 * ((count+1) % compass_count)), ],
+                ]
+            self.progress("Setting calibration mode")
+            self.wait_heartbeat()
+            self.customise_SITL_commandline(["-M", "calibration"])
+            self.mavproxy_load_module("sitl_calibration")
+            self.mavproxy_load_module("calibration")
+            self.mavproxy_load_module("relay")
+            self.mavproxy.expect("is using GPS")
+            self.mavproxy.send("accelcalsimple\n")
+            self.mavproxy.expect("Calibrated")
+            # disable it to not interfert with calibration acceptation
+            self.mavproxy_unload_module("calibration")
+            if self.is_copter():
+                # set frame class to pass arming check on copter
+                self.set_parameter("FRAME_CLASS", 1)
+            self.drain_mav()
+            self.progress("Setting SITL Magnetometer model value")
+            MAG_ORIENT = 4
+            self.set_parameter("SIM_MAG_ORIENT", MAG_ORIENT)
+            for count in range(2, compass_count + 1):
+                self.set_parameter("SIM_MAG%d_ORIENT" % count, MAG_ORIENT * (count % 41))
+                # set compass external to check that orientation is found and auto set
+                self.set_parameter("COMPASS_EXTERN%d" % count, 1)
+            for param_set in params:
+                for param in param_set:
+                    (_in, _out, value) = param
+                    self.set_parameter(_in, value)
+                    self.set_parameter(_out, value)
+            self.start_subtest("Zeroing Mag OFS parameters with Mavlink")
+            self.zero_mag_offset_parameters()
+            self.progress("=========================================")
+            # Change the default value to unexpected 42
+            self.forty_two_mag_dia_odi_parameters()
+            self.progress("Zeroing Mags orientations")
+            self.set_parameter("COMPASS_ORIENT", 0)
+            for count in range(2, compass_count + 1):
+                self.set_parameter("COMPASS_ORIENT%d" % count, 0)
+
+            # Only care about compass prearm
+            self.set_parameter("ARMING_CHECK", 4)
+
+        #################################################
+        def do_test_mag_cal(params, compass_tnumber):
+            self.start_subtest("Try magcal and make it stop around 30%")
+            self.progress("Compass mask is %s" % "{0:b}".format(target_mask))
+            reset_pos_and_start_magcal(target_mask)
+            tstart = self.get_sim_time()
+            reached_pct = [0] * compass_tnumber
+            tstop = None
+            while True:
+                if self.get_sim_time_cached() - tstart > timeout:
+                    raise NotAchievedException("Cannot receive enough MAG_CAL_PROGRESS")
+                m = self.mav.recv_match(type='MAG_CAL_PROGRESS', blocking=True, timeout=5)
+                if m is None:
+                    if tstop is not None:
+                        # wait 3 second to unsure that the calibration is well stopped
+                        if self.get_sim_time_cached() - tstop > 10:
+                            if reached_pct[0] > 33:
+                                raise NotAchievedException("Mag calibration didn't stop")
+                            else:
+                                break
+                        else:
+                            continue
+                    else:
+                        continue
+                if m is not None:
+                    cid = m.compass_id
+                    new_pct = int(m.completion_pct)
+                    if new_pct != reached_pct[cid]:
+                        if new_pct < reached_pct[cid]:
+                            raise NotAchievedException("Mag calibration restart when it shouldn't")
+                        reached_pct[cid] = new_pct
+                        self.progress("Calibration progress compass ID %d: %s" % (cid, str(reached_pct[cid])))
+                        if cid == 0 and 13 <= reached_pct[0] <= 15:
+                            self.progress("Request again to start calibration, it shouldn't restart from 0")
+                            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+                                         target_mask,
+                                         0,
+                                         0,
+                                         0,
+                                         0,
+                                         0,
+                                         0,
+                                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                                         timeout=20,
+                                         )
+
+                if reached_pct[0] > 30:
+                    self.run_cmd(mavutil.mavlink.MAV_CMD_DO_CANCEL_MAG_CAL,
+                                 target_mask,  # p1: mag_mask
+                                 0,  # param2
+                                 0,  # param3
+                                 0,  # param4
+                                 0,  # param5
+                                 0,  # param6
+                                 0,  # param7
+                                 want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                                 )
+                    if tstop is None:
+                        tstop = self.get_sim_time_cached()
+                if tstop is not None:
+                    # wait 3 second to unsure that the calibration is well stopped
+                    if self.get_sim_time_cached() - tstop > 3:
+                        raise NotAchievedException("Mag calibration didn't stop")
+            self.check_zero_mag_parameters(params)
+            self.check_zeros_mag_orient()
+
+            #################################################
+            self.start_subtest("Try magcal and make it failed")
+            self.progress("Compass mask is %s" % "{0:b}".format(target_mask))
+            old_cal_fit = self.get_parameter("COMPASS_CAL_FIT")
+            self.set_parameter("COMPASS_CAL_FIT", 0.001, add_to_context=False)
+            reset_pos_and_start_magcal(target_mask)
+            tstart = self.get_sim_time()
+            reached_pct = [0] * compass_tnumber
+            report_get = [0] * compass_tnumber
+            while True:
+                if self.get_sim_time_cached() - tstart > timeout:
+                    raise NotAchievedException("Cannot receive enough MAG_CAL_PROGRESS")
+                m = self.mav.recv_match(type=["MAG_CAL_PROGRESS", "MAG_CAL_REPORT"], blocking=True, timeout=5)
+                if m.get_type() == "MAG_CAL_REPORT":
+                    if report_get[m.compass_id] == 0:
+                        self.progress("Report: %s" % str(m))
+                        if m.cal_status == mavutil.mavlink.MAG_CAL_FAILED:
+                            report_get[m.compass_id] = 1
+                        else:
+                            raise NotAchievedException("Mag calibration didn't failed")
+                    if all(ele >= 1 for ele in report_get):
+                        self.progress("All Mag report failure")
+                        break
+                if m is not None and m.get_type() == "MAG_CAL_PROGRESS":
+                    cid = m.compass_id
+                    new_pct = int(m.completion_pct)
+                    if new_pct != reached_pct[cid]:
+                        reached_pct[cid] = new_pct
+                        self.progress("Calibration progress compass ID %d: %s" % (cid, str(reached_pct[cid])))
+                        if cid == 0 and 49 <= reached_pct[0] <= 50:
+                            self.progress("Try arming during calibration, should failed")
+                            self.try_arm(False, "Compass calibration running")
+
+            self.check_zero_mag_parameters(params)
+            self.check_zeros_mag_orient()
+            self.set_parameter("COMPASS_CAL_FIT", old_cal_fit, add_to_context=False)
+
+            #################################################
+            self.start_subtest("Try magcal and wait success")
+            self.progress("Compass mask is %s" % "{0:b}".format(target_mask))
+            reset_pos_and_start_magcal(target_mask)
+            reached_pct = [0] * compass_tnumber
+            report_get = [0] * compass_tnumber
+            tstart = self.get_sim_time()
+            while True:
+                if self.get_sim_time_cached() - tstart > timeout:
+                    raise NotAchievedException("Cannot receive enough MAG_CAL_PROGRESS")
+                m = self.mav.recv_match(type=["MAG_CAL_PROGRESS", "MAG_CAL_REPORT"], blocking=True, timeout=5)
+                if m.get_type() == "MAG_CAL_REPORT":
+                    if report_get[m.compass_id] == 0:
+                        self.progress("Report: %s" % str(m))
+                        if m.cal_status == mavutil.mavlink.MAG_CAL_SUCCESS:
+                            if reached_pct[m.compass_id] < 99:
+                                raise NotAchievedException("Mag calibration report SUCCESS without 100%% completion")
+                            report_get[m.compass_id] = 1
+                        else:
+                            raise NotAchievedException("Mag calibration didn't SUCCESS")
+                    if all(ele >= 1 for ele in report_get):
+                        self.progress("All Mag report SUCCESS")
+                        break
+                if m is not None and m.get_type() == "MAG_CAL_PROGRESS":
+                    cid = m.compass_id
+                    new_pct = int(m.completion_pct)
+                    if new_pct != reached_pct[cid]:
+                        reached_pct[cid] = new_pct
+                        self.progress("Calibration progress compass ID %d: %s" % (cid, str(reached_pct[cid])))
+            self.mavproxy.send("sitl_stop\n")
+            self.mavproxy.send("sitl_attitude 0 0 0\n")
+            self.progress("Checking that value aren't changed without acceptation")
+            self.check_zero_mag_parameters(params)
+            self.check_zeros_mag_orient()
+            self.progress("Send acceptation and check value")
+            self.wait_heartbeat()
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_ACCEPT_MAG_CAL,
+                         target_mask, # p1: mag_mask
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                         timeout=20,
+                         )
+            self.check_mag_parameters(params, compass_tnumber)
+            self.verify_parameter_values({"COMPASS_ORIENT": self.get_parameter("SIM_MAG_ORIENT")})
+            for count in range(2, compass_tnumber + 1):
+                self.verify_parameter_values({"COMPASS_ORIENT%d" % count: self.get_parameter("SIM_MAG%d_ORIENT" % count)})
+            self.try_arm(False, "Compass calibrated requires reboot")
+
+            # test buzzer/notify ?
+            self.progress("Rebooting and making sure we could arm with these values")
+            self.drain_mav()
+            self.reboot_sitl()
+            self.wait_ready_to_arm(timeout=60)
+            self.progress("Setting manually the parameter for other sensor to avoid compass consistency error")
+            for idx in range(compass_tnumber, compass_count, 1):
+                for param in params[idx]:
+                    (_in, _out, value) = param
+                    self.set_parameter(_out, value)
+            for count in range(compass_tnumber + 1, compass_count + 1):
+                self.set_parameter("COMPASS_ORIENT%d" % count, self.get_parameter("SIM_MAG%d_ORIENT" % count))
+            self.arm_vehicle()
+            self.progress("Test calibration rejection when armed")
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+                         target_mask, # p1: mag_mask
+                         0, # p2: retry
+                         0, # p3: autosave
+                         0, # p4: delay
+                         0, # param5
+                         0, # param6
+                         0, # param7
+                         want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+                         timeout=20,
+                         )
+            self.disarm_vehicle()
+            self.mavproxy_unload_module("relay")
+            self.mavproxy_unload_module("sitl_calibration")
+
+        try:
+            curr_params = []
+            target_mask = 0
+            # we test all bitmask plus 0 for all
+            for run in range(-1, compass_count, 1):
+                ntest_compass = compass_count
+                if run < 0:
+                    # use bitmask 0 for all compass
+                    target_mask = 0
+                else:
+                    target_mask |= (1 << run)
+                    ntest_compass = run + 1
+                do_prep_mag_cal_test(curr_params)
+                do_test_mag_cal(curr_params, ntest_compass)
+
+        except Exception as e:
+            self.progress("Caught exception: %s" %
+                          self.get_exception_stacktrace(e))
+            ex = e
+            self.mavproxy_unload_module("relay")
+            self.mavproxy_unload_module("sitl_calibration")
+        if ex is not None:
+            raise ex
+
     def test_fixed_yaw_calibration(self):
         self.context_push()
         ex = None
         try:
+            MAG_OFS_X = 100
+            MAG_OFS_Y = 200
+            MAG_OFS_Z = 300
             wanted = {
-                "COMPASS_OFS_X": (100, 3.0),
-                "COMPASS_OFS_Y": (200, 3.0),
-                "COMPASS_OFS_Z": (300, 3.0),
+                "COMPASS_OFS_X": (MAG_OFS_X, 3.0),
+                "COMPASS_OFS_Y": (MAG_OFS_Y, 3.0),
+                "COMPASS_OFS_Z": (MAG_OFS_Z, 3.0),
                 "COMPASS_DIA_X": 1,
                 "COMPASS_DIA_Y": 1,
                 "COMPASS_DIA_Z": 1,
@@ -4002,9 +4405,9 @@ class AutoTest(ABC):
                 "COMPASS_ODI_Y": 0,
                 "COMPASS_ODI_Z": 0,
 
-                "COMPASS_OFS2_X": (100, 3.0),
-                "COMPASS_OFS2_Y": (200, 3.0),
-                "COMPASS_OFS2_Z": (300, 3.0),
+                "COMPASS_OFS2_X": (MAG_OFS_X, 3.0),
+                "COMPASS_OFS2_Y": (MAG_OFS_Y, 3.0),
+                "COMPASS_OFS2_Z": (MAG_OFS_Z, 3.0),
                 "COMPASS_DIA2_X": 1,
                 "COMPASS_DIA2_Y": 1,
                 "COMPASS_DIA2_Z": 1,
@@ -4012,20 +4415,19 @@ class AutoTest(ABC):
                 "COMPASS_ODI2_Y": 0,
                 "COMPASS_ODI2_Z": 0,
 
-                "COMPASS_OFS3_X": (100, 3.0),
-                "COMPASS_OFS3_Y": (200, 3.0),
-                "COMPASS_OFS3_Z": (300, 3.0),
+                "COMPASS_OFS3_X": (MAG_OFS_X, 3.0),
+                "COMPASS_OFS3_Y": (MAG_OFS_Y, 3.0),
+                "COMPASS_OFS3_Z": (MAG_OFS_Z, 3.0),
                 "COMPASS_DIA3_X": 1,
                 "COMPASS_DIA3_Y": 1,
                 "COMPASS_DIA3_Z": 1,
-                "COMPASS_ODI2_X": 0,
-                "COMPASS_ODI2_Y": 0,
-                "COMPASS_ODI2_Z": 0,
+                "COMPASS_ODI3_X": 0,
+                "COMPASS_ODI3_Y": 0,
+                "COMPASS_ODI3_Z": 0,
             }
-            self.set_parameter("SIM_MAG_OFS_X", 100)
-            self.set_parameter("SIM_MAG_OFS_Y", 200)
-            self.set_parameter("SIM_MAG_OFS_Z", 300)
-
+            self.set_parameter("SIM_MAG_OFS_X", MAG_OFS_X)
+            self.set_parameter("SIM_MAG_OFS_Y", MAG_OFS_Y)
+            self.set_parameter("SIM_MAG_OFS_Z", MAG_OFS_Z)
             # set to some sensible-ish initial values.  If your initial
             # offsets are way, way off you can get some very odd effects.
             for param in wanted:
@@ -4035,28 +4437,9 @@ class AutoTest(ABC):
                 elif "ODI" in param:
                     value = 0.001
                 self.set_parameter(param, value)
-            # zero the parameters:
-            self.progress("zeroing parameters")
-            self.drain_mav()  # these two lines are odd....
-            self.get_sim_time()
-            self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
-                         2, # param1 (compass0)
-                         0, # param2
-                         0, # param3
-                         0, # param4
-                         0, # param5
-                         0, # param6
-                         0 # param7
-            )
-            self.progress("zeroed parameters")
-            # ensure these are all zero; note that we don't set the DIA or
-            # ODI in SET_SENSOR_OFFSETS...
-            for axis in "X", "Y", "Z":
-                name = "COMPASS_OFS_%s" % axis
-                value = self.get_parameter(name)
-                if value != 0.0:
-                    raise NotAchievedException("Failed to zero %s; got %f" %
-                                               (name, value))
+
+            self.zero_mag_parameters()
+
             self.change_mode('LOITER')
             self.wait_ready_to_arm() # so we definitely have position
             ss = self.mav.recv_match(type='SIMSTATE', blocking=True, timeout=1)

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -31,7 +31,7 @@ AP_Compass_SITL::AP_Compass_SITL()
         // Scroll through the registered compasses, and set the offsets
         for (uint8_t i=0; i<_num_compass; i++) {
             if (_compass.get_offsets(i).is_zero()) {
-                _compass.set_offsets(i, _sitl->mag_ofs);
+                _compass.set_offsets(i, _sitl->mag_ofs[i]);
             }
         }
         
@@ -46,14 +46,14 @@ AP_Compass_SITL::AP_Compass_SITL()
 /*
   create correction matrix for diagnonals and off-diagonals
 */
-void AP_Compass_SITL::_setup_eliptical_correcion(void)
+void AP_Compass_SITL::_setup_eliptical_correcion(uint8_t i)
 {
-    Vector3f diag = _sitl->mag_diag.get();
+    Vector3f diag = _sitl->mag_diag[i].get();
     if (diag.is_zero()) {
         diag(1,1,1);
     }
     const Vector3f &diagonals = diag;
-    const Vector3f &offdiagonals = _sitl->mag_offdiag;
+    const Vector3f &offdiagonals = _sitl->mag_offdiag[i];
     
     if (diagonals == _last_dia && offdiagonals == _last_odi) {
         return;
@@ -116,23 +116,18 @@ void AP_Compass_SITL::_timer()
         new_mag_data = buffer[best_index].data;
     }
 
-    _setup_eliptical_correcion();        
-    
-    new_mag_data = _eliptical_corr * new_mag_data;
-    new_mag_data -= _sitl->mag_ofs.get();
-
     for (uint8_t i=0; i<_num_compass; i++) {
-        Vector3f f = new_mag_data;
+        _setup_eliptical_correcion(i);
+        Vector3f f = (_eliptical_corr * new_mag_data) - _sitl->mag_ofs[i].get();
+        // rotate compass
+        f.rotate_inverse((enum Rotation)_sitl->mag_orient[i].get());
+        // and add in AHRS_ORIENTATION setting if not an external compass
+        if (get_board_orientation() == ROTATION_CUSTOM) {
+            f = _sitl->ahrs_rotation * f;
+        } else {
+            f.rotate(get_board_orientation());
+        }
         if (i == 0) {
-            // rotate the first compass, allowing for testing of external compass rotation
-            f.rotate_inverse((enum Rotation)_sitl->mag_orient.get());
-            // and add in AHRS_ORIENTATION setting if not an external compass
-            if (get_board_orientation() == ROTATION_CUSTOM) {
-                f = _sitl->ahrs_rotation * f;
-            } else {
-                f.rotate(get_board_orientation());
-            }
-
             // scale the first compass to simulate sensor scale factor errors
             f *= _sitl->mag_scaling;
         }

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -35,7 +35,7 @@ private:
     void _timer();
     uint32_t _last_sample_time;
 
-    void _setup_eliptical_correcion();
+    void _setup_eliptical_correcion(uint8_t i);
     
     Matrix3f _eliptical_corr;
     Vector3f _last_dia;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -75,7 +75,7 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("BARO_DELAY",    38, SITL,  baro_delay, 0),
     AP_GROUPINFO("MAG_DELAY",     39, SITL,  mag_delay, 0),
     AP_GROUPINFO("WIND_DELAY",    40, SITL,  wind_delay, 0),
-    AP_GROUPINFO("MAG_OFS",       41, SITL,  mag_ofs, 0),
+    AP_GROUPINFO("MAG_OFS",       41, SITL,  mag_ofs[0], 0),
     AP_GROUPINFO("ACC2_RND",      42, SITL,  accel2_noise, 0),
     AP_GROUPINFO("ARSPD_FAIL",    43, SITL,  arspd_fail, 0),
     AP_GROUPINFO("GYR_SCALE",     44, SITL,  gyro_scale, 0),
@@ -119,9 +119,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),
     AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
     AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
-    AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag, 0),
-    AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag, 0),
-    AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient, 0),
+    AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag[0], 0),
+    AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag[0], 0),
+    AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient[0], 0),
     AP_GROUPINFO("RC_CHANCOUNT",21, SITL,  rc_chancount, 16),
     // @Group: SPR_
     // @Path: ./SIM_Sprayer.cpp
@@ -251,6 +251,19 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     // vicon yaw error in degrees (added to reported yaw sent to vehicle)
     AP_GROUPINFO("VICON_YAWERR",  19, SITL,  vicon_yaw_error, 0),
 
+#if HAL_COMPASS_MAX_SENSORS > 1
+    AP_GROUPINFO("MAG2_OFS",     20, SITL,  mag_ofs[1], 0),
+    AP_GROUPINFO("MAG2_DIA",     21, SITL,  mag_diag[1], 0),
+    AP_GROUPINFO("MAG2_ODI",     22, SITL,  mag_offdiag[1], 0),
+    AP_GROUPINFO("MAG2_ORIENT",  23, SITL,  mag_orient[1], 0),
+#endif
+
+#if HAL_COMPASS_MAX_SENSORS > 2
+    AP_GROUPINFO("MAG3_OFS",     24, SITL,  mag_ofs[2], 0),
+    AP_GROUPINFO("MAG3_DIA",     25, SITL,  mag_diag[2], 0),
+    AP_GROUPINFO("MAG3_ODI",     26, SITL,  mag_offdiag[2], 0),
+    AP_GROUPINFO("MAG3_ORIENT",  27, SITL,  mag_orient[2], 0),
+#endif
     AP_GROUPEND
 
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -73,7 +73,9 @@ public:
 
     SITL() {
         // set a default compass offset
-        mag_ofs.set(Vector3f(5, 13, -18));
+        for (uint8_t i = 0; i < HAL_COMPASS_MAX_SENSORS; i++) {
+            mag_ofs[i].set(Vector3f(5, 13, -18));
+        }
         AP_Param::setup_object_defaults(this, var_info);
         AP_Param::setup_object_defaults(this, var_info2);
         AP_Param::setup_object_defaults(this, var_info3);
@@ -151,10 +153,10 @@ public:
 
     AP_Float mag_noise;   // in mag units (earth field is 818)
     AP_Vector3f mag_mot;  // in mag units per amp
-    AP_Vector3f mag_ofs;  // in mag units
-    AP_Vector3f mag_diag;  // diagonal corrections
-    AP_Vector3f mag_offdiag;  // off-diagonal corrections
-    AP_Int8 mag_orient;   // external compass orientation
+    AP_Vector3f mag_ofs[HAL_COMPASS_MAX_SENSORS];  // in mag units
+    AP_Vector3f mag_diag[HAL_COMPASS_MAX_SENSORS];  // diagonal corrections
+    AP_Vector3f mag_offdiag[HAL_COMPASS_MAX_SENSORS];  // off-diagonal corrections
+    AP_Int8 mag_orient[HAL_COMPASS_MAX_SENSORS];   // external compass orientation
     AP_Float servo_speed; // servo speed in seconds
 
     AP_Float sonar_glitch;// probablility between 0-1 that any given sonar sample will read as max distance


### PR DESCRIPTION
Improve calibration testing process:
Try calibration cancellation and check it doesn't write params and orient
Try calibration start during an already calibration running and check that it doesn't reset the calibration
Try calibration failure and check that it doesn't write params and orient
Try arming during calibration and check it is rejected
Try calibration, wait success, check that it doesn't write params without acceptation, check acception, check that params are updated, check that orientation is updated, check that it request reboot to arm. Test arming after calibration.

Two things aren't tested yet: selecting the compass to calibration, calibrate all compass at once, buzzer and notify during calibration