### PR TITLE
Add simulation of i2c devices to SITL

### DIFF
--- a/libraries/AP_HAL_SITL/AP_HAL_SITL_Namespace.h
+++ b/libraries/AP_HAL_SITL/AP_HAL_SITL_Namespace.h
@@ -6,6 +6,8 @@ class Scheduler;
 class SITL_State;
 class Storage;
 class AnalogIn;
+class I2CDevice;
+class I2CDeviceManager;
 class RCInput;
 class RCOutput;
 class ADCSource;

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -13,6 +13,7 @@
 #include "Scheduler.h"
 #include "AnalogIn.h"
 #include "UARTDriver.h"
+#include "I2CDevice.h"
 #include "Storage.h"
 #include "RCInput.h"
 #include "RCOutput.h"
@@ -40,7 +41,6 @@ static DSP dspDriver;
 
 
 // use the Empty HAL for hardware we don't emulate
-static Empty::I2CDeviceManager i2c_mgr_instance;
 static Empty::SPIDeviceManager emptySPI;
 static Empty::OpticalFlow emptyOpticalFlow;
 static Empty::Flash emptyFlash;
@@ -53,6 +53,8 @@ static UARTDriver sitlUart4Driver(4, &sitlState);
 static UARTDriver sitlUart5Driver(5, &sitlState);
 static UARTDriver sitlUart6Driver(6, &sitlState);
 static UARTDriver sitlUart7Driver(7, &sitlState);
+
+static I2CDeviceManager i2c_mgr_instance;
 
 static Util utilInstance(&sitlState);
 

