### PR TITLE
AC_Avoid: Add feature to reject obstacles near home loc

### DIFF
--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -89,6 +89,7 @@ private:
     AP_Float        _beam_width;                            // beam width used when converting lidar readings to object radius
     AP_Float        _radius_min;                            // objects minimum radius (in meters)
     AP_Float        _dist_max;                              // objects maximum distance (in meters)
+    AP_Float        _min_alt;                               // OADatabase minimum vehicle height check (in meters)
 
     struct {
         ObjectBuffer<OA_DbItem> *items;                     // thread safe incoming queue of points from proximity sensor to be put into database


### PR DESCRIPTION
This adds the ability for a user to potentially ignore obstacles that are within a 3 meter radius of a Copter, below "ALT_MIN" height above home.
This has been a problem when you're taking off, OA DB might see the ground and continue to store the obstacles. Then the user has to wait for a while before the obstacle vanishes from the DB which is irritating to say the least.
This feature is even more essential to the new 3-D depth cameras that have a large FOV and can probably see a large area of the land below while taking off. 
As a demo, see this simulation on Morse: https://youtu.be/4dU48pAg7Fg  (alt limit is set to 3 meters)