### PR TITLE
AP_VisualOdom: NoopLoop driver (WIP)

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -91,7 +91,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:NoopLoop
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink2),
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:NoopLoop
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SERIAL2_PROTOCOL),
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:NoopLoop
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SERIAL3_PROTOCOL),
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:NoopLoop
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SERIAL4_PROTOCOL),
@@ -159,7 +159,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:NoopLoop
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
@@ -178,7 +178,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 6_PROTOCOL
     // @DisplayName: Serial6 protocol selection
     // @Description: Control what protocol Serial6 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:NoopLoop
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("6_PROTOCOL",  12, AP_SerialManager, state[6].protocol, SERIAL6_PROTOCOL),
@@ -277,7 +277,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 7_PROTOCOL
     // @DisplayName: Serial7 protocol selection
     // @Description: Control what protocol Serial7 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:NoopLoop
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("7_PROTOCOL",  23, AP_SerialManager, state[7].protocol, SERIAL7_PROTOCOL),

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -137,6 +137,7 @@ public:
         SerialProtocol_RunCam = 26,
         SerialProtocol_Hott = 27,
         SerialProtocol_Scripting = 28,
+        SerialProtocol_NoopLoop = 29                  // for use by NoopLoop positioning system (see AP_VisualOdom driver)
     };
 
     // get singleton instance

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -130,6 +130,9 @@ void AP_Vehicle::fast_loop()
   and the maximum time they are expected to take (in microseconds)
  */
 const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
+#if HAL_VISUALODOM_ENABLED
+    SCHED_TASK_CLASS(AP_VisualOdom, &vehicle.visual_odom,   update,                  400, 50),
+#endif
 #if HAL_RUNCAM_ENABLED
     SCHED_TASK_CLASS(AP_RunCam,    &vehicle.runcam,         update,                   50, 50),
 #endif

--- a/libraries/AP_VisualOdom/AP_VisualOdom.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.cpp
@@ -20,6 +20,7 @@
 #include "AP_VisualOdom_Backend.h"
 #include "AP_VisualOdom_MAV.h"
 #include "AP_VisualOdom_IntelT265.h"
+#include "AP_VisualOdom_NoopLoop.h"
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
@@ -134,6 +135,17 @@ void AP_VisualOdom::init()
     case AP_VisualOdom_Type_IntelT265:
         _driver = new AP_VisualOdom_IntelT265(*this);
         break;
+    case AP_VisualOdom_Type_NoopLoop:
+        _driver = new AP_VisualOdom_NoopLoop(*this);
+        break;
+    }
+}
+
+// update sensor driver backends
+void AP_VisualOdom::update()
+{
+    if (_driver != nullptr) {
+        _driver->update();
     }
 }
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.h
@@ -47,11 +47,15 @@ public:
     enum AP_VisualOdom_Type {
         AP_VisualOdom_Type_None         = 0,
         AP_VisualOdom_Type_MAV          = 1,
-        AP_VisualOdom_Type_IntelT265    = 2
+        AP_VisualOdom_Type_IntelT265    = 2,
+        AP_VisualOdom_Type_NoopLoop     = 3
     };
 
     // detect and initialise any sensors
     void init();
+
+    // update sensor driver backends
+    void update();
 
     // return true if sensor is enabled
     bool enabled() const;

--- a/libraries/AP_VisualOdom/AP_VisualOdom_Backend.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_Backend.h
@@ -24,6 +24,9 @@ public:
     // constructor. This incorporates initialisation as well.
     AP_VisualOdom_Backend(AP_VisualOdom &frontend);
 
+    // update sensor driver
+    virtual void update() {}
+
     // return true if sensor is basically healthy (we are receiving data)
     bool healthy() const;
 
@@ -31,10 +34,10 @@ public:
     void handle_vision_position_delta_msg(const mavlink_message_t &msg);
 
     // consume vision position estimate data and send to EKF. distances in meters
-    virtual void handle_vision_position_estimate(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, const Quaternion &attitude, float posErr, float angErr, uint8_t reset_counter) = 0;
+    virtual void handle_vision_position_estimate(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, const Quaternion &attitude, float posErr, float angErr, uint8_t reset_counter) {};
 
     // consume vision velocity estimate data and send to EKF, velocity in NED meters per second
-    virtual void handle_vision_speed_estimate(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, uint8_t reset_counter) = 0;
+    virtual void handle_vision_speed_estimate(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, uint8_t reset_counter) {};
 
     // handle request to align camera's attitude with vehicle's AHRS/EKF attitude
     virtual void align_sensor_to_vehicle() {}

