### PR TITLE
Plane: Update Log_Write_Fast comment for accuracy

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -52,7 +52,7 @@ void Plane::Log_Write_Attitude(void)
     logger.Write_POS();
 }
 
-// do logging at loop rate
+// do fast logging for plane
 void Plane::Log_Write_Fast(void)
 {
     if (should_log(MASK_LOG_ATTITUDE_FAST)) {


### PR DESCRIPTION
The loop rate is usually 50 Hz and this logging happens at 25 Hz in the scheduler. Making it clearer to someone running through the code.