--- a/libraries/AP_HAL_SITL/I2CDevice.cpp
+++ b/libraries/AP_HAL_SITL/I2CDevice.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2020  Peter Barker. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "I2CDevice.h"
+
+#include <AP_HAL/AP_HAL.h>
+#include <SITL/SITL.h>
+
+extern const AP_HAL::HAL& hal;
+
+using namespace HALSITL;
+
+/*
+ * I2CBus
+ */
+class I2CBus {
+    friend class I2CDeviceManager;
+public:
+    uint8_t bus;
+    Semaphore sem;
+    int ioctl(uint8_t ioctl_number, void *data) {
+        return _ioctl(ioctl_number, data);
+    }
+    void _timer_tick(); // in lieu of a thread-per-bus
+    AP_HAL::Device::PeriodicHandle register_periodic_callback(uint32_t period_usec, AP_HAL::Device::PeriodicCb cb);
+
+private:
+    int _ioctl(uint8_t ioctl_number, void *data);
+
+    struct callback_info {
+        struct callback_info *next;
+        AP_HAL::Device::PeriodicCb cb;
+        uint32_t period_usec;
+        uint64_t next_usec;
+    } *callbacks;
+};
+
+int I2CBus::_ioctl(uint8_t ioctl_number, void *data)
+{
+    SITL::SITL *sitl = AP::sitl();
+    return sitl->i2c_ioctl(ioctl_number, data);
+}
+
+AP_HAL::Device::PeriodicHandle I2CBus::register_periodic_callback(uint32_t period_usec, AP_HAL::Device::PeriodicCb cb)
+{
+    // mostly swiped from ChibiOS:
+    I2CBus::callback_info *callback = new I2CBus::callback_info;
+    if (callback == nullptr) {
+        return nullptr;
+    }
+    callback->cb = cb;
+    callback->period_usec = period_usec;
+    callback->next_usec = AP_HAL::micros64() + period_usec;
+
+    // add to linked list of callbacks on thread
+    callback->next = callbacks;
+    callbacks = callback;
+    return callback;
+}
+
+void I2CBus::_timer_tick()
+{
+    const uint64_t now = AP_HAL::micros64();
+    for (struct callback_info *ci = callbacks; ci != nullptr; ci = ci->next) {
+        if (ci->next_usec >= now) {
+            ci->cb();
+            ci->next_usec += ci->period_usec;
+        }
+    }
+}
+
+/*
+ * I2CDeviceManager
+ */
+
+I2CBus I2CDeviceManager::buses[NUM_SITL_I2C_BUSES];
+
+I2CDeviceManager::I2CDeviceManager()
+{
+}
+
+AP_HAL::OwnPtr<AP_HAL::I2CDevice>
+I2CDeviceManager::get_device(uint8_t bus,
+                             uint8_t address,
+                             uint32_t bus_clock,
+                             bool use_smbus,
+                             uint32_t timeout_ms)
+{
+    if (bus >= ARRAY_SIZE(buses)) {
+        return AP_HAL::OwnPtr<AP_HAL::I2CDevice>(nullptr);
+    }
+    auto dev = AP_HAL::OwnPtr<AP_HAL::I2CDevice>(new I2CDevice(buses[bus], address));
+    return dev;
+}
+
+void I2CDeviceManager::_timer_tick()
+{
+    for (auto bus : buses) {
+        bus._timer_tick();
+    }
+}
+
+/*
+ * I2CDevice
+ */
+
+I2CDevice::I2CDevice(I2CBus &bus, uint8_t address)
+    : _bus(bus)
+    , _address(address)
+{
+    set_device_bus(bus.bus);
+    set_device_address(address);
+}
+
+#include <stdio.h>
+
+#include <signal.h>
+
+bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
+                         uint8_t *recv, uint32_t recv_len)
+{
+//    kill(0, SIGTRAP);
+    // combined transfer
+    if (!_transfer(send, send_len, recv, recv_len)) {
+        return false;
+    }
+    return true;
+}
+
+bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
+                          uint8_t *recv, uint32_t recv_len)
+{
+    struct i2c_msg msgs[2] = { };
+    unsigned nmsgs = 0;
+
+    if (send && send_len != 0) {
+        msgs[nmsgs].addr = _address;
+        msgs[nmsgs].flags = 0;
+        msgs[nmsgs].buf = const_cast<uint8_t*>(send);
+        msgs[nmsgs].len = send_len;
+        nmsgs++;
+    }
+
+    if (recv && recv_len != 0) {
+        msgs[nmsgs].addr = _address;
+        msgs[nmsgs].flags = I2C_M_RD;
+        msgs[nmsgs].buf = recv;
+        msgs[nmsgs].len = recv_len;
+        nmsgs++;
+    }
+
+    /* interpret it as an input error if nothing has to be done */
+    if (!nmsgs) {
+        return false;
+    }
+
+    struct i2c_rdwr_ioctl_data i2c_data = { };
+
+    i2c_data.msgs = msgs;
+    i2c_data.nmsgs = nmsgs;
+
+    int r;
+    unsigned retries = _retries;
+    do {
+        r = _bus.ioctl(I2C_RDWR, &i2c_data);
+    } while (r == -1 && retries-- > 0);
+
+    return r != -1;
+}
+
+bool I2CDevice::read_registers_multiple(uint8_t first_reg, uint8_t *recv,
+                                        uint32_t recv_len, uint8_t times)
+{
+    ::fprintf(stderr, "read_registers_multiple called\n");
+    return false;
+}
+
+AP_HAL::Semaphore *I2CDevice::get_semaphore() {
+    return &_bus.sem;
+}
+
+AP_HAL::Device::PeriodicHandle I2CDevice::register_periodic_callback(uint32_t period_usec, AP_HAL::Device::PeriodicCb cb)
+{
+    return _bus.register_periodic_callback(period_usec, cb);
+}
+
+bool I2CDevice::adjust_periodic_callback(Device::PeriodicHandle h, uint32_t period_usec)
+{
+    return false;
+}
+

