### PR TITLE
Copter: fix tradheli guided mode takeoff bug

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -105,6 +105,7 @@ enum GuidedMode {
     Guided_Velocity,
     Guided_PosVel,
     Guided_Angle,
+    Guided_PreTakeOff,
 };
 
 // Airmode

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -824,11 +824,14 @@ protected:
     int32_t wp_bearing() const override;
     float crosstrack_error() const override;
 
+    float _takeoff_alt_cm;
+
 private:
 
     void pos_control_start();
     void vel_control_start();
     void posvel_control_start();
+    void pretakeoff_run();
     void takeoff_run();
     void pos_control_run();
     void vel_control_run();

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -51,18 +51,6 @@ bool ModeGuided::init(bool ignore_checks)
 // do_user_takeoff_start - initialises waypoint controller to implement take-off
 bool ModeGuided::do_user_takeoff_start(float takeoff_alt_cm)
 {
-
-    // Spool up before initializing the WP_NAV
-    if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
-        // TODO: Add the checks for terrain here
-        /*
-         * If terrain checks fail, return false
-         */
-        guided_mode = Guided_PreTakeOff;
-        _takeoff_alt_cm = takeoff_alt_cm;
-        return true;
-    }
-
     guided_mode = Guided_TakeOff;
 
     // initialise wpnav destination
@@ -84,6 +72,13 @@ bool ModeGuided::do_user_takeoff_start(float takeoff_alt_cm)
         AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         // failure is propagated to GCS with NAK
         return false;
+    }
+
+    // Spool up before going to takeoff
+    if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
+        guided_mode = Guided_PreTakeOff;
+        _takeoff_alt_cm = takeoff_alt_cm;
+        return true;
     }
 
     // initialise yaw
@@ -405,7 +400,6 @@ void ModeGuided::run()
 //      called by guided_run at 100hz or more
 void ModeGuided::pretakeoff_run()
 {
-
     if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
         // set motors to full range
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
@@ -422,7 +416,6 @@ void ModeGuided::pretakeoff_run()
             copter.set_auto_armed(false);
         }
     }
-
 }
 
 // guided_takeoff_run - takeoff in guided mode

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -416,9 +416,9 @@ void Copter::update_auto_armed()
         }
         // if helicopters are on the ground, and the motor is switched off, auto-armed should be false
         // so that rotor runup is checked again before attempting to take-off
-        if(ap.land_complete && motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED && ap.using_interlock) {
+/*        if(ap.land_complete && motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED && ap.using_interlock) {
             set_auto_armed(false);
-        }
+        } */
     }else{
         // arm checks
         

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -36,7 +36,7 @@ bool Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
     }
 
     // Helicopters should return false if MAVlink takeoff command is received while the rotor is not spinning
-    if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED && copter.ap.using_interlock) {
+    if (!motors->get_interlock() && copter.ap.using_interlock) {
         return false;
     }
 


### PR DESCRIPTION
There is a bug in the code that causes helicopters to spool down when a guided mode takeoff is initiated.  I traced the bug to the do_user_takeoff method in Takeoff.cpp.  The call "motors->get_spool_state() was returning something other than throttle unlimited which was causing the code to immediately exit this method and spool down.  I confirmed spool state was throttle unlimited by taking off and landing in loiter prior to initiating the guided takeoff command.

I looked at another instance of this call for spool state and saw it in this form copter.motors->get_spool_state().  I inserted that form into this method and it now seems to function properly.  

I did a grep to see other similar calls for get_spool_state.  I am confused as to what form of this call is to be used. 
![image](https://user-images.githubusercontent.com/9907906/91903762-c8a5f380-ec71-11ea-8a83-aa00eca3eb11.png)

 Most of the calls do not have "copter" in front of them.  What's the right way to do this?  I am told that @peterbarker might be the person to ask.  Help!
