### PR TITLE
HAL_ChibiOS: Add DPS310 for MatekF405-WING,F765-WING and H743

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
@@ -147,8 +147,9 @@ SPIDEV sdcard SPI3 DEVID3 SDCARD_CS MODE0 400*KHZ 25*MHZ
 # one IMU
 IMU Invensense SPI:mpu6000 ROTATION_YAW_180
 
-# one baro
+# one baro, multiple possible choices for different board varients
 BARO BMP280 I2C:0:0x76
+BARO DPS280 I2C:0:0x76
 
 define HAL_OS_FATFS_IO 1
 define HAL_BOARD_LOG_DIRECTORY "/APM/LOGS"

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF765-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF765-Wing/hwdef.dat
@@ -187,7 +187,7 @@ define HAL_DEFAULT_INS_FAST_SAMPLE 1
 # one BARO, multiple possible choices for different
 # board varients
 BARO BMP280 I2C:0:0x76
-BARO BMP388 I2C:0:0x76
+BARO DPS280 I2C:0:0x76
 BARO MS56XX I2C:0:0x77
 
 define HAL_OS_FATFS_IO 1
@@ -200,5 +200,4 @@ define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 define BOARD_PWM_COUNT_DEFAULT 13
-
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
@@ -200,8 +200,8 @@ define HAL_DEFAULT_INS_FAST_SAMPLE 1
 
 # MS5611 integrated on I2C2 bus, multiple possible choices for external barometer
 BARO MS56XX I2C:0:0x77
+BARO DPS280 I2C:0:0x76
 BARO BMP280 I2C:0:0x76
-BARO BMP388 I2C:0:0x76
 
 define HAL_OS_FATFS_IO 1
 define HAL_BOARD_LOG_DIRECTORY "/APM/LOGS"
@@ -213,5 +213,4 @@ define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 define BOARD_PWM_COUNT_DEFAULT 13
-
 


### PR DESCRIPTION
DPS310 has same package and pinout as BMP280.  We're going to use DPS310 on these flight controllers in future.
We compared DPS310 and MS5611 on H743-WING board. DPS310 performed better.