### PR TITLE
Rover: Walking robot support

### DIFF
--- a/Rover/AP_MotorsUGV.cpp
+++ b/Rover/AP_MotorsUGV.cpp
@@ -210,6 +210,18 @@ void AP_MotorsUGV::set_lateral(float lateral)
     _lateral = constrain_float(lateral, -100.0f, 100.0f);
 }
 
+// set roll input as a value from -100 to +100
+void AP_MotorsUGV::set_roll(float roll)
+{
+    _roll = constrain_float(roll, -100.0f, 100.0f);
+}
+
+// set pitch input as a value from -100 to +100
+void AP_MotorsUGV::set_pitch(float pitch)
+{
+    _pitch = constrain_float(pitch, -100.0f, 100.0f);
+}
+
 // set mainsail input as a value from 0 to 100
 void AP_MotorsUGV::set_mainsail(float mainsail)
 {

--- a/Rover/AP_MotorsUGV.h
+++ b/Rover/AP_MotorsUGV.h
@@ -60,6 +60,14 @@ public:
     float get_throttle() const { return _throttle; }
     void set_throttle(float throttle);
 
+    // get roll as a value from -100 to 100
+    float get_roll() const { return _roll; }
+    void set_roll(float roll);
+
+    // get pitch as a value from -100 to 100
+    float get_pitch() const { return _pitch; }
+    void set_pitch(float pitch);
+
     // get or set lateral input as a value from -100 to +100
     float get_lateral() const { return _lateral; }
     void set_lateral(float lateral);
@@ -179,6 +187,8 @@ protected:
     // internal variables
     float   _steering;  // requested steering as a value from -4500 to +4500
     float   _throttle;  // requested throttle as a value from -100 to 100
+    float   _roll;  // requested throttle as a value from -100 to 100
+    float   _pitch;  // requested pitch as a value from -100 to 100
     float   _throttle_prev; // throttle input from previous iteration
     bool    _scale_steering = true; // true if we should scale steering by speed or angle
     float   _lateral;  // requested lateral input as a value from -100 to +100

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -276,6 +276,36 @@ void GCS_MAVLINK_Rover::send_pid_tuning()
             return;
         }
     }
+
+    // roll angle pid
+    if (g.gcs_pid_mask & 64) {
+        pid_info = &g2.attitude_control.get_roll_pid().get_pid_info();
+        mavlink_msg_pid_tuning_send(chan, 10,
+                                    degrees(pid_info->target),
+                                    degrees(pid_info->actual),
+                                    pid_info->FF,
+                                    pid_info->P,
+                                    pid_info->I,
+                                    pid_info->D);
+        if (!HAVE_PAYLOAD_SPACE(chan, PID_TUNING)) {
+            return;
+        }
+    }
+
+    // pitch angle pid
+    if (g.gcs_pid_mask & 128) {
+        pid_info = &g2.attitude_control.get_pitch_pid().get_pid_info();
+        mavlink_msg_pid_tuning_send(chan, 11,
+                                    degrees(pid_info->target),
+                                    degrees(pid_info->actual),
+                                    pid_info->FF,
+                                    pid_info->P,
+                                    pid_info->I,
+                                    pid_info->D);
+        if (!HAVE_PAYLOAD_SPACE(chan, PID_TUNING)) {
+            return;
+        }
+    }
 }
 
 void Rover::send_wheel_encoder_distance(const mavlink_channel_t chan)

--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -30,6 +30,10 @@ void Rover::Log_Write_Attitude()
     // log heel to sail control for sailboats
     if (rover.g2.sailboat.sail_enabled()) {
         logger.Write_PID(LOG_PIDR_MSG, g2.attitude_control.get_sailboat_heel_pid().get_pid_info());
+
+    // log roll and pitch controller PID logs
+    logger.Write_PID(LOG_ROLL_PID2, g2.attitude_control.get_roll_pid().get_pid_info());
+    logger.Write_PID(LOG_PITCH_PID2, g2.attitude_control.get_pitch_pid().get_pid_info());
     }
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE();
@@ -329,6 +333,10 @@ const LogStructure Rover::log_structure[] = {
     
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-000000" },
+    { LOG_ROLL_PID2, sizeof(log_PID),
+      "PI2R", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
+    { LOG_PITCH_PID2, sizeof(log_PID),
+      "PI2P", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
 };
 
 void Rover::log_init(void)

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -64,7 +64,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: GCS PID tuning mask
     // @Description: bitmask of PIDs to send MAVLink PID_TUNING messages for
     // @User: Advanced
-    // @Values: 0:None,1:Steering,2:Throttle,4:Pitch,8:Left Wheel,16:Right Wheel,32:Sailboat Heel
+    // @Values: 0:None,1:Steering,2:Throttle,4:Pitch,8:Left Wheel,16:Right Wheel,32:Sailboat Heel,64:roll,128:pitch
     // @Bitmask: 0:Steering,1:Throttle,2:Pitch,3:Left Wheel,4:Right Wheel,5:Sailboat Heel
     GSCALAR(gcs_pid_mask,           "GCS_PID_MASK",     0),
 

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -636,6 +636,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FS_OPTIONS", 48, ParametersG2, fs_options, 0),
 
+    // @Param: ANGLE_MAX
+    // @DisplayName: Rover roll and pitch angle max
+    // @Description:  Rover roll and pitch angle max
+    // @Units: deg
+    // @Range: 0 45
+    // @User: Standard
+    AP_GROUPINFO("ANGLE_MAX", 49, ParametersG2, angle_max, 10),
+
+
     AP_GROUPEND
 };
 

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -399,6 +399,9 @@ public:
 
     // FS options
     AP_Int32 fs_options;
+
+    // angle max
+    AP_Float angle_max;
 };
 
 extern const AP_Param::Info var_info[];

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -185,6 +185,12 @@ bool Rover::set_steering_and_throttle(float steering, float throttle)
 bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value)
 {
     switch (control_output) {
+    case AP_Vehicle::ControlOutput::Roll:
+        control_value = g2.motors.get_roll();
+        return true;
+    case AP_Vehicle::ControlOutput::Pitch:
+        control_value = g2.motors.get_pitch();
+        return true;
     case AP_Vehicle::ControlOutput::Throttle:
         control_value = constrain_float(g2.motors.get_throttle() / 100.0f, -1.0f, 1.0f);
         return true;

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -143,6 +143,8 @@ private:
     RC_Channel *channel_steer;
     RC_Channel *channel_throttle;
     RC_Channel *channel_lateral;
+    RC_Channel *channel_roll;
+    RC_Channel *channel_pitch;
 
     AP_Logger logger;
 

--- a/Rover/defines.h
+++ b/Rover/defines.h
@@ -27,6 +27,8 @@
 #define LOG_STARTUP_MSG         0x06
 #define LOG_STEERING_MSG        0x0D
 #define LOG_GUIDEDTARGET_MSG    0x0E
+#define LOG_ROLL_PID2           0x0F
+#define LOG_PITCH_PID2          0x10
 
 #define TYPE_GROUNDSTART_MSG    0x01
 

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -8,6 +8,8 @@ Mode::Mode() :
     channel_steer(rover.channel_steer),
     channel_throttle(rover.channel_throttle),
     channel_lateral(rover.channel_lateral),
+    channel_roll(rover.channel_roll),
+    channel_pitch(rover.channel_pitch), 
     attitude_control(rover.g2.attitude_control)
 { }
 
@@ -95,6 +97,14 @@ void Mode::get_pilot_input(float &steering_out, float &throttle_out)
             break;
         }
     }
