### PR TITLE
Autotest: Enfore use of our set_rc function

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -175,7 +175,7 @@ class AutoTestCopter(AutoTest):
     def takeoffAndMoveAway(self, dAlt=50, dDist=50):
         self.progress("Centering sticks")
         self.set_roll(1500)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.set_throttle(1000)
         self.set_yaw(1500)
         self.takeoff(alt_min=dAlt)
@@ -187,9 +187,9 @@ class AutoTestCopter(AutoTest):
         self.set_yaw(1500)
 
         self.progress("Fly eastbound away from home")
-        self.set_rc(2, 1800)
+        self.set_pitch(1800)
         self.delay_sim_time(10)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.hover()
         self.progress("Cotper staging 50 meters east of home at 50 meters altitude In mode Alt Hold")
 
@@ -209,9 +209,9 @@ class AutoTestCopter(AutoTest):
         self.set_yaw(1500)
 
         # fly south east 50m
-        self.set_rc(2, 1100)
+        self.set_pitch(1100)
         self.wait_distance(50)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # wait for copter to slow moving
         self.wait_groundspeed(0, 2)
@@ -262,10 +262,10 @@ class AutoTestCopter(AutoTest):
         # feed in full elevator and aileron input and make sure we
         # retain altitude:
         self.set_roll(1000)
-        self.set_rc(2, 1000)
+        self.set_pitch(1000)
         self.watch_altitude_maintained(9, 11, timeout=5)
         self.set_roll(1500)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.do_RTL()
 
     def change_alt(self, alt_min, climb_throttle=1920, descend_throttle=1080):
@@ -308,7 +308,7 @@ class AutoTestCopter(AutoTest):
 
         # ensure all sticks in the middle
         self.set_roll(1500)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.set_throttle(1500)
         self.set_yaw(1500)
 
@@ -333,9 +333,9 @@ class AutoTestCopter(AutoTest):
 
         # pitch forward to fly north
         self.progress("Going north %u meters" % side)
-        self.set_rc(2, 1300)
+        self.set_pitch(1300)
         self.wait_distance(side)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # save top left corner of square as waypoint
         self.progress("Save WP 3")
@@ -353,9 +353,9 @@ class AutoTestCopter(AutoTest):
 
         # pitch back to fly south
         self.progress("Going south %u meters" % side)
-        self.set_rc(2, 1700)
+        self.set_pitch(1700)
         self.wait_distance(side)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # save bottom right corner of square as waypoint
         self.progress("Save WP 5")
@@ -951,9 +951,9 @@ class AutoTestCopter(AutoTest):
         self.set_yaw(1500)
 
         # fly west 80m
-        self.set_rc(2, 1100)
+        self.set_pitch(1100)
         self.wait_distance(80)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # wait for copter to slow moving
         self.wait_groundspeed(0, 2)
@@ -1028,7 +1028,7 @@ class AutoTestCopter(AutoTest):
         self.set_throttle(1700)
         self.wait_altitude(10, 100, relative=True)
         self.set_throttle(1500)
-        self.set_rc(2, 1400)
+        self.set_pitch(1400)
         self.wait_distance_to_home(12, 20)
         tstart = self.get_sim_time()
         push_time = 70 # push against barrier for 60 seconds
@@ -1061,7 +1061,7 @@ class AutoTestCopter(AutoTest):
             raise NotAchievedException("Failed min")
         if failed_max:
             raise NotAchievedException("Failed max")
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.do_RTL()
 
     def fly_fence_avoid_test(self, timeout=180):
@@ -1161,7 +1161,7 @@ class AutoTestCopter(AutoTest):
 
         self.progress("flying forward (east) until we hit fence")
         pitching_forward = True
-        self.set_rc(2, 1100)
+        self.set_pitch(1100)
 
         self.progress("Waiting for fence breach")
         tstart = self.get_sim_time()
@@ -1186,7 +1186,7 @@ class AutoTestCopter(AutoTest):
             # recenter pitch sticks once we're home so we don't fly off again
             if pitching_forward and home_distance < 50:
                 pitching_forward = False
-                self.set_rc(2, 1475)
+                self.set_pitch(1475)
                 # disable fence
                 self.set_parameter("FENCE_ENABLE", 0)
             if (alt <= 1 and home_distance < 10) or (not self.armed() and home_distance < 10):
@@ -1226,11 +1226,11 @@ class AutoTestCopter(AutoTest):
         self.set_yaw(1500)
 
         # fly forward (east) at least 20m
-        self.set_rc(2, 1100)
+        self.set_pitch(1100)
         self.wait_distance(20)
 
         # stop flying forward and start flying up:
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.set_throttle(1800)
 
         # wait for fence to trigger
@@ -1278,9 +1278,9 @@ class AutoTestCopter(AutoTest):
             self.wait_heading(150)
             self.set_yaw(1500)
             # fly forward (south east) at least 60m
-            self.set_rc(2, 1100)
+            self.set_pitch(1100)
             self.wait_distance(60)
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             # wait for copter to slow down
         except Exception as e:
             if self.use_map:
@@ -1468,11 +1468,11 @@ class AutoTestCopter(AutoTest):
 
         # fly west 8 seconds
         self.progress("# Flying west for 8 seconds")
-        self.set_rc(2, 1300)
+        self.set_pitch(1300)
         tstart = self.get_sim_time()
         while self.get_sim_time_cached() < (tstart + 8):
             self.mav.recv_match(type='VFR_HUD', blocking=True)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # fly north 25 meters
         self.progress("# Flying north %u meters" % (side/2.0))
@@ -1482,11 +1482,11 @@ class AutoTestCopter(AutoTest):
 
         # fly east 8 seconds
         self.progress("# Flying east for 8 seconds")
-        self.set_rc(2, 1700)
+        self.set_pitch(1700)
         tstart = self.get_sim_time()
         while self.get_sim_time_cached() < (tstart + 8):
             self.mav.recv_match(type='VFR_HUD', blocking=True)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # hover in place
         self.hover()
@@ -1499,9 +1499,9 @@ class AutoTestCopter(AutoTest):
 
         # fly forward 20m
         self.progress("# Flying forward 20 meters")
-        self.set_rc(2, 1300)
+        self.set_pitch(1300)
         self.wait_distance(20, 5, 60)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # set SUPER SIMPLE mode for all flight modes
         self.set_parameter("SUPER_SIMPLE", 63)
@@ -1552,10 +1552,10 @@ class AutoTestCopter(AutoTest):
         self.set_parameter("CIRCLE_RADIUS", 3000)
 
         # fly forward (east) at least 100m
-        self.set_rc(2, 1100)
+        self.set_pitch(1100)
         self.wait_distance(100)
         # return pitch stick back to middle
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # set CIRCLE mode
         self.mavproxy.send('switch 1\n')  # circle mode
@@ -1621,14 +1621,14 @@ class AutoTestCopter(AutoTest):
             self.hover()
 
             self.progress("Flipping in pitch")
-            self.set_rc(2, 1700)
+            self.set_pitch(1700)
             self.mavproxy.send('mode FLIP\n') # don't wait for heartbeat!
             self.wait_attitude(despitch=45, desroll=0, tolerance=30)
             # can't check roll here as it flips from 0 to -180..
             self.wait_attitude(despitch=90, tolerance=30)
             self.wait_attitude(despitch=-45, tolerance=30)
             self.progress("Waiting for level")
-            self.set_rc(2, 1500) # can't change quickly enough!
+            self.set_pitch(1500) # can't change quickly enough!
             self.wait_attitude(despitch=0, desroll=0, tolerance=5)
             self.set_parameter('SIM_SPEEDUP', old_speedup)
             self.change_mode('RTL')
@@ -1663,7 +1663,7 @@ class AutoTestCopter(AutoTest):
             self.wait_mode('LOITER')
 
             # speed should be limited to <10m/s
-            self.set_rc(2, 1000)
+            self.set_pitch(1000)
 
             tstart = self.get_sim_time()
             timeout = 60
@@ -1686,7 +1686,7 @@ class AutoTestCopter(AutoTest):
         except Exception as e:
             ex = e
 
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.context_pop()
         self.disarm_vehicle(force=True)
         self.reboot_sitl()
@@ -2317,7 +2317,7 @@ class AutoTestCopter(AutoTest):
             self.progress("Original alt: absolute=%f" % orig_absolute_alt_mm)
 
             self.progress("Flying somewhere which surface is known lower compared to takeoff point")
-            self.set_rc(2, 1450)
+            self.set_pitch(1450)
             tstart = self.get_sim_time()
             while True:
                 if self.get_sim_time() - tstart > 200:
@@ -2334,7 +2334,7 @@ class AutoTestCopter(AutoTest):
                         raise NotAchievedException("Did not dip in altitude as expected")
                     break
 
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             self.do_RTL()
 
         except Exception as e:
@@ -2367,7 +2367,7 @@ class AutoTestCopter(AutoTest):
             self.wait_ready_to_arm()
             self.arm_vehicle()
             self.set_throttle(1800)
-            self.set_rc(2, 1200)
+            self.set_pitch(1200)
             # wait till we get to 50m
             self.wait_altitude(50, 52, True, 60)
 
@@ -2376,7 +2376,7 @@ class AutoTestCopter(AutoTest):
             self.wait_altitude(25, 27, True, 120)
 
             # level up
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             self.wait_altitude(14, 15, relative=True)
 
             tstart = self.get_sim_time()
@@ -2841,9 +2841,9 @@ class AutoTestCopter(AutoTest):
             while i < 2:
                 self.start_subtest("Run zigzag A->B and B->A (i=%d)" % i)
                 self.progress("## fly forward for 10 meter ##")
