### PR TITLE
AP_Scripting: Add user accessable script parameters

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -77,6 +77,30 @@ const AP_Param::GroupInfo AP_Scripting::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DEBUG_LVL", 4, AP_Scripting, _debug_level, 0),
 
+    // @Param: USER1
+    // @DisplayName: Scripting User Parameter1
+    // @Description: General purpose user variable input for scripts
+    // @User: Standard
+    AP_GROUPINFO("USER1", 5, AP_Scripting, _user[0], 0.0),
+
+    // @Param: USER2
+    // @DisplayName: Scripting User Parameter2
+    // @Description: General purpose user variable input for scripts
+    // @User: Standard
+    AP_GROUPINFO("USER2", 6, AP_Scripting, _user[1], 0.0),
+
+    // @Param: USER3
+    // @DisplayName: Scripting User Parameter3
+    // @Description: General purpose user variable input for scripts
+    // @User: Standard
+    AP_GROUPINFO("USER3", 7, AP_Scripting, _user[2], 0.0),
+
+    // @Param: USER4
+    // @DisplayName: Scripting User Parameter4
+    // @Description: General purpose user variable input for scripts
+    // @User: Standard
+    AP_GROUPINFO("USER4", 8, AP_Scripting, _user[3], 0.0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -41,6 +41,9 @@ public:
 
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
 
+   // User parameters for inputs into scripts 
+   AP_Float _user[4]; 
+
     struct terminal_s {
         int output_fd;
         off_t input_offset;


### PR DESCRIPTION
complementing  #14777 which I had suggested and @IamPete1 quickly,, and generously, coded to get user re-configurations into a script without the user having to actually edit a script (simple, but which may be daunting to some), I think this is also needed.

- it allows analog variable input by user param into the script
flagging both with DEVCALL for discussion