### PR TITLE
Copter: Enable 0 second delay

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1368,7 +1368,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
 {
     nav_delay_time_start_ms = millis();
 
-    if (cmd.content.nav_delay.seconds > 0) {
+    if (cmd.content.nav_delay.seconds >= 0) {
         // relative delay
         nav_delay_time_max_ms = cmd.content.nav_delay.seconds * 1000; // convert seconds to milliseconds
     } else {

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -475,7 +475,7 @@ void Sub::do_nav_delay(const AP_Mission::Mission_Command& cmd)
 {
     nav_delay_time_start_ms = AP_HAL::millis();
 
-    if (cmd.content.nav_delay.seconds > 0) {
+    if (cmd.content.nav_delay.seconds >= 0) {
         // relative delay
         nav_delay_time_max_ms = cmd.content.nav_delay.seconds * 1000; // convert seconds to milliseconds
     } else {

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -576,7 +576,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         start_stop();
     }
 
-    if (cmd.content.nav_delay.seconds > 0) {
+    if (cmd.content.nav_delay.seconds >= 0) {
         // relative delay
         nav_delay_time_max_ms = cmd.content.nav_delay.seconds * 1000; // convert seconds to milliseconds
     } else {


### PR DESCRIPTION
In the MAVLINK specification, -1 is defined as TIMEOFDAY.
Therefore, 0 second delay is a valid value.

https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_DELAY