### PR TITLE
Plane: use has_valid_input in place of checking throttle counter

### DIFF
--- a/ArduPlane/control_modes.cpp
+++ b/ArduPlane/control_modes.cpp
@@ -107,9 +107,8 @@ void Plane::read_control_switch()
     // If we get this value we do not want to change modes.
     if(switchPosition == 255) return;
 
-    if (failsafe.rc_failsafe || failsafe.throttle_counter > 0) {
-        // when we are in rc_failsafe mode then RC input is not
-        // working, and we need to ignore the mode switch channel
+    if (!rc().has_valid_input()) {
+        // ignore the mode switch channel if there is no valid RC input
         return;
     }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1224,7 +1224,8 @@ float QuadPlane::get_desired_yaw_rate_cds(bool should_weathervane)
 // get pilot desired climb rate in cm/s
 float QuadPlane::get_pilot_desired_climb_rate_cms(void) const
 {
-    if (plane.failsafe.rc_failsafe || plane.failsafe.throttle_counter > 0) {
+    if (!rc().has_valid_input()) {
+        // no valid input means no sensible pilot desired climb rate.
         // descend at 0.5m/s for now
         return -50;
     }
@@ -1735,8 +1736,7 @@ void QuadPlane::update(void)
     // disable throttle_wait when throttle rises above 10%
     if (throttle_wait &&
         (plane.get_throttle_input() > 10 ||
-         plane.failsafe.rc_failsafe ||
-         plane.failsafe.throttle_counter>0)) {
+         !rc().has_valid_input())) {
         throttle_wait = false;
     }
 

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -561,7 +561,7 @@ void Plane::set_servos_controlled(void)
                control_mode == &mode_fbwa ||
                control_mode == &mode_autotune) {
         // a manual throttle mode
-        if (failsafe.throttle_counter) {
+        if (!rc().has_valid_input()) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0.0);
         } else if (g.throttle_passthru_stabilize) {
             // manual pass through of throttle while in FBWA or
@@ -615,7 +615,7 @@ void Plane::set_servos_flaps(void)
     int8_t manual_flap_percent = 0;
 
     // work out any manual flap input
-    if (channel_flap != nullptr && !failsafe.rc_failsafe && failsafe.throttle_counter == 0) {
+    if (channel_flap != nullptr && rc().has_valid_input()) {
         manual_flap_percent = channel_flap->percent_input();
     }
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5799,6 +5799,21 @@ class AutoTest(ABC):
             if comparator(m_value, value):
                 return m_value
 
+    def assert_servo_channel_value(self, channel, value, comparator=operator.eq):
+        """assert channel value (default condition is equality)"""
+        channel_field = "servo%u_raw" % channel
+        opstring = ("%s" % comparator)[-3:-1]
+        m = self.assert_receive_message('SERVO_OUTPUT_RAW', timeout=1)
+        m_value = getattr(m, channel_field, None)
+        if m_value is None:
+            raise ValueError("message (%s) has no field %s" %
+                             (str(m), channel_field))
+        self.progress("assert SERVO_OUTPUT_RAW.%s=%u %s %u" %
+                      (channel_field, m_value, opstring, value))
+        if comparator(m_value, value):
+            return m_value
+        raise NotAchievedException("Wrong value")
+
     def get_rc_channel_value(self, channel, timeout=2):
         """wait for channel to hit value"""
         channel_field = "chan%u_raw" % channel
@@ -5830,6 +5845,16 @@ class AutoTest(ABC):
                           (channel_field, m_value, value))
             if value == m_value:
                 return
+
+    def assert_rc_channel_value(self, channel, value):
+        channel_field = "chan%u_raw" % channel
+
+        m_value = self.get_rc_channel_value(channel, timeout=1)
+        self.progress("RC_CHANNELS.%s=%u want=%u" %
+                      (channel_field, m_value, value))
+        if value != m_value:
+            raise NotAchievedException("Expected %s to be %u got %u" %
+                                       (channel, value, m_value))
 
     def wait_location(self,
                       loc,


### PR DESCRIPTION
Also, use has_valid_input() in place of just the (parameter-controlled) throttle failsafe counter when passing throttle through in manual-throttle modes.


Use the `rc().has_valid_input()` for what it is good for (that's a virtual method which allows the RC_Channels library to know if the vehicle thinks the input is good.  Hopefully we can unify that behaviour across vehicles into the future, and this PR is a small stepping stone to that.

Most of the changes here are just taking the same in-line checks to do with in-failsafe and counter-is-zero and calling the method (which does exactly the same thing) instead.

However, the change in `set_servos_controlled` method needs more staring at.

If:
 -  your RC receiver is hit my a micro black hole in flight and is annihilated, you will stop getting pulses
 - you have throttle-failsafe disabled

Then:
 - the throttle counter won't increase
 - the code in set_servos_controlled will continue to use the RC input throttle level

Pretty sure the throttle failsafe counter (as enabled by the throttle failsafe parameter) should only be determining whether the RC input is good to use, not gating outputs as it is here.  There are additional ways we can detect that the RC is not good to use, and that's what the `has_valid_input()` method is supposed to be doing.

I'll need to put an autotest together for before/after on this PR.