+}
+
+// roll_out is in the range -100 ~ +100
+// pitch_out is in the range -100 ~ +100
+void Mode::get_pilot_desired_roll_and_pitch(float &roll_out, float &pitch_out)
+{
+    roll_out = rover.channel_roll->get_control_in();
+    pitch_out = rover.channel_pitch->get_control_in();
 }
 
 // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -103,8 +103,31 @@ void Mode::get_pilot_input(float &steering_out, float &throttle_out)
 // pitch_out is in the range -100 ~ +100
 void Mode::get_pilot_desired_roll_and_pitch(float &roll_out, float &pitch_out)
 {
-    roll_out = rover.channel_roll->get_control_in();
-    pitch_out = rover.channel_pitch->get_control_in();
+    roll_out = rover.channel_roll->get_control_in() * radians(g2.angle_max) * 0.01;
+    pitch_out = rover.channel_pitch->get_control_in() * radians(g2.angle_max) * 0.01;
+}
+
+// pass target angles to attitude control and output result to motors
+void Mode::calc_roll_pitch(float target_roll, float target_pitch)
+{
+    // apply PID's
+    const float roll = g2.attitude_control.get_servo_out_from_roll(target_roll, rover.G_Dt);
+    const float pitch = g2.attitude_control.get_servo_out_from_pitch(target_pitch, rover.G_Dt);
+
+    // output to motors
+    g2.motors.set_pitch(pitch);
+    g2.motors.set_roll(roll);
+}
+
+// get desired lean angles and output to motors
+void Mode::calc_and_set_roll_pitch()
+{
+    float target_roll = 0.0f;
+    float target_pitch = 0.0f;
+
+    get_pilot_desired_roll_and_pitch(target_roll,target_pitch);
+
+    calc_roll_pitch(target_roll,target_pitch);
 }
 
 // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -139,6 +139,10 @@ protected:
     // subclasses override this to perform any required cleanup when exiting the mode
     virtual void _exit() { return; }
 
+    // roll_out is in the range -100 ~ +100
+    // pitch_out is in the range -100 ~ +100
+    void get_pilot_desired_roll_and_pitch(float &roll_out, float &pitch_out);
+
     // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments
     // steering_out is in the range -4500 ~ +4500 with positive numbers meaning rotate clockwise
     // throttle_out is in the range -100 ~ +100
@@ -197,6 +201,8 @@ protected:
     class RC_Channel *&channel_steer;
     class RC_Channel *&channel_throttle;
     class RC_Channel *&channel_lateral;
+    class RC_Channel *&channel_roll;
+    class RC_Channel *&channel_pitch;
     class AR_AttitudeControl &attitude_control;
 
     // private members for waypoint navigation

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -186,6 +186,12 @@ protected:
     //  reversed should be true if the vehicle is intentionally backing up which allows the pilot to increase the backing up speed by pulling the throttle stick down
     float calc_speed_nudge(float target_speed, bool reversed);
 
+    // calculate target roll and pitch angles and output
+    void calc_and_set_roll_pitch();
+
+    // pass target angles to attitude control and output result to motors
+    void calc_roll_pitch(float target_roll, float target_pitch);
+
 protected:
 
     // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments

--- a/Rover/mode_acro.cpp
+++ b/Rover/mode_acro.cpp
@@ -45,6 +45,8 @@ void ModeAcro::update()
     }
 
     set_steering(steering_out * 4500.0f);
+
+    calc_and_set_roll_pitch();
 }
 
 bool ModeAcro::requires_velocity() const

--- a/Rover/mode_manual.cpp
+++ b/Rover/mode_manual.cpp
@@ -15,7 +15,7 @@ void ModeManual::update()
 
     //walking robot roll and pitch
     get_pilot_desired_roll_and_pitch(desired_roll,desired_pitch);
-    
+
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
         rover.balancebot_pitch_control(desired_throttle);
@@ -31,5 +31,7 @@ void ModeManual::update()
     // copy RC scaled inputs to outputs
     g2.motors.set_throttle(desired_throttle);
     g2.motors.set_steering(desired_steering, false);
+    g2.motors.set_roll(desired_roll);
+    g2.motors.set_pitch(desired_pitch);
     g2.motors.set_lateral(desired_lateral);
 }

--- a/Rover/mode_manual.cpp
+++ b/Rover/mode_manual.cpp
@@ -9,10 +9,13 @@ void ModeManual::_exit()
 
 void ModeManual::update()
 {
-    float desired_steering, desired_throttle, desired_lateral;
+    float desired_steering, desired_throttle, desired_lateral, desired_roll, desired_pitch;
     get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
     get_pilot_desired_lateral(desired_lateral);
 
+    //walking robot roll and pitch
+    get_pilot_desired_roll_and_pitch(desired_roll,desired_pitch);
+    
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
         rover.balancebot_pitch_control(desired_throttle);

--- a/Rover/radio.cpp
+++ b/Rover/radio.cpp
@@ -9,10 +9,14 @@ void Rover::set_control_channels(void)
     channel_steer    = rc().channel(rcmap.roll()-1);
     channel_throttle = rc().channel(rcmap.throttle()-1);
     channel_lateral  = rc().channel(rcmap.yaw()-1);
+    channel_roll     = rc().channel(rcmap.yaw()-1);
+    channel_pitch    = rc().channel(rcmap.pitch()-1);
 
     // set rc channel ranges
     channel_steer->set_angle(SERVO_MAX);
     channel_throttle->set_angle(100);
+    channel_roll->set_angle(100);
+    channel_pitch->set_angle(100);
     if (channel_lateral != nullptr) {
         channel_lateral->set_angle(100);
     }
@@ -38,6 +42,8 @@ void Rover::init_rc_in()
     // set rc dead zones
     channel_steer->set_default_dead_zone(30);
     channel_throttle->set_default_dead_zone(30);
+    channel_roll->set_default_dead_zone(30);
+    channel_pitch->set_default_dead_zone(30);
     if (channel_lateral != nullptr) {
         channel_lateral->set_default_dead_zone(30);
     }

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -335,6 +335,128 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @User: Standard
     AP_SUBGROUPINFO(_sailboat_heel_pid, "_SAIL_", 12, AR_AttitudeControl, AC_PID),
 
+    // @Param: _ROLL_P
+    // @DisplayName: Roll control P gain
+    // @Description: Roll angle controller P gain
+    // @Range: 0.000 2.000
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: _ROLL_I
+    // @DisplayName: Roll control I gain
+    // @Description: Roll angle controller I gain
+    // @Range: 0.000 2.000
+    // @User: Standard
+
+    // @Param: _ROLL_IMAX
+    // @DisplayName: Roll control I gain maximum
+    // @Description: Roll control I gain maximum gain
+    // @Range: 0.000 1.000
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: _ROLL_D
+    // @DisplayName: Roll control D gain
+    // @Description: Roll control D gain
+    // @Range: 0.000 0.100
+    // @Increment: 0.001
+    // @User: Standard
+
+    // @Param: _ROLL_FF
+    // @DisplayName: Roll control feed forward
+    // @Description: Roll control feed forward
+    // @Range: 0.000 0.500
+    // @Increment: 0.001
+    // @User: Standard
+
+    // @Param: _ROLL_FILT
+    // @DisplayName: Roll control filter frequency
+    // @Description: Roll control input filter.  Lower values reduce noise but add delay.
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _ROLL_FLTT
+    // @DisplayName: Roll control Target filter frequency in Hz
+    // @Description: Target filter frequency in Hz
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _ROLL_FLTE
+    // @DisplayName: Roll control Error filter frequency in Hz
+    // @Description: Error filter frequency in Hz
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _ROLL_FLTD
+    // @DisplayName: Roll control Derivative term filter frequency in Hz
+    // @Description: Derivative filter frequency in Hz
+    // @Units: Hz
+    // @User: Standard
+    AP_SUBGROUPINFO(_roll_pid, "_ROLL_", 13, AR_AttitudeControl, AC_PID),
+
+    // @Param: _PITCH_P
+    // @DisplayName: Pitch control P gain
+    // @Description: Pitch angle controller P gain
+    // @Range: 0.000 2.000
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: _PITCH_I
+    // @DisplayName: Pitch control I gain
+    // @Description: Pitch angle controller I gain
+    // @Range: 0.000 2.000
+    // @User: Standard
+
+    // @Param: _PITCH_IMAX
+    // @DisplayName: Pitch control I gain maximum
+    // @Description: Pitch control I gain maximum gain
+    // @Range: 0.000 1.000
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: _PITCH_D
+    // @DisplayName: Pitch control D gain
+    // @Description: Pitch control D gain
+    // @Range: 0.000 0.100
+    // @Increment: 0.001
+    // @User: Standard
+
+    // @Param: _PITCH_FF
+    // @DisplayName: Pitch control feed forward
+    // @Description: Pitch control feed forward
+    // @Range: 0.000 0.500
+    // @Increment: 0.001
+    // @User: Standard
+
+    // @Param: _PITCH_FILT
+    // @DisplayName: Pitch control filter frequency
+    // @Description: Pitch control input filter.  Lower values reduce noise but add delay.
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _PITCH_FLTT
+    // @DisplayName: Pitch control Target filter frequency in Hz
+    // @Description: Target filter frequency in Hz
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _PITCH_FLTE
+    // @DisplayName: Pitch control Error filter frequency in Hz
+    // @Description: Error filter frequency in Hz
+    // @Units: Hz
+    // @User: Standard
+
+    // @Param: _PITCH_FLTD
+    // @DisplayName: Pitch control Derivative term filter frequency in Hz
+    // @Description: Derivative filter frequency in Hz
+    // @Units: Hz
+    // @User: Standard    
+    AP_SUBGROUPINFO(_pitch_pid, "_PITCH_", 14, AR_AttitudeControl, AC_PID),
+
     AP_GROUPEND
 };
 
