### PR TITLE
Fix compiler warning about initialising a complex object with memset

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -340,8 +340,8 @@ void NavEKF2_core::InitialiseVariables()
     extNavUsedForPos = false;
     extNavYawResetRequest = false;
 
-    memset(&extNavVelNew, 0, sizeof(extNavVelNew));
-    memset(&extNavVelDelayed, 0, sizeof(extNavVelDelayed));
+    extNavVelNew = {};
+    extNavVelDelayed = {};
     extNavVelToFuse = false;
     extNavVelMeasTime_ms = 0;
     useExtNavVel = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -403,8 +403,8 @@ void NavEKF3_core::InitialiseVariables()
     extNavLastPosResetTime_ms = 0;
     extNavDataToFuse = false;
     extNavUsedForPos = false;
-    memset(&extNavVelNew, 0, sizeof(extNavVelNew));
-    memset(&extNavVelDelayed, 0, sizeof(extNavVelDelayed));
+    extNavVelNew = {};
+    extNavVelDelayed = {};
     extNavVelToFuse = false;
     useExtNavVel = false;
     extNavVelMeasTime_ms = 0;


### PR DESCRIPTION
This is complex because it has a Vector3 in it.  Vector3 has a constructor which zeroes it.  C++ is annoyed because you ought to be calling the constructor when making a Vector3.

While in this case the result is the same (apart from the compiler warning), we might like to make -Wclass-memaccess an error at some point to catch real bugs.
