### PR TITLE
AP_NavEKF3: Add cast for wheel encoder data

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -453,7 +453,7 @@ bool NavEKF3_core::readyToUseBodyOdm(void) const
     bool visoDataGood = (imuSampleTime_ms - bodyOdmMeasTime_ms < 200) && (bodyOdmDataNew.velErr < 1.0f);
 
     // Check for fresh wheel encoder data
-    bool wencDataGood = (imuSampleTime_ms - wheelOdmMeasTime_ms < 200);
+    bool wencDataGood = ((int)(imuSampleTime_ms - wheelOdmMeasTime_ms) < 200);
 
     // We require stable roll/pitch angles and gyro bias estimates but do not need the yaw angle aligned to use odometry measurements
     // because they are in a body frame of reference


### PR DESCRIPTION
This is based on the issue at https://github.com/ArduPilot/ardupilot/issues/13677:

> Relative aiding cannot be started for non-gps-navigation with wheel encoders.
> The reason is because the next line always returns false
> 
> ardupilot/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
> 
> Line 429 in c6f12e5
> ```bool wencDataGood = (imuSampleTime_ms - wheelOdmMeasTime_ms < 200); ```
> 
> Which, in turn, is because the latest wheel encoder reading wheelOdmMeasTime_ms is always a few ms fresher than the latest IMU reading imuSampleTime_ms, while the comparison is made for unsigned integers.
> Casting the difference to signed integer solves the problem
> ```bool wencDataGood = ((int)(imuSampleTime_ms - wheelOdmMeasTime_ms) < 200);```

This patch fixes the calculation so that wheel encoder data can be used for non-GPS navigation.

Tested on a Pixhawk1. Logs are below, with current master with and without the patch.

[logs.zip](https://github.com/ArduPilot/ardupilot/files/5067075/logs.zip)
