### PR TITLE
AC_Avoid: Extend BendyRuler functionality to search for vertical paths

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -14,12 +14,14 @@
  */
 
 #include "AP_OABendyRuler.h"
+#include <AC_Avoidance/AP_OAPathPlanner.h>
 #include <AC_Avoidance/AP_OADatabase.h>
 #include <AC_Fence/AC_Fence.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
-const int16_t OA_BENDYRULER_BEARING_INC = 5;            // check every 5 degrees around vehicle
+const int16_t OA_BENDYRULER_BEARING_INC_XY = 5;            // check every 5 degrees around vehicle
+const int16_t OA_BENDYRULER_BEARING_INC_VERTICAL = 90;
 const float OA_BENDYRULER_LOOKAHEAD_STEP2_RATIO = 1.0f; // step2's lookahead length as a ratio of step1's lookahead length
 const float OA_BENDYRULER_LOOKAHEAD_STEP2_MIN = 2.0f;   // step2 checks at least this many meters past step1's location
 const float OA_BENDYRULER_LOOKAHEAD_PAST_DEST = 2.0f;   // lookahead length will be at least this many meters past the destination
@@ -36,6 +38,15 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
     const float bearing_to_dest = current_loc.get_bearing_to(destination) * 0.01f;
     const float distance_to_dest = current_loc.get_distance(destination);
 
+    // get ground course
+    float ground_course_deg;
+    if (ground_speed_vec.length_squared() < OA_BENDYRULER_LOW_SPEED_SQUARED) {
+        // with zero ground speed use vehicle's heading
+        ground_course_deg = AP::ahrs().yaw_sensor * 0.01f;
+    } else {
+        ground_course_deg = degrees(ground_speed_vec.angle());
+    }
+
     // lookahead distance is adjusted dynamically based on avoidance results
     _current_lookahead = constrain_float(_current_lookahead, _lookahead * 0.5f, _lookahead);
 
@@ -46,17 +57,29 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
     // calculate lookahead dist for step2
     const float lookahead_step2_dist = _current_lookahead * OA_BENDYRULER_LOOKAHEAD_STEP2_RATIO;
 
