### PR TITLE
GCS: fix rc override for channels > 8

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3115,8 +3115,8 @@ void GCS_MAVLINK::handle_rc_channels_override(const mavlink_message_t &msg)
     };
 
     for (uint8_t i=0; i<ARRAY_SIZE(override_data); i++) {
-        // Per MAVLink spec a value of UINT16_MAX means to ignore this field.
-        if (override_data[i] != UINT16_MAX) {
+        // Per MAVLink spec a value of UINT16_MAX means to ignore this field. For channels 9+  0 and UINT16_MAX
+        if (override_data[i] != UINT16_MAX && !(override_data[i] == 0 && i >= 8)) {
             RC_Channels::set_override(i, override_data[i], tnow);
         }
     }


### PR DESCRIPTION
mavlink spec is
RC channel 9 value. A value of 0 or UINT16_MAX means to ignore this field.  [us]

for 1-8 = UINT16_MAX  only.