### PR TITLE
Docker: add /buildlogs directory for autotests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN echo "alias waf=\"/ardupilot/waf\"" >> ~/.bashrc
 # Check that local/bin are in PATH for pip --user installed package
 RUN echo "if [ -d \"\$HOME/.local/bin\" ] ; then\nPATH=\"\$HOME/.local/bin:\$PATH\"\nfi" >> ~/.bashrc
 
+# Set the buildlogs directory into /tmp as other directory aren't accessible
+ENV BUILDLOGS=/tmp/buildlogs
+
 # Cleanup
 RUN DEBIAN_FRONTEND=noninteractive sudo apt-get clean \
     && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
It was failing as the docker user is ardupilot and it cannot make a directory on / as it need to be root. This should have been done earlier in the image building but I don't want everybody to rebuild their images so I add it on the end so the rebuild is minimal