### PR TITLE
AP_HAL_SITL: correct use of uninitialised value in tcp UARTDriver

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -91,6 +91,7 @@ private:
     bool _connected = false; // true if a client has connected
     bool _use_send_recv = false;
     int _listen_fd;  // socket we are listening on
+    struct sockaddr_in _listen_sockaddr;
     int _serial_port;
     static bool _console;
     bool _nonblocking_writes;


### PR DESCRIPTION
In the case we already have a _listen_fd, sockaddr wasn't being
initialised before being printed to stdout.