### PR TITLE
Add support for register check in Invensensev2 Driver

### DIFF
--- a/libraries/AP_HAL/Device.cpp
+++ b/libraries/AP_HAL/Device.cpp
@@ -79,6 +79,29 @@ void AP_HAL::Device::set_checked_register(uint8_t reg, uint8_t val)
     _checked.n_set++;
 }
 
+void AP_HAL::Device::set_checked_register(uint8_t bank, uint8_t reg, uint8_t val)
+{
+    if (_checked.regs == nullptr) {
+        return;
+    }
+    struct checkreg *regs = _checked.regs;
+    for (uint8_t i=0; i<_checked.n_set; i++) {
+        if (regs[i].regnum == reg && regs[i].bank == bank) {
+            regs[i].value = val;
+            return;
+        }
+    }
+    if (_checked.n_set == _checked.n_allocated) {
+        printf("Not enough checked registers for reg 0x%02x on device 0x%x\n",
+               (unsigned)reg, (unsigned)get_bus_id());
+        return;
+    }
+    regs[_checked.n_set].bank = bank;
+    regs[_checked.n_set].regnum = reg;
+    regs[_checked.n_set].value = val;
+    _checked.n_set++;
+}
+
 /*
   check one register value
  */
@@ -94,6 +117,19 @@ bool AP_HAL::Device::check_next_register(void)
 
     struct checkreg &reg = _checked.regs[_checked.next];
     uint8_t v;
+
+    if (_bank_select) {
+        if (!_bank_select(reg.bank)) {
+        // Cannot set bank
+#if 0
+        printf("Device 0x%x set bank 0x%02x\n",
+               (unsigned)get_bus_id(),
+               (unsigned)reg.bank);
+#endif
+            return false;
+        }
+    }
+
     if (!read_registers(reg.regnum, &v, 1) || v != reg.value) {
         // a register has changed value unexpectedly. Try changing it back
         // and re-check it next time


### PR DESCRIPTION
This PR adds support for checked register setup for bank based addressing setups, like the one employed in Invensensev2 Driver.
The Logic trace is attached herewith for anyone to look. The contains data on the SPI bus on IMU board in CubeOrange, the sensor comms were disabled by pulling up the CS pin of the Invensensev2 sensor. Will also upload the flight test results as soon as done

[Download Logic Data Trace](https://drive.google.com/file/d/1crti36z60MVKRTWvrzIAKFmvAmZUgAgl/view?usp=sharing
)

