### PR TITLE
New quadplane landing approach system

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -109,9 +109,19 @@ void Plane::stabilize_roll(float speed_scaler)
     if (control_mode == &mode_stabilize && channel_roll->get_control_in() != 0) {
         disable_integrator = true;
     }
-    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, rollController.get_servo_out(nav_roll_cd - ahrs.roll_sensor, 
-                                                                                         speed_scaler, 
-                                                                                         disable_integrator));
+    int32_t roll_out;
+    if (!quadplane.use_fw_attitude_controllers()) {
+        // use the VTOL rate for control, to ensure consistency
+        const auto &pid_info = quadplane.attitude_control->get_rate_roll_pid().get_pid_info();
+        roll_out = rollController.get_rate_out(degrees(pid_info.target), speed_scaler);
+        /* when slaving fixed wing control to VTOL control we need to decay the integrator to prevent
+           opposing integrators balancing between the two controllers
+        */
+        rollController.decay_I();
+    } else {
+        roll_out = rollController.get_servo_out(nav_roll_cd - ahrs.roll_sensor, speed_scaler, disable_integrator);
+    }
+    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, roll_out);
 }
 
 /*
@@ -134,14 +144,28 @@ void Plane::stabilize_pitch(float speed_scaler)
         disable_integrator = true;
     }
 
-   // if LANDING_FLARE RCx_OPTION switch is set and in FW mode, manual throttle,throttle idle then set pitch to LAND_PITCH_CD if flight option FORCE_FLARE_ATTITUDE is set
-    if (!quadplane.in_transition() && !control_mode->is_vtol_mode() && channel_throttle->in_trim_dz() && !control_mode->does_auto_throttle() && flare_mode == FlareMode::ENABLED_PITCH_TARGET) {
-       demanded_pitch = landing.get_pitch_cd();
-   }
+    int32_t pitch_out;
+    if (!quadplane.use_fw_attitude_controllers()) {
+        // use the VTOL rate for control, to ensure consistency
+        const auto &pid_info = quadplane.attitude_control->get_rate_pitch_pid().get_pid_info();
+        pitch_out = pitchController.get_rate_out(degrees(pid_info.target), speed_scaler);
+        /* when slaving fixed wing control to VTOL control we need to decay the integrator to prevent
+           opposing integrators balancing between the two controllers
+        */
+        pitchController.decay_I();
+    } else {
+        // if LANDING_FLARE RCx_OPTION switch is set and in FW mode, manual throttle,throttle idle then set pitch to LAND_PITCH_CD if flight option FORCE_FLARE_ATTITUDE is set
+        if (!quadplane.in_transition() &&
+            !control_mode->is_vtol_mode() &&
+            channel_throttle->in_trim_dz() &&
+            !control_mode->does_auto_throttle() &&
+            flare_mode == FlareMode::ENABLED_PITCH_TARGET) {
+            demanded_pitch = landing.get_pitch_cd();
+        }
 
-    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, pitchController.get_servo_out(demanded_pitch - ahrs.pitch_sensor, 
-                                                                                           speed_scaler, 
-                                                                                           disable_integrator));
+        pitch_out = pitchController.get_servo_out(demanded_pitch - ahrs.pitch_sensor, speed_scaler, disable_integrator);
+    }
+    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, pitch_out);
 }
 
 /*

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -314,7 +314,6 @@ const struct LogStructure Plane::log_structure[] = {
 
 // @LoggerMessage: NTUN
 // @Description: Navigation Tuning information - e.g. vehicle destination
-// @URL: http://ardupilot.org/rover/docs/navigation.html
 // @Field: TimeUS: Time since system startup
 // @Field: Dist: distance to the current navigation waypoint
 // @Field: TBrg: bearing to the current navigation waypoint

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -814,7 +814,7 @@ private:
     void update_load_factor(void);
     void adjust_altitude_target();
     void setup_glide_slope(void);
-    int32_t get_RTL_altitude() const;
+    int32_t get_RTL_altitude_cm() const;
     float relative_ground_altitude(bool use_rangefinder_if_available);
     void set_target_altitude_current(void);
     void set_target_altitude_current_adjusted(void);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -52,7 +52,9 @@ void Plane::adjust_altitude_target()
         set_target_altitude_location(temp);
     } else 
 #endif // OFFBOARD_GUIDED == ENABLED
-      if (landing.is_flaring()) {
+      if (control_mode->update_target_altitude()) {
+          // handled in mode specific code
+    } else if (landing.is_flaring()) {
         // during a landing flare, use TECS_LAND_SINK as a target sink
         // rate, and ignores the target altitude
         set_target_altitude_location(next_WP_loc);
@@ -135,9 +137,9 @@ void Plane::setup_glide_slope(void)
 }
 
 /*
-  return RTL altitude as AMSL altitude
+  return RTL altitude as AMSL cm
  */
