### PR TITLE
SITL: JSON: support quaternion and euler attitude

### DIFF
--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -57,7 +57,7 @@ private:
     void output_servos(const struct sitl_input &input);
     void recv_fdm(const struct sitl_input &input);
 
-    bool parse_sensors(const char *json);
+    uint8_t parse_sensors(const char *json);
 
     // buffer for parsing pose data in JSON format
     uint8_t sensor_buffer[65000];
@@ -68,6 +68,7 @@ private:
         DATA_FLOAT,
         DATA_DOUBLE,
         DATA_VECTOR3F,
+        QUATERNION,
     };
 
     struct {
@@ -78,6 +79,7 @@ private:
         } imu;
         Vector3f position;
         Vector3f attitude;
+        Quaternion quaternion;
         Vector3f velocity;
     } state;
 
@@ -87,13 +89,26 @@ private:
         const char *key;
         void *ptr;
         enum data_type type;
-    } keytable[6] = {
-        { "", "timestamp", &state.timestamp_s, DATA_DOUBLE },
-        { "imu", "gyro",    &state.imu.gyro, DATA_VECTOR3F },
-        { "imu", "accel_body", &state.imu.accel_body, DATA_VECTOR3F },
-        { "", "position", &state.position, DATA_VECTOR3F },
-        { "", "attitude", &state.attitude, DATA_VECTOR3F },
-        { "", "velocity", &state.velocity, DATA_VECTOR3F },
+        bool required;
+    } keytable[7] = {
+        { "", "timestamp", &state.timestamp_s, DATA_DOUBLE, true },
+        { "imu", "gyro",    &state.imu.gyro, DATA_VECTOR3F, true },
+        { "imu", "accel_body", &state.imu.accel_body, DATA_VECTOR3F, true },
+        { "", "position", &state.position, DATA_VECTOR3F, true },
+        { "", "attitude", &state.attitude, DATA_VECTOR3F, false },
+        { "", "quaternion", &state.quaternion, QUATERNION, false },
+        { "", "velocity", &state.velocity, DATA_VECTOR3F, true },
+    };
+
+    // Enum coresponding to the ordering of keys in the keytable.
+    enum DataKey {
+        TIMESTAMP   = 1U << 0,
+        GYRO        = 1U << 1,
+        ACCEL_BODY  = 1U << 2,
+        POSITION    = 1U << 3,
+        EULER_ATT   = 1U << 4,
+        QUAT_ATT    = 1U << 5,
+        VELOCITY    = 1U << 6,
     };
 };
 

--- a/libraries/SITL/examples/JSON/readme.md
+++ b/libraries/SITL/examples/JSON/readme.md
@@ -28,13 +28,19 @@ Data is received from the physics backend in a plain text JSON format. The data 
     imu:
         gyro(roll, pitch, yaw) (radians/sec) body frame
         accel_body(x, y, z) (m/s^2) body frame
-
     position(north, east, down) (m) earth frame
-    attitude(roll, pitch yaw) (radians)
     velocity(north, east, down) (m/s) earth frame
 ```
+
+It is possible to send the attitude in a euler format using ```attitude``` or as a quaternion with ```quaternion```, one of these fields must be received. If both are received the quaternion attitude will be used.
+
+```
+    attitude(roll, pitch yaw) (radians)
+    quaternion(q1, q2, q3, q4)
+```
+
 This is a example input frame, it should be preceded by and terminated with a carriage return ("\n") :
 ```
 {"timestamp":2500,"imu":{"gyro":[0,0,0],"accel_body":[0,0,0]},"position":[0,0,0],"attitude":[0,0,0],"velocity":[0,0,0]}
 ```
-The order of fields is not important, this is minimum required fields. In the future a support for a number of additional optional felids will be added to allow readings to be provided for additional sensors such as airspeed and lidar.
+The order of fields is not important. In the future support for additional optional fields could be added to allow readings to be provided for additional sensors.


### PR DESCRIPTION
This adds the ability for the JSON sitl backend to optionally receive things. This allows us to receive attitude as either a Euler angle or quaternion.

I have tested for Euler angles, @Williangalvani it would be great if you could check it for quaternion.

If this works it needs a short up date to the read me. Would be quite easy to add in more optional fields, airspeed being a obvious one. 

Currently there is no way to tell what it is receiving, not sure what we can do for optional fields. We could print what we got on the first connect.  