### PR TITLE
Keep trying to initialize RunCam after boot

### DIFF
--- a/libraries/AP_Camera/AP_RunCam.h
+++ b/libraries/AP_Camera/AP_RunCam.h
@@ -379,6 +379,8 @@ private:
     void receive();
     // empty the receive side of the serial port
     void drain();
+    // start the uart with appropriate settings
+    void start_uart();
 
     // get the RunCam device information
     void get_device_info();
@@ -399,8 +401,6 @@ private:
         uint16_t maxRetryTimes, parse_func_t parseFunc);
     // send a packet to the serial port
     void send_packet(Command command, uint8_t param);
-    // crc functions
-    static uint8_t crc8_high_first(uint8_t *ptr, uint8_t len);
     // handle a device info response
     void parse_device_info(const Request& request);
     // wait for the RunCam device to be fully ready


### PR DESCRIPTION
This is a small improvement to the RunCam code which means the driver continues to try and initialize the camera after boot. This is useful if the camera is not initially powered and responding on the UART.