### PR TITLE
Copter: parachute improvements

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -969,6 +969,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPPTR(mode_zigzag_ptr, "ZIGZ_", 38, ParametersG2, ModeZigZag),
 #endif
 
+    // @Param: CHUTE_TRIG_DELAY
+    // @DisplayName: Parachute trigger delay
+    // @Description: The time it will take before automatic parachute will trigger
+    // @Units: ms
+    // @Range: 250 5000
+    // @Increment: 10
+    // @User: Standard
+    AP_GROUPINFO("CHUTE_TRIG_DELAY", 39, ParametersG2, parachute_trigger_delay, 500),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -616,6 +616,8 @@ public:
     void *mode_zigzag_ptr;
 #endif
 
+    AP_Int16 parachute_trigger_delay;
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -154,7 +154,6 @@ void Copter::thrust_loss_check()
 void Copter::parachute_check()
 {
     static uint16_t control_loss_count; // number of iterations we have been out of control
-    static int32_t baro_alt_start;
 
     // exit immediately if parachute is not enabled
     if (!parachute.enabled()) {
@@ -187,6 +186,12 @@ void Copter::parachute_check()
         return;
     }
 
+    // ensure we are going down
+    if (is_positive(barometer.get_climb_rate())) {
+        control_loss_count = 0;
+        return;
+    }
+
     // ensure the first control_loss event is from above the min altitude
     if (control_loss_count == 0 && parachute.alt_min() != 0 && (current_loc.alt < (int32_t)parachute.alt_min() * 100)) {
         return;
@@ -204,21 +209,7 @@ void Copter::parachute_check()
     // increment counter
     if (control_loss_count < (PARACHUTE_CHECK_TRIGGER_SEC*scheduler.get_loop_rate_hz())) {
         control_loss_count++;
-    }
-
-    // record baro alt if we have just started losing control
-    if (control_loss_count == 1) {
-        baro_alt_start = baro_alt;
-
-    // exit if baro altitude change indicates we are not falling
-    } else if (baro_alt >= baro_alt_start) {
-        control_loss_count = 0;
-        return;
-
-    // To-Do: add check that the vehicle is actually falling
-
-    // check if loss of control for at least 1 second
-    } else if (control_loss_count >= (PARACHUTE_CHECK_TRIGGER_SEC*scheduler.get_loop_rate_hz())) {
+    } else { // loss of control for at least 1 second
         // reset control loss counter
         control_loss_count = 0;
         AP::logger().Write_Error(LogErrorSubsystem::CRASH_CHECK, LogErrorCode::CRASH_CHECK_LOSS_OF_CONTROL);


### PR DESCRIPTION
These improvements were done some time ago for Percepto and have been extensively tested by them.

The first commit was discussed last year with @rmackay9, after Percepto had an issue with current code: the baro altitude was initially going down and up, and that was constantly resetting the counter to 0 - that led to the parachute not deploying fast enough.

The second commit was made after more tests from Percepto: we realized that when the copter started falling, the climb rate from baro wasn't good enough and it would still reset the counter. The solution was to also look at the climb rate from AHRS and only reset the counter if they both agree vehicle is going up - if only one says it is climbing, we don't change the counter (no increase, decrease or reset).

In addition, we added a parameter to set the minimum time it will take before parachute is deployed. The default has been reduced from 1s to 0.5s since that was the best value for their vehicle - that might not match every vehicle and we can change it back, that's why it's a parameter 🙂

[Here](https://github.com/ArduPilot/ardupilot/files/4822308/Percepto_parachute_logs.zip) are 3 logs provided by Percepto:

1. original code
1. with first commit - loss of control identification is still quite long here - 3.8 sec.
1. final implementation - with parameter set to 500 ms, they performed over 100 successful experiments (on three different test platforms). In this log the loss of control identification took 1.3 sec.

Disclosure: Percepto is sponsoring upstreaming this code.