### PR TITLE
RC_Channels logs input; add option to log at consumption rate

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -103,9 +103,6 @@ void Tracker::ten_hz_logging_loop()
     if (should_log(MASK_LOG_ATTITUDE)) {
         Log_Write_Attitude();
     }
-    if (should_log(MASK_LOG_RCIN)) {
-        logger.Write_RCIN();
-    }
     if (should_log(MASK_LOG_RCOUT)) {
         logger.Write_RCOUT();
     }

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -59,6 +59,7 @@ void Tracker::init_ardupilot()
     serial_manager.set_blocking_writes_all(false);
 
     // initialise rc channels including setting mode
+    rc().set_log_bit(MASK_LOG_RCIN);
     rc().init();
 
     // initialise servos

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -400,7 +400,6 @@ void Copter::ten_hz_logging_loop()
         Log_Write_MotBatt();
     }
     if (should_log(MASK_LOG_RCIN)) {
-        logger.Write_RCIN();
         if (rssi.enabled()) {
             logger.Write_RSSI();
         }

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -84,6 +84,7 @@ void Copter::init_ardupilot()
     allocate_motors();
 
     // initialise rc channels including setting mode
+    rc().set_log_bit(MASK_LOG_RCIN);
     rc().init();
 
     // sets up motors and output to escs

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -246,7 +246,6 @@ void Plane::Log_Write_AETR()
 
 void Plane::Log_Write_RC(void)
 {
-    logger.Write_RCIN();
     logger.Write_RCOUT();
     if (rssi.enabled()) {
         logger.Write_RSSI();

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -188,9 +188,6 @@ void Sub::ten_hz_logging_loop()
     if (should_log(MASK_LOG_MOTBATT)) {
         Log_Write_MotBatt();
     }
-    if (should_log(MASK_LOG_RCIN)) {
-        logger.Write_RCIN();
-    }
     if (should_log(MASK_LOG_RCOUT)) {
         logger.Write_RCOUT();
     }

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -61,6 +61,7 @@ void Sub::init_ardupilot()
 #endif
 
     // initialise rc channels including setting mode
+    rc().set_log_bit(MASK_LOG_RCIN);
     rc().init();
 
     init_rc_in();               // sets up rc channels from radio

--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -246,7 +246,6 @@ void Rover::Log_Write_Throttle()
 
 void Rover::Log_Write_RC(void)
 {
-    logger.Write_RCIN();
     logger.Write_RCOUT();
     if (rssi.enabled()) {
         logger.Write_RSSI();

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -434,6 +434,8 @@ public:
 
     uint32_t last_input_ms() const { return last_update_ms; };
 
+    void set_log_bit(uint32_t log_bit) { _log_bit = log_bit; }
+
 protected:
 
     enum class Option {
@@ -445,7 +447,11 @@ protected:
         ARMING_CHECK_THROTTLE = (1 << 5), // run an arming check for neutral throttle
         ARMING_SKIP_CHECK_RPY = (1 << 6), // skip the an arming checks for the roll/pitch/yaw channels
         ALLOW_SWITCH_REV      = (1 << 7), // honor the reversed flag on switches
+        LOG_RC_CONSUMPTION    = (1 << 8), // log RC as we copy it from the HAL
     };
+    inline bool option_is_set(Option option) const {
+        return _options & uint32_t(option);
+    }
 
     void new_override_received() {
         has_new_overrides = true;
@@ -470,6 +476,10 @@ private:
 
     // Allow override by default at start
     bool _gcs_overrides_enabled = true;
+
+    uint32_t _log_bit;
+    uint32_t _last_log_write_ms;
+    void log_rc_consumption();
 };
 
 RC_Channels &rc();

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks, 7:Allow Switch reverse
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks, 7:Allow Switch reverse, 8:Log RC channels as consumed
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE),
 
     // @Param: _PROTOCOLS


### PR DESCRIPTION
At the moment each of our vehicles logs RC input @10Hz.

This PR moves responsibility for logging into the RC_Channels library.

By default logging continues to be done @10Hz, however if a new `LOG_CONSUMPTION` `RC_OPTIONS` bit is set we instead log at the rate at which we copy from the hal layer into the RC_Channels layer.

This is on a real Rover - the bit is set part-way through this graph:

![image](https://user-images.githubusercontent.com/7077857/91379012-0c10f400-e865-11ea-9374-e5e7fddc1748.png)

Bouncing between 25Hz and 50Hz is the beat frequency for calls to `RC_Channels::read_input` and input parsed from the receiver.
