### PR TITLE
AP_NavEKF3: Accumulate error for cores

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -500,6 +500,8 @@ struct PACKED log_NKF3 {
     int16_t innovMZ;
     int16_t innovYaw;
     int16_t innovVT;
+    float rerr;
+    float errorScore;
 };
 
 struct PACKED log_EKF4 {
@@ -1778,6 +1780,8 @@ struct PACKED log_Arm_Disarm {
 // @Field: IMZ: Innovation in magnetic field strength (Z-axis component)
 // @Field: IYAW: Innovation in vehicle yaw
 // @Field: IVT: Innovation in true-airspeed
+// @Field: RErr: Accumulated relative error of this core with respect to active primary core
+// @Field: ErSc: A consolidated error score where higher numbers are less healthy
 
 // @LoggerMessage: NKF4
 // @Description: EKF2 variances
@@ -2200,6 +2204,8 @@ struct PACKED log_Arm_Disarm {
 // @Field: IMZ: Innovation in magnetic field strength (Z-axis component)
 // @Field: IYAW: Innovation in vehicle yaw
 // @Field: IVT: Innovation in true-airspeed
+// @Field: RErr: Accumulated relative error of this core with respect to active primary core
+// @Field: ErSc: A consolidated error score where higher numbers are less healthy
 
 // @LoggerMessage: XKF4
 // @Description: EKF3 variances
@@ -2377,7 +2383,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_NKF2_MSG, sizeof(log_NKF2), \
       "NKF2","QBbccccchhhhhhB","TimeUS,C,AZbias,GSX,GSY,GSZ,VWN,VWE,MN,ME,MD,MX,MY,MZ,MI", "s#----nnGGGGGG-", "F-----BBCCCCCC-" }, \
     { LOG_NKF3_MSG, sizeof(log_NKF3), \
-      "NKF3","QBcccccchhhcc","TimeUS,C,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT", "s#nnnmmmGGG??", "F-BBBBBBCCCBB" }, \
+      "NKF3","QBcccccchhhccff","TimeUS,C,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT,RErr,ErSc", "s#nnnmmmGGG??--", "F-BBBBBBCCCBB00" }, \
     { LOG_NKF4_MSG, sizeof(log_NKF4), \
       "NKF4","QBcccccfbbHBIHb","TimeUS,C,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI", "s#------??-----", "F-------??-----" }, \
     { LOG_NKF5_MSG, sizeof(log_NKF5), \
@@ -2390,7 +2396,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_XKF2_MSG, sizeof(log_XKF2), \
       "XKF2","QBccccchhhhhhB","TimeUS,C,AX,AY,AZ,VWN,VWE,MN,ME,MD,MX,MY,MZ,MI", "s#---nnGGGGGG-", "F----BBCCCCCC-" }, \
     { LOG_XKF3_MSG, sizeof(log_NKF3), \
-      "XKF3","QBcccccchhhcc","TimeUS,C,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT", "s#nnnmmmGGG??", "F-BBBBBBCCCBB" }, \
+      "XKF3","QBcccccchhhccff","TimeUS,C,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT,RErr,ErSc", "s#nnnmmmGGG??--", "F-BBBBBBCCCBB00" }, \
     { LOG_XKF4_MSG, sizeof(log_NKF4), \
       "XKF4","QBcccccfbbHBIHb","TimeUS,C,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI", "s#------??-----", "F-------??-----" }, \
     { LOG_XKF5_MSG, sizeof(log_NKF5), \

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -102,7 +102,9 @@ void NavEKF2::Log_Write_NKF3(uint8_t _core, uint64_t time_us) const
         innovMY : (int16_t)(magInnov.y),
         innovMZ : (int16_t)(magInnov.z),
         innovYaw : (int16_t)(100*degrees(yawInnov)),
-        innovVT : (int16_t)(100*tasInnov)
+        innovVT : (int16_t)(100*tasInnov),
+        rerr : 0, // TODO : Relative Error based Lane-Switching like EK3
+        errorScore : 0 // TODO : Relative Error based Lane-Switching like EK3
     };
     AP::logger().WriteBlock(&pkt3, sizeof(pkt3));
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -704,14 +704,14 @@ bool NavEKF3::InitialiseFilter(void)
         _imuMask.set(_imuMask.get() & mask);
         
         // initialise the setup variables
