### PR TITLE
Fixed alignment errors in several subsystems

### DIFF
--- a/libraries/AP_Common/AP_ExpandingArray.h
+++ b/libraries/AP_Common/AP_ExpandingArray.h
@@ -95,15 +95,23 @@ public:
     T &operator[](uint16_t i)
     {
         const uint16_t chunk_num = i / chunk_size;
-        const uint16_t chunk_index = (i % chunk_size) * elem_size;
-        return (T &)(chunk_ptrs[chunk_num][chunk_index]);
+        const uint16_t chunk_index = (i % chunk_size);
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wcast-align"
+        T *el_array = (T *)chunk_ptrs[chunk_num];
+        #pragma pop
+        return el_array[chunk_index];
     }
 
     // allow use as an array for accessing elements. no bounds checking is performed
     const T &operator[](uint16_t i) const
     {
         const uint16_t chunk_num = i / chunk_size;
-        const uint16_t chunk_index = (i % chunk_size) * elem_size;
-        return (const T &)(chunk_ptrs[chunk_num][chunk_index]);
+        const uint16_t chunk_index = (i % chunk_size);
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wcast-align"
+        const T *el_array = (const T *)chunk_ptrs[chunk_num];
+        #pragma pop
+        return el_array[chunk_index];
     }
 };

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -112,8 +112,9 @@ bool AP_Generator_RichenPower::get_reading()
 
     // calculate checksum....
     uint16_t checksum = 0;
+    const uint8_t *checksum_buffer = &u.parse_buffer[2];
     for (uint8_t i=0; i<5; i++) {
-        checksum += be16toh(checksum_buffer[i]);
+        checksum += be16toh_ptr(&checksum_buffer[2*i]);
     }
 
     if (checksum != be16toh(u.packet.checksum)) {

--- a/libraries/AP_Generator/AP_Generator_RichenPower.h
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.h
@@ -156,7 +156,6 @@ private:
         struct RichenPacket packet;
     };
     RichenUnion u;
-    uint16_t *checksum_buffer = (uint16_t*)&u.parse_buffer[2];
 
     uint8_t body_length;
 

--- a/libraries/AP_HAL/utility/sparse-endian.h
+++ b/libraries/AP_HAL/utility/sparse-endian.h
@@ -84,5 +84,16 @@ static inline uint16_t be16toh(be16_t value) { return bswap_16_on_le((uint16_t _
 static inline uint32_t be32toh(be32_t value) { return bswap_32_on_le((uint32_t __ap_force)value); }
 static inline uint64_t be64toh(be64_t value) { return bswap_64_on_le((uint64_t __ap_force)value); }
 
+// methods for misaligned buffers
+static inline uint16_t le16toh_ptr(const uint8_t *p) { return p[0] | (p[1]<<8U); }
+static inline uint32_t le32toh_ptr(const uint8_t *p) { return p[0] | (p[1]<<8U) | (p[2]<<16U) | (p[3]<<24U); }
+static inline uint16_t be16toh_ptr(const uint8_t *p) { return p[1] | (p[0]<<8U); }
+static inline uint32_t be32toh_ptr(const uint8_t *p) { return p[3] | (p[2]<<8U) | (p[1]<<16U) | (p[0]<<24U); }
+
+static inline void put_le16_ptr(uint8_t *p, uint16_t v) { p[0] = (v&0xFF); p[1] = (v>>8); }
+static inline void put_le32_ptr(uint8_t *p, uint32_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; p[3] = (v>>24)&0xFF; }
+static inline void put_be16_ptr(uint8_t *p, uint16_t v) { p[1] = (v&0xFF); p[0] = (v>>8); }
+static inline void put_be32_ptr(uint8_t *p, uint32_t v) { p[3] = (v&0xFF); p[2] = (v>>8)&0xFF; p[1] = (v>>16)&0xFF; p[0] = (v>>24)&0xFF; }
+
 #undef __ap_bitwise
 #undef __ap_force

--- a/libraries/AP_HAL_Linux/RCInput_UART.h
+++ b/libraries/AP_HAL_Linux/RCInput_UART.h
@@ -22,7 +22,7 @@ private:
     int _fd;
     uint8_t *_pdata;
     ssize_t _remain;
-    struct PACKED {
+    struct {
         uint16_t magic;
         uint16_t values[CHANNELS];
     } _data;

--- a/libraries/AP_HAL_Linux/RCInput_UDP.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_UDP.cpp
@@ -79,5 +79,7 @@ void RCInput_UDP::_timer_tick(void)
     _last_buf_ts = _buf.timestamp_us;
     _last_buf_seq = _buf.sequence;
 
-    _update_periods(_buf.pwms, n_channels);
+    uint16_t pwms[n_channels];
+    memcpy(pwms, _buf.pwms, n_channels*sizeof(uint16_t));
+    _update_periods(pwms, n_channels);
 }

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -35,7 +35,7 @@ public:
     }
 
     // static functions for SRXL2 callbacks
-    static void capture_scaled_input(const uint16_t *values, bool in_failsafe, int16_t rssi);
+    static void capture_scaled_input(const uint8_t *values_p, bool in_failsafe, int16_t rssi);
     static void send_on_uart(uint8_t* pBuffer, uint8_t length);
     static void change_baud_rate(uint32_t baudrate);
 
@@ -48,7 +48,7 @@ private:
     void _process_byte(uint32_t timestamp_us, uint8_t byte);
     void _send_on_uart(uint8_t* pBuffer, uint8_t length);
     void _change_baud_rate(uint32_t baudrate);
-    void _capture_scaled_input(const uint16_t *values, bool in_failsafe, int16_t rssi);
+    void _capture_scaled_input(const uint8_t *values_p, bool in_failsafe, int16_t rssi);
 
     uint8_t _buffer[SRXL2_FRAMELEN_MAX];       /* buffer for raw srxl frame data in correct order --> buffer[0]=byte0  buffer[1]=byte1  */
     uint8_t _buflen;                          /* length in number of bytes of received srxl dataframe in buffer  */


### PR DESCRIPTION
Fixes warnings in:
 - ExpandingArray
 - HAL_Linux
 - RCProtocol SRXL2
 - AP_Generator RicenPower

Ping @peterbarker  @andyp1per @rmackay9 
