### PR TITLE
GCS_MAVLink: Allow the user to specify private channels

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -53,16 +53,17 @@ public:
     virtual uint8_t get_options(void) const { return 0; }
 
     enum {
-        OPTION_RXINV        = (1U<<0),  // invert RX line
-        OPTION_TXINV        = (1U<<1),  // invert TX line
-        OPTION_HDPLEX       = (1U<<2), // half-duplex (one-wire) mode
-        OPTION_SWAP         = (1U<<3), // swap RX and TX pins
-        OPTION_PULLDOWN_RX  = (1U<<4), // apply pulldown to RX
-        OPTION_PULLUP_RX    = (1U<<5), // apply pullup to RX
-        OPTION_PULLDOWN_TX  = (1U<<6), // apply pulldown to TX
-        OPTION_PULLUP_TX    = (1U<<7), // apply pullup to TX
-        OPTION_NODMA_RX     = (1U<<8), // don't use DMA for RX
-        OPTION_NODMA_TX     = (1U<<9), // don't use DMA for TX
+        OPTION_RXINV              = (1U<<0),  // invert RX line
+        OPTION_TXINV              = (1U<<1),  // invert TX line
+        OPTION_HDPLEX             = (1U<<2), // half-duplex (one-wire) mode
+        OPTION_SWAP               = (1U<<3), // swap RX and TX pins
+        OPTION_PULLDOWN_RX        = (1U<<4), // apply pulldown to RX
+        OPTION_PULLUP_RX          = (1U<<5), // apply pullup to RX
+        OPTION_PULLDOWN_TX        = (1U<<6), // apply pulldown to TX
+        OPTION_PULLUP_TX          = (1U<<7), // apply pullup to TX
+        OPTION_NODMA_RX           = (1U<<8), // don't use DMA for RX
+        OPTION_NODMA_TX           = (1U<<9), // don't use DMA for TX
+        OPTION_MAVLINK_NO_FORWARD = (1U<<10), // don't forward MAVLink data to or from this device
     };
 
     enum flow_control {

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -548,6 +548,15 @@ bool AP_SerialManager::get_mavlink_channel(enum SerialProtocol protocol, uint8_t
     return false;
 }
 
+// should_forward_mavlink_telemetry - returns true if this port should forward telemetry
+bool AP_SerialManager::should_forward_mavlink_telemetry(enum SerialProtocol protocol, uint8_t instance) const
+{
+    const struct UARTState *_state = find_protocol_instance(protocol, instance);
+    if (_state == nullptr) {
+        return true;
+    }
+    return (_state->options & AP_HAL::UARTDriver::OPTION_MAVLINK_NO_FORWARD) != AP_HAL::UARTDriver::OPTION_MAVLINK_NO_FORWARD;
+}
 
 // get_mavlink_protocol - provides the specific MAVLink protocol for a
 // given channel, or SerialProtocol_None if not found

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -165,6 +165,9 @@ public:
     //  returns true if a channel is found, false if not
     bool get_mavlink_channel(enum SerialProtocol protocol, uint8_t instance, mavlink_channel_t &mav_chan) const;
 
+    // should_forward_mavlink_telemetry - returns true if this port should forward telemetry
+    bool should_forward_mavlink_telemetry(enum SerialProtocol protocol, uint8_t instance) const;
+
     // get_mavlink_protocol - provides the specific MAVLink protocol for a
     // given channel, or SerialProtocol_None if not found
     SerialProtocol get_mavlink_protocol(mavlink_channel_t mav_chan) const;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -108,6 +108,10 @@ bool GCS_MAVLINK::init(uint8_t instance)
         return false;
     }
 
+    if (!serial_manager.should_forward_mavlink_telemetry(protocol, instance)) {
+        set_channel_private(chan);
+    }
+
     /*
       Now try to cope with SiK radios that may be stuck in bootloader
       mode because CTS was held while powering on. This tells the

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -97,6 +97,11 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
         return true;
     }
 
+    // don't ever forward data from a private channel
+    if ((GCS_MAVLINK::is_private(in_channel))) {
+        return true;
+    }
+
     // learn new routes
     learn_route(in_channel, msg);
 


### PR DESCRIPTION
This allows you to mark a serial channel via the `SERIALx_OPTIONS` bitmask as a channel that the MAVLink data shouldn't be forwarded to or from. The motivating reason for this is an embedded device which has misunderstood some of the implementation details of `MESSAGE_INTERVAL` and is sending out messages that don't help any GCS, and we don't want to forward any of the debug messages onto the telemetry link to the GCS as it's consuming the bandwidth.

There is a behaviour change here in that this extends the concept of private channels to mean "no data from this channel is sent to the GCS" where before it was simply "no data gets forwarded to a private channel". Before this patch the only thing that could be a private channel was a Solo gimbal. As I understand it, this was done because the gimbal was getting confused by MAVLink messages from the GCS. This change would mean you can't receive messages from the gimbal on the GCS with this patch set, but in an inital conversation with @Pedals2Paddles it was believed this was okay. This does need to be tested before we bring this in so it doesn't break anything for the solo gimbal support. If that doesn't work I can add a new bitmask in parallel to `is_private()` but I didn't want to add that if it wasn't needed.

I've locally tested that this suppresses the data I didn't want to see from the GCS, however I don't have a solo to test if this breaks anything there.