### PR TITLE
Fix SITL hand launch behaviour

### DIFF
--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -71,8 +71,8 @@ Plane::Plane(const char *frame_str) :
     }
     if (strstr(frame_str, "-throw")) {
         have_launcher = true;
-        launch_accel = 10;
-        launch_time = 1;
+        launch_accel = 25;
+        launch_time = 0.4;
     }
     if (strstr(frame_str, "-tailsitter")) {
         tailsitter = true;
@@ -338,8 +338,8 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
                 launch_start_ms = now;
             }
             if (now - launch_start_ms < launch_time*1000) {
-                force.x += launch_accel;
-                force.z += launch_accel/3;
+                force.x += mass * launch_accel;
+                force.z += mass * launch_accel/3;
             }
         } else {
             // allow reset of catapult


### PR DESCRIPTION
Launch acceleration should be multiplied by vehicle mass when calculating launch force.
10 m/s (1g) is much too low for a hand launch. 25 m/s (2.5g) over a shorter period is more realistic and will trigger the recommended value of TKOFF_THR_MINACC of 15 recommended for hand launches.

SITL testing using the --frame plane-throw option was used to test it. The kinematic constraint when on ground is supplementing the vertical throw force which is less than 1g, hence no visible change in vertical g until throw complete.

<img width="1031" alt="Screen Shot 2020-06-07 at 10 49 32 am" src="https://user-images.githubusercontent.com/3596952/83957613-ab4ccd80-a8ac-11ea-92e9-58ef2b897375.png">
