### PR TITLE
Plane: Stall detection

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -90,6 +90,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Terrain, &plane.terrain, update, 10, 200),
 #endif // AP_TERRAIN_AVAILABLE
     SCHED_TASK(update_is_flying_5Hz,    5,    100),
+    SCHED_TASK_CLASS(StallState, &plane.stall_state, detection_update, 5, 100),
 #if LOGGING_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Logger, &plane.logger, periodic_tasks, 50, 400),
 #endif

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1117,6 +1117,10 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: mode_takeoff.cpp
     GOBJECT(mode_takeoff, "TKOFF_", ModeTakeoff),
 
+    // @Group: STALL_
+    // @Path: stall_detection.cpp
+    GOBJECT(stall_state, "STALL_", StallState),
+
     // @Group:
     // @Path: ../libraries/AP_Vehicle/AP_Vehicle.cpp
     { AP_PARAM_GROUP, "", Parameters::k_param_vehicle, (const void *)&plane, {group_info : AP_Vehicle::var_info} },

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -128,7 +128,7 @@ public:
         k_param_override_channel,
         k_param_stall_prevention,
         k_param_optflow,
-        k_param_cli_enabled_old, // unused - CLI removed
+        k_param_stall_state,    // was cli_enabled_old
         k_param_trim_rc_at_start, // unused
         k_param_hil_mode,
         k_param_land_disarm_delay,  // unused - moved to AP_Landing

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -147,6 +147,24 @@ enum {
     USE_REVERSE_THRUST_AUTO_LANDING_PATTERN     = (1<<11),
 };
 
