### PR TITLE
AP_Proximity: Check for valid reading before pushing to OA DB

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -174,7 +174,7 @@ void AP_Proximity_Backend::update_boundary_for_sector(const uint8_t sector, cons
         return;
     }
 
-    if (push_to_OA_DB) {
+    if (push_to_OA_DB && _distance_valid[sector]) {
         database_push(_angle[sector], _distance[sector]);
     }
 


### PR DESCRIPTION
Has been tested on CubeOrange + Benewake Tfmini plus.
This single word addition made all the difference. False data was being pushed into OA Database (Like out of range reading, was being sent as "0" distance") hence tricking BendyRuler to act against false objects.