### PR TITLE
Rover: improve navigation for skid-steering vehicles

### DIFF
--- a/Rover/AP_MotorsUGV.h
+++ b/Rover/AP_MotorsUGV.h
@@ -173,6 +173,7 @@ protected:
     AP_Float _thrust_curve_expo; // thrust curve exponent from -1 to +1 with 0 being linear
     AP_Float _vector_throttle_base;  // throttle level above which steering is scaled down when using vector thrust.  zero to disable vectored thrust
     AP_Float _speed_scale_base;  // speed above which steering is scaled down when using regular steering/throttle vehicles.  zero to disable speed scaling
+    AP_Float _steering_throttle_mix; // Steering vs Throttle priorisation.  Higher numbers prioritise steering, lower numbers prioritise throttle.  Only valid for Skid Steering vehicles
 
     // internal variables
     float   _steering;  // requested steering as a value from -4500 to +4500

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -24,6 +24,7 @@ extern const AP_HAL::HAL& hal;
 #define AR_WPNAV_RADIUS_DEFAULT         2.0f
 #define AR_WPNAV_OVERSHOOT_DEFAULT      2.0f
 #define AR_WPNAV_PIVOT_ANGLE_DEFAULT    60
+#define AR_WPNAV_PIVOT_ANGLE_ACCURACY   10      // vehicle will pivot to within this many degrees of destination
 #define AR_WPNAV_PIVOT_RATE_DEFAULT     90
 
 const AP_Param::GroupInfo AR_WPNav::var_info[] = {
@@ -141,6 +142,11 @@ void AR_WPNav::update(float dt)
 
     update_distance_and_bearing_to_destination();
 
+    // if object avoidance is active check if vehicle should pivot towards destination
+    if (_oa_active) {
+        update_pivot_active_flag();
+    }
+
     // check if vehicle is in recovering state after switching off OA
     if (!_oa_active && _oa_was_active) {
         if (oa->get_options() & AP_OAPathPlanner::OA_OPTION_WP_RESET) {
@@ -192,7 +198,10 @@ bool AR_WPNav::set_desired_location(const struct Location& destination, float ne
     _reached_destination = false;
     update_distance_and_bearing_to_destination();
 
-    // set final desired speed
+    // determine if we should pivot immediately
+    update_pivot_active_flag();
+
+    // set final desired speed and whether vehicle should pivot
     _desired_speed_final = 0.0f;
     if (!is_equal(next_leg_bearing_cd, AR_WPNAV_HEADING_UNKNOWN)) {
         const float curr_leg_bearing_cd = _origin.get_bearing_to(_destination);
@@ -273,7 +282,7 @@ bool AR_WPNav::get_stopping_location(Location& stopping_loc)
 bool AR_WPNav::use_pivot_steering_at_next_WP(float yaw_error_cd) const
 {
     // check cases where we clearly cannot use pivot steering
-    if (!_pivot_possible || _pivot_angle <= 0) {
+    if (!_pivot_possible || _pivot_angle <= AR_WPNAV_PIVOT_ANGLE_ACCURACY) {
         return false;
     }
 
@@ -285,32 +294,32 @@ bool AR_WPNav::use_pivot_steering_at_next_WP(float yaw_error_cd) const
     return false;
 }
 
-// returns true if vehicle should pivot immediately (because heading error is too large)
-bool AR_WPNav::use_pivot_steering(float yaw_error_cd)
+// updates _pivot_active flag based on heading error to destination
+// relies on update_distance_and_bearing_to_destination having been called first
+// to update _oa_wp_bearing and _reversed variables
+void AR_WPNav::update_pivot_active_flag()
 {
     // check cases where we clearly cannot use pivot steering
-    if (!_pivot_possible || (_pivot_angle <= 0)) {
+    if (!_pivot_possible || (_pivot_angle <= AR_WPNAV_PIVOT_ANGLE_ACCURACY)) {
         _pivot_active = false;
-        return false;
+        return;
     }
 
-    // calc bearing error
-    const float yaw_error = fabsf(yaw_error_cd) * 0.01f;
+    // calc yaw error
+    const float yaw_cd = _reversed ? wrap_360_cd(_oa_wp_bearing_cd + 18000) : _oa_wp_bearing_cd;
+    const float yaw_error = fabsf(wrap_180_cd(yaw_cd - AP::ahrs().yaw_sensor)) * 0.01f;
 
     // if error is larger than _pivot_angle start pivot steering
     if (yaw_error > _pivot_angle) {
         _pivot_active = true;
-        return true;
+        return;
     }
 
     // if within 10 degrees of the target heading, exit pivot steering
-    if (yaw_error < 10.0f) {
+    if (yaw_error < AR_WPNAV_PIVOT_ANGLE_ACCURACY) {
         _pivot_active = false;
-        return false;
+        return;
     }
-
-    // by default stay in
-    return _pivot_active;
 }
 
 // true if update has been called recently
@@ -350,16 +359,15 @@ void AR_WPNav::update_distance_and_bearing_to_destination()
 // relies on update_distance_and_bearing_to_destination being called first so _wp_bearing_cd has been updated
 void AR_WPNav::update_steering(const Location& current_loc, float current_speed)
 {
-    // calculate yaw error for determining if vehicle should pivot towards waypoint
-    float yaw_cd = _reversed ? wrap_360_cd(_oa_wp_bearing_cd + 18000) : _oa_wp_bearing_cd;
-    float yaw_error_cd = wrap_180_cd(yaw_cd - AP::ahrs().yaw_sensor);
-
     // calculate desired turn rate and update desired heading
-    if (use_pivot_steering(yaw_error_cd)) {
+    if (_pivot_active) {
         _cross_track_error = 0.0f;
-        _desired_heading_cd = yaw_cd;
+        _desired_heading_cd = _reversed ? wrap_360_cd(_oa_wp_bearing_cd + 18000) : _oa_wp_bearing_cd;;
         _desired_lat_accel = 0.0f;
-        _desired_turn_rate_rads = _atc.get_turn_rate_from_heading(radians(yaw_cd * 0.01f), radians(_pivot_rate));
+        _desired_turn_rate_rads = _atc.get_turn_rate_from_heading(radians(_desired_heading_cd * 0.01f), radians(_pivot_rate));
+
+        // update flag so that it can be cleared
+        update_pivot_active_flag();
     } else {
         // run L1 controller
         _nav_controller.set_reverse(_reversed);

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AR_WPNav::var_info[] = {
 
     // @Param: PIVOT_ANGLE
     // @DisplayName: Waypoint Pivot Angle
-    // @Description: Pivot when the difference bewteen the vehicle's heading and it's target heading is more than this many degrees.  Set to zero to disable pivot turns
+    // @Description: Pivot when the difference between the vehicle's heading and its target heading is more than this many degrees.  Set to zero to disable pivot turns
     // @Units: deg
     // @Range: 0 360
     // @Increment: 1

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -112,6 +112,9 @@ private:
     // adjust speed to ensure it does not fall below value held in SPEED_MIN
     void apply_speed_min(float &desired_speed);
 
+    // calculate the crosstrack error (does not rely on L1 controller)
+    float calc_crosstrack_error(const Location& current_loc) const;
+
 private:
 
     // parameters

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -104,8 +104,10 @@ private:
     // returns true if vehicle should pivot turn at next waypoint
     bool use_pivot_steering_at_next_WP(float yaw_error_cd) const;
 
-    // returns true if vehicle should pivot immediately (because heading error is too large)
-    bool use_pivot_steering(float yaw_error_cd);
+    // updates _pivot_active flag based on heading error to destination
+    // relies on update_distance_and_bearing_to_destination having been called first
+    // to update _oa_wp_bearing and _reversed variables
+    void update_pivot_active_flag();
 
     // adjust speed to ensure it does not fall below value held in SPEED_MIN
     void apply_speed_min(float &desired_speed);


### PR DESCRIPTION
This PR slightly improves navigation of skid-steering vehicles

1. AP_MotorsUGV gets a new parameter, MOT_STR_THR_MIX, which allows adjusting the prioritisation of steering vs throttle when skid-steering vehicle outputs saturate.  This helps skid-steering vehicles keep on the line during auto missions where the WP_SPEED is set close to the vehicle's physical limits.  The default value of 0.5 behaves as master does by proportionally reducing throttle and steering.  If this parameter is set higher (meaning prioritise steering) then steering will be scaled back less and throttle will be scaled back more. The extreme case is when MOT_STR_THR_MIX = 1.0 which will lead to steering not being scaled back at all.  Here are some example outputs:

     - MOT_STR_THR_MIX=0.5 (balanced), ThrIn=100%, StrIn=50%, ThrOut=66%, StrOut=33%
     - MOT_STR_THR_MIX=0.0 (prioritise throttle), ThrIn=100%, StrIn=50%, ThrOut=100%, StrOut=0%
     - MOT_STR_THR_MIX=1.0 (prioritise steering), ThrIn=100%, StrIn=50%, ThrOut=50%, StrOut=50%
     - MOT_STR_THR_MIX=0.5 (balanced), ThrIn=80%, StrIn=80%, ThrOut=50%, StrOut=50%
     - MOT_STR_THR_MIX=0.0 (prioritise throttle), ThrIn=80%, StrIn=80%, ThrOut=80%, StrOut=20%
     - MOT_STR_THR_MIX=1.0 (prioritise steering), ThrIn=80%, StrIn=80%, ThrOut=20%, StrOut=80%

Below is a screen shot of testing with debug showing inputs, new algorithm's outputs and previous algorithm's outputs.  The point of this picture is mostly just to demonstrate that I've tested this thoroughly
![image](https://user-images.githubusercontent.com/1498098/89150330-486c6f80-d599-11ea-98e7-1926252cd09a.png)

2. AR_WPNav is modified so that In autonomous modes (Auto, Guided, RTL, etc) pivot turns will only occur after the destination is changed instead of whenever the heading error is greater than WP_PIVOT_ANGLE.  This avoids unnecessary pivots just before the waypoint when WP_RADIUS is set very low.  Below is a before-vs-after screen shot of a vehicle with a poor navigation tune so that it reaches the waypoint off the line.  Previously it would turn just before the turn, now it turns just after.  In real-life the vehicle may two two pivots.  BTW, I think the rover overshoots the point because its forward velocity is limited based on the distance to the waypoint which includes the cross track error.
![rover-turn-before-after](https://user-images.githubusercontent.com/1498098/89152015-2bd23680-d59d-11ea-9739-3de108724d2b.png)

3. AR_WPNav gets a fix so that crosstrack error is calculated even during pivot turns.  This is only for reporting purposes.
![nav-xtrack-fix](https://user-images.githubusercontent.com/1498098/89152720-a059a500-d59e-11ea-9bcd-2727f7c2a3b7.png)

4. Mode::get_pilot_desired_steering_and_throttle handles saturation of the inputs which makes Manual mode feel the same as it did before the addition of the MOT_STR_THR_MIX parameter.  Without this change, if the user set MOT_STR_THR_MIX to 1.0 (prioritise steering) they would find the vehicle slowed to a stop when they gave full steering and throttle input.  A more natural feel for the driver is to get a 50/50 blend.  This leaves MOT_STR_THR_MIX to be used for prioritisation in all other modes where the steering and throttle will come from the turn-rate and speed-controllers.  Below is a screen shot of some testing to ensure the scaling was being done correctly.
![manual-input-scaling](https://user-images.githubusercontent.com/1498098/89253586-ffc7bb80-d657-11ea-9506-b428f751ffc5.png)


