### PR TITLE
Create and use an AP_Avoidance::RecoveryAction enumeration

### DIFF
--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -97,7 +97,7 @@ MAV_COLLISION_ACTION AP_Avoidance_Copter::handle_avoidance(const AP_Avoidance::O
     return actual_action;
 }
 
-void AP_Avoidance_Copter::handle_recovery(uint8_t recovery_action)
+void AP_Avoidance_Copter::handle_recovery(RecoveryAction recovery_action)
 {
     // check we are coming out of failsafe
     if (copter.failsafe.adsb) {
@@ -109,19 +109,19 @@ void AP_Avoidance_Copter::handle_recovery(uint8_t recovery_action)
         if (copter.control_mode_reason == ModeReason::AVOIDANCE) {
             switch (recovery_action) {
 
-            case AP_AVOIDANCE_RECOVERY_REMAIN_IN_AVOID_ADSB:
+            case RecoveryAction::REMAIN_IN_AVOID_ADSB:
                 // do nothing, we'll stay in the AVOID_ADSB mode which is guided which will loiter forever
                 break;
 
-            case AP_AVOIDANCE_RECOVERY_RESUME_PREVIOUS_FLIGHTMODE:
+            case RecoveryAction::RESUME_PREVIOUS_FLIGHTMODE:
                 set_mode_else_try_RTL_else_LAND(prev_control_mode);
                 break;
 
-            case AP_AVOIDANCE_RECOVERY_RTL:
+            case RecoveryAction::RTL:
                 set_mode_else_try_RTL_else_LAND(Mode::Number::RTL);
                 break;
 
-            case AP_AVOIDANCE_RECOVERY_RESUME_IF_AUTO_ELSE_LOITER:
+            case RecoveryAction::RESUME_IF_AUTO_ELSE_LOITER:
                 if (prev_control_mode == Mode::Number::AUTO) {
                     set_mode_else_try_RTL_else_LAND(Mode::Number::AUTO);
                 }

--- a/ArduCopter/avoidance_adsb.h
+++ b/ArduCopter/avoidance_adsb.h
@@ -24,7 +24,7 @@ protected:
     MAV_COLLISION_ACTION handle_avoidance(const AP_Avoidance::Obstacle *obstacle, MAV_COLLISION_ACTION requested_action) override;
 
     // override recovery handler
-    void handle_recovery(uint8_t recovery_action) override;
+    void handle_recovery(RecoveryAction recovery_action) override;
 
     // check flight mode is avoid_adsb
     bool check_flightmode(bool allow_mode_change);

--- a/ArduPlane/avoidance_adsb.cpp
+++ b/ArduPlane/avoidance_adsb.cpp
@@ -97,34 +97,34 @@ MAV_COLLISION_ACTION AP_Avoidance_Plane::handle_avoidance(const AP_Avoidance::Ob
     return actual_action;
 }
 
-void AP_Avoidance_Plane::handle_recovery(uint8_t recovery_action)
+void AP_Avoidance_Plane::handle_recovery(RecoveryAction recovery_action)
 {
     // check we are coming out of failsafe
     if (plane.failsafe.adsb) {
         plane.failsafe.adsb = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "Avoid: Resuming with action: %d", recovery_action);
+        gcs().send_text(MAV_SEVERITY_INFO, "Avoid: Resuming with action: %u", (unsigned)recovery_action);
 
         // restore flight mode if requested and user has not changed mode since
         if (plane.control_mode_reason == ModeReason::AVOIDANCE) {
             switch (recovery_action) {
 
-            case AP_AVOIDANCE_RECOVERY_REMAIN_IN_AVOID_ADSB:
+            case RecoveryAction::REMAIN_IN_AVOID_ADSB:
                 // do nothing, we'll stay in the AVOID_ADSB mode which is guided which will loiter
                 break;
 
-            case AP_AVOIDANCE_RECOVERY_RESUME_PREVIOUS_FLIGHTMODE:
+            case RecoveryAction::RESUME_PREVIOUS_FLIGHTMODE:
                 plane.set_mode_by_number(prev_control_mode_number, ModeReason::AVOIDANCE_RECOVERY);
                 break;
 
-            case AP_AVOIDANCE_RECOVERY_RTL:
+            case RecoveryAction::RTL:
                 plane.set_mode(plane.mode_rtl, ModeReason::AVOIDANCE_RECOVERY);
                 break;
 
-            case AP_AVOIDANCE_RECOVERY_RESUME_IF_AUTO_ELSE_LOITER:
+            case RecoveryAction::RESUME_IF_AUTO_ELSE_LOITER:
                 if (prev_control_mode_number == Mode::Number::AUTO) {
                     plane.set_mode(plane.mode_auto, ModeReason::AVOIDANCE_RECOVERY);
                 }
-                // else do nothing, same as AP_AVOIDANCE_RECOVERY_LOITER
+                // else do nothing, same as RecoveryAction::LOITER
                 break;
 
             default:

--- a/ArduPlane/avoidance_adsb.h
+++ b/ArduPlane/avoidance_adsb.h
@@ -20,7 +20,7 @@ protected:
     MAV_COLLISION_ACTION handle_avoidance(const AP_Avoidance::Obstacle *obstacle, MAV_COLLISION_ACTION requested_action) override;
 
     // override recovery handler
-    void handle_recovery(uint8_t recovery_action) override;
+    void handle_recovery(RecoveryAction recovery_action) override;
 
     // check flight mode is avoid_adsb
     bool check_flightmode(bool allow_mode_change);

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -15,7 +15,7 @@ extern const AP_HAL::HAL& hal;
     #define AP_AVOIDANCE_WARN_DISTANCE_Z_DEFAULT        300
     #define AP_AVOIDANCE_FAIL_DISTANCE_XY_DEFAULT       300
     #define AP_AVOIDANCE_FAIL_DISTANCE_Z_DEFAULT        100
-    #define AP_AVOIDANCE_RECOVERY_DEFAULT               AP_AVOIDANCE_RECOVERY_RESUME_IF_AUTO_ELSE_LOITER
+    #define AP_AVOIDANCE_RECOVERY_DEFAULT               RecoveryAction::RESUME_IF_AUTO_ELSE_LOITER
     #define AP_AVOIDANCE_FAIL_ACTION_DEFAULT            MAV_COLLISION_ACTION_REPORT
 #else // APM_BUILD_TYPE(APM_BUILD_ArduCopter), Rover, Boat
     #define AP_AVOIDANCE_WARN_TIME_DEFAULT              30
@@ -24,7 +24,7 @@ extern const AP_HAL::HAL& hal;
     #define AP_AVOIDANCE_WARN_DISTANCE_Z_DEFAULT        300
     #define AP_AVOIDANCE_FAIL_DISTANCE_XY_DEFAULT       100
     #define AP_AVOIDANCE_FAIL_DISTANCE_Z_DEFAULT        100
-    #define AP_AVOIDANCE_RECOVERY_DEFAULT               AP_AVOIDANCE_RECOVERY_RTL
+    #define AP_AVOIDANCE_RECOVERY_DEFAULT               RecoveryAction::RTL
     #define AP_AVOIDANCE_FAIL_ACTION_DEFAULT            MAV_COLLISION_ACTION_REPORT
 #endif
 
@@ -64,7 +64,7 @@ const AP_Param::GroupInfo AP_Avoidance::var_info[] = {
     // @Description: Determines what the aircraft will do after a fail event is resolved
     // @Values: 0:Remain in AVOID_ADSB,1:Resume previous flight mode,2:RTL,3:Resume if AUTO else Loiter
     // @User: Advanced
-    AP_GROUPINFO("F_RCVRY",     4, AP_Avoidance, _fail_recovery, AP_AVOIDANCE_RECOVERY_DEFAULT),
+    AP_GROUPINFO("F_RCVRY",     4, AP_Avoidance, _fail_recovery, uint8_t(AP_AVOIDANCE_RECOVERY_DEFAULT)),
 
     // @Param: OBS_MAX
     // @DisplayName: Maximum number of obstacles to track
@@ -168,7 +168,7 @@ void AP_Avoidance::deinit(void)
         delete [] _obstacles;
         _obstacles = nullptr;
         _obstacles_allocated = 0;
-        handle_recovery(AP_AVOIDANCE_RECOVERY_RTL);
+        handle_recovery(RecoveryAction::RTL);
     }
     _obstacle_count = 0;
 }
@@ -554,7 +554,7 @@ void AP_Avoidance::handle_avoidance_local(AP_Avoidance::Obstacle *threat)
         if (((now - _last_state_change_ms) > AP_AVOIDANCE_STATE_RECOVERY_TIME_MS) || (new_threat_level > _threat_level)) {
             // handle recovery from high threat level
             if (_threat_level == MAV_COLLISION_THREAT_LEVEL_HIGH) {
-                handle_recovery(_fail_recovery);
+                handle_recovery(RecoveryAction(_fail_recovery.get()));
                 _latest_action = MAV_COLLISION_ACTION_NONE;
             }
 

--- a/libraries/AP_Avoidance/AP_Avoidance.h
+++ b/libraries/AP_Avoidance/AP_Avoidance.h
@@ -27,12 +27,6 @@
 
 #include <AP_ADSB/AP_ADSB.h>
 
-// F_RCVRY possible parameter values
-#define AP_AVOIDANCE_RECOVERY_REMAIN_IN_AVOID_ADSB                  0
-#define AP_AVOIDANCE_RECOVERY_RESUME_PREVIOUS_FLIGHTMODE            1
-#define AP_AVOIDANCE_RECOVERY_RTL                                   2
-#define AP_AVOIDANCE_RECOVERY_RESUME_IF_AUTO_ELSE_LOITER            3
-
 #define AP_AVOIDANCE_STATE_RECOVERY_TIME_MS                 2000    // we will not downgrade state any faster than this (2 seconds)
 
 #define AP_AVOIDANCE_ESCAPE_TIME_SEC                        2       // vehicle runs from thread for 2 seconds
@@ -51,6 +45,14 @@ public:
     static AP_Avoidance *get_singleton() {
         return _singleton;
     }
+
+    // F_RCVRY possible parameter values:
+    enum class RecoveryAction {
+        REMAIN_IN_AVOID_ADSB       = 0,
+        RESUME_PREVIOUS_FLIGHTMODE = 1,
+        RTL                        = 2,
+        RESUME_IF_AUTO_ELSE_LOITER = 3,
+    };
 
     // obstacle class to hold latest information for a known obstacles
     class Obstacle {
@@ -114,7 +116,7 @@ protected:
 
     // recover after all threats have cleared.  child classes must override this method
     // recovery_action is from F_RCVRY parameter
-    virtual void handle_recovery(uint8_t recovery_action) = 0;
+    virtual void handle_recovery(RecoveryAction recovery_action) = 0;
 
     uint32_t _last_state_change_ms = 0;
     MAV_COLLISION_THREAT_LEVEL _threat_level = MAV_COLLISION_THREAT_LEVEL_NONE;


### PR DESCRIPTION
NFC - simply makes an enumeration to hold the values.

This will allow future cleanups to get the compile to catch unhandled cases in switch statements.
