### PR TITLE
TOOLS:Bootloader - board_types white space fix (NFC)

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -6,7 +6,7 @@ TARGET_HW_PX4_FMU_V2                    9
 TARGET_HW_PX4_FMU_V3                    9 # same as FMU_V2
 TARGET_HW_PX4_FMU_V4                   11
 TARGET_HW_PX4_FMU_V4_PRO               13
-TARGET_HW_UVIFY_CORE		       20
+TARGET_HW_UVIFY_CORE		           20
 TARGET_HW_PX4_FMU_V5                   50
 TARGET_HW_PX4_FMU_V5X                  51
 TARGET_HW_PX4_FMU_V6                   52
@@ -28,7 +28,7 @@ TARGET_HW_AV_V1                        29
 TARGET_HW_KAKUTEF7                    123
 TARGET_HW_SMARTAP_PRO                  32
 TARGET_HW_MODALAI_FC_V1             41775
-TARGET_HW_HOLYBRO_PIX32_V5                  78
+TARGET_HW_HOLYBRO_PIX32_V5             78
 
 Reserved  PX4 [BL] FMU v5X.x           51
 Reserved "PX4 [BL] FMU v6.x"           52
@@ -98,4 +98,3 @@ AP_HW_HITEC_MOSAIC                   1016
 AP_HW_MRO_PIXRACER_PRO               1017
 AP_HW_TWD_H7                         1018
 AP_HW_MAMBA405                       1019
-


### PR DESCRIPTION
just tidied up text alignment.  Not important.