### PR TITLE
examples/BARO_generic: Instantiating sitl to fix nullptr panic

### DIFF
--- a/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
+++ b/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
@@ -32,6 +32,11 @@ static uint32_t timer;
 static uint8_t counter;
 static AP_BoardConfig board_config;
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <SITL/SITL.h>
+SITL::SITL sitl;
+#endif
+
 void setup();
 void loop();
 


### PR DESCRIPTION
examples/BARO_generic generated a panic in AP_Baro/AP_Baro.cpp#L606 because sitl was a nullptr.

Instantiating the singleton solves the problem.