### PR TITLE
AP_Soaring: Fix thermalling in mid switch position

### DIFF
--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -190,7 +190,7 @@ SoaringController::LoiterStatus SoaringController::check_cruise_criteria(Vector2
 {
     ActiveStatus status = active_state();
 
-    if (status != ActiveStatus::AUTO_MODE_CHANGE) {
+    if (status == ActiveStatus::SOARING_DISABLED) {
         _cruise_criteria_msg_last = LoiterStatus::DISABLED;
         return LoiterStatus::DISABLED;
     }


### PR DESCRIPTION
This fix applies to the situation of thermalling manually initiated by changing mode to LOITER when the soaring RC switch is in the middle position. Currently the behaviour is to incorrectly exit thermalling right away. This fixes it to continue thermalling as per the wiki.