### PR TITLE
SITL: add rangefinder and use in JSON backend 

### DIFF
--- a/libraries/AP_HAL_SITL/sitl_rangefinder.cpp
+++ b/libraries/AP_HAL_SITL/sitl_rangefinder.cpp
@@ -65,6 +65,11 @@ void SITL_State::_update_rangefinder(float range_value)
         }
     }
 
+    // if not populated also fill out the STIL rangefinder array
+    if (is_equal(_sitl->state.rangefinder_m[0],-1.0f)) {
+        _sitl->state.rangefinder_m[0] = altitude;
+    }
+
     sonar_pin_value = 1023 * (voltage / 5.0f);
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -45,6 +45,7 @@
 #include "AP_RangeFinder_UAVCAN.h"
 #include "AP_RangeFinder_Lanbao.h"
 #include "AP_RangeFinder_LeddarVu8.h"
+#include "AP_RangeFinder_SITL.h"
 
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
@@ -533,6 +534,12 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
             drivers[instance] = new AP_RangeFinder_GYUS42v2(state[instance], params[instance], serial_instance++);
         }
         break;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    case Type::SITL:
+        drivers[instance] = new AP_RangeFinder_SITL(state[instance], params[instance], instance);
+        break;
+#endif
 
     default:
         break;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -81,6 +81,7 @@ public:
         LeddarVu8_Serial = 29,
         HC_SR04 = 30,
         GYUS42v2 = 31,
+        SITL = 100,
     };
 
     enum class Function {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
@@ -1,0 +1,52 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include "AP_RangeFinder_SITL.h"
+
+extern const AP_HAL::HAL& hal;
+
+/*
+  constructor - registers instance at top RangeFinder driver
+ */
+AP_RangeFinder_SITL::AP_RangeFinder_SITL(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, uint8_t instance) :
+    AP_RangeFinder_Backend(_state, _params),
+    sitl(AP::sitl()),
+    _instance(instance)
+{}
+
+/*
+  update distance_cm
+ */
+void AP_RangeFinder_SITL::update(void)
+{
+    const float dist = sitl->get_rangefinder(_instance);
+
+    // negative distance means nothing is connected
+    if (is_negative(dist)) {
+        state.status = RangeFinder::Status::NoData;
+        return;
+    }
+
+    state.distance_cm = dist * 100.0f;
+    state.last_reading_ms = AP_HAL::millis();
+
+    // update range_valid state based on distance measured
+    update_status();
+}
+
+#endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.h
@@ -1,0 +1,44 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "AP_RangeFinder_Backend.h"
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include <SITL/SITL.h>
+
+class AP_RangeFinder_SITL : public AP_RangeFinder_Backend {
+public:
+    // constructor. This incorporates initialisation as well.
+    AP_RangeFinder_SITL(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, uint8_t instance);
+
+    // update the state structure
+    void update() override;
+
+protected:
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_UNKNOWN;
+    }
+
+private:
+    SITL::SITL *sitl;
+
+    uint8_t _instance;
+
+};
+
+#endif

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -83,6 +83,11 @@ Aircraft::Aircraft(const char *frame_str) :
     }
 
     terrain = &AP::terrain();
+
+    // init rangefinder array to -1 to signify no data
+    for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++){
+        rangefinder_m[i] = -1.0f;
+    }
 }
 
 void Aircraft::set_start_location(const Location &start_loc, const float start_yaw)
@@ -373,6 +378,9 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
     // copy laser scanner results
     fdm.scanner.points = scanner.points;
     fdm.scanner.ranges = scanner.ranges;
+
+    // copy rangefinder
+    memcpy(fdm.rangefinder_m, rangefinder_m, sizeof(fdm.rangefinder_m));
 
     if (is_smoothed) {
         fdm.xAccel = smoothing.accel_body.x;

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -177,7 +177,10 @@ protected:
         struct vector3f_array points;
         struct float_array ranges;
     } scanner;
-    
+
+    // Rangefinder
+    float rangefinder_m[RANGEFINDER_MAX_INSTANCES];
+
     // Wind Turbulence simulated Data
     float turbulence_azimuth = 0.0f;
     float turbulence_horizontal_speed = 0.0f;  // m/s

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -124,9 +124,9 @@ void JSON::output_servos(const struct sitl_input &input)
     This parser does not do any syntax checking, and is not at all
     general purpose
 */
