### PR TITLE
get rid of strncpy() warnings

### DIFF
--- a/libraries/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/AP_Common.cpp
@@ -70,3 +70,16 @@ bool hex_to_uint8(uint8_t a, uint8_t &res)
     }
     return true;
 }
+
+/*
+  strncpy without the warning for not leaving room for nul termination
+ */
+void strncpy_noterm(char *dest, const char *src, size_t n)
+{
+    size_t len = strnlen(src, n);
+    if (len < n) {
+        // include nul term if it fits
+        len++;
+    }
+    memcpy(dest, src, len);
+}

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -138,3 +138,8 @@ template<typename s, size_t t> struct assert_storage_size {
 bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 
 bool hex_to_uint8(uint8_t a, uint8_t &res);  // return the uint8 value of an ascii hex character
+
+/*
+  strncpy without the warning for not leaving room for nul termination
+ */
+void strncpy_noterm(char *dest, const char *src, size_t n);

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -100,7 +100,7 @@ void AP_stack_overflow(const char *thread_name)
     if (!done_stack_overflow) {
         // we don't want to record the thread name more than once, as
         // first overflow can trigger a 2nd
-        strncpy(hal.util->persistent_data.thread_name4, thread_name, 4);
+        strncpy_noterm(hal.util->persistent_data.thread_name4, thread_name, 4);
         done_stack_overflow = true;
     }
     hal.util->persistent_data.fault_type = 42; // magic value

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -32,9 +32,9 @@ void AP_Logger_Backend::Fill_Format(const struct LogStructure *s, struct log_For
     pkt.msgid = LOG_FORMAT_MSG;
     pkt.type = s->msg_type;
     pkt.length = s->msg_len;
-    strncpy(pkt.name, s->name, sizeof(pkt.name));
-    strncpy(pkt.format, s->format, sizeof(pkt.format));
-    strncpy(pkt.labels, s->labels, sizeof(pkt.labels));
+    strncpy_noterm(pkt.name, s->name, sizeof(pkt.name));
+    strncpy_noterm(pkt.format, s->format, sizeof(pkt.format));
+    strncpy_noterm(pkt.labels, s->labels, sizeof(pkt.labels));
 }
 
 /*
@@ -48,8 +48,8 @@ void AP_Logger_Backend::Fill_Format_Units(const struct LogStructure *s, struct l
     pkt.msgid = LOG_FORMAT_UNITS_MSG;
     pkt.time_us = AP_HAL::micros64();
     pkt.format_type = s->msg_type;
-    strncpy(pkt.units, s->units, sizeof(pkt.units));
-    strncpy(pkt.multipliers, s->multipliers, sizeof(pkt.multipliers));
+    strncpy_noterm(pkt.units, s->units, sizeof(pkt.units));
+    strncpy_noterm(pkt.multipliers, s->multipliers, sizeof(pkt.multipliers));
 }
 
 /*
@@ -73,7 +73,7 @@ bool AP_Logger_Backend::Write_Unit(const struct UnitStructure *s)
         type    : s->ID,
         unit    : { }
     };
-    strncpy(pkt.unit, s->unit, sizeof(pkt.unit));
+    strncpy_noterm(pkt.unit, s->unit, sizeof(pkt.unit));
 
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
@@ -114,7 +114,7 @@ bool AP_Logger_Backend::Write_Parameter(const char *name, float value)
         name  : {},
         value : value
     };
-    strncpy(pkt.name, name, sizeof(pkt.name));
+    strncpy_noterm(pkt.name, name, sizeof(pkt.name));
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
@@ -462,7 +462,7 @@ bool AP_Logger_Backend::Write_Message(const char *message)
         time_us : AP_HAL::micros64(),
         msg  : {}
     };
-    strncpy(pkt.msg, message, sizeof(pkt.msg));
+    strncpy_noterm(pkt.msg, message, sizeof(pkt.msg));
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
@@ -143,7 +143,7 @@ void AP_RCTelemetry::queue_message(MAV_SEVERITY severity, const char *text)
     mavlink_statustext_t statustext{};
 
     statustext.severity = severity;
-    strncpy(statustext.text, text, sizeof(statustext.text));
+    strncpy_noterm(statustext.text, text, sizeof(statustext.text));
 
     // The force push will ensure comm links do not block other comm links forever if they fail.
     // If we push to a full buffer then we overwrite the oldest entry, effectively removing the

--- a/libraries/AP_Scripting/lua/src/ldebug.c
+++ b/libraries/AP_Scripting/lua/src/ldebug.c
@@ -29,7 +29,8 @@
 #include "ltm.h"
 #include "lvm.h"
 
-
+// lua code does lots of casting, these warnings are not helpful
+#pragma GCC diagnostic ignored "-Wcast-align"
 
 #define noLuaClosure(f)		((f) == NULL || (f)->c.tt == LUA_TCCL)
 

--- a/libraries/AP_Scripting/lua/src/ldo.c
+++ b/libraries/AP_Scripting/lua/src/ldo.c
@@ -33,7 +33,8 @@
 #include "lvm.h"
 #include "lzio.h"
 
-
+// lua code does lots of casting, these warnings are not helpful
+#pragma GCC diagnostic ignored "-Wcast-align"
 
 #define errorstatus(s)	((s) > LUA_YIELD)
 

--- a/libraries/AP_Scripting/lua/src/llex.c
+++ b/libraries/AP_Scripting/lua/src/llex.c
@@ -27,6 +27,8 @@
 #include "ltable.h"
 #include "lzio.h"
 
+// lua code does lots of casting, these warnings are not helpful
+#pragma GCC diagnostic ignored "-Wcast-align"
 
 
 #define next(ls) (ls->current = zgetc(ls->z))

--- a/libraries/AP_Scripting/lua/src/lstate.c
+++ b/libraries/AP_Scripting/lua/src/lstate.c
@@ -27,6 +27,9 @@
 #include "ltable.h"
 #include "ltm.h"
 
+// lua code does lots of casting, these warnings are not helpful
+#pragma GCC diagnostic ignored "-Wcast-align"
+
 
 #if !defined(LUAI_GCPAUSE)
 #define LUAI_GCPAUSE	200  /* 200% */

--- a/libraries/AP_Scripting/lua/src/ltm.c
+++ b/libraries/AP_Scripting/lua/src/ltm.c
@@ -23,6 +23,8 @@
 #include "ltm.h"
 #include "lvm.h"
 
+// lua code does lots of casting, these warnings are not helpful
+#pragma GCC diagnostic ignored "-Wcast-align"
 
 static const char udatatypename[] = "userdata";
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2220,15 +2220,15 @@ void GCS_MAVLINK::send_autopilot_version() const
                         (uint32_t)(version.fw_type) << (8 * 0);
 
     if (version.fw_hash_str) {
-        strncpy(flight_custom_version, version.fw_hash_str, ARRAY_SIZE(flight_custom_version));
+        strncpy_noterm(flight_custom_version, version.fw_hash_str, ARRAY_SIZE(flight_custom_version));
     }
 
     if (version.middleware_hash_str) {
-        strncpy(middleware_custom_version, version.middleware_hash_str, ARRAY_SIZE(middleware_custom_version));
+        strncpy_noterm(middleware_custom_version, version.middleware_hash_str, ARRAY_SIZE(middleware_custom_version));
     }
 
     if (version.os_hash_str) {
-        strncpy(os_custom_version, version.os_hash_str, ARRAY_SIZE(os_custom_version));
+        strncpy_noterm(os_custom_version, version.os_hash_str, ARRAY_SIZE(os_custom_version));
     }
 
     mavlink_msg_autopilot_version_send(


### PR DESCRIPTION
and suppress cast-align warnings in Lua

this leaves us with the only warnings on navio being for Perf.cpp, which should be removed soon
