### PR TITLE
EKF: fixed handling of compass sensor failure

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1585,6 +1585,50 @@ class AutoTestCopter(AutoTest):
 
         self.do_RTL()
 
+    # test_mag_fail - test failover of compass in EKF
+    def test_mag_fail(self):
+        # we want both EK2 and EK3
+        self.set_parameter("EK2_ENABLE", 1)
+        self.set_parameter("EK3_ENABLE", 1)
+
+        self.takeoff(10, mode="LOITER")
+
+        self.mavproxy.send('mode CIRCLE\n')
+        self.wait_mode('CIRCLE')
+
+        self.delay_sim_time(20)
+
+        self.progress("Failing first compass")
+        self.set_parameter("SIM_MAG1_FAIL", 1)
+
+        # we want for the message twice, one for EK2 and again for EK3
+        self.wait_statustext("IMU0 switching to compass 1")
+        self.wait_statustext("IMU0 switching to compass 1")
+        self.progress("compass switch 1 OK")
+
+        self.delay_sim_time(2)
+
+        self.progress("Failing 2nd compass")
+        self.set_parameter("SIM_MAG2_FAIL", 1)
+
+        self.wait_statustext("IMU0 switching to compass 2")
+        self.wait_statustext("IMU0 switching to compass 2")
+
+        self.progress("compass switch 2 OK")
+
+        self.delay_sim_time(2)
+
+        self.progress("Failing 3rd compass")
+        self.set_parameter("SIM_MAG3_FAIL", 1)
+        self.delay_sim_time(2)
+        self.set_parameter("SIM_MAG1_FAIL", 0)
+
+        self.wait_statustext("IMU0 switching to compass 0")
+        self.wait_statustext("IMU0 switching to compass 0")
+        self.progress("compass switch 0 OK")
+
+        self.do_RTL()
+        
     def wait_attitude(self, desroll=None, despitch=None, timeout=2, tolerance=10):
         '''wait for an attitude (degrees)'''
         if desroll is None and despitch is None:
@@ -5323,6 +5367,10 @@ class AutoTestCopter(AutoTest):
             ("ModeCircle",
              "Fly CIRCLE mode",
              self.fly_circle),
+
+            ("MagFail",
+             "Test magnetometer failure",
+             self.test_mag_fail),
 
             ("OpticalFlowLimits",
              "Fly Optical Flow limits",

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -970,7 +970,6 @@ class AutoTest(ABC):
             self.params = [self.params]
         for x in self.params:
             self.repeatedly_apply_parameter_file(os.path.join(testdir, x))
-        self.set_parameter('LOG_REPLAY', 1)
         self.set_parameter('LOG_DISARMED', 1)
         if self.force_ahrs_type is not None:
             if self.force_ahrs_type == 2:

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1483,8 +1483,10 @@ Compass::read(void)
         _backends[i]->read();
     }
     uint32_t time = AP_HAL::millis();
+    bool any_healthy = false;
     for (StateIndex i(0); i < COMPASS_MAX_INSTANCES; i++) {
         _state[i].healthy = (time - _state[i].last_update_ms < 500);
+        any_healthy |= _state[i].healthy;
     }
 #if COMPASS_LEARN_ENABLED
     if (_learn == LEARN_INFLIGHT && !learn_allocated) {
@@ -1494,14 +1496,13 @@ Compass::read(void)
     if (_learn == LEARN_INFLIGHT && learn != nullptr) {
         learn->update();
     }
-    bool ret = healthy();
-    if (ret && _log_bit != (uint32_t)-1 && AP::logger().should_log(_log_bit) && !AP::ahrs().have_ekf_logging()) {
+#endif
+#ifndef HAL_NO_LOGGING
+    if (any_healthy && _log_bit != (uint32_t)-1 && AP::logger().should_log(_log_bit) && !AP::ahrs().have_ekf_logging()) {
         AP::logger().Write_Compass();
     }
-    return ret;
-#else
-    return healthy();
 #endif
+    return healthy();
 }
 
 uint8_t

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -128,12 +128,22 @@ void AP_Compass_SITL::_timer()
         } else {
             f.rotate(get_board_orientation());
         }
