### PR TITLE
Copter: Add a message when AC_FENCE is disabled

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -480,6 +480,8 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
             copter.fence.enable(true);
             gcs().send_text(MAV_SEVERITY_INFO, "Fence Enabled");
         }
+#else
+        gcs().send_text(MAV_SEVERITY_INFO, "Fence UnSupported");
 #endif //AC_FENCE == ENABLED
         break;
 


### PR DESCRIPTION
GCS is not known to be disabled when the FENCE function is disabled while executing an automatic flight plan.
Add a message to indicate that GCS is disabled as a means of knowing that GCS is disabled.

APM: Mission: 2 FenceEnable
APM: Fence UnSupported ★
APM: Mission: 3 WP
Waypoint 3