### PR TITLE
rename 'enum aux_switch_pos_t' to 'enum class AuxSwitchPos'

### DIFF
--- a/ArduCopter/RC_Channel.h
+++ b/ArduCopter/RC_Channel.h
@@ -11,14 +11,14 @@ public:
 
 protected:
 
-    void init_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
-    void do_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
+    void init_aux_function(aux_func_t ch_option, AuxSwitchPos) override;
+    void do_aux_function(aux_func_t ch_option, AuxSwitchPos) override;
 
 private:
 
-    void do_aux_function_armdisarm(const aux_switch_pos_t ch_flag) override;
+    void do_aux_function_armdisarm(const AuxSwitchPos ch_flag) override;
     void do_aux_function_change_mode(const Mode::Number mode,
-                                     const aux_switch_pos_t ch_flag);
+                                     const AuxSwitchPos ch_flag);
 
     // called when the mode switch changes position:
     void mode_switch_changed(modeswitch_pos_t new_pos) override;

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -33,10 +33,10 @@ RC_Channel * RC_Channels_Plane::get_arming_channel(void) const
 }
 
 void RC_Channel_Plane::do_aux_function_change_mode(const Mode::Number number,
-                                                   const aux_switch_pos_t ch_flag)
+                                                   const AuxSwitchPos ch_flag)
 {
     switch(ch_flag) {
-    case HIGH: {
+    case AuxSwitchPos::HIGH: {
         // engage mode (if not possible we remain in current flight mode)
         const bool success = plane.set_mode_by_number(number, ModeReason::RC_COMMAND);
         if (plane.control_mode != &plane.mode_initializing) {
@@ -58,20 +58,20 @@ void RC_Channel_Plane::do_aux_function_change_mode(const Mode::Number number,
     }
 }
 
-void RC_Channel_Plane::do_aux_function_q_assist_state(aux_switch_pos_t ch_flag)
+void RC_Channel_Plane::do_aux_function_q_assist_state(AuxSwitchPos ch_flag)
 {
     switch(ch_flag) {
-        case HIGH:
+        case AuxSwitchPos::HIGH:
             gcs().send_text(MAV_SEVERITY_INFO, "QAssist: Force enabled");
             plane.quadplane.set_q_assist_state(plane.quadplane.Q_ASSIST_STATE_ENUM::Q_ASSIST_FORCE);
             break;
 
-        case MIDDLE:
+        case AuxSwitchPos::MIDDLE:
             gcs().send_text(MAV_SEVERITY_INFO, "QAssist: Enabled");
             plane.quadplane.set_q_assist_state(plane.quadplane.Q_ASSIST_STATE_ENUM::Q_ASSIST_ENABLED);
             break;
 
-        case LOW:
+        case AuxSwitchPos::LOW:
             gcs().send_text(MAV_SEVERITY_INFO, "QAssist: Disabled");
             plane.quadplane.set_q_assist_state(plane.quadplane.Q_ASSIST_STATE_ENUM::Q_ASSIST_DISABLED);
             break;
@@ -79,7 +79,7 @@ void RC_Channel_Plane::do_aux_function_q_assist_state(aux_switch_pos_t ch_flag)
 }
 
 void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
-                                         const RC_Channel::aux_switch_pos_t ch_flag)
+                                         const RC_Channel::AuxSwitchPos ch_flag)
 {
     switch(ch_option) {
     // the following functions do not need to be initialised:
@@ -117,15 +117,15 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
 }
 
 // do_aux_function - implement the function invoked by auxillary switches
-void RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+void RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos ch_flag)
 {
     switch(ch_option) {
     case AUX_FUNC::INVERTED:
-        plane.inverted_flight = (ch_flag == HIGH);
+        plane.inverted_flight = (ch_flag == AuxSwitchPos::HIGH);
         break;
 
     case AUX_FUNC::REVERSE_THROTTLE:
-        plane.reversed_throttle = (ch_flag == HIGH);
+        plane.reversed_throttle = (ch_flag == AuxSwitchPos::HIGH);
         gcs().send_text(MAV_SEVERITY_INFO, "RevThrottle: %s", plane.reversed_throttle?"ENABLE":"DISABLE");
         break;
 

--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -10,15 +10,15 @@ public:
 protected:
 
     void init_aux_function(aux_func_t ch_option,
-                           aux_switch_pos_t ch_flag) override;
-    void do_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
+                           AuxSwitchPos ch_flag) override;
+    void do_aux_function(aux_func_t ch_option, AuxSwitchPos) override;
 
 private:
 
     void do_aux_function_change_mode(Mode::Number number,
-                                     aux_switch_pos_t ch_flag);
+                                     AuxSwitchPos ch_flag);
 
-    void do_aux_function_q_assist_state(aux_switch_pos_t ch_flag);
+    void do_aux_function_q_assist_state(AuxSwitchPos ch_flag);
 };
 
 class RC_Channels_Plane : public RC_Channels

--- a/Rover/RC_Channel.cpp
+++ b/Rover/RC_Channel.cpp
@@ -28,7 +28,7 @@ void RC_Channel_Rover::mode_switch_changed(modeswitch_pos_t new_pos)
 }
 
 // init_aux_switch_function - initialize aux functions
-void RC_Channel_Rover::init_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+void RC_Channel_Rover::init_aux_function(const aux_func_t ch_option, const AuxSwitchPos ch_flag)
 {
     // init channel options
     switch (ch_option) {
@@ -74,16 +74,16 @@ RC_Channel * RC_Channels_Rover::get_arming_channel(void) const
 }
 
 void RC_Channel_Rover::do_aux_function_change_mode(Mode &mode,
-        const aux_switch_pos_t ch_flag)
+        const AuxSwitchPos ch_flag)
 {
     switch (ch_flag) {
-    case HIGH:
+    case AuxSwitchPos::HIGH:
         rover.set_mode(mode, ModeReason::RC_COMMAND);
         break;
-    case MIDDLE:
+    case AuxSwitchPos::MIDDLE:
         // do nothing
         break;
-    case LOW:
+    case AuxSwitchPos::LOW:
         if (rover.control_mode == &mode) {
             rc().reset_mode_switch();
         }
@@ -107,28 +107,28 @@ void RC_Channel_Rover::add_waypoint_for_current_loc()
     }
 }
 
-void RC_Channel_Rover::do_aux_function_sailboat_motor_3pos(const aux_switch_pos_t ch_flag)
+void RC_Channel_Rover::do_aux_function_sailboat_motor_3pos(const AuxSwitchPos ch_flag)
 {
     switch (ch_flag) {
-    case HIGH:
+    case AuxSwitchPos::HIGH:
         rover.g2.sailboat.set_motor_state(Sailboat::UseMotor::USE_MOTOR_ALWAYS);
         break;
-    case MIDDLE:
+    case AuxSwitchPos::MIDDLE:
         rover.g2.sailboat.set_motor_state(Sailboat::UseMotor::USE_MOTOR_ASSIST);
         break;
-    case LOW:
+    case AuxSwitchPos::LOW:
         rover.g2.sailboat.set_motor_state(Sailboat::UseMotor::USE_MOTOR_NEVER);
         break;
     }
 }
 
-void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos ch_flag)
 {
     switch (ch_option) {
     case AUX_FUNC::DO_NOTHING:
         break;
     case AUX_FUNC::SAVE_WP:
-        if (ch_flag == HIGH) {
+        if (ch_flag == AuxSwitchPos::HIGH) {
             // do nothing if in AUTO mode
             if (rover.control_mode == &rover.mode_auto) {
                 return;
@@ -156,7 +156,7 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
 
     // learn cruise speed and throttle
     case AUX_FUNC::LEARN_CRUISE:
-        if (ch_flag == HIGH) {
+        if (ch_flag == AuxSwitchPos::HIGH) {
             rover.cruise_learn_start();
         }
         break;
@@ -235,7 +235,7 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
     case AUX_FUNC::SAVE_TRIM:
         if (!rover.g2.motors.have_skid_steering() && rover.arming.is_armed() &&
             (rover.control_mode != &rover.mode_loiter)
-            && (rover.control_mode != &rover.mode_hold) && ch_flag == HIGH) {
+            && (rover.control_mode != &rover.mode_hold) && ch_flag == AuxSwitchPos::HIGH) {
             SRV_Channels::set_trim_to_servo_out_for(SRV_Channel::k_steering);
             gcs().send_text(MAV_SEVERITY_CRITICAL, "Steering trim saved!");
         }

--- a/Rover/RC_Channel.h
+++ b/Rover/RC_Channel.h
@@ -11,8 +11,8 @@ public:
 
 protected:
 
-    void init_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
-    void do_aux_function(aux_func_t ch_option, aux_switch_pos_t) override;
+    void init_aux_function(aux_func_t ch_option, AuxSwitchPos) override;
+    void do_aux_function(aux_func_t ch_option, AuxSwitchPos) override;
 
     // called when the mode switch changes position:
     void mode_switch_changed(modeswitch_pos_t new_pos) override;
@@ -20,11 +20,11 @@ protected:
 private:
 
     void do_aux_function_change_mode(Mode &mode,
-                                     const aux_switch_pos_t ch_flag);
+                                     const AuxSwitchPos ch_flag);
 
     void add_waypoint_for_current_loc();
 
-    void do_aux_function_sailboat_motor_3pos(const aux_switch_pos_t ch_flag);
+    void do_aux_function_sailboat_motor_3pos(const AuxSwitchPos ch_flag);
 };
 
 class RC_Channels_Rover : public RC_Channels

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1241,7 +1241,7 @@ bool AP_Arming::disarm_switch_checks(bool display_failure) const
 {
     const RC_Channel *chan = rc().find_channel_for_option(RC_Channel::AUX_FUNC::DISARM);
     if (chan != nullptr &&
-        chan->get_aux_switch_pos() == RC_Channel::aux_switch_pos_t::HIGH &&
+        chan->get_aux_switch_pos() == RC_Channel::AuxSwitchPos::HIGH &&
         (checks_to_perform & ARMING_CHECK_ALL)) {
         check_failed(display_failure, "Disarm Switch on");
         return false;

--- a/libraries/AP_Camera/AP_RunCam.cpp
+++ b/libraries/AP_Camera/AP_RunCam.cpp
@@ -437,40 +437,40 @@ void AP_RunCam::handle_in_menu(Event ev)
 // map rc input to an event
 AP_RunCam::Event AP_RunCam::map_rc_input_to_event() const
 {
-    const RC_Channel::aux_switch_pos_t throttle = rc().get_channel_pos(AP::rcmap()->throttle());
-    const RC_Channel::aux_switch_pos_t yaw = rc().get_channel_pos(AP::rcmap()->yaw());
-    const RC_Channel::aux_switch_pos_t roll = rc().get_channel_pos(AP::rcmap()->roll());
-    const RC_Channel::aux_switch_pos_t pitch = rc().get_channel_pos(AP::rcmap()->pitch());
+    const RC_Channel::AuxSwitchPos throttle = rc().get_channel_pos(AP::rcmap()->throttle());
+    const RC_Channel::AuxSwitchPos yaw = rc().get_channel_pos(AP::rcmap()->yaw());
+    const RC_Channel::AuxSwitchPos roll = rc().get_channel_pos(AP::rcmap()->roll());
+    const RC_Channel::AuxSwitchPos pitch = rc().get_channel_pos(AP::rcmap()->pitch());
 
     Event result = Event::NONE;
 
     if (_button_pressed != ButtonState::NONE) {
-        if (_button_pressed == ButtonState::PRESSED && yaw == RC_Channel::MIDDLE && pitch == RC_Channel::MIDDLE && roll == RC_Channel::MIDDLE) {
+        if (_button_pressed == ButtonState::PRESSED && yaw == RC_Channel::AuxSwitchPos::MIDDLE && pitch == RC_Channel::AuxSwitchPos::MIDDLE && roll == RC_Channel::AuxSwitchPos::MIDDLE) {
             result = Event::BUTTON_RELEASE;
         } else {
             result = Event::NONE; // still waiting to be released
         }
-    } else if (throttle == RC_Channel::MIDDLE && yaw == RC_Channel::LOW
-        && pitch == RC_Channel::MIDDLE && roll == RC_Channel::MIDDLE
+    } else if (throttle == RC_Channel::AuxSwitchPos::MIDDLE && yaw == RC_Channel::AuxSwitchPos::LOW
+        && pitch == RC_Channel::AuxSwitchPos::MIDDLE && roll == RC_Channel::AuxSwitchPos::MIDDLE
         // don't allow an action close to arming unless the user had configured it or arming is not possible
         // but don't prevent the 5-Key control actually working
         && (_cam_control_option & uint8_t(ControlOption::STICK_YAW_RIGHT) || is_arming_prevented())) {
         result = Event::EXIT_MENU;
-    } else if (throttle == RC_Channel::MIDDLE && yaw == RC_Channel::HIGH
-        && pitch == RC_Channel::MIDDLE && roll == RC_Channel::MIDDLE
+    } else if (throttle == RC_Channel::AuxSwitchPos::MIDDLE && yaw == RC_Channel::AuxSwitchPos::HIGH
+        && pitch == RC_Channel::AuxSwitchPos::MIDDLE && roll == RC_Channel::AuxSwitchPos::MIDDLE
         && (_cam_control_option & uint8_t(ControlOption::STICK_YAW_RIGHT) || is_arming_prevented())) {
         result = Event::ENTER_MENU;
-    } else if (roll == RC_Channel::LOW) {
+    } else if (roll == RC_Channel::AuxSwitchPos::LOW) {
         result = Event::IN_MENU_EXIT;
-    } else if (yaw == RC_Channel::MIDDLE && pitch == RC_Channel::MIDDLE && roll == RC_Channel::HIGH) {
+    } else if (yaw == RC_Channel::AuxSwitchPos::MIDDLE && pitch == RC_Channel::AuxSwitchPos::MIDDLE && roll == RC_Channel::AuxSwitchPos::HIGH) {
         if (has_feature(Feature::RCDEVICE_PROTOCOL_FEATURE_SIMULATE_5_KEY_OSD_CABLE)) {
             result = Event::IN_MENU_RIGHT;
         } else {
             result = Event::IN_MENU_ENTER;
         }
-    } else if (pitch == RC_Channel::LOW) {
+    } else if (pitch == RC_Channel::AuxSwitchPos::LOW) {
         result = Event::IN_MENU_UP;
-    } else if (pitch == RC_Channel::HIGH) {
+    } else if (pitch == RC_Channel::AuxSwitchPos::HIGH) {
         result = Event::IN_MENU_DOWN;
     } else if (_video_recording != _last_video_recording) {
         switch (_video_recording) {

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -409,7 +409,7 @@ void RC_Channel::read_mode_switch()
     else if (pulsewidth < 1750) position = 4;
     else position = 5;
 
-    if (!debounce_completed(position)) {
+    if (!debounce_completed((int8_t)position)) {
         return;
     }
 
@@ -446,7 +446,7 @@ bool RC_Channel::debounce_completed(int8_t position)
 //
 
 // init_aux_switch_function - initialize aux functions
-void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPos ch_flag)
 {
     // init channel options
     switch(ch_option) {
@@ -506,12 +506,12 @@ bool RC_Channel::read_aux()
         // here e.g. RCMAP_ROLL etc once they become options
         return false;
     }
-    aux_switch_pos_t new_position;
+    AuxSwitchPos new_position;
     if (!read_3pos_switch(new_position)) {
         return false;
     }
 
-    if (!debounce_completed(new_position)) {
+    if (!debounce_completed((int8_t)new_position)) {
         return false;
     }
 
@@ -521,23 +521,23 @@ bool RC_Channel::read_aux()
 }
 
 
-void RC_Channel::do_aux_function_armdisarm(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_armdisarm(const AuxSwitchPos ch_flag)
 {
     // arm or disarm the vehicle
     switch (ch_flag) {
-    case HIGH:
+    case AuxSwitchPos::HIGH:
         AP::arming().arm(AP_Arming::Method::AUXSWITCH, true);
         break;
-    case MIDDLE:
+    case AuxSwitchPos::MIDDLE:
         // nothing
         break;
-    case LOW:
+    case AuxSwitchPos::LOW:
         AP::arming().disarm(AP_Arming::Method::AUXSWITCH);
         break;
     }
 }
 
-void RC_Channel::do_aux_function_avoid_adsb(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag)
 {
     AP_Avoidance *avoidance = AP::ap_avoidance();
     if (avoidance == nullptr) {
@@ -547,7 +547,7 @@ void RC_Channel::do_aux_function_avoid_adsb(const aux_switch_pos_t ch_flag)
     if (adsb == nullptr) {
         return;
     }
-    if (ch_flag == HIGH) {
+    if (ch_flag == AuxSwitchPos::HIGH) {
         // try to enable AP_Avoidance
         if (!adsb->enabled()) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "ADSB not enabled");
@@ -565,7 +565,7 @@ void RC_Channel::do_aux_function_avoid_adsb(const aux_switch_pos_t ch_flag)
     gcs().send_text(MAV_SEVERITY_CRITICAL, "ADSB Avoidance Disabled");
 }
 
-void RC_Channel::do_aux_function_avoid_proximity(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_avoid_proximity(const AuxSwitchPos ch_flag)
 {
     AC_Avoid *avoid = AP::ac_avoid();
     if (avoid == nullptr) {
@@ -573,30 +573,30 @@ void RC_Channel::do_aux_function_avoid_proximity(const aux_switch_pos_t ch_flag)
     }
 
     switch (ch_flag) {
-    case HIGH:
+    case AuxSwitchPos::HIGH:
         avoid->proximity_avoidance_enable(true);
         break;
-    case MIDDLE:
+    case AuxSwitchPos::MIDDLE:
         // nothing
         break;
-    case LOW:
+    case AuxSwitchPos::LOW:
         avoid->proximity_avoidance_enable(false);
         break;
     }
 }
 
-void RC_Channel::do_aux_function_camera_trigger(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_camera_trigger(const AuxSwitchPos ch_flag)
 {
     AP_Camera *camera = AP::camera();
     if (camera == nullptr) {
         return;
     }
-    if (ch_flag == HIGH) {
+    if (ch_flag == AuxSwitchPos::HIGH) {
         camera->take_picture();
     }
 }
 
-void RC_Channel::do_aux_function_runcam_control(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_runcam_control(const AuxSwitchPos ch_flag)
 {
 #if HAL_RUNCAM_ENABLED
     AP_RunCam *runcam = AP::runcam();
@@ -605,20 +605,20 @@ void RC_Channel::do_aux_function_runcam_control(const aux_switch_pos_t ch_flag)
     }
 
     switch (ch_flag) {
-        case HIGH:
+        case AuxSwitchPos::HIGH:
             runcam->start_recording();
             break;
-        case MIDDLE:
+        case AuxSwitchPos::MIDDLE:
             runcam->osd_option();
             break;
-        case LOW:
+        case AuxSwitchPos::LOW:
             runcam->stop_recording();
             break;
     }
 #endif
 }
 
-void RC_Channel::do_aux_function_runcam_osd_control(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_runcam_osd_control(const AuxSwitchPos ch_flag)
 {
 #if HAL_RUNCAM_ENABLED
     AP_RunCam *runcam = AP::runcam();
@@ -627,11 +627,11 @@ void RC_Channel::do_aux_function_runcam_osd_control(const aux_switch_pos_t ch_fl
     }
 
     switch (ch_flag) {
-        case HIGH:
+        case AuxSwitchPos::HIGH:
             runcam->enter_osd();
             break;
-        case MIDDLE:
-        case LOW:
+        case AuxSwitchPos::MIDDLE:
+        case AuxSwitchPos::LOW:
             runcam->exit_osd();
             break;
     }
@@ -639,7 +639,7 @@ void RC_Channel::do_aux_function_runcam_osd_control(const aux_switch_pos_t ch_fl
 }
 
 // enable or disable the fence
-void RC_Channel::do_aux_function_fence(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_fence(const AuxSwitchPos ch_flag)
 {
     AC_Fence *fence = AP::fence();
     if (fence == nullptr) {
@@ -647,7 +647,7 @@ void RC_Channel::do_aux_function_fence(const aux_switch_pos_t ch_flag)
     }
 
     AP_Logger *logger = AP_Logger::get_singleton();
-    if (ch_flag == HIGH) {
+    if (ch_flag == AuxSwitchPos::HIGH) {
         fence->enable(true);
         if (logger != nullptr) {
             logger->Write_Event(LogEvent::FENCE_ENABLE);
@@ -660,13 +660,13 @@ void RC_Channel::do_aux_function_fence(const aux_switch_pos_t ch_flag)
     }
 }
 
-void RC_Channel::do_aux_function_clear_wp(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_clear_wp(const AuxSwitchPos ch_flag)
 {
     AP_Mission *mission = AP::mission();
     if (mission == nullptr) {
         return;
     }
-    if (ch_flag == HIGH) {
+    if (ch_flag == AuxSwitchPos::HIGH) {
         mission->clear();
     }
 }
@@ -680,7 +680,7 @@ void RC_Channel::do_aux_function_relay(const uint8_t relay, bool val)
     servorelayevents->do_set_relay(relay, val);
 }
 
-void RC_Channel::do_aux_function_sprayer(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_sprayer(const AuxSwitchPos ch_flag)
 {
 #if HAL_SPRAYER_ENABLED
     AC_Sprayer *sprayer = AP::sprayer();
@@ -688,13 +688,13 @@ void RC_Channel::do_aux_function_sprayer(const aux_switch_pos_t ch_flag)
         return;
     }
 
-    sprayer->run(ch_flag == HIGH);
+    sprayer->run(ch_flag == AuxSwitchPos::HIGH);
     // if we are disarmed the pilot must want to test the pump
-    sprayer->test_pump((ch_flag == HIGH) && !hal.util->get_soft_armed());
+    sprayer->test_pump((ch_flag == AuxSwitchPos::HIGH) && !hal.util->get_soft_armed());
 #endif // HAL_SPRAYER_ENABLED
 }
 
-void RC_Channel::do_aux_function_gripper(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_gripper(const AuxSwitchPos ch_flag)
 {
     AP_Gripper *gripper = AP::gripper();
     if (gripper == nullptr) {
@@ -702,53 +702,53 @@ void RC_Channel::do_aux_function_gripper(const aux_switch_pos_t ch_flag)
     }
 
     switch(ch_flag) {
-    case LOW:
+    case AuxSwitchPos::LOW:
         gripper->release();
         break;
-    case MIDDLE:
+    case AuxSwitchPos::MIDDLE:
         // nothing
         break;
-    case HIGH:
+    case AuxSwitchPos::HIGH:
         gripper->grab();
         break;
     }
 }
 
-void RC_Channel::do_aux_function_lost_vehicle_sound(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_lost_vehicle_sound(const AuxSwitchPos ch_flag)
 {
     switch (ch_flag) {
-    case HIGH:
+    case AuxSwitchPos::HIGH:
         AP_Notify::flags.vehicle_lost = true;
         break;
-    case MIDDLE:
+    case AuxSwitchPos::MIDDLE:
         // nothing
         break;
-    case LOW:
+    case AuxSwitchPos::LOW:
         AP_Notify::flags.vehicle_lost = false;
         break;
     }
 }
 
-void RC_Channel::do_aux_function_rc_override_enable(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_rc_override_enable(const AuxSwitchPos ch_flag)
 {
     switch (ch_flag) {
-    case HIGH: {
+    case AuxSwitchPos::HIGH: {
         rc().set_gcs_overrides_enabled(true);
         break;
     }
-    case MIDDLE:
+    case AuxSwitchPos::MIDDLE:
         // nothing
         break;
-    case LOW: {
+    case AuxSwitchPos::LOW: {
         rc().set_gcs_overrides_enabled(false);
         break;
     }
     }
 }
 
-void RC_Channel::do_aux_function_mission_reset(const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function_mission_reset(const AuxSwitchPos ch_flag)
 {
-    if (ch_flag != HIGH) {
+    if (ch_flag != AuxSwitchPos::HIGH) {
         return;
     }
     AP_Mission *mission = AP::mission();
@@ -758,7 +758,7 @@ void RC_Channel::do_aux_function_mission_reset(const aux_switch_pos_t ch_flag)
     mission->reset();
 }
 
-void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
+void RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos ch_flag)
 {
     switch(ch_option) {
     case AUX_FUNC::CAMERA_TRIGGER:
@@ -783,22 +783,22 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         break;
 
     case AUX_FUNC::RELAY:
-        do_aux_function_relay(0, ch_flag == HIGH);
+        do_aux_function_relay(0, ch_flag == AuxSwitchPos::HIGH);
         break;
     case AUX_FUNC::RELAY2:
-        do_aux_function_relay(1, ch_flag == HIGH);
+        do_aux_function_relay(1, ch_flag == AuxSwitchPos::HIGH);
         break;
     case AUX_FUNC::RELAY3:
-        do_aux_function_relay(2, ch_flag == HIGH);
+        do_aux_function_relay(2, ch_flag == AuxSwitchPos::HIGH);
         break;
     case AUX_FUNC::RELAY4:
-        do_aux_function_relay(3, ch_flag == HIGH);
+        do_aux_function_relay(3, ch_flag == AuxSwitchPos::HIGH);
         break;
     case AUX_FUNC::RELAY5:
-        do_aux_function_relay(4, ch_flag == HIGH);
+        do_aux_function_relay(4, ch_flag == AuxSwitchPos::HIGH);
         break;
     case AUX_FUNC::RELAY6:
-        do_aux_function_relay(5, ch_flag == HIGH);
+        do_aux_function_relay(5, ch_flag == AuxSwitchPos::HIGH);
         break;
 
     case AUX_FUNC::RUNCAM_CONTROL:
@@ -833,13 +833,13 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         break;
 
     case AUX_FUNC::DISARM:
-        if (ch_flag == HIGH) {
+        if (ch_flag == AuxSwitchPos::HIGH) {
             AP::arming().disarm(AP_Arming::Method::AUXSWITCH);
         }
         break;
 
     case AUX_FUNC::COMPASS_LEARN:
-        if (ch_flag == HIGH) {
+        if (ch_flag == AuxSwitchPos::HIGH) {
             Compass &compass = AP::compass();
             compass.set_learn_type(Compass::LEARN_INFLIGHT, false);
         }
@@ -851,13 +851,13 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
             break;
         }
         switch (ch_flag) {
-        case LOW:
+        case AuxSwitchPos::LOW:
             lg->set_position(AP_LandingGear::LandingGear_Deploy);
             break;
-        case MIDDLE:
+        case AuxSwitchPos::MIDDLE:
             // nothing
             break;
-        case HIGH:
+        case AuxSwitchPos::HIGH:
             lg->set_position(AP_LandingGear::LandingGear_Retract);
             break;
         }
@@ -865,12 +865,12 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
     }
 
     case AUX_FUNC::GPS_DISABLE:
-        AP::gps().force_disable(ch_flag == HIGH);
+        AP::gps().force_disable(ch_flag == AuxSwitchPos::HIGH);
         break;
 
     case AUX_FUNC::MOTOR_ESTOP:
         switch (ch_flag) {
-        case HIGH: {
+        case AuxSwitchPos::HIGH: {
             SRV_Channels::set_emergency_stop(true);
 
             // log E-stop
@@ -880,10 +880,10 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
             }
             break;
         }
-        case MIDDLE:
+        case AuxSwitchPos::MIDDLE:
             // nothing
             break;
-        case LOW: {
+        case AuxSwitchPos::LOW: {
             SRV_Channels::set_emergency_stop(false);
 
             // log E-stop cleared
@@ -898,7 +898,7 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
 
     case AUX_FUNC::VISODOM_CALIBRATE:
 #if HAL_VISUALODOM_ENABLED
-        if (ch_flag == HIGH) {
+        if (ch_flag == AuxSwitchPos::HIGH) {
             AP_VisualOdom *visual_odom = AP::visualodom();
             if (visual_odom != nullptr) {
                 visual_odom->align_sensor_to_vehicle();
@@ -909,7 +909,7 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
 
 #if !HAL_MINIMIZE_FEATURES
     case AUX_FUNC::KILL_IMU1:
-        if (ch_flag == HIGH) {
+        if (ch_flag == AuxSwitchPos::HIGH) {
             AP::ins().kill_imu(0, true);
         } else {
             AP::ins().kill_imu(0, false);
@@ -917,7 +917,7 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         break;
 
     case AUX_FUNC::KILL_IMU2:
-        if (ch_flag == HIGH) {
+        if (ch_flag == AuxSwitchPos::HIGH) {
             AP::ins().kill_imu(1, true);
         } else {
             AP::ins().kill_imu(1, false);
@@ -932,13 +932,13 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
             break;
         }
         switch (ch_flag) {
-        case LOW:
+        case AuxSwitchPos::LOW:
             // nothing
             break;
-        case MIDDLE:
+        case AuxSwitchPos::MIDDLE:
             // nothing
             break;
-        case HIGH:
+        case AuxSwitchPos::HIGH:
             camera->cam_mode_toggle();
             break;
         }
@@ -963,35 +963,35 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
 
 void RC_Channel::init_aux()
 {
-    aux_switch_pos_t position;
+    AuxSwitchPos position;
     if (!read_3pos_switch(position)) {
-        position = aux_switch_pos_t::LOW;
+        position = AuxSwitchPos::LOW;
     }
     init_aux_function((aux_func_t)option.get(), position);
 }
 
 // read_3pos_switch
-bool RC_Channel::read_3pos_switch(RC_Channel::aux_switch_pos_t &ret) const
+bool RC_Channel::read_3pos_switch(RC_Channel::AuxSwitchPos &ret) const
 {
     const uint16_t in = get_radio_in();
     if (in <= 900 or in >= 2200) {
         return false;
     }
     if (in < AUX_PWM_TRIGGER_LOW) {
-        ret = LOW;
+        ret = AuxSwitchPos::LOW;
     } else if (in > AUX_PWM_TRIGGER_HIGH) {
-        ret = HIGH;
+        ret = AuxSwitchPos::HIGH;
     } else {
-        ret = MIDDLE;
+        ret = AuxSwitchPos::MIDDLE;
     }
     return true;
 }
 
 // return switch position value as LOW, MIDDLE, HIGH
 // if reading the switch fails then it returns LOW
-RC_Channel::aux_switch_pos_t RC_Channel::get_aux_switch_pos() const
+RC_Channel::AuxSwitchPos RC_Channel::get_aux_switch_pos() const
 {
-    aux_switch_pos_t position = aux_switch_pos_t::LOW;
+    AuxSwitchPos position = AuxSwitchPos::LOW;
     UNUSED_RESULT(read_3pos_switch(position));
 
     return position;
@@ -999,10 +999,10 @@ RC_Channel::aux_switch_pos_t RC_Channel::get_aux_switch_pos() const
 
 // return switch position value as LOW, MIDDLE, HIGH
 // if reading the switch fails then it returns LOW
-RC_Channel::aux_switch_pos_t RC_Channels::get_channel_pos(const uint8_t rcmapchan) const
+RC_Channel::AuxSwitchPos RC_Channels::get_channel_pos(const uint8_t rcmapchan) const
 {
     const RC_Channel* chan = rc().channel(rcmapchan-1);
-    return chan != nullptr ? chan->get_aux_switch_pos() : RC_Channel::aux_switch_pos_t::LOW;
+    return chan != nullptr ? chan->get_aux_switch_pos() : RC_Channel::AuxSwitchPos::LOW;
 }
 
 RC_Channel *RC_Channels::find_channel_for_option(const RC_Channel::aux_func_t option)

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -196,34 +196,34 @@ public:
     typedef enum AUX_FUNC aux_func_t;
 
     // auxillary switch handling (n.b.: we store this as 2-bits!):
-    enum aux_switch_pos_t : uint8_t {
+    enum class AuxSwitchPos : uint8_t {
         LOW,       // indicates auxiliary switch is in the low position (pwm <1200)
         MIDDLE,    // indicates auxiliary switch is in the middle position (pwm >1200, <1800)
         HIGH       // indicates auxiliary switch is in the high position (pwm >1800)
     };
 
-    bool read_3pos_switch(aux_switch_pos_t &ret) const WARN_IF_UNUSED;
-    aux_switch_pos_t get_aux_switch_pos() const;
+    bool read_3pos_switch(AuxSwitchPos &ret) const WARN_IF_UNUSED;
+    AuxSwitchPos get_aux_switch_pos() const;
 
 protected:
 
-    virtual void init_aux_function(aux_func_t ch_option, aux_switch_pos_t);
-    virtual void do_aux_function(aux_func_t ch_option, aux_switch_pos_t);
+    virtual void init_aux_function(aux_func_t ch_option, AuxSwitchPos);
+    virtual void do_aux_function(aux_func_t ch_option, AuxSwitchPos);
 
-    virtual void do_aux_function_armdisarm(const aux_switch_pos_t ch_flag);
-    void do_aux_function_avoid_adsb(const aux_switch_pos_t ch_flag);
-    void do_aux_function_avoid_proximity(const aux_switch_pos_t ch_flag);
-    void do_aux_function_camera_trigger(const aux_switch_pos_t ch_flag);
-    void do_aux_function_runcam_control(const aux_switch_pos_t ch_flag);
-    void do_aux_function_runcam_osd_control(const aux_switch_pos_t ch_flag);
-    void do_aux_function_fence(const aux_switch_pos_t ch_flag);
-    void do_aux_function_clear_wp(const aux_switch_pos_t ch_flag);
-    void do_aux_function_gripper(const aux_switch_pos_t ch_flag);
-    void do_aux_function_lost_vehicle_sound(const aux_switch_pos_t ch_flag);
-    void do_aux_function_mission_reset(const aux_switch_pos_t ch_flag);
-    void do_aux_function_rc_override_enable(const aux_switch_pos_t ch_flag);
+    virtual void do_aux_function_armdisarm(const AuxSwitchPos ch_flag);
+    void do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag);
+    void do_aux_function_avoid_proximity(const AuxSwitchPos ch_flag);
+    void do_aux_function_camera_trigger(const AuxSwitchPos ch_flag);
+    void do_aux_function_runcam_control(const AuxSwitchPos ch_flag);
+    void do_aux_function_runcam_osd_control(const AuxSwitchPos ch_flag);
+    void do_aux_function_fence(const AuxSwitchPos ch_flag);
+    void do_aux_function_clear_wp(const AuxSwitchPos ch_flag);
+    void do_aux_function_gripper(const AuxSwitchPos ch_flag);
+    void do_aux_function_lost_vehicle_sound(const AuxSwitchPos ch_flag);
+    void do_aux_function_mission_reset(const AuxSwitchPos ch_flag);
+    void do_aux_function_rc_override_enable(const AuxSwitchPos ch_flag);
     void do_aux_function_relay(uint8_t relay, bool val);
-    void do_aux_function_sprayer(const aux_switch_pos_t ch_flag);
+    void do_aux_function_sprayer(const AuxSwitchPos ch_flag);
 
     typedef int8_t modeswitch_pos_t;
     virtual void mode_switch_changed(modeswitch_pos_t new_pos) {
@@ -326,7 +326,7 @@ public:
 
     class RC_Channel *find_channel_for_option(const RC_Channel::aux_func_t option);
     bool duplicate_options_exist();
-    RC_Channel::aux_switch_pos_t get_channel_pos(const uint8_t rcmapchan) const;
+    RC_Channel::AuxSwitchPos get_channel_pos(const uint8_t rcmapchan) const;
 
     void init_aux_all();
     void read_aux_all();


### PR DESCRIPTION
Should be NFC; it's just a namespace change for the enumeration.

Perhaps we should rename `ch_flag` to `ch_pos` as part of this?
