### PR TITLE
Dynamic harmonic notch filters with dynamic harmonics

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -354,8 +354,6 @@ void Copter::throttle_loop()
 
     // compensate for ground effect (if enabled)
     update_ground_effect_detector();
-
-    update_dynamic_notch();
 }
 
 // update_batt_compass - read battery and compass
@@ -631,6 +629,8 @@ void Copter::update_altitude()
         Log_Write_Control_Tuning();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
+#else
+        write_notch_log_messages();
 #endif
     }
 }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -863,7 +863,7 @@ private:
     // system.cpp
     void init_ardupilot() override;
     void startup_INS_ground();
-    void update_dynamic_notch();
+    void update_dynamic_notch() override;
     bool position_ok() const;
     bool ekf_position_ok() const;
     bool optflow_position_ok() const;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -248,16 +248,17 @@ void Copter::update_dynamic_notch()
     }
     const float ref_freq = ins.get_gyro_harmonic_notch_center_freq_hz();
     const float ref = ins.get_gyro_harmonic_notch_reference();
-
     if (is_zero(ref)) {
         ins.update_harmonic_notch_freq_hz(ref_freq);
         return;
     }
 
+    const float throttle_freq = ref_freq * MAX(1.0f, sqrtf(motors->get_throttle_out() / ref));
+
     switch (ins.get_gyro_harmonic_notch_tracking_mode()) {
         case HarmonicNotchDynamicMode::UpdateThrottle: // throttle based tracking
             // set the harmonic notch filter frequency approximately scaled on motor rpm implied by throttle
-            ins.update_harmonic_notch_freq_hz(ref_freq * MAX(1.0f, sqrtf(motors->get_throttle_out() / ref)));
+            ins.update_harmonic_notch_freq_hz(throttle_freq);
             break;
 
 #if RPM_ENABLED == ENABLED
@@ -273,13 +274,35 @@ void Copter::update_dynamic_notch()
 #endif
 #ifdef HAVE_AP_BLHELI_SUPPORT
         case HarmonicNotchDynamicMode::UpdateBLHeli: // BLHeli based tracking
-            ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP_BLHeli::get_singleton()->get_average_motor_frequency_hz() * ref));
+            // set the harmonic notch filter frequency scaled on measured frequency
+            if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
+                float notches[INS_MAX_NOTCHES];
+                const uint8_t num_notches = AP_BLHeli::get_singleton()->get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
+
+                for (uint8_t i = 0; i < num_notches; i++) {
+                    notches[i] =  MAX(ref_freq, notches[i]);
+                }
+                if (num_notches > 0) {
+                    ins.update_harmonic_notch_frequencies_hz(num_notches, notches);
+                } else {    // throttle fallback
+                    ins.update_harmonic_notch_freq_hz(throttle_freq);
+                }
+            } else {
+                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP_BLHeli::get_singleton()->get_average_motor_frequency_hz() * ref));
+            }
             break;
 #endif
 #if HAL_GYROFFT_ENABLED
         case HarmonicNotchDynamicMode::UpdateGyroFFT: // FFT based tracking
             // set the harmonic notch filter frequency scaled on measured frequency
-            ins.update_harmonic_notch_freq_hz(gyro_fft.get_weighted_noise_center_freq_hz());
+            if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
+                float notches[INS_MAX_NOTCHES];
+                const uint8_t peaks = gyro_fft.get_weighted_noise_center_frequencies_hz(INS_MAX_NOTCHES, notches);
+
+                ins.update_harmonic_notch_frequencies_hz(peaks, notches);
+            } else {
+                ins.update_harmonic_notch_freq_hz(gyro_fft.get_weighted_noise_center_freq_hz());
+            }
             break;
 #endif
         case HarmonicNotchDynamicMode::Fixed: // static

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -110,7 +110,6 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if EFI_ENABLED
     SCHED_TASK(efi_update,             10,    200),
 #endif
