### PR TITLE
AP_NavEKF3/AP_VisualOdom/SITL: add support for vision-speed-estimates

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1480,6 +1480,9 @@ void AP_AHRS_NavEKF::writeExtNavVelData(const Vector3f &vel, float err, uint32_t
 #if HAL_NAVEKF2_AVAILABLE
     EKF2.writeExtNavVelData(vel, err, timeStamp_ms, delay_ms);
 #endif
+#if HAL_NAVEKF3_AVAILABLE
+    EKF3.writeExtNavVelData(vel, err, timeStamp_ms, delay_ms);
+#endif
 }
 
 // inhibit GPS usage

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -563,6 +563,7 @@ void SITL_State::_fdm_input_local(void)
         sitl_model->get_attitude(attitude);
         vicon->update(sitl_model->get_location(),
                       sitl_model->get_position(),
+                      sitl_model->get_velocity_ef(),
                       attitude);
     }
     if (benewake_tf02 != nullptr) {

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -282,7 +282,7 @@ public:
                           const RallyLocation &rally_point);
     void Write_VisualOdom(float time_delta, const Vector3f &angle_delta, const Vector3f &position_delta, float confidence);
     void Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, float roll, float pitch, float yaw, uint8_t reset_counter);
-    void Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, uint8_t reset_counter);
+    void Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, float vel_err, uint8_t reset_counter);
     void Write_AOA_SSA(AP_AHRS &ahrs);
     void Write_Beacon(AP_Beacon &beacon);
     void Write_Proximity(AP_Proximity &proximity);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -930,7 +930,7 @@ void AP_Logger::Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, 
 }
 
 // Write visual velocity sensor data, velocity in NED meters per second
-void AP_Logger::Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, uint8_t reset_counter)
+void AP_Logger::Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, float vel_err, uint8_t reset_counter)
 {
     const struct log_VisualVelocity pkt_visualvel {
         LOG_PACKET_HEADER_INIT(LOG_VISUALVEL_MSG),
@@ -940,6 +940,7 @@ void AP_Logger::Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, 
         vel_x           : vel.x,
         vel_y           : vel.y,
         vel_z           : vel.z,
+        vel_err         : vel_err,
         reset_counter   : reset_counter
     };
     WriteBlock(&pkt_visualvel, sizeof(log_VisualVelocity));

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -636,6 +636,7 @@ struct PACKED log_VisualVelocity {
     float vel_x;
     float vel_y;
     float vel_z;
+    float vel_err;
     uint8_t reset_counter;
 };
 
@@ -2494,7 +2495,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_VISUALPOS_MSG, sizeof(log_VisualPosition), \
       "VISP", "QQIffffffb", "TimeUS,RemTimeUS,CTimeMS,PX,PY,PZ,Roll,Pitch,Yaw,ResetCnt", "sssmmmddh-", "FFC000000-" }, \
     { LOG_VISUALVEL_MSG, sizeof(log_VisualVelocity), \
-      "VISV", "QQIfffb", "TimeUS,RemTimeUS,CTimeMS,VX,VY,VZ,ResetCnt", "sssnnn-", "FFC000-" }, \
+      "VISV", "QQIffffb", "TimeUS,RemTimeUS,CTimeMS,VX,VY,VZ,VErr,ResetCnt", "sssnnnn-", "FFC0000-" }, \
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \
       "OF",   "QBffff",   "TimeUS,Qual,flowX,flowY,bodyX,bodyY", "s-EEnn", "F-0000" }, \
     { LOG_WHEELENCODER_MSG, sizeof(log_WheelEncoder), \

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -2136,6 +2136,17 @@ struct PACKED log_Arm_Disarm {
 // @Field: Yaw: Yaw angle
 // @Field: ResetCnt: Position reset counter
 
+// @LoggerMessage: VISV
+// @Description: Vision Velocity
+// @Field: TimeUS: System time
+// @Field: RemTimeUS: Remote system time
+// @Field: CTimeMS: Corrected system time
+// @Field: VX: Velocity X-axis (North-South)
+// @Field: VY: Velocity Y-axis (East-West)
+// @Field: VZ: Velocity Z-axis (Down-Up)
+// @Field: VErr: Velocity estimate error
+// @Field: ResetCnt: Position reset counter
+
 // @LoggerMessage: WENC
 // @Description: Wheel encoder measurements
 // @Field: TimeUS: Time since system startup

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -340,6 +340,7 @@ bool rotation_equal(enum Rotation r1, enum Rotation r2)
 
 /*
  * return a velocity correction (in m/s in NED) for a sensor's position given it's position offsets
+ * this correction should be added to the sensor NED measurement
  * sensor_offset_bf is in meters in body frame (Foward, Right, Down)
  * rot_ef_to_bf is a rotation matrix to rotate from earth-frame (NED) to body frame
  * angular_rate is rad/sec

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -279,6 +279,7 @@ bool rotation_equal(enum Rotation r1, enum Rotation r2) WARN_IF_UNUSED;
 
 /*
  * return a velocity correction (in m/s in NED) for a sensor's position given it's position offsets
+ * this correction should be added to the sensor NED measurement
  * sensor_offset_bf is in meters in body frame (Foward, Right, Down)
  * rot_ef_to_bf is a rotation matrix to rotate from earth-frame (NED) to body frame
  * angular_rate is rad/sec

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1337,6 +1337,21 @@ void NavEKF3::writeExtNavData(const Vector3f &pos, const Quaternion &quat, float
     }
 }
 
+/* Write velocity data from an external navigation system
+ * vel : velocity in NED (m)
+ * err : velocity error (m/s)
+ * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+ * delay_ms : average delay of external nav system measurements relative to inertial measurements
+*/
+void NavEKF3::writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms)
+{
+    if (core) {
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].writeExtNavVelData(vel, err, timeStamp_ms, delay_ms);
+        }
+    }
+}
+
 // return data for debugging optical flow fusion
 void NavEKF3::getFlowDebug(int8_t instance, float &varFlow, float &gndOffset, float &flowInnovX, float &flowInnovY, float &auxInnov,
                            float &HAGL, float &rngInnov, float &range, float &gndOffsetErr) const

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -296,6 +296,16 @@ public:
     */
     void writeExtNavData(const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint16_t delay_ms, uint32_t resetTime_ms);
 
