### PR TITLE
Plane: tailsitters in Qassist inherit motor state

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -86,3 +86,17 @@ bool Mode::enter()
     return enter_result;
 }
 
+bool Mode::is_vtol_man_throttle() const
+{
+    if (!plane.quadplane.in_vtol_mode() &&
+        plane.quadplane.is_tailsitter() && 
+        plane.quadplane.tailsitter_transition_fw_complete() && 
+        plane.quadplane.assisted_flight) {
+        // a tailsitter that has fully transisisoned to Q-assisted forward flight
+        // in this case the forward throttle directly drives the vertical throttle
+        // set vertical throttle state to match the forward throttle state. Confusingly the booleans are inverted,
+        // forward throttle uses 'auto_throttle_mode' whereas vertical used 'is_vtol_man_throttle'
+        return !plane.auto_throttle_mode;
+    }
+    return false;
+}

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -71,7 +71,7 @@ public:
 
     // true for all q modes
     virtual bool is_vtol_mode() const { return false; }
-    virtual bool is_vtol_man_throttle() const { return false; }
+    virtual bool is_vtol_man_throttle() const;
     virtual bool is_vtol_man_mode() const { return false; }
     // guided or adsb mode
     virtual bool is_guided_mode() const { return false; }


### PR DESCRIPTION
This correctly sets the motor state for tailsitters in Qassist, this results in the correct Q_A_THR_MIX_ param being used. 

This is with Q_A_MOT_MIX_MAN = 0.9 and Q_A_MOT_MIX_MAX = 0.5, switching from FBWA to FBWB and back

Current master: 

![THR_MIX without](https://user-images.githubusercontent.com/33176108/91080482-8b23e380-e63d-11ea-9a0d-25d5912ab5ad.png)

With this patch:
![THR_MIX with](https://user-images.githubusercontent.com/33176108/91080495-9119c480-e63d-11ea-87bd-6b09bdab9ac0.png)
