### PR TITLE
autotest: Calculate current in SIM_Plane.

### DIFF
--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -308,6 +308,9 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     
     float thrust     = throttle;
 
+    battery_voltage = sitl->batt_voltage - 0.7*throttle;
+    battery_current = 50.0f*throttle;
+
     if (ice_engine) {
         thrust = icengine.update(input);
     }


### PR DESCRIPTION
This calculates current in SIM_Plane, avoiding it being calculated in SITL_State. The advantage of doing it here is that reverse thrust is handled properly (zero current at 1500us PWM), whereas SITL_State assumes 1500us is 50% throttle.