### PR TITLE
Support FETtecOneWire ESC protocol (with telemetry)

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -106,6 +106,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_WheelEncoder',
     'AP_ExternalAHRS',
     'AP_VideoTX',
+    'AP_FETtecOneWire',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -1,0 +1,761 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Protocol implementation was provided by FETtec */
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_FETtecOneWire.h"
+#include <stdio.h>
+
+// constructor
+AP_FETtecOneWire::AP_FETtecOneWire()
+{
+    FETtecOneWire_ResponseLength[OW_OK] = 1;
+    FETtecOneWire_ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
+    FETtecOneWire_ResponseLength[OW_NOT_OK] = 1;
+    FETtecOneWire_ResponseLength[OW_BL_START_FW] = 0;       // BL only
+    FETtecOneWire_ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    FETtecOneWire_ResponseLength[OW_REQ_TYPE] = 1;
+    FETtecOneWire_ResponseLength[OW_REQ_SN] = 12;
+    FETtecOneWire_ResponseLength[OW_REQ_SW_VER] = 2;
+    FETtecOneWire_ResponseLength[OW_RESET_TO_BL] = 0;
+    FETtecOneWire_ResponseLength[OW_THROTTLE] = 1;
+    FETtecOneWire_ResponseLength[OW_REQ_TLM] = 2;
+    FETtecOneWire_ResponseLength[OW_BEEP] = 0;
+
+    FETtecOneWire_ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_USE_SIN_START] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_USE_SIN_START] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_3D_MODE] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_3D_MODE] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_ID] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_ID] = 1;
+
+/*
+    FETtecOneWire_ResponseLength[OW_GET_LINEAR_THRUST] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    FETtecOneWire_ResponseLength[OW_GET_EEVER] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_PWM_MIN] = 2;
+    FETtecOneWire_ResponseLength[OW_SET_PWM_MIN] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_PWM_MAX] = 2;
+    FETtecOneWire_ResponseLength[OW_SET_PWM_MAX] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_ESC_BEEP] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_ESC_BEEP] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_CURRENT_CALIB] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_CURRENT_CALIB] = 1;
+
+    FETtecOneWire_ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
+    FETtecOneWire_ResponseLength[OW_GET_LED_COLOR] = 5;
+    FETtecOneWire_ResponseLength[OW_SET_LED_COLOR] = 1;
+
+    FETtecOneWire_RequestLength[OW_OK] = 1;
+    FETtecOneWire_RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
+    FETtecOneWire_RequestLength[OW_NOT_OK] = 1;
+    FETtecOneWire_RequestLength[OW_BL_START_FW] = 1;        // BL only
+    FETtecOneWire_RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    FETtecOneWire_RequestLength[OW_REQ_TYPE] = 1;
+    FETtecOneWire_RequestLength[OW_REQ_SN] = 1;
+    FETtecOneWire_RequestLength[OW_REQ_SW_VER] = 1;
+    FETtecOneWire_RequestLength[OW_RESET_TO_BL] = 1;
+    FETtecOneWire_RequestLength[OW_THROTTLE] = 1;
+    FETtecOneWire_RequestLength[OW_REQ_TLM] = 1;
+    FETtecOneWire_RequestLength[OW_BEEP] = 2;
+
+    FETtecOneWire_RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
+
+    FETtecOneWire_RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
+    FETtecOneWire_RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_USE_SIN_START] = 1;
+    FETtecOneWire_RequestLength[OW_SET_USE_SIN_START] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_3D_MODE] = 1;
+    FETtecOneWire_RequestLength[OW_SET_3D_MODE] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_ID] = 1;
+    FETtecOneWire_RequestLength[OW_SET_ID] = 1;
+
+/*
+    FETtecOneWire_RequestLength[OW_GET_LINEAR_THRUST] = 1;
+    FETtecOneWire_RequestLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    FETtecOneWire_RequestLength[OW_GET_EEVER] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_PWM_MIN] = 1;
+    FETtecOneWire_RequestLength[OW_SET_PWM_MIN] = 2;
+
+    FETtecOneWire_RequestLength[OW_GET_PWM_MAX] = 1;
+    FETtecOneWire_RequestLength[OW_SET_PWM_MAX] = 2;
+
+    FETtecOneWire_RequestLength[OW_GET_ESC_BEEP] = 1;
+    FETtecOneWire_RequestLength[OW_SET_ESC_BEEP] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_CURRENT_CALIB] = 1;
+    FETtecOneWire_RequestLength[OW_SET_CURRENT_CALIB] = 1;
+
+    FETtecOneWire_RequestLength[OW_SET_LED_TMP_COLOR] = 4;
+    FETtecOneWire_RequestLength[OW_GET_LED_COLOR] = 1;
+    FETtecOneWire_RequestLength[OW_SET_LED_COLOR] = 5;
+
+}
+
+void AP_FETtecOneWire::init()
+{
+    AP_SerialManager& serial_manager = AP::serialmanager();
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FETtechOneWire, 0);
+    if (_uart) {
+        _uart->begin(2000000);
+    }
+    FETtecOneWire_Init();
+}
+
+void AP_FETtecOneWire::update()
+{
+    if (!initialised) {
+        initialised = true;
+        init();
+        last_send_us = AP_HAL::micros();
+        return;
+    }
+
+    if (_uart == nullptr) {
+        return;
+    }
+
+    uint16_t requestedTelemetry[MOTOR_COUNT] = {0};
+    int8_t TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT, TLM_request);
+    if (TelemetryAvailable != -1) {
+        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+            completeTelemetry[i][TelemetryAvailable] = requestedTelemetry[i];
+        }
+    }
+    if (++TLM_request == 5) {
+        TLM_request = 0;
+    }
+    if (TelemetryAvailable != -1) {
+        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+            printf(" esc: %d", i + 1);
+            printf(" Temperature: %d", completeTelemetry[i][0]);
+            printf(", Voltage: %d", completeTelemetry[i][1]);
+            printf(", Current: %d", completeTelemetry[i][2]);
+            printf(", E-rpm: %d", completeTelemetry[i][3]);
+            printf(", consumption: %d", completeTelemetry[i][4]);
+            printf("\n");
+        }
+    }
+}
+
+/*
+    initialize FETtecOneWire protocol
+*/
+void AP_FETtecOneWire::FETtecOneWire_Init()
+{
+    if (FETtecOneWire_firstInitDone == 0) {
+        FETtecOneWire_FoundESCs = 0;
+        FETtecOneWire_ScanActive = 0;
+        FETtecOneWire_SetupActive = 0;
+        FETtecOneWire_minID = 25;
+        FETtecOneWire_maxID = 0;
+        FETtecOneWire_IDcount = 0;
+        FETtecOneWire_FastThrottleByteCount = 0;
+        for (uint8_t i = 0; i < 25; i++) {
+            FETtecOneWire_activeESC_IDs[i] = 0;
+        }
+    }
+    FETtecOneWire_IgnoreOwnBytes = 0;
+    FETtecOneWire_PullSuccess = 0;
+    FETtecOneWire_PullBusy = 0;
+    FETtecOneWire_firstInitDone = 1;
+}
+
+/*
+    generates used 8 bit CRC
+    crc = byte to be added to CRC
+    crc_seed = CRC where it gets added too
+    returns 8 bit CRC
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed)
+{
+    uint8_t crc_u, i;
+    crc_u = crc;
+    crc_u ^= crc_seed;
+    for (i = 0; i < 8; i++) {
+        crc_u = (crc_u & 0x80) ? 0x7 ^ (crc_u << 1) : (crc_u << 1);
+    }
+    return (crc_u);
+}
+
+/*
+    generates used 8 bit CRC for arrays
+    Buf = 8 bit byte array
+    BufLen = count of bytes that should be used for CRC calculation
+    returns 8 bit CRC
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen)
+{
+    uint8_t crc = 0;
+    for (uint16_t i = 0; i < BufLen; i++) {
+        crc = FETtecOneWire_UpdateCrc8(Buf[i], crc);
+    }
+    return (crc);
+}
+
+/*
+    transmitts a FETtecOneWire frame to a ESC
+    ESC_id = id of the ESC
+    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    Length = length of the Bytes array
+    returns nothing
+*/
+void AP_FETtecOneWire::FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t* Bytes, uint8_t Length)
+{
+    /*
+    a frame lookes like:
+    byte 1 = fremae header (master is always 0x01)
+    byte 2 = target ID (5bit)
+    byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
+    byte 5 = frame length over all bytes
+    byte 6 - X = request type, followed by the payload
+    byte X+1 = 8bit CRC
+    */
+    uint8_t transmitArr[256] = {0x01, ESC_id, 0x00, 0x00};
+    transmitArr[4] = Length + 6;
+    for (uint8_t i = 0; i < Length; i++) {
+        transmitArr[i + 5] = Bytes[i];
+    }
+    transmitArr[Length + 5] = FETtecOneWire_GetCrc8(transmitArr, Length + 5); // crc
+    _uart->write(transmitArr, Length + 6);
+    FETtecOneWire_IgnoreOwnBytes += Length + 6;
+}
+
+/*
+    reads the answer frame of a ESC
+    Bytes = 8 bit byte array, where the received answer gets stored in
+    Length = the expected answer length
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the expected answer frame was there, 0 if dont
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, uint8_t returnFullFrame)
+{
+    /*
+    a frame lookes like:
+    byte 1 = fremae header (0x02 = bootloader, 0x03 = ESC firmware)
+    byte 2 = sender ID (5bit)
+    byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
+    byte 5 = frame length over all bytes
+    byte 6 - X = answer type, followed by the payload
+    byte X+1 = 8bit CRC
+    */
+
+    //ignore own bytes
+    while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
+        FETtecOneWire_IgnoreOwnBytes--;
+        _uart->read();
+    }
+    // look for the real answer
+    if (_uart->available() >= Length + 6u) {
+        // sync to frame starte byte
+        uint8_t testFrameStart = 0;
+        do {
+            testFrameStart = _uart->read();
+        }
+        while (testFrameStart != 0x02 && testFrameStart != 0x03 && _uart->available());
+        // copy message
+        if (_uart->available() >= Length + 5u) {
+            uint8_t ReceiveBuf[20] = {0};
+            ReceiveBuf[0] = testFrameStart;
+            for (uint8_t i = 1; i < Length + 6; i++) {
+                ReceiveBuf[i] = _uart->read();
+            }
+            // check CRC
+            if (FETtecOneWire_GetCrc8(ReceiveBuf, Length + 5) == ReceiveBuf[Length + 5]) {
+                if (!returnFullFrame) {
+                    for (uint8_t i = 0; i < Length; i++) {
+                        Bytes[i] = ReceiveBuf[5 + i];
+                    }
+                } else {
+                    for (uint8_t i = 0; i < Length + 6; i++) {
+                        Bytes[i] = ReceiveBuf[i];
+                    }
+                }
+                return 1;
+            } else {
+                return 0;
+            } // crc missmatch
+        } else {
+            return 0;
+        } // no answer yet
+    } else {
+        return 0;
+    } // no answer yet
+}
+
+/*
+    makes all connected ESC's beep
+    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
+*/
+void AP_FETtecOneWire::FETtecOneWire_Beep(uint8_t beepFreqency)
+{
+    if (FETtecOneWire_IDcount > 0) {
+        uint8_t request[2] = {OW_BEEP, beepFreqency};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
+            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
+            _uart->write(spacer, 2);
+            FETtecOneWire_IgnoreOwnBytes += 2;
+        }
+    }
+}
+
+/*
+    sets the racewire color for all ESC's
+    R, G, B = 8bit colors
+*/
+void AP_FETtecOneWire::FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
+{
+    if (FETtecOneWire_IDcount > 0) {
+        uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
+            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
+            _uart->write(spacer, 2);
+            FETtecOneWire_IgnoreOwnBytes += 2;
+        }
+    }
+}
+
+/*
+    Resets a pending pull request
+    returns nothing
+*/
+void AP_FETtecOneWire::FETtecOneWire_PullReset()
+{
+    FETtecOneWire_PullSuccess = 0;
+    FETtecOneWire_PullBusy = 0;
+}
+
+/*
+    Pulls a complete request between for ESC
+    ESC_id = id of the ESC
+    command = 8bit array containing the command that thould be send including the possible payload
+    response = 8bit array where the response will be stored in
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the request is completed, 0 if dont
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t* command, uint8_t* response,
+        uint8_t returnFullFrame)
+{
+    if (!FETtecOneWire_PullBusy) {
+        FETtecOneWire_PullBusy = 1;
+        FETtecOneWire_PullSuccess = 0;
+        FETtecOneWire_Transmit(ESC_id, command, FETtecOneWire_RequestLength[command[0]]);
+    } else {
+        if (FETtecOneWire_Receive(response, FETtecOneWire_ResponseLength[command[0]], returnFullFrame)) {
+            FETtecOneWire_PullSuccess = 1;
+            FETtecOneWire_PullBusy = 0;
+        }
+    }
+    return FETtecOneWire_PullSuccess;
+}
+
+/*
+    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
+    returns the currend scanned ID
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_ScanESCs()
+{
+    static uint16_t delayLoops = 500;
+    static uint8_t scanID = 0;
+    static uint8_t scanState = 0;
+    static uint8_t scanTimeOut = 0;
+    uint8_t response[18] = {0};
+    uint8_t request[1] = {0};
+    if (FETtecOneWire_ScanActive == 0) {
+        delayLoops = 500;
+        scanID = 0;
+        scanState = 0;
+        scanTimeOut = 0;
+        return FETtecOneWire_ScanActive + 1;
+    }
+    if (delayLoops > 0) {
+        delayLoops--;
+        return FETtecOneWire_ScanActive;
+    }
+    if (scanID < FETtecOneWire_ScanActive) {
+        scanID = FETtecOneWire_ScanActive;
+        scanState = 0;
+        scanTimeOut = 0;
+    }
+    if (scanTimeOut == 3 || scanTimeOut == 6 || scanTimeOut == 9 || scanTimeOut == 12) {
+        FETtecOneWire_PullReset();
+    }
+    if (scanTimeOut < 15) {
+        switch (scanState) {
+        case 0:request[0] = OW_OK;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_FULL_FRAME)) {
+                scanTimeOut = 0;
+                FETtecOneWire_activeESC_IDs[scanID] = 1;
+                FETtecOneWire_FoundESCs++;
+                if (response[0] == 0x02) {
+                    FETtecOneWire_foundESCs[scanID].inBootLoader = 1;
+                } else {
+                    FETtecOneWire_foundESCs[scanID].inBootLoader = 0;
+                }
+                delayLoops = 1;
+                scanState++;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        case 1:request[0] = OW_REQ_TYPE;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
+                scanTimeOut = 0;
+                FETtecOneWire_foundESCs[scanID].ESCtype = response[0];
+                delayLoops = 1;
+                scanState++;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        case 2:request[0] = OW_REQ_SW_VER;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
+                scanTimeOut = 0;
+                FETtecOneWire_foundESCs[scanID].firmWareVersion = response[0];
+                FETtecOneWire_foundESCs[scanID].firmWareSubVersion = response[1];
+                delayLoops = 1;
+                scanState++;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        case 3:request[0] = OW_REQ_SN;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
+                scanTimeOut = 0;
+                for (uint8_t i = 0; i < 12; i++) {
+                    FETtecOneWire_foundESCs[scanID].serialNumber[i] = response[i];
+                }
+                delayLoops = 1;
+                return scanID + 1;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        }
+    } else {
+        FETtecOneWire_PullReset();
+        return scanID + 1;
+    }
+    return scanID;
+}
+
+/*
+    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
+    returns the current used ID
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_InitESCs()
+{
+    static uint8_t delayLoops = 0;
+    static uint8_t activeID = 1;
+    static uint8_t State = 0;
+    static uint8_t TimeOut = 0;
+    static uint8_t wakeFromBL = 1;
+    static uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
+    uint8_t response[18] = {0};
+    uint8_t request[1] = {0};
+    if (FETtecOneWire_SetupActive == 0) {
+        delayLoops = 0;
+        activeID = 1;
+        State = 0;
+        TimeOut = 0;
+        wakeFromBL = 1;
+        return FETtecOneWire_SetupActive + 1;
+    }
+    while (FETtecOneWire_activeESC_IDs[FETtecOneWire_SetupActive] == 0 && FETtecOneWire_SetupActive < 25) {
+        FETtecOneWire_SetupActive++;
+    }
+
+    if (FETtecOneWire_SetupActive == 25 && wakeFromBL == 0) {
+        return FETtecOneWire_SetupActive;
+    } else if (FETtecOneWire_SetupActive == 25 && wakeFromBL) {
+        wakeFromBL = 0;
+        activeID = 1;
+        FETtecOneWire_SetupActive = 1;
+        State = 0;
+        TimeOut = 0;
+
+        FETtecOneWire_minID = 25;
+        FETtecOneWire_maxID = 0;
+        FETtecOneWire_IDcount = 0;
+        for (uint8_t i = 0; i < 25; i++) {
+            if (FETtecOneWire_activeESC_IDs[i] != 0) {
+                FETtecOneWire_IDcount++;
+                if (i < FETtecOneWire_minID) {
+                    FETtecOneWire_minID = i;
+                }
+                if (i > FETtecOneWire_maxID) {
+                    FETtecOneWire_maxID = i;
+                }
+            }
+        }
+
+        if (FETtecOneWire_IDcount == 0
+                || FETtecOneWire_maxID - FETtecOneWire_minID > FETtecOneWire_IDcount - 1) { // loop forever
+            wakeFromBL = 1;
+            return activeID;
+        }
+        FETtecOneWire_FastThrottleByteCount = 1;
+        int8_t bitCount = 12 + (FETtecOneWire_IDcount * 11);
+        while (bitCount > 0) {
+            FETtecOneWire_FastThrottleByteCount++;
+            bitCount -= 8;
+        }
+        setFastCommand[1] = FETtecOneWire_FastThrottleByteCount; // just for older ESC FW versions since 1.0 001 this byte is ignored as the ESC calculates it itself
+        setFastCommand[2] = FETtecOneWire_minID;                 // min ESC id
+        setFastCommand[3] = FETtecOneWire_IDcount;                 // count of ESC's that will get signals
+    }
+
+    if (delayLoops > 0) {
+        delayLoops--;
+        return FETtecOneWire_SetupActive;
+    }
+
+    if (activeID < FETtecOneWire_SetupActive) {
+        activeID = FETtecOneWire_SetupActive;
+        State = 0;
+        TimeOut = 0;
+    }
+
+    if (TimeOut == 3 || TimeOut == 6 || TimeOut == 9 || TimeOut == 12) {
+        FETtecOneWire_PullReset();
+    }
+
+    if (TimeOut < 15) {
+        if (wakeFromBL) {
+            switch (State) {
+            case 0:request[0] = OW_BL_START_FW;
+                if (FETtecOneWire_foundESCs[activeID].inBootLoader == 1) {
+                    FETtecOneWire_Transmit(activeID, request, FETtecOneWire_RequestLength[request[0]]);
+                    delayLoops = 5;
+                } else {
+                    return activeID + 1;
+                }
+                State = 1;
+                break;
+            case 1:request[0] = OW_OK;
+                if (FETtecOneWire_PullCommand(activeID, request, response, OW_RETURN_FULL_FRAME)) {
+                    TimeOut = 0;
+                    if (response[0] == 0x02) {
+                        FETtecOneWire_foundESCs[activeID].inBootLoader = 1;
+                        State = 0;
+                    } else {
+                        FETtecOneWire_foundESCs[activeID].inBootLoader = 0;
+                        delayLoops = 1;
+                        return activeID + 1;
+                    }
+                } else {
+                    TimeOut++;
+                }
+                break;
+            }
+        } else {
+            if (FETtecOneWire_PullCommand(activeID, setFastCommand, response, OW_RETURN_RESPONSE)) {
+                TimeOut = 0;
+                delayLoops = 1;
+                return activeID + 1;
+            } else {
+                TimeOut++;
+            }
+        }
+    } else {
+        FETtecOneWire_PullReset();
+        return activeID + 1;
+    }
+    return activeID;
+}
+
+/*
+    checks if the requested telemetry is available. 
+    Telemetry = 16bit array where the read Telemetry will be stored in. 
+    returns the telemetry request number or -1 if unavailable
+*/
+int8_t AP_FETtecOneWire::FETtecOneWire_CheckForTLM(uint16_t* Telemetry)
+{
+    int8_t return_TLM_request = 0;
+    if (FETtecOneWire_IDcount > 0) {
+        // empty buffer
+        while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
+            _uart->read();
+            FETtecOneWire_IgnoreOwnBytes--;
+        }
+
+        // first two byte are the ESC Telemetry of the first ESC. next two byte of the second....
+        if (_uart->available() == (FETtecOneWire_IDcount * 2) + 1u) {
+            // look if first byte in buffer is equal to last byte of throttle command (crc)
+            if (_uart->read() == FETtecOneWire_lastCRC) {
+                for (uint8_t i = 0; i < FETtecOneWire_IDcount; i++) {
+                    Telemetry[i] = _uart->read() << 8;
+                    Telemetry[i] |= _uart->read();
+                }
+                return_TLM_request = FETtecOneWire_TLM_request;
+            } else {
+                return_TLM_request = -1;
+            }
+        } else {
+            return_TLM_request = -1;
+        }
+    } else {
+        return_TLM_request = -1;
+    }
+    return return_TLM_request;
+}
+
+/*
+    does almost all of the job.
+    scans for ESC's if not already done.
+    initializes the ESC's if not already done.
+    sends fast throttle signals if init is complete.
+    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    Telemetry = 16bit array where the read telemetry will be stored in. 
+    motorCount = the count of motors that should get values send
+    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
+    returns the telemetry request if telemetry was available, -1 if dont
+*/
+int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,
+        uint8_t tlmRequest)
+{
+    int8_t return_TLM_request = -2;
+
+    // init should not be done too fast. as at last the bootloader has some timing requirements with messages. so loop delays must fit more or less
+    if (FETtecOneWire_ScanActive < 25 || FETtecOneWire_SetupActive < 25) {
+        const uint32_t now = AP_HAL::micros();
+        if (now - last_send_us < DELAY_TIME_US) {
+            return 0;
+        } else {
+            last_send_us = now;
+        }
+
+        if (FETtecOneWire_ScanActive < 25) {
+            // scan for all ESC's in onewire bus
+            FETtecOneWire_ScanActive = FETtecOneWire_ScanESCs();
+        } else if (FETtecOneWire_SetupActive < 25) {
+            if (FETtecOneWire_FoundESCs == 0) {
+                FETtecOneWire_ScanActive = 0;
+            } else {
+                // check if in bootloader, start ESC's FW if they are and prepare fast throttle command
+                FETtecOneWire_SetupActive = FETtecOneWire_InitESCs();
+            }
+        }
+    } else {
+        //send fast throttle signals
+        if (FETtecOneWire_IDcount > 0) {
+
+            // check for telemetry
+            return_TLM_request = FETtecOneWire_CheckForTLM(Telemetry);
+            FETtecOneWire_TLM_request = tlmRequest;
+
+            //prepare fast throttle signals
+            uint16_t useSignals[24] = {0};
+            uint8_t OneWireFastThrottleCommand[36] = {0};
+            if (motorCount > FETtecOneWire_IDcount) {
+                motorCount = FETtecOneWire_IDcount;
+            }
+            for (uint8_t i = 0; i < motorCount; i++) {
+                useSignals[i] = constrain_int16(motorValues[i], 0, 2000);
+            }
+
+            uint8_t actThrottleCommand = 0;
+
+            // byte 1:
+            // bit 0 = TLMrequest, bit 1,2,3 = TLM type, bit 4 = first bit of first ESC (11bit)signal, bit 5,6,7 = frame header
+            // so ABBBCDDD
+            // A = TLM request yes or no
+            // B = TLM request type (temp, volt, current, erpm, consumption, debug1, debug2, debug3)
+            // C = first bit from first throttle signal
+            // D = frame header
+            OneWireFastThrottleCommand[0] = 128 | (FETtecOneWire_TLM_request << 4);
+            OneWireFastThrottleCommand[0] |= ((useSignals[actThrottleCommand] >> 10) & 0x01) << 3;
+            OneWireFastThrottleCommand[0] |= 0x01;
+
+            // byte 2:
+            // AAABBBBB
+            // A = next 3 bits from (11bit)throttle signal
+            // B = 5bit target ID
+            OneWireFastThrottleCommand[1] = (((useSignals[actThrottleCommand] >> 7) & 0x07)) << 5;
+            OneWireFastThrottleCommand[1] |= ALL_ID;
+
+            // following bytes are the rest 7 bit of the first (11bit)throttle signal, and all bit from all other signals, followed by the CRC byte
+            uint8_t BitsLeftFromCommand = 7;
+            uint8_t actByte = 2;
+            uint8_t bitsFromByteLeft = 8;
+            uint8_t bitsToAddLeft = (12 + (((FETtecOneWire_maxID - FETtecOneWire_minID) + 1) * 11)) - 16;
+            while (bitsToAddLeft > 0) {
+                if (bitsFromByteLeft >= BitsLeftFromCommand) {
+                    OneWireFastThrottleCommand[actByte] |=
+                            (useSignals[actThrottleCommand] & ((1 << BitsLeftFromCommand) - 1))
+                                    << (bitsFromByteLeft - BitsLeftFromCommand);
+                    bitsToAddLeft -= BitsLeftFromCommand;
+                    bitsFromByteLeft -= BitsLeftFromCommand;
+                    actThrottleCommand++;
+                    BitsLeftFromCommand = 11;
+                    if (bitsToAddLeft == 0) {
+                        actByte++;
+                        bitsFromByteLeft = 8;
+                    }
+                } else {
+                    OneWireFastThrottleCommand[actByte] |=
+                            (useSignals[actThrottleCommand] >> (BitsLeftFromCommand - bitsFromByteLeft))
+                                    & ((1 << bitsFromByteLeft) - 1);
+                    bitsToAddLeft -= bitsFromByteLeft;
+                    BitsLeftFromCommand -= bitsFromByteLeft;
+                    actByte++;
+                    bitsFromByteLeft = 8;
+                    if (BitsLeftFromCommand == 0) {
+                        actThrottleCommand++;
+                        BitsLeftFromCommand = 11;
+                    }
+                }
+            }
+            // empty buffer
+            while (_uart->available()) {
+                _uart->read();
+            }
+
+            // send throttle signal
+            OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1] = FETtecOneWire_GetCrc8(
+                    OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount - 1);
+            _uart->write(OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount);
+            // last byte of signal can be used to make sure the first TLM byte is correct, in case of spike corruption
+            FETtecOneWire_IgnoreOwnBytes = FETtecOneWire_FastThrottleByteCount - 1;
+            FETtecOneWire_lastCRC = OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1];
+            // the ESC's will answer the TLM as 16bit each ESC, so 2byte each ESC.
+        }
+    }
+    return return_TLM_request; // returns the readed tlm as it is 1 loop delayed
+}

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -180,24 +180,24 @@ void AP_FETtecOneWire::update()
 
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
     _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
