### PR TITLE
Configure VTX from SRXL2 or DSM VTX packet

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -18,12 +18,12 @@
  */
 
 #include "AP_RCProtocol.h"
-#include "AP_RCProtocol_SRXL.h"
 #include "AP_RCProtocol_SRXL2.h"
 #include <AP_Math/AP_Math.h>
 #include <AP_RCTelemetry/AP_Spektrum_Telem.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_HAL/utility/sparse-endian.h>
+#include <AP_RCTelemetry/AP_VideoTX.h>
 
 #include "spm_srxl.h"
 
@@ -241,6 +241,59 @@ void AP_RCProtocol_SRXL2::send_on_uart(uint8_t* pBuffer, uint8_t length)
     }
 }
 
+// configure the video transmitter, the input values are Spektrum-oriented
+void AP_RCProtocol_SRXL2::configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode)
+{
+    AP_VideoTX& vtx = AP::vtx();
+    // VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A)
+    // map to TBS band A, B, E, Race, Airwave, LoRace
+    switch (band) {
+    case VTX_BAND_FATSHARK:
+        vtx.set_configured_band(AP_VideoTX::VideoBand::FATSHARK);
+        break;
+    case VTX_BAND_RACEBAND:
+        vtx.set_configured_band(AP_VideoTX::VideoBand::RACEBAND);
+        break;
+    case VTX_BAND_E_BAND:
+        vtx.set_configured_band(AP_VideoTX::VideoBand::BAND_E);
+        break;
+    case VTX_BAND_B_BAND:
+        vtx.set_configured_band(AP_VideoTX::VideoBand::BAND_B);
+        break;
+    case VTX_BAND_A_BAND:
+        vtx.set_configured_band(AP_VideoTX::VideoBand::BAND_A);
+        break;
+    default:
+        break;
+    }
+    // VTX Channel (0-7)
+    vtx.set_configured_channel(channel);
+    if (pitmode) {
+        vtx.set_configured_options(vtx.get_options() | uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE));
+    } else {
+        vtx.set_configured_options(vtx.get_options() & ~uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE));
+    }
+
+    switch (power) {
+    case VTX_POWER_1MW_14MW:
+    case VTX_POWER_15MW_25MW:
+        vtx.set_configured_power_mw(25);
+        break;
+    case VTX_POWER_26MW_99MW:
+    case VTX_POWER_100MW_299MW:
+        vtx.set_configured_power_mw(100);
+        break;
+    case VTX_POWER_300MW_600MW:
+        vtx.set_configured_power_mw(400);
+        break;
+    case VTX_POWER_601_PLUS:
+        vtx.set_configured_power_mw(800);
+        break;
+    default:
+        break;
+    }
+}
+
 // send data to the uart
 void AP_RCProtocol_SRXL2::_send_on_uart(uint8_t* pBuffer, uint8_t length)
 {
@@ -343,4 +396,5 @@ bool srxlOnBind(SrxlFullID device, SrxlBindData info)
 // User-provided callback routine to handle reception of a VTX control packet.
 void srxlOnVtx(SrxlVtxData* pVtxData)
 {
+    AP_RCProtocol_SRXL2::configure_vtx(pVtxData->band, pVtxData->channel, pVtxData->power, pVtxData->pit);
 }

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -17,6 +17,7 @@
 
 #include "AP_RCProtocol.h"
 #include <AP_Math/AP_Math.h>
+#include "AP_RCProtocol_SRXL.h"
 #include "SoftSerial.h"
 
 #define SRXL2_MAX_CHANNELS 32U           /* Maximum number of channels from srxl2 datastream  */
@@ -39,6 +40,8 @@ public:
     static void capture_scaled_input(const uint8_t *values_p, bool in_failsafe, int16_t rssi);
     static void send_on_uart(uint8_t* pBuffer, uint8_t length);
     static void change_baud_rate(uint32_t baudrate);
+    // configure the VTX from Spektrum data
+    static void configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode);
 
 private:
 

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -87,7 +87,7 @@ public:
         uint8_t origin; // address
         uint8_t power;              // power in dBm
         uint16_t frequency;         // frequency in Mhz
-        bool pitmode;               // disable 0, enable 1
+        uint8_t pitmode;            // disable 0, enable 1
     } PACKED;
 
     struct LinkStatisticsFrame {

--- a/libraries/AP_RCTelemetry/AP_VideoTX.cpp
+++ b/libraries/AP_RCTelemetry/AP_VideoTX.cpp
@@ -127,7 +127,7 @@ bool AP_VideoTX::get_band_and_channel(uint16_t freq, VideoBand& band, uint8_t& c
 
 // set the current power
 void AP_VideoTX::set_configured_power_mw(uint16_t power) {
-    _power_mw.set_and_save(power);
+    _power_mw.set_and_save_ifchanged(power);
 }
 
 // set the power in dbm, rounding appropriately

--- a/libraries/AP_RCTelemetry/AP_VideoTX.h
+++ b/libraries/AP_RCTelemetry/AP_VideoTX.h
@@ -44,12 +44,12 @@ public:
     };
 
     enum VideoBand {
-        VTX_BAND_A,
-        VTX_BAND_B,
-        VTX_BAND_E,
-        VTX_BAND_FATSHARK,
-        VTX_BAND_RACEBAND,
-        VTX_BAND_LOW_RACEBAND,
+        BAND_A,
+        BAND_B,
+        BAND_E,
+        FATSHARK,
+        RACEBAND,
+        LOW_RACEBAND,
         MAX_BANDS
     };
 
@@ -70,16 +70,19 @@ public:
     bool update_power() const { return _defaults_set && _power_mw != _current_power; }
     // get / set the frequency band
     void set_band(uint8_t band) { _current_band = band; }
+    void set_configured_band(uint8_t band) { _band.set_and_save_ifchanged(band); }
     uint8_t get_configured_band() const { return _band; }
     uint8_t get_band() const { return _current_band; }
     bool update_band() const { return _defaults_set && _band != _current_band; }
     // get / set the frequency channel
     void set_channel(uint8_t channel) { _current_channel = channel; }
+    void set_configured_channel(uint8_t channel) { _channel.set_and_save_ifchanged(channel); }
     uint8_t get_configured_channel() const { return _channel; }
     uint8_t get_channel() const { return _current_channel; }
     bool update_channel() const { return _defaults_set && _channel != _current_channel; }
     // get / set vtx option
     void set_options(uint8_t options) { _current_options = options; }
+    void set_configured_options(uint8_t options) { _options.set_and_save_ifchanged(options); }
     uint8_t get_configured_options() const { return _options; }
     uint8_t get_options() const { return _current_options; }
     bool update_options() const { return _defaults_set && _options != _current_options; }


### PR DESCRIPTION
This configures the VTX singleton from the SRXL2 or DSM VTX packet. If you have a Spektrum TX that supports it and a supported VTX (currently only CRSF) this allows you to configure the VTX from your transmitter.