-    SCHED_TASK(update_dynamic_notch,   50,    200),
 };
 
 void Plane::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
@@ -218,6 +217,8 @@ void Plane::update_logging2(void)
         Log_Write_Control_Tuning();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
+#else
+        write_notch_log_messages();
 #endif
     }
     

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1014,7 +1014,7 @@ private:
     void startup_INS_ground(void);
     bool should_log(uint32_t mask);
     int8_t throttle_percentage(void);
-    void update_dynamic_notch();
+    void update_dynamic_notch() override;
     void notify_mode(const Mode& mode);
 
     // takeoff.cpp

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -456,7 +456,7 @@ void Plane::update_dynamic_notch()
     }
 
     switch (ins.get_gyro_harmonic_notch_tracking_mode()) {
-    case HarmonicNotchDynamicMode::UpdateThrottle: // throttle based tracking
+        case HarmonicNotchDynamicMode::UpdateThrottle: // throttle based tracking
             // set the harmonic notch filter frequency approximately scaled on motor rpm implied by throttle
             if (quadplane.available()) {
                 ins.update_harmonic_notch_freq_hz(ref_freq * MAX(1.0f, sqrtf(quadplane.motors->get_throttle_out() / ref)));
@@ -474,13 +474,37 @@ void Plane::update_dynamic_notch()
             break;
 #ifdef HAVE_AP_BLHELI_SUPPORT
         case HarmonicNotchDynamicMode::UpdateBLHeli: // BLHeli based tracking
-            ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP_BLHeli::get_singleton()->get_average_motor_frequency_hz() * ref));
+            // set the harmonic notch filter frequency scaled on measured frequency
+            if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
+                float notches[INS_MAX_NOTCHES];
+                const uint8_t num_notches = AP_BLHeli::get_singleton()->get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
+
+                for (uint8_t i = 0; i < num_notches; i++) {
+                    notches[i] =  MAX(ref_freq, notches[i]);
+                }
+                if (num_notches > 0) {
+                    ins.update_harmonic_notch_frequencies_hz(num_notches, notches);
+                } else if (quadplane.available()) {    // throttle fallback
+                    ins.update_harmonic_notch_freq_hz(ref_freq * MAX(1.0f, sqrtf(quadplane.motors->get_throttle_out() / ref)));
+                } else {
+                    ins.update_harmonic_notch_freq_hz(ref_freq);
+                }
+            } else {
+                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP_BLHeli::get_singleton()->get_average_motor_frequency_hz() * ref));
+            }
             break;
 #endif
 #if HAL_GYROFFT_ENABLED
         case HarmonicNotchDynamicMode::UpdateGyroFFT: // FFT based tracking
             // set the harmonic notch filter frequency scaled on measured frequency
-            ins.update_harmonic_notch_freq_hz(gyro_fft.get_weighted_noise_center_freq_hz());
+            if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
+                float notches[INS_MAX_NOTCHES];
+                const uint8_t peaks = gyro_fft.get_weighted_noise_center_frequencies_hz(INS_MAX_NOTCHES, notches);
+
+                ins.update_harmonic_notch_frequencies_hz(peaks, notches);
+            } else {
+                ins.update_harmonic_notch_freq_hz(gyro_fft.get_weighted_noise_center_freq_hz());
+            }
             break;
 #endif
         case HarmonicNotchDynamicMode::Fixed: // static

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -329,6 +329,8 @@ void Sub::update_altitude()
         Log_Write_Control_Tuning();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
+#else
+        write_notch_log_messages();
 #endif
     }
 }

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -121,6 +121,8 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     AP_GROUPEND
 };
 
+#define RPM_SLEW_RATE 50
+
 AP_BLHeli *AP_BLHeli::_singleton;
 
 // constructor
