### PR TITLE
git: update contributing page with discourse and gitter

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,8 +25,8 @@ Please see our [wiki article](https://ardupilot.org/dev/docs/submitting-patches-
 
 The ArduPilot project is open source and [maintained](https://github.com/ArduPilot/ardupilot#maintainers) by a team of volunteers.
 
-To contribute, you can send a pull request on Github. You can also
-join the [development discussion on Google
-Groups](https://groups.google.com/forum/?fromgroups#!forum/drones-discuss). Note
-that the Google Groups mailing lists are NOT for user tech support,
-and are moderated for new users to prevent off-topic discussion.
+To contribute, you can send a pull request on Github. You can also join the
+[development discussion on Discourse](https://discuss.ardupilot.org/c/development-team),
+or [Gitter](https://gitter.im/ArduPilot/ardupilot). Note that our Discourse
+and Gitter are NOT for user tech support, and are moderated for new users to
+prevent off-topic discussion.


### PR DESCRIPTION
The existing contributor guidelines point towards a many-years-outdated Google Group.

This replaces that content, pointing towards the relevant areas in Discourse and Gitter instead.