### PR TITLE
Copter: add EKF failsafe notify tones

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -191,6 +191,10 @@ void Copter::failsafe_ekf_event()
             set_mode_land_with_pause(ModeReason::EKF_FAILSAFE);
             break;
     }
+
+    // set true if ekf action is triggered
+    AP_Notify::flags.failsafe_ekf = true;
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "EKF Failsafe: changed to %s Mode", flightmode->name());
 }
 
 // failsafe_ekf_off_event - actions to take when EKF failsafe is cleared
@@ -202,6 +206,10 @@ void Copter::failsafe_ekf_off_event(void)
     }
 
     failsafe.ekf = false;
+    if (AP_Notify::flags.failsafe_ekf) {
+        AP_Notify::flags.failsafe_ekf = false;
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "EKF Failsafe Cleared");
+    }
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV, LogErrorCode::FAILSAFE_RESOLVED);
 }
 

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -90,6 +90,7 @@ public:
         bool failsafe_radio;      // true if radio failsafe
         bool failsafe_battery;    // true if battery failsafe
         bool failsafe_gcs;        // true if GCS failsafe
+        bool failsafe_ekf;        // true if ekf failsafe
         bool parachute_release;   // true if parachute is being released
         bool ekf_bad;             // true if ekf is reporting problems
         bool autopilot_mode;      // true if vehicle is in an autopilot flight mode (only used by OreoLEDs)

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -96,6 +96,8 @@ const AP_ToneAlarm::Tone AP_ToneAlarm::_tones[] {
     { "MFT240L8O4aO5dcO4aO5dcO4aO5dcL16dcdcdcdc", false },
 #define AP_NOTIFY_TONE_NO_SDCARD 30
     { "MNBGG", false },
+#define AP_NOTIFY_TONE_EKF_ALERT 31
+    { "MBNT255>A#8A#8A#8A#8P8A#8A#8A#8A#8P8A#8A#8A#8A#8P8A#8A#8A#8A#8", true },
 };
 
 bool AP_ToneAlarm::init()
@@ -430,6 +432,14 @@ void AP_ToneAlarm::update()
     if (AP_Notify::events.tune_error) {
         play_tone(AP_NOTIFY_TONE_TUNING_ERROR);
         AP_Notify::events.tune_error = 0;
+    }
+
+    // notify the user when ekf failsafe is triggered
+    if (flags.failsafe_ekf != AP_Notify::flags.failsafe_ekf) {
+        flags.failsafe_ekf = AP_Notify::flags.failsafe_ekf;
+        if (flags.failsafe_ekf) {
+            play_tone(AP_NOTIFY_TONE_EKF_ALERT);
+        }
     }
 }
 

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -59,6 +59,7 @@ private:
         uint16_t pre_arm_check         : 1;    // 0 = failing checks, 1 = passed
         uint16_t failsafe_radio        : 1;    // 1 if radio failsafe
         uint16_t failsafe_gcs          : 1;    // 1 if gcs failsafe
+        uint16_t failsafe_ekf          : 1;    // 1 if ekf failsafe
         uint16_t vehicle_lost          : 1;    // 1 if lost copter tone requested
         uint16_t compass_cal_running   : 1;    // 1 if compass calibration is running
         uint16_t waiting_for_throw     : 1;    // 1 if waiting for copter throw launch


### PR DESCRIPTION
When EKF failsafe was triggered, some users were unaware that it was switched to LAND.
They feel that the copter suddenly become unstable and descend.
I think ToneAlarm makes the user aware the failsafe easily.

I tested this in Copter using CubeBlack without propellers.
If EKF failsafe is triggered, activates buzzer.
After disarmed, stop the buzzer.

If we need same functionality in other vehicles, I can add it.