### PR TITLE
Add autotest for binary Lightware RF protocol.

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4882,7 +4882,8 @@ class AutoTestCopter(AutoTest):
         self.set_parameter("RTL_ALT", 500)
         self.set_parameter("RTL_ALT_TYPE", 1)
         drivers = [
-            ("lightwareserial",8),
+            ("lightwareserial",8), # autodetected between this and -binary
+            ("lightwareserial-binary",8),
             ("ulanding_v0", 11),
             ("ulanding_v1", 11),
             ("leddarone", 12),

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -261,6 +261,12 @@ int SITL_State::sim_fd(const char *name, const char *arg)
         }
         lightwareserial = new SITL::RF_LightWareSerial();
         return lightwareserial->fd();
+    } else if (streq(name, "lightwareserial-binary")) {
+        if (lightwareserial_binary != nullptr) {
+            AP_HAL::panic("Only one lightwareserial-binary at a time");
+        }
+        lightwareserial_binary = new SITL::RF_LightWareSerialBinary();
+        return lightwareserial_binary->fd();
     } else if (streq(name, "lanbao")) {
         if (lanbao != nullptr) {
             AP_HAL::panic("Only one lanbao at a time");
@@ -373,6 +379,11 @@ int SITL_State::sim_fd_write(const char *name)
             AP_HAL::panic("No lightwareserial created");
         }
         return lightwareserial->write_fd();
+    } else if (streq(name, "lightwareserial-binary")) {
+        if (lightwareserial_binary == nullptr) {
+            AP_HAL::panic("No lightwareserial_binary created");
+        }
+        return lightwareserial_binary->write_fd();
     } else if (streq(name, "lanbao")) {
         if (lanbao == nullptr) {
             AP_HAL::panic("No lanbao created");
@@ -577,6 +588,9 @@ void SITL_State::_fdm_input_local(void)
     }
     if (lightwareserial != nullptr) {
         lightwareserial->update(sitl_model->get_range());
+    }
+    if (lightwareserial_binary != nullptr) {
+        lightwareserial_binary->update(sitl_model->get_range());
     }
     if (lanbao != nullptr) {
         lanbao->update(sitl_model->get_range());

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -28,6 +28,7 @@
 #include <SITL/SIM_RF_Benewake_TF03.h>
 #include <SITL/SIM_RF_Benewake_TFmini.h>
 #include <SITL/SIM_RF_LightWareSerial.h>
+#include <SITL/SIM_RF_LightWareSerialBinary.h>
 #include <SITL/SIM_RF_Lanbao.h>
 #include <SITL/SIM_RF_BLping.h>
 #include <SITL/SIM_RF_LeddarOne.h>
@@ -249,8 +250,10 @@ private:
     // simulated Benewake tfmini rangefinder:
     SITL::RF_Benewake_TFmini *benewake_tfmini;
 
-    // simulated LightWareSerial rangefinder:
+    // simulated LightWareSerial rangefinder - legacy protocol::
     SITL::RF_LightWareSerial *lightwareserial;
+    // simulated LightWareSerial rangefinder - binary protocol:
+    SITL::RF_LightWareSerialBinary *lightwareserial_binary;
     // simulated Lanbao rangefinder:
     SITL::RF_Lanbao *lanbao;
     // simulated BLping rangefinder:

--- a/libraries/SITL/SIM_RF_LightWareSerialBinary.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerialBinary.cpp
@@ -1,0 +1,34 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the serial LightWare rangefinder - binary mode
+*/
+
+#include "SIM_RF_LightWareSerialBinary.h"
+
+#include <GCS_MAVLink/GCS.h>
+#include <stdio.h>
+
+
+using namespace SITL;
+
+uint32_t RF_LightWareSerialBinary::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+{
+    // high byte is second 7 bits but high bit set
+    buffer[0] = ((alt_cm >> 7) & 0x7f) | (1<<7);
+    // low byte is just first 7 bits
+    buffer[1] = alt_cm & 0x7f;
+    return 2;
+}

--- a/libraries/SITL/SIM_RF_LightWareSerialBinary.h
+++ b/libraries/SITL/SIM_RF_LightWareSerialBinary.h
@@ -1,0 +1,43 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the serial LightWare rangefinder - binary mode
+
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:lightwareserial-binary --speedup=1
+
+param set SERIAL5_PROTOCOL 9
+param set RNGFND1_TYPE 8
+graph RANGEFINDER.distance
+graph GLOBAL_POSITION_INT.relative_alt/1000-RANGEFINDER.distance
+reboot
+
+arm throttle
+rc 3 1600
+*/
+
+#pragma once
+
+#include "SIM_SerialRangeFinder.h"
+
+namespace SITL {
+
+class RF_LightWareSerialBinary : public SerialRangeFinder {
+public:
+
+    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+
+};
+
+}


### PR DESCRIPTION
Should be merged after https://github.com/ArduPilot/ardupilot/pull/14701 (it contains those commits)

