### PR TITLE
Plane: all reverse thrust on landing pattern

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -216,7 +216,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Bitmask for when to allow negative reverse thrust
     // @Description: This controls when to use reverse thrust. If set to zero then reverse thrust is never used. If set to a non-zero value then the bits correspond to flight stages where reverse thrust may be used. Note that reverse thrust is only ever auto-enabled in auto-throttle modes. In modes where throttle control is pilot controlled the ability to do reverse thrust is controlled by throttle stick input. The most commonly used value for USE_REV_THRUST is 2, which means AUTO_LAND only. That enables reverse thrust in the landing stage of AUTO mode. Another common choice is 1, which means to use reverse thrust in all auto flight stages.
     // @Values: 0:Never,1:AutoAlways,2:AutoLanding
-    // @Bitmask: 0:AUTO_ALWAYS,1:AUTO_LAND,2:AUTO_LOITER_TO_ALT,3:AUTO_LOITER_ALL,4:AUTO_WAYPOINTS,5:LOITER,6:RTL,7:CIRCLE,8:CRUISE,9:FBWB,10:GUIDED
+    // @Bitmask: 0:AUTO_ALWAYS,1:AUTO_LAND,2:AUTO_LOITER_TO_ALT,3:AUTO_LOITER_ALL,4:AUTO_WAYPOINTS,5:LOITER,6:RTL,7:CIRCLE,8:CRUISE,9:FBWB,10:GUIDED,11:AUTO_LANDING_PATTERN
     // @User: Advanced
     GSCALAR(use_reverse_thrust,     "USE_REV_THRUST",  USE_REVERSE_THRUST_AUTO_LAND_APPROACH),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -144,6 +144,7 @@ enum {
     USE_REVERSE_THRUST_CRUISE                   = (1<<8),
     USE_REVERSE_THRUST_FBWB                     = (1<<9),
     USE_REVERSE_THRUST_GUIDED                   = (1<<10),
+    USE_REVERSE_THRUST_AUTO_LANDING_PATTERN     = (1<<11),
 };
 
 enum FlightOptions {

--- a/ArduPlane/reverse_thrust.cpp
+++ b/ArduPlane/reverse_thrust.cpp
@@ -61,6 +61,10 @@ bool Plane::allow_reverse_thrust(void) const
         allow |= (g.use_reverse_thrust & USE_REVERSE_THRUST_AUTO_WAYPOINT) &&
                     (nav_cmd == MAV_CMD_NAV_WAYPOINT ||
                      nav_cmd == MAV_CMD_NAV_SPLINE_WAYPOINT);
+
+        // we are on a landing pattern
+        allow |= (g.use_reverse_thrust & USE_REVERSE_THRUST_AUTO_LANDING_PATTERN) &&
+                mission.get_in_landing_sequence_flag();
         }
         break;
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -529,6 +529,11 @@ public:
         _flags.in_landing_sequence = flag;
     }
 
+    // get in_landing_sequence flag
+    bool get_in_landing_sequence_flag() const {
+        return _flags.in_landing_sequence;
+    }
+
     // force mission to resume when start_or_resume() is called
     void set_force_resume(bool force_resume)
     {


### PR DESCRIPTION
This allows another bit to allow reverse thrust when in a landing pattern. The landing pattern is defined as between DO_LAND_START and DO_LAND. This logic correctly handles aborted landings but does not yet correctly handle scenarios where you manually set the waypoint.