### PR TITLE
SITL: fix when speedup is specified as a startup parameter

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -432,6 +432,11 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
             fdm.quaternion.from_rotation_matrix(m);
         }
     }
+
+    // in the first call here, if a speedup option is specified, overwrite it
+    if (is_equal(last_speedup, -1.0f) && !is_equal(get_speedup(), 1.0f)) {
+        sitl->speedup = get_speedup();
+    }
     
     if (!is_equal(last_speedup, float(sitl->speedup)) && sitl->speedup > 0) {
         set_speedup(sitl->speedup);


### PR DESCRIPTION
Even if I use speedup option when run sim_vehicle.py like "sim_vehicle.py --speedup=5", SIM_SPEEDUP is back to the parameter of eeprom.bin.
I've fixed this issue.

Before
![image](https://user-images.githubusercontent.com/16643069/91306118-14c2e500-e7e7-11ea-9974-6b8bea955c80.png)

After
![image](https://user-images.githubusercontent.com/16643069/91306173-273d1e80-e7e7-11ea-8620-f79c7714d605.png)