### PR TITLE
Revert "Tools: make non DEBUG SITL use -march=native"

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -417,7 +417,6 @@ class sitl(Board):
         if not cfg.env.DEBUG:
             env.CXXFLAGS += [
                 '-O3',
-                '-march=native',
             ]
 
         if 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:


### PR DESCRIPTION
This reverts commit 85b599b2d75700433dc5c5a0c57fa5089bb8abb8.

This breaks the cygwin binaries that MissionPlanner uses for simulation