### PR TITLE
AP_Scripting: auto generate metatables entries for manual bindings

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -277,3 +277,11 @@ singleton AP_RPM method get_rpm boolean uint8_t 0 RPM_MAX_INSTANCES float'Null
 include AP_Button/AP_Button.h
 singleton AP_Button alias button
 singleton AP_Button method get_button_state boolean uint8_t 1 AP_BUTTON_NUM_PINS
+
+include AP_Logger/AP_Logger.h
+singleton AP_Logger alias logger
+singleton AP_Logger manual write AP_Logger_Write
+singleton AP_Logger method logging_present boolean
+singleton AP_Logger method logging_enabled boolean
+singleton AP_Logger method logging_failed boolean
+

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -1,7 +1,6 @@
 #include <AP_Common/AP_Common.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_HAL/HAL.h>
-#include <AP_Logger/AP_Logger.h>
 
 #include "lua_bindings.h"
 
@@ -207,16 +206,7 @@ static int AP_Logger_Write(lua_State *L) {
     return 0;
 }
 
-const luaL_Reg AP_Logger_functions[] = {
-    {"write", AP_Logger_Write},
-    {NULL, NULL}
-};
-
 void load_lua_bindings(lua_State *L) {
-    lua_pushstring(L, "logger");
-    luaL_newlib(L, AP_Logger_functions);
-    lua_settable(L, -3);
-
     luaL_setfuncs(L, global_functions, 0);
 }
 

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -4,3 +4,5 @@
 
 // load all known lua bindings into the state
 void load_lua_bindings(lua_State *state);
+
+static int AP_Logger_Write(lua_State *L);


### PR DESCRIPTION
This is a change to the binding generator that allows singletons to have a combination of manually generated and auto generated functions. This also makes it slightly easier to add manual bindings.

Binding generator seems to work as expected, however there is a issue with getting the auto generated bindings to see the maunal one. 

```
lib/libArduCopter_libs.a(lua_generated_bindings.cpp.0.o):(.data.rel.ro.local._ZL14AP_Logger_meta+0x38):` undefined reference to `AP_Logger_Write(lua_State*)'
collect2: error: ld returned 1 exit status

```
also some warnings

```
In file included from ../../libraries/AP_Scripting/lua_scripts.h:22:0,
                 from ../../libraries/AP_Scripting/lua_repl.cpp:6:
../../libraries/AP_Scripting/lua_bindings.h:8:12: warning: ‘int AP_Logger_Write(lua_State*)’ declared ‘static’ but never defined [-Wunused-function]
 static int AP_Logger_Write(lua_State *L);
            ^~~~~~~~~~~~~~~
```

This all works if the maunal binding is put in `lua_bindings.h` so I expect I have made some basic mistake somewhere

