### PR TITLE
AP_NavEKF3: allow switch to ExtNav from optflow

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -225,7 +225,7 @@ void NavEKF3_core::setAidingMode()
             bool bodyOdmFusionTimeout = ((imuSampleTime_ms - prevBodyVelFuseTime_ms) > 5000);
             // Enable switch to absolute position mode if GPS or range beacon data is available
             // If GPS or range beacons data is not available and flow fusion has timed out, then fall-back to no-aiding
-            if(readyToUseGPS() || readyToUseRangeBeacon()) {
+            if (readyToUseGPS() || readyToUseRangeBeacon() || readyToUseExtNav()) {
                 PV_AidingMode = AID_ABSOLUTE;
             } else if (flowFusionTimeout && bodyOdmFusionTimeout) {
                 PV_AidingMode = AID_NONE;


### PR DESCRIPTION
This is a small bug fix that allows the EKF3 to switch from relative aiding (i.e. optical flow, wheel encoders or vision-position-deltas) to absolute aiding using external nav.  This is important because otherwise users with both optical flow and vision-position systems (i.e. Intel T265) enabled may find their vehicle is actually flying only using the flow sensor.

I'm sure this was just a small oversight because we see [the correct check a few lines higher](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp#L214) used to allow switching from AID_NONE to AID_ABSOLUTE.

The problem can be reproduced in SITL by doing the following:

- param set EK3_ENABLE 1
- param set EK3_GPS_TYPE 3 (not using GPS)
- param set EK2_ENABLE 0
- param set AHRS_EKF_TYPE 3 (using EKF3)
- param set GPS_TYPE 0 (disable GPS)
- param load [../Tools/autotest/default-params/copter-optflow.parm](https://github.com/ArduPilot/ardupilot/blob/master/Tools/autotest/default_params/copter-optflow.parm) (restart SITL)
- enable vicon:
  - param set VISO_TYPE 1
  - param set SERIAL5_PROTOCOL 1
- cd ArduCopter
- ../Tools/autotest/sim_vehicle.py --map --console -A "--uartC=sim:vicon:"

You will see that the EKF remains in relative aiding (i.e. using optical flow) instead of being "promoted" to absolute aiding using external nav.  The pic below shows this.
![ekf3-flow-to-extnav-before](https://user-images.githubusercontent.com/1498098/90946883-56146700-e46c-11ea-9d7f-9d3597292022.png)


After the fix the EKF properly switches to external nav as shown below
![ekf3-flow-to-extnav-after](https://user-images.githubusercontent.com/1498098/90946927-98d63f00-e46c-11ea-87bf-cc0faf86ec8f.png)

I've also tested the failover between optical flow and vicon and it works post this change.