### PR TITLE
AC_AttitudeControl_Multi: hover throttle for max lean angle

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -225,7 +225,7 @@ AC_AttitudeControl_Multi::AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_
 }
 
 // Update Alt_Hold angle maximum
-void AC_AttitudeControl_Multi::update_althold_lean_angle_max(float throttle_in)
+void AC_AttitudeControl_Multi::update_althold_lean_angle_max(float hover_throttle)
 {
     // calc maximum tilt angle based on throttle
     float thr_max = _motors_multi.get_throttle_thrust_max();
@@ -236,14 +236,14 @@ void AC_AttitudeControl_Multi::update_althold_lean_angle_max(float throttle_in)
         return;
     }
 
-    float althold_lean_angle_max = acosf(constrain_float(throttle_in / (AC_ATTITUDE_CONTROL_ANGLE_LIMIT_THROTTLE_MAX * thr_max), 0.0f, 1.0f));
+    float althold_lean_angle_max = acosf(constrain_float(hover_throttle / (AC_ATTITUDE_CONTROL_ANGLE_LIMIT_THROTTLE_MAX * thr_max), 0.0f, 1.0f));
     _althold_lean_angle_max = _althold_lean_angle_max + (_dt / (_dt + _angle_limit_tc)) * (althold_lean_angle_max - _althold_lean_angle_max);
 }
 
 void AC_AttitudeControl_Multi::set_throttle_out(float throttle_in, bool apply_angle_boost, float filter_cutoff)
 {
     _throttle_in = throttle_in;
-    update_althold_lean_angle_max(throttle_in);
+    update_althold_lean_angle_max(_motors_multi.get_throttle_hover());
     _motors.set_throttle_filter_cutoff(filter_cutoff);
     if (apply_angle_boost) {
         // Apply angle boost

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -52,7 +52,7 @@ public:
     AC_PID& get_rate_yaw_pid() override { return _pid_rate_yaw; }
 
     // Update Alt_Hold angle maximum
-    void update_althold_lean_angle_max(float throttle_in) override;
+    void update_althold_lean_angle_max(float hover_throttle) override;
 
     // Set output throttle
     void set_throttle_out(float throttle_in, bool apply_angle_boost, float filt_cutoff) override;


### PR DESCRIPTION
This changes the maximum lean angle to be based on hover throttle rather than current throttle. 

Not sure the reasoning for it to use current throttle. In altitude hold, for example, the throttle is proportional to lean angle. This would cause the max lean angle to change as you lean over. You could be leaned over at 45 deg using 70% throttle and the equation would put angle max at 29 deg despite currently flying at 45.

This is the graph of the equation (assuming thr_max  = 1), using hover throttle would put us on a single point on the graph rather than moving with throttle.

![image](https://user-images.githubusercontent.com/33176108/91910087-497ee280-eca6-11ea-8a9b-cd8b4593f9e8.png)

Maybe there is something I have missed?

