### PR TITLE
RC_Channel: announce RC switch changes via statustext

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -274,6 +274,17 @@ private:
     void reset_mode_switch();
     void read_mode_switch();
     bool debounce_completed(int8_t position);
+
+#if !HAL_MINIMIZE_FEATURES
+    // Structure to lookup switch change announcements
+    struct LookupTable{
+       AUX_FUNC option;
+       const char *announcement;
+    };
+
+    static const LookupTable lookuptable[];
+    const char *string_for_aux_function(AUX_FUNC function) const;
+#endif
 };
 
 


### PR DESCRIPTION
a variation on #14509 that is table based and saves ~210 bytes at the expense of greater difficulty to add items....however, if I knew a method for determining the table row count, it could be easily made such that additions are just as easy...