### PR TITLE
Add support for EcoTrons EcoEFI over serial

### DIFF
--- a/libraries/AP_EFI/AP_EFI.cpp
+++ b/libraries/AP_EFI/AP_EFI.cpp
@@ -25,6 +25,7 @@
 #include "AP_EFI_Scripting.h"
 #include "AP_EFI_MAV.h"
 
+#include "AP_EFI_Serial_EcoEFI.h"
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 
@@ -122,6 +123,11 @@ void AP_EFI::init(void)
     case Type::MAV:
             backend = new AP_EFI_MAV(*this);
             break;
+#endif
+#if HAL_EFI_ECO_ENABLED
+    case Type::EcoEFI:
+        backend = new AP_EFI_Serial_EcoEFI(*this);
+        break;
 #endif
     default:
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Unknown EFI type");

--- a/libraries/AP_EFI/AP_EFI.h
+++ b/libraries/AP_EFI/AP_EFI.h
@@ -98,6 +98,7 @@ public:
 #endif
         // Hirth      = 8 /* Reserved for future implementation */
 		MAV = 9,
+        EcoEFI     = 10,
     };
 
     static AP_EFI *get_singleton(void) {

--- a/libraries/AP_EFI/AP_EFI_Serial_EcoEFI.cpp
+++ b/libraries/AP_EFI/AP_EFI_Serial_EcoEFI.cpp
@@ -1,0 +1,128 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_EFI_Serial_EcoEFI.h"
+
+#if EFI_ENABLED
+#include <AP_SerialManager/AP_SerialManager.h>
+
+#include <AP_HAL/utility/sparse-endian.h>
+
+AP_EFI_Serial_EcoEFI::AP_EFI_Serial_EcoEFI(AP_EFI &_frontend):
+    AP_EFI_Backend(_frontend)
+{
+    uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_EcoEFI, 0);
+    if (uart == nullptr) {
+        return;
+    }
+    uart->begin(115200);
+}
+
+
+extern const AP_HAL::HAL &hal;
+
+
+// find an EcoEFI message in the buffer, starting at initial_offset.
+// If found, that message (or partial message) will be moved to the
+// start of the buffer.
+void AP_EFI_Serial_EcoEFI::move_header_in_buffer(uint8_t initial_offset)
+{
+    uint8_t header_offset;
+    for (header_offset=initial_offset; header_offset<body_length; header_offset++) {
+        if (u.parse_buffer[header_offset] == HEADER_MAGIC1) {
+            break;
+        }
+    }
+    if (header_offset != 0) {
+        // header was found, but not at index 0; move it back to start of array
+        memmove(u.parse_buffer, &u.parse_buffer[header_offset], body_length - header_offset);
+        body_length -= header_offset;
+    }
+}
+
+void AP_EFI_Serial_EcoEFI::update()
+{
+    if (uart == nullptr) {
+        return;
+    }
+
+    for (uint8_t msg=0; msg<5; msg++) {  // process a maximum of 5 messages
+        uint32_t nbytes = uart->read(&u.parse_buffer[body_length],
+                                     ARRAY_SIZE(u.parse_buffer)-body_length);
+        if (nbytes == 0) {
+            return;
+        }
+        body_length += nbytes;
+
+        move_header_in_buffer(0);
+
+        // header byte 1 is correct.
+        if (body_length < ARRAY_SIZE(u.parse_buffer)) {
+            // need a full buffer to have a valid message...
+            return;
+        }
+
+        if (u.packet.headermagic2 != HEADER_MAGIC2) {
+            move_header_in_buffer(2);
+            return;
+        }
+
+        if (u.packet.headermagic3 != HEADER_MAGIC3) {
+            move_header_in_buffer(3); // we know MAGIC1 != MAGIC2
+            return;
+        }
+
+        if (u.packet.data_field_length != DATA_FIELD_LENGTH) {
+            move_header_in_buffer(3);
+            return;
+        }
+
+        if (u.packet.service_id != SERVICE_ID) {
+            move_header_in_buffer(3);
+            return;
+        }
+
+        // calculate checksum....
+        uint8_t checksum = 0;
+        for (uint8_t i=0; i<ARRAY_SIZE(u.parse_buffer)-1; i++) {
+            checksum += u.parse_buffer[i];
+        }
+        if (checksum != u.packet.checksum) {
+            move_header_in_buffer(3);
+            return;
+        }
+
+        internal_state.engine_speed_rpm = be16toh(u.packet.RPM) * 4;
+        internal_state.intake_manifold_pressure_kpa = be16toh(u.packet.MAP) * 0.0039;
+        internal_state.throttle_position_percent = be16toh(u.packet.TPS) * 0.0015;
+        internal_state.coolant_temperature = be16toh(u.packet.ECT) * 1.25 - 40 + 273;
+        internal_state.intake_manifold_temperature = be16toh(u.packet.IAT) * 1.25 - 40 + 273;
+//        internal_state.oxygen_sensor_volts = be16toh(u.packet.O2S) * 0.0012;
+//        internal_state.spark_current_amps = be16toh(u.packet.SPARK) * 0.75;  // just a guess at units....
+//        internal_state.something_something_ms = be16toh(u.packet.FUELPW1) * 0.001;
+//        internal_state.something_something_else_ms = be16toh(u.packet.FUELPW2) * 0.001;
+//        internal_state.something_something_volts = be16toh(u.packet.ubAdc) * 0.00625;
+//        internal_state.something_something_percent = u.packet.FuelLvl * 0.4;
+        internal_state.atmospheric_pressure_kpa = be16toh(u.packet.BARO) * 0.0039;
+//        internal_state.something_something_grams_per_minute = u.packet.Field_Consumption * 0.0116;
+
+        copy_to_frontend();
+
+        body_length = 0;
+    }
+}
+
+#endif // EFI_ENABLED

