### PR TITLE
align GCS PID messages with loged PID values

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -186,7 +186,6 @@ int16_t GCS_MAVLINK_Copter::vfr_hud_throttle() const
  */
 void GCS_MAVLINK_Copter::send_pid_tuning()
 {
-    const Vector3f &gyro = AP::ahrs().get_gyro();
     static const PID_TUNING_AXIS axes[] = {
         PID_TUNING_ROLL,
         PID_TUNING_PITCH,
@@ -201,23 +200,18 @@ void GCS_MAVLINK_Copter::send_pid_tuning()
             return;
         }
         const AP_Logger::PID_Info *pid_info = nullptr;
-        float achieved;
         switch (axes[i]) {
         case PID_TUNING_ROLL:
             pid_info = &copter.attitude_control->get_rate_roll_pid().get_pid_info();
-            achieved = degrees(gyro.x);
             break;
         case PID_TUNING_PITCH:
             pid_info = &copter.attitude_control->get_rate_pitch_pid().get_pid_info();
-            achieved = degrees(gyro.y);
             break;
         case PID_TUNING_YAW:
             pid_info = &copter.attitude_control->get_rate_yaw_pid().get_pid_info();
-            achieved = degrees(gyro.z);
             break;
         case PID_TUNING_ACCZ:
             pid_info = &copter.pos_control->get_accel_z_pid().get_pid_info();
-            achieved = -(AP::ahrs().get_accel_ef_blended().z + GRAVITY_MSS);
             break;
         default:
             continue;
@@ -225,12 +219,12 @@ void GCS_MAVLINK_Copter::send_pid_tuning()
         if (pid_info != nullptr) {
             mavlink_msg_pid_tuning_send(chan,
                                         axes[i],
-                                        pid_info->target*0.01f,
-                                        achieved,
-                                        pid_info->FF*0.01f,
-                                        pid_info->P*0.01f,
-                                        pid_info->I*0.01f,
-                                        pid_info->D*0.01f);
+                                        pid_info->target,
+                                        pid_info->actual,
+                                        pid_info->FF,
+                                        pid_info->P,
+                                        pid_info->I,
+                                        pid_info->D);
         }
     }
 }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -345,9 +345,7 @@ void GCS_MAVLINK_Plane::send_pid_tuning()
     }
 
     const Parameters &g = plane.g;
-    AP_AHRS &ahrs = AP::ahrs();
 
-    const Vector3f &gyro = ahrs.get_gyro();
     const AP_Logger::PID_Info *pid_info;
     if (g.gcs_pid_mask & TUNING_BITS_ROLL) {
         if (plane.quadplane.in_vtol_mode()) {
@@ -355,7 +353,7 @@ void GCS_MAVLINK_Plane::send_pid_tuning()
         } else {
             pid_info = &plane.rollController.get_pid_info();
         }
-        send_pid_info(pid_info, PID_TUNING_ROLL, degrees(gyro.x));
+        send_pid_info(pid_info, PID_TUNING_ROLL, pid_info->actual);
     }
     if (g.gcs_pid_mask & TUNING_BITS_PITCH) {
         if (plane.quadplane.in_vtol_mode()) {
@@ -363,7 +361,7 @@ void GCS_MAVLINK_Plane::send_pid_tuning()
         } else {
             pid_info = &plane.pitchController.get_pid_info();
         }
-        send_pid_info(pid_info, PID_TUNING_PITCH, degrees(gyro.y));
+        send_pid_info(pid_info, PID_TUNING_PITCH, pid_info->actual);
     }
     if (g.gcs_pid_mask & TUNING_BITS_YAW) {
         if (plane.quadplane.in_vtol_mode()) {
@@ -371,18 +369,20 @@ void GCS_MAVLINK_Plane::send_pid_tuning()
         } else {
             pid_info = &plane.yawController.get_pid_info();
         }
-        send_pid_info(pid_info, PID_TUNING_YAW, degrees(gyro.z));
+        send_pid_info(pid_info, PID_TUNING_YAW, pid_info->actual);
     }
     if (g.gcs_pid_mask & TUNING_BITS_STEER) {
-        send_pid_info(&plane.steerController.get_pid_info(), PID_TUNING_STEER, degrees(gyro.z));
+        pid_info = &plane.steerController.get_pid_info();
+        send_pid_info(pid_info, PID_TUNING_STEER, pid_info->actual);
     }
     if ((g.gcs_pid_mask & TUNING_BITS_LAND) && (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND)) {
+        AP_AHRS &ahrs = AP::ahrs();
+        const Vector3f &gyro = ahrs.get_gyro();
         send_pid_info(plane.landing.get_pid_info(), PID_TUNING_LANDING, degrees(gyro.z));
     }
     if (g.gcs_pid_mask & TUNING_BITS_ACCZ && plane.quadplane.in_vtol_mode()) {
-        const Vector3f &accel = ahrs.get_accel_ef();
         pid_info = &plane.quadplane.pos_control->get_accel_z_pid().get_pid_info();
-        send_pid_info(pid_info, PID_TUNING_ACCZ, -accel.z);
+        send_pid_info(pid_info, PID_TUNING_ACCZ, pid_info->actual);
     }
  }
 

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -184,7 +184,6 @@ void GCS_MAVLINK_Rover::send_pid_tuning()
 {
     Parameters &g = rover.g;
     ParametersG2 &g2 = rover.g2;
-    const AP_AHRS &ahrs = AP::ahrs();
 
     const AP_Logger::PID_Info *pid_info;
 
@@ -193,7 +192,7 @@ void GCS_MAVLINK_Rover::send_pid_tuning()
         pid_info = &g2.attitude_control.get_steering_rate_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_STEER,
                                     degrees(pid_info->target),
-                                    degrees(ahrs.get_yaw_rate_earth()),
+                                    degrees(pid_info->actual),
                                     pid_info->FF,
                                     pid_info->P,
                                     pid_info->I,
@@ -206,12 +205,10 @@ void GCS_MAVLINK_Rover::send_pid_tuning()
     // speed to throttle PID
     if (g.gcs_pid_mask & 2) {
         pid_info = &g2.attitude_control.get_throttle_speed_pid().get_pid_info();
-        float speed = 0.0f;
-        g2.attitude_control.get_forward_speed(speed);
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_ACCZ,
                                     pid_info->target,
-                                    speed,
-                                    0,
+                                    pid_info->actual,
+                                    pid_info->FF,
                                     pid_info->P,
                                     pid_info->I,
                                     pid_info->D);
@@ -225,7 +222,7 @@ void GCS_MAVLINK_Rover::send_pid_tuning()
         pid_info = &g2.attitude_control.get_pitch_to_throttle_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_PITCH,
                                     degrees(pid_info->target),
-                                    degrees(ahrs.pitch),
+                                    degrees(pid_info->actual),
                                     pid_info->FF,
                                     pid_info->P,
                                     pid_info->I,


### PR DESCRIPTION
This fixs a bug in copter where we were reporting the actual in degrees and the target in radians / 100. 

It also makes most GCS PID for all vehicles identical to what is seen in the log. In some cases this might mean change from deg/s to radians. The mavlink spec calls for deg/s but were are using the same message for acceleration targets and other things, so were ignoring that in most places.

The only one where this couldn't be done if the plane deep-stall landing controller, this seems to be the only thing still using PID rather than AC_PID.