### PR TITLE
APM_Control: Modified PID structure to be a rate PID + FF

### DIFF
--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -149,7 +149,7 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
              */
             k_I = MAX(k_I, 0.15f);
         }
-        float ki_rate = k_I * gains.tau;
+        float ki_rate = k_I;
 		//only integrate if gain and time step are positive and airspeed above min value.
 		if (dt > 0 && aspeed > 0.5f*float(aparm.airspeed_min)) {
 		    float integrator_delta = rate_error * ki_rate * delta_time * scaler;
@@ -165,6 +165,26 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
 	} else {
 		_pid_info.I = 0;
 	}
+	
+	static const float D_Filt_f3db = 1.0f; // hz for 3 dB cutoff
+	static const float tau = 1.0f / (2.0f * M_PI * D_Filt_f3db); // tau for filtering
+	
+	// Calculate the Derivative output
+    if ( dt > 0 ) {
+		
+		//Tustin transform([Kd] * [s] * [1/(s*tau+1)]) // s => (2/T)(z-1) / (z+1)
+		// work by "Phil S" - "PID Contoller Implementation in Software"
+		// Tustin transform is stable where continuous time controller is stable. 
+		// as tau tends away from 0 low pass phase shifts D control to P control
+		
+		float D_measure = -achieved_rate * scaler * scaler;
+		
+		_pid_info.D = (2.0f * gains.D * (D_measure - _last_rate) 
+			+ (2.0f * tau - delta_time) * _pid_info.D) 
+			/ (2.0f * tau + delta_time);
+			
+		_last_rate =  D_measure; 
+	}
 
     // Scale the integration limit
     float intLimScaled = gains.imax * 0.01f;
@@ -175,16 +195,15 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
 	// Calculate equivalent gains so that values for K_P and K_I can be taken across from the old PID law
     // No conversion is required for K_D
     float eas2tas = _ahrs.get_EAS2TAS();
-	float kp_ff = MAX((gains.P - gains.I * gains.tau) * gains.tau  - gains.D , 0) / eas2tas;
+	//float kp_ff = MAX((gains.P - gains.I * gains.tau) * gains.tau  - gains.D , 0) / eas2tas;
     float k_ff = gains.FF / eas2tas;
 	
 	// Calculate the demanded control surface deflection
 	// Note the scaler is applied again. We want a 1/speed scaler applied to the feed-forward
 	// path, but want a 1/speed^2 scaler applied to the rate error path. 
 	// This is because acceleration scales with speed^2, but rate scales with speed.
-    _pid_info.P = desired_rate * kp_ff * scaler;
+    _pid_info.P = rate_error * gains.P * scaler;
     _pid_info.FF = desired_rate * k_ff * scaler;
-    _pid_info.D = rate_error * gains.D * scaler;
 	_last_out = _pid_info.D + _pid_info.FF + _pid_info.P;
     _pid_info.target = desired_rate;
     _pid_info.actual = achieved_rate;

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -195,8 +195,7 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
 	// Calculate equivalent gains so that values for K_P and K_I can be taken across from the old PID law
     // No conversion is required for K_D
     float eas2tas = _ahrs.get_EAS2TAS();
-	//float kp_ff = MAX((gains.P - gains.I * gains.tau) * gains.tau  - gains.D , 0) / eas2tas;
-    float k_ff = gains.FF / eas2tas;
+	float k_ff = gains.FF / eas2tas;
 	
 	// Calculate the demanded control surface deflection
 	// Note the scaler is applied again. We want a 1/speed scaler applied to the feed-forward

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -54,6 +54,7 @@ private:
 	AP_Float _roll_ff;
 	uint32_t _last_t;
 	float _last_out;
+	float _last_rate;
 	
     AP_Logger::PID_Info _pid_info;
 

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -100,10 +100,9 @@ int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool 
 	
 	// Calculate equivalent gains so that values for K_P and K_I can be taken across from the old PID law
     // No conversion is required for K_D
-	float ki_rate = gains.I * gains.tau;
     float eas2tas = _ahrs.get_EAS2TAS();
-	float kp_ff = MAX((gains.P - gains.I * gains.tau) * gains.tau  - gains.D , 0) / eas2tas;
-    float k_ff = gains.FF / eas2tas;
+	float k_ff = gains.FF / eas2tas;
+	
 	float delta_time    = (float)dt * 0.001f;
     // Get body rate vector (radians/sec)
 	float omega_x = _ahrs.get_gyro().x;
@@ -122,10 +121,10 @@ int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool 
 	// Scaler is applied before integrator so that integrator state relates directly to aileron deflection
 	// This means aileron trim offset doesn't change as the value of scaler changes with airspeed
 	// Don't integrate if in stabilise mode as the integrator will wind up against the pilots inputs
-	if (!disable_integrator && ki_rate > 0) {
+	if (!disable_integrator && gains.I > 0) {
 		//only integrate if gain and time step are positive and airspeed above min value.
 		if (dt > 0 && aspeed > float(aparm.airspeed_min)) {
-		    float integrator_delta = rate_error * ki_rate * delta_time * scaler;
+		    float integrator_delta = rate_error * gains.I * delta_time * scaler;
 			// prevent the integrator from increasing if surface defln demand is above the upper limit
 			if (_last_out < -45) {
                 integrator_delta = MAX(integrator_delta , 0);
@@ -149,8 +148,7 @@ int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool 
 	// Note the scaler is applied again. We want a 1/speed scaler applied to the feed-forward
 	// path, but want a 1/speed^2 scaler applied to the rate error path. 
 	// This is because acceleration scales with speed^2, but rate scales with speed.
-    _pid_info.D = rate_error * gains.D * scaler;
-    _pid_info.P = desired_rate * kp_ff * scaler;
+    _pid_info.P = rate_error * gains.P * scaler;
     _pid_info.FF = desired_rate * k_ff * scaler;
     _pid_info.target = desired_rate;
     _pid_info.actual = achieved_rate;

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -59,6 +59,7 @@ private:
     AP_AutoTune autotune;
 	uint32_t _last_t;
 	float _last_out;
+	float _last_rate;
 
     AP_Logger::PID_Info _pid_info;
 


### PR DESCRIPTION
The tuning and behavior of the system was confusing.
P was the same as FF so there were two FF's
D was actually a rate P and included the set point.
Old tuning structure is still present but re-mapped.
P->FF, FF_new = old (FF + MAX((gains.P - gains.I * gains.tau) * gains.tau  - gains.D , 0))
D->P (no scaling needed)
new D term is introduced:
rate feedback without setpoint.
low pass filtered. cuttoff currently set at 1 HZ