### PR TITLE
AP_Scripting: add to servo bindings

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -182,6 +182,8 @@ singleton SRV_Channels method set_output_pwm_chan_timeout void uint8_t 0 NUM_SER
 singleton SRV_Channels method set_output_scaled void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 int16_t INT16_MIN INT16_MAX
 singleton SRV_Channels method get_output_pwm boolean SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'Null
 singleton SRV_Channels method get_output_scaled int16_t SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1
+singleton SRV_Channels method set_angle void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_scripting1 SRV_Channel::k_scripting16 int16_t INT16_MIN INT16_MAX
+singleton SRV_Channels method set_range void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_scripting1 SRV_Channel::k_scripting16 int16_t INT16_MIN INT16_MAX
 
 include RC_Channel/RC_Channel.h
 singleton RC_Channels alias rc


### PR DESCRIPTION
This adds a get servo scaled binding along with set_angle and set_range for the scripting servo functions. Currently you cant use set_output_scaled with the scripting servo functions as the default to a angle/range of zero.

The use case for this was to apply additional scaling to a tilt motor. You can read in the scaled value from the normal outputs apply some scaling and write it to a new scripting servo function.

I have not exposed set angle or set range for the none scripting servo output functions, there are loads of assumptions based on them being known values for the majority of the outputs.