### PR TITLE
Support configurable backend gyro and accel rates on Invensense sensors to support 8k gyros and fast-sampling on MPU6000

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -505,7 +505,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @DisplayName: Gyro rate for IMUs with Fast Sampling enabled
     // @Description: Gyro rate for IMUs with fast sampling enabled. The gyro rate is the sample rate at which the IMU filters operate and needs to be at least double the maximum filter frequency. If the sensor does not support the selected rate the next highest supported rate will be used. For IMUs which do not support fast sampling this setting is ignored and the default gyro rate of 1Khz is used.
     // @User: Advanced
-    // @Values: 0:1 kHz,1:2 kHz,3:4 kHz
+    // @Values: 0:1kHz,1:2kHz,2:4kHz,3:8kHz
     // @RebootRequired: True
     AP_GROUPINFO("GYRO_RATE",  42, AP_InertialSensor, _fast_sampling_rate, MPU_FIFO_FASTSAMPLE_DEFAULT),
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -138,11 +138,20 @@ private:
     // are we doing more than 1kHz sampling?
     bool _fast_sampling;
 
-    // what downsampling rate are we using from the FIFO?
-    uint8_t _fifo_downsample_rate;
+    // what downsampling rate are we using from the FIFO for gyros?
+    uint8_t _gyro_fifo_downsample_rate;
 
-    // what rate are we generating samples into the backend?
-    uint16_t _backend_rate_hz;
+    // what downsampling rate are we using from the FIFO for accels?
+    uint8_t _accel_fifo_downsample_rate;
+
+    // ratio of raw gyro to accel sample rate
+    uint8_t _gyro_to_accel_sample_ratio;
+
+    // what rate are we generating samples into the backend for gyros?
+    uint16_t _gyro_backend_rate_hz;
+
+    // what rate are we generating samples into the backend for accels?
+    uint16_t _accel_backend_rate_hz;
 
     // Last status from register user control
     uint8_t _last_stat_user_ctrl;    
@@ -157,7 +166,8 @@ private:
     struct {
         Vector3f accel;
         Vector3f gyro;
-        uint8_t count;
+        uint8_t accel_count;
+        uint8_t gyro_count;
         LowPassFilterVector3f accel_filter{4000, 188};
         LowPassFilterVector3f gyro_filter{8000, 188};
     } _accum;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.h
@@ -128,11 +128,17 @@ private:
     // are we doing more than 1kHz sampling?
     bool _fast_sampling;
 
-    // what downsampling rate are we using from the FIFO?
-    uint8_t _fifo_downsample_rate;
+    // what downsampling rate are we using from the FIFO for gyros?
+    uint8_t _gyro_fifo_downsample_rate;
 
-    // what rate are we generating samples into the backend?
-    uint16_t _backend_rate_hz;
+    // what downsampling rate are we using from the FIFO for accels?
+    uint8_t _accel_fifo_downsample_rate;
+
+    // what rate are we generating samples into the backend for gyros?
+    uint16_t _gyro_backend_rate_hz;
+
+    // what rate are we generating samples into the backend for accels?
+    uint16_t _accel_backend_rate_hz;
 
     // Last status from register user control
     uint8_t _last_stat_user_ctrl;    
@@ -148,7 +154,8 @@ private:
     struct {
         Vector3f accel;
         Vector3f gyro;
-        uint8_t count;
+        uint8_t accel_count;
+        uint8_t gyro_count;
         LowPassFilterVector3f accel_filter{4500, 188};
         LowPassFilterVector3f gyro_filter{9000, 188};
     } _accum;


### PR DESCRIPTION
This PR decouples the accel and gyro backend sample rates so that they can run at different speeds. This allows gyro samples to be delivered more quickly than accel samples meaning that we can run gyros at 8k regardless of the maximum sensor rate for accels.
This also means that we can now support fast sampling on IMU's that only have fast sampling for gyros - e.g. the MPU6000.

Flown on a KakuteF7Mini v2 (MPU6000) @2kHz and 8kHz