### PR TITLE
AP_NavEKF2:  fix pos not reset to ext nav init pos

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -155,6 +155,8 @@ void NavEKF2_core::setWindMagStateLearningMode()
 // Set inertial navigation aiding mode
 void NavEKF2_core::setAidingMode()
 {
+    resetDataSource resetSrc = DEFAULT;
+
     // Save the previous status so we can detect when it has changed
     PV_AidingModePrev = PV_AidingMode;
 
@@ -316,6 +318,7 @@ void NavEKF2_core::setAidingMode()
             }
             // We have commenced aiding and external nav usage is allowed
             if (canUseExtNav) {
+                resetSrc = EXTNAV;
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using external nav data",(unsigned)imu_index);
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial pos NED = %3.1f,%3.1f,%3.1f (m)",(unsigned)imu_index,(double)extNavDataDelayed.pos.x,(double)extNavDataDelayed.pos.y,(double)extNavDataDelayed.pos.z);
                 //handle yaw reset as special case only if compass is disabled
@@ -337,7 +340,7 @@ void NavEKF2_core::setAidingMode()
 
         // Always reset the position and velocity when changing mode
         ResetVelocity();
-        ResetPosition();
+        ResetPosition(resetSrc);
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -82,7 +82,7 @@ void NavEKF2_core::ResetVelocity(void)
 }
 
 // resets position states to last GPS measurement or to zero if in constant position mode
-void NavEKF2_core::ResetPosition(void)
+void NavEKF2_core::ResetPosition(resetDataSource resetSrc)
 {
     // Store the position before the reset so that we can record the reset delta
     posResetNE.x = stateStruct.position.x;
@@ -124,9 +124,9 @@ void NavEKF2_core::ResetPosition(void)
             // clear the timeout flags and counters
             rngBcnTimeout = false;
             lastRngBcnPassTime_ms = imuSampleTime_ms;
-        } else if (imuSampleTime_ms - extNavMeasTime_ms < 250) {
+        } else if ((imuSampleTime_ms - extNavDataDelayed.time_ms < 250) || resetSrc == EXTNAV) {
             // use external nav data as the third preference
-            ext_nav_elements extNavCorrected = extNavDataNew;
+            ext_nav_elements extNavCorrected = extNavDataDelayed;
             // extNavDataDelay is too old to pass time check
             CorrectExtNavForSensorOffset(extNavCorrected.pos);
             stateStruct.position.x = extNavCorrected.pos.x;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -124,14 +124,18 @@ void NavEKF2_core::ResetPosition(void)
             // clear the timeout flags and counters
             rngBcnTimeout = false;
             lastRngBcnPassTime_ms = imuSampleTime_ms;
-        } else if (imuSampleTime_ms - extNavDataDelayed.time_ms < 250) {
+        } else if (imuSampleTime_ms - extNavMeasTime_ms < 250) {
             // use external nav data as the third preference
-            ext_nav_elements extNavCorrected = extNavDataDelayed;
+            ext_nav_elements extNavCorrected = extNavDataNew;
+            // extNavDataDelay is too old to pass time check
             CorrectExtNavForSensorOffset(extNavCorrected.pos);
             stateStruct.position.x = extNavCorrected.pos.x;
             stateStruct.position.y = extNavCorrected.pos.y;
             // set the variances from the external nav filter
             P[7][7] = P[6][6] = sq(extNavCorrected.posErr);
+            // clear the timeout flags and counters
+            posTimeout = false;
+            lastPosPassTime_ms = imuSampleTime_ms;
         }
     }
     for (uint8_t i=0; i<imu_buffer_length; i++) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1187,7 +1187,6 @@ private:
     ext_nav_elements extNavDataDelayed; // External nav at the fusion time horizon
     uint32_t extNavMeasTime_ms;         // time external measurements were accepted for input to the data buffer (msec)
     uint32_t extNavLastPosResetTime_ms; // last time the external nav systen performed a position reset (msec)
-    uint32_t lastExtNavPassTime_ms;     // time stamp when external nav position measurement last passed innovation consistency check (msec)
     bool extNavDataToFuse;              // true when there is new external nav data to fuse
     bool extNavUsedForYaw;              // true when the external nav data is also being used as a yaw observation
     bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -524,6 +524,19 @@ private:
         uint32_t time_ms;           // measurement timestamp (msec)
     };
 
+    // Specify source of data to be used for a partial state reset
+    // Checking the availability and quality of the data source specified is the responsibility of the caller
+    enum resetDataSource {
+                    DEFAULT=0,      // Use data source selected by reset function internal rules
+                    GPS=1,          // Use GPS
+                    RNGBCN=2,       // Use beacon range data
+                    FLOW=3,         // Use optical flow rates
+                    BARO=4,         // Use Baro height
+                    MAG=5,          // Use magnetometer data
+                    RNGFND=6,       // Use rangefinder data
+                    EXTNAV=7        // Use external nav data
+                        };
+
     // update the navigation filter status
     void  updateFilterStatus(void);
 
@@ -685,7 +698,7 @@ private:
     void InitialiseVariablesMag();
 
     // reset the horizontal position states uing the last GPS measurement
-    void ResetPosition(void);
+    void ResetPosition(resetDataSource resetSrc = DEFAULT);
 
     // reset the stateStruct's NE position to the specified position
     void ResetPositionNE(float posN, float posE);


### PR DESCRIPTION
replace #14805 to fix #14801

`ResetPosition()` use `extNavDataDelayed`, but it is too old to pass `imuSampleTime_ms - extNavDataDelayed.time_ms < 250`. It makes EKF never reset to ext nav init pos

flight test log for this PR [36 1980-1-1 08-00-00.zip](https://github.com/ArduPilot/ardupilot/files/4917138/36.1980-1-1.08-00-00.zip)

And lastExtNavPassTime_ms is not really necessary.