-    // get ground course
-    float ground_course_deg;
-    if (ground_speed_vec.length_squared() < OA_BENDYRULER_LOW_SPEED_SQUARED) {
-        // with zero ground speed use vehicle's heading
-        ground_course_deg = AP::ahrs().yaw_sensor * 0.01f;
-    } else {
-        ground_course_deg = degrees(ground_speed_vec.angle());
+    bool state;
+    switch (_bendy_type) {
+        #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+        case AP_OAPathPlanner::OA_BENDY_VERTICAL:
+            state = search_vertical_path(current_loc, destination, destination_new, lookahead_step1_dist, lookahead_step2_dist, bearing_to_dest, distance_to_dest);
+            break;
+        #endif
+
+        case AP_OAPathPlanner::OA_BENDY_HORIZONTAL:
+        default:
+            state = search_xy_path(current_loc,destination,ground_course_deg,destination_new,lookahead_step1_dist,lookahead_step2_dist,bearing_to_dest,distance_to_dest);
+            break;
     }
 
-    // check OA_BEARING_INC definition allows checking in all directions
-    static_assert(360 % OA_BENDYRULER_BEARING_INC == 0, "check 360 is a multiple of OA_BEARING_INC");
+    return state;
+}
+
+// Search for path in XY direction
+bool AP_OABendyRuler::search_xy_path(const Location& current_loc, const Location& destination, const float &ground_course_deg, Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest ) 
+{
+    
+    // check OA_BEARING_INC_XY definition allows checking in all directions
+    static_assert(360 % OA_BENDYRULER_BEARING_INC_XY == 0, "check 360 is a multiple of OA_BEARING_INC_XY");
 
     // search in OA_BENDYRULER_BEARING_INC degree increments around the vehicle alternating left
     // and right. For each direction check if vehicle would avoid all obstacles
@@ -65,14 +88,14 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
     float best_margin = -FLT_MAX;
     float best_margin_bearing = best_bearing;
 
-    for (uint8_t i = 0; i <= (170 / OA_BENDYRULER_BEARING_INC); i++) {
+    for (uint8_t i = 0; i <= (170 / OA_BENDYRULER_BEARING_INC_XY); i++) {
         for (uint8_t bdir = 0; bdir <= 1; bdir++) {
             // skip duplicate check of bearing straight towards destination
             if ((i==0) && (bdir > 0)) {
                 continue;
             }
             // bearing that we are probing
-            const float bearing_delta = i * OA_BENDYRULER_BEARING_INC * (bdir == 0 ? -1.0f : 1.0f);
+            const float bearing_delta = i * OA_BENDYRULER_BEARING_INC_XY * (bdir == 0 ? -1.0f : 1.0f);
             const float bearing_test = wrap_180(bearing_to_dest + bearing_delta);
 
             // ToDo: add effective groundspeed calculations using airspeed
@@ -116,9 +139,10 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
                         destination_new = current_loc;
                         destination_new.offset_bearing(bearing_test, distance_to_dest);
                         _current_lookahead = MIN(_lookahead, _current_lookahead * 1.1f);
-                        // if the chosen direction is directly towards the destination turn off avoidance
+                        // if the chosen direction is directly towards the destination turn off avoidance 
+                        // i == 0 && j == 0 implies no deviation from bearing to destination
                         const bool active = (i != 0 || j != 0);
-                        AP::logger().Write_OABendyRuler(active, bearing_to_dest, margin, destination, destination_new);
+                        AP::logger().Write_OABendyRuler(_bendy_type, active, bearing_to_dest, margin, destination, destination_new);
                         return active;
                     }
                 }
@@ -144,7 +168,97 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
     destination_new.offset_bearing(chosen_bearing, distance_to_dest);
 
     // log results
-    AP::logger().Write_OABendyRuler(true, chosen_bearing, best_margin, destination, destination_new);
+    AP::logger().Write_OABendyRuler(_bendy_type, true, chosen_bearing, best_margin, destination, destination_new);
+
+    return true;
+}
+
+// Search for path in the Vertical directions
+bool AP_OABendyRuler::search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest) 
+{
+    // check OA_BEARING_INC_VERTICAL definition allows checking in all directions
+    static_assert(360 % OA_BENDYRULER_BEARING_INC_VERTICAL == 0, "check 360 is a multiple of OA_BEARING_INC_VERTICAL");
+    float best_vertical_bearing = 0.0f;
+    bool  have_best_vertical_bearing = false;
+    float best_margin = -FLT_MAX;
+    float best_margin_pitch = best_vertical_bearing;
+    const uint8_t limit = 180 / OA_BENDYRULER_BEARING_INC_VERTICAL;
+    
+    for (uint8_t i = 0; i <= limit; i++) {
+        for (uint8_t bdir = 0; bdir <= 1; bdir++) {
+            // skip duplicate check of bearing straight towards destination or 180 degrees behind
+            if (((i==0) && (bdir > 0)) || ((i == limit) && (bdir > 0))) {
+                continue;
+            }
+
+            // bearing that we are probing
+            const float vertical_bearing_delta = i * OA_BENDYRULER_BEARING_INC_VERTICAL * (bdir == 0 ? 1.0f : -1.0f);
+            
+            Location test_loc = current_loc;
+            test_loc.offset_bearing_and_pitch(bearing_to_dest, vertical_bearing_delta,lookahead_step1_dist);
+
+            // calculate margin from fence for this scenario
+            float margin = calc_avoidance_margin(current_loc, test_loc);
+
+            if (margin > best_margin) {
+                best_margin_pitch = vertical_bearing_delta;
+                best_margin = margin;
+            }
+
+            if (margin > _margin_max) {
+                //This path avoids the obstacles with the required margin, now check for the path ahead
+                if(!have_best_vertical_bearing) {
+                    best_vertical_bearing = vertical_bearing_delta;
+                    have_best_vertical_bearing = true;
+                }
+                const float test_vertical_bearings_step2[] { 0.0f, 90.0f, -90.0f, 180.0f};
+                float bearing_to_dest2;
+                is_equal(fabsf(vertical_bearing_delta), 90.0f) ? (bearing_to_dest2 = bearing_to_dest) : (bearing_to_dest2 = test_loc.get_bearing_to(destination) * 0.01f);
+                float distance2 = constrain_float(lookahead_step2_dist, OA_BENDYRULER_LOOKAHEAD_STEP2_MIN, test_loc.get_distance(destination));
+
+                for (uint8_t j = 0; j < ARRAY_SIZE(test_vertical_bearings_step2); j++) {
+                    float bearing_test2 = wrap_180(test_vertical_bearings_step2[j]);
+                    Location test_loc2 = test_loc;
+                    test_loc2.offset_bearing_and_pitch(bearing_to_dest2,bearing_test2 ,distance2);
+
+                    // calculate minimum margin to fence and obstacles for this scenario
+                    float margin2 = calc_avoidance_margin(test_loc, test_loc2);
+                    if (margin2 > _margin_max) {
+                        // all good, now project in the chosen direction by the full distance
+                        destination_new = current_loc;
+                        destination_new.offset_bearing_and_pitch(bearing_to_dest,vertical_bearing_delta, distance_to_dest);
+                        _current_lookahead = MIN(_lookahead, _current_lookahead * 1.1f);
+                        // if the chosen direction is directly towards the destination turn off avoidance
+                        // i == 0 && j == 0 implies no deviation from bearing to destination
+                        const bool active = (i != 0 || j != 0);
+                        AP::logger().Write_OABendyRuler(_bendy_type, active, vertical_bearing_delta, margin, destination, destination_new);
+                        return active;
+                    }
+                }
+            }
+
+        }        
+    }   
+
+    float chosen_vertical_bearing;
+    if (have_best_vertical_bearing) {
+        // none of the directions tested were OK for 2-step checks. Choose the direction
+        // that was best for the first step
+        chosen_vertical_bearing = best_vertical_bearing;
+        _current_lookahead = MIN(_lookahead, _current_lookahead * 1.05f);
+    } else {
+        // none of the possible paths had a positive margin. Choose
+        // the one with the highest margin
+        chosen_vertical_bearing = best_margin_pitch;
+        _current_lookahead = MAX(_lookahead * 0.5f, _current_lookahead * 0.9f);
+    }
+
+    // calculate new target based on best effort
+    destination_new = current_loc;
+    destination_new.offset_bearing_and_pitch(bearing_to_dest,chosen_vertical_bearing, distance_to_dest);
+
+    // log results
+    AP::logger().Write_OABendyRuler(_bendy_type, true, chosen_vertical_bearing, best_margin, destination, destination_new);
 
     return true;
 }
