### PR TITLE
autotest: fix frsky bitop on float issue

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -6180,9 +6180,9 @@ switch value'''
     def tf_encode_gps_latitude(self,lat):
         value = 0
         if lat < 0:
-            value = ((abs(lat)/100)*6) | 0x40000000
+            value = ((abs(lat)//100)*6) | 0x40000000
         else:
-            value = ((abs(lat)/100)*6)
+            value = ((abs(lat)//100)*6)
         return value
 
     def tf_validate_gps(self, value): # shared by proto 4 and proto 10


### PR DESCRIPTION
Crops up in Python 3.8:

```
    gpi_lat = self.tf_encode_gps_latitude(gpi.lat)
  File "/home/pbarker/rc/ardupilot/Tools/autotest/common.py", line 6183, in tf_encode_gps_latitude
    value = ((abs(lat)/100)*6) | 0x40000000
TypeError: unsupported operand type(s) for |: 'float' and 'int'
```