### PR TITLE
SITL: read 12 flightaxis input channels

### DIFF
--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -169,7 +169,7 @@ protected:
     uint8_t num_motors = 1;
     float rpm[12];
     uint8_t rcin_chan_count = 0;
-    float rcin[8];
+    float rcin[12];
     float range = -1.0f;                 // rangefinder detection in m
 
     struct {

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -484,9 +484,9 @@ void FlightAxis::update(const struct sitl_input &input)
     rpm[1] = state.m_propRPM;
 
     /*
-      the interlink interface supports 8 input channels
+      the interlink interface supports 12 input channels
      */
-    rcin_chan_count = 8;
+    rcin_chan_count = 12;
     for (uint8_t i=0; i<rcin_chan_count; i++) {
         rcin[i] = state.rcin[i];
     }

--- a/libraries/SITL/SIM_FlightAxis.h
+++ b/libraries/SITL/SIM_FlightAxis.h
@@ -40,7 +40,7 @@ public:
     }
 
     struct state {
-        double rcin[8];
+        double rcin[12];
         double m_airspeed_MPS;
         double m_altitudeASL_MTR;
         double m_altitudeAGL_MTR;
@@ -103,6 +103,10 @@ public:
         { "item", state.rcin[5] },
         { "item", state.rcin[6] },
         { "item", state.rcin[7] },
+        { "item", state.rcin[8] },
+        { "item", state.rcin[9] },
+        { "item", state.rcin[10] },
+        { "item", state.rcin[11] },
         { "m-airspeed-MPS", state.m_airspeed_MPS },
         { "m-altitudeASL-MTR", state.m_altitudeASL_MTR },
         { "m-altitudeAGL-MTR", state.m_altitudeAGL_MTR },

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -56,7 +56,7 @@ struct sitl_fdm {
     uint8_t num_motors;
     float rpm[12];         // RPM of all motors
     uint8_t rcin_chan_count;
-    float  rcin[8];         // RC input 0..1
+    float  rcin[12];         // RC input 0..1
     double range;           // rangefinder value
     Vector3f bodyMagField;  // Truth XYZ magnetic field vector in body-frame. Includes motor interference. Units are milli-Gauss.
     Vector3f angAccel; // Angular acceleration in degrees/s/s about the XYZ body axes


### PR DESCRIPTION
flightaxis interface now supports 12 input channels (increased from 8)