-    if (_telem_avail != -1) {
-        // TODO: take the _telem_semaphore here
-        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            _telemetry[i][_telem_avail] = requestedTelemetry[i];
-            _telemetry[i][5]++;
-        }
-    }
+
     if (++_telem_req_type == OW_TLM_DEBUG1) {
         // OW_TLM_DEBUG1, OW_TLM_DEBUG2, OW_TLM_DEBUG3 are ignored
         _telem_req_type = OW_TLM_TEMP;
     }
 
     if (_telem_avail != -1) {
+        // TODO: take the _telem_semaphore here
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+            _telemetry[i][_telem_avail] = requestedTelemetry[i];
+            _telemetry[i][5]++;
+        }
+        // TODO: give back the _telem_semaphore here
+
         AP_Logger *logger = AP_Logger::get_singleton();
         const uint32_t now = AP_HAL::millis();
         // log at 10Hz
         if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
-            // TODO: take the _telem_semaphore here
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -28,7 +28,7 @@
 const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
     // @Param: MASK
     // @DisplayName: Channel Bitmask
-    // @Description: Enable of volz servo protocol to specific channels
+    // @Description: Enable of FETtec OneWire ESC protocol to specific channels
     // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
     // @User: Standard
     AP_GROUPINFO("MASK",  1, AP_FETtecOneWire, motor_mask, 0),
@@ -38,111 +38,108 @@ const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
 
 AP_FETtecOneWire *AP_FETtecOneWire::_singleton;
 
-static uint8_t FETtecOneWire_ResponseLength[54];
-static uint8_t FETtecOneWire_RequestLength[54];
-
 AP_FETtecOneWire::AP_FETtecOneWire()
 {
     _singleton = this;
-    FETtecOneWire_ResponseLength[OW_OK] = 1;
-    FETtecOneWire_ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
-    FETtecOneWire_ResponseLength[OW_NOT_OK] = 1;
-    FETtecOneWire_ResponseLength[OW_BL_START_FW] = 0;       // BL only
-    FETtecOneWire_ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
-    FETtecOneWire_ResponseLength[OW_REQ_TYPE] = 1;
-    FETtecOneWire_ResponseLength[OW_REQ_SN] = 12;
-    FETtecOneWire_ResponseLength[OW_REQ_SW_VER] = 2;
-    FETtecOneWire_ResponseLength[OW_RESET_TO_BL] = 0;
-    FETtecOneWire_ResponseLength[OW_THROTTLE] = 1;
-    FETtecOneWire_ResponseLength[OW_REQ_TLM] = 2;
-    FETtecOneWire_ResponseLength[OW_BEEP] = 0;
+    _ResponseLength[OW_OK] = 1;
+    _ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
+    _ResponseLength[OW_NOT_OK] = 1;
+    _ResponseLength[OW_BL_START_FW] = 0;       // BL only
+    _ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    _ResponseLength[OW_REQ_TYPE] = 1;
+    _ResponseLength[OW_REQ_SN] = 12;
+    _ResponseLength[OW_REQ_SW_VER] = 2;
+    _ResponseLength[OW_RESET_TO_BL] = 0;
+    _ResponseLength[OW_THROTTLE] = 1;
+    _ResponseLength[OW_REQ_TLM] = 2;
+    _ResponseLength[OW_BEEP] = 0;
 
-    FETtecOneWire_ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
+    _ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
+    _ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
+    _ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_USE_SIN_START] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_USE_SIN_START] = 1;
+    _ResponseLength[OW_GET_USE_SIN_START] = 1;
+    _ResponseLength[OW_SET_USE_SIN_START] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_3D_MODE] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_3D_MODE] = 1;
+    _ResponseLength[OW_GET_3D_MODE] = 1;
+    _ResponseLength[OW_SET_3D_MODE] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_ID] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_ID] = 1;
-
-/*
-    FETtecOneWire_ResponseLength[OW_GET_LINEAR_THRUST] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_LINEAR_THRUST] = 1;
-*/
-
-    FETtecOneWire_ResponseLength[OW_GET_EEVER] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_PWM_MIN] = 2;
-    FETtecOneWire_ResponseLength[OW_SET_PWM_MIN] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_PWM_MAX] = 2;
-    FETtecOneWire_ResponseLength[OW_SET_PWM_MAX] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_ESC_BEEP] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_ESC_BEEP] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_CURRENT_CALIB] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_CURRENT_CALIB] = 1;
-
-    FETtecOneWire_ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
-    FETtecOneWire_ResponseLength[OW_GET_LED_COLOR] = 5;
-    FETtecOneWire_ResponseLength[OW_SET_LED_COLOR] = 1;
-
-    FETtecOneWire_RequestLength[OW_OK] = 1;
-    FETtecOneWire_RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
-    FETtecOneWire_RequestLength[OW_NOT_OK] = 1;
-    FETtecOneWire_RequestLength[OW_BL_START_FW] = 1;        // BL only
-    FETtecOneWire_RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
-    FETtecOneWire_RequestLength[OW_REQ_TYPE] = 1;
-    FETtecOneWire_RequestLength[OW_REQ_SN] = 1;
-    FETtecOneWire_RequestLength[OW_REQ_SW_VER] = 1;
-    FETtecOneWire_RequestLength[OW_RESET_TO_BL] = 1;
-    FETtecOneWire_RequestLength[OW_THROTTLE] = 1;
-    FETtecOneWire_RequestLength[OW_REQ_TLM] = 1;
-    FETtecOneWire_RequestLength[OW_BEEP] = 2;
-
-    FETtecOneWire_RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
-
-    FETtecOneWire_RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
-    FETtecOneWire_RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
-
-    FETtecOneWire_RequestLength[OW_GET_USE_SIN_START] = 1;
-    FETtecOneWire_RequestLength[OW_SET_USE_SIN_START] = 1;
-
-    FETtecOneWire_RequestLength[OW_GET_3D_MODE] = 1;
-    FETtecOneWire_RequestLength[OW_SET_3D_MODE] = 1;
-
-    FETtecOneWire_RequestLength[OW_GET_ID] = 1;
-    FETtecOneWire_RequestLength[OW_SET_ID] = 1;
+    _ResponseLength[OW_GET_ID] = 1;
+    _ResponseLength[OW_SET_ID] = 1;
 
 /*
-    FETtecOneWire_RequestLength[OW_GET_LINEAR_THRUST] = 1;
-    FETtecOneWire_RequestLength[OW_SET_LINEAR_THRUST] = 1;
+    _ResponseLength[OW_GET_LINEAR_THRUST] = 1;
+    _ResponseLength[OW_SET_LINEAR_THRUST] = 1;
 */
 
