### PR TITLE
Add support for multiple simulated i2c buses

### DIFF
--- a/libraries/AP_HAL_SITL/I2CDevice.cpp
+++ b/libraries/AP_HAL_SITL/I2CDevice.cpp
@@ -101,6 +101,9 @@ I2CBus I2CDeviceManager::buses[NUM_SITL_I2C_BUSES] {};
 
 I2CDeviceManager::I2CDeviceManager()
 {
+    for (uint8_t i=0; i<ARRAY_SIZE(buses); i++) {
+        buses[i].bus = i;
+    }
 }
 
 AP_HAL::OwnPtr<AP_HAL::I2CDevice>
@@ -132,6 +135,7 @@ I2CDevice::I2CDevice(I2CBus &bus, uint8_t address)
     : _bus(bus)
     , _address(address)
 {
+    ::fprintf(stderr, "bus.bus=%u address=0x%02x\n", bus.bus, address);
     set_device_bus(bus.bus);
     set_device_address(address);
 }
@@ -159,6 +163,7 @@ bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
     unsigned nmsgs = 0;
 
     if (send && send_len != 0) {
+        msgs[nmsgs].bus = _bus.bus;
         msgs[nmsgs].addr = _address;
         msgs[nmsgs].flags = 0;
         msgs[nmsgs].buf = const_cast<uint8_t*>(send);

--- a/libraries/AP_HAL_SITL/I2CDevice.h
+++ b/libraries/AP_HAL_SITL/I2CDevice.h
@@ -81,6 +81,7 @@ public:
 #define I2C_M_RD 1
 #define I2C_RDWR 0
     struct i2c_msg {
+        uint8_t bus;
         uint8_t addr;
         uint8_t flags;
         uint8_t *buf;

--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -94,7 +94,7 @@ int I2C::ioctl_rdwr(i2c_rdwr_ioctl_data *data)
             }
         }
         if (!handled) {
-            ::fprintf(stderr, "Unhandled i2c message: addr=0x%x flags=%u len=%u\n", msg.addr, msg.flags, msg.len);
+            ::fprintf(stderr, "Unhandled i2c message: bus=%u addr=0x%02x flags=%u len=%u\n", msg.bus, msg.addr, msg.flags, msg.len);
             return -1;  // ?!
         }
     }

--- a/libraries/SITL/SIM_I2C.h
+++ b/libraries/SITL/SIM_I2C.h
@@ -40,6 +40,7 @@ public:
 #define I2C_M_RD 1
 #define I2C_RDWR 0
     struct i2c_msg {
+        uint8_t bus;
         uint8_t addr;
         uint8_t flags;
         uint8_t *buf;


### PR DESCRIPTION
This is a rough-as-guts implementation of a simulated QMC5883L i2c device.

It's also on i2c bus 2 for a change - I added multi-bus support.

This was just reverse-engineered from our driver.  Done properly someone needs to read the data sheet....

There's quite a few FIXMEs here.

In particular, need to swipe stuff from the simulated compass driver for noise and adding in compass offsets and whatnot.

![image](https://user-images.githubusercontent.com/7077857/90606657-757c7b80-e243-11ea-920f-1acd8cb0b9a3.png)
