### PR TITLE
Backport of storage erase to Copter 4.0

### DIFF
--- a/libraries/AP_HAL/Storage.cpp
+++ b/libraries/AP_HAL/Storage.cpp
@@ -1,0 +1,17 @@
+#include "AP_HAL.h"
+#include "Storage.h"
+#include <AP_Math/AP_Math.h>
+
+/*
+  default erase method
+ */
+bool AP_HAL::Storage::erase(void)
+{
+    uint8_t blk[16] {};
+    uint32_t ofs;
+    for (ofs=0; ofs<HAL_STORAGE_SIZE; ofs += sizeof(blk)) {
+        uint32_t n = MIN(sizeof(blk), HAL_STORAGE_SIZE - ofs);
+        write_block(ofs, blk, n);
+    }
+    return true;
+}

--- a/libraries/AP_HAL/Storage.h
+++ b/libraries/AP_HAL/Storage.h
@@ -6,6 +6,7 @@
 class AP_HAL::Storage {
 public:
     virtual void init() = 0;
+    virtual bool erase();
     virtual void read_block(void *dst, uint16_t src, size_t n) = 0;
     virtual void write_block(uint16_t dst, const void* src, size_t n) = 0;
     virtual void _timer_tick(void) {};

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -380,4 +380,26 @@ bool Storage::healthy(void)
             (AP_HAL::millis() - _last_empty_ms < 2000u));
 }
 
+/*
+  erase all storage
+ */
+bool Storage::erase(void)
+{
+#if HAL_WITH_RAMTRON
+    if (_initialisedType == StorageBackend::FRAM) {
+        return AP_HAL::Storage::erase();
+    }
+#endif
+#ifdef USE_POSIX
+    if (_initialisedType == StorageBackend::SDCard) {
+        return AP_HAL::Storage::erase();
+    }
+#endif
+#ifdef STORAGE_FLASH_PAGE
+    return _flash.erase();
+#else
+    return false;
+#endif
+}
+
 #endif // HAL_USE_EMPTY_STORAGE

--- a/libraries/AP_HAL_ChibiOS/Storage.h
+++ b/libraries/AP_HAL_ChibiOS/Storage.h
@@ -40,6 +40,7 @@ static_assert(CH_STORAGE_SIZE % CH_STORAGE_LINE_SIZE == 0,
 class ChibiOS::Storage : public AP_HAL::Storage {
 public:
     void init() override {}
+    bool erase() override;
     void read_block(void *dst, uint16_t src, size_t n) override;
     void write_block(uint16_t dst, const void* src, size_t n) override;
 

--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -21,6 +21,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "StorageManager.h"
+#include <stdio.h>
 
 
 extern const AP_HAL::HAL& hal;
@@ -110,21 +111,9 @@ const StorageManager::StorageArea *StorageManager::layout = layout_default;
  */
 void StorageManager::erase(void)
 {
-    uint8_t blk[16];
-    memset(blk, 0, sizeof(blk));
-    for (uint8_t i=0; i<STORAGE_NUM_AREAS; i++) {
-        const StorageManager::StorageArea &area = StorageManager::layout[i];
-        uint16_t length = area.length;
-        uint16_t offset = area.offset;
-        for (uint16_t ofs=0; ofs<length; ofs += sizeof(blk)) {
-            uint8_t n = 16;
-            if (ofs + n > length) {
-                n = length - ofs;
-            }
-            hal.storage->write_block(offset + ofs, blk, n);
-        }
+    if (!hal.storage->erase()) {
+        ::printf("StorageManager: erase failed\n");
     }
-    
 }
 
 /*


### PR DESCRIPTION
Note that this is not essential for 4.0, as it did erase all storage areas already, including DNA areas, so the key change is that it fixes an issue with erasing the underlying sectors for boards that use AP_FlashStorage
