### PR TITLE
AP_Arming: Check operation guarantee temperature.

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -122,6 +122,22 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
+    // @Param: OPE_TMIN
+    // @DisplayName: operating min temperature 
+    // @Description: Guaranteed minimum operating temperature
+    // @Range: -100.0 100.0
+    // @Units: degC
+    // @User: Advanced
+    AP_GROUPINFO("OPE_TMIN",        9,     AP_Arming, _operating_temperature_min,   -100.0f),
+
+    // @Param: OPE_T
+    // @DisplayName: operating maximum temperature 
+    // @Description: Guaranteed maximum operating temperature
+    // @Range: -100.0 100.0
+    // @Units: degC
+    // @User: Advanced
+    AP_GROUPINFO("OPE_TMAX",        10,     AP_Arming, _operating_temperature_max,  100.0f),
+
     AP_GROUPEND
 };
 
@@ -204,6 +220,12 @@ bool AP_Arming::barometer_checks(bool report)
         (checks_to_perform & ARMING_CHECK_BARO)) {
         if (!AP::baro().all_healthy()) {
             check_failed(ARMING_CHECK_BARO, report, "Barometer not healthy");
+            return false;
+        }
+
+        // operating temperature
+        if (AP::baro().get_temperature() < _operating_temperature_min || AP::baro().get_temperature() > _operating_temperature_max) {
+            check_failed(ARMING_CHECK_BARO, report, "Not operating temp(%.1lfC,%.1lfC,%.1lfC)", static_cast<double>(AP::baro().get_temperature()), static_cast<double>(_operating_temperature_min), static_cast<double>(_operating_temperature_max));
             return false;
         }
     }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -131,6 +131,8 @@ protected:
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
     AP_Int32                 _required_mission_items;
+    AP_Float                _operating_temperature_min;  // Guaranteed minimum operating temperature
+    AP_Float                _operating_temperature_max;  // Guaranteed maximum operating temperature
 
     // internal members
     bool                    armed;


### PR DESCRIPTION
I live in the country of Japan.
I fly the drone in hot and cold places.
When it's hot, the FC will run out of control due to heat.
I did PR #8846 two years ago to check the operating temperature of the FC in an arming check.
I have changed the process.
I think I should check the ambient temperature and warn you if the temperature is such that it is malfunctioning.

I want the default value to be a value that disables the temperature check.
I've set it to -100 degrees, 100 degrees.
I would expect you to set the proper value when checking the operating temperature.

![Screenshot from 2020-08-21 07-46-11](https://user-images.githubusercontent.com/646194/90833515-276e9180-e383-11ea-8a7d-e75de6244ca5.png)