### PR TITLE
Copter: verify_circle loses redundant setting of circle center

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1822,23 +1822,6 @@ bool ModeAuto::verify_circle(const AP_Mission::Mission_Command& cmd)
     // check if we've reached the edge
     if (mode() == Auto_CircleMoveToEdge) {
         if (copter.wp_nav->reached_wp_destination()) {
-            Vector3f circle_center;
-            if (!cmd.content.location.get_vector_from_origin_NEU(circle_center)) {
-                // should never happen
-                return true;
-            }
-            const Vector3f curr_pos = copter.inertial_nav.get_position();
-            // set target altitude if not provided
-            if (is_zero(circle_center.z)) {
-                circle_center.z = curr_pos.z;
-            }
-
-            // set lat/lon position if not provided
-            if (cmd.content.location.lat == 0 && cmd.content.location.lng == 0) {
-                circle_center.x = curr_pos.x;
-                circle_center.y = curr_pos.y;
-            }
-
             // start circling
             circle_start();
         }


### PR DESCRIPTION
This PR simplifies the verify_circle() command (used when executing LOITER_TURN mission commands) so that it does not reset the circle center.  There is no need to set the circle's center because it has already been set in **circle_movetoedge_start()** which is always been called (by do_circle()) before **verify_circle()**.

The redundant code is also incorrect because it was missed from PR https://github.com/ArduPilot/ardupilot/pull/14028 which added terrain following support to Loiter Turns.

This has been successfully tested in SITL and on a real vehicle.

Terrain following in Circle mode is a new feature that has not been released yet so no need to backport this fix.