### PR TITLE
AP_Rangefinder: add programmable glitch and averager filters to rangefinders

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -294,6 +294,7 @@ void RangeFinder::init(enum Rotation orientation_default)
  */
 void RangeFinder::update(void)
 {
+
     for (uint8_t i=0; i<num_instances; i++) {
         if (drivers[i] != nullptr) {
             if ((Type)params[i].type.get() == Type::NONE) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -104,6 +104,7 @@ public:
         uint8_t  range_valid_count;     // number of consecutive valid readings (maxes out at 10)
         uint32_t last_reading_ms;       // system time of last successful update from sensor
 
+
         const struct AP_Param::GroupInfo *var_info;
     };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -74,4 +74,9 @@ protected:
     RangeFinder::Type _backend_type;
 
     virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const = 0;
+
+private:
+
+        uint32_t avrgd_distance_cm;     // last distance reported , a running average
+        uint8_t glitch_count;           // glitch counter
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -129,6 +129,24 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ORIENT", 53, AP_RangeFinder_Params, orientation, ROTATION_PITCH_270),
 
+    // @Param: FLT_COEF
+    // @DisplayName: Coefficient for running average filter on rangefinder measurements
+    // @Description: This parameter sets the weight of the measurement moving average versus the current measurement in the filter. 0.7 is usually a good value, 0 disables
+    // @Range: 0 .95
+    // @Increment: .01
+    // @User: Advanced
+    AP_GROUPINFO("FLT_COEF", 54, AP_RangeFinder_Params, flt_coeff, 0),
+
+
+    // @Param: GLTCH_CNT
+    // @DisplayName: Number of measurement glitches in a row to ignore
+    // @Description: This parameter sets the number of glitches (>25% delta in a measurement from running average) to ignore. If the FLT_COEF =0, both glitch detection and running average is disabled and raw measurements are passed, but status is updated if out of range. A value of 0 disables the glitch filter.
+    // @Range: 0 127
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("GLCH_CNT", 55, AP_RangeFinder_Params, glitchcount, 4),
+
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -24,7 +24,11 @@ public:
     AP_Int16 min_distance_cm;
     AP_Int16 max_distance_cm;
     AP_Int8  ground_clearance_cm;
+    AP_Int8  glitch_count;
+    AP_Int16 glitch_distance_cm;
     AP_Int8  address;
     AP_Vector3f pos_offset; // position offset in body frame
     AP_Int8  orientation;
+    AP_Float flt_coeff;
+    AP_Int8  glitchcount;
 };


### PR DESCRIPTION
add the same filter as in the HC-SR04....the sensor in I2C mode has the same glitches as manifested when it was in the Triggger/Echo mode....same results...
raw:
![MaxBotixI2Craw](https://user-images.githubusercontent.com/6076534/83953181-c4e60a80-a803-11ea-998e-21e0dbc3ba72.PNG)
after filter is added:
![MaxBotixI2CwithGlitchfltr](https://user-images.githubusercontent.com/6076534/83953182-c57ea100-a803-11ea-9954-051a5aa8c682.PNG)
