### PR TITLE
Allow SITL physics loop rate to be set with SIM_RATE_HZ

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -150,7 +150,7 @@ void AP_InertialSensor_SITL::generate_accel()
 
     accel_accum /= nsamples;
     _rotate_and_correct_accel(accel_instance, accel_accum);
-    _notify_new_accel_raw_sample(accel_instance, accel_accum);
+    _notify_new_accel_raw_sample(accel_instance, accel_accum, AP_HAL::micros64());
 
     _publish_temperature(accel_instance, 23);
 }
@@ -235,7 +235,7 @@ void AP_InertialSensor_SITL::generate_gyro()
     }
     gyro_accum /= nsamples;
     _rotate_and_correct_gyro(gyro_instance, gyro_accum);
-    _notify_new_gyro_raw_sample(gyro_instance, gyro_accum);
+    _notify_new_gyro_raw_sample(gyro_instance, gyro_accum, AP_HAL::micros64());
 }
 
 void AP_InertialSensor_SITL::timer_update(void)

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -598,6 +598,9 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
         }
         }
     }
+
+    // allow for changes in physics step
+    adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
 }
 
 /*

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -257,6 +257,8 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     // vicon velocity glitch in NED frame
     AP_GROUPINFO("VICON_VGLI",    21, SITL,  vicon_vel_glitch, 0),
 
+    AP_GROUPINFO("RATE_HZ",  22, SITL,  loop_rate_hz, 1200),
+
     AP_GROUPEND
 
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -194,6 +194,7 @@ public:
     AP_Float mag_scaling; // scaling factor on first compasses
     AP_Int32 mag_devid[MAX_CONNECTED_MAGS]; // Mag devid
     AP_Float buoyancy; // submarine buoyancy in Newtons
+    AP_Int16 loop_rate_hz;
 
     // EFI type
     enum EFIType {


### PR DESCRIPTION
This allows for much higher levels of speedups, plus it fixes an issue with timestamps in the SITL INS driver that was affecting backends like XPlane and RealFlight