### PR TITLE
Add alt configs for more PWM outputs to KakuteF7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
@@ -109,8 +109,9 @@ PC9  TIM3_CH4 TIM3 PWM(5) GPIO(54)
 PA3  TIM5_CH4 TIM5 PWM(6) GPIO(55)
 
 # extra PWM outs
-#PD12  TIM4_CH1 TIM4 PWM(7) GPIO(56) # led pin
-#PD15 TIM4_CH4 TIM4 PWM(8) GPIO(57) # buzzer pin (need to comment out buzzer)
+PD12  TIM4_CH1 TIM4 PWM(7) GPIO(56) ALT(2) # led pin
+PD12  TIM4_CH1 TIM4 PWM(7) GPIO(56) ALT(3) # led pin
+PD15  TIM4_CH4 TIM4 PWM(8) GPIO(57) ALT(3) # buzzer pin
 
 DMA_PRIORITY S*
 


### PR DESCRIPTION
this fails for no apparent reason....see https://github.com/ArduPilot/ardupilot/issues/13929 for similar issue