### PR TITLE
Copter: correct mode change for GCS failsafe in SmartRTL

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1052,7 +1052,7 @@ public:
     // this should probably not be exposed
     bool state_complete() { return _state_complete; }
 
-    bool is_landing() const override;
+    virtual bool is_landing() const override;
 
     void restart_without_terrain();
 
@@ -1132,6 +1132,8 @@ public:
 
     void save_position();
     void exit();
+
+    bool is_landing() const override;
 
 protected:
 

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -59,6 +59,11 @@ void ModeSmartRTL::run()
     }
 }
 
+bool ModeSmartRTL::is_landing() const
+{
+    return smart_rtl_state == SmartRTL_Land;
+}
+
 void ModeSmartRTL::wait_cleanup_run()
 {
     // hover at current target position


### PR DESCRIPTION
```
    In the case that you:
     - have previously done a successful SmartRTL flight
     - get a mid-air gcs failsafe and enter SmartRTL
     - recover from that gcs failsafe but remain in SmartRTL
     - get another mid-air failsafe
    
    then without this patch you will enter LAND mode.
    
    When determining our failsafe action, we were looking at whether we
    should just continue landing.  To do that, we ask the current mode if we
    are landing.  Problem is that SmartRTL was handing back the wrong answer
    - it was handing back ModeRTL's answer rather than its own, and
    ModeRTL's answer was "yes, I'm landing", as that's the last state that
    step 1 in the above list leaves that mode in.
    
    This patch simply hands back the correct answer for, "am I landing"
```


Adds test for same.

Drive-by fix for annoying Cotper twiddle.
