### PR TITLE
AP_HAL_Chibios: Adjust MatekF765-Wing voltage and current scales

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF765-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF765-Wing/hwdef.dat
@@ -79,8 +79,8 @@ define HAL_DEFAULT_AIRSPEED_PIN 10
 # define default battery setup
 define HAL_BATT_VOLT_PIN 12
 define HAL_BATT_CURR_PIN 13
-define HAL_BATT_VOLT_SCALE 10.1
-define HAL_BATT_CURR_SCALE 17.0
+define HAL_BATT_VOLT_SCALE 11
+define HAL_BATT_CURR_SCALE 40
 
 # analog RSSI
 PC1 RSSI_ADC ADC1


### PR DESCRIPTION
The new values matches the ones from here:
http://www.mateksys.com/?portfolio=f765-wing#tab-id-5

Also verified to be a lot more accurate in real life.