### PR TITLE
SRV_Channel: Set the servo's output in the minimum to maximum range.

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -60,7 +60,8 @@ void SRV_Channel::output_ch(void)
         }
     }
     if (!(SRV_Channels::disabled_mask & (1U<<ch_num))) {
-        hal.rcout->write(ch_num, output_pwm);
+        uint16_t servoPWM = constrain_int16(output_pwm, SRV_Channels::channels[ch_num].servo_min, SRV_Channels::channels[ch_num].servo_max);
+        hal.rcout->write(ch_num, servoPWM);
     }
 }
 


### PR DESCRIPTION
I have the maximum and minimum servo values set in the config parameter.
I think the output of the servo should be in this range.

ISSUE: #15252 

After:
MIN: Input 1000 to output 1100
![Screenshot from 2020-09-12 02-14-12](https://user-images.githubusercontent.com/646194/92955100-85ccf280-f49f-11ea-92d6-8fda59df2628.png)

MAX: Input 2000 to output 1900
![Screenshot from 2020-09-12 02-13-52](https://user-images.githubusercontent.com/646194/92955103-8796b600-f49f-11ea-8a4d-fca3d30c5cc8.png)
