### PR TITLE
SRV_Channel: set disabled output_function to trim value

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -31,6 +31,9 @@ void SRV_Channel::output_ch(void)
     // take care of special function cases
     switch(function)
     {
+    case k_none: //for normal operation, the disabled output function sets the output value of the channel to the trim value
+        output_pwm = servo_trim.get();
+        break;
     case k_manual:              // manual
         passthrough_from = ch_num;
         break;


### PR DESCRIPTION
In the official documentation of [Autopilot Output Functions](https://ardupilot.org/copter/docs/common-rcoutput-mapping.html) is reported:

> For normal operation, the **Disabled output function sets the output value of the channel to the trim value** (for example, if SERVO5_FUNCTION is 0 then channel 5 will output SERVO5_TRIM). The exception to this is when a MAVLink override of the channel or a mission servo set is used. So in some ways “disabled” could be called “mission-controlled”.

According to my tests, disabling the output function does not set the output value of the channel to the trim value. Therefore, I propose here a small correction.

I my case, I have a 6-channel radio and I need to use the remaining RC channel (number 6) for "in flight tuning", while the governor input signal (or even the gyro input gain) can as well be controlled by a fixed signal (set here to the trim value).

Please find below some tests:

![2020-08-03 14_49_21-Window](https://user-images.githubusercontent.com/8594515/89189145-df3c2a80-d59f-11ea-961e-8a96a21258b2.png)