### PR TITLE
AP_Param: minor compile warning fix when AP_PARAM_KEY_DUMP=1

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2556,7 +2556,7 @@ void AP_Param::show_all(AP_HAL::BetterStream *port, bool showKeyValues)
          ap;
          ap=AP_Param::next_scalar(&token, &type)) {
         if (showKeyValues) {
-            port->printf("Key %i: Index %i: GroupElement %i  :  ", token.key, token.idx, token.group_element);
+            port->printf("Key %u: Index %u: GroupElement %u  :  ", (unsigned)token.key, (unsigned)token.idx, (unsigned)token.group_element);
         }
         show(ap, token, type, port);
         hal.scheduler->delay(1);

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -292,7 +292,7 @@ public:
     /// gat a value by name, used by scripting
     ///
     /// @param  name            The full name of the variable to be found.
-    /// @param  value           A refernce to the variable
+    /// @param  value           A reference to the variable
     /// @return                 true if the variable is found
     static bool get(const char *name, float &value);
 


### PR DESCRIPTION
This PR removes some compiler warning (or errors) when developers enable the dumping of parameter keys to the GCS.

For some reason I found builds on my Windows machine of master (with this definition set) would fail while they would succeed on my Ubuntu 14.04 virtual machine.  In any case, I think it's a small improvement.

I've tested on SITL and all the parameter keys are being displayed after this change is made.

Here's the original compile error I was seeing.

../../libraries/AP_Param/AP_Param.cpp: In static member function 'static void AP_Param::show_all(AP_HAL::BetterStream*, bool)':
../../libraries/AP_Param/AP_Param.cpp:2559:109: error: format '%i' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Werror=format=]
             port->printf("Key %i: Index %i: GroupElement %i  :  ", token.key, token.idx, token.group_element);
                                                                                                             ^
compilation terminated due to -Wfatal-errors.
cc1plus.exe: some warnings being treated as errors
