### PR TITLE
AP_Notify: set led_off instead 0 for Navio

### DIFF
--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -220,9 +220,9 @@ void RGBLed::update()
 
     const uint8_t colour = (current_colour_sequence >> (step*3)) & 7;
 
-    _red_des = (colour & RED) ? brightness : 0;
-    _green_des = (colour & GREEN) ? brightness : 0;
-    _blue_des = (colour & BLUE) ? brightness : 0;
+    _red_des = (colour & RED) ? brightness : _led_off;
+    _green_des = (colour & GREEN) ? brightness : _led_off;
+    _blue_des = (colour & BLUE) ? brightness : _led_off;
 
     set_rgb(_red_des, _green_des, _blue_des);
 }


### PR DESCRIPTION
Since all the vehicles have the problem with LED on Navio2 that doesn't lightning up ([the problem](https://discuss.ardupilot.org/t/copter-4-0-0-rc2-available-for-beta-testing/48851/19) can be seen in #12547), I suppose those changes because Led off value can be differ from 0 if the indication is inverted.

These will allow the LED for Navio boards to work correctly.