@@ -344,7 +466,9 @@ AR_AttitudeControl::AR_AttitudeControl(AP_AHRS &ahrs) :
     _steer_rate_pid(AR_ATTCONTROL_STEER_RATE_P, AR_ATTCONTROL_STEER_RATE_I, AR_ATTCONTROL_STEER_RATE_D, AR_ATTCONTROL_STEER_RATE_FF, AR_ATTCONTROL_STEER_RATE_IMAX, 0.0f, AR_ATTCONTROL_STEER_RATE_FILT, 0.0f, AR_ATTCONTROL_DT),
     _throttle_speed_pid(AR_ATTCONTROL_THR_SPEED_P, AR_ATTCONTROL_THR_SPEED_I, AR_ATTCONTROL_THR_SPEED_D, 0.0f, AR_ATTCONTROL_THR_SPEED_IMAX, 0.0f, AR_ATTCONTROL_THR_SPEED_FILT, 0.0f, AR_ATTCONTROL_DT),
     _pitch_to_throttle_pid(AR_ATTCONTROL_PITCH_THR_P, AR_ATTCONTROL_PITCH_THR_I, AR_ATTCONTROL_PITCH_THR_D, 0.0f, AR_ATTCONTROL_PITCH_THR_IMAX, 0.0f, AR_ATTCONTROL_PITCH_THR_FILT, 0.0f, AR_ATTCONTROL_DT),
-    _sailboat_heel_pid(AR_ATTCONTROL_HEEL_SAIL_P, AR_ATTCONTROL_HEEL_SAIL_I, AR_ATTCONTROL_HEEL_SAIL_D, 0.0f, AR_ATTCONTROL_HEEL_SAIL_IMAX, 0.0f, AR_ATTCONTROL_HEEL_SAIL_FILT, 0.0f, AR_ATTCONTROL_DT)
+    _sailboat_heel_pid(AR_ATTCONTROL_HEEL_SAIL_P, AR_ATTCONTROL_HEEL_SAIL_I, AR_ATTCONTROL_HEEL_SAIL_D, 0.0f, AR_ATTCONTROL_HEEL_SAIL_IMAX, 0.0f, AR_ATTCONTROL_HEEL_SAIL_FILT, 0.0f, AR_ATTCONTROL_DT),
+    _roll_pid(AR_ATTCONTROL_ROLL_P, AR_ATTCONTROL_ROLL_I, AR_ATTCONTROL_ROLL_D, 0.0f, AR_ATTCONTROL_ROLL_IMAX, 0.0f, AR_ATTCONTROL_ROLL_FILT, 0.0f, AR_ATTCONTROL_DT),
+    _pitch_pid(AR_ATTCONTROL_PITCH_P, AR_ATTCONTROL_PITCH_I, AR_ATTCONTROL_PITCH_D, 0.0f, AR_ATTCONTROL_PITCH_IMAX, 0.0f, AR_ATTCONTROL_PITCH_FILT, 0.0f, AR_ATTCONTROL_DT)
     {
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -664,6 +788,76 @@ float AR_AttitudeControl::get_sail_out_from_heel(float desired_heel, float dt)
 
     // constrain and return final output
     return (ff + p + i + d) * -1.0f;
+}
+
+// roll angle controller for boats with trim tabs
+float AR_AttitudeControl::get_servo_out_from_roll(float desired_roll, float dt)
+{
+    // sanity check dt
+    dt = constrain_float(dt, 0.0f, 1.0f);
+
+    // if not called recently, reset input filter
+    const uint32_t now = AP_HAL::millis();
+    if ((_roll_controller_last_ms == 0) || ((now - _roll_controller_last_ms) > AR_ATTCONTROL_TIMEOUT_MS)) {
+        _roll_pid.reset_filter();
+        _roll_pid.reset_I();
+    }
+    _roll_controller_last_ms = now;
+
+    // set PID's dt
+    _roll_pid.set_dt(dt);
+
+    _roll_pid.update_all(desired_roll, _ahrs.roll);
+
+    // get feed-forward
+    const float ff = _roll_pid.get_ff(desired_roll);
+
+    // get p
+    const float p = _roll_pid.get_p();
+
+    // get i
+    const float i = _roll_pid.get_i();
+
+    // get d
+    const float d = _roll_pid.get_d();
+
+    // return final output
+    return (ff + p + i + d);
+}
+
+// pitch angle controller
+float AR_AttitudeControl::get_servo_out_from_pitch(float desired_pitch, float dt)
+{
+    // sanity check dt
+    dt = constrain_float(dt, 0.0f, 1.0f);
+
+    // if not called recently, reset input filter
+    const uint32_t now = AP_HAL::millis();
+    if ((_pitch_controller_last_ms == 0) || ((now - _pitch_controller_last_ms) > AR_ATTCONTROL_TIMEOUT_MS)) {
+        _pitch_pid.reset_filter();
+        _pitch_pid.reset_I();
+    }
+    _pitch_controller_last_ms = now;
+
+    // set PID's dt
+    _pitch_pid.set_dt(dt);
+
+    _pitch_pid.update_all(desired_pitch, _ahrs.pitch);
+
+    // get feed-forward
+    const float ff = _pitch_pid.get_ff(desired_pitch);
+
+    // get p
+    const float p = _pitch_pid.get_p();
+
+    // get i
+    const float i = _pitch_pid.get_i();
+
+    // get d
+    const float d = _pitch_pid.get_d();
+
+    // return final output
+    return (ff + p + i + d );
 }
 
 // get forward speed in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -35,6 +35,18 @@
 #define AR_ATTCONTROL_HEEL_SAIL_FILT    10.0f
 #define AR_ATTCONTROL_DT                0.02f
 
