### PR TITLE
Add support for reporting rtkbaseline from ublox driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -143,7 +143,7 @@ public:
 
     // ublox specific healthy checks
     bool is_healthy(void) const override;
-    
+    bool supports_mavlink_gps_rtk_message() const override { return true; }
 private:
     // u-blox UBX protocol essentials
     struct PACKED ubx_header {


### PR DESCRIPTION
This PR is addresses the feature request #14965. Two files, UBLOX.cpp and UBLOX.h have changes that allow the driver to support and report baseline distances parsed from the `RELPOSNED` message if available from a rover unit. This works with the latest Copter with two Ublox ZED-F9P devices configured as base and rover.

There are a few other fields that can be filled, but I'm not sure if (a) they are critical, and (b) if `RELPOSNED` contains those. The contents of this PR basically allow reporting baseline distances and the rover's accuracy, so that a map in the base-station's NED frame can be obtained.

**Addendum:**
The baseline info is picked up by `GPS_RTK` message in Mavlink, and is now supported in Mavros through [this merge commit](https://github.com/mavlink/mavros/commit/0f92d8853c3da4dce76910716e75725d76a486ff).