### PR TITLE
Add OLC (pluscode) library and its element to OSD

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -101,6 +101,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_RCTelemetry',
     'AP_Generator',
     'AP_MSP',
+    'AP_OLC',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_OLC/AP_OLC.cpp
+++ b/libraries/AP_OLC/AP_OLC.cpp
@@ -1,0 +1,226 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * AP_OLC is based on INAV olc.c implemention, thanks @fiam and other contributors.
+ */
+
+#include <math.h>
+#include <algorithm>
+#include "AP_OLC.h"
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+
+// This is a port of https://github.com/google/open-location-code/blob/master/c/olc.c
+// to avoid double floating point math and use integer math as much as possible.
+
+static constexpr char SEPARATOR_CHAR = '+';
+static constexpr int SEPARATOR_POS = 8;
+static constexpr char PADDING_CHAR = '0';
+
+static constexpr int ENCODING_BASE = 20;
+static constexpr unsigned int PAIR_CODE_LEN = 10;
+static constexpr unsigned int CODE_LEN_MAX = 15;
+
+static constexpr int GRID_COLS = 4;
+static constexpr int GRID_ROWS = ENCODING_BASE / GRID_COLS;
+
+
+static constexpr olc_coord_t LAT_MAX = 90 * OLC_DEG_MULTIPLIER;
+static constexpr olc_coord_t LON_MAX = 180 * OLC_DEG_MULTIPLIER;
+
+olc_coord_t AP_OLC::grid_size;
+olc_coord_t AP_OLC::initial_resolution;
+const char AP_OLC::alphabet[] = "23456789CFGHJMPQRVWX";
+
+bool AP_OLC::inited = false;
+
+
+void AP_OLC::init_constants(void)
+{
+    if (inited) {
+        return;
+    }
+    inited = true;
+
+    // Work out the encoding base exponent necessary to represent 360 degrees.
+    olc_coord_t initial_exponent = floorf(logf(2 * (LON_MAX / OLC_DEG_MULTIPLIER)) / logf(ENCODING_BASE));
+
+    // Work out the enclosing resolution (in degrees) for the grid algorithm.
+    AP_OLC::grid_size = (1 / powf(ENCODING_BASE, PAIR_CODE_LEN / 2 - (initial_exponent + 1))) * OLC_DEG_MULTIPLIER;
+
+    // Work out the initial resolution
+    AP_OLC::initial_resolution = powf(ENCODING_BASE, initial_exponent) * OLC_DEG_MULTIPLIER;
+}
+
+// Compute the latitude precision value for a given code length.  Lengths <= 10
+// have the same precision for latitude and longitude, but lengths > 10 have
+// different precisions due to the grid method having fewer columns than rows.
+float AP_OLC::compute_precision_for_length(int length)
+{
+    // Magic numbers!
+    if (length <= (int)PAIR_CODE_LEN) {
+        return powf(ENCODING_BASE, floorf((length / -2) + 2));
+    }
+
+    return powf(ENCODING_BASE, -3) / powf(5, length - (int)PAIR_CODE_LEN);
+}
+
+olc_coord_t AP_OLC::adjust_latitude(olc_coord_t lat, size_t code_len)
+{
+    if (lat < -LAT_MAX) {
+        lat = -LAT_MAX;
+    }
+    if (lat > LAT_MAX) {
+        lat = LAT_MAX;
+    }
+    if (lat >= LAT_MAX) {
+        // Subtract half the code precision to get the latitude into the code area.
+        olc_coord_t precision = compute_precision_for_length(code_len) * OLC_DEG_MULTIPLIER;
+        lat -= precision / 2;
+    }
+    return lat;
+}
+
+olc_coord_t AP_OLC::normalize_longitude(olc_coord_t lon)
+{
+    while (lon < -LON_MAX) {
+        lon += LON_MAX;
+        lon += LON_MAX;
+    }
+    while (lon >= LON_MAX) {
+        lon -= LON_MAX;
+        lon -= LON_MAX;
+    }
+    return lon;
+}
+
+// Encodes positive range lat,lon into a sequence of OLC lat/lon pairs.  This
+// uses pairs of characters (latitude and longitude in that order) to represent
+// each step in a 20x20 grid.  Each code, therefore, has 1/400th the area of
+// the previous code.
+unsigned AP_OLC::encode_pairs(uolc_coord_t lat, uolc_coord_t lon, size_t length, char *buf, size_t bufsize)
+{
+    if ((length + 1) >= bufsize) {
+        buf[0] = '\0';
+        return 0;
+    }
+
+    unsigned pos = 0;
+    olc_coord_t resolution = AP_OLC::initial_resolution;
+    // Add two digits on each pass.
+    for (size_t digit_count = 0;
+         digit_count < length;
+         digit_count += 2, resolution /= ENCODING_BASE) {
+        size_t digit_value;
+
+        // Do the latitude - gets the digit for this place and subtracts that
+        // for the next digit.
+        digit_value = lat / resolution;
+        lat -= digit_value * resolution;
+        buf[pos++] = alphabet[digit_value];
+
+        // Do the longitude - gets the digit for this place and subtracts that
+        // for the next digit.
+        digit_value = lon / resolution;
+        lon -= digit_value * resolution;
+        buf[pos++] = alphabet[digit_value];
+
+        // Should we add a separator here?
+        if (pos == SEPARATOR_POS && pos < length) {
+            buf[pos++] = SEPARATOR_CHAR;
+        }
+    }
+    while (pos < SEPARATOR_POS) {
+        buf[pos++] = PADDING_CHAR;
+    }
+    if (pos == SEPARATOR_POS) {
+        buf[pos++] = SEPARATOR_CHAR;
+    }
+    buf[pos] = '\0';
+    return pos;
+}
+
+// Encodes a location using the grid refinement method into an OLC string.  The
+// grid refinement method divides the area into a grid of 4x5, and uses a
+// single character to refine the area.  The grid squares use the OLC
+// characters in order to number the squares as follows:
+//
+//   R V W X
+//   J M P Q
+//   C F G H
+//   6 7 8 9
+//   2 3 4 5
+//
+// This allows default accuracy OLC codes to be refined with just a single
+// character.
+int AP_OLC::encode_grid(uolc_coord_t lat, uolc_coord_t lon, size_t length,
+                       char *buf, size_t bufsize)
+{
+    if ((length + 1) >= bufsize) {
+        buf[0] = '\0';
+        return 0;
+    }
+
+    int pos = 0;
+
+    olc_coord_t lat_grid_size = AP_OLC::grid_size;
+    olc_coord_t lon_grid_size = AP_OLC::grid_size;
+
+    lat %= lat_grid_size;
+    lon %= lon_grid_size;
+
+    for (size_t i = 0; i < length; i++) {
+        olc_coord_t lat_div = lat_grid_size / GRID_ROWS;
+        olc_coord_t lon_div = lon_grid_size / GRID_COLS;
+
+        if (lat_div == 0 || lon_div == 0) {
+            // This case happens when OLC_DEG_MULTIPLIER doesn't have enough
+            // precision for the requested length.
+            break;
+        }
+
+        // Work out the row and column.
+        size_t row = lat / lat_div;
+        size_t col = lon / lon_div;
+        lat_grid_size /= GRID_ROWS;
+        lon_grid_size /= GRID_COLS;
+        lat -= row * lat_grid_size;
+        lon -= col * lon_grid_size;
+        buf[pos++] = alphabet[row * GRID_COLS + col];
+    }
+    buf[pos] = '\0';
+    return pos;
+}
+
+int AP_OLC::olc_encode(olc_coord_t lat, olc_coord_t lon, size_t length, char *buf, size_t bufsize)
+{
+    int pos = 0;
+
+    length = MIN(length, CODE_LEN_MAX);
+
+    // Adjust latitude and longitude so they fall into positive ranges.
+    uolc_coord_t alat = adjust_latitude(lat, length) + LAT_MAX;
+    uolc_coord_t alon = normalize_longitude(lon) + LON_MAX;
+
+    init_constants();
+
+    pos += encode_pairs(alat, alon, MIN(length, PAIR_CODE_LEN), buf + pos, bufsize - pos);
+    // If the requested length indicates we want grid refined codes.
+    if (length > PAIR_CODE_LEN) {
+        pos += encode_grid(alat, alon, length - PAIR_CODE_LEN, buf + pos, bufsize - pos);
+    }
+    buf[pos] = '\0';
+    return pos;
+}