-                self.set_rc(2, 1300)
+                self.set_pitch(1300)
                 self.wait_distance(10)
-                self.set_rc(2, 1500)    # re-centre pitch rc control
+                self.set_pitch(1500)    # re-centre pitch rc control
                 self.wait_groundspeed(0, slowdown_speed)   # wait until the copter slows down
                 self.set_rc(8, 1500)    # switch to mid position
                 self.progress("## auto execute vector BA ##")
@@ -2852,9 +2852,9 @@ class AutoTestCopter(AutoTest):
                 self.wait_groundspeed(0, slowdown_speed)   # wait until the copter slows down
 
                 self.progress("## fly forward for 10 meter ##")
-                self.set_rc(2, 1300)    # fly forward for 10 meter
+                self.set_pitch(1300)    # fly forward for 10 meter
                 self.wait_distance(10)
-                self.set_rc(2, 1500)    # re-centre pitch rc control
+                self.set_pitch(1500)    # re-centre pitch rc control
                 self.wait_groundspeed(0, slowdown_speed)   # wait until the copter slows down
                 self.set_rc(8, 1500)    # switch to mid position
                 self.progress("## auto execute vector AB ##")
@@ -2865,9 +2865,9 @@ class AutoTestCopter(AutoTest):
             # test the case when pilot switch to manual control during the auto flight
             self.start_subtest("test the case when pilot switch to manual control during the auto flight")
             self.progress("## fly forward for 10 meter ##")
-            self.set_rc(2, 1300)    # fly forward for 10 meter
+            self.set_pitch(1300)    # fly forward for 10 meter
             self.wait_distance(10)
-            self.set_rc(2, 1500)    # re-centre pitch rc control
+            self.set_pitch(1500)    # re-centre pitch rc control
             self.wait_groundspeed(0, 0.3)   # wait until the copter slows down
             self.set_rc(8, 1500)    # switch to mid position
             self.progress("## auto execute vector BA ##")
@@ -2876,9 +2876,9 @@ class AutoTestCopter(AutoTest):
             self.set_rc(8, 1500)
             self.wait_groundspeed(0, slowdown_speed)   # copter should slow down here
             self.progress("## Manual control to fly forward ##")
-            self.set_rc(2, 1300)    # manual control to fly forward
+            self.set_pitch(1300)    # manual control to fly forward
             self.wait_distance(8)
-            self.set_rc(2, 1500)    # re-centre pitch rc control
+            self.set_pitch(1500)    # re-centre pitch rc control
             self.wait_groundspeed(0, slowdown_speed)   # wait until the copter slows down
             self.progress("## continue vector BA ##")
             self.set_rc(8, 1100)    # copter should continue mission here
@@ -4254,10 +4254,10 @@ class AutoTestCopter(AutoTest):
 
                 # fly fast forrest!
                 self.set_throttle(1900)
-                self.set_rc(2, 1200)
+                self.set_pitch(1200)
                 self.wait_groundspeed(5, 1000)
                 self.set_throttle(1500)
-                self.set_rc(2, 1500)
+                self.set_pitch(1500)
 
                 self.do_RTL()
                 psd = self.mavfft_fttd(1, 0, tstart * 1.0e6, tend * 1.0e6)
@@ -4317,13 +4317,13 @@ class AutoTestCopter(AutoTest):
         self.progress("Ensuring RC inputs have no effect in brake mode")
         self.change_mode("STABILIZE")
         self.set_throttle(1500)
-        self.set_rc(2, 1200)
+        self.set_pitch(1200)
         self.wait_groundspeed(5, 1000)
 
         self.change_mode("BRAKE")
         self.wait_groundspeed(0, 1)
 
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         self.do_RTL()
         self.progress("Ran brake  mode")
@@ -4468,9 +4468,9 @@ class AutoTestCopter(AutoTest):
                                relative=True)
             self.set_throttle(1500)
             # move away a little
-            self.set_rc(2, 1550)
+            self.set_pitch(1550)
             self.wait_distance(5, accuracy=1)
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             self.mavproxy.send('mode loiter\n')
             self.wait_mode('LOITER')
 
@@ -4633,7 +4633,7 @@ class AutoTestCopter(AutoTest):
 
     def check_avoidance_corners(self):
             self.takeoff(10, mode="LOITER")
-            self.set_rc(2, 1400)
+            self.set_pitch(1400)
             west_loc = mavutil.location(-35.363007,
 	                                    149.164911,
                                         0,
@@ -4653,7 +4653,7 @@ class AutoTestCopter(AutoTest):
             self.wait_location(east_loc, accuracy=6)
             self.reach_heading_manual(225);
             self.wait_location(west_loc, accuracy=6, timeout =200)
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             self.do_RTL()
 
     def fly_proximity_avoidance_test(self):
@@ -4793,9 +4793,9 @@ class AutoTestCopter(AutoTest):
 
             self.progress("Moving to ensure location is tracked")
             self.takeoff(10, mode="LOITER")
-            self.set_rc(2, 1400)
+            self.set_pitch(1400)
             self.delay_sim_time(5)
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             self.wait_groundspeed(0, 0.1)
             pos_delta = self.get_distance(self.sim_location(), self.mav.location)
             if pos_delta > max_delta:
@@ -4825,21 +4825,21 @@ class AutoTestCopter(AutoTest):
             self.reboot_sitl()
 
             self.takeoff(10, mode="LOITER")
-            self.set_rc(2, 1400)
+            self.set_pitch(1400)
             west_loc = mavutil.location(-35.362919, 149.165055, 0, 0)
             self.wait_location(west_loc, accuracy=7)
             self.reach_heading_manual(0)
             north_loc = mavutil.location(-35.362881, 149.165103, 0, 0)
             self.wait_location(north_loc, accuracy=7)
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             self.set_roll(1600)
             east_loc = mavutil.location(-35.362986, 149.165227, 0, 0)
             self.wait_location(east_loc, accuracy=7)
             self.set_roll(1500)
-            self.set_rc(2, 1600)
+            self.set_pitch(1600)
             south_loc = mavutil.location(-35.363025, 149.165182, 0, 0)
             self.wait_location(south_loc, accuracy=7)
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
             self.do_RTL()
 
         except Exception as e:

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -134,7 +134,7 @@ class AutoTestCopter(AutoTest):
             self.wait_ready_to_arm(require_absolute=require_absolute)
             self.zero_throttle()
             self.arm_vehicle()
-        self.set_rc(3, takeoff_throttle)
+        self.set_throttle(takeoff_throttle)
         self.wait_for_alt(alt_min=alt_min, timeout=timeout)
         self.hover()
         self.progress("TAKEOFF COMPLETE")
@@ -158,16 +158,16 @@ class AutoTestCopter(AutoTest):
         self.wait_disarmed()
 
     def hover(self, hover_throttle=1500):
-        self.set_rc(3, hover_throttle)
+        self.set_throttle(hover_throttle)
     
     #Climb/descend to a given altitude
     def setAlt(self, desiredAlt=50):
         pos = self.mav.location(relative_alt=True)
         if pos.alt > desiredAlt:
-            self.set_rc(3, 1300)
+            self.set_throttle(1300)
             self.wait_altitude((desiredAlt-5), desiredAlt, relative=True)
         if pos.alt < (desiredAlt-5):
-            self.set_rc(3, 1800)
+            self.set_throttle(1800)
             self.wait_altitude((desiredAlt-5), desiredAlt, relative=True)
         self.hover()
     
@@ -176,7 +176,7 @@ class AutoTestCopter(AutoTest):
         self.progress("Centering sticks")
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
-        self.set_rc(3, 1000)
+        self.set_throttle(1000)
         self.set_rc(4, 1500)
         self.takeoff(alt_min=dAlt)
         self.change_mode("ALT_HOLD")
@@ -274,9 +274,9 @@ class AutoTestCopter(AutoTest):
             if math.fabs(current_alt - target_alt) <= accuracy:
                 self.hover()
             elif current_alt < target_alt:
-                self.set_rc(3, climb_throttle)
+                self.set_throttle(climb_throttle)
             else:
-                self.set_rc(3, descend_throttle)
+                self.set_throttle(descend_throttle)
         self.wait_altitude((alt_min - 5), alt_min, relative=True, called_function=lambda current_alt, target_alt: adjust_altitude(current_alt, target_alt, 1))
         self.hover()
 
@@ -309,7 +309,7 @@ class AutoTestCopter(AutoTest):
         # ensure all sticks in the middle
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.set_rc(4, 1500)
 
         # switch to loiter mode temporarily to stop us from rising
@@ -329,7 +329,7 @@ class AutoTestCopter(AutoTest):
         self.change_mode('STABILIZE')
 
         # increase throttle a bit because we're about to pitch:
-        self.set_rc(3, 1525)
+        self.set_throttle(1525)
 
         # pitch forward to fly north
         self.progress("Going north %u meters" % side)
@@ -372,19 +372,19 @@ class AutoTestCopter(AutoTest):
         self.save_wp()
 
         # reduce throttle again
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
 
         # descend to 10m
         self.progress("Descend to 10m in Loiter")
         self.mavproxy.send('switch 5\n')  # loiter mode
         self.wait_mode('LOITER')
-        self.set_rc(3, 1300)
+        self.set_throttle(1300)
         time_left = timeout - (self.get_sim_time() - tstart)
         self.progress("timeleft = %u" % time_left)
         if time_left < 20:
             time_left = 20
         self.wait_altitude(-10, 10, timeout=time_left, relative=True)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.save_wp()
 
         # save the stored mission to file
@@ -406,7 +406,7 @@ class AutoTestCopter(AutoTest):
     def do_RTL(self, timeout=250):
         """Return, land."""
         self.change_mode("RTL")
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         tstart = self.get_sim_time()
         while self.get_sim_time_cached() < tstart + timeout:
             m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True)
