### PR TITLE
autotest: make LogUpload the last test again

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2105,12 +2105,12 @@ class AutoTestPlane(AutoTest):
              "Test deadreckoning support",
              self.deadreckoning),
 
-            ("LogUpload",
-             "Log upload",
-             self.log_upload),
-
             ("EKFlaneswitch",
              "Test EKF3 Affinity and Lane Switching",
              self.ekf_lane_switch),
+
+            ("LogUpload",
+             "Log upload",
+             self.log_upload),
         ])
         return ret


### PR DESCRIPTION
ATM any logs produced by EKFLaneswitch won't get uploaded in case of
failure