### PR TITLE
AP_Winch: correct Daiwa line lengtha and speed scaling

### DIFF
--- a/libraries/AP_Winch/AP_Winch_Daiwa.cpp
+++ b/libraries/AP_Winch/AP_Winch_Daiwa.cpp
@@ -60,7 +60,7 @@ void AP_Winch_Daiwa::send_status(const GCS_MAVLINK &channel)
     }
 
     // convert speed percentage to absolute speed
-    const float speed_ms = fabsf(config.rate_max) * (float)latest.speed_pct;
+    const float speed_ms = fabsf(config.rate_max) * (float)latest.speed_pct * 0.01f;
 
     // send status
     mavlink_msg_winch_status_send(

--- a/libraries/AP_Winch/AP_Winch_Daiwa.h
+++ b/libraries/AP_Winch/AP_Winch_Daiwa.h
@@ -64,7 +64,7 @@ private:
 
     static const uint8_t buff_len_max = 20; // buffer maximum length
     static const int16_t output_dz = 100;   // output deadzone in scale of -1000 to +1000
-    const float line_length_correction_factor = 0.0357f;    // convert winch counter to meters
+    const float line_length_correction_factor = 0.003333f;  // convert winch counter to meters
 
     AP_HAL::UARTDriver *uart;
     char buff[buff_len_max];    // buffer holding latest data from winch


### PR DESCRIPTION
This PR includes two small changes to the processing of the Daiwa winch driver's scaling of "telemetry" information from the winch.  These two fixes are the result of real-world testing with the hardware.  The previous PR was written doing bench testing only and so these bugs were missed.