+#define AR_ATTCONTROL_ROLL_P       1.0f
+#define AR_ATTCONTROL_ROLL_I       0.1f
+#define AR_ATTCONTROL_ROLL_D       0.0f
+#define AR_ATTCONTROL_ROLL_IMAX    1.0f
+#define AR_ATTCONTROL_ROLL_FILT    10.0f
+
+#define AR_ATTCONTROL_PITCH_P       1.0f
+#define AR_ATTCONTROL_PITCH_I       0.1f
+#define AR_ATTCONTROL_PITCH_D       0.0f
+#define AR_ATTCONTROL_PITCH_IMAX    1.0f
+#define AR_ATTCONTROL_PITCH_FILT    10.0f
+
 // throttle/speed control maximum acceleration/deceleration (in m/s) (_ACCEL_MAX parameter default)
 #define AR_ATTCONTROL_THR_ACCEL_MAX     2.00f
 
@@ -115,12 +127,18 @@ public:
     // Sailboat heel(roll) angle contorller, release sail to keep at maximum heel angle
     float get_sail_out_from_heel(float desired_heel, float dt);
 
+    // roll and pitch angle controllers for boats with trim tabs
+    float get_servo_out_from_roll(float desired_roll, float dt);
+    float get_servo_out_from_pitch(float desired_pitch, float dt);
+
     // low level control accessors for reporting and logging
     AC_P& get_steering_angle_p() { return _steer_angle_p; }
     AC_PID& get_steering_rate_pid() { return _steer_rate_pid; }
     AC_PID& get_throttle_speed_pid() { return _throttle_speed_pid; }
     AC_PID& get_pitch_to_throttle_pid() { return _pitch_to_throttle_pid; }
     AC_PID& get_sailboat_heel_pid() { return _sailboat_heel_pid; }
+    AC_PID& get_roll_pid() { return _roll_pid; }
+    AC_PID& get_pitch_pid() { return _pitch_pid; }
 
     // get forward speed in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success
     bool get_forward_speed(float &speed) const;
@@ -187,4 +205,9 @@ private:
     // Sailboat heel control
     AC_PID   _sailboat_heel_pid;    // Sailboat heel angle pid controller
     uint32_t _heel_controller_last_ms = 0;
+
+    AC_PID   _roll_pid;     // roll angle pid controller
+    AC_PID   _pitch_pid;    // pitch angle pid controller
+    uint32_t _roll_controller_last_ms = 0;
+    uint32_t _pitch_controller_last_ms = 0;
 };

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -707,7 +707,9 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
             pwm_output[0] = pwm_output[1] = pwm_output[3] = 1500;
         }
         if (_vehicle == Rover) {
-            pwm_output[0] = pwm_output[1] = pwm_output[2] = pwm_output[3] = 1500;
+            for (i=0; i<SITL_NUM_CHANNELS; i++) {
+                pwm_output[i] = 1500;
+            }
         }
     }
 

