### PR TITLE
AP_HAL_SITL: fix segv in examples

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -429,8 +429,10 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         exit(1);
     }
 
-    // Set SITL start time.
-    AP::sitl()->start_time_UTC = start_time_UTC;
+    if (AP::sitl()) {
+        // Set SITL start time.
+        AP::sitl()->start_time_UTC = start_time_UTC;
+    }
 
     fprintf(stdout, "Starting sketch '%s'\n", SKETCH);
 


### PR DESCRIPTION
recent change to SITL_State::_parse_command_line expected AP::sitl() to be non-null, but the SITL singleton is optional, even for SITL builds