### PR TITLE
AP_GPS: redetection not necessary for UAVCAN GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -717,8 +717,8 @@ void AP_GPS::update_instance(uint8_t instance)
             state[instance].vdop = GPS_UNKNOWN_DOP;
             timing[instance].last_message_time_ms = tnow;
             timing[instance].delta_time_ms = GPS_TIMEOUT_MS;
-            // do not try to detect again if type is MAV
-            if (_type[instance] == GPS_TYPE_MAV) {
+            // do not try to detect again if type is MAV or UAVCAN
+            if (_type[instance] == GPS_TYPE_MAV || _type[instance] == GPS_TYPE_UAVCAN) {
                 state[instance].status = NO_FIX;
             } else {
                 // free the driver before we run the next detection, so we


### PR DESCRIPTION
Disconnected GPS leads to wrongly deleting the compass instance without removing the associated field in detected modules list in AP_GPS_UAVCAN. This is really bad as it can potentially lead to fault in case the GPS disappears.

Technically we don't need to delete the driver object and reinitialise, as there is nothing to re-initialise for UAVCAN GPS, it's all done by the UAVCAN module itself.