### PR TITLE
AC_Avoid/AP_Proximity: Push 3D data into OA Database

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -354,8 +354,8 @@ bool AP_OABendyRuler::calc_margin_from_object_database(const Location &start, co
     }
 
     // convert start and end to offsets (in cm) from EKF origin
-    Vector2f start_NE, end_NE;
-    if (!start.get_vector_xy_from_origin_NE(start_NE) || !end.get_vector_xy_from_origin_NE(end_NE)) {
+    Vector3f start_NEU,end_NEU;
+    if (!start.get_vector_from_origin_NEU(start_NEU) || !end.get_vector_from_origin_NEU(end_NEU)) {
         return false;
     }
 
@@ -363,9 +363,9 @@ bool AP_OABendyRuler::calc_margin_from_object_database(const Location &start, co
     float smallest_margin = FLT_MAX;
     for (uint16_t i=0; i<oaDb->database_count(); i++) {
         const AP_OADatabase::OA_DbItem& item = oaDb->get_item(i);
-        const Vector2f point_cm = item.pos * 100.0f;
+        const Vector3f point_cm = item.pos * 100.0f;
         // margin is distance between line segment and obstacle minus obstacle's radius
-        const float m = Vector2f::closest_distance_between_line_and_point(start_NE, end_NE, point_cm) * 0.01f - item.radius;
+        const float m = Vector3f::closest_distance_between_line_and_point(start_NEU, end_NEU, point_cm) * 0.01f - item.radius;
         if (m < smallest_margin) {
             smallest_margin = m;
         }

--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -131,7 +131,7 @@ void AP_OADatabase::update()
 }
 
 // push a location into the database
-void AP_OADatabase::queue_push(const Vector2f &pos, uint32_t timestamp_ms, float distance)
+void AP_OADatabase::queue_push(const Vector3f &pos, uint32_t timestamp_ms, float distance)
 {
     if (!healthy()) {
         return;
@@ -341,12 +341,6 @@ void AP_OADatabase::send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_
         return;
     }
 
-    // use vehicle's current altitude
-    Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
-        current_loc.alt = 0;
-    }
-
     const uint8_t chan_as_bitmask = 1 << chan;
     const char callsign[9] = "OA_DB";
 
@@ -380,14 +374,14 @@ void AP_OADatabase::send_adsb_vehicle(mavlink_channel_t chan, uint16_t interval_
         }
 
         // convert object's position as an offset from EKF origin to Location
-        const Location item_loc(Vector3f(_database.items[idx].pos.x * 100.0f, _database.items[idx].pos.y * 100.0f, 0));
+        const Location item_loc(Vector3f(_database.items[idx].pos.x * 100.0f, _database.items[idx].pos.y * 100.0f, _database.items[idx].pos.z * 100.0f));
 
         mavlink_msg_adsb_vehicle_send(chan,
             idx,
             item_loc.lat,
             item_loc.lng,
             0,                          // altitude_type
-            current_loc.alt,            // use vehicle's current altitude
+            item_loc.alt,               
             0,                          // heading
             0,                          // hor_velocity
             0,                          // ver_velocity

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -24,7 +24,7 @@ public:
     };
 
     struct OA_DbItem {
-        Vector2f pos;           // position of the object as an offset in meters from the EKF origin
+        Vector3f pos;           // position of the object as an offset in meters from the EKF origin
         uint32_t timestamp_ms;  // system time that object was last updated
         float radius;           // objects radius in meters
         uint8_t send_to_gcs;    // bitmask of mavlink comports to which details of this object should be sent
@@ -35,7 +35,7 @@ public:
     void update();
 
     // push an object into the database.  Pos is the offset in meters from the EKF origin, angle is in degrees, distance in meters
-    void queue_push(const Vector2f &pos, uint32_t timestamp_ms, float distance);
+    void queue_push(const Vector3f &pos, uint32_t timestamp_ms, float distance);
 
     // returns true if database is healthy
     bool healthy() const { return (_queue.items != nullptr) && (_database.items != nullptr); }

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -444,6 +444,32 @@ float Vector3<T>::distance_to_segment(const Vector3<T> &seg_start, const Vector3
     return 2.0f*area/b;
 }
 
+// Shortest distance between point(p) to a point contained in the line segment defined by w1,w2
+// this is based on the explanation given here: www.fundza.com/vectors/point2line/index.html
+template <typename T>
+float Vector3<T>::closest_distance_between_line_and_point(const Vector3<T> &w1, const Vector3<T> &w2, const Vector3<T> &p)
+{   
+    const Vector3<T> line_vec = w2-w1;
+    const Vector3<T> p_vec = p - w1;
+    
+    const float line_vec_len = line_vec.length();
+    // protection against divide by zero
+    if(::is_zero(line_vec_len)) {
+        return 0.0f;
+    }
+
+    const float scale = 1/line_vec_len;
+    const Vector3<T> unit_vec = line_vec * scale;
+    const Vector3<T> scaled_p_vec = p_vec * scale;
+
+    float dot_product = unit_vec * scaled_p_vec;
+    dot_product = constrain_float(dot_product,0.0f,1.0f); 
+ 
+    const Vector3<T> nearest = line_vec * dot_product;
+    const float dist = (nearest - p_vec).length();
+    return dist;
+}
+
 // define for float
 template void Vector3<float>::rotate(enum Rotation);
 template void Vector3<float>::rotate_inverse(enum Rotation);
@@ -467,7 +493,7 @@ template bool Vector3<float>::is_nan(void) const;
 template bool Vector3<float>::is_inf(void) const;
 template float Vector3<float>::angle(const Vector3<float> &v) const;
 template float Vector3<float>::distance_to_segment(const Vector3<float> &seg_start, const Vector3<float> &seg_end) const;
-
+template float Vector3<float>::closest_distance_between_line_and_point(const Vector3<float> &w1, const Vector3<float> &w2, const Vector3<float> &p);
 // define needed ops for Vector3l
 template Vector3<int32_t> &Vector3<int32_t>::operator +=(const Vector3<int32_t> &v);
 

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -256,6 +256,8 @@ public:
         return perpendicular;
     }
 
+    // Shortest distance between point(p) to a point contained in the line segment defined by w1,w2
+    static float closest_distance_between_line_and_point(const Vector3<T> &w1, const Vector3<T> &w2, const Vector3<T> &p);
 };
 
 typedef Vector3<int16_t>                Vector3i;

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -84,10 +84,9 @@ protected:
     bool ignore_reading(uint16_t angle_deg) const;
 
     // database helpers.  all angles are in degrees
-    bool database_prepare_for_push(Vector2f &current_pos, float &current_heading);
+    bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);
     void database_push(float angle, float distance);
