### PR TITLE
Copter: Automatic flight domain fence check.

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -31,6 +31,11 @@ bool ModeAuto::init(bool ignore_checks)
             return false;
         }
 
+        if (AP::fence()->enabled() == 0 || (AP::fence()->get_enabled_fences() & 0x1) == 0 || (AP::fence()->get_enabled_fences() & 0x6) == 0) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto: The fence is disabled.");
+            return false;
+        }
+
         // stop ROI from carrying over from previous runs of the mission
         // To-Do: reset the yaw as part of auto_wp_start when the previous command was not a wp command to remove the need for this special ROI check
         if (auto_yaw.mode() == AUTO_YAW_ROI) {


### PR DESCRIPTION
I want the auto-flight to fly in a fenced area.
If I disable the fence feature and autoflight, it will fly beyond the flight area.
I would prefer not to auto-fly when the fence feature is disabled.
I live in Japan.
In Japan, there are places where the flight area is restricted. The flight altitude is also restricted in some places in Japan.
I think the fencing system is effective to protect this restriction.

![Screenshot from 2020-08-23 10-46-51](https://user-images.githubusercontent.com/646194/90969159-5a09bd00-e530-11ea-936c-a9f463c54946.png)