### PR TITLE
Plane: don't relax pitch attitude controller for vectored tailsitters

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -910,10 +910,7 @@ void QuadPlane::hold_stabilize(float throttle_in)
     if ((throttle_in <= 0) && (air_mode == AirMode::OFF)) {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0, true, 0);
-        if (!is_tailsitter()) {
-            // always stabilize with tailsitters so we can do belly takeoffs
-            attitude_control->relax_attitude_controllers();
-        }
+        relax_attitude_control();
     } else {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
         bool should_boost = true;
@@ -1113,8 +1110,10 @@ void QuadPlane::control_qacro(void)
 
 void QuadPlane::relax_attitude_control()
 {
+    // disable some or all axis controllers to prevent windup
     if (is_vectored_tailsitter()) {
-        // disable roll and yaw control for vectored tailsitters
+        // always stabilize pitch for vectored tailsitters so we can do belly takeoffs
+        // but disable roll and yaw control
         attitude_control->relax_roll_and_yaw_controllers();
     } else {
         // if not a vectored tailsitter completely disable attitude control

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -984,7 +984,7 @@ void QuadPlane::check_attitude_relax(void)
 {
     uint32_t now = AP_HAL::millis();
     if (now - last_att_control_ms > 100) {
-        attitude_control->relax_attitude_controllers();
+        relax_attitude_control();
     }
     last_att_control_ms = now;
 }
@@ -1078,7 +1078,7 @@ void QuadPlane::control_qacro(void)
     if (throttle_wait) {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0, true, 0);
-        attitude_control->relax_attitude_controllers();
+        relax_attitude_control();
     } else {
         check_attitude_relax();
 
@@ -1111,6 +1111,17 @@ void QuadPlane::control_qacro(void)
     }
 }
 
+void QuadPlane::relax_attitude_control()
+{
+    if (is_vectored_tailsitter()) {
+        // disable roll and yaw control for vectored tailsitters
+        attitude_control->relax_roll_and_yaw_controllers();
+    } else {
+        // if not a vectored tailsitter completely disable attitude control
+        attitude_control->relax_attitude_controllers();
+    }
+}
+
 /*
   control QHOVER mode
  */
@@ -1119,7 +1130,7 @@ void QuadPlane::control_hover(void)
     if (throttle_wait) {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0, true, 0);
-        attitude_control->relax_attitude_controllers();
+        relax_attitude_control();
         pos_control->relax_alt_hold_controllers(0);
     } else {
         hold_hover(get_pilot_desired_climb_rate_cms());
@@ -1253,7 +1264,7 @@ void QuadPlane::control_loiter()
     if (throttle_wait) {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0, true, 0);
-        attitude_control->relax_attitude_controllers();
+        relax_attitude_control();
         pos_control->relax_alt_hold_controllers(0);
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
@@ -1467,7 +1478,7 @@ float QuadPlane::desired_auto_yaw_rate_cds(void) const
  */
 bool QuadPlane::assistance_needed(float aspeed, bool have_airspeed)
 {
-    if (assist_speed <= 0 || is_contol_surface_tailsitter()) {
+    if (assist_speed <= 0 || is_control_surface_tailsitter()) {
         // assistance disabled
         in_angle_assist = false;
         angle_error_start_ms = 0;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -115,8 +115,11 @@ public:
     // return true when tailsitter frame configured
     bool is_tailsitter(void) const;
 
-    // return true when flying a control surface only tailsitter tailsitter
-    bool is_contol_surface_tailsitter(void) const;
+    // return true when flying a control surface only tailsitter
+    bool is_control_surface_tailsitter(void) const;
+
+    // return true when flying a tilt-vectored tailsitter
+    bool is_vectored_tailsitter(void) const;
 
     // return true when flying a tailsitter in VTOL
     bool tailsitter_active(void);
@@ -243,6 +246,8 @@ private:
     void control_qacro(void);
     void init_hover(void);
     void control_hover(void);
+    void relax_attitude_control();
+
 
     void init_loiter(void);
     void init_qland(void);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -32,12 +32,21 @@ bool QuadPlane::is_tailsitter(void) const
 }
 
 /*
-  return true when flying a control surface only tailsitter tailsitter
+  return true when flying a control surface only tailsitter
  */
-bool QuadPlane::is_contol_surface_tailsitter(void) const
+bool QuadPlane::is_control_surface_tailsitter(void) const
 {
     return frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER
            && ( is_zero(tailsitter.vectored_hover_gain) || !SRV_Channels::function_assigned(SRV_Channel::k_tiltMotorLeft));
+}
+
+/*
+  return true when flying a tilt-vectored tailsitter
+ */
+bool QuadPlane::is_vectored_tailsitter(void) const
+{
+    return frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER
+           && ( !is_zero(tailsitter.vectored_hover_gain) && SRV_Channels::function_assigned(SRV_Channel::k_tiltMotorLeft));
 }
 
 /*

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -172,6 +172,37 @@ void AC_AttitudeControl::relax_attitude_controllers()
     reset_rate_controller_I_terms();
 }
 
+// For tilt-vectored tailsitters only: relax roll and yaw rate controller outputs
+// leaving pitch controller active to let motors tilt up while in throttle_wait
+void AC_AttitudeControl::relax_roll_and_yaw_controllers()
+{
+    // Get the current attitude quaternion
+    Quaternion current_attitude;
+    _ahrs.get_quat_body_to_ned(current_attitude);
+
+    Vector3f current_eulers;
+    current_attitude.to_euler(current_eulers.x, current_eulers.y, current_eulers.z);
+
+    // set target attitude to zero pitch with (approximate) current roll and yaw
+    // by rotating the current_attitude quaternion by the error in desired pitch
+    Quaternion pitch_rotation;
+    pitch_rotation.from_axis_angle(Vector3f(0, -1, 0), current_eulers.y);
+    _attitude_target_quat = current_attitude * pitch_rotation;
+    _attitude_target_quat.normalize();
+    _attitude_target_quat.to_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
+    _attitude_ang_error = current_attitude.inverse() * _attitude_target_quat;
+
+    // Initialize the roll and yaw angular rate variables to the current rate
+    _attitude_target_ang_vel = _ahrs.get_gyro();
+    ang_vel_to_euler_rate(_attitude_target_euler_angle, _attitude_target_ang_vel, _attitude_target_euler_rate);
+    _rate_target_ang_vel.x = _ahrs.get_gyro().x;
+    _rate_target_ang_vel.z = _ahrs.get_gyro().z;
+
+    // Reset the roll and yaw I terms
+    get_rate_roll_pid().reset_I();
+    get_rate_yaw_pid().reset_I();
+}
+
 void AC_AttitudeControl::reset_rate_controller_I_terms()
 {
     get_rate_roll_pid().reset_I();
@@ -360,7 +391,7 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool pla
     // Compute attitude error
     Quaternion attitude_vehicle_quat;
     Quaternion error_quat;
-    attitude_vehicle_quat.from_rotation_matrix(_ahrs.get_rotation_body_to_ned());
+    _ahrs.get_quat_body_to_ned(attitude_vehicle_quat);
     error_quat = attitude_vehicle_quat.inverse() * _attitude_target_quat;
     Vector3f att_error;
     error_quat.to_axis_angle(att_error);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -111,6 +111,9 @@ public:
     // Ensure attitude controller have zero errors to relax rate controller output
     void relax_attitude_controllers();
 
+    // Relax only the roll and yaw rate controllers
+    void relax_roll_and_yaw_controllers();
+
     // reset rate controller I terms
     void reset_rate_controller_I_terms();
 


### PR DESCRIPTION
This is a fix for the problem referenced in https://github.com/ArduPilot/ardupilot_wiki/pull/2990

It allows the motors to tilt up in all vtol modes (not just qstabilize) prior to raising the throttle, and prevents prop strikes on arming.