### PR TITLE
AP_Arming: add vehicle specific metadata for ARMING_REQUIRE

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -74,7 +74,8 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: REQUIRE
     // @DisplayName: Require Arming Motors 
     // @Description: Arming disabled until some requirements are met. If 0, there are no requirements (arm immediately).  If 1, require rudder stick or GCS arming before arming motors and sends the minimum throttle PWM value to the throttle channel when disarmed.  If 2, require rudder stick or GCS arming and send 0 PWM to throttle channel when disarmed. See the ARMING_CHECK_* parameters to see what checks are done before arming. Note, if setting this parameter to 0 a reboot is required to arm the plane.  Also note, even with this parameter at 0, if ARMING_CHECK parameter is not also zero the plane may fail to arm throttle at boot due to a pre-arm check failure.
-    // @Values: 0:Disabled,1:THR_MIN PWM when disarmed,2:0 PWM when disarmed
+    // @Values{Plane}: 0:Disabled,1:THR_MIN PWM when disarmed,2:0 PWM when disarmed
+    // @Values{Rover}: 0:Disabled,1:THR_MIN PWM when disarmed,2:0 PWM when disarmed
     // @User: Advanced
     AP_GROUPINFO_FLAGS_FRAME("REQUIRE",     0,      AP_Arming,  require,                 1,
                              AP_PARAM_NO_SHIFT,


### PR DESCRIPTION
prevent it appearing in Copter wiki