### PR TITLE
travis: shift embedded tests to avoid travis time overrun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,16 +57,16 @@ matrix:
   include:
     - if: type != cron
       compiler: "gcc"
-      env: CI_BUILD_TARGET="revo-bootloader periph-build CubeOrange-bootloader navigator iofirmware stm32f7 stm32h7 fmuv2-plane sitltest-copter-tests2"
+      env: CI_BUILD_TARGET="sitltest-copter-tests2 sitltest-heli"
     - if: type != cron
       compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest-copter-tests1"
     - if: type != cron
       compiler: "gcc"
-      env: CI_BUILD_TARGET="sitltest-quadplane sitltest-plane"
+      env: CI_BUILD_TARGET="sitltest-tracker sitltest-quadplane sitltest-plane"
     - if: type != cron
       compiler: "clang-7"
       env: CI_BUILD_TARGET="sitltest-rover sitltest-sub sitltest-balancebot"
     - if: type != cron
       compiler: "clang-7"
-      env: CI_BUILD_TARGET="unit-tests sitl sitltest-tracker sitltest-heli"
+      env: CI_BUILD_TARGET="revo-bootloader periph-build CubeOrange-bootloader navigator iofirmware stm32f7 stm32h7 fmuv2-plane unit-tests sitl"


### PR DESCRIPTION
Recent additions to copter-tests2 mean we're running out of time there