### PR TITLE
AP_Scripting: add default case to fix uninitialised use situation

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -174,6 +174,7 @@ void trace(const int trace, const char *message, ...) {
   }
 }
 
+void error(const int code, const char *message, ...) __attribute__ ((noreturn));
 void error(const int code, const char *message, ...) {
   char * fmt = malloc(strlen(message)+1024);
   if (fmt == NULL) {


### PR DESCRIPTION
This is a curious issue, as it generated build error when I built it on my machine using following compiler:

arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors 6-2017-q2-update) 6.3.1 20170620 (release) [ARM/embedded-6-branch revision 249437]
