### PR TITLE
Plane: never reset auto_state.sink_rate

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -15,9 +15,6 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
 
     // special handling for nav vs non-nav commands
     if (AP_Mission::is_nav_cmd(cmd)) {
-        // set land_complete to false to stop us zeroing the throttle
-        auto_state.sink_rate = 0;
-
         // set takeoff_complete to true so we don't add extra elevator
         // except in a takeoff
         auto_state.takeoff_complete = true;


### PR DESCRIPTION
This is a bug introduced back in 2015 during a refactor. The semi-cached sink.rate value used by landing and takeoff was being reset at the start of every waypoint and then had to pass through the filter to come back to it's true value.

SITL tests show there's a slight, if any, slope improvement when starting a NAV_LAND. No noticeable overshot change on takeoff complete.