-    FETtecOneWire_RequestLength[OW_GET_EEVER] = 1;
+    _ResponseLength[OW_GET_EEVER] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_PWM_MIN] = 1;
-    FETtecOneWire_RequestLength[OW_SET_PWM_MIN] = 2;
+    _ResponseLength[OW_GET_PWM_MIN] = 2;
+    _ResponseLength[OW_SET_PWM_MIN] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_PWM_MAX] = 1;
-    FETtecOneWire_RequestLength[OW_SET_PWM_MAX] = 2;
+    _ResponseLength[OW_GET_PWM_MAX] = 2;
+    _ResponseLength[OW_SET_PWM_MAX] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_ESC_BEEP] = 1;
-    FETtecOneWire_RequestLength[OW_SET_ESC_BEEP] = 1;
+    _ResponseLength[OW_GET_ESC_BEEP] = 1;
+    _ResponseLength[OW_SET_ESC_BEEP] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_CURRENT_CALIB] = 1;
-    FETtecOneWire_RequestLength[OW_SET_CURRENT_CALIB] = 1;
+    _ResponseLength[OW_GET_CURRENT_CALIB] = 1;
+    _ResponseLength[OW_SET_CURRENT_CALIB] = 1;
 
-    FETtecOneWire_RequestLength[OW_SET_LED_TMP_COLOR] = 4;
-    FETtecOneWire_RequestLength[OW_GET_LED_COLOR] = 1;
-    FETtecOneWire_RequestLength[OW_SET_LED_COLOR] = 5;
+    _ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
+    _ResponseLength[OW_GET_LED_COLOR] = 5;
+    _ResponseLength[OW_SET_LED_COLOR] = 1;
+
+    _RequestLength[OW_OK] = 1;
+    _RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
+    _RequestLength[OW_NOT_OK] = 1;
+    _RequestLength[OW_BL_START_FW] = 1;       // BL only
+    _RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    _RequestLength[OW_REQ_TYPE] = 1;
+    _RequestLength[OW_REQ_SN] = 1;
+    _RequestLength[OW_REQ_SW_VER] = 1;
+    _RequestLength[OW_RESET_TO_BL] = 1;
+    _RequestLength[OW_THROTTLE] = 1;
+    _RequestLength[OW_REQ_TLM] = 1;
+    _RequestLength[OW_BEEP] = 2;
+
+    _RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
+
+    _RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
+    _RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    _RequestLength[OW_GET_USE_SIN_START] = 1;
+    _RequestLength[OW_SET_USE_SIN_START] = 1;
+
+    _RequestLength[OW_GET_3D_MODE] = 1;
+    _RequestLength[OW_SET_3D_MODE] = 1;
+
+    _RequestLength[OW_GET_ID] = 1;
+    _RequestLength[OW_SET_ID] = 1;
+
+/*
+    _RequestLength[OW_GET_LINEAR_THRUST] = 1;
+    _RequestLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    _RequestLength[OW_GET_EEVER] = 1;
+
+    _RequestLength[OW_GET_PWM_MIN] = 1;
+    _RequestLength[OW_SET_PWM_MIN] = 2;
+
+    _RequestLength[OW_GET_PWM_MAX] = 1;
+    _RequestLength[OW_SET_PWM_MAX] = 2;
+
+    _RequestLength[OW_GET_ESC_BEEP] = 1;
+    _RequestLength[OW_SET_ESC_BEEP] = 1;
+
+    _RequestLength[OW_GET_CURRENT_CALIB] = 1;
+    _RequestLength[OW_SET_CURRENT_CALIB] = 1;
+
+    _RequestLength[OW_SET_LED_TMP_COLOR] = 4;
+    _RequestLength[OW_GET_LED_COLOR] = 1;
+    _RequestLength[OW_SET_LED_COLOR] = 5;
 
 }
 
@@ -153,15 +150,15 @@ void AP_FETtecOneWire::init()
     if (_uart) {
         _uart->begin(2000000);
     }
-    FETtecOneWire_Init();
+    Init();
 }
 
 void AP_FETtecOneWire::update()
 {
-    if (!initialised) {
-        initialised = true;
+    if (!_initialised) {
+        _initialised = true;
         init();
-        last_send_us = AP_HAL::micros();
+        _last_send_us = AP_HAL::micros();
         return;
     }
 
@@ -178,57 +175,60 @@ void AP_FETtecOneWire::update()
         if (c == nullptr) {
             continue;
         }
-        motorpwm[i] = c->get_output_pwm();
+        _motorpwm[i] = c->get_output_pwm();
     }
 
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
-    TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, TLM_request);
-    if (TelemetryAvailable != -1) {
+    _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
+    if (_telem_avail != -1) {
         for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            completeTelemetry[i][TelemetryAvailable] = requestedTelemetry[i];
-            completeTelemetry[i][5]++;
+            _telemetry[i][_telem_avail] = requestedTelemetry[i];
+            _telemetry[i][5]++;
         }
     }
-    if (++TLM_request == 5) {
-        TLM_request = 0;
+    if (++_telem_req_type == OW_TLM_DEBUG1) {
+        // OW_TLM_DEBUG1, OW_TLM_DEBUG2, OW_TLM_DEBUG3 are ignored
+        _telem_req_type = OW_TLM_TEMP;
     }
 
-    if (TelemetryAvailable != -1) {
-        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            printf(" esc: %d", i + 1);
-            printf(" Temperature: %d", completeTelemetry[i][0]);
-            printf(", Voltage: %d", completeTelemetry[i][1]);
-            printf(", Current: %d", completeTelemetry[i][2]);
-            printf(", E-rpm: %d", completeTelemetry[i][3]);
-            printf(", consumption: %d", completeTelemetry[i][4]);
-            printf("\n");
-            AP_Logger *logger = AP_Logger::get_singleton();
+    if (_telem_avail != -1) {
+        AP_Logger *logger = AP_Logger::get_singleton();
+        const uint32_t now = AP_HAL::millis();
+        // log at 10Hz
+        if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
+            for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+                // TODO: remove printfs
+                printf(" esc: %d", i + 1);
+                printf(" Temperature: %d", _telemetry[i][OW_TLM_TEMP]);
+                printf(", Voltage: %d", _telemetry[i][OW_TLM_VOLT]);
+                printf(", Current: %d", _telemetry[i][OW_TLM_CURRENT]);
+                printf(", E-rpm: %d", _telemetry[i][OW_TLM_ERPM]);
+                printf(", consumption: %d", _telemetry[i][OW_TLM_CONSUMPTION]);
+                printf("\n");
 
-            // log at 10Hz
-            const uint32_t now = AP_HAL::millis();
-            if (logger && logger->logging_enabled() && now - last_log_ms > 100) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
-                        completeTelemetry[i][3] * 100U,
-                        completeTelemetry[i][1],
-                        completeTelemetry[i][2],
-                        completeTelemetry[i][0] * 100U,
-                        completeTelemetry[i][4],
+                        _telemetry[i][OW_TLM_ERPM] * 100U,
+                        _telemetry[i][OW_TLM_VOLT],
+                        _telemetry[i][OW_TLM_CURRENT],
+                        _telemetry[i][OW_TLM_TEMP] * 100U,
+                        _telemetry[i][OW_TLM_CONSUMPTION],
                         0,
                         0);
-                last_log_ms = now;
             }
+            _last_log_ms = now;
         }
     }
 
 }
 
-/*
+/**
   send ESC telemetry messages over MAVLink
+  @param mav_chan mavlink channel
  */
-void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan)
+void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
 {
-    if (TelemetryAvailable == -1) {
+    if (_telem_avail == -1) {
         return;
     }
     uint8_t temperature[4] {};
@@ -239,56 +239,62 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan)
     uint16_t count[4] {};
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
-        temperature[idx] = completeTelemetry[i][0];
-        voltage[idx] = completeTelemetry[i][1];
-        current[idx] = completeTelemetry[i][2];
-        rpm[idx] = completeTelemetry[i][3];
-        totalcurrent[idx] = completeTelemetry[i][4];
-        count[idx] = completeTelemetry[i][5];
-        if (i % 4 == 3 || i == MOTOR_COUNT_MAX - 1) {
+        temperature[idx] = _telemetry[i][OW_TLM_TEMP];
+        voltage[idx] = _telemetry[i][OW_TLM_VOLT];
+        current[idx] = _telemetry[i][OW_TLM_CURRENT];
+        rpm[idx] = _telemetry[i][OW_TLM_ERPM];
+        totalcurrent[idx] = _telemetry[i][OW_TLM_CONSUMPTION];
+        count[idx] = _telemetry[i][5];
+        if (idx == 3 || i == MOTOR_COUNT_MAX - 1) {
             if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
                 return;
             }
+            static_assert(MOTOR_COUNT_MAX <= 12, "AP_FETtecOneWire::send_esc_telemetry_mavlink() support 12 or less motors");
             if (i < 4) {
                 mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
-            } else {
+            } else if (i < 8) {
                 mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
+            } else {
+                mavlink_msg_esc_telemetry_9_to_12_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
             }
         }
     }
 }
 
-/*
+/**
     initialize FETtecOneWire protocol
 */
-void AP_FETtecOneWire::FETtecOneWire_Init()
+void AP_FETtecOneWire::Init()
 {
-    if (FETtecOneWire_firstInitDone == 0) {
-        FETtecOneWire_FoundESCs = 0;
-        FETtecOneWire_ScanActive = 0;
-        FETtecOneWire_SetupActive = 0;
-        FETtecOneWire_minID = 25;
-        FETtecOneWire_maxID = 0;
-        FETtecOneWire_IDcount = 0;
-        FETtecOneWire_FastThrottleByteCount = 0;
-        for (uint8_t i = 0; i < 25; i++) {
-            FETtecOneWire_activeESC_IDs[i] = 0;
+    // TODO: move this entire code inside AP_FETtecOneWire::init()
+    if (_firstInitDone == 0) {
+        _FoundESCs = 0;
+        _ScanActive = 0;
+        _SetupActive = 0;
+        _minID = MOTOR_COUNT_MAX;
+        _maxID = 0;
+        _IDcount = 0;
+        _FastThrottleByteCount = 0;
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+            _activeESC_IDs[i] = 0;
         }
     }
-    FETtecOneWire_IgnoreOwnBytes = 0;
-    FETtecOneWire_PullSuccess = 0;
-    FETtecOneWire_PullBusy = 0;
-    FETtecOneWire_firstInitDone = 1;
+    _IgnoreOwnBytes = 0;
+    _PullSuccess = 0;
+    _PullBusy = 0;
+    _firstInitDone = 1;
 }
 
-/*
+/**
     generates used 8 bit CRC
-    crc = byte to be added to CRC
-    crc_seed = CRC where it gets added too
-    returns 8 bit CRC
+    @param crc byte to be added to CRC
+    @param crc_seed CRC where it gets added too
+    @return 8 bit CRC
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed)
+uint8_t AP_FETtecOneWire::Update_crc8(uint8_t crc, uint8_t crc_seed) const
 {
+    // TODO: is there a similar CRC function in the ArduPilot codebase already?
+    // If yes, remove this one and use that instead
     uint8_t crc_u, i;
     crc_u = crc;
     crc_u ^= crc_seed;
@@ -298,33 +304,32 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed
     return (crc_u);
 }
 
-/*
+/**
     generates used 8 bit CRC for arrays
-    Buf = 8 bit byte array
-    BufLen = count of bytes that should be used for CRC calculation
-    returns 8 bit CRC
+    @param Buf 8 bit byte array
+    @param BufLen count of bytes that should be used for CRC calculation
+    @return 8 bit CRC
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen)
+uint8_t AP_FETtecOneWire::Get_crc8(uint8_t* Buf, uint16_t BufLen) const
 {
     uint8_t crc = 0;
     for (uint16_t i = 0; i < BufLen; i++) {
-        crc = FETtecOneWire_UpdateCrc8(Buf[i], crc);
+        crc = Update_crc8(Buf[i], crc);
     }
     return (crc);
 }
 
-/*
+/**
     transmitts a FETtecOneWire frame to a ESC
-    ESC_id = id of the ESC
-    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
-    Length = length of the Bytes array
-    returns nothing
+    @param ESC_id id of the ESC
+    @param Bytes 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    @param Length length of the Bytes array
 */
-void AP_FETtecOneWire::FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t* Bytes, uint8_t Length)
+void AP_FETtecOneWire::Transmit(uint8_t ESC_id, uint8_t* Bytes, uint8_t Length)
 {
     /*
-    a frame lookes like:
-    byte 1 = fremae header (master is always 0x01)
+    a frame looks like:
+    byte 1 = frame header (master is always 0x01)
     byte 2 = target ID (5bit)
     byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
     byte 5 = frame length over all bytes
@@ -336,23 +341,23 @@ void AP_FETtecOneWire::FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t* Bytes, ui
     for (uint8_t i = 0; i < Length; i++) {
         transmitArr[i + 5] = Bytes[i];
     }
-    transmitArr[Length + 5] = FETtecOneWire_GetCrc8(transmitArr, Length + 5); // crc
+    transmitArr[Length + 5] = Get_crc8(transmitArr, Length + 5); // crc
     _uart->write(transmitArr, Length + 6);
-    FETtecOneWire_IgnoreOwnBytes += Length + 6;
+    _IgnoreOwnBytes += Length + 6;
 }
 
-/*
+/**
     reads the answer frame of a ESC
-    Bytes = 8 bit byte array, where the received answer gets stored in
-    Length = the expected answer length
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the expected answer frame was there, 0 if dont
+    @param Bytes 8 bit byte array, where the received answer gets stored in
+    @param Length the expected answer length
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the expected answer frame was there, 0 if dont
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, uint8_t returnFullFrame)
+uint8_t AP_FETtecOneWire::Receive(uint8_t* Bytes, uint8_t Length, uint8_t returnFullFrame)
 {
     /*
-    a frame lookes like:
-    byte 1 = fremae header (0x02 = bootloader, 0x03 = ESC firmware)
+    a frame looks like:
+    byte 1 = frame header (0x02 = bootloader, 0x03 = ESC firmware)
     byte 2 = sender ID (5bit)
     byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
     byte 5 = frame length over all bytes
@@ -361,8 +366,8 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, 
     */
 
     //ignore own bytes
-    while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
-        FETtecOneWire_IgnoreOwnBytes--;
+    while (_IgnoreOwnBytes > 0 && _uart->available()) {
+        _IgnoreOwnBytes--;
         _uart->read();
     }
     // look for the real answer
@@ -381,7 +386,7 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, 
                 ReceiveBuf[i] = _uart->read();
             }
             // check CRC
-            if (FETtecOneWire_GetCrc8(ReceiveBuf, Length + 5) == ReceiveBuf[Length + 5]) {
+            if (Get_crc8(ReceiveBuf, Length + 5) == ReceiveBuf[Length + 5]) {
                 if (!returnFullFrame) {
                     for (uint8_t i = 0; i < Length; i++) {
                         Bytes[i] = ReceiveBuf[5 + i];
@@ -403,315 +408,268 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, 
     } // no answer yet
 }
 
-/*
-    makes all connected ESC's beep
-    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
-*/
-void AP_FETtecOneWire::FETtecOneWire_Beep(uint8_t beepFreqency)
-{
-    if (FETtecOneWire_IDcount > 0) {
-        uint8_t request[2] = {OW_BEEP, beepFreqency};
-        uint8_t spacer[2] = {0, 0};
-        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
-            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
-            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
-            _uart->write(spacer, 2);
-            FETtecOneWire_IgnoreOwnBytes += 2;
-        }
-    }
-}
-
-/*
-    sets the racewire color for all ESC's
-    R, G, B = 8bit colors
-*/
-void AP_FETtecOneWire::FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
-{
-    if (FETtecOneWire_IDcount > 0) {
-        uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
-        uint8_t spacer[2] = {0, 0};
-        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
-            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
-            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
-            _uart->write(spacer, 2);
-            FETtecOneWire_IgnoreOwnBytes += 2;
-        }
-    }
-}
-
-/*
+/**
     Resets a pending pull request
-    returns nothing
 */