--- a/libraries/AP_Scripting/examples/quadruped.lua
+++ b/libraries/AP_Scripting/examples/quadruped.lua
@@ -1,0 +1,299 @@
+-- quadruped robot script 
+
+local L = 80  -- length of frame
+local W = 150  -- width of frame 
+
+local L_COXA = 30 --distance from coxa servo to femur servo
+local L_FEMUR = 85    --distance from femur servo to tibia servo
+local L_TIBIA = 125   --distance from tibia servo to foot
+
+--body position and rotation parameters
+local bodyRotX = 0
+local bodyRotY = 0         
+local bodyRotZ = 0    
+local bodyPosX = 0     
+local bodyPosY = 0            
+local bodyPosZ = 0
+
+-- starting positions of the legs
+local endpoints1 = {math.cos(45/180*math.pi)*(L_COXA + L_FEMUR), math.sin(45/180*math.pi)*(L_COXA + L_FEMUR),      L_TIBIA }
+local endpoints2 = {math.cos(45/180*math.pi)*(L_COXA + L_FEMUR), math.sin(-45/180*math.pi)*(L_COXA + L_FEMUR),      L_TIBIA }
+local endpoints3 = {-math.cos(45/180*math.pi)*(L_COXA + L_FEMUR), math.sin(-45/180*math.pi)*(L_COXA + L_FEMUR),      L_TIBIA }
+local endpoints4 = {-math.cos(45/180*math.pi)*(L_COXA + L_FEMUR), math.sin(45/180*math.pi)*(L_COXA + L_FEMUR),      L_TIBIA }
+
+--select a gait pattern(default gait = 0)
+local GaitType = 0
+--lift height while walking 
+local LegLiftHeight = 50  
+--gait step in exectution 
+local GaitStep = 0   
+--initial position of the leg
+local GaitLegNr = {0,0,0,0}  
+local TLDivFactor = 0       
+local NrLiftedPos = 0    
+local LiftDivFactor = 0    
+local HalfLiftHeigth = 0     
+local FrontDownPos = 0			
+local TravelRequest = false       
+--Number of steps in gait     
+local StepsInGait = 0 
+local GaitStep = 0         
+local GaitPosX = {0,0,0,0}         
+local GaitPosY = {0,0,0,0}            
+local GaitPosZ = {0,0,0,0}             
+local GaitRotZ = {0,0,0,0}      
+local LegIndex = 0   
+local Walking = false
+local X_speed = 0
+local Yaw_speed = 0
+local Y_speed = 0
+local DeadZone = 5
+local last_angle = {0,0,0,0,0,0,0,0,0,0,0,0}
+local current = {0,0,0,0,0,0,0,0,0,0,0,0}
+local start_time = 0
+local curr_target = 0
+local throttle = 3
+local yaw = 4
+local roll = 1
+local pitch = 2
+local gait = 5
+local mode = 6
+local max_step_factor = 40
+local max_rotation_factor = 10
+local max_yaw_factor = 10
+local pwm = { 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500}
+-- turn off rudder based arming/disarming
+param:set_and_save('ARMING_RUDDER',0)
+function Gaitselect()
+    --Alternating gait
+    if (GaitType == 0) then
+        GaitLegNr = {1,4,1,4}
+        NrLiftedPos = 2
+        FrontDownPos = 1	
+        LiftDivFactor = 2
+        HalfLiftHeigth = 1
+        TLDivFactor = 4   
+        StepsInGait = 6    
+    elseif (GaitType == 1) then
+    -- wave gait with 28 steps
+        GaitLegNr = {8,15,1,22}
+        NrLiftedPos = 3
+        FrontDownPos = 2	
+        LiftDivFactor = 2
+        HalfLiftHeigth = 3
+        TLDivFactor = 24 
+        StepsInGait = 28
+    end 
+end
+
+-- Calculate Gait sequence
+function Sequence_Gen()
+    TravelRequest =(math.abs(X_speed) > DeadZone) or (math.abs(Y_speed) > DeadZone) or (math.abs(Yaw_speed) > DeadZone) 
+    
+    if TravelRequest then
+        for LegIndex=1,4,1 
+        do 
+            Gaitgen(LegIndex)
+        end
+
+        GaitStep = GaitStep + 1
+        if (GaitStep>StepsInGait) then
+            GaitStep = 1
+        end 
+    else
+        GaitPosX = {0,0,0,0}         
+        GaitPosY = {0,0,0,0}            
+        GaitPosZ = {0,0,0,0}             
+        GaitRotZ = {0,0,0,0}  
+    end
+end
+
+-- In order for the bot to move forward it needs to move its legs in a
+-- specific order and this is repeated over and over to attain linear motion . when a
+-- specific leg number is passed the Gaitgen() produces the set off values for the
+-- given leg at that step , for each cycle of the gait each leg will move to a set
+-- distance which is decided by the X_speed,Yaw_speed,Y_speed
+function Gaitgen(moving_leg)
+    local LegStep = GaitStep - GaitLegNr[moving_leg]
+
+    if ((TravelRequest and (NrLiftedPos and 1) and 
+    LegStep==0) or 
+    (not TravelRequest and LegStep==0 and ((GaitPosX[moving_leg]>2) or 
+    (GaitPosZ[moving_leg]>2) or (GaitRotZ[moving_leg] >2)))) 
+    then
+        GaitPosX[moving_leg] = 0
+        GaitPosZ[moving_leg] = -LegLiftHeight
+        GaitPosY[moving_leg] = 0
+        GaitRotZ[moving_leg] = 0
+
+    elseif (((NrLiftedPos==2 and LegStep==0) or (NrLiftedPos>=3 and 
+    (LegStep==-1 or LegStep==(StepsInGait-1))))
+    and TravelRequest)
+    then
+        GaitPosX[moving_leg] = -X_speed/LiftDivFactor
+        GaitPosZ[moving_leg] = -3*LegLiftHeight/(3+HalfLiftHeigth)  
+        GaitPosY[moving_leg] = -Y_speed/LiftDivFactor
+        GaitRotZ[moving_leg] = -Yaw_speed/LiftDivFactor
+
+    elseif ((NrLiftedPos>=2) and (LegStep==1 or LegStep==-(StepsInGait-1)) and TravelRequest)
+    then
+        GaitPosX[moving_leg] = X_speed/LiftDivFactor
+        GaitPosZ[moving_leg] = -3*LegLiftHeight/(3+HalfLiftHeigth)  
+        GaitPosY[moving_leg] = Y_speed/LiftDivFactor
+        GaitRotZ[moving_leg] = Yaw_speed/LiftDivFactor
+
+    elseif (((NrLiftedPos==5 and (LegStep==-2 ))) and TravelRequest)
+    then
+        GaitPosX[moving_leg] = -X_speed/2
+        GaitPosZ[moving_leg] = -LegLiftHeight/2 
+        GaitPosY[moving_leg] = -Y_speed/2
+        GaitRotZ[moving_leg] = -Yaw_speed/2
+
+    elseif ((NrLiftedPos==5) and (LegStep==2 or LegStep==-(StepsInGait-2)) and TravelRequest)
+    then
+        GaitPosX[moving_leg] = X_speed/2
+        GaitPosZ[moving_leg] = -LegLiftHeight/2 
+        GaitPosY[moving_leg] = Y_speed/2
+        GaitRotZ[moving_leg] = Yaw_speed/2
+
+    elseif ((LegStep==FrontDownPos or LegStep==-(StepsInGait-FrontDownPos)) and GaitPosY[moving_leg]<0)
+    then
+        GaitPosX[moving_leg] = X_speed/2
+        GaitPosZ[moving_leg] = Y_speed/2
+        GaitPosY[moving_leg] = Yaw_speed/2   
+        GaitRotZ[moving_leg] = 0
+
+    else 
+        GaitPosX[moving_leg] = GaitPosX[moving_leg] - (X_speed/TLDivFactor)
+        GaitPosZ[moving_leg] = 0
+        GaitPosY[moving_leg] = GaitPosZ[moving_leg] - (Y_speed/TLDivFactor)
+        GaitRotZ[moving_leg] = GaitRotZ[moving_leg] - (Yaw_speed/TLDivFactor)
+    end
+end
+
+-- This function determines where each leg should be.
+-- To calculate each legs pose this takes pose of the body
+-- as input bodyRotX, bodyRotY, bodyRotZ - rotation of and body ,bodyPosX,
+-- bodyPosY - offset of the center of body
+function Body_FK(X , Y , Z,   Xdist, Ydist,Zrot)
+    local totaldist = { X + Xdist + bodyPosX, Y + Ydist + bodyPosY }
+    local distBodyCenterFeet = math.sqrt(totaldist[1]^2 + totaldist[2]^2)
+    local AngleBodyCenter = math.atan(totaldist[2], totaldist[1])
+    local rolly = math.tan(bodyRotY * math.pi/180) * totaldist[1]
+    local pitchy = math.tan(bodyRotX * math.pi/180) * totaldist[2]
+
+    local ansx = math.cos(AngleBodyCenter + ((bodyRotZ+Zrot)  * math.pi/180)) * distBodyCenterFeet - totaldist[1] + bodyPosX
+    local ansy = math.sin(AngleBodyCenter + ((bodyRotZ+Zrot) * math.pi/180)) * distBodyCenterFeet - totaldist[2] + bodyPosY
+    local ansz = rolly+pitchy + bodyPosZ
+    local ans = {ansx, ansy ,ansz}
+    return ans 
+end 
+
+-- Calculates the angles of servos of each joint using the output of the
+-- Body_FK() function which gives the origin of each leg on the body frame
+function Leg_IK(X , Y , Z)
+    local coxa = math.atan(X,Y)* 180/math.pi
+    local trueX = math.sqrt(X^2+ Y^2 ) - L_COXA
+    local im = math.sqrt(trueX^2 + Z^2)
+
+    local q1 = -math.atan(Z,trueX)
+    local d1 = L_FEMUR^2 - L_TIBIA^2 + im^2
+    local d2 = 2*L_FEMUR*im
+    local q2 = math.acos(d1/d2)
+    local femur = (q1+q2) * 180/math.pi
+
+    local d1 = L_FEMUR^2 - im^2 + L_TIBIA^2
+    local d2 = 2*L_TIBIA*L_FEMUR
+    local tibia = (math.acos(d1/d2)-1.57) * 180/math.pi
+    local ang = { coxa, -femur ,-tibia}
+    return ang 
+end
+
+-- checks if the servo has moved to its expected postion 
+function servo_estimate(start_time,current,last_angle)
+    local target = 0
+    for j = 1, 12 do
+        curr_target = math.abs(current[j] - last_angle[j])
+        if curr_target > target then
+            target = curr_target
+        end
+    end    
+    local target_time = target * (0.24/60) * 1000 
+    local now = millis()
+
+    if (target_time + start_time) <= now then
+        return true
+    else
+        return false
+    end   
+end
+
+-- main_IK produces the IK solution for each
+-- leg joint servos by taking into consideration the initial_pos, gait offset and the
+-- bodyIK values.
+function main_IK()
+    local ans1 = Body_FK(endpoints1[1]+GaitPosX[1], endpoints1[2]+GaitPosY[1], endpoints1[3]+GaitPosZ[1], L/2, W/2,GaitRotZ[1])
+    local angles1 = Leg_IK(endpoints1[1]+ans1[1]+GaitPosX[1],endpoints1[2]+ans1[2]+GaitPosY[1], endpoints1[3]+ans1[3]+GaitPosZ[1])
+    angles1 = {-45 + angles1[1],angles1[2],angles1[3]}
+
+    local ans2 = Body_FK(endpoints2[1]+GaitPosX[2], endpoints2[2]+GaitPosY[2], endpoints2[3]+GaitPosZ[2], L/2, -W/2,GaitRotZ[2])
+    local angles2 = Leg_IK(endpoints2[1]+ans2[1]+GaitPosX[2],endpoints2[2]+ans2[2]+GaitPosY[2], endpoints2[3]+ans2[3]+GaitPosZ[2])
+    angles2 = {-135 + angles2[1],angles2[2],angles2[3]}
+
+    local ans3 = Body_FK(endpoints3[1]+GaitPosX[3], endpoints3[2]+GaitPosY[3], endpoints3[3]+GaitPosZ[3], -L/2, -W/2,GaitRotZ[3])
+    local angles3 = Leg_IK(endpoints3[1]+ans3[1]+GaitPosX[3],endpoints3[2]+ans3[2]+GaitPosY[3], endpoints3[3]+ans3[3]+GaitPosZ[3])
+    angles3 = {135 + angles3[1],angles3[2],angles3[3]}
+
+    local ans4 = Body_FK(endpoints4[1]+GaitPosX[4], endpoints4[2]+GaitPosY[4], endpoints4[3]+GaitPosZ[4], -L/2, W/2,GaitRotZ[4])
+    local angles4 = Leg_IK(endpoints4[1]+ans4[1]+GaitPosX[4],endpoints4[2]+ans4[2]+GaitPosY[4], endpoints4[3]+ans4[3]+GaitPosZ[4])
+    angles4 = {45 + angles4[1],angles4[2],angles4[3]}
+    Gaitselect()
+    current = {angles1[1],angles1[2],angles1[3],angles2[1],angles2[2],angles2[3],angles3[1],angles3[2],angles3[3],angles4[1],angles4[2],angles4[3]}
+  
+    if servo_estimate(start_time,current,last_angle) then
+        start_time = millis()
+        Sequence_Gen()
+        last_angle = current
+    end
+
+    return angles1,angles4,angles3,angles2
+end
+
+local rest_angles = { 45, -90, 40,
+                -45, -90, 40,
+                45, -90, 40,
+                -45, -90, 40}
+local servo_direction = { 1,1,1,
+                        -1,-1,-1,
+                        -1,-1,1,
+                        1,1,-1} 
+
+function update()
+    X_speed = vehicle:get_control_output(throttle) * max_step_factor
+    Yaw_speed = vehicle:get_control_output(yaw) * max_yaw_factor
+
+    bodyRotX = - (vehicle:get_control_output(roll) * 180/math.pi) 
+    bodyRotY = - (vehicle:get_control_output(pitch) * 180/math.pi) 
+
+    if arming:is_armed() then
+        FR_angles ,  BL_angles, BR_angles, FL_angles = main_IK()
+
+        angles = { FR_angles[1],FR_angles[2],FR_angles[3] , FL_angles[1],FL_angles[2],FL_angles[3],BR_angles[1],BR_angles[2],BR_angles[3], BL_angles[1],BL_angles[2],BL_angles[3]}
+    else
+        angles = rest_angles
+    end
+
+    for j = 1, 12 do
+        pwm[j] = math.floor(((angles[j] * servo_direction[j] * 1000)/90) + 1500)
+    end
+
+    for i = 1, 12 do
+        SRV_Channels:set_output_pwm_chan_timeout(i-1, pwm[i], 1000)
+    end
+
+    return update,10
+
+end
+
+gcs:send_text(0, "quadruped simulation")
+return update()

