### PR TITLE
AP_GPS: Only call AP::rtc().set_utc_usec on the main GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -812,7 +812,7 @@ void AP_GPS::update_instance(uint8_t instance)
         AP::logger().Write_GPS(instance);
     }
 
-    if (state[instance].status >= GPS_OK_FIX_3D) {
+    if (state[instance].status >= GPS_OK_FIX_3D && instance == 0) {
         const uint64_t now = time_epoch_usec(instance);
         if (now != 0) {
             AP::rtc().set_utc_usec(now, AP_RTC::SOURCE_GPS);


### PR DESCRIPTION
When using multiple units the time might jitter and/or no longer be monotonic

This is not a nice fix, but I do think we need to fix this somehow.