--- a/libraries/AP_HAL_SITL/I2CDevice.h
+++ b/libraries/AP_HAL_SITL/I2CDevice.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2020  Peter Barker. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <inttypes.h>
+
+#include <AP_HAL/HAL.h>
+#include <AP_HAL/I2CDevice.h>
+#include <AP_HAL/utility/OwnPtr.h>
+
+#include "AP_HAL_SITL_Namespace.h"
+#include "Semaphores.h"
+
+class I2CBus;
+
+class HALSITL::I2CDevice : public AP_HAL::I2CDevice {
+public:
+    static I2CDevice *from(AP_HAL::I2CDevice *dev) {
+        return static_cast<I2CDevice*>(dev);
+    }
+
+    /* AP_HAL::I2CDevice implementation */
+
+    I2CDevice(I2CBus &bus, uint8_t address);
+
+    ~I2CDevice() {}
+
+    /* See AP_HAL::I2CDevice::set_address() */
+    void set_address(uint8_t address) override { _address = address; }
+
+    /* See AP_HAL::I2CDevice::set_retries() */
+    void set_retries(uint8_t retries) override { _retries = retries; }
+
+    /* AP_HAL::Device implementation */
+
+    /* See AP_HAL::Device::set_speed(): Empty implementation, not supported. */
+    bool set_speed(enum Device::Speed speed) override { return true; }
+
+    /* See AP_HAL::Device::transfer() */
+    bool transfer(const uint8_t *send, uint32_t send_len,
+                  uint8_t *recv, uint32_t recv_len) override;
+
+    bool read_registers_multiple(uint8_t first_reg, uint8_t *recv,
+                                 uint32_t recv_len, uint8_t times) override;
+
+    /* See AP_HAL::Device::get_semaphore() */
+    AP_HAL::Semaphore *get_semaphore() override;
+
+    /* See AP_HAL::Device::register_periodic_callback() */
+    AP_HAL::Device::PeriodicHandle register_periodic_callback(
+        uint32_t period_usec, AP_HAL::Device::PeriodicCb) override;
+
+    /* See AP_HAL::Device::adjust_periodic_callback() */
+    bool adjust_periodic_callback(
+        AP_HAL::Device::PeriodicHandle h, uint32_t period_usec) override;
+
+    /* set split transfers flag */
+    void set_split_transfers(bool set) override {
+        _split_transfers = set;
+    }
+
+    static void sitl_update();
+
+  // the following must be identical to the structure in SITL/SIM_I2C.h!
+#define I2C_M_RD 1
+#define I2C_RDWR 0
+    struct i2c_msg {
+        uint8_t addr;
+        uint8_t flags;
+        uint8_t *buf;
+        uint16_t len; // FIXME: what type should this be?
+    };
+    struct i2c_rdwr_ioctl_data {
+        i2c_msg *msgs;
+        uint8_t nmsgs;
+    };
+    // end "the following"
+
+protected:
+    I2CBus &_bus;
+    uint8_t _address;
+    uint8_t _retries;
+    bool _split_transfers = false;
+
+    bool _transfer(const uint8_t *send, uint32_t send_len,
+                   uint8_t *recv, uint32_t recv_len);
+};
+
+class HALSITL::I2CDeviceManager : public AP_HAL::I2CDeviceManager {
+public:
+    friend class I2CDevice;
+
+    static I2CDeviceManager *from(AP_HAL::I2CDeviceManager *i2c_mgr)
+    {
+        return static_cast<I2CDeviceManager*>(i2c_mgr);
+    }
+
+    I2CDeviceManager();
+    ~I2CDeviceManager() {};
+
+    void _timer_tick(); // in lieu of a thread-per-bus
+
+    /* AP_HAL::I2CDeviceManager implementation */
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
+                                                 uint32_t bus_clock=400000,
+                                                 bool use_smbus = false,
+                                                 uint32_t timeout_ms=4) override;
+
+protected:
+
+    #define NUM_SITL_I2C_BUSES 4
+    static I2CBus buses[];
+};

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -95,6 +95,7 @@ void SITL_State::_sitl_setup(const char *home_str)
         sitl_model->set_gripper_epm(&_sitl->gripper_epm_sim);
         sitl_model->set_parachute(&_sitl->parachute_sim);
         sitl_model->set_precland(&_sitl->precland_sim);
