### PR TITLE
AP_OSD_Param_Setting: fix copter FS_OPTIONS mnemonics

### DIFF
--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -204,8 +204,8 @@ static const char* FLTMODES[] = {
 };
 
 static const char* FS_OPTIONS[] = {
-    "NONE", "CONT_RCFS", "CONT_GCSFS", "CONT_RC/GCSFS", "", "", "", "CONT_LAND", "",
-    "", "", "", "", "", "", "CONT_CTRL_GCS", "", "", "CONTNUE"
+    "NONE", "CONT_RCFS", "CONT_GCSFS", "CONT_RC/GCSFS", "CONT_GUID_RC", "", "", "", "CONT_LAND", "",
+    "", "", "", "", "", "CONT_CTRL_GCS", "", "", "CONTNUE"
 };
 
 static const char* THR_FS_ACT[] = {


### PR DESCRIPTION
stumbled across this while trying to wrap my head around FS_ACTION_1/2/3 systematics...

![image](https://user-images.githubusercontent.com/9342253/92974448-7beac580-f486-11ea-8a2d-93b9ca039d48.png)
