### PR TITLE
AP_Scripting: generate metadata

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -272,8 +272,17 @@ userdata mavlink_mission_item_int_t field current uint8_t read write  0 UINT8_MA
 
 include AP_RPM/AP_RPM.h
 singleton AP_RPM alias RPM
+
+@Description: get the rpm from a RPM sensor backend
+@Link: https://github.com/ArduPilot/ardupilot/blob/afa153fb6fb569419455eb37384a1889971bd5bf/libraries/AP_RPM/AP_RPM.cpp#L200
+@Field: instance
+@Return: value
 singleton AP_RPM method get_rpm boolean uint8_t 0 RPM_MAX_INSTANCES float'Null
 
 include AP_Button/AP_Button.h
 singleton AP_Button alias button
+@Description: Get the state of buttons from AP_Button
+@Link: https://github.com/ArduPilot/ardupilot/blob/afa153fb6fb569419455eb37384a1889971bd5bf/libraries/AP_Button/AP_Button.cpp#L123
+@Return: valid reading
+@Field: button number
 singleton AP_Button method get_button_state boolean uint8_t 1 AP_BUTTON_NUM_PINS

--- a/libraries/AP_Scripting/generator/description/scripting_metadata.cpp
+++ b/libraries/AP_Scripting/generator/description/scripting_metadata.cpp
@@ -1,0 +1,15 @@
+// auto generated binding metadata, don't manually edit.
+
+//@Name: get_rpm
+//@Description: get the rpm from a RPM sensor backend
+//@Link: https://github.com/ArduPilot/ardupilot/blob/afa153fb6fb569419455eb37384a1889971bd5bf/libraries/AP_RPM/AP_RPM.cpp#L200
+//@Field: instance type:uint8_t range:0 RPM_MAX_INSTANCES
+//@Return: value type:nullable float
+
+//@Name: get_button_state
+//@Description: Get the state of buttons from AP_Button
+//@Link: https://github.com/ArduPilot/ardupilot/blob/afa153fb6fb569419455eb37384a1889971bd5bf/libraries/AP_Button/AP_Button.cpp#L123
+//@Return: valid reading type:bool
+//@Field: button number type:uint8_t range:1 AP_BUTTON_NUM_PINS
+
+// auto generated binding metadata, don't manually edit.


### PR DESCRIPTION
This is adds some basic metadata to the bindings description, this is then expanded by the scripting generator to add types and ranges.

The idea being that this meta data could then be parsed in a similar way to logs and params to auto-generate docs.

This does revert to having to update a generated file in AP_Scripting, however I think that could be fixed with a parser script that would run the generator itself.