### PR TITLE
AP_HAL_ChibiOS: disable IMU fast sampling on F35 / WingFC10

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
@@ -161,3 +161,6 @@ define HAL_BATT_VOLT_PIN 11
 define HAL_BATT_CURR_PIN 12
 define HAL_BATT_VOLT_SCALE 11
 define HAL_BATT_CURR_SCALE 25
+
+# disable IMU fast sampling
+define HAL_DEFAULT_INS_FAST_SAMPLE 0


### PR DESCRIPTION
fast sampling introduces random IMU glitches, bisect search identifies https://github.com/ArduPilot/ardupilot/commit/9c2caf5b121f26a19e3ee5a7d0016e54d8b17fc1 
disabling fast sampling fixes IMU back to expected behaviour. 
see:
https://github.com/ArduPilot/ardupilot/issues/15090
https://discuss.ardupilot.org/t/shaking-horizon-and-jittering-servos/60420
for reference