### PR TITLE
Rover: astyle, reformatting few files in Rover Dir

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -10,8 +10,8 @@ bool AP_Arming_Rover::rc_calibration_checks(const bool display_failure)
     }
 
     const RC_Channel *channels[] = {
-            rover.channel_steer,
-            rover.channel_throttle,
+        rover.channel_steer,
+        rover.channel_throttle
     };
     const char *channel_names[] = {"Steer", "Throttle"};
 
@@ -188,7 +188,7 @@ bool AP_Arming_Rover::parameter_checks(bool report)
 
 // check if arming allowed from this mode
 bool AP_Arming_Rover::mode_checks(bool report)
-{   
+{
     //display failure if arming in this mode is not allowed
     if (!rover.control_mode->allows_arming()) {
         check_failed(report, "Mode not armable");

--- a/Rover/AP_MotorsUGV.cpp
+++ b/Rover/AP_MotorsUGV.cpp
@@ -436,8 +436,7 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
         return false;
     }
     // check all omni motor outputs have been configured
-    for (uint8_t i=0; i<_motors_num; i++)
-    {
+    for (uint8_t i=0; i<_motors_num; i++) {
         SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
         if (!SRV_Channels::function_assigned(function)) {
             if (report) {

--- a/Rover/AP_MotorsUGV.h
+++ b/Rover/AP_MotorsUGV.h
@@ -6,7 +6,6 @@
 
 class AP_MotorsUGV {
 public:
-
     // Constructor
     AP_MotorsUGV(AP_ServoRelayEvents &relayEvents);
 
@@ -20,7 +19,7 @@ public:
         PWM_TYPE_DSHOT300 = 6,
         PWM_TYPE_DSHOT600 = 7,
         PWM_TYPE_DSHOT1200 = 8
-     };
+    };
 
     enum motor_test_order {
         MOTOR_TEST_THROTTLE = 1,
@@ -110,7 +109,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:
-
     // sanity check parameters
     void sanity_check_parameters();
 

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -50,7 +50,7 @@ MAV_MODE GCS_MAVLINK_Rover::base_mode() const
     // indicate we have set a custom mode
     _base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-return (MAV_MODE)_base_mode;
+    return (MAV_MODE)_base_mode;
 }
 
 uint32_t GCS_Rover::custom_mode() const
@@ -294,6 +294,7 @@ uint8_t GCS_MAVLINK_Rover::sysid_my_gcs() const
 {
     return rover.g.sysid_my_gcs;
 }
+
 bool GCS_MAVLINK_Rover::sysid_enforce() const
 {
     return rover.g2.sysid_enforce;
@@ -585,6 +586,7 @@ MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlin
 bool GCS_MAVLINK_Rover::set_home_to_current_location(bool _lock) {
     return rover.set_home_to_current_location(_lock);
 }
+
 bool GCS_MAVLINK_Rover::set_home(const Location& loc, bool _lock) {
     return rover.set_home(loc, _lock);
 }
@@ -678,7 +680,6 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
     }
 }
 
-
 // a RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes
 void GCS_MAVLINK_Rover::handle_rc_channels_override(const mavlink_message_t &msg)
 {
@@ -686,13 +687,9 @@ void GCS_MAVLINK_Rover::handle_rc_channels_override(const mavlink_message_t &msg
     GCS_MAVLINK::handle_rc_channels_override(msg);
 }
 
-
 void GCS_MAVLINK_Rover::handleMessage(const mavlink_message_t &msg)
 {
     switch (msg.msgid) {
-
-    
-
     case MAVLINK_MSG_ID_MANUAL_CONTROL:
     {
         if (msg.sysid != rover.g.sysid_my_gcs) {  // Only accept control from our gcs

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -16,7 +16,7 @@ bool Rover::set_home_to_current_location(bool lock)
 }
 
 // sets ahrs home to specified location
-//  returns true if home location set successfully
+// returns true if home location set successfully
 bool Rover::set_home(const Location& loc, bool lock)
 {
     const bool home_was_set = ahrs.home_is_set();

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -479,7 +479,7 @@ Mode *Rover::mode_from_mode_num(const enum Mode::Number num)
         ret = &mode_smartrtl;
         break;
     case Mode::Number::GUIDED:
-       ret = &mode_guided;
+        ret = &mode_guided;
         break;
     case Mode::Number::INITIALISING:
         ret = &mode_initializing;

--- a/Rover/mode_loiter.cpp
+++ b/Rover/mode_loiter.cpp
@@ -37,14 +37,14 @@ void ModeLoiter::update()
             _desired_yaw_cd = degrees(g2.windvane.get_true_wind_direction_rad()) * 100.0f;
         }
     } else {
-        // P controller with hard-coded gain to convert distance to desired speed       
+        // P controller with hard-coded gain to convert distance to desired speed
         _desired_speed = MIN((_distance_to_destination - loiter_radius) * g2.loiter_speed_gain, g2.wp_nav.get_default_speed());
 
-       // calculate bearing to destination
+        // calculate bearing to destination
         _desired_yaw_cd = rover.current_loc.get_bearing_to(_destination);
         float yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
         // if destination is behind vehicle, reverse towards it
-        if ((fabsf(yaw_error_cd) > 9000 && g2.loit_type == 0) || g2.loit_type == 2){
+        if ((fabsf(yaw_error_cd) > 9000 && g2.loit_type == 0) || g2.loit_type == 2) {
             _desired_yaw_cd = wrap_180_cd(_desired_yaw_cd + 18000);
             yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
             _desired_speed = -_desired_speed;


### PR DESCRIPTION
This PR to re-format few files in Rover Dir _(files btw a & c)_.

+Process followed:+
- Used https://ardupilot.org/dev/docs/style-guide.html for style reference.
- Ran the files with **astyle** tool and Added the changes **manually** which are only appropriate.
- For easier verification and merging, Splitting my changes into **multiple** PR's.

Queries, 
- Shouldn't the function definition's **brace** be-the-same-line ?
- I went thought some of the files and For most func def opening brace is no the next line. 
If it is acceptable, I would update the function braces as well.

PS: New here, and not sure from where to start contributing. 
Any suggestion or references are welcomed :).