+    /*
+     * Write velocity data from an external navigation system
+     *
+     * vel : velocity in NED (m)
+     * err : velocity error (m/s)
+     * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+     * delay_ms   : average delay of external nav system measurements relative to inertial measurements
+    */
+    void writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms);
+
     // called by vehicle code to specify that a takeoff is happening
     // causes the EKF to compensate for expected barometer errors due to ground effect
     void setTakeoffExpected(bool val);

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -503,6 +503,7 @@ private:
     const float gpsNEVelVarAccScale = 0.05f;       // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration
     const float gpsDVelVarAccScale = 0.07f;        // Scale factor applied to vertical velocity measurement variance due to manoeuvre acceleration
     const float gpsPosVarAccScale = 0.05f;         // Scale factor applied to horizontal position measurement variance due to manoeuvre acceleration
+    const float extNavVelVarAccScale = 0.05f;      // Scale factor applied to ext nav velocity measurement variance due to manoeuvre acceleration
     const uint16_t magDelay_ms = 60;               // Magnetometer measurement delay (msec)
     const uint16_t tasDelay_ms = 100;              // Airspeed measurement delay (msec)
     const uint16_t tiltDriftTimeMax_ms = 15000;    // Maximum number of ms allowed without any form of tilt aiding (GPS, flow, TAS, etc)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -581,7 +581,7 @@ void  NavEKF3_core::updateFilterStatus(void)
     bool doingFlowNav = (PV_AidingMode != AID_NONE) && flowDataValid;
     bool doingWindRelNav = !tasTimeout && assume_zero_sideslip();
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
-    bool someVertRefData = (!velTimeout && useGpsVertVel) || !hgtTimeout;
+    bool someVertRefData = (!velTimeout && (useGpsVertVel || useExtNavVel)) || !hgtTimeout;
     bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout) || doingFlowNav || doingBodyVelNav;
     bool filterHealthy = healthy() && tiltAlignComplete && (yawAlignComplete || (!use_compass() && (PV_AidingMode != AID_ABSOLUTE)));
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -988,6 +988,24 @@ void NavEKF3_core::writeExtNavData(const Vector3f &pos, const Quaternion &quat, 
     storedExtNav.push(extNavDataNew);
 }
 
