### PR TITLE
Copter: pass reason through in set_mode AP_Vehicle override

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -300,7 +300,7 @@ bool Copter::set_mode(const uint8_t new_mode, const ModeReason reason)
         return false;
     }
 #endif
-    return copter.set_mode(static_cast<Mode::Number>(new_mode), ModeReason::GCS_COMMAND);
+    return copter.set_mode(static_cast<Mode::Number>(new_mode), reason);
 }
 
 // update_flight_mode - calls the appropriate attitude controllers based on flight mode


### PR DESCRIPTION
Other vehicles seem to do this correctly.