### PR TITLE
Copter: Removing quotes in defines.h

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -67,7 +67,6 @@
 #include <AC_Sprayer/AC_Sprayer.h>
 
 // Configuration
-#include "defines.h"
 #include "config.h"
 
 #if FRAME_CONFIG == HELI_FRAME


### PR DESCRIPTION
I found a reference to defines.h in config.h.
I don't think it's necessary to write config.h.