### PR TITLE
AP_Logger: fix description of BAT.Res

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1448,7 +1448,7 @@ struct PACKED log_PSC {
 // @Field: CurrTot: current * time
 // @Field: EnrgTot: energy this battery has produced
 // @Field: Temp: measured temperature
-// @Field: Res: estimated temperature resistance
+// @Field: Res: estimated battery resistance
 
 // @LoggerMessage: BCL
 // @Description: Battery cell voltage information


### PR DESCRIPTION
would "internal resistance" be more appropriate than "battery resistance"?