### PR TITLE
AP_Scripting: start, stop and query scripts from other scripts

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -186,7 +186,7 @@ void AP_Scripting::repl_stop(void) {
 }
 
 void AP_Scripting::thread(void) {
-    lua_scripts *lua = new lua_scripts(_script_vm_exec_count, _script_heap_size, _debug_level, terminal);
+    lua = new lua_scripts(_script_vm_exec_count, _script_heap_size, _debug_level, terminal);
     if (lua == nullptr || !lua->heap_allocated()) {
         gcs().send_text(MAV_SEVERITY_CRITICAL, "Unable to allocate scripting memory");
         delete lua;
@@ -197,6 +197,31 @@ void AP_Scripting::thread(void) {
 
     // only reachable if the lua backend has died for any reason
     gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting has stopped");
+}
+
+// start, stop and check on scripts
+bool AP_Scripting::script_start(const char *filename)
+{
+    if (lua == nullptr) {
+        return false;
+    }
+    return lua->script_start(filename);
+}
+
+bool AP_Scripting::script_stop(const char *filename)
+{
+    if (lua == nullptr) {
+        return false;
+    }
+    return lua->script_stop(filename);
+}
+
+bool AP_Scripting::script_running(const char *filename)
+{
+    if (lua == nullptr) {
+        return false;
+    }
+    return lua->script_running(filename);
 }
 
 AP_Scripting *AP_Scripting::_singleton = nullptr;

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -21,6 +21,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 
+class lua_scripts;
 class AP_Scripting
 {
 public:
@@ -50,12 +51,17 @@ public:
         bool session;
     } terminal;
 
+    // start, stop and check on scripts
+    bool script_start(const char *filename);
+    bool script_stop(const char *filename);
+    bool script_running(const char *filename);
+
 private:
+
+    lua_scripts* lua;
 
     bool repl_start(void);
     void repl_stop(void);
-
-    void load_script(const char *filename); // load a script from a file
 
     void thread(void); // main script execution thread
 

--- a/libraries/AP_Scripting/examples/Script_start_stop.lua
+++ b/libraries/AP_Scripting/examples/Script_start_stop.lua
@@ -1,0 +1,43 @@
+-- Test script for finding, starting, stopping and querying scripts
+
+local files
+local i = 0
+
+function update()
+
+  -- Print if a file is running or not, out of the original scripts found
+  for count = 1, #files do
+    if scripting:running(files[count]) then
+      gcs:send_text(0, files[count] .. " running")
+    else
+      gcs:send_text(0, files[count] .. " stopped")
+    end
+  end
+
+  -- Stop and Start again the simple loop (on sitl)
+  -- "/APM/scripts/simple_loop.lua" on real hardware
+  if i == 5 then
+    scripting:stop("./scripts/simple_loop.lua")
+  elseif i == 10 then
+    scripting:start("./scripts/simple_loop.lua")
+    i = 0
+  end
+  i = i + 1
+
+
+  return update, 2000
+end
+
+
+function init()
+  -- Print all the scripts found in the given directory
+  -- "./scripts" for SITL
+  -- '/APM/scripts' and '@ROMFS/scripts' on real hardware
+  files = scripting:find_in_dir("./scripts")
+  for count = 1, #files do
+    gcs:send_text(0, "found: " .. files[count])
+  end
+  return update, 2000
+end
+
+return init(), 5000

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -61,6 +61,11 @@ public:
     // run scripts, does not return unless an error occured
     void run(void);
 
+    // start, stop and check on scripts
+    bool script_start(const char *filename);
+    bool script_stop(const char *filename);
+    bool script_running(const char *filename);
+
     static bool overtime; // script exceeded it's execution slot, and we are bailing out
 private:
 
@@ -120,4 +125,6 @@ private:
     static void *alloc(void *ud, void *ptr, size_t osize, size_t nsize);
 
     static void *_heap;
+
+    HAL_Semaphore sem;
 };


### PR DESCRIPTION
alternate to https://github.com/ArduPilot/ardupilot/pull/14521 This adds the ability to stop, start and query scripts at runtime. I have added bindings so scripts can start each other. This would make it simple to run a 'watchdog' script to spot if a script has stopped and decide if it should be re-started. 

This also gives the ability to run scripts from different directorys, you could have some script subdirectory so they wont auto start but a 'loader' script could start up all scripts in folder x. 

Should be fairly straight forward to re-use these function to start or stop scripts over MAVLink.

Only run in SITL, seems to work, although in my testing the running script cannot tell if its running or not, suspect there is a bug somewhere. 

Looking some feedback on the general approach.