### PR TITLE
SITL: allow to set sysid at start

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -627,6 +627,8 @@ def start_vehicle(binary, opts, stuff, spawns=None):
         cmd.append("-w")
     cmd.extend(["--model", stuff["model"]])
     cmd.extend(["--speedup", str(opts.speedup)])
+    if opts.sysid is not None:
+        cmd.extend(["--sysid", str(opts.sysid)])
     if opts.sitl_instance_args:
         # this could be a lot better:
         cmd.extend(opts.sitl_instance_args.split(" "))
@@ -1064,6 +1066,10 @@ group_sim.add_option("", "--start-time",
                      default=None,
                      type='string',
                      help="specify simulation start time in format YYYY-MM-DD-HH:MM in your local time zone")
+group_sim.add_option("", "--sysid",
+                     type='int',
+                     default=None,
+                     help="Set SYSID_THISMAV")
 parser.add_option_group(group_sim)
 
 

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -37,6 +37,9 @@ public:
         return HAL_PARAM_DEFAULTS_PATH;
     }
 
+    // set command line parameters to the eeprom on start
+    virtual void set_cmdline_parameters() {};
+
     // run a debug shall on the given stream if possible. This is used
     // to support dropping into a debug shell to run firmware upgrade
     // commands

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -14,6 +14,7 @@
 #include <netinet/in.h>
 #include <netinet/udp.h>
 #include <arpa/inet.h>
+#include <vector>
 
 #include <AP_Baro/AP_Baro.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
@@ -105,6 +106,7 @@ public:
         "tcp:5",
         "tcp:6",
     };
+    std::vector<struct AP_Param::defaults_table_struct> cmdline_param;
 
     /* parse a home location string */
     static bool parse_home(const char *home_str,

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -97,6 +97,7 @@ void SITL_State::_usage(void)
            "\t--sim-port-out PORT      set port num for simulator out\n"
            "\t--irlock-port PORT       set port num for irlock\n"
            "\t--start-time TIMESTR     set simulation start time in UNIX timestamp"
+           "\t--sysid ID               set SYSID_THISMAV\n"
         );
 }
 
@@ -228,6 +229,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         CMDLINE_SIM_PORT_OUT,
         CMDLINE_IRLOCK_PORT,
         CMDLINE_START_TIME,
+        CMDLINE_SYSID,
     };
 
     const struct GetOptLong::option options[] = {
@@ -264,6 +266,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         {"sim-port-out",    true,   0, CMDLINE_SIM_PORT_OUT},
         {"irlock-port",     true,   0, CMDLINE_IRLOCK_PORT},
         {"start-time",      true,   0, CMDLINE_START_TIME},
+        {"sysid",           true,   0, CMDLINE_SYSID},
         {0, false, 0, 0}
     };
 
@@ -385,6 +388,17 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         case CMDLINE_START_TIME:
             start_time_UTC = atoi(gopt.optarg);
             break;
+        case CMDLINE_SYSID: {
+            const int32_t sysid = atoi(gopt.optarg);
+            if (sysid < 1 || sysid > 255) {
+                fprintf(stderr, "You must specify a SYSID greater than 0 and less than 256\n");
+                exit(1);
+            }
+            char sysid_string[18];
+            snprintf(sysid_string, sizeof(sysid_string), "SYSID_THISMAV=%s", gopt.optarg);
+            _set_param_default(sysid_string);
+            break;
+        }
         default:
             _usage();
             exit(1);

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -8,6 +8,7 @@
 #include "UARTDriver.h"
 #include <AP_HAL/utility/getopt_cpp.h>
 #include <AP_Logger/AP_Logger_SITL.h>
+#include <AP_Param/AP_Param.h>
 
 #include <SITL/SIM_Multicopter.h>
 #include <SITL/SIM_Helicopter.h>
@@ -201,6 +202,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     uint16_t simulator_port_in = SIM_IN_PORT;
     uint16_t simulator_port_out = SIM_OUT_PORT;
     _irlock_port = IRLOCK_PORT;
