### PR TITLE
AP_Common: Replace some Macro with Type safe template

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -1,6 +1,7 @@
 #include "Copter.h"
 
 #include "RC_Channel.h"
+#include <AP_Common/bitops.h>
 
 
 // defining these two macros and including the RC_Channels_VarInfo header defines the parameter information common to all vehicle types

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -39,10 +39,10 @@ void RC_Channel_Copter::mode_switch_changed(modeswitch_pos_t new_pos)
         !rc().find_channel_for_option(AUX_FUNC::SUPERSIMPLE_MODE)) {
         // if none of the Aux Switches are set to Simple or Super Simple Mode then
         // set Simple Mode using stored parameters from EEPROM
-        if (BIT_IS_SET(copter.g.super_simple, new_pos)) {
+        if (BIT_IS_SET(copter.g.super_simple.get(), new_pos)) {
             copter.set_simple_mode(Copter::SimpleMode::SUPERSIMPLE);
         } else {
-            copter.set_simple_mode(BIT_IS_SET(copter.g.simple_modes, new_pos) ? Copter::SimpleMode::SIMPLE : Copter::SimpleMode::NONE);
+            copter.set_simple_mode(BIT_IS_SET(copter.g.simple_modes.get(), new_pos) ? Copter::SimpleMode::SIMPLE : Copter::SimpleMode::NONE);
         }
     }
 }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1,4 +1,5 @@
 #include "Copter.h"
+#include <AP_Common/bitops.h>
 
 #if MODE_AUTO_ENABLED == ENABLED
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -1,4 +1,5 @@
 #include "Plane.h"
+#include <AP_Common/bitops.h>
 
 /********************************************************************************/
 // Command Event Handlers

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -1,6 +1,7 @@
 #include "Sub.h"
 
 #include <AP_RTC/AP_RTC.h>
+#include <AP_Common/bitops.h>
 
 static enum AutoSurfaceState auto_surface_state = AUTO_SURFACE_STATE_GO_TO_LOCATION;
 

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -22,7 +22,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <type_traits>
 
 // used to pack structures
 #define PACKED __attribute__((__packed__))
@@ -72,44 +71,6 @@
 #define DEFINE_BYTE_ARRAY_METHODS                                                                   \
     inline uint8_t &operator[](size_t i) { return reinterpret_cast<uint8_t *>(this)[i]; }           \
     inline uint8_t operator[](size_t i) const { return reinterpret_cast<const uint8_t *>(this)[i]; }
-
-/**
- * Check if bit bitnumber is set in value, returned as a
- * bool. Bitnumber starts at 0 for the first bit
- * @tparam T the variable type. It should be an integer type
- * @param value the variable
- * @param bitnumber bit number to be checked
- * @return true if the bit is setted, false otherwise
- */
-template <typename T>
-bool BIT_IS_SET(T value, uint8_t bitnumber) noexcept {
-    static_assert(std::is_integral<T>::value, "Integral required.");
-    return (value & (1U<<(bitnumber))) != 0;
-}
-
-/**
- * Get low byte from 2 bytes integer
- * @tparam T the variable type. It will be checked to be uint16_t
- * @param i the variable
- * @return the low byte
- */
-template <typename T>
-uint8_t LOWBYTE (T const& i) noexcept {
-    static_assert(std::is_same<T, uint16_t>::value, "type must be `uint16_t`");
-    return static_cast<uint8_t>(i);
-}
-
-/**
- * Get high byte from 2 bytes integer
- * @tparam T the variable type. It will be checked to be uint16_t
- * @param i the variable
- * @return the high byte
- */
-template <typename T>
-uint8_t HIGHBYTE (T const& i) noexcept {
-    static_assert(std::is_same<T, uint16_t>::value, "type must be `uint16_t`");
-    return static_cast<uint8_t>(i>>8);
-}
 
 #define ARRAY_SIZE(_arr) (sizeof(_arr) / sizeof(_arr[0]))
 
@@ -173,17 +134,3 @@ bool hex_to_uint8(uint8_t a, uint8_t &res);  // return the uint8 value of an asc
   strncpy without the warning for not leaving room for nul termination
  */
 void strncpy_noterm(char *dest, const char *src, size_t n);
