### PR TITLE
SRV_Channels: Servo override with timeout

### DIFF
--- a/libraries/AP_Scripting/examples/servo_override.lua
+++ b/libraries/AP_Scripting/examples/servo_override.lua
@@ -1,0 +1,21 @@
+-- Testing set_output_pwm_chan_timeout
+--
+-- This will set MAIN1 servo to 1700 pwm for 1 second,
+-- then assigned function behavior for 1 second, and then 1100 pwm for 1 second
+
+local flipflop = true
+
+function update()
+    if flipflop then
+        SRV_Channels:set_output_pwm_chan_timeout(0, 1700, 1000)
+        gcs:send_text(6, "flip---")
+    else
+        SRV_Channels:set_output_pwm_chan_timeout(0, 1100, 1000)
+        gcs:send_text(6, "---flop")
+    end
+    flipflop = not flipflop
+    return update, 2000
+end
+
+gcs:send_text(6, "servo_override.lua is running")
+return update, 1000

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -171,6 +171,7 @@ singleton SRV_Channels alias SRV_Channels
 singleton SRV_Channels method find_channel boolean SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint8_t'Null
 singleton SRV_Channels method set_output_pwm void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t 0 UINT16_MAX
 singleton SRV_Channels method set_output_pwm_chan void uint8_t 0 NUM_SERVO_CHANNELS-1 uint16_t 0 UINT16_MAX
+singleton SRV_Channels method set_output_pwm_chan_timeout void uint8_t 0 NUM_SERVO_CHANNELS-1 uint16_t 0 UINT16_MAX uint16_t 0 UINT16_MAX
 singleton SRV_Channels method set_output_scaled void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 int16_t INT16_MIN INT16_MAX
 
 include RC_Channel/RC_Channel.h

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -317,6 +317,9 @@ public:
     // set output value for a specific function channel as a pwm value
     static void set_output_pwm_chan(uint8_t chan, uint16_t value);
 
+    // set output value for a specific function channel as a pwm value for specified override time in ms
+    static void set_output_pwm_chan_timeout(uint8_t chan, uint16_t value, uint16_t timeout_ms);
+
     // set output value for a function channel as a scaled value. This
     // calls calc_pwm() to also set the pwm value
     static void set_output_scaled(SRV_Channel::Aux_servo_function_t function, int16_t value);
@@ -531,6 +534,9 @@ private:
 
     SRV_Channel obj_channels[NUM_SERVO_CHANNELS];
 
+    // override loop counter
+    static uint16_t override_counter[NUM_SERVO_CHANNELS];
+
     static struct srv_function {
         // mask of what channels this applies to
         SRV_Channel::servo_mask_t channel_mask;
@@ -548,4 +554,7 @@ private:
     }
 
     static bool emergency_stop;
+
+    // semaphore for multi-thread use of override_counter array
+    HAL_Semaphore override_counter_sem;
 };

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -41,6 +41,7 @@ SRV_Channels *SRV_Channels::_singleton;
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
 AP_SBusOut *SRV_Channels::sbus_ptr;
 AP_RobotisServo *SRV_Channels::robotis_ptr;
+uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
 
 #if HAL_SUPPORT_RCOUT_SERIAL
 AP_BLHeli *SRV_Channels::blheli_ptr;
@@ -153,7 +154,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Group: _ROB_
     // @Path: ../AP_RobotisServo/AP_RobotisServo.cpp
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
-    
+
     AP_GROUPEND
 };
 
@@ -208,8 +209,16 @@ void SRV_Channels::setup_failsafe_trim_all_non_motors(void)
  */
 void SRV_Channels::calc_pwm(void)
 {
+    WITH_SEMAPHORE(_singleton->override_counter_sem);
+
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
-        channels[i].calc_pwm(functions[channels[i].function].output_scaled);
+        // check if channel has been locked out for this loop
+        // if it has, decrement the loop count for that channel
+        if (override_counter[i] == 0) {
+            channels[i].calc_pwm(functions[channels[i].function].output_scaled);
+        } else {
+            override_counter[i]--;
+        }
     }
 }
 
@@ -218,6 +227,22 @@ void SRV_Channels::set_output_pwm_chan(uint8_t chan, uint16_t value)
 {
     if (chan < NUM_SERVO_CHANNELS) {
         channels[chan].set_output_pwm(value);
+    }
+}
+
+// set output value for a specific function channel as a pwm value with loop based timeout
+// timeout_ms of zero will clear override of the channel
+// minimum override is 1 MAIN_LOOP
+void SRV_Channels::set_output_pwm_chan_timeout(uint8_t chan, uint16_t value, uint16_t timeout_ms)
+{
+    WITH_SEMAPHORE(_singleton->override_counter_sem);
+
+    if (chan < NUM_SERVO_CHANNELS) {
+        const uint32_t loop_period_us = AP::scheduler().get_loop_period_us();
+        // round up so any non-zero requested value will result in at least one loop
+        const uint32_t loop_count = ((timeout_ms * 1000U) + (loop_period_us - 1U)) / loop_period_us;
+        override_counter[chan] = constrain_int32(loop_count, 0, UINT16_MAX);
+        SRV_Channels::set_output_pwm_chan(chan, value);
     }
 }
 


### PR DESCRIPTION
This adds a feature to override a servo output channel for a given number of loops. Scripting bindings and an example script are also included. Scripting documentation is included in [this wiki PR](https://github.com/ArduPilot/ardupilot_wiki/pull/2751).

This change came from a desire to safely set control surface positions in Lua scripts. Currently in order to override commands from the autopilot in a script the SERVOx_FUNCTION parameter must be changed. An example of a script that preforms doublets can be seen [here](https://github.com/TunaLobster/ardupilot/blob/doublet-scripting/ArduPlane/scripts/doublet.lua). In order to safely ensure that in the case of the scripts being dumped control surface function parameters were correctly assigned, a script on the GCS was used to send parameters automatically after the script failed to send a "DOUBLET FINISHED" message. The downside is the dependence on a GCS to preform the rescue actions. Some other comments and discussion can be seen in #14192.

Another option is proposed in this PR. Setting PWM output and allowing the override to timeout after the specified number of main loops have passed. This is directly related to the SCHED_LOOP_RATE parameter. So to get t seconds of position on a servo it would be t * SCHED_LOOP_RATE = counter.

Video showing the changes running on a Cube Orange with a servo on the MAIN1 output that is also assigned the Throttle function.
https://youtu.be/2-uDlzXhLQo