--- a/libraries/AP_EFI/AP_EFI_Serial_EcoEFI.h
+++ b/libraries/AP_EFI/AP_EFI_Serial_EcoEFI.h
@@ -1,0 +1,78 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "AP_EFI.h"
+#include "AP_EFI_Backend.h"
+
+class AP_EFI_Serial_EcoEFI: public AP_EFI_Backend {
+
+public:
+    // Constructor with initialization
+    AP_EFI_Serial_EcoEFI(AP_EFI &_frontend);
+
+    // Update the state structure
+    void update() override;
+
+private:
+
+    AP_HAL::UARTDriver *uart;
+
+    struct PACKED EcoEFIPacket {
+        uint8_t headermagic1;
+        uint8_t headermagic2;
+        uint8_t headermagic3;
+        uint8_t data_field_length;
+        uint8_t service_id;
+        uint8_t timestamp;
+        uint16_t RPM;
+        uint16_t MAP;
+        uint16_t TPS;
+        uint16_t ECT;
+        uint16_t IAT;
+        uint16_t O2S;
+        uint16_t SPARK;
+        uint16_t FUELPW1;
+        uint16_t FUELPW2;
+        uint16_t UbAdc;
+        uint8_t FuelLvl;
+        uint16_t BARO;
+        uint16_t Field_Consumption;
+        uint8_t checksum;
+    };
+    assert_storage_size<EcoEFIPacket, 32> _assert_storage_size_EcoEFIPacket;
+
+    union EcoEFIUnion {
+        uint8_t parse_buffer[32];
+        struct EcoEFIPacket packet;
+    };
+    assert_storage_size<EcoEFIUnion, 32> _assert_storage_size_EcoEFIUnion;
+
+    EcoEFIUnion u;
+
+    uint8_t body_length;
+
+    // move the expected header bytes into &buffer[0], adjusting
+    // body_length as appropriate.
+    void move_header_in_buffer(uint8_t initial_offset);
+
+    // the datasheet specifies *all* of these as constants.  5 magic
+    // bytes seems a bit much :-)
+    static constexpr uint8_t HEADER_MAGIC1 = 0x80;
+    static constexpr uint8_t HEADER_MAGIC2 = 0x8F;
+    static constexpr uint8_t HEADER_MAGIC3 = 0xEA;
+    static constexpr uint8_t DATA_FIELD_LENGTH = 0x1B;
+    static constexpr uint8_t SERVICE_ID = 0x50;
+};

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -63,6 +63,9 @@ SITL::SerialDevice *SITL_State_Common::create_serial_sim(const char *name, const
         }
         benewake_tfmini = new SITL::RF_Benewake_TFmini();
         return benewake_tfmini;
