### PR TITLE
Fix Plane Forward Throttle Battery Voltage Scaling

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1250,7 +1250,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: FWD_BAT_VOLT_MAX
     // @DisplayName: Forward throttle battery voltage compensation maximum voltage
-    // @Description: Forward throttle battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.4 * cell count, 0 = Disabled
+    // @Description: Forward throttle battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust). Recommend 4.2 * cell count, 0 = Disabled. Recommend THR_MAX is set to no more than 100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX, THR_MIN is set to no less than -100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX and climb descent rate limits are set accordingly.
     // @Range: 6 35
     // @Units: V
     // @User: Advanced
@@ -1258,7 +1258,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: FWD_BAT_VOLT_MIN
     // @DisplayName: Forward throttle battery voltage compensation minimum voltage
-    // @Description: Forward throttle battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.5 * cell count, 0 = Disabled
+    // @Description: Forward throttle battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.5 * cell count, 0 = Disabled. Recommend THR_MAX is set to no more than 100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX, THR_MIN is set to no less than -100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX and climb descent rate limits are set accordingly.
     // @Range: 6 35
     // @Units: V
     // @User: Advanced

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1042,7 +1042,7 @@ private:
     void servos_output(void);
     void servos_auto_trim(void);
     void servos_twin_engine_mix();
-    void throttle_voltage_comp();
+    void throttle_voltage_comp(int8_t &min_throttle, int8_t &max_throttle);
     void throttle_watt_limiter(int8_t &min_throttle, int8_t &max_throttle);
     void throttle_slew_limit(SRV_Channel::Aux_servo_function_t func);
     bool suppress_throttle(void);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -345,7 +345,7 @@ void Plane::set_servos_manual_passthrough(void)
 /*
   Scale the throttle to conpensate for battery voltage drop
  */
-void Plane::throttle_voltage_comp()
+void Plane::throttle_voltage_comp(int8_t &min_throttle, int8_t &max_throttle)
 {
     // return if not enabled, or setup incorrectly
     if (g2.fwd_thr_batt_voltage_min >= g2.fwd_thr_batt_voltage_max || !is_positive(g2.fwd_thr_batt_voltage_max)) {
@@ -369,6 +369,10 @@ void Plane::throttle_voltage_comp()
     // Scale the throttle up to compensate for voltage drop
     // Ratio = 1 when voltage = voltage max, ratio increases as voltage drops
     const float ratio = g2.fwd_thr_batt_voltage_max / batt_voltage_resting_estimate;
+
+    // Scale the throttle limits to prevent subsequent clipping
+    min_throttle = MAX((int8_t)(ratio * (float)min_throttle), -100);
+    max_throttle = MIN((int8_t)(ratio * (float)max_throttle),  100);
 
     SRV_Channels::set_output_scaled(SRV_Channel::k_throttle,
                                         constrain_int16(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * ratio, -100, 100));
@@ -455,7 +459,7 @@ void Plane::set_servos_controlled(void)
     }
 
     // conpensate for battery voltage drop
-    throttle_voltage_comp();
+    throttle_voltage_comp(min_throttle, max_throttle);
 
     // apply watt limiter
     throttle_watt_limiter(min_throttle, max_throttle);


### PR DESCRIPTION
Scaling as implemented previously does not adjust upper and lower throttle limits. This has the undesired effect that as battery voltage drops off towards end of discharge, the maximum climb performance continues to reduce which is unsafe when flying without an airspeed sensor.

Consistent climb and reverse thrust descent operation without an airspeed sensor requires that 

THR_MAX <= FWD_THR_BATT_VOLT_MIN / FWD_THR_BATT_VOLT_MAX 

and 

THR_MAX >= -FWD_THR_BATT_VOLT_MIN / FWD_THR_BATT_VOLT_MAX

There has been limited SITL testing with 

ARSPD_USE = 0
THR_MAX = 70
FWD_THR_BATT_VOLT_MAX = 12.6
FWD_THR_BATT_VOLT_MIN = 9.9

I will be testing this on a Strix Nano Goblin with Matek F765 Wing board.