### PR TITLE
AP_IOMCU: fixed handling of RC ignore failsafe option

### DIFF
--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -288,6 +288,9 @@ void AP_IOMCU::read_rc_input()
     if (!read_registers(PAGE_RAW_RCIN, 0, sizeof(rc_input)/2, r)) {
         return;
     }
+    if (rc_input.flags_failsafe && rc().ignore_rc_failsafe()) {
+        rc_input.flags_failsafe = false;
+    }
     if (rc_input.flags_rc_ok && !rc_input.flags_failsafe) {
         rc_last_input_ms = AP_HAL::millis();
     }


### PR DESCRIPTION
this allows for ignoring SBUS failsafe on boards using an IOMCU
The RC_OPTIONS ignore failsafe bit worked on FMU, but not on IOMCU. This fixes it to work on both