-
-/*
-  Bit manipulation
- */
-//#define BIT_SET(value, bitnumber) ((value) |= (((typeof(value))1U) << (bitnumber)))
-template <typename T> void BIT_SET (T& value, uint8_t bitnumber) noexcept {
-     static_assert(std::is_integral<T>::value, "Integral required.");
-     ((value) |= ((T)(1U) << (bitnumber)));
- }
-//#define BIT_CLEAR(value, bitnumber) ((value) &= ~(((typeof(value))1U) << (bitnumber)))
-template <typename T> void BIT_CLEAR (T& value, uint8_t bitnumber) noexcept {
-     static_assert(std::is_integral<T>::value, "Integral required.");
-     ((value) &= ~((T)(1U) << (bitnumber)));
- }

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -73,11 +73,19 @@
     inline uint8_t &operator[](size_t i) { return reinterpret_cast<uint8_t *>(this)[i]; }           \
     inline uint8_t operator[](size_t i) const { return reinterpret_cast<const uint8_t *>(this)[i]; }
 
-/*
-  check if bit bitnumber is set in value, returned as a
-  bool. Bitnumber starts at 0 for the first bit
+/**
+ * Check if bit bitnumber is set in value, returned as a
+ * bool. Bitnumber starts at 0 for the first bit
+ * @tparam T the variable type. It should be an integer type
+ * @param value the variable
+ * @param bitnumber bit number to be checked
+ * @return true if the bit is setted, false otherwise
  */
-#define BIT_IS_SET(value, bitnumber) (((value) & (1U<<(bitnumber))) != 0)
+template <typename T>
+bool BIT_IS_SET(T value, uint8_t bitnumber) noexcept {
+    static_assert(std::is_integral<T>::value, "Integral required.");
+    return (value & (1U<<(bitnumber))) != 0;
+}
 
 /**
  * Get low byte from 2 bytes integer

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -79,9 +79,29 @@
  */
 #define BIT_IS_SET(value, bitnumber) (((value) & (1U<<(bitnumber))) != 0)
 
-// get high or low bytes from 2 byte integer
-#define LOWBYTE(i) ((uint8_t)(i))
-#define HIGHBYTE(i) ((uint8_t)(((uint16_t)(i))>>8))
+/**
+ * Get low byte from 2 bytes integer
+ * @tparam T the variable type. It will be checked to be uint16_t
+ * @param i the variable
+ * @return the low byte
+ */
+template <typename T>
+uint8_t LOWBYTE (T const& i) noexcept {
+    static_assert(std::is_same<T, uint16_t>::value, "type must be `uint16_t`");
+    return static_cast<uint8_t>(i);
+}
+
+/**
+ * Get high byte from 2 bytes integer
+ * @tparam T the variable type. It will be checked to be uint16_t
+ * @param i the variable
+ * @return the high byte
+ */
+template <typename T>
+uint8_t HIGHBYTE (T const& i) noexcept {
+    static_assert(std::is_same<T, uint16_t>::value, "type must be `uint16_t`");
+    return static_cast<uint8_t>(i>>8);
+}
 
 #define ARRAY_SIZE(_arr) (sizeof(_arr) / sizeof(_arr[0]))
 

--- a/libraries/AP_Common/bitops.h
+++ b/libraries/AP_Common/bitops.h
@@ -1,0 +1,87 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Bits manipulations utilities
+ */
+#pragma once
+
+#include <type_traits>
+#include <stdint.h>
+
+/**
+ * Check if bit bitnumber is set in value, returned as a
+ * bool. Bitnumber starts at 0 for the first bit
+ * @tparam T the variable type. It should be an integer type
+ * @param value the variable
+ * @param bitnumber bit number to be checked
+ * @return true if the bit is setted, false otherwise
+ */
+template <typename T>
+bool BIT_IS_SET(T value, uint8_t bitnumber) noexcept {
+    static_assert(std::is_integral<T>::value, "Integral required.");
+    return (value & (1U<<(bitnumber))) != 0;
+}
+
+/**
+ * Get low byte from 2 bytes integer
+ * @tparam T the variable type. It will be checked to be uint16_t
+ * @param i the variable
+ * @return the low byte
+ */
+template <typename T>
+uint8_t LOWBYTE (T const& i) noexcept {
+    static_assert(std::is_same<T, uint16_t>::value, "type must be `uint16_t`");
+    return static_cast<uint8_t>(i);
+}
+
+/**
+ * Get high byte from 2 bytes integer
+ * @tparam T the variable type. It will be checked to be uint16_t
+ * @param i the variable
+ * @return the high byte
+ */
+template <typename T>
+uint8_t HIGHBYTE (T const& i) noexcept {
+    static_assert(std::is_same<T, uint16_t>::value, "type must be `uint16_t`");
+    return static_cast<uint8_t>(i>>8);
+}
+
+/*
+  Bit manipulation
+ */
+/**
+ * Set a bit in a variable
+ * @tparam T the variable type. It will be checked to be integral type
+ * @param value the variable
+ * @param bitnumber the bit to set
+ */
+//#define BIT_SET(value, bitnumber) ((value) |= (((typeof(value))1U) << (bitnumber)))
+template <typename T> void BIT_SET (T& value, uint8_t bitnumber) noexcept {
+    static_assert(std::is_integral<T>::value, "Integral required.");
+    ((value) |= (static_cast<T>(1U) << (bitnumber)));
+}
+
+/**
+ * Clear a bit in a variable
+ * @tparam T the variable type. It will be checked to be integral type
+ * @param value the variable
+ * @param bitnumber the bit to clear
+ */
+//#define BIT_CLEAR(value, bitnumber) ((value) &= ~(((typeof(value))1U) << (bitnumber)))
+template <typename T> void BIT_CLEAR (T& value, uint8_t bitnumber) noexcept {
+    static_assert(std::is_integral<T>::value, "Integral required.");
+    ((value) &= ~(static_cast<T>(1U) << (bitnumber)));
+}

