### PR TITLE
AP_Periph: hwing_esc: restart parsing if second magic not found

### DIFF
--- a/Tools/AP_Periph/hwing_esc.cpp
+++ b/Tools/AP_Periph/hwing_esc.cpp
@@ -66,6 +66,9 @@ bool HWESC_Telem::update()
             continue;
         }
         if (len == 1 && b != TELEM_LEN) {
+            if (b != TELEM_HEADER) {
+                len = 0; // start again
+            }
             continue;
         }
         uint8_t *buf = (uint8_t *)&pkt;


### PR DESCRIPTION
If there is corruption AND then TELEM_LEN appears in the middle of a
packet we'd throw away more bytes than we need to.

I don't have hardware to test this on.
