### PR TITLE
AP_NavEKF3: correct ext nav for sensor offset after recall

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1364,7 +1364,7 @@ private:
 
     // external navigation fusion
     obs_ring_buffer_t<ext_nav_elements> storedExtNav; // external navigation data buffer
-    ext_nav_elements extNavDataDelayed; // External nav at the fusion time horizon
+    ext_nav_elements extNavDataDelayed; // External nav at the fusion time horizon. Already corrected for sensor position
     uint32_t extNavMeasTime_ms;         // time external measurements were accepted for input to the data buffer (msec)
     uint32_t extNavLastPosResetTime_ms; // last time the external nav systen performed a position reset (msec)
     bool extNavDataToFuse;              // true when there is new external nav data to fuse


### PR DESCRIPTION
Currently, ext nav data need to corrected for sensor offset in ResetPosition(), while ext nav vel do not need to do so in ResetVelocity() (it is corrected after it is recalled). Maybe we could do it in a coherent way? Always corrected it after it is recalled from buffer.