### PR TITLE
Adding GCS messages for Compass Calibration Start/Finish

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -115,6 +115,9 @@ void Compass::start_calibration_all(bool retry, bool autosave, float delay, bool
         // start all should only calibrate compasses that are being used
         _start_calibration(i,retry,delay);
     }
+
+    gcs().send_text(MAV_SEVERITY_INFO, "Beginning Compass Calibration");
+
 }
 
 void Compass::_cancel_calibration(uint8_t i)
@@ -169,6 +172,9 @@ bool Compass::_accept_calibration(uint8_t i)
         if (!is_calibrating()) {
             AP_Notify::events.compass_cal_saved = 1;
         }
+
+        gcs().send_text(MAV_SEVERITY_INFO, "Compass Calibration Complete");
+
         return true;
     } else {
         return false;


### PR DESCRIPTION
With FPV planes, it is common for a user to have a compass, but no telemetry radio, and no buzzer. When doing a compass calibration, it can be difficult to tell when you have successfully completed a compass calibration, or when you have successfully started a compass calibration using the joystick command. 

This is a super small change that adds a GCS message to the start and finish of the compass calibration, so that a user can see the message on Yaapu on their transmitter, or on their FPV OSD. 