### PR TITLE
Dynamic Harmonics uses wrong number of harmonics with FFT

### DIFF
--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -249,17 +249,23 @@ void AP_GyroFFT::init(uint32_t target_looptime_us)
         return;
     }
 
+    // count the number of active harmonics
+    for (uint8_t i = 0; i < HNF_MAX_HARMONICS; i++) {
+        if (_ins->get_gyro_harmonic_notch_harmonics() & (1<<i)) {
+            _harmonics++;
+        }
+    }
+    _harmonics = constrain_int16(_harmonics, 1, FrequencyPeak::MAX_TRACKED_PEAKS);
+
     // calculate harmonic multiplier. this assumes the harmonics configured on the 
     // harmonic notch reflect the multiples of the fundamental harmonic that should be tracked
     uint8_t first_harmonic = 0;
-    _harmonics = 1; // always search for 1
     if (_harmonic_fit > 0) {
         for (uint8_t i = 0; i < HNF_MAX_HARMONICS; i++) {
             if (_ins->get_gyro_harmonic_notch_harmonics() & (1<<i)) {
                 if (first_harmonic == 0) {
                     first_harmonic = i + 1;
                 } else {
-                    _harmonics++;
                     _harmonic_multiplier = float(i + 1) / first_harmonic;
                     break;
                 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -726,17 +726,8 @@ AP_InertialSensor::init(uint16_t sample_rate)
     _calculated_harmonic_notch_freq_hz[0] = _harmonic_notch_filter.center_freq_hz();
     _num_calculated_harmonic_notch_frequencies = 1;
 
-    uint8_t harmonics = _harmonic_notch_filter.harmonics();
-    // allocate INS_MAX_NOTCHES as harmonics if using DynamicHarmonic
-    if (_harmonic_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
-        harmonics = 0;
-        for (uint8_t h = 0; h < INS_MAX_NOTCHES; h++) {
-            harmonics = (harmonics << 1) + 1;
-        }
-    }
-
     for (uint8_t i=0; i<get_gyro_count(); i++) {
-        _gyro_harmonic_notch_filter[i].allocate_filters(harmonics, _harmonic_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch));
+        _gyro_harmonic_notch_filter[i].allocate_filters(_harmonic_notch_filter.harmonics(), _harmonic_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch));
         // initialise default settings, these will be subsequently changed in AP_InertialSensor_Backend::update_gyro()
         _gyro_harmonic_notch_filter[i].init(_gyro_raw_sample_rates[i], _calculated_harmonic_notch_freq_hz[0],
              _harmonic_notch_filter.bandwidth_hz(), _harmonic_notch_filter.attenuation_dB());

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -20,6 +20,7 @@
 #include "NotchFilter.h"
 
 #define HNF_MAX_HARMONICS 8
+#define HNF_MAX_HMNC_BITSET 0xF
 
 /*
   a filter that manages a set of notch filters targetted at a fundamental center frequency
@@ -87,7 +88,7 @@ public:
     // set the fundamental center frequency of the harmonic notch
     void set_center_freq_hz(float center_freq) { _center_freq_hz.set(center_freq); }
     // harmonics enabled on the harmonic notch
-    uint8_t harmonics(void) const { return _harmonics; }
+    uint8_t harmonics(void) const { return hasOption(Options::DynamicHarmonic) ? HNF_MAX_HMNC_BITSET : _harmonics; }
     // reference value of the harmonic notch
     float reference(void) const { return _reference; }
     // notch options
@@ -97,7 +98,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    // notch harmonics
+    // configured notch harmonics
     AP_Int8 _harmonics;
     // notch reference value
     AP_Float _reference;


### PR DESCRIPTION
The FFT subsystem ends up using the configured number of harmonics rather than the three peaks that are tracked even when INS_HNTCH_OPTS=2 (dynamic harmonics). The FFT code also stops too early when calculating the number of harmonics so that you can never have more than two.

Before this change I would only ever get two notches active on my Y6B