### PR TITLE
AP_Mission: Reflecting the result of the process

### DIFF
--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -43,25 +43,21 @@ bool AP_Mission::start_command_do_servorelayevents(const AP_Mission::Mission_Com
 
     switch (cmd.id) {
     case MAV_CMD_DO_SET_SERVO:
-        sre->do_set_servo(cmd.content.servo.channel, cmd.content.servo.pwm);
-        return true;
+        return sre->do_set_servo(cmd.content.servo.channel, cmd.content.servo.pwm);
 
     case MAV_CMD_DO_SET_RELAY:
-        sre->do_set_relay(cmd.content.relay.num, cmd.content.relay.state);
-        return true;
+        return sre->do_set_relay(cmd.content.relay.num, cmd.content.relay.state);
 
     case MAV_CMD_DO_REPEAT_SERVO:
-        sre->do_repeat_servo(cmd.content.repeat_servo.channel,
-                             cmd.content.repeat_servo.pwm,
-                             cmd.content.repeat_servo.repeat_count,
-                             cmd.content.repeat_servo.cycle_time * 1000.0f);
-        return true;
+        return sre->do_repeat_servo(cmd.content.repeat_servo.channel,
+                                    cmd.content.repeat_servo.pwm,
+                                    cmd.content.repeat_servo.repeat_count,
+                                    cmd.content.repeat_servo.cycle_time * 1000.0f);
 
     case MAV_CMD_DO_REPEAT_RELAY:
-        sre->do_repeat_relay(cmd.content.repeat_relay.num,
-                             cmd.content.repeat_relay.repeat_count,
-                             cmd.content.repeat_relay.cycle_time * 1000.0f);
-        return true;
+        return sre->do_repeat_relay(cmd.content.repeat_relay.num,
+                                    cmd.content.repeat_relay.repeat_count,
+                                    cmd.content.repeat_relay.cycle_time * 1000.0f);
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Unhandled servo/relay case");


### PR DESCRIPTION
I was returning TRUE to an uncapped limit without using the processing results.
I think it would be better if the FC used the processing results and correctly when auto flying out of sight.