### PR TITLE
Support multiple barometers in SITL

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -573,10 +573,7 @@ void AP_Baro::init(void)
     if (sitl == nullptr) {
         AP_HAL::panic("No SITL pointer");
     }
-    if (sitl->baro_count > 1) {
-        ::fprintf(stderr, "More than one baro not supported.  Sorry.");
-    }
-    if (sitl->baro_count == 1) {
+    for(uint8_t i = 0; i < sitl->baro_count; i++) {
         ADD_BACKEND(new AP_Baro_SITL(*this));
     }
 #elif HAL_BARO_DEFAULT == HAL_BARO_HIL

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -54,16 +54,16 @@ void AP_Baro_SITL::_timer()
 
     float sim_alt = _sitl->state.altitude;
 
-    if (_sitl->baro_disable) {
+    if (_sitl->baro_disable[_instance]) {
         // barometer is disabled
         return;
     }
 
-    sim_alt += _sitl->baro_drift * now / 1000.0f;
-    sim_alt += _sitl->baro_noise * rand_float();
+    sim_alt += _sitl->baro_drift[_instance] * now / 1000.0f;
+    sim_alt += _sitl->baro_noise[_instance] * rand_float();
 
     // add baro glitch
-    sim_alt += _sitl->baro_glitch;
+    sim_alt += _sitl->baro_glitch[_instance];
 
     // add delay
     uint32_t best_time_delta = 200;  // initialise large time representing buffer entry closest to current time - delay.
@@ -116,6 +116,12 @@ void AP_Baro_SITL::_timer()
     _recent_press = p;
     _recent_temp = T;
     _has_sample = true;
+}
+
+// unhealthy if baro is turned off or beyond supported instances
+bool AP_Baro_SITL::healthy(uint8_t instance) 
+{
+    return !_sitl->baro_disable[instance];
 }
 
 // Read the sensor

--- a/libraries/AP_Baro/AP_Baro_SITL.h
+++ b/libraries/AP_Baro/AP_Baro_SITL.h
@@ -14,7 +14,7 @@ public:
 
 protected:
 
-    void update_healthy_flag(uint8_t instance) override { _frontend.sensors[instance].healthy = true; }
+    void update_healthy_flag(uint8_t instance) override { _frontend.sensors[instance].healthy = healthy(instance); };
 
 private:
     uint8_t _instance;
@@ -32,7 +32,10 @@ private:
 
     // adjust for simulated board temperature
     void temperature_adjustment(float &p, float &T);
-
+    
+    // is the barometer usable for flight 
+    bool healthy(uint8_t instance);
+    
     void _timer();
     bool _has_sample;
     uint32_t _last_sample_time;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -35,7 +35,7 @@ SITL *SITL::_singleton = nullptr;
 
 // table of user settable parameters
 const AP_Param::GroupInfo SITL::var_info[] = {
-    AP_GROUPINFO("BARO_RND",   0, SITL,  baro_noise,  0.2f),
+    AP_GROUPINFO("BARO_RND",   0, SITL,  baro_noise[0],  0.2f),
     AP_GROUPINFO("GYR_RND",    1, SITL,  gyro_noise,  0),
     AP_GROUPINFO("ACC_RND",    2, SITL,  accel_noise, 0),
     AP_GROUPINFO("MAG_RND",    3, SITL,  mag_noise,   0),
@@ -56,16 +56,16 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("BATT_VOLTAGE",  19, SITL,  batt_voltage,  12.6f),
     AP_GROUPINFO("ARSPD_RND",     20, SITL,  arspd_noise,  0.5f),
     AP_GROUPINFO("ACCEL_FAIL",    21, SITL,  accel_fail,  0),
-    AP_GROUPINFO("BARO_DRIFT",    22, SITL,  baro_drift,  0),
+    AP_GROUPINFO("BARO_DRIFT",    22, SITL,  baro_drift[0],  0),
     AP_GROUPINFO("SONAR_GLITCH",  23, SITL,  sonar_glitch, 0),
     AP_GROUPINFO("SONAR_RND",     24, SITL,  sonar_noise, 0),
     AP_GROUPINFO("RC_FAIL",       25, SITL,  rc_fail, 0),
     AP_GROUPINFO("GPS2_ENABLE",   26, SITL,  gps2_enable, 0),
-    AP_GROUPINFO("BARO_DISABLE",  27, SITL,  baro_disable, 0),
+    AP_GROUPINFO("BARO_DISABLE",  27, SITL,  baro_disable[0], 0),
     AP_GROUPINFO("FLOAT_EXCEPT",  28, SITL,  float_exception, 1),
     AP_GROUPINFO("MAG_MOT",       29, SITL,  mag_mot, 0),
     AP_GROUPINFO("ACC_BIAS",      30, SITL,  accel_bias, 0),
-    AP_GROUPINFO("BARO_GLITCH",   31, SITL,  baro_glitch, 0),
+    AP_GROUPINFO("BARO_GLITCH",   31, SITL,  baro_glitch[0], 0),
     AP_GROUPINFO("SONAR_SCALE",   32, SITL,  sonar_scale, 12.1212f),
     AP_GROUPINFO("FLOW_ENABLE",   33, SITL,  flow_enable, 0),
     AP_GROUPINFO("TERRAIN",       34, SITL,  terrain_enable, 1),
@@ -276,8 +276,13 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     // @Path: ./SIM_RichenPower.cpp
     AP_SUBGROUPINFO(richenpower_sim, "RICH_", 31, SITL, RichenPower),
 
-    AP_GROUPEND
+    // user settable parameters for the 2nd barometer
+    AP_GROUPINFO("BARO2_RND",    32, SITL,  baro_noise[1], 0.1f),
+    AP_GROUPINFO("BARO2_DRIFT",  33, SITL,  baro_drift[1], 0),
+    AP_GROUPINFO("BARO2_DISABL", 34, SITL,  baro_disable[1], 0),
+    AP_GROUPINFO("BARO2_GLITCH", 35, SITL,  baro_glitch[1], 0),
 
+    AP_GROUPEND
 };
     
 /* report SITL state via MAVLink */

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -6,6 +6,7 @@
 
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Baro/AP_Baro.h>
 #include <AP_Common/Location.h>
 #include <AP_Compass/AP_Compass.h>
 #include "SIM_Buzzer.h"
@@ -132,9 +133,9 @@ public:
     Matrix3f ahrs_rotation_inv;
 
     // noise levels for simulated sensors
-    AP_Float baro_noise;  // in metres
-    AP_Float baro_drift;  // in metres per second
-    AP_Float baro_glitch; // glitch in meters
+    AP_Float baro_noise[BARO_MAX_INSTANCES];  // in metres
+    AP_Float baro_drift[BARO_MAX_INSTANCES];  // in metres per second
+    AP_Float baro_glitch[BARO_MAX_INSTANCES]; // glitch in meters
     AP_Float gyro_noise;  // in degrees/second
     AP_Vector3f gyro_scale;  // percentage
     AP_Float accel_noise; // in m/s/s
@@ -180,7 +181,7 @@ public:
     AP_Float accel_fail;  // accelerometer failure value
     AP_Int8  rc_fail;     // fail RC input
     AP_Int8  rc_chancount; // channel count
-    AP_Int8  baro_disable; // disable simulated barometer
+    AP_Int8  baro_disable[BARO_MAX_INSTANCES]; // disable simulated barometers
     AP_Int8  float_exception; // enable floating point exception checks
     AP_Int8  flow_enable; // enable simulated optflow
     AP_Int16 flow_rate; // optflow data rate (Hz)


### PR DESCRIPTION
This PR adds support for using multiple barometers in SITL which could be useful in testing, especially in EKF Affinity (PRs #11257 and #14674 )

Added SIM parameters only for the 2nd barometer. We can individually disable barometers and set their noise, drift, glitches. Disabling a baro would mark it as unhealthy. Would appreciate some feedback on - 

1. Add parameters for 3rd barometer ?
2. should [baro_delay](https://github.com/ArduPilot/ardupilot/blob/49be9d16263dcfcd4e931eae72eaed058a47dc90/libraries/SITL/SITL.cpp#L75) and [temp_baro_factor](https://github.com/ArduPilot/ardupilot/blob/49be9d16263dcfcd4e931eae72eaed058a47dc90/libraries/SITL/SITL.cpp#L109) also be different for multiple baros ?
3. For maximum allowed baros, Is it right to use BARO_MAX_INSTANCES from the main Baro library or should be have a separate limit for SITL ?

Let me know if any specific tests might be required for better judgement.