### PR TITLE
AC_Fence: Matching Message Style

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -169,7 +169,7 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
         (_enabled_fences & AC_FENCE_TYPE_POLYGON)) {
         Vector2f position;
         if (!AP::ahrs().get_relative_position_NE_home(position)) {
-            fail_msg = "fence requires position";
+            fail_msg = "Fence requires position";
             return false;
         }
     }


### PR DESCRIPTION
I saw a discrepancy in the style of GCS messages.
I think we should match styles.

before:
[MAV 001:1] PreArm: fence requires position ★
[MAV 001:1] PreArm: Fence enabled, need 3D Fix 

After:
[MAV 001:1] PreArm: Fence requires position ★
[MAV 001:1] PreArm: Fence enabled, need 3D Fix 