-int32_t Plane::get_RTL_altitude() const
+int32_t Plane::get_RTL_altitude_cm() const
 {
     if (g.RTL_altitude_cm < 0) {
         return current_loc.alt;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -302,12 +302,12 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
 //  Nav (Must) commands
 /********************************************************************************/
 
-void Plane::do_RTL(int32_t rtl_altitude)
+void Plane::do_RTL(int32_t rtl_altitude_AMSL_cm)
 {
     auto_state.next_wp_crosstrack = false;
     auto_state.crosstrack = false;
     prev_WP_loc = current_loc;
-    next_WP_loc = rally.calc_best_rally_or_home_location(current_loc, rtl_altitude);
+    next_WP_loc = rally.calc_best_rally_or_home_location(current_loc, rtl_altitude_AMSL_cm);
     setup_terrain_target_alt(next_WP_loc);
     set_target_altitude_location(next_WP_loc);
 

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -71,7 +71,7 @@ void Plane::fence_check()
             g.auto_trim.set(saved_auto_trim);
 
             if (fence.get_return_rally() != 0 || fence_act == AC_FENCE_ACTION_RTL_AND_LAND) {
-                guided_WP_loc = rally.calc_best_rally_or_home_location(current_loc, get_RTL_altitude());
+                guided_WP_loc = rally.calc_best_rally_or_home_location(current_loc, get_RTL_altitude_cm());
             } else {
                 //return to fence return point, not a rally point
                 guided_WP_loc = {};

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -524,6 +524,8 @@ public:
 
     bool allows_arming() const override { return false; }
 
+    bool does_auto_throttle() const override { return true; }
+
 protected:
 
     bool _enter() override;

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -101,6 +101,9 @@ public:
     // whether control input is ignored with STICK_MIXING=0
     virtual bool does_auto_throttle() const { return false; }
 
+    // method for mode specific target altitude profiles
+    virtual bool update_target_altitude() { return false; }
+    
 protected:
 
     // subclasses override this to perform checks before entering the mode
@@ -525,6 +528,8 @@ public:
     bool allows_arming() const override { return false; }
 
     bool does_auto_throttle() const override { return true; }
+
+    bool update_target_altitude() override;
 
 protected:
 

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -9,6 +9,14 @@ bool ModeGuided::_enter()
       location. This matches the behaviour of the copter code
     */
     plane.guided_WP_loc = plane.current_loc;
+
+    if (plane.quadplane.guided_mode_enabled()) {
+        /*
+          if using Q_GUIDED_MODE then project forward by the stopping distance
+        */
+        plane.guided_WP_loc.offset_bearing(degrees(plane.ahrs.groundspeed_vector().angle()),
+                                           plane.quadplane.stopping_distance());
+    }
     plane.set_guided_WP();
     return true;
 }

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -11,3 +11,35 @@ void ModeQRTL::update()
     plane.mode_qstabilize.update();
 }
 
+/*
+  update target altitude for QRTL profile
+ */
+bool ModeQRTL::update_target_altitude()
+{
+    /*
+      update height target in approach
+     */
+    if (plane.quadplane.poscontrol.get_state() != QuadPlane::QPOS_APPROACH) {
+        return false;
+    }
+
+    /*
+      initially approach at RTL_ALT_CM, then drop down to QRTL_ALT based on maximum sink rate from TECS,
+      giving time to lose speed before we transition
+     */
+    const float radius = MAX(fabsf(plane.aparm.loiter_radius), fabsf(plane.g.rtl_radius));
+    const float rtl_alt_delta = MAX(0, plane.g.RTL_altitude_cm*0.01 - plane.quadplane.qrtl_alt);
+    const float sink_time = rtl_alt_delta / MAX(0.6*plane.SpdHgt_Controller->get_max_sinkrate(), 1);
+    const float sink_dist = plane.aparm.airspeed_cruise_cm * 0.01 * sink_time;
+    const float dist = plane.auto_state.wp_distance;
+    const float rad_min = 2*radius;
+    const float rad_max = 20*radius;
+    float alt = linear_interpolate(0, rtl_alt_delta,
+                                   dist,
+                                   rad_min, MAX(rad_min, MIN(rad_max, rad_min+sink_dist)));
+    Location loc = plane.next_WP_loc;
+    loc.alt += alt*100;
+    plane.set_target_altitude_location(loc);
+    return true;
+}
+

--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -4,7 +4,7 @@
 bool ModeRTL::_enter()
 {
     plane.prev_WP_loc = plane.current_loc;
-    plane.do_RTL(plane.get_RTL_altitude());
+    plane.do_RTL(plane.get_RTL_altitude_cm());
     plane.rtl.done_climb = false;
     plane.vtol_approach_s.approach_stage = Plane::Landing_ApproachStage::RTL;
 

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -199,6 +199,8 @@ void Plane::calc_airspeed_errors()
                          // fallover to normal airspeed
                          target_airspeed_cm = aparm.airspeed_cruise_cm;
                      }
+        } else if (quadplane.in_vtol_land_approach()) {
+            target_airspeed_cm = quadplane.get_land_airspeed() * 100;
         } else {
             // normal AUTO mode and new_airspeed variable was set by DO_CHANGE_SPEED command while in AUTO mode
             if (new_airspeed_cm > 0) {
@@ -208,6 +210,8 @@ void Plane::calc_airspeed_errors()
                 target_airspeed_cm = aparm.airspeed_cruise_cm;
             }
         }
+    } else if (control_mode == &mode_qrtl && quadplane.in_vtol_land_approach()) {
+        target_airspeed_cm = quadplane.get_land_airspeed() * 100;
     } else {
         // Normal airspeed target for all other cases
         target_airspeed_cm = aparm.airspeed_cruise_cm;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2604,7 +2604,7 @@ void QuadPlane::vtol_position_controller(void)
         const float aspeed_threshold = MAX(plane.aparm.airspeed_min, assist_speed);
 
         // run fixed wing navigation
-        plane.nav_controller->update_waypoint(plane.prev_WP_loc, loc);
+        plane.nav_controller->update_waypoint(plane.current_loc, loc);
 
         // use TECS for throttle
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.SpdHgt_Controller->get_throttle_demand());
@@ -2705,7 +2705,7 @@ void QuadPlane::vtol_position_controller(void)
         }
 
         // run fixed wing navigation
