### PR TITLE
Log accumulated power status bits

### DIFF
--- a/libraries/AP_HAL/AnalogIn.h
+++ b/libraries/AP_HAL/AnalogIn.h
@@ -36,6 +36,10 @@ public:
 
     // power supply status flags, see MAV_POWER_STATUS
     virtual uint16_t power_status_flags(void) { return 0; }
+
+    // bitmask of all _power_flags bits ever set, so transient
+    // failures can still be diagnosed
+    virtual uint16_t accumulated_power_status_flags(void) const { return 0; }
 };
 
 #define ANALOG_INPUT_BOARD_VCC 254

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -473,6 +473,7 @@ void AnalogIn::update_power_flags(void)
         // the power status has changed while armed
         flags |= MAV_POWER_STATUS_CHANGED;
     }
+    _accumulated_power_flags |= flags;
     _power_flags = flags;
 }
 #endif // HAL_USE_ADC

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.h
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.h
@@ -61,6 +61,7 @@ public:
     float board_voltage(void) override { return _board_voltage; }
     float servorail_voltage(void) override { return _servorail_voltage; }
     uint16_t power_status_flags(void) override { return _power_flags; }
+    uint16_t accumulated_power_status_flags(void) const override { return _accumulated_power_flags; }
     static void adccallback(ADCDriver *adcp);
 
 private:
@@ -74,6 +75,8 @@ private:
     float _servorail_voltage;
     float _rssi_voltage;
     uint16_t _power_flags;
+    uint16_t _accumulated_power_flags;  // bitmask of all _power_flags ever set
+
     ADCConversionGroup adcgrpcfg;
 
     struct pin_info {

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -480,6 +480,7 @@ void AP_Logger::Write_Power(void)
         Vcc     : hal.analogin->board_voltage(),
         Vservo  : hal.analogin->servorail_voltage(),
         flags   : hal.analogin->power_status_flags(),
+        accumulated_flags   : hal.analogin->accumulated_power_status_flags(),
         safety_and_arm : safety_and_armed
     };
     WriteBlock(&pkt, sizeof(pkt));

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -392,6 +392,7 @@ struct PACKED log_POWR {
     float Vcc;
     float Vservo;
     uint16_t flags;
+    uint16_t accumulated_flags;
     uint8_t safety_and_arm;
 };
 
@@ -1930,6 +1931,7 @@ struct PACKED log_Arm_Disarm {
 // @Field: Vcc: Flight board voltage
 // @Field: VServo: Servo rail voltage
 // @Field: Flags: System power flags
+// @Field: AccFlags: Accumulated System power flags; all flags which have ever been set
 // @Field: Safety: Hardware Safety Switch status
 
 // @LoggerMessage: PRX
@@ -2356,7 +2358,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_BARO_MSG, sizeof(log_BARO), \
       "BARO",  BARO_FMT, BARO_LABELS, BARO_UNITS, BARO_MULTS }, \
     { LOG_POWR_MSG, sizeof(log_POWR), \
-      "POWR","QffHB","TimeUS,Vcc,VServo,Flags,Safety", "svv--", "F00--" },  \
+      "POWR","QffHHB","TimeUS,Vcc,VServo,Flags,AccFlags,Safety", "svv---", "F00---" },  \
     { LOG_CMD_MSG, sizeof(log_Cmd), \
       "CMD", "QHHHffffLLfB","TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt,Frame", "s-------DUm-", "F-------GG0-" }, \
     { LOG_MAVLINK_COMMAND_MSG, sizeof(log_MAVLink_Command), \


### PR DESCRIPTION
A recent log from a partner showed that had been a power anomaly - but the power flags are only logged at 10Hz and events can be missed.  You do see a "changed when armed" signal in the log - but that's not as useful as it could be.

This PR adds a column to the `POWR` log message to keep a record of all bits ever set in the power status flags result.

![image](https://user-images.githubusercontent.com/7077857/87889573-9d769480-ca75-11ea-8cf1-204548c659d1.png)

That shows a PixRacer having main battery and USB connected/disconnected.  The accumulated bits show that both have been connected.  If I were to create an overcurrent event I would expect to see that represented continuously in the new column after that point.
