### PR TITLE
Copter: Display the HDOP value

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -437,7 +437,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
 
     // warn about hdop separately - to prevent user confusion with no gps lock
     if (copter.gps.get_hdop() > copter.g.gps_hdop_good) {
-        check_failed(ARMING_CHECK_GPS, display_failure, "High GPS HDOP");
+        check_failed(ARMING_CHECK_GPS, display_failure, "High GPS HDOP(%.2lf>%.2lf)", static_cast<double>(copter.gps.get_hdop()/100.0f), static_cast<double>(copter.g.gps_hdop_good/100.0f));
         AP_Notify::flags.pre_arm_gps_check = false;
         return false;
     }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -437,7 +437,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
 
     // warn about hdop separately - to prevent user confusion with no gps lock
     if (copter.gps.get_hdop() > copter.g.gps_hdop_good) {
-        check_failed(ARMING_CHECK_GPS, display_failure, "High GPS HDOP(%.2lf>%.2lf)", static_cast<double>(copter.gps.get_hdop()/100.0f), static_cast<double>(copter.g.gps_hdop_good/100.0f));
+        check_failed(ARMING_CHECK_GPS, display_failure, "High GPS HDOP(%.2lfm>%.2lfm)", static_cast<double>(copter.gps.get_hdop()/100.0f), static_cast<double>(copter.g.gps_hdop_good/100.0f));
         AP_Notify::flags.pre_arm_gps_check = false;
         return false;
     }


### PR DESCRIPTION
I think it would be better to show the HDOP decision values.
I am providing the ArduPilot aircraft to the users.
I know that the user is not familiar with ArduPilot.
I want to understand the status of the airframe from the notified message.

![Screenshot from 2020-08-02 22-13-18](https://user-images.githubusercontent.com/646194/89123982-7789cf00-d50e-11ea-8474-c03c6b42fe66.png)
