### PR TITLE
Plane: Soaring: Allow pilot to commanded exit from thermalling via RC

### DIFF
--- a/ArduPlane/soaring.cpp
+++ b/ArduPlane/soaring.cpp
@@ -147,6 +147,9 @@ void Plane::update_soaring() {
         case SoaringController::LoiterStatus::DRIFT_EXCEEDED:
             soaring_restore_mode("Drifted too far", ModeReason::SOARING_DRIFT_EXCEEDED, *exit_mode);
             break;
+        case SoaringController::LoiterStatus::EXIT_COMMANDED:
+            soaring_restore_mode("Exit via RC switch", ModeReason::RC_COMMAND, *exit_mode);
+            break;
         } // switch loiterStatus
 
         break;

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -81,7 +81,8 @@ public:
         THERMAL_WEAK,
         ALT_LOST,
         DRIFT_EXCEEDED,
-        GOOD_TO_KEEP_LOITERING
+        GOOD_TO_KEEP_LOITERING,
+        EXIT_COMMANDED,
     };
 
     enum class ActiveStatus {
@@ -133,4 +134,6 @@ private:
     ActiveStatus _pilot_desired_state = ActiveStatus::AUTO_MODE_CHANGE;
 
     ActiveStatus active_state() const;
+
+    bool _exit_commanded;
 };


### PR DESCRIPTION
This is a good idea from @Hwurzburg.

Right now we have an RC option for setting soaring behaviour. Switching between mid and high switch positions does nothing while the plane is in thermalling state in LOITER mode.

This PR allows using the switch (usually toggling to the other position and back) to command ending thermalling and restoring previous mode. This avoids the pilot needing to use the mode switch and it also allows the usual attempt to align the heading before actually changing mode.