### PR TITLE
GCS_MAVLINK: fixed logging over mavlink for CubeOrange

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -126,7 +126,8 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     bool broadcast_component = (target_component == 0 || target_component == -1);
     bool match_system = broadcast_system || (target_system == mavlink_system.sysid);
     bool match_component = match_system && (broadcast_component || 
-                                            (target_component == mavlink_system.compid));
+                                            target_component == mavlink_system.compid ||
+                                            target_component == MAV_COMP_ID_LOG);
     bool process_locally = match_system && match_component;
 
     if (process_locally && !broadcast_system && !broadcast_component) {


### PR DESCRIPTION
CubeOrange has an ADSB dongle enabled by default, which breaks logging
over mavlink with mavproxy which sends the logging start request to
the broadcast ID