### PR TITLE
AP_Logger: No extra log files generated over MAVLINK when LOG_DISARMED enabled

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -87,6 +87,8 @@ private:
 
     uint16_t _cached_oldest_log;
 
+    bool _read_write_access;
+
     // should we rotate when we next stop logging
     bool _rotate_pending;
 


### PR DESCRIPTION
Fixed for #13353.

By doing this, user can prevent extra log files being generated while in downloaded over MAVLINK from GCS with LOG_DISARMED enabled. Once the handle request for log data is triggered, ongoing logged file is then closed and LOG_DISARMED is back to 0.