### PR TITLE
AP_Scripting: pass by reference, AP_Notify: add scripting LED backend

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include "AP_BoardLED2.h"
 #include "ProfiLED.h"
+#include "ScriptingLED.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -146,7 +147,7 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Param: LED_TYPES
     // @DisplayName: LED Driver Types
     // @Description: Controls what types of LEDs will be enabled
-    // @Bitmask: 0:Build in LED, 1:Internal ToshibaLED, 2:External ToshibaLED, 3:External PCA9685, 4:Oreo LED, 5:UAVCAN, 6:NCP5623 External, 7:NCP5623 Internal, 8:NeoPixel, 9:ProfiLED
+    // @Bitmask: 0:Build in LED, 1:Internal ToshibaLED, 2:External ToshibaLED, 3:External PCA9685, 4:Oreo LED, 5:UAVCAN, 6:NCP5623 External, 7:NCP5623 Internal, 8:NeoPixel, 9:ProfiLED, 10:Scripting
     // @User: Advanced
     AP_GROUPINFO("LED_TYPES", 6, AP_Notify, _led_type, BUILD_DEFAULT_LED_TYPE),
 
@@ -286,6 +287,12 @@ void AP_Notify::add_backends(void)
 #if HAL_ENABLE_LIBUAVCAN_DRIVERS
                 ADD_BACKEND(new UAVCAN_RGB_LED(0));
 #endif // HAL_ENABLE_LIBUAVCAN_DRIVERS
+                break;
+
+            case Notify_LED_Scripting:
+#ifdef ENABLE_SCRIPTING
+                ADD_BACKEND(new ScriptingLED());
+#endif
                 break;
 
         }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -71,6 +71,7 @@ public:
         Notify_LED_NCP5623_I2C_Internal     = (1 << 7), // Internal NCP5623
         Notify_LED_NeoPixel                 = (1 << 8), // NeoPixel 5050 AdaFruit 1655 SK6812  Worldsemi WS2812B
         Notify_LED_ProfiLED                 = (1 << 9), // ProfiLED
+        Notify_LED_Scripting                = (1 << 10),// Colour accessor for scripting
         Notify_LED_MAX
     };
 

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -220,11 +220,11 @@ void RGBLed::update()
 
     const uint8_t colour = (current_colour_sequence >> (step*3)) & 7;
 
-    _red_des = (colour & RED) ? brightness : _led_off;
-    _green_des = (colour & GREEN) ? brightness : _led_off;
-    _blue_des = (colour & BLUE) ? brightness : _led_off;
+    uint8_t red_des = (colour & RED) ? brightness : _led_off;
+    uint8_t green_des = (colour & GREEN) ? brightness : _led_off;
+    uint8_t blue_des = (colour & BLUE) ? brightness : _led_off;
 
