### PR TITLE
Rover: add support for MAV_CMD_DO_REPOSITION

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -603,6 +603,9 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_in
         }
         return MAV_RESULT_ACCEPTED;
 
+    case MAV_CMD_DO_REPOSITION:
+        return handle_command_int_do_reposition(packet);
+
     case MAV_CMD_DO_SET_REVERSE:
         // param1 : Direction (0=Forward, 1=Reverse)
         rover.control_mode->set_reversed(is_equal(packet.param1,1.0f));
@@ -678,6 +681,49 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
     default:
         return GCS_MAVLINK::handle_command_long_packet(packet);
     }
+}
+
+MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_do_reposition(const mavlink_command_int_t &packet)
+{
+    const bool change_modes = ((int32_t)packet.param2 & MAV_DO_REPOSITION_FLAGS_CHANGE_MODE) == MAV_DO_REPOSITION_FLAGS_CHANGE_MODE;
+    if (!rover.control_mode->in_guided_mode() && !change_modes) {
+        return MAV_RESULT_DENIED;
+    }
+
+    // sanity check location
+    if (!check_latlng(packet.x, packet.y)) {
+        return MAV_RESULT_DENIED;
+    }
+    if (packet.x == 0 && packet.y == 0) {
+        return MAV_RESULT_DENIED;
+    }
+
+    Location request_location {};
+    request_location.lat = packet.x;
+    request_location.lng = packet.y;
+
+    if (fabsf(packet.z) > LOCATION_ALT_MAX_M) {
+        return MAV_RESULT_DENIED;
+    }
+
+    Location::AltFrame frame;
+    if (!mavlink_coordinate_frame_to_location_alt_frame((MAV_FRAME)packet.frame, frame)) {
+        return MAV_RESULT_DENIED; // failed as the location is not valid
+    }
+    request_location.set_alt_cm((int32_t)(packet.z * 100.0f), frame);
+
+    if (!rover.control_mode->in_guided_mode()) {
+        if (!rover.set_mode(Mode::Number::GUIDED, ModeReason::GCS_COMMAND)) {
+            return MAV_RESULT_FAILED;
+        }
+    }
+
+    // set the destination
+    if (!rover.mode_guided.set_desired_location(request_location)) {
+        return MAV_RESULT_FAILED;
+    }
+
+    return MAV_RESULT_ACCEPTED;
 }
 
 // a RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes

--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -18,6 +18,7 @@ protected:
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);
 
     void send_position_target_global_int() override;
 


### PR DESCRIPTION
This extends PR https://github.com/ArduPilot/ardupilot/pull/14720 by adding Rover support for the [MAV_CMD_DO_REPOSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_REPOSITION) (sent via [COMMAND_INT](https://mavlink.io/en/messages/common.html#COMMAND_INT)).

This has been tested in SITL including these checks:

- Command fails (as it should) if the vehicle is not in Guided mode and param2 = 0
- Vehicle switches to Guided mode if param2 = 1
- Command fails (as it should) if invalid altitude frame is provided
- Command fails (as it should) if lat,lon of 0,0 is provided

Notes:

- Unlike Copter and Plane, we don't call Location::sanitize() because this would stop users from entering locations with zero relative altitude.  An extra check that lat,lon is not 0,0 has been added though.
- The destination's altitude and alt-frame are checked (i.e. command could be rejected) even though Rovers can't control their altitude.  It seemed somehow nicer to be consistent with other vehicles but I don't feel strongly about this.
- Only implemented for COMMAND_INT.  Not implemented for COMMAND_LONG which is consistent with Plane and Copter

Screenshot of SITL testing:
![image](https://user-images.githubusercontent.com/1498098/92437260-7456c280-f1e1-11ea-9cc3-95a79f15f3f1.png)