@@ -453,11 +453,11 @@ class AutoTestCopter(AutoTest):
             self.mavproxy.send('mode auto\n')
             self.wait_mode('AUTO')
 
-            self.set_rc(3, 1550)
+            self.set_throttle(1550)
 
             self.wait_current_waypoint(2)
 
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
 
             self.wait_waypoint(0, num_wp-1, timeout=500)
 
@@ -1025,9 +1025,9 @@ class AutoTestCopter(AutoTest):
             raise PreconditionFailedException("Expected to be within 5m of home")
         self.zero_throttle()
         self.arm_vehicle()
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         self.wait_altitude(10, 100, relative=True)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.set_rc(2, 1400)
         self.wait_distance_to_home(12, 20)
         tstart = self.get_sim_time()
@@ -1231,7 +1231,7 @@ class AutoTestCopter(AutoTest):
 
         # stop flying forward and start flying up:
         self.set_rc(2, 1500)
-        self.set_rc(3, 1800)
+        self.set_throttle(1800)
 
         # wait for fence to trigger
         self.wait_mode('RTL', timeout=120)
@@ -1390,7 +1390,7 @@ class AutoTestCopter(AutoTest):
         # switch into AUTO mode and raise throttle
         self.mavproxy.send('switch 4\n')  # auto mode
         self.wait_mode('AUTO')
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
 
         # wait until 100m from home
         try:
@@ -1458,7 +1458,7 @@ class AutoTestCopter(AutoTest):
         # switch to stabilize mode
         self.mavproxy.send('switch 6\n')
         self.wait_mode('STABILIZE')
-        self.set_rc(3, 1545)
+        self.set_throttle(1545)
 
         # fly south 50m
         self.progress("# Flying south %u meters" % side)
@@ -1508,7 +1508,7 @@ class AutoTestCopter(AutoTest):
 
         # switch to stabilize mode
         self.change_mode("STABILIZE")
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
 
         # start copter yawing slowly
         self.set_rc(4, 1550)
@@ -1616,7 +1616,7 @@ class AutoTestCopter(AutoTest):
 
             self.progress("Regaining altitude")
             self.change_mode('STABILIZE')
-            self.set_rc(3, 1800)
+            self.set_throttle(1800)
             self.wait_for_alt(20)
             self.hover()
 
@@ -1802,7 +1802,7 @@ class AutoTestCopter(AutoTest):
                     or rllp == self.get_parameter("ATC_RAT_RLL_P")):
                     raise NotAchievedException("AUTOTUNE gains not present in pilot testing")
                 # land without changing mode
-                self.set_rc(3, 1000)
+                self.set_throttle(1000)
                 self.wait_for_alt(0)
                 self.wait_disarmed()
                 # Check gains are still there after disarm
@@ -1843,7 +1843,7 @@ class AutoTestCopter(AutoTest):
 
         # switch into AUTO mode and raise throttle
         self.change_mode("AUTO")
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
 
         # fly the mission
         self.wait_waypoint(0, num_wp-1, timeout=500)
@@ -2101,7 +2101,7 @@ class AutoTestCopter(AutoTest):
             self.set_rc(1, 1500)
             self.progress("# Enter RTL")
             self.mavproxy.send('switch 3\n')
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
             tstart = self.get_sim_time()
             while True:
                 if self.get_sim_time_cached() - tstart > 200:
@@ -2142,7 +2142,7 @@ class AutoTestCopter(AutoTest):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.change_mode('AUTO')
-        self.set_rc(3, 1600)
+        self.set_throttle(1600)
         self.wait_altitude(19, 25, relative=True)
         self.wait_groundspeed(wpnav_speed_ms-tolerance, wpnav_speed_ms+tolerance)
         self.monitor_groundspeed(wpnav_speed_ms, timeout=20)
@@ -2168,7 +2168,7 @@ class AutoTestCopter(AutoTest):
 
         self.arm_vehicle()
         self.change_mode("AUTO")
-        self.set_rc(3, 1600)
+        self.set_throttle(1600)
         count_start = -1
         count_stop = -1
         tstart = self.get_sim_time()
@@ -2366,7 +2366,7 @@ class AutoTestCopter(AutoTest):
             self.change_mode("LOITER")
             self.wait_ready_to_arm()
             self.arm_vehicle()
-            self.set_rc(3, 1800)
+            self.set_throttle(1800)
             self.set_rc(2, 1200)
             # wait till we get to 50m
             self.wait_altitude(50, 52, True, 60)
@@ -2421,7 +2421,7 @@ class AutoTestCopter(AutoTest):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.change_mode('AUTO')
-        self.set_rc(3, 1600)
+        self.set_throttle(1600)
         self.mavproxy.expect('BANG')
         self.disarm_vehicle(force=True)
         self.reboot_sitl()
@@ -2743,7 +2743,7 @@ class AutoTestCopter(AutoTest):
 
         self.arm_vehicle()
         self.change_mode("AUTO")
-        self.set_rc(3, 1600)
+        self.set_throttle(1600)
         count_stop = -1
         tstart = self.get_sim_time()
         while self.armed(): # we RTL at end of mission
@@ -2782,7 +2782,7 @@ class AutoTestCopter(AutoTest):
         self.arm_vehicle()
         self.change_mode("AUTO")
 
-        self.set_rc(3, 1600)
+        self.set_throttle(1600)
 
         # should not take off for about least 77 seconds
         tstart = self.get_sim_time()
@@ -3276,7 +3276,7 @@ class AutoTestCopter(AutoTest):
             self.wait_heartbeat()
             self.wait_mode('AUTO')
 
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
             self.wait_text("Gripper load releas", timeout=90)
 
             self.wait_disarmed()
@@ -3336,7 +3336,7 @@ class AutoTestCopter(AutoTest):
             self.arm_vehicle()
             self.mavproxy.send('mode auto\n')
             self.wait_mode('AUTO')
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
             self.mavproxy.expect("Gripper Grabbed")
             self.mavproxy.expect("Gripper Released")
         except Exception as e:
@@ -3359,7 +3359,7 @@ class AutoTestCopter(AutoTest):
             self.arm_vehicle()
             self.mavproxy.send('mode auto\n')
             self.wait_mode('AUTO')
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
             self.wait_altitude(10, 3000, relative=True)
         except Exception as e:
             self.progress("Exception caught: %s" % (
@@ -3379,7 +3379,7 @@ class AutoTestCopter(AutoTest):
         self.change_mode("ACRO")
         self.change_mode("STABILIZE")
         self.change_mode("GUIDED")
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         self.watch_altitude_maintained(-1, 0.2) # should not take off in guided
         self.run_cmd_do_set_mode(
             "ACRO",
@@ -3390,7 +3390,7 @@ class AutoTestCopter(AutoTest):
         self.run_cmd_do_set_mode(
             "DRIFT",
             want_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED) # should fix this result code!
-        self.set_rc(3, 1000)
+        self.set_throttle(1000)
         self.run_cmd_do_set_mode("ACRO")
         self.wait_disarmed()
 
@@ -4253,10 +4253,10 @@ class AutoTestCopter(AutoTest):
                 tend = self.get_sim_time()
 
                 # fly fast forrest!
-                self.set_rc(3, 1900)
+                self.set_throttle(1900)
                 self.set_rc(2, 1200)
                 self.wait_groundspeed(5, 1000)
-                self.set_rc(3, 1500)
+                self.set_throttle(1500)
                 self.set_rc(2, 1500)
 
                 self.do_RTL()
@@ -4316,7 +4316,7 @@ class AutoTestCopter(AutoTest):
 
         self.progress("Ensuring RC inputs have no effect in brake mode")
         self.change_mode("STABILIZE")
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.set_rc(2, 1200)
         self.wait_groundspeed(5, 1000)
 
@@ -4461,12 +4461,12 @@ class AutoTestCopter(AutoTest):
                                         blocking=True)
 
             self.arm_vehicle()
-            self.set_rc(3, 1800)
+            self.set_throttle(1800)
             alt_min = 10
             self.wait_altitude(alt_min,
                                (alt_min + 5),
                                relative=True)
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
             # move away a little
             self.set_rc(2, 1550)
             self.wait_distance(5, accuracy=1)
@@ -4533,7 +4533,7 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("PILOT_TKOFF_ALT", 700)
             self.mavproxy.send('mode POSHOLD\n')
             self.wait_mode('POSHOLD')
-            self.set_rc(3, 1000)
+            self.set_throttle(1000)
             self.wait_ready_to_arm()
             self.arm_vehicle()
             self.delay_sim_time(2)
@@ -4543,10 +4543,10 @@ class AutoTestCopter(AutoTest):
                 raise NotAchievedException("Took off prematurely")
 
             self.progress("Pushing throttle up")
-            self.set_rc(3, 1710)
+            self.set_throttle(1710)
             self.delay_sim_time(0.5)
             self.progress("Bringing back to hover throttle")
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
 
             # make sure we haven't already reached alt:
             m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True)
@@ -5490,7 +5490,7 @@ class AutoTestHeli(AutoTestCopter):
         self.set_parameter("H_RSC_RUNUP_TIME", TARGET_RUNUP_TIME)
         self.progress("Initiate Runup by putting some throttle")
         self.set_rc(8, 2000)
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         self.progress("Collective threshold PWM %u" % coll)
         tstart = self.get_sim_time()
         self.progress("Wait that collective PWM pass threshold value")
@@ -5539,7 +5539,7 @@ class AutoTestHeli(AutoTestCopter):
         # switch into AUTO mode and raise throttle
         self.mavproxy.send('switch 4\n')  # auto mode
         self.wait_mode('AUTO')
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
 
         # fly the mission
         self.wait_waypoint(0, num_wp-1, timeout=500)
@@ -5579,10 +5579,10 @@ class AutoTestHeli(AutoTestCopter):
             if abs(m.relative_alt) > 100:
                 raise NotAchievedException("Took off prematurely")
             self.progress("Pushing throttle past half-way")
-            self.set_rc(3, 1600)
+            self.set_throttle(1600)
             self.delay_sim_time(0.5)
             self.progress("Bringing back to hover throttle")
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
 
             # make sure we haven't already reached alt:
             m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True)
