### PR TITLE
AP_HAL_ChibiOS: CubeOrange map EXTERN_DRDY and !EXTERN_CS to ADC

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md
@@ -590,6 +590,8 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
  - PWM4 53
  - PWM5 54
  - PWM6 55
+ - EXTERN_GPIO1 1 (requires custom carrier board, and alternate pin configuration 2)
+ - EXTERN_GPIO2 2 (requires custom carrier board, and alternate pin configuration 2)
 
 ## Analog inputs
 
@@ -601,6 +603,8 @@ The CubeOrange has 7 analog inputs
  - ADC Pin4 -> Battery2 Current Sensor
  - ADC Pin18 -> Vdd 5V supply sense
  - ADC Pin8 -> ADC port input
+ - ADC Pin9 -> EXTERN_GPIO1 (requires custom carrier board)
+ - ADC Pin5 -> EXTERN_GPIO2 (requires custom carrier board)
  - ADC Pin103 -> RSSI voltage monitoring
 
 ## IMU Heater

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc
@@ -71,10 +71,12 @@ PA14 JTCK-SWCLK SWD
 # PWM output for buzzer
 PA15 TIM2_CH1 TIM2 GPIO(77) ALARM
 
-# This defines a couple of general purpose outputs, mapped to GPIO
-# numbers 1 and 2 for users.
-PB0 EXTERN_GPIO1 OUTPUT GPIO(1)
-PB1 EXTERN_GPIO2 OUTPUT GPIO(2)
+# Map the EXTERN_DRDY and !EXTERN_CS as analog inputs in
+PB0 PB0_ADC ADC1 SCALE(1)
+PB1 PB1_ADC ADC1 SCALE(1)
+# also keep them available as a GPIO alt config
+PB0 EXTERN_GPIO1 OUTPUT GPIO(1) ALT(2)
+PB1 EXTERN_GPIO2 OUTPUT GPIO(2) ALT(2)
 
 # This defines some input pins, currently unused.
 PB2 BOOT1 INPUT

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
@@ -590,6 +590,8 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
  - PWM4 53
  - PWM5 54
  - PWM6 55
+ - EXTERN_GPIO1 1 (requires custom carrier board, and alternate pin configuration 2)
+ - EXTERN_GPIO2 2 (requires custom carrier board, and alternate pin configuration 2)
 
 ## Analog inputs
 
@@ -601,6 +603,8 @@ The CubeOrangePlus has 7 analog inputs
  - ADC Pin4 -> Battery2 Current Sensor
  - ADC Pin18 -> Vdd 5V supply sense
  - ADC Pin8 -> ADC port input
+ - ADC Pin9 -> EXTERN_GPIO1 (requires custom carrier board)
+ - ADC Pin5 -> EXTERN_GPIO2 (requires custom carrier board)
  - ADC Pin103 -> RSSI voltage monitoring
 
 ## IMU Heater


### PR DESCRIPTION
This maps the same change onto CubeOrange that we have for CubeBlack, which allows you to use the EXTERN_DRDY and !EXTERN_CS pins as ADC pins. This is generally useful as I have carrier boards which map this out and use it, and the usage of the bus as SPI is strongly discouraged/not desired. I've validated this on my carrier board here.

@bugobliterator @proficnc any concerns with bringing this change in by default, so that we don't have to maintain a custom hwdef for the feature?