### PR TITLE
Pre-arm throttle check: enable by default

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1220,6 +1220,7 @@ void Copter::convert_pid_parameters(void)
         { "PSC_VELXY_I", 0.5f },
         { "PSC_VELXY_P", 1.0f },
         { "RC8_OPTION", 32 },
+        { "RC_OPTIONS", 0 },
     };
     AP_Param::set_defaults_from_table(heli_defaults_table, ARRAY_SIZE(heli_defaults_table));
 #endif

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -166,6 +166,7 @@ class AutoTestQuadPlane(AutoTest):
         self.wait_disarmed()
 
     def takeoff(self, height, mode):
+        """climb to specified height and set throttle to 1500"""
         self.change_mode(mode)
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -180,6 +181,7 @@ class AutoTestQuadPlane(AutoTest):
         self.change_mode("QRTL")
         self.wait_altitude(-5, 1, relative=True, timeout=60)
         self.wait_disarmed()
+        self.zero_throttle()
 
     def fly_home_land_and_disarm(self, timeout=30):
         self.set_parameter("LAND_TYPE", 0)
@@ -395,6 +397,11 @@ class AutoTestQuadPlane(AutoTest):
 
     def test_parameter_checks(self):
         self.test_parameter_checks_poscontrol("Q_P")
+
+    def rc_defaults(self):
+        ret = super(AutoTestQuadPlane, self).rc_defaults()
+        ret[3] = 1000
+        return ret
 
     def default_mode(self):
         return "MANUAL"

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -545,7 +545,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
         return true;
     }
 
-    // only check if we've recieved some form of input within the last second
+    // only check if we've received some form of input within the last second
     // this is a protection against a vehicle having never enabled an input
     uint32_t last_input_ms = rc().last_input_ms();
     if ((last_input_ms == 0) || ((AP_HAL::millis() - last_input_ms) > 1000)) {
@@ -577,6 +577,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
             }
         }
 
+        // if throttle check is enabled, require zero input
         if (rc().arming_check_throttle()) {
             RC_Channel *c = rc().channel(rcmap->throttle() - 1);
             if (c != nullptr) {

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "RC_Channel.h"
+
+
 /*
   this header file is expected to be #included by Vehicle subclasses
   of RC_Channels after defining RC_CHANNELS_SUBCLASS and
@@ -87,7 +90,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @Description: RC input options
     // @User: Advanced
     // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks, 7:Allow Switch reverse
-    AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, 0),
+    AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE),
 
     AP_GROUPEND
 };


### PR DESCRIPTION
broken out from #14520 since scope is much broader

potential safety enhancement which prevents arming at high throttle from GCS or aux switch

Skips the check if AP_Notify::flags.flying is true to allow in-air rearm,
probably should also skip the RPY input checks when flying. 

Hopefully there is a better way to make the autotests pass; for some reason putting the zero_throttle call inside arm_vehicle caused other tests to fail.