@@ -5624,7 +5624,7 @@ class AutoTestHeli(AutoTestCopter):
         ex = None
         try:
             self.change_mode('STABILIZE')
-            self.set_rc(3, 1000)
+            self.set_throttle(1000)
             self.set_rc(8, 1000)
             self.wait_ready_to_arm()
             self.arm_vehicle()
@@ -5637,7 +5637,7 @@ class AutoTestHeli(AutoTestCopter):
             if abs(m.relative_alt) > 100:
                 raise NotAchievedException("Took off prematurely")
             self.progress("Pushing throttle past half-way")
-            self.set_rc(3, 1600)
+            self.set_throttle(1600)
 
             self.progress("Monitoring takeoff")
             self.wait_altitude(6.9, 8, relative=True)
@@ -5666,7 +5666,7 @@ class AutoTestHeli(AutoTestCopter):
         self.set_rc(8, 2000)
         self.delay_sim_time(20)
         self.change_mode("AUTO")
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         tstart = self.get_sim_time()
         while True:
             if self.get_sim_time() - tstart > timeout:
@@ -5684,7 +5684,7 @@ class AutoTestHeli(AutoTestCopter):
         self.set_parameter("PILOT_TKOFF_ALT", start_alt * 100)
         self.mavproxy.send('mode POSHOLD\n')
         self.wait_mode('POSHOLD')
