### PR TITLE
AP_Scheduler: Make sure the header information is written

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -412,7 +412,7 @@ size_t AP_Scheduler::task_info(char *buf, size_t bufsize)
     // a header to allow for machine parsers to determine format
     int n = hal.util->snprintf(buf, bufsize, "TasksV1\n");
 
-    if (n <= 0) {
+    if (n < 8) {
         return 0;
     }
 


### PR DESCRIPTION
The write byte count check was less than 0.
The header information is 8 bytes.
I think you should check it by the number of header information bytes.