### PR TITLE
Add read(buffer, buffersize) method to BetterStream (and thus UARTDriver)

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1368,17 +1368,13 @@ uint8_t AP_BLHeli::telem_crc8(uint8_t crc, uint8_t crc_seed) const
 void AP_BLHeli::read_telemetry_packet(void)
 {
     uint8_t buf[telem_packet_size];
-    uint8_t crc = 0;
-    for (uint8_t i=0; i<telem_packet_size; i++) {
-        int16_t v = telem_uart->read();
-        if (v < 0) {
-            // short read, we should have 10 bytes ready when this function is called
-            return;
-        }
-        buf[i] = uint8_t(v);
+    if (telem_uart->read(buf, telem_packet_size) < telem_packet_size) {
+        // short read, we should have 10 bytes ready when this function is called
+        return;
     }
 
     // calculate crc
+    uint8_t crc = 0;
     for (uint8_t i=0; i<telem_packet_size-1; i++) {    
         crc = telem_crc8(buf[i], crc);
     }

--- a/libraries/AP_HAL/utility/BetterStream.cpp
+++ b/libraries/AP_HAL/utility/BetterStream.cpp
@@ -19,3 +19,15 @@ size_t AP_HAL::BetterStream::write(const char *str)
 {
     return write((const uint8_t *)str, strlen(str));
 }
+
+ssize_t AP_HAL::BetterStream::read(uint8_t *buffer, uint16_t count) {
+    uint16_t offset = 0;
+    while (count--) {
+        const int16_t x = read();
+        if (x == -1) {
+            return offset;
+        }
+        buffer[offset++] = (uint8_t)x;
+    }
+    return offset;
+}

--- a/libraries/AP_HAL/utility/BetterStream.h
+++ b/libraries/AP_HAL/utility/BetterStream.h
@@ -19,10 +19,11 @@
 //
 #pragma once
 
-#include <stdarg.h>
-
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL_Namespace.h>
+
+#include <stdarg.h>
+#include <unistd.h>
 
 class AP_HAL::BetterStream {
 public:
@@ -47,6 +48,10 @@ public:
     // do things efficiently.  Looping over 2^32-1 bytes would be bad.
     // returns false if discard failed (e.g. port locked)
     virtual bool discard_input() = 0; // discard all bytes available for reading
+
+    // returns -1 on error (e.g. port locked), number of bytes read
+    // otherwise
+    virtual ssize_t read(uint8_t *buffer, uint16_t count);
 
     /* NB txspace was traditionally a member of BetterStream in the
      * FastSerial library. As far as concerns go, it belongs with available() */

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -582,6 +582,27 @@ bool UARTDriver::discard_input()
     return true;
 }
 
+ssize_t UARTDriver::read(uint8_t *buffer, uint16_t count)
+{
+    if (lock_read_key != 0 || _uart_owner_thd != chThdGetSelfX()){
+        return -1;
+    }
+    if (!_initialised) {
+        return -1;
+    }
+
+    const uint32_t ret = _readbuf.read(buffer, count);
+    if (ret == 0) {
+        return 0;
+    }
+
+    if (!_rts_is_active) {
+        update_rts_line();
+    }
+
+    return ret;
+}
+
 int16_t UARTDriver::read()
 {
     if (lock_read_key != 0 || _uart_owner_thd != chThdGetSelfX()){

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -44,6 +44,7 @@ public:
     uint32_t available() override;
     uint32_t txspace() override;
     int16_t read() override;
+    ssize_t read(uint8_t *buffer, uint16_t count) override;
     int16_t read_locked(uint32_t key) override;
     void _timer_tick(void) override;
 


### PR DESCRIPTION
Also add a user of the function, blheli.

Tested this on a blheli-capable ESC, which continued to provide telem data without issue.
