### PR TITLE
AP_RangeFinder: No specification of baud rate

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
@@ -34,7 +34,7 @@ AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial(
 {
     uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {
-        uart->begin(initial_baudrate(serial_instance), rx_bufsize(), tx_bufsize());
+        uart->begin(0, rx_bufsize(), tx_bufsize());
     }
 }
 


### PR DESCRIPTION
I found out that the UART->begin baud rate re-set doesn't work.
I looked at the source and misunderstood that it would be reconfigured.
I think it would be better to limit the buffer size specification to TX and RX.
I would set the baud rate setting to 0.

I would set the baud rate value to the SERIALx baud rate in the config parameter, if this feature is enabled. There is no need to set the It also eliminates the need to describe the WIKI baud rate.

https://github.com/ArduPilot/ardupilot/issues/14796