### PR TITLE
Remove ability to use vector3 as function

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -182,7 +182,7 @@ void AP_AHRS_NavEKF::update_DCM(bool skip_ins_update)
     AP_AHRS_DCM::update(skip_ins_update);
 
     // keep DCM attitude available for get_secondary_attitude()
-    _dcm_attitude(roll, pitch, yaw);
+    _dcm_attitude = {roll, pitch, yaw};
 }
 
 #if HAL_NAVEKF2_AVAILABLE
@@ -419,7 +419,7 @@ void AP_AHRS_NavEKF::reset(bool recover_eulers)
     WITH_SEMAPHORE(_rsem);
     
     AP_AHRS_DCM::reset(recover_eulers);
-    _dcm_attitude(roll, pitch, yaw);
+    _dcm_attitude = {roll, pitch, yaw};
 #if HAL_NAVEKF2_AVAILABLE
     if (_ekf2_started) {
         _ekf2_started = EKF2.InitialiseFilter();
@@ -439,7 +439,7 @@ void AP_AHRS_NavEKF::reset_attitude(const float &_roll, const float &_pitch, con
     WITH_SEMAPHORE(_rsem);
     
     AP_AHRS_DCM::reset_attitude(_roll, _pitch, _yaw);
-    _dcm_attitude(roll, pitch, yaw);
+    _dcm_attitude = {roll, pitch, yaw};
 #if HAL_NAVEKF2_AVAILABLE
     if (_ekf2_started) {
         _ekf2_started = EKF2.InitialiseFilter();

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1673,7 +1673,7 @@ const Vector3f& Compass::getHIL(uint8_t instance) const
 void Compass::_setup_earth_field(void)
 {
     // assume a earth field strength of 400
-    _hil.Bearth(400, 0, 0);
+    _hil.Bearth = {400, 0, 0};
 
     // rotate _Bearth for inclination and declination. -66 degrees
     // is the inclination in Canberra, Australia

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -138,7 +138,6 @@ void AP_Compass_LIS3MDL::timer()
         int16_t magz;
     } data;
     const float range_scale = 1000.0f / 6842.0f;
-    Vector3f field;
 
     // check data ready
     uint8_t status;
@@ -154,9 +153,15 @@ void AP_Compass_LIS3MDL::timer()
         goto check_registers;
     }
 
-    field(data.magx * range_scale, data.magy * range_scale, data.magz * range_scale);
+    {
+        Vector3f field{
+            data.magx * range_scale,
+            data.magy * range_scale,
+            data.magz * range_scale,
+        };
 
-    accumulate_sample(field, compass_instance);
+        accumulate_sample(field, compass_instance);
+    }
 
 check_registers:
     dev->check_next_register();

--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -177,7 +177,6 @@ void AP_Compass_RM3100::timer()
         uint8_t magz_1;
         uint8_t magz_0;
     } data;
-    Vector3f field;
 
     int32_t magx = 0;
     int32_t magy = 0;
@@ -209,10 +208,16 @@ void AP_Compass_RM3100::timer()
     magy >>= 8;
     magz >>= 8;
 
-    // apply scaler and store in field vector
-    field(magx * _scaler, magy * _scaler, magz * _scaler);
+    {
+        // apply scaler and store in field vector
+         Vector3f field{
+             magx * _scaler,
+             magy * _scaler,
+             magz * _scaler
+         };
 
-    accumulate_sample(field, compass_instance);
+        accumulate_sample(field, compass_instance);
+    }
 
 check_registers:
     dev->check_next_register();

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -51,7 +51,7 @@ void AP_Compass_SITL::_setup_eliptical_correcion(uint8_t i)
 {
     Vector3f diag = _sitl->mag_diag[i].get();
     if (diag.is_zero()) {
-        diag(1,1,1);
+        diag = {1,1,1};
     }
     const Vector3f &diagonals = diag;
     const Vector3f &offdiagonals = _sitl->mag_offdiag[i];

--- a/libraries/AP_Math/AP_GeodesicGrid.cpp
+++ b/libraries/AP_Math/AP_GeodesicGrid.cpp
@@ -427,10 +427,10 @@ int AP_GeodesicGrid::_triangle_index(const Vector3f &v, bool inclusive)
         w.z = -w.z;
         break;
     case 1:
-        w(w.y, w.z, -w.x);
+        w = {w.y, w.z, -w.x};
         break;
     case 2:
-        w(w.z, w.x, -w.y);
+        w = {w.z, w.x, -w.y};
         break;
     }
 

--- a/libraries/AP_Math/matrix3.cpp
+++ b/libraries/AP_Math/matrix3.cpp
@@ -62,9 +62,9 @@ void Matrix3<T>::to_euler(float *roll, float *pitch, float *yaw) const
 template <typename T>
 void Matrix3<T>::from_rotation(enum Rotation rotation)
 {
-    (*this).a(1,0,0);
-    (*this).b(0,1,0);
-    (*this).c(0,0,1);
+    (*this).a = {1,0,0};
+    (*this).b = {0,1,0};
+    (*this).c = {0,0,1};
 
     (*this).a.rotate(rotation);
     (*this).b.rotate(rotation);

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -78,12 +78,6 @@ public:
         , y(y0)
         , z(z0) {}
 
-    // function call operator
-    void operator ()(const T x0, const T y0, const T z0)
-    {
-        x= x0; y= y0; z= z0;
-    }
-
     // test for equality
     bool operator ==(const Vector3<T> &v) const;
 

--- a/libraries/SITL/SIM_Calibration.cpp
+++ b/libraries/SITL/SIM_Calibration.cpp
@@ -45,7 +45,7 @@ void SITL::Calibration::update(const struct sitl_input &input)
         _angular_velocity_control(input, rot_accel);
     }
 
-    accel_body(0, 0, 0);
+    accel_body.zero();
     update_dynamics(rot_accel);
     update_position();
     time_advance();
@@ -172,6 +172,6 @@ void SITL::Calibration::_calibration_poses(Vector3f& rot_accel)
     r2.from_axis_angle(axis, rot_angle);
     dcm = r2 * dcm;
 
-    accel_body(0, 0, -GRAVITY_MSS);
+    accel_body = {0, 0, -GRAVITY_MSS};
     accel_body = dcm.transposed() * accel_body;
 }

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -428,9 +428,11 @@ void FlightAxis::update(const struct sitl_input &input)
                         state.m_aircraftPositionX_MTR,
                         -state.m_altitudeASL_MTR - home.alt*0.01);
 