--- a/libraries/AP_OLC/AP_OLC.cpp
+++ b/libraries/AP_OLC/AP_OLC.cpp
@@ -15,7 +15,6 @@
  * AP_OLC is based on INAV olc.c implemention, thanks @fiam and other contributors.
  */
 
-#include <algorithm>
 #include "AP_OLC.h"
 
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_OLC/AP_OLC.h
+++ b/libraries/AP_OLC/AP_OLC.h
@@ -1,0 +1,50 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * AP_OLC is based on INAV olc.c implemention, thanks @fiam and other contributors.
+ */
+
+#pragma once
+#include <AP_Common/AP_Common.h>
+
+typedef int32_t olc_coord_t;
+typedef uint32_t uolc_coord_t;
+
+static constexpr olc_coord_t OLC_DEG_MULTIPLIER = 10000000; // 1e7
+
+class AP_OLC
+{
+public:
+
+// olc_encodes the given coordinates in lat and lon (deg * OLC_DEG_MULTIPLIER)
+// as an OLC code of the given length. It returns the number of characters
+// written to buf.
+static int olc_encode(olc_coord_t lat, olc_coord_t lon, size_t length, char *buf, size_t bufsize);
+
+private:
+
+static bool inited;
+// Initialized via init_constants()
+static olc_coord_t grid_size;
+static olc_coord_t initial_resolution;
+static const char alphabet[];
+
+static void init_constants(void);
+static float compute_precision_for_length(int length);
+static olc_coord_t adjust_latitude(olc_coord_t lat, size_t code_len);
+static olc_coord_t normalize_longitude(olc_coord_t lon);
+static unsigned encode_pairs(uolc_coord_t lat, uolc_coord_t lon, size_t length, char *buf, size_t bufsize);
+static int encode_grid(uolc_coord_t lat, uolc_coord_t lon, size_t length,char *buf, size_t bufsize);
+
+};

