### PR TITLE
Rover: Add param to reset WP origin while recovering from BendyRuler

### DIFF
--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -26,6 +26,9 @@ extern const AP_HAL::HAL &hal;
 // parameter defaults
 const float OA_LOOKAHEAD_DEFAULT = 15;
 const float OA_MARGIN_MAX_DEFAULT = 5;
+#if APM_BUILD_TYPE(APM_BUILD_Rover)
+    const int16_t OA_OPTIONS_DEFAULT = 1;
+#endif
 
 const int16_t OA_UPDATE_MS = 1000;      // path planning updates run at 1hz
 const int16_t OA_TIMEOUT_MS = 3000;     // results over 3 seconds old are ignored
@@ -60,6 +63,16 @@ const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
     // @Group: DB_
     // @Path: AP_OADatabase.cpp
     AP_SUBGROUPINFO(_oadatabase, "DB_", 4, AP_OAPathPlanner, AP_OADatabase),
+
+#if APM_BUILD_TYPE(APM_BUILD_Rover)
+    // @Param: OPTIONS
+    // @DisplayName: Options while recovering from Object Avoidance
+    // @Description: Bitmask which will govern vehicles behaviour while recovering from Obstacle Avoidance (i.e Avoidance is turned off after the path ahead is clear).   
+    // @Values: 0:Vehicle will return to its original waypoint trajectory, 1:Reset the origin of the waypoint to the present location
+    // @Bitmask: 0: Reset the origin of the waypoint to the present location
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 5, AP_OAPathPlanner, _options, OA_OPTIONS_DEFAULT),
+#endif
 
     AP_GROUPEND
 };

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -54,6 +54,14 @@ public:
         OA_PATHPLAN_DIJKSTRA = 2
     };
 
+    // enumeration for _OPTION parameter
+    enum OARecoveryOptions {
+        OA_OPTION_DISABLED = 0,
+        OA_OPTION_WP_RESET = (1 << 0),
+    };
+
+    uint16_t get_options() const { return _options;}
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -81,10 +89,10 @@ private:
     } avoidance_result;
 
     // parameters
-    AP_Int8 _type;                  // avoidance algorith to be used
+    AP_Int8 _type;                  // avoidance algorithm to be used
     AP_Float _lookahead;            // object avoidance will look this many meters ahead of vehicle
     AP_Float _margin_max;           // object avoidance will ignore objects more than this many meters from vehicle
-
+    AP_Int16 _options;              // Bitmask for options while recovering from Object Avoidance
     // internal variables used by front end
     HAL_Semaphore _rsem;            // semaphore for multi-thread use of avoidance_request and avoidance_result
     bool _thread_created;           // true once background thread has been created

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -112,6 +112,10 @@ void AR_WPNav::update(float dt)
 
     // run path planning around obstacles
     bool stop_vehicle = false;
+   
+    // true if OA has been recently active;
+    bool _oa_was_active = _oa_active;
+
     AP_OAPathPlanner *oa = AP_OAPathPlanner::get_singleton();
     if (oa != nullptr) {
         const AP_OAPathPlanner::OA_RetState oa_retstate = oa->mission_avoidance(current_loc, _origin, _destination, _oa_origin, _oa_destination);
@@ -136,6 +140,14 @@ void AR_WPNav::update(float dt)
     }
 
     update_distance_and_bearing_to_destination();
+
+    // check if vehicle is in recovering state after switching off OA
+    if (!_oa_active && _oa_was_active) {
+        if (oa->get_options() & AP_OAPathPlanner::OA_OPTION_WP_RESET) {
+            //reset wp origin to vehicles current location
+            _origin = current_loc;
+        }
+    }
 
     // check if vehicle has reached the destination
     const bool near_wp = _distance_to_destination <= _radius;


### PR DESCRIPTION
This PR fixes https://github.com/ArduPilot/ardupilot/issues/11565

I have added a parameter (OA_RESET_ORGIN) in OA library to allow the user if they want to reset the Waypoint origin or not while recovering from Bendy Ruler.
If OA_RESET_ORIGIN is set 0, the behaviour will be as it is in master right now. 
![before](https://user-images.githubusercontent.com/36970042/82551756-6facc680-9b7e-11ea-847c-af0e8be3722a.png)


But if OA_RESET_ORGIN is set to 1, which is the default in this PR, the following happens:
![after](https://user-images.githubusercontent.com/36970042/82551764-72a7b700-9b7e-11ea-90ba-739deba3c840.png)

@rmackay9 please let me know if this is the approach you were looking for. Thanks!