### PR TITLE
AR_AttitudeControl: update param desc increment and range

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -26,14 +26,14 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @DisplayName: Steering control rate P gain
     // @Description: Steering control rate P gain.  Converts the turn rate error (in radians/sec) to a steering control output (in the range -1 to +1)
     // @Range: 0.000 2.000
-    // @Increment: 0.01
+    // @Increment: 0.001
     // @User: Standard
 
     // @Param: _STR_RAT_I
     // @DisplayName: Steering control I gain
     // @Description: Steering control I gain.  Corrects long term error between the desired turn rate (in rad/s) and actual
     // @Range: 0.000 2.000
-    // @Increment: 0.01
+    // @Increment: 0.001
     // @User: Standard
 
     // @Param: _STR_RAT_IMAX
@@ -68,18 +68,24 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _STR_RAT_FLTT
     // @DisplayName: Steering control Target filter frequency in Hz
     // @Description: Target filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _STR_RAT_FLTE
     // @DisplayName: Steering control Error filter frequency in Hz
     // @Description: Error filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _STR_RAT_FLTD
     // @DisplayName: Steering control Derivative term filter frequency in Hz
     // @Description: Derivative filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
     AP_SUBGROUPINFO(_steer_rate_pid, "_STR_RAT_", 1, AR_AttitudeControl, AC_PID),
@@ -95,6 +101,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @DisplayName: Speed control I gain
     // @Description: Speed control I gain.  Corrects long term error between the desired speed (in m/s) and actual speed
     // @Range: 0.000 2.000
+    // @Increment: 0.01
     // @User: Standard
 
     // @Param: _SPEED_IMAX
@@ -129,18 +136,24 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _SPEED_FLTT
     // @DisplayName: Speed control Target filter frequency in Hz
     // @Description: Target filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _SPEED_FLTE
     // @DisplayName: Speed control Error filter frequency in Hz
     // @Description: Error filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _SPEED_FLTD
     // @DisplayName: Speed control Derivative term filter frequency in Hz
     // @Description: Derivative filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
     AP_SUBGROUPINFO(_throttle_speed_pid, "_SPEED_", 2, AR_AttitudeControl, AC_PID),
@@ -216,6 +229,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @DisplayName: Pitch control I gain
     // @Description: Pitch control I gain for BalanceBots.  Corrects long term error between the desired pitch (in radians) and actual pitch
     // @Range: 0.000 2.000
+    // @Increment: 0.01
     // @User: Standard
 
     // @Param: _BAL_IMAX
@@ -250,18 +264,24 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _BAL_FLTT
     // @DisplayName: Pitch control Target filter frequency in Hz
     // @Description: Target filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _BAL_FLTE
     // @DisplayName: Pitch control Error filter frequency in Hz
     // @Description: Error filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _BAL_FLTD
     // @DisplayName: Pitch control Derivative term filter frequency in Hz
     // @Description: Derivative filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
     AP_SUBGROUPINFO(_pitch_to_throttle_pid, "_BAL_", 10, AR_AttitudeControl, AC_PID),
@@ -285,6 +305,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @DisplayName: Sail Heel control I gain
     // @Description: Sail Heel control I gain for sailboats.  Corrects long term error between the desired heel angle (in radians) and actual
     // @Range: 0.000 2.000
+    // @Increment: 0.01
     // @User: Standard
 
     // @Param: _SAIL_IMAX
@@ -319,18 +340,24 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _SAIL_FLTT
     // @DisplayName: Sail Heel Target filter frequency in Hz
     // @Description: Target filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _SAIL_FLTE
     // @DisplayName: Sail Heel Error filter frequency in Hz
     // @Description: Error filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
 
     // @Param: _SAIL_FLTD
     // @DisplayName: Sail Heel Derivative term filter frequency in Hz
     // @Description: Derivative filter frequency in Hz
+    // @Range: 0.000 100.000
+    // @Increment: 0.1
     // @Units: Hz
     // @User: Standard
     AP_SUBGROUPINFO(_sailboat_heel_pid, "_SAIL_", 12, AR_AttitudeControl, AC_PID),


### PR DESCRIPTION
This adds or updates missing increment and range values for some Rover parameters.

This comes from a recent experience tuning a skid-steering rover with wheels that were very close together.  This resulted in insanely responsive turn rates that required very low steering control gains (i.e. 0.001 to 0.005).

Also added ranges and increments that were missing for the new PID filtering parameters added in 4.0.x.