### PR TITLE
Do not report battery capacity remaining for Sub

### DIFF
--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -39,6 +39,8 @@ protected:
 
     uint64_t capabilities() const override;
 
+    int8_t get_battery_remaining_percentage() const override { return -1; };
+
 private:
 
     void handleMessage(const mavlink_message_t &msg) override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -504,6 +504,7 @@ protected:
     virtual float vfr_hud_airspeed() const;
     virtual int16_t vfr_hud_throttle() const { return 0; }
     virtual float vfr_hud_alt() const;
+    virtual int8_t get_battery_remaining_percentage() const;
 
     static constexpr const float magic_force_arm_value = 2989.0f;
     static constexpr const float magic_force_disarm_value = 21196.0f;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4277,7 +4277,7 @@ void GCS_MAVLINK::send_sys_status()
     int8_t battery_remaining;
 
     if (battery.healthy() && battery.current_amps(battery_current)) {
-        battery_remaining = battery.capacity_remaining_pct();
+        battery_remaining = get_battery_remaining_percentage();
         battery_current = constrain_float(battery_current * 100,-INT16_MAX,INT16_MAX);
     } else {
         battery_current = -1;
@@ -5061,6 +5061,11 @@ void GCS_MAVLINK::manual_override(RC_Channel *c, int16_t value_in, const uint16_
         override_value = radio_min + (radio_max - radio_min) * (value_in + offset) / scaler;
     }
     c->set_override(override_value, tnow);
+}
+
+int8_t GCS_MAVLINK::get_battery_remaining_percentage() const {
+    const AP_BattMonitor &battery = AP::battery();
+    return battery.capacity_remaining_pct();
 }
 
 GCS &gcs()


### PR DESCRIPTION
Subs can easily do multiple flights on one battery, or start flights on a half-charged battery. In these cases integrating the battery current would give a false percentage.

This makes Sub always return -1 for battery capacity remaining. QGC interprets the "-1" as "Battery remaining energy not sent by autopilot" as defined in [SYS_STATUS](https://mavlink.io/en/messages/common.html#SYS_STATUS) spec, and displays voltage instead.

This PR will make users monitor the battery voltage instead of the percentage reported.