### PR TITLE
AP_NavEKF2: fix ext nav init pos reset

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -320,6 +320,7 @@ void NavEKF2_core::setAidingMode()
             }
             // We have commenced aiding and external nav usage is allowed
             if (canUseExtNav) {
+                extNavPosResetRequest = true;
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using external nav data",(unsigned)imu_index);
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial pos NED = %3.1f,%3.1f,%3.1f (m)",(unsigned)imu_index,(double)extNavDataDelayed.pos.x,(double)extNavDataDelayed.pos.y,(double)extNavDataDelayed.pos.z);
                 //handle yaw reset as special case only if compass is disabled

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -540,7 +540,8 @@ void NavEKF2_core::SelectVelPosFusion()
     }
 
     // check for external nav position reset
-    if (extNavDataToFuse && (PV_AidingMode == AID_ABSOLUTE) && (frontend->_fusionModeGPS == 3) && extNavDataDelayed.posReset) {
+    if (extNavDataToFuse && (PV_AidingMode == AID_ABSOLUTE) && (frontend->_fusionModeGPS == 3) && (extNavDataDelayed.posReset || extNavPosResetRequest)) {
+        extNavPosResetRequest = false;
         ResetPositionNE(extNavDataDelayed.pos.x, extNavDataDelayed.pos.y);
         if (activeHgtSource == HGT_SOURCE_EXTNAV) {
             ResetPositionD(-hgtMea);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -338,6 +338,7 @@ void NavEKF2_core::InitialiseVariables()
     extNavUsedForYaw = false;
     extNavUsedForPos = false;
     extNavYawResetRequest = false;
+    extNavPosResetRequest = false;
 
     extNavVelNew = {};
     extNavVelDelayed = {};

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1192,6 +1192,7 @@ private:
     bool extNavUsedForYaw;              // true when the external nav data is also being used as a yaw observation
     bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.
     bool extNavYawResetRequest;         // true when a reset of vehicle yaw using the external nav data is requested
+    bool extNavPosResetRequest;         // true when a reset of vehicle pos using the external nav data is requested
 
     obs_ring_buffer_t<ext_nav_vel_elements> storedExtNavVel; // external navigation velocity data buffer
     ext_nav_vel_elements extNavVelNew;                       // external navigation velocity data at the current time horizon


### PR DESCRIPTION
fix #14801 

It reuse codes added in  #14122 (thanks @rmackay9)

[23 1980-1-1 08-00-00.zip](https://github.com/ArduPilot/ardupilot/files/4911375/23.1980-1-1.08-00-00.zip)
![Log Browser - 23 1980-1-1 上午 08-00-00 bin 2020_7_13 下午 04_55_24](https://user-images.githubusercontent.com/19793511/87285080-ab825d80-c529-11ea-8055-f4faab9e3e3e.png)

It seems a little strange that ResetPosition() in AP_NavEKF2_Control.cpp do not work
https://github.com/ArduPilot/ardupilot/blob/907ad5e25c1229cccbf056599e0284d8a8dbd830/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp#L346

But ResetPositionNE() added in  #14122 works well
https://github.com/ArduPilot/ardupilot/blob/907ad5e25c1229cccbf056599e0284d8a8dbd830/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp#L544