+    } else if (streq(name, "ecoefi")) {
+        sitl_model->set_ecoefi(&_sitl->ecoefi_sim);
+        return _sitl->ecoefi_sim;
     } else if (streq(name, "nooploop_tofsense")) {
         if (nooploop != nullptr) {
             AP_HAL::panic("Only one nooploop_tofsense at a time");

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1006,6 +1006,11 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
         fetteconewireesc->update(*this);
     }
 
+    // update EcoTrons EFI
+    if (ecoefi) {
+        ecoefi->update(input);
+    }
+
 #if AP_SIM_SHIP_ENABLED
     sitl->shipsim.update();
 #endif

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -31,6 +31,7 @@
 #include "SIM_Precland.h"
 #include "SIM_RichenPower.h"
 #include "SIM_FETtecOneWireESC.h"
+#include "SIM_EcoEFI.h"
 #include "SIM_I2C.h"
 #include "SIM_Buzzer.h"
 #include "SIM_Battery.h"
@@ -143,6 +144,7 @@ public:
     void set_richenpower(RichenPower *_richenpower) { richenpower = _richenpower; }
     void set_fetteconewireesc(FETtecOneWireESC *_fetteconewireesc) { fetteconewireesc = _fetteconewireesc; }
     void set_ie24(IntelligentEnergy24 *_ie24) { ie24 = _ie24; }
+    void set_ecoefi(EcoEFI *_ecoefi) { ecoefi = _ecoefi; }
     void set_gripper_servo(Gripper_Servo *_gripper) { gripper = _gripper; }
     void set_gripper_epm(Gripper_EPM *_gripper_epm) { gripper_epm = _gripper_epm; }
     void set_precland(SIM_Precland *_precland);
@@ -327,6 +329,7 @@ private:
     LowPassFilterFloat servo_filter[5];
 
     Buzzer *buzzer;
+    EcoEFI *ecoefi;
     Sprayer *sprayer;
     Gripper_Servo *gripper;
     Gripper_EPM *gripper_epm;

--- a/libraries/SITL/SIM_EcoEFI.cpp
+++ b/libraries/SITL/SIM_EcoEFI.cpp
@@ -1,0 +1,95 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the EcoEFI ECU
+*/
+
+#include <AP_Math/AP_Math.h>
+
+#include "SIM_EcoEFI.h"
+#include "SITL.h"
+#include <AP_HAL/utility/sparse-endian.h>
+
+#include <stdio.h>
+#include <errno.h>
+
+using namespace SITL;
+
+// table of user settable parameters
+const AP_Param::GroupInfo EcoEFI::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: EcoEFI sim enable/disable
+    // @Description: Allows you to enable (1) or disable (0) the EcoEFI simulator
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("ENABLE", 0, EcoEFI, _enabled, 0),
+
+    AP_GROUPEND
+};
+
+EcoEFI::EcoEFI() : SerialDevice::SerialDevice()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+
+    u.packet.headermagic1 = 0x80;
+    u.packet.headermagic2 = 0x8F;
+    u.packet.headermagic3 = 0xEA;
+    u.packet.data_field_length = 0x1B;
+    u.packet.service_id = 0x50;
+}
+
+void EcoEFI::update(const struct sitl_input &input)
+{
+    update_send();
+}
+
+#include <stdio.h>
+
+void EcoEFI::EcoEFIUnion::update_checksum()
+{
+    packet.checksum = 0;
+    for (uint8_t i=0; i<ARRAY_SIZE(u.parse_buffer)-1; i++) {
+        packet.checksum += parse_buffer[i];
+    }
+}
+
+void EcoEFI::update_send()
+{
+    auto sitl = AP::sitl();
+    if (sitl == nullptr || sitl->efi_type == SITL::EFI_TYPE_NONE) {
+        return;
+    }
+
+    // just send a chunk of data at 10Hz:
+    const uint32_t now = AP_HAL::millis();
+    if (now - last_sent_ms < 100) {
+        return;
+    }
+    last_sent_ms = now;
+
+    u.packet.timestamp += 1;
+    u.packet.RPM = htobe16(sitl->state.rpm[0] * 0.25);
+    u.packet.MAP = htobe16(AP::baro().get_pressure()/1000.0*0.9 * (1/0.0039));
+    u.packet.TPS = htobe16(17 * (1/0.0015));
+    u.packet.ECT = htobe16((15.0 +40) * (1/1.25));
+    u.packet.IAT = htobe16((26.0 +40) * (1/1.25));
+    u.packet.BARO = htobe16(AP::baro().get_pressure()/1000.0 * (1/0.0039));
+    u.update_checksum();
+
+    if (write_to_autopilot((char*)u.parse_buffer, ARRAY_SIZE(u.parse_buffer)) != ARRAY_SIZE(u.parse_buffer)) {
+        AP_HAL::panic("Failed to write to autopilot: %s", strerror(errno));
+    }
+}