-uint8_t JSON::parse_sensors(const char *json)
+uint16_t JSON::parse_sensors(const char *json)
 {
-    uint8_t received_bitmask = 0;
+    uint16_t received_bitmask = 0;
 
     //printf("%s\n", json);
     for (uint16_t i=0; i<ARRAY_SIZE(keytable); i++) {
@@ -234,9 +234,10 @@ void JSON::recv_fdm(const struct sitl_input &input)
         return;
     }
 
-    const uint8_t received_bitmask = parse_sensors((const char *)(p1+1));
+    const uint16_t received_bitmask = parse_sensors((const char *)(p1+1));
     if (received_bitmask == 0) {
-        // did not receve one of the required fields
+        // did not receve one of the mandatory fields
+        printf("Did not contain all mandatory fields\n");
         return;
     }
 
@@ -245,6 +246,20 @@ void JSON::recv_fdm(const struct sitl_input &input)
         printf("Did not receive attitude or quaternion\n");
         return;
     }
+
+    if (received_bitmask != last_received_bitmask) {
+        // some change in the message we have received, print what we got
+        printf("\nJSON received:\n");
+        for (uint16_t i=0; i<ARRAY_SIZE(keytable); i++) {
+            struct keytable &key = keytable[i];
+            if ((received_bitmask &  1U << i) == 0) {
+                continue;
+            }
+            printf("\t%s\n",key.key);
+        }
+        printf("\n");
+    }
+    last_received_bitmask = received_bitmask;
 
     memmove(sensor_buffer, p2, sensor_buffer_len - (p2 - sensor_buffer));
     sensor_buffer_len = sensor_buffer_len - (p2 - sensor_buffer);
@@ -274,11 +289,20 @@ void JSON::recv_fdm(const struct sitl_input &input)
     // Convert from a meters from origin physics to a lat long alt
     update_position();
 
+    // update range finder distances
+    for (uint8_t i=7; i<13; i++) {
+        if ((received_bitmask &  1U << i) == 0) {
+            continue;
+        }
+        rangefinder_m[i-7] = state.rng[i-7];
+    }
+
     double deltat;
     if (state.timestamp_s < last_timestamp_s) {
-        // Physics time has gone backwards, don't reset AP, assume an average size timestep
+        // Physics time has gone backwards, don't reset AP
         printf("Detected physics reset\n");
         deltat = 0;
+        last_received_bitmask = 0;
     } else {
         deltat = state.timestamp_s - last_timestamp_s;
     }

--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -57,7 +57,7 @@ private:
     void output_servos(const struct sitl_input &input);
     void recv_fdm(const struct sitl_input &input);
 
-    uint8_t parse_sensors(const char *json);
+    uint16_t parse_sensors(const char *json);
 
     // buffer for parsing pose data in JSON format
     uint8_t sensor_buffer[65000];
@@ -81,6 +81,7 @@ private:
         Vector3f attitude;
         Quaternion quaternion;
         Vector3f velocity;
+        float rng[6];
     } state;
 
     // table to aid parsing of JSON sensor data
@@ -90,7 +91,7 @@ private:
         void *ptr;
         enum data_type type;
         bool required;
-    } keytable[7] = {
+    } keytable[13] = {
         { "", "timestamp", &state.timestamp_s, DATA_DOUBLE, true },
         { "imu", "gyro",    &state.imu.gyro, DATA_VECTOR3F, true },
         { "imu", "accel_body", &state.imu.accel_body, DATA_VECTOR3F, true },
@@ -98,6 +99,12 @@ private:
         { "", "attitude", &state.attitude, DATA_VECTOR3F, false },
         { "", "quaternion", &state.quaternion, QUATERNION, false },
         { "", "velocity", &state.velocity, DATA_VECTOR3F, true },
+        { "", "rng_1", &state.rng[0], DATA_FLOAT, false },
+        { "", "rng_2", &state.rng[1], DATA_FLOAT, false },
+        { "", "rng_3", &state.rng[2], DATA_FLOAT, false },
+        { "", "rng_4", &state.rng[3], DATA_FLOAT, false },
+        { "", "rng_5", &state.rng[4], DATA_FLOAT, false },
+        { "", "rng_6", &state.rng[5], DATA_FLOAT, false },
     };
 
     // Enum coresponding to the ordering of keys in the keytable.