+void NavEKF3_core::writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms)
+{
+    if ((timeStamp_ms - extNavVelMeasTime_ms) < 70) {
+        return;
+    }
+
+    extNavVelMeasTime_ms = timeStamp_ms - delay_ms;
+    useExtNavVel = true;
+    extNavVelNew.vel = vel;
+    extNavVelNew.err = err;
+    // Correct for the average intersampling delay due to the filter updaterate
+    timeStamp_ms -= localFilterTimeStep_ms/2;
+    // Prevent time delay exceeding age of oldest IMU data in the buffer
+    timeStamp_ms = MAX(timeStamp_ms,imuDataDelayed.time_ms);
+    extNavVelNew.time_ms = timeStamp_ms;
+    storedExtNavVel.push(extNavVelNew);
+}
+
 /*
   update timing statistics structure
  */

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -630,7 +630,13 @@ void NavEKF3_core::FuseVelPosNED()
             // For data integrity checks we use the same measurement variances as used to calculate the Kalman gains for all measurements except GPS horizontal velocity
             // For horizontal GPS velocity we don't want the acceptance radius to increase with reported GPS accuracy so we use a value based on best GPS performance
             // plus a margin for manoeuvres. It is better to reject GPS horizontal velocity errors early
-            for (uint8_t i=0; i<=2; i++) R_OBS_DATA_CHECKS[i] = sq(constrain_float(frontend->_gpsHorizVelNoise, 0.05f, 5.0f)) + sq(frontend->gpsNEVelVarAccScale * accNavMag);
+            float obs_data_chk;
+            if (extNavVelToFuse) {
+                obs_data_chk = sq(constrain_float(extNavVelDelayed.err, 0.05f, 5.0f)) + sq(frontend->extNavVelVarAccScale * accNavMag);
+            } else {
+                obs_data_chk = sq(constrain_float(frontend->_gpsHorizVelNoise, 0.05f, 5.0f)) + sq(frontend->gpsNEVelVarAccScale * accNavMag);
+            }
+            R_OBS_DATA_CHECKS[0] = R_OBS_DATA_CHECKS[1] = R_OBS_DATA_CHECKS[2] = obs_data_chk;
         }
         R_OBS[5] = posDownObsNoise;
         for (uint8_t i=3; i<=5; i++) R_OBS_DATA_CHECKS[i] = R_OBS[i];

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -143,6 +143,9 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
     if (!storedExtNav.init(obs_buffer_length)) {
         return false;
     }
+    if (!storedExtNavVel.init(obs_buffer_length)) {
+        return false;
+    }
     if(!storedIMU.init(imu_buffer_length)) {
         return false;
     }
@@ -400,6 +403,11 @@ void NavEKF3_core::InitialiseVariables()
     extNavLastPosResetTime_ms = 0;
     extNavDataToFuse = false;
     extNavUsedForPos = false;
+    memset(&extNavVelNew, 0, sizeof(extNavVelNew));
+    memset(&extNavVelDelayed, 0, sizeof(extNavVelDelayed));
+    extNavVelToFuse = false;
+    useExtNavVel = false;
+    extNavVelMeasTime_ms = 0;
 
     // zero data buffers
     storedIMU.reset();
@@ -412,6 +420,7 @@ void NavEKF3_core::InitialiseVariables()
     storedBodyOdm.reset();
     storedWheelOdm.reset();
     storedExtNav.reset();
+    storedExtNavVel.reset();
 
     // initialise pre-arm message
     hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "EKF3 still initialising");

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -302,6 +302,16 @@ public:
     */
     void writeExtNavData(const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint16_t delay_ms, uint32_t resetTime_ms);
 
+    /*
+     * Write velocity data from an external navigation system
+     *
+     * vel : velocity in NED (m)
+     * err : velocity error (m/s)
+     * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+     * delay_ms : average delay of external nav system measurements relative to inertial measurements
+    */
+    void writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms);
+
     // called by vehicle code to specify that a takeoff is happening
     // causes the EKF to compensate for expected barometer errors due to ground effect
     void setTakeoffExpected(bool val);
