### PR TITLE
AP_NavEKF3: move extNavVelNew to local variable

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1012,13 +1012,15 @@ void NavEKF3_core::writeExtNavVelData(const Vector3f &vel, float err, uint32_t t
 
     extNavVelMeasTime_ms = timeStamp_ms - delay_ms;
     useExtNavVel = true;
-    extNavVelNew.vel = vel;
-    extNavVelNew.err = err;
     // Correct for the average intersampling delay due to the filter updaterate
     timeStamp_ms -= localFilterTimeStep_ms/2;
     // Prevent time delay exceeding age of oldest IMU data in the buffer
     timeStamp_ms = MAX(timeStamp_ms,imuDataDelayed.time_ms);
-    extNavVelNew.time_ms = timeStamp_ms;
+    const ext_nav_vel_elements extNavVelNew {
+        vel,
+        err,
+        timeStamp_ms
+    };
     storedExtNavVel.push(extNavVelNew);
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -416,7 +416,6 @@ void NavEKF3_core::InitialiseVariables()
     extNavLastPosResetTime_ms = 0;
     extNavDataToFuse = false;
     extNavUsedForPos = false;
-    extNavVelNew = {};
     extNavVelDelayed = {};
     extNavVelToFuse = false;
     useExtNavVel = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1370,7 +1370,6 @@ private:
     bool extNavDataToFuse;              // true when there is new external nav data to fuse
     bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.
     obs_ring_buffer_t<ext_nav_vel_elements> storedExtNavVel;    // external navigation velocity data buffer
-    ext_nav_vel_elements extNavVelNew;  // external navigation velocity data at the current time horizon
     ext_nav_vel_elements extNavVelDelayed;  // external navigation velocity data at the fusion time horizon.  Already corrected for sensor position
     uint32_t extNavVelMeasTime_ms;      // time external navigation velocity measurements were accepted for input to the data buffer (msec)
     bool extNavVelToFuse;               // true when there is new external navigation velocity to fuse


### PR DESCRIPTION
extNavVelNew is only used in writeExtNavVelData(). Myabe it would be better to move it to local variable, just like what we already done for extNavDataNew 
https://github.com/ArduPilot/ardupilot/blob/eb4b5fb720aaa97043ad0838e33372cf6c5aa99b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp#L967