### PR TITLE
Plane: check motors has init, AP_MotorsTri: only check for yaw servo on copter

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -77,6 +77,11 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
         ret = false;
     }
 
+    if (plane.quadplane.available() && !plane.quadplane.motors->initialised_ok()) {
+        check_failed(display_failure, "Quadplane: check motor setup");
+        ret = false;
+    }
+
     if (plane.quadplane.enabled() && plane.quadplane.available()) {
         // ensure controllers are OK with us arming:
         char failure_msg[50];

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -35,13 +35,14 @@ void AP_MotorsTri::init(motor_frame_class frame_class, motor_frame_type frame_ty
     motor_enabled[AP_MOTORS_MOT_2] = true;
     motor_enabled[AP_MOTORS_MOT_4] = true;
 
+#if !APM_BUILD_TYPE(APM_BUILD_ArduPlane) // Tilt Rotors do not need a yaw servo
     // find the yaw servo
-    _yaw_servo = SRV_Channels::get_channel_for(SRV_Channel::k_motor7, AP_MOTORS_CH_TRI_YAW);
-    if (!_yaw_servo) {
+    if (!SRV_Channels::get_channel_for(SRV_Channel::k_motor7, AP_MOTORS_CH_TRI_YAW)) {
         gcs().send_text(MAV_SEVERITY_ERROR, "MotorsTri: unable to setup yaw channel");
         // don't set initialised_ok
         return;
     }
+#endif
 
     // allow mapping of motor7
     add_motor_num(AP_MOTORS_CH_TRI_YAW);
@@ -67,7 +68,7 @@ void AP_MotorsTri::set_frame_class_and_type(motor_frame_class frame_class, motor
         _pitch_reversed = false;
     }
 
-    _flags.initialised_ok = (frame_class == MOTOR_FRAME_TRI);
+    _flags.initialised_ok = (frame_class == MOTOR_FRAME_TRI) && SRV_Channels::function_assigned(SRV_Channel::k_motor7);
 }
 
 // set update rate to motors - a value in hertz

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -63,7 +63,6 @@ protected:
     
     // parameters
 
-    SRV_Channel     *_yaw_servo; // yaw output channel
     float           _pivot_angle;                       // Angle of yaw pivot
     float           _thrust_right;
     float           _thrust_rear;


### PR DESCRIPTION
Tracking down a [strange observation](https://discuss.ardupilot.org/t/vtol-reversed-trirotor-tilt-rotors/60922/35?u=iampete) from Paolo on the forum.

Was extremely surprised to find that Quadplane does not check if AP_Motors has init. Paolo should have been hitting a pre-arm check because Tricopter could not find a tail servo.

In actual fact we don't need a tail servo on plane because we can do yaw with the left and right tilt. So I have removed the yaw servo check (for plane) that was causing the original issue.