### PR TITLE
Plane: Ensure that only one form of throttle nudging is active at once

### DIFF
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -207,6 +207,8 @@ void Plane::read_radio()
 
     control_failsafe();
 
+    airspeed_nudge_cm = 0;
+    throttle_nudge = 0;
     if (g.throttle_nudge && channel_throttle->get_control_in() > 50 && geofence_stickmixing()) {
         float nudge = (channel_throttle->get_control_in() - 50) * 0.02f;
         if (ahrs.airspeed_sensor_enabled()) {
@@ -214,9 +216,6 @@ void Plane::read_radio()
         } else {
             throttle_nudge = (aparm.throttle_max - aparm.throttle_cruise) * nudge;
         }
-    } else {
-        airspeed_nudge_cm = 0;
-        throttle_nudge = 0;
     }
 
     rudder_arm_disarm_check();


### PR DESCRIPTION
I noticed this while looking into throttle nudging for someone else, if nudging is enabled and we change state on `ahrs.airspeed_sensor_enabled()` then the old nudge value will be left locked in, which leads to having 2 levels of stick nudging applied at once. This simply ensures that we only have one form of mixing enabled at once. The PR as presented is the smaller build version, although you get a duplicate assignment with it, that should be cheaper then the extra branch you otherwise take to 0 these out.

Alternate version that is clear, but probably a bit slower (as well as a larger build):
```diff
diff --git a/ArduPlane/radio.cpp b/ArduPlane/radio.cpp
index 7e86a7b437..e9b4c4ec21 100644
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -211,7 +211,9 @@ void Plane::read_radio()
         float nudge = (channel_throttle->get_control_in() - 50) * 0.02f;
         if (ahrs.airspeed_sensor_enabled()) {
             airspeed_nudge_cm = (aparm.airspeed_max * 100 - aparm.airspeed_cruise_cm) * nudge;
+            throttle_nudge = 0;
         } else {
+            airspeed_nudge_cm = 0;
             throttle_nudge = (aparm.throttle_max - aparm.throttle_cruise) * nudge;
         }
     } else {
```