### PR TITLE
Rover/AP_Scripting: scripting support for direct steering and throttle control

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -167,6 +167,19 @@ bool Rover::set_target_velocity_NED(const Vector3f& vel_ned)
     return true;
 }
 
+// set steering and throttle (-1 to +1) (for use by scripting)
+bool Rover::set_steering_and_throttle(float steering, float throttle)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!control_mode->in_guided_mode()) {
+        return false;
+    }
+
+    // set steering and throttle
+    mode_guided.set_steering_and_throttle(steering, throttle);
+    return true;
+}
+
 #if STATS_ENABLED == ENABLED
 /*
   update AP_Stats

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -278,6 +278,7 @@ private:
     // Rover.cpp
     bool set_target_location(const Location& target_loc) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
+    bool set_steering_and_throttle(float steering, float throttle) override;
     void stats_update();
     void ahrs_update();
     void gcs_failsafe_check(void);

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -387,6 +387,9 @@ public:
     void set_desired_heading_delta_and_speed(float yaw_delta_cd, float target_speed);
     void set_desired_turn_rate_and_speed(float turn_rate_cds, float target_speed);
 
+    // set steering and throttle (-1 to +1).  Only called from scripts
+    void set_steering_and_throttle(float steering, float throttle);
+
     // vehicle start loiter
     bool start_loiter();
 
@@ -402,7 +405,8 @@ protected:
         Guided_WP,
         Guided_HeadingAndSpeed,
         Guided_TurnRateAndSpeed,
-        Guided_Loiter
+        Guided_Loiter,
+        Guided_SteeringAndThrottle
     };
 
     bool _enter() override;
@@ -415,6 +419,12 @@ protected:
     float _desired_yaw_rate_cds;// target turn rate centi-degrees per second
     bool sent_notification;     // used to send one time notification to ground station
     float _desired_speed;       // desired speed used only in HeadingAndSpeed submode
+
+    // direct steering and throttle control
+    bool _have_strthr;          // true if we have a valid direct steering and throttle inputs
+    uint32_t _strthr_time_ms;   // system time last call to set_steering_and_throttle was made (used for timeout)
+    float _strthr_steering;     // direct steering input in the range -1 to +1
+    float _strthr_throttle;     // direct throttle input in the range -1 to +1
 
     // limits
     struct {

--- a/libraries/AP_Scripting/examples/rover-set-steering-and-throttle.lua
+++ b/libraries/AP_Scripting/examples/rover-set-steering-and-throttle.lua
@@ -1,0 +1,60 @@
+-- cause a rover to drive in a figure of eight pattern by directly controlling steering and throttle
+--
+-- CAUTION: This script only works for Rover
+-- this script waits for the vehicle to be armed and RC6 input > 1800 and then:
+--    a) switches to Guided mode
+--    b) increases throttle to 30% and turns right at 20% for 10 seconds
+--    c) keep throttle at 30% and turns left at 20% for 10 seconds
+--    d) switches to Hold mode
+
+local stage = 0
+local stage_counter = 0
+local rover_guided_mode_num = 15
+local rover_hold_mode_num = 4
+
+-- the main update function that directly sets throttle and steering out to drive a figure of eight pattern
+function update()
+  if not arming:is_armed() then -- reset state when disarmed
+    stage = 0
+    stage_counter = 0
+  else
+    pwm6 = rc:get_pwm(6)
+    if pwm6 and pwm6 > 1800 then    -- check if RC6 input has moved high
+      if (stage == 0) then          -- change to guided mode
+        if (vehicle:set_mode(rover_guided_mode_num)) then     -- change to Guided mode
+          stage = stage + 1
+          stage_counter = 0
+        end
+      elseif (stage == 1) then      -- Stage1: increase throttle to 30% and turn right 20%
+        if (vehicle:set_steering_and_throttle(0.2, 0.3)) then
+          stage_counter = stage_counter + 1
+          if (stage_counter >= 10) then
+            stage = stage + 1
+            stage_counter = 0
+          end
+        end
+      elseif (stage == 2) then      -- Stage2: keep throttle at 30% and turn left 20%
+        if (vehicle:set_steering_and_throttle(-0.2, 0.3)) then
+          stage_counter = stage_counter + 1
+          if (stage_counter >= 10) then
+            stage = stage + 1
+            stage_counter = 0
+          end
+        end
+      elseif (stage == 3) then      -- Stage3: change to Hold mode
+        vehicle:set_mode(rover_hold_mode_num)
+        stage = stage + 1
+        gcs:send_text(0, "finished, switching to Hold")
+      end
+    else -- RC6 has been moved low
+      if stage > 3 then 
+        stage = 0
+        stage_counter = 0
+      end
+    end
+  end
+
+  return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -165,6 +165,7 @@ singleton AP_Vehicle method set_target_location boolean Location
 singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f
 singleton AP_Vehicle method set_target_angle_and_climbrate boolean float -180 180 float -90 90 float -360 360 float -FLT_MAX FLT_MAX boolean float -FLT_MAX FLT_MAX
+singleton AP_Vehicle method set_steering_and_throttle boolean float -1 1 float -1 1
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -172,7 +172,6 @@ public:
     virtual bool set_target_velocity_NED(const Vector3f& vel_ned) { return false; }
     virtual bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) { return false; }
 
-
     // get target location (for use by scripting)
     virtual bool get_target_location(Location& target_loc) { return false; }
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -176,6 +176,9 @@ public:
     // get target location (for use by scripting)
     virtual bool get_target_location(Location& target_loc) { return false; }
 
+    // set steering and throttle (-1 to +1) (for use by scripting with Rover)
+    virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
+
     // write out harmonic notch log messages
     void write_notch_log_messages() const;
     // update the harmonic notch


### PR DESCRIPTION
This PR add support for Lua scripts to directly control a Rover's steering and throttle.

It's pretty straight forward but:

- AP_Vehicle and Rover implement a new set_desired_steering_and_throttle() method.  The steering is in the (odd) range of -4500 to +4500 and throttle is in the range -100 to +100.  I'm happy to change these ranges to be -1 to +1 if others would prefer this.
- AP_Scripting's bindings make the new method visible to scripts
- AP_Scripting gets a new example script, rover-set-steering-and-throttle.lua

This has been tested in SITL and below is a screen shot of the script running successfully
![image](https://user-images.githubusercontent.com/1498098/84641498-0f6b3380-af36-11ea-9b08-e6f226d73597.png)