-        if (i == 0) {
-            // scale the first compass to simulate sensor scale factor errors
-            f *= _sitl->mag_scaling;
+        // scale the compass to simulate sensor scale factor errors
+        f *= _sitl->mag_scaling[i];
+
+        switch (_sitl->mag_fail[i]) {
+        case 0:
+            accumulate_sample(f, _compass_instance[i], 10);
+            _last_data[i] = f;
+            break;
+        case 1:
+            // no data
+            break;
+        case 2:
+            // frozen compass
+            accumulate_sample(_last_data[i], _compass_instance[i], 10);
+            break;
         }
-        
-        accumulate_sample(f, _compass_instance[i], 10);
     }
 }
 

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -40,5 +40,6 @@ private:
     Matrix3f _eliptical_corr;
     Vector3f _last_dia;
     Vector3f _last_odi;
+    Vector3f _last_data[MAX_SITL_COMPASSES];
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -255,9 +255,6 @@ void NavEKF2_core::SelectMagFusion()
         return;
     }
 
-    // check for and read new magnetometer measurements
-    readMagData();
-
     // If we are using the compass and the magnetometer has been unhealthy for too long we declare a timeout
     if (magHealth) {
         magTimeout = false;
@@ -265,6 +262,9 @@ void NavEKF2_core::SelectMagFusion()
     } else if ((imuSampleTime_ms - lastHealthyMagTime_ms) > frontend->magFailTimeLimit_ms && use_compass()) {
         magTimeout = true;
     }
+
+    // check for and read new magnetometer measurements
+    readMagData();
 
     // check for availability of magnetometer data to fuse
     magDataToFuse = storedMag.recall(magDataDelayed,imuDataDelayed.time_ms);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -192,6 +192,41 @@ void NavEKF2_core::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f
 *                      MAGNETOMETER                     *
 ********************************************************/
 
+// try changing to another compass
+void NavEKF2_core::tryChangeCompass(void)
+{
+    const Compass &compass = AP::compass();
+    const uint8_t maxCount = compass.get_count();
+
+    // search through the list of magnetometers
+    for (uint8_t i=1; i<maxCount; i++) {
+        uint8_t tempIndex = magSelectIndex + i;
+        // loop back to the start index if we have exceeded the bounds
+        if (tempIndex >= maxCount) {
+            tempIndex -= maxCount;
+        }
+        // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
+        if (compass.healthy(tempIndex) && compass.use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
+            magSelectIndex = tempIndex;
+            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
+            // reset the timeout flag and timer
+            magTimeout = false;
+            lastHealthyMagTime_ms = imuSampleTime_ms;
+            // zero the learned magnetometer bias states
+            stateStruct.body_magfield.zero();
+            // clear the measurement buffer
+            storedMag.reset();
+            // clear the data waiting flag so that we do not use any data pending from the previous sensor
+            magDataToFuse = false;
+            // request a reset of the magnetic field states
+            magStateResetRequest = true;
+            // declare the field unlearned so that the reset request will be obeyed
+            magFieldLearned = false;
+            return;
+        }
+    }
+}
+
 // check for new magnetometer data and update store measurements if available
 void NavEKF2_core::readMagData()
 {
@@ -222,44 +257,25 @@ void NavEKF2_core::readMagData()
         InitialiseVariablesMag();
     }
 
+    // check for a failed compass and switch if failed for magFailTimeLimit_ms
+    if (maxCount > 1 &&
+        !compass.healthy(magSelectIndex) &&
+        imuSampleTime_ms - lastMagRead_ms > frontend->magFailTimeLimit_ms) {
+        tryChangeCompass();
+    }
     
     // do not accept new compass data faster than 14Hz (nominal rate is 10Hz) to prevent high processor loading
     // because magnetometer fusion is an expensive step and we could overflow the FIFO buffer