--- a/libraries/SITL/examples/JSON/pybullet/models/quadruped/quadruped.urdf
+++ b/libraries/SITL/examples/JSON/pybullet/models/quadruped/quadruped.urdf
@@ -1,0 +1,375 @@
+<?xml version="1.0"?>
+<robot name="materials">
+
+  <material name="blue">
+    <color rgba="0 0 0.8 1"/>
+  </material>
+
+  <material name="white">
+    <color rgba="1 1 1 1"/>
+  </material>
+
+  <material name="red">
+    <color rgba="0.8 0 0 1"/>
+  </material>
+
+  <link name="base_link">
+    <collision>
+        <geometry>
+          <box size="1.5 0.8 0.08"/>
+        </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0"/>
+      <mass value="100.843" />
+      <inertia ixx="0.002480" ixy="9.381E-19" ixz="-3.172E-18"
+                              iyy="1.060E-02" iyz="1002.754E-09"
+                                              izz="1.243E-02" />
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="1.5 0.8 0.08"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+  </link>
+
+
+#FRONT RIGHT
+  <link name="coxa_FR">
+ 
+    <visual>
+      <geometry>
+        <cylinder length="0.3" radius="0.1"/>
+      </geometry>
+      <origin rpy="1.57 0 0" xyz="0.0 -0.15 0"/>
+      <material name="red"/>
+    </visual>
+  </link>
+
+  <link name="femur_FR">
+    
+    <visual>
+      <geometry>
+         <cylinder length="0.85" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.425"/>
+      <material name="white"/>
+    </visual>
+  </link>
+
+  <link name="tibia_FR">
+
+    <visual>
+      <geometry>
+       <cylinder length="1.25" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.625"/>
+      <material name="blue"/>
+    </visual>
+  </link>
+
+  <link name="foot_FR">
+    <collision>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+    </collision>
+   <mass value="200.843" />
+    <visual>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+  </link>
+  
+  <joint name="coxaF_FR" type="revolute">
+    <axis xyz="0 0 1"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="base_link"/>
+    <child link="coxa_FR"/>
+    <origin rpy="0 0 0.785398" xyz="0.75 -0.4 0"/>
+  </joint>
+
+  <joint name="femurF_FR" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="coxa_FR"/>
+    <child link="femur_FR"/>
+    <origin rpy="4.71239 0 0" xyz="0 -0.3 0"/>
+  </joint>
+
+  <joint name="tibiaF_FR" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="femur_FR"/>
+    <child link="tibia_FR"/>
+    <origin rpy="1.5708 0 0" xyz="0 0 -0.85"/>
+  </joint>
+
+  <joint name="footF_FR" type="fixed">
+    <parent link="tibia_FR"/>
+    <child link="foot_FR"/>
+    <origin xyz="0 0 -1.25"/>
+  </joint>
+
+
+
+
+#FRONT LEFT
+
+
+
+  <link name="coxa_FL">
+
+    <visual>
+      <geometry>
+        <cylinder length="0.3" radius="0.1"/>
+      </geometry>
+      <origin rpy="1.57 0 0" xyz="0 -0.15 0"/>
+      <material name="red"/>
+    </visual>
+  </link>
+
+  <link name="femur_FL">
+  
+    <visual>
+      <geometry>
+        <cylinder length="0.85" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.425"/>
+      <material name="white"/>
+    </visual>
+  </link>
+
+  <link name="tibia_FL">
+
+    <visual>
+      <geometry>
+        <cylinder length="1.25" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.625"/>
+      <material name="blue"/>
+    </visual>
+  </link>
+
+  <link name="foot_FL">
+    <collision>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+    </collision>
+  <mass value="200.843" />
+    <visual>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+  </link>
+  
+  <joint name="coxaF_FL" type="revolute">
+    <axis xyz="0 0 1"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="base_link"/>
+    <child link="coxa_FL"/>
+    <origin rpy="0 0 2.35619" xyz="0.74 0.4 0"/>
+  </joint>
+
+  <joint name="femurF_FL" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="coxa_FL"/>
+    <child link="femur_FL"/>
+    <origin rpy="4.71239 0 0" xyz="0 -0.3 0"/>
+  </joint>
+
+  <joint name="tibiaF_FL" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="femur_FL"/>
+    <child link="tibia_FL"/>
+    <origin rpy="1.5708 0 0" xyz="0 0 -0.85"/>
+  </joint>
+
+  <joint name="footF_FL" type="fixed">
+    <parent link="tibia_FL"/>
+    <child link="foot_FL"/>
+    <origin xyz="0 0 -1.25"/>
+  </joint>
+
+
+
+
+
+
+
+#BACK RIGHT
+
+
+
+<link name="coxa_BR">
+ 
+    <visual>
+      <geometry>
+        <cylinder length="0.3" radius="0.1"/>
+      </geometry>
+      <origin rpy="1.57 0 0" xyz="0.0 -0.15 0"/>
+      <material name="red"/>
+    </visual>
+  </link>
+
+  <link name="femur_BR">
+ 
+    <visual>
+      <geometry>
+         <cylinder length="0.85" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.425"/>
+      <material name="white"/>
+    </visual>
+  </link>
+
+  <link name="tibia_BR">
+
+    <visual>
+      <geometry>
+       <cylinder length="1.25" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.625"/>
+      <material name="blue"/>
+    </visual>
+  </link>
+
+  <link name="foot_BR">
+    <collision>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+    </collision>
+   <mass value="200.843" />
+    <visual>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+  </link>
+  
+  <joint name="coxaF_BR" type="revolute">
+    <axis xyz="0 0 1"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="base_link"/>
+    <child link="coxa_BR"/>
+    <origin rpy="0 0 3.92699" xyz="-0.75 0.4 0"/>
+  </joint>
+
+  <joint name="femurF_BR" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="coxa_BR"/>
+    <child link="femur_BR"/>
+    <origin rpy="4.71239 0 0" xyz="0 -0.3 0"/>
+  </joint>
+
+  <joint name="tibiaF_BR" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="femur_BR"/>
+    <child link="tibia_BR"/>
+    <origin rpy="1.5708 0 0" xyz="0 0 -0.85"/>
+  </joint>
+
+  <joint name="footF_BR" type="fixed">
+    <parent link="tibia_BR"/>
+    <child link="foot_BR"/>
+    <origin xyz="0 0 -1.25"/>
+  </joint>
+
+
+
+
+#BACK LEFT
+
+
+
+<link name="coxa_BL">
+ 
+    <visual>
+      <geometry>
+        <cylinder length="0.3" radius="0.1"/>
+      </geometry>
+      <origin rpy="1.57 0 0" xyz="0.0 -0.15 0"/>
+      <material name="red"/>
+    </visual>
+  </link>
+
+  <link name="femur_BL">
+  
+    <visual>
+      <geometry>
+         <cylinder length="0.85" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.425"/>
+      <material name="white"/>
+    </visual>
+  </link>
+
+  <link name="tibia_BL">
+  
+    <visual>
+      <geometry>
+       <cylinder length="1.25" radius="0.1"/>
+      </geometry>
+      <origin xyz="0 0 -0.625"/>
+      <material name="blue"/>
+    </visual>
+  </link>
+
+  <link name="foot_BL">
+    <collision>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+    </collision>
+   <mass value="200.843" />
+    <visual>
+      <geometry>
+        <sphere radius="0.2"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+  </link>
+  
+  <joint name="coxaF_BL" type="revolute">
+    <axis xyz="0 0 1"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="base_link"/>
+    <child link="coxa_BL"/>
+    <origin rpy="0 0 5.48033" xyz="-0.75 -0.4 0"/>
+  </joint>
+
+  <joint name="femurF_BL" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="coxa_BL"/>
+    <child link="femur_BL"/>
+    <origin rpy="4.71239 0 0" xyz="0 -0.3 0"/>
+  </joint>
+
+  <joint name="tibiaF_BL" type="revolute">
+    <axis xyz="1 0 0"/>
+    <limit effort="1000.0" velocity="0.5"/>
+    <parent link="femur_BL"/>
+    <child link="tibia_BL"/>
+    <origin rpy="1.5708 0 0" xyz="0 0 -0.85"/>
+  </joint>
+
+  <joint name="footF_BL" type="fixed">
+    <parent link="tibia_BL"/>
+    <child link="foot_BL"/>
+    <origin xyz="0 0 -1.25"/>
+  </joint>
+
+</robot>