-    set_rgb(_red_des, _green_des, _blue_des);
+    set_rgb(red_des, green_des, blue_des);
 }
 
 /*

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -166,7 +166,7 @@ uint32_t RGBLed::get_colour_sequence(void) const
 uint32_t RGBLed::get_colour_sequence_traffic_light(void) const
 {
     if (AP_Notify::flags.initialising) {
-        return DEFINE_COLOUR_SEQUENCE(RED,GREEN,BLUE,RED,GREEN,BLUE,RED,GREEN,BLUE,OFF);
+        return DEFINE_COLOUR_SEQUENCE(RED,GREEN,BLUE,RED,GREEN,BLUE,RED,GREEN,BLUE,BLACK);
     }
 
     if (AP_Notify::flags.armed) {
@@ -175,14 +175,14 @@ uint32_t RGBLed::get_colour_sequence_traffic_light(void) const
 
     if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED) {
         if (!AP_Notify::flags.pre_arm_check) {
-            return DEFINE_COLOUR_SEQUENCE_ALTERNATE(YELLOW, OFF);
+            return DEFINE_COLOUR_SEQUENCE_ALTERNATE(YELLOW, BLACK);
         } else {
             return DEFINE_COLOUR_SEQUENCE_SLOW(YELLOW);
         }
     }
 
     if (!AP_Notify::flags.pre_arm_check) {
-        return DEFINE_COLOUR_SEQUENCE_ALTERNATE(GREEN, OFF);
+        return DEFINE_COLOUR_SEQUENCE_ALTERNATE(GREEN, BLACK);
     }
     return DEFINE_COLOUR_SEQUENCE_SLOW(GREEN);
 }

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -78,7 +78,7 @@ private:
     ((S0) << (0*3) | (S1) << (1*3) | (S2) << (2*3) | (S3) << (3*3) | (S4) << (4*3) | (S5) << (5*3) | (S6) << (6*3) | (S7) << (7*3) | (S8) << (8*3) | (S9) << (9*3))
 
 #define DEFINE_COLOUR_SEQUENCE_SLOW(colour)                       \
-    DEFINE_COLOUR_SEQUENCE(colour,colour,colour,colour,colour,OFF,OFF,OFF,OFF,OFF)
+    DEFINE_COLOUR_SEQUENCE(colour,colour,colour,colour,colour,BLACK,BLACK,BLACK,BLACK,BLACK)
 #define DEFINE_COLOUR_SEQUENCE_FAILSAFE(colour) \
     DEFINE_COLOUR_SEQUENCE(YELLOW,YELLOW,YELLOW,YELLOW,YELLOW,colour,colour,colour,colour,colour)
 #define DEFINE_COLOUR_SEQUENCE_SOLID(colour) \
@@ -86,7 +86,7 @@ private:
 #define DEFINE_COLOUR_SEQUENCE_ALTERNATE(colour1, colour2)                      \
     DEFINE_COLOUR_SEQUENCE(colour1,colour2,colour1,colour2,colour1,colour2,colour1,colour2,colour1,colour2)
 
-#define OFF    0
+#define BLACK  0
 #define BLUE   1
 #define GREEN  2
 #define RED    4
@@ -94,16 +94,16 @@ private:
 #define WHITE (RED|GREEN|BLUE)
 
     const uint32_t sequence_initialising = DEFINE_COLOUR_SEQUENCE_ALTERNATE(RED,BLUE);
-    const uint32_t sequence_trim_or_esc = DEFINE_COLOUR_SEQUENCE(RED,BLUE,GREEN,RED,BLUE,GREEN,RED,BLUE,GREEN,OFF);
+    const uint32_t sequence_trim_or_esc = DEFINE_COLOUR_SEQUENCE(RED,BLUE,GREEN,RED,BLUE,GREEN,RED,BLUE,GREEN,BLACK);
     const uint32_t sequence_failsafe_leak = DEFINE_COLOUR_SEQUENCE_FAILSAFE(WHITE);
     const uint32_t sequence_failsafe_ekf = DEFINE_COLOUR_SEQUENCE_FAILSAFE(RED);
     const uint32_t sequence_failsafe_gps_glitching = DEFINE_COLOUR_SEQUENCE_FAILSAFE(BLUE);
-    const uint32_t sequence_failsafe_radio_or_battery = DEFINE_COLOUR_SEQUENCE_FAILSAFE(OFF);
+    const uint32_t sequence_failsafe_radio_or_battery = DEFINE_COLOUR_SEQUENCE_FAILSAFE(BLACK);
 
     const uint32_t sequence_armed = DEFINE_COLOUR_SEQUENCE_SOLID(GREEN);
     const uint32_t sequence_armed_nogps = DEFINE_COLOUR_SEQUENCE_SOLID(BLUE);
-    const uint32_t sequence_prearm_failing = DEFINE_COLOUR_SEQUENCE(YELLOW,YELLOW,OFF,OFF,YELLOW,YELLOW,OFF,OFF,OFF,OFF);
-    const uint32_t sequence_disarmed_good_dgps = DEFINE_COLOUR_SEQUENCE_ALTERNATE(GREEN,OFF);
+    const uint32_t sequence_prearm_failing = DEFINE_COLOUR_SEQUENCE(YELLOW,YELLOW,BLACK,BLACK,YELLOW,YELLOW,BLACK,BLACK,BLACK,BLACK);
+    const uint32_t sequence_disarmed_good_dgps = DEFINE_COLOUR_SEQUENCE_ALTERNATE(GREEN,BLACK);
     const uint32_t sequence_disarmed_good_gps = DEFINE_COLOUR_SEQUENCE_SLOW(GREEN);
     const uint32_t sequence_disarmed_bad_gps = DEFINE_COLOUR_SEQUENCE_SLOW(BLUE);
 

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -54,7 +54,6 @@ protected:
     void update_override();
     
     // meta-data common to all hw devices
-    uint8_t _red_des, _green_des, _blue_des;     // color requested by timed update
     uint8_t _red_curr, _green_curr, _blue_curr;  // current colours displayed by the led
     uint8_t _led_off;
     uint8_t _led_bright;

--- a/libraries/AP_Notify/ScriptingLED.cpp
+++ b/libraries/AP_Notify/ScriptingLED.cpp
@@ -1,0 +1,39 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Notify/AP_Notify.h"
+#include "ScriptingLED.h"
+
+#ifdef ENABLE_SCRIPTING
+
+ScriptingLED *ScriptingLED::_singleton;
+
+ScriptingLED::ScriptingLED() :
+    RGBLed(0, 255, 170, 85)
+{
+    if (_singleton != nullptr) {
+        AP_HAL::panic("ScriptingLED must be singleton");
+    }
+    _singleton = this;
+}
+
+void ScriptingLED::get_rgb(uint8_t& red, uint8_t& green, uint8_t& blue)
+{
+    red = _red_curr;
+    green = _green_curr;
+    blue = _blue_curr;
+}
+
+#endif

--- a/libraries/AP_Notify/ScriptingLED.h
+++ b/libraries/AP_Notify/ScriptingLED.h
@@ -1,0 +1,47 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "RGBLed.h"
+#include <AP_Common/AP_Common.h>
+
+#ifdef ENABLE_SCRIPTING
+
+class ScriptingLED: public RGBLed {
+public:
+    ScriptingLED();
+
+    /* Do not allow copies */
+    ScriptingLED(const AP_Notify &other) = delete;
+    ScriptingLED &operator=(const AP_Notify&) = delete;
+
+    // get singleton instance
+    static ScriptingLED *get_singleton(void) {
+        return _singleton;
+    }
+
+    void get_rgb(uint8_t& red, uint8_t& green, uint8_t& blue);
+
+protected:
+
+    bool hw_init() override  {return true;};
+    bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) override {return true;}
+
+private:
+    static ScriptingLED *_singleton;
+
+};
+
+#endif

