### PR TITLE
AP_Logger: add min MB free param

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -94,6 +94,7 @@ known_units = {
 # compound
 
              'kB'      : 'kilobytes'                ,
+             'MB'      : 'megabyte'                ,
              'm.m/s/s' : 'square meter per square second',
              'deg/m/s' : 'degrees per meter per second'  ,
              'm/s/m'   : 'meters per second per meter'   , # Why not use Hz here ????

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -92,7 +92,15 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
     // @User: Standard
     // @Units: s
     AP_GROUPINFO("_FILE_TIMEOUT",  6, AP_Logger, _params.file_timeout,     HAL_LOGGING_FILE_TIMEOUT),
-    
+
+    // @Param: _FILE_MB_FREE
+    // @DisplayName: Old logs on the SD card will be deleted to maintain this amount of free space
+    // @Description: Set this such that the free space is larger than your largest typical flight log
+    // @Units: MB
+    // @Range: 10 1000
+    // @User: Standard
+    AP_GROUPINFO("_FILE_MB_FREE",  7, AP_Logger, _params.min_MB_free, 500),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -343,6 +343,7 @@ public:
         AP_Int8 log_replay;
         AP_Int8 mav_bufsize; // in kilobytes
         AP_Int16 file_timeout; // in seconds
+        AP_Int16 min_MB_free;
     } _params;
 
     const struct LogStructure *structure(uint16_t num) const;

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -97,17 +97,10 @@ private:
     uint16_t find_oldest_log();
     int64_t disk_space_avail();
     int64_t disk_space();
-    float avail_space_percent();
 
     bool file_exists(const char *filename) const;
     bool log_exists(const uint16_t lognum) const;
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-    // I always seem to have less than 10% free space on my laptop:
-    const float min_avail_space_percent = 0.1f;
-#else
-    const float min_avail_space_percent = 10.0f;
-#endif
     // write buffer
     ByteBuffer _writebuf;
     const uint16_t _writebuf_chunk;


### PR DESCRIPTION
This moves a compile time hard coded value to a param. The use case is to ensure a full flight log can be recorded. The hard coded 10% free was not enough for those doing multiple hour flights. This saves having to delete ensuring the latest logs are kept in full.