### PR TITLE
AP_NavEKF2/3: add checks for external nav position, velocity and attitude being NaN

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -924,7 +924,6 @@ void NavEKF2_core::writeExtNavData(const Vector3f &pos, const Quaternion &quat, 
     extNavDataNew.time_ms = timeStamp_ms;
 
     storedExtNav.push(extNavDataNew);
-
 }
 
 /*

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -892,6 +892,11 @@ void NavEKF2_core::getTimingStatistics(struct ekf_timing &_timing)
 
 void NavEKF2_core::writeExtNavData(const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint16_t delay_ms, uint32_t resetTime_ms)
 {
+    // protect against NaN
+    if (pos.is_nan() || isnan(posErr) || quat.is_nan() || isnan(angErr)) {
+        return;
+    }
+
     // limit update rate to maximum allowed by sensor buffers and fusion process
     // don't try to write to buffer until the filter has been initialised
     if ((timeStamp_ms - extNavMeasTime_ms) < 20) {
@@ -1014,6 +1019,11 @@ void NavEKF2_core::writeDefaultAirSpeed(float airspeed)
 
 void NavEKF2_core::writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms)
 {
+    // protect against NaN
+    if (vel.is_nan() || isnan(err)) {
+        return;
+    }
+
     if ((timeStamp_ms - extNavVelMeasTime_ms) < 20) {
         return;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -120,6 +120,11 @@ void NavEKF3_core::readRangeFinder(void)
 
 void NavEKF3_core::writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, uint16_t delay_ms, const Vector3f &posOffset)
 {
+    // protect against NaN
+    if (isnan(quality) || delPos.is_nan() || delAng.is_nan() || isnan(delTime) || posOffset.is_nan()) {
+        return;
+    }
+
     // limit update rate to maximum allowed by sensor buffers and fusion process
     // don't try to write to buffer until the filter has been initialised
     if (((timeStamp_ms - bodyOdmMeasTime_ms) < frontend->sensorIntervalMin_ms) || (delTime < dtEkfAvg) || !statesInitialised) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -978,6 +978,9 @@ void NavEKF3_core::writeExtNavData(const Vector3f &pos, const Quaternion &quat, 
     timeStamp_ms = MAX(timeStamp_ms, imuDataDelayed.time_ms);
     extNavDataNew.time_ms = timeStamp_ms;
 
+    // store position data to buffer
+    storedExtNav.push(extNavDataNew);
+
     // protect against attitude or angle being NaN
     if (!quat.is_nan() && !isnan(angErr)) {
         // extract yaw from the attitude
@@ -988,8 +991,6 @@ void NavEKF3_core::writeExtNavData(const Vector3f &pos, const Quaternion &quat, 
         const float yaw_accuracy_rad = MAX(angErr, radians(5.0f));
         writeEulerYawAngle(yaw_rad, yaw_accuracy_rad, timeStamp_ms, 2);
     }
-
-    storedExtNav.push(extNavDataNew);
 }
 
 void NavEKF3_core::writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms)


### PR DESCRIPTION
This resolves a reported crash while testing the Intel RealSense T265 (wiki) when the camera produced NaN values.  Below is a screen shot of the onboard log and we can see that the Visual Odometry information being fed into the EKF becomes NaN.  The EKF3's Roll, Pitch and Yaw estimates become zero and the copter flips and crashes.
![T265-NaNinLogs2](https://user-images.githubusercontent.com/1498098/84614708-e8930a00-af01-11ea-840b-d461b34acf77.png)

This PR adds additional checks into EKF2 and EKF3 so that they do not consume External Nav position, velocity or attitude if they are NaN.

This has been successfully tested in SITL for both EKF2 and EKF3.  For the test I modified SIM_Vicon.cpp so that if SIM_VICON_FAIL was set to 2, 3 or 4, NaNs were introduced into the position, attitude and velocity respectively.  I was able to recreate the failure and then re-tested with this PR's changes and proved the vehicle did not crash.  Instead and EKF failsafe was triggered as if the data was no longer arriving into the EKF.