### PR TITLE
AP_Scripting: fixed equality test for uint32_t

### DIFF
--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -109,7 +109,7 @@ UINT32_T_BOX_OP(shr, >>)
         return 1; \
     }
 
-UINT32_T_BOX_OP_BOOL(eq, =)
+UINT32_T_BOX_OP_BOOL(eq, ==)
 UINT32_T_BOX_OP_BOOL(lt, <)
 UINT32_T_BOX_OP_BOOL(le, <=)
 


### PR DESCRIPTION
fixes == and ~= for uint32_t
