### PR TITLE
Replace message indicating that initialisation has completed

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -79,7 +79,6 @@ void Tracker::init_ardupilot()
         get_home_eeprom(current_loc);
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO,"Ready to track");
     hal.scheduler->delay(1000); // Why????
 
     Mode *newmode = mode_from_mode_num((Mode::Number)g.initial_mode.get());

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -223,8 +223,6 @@ void Copter::init_ardupilot()
     // disable safety if requested
     BoardConfig.init_safety();
 
-    hal.console->printf("\nReady to FLY ");
-
     // flag that initialisation has completed
     ap.initialised = true;
 }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -210,8 +210,6 @@ void Plane::startup_ground(void)
     // mid-flight, so set the serial ports non-blocking once we are
     // ready to fly
     serial_manager.set_blocking_writes_all(false);
-
-    gcs().send_text(MAV_SEVERITY_INFO,"Ground start complete");
 }
 
 

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -176,9 +176,7 @@ void Sub::init_ardupilot()
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
     // disable safety if requested
-    BoardConfig.init_safety();    
-    
-    hal.console->print("\nInit complete");
+    BoardConfig.init_safety();
 
     // flag that initialisation has completed
     ap.initialised = true;

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -166,8 +166,6 @@ void Rover::startup_ground(void)
     // we don't want writes to the serial port to cause us to pause
     // so set serial ports non-blocking once we are ready to drive
     serial_manager.set_blocking_writes_all(false);
-
-    gcs().send_text(MAV_SEVERITY_INFO, "Ready to drive");
 }
 
 // update the ahrs flyforward setting which can allow

--- a/Tools/scripts/runfliptest.py
+++ b/Tools/scripts/runfliptest.py
@@ -37,7 +37,7 @@ def wait_time(mav, simtime):
 
 cmd = 'sim_vehicle.py -j4 -D -L KSFO -S5'
 mavproxy = pexpect.spawn(cmd, logfile=sys.stdout, timeout=30)
-mavproxy.expect("Ready to FLY")
+mavproxy.expect("ArduPilot Ready")
 
 mav = mavutil.mavlink_connection('127.0.0.1:14550')
 

--- a/Tools/scripts/runplanetest.py
+++ b/Tools/scripts/runplanetest.py
@@ -37,7 +37,7 @@ def wait_time(mav, simtime):
 
 cmd = 'sim_vehicle.py -j4 -D -f plane'
 mavproxy = pexpect.spawn(cmd, logfile=sys.stdout, timeout=30)
-mavproxy.expect("Ground start complete")
+mavproxy.expect("ArduPilot Ready")
 
 mav = mavutil.mavlink_connection('127.0.0.1:14550')
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -103,6 +103,7 @@ void AP_Vehicle::setup()
 
     // init_ardupilot is where the vehicle does most of its initialisation.
     init_ardupilot();
+    gcs().send_text(MAV_SEVERITY_INFO, "ArduPilot Ready");
 
     // gyro FFT needs to be initialized really late
 #if HAL_GYROFFT_ENABLED


### PR DESCRIPTION
This is NFC, but I fix it because I see it every time I start SITL.

Copter
![image](https://user-images.githubusercontent.com/16643069/92988966-7a171580-f50b-11ea-9128-4e11fb9db06b.png)

Sub
![image](https://user-images.githubusercontent.com/16643069/92988967-7c796f80-f50b-11ea-948b-b4b8c24aedd5.png)

In Copter, "*" is here.
https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_InertialSensor/AP_InertialSensor.cpp#L1233
This is also displayed in Rover. I will leave it because I couldn't decide if it was necessary.

By the way, send_text is used in the other three vehicles. I think it's okay to unify to send_text.

AntennaTracker
https://github.com/ArduPilot/ardupilot/blob/master/AntennaTracker/system.cpp#L82
> gcs().send_text(MAV_SEVERITY_INFO,"Ready to track");

ArduPlane
https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/system.cpp#L214
> gcs().send_text(MAV_SEVERITY_INFO,"Ground start complete");

Rover
https://github.com/ArduPilot/ardupilot/blob/master/Rover/system.cpp#L170
> gcs().send_text(MAV_SEVERITY_INFO, "Ready to drive");