### PR TITLE
autotest: attempt to make parameter download more reliable

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5217,6 +5217,7 @@ switch value'''
                                                    (str(count), str(expected_count), len(seen_ids.keys())))
                 elif attempt_count != 0:
                     self.progress("Download failed; retrying")
+                    self.delay_sim_time(1)
                 self.drain_mav()
                 self.mav.mav.param_request_list_send(target_system, target_component)
                 attempt_count += 1


### PR DESCRIPTION
something is stopping parameters from being fetched.  Give it time to
clear.