@@ -1337,7 +1339,9 @@ float AP_BLHeli::get_average_motor_frequency_hz() const
     for (uint8_t i = 0; i < num_motors; i++) {
         if (last_telem[i].timestamp_ms && (now - last_telem[i].timestamp_ms < 1000)) {
             valid_escs++;
-            motor_freq += last_telem[i].rpm / 60.0f;
+            // slew the update
+            const float slew = MIN(1.0f, (now - last_telem[i].timestamp_ms) * telem_rate / 1000.0f);
+            motor_freq += (prev_motor_rpm[i] + (last_telem[i].rpm - prev_motor_rpm[i]) * slew) / 60.0f;
         }
     }
     if (valid_escs > 0) {
@@ -1345,6 +1349,23 @@ float AP_BLHeli::get_average_motor_frequency_hz() const
     }
 
     return motor_freq;
+}
+
+// return all the motor frequencies in Hz for dynamic filtering
+uint8_t AP_BLHeli::get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) const
+{
+    const uint32_t now = AP_HAL::millis();
+    uint8_t valid_escs = 0;
+    // average the rpm of each motor as reported by BLHeli and convert to Hz
+    for (uint8_t i = 0; i < num_motors && i < nfreqs; i++) {
+        if (last_telem[i].timestamp_ms && (now - last_telem[i].timestamp_ms < 1000)) {
+            // slew the update
+            const float slew = MIN(1.0f, (now - last_telem[i].timestamp_ms) * telem_rate / 1000.0f);
+            freqs[valid_escs++] = (prev_motor_rpm[i] + (last_telem[i].rpm - prev_motor_rpm[i]) * slew) / 60.0f;
+        }
+    }
+
+    return MIN(valid_escs, nfreqs);
 }
 
 /*
@@ -1391,6 +1412,8 @@ void AP_BLHeli::read_telemetry_packet(void)
     td.consumption = (buf[5]<<8) | buf[6];
     td.rpm = ((buf[7]<<8) | buf[8]) * 200 / motor_poles;
     td.timestamp_ms = AP_HAL::millis();
+    // record the previous rpm so that we can slew to the new one
+    prev_motor_rpm[last_telem_esc] = last_telem[last_telem_esc].rpm;
 
     last_telem[last_telem_esc] = td;
     last_telem[last_telem_esc].count++;

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -29,6 +29,7 @@
 #define HAVE_AP_BLHELI_SUPPORT
 
 #include <AP_Param/AP_Param.h>
+#include <Filter/LowPassFilter.h>
 #include "msp_protocol.h"
 #include "blheli_4way_protocol.h"
 
@@ -59,6 +60,8 @@ public:
     bool get_telem_data(uint8_t esc_index, struct telem_data &td);
     // return the average motor frequency in Hz for dynamic filtering
     float get_average_motor_frequency_hz() const;
+    // return all of the motor frequencies in Hz for dynamic filtering
+    uint8_t get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) const;
 
     static AP_BLHeli *get_singleton(void) {
         return _singleton;
@@ -223,6 +226,9 @@ private:
     uint8_t num_motors;
 
     struct telem_data last_telem[max_motors];
+
+    // previous motor rpm so that changes can be slewed
+    float prev_motor_rpm[max_motors];
 
     // have we initialised the interface?
     bool initialised;

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -24,6 +24,7 @@
 #include <Filter/HarmonicNotchFilter.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Arming/AP_Arming.h>
+#include <AP_Vehicle/AP_Vehicle.h>
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
@@ -352,6 +353,23 @@ void AP_GyroFFT::update()
 
     _config._analysis_enabled = _analysis_enabled;
     _global_state = _thread_state;
+
+    // calculate health based on being 5 frames behind, SITL needs longer
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    const uint32_t output_delay = _frame_time_ms * FFT_MAX_MISSED_UPDATES * 2;
+#else
+    const uint32_t output_delay = _frame_time_ms * FFT_MAX_MISSED_UPDATES;
+#endif
+    uint32_t now = AP_HAL::millis();
+    _rpy_health.x = (now - _global_state._health_ms.x <= output_delay);
+    _rpy_health.y = (now - _global_state._health_ms.y <= output_delay);
+    _rpy_health.z = (now - _global_state._health_ms.z <= output_delay);
+
+    if (!_rpy_health.x && !_rpy_health.y) {
+        _health = 0;
+    } else {
+        _health = MIN(_global_state._health, _harmonics);
+    }
 }
 
 // analyse gyro data using FFT, returns number of samples still held
@@ -625,20 +643,13 @@ AP_GyroFFT::FrequencyPeak AP_GyroFFT::get_tracked_noise_peak() const
 
 // return an average center frequency weighted by bin energy
 // called from main thread
-float AP_GyroFFT::get_weighted_noise_center_freq_hz()
+float AP_GyroFFT::get_weighted_noise_center_freq_hz() const
 {
     if (!analysis_enabled()) {
         return _fft_min_hz;
     }
-    // calculate health based on being 5 frames behind, SITL needs longer
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    const uint32_t output_delay = _frame_time_ms * FFT_MAX_MISSED_UPDATES * 2;
-#else
-    const uint32_t output_delay = _frame_time_ms * FFT_MAX_MISSED_UPDATES;
-#endif
-    uint32_t now = AP_HAL::millis();
-    if (now - _global_state._health_ms.x > output_delay && now - _global_state._health_ms.y > output_delay) {
-        _health = 0;
+
+    if (!_health) {
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
         AP_Motors* motors = AP::motors();
         if (motors != nullptr) {
@@ -648,22 +659,62 @@ float AP_GyroFFT::get_weighted_noise_center_freq_hz()
 #endif
     }
 
-    _health = _global_state._health;
-
     const FrequencyPeak peak = get_tracked_noise_peak();
     // pitch was good or required, roll was not, use pitch only
-    if (now - _global_state._health_ms.x > output_delay || _harmonic_peak == FFT_HARMONIC_FIT_TRACK_PITCH) {
+    if (!_rpy_health.x || _harmonic_peak == FFT_HARMONIC_FIT_TRACK_PITCH) {
         return get_noise_center_freq_hz(peak).y;
     }
     // roll was good or required, pitch was not, use roll only
-    if (now - _global_state._health_ms.y > output_delay || _harmonic_peak == FFT_HARMONIC_FIT_TRACK_ROLL) {
+    if (!_rpy_health.y || _harmonic_peak == FFT_HARMONIC_FIT_TRACK_ROLL) {
         return get_noise_center_freq_hz(peak).x;
     }
 
     return calculate_weighted_freq_hz(get_center_freq_energy(peak), get_noise_center_freq_hz(peak));
 }
 
-float AP_GyroFFT::calculate_weighted_freq_hz(const Vector3f& energy, const Vector3f& freq)
+// return all the center frequencies weighted by bin energy
+// called from main thread
+uint8_t AP_GyroFFT::get_weighted_noise_center_frequencies_hz(uint8_t num_freqs, float* freqs) const
+{
+    if (!analysis_enabled()) {
+        freqs[0] = _fft_min_hz;
+        return 1;
+    }
+
+    if (!_health) {
+#if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+        AP_Motors* motors = AP::motors();
+        if (motors != nullptr) {
+            // FFT is not healthy, fallback to throttle-based estimate
+            freqs[0] = constrain_float(_fft_min_hz * MAX(1.0f, sqrtf(motors->get_throttle_out() / _throttle_ref)), _fft_min_hz, _fft_max_hz);
+            return 1;
+        }
+#endif
+    }
+
+    const uint8_t tracked_peaks = MIN(_health, num_freqs);
+    // pitch was good or required, roll was not, use pitch only
+    if (!_rpy_health.x || _harmonic_peak == FFT_HARMONIC_FIT_TRACK_PITCH) {
+        for (uint8_t i = 0; i < tracked_peaks; i++) {
+            freqs[i] = get_noise_center_freq_hz(FrequencyPeak(i)).y;
+        }
+        return tracked_peaks;
+    }
+    // roll was good or required, pitch was not, use roll only
+    if (!_rpy_health.y || _harmonic_peak == FFT_HARMONIC_FIT_TRACK_ROLL) {
+        for (uint8_t i = 0; i < tracked_peaks; i++) {
+            freqs[i] = get_noise_center_freq_hz(FrequencyPeak(i)).x;
+        }
+        return tracked_peaks;
+    }
+
+    for (uint8_t i = 0; i < tracked_peaks; i++) {
+        freqs[i] = calculate_weighted_freq_hz(get_center_freq_energy(FrequencyPeak(i)), get_noise_center_freq_hz(FrequencyPeak(i)));
+    }
+    return tracked_peaks;
+}
+
+float AP_GyroFFT::calculate_weighted_freq_hz(const Vector3f& energy, const Vector3f& freq) const
 {
     // there is generally a lot of high-energy, slightly lower frequency noise on yaw, however this
     // appears to be a second-order effect as only targetting pitch and roll (x & y) produces much cleaner output all round
@@ -696,8 +747,7 @@ void AP_GyroFFT::write_log_messages()
 {
     if (!analysis_enabled()) {
         // still want to see the harmonic notch values
-        AP::logger().Write(
-            "FTN", "TimeUS,DnF", "sz", "F-", "Qf", AP_HAL::micros64(), AP::ins().get_gyro_dynamic_notch_center_freq_hz());
+        AP::vehicle()->write_notch_log_messages();
         return;
     }
 
@@ -719,10 +769,12 @@ void AP_GyroFFT::write_log_messages()
         get_raw_noise_harmonic_fit().z,
         _health, _output_cycle_micros);
 
-    log_noise_peak(0, FrequencyPeak::CENTER);
+    const float* notches = _ins->get_gyro_dynamic_notch_center_frequencies_hz();
+
+    log_noise_peak(0, FrequencyPeak::CENTER, notches[0]);
     if (_harmonics > 1) {
-        log_noise_peak(1, FrequencyPeak::LOWER_SHOULDER);
-        log_noise_peak(2, FrequencyPeak::UPPER_SHOULDER);
+        log_noise_peak(1, FrequencyPeak::LOWER_SHOULDER, notches[1]);
+        log_noise_peak(2, FrequencyPeak::UPPER_SHOULDER, notches[2]);
     }
 
 #if DEBUG_FFT
@@ -747,6 +799,7 @@ void AP_GyroFFT::write_log_messages()
 // @Field: PkX: noise frequency of the peak on roll
 // @Field: PkY: noise frequency of the peak on pitch
 // @Field: PkZ: noise frequency of the peak on yaw
+// @Field: DnF: dynamic harmonic notch centre frequency
 // @Field: BwX: bandwidth of the peak freqency on roll where edges are determined by FFT_ATT_REF
 // @Field: BwY: bandwidth of the peak freqency on pitch where edges are determined by FFT_ATT_REF
 // @Field: BwZ: bandwidth of the peak freqency on yaw where edges are determined by FFT_ATT_REF
@@ -755,14 +808,15 @@ void AP_GyroFFT::write_log_messages()
 // @Field: EnZ: power spectral density bin energy of the peak on roll
 
 // write a single log message
-void AP_GyroFFT::log_noise_peak(uint8_t id, FrequencyPeak peak)
+void AP_GyroFFT::log_noise_peak(uint8_t id, FrequencyPeak peak, float notch)
 {
-    AP::logger().Write("FTN2", "TimeUS,Id,PkX,PkY,PkZ,BwX,BwY,BwZ,EnX,EnY,EnZ", "s#zzzzzz---", "F----------", "QBfffffffff",
+    AP::logger().Write("FTN2", "TimeUS,Id,PkX,PkY,PkZ,DnF,BwX,BwY,BwZ,EnX,EnY,EnZ", "s#zzzzzzz---", "F-----------", "QBffffffffff",
         AP_HAL::micros64(),
         id,
         get_noise_center_freq_hz(peak).x,
         get_noise_center_freq_hz(peak).y,
         get_noise_center_freq_hz(peak).z,
+        notch,
         get_noise_center_bandwidth_hz(peak).x,
         get_noise_center_bandwidth_hz(peak).y,
         get_noise_center_bandwidth_hz(peak).z,
@@ -773,7 +827,7 @@ void AP_GyroFFT::log_noise_peak(uint8_t id, FrequencyPeak peak)
 
 // return an average noise bandwidth weighted by bin energy
 // called from main thread
-float AP_GyroFFT::get_weighted_noise_center_bandwidth_hz()
+float AP_GyroFFT::get_weighted_noise_center_bandwidth_hz() const
 {
     if (!analysis_enabled()) {
         return 0.0f;

--- a/libraries/AP_GyroFFT/AP_GyroFFT.h
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.h
@@ -80,7 +80,9 @@ public:
     // energy of the background noise at the detected center frequency
     const Vector3f& get_noise_signal_to_noise_db() const { return _global_state._center_snr; }
     // detected peak frequency weighted by energy
-    float get_weighted_noise_center_freq_hz();
+    float get_weighted_noise_center_freq_hz() const;
+    // all detected peak frequencies weighted by energy
+    uint8_t get_weighted_noise_center_frequencies_hz(uint8_t num_freqs, float* freqs) const;
     // detected peak frequency
     const Vector3f& get_raw_noise_center_freq_hz() const { return _global_state._center_freq_hz; }
     // match between first and second harmonics
@@ -94,7 +96,7 @@ public:
     const Vector3f& get_noise_center_bandwidth_hz() const { return get_noise_center_bandwidth_hz(FrequencyPeak::CENTER); }
     const Vector3f& get_noise_center_bandwidth_hz(FrequencyPeak peak) const { return _global_state._center_bandwidth_hz_filtered[peak]; };
     // weighted detected peak bandwidth
-    float get_weighted_noise_center_bandwidth_hz();
+    float get_weighted_noise_center_bandwidth_hz() const;
     // log gyro fft messages
     void write_log_messages();
 
@@ -170,7 +172,7 @@ private:
         return (_thread_state._center_bandwidth_hz_filtered[peak][axis] = _center_bandwidth_filter[peak].apply(axis, value));
     }
     // write single log mesages
-    void log_noise_peak(uint8_t id, FrequencyPeak peak);
+    void log_noise_peak(uint8_t id, FrequencyPeak peak, float notch_freq);
     // calculate the peak noise frequency
     void calculate_noise(bool calibrating, const EngineConfig& config);
     // calculate noise peaks based on energy and history
@@ -186,7 +188,7 @@ private:
     // return the instantaneous peak that is closest to the target estimate peak
     FrequencyPeak find_closest_peak(const FrequencyPeak target, const DistanceMatrix& distance_matrix, uint8_t ignore = 0) const;
     // detected peak frequency weighted by energy
-    float calculate_weighted_freq_hz(const Vector3f& energy, const Vector3f& freq);
+    float calculate_weighted_freq_hz(const Vector3f& energy, const Vector3f& freq) const;
     // update the estimation of the background noise energy
     void update_ref_energy(uint16_t max_bin);
     // test frequency detection for all of the allowable bins
@@ -269,8 +271,10 @@ private:
     float _harmonic_multiplier;
     // searched harmonics - inferred from harmonic notch harmonics
     uint8_t _harmonics;
-    // engine health
+    // engine health in tracked peaks
     uint8_t _health;
+    // engine health on roll/pitch/yaw
+    Vector3<uint8_t> _rpy_health;
 
     // smoothing filter on the output
     MedianLowPassFilter3dFloat _center_freq_filter[FrequencyPeak::MAX_TRACKED_PEAKS];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -13,6 +13,7 @@
  */
 #define INS_MAX_INSTANCES 3
 #define INS_MAX_BACKENDS  6
