### PR TITLE
AP_Scripting: Fix generator for nullable types with multiple return values

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1556,8 +1556,9 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
           arg_index++;
           arg = arg->next;
         }
+        fprintf(source, "        return %d;\n", return_count);
         fprintf(source, "    } else {\n");
-        fprintf(source, "        lua_pushnil(L);\n");
+        fprintf(source, "        return 0;\n");
         fprintf(source, "    }\n");
       } else {
         fprintf(source, "    lua_pushboolean(L, data);\n");
@@ -1601,7 +1602,9 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       break;
   }
 
-  fprintf(source, "    return %d;\n", return_count);
+  if ((method->return_type.type != TYPE_BOOLEAN) || ((method->flags & TYPE_FLAGS_NULLABLE) == 0)) {
+      fprintf(source, "    return %d;\n", return_count);
+  }
 
   fprintf(source, "}\n\n");
 }


### PR DESCRIPTION
This should fix https://github.com/ArduPilot/ardupilot/pull/14921#discussion_r461213374 What was happening was that we always returned the expected number of arguments if everything worked correctly, this was masked before because we had pushed the nil, but without that we were just reading values of the call stack. Instead of pushing nil we should just indicate the function had no return values and return early.

I haven't gotten to actually run a script with this yet, I've simply checked it runs, if @IamPete1 or @tajisoft have a chance to test this that would be great, otherwise I should get back to run a check on this soon. But it's definitely a bug in the generator, well spotted.