### PR TITLE
AP_NavEKF3/AP_Beacon/SITL: fix SITL environment for testing Beacons

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4764,12 +4764,13 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("BCN_LATITUDE", SITL_START_LOCATION.lat)
             self.set_parameter("BCN_LONGITUDE", SITL_START_LOCATION.lng)
             self.set_parameter("BCN_ALT", SITL_START_LOCATION.alt)
-            self.set_parameter("BCN_ORIENT_YAW", 45)
+            self.set_parameter("BCN_ORIENT_YAW", 0)
             self.set_parameter("AVOID_ENABLE", 4)
             self.set_parameter("GPS_TYPE", 0)
-            self.set_parameter("EK3_GPS_TYPE", 3) # NOGPS
             self.set_parameter("EK3_ENABLE", 1)
+            self.set_parameter("EK3_GPS_TYPE", 3) # NOGPS
             self.set_parameter("EK2_ENABLE", 0)
+            self.set_parameter("AHRS_EKF_TYPE", 3)
 
             self.reboot_sitl()
 

--- a/libraries/AP_Beacon/AP_Beacon_Backend.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Backend.cpp
@@ -26,8 +26,8 @@ AP_Beacon_Backend::AP_Beacon_Backend(AP_Beacon &frontend) :
 {
 }
 
