### PR TITLE
ICE: Debounce start channel, and have a min PWM

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -171,7 +171,7 @@ void AP_ICEngine::update(void)
         // while ignoring tiny noise
         if (cvalue >= 1700) {
             cvalue = 2000;
-        } else if (cvalue <= 1300) {
+        } else if ((cvalue > 800) && (cvalue <= 1300)) {
             cvalue = 1300;
         } else {
             cvalue = 1500;

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -169,7 +169,7 @@ void AP_ICEngine::update(void)
 
     uint16_t cvalue = 1500;
     RC_Channel *c = rc().channel(start_chan-1);
-    if (c != nullptr) {
+    if (c != nullptr && rc().has_valid_input()) {
         // get starter control channel
         cvalue = c->get_radio_in();
 
@@ -357,7 +357,7 @@ bool AP_ICEngine::engine_control(float start_control, float cold_start, float he
         return true;
     }
     RC_Channel *c = rc().channel(start_chan-1);
-    if (c != nullptr) {
+    if (c != nullptr && rc().has_valid_input()) {
         // get starter control channel
         uint16_t cvalue = c->get_radio_in();
         if (cvalue >= start_chan_min_pwm && cvalue <= 1300) {

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -123,7 +123,7 @@ private:
     AP_Int16 options;
 
     // start_chan debounce
-    uint16_t start_chan_last_value;
+    uint16_t start_chan_last_value = 1500;
     uint32_t start_chan_last_ms;
 };
 

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -66,6 +66,9 @@ private:
     // channel for pilot to command engine start, 0 for none
     AP_Int8 start_chan;
 
+    // min pwm on start channel for engine stop
+    AP_Int16 start_chan_min_pwm;
+    
     // which RPM instance to use
     AP_Int8 rpm_instance;
     

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -121,6 +121,10 @@ private:
         DISABLE_IGNITION_RC_FAILSAFE=(1U<<0),
     };
     AP_Int16 options;
+
+    // start_chan debounce
+    uint16_t start_chan_last_value;
+    uint32_t start_chan_last_ms;
 };
 
 


### PR DESCRIPTION
This combines some work that @magicrub  has done for debouncing the start channel with a new parameter that sets a min PWM for the start channel. This results in more robust operation on loss of RC link
