### PR TITLE
ArduPlane: conform to the format

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -395,7 +395,7 @@ void Plane::do_land(const AP_Mission::Mission_Command& cmd)
         if (! geofence_set_floor_enabled(false)) {
             gcs().send_text(MAV_SEVERITY_NOTICE, "Disable fence floor failed (autodisable)");
         } else {
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Fence floor disabled (auto disable)");
+            gcs().send_text(MAV_SEVERITY_NOTICE, "Fence floor disabled (autodisable)");
         }
     }
 #endif


### PR DESCRIPTION
I had "autodisable" and different "auto disable" in the same method.
I don't feel the need to make it "auto disable".
I think it would be better to match the formatting.