--- a/libraries/AP_VisualOdom/AP_VisualOdom_NoopLoop.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_NoopLoop.cpp
@@ -1,0 +1,226 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_VisualOdom_NoopLoop.h"
+
+#if HAL_VISUALODOM_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Logger/AP_Logger.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <GCS_MAVLink/GCS.h>
+
+#define NOOPLOOP_HEADER                     0x55    // message header
+#define NOOPLOOP_NODE_FRAME2_FRAMELEN_MAX   4096    // frames should be less than 4k bytes
+#define NOOPLOOP_NODE_FRAME2_SYSTIME        6       // start of 4 bytes holding system time in ms
+#define NOOPLOOP_NODE_FRAME2_PRECISION_X    10      // start of 1 byte holding precision in m*100 in x axis
+#define NOOPLOOP_NODE_FRAME2_PRECISION_Y    11      // start of 1 byte holding precision in m*100 in y axis
+#define NOOPLOOP_NODE_FRAME2_PRECISION_Z    12      // start of 1 byte holding precision in m*100 in y axis
+#define NOOPLOOP_NODE_FRAME2_POSX           13      // start of 3 bytes holding x position in m*1000
+#define NOOPLOOP_NODE_FRAME2_POSY           16      // start of 3 bytes holding y position in m*1000
+#define NOOPLOOP_NODE_FRAME2_POSZ           19      // start of 3 bytes holding z position in m*1000
+#define NOOPLOOP_NODE_FRAME2_VELX           22      // start of 3 bytes holding x velocity in m/s*10000
+#define NOOPLOOP_NODE_FRAME2_VELY           25      // start of 3 bytes holding y velocity in m/s*10000
+#define NOOPLOOP_NODE_FRAME2_VELZ           28      // start of 3 bytes holding z velocity in m/s*10000
+#define NOOPLOOP_NODE_FRAME2_ROLL           76      // start of 2 bytes holding roll lean angle in degrees
+#define NOOPLOOP_NODE_FRAME2_PITCH          78      // start of 2 bytes holding pitch lean angle in degrees
+#define NOOPLOOP_NODE_FRAME2_YAW            80      // start of 2 bytes holding yaw lean angle in degrees
+
+extern const AP_HAL::HAL& hal;
+
+/*
+  base class constructor.
+  This incorporates initialisation as well.
+*/
+AP_VisualOdom_NoopLoop::AP_VisualOdom_NoopLoop(AP_VisualOdom &frontend) :
+    AP_VisualOdom_Backend(frontend)
+{
+    // find uart
+    _uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_NoopLoop, 0);
+}
+
+// consume vision position estimate data and send to EKF. distances in meters
+void AP_VisualOdom_NoopLoop::update()
+{
+    // return immediately if not serial port
+    if (_uart == nullptr) {
+        return;
+    }
+
+    // check uart for any incoming messages
+    int16_t nbytes = _uart->available();
+    while (nbytes-- > 0) {
+        const int16_t r = _uart->read();
+        if ((r < 0) || (r > 0xFF)) {
+            continue;
+        }
+        if (parse_byte((uint8_t)r)) {
+            parse_msgbuf();
+        }
+    }
+}
+
+// process one byte received on serial port
+// returns true if a message has been successfully parsed
+// message is stored in _msgbuf
+bool AP_VisualOdom_NoopLoop::parse_byte(uint8_t b)
+{
+    // process byte depending upon current state
+    switch (_state) {
+
+    case ParseState::HEADER:
+        if (b == NOOPLOOP_HEADER) {
+            _msgbuf[0] = b;
+            _msg_len = 1;
+            _crc_expected = b;
+            _state = ParseState::FUNCTION_MARK;
+        }
+        break;
+
+    case ParseState::FUNCTION_MARK:
+        if (b == (uint8_t)FunctionMark::NODE_FRAME2) {
+            _msgbuf[_msg_len] = b;
+            _msg_len++;
+            _crc_expected += b;
+            _state = ParseState::LEN_L;
+        } else {
+            _state = ParseState::HEADER;
+        }
+        break;
+
+    case ParseState::LEN_L:
+        _msgbuf[_msg_len] = b;
+        _msg_len++;
+        _crc_expected += b;
+        _state = ParseState::LEN_H;
+        break;
+
+    case ParseState::LEN_H:
+        // extract and sanity check frame length
+        _frame_len = (uint16_t)b << 8 | _msgbuf[_msg_len-1];
+        if (_frame_len > NOOPLOOP_NODE_FRAME2_FRAMELEN_MAX) {
+            _state = ParseState::HEADER;
+            gcs().send_text(MAV_SEVERITY_CRITICAL,"invalid len:%d", (int)_frame_len);
+        } else {
+            _msgbuf[_msg_len] = b;
+            _msg_len++;
+            _crc_expected += b;
+            _state = ParseState::PAYLOAD;
+        }
+        break;
+
+    case ParseState::PAYLOAD:
+        // add byte to buffer if there is room
+        if (_msg_len < msgbuf_len_max) {
+            _msgbuf[_msg_len] = b;
+        }
+        _msg_len++;
+        if (_msg_len >= _frame_len) {
+            _state = ParseState::HEADER;
+            // check crc
+            return (b == _crc_expected);
+        } else {
+            _crc_expected += b;
+        }
+        break;
+    }
+
+    return false;
+}
+
+// parse msgbuf and update the EKF
+void AP_VisualOdom_NoopLoop::parse_msgbuf()
+{
+    // a message has been received
+    const uint32_t now_ms = AP_HAL::millis();
+    _last_update_ms = now_ms;
+
+    // remote system time in milliseconds
+    // To-Do: add jitter correction
+    const uint32_t remote_systime_ms = (uint32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_SYSTIME+3] << 24 | (uint32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_SYSTIME+2] << 16 | (uint32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_SYSTIME+1] << 8 | (uint32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_SYSTIME];
+    const uint64_t remote_systime_us = remote_systime_ms * 1000UL;
+
+    // estimated precision for x,y,z position in meters
+    const float precision_x = _msgbuf[NOOPLOOP_NODE_FRAME2_PRECISION_X] * 0.01;
+    const float precision_y = _msgbuf[NOOPLOOP_NODE_FRAME2_PRECISION_Y] * 0.01;
+    const float precision_z = _msgbuf[NOOPLOOP_NODE_FRAME2_PRECISION_Z] * 0.01;
+    const float pos_err = constrain_float(cbrtf(sq(precision_x)+sq(precision_y)+sq(precision_z)), _frontend.get_pos_noise(), 100.0f);
+
+    // x,y,z position in m*1000 in NEU frame
+    const int32_t pos_x = ((int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSX+2] << 24 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSX+1] << 16 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSX] << 8) >> 8;
+    const int32_t pos_y = ((int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSY+2] << 24 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSY+1] << 16 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSY] << 8) >> 8;
+    const int32_t pos_z = ((int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSZ+2] << 24 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSZ+1] << 16 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_POSZ] << 8) >> 8;
+
+    // position scaled to meters in NED
+    const Vector3f pos_m {pos_x * 0.001f, pos_y * 0.001f, -pos_z * 0.001f};
+
+    // x,y,z velocity in m/s*10000 in NEU
+    const int32_t vel_x = ((int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELX+2] << 24 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELX+1] << 16 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELX] << 8) >> 8;
+    const int32_t vel_y = ((int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELY+2] << 24 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELY+1] << 16 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELY] << 8) >> 8;
+    const int32_t vel_z = ((int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELZ+2] << 24 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELZ+1] << 16 | (int32_t)_msgbuf[NOOPLOOP_NODE_FRAME2_VELZ] << 8) >> 8;
+
+    // velocity scaled to m/s in NED
+    const Vector3f vel_ms {vel_x * 0.0001f, vel_y * 0.0001f, -vel_z * 0.0001f};
+
+    // sensor does not provide accurate attitude or reset information
+    const Quaternion att_none;
+    const float att_err = _frontend.get_yaw_noise();
+    const uint8_t reset_counter = 0;
+
+    // write data to EKF
+    AP::ahrs().writeExtNavData(pos_m, att_none, pos_err, att_err, now_ms, _frontend.get_delay_ms(), reset_counter);
+    AP::ahrs().writeExtNavVelData(vel_ms, _frontend.get_vel_noise(), now_ms, _frontend.get_delay_ms());
+
+    // log sensor data
+    AP::logger().Write_VisualPosition(remote_systime_us, now_ms, pos_m.x, pos_m.y, pos_m.z, 0.0f, 0.0f, 0.0f, pos_err, att_err, reset_counter);
+    AP::logger().Write_VisualVelocity(remote_systime_us, now_ms, vel_ms, _frontend.get_vel_noise(), reset_counter);
+
+    // debug
+    /*static uint8_t counter = 0;
+    counter++;
+    if (counter >= 10) {
+        counter = 0;
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"t:%llu, x:%4.2f y:%4.2f z:%4.2f vx:%4.2f vy:%4.2f vz:%4.2f",
+                    //(unsigned long long)remote_systime_ms,
+                    (unsigned long long)remote_systime_us,
+                    (double)pos_m.x,
+                    (double)pos_m.y,
+                    (double)pos_m.z,
+                    (double)vel_ms.x,
+                    (double)vel_ms.y,
+                    (double)vel_ms.z);
+    }
+    */
+}
+
+// returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+bool AP_VisualOdom_NoopLoop::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
+{
+    if (_uart == nullptr) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "No SERIALx_PROTOCOL = 29");
+        return false;
+    }
+
+    // exit immediately if not healthy
+    if (!healthy()) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "not healthy");
+        return false;
+    }
+
+    return true;
+}
+
+#endif