-void AP_FETtecOneWire::FETtecOneWire_PullReset()
+void AP_FETtecOneWire::PullReset()
 {
-    FETtecOneWire_PullSuccess = 0;
-    FETtecOneWire_PullBusy = 0;
+    _PullSuccess = 0;
+    _PullBusy = 0;
 }
 
-/*
+/**
     Pulls a complete request between for ESC
-    ESC_id = id of the ESC
-    command = 8bit array containing the command that thould be send including the possible payload
-    response = 8bit array where the response will be stored in
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the request is completed, 0 if dont
+    @param ESC_id  id of the ESC
+    @param command 8bit array containing the command that should be send including the possible payload
+    @param response 8bit array where the response will be stored in
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the request is completed, 0 if dont
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t* command, uint8_t* response,
+uint8_t AP_FETtecOneWire::PullCommand(uint8_t ESC_id, uint8_t* command, uint8_t* response,
         uint8_t returnFullFrame)
 {
-    if (!FETtecOneWire_PullBusy) {
-        FETtecOneWire_PullBusy = 1;
-        FETtecOneWire_PullSuccess = 0;
-        FETtecOneWire_Transmit(ESC_id, command, FETtecOneWire_RequestLength[command[0]]);
+    if (!_PullBusy) {
+        _PullBusy = 1;
+        _PullSuccess = 0;
+        Transmit(ESC_id, command, _RequestLength[command[0]]);
     } else {
-        if (FETtecOneWire_Receive(response, FETtecOneWire_ResponseLength[command[0]], returnFullFrame)) {
-            FETtecOneWire_PullSuccess = 1;
-            FETtecOneWire_PullBusy = 0;
+        if (Receive(response, _ResponseLength[command[0]], returnFullFrame)) {
+            _PullSuccess = 1;
+            _PullBusy = 0;
         }
     }
-    return FETtecOneWire_PullSuccess;
+    return _PullSuccess;
 }
 
-/*
-    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
-    returns the currend scanned ID
+/**
+    scans for ESCs in bus. should be called until _ScanActive >= MOTOR_COUNT_MAX
+    @return the current scanned ID
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_ScanESCs()
+uint8_t AP_FETtecOneWire::ScanESCs()
 {
-    static uint16_t delayLoops = 500;
-    static uint8_t scanID = 0;
-    static uint8_t scanState = 0;
-    static uint8_t scanTimeOut = 0;
     uint8_t response[18] = {0};
     uint8_t request[1] = {0};
-    if (FETtecOneWire_ScanActive == 0) {
-        delayLoops = 500;
-        scanID = 0;
-        scanState = 0;
-        scanTimeOut = 0;
-        return FETtecOneWire_ScanActive + 1;
+    if (_ScanActive == 0) {
+        _ss.delayLoops = 500;
+        _ss.scanID = 0;
+        _ss.scanState = 0;
+        _ss.scanTimeOut = 0;
+        return _ScanActive + 1;
     }
-    if (delayLoops > 0) {
-        delayLoops--;
-        return FETtecOneWire_ScanActive;
+    if (_ss.delayLoops > 0) {
+        _ss.delayLoops--;
+        return _ScanActive;
     }
-    if (scanID < FETtecOneWire_ScanActive) {
-        scanID = FETtecOneWire_ScanActive;
-        scanState = 0;
-        scanTimeOut = 0;
+    if (_ss.scanID < _ScanActive) {
+        _ss.scanID = _ScanActive;
+        _ss.scanState = 0;
+        _ss.scanTimeOut = 0;
     }
-    if (scanTimeOut == 3 || scanTimeOut == 6 || scanTimeOut == 9 || scanTimeOut == 12) {
-        FETtecOneWire_PullReset();
+    if (_ss.scanTimeOut == 3 || _ss.scanTimeOut == 6 || _ss.scanTimeOut == 9 || _ss.scanTimeOut == 12) {
+        PullReset();
     }
-    if (scanTimeOut < 15) {
-        switch (scanState) {
+    if (_ss.scanTimeOut < 15) {
+        switch (_ss.scanState) {
         case 0:request[0] = OW_OK;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_FULL_FRAME)) {
-                scanTimeOut = 0;
-                FETtecOneWire_activeESC_IDs[scanID] = 1;
-                FETtecOneWire_FoundESCs++;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_FULL_FRAME)) {
+                _ss.scanTimeOut = 0;
+                _activeESC_IDs[_ss.scanID] = 1;
+                _FoundESCs++;
                 if (response[0] == 0x02) {
-                    FETtecOneWire_foundESCs[scanID].inBootLoader = 1;
+                    _foundESCs[_ss.scanID].inBootLoader = 1;
                 } else {
-                    FETtecOneWire_foundESCs[scanID].inBootLoader = 0;
+                    _foundESCs[_ss.scanID].inBootLoader = 0;
                 }
-                delayLoops = 1;
-                scanState++;
+                _ss.delayLoops = 1;
+                _ss.scanState++;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         case 1:request[0] = OW_REQ_TYPE;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
-                scanTimeOut = 0;
-                FETtecOneWire_foundESCs[scanID].ESCtype = response[0];
-                delayLoops = 1;
-                scanState++;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
+                _ss.scanTimeOut = 0;
+                _foundESCs[_ss.scanID].ESCtype = response[0];
+                _ss.delayLoops = 1;
+                _ss.scanState++;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         case 2:request[0] = OW_REQ_SW_VER;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
-                scanTimeOut = 0;
-                FETtecOneWire_foundESCs[scanID].firmWareVersion = response[0];
-                FETtecOneWire_foundESCs[scanID].firmWareSubVersion = response[1];
-                delayLoops = 1;
-                scanState++;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
+                _ss.scanTimeOut = 0;
+                _foundESCs[_ss.scanID].firmWareVersion = response[0];
+                _foundESCs[_ss.scanID].firmWareSubVersion = response[1];
+                _ss.delayLoops = 1;
+                _ss.scanState++;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         case 3:request[0] = OW_REQ_SN;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
-                scanTimeOut = 0;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
+                _ss.scanTimeOut = 0;
                 for (uint8_t i = 0; i < 12; i++) {
-                    FETtecOneWire_foundESCs[scanID].serialNumber[i] = response[i];
+                    _foundESCs[_ss.scanID].serialNumber[i] = response[i];
                 }
-                delayLoops = 1;
-                return scanID + 1;
+                _ss.delayLoops = 1;
+                return _ss.scanID + 1;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         }
     } else {
-        FETtecOneWire_PullReset();
-        return scanID + 1;
+        PullReset();
+        return _ss.scanID + 1;
     }
-    return scanID;
+    return _ss.scanID;
 }
 
-/*
-    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
-    returns the current used ID
+/**
+    starts all ESCs in bus and prepares them for receiving the fast throttle command should be called until _SetupActive >= MOTOR_COUNT_MAX
+    @return the current used ID
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_InitESCs()
+uint8_t AP_FETtecOneWire::InitESCs()
 {
-    static uint8_t delayLoops = 0;
-    static uint8_t activeID = 1;
-    static uint8_t State = 0;
-    static uint8_t TimeOut = 0;
-    static uint8_t wakeFromBL = 1;
-    static uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
     uint8_t response[18] = {0};
     uint8_t request[1] = {0};
-    if (FETtecOneWire_SetupActive == 0) {
-        delayLoops = 0;
-        activeID = 1;
-        State = 0;
-        TimeOut = 0;
-        wakeFromBL = 1;
-        return FETtecOneWire_SetupActive + 1;
+    if (_SetupActive == 0) {
+        _is.delayLoops = 0;
+        _is.activeID = 1;
+        _is.State = 0;
+        _is.TimeOut = 0;
+        _is.wakeFromBL = 1;
+        return _SetupActive + 1;
     }
-    while (FETtecOneWire_activeESC_IDs[FETtecOneWire_SetupActive] == 0 && FETtecOneWire_SetupActive < 25) {
-        FETtecOneWire_SetupActive++;
+    while (_activeESC_IDs[_SetupActive] == 0 && _SetupActive < MOTOR_COUNT_MAX) {
+        _SetupActive++;
     }
 
-    if (FETtecOneWire_SetupActive == 25 && wakeFromBL == 0) {
-        return FETtecOneWire_SetupActive;
-    } else if (FETtecOneWire_SetupActive == 25 && wakeFromBL) {
-        wakeFromBL = 0;
-        activeID = 1;
-        FETtecOneWire_SetupActive = 1;
-        State = 0;
-        TimeOut = 0;
+    if (_SetupActive == MOTOR_COUNT_MAX && _is.wakeFromBL == 0) {
+        return _SetupActive;
+    } else if (_SetupActive == MOTOR_COUNT_MAX && _is.wakeFromBL) {
+        _is.wakeFromBL = 0;
+        _is.activeID = 1;
+        _SetupActive = 1;
+        _is.State = 0;
+        _is.TimeOut = 0;
 
-        FETtecOneWire_minID = 25;
-        FETtecOneWire_maxID = 0;
-        FETtecOneWire_IDcount = 0;
-        for (uint8_t i = 0; i < 25; i++) {
-            if (FETtecOneWire_activeESC_IDs[i] != 0) {
-                FETtecOneWire_IDcount++;
-                if (i < FETtecOneWire_minID) {
-                    FETtecOneWire_minID = i;
+        _minID = MOTOR_COUNT_MAX;
+        _maxID = 0;
+        _IDcount = 0;
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+            if (_activeESC_IDs[i] != 0) {
+                _IDcount++;
+                if (i < _minID) {
+                    _minID = i;
                 }
-                if (i > FETtecOneWire_maxID) {
-                    FETtecOneWire_maxID = i;
+                if (i > _maxID) {
+                    _maxID = i;
                 }
             }
         }
 
-        if (FETtecOneWire_IDcount == 0
-                || FETtecOneWire_maxID - FETtecOneWire_minID > FETtecOneWire_IDcount - 1) { // loop forever
-            wakeFromBL = 1;
-            return activeID;
+        if (_IDcount == 0
+                || _maxID - _minID > _IDcount - 1) { // loop forever
+            _is.wakeFromBL = 1;
+            return _is.activeID;
         }
-        FETtecOneWire_FastThrottleByteCount = 1;
-        int8_t bitCount = 12 + (FETtecOneWire_IDcount * 11);
+        _FastThrottleByteCount = 1;
+        int8_t bitCount = 12 + (_IDcount * 11);
         while (bitCount > 0) {
-            FETtecOneWire_FastThrottleByteCount++;
+            _FastThrottleByteCount++;
             bitCount -= 8;
         }
-        setFastCommand[1] = FETtecOneWire_FastThrottleByteCount; // just for older ESC FW versions since 1.0 001 this byte is ignored as the ESC calculates it itself
-        setFastCommand[2] = FETtecOneWire_minID;                 // min ESC id
-        setFastCommand[3] = FETtecOneWire_IDcount;                 // count of ESC's that will get signals
+        _is.setFastCommand[1] = _FastThrottleByteCount; // just for older ESC FW versions since 1.0 001 this byte is ignored as the ESC calculates it itself
+        _is.setFastCommand[2] = _minID;                 // min ESC id
+        _is.setFastCommand[3] = _IDcount;               // count of ESCs that will get signals
     }
 
-    if (delayLoops > 0) {
-        delayLoops--;
-        return FETtecOneWire_SetupActive;
+    if (_is.delayLoops > 0) {
+        _is.delayLoops--;
+        return _SetupActive;
     }
 
-    if (activeID < FETtecOneWire_SetupActive) {
-        activeID = FETtecOneWire_SetupActive;
-        State = 0;
-        TimeOut = 0;
+    if (_is.activeID < _SetupActive) {
+        _is.activeID = _SetupActive;
+        _is.State = 0;
+        _is.TimeOut = 0;
     }
 
-    if (TimeOut == 3 || TimeOut == 6 || TimeOut == 9 || TimeOut == 12) {
-        FETtecOneWire_PullReset();
+    if (_is.TimeOut == 3 || _is.TimeOut == 6 || _is.TimeOut == 9 || _is.TimeOut == 12) {
+        PullReset();
     }
 
-    if (TimeOut < 15) {
-        if (wakeFromBL) {
-            switch (State) {
+    if (_is.TimeOut < 15) {
+        if (_is.wakeFromBL) {
+            switch (_is.State) {
             case 0:request[0] = OW_BL_START_FW;
-                if (FETtecOneWire_foundESCs[activeID].inBootLoader == 1) {
-                    FETtecOneWire_Transmit(activeID, request, FETtecOneWire_RequestLength[request[0]]);
-                    delayLoops = 5;
+                if (_foundESCs[_is.activeID].inBootLoader == 1) {
+                    Transmit(_is.activeID, request, _RequestLength[request[0]]);
+                    _is.delayLoops = 5;
                 } else {
-                    return activeID + 1;
+                    return _is.activeID + 1;
                 }
-                State = 1;
+                _is.State = 1;
                 break;
             case 1:request[0] = OW_OK;
-                if (FETtecOneWire_PullCommand(activeID, request, response, OW_RETURN_FULL_FRAME)) {
-                    TimeOut = 0;
+                if (PullCommand(_is.activeID, request, response, OW_RETURN_FULL_FRAME)) {
+                    _is.TimeOut = 0;
                     if (response[0] == 0x02) {
-                        FETtecOneWire_foundESCs[activeID].inBootLoader = 1;
-                        State = 0;
+                        _foundESCs[_is.activeID].inBootLoader = 1;
+                        _is.State = 0;
                     } else {
-                        FETtecOneWire_foundESCs[activeID].inBootLoader = 0;
-                        delayLoops = 1;
-                        return activeID + 1;
+                        _foundESCs[_is.activeID].inBootLoader = 0;
+                        _is.delayLoops = 1;
+                        return _is.activeID + 1;
                     }
                 } else {
-                    TimeOut++;
+                    _is.TimeOut++;
                 }
                 break;
             }
         } else {
-            if (FETtecOneWire_PullCommand(activeID, setFastCommand, response, OW_RETURN_RESPONSE)) {
-                TimeOut = 0;
-                delayLoops = 1;
-                return activeID + 1;
+            if (PullCommand(_is.activeID, _is.setFastCommand, response, OW_RETURN_RESPONSE)) {
+                _is.TimeOut = 0;
+                _is.delayLoops = 1;
+                return _is.activeID + 1;
             } else {
-                TimeOut++;
+                _is.TimeOut++;
             }
         }
     } else {
-        FETtecOneWire_PullReset();
-        return activeID + 1;
+        PullReset();
+        return _is.activeID + 1;
     }
-    return activeID;
+    return _is.activeID;
 }
 
-/*
+/**
     checks if the requested telemetry is available. 
-    Telemetry = 16bit array where the read Telemetry will be stored in. 
-    returns the telemetry request number or -1 if unavailable
+    @param Telemetry 16bit array where the read Telemetry will be stored in.
+    @return the telemetry request number or -1 if unavailable
 */
