### PR TITLE
AP_HAL_ChibiOS: add USART3 as alt config on OmnibusNanoV6

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
@@ -1,6 +1,6 @@
 # hw definition file for processing by chibios_pins.py
 # Omnibus F4 Nano V6 only
-# with F405 mcu, mpu6000 imu, bmp280 barometer, 7456 series osd, no flash log storage
+# with F405 mcu, mpu6000 imu, bmp280 barometer, 7456 series osd, flash log storage
 
 MCU STM32F4xx STM32F405xx
 
@@ -17,10 +17,10 @@ FLASH_SIZE_KB 1024
 FLASH_RESERVE_START_KB 64
 
 # order of I2C buses
-I2C_ORDER I2C2
+I2C_ORDER I2C2 I2C1
 
 # order of UARTs
-SERIAL_ORDER OTG1 USART1 UART4 USART6
+SERIAL_ORDER OTG1 USART1 UART4 USART6 USART3
 
 #adc
 PC1 BAT_CURR_SENS ADC1 SCALE(1)
@@ -43,16 +43,26 @@ PA7 SPI1_MOSI SPI1
 PB10 I2C2_SCL I2C2 PULLUP
 PB11 I2C2_SDA I2C2 PULLUP
 
+# I2C1 on PPM / PB9 pads of V6.x board revision
+PB8 I2C1_SCL I2C1 PULLUP
+PB9 I2C1_SDA I2C1 PULLUP
+
+# use RX3 / TX3 pins as USART3 = SERIAL4 in BRD_ALT_CONFIG = 1
+PB10 USART3_TX USART3 ALT(1)
+PB11 USART3_RX USART3 ALT(1)
+
 # SPI2 for flash
 PB15 SPI2_MOSI SPI2
 PB14 SPI2_MISO SPI2
 PB13 SPI2_SCK SPI2
 PB12 FLASH_CS CS
 
-
+# USART1 = SERIAL1 on original V6 revision only
+# not available on V6.x revisions due to altered inverter layout
 PA10 USART1_RX USART1
 PA9 USART1_TX USART1
 
+# USART6 = SERIAL3
 PC6 USART6_TX USART6
 PC7 USART6_RX USART6
 


### PR DESCRIPTION
this PR allows use RX3 / TX3 as USART3 = SERIAL4 in BRD_ALT_CONFIG = 1. 
additionally it allows to keep 2 full UARTS + I2C on recent 6.x board revisions that have a fixed inverter on USART1, by adding I2C1 on PPM (PB8) and PB9 pads.

tested on V6.2 as well as original V6 board types.