+        sitl_model->set_i2c(&_sitl->i2c_sim);
 
         if (_use_fg_view) {
             fg_socket.connect(_fg_address, _fg_view_port);

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -601,49 +601,49 @@ void SITL_State::_fdm_input_local(void)
                       attitude);
     }
     if (benewake_tf02 != nullptr) {
-        benewake_tf02->update(sitl_model->get_range());
+        benewake_tf02->update(sitl_model->rangefinder_range());
     }
     if (benewake_tf03 != nullptr) {
-        benewake_tf03->update(sitl_model->get_range());
+        benewake_tf03->update(sitl_model->rangefinder_range());
     }
     if (benewake_tfmini != nullptr) {
-        benewake_tfmini->update(sitl_model->get_range());
+        benewake_tfmini->update(sitl_model->rangefinder_range());
     }
     if (lightwareserial != nullptr) {
-        lightwareserial->update(sitl_model->get_range());
+        lightwareserial->update(sitl_model->rangefinder_range());
     }
     if (lightwareserial_binary != nullptr) {
-        lightwareserial_binary->update(sitl_model->get_range());
+        lightwareserial_binary->update(sitl_model->rangefinder_range());
     }
     if (lanbao != nullptr) {
-        lanbao->update(sitl_model->get_range());
+        lanbao->update(sitl_model->rangefinder_range());
     }
     if (blping != nullptr) {
-        blping->update(sitl_model->get_range());
+        blping->update(sitl_model->rangefinder_range());
     }
     if (leddarone != nullptr) {
-        leddarone->update(sitl_model->get_range());
+        leddarone->update(sitl_model->rangefinder_range());
     }
     if (ulanding_v0 != nullptr) {
-        ulanding_v0->update(sitl_model->get_range());
+        ulanding_v0->update(sitl_model->rangefinder_range());
     }
     if (ulanding_v1 != nullptr) {
-        ulanding_v1->update(sitl_model->get_range());
+        ulanding_v1->update(sitl_model->rangefinder_range());
     }
     if (maxsonarseriallv != nullptr) {
-        maxsonarseriallv->update(sitl_model->get_range());
+        maxsonarseriallv->update(sitl_model->rangefinder_range());
     }
     if (wasp != nullptr) {
-        wasp->update(sitl_model->get_range());
+        wasp->update(sitl_model->rangefinder_range());
     }
     if (nmea != nullptr) {
-        nmea->update(sitl_model->get_range());
+        nmea->update(sitl_model->rangefinder_range());
     }
     if (rf_mavlink != nullptr) {
-        rf_mavlink->update(sitl_model->get_range());
+        rf_mavlink->update(sitl_model->rangefinder_range());
     }
     if (gyus42v2 != nullptr) {
-        gyus42v2->update(sitl_model->get_range());
+        gyus42v2->update(sitl_model->rangefinder_range());
     }
 
     if (frsky_d != nullptr) {

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_HAL_SITL.h"
+#include <AP_HAL_SITL/I2CDevice.h>
 #include "Scheduler.h"
 #include "UARTDriver.h"
 #include <sys/time.h>
@@ -239,6 +240,9 @@ void Scheduler::_run_io_procs()
     hal.uartG->_timer_tick();
     hal.uartH->_timer_tick();
     hal.storage->_timer_tick();
+
+    // in lieu of a thread-per-bus:
+    ((HALSITL::I2CDeviceManager*)(hal.i2c_mgr))->_timer_tick();
 
 #if SITL_STACK_CHECKING_ENABLED
     check_thread_stacks();

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -849,6 +849,11 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
         external_payload_mass += sprayer->payload_mass();
     }
 
