### PR TITLE
Global: Change to the snprintf method of hal.util class

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1282,16 +1282,16 @@ void Copter::convert_lgr_parameters(void)
 
     enum ap_var_type ptype;
     // get pointers to the servo min, max and trim parameters
-    snprintf(pname, sizeof(pname), "SERVO%u_MIN", chan);
+    hal.util->snprintf(pname, sizeof(pname), "SERVO%u_MIN", chan);
     servo_min = (AP_Int16 *)AP_Param::find(pname, &ptype);
 
-    snprintf(pname, sizeof(pname), "SERVO%u_MAX", chan);
+    hal.util->snprintf(pname, sizeof(pname), "SERVO%u_MAX", chan);
     servo_max = (AP_Int16 *)AP_Param::find(pname, &ptype);
 
-    snprintf(pname, sizeof(pname), "SERVO%u_TRIM", chan);
+    hal.util->snprintf(pname, sizeof(pname), "SERVO%u_TRIM", chan);
     servo_trim = (AP_Int16 *)AP_Param::find(pname, &ptype);
 
-    snprintf(pname, sizeof(pname), "SERVO%u_REVERSED", chan & 0x3F); // Only use the 6 LSBs, avoids a cpp warning
+    hal.util->snprintf(pname, sizeof(pname), "SERVO%u_REVERSED", chan & 0x3F); // Only use the 6 LSBs, avoids a cpp warning
     servo_reversed = (AP_Int16 *)AP_Param::find(pname, &ptype);
 
     if (!servo_min || !servo_max || !servo_trim || !servo_reversed) {

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -372,7 +372,7 @@ void Copter::do_failsafe_action(Failsafe_Action action, ModeReason reason){
         case Failsafe_Action_Terminate:
 #if ADVANCED_FAILSAFE == ENABLED
             char battery_type_str[17];
-            snprintf(battery_type_str, 17, "%s battery", type_str);
+            hal.util->snprintf(battery_type_str, 17, "%s battery", type_str);
             g2.afs.gcs_terminate(true, battery_type_str);
 #else
             arming.disarm(AP_Arming::Method::FAILSAFE_ACTION_TERMINATE);

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -716,7 +716,7 @@ uint8_t AP_ADSB::get_encoded_callsign_null_char()
 
     // using the above logic, we must always assign the squawk. once we get configured
     // externally then get_encoded_callsign_null_char() stops getting called
-    snprintf(out_state.cfg.callsign, 5, "%04d", unsigned(out_state.cfg.squawk_octal) & 0x1FFF);
+    hal.util->snprintf(out_state.cfg.callsign, 5, "%04d", unsigned(out_state.cfg.squawk_octal) & 0x1FFF);
     memset(&out_state.cfg.callsign[4], 0, 5); // clear remaining 5 chars
     encoded_null |= 0x40;
 
@@ -874,7 +874,7 @@ void AP_ADSB::set_callsign(const char* str, const bool append_icao)
     } // for i
 
     if (append_icao) {
-        snprintf(&out_state.cfg.callsign[4], 5, "%04X", unsigned(out_state.cfg.ICAO_id % 0x10000));
+        hal.util->snprintf(&out_state.cfg.callsign[4], 5, "%04X", unsigned(out_state.cfg.ICAO_id % 0x10000));
     }
 }
 

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -388,14 +388,14 @@ const char* SLCAN::CANIface::processCommand(char* cmd)
         return getASCIIStatusCode(true);    // Returning success for compatibility reasons
     }
     case 'F': {             // Get status flags
-        resp_len = snprintf((char*)resp_bytes, sizeof(resp_bytes), "F%02X\r", unsigned(0));    // Returning success for compatibility reasons
+        resp_len = hal.util->snprintf((char*)resp_bytes, sizeof(resp_bytes), "F%02X\r", unsigned(0));    // Returning success for compatibility reasons
         if (resp_len > 0) {
             _port->write_locked(resp_bytes, resp_len, _serial_lock_key);
         }
         return nullptr;
     }
     case 'V': {             // HW/SW version
-        resp_len = snprintf((char*)resp_bytes, sizeof(resp_bytes),"V%x%x%x%x\r", 1, 0, 1, 0);
+        resp_len = hal.util->snprintf((char*)resp_bytes, sizeof(resp_bytes),"V%x%x%x%x\r", 1, 0, 1, 0);
         if (resp_len > 0) {
             _port->write_locked(resp_bytes, resp_len, _serial_lock_key);
         }
@@ -414,7 +414,7 @@ const char* SLCAN::CANIface::processCommand(char* cmd)
             }
         }
         *pos++ = '\0';
-        resp_len = snprintf((char*)resp_bytes, sizeof(resp_bytes),"N%s\r", &buf[0]);
+        resp_len = hal.util->snprintf((char*)resp_bytes, sizeof(resp_bytes),"N%s\r", &buf[0]);
         if (resp_len > 0) {
             _port->write_locked(resp_bytes, resp_len, _serial_lock_key);
         }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1777,11 +1777,11 @@ bool Compass::configured(char *failure_msg, uint8_t failure_msg_len)
     for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_priority_did_list[i] != 0 && use_for_yaw(uint8_t(i))) {
             if (!_get_state(i).registered) {
-                snprintf(failure_msg, failure_msg_len, "Compass %d not Found", uint8_t(i));
+                hal.util->snprintf(failure_msg, failure_msg_len, "Compass %d not Found", uint8_t(i));
                 return false;
             }
             if (_priority_did_list[i] != _priority_did_stored_list[i]) {
-                snprintf(failure_msg, failure_msg_len, "Compass order change requires reboot");
+                hal.util->snprintf(failure_msg, failure_msg_len, "Compass order change requires reboot");
                 return false;
             }
         }
