### PR TITLE
AP_Scripting: auto restart failed scripts

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -73,6 +73,8 @@ private:
 
     void load_all_scripts_in_dir(lua_State *L, const char *dirname);
 
+    void load_scripts(lua_State *L);
+
     void run_next_script(lua_State *L);
 
     void remove_script(lua_State *L, script_info *script);
@@ -93,6 +95,8 @@ private:
     const char * get_prompt(lua_State *L, int firstline);
     int docall(lua_State *L, int narg, int nres);
     int sandbox_ref;
+
+    bool reload;
 
     script_info *scripts; // linked list of scripts to be run, sorted by next run time (soonest first)
 


### PR DESCRIPTION
This allows scripts to automatically restart if they have failed. They must have failed due to a code error or overtime. There must be no scripts running, scripting then waits for 10 seconds and re-loads all scripts if disarmed.  

This means the error message gets re-emitted so you don't have to catch it at boot and you can fix and upload you script without a re-boot.

If a script fails when armed then it will not re-start unless you reboot.