### PR TITLE
Fix SRXL2 channel order

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -63,6 +63,11 @@ public:
         return frontend._detected_with_bytes?frontend.added.uart:nullptr;
     }
 
+    // get an available uart regardless of whether we have detected a protocol via it
+    AP_HAL::UARTDriver *get_available_UART(void) const {
+        return frontend.added.uart;
+    }
+
     // return true if we have a uart available for protocol handling.
     bool have_UART(void) const {
         return frontend.added.uart != nullptr;


### PR DESCRIPTION
I am really struggling to get https://github.com/ArduPilot/ardupilot/pull/14341 to work realiably, so this PR pulls out the more important bug fixes and improvements for regular SRXL2.

For all other DSMX protocols we switch the channel order to AP order - this does the same for SRXL2.
