### PR TITLE
Tools tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /ardupilot
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN useradd -U -m ardupilot && \
     usermod -G users ardupilot
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-install-recommends -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     lsb-release \
     sudo \
     software-properties-common
@@ -35,7 +36,7 @@ RUN echo "if [ -d \"\$HOME/.local/bin\" ] ; then\nPATH=\"\$HOME/.local/bin:\$PAT
 ENV BUILDLOGS=/tmp/buildlogs
 
 # Cleanup
-RUN DEBIAN_FRONTEND=noninteractive sudo apt-get clean \
+RUN sudo apt-get clean \
     && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV CCACHE_MAXSIZE=1G

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -250,6 +250,7 @@ grep -Fxq "$exportline2" ~/$SHELL_LOGIN 2>/dev/null || {
     fi
 }
 
+if [[ $SKIP_AP_COMPLETION_ENV -ne 1 ]]; then
 exportline3="source $ARDUPILOT_ROOT/Tools/completion/completion.bash";
 grep -Fxq "$exportline3" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Add ArduPilot Bash Completion to your bash shell [N/y]?" ; then
@@ -259,7 +260,7 @@ grep -Fxq "$exportline3" ~/$SHELL_LOGIN 2>/dev/null || {
         echo "Skipping adding ArduPilot Bash Completion."
     fi
 }
-
+fi
 
 exportline4="export PATH=/usr/lib/ccache:\$PATH";
 grep -Fxq "$exportline4" ~/$SHELL_LOGIN 2>/dev/null || {


### PR DESCRIPTION
Docker : 
move DEBIAN_FRONTEND=noninteractive as ARG on build phase so it don't apply after. It also prevent issue with TZdata installation.

install-prereqs-ubuntu.sh:
Add variable to allow to skip completion installation

CI scripts:
use python -m pip instead of pip to allow those to be use with python3 directly. The issue is that on python3 system pip doesn't exist and only pip3 exist. Using python -m pip allow to call pip with the right python version !

