### PR TITLE
Plane: Protect against a divide by 0 when calculating the forward throttle compensation

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -361,6 +361,11 @@ void Plane::throttle_voltage_comp()
     // constrain read voltage to min and max params
     batt_voltage_resting_estimate = constrain_float(batt_voltage_resting_estimate,g2.fwd_thr_batt_voltage_min,g2.fwd_thr_batt_voltage_max);
 
+    // don't apply compensation if the voltage is excessively low
+    if (batt_voltage_resting_estimate < 1) {
+        return;
+    }
+
     // Scale the throttle up to compensate for voltage drop
     // Ratio = 1 when voltage = voltage max, ratio increases as voltage drops
     const float ratio = g2.fwd_thr_batt_voltage_max / batt_voltage_resting_estimate;


### PR DESCRIPTION
I found this the hardway, where the MAX parameter was appropriately set, but the battery monitor wasn't enabled. This was killing SITL with FPE's, and was unrecoverable. With a bit more thought I decided we should have a general protection, because if you try and enable this in flight, your parameter writes may arrive out of order, and it'd be better to not start feeding random scalars into the constraint code, because while the constraint will attempt to protect you here, it will arrive at the average of high and low, which feeds a value of 0 as your throttle output.