### PR TITLE
AP_SerialManager: default serial1 and serial2 protocols to MAVLink2

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/DrotekP3Pro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DrotekP3Pro/hwdef.dat
@@ -239,7 +239,7 @@ define HAL_BATT_VOLT_SCALE 10.1
 define HAL_BATT_CURR_SCALE 17.0
 
 # setup serial port defaults for ESP8266
-define HAL_SERIAL5_PROTOCOL SerialProtocol_MAVLink
+define HAL_SERIAL5_PROTOCOL SerialProtocol_MAVLink2
 define HAL_SERIAL5_BAUD 921600
 
 # 8 PWM available by default

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
@@ -207,7 +207,7 @@ define HAL_BATT_VOLT_SCALE 10.1
 define HAL_BATT_CURR_SCALE 17.0
 
 # setup serial port defaults for ESP8266
-define HAL_SERIAL5_PROTOCOL SerialProtocol_MAVLink
+define HAL_SERIAL5_PROTOCOL SerialProtocol_MAVLink2
 define HAL_SERIAL5_BAUD 921600
 
 # 6 PWM available by default

--- a/libraries/AP_HAL_ChibiOS/hwdef/luminousbee4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/luminousbee4/hwdef.dat
@@ -169,7 +169,7 @@ define HAL_BATT_VOLT_SCALE 10.1
 define HAL_BATT_CURR_SCALE 17.0
 
 # setup serial port defaults for ESP8266
-define HAL_SERIAL5_PROTOCOL SerialProtocol_MAVLink
+define HAL_SERIAL5_PROTOCOL SerialProtocol_MAVLink2
 define HAL_SERIAL5_BAUD 921600
 
 # 6 PWM available by default

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -30,7 +30,7 @@ extern const AP_HAL::HAL& hal;
 #ifdef HAL_SERIAL2_PROTOCOL
 #define SERIAL2_PROTOCOL HAL_SERIAL2_PROTOCOL
 #else
-#define SERIAL2_PROTOCOL SerialProtocol_MAVLink
+#define SERIAL2_PROTOCOL SerialProtocol_MAVLink2
 #endif
 
 #ifndef HAL_SERIAL3_PROTOCOL
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting
     // @User: Standard
     // @RebootRequired: True
-    AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink),
+    AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink2),
 
     // @Param: 1_BAUD
     // @DisplayName: Telem1 Baud Rate


### PR DESCRIPTION
This changes the default protocol for serial1 and serial2 to MAVLink2 for all boards.  It also updates the hwdef files for 3 other boards so their Serial5 ports are also MAVLink2.

We've discussed making this change a few times in the past.  The downside is that there are probably some radios out there which don't support MAVLink2 that will have problems.  On the otherhand we have a growing number of problems caused by not defaulting to MAVLink2.  A recent example is a user struggling with Copter/Rover complex fences which require MAVLink2 (https://github.com/ArduPilot/MissionPlanner/issues/2285)

I've added the DevCallTopic because we probably need to decide what level of testing is required before this can be merged.
