### PR TITLE
SITL: Set message output to two second.

### DIFF
--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -79,7 +79,11 @@ int I2C::ioctl_rdwr(i2c_rdwr_ioctl_data *data)
             }
         }
         if (!handled) {
-            ::fprintf(stderr, "Unhandled i2c message: addr=0x%x flags=%u len=%u\n", msg.addr, msg.flags, msg.len);
+            static uint32_t lastMsg;
+            if ((AP_HAL::millis() - lastMsg) > 2000) {
+                ::fprintf(stderr, "Unhandled i2c message: addr=0x%x flags=%u len=%u\n", msg.addr, msg.flags, msg.len);
+                lastMsg = AP_HAL::millis();
+            }
             return -1;  // ?!
         }
     }


### PR DESCRIPTION
I have too many messages.
I output the messages in 2 second increments.

After:
![Screenshot from 2020-08-07 07-20-57](https://user-images.githubusercontent.com/646194/89588613-f79d9500-d87e-11ea-99da-f3894f956874.png)

Before
![Screenshot from 2020-08-07 07-09-28](https://user-images.githubusercontent.com/646194/89588590-eb193c80-d87e-11ea-9cca-567fd95b1740.png)