-        for (uint8_t i=0; i<7; i++) {
+        for (uint8_t i=0; i<MAX_EKF_CORES; i++) {
             coreSetupRequired[i] = false;
             coreImuIndex[i] = 0;
         }
         num_cores = 0;
 
         // count IMUs from mask
-        for (uint8_t i=0; i<7; i++) {
+        for (uint8_t i=0; i<MAX_EKF_CORES; i++) {
             if (_imuMask & (1U<<i)) {
                 coreSetupRequired[num_cores] = true;
                 coreImuIndex[num_cores] = i;
@@ -757,6 +757,9 @@ bool NavEKF3::InitialiseFilter(void)
         return false;
     }
 
+    // initialize relative error scores for all cores to 0
+    resetCoreErrors();
+
     // Set the primary initially to be the lowest index
     primary = 0;
 
@@ -779,7 +782,10 @@ bool NavEKF3::InitialiseFilter(void)
     return ret;
 }
 
-// Update Filter States - this should be called whenever new IMU data is available
+/* 
+  Update Filter States - this should be called whenever new IMU data is available
+  Execution speed governed by SCHED_LOOP_RATE
+*/
 void NavEKF3::UpdateFilter(void)
 {
     if (!core) {
@@ -815,34 +821,54 @@ void NavEKF3::UpdateFilter(void)
         }
         runCoreSelection = (imuSampleTime_us - lastUnhealthyTime_us) > 1E7;
     }
-    float primaryErrorScore = core[primary].errorScore();
-    if ((primaryErrorScore > 1.0f || !core[primary].healthy()) && runCoreSelection) {
-        float lowestErrorScore = 0.67f * primaryErrorScore;
-        uint8_t newPrimaryIndex = primary; // index for new primary
+                                   
+    if (runCoreSelection) {
+        // update this instance's error scores for all active cores and get the primary core's error score
+        float primaryErrorScore = updateCoreErrorScores();
+
+        // update the accumulated relative error scores for all active cores
+        updateCoreRelativeErrors();
+
+        bool betterCore = false;
+        bool altCoreAvailable = false;
+        float maxCoreError = 0; // looking for cores that have error lower than the current primary
+        uint8_t newPrimaryIndex = primary;
+
+        // loop through all available cores to find if an alternative core is available
         for (uint8_t coreIndex=0; coreIndex<num_cores; coreIndex++) {
-
             if (coreIndex != primary) {
-                // an alternative core is available for selection only if healthy and if states have been updated on this time step
-                bool altCoreAvailable = core[coreIndex].healthy() && statePredictEnabled[coreIndex];
+                float altCoreError = coreRelativeErrors[coreIndex];
 
-                // If the primary core is unhealthy and another core is available, then switch now
-                // If the primary core is still healthy,then switching is optional and will only be done if
-                // a core with a significantly lower error score can be found
-                float altErrorScore = core[coreIndex].errorScore();
-                if (altCoreAvailable && (!core[newPrimaryIndex].healthy() || altErrorScore < lowestErrorScore)) {
+                // an alternative core is available for selection based on 2 conditions -
+                // 1. healthy and states have been updated on this time step
+                // 2. has relative error less than primary core error
+                altCoreAvailable = core[coreIndex].healthy() && statePredictEnabled[coreIndex] && altCoreError < maxCoreError;
+
+                if (altCoreAvailable) {
+                    // if this core has a significantly lower relative error to the active primary, we consider it as a 
+                    // better core and would like to switch to it even if the current primary is healthy
+                    betterCore = altCoreError <= -BETTER_THRESH; // a better core if its relative error is below a substantial level than the primary's
+                    maxCoreError = altCoreError;
                     newPrimaryIndex = coreIndex;
-                    lowestErrorScore = altErrorScore;
-                }
+                } 
             }
         }
-        // update the yaw and position reset data to capture changes due to the lane switch
-        if (newPrimaryIndex != primary) {
+        altCoreAvailable = newPrimaryIndex != primary;
+
+        // Switch cores if another core is available and the active primary core meets one of the following conditions - 
+        // 1. has a bad error score
+        // 2. is unhealthy
+        // 3. is healthy, but a better core is available
+        // also update the yaw and position reset data to capture changes due to the lane switch
+        if (altCoreAvailable && (primaryErrorScore > 1.0f || !core[primary].healthy() || betterCore)) {
             updateLaneSwitchYawResetData(newPrimaryIndex, primary);
             updateLaneSwitchPosResetData(newPrimaryIndex, primary);
             updateLaneSwitchPosDownResetData(newPrimaryIndex, primary);
+            resetCoreErrors();
             primary = newPrimaryIndex;
             lastLaneSwitch_ms = AP_HAL::millis();
-        }
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "NavEKF3: lane switch %u", primary);
+        }       
     }
 
     if (primary != 0 && core[0].healthy() && !hal.util->get_soft_armed()) {
@@ -904,6 +930,46 @@ void NavEKF3::requestYawReset(void)
 {
     for (uint8_t i = 0; i < num_cores; i++) {
         core[primary].EKFGSF_requestYawReset();
+    }
+}
+
+/*
+  Update this instance error score value for all active cores
+*/
+float NavEKF3::updateCoreErrorScores()
+{
+    for (uint8_t i = 0; i < num_cores; i++) {
+        coreErrorScores[i] = core[i].errorScore();
+    }
+    return coreErrorScores[primary];
+}
+
+/*
+  Update the relative error for all alternate available cores with respect to primary core's error.
+  A positive relative error for a core means it has been more erroneous than the existing primary.
+  A negative relative error indicates a core which can be switched to.
+*/
+void NavEKF3::updateCoreRelativeErrors()
+{
+    float error = 0;
+    for (uint8_t i = 0; i < num_cores; i++) {
+        if(i != primary) {
+            error = coreErrorScores[i] - coreErrorScores[primary];
+
+            // reduce error for a core only if its better than the primary lane by at least the Relative Error Threshold, this should prevent unnecessary lane changes
+            if(error > 0 || error < -REL_ERR_THRESH) {
+                coreRelativeErrors[i] += error;
+                coreRelativeErrors[i] = constrain_float(coreRelativeErrors[i], -CORE_ERR_LIM, CORE_ERR_LIM);
+            }
+        }
+    }
+}
+
+// Reset the relative error values
+void NavEKF3::resetCoreErrors(void)
+{
+    for (uint8_t i = 0; i < num_cores; i++) {
+        coreRelativeErrors[i] = 0;
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -58,8 +58,18 @@ public:
     
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
+
     // Check that all cores are started and healthy
     bool all_cores_healthy(void) const;
+
+    // Update instance error scores for all available cores 
+    float updateCoreErrorScores(void);
+
+    // Update relative error scores for all alternate available cores
+    void updateCoreRelativeErrors(void);
+
+    // Reset error scores for all available cores
+    void resetCoreErrors(void);
 
     // returns the index of the primary core
     // return -1 if no primary core selected
@@ -553,9 +563,16 @@ private:
         float core_delta;             // the amount of D position change between cores when a change happened
     } pos_down_reset_data;
 
-    bool runCoreSelection; // true when the primary core has stabilised and the core selection logic can be started
-    bool coreSetupRequired[7]; // true when this core index needs to be setup
-    uint8_t coreImuIndex[7];   // IMU index used by this core
+#define MAX_EKF_CORES     3 // maximum allowed EKF Cores to be instantiated
+#define CORE_ERR_LIM      1 // -LIM to LIM relative error range for a core
+#define REL_ERR_THRESH  0.2 // lanes have to be consistently better than the primary by at least this threshold to reduce their overall relativeCoreError
+#define BETTER_THRESH   0.5 // a lane should have this much relative error difference to 
+    
+    bool runCoreSelection;                    // true when the primary core has stabilised and the core selection logic can be started
+    bool coreSetupRequired[MAX_EKF_CORES];    // true when this core index needs to be setup
+    uint8_t coreImuIndex[MAX_EKF_CORES];      // IMU index used by this core
+    float coreRelativeErrors[MAX_EKF_CORES];   // relative errors of cores with respect to primary
+    float coreErrorScores[MAX_EKF_CORES];     // the instance error values used to update relative core error
 
     bool inhibitGpsVertVelUse;  // true when GPS vertical velocity use is prohibited
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -99,7 +99,9 @@ void NavEKF3::Log_Write_XKF3(uint8_t _core, uint64_t time_us) const
         innovMY : (int16_t)(magInnov.y),
         innovMZ : (int16_t)(magInnov.z),
         innovYaw : (int16_t)(100*degrees(yawInnov)),
-        innovVT : (int16_t)(100*tasInnov)
+        innovVT : (int16_t)(100*tasInnov),
+        rerr : coreRelativeErrors[_core],
+        errorScore : coreErrorScores[_core]
     };
     AP::logger().WriteBlock(&pkt3, sizeof(pkt3));
 }
@@ -177,7 +179,7 @@ void NavEKF3::Log_Write_XKF5(uint64_t time_us) const
         angErr : (float)predictorErrors.x,
         velErr : (float)predictorErrors.y,
         posErr : (float)predictorErrors.z
-     };
+    };
     AP::logger().WriteBlock(&pkt5, sizeof(pkt5));
 }
 


### PR DESCRIPTION
To improve core selection logic, accumulate error for each EKF lane then select the one with lowest error as new primary.

We start by simply adding up NavEKF3_core::errorScore() for each lane. We would like to explore a better metric that takes into account - 
1. State Difference
2. Innovations
3. Variances

Finally, the error should be some weighted combination of factors can quantify a core's error.