-    void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector2f &current_pos, float current_heading);
-
+    void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
 

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -303,9 +303,9 @@ void AP_Proximity_LightWareSF40C::process_message()
         }
 
         // prepare to push to object database
-        Vector2f current_pos;
-        float current_heading;
-        const bool database_ready = database_prepare_for_push(current_pos, current_heading);
+        Vector3f current_pos;
+        Matrix3f body_to_ned;
+        const bool database_ready = database_prepare_for_push(current_pos, body_to_ned);
 
         // process each point
         const float angle_inc_deg = (1.0f / point_total) * 360.0f;
@@ -361,7 +361,7 @@ void AP_Proximity_LightWareSF40C::process_message()
             // send combined distance to object database
             if ((i+1 >= point_count) || (combined_count >= PROXIMITY_SF40C_COMBINE_READINGS)) {
                 if ((combined_dist_m < INT16_MAX) && database_ready) {
-                    database_push(combined_angle_deg, combined_dist_m, _last_distance_received_ms, current_pos, current_heading);
+                    database_push(combined_angle_deg, combined_dist_m, _last_distance_received_ms, current_pos,body_to_ned);
                 }
                 combined_count = 0;
                 combined_dist_m = INT16_MAX;

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -103,9 +103,9 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
             increment *= -1;
         }
 
-        Vector2f current_pos;
-        float current_heading;
-        const bool database_ready = database_prepare_for_push(current_pos, current_heading);
+        Vector3f current_pos;
+        Matrix3f body_to_ned;
+        const bool database_ready = database_prepare_for_push(current_pos, body_to_ned);
 
         // initialise updated array and proximity sector angles (to closest object) and distances
         bool sector_updated[PROXIMITY_NUM_SECTORS];
@@ -143,7 +143,7 @@ void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
 
             // update Object Avoidance database with Earth-frame point
             if (database_ready) {
-                database_push(mid_angle, packet_distance_m, _last_update_ms, current_pos, current_heading);
+                database_push(mid_angle, packet_distance_m, _last_update_ms, current_pos, body_to_ned);
             }
         }
 


### PR DESCRIPTION
This PR fixes: https://github.com/ArduPilot/ardupilot/issues/13215
The vehicle's orientation is now taken into account while projecting the location of the object from the vehicle, and then calculating its position in Earth-Frame as a Vector3f from origin. 
This greatly improves the accuracy of the location of the object. An immediate result of this being, it should now be easier to fly low altitude, high -pitch mission because the OA_DB will no longer think the obstacle is in front of it, while really its much below it. 

**TESTING:**
This PR has not yet been tested on a real vehicle but certain bench test with a pixhawk 2.4.8 clone  were done. I have also extensively tested this on SITL + Morse in multiple terrains. I hope to test this out on a real vehicle soon. 

Live example:
1. Before vs After video for low flying (I set the exact same path for master, and my branch with a **3 meters** altitude auto mission): https://www.youtube.com/watch?v=KpQODO9YYGY
Follow the map module and the path shown to see how much trouble the current master has. The actual live video can be ignored behind as I has a tough time following the vehicle around manually.  
A bumpy grass map was used:
![image](https://user-images.githubusercontent.com/36970042/84003159-3b5f4580-a987-11ea-8a32-70ff70536c86.png)

It can be quiet clearly seen that the current master has a lot of trouble navigating, but my changes seem to make things better (atleast relatively)

2. A simulation to see it can still dodge big walls after my changes: https://www.youtube.com/watch?v=auyWNQ6Eyms

3. Bench Test:
After disabling interrupts using: `hal.scheduler->disable_interrupts_save() `  and putting a US timer in both the 2D and then 3D calculations I found out the current master takes 5 us approximately , where as my branch takes 8us to iterate once.  Therefore an extra **3us**  (2.5-3.5 on average) is now taken.

4. Memory:
Although I havent done any formal testing in this area but all the Vector2f's are now 3f's. So extra float per object is now stored in the Object Database. Other than that, there should not be a major change.


Please let me know if there are more efficient ways to make these changes, or any ideas on how I can test this more. Thanks!