### PR TITLE
Memleak fixes

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -171,6 +171,8 @@ void trace(const int trace, const char *message, ...) {
     va_start(args, message);
     vfprintf(stderr, fmt, args);
     va_end(args);
+    free(fmt);
+    fmt = NULL;
   }
 }
 
@@ -191,7 +193,8 @@ void error(const int code, const char *message, ...) {
   va_start(args, message);
   vfprintf(stderr, fmt, args);
   va_end(args);
-
+  free(fmt);
+  fmt = NULL;
   exit(code);
 }
 


### PR DESCRIPTION
The PR fixes some memleak.

The scripting and SITL one are interesting but not critical. Still nice to make analyzer warning disappeared

I am unsure about the other on CAN as they are just before a Panic. Should we cleanup things before a Panic ?
