### PR TITLE
AP_TECS: Use LAND_THR_SLEW if appropriate [Bugfix]

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -699,8 +699,15 @@ void AP_TECS::_update_throttle_with_airspeed(void)
 
         // Rate limit PD + FF throttle
         // Calculate the throttle increment from the specified slew time
-        if (aparm.throttle_slewrate != 0) {
-            float thrRateIncr = _DT * (_THRmaxf - THRminf_clipped_to_zero) * aparm.throttle_slewrate * 0.01f;
+        int8_t throttle_slewrate = aparm.throttle_slewrate;
+        int8_t land_slewrate = _landing.get_throttle_slewrate();
+
+        if (_landing.is_on_approach() && land_slewrate >0) {
+            throttle_slewrate = land_slewrate;
+        }
+
+        if (throttle_slewrate != 0) {
+            float thrRateIncr = _DT * (_THRmaxf - THRminf_clipped_to_zero) * throttle_slewrate * 0.01f;
 
             _throttle_dem = constrain_float(_throttle_dem,
                                             _last_throttle_dem - thrRateIncr,

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -700,10 +700,11 @@ void AP_TECS::_update_throttle_with_airspeed(void)
         // Rate limit PD + FF throttle
         // Calculate the throttle increment from the specified slew time
         int8_t throttle_slewrate = aparm.throttle_slewrate;
-        int8_t land_slewrate = _landing.get_throttle_slewrate();
-
-        if (_landing.is_on_approach() && land_slewrate >0) {
-            throttle_slewrate = land_slewrate;
+        if (_landing.is_on_approach()) {
+            const int8_t land_slewrate = _landing.get_throttle_slewrate();
+            if (land_slewrate > 0) {
+                throttle_slewrate = land_slewrate;
+            }
         }
 
         if (throttle_slewrate != 0) {


### PR DESCRIPTION
This fixes a bug that causes LAND_THR_SLEW not to be observed if it is faster than THR_SLEWRATE. This is because TECS always used THR_SLEWRATE.