### PR TITLE
AP_BoardConfig: Define a method class

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -205,6 +205,7 @@ private:
     bool spi_check_register(const char *devname, uint8_t regnum, uint8_t value, uint8_t read_flag = 0x80);
     void validate_board_type(void);
     void board_autodetect(void);
+    bool check_ms5611(const char* devname);
 
 #endif // AP_FEATURE_BOARD_DETECT
 

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -153,7 +153,7 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
 }
 
 #if defined(HAL_VALIDATE_BOARD)
-static bool check_ms5611(const char* devname) {
+bool AP_BoardConfig::check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
     if (!dev) {
 #if SPI_PROBE_DEBUG


### PR DESCRIPTION
Rework from https://github.com/ArduPilot/ardupilot/pull/14212
Tested on a cubeBlack with Cubeblack target and FMUV3 target. It works as expected, I have check by putting a panic at the end of check_ms5611(), the panic is triggered on Cubeblack but not FMUv3.

```
THIS PR
CUBEBLACK

BUILD SUMMARY
Build directory: /home/khancyr/Workspace/ardupilot/build/CubeBlack
Target               Text     Data  BSS     Total  
---------------------------------------------------
bin/antennatracker   1077632  1456  195368  1274456
bin/arducopter       1385980  1484  195348  1582812
bin/arducopter-heli  1367544  1484  195344  1564372
bin/arduplane        1394304  1472  195352  1591128
bin/ardusub          1221376  1496  195328  1418200
bin/ardurover        1248004  1468  195356  1444828



SITL

BUILD SUMMARY
Build directory: /home/khancyr/Workspace/ardupilot/build/sitl
Target               Text     Data    BSS    Total  
----------------------------------------------------
bin/antennatracker   1960068   76435  77408  2113911
bin/arducopter       2623176  110195  86336  2819707
bin/arducopter-heli  2581840  113267  86304  2781411
bin/arduplane        2614336  117147  85024  2816507
bin/ardusub          2272568   89291  80320  2442179
bin/ardurover        2353288  100379  81888  2535555


MASTER:
SITL
BUILD SUMMARY
Build directory: /home/khancyr/Workspace/ardupilot/build/sitl
Target               Text     Data    BSS    Total  
----------------------------------------------------
bin/antennatracker   1960068   76435  77408  2113911
bin/arducopter       2623176  110195  86336  2819707
bin/arducopter-heli  2581840  113267  86304  2781411
bin/arduplane        2614336  117147  85024  2816507
bin/ardusub          2272568   89291  80320  2442179
bin/ardurover        2353288  100379  81888  2535555


CUBEBLACK 

BUILD SUMMARY
Build directory: /home/khancyr/Workspace/ardupilot/build/CubeBlack
Target               Text     Data  BSS     Total  
---------------------------------------------------
bin/antennatracker   1077624  1456  195368  1274448
bin/arducopter       1385972  1484  195348  1582804
bin/arducopter-heli  1367536  1484  195344  1564364
bin/arduplane        1394296  1472  195352  1591120
bin/ardusub          1221368  1496  195328  1418192
bin/ardurover        1247996  1468  195356  1444820

```
I am unsure why on copter and sub, use 8 bytes more and on other target 8 bytes less ...