### PR TITLE
AP_NavEKF3: fix ext nav vel timestamp cal

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1010,8 +1010,10 @@ void NavEKF3_core::writeExtNavVelData(const Vector3f &vel, float err, uint32_t t
         return;
     }
 
-    extNavVelMeasTime_ms = timeStamp_ms - delay_ms;
+    extNavVelMeasTime_ms = timeStamp_ms;
     useExtNavVel = true;
+    // calculate timestamp
+    timeStamp_ms = timeStamp_ms - delay_ms;
     // Correct for the average intersampling delay due to the filter updaterate
     timeStamp_ms -= localFilterTimeStep_ms/2;
     // Prevent time delay exceeding age of oldest IMU data in the buffer


### PR DESCRIPTION
I think there may be a typo here. Comparing to timestamp calculation in [writeExtNavData()](https://github.com/ArduPilot/ardupilot/blob/c722367c6c48a01260e7bf6af4edc0e513af5132/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp#L952)
https://github.com/ArduPilot/ardupilot/blob/c722367c6c48a01260e7bf6af4edc0e513af5132/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp#L979-L980

flight log 
[fix_extnav_vel_ts.zip](https://github.com/ArduPilot/ardupilot/files/5061129/fix_extnav_vel_ts.zip) kakute f7 quad
[fix_ext_nav_vel_ts2.zip](https://github.com/ArduPilot/ardupilot/files/5067528/fix_ext_nav_vel_ts2.zip) pixhawk 4 mini hexa

