### PR TITLE
AP_AHRS: remove Rover's fall back to DCM even if GPS is enabled

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1230,8 +1230,7 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
       wing and rover
      */
     if (ret != EKFType::NONE &&
-        (_vehicle_class == AHRS_VEHICLE_FIXED_WING ||
-         _vehicle_class == AHRS_VEHICLE_GROUND) &&
+        (_vehicle_class == AHRS_VEHICLE_FIXED_WING) &&
         (_flags.fly_forward || !hal.util->get_soft_armed())) {
         nav_filter_status filt_state;
 #if HAL_NAVEKF2_AVAILABLE
@@ -1251,7 +1250,7 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
 #endif
         if (hal.util->get_soft_armed() && !filt_state.flags.using_gps && AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D) {
             // if the EKF is not fusing GPS and we have a 3D lock, then
-            // plane and rover would prefer to use the GPS position from
+            // plane would prefer to use the GPS position from
             // DCM. This is a safety net while some issues with the EKF
             // get sorted out
             return EKFType::NONE;


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/15125 which involves a Rover switching to DCM if the GPS is enabled (i.e. GPS_TYPE = 1) but the EKF is not fusing the GPS data.  Put another way this means Rover can be setup so that the GPS is enabled (and sets the EKF origin) but the wheel encoders are used position estimation.

Originally I thought [the issue](https://github.com/ArduPilot/ardupilot/issues/15125) would stop the EKF from falling back from GPS to wheel encoders but upon further testing I cannot find a situation where it fails.

Longer-term this change will be required assuming PR https://github.com/ArduPilot/ardupilot/pull/14803 is eventually merged which allows user to switching of sources in "flight".

Here is the SITL screen shot before the fix:
![image](https://user-images.githubusercontent.com/1498098/91004461-3f5a4580-e60f-11ea-8ecf-65acd9464bfe.png)

Here's the SITL screen shot after the fix:
![image](https://user-images.githubusercontent.com/1498098/91004786-200fe800-e610-11ea-903a-32a6d6b445a8.png)