--- a/libraries/AP_Scripting/examples/get_notify_RGB.lua
+++ b/libraries/AP_Scripting/examples/get_notify_RGB.lua
@@ -1,0 +1,26 @@
+-- example of getting the current notify LED colour
+
+function update() -- this is the loop which periodically runs
+
+  local r, g, b = LED:get_rgb()
+  gcs:send_text(0, "Notify LED: r: " .. tostring(r) .. ", g: " .. tostring(g) ..", b:" .. tostring(b))
+
+  return update, 1000 -- reschedules the loop
+end
+
+-- make sure Scripting LED is enabled
+local led_parm = param:get('NTF_LED_TYPES')
+if not led_parm then
+  error('Could not find NTF_LED_TYPES param')
+end
+
+if (led_parm & (1 << 10)) == 0 then
+  -- try and enable it
+  if param:set_and_save('NTF_LED_TYPES',led_parm | (1 << 10)) then
+    error('Enabled Notify Scripting LED, please reboot')
+  else
+    error('Could not set NTF_LED_TYPES param')
+  end
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -280,3 +280,8 @@ singleton AP_RPM method get_rpm boolean uint8_t 0 RPM_MAX_INSTANCES float'Null
 include AP_Button/AP_Button.h
 singleton AP_Button alias button
 singleton AP_Button method get_button_state boolean uint8_t 1 AP_BUTTON_NUM_PINS
