### PR TITLE
AP_Proximity: remove unused definition

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -24,10 +24,6 @@ public:
     void handle_msg(const mavlink_message_t &msg) override;
 
 private:
-
-    // initialise sensor (returns true if sensor is successfully initialised)
-    bool initialise();
-
     // horizontal distance support
     uint32_t _last_update_ms;   // system time of last DISTANCE_SENSOR message received
     float _distance_max;        // max range of sensor in meters


### PR DESCRIPTION
`bool initialise()`  is not defined in ap_proximity_mav. Maybe it would be better to remove its declaration