@@ -1793,7 +1793,7 @@ bool Compass::configured(char *failure_msg, uint8_t failure_msg_len)
         all_configured = all_configured && (!use_for_yaw(i) || configured(i));
     }
     if (!all_configured) {
-        snprintf(failure_msg, failure_msg_len, "Compass not calibrated");
+        hal.util->snprintf(failure_msg, failure_msg_len, "Compass not calibrated");
     }
     return all_configured;
 }

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -340,14 +340,14 @@ bool AP_Generator_RichenPower::pre_arm_check(char *failmsg, uint8_t failmsg_len)
     const uint32_t now = AP_HAL::millis();
 
     if (now - last_reading_ms > 2000) { // we expect @1Hz
-        snprintf(failmsg, failmsg_len, "no messages in %ums", unsigned(now - last_reading_ms));
+        hal.util->snprintf(failmsg, failmsg_len, "no messages in %ums", unsigned(now - last_reading_ms));
         return false;
     }
     if (last_reading.seconds_until_maintenance == 0) {
-        snprintf(failmsg, failmsg_len, "requires maintenance");
+        hal.util->snprintf(failmsg, failmsg_len, "requires maintenance");
     }
     if (SRV_Channels::get_channel_for(SRV_Channel::k_generator_control) == nullptr) {
-        snprintf(failmsg, failmsg_len, "need a servo output channel");
+        hal.util->snprintf(failmsg, failmsg_len, "need a servo output channel");
         return false;
     }
 
@@ -355,26 +355,26 @@ bool AP_Generator_RichenPower::pre_arm_check(char *failmsg, uint8_t failmsg_len)
         for (uint16_t i=0; i<16; i++) {
             if (last_reading.errors & (1U << (uint16_t)i)) {
                 if (i < (uint16_t)Errors::LAST) {
-                    snprintf(failmsg, failmsg_len, "error: %s", error_strings[i]);
+                    hal.util->snprintf(failmsg, failmsg_len, "error: %s", error_strings[i]);
                 } else {
-                    snprintf(failmsg, failmsg_len, "unknown error: 1U<<%u", i);
+                    hal.util->snprintf(failmsg, failmsg_len, "unknown error: 1U<<%u", i);
                 }
             }
         }
         return false;
     }
     if (pilot_desired_runstate != RunState::RUN) {
-        snprintf(failmsg, failmsg_len, "requested state is not RUN");
+        hal.util->snprintf(failmsg, failmsg_len, "requested state is not RUN");
         return false;
     }
     if (commanded_runstate != RunState::RUN) {
-        snprintf(failmsg, failmsg_len, "Generator warming up (%.0f%%)", (heat *100 / heat_required_for_run()));
+        hal.util->snprintf(failmsg, failmsg_len, "Generator warming up (%.0f%%)", (heat *100 / heat_required_for_run()));
         return false;
     }
     if (last_reading.mode != Mode::RUN &&
         last_reading.mode != Mode::CHARGE &&
         last_reading.mode != Mode::BALANCE) {
-        snprintf(failmsg, failmsg_len, "not running");
+        hal.util->snprintf(failmsg, failmsg_len, "not running");
         return false;
     }
 

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -863,7 +863,7 @@ uint32_t CANIface::get_stats(char* data, uint32_t max_size)
         return 0;
     }
     CriticalSectionLocker lock;
