### PR TITLE
AC_Autotune: Print gains before discarding

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -900,11 +900,7 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method)
 
 #if AUTOTUNE_ENABLED == ENABLED
     // save auto tuned parameters
-    if (copter.flightmode == &copter.mode_autotune) {
-        copter.mode_autotune.save_tuning_gains();
-    } else {
-        copter.mode_autotune.reset();
-    }
+    copter.mode_autotune.disarmed(copter.flightmode == &copter.mode_autotune);
 #endif
 
     // we are not in the air

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -550,9 +550,8 @@ public:
     bool allows_arming(bool from_gcs) const override { return false; }
     bool is_autopilot() const override { return false; }
 
-    void save_tuning_gains();
+    void disarmed(bool save);
     void stop();
-    void reset();
 
 protected:
 

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -137,19 +137,14 @@ void ModeAutoTune::run()
     copter.autotune.run();
 }
 
-void ModeAutoTune::save_tuning_gains()
+void ModeAutoTune::disarmed(bool save)
 {
-    copter.autotune.save_tuning_gains();
+    copter.autotune.disarmed(save);
 }
 
 void ModeAutoTune::stop()
 {
     copter.autotune.stop();
-}
-
-void ModeAutoTune::reset()
-{
-    copter.autotune.reset();
 }
 
 #endif  // AUTOTUNE_ENABLED == ENABLED

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -227,11 +227,7 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method)
 
 #if QAUTOTUNE_ENABLED
     //save qautotune gains if enabled and success
-    if (plane.control_mode == &plane.mode_qautotune) {
-        plane.quadplane.qautotune.save_tuning_gains();
-    } else {
-        plane.quadplane.qautotune.reset();
-    }
+    plane.quadplane.qautotune.disarmed(plane.control_mode == &plane.mode_qautotune);
 #endif
 
     gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -31,17 +31,11 @@ public:
     // main run loop
     virtual void run();
 
-    // save gained, called on disarm
-    void save_tuning_gains();
+    // save or discard gains, called on disarm
+    void disarmed(bool save);
 
     // stop tune, reverting gains
     void stop();
-
-    // reset Autotune so that gains are not saved again and autotune can be run again.
-    void reset() {
-        mode = UNINITIALISED;
-        axes_completed = 0;
-    }
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
@@ -65,6 +59,12 @@ protected:
     // start tune - virtual so that vehicle code can add additional pre-conditions
     virtual bool start(void);
 
+    // reset Autotune so that gains are not saved again and autotune can be run again.
+    void reset() {
+        mode = UNINITIALISED;
+        axes_completed = 0;
+    }
+
     // return true if we have a good position estimate
     virtual bool position_ok();
 
@@ -83,6 +83,7 @@ private:
     void load_intra_test_gains();
     void load_twitch_gains();
     void update_gcs(uint8_t message_id);
+    void update_gcs_discarded_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float angle_P, float rate_max);
     bool roll_enabled();
     bool pitch_enabled();
     bool yaw_enabled();

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -23,6 +23,8 @@
 #include <AC_AttitudeControl/AC_AttitudeControl_Multi.h>
 #include <AC_AttitudeControl/AC_PosControl.h>
 
+#define verbose_GCS 0
+
 class AC_AutoTune {
 public:
     // constructor
@@ -101,10 +103,12 @@ private:
     void Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt);
     void Log_Write_AutoTuneDetails(float angle_cd, float rate_cds);
 
+#if verbose_GCS
     void send_step_string();
     const char *level_issue_string() const;
     const char * type_string() const;
     void announce_state_to_gcs();
+#endif
     void do_gcs_announcements();
 
     enum struct LevelIssue {


### PR DESCRIPTION
People are often caught out by not following the correct procedure to save gains after having completed a autotune. This prints the gains before discarding to make it much easier to recover.

![image](https://user-images.githubusercontent.com/33176108/92383241-df32cb80-f105-11ea-8c25-5d8337cca481.png)
