### PR TITLE
autotest: remove doubled up disable-anti-alias-hud

### DIFF
--- a/Tools/autotest/fg_plane_view.bat
+++ b/Tools/autotest/fg_plane_view.bat
@@ -11,7 +11,6 @@ fgfs ^
     --airport=KSFO ^
     --geometry=650x550 ^
     --bpp=32 ^
-    --disable-anti-alias-hud ^
     --disable-hud-3d ^
     --disable-horizon-effect ^
     --timeofday=noon ^

--- a/Tools/autotest/fg_plane_view.sh
+++ b/Tools/autotest/fg_plane_view.sh
@@ -10,7 +10,6 @@ nice fgfs \
     --airport=YKRY \
     --geometry=650x550 \
     --bpp=32 \
-    --disable-anti-alias-hud \
     --disable-hud-3d \
     --disable-horizon-effect \
     --timeofday=noon \

--- a/Tools/autotest/fg_quad_view.bat
+++ b/Tools/autotest/fg_quad_view.bat
@@ -12,7 +12,6 @@ fgfs ^
     --airport=KSFO ^
     --geometry=650x550 ^
     --bpp=32 ^
-    --disable-anti-alias-hud ^
     --disable-hud-3d ^
     --disable-horizon-effect ^
     --timeofday=noon ^

--- a/Tools/autotest/fg_quad_view.sh
+++ b/Tools/autotest/fg_quad_view.sh
@@ -10,7 +10,6 @@ nice fgfs \
     --airport=YKRY \
     --geometry=650x550 \
     --bpp=32 \
-    --disable-anti-alias-hud \
     --disable-hud-3d \
     --disable-horizon-effect \
     --timeofday=noon \


### PR DESCRIPTION
The FlightGear launch scripts all appear to have `disable-anti-alias-hud` doubled up, which this PR resolves.

The info provided by `fgfs --help --verbose` doesn't mention anything about the option being usefully repeated.  So, the doubling up seems to be unintentional rather than on purpose.

@tridge git blame says the scripts were yours. Any idea if the doubling up does something useful? :smile:

