### PR TITLE
GCS_MAVLink: avoid catching up on sending messages when sending disrupted

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5902,7 +5902,7 @@ Also, ignores heartbeats not from our target system'''
                 rate = round(self.get_message_rate("CAMERA_FEEDBACK", 20))
                 self.progress("Want=%u got=%u" % (want_rate, rate))
                 if rate != want_rate:
-                    raise NotAchievedException("Did not get expected rate")
+                    raise NotAchievedException("Did not get expected rate (want=%u got=%u" % (want_rate, rate))
 
 
             self.progress("try at the main loop rate")
@@ -5921,9 +5921,6 @@ Also, ignores heartbeats not from our target system'''
 
             self.drain_mav()
 
-            self.progress("Resetting CAMERA_FEEDBACK rate to zero")
-            self.set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_CAMERA_FEEDBACK, -1)
-
             non_existant_id = 145
             self.send_get_message_interval(non_existant_id)
             m = self.mav.recv_match(type='MESSAGE_INTERVAL', blocking=True)
@@ -5937,6 +5934,9 @@ Also, ignores heartbeats not from our target system'''
             self.progress("Caught exception: %s" %
                           self.get_exception_stacktrace(e))
             ex = e
+
+        self.progress("Resetting CAMERA_FEEDBACK rate to zero")
+        self.set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_CAMERA_FEEDBACK, -1)
 
         # tell MAVProxy to start stuffing around with the rates:
         sr = self.sitl_streamrate()

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -597,7 +597,7 @@ private:
     int8_t get_deferred_message_index(const ap_message id) const;
     // returns index of a message in deferred_message[] which should
     // be sent (or -1 if none to send at the moment)
-    int8_t deferred_message_to_send_index();
+    int8_t deferred_message_to_send_index(uint16_t now16_ms);
     // cache of which deferred message should be sent next:
     int8_t next_deferred_message_to_send_cache = -1;
 
@@ -612,8 +612,8 @@ private:
     uint8_t sending_bucket_id = no_bucket_to_send;
     Bitmask<MSG_LAST> bucket_message_ids_to_send;
 
-    ap_message next_deferred_bucket_message_to_send();
-    void find_next_bucket_to_send();
+    ap_message next_deferred_bucket_message_to_send(uint16_t now16_ms);
+    void find_next_bucket_to_send(uint16_t now16_ms);
     void remove_message_from_bucket(int8_t bucket, ap_message id);
 
     // bitmask of IDs the code has spontaneously decided it wants to

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1066,6 +1066,7 @@ void GCS_MAVLINK::update_send()
 #endif
 
     const uint32_t start = AP_HAL::millis();
+    const uint16_t start16 = AP_HAL::millis16();
     while (AP_HAL::millis() - start < 5) { // spend a max of 5ms sending messages.  This should never trigger - out_of_time() should become true
         if (gcs().out_of_time()) {
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS
@@ -1085,7 +1086,15 @@ void GCS_MAVLINK::update_send()
                 if (!do_try_send_message(deferred_message[next].id)) {
                     break;
                 }
-                deferred_message[next].last_sent_ms += deferred_message[next].interval_ms;
+                // we try to keep output on a regular clock to avoid
+                // user support questions:
+                const uint16_t interval_ms = deferred_message[next].interval_ms;
+                deferred_message[next].last_sent_ms += interval_ms;
+                // but we do not want to try to catch up too much:
+                if (uint16_t(start16 - deferred_message[next].last_sent_ms) > interval_ms) {
+                    deferred_message[next].last_sent_ms = start16;
+                }
+
                 next_deferred_message_to_send_cache = -1; // deferred_message_to_send will recalculate
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS
                 const uint32_t stop = AP_HAL::micros();
@@ -1126,8 +1135,14 @@ void GCS_MAVLINK::update_send()
             bucket_message_ids_to_send.clear(next);
             if (bucket_message_ids_to_send.count() == 0) {
                 // we sent everything in the bucket.  Reschedule it.
-                deferred_message_bucket[sending_bucket_id].last_sent_ms +=
-                    get_reschedule_interval_ms(deferred_message_bucket[sending_bucket_id]);
+                // we try to keep output on a regular clock to avoid
+                // user support questions:
+                const uint16_t interval_ms = get_reschedule_interval_ms(deferred_message_bucket[sending_bucket_id]);
+                deferred_message_bucket[sending_bucket_id].last_sent_ms += interval_ms;
+                // but we do not want to try to catch up too much:
+                if (uint16_t(start16 - deferred_message_bucket[sending_bucket_id].last_sent_ms) > interval_ms) {
+                    deferred_message_bucket[sending_bucket_id].last_sent_ms = start16;
+                }
                 find_next_bucket_to_send();
             }
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS


### PR DESCRIPTION
The code here was never meant to maintain an "average" streamrate.  It
was designed so that we would maintain a consistent clock in the face of
minor scheduling anomalies (like an EKF fusion step).

The way this is written, however, makes us spit out a message for each
of the intervals we missed - clearly not intended behaviour.

This was tested by inserting the following code:

```
 void GCS_MAVLINK::update_send()
 {
+    const uint32_t xnow = AP_HAL::millis();
+    if (xnow > 10000 &&
+        xnow < 20000) {
+        return;
+    }
+
```

After fix:
![image](https://user-images.githubusercontent.com/7077857/91000140-d7eec680-e60b-11ea-8bbf-2b16a1a826e7.png)

Before fix:
![image](https://user-images.githubusercontent.com/7077857/91000230-09679200-e60c-11ea-90df-1c331ec32d73.png)

Zooming in:
![image](https://user-images.githubusercontent.com/7077857/91000267-1be1cb80-e60c-11ea-82e1-ef7ce7f0064f.png)
