### PR TITLE
Plane: Remove the use of RTL_RADIUS from LOITER_UNLIM mission items

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -657,14 +657,8 @@ bool Plane::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 
 bool Plane::verify_loiter_unlim(const AP_Mission::Mission_Command &cmd)
 {
-    if (cmd.p1 <= 1 && abs(g.rtl_radius) > 1) {
-        // if mission radius is 0,1, and rtl_radius is valid, use rtl_radius.
-        loiter.direction = (g.rtl_radius < 0) ? -1 : 1;
-        update_loiter(abs(g.rtl_radius));
-    } else {
-        // else use mission radius
-        update_loiter(cmd.p1);
-    }
+    // else use mission radius
+    update_loiter(cmd.p1);
     return false;
 }
 


### PR DESCRIPTION
So this is an old behavior I just noticed. If you are trying to just flag CW/CCW from a GCS you can normally specify -1 or +1 to change the direction without having overridden `WP_LOITER_RAD`. However if you are using `RTL_RADIUS` then this is suddenly the value that's used here. I can't figure out the justification for that as it doesn't apply to any of the other loiter commands which support radius overrides, nor is it in the docs for `RTL_RADIUS`

`// @Description: Defines the radius of the loiter circle when in RTL mode. If this is zero then WP_LOITER_RAD is used. If the radius is negative then a counter-clockwise is used. If positive then a clockwise loiter is used.`

This just removes the odd override behavior. Is there a reason why this would be bad? From a user experience and documentation perspective I was really surprised to find this.