### PR TITLE
AP_MotorsUGV: Fix application of MOT_SLEWRATE to achieve full range.

### DIFF
--- a/Rover/AP_MotorsUGV.cpp
+++ b/Rover/AP_MotorsUGV.cpp
@@ -224,7 +224,7 @@ float AP_MotorsUGV::get_slew_limited_throttle(float throttle, float dt) const
         return throttle;
     }
 
-    const float throttle_change_max = MAX(1.0f, (float)_slew_rate * dt);
+    const float throttle_change_max = MIN(1000.0f * dt, (float)_slew_rate * dt);
     return constrain_float(throttle, _throttle_prev - throttle_change_max, _throttle_prev + throttle_change_max);
 }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1716,6 +1716,24 @@ class AutoTestCopter(AutoTest):
     def fly_autotune_switch(self):
         """Test autotune on a switch with gains being saved"""
 
+        self.context_push()
+
+        ex = None
+
+        try:
+            self.fly_autotune_switch_body()
+        except Exception as e:
+            self.progress("Exception caught: %s" % (
+                self.get_exception_stacktrace(e)))
+            ex = e
+
+        self.context_pop()
+        self.reboot_sitl()
+
+        if ex is not None:
+            raise ex
+
+    def fly_autotune_switch_body(self):
         self.set_parameter("RC8_OPTION", 17)
         self.set_parameter("ATC_RAT_RLL_FLTT", 20)
         rlld = self.get_parameter("ATC_RAT_RLL_D")


### PR DESCRIPTION
The actual slew rate achievable using the MOT_SLEWRATE parameter does not seem to correspond with stated range of 0-1000 percent throttle per second. The current code limits the minimum delta to 1 percent of throttle per loop cycle. For the Rover default of 50Hz, this equates to 50% throttle per second - any parameter values less than 50 results in the same slew rate of 50. For faster loop rates the minimum possible slew rate is higher - for instance, at 400Hz the minimum achievable rate is 400% throttle per second. The proposed change results in slew rates that cover the whole of the intended range.