### PR TITLE
Copter: poshold wind effect comp limited to 2/3rds of angle max

### DIFF
--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -22,6 +22,7 @@
 // definitions that are independent of main loop rate
 #define POSHOLD_STICK_RELEASE_SMOOTH_ANGLE      1800    // max angle required (in centi-degrees) after which the smooth stick release effect is applied
 #define POSHOLD_WIND_COMP_ESTIMATE_SPEED_MAX    10      // wind compensation estimates will only run when velocity is at or below this speed in cm/s
+#define POSHOLD_WIND_COMP_LEAN_PCT_MAX          0.6666f // wind compensation no more than 2/3rds of angle max to ensure pilot can always override
 
 // poshold_init - initialise PosHold controller
 bool ModePosHold::init(bool ignore_checks)
@@ -594,6 +595,13 @@ void ModePosHold::update_wind_comp_estimate()
     } else {
         // low pass filter the position controller's lean angle output
         wind_comp_ef.y = (1.0f-TC_WIND_COMP)*wind_comp_ef.y + TC_WIND_COMP*accel_target.y;
+    }
+
+    // limit acceleration
+    const float accel_lim_cmss = tanf(radians(POSHOLD_WIND_COMP_LEAN_PCT_MAX * copter.aparm.angle_max * 0.01f)) * 981.0f;
+    const float wind_comp_ef_len = wind_comp_ef.length();
+    if (!is_zero(accel_lim_cmss) && (wind_comp_ef_len > accel_lim_cmss)) {
+        wind_comp_ef *= accel_lim_cmss / wind_comp_ef_len;
     }
 }
 


### PR DESCRIPTION
This partially resolves issue https://github.com/ArduPilot/ardupilot/issues/15275 by limiting the maximum lean angle due to wind estimate compensation to 2/3rds of the ANGLE_MAX parameter.  This means that the pilot is always able to override the vehicle's lean angle and get the vehicle home (although it may take some time at only 1/3rd of ANGLE_MAX).

This has been tested in SITL and with ANGLE_MAX = 2500, the maximum lean angle from wind estimate compensation was 17 degrees.

This change causes slightly odd behaviour in very strong winds (i.e. where fighting against the wind takes more than 2/3rds of ANGLE_MAX) because while PosHold is in the "Loiter" submode the loiter controller can use the entire ANGLE_MAX range but as soon as the pilot provides some roll or pitch input the position hold limit becomes 2/3rds of ANGLE_MAX.  This means that the vehicle may lean in the wrong direction from the pilot input which is unintuitive.