@@ -158,7 +272,12 @@ float AP_OABendyRuler::calc_avoidance_margin(const Location &start, const Locati
     if (calc_margin_from_circular_fence(start, end, latest_margin)) {
         margin_min = MIN(margin_min, latest_margin);
     }
-
+    // keep track of alt fence if Vertical type BendyRuler is selected
+    #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+    if (calc_margin_from_alt_fence(start, end, latest_margin)) {
+        margin_min = MIN(margin_min, latest_margin);
+    }
+    #endif
     if (calc_margin_from_object_database(start, end, latest_margin)) {
         margin_min = MIN(margin_min, latest_margin);
     }
@@ -198,6 +317,38 @@ bool AP_OABendyRuler::calc_margin_from_circular_fence(const Location &start, con
 
     // margin is fence radius minus the longer of start or end distance
     margin = fence_radius_plus_margin - sqrtf(MAX(start_dist_sq, end_dist_sq));
+    return true;
+}
+
+// calculate minimum distance between a path and the altitude fence
+// on success returns true and updates margin
+bool AP_OABendyRuler::calc_margin_from_alt_fence(const Location &start, const Location &end, float &margin)
+{   
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) == 0) {
+        return false;
+    }
+
+    int32_t alt_above_home_cm_start, alt_above_home_cm_end;    
+    if (!start.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm_start)) {
+        return false;
+    }
+    if (!end.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm_end )) {
+        return false;
+    }
+
+    //safe max alt = Fence alt - fence margin
+    const float max_fence_alt = fence->get_safe_alt_max();
+    const float margin_start =  max_fence_alt - alt_above_home_cm_start * 0.01f;
+    const float margin_end =  max_fence_alt - alt_above_home_cm_end * 0.01f;
+    
+    //margin is minimum distance to fence from either start or end location
+    margin = MIN(margin_start,margin_end);
+
     return true;
 }
 

