### PR TITLE
SmartRTL wait on bad semaphore instead of landing

### DIFF
--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -86,21 +86,23 @@ void ModeSmartRTL::path_follow_run()
 
     // if we are close to current target point, switch the next point to be our target.
     if (wp_nav->reached_wp_destination()) {
-        Vector3f next_point;
-        if (g2.smart_rtl.pop_point(next_point)) {
-            bool fast_waypoint = true;
-            if (g2.smart_rtl.get_num_points() == 0) {
-                // this is the very last point, add 2m to the target alt and move to pre-land state
-                next_point.z -= 2.0f;
+        if (g2.smart_rtl.get_num_points() != 0) {
+            Vector3f next_point;
+            if (g2.smart_rtl.pop_point(next_point)) {
+                bool fast_waypoint = true;
+                if (g2.smart_rtl.get_num_points() == 0) {
+                    // this is the very last point, add 2m to the target alt and move to pre-land state
+                    next_point.z -= 2.0f;
+                    smart_rtl_state = SmartRTL_PreLandPosition;
+                    fast_waypoint = false;
+                }
+                // send target to waypoint controller
+                wp_nav->set_wp_destination_NED(next_point);
+                wp_nav->set_fast_waypoint(fast_waypoint);
+            } else {
+                // this can only happen if we have no points left to get
                 smart_rtl_state = SmartRTL_PreLandPosition;
-                fast_waypoint = false;
             }
-            // send target to waypoint controller
-            wp_nav->set_wp_destination_NED(next_point);
-            wp_nav->set_fast_waypoint(fast_waypoint);
-        } else {
-            // this can only happen if we fail to get the semaphore which should never happen but just in case, land
-            smart_rtl_state = SmartRTL_PreLandPosition;
         }
     }
 

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -86,6 +86,7 @@ void ModeSmartRTL::path_follow_run()
 
     // if we are close to current target point, switch the next point to be our target.
     if (wp_nav->reached_wp_destination()) {
+        // check to see if any more valid waypoints; if not, we're at home and move to PreLandPosition
         if (g2.smart_rtl.get_num_points() != 0) {
             Vector3f next_point;
             if (g2.smart_rtl.pop_point(next_point)) {
@@ -99,10 +100,10 @@ void ModeSmartRTL::path_follow_run()
                 // send target to waypoint controller
                 wp_nav->set_wp_destination_NED(next_point);
                 wp_nav->set_fast_waypoint(fast_waypoint);
-            } else {
-                // this can only happen if we have no points left to get
-                smart_rtl_state = SmartRTL_PreLandPosition;
             }
+        } else {
+            // this can only happen if we have no points left to get
+            smart_rtl_state = SmartRTL_PreLandPosition;
         }
     }
 


### PR DESCRIPTION
Previously, one bad semaphore would case the copter to land. Now, the
copter waits at the current waypoint until the next point is accessed. Bug reported at https://discuss.ardupilot.org/t/smart-rtl-failure-cause