### PR TITLE
Plane: log synthetic airspeed

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -272,6 +272,12 @@ public:
         return true;
     }
 
+    // return a synthetic airspeed estimate (one derived from sensors
+    // other than an actual airspeed sensor), if available. return
+    // true if we have a synthetic airspeed.  ret will not be modified
+    // on failure.
+    virtual bool synthetic_airspeed(float &ret) const WARN_IF_UNUSED = 0;
+
     // get apparent to true airspeed ratio
     float get_EAS2TAS(void) const;
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -94,6 +94,15 @@ public:
     // if we have an estimate
     bool airspeed_estimate(float &airspeed_ret) const override;
 
+    // return a synthetic airspeed estimate (one derived from sensors
+    // other than an actual airspeed sensor), if available. return
+    // true if we have a synthetic airspeed.  ret will not be modified
+    // on failure.
+    bool synthetic_airspeed(float &ret) const override WARN_IF_UNUSED {
+        ret = _last_airspeed;
+        return true;
+    }
+
     bool            use_compass() override;
 
     // return the quaternion defining the rotation from NED to XYZ (body) axes


### PR DESCRIPTION
This was discussed at the devcall this-morning.

I'm not actually convinced `CTUN` is the correct place to be doing this - it is probably valid and useful on other vehicles.

Short of having a `DCM` message, or adding a field to `NKF5` or something, this might do in the short term.
