### PR TITLE
Tools: remove duplicated parameters to be setted back

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2890,7 +2890,9 @@ class AutoTest(ABC):
             if abs(delta) < epsilon:
                 # yes, near-enough-to-equal.
                 if add_to_context:
-                    self.context_get().parameters.append((name, old_value))
+                    context_param_name_list = [p[0] for p in self.context_get().parameters]
+                    if name.upper() not in context_param_name_list:
+                        self.context_get().parameters.append((name, old_value))
                 if self.should_fetch_all_for_parameter_change(name.upper()) and value != 0:
                     self.fetch_parameters()
                 return
@@ -2929,7 +2931,6 @@ class AutoTest(ABC):
     def context_pop(self):
         """Set parameters to origin values in reverse order."""
         dead = self.contexts.pop()
-
         dead_parameters = dead.parameters
         dead_parameters.reverse()
         for p in dead_parameters:


### PR DESCRIPTION
Example on Copter.ThrottleFailsafe,
we pass from :
`
[('DISARM_DELAY', 10.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('DISARM_DELAY', 0.0), ('FS_THR_ENABLE', 1.0), ('FS_OPTIONS', 0.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_THR_ENABLE', 0.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_THR_ENABLE', 1.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_THR_ENABLE', 3.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_THR_ENABLE', 4.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_THR_ENABLE', 5.0), ('SIM_GPS_DISABLE', 0.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('SIM_GPS_DISABLE', 1.0), ('FS_THR_ENABLE', 1.0), ('SIM_GPS_DISABLE', 0.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('SIM_GPS_DISABLE', 1.0), ('FS_THR_ENABLE', 4.0), ('SIM_GPS_DISABLE', 0.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('SIM_GPS_DISABLE', 1.0), ('FS_THR_ENABLE', 5.0), ('SIM_GPS_DISABLE', 0.0), ('SIM_GPS_DISABLE', 1.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_THR_ENABLE', 4.0), ('SIM_GPS_DISABLE', 0.0), ('SIM_GPS_DISABLE', 1.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('SIM_SPEEDUP', 8.0), ('FS_GCS_ENABLE', 0.0), ('FS_THR_ENABLE', 5.0), ('FS_OPTIONS', 0.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_GCS_ENABLE', 1.0), ('SIM_SPEEDUP', 4.0), ('FS_OPTIONS', 4.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_OPTIONS', 1.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('FS_THR_ENABLE', 1.0)]`

to 
`
[('DISARM_DELAY', 10.0), ('SIM_RC_FAIL', 0.0), ('SIM_RC_FAIL', 1.0), ('DISARM_DELAY', 0.0), ('FS_THR_ENABLE', 1.0), ('FS_OPTIONS', 0.0), ('FS_THR_ENABLE', 0.0), ('FS_THR_ENABLE', 3.0), ('FS_THR_ENABLE', 4.0), ('FS_THR_ENABLE', 5.0), ('SIM_GPS_DISABLE', 0.0), ('SIM_GPS_DISABLE', 1.0), ('SIM_SPEEDUP', 8.0), ('FS_GCS_ENABLE', 0.0), ('FS_GCS_ENABLE', 1.0), ('SIM_SPEEDUP', 4.0), ('FS_OPTIONS', 4.0), ('FS_OPTIONS', 1.0)]`

This save us a large amount of time : 
Master : real 138,58s user 42,47s system 88% cpu 3:25,12 total
PR : real 128,33s user 38,58s system 88% cpu 3:08,02 total