-    if (use_compass() && compass.last_update_usec() - lastMagUpdate_us > 70000) {
+    if (use_compass() &&
+        compass.healthy(magSelectIndex) &&
+        compass.last_update_usec(magSelectIndex) - lastMagUpdate_us > 70000) {
         frontend->logging.log_compass = true;
 
         // If the magnetometer has timed out (been rejected too long) we find another magnetometer to use if available
         // Don't do this if we are on the ground because there can be magnetic interference and we need to know if there is a problem
         // before taking off. Don't do this within the first 30 seconds from startup because the yaw error could be due to large yaw gyro bias affsets
         if (magTimeout && (maxCount > 1) && !onGround && imuSampleTime_ms - ekfStartTime_ms > 30000) {
-
-            // search through the list of magnetometers
-            for (uint8_t i=1; i<maxCount; i++) {
-                uint8_t tempIndex = magSelectIndex + i;
-                // loop back to the start index if we have exceeded the bounds
-                if (tempIndex >= maxCount) {
-                    tempIndex -= maxCount;
-                }
-                // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
-                if (compass.use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
-                    magSelectIndex = tempIndex;
-                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
-                    // reset the timeout flag and timer
-                    magTimeout = false;
-                    lastHealthyMagTime_ms = imuSampleTime_ms;
-                    // zero the learned magnetometer bias states
-                    stateStruct.body_magfield.zero();
-                    // clear the measurement buffer
-                    storedMag.reset();
-                    // clear the data waiting flag so that we do not use any data pending from the previous sensor
-                    magDataToFuse = false;
-                    // request a reset of the magnetic field states
-                    magStateResetRequest = true;
-                    // declare the field unlearned so that the reset request will be obeyed
-                    magFieldLearned = false;
-                    break;
-                }
-            }
+            tryChangeCompass();
         }
 
         // detect changes to magnetometer offset parameters and reset states
@@ -277,6 +293,9 @@ void NavEKF2_core::readMagData()
         // store time of last measurement update
         lastMagUpdate_us = compass.last_update_usec(magSelectIndex);
 
+        // Magnetometer data at the current time horizon
+        mag_elements magDataNew;
+
         // estimate of time magnetometer measurement was taken, allowing for delays
         magDataNew.time_ms = imuSampleTime_ms - frontend->magDelay_ms;
 
@@ -291,6 +310,9 @@ void NavEKF2_core::readMagData()
 
         // save magnetometer measurement to buffer to be fused later
         storedMag.push(magDataNew);
+
+        // remember time we read compass, to detect compass sensor failure
+        lastMagRead_ms = imuSampleTime_ms;
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -257,6 +257,18 @@ void NavEKF2_core::readMagData()
         InitialiseVariablesMag();
     }
 
+    // If the magnetometer has timed out (been rejected for too long), we find another magnetometer to use if available
+    // Don't do this if we are on the ground because there can be magnetic interference and we need to know if there is a problem
+    // before taking off. Don't do this within the first 30 seconds from startup because the yaw error could be due to large yaw gyro bias affsets
+    // if the timeout is due to a sensor failure, then declare a timeout regardless of onground status
+    if (maxCount > 1) {
+        bool fusionTimeout = magTimeout && !onGround && imuSampleTime_ms - ekfStartTime_ms > 30000;
+        bool sensorTimeout = !compass.healthy(magSelectIndex) && imuSampleTime_ms - lastMagRead_ms > frontend->magFailTimeLimit_ms;
+        if (fusionTimeout || sensorTimeout) {
+            tryChangeCompass();
+        }
+    }
+
     // check for a failed compass and switch if failed for magFailTimeLimit_ms
     if (maxCount > 1 &&
         !compass.healthy(magSelectIndex) &&
@@ -271,12 +283,6 @@ void NavEKF2_core::readMagData()
         compass.last_update_usec(magSelectIndex) - lastMagUpdate_us > 70000) {
         frontend->logging.log_compass = true;
 
-        // If the magnetometer has timed out (been rejected too long) we find another magnetometer to use if available
-        // Don't do this if we are on the ground because there can be magnetic interference and we need to know if there is a problem
-        // before taking off. Don't do this within the first 30 seconds from startup because the yaw error could be due to large yaw gyro bias affsets
-        if (magTimeout && (maxCount > 1) && !onGround && imuSampleTime_ms - ekfStartTime_ms > 30000) {
-            tryChangeCompass();
-        }
 
         // detect changes to magnetometer offset parameters and reset states
         Vector3f nowMagOffsets = compass.get_offsets(magSelectIndex);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -651,6 +651,9 @@ private:
     // check for new magnetometer data and update store measurements if available
     void readMagData();
 
+    // try changing compasses on compass failure or timeout
+    void tryChangeCompass(void);
+
     // check for new airspeed data and update stored measurements if available
     void readAirSpdData();
 
@@ -905,6 +908,7 @@ private:
     uint32_t prevTasStep_ms;        // time stamp of last TAS fusion step
     uint32_t prevBetaStep_ms;       // time stamp of last synthetic sideslip fusion step
     uint32_t lastMagUpdate_us;      // last time compass was updated in usec
+    uint32_t lastMagRead_ms;        // last time compass data was successfully read
     Vector3f velDotNED;             // rate of change of velocity in NED frame
     Vector3f velDotNEDfilt;         // low pass filtered velDotNED
     uint32_t imuSampleTime_ms;      // time that the last IMU value was taken
@@ -967,7 +971,6 @@ private:
     tas_elements tasDataNew;        // TAS data at the current time horizon
     tas_elements tasDataDelayed;    // TAS data at the fusion time horizon
     uint8_t tasStoreIndex;          // TAS data storage index
-    mag_elements magDataNew;        // Magnetometer data at the current time horizon
     mag_elements magDataDelayed;    // Magnetometer data at the fusion time horizon
     uint8_t magStoreIndex;          // Magnetometer data storage index
     gps_elements gpsDataNew;        // GPS data at the current time horizon

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -358,19 +358,19 @@ void NavEKF3_core::SelectMagFusion()
         // fall through to magnetometer fusion
     }
 
-    if (effectiveMagCal != MagCal::EXTERNAL_YAW_FALLBACK) {
-        // check for and read new magnetometer measurements. We don't
-        // real for EXTERNAL_YAW_FALLBACK as it has already been read
-        // above
-        readMagData();
-    }
-
     // If we are using the compass and the magnetometer has been unhealthy for too long we declare a timeout
     if (magHealth) {
         magTimeout = false;
         lastHealthyMagTime_ms = imuSampleTime_ms;
     } else if ((imuSampleTime_ms - lastHealthyMagTime_ms) > frontend->magFailTimeLimit_ms && use_compass()) {
         magTimeout = true;
+    }
+
+    if (effectiveMagCal != MagCal::EXTERNAL_YAW_FALLBACK) {
+        // check for and read new magnetometer measurements. We don't
+        // real for EXTERNAL_YAW_FALLBACK as it has already been read
+        // above
+        readMagData();
     }
 
     // check for availability of magnetometer or other yaw data to fuse

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -313,11 +313,16 @@ void NavEKF3_core::readMagData()
         InitialiseVariablesMag();
     }
 
