### PR TITLE
AP_BattMonitor: SMBus Generic reads up to 12 cell voltages

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -72,6 +72,7 @@ public:
         return _singleton;
     }
 
+    // cell voltages in millivolts
     struct cells {
         uint16_t cells[AP_BATT_MONITOR_CELLS_MAX];
     };
@@ -109,7 +110,7 @@ public:
     bool healthy(uint8_t instance) const;
     bool healthy() const { return healthy(AP_BATT_PRIMARY_INSTANCE); }
 
-    /// voltage - returns battery voltage in millivolts
+    /// voltage - returns battery voltage in volts
     float voltage(uint8_t instance) const;
     float voltage() const { return voltage(AP_BATT_PRIMARY_INSTANCE); }
 
@@ -149,11 +150,11 @@ public:
     bool overpower_detected() const;
     bool overpower_detected(uint8_t instance) const;
 
-    // cell voltages
+    // cell voltages in millivolts
     bool has_cell_voltages() { return has_cell_voltages(AP_BATT_PRIMARY_INSTANCE); }
     bool has_cell_voltages(const uint8_t instance) const;
-    const cells & get_cell_voltages() const { return get_cell_voltages(AP_BATT_PRIMARY_INSTANCE); }
-    const cells & get_cell_voltages(const uint8_t instance) const;
+    const cells &get_cell_voltages() const { return get_cell_voltages(AP_BATT_PRIMARY_INSTANCE); }
+    const cells &get_cell_voltages(const uint8_t instance) const;
 
     // temperature
     bool get_temperature(float &temperature) const { return get_temperature(temperature, AP_BATT_PRIMARY_INSTANCE); }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -19,6 +19,8 @@
 #define AP_BATT_MONITOR_RES_EST_TC_1        0.5f
 #define AP_BATT_MONITOR_RES_EST_TC_2        0.1f
 
+#define AP_BATT_MONITOR_CELLS_MAX           12
+
 #ifndef HAL_BATTMON_SMBUS_ENABLE
 #define HAL_BATTMON_SMBUS_ENABLE 1
 #endif
@@ -71,7 +73,7 @@ public:
     }
 
     struct cells {
-        uint16_t cells[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN];
+        uint16_t cells[AP_BATT_MONITOR_CELLS_MAX];
     };
 
     // The BattMonitor_State structure is filled in by the backend driver

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
@@ -19,7 +19,7 @@ uint8_t smbus_cell_ids[] = { 0x3f,  // cell 1
                              0x34}; // cell 12
 
 #define SMBUS_READ_BLOCK_MAXIMUM_TRANSFER    0x20   // A Block Read or Write is allowed to transfer a maximum of 32 data bytes.
