### PR TITLE
AC_Fence: remove dead and misleading assignment

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -117,7 +117,6 @@ bool AC_PolyFence_loader::get_item(const uint16_t seq, AC_PolyFenceItem &item)
             return false;
         }
         item.radius = fence_storage.read_uint32(offset);
-        offset += 4;
         break;
     case AC_PolyFenceType::POLYGON_INCLUSION:
     case AC_PolyFenceType::POLYGON_EXCLUSION:


### PR DESCRIPTION
This is never used again.  Presumably this was factored out of something
else where it might have mattered.

This was found with clang's scan function.