-        plane.nav_controller->update_waypoint(plane.prev_WP_loc, loc);
+        plane.nav_controller->update_waypoint(plane.current_loc, loc);
 
         /*
           calculate target velocity, not dropping it below 2m/s
@@ -2793,7 +2793,7 @@ void QuadPlane::vtol_position_controller(void)
         }
 
         // also run fixed wing navigation
-        plane.nav_controller->update_waypoint(plane.prev_WP_loc, loc);
+        plane.nav_controller->update_waypoint(plane.current_loc, loc);
 
         update_land_positioning();
 
@@ -3123,7 +3123,7 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     pos_control->init_z_controller();
 
     // also update nav_controller for status output
-    plane.nav_controller->update_waypoint(plane.prev_WP_loc, plane.next_WP_loc);
+    plane.nav_controller->update_waypoint(plane.current_loc, plane.next_WP_loc);
 
     // calculate the time required to complete a takeoff
     // this may be conservative and accept extra time due to clamping
@@ -3178,7 +3178,7 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
     plane.crash_state.is_crashed = false;
     
     // also update nav_controller for status output
-    plane.nav_controller->update_waypoint(plane.prev_WP_loc, plane.next_WP_loc);
+    plane.nav_controller->update_waypoint(plane.current_loc, plane.next_WP_loc);
 
     poscontrol_init_approach();
     return true;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3089,6 +3089,13 @@ void QuadPlane::init_qrtl(void)
     pos_control->set_accel_desired_xy_cmss(Vector2f());
     pos_control->init_xy_controller();
     poscontrol_init_approach();
+    float dist = plane.next_WP_loc.get_distance(plane.current_loc);
+    const float radius = MAX(fabsf(plane.aparm.loiter_radius), fabsf(plane.g.rtl_radius));
+    if (dist < 1.5*radius &&
+        motors->get_desired_spool_state() == AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED) {
+        // we're close to destination and already running VTOL motors, don't transition
+        poscontrol.set_state(QPOS_POSITION1);
+    }
     int32_t from_alt;
     int32_t to_alt;
     if (plane.current_loc.get_alt_cm(Location::AltFrame::ABSOLUTE,from_alt) && plane.next_WP_loc.get_alt_cm(Location::AltFrame::ABSOLUTE,to_alt)) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2631,14 +2631,11 @@ void QuadPlane::vtol_position_controller(void)
           to prevent inability to progress to position if moving from a loiter
           to landing
          */
