### PR TITLE
HAL_ChibiOS: add fair scheduling for UARTs

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -178,6 +178,7 @@ private:
     volatile uint8_t rx_bounce_idx;
     uint8_t *rx_bounce_buf[2];
     uint8_t *tx_bounce_buf;
+    uint16_t contention_counter;
 #endif
     ByteBuffer _readbuf{0};
     ByteBuffer _writebuf{0};


### PR DESCRIPTION
if two UARTs have DMA contention then we can get 2nd UART always
failing to send as as always do sends in the same order per 1kHz
loop. This ensures we give equal priority to all UARTs

see issue #14581