--- a/libraries/AP_OLC/AP_OLC.h
+++ b/libraries/AP_OLC/AP_OLC.h
@@ -16,35 +16,34 @@
  */
 
 #pragma once
-#include <AP_Common/AP_Common.h>
+#include <stdint.h>
 
-typedef int32_t olc_coord_t;
-typedef uint32_t uolc_coord_t;
+typedef int32_t int32_t;
 
-static constexpr olc_coord_t OLC_DEG_MULTIPLIER = 10000000; // 1e7
+
+static constexpr int32_t OLC_DEG_MULTIPLIER = 10000000; // 1e7
 
 class AP_OLC
 {
 public:
 
-// olc_encodes the given coordinates in lat and lon (deg * OLC_DEG_MULTIPLIER)
-// as an OLC code of the given length. It returns the number of characters
-// written to buf.
-static int olc_encode(olc_coord_t lat, olc_coord_t lon, size_t length, char *buf, size_t bufsize);
+    // olc_encodes the given coordinates in lat and lon (deg * OLC_DEG_MULTIPLIER)
+    // as an OLC code of the given length. It returns the number of characters
+    // written to buf.
+    static int olc_encode(int32_t lat, int32_t lon, size_t length, char *buf, size_t bufsize);
 
 private:
 
-static bool inited;
-// Initialized via init_constants()
-static olc_coord_t grid_size;
-static olc_coord_t initial_resolution;
-static const char alphabet[];
+    static bool inited;
+    // Initialized via init_constants()
+    static int32_t grid_size;
+    static int32_t initial_resolution;
 
-static void init_constants(void);
-static float compute_precision_for_length(int length);
-static olc_coord_t adjust_latitude(olc_coord_t lat, size_t code_len);
-static olc_coord_t normalize_longitude(olc_coord_t lon);
-static unsigned encode_pairs(uolc_coord_t lat, uolc_coord_t lon, size_t length, char *buf, size_t bufsize);
-static int encode_grid(uolc_coord_t lat, uolc_coord_t lon, size_t length,char *buf, size_t bufsize);
+    static void init_constants(void);
+    static float compute_precision_for_length(int length);
+    static int32_t adjust_latitude(int32_t lat, size_t code_len);
+    static int32_t normalize_longitude(int32_t lon);
+    static unsigned encode_pairs(uint32_t lat, uint32_t lon, size_t length, char *buf, size_t bufsize);
+    static int encode_grid(uint32_t lat, uint32_t lon, size_t length,char *buf, size_t bufsize);
 
 };