+    // update i2c
+    if (i2c) {
+        i2c->update(*this);
+    }
+
     // update buzzer
     if (buzzer && buzzer->is_enabled()) {
         buzzer->update(input);

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -29,6 +29,7 @@
 #include "SIM_Parachute.h"
 #include "SIM_Precland.h"
 #include "SIM_RichenPower.h"
+#include "SIM_I2C.h"
 #include "SIM_Buzzer.h"
 #include <Filter/Filter.h>
 
@@ -144,6 +145,7 @@ public:
     void set_gripper_servo(Gripper_Servo *_gripper) { gripper = _gripper; }
     void set_gripper_epm(Gripper_EPM *_gripper_epm) { gripper_epm = _gripper_epm; }
     void set_precland(SIM_Precland *_precland);
+    void set_i2c(class I2C *_i2c) { i2c = _i2c; }
 
 protected:
     SITL *sitl;
@@ -302,6 +304,7 @@ private:
     Parachute *parachute;
     RichenPower *richenpower;
     SIM_Precland *precland;
+    class I2C *i2c;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -126,7 +126,9 @@ public:
     const Location &get_location() const { return location; }
 
     const Vector3f &get_position() const { return position; }
-    const float &get_range() const { return range; }
+
+    // distance the rangefinder is perceiving
+    float rangefinder_range() const;
 
     void get_attitude(Quaternion &attitude) const {
         attitude.from_rotation_matrix(dcm);
@@ -170,7 +172,7 @@ protected:
     float rpm[12];
     uint8_t rcin_chan_count = 0;
     float rcin[12];
-    float range = -1.0f;                 // rangefinder detection in m
+    float range = -1.0f;                 // externally supplied rangefinder value, assumed to have been corrected for vehicle attitude
 
     struct {
         // data from simulated laser scanner, if available

--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -1,0 +1,93 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulated i2c buses and devices
+*/
+
+
+#include <GCS_MAVLink/GCS.h>
+#include <SITL/SITL.h>
+
+#include "SIM_I2C.h"
+#include "SIM_ToshibaLED.h"
+
+#include <signal.h>
+
+using namespace SITL;
+
+enum class IOCtlType {
+    RDWR = 0,
+};
+
+class IgnoredI2CDevice : public I2CDevice
+{
+public:
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override {
+        return -1;
+    }
+};
+static IgnoredI2CDevice ignored;
+
+static ToshibaLED toshibaled;
+
+struct i2c_device_at_address {
+    uint8_t bus;
+    uint8_t addr;
+    I2CDevice &device;
+} i2c_devices[] {
+    { 1, 0x55, toshibaled },
+    { 1, 0x38, ignored }, // NCP5623
+    { 1, 0x39, ignored }, // NCP5623C
+    { 1, 0x40, ignored }, // KellerLD
+    { 1, 0x76, ignored }, // MS56XX
+};
+
+void I2C::update(const class Aircraft &aircraft)
+{
+    for (auto daa : i2c_devices) {
+        daa.device.update(aircraft);
+    }
+}
+
+int I2C::ioctl_rdwr(i2c_rdwr_ioctl_data *data)
+{
+    int ret = 0;
+    for (uint8_t i=0; i<data->nmsgs; i++) {
+        const i2c_msg &msg = data->msgs[i];
+        const uint8_t addr = msg.addr;
+        bool handled = false;
+        for (auto dev_at_address : i2c_devices) {
+            // where's the bus check?!
+            if (dev_at_address.addr == addr) {
+                ret = dev_at_address.device.rdwr(data);
+                handled = true;
+            }
+        }
+        if (!handled) {
+            ::fprintf(stderr, "Unhandled i2c message: addr=0x%x flags=%u len=%u\n", msg.addr, msg.flags, msg.len);
+            return -1;  // ?!
+        }
+    }
+    return ret;
+}
+
+int I2C::ioctl(uint8_t ioctl_type, void *data)
+{
+    switch ((IOCtlType) ioctl_type) {
+    case IOCtlType::RDWR:
+        return ioctl_rdwr((i2c_rdwr_ioctl_data*)data);
+    }
+    return -1;
+}

--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -22,6 +22,7 @@
 
 #include "SIM_I2C.h"
 #include "SIM_ToshibaLED.h"
+#include "SIM_MaxSonarI2CXL.h"
 
 #include <signal.h>
 
@@ -41,6 +42,7 @@ public:
 static IgnoredI2CDevice ignored;
 
 static ToshibaLED toshibaled;
+static MaxSonarI2CXL maxsonari2cxl;
 
 struct i2c_device_at_address {
     uint8_t bus;
@@ -51,6 +53,7 @@ struct i2c_device_at_address {
     { 1, 0x38, ignored }, // NCP5623
     { 1, 0x39, ignored }, // NCP5623C
     { 1, 0x40, ignored }, // KellerLD
+    { 1, 0x70, maxsonari2cxl },
     { 1, 0x76, ignored }, // MS56XX
 };
 

--- a/libraries/SITL/SIM_I2C.h
+++ b/libraries/SITL/SIM_I2C.h
@@ -1,0 +1,57 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  Simulated i2c buses and devices
+*/
+
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+
+#include "stdint.h"
+
+namespace SITL {
+
+class I2C {
+public:
+    I2C() {}
+
+    // update i2c state
+    void update(const class Aircraft &aircraft);
+
+    int ioctl(uint8_t ioctl_type, void *data);
+
+    // the following must be identical to AP_HAL_SITL/I2CDevice.h
+#define I2C_M_RD 1
+#define I2C_RDWR 0
+    struct i2c_msg {
+        uint8_t addr;
+        uint8_t flags;
+        uint8_t *buf;
+        uint16_t len; // FIXME: what type should this be?
+    };
+    struct i2c_rdwr_ioctl_data {
+        i2c_msg *msgs;
+        uint8_t nmsgs;
+    };
+    // end "the following"
+
+private:
+    int ioctl_rdwr(i2c_rdwr_ioctl_data *data);
+
+};
+
+}

--- a/libraries/SITL/SIM_I2CDevice.h
+++ b/libraries/SITL/SIM_I2CDevice.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "SIM_I2C.h"
+
+#include <SITL/SIM_Aircraft.h>
+
+namespace SITL {
+
+class I2CDevice {
+public:
+    virtual void update(const class Aircraft &aircraft) { }
+
+    virtual int rdwr(I2C::i2c_rdwr_ioctl_data *&data) = 0;
+};
+
+} // namespace SITL

--- a/libraries/SITL/SIM_MaxSonarI2CXL.cpp
+++ b/libraries/SITL/SIM_MaxSonarI2CXL.cpp
@@ -1,0 +1,45 @@
+#include "SIM_MaxSonarI2CXL.h"
+
+#include <SITL/SITL.h>
+#include <SITL/SIM_Aircraft.h>
+
+#include <stdio.h>
+
+int SITL::MaxSonarI2CXL::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
+{
+    const uint32_t now = AP_HAL::millis();
+
+    struct I2C::i2c_msg &msg = data->msgs[0];
+    if (msg.flags == I2C_M_RD) {
+        // driver is attempting to receive reading...
+        if (now - cmd_take_reading_received_ms < 20) {
+            // not sure we ought to be returning -1 here - what does
+            // the real device do?  return stale data?  garbage data?
+            return -1;
+        }
+        if (msg.len != 2) {
+            AP_HAL::panic("Unxpected message length (%u)", msg.len);
+        }
+
+        const uint16_t range_cm = rangefinder_range * 100;
+
+        msg.buf[0] = range_cm >> 8;
+        msg.buf[1] = range_cm & 0xff;
+
+        return 0;
+    }
+
+    const uint8_t CMD_TAKE_READING  = 0x51;
+    const uint8_t cmd = msg.buf[0];
+    if (cmd != CMD_TAKE_READING) {
+        AP_HAL::panic("Unknown command (%u)", cmd);
+    }
+    cmd_take_reading_received_ms = now;
+
+    return 0;
+};
+
+void SITL::MaxSonarI2CXL::update(const Aircraft &aircraft)
+{
+    rangefinder_range = aircraft.rangefinder_range();
+}

--- a/libraries/SITL/SIM_MaxSonarI2CXL.h
+++ b/libraries/SITL/SIM_MaxSonarI2CXL.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "SIM_I2CDevice.h"
+
+namespace SITL {
+
+class MaxSonarI2CXL : public I2CDevice
+{
+public:
+
+    void update(const class Aircraft &aircraft) override;
+
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
+
+private:
+    uint32_t cmd_take_reading_received_ms;
+
+    float rangefinder_range;
+};
+
+} // namespace SITL

--- a/libraries/SITL/SIM_SerialRangeFinder.cpp
+++ b/libraries/SITL/SIM_SerialRangeFinder.cpp
@@ -20,45 +20,6 @@
 
 using namespace SITL;
 
-uint16_t SerialRangeFinder::calculate_range_cm(float range_value) const
-{
-    // swiped from sitl_rangefinder.cpp - we should unify them at some stage
-
-    const SITL *sitl = AP::sitl();
-
-    float altitude = range_value;
-    if (is_equal(range_value, -1.0f)) {  // Use SITL altitude as reading by default
-        altitude = AP::sitl()->height_agl;
-    }
-
-    // sensor position offset in body frame
-    const Vector3f relPosSensorBF = sitl->rngfnd_pos_offset;
-
-    // adjust altitude for position of the sensor on the vehicle if position offset is non-zero
-    if (!relPosSensorBF.is_zero()) {
-        // get a rotation matrix following DCM conventions (body to earth)
-        Matrix3f rotmat;
-        sitl->state.quaternion.rotation_matrix(rotmat);
-        // rotate the offset into earth frame
-        const Vector3f relPosSensorEF = rotmat * relPosSensorBF;
-        // correct the altitude at the sensor
-        altitude -= relPosSensorEF.z;
-    }
-
-    // If the attidude is non reversed for SITL OR we are using rangefinder from external simulator,
-    // We adjust the reading with noise, glitch and scaler as the reading is on analog port.
-    if ((fabs(sitl->state.rollDeg) < 90.0 && fabs(sitl->state.pitchDeg) < 90.0) || !is_equal(range_value, -1.0f)) {
-        if (is_equal(range_value, -1.0f)) {  // disable for external reading that already handle this
-            // adjust for apparent altitude with roll
-            altitude /= cosf(radians(sitl->state.rollDeg)) * cosf(radians(sitl->state.pitchDeg));
-        }
-        // Add some noise on reading
-        altitude += sitl->sonar_noise * rand_float();
-    }
-
-    return altitude * 100.0f;
-}
-
 void SerialRangeFinder::update(float range)
 {
     // just send a chunk of data at 5Hz:
@@ -68,8 +29,9 @@ void SerialRangeFinder::update(float range)
     }
     last_sent_ms = now;
 
+    const uint16_t range_cm = uint16_t(range*100);
     uint8_t data[255];
-    const uint32_t packetlen = packet_for_alt(calculate_range_cm(range),
+    const uint32_t packetlen = packet_for_alt(range_cm,
                                               data,
                                               ARRAY_SIZE(data));
 

--- a/libraries/SITL/SIM_SerialRangeFinder.h
+++ b/libraries/SITL/SIM_SerialRangeFinder.h
@@ -41,9 +41,6 @@ public:
 private:
 
     uint32_t last_sent_ms;
-
-    uint16_t calculate_range_cm(float range_value) const;
-
 };
 
 }

--- a/libraries/SITL/SIM_ToshibaLED.cpp
+++ b/libraries/SITL/SIM_ToshibaLED.cpp
@@ -1,0 +1,46 @@
+#include "SIM_ToshibaLED.h"
+
+#include <stdio.h>
+
+#define TOSHIBA_LED_PWM0    0x01    // pwm0 register
+#define TOSHIBA_LED_PWM1    0x02    // pwm1 register
+#define TOSHIBA_LED_PWM2    0x03    // pwm2 register
+#define TOSHIBA_LED_ENABLE  0x04    // enable register
+
+int SITL::ToshibaLED::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
+{
+    if (data->nmsgs != 1) {
+        // this is really just because it is unexpected from the
+        // ArduPilot code, rather than being incorrect from a
+        // simulated device perspective.
+        AP_HAL::panic("Reading from Toshiba LED?!");
+    }
+    const struct I2C::i2c_msg &msg = data->msgs[0];
+    const uint8_t reg = msg.buf[0];
+    const uint8_t val = msg.buf[1];
+    switch(reg) {
+    case TOSHIBA_LED_PWM0:
+        // ::fprintf(stderr, "ToshibaLED: pwm0=%u %u %u\n", msg.buf[1], msg.buf[2], msg.buf[3]);
+        _pwm0 = val;
+        break;
+    case TOSHIBA_LED_PWM1:
+        // ::fprintf(stderr, "ToshibaLED: pwm1=%u\n", val);
+        _pwm1 = val;
+        break;
+    case TOSHIBA_LED_PWM2:
+        // ::fprintf(stderr, "ToshibaLED: pwm2=%u\n", val);
+        _pwm2 = val;
+        break;
+    case TOSHIBA_LED_ENABLE:
+        if (val != 0x03) {
+            AP_HAL::panic("Unexpected enable value (%u)", val);
+        }
+        // ::fprintf(stderr, "ToshibaLED: enabling\n");
+        _enabled = true;
+        break;
+    default:
+        AP_HAL::panic("Unexpected register (%u)", reg);
+    }
+    // kill(0, SIGTRAP);
+    return -1;
+}

--- a/libraries/SITL/SIM_ToshibaLED.h
+++ b/libraries/SITL/SIM_ToshibaLED.h
@@ -1,0 +1,19 @@
+#include "SIM_I2CDevice.h"
+
+namespace SITL {
+
+class ToshibaLED : public I2CDevice
+{
+public:
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
+    // void update(const struct sitl_input input) override;
+private:
+    bool _enabled;
+    bool _pwm0; // FIXME: just an array of register values?!
+    bool _pwm1;
+    bool _pwm2;
+    bool _pwm3;
+    uint32_t last_internal_clock_update_ms;
+};
+
+} // namespace SITL

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -12,6 +12,7 @@
 #include "SIM_Buzzer.h"
 #include "SIM_Gripper_EPM.h"
 #include "SIM_Gripper_Servo.h"
+#include "SIM_I2C.h"
 #include "SIM_Parachute.h"
 #include "SIM_Precland.h"
 #include "SIM_Sprayer.h"
@@ -350,6 +351,10 @@ public:
     // convert a set of roll rates from body frame to earth frame
     static Vector3f convert_earth_frame(const Matrix3f &dcm, const Vector3f &gyro);
 
+    int i2c_ioctl(uint8_t i2c_operation, void *data) {
+        return i2c_sim.ioctl(i2c_operation, data);
+    }
+
     Sprayer sprayer_sim;
 
     // simulated ship takeoffs
@@ -360,6 +365,7 @@ public:
 
     Parachute parachute_sim;
     Buzzer buzzer_sim;
+    I2C i2c_sim;
     ToneAlarm tonealarm_sim;
     SIM_Precland precland_sim;
     RichenPower richenpower_sim;


### PR DESCRIPTION
Simulated MaxSonarI2CXL i2c device:

![image](https://user-images.githubusercontent.com/7077857/89143247-46041880-d58d-11ea-83b4-17c1a770ab7b.png)

This is pretty rough - multiple i2c buses are NOT handled well, but it would be nice to get this in as something that can be incrementally improved upon.

Currently only two devices are simulated - and badly, at that.  Adding visual bling for the ToshibaLED would probably be best by removing the existing Notify SFML LED driver bits and moving all of the SFML stuff down into this simulated i2c device.