+
+
+include AP_Notify/ScriptingLED.h
+singleton ScriptingLED alias LED
+singleton ScriptingLED method get_rgb void uint8_t'Ref uint8_t'Ref uint8_t'Ref

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -27,6 +27,7 @@ char keyword_write[]               = "write";
 char keyword_attr_enum[]    = "'enum";
 char keyword_attr_literal[] = "'literal";
 char keyword_attr_null[]    = "'Null";
+char keyword_attr_reference[]  = "'Ref";
 
 // type keywords
 char keyword_boolean[]  = "boolean";
@@ -139,6 +140,7 @@ struct range_check {
 enum type_flags {
   TYPE_FLAGS_NULLABLE = (1U << 1),
   TYPE_FLAGS_ENUM     = (1U << 2),
+  TYPE_FLAGS_REFERNCE = (1U << 3),
 };
 
 struct type {
@@ -485,6 +487,8 @@ int parse_type(struct type *type, const uint32_t restrictions, enum range_check_
         error(ERROR_USERDATA, "%s is not nullable in this context", data_type);
       }
       type->flags |= TYPE_FLAGS_NULLABLE;
+    } else if (strcmp(attribute, keyword_attr_reference) == 0) {
+      type->flags |= TYPE_FLAGS_REFERNCE;
     } else {
       error(ERROR_USERDATA, "Unknown attribute: %s", attribute);
     }
@@ -533,7 +537,7 @@ int parse_type(struct type *type, const uint32_t restrictions, enum range_check_
   }
 
   // sanity check that only supported types are nullable
-  if (type->flags & TYPE_FLAGS_NULLABLE) {
+  if (type->flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) {
     // a switch is a very verbose way to do this, but forces users to consider new types added
     switch (type->type) {
       case TYPE_FLOAT:
@@ -551,13 +555,17 @@ int parse_type(struct type *type, const uint32_t restrictions, enum range_check_
       case TYPE_AP_OBJECT:
       case TYPE_LITERAL:
       case TYPE_NONE:
-        error(ERROR_USERDATA, "%s types cannot be nullable", data_type);
+        if (type->flags & TYPE_FLAGS_NULLABLE) {
+          error(ERROR_USERDATA, "%s types cannot be nullable", data_type);
+        } else {
+          error(ERROR_USERDATA, "%s types cannot be passed as reference", data_type);
+        }
         break;
     }
   }
 
   // add range checks, unless disabled or a nullable type
-  if (range_type != RANGE_CHECK_NONE && !(type->flags & TYPE_FLAGS_NULLABLE)) {
+  if (range_type != RANGE_CHECK_NONE && !(type->flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE))) {
     switch (type->type) {
       case TYPE_FLOAT:
       case TYPE_INT8_T:
@@ -658,8 +666,14 @@ void handle_method(char *parent_name, struct method **methods) {
     if ((method->return_type.type != TYPE_BOOLEAN) && (arg_type.flags & TYPE_FLAGS_NULLABLE)) {
       error(ERROR_USERDATA, "Nullable arguments are only available on a boolean method");
     }
+    if ((method->return_type.type == TYPE_BOOLEAN) && (arg_type.flags & TYPE_FLAGS_REFERNCE)) {
+      error(ERROR_USERDATA, "Use Nullable arguments on a boolean method, not 'Ref");
+    }
     if (arg_type.flags & TYPE_FLAGS_NULLABLE) {
       method->flags |= TYPE_FLAGS_NULLABLE;
+    }
+    if (arg_type.flags & TYPE_FLAGS_REFERNCE) {
+      method->flags |= TYPE_FLAGS_REFERNCE;
     }
     struct argument * arg = allocate(sizeof(struct argument));
     memcpy(&(arg->type), &arg_type, sizeof(struct type));
@@ -1024,7 +1038,7 @@ void emit_checker(const struct type t, int arg_number, int skipped, const char *
     error(ERROR_INTERNAL, "Can't handle more then %d arguments to a function", NULLABLE_ARG_COUNT_BASE);
   }
 
-  if (t.flags & TYPE_FLAGS_NULLABLE) {
+  if (t.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) {
     arg_number = arg_number + NULLABLE_ARG_COUNT_BASE;
     switch (t.type) {
       case TYPE_BOOLEAN:
@@ -1310,6 +1324,57 @@ void emit_userdata_fields() {
   }
 }
 
+// emit refences functions for a call, return the number of arduments added
+int emit_references(const struct argument *arg, const char * tab) {
+  int arg_index = NULLABLE_ARG_COUNT_BASE + 2;
+  int return_count = 0;
+  while (arg != NULL) {
+    if (arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) {
+      return_count++;
+      switch (arg->type.type) {
+        case TYPE_BOOLEAN:
+          fprintf(source, "%slua_pushboolean(L, data_%d);\n", tab, arg_index);
+          break;
+        case TYPE_FLOAT:
+          fprintf(source, "%slua_pushnumber(L, data_%d);\n", tab, arg_index);
+          break;
+        case TYPE_INT8_T:
+        case TYPE_INT16_T:
+        case TYPE_INT32_T:
+        case TYPE_UINT8_T:
+        case TYPE_UINT16_T:
+        case TYPE_ENUM:
+          fprintf(source, "%slua_pushinteger(L, data_%d);\n", tab, arg_index);
+          break;
+        case TYPE_UINT32_T:
+          fprintf(source, "%snew_uint32_t(L);\n", tab);
+          fprintf(source, "%s*static_cast<uint32_t *>(luaL_checkudata(L, -1, \"uint32_t\")) = data_%d;\n", tab, arg_index);
+          break;
+        case TYPE_STRING:
+          fprintf(source, "%slua_pushstring(L, data_%d);\n", tab, arg_index);
+          break;
+        case TYPE_USERDATA:
+          // userdatas must allocate a new container to return
+          fprintf(source, "%snew_%s(L);\n", tab, arg->type.data.ud.sanatized_name);
+          fprintf(source, "%s*check_%s(L, -1) = data_%d;\n", tab, arg->type.data.ud.sanatized_name, arg_index);
+          break;
+        case TYPE_NONE:
+          error(ERROR_INTERNAL, "Attempted to emit a nullable or reference  argument of type none");
+          break;
+        case TYPE_LITERAL:
+          error(ERROR_INTERNAL, "Attempted to make a nullable or reference literal");
+          break;
+        case TYPE_AP_OBJECT: // FIXME: collapse these to a single failure case
+          error(ERROR_INTERNAL, "Attempted to make a nullable or reference ap_object");
+          break;
+      }
+    }
+    arg_index++;
+    arg = arg->next;
+  }
+  return return_count;
+}
+
 void emit_userdata_method(const struct userdata *data, const struct method *method) {
   int arg_count = 1;
 
@@ -1330,7 +1395,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
   // sanity check number of args called with
   arg_count = 1;
   while (arg != NULL) {
-    if (!(arg->type.flags & TYPE_FLAGS_NULLABLE) && !(arg->type.type == TYPE_LITERAL)) {
+    if (!(arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) && !(arg->type.type == TYPE_LITERAL)) {
       arg_count++;
     }
     arg = arg->next;
@@ -1365,7 +1430,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       arg_count++;
     }
     if (//arg->type.type == TYPE_LITERAL ||
-        arg->type.flags & TYPE_FLAGS_NULLABLE) {
+        arg->type.flags & (TYPE_FLAGS_NULLABLE| TYPE_FLAGS_REFERNCE)) {
       skipped++;
     }
     arg = arg->next;
@@ -1475,7 +1540,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       case TYPE_ENUM:
       case TYPE_USERDATA:
       case TYPE_AP_OBJECT:
-        fprintf(source, "            data_%d", arg_count + ((arg->type.flags & TYPE_FLAGS_NULLABLE) ? NULLABLE_ARG_COUNT_BASE : 0));
+        fprintf(source, "            data_%d", arg_count + ((arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) ? NULLABLE_ARG_COUNT_BASE : 0));
         break;
       case TYPE_LITERAL:
         fprintf(source, "            %s", arg->type.data.literal);
@@ -1506,60 +1571,21 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
     fprintf(source, "    AP::scheduler().get_semaphore().give();\n");
   }
 
-  int return_count = 1; // number of arguments to return
+  // we need to emit out refernce arguments, iterate the args again, creating and copying objects, while keeping a new count
+  int return_count = 1; 
+  if (method->flags & TYPE_FLAGS_REFERNCE) {
+    arg = method->arguments;
+    // number of arguments to return
+    return_count += emit_references(arg,"    ");
+  }
+
   switch (method->return_type.type) {
     case TYPE_BOOLEAN:
       if (method->flags & TYPE_FLAGS_NULLABLE) {
         fprintf(source, "    if (data) {\n");
         // we need to emit out nullable arguments, iterate the args again, creating and copying objects, while keeping a new count
-        return_count = 0;
         arg = method->arguments;
-        int arg_index = NULLABLE_ARG_COUNT_BASE + 2;
-        while (arg != NULL) {
-          if (arg->type.flags & TYPE_FLAGS_NULLABLE) {
-            return_count++;
-            switch (arg->type.type) {
-              case TYPE_BOOLEAN:
-                fprintf(source, "        lua_pushboolean(L, data_%d);\n", arg_index);
-                break;
-              case TYPE_FLOAT:
-                fprintf(source, "        lua_pushnumber(L, data_%d);\n", arg_index);
-                break;
-              case TYPE_INT8_T:
-              case TYPE_INT16_T:
-              case TYPE_INT32_T:
-              case TYPE_UINT8_T:
-              case TYPE_UINT16_T:
-              case TYPE_ENUM:
-                fprintf(source, "        lua_pushinteger(L, data_%d);\n", arg_index);
-                break;
-              case TYPE_UINT32_T:
-                fprintf(source, "        new_uint32_t(L);\n");
-                fprintf(source, "        *static_cast<uint32_t *>(luaL_checkudata(L, -1, \"uint32_t\")) = data_%d;\n", arg_index);
-                break;
-              case TYPE_STRING:
-                fprintf(source, "        lua_pushstring(L, data_%d);\n", arg_index);
-                break;
-              case TYPE_USERDATA:
-                // userdatas must allocate a new container to return
-                fprintf(source, "        new_%s(L);\n", arg->type.data.ud.sanatized_name);
-                fprintf(source, "        *check_%s(L, -1) = data_%d;\n", arg->type.data.ud.sanatized_name, arg_index);
-                break;
-              case TYPE_NONE:
-                error(ERROR_INTERNAL, "Attempted to emit a nullable argument of type none");
-                break;
-              case TYPE_LITERAL:
-                error(ERROR_INTERNAL, "Attempted to make a nullable literal");
-                break;
-              case TYPE_AP_OBJECT: // FIXME: collapse these to a single failure case
-                error(ERROR_INTERNAL, "Attempted to make a nullable ap_object");
-                break;
-            }
-          }
-
-          arg_index++;
-          arg = arg->next;
-        }
+        return_count = emit_references(arg,"        ");
         fprintf(source, "        return %d;\n", return_count);
         fprintf(source, "    } else {\n");
         fprintf(source, "        return 0;\n");
@@ -1602,7 +1628,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
     case TYPE_NONE:
     case TYPE_LITERAL:
       // no return value, so don't worry about pushing a value
-      return_count = 0;
+      return_count--;
       break;
   }
 


### PR DESCRIPTION
This edits the scripting generator to allow passing by reference on none boolean methods. There is no change in the generated bindings due to this.

This also moves the calculation of the notify RGB color up from RGBLed.cpp to AP_Notify. This allows scripting to ask Notify what color its LED's are. 

This allows fancy scripts to show the standard scheme when not flying and be nav lights when in the air. Or to be nav lights unless the notify color is not green. We could do this previously but only by changing all LEDs from one to the other with a param. Now we could have half a strip be notify and have the other half playing pong, for example.