### PR TITLE
Fixed divergence of EKF with RTK GPS data

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -517,6 +517,7 @@ void NavEKF2_core::readGpsData()
             } else {
                 gpsSpdAccuracy = MAX(gpsSpdAccuracy,gpsSpdAccRaw);
                 gpsSpdAccuracy = MIN(gpsSpdAccuracy,50.0f);
+                gpsSpdAccuracy = MAX(gpsSpdAccuracy,frontend->_gpsHorizVelNoise);
             }
             gpsPosAccuracy *= (1.0f - alpha);
             float gpsPosAccRaw;
@@ -525,6 +526,7 @@ void NavEKF2_core::readGpsData()
             } else {
                 gpsPosAccuracy = MAX(gpsPosAccuracy,gpsPosAccRaw);
                 gpsPosAccuracy = MIN(gpsPosAccuracy,100.0f);
+                gpsPosAccuracy = MAX(gpsPosAccuracy, frontend->_gpsHorizPosNoise);
             }
             gpsHgtAccuracy *= (1.0f - alpha);
             float gpsHgtAccRaw;
@@ -533,6 +535,7 @@ void NavEKF2_core::readGpsData()
             } else {
                 gpsHgtAccuracy = MAX(gpsHgtAccuracy,gpsHgtAccRaw);
                 gpsHgtAccuracy = MIN(gpsHgtAccuracy,100.0f);
+                gpsHgtAccuracy = MAX(gpsHgtAccuracy, 1.5f * frontend->_gpsHorizPosNoise);
             }
 
             // check if we have enough GPS satellites and increase the gps noise scaler if we don't

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -564,6 +564,7 @@ void NavEKF3_core::readGpsData()
             } else {
                 gpsSpdAccuracy = MAX(gpsSpdAccuracy,gpsSpdAccRaw);
                 gpsSpdAccuracy = MIN(gpsSpdAccuracy,50.0f);
+                gpsSpdAccuracy = MAX(gpsSpdAccuracy,frontend->_gpsHorizVelNoise);
             }
             gpsPosAccuracy *= (1.0f - alpha);
             float gpsPosAccRaw;
@@ -572,6 +573,7 @@ void NavEKF3_core::readGpsData()
             } else {
                 gpsPosAccuracy = MAX(gpsPosAccuracy,gpsPosAccRaw);
                 gpsPosAccuracy = MIN(gpsPosAccuracy,100.0f);
+                gpsPosAccuracy = MAX(gpsPosAccuracy, frontend->_gpsHorizPosNoise);
             }
             gpsHgtAccuracy *= (1.0f - alpha);
             float gpsHgtAccRaw;
@@ -580,6 +582,7 @@ void NavEKF3_core::readGpsData()
             } else {
                 gpsHgtAccuracy = MAX(gpsHgtAccuracy,gpsHgtAccRaw);
                 gpsHgtAccuracy = MIN(gpsHgtAccuracy,100.0f);
+                gpsHgtAccuracy = MAX(gpsHgtAccuracy, 1.5f * frontend->_gpsHorizPosNoise);
             }
 
             // check if we have enough GPS satellites and increase the gps noise scaler if we don't


### PR DESCRIPTION
This fixes an issue in both EKF2 and EKF3 where use of RTK GPS can lead to high innovations and loss of position estimate. The RTK GPS is reporting 1cm accuracy both horizontally and vertically.
We were applying the minimum from the EKF parameters in some places in the code but not all. Some logs are here demonstrating the issue:
http://uav.tridgell.net/EKF/NateRTK/
In log 00000052.BIN and Crash.BIN we see both EKF2 and EKF3 getting high innovations. The unique feature is that the RTK GPS is claiming low accuracy numbers (1cm).
![image](https://user-images.githubusercontent.com/831867/90717949-293d4400-e2f4-11ea-8d68-9e4d8bd35226.png)
the same pattern is seen in both EKF3 lanes and in EKF2. Examination of the raw GPS data seems to indicate that is is OK, the position and velocity data is kinematically consistent (remarkably so actually) and the EKF innovations make no sense, especially for GPS based height.
In log 00000055.BIN we did an experiment using this patch:
https://github.com/tridge/ardupilot/commit/b1932b49a28b65e844c14532171fb11ec1f0aac3
that patch applies the EKF parameter constraints on the accuracy at the point it is collected from AP_GPS, ensuring we can't miss any place where the accuracy is applied. The constraint is only applied on the first EKF lane, allowing us to see the impact of the change. That branch was tested with a static GPS (roof mounted) and gave this result:
![image](https://user-images.githubusercontent.com/831867/90716430-4bcd5e00-e2f0-11ea-89f3-c0881e5fdeee.png)
The result shows that applying the parameter constraints does make a dramatic difference.