--- a/libraries/SITL/examples/JSON/pybullet/walking_robot.py
+++ b/libraries/SITL/examples/JSON/pybullet/walking_robot.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+import os, inspect, sys
+
+import socket
+import struct
+import json
+import math
+import pybullet_data
+import pybullet as p
+# use pymavlink for ArduPilot convention transformations
+from pymavlink.rotmat import Vector3, Matrix3
+from pymavlink.quaternion import Quaternion
+
+import time
+
+import argparse
+from math import degrees, radians
+
+parser = argparse.ArgumentParser(description="pybullet robot")
+parser.add_argument("--fps", type=float, default=1000.0, help="physics frame rate")
+
+args = parser.parse_args()
+
+RATE_HZ = args.fps
+TIME_STEP = 1.0 / RATE_HZ
+GRAVITY_MSS = 9.80665
+
+# Create simulator
+physicsClient = p.connect(p.GUI)#or p.DIRECT for non-graphical version
+p.setAdditionalSearchPath(pybullet_data.getDataPath()) #optionally
+p.setGravity(0,0,-10)
+FixedBase = False #if fixed no plane is imported
+if (FixedBase == False):
+    p.loadURDF("plane.urdf")
+p.changeDynamics(FixedBase,-1,lateralFriction=1.,
+                 spinningFriction=0., rollingFriction=0., contactStiffness=-1, contactDamping=-1)
+
+last_angles = [0.0] * 12
+force = [500] * 12
+servo_direction = [1,-1, 1,
+                   1, 1,-1,
+                   1,-1, 1,
+                   1, 1,-1]
+def control_joints(pwm):
+    '''control a joint based bot'''
+    global last_angles
+    joint_speed = radians(250)
+    joints = [0,1,2,4,5,6,8,9,10,12,13,14]
+    pwm = pwm[0:len(joints)]
+    angles = [radians(((v-1500.0)*90)/1000) for v in pwm ]
+    for i in range(len(angles)):
+      angles[i] = angles[i] * servo_direction[i]
+    current = last_angles
+    max_change = joint_speed * TIME_STEP
+    for i in range(len(angles)):
+        angles[i] = constrain(angles[i], current[i]-max_change, current[i]+max_change)
+    p.setJointMotorControlArray(robot, joints, p.POSITION_CONTROL, angles,forces = force)
+    last_angles = angles
+
+#spawn robot
+position = [0, 0, 1.6]
+robot = p.loadURDF("models/quadruped/quadruped.urdf",position, useFixedBase=FixedBase)
+control_pwm = control_joints
+
+p.setTimeStep(TIME_STEP)
+time_now = 0
+last_velocity = None
+
+def quaternion_to_AP(quaternion):
+    '''convert pybullet quaternion to ArduPilot quaternion'''
+    return Quaternion([quaternion[3], quaternion[0], -quaternion[1], -quaternion[2]])
+
+def vector_to_AP(vec):
+    '''convert pybullet vector tuple to ArduPilot Vector3'''
+    return Vector3(vec[0], -vec[1], -vec[2])
+
+def quaternion_from_AP(q):
+    '''convert ArduPilot quaternion to pybullet quaternion'''
+    return [q.q[1], -q.q[2], -q.q[3], q.q[0]]
+
+def to_tuple(vec3):
+    '''convert a Vector3 to a tuple'''
+    return (vec3.x, vec3.y, vec3.z)
+
+def init():
+  global time_now
+  time_now = 0
+  position = [0,0,0]
+  orientation = [0,0,0,1]
+  p.reset_Base_Position_And_Orientations(robot,position,orientation)
+
+
+def constrain(v,min_v,max_v):
+    '''constrain a value'''
+    if v < min_v:
+        v = min_v
+    if v > max_v:
+        v = max_v
+    return v
+
+#robot.position = [ 0, 0, 2]
+#robot.orientation = quaternion_from_AP(Quaternion([math.radians(0), math.radians(0), math.radians(50)]))
+def step(sleep_dt=None):
+    # # call the step method for each body
+    # for body in self.bodies.values():
+    #     if isinstance(body, Body):
+    #         body.step()
+
+    # call simulation step
+    p.stepSimulation()
+
+    # sleep
+    if sleep_dt is not None:
+        time.sleep(sleep_dt)
+
+def physics_step(pwm_in):
+
+  control_pwm(pwm_in)
+  
+  step(sleep_dt=0)
+  # p.setRealTimeSimulation(1)
+  global time_now
+  time_now += TIME_STEP
+
+  # get the position orientation and velocity
+  pos,ori = p.getBasePositionAndOrientation(robot)
+  quaternion = quaternion_to_AP(ori)
+  roll, pitch, yaw = quaternion.euler
+  linear,angular = p.getBaseVelocity(robot)
+  velocity = vector_to_AP(linear)
+  position = vector_to_AP(pos)
+
+  # get ArduPilot DCM matrix (rotation matrix)
+  dcm = quaternion.dcm
+
+  # get gyro vector in body frame
+  gyro = dcm.transposed() * vector_to_AP(angular)
+  
+  # calculate acceleration
+  global last_velocity
+  if last_velocity is None:
+      last_velocity = velocity
+
+  accel = (velocity - last_velocity) * (1.0 / TIME_STEP)
+  last_velocity = velocity
+
+  # add in gravity in earth frame
+  accel.z -= GRAVITY_MSS
+
+  # convert accel to body frame
+  accel = dcm.transposed() * accel
+
+  # convert to tuples
+  accel = to_tuple(accel)
+  gyro = to_tuple(gyro)
+  position = to_tuple(position)
+  velocity = to_tuple(velocity)
+  euler = (roll, pitch, yaw)
+
+  return time_now,gyro,accel,position,euler,velocity
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(('', 9002))
+sock.settimeout(0.1)
+
+last_SITL_frame = -1
+connected = False
+frame_count = 0
+frame_time = time.time()
+print_frame_count = 1000
+
+move_accel = 0.0
+last_move = time.time()
+
+while True:
+
+  py_time = time.time()
+
+  try:
+      data,address = sock.recvfrom(100)
+  except Exception as ex:
+      time.sleep(0.01)
+      continue
+
+  parse_format = 'HHI16H'
+  magic = 18458
+
+  if len(data) != struct.calcsize(parse_format):
+    print("got packet of len %u, expected %u" % (len(data), struct.calcsize(parse_format)))
+    continue
+
+
+  decoded = struct.unpack(parse_format,data)
+
+  if magic != decoded[0]:
+      print("Incorrect protocol magic %u should be %u" % (decoded[0], magic))
+      continue
+
+  frame_rate_hz = decoded[1]
+  frame_count = decoded[2]
+  pwm = decoded[3:]
+
+  if frame_rate_hz != RATE_HZ:
+      print("New frame rate %u" % frame_rate_hz)
+      RATE_HZ = frame_rate_hz
+      TIME_STEP = 1.0 / RATE_HZ
+      p.setTimeStep(TIME_STEP)
+
+  # Check if the fame is in expected order
+  if frame_count < last_SITL_frame:
+    # Controller has reset, reset physics also
+    init()
+    print('Controller reset')
+  elif frame_count == last_SITL_frame:
+    # duplicate frame, skip
+    print('Duplicate input frame')
+    continue
+  elif frame_count != last_SITL_frame + 1 and connected:
+    print('Missed {0} input frames'.format(frame_count - last_SITL_frame - 1))
+  last_SITL_frame = frame_count
+
+  if not connected:
+    connected = True
+    print('Connected to {0}'.format(str(address)))
+  frame_count += 1
+
+  # physics time step
+  phys_time,gyro,accel,pos,euler,velo = physics_step(pwm)
+
+  # build JSON format
+  IMU_fmt = {
+    "gyro" : gyro,
+    "accel_body" : accel
+  }
+  JSON_fmt = {
+    "timestamp" : phys_time,
+    "imu" : IMU_fmt,
+    "position" : pos,
+    "attitude" : euler,
+    "velocity" : velo
+  }
+  JSON_string = "\n" + json.dumps(JSON_fmt,separators=(',', ':')) + "\n"
+
+  # Send to AP
+  sock.sendto(bytes(JSON_string,"ascii"), address)
+
+  # Track frame rate
+  if frame_count % print_frame_count == 0:
+    now = time.time()
+    total_time = now - frame_time
+    print("%.2f fps T=%.3f dt=%.3f" % (print_frame_count/total_time, phys_time, total_time))
+    frame_time = now