-// set vehicle position:
-// pos should be in the beacon's local frame in meters
+// set vehicle position
+// pos should be in meters in NED frame from the beacon's local origin
 // accuracy_estimate is also in meters
 void AP_Beacon_Backend::set_vehicle_position(const Vector3f& pos, float accuracy_estimate)
 {
@@ -36,7 +36,7 @@ void AP_Beacon_Backend::set_vehicle_position(const Vector3f& pos, float accuracy
     _frontend.veh_pos_ned = correct_for_orient_yaw(pos);
 }
 
-// set individual beacon distance in meters
+// set individual beacon distance from vehicle in meters in NED frame
 void AP_Beacon_Backend::set_beacon_distance(uint8_t beacon_instance, float distance)
 {
     // sanity check instance
@@ -54,8 +54,8 @@ void AP_Beacon_Backend::set_beacon_distance(uint8_t beacon_instance, float dista
     _frontend.beacon_state[beacon_instance].healthy = true;
 }
 
-// configure beacon's position in meters from origin
-// pos should be in the beacon's local frame (meters)
+// set beacon's position
+// pos should be in meters in NED from the beacon's local origin
 void AP_Beacon_Backend::set_beacon_position(uint8_t beacon_instance, const Vector3f& pos)
 {
     // sanity check instance

--- a/libraries/AP_Beacon/AP_Beacon_Backend.h
+++ b/libraries/AP_Beacon/AP_Beacon_Backend.h
@@ -31,14 +31,16 @@ public:
     // update
     virtual void update() = 0;
 
-    // set vehicle position, pos should be in the beacon's local frame
+    // set vehicle position
+    // pos should be in meters in NED frame from the beacon's local origin
+    // accuracy_estimate is also in meters
     void set_vehicle_position(const Vector3f& pos, float accuracy_estimate);
 
-    // set individual beacon distance in meters
+    // set individual beacon distance from vehicle in meters in NED frame
     void set_beacon_distance(uint8_t beacon_instance, float distance);
 
-    // configure beacon's position in meters from origin
-    // pos should be in the beacon's local frame
+    // set beacon's position
+    // pos should be in meters in NED from the beacon's local origin
     void set_beacon_position(uint8_t beacon_instance, const Vector3f& pos);
 
     float get_beacon_origin_lat(void) const { return _frontend.origin_lat; }

--- a/libraries/AP_Beacon/AP_Beacon_SITL.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_SITL.cpp
@@ -100,8 +100,8 @@ void AP_Beacon_SITL::update(void)
     const Vector2f beac_diff = beacon_origin.get_distance_NE(beacon_loc);
     const Vector2f veh_diff = beacon_origin.get_distance_NE(current_loc);
 
-    Vector3f veh_pos3d(veh_diff.x, veh_diff.y, (current_loc.alt - beacon_origin.alt)*1.0e-2f);
-    Vector3f beac_pos3d(beac_diff.x, beac_diff.y, (beacon_origin.alt - beacon_loc.alt)*1.0e-2f);
+    Vector3f veh_pos3d(veh_diff.x, veh_diff.y, (beacon_origin.alt - current_loc.alt)*1.0e-2f);
+    Vector3f beac_pos3d(beac_diff.x, beac_diff.y, (beacon_loc.alt - beacon_origin.alt)*1.0e-2f);
     Vector3f beac_veh_offset = veh_pos3d - beac_pos3d;
 
     set_beacon_position(beacon_id, beac_pos3d);

--- a/libraries/AP_Beacon/AP_Beacon_SITL.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_SITL.cpp
@@ -108,7 +108,6 @@ void AP_Beacon_SITL::update(void)
     set_beacon_distance(beacon_id, beac_veh_offset.length());
     set_vehicle_position(veh_pos3d, 0.5f);
     last_update_ms = now;
-
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -883,14 +883,14 @@ void NavEKF3_core::readRngBcnData()
     }
 
     // Check if the range beacon data can be used to align the vehicle position
-    if (imuSampleTime_ms - rngBcnLast3DmeasTime_ms < 250 && beaconVehiclePosErr < 1.0f && rngBcnAlignmentCompleted) {
+    if ((imuSampleTime_ms - rngBcnLast3DmeasTime_ms < 250) && (beaconVehiclePosErr < 1.0f) && rngBcnAlignmentCompleted) {
         // check for consistency between the position reported by the beacon and the position from the 3-State alignment filter
         const float posDiffSq = sq(receiverPos.x - beaconVehiclePosNED.x) + sq(receiverPos.y - beaconVehiclePosNED.y);
         const float posDiffVar = sq(beaconVehiclePosErr) + receiverPosCov[0][0] + receiverPosCov[1][1];
         if (posDiffSq < 9.0f * posDiffVar) {
             rngBcnGoodToAlign = true;
             // Set the EKF origin and magnetic field declination if not previously set
-            if (!validOrigin && PV_AidingMode != AID_ABSOLUTE) {
+            if (!validOrigin && (PV_AidingMode != AID_ABSOLUTE)) {
                 // get origin from beacon system
                 Location origin_loc;
                 if (beacon->get_origin(origin_loc)) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -828,7 +828,7 @@ void NavEKF3_core::readRngBcnData()
     }
 
     // get the number of beacons in use
-    N_beacons = beacon->count();
+    N_beacons = MIN(beacon->count(), ARRAY_SIZE(lastTimeRngBcn_ms));
 
     // search through all the beacons for new data and if we find it stop searching and push the data into the observation buffer
     bool newDataPushed = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -831,11 +831,11 @@ void NavEKF3_core::readRngBcnData()
     N_beacons = beacon->count();
 
     // search through all the beacons for new data and if we find it stop searching and push the data into the observation buffer
-    bool newDataToPush = false;
+    bool newDataPushed = false;
     uint8_t numRngBcnsChecked = 0;
     // start the search one index up from where we left it last time
     uint8_t index = lastRngBcnChecked;
-    while (!newDataToPush && numRngBcnsChecked < N_beacons) {
+    while (!newDataPushed && (numRngBcnsChecked < N_beacons)) {
         // track the number of beacons checked
         numRngBcnsChecked++;
 
@@ -846,9 +846,9 @@ void NavEKF3_core::readRngBcnData()
         }
 
         // check that the beacon is healthy and has new data
-        if (beacon->beacon_healthy(index) &&
-                beacon->beacon_last_update_ms(index) != lastTimeRngBcn_ms[index])
-        {
+        if (beacon->beacon_healthy(index) && beacon->beacon_last_update_ms(index) != lastTimeRngBcn_ms[index]) {
+            rng_bcn_elements rngBcnDataNew = {};
+
             // set the timestamp, correcting for measurement delay and average intersampling delay due to the filter update rate
             lastTimeRngBcn_ms[index] = beacon->beacon_last_update_ms(index);
             rngBcnDataNew.time_ms = lastTimeRngBcn_ms[index] - frontend->_rngBcnDelay_ms - localFilterTimeStep_ms/2;
@@ -867,10 +867,13 @@ void NavEKF3_core::readRngBcnData()
             rngBcnDataNew.beacon_ID = index;
 
             // indicate we have new data to push to the buffer
-            newDataToPush = true;
+            newDataPushed = true;
 
             // update the last checked index
             lastRngBcnChecked = index;
+
+            // Save data into the buffer to be fused when the fusion time horizon catches up with it
+            storedRangeBeacon.push(rngBcnDataNew);
         }
     }
 
@@ -906,11 +909,6 @@ void NavEKF3_core::readRngBcnData()
         }
     } else {
         rngBcnGoodToAlign = false;
-    }
-
-    // Save data into the buffer to be fused when the fusion time horizon catches up with it
-    if (newDataToPush) {
-        storedRangeBeacon.push(rngBcnDataNew);
     }
 
     // Check the buffer for measurements that have been overtaken by the fusion time horizon and need to be fused

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -815,6 +815,10 @@ void NavEKF3_core::readAirSpdData()
 // check for new range beacon data and push to data buffer if available
 void NavEKF3_core::readRngBcnData()
 {
+    // check that arrays are large enough
+    static_assert(ARRAY_SIZE(lastTimeRngBcn_ms) >= AP_BEACON_MAX_BEACONS, "lastTimeRngBcn_ms should have at least AP_BEACON_MAX_BEACONS elements");
+    static_assert(ARRAY_SIZE(rngBcnFusionReport) >= AP_BEACON_MAX_BEACONS, "rngBcnFusionReport should have at least AP_BEACON_MAX_BEACONS elements");
+
     // get the location of the beacon data
     const AP_Beacon *beacon = AP::beacon();
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -24,7 +24,7 @@ void NavEKF3_core::SelectRngBcnFusion()
                 FuseRngBcn();
             } else {
                 // If we are using GPS, then GPS is the primary reference, but we continue to use the beacon data
-                // to calculate an independant position that is used to update the beacon position offset if we need to
+                // to calculate an independent position that is used to update the beacon position offset if we need to
                 // start using beacon data as the primary reference.
                 FuseRngBcnStatic();
                 // record that the beacon origin needs to be initialised

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -151,7 +151,7 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
         return false;
     }
     // Note: range beacon data is read one beacon at a time and can arrive at a high rate
-    if(!storedRangeBeacon.init(imu_buffer_length)) {
+    if(!storedRangeBeacon.init(imu_buffer_length+1)) {
         return false;
     }
     if (!storedExtNav.init(extnav_buffer_length)) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -353,7 +353,6 @@ void NavEKF3_core::InitialiseVariables()
     memset(&velPosObs, 0, sizeof(velPosObs));
 
     // range beacon fusion variables
-    memset((void *)&rngBcnDataNew, 0, sizeof(rngBcnDataNew));
     memset((void *)&rngBcnDataDelayed, 0, sizeof(rngBcnDataDelayed));
     rngBcnStoreIndex = 0;
     lastRngBcnPassTime_ms = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1284,7 +1284,7 @@ private:
     bool rngBcnTimeout;                 // boolean true if range beacon measurements have failed innovation consistency checks for too long
     float varInnovRngBcn;               // range beacon observation innovation variance (m^2)
     float innovRngBcn;                  // range beacon observation innovation (m)
-    uint32_t lastTimeRngBcn_ms[10];     // last time we received a range beacon measurement (msec)
+    uint32_t lastTimeRngBcn_ms[4];      // last time we received a range beacon measurement (msec)
     bool rngBcnDataToFuse;              // true when there is new range beacon data to fuse
     Vector3f beaconVehiclePosNED;       // NED position estimate from the beacon system (NED)
     float beaconVehiclePosErr;          // estimated position error from the beacon system (m)
@@ -1323,7 +1323,7 @@ private:
         float innovVar;     // innovation variance (m^2)
         float testRatio;    // innovation consistency test ratio
         Vector3f beaconPosNED; // beacon NED position
-    } rngBcnFusionReport[10];
+    } rngBcnFusionReport[4];
 
     // height source selection logic
     uint8_t activeHgtSource;    // integer defining active height source

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1275,7 +1275,6 @@ private:
 
     // Range Beacon Sensor Fusion
     obs_ring_buffer_t<rng_bcn_elements> storedRangeBeacon; // Beacon range buffer
-    rng_bcn_elements rngBcnDataNew;     // Range beacon data at the current time horizon
     rng_bcn_elements rngBcnDataDelayed; // Range beacon data at the fusion time horizon
     uint8_t rngBcnStoreIndex;           // Range beacon data storage index
     uint32_t lastRngBcnPassTime_ms;     // time stamp when the range beacon measurement last passed innovation consistency checks (msec)


### PR DESCRIPTION
This PR allows EKF3's beacons to be tested in SITL and includes the following changes

1. Bug fix for AP_Beacon_SITL's Z-axis position calc.  The sign was reversed compared to the NED that the EKF3 expects
2. AP_NavEKF3 get a few changes:
    - The beacon data buffer is increased by one element to support 100hz update rate from SITL.  The alternative is to slow SITL to send at about 33hz but increasing the buffer by one element seemed like a good trade.
    - Minor memory improvements to more than makeup for the above change including making rngBcnDataNew local and reducing two arrays from 10 elements to 4 and then adding an assert to ensure they are always big enough
3. AutoTest script is slightly fixed up although it's still not good enough to pass.  This test has been disabled for a long time however.

I have tested this change quite a lot in SITL.  It has not been tested on a real vehicle.  It is slightly difficult to get testers of this rarely used feature but I know of one person that I will contact and ask if they can test.

By the way, I don't fully understand what increasing the buffer size is necessary.  I'm sure it has to do with the EKF's maximum loop rate being 100hz and SITL also being 100hz.

One interesting thing I saw while testing was when I added debug to SITL to print "pushed" when it updated a beacon's length, and then added debug to EKF3 to print a corresponding "recalled" message when the new distance was consumed.  Before the fix, I saw the time between the two grew like below.  After the change they appear one after another.
![image](https://user-images.githubusercontent.com/1498098/90618476-06a32080-e24b-11ea-9d32-bd36ebf6eb21.png)
