### PR TITLE
Correct units on raw accel data

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1277,7 +1277,7 @@ struct PACKED log_Winch {
 
 #define ACC_LABELS "TimeUS,SampleUS,AccX,AccY,AccZ"
 #define ACC_FMT   "QQfff"
-#define ACC_UNITS "ssnnn"
+#define ACC_UNITS "ssooo"
 #define ACC_MULTS "FF000"
 
 // see "struct sensor" in AP_Baro.h and "Write_Baro":


### PR DESCRIPTION
The raw accel data was marked as m/s but it should be m/s/s