-int8_t AP_FETtecOneWire::FETtecOneWire_CheckForTLM(uint16_t* Telemetry)
+int8_t AP_FETtecOneWire::CheckForTLM(uint16_t* Telemetry)
 {
     int8_t return_TLM_request = 0;
-    if (FETtecOneWire_IDcount > 0) {
+    if (_IDcount > 0) {
         // empty buffer
-        while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
+        while (_IgnoreOwnBytes > 0 && _uart->available()) {
             _uart->read();
-            FETtecOneWire_IgnoreOwnBytes--;
+            _IgnoreOwnBytes--;
         }
 
         // first two byte are the ESC Telemetry of the first ESC. next two byte of the second....
-        if (_uart->available() == (FETtecOneWire_IDcount * 2) + 1u) {
+        if (_uart->available() == (_IDcount * 2) + 1u) {
             // look if first byte in buffer is equal to last byte of throttle command (crc)
-            if (_uart->read() == FETtecOneWire_lastCRC) {
-                for (uint8_t i = 0; i < FETtecOneWire_IDcount; i++) {
+            if (_uart->read() == _lastCRC) {
+                for (uint8_t i = 0; i < _IDcount; i++) {
                     Telemetry[i] = _uart->read() << 8;
                     Telemetry[i] |= _uart->read();
                 }
-                return_TLM_request = FETtecOneWire_TLM_request;
+                return_TLM_request = _TLM_request;
             } else {
                 return_TLM_request = -1;
             }
@@ -724,55 +682,55 @@ int8_t AP_FETtecOneWire::FETtecOneWire_CheckForTLM(uint16_t* Telemetry)
     return return_TLM_request;
 }
 
-/*
+/**
     does almost all of the job.
-    scans for ESC's if not already done.
-    initializes the ESC's if not already done.
+    scans for ESCs if not already done.
+    initializes the ESCs if not already done.
     sends fast throttle signals if init is complete.
-    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
-    Telemetry = 16bit array where the read telemetry will be stored in. 
-    motorCount = the count of motors that should get values send
-    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
-    returns the telemetry request if telemetry was available, -1 if dont
+    @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    @param Telemetry 16bit array where the read telemetry will be stored in.
+    @param motorCount the count of motors that should get values send
+    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @return the telemetry request if telemetry was available, -1 if dont
 */
-int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,
+int8_t AP_FETtecOneWire::ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,
         uint8_t tlmRequest)
 {
     int8_t return_TLM_request = -2;
 
     // init should not be done too fast. as at last the bootloader has some timing requirements with messages. so loop delays must fit more or less
-    if (FETtecOneWire_ScanActive < 25 || FETtecOneWire_SetupActive < 25) {
+    if (_ScanActive < MOTOR_COUNT_MAX || _SetupActive < MOTOR_COUNT_MAX) {
         const uint32_t now = AP_HAL::micros();
-        if (now - last_send_us < DELAY_TIME_US) {
+        if (now - _last_send_us < DELAY_TIME_US) {
             return 0;
         } else {
-            last_send_us = now;
+            _last_send_us = now;
         }
 
-        if (FETtecOneWire_ScanActive < 25) {
-            // scan for all ESC's in onewire bus
-            FETtecOneWire_ScanActive = FETtecOneWire_ScanESCs();
-        } else if (FETtecOneWire_SetupActive < 25) {
-            if (FETtecOneWire_FoundESCs == 0) {
-                FETtecOneWire_ScanActive = 0;
+        if (_ScanActive < MOTOR_COUNT_MAX) {
+            // scan for all ESCs in onewire bus
+            _ScanActive = ScanESCs();
+        } else if (_SetupActive < MOTOR_COUNT_MAX) {
+            if (_FoundESCs == 0) {
+                _ScanActive = 0;
             } else {
-                // check if in bootloader, start ESC's FW if they are and prepare fast throttle command
-                FETtecOneWire_SetupActive = FETtecOneWire_InitESCs();
+                // check if in bootloader, start ESCs FW if they are and prepare fast throttle command
+                _SetupActive = InitESCs();
             }
         }
     } else {
         //send fast throttle signals
-        if (FETtecOneWire_IDcount > 0) {
+        if (_IDcount > 0) {
 
             // check for telemetry
-            return_TLM_request = FETtecOneWire_CheckForTLM(Telemetry);
-            FETtecOneWire_TLM_request = tlmRequest;
+            return_TLM_request = CheckForTLM(Telemetry);
+            _TLM_request = tlmRequest;
 
             //prepare fast throttle signals
             uint16_t useSignals[24] = {0};
             uint8_t OneWireFastThrottleCommand[36] = {0};
-            if (motorCount > FETtecOneWire_IDcount) {
-                motorCount = FETtecOneWire_IDcount;
+            if (motorCount > _IDcount) {
+                motorCount = _IDcount;
             }
             for (uint8_t i = 0; i < motorCount; i++) {
                 useSignals[i] = constrain_int16(motorValues[i], 0, 2000);
@@ -787,7 +745,7 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
             // B = TLM request type (temp, volt, current, erpm, consumption, debug1, debug2, debug3)
             // C = first bit from first throttle signal
             // D = frame header
-            OneWireFastThrottleCommand[0] = 128 | (FETtecOneWire_TLM_request << 4);
+            OneWireFastThrottleCommand[0] = 128 | (_TLM_request << 4);
             OneWireFastThrottleCommand[0] |= ((useSignals[actThrottleCommand] >> 10) & 0x01) << 3;
             OneWireFastThrottleCommand[0] |= 0x01;
 
@@ -798,11 +756,11 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
             OneWireFastThrottleCommand[1] = (((useSignals[actThrottleCommand] >> 7) & 0x07)) << 5;
             OneWireFastThrottleCommand[1] |= ALL_ID;
 
-            // following bytes are the rest 7 bit of the first (11bit)throttle signal, and all bit from all other signals, followed by the CRC byte
+            // following bytes are the rest 7 bit of the first (11bit) throttle signal, and all bit from all other signals, followed by the CRC byte
             uint8_t BitsLeftFromCommand = 7;
             uint8_t actByte = 2;
             uint8_t bitsFromByteLeft = 8;
-            uint8_t bitsToAddLeft = (12 + (((FETtecOneWire_maxID - FETtecOneWire_minID) + 1) * 11)) - 16;
+            uint8_t bitsToAddLeft = (12 + (((_maxID - _minID) + 1) * 11)) - 16;
             while (bitsToAddLeft > 0) {
                 if (bitsFromByteLeft >= BitsLeftFromCommand) {
                     OneWireFastThrottleCommand[actByte] |=
@@ -836,15 +794,15 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
             }
 
             // send throttle signal
-            OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1] = FETtecOneWire_GetCrc8(
-                    OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount - 1);
-            _uart->write(OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount);
+            OneWireFastThrottleCommand[_FastThrottleByteCount - 1] = Get_crc8(
+                    OneWireFastThrottleCommand, _FastThrottleByteCount - 1);
+            _uart->write(OneWireFastThrottleCommand, _FastThrottleByteCount);
             // last byte of signal can be used to make sure the first TLM byte is correct, in case of spike corruption
-            FETtecOneWire_IgnoreOwnBytes = FETtecOneWire_FastThrottleByteCount - 1;
-            FETtecOneWire_lastCRC = OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1];
-            // the ESC's will answer the TLM as 16bit each ESC, so 2byte each ESC.
+            _IgnoreOwnBytes = _FastThrottleByteCount - 1;
+            _lastCRC = OneWireFastThrottleCommand[_FastThrottleByteCount - 1];
+            // the ESCs will answer the TLM as 16bit each ESC, so 2byte each ESC.
         }
     }
-    return return_TLM_request; // returns the readed tlm as it is 1 loop delayed
+    return return_TLM_request; // returns the read tlm as it is 1 loop delayed
 }
 #endif  // HAL_AP_FETTECONEWIRE_ENABLED

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -197,15 +197,6 @@ void AP_FETtecOneWire::update()
         // log at 10Hz
         if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-                // TODO: remove printfs
-                printf(" esc: %d", i + 1);
-                printf(" Temperature: %d", _telemetry[i][OW_TLM_TEMP]);
-                printf(", Voltage: %d", _telemetry[i][OW_TLM_VOLT]);
-                printf(", Current: %d", _telemetry[i][OW_TLM_CURRENT]);
-                printf(", E-rpm: %d", _telemetry[i][OW_TLM_ERPM]);
-                printf(", consumption: %d", _telemetry[i][OW_TLM_CONSUMPTION]);
-                printf("\n");
-
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
                         _telemetry[i][OW_TLM_ERPM] * 100U,

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -181,9 +181,9 @@ void AP_FETtecOneWire::update()
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
     _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
 
-    if (++_telem_req_type == OW_TLM_DEBUG1) {
-        // OW_TLM_DEBUG1, OW_TLM_DEBUG2, OW_TLM_DEBUG3 are ignored
-        _telem_req_type = OW_TLM_TEMP;
+    if (++_telem_req_type == telem_type::DEBUG1) {
+        // telem_type::DEBUG1, telem_type::DEBUG2, telem_type::DEBUG3 are ignored
+        _telem_req_type = telem_type::TEMP;
     }
 
     if (_telem_avail != -1) {
@@ -201,11 +201,11 @@ void AP_FETtecOneWire::update()
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
-                        _telemetry[i][OW_TLM_ERPM] * 100U,
-                        _telemetry[i][OW_TLM_VOLT],
-                        _telemetry[i][OW_TLM_CURRENT],
-                        _telemetry[i][OW_TLM_TEMP] * 100U,
-                        _telemetry[i][OW_TLM_CONSUMPTION],
+                        _telemetry[i][telem_type::ERPM] * 100U,
+                        _telemetry[i][telem_type::VOLT],
+                        _telemetry[i][telem_type::CURRENT],
+                        _telemetry[i][telem_type::TEMP] * 100U,
+                        _telemetry[i][telem_type::CONSUMPTION],
                         0,
                         0);
             }
@@ -233,11 +233,11 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
     // TODO: take the _telem_semaphore here
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
-        temperature[idx] = _telemetry[i][OW_TLM_TEMP];
-        voltage[idx] = _telemetry[i][OW_TLM_VOLT];
-        current[idx] = _telemetry[i][OW_TLM_CURRENT];
-        rpm[idx] = _telemetry[i][OW_TLM_ERPM];
-        totalcurrent[idx] = _telemetry[i][OW_TLM_CONSUMPTION];
+        temperature[idx] = _telemetry[i][telem_type::TEMP];
+        voltage[idx] = _telemetry[i][telem_type::VOLT];
+        current[idx] = _telemetry[i][telem_type::CURRENT];
+        rpm[idx] = _telemetry[i][telem_type::ERPM];
+        totalcurrent[idx] = _telemetry[i][telem_type::CONSUMPTION];
         count[idx] = _telemetry[i][5];
         if (idx == 3 || i == MOTOR_COUNT_MAX - 1) {
             if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
@@ -684,7 +684,7 @@ int8_t AP_FETtecOneWire::CheckForTLM(uint16_t* Telemetry)
     @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
     @param Telemetry 16bit array where the read telemetry will be stored in.
     @param motorCount the count of motors that should get values send
-    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @param tlmRequest the requested telemetry type (telem_type::XXXXX)
     @return the telemetry request if telemetry was available, -1 if dont
 */
 int8_t AP_FETtecOneWire::ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -181,6 +181,7 @@ void AP_FETtecOneWire::update()
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
     _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
     if (_telem_avail != -1) {
+        // TODO: take the _telem_semaphore here
         for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
             _telemetry[i][_telem_avail] = requestedTelemetry[i];
             _telemetry[i][5]++;
@@ -196,6 +197,7 @@ void AP_FETtecOneWire::update()
         const uint32_t now = AP_HAL::millis();
         // log at 10Hz
         if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
+            // TODO: take the _telem_semaphore here
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
@@ -228,6 +230,7 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
     uint16_t totalcurrent[4] {};
     uint16_t rpm[4] {};
     uint16_t count[4] {};
+    // TODO: take the _telem_semaphore here
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
         temperature[idx] = _telemetry[i][OW_TLM_TEMP];

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -41,22 +41,106 @@ AP_FETtecOneWire *AP_FETtecOneWire::_singleton;
 AP_FETtecOneWire::AP_FETtecOneWire()
 {
     _singleton = this;
-
     _ResponseLength[OW_OK] = 1;
+    _ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
+    _ResponseLength[OW_NOT_OK] = 1;
     _ResponseLength[OW_BL_START_FW] = 0;       // BL only
+    _ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
     _ResponseLength[OW_REQ_TYPE] = 1;
     _ResponseLength[OW_REQ_SN] = 12;
     _ResponseLength[OW_REQ_SW_VER] = 2;
+    _ResponseLength[OW_RESET_TO_BL] = 0;
+    _ResponseLength[OW_THROTTLE] = 1;
+    _ResponseLength[OW_REQ_TLM] = 2;
     _ResponseLength[OW_BEEP] = 0;
+
+    _ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
+
+    _ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
+    _ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    _ResponseLength[OW_GET_USE_SIN_START] = 1;
+    _ResponseLength[OW_SET_USE_SIN_START] = 1;
+
+    _ResponseLength[OW_GET_3D_MODE] = 1;
+    _ResponseLength[OW_SET_3D_MODE] = 1;
+
+    _ResponseLength[OW_GET_ID] = 1;
+    _ResponseLength[OW_SET_ID] = 1;
+
+/*
+    _ResponseLength[OW_GET_LINEAR_THRUST] = 1;
+    _ResponseLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    _ResponseLength[OW_GET_EEVER] = 1;
+
+    _ResponseLength[OW_GET_PWM_MIN] = 2;
+    _ResponseLength[OW_SET_PWM_MIN] = 1;
+
+    _ResponseLength[OW_GET_PWM_MAX] = 2;
+    _ResponseLength[OW_SET_PWM_MAX] = 1;
+
+    _ResponseLength[OW_GET_ESC_BEEP] = 1;
+    _ResponseLength[OW_SET_ESC_BEEP] = 1;
+
+    _ResponseLength[OW_GET_CURRENT_CALIB] = 1;
+    _ResponseLength[OW_SET_CURRENT_CALIB] = 1;
+
     _ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
+    _ResponseLength[OW_GET_LED_COLOR] = 5;
+    _ResponseLength[OW_SET_LED_COLOR] = 1;
 
     _RequestLength[OW_OK] = 1;
+    _RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
+    _RequestLength[OW_NOT_OK] = 1;
     _RequestLength[OW_BL_START_FW] = 1;       // BL only
+    _RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
     _RequestLength[OW_REQ_TYPE] = 1;
     _RequestLength[OW_REQ_SN] = 1;
     _RequestLength[OW_REQ_SW_VER] = 1;
+    _RequestLength[OW_RESET_TO_BL] = 1;
+    _RequestLength[OW_THROTTLE] = 1;
+    _RequestLength[OW_REQ_TLM] = 1;
     _RequestLength[OW_BEEP] = 2;
+
+    _RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
+
+    _RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
+    _RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    _RequestLength[OW_GET_USE_SIN_START] = 1;
+    _RequestLength[OW_SET_USE_SIN_START] = 1;
+
+    _RequestLength[OW_GET_3D_MODE] = 1;
+    _RequestLength[OW_SET_3D_MODE] = 1;
+
+    _RequestLength[OW_GET_ID] = 1;
+    _RequestLength[OW_SET_ID] = 1;
+
+/*
+    _RequestLength[OW_GET_LINEAR_THRUST] = 1;
+    _RequestLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    _RequestLength[OW_GET_EEVER] = 1;
+
+    _RequestLength[OW_GET_PWM_MIN] = 1;
+    _RequestLength[OW_SET_PWM_MIN] = 2;
+
+    _RequestLength[OW_GET_PWM_MAX] = 1;
+    _RequestLength[OW_SET_PWM_MAX] = 2;
+
+    _RequestLength[OW_GET_ESC_BEEP] = 1;
+    _RequestLength[OW_SET_ESC_BEEP] = 1;
+
+    _RequestLength[OW_GET_CURRENT_CALIB] = 1;
+    _RequestLength[OW_SET_CURRENT_CALIB] = 1;
+
     _RequestLength[OW_SET_LED_TMP_COLOR] = 4;
+    _RequestLength[OW_GET_LED_COLOR] = 1;
+    _RequestLength[OW_SET_LED_COLOR] = 5;
+
 }
 
 void AP_FETtecOneWire::init()

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -14,14 +14,36 @@
  */
 
 /* Protocol implementation was provided by FETtec */
+
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
+
 #include "AP_FETtecOneWire.h"
+#if HAL_AP_FETTECONEWIRE_ENABLED
 #include <stdio.h>
 
-// constructor
+const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
+    // @Param: MASK
+    // @DisplayName: Channel Bitmask
+    // @Description: Enable of volz servo protocol to specific channels
+    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @User: Standard
+    AP_GROUPINFO("MASK",  1, AP_FETtecOneWire, motor_mask, 0),
+
+    AP_GROUPEND
+};
+
+AP_FETtecOneWire *AP_FETtecOneWire::_singleton;
+
+static uint8_t FETtecOneWire_ResponseLength[54];
+static uint8_t FETtecOneWire_RequestLength[54];
+
 AP_FETtecOneWire::AP_FETtecOneWire()
 {
+    _singleton = this;
     FETtecOneWire_ResponseLength[OW_OK] = 1;
     FETtecOneWire_ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
     FETtecOneWire_ResponseLength[OW_NOT_OK] = 1;
@@ -147,18 +169,32 @@ void AP_FETtecOneWire::update()
         return;
     }
 
-    uint16_t requestedTelemetry[MOTOR_COUNT] = {0};
-    int8_t TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT, TLM_request);
+    const uint16_t mask = uint16_t(motor_mask.get());
+
+    // tell SRV_Channels about ESC capabilities
+    SRV_Channels::set_digital_mask(mask);
+    for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+        SRV_Channel* c = SRV_Channels::srv_channel(i);
+        if (c == nullptr) {
+            continue;
+        }
+        motorpwm[i] = c->get_output_pwm();
+    }
+
+    uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
+    TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, TLM_request);
     if (TelemetryAvailable != -1) {
-        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
             completeTelemetry[i][TelemetryAvailable] = requestedTelemetry[i];
+            completeTelemetry[i][5]++;
         }
     }
     if (++TLM_request == 5) {
         TLM_request = 0;
     }
+
     if (TelemetryAvailable != -1) {
-        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
             printf(" esc: %d", i + 1);
             printf(" Temperature: %d", completeTelemetry[i][0]);
             printf(", Voltage: %d", completeTelemetry[i][1]);
@@ -166,6 +202,58 @@ void AP_FETtecOneWire::update()
             printf(", E-rpm: %d", completeTelemetry[i][3]);
             printf(", consumption: %d", completeTelemetry[i][4]);
             printf("\n");
+            AP_Logger *logger = AP_Logger::get_singleton();
+
+            // log at 10Hz
+            const uint32_t now = AP_HAL::millis();
+            if (logger && logger->logging_enabled() && now - last_log_ms > 100) {
+                logger->Write_ESC(i,
+                        AP_HAL::micros64(),
+                        completeTelemetry[i][3] * 100U,
+                        completeTelemetry[i][1],
+                        completeTelemetry[i][2],
+                        completeTelemetry[i][0] * 100U,
+                        completeTelemetry[i][4],
+                        0,
+                        0);
+                last_log_ms = now;
+            }
+        }
+    }
+
+}
+
+/*
+  send ESC telemetry messages over MAVLink
+ */
+void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan)
+{
+    if (TelemetryAvailable == -1) {
+        return;
+    }
+    uint8_t temperature[4] {};
+    uint16_t voltage[4] {};
+    uint16_t current[4] {};
+    uint16_t totalcurrent[4] {};
+    uint16_t rpm[4] {};
+    uint16_t count[4] {};
+    for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
+        uint8_t idx = i % 4;
+        temperature[idx] = completeTelemetry[i][0];
+        voltage[idx] = completeTelemetry[i][1];
+        current[idx] = completeTelemetry[i][2];
+        rpm[idx] = completeTelemetry[i][3];
+        totalcurrent[idx] = completeTelemetry[i][4];
+        count[idx] = completeTelemetry[i][5];
+        if (i % 4 == 3 || i == MOTOR_COUNT_MAX - 1) {
+            if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
+                return;
+            }
+            if (i < 4) {
+                mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
+            } else {
+                mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
+            }
         }
     }
 }
@@ -759,3 +847,4 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
     }
     return return_TLM_request; // returns the readed tlm as it is 1 loop delayed
 }
+#endif  // HAL_AP_FETTECONEWIRE_ENABLED

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -41,106 +41,22 @@ AP_FETtecOneWire *AP_FETtecOneWire::_singleton;
 AP_FETtecOneWire::AP_FETtecOneWire()
 {
     _singleton = this;
+
     _ResponseLength[OW_OK] = 1;
-    _ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
-    _ResponseLength[OW_NOT_OK] = 1;
     _ResponseLength[OW_BL_START_FW] = 0;       // BL only
-    _ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
     _ResponseLength[OW_REQ_TYPE] = 1;
     _ResponseLength[OW_REQ_SN] = 12;
     _ResponseLength[OW_REQ_SW_VER] = 2;
-    _ResponseLength[OW_RESET_TO_BL] = 0;
-    _ResponseLength[OW_THROTTLE] = 1;
-    _ResponseLength[OW_REQ_TLM] = 2;
     _ResponseLength[OW_BEEP] = 0;
-
-    _ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
-
-    _ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
-    _ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
-
-    _ResponseLength[OW_GET_USE_SIN_START] = 1;
-    _ResponseLength[OW_SET_USE_SIN_START] = 1;
-
-    _ResponseLength[OW_GET_3D_MODE] = 1;
-    _ResponseLength[OW_SET_3D_MODE] = 1;
-
-    _ResponseLength[OW_GET_ID] = 1;
-    _ResponseLength[OW_SET_ID] = 1;
-
-/*
-    _ResponseLength[OW_GET_LINEAR_THRUST] = 1;
-    _ResponseLength[OW_SET_LINEAR_THRUST] = 1;
-*/
-
-    _ResponseLength[OW_GET_EEVER] = 1;
-
-    _ResponseLength[OW_GET_PWM_MIN] = 2;
-    _ResponseLength[OW_SET_PWM_MIN] = 1;
-
-    _ResponseLength[OW_GET_PWM_MAX] = 2;
-    _ResponseLength[OW_SET_PWM_MAX] = 1;
-
-    _ResponseLength[OW_GET_ESC_BEEP] = 1;
-    _ResponseLength[OW_SET_ESC_BEEP] = 1;
-
-    _ResponseLength[OW_GET_CURRENT_CALIB] = 1;
-    _ResponseLength[OW_SET_CURRENT_CALIB] = 1;
-
     _ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
-    _ResponseLength[OW_GET_LED_COLOR] = 5;
-    _ResponseLength[OW_SET_LED_COLOR] = 1;
 
     _RequestLength[OW_OK] = 1;
-    _RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
-    _RequestLength[OW_NOT_OK] = 1;
     _RequestLength[OW_BL_START_FW] = 1;       // BL only
-    _RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
     _RequestLength[OW_REQ_TYPE] = 1;
     _RequestLength[OW_REQ_SN] = 1;
     _RequestLength[OW_REQ_SW_VER] = 1;
-    _RequestLength[OW_RESET_TO_BL] = 1;
-    _RequestLength[OW_THROTTLE] = 1;
-    _RequestLength[OW_REQ_TLM] = 1;
     _RequestLength[OW_BEEP] = 2;
-
-    _RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
-
-    _RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
-    _RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
-
-    _RequestLength[OW_GET_USE_SIN_START] = 1;
-    _RequestLength[OW_SET_USE_SIN_START] = 1;
-
-    _RequestLength[OW_GET_3D_MODE] = 1;
-    _RequestLength[OW_SET_3D_MODE] = 1;
-
-    _RequestLength[OW_GET_ID] = 1;
-    _RequestLength[OW_SET_ID] = 1;
-
-/*
-    _RequestLength[OW_GET_LINEAR_THRUST] = 1;
-    _RequestLength[OW_SET_LINEAR_THRUST] = 1;
-*/
-
-    _RequestLength[OW_GET_EEVER] = 1;
-
-    _RequestLength[OW_GET_PWM_MIN] = 1;
-    _RequestLength[OW_SET_PWM_MIN] = 2;
-
-    _RequestLength[OW_GET_PWM_MAX] = 1;
-    _RequestLength[OW_SET_PWM_MAX] = 2;
-
-    _RequestLength[OW_GET_ESC_BEEP] = 1;
-    _RequestLength[OW_SET_ESC_BEEP] = 1;
-
-    _RequestLength[OW_GET_CURRENT_CALIB] = 1;
-    _RequestLength[OW_SET_CURRENT_CALIB] = 1;
-
     _RequestLength[OW_SET_LED_TMP_COLOR] = 4;
-    _RequestLength[OW_GET_LED_COLOR] = 1;
-    _RequestLength[OW_SET_LED_COLOR] = 5;
-
 }
 
 void AP_FETtecOneWire::init()

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -140,12 +140,12 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
     if (_telem_avail == -1) {
         return;
     }
-    uint8_t temperature[4] {};
-    uint16_t voltage[4] {};
-    uint16_t current[4] {};
-    uint16_t totalcurrent[4] {};
-    uint16_t rpm[4] {};
-    uint16_t count[4] {};
+    uint8_t temperature[4] {};   // deg C
+    uint16_t voltage[4] {};      // cV
+    uint16_t current[4] {};      // cA
+    uint16_t totalcurrent[4] {}; // mA.h
+    uint16_t rpm[4] {};          // eRPM
+    uint16_t count[4] {};        // ESC telemetry packets received
     // TODO: take the _telem_semaphore here
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
@@ -159,7 +159,7 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
             if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
                 return;
             }
-            static_assert(MOTOR_COUNT_MAX <= 12, "AP_FETtecOneWire::send_esc_telemetry_mavlink() support 12 or less motors");
+            static_assert(MOTOR_COUNT_MAX <= 12, "AP_FETtecOneWire::send_esc_telemetry_mavlink() only supports up-to 12 motors");
             if (i < 4) {
                 mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
             } else if (i < 8) {

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -1,0 +1,256 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+    /* Protocol implementation was provided by FETtec */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#ifndef HAL_AP_FETTECONEWIRE_ENABLED
+#define HAL_AP_FETTECONEWIRE_ENABLED !HAL_MINIMIZE_FEATURES && !defined(HAL_BUILD_AP_PERIPH) && BOARD_FLASH_SIZE > 1024
+#endif
+
+#if HAL_AP_FETTECONEWIRE_ENABLED
+
+class AP_FETtecOneWire {
+public:
+    AP_FETtecOneWire();
+
+    void update();
+private:
+    void init();
+    bool initialised;
+    AP_HAL::UARTDriver *_uart;
+    uint32_t last_send_us;
+    static constexpr uint32_t DELAY_TIME_US = 700;
+    static constexpr uint8_t DETECT_ESC_COUNT = 4;  // TODO needed ?
+    static constexpr uint8_t MOTOR_COUNT = 4;
+    uint16_t completeTelemetry[MOTOR_COUNT][5] = {0};
+    uint16_t motorpwm[MOTOR_COUNT] = {1000};
+    uint8_t TLM_request = 0;
+    /*
+    initialize FETtecOneWire protocol
+*/
+    void FETtecOneWire_Init(void);
+
+/*
+    deinitialize FETtecOneWire protocol
+*/
+    void FETtecOneWire_DeInit(void);
+
+/*
+    generates used 8 bit CRC
+    crc = byte to be added to CRC
+    crc_seed = CRC where it gets added too
+    returns 8 bit CRC
+*/
+    uint8_t FETtecOneWire_Update_crc8(uint8_t crc, uint8_t crc_seed);
+
+/*
+    generates used 8 bit CRC for arrays
+    Buf = 8 bit byte array
+    BufLen = count of bytes that should be used for CRC calculation
+    returns 8 bit CRC
+*/
+    uint8_t FETtecOneWire_Get_crc8(uint8_t *Buf, uint16_t BufLen);
+
+/*
+    transmitts a FETtecOneWire frame to a ESC
+    ESC_id = id of the ESC
+    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    Length = length of the Bytes array
+    returns nothing
+*/
+    void FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t *Bytes, uint8_t Length);
+
+/*
+    reads the answer frame of a ESC
+    Bytes = 8 bit byte array, where the received answer gets stored in
+    Length = the expected answer length
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the expected answer frame was there, 0 if dont
+*/
+    uint8_t FETtecOneWire_Receive(uint8_t *Bytes, uint8_t Length, uint8_t returnFullFrame);
+
+/*
+    makes all connected ESC's beep
+    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
+*/
+    void FETtecOneWire_Beep(uint8_t beepFreqency);
+
+/*
+    sets the racewire color for all ESC's
+    R, G, B = 8bit colors
+*/
+    void FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B);
+
+/*
+    Resets a pending pull request
+    returns nothing
+*/
+    void FETtecOneWire_PullReset(void);
+
+/*
+    Pulls a complete request between for ESC
+    ESC_id = id of the ESC
+    command = 8bit array containing the command that thould be send including the possible payload
+    response = 8bit array where the response will be stored in
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the request is completed, 0 if dont
+*/
+    uint8_t FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t *command, uint8_t *response, uint8_t returnFullFrame);
+
+/*
+    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
+    returns the current scanned ID
+*/
+    uint8_t FETtecOneWire_ScanESCs(void);
+
+/*
+    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
+    returns the current used ID
+*/
+    uint8_t FETtecOneWire_InitESCs(void);
+
+/*
+    checks if the requested telemetry is available.
+    Telemetry = 16bit array where the read Telemetry will be stored in.
+    returns the telemetry request number or -1 if unavailable
+*/
+    int8_t FETtecOneWire_CheckForTLM(uint16_t *Telemetry);
+
+/*
+    does almost all of the job.
+    scans for ESC's if not already done.
+    initializes the ESC's if not already done.
+    sends fast throttle signals if init is complete.
+    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    Telemetry = 16bit array where the read telemetry will be stored in.
+    motorCount = the count of motors that should get values send
+    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
+    returns the telemetry request if telemetry was available, -1 if dont
+*/
+    int8_t FETtecOneWire_ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
+
+    uint8_t FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed);  //TODO remove
+    uint8_t FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen);
+    static constexpr uint8_t ALL_ID = 0x1F;
+    typedef struct FETtecOneWireESC
+    {
+      uint8_t inBootLoader;
+      uint8_t firmWareVersion;
+      uint8_t firmWareSubVersion;
+      uint8_t ESCtype;
+      uint8_t serialNumber[12];
+    } FETtecOneWireESC_t;
+
+    uint8_t FETtecOneWire_activeESC_IDs[25] = {0};
+    FETtecOneWireESC_t FETtecOneWire_foundESCs[25];
+    uint8_t FETtecOneWire_FoundESCs = 0;
+    uint8_t FETtecOneWire_ScanActive = 0;
+    uint8_t FETtecOneWire_SetupActive = 0;
+    uint8_t FETtecOneWire_IgnoreOwnBytes = 0;
+    int8_t FETtecOneWire_minID = 25;
+    int8_t FETtecOneWire_maxID = 0;
+    uint8_t FETtecOneWire_IDcount = 0;
+    uint8_t FETtecOneWire_FastThrottleByteCount = 0;
+    uint8_t FETtecOneWire_PullSuccess = 0;
+    uint8_t FETtecOneWire_PullBusy = 0;
+    uint8_t FETtecOneWire_TLM_request = 0;
+    uint8_t FETtecOneWire_lastCRC = 0;
+    uint8_t FETtecOneWire_firstInitDone = 0;
+
+
+    enum
+    {
+      OW_RETURN_RESPONSE,
+      OW_RETURN_FULL_FRAME
+    };
+
+    enum
+    {
+      OW_OK,
+      OW_BL_PAGE_CORRECT,   // BL only
+      OW_NOT_OK,
+      OW_BL_START_FW,       // BL only
+      OW_BL_PAGES_TO_FLASH, // BL only
+      OW_REQ_TYPE,
+      OW_REQ_SN,
+      OW_REQ_SW_VER
+    };
+
+    enum
+    {
+      OW_RESET_TO_BL = 10,
+      OW_THROTTLE = 11,
+      OW_REQ_TLM = 12,
+      OW_BEEP = 13,
+
+      OW_SET_FAST_COM_LENGTH = 26,
+
+      OW_GET_ROTATION_DIRECTION = 28,
+      OW_SET_ROTATION_DIRECTION = 29,
+
+      OW_GET_USE_SIN_START = 30,
+      OW_SET_USE_SIN_START = 31,
+
+      OW_GET_3D_MODE = 32,
+      OW_SET_3D_MODE = 33,
+
+      OW_GET_ID = 34,
+      OW_SET_ID = 35,
+
+/*
+    OW_GET_LINEAR_THRUST = 36,
+    OW_SET_LINEAR_THRUST = 37,
+*/
+
+      OW_GET_EEVER = 38,
+
+      OW_GET_PWM_MIN = 39,
+      OW_SET_PWM_MIN = 40,
+
+      OW_GET_PWM_MAX = 41,
+      OW_SET_PWM_MAX = 42,
+
+      OW_GET_ESC_BEEP = 43,
+      OW_SET_ESC_BEEP = 44,
+
+      OW_GET_CURRENT_CALIB = 45,
+      OW_SET_CURRENT_CALIB = 46,
+
+      OW_SET_LED_TMP_COLOR = 51,
+      OW_GET_LED_COLOR = 52,
+      OW_SET_LED_COLOR = 53
+
+    };
+
+    enum
+    {
+      OW_TLM_TEMP,
+      OW_TLM_VOLT,
+      OW_TLM_CURRENT,
+      OW_TLM_ERPM,
+      OW_TLM_CONSUMPTION,
+      OW_TLM_DEBUG1,
+      OW_TLM_DEBUG2,
+      OW_TLM_DEBUG3
+    };
+    static uint8_t FETtecOneWire_ResponseLength[54];
+    static uint8_t FETtecOneWire_RequestLength[54];
+};
+#endif // HAL_AP_FETTECONEWIRE_ENABLED
+

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -66,7 +66,7 @@ private:
     ///  - _telemetry[i][5] -> count[idx]
     uint16_t _telemetry[MOTOR_COUNT_MAX][6] = {0};
     uint16_t _motorpwm[MOTOR_COUNT_MAX] = {1000};
