### PR TITLE
Plane: added arming check for terrain data

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -95,6 +95,21 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
         }
     }
 
+#if AP_TERRAIN_AVAILABLE
+    if (plane.g.terrain_follow || plane.mission.contains_terrain_relative()) {
+        // check terrain data is loaded and healthy
+        uint16_t terr_pending=0, terr_loaded=0;
+        plane.terrain.get_statistics(terr_pending, terr_loaded);
+        if (plane.terrain.status() != AP_Terrain::TerrainStatusOK) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "terrain data unhealthy");
+            ret = false;
+        } else if (terr_pending != 0) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "waiting for terrain data");
+            ret = false;
+        }
+    }
+#endif
+    
     if (plane.control_mode == &plane.mode_auto && plane.mission.num_commands() <= 1) {
         check_failed(display_failure, "No mission loaded");
         ret = false;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2326,6 +2326,23 @@ bool AP_Mission::contains_item(MAV_CMD command) const
     return false;
 }
 
+/*
+  return true if the mission has a terrain relative item
+ */
+bool AP_Mission::contains_terrain_relative(void) const
+{
+    for (int i = 1; i < num_commands(); i++) {
+        Mission_Command tmp;
+        if (!read_cmd_from_storage(i, tmp)) {
+            continue;
+        }
+        if (stored_in_location(tmp.id) && tmp.content.location.terrain_alt) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // reset the mission history to prevent recalling previous mission histories after a mission restart.
 void AP_Mission::reset_wp_history(void)
 {

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -577,6 +577,9 @@ public:
     // returns true if the mission contains the requested items
     bool contains_item(MAV_CMD command) const;
 
+    // returns true if the mission has a terrain relative mission item
+    bool contains_terrain_relative(void) const;
+    
     // reset the mission history to prevent recalling previous mission histories when restarting missions.
     void reset_wp_history(void);
 


### PR DESCRIPTION
This was in copter but not in plane. We must check for terrain data if TERRAIN_FOLLOW=1 or the mission has terrain items
