### PR TITLE
Copter: Check the validity of the conditional values first.

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -154,7 +154,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         // failsafe parameter checks
         if (copter.g.failsafe_throttle) {
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
-            if (copter.channel_throttle->get_radio_min() <= copter.g.failsafe_throttle_value+10 || copter.g.failsafe_throttle_value < 910) {
+            if (copter.g.failsafe_throttle_value < 910 || copter.channel_throttle->get_radio_min() <= copter.g.failsafe_throttle_value+10) {
                 check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check FS_THR_VALUE");
                 return false;
             }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -244,7 +244,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FS_THR_VALUE
     // @DisplayName: Throttle Failsafe Value
     // @Description: The PWM level in microseconds on channel 3 below which throttle failsafe triggers
-    // @Range: 925 1100
+    // @Range: 910 1100
     // @Units: PWM
     // @Increment: 1
     // @User: Standard


### PR DESCRIPTION
I first check the validity of the conditional values set in the config parameter.
I would check the input value if this conditional value is justified, in that order.
I found out that the minimum value of failsafe_throttle_value is 910.
I changed the range value of the config parameter.