-    uint8_t _telem_req_type; /// the requested telemetry type (OW_TLM_XXXXX)
+    uint8_t _telem_req_type; /// the requested telemetry type (telem_type::XXXXX)
 
 /**
     initialize FETtecOneWire protocol
@@ -154,7 +154,7 @@ private:
     @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
     @param Telemetry 16bit array where the read telemetry will be stored in.
     @param motorCount the count of motors that should get values send
-    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @param tlmRequest the requested telemetry type (telem_type::XXXXX)
     @return the telemetry request if telemetry was available, -1 if dont
 */
     int8_t ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
@@ -185,14 +185,13 @@ private:
     uint8_t _lastCRC;
     uint8_t _firstInitDone;
 
-
-    enum
+    enum return_type
     {
       OW_RETURN_RESPONSE,
       OW_RETURN_FULL_FRAME
     };
 
-    enum
+    enum msg_type
     {
       OW_OK,
       OW_BL_PAGE_CORRECT,   // BL only
@@ -250,16 +249,16 @@ private:
 
     };
 
-    enum
+    enum telem_type
     {
-      OW_TLM_TEMP,
-      OW_TLM_VOLT,
-      OW_TLM_CURRENT,
-      OW_TLM_ERPM,
-      OW_TLM_CONSUMPTION,
-      OW_TLM_DEBUG1,
-      OW_TLM_DEBUG2,
-      OW_TLM_DEBUG3
+      TEMP,
+      VOLT,
+      CURRENT,
+      ERPM,
+      CONSUMPTION,
+      DEBUG1,
+      DEBUG2,
+      DEBUG3
     };
 
     /// presistent scan state data (only used inside ScanESCs() function)

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -34,139 +34,131 @@ class AP_FETtecOneWire {
 public:
     AP_FETtecOneWire();
 
-    /* Do not allow copies */
+    /// Do not allow copies
     AP_FETtecOneWire(const AP_FETtecOneWire &other) = delete;
     AP_FETtecOneWire &operator=(const AP_FETtecOneWire&) = delete;
 
     static const struct AP_Param::GroupInfo var_info[];
 
     void update();
-    void send_esc_telemetry_mavlink(uint8_t mav_chan);
+    void send_esc_telemetry_mavlink(uint8_t mav_chan) const;
     static AP_FETtecOneWire *get_singleton() {
         return _singleton;
     }
 private:
     void init();
     static AP_FETtecOneWire *_singleton;
-    bool initialised;
+    bool _initialised;
     AP_HAL::UARTDriver *_uart;
     AP_Int32 motor_mask;
 
-    uint32_t last_send_us;
-    uint32_t last_log_ms;
+    uint32_t _last_send_us;
+    uint32_t _last_log_ms;
     static constexpr uint32_t DELAY_TIME_US = 700;
-    static constexpr uint8_t DETECT_ESC_COUNT = 4;  // TODO needed ?
-    static constexpr uint8_t MOTOR_COUNT_MAX = 8;
-    int8_t TelemetryAvailable = -1;
-    uint16_t completeTelemetry[MOTOR_COUNT_MAX][6] = {0};
-    uint16_t motorpwm[MOTOR_COUNT_MAX] = {1000};
-    uint8_t TLM_request = 0;
-    /*
+    static constexpr uint8_t MOTOR_COUNT_MAX = 12; /// OneWire supports up-to 25 ESCs, but Ardupilot only supports 12
+    int8_t _telem_avail = -1;
+    /// contains 6 fields per ESC:
+    ///  - _telemetry[i][0] -> temperature[idx]
+    ///  - _telemetry[i][1] -> voltage[idx]
+    ///  - _telemetry[i][2] -> current[idx]
+    ///  - _telemetry[i][3] -> rpm[idx]
+    ///  - _telemetry[i][4] -> totalcurrent[idx]
+    ///  - _telemetry[i][5] -> count[idx]
+    uint16_t _telemetry[MOTOR_COUNT_MAX][6] = {0};
+    uint16_t _motorpwm[MOTOR_COUNT_MAX] = {1000};
+    uint8_t _telem_req_type; /// the requested telemetry type (OW_TLM_XXXXX)
+
+/**
     initialize FETtecOneWire protocol
 */
-    void FETtecOneWire_Init(void);
+    void Init();
 
-/*
+/**
     deinitialize FETtecOneWire protocol
+    TODO: remove it? it is not used anywhere
 */
-    void FETtecOneWire_DeInit(void);
+    void DeInit();
 
-/*
+/**
     generates used 8 bit CRC
-    crc = byte to be added to CRC
-    crc_seed = CRC where it gets added too
-    returns 8 bit CRC
+    @param crc byte to be added to CRC
+    @param crc_seed CRC where it gets added too
+    @return 8 bit CRC
 */
-    uint8_t FETtecOneWire_Update_crc8(uint8_t crc, uint8_t crc_seed);
+    uint8_t Update_crc8(uint8_t crc, uint8_t crc_seed) const;
 
-/*
+/**
     generates used 8 bit CRC for arrays
-    Buf = 8 bit byte array
-    BufLen = count of bytes that should be used for CRC calculation
-    returns 8 bit CRC
+    @param Buf 8 bit byte array
+    @param BufLen count of bytes that should be used for CRC calculation
+    @return 8 bit CRC
 */
-    uint8_t FETtecOneWire_Get_crc8(uint8_t *Buf, uint16_t BufLen);
+    uint8_t Get_crc8(uint8_t *Buf, uint16_t BufLen) const;
 
-/*
+/**
     transmitts a FETtecOneWire frame to a ESC
-    ESC_id = id of the ESC
-    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
-    Length = length of the Bytes array
-    returns nothing
+    @param ESC_id id of the ESC
+    @param Bytes  8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    @param Length length of the Bytes array
 */
-    void FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t *Bytes, uint8_t Length);
+    void Transmit(uint8_t ESC_id, uint8_t *Bytes, uint8_t Length);
 
