### PR TITLE
AC_WPNav: fix OA_ERROR state overwrite terrain_alt

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -100,7 +100,7 @@ bool AC_WPNav_OA::update_wpnav()
                 Vector3f stopping_point;
                 get_wp_stopping_point(stopping_point);
                 _oa_destination = Location(stopping_point);
-                if (set_wp_destination(stopping_point, false)) {
+                if (set_wp_destination(stopping_point, _terrain_alt)) {
                     _oa_state = oa_retstate;
                 }
             }


### PR DESCRIPTION
OA_ERROR state overwrite the terrain alt state so it wouldn't exec terrain follow in current waypoint