### PR TITLE
Autotest cleanup generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ ParameterMetaData.xml
 apm.pdef.xml
 apm.pdef.json
 parameters.edn
+LogMessages.html
+LogMessages.rst
+LogMessages.xml
 # JetBrains IDE files
 .idea/*
 # CMake

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1101,7 +1101,7 @@ class AutoTest(ABC):
         return htree
 
     def test_parameter_documentation_get_all_parameters(self):
-        xml_filepath = os.path.join(self.rootdir(), "apm.pdef.xml")
+        xml_filepath = os.path.join(self.buildlogs_dirpath(), "apm.pdef.xml")
         param_parse_filepath = os.path.join(self.rootdir(), 'Tools', 'autotest', 'param_metadata', 'param_parse.py')
         try:
             os.unlink(xml_filepath)
@@ -1113,9 +1113,8 @@ class AutoTest(ABC):
         if vehicle == "QuadPlane":
             vehicle = "ArduPlane"
         cmd = [param_parse_filepath, '--vehicle', vehicle]
-#        cmd.append("--verbose")
-        if util.run_cmd(cmd,
-                        directory=util.reltopdir('.')) != 0:
+        # cmd.append("--verbose")
+        if util.run_cmd(cmd, directory=self.buildlogs_dirpath()) != 0:
             self.progress("Failed param_parse.py (%s)" % vehicle)
             return False
         htree = self.htree_from_xml(xml_filepath)
@@ -1394,7 +1393,7 @@ class AutoTest(ABC):
 
     def test_onboard_logging_generation(self):
         '''just generates, as we can't do a lot of testing'''
-        xml_filepath = os.path.join(self.rootdir(), "LogMessages.xml")
+        xml_filepath = os.path.join(self.buildlogs_dirpath(), "LogMessages.xml")
         parse_filepath = os.path.join(self.rootdir(), 'Tools', 'autotest', 'logger_metadata', 'parse.py')
         try:
             os.unlink(xml_filepath)
@@ -1414,8 +1413,7 @@ class AutoTest(ABC):
 
         cmd = [parse_filepath, '--vehicle', vehicle]
 #        cmd.append("--verbose")
-        if util.run_cmd(cmd,
-                        directory=util.reltopdir('.')) != 0:
+        if util.run_cmd(cmd, directory=self.buildlogs_dirpath()) != 0:
             self.progress("Failed parse.py (%s)" % vehicle)
             return False
         length = os.path.getsize(xml_filepath)

--- a/Tools/autotest/logger_metadata/parse.py
+++ b/Tools/autotest/logger_metadata/parse.py
@@ -82,6 +82,7 @@ class LoggerDocco(object):
     def search_for_files(self, dirs_to_search):
         _next = []
         for _dir in dirs_to_search:
+            _dir = os.path.join(topdir, _dir)
             for entry in os.listdir(_dir):
                 filepath = os.path.join(_dir, entry)
                 if os.path.isdir(filepath):


### PR DESCRIPTION
Add LogMessages files to gitignore list
Put the generated files into buildlogs directory
fix logger_metadata generation on relative path