### PR TITLE
Added check for input arguments in ardupilot-astyle.sh

### DIFF
--- a/Tools/CodeStyle/ardupilot-astyle.sh
+++ b/Tools/CodeStyle/ardupilot-astyle.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    printf "\nArguments missing, Usage: '$0 <files to style>'\n\n"
+    exit 1
+fi
 
 if [ $(uname) = "Darwin" ]; then
     DIR=$(dirname $(greadlink -f $0))
@@ -7,4 +12,3 @@ else
 fi
 
 astyle --options="${DIR}"/astylerc $*
-


### PR DESCRIPTION
### Issue:
- Currently, there is no check for input arguments.

### Changes made:
- Now, Script will check for arguments and If not available, will exit by print the usage.
- To make sure it works, Tested on **sh**, **bash** and **zsh**.

### Log Snippet:
> $ sh ./ardupilot-astyle.sh
> 'Arguments missing, Usage: './ardupilot-astyle.sh \<files to style\>'

> $ bash ./ardupilot-astyle.sh
> Arguments missing, Usage: './ardupilot-astyle.sh \<files to style\>'

> $ zsh ./ardupilot-astyle.sh
> Arguments missing, Usage: './ardupilot-astyle.sh \<files to style\>'