### PR TITLE
Rover: arming revert to single &

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -88,11 +88,11 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
     }
 
     return (AP_Arming::pre_arm_checks(report)
-            && rover.g2.motors.pre_arm_check(report)
-            && fence_checks(report)
-            && oa_check(report)
-            && parameter_checks(report)
-            && mode_checks(report));
+            & rover.g2.motors.pre_arm_check(report)
+            & fence_checks(report)
+            & oa_check(report)
+            & parameter_checks(report)
+            & mode_checks(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)


### PR DESCRIPTION
Using a single & here means that all checks are run even if the first fails. && would run only the first check and return if it fails.

Follow up to incorrect change in https://github.com/ArduPilot/ardupilot/pull/14929#discussion_r461958466

