### PR TITLE
Plane: Move flap channel assignment

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -177,6 +177,7 @@ private:
     RC_Channel *channel_pitch;
     RC_Channel *channel_throttle;
     RC_Channel *channel_rudder;
+    RC_Channel *channel_flap;
     RC_Channel *channel_airbrake;
 
     AP_Logger logger;

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -40,7 +40,8 @@ void Plane::set_control_channels(void)
         SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 100);
     }
 
-    // update airbrake channel assignment
+    // update flap and airbrake channel assignment
+    channel_flap     = rc().find_channel_for_option(RC_Channel::AUX_FUNC::FLAP);
     channel_airbrake = rc().find_channel_for_option(RC_Channel::AUX_FUNC::AIRBRAKE);
 
     // update manual forward throttle channel assignment

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -584,9 +584,8 @@ void Plane::set_servos_flaps(void)
     int8_t manual_flap_percent = 0;
 
     // work out any manual flap input
-    RC_Channel *flapin = rc().find_channel_for_option(RC_Channel::AUX_FUNC::FLAP);
-    if (flapin != nullptr && !failsafe.rc_failsafe && failsafe.throttle_counter == 0) {
-        manual_flap_percent = flapin->percent_input();
+    if (channel_flap != nullptr && !failsafe.rc_failsafe && failsafe.throttle_counter == 0) {
+        manual_flap_percent = channel_flap->percent_input();
     }
 
     if (auto_throttle_mode) {


### PR DESCRIPTION
As discussed in https://github.com/ArduPilot/ardupilot/pull/15206, moves expensive call to `rc().find_channel_for_option()` from `set_servos_flaps()` to `set_control_channels()`