+#define INS_MAX_NOTCHES 4
 #define INS_VIBRATION_CHECK_INSTANCES 2
 #define XYZ_AXIS_COUNT    3
 // The maximum we need to store is gyro-rate / loop-rate, worst case ArduCopter with BMI088 is 2000/400
@@ -218,6 +219,8 @@ public:
 
     // Update the harmonic notch frequency
     void update_harmonic_notch_freq_hz(float scaled_freq);
+    // Update the harmonic notch frequencies
+    void update_harmonic_notch_frequencies_hz(uint8_t num_freqs, const float scaled_freq[]);
 
     // enable HIL mode
     void set_hil_mode(void) { _hil_mode = true; }
@@ -229,7 +232,13 @@ public:
     uint16_t get_accel_filter_hz(void) const { return _accel_filter_cutoff; }
 
     // harmonic notch current center frequency
-    float get_gyro_dynamic_notch_center_freq_hz(void) const { return _calculated_harmonic_notch_freq_hz; }
+    float get_gyro_dynamic_notch_center_freq_hz(void) const { return _calculated_harmonic_notch_freq_hz[0]; }
+
+    // set of harmonic notch current center frequencies
+    const float* get_gyro_dynamic_notch_center_frequencies_hz(void) const { return _calculated_harmonic_notch_freq_hz; }
+
+    // number of harmonic notch current center frequencies
+    uint8_t get_num_gyro_dynamic_notch_center_frequencies(void) const { return _num_calculated_harmonic_notch_frequencies; }
 
     // harmonic notch reference center frequency
     float get_gyro_harmonic_notch_center_freq_hz(void) const { return _harmonic_notch_filter.center_freq_hz(); }
