### PR TITLE
autotest: increase delay allowed for receiving ACKs

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -2310,7 +2310,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress("Expecting mission ack")
         m = mav.recv_match(type='MISSION_ACK',
                            blocking=True,
-                           timeout=5)
+                           timeout=20)
         self.progress("Received ACK (%s)" % str(m))
         if m is None:
             raise NotAchievedException("Expected mission ACK")


### PR DESCRIPTION
No test is really wanting to know these are coming in fast