### PR TITLE
Autotest: remove special case for vicon and default vicon for copter …

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -80,9 +80,6 @@ class AutoTestCopter(AutoTest):
     def default_frame(self):
         return "+"
 
-    def uses_vicon(self):
-        return True
-
     def wait_disarmed_default_wait_time(self):
         return 120
 
@@ -2044,6 +2041,7 @@ class AutoTestCopter(AutoTest):
         """Disable GPS navigation, enable Vicon input."""
         # scribble down a location we can set origin to:
 
+        self.customise_SITL_commandline(["--uartF=sim:vicon:"])
         self.progress("Waiting for location")
         self.mavproxy.send('switch 6\n')  # stabilize mode
         self.wait_heartbeat()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4025,9 +4025,6 @@ Also, ignores heartbeats not from our target system'''
             exit(1)
         self.progress("PASSED: Check for syntax mistake in autotest lambda")
 
-    def uses_vicon(self):
-        return False
-
     def defaults_filepath(self):
         return None
 
@@ -4055,7 +4052,6 @@ Also, ignores heartbeats not from our target system'''
             "home": self.sitl_home(),
             "speedup": self.speedup,
             "valgrind": self.valgrind,
-            "vicon": self.uses_vicon(),
             "wipe": True,
         }
         start_sitl_args.update(**sitl_args)

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -260,7 +260,6 @@ def start_SITL(binary,
                gdbserver=False,
                breakpoints=[],
                disable_breakpoints=False,
-               vicon=False,
                customisations=[],
                lldb=False):
 
@@ -349,8 +348,6 @@ def start_SITL(binary,
         cmd.extend(['--defaults', defaults_filepath])
     if unhide_parameters:
         cmd.extend(['--unhide-groups'])
-    if vicon:
-        cmd.extend(["--uartF=sim:vicon:"])
     cmd.extend(customisations)
 
     if (gdb or lldb) and sys.platform == "darwin" and os.getenv('DISPLAY'):


### PR DESCRIPTION
…to false

Prevent unecessary addition of --uartF=sim:vicon: on Copter test as only one test really use vicon