+    struct AP_Param::defaults_table_struct temp_cmdline_param{};
 
     // Set default start time to the real system time.
     // This will be overwritten if argument provided.
@@ -280,7 +282,6 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 
     GetOptLong gopt(argc, argv, "hwus:r:CI:P:SO:M:F:c:",
                     options);
-
     while ((opt = gopt.getoption()) != -1) {
         switch (opt) {
         case 'w':
@@ -292,9 +293,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             break;
         case 's':
             speedup = strtof(gopt.optarg, nullptr);
-            char speedup_string[18];
-            snprintf(speedup_string, sizeof(speedup_string), "SIM_SPEEDUP=%s", gopt.optarg);
-            _set_param_default(speedup_string);
+            temp_cmdline_param = {"SIM_SPEEDUP", speedup};
+            cmdline_param.push_back(temp_cmdline_param);
+            printf("Setting SIM_SPEEDUP=%f\n", speedup);
             break;
         case 'r':
             _framerate = (unsigned)atoi(gopt.optarg);
@@ -394,9 +395,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
                 fprintf(stderr, "You must specify a SYSID greater than 0 and less than 256\n");
                 exit(1);
             }
-            char sysid_string[18];
-            snprintf(sysid_string, sizeof(sysid_string), "SYSID_THISMAV=%s", gopt.optarg);
-            _set_param_default(sysid_string);
+            temp_cmdline_param = {"SYSID_THISMAV", static_cast<float>(sysid)};
+            cmdline_param.push_back(temp_cmdline_param);
+            printf("Setting SYSID_THISMAV=%d\n", sysid);
             break;
         }
         default:

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -1,5 +1,6 @@
 #include "Util.h"
 #include <sys/time.h>
+#include <AP_Param/AP_Param.h>
 
 #ifdef WITH_SITL_TONEALARM
 HALSITL::ToneAlarm_SF HALSITL::Util::_toneAlarm;
@@ -137,4 +138,11 @@ enum AP_HAL::Util::safety_state HALSITL::Util::safety_switch_state(void)
         return AP_HAL::Util::SAFETY_NONE;
     }
     return sitl->safety_switch_state();
+}
+
+void HALSITL::Util::set_cmdline_parameters()
+{
+    for (auto param: sitlState->cmdline_param) {
+        AP_Param::set_default_by_name(param.name, param.value);
+    }
 }

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -68,6 +68,7 @@ public:
 #endif
     }
 
+    void set_cmdline_parameters() override;
 private:
     SITL_State *sitlState;
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -33,6 +33,9 @@
 #include <StorageManager/StorageManager.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <stdio.h>
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    #include <SITL/SITL.h>
+#endif
 
 extern const AP_HAL::HAL &hal;
 
@@ -1485,6 +1488,9 @@ void AP_Param::reload_defaults_file(bool last_pass)
             AP_HAL::panic("Failed to load defaults from %s\n", default_file);
         }
     }
+#endif
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    hal.util->set_cmdline_parameters();
 #endif
 }
 


### PR DESCRIPTION
This is really useful for all swarm application.
The main issue with sysid setting is that it is loaded early on vehicle initialization, changing this parameters need a reboot. This PR allow to pass --sysid X to SITL cmdline to set the sysid on start.
It also fix SPEEDUP parameter been set to X in SITL backend but at 1 in parameter if we use the -w flag. This issue comes to the fact that when we erase the EEPROM with -w, the vehicle will start by searching the FORMAT_VERSION parameter in the EEPROM, as we erase it, the vehicle won't find it and trigger another erase and load the default parameters. Thus every parameter pass on cmdline where lost ...This PR address this issue by allow to load the cmdline parameter in the same manner than the default file. That way the parameter are setted on start and are written back in case of erase.

On the SYSID matter. The current alternative where to launch the vehicle, change the SYSID_THISMAV parameter and reboot ... quite long.
Generate a parameters file with the SYSID_THISMAV modification and pass it with the --defaults option : example in https://github.com/ArduPilot/ardupilot/blob/master/libraries/SITL/examples/Morse/start_follow.sh

The option is also added to sim_vehicle.py that already have some option for swarm launch