### PR TITLE
SITL: JSON: don't warn for none required sections

### DIFF
--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -136,7 +136,10 @@ uint16_t JSON::parse_sensors(const char *json)
         const char *p = strstr(json, key.section);
         if (!p) {
             // we don't have this sensor
-            printf("Failed to find %s\n", key.section);
+            if (key.required) {
+                printf("Failed to find %s\n", key.section);
+                return 0;
+            }
             continue;
         }
         p += strlen(key.section)+1;
@@ -147,9 +150,8 @@ uint16_t JSON::parse_sensors(const char *json)
             if (key.required) {
                 printf("Failed to find key %s/%s\n", key.section, key.key);
                 return 0;
-            } else {
-                continue;
             }
+            continue;
         }
 
         // record the keys that are found


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/ArduPilot/ardupilot/pull/15061

Current master prints a waning for not getting the Windvane section, dispute not requiring any of the keys in the section. I had only tested if we lost one or the other keys in each section.