### PR TITLE
autotest: add do_timesync_roundtrip to do a timesync against SITL

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -704,7 +704,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 65535, # chan6_raw
                 65535, # chan7_raw
                 65535) # chan8_raw
-
+            self.do_timesync_roundtrip()
             m = self.mav.recv_match(type='RC_CHANNELS', blocking=True)
             self.progress("chan3=%f want=%f" % (m.chan3_raw, normal_rc_throttle))
             if m.chan3_raw == normal_rc_throttle:


### PR DESCRIPTION
On the assumption that ArduPilot processes mavlink packets
synchronously (or at least in order), after we have run a timesync
roundtrip we can reasonably expect any mavlink command we have sent
prior to the roundtrip to have been processed, and we should be able to
see the results in the mavlink stream.

This is being added to try to track down an issue where Rover doesn't seem to cancel overrides when it should:
```
    RCOverridesCancel (Test RC overrides Cancel) (Did not cancel override) (see /home/travis/build/ArduPilot/buildlogs/Rover-RCOverridesCancel.txt)
```
