### PR TITLE
GCS_Common: LOCAL_POSITION_NED sent using offset from origin (instead of offset from home)

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1101,16 +1101,6 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
                 packet.coordinate_frame == MAV_FRAME_BODY_NED ||
                 packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
                 pos_vector += copter.inertial_nav.get_position();
-            } else {
-                // convert from alt-above-home to alt-above-ekf-origin
-                if (!AP::ahrs().home_is_set()) {
-                    break;
-                }
-                Location origin;
-                pos_vector.z += AP::ahrs().get_home().alt;
-                if (copter.ahrs.get_origin(origin)) {
-                    pos_vector.z -= origin.alt;
-                }
             }
         }
 

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -766,6 +766,12 @@ void GCS_MAVLINK_Rover::handleMessage(const mavlink_message_t &msg)
                 break;
             }
 
+            // need ekf origin
+            Location ekf_origin;
+            if (!rover.ahrs.get_origin(ekf_origin)) {
+                break;
+            }
+
             // check for supported coordinate frames
             if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED &&
                 packet.coordinate_frame != MAV_FRAME_LOCAL_OFFSET_NED &&
@@ -799,9 +805,10 @@ void GCS_MAVLINK_Rover::handleMessage(const mavlink_message_t &msg)
                     target_loc.offset(packet.x, packet.y);
                     break;
 
+                case MAV_FRAME_LOCAL_NED:
                 default:
-                    // MAV_FRAME_LOCAL_NED interpret as an offset from home
-                    target_loc = rover.ahrs.get_home();
+                    // MAV_FRAME_LOCAL_NED is interpreted as an offset from EKF origin
+                    target_loc = ekf_origin;
                     target_loc.offset(packet.x, packet.y);
                     break;
                 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2271,7 +2271,7 @@ void GCS_MAVLINK::send_local_position() const
     const AP_AHRS &ahrs = AP::ahrs();
 
     Vector3f local_position, velocity;
-    if (!ahrs.get_relative_position_NED_home(local_position) ||
+    if (!ahrs.get_relative_position_NED_origin(local_position) ||
         !ahrs.get_velocity_NED(velocity)) {
         // we don't know the position and velocity
         return;


### PR DESCRIPTION
This PR replaces https://github.com/ArduPilot/ardupilot/pull/6893 but the only change is the commit message.

I've lightly re-tested this and it works.  Below are some screen shots showing that before the position sent was reset when the vehicle disarmed (because home moved) while after it does not.

Before:
![randy-local-pos-ned-reporting-before](https://user-images.githubusercontent.com/1498098/91372785-9189a980-e84f-11ea-82b1-6dfe21bfe3a3.png)

After:
![randy-local-pos-ned-reporting-after](https://user-images.githubusercontent.com/1498098/91372789-93ec0380-e84f-11ea-8151-6a6229ea59d1.png)

If there are no objections I'll merge this after it passes travis because the previous PR was already approved.