@@ -242,6 +251,11 @@ public:
 
     // harmonic notch harmonics
     uint8_t get_gyro_harmonic_notch_harmonics(void) const { return _harmonic_notch_filter.harmonics(); }
+
+    // harmonic notch options
+    bool has_harmonic_option(HarmonicNotchFilterParams::Options option) {
+        return _harmonic_notch_filter.hasOption(option);
+    }
 
     // indicate which bit in LOG_BITMASK indicates raw logging enabled
     void set_log_raw_bit(uint32_t log_raw_bit) { _log_raw_bit = log_raw_bit; }
@@ -456,7 +470,8 @@ private:
     HarmonicNotchFilterParams _harmonic_notch_filter;
     HarmonicNotchFilterVector3f _gyro_harmonic_notch_filter[INS_MAX_INSTANCES];
     // the current center frequency for the notch
-    float _calculated_harmonic_notch_freq_hz;
+    float _calculated_harmonic_notch_freq_hz[INS_MAX_NOTCHES];
+    uint8_t _num_calculated_harmonic_notch_frequencies;
 
     // Most recent gyro reading
     Vector3f _gyro[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -234,8 +234,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
             _imu._gyro_window[instance][2].push(scaled_gyro.z);
         }
 #endif
-        // apply the low pass filter
-        Vector3f gyro_filtered = _imu._gyro_filter[instance].apply(gyro);
+        Vector3f gyro_filtered = gyro;
 
         // apply the notch filter
         if (_gyro_notch_enabled()) {
@@ -246,6 +245,9 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
         if (gyro_harmonic_notch_enabled()) {
             gyro_filtered = _imu._gyro_harmonic_notch_filter[instance].apply(gyro_filtered);
         }
+
+        // apply the low pass filter last to attentuate any notch induced noise
+        gyro_filtered = _imu._gyro_filter[instance].apply(gyro_filtered);
 
         // if the filtering failed in any way then reset the filters and keep the old value
         if (gyro_filtered.is_nan() || gyro_filtered.is_inf()) {
@@ -539,7 +541,11 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
         _last_harmonic_notch_bandwidth_hz = gyro_harmonic_notch_bandwidth_hz();
         _last_harmonic_notch_attenuation_dB = gyro_harmonic_notch_attenuation_dB();
     } else if (!is_equal(_last_harmonic_notch_center_freq_hz, gyro_harmonic_notch_center_freq_hz())) {
-        _imu._gyro_harmonic_notch_filter[instance].update(gyro_harmonic_notch_center_freq_hz());
+        if (num_gyro_harmonic_notch_center_frequencies() > 1) {
+            _imu._gyro_harmonic_notch_filter[instance].update(num_gyro_harmonic_notch_center_frequencies(), gyro_harmonic_notch_center_frequencies_hz());
+        } else {
+            _imu._gyro_harmonic_notch_filter[instance].update(gyro_harmonic_notch_center_freq_hz());
+        }
         _last_harmonic_notch_center_freq_hz = gyro_harmonic_notch_center_freq_hz();
     }
     // possily update the notch filter parameters

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -248,7 +248,13 @@ protected:
     bool _gyro_notch_enabled(void) const { return _imu._notch_filter.enabled(); }
 
     // return the harmonic notch filter center in Hz for the sample rate
-    float gyro_harmonic_notch_center_freq_hz() const { return _imu._calculated_harmonic_notch_freq_hz; }
+    float gyro_harmonic_notch_center_freq_hz() const { return _imu.get_gyro_dynamic_notch_center_freq_hz(); }
+
+    // set of harmonic notch current center frequencies
+    const float* gyro_harmonic_notch_center_frequencies_hz(void) const { return _imu.get_gyro_dynamic_notch_center_frequencies_hz(); }
+
+    // number of harmonic notch current center frequencies
+    uint8_t num_gyro_harmonic_notch_center_frequencies(void) const { return _imu.get_num_gyro_dynamic_notch_center_frequencies(); }
 
     // return the harmonic notch filter bandwidth in Hz for the sample rate
     float gyro_harmonic_notch_bandwidth_hz(void) const { return _imu._harmonic_notch_filter.bandwidth_hz(); }

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -176,6 +176,11 @@ public:
     // get target location (for use by scripting)
     virtual bool get_target_location(Location& target_loc) { return false; }
 
+    // write out harmonic notch log messages
+    void write_notch_log_messages() const;
+    // update the harmonic notch
+    virtual void update_dynamic_notch() {};
+    
 protected:
 
     virtual void init_ardupilot() = 0;

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -35,6 +35,8 @@ public:
     void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
     // update the underlying filters' center frequencies using center_freq_hz as the fundamental
     void update(float center_freq_hz);
+    // update all o fthe underlying center frequencies individually
+    void update(uint8_t num_centers, const float center_freq_hz[]);
     // apply a sample to each of the underlying filters in turn
     T apply(const T &sample);
     // reset each of the underlying filters
@@ -78,6 +80,7 @@ class HarmonicNotchFilterParams : public NotchFilterParams {
 public:
     enum class Options {
         DoubleNotch = 1<<0,
+        DynamicHarmonic = 1<<1,
     };
 
     HarmonicNotchFilterParams(void);


### PR DESCRIPTION
This allows the three frequency peaks that the FFT is tracking to be used to set three individual harmonic notches rather than setting the lower one and relying on harmonic multipliers. This does not increase the number of notches used, it merely sets their center frequencies individually. There is no increased CPU cost in doing it this way versus a harmonic notch with three harmonics (the default). 

It occurred to me that 3 individual notches was only one off the 4 required to have individual notches per motor. So I have added that support for ESC telemetry.

Works quite well, flown on both a Y6B/Durandal/FFT and 3"/KakuteF7Mini/ESC

@tridge if this works well it would be super useful for quadplane.