### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3896,7 +3896,7 @@ class AutoTestCopter(AutoTest):
 
             except Exception as e:
                 self.progress("Exception caught in %s loop: %s" % (loop, self.get_exception_stacktrace(e)))
-                if loop is not "second":
+                if loop != "second":
                     continue
                 ex = e
             break
@@ -4044,7 +4044,7 @@ class AutoTestCopter(AutoTest):
 
             except Exception as e:
                 self.progress("Exception caught in %s loop: %s" % (loop, self.get_exception_stacktrace(e)))
-                if loop is not "second":
+                if loop != "second":
                     continue
                 ex = e
             break


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "second" is "second"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
`flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./Tools/autotest/arducopter.py:3899:20: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
                if loop is not "second":
                   ^
./Tools/autotest/arducopter.py:4047:20: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
                if loop is not "second":
                   ^
2     F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
2
```