### PR TITLE
AP_HAL_Linux: Allow for parameters to be passed with -G, -H

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -300,7 +300,7 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
         {0, false, 0, 0}
     };
 
-    GetOptLong gopt(argc, argv, "A:B:C:D:E:F:l:t:s:he:SM:",
+    GetOptLong gopt(argc, argv, "A:B:C:D:E:F:G:H:l:t:s:he:SM:",
                     options);
 
     /*


### PR DESCRIPTION
All other work has been previously implemented, however when fetching
params these values were ignored.

Fixes ArduPilot/ardupilot#14824 .