### PR TITLE
AP_Scripting/Rover: support Lua motor drivers

### DIFF
--- a/Rover/AP_MotorsUGV.h
+++ b/Rover/AP_MotorsUGV.h
@@ -60,7 +60,8 @@ public:
     float get_throttle() const { return _throttle; }
     void set_throttle(float throttle);
 
-    // set lateral input as a value from -100 to +100
+    // get or set lateral input as a value from -100 to +100
+    float get_lateral() const { return _lateral; }
     void set_lateral(float lateral);
 
     // set or get mainsail input as a value from 0 to 100

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -180,6 +180,32 @@ bool Rover::set_steering_and_throttle(float steering, float throttle)
     return true;
 }
 
+// get control output (for use in scripting)
+// returns true on success and control_value is set to a value in the range -1 to +1
+bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value)
+{
+    switch (control_output) {
+    case AP_Vehicle::ControlOutput::Throttle:
+        control_value = constrain_float(g2.motors.get_throttle() / 100.0f, -1.0f, 1.0f);
+        return true;
+    case AP_Vehicle::ControlOutput::Yaw:
+        control_value = constrain_float(g2.motors.get_steering() / 4500.0f, -1.0f, 1.0f);
+        return true;
+    case AP_Vehicle::ControlOutput::Lateral:
+        control_value = constrain_float(g2.motors.get_lateral() / 100.0f, -1.0f, 1.0f);
+        return true;
+    case AP_Vehicle::ControlOutput::MainSail:
+        control_value = constrain_float(g2.motors.get_mainsail() / 100.0f, -1.0f, 1.0f);
+        return true;
+    case AP_Vehicle::ControlOutput::WingSail:
+        control_value = constrain_float(g2.motors.get_wingsail() / 100.0f, -1.0f, 1.0f);
+        return true;
+    default:
+        return false;
+    }
+    return false;
+}
+
 #if STATS_ENABLED == ENABLED
 /*
   update AP_Stats

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -276,6 +276,7 @@ private:
     bool set_target_location(const Location& target_loc) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_steering_and_throttle(float steering, float throttle) override;
+    bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) override;
     void stats_update();
     void ahrs_update();
     void gcs_failsafe_check(void);

--- a/libraries/AP_Scripting/examples/rover-motor-driver.lua
+++ b/libraries/AP_Scripting/examples/rover-motor-driver.lua
@@ -1,0 +1,40 @@
+-- Rover motor driver for an Ackerman style vehicle (i.e. the frame has separate throttle and steering controls)
+--
+-- The following parameters should be set:
+--     SERVO1_FUNCTION = 94 (Script 1) 
+--     SERVO3_FUNCTION = 96 (Script 3)
+-- 
+-- The Frame's steering control should be connected to the autopilot's output1, throttle control to output3
+--
+-- CAUTION: This script only works for Rover
+-- This script retrieves the high level controller outputs that have been sent to the regular motor driver
+-- and then outputs them to the "Script 1" and "Script 3" outputs.  This does not add any real value beyond
+-- serving as an example of how lua scripts can be used to implement a custom motor driver 
+
+local K_SCRIPTING1 = 94 -- for steering control
+local K_SCRIPTING3 = 96 -- for throttle control
+local CONTROL_OUTPUT_THROTTLE = 3
+local CONTROL_OUTPUT_YAW = 4
+
+function update()
+  if not arming:is_armed() then
+    -- if not armed move steering and throttle to mid
+    SRV_Channels:set_output_norm(K_SCRIPTING1, 0)
+    SRV_Channels:set_output_norm(K_SCRIPTING3, 0)
+  else
+    -- retrieve high level steering and throttle control outputs from vehicle in -1 to +1 range
+    local steering = vehicle:get_control_output(CONTROL_OUTPUT_YAW)
+    local throttle = vehicle:get_control_output(CONTROL_OUTPUT_THROTTLE)
+    if (steering and throttle) then
+      if throttle < 0 then
+          steering = -steering
+      end
+      SRV_Channels:set_output_norm(K_SCRIPTING1, steering)
+      SRV_Channels:set_output_norm(K_SCRIPTING3, throttle)
+    end
+  end
+  return update, 10 -- run at 100hz
+end
+
+gcs:send_text(6, "rover-motor-driver.lua is running")
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -202,6 +202,8 @@ singleton SRV_Channels method set_output_scaled void SRV_Channel::Aux_servo_func
 singleton SRV_Channels method get_output_pwm boolean SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'Null
 singleton SRV_Channels method get_output_scaled int16_t SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1
 singleton SRV_Channels method set_output_norm void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 float -1 1
+singleton SRV_Channels method set_angle void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t 0 UINT16_MAX
+singleton SRV_Channels method set_range void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t 0 UINT16_MAX
 
 ap_object RC_Channel method norm_input float
 ap_object RC_Channel method get_aux_switch_pos uint8_t

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -179,7 +179,7 @@ singleton AP_Vehicle method get_likely_flying boolean
 singleton AP_Vehicle method get_time_flying_ms uint32_t
 singleton AP_Vehicle method start_takeoff boolean float (-LOCATION_ALT_MAX_M*100+1) (LOCATION_ALT_MAX_M*100-1)
 singleton AP_Vehicle method set_target_location boolean Location
-singleton AP_Vehicle method get_control_output boolean AP_Vehicle::ControlOutput'enum AP_Vehicle::ControlOutput::Roll AP_Vehicle::ControlOutput::Last_ControlOutput float'Null
+singleton AP_Vehicle method get_control_output boolean AP_Vehicle::ControlOutput'enum AP_Vehicle::ControlOutput::Roll ((uint32_t)AP_Vehicle::ControlOutput::Last_ControlOutput-1) float'Null
 singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f
 singleton AP_Vehicle method set_target_angle_and_climbrate boolean float -180 180 float -90 90 float -360 360 float -FLT_MAX FLT_MAX boolean float -FLT_MAX FLT_MAX

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -201,7 +201,7 @@ singleton SRV_Channels method set_output_pwm_chan_timeout void uint8_t 0 NUM_SER
 singleton SRV_Channels method set_output_scaled void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 int16_t INT16_MIN INT16_MAX
 singleton SRV_Channels method get_output_pwm boolean SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'Null
 singleton SRV_Channels method get_output_scaled int16_t SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1
-
+singleton SRV_Channels method set_output_norm void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 float -1 1
 
 ap_object RC_Channel method norm_input float
 ap_object RC_Channel method get_aux_switch_pos uint8_t

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -179,6 +179,7 @@ singleton AP_Vehicle method get_likely_flying boolean
 singleton AP_Vehicle method get_time_flying_ms uint32_t
 singleton AP_Vehicle method start_takeoff boolean float (-LOCATION_ALT_MAX_M*100+1) (LOCATION_ALT_MAX_M*100-1)
 singleton AP_Vehicle method set_target_location boolean Location
+singleton AP_Vehicle method get_control_output boolean AP_Vehicle::ControlOutput'enum AP_Vehicle::ControlOutput::Roll AP_Vehicle::ControlOutput::Last_ControlOutput float'Null
 singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f
 singleton AP_Vehicle method set_target_angle_and_climbrate boolean float -180 180 float -90 90 float -360 360 float -FLT_MAX FLT_MAX boolean float -FLT_MAX FLT_MAX

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -183,6 +183,22 @@ public:
     // set steering and throttle (-1 to +1) (for use by scripting with Rover)
     virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
 
+    // control outputs enumeration
+    enum class ControlOutput {
+        Roll = 1,
+        Pitch = 2,
+        Throttle = 3,
+        Yaw = 4,
+        Lateral = 5,
+        MainSail = 6,
+        WingSail = 7,
+        Last_ControlOutput  // place new values before this
+    };
+
+    // get control output (for use in scripting)
+    // returns true on success and control_value is set to a value in the range -1 to +1
+    virtual bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) { return false; }
+
     // write out harmonic notch log messages
     void write_notch_log_messages() const;
     // update the harmonic notch

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -171,7 +171,7 @@ float SRV_Channel::get_output_norm(void)
         ret = 0;
     }
     if (get_reversed()) {
-           ret = -ret;
+        ret = -ret;
     }
     return ret;
 }

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -137,6 +137,17 @@ void SRV_Channel::set_output_pwm(uint16_t pwm, bool force)
     }
 }
 
+// set normalised output from -1 to 1, assuming 0 at mid point of servo_min/servo_max
+void SRV_Channel::set_output_norm(float value)
+{
+    // convert normalised value to pwm
+    if (type_angle) {
+        set_output_pwm(pwm_from_angle(value * high_out));
+    } else {
+        set_output_pwm(pwm_from_range(value * high_out));
+    }
+}
+
 // set angular range of scaled output
 void SRV_Channel::set_angle(int16_t angle)
 {

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -277,7 +277,7 @@ private:
     // return PWM for a given limit value
     uint16_t get_limit_pwm(Limit limit) const;
 
-    // get normalised output from -1 to 1
+    // get normalised output from -1 to 1, assuming 0 at mid point of servo_min/servo_max
     float get_output_norm(void);
 
     // a bitmask type wide enough for NUM_SERVO_CHANNELS
@@ -337,8 +337,8 @@ public:
     // get pwm output for the first channel of the given function type.
     static bool get_output_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t &value);
 
-    // get normalised output (-1 to 1 for angle, 0 to 1 for range). Value is taken from pwm value
-    // return zero on error.
+    // get normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max)
+    // Value is taken from pwm value.  Returns zero on error.
     static float get_output_norm(SRV_Channel::Aux_servo_function_t function);
 
     // get output channel mask for a function

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -174,6 +174,9 @@ public:
     // get the output value as a pwm value
     uint16_t get_output_pwm(void) const { return output_pwm; }
 
+    // set normalised output from -1 to 1, assuming 0 at mid point of servo_min/servo_max
+    void set_output_norm(float value);
+
     // set angular range of scaled output
     void set_angle(int16_t angle);
 
@@ -340,6 +343,9 @@ public:
     // get normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max)
     // Value is taken from pwm value.  Returns zero on error.
     static float get_output_norm(SRV_Channel::Aux_servo_function_t function);
+
+    // set normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max) for the given function
+    static void set_output_norm(SRV_Channel::Aux_servo_function_t function, float value);
 
     // get output channel mask for a function
     static uint16_t get_output_channel_mask(SRV_Channel::Aux_servo_function_t function);

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -124,6 +124,22 @@ void SRV_Channel::aux_servo_function_setup(void)
     case k_elevon_right:
     case k_vtail_left:
     case k_vtail_right:
+    case k_scripting1:
+    case k_scripting2:
+    case k_scripting3:
+    case k_scripting4:
+    case k_scripting5:
+    case k_scripting6:
+    case k_scripting7:
+    case k_scripting8:
+    case k_scripting9:
+    case k_scripting10:
+    case k_scripting11:
+    case k_scripting12:
+    case k_scripting13:
+    case k_scripting14:
+    case k_scripting15:
+    case k_scripting16:
     case k_roll_out:
     case k_pitch_out:
     case k_yaw_out:

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -641,6 +641,20 @@ float SRV_Channels::get_output_norm(SRV_Channel::Aux_servo_function_t function)
     return channels[chan].get_output_norm();
 }
 
+// set normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max) for the given function
+void SRV_Channels::set_output_norm(SRV_Channel::Aux_servo_function_t function, float value)
+{
+    if (!function_assigned(function)) {
+        return;
+    }
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+        SRV_Channel &c = channels[i];
+        if (c.function == function) {
+            c.set_output_norm(value);
+        }
+    }
+}
+
 /*
   limit slew rate for an output function to given rate in percent per
   second. This assumes output has not yet done to the hal


### PR DESCRIPTION
This PR includes part of the walking robots PR https://github.com/ArduPilot/ardupilot/pull/14884 but is smaller allowing it to be more easily merged.

Similar to @IamPete1's PR https://github.com/ArduPilot/ardupilot/pull/14552, the controversial part of this change is exposing set_angle and set_range to scripting.  The request to add set_output_norm() is not straightforward though and becomes a significant blocker for the walking robots GSoC project.

This PR allows Lua scripts to implement motor drivers for Rovers.  The changes include:

- AP_Vehicle gets a new "get_control_output" function that allows the caller to retrieve the high level outputs of the controllers (attitude, steering, etc) in the range of -1 to +1
- Rover implements "get_control_output" for yaw (aka Steering) and throttle. In the case of Rover these control outputs are held within the Motors library as inputs.  I.e. retrieving the input from the motors library is the same as retrieving the outputs from the controllers.
- AP_Script gets bindings for AP_Vehicle's get_control_output
- AP_Script gets bindings for SRV_Channels's set_angle and set_range
- A new example script is added to AP_Scripting which demonstrates that this all works for a simple ackerman steering vehicle.  Below is a screen shot of the rover driving around successfully

![image](https://user-images.githubusercontent.com/1498098/89699747-ea0e0b00-d963-11ea-8c56-b8a30c0fd53d.png)

This has been tested in SITL by comparing the regular motor driver's outputs to throttle and steering channels to the scripts outputs for script1 and script3 and the outputs were identical.
