### PR TITLE
Copter: Check the number of motors

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -406,7 +406,7 @@ bool AP_Arming_Copter::motor_count_check()
         }
     }
 
-    printf("### motorNum %d motorCount %d\n", motorNum, motorCount);
+    // printf("### motorNum %d motorCount %d\n", motorNum, motorCount); // for debug message
     if (motorNum != motorCount) {
         return false;
     }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -304,7 +304,7 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
         return true;
     }
 
-    // 
+    // Check the number of motors in the frame and the number of motors in the servo.
     if (!motor_count_check()) {
         check_failed(display_failure, "check SERVOx_FUNCTION Motor x");
         return false;
@@ -415,7 +415,7 @@ bool AP_Arming_Copter::motor_count_check()
 
 bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
 {
-    // check throttle is above failsafe thbarometer_checksrottle
+    // check throttle is above failsafe throttle
     // this is near the bottom to allow other failures to be displayed before checking pilot throttle
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
         if (copter.g.failsafe_throttle != FS_THR_DISABLED && copter.channel_throttle->get_radio_in() < copter.g.failsafe_throttle_value) {

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -46,6 +46,7 @@ protected:
     // NOTE! the following check functions *DO NOT* call into AP_Arming!
     bool parameter_checks(bool display_failure);
     bool motor_checks(bool display_failure);
+    bool motor_count_check(void);
     bool pilot_throttle_checks(bool display_failure);
     bool oa_checks(bool display_failure);
     bool mandatory_gps_checks(bool display_failure);

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -283,6 +283,26 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
         return;
     }
 
+    // Check SERVO1_FUNCTION - SERVO16_FUNCTION
+    for (int8_t i = 1; i <= NUM_SERVO_CHANNELS; ++i) {
+        char buf[17];
+        memset(buf, 0, sizeof(buf));
+        hal.util->snprintf(buf, sizeof(buf), "SERVO%d_FUNCTION", i);
+        if (strncmp(key, buf, 16) == 0) {
+            if ((old_value >= 33.0f && old_value <= 40.0f) || (old_value >= 82.0f && old_value <= 85.0f)) {
+                // now motor
+                if (is_negative(packet.param_value)) {
+                    break;
+                } else {
+                    printf("### %s is motor and set value not -1\n", buf);
+                    return;
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
     // set the value
     vp->set_float(packet.param_value, var_type);
 

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -294,7 +294,7 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
                 if (!hal.util->get_soft_armed()) {
                     break;
                 } else {
-                    printf("### %s is a motor and currently arming\n", buf);
+                    // printf("### %s is a motor and currently arming\n", buf);  // for debug message
                     return;
                 }
             } else {

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -291,10 +291,10 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
         if (strncmp(key, buf, 16) == 0) {
             if ((old_value >= 33.0f && old_value <= 40.0f) || (old_value >= 82.0f && old_value <= 85.0f)) {
                 // now motor
-                if (is_negative(packet.param_value)) {
+                if (!hal.util->get_soft_armed()) {
                     break;
                 } else {
-                    printf("### %s is motor and set value not -1\n", buf);
+                    printf("### %s is a motor and currently arming\n", buf);
                     return;
                 }
             } else {


### PR DESCRIPTION
I would suggest checking when setting the gimbal to resolve #14994.
I would suggest prioritizing the motor settings.
I have a gimbal setting on the APM PLANNER 2 that requires the servo setting to the FC each time I select a servo.
I set a negative value if the servo is already set on the motor and then enable the servo re-set.
I first made a decision on the DISABLED. This was used to override the earlier setting.