### PR TITLE
Global: shorten the distinguished name

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1254,7 +1254,7 @@ bool AP_Arming::visodom_checks(bool display_failure) const
     if (visual_odom != nullptr) {
         char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
         if (!visual_odom->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-            check_failed(ARMING_CHECK_VISION, display_failure, "VisualOdom: %s", fail_msg);
+            check_failed(ARMING_CHECK_VISION, display_failure, "VisOdom: %s", fail_msg);
             return false;
         }
     }

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -148,7 +148,7 @@ bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, 
     ahrs_quat.angular_difference(att_corrected).to_axis_angle(angle_diff);
     const float yaw_trim_orig = _yaw_trim;
     _yaw_trim = angle_diff.z;
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "VisualOdom: yaw shifted %d to %d deg",
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "VisOdom: yaw shifted %d to %d deg",
                     (int)degrees(_yaw_trim - yaw_trim_orig),
                     (int)wrap_360(degrees(sens_yaw + _yaw_trim)));
 


### PR DESCRIPTION
I found the message split.
I shortened the distinguished names.
I was able to see that the message was no longer splitting.

After:
2020/07/26 23:09:12 : PreArm: VisO: roll/pitch diff 165.2 deg (>10)

Before:
2020/07/26 22:52:49 : PreArm: VisualOdom: roll/pitch diff 164.1 deg (>10
2020/07/26 22:52:19 : )