### PR TITLE
Add quaternion support to SIM_JSON

### DIFF
--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -173,6 +173,15 @@ bool JSON::parse_sensors(const char *json)
                 break;
             }
 
+            case DATA_VECTOR4F: {
+                VECTOR4F *v = static_cast<VECTOR4F*>(key.ptr);
+                if (sscanf(p, "[%f, %f, %f, %f]", &(v->w), &(v->x), &(v->y), &(v->z)) != 4) {
+                    printf("Failed to parse Vector4f for %s/%s\n", key.section, key.key);
+                    return false;
+                }
+                break;
+            }
+
         }
     }
     return true;
@@ -236,7 +245,14 @@ void JSON::recv_fdm(const struct sitl_input &input)
                             state.position[1],
                             state.position[2]);
 
-    dcm.from_euler(state.attitude[0], state.attitude[1], state.attitude[2]);
+    // dcm.from_euler(state.attitude[0], state.attitude[1], state.attitude[2]);
+
+    Quaternion quat(static_cast<float>(state.attitudeQ.w),
+                    static_cast<float>(state.attitudeQ.x),
+                    static_cast<float>(state.attitudeQ.y),
+                    static_cast<float>(state.attitudeQ.z));
+    quat.rotation_matrix(dcm);
+
 
     // Convert from a meters from origin physics to a lat long alt
     update_position();

--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -19,6 +19,12 @@
 
 namespace SITL {
 
+struct vector4f
+{
+    float w,x,y,z;
+};
+typedef struct vector4f VECTOR4F;
+
 class JSON : public Aircraft {
 public:
     JSON(const char *frame_str);
@@ -68,6 +74,7 @@ private:
         DATA_FLOAT,
         DATA_DOUBLE,
         DATA_VECTOR3F,
+        DATA_VECTOR4F,
     };
 
     struct {
@@ -78,6 +85,7 @@ private:
         } imu;
         Vector3f position;
         Vector3f attitude;
+        VECTOR4F attitudeQ;
         Vector3f velocity;
     } state;
 
@@ -87,12 +95,13 @@ private:
         const char *key;
         void *ptr;
         enum data_type type;
-    } keytable[6] = {
+    } keytable[7] = {
         { "", "timestamp", &state.timestamp_s, DATA_DOUBLE },
         { "imu", "gyro",    &state.imu.gyro, DATA_VECTOR3F },
         { "imu", "accel_body", &state.imu.accel_body, DATA_VECTOR3F },
         { "", "position", &state.position, DATA_VECTOR3F },
         { "", "attitude", &state.attitude, DATA_VECTOR3F },
+        { "", "attitudeQ", &state.attitudeQ, DATA_VECTOR4F },
         { "", "velocity", &state.velocity, DATA_VECTOR3F },
     };
 };


### PR DESCRIPTION
I can't think of a nice way to get the parser to take either attitude or attitudeQ keys. Any suggestions?