### PR TITLE
AP_NavEKF3: max delay includes visual odometry

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -6,6 +6,7 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_VisualOdom/AP_VisualOdom.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -92,6 +93,14 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
     if (_ahrs->airspeed_sensor_enabled()) {
         maxTimeDelay_ms = MAX(maxTimeDelay_ms , frontend->tasDelay_ms);
     }
+
+#if HAL_VISUALODOM_ENABLED
+    // include delay from visual odometry if enabled
+    AP_VisualOdom *visual_odom = AP::visualodom();
+    if ((visual_odom != nullptr) && visual_odom->enabled()) {
+        maxTimeDelay_ms = MAX(maxTimeDelay_ms, MIN(visual_odom->get_delay_ms(), 250));
+    }
+#endif
 
     // calculate the IMU buffer length required to accommodate the maximum delay with some allowance for jitter
     imu_buffer_length = (maxTimeDelay_ms / (uint16_t)(EKF_TARGET_DT_MS)) + 1;


### PR DESCRIPTION
This PR updates EKF3's maximum delay calculation so that it takes into account the Visual Odometry delay (VISO_DELAY_MS parameter) which improves performance for external navigation systems that have a delay longer than the other sensors (barometer, optical flow, rangefinder, compass).  The maximum delay is still capped at 250ms.

This resolves issue https://github.com/ArduPilot/ardupilot/issues/14818

This has been lightly tested in SITL and on a real vehicle that had an external navigation system with about 250ms of delay and this PR visibly improved performance.

Below is a screen shot of a SITL test in which the maximum delay is displayed on the GCS to ensure the viso delay was being included correctly.
![ekf3-viso-delay](https://user-images.githubusercontent.com/1498098/87512111-6be67d80-c6b1-11ea-92c2-19996072884e.png)

