### PR TITLE
AP_Motors: implement EngineRunEnable servo output function for multcopters.

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -258,6 +258,9 @@ void AP_MotorsMulticopter::output()
 
     // output raw roll/pitch/yaw/thrust
     output_rpyt();
+
+    // Output armed state on servo outputs
+    output_armed_state();
 };
 
 // output booster throttle, if any
@@ -790,5 +793,17 @@ void AP_MotorsMulticopter::save_params_on_disarm()
     // save hover throttle
     if (_throttle_hover_learn == HOVER_LEARN_AND_SAVE) {
         _throttle_hover.save();
+    }
+}
+
+void AP_MotorsMulticopter::output_armed_state()
+{
+    if(armed())
+    {
+        SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::SRV_CHANNEL_LIMIT_MAX);
+    }
+    else
+    {
+        SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
     }
 }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -143,6 +143,9 @@ protected:
     // save parameters as part of disarming
     void                save_params_on_disarm() override;
 
+    // if configured, output arm/disarm state on servo outputs
+    void                output_armed_state();
+
     // enum values for HOVER_LEARN parameter
     enum HoverLearn {
         HOVER_LEARN_DISABLED = 0,

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -71,7 +71,7 @@ public:
         k_parachute_release     = 27,            ///< parachute release
         k_gripper               = 28,            ///< gripper
         k_landing_gear_control  = 29,            ///< landing gear controller
-        k_engine_run_enable     = 30,            ///< engine kill switch, used for gas airplanes and helicopters
+        k_engine_run_enable     = 30,            ///< Gas airplaines and helicopters: engine kill switch, Copter: monitor armed state
         k_heli_rsc              = 31,            ///< helicopter RSC output
         k_heli_tail_rsc         = 32,            ///< helicopter tail RSC output
         k_motor1                = 33,            ///< these allow remapping of copter motors


### PR DESCRIPTION
Implement the EngineRunEnable servo output function (SERVO<N>_FUNCTION == 30) for multicopters, which simply monitors the armed state.