### PR TITLE
Remove ICM Gyro Pre-filter

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -521,7 +521,7 @@ bool AP_InertialSensor_Invensense::_accumulate_sensor_rate_sampling(uint8_t *sam
         Vector3f g2 = g * _gyro_scale;
         _notify_new_gyro_sensor_rate_sample(_gyro_instance, g2);
 
-        _accum.gyro += _accum.gyro_filter.apply(g);
+        _accum.gyro += g;
 
         if (_accum.gyro_count % _gyro_fifo_downsample_rate == 0) {
             _accum.gyro *= _fifo_gyro_scale;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -169,7 +169,6 @@ private:
         uint8_t accel_count;
         uint8_t gyro_count;
         LowPassFilterVector3f accel_filter{4000, 188};
-        LowPassFilterVector3f gyro_filter{8000, 188};
     } _accum;
 };
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
@@ -413,7 +413,7 @@ bool AP_InertialSensor_Invensensev2::_accumulate_sensor_rate_sampling(uint8_t *s
         Vector3f g2 = g * GYRO_SCALE;
         _notify_new_gyro_sensor_rate_sample(_gyro_instance, g2);
 
-        _accum.gyro += _accum.gyro_filter.apply(g);
+        _accum.gyro += g;
 
         if (_accum.gyro_count % _gyro_fifo_downsample_rate == 0) {
             _accum.gyro *= _fifo_gyro_scale;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.h
@@ -157,7 +157,6 @@ private:
         uint8_t accel_count;
         uint8_t gyro_count;
         LowPassFilterVector3f accel_filter{4500, 188};
-        LowPassFilterVector3f gyro_filter{9000, 188};
     } _accum;
 };
 


### PR DESCRIPTION
This PR is on top of #14423 and removes the gyro pre-filter that is applied in the ICM drivers.
There are a few reasons for doing this:

- You only want as much filtering as you need and what you need will vary. A fixed 188Hz filter removes that configurability.
- With the introduction of INS_GYRO_RATE we have remove the fixed backend rate of 1000Hz, a fixed 188Hz is likely to affect the gyro values differently as we modify the backend rate
- It introduces delay (and CPU cost)
- With notch filtering its now likely less important
- It makes it harder for the FFT to track noise.

So although removing the filter will inevitably add some noise. The question is - does it matter?

I ran tests with a gyro rate of 2kHz on an MPU6000 with/without and with double-notches. I picked 2kHz here because this was the frequency at which the differences were most evident. These were the results:

Standard:
![image](https://user-images.githubusercontent.com/2893260/88335272-f0c53d00-cd2a-11ea-9e8a-f837fb93d797.png)

No pre-filter:
![image](https://user-images.githubusercontent.com/2893260/88335308-033f7680-cd2b-11ea-8193-eff549292568.png)

No pre-filter, double notches:
![image](https://user-images.githubusercontent.com/2893260/88335347-12bebf80-cd2b-11ea-88d6-3a079f74aac0.png)

A few things to note:

- There is more noise without the filter
- The noise peaks are much clearer
- The noise levels are perfectly acceptable
- Double-notches squash the extra noise very nicely
- There is no discernable aliasing noise

Note to reviewers - this is actually a two-line change, most of the changes are in #14423