### PR TITLE
AP_NavEKF3: fix extnav vel reset

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -370,9 +370,14 @@ void NavEKF3_core::setAidingMode()
             } else if (readyToUseExtNav()) {
                 // we are commencing aiding using external nav
                 posResetSource = EXTNAV;
-                velResetSource = DEFAULT;
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u is using external nav data",(unsigned)imu_index);
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u initial pos NED = %3.1f,%3.1f,%3.1f (m)",(unsigned)imu_index,(double)extNavDataDelayed.pos.x,(double)extNavDataDelayed.pos.y,(double)extNavDataDelayed.pos.z);
+                if (useExtNavVel) {
+                    velResetSource = EXTNAV;
+                    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u initial vel NED = %3.1f,%3.1f,%3.1f (m/s)",(unsigned)imu_index,(double)extNavVelDelayed.vel.x,(double)extNavVelDelayed.vel.y,(double)extNavVelDelayed.vel.z);
+                } else {
+                    velResetSource = DEFAULT;
+                }
                 // handle height reset as special case
                 hgtMea = -extNavDataDelayed.pos.z;
                 posDownObsNoise = sq(constrain_float(extNavDataDelayed.posErr, 0.1f, 10.0f));


### PR DESCRIPTION
I think maybe there is a typo in following line?
https://github.com/ArduPilot/ardupilot/blob/16a15f5450346d99fb5a361bebb627e1e5c89caf/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp#L48

In current implement, VISION_SPEED_ESTIMATE must be received before VISION_POSITION_ESTIMATE, so that it can be used to reset velocity

flight test
[46 1980-1-1 08-00-00.zip](https://github.com/ArduPilot/ardupilot/files/4930799/46.1980-1-1.08-00-00.zip)
