### PR TITLE
Use AP::airspeed() to get airspeed sensor, rather than going via AP_AHRS

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -97,9 +97,6 @@ void Plane::init_ardupilot()
     g2.efi.init();
 #endif
 
-    // give AHRS the airspeed sensor
-    ahrs.set_airspeed(&airspeed);
-
     // GPS Initialization
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init(serial_manager);

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -129,14 +129,6 @@ public:
     // this makes initial config easier
     void update_orientation();
 
-    void set_airspeed(AP_Airspeed *airspeed) {
-        _airspeed = airspeed;
-    }
-
-    const AP_Airspeed *get_airspeed(void) const {
-        return _airspeed;
-    }
-
     // return the index of the primary core or -1 if no primary core selected
     virtual int8_t get_primary_core_index() const { return -1; }
 
@@ -285,12 +277,14 @@ public:
     // return true if airspeed comes from an airspeed sensor, as
     // opposed to an IMU estimate
     bool airspeed_sensor_enabled(void) const {
+        const AP_Airspeed *_airspeed = AP::airspeed();
         return _airspeed != nullptr && _airspeed->use() && _airspeed->healthy();
     }
 
     // return true if airspeed comes from a specific airspeed sensor, as
     // opposed to an IMU estimate
     bool airspeed_sensor_enabled(uint8_t airspeed_index) const {
+        const AP_Airspeed *_airspeed = AP::airspeed();
         return _airspeed != nullptr && _airspeed->use(airspeed_index) && _airspeed->healthy(airspeed_index);
     }
 
@@ -661,7 +655,6 @@ protected:
     const OpticalFlow *_optflow;
 
     // pointer to airspeed object, if available
-    AP_Airspeed     * _airspeed;
 
     // time in microseconds of last compass update
     uint32_t _compass_last_update;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -2235,6 +2235,7 @@ uint8_t AP_AHRS_NavEKF::get_active_airspeed_index() const
     }
 #endif
     // for the rest, let the primary airspeed sensor be used
+    const AP_Airspeed * _airspeed = AP::airspeed();
     if (_airspeed != nullptr) {
         return _airspeed->get_primary();
     }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -516,7 +516,7 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_velandyaw(void)
     AP_AHRS &_ahrs = AP::ahrs();
     WITH_SEMAPHORE(_ahrs.get_semaphore());
     // horizontal velocity in dm/s (use airspeed if available and enabled - even if not used - otherwise use groundspeed)
-    const AP_Airspeed *aspeed = _ahrs.get_airspeed();
+    const AP_Airspeed *aspeed = AP::airspeed();
     if (aspeed && aspeed->enabled()) {
         velandyaw |= prep_number(roundf(aspeed->get_airspeed() * 10), 2, 1)<<VELANDYAW_XYVEL_OFFSET;
     } else { // otherwise send groundspeed estimate from ahrs

--- a/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
+++ b/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
@@ -121,7 +121,7 @@ void AP_LTM_Telem::send_Sframe(void)
     const uint16_t amp = (uint16_t) roundf(current * 100.0f);                          // current sensor (expects value in hundredth of A)
 
     // airspeed in m/s if available and enabled - even if not used - otherwise send 0
-    const AP_Airspeed *aspeed = AP::ahrs().get_airspeed();
+    const AP_Airspeed *aspeed = AP::airspeed();
     uint8_t airspeed = 0; // airspeed sensor (m/s)
     if (aspeed && aspeed->enabled()) {
         airspeed = (uint8_t) roundf(aspeed->get_airspeed());

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
@@ -435,7 +435,7 @@ void AP_Spektrum_Telem::calc_airspeed()
     AP_AHRS &ahrs = AP::ahrs();
     WITH_SEMAPHORE(ahrs.get_semaphore());
 
-    const AP_Airspeed *airspeed = ahrs.get_airspeed();
+    const AP_Airspeed *airspeed = AP::airspeed();
     float speed = 0.0f;
     if (airspeed && airspeed->healthy()) {
         speed = roundf(airspeed->get_airspeed() * 3.6);


### PR DESCRIPTION
Setting the pointer in the AHRS predates our use of singletons.

Some of the users of this should probably be failling back to using a synthetic airspeed estimate instead of giving up if we don't have a true airspeed sensor.
