### PR TITLE
SITL_AirSim: moved NED position initialization out of always false if-statement

### DIFF
--- a/libraries/SITL/SIM_AirSim.cpp
+++ b/libraries/SITL/SIM_AirSim.cpp
@@ -307,6 +307,8 @@ void AirSim::recv_fdm(const sitl_input& input)
     location.lng = state.gps.lon * 1.0e7;
     location.alt = state.gps.alt * 100.0f;
 
+    position = home.get_distance_NED(location);
+
     dcm.from_euler(state.pose.roll, state.pose.pitch, state.pose.yaw);
 
     if (last_timestamp) {
@@ -358,7 +360,6 @@ void AirSim::recv_fdm(const sitl_input& input)
                        degrees(gyro.z));
 
     Vector3f velocity_bf = dcm.transposed() * velocity_ef;
-    position = home.get_distance_NED(location);
 
 // @LoggerMessage: ASM2
 // @Description: More AirSim simulation data


### PR DESCRIPTION
While testing AirSim SITL with Vicon position estimate, VISION_POSITION_ESTIMATE comes with zero XYZ-coordinates no matter how vehicle is moving.

Steps to reproduce:
1. Set necessary parameters (described here https://ardupilot.org/dev/docs/using-sitl-for-ardupilot-testing.html#testing-vicon-aka-vision-positioning)
2. Run any AirSim environment
3. Run SITL `./Tools/autotest/sim_vehicle.py -v ArduCopter -f airsim-copter --map --console -A "--uartC=sim:vicon:"`
4. Switch to STABILIZE, arm vehicle, switch to LOITER.
5. Make some movements i.e. `rc 3 1800; rc 2 1400`
5. check vision position `status VISION_POSITION_ESTIMATE`