--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -18,7 +18,7 @@ public:
     AP_OABendyRuler &operator=(const AP_OABendyRuler&) = delete;
 
     // send configuration info stored in front end parameters
-    void set_config(float lookahead, float margin_max) { _lookahead = MAX(lookahead, 1.0f); _margin_max = MAX(margin_max, 0.0f); }
+    void set_config(float lookahead, float margin_max, uint16_t bendy_type) { _lookahead = MAX(lookahead, 1.0f); _margin_max = MAX(margin_max, 0.0f); _bendy_type = bendy_type;}
 
     // run background task to find best path and update avoidance_results
     // returns true and populates origin_new and destination_new if OA is required.  returns false if OA is not required
@@ -26,12 +26,22 @@ public:
 
 private:
 
+    // Search for path in XY direction
+    bool search_xy_path(const Location& current_loc, const Location& destination, const float &ground_course_deg, Location &destination_new, const float &lookahead_step_1_dist, const float &lookahead_step_2_dist, const float &bearing_to_dest, const float &distance_to_dest);
+
+    // Search for path in the Vertical directions
+    bool search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest); 
+
     // calculate minimum distance between a path and any obstacle
     float calc_avoidance_margin(const Location &start, const Location &end);
 
     // calculate minimum distance between a path and the circular fence (centered on home)
     // on success returns true and updates margin
     bool calc_margin_from_circular_fence(const Location &start, const Location &end, float &margin);
+
+    // calculate minimum distance between a path and the altitude fence
+    // on success returns true and updates margin
+    bool calc_margin_from_alt_fence(const Location &start, const Location &end, float &margin);
 
     // calculate minimum distance between a path and all inclusion and exclusion polygons
     // on success returns true and updates margin
@@ -48,6 +58,7 @@ private:
     // configuration parameters
     float _lookahead;               // object avoidance will look this many meters ahead of vehicle
     float _margin_max;              // object avoidance will ignore objects more than this many meters from vehicle
+    uint16_t _bendy_type;           // type of BendyRuler to run
 
     // internal variables used by background thread
     float _current_lookahead;       // distance (in meters) ahead of the vehicle we are looking for obstacles

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -29,6 +29,7 @@ const float OA_MARGIN_MAX_DEFAULT = 5;
 #if APM_BUILD_TYPE(APM_BUILD_Rover)
     const int16_t OA_OPTIONS_DEFAULT = 1;
 #endif
+const int16_t OA_BENDY_TYPE_DEFAULT = 1;
 
 const int16_t OA_UPDATE_MS = 1000;      // path planning updates run at 1hz
 const int16_t OA_TIMEOUT_MS = 3000;     // results over 3 seconds old are ignored
@@ -73,6 +74,14 @@ const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 5, AP_OAPathPlanner, _options, OA_OPTIONS_DEFAULT),
 #endif
+
+    // @Param: BENDY_TYPE
+    // @DisplayName: Type of BendyRuler
+    // @Description: BendyRuler will search for clear path along the direction defined by this parameter
+    // @Values{Rover}: 1:Horizontal search
+    // @Values: 1:Horizontal search, 2:Vertical search
+    // @User: Standard
+    AP_GROUPINFO("BENDY_TYPE", 6, AP_OAPathPlanner, _bendy_type, OA_BENDY_TYPE_DEFAULT),
 
     AP_GROUPEND
 };
@@ -248,7 +257,7 @@ void AP_OAPathPlanner::avoidance_thread()
             if (_oabendyruler == nullptr) {
                 continue;
             }
-            _oabendyruler->set_config(_lookahead, _margin_max);
+            _oabendyruler->set_config(_lookahead, _margin_max, _bendy_type);
             if (_oabendyruler->update(avoidance_request2.current_loc, avoidance_request2.destination, avoidance_request2.ground_speed_vec, origin_new, destination_new)) {
                 res = OA_SUCCESS;
             }

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -60,7 +60,16 @@ public:
         OA_OPTION_WP_RESET = (1 << 0),
     };
 