+enum class Stall_Detect {
+    NEVER                                       = 0,
+    BAD_DESCENT                                 = (1<<0),
+    SINKRATE_2X_MAX                             = (1<<1),
+    SINKRATE_4X_MAX                             = (1<<2),
+    BAD_ROLL_20DEG                              = (1<<3),
+    BAD_ROLL_30DEG                              = (1<<4),
+    BAD_ROLL_45DEG                              = (1<<5),
+    BAD_PITCH_10DEG                             = (1<<6),
+    BAD_PITCH_20DEG                             = (1<<7),
+    BAD_PITCH_30DEG                             = (1<<8),
+    BAD_PITCH_40DEG                             = (1<<9),
+    BAD_ALT_10m                                 = (1<<10),
+    BAD_ALT_20m                                 = (1<<11),
+    BAD_ALT_40m                                 = (1<<12),
+    BAD_ALT_60m                                 = (1<<13),
+};
+
 enum FlightOptions {
     DIRECT_RUDDER_ONLY   = (1 << 0),
     CRUISE_TRIM_THROTTLE = (1 << 1),

--- a/ArduPlane/stall_detection.cpp
+++ b/ArduPlane/stall_detection.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2020  Kraus Hamdani Aerospace Inc. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Author: Tom Pittenger, Samuel Tabor
+ */
+
+
+#include "Plane.h"
+
+/*
+  stall detection algorithm and anti-stall management
+ */
+
+
+const AP_Param::GroupInfo Plane::StallState::var_info[] = {
+    // @Param: STALL_DETECT
+    // @DisplayName: Stall detection type
+    // @Description: Stall detection type. Different aircraft stall in different ways.
+    // @User: Advanced
+    // @Bitmask: 0:CantHoldAltitude,1:SinkRate*2Max,2:SinkRate*4Max,3:RollError20deg,4:RollError30deg,5:RollError45deg,6:PitchError10deg,7:PitchError20deg,8:PitchError20deg,9:PitchError30deg,10:PitchError40deg,11:AltError10m,12:AltError20m,13:AltError40m,14:AltError60m
+    AP_GROUPINFO("DETECT", 0, StallState, detection_bitmask, 0),
+
+    AP_GROUPEND
+};
+
+
+/*
+  Do we think we are stalled?
+  Probabilistic method where a bool is low-passed and considered a probability.
+*/
+void Plane::StallState::detection_update(void)
+{
+    if (!plane.arming.is_armed() ||
+        !plane.is_flying() ||
+        plane.crash_state.is_crashed)
+    {
+        stall_clear();
+        count = 0;
+        detection_log();
+        return;
+    }
+
+    const bool is_stalled_initial = is_stalled();
+
+    last_detection = detect_stall(true);
+
+    // LPF confidence
+    confidence = ((float)last_detection * LPFcoef) + (confidence * (1.0f - LPFcoef));
+
+    if ((is_stalled_initial != is_stalled()) && is_stalled()) {
+        // we just stalled
+
+        plane.gcs().send_text_rate_limited(MAV_SEVERITY_WARNING, 1000, detect_notify_gcs_last_ms, "STALL DETECTED!");
+
+        stall_start();
+        // TODO: trigger stall recovery
+    }
+    detection_log();
+}
+
+void Plane::StallState::detection_log()
+{
+    // log to AP_Logger
+    AP::logger().Write(
+       "STAL",
+       "TimeUS,Actv,Raw,Any,Conf",
+       "s---%",
+       "F----",
+       "QBBIf",
+       AP_HAL::micros64(),
+       (uint8_t)is_stalled(),
+       (uint8_t)last_detection,
+       (uint32_t)detection_bitmask_if_everything_enabled,
+       (double)confidence);
+}
+
+// return true if we think we're stalling
+bool Plane::StallState::detect_stall(bool allow_changing_state)
+{
+    //
+    // Pre-process nav roll to apply rate limit. Needs to be done before potential early returns.
+    //
+    const uint32_t now_ms = AP_HAL::millis();
+
+    // Time since last update.
+    const float deltaT = 0.001f * (now_ms - last_update_ms);
+
+    // Directly take nav_roll_cd, used if time since last update is too long indicating a reset.
+    float limited_nav_roll = 0.01f*plane.nav_roll_cd;
+
+    if (deltaT < 0.5) {
+        // Difference between current nav roll and previous limited value.
+        const float delta_angle      = 0.01f*plane.nav_roll_cd - last_limited_nav_roll;
+
+        // New limited nav roll
+        limited_nav_roll = last_limited_nav_roll + constrain_float(delta_angle, -50.0f*deltaT, 50.0f*deltaT);
+    }
+
+    // Save into old values
+    last_update_ms        = now_ms;
+    last_limited_nav_roll = limited_nav_roll;
+
+    bool is_stalled = true;
+
+    // check some generic things that are true for all aircraft types
+    // ----------------
+
+    if (plane.auto_state.sink_rate < definitely_not_stalling_sink_rate) {
+        // we're going up fast, this is strong evidence that we're not stalling
+        is_stalled = false;
+
+        if (allow_changing_state) {
+            stall_clear();
+        }
+    }
+
+
+
+    // check bitmask options
+    // ----------------
+    // TECS is not able to hold the desired altitude
+    const bool uncommanded_altitude_loss = plane.SpdHgt_Controller->uncommanded_altitude_loss();
+    is_stalled &= detection_single_check(Stall_Detect::BAD_DESCENT, uncommanded_altitude_loss);
+
+
+    // we're sinking faster than a controlled sink is allowed to be
+    const float sink_rate = plane.SpdHgt_Controller->get_max_sinkrate();
+    is_stalled &= detection_single_check(Stall_Detect::SINKRATE_2X_MAX, plane.auto_state.sink_rate > (sink_rate * 2));
+    is_stalled &= detection_single_check(Stall_Detect::SINKRATE_4X_MAX, plane.auto_state.sink_rate > (sink_rate * 4));
+
+
+    // we're rolling faster than a controlled roll is allowed to be
+    const uint32_t roll_error_cd = fabsf(100.0f*limited_nav_roll - plane.ahrs.roll_sensor);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_ROLL_20DEG, roll_error_cd > 2000);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_ROLL_30DEG, roll_error_cd > 3000);
+
+
+    // we're pitching faster than a controlled pitch is allowed to be
+    const uint32_t pitch_error_cd = labs(labs(plane.nav_pitch_cd) - labs(plane.ahrs.pitch_sensor));
+    is_stalled &= detection_single_check(Stall_Detect::BAD_PITCH_10DEG, pitch_error_cd > 1000);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_PITCH_20DEG, pitch_error_cd > 2000);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_PITCH_30DEG, pitch_error_cd > 3000);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_PITCH_40DEG, pitch_error_cd > 4000);
+
+
+    // We don't use plane.altitude_error because the target component of this is not
+    // limited by the maximum climb/sink rates.
+    // positive plane.altitude_error_cm means too low
+    const float altitude_error = plane.SpdHgt_Controller->get_altitude_error();
+    is_stalled &= detection_single_check(Stall_Detect::BAD_ALT_10m, altitude_error > 10.0f);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_ALT_20m, altitude_error > 20.0f);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_ALT_40m, altitude_error > 40.0f);
+    is_stalled &= detection_single_check(Stall_Detect::BAD_ALT_60m, altitude_error > 60.0f);
+
+    return is_stalled;
+}
+
+bool Plane::StallState::detection_single_check(const Stall_Detect _bitmask, const bool check)
+{
+    const uint32_t bitmask = static_cast<uint32_t>(_bitmask);
+
+    if (check) {
+        detection_bitmask_if_everything_enabled |= bitmask;
+    } else {
+        detection_bitmask_if_everything_enabled &= !bitmask;
+    }
+
+    return (detection_bitmask & bitmask) != 0;
+}
+

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -50,6 +50,12 @@ public:
 	// return maximum climb rate
 	virtual float get_max_climbrate(void) const = 0;
 
