### PR TITLE
AP_Soaring: Improve timeouts

### DIFF
--- a/ArduPlane/soaring.cpp
+++ b/ArduPlane/soaring.cpp
@@ -111,8 +111,9 @@ void Plane::update_soaring() {
 
         // Some other loiter status, we need to think about exiting loiter.
         const uint32_t time_in_loiter_ms = AP_HAL::millis() - plane.soaring_mode_timer_ms;
+        const uint32_t timeout = MIN(1000*g2.soaring_controller.get_circling_time(), 20000);
 
-        if (!soaring_exit_heading_aligned() && loiterStatus!=SoaringController::LoiterStatus::ALT_TOO_LOW && time_in_loiter_ms < 20000) {
+        if (!soaring_exit_heading_aligned() && loiterStatus != SoaringController::LoiterStatus::ALT_TOO_LOW && time_in_loiter_ms < timeout) {
             // Heading not lined up, and not timed out or in a condition requiring immediate exit.
             break;
         }

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Units: s
     // @Range: 0 600
     // @User: Advanced
-    AP_GROUPINFO("MIN_CRSE_S", 8, SoaringController, min_cruise_s, 30),
+    AP_GROUPINFO("MIN_CRSE_S", 8, SoaringController, min_cruise_s, 10),
 
     // @Param: POLAR_CD0
     // @DisplayName: Zero lift drag coef.

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -127,6 +127,8 @@ public:
 
     float get_alt_cutoff() const {return alt_cutoff;}
 
+    float get_circling_time() const {return _vario.tau;}
+
 private:
     // slow down messages if they are the same. During loiter we could smap the same message. Only show new messages during loiters
     LoiterStatus _cruise_criteria_msg_last;


### PR DESCRIPTION
This makes two changes - 

 - Reduces default value of SOAR_MIN_CRSE_S to a better value of 10s. Makes the aircraft less likely to miss lift shortly after starting gliding.
 - Reduces the timeout for heading alignment when exiting loiter mode to the theoretical time to complete a loiter circle, if this is less than the existing 20s.  This gets small/slow aircraft out of sink more quickly, especially in windy conditions in which heading can be slow to align to target.