+    // enumeration for _BENDY_TYPE parameter
+    enum OABendyType {
+        OA_BENDY_HORIZONTAL = 1,
+        OA_BENDY_VERTICAL   = 2,
+    };
+
     uint16_t get_options() const { return _options;}
+    
+    uint16_t get_bendy_type() const {return _bendy_type;}
+
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -93,6 +102,8 @@ private:
     AP_Float _lookahead;            // object avoidance will look this many meters ahead of vehicle
     AP_Float _margin_max;           // object avoidance will ignore objects more than this many meters from vehicle
     AP_Int16 _options;              // Bitmask for options while recovering from Object Avoidance
+    AP_Int16 _bendy_type;           // Type of BendyRuler to run
+
     // internal variables used by front end
     HAL_Semaphore _rsem;            // semaphore for multi-thread use of avoidance_request and avoidance_result
     bool _thread_created;           // true once background thread has been created

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -112,10 +112,12 @@ bool AC_WPNav_OA::update_wpnav()
                 // convert Location to offset from EKF origin
                 Vector3f dest_NEU;
                 if (_oa_destination.get_vector_from_origin_NEU(dest_NEU)) {
-                    // calculate target altitude by calculating OA adjusted destination's distance along the original track
-                    // and then linear interpolate using the original track's origin and destination altitude
-                    const float dist_along_path = constrain_float(oa_destination_new.line_path_proportion(origin_loc, destination_loc), 0.0f, 1.0f);
-                    dest_NEU.z = linear_interpolate(_origin_oabak.z, _destination_oabak.z, dist_along_path, 0.0f, 1.0f);
+                    if (oa_ptr->get_bendy_type() == AP_OAPathPlanner::OA_BENDY_HORIZONTAL) {
+                        // calculate target altitude by calculating OA adjusted destination's distance along the original track
+                        // and then linear interpolate using the original track's origin and destination altitude
+                        const float dist_along_path = constrain_float(oa_destination_new.line_path_proportion(origin_loc, destination_loc), 0.0f, 1.0f);
+                        dest_NEU.z = linear_interpolate(_origin_oabak.z, _destination_oabak.z, dist_along_path, 0.0f, 1.0f);
+                    }
                     if (set_wp_destination(dest_NEU, _terrain_alt)) {
                         _oa_state = oa_retstate;
                     }

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -265,6 +265,16 @@ void Location::offset_bearing(float bearing, float distance)
     offset(ofs_north, ofs_east);
 }
 
+// extrapolate latitude/longitude given bearing, pitch and distance
+void Location::offset_bearing_and_pitch(float bearing, float pitch, float distance)
+{
+    const float ofs_north =  cosf(radians(pitch)) * cosf(radians(bearing)) * distance;
+    const float ofs_east  =  cosf(radians(pitch)) * sinf(radians(bearing)) * distance;
+    offset(ofs_north, ofs_east);
+    const int32_t dalt =  sinf(radians(pitch)) * distance *100.0f;
+    alt += dalt; 
+}
+
 float Location::longitude_scale() const
 {
     float scale = cosf(lat * (1.0e-7f * DEG_TO_RAD));

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -74,6 +74,10 @@ public:
     // extrapolate latitude/longitude given bearing and distance
     void offset_bearing(float bearing, float distance);
 
+    // extrapolate latitude/longitude given bearing, pitch and distance
+    void offset_bearing_and_pitch(float bearing, float pitch, float distance);
+
+
     // longitude_scale - returns the scaler to compensate for
     // shrinking longitude as you move north or south from the equator
     // Note: this does not include the scaling to convert

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -287,7 +287,7 @@ public:
     void Write_Beacon(AP_Beacon &beacon);
     void Write_Proximity(AP_Proximity &proximity);
     void Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& point);