-    // check for a failed compass and switch if failed for magFailTimeLimit_ms
-    if (maxCount > 1 &&
-        !compass.healthy(magSelectIndex) &&
-        imuSampleTime_ms - lastMagRead_ms > frontend->magFailTimeLimit_ms) {
-        tryChangeCompass();
+    // If the magnetometer has timed out (been rejected for too long), we find another magnetometer to use if available
+    // Don't do this if we are on the ground because there can be magnetic interference and we need to know if there is a problem
+    // before taking off. Don't do this within the first 30 seconds from startup because the yaw error could be due to large yaw gyro bias affsets
+    // if the timeout is due to a sensor failure, then declare a timeout regardless of onground status
+    if (maxCount > 1) {
+        bool fusionTimeout = magTimeout && !onGround && imuSampleTime_ms - ekfStartTime_ms > 30000 && !(frontend->_affinity & EKF_AFFINITY_MAG);
+        bool sensorTimeout = !compass.healthy(magSelectIndex) && imuSampleTime_ms - lastMagRead_ms > frontend->magFailTimeLimit_ms;
+        if (fusionTimeout || sensorTimeout) {
+            tryChangeCompass();
+        }
     }
 
     // limit compass update rate to prevent high processor loading because magnetometer fusion is an expensive step and we could overflow the FIFO buffer
@@ -325,18 +330,6 @@ void NavEKF3_core::readMagData()
         compass.healthy(magSelectIndex) &&
         ((compass.last_update_usec(magSelectIndex) - lastMagUpdate_us) > 1000 * frontend->sensorIntervalMin_ms)) {
         frontend->logging.log_compass = true;
-
-        // If the magnetometer has timed out (been rejected too long) we find another magnetometer to use if available
-        // Don't do this if we are on the ground because there can be magnetic interference and we need to know if there is a problem
-        // before taking off. Don't do this within the first 30 seconds from startup because the yaw error could be due to large yaw gyro bias affsets
-        if (magTimeout && (maxCount > 1) &&
-            !onGround &&
-            imuSampleTime_ms - ekfStartTime_ms > 30000 &&
-            !(frontend->_affinity & EKF_AFFINITY_MAG)) {
-
-            // this compass has timed out (innovations too large for magFailTimeLimit_ms), try a new compass
-            tryChangeCompass();
-        }
 
         // detect changes to magnetometer offset parameters and reset states
         Vector3f nowMagOffsets = compass.get_offsets(magSelectIndex);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -248,6 +248,41 @@ void NavEKF3_core::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f
 *                      MAGNETOMETER                     *
 ********************************************************/
 
+// try changing compass, return true if a new compass is found
+void NavEKF3_core::tryChangeCompass(void)
+{
+    const Compass &compass = AP::compass();
+    const uint8_t maxCount = compass.get_count();
+
+    // search through the list of magnetometers
+    for (uint8_t i=1; i<maxCount; i++) {
+        uint8_t tempIndex = magSelectIndex + i;
+        // loop back to the start index if we have exceeded the bounds
+        if (tempIndex >= maxCount) {
+            tempIndex -= maxCount;
+        }
+        // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
+        if (compass.healthy(tempIndex) && compass.use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
+            magSelectIndex = tempIndex;
+            gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
+            // reset the timeout flag and timer
+            magTimeout = false;
+            lastHealthyMagTime_ms = imuSampleTime_ms;
+            // zero the learned magnetometer bias states
+            stateStruct.body_magfield.zero();
+            // clear the measurement buffer
+            storedMag.reset();
+            // clear the data waiting flag so that we do not use any data pending from the previous sensor
+            magDataToFuse = false;
+            // request a reset of the magnetic field states
+            magStateResetRequest = true;
+            // declare the field unlearned so that the reset request will be obeyed
+            magFieldLearned = false;
+            return;
+        }
+    }
+}
+
 // check for new magnetometer data and update store measurements if available
 void NavEKF3_core::readMagData()
 {
@@ -260,7 +295,7 @@ void NavEKF3_core::readMagData()
 
     // If we are a vehicle with a sideslip constraint to aid yaw estimation and we have timed out on our last avialable
     // magnetometer, then declare the magnetometers as failed for this flight
-    uint8_t maxCount = compass.get_count();
+    const uint8_t maxCount = compass.get_count();
     if (allMagSensorsFailed || (magTimeout && assume_zero_sideslip() && magSelectIndex >= maxCount-1 && inFlight)) {
         allMagSensorsFailed = true;
         return;
@@ -277,9 +312,18 @@ void NavEKF3_core::readMagData()
         yawAlignComplete = false;
         InitialiseVariablesMag();
     }
-    
+
+    // check for a failed compass and switch if failed for magFailTimeLimit_ms
+    if (maxCount > 1 &&
+        !compass.healthy(magSelectIndex) &&
+        imuSampleTime_ms - lastMagRead_ms > frontend->magFailTimeLimit_ms) {
+        tryChangeCompass();
+    }
+
     // limit compass update rate to prevent high processor loading because magnetometer fusion is an expensive step and we could overflow the FIFO buffer
-    if (use_compass() && ((compass.last_update_usec() - lastMagUpdate_us) > 1000 * frontend->sensorIntervalMin_ms)) {
+    if (use_compass() &&
+        compass.healthy(magSelectIndex) &&
+        ((compass.last_update_usec(magSelectIndex) - lastMagUpdate_us) > 1000 * frontend->sensorIntervalMin_ms)) {
         frontend->logging.log_compass = true;
 
         // If the magnetometer has timed out (been rejected too long) we find another magnetometer to use if available
@@ -290,33 +334,8 @@ void NavEKF3_core::readMagData()
             imuSampleTime_ms - ekfStartTime_ms > 30000 &&
             !(frontend->_affinity & EKF_AFFINITY_MAG)) {
 
-            // search through the list of magnetometers
-            for (uint8_t i=1; i<maxCount; i++) {
-                uint8_t tempIndex = magSelectIndex + i;
-                // loop back to the start index if we have exceeded the bounds
-                if (tempIndex >= maxCount) {
-                    tempIndex -= maxCount;
-                }
-                // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
-                if (compass.use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
-                    magSelectIndex = tempIndex;
-                    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
-                    // reset the timeout flag and timer
-                    magTimeout = false;
-                    lastHealthyMagTime_ms = imuSampleTime_ms;
-                    // zero the learned magnetometer bias states
-                    stateStruct.body_magfield.zero();
-                    // clear the measurement buffer
-                    storedMag.reset();
-                    // clear the data waiting flag so that we do not use any data pending from the previous sensor
-                    magDataToFuse = false;
-                    // request a reset of the magnetic field states
-                    magStateResetRequest = true;
-                    // declare the field unlearned so that the reset request will be obeyed
-                    magFieldLearned = false;
-                    break;
-                }
-            }
+            // this compass has timed out (innovations too large for magFailTimeLimit_ms), try a new compass
+            tryChangeCompass();
         }
 
         // detect changes to magnetometer offset parameters and reset states
@@ -334,6 +353,9 @@ void NavEKF3_core::readMagData()
         // store time of last measurement update
         lastMagUpdate_us = compass.last_update_usec(magSelectIndex);
 
+        // Magnetometer data at the current time horizon
+        mag_elements magDataNew;
+
         // estimate of time magnetometer measurement was taken, allowing for delays
         magDataNew.time_ms = imuSampleTime_ms - frontend->magDelay_ms;
 
@@ -348,6 +370,9 @@ void NavEKF3_core::readMagData()
 
         // save magnetometer measurement to buffer to be fused later
         storedMag.push(magDataNew);
+
+        // remember time we read compass, to detect compass sensor failure
+        lastMagRead_ms = imuSampleTime_ms;
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -772,6 +772,9 @@ private:
     // check for new magnetometer data and update store measurements if available
     void readMagData();
 
+    // try changing compasses on compass failure or timeout
+    void tryChangeCompass(void);
+
     // check for new airspeed data and update stored measurements if available
     void readAirSpdData();
 
@@ -1047,6 +1050,7 @@ private:
     uint32_t prevTasStep_ms;        // time stamp of last TAS fusion step
     uint32_t prevBetaStep_ms;       // time stamp of last synthetic sideslip fusion step
     uint32_t lastMagUpdate_us;      // last time compass was updated in usec
+    uint32_t lastMagRead_ms;        // last time compass data was successfully read
     Vector3f velDotNED;             // rate of change of velocity in NED frame
     Vector3f velDotNEDfilt;         // low pass filtered velDotNED
     uint32_t imuSampleTime_ms;      // time that the last IMU value was taken
@@ -1108,7 +1112,6 @@ private:
     tas_elements tasDataNew;        // TAS data at the current time horizon
     tas_elements tasDataDelayed;    // TAS data at the fusion time horizon
     uint8_t tasStoreIndex;          // TAS data storage index
-    mag_elements magDataNew;        // Magnetometer data at the current time horizon
     mag_elements magDataDelayed;    // Magnetometer data at the fusion time horizon
     uint8_t magStoreIndex;          // Magnetometer data storage index
     gps_elements gpsDataNew;        // GPS data at the current time horizon

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -303,7 +303,7 @@ const AP_Param::GroupInfo SITL::var_mag[] = {
     AP_GROUPINFO("MAG_DIA",        7, SITL,  mag_diag[0], 0),
     AP_GROUPINFO("MAG_ODI",        8, SITL,  mag_offdiag[0], 0),
     AP_GROUPINFO("MAG_ORIENT",     9, SITL,  mag_orient[0], 0),
-    AP_GROUPINFO("MAG_SCALING",   10, SITL,  mag_scaling, 1),
+    AP_GROUPINFO("MAG1_SCALING",  10, SITL,  mag_scaling[0], 1),
     AP_GROUPINFO("MAG1_DEVID",    11, SITL,  mag_devid[0], 97539),
     AP_GROUPINFO("MAG2_DEVID",    12, SITL,  mag_devid[1], 131874),
     AP_GROUPINFO("MAG3_DEVID",    13, SITL,  mag_devid[2], 263178),
@@ -311,17 +311,22 @@ const AP_Param::GroupInfo SITL::var_mag[] = {
     AP_GROUPINFO("MAG5_DEVID",    15, SITL,  mag_devid[4], 97795),
     AP_GROUPINFO("MAG6_DEVID",    16, SITL,  mag_devid[5], 98051),
     AP_GROUPINFO("MAG7_DEVID",    17, SITL,  mag_devid[6], 0),
-    AP_GROUPINFO("MAG8_DEVID",    18, SITL, mag_devid[7], 0),
+    AP_GROUPINFO("MAG8_DEVID",    18, SITL,  mag_devid[7], 0),
+    AP_GROUPINFO("MAG1_FAIL",     26, SITL,  mag_fail[0], 0),
 #if HAL_COMPASS_MAX_SENSORS > 1
     AP_GROUPINFO("MAG2_OFS",      19, SITL,  mag_ofs[1], 0),
     AP_GROUPINFO("MAG2_DIA",      20, SITL,  mag_diag[1], 0),
     AP_GROUPINFO("MAG2_ODI",      21, SITL,  mag_offdiag[1], 0),
     AP_GROUPINFO("MAG2_ORIENT",   22, SITL,  mag_orient[1], 0),
+    AP_GROUPINFO("MAG2_FAIL",     27, SITL,  mag_fail[1], 0),
+    AP_GROUPINFO("MAG2_SCALING",  28, SITL,  mag_scaling[1], 1),
 #endif
 #if HAL_COMPASS_MAX_SENSORS > 2
     AP_GROUPINFO("MAG3_OFS",      23, SITL,  mag_ofs[2], 0),
     AP_GROUPINFO("MAG3_DIA",      24, SITL,  mag_diag[2], 0),
     AP_GROUPINFO("MAG3_ODI",      25, SITL,  mag_offdiag[2], 0),
+    AP_GROUPINFO("MAG3_FAIL",     29, SITL,  mag_fail[2], 0),
+    AP_GROUPINFO("MAG3_SCALING",  30, SITL,  mag_scaling[2], 1),
     AP_GROUPINFO("MAG3_ORIENT",   36, SITL,  mag_orient[2], 0),
 #endif
     AP_GROUPEND

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -165,6 +165,7 @@ public:
     AP_Vector3f mag_diag[HAL_COMPASS_MAX_SENSORS];  // diagonal corrections
     AP_Vector3f mag_offdiag[HAL_COMPASS_MAX_SENSORS];  // off-diagonal corrections
     AP_Int8 mag_orient[HAL_COMPASS_MAX_SENSORS];   // external compass orientation
+    AP_Int8 mag_fail[HAL_COMPASS_MAX_SENSORS];   // fail magnetometer, 1 for no data, 2 for freeze
     AP_Float servo_speed; // servo speed in seconds
 
     AP_Float sonar_glitch;// probablility between 0-1 that any given sonar sample will read as max distance
@@ -210,7 +211,7 @@ public:
     AP_Int8  baro_count; // number of simulated baros to create
     AP_Int8  imu_count; // number of simulated IMUs to create
     AP_Int32 loop_delay; // extra delay to add to every loop
-    AP_Float mag_scaling; // scaling factor on first compasses
+    AP_Float mag_scaling[MAX_CONNECTED_MAGS]; // scaling factor
     AP_Int32 mag_devid[MAX_CONNECTED_MAGS]; // Mag devid
     AP_Float buoyancy; // submarine buoyancy in Newtons
     AP_Int16 loop_rate_hz;


### PR DESCRIPTION
This fixes handling of sensor failure for EK2/EK3. If the primary compass failed we did not switch to a backup compass for either EKF2 or EKF3.
There were several bugs:
 - use_compass() didn't check if compass was healthy before fetching data
 - we were using the wrong compass timestamp when checking for new data (not passing magSelectIndex)
 - we stopped logging all compasses when first compass was unhealthy

This also adds a test suite for compass failure handling. Tested only in SITL

