### PR TITLE
GCS_MAVLink: Only send a single battery status per call

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -222,7 +222,7 @@ public:
     void send_fence_status() const;
     void send_power_status(void);
     void send_battery_status(const uint8_t instance) const;
-    bool send_battery_status() const;
+    bool send_battery_status();
     void send_distance_sensor() const;
     // send_rangefinder sends only if a downward-facing instance is
     // found.  Rover overrides this!
@@ -843,6 +843,8 @@ private:
 #endif
 
     uint32_t last_mavlink_stats_logged;
+
+    uint8_t last_battery_status_idx;
 
     // true if we should NOT do MAVLink on this port (usually because
     // someone's doing SERIAL_CONTROL over mavlink)

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -246,14 +246,19 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
 }
 
 // returns true if all battery instances were reported
-bool GCS_MAVLINK::send_battery_status() const
+bool GCS_MAVLINK::send_battery_status()
 {
     const AP_BattMonitor &battery = AP::battery();
 
-    for(uint8_t i = 0; i < battery.num_instances(); i++) {
-        if (battery.get_type(i) != AP_BattMonitor_Params::BattMonitor_Type::BattMonitor_TYPE_NONE) {
+    for(uint8_t i = 0; i < AP_BATT_MONITOR_MAX_INSTANCES; i++) {
+        const uint8_t battery_id = (last_battery_status_idx + 1) % AP_BATT_MONITOR_MAX_INSTANCES;
+        if (battery.get_type(battery_id) != AP_BattMonitor_Params::BattMonitor_Type::BattMonitor_TYPE_NONE) {
             CHECK_PAYLOAD_SIZE(BATTERY_STATUS);
-            send_battery_status(i);
+            send_battery_status(battery_id);
+            last_battery_status_idx = battery_id;
+            return true;
+        } else {
+            last_battery_status_idx = battery_id;
         }
     }
     return true;


### PR DESCRIPTION
This is done for the same reasons as #14589. The spamming of all the messages in the same slot can lead to never receiving batteries 2-9 on a GCS, while getting reliable updates on battery 1.

On the MAG_CAL PR I think a single message per call was absolutely correct. On this one I think there is an argument that says we should still try and send the number of instances at once, but ensure we send the first one we didn't send last time first, that way we minimize the impact of dropped data. But I'm willing to present it like this first. It's mostly notable that this makes a big impact on the apparent battery update rates if you have multiple batteries enabled (particularly with 4 monitors in my testing it starts to be quite evident). If we did the send all but start from the first one not sent it wouldn't show up on GCS's that weren't tweaking that message up. (It's also hard for a GCS to tweak that reliably in advance since you have to know how many monitors are around)