### PR TITLE
ArduPlane: remove duplicate fail-safe time check

### DIFF
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -250,7 +250,7 @@ int16_t Plane::rudder_input(void)
 
 void Plane::control_failsafe()
 {
-    if (millis() - failsafe.last_valid_rc_ms > 1000 || rc_failsafe_active()) {
+    if (rc_failsafe_active()) {
         // we do not have valid RC input. Set all primary channel
         // control inputs to the trim value and throttle to min
         channel_roll->set_radio_in(channel_roll->get_radio_trim());


### PR DESCRIPTION
The time is already checked in the rc_failsafe_active() function

https://github.com/ArduPilot/ardupilot/blob/39f16c4679c373b965ce2b92d70de026bc6f0e49/ArduPlane/radio.cpp#L392