### PR TITLE
GCS_MAVLink: revert removal of private channel check when forwarding

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -145,6 +145,13 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     memset(sent_to_chan, 0, sizeof(sent_to_chan));
     for (uint8_t i=0; i<num_routes; i++) {
 
+        // Skip if channel is private and the target system or component IDs do not match
+        if ((GCS_MAVLINK::is_private(routes[i].channel)) &&
+            (target_system != routes[i].sysid ||
+             target_component != routes[i].compid)) {
+            continue;
+        }
+
         if (broadcast_system || (target_system == routes[i].sysid &&
                                  (broadcast_component || 
                                   target_component == routes[i].compid ||


### PR DESCRIPTION
This reverts 6dc77c97ce526a1f3c6e04f3e1ea8e79db762518

The commit caused a regression on Solo as the gimbal is "nodding",
indicating traffic from the autopilot is getting through to the gimbal.