+    // return maximum sink rate
+    virtual float get_max_sinkrate(void) const = 0;
+
+    // true when aircraft is trying but not able to maintain target altitude (indicative of motor failure or stall event)
+    virtual bool uncommanded_altitude_loss(void) const { return false; };
+
     // added to let SoaringController reset pitch integrator to zero
     virtual void reset_pitch_I(void) = 0;
     
@@ -70,6 +76,9 @@ public:
 
     // set propulsion failed flag
     virtual void set_propulsion_failed_flag(bool propulsion_failed) = 0;
+
+    // get altitude error. Positive m if too low.
+    virtual float get_altitude_error(void) const = 0;
 
 	// add new controllers to this enum. Users can then
 	// select which controller to use by setting the

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -81,6 +81,16 @@ public:
         return _maxClimbRate;
     }
 
+    // return maximum sink rate
+    float get_max_sinkrate(void) const override {
+        return _maxSinkRate;
+    }
+
+    // true when in Bad descent condition caused by unachievable airspeed demand
+    bool uncommanded_altitude_loss(void) const override {
+        return _flags.badDescent;
+    }
+
     // added to let SoaringContoller reset pitch integrator to zero
     void reset_pitch_I(void) override {
         _integSEB_state = 0.0f;
@@ -131,6 +141,10 @@ public:
     void reset(void) override {
         _need_reset = true;
     }
+
+    float get_altitude_error(void) const override {
+        return _hgt_dem_adj - _height;
+    };
 
     // this supports the TECS_* user settable parameters
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -73,6 +73,22 @@ void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)
     va_end(arg_list);
 }
 
+// same as send_text() but will accept a reference to a uint32 timestamp reference that it will use to rate-limit the output.
+// Any attempts to send faster will be dropped. Useful when debugging high-rate loops or events that may cause spurious repeat spam
+void GCS::send_text_rate_limited(MAV_SEVERITY severity, const uint32_t interval_ms, uint32_t &ref_to_timetime_ms, const char *fmt, ...)
+{
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - ref_to_timetime_ms < interval_ms) {
+        return;
+    }
+    ref_to_timetime_ms = now_ms;
+
+    va_list arg_list;
+    va_start(arg_list, fmt);
+    send_textv(severity, fmt, arg_list);
+    va_end(arg_list);
+}
+
 void GCS::send_to_active_channels(uint32_t msgid, const char *pkt)
 {
     const mavlink_msg_entry_t *entry = mavlink_get_msg_entry(msgid);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -890,6 +890,7 @@ public:
     void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
     virtual void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t mask);
     uint8_t statustext_send_channel_mask() const;
+    void send_text_rate_limited(MAV_SEVERITY severity, const uint32_t interval_ms, uint32_t &ref_to_timetime_ms, const char *fmt, ...);
 
     virtual GCS_MAVLINK *chan(const uint8_t ofs) = 0;
     virtual const GCS_MAVLINK *chan(const uint8_t ofs) const = 0;


### PR DESCRIPTION
Stall Detection for Plane.. IT'S FINALLY HERE!!!!!
Closes https://github.com/ArduPilot/ardupilot/issues/2933

I have been flying this with amazingly good results. I've also created an automated stall-recovery that will come in a following PR that uses this to trigger it.

All the magic happens in stall_detection_algorithm(), everything else is boiler plate.
Idea:
- Constantly check various roll error, pitch error, alt errors and if they meet a user-defined threshold.
- if user-defined threshold check returns a boolean which is low-passed to become a probability. This is how the is_flying flag works.

This PR implements a completely passive system where, at worst, you'll get a GCS msg. Everything is just logged. (Following stall-recovery PR is the fun bit). And when I say "everything" is logged, I mean it logs what thresholds are currently being met regardless if they're enabled or not. This is useful to look back at your aircraft logs and see what is normal for your aircraft.

