### PR TITLE
AP_GPS: NMEA: only decode each message once

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -87,6 +87,9 @@ bool AP_GPS_NMEA::_decode(char c)
     case '\r':
     case '\n':
     case '*':
+        if (_sentence_done) {
+            return false;
+        }
         if (_term_offset < sizeof(_term)) {
             _term[_term_offset] = 0;
             valid_sentence = _term_complete();
@@ -103,6 +106,7 @@ bool AP_GPS_NMEA::_decode(char c)
         _is_checksum_term = false;
         _gps_data_good = false;
         _sentence_length = 1;
+        _sentence_done = false;
         return valid_sentence;
     }
 
@@ -227,6 +231,7 @@ bool AP_GPS_NMEA::_term_complete()
 {
     // handle the last term in a message
     if (_is_checksum_term) {
+        _sentence_done = true;
         uint8_t nibble_high = 0;
         uint8_t nibble_low  = 0;
         if (!hex_to_uint8(_term[0], nibble_high) || !hex_to_uint8(_term[1], nibble_low)) {

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -122,6 +122,7 @@ private:
     uint8_t _term_offset;                                       ///< character offset with the term being received
     uint16_t _sentence_length;
     bool _gps_data_good;                                        ///< set when the sentence indicates data is good
+    bool _sentence_done;                                        ///< set when a sentence has been fully decoded
 
     // The result of parsing terms within a message is stored temporarily until
     // the message is completely processed and the checksum validated.


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/14867 for NMEA GPS, tested with SITL NEMA GPS.

I do notice we have a special function for spotting duplicate messages, it is possible that this  fix removes the need for that but it could also be that there are some GPS's out there that do send duplicate messages.

https://github.com/ArduPilot/ardupilot/blob/89217a3804391ef909707fab6470e6097270d021/libraries/AP_GPS/AP_GPS_NMEA.cpp#L194