### PR TITLE
AP_Bootloader: Increment BL Protocol Version

### DIFF
--- a/Tools/AP_Bootloader/bl_protocol.cpp
+++ b/Tools/AP_Bootloader/bl_protocol.cpp
@@ -79,7 +79,7 @@
 // RESET		finalise flash programming, reset chip and starts application
 //
 
-#define BL_PROTOCOL_VERSION 		5		// The revision of the bootloader protocol
+#define BL_PROTOCOL_VERSION			6		// The revision of the bootloader protocol
 // protocol bytes
 #define PROTO_INSYNC				0x12    // 'in sync' byte sent before status
 #define PROTO_EOC					0x20    // end of command


### PR DESCRIPTION
This is required to identify boards that are not running the most current bootloader, and prompt for an upgrade. If there is another way to detect this, please let me know