### PR TITLE
Create and use new AP_HAL::PWMSource

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.h
@@ -22,14 +22,6 @@ public:
     void init(void) override {}
 
 private:
-    void irq_handler(uint8_t pin, bool pin_state, uint32_t timestamp);
 
-    struct IrqState {
-        uint32_t last_pulse_us;
-        uint32_t pulse_width_us;
-        uint32_t pulse_count1;
-    } irq_state;
-
-    int8_t last_pin = -1;
-    uint32_t pulse_count2;
+    AP_HAL::PWMSource pwm_source;
 };

--- a/libraries/AP_HAL/AP_HAL_Namespace.h
+++ b/libraries/AP_HAL/AP_HAL_Namespace.h
@@ -22,6 +22,7 @@ namespace AP_HAL {
     class AnalogIn;
     class Storage;
     class DigitalSource;
+    class PWMSource;
     class GPIO;
     class RCInput;
     class RCOutput;

--- a/libraries/AP_HAL/GPIO.cpp
+++ b/libraries/AP_HAL/GPIO.cpp
@@ -1,0 +1,108 @@
+#include "GPIO.h"
+
+#include <AP_HAL/AP_HAL.h>
+#if defined(HAL_NO_GCS) || defined(HAL_BOOTLOADER_BUILD)
+#define GCS_SEND_TEXT(severity, format, args...)
+#else
+#include <GCS_MAVLink/GCS.h>
+#endif
+
+extern const AP_HAL::HAL& hal;
+
+bool AP_HAL::PWMSource::set_pin(int16_t new_pin, const char *subsystem)
+{
+    if (new_pin == _pin) {
+        // we've already tried to attach to this pin
+        return interrupt_attached;
+    }
+
+    if (interrupt_attached) {
+        if (!hal.gpio->detach_interrupt(_pin)) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                          "%s: Failed to detach interrupt from %d",
+                          subsystem,
+                          _pin);
+        }
+        interrupt_attached = false;
+    }
+
+    // don't want to try to attach more than once:
+    _pin = new_pin;
+
+    if (_pin <= 0) {
+        // invalid pin
+        return false;
+    }
+
+    // install interrupt handler on rising and falling edge
+    hal.gpio->pinMode(_pin, HAL_GPIO_INPUT);
+    if (!hal.gpio->attach_interrupt(
+            _pin,
+            FUNCTOR_BIND_MEMBER(&AP_HAL::PWMSource::irq_handler,
+                                void,
+                                uint8_t,
+                                bool,
+                                uint32_t),
+            AP_HAL::GPIO::INTERRUPT_BOTH)) {
+        // failed to attach interrupt
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                      "%s: Failed to attach interrupt to %d",
+                      subsystem,
+                      _pin);
+        return false;
+    }
+
+    interrupt_attached = true;
+
+    return interrupt_attached;
+}
+
+// interrupt handler for reading pwm value
+void AP_HAL::PWMSource::irq_handler(uint8_t a_pin, bool pin_high, uint32_t timestamp_us)
+{
+    if (pin_high) {
+        _pulse_start_us = timestamp_us;
+        return;
+    }
+    if (_pulse_start_us == 0) {
+        // if we miss interrupts we could get two lows in a row.  If
+        // we miss interrupts we're definitely handing back bad
+        // values anyway....
+        return;
+    }
+    _irq_value_us = timestamp_us - _pulse_start_us;
+    _pulse_start_us = 0;
+
+    // update fields for taking an average reading:
+    _irq_value_us_sum += _irq_value_us;
+    _irq_value_us_count++;
+}
+
+
+uint16_t AP_HAL::PWMSource::get_pwm_us()
+{
+    // disable interrupts and grab state
+    void *irqstate = hal.scheduler->disable_interrupts_save();
+    const uint32_t ret = _irq_value_us;
+    _irq_value_us = 0;
+    hal.scheduler->restore_interrupts(irqstate);
+
+    return ret;
+}
+
+uint16_t AP_HAL::PWMSource::get_pwm_avg_us()
+{
+    // disable interrupts and grab state
+    void *irqstate = hal.scheduler->disable_interrupts_save();
+    uint32_t ret;
+    if (_irq_value_us_count == 0) {
+        ret = 0;
+    } else {
+        ret = _irq_value_us_sum / _irq_value_us_count;
+    }
+    _irq_value_us_sum = 0;
+    _irq_value_us_count = 0;
+    hal.scheduler->restore_interrupts(irqstate);
+
+    return ret;
+}

--- a/libraries/AP_HAL/GPIO.h
+++ b/libraries/AP_HAL/GPIO.h
@@ -16,6 +16,31 @@ public:
     virtual void    toggle() = 0;
 };
 
