### PR TITLE
Plane: check gps.status BEFORE doing other checks that need it

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -290,8 +290,8 @@ void Plane::one_second_loop()
     // update home position if NOT armed and gps position has
     // changed. Update every 5s at most
     if (!arming.is_armed() &&
-        gps.last_message_time_ms() - last_home_update_ms > 5000 &&
-        gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+            gps.status() >= AP_GPS::GPS_OK_FIX_3D &&
+            gps.last_message_time_ms() - last_home_update_ms > 5000) {
             last_home_update_ms = gps.last_message_time_ms();
             update_home();
             
@@ -368,7 +368,7 @@ void Plane::update_GPS_50Hz(void)
 void Plane::update_GPS_10Hz(void)
 {
     static uint32_t last_gps_msg_ms;
-    if (gps.last_message_time_ms() != last_gps_msg_ms && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+    if (gps.status() >= AP_GPS::GPS_OK_FIX_3D && gps.last_message_time_ms() != last_gps_msg_ms) {
         last_gps_msg_ms = gps.last_message_time_ms();
 
         if (ground_start_count > 1) {

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -122,7 +122,7 @@ void Plane::update_home()
     }
     if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         Location loc;
-        if(ahrs.get_position(loc) && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+        if (gps.status() >= AP_GPS::GPS_OK_FIX_3D && ahrs.get_position(loc)) {
             // we take the altitude directly from the GPS as we are
             // about to reset the baro calibration. We can't use AHRS
             // altitude or we can end up perpetuating a bias in

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -40,8 +40,8 @@ void Plane::update_is_flying_5Hz(void)
     } else if(arming.is_armed()) {
         // when armed assuming flying and we need overwhelming evidence that we ARE NOT flying
         // short drop-outs of GPS are common during flight due to banking which points the antenna in different directions
-        bool gps_lost_recently = (gps.last_fix_time_ms() > 0) && // we have locked to GPS before
-                        (gps.status() < AP_GPS::GPS_OK_FIX_2D) && // and it's lost now
+        bool gps_lost_recently = (gps.status() < AP_GPS::GPS_OK_FIX_2D) && // We don't have a GPS lock
+                        (gps.last_fix_time_ms() > 0) && // but we've seen GPS before
                         (now_ms - gps.last_fix_time_ms() < 5000); // but it wasn't that long ago (<5s)
 
         if ((auto_state.last_flying_ms > 0) && gps_lost_recently) {


### PR DESCRIPTION
This is a simple reordering on the check to save a tiny bit of work when it's not needed