-/*
+/**
     reads the answer frame of a ESC
-    Bytes = 8 bit byte array, where the received answer gets stored in
-    Length = the expected answer length
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the expected answer frame was there, 0 if dont
+    @param Bytes 8 bit byte array, where the received answer gets stored in
+    @param Length the expected answer length
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the expected answer frame was there, 0 if dont
 */
-    uint8_t FETtecOneWire_Receive(uint8_t *Bytes, uint8_t Length, uint8_t returnFullFrame);
+    uint8_t Receive(uint8_t *Bytes, uint8_t Length, uint8_t returnFullFrame);
 
-/*
-    makes all connected ESC's beep
-    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
-*/
-    void FETtecOneWire_Beep(uint8_t beepFreqency);
-
-/*
-    sets the racewire color for all ESC's
-    R, G, B = 8bit colors
-*/
-    void FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B);
-
-/*
+/**
     Resets a pending pull request
-    returns nothing
 */
-    void FETtecOneWire_PullReset(void);
+    void PullReset();
 
-/*
+/**
     Pulls a complete request between for ESC
-    ESC_id = id of the ESC
-    command = 8bit array containing the command that thould be send including the possible payload
-    response = 8bit array where the response will be stored in
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the request is completed, 0 if dont
+    @param ESC_id id of the ESC
+    @param command 8bit array containing the command that should be send including the possible payload
+    @param response 8bit array where the response will be stored in
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the request is completed, 0 if dont
 */
-    uint8_t FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t *command, uint8_t *response, uint8_t returnFullFrame);
+    uint8_t PullCommand(uint8_t ESC_id, uint8_t *command, uint8_t *response, uint8_t returnFullFrame);
 
-/*
-    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
-    returns the current scanned ID
+/**
+    scans for ESCs in bus. should be called until _ScanActive >= MOTOR_COUNT_MAX
+    @return the current scanned ID
 */
-    uint8_t FETtecOneWire_ScanESCs(void);
+    uint8_t ScanESCs();
 
-/*
-    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
-    returns the current used ID
+/**
+    starts all ESCs in bus and prepares them for receiving teh fast throttle command should be called until _SetupActive >= MOTOR_COUNT_MAX
+    @return the current used ID
 */
-    uint8_t FETtecOneWire_InitESCs(void);
+    uint8_t InitESCs();
 
-/*
+/**
     checks if the requested telemetry is available.
-    Telemetry = 16bit array where the read Telemetry will be stored in.
-    returns the telemetry request number or -1 if unavailable
+    @param Telemetry 16bit array where the read Telemetry will be stored in.
+    @param return the telemetry request number or -1 if unavailable
 */
-    int8_t FETtecOneWire_CheckForTLM(uint16_t *Telemetry);
+    int8_t CheckForTLM(uint16_t *Telemetry);
 
-/*
+/**
     does almost all of the job.
-    scans for ESC's if not already done.
-    initializes the ESC's if not already done.
+    scans for ESCs if not already done.
+    initializes the ESCs if not already done.
     sends fast throttle signals if init is complete.
-    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
-    Telemetry = 16bit array where the read telemetry will be stored in.
-    motorCount = the count of motors that should get values send
-    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
-    returns the telemetry request if telemetry was available, -1 if dont
+    @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    @param Telemetry 16bit array where the read telemetry will be stored in.
+    @param motorCount the count of motors that should get values send
+    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @return the telemetry request if telemetry was available, -1 if dont
 */
-    int8_t FETtecOneWire_ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
+    int8_t ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
 
-    uint8_t FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed);  //TODO remove
-    uint8_t FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen);
     static constexpr uint8_t ALL_ID = 0x1F;
     typedef struct FETtecOneWireESC
     {
@@ -177,21 +169,21 @@ private:
       uint8_t serialNumber[12];
     } FETtecOneWireESC_t;
 
-    uint8_t FETtecOneWire_activeESC_IDs[25] = {0};
-    FETtecOneWireESC_t FETtecOneWire_foundESCs[25];
-    uint8_t FETtecOneWire_FoundESCs = 0;
-    uint8_t FETtecOneWire_ScanActive = 0;
-    uint8_t FETtecOneWire_SetupActive = 0;
-    uint8_t FETtecOneWire_IgnoreOwnBytes = 0;
-    int8_t FETtecOneWire_minID = 25;
-    int8_t FETtecOneWire_maxID = 0;
-    uint8_t FETtecOneWire_IDcount = 0;
-    uint8_t FETtecOneWire_FastThrottleByteCount = 0;
-    uint8_t FETtecOneWire_PullSuccess = 0;
-    uint8_t FETtecOneWire_PullBusy = 0;
-    uint8_t FETtecOneWire_TLM_request = 0;
-    uint8_t FETtecOneWire_lastCRC = 0;
-    uint8_t FETtecOneWire_firstInitDone = 0;
+    uint8_t _activeESC_IDs[MOTOR_COUNT_MAX] = {0};
+    FETtecOneWireESC_t _foundESCs[MOTOR_COUNT_MAX];
+    uint8_t _FoundESCs;
+    uint8_t _ScanActive;
+    uint8_t _SetupActive;
+    uint8_t _IgnoreOwnBytes;
+    int8_t _minID = MOTOR_COUNT_MAX;
+    int8_t _maxID;
+    uint8_t _IDcount;
+    uint8_t _FastThrottleByteCount;
+    uint8_t _PullSuccess;
+    uint8_t _PullBusy;
+    uint8_t _TLM_request;
+    uint8_t _lastCRC;
+    uint8_t _firstInitDone;
 
 
     enum
@@ -269,6 +261,30 @@ private:
       OW_TLM_DEBUG2,
       OW_TLM_DEBUG3
     };
+
+    /// presistent scan state data (only used inside ScanESCs() function)
+    struct scan_state
+    {
+      uint16_t delayLoops = 500;
+      uint8_t scanID = 0;
+      uint8_t scanState = 0;
+      uint8_t scanTimeOut = 0;
+    } _ss;
+
+    /// presistent init state data (only used inside InitESCs() function)
+    struct init_state
+    {
+      uint8_t delayLoops = 0;
+      uint8_t activeID = 1;
+      uint8_t State = 0;
+      uint8_t TimeOut = 0;
+      uint8_t wakeFromBL = 1;
+      uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
+    } _is;
+
+    uint8_t _ResponseLength[54];
+    uint8_t _RequestLength[54];
+
 };
 #endif // HAL_AP_FETTECONEWIRE_ENABLED
 

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -200,53 +200,10 @@ private:
       OW_BL_PAGES_TO_FLASH, // BL only
       OW_REQ_TYPE,
       OW_REQ_SN,
-      OW_REQ_SW_VER
-    };
-
-    enum
-    {
-      OW_RESET_TO_BL = 10,
-      OW_THROTTLE = 11,
-      OW_REQ_TLM = 12,
+      OW_REQ_SW_VER,
       OW_BEEP = 13,
-
       OW_SET_FAST_COM_LENGTH = 26,
-
-      OW_GET_ROTATION_DIRECTION = 28,
-      OW_SET_ROTATION_DIRECTION = 29,
-
-      OW_GET_USE_SIN_START = 30,
-      OW_SET_USE_SIN_START = 31,
-
-      OW_GET_3D_MODE = 32,
-      OW_SET_3D_MODE = 33,
-
-      OW_GET_ID = 34,
-      OW_SET_ID = 35,
-
-/*
-    OW_GET_LINEAR_THRUST = 36,
-    OW_SET_LINEAR_THRUST = 37,
-*/
-
-      OW_GET_EEVER = 38,
-
-      OW_GET_PWM_MIN = 39,
-      OW_SET_PWM_MIN = 40,
-
-      OW_GET_PWM_MAX = 41,
-      OW_SET_PWM_MAX = 42,
-
-      OW_GET_ESC_BEEP = 43,
-      OW_SET_ESC_BEEP = 44,
-
-      OW_GET_CURRENT_CALIB = 45,
-      OW_SET_CURRENT_CALIB = 46,
-
       OW_SET_LED_TMP_COLOR = 51,
-      OW_GET_LED_COLOR = 52,
-      OW_SET_LED_COLOR = 53
-
     };
 
     enum telem_type

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -200,10 +200,53 @@ private:
       OW_BL_PAGES_TO_FLASH, // BL only
       OW_REQ_TYPE,
       OW_REQ_SN,
