### PR TITLE
AR_WPNav: Fix issue with WP_SPEED_MIN unintentionally being applied in reverse

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -447,6 +447,6 @@ void AR_WPNav::apply_speed_min(float &desired_speed)
 
     // ensure speed does not fall below minimum
     if (fabsf(desired_speed) < speed_min) {
-        desired_speed = is_negative(desired_speed) ? -speed_min : speed_min;
+        desired_speed = is_negative(_desired_speed) ? -speed_min : speed_min;
     }
 }


### PR DESCRIPTION
_desired_speed should be used in place of desired_speed when determining the direction of to apply speed_min (WP_SPEED_MIN). desired_speed can take many cycles to achieve _desired_speed and the lag can cause min_speed to be applied in the wrong direction. Once the incorrect min_speed is applied, there is no way to exit this condition and the rover is stuck reversing forwver. 