### PR TITLE
GCS_MAVLink: fixed overrun of text passed to other libraries

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1836,7 +1836,7 @@ void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, u
         // send_text can be called from multiple threads; we must
         // protect the "text" member with _statustext_sem
         hal.util->vsnprintf(statustext_printf_buffer, sizeof(statustext_printf_buffer), fmt, arg_list);
-        memcpy(first_piece_of_text, statustext_printf_buffer, ARRAY_SIZE(first_piece_of_text));
+        memcpy(first_piece_of_text, statustext_printf_buffer, ARRAY_SIZE(first_piece_of_text)-1);
 
         // filter destination ports to only allow active ports.
         statustext_t statustext{};


### PR DESCRIPTION
this caused corruption in log files, and was passing a non-nul-terminated string to notify and other libraries
This bug showed up with the following message:

  EKF3 IMU0 buffs IMU=11 OBS=4 OF=10 EN:10, dt=0.0120ɖU

the length of the string is 54 bytes, for a string of length 51
