### PR TITLE
AP_NavEKF3: fix skipping of optflow fusion if mag fusion performed

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -20,9 +20,6 @@ void NavEKF3_core::SelectFlowFusion()
     // start performance timer
     hal.util->perf_begin(_perf_FuseOptFlow);
 
-    // Check for data at the fusion time horizon
-    flowDataToFuse = storedOF.recall(ofDataDelayed, imuDataDelayed.time_ms);
-
     // Check if the magnetometer has been fused on that time step and the filter is running at faster than 200 Hz
     // If so, don't fuse measurements on this time step to reduce frame over-runs
     // Only allow one time slip to prevent high rate magnetometer data preventing fusion of other measurements
@@ -32,6 +29,9 @@ void NavEKF3_core::SelectFlowFusion()
     } else {
         optFlowFusionDelayed = false;
     }
+
+    // Check for data at the fusion time horizon
+    flowDataToFuse = storedOF.recall(ofDataDelayed, imuDataDelayed.time_ms);
 
     // Perform Data Checks
     // Check if the optical flow data is still valid

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -31,7 +31,7 @@ void NavEKF3_core::SelectFlowFusion()
     }
 
     // Check for data at the fusion time horizon
-    flowDataToFuse = storedOF.recall(ofDataDelayed, imuDataDelayed.time_ms);
+    const bool flowDataToFuse = storedOF.recall(ofDataDelayed, imuDataDelayed.time_ms);
 
     // Perform Data Checks
     // Check if the optical flow data is still valid
@@ -63,8 +63,6 @@ void NavEKF3_core::SelectFlowFusion()
             // Fuse the optical flow X and Y axis data into the main filter sequentially
             FuseOptFlow();
         }
-        // reset flag to indicate that no new flow data is available for fusion
-        flowDataToFuse = false;
     }
 
     // stop the performance timer

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1195,7 +1195,6 @@ private:
     of_elements ofDataNew;          // OF data at the current time horizon
     of_elements ofDataDelayed;      // OF data at the fusion time horizon
     uint8_t ofStoreIndex;           // OF data storage index
-    bool flowDataToFuse;            // true when optical flow data has is ready for fusion
     bool flowDataValid;             // true while optical flow data is still fresh
     Vector2f auxFlowObsInnov;       // optical flow rate innovation from 1-state terrain offset estimator
     uint32_t flowValidMeaTime_ms;   // time stamp from latest valid flow measurement (msec)


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/15076 which involved EKF3 not consuming optical flow messages if they happened to be recalled from the buffer on an iteration where mag fusion was performed.

This PR also reduces the scope of the "flowDataToFuse" variable to be local to the SelectFlowFusion() method.  This variable is never used outside the SelectFlowFusion() method and it is always updated at the top of the function meaning subsequent calls to the function will always overwrite its previous value.

I've done these tests in SITL:

- The original issue was recreated in SITL by adding some debug to which prints the message, "optflow fusion delayed" if the recall pulled an item out of the buffer but it was not immediately processed.  Then on the next iteration it prints, "flow data to fuse: 0/1" to indicate whether "FlowDataToFuse" was true or not.  Below is a screen shot showing the optical flow messages are being missed.
![image](https://user-images.githubusercontent.com/1498098/90462757-4e8b5000-e144-11ea-9ca7-efb90464dcac.png)

- Next I tested the fix by adding debug to display cases where the flow was delayed but then processed.  Below is a screen shot of this.  I also tested that optical flow worked after the change (i.e. the vehicle could fly in Loiter without a GPS).
![image](https://user-images.githubusercontent.com/1498098/90463011-f143ce80-e144-11ea-96ea-04278c9792d7.png)

I've had a peek at EKF2 but it has a very different method of recalling the flow messages and I think it doesn't suffer from the same bug.  I also checked some of the other sensors (extnav, beacons, etc) and didn't see any other cases of this particular bug.