### PR TITLE
update gbenchmark for recent linux

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -383,6 +383,14 @@ def ap_find_benchmarks(bld, use=[]):
         return
 
     includes = [bld.srcnode.abspath() + '/benchmarks/']
+    to_remove = '-Werror=suggest-override'
+    if to_remove in bld.env.CXXFLAGS:
+        need_remove = True
+    else:
+        need_remove = False
+    if need_remove:
+        while to_remove in bld.env.CXXFLAGS:
+            bld.env.CXXFLAGS.remove(to_remove)
 
     for f in bld.path.ant_glob(incl='*.cpp'):
         ap_program(

--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -47,6 +47,8 @@ def libbenchmark(bld):
         cmake_vars=dict(
             CMAKE_BUILD_TYPE='Release',
             CMAKE_INSTALL_PREFIX=prefix_node.abspath(),
+            BENCHMARK_ENABLE_GTEST_TESTS='OFF',
+            BENCHMARK_ENABLE_TESTING='OFF',
         ),
     )
 
@@ -54,9 +56,6 @@ def libbenchmark(bld):
     output_paths = (
         'lib/libbenchmark.a',
         'include/benchmark/benchmark.h',
-        'include/benchmark/macros.h',
-        'include/benchmark/benchmark_api.h',
-        'include/benchmark/reporter.h',
     )
     outputs = [prefix_node.make_node(path) for path in output_paths]
     gbenchmark.build('install', target=outputs)

--- a/libraries/AP_Math/benchmarks/benchmark_geodesic_grid.cpp
+++ b/libraries/AP_Math/benchmarks/benchmark_geodesic_grid.cpp
@@ -98,4 +98,4 @@ static void BM_GeodesicGridSections(benchmark::State& state)
 /* Benchmark each section */
 BENCHMARK(BM_GeodesicGridSections)->DenseRange(0, 79);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();

--- a/libraries/AP_Math/benchmarks/benchmark_matrix.cpp
+++ b/libraries/AP_Math/benchmarks/benchmark_matrix.cpp
@@ -19,4 +19,4 @@ static void BM_MatrixMultiplication(benchmark::State& state)
 
 BENCHMARK(BM_MatrixMultiplication);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();


### PR DESCRIPTION
This update Gbenchmark to the latest release : v1.5.1 
It solve an error on ubuntu 20.04 : 
```
/usr/include/x86_64-linux-gnu/sys/sysctl.h:21:2: error: #warning "The <sys/sysctl.h> header is deprecated and will be removed." [-Werror=cpp]
   21 | #warning "The <sys/sysctl.h> header is deprecated and will be removed."
```

Moreover, the building on benchmark target need to be adjusted as benchmark.h is only C++03 compatible and don't allow "override" word. 
Another solution would be to fork gbenchmark and patch it on our side. 