### PR TITLE
Allow compilation with musl libc

### DIFF
--- a/libraries/AP_Common/missing/string.h
+++ b/libraries/AP_Common/missing/string.h
@@ -1,0 +1,15 @@
+#include_next <string.h>
+
+// Necessary for toolchains that does not provide `strndupa`, such as musl.
+#if !defined(HAVE_DECL_STRNDUPA) && !defined(strndupa)
+// The last value of the GCC extension "statement exprs" will be
+// evaluated and returned, E.g: `#define foo(n) ({ n; })` is equivalent for
+// `auto foo(auto n) { return n; }`
+#define strndupa(old_string, len)                                     \
+({                                                                    \
+    const size_t string_len = strnlen(old_string, len);               \
+    char *new_string = static_cast<char*>(alloca(string_len + 1));    \
+    new_string[string_len] = '\0';                                    \
+    static_cast<char*>(memcpy(new_string, old_string, len));          \
+})
+#endif

--- a/libraries/AP_HAL/utility/RCOutput_Tap_Linux.cpp
+++ b/libraries/AP_HAL/utility/RCOutput_Tap_Linux.cpp
@@ -23,6 +23,7 @@
 #include <asm/termbits.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <asm/ioctls.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -75,7 +75,7 @@ void Scheduler::init_realtime()
     mlockall(MCL_CURRENT|MCL_FUTURE);
 
     struct sched_param param = { .sched_priority = APM_LINUX_MAIN_PRIORITY };
-    if (sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &param) == -1) {
         AP_HAL::panic("Scheduler: failed to set scheduling parameters: %s",
                       strerror(errno));
     }

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -85,7 +85,9 @@ void Thread::_poison_stack()
     void *stackp;
     uint32_t *p, *curr, *begin, *end;
 
-    if (pthread_getattr_np(_ctx, &attr) != 0 ||
+    // `pthread_self` should be used here since _ctx could be not initialized
+    // in a race condition.
+    if (pthread_getattr_np(pthread_self(), &attr) != 0 ||
         pthread_attr_getstack(&attr, &stackp, &stack_size) != 0 ||
         pthread_attr_getguardsize(&attr, &guard_size) != 0) {
         return;


### PR DESCRIPTION
Allow compilation with toolchains that use musl, such as: `arm-linux-musleabihf-cross`