### PR TITLE
AP_ADSB: set Sagetech for 2MB only

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -32,6 +32,10 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
 
+#ifndef ADSB_SAGETECH_ENABLED
+    #define ADSB_SAGETECH_ENABLED !HAL_MINIMIZE_FEATURES
+#endif
+
 
 //#define ADSB_STATIC_CALLSIGN            "APM1234"  // 8 ASCII chars of a Callsign. This can be overwritten by MAVLink msg UAVIONIX_ADSB_OUT_CFG
 
@@ -182,9 +186,12 @@ void AP_ADSB::hw_init(void)
         return;
     }
 
+#if ADSB_SAGETECH_ENABLED
     if (AP_ADSB_Sagetech::detect()) {
         backend = new AP_ADSB_Sagetech(*this);
-    } else {
+    } else
+#endif
+    {
         backend = new AP_ADSB_MAVLink(*this);
     }
 


### PR DESCRIPTION
This sets the Sagetech ADSB driver to be for 2MB boards only.

Build directory: /mnt/c/Users/magic/Documents/GitHub/ardupilot/build/fmuv2
Target         Text    Data  BSS     Total
.--------------------------------------------
bin/arduplane  975852  1172  195636  1172660
vs
bin/arduplane  972548  1172  195636  1169356


Saves 3304 bytes of Flash.