--- a/libraries/AP_OLC/AP_OLC.h
+++ b/libraries/AP_OLC/AP_OLC.h
@@ -17,12 +17,15 @@
 
 #pragma once
 #include <stdint.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
-typedef int32_t int32_t;
+#ifndef HAL_PLUSCODE_ENABLE
+#define HAL_PLUSCODE_ENABLE !HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024
+#endif
 
 
-static constexpr int32_t OLC_DEG_MULTIPLIER = 10000000; // 1e7
-
+#if HAL_PLUSCODE_ENABLE
 class AP_OLC
 {
 public:
@@ -34,16 +37,36 @@ public:
 
 private:
 
-    static bool inited;
-    // Initialized via init_constants()
-    static int32_t grid_size;
-    static int32_t initial_resolution;
+    static constexpr uint8_t SEPARATOR_CHAR = '+';
+    static constexpr uint8_t SEPARATOR_POS = 8;
+    static constexpr uint8_t PADDING_CHAR = '0';
 
-    static void init_constants(void);
+    static constexpr uint8_t ENCODING_BASE = 20;
+    static constexpr uint8_t PAIR_CODE_LEN = 10;
+    static constexpr uint8_t CODE_LEN_MAX = 15;
+
+    static constexpr uint8_t GRID_COLS = 4;
+    static constexpr uint8_t GRID_ROWS = ENCODING_BASE / GRID_COLS;
+
+    static constexpr int32_t OLC_DEG_MULTIPLIER = 10000000; // 1e7
+
+    static constexpr int32_t LAT_MAX = 90 * OLC_DEG_MULTIPLIER;
+    static constexpr int32_t LON_MAX = 180 * OLC_DEG_MULTIPLIER;
+
+    static const int32_t initial_exponent;
+    // Work out the enclosing resolution (in degrees) for the grid algorithm.
+    static const int32_t grid_size;
+    // Work out the initial resolution
+    static const int32_t initial_resolution;
+
+    static constexpr char olc_alphabet[] = "23456789CFGHJMPQRVWX";
+
     static float compute_precision_for_length(int length);
     static int32_t adjust_latitude(int32_t lat, size_t code_len);
     static int32_t normalize_longitude(int32_t lon);
     static unsigned encode_pairs(uint32_t lat, uint32_t lon, size_t length, char *buf, size_t bufsize);
-    static int encode_grid(uint32_t lat, uint32_t lon, size_t length,char *buf, size_t bufsize);
+    static int encode_grid(uint32_t lat, uint32_t lon, size_t length, char *buf, size_t bufsize);
 
 };
+
+#endif

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -175,6 +175,7 @@ private:
     AP_OSD_Setting bat2_vlt{false, 0, 0};
     AP_OSD_Setting bat2used{false, 0, 0};
     AP_OSD_Setting clk{false, 0, 0};
+    AP_OSD_Setting pluscode{false, 0, 0};
     
     // MSP OSD only
     AP_OSD_Setting sidebars{false, 0, 0};
