### PR TITLE
Plane: don't crosstrack after AUTO VTOL takeoff

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2762,7 +2762,10 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
         // takeoff height.
         plane.SpdHgt_Controller->reset();
     }
-    
+
+    // don't crosstrack on next WP
+    plane.auto_state.next_wp_crosstrack = false;
+
     return true;
 }
 


### PR DESCRIPTION
This matches what we do in fixed wing takeoff, and prevents some odd flight paths after transition, especially with level transition enabled