-    void Write_OABendyRuler(bool active, float target_yaw, float margin, const Location &final_dest, const Location &oa_dest);
+    void Write_OABendyRuler(uint16_t type, bool active, float target, float margin, const Location &final_dest, const Location &oa_dest);
     void Write_OADijkstra(uint8_t state, uint8_t error_id, uint8_t curr_point, uint8_t tot_points, const Location &final_dest, const Location &oa_dest);
 
     void Write(const char *name, const char *labels, const char *fmt, ...);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -1042,13 +1042,14 @@ void AP_Logger::Write_SRTL(bool active, uint16_t num_points, uint16_t max_points
     WriteBlock(&pkt_srtl, sizeof(pkt_srtl));
 }
 
-void AP_Logger::Write_OABendyRuler(bool active, float target_yaw, float margin, const Location &final_dest, const Location &oa_dest)
+void AP_Logger::Write_OABendyRuler(uint16_t type, bool active, float target, float margin, const Location &final_dest, const Location &oa_dest)
 {
     const struct log_OABendyRuler pkt{
         LOG_PACKET_HEADER_INIT(LOG_OA_BENDYRULER_MSG),
         time_us     : AP_HAL::micros64(),
+        type        : type,
         active      : active,
-        target_yaw  : (uint16_t)wrap_360(target_yaw),
+        target      : (uint16_t)wrap_360(target),
         yaw         : (uint16_t)wrap_360(AP::ahrs().yaw_sensor * 0.01f),
         margin      : margin,
         final_lat   : final_dest.lat,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1168,8 +1168,9 @@ struct PACKED log_SRTL {
 struct PACKED log_OABendyRuler {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint16_t type;
     uint8_t active;
-    uint16_t target_yaw;
+    uint16_t target;
     uint16_t yaw;
     float margin;
     int32_t final_lat;
@@ -1839,8 +1840,9 @@ struct PACKED log_Arm_Disarm {
 // @LoggerMessage: OABR
 // @Description: Object avoidance (Bendy Ruler) diagnostics
 // @Field: TimeUS: Time since system startup
+// @Field: Type: Type of BendyRuler currently active
 // @Field: Active: True if Bendy Ruler avoidance is being used
-// @Field: DesYaw: Best yaw chosen to avoid obstacle
+// @Field: Target: Best yaw or pitch chosen to avoid obstacle
 // @Field: Yaw: Current vehicle yaw
 // @Field: Mar: Margin from path to obstacle on best yaw chosen
 // @Field: DLat: Destination latitude
@@ -2386,7 +2388,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
       "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }, \
     { LOG_OA_BENDYRULER_MSG, sizeof(log_OABendyRuler), \
-      "OABR","QBHHfLLLL","TimeUS,Active,DesYaw,Yaw,Mar,DLat,DLng,OALat,OALng", "sbddmDUDU", "F----GGGG" }, \
+      "OABR","QHBHHfLLLL","TimeUS,Type,Active,Target,Yaw,Mar,DLat,DLng,OALat,OALng", "s-bddmDUDU", "F-----GGGG" }, \
     { LOG_OA_DIJKSTRA_MSG, sizeof(log_OADijkstra), \
       "OADJ","QBBBBLLLL","TimeUS,State,Err,CurrPoint,TotPoints,DLat,DLng,OALat,OALng", "sbbbbDUDU", "F----GGGG" }, \
     { LOG_IMU2_MSG, sizeof(log_IMU), \


### PR DESCRIPTION
This PR brings about the following changes:
1. A new param called "OA_BENDY_TYPE" that lets a user select which type of avoidance they want
2. Break BendyRuler's update function to call the required type of BendyRuler.
3. Add method to **look for obstacles Up and Down and either climb/descend vertically** OR go back. (90,-90,180)
4. **Add altitude fence in Margin checks**
5. OA_WP lib will handle way points according to BendyRuler type

Two obvious facts:
- This change will only affect copter
- Its useless angainst fence's 

TESTING - 
This has been tested on Morse + SITL, and purely SITL:
1. A quadcopter trying to avoid a series of walls - https://www.youtube.com/watch?v=EpwSMcorank
2. A pure SITL demonstration, with **alt fence set up at 50 meters**: https://www.youtube.com/watch?v=A6VhvNTVtco

3. Although this PR will make the ArduCopter go vertically up, this can also be very easily modified to climb while going towards the destination, here is a example:
https://www.youtube.com/watch?v=qfEcdHXy6CA