### PR TITLE
Rover: add arming check for windvane if sailing enabled

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -82,12 +82,17 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
         return false;
     }
 
+    if (rover.g2.sailboat.sail_enabled() && !rover.g2.windvane.enabled()) {
+        check_failed(report, "Sailing enabled with no WindVane");
+        return false;
+    }
+
     return (AP_Arming::pre_arm_checks(report)
-            & rover.g2.motors.pre_arm_check(report)
-            & fence_checks(report)
-            & oa_check(report)
-            & parameter_checks(report)
-            & mode_checks(report));
+            && rover.g2.motors.pre_arm_check(report)
+            && fence_checks(report)
+            && oa_check(report)
+            && parameter_checks(report)
+            && mode_checks(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)


### PR DESCRIPTION
Sailing won't work with no windvane, we should be warning of this