-      OW_REQ_SW_VER,
+      OW_REQ_SW_VER
+    };
+
+    enum
+    {
+      OW_RESET_TO_BL = 10,
+      OW_THROTTLE = 11,
+      OW_REQ_TLM = 12,
       OW_BEEP = 13,
+
       OW_SET_FAST_COM_LENGTH = 26,
+
+      OW_GET_ROTATION_DIRECTION = 28,
+      OW_SET_ROTATION_DIRECTION = 29,
+
+      OW_GET_USE_SIN_START = 30,
+      OW_SET_USE_SIN_START = 31,
+
+      OW_GET_3D_MODE = 32,
+      OW_SET_3D_MODE = 33,
+
+      OW_GET_ID = 34,
+      OW_SET_ID = 35,
+
+/*
+    OW_GET_LINEAR_THRUST = 36,
+    OW_SET_LINEAR_THRUST = 37,
+*/
+
+      OW_GET_EEVER = 38,
+
+      OW_GET_PWM_MIN = 39,
+      OW_SET_PWM_MIN = 40,
+
+      OW_GET_PWM_MAX = 41,
+      OW_SET_PWM_MAX = 42,
+
+      OW_GET_ESC_BEEP = 43,
+      OW_SET_ESC_BEEP = 44,
+
+      OW_GET_CURRENT_CALIB = 45,
+      OW_SET_CURRENT_CALIB = 46,
+
       OW_SET_LED_TMP_COLOR = 51,
+      OW_GET_LED_COLOR = 52,
+      OW_SET_LED_COLOR = 53
+
     };
 
     enum telem_type

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -1,0 +1,102 @@
+==============
+FETtec OneWire
+==============
+
+This is a half duplex serial protocol with a 2Mbit/s Baudrate created by Felix Niessen (former Flyduino KISS developer) from `FETtec <https://fettec.net/>`_.
+
+
+Ardupilot to ESC protocol
+=========================
+
+How many bytes per message?
+Which CRC? What proprieties has this CRC?
+How many ESCs are supported? At which Rate?
+What is the pause time between messages?
+What can we configure in the ESCs?
+What is the signal resolution?
+Can the motors rotate in both directions? How is that done ?
+
+ESC to Ardupilot protocol
+=========================
+
+How many bytes per message?
+Which CRC? What proprieties has this CRC?
+
+It supports ESC telemetry, so information from the ESC status can be sent back to the autopilot:
+
+- Electronic rotations per minute (RPM) (must be divided by number of motor poles to translate to propeller RPM)
+- Input voltage (V)
+- Current draw (A)
+- Power consumption (W)
+- Temperature (°C)
+
+At which Rate?
+
+This information allows the autopilot to:
+
+- dynamically change the center frequency of the notch filters used to reduce frame vibration noise in the gyros
+- log the status of each ESC to the SDCard or internal Flash, for post flight analysis
+- send the status of each ESC to the Ground Station or companion computer for real-time monitoring
+
+
+Extra features
+==============
+
+The ESC can beep and have lights. To control this you must add this code snippet to the header file:
+
+```
+public:
+/**
+    makes all connected ESCs beep
+    @param beepFrequency a 8 bit value from 0-255. higher make a higher beep
+*/
+    void Beep(uint8_t beepFrequency);
+
+/**
+    sets the racewire color for all ESCs
+    R, G, B = 8bit colors
+*/
+    void RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B);
+```
+
+And this code snippet to the .cpp file:
+
+```
+/**
+    makes all connected ESCs beep
+    @param beepFrequency a 8 bit value from 0-255. higher make a higher beep
+*/
+void AP_FETtecOneWire::Beep(uint8_t beepFrequency)
+{
+    if (_IDcount > 0) {
+        uint8_t request[2] = {OW_BEEP, beepFrequency};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = _minID; i < _maxID + 1; i++) {
+            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
+            _uart->write(spacer, 2);
+            _IgnoreOwnBytes += 2;
+        }
+    }
+}
+
+/**
+    sets the racewire color for all ESCs
+    @param R red brightness
+    @param G green brightness
+    @param B blue brightness
+*/
+void AP_FETtecOneWire::RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
+{
+    if (_IDcount > 0) {
+        uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = _minID; i < _maxID + 1; i++) {
+            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
+            _uart->write(spacer, 2);
+            _IgnoreOwnBytes += 2;
+        }
+    }
+}
+```

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -9,35 +9,66 @@ Ardupilot to ESC protocol
 =========================
 
 How many bytes per message?
+There are two types of messages:
+	- Configuration message consists of six frame bytes + payload bytes.
+	Byte 0 is the transfer direction(e.g. 0x01 Master to Slave)
+	Byte 1 is the ID
+	Byte 2 is the frame type (Low byte)
+	Byte 3 is the frame type (High byte)
+	Byte 4 is the frame length
+	Byte 5-254 is the payload
+	Byte 6-255 is CRC (last Byte after the Payload)
+	
+	- Fast Throttle Signal
+	The signal is used to transfer the eleven bit throttle signals with as few bytes as possible
+	The structure is a bit more complex. In the first two bytes are frame header and telemetry request as well as the first parts of the throttle
+	signal. The following bytes are transmitting the throttle signals for the ESCs (11bit per ESC) followed by the CRC. 
+	
+	If telemetry is requested the ESCs will answer them in the ESC-ID order. See comments in onewire.c for details.
+	
 Which CRC? What proprieties has this CRC?
-How many ESCs are supported? At which Rate?
-What is the pause time between messages?
-What can we configure in the ESCs?
-What is the signal resolution?
-Can the motors rotate in both directions? How is that done ?
+	The CRC is a well known bytewise 8bit CRC not bitwise as DSHOT is. 
 
+
+How many ESCs are supported? At which Rate?
+	Four ESCs need 90uS for the throttle request and telemetry receiption. With four ESCs 11kHz are possible. As each additional ESC adds 11bits
+	and 16 telemetry bits the rate is lowered by each ESC. 
+	
+	8 ESCs need 160uS including telemetry response, so 5.8kHz are possible. 
+	
+	
+What is the pause time between messages?
+	250ms then the Motors will disarm.
+	
+What can we configure in the ESCs?
+	Every setting that the ESCs offer. The FETtec configurator uses OneWire too. Even the firmware updater bootloader uses onewire. 
+	
+What is the signal resolution?
+	11bits per throttle signal, 16 bits per telemetry type.
+	
+Can the motors rotate in both directions? How is that done ?
+	yes this is standard. (1020-2000 is throttle forward, 980-0 is throttle backward)
+	
+	
 ESC to Ardupilot protocol
 =========================
 
-How many bytes per message?
-Which CRC? What proprieties has this CRC?
-
 It supports ESC telemetry, so information from the ESC status can be sent back to the autopilot:
 
-- Electronic rotations per minute (RPM) (must be divided by number of motor poles to translate to propeller RPM)
-- Input voltage (V)
-- Current draw (A)
-- Power consumption (W)
+- Electronic rotations per minute (eRPM) (must be divided by number of motor poles to translate to propeller RPM)
+- Input voltage (V/10)
+- Current draw (A/10)
+- Power consumption (mAh)
 - Temperature (°C)
 
 At which Rate?
-
+ As described above. 
 This information allows the autopilot to:
 
 - dynamically change the center frequency of the notch filters used to reduce frame vibration noise in the gyros
 - log the status of each ESC to the SDCard or internal Flash, for post flight analysis
 - send the status of each ESC to the Ground Station or companion computer for real-time monitoring
-
+- 
 
 Extra features
 ==============
@@ -100,3 +131,15 @@ void AP_FETtecOneWire::RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
     }
 }
 ```
+
+Connection and Halfduplex with STM
+==================================
+Normally halfduplex can be used for the communication. 
+To have reliable 2Mbit/s Baudrate the GPIO should be set to PushPull.
+On STM it is a special mode that is initialized like:
+
+gpioInit.mode = LL_GPIO_MODE_ALTERNATE;
+gpioInit.Pull = LL_GPIO_MODE_ALTERNATE;
+gpio.Pull = LL_GPIO_PULL_UP;
+gpioInit.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+gpioInit.Alternate = LL_GPIO_AF_1;

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -143,3 +143,37 @@ gpioInit.Pull = LL_GPIO_MODE_ALTERNATE;
 gpio.Pull = LL_GPIO_PULL_UP;
 gpioInit.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
 gpioInit.Alternate = LL_GPIO_AF_1;
+
+
+
+FullDuplex with Diode
+==================================
+If halfduplex is not available or working there is a workaround with a diode using the normal full duplex.
+This is also working with other "non-halfduplex" Controller like ESP32.
+
+The TLM-Pin (ESC) and RX (FC) connects to the anode (black side) of the diode.
+TX (FC) connects to cathode (white striped side) of the diode.
+
+ (TX --|<-- RX, TLM)
+ 
+ 
+OneWire Configuration:
+==================================
+This settings have to be changed under CONFIG -> Full Parameter List to get it working.
+MOT_PWM_MAX 2000
+MOT_PWM_MIN 1000
+Serial2_OPTIONS 160 #FOR full duplex - Use with diode
+Serial2_OPTIONS 164 #FOR half duplex - Use without diode -> TX from FC to TLM of FETtec ESC
+
+#FOR QUADCOPTER -> Sum of binary values
+SERVO_FTW_MASK 15 
+MOTOR 		1 | 2 | 3 | 4 | 5 | 6  ...
+BIN VAL	1 | 2 | 4 | 8 | 16| 32 ...
+ACTIV		X | X | X | X | 0 | 0  ...
+SUM     	1 + 2 + 4 + 8 = 15
+
+SERVO1_FUNCTION 33
+SERVO2_FUNCTION 34
+SERVO*_FUNCTION 33-38
+
+To change the motor direction change the SERVO*_FUNCTIONS

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -168,12 +168,13 @@ Serial2_OPTIONS 164 #FOR half duplex - Use without diode -> TX from FC to TLM of
 #FOR QUADCOPTER -> Sum of binary values
 SERVO_FTW_MASK 15 
 MOTOR 		1 | 2 | 3 | 4 | 5 | 6  ...
-BIN VAL	1 | 2 | 4 | 8 | 16| 32 ...
+BIN VAL	    1 | 2 | 4 | 8 | 16| 32 ...
 ACTIV		X | X | X | X | 0 | 0  ...
 SUM     	1 + 2 + 4 + 8 = 15
 
+Change SERVO*_FUNCTION to 33-38 according to the needed motor order e.g.:
 SERVO1_FUNCTION 33
 SERVO2_FUNCTION 34
-SERVO*_FUNCTION 33-38
+SERVO3_FUNCTION 35
+SERVO4_FUNCTION 36
 
-To change the motor direction change the SERVO*_FUNCTIONS

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -103,7 +103,7 @@ void AP_FETtecOneWire::Beep(uint8_t beepFrequency)
         uint8_t request[2] = {OW_BEEP, beepFrequency};
         uint8_t spacer[2] = {0, 0};
         for (uint8_t i = _minID; i < _maxID + 1; i++) {
-            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            Transmit(i, request, _RequestLength[request[0]]);
             // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
             _uart->write(spacer, 2);
             _IgnoreOwnBytes += 2;
@@ -123,7 +123,7 @@ void AP_FETtecOneWire::RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
         uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
         uint8_t spacer[2] = {0, 0};
         for (uint8_t i = _minID; i < _maxID + 1; i++) {
-            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            Transmit(i, request, _RequestLength[request[0]]);
             // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
             _uart->write(spacer, 2);
             _IgnoreOwnBytes += 2;

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36: AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36: AHRS, 37: SmartAudio, 38: FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink2),
@@ -144,7 +144,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SERIAL2_PROTOCOL),
@@ -161,7 +161,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SERIAL3_PROTOCOL),
@@ -178,7 +178,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SERIAL4_PROTOCOL),
@@ -195,7 +195,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
@@ -214,7 +214,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 6_PROTOCOL
     // @DisplayName: Serial6 protocol selection
     // @Description: Control what protocol Serial6 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("6_PROTOCOL",  12, AP_SerialManager, state[6].protocol, SERIAL6_PROTOCOL),
@@ -313,7 +313,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 7_PROTOCOL
     // @DisplayName: Serial7 protocol selection
     // @Description: Control what protocol Serial7 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("7_PROTOCOL",  23, AP_SerialManager, state[7].protocol, SERIAL7_PROTOCOL),
@@ -338,7 +338,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 8_PROTOCOL
     // @DisplayName: Serial8 protocol selection
     // @Description: Control what protocol Serial8 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtechOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("8_PROTOCOL",  26, AP_SerialManager, state[8].protocol, SERIAL8_PROTOCOL),

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -151,6 +151,7 @@ public:
         SerialProtocol_ADSB = 35,
         SerialProtocol_AHRS = 36,
         SerialProtocol_SmartAudio = 37,
+        SerialProtocol_FETtechOneWire = 38,
         SerialProtocol_NumProtocols                    // must be the last value
     };
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4931,7 +4931,7 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
             }
         }
 #endif
-#ifdef HAL_AP_FETTECONEWIRE_ENABLED
+#if HAL_AP_FETTECONEWIRE_ENABLED
         CHECK_PAYLOAD_SIZE(ESC_TELEMETRY_1_TO_4);
         AP_FETtecOneWire *fetteconewire = AP_FETtecOneWire::get_singleton();
         if (fetteconewire) {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4931,6 +4931,13 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
             }
         }
 #endif
+#ifdef HAL_AP_FETTECONEWIRE_ENABLED
+        CHECK_PAYLOAD_SIZE(ESC_TELEMETRY_1_TO_4);
+        AP_FETtecOneWire *fetteconewire = AP_FETtecOneWire::get_singleton();
+        if (fetteconewire) {
+            fetteconewire->send_esc_telemetry_mavlink(uint8_t(chan));
+        }
+#endif
         break;
     }
 

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -20,6 +20,7 @@
 #include <AP_RobotisServo/AP_RobotisServo.h>
 #include <AP_SBusOut/AP_SBusOut.h>
 #include <AP_BLHeli/AP_BLHeli.h>
+#include <AP_FETtecOneWire/AP_FETtecOneWire.h>
 
 #if !defined(NUM_SERVO_CHANNELS) && defined(HAL_BUILD_AP_PERIPH) && defined(HAL_PWM_COUNT) && (HAL_PWM_COUNT >= 1)
     #define NUM_SERVO_CHANNELS HAL_PWM_COUNT
@@ -547,6 +548,11 @@ private:
     AP_BLHeli blheli;
     static AP_BLHeli *blheli_ptr;
 #endif
+
+#if HAL_AP_FETTECONEWIRE_ENABLED
+    AP_FETtecOneWire fettechonwire;
+    static AP_FETtecOneWire *fettechonwire_ptr;
+#endif  // HAL_AP_FETTECONEWIRE_ENABLED
 #endif // HAL_BUILD_AP_PERIPH
 
     static uint16_t disabled_mask;

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -43,6 +43,7 @@ SRV_Channels *SRV_Channels::_singleton;
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
 AP_SBusOut *SRV_Channels::sbus_ptr;
 AP_RobotisServo *SRV_Channels::robotis_ptr;
+AP_FETtecOneWire *SRV_Channels::fettechonwire_ptr;
 #endif // HAL_BUILD_AP_PERIPH
 
 uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
@@ -193,6 +194,10 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Group: _ROB_
     // @Path: ../AP_RobotisServo/AP_RobotisServo.cpp
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
+
+    // @Group: _FTW_
+    // @Path: ../AP_FETtecOneWire/AP_FETtecOneWire.cpp
+    AP_SUBGROUPINFO(fettechonwire, "_FTW_",  23, SRV_Channels, AP_FETtecOneWire),
 #endif // HAL_BUILD_AP_PERIPH
 
     AP_GROUPEND
@@ -218,6 +223,7 @@ SRV_Channels::SRV_Channels(void)
     volz_ptr = &volz;
     sbus_ptr = &sbus;
     robotis_ptr = &robotis;
+    fettechonwire_ptr = &fettechonwire;
 #if HAL_SUPPORT_RCOUT_SERIAL
     blheli_ptr = &blheli;
 #endif
@@ -315,7 +321,8 @@ void SRV_Channels::push()
 
     // give robotis library a chance to update
     robotis_ptr->update();
-    
+
+    fettechonwire_ptr->update();
 #if HAL_SUPPORT_RCOUT_SERIAL
     // give blheli telemetry a chance to update
     blheli_ptr->update_telemetry();

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -43,7 +43,9 @@ SRV_Channels *SRV_Channels::_singleton;
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
 AP_SBusOut *SRV_Channels::sbus_ptr;
 AP_RobotisServo *SRV_Channels::robotis_ptr;
+#if HAL_AP_FETTECONEWIRE_ENABLED
 AP_FETtecOneWire *SRV_Channels::fettechonwire_ptr;
+#endif
 #endif // HAL_BUILD_AP_PERIPH
 
 uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
@@ -195,9 +197,12 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Path: ../AP_RobotisServo/AP_RobotisServo.cpp
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
 
+#if HAL_AP_FETTECONEWIRE_ENABLED
     // @Group: _FTW_
     // @Path: ../AP_FETtecOneWire/AP_FETtecOneWire.cpp
     AP_SUBGROUPINFO(fettechonwire, "_FTW_",  23, SRV_Channels, AP_FETtecOneWire),
+#endif
+
 #endif // HAL_BUILD_AP_PERIPH
 
     AP_GROUPEND
@@ -223,7 +228,9 @@ SRV_Channels::SRV_Channels(void)
     volz_ptr = &volz;
     sbus_ptr = &sbus;
     robotis_ptr = &robotis;
+#if HAL_AP_FETTECONEWIRE_ENABLED
     fettechonwire_ptr = &fettechonwire;
+#endif
 #if HAL_SUPPORT_RCOUT_SERIAL
     blheli_ptr = &blheli;
 #endif
@@ -322,7 +329,10 @@ void SRV_Channels::push()
     // give robotis library a chance to update
     robotis_ptr->update();
 
+#if HAL_AP_FETTECONEWIRE_ENABLED
     fettechonwire_ptr->update();
+#endif
+
 #if HAL_SUPPORT_RCOUT_SERIAL
     // give blheli telemetry a chance to update
     blheli_ptr->update_telemetry();


### PR DESCRIPTION
This is a 2Mbaud UART based bi-directional protocol.
The initial code version was provided directly by FETtec

I need some help integrating this because there is no UART based ESCs that I know of.
The protocol supports up-to 25 ESC using a single UART and a single wire.

FETtec will provide hardware to anyone willing to help on this one.
