### PR TITLE
AP_RangeFinder: maxbotix: use i2c-address parameter

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5566,6 +5566,75 @@ class AutoTestCopter(AutoTest):
         self.progress("mavlink rangefinder OK")
         self.land_and_disarm()
 
+    def fly_rangefinder_driver_maxbotix(self):
+        ex = None
+        try:
+            self.context_push()
+
+            self.start_subtest("No messages")
+            rf = self.mav.recv_match(type="DISTANCE_SENSOR", timeout=5, blocking=True)
+            if rf is not None:
+                raise NotAchievedException("Receiving DISTANCE_SENSOR when I shouldn't be")
+
+            self.start_subtest("Default address")
+            self.set_parameter("RNGFND1_TYPE", 2)  # maxbotix
+            self.reboot_sitl()
+            self.do_timesync_roundtrip()
+            rf = self.mav.recv_match(type="DISTANCE_SENSOR", timeout=5, blocking=True)
+            self.progress("Got (%s)" % str(rf))
+            if rf is None:
+                raise NotAchievedException("Didn't receive DISTANCE_SENSOR when I should've")
+
+            self.start_subtest("Explicitly set to default address")
+            self.set_parameter("RNGFND1_TYPE", 2)  # maxbotix
+            self.set_parameter("RNGFND1_ADDR", 0x70)
+            self.reboot_sitl()
+            self.do_timesync_roundtrip()
+            rf = self.mav.recv_match(type="DISTANCE_SENSOR", timeout=5, blocking=True)
+            self.progress("Got (%s)" % str(rf))
+            if rf is None:
+                raise NotAchievedException("Didn't receive DISTANCE_SENSOR when I should've")
+
+            self.start_subtest("Explicitly set to non-default address")
+            self.set_parameter("RNGFND1_ADDR", 0x71)
+            self.reboot_sitl()
+            self.do_timesync_roundtrip()
+            rf = self.mav.recv_match(type="DISTANCE_SENSOR", timeout=5, blocking=True)
+            self.progress("Got (%s)" % str(rf))
+            if rf is None:
+                raise NotAchievedException("Didn't receive DISTANCE_SENSOR when I should've")
+
+            self.start_subtest("Two MaxBotix RangeFinders")
+            self.set_parameter("RNGFND1_TYPE", 2)  # maxbotix
+            self.set_parameter("RNGFND1_ADDR", 0x70)
+            self.set_parameter("RNGFND1_MIN_CM", 150)
+            self.set_parameter("RNGFND2_TYPE", 2)  # maxbotix
+            self.set_parameter("RNGFND2_ADDR", 0x71)
+            self.set_parameter("RNGFND2_MIN_CM", 250)
+            self.reboot_sitl()
+            self.do_timesync_roundtrip()
+            for i in [0, 1]:
+                rf = self.mav.recv_match(type="DISTANCE_SENSOR", timeout=5, blocking=True, condition="DISTANCE_SENSOR.id==%u" % i)
+                self.progress("Got id==%u (%s)" % (i, str(rf)))
+                if rf is None:
+                    raise NotAchievedException("Didn't receive DISTANCE_SENSOR when I should've")
+                expected_dist = 150
+                if i == 1:
+                    expected_dist = 250
+                if rf.min_distance != expected_dist:
+                    raise NotAchievedException("Unexpected min_cm (want=%u got=%u)" %
+                    (expected_dist, rf.min_distance))
+
+            self.context_pop()
+        except Exception as e:
+            self.progress("Caught exception: %s" %
+                          self.get_exception_stacktrace(e))
+            ex = e
+
+        self.reboot_sitl()
+        if ex is not None:
+            raise ex
+
     def fly_rangefinder_drivers(self):
         self.set_parameter("RTL_ALT", 500)
         self.set_parameter("RTL_ALT_TYPE", 1)
@@ -6097,6 +6166,10 @@ class AutoTestCopter(AutoTest):
             ("RangeFinderDrivers",
              "Test rangefinder drivers",
              self.fly_rangefinder_drivers), #62s
+
+            ("MaxBotixI2CXL",
+             "Test maxbotix rangefinder drivers",
+             self.fly_rangefinder_driver_maxbotix), #62s
 
             ("ParameterValidation",
              "Test parameters are checked for validity",

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -350,15 +350,20 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
             }
         }
         break;
-    case Type::MBI2C:
+    case Type::MBI2C: {
+        uint8_t addr = AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR;
+        if (params[instance].address != 0) {
+            addr = params[instance].address;
+        }
         FOREACH_I2C(i) {
             if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
-                                                                  hal.i2c_mgr->get_device(i, AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR)),
+                                                                  hal.i2c_mgr->get_device(i, addr)),
                              instance)) {
                 break;
             }
         }
         break;
+    }
     case Type::LWI2C:
         if (params[instance].address) {
             // the LW20 needs a long time to boot up, so we delay 1.5s here

--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -48,6 +48,7 @@ static IgnoredI2CDevice ignored;
 
 static ToshibaLED toshibaled;
 static MaxSonarI2CXL maxsonari2cxl;
+static MaxSonarI2CXL maxsonari2cxl_2;
 static Maxell maxell;
 static Rotoye rotoye;
 static Airspeed_DLVR airspeed_dlvr;
@@ -60,6 +61,7 @@ struct i2c_device_at_address {
     I2CDevice &device;
 } i2c_devices[] {
     { 0, 0x70, maxsonari2cxl },
+    { 0, 0x71, maxsonari2cxl_2 },
     { 1, 0x01, icm40609 },
     { 1, 0x55, toshibaled },
     { 1, 0x38, ignored }, // NCP5623


### PR DESCRIPTION
Closes #14535

This is contrary to the description on the ADDR field; 0 does not disable the maxbotix sensor, it uses the default address (0x70).  But then, it seems a few other drivers ignore that bit anyway.
