### PR TITLE
Tools: build_log_message_documentation.sh: compress log message docum…

### DIFF
--- a/Tools/scripts/build_log_message_documentation.sh
+++ b/Tools/scripts/build_log_message_documentation.sh
@@ -20,6 +20,8 @@ generate_log_message_documentation() {
     VEHICLE_DIR="$DIR/$VEHICLE"
     mkdir -p "$VEHICLE_DIR"
     /bin/cp LogMessages.* "$VEHICLE_DIR/"
+    gzip -9 <"$VEHICLE_DIR"/LogMessages.xml >"$VEHICLE_DIR"/LogMessages.xml.gz.new && mv "$VEHICLE_DIR"/LogMessages.xml.gz.new "$VEHICLE_DIR"/LogMessages.xml.gz
+    xz -e <"$VEHICLE_DIR"/LogMessages.xml >"$VEHICLE_DIR"/LogMessages.xml.xz.new && mv "$VEHICLE_DIR"/LogMessages.xml.xz.new "$VEHICLE_DIR"/LogMessages.xml.xz
 }
 
 for vehicle in Rover Plane Copter Tracker; do


### PR DESCRIPTION
…entation files

This will allow GCSs to download the logger message documentation somewhat faster.

```
pbarker@bluebottle:~/rc/ardupilot(pr/compress-logmessages)$ tree -s ../buildlogs/LogMessages
../buildlogs/LogMessages
├── [       4096]  Copter
│   ├── [     132062]  LogMessages.html
│   ├── [     214150]  LogMessages.rst
│   ├── [     215655]  LogMessages.xml
│   ├── [      19020]  LogMessages.xml.gz
│   └── [      14508]  LogMessages.xml.xz
├── [       4096]  Plane
│   ├── [     134545]  LogMessages.html
│   ├── [     219325]  LogMessages.rst
│   ├── [     220040]  LogMessages.xml
│   ├── [      19365]  LogMessages.xml.gz
│   └── [      14808]  LogMessages.xml.xz
├── [       4096]  Rover
│   ├── [     122714]  LogMessages.html
│   ├── [     197244]  LogMessages.rst
│   ├── [     200438]  LogMessages.xml
│   ├── [      17566]  LogMessages.xml.gz
│   └── [      13352]  LogMessages.xml.xz
└── [       4096]  Tracker
    ├── [     119222]  LogMessages.html
    ├── [     192016]  LogMessages.rst
    ├── [     194982]  LogMessages.xml
    ├── [      16869]  LogMessages.xml.gz
    └── [      12828]  LogMessages.xml.xz
```
