### PR TITLE
Create directory in log open

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -79,9 +79,6 @@ void AP_Logger_File::Init()
 {
     AP_Logger_Backend::Init();
 
-    // create the log directory if need be
-    ensure_log_directory_exists();
-
     // determine and limit file backend buffersize
     uint32_t bufsize = _front._params.file_bufsize;
     if (bufsize > 64) {
@@ -842,6 +839,9 @@ void AP_Logger_File::start_new_log(void)
     uint64_t utc_usec;
     _need_rtc_update = !AP::rtc().get_utc_usec(utc_usec);
 #endif
+
+    // create the log directory if need be
+    ensure_log_directory_exists();
 
     EXPECT_DELAY_MS(3000);
     _write_fd = AP::FS().open(_write_filename, O_WRONLY|O_CREAT|O_TRUNC);

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -55,10 +55,8 @@ AP_Logger_File::AP_Logger_File(AP_Logger &front,
 }
 
 
-void AP_Logger_File::Init()
+void AP_Logger_File::ensure_log_directory_exists()
 {
-    AP_Logger_Backend::Init();
-    // create the log directory if need be
     int ret;
     struct stat st;
 
@@ -75,6 +73,14 @@ void AP_Logger_File::Init()
     if (ret == -1 && errno != EEXIST) {
         printf("Failed to create log directory %s : %s\n", _log_directory, strerror(errno));
     }
+}
+
+void AP_Logger_File::Init()
+{
+    AP_Logger_Backend::Init();
+
+    // create the log directory if need be
+    ensure_log_directory_exists();
 
     // determine and limit file backend buffersize
     uint32_t bufsize = _front._params.file_bufsize;

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -99,6 +99,8 @@ private:
     int64_t disk_space();
     float avail_space_percent();
 
+    void ensure_log_directory_exists();
+
     bool file_exists(const char *filename) const;
     bool log_exists(const uint16_t lognum) const;
 


### PR DESCRIPTION
Moves the directory creation to where we open the logfile.

This has the advantage that if someone inserts an SD card late that doesn't have the directory structure we may be able to start logging.

This still relies on the HAL creating all the directories leading up to this one.