--- a/libraries/AP_VisualOdom/AP_VisualOdom_NoopLoop.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_NoopLoop.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "AP_VisualOdom_Backend.h"
+
+#if HAL_VISUALODOM_ENABLED
+
+class AP_VisualOdom_NoopLoop : public AP_VisualOdom_Backend
+{
+
+public:
+
+    using AP_VisualOdom_Backend::AP_VisualOdom_Backend;
+
+    // constructor
+    AP_VisualOdom_NoopLoop(AP_VisualOdom &frontend);
+
+    // update sensor driver
+    void update() override;
+
+    // arming check
+    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const override;
+
+protected:
+
+    // process one byte received on serial port
+    // returns true if a message has been successfully parsed
+    // message is stored in _msgbuf
+    bool parse_byte(uint8_t b);
+
+    // parse msgbuf and update the EKF
+    void parse_msgbuf();
+
+    // enum of valid function marks
+    enum class FunctionMark : uint8_t {
+        ANCHOR_FRAME0 = 0x00,
+        TAG_FRAME0 = 0x01,
+        NODE_FRAME0 = 0x02,
+        NODE_FRAME1 = 0x03,
+        NODE_FRAME2 = 0x04,
+        NODE_FRAME3 = 0x05
+    };
+
+    enum class ParseState : uint8_t {
+        HEADER = 0,         // waiting for header
+        FUNCTION_MARK,      // waiting for function mark
+        LEN_L,              // waiting for low byte of length
+        LEN_H,              // waiting for high byte of length
+        PAYLOAD,            // receiving payload bytes
+    } _state;
+
+    // constants
+    static const uint16_t msgbuf_len_max = 128; // maximum message length
+
+    // members
+    AP_HAL::UARTDriver *_uart = nullptr;        // pointer to uart configured for use with nooploop
+    uint8_t _msgbuf[msgbuf_len_max];            // buffer to hold most recent message from tag
+    uint8_t _msg_len;                           // number of bytes received from the current message (may be larger than size of _msgbuf)
+    uint16_t _frame_len;                        // message supplied frame length
+    uint8_t _crc_expected;                      // calculated crc which is compared against actual received crc
+};
+
+#endif

