### PR TITLE
AP_Scripting: Fixing the warnings of the luacheck tool

### DIFF
--- a/libraries/AP_Scripting/examples/rangefinder_test.lua
+++ b/libraries/AP_Scripting/examples/rangefinder_test.lua
@@ -25,7 +25,8 @@ function info(rotation)
   local offset = rangefinder:get_pos_offset_orient(rotation)
   local distance_cm = rangefinder:distance_cm_orient(rotation)
 
-  gcs:send_text(0, string.format("Ratation %d %.0f cm range %d - %d offset %.0f %.0f %.0f ground clearance %.0f", rotation, distance_cm, distance_min, distance_max, offset:x(), offset:y(), offset:z(), ground_clearance))
+  gcs:send_text(0, string.format("Ratation %d %.0f cm range %d - %d offset %.0f %.0f %.0f ground clearance %.0f", 
+    rotation, distance_cm, distance_min, distance_max, offset:x(), offset:y(), offset:z(), ground_clearance))
 end
 
 return update(), 1000 -- first message may be displayed 1 seconds after start-up

--- a/libraries/AP_Scripting/examples/set-target-velocity.lua
+++ b/libraries/AP_Scripting/examples/set-target-velocity.lua
@@ -80,7 +80,8 @@ function update()
 
           -- send velocity request
           if (vehicle:set_target_velocity_NED(target_vel)) then   -- send target velocity to vehicle
-            gcs:send_text(0, "pos:" .. tostring(math.floor(dist_NE:x())) .. "," .. tostring(math.floor(dist_NE:y())) .. " sent vel x:" .. tostring(target_vel:x()) .. " y:" .. tostring(target_vel:y()))
+            gcs:send_text(0, "pos:" .. tostring(math.floor(dist_NE:x())) .. "," .. tostring(math.floor(dist_NE:y())) .. 
+              " sent vel x:" .. tostring(target_vel:x()) .. " y:" .. tostring(target_vel:y()))
           else
             gcs:send_text(0, "failed to execute velocity command")
           end


### PR DESCRIPTION
I will resolve #15011.

I used the LUACHECK tool to check the AP_Scripting examples.
I found warnings in two files that exceeded 120 characters per line in length.
I think that if ArduPilot's LUA is standard, it should be less than 120 characters.