### PR TITLE
RC channel handling with MAVLink overrides

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -567,7 +567,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
                 if (c == nullptr) {
                     continue;
                 }
-                if (!c->in_trim_dz()) {
+                if (c->get_control_in() != 0) {
                     if ((method != Method::RUDDER) || (c != rc().get_arming_channel())) { // ignore the yaw input channel if rudder arming
                         check_failed(ARMING_CHECK_RC, true, "%s (RC%d) is not neutral", names[i], channels[i]);
                         check_passed = false;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -135,7 +135,7 @@ bool RC_Channel::update(void)
 {
     if (has_override() && !rc().ignore_overrides()) {
         radio_in = override_value;
-    } else if (!rc().ignore_receiver()) {
+    } else if (rc().has_had_rc_receiver() && !rc().ignore_receiver()) {
         radio_in = hal.rcin->read(ch_in);
     } else {
         return false;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -401,7 +401,10 @@ public:
     float override_timeout_ms() const {
         return _override_timeout.get() * 1e3f;
     }
-    
+
+    // returns true if we have had a direct detach RC reciever, does not include overrides
+    bool has_had_rc_receiver() const { return _has_had_rc_receiver; }
+
     /*
       get the RC input PWM value given a channel number.  Note that
       channel numbers start at 1, as this API is designed for use in
@@ -435,6 +438,7 @@ private:
 
     uint32_t last_update_ms;
     bool has_new_overrides;
+    bool _has_had_rc_receiver; // true if we have had a direct detach RC reciever, does not include overrides
 
     AP_Float _override_timeout;
     AP_Int32  _options;

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -68,7 +68,9 @@ uint8_t RC_Channels::get_radio_in(uint16_t *chans, const uint8_t num_channels)
 // update all the input channels
 bool RC_Channels::read_input(void)
 {
-    if (!hal.rcin->new_input() && !has_new_overrides) {
+    if (hal.rcin->new_input()) {
+        _has_had_rc_receiver = true;
+    } else if (!has_new_overrides) {
         return false;
     }
 


### PR DESCRIPTION
This is a cleanup with the handling of MAVLink overrides that can cause garbage data to be consumed.

There is a particular vehicle setup to make it happen:
- Do not use a RC receiver at all
- Send any form of MAVLink RC input that doesn't provide a value for all the channels (a prime way to do this is `MANUAL_CONTROL`)

The situation that arises is as follows:
1. The RC `control_in` and `radio_in` are both at 0 from the initial reset
1. The GCS sends a `MANUAL_CONTROL` message. This message specified say the roll and throttle channels, and left the others as do not use. This causes us to flag that we have new overrides.
1. We call `read_input` which sees that we have new overrides so it polls all the channels to update themselves
1. The channels poll themselves, the ones with an override value happily just use that and update themselves, however for a channel that didn't have a value, such as say `pitch` what happens is they call the hal method to read the value for that channel, which has no way to flag it didn't have anything real. The effect is garbage data gets trickled up, and used for the channel.

This patch works around this by assuming we can't trust the HAL to manage this case for us. It just wasn't quickly obvious to me how this was going wrong when I tried to investigate ChibiOS's implementation. SITL also went wrong, and I didn't see a good way to solve this without a deep dive into HAL's that I didn't have a way to test.

This still needs more bench testing before coming in, I've only managed to SITL test the described case above so far, I just wanted this presented for earlier review, and guidance.