--- a/libraries/SITL/SIM_Vicon.h
+++ b/libraries/SITL/SIM_Vicon.h
@@ -13,7 +13,22 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-  simple particle sensor simulation
+  simple Vicon simulation
+
+  NoopLoop testing:
+
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:vicon --speedup=1
+
+param set GPS_TYPE 0
+param set EK2_GPS_TYPE 3
+param set VISO_TYPE 3
+param set SERIAL5_PROTOCOL 29
+param set SIM_VICON_TMASK 8
+reboot
+
+arm throttle
+rc 3 1600
+
 */
 
 #pragma once
@@ -52,14 +67,16 @@ private:
     // buffer of messages to send
     struct {
         uint64_t time_send_us;      // system time this message should be sent or 0 if no message to send
-        mavlink_message_t obs_msg;  // message to be sent
+        uint8_t obs_msg[300];  // message to be sent
+        uint16_t obs_msg_len;
     } msg_buf[3];
 
     // SIM_VICON_TYPE parameter bit values
     enum class ViconTypeMask : uint8_t {
         VISION_POSITION_ESTIMATE    = (1 << 0),
         VISION_SPEED_ESTIMATE       = (1 << 1),
-        VICON_POSITION_ESTIMATE     = (1 << 2)
+        VICON_POSITION_ESTIMATE     = (1 << 2),
+        NOOPLOOP                    = (1 << 3),
     };
 
     // return true if the given message type should be sent


### PR DESCRIPTION
This PR adds an AP_VisualOdom library backend for the NoopLoop (https://www.nooploop.com/) indoor positioning system.

Setup:

- The NoopLoop beacons must be setup so that the system's X-axis aligns with physical North-South because the system cannot provide a yaw attitude meaning we must use the autopilot's built-in compass.  Note that indoors this compass is very likely to suffer from interference from metal objects nearby.
- Connect the NoopLoop tag's 4-pin UART to one of the autopilot's serial ports (i.e. Telem2/Serial2)
- SERIAL2_PROTOCOL = 29
- SERIAL2_BAUD = 921
- VISO_TYPE = 3 (For NoopLoop)
- GPS_TYPE = 0
- EK2_GPS_TYPE or EK3_GPS_TYPE = 3 (do not use GPS)

Optically enable EKF3:
- AHRS_EKF_TYPE = 3
- EK2_ENABLE = 0
- EK3_ENABLE = 1

It may be helpful to adjust these parameters based on the noisiness of the system (we don't know what values are best yet)

- VISO_POS_M_NSE = reduce from 0.2 to 0.1?
- VISO_VEL_M_NSE = increase from 0.2 to 0.3 of 0.5?

So far this has only been lightly bench tested.