### PR TITLE
AP_AHRS: remove unused base-class airspeed_estimate method

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -179,26 +179,6 @@ Vector3f AP_AHRS::get_gyro_latest(void) const
     return AP::ins().get_gyro(primary_gyro) + get_gyro_drift();
 }
 
-// return airspeed estimate if available
-bool AP_AHRS::airspeed_estimate(float &airspeed_ret) const
-{
-    if (airspeed_sensor_enabled()) {
-        airspeed_ret = _airspeed->get_airspeed();
-        if (_wind_max > 0 && AP::gps().status() >= AP_GPS::GPS_OK_FIX_2D) {
-            // constrain the airspeed by the ground speed
-            // and AHRS_WIND_MAX
-            const float gnd_speed = AP::gps().ground_speed();
-            float true_airspeed = airspeed_ret * get_EAS2TAS();
-            true_airspeed = constrain_float(true_airspeed,
-                                            gnd_speed - _wind_max,
-                                            gnd_speed + _wind_max);
-            airspeed_ret = true_airspeed / get_EAS2TAS();
-        }
-        return true;
-    }
-    return false;
-}
-
 // set_trim
 void AP_AHRS::set_trim(const Vector3f &new_trim)
 {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -260,7 +260,7 @@ public:
 
     // return an airspeed estimate if available. return true
     // if we have an estimate
-    virtual bool airspeed_estimate(float &airspeed_ret) const WARN_IF_UNUSED;
+    virtual bool airspeed_estimate(float &airspeed_ret) const WARN_IF_UNUSED = 0;
 
     // return a true airspeed estimate (navigation airspeed) if
     // available. return true if we have an estimate


### PR DESCRIPTION
AP_AHRS_NavEKF is an AP_AHRS_DCM, and that implements the method.  We don't need the base class implementation - so make it pure-virtual.

This does point out the fact we don't limit the airspeed sensor data return value in `AP_AHRS_DCM` according to `WIND_MAX`, where the base class implementation did (but was never used).

Saves a few bytes:
```
This branch:
  bin/arducopter  1424796  1532  129764  1556092
master:
  bin/arducopter  1425048  1532  129760  1556340
```