--- a/libraries/AP_Common/examples/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/examples/AP_Common/AP_Common.cpp
@@ -4,6 +4,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Common/bitops.h>
 
 void setup();
 void loop();

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -27,6 +27,7 @@
 #include <AP_RSSI/AP_RSSI.h>
 #include <AP_RTC/AP_RTC.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Common/bitops.h>
 
 #include "AP_MSP.h"
 #include "AP_MSP_Telem_Backend.h"

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -15,6 +15,7 @@
 
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_Common/bitops.h>
 
 #include "AP_MSP.h"
 #include "AP_MSP_Telem_DJI.h"

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -5,6 +5,7 @@
 #include <AP_Terrain/AP_Terrain.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Common/bitops.h>
 
 const AP_Param::GroupInfo AP_Mission::var_info[] = {
 

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -18,6 +18,7 @@
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/crc.h>
 #include "AP_Proximity_LightWareSF40C.h"
+#include <AP_Common/bitops.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSerial.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSerial.cpp
@@ -19,6 +19,7 @@
 #include <AP_Math/crc.h>
 #include "AP_Proximity_LightWareSerial.h"
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Common/bitops.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
@@ -16,6 +16,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
 #include "AP_RangeFinder_BLPing.h"
+#include <AP_Common/bitops.h>
 
 void AP_RangeFinder_BLPing::update(void)
 {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
@@ -116,9 +116,9 @@ void PingProtocol::send_message(AP_HAL::UARTDriver *uart, PingProtocol::MessageI
     crc += LOWBYTE(payload_len) + HIGHBYTE(payload_len);
 
     // message id
-    uart->write(LOWBYTE(msg_id));
-    uart->write(HIGHBYTE(msg_id));
-    crc += LOWBYTE(msg_id) + HIGHBYTE(msg_id);
+    uart->write(LOWBYTE(static_cast<uint16_t>(msg_id)));
+    uart->write(HIGHBYTE(static_cast<uint16_t>(msg_id)));
+    crc += LOWBYTE(static_cast<uint16_t>(msg_id)) + HIGHBYTE(static_cast<uint16_t>(msg_id));
 
     // src dev id
     uart->write(_src_id);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.h
@@ -26,7 +26,7 @@ class PingProtocol {
     static constexpr uint16_t _dst_id = 1; // sensor's id
 
 public:
-    enum class MessageId {
+    enum class MessageId : uint16_t {
         INVALID = 0,
         SET_PING_INTERVAL = 1004,
         DISTANCE_SIMPLE = 1211,

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -17,6 +17,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/crc.h>
+#include <AP_Common/bitops.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarVu8.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarVu8.cpp
@@ -17,6 +17,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <ctype.h>
+#include <AP_Common/bitops.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -17,6 +17,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <ctype.h>
+#include <AP_Common/bitops.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
@@ -6,6 +6,7 @@
  */
 #include <AP_HAL/AP_HAL.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <AP_Common/bitops.h>
 
 #include "AP_Volz_Protocol.h"
 


### PR DESCRIPTION
Replace some macro with their template equivalent.
Output is the same on optimized code see https://gcc.godbolt.org/z/svh3bP
The template version is safer and allow to put more static check in it