### PR TITLE
AP_Scripting: logging add units and multipliers

### DIFF
--- a/libraries/AP_Scripting/examples/logging.lua
+++ b/libraries/AP_Scripting/examples/logging.lua
@@ -27,9 +27,13 @@ local function write_to_dataflash()
 
   -- care must be taken when selecting a name, must be less than four characters and not clash with an existing log type
   -- format characters specify the type of variable to be logged, see AP_Logger/README.md
+  -- https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Logger
   -- not all format types are supported by scripting only: i, L, e, f, n, M, B, I, E, and N
   -- lua automatically adds a timestamp in micro seconds
-  logger.write('SCR','roll(deg),pitch(deg),yaw(deg)','fff',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
+  logger.write('SCR1','roll(deg),pitch(deg),yaw(deg)','fff',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
+
+  -- it is also possible to give units and multipliers
+  logger.write('SCR2','roll,pitch,yaw','fff','ddd','---',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
 
 end
 


### PR DESCRIPTION
This adds the ability to log units and multipliers from scripting. 

Works as expected except I'm losing the first two characters of the multipliers, they seem to be OK before they get sent to AP_Logger, any ideas?