### PR TITLE
Copter: add pre-arm and mode init checks of ekf's altitude estimate

### DIFF
--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -51,6 +51,7 @@ protected:
     bool mandatory_gps_checks(bool display_failure);
     bool gcs_failsafe_check(bool display_failure);
     bool winch_checks(bool display_failure) const;
+    bool alt_checks(bool display_failure);
 
     void set_pre_arm_check(bool b);
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -863,6 +863,7 @@ private:
     bool position_ok() const;
     bool ekf_position_ok() const;
     bool optflow_position_ok() const;
+    bool ekf_alt_ok() const;
     void update_auto_armed();
     bool should_log(uint32_t mask);
     MAV_TYPE get_frame_mav_type();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -385,6 +385,21 @@ bool Copter::optflow_position_ok() const
     }
 }
 
+// returns true if the ekf has a good altitude estimate (required for modes which do AltHold)
+bool Copter::ekf_alt_ok() const
+{
+    if (!ahrs.have_inertial_nav()) {
+        // do not allow alt control with only dcm
+        return false;
+    }
+
+    // with EKF use filter status and ekf check
+    nav_filter_status filt_status = inertial_nav.get_filter_status();
+
+    // require both vertical velocity and position
+    return (filt_status.flags.vert_vel && filt_status.flags.vert_pos);
+}
+
 // update_auto_armed - update status of auto_armed flag
 void Copter::update_auto_armed()
 {


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/14757 by adding a mandatory pre-arm check of the AHRS/EKF altitude estimate.  A check is also added to the set_mode call to catch problems when the user attempts to switch modes.

The issue is more serious than initially expected if the user sets EKx_ALT_SOURCE = 2 (GPS) because the user could more easily arm and takeoff in AltHold before the EKF gets a good height estimate.  This can lead to the vehicle continuously climbing or descending at it's maximum rate (i.e. 2.5m/s or 1.5m/s) which at best leads to a hard landing.

This has been tested in SITL including reproducing the existing behaviour in master (see below)
![copter-alt-source2-althold](https://user-images.githubusercontent.com/1498098/90481124-35969500-e16c-11ea-8629-cdeff83106fc.png)

Below is a screen shot of some SITL testing in which arming and switching modes while flying was prevented.
![image](https://user-images.githubusercontent.com/1498098/90480236-ee5bd480-e16a-11ea-9d5d-deda8fafb30a.png)

The only small issue we may have is that both the, "Need Position Estimate" and "Need Alt Estimate" messages may be displayed before there is a GPS lock and EKx_ALT_SOURCE = 2.
