### PR TITLE
AP_Compass: fix reordering compass devid by priority at boot

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5413,6 +5413,10 @@ class AutoTestCopter(AutoTest):
              "Test SITL onboard compass calibration",
              self.test_mag_calibration),
 
+            ("CompassReordering",
+             "Test Compass reordering when priorities are changed",
+             self.test_mag_reordering),
+
             ("CRSF",
              "Test RC CRSF",
              self.test_crsf),

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2896,8 +2896,8 @@ class AutoTest(ABC):
                 if self.should_fetch_all_for_parameter_change(name.upper()) and value != 0:
                     self.fetch_parameters()
                 return
-        raise ValueError("Param fetch returned incorrect value (%s) vs (%s)"
-                         % (returned_value, value))
+        raise ValueError("Param fetch returned incorrect value for (%s): (%s) vs (%s)"
+                         % (name, returned_value, value))
 
     def get_parameter(self, name, attempts=1, timeout=60):
         """Get parameters from vehicle."""
@@ -4826,6 +4826,163 @@ Also, ignores heartbeats not from our target system'''
             ex = e
             self.mavproxy_unload_module("relay")
             self.mavproxy_unload_module("sitl_calibration")
+        if ex is not None:
+            raise ex
+
+
+    def test_mag_reordering_assert_mag_transform(self, values, transforms):
+        '''transforms ought to be read as, "take all the parameter values from
+        the first compass parameters and shove them into the second indicating
+        compass parameters'''
+                               # create a set of mappings from one
+                               # parameter name to another
+                               # e.g. COMPASS_OFS_X => COMPASS_OFS2_X
+                               # if the transform is [(1,2)].
+                               # [(1,2),(2,1)] should swap the compass
+                               # values
+
+        parameter_mappings = {}
+        for key in values.keys():
+            parameter_mappings[key] = key
+        for (old_compass_num, new_compass_num) in transforms:
+            old_key_compass_bit = str(old_compass_num)
+            if old_key_compass_bit == "1":
+                old_key_compass_bit = ""
+            new_key_compass_bit = str(new_compass_num)
+            if new_key_compass_bit == "1":
+                new_key_compass_bit = ""
+            # vectors first:
+            for key_vector_bit in ["OFS", "DIA", "ODI", "MOT"]:
+                for axis in "X", "Y", "Z":
+                    old_key = "COMPASS_%s%s_%s" % (key_vector_bit,
+                                                   old_key_compass_bit,
+                                                   axis)
+                    new_key = "COMPASS_%s%s_%s" % (key_vector_bit,
+                                                   new_key_compass_bit,
+                                                   axis)
+                    parameter_mappings[old_key] = new_key
+            # then non-vectorey bits:
+            for key_bit in "SCALE", "ORIENT":
+                old_key = "COMPASS_%s%s" % (key_bit, old_key_compass_bit)
+                new_key = "COMPASS_%s%s" % (key_bit, new_key_compass_bit)
+                parameter_mappings[old_key] = new_key
+            # then a sore thumb:
+            if old_key_compass_bit == "":
+                old_key = "COMPASS_EXTERNAL"
+            else:
+                old_key = "COMPASS_EXTERN%s" % old_key_compass_bit
+            if new_key_compass_bit == "":
+                new_key = "COMPASS_EXTERNAL"
+            else:
+                new_key = "COMPASS_EXTERN%s" % new_key_compass_bit
+            parameter_mappings[old_key] = new_key
+
+        for key in values.keys():
+            newkey = parameter_mappings[key]
+            current_value = self.get_parameter(newkey)
+            expected_value = values[key]
+            if abs(current_value - expected_value) > 0.001:
+                raise NotAchievedException("%s has wrong value; want=%f got=%f transforms=%s (old parameter name=%s)" %
+                                           (newkey, expected_value, current_value, str(transforms), key))
+
+    def test_mag_reordering(self):
+        self.context_push()
+        ex = None
+        try:
+            originals = {
+                "COMPASS_OFS_X": 1.1,
+                "COMPASS_OFS_Y": 1.2,
+                "COMPASS_OFS_Z": 1.3,
+                "COMPASS_DIA_X": 1.4,
+                "COMPASS_DIA_Y": 1.5,
+                "COMPASS_DIA_Z": 1.6,
+                "COMPASS_ODI_X": 1.7,
+                "COMPASS_ODI_Y": 1.8,
+                "COMPASS_ODI_Z": 1.9,
+                "COMPASS_MOT_X": 1.91,
+                "COMPASS_MOT_Y": 1.92,
+                "COMPASS_MOT_Z": 1.93,
+                "COMPASS_SCALE": 1.94,
+                "COMPASS_ORIENT": 1,
+                "COMPASS_EXTERNAL": 2,
+
+                "COMPASS_OFS2_X": 2.1,
+                "COMPASS_OFS2_Y": 2.2,
+                "COMPASS_OFS2_Z": 2.3,
+                "COMPASS_DIA2_X": 2.4,
+                "COMPASS_DIA2_Y": 2.5,
+                "COMPASS_DIA2_Z": 2.6,
+                "COMPASS_ODI2_X": 2.7,
+                "COMPASS_ODI2_Y": 2.8,
+                "COMPASS_ODI2_Z": 2.9,
+                "COMPASS_MOT2_X": 2.91,
+                "COMPASS_MOT2_Y": 2.92,
+                "COMPASS_MOT2_Z": 2.93,
+                "COMPASS_SCALE2": 2.94,
+                "COMPASS_ORIENT2": 3,
+                "COMPASS_EXTERN2": 4,
+
+                "COMPASS_OFS3_X": 3.1,
+                "COMPASS_OFS3_Y": 3.2,
+                "COMPASS_OFS3_Z": 3.3,
+                "COMPASS_DIA3_X": 3.4,
+                "COMPASS_DIA3_Y": 3.5,
+                "COMPASS_DIA3_Z": 3.6,
+                "COMPASS_ODI3_X": 3.7,
+                "COMPASS_ODI3_Y": 3.8,
+                "COMPASS_ODI3_Z": 3.9,
+                "COMPASS_MOT3_X": 3.91,
+                "COMPASS_MOT3_Y": 3.92,
+                "COMPASS_MOT3_Z": 3.93,
+                "COMPASS_SCALE3": 3.94,
+                "COMPASS_ORIENT3": 5,
+                "COMPASS_EXTERN3": 6,
+            }
+
+            # quick sanity check to ensure all values are unique:
+            if len(originals.values()) != len(set(originals.values())):
+                raise NotAchievedException("Values are not all unique!")
+
+            self.progress("Setting parameters")
+            for param in originals.keys():
+                self.set_parameter(param, originals[param])
+
+            self.reboot_sitl()
+
+            # no transforms means our originals should be our finals:
+            self.test_mag_reordering_assert_mag_transform(originals, [])
+
+            self.start_subtest("Pushing 1st mag to 3rd")
+            ey = None
+            self.context_push()
+            try:
+                # now try reprioritising compass 1 to be higher than compass 0:
+                prio1_id = self.get_parameter("COMPASS_PRIO1_ID")
+                prio2_id = self.get_parameter("COMPASS_PRIO2_ID")
+                prio3_id = self.get_parameter("COMPASS_PRIO3_ID")
+                self.set_parameter("COMPASS_PRIO1_ID", prio2_id)
+                self.set_parameter("COMPASS_PRIO2_ID", prio3_id)
+                self.set_parameter("COMPASS_PRIO3_ID", prio1_id)
+
+                self.reboot_sitl()
+
+                self.test_mag_reordering_assert_mag_transform(originals, [(2,1),(3,2),(1,3)])
+
+            except Exception as e:
+                self.progress("Caught exception: %s" %
+                              self.get_exception_stacktrace(e))
+                ey = e
+            self.context_pop()
+            self.reboot_sitl()
+            if ey is not None:
+                raise ey
+
+        except Exception as e:
+            self.progress("Caught exception: %s" %
+                          self.get_exception_stacktrace(e))
+            ex = e
+        self.context_pop()
+        self.reboot_sitl()
         if ex is not None:
             raise ex
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -732,7 +732,9 @@ void Compass::init()
     }
 #endif
 
+#if COMPASS_MAX_INSTANCES > 1
     _reorder_compass_params();
+#endif
 
     if (_compass_count == 0) {
         // detect available backends. Only called once
@@ -801,6 +803,7 @@ Compass::Priority Compass::_update_priority_list(int32_t dev_id)
 #endif
 
 
+#if COMPASS_MAX_INSTANCES > 1
 // This method reorganises devid list to match
 // priority list, only call before detection at boot
 void Compass::_reorder_compass_params()
@@ -808,7 +811,16 @@ void Compass::_reorder_compass_params()
     mag_state swap_state;
     StateIndex curr_state_id;
     for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
-        curr_state_id = _get_state_id(i);
+        if (_priority_did_list[i] == 0) {
+            continue;
+        }
+        curr_state_id = COMPASS_MAX_INSTANCES;
+        for (StateIndex j(0); j<COMPASS_MAX_INSTANCES; j++) {
+            if (_priority_did_list[i] == _state[j].dev_id) {
+                curr_state_id = j;
+                break;
+            }
+        }
         if (curr_state_id != COMPASS_MAX_INSTANCES && uint8_t(curr_state_id) != uint8_t(i)) {
             //let's swap
             swap_state.copy_from(_state[curr_state_id]);
@@ -817,6 +829,7 @@ void Compass::_reorder_compass_params()
         }
     }
 }
+#endif
 
 void Compass::mag_state::copy_from(const Compass::mag_state& state)
 {

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -530,7 +530,9 @@ private:
     void _detect_runtime(void);
     // This method reorganises devid list to match
     // priority list, only call before detection at boot
+#if COMPASS_MAX_INSTANCES > 1
     void _reorder_compass_params();
+#endif
     // Update Priority List for Mags, by default, we just
     // load them as they come up the first time
     Priority _update_priority_list(int32_t dev_id);


### PR DESCRIPTION
We were using detected compass state id as we do during runtime. But these values are not filled during boot, leading to invalid ordering per Priority. This PR fixes that by using stored params instead.

This doesn't impact functioning of Compass library, just is bad UX. As user might see different order under devid list and logging/telemetry.