--- a/libraries/SITL/SIM_EcoEFI.h
+++ b/libraries/SITL/SIM_EcoEFI.h
@@ -1,0 +1,93 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the EcoEFI Serial connection
+
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:ecoefi --speedup=1 --console
+
+param set SERIAL5_PROTOCOL 32
+param set EFI_TYPE 2
+
+reboot
+
+*/
+
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+
+#include "SITL_Input.h"
+
+#include "SIM_SerialDevice.h"
+
+#include <stdio.h>
+
+namespace SITL {
+
+class EcoEFI : public SerialDevice {
+public:
+
+    EcoEFI();
+
+    // update state
+    void update(const struct sitl_input &input);
+
+    static const AP_Param::GroupInfo var_info[];
+
+private:
+
+    void update_send();
+
+    AP_Int8  _enabled;  // enable richenpower sim
+
+    // packet to send:
+    struct PACKED EcoEFIPacket {
+        uint8_t headermagic1;
+        uint8_t headermagic2;
+        uint8_t headermagic3;
+        uint8_t data_field_length;
+        uint8_t service_id;
+        uint8_t timestamp;
+        uint16_t RPM;
+        uint16_t MAP;
+        uint16_t TPS;
+        uint16_t ECT;
+        uint16_t IAT;
+        uint16_t O2S;
+        uint16_t SPARK;
+        uint16_t FUELPW1;
+        uint16_t FUELPW2;
+        uint16_t UbAdc;
+        uint8_t FuelLvl;
+        uint16_t BARO;
+        uint16_t Field_Consumption;
+        uint8_t checksum;
+    };
+    assert_storage_size<EcoEFIPacket, 32> _assert_storage_size_EcoEFIPacket;
+
+    union EcoEFIUnion {
+        uint8_t parse_buffer[32];
+        struct EcoEFIPacket packet;
+
+        void update_checksum();
+    };
+    assert_storage_size<EcoEFIUnion, 32> _assert_storage_size_EcoEFIUnion;
+
+    EcoEFIUnion u;
+
+    uint32_t last_sent_ms;
+};
+
+}

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -12,6 +12,7 @@
 #include <AP_Compass/AP_Compass.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #include "SIM_Buzzer.h"
+#include "SIM_EcoEFI.h"
 #include "SIM_Gripper_EPM.h"
 #include "SIM_Gripper_Servo.h"
 #include "SIM_I2C.h"
@@ -454,6 +455,8 @@ public:
         uint8_t num_leds[16];
         uint32_t send_counter;
     } led;
+
+    EcoEFI ecoefi_sim;
 
     AP_Int8 led_layout;
 


### PR DESCRIPTION
This currently has a debug commit on top on the assumption that I haven't gotten the protocol correct ATM.

Adds simulator for same.

Only RPM is taken from the EFI packet ATM.
