### PR TITLE
Tools: AP_Bootloader: remove unused BL_WAIT_MAGIC define

### DIFF
--- a/Tools/AP_Bootloader/bl_protocol.h
+++ b/Tools/AP_Bootloader/bl_protocol.h
@@ -1,8 +1,6 @@
 void jump_to_app(void);
 void bootloader(unsigned timeout);
 
-#define BL_WAIT_MAGIC	0x19710317		/* magic number in PWR regs to wait in bootloader */
-
 /*****************************************************************************
  * Chip/board functions.
  */


### PR DESCRIPTION
This has been replaced with RTC_BOOT_HOLD