### PR TITLE
AP_TECS: Improve OPTION_GLIDER_ONLY

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -245,7 +245,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Extra TECS options
     // @Description: This allows the enabling of special features in the speed/height controller
-    // @Bitmask: 0:GliderOnly
+    // @Bitmask: 0:Glider only (zero throttle output and prioritize airspeed control while ignoring altitude)
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 28, AP_TECS, _options, 0),
 
@@ -1006,7 +1006,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     _DT = (now - _update_pitch_throttle_last_usec) * 1.0e-6f;
     _update_pitch_throttle_last_usec = now;
 
-    _flags.is_gliding = _flags.gliding_requested || _flags.propulsion_failed || aparm.throttle_max==0;
+    _flags.is_gliding = _flags.gliding_requested || _flags.propulsion_failed || (aparm.throttle_max==0) || (_options & OPTION_GLIDER_ONLY);
     _flags.is_doing_auto_land = (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND);
     _distance_beyond_land_wp = distance_beyond_land_wp;
     _flight_stage = flight_stage;
@@ -1159,10 +1159,6 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 
     // Detect bad descent due to demanded airspeed being too high
     _detect_bad_descent();
-
-    if (_options & OPTION_GLIDER_ONLY) {
-        _flags.badDescent = false;        
-    }
 
     // Calculate pitch demand
     _update_pitch();


### PR DESCRIPTION
This unifies the existing OPTION_GLIDER_ONLY with the `_flags.is_gliding` system used by soaring.

There are some resulting behaviour changes when using OPTION_GLIDER_ONLY
 - Speed weight set to 2.0 to prioritise speed control using pitch regardless of the parameter setting
 - Throttle output set to 0
 - Pitch to airspeed feedforward parameters become active (default values are zero however)
