### PR TITLE
Copter: enable CONDITION_YAW turn rate in auto

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -77,7 +77,6 @@ void Mode::AutoYaw::set_mode(autopilot_yaw_mode yaw_mode)
         break;
 
     case AUTO_YAW_FIXED:
-    case AUTO_YAW_FIXED_WITH_RATE:
         // keep heading pointing in the direction held in fixed_yaw
         // caller should set the fixed_yaw
         break;
@@ -128,8 +127,6 @@ void Mode::AutoYaw::set_fixed_yaw(float angle_deg, float turn_rate_dps, int8_t d
     }
 
     set_rate(_fixed_yaw_slewrate);
-    // set yaw mode
-    set_mode(AUTO_YAW_FIXED_WITH_RATE);
 
     // TO-DO: restore support for clockwise and counter clockwise rotation held in cmd.content.yaw.direction.  1 = clockwise, -1 = counterclockwise
 }
@@ -190,7 +187,6 @@ float Mode::AutoYaw::yaw()
         return roi_yaw();
 
     case AUTO_YAW_FIXED:
-    case AUTO_YAW_FIXED_WITH_RATE:
        // keep heading pointing in the direction held in fixed_yaw
         // with no pilot input allowed
         return _fixed_yaw;

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -20,7 +20,6 @@ enum autopilot_yaw_mode {
     AUTO_YAW_RESETTOARMEDYAW =  5,  // point towards heading at time motors were armed
     AUTO_YAW_RATE =             6,  // turn at a specified rate (held in auto_yaw_rate)
     AUTO_YAW_CIRCLE =           7,  // use AC_Circle's provided yaw (used during Loiter-Turns commands)
-    AUTO_YAW_FIXED_WITH_RATE =  8,
 };
 
 // Frame types

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -20,6 +20,7 @@ enum autopilot_yaw_mode {
     AUTO_YAW_RESETTOARMEDYAW =  5,  // point towards heading at time motors were armed
     AUTO_YAW_RATE =             6,  // turn at a specified rate (held in auto_yaw_rate)
     AUTO_YAW_CIRCLE =           7,  // use AC_Circle's provided yaw (used during Loiter-Turns commands)
+    AUTO_YAW_FIXED_WITH_RATE =  8,
 };
 
 // Frame types

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -202,6 +202,8 @@ public:
                            float turn_rate_dps,
                            int8_t direction,
                            bool relative_angle);
+        
+        void check_reached_desired_yaw_angle();
 
     private:
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -751,6 +751,11 @@ void ModeAuto::wp_run()
     if (auto_yaw.mode() == AUTO_YAW_HOLD) {
         // roll & pitch from waypoint controller, yaw rate from pilot
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
+    } else if (auto_yaw.mode() == AUTO_YAW_FIXED_WITH_RATE) {
+        // check reaching desired yaw angle
+        auto_yaw.check_reached_desired_yaw_angle();
+        // roll & pitch from waypoint controller, yaw rate from auto_yaw
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.rate_cds());
     } else {
         // roll, pitch from waypoint controller, yaw heading from auto_heading()
         attitude_control->input_euler_angle_roll_pitch_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.yaw(), true);
@@ -791,6 +796,11 @@ void ModeAuto::spline_run()
     if (auto_yaw.mode() == AUTO_YAW_HOLD) {
         // roll & pitch from waypoint controller, yaw rate from pilot
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
+    } else if (auto_yaw.mode() == AUTO_YAW_FIXED_WITH_RATE) {
+        // check reaching desired yaw angle
+        auto_yaw.check_reached_desired_yaw_angle();
+        // roll & pitch from waypoint controller, yaw rate from auto_yaw
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.rate_cds());
     } else {
         // roll, pitch from waypoint controller, yaw heading from auto_heading()
         attitude_control->input_euler_angle_roll_pitch_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.yaw(), true);
@@ -848,6 +858,11 @@ void ModeAuto::circle_run()
     if (auto_yaw.mode() == AUTO_YAW_HOLD) {
         // roll & pitch from waypoint controller, yaw rate from pilot
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(copter.circle_nav->get_roll(), copter.circle_nav->get_pitch(), target_yaw_rate);
+    } else if (auto_yaw.mode() == AUTO_YAW_FIXED_WITH_RATE) {
+        // check reaching desired yaw angle
+        auto_yaw.check_reached_desired_yaw_angle();
+        // roll & pitch from waypoint controller, yaw rate from auto_yaw
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.rate_cds());
     } else {
         // roll, pitch from waypoint controller, yaw heading from auto_heading()
         attitude_control->input_euler_angle_roll_pitch_yaw(copter.circle_nav->get_roll(), copter.circle_nav->get_pitch(), auto_yaw.yaw(), true);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -751,7 +751,7 @@ void ModeAuto::wp_run()
     if (auto_yaw.mode() == AUTO_YAW_HOLD) {
         // roll & pitch from waypoint controller, yaw rate from pilot
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
-    } else if (auto_yaw.mode() == AUTO_YAW_FIXED_WITH_RATE) {
+    } else if (auto_yaw.mode() == AUTO_YAW_RATE) {
         // check reaching desired yaw angle
         auto_yaw.check_reached_desired_yaw_angle();
         // roll & pitch from waypoint controller, yaw rate from auto_yaw
@@ -796,7 +796,7 @@ void ModeAuto::spline_run()
     if (auto_yaw.mode() == AUTO_YAW_HOLD) {
         // roll & pitch from waypoint controller, yaw rate from pilot
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
-    } else if (auto_yaw.mode() == AUTO_YAW_FIXED_WITH_RATE) {
+    } else if (auto_yaw.mode() == AUTO_YAW_RATE) {
         // check reaching desired yaw angle
         auto_yaw.check_reached_desired_yaw_angle();
         // roll & pitch from waypoint controller, yaw rate from auto_yaw
@@ -858,7 +858,7 @@ void ModeAuto::circle_run()
     if (auto_yaw.mode() == AUTO_YAW_HOLD) {
         // roll & pitch from waypoint controller, yaw rate from pilot
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(copter.circle_nav->get_roll(), copter.circle_nav->get_pitch(), target_yaw_rate);
-    } else if (auto_yaw.mode() == AUTO_YAW_FIXED_WITH_RATE) {
+    } else if (auto_yaw.mode() == AUTO_YAW_RATE) {
         // check reaching desired yaw angle
         auto_yaw.check_reached_desired_yaw_angle();
         // roll & pitch from waypoint controller, yaw rate from auto_yaw


### PR DESCRIPTION
I want the angular speed of MAV_CMD_CONDITION_YAW(115) to be reflected in auto. I've tested it with SITL, but I still want some advice to make it better.