### PR TITLE
add support for checked register in Invensensev2 Driver

### DIFF
--- a/libraries/AP_HAL/Device.h
+++ b/libraries/AP_HAL/Device.h
@@ -42,6 +42,8 @@ public:
     FUNCTOR_TYPEDEF(PeriodicCb, void);
     typedef void* PeriodicHandle;
 
+    FUNCTOR_TYPEDEF(BankSelectCb, bool, uint8_t);
+
     Device(enum BusType type)
     {
         _bus_id.devid_s.bus_type = type;
@@ -133,6 +135,56 @@ public:
     }
 
     /**
+     * Wrapper function over #transfer() to call bank selection callback
+     * and then invoke the transfer call
+     *
+     * Return: true on a successful transfer, false on failure.
+     */
+    bool transfer_bank(uint8_t bank, const uint8_t *send, uint32_t send_len,
+                          uint8_t *recv, uint32_t recv_len) {
+        if (_bank_select) {
+            if (!_bank_select(bank)) {
+                return false;
+            }
+        }
+        return transfer(send, send_len, recv, recv_len);
+    }
+
+    /**
+     * Wrapper function over #transfer_bank() to read recv_len registers, starting
+     * by first_reg, into the array pointed by recv. The read flag passed to
+     * #set_read_flag(uint8_t) is ORed with first_reg before performing the
+     * transfer.
+     *
+     * Return: true on a successful transfer, false on failure.
+     */
+    bool read_bank_registers(uint8_t bank, uint8_t first_reg, uint8_t *recv, uint32_t recv_len)
+    {
+        first_reg |= _read_flag;
+        return transfer_bank(bank, &first_reg, 1, recv, recv_len);
+    }
+
+    /**
+     * Wrapper function over #transfer_bank() to write a byte to the register reg.
+     * The transfer is done by sending reg and val in that order.
+     *
+     * Return: true on a successful transfer, false on failure.
+     */
+    bool write_bank_register(uint8_t bank, uint8_t reg, uint8_t val, bool checked=false)
+    {
+        uint8_t buf[2] = { reg, val };
+        if (checked) {
+            set_checked_register(bank, reg, val);
+        }
+        return transfer_bank(bank, buf, sizeof(buf), nullptr, 0);
+    }
+
+    /**
+     * set a value for a checked register in a bank
+     */
+    void set_checked_register(uint8_t bank, uint8_t reg, uint8_t val);
+
+    /**
      * set a value for a checked register
      */
     void set_checked_register(uint8_t reg, uint8_t val);
@@ -197,6 +249,20 @@ public:
      * otherwise.
      */
     virtual bool unregister_callback(PeriodicHandle h) { return false; }
+
+    /*
+     * Sets a bank_select callback to be used for bank selection during register check
+     */
+    virtual void setup_bankselect_callback(BankSelectCb bank_select) {
+        _bank_select = bank_select;
+    }
+
+    /*
+     * Sets a bank_select callback to be used for bank selection during register check
+     */
+    virtual void deregister_bankselect_callback() {
+        _bank_select = nullptr;
+    }
 
 
     /*
@@ -322,8 +388,11 @@ protected:
     }
 
 private:
+    BankSelectCb _bank_select;
+
     // checked registers
     struct checkreg {
+        uint8_t bank;
         uint8_t regnum;
         uint8_t value;
     };

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -125,6 +125,7 @@ SPIDevice::SPIDevice(SPIBus &_bus, SPIDesc &_device_desc)
     asprintf(&pname, "SPI:%s:%u:%u",
              device_desc.name,
              (unsigned)bus.bus, (unsigned)device_desc.device);
+    AP_HAL::SPIDevice::setup_bankselect_callback(device_desc.bank_select_cb);
     //printf("SPI device %s on %u:%u at speed %u mode %u\n",
     //       device_desc.name,
     //       (unsigned)bus.bus, (unsigned)device_desc.device,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.h
@@ -94,7 +94,7 @@ private:
     bool _block_read(uint16_t reg, uint8_t *buf, uint32_t size);
     uint8_t _register_read(uint16_t reg);
     void _register_write(uint16_t reg, uint8_t val, bool checked=false);
-    void _select_bank(uint8_t bank);
+    bool _select_bank(uint8_t bank);
 
     bool _accumulate(uint8_t *samples, uint8_t n_samples);
     bool _accumulate_sensor_rate_sampling(uint8_t *samples, uint8_t n_samples);

--- a/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
+++ b/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
@@ -54,11 +54,11 @@ void GCS_MAVLINK::handle_device_op_read(const mavlink_message_t &msg)
     }
     if (regstart == 0xff) {
         // assume raw transfer, non-register interface
-        ret = dev->transfer(nullptr, 0, data, packet.count);
+        ret = dev->transfer_bank(packet.bank, nullptr, 0, data, packet.count);
         // reply using register start 0 for display purposes
         regstart = 0;
     } else {
-        ret = dev->read_registers(packet.regstart, data, packet.count);
+        ret = dev->read_bank_registers(packet.bank, packet.regstart, data, packet.count);
     }
     dev->get_semaphore()->give();
     if (!ret) {
@@ -71,7 +71,8 @@ void GCS_MAVLINK::handle_device_op_read(const mavlink_message_t &msg)
         retcode,
         regstart,
         packet.count,
-        data);
+        data,
+        packet.bank);
     return;
 
 fail:
@@ -81,7 +82,8 @@ fail:
         retcode,
         packet.regstart,
         0,
-        nullptr);
+        nullptr,
+        packet.bank);
 }
 
 /*
@@ -112,12 +114,12 @@ void GCS_MAVLINK::handle_device_op_write(const mavlink_message_t &msg)
     }
     if (packet.regstart == 0xff) {
         // assume raw transfer, non-register interface
-        if (!dev->transfer(packet.data, packet.count, nullptr, 0)) {
+        if (!dev->transfer_bank(packet.bank, packet.data, packet.count, nullptr, 0)) {
             retcode = 4;
         }
     } else {
         for (uint8_t i=0; i<packet.count; i++) {
-            if (!dev->write_register(packet.regstart+i, packet.data[i])) {
+            if (!dev->write_bank_register(packet.bank, packet.regstart+i, packet.data[i])) {
                 retcode = 4;
                 break;
             }


### PR DESCRIPTION
This PR adds support for checked register setup for bank based addressing setups, like the one employed in Invensensev2 Driver.
The Logic trace is attached herewith for anyone to look. The contains data on the SPI bus on IMU board in CubeOrange, the sensor comms were disabled by pulling up the CS pin of the Invensensev2 sensor. Will also upload the flight test results as soon as done

[Download Logic Data Trace](https://drive.google.com/file/d/1crti36z60MVKRTWvrzIAKFmvAmZUgAgl/view?usp=sharing
)