### PR TITLE
AP_ToshibaCAN: correct rpm reporting

### DIFF
--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -310,7 +310,7 @@ void AP_ToshibaCAN::loop()
                     const uint8_t esc_id = recv_frame.id - MOTOR_DATA1;
                     if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
                         WITH_SEMAPHORE(_telem_sem);
-                        _telemetry[esc_id].rpm = be16toh(reply_data.rpm);
+                        _telemetry[esc_id].rpm = (int16_t)be16toh(reply_data.rpm);
                         _telemetry[esc_id].current_ca = MAX((int16_t)be16toh(reply_data.current_ma), 0) * (4.0f * 0.1f);    // milli-amps to centi-amps
                         _telemetry[esc_id].voltage_cv = be16toh(reply_data.voltage_mv) * 0.1f;  // millivolts to centi-volts
                         _telemetry[esc_id].count++;
@@ -532,7 +532,7 @@ void AP_ToshibaCAN::send_esc_telemetry_mavlink(uint8_t mav_chan)
                 voltage[j] = _telemetry[esc_id].voltage_cv;
                 current[j] = _telemetry[esc_id].current_ca;
                 current_tot[j] = constrain_float(_telemetry[esc_id].current_tot_mah, 0, UINT16_MAX);
-                rpm[j] = _telemetry[esc_id].rpm;
+                rpm[j] = abs(_telemetry[esc_id].rpm);   // mavlink message only accepts positive rpm values
                 count[j] = _telemetry[esc_id].count;
             }
 

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -154,8 +154,9 @@ private:
     // structure for replies from ESC of data1 (rpm and voltage)
     union motor_reply_data1_t {
         struct PACKED {
-            uint8_t rxng:1;
-            uint8_t state:7;
+            uint8_t rxng:1;         // RX No Good. "1" if ESC encountered error receiving a message since MOTOR_DATA1 was last sent
+            uint8_t stepout:1;      // "1" if a "step out" has occured since MOTOR_DATA1 was last sent
+            uint8_t state:6;
             int16_t rpm;
             uint16_t current_ma;    // current in milliamps
             uint16_t voltage_mv;    // voltage in millivolts

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -78,7 +78,7 @@ private:
     // telemetry data (rpm, voltage)
     HAL_Semaphore _telem_sem;
     struct telemetry_info_t {
-        uint16_t rpm;               // rpm
+        int16_t rpm;                // rpm
         uint16_t voltage_cv;        // voltage in centi-volts
         uint16_t current_ca;        // current in centi-amps
         uint16_t esc_temp;          // esc temperature in degrees
@@ -156,7 +156,7 @@ private:
         struct PACKED {
             uint8_t rxng:1;
             uint8_t state:7;
-            uint16_t rpm;
+            int16_t rpm;
             uint16_t current_ma;    // current in milliamps
             uint16_t voltage_mv;    // voltage in millivolts
             uint8_t position_est_error;


### PR DESCRIPTION
This PR corrects the consumption of the rpm value from the ToshibaCAN ESCs ([wiki](https://ardupilot.org/copter/docs/common-toshiba-can-escs.html)).  In particular the returned rpm value apparently includes a direction and rpm value where negative numbers mean the propeller is spinning in the wrong direction.  In general this only happens if something is going wrong with the ESC's control of the motor, for example if one of the three wires is disconnected.

Below is a screen shot of the before/after rpm value when a single motor wire was disconnected.  We can see that we lose the crazy ~65000 rpm values.

![tcan-rpm-before-after](https://user-images.githubusercontent.com/1498098/85819486-c70e0a00-b7ae-11ea-9d3c-9a062b855f30.png)