+class AP_HAL::PWMSource {
+public:
+
+    bool set_pin(int16_t new_pin, const char *subsystem);
+    int16_t pin() const { return _pin; }  // returns pin this is attached to
+
+    uint16_t get_pwm_us();            // return last measured PWM input
+    uint16_t get_pwm_avg_us();        // return average PWM since last call to get_pwm_avg_us
+
+private:
+    uint16_t _irq_value_us;         // last calculated pwm value (irq copy)
+    uint32_t _pulse_start_us;       // system time of start of pulse
+    int16_t _pin = -1;
+
+    uint32_t _irq_value_us_sum;     // for get_pwm_avg_us
+    uint32_t _irq_value_us_count;   // for get_pwm_avg_us
+
+    bool interrupt_attached;
+
+    // PWM input handling
+    void irq_handler(uint8_t pin,
+                     bool pin_state,
+                     uint32_t timestamp);
+};
+
 class AP_HAL::GPIO {
 public:
     GPIO() {}

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -77,19 +77,15 @@ private:
 
     // PWM input
     struct PWMState {
-        int8_t last_rssi_analog_pin; // last pin used for reading pwm (used to recognise change in pin assignment)
+        int8_t last_warn_pin; // last pin used for reading pwm (used to recognise change failure in pin assignment)
         uint32_t last_reading_ms;      // system time of last read (used for health reporting)
         float rssi_value;              // last calculated RSSI value
         // the following two members are updated by the interrupt handler
-        uint32_t irq_value_us;         // last calculated pwm value (irq copy)
-        uint32_t pulse_start_us;       // system time of start of pulse
+        AP_HAL::PWMSource pwm_source;
     } pwm_state;
 
     // read the RSSI value from an analog pin - returns float in range 0.0 to 1.0
     float read_pin_rssi();
-
-    // check if pin has changed and configure interrupt handlers if required
-    void check_pwm_pin_rssi();
 
     // read the RSSI value from a PWM value on a RC channel
     float read_channel_rssi();
@@ -102,11 +98,6 @@ private:
 
     // Scale and constrain a float rssi value to 0.0 to 1.0 range
     float scale_and_constrain_float_rssi(float current_rssi_value, float low_rssi_range, float high_rssi_range);
-
-    // PWM input handling
-    void irq_handler(uint8_t pin,
-                     bool pin_state,
-                     uint32_t timestamp);
 };
 
 namespace AP {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.h
@@ -24,20 +24,17 @@ protected:
 
 private:
 
-    void check_pins();
-    void check_echo_pin();
+    bool check_pins();
+    bool check_echo_pin();
     void check_trigger_pin();
-    void irq_handler(uint8_t pin, bool pin_high, uint32_t timestamp_us);
 
-    int8_t echo_pin;
     int8_t trigger_pin;
     uint32_t last_reading_ms;      // system time of last read (used for health reporting)
     uint32_t last_distance_cm;     // last distance reported (used to prevent glitches in measurement)
     uint8_t glitch_count;           // glitch counter
 
-    // follow are modified by the IRQ handler:
-    uint32_t pulse_start_us;      // system time of start of timing pulse
-    uint32_t irq_value_us;         // last calculated pwm value (irq copy)
+    int8_t last_warn_echo_pin;
+    AP_HAL::PWMSource pwm_source;
 
     uint32_t last_ping_ms;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
@@ -44,19 +44,14 @@ protected:
 
 private:
 
-    int8_t last_pin; // last pin used for reading pwm (used to recognise change in pin assignment)
+    int8_t last_warn_pin; // last pin used for reading pwm (used to recognise change in pin assignment)
 
-    // the following three members are updated by the interrupt handler
-    uint32_t irq_value_us;         // some of calculated pwm values (irq copy)
-    uint16_t irq_sample_count;     // number of pwm values in irq_value_us (irq copy)
-    uint32_t irq_pulse_start_us;   // system time of start of pulse
-
-    void irq_handler(uint8_t pin, bool pin_high, uint32_t timestamp_us);
-
-    void check_pin();
+    bool check_pin();
     void check_stop_pin();
-    void check_pins();
+    bool check_pins();
     uint8_t last_stop_pin = -1;
+
+    AP_HAL::PWMSource pwm_source;
 
     float &estimated_terrain_height;
 


### PR DESCRIPTION
This factors out some common code from several classes into the HAL.

A third candidate, `AP_RPM_Pin` is not shifted as it does some filtering on the input pin which may actually be a good idea to have generally - but wasn't in the other drivers.  Similarly for the FuelFlow driver (but not the FuelLevel driver!)

This work was done because I was looking at adding *another* very similar implementation and thought we should do better.
