### PR TITLE
AP_Scripting: add ahrs-print-angle-and-rates example

### DIFF
--- a/libraries/AP_Scripting/examples/ahrs-print-angle-and-rates.lua
+++ b/libraries/AP_Scripting/examples/ahrs-print-angle-and-rates.lua
@@ -1,0 +1,21 @@
+-- This script displays the vehicle lean angles and rotation rates at 1hz
+
+function update() -- this is the loop which periodically runs
+  roll = math.deg(ahrs:get_roll())
+  pitch = math.deg(ahrs:get_pitch())
+  yaw = math.deg(ahrs:get_yaw())
+  rates = ahrs:get_gyro()
+  if rates then
+    roll_rate = math.deg(rates:x())
+    pitch_rate = math.deg(rates:y())
+    yaw_rate = math.deg(rates:z())
+  else
+    roll_rate = 0
+    pitch_rate = 0
+    yaw_rate = 0
+  end
+  gcs:send_text(0, string.format("Ang R:%.1f P:%.1f Y:%.1f Rate R:%.1f P:%.1f Y:%.1f", roll, pitch, yaw, roll_rate, pitch_rate, yaw_rate))
+  return update, 1000 -- reschedules the loop
+end
+
+return update() -- run immediately before starting to reschedule


### PR DESCRIPTION
This PR adds an example script to display the AHRS roll, pitch and yaw angles and rates at 1hz.  This is in response to a member of the Drone Japan school struggling to get this information out of the AHRS.  It may at first seem simple but it's quite easy for users to get confused about whether they should use "." or ":" and whether the "()" is required.

This has been tested in SITL
![image](https://user-images.githubusercontent.com/1498098/87900401-3a91f700-ca8f-11ea-8df4-6ff961c9eee4.png)
