### PR TITLE
Plane: use throttle in for transition max comparison

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1760,7 +1760,7 @@ void QuadPlane::update_transition(void)
                                                                       plane.nav_pitch_cd,
                                                                       0);
         // set throttle at either hover throttle or current throttle, whichever is higher, through the transition
-        attitude_control->set_throttle_out(MAX(motors->get_throttle_hover(),motors->get_throttle()), true, 0);
+        attitude_control->set_throttle_out(MAX(motors->get_throttle_hover(),attitude_control->get_throttle_in()), true, 0);
         break;
     }
 


### PR DESCRIPTION
This fixes a bug inadvertently introduced in https://github.com/ArduPilot/ardupilot/pull/14102. When angle boost is enabled you end up with full throttle for the transition. This is because the code is setting the throttle to the motors throttle after boost is applied. You get a 1/cos(pitch) multiplier on throttle each loop, this quickly saturates to 1.

![THR_boost_issue](https://user-images.githubusercontent.com/33176108/91599286-f3383980-e95d-11ea-8e8b-bb424109cc3c.png)

This fix used the input throttle pre-boost. This results in the intended behavior.

![THR_boost_fix](https://user-images.githubusercontent.com/33176108/91599351-11059e80-e95e-11ea-80b7-5b2118f72b10.png)

![THR_boost_fix2](https://user-images.githubusercontent.com/33176108/91599363-14992580-e95e-11ea-9726-1f01473379d5.png)

Tested using realflight with striker copter tailsitter.