### PR TITLE
Arming check duplicate switch options on Rover and Plane problem

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -149,12 +149,6 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
     // check various parameter values
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_PARAMETERS)) {
 
-        // ensure all rc channels have different functions
-        if (rc().duplicate_options_exist()) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Duplicate Aux Switch Options");
-            return false;
-        }
-
         // failsafe parameter checks
         if (copter.g.failsafe_throttle) {
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -550,7 +550,11 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
     if ((last_input_ms == 0) || ((AP_HAL::millis() - last_input_ms) > 1000)) {
         return true;
     }
-
+    // ensure all rc channels have different functions
+    if (rc().duplicate_options_exist()) {
+        check_failed(ARMING_CHECK_PARAMETERS, true, "Duplicate Aux Switch Options");
+        return false;
+    }
     bool check_passed = true;
     const RCMapper * rcmap = AP::rcmap();
     if (rcmap != nullptr) {


### PR DESCRIPTION
Arming check for duplicate aux switch options needs to move up #14443:
We're not checking for duplicate switch options when we should on Rover and Plane.
I hope my pull request will fix it.