@@ -593,6 +603,12 @@ private:
         float           posErr;     // spherical poition measurement error 1-std (m)
         uint32_t        time_ms;    // measurement timestamp (msec)
         bool            posReset;   // true when the position measurement has been reset
+    };
+
+    struct ext_nav_vel_elements {
+        Vector3f vel;               // velocity in NED (m/s)
+        float err;                  // velocity measurement error (m/s)
+        uint32_t time_ms;           // measurement timestamp (msec)
     };
 
     // bias estimates for the IMUs that are enabled but not being used
@@ -924,6 +940,9 @@ private:
 
     // correct external navigation earth-frame position using sensor body-frame offset
     void CorrectExtNavForSensorOffset(Vector3f &ext_position);
+
+    // correct external navigation earth-frame velocity using sensor body-frame offset
+    void CorrectExtNavVelForSensorOffset(Vector3f &ext_velocity) const;
 
     // Runs the IMU prediction step for an independent GSF yaw estimator algorithm
     // that uses IMU, GPS horizontal velocity and optionally true airspeed data.
@@ -1336,6 +1355,12 @@ private:
     uint32_t extNavLastPosResetTime_ms; // last time the external nav systen performed a position reset (msec)
     bool extNavDataToFuse;              // true when there is new external nav data to fuse
     bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.
+    obs_ring_buffer_t<ext_nav_vel_elements> storedExtNavVel;    // external navigation velocity data buffer
+    ext_nav_vel_elements extNavVelNew;  // external navigation velocity data at the current time horizon
+    ext_nav_vel_elements extNavVelDelayed;  // external navigation velocity data at the fusion time horizon
+    uint32_t extNavVelMeasTime_ms;      // time external navigation velocity measurements were accepted for input to the data buffer (msec)
+    bool extNavVelToFuse;               // true when there is new external navigation velocity to fuse
+    bool useExtNavVel;                  // true if external nav velocity should be used
 
     // flags indicating severe numerical errors in innovation variance calculation for different fusion operations
     struct {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1357,7 +1357,7 @@ private:
     bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.
     obs_ring_buffer_t<ext_nav_vel_elements> storedExtNavVel;    // external navigation velocity data buffer
     ext_nav_vel_elements extNavVelNew;  // external navigation velocity data at the current time horizon
-    ext_nav_vel_elements extNavVelDelayed;  // external navigation velocity data at the fusion time horizon
+    ext_nav_vel_elements extNavVelDelayed;  // external navigation velocity data at the fusion time horizon.  Already corrected for sensor position
     uint32_t extNavVelMeasTime_ms;      // time external navigation velocity measurements were accepted for input to the data buffer (msec)
     bool extNavVelToFuse;               // true when there is new external navigation velocity to fuse
     bool useExtNavVel;                  // true if external nav velocity should be used

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -75,7 +75,7 @@ void AP_VisualOdom_IntelT265::handle_vision_speed_estimate(uint64_t remote_time_
     // record time for health monitoring
     _last_update_ms = AP_HAL::millis();
 
-    AP::logger().Write_VisualVelocity(remote_time_us, time_ms, vel_corrected, reset_counter);
+    AP::logger().Write_VisualVelocity(remote_time_us, time_ms, vel_corrected, _frontend.get_vel_noise(), reset_counter);
 }
 
 // apply rotation and correction to position

--- a/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp
@@ -61,7 +61,7 @@ void AP_VisualOdom_MAV::handle_vision_speed_estimate(uint64_t remote_time_us, ui
     // record time for health monitoring
     _last_update_ms = AP_HAL::millis();
 
-    AP::logger().Write_VisualVelocity(remote_time_us, time_ms, vel, reset_counter);
+    AP::logger().Write_VisualVelocity(remote_time_us, time_ms, vel, _frontend.get_vel_noise(), reset_counter);
 }
 
 #endif

--- a/libraries/SITL/SIM_Vicon.cpp
+++ b/libraries/SITL/SIM_Vicon.cpp
@@ -26,9 +26,6 @@
 
 using namespace SITL;
 
-#define USE_VISION_POSITION_ESTIMATE 1  // 1 = send VISION_POSITION_ESTIMATE messages, 0 = send VICON_POSITION_ESTIMATE
-
-
 Vicon::Vicon() :
     SerialDevice::SerialDevice()
 {
@@ -58,27 +55,47 @@ void Vicon::maybe_send_heartbeat()
                                0);
 }
 