@@ -185,6 +186,7 @@ private:
     AP_OSD_Setting cell_volt{true, 1, 1};
     AP_OSD_Setting batt_bar{true, 1, 1};
     AP_OSD_Setting arming{true, 1, 1};
+    
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);
@@ -206,6 +208,7 @@ private:
     void draw_aspd1(uint8_t x, uint8_t y);
     void draw_aspd2(uint8_t x, uint8_t y);
     void draw_vspeed(uint8_t x, uint8_t y);
+    void draw_pluscode(uint8_t x, uint8_t y);
 
     //helper functions
     void draw_speed_vector(uint8_t x, uint8_t y, Vector2f v, int32_t yaw);

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -176,7 +176,7 @@ private:
     AP_OSD_Setting bat2used{false, 0, 0};
     AP_OSD_Setting clk{false, 0, 0};
     AP_OSD_Setting pluscode{false, 0, 0};
-    
+
     // MSP OSD only
     AP_OSD_Setting sidebars{false, 0, 0};
     AP_OSD_Setting crosshair{false, 0, 0};
@@ -186,7 +186,6 @@ private:
     AP_OSD_Setting cell_volt{true, 1, 1};
     AP_OSD_Setting batt_bar{true, 1, 1};
     AP_OSD_Setting arming{true, 1, 1};
-    
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -23,6 +23,7 @@
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_OLC/AP_OLC.h>
 
 #ifndef OSD_ENABLED
 #define OSD_ENABLED 0
@@ -175,7 +176,9 @@ private:
     AP_OSD_Setting bat2_vlt{false, 0, 0};
     AP_OSD_Setting bat2used{false, 0, 0};
     AP_OSD_Setting clk{false, 0, 0};
+#if HAL_PLUSCODE_ENABLE
     AP_OSD_Setting pluscode{false, 0, 0};
+#endif
 
     // MSP OSD only
     AP_OSD_Setting sidebars{false, 0, 0};
@@ -207,7 +210,9 @@ private:
     void draw_aspd1(uint8_t x, uint8_t y);
     void draw_aspd2(uint8_t x, uint8_t y);
     void draw_vspeed(uint8_t x, uint8_t y);
+#if HAL_PLUSCODE_ENABLE
     void draw_pluscode(uint8_t x, uint8_t y);
+#endif
 
     //helper functions
     void draw_speed_vector(uint8_t x, uint8_t y, Vector2f v, int32_t yaw);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -706,22 +706,6 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(clk, "CLK", 43, AP_OSD_Screen, AP_OSD_Setting),
     
-    // @Param: PLUSCODE_EN
-    // @DisplayName: PLUSCODE_EN
-    // @Description: Displays total flight time
-    // @Values: 0:Disabled,1:Enabled
-
-    // @Param: PLUSCODE_X
-    // @DisplayName: PLUSCODE_X
-    // @Description: Horizontal position on screen
-    // @Range: 0 29
-
-    // @Param: PLUSCODE_Y
-    // @DisplayName: PLUSCODE_Y
-    // @Description: Vertical position on screen
-    // @Range: 0 15
-    AP_SUBGROUPINFO(pluscode, "PLUSCODE", 44, AP_OSD_Screen, AP_OSD_Setting),
-    
 #if HAL_MSP_ENABLED
     // @Param: SIDEBARS_EN
     // @DisplayName: SIDEBARS_EN
@@ -852,6 +836,21 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     AP_SUBGROUPINFO(arming, "ARMING", 51, AP_OSD_Screen, AP_OSD_Setting),
 #endif //HAL_MSP_ENABLED
 
+    // @Param: PLUSCODE_EN
+    // @DisplayName: PLUSCODE_EN
+    // @Description: Displays pluscode (OLC) element 
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: PLUSCODE_X
+    // @DisplayName: PLUSCODE_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: PLUSCODE_Y
+    // @DisplayName: PLUSCODE_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(pluscode, "PLUSCODE", 52, AP_OSD_Screen, AP_OSD_Setting),
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -35,7 +35,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_RTC/AP_RTC.h>
 #include <AP_MSP/msp.h>
