### PR TITLE
AC_Avoid: Check if origin is set before any obstacle avoidance algorithm is run

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -37,16 +37,6 @@ AP_OADijkstra::AP_OADijkstra() :
 // returns DIJKSTRA_STATE_SUCCESS and populates origin_new and destination_new if avoidance is required
 AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current_loc, const Location &destination, Location& origin_new, Location& destination_new)
 {
-    // require ekf origin to have been set
-    struct Location ekf_origin {};
-    {
-        WITH_SEMAPHORE(AP::ahrs().get_semaphore());
-        if (!AP::ahrs().get_origin(ekf_origin)) {
-            AP::logger().Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, 0, destination, destination);
-            return DIJKSTRA_STATE_NOT_REQUIRED;
-        }
-    }
-
     WITH_SEMAPHORE(AP::fence()->polyfence().get_loaded_fence_semaphore());
 
     // avoidance is not required if no fences

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -204,7 +204,18 @@ AP_OAPathPlanner::OA_RetState AP_OAPathPlanner::mission_avoidance(const Location
 
 // avoidance thread that continually updates the avoidance_result structure based on avoidance_request
 void AP_OAPathPlanner::avoidance_thread()
-{
+{   
+    // require ekf origin to have been set
+    bool origin_set = false;
+    while (!origin_set) {
+        hal.scheduler->delay(500);
+        struct Location ekf_origin {};
+        {
+            WITH_SEMAPHORE(AP::ahrs().get_semaphore());
+            origin_set = AP::ahrs().get_origin(ekf_origin);    
+        }
+    }
+
     while (true) {
 
         // if database queue needs attention, service it faster


### PR DESCRIPTION
Both BendyRuler and Djikstra's require origin to have been set before being run but BendyRuler does not have this check. This might lead to an issue where the location used in BendyRuler is not initialized (i.e. 0,0,0) and we still run the algorithm. 
This issue has been fixed by moving the check up from Djikstra's to PathPlanner. 
@rmackay9 @khancyr 
