### PR TITLE
Copter: fix GUID log message scaling

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -430,6 +430,8 @@ struct PACKED log_GuidedTarget {
 };
 
 // Write a Guided mode target
+// pos_target is lat, lon, alt OR offset from ekf origin in cm OR roll, pitch, yaw target in centi-degrees
+// vel_target is cm/s
 void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target)
 {
     struct log_GuidedTarget pkt = {
@@ -604,7 +606,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: vZ: Target velocity, Z-Axis
     
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
-      "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-000000" },
+      "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-BBBBBB" },
 };
 
 void Copter::Log_Write_Vehicle_Startup_Messages()

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -557,7 +557,6 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: LastMeasUS: Time when target was last detected
 // @Field: EKFOutl: EKF's outlier count
 // @Field: Est: Type of estimator used
-
 #if PRECISION_LANDING == ENABLED
     { LOG_PRECLAND_MSG, sizeof(log_Precland),
       "PL",    "QBBfffffffIIB",    "TimeUS,Heal,TAcq,pX,pY,vX,vY,mX,mY,mZ,LastMeasUS,EKFOutl,Est", "s--ddmmddms--","F--00BB00BC--" },
@@ -578,7 +577,7 @@ const struct LogStructure Copter::log_structure[] = {
 
     { LOG_SYSIDD_MSG, sizeof(log_SysIdD),
       "SIDD", "Qfffffffff",  "TimeUS,Time,Targ,F,Gx,Gy,Gz,Ax,Ay,Az", "ss-zkkkooo", "F---------" },
-   
+
 // @LoggerMessage: SIDS
 // @Description: System ID settings
 // @Field: TimeUS: Time since system startup
@@ -593,7 +592,7 @@ const struct LogStructure Copter::log_structure[] = {
 
     { LOG_SYSIDS_MSG, sizeof(log_SysIdS),
       "SIDS", "QBfffffff",  "TimeUS,Ax,Mag,FSt,FSp,TFin,TC,TR,TFout", "s--ssssss", "F--------" },
-    
+
 // @LoggerMessage: GUID
 // @Description: Guided mode target information
 // @Field: TimeUS: Time since system startup
@@ -604,7 +603,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: vX: Target velocity, X-Axis
 // @Field: vY: Target velocity, Y-Axis
 // @Field: vZ: Target velocity, Z-Axis
-    
+
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-BBBBBB" },
 };


### PR DESCRIPTION
This changes the GUID onboard log message scaling so that position, velocity and angles are scaled to meters, m/s and degrees respectively.

The use of the GUID message is a bit bad because it overloads the pos_target to be lat,lon,alt, offsets from the ekf origin or angles.  I've added a comment to make this more clear but of course, a better long term solution would be to use 3 different messages.

This has been lightly tested in SITL.  Below are before and after screenshots of the Lua example script, "set-target-velocity.lua" that flies the vehicle in a rough square at 2m/s.  Note that in the Before image that the velocity shows as 200 while in the After it shows correctly as 2m/s.

![GUID-fix-before-after](https://user-images.githubusercontent.com/1498098/85496468-4d8fe380-b617-11ea-9430-b3fd66ac2af6.png)
