### PR TITLE
AC_Avoid: Do not show some param's for Rover and Remove extra margin used in stop behaviour in circular fences

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -37,21 +37,21 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ENABLE", 1,  AC_Avoid, _enabled, AC_AVOID_DEFAULT),
 
-    // @Param: ANGLE_MAX
+    // @Param{Copter}: ANGLE_MAX
     // @DisplayName: Avoidance max lean angle in non-GPS flight modes
     // @Description: Max lean angle used to avoid obstacles while in non-GPS modes
     // @Units: cdeg
     // @Range: 0 4500
     // @User: Standard
-    AP_GROUPINFO("ANGLE_MAX", 2,  AC_Avoid, _angle_max, 1000),
+    AP_GROUPINFO_FRAME("ANGLE_MAX", 2,  AC_Avoid, _angle_max, 1000, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
 
-    // @Param: DIST_MAX
+    // @Param{Copter}: DIST_MAX
     // @DisplayName: Avoidance distance maximum in non-GPS flight modes
     // @Description: Distance from object at which obstacle avoidance will begin in non-GPS modes
     // @Units: m
     // @Range: 1 30
     // @User: Standard
-    AP_GROUPINFO("DIST_MAX", 3,  AC_Avoid, _dist_max, AC_AVOID_NONGPS_DIST_MAX_DEFAULT),
+    AP_GROUPINFO_FRAME("DIST_MAX", 3,  AC_Avoid, _dist_max, AC_AVOID_NONGPS_DIST_MAX_DEFAULT, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
 
     // @Param: MARGIN
     // @DisplayName: Avoidance distance margin in GPS modes
@@ -61,12 +61,12 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("MARGIN", 4, AC_Avoid, _margin, 2.0f),
 
-    // @Param: BEHAVE
+    // @Param{Copter}: BEHAVE
     // @DisplayName: Avoidance behaviour
     // @Description: Avoidance behaviour (slide or stop)
     // @Values: 0:Slide,1:Stop
     // @User: Standard
-    AP_GROUPINFO("BEHAVE", 5, AC_Avoid, _behavior, AP_AVOID_BEHAVE_DEFAULT),
+    AP_GROUPINFO_FRAME("BEHAVE", 5, AC_Avoid, _behavior, AP_AVOID_BEHAVE_DEFAULT, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
 
     AP_GROUPEND
 };

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -375,7 +375,7 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
             // shorten vector without adjusting its direction
             Vector2f intersection;
             if (Vector2f::circle_segment_intersection(position_xy, stopping_point_plus_margin, Vector2f(0.0f,0.0f), fence_radius - margin_cm, intersection)) {
-                const float distance_to_target = MAX((intersection - position_xy).length() - margin_cm, 0.0f);
+                const float distance_to_target = (intersection - position_xy).length();
                 const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
                 if (max_speed < desired_speed) {
                     desired_vel_cms *= MAX(max_speed, 0.0f) / desired_speed;
@@ -525,7 +525,7 @@ void AC_Avoid::adjust_velocity_inclusion_circles(float kP, float accel_cmss, Vec
                         // shorten vector without adjusting its direction
                         Vector2f intersection;
                         if (Vector2f::circle_segment_intersection(position_NE_rel, stopping_point_plus_margin, Vector2f(0.0f,0.0f), radius_cm - margin_cm, intersection)) {
-                            const float distance_to_target = MAX((intersection - position_NE_rel).length() - margin_cm, 0.0f);
+                            const float distance_to_target = (intersection - position_NE_rel).length();
                             const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
                             if (max_speed < desired_speed) {
                                 desired_vel_cms *= MAX(max_speed, 0.0f) / desired_speed;
@@ -635,7 +635,7 @@ void AC_Avoid::adjust_velocity_exclusion_circles(float kP, float accel_cmss, Vec
                         // shorten vector without adjusting its direction
                         Vector2f intersection;
                         if (Vector2f::circle_segment_intersection(position_NE_rel, stopping_point_plus_margin, Vector2f(0.0f,0.0f), radius_cm + margin_cm, intersection)) {
-                            const float distance_to_target = MAX((intersection - position_NE_rel).length() - margin_cm, 0.0f);
+                            const float distance_to_target = (intersection - position_NE_rel).length();
                             const float max_speed = get_max_speed(kP, accel_cmss, distance_to_target, dt);
                             if (max_speed < desired_speed) {
                                 desired_vel_cms *= MAX(max_speed, 0.0f) / desired_speed;


### PR DESCRIPTION
This PR contains to completely different commits:
1. Solves #14806
2. Is something that I found, if one notice's looks at the stop behavior in Fence for simple avoidance, Margin has been used twice in most places... So for eg: 
` if you look at line 377,378 https://github.com/ArduPilot/ardupilot/blob/1db0feea59bfc7b531fff957d7eed4ff00b1dfb7/libraries/AC_Avoidance/AC_Avoid.cpp#L377
https://github.com/ArduPilot/ardupilot/blob/1db0feea59bfc7b531fff957d7eed4ff00b1dfb7/libraries/AC_Avoidance/AC_Avoid.cpp#L378

First fence radius is calculated with a margin... Then distance to target is caculated with a margin, leading to the vehicle stopping at twice the margin.

**Testing videos** (do look at console for distance to fence, and titile for FENCE_MARGIN param) :
A. Exclusion Fence:

-  Master: https://youtu.be/SYBAOh35md4
-  After PR: https://youtu.be/nECBbCLqEJQ

B. Circular Fence:
- Master: https://youtu.be/24hvm1djefw
- After PR: https://youtu.be/zhElpfYIxs0

C. Inclusion Fence:
- After PR: https://youtu.be/GvyGbDDmWTg

You might be able to notice that the vehicle now breaches the margin just by a few cm's (I guess because of the inertia it has before stopping). I think this is better than stopping at twice the margin... Also backing away from objects is soon going to be a part of Simple Avoidance... So I guess we can afford it.