### PR TITLE
Tools: make non DEBUG SITL use -march=native

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -417,6 +417,7 @@ class sitl(Board):
         if not cfg.env.DEBUG:
             env.CXXFLAGS += [
                 '-O3',
+                '-march=native',
             ]
 
         if 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:


### PR DESCRIPTION
let the compiler optimise a little more SITL when we aren't debugging. 
it also reduces the binary size
No impact on build time.