-        float minlimit = linear_interpolate(-aparm.angle_max, -300,
-                                            speed_towards_target, 
-                                            wp_nav->get_default_speed_xy() * 0.01, 
-                                            wp_nav->get_default_speed_xy() * 0.015);
-        float pitch_limit_cd = linear_interpolate(minlimit, plane.aparm.pitch_limit_min_cd,
-                                                  plane.auto_state.wp_proportion, 0, 1);
-        if (plane.nav_pitch_cd < pitch_limit_cd) {
-            plane.nav_pitch_cd = pitch_limit_cd;
+        float minlimit_cd = linear_interpolate(-300, MAX(-aparm.angle_max,plane.aparm.pitch_limit_min_cd),
+                                               poscontrol.time_since_state_start_ms(),
+                                               0, 5000);
+        if (plane.nav_pitch_cd < minlimit_cd) {
+            plane.nav_pitch_cd = minlimit_cd;
             // tell the pos controller we have limited the pitch to
             // stop integrator buildup
             pos_control->set_externally_limited_xy();
@@ -3746,7 +3743,6 @@ uint16_t QuadPlane::get_pilot_velocity_z_max_dn() const
  */
 bool QuadPlane::use_fw_attitude_controllers(void) const
 {
-#if 1
     if (available() &&
         motors->armed() &&
         motors->get_desired_spool_state() >= AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED &&
@@ -3756,7 +3752,6 @@ bool QuadPlane::use_fw_attitude_controllers(void) const
         // multicopter rates
         return false;
     }
-#endif
     return true;
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3690,7 +3690,13 @@ bool QuadPlane::do_user_takeoff(float takeoff_altitude)
 // return true if the wp_nav controller is being updated
 bool QuadPlane::using_wp_nav(void) const
 {
-    return plane.control_mode == &plane.mode_qloiter || plane.control_mode == &plane.mode_qland || plane.control_mode == &plane.mode_qrtl;
+    if (plane.control_mode == &plane.mode_qloiter || plane.control_mode == &plane.mode_qland) {
+        return true;
+    }
+    if (plane.control_mode == &plane.mode_qrtl && poscontrol.get_state() >= QPOS_POSITION2) {
+        return true;
+    }
+    return false;
 }
 
 /*

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -599,6 +599,7 @@ static const struct AP_Param::defaults_table_struct defaults_table_tailsitter[] 
     { "MIXING_GAIN",      1.0 },
     { "RUDD_DT_GAIN",      10 },
     { "Q_TRANSITION_MS",   2000 },
+    { "Q_TRANS_DECEL",    6 },
 };
 
 /*

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3741,4 +3741,23 @@ uint16_t QuadPlane::get_pilot_velocity_z_max_dn() const
     return abs(pilot_velocity_z_max_dn);
 }
 
+/*
+  should we use the fixed wing attitude controllers for roll/pitch control
+ */
+bool QuadPlane::use_fw_attitude_controllers(void) const
+{
+#if 1
+    if (available() &&
+        motors->armed() &&
+        motors->get_desired_spool_state() >= AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED &&
+        in_vtol_mode() &&
+        !is_tailsitter()) {
+        // we want the desired rates for fixed wing slaved to the
+        // multicopter rates
+        return false;
+    }
+#endif
+    return true;
+}
+
 QuadPlane *QuadPlane::_singleton = nullptr;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -467,15 +467,12 @@ private:
         QPOS_LAND_FINAL,
         QPOS_LAND_COMPLETE
     };
-    struct {
+    class PosControlState {
     public:
         enum position_control_state get_state() const {
             return state;
         }
-        void set_state(enum position_control_state s) {
-            state = s;
-            last_state_change_ms = AP_HAL::millis();
-        }
+        void set_state(enum position_control_state s);
         uint32_t time_since_state_start_ms() const {
             return AP_HAL::millis() - last_state_change_ms;
         }
@@ -487,9 +484,8 @@ private:
         bool slow_descent:1;
         bool pilot_correction_active;
         bool pilot_correction_done;
-        float start_closing_vel;
-        float start_dist;
         uint32_t thrust_loss_start_ms;
+        uint32_t last_log_ms;
     private:
         uint32_t last_state_change_ms;
         enum position_control_state state;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -466,7 +466,17 @@ private:
         QPOS_LAND_COMPLETE
     };
     struct {
-        enum position_control_state state;
+    public:
+        enum position_control_state get_state() const {
+            return state;
+        }
+        void set_state(enum position_control_state s) {
+            state = s;
+            last_state_change_ms = AP_HAL::millis();
+        }
+        uint32_t time_since_state_start_ms() const {
+            return AP_HAL::millis() - last_state_change_ms;
+        }
         float speed_scale;
         Vector2f target_velocity;
         float max_speed;
@@ -475,6 +485,9 @@ private:
         bool slow_descent:1;
         bool pilot_correction_active;
         bool pilot_correction_done;
+    private:
+        uint32_t last_state_change_ms;
+        enum position_control_state state;
     } poscontrol;
 
     struct {

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -459,6 +459,8 @@ private:
     uint32_t last_loiter_ms;
 
     enum position_control_state {
+        QPOS_APPROACH,
+        QPOS_AIRBRAKE,
         QPOS_POSITION1,
         QPOS_POSITION2,
         QPOS_LAND_DESCEND,
@@ -485,6 +487,8 @@ private:
         bool slow_descent:1;
         bool pilot_correction_active;
         bool pilot_correction_done;
+        float start_closing_vel;
+        float start_dist;
     private:
         uint32_t last_state_change_ms;
         enum position_control_state state;
@@ -636,6 +640,7 @@ private:
         OPTION_DISABLE_GROUND_EFFECT_COMP=(1<<13),
         OPTION_INGORE_FW_ANGLE_LIMITS_IN_Q_MODES=(1<<14),
         OPTION_THR_LANDING_CONTROL=(1<<15),
+        OPTION_DISABLE_APPROACH=(1<<16),
     };
 
     AP_Float takeoff_failure_scalar;
@@ -692,6 +697,32 @@ private:
       return true if we should use the fixed wing attitude control loop
      */
     bool use_fw_attitude_controllers(void) const;
+
+    /*
+      get the airspeed for landing approach
+     */
+    float get_land_airspeed(void);
+
+    /*
+      setup for landing approach
+     */
+    void poscontrol_init_approach(void);
+
+    /*
+      calculate our closing velocity vector on the landing
+      point. Takes account of the landing point having a velocity
+     */
+    Vector2f landing_closing_velocity();
+
+    /*
+      calculate our desired closing velocity vector on the landing point.
+    */
+    Vector2f landing_desired_closing_velocity();
+
+    /*
+      change spool state, providing easy hook for catching changes in debug
+     */
+    void set_desired_spool_state(AP_Motors::DesiredSpoolState state);
 
 public:
     void motor_test_output();

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -675,6 +675,11 @@ private:
     // Q assist state, can be enabled, disabled or force. Default to enabled
     Q_ASSIST_STATE_ENUM q_assist_state = Q_ASSIST_STATE_ENUM::Q_ASSIST_ENABLED;
 
+    /*
+      return true if we should use the fixed wing attitude control loop
+     */
+    bool use_fw_attitude_controllers(void) const;
+
 public:
     void motor_test_output();
     MAV_RESULT mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type,

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -489,6 +489,7 @@ private:
         bool pilot_correction_done;
         float start_closing_vel;
         float start_dist;
+        uint32_t thrust_loss_start_ms;
     private:
         uint32_t last_state_change_ms;
         enum position_control_state state;

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -259,20 +259,20 @@ void Location::offset(float ofs_north, float ofs_east)
  * positions, so it keeps the accuracy even when dealing with small
  * distances and floating point numbers
  */
-void Location::offset_bearing(float bearing, float distance)
+void Location::offset_bearing(float bearing_deg, float distance)
 {
-    const float ofs_north = cosf(radians(bearing)) * distance;
-    const float ofs_east  = sinf(radians(bearing)) * distance;
+    const float ofs_north = cosf(radians(bearing_deg)) * distance;
+    const float ofs_east  = sinf(radians(bearing_deg)) * distance;
     offset(ofs_north, ofs_east);
 }
 
 // extrapolate latitude/longitude given bearing, pitch and distance
-void Location::offset_bearing_and_pitch(float bearing, float pitch, float distance)
+void Location::offset_bearing_and_pitch(float bearing_deg, float pitch_deg, float distance)
 {
-    const float ofs_north =  cosf(radians(pitch)) * cosf(radians(bearing)) * distance;
-    const float ofs_east  =  cosf(radians(pitch)) * sinf(radians(bearing)) * distance;
+    const float ofs_north =  cosf(radians(pitch_deg)) * cosf(radians(bearing_deg)) * distance;
+    const float ofs_east  =  cosf(radians(pitch_deg)) * sinf(radians(bearing_deg)) * distance;
     offset(ofs_north, ofs_east);
-    const int32_t dalt =  sinf(radians(pitch)) * distance *100.0f;
+    const int32_t dalt =  sinf(radians(pitch_deg)) * distance *100.0f;
     alt += dalt; 
 }
 

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -72,10 +72,10 @@ public:
     void offset(float ofs_north, float ofs_east);
 
     // extrapolate latitude/longitude given bearing and distance
-    void offset_bearing(float bearing, float distance);
+    void offset_bearing(float bearing_deg, float distance);
     
     // extrapolate latitude/longitude given bearing, pitch and distance
-    void offset_bearing_and_pitch(float bearing, float pitch, float distance);
+    void offset_bearing_and_pitch(float bearing_deg, float pitch_deg, float distance);
 
     // longitude_scale - returns the scaler to compensate for
     // shrinking longitude as you move north or south from the equator

--- a/libraries/AP_HAL_ChibiOS/hwdef/VRBrain-v51/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VRBrain-v51/hwdef.dat
@@ -169,3 +169,7 @@ define STM32_PWM_USE_ADVANCED TRUE
 # 12 PWM available by default
 define BOARD_PWM_COUNT_DEFAULT 14
 
+# save some flash
+define GENERATOR_ENABLED 0
+define AC_OAPATHPLANNER_ENABLED 0
+define PRECISION_LANDING 0

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -83,12 +83,27 @@ template float safe_sqrt<float>(const float v);
 template float safe_sqrt<double>(const double v);
 
 /*
+  replacement for std::swap() needed for STM32
+ */
+static void swap_float(float &f1, float &f2)
+{
+    float tmp = f1;
+    f1 = f2;
+    f2 = tmp;
+}
+
+/*
  * linear interpolation based on a variable in a range
  */
 float linear_interpolate(float low_output, float high_output,
                          float var_value,
                          float var_low, float var_high)
 {
+    if (var_low > var_high) {
+        // support either polarity
+        swap_float(var_low, var_high);
+        swap_float(low_output, high_output);
+    }
     if (var_value <= var_low) {
         return low_output;
     }

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -248,6 +248,9 @@ inline constexpr uint32_t usec_to_hz(uint32_t usec)
 
 /*
   linear interpolation based on a variable in a range
+  return value will be in the range [var_low,var_high]
+
+  Either polarity is supported, so var_low can be higher than var_high
  */
 float linear_interpolate(float low_output, float high_output,
                          float var_value,

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -50,6 +50,9 @@ public:
 	// return maximum climb rate
 	virtual float get_max_climbrate(void) const = 0;
 
+    // return maximum sink rate (+ve number)
+    virtual float get_max_sinkrate(void) const = 0;
+
     // added to let SoaringController reset pitch integrator to zero
     virtual void reset_pitch_I(void) = 0;
     

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -81,6 +81,11 @@ public:
         return _maxClimbRate;
     }
 
+    // return maximum sink rate (+ve number down)
+    float get_max_sinkrate(void) const override {
+        return _maxSinkRate;
+    }
+    
     // added to let SoaringContoller reset pitch integrator to zero
     void reset_pitch_I(void) override {
         _integSEB_state = 0.0f;


### PR DESCRIPTION
This implements a new quadplane landing approach system.
Key features:
 - adds a new QPOS_APPROACH stage for a NAV_VTOL_LAND waypoint, which is done as fixed wing. Similar to what RTL/QRTL does it will automatically switch to VTOL once the stopping distance calculated from Q_TRANS_DECEL is reached
 - adds a new QPOS_AIRBRAKE stage after QPOS_APPROACH which uses the VTOL motors to create drag to slow the aircraft in preparation for QPOS_POSITION1 stage (airbrake stage is skipped for tailsitters)
 - new velocity profile for QPOS_POSITION1 based on work done by @lukedepmsey in #14778 
 - new path to switching from QPOS_POSITION1 to QPOS_POSITION2 based on low velocity, to cope with the possibility that the fwd motor is not working
 - allow start of descent when distance remaining is below 2*height. This makes for a much smoother landing, and saves us spending a long time on the final piece of the positiioning (wasting battery)

In the RF9 AltiTransition the overall battery savings on landing is around 30%. It also means that users don't need to carefully setup the transition waypoint for a VTOL_LAND in AUTO. They can setup the mission to start the land way back and it will fly as fixed wing until it needs to transition.

The new stages apply both to VTOL_LAND and to QRTL, which means you can now do QRTL from a long way away and it will fly as fixed wing until the right transition point. Previously you needed to use Q_RTL_MODE=1 to achieve that.

UPDATE: This PR is now rebased on Leonards pending PR #17345