### PR TITLE
AP_Logger/AC_AttitudeControl: revert psc pid logging

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -896,8 +896,6 @@ void AC_PosControl::write_log()
 
    AP::logger().Write_PSC(get_pos_target(), _inav.get_position(), get_vel_target(), _inav.get_velocity(), get_accel_target(), accel_x, accel_y);
 
-   AP::logger().Write_PSCP(_vel_error, _vel_xy_p, _vel_xy_i, _vel_xy_d);
-
 }
 
 /// init_vel_controller_xyz - initialise the velocity controller - should be called once before the caller attempts to use the controller
@@ -1040,7 +1038,7 @@ void AC_PosControl::run_xy_controller(float dt)
 
     // the following section converts desired velocities in lat/lon directions to accelerations in lat/lon frame
 
-    Vector2f accel_target;
+    Vector2f accel_target, vel_xy_p, vel_xy_i, vel_xy_d;
 
     // check if vehicle velocity is being overridden
     if (_flags.vehicle_horiz_vel_override) {
@@ -1059,22 +1057,22 @@ void AC_PosControl::run_xy_controller(float dt)
     _pid_vel_xy.set_input(_vel_error);
 
     // get p
-    _vel_xy_p = _pid_vel_xy.get_p();
+    vel_xy_p = _pid_vel_xy.get_p();
 
     // update i term if we have not hit the accel or throttle limits OR the i term will reduce
     // TODO: move limit handling into the PI and PID controller
     if (!_limit.accel_xy && !_motors.limit.throttle_upper) {
-        _vel_xy_i = _pid_vel_xy.get_i();
+        vel_xy_i = _pid_vel_xy.get_i();
     } else {
-       _vel_xy_i = _pid_vel_xy.get_i_shrink();
+        vel_xy_i = _pid_vel_xy.get_i_shrink();
     }
 
     // get d
-    _vel_xy_d = _pid_vel_xy.get_d();
+    vel_xy_d = _pid_vel_xy.get_d();
 
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
-    accel_target.x = (_vel_xy_p.x + _vel_xy_i.x + _vel_xy_d.x) * ekfNavVelGainScaler;
-    accel_target.y = (_vel_xy_p.y + _vel_xy_i.y + _vel_xy_d.y) * ekfNavVelGainScaler;
+    accel_target.x = (vel_xy_p.x + vel_xy_i.x + vel_xy_d.x) * ekfNavVelGainScaler;
+    accel_target.y = (vel_xy_p.y + vel_xy_i.y + vel_xy_d.y) * ekfNavVelGainScaler;
 
     // reset accel to current desired acceleration
     if (_flags.reset_accel_to_lean_xy) {

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -421,9 +421,6 @@ protected:
     Vector2f    _vehicle_horiz_vel;     // velocity to use if _flags.vehicle_horiz_vel_override is set
     LowPassFilterFloat _vel_error_filter;   // low-pass-filter on z-axis velocity error
 
-    // XY PID terms for logging
-    Vector2f _vel_xy_p, _vel_xy_i, _vel_xy_d;
-
     LowPassFilterVector2f _accel_target_filter; // acceleration target filter
 
     // ekf reset handling

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -290,7 +290,6 @@ public:
     void Write_SimpleAvoidance(uint8_t state, const Vector2f& desired_vel, const Vector2f& modified_vel, bool back_up);
     void Write_Winch(bool healthy, bool thread_end, bool moving, bool clutch, uint8_t mode, float desired_length, float length, float desired_rate, uint16_t tension, float voltage, int8_t temp);
     void Write_PSC(const Vector3f &pos_target, const Vector3f &position, const Vector3f &vel_target, const Vector3f &velocity, const Vector3f &accel_target, const float &accel_x, const float &accel_y);
-    void Write_PSCP(const Vector3f &vel_error, const Vector2f &vel_xy_p, const Vector2f &vel_xy_i, const Vector2f &vel_xy_d);
 
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -1155,20 +1155,3 @@ void AP_Logger::Write_PSC(const Vector3f &pos_target, const Vector3f &position, 
     };
     WriteBlock(&pkt, sizeof(pkt));
 }
-
-void AP_Logger::Write_PSCP(const Vector3f &vel_error, const Vector2f &vel_xy_p, const Vector2f &vel_xy_i, const Vector2f &vel_xy_d)
-{
-    struct log_PSCP pkt{
-        LOG_PACKET_HEADER_INIT(LOG_PSCP_MSG),
-        time_us     : AP_HAL::micros64(),
-        vel_error_x : vel_error.x * 0.01f,
-        vel_xy_p_x  : vel_xy_p.x,
-        vel_xy_i_x  : vel_xy_i.x,
-        vel_xy_d_x  : vel_xy_d.x,
-        vel_error_y : vel_error.y * 0.01f,
-        vel_xy_p_y  : vel_xy_p.y,
-        vel_xy_i_y  : vel_xy_i.y,
-        vel_xy_d_y  : vel_xy_d.y
-    };
-    WriteBlock(&pkt, sizeof(pkt));
-}

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1288,19 +1288,6 @@ struct PACKED log_PSC {
     float accel_y;
 };
 
-struct PACKED log_PSCP {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    float vel_error_x;
-    float vel_xy_p_x;
-    float vel_xy_i_x;
-    float vel_xy_d_x;
-    float vel_error_y;
-    float vel_xy_p_y;
-    float vel_xy_i_y;
-    float vel_xy_d_y;
-};
-
 // FMT messages define all message formats other than FMT
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
@@ -2497,18 +2484,6 @@ struct PACKED log_PSCP {
 // @Field: AX: Acceleration, X-axis
 // @Field: AY: Acceleration, Y-axis
 
-// @LoggerMessage: PSCP
-// @Description: Position Control velocity PID gains
-// @Field: TimeUS: Time since system startup
-// @Field: EX: Velocity error, X-axis
-// @Field: kPX: Velocity P gain, X-axis
-// @Field: kIX: Velocity I gain, X-axis
-// @Field: kDX: Velocity D gain, X-axis
-// @Field: EY: Velocity error, Y-axis
-// @Field: kPY: Velocity P gain, Y-axis
-// @Field: kIY: Velocity I gain, Y-axis
-// @Field: kDY: Velocity D gain, Y-axis
-
 // messages for all boards
 #define LOG_BASE_STRUCTURES \
     { LOG_FORMAT_MSG, sizeof(log_Format), \
@@ -2728,9 +2703,7 @@ struct PACKED log_PSCP {
     { LOG_WINCH_MSG, sizeof(log_Winch), \
       "WINC", "QBBBBBfffHfb", "TimeUS,Heal,ThEnd,Mov,Clut,Mode,DLen,Len,DRate,Tens,Vcc,Temp", "s-----mmn?vO", "F-----000000" }, \
     { LOG_PSC_MSG, sizeof(log_PSC), \
-      "PSC", "Qffffffffffff", "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY", "smmmmnnnnoooo", "F000000000000" }, \
-    { LOG_PSCP_MSG, sizeof(log_PSCP), \
-      "PSCP", "Qffffffff", "TimeUS,EX,kPX,kIX,kDX,EY,kPY,kIY,kDY", "sn---n---", "F00000000"}
+      "PSC", "Qffffffffffff", "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY", "smmmmnnnnoooo", "F000000000000" }
 
 // @LoggerMessage: SBPH
 // @Description: Swift Health Data
@@ -2893,7 +2866,6 @@ enum LogMessages : uint8_t {
     LOG_SIMPLE_AVOID_MSG,
     LOG_WINCH_MSG,
     LOG_PSC_MSG,
-    LOG_PSCP_MSG,
 
     _LOG_LAST_MSG_
 };


### PR DESCRIPTION
We don't need to do this very often but due to a miscommunication I'd like to revert a portion of PR: https://github.com/ArduPilot/ardupilot/pull/15231 because it interferes with the s-curve work.

@IamPete1 if you want to have a go at re-implementing on-top of the s-curve work you can find the latest here: https://github.com/rmackay9/rmackay9-ardupilot/tree/lthall-scurve4