-#define SMBUS_CELL_COUNT_CHECK_TIMEOUT       15000000   // check cell count for up to 15 seconds
+#define SMBUS_CELL_COUNT_CHECK_TIMEOUT       15     // check cell count for up to 15 seconds
 
 /*
  * Other potentially useful registers, listed here for future use
@@ -51,7 +51,7 @@ void AP_BattMonitor_SMBus_Generic::timer()
         return;
     }
 
-    uint16_t data = UINT16_MAX;
+    uint16_t data;
     uint32_t tnow = AP_HAL::micros();
 
     // read voltage (V)
@@ -61,8 +61,8 @@ void AP_BattMonitor_SMBus_Generic::timer()
         _state.healthy = true;
     }
 
-    // assert that BATTMONITOR_SMBUS_NUM_CELLS_MAX matches smbus_cell_ids
-    static_assert(BATTMONITOR_SMBUS_NUM_CELLS_MAX == ARRAY_SIZE(smbus_cell_ids), "BATTMONITOR_SMBUS_NUM_CELLS_MAX must match smbus_cell_ids");
+    // assert that BATTMONITOR_SMBUS_NUM_CELLS_MAX must be no more than smbus_cell_ids
+    static_assert(BATTMONITOR_SMBUS_NUM_CELLS_MAX <= ARRAY_SIZE(smbus_cell_ids), "BATTMONITOR_SMBUS_NUM_CELLS_MAX must be no more than smbus_cell_ids");
 
     // check cell count
     if (!_cell_count_fixed) {
@@ -71,7 +71,7 @@ void AP_BattMonitor_SMBus_Generic::timer()
             if (_cell_count_check_start_us == 0) {
                 _cell_count_check_start_us = tnow;
             }
-            if (tnow - _cell_count_check_start_us > SMBUS_CELL_COUNT_CHECK_TIMEOUT) {
+            if (tnow - _cell_count_check_start_us > (SMBUS_CELL_COUNT_CHECK_TIMEOUT * 1e6)) {
                 // give up checking cell count after 15sec of continuous healthy battery reads
                 _cell_count_fixed = true;
             }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
@@ -5,14 +5,21 @@
 #include "AP_BattMonitor_SMBus_Generic.h"
 #include <utility>
 
-uint8_t maxell_cell_ids[] = { 0x3f,  // cell 1
-                              0x3e,  // cell 2
-                              0x3d,  // cell 3
-                              0x3c,  // cell 4
-                              0x3b,  // cell 5
-                              0x3a}; // cell 6
+uint8_t smbus_cell_ids[] = { 0x3f,  // cell 1
+                             0x3e,  // cell 2
+                             0x3d,  // cell 3
+                             0x3c,  // cell 4
+                             0x3b,  // cell 5
+                             0x3a,  // cell 6
+                             0x39,  // cell 7
+                             0x38,  // cell 8
+                             0x37,  // cell 9
+                             0x36,  // cell 10
+                             0x35,  // cell 11
+                             0x34}; // cell 12
 
 #define SMBUS_READ_BLOCK_MAXIMUM_TRANSFER    0x20   // A Block Read or Write is allowed to transfer a maximum of 32 data bytes.
+#define SMBUS_CELL_COUNT_CHECK_TIMEOUT       15000000   // check cell count for up to 15 seconds
 
 /*
  * Other potentially useful registers, listed here for future use
@@ -44,7 +51,7 @@ void AP_BattMonitor_SMBus_Generic::timer()
         return;
     }
 
-    uint16_t data;
+    uint16_t data = UINT16_MAX;
     uint32_t tnow = AP_HAL::micros();
 
     // read voltage (V)
@@ -54,13 +61,36 @@ void AP_BattMonitor_SMBus_Generic::timer()
         _state.healthy = true;
     }
 
+    // assert that BATTMONITOR_SMBUS_NUM_CELLS_MAX matches smbus_cell_ids
+    static_assert(BATTMONITOR_SMBUS_NUM_CELLS_MAX == ARRAY_SIZE(smbus_cell_ids), "BATTMONITOR_SMBUS_NUM_CELLS_MAX must match smbus_cell_ids");
+
+    // check cell count
+    if (!_cell_count_fixed) {
+        if (_state.healthy) {
+            // when battery first becomes healthy, start check of cell count
+            if (_cell_count_check_start_us == 0) {
+                _cell_count_check_start_us = tnow;
+            }
+            if (tnow - _cell_count_check_start_us > SMBUS_CELL_COUNT_CHECK_TIMEOUT) {
+                // give up checking cell count after 15sec of continuous healthy battery reads
+                _cell_count_fixed = true;
+            }
+        } else {
+            // if battery becomes unhealthy restart cell count check
+            _cell_count_check_start_us = 0;
+        }
+    }
+
     // read cell voltages
-    for (uint8_t i = 0; i < BATTMONITOR_SMBUS_MAXELL_NUM_CELLS; i++) {
-        if (read_word(maxell_cell_ids[i], data)) {
+    for (uint8_t i = 0; i < (_cell_count_fixed ? _cell_count : BATTMONITOR_SMBUS_NUM_CELLS_MAX); i++) {
+        if (read_word(smbus_cell_ids[i], data) && (data > 0) && (data < UINT16_MAX)) {
             _has_cell_voltages = true;
             _state.cell_voltages.cells[i] = data;
-            _last_cell_update_ms[i] = tnow;
-        } else if ((tnow - _last_cell_update_ms[i]) > AP_BATTMONITOR_SMBUS_TIMEOUT_MICROS) {
+            _last_cell_update_us[i] = tnow;
+            if (!_cell_count_fixed) {
+                _cell_count = MAX(_cell_count, i + 1);
+            }
+        } else if ((tnow - _last_cell_update_us[i]) > AP_BATTMONITOR_SMBUS_TIMEOUT_MICROS) {
             _state.cell_voltages.cells[i] = UINT16_MAX;
         }
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.h
@@ -2,7 +2,7 @@
 
 #include "AP_BattMonitor_SMBus.h"
 
-#define BATTMONITOR_SMBUS_MAXELL_NUM_CELLS 6
+#define BATTMONITOR_SMBUS_NUM_CELLS_MAX 12
 
 class AP_BattMonitor_SMBus_Generic : public AP_BattMonitor_SMBus
 {
@@ -26,5 +26,8 @@ private:
     uint8_t read_block(uint8_t reg, uint8_t* data, bool append_zero) const;
 
     uint8_t _pec_confirmed; // count of the number of times PEC has been confirmed as working
-    uint32_t _last_cell_update_ms[BATTMONITOR_SMBUS_MAXELL_NUM_CELLS];  // system time of last successful read of cell voltage
+    uint32_t _last_cell_update_us[BATTMONITOR_SMBUS_NUM_CELLS_MAX]; // system time of last successful read of cell voltage
+    uint32_t _cell_count_check_start_us;  // system time we started attempting to count the number of cells
+    uint8_t _cell_count;    // number of cells returning voltages
+    bool _cell_count_fixed; // true when cell count check is complete
 };

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -2368,7 +2368,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_CURRENT_MSG, sizeof(log_Current),                     \
       "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "s#vvAiJOw", "F-000!/?0" },  \
     { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
-      "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0000000000000" }, \
+      "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" }, \
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw", "sddddhhdh", "FBBBBBBBB" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -798,7 +798,7 @@ struct PACKED log_Current_Cells {
     uint64_t time_us;
     uint8_t  instance;
     float    voltage;
-    uint16_t cell_voltages[10];
+    uint16_t cell_voltages[12];
 };
 
 struct PACKED log_Compass {
@@ -1395,6 +1395,8 @@ struct PACKED log_Arm_Disarm {
 // @Field: V8: eighth cell voltage
 // @Field: V9: ninth cell voltage
 // @Field: V10: tenth cell voltage
+// @Field: V11: eleventh cell voltage
+// @Field: V12: twelfth cell voltage
 
 // @LoggerMessage: BCN
 // @Description: Beacon informtaion
@@ -2366,7 +2368,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_CURRENT_MSG, sizeof(log_Current),                     \
       "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "s#vvAiJOw", "F-000!/?0" },  \
     { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
-      "BCL", "QBfHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10", "s#vvvvvvvvvvv", "F-00000000000" }, \
+      "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0000000000000" }, \
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw", "sddddhhdh", "FBBBBBBBB" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -203,13 +203,12 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
     uint16_t cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN];
     if (battery.has_cell_voltages(instance)) {
         const AP_BattMonitor::cells& batt_cells = battery.get_cell_voltages(instance);
-        for (uint8_t i = 0; i < ARRAY_SIZE(batt_cells.cells); i++) {
-            if (i < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN) {
-                cell_volts[i] = batt_cells.cells[i];
-            } else {
-                // 10th cell reports the lowest voltage of the last 3 cells
-                cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN-1] = MIN(cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN-1], batt_cells.cells[i]);
-            }
+        // copy the first 10 cells
+        memcpy(cell_volts, batt_cells.cells, sizeof(cell_volts));
+        // 10th cell reports the lowest voltage of the last 3 cells
+        for (uint8_t i = MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN; i < ARRAY_SIZE(batt_cells.cells); i++) {
+            cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN-1] = MIN(cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN-1],
+                                                                              batt_cells.cells[i]);
         }
     } else {
         // for battery monitors that cannot provide voltages for individual cells the battery's total voltage is put into the first cell

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -199,19 +199,29 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
     float temp;
     bool got_temperature = battery.get_temperature(temp, instance);
 
-    // ensure we always send a voltage estimate to the GCS, because not all battery monitors monitor individual cells
-    // as a work around for this we create a set of fake cells to be used if the backend doesn't provide direct monitoring
-    // the GCS can then recover the pack voltage by summing all non ignored cell values. Because this is looped we can
-    // report a pack up to 655.34 V with this method
-    AP_BattMonitor::cells fake_cells;
-    if (!battery.has_cell_voltages(instance)) {
+    // prepare array of individual cell voltage
+    uint16_t cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN];
+    if (battery.has_cell_voltages(instance)) {
+        const AP_BattMonitor::cells& batt_cells = battery.get_cell_voltages(instance);
+        for (uint8_t i = 0; i < ARRAY_SIZE(batt_cells.cells); i++) {
+            if (i < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN) {
+                cell_volts[i] = batt_cells.cells[i];
+            } else {
+                // 10th cell reports the lowest voltage of the last 3 cells
+                cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN-1] = MIN(cell_volts[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN-1], batt_cells.cells[i]);
+            }
+        }
+    } else {
+        // for battery monitors that cannot provide voltages for individual cells the battery's total voltage is put into the first cell
+        // if the total voltage cannot fit into a single field, the remainder into subsequent fields.
+        // the GCS can then recover the pack voltage by summing all non ignored cell values an we can report a pack up to 655.34 V
         float voltage = battery.voltage(instance) * 1e3f;
         for (uint8_t i = 0; i < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN; i++) {
           if (voltage < 0.001f) {
               // too small to send to the GCS, set it to the no cell value
-              fake_cells.cells[i] = UINT16_MAX;
+              cell_volts[i] = UINT16_MAX;
           } else {
-              fake_cells.cells[i] = MIN(voltage, 65534.0f); // Can't send more then UINT16_MAX - 1 in a cell
+              cell_volts[i] = MIN(voltage, 65534.0f); // Can't send more then UINT16_MAX - 1 in a cell
               voltage -= 65534.0f;
           }
         }
@@ -236,7 +246,7 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
                                     MAV_BATTERY_FUNCTION_UNKNOWN, // function
                                     MAV_BATTERY_TYPE_UNKNOWN, // type
                                     got_temperature ? ((int16_t) (temp * 100)) : INT16_MAX, // temperature. INT16_MAX if unknown
-                                    battery.has_cell_voltages(instance) ? battery.get_cell_voltages(instance).cells : fake_cells.cells, // cell voltages
+                                    cell_volts, // cell voltages
                                     current,      // current in centiampere
                                     consumed_mah, // total consumed current in milliampere.hour
                                     consumed_wh,  // consumed energy in hJ (hecto-Joules)


### PR DESCRIPTION
This PR enhances the SMBus_Generic (and Maxell) battery monitors so they can read up to 12 cell voltages (the previous limit was 6 cells).

- AP_BattMonitor_SMBus_Generic reads voltages from cells 7 to 12.  In order to reduce excessive I2C traffic for batteries with fewer cells, the driver records the highest cell that it can successfully read from over a 15 second period starting from when the battery first becomes healthy.
- AP_Logger's BCL message gets two extra fields so that cells 11 and 12 are logged.  Previously it logged up to 10 cell voltages which is slightly odd because as far as I can see no battery monitor filled in more than 6 cell voltages
- GCS_MAVLink sends the BATTERY_STATUS_FIELD_VOLTAGES message as it always has but now it fills in cell voltage 10 (the highest that the mavlink message supports) with the lowest of cells 10, 11 and 12.
- Fixes a scaling bug in the AP_Logger's BCL logging

This has been tested on 6S and 12S maxell batteries.  Below is a screen shot of some debug output when testing the 6S battery.  The individual cell voltages shown are from the first time the driver successfully retrieved a voltage from each cell.  The "battery has 6 cells" is from the moment (15 sec later) when the driver decided it knew how many cells were present.

![image](https://user-images.githubusercontent.com/1498098/84231901-24a52400-ab2a-11ea-800a-410054c076af.png)

The logic to put the lowest voltage from cells 10, 11 and 12 into the 10th field of the mavlink message has also been (lightly) tested.