### PR TITLE
AP_Bootloader: avoid compilation error with -Werror=type-limits

### DIFF
--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -88,6 +88,8 @@ void flash_init(void)
         reserved += stm32_flash_getpagesize(flash_base_page);
         flash_base_page++;
     }
+
+#if FLASH_RESERVE_END_KB
     /*
       reduce num_pages to account for FLASH_RESERVE_END_KB
      */
@@ -96,6 +98,7 @@ void flash_init(void)
         reserved += stm32_flash_getpagesize(num_pages-1);
         num_pages--;
     }
+#endif
 }
 
 void flash_set_keep_unlocked(bool set)


### PR DESCRIPTION
See https://github.com/ArduPilot/ardupilot/issues/14596

I am getting this error while building the bootloader for mRoControlZeroF7 device. Please help me.

[81/85] Linking build/mRoControlZeroF7/Tools/AP_Bootloader/liblibcanard.a
../../Tools/AP_Bootloader/support.cpp: In function 'void flash_init()':
../../Tools/AP_Bootloader/support.cpp:95:21: error: comparison of unsigned expression < 0 is always false [-Werror=type-limits]
while (reserved < FLASH_RESERVE_END_KB * 1024U) {
^
compilation terminated due to -Wfatal-errors.

Closes https://github.com/ArduPilot/ardupilot/issues/14596