@@ -109,7 +116,14 @@ private:
         EULER_ATT   = 1U << 4,
         QUAT_ATT    = 1U << 5,
         VELOCITY    = 1U << 6,
+        RNG_1       = 1U << 7,
+        RNG_2       = 1U << 8,
+        RNG_3       = 1U << 9,
+        RNG_4       = 1U << 10,
+        RNG_5       = 1U << 11,
+        RNG_6       = 1U << 12,
     };
+    uint16_t last_received_bitmask;
 };
 
 }

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -403,6 +403,14 @@ Vector3f SITL::convert_earth_frame(const Matrix3f &dcm, const Vector3f &gyro)
     return Vector3f(phiDot, thetaDot, psiDot);
 }
 
+// get the rangefinder reading for the desired rotation, returns -1 for no data
+float SITL::get_rangefinder(uint8_t instance) {
+    if (instance < RANGEFINDER_MAX_INSTANCES) {
+        return state.rangefinder_m[instance];
+    }
+    return -1;
+};
+
 } // namespace SITL
 
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -19,6 +19,7 @@
 #include "SIM_EFI_MegaSquirt.h"
 #include "SIM_RichenPower.h"
 #include "SIM_Ship.h"
+#include <AP_RangeFinder/AP_RangeFinder.h>
 
 namespace SITL {
 
@@ -66,6 +67,8 @@ struct sitl_fdm {
         struct vector3f_array points;
         struct float_array ranges;
     } scanner;
+
+    float rangefinder_m[RANGEFINDER_MAX_INSTANCES];
 };
 
 // number of rc output channels
@@ -384,6 +387,10 @@ public:
     AP_Int16 vicon_yaw_error;   // vicon yaw error in degrees (added to reported yaw sent to vehicle)
     AP_Int8 vicon_type_mask;    // vicon message type mask (bit0:vision position estimate, bit1:vision speed estimate, bit2:vicon position estimate)
     AP_Vector3f vicon_vel_glitch;   // velocity glitch in m/s in vicon's local frame
+
+    // get the rangefinder reading for the desired instance, returns -1 for no data
+    float get_rangefinder(uint8_t instance);
+
 };
 
 } // namespace SITL

--- a/libraries/SITL/examples/JSON/readme.md
+++ b/libraries/SITL/examples/JSON/readme.md
@@ -43,4 +43,30 @@ This is a example input frame, it should be preceded by and terminated with a ca
 ```
 {"timestamp":2500,"imu":{"gyro":[0,0,0],"accel_body":[0,0,0]},"position":[0,0,0],"attitude":[0,0,0],"velocity":[0,0,0]}
 ```
-The order of fields is not important. In the future support for additional optional fields could be added to allow readings to be provided for additional sensors.
+The order of fields is not important.
+
+It is possible to send optional fields to provide data for additional sensors, in most cases this will require setting the relevant sensor type param to the SITL driver.
+
+rangefinder distances corresponding to driver instances:
+```
+    rng_1 (m)
+    rng_2 (m)
+    rng_3 (m)
+    rng_4 (m)
+    rng_5 (m)
+    rng_6 (m)
+```
+
+When first connecting you will see a message reporting what fields were successfully received. If any of the mandatory fields are missing SITL will stop, however it will run without the optional fields. This message can be used to double check SITL is receiving everything being sent by the physics backend.
+
+For example:
+```
+JSON received:
+        timestamp
+        gyro
+        accel_body
+        position
+        attitude
+        velocity
+        rng_1
+```


### PR DESCRIPTION
I was quite surprised we did not have a rangefinder SITL backed. We have lots designed for testing drivers, but none that could be used with data from a simulator. 

This adds that. 

I have added support for all rotations, however this does mean were carrying a 42 float array in two places (SITL only). Maybe we could cut this down, the JSON backend only supports the 6 major directions.

Tested using MATLAB, I have also added a new print to the JSON backed that tells you what it is receiving, this is nice now we have more optional fields.