### PR TITLE
Copter: Dividing battery and compass acquisition into tasks

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -95,7 +95,8 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if OPTFLOW == ENABLED
     SCHED_TASK_CLASS(OpticalFlow,          &copter.optflow,             update,         200, 160),
 #endif
-    SCHED_TASK(update_batt_compass,   10,    120),
+    SCHED_TASK(update_battery,        10,    120),
+    SCHED_TASK(update_compass,        10,    120),
     SCHED_TASK_CLASS(RC_Channels,          (RC_Channels*)&copter.g2.rc_channels,      read_aux_all,    10,     50),
     SCHED_TASK(arm_motors_check,      10,     50),
 #if TOY_MODE_ENABLED == ENABLED
@@ -360,17 +361,25 @@ void Copter::throttle_loop()
     update_ekf_terrain_height_stable();
 }
 
-// update_batt_compass - read battery and compass
+// update_battery - read battery
 // should be called at 10hz
-void Copter::update_batt_compass(void)
+void Copter::update_battery(void)
 {
     // read battery before compass because it may be used for motor interference compensation
     battery.read();
 
     if(AP::compass().enabled()) {
+        compass.set_voltage(battery.voltage());
+    }
+}
+
+// update_compass - read compass
+// should be called at 10hz
+void Copter::update_compass(void)
+{
+    if(AP::compass().enabled()) {
         // update compass with throttle value - used for compassmot
         compass.set_throttle(motors->get_throttle());
-        compass.set_voltage(battery.voltage());
         compass.read();
     }
 }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -646,7 +646,8 @@ private:
     bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) override;
     void rc_loop();
     void throttle_loop();
-    void update_batt_compass(void);
+    void update_battery(void);
+    void update_compass(void);
     void fourhundred_hz_logging();
     void ten_hz_logging_loop();
     void twentyfive_hz_logging();


### PR DESCRIPTION
Performance cannot be measured by making battery data acquisition and compass data acquisition a single task.
Especially in the case of smart batteries, data is acquired from the I2C bus, which is slower than the acquisition of analog voltage and current.
Therefore, I want to make it easier to measure performance by separating the tasks.