### PR TITLE
Return id of max empty compass state when PRIO id is 0

### DIFF
--- a/Tools/mavproxy_modules/sitl_calibration.py
+++ b/Tools/mavproxy_modules/sitl_calibration.py
@@ -300,8 +300,8 @@ class MagcalController(CalController):
         if m.get_type() == 'MAG_CAL_REPORT':
             # NOTE: This may be not the ideal way to handle it
             if m.compass_id in self.last_progress:
-                del self.last_progress[m.compass_id]
-            if not self.last_progress:
+                self.last_progress[m.compass_id] = None
+            if len(self.last_progress.values()) and all(progress == None for progress in self.last_progress.values()):
                 self.stop()
             return
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -896,6 +896,9 @@ bool Compass::register_compass(int32_t dev_id, uint8_t& instance)
 Compass::StateIndex Compass::_get_state_id(Compass::Priority priority) const
 {
 #if COMPASS_MAX_INSTANCES > 1
+    if (_priority_did_list[priority] == 0) {
+        return StateIndex(COMPASS_MAX_INSTANCES);
+    }
     for (StateIndex i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_priority_did_list[priority] == _state[i].expected_dev_id) {
             return i;
@@ -1569,7 +1572,8 @@ bool Compass::configured(uint8_t i)
 
     StateIndex id = _get_state_id(Priority(i));
     // exit immediately if dev_id hasn't been detected
-    if (_state[id].detected_dev_id == 0) {
+    if (_state[id].detected_dev_id == 0 || 
+        id == COMPASS_MAX_INSTANCES) {
         return false;
     }
 


### PR DESCRIPTION
This fixes the issue of needless parameter swapping that occurs when PRIO_ID and DEV_ID both are zero for more than 1 devices. This issue did not create any bad behaviour except for extraneous FRAM writes.