-        self.set_rc(3, 1000)
+        self.set_throttle(1000)
         self.set_rc(8, 1000)
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -5692,7 +5692,7 @@ class AutoTestHeli(AutoTestCopter):
         self.progress("wait for rotor runup to complete")
         self.wait_servo_channel_value(8, 1660, timeout=10)
         self.delay_sim_time(20)
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.wait_altitude(start_alt - 1,
                            (start_alt + 5),
                            relative=True,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -174,7 +174,7 @@ class AutoTestCopter(AutoTest):
     # Takeoff, climb to given altitude, and fly east for 10 seconds
     def takeoffAndMoveAway(self, dAlt=50, dDist=50):
         self.progress("Centering sticks")
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.set_rc(2, 1500)
         self.set_throttle(1000)
         self.set_yaw(1500)
@@ -261,10 +261,10 @@ class AutoTestCopter(AutoTest):
         self.watch_altitude_maintained(9, 11, timeout=5)
         # feed in full elevator and aileron input and make sure we
         # retain altitude:
-        self.set_rc(1, 1000)
+        self.set_roll(1000)
         self.set_rc(2, 1000)
         self.watch_altitude_maintained(9, 11, timeout=5)
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.set_rc(2, 1500)
         self.do_RTL()
 
@@ -307,7 +307,7 @@ class AutoTestCopter(AutoTest):
         tstart = self.get_sim_time()
 
         # ensure all sticks in the middle
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.set_rc(2, 1500)
         self.set_throttle(1500)
         self.set_yaw(1500)
@@ -343,9 +343,9 @@ class AutoTestCopter(AutoTest):
 
         # roll right to fly east
         self.progress("Going east %u meters" % side)
-        self.set_rc(1, 1700)
+        self.set_roll(1700)
         self.wait_distance(side)
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
 
         # save top right corner of square as waypoint
         self.progress("Save WP 4")
@@ -363,9 +363,9 @@ class AutoTestCopter(AutoTest):
 
         # roll left to fly west
         self.progress("Going west %u meters" % side)
-        self.set_rc(1, 1300)
+        self.set_roll(1300)
         self.wait_distance(side)
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
 
         # save bottom left corner of square (should be near home) as waypoint
         self.progress("Save WP 6")
@@ -1462,9 +1462,9 @@ class AutoTestCopter(AutoTest):
 
         # fly south 50m
         self.progress("# Flying south %u meters" % side)
-        self.set_rc(1, 1300)
+        self.set_roll(1300)
         self.wait_distance(side, 5, 60)
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
 
         # fly west 8 seconds
         self.progress("# Flying west for 8 seconds")
@@ -1476,9 +1476,9 @@ class AutoTestCopter(AutoTest):
 
         # fly north 25 meters
         self.progress("# Flying north %u meters" % (side/2.0))
-        self.set_rc(1, 1700)
+        self.set_roll(1700)
         self.wait_distance(side/2, 5, 60)
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
 
         # fly east 8 seconds
         self.progress("# Flying east for 8 seconds")
@@ -1516,13 +1516,13 @@ class AutoTestCopter(AutoTest):
         # roll left for timeout seconds
         self.progress("# rolling left from pilot's POV for %u seconds"
                       % timeout)
-        self.set_rc(1, 1300)
+        self.set_roll(1300)
         tstart = self.get_sim_time()
         while self.get_sim_time_cached() < (tstart + timeout):
             self.mav.recv_match(type='VFR_HUD', blocking=True)
 
         # stop rolling and yawing
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.set_yaw(1500)
 
         # restore simple mode parameters to default
@@ -1605,13 +1605,13 @@ class AutoTestCopter(AutoTest):
             old_speedup = self.get_parameter("SIM_SPEEDUP")
             self.set_parameter('SIM_SPEEDUP', 1)
             self.progress("Flipping in roll")
-            self.set_rc(1, 1700)
+            self.set_roll(1700)
             self.mavproxy.send('mode FLIP\n') # don't wait for heartbeat!
             self.wait_attitude(despitch=0, desroll=45, tolerance=30)
             self.wait_attitude(despitch=0, desroll=90, tolerance=30)
             self.wait_attitude(despitch=0, desroll=-45, tolerance=30)
             self.progress("Waiting for level")
-            self.set_rc(1, 1500) # can't change quickly enough!
+            self.set_roll(1500) # can't change quickly enough!
             self.wait_attitude(despitch=0, desroll=0, tolerance=5)
 
             self.progress("Regaining altitude")
@@ -2082,7 +2082,7 @@ class AutoTestCopter(AutoTest):
                     raise AutoTestTimeoutException("Did not get non-zero lat")
 
             self.takeoff()
-            self.set_rc(1, 1600)
+            self.set_roll(1600)
             tstart = self.get_sim_time()
             while True:
                 vicon_pos = self.mav.recv_match(type='VISION_POSITION_ESTIMATE',
@@ -2098,7 +2098,7 @@ class AutoTestCopter(AutoTest):
                     raise AutoTestTimeoutException("Vicon showed no movement")
 
             # recenter controls:
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
             self.progress("# Enter RTL")
             self.mavproxy.send('switch 3\n')
             self.set_throttle(1500)
@@ -2829,9 +2829,9 @@ class AutoTestCopter(AutoTest):
             self.change_mode(ZIGZAG)
             self.progress("## Record Point A ##")
             self.set_rc(8, 1100)  # record point A
-            self.set_rc(1, 1700)  # fly side-way for 20m
+            self.set_roll(1700)  # fly side-way for 20m
             self.wait_distance(20)
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
             self.wait_groundspeed(0, slowdown_speed)   # wait until the copter slows down
             self.progress("## Record Point A ##")
             self.set_rc(8, 1500)    # pilot always have to cross mid position when changing for low to high position
@@ -4832,10 +4832,10 @@ class AutoTestCopter(AutoTest):
             north_loc = mavutil.location(-35.362881, 149.165103, 0, 0)
             self.wait_location(north_loc, accuracy=7)
             self.set_rc(2, 1500)
-            self.set_rc(1, 1600)
+            self.set_roll(1600)
             east_loc = mavutil.location(-35.362986, 149.165227, 0, 0)
             self.wait_location(east_loc, accuracy=7)
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
             self.set_rc(2, 1600)
             south_loc = mavutil.location(-35.363025, 149.165182, 0, 0)
             self.wait_location(south_loc, accuracy=7)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -177,14 +177,14 @@ class AutoTestCopter(AutoTest):
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
         self.set_throttle(1000)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
         self.takeoff(alt_min=dAlt)
         self.change_mode("ALT_HOLD")
 
         self.progress("Yaw to east")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         self.wait_heading(90)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         self.progress("Fly eastbound away from home")
         self.set_rc(2, 1800)
@@ -204,9 +204,9 @@ class AutoTestCopter(AutoTest):
 
         # first aim south east
         self.progress("turn south east")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         self.wait_heading(170)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         # fly south east 50m
         self.set_rc(2, 1100)
@@ -310,16 +310,16 @@ class AutoTestCopter(AutoTest):
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
         self.set_throttle(1500)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         # switch to loiter mode temporarily to stop us from rising
         self.change_mode('LOITER')
 
         # first aim north
         self.progress("turn right towards north")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         self.wait_heading(10)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         # save bottom left corner of box as waypoint
         self.progress("Save WP 1 & 2")
@@ -946,9 +946,9 @@ class AutoTestCopter(AutoTest):
 
         # first south
         self.progress("turn south")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         self.wait_heading(180)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         # fly west 80m
         self.set_rc(2, 1100)
@@ -1153,9 +1153,9 @@ class AutoTestCopter(AutoTest):
 
         # first east
         self.progress("turn east")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         self.wait_heading(160)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         fence_radius = self.get_parameter("FENCE_RADIUS")
 
@@ -1221,9 +1221,9 @@ class AutoTestCopter(AutoTest):
 
         # first east
         self.progress("turn east")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         self.wait_heading(160)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         # fly forward (east) at least 20m
         self.set_rc(2, 1100)
@@ -1273,10 +1273,10 @@ class AutoTestCopter(AutoTest):
 
         # turn south east
         self.progress("turn south east")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         try:
             self.wait_heading(150)
-            self.set_rc(4, 1500)
+            self.set_yaw(1500)
             # fly forward (south east) at least 60m
             self.set_rc(2, 1100)
             self.wait_distance(60)
@@ -1511,7 +1511,7 @@ class AutoTestCopter(AutoTest):
         self.set_throttle(1700)
 
         # start copter yawing slowly
-        self.set_rc(4, 1550)
+        self.set_yaw(1550)
 
         # roll left for timeout seconds
         self.progress("# rolling left from pilot's POV for %u seconds"
@@ -1523,7 +1523,7 @@ class AutoTestCopter(AutoTest):
 
         # stop rolling and yawing
         self.set_rc(1, 1500)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         # restore simple mode parameters to default
         self.set_parameter("SUPER_SIMPLE", 0)
@@ -1544,9 +1544,9 @@ class AutoTestCopter(AutoTest):
 
         # face west
         self.progress("turn west")
-        self.set_rc(4, 1580)
+        self.set_yaw(1580)
         self.wait_heading(270)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
 
         # set CIRCLE radius
         self.set_parameter("CIRCLE_RADIUS", 3000)
@@ -2823,9 +2823,9 @@ class AutoTestCopter(AutoTest):
         while j < 4:
             self.progress("## Align heading with the run-way (j=%d)##" % j)
             self.set_rc(8, 1500)
-            self.set_rc(4, 1420)
+            self.set_yaw(1420)
             self.wait_heading(352-j*90)
-            self.set_rc(4, 1500)
+            self.set_yaw(1500)
             self.change_mode(ZIGZAG)
             self.progress("## Record Point A ##")
             self.set_rc(8, 1100)  # record point A

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -93,7 +93,7 @@ class AutoTestPlane(AutoTest):
         self.set_yaw(1700)
 
         # some up elevator to keep the tail down
-        self.set_rc(2, 1200)
+        self.set_pitch(1200)
 
         # get it moving a bit first
         self.set_throttle(1300)
@@ -105,14 +105,14 @@ class AutoTestPlane(AutoTest):
         self.wait_groundspeed(12, 100)
 
         # hit the gas harder now, and give it some more elevator
-        self.set_rc(2, 1100)
+        self.set_pitch(1100)
         self.set_throttle(2000)
 
         # gain a bit of altitude
         self.wait_altitude(alt, alt_max, timeout=30, relative=relative)
 
         # level off
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         self.progress("TAKEOFF COMPLETE")
 
@@ -210,7 +210,7 @@ class AutoTestPlane(AutoTest):
         tstart = self.get_sim_time()
         self.progress("Waiting for level flight")
         self.set_roll(1500)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.set_yaw(1500)
         while self.get_sim_time_cached() < tstart + timeout:
             m = self.mav.recv_match(type='ATTITUDE', blocking=True)
@@ -228,11 +228,11 @@ class AutoTestPlane(AutoTest):
         self.wait_mode('FBWA')
         alt_error = self.mav.messages['VFR_HUD'].alt - altitude
         if alt_error > 0:
-            self.set_rc(2, 2000)
+            self.set_pitch(2000)
         else:
-            self.set_rc(2, 1000)
+            self.set_pitch(1000)
         self.wait_altitude(altitude-accuracy/2, altitude+accuracy/2)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.progress("Reached target altitude at %u" %
                       self.mav.messages['VFR_HUD'].alt)
         return self.wait_level_flight()
@@ -277,13 +277,13 @@ class AutoTestPlane(AutoTest):
 
         while count > 0:
             self.progress("Starting loop")
-            self.set_rc(2, 1000)
+            self.set_pitch(1000)
             self.wait_pitch(-60, accuracy=20)
             self.wait_pitch(0, accuracy=20)
             count -= 1
 
         # back to FBWA
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.mavproxy.send('switch 4\n')
         self.wait_mode('FBWA')
         self.set_throttle(1700)
@@ -380,9 +380,9 @@ class AutoTestPlane(AutoTest):
         """Fly stabilize mode."""
         # full throttle!
         self.set_throttle(2000)
-        self.set_rc(2, 1300)
+        self.set_pitch(1300)
         self.change_altitude(self.homeloc.alt+300)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         self.mavproxy.send("mode STABILIZE\n")
         self.wait_mode('STABILIZE')
@@ -408,9 +408,9 @@ class AutoTestPlane(AutoTest):
         """Fly ACRO mode."""
         # full throttle!
         self.set_throttle(2000)
-        self.set_rc(2, 1300)
+        self.set_pitch(1300)
         self.change_altitude(self.homeloc.alt+300)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         self.mavproxy.send("mode ACRO\n")
         self.wait_mode('ACRO')
@@ -436,12 +436,12 @@ class AutoTestPlane(AutoTest):
         count = 2
         while count > 0:
             self.progress("Starting loop")
-            self.set_rc(2, 1000)
+            self.set_pitch(1000)
             self.wait_pitch(-60, accuracy=20)
             self.wait_pitch(0, accuracy=20)
             count -= 1
 
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # back to FBWA
         self.mavproxy.send('mode FBWA\n')
@@ -454,12 +454,12 @@ class AutoTestPlane(AutoTest):
         self.mavproxy.send("mode %s\n" % mode)
         self.wait_mode(mode)
         self.set_throttle(1700)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
 
         # lock in the altitude by asking for an altitude change then releasing
-        self.set_rc(2, 1000)
+        self.set_pitch(1000)
         self.wait_distance(50, accuracy=20)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.wait_distance(50, accuracy=20)
 
         m = self.mav.recv_match(type='VFR_HUD', blocking=True)
@@ -1259,7 +1259,7 @@ class AutoTestPlane(AutoTest):
         self.takeoff(alt=300)
 
         self.progress("Diving")
-        self.set_rc(2, 2000)
+        self.set_pitch(2000)
         self.mavproxy.expect("BANG")
 
         self.disarm_vehicle(force=True)
@@ -1609,7 +1609,7 @@ class AutoTestPlane(AutoTest):
         self.progress("Initial throttle: %u" % initial_throttle)
         # pitch down, ensure throttle decreases:
         rc2_max = self.get_parameter("RC2_MAX")
-        self.set_rc(2, rc2_max)
+        self.set_pitch(rc2_max)
         tstart = self.get_sim_time()
         while True:
             now = self.get_sim_time_cached()
@@ -1633,7 +1633,7 @@ class AutoTestPlane(AutoTest):
                 self.progress("Throttle delta achieved")
                 break
         self.progress("Centering elevator and ensuring we get back to loiter altitude")
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.wait_altitude(initial_alt-1, initial_alt+1)
         self.fly_home_land_and_disarm()
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -90,7 +90,7 @@ class AutoTestPlane(AutoTest):
         self.arm_vehicle()
 
         # some rudder to counteract the prop torque
-        self.set_rc(4, 1700)
+        self.set_yaw(1700)
 
         # some up elevator to keep the tail down
         self.set_rc(2, 1200)
@@ -101,7 +101,7 @@ class AutoTestPlane(AutoTest):
 
         # a bit faster again, straighten rudder
         self.set_throttle(1600)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
         self.wait_groundspeed(12, 100)
 
         # hit the gas harder now, and give it some more elevator
@@ -211,7 +211,7 @@ class AutoTestPlane(AutoTest):
         self.progress("Waiting for level flight")
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
         while self.get_sim_time_cached() < tstart + timeout:
             m = self.mav.recv_match(type='ATTITUDE', blocking=True)
             roll = math.degrees(m.roll)
@@ -487,13 +487,13 @@ class AutoTestPlane(AutoTest):
         for i in range(0, 4):
             # hard left
             self.progress("Starting turn %u" % i)
-            self.set_rc(4, 1900)
+            self.set_yaw(1900)
             try:
                 self.wait_heading(360 - (90*i), accuracy=20, timeout=60)
             except Exception as e:
-                self.set_rc(4, 1500)
+                self.set_yaw(1500)
                 raise e
-            self.set_rc(4, 1500)
+            self.set_yaw(1500)
             self.progress("Starting leg %u" % i)
             self.wait_distance(100, accuracy=20)
         self.progress("Circuit complete")

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -96,17 +96,17 @@ class AutoTestPlane(AutoTest):
         self.set_rc(2, 1200)
 
         # get it moving a bit first
-        self.set_rc(3, 1300)
+        self.set_throttle(1300)
         self.wait_groundspeed(6, 100)
 
         # a bit faster again, straighten rudder
-        self.set_rc(3, 1600)
+        self.set_throttle(1600)
         self.set_rc(4, 1500)
         self.wait_groundspeed(12, 100)
 
         # hit the gas harder now, and give it some more elevator
         self.set_rc(2, 1100)
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
 
         # gain a bit of altitude
         self.wait_altitude(alt, alt_max, timeout=30, relative=relative)
@@ -120,7 +120,7 @@ class AutoTestPlane(AutoTest):
         """Fly a left circuit, 200m on a side."""
         self.mavproxy.send('switch 4\n')
         self.wait_mode('FBWA')
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.wait_level_flight()
 
         self.progress("Flying left circuit")
@@ -240,7 +240,7 @@ class AutoTestPlane(AutoTest):
     def axial_left_roll(self, count=1):
         """Fly a left axial roll."""
         # full throttle!
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.change_altitude(self.homeloc.alt+300)
 
         # fly the roll in manual
@@ -263,13 +263,13 @@ class AutoTestPlane(AutoTest):
         self.set_rc(1, 1500)
         self.mavproxy.send('switch 4\n')
         self.wait_mode('FBWA')
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         return self.wait_level_flight()
 
     def inside_loop(self, count=1):
         """Fly a inside loop."""
         # full throttle!
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.change_altitude(self.homeloc.alt+300)
         # fly the loop in manual
         self.mavproxy.send('switch 6\n')
@@ -286,7 +286,7 @@ class AutoTestPlane(AutoTest):
         self.set_rc(2, 1500)
         self.mavproxy.send('switch 4\n')
         self.wait_mode('FBWA')
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         return self.wait_level_flight()
 
     def set_attitude_target(self, tolerance=10):
@@ -367,19 +367,19 @@ class AutoTestPlane(AutoTest):
         except Exception as e:
             self.mavproxy.send('mode FBWA\n')
             self.wait_mode('FBWA')
-            self.set_rc(3, 1700)
+            self.set_throttle(1700)
             raise e
 
         # back to FBWA
         self.mavproxy.send('mode FBWA\n')
         self.wait_mode('FBWA')
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         self.wait_level_flight()
 
     def test_stabilize(self, count=1):
         """Fly stabilize mode."""
         # full throttle!
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.set_rc(2, 1300)
         self.change_altitude(self.homeloc.alt+300)
         self.set_rc(2, 1500)
@@ -401,13 +401,13 @@ class AutoTestPlane(AutoTest):
         # back to FBWA
         self.mavproxy.send('mode FBWA\n')
         self.wait_mode('FBWA')
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         return self.wait_level_flight()
 
     def test_acro(self, count=1):
         """Fly ACRO mode."""
         # full throttle!
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.set_rc(2, 1300)
         self.change_altitude(self.homeloc.alt+300)
         self.set_rc(2, 1500)
@@ -446,14 +446,14 @@ class AutoTestPlane(AutoTest):
         # back to FBWA
         self.mavproxy.send('mode FBWA\n')
         self.wait_mode('FBWA')
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         return self.wait_level_flight()
 
     def test_FBWB(self, mode='FBWB'):
         """Fly FBWB or CRUISE mode."""
         self.mavproxy.send("mode %s\n" % mode)
         self.wait_mode(mode)
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         self.set_rc(2, 1500)
 
         # lock in the altitude by asking for an altitude change then releasing
@@ -526,7 +526,7 @@ class AutoTestPlane(AutoTest):
     def fly_do_reposition(self):
         self.progress("Takeoff")
         self.takeoff(alt=50)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.progress("Entering guided and flying somewhere constant")
         self.change_mode("GUIDED")
         loc = self.mav.location()
@@ -606,7 +606,7 @@ class AutoTestPlane(AutoTest):
 
         self.progress("Takeoff")
         self.takeoff(alt=100)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         # ensure we know what the airspeed is:
         self.progress("Entering guided and flying somewhere constant")
         self.change_mode("GUIDED")
@@ -952,7 +952,7 @@ class AutoTestPlane(AutoTest):
 
         self.set_parameter("FENCE_CHANNEL", 7)
         self.set_parameter("FENCE_ACTION", 4)
-        self.set_rc(3, 1000)
+        self.set_throttle(1000)
         self.set_rc(7, 2000)
 
         self.progress("Checking fence is initially OK")
@@ -1522,7 +1522,7 @@ class AutoTestPlane(AutoTest):
     def fly_do_guided_request(self, target_system=1, target_component=1):
         self.progress("Takeoff")
         self.takeoff(alt=50)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.start_subtest("Ensure command bounced outside guided mode")
         desired_relative_alt = 33
         loc = self.mav.location()
@@ -1583,7 +1583,7 @@ class AutoTestPlane(AutoTest):
 
     def LOITER(self):
         self.takeoff(alt=200)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.change_mode("LOITER")
         self.progress("Doing a bit of loitering to start with")
         tstart = self.get_sim_time()

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -128,9 +128,9 @@ class AutoTestPlane(AutoTest):
         for i in range(0, 4):
             # hard left
             self.progress("Starting turn %u" % i)
-            self.set_rc(1, 1000)
+            self.set_roll(1000)
             self.wait_heading(270 - (90*i), accuracy=10)
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
             self.progress("Starting leg %u" % i)
             self.wait_distance(100, accuracy=20)
         self.progress("Circuit complete")
@@ -209,7 +209,7 @@ class AutoTestPlane(AutoTest):
         """Wait for level flight."""
         tstart = self.get_sim_time()
         self.progress("Waiting for level flight")
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.set_rc(2, 1500)
         self.set_yaw(1500)
         while self.get_sim_time_cached() < tstart + timeout:
@@ -249,18 +249,18 @@ class AutoTestPlane(AutoTest):
 
         while count > 0:
             self.progress("Starting roll")
-            self.set_rc(1, 1000)
+            self.set_roll(1000)
             try:
                 self.wait_roll(-150, accuracy=90)
                 self.wait_roll(150, accuracy=90)
                 self.wait_roll(0, accuracy=90)
             except Exception as e:
-                self.set_rc(1, 1500)
+                self.set_roll(1500)
                 raise e
             count -= 1
 
         # back to FBWA
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.mavproxy.send('switch 4\n')
         self.wait_mode('FBWA')
         self.set_throttle(1700)
@@ -389,13 +389,13 @@ class AutoTestPlane(AutoTest):
 
         while count > 0:
             self.progress("Starting roll")
-            self.set_rc(1, 2000)
+            self.set_roll(2000)
             self.wait_roll(-150, accuracy=90)
             self.wait_roll(150, accuracy=90)
             self.wait_roll(0, accuracy=90)
             count -= 1
 
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.wait_roll(0, accuracy=5)
 
         # back to FBWA
@@ -417,12 +417,12 @@ class AutoTestPlane(AutoTest):
 
         while count > 0:
             self.progress("Starting roll")
-            self.set_rc(1, 1000)
+            self.set_roll(1000)
             self.wait_roll(-150, accuracy=90)
             self.wait_roll(150, accuracy=90)
             self.wait_roll(0, accuracy=90)
             count -= 1
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
 
         # back to FBWA
         self.mavproxy.send('mode FBWA\n')
@@ -471,13 +471,13 @@ class AutoTestPlane(AutoTest):
         for i in range(0, 4):
             # hard left
             self.progress("Starting turn %u" % i)
-            self.set_rc(1, 1800)
+            self.set_roll(1800)
             try:
                 self.wait_heading(0 + (90*i), accuracy=20, timeout=60)
             except Exception as e:
-                self.set_rc(1, 1500)
+                self.set_roll(1500)
                 raise e
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
             self.progress("Starting leg %u" % i)
             self.wait_distance(100, accuracy=20)
         self.progress("Circuit complete")

--- a/Tools/autotest/balancebot.py
+++ b/Tools/autotest/balancebot.py
@@ -65,7 +65,7 @@ class AutoTestBalanceBot(AutoTestRover):
             self.wait_ready_to_arm()
             self.change_mode("ACRO")
             self.arm_vehicle()
-            self.set_rc(3, 1600)
+            self.set_throttle(1600)
 
             m = self.mav.recv_match(type='WHEEL_DISTANCE', blocking=True, timeout=5)
             if m is None:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3336,7 +3336,7 @@ class AutoTest(ABC):
     def reach_heading_manual(self, heading, turn_right=True):
         """Manually direct the vehicle to the target heading."""
         if self.is_copter() or self.is_sub():
-            self.mavproxy.send('rc 4 1580\n')
+            self.set_yaw(1580)
             self.wait_heading(heading)
             self.set_yaw(1500)
         if self.is_plane():
@@ -3345,8 +3345,8 @@ class AutoTest(ABC):
             steering_pwm = 1700
             if not turn_right:
                 steering_pwm = 1300
-            self.mavproxy.send('rc 1 %u\n' % steering_pwm)
-            self.mavproxy.send('rc 3 1550\n')
+            self.set_roll(steering_pwm)
+            self.set_throttle(1550)
             self.wait_heading(heading)
             self.set_throttle(1500)
             self.set_rc(1, 1500)
@@ -3380,7 +3380,7 @@ class AutoTest(ABC):
         if self.is_plane():
             self.progress("NOT IMPLEMENTED")
         if self.is_rover():
-            self.mavproxy.send('rc 3 1700\n')
+            self.set_throttle(1700)
             self.wait_distance(distance, accuracy=2)
             self.set_throttle(1500)
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3338,7 +3338,7 @@ class AutoTest(ABC):
         if self.is_copter() or self.is_sub():
             self.mavproxy.send('rc 4 1580\n')
             self.wait_heading(heading)
-            self.set_rc(4, 1500)
+            self.set_yaw(1500)
         if self.is_plane():
             self.progress("NOT IMPLEMENTED")
         if self.is_rover():

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -807,6 +807,11 @@ class AutoTest(ABC):
         self.logs_dir = logs_dir
         self.timesync_number = 137
 
+        self.rc_throttle = 3
+        self.rc_pitch = 2
+        self.rc_roll = 1
+        self.rc_yaw = 4
+
     @staticmethod
     def progress(text):
         """Display autotest progress text."""
@@ -2462,6 +2467,29 @@ class AutoTest(ABC):
         """Setup all simulated RC control to 1500."""
         _defaults = self.rc_defaults()
         self.set_rc_from_map(_defaults)
+
+    def set_rcmap(self):
+        """Get RCMAP from vehicle and save it for further use."""
+        self.rc_throttle = int(self.get_parameter("RCMAP_THROTTLE"))
+        self.rc_pitch = int(self.get_parameter("RCMAP_PITCH"))
+        self.rc_roll = int(self.get_parameter("RCMAP_ROLL"))
+        self.rc_yaw = int(self.get_parameter("RCMAP_YAW"))
+
+    def set_throttle(self, pwm):
+        """Set RC throttle."""
+        self.set_rc(self.rc_throttle, pwm)
+
+    def set_pitch(self, pwm):
+        """Set RC pitch."""
+        self.set_rc(self.rc_pitch, pwm)
+
+    def set_roll(self, pwm):
+        """Set RC roll."""
+        self.set_rc(self.rc_roll, pwm)
+
+    def set_yaw(self, pwm):
+        """Set RC yaw."""
+        self.set_rc(self.rc_yaw, pwm)
 
     def check_rc_defaults(self):
         """Ensure all rc outputs are at defaults"""
@@ -5763,6 +5791,7 @@ switch value'''
             self.wait_heartbeat()
             self.wait_for_initial_mode()
             self.progress("Setting up RC parameters")
+            self.set_rcmap()
             self.set_rc_default()
             self.wait_for_mode_switch_poll()
             if not self.is_tracker(): # FIXME - more to the point, fix Tracker's mission handling

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3349,7 +3349,7 @@ class AutoTest(ABC):
             self.set_throttle(1550)
             self.wait_heading(heading)
             self.set_throttle(1500)
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
 
     def assert_vehicle_location_is_at_startup_location(self, dist_max=1):
         here = self.mav.location()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3374,9 +3374,9 @@ class AutoTest(ABC):
     def reach_distance_manual(self, distance):
         """Manually direct the vehicle to the target distance from home."""
         if self.is_copter():
-            self.set_rc(2, 1350)
+            self.set_pitch(1350)
             self.wait_distance(distance, accuracy=5, timeout=60)
-            self.set_rc(2, 1500)
+            self.set_pitch(1500)
         if self.is_plane():
             self.progress("NOT IMPLEMENTED")
         if self.is_rover():

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2550,9 +2550,9 @@ class AutoTest(ABC):
     def zero_throttle(self):
         """Set throttle to zero."""
         if self.is_rover():
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
         else:
-            self.set_rc(3, 1000)
+            self.set_throttle(1000)
 
     def set_output_to_max(self, chan):
         """Set output to max with RC Radio taking into account REVERSED parameter."""
@@ -3348,7 +3348,7 @@ class AutoTest(ABC):
             self.mavproxy.send('rc 1 %u\n' % steering_pwm)
             self.mavproxy.send('rc 3 1550\n')
             self.wait_heading(heading)
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
             self.set_rc(1, 1500)
 
     def assert_vehicle_location_is_at_startup_location(self, dist_max=1):
@@ -3382,7 +3382,7 @@ class AutoTest(ABC):
         if self.is_rover():
             self.mavproxy.send('rc 3 1700\n')
             self.wait_distance(distance, accuracy=2)
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
 
     def guided_achieve_heading(self, heading):
         tstart = self.get_sim_time()
@@ -5078,7 +5078,7 @@ Also, ignores heartbeats not from our target system'''
 
             if self.is_copter():
                 self.start_subtest("Test arming failure with throttle too high")
-                self.set_rc(3, 1800)
+                self.set_throttle(1800)
                 try:
                     if self.arm_vehicle():
                         raise NotAchievedException("Armed when throttle too high")

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -347,7 +347,7 @@ class AutoTestQuadPlane(AutoTest):
         tstart = self.get_sim_time()
         self.progress("Waiting for level flight")
         self.set_roll(1500)
-        self.set_rc(2, 1500)
+        self.set_pitch(1500)
         self.set_yaw(1500)
         while self.get_sim_time_cached() < tstart + timeout:
             m = self.mav.recv_match(type='ATTITUDE', blocking=True)

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -348,7 +348,7 @@ class AutoTestQuadPlane(AutoTest):
         self.progress("Waiting for level flight")
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
         while self.get_sim_time_cached() < tstart + timeout:
             m = self.mav.recv_match(type='ATTITUDE', blocking=True)
             roll = math.degrees(m.roll)
@@ -566,13 +566,13 @@ class AutoTestQuadPlane(AutoTest):
     def test_pilot_yaw(self):
         self.takeoff(10, mode="QLOITER")
         self.set_parameter("STICK_MIXING", 0)
-        self.set_rc(4, 1700)
+        self.set_yaw(1700)
         for mode in "QLOITER", "QHOVER":
             self.wait_heading(45)
             self.wait_heading(90)
             self.wait_heading(180)
             self.wait_heading(275)
-        self.set_rc(4, 1500)
+        self.set_yaw(1500)
         self.do_RTL()
 
     def CPUFailsafe(self):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -346,7 +346,7 @@ class AutoTestQuadPlane(AutoTest):
         """Wait for level flight."""
         tstart = self.get_sim_time()
         self.progress("Waiting for level flight")
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.set_rc(2, 1500)
         self.set_yaw(1500)
         while self.get_sim_time_cached() < tstart + timeout:
@@ -371,9 +371,9 @@ class AutoTestQuadPlane(AutoTest):
         for i in range(0, 4):
             # hard left
             self.progress("Starting turn %u" % i)
-            self.set_rc(1, 1000)
+            self.set_roll(1000)
             self.wait_heading(270 - (90*i), accuracy=10)
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
             self.progress("Starting leg %u" % i)
             self.wait_distance(100, accuracy=20)
         self.progress("Circuit complete")
@@ -610,14 +610,14 @@ class AutoTestQuadPlane(AutoTest):
 
         self.context_push()
         self.progress("Rolling over hard")
-        self.set_rc(1, 1000)
+        self.set_roll(1000)
         self.wait_roll(-65, 5)
         self.progress("Killing servo outputs to force qassist to help")
         self.set_parameter("SERVO1_MIN", 1480)
         self.set_parameter("SERVO1_MAX", 1480)
         self.set_parameter("SERVO1_TRIM", 1480)
         self.progress("Trying to roll over hard the other way")
-        self.set_rc(1, 2000)
+        self.set_roll(2000)
         self.progress("Waiting for qassist (angle) to kick in")
         self.wait_servo_channel_value(5, 1100, timeout=30, comparator=operator.gt)
         self.wait_roll(85, 5)

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -247,11 +247,11 @@ class AutoTestQuadPlane(AutoTest):
             self.change_mode(mode)
             self.arm_vehicle()
             self.progress("Raising throttle")
-            self.set_rc(3, 1800)
+            self.set_throttle(1800)
             self.progress("Waiting for Motor1 to start")
             self.wait_servo_channel_value(5, 1100, comparator=operator.gt)
 
-            self.set_rc(3, 1000)
+            self.set_throttle(1000)
             self.disarm_vehicle()
             self.wait_ready_to_arm()
 
@@ -283,12 +283,12 @@ class AutoTestQuadPlane(AutoTest):
         self.change_mode("QHOVER")
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        self.set_rc(3, 1800)
+        self.set_throttle(1800)
         self.wait_altitude(30,
                            40,
                            relative=True,
                            timeout=30)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.change_mode("QAUTOTUNE")
         tstart = self.get_sim_time()
         sim_time_expected = 5000
@@ -304,7 +304,7 @@ class AutoTestQuadPlane(AutoTest):
             if "AutoTune: Success" in m.text:
                 break
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-        self.set_rc(3, 1200)
+        self.set_throttle(1200)
         self.wait_altitude(-5, 1, relative=True, timeout=30)
         while self.get_sim_time_cached() < deadline:
             self.mavproxy.send('disarm\n')
@@ -320,12 +320,12 @@ class AutoTestQuadPlane(AutoTest):
         self.change_mode(mode)
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        self.set_rc(3, 1800)
+        self.set_throttle(1800)
         self.wait_altitude(height,
                            height+5,
                            relative=True,
                            timeout=30)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
 
     def do_RTL(self):
         self.change_mode("QRTL")
@@ -363,7 +363,7 @@ class AutoTestQuadPlane(AutoTest):
         """Fly a left circuit, 200m on a side."""
         self.mavproxy.send('switch 4\n')
         self.change_mode('FBWA')
-        self.set_rc(3, 1700)
+        self.set_throttle(1700)
         self.wait_level_flight()
 
         self.progress("Flying left circuit")
@@ -378,11 +378,11 @@ class AutoTestQuadPlane(AutoTest):
             self.wait_distance(100, accuracy=20)
         self.progress("Circuit complete")
         self.change_mode('QHOVER')
-        self.set_rc(3, 1100)
+        self.set_throttle(1100)
         self.wait_altitude(10, 15,
                            relative=True,
                            timeout=60)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
 
     def hover_and_check_matched_frequency(self, dblevel=-15, minhz=200, maxhz=300, fftLength=32, peakhz=None):
 
@@ -582,7 +582,7 @@ class AutoTestQuadPlane(AutoTest):
     def test_qassist(self):
         # find a motor peak
         self.takeoff(10, mode="QHOVER")
-        self.set_rc(3, 1800)
+        self.set_throttle(1800)
         self.change_mode("FBWA")
         thr_min_pwm = self.get_parameter("Q_THR_MIN_PWM")
         self.progress("Waiting for motors to stop (transition completion)")
@@ -596,17 +596,17 @@ class AutoTestQuadPlane(AutoTest):
                                       timeout=30,
                                       comparator=operator.eq)
         self.progress("Stopping forward motor to kill airspeed below limit")
-        self.set_rc(3, 1000)
+        self.set_throttle(1000)
         self.progress("Waiting for qassist to kick in")
         self.wait_servo_channel_value(5, 1400, timeout=30, comparator=operator.gt)
         self.progress("Move forward again, check qassist stops")
-        self.set_rc(3, 1800)
+        self.set_throttle(1800)
         self.progress("Checking qassist stops")
         self.wait_servo_channel_value(5,
                                       thr_min_pwm,
                                       timeout=30,
                                       comparator=operator.eq)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
 
         self.context_push()
         self.progress("Rolling over hard")

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -167,9 +167,9 @@ class AutoTestRover(AutoTest):
         for i in range(0, 4):
             # hard left
             self.progress("Starting turn %u" % i)
-            self.set_rc(1, 1000)
+            self.set_roll(1000)
             self.wait_heading(270 - (90*i), accuracy=10)
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
             self.progress("Starting leg %u" % i)
             self.wait_distance(50, accuracy=7)
         self.set_throttle(1500)
@@ -316,7 +316,7 @@ class AutoTestRover(AutoTest):
             self.arm_vehicle()
 
             self.set_throttle(2000)
-            self.set_rc(1, 1000)
+            self.set_roll(1000)
 
             tstart = self.get_sim_time()
             while self.get_sim_time_cached() - tstart < timeout:
@@ -326,7 +326,7 @@ class AutoTestRover(AutoTest):
 
             # reduce throttle
             self.set_throttle(1500)
-            self.set_rc(1, 1500)
+            self.set_roll(1500)
 
         except Exception as e:
             self.progress("Caught exception: %s" %
@@ -5095,18 +5095,18 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.arm_vehicle()
         self.progress("get a known heading to avoid worrying about wrap")
         # this is steering-type-two-paddles
-        self.set_rc(1, 1400)
+        self.set_roll(1400)
         self.set_throttle(1500)
         self.wait_heading(90)
         self.progress("straighten up")
-        self.set_rc(1, 1500)
+        self.set_roll(1500)
         self.set_throttle(1500)
         self.progress("steer one way")
-        self.set_rc(1, 1600)
+        self.set_roll(1600)
         self.set_throttle(1400)
         self.wait_heading(120)
         self.progress("steer the other")
-        self.set_rc(1, 1400)
+        self.set_roll(1400)
         self.set_throttle(1600)
         self.wait_heading(60)
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -160,7 +160,7 @@ class AutoTestRover(AutoTest):
         """Drive a left circuit, 50m on a side."""
         self.mavproxy.send('switch 6\n')
         self.wait_mode('MANUAL')
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
 
         self.progress("Driving left circuit")
         # do 4 turns
@@ -172,7 +172,7 @@ class AutoTestRover(AutoTest):
             self.set_rc(1, 1500)
             self.progress("Starting leg %u" % i)
             self.wait_distance(50, accuracy=7)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.progress("Circuit complete")
 
     # def test_throttle_failsafe(self, home, distance_min=10, side=60,
@@ -195,7 +195,7 @@ class AutoTestRover(AutoTest):
     #
     #     # pull throttle low
     #     self.progress("# Enter Failsafe")
-    #     self.mavproxy.send('rc 3 900\n')
+    #     self.set_throttle(900)
     #
     #     tstart = self.get_sim_time()
     #     success = False
@@ -211,7 +211,7 @@ class AutoTestRover(AutoTest):
     #             success = True
     #
     #     # reduce throttle
-    #     self.mavproxy.send('rc 3 1500\n')
+    #     self.set_throttle(1500)
     #     self.mavproxy.expect('APM: Failsafe ended')
     #     self.mavproxy.send('switch 2\n')  # manual mode
     #     self.wait_heartbeat()
@@ -287,7 +287,7 @@ class AutoTestRover(AutoTest):
             self.wait_servo_channel_value(pump_ch, pump_ch_min)
 
             self.progress("Testing speed-ramping")
-            self.set_rc(3, 1700) # start driving forward
+            self.set_throttle(1700) # start driving forward
 
             # this is somewhat empirical...
             self.wait_servo_channel_value(pump_ch, 1695, timeout=60)
@@ -315,7 +315,7 @@ class AutoTestRover(AutoTest):
             self.wait_ready_to_arm()
             self.arm_vehicle()
 
-            self.set_rc(3, 2000)
+            self.set_throttle(2000)
             self.set_rc(1, 1000)
 
             tstart = self.get_sim_time()
@@ -325,7 +325,7 @@ class AutoTestRover(AutoTest):
                     self.progress("Current speed: %f" % m.groundspeed)
 
             # reduce throttle
-            self.set_rc(3, 1500)
+            self.set_throttle(1500)
             self.set_rc(1, 1500)
 
         except Exception as e:
@@ -349,7 +349,7 @@ class AutoTestRover(AutoTest):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.mavproxy.send('switch 4\n')  # auto mode
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.wait_mode('AUTO')
         self.wait_waypoint(1, 4, max_dist=5)
         self.mavproxy.expect("Mission Complete")
@@ -392,7 +392,7 @@ class AutoTestRover(AutoTest):
         # at time of writing, the vehicle is only capable of 10m/s/s accel
         self.set_parameter('ATC_ACCEL_MAX', 15)
         self.change_mode("STEERING")
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.wait_groundspeed(15, 100)
         initial = self.mav.location()
         initial_time = time.time()
@@ -401,7 +401,7 @@ class AutoTestRover(AutoTest):
             start = self.mav.location()
             if start != initial:
                 break
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.wait_groundspeed(0, 0.2)  # why do we not stop?!
         initial = self.mav.location()
         initial_time = time.time()
@@ -515,7 +515,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             # first make sure we can breach the fence:
             self.set_rc(10, 1000)
             self.change_mode("ACRO")
-            self.set_rc(3, 1550)
+            self.set_throttle(1550)
             self.wait_distance_to_home(25, 100000, timeout=60)
             self.change_mode("RTL")
             self.mavproxy.expect("APM: Reached destination")
@@ -652,7 +652,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         throttle_override = 1900
 
         self.progress("Establishing baseline RC input")
-        self.mavproxy.send('rc 3 %u\n' % normal_rc_throttle)
+        self.set_throttle(normal_rc_throttle)
         self.drain_mav()
         tstart = self.get_sim_time()
         while True:
@@ -721,11 +721,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.mavproxy.send('switch 6\n')  # Manual mode
             self.wait_mode('MANUAL')
             self.wait_ready_to_arm()
-            self.mavproxy.send('rc 3 1500\n')  # throttle at zero
+            self.zero_throttle()
             self.arm_vehicle()
             # start moving forward a little:
             normal_rc_throttle = 1700
-            self.mavproxy.send('rc 3 %u\n' % normal_rc_throttle)
+            self.set_throttle(normal_rc_throttle)
             self.wait_groundspeed(5, 100)
 
             # allow overrides:
@@ -908,7 +908,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.arm_vehicle()
             self.progress("start moving forward a little")
             normal_rc_throttle = 1700
-            self.mavproxy.send('rc 3 %u\n' % normal_rc_throttle)
+            self.set_throttle(normal_rc_throttle)
             self.wait_groundspeed(5, 100)
 
             self.progress("allow overrides")
@@ -4399,17 +4399,17 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # the middle of the square
         self.progress("Driving North")
         self.reach_heading_manual(0)
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.delay_sim_time(5)
-        self.set_rc(3, 1000)
+        self.set_throttle(1000)
         self.wait_groundspeed(0, 1)
         loc = self.mav.location()
         self.progress("Driving East")
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.reach_heading_manual(90)
-        self.set_rc(3, 2000)
+        self.set_throttle(2000)
         self.delay_sim_time(5)
-        self.set_rc(3, 1000)
+        self.set_throttle(1000)
 
         self.progress("Entering smartrtl")
         self.change_mode("SMART_RTL")
@@ -4543,7 +4543,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.wait_ready_to_arm()
             self.change_mode("MANUAL")
             self.arm_vehicle()
-            self.set_rc(3, 1600)
+            self.set_throttle(1600)
 
             m = self.mav.recv_match(type='WHEEL_DISTANCE', blocking=True, timeout=5)
             if m is None:
@@ -5096,18 +5096,18 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress("get a known heading to avoid worrying about wrap")
         # this is steering-type-two-paddles
         self.set_rc(1, 1400)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.wait_heading(90)
         self.progress("straighten up")
         self.set_rc(1, 1500)
-        self.set_rc(3, 1500)
+        self.set_throttle(1500)
         self.progress("steer one way")
         self.set_rc(1, 1600)
-        self.set_rc(3, 1400)
+        self.set_throttle(1400)
         self.wait_heading(120)
         self.progress("steer the other")
         self.set_rc(1, 1400)
-        self.set_rc(3, 1600)
+        self.set_throttle(1600)
         self.wait_heading(60)
 
     def tests(self):


### PR DESCRIPTION
Enforce use of our set_rc function. Add helper for RCMAP channel.
add test to validate that forbidden function aren't used.

The goal is to prevent copy-past error like in https://github.com/ArduPilot/ardupilot/pull/15036