+// get unused index in msg_buf
+bool Vicon::get_free_msg_buf_index(uint8_t &index)
+{
+    for (uint8_t i=0; i<ARRAY_SIZE(msg_buf); i++) {
+        if (msg_buf[i].time_send_us == 0) {
+            index = i;
+            return true;
+        }
+    }
+    return false;
+}
+
 void Vicon::update_vicon_position_estimate(const Location &loc,
                                            const Vector3f &position,
+                                           const Vector3f &velocity,
                                            const Quaternion &attitude)
 {
     const uint64_t now_us = AP_HAL::micros64();
 
+    // calculate a random time offset to the time sent in the message
+    // simulates a time difference between the remote computer and autopilot
     if (time_offset_us == 0) {
         time_offset_us = (unsigned(random()) % 7000) * 1000000ULL;
         printf("time_offset_us %llu\n", (long long unsigned)time_offset_us);
     }
-    
-    if (time_send_us && now_us >= time_send_us) {
-        uint8_t msgbuf[300];
-        uint16_t msgbuf_len = mavlink_msg_to_send_buffer(msgbuf, &obs_msg);
 
-        if (::write(fd_my_end, (void*)&msgbuf, msgbuf_len) != msgbuf_len) {
-            ::fprintf(stderr, "Vicon: write failure\n");
+    // send all messages in the buffer
+    bool waiting_to_send = false;
+    for (uint8_t i=0; i<ARRAY_SIZE(msg_buf); i++) {
+        if ((msg_buf[i].time_send_us > 0) && (now_us >= msg_buf[i].time_send_us)) {
+            uint8_t buf[300];
+            uint16_t buf_len = mavlink_msg_to_send_buffer(buf, &msg_buf[i].obs_msg);
+
+            if (::write(fd_my_end, (void*)&buf, buf_len) != buf_len) {
+                ::fprintf(stderr, "Vicon: write failure\n");
+            }
+            msg_buf[i].time_send_us = 0;
         }
-        time_send_us = 0;
+        waiting_to_send = msg_buf[i].time_send_us != 0;
     }
-    if (time_send_us != 0) {
+    if (waiting_to_send) {
         // waiting for the last msg to go out
         return;
     }
@@ -107,7 +124,18 @@ void Vicon::update_vicon_position_estimate(const Location &loc,
     // add earth frame sensor offset and glitch to position
     Vector3f pos_corrected = position + pos_offset_ef + _sitl->vicon_glitch.get();
 
-    // adjust yaw and position to account for vicon's yaw
+    // calculate a velocity offset due to the antenna position offset and body rotation rate
+    // note: % operator is overloaded for cross product
+    Vector3f gyro(radians(_sitl->state.rollRate),
+                  radians(_sitl->state.pitchRate),
+                  radians(_sitl->state.yawRate));
+    Vector3f vel_rel_offset_bf = gyro % pos_offset;
+
+    // rotate the velocity offset into earth frame and add to the c.g. velocity
+    Vector3f vel_rel_offset_ef = rot * vel_rel_offset_bf;
+    Vector3f vel_corrected = velocity + vel_rel_offset_ef + _sitl->vicon_vel_glitch.get();
+
+    // adjust yaw, position and velocity to account for vicon's yaw
     const int16_t vicon_yaw_deg = _sitl->vicon_yaw.get();
     if (vicon_yaw_deg != 0) {
         const float vicon_yaw_rad = radians(vicon_yaw_deg);
@@ -115,56 +143,79 @@ void Vicon::update_vicon_position_estimate(const Location &loc,
         Matrix3f vicon_yaw_rot;
         vicon_yaw_rot.from_euler(0, 0, -vicon_yaw_rad);
         pos_corrected = vicon_yaw_rot * pos_corrected;
+        vel_corrected = vicon_yaw_rot * vel_corrected;
     }
 
     // add yaw error reported to vehicle
     yaw = wrap_PI(yaw + radians(_sitl->vicon_yaw_error.get()));
 
-#if USE_VISION_POSITION_ESTIMATE
-    // use the more recent VISION_POSITION_ESTIMATE message
-    mavlink_msg_vision_position_estimate_pack_chan(
-        system_id,
-        component_id,
-        mavlink_ch,
-        &obs_msg,
-        now_us + time_offset_us,
-        pos_corrected.x,
-        pos_corrected.y,
-        pos_corrected.z,
-        roll,
-        pitch,
-        yaw,
-        NULL, 0);
-#else
-    mavlink_msg_vicon_position_estimate_pack_chan(
-        system_id,
-        component_id,
-        mavlink_ch,
-        &obs_msg,
-        now_us + time_offset_us,
-        pos_corrected.x,
-        pos_corrected.y,
-        pos_corrected.z,
-        roll,
-        pitch,
-        yaw,
-        NULL);
-#endif // USE_VISION_POSITION_ESTIMATE
-
+    // 25ms to 324ms delay before sending
     uint32_t delay_ms = 25 + unsigned(random()) % 300;
-    time_send_us = now_us + delay_ms * 1000UL;
+    uint64_t time_send_us = now_us + delay_ms * 1000UL;
+
+    // send vision position estimate message
+    uint8_t msg_buf_index;
+    if (should_send(ViconTypeMask::VISION_POSITION_ESTIMATE) && get_free_msg_buf_index(msg_buf_index)) {
+        mavlink_msg_vision_position_estimate_pack_chan(
+            system_id,
+            component_id,
+            mavlink_ch,
+            &msg_buf[msg_buf_index].obs_msg,
+            now_us + time_offset_us,
+            pos_corrected.x,
+            pos_corrected.y,
+            pos_corrected.z,
+            roll,
+            pitch,
+            yaw,
+            NULL, 0);
+        msg_buf[msg_buf_index].time_send_us = time_send_us;
+    }
+
+    // send older vicon position estimate message
+    if (should_send(ViconTypeMask::VICON_POSITION_ESTIMATE) && get_free_msg_buf_index(msg_buf_index)) {
+        mavlink_msg_vicon_position_estimate_pack_chan(
+            system_id,
+            component_id,
+            mavlink_ch,
+            &msg_buf[msg_buf_index].obs_msg,
+            now_us + time_offset_us,
+            pos_corrected.x,
+            pos_corrected.y,
+            pos_corrected.z,
+            roll,
+            pitch,
+            yaw,
+            NULL);
+        msg_buf[msg_buf_index].time_send_us = time_send_us;
+    }
+
+    // send vision speed estimate
+    if (should_send(ViconTypeMask::VISION_SPEED_ESTIMATE) && get_free_msg_buf_index(msg_buf_index)) {
+        mavlink_msg_vision_speed_estimate_pack_chan(
+            system_id,
+            component_id,
+            mavlink_ch,
+            &msg_buf[msg_buf_index].obs_msg,
+            now_us + time_offset_us,
+            vel_corrected.x,
+            vel_corrected.y,
+            vel_corrected.z,
+            NULL, 0);
+        msg_buf[msg_buf_index].time_send_us = time_send_us;
+    }
 }
 
 /*
   update vicon sensor state
  */
-void Vicon::update(const Location &loc, const Vector3f &position, const Quaternion &attitude)
+void Vicon::update(const Location &loc, const Vector3f &position, const Vector3f &velocity, const Quaternion &attitude)
 {
     if (!init_sitl_pointer()) {
         return;
     }
 
     maybe_send_heartbeat();
-    update_vicon_position_estimate(loc, position, attitude);
+    update_vicon_position_estimate(loc, position, velocity, attitude);
 }
 

--- a/libraries/SITL/SIM_Vicon.cpp
+++ b/libraries/SITL/SIM_Vicon.cpp
@@ -149,8 +149,8 @@ void Vicon::update_vicon_position_estimate(const Location &loc,
     // add yaw error reported to vehicle
     yaw = wrap_PI(yaw + radians(_sitl->vicon_yaw_error.get()));
 
-    // 25ms to 324ms delay before sending
-    uint32_t delay_ms = 25 + unsigned(random()) % 300;
+    // 25ms to 124ms delay before sending
+    uint32_t delay_ms = 25 + unsigned(random()) % 100;
     uint64_t time_send_us = now_us + delay_ms * 1000UL;
 
     // send vision position estimate message

--- a/libraries/SITL/SIM_Vicon.h
+++ b/libraries/SITL/SIM_Vicon.h
@@ -51,11 +51,6 @@ private:
     uint64_t time_offset_us;
     mavlink_message_t obs_msg;
 
-    struct obs_elements {
-        uint32_t    time_ms;        // measurement timestamp (msec)
-        Vector3f    position;
-        Quaternion  attitude;
-    };
 
     void update_vicon_position_estimate(const Location &loc,
                                         const Vector3f &position,

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -251,6 +251,12 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     // vicon yaw error in degrees (added to reported yaw sent to vehicle)
     AP_GROUPINFO("VICON_YAWERR",  19, SITL,  vicon_yaw_error, 0),
 
+    // vicon message type mask
+    AP_GROUPINFO("VICON_TMASK",   20, SITL,  vicon_type_mask, 1),
+
+    // vicon velocity glitch in NED frame
+    AP_GROUPINFO("VICON_VGLI",    21, SITL,  vicon_vel_glitch, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -367,6 +367,8 @@ public:
     AP_Int8 vicon_fail;         // trigger vicon failure
     AP_Int16 vicon_yaw;         // vicon local yaw in degrees
     AP_Int16 vicon_yaw_error;   // vicon yaw error in degrees (added to reported yaw sent to vehicle)
+    AP_Int8 vicon_type_mask;    // vicon message type mask (bit0:vision position estimate, bit1:vision speed estimate, bit2:vicon position estimate)
+    AP_Vector3f vicon_vel_glitch;   // velocity glitch in m/s in vicon's local frame
 };
 
 } // namespace SITL


### PR DESCRIPTION
This is built on top of PR https://github.com/ArduPilot/ardupilot/pull/14368 from @chobitsfan (this original PR should be merged first).

This PR has the following enhancements (on top of the older PR):

- EKF3 is enhanced to consume the [VISION_SPEED_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_SPEED_ESTIMATE) mavlink messages via the AP_VisualOdom library
  - Vision-position-estimate messages must also be received for it to function properly (this keeps the code similar to the GPS which can also provide position and velocity but not velocity alone)
  - ResetVelocity enhanced to reset to the external nav velocity
  - CorrectExtNavVelForSensorOffset() corrects the external navigation's velocity based on the sensor position
- AP_Logger's VISV message is used to log all the new data
- SITL's SIM_Vicon class is enhanced so it can send the vision-speed-estimate message and the following params are added:
  - SIM_VICON_TMASK (for "Type Mask") allows real-time control of which of the three supported messages (vision-position-estimate, vision-**speed**-estimate and **vicon**-position-estimate) are sent
  - SIM_VICON_VGLIT_X/Y/Z allows adding an earth-frame glitch (in m/s) to the simulated velocity
- AP_Math::get_vel_correction_for_sensor_offset is added so we can reduce some duplicate code in EKF2, EKF3 and the simulator that adjusts the velocity based on the sensor's offsets.  In this PR the new function is only used for external nav velocities so the scope is kept small

Some non-blocking issues:

- if vision-speed-estimates are sent without also sending vision-position-estimates the EKF will not complete initialisation.  Theoretically we should be able to provide only velocities but this does not work yet from some reason and is left for a future PR
- the vision-speed-estimate messages's reset_counter are logged but not used.  In the short-term this is OK because Thien's T265 scripts will send the reset using the vision-position-estimate message but eventually we will want to support this especially if we resolve the issue directly above
- we should extend the AP_Math::get_vel_correction_for_sensor_offset to be used for the existing GPS code.  This was not done in order to limit the scope of this PR's changes

Testing done so far:

- The EKF2 changes have been tested in SITL and on a real vehicle
- The EKF3 changes have been tested in SITL including
    - checking that the velocity corrections for sensor position are correct
    - vision sensor failure and glitches seem to be handled correctly

Some more SITL and actual flight tests (using EKF3) will be completed before merging