-
+#include <AP_OLC/AP_OLC.h>
 #include <ctype.h>
 #include <GCS_MAVLink/GCS.h>
 
@@ -705,6 +705,22 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     AP_SUBGROUPINFO(clk, "CLK", 43, AP_OSD_Screen, AP_OSD_Setting),
+    
+    // @Param: PLUSCODE_EN
+    // @DisplayName: PLUSCODE_EN
+    // @Description: Displays total flight time
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: PLUSCODE_X
+    // @DisplayName: PLUSCODE_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: PLUSCODE_Y
+    // @DisplayName: PLUSCODE_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(pluscode, "PLUSCODE", 44, AP_OSD_Screen, AP_OSD_Setting),
     
 #if HAL_MSP_ENABLED
     // @Param: SIDEBARS_EN
@@ -1690,6 +1706,19 @@ void AP_OSD_Screen::draw_clk(uint8_t x, uint8_t y)
     }
 }
 
+void AP_OSD_Screen::draw_pluscode(uint8_t x, uint8_t y)
+{
+    AP_GPS & gps = AP::gps();
+    const Location &loc = gps.location();
+    char buff[16];
+    if (gps.status() == AP_GPS::NO_GPS || gps.status() == AP_GPS::NO_FIX){
+        backend->write(x, y, false, "--------+--");
+    } else {
+        AP_OLC::olc_encode(loc.lat, loc.lng, 10, buff, sizeof(buff));
+        backend->write(x, y, false, buff);
+    }
+}
+
 #define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
 
 #if HAL_WITH_OSD_BITMAP
@@ -1742,6 +1771,7 @@ void AP_OSD_Screen::draw(void)
 
     DRAW_SETTING(gps_latitude);
     DRAW_SETTING(gps_longitude);
+    DRAW_SETTING(pluscode);
     DRAW_SETTING(dist);
     DRAW_SETTING(stat);
     DRAW_SETTING(climbeff);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -836,6 +836,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     AP_SUBGROUPINFO(arming, "ARMING", 51, AP_OSD_Screen, AP_OSD_Setting),
 #endif //HAL_MSP_ENABLED
 
+#if HAL_PLUSCODE_ENABLE
     // @Param: PLUSCODE_EN
     // @DisplayName: PLUSCODE_EN
     // @Description: Displays pluscode (OLC) element 
@@ -851,6 +852,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     AP_SUBGROUPINFO(pluscode, "PLUSCODE", 52, AP_OSD_Screen, AP_OSD_Setting),
+#endif
     AP_GROUPEND
 };
 
@@ -1705,6 +1707,7 @@ void AP_OSD_Screen::draw_clk(uint8_t x, uint8_t y)
     }
 }
 
+#if HAL_PLUSCODE_ENABLE
 void AP_OSD_Screen::draw_pluscode(uint8_t x, uint8_t y)
 {
     AP_GPS & gps = AP::gps();
@@ -1717,6 +1720,7 @@ void AP_OSD_Screen::draw_pluscode(uint8_t x, uint8_t y)
         backend->write(x, y, false, buff);
     }
 }
+#endif
 
 #define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
 
@@ -1770,7 +1774,9 @@ void AP_OSD_Screen::draw(void)
 
     DRAW_SETTING(gps_latitude);
     DRAW_SETTING(gps_longitude);
+#if HAL_PLUSCODE_ENABLE
     DRAW_SETTING(pluscode);
+#endif
     DRAW_SETTING(dist);
     DRAW_SETTING(stat);
     DRAW_SETTING(climbeff);


### PR DESCRIPTION
This PR adds the AP_OLC library that allows to generate OLC (open location codes) from a give latitude and longitude pair and  a new OSD element, PLUSCODE, that allow to display the +code on the OSD screen using less space than the current lat/lon pair.
More info on: https://github.com/google/open-location-code

Thanks @shellixyz for the help and @fiam for the original code in INAV.