### PR DESCRIPTION
**This PR adds support for walking robots**

 [Demo video](https://youtu.be/79nVlsYmy2U)

**Steps to run simulation :** 
1. Ensure the PC is runing Ubuntu 18.04 (other versions may work but this has not been confirmed yet)
2. pip3 install pybullet
3. cd to the ardupilot/Rover directory
4. create a "scripts" directory and copy "[/libraries/AP_Scripting/examples/quadruped.lua](https://github.com/ashvath100/ardupilot/blob/walkingrobot_support/libraries/AP_Scripting/examples/quadruped.lua)" into it
5. start SITL using, "../Tools/autotest/simvehicle.py --map --console -D -f JSON"
6. Enable scripting with "param set SCR_ENABLE 1" and then restart SITL
7.  From`ardupilot/libraries/SITL/examples/JSON/pybullet/`

     run `python3 walking_robot.py`

**Control inputs :** 
- Channel 1: Yaw input

- Channel 3: Throttle input 

- Channel 6: Gait select (switch)
rc 6 > 1500 : two legs alternating gait 
rc 6 < 1500 : one leg wave gait 

- Channel 7: Control mode selector (3 way switch)
rc 7 = 1500 : Height control 
rc 7 >1500 : Rotation control
rc 7 < 1500 : Position control

In Height control
- Channel 2: height input

In Rotation control 
- Channel 2: Roll input 
- Channel 4: Pitch input

In Position control
- Channel 2: X axis input 
- Channel 4: Y axis input

**To do:**
1. add Stabilize mode
2. Hardware testing  

