### PR TITLE
use enum class for AC_Fence::Type and AC_Fence::Action

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -429,7 +429,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     bool fence_requires_gps = false;
     #if AC_FENCE == ENABLED
     // if circular or polygon fence is enabled we need GPS
-    fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) > 0;
+    fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_Fence::Type::CIRCLE | AC_Fence::Type::POLYGON)) > 0;
     #endif
 
     // return true if GPS is not required
@@ -523,7 +523,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     bool fence_requires_gps = false;
     #if AC_FENCE == ENABLED
     // if circular or polygon fence is enabled we need GPS
-    fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) > 0;
+    fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_Fence::Type::CIRCLE | AC_Fence::Type::POLYGON)) > 0;
     #endif
 
     if (mode_requires_gps) {

--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -24,12 +24,12 @@ void Copter::fence_check()
     if (new_breaches) {
 
         // if the user wants some kind of response and motors are armed
-        uint8_t fence_act = fence.get_action();
-        if (fence_act != AC_FENCE_ACTION_REPORT_ONLY ) {
+        AC_Fence::Action fence_act = fence.get_action();
+        if (fence_act != AC_Fence::Action::REPORT_ONLY ) {
 
             // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down
-            if (ap.land_complete || (flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & AC_FENCE_TYPE_ALT_MAX)== 0))){
+            if (ap.land_complete || (flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & AC_Fence::Type::ALT_MAX)== 0))){
                 arming.disarm(AP_Arming::Method::FENCEBREACH);
 
             } else {
@@ -39,18 +39,18 @@ void Copter::fence_check()
                     set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                 } else {
                     switch (fence_act) {
-                    case AC_FENCE_ACTION_RTL_AND_LAND:
+                    case AC_Fence::Action::RTL_AND_LAND:
                     default:
                         // switch to RTL, if that fails then Land
                         if (!set_mode(Mode::Number::RTL, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         }
                         break;
-                    case AC_FENCE_ACTION_ALWAYS_LAND:
+                    case AC_Fence::Action::ALWAYS_LAND:
                         // if always land option mode is specified, land
                         set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         break;
-                    case AC_FENCE_ACTION_SMART_RTL:
+                    case AC_Fence::Action::SMART_RTL:
                         // Try SmartRTL, if that fails, RTL, if that fails Land
                         if (!set_mode(Mode::Number::SMART_RTL, ModeReason::FENCE_BREACHED)) {
                             if (!set_mode(Mode::Number::RTL, ModeReason::FENCE_BREACHED)) {
@@ -58,7 +58,7 @@ void Copter::fence_check()
                             }
                         }
                         break;
-                    case AC_FENCE_ACTION_BRAKE:
+                    case AC_Fence::Action::BRAKE:
                         // Try Brake, if that fails Land
                         if (!set_mode(Mode::Number::BRAKE, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -516,7 +516,7 @@ void ModeRTL::compute_return_target()
     //       if terrain altitudes are being used, the code below which reduces the return_target's altitude can lead to
     //       the vehicle not climbing at all as RTL begins.  This can be overly conservative and it might be better
     //       to apply the fence alt limit independently on the origin_point and return_target
-    if ((copter.fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) != 0) {
+    if ((copter.fence.get_enabled_fences() & AC_Fence::Type::ALT_MAX) != 0) {
         // get return target as alt-above-home so it can be compared to fence's alt
         if (rtl_path.return_target.get_alt_cm(Location::AltFrame::ABOVE_HOME, target_alt)) {
             float fence_alt = copter.fence.get_safe_alt_max()*100.0f;

--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -175,7 +175,7 @@ void Sub::update_poscon_alt_max()
 
 #if AC_FENCE == ENABLED
     // set fence altitude limit in position controller
-    if ((fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) != 0) {
+    if ((fence.get_enabled_fences() & AC_Fence::Type::ALT_MAX) != 0) {
         min_alt_cm = fence.get_safe_alt_min()*100.0f;
         max_alt_cm = fence.get_safe_alt_max()*100.0f;
     }

--- a/ArduSub/fence.cpp
+++ b/ArduSub/fence.cpp
@@ -13,16 +13,16 @@ void Sub::fence_check()
         return;
     }
 
-    const uint8_t orig_breaches = fence.get_breaches();
+    const AC_Fence::TypeMask orig_breaches = fence.get_breaches();
 
     // check for new breaches; new_breaches is bitmask of fence types breached
-    const uint8_t new_breaches = fence.check();
+    const AC_Fence::TypeMask new_breaches = fence.check();
 
     // if there is a new breach take action
     if (new_breaches) {
 
         // if the user wants some kind of response and motors are armed
-        if (fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY) {
+        if (fence.get_action() != AC_Fence::Action::REPORT_ONLY) {
             //
             //            // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             //            // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down

--- a/Rover/fence.cpp
+++ b/Rover/fence.cpp
@@ -17,28 +17,28 @@ void Rover::fence_check()
     // if there is a new breach take action
     if (new_breaches) {
         // if the user wants some kind of response and motors are armed
-        if (g2.fence.get_action() != Failsafe_Action_None) {
+        if (g2.fence.get_action() != AC_Fence::Action::REPORT_ONLY) {
             // if within 100m of the fence, it will take the action specified by the FENCE_ACTION parameter
             if (g2.fence.get_breach_distance(new_breaches) <= AC_FENCE_GIVE_UP_DISTANCE) {
                 switch (g2.fence.get_action()) {
-                case Failsafe_Action_None:
+                case AC_Fence::Action::REPORT_ONLY:
                     break;
-                case Failsafe_Action_RTL:
+                case AC_Fence::Action::RTL_AND_LAND:
                     if (!set_mode(mode_rtl, ModeReason::FENCE_BREACHED)) {
                         set_mode(mode_hold, ModeReason::FENCE_BREACHED);
                     }
                     break;
-                case Failsafe_Action_Hold:
+                case AC_Fence::Action::HOLD:
                     set_mode(mode_hold, ModeReason::FENCE_BREACHED);
                     break;
-                case Failsafe_Action_SmartRTL:
+                case AC_Fence::Action::SMART_RTL:
                     if (!set_mode(mode_smartrtl, ModeReason::FENCE_BREACHED)) {
                         if (!set_mode(mode_rtl, ModeReason::FENCE_BREACHED)) {
                             set_mode(mode_hold, ModeReason::FENCE_BREACHED);
                         }
                     }
                     break;
-                case Failsafe_Action_SmartRTL_Hold:
+                case AC_Fence::Action::SMART_RTL_HOLD:
                     if (!set_mode(mode_smartrtl, ModeReason::FENCE_BREACHED)) {
                         set_mode(mode_hold, ModeReason::FENCE_BREACHED);
                     }

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -236,7 +236,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
 
     // calculate distance below fence
     AC_Fence *fence = AP::fence();
-    if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0 && fence && (fence->get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) > 0) {
+    if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0 && fence && (fence->get_enabled_fences() & AC_Fence::Type::ALT_MAX) != 0) {
         // calculate distance from vehicle to safe altitude
         float veh_alt;
         _ahrs.get_relative_position_D_home(veh_alt);
@@ -431,12 +431,12 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
     AC_Fence &_fence = *fence;
 
     // exit if circular fence is not enabled
-    if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
+    if ((_fence.get_enabled_fences() & AC_Fence::Type::CIRCLE) == 0) {
         return;
     }
 
     // exit if the circular fence has already been breached
-    if ((_fence.get_breaches() & AC_FENCE_TYPE_CIRCLE) != 0) {
+    if ((_fence.get_breaches() & AC_Fence::Type::CIRCLE) != 0) {
         return;
     }
 
@@ -543,7 +543,7 @@ void AC_Avoid::adjust_velocity_inclusion_and_exclusion_polygons(float kP, float 
     }
 
     // exit if polygon fences are not enabled
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & AC_Fence::Type::POLYGON) == 0) {
         return;
     }
 
@@ -592,7 +592,7 @@ void AC_Avoid::adjust_velocity_inclusion_circles(float kP, float accel_cmss, Vec
     }
 
     // exit if polygon fences are not enabled
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & AC_Fence::Type::POLYGON) == 0) {
         return;
     }
 
@@ -729,7 +729,7 @@ void AC_Avoid::adjust_velocity_exclusion_circles(float kP, float accel_cmss, Vec
     }
 
     // exit if polygon fences are not enabled
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & AC_Fence::Type::POLYGON) == 0) {
         return;
     }
 

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -449,7 +449,7 @@ bool AP_OABendyRuler::calc_margin_from_circular_fence(const Location &start, con
     if (fence == nullptr) {
         return false;
     }
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
+    if ((fence->get_enabled_fences() & AC_Fence::Type::CIRCLE) == 0) {
         return false;
     }
 
@@ -508,7 +508,7 @@ bool AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_polygons(const Lo
     }
 
     // exclusion polygons enabled along with polygon fences
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & AC_Fence::Type::POLYGON) == 0) {
         return false;
     }
 
@@ -575,7 +575,7 @@ bool AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_circles(const Loc
     }
 
     // inclusion/exclusion circles enabled along with polygon fences
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & AC_Fence::Type::POLYGON) == 0) {
         return false;
     }
 

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -475,7 +475,7 @@ bool AP_OABendyRuler::calc_margin_from_alt_fence(const Location &start, const Lo
     if (fence == nullptr) {
         return false;
     }
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) == 0) {
+    if ((fence->get_enabled_fences() & AC_Fence::Type::ALT_MAX) == 0) {
         return false;
     }
 

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -181,7 +181,7 @@ bool AP_OADijkstra::some_fences_enabled() const
         (fence->polyfence().get_exclusion_circle_count() == 0)) {
         return false;
     }
-    return ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) > 0);
+    return ((fence->get_enabled_fences() & AC_Fence::Type::POLYGON) > 0);
 }
 
 // return error message for a given error id

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -45,8 +45,10 @@ public:
         REPORT_ONLY  = 0, // report to GCS that boundary has been breached but take no further action
         RTL_AND_LAND = 1, // return to launch and, if that fails, land
         ALWAYS_LAND  = 2, // always land
+        HOLD         = 2, // for Rover
         SMART_RTL    = 3, // smartRTL, if that fails, RTL, it that still fails, land
         BRAKE        = 4, // brake, if that fails, land
+        SMART_RTL_HOLD = 4, // for Rover
     };
 
     /* Do not allow copies */

--- a/libraries/GCS_MAVLink/GCS_Fence.cpp
+++ b/libraries/GCS_MAVLink/GCS_Fence.cpp
@@ -55,11 +55,11 @@ void GCS_MAVLINK::send_fence_status() const
 
     // traslate fence library breach types to mavlink breach types
     uint8_t mavlink_breach_type = FENCE_BREACH_NONE;
-    const uint8_t breaches = fence->get_breaches();
-    if ((breaches & AC_FENCE_TYPE_ALT_MAX) != 0) {
+    const AC_Fence::TypeMask breaches = fence->get_breaches();
+    if ((breaches & AC_Fence::Type::ALT_MAX) != 0) {
         mavlink_breach_type = FENCE_BREACH_MAXALT;
     }
-    if ((breaches & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) != 0) {
+    if ((breaches & (AC_Fence::Type::CIRCLE | AC_Fence::Type::POLYGON)) != 0) {
         mavlink_breach_type = FENCE_BREACH_BOUNDARY;
     }
 


### PR DESCRIPTION
This doesn't currently pass CI - there is something very, very odd going on in Rover for these actions - the parameter description for the action is not vehicle-dependent so we shouldn't use the Rover failsafe enumeration (see `fence_check(...) in `Rover/fence.cpp`)
