### PR TITLE
Support 3-D obstacle vectors from Depth Cameras

### DIFF
--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -31,6 +31,9 @@ extern const AP_HAL::HAL& hal;
     #define AP_OADATABASE_QUEUE_SIZE_DEFAULT 80
 #endif
 
+#ifndef AP_OADATABASE_DISTANCE_FROM_HOME
+    #define AP_OADATABASE_DISTANCE_FROM_HOME 2
+#endif
 
 const AP_Param::GroupInfo AP_OADatabase::var_info[] = {
 
@@ -91,6 +94,14 @@ const AP_Param::GroupInfo AP_OADatabase::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DIST_MAX", 7, AP_OADatabase, _dist_max, 0.0f),
 
+    // @Param{Copter}: MIN_ALT
+    // @DisplayName: OADatabase minimum altitude above home check 
+    // @Description: OADatabase will reject obstacle's if vehicle's altitude above home is below this parameter, in a 2 meter radius around home. Set 0 to disable this feature.
+    // @Units: m
+    // @Range: 0 3
+    // @User: Advanced
+    AP_GROUPINFO_FRAME("MIN_ALT", 8, AP_OADatabase, _min_alt, 1.0f, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
+
     AP_GROUPEND
 };
 
@@ -137,6 +148,26 @@ void AP_OADatabase::queue_push(const Vector3f &pos, uint32_t timestamp_ms, float
         return;
     }
 
+    // check if this obstacle needs to be rejected from DB because of low altitude near home
+    #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+    Vector2f current_pos;
+    if (!is_zero(_min_alt)) { 
+        if (!AP::ahrs().get_relative_position_NE_home(current_pos)) {
+            // we do not know where the vehicle is
+            return;
+        }
+        if (current_pos.length() < AP_OADATABASE_DISTANCE_FROM_HOME) {
+            // vehicle is within a small radius of home 
+            float height_above_home;
+            AP::ahrs().get_relative_position_D_home(height_above_home);
+            if (-height_above_home < _min_alt) {
+                // vehicle is below the minimum alt
+                return;
+            }
+        }
+    }
+    #endif
+    
     // ignore objects that are far away
     if ((_dist_max > 0.0f) && (distance > _dist_max)) {
         return;

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -89,6 +89,7 @@ private:
     AP_Float        _beam_width;                            // beam width used when converting lidar readings to object radius
     AP_Float        _radius_min;                            // objects minimum radius (in meters)
     AP_Float        _dist_max;                              // objects maximum distance (in meters)
+    AP_Float        _min_alt;                               // OADatabase minimum vehicle height check (in meters)
 
     struct {
         ObjectBuffer<OA_DbItem> *items;                     // thread safe incoming queue of points from proximity sensor to be put into database

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -299,3 +299,18 @@ void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t t
     
     oaDb->queue_push(temp_pos, timestamp_ms, distance);
 }
+
+void AP_Proximity_Backend::database_push_3D_obstacle(const Vector3f &obstacle, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned) 
+{
+    AP_OADatabase *oaDb = AP::oadatabase();
+    if (oaDb == nullptr || !oaDb->healthy()) {
+        return;
+    }
+
+    const Vector3f rotated_object_3D = body_to_ned * obstacle;
+    //Calculate the position vector from origin
+    Vector3f temp_pos = current_pos + rotated_object_3D;
+    //Convert the vector to a NEU frame from NED
+    temp_pos.z = temp_pos.z * -1.0f;
+    oaDb->queue_push(temp_pos, timestamp_ms, obstacle.length());
+}

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -87,6 +87,7 @@ protected:
     bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);
     void database_push(float angle, float distance);
     void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
+    void database_push_3D_obstacle(const Vector3f &obstacle, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -393,6 +393,7 @@ protected:
 
     void handle_distance_sensor(const mavlink_message_t &msg);
     void handle_obstacle_distance(const mavlink_message_t &msg);
+    void handle_viso_obstacle_distance(const mavlink_message_t &msg);
 
     void handle_common_param_message(const mavlink_message_t &msg);
     void handle_param_set(const mavlink_message_t &msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3168,6 +3168,14 @@ void GCS_MAVLINK::handle_obstacle_distance(const mavlink_message_t &msg)
     }
 }
 
+void GCS_MAVLINK::handle_viso_obstacle_distance(const mavlink_message_t &msg)
+{
+    AP_Proximity *proximity = AP::proximity();
+    if (proximity != nullptr) {
+        proximity->handle_msg(msg);
+    }
+}
+
 /*
   handle messages which don't require vehicle specific data
  */
@@ -3353,7 +3361,10 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_OBSTACLE_DISTANCE:
         handle_obstacle_distance(msg);
         break;
-
+    
+    case MAVLINK_MSG_ID_VISO_OBSTACLE_DISTANCE:
+        handle_viso_obstacle_distance(msg);
+        break;
     }
 
 }


### PR DESCRIPTION
This PR is the beginning of a new method for Obstacle Avoidance. 
It adds a new message to take in a body frame 3D vector in meters and feed it to OA DB.
Conventional lidars, at best, can give us 360 degrees information in a horizontal plane. Depth Cameras on the other hand can give much more information in the FOV in front of it.
At a later stage this can also be modified to act on identified obstacle. So for eg: if the camera detects a human, we give it a unique ID and start tracking it as a obstacle. So we can differentiate between static obstacles, land, moving obstacles etc. For an even smoother OA experience!

This also add's another feature to OA DB, which solves a common problem that many people face. We can now have an option to reject obstacles close to home while we are under a certain height. This feature will definitely be needed to support Depth Cameras  owing to large FOV.

TESTING:
This has been heavily tested on Morse + SITL


Obstacle on right, makes BendyRuler turn the vehicle left
![vlcsnap-2020-08-20-11h19m21s878](https://user-images.githubusercontent.com/36970042/90722606-c5595200-e2d8-11ea-957d-f1dfef572acb.png)

Obstacle on left, makes BendyRuler turn vehicle right:
![vlcsnap-2020-08-20-11h20m09s038](https://user-images.githubusercontent.com/36970042/90722613-cd18f680-e2d8-11ea-826c-fcab20b9545a.png)

This needs: https://github.com/ArduPilot/mavlink/pull/148 to support the new mavlink message