### PR TITLE
AP_Proximity:Fix proximity ignored zone calulation

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -239,7 +239,7 @@ bool AP_Proximity_Backend::ignore_reading(uint16_t angle_deg) const
     // check angle vs each ignore area
     for (uint8_t i=0; i < PROXIMITY_MAX_IGNORE; i++) {
         if (frontend._ignore_width_deg[i] != 0) {
-            if (abs(angle_deg - frontend._ignore_width_deg[i]) <= (frontend._ignore_width_deg[i]/2)) {
+            if (abs(angle_deg - frontend._ignore_angle_deg[i]) <= (frontend._ignore_width_deg[i]/2)) {
                 return true;
             }
         }


### PR DESCRIPTION
It seems there was a typo in the checking of proximity ignored zones.
-- I just wonder how many people actually using this, if this is not discovered yet.