### PR TITLE
Add compile time flag for disabling the interlock on the Heli frame type

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -207,7 +207,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
             return false;
         }
         // Ensure an Aux Channel is configured for motor interlock
-        if (rc().find_channel_for_option(RC_Channel::aux_func_t::MOTOR_INTERLOCK) == nullptr) {
+        if (copter.ap.using_interlock && rc().find_channel_for_option(RC_Channel::aux_func_t::MOTOR_INTERLOCK) == nullptr) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Motor Interlock not configured");
             return false;
         }

--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -84,7 +84,7 @@ void Copter::update_using_interlock()
 {
 #if FRAME_CONFIG == HELI_FRAME
     // helicopters are always using motor interlock
-    ap.using_interlock = true;
+    ap.using_interlock = HELI_USING_INTERLOCK;
 #else
     // check if we are using motor interlock control on an aux switch or are in throw mode
     // which uses the interlock to stop motors while the copter is being thrown

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -8,6 +8,10 @@
  #define HELI_DYNAMIC_FLIGHT_SPEED_MIN      500     // we are in "dynamic flight" when the speed is over 5m/s for 2 seconds
 #endif
 
+#ifndef HELI_USING_INTERLOCK
+ #define HELI_USING_INTERLOCK               true
+#endif
+
 // counter to control dynamic flight profile
 static int8_t heli_dynamic_flight_counter;
 


### PR DESCRIPTION
This change allows for the `using_interlocks` field to be changed at compile time. This is important when using a companion computer without an RC controller in the loop. Without this change, the companion computer would either need to:

1) Override pre-arming checks in the COMPONENT_ARM_DISARM command.
2) Use RC_OVERRIDE to manipulate the interlock

Both of these approaches are error prone. For case (1) this could result in the companion computer accidentally overriding other important pre-arm checks. For case (2) the use of RC_OVERRIDE is difficult to pull off in a sane way as these mavlink commands change the state of the RC_Channels, and is thus an additional safety-critical state the companion computer must keep track of.