### PR TITLE
AP_Proximity : RPLidar update for Slamtech RPLidar S1

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Proximity type
     // @Description: What type of proximity sensor is connected
-    // @Values: 0:None,7:LightwareSF40c,1:LightWareSF40C-legacy,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2,6:TeraRangerTowerEvo,10:SITL,11:MorseSITL,12:AirSimSITL
+    // @Values: 0:None,7:LightwareSF40c,1:LightWareSF40C-legacy,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2,6:TeraRangerTowerEvo,8:RPLidarS1,10:SITL,11:MorseSITL,12:AirSimSITL
     // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO("_TYPE",   1, AP_Proximity, _type[0], 0),
@@ -287,7 +287,9 @@ void AP_Proximity::detect_instance(uint8_t instance)
             return;
         }
         break;
+    //A2 and S1 uses the same protocol, only differ in reset
     case Type::RPLidarA2:
+    case Type::RPLidarS1:
         if (AP_Proximity_RPLidarA2::detect()) {
             state[instance].instance = instance;
             drivers[instance] = new AP_Proximity_RPLidarA2(*this, state[instance]);

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -47,6 +47,7 @@ public:
         RPLidarA2 = 5,
         TRTOWEREVO = 6,
         SF40C = 7,
+        RPLidarS1 = 8,
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         SITL    = 10,
         MorseSITL = 11,


### PR DESCRIPTION
This update in RPLidar driver adds support for Slamtech's new S1 lidar. A new type (8) is added.
S1 uses the same protocol as A1, A2 lidars, except that it does not send out any data after reset, but require a 2second delay before accepting commands.