-    uint32_t ret = snprintf(data, max_size,
+    uint32_t ret = hal.util->snprintf(data, max_size,
                             "tx_requests:    %lu\n"
                             "tx_rejected:    %lu\n"
                             "tx_success:     %lu\n"

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -873,7 +873,7 @@ uint32_t CANIface::get_stats(char* data, uint32_t max_size)
         return 0;
     }
     CriticalSectionLocker lock;
-    uint32_t ret = snprintf(data, max_size,
+    uint32_t ret = hal.util->snprintf(data, max_size,
                             "tx_requests:    %lu\n"
                             "tx_rejected:    %lu\n"
                             "tx_success:     %lu\n"

--- a/libraries/AP_HAL_ChibiOS/Device.cpp
+++ b/libraries/AP_HAL_ChibiOS/Device.cpp
@@ -104,12 +104,12 @@ AP_HAL::Device::PeriodicHandle DeviceBus::register_periodic_callback(uint32_t pe
         char *name = (char *)malloc(name_len);
         switch (hal_device->bus_type()) {
         case AP_HAL::Device::BUS_TYPE_I2C:
-            snprintf(name, name_len, "I2C%u",
+            hal.util->snprintf(name, name_len, "I2C%u",
                      hal_device->bus_num());
             break;
 
         case AP_HAL::Device::BUS_TYPE_SPI:
-            snprintf(name, name_len, "SPI%u",
+            hal.util->snprintf(name, name_len, "SPI%u",
                      hal_device->bus_num());
             break;
         default:

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -176,7 +176,7 @@ void Storage::_save_backup(void)
     fname = nullptr;
     if (fd != -1) {
         char buf[10];
-        snprintf(buf, sizeof(buf), "%u\r\n", (unsigned)curr_bak);
+        hal.util->snprintf(buf, sizeof(buf), "%u\r\n", (unsigned)curr_bak);
         const ssize_t to_write = strlen(buf);
         const ssize_t written = AP::FS().write(fd, buf, to_write);
         AP::FS().close(fd);

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -272,7 +272,7 @@ bool Util::get_system_id(char buf[40])
     board_name[13] = 0;
 
     // this format is chosen to match the format used by HAL_PX4
-    snprintf(buf, 40, "%s %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X",
+    hal.util->snprintf(buf, 40, "%s %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X",
              board_name,
              (unsigned)serialid[3], (unsigned)serialid[2], (unsigned)serialid[1], (unsigned)serialid[0],
              (unsigned)serialid[7], (unsigned)serialid[6], (unsigned)serialid[5], (unsigned)serialid[4],
@@ -314,7 +314,7 @@ size_t Util::thread_info(char *buf, size_t bufsize)
   size_t total = 0;
 
   // a header to allow for machine parsers to determine format
-  int n = snprintf(buf, bufsize, "ThreadsV1\n");
+  int n = hal.util->snprintf(buf, bufsize, "ThreadsV1\n");
   if (n <= 0) {
       return 0;
   }
@@ -331,7 +331,7 @@ size_t Util::thread_info(char *buf, size_t bufsize)
           p++;
       }
       uint32_t stack_left = ((uint32_t)p) - stklimit;
-      n = snprintf(buf, bufsize, "%-13.13s PRI=%3u STACK_LEFT=%u\n", tp->name, unsigned(tp->prio), unsigned(stack_left));
+      n = hal.util->snprintf(buf, bufsize, "%-13.13s PRI=%3u STACK_LEFT=%u\n", tp->name, unsigned(tp->prio), unsigned(stack_left));
       if (n <= 0) {
           break;
       }

--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -568,7 +568,7 @@ uint32_t CANIface::get_stats(char* data, uint32_t max_size)
     if (data == nullptr) {
         return 0;
     }
-    uint32_t ret = snprintf(data, max_size,
+    uint32_t ret = hal.util->snprintf(data, max_size,
                             "tx_requests:    %u\n"
                             "tx_write_fail:  %u\n"
                             "tx_full:        %u\n"

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -290,7 +290,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         case 's':
             speedup = strtof(gopt.optarg, nullptr);
             char speedup_string[18];
-            snprintf(speedup_string, sizeof(speedup_string), "SIM_SPEEDUP=%s", gopt.optarg);
+            hal.util->snprintf(speedup_string, sizeof(speedup_string), "SIM_SPEEDUP=%s", gopt.optarg);
             _set_param_default(speedup_string);
             break;
         case 'r':

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -662,7 +662,7 @@ void SITL_State::_gps_nmea_printf(uint8_t instance, const char *fmt, ...)
     vasprintf(&s, fmt, ap);
     va_end(ap);
     csum = _gps_nmea_checksum(s);
-    snprintf(trailer, sizeof(trailer), "*%02X\r\n", (unsigned)csum);
+    hal.util->snprintf(trailer, sizeof(trailer), "*%02X\r\n", (unsigned)csum);
     _gps_write((const uint8_t*)s, strlen(s), instance);
     _gps_write((const uint8_t*)trailer, 5, instance);
     free(s);
@@ -686,21 +686,21 @@ void SITL_State::_update_gps_nmea(const struct gps_data *d, uint8_t instance)
     tm = gmtime(&tv.tv_sec);
 
     // format time string
-    snprintf(tstring, sizeof(tstring), "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + tv.tv_usec*1.0e-6);
+    hal.util->snprintf(tstring, sizeof(tstring), "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + tv.tv_usec*1.0e-6);
 
     // format date string
-    snprintf(dstring, sizeof(dstring), "%02u%02u%02u", tm->tm_mday, tm->tm_mon+1, tm->tm_year % 100);
+    hal.util->snprintf(dstring, sizeof(dstring), "%02u%02u%02u", tm->tm_mday, tm->tm_mon+1, tm->tm_year % 100);
 
     // format latitude
     double deg = fabs(d->latitude);
-    snprintf(lat_string, sizeof(lat_string), "%02u%08.5f,%c",
+    hal.util->snprintf(lat_string, sizeof(lat_string), "%02u%08.5f,%c",
              (unsigned)deg,
              (deg - int(deg))*60,
              d->latitude<0?'S':'N');
 
     // format longitude
     deg = fabs(d->longitude);
-    snprintf(lng_string, sizeof(lng_string), "%03u%08.5f,%c",
+    hal.util->snprintf(lng_string, sizeof(lng_string), "%03u%08.5f,%c",
              (unsigned)deg,
              (deg - int(deg))*60,
              d->longitude<0?'W':'E');

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -84,12 +84,12 @@ void dump_stack_trace()
     }
 
     char output_filepath[30];
-    snprintf(output_filepath,
+    hal.util->snprintf(output_filepath,
              ARRAY_SIZE(output_filepath),
              "dumpstack_%s.%d.out",
              p+1,
              (int)getpid());
-	snprintf(cmd,
+	hal.util->snprintf(cmd,
              sizeof(cmd),
              "sh %s %d >%s 2>&1",
              dumpstack,

--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -360,7 +360,7 @@ void AP_Hott_Telem::send_Vario(void)
             const AP_Mission *mission = AP::mission();
             if (mission) {
                 char wp[10] {};
-                snprintf(wp, sizeof(wp), "WP %3u", mission->get_current_nav_index());
+                hal.util->snprintf(wp, sizeof(wp), "WP %3u", mission->get_current_nav_index());
                 memcpy(msg.text[2], wp, sizeof(msg.text[2]));
             }
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -362,7 +362,7 @@ void AP_InertialSensor_Invensense::start()
 // get a startup banner to output to the GCS
 bool AP_InertialSensor_Invensense::get_output_banner(char* banner, uint8_t banner_len) {
     if (_fast_sampling) {
-        snprintf(banner, banner_len, "IMU%u: fast sampling enabled %.1fkHz/%.1fkHz",
+        hal.util->snprintf(banner, banner_len, "IMU%u: fast sampling enabled %.1fkHz/%.1fkHz",
             _gyro_instance, _gyro_backend_rate_hz * _gyro_fifo_downsample_rate / 1000.0, _gyro_backend_rate_hz / 1000.0);
         return true;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
@@ -242,7 +242,7 @@ void AP_InertialSensor_Invensensev2::start()
 // get a startup banner to output to the GCS
 bool AP_InertialSensor_Invensensev2::get_output_banner(char* banner, uint8_t banner_len) {
     if (_fast_sampling) {
-        snprintf(banner, banner_len, "IMU%u: fast sampling enabled %.1fkHz/%.1fkHz",
+        hal.util->snprintf(banner, banner_len, "IMU%u: fast sampling enabled %.1fkHz/%.1fkHz",
             _gyro_instance, _gyro_backend_rate_hz * _gyro_fifo_downsample_rate / 1000.0, _gyro_backend_rate_hz / 1000.0);
         return true;
     }

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -162,7 +162,7 @@ void AP_KDECAN::init(uint8_t driver_index, bool enable_filters)
         debug_can(AP_CANManager::LOG_DEBUG, "found ESC id %u", id.source_id);
     }
 
-    snprintf(_thread_name, sizeof(_thread_name), "kdecan_%u", driver_index);
+    hal.util->snprintf(_thread_name, sizeof(_thread_name), "kdecan_%u", driver_index);
 
     // start thread for receiving and sending CAN frames
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_KDECAN::loop, void), _thread_name, 4096, AP_HAL::Scheduler::PRIORITY_CAN, 0)) {
@@ -629,12 +629,12 @@ bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
 {
     if (!_enum_sem.take(1)) {
         debug_can(AP_CANManager::LOG_DEBUG, "failed to get enumeration semaphore on read");
-        snprintf(reason, reason_len ,"Enumeration state unknown");
+        hal.util->snprintf(reason, reason_len ,"Enumeration state unknown");
         return false;
     }
 
     if (_enumeration_state != ENUMERATION_STOPPED) {
-        snprintf(reason, reason_len ,"Enumeration running");
+        hal.util->snprintf(reason, reason_len ,"Enumeration running");
         _enum_sem.give();
         return false;
     }
@@ -652,17 +652,17 @@ bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
     uint8_t num_present_escs = __builtin_popcount(_esc_present_bitmask);
 
     if (num_present_escs < num_expected_motors) {
-        snprintf(reason, reason_len, "Too few ESCs detected");
+        hal.util->snprintf(reason, reason_len, "Too few ESCs detected");
         return false;
     }
 
     if (num_present_escs > num_expected_motors) {
-        snprintf(reason, reason_len, "Too many ESCs detected");
+        hal.util->snprintf(reason, reason_len, "Too many ESCs detected");
         return false;
     }
 
     if (_esc_max_node_id != num_expected_motors) {
-        snprintf(reason, reason_len, "Wrong node IDs, run enumeration");
+        hal.util->snprintf(reason, reason_len, "Wrong node IDs, run enumeration");
         return false;
     }
 

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -825,7 +825,7 @@ void AP_Logger_File::start_new_log(void)
     }
 
     char buf[30];
-    snprintf(buf, sizeof(buf), "%u\r\n", (unsigned)log_num);
+    hal.util->snprintf(buf, sizeof(buf), "%u\r\n", (unsigned)log_num);
     const ssize_t to_write = strlen(buf);
     const ssize_t written = AP::FS().write(fd, buf, to_write);
     AP::FS().close(fd);

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -298,9 +298,9 @@ void AP_MSP_Telem_Backend::update_flight_mode_str(char *flight_mode_str, bool wi
             const int32_t angle = wrap_360_cd(DEGX100 * atan2f(v.y, v.x) - ahrs.yaw_sensor);
             const int32_t interval = 36000 / ARRAY_SIZE(arrows);
             uint8_t arrow = arrows[((angle + interval / 2) / interval) % ARRAY_SIZE(arrows)];
-            snprintf(flight_mode_str, MSP_TXT_BUFFER_SIZE, "%s %d%s%c%c%c", notify->get_flight_mode_str(),  (uint8_t)roundf(v_length), unit, 0xE2, 0x86, arrow);
+            hal.util->snprintf(flight_mode_str, MSP_TXT_BUFFER_SIZE, "%s %d%s%c%c%c", notify->get_flight_mode_str(),  (uint8_t)roundf(v_length), unit, 0xE2, 0x86, arrow);
         } else {
-            snprintf(flight_mode_str, MSP_TXT_BUFFER_SIZE, "%s ---%s", notify->get_flight_mode_str(), unit);
+            hal.util->snprintf(flight_mode_str, MSP_TXT_BUFFER_SIZE, "%s ---%s", notify->get_flight_mode_str(), unit);
         }
     } else {
         /*
@@ -316,10 +316,10 @@ void AP_MSP_Telem_Backend::update_flight_mode_str(char *flight_mode_str, bool wi
 
         char buffer[MSP_TXT_BUFFER_SIZE] {};
         // flightmode
-        const uint8_t used = snprintf(buffer, ARRAY_SIZE(buffer), "%s%s", notify->get_flight_mode_str(), simple_mode_str);
+        const uint8_t used = hal.util->snprintf(buffer, ARRAY_SIZE(buffer), "%s%s", notify->get_flight_mode_str(), simple_mode_str);
         // left pad
         uint8_t left_padded_len = MSP_TXT_VISIBLE_CHARS - (MSP_TXT_VISIBLE_CHARS - used)/2;
-        snprintf(flight_mode_str, MSP_TXT_BUFFER_SIZE, "%*s", left_padded_len, buffer);
+        hal.util->snprintf(flight_mode_str, MSP_TXT_BUFFER_SIZE, "%*s", left_padded_len, buffer);
     }
 }
 

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -28,6 +28,8 @@
 #include <stdio.h>
 #include <time.h>
 
+extern const AP_HAL::HAL& hal;
+
 AP_NMEA_Output* AP_NMEA_Output::_singleton;
 
 AP_NMEA_Output::AP_NMEA_Output()
@@ -87,11 +89,11 @@ void AP_NMEA_Output::update()
 
     // format time string
     char tstring[11];
-    snprintf(tstring, sizeof(tstring), "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
+    hal.util->snprintf(tstring, sizeof(tstring), "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
 
     // format date string
     char dstring[7];
-    snprintf(dstring, sizeof(dstring), "%02u%02u%02u", tm->tm_mday, tm->tm_mon+1, tm->tm_year % 100);
+    hal.util->snprintf(dstring, sizeof(dstring), "%02u%02u%02u", tm->tm_mday, tm->tm_mon+1, tm->tm_year % 100);
 
     AP_AHRS_NavEKF& ahrs = AP::ahrs_navekf();
 
@@ -102,7 +104,7 @@ void AP_NMEA_Output::update()
     // format latitude
     char lat_string[13];
     float deg = fabsf(loc.lat * 1.0e-7f);
-    snprintf(lat_string,
+    hal.util->snprintf(lat_string,
              sizeof(lat_string),
              "%02u%08.5f,%c",
              (unsigned) deg,
@@ -112,7 +114,7 @@ void AP_NMEA_Output::update()
     // format longitude
     char lng_string[14];
     deg = fabsf(loc.lng * 1.0e-7f);
-    snprintf(lng_string,
+    hal.util->snprintf(lng_string,
              sizeof(lng_string),
              "%03u%08.5f,%c",
              (unsigned) deg,
@@ -134,7 +136,7 @@ void AP_NMEA_Output::update()
         return;
     }
     char gga_end[6];
-    snprintf(gga_end, sizeof(gga_end), "*%02X\r\n", (unsigned) _nmea_checksum(gga));
+    hal.util->snprintf(gga_end, sizeof(gga_end), "*%02X\r\n", (unsigned) _nmea_checksum(gga));
 
     // get speed
     Vector2f speed = ahrs.groundspeed_vector();
@@ -157,7 +159,7 @@ void AP_NMEA_Output::update()
         return;
     }
     char rmc_end[6];
-    snprintf(rmc_end, sizeof(rmc_end), "*%02X\r\n", (unsigned) _nmea_checksum(rmc));
+    hal.util->snprintf(rmc_end, sizeof(rmc_end), "*%02X\r\n", (unsigned) _nmea_checksum(rmc));
 
     const uint32_t space_required = strlen(gga) + strlen(gga_end) + strlen(rmc) + strlen(rmc_end);
 

--- a/libraries/AP_Notify/Display.cpp
+++ b/libraries/AP_Notify/Display.cpp
@@ -501,7 +501,7 @@ void Display::update_gps(uint8_t r)
             fixname = gpsfixname[0];
             break;
     }
-    snprintf(msg, DISPLAY_MESSAGE_SIZE, "GPS:%-5s Sats:%2u", fixname, (unsigned)AP_Notify::flags.gps_num_sats) ;
+    hal.util->snprintf(msg, DISPLAY_MESSAGE_SIZE, "GPS:%-5s Sats:%2u", fixname, (unsigned)AP_Notify::flags.gps_num_sats) ;
     draw_text(COLUMN(0), ROW(r), msg);
 }
 
@@ -526,7 +526,7 @@ void Display::update_battery(uint8_t r)
     char msg [DISPLAY_MESSAGE_SIZE];
     AP_BattMonitor &battery = AP::battery();
     uint8_t pct = battery.capacity_remaining_pct();
-    snprintf(msg, DISPLAY_MESSAGE_SIZE, "BAT:%4.2fV %2d%% ", (double)battery.voltage(), pct) ;
+    hal.util->snprintf(msg, DISPLAY_MESSAGE_SIZE, "BAT:%4.2fV %2d%% ", (double)battery.voltage(), pct) ;
     draw_text(COLUMN(0), ROW(r), msg);
  }
 
@@ -534,7 +534,7 @@ void Display::update_mode(uint8_t r)
 {
     char msg [DISPLAY_MESSAGE_SIZE];
     if (pNotify->get_flight_mode_str()) {
-        snprintf(msg, DISPLAY_MESSAGE_SIZE, "Mode: %s", pNotify->get_flight_mode_str()) ;
+        hal.util->snprintf(msg, DISPLAY_MESSAGE_SIZE, "Mode: %s", pNotify->get_flight_mode_str()) ;
         draw_text(COLUMN(0), ROW(r), msg);
     }
 }
@@ -564,7 +564,7 @@ void Display::update_text(uint8_t r)
         return;
     }
 
-    snprintf(txt, sizeof(txt), "%s", pNotify->get_text());
+    hal.util->snprintf(txt, sizeof(txt), "%s", pNotify->get_text());
 
     memset(msg, ' ', sizeof(msg)-1); // leave null termination
     const uint8_t len = strlen(&txt[_mstartpos]);

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -101,7 +101,7 @@ void AP_PiccoloCAN::init(uint8_t driver_index, bool enable_filters)
 
     _initialized = true;
 
-    snprintf(_thread_name, sizeof(_thread_name), "PiccoloCAN_%u", driver_index);
+    hal.util->snprintf(_thread_name, sizeof(_thread_name), "PiccoloCAN_%u", driver_index);
 
     debug_can(AP_CANManager::LOG_DEBUG, "PiccoloCAN: init done\n\r");
 }
@@ -525,14 +525,14 @@ bool AP_PiccoloCAN::pre_arm_check(char* reason, uint8_t reason_len)
         if (SRV_Channels::function_assigned(motor_function)) {
 
             if (!is_esc_present(ii)) {
-                snprintf(reason, reason_len, "ESC %u not detected", ii + 1);
+                hal.util->snprintf(reason, reason_len, "ESC %u not detected", ii + 1);
                 return false;
             }
 
             PiccoloESC_Info_t &esc = _esc_info[ii];
 
             if (esc.statusA.status.hwInhibit) {
-                snprintf(reason, reason_len, "ESC %u is hardware inhibited", (ii + 1));
+                hal.util->snprintf(reason, reason_len, "ESC %u is hardware inhibited", (ii + 1));
                 return false;
             }
         }

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
@@ -139,7 +139,7 @@ void AP_Proximity_LightWareSF40C_v09::set_forward_direction()
     char request_str[15];
     int16_t yaw_corr = frontend.get_yaw_correction(state.instance);
     yaw_corr = constrain_int16(yaw_corr, -999, 999);
-    snprintf(request_str, sizeof(request_str), "#MBF,%d\r\n", yaw_corr);
+    hal.util->snprintf(request_str, sizeof(request_str), "#MBF,%d\r\n", yaw_corr);
     _uart->write(request_str);
 
     // request update on motor direction
@@ -203,7 +203,7 @@ bool AP_Proximity_LightWareSF40C_v09::send_request_for_distance()
 
     // prepare request
     char request_str[16];
-    snprintf(request_str, sizeof(request_str), "?TS,%u,%u\r\n",
+    hal.util->snprintf(request_str, sizeof(request_str), "?TS,%u,%u\r\n",
              (unsigned int)PROXIMITY_SECTOR_WIDTH_DEG,
              _sector_middle_deg[_last_sector]);
     _uart->write(request_str);

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
@@ -46,7 +46,7 @@ bool AP_RCTelemetry::init(void)
         queue_message(MAV_SEVERITY_INFO, AP::fwversion().fw_string);
     } else {
         char firmware_buf[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
-        snprintf(firmware_buf, sizeof(firmware_buf), "%s %s", AP::fwversion().fw_string, _frame_string);
+        hal.util->snprintf(firmware_buf, sizeof(firmware_buf), "%s %s", AP::fwversion().fw_string, _frame_string);
         queue_message(MAV_SEVERITY_INFO, firmware_buf);
     }
 #endif

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -147,7 +147,7 @@ void lua_scripts::load_all_scripts_in_dir(lua_State *L, const char *dirname) {
         if (filename == nullptr) {
             continue;
         }
-        snprintf(filename, size, "%s/%s", dirname, de->d_name);
+        hal.util->snprintf(filename, size, "%s/%s", dirname, de->d_name);
 
         // we have something that looks like a lua file, attempt to load it
         script_info * script = load_script(L, filename);

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -175,7 +175,7 @@ void AP_Terrain::open_file(void)
     if (lon_tmp > 999U) {
         lon_tmp = 999;
     }
-    snprintf(p, 13, "/%c%02u%c%03u.DAT",
+    hal.util->snprintf(p, 13, "/%c%02u%c%03u.DAT",
              block.lat_degrees<0?'S':'N',
              (unsigned)lat_tmp,
              block.lon_degrees<0?'W':'E',

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -207,7 +207,7 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     _node->setNodeID(self_node_id);
 
     char ndname[20];
-    snprintf(ndname, sizeof(ndname), "org.ardupilot:%u", driver_index);
+    hal.util->snprintf(ndname, sizeof(ndname), "org.ardupilot:%u", driver_index);
 
     uavcan::NodeStatusProvider::NodeName name(ndname);
     _node->setName(name);
@@ -316,7 +316,7 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     // Spin node for device discovery
     _node->spin(uavcan::MonotonicDuration::fromMSec(5000));
 
-    snprintf(_thread_name, sizeof(_thread_name), "uavcan_%u", driver_index);
+    hal.util->snprintf(_thread_name, sizeof(_thread_name), "uavcan_%u", driver_index);
 
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_UAVCAN::loop, void), _thread_name, 4096, AP_HAL::Scheduler::PRIORITY_CAN, 0)) {
         _node->setModeOfflineAndPublish();

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
@@ -667,15 +667,15 @@ bool AP_UAVCAN_DNA_Server::prearm_check(char* fail_msg, uint8_t fail_msg_len) co
     case HEALTHY:
         return true;
     case STORAGE_FAILURE: {
-        snprintf(fail_msg, fail_msg_len, "Failed to access storage!");
+        hal.util->snprintf(fail_msg, fail_msg_len, "Failed to access storage!");
         return false;
     }
     case DUPLICATE_NODES: {
-        snprintf(fail_msg, fail_msg_len, "Duplicate Node %s../%d!", fault_node_name, fault_node_id);
+        hal.util->snprintf(fail_msg, fail_msg_len, "Duplicate Node %s../%d!", fault_node_name, fault_node_id);
         return false;
     }
     case FAILED_TO_ADD_NODE: {
-        snprintf(fail_msg, fail_msg_len, "Failed to add Node %d!", fault_node_id);
+        hal.util->snprintf(fail_msg, fail_msg_len, "Failed to add Node %d!", fault_node_id);
         return false;
     }
     }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -142,10 +142,10 @@ bool GCS_MAVLINK::init(uint8_t instance)
     mavlink_comm_port[chan] = _port;
 
     // create performance counters
-    snprintf(_perf_packet_name, sizeof(_perf_packet_name), "GCS_Packet_%u", chan);
+    hal.util->snprintf(_perf_packet_name, sizeof(_perf_packet_name), "GCS_Packet_%u", chan);
     _perf_packet = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, _perf_packet_name);
 
-    snprintf(_perf_update_name, sizeof(_perf_update_name), "GCS_Update_%u", chan);
+    hal.util->snprintf(_perf_update_name, sizeof(_perf_update_name), "GCS_Update_%u", chan);
     _perf_update = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, _perf_update_name);
 
     AP_SerialManager::SerialProtocol mavlink_protocol = serial_manager.get_mavlink_protocol(chan);

--- a/libraries/SITL/SIM_ADSB.cpp
+++ b/libraries/SITL/SIM_ADSB.cpp
@@ -24,6 +24,8 @@
 #include "SIM_Aircraft.h"
 #include <AP_HAL_SITL/SITL_State.h>
 
+extern const AP_HAL::HAL& hal;
+
 namespace SITL {
 
 SITL *_sitl;
@@ -36,7 +38,7 @@ void ADSB_Vehicle::update(float delta_t)
     if (!initialised) {
         initialised = true;
         ICAO_address = (uint32_t)(rand() % 10000);
-        snprintf(callsign, sizeof(callsign), "SIM%u", ICAO_address);
+        hal.util->snprintf(callsign, sizeof(callsign), "SIM%u", ICAO_address);
         position.x = Aircraft::rand_normal(0, _sitl->adsb_radius_m);
         position.y = Aircraft::rand_normal(0, _sitl->adsb_radius_m);
         position.z = -fabsf(_sitl->adsb_altitude_m);

--- a/libraries/SITL/SIM_Morse.cpp
+++ b/libraries/SITL/SIM_Morse.cpp
@@ -371,7 +371,7 @@ void Morse::output_rover_regular(const struct sitl_input &input)
 
     // construct a JSON packet for steer/force
     char buf[60];
-    snprintf(buf, sizeof(buf)-1, "{\"steer\": %.3f, \"force\": %.2f, \"brake\": %.2f}\n",
+    hal.util->snprintf(buf, sizeof(buf)-1, "{\"steer\": %.3f, \"force\": %.2f, \"brake\": %.2f}\n",
              steer, -force, 0.0);
     buf[sizeof(buf)-1] = 0;
 
@@ -392,7 +392,7 @@ void Morse::output_rover_skid(const struct sitl_input &input)
 
     // construct a JSON packet for v and w
     char buf[60];
-    snprintf(buf, sizeof(buf)-1, "{\"v\": %.3f, \"w\": %.2f}\n",
+    hal.util->snprintf(buf, sizeof(buf)-1, "{\"v\": %.3f, \"w\": %.2f}\n",
              speed_ms, -steering_rps);
     buf[sizeof(buf)-1] = 0;
 
@@ -422,7 +422,7 @@ void Morse::output_quad(const struct sitl_input &input)
 
     // construct a JSON packet for motors
     char buf[60];
-    snprintf(buf, sizeof(buf)-1, "{\"engines\": [%.3f, %.3f, %.3f, %.3f]}\n",
+    hal.util->snprintf(buf, sizeof(buf)-1, "{\"engines\": [%.3f, %.3f, %.3f, %.3f]}\n",
              m_back, m_right, m_front, m_left);
     buf[sizeof(buf)-1] = 0;
 
@@ -436,7 +436,7 @@ void Morse::output_quad(const struct sitl_input &input)
 void Morse::output_pwm(const struct sitl_input &input)
 {
     char buf[200];
-    snprintf(buf, sizeof(buf)-1, "{\"pwm\": [%u, %uf, %u, %u, %u, %uf, %u, %u, %u, %uf, %u, %u, %u, %uf, %u, %u]}\n",
+    hal.util->snprintf(buf, sizeof(buf)-1, "{\"pwm\": [%u, %uf, %u, %u, %u, %uf, %u, %u, %u, %uf, %u, %u, %u, %uf, %u, %u]}\n",
              input.servos[0], input.servos[1], input.servos[2], input.servos[3],
              input.servos[4], input.servos[5], input.servos[6], input.servos[7],
              input.servos[8], input.servos[9], input.servos[10], input.servos[11],

--- a/libraries/SITL/SIM_RF_LightWareSerial.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerial.cpp
@@ -21,6 +21,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <stdio.h>
 
+extern const AP_HAL::HAL& hal;
 
 using namespace SITL;
 
@@ -50,5 +51,5 @@ void RF_LightWareSerial::update(float range)
 
 uint32_t RF_LightWareSerial::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
-    return snprintf((char*)buffer, buflen, "%f\r", alt_cm / 100.0f); // note tragic lack of snprintf return checking
+    return hal.util->snprintf((char*)buffer, buflen, "%f\r", alt_cm / 100.0f); // note tragic lack of snprintf return checking
 }

--- a/libraries/SITL/SIM_RF_MaxsonarSerialLV.cpp
+++ b/libraries/SITL/SIM_RF_MaxsonarSerialLV.cpp
@@ -21,10 +21,12 @@
 #include <GCS_MAVLink/GCS.h>
 #include <stdio.h>
 
+extern const AP_HAL::HAL& hal;
+
 using namespace SITL;
 
 uint32_t RF_MaxsonarSerialLV::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
     const float inches = alt_cm / 2.54f;
-    return snprintf((char*)buffer, buflen, "%u\r", (unsigned)inches);
+    return hal.util->snprintf((char*)buffer, buflen, "%u\r", (unsigned)inches);
 }

--- a/libraries/SITL/SIM_RF_NMEA.cpp
+++ b/libraries/SITL/SIM_RF_NMEA.cpp
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <string.h>
 
+extern const AP_HAL::HAL& hal;
+
 using namespace SITL;
 
 uint32_t RF_NMEA::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
@@ -30,11 +32,11 @@ uint32_t RF_NMEA::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t bufle
 // Format 2 DBT NMEA mode (e.g. $SMDBT,5.94,f,1.81,M,67)
 // Format 3 DPT NMEA mode (e.g. $SMDPT,1.81,0.066)
 
-    ssize_t ret = snprintf((char*)buffer, buflen, "$SMDPT,%f,%f", alt_cm/100.0f, 0.01f);
+    ssize_t ret = hal.util->snprintf((char*)buffer, buflen, "$SMDPT,%f,%f", alt_cm/100.0f, 0.01f);
     uint8_t checksum = 0;
     for (uint8_t i=1; i<ret; i++) { // 1 because the initial $ is skipped
         checksum ^= buffer[i];
     }
-    ret += snprintf((char*)&buffer[ret], buflen-ret, "*%02X\r\n", checksum);
+    ret += hal.util->snprintf((char*)&buffer[ret], buflen-ret, "*%02X\r\n", checksum);
     return ret;
 }

--- a/libraries/SITL/SIM_RF_Wasp.cpp
+++ b/libraries/SITL/SIM_RF_Wasp.cpp
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <string.h>
 
+extern const AP_HAL::HAL& hal;
+
 using namespace SITL;
 
 void RF_Wasp::check_configuration()
@@ -59,7 +61,7 @@ void RF_Wasp::check_configuration()
                     strncpy(string_configs[i].value, &_buffer[offs], MIN(ARRAY_SIZE(config.format), unsigned(cr - _buffer - offs - 1))); // -1 for the lf, -1 for the cr
 //                    gcs().send_text(MAV_SEVERITY_INFO, "Wasp: config (%s) (%s)", string_configs[i].name, string_configs[i].value);
                     char response[128];
-                    const size_t x = snprintf(response,
+                    const size_t x = hal.util->snprintf(response,
                                               ARRAY_SIZE(response),
                                               "%s %s\n",
                                               string_configs[i].name,
@@ -82,7 +84,7 @@ void RF_Wasp::check_configuration()
                     *(integer_configs[i].value) = atoi(tmp);
 //                    gcs().send_text(MAV_SEVERITY_INFO, "Wasp: config (%s) (%d)", integer_configs[i].name, *(integer_configs[i].value));
                     char response[128];
-                    const size_t x = snprintf(response,
+                    const size_t x = hal.util->snprintf(response,
                                               ARRAY_SIZE(response),
                                               "%s %d\n",
                                               integer_configs[i].name,
@@ -113,5 +115,5 @@ void RF_Wasp::update(float range)
 
 uint32_t RF_Wasp::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
-    return snprintf((char*)buffer, buflen, "%f\n", alt_cm/100.0f);
+    return hal.util->snprintf((char*)buffer, buflen, "%f\n", alt_cm/100.0f);
 }

--- a/libraries/SITL/SIM_Webots.cpp
+++ b/libraries/SITL/SIM_Webots.cpp
@@ -357,7 +357,7 @@ void Webots::output_rover(const struct sitl_input &input)
     // construct a JSON packet for v and w
     char buf[200];
     
-    const int len = snprintf(buf, sizeof(buf)-1, "{\"rover\": [%f, %f], \"wnd\": [%f, %f, %f, %f]}\n",
+    const int len = hal.util->snprintf(buf, sizeof(buf)-1, "{\"rover\": [%f, %f], \"wnd\": [%f, %f, %f, %f]}\n",
              motor1, motor2,
              input.wind.speed, wind_ef.x, wind_ef.y, wind_ef.z);
     
@@ -385,7 +385,7 @@ void Webots::output_tricopter(const struct sitl_input &input)
 
     // construct a JSON packet for motors
     char buf[200];
-    const int len = snprintf(buf, sizeof(buf)-1, "{\"eng\": [%.3f, %.3f, %.3f, %.3f], \"wnd\": [%f, %3.1f, %1.1f, %2.1f]}\n",
+    const int len = hal.util->snprintf(buf, sizeof(buf)-1, "{\"eng\": [%.3f, %.3f, %.3f, %.3f], \"wnd\": [%f, %3.1f, %1.1f, %2.1f]}\n",
              m_right, m_left, m_servo, m_back,
              input.wind.speed, wind_ef.x, wind_ef.y, wind_ef.z);
     //printf("\"eng\": [%.3f, %.3f, %.3f, %.3f]\n",m_right, m_left, m_servo, m_back);
@@ -419,7 +419,7 @@ void Webots::output_quad(const struct sitl_input &input)
 
     // construct a JSON packet for motors
     char buf[200];
-    const int len = snprintf(buf, sizeof(buf)-1, "{\"eng\": [%.3f, %.3f, %.3f, %.3f], \"wnd\": [%f, %3.1f, %1.1f, %2.1f]}\n",
+    const int len = hal.util->snprintf(buf, sizeof(buf)-1, "{\"eng\": [%.3f, %.3f, %.3f, %.3f], \"wnd\": [%f, %3.1f, %1.1f, %2.1f]}\n",
              m_front, m_right, m_back, m_left,
              input.wind.speed, wind_ef.x, wind_ef.y, wind_ef.z);
     buf[len] = 0;
@@ -433,7 +433,7 @@ void Webots::output_quad(const struct sitl_input &input)
 void Webots::output_pwm(const struct sitl_input &input)
 {
     char buf[2000];
-    const int len = snprintf(buf, sizeof(buf)-1, "{\"pwm\": [%d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0], \"wnd\": [%3.3f, %f, %3.3f, %3.3f]}\n",
+    const int len = hal.util->snprintf(buf, sizeof(buf)-1, "{\"pwm\": [%d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0, %d.0], \"wnd\": [%3.3f, %f, %3.3f, %3.3f]}\n",
              input.servos[0], input.servos[1], input.servos[2], input.servos[3],
              input.servos[4], input.servos[5], input.servos[6], input.servos[7],
              input.servos[8], input.servos[9], input.servos[10], input.servos[11],


### PR DESCRIPTION
I added the snprintf method in the hal.util class and it is used in many classes.
I think it's better to have one method than using different classes with the same method name.