### PR TITLE
AP_BattMonitor: Rearrange arming check order

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -168,12 +168,12 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
                                 is_positive(_params._low_voltage) &&
                                 (_params._low_voltage < _params._critical_voltage);
 
-    bool result = update_check(buflen, buffer, low_voltage,  "low voltage failsafe");
+    bool result =      update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
+    result = result && update_check(buflen, buffer, below_arming_capacity, "below minimum arming capacity");
+    result = result && update_check(buflen, buffer, low_voltage,  "low voltage failsafe");
     result = result && update_check(buflen, buffer, low_capacity, "low capacity failsafe");
     result = result && update_check(buflen, buffer, critical_voltage, "critical voltage failsafe");
     result = result && update_check(buflen, buffer, critical_capacity, "critical capacity failsafe");
-    result = result && update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
-    result = result && update_check(buflen, buffer, below_arming_capacity, "below minimum arming capacity");
     result = result && update_check(buflen, buffer, fs_capacity_inversion, "capacity failsafe critical > low");
     result = result && update_check(buflen, buffer, fs_voltage_inversion, "voltage failsafe critical > low");
 


### PR DESCRIPTION
This rearranges the battery pre arm check so that the first check you actually receive is the arming specific ones. This was done because these are normally the highest thresholds (IE BATT_ARM_VOLT might be 24.5, while BATT_LOW_VOLT is 18.0 ) the main advantage of this order is that it's an easier set of things to describe in a manual, as the user will always hit those first if they opted into them, and means you don't need to describe the other case which they won't be seeing.