### PR TITLE
AP_Terrain: allow download of terrain data when no GPS lock

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -106,6 +106,7 @@ public:
     enum TerrainStatus status(void) const { return system_status; }
 
     // send any pending terrain request message
+    bool send_cache_request(mavlink_channel_t chan);
     void send_request(mavlink_channel_t chan);
 
     // handle terrain data and reports from GCS
@@ -391,6 +392,7 @@ private:
 
     // do we have an IO failure
     volatile bool io_failure;
+    uint32_t last_retry_ms;
 
     // have we created the terrain directory?
     bool directory_created;

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -331,8 +331,12 @@ void AP_Terrain::read_block(void)
 void AP_Terrain::io_timer(void)
 {
     if (io_failure) {
-        // don't keep trying io, so we don't thrash the filesystem
-        // code while flying
+        // retry the IO every 5s to allow for remount of sdcard
+        uint32_t now = AP_HAL::millis();
+        if (now - last_retry_ms > 5000) {
+            io_failure = false;
+            last_retry_ms = now;
+        }
         return;
     }
 


### PR DESCRIPTION
this fixes several issues:

 - allows users to download terrain data at home with no GPS lock

 - allows for a TERRAIN_CHECK without GPS lock

 - retries opening of files every 5 seconds to allow for remount of sd
   card after boot