### PR TITLE
Copter: Mission range notification

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -760,6 +760,9 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             if (copter.mode_auto.mission.state() != AP_Mission::MISSION_RUNNING) {
                 copter.mode_auto.mission.start_or_resume();
             }
+            if (!is_zero(packet.param1) || !is_zero(packet.param2)) {
+                gcs().send_text(MAV_SEVERITY_NOTICE, "Ignore the mission execution range (%d to %d)", int32_t(packet.param1), int32_t(packet.param2));
+            }
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_FAILED;


### PR DESCRIPTION
I use the MAV_CMD_MISSION_START command with parameters 1 and 2 to specify the range of the automatic flight plan.
ArduPilot cannot specify a range.
I've seen planners create flight plans with the standard MAVLINK protocol.
I think it would be better to notify human error.

after:
![Screenshot from 2020-07-31 06-34-37](https://user-images.githubusercontent.com/646194/88977949-c14d9c00-d2f9-11ea-9494-eb8bb5757c8a.png)