### PR TITLE
AC_Avoid: Added new OA type (Dijkstra + BendyRuler fusion)

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -21,7 +21,7 @@ public:
 
     // run background task to find best path and update avoidance_results
     // returns true and populates origin_new and destination_new if OA is required.  returns false if OA is not required
-    bool update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new);
+    bool update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new, bool proximity_only);
 
     enum class OABendyType {
         OA_BENDY_DISABLED   = 0,
@@ -33,20 +33,20 @@ public:
     OABendyType get_type() const;
 
     // search for path in XY direction
-    bool search_xy_path(const Location& current_loc, const Location& destination, float ground_course_deg, Location &destination_new, float lookahead_step_1_dist, float lookahead_step_2_dist, float bearing_to_dest, float distance_to_dest);
+    bool search_xy_path(const Location& current_loc, const Location& destination, float ground_course_deg, Location &destination_new, float lookahead_step_1_dist, float lookahead_step_2_dist, float bearing_to_dest, float distance_to_dest, bool proximity_only);
 
     // search for path in the Vertical directions
-    bool search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest); 
+    bool search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest, bool proximity_only); 
 
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
 
     // calculate minimum distance between a path and any obstacle
-    float calc_avoidance_margin(const Location &start, const Location &end) const;
+    float calc_avoidance_margin(const Location &start, const Location &end, bool proximity_only) const;
 
     // determine if BendyRuler should accept the new bearing or try and resist it. Returns true if bearing is not changed  
-    bool resist_bearing_change(const Location &destination, const Location &current_loc, bool active, float bearing_test, float lookahead_step1_dist, float margin, Location &prev_dest, float &prev_bearing, float &final_bearing, float &final_margin) const;    
+    bool resist_bearing_change(const Location &destination, const Location &current_loc, bool active, float bearing_test, float lookahead_step1_dist, float margin, Location &prev_dest, float &prev_bearing, float &final_bearing, float &final_margin, bool proximity_only) const;    
 
     // calculate minimum distance between a path and the circular fence (centered on home)
     // on success returns true and updates margin

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -22,6 +22,9 @@ public:
     // set fence margin (in meters) used when creating "safe positions" within the polygon fence
     void set_fence_margin(float margin) { _polyfence_margin = MAX(margin, 0.0f); }
 
+    // trigger Dijkstra's to recalculate shortest path based on current location 
+    void recalculate_path() { _shortest_path_ok = false; }
+
     // update return status enum
     enum AP_OADijkstra_State : uint8_t {
         DIJKSTRA_STATE_NOT_REQUIRED = 0,

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -51,7 +51,8 @@ public:
     enum OAPathPlanTypes {
         OA_PATHPLAN_DISABLED = 0,
         OA_PATHPLAN_BENDYRULER = 1,
-        OA_PATHPLAN_DIJKSTRA = 2
+        OA_PATHPLAN_DIJKSTRA = 2,
+        OA_PATHPLAN_DJIKSTRA_BENDYRULER = 3,
     };
 
     // enumeration for _OPTION parameter
@@ -104,6 +105,7 @@ private:
     AP_OADatabase _oadatabase;      // Database of dynamic objects to avoid
     uint32_t avoidance_latest_ms;   // last time Dijkstra's or BendyRuler algorithms ran
 
+    bool proximity_only = true;
     static AP_OAPathPlanner *_singleton;
 };
 


### PR DESCRIPTION
This PR creates a new OA Type which attempts to fuse Dijkstra and BendyRuler to be used together.
The basic idea is:
1. For WP Navigation through fence, Dijkstra's calculates the shortest path
2. BendyRuler is meanwhile set to only look for Proximity Sensor found obstacles.
3. The mission is run as if it was Normal Dijkstra's, UNTIL a physical obstacle is detected.
4. After that we switch to (Dijkstra's is turned off) BendyRuler type avoidance again (for both fence + obstacles)
5. After the BendyRuler turns off (I,.e path is clear towards destination), Dijkstras is triggered to calculate new path based on deviated current position and Dijkstra's becomes active again (BendyRuler goes back to only looking for physical obstacles).

Testing:
This has been tested on Morse + SITL with fence's and obstacle in between a guided mission
https://www.youtube.com/watch?v=s0z0b2U2fAk