### PR TITLE
Plane: Add airbrake function for autoland

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -177,6 +177,7 @@ private:
     RC_Channel *channel_pitch;
     RC_Channel *channel_throttle;
     RC_Channel *channel_rudder;
+    RC_Channel *channel_airbrake;
 
     AP_Logger logger;
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1034,6 +1034,7 @@ private:
     void set_servos_flaps(void);
     void set_landing_gear(void);
     void dspoiler_update(void);
+    void airbrake_update(void);
     void servo_output_mixers(void);
     void servos_output(void);
     void servos_auto_trim(void);

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -40,6 +40,9 @@ void Plane::set_control_channels(void)
         SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 100);
     }
 
+    // update airbrake channel assignment
+    channel_airbrake = rc().find_channel_for_option(RC_Channel::AUX_FUNC::AIRBRAKE);
+
     // update manual forward throttle channel assignment
     quadplane.rc_fwd_thr_ch = rc().find_channel_for_option(RC_Channel::AUX_FUNC::FWD_THR);
 

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -296,11 +296,9 @@ void Plane::airbrake_update(void)
 {
     // Calculate any manual airbrake input from RC channel option.
     int8_t manual_airbrake_percent = 0;
-    
-    RC_Channel *airbrake_in_ch = rc().find_channel_for_option(RC_Channel::AUX_FUNC::AIRBRAKE);
-    
-    if (airbrake_in_ch != nullptr && !failsafe.rc_failsafe && failsafe.throttle_counter == 0) {
-        manual_airbrake_percent = airbrake_in_ch->percent_input();
+
+    if (channel_airbrake != nullptr && !failsafe.rc_failsafe && failsafe.throttle_counter == 0) {
+        manual_airbrake_percent = channel_airbrake->percent_input();
     }
 
     // Calculate auto airbrake from negative throttle.

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -202,6 +202,7 @@ public:
         MAINSAIL =           207, // mainsail input
         FLAP =               208, // flap input
         FWD_THR =            209, // VTOL manual forward throttle
+        AIRBRAKE =           210, // manual airbrake control
 
         // inputs for the use of onboard lua scripting
         SCRIPTING_1 =        300,

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -143,6 +143,7 @@ public:
         k_scripting14           = 107,
         k_scripting15           = 108,
         k_scripting16           = 109,
+        k_airbrake              = 110,
         k_LED_neopixel1         = 120,
         k_LED_neopixel2         = 121,
         k_LED_neopixel3         = 122,

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -148,6 +148,7 @@ void SRV_Channel::aux_servo_function_setup(void)
     case k_throttle:
     case k_throttleLeft:
     case k_throttleRight:
+    case k_airbrake:
         // fixed wing throttle
         set_range(100);
         break;


### PR DESCRIPTION
This adds an airbrake servo output function that is driven by the negative throttle values. This allows accurate autolanding of planes (by allowing shedding of energy in a similar manner to reverse thrust), but especially gliders, using DIY or commercial airbrake actuators such as [these](http://www.icare-icarus.com/Schambeck-Two-stage-precision-airbrakes-3-6-meter_p_1456.html). An RC channel option is also provided as a manual alternative or override.

This has been extensively tested on board the K1000ULE and other gliders. It has been changed a little to use RCX_OPTION rather than a separate parameter for input channel so I will test it again in the next few days.
