### PR TITLE
Copter: Correction of spelling errors (NFC)

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -771,7 +771,7 @@ void ModeAuto::spline_run()
     // process pilot's yaw input
     float target_yaw_rate = 0;
     if (!copter.failsafe.radio) {
-        // get pilot's desired yaw rat
+        // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             auto_yaw.set_mode(AUTO_YAW_HOLD);


### PR DESCRIPTION
I discovered a misspelling of RATE.
I have corrected it from RAT to RATE.