-    accel_body(state.m_accelerationBodyAX_MPS2,
-               state.m_accelerationBodyAY_MPS2,
-               state.m_accelerationBodyAZ_MPS2);
+    accel_body = {
+        float(state.m_accelerationBodyAX_MPS2),
+        float(state.m_accelerationBodyAY_MPS2),
+        float(state.m_accelerationBodyAZ_MPS2)
+    };
 
     // accel on the ground is nasty in realflight, and prevents helicopter disarm
     if (!is_zero(state.m_isTouchingGround)) {

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -39,7 +39,7 @@ void Motor::calculate_forces(const struct sitl_input &input,
     Vector3f rotor_torque(0, 0, yaw_factor * motor_speed * yaw_scale);
 
     // get thrust for untilted motor
-    thrust(0, 0, -motor_speed);
+    thrust = {0, 0, -motor_speed};
 
     // define the arm position relative to center of mass
     Vector3f arm(arm_scale * cosf(radians(angle)), arm_scale * sinf(radians(angle)), 0);

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -311,7 +311,7 @@ bool XPlane::receive_data(void)
         printf("X-Plane home reset dist=%f alt=%.1f/%.1f\n",
                loc.get_distance(location), loc.alt*0.01f, location.alt*0.01f);
         // reset home location
-        position_zero(-pos.x, -pos.y, -pos.z);
+        position_zero = {-pos.x, -pos.y, -pos.z};
         home.lat = loc.lat;
         home.lng = loc.lng;
         home.alt = loc.alt;


### PR DESCRIPTION
This removes one of the weirdnesses in the code, the ability to use a Vector3 as a function.  Let's make assignments look like assignments.

The number of places we do this is dwarfed by the number of places we construct and assign from a Vector3.

Assigning from {}-enclosed lists has the advantage of warning about narrowing-conversions, too.

The code can be made slightly smaller my multiplying the vector be its scaler after construction - but that's likely to incur a call overhead.
