### PR TITLE
AP_Scripting: add rangefinder and proximiy bindings

### DIFF
--- a/libraries/AP_Scripting/examples/proximity_test.lua
+++ b/libraries/AP_Scripting/examples/proximity_test.lua
@@ -1,0 +1,27 @@
+-- This script checks Proximity
+
+function update()
+  sensor_count = proximity:num_sensors()
+  gcs:send_text(0, string.format("%d proximity sensors found.", sensor_count))
+
+  if sensor_count > 0 then
+    object_count = proximity:get_object_count()
+    gcs:send_text(0, string.format("%d objects found.", object_count))
+
+    closest_angle, closest_distance = proximity:get_closest_object()
+    if closest_angle ~= nil and closest_distance ~= nil then
+      gcs:send_text(0, "Closest object at angle "..closest_angle.." distance "..closest_distance)
+    end
+    
+    for i = 0, object_count do
+      angle, distance = proximity:get_object_angle_and_distance(i)
+      if angle ~= nil and distance ~= nil then
+        gcs:send_text(0, "Object"..i.." at angle "..angle.." distance "..distance)
+      end
+    end
+  end
+
+  return update, 2000 -- check again in 0.5Hz
+end
+
+return update(), 2000 -- first message may be displayed 1 seconds after start-up

--- a/libraries/AP_Scripting/examples/rangefinder_test.lua
+++ b/libraries/AP_Scripting/examples/rangefinder_test.lua
@@ -1,0 +1,31 @@
+-- This script checks RangeFinder
+
+local rotation_downward = 25
+local rotation_forward = 0
+
+function update()
+  local sensor_count = rangefinder:num_sensors()
+  gcs:send_text(0, string.format("%d rangefinder sensors found.", sensor_count))
+
+  for i = 0, rangefinder:num_sensors() do
+    if rangefinder:has_data_orient(rotation_downward) then
+      info(rotation_downward)
+    elseif rangefinder:has_data_orient(rotation_forward) then
+      info(rotation_forward)
+    end
+  end
+
+  return update, 1000 -- check again in 1Hz
+end
+
+function info(rotation)
+  local ground_clearance = rangefinder:ground_clearance_cm_orient(rotation)
+  local distance_min = rangefinder:min_distance_cm_orient(rotation)
+  local distance_max = rangefinder:max_distance_cm_orient(rotation)
+  local offset = rangefinder:get_pos_offset_orient(rotation)
+  local distance_cm = rangefinder:distance_cm_orient(rotation)
+
+  gcs:send_text(0, string.format("Ratation %d %.0f cm range %d - %d offset %.0f %.0f %.0f ground clearance %.0f", rotation, distance_cm, distance_min, distance_max, offset:x(), offset:y(), offset:z(), ground_clearance))
+end
+
+return update(), 1000 -- first message may be displayed 1 seconds after start-up

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -124,10 +124,26 @@ singleton AP_Notify alias notify
 singleton AP_Notify method play_tune void string
 singleton AP_Notify method handle_rgb void uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX
 
+include AP_Proximity/AP_Proximity.h
+
+singleton AP_Proximity alias proximity
+singleton AP_Proximity method num_sensors uint8_t
+singleton AP_Proximity method get_object_count uint8_t
+singleton AP_Proximity method get_closest_object boolean float'Null float'Null
+singleton AP_Proximity method get_object_angle_and_distance boolean uint8_t 0 UINT8_MAX float'Null float'Null
+
 include AP_RangeFinder/AP_RangeFinder.h
 
 singleton RangeFinder alias rangefinder
 singleton RangeFinder method num_sensors uint8_t
+singleton RangeFinder method has_orientation boolean Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
+singleton RangeFinder method distance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
+singleton RangeFinder method voltage_mv_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
+singleton RangeFinder method max_distance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
+singleton RangeFinder method min_distance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
+singleton RangeFinder method ground_clearance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
+singleton RangeFinder method has_data_orient boolean Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
+singleton RangeFinder method get_pos_offset_orient Vector3f Rotation'enum ROTATION_NONE ROTATION_ROLL_90_PITCH_315
 
 include AP_Terrain/AP_Terrain.h
 


### PR DESCRIPTION
I make a PR because I want to access RangeFinder and Proximity from Lua Script.
This PR has some overlap with https://github.com/ArduPilot/ardupilot/pull/13812.
According to https://github.com/ArduPilot/ardupilot/pull/13812, it is better not to include the Rotation enum. This PR may not be a good way. I would be happy if you could give me some advice.