### PR TITLE
HAL_ChibiOS: add a max quota of GPIO interrupts

### DIFF
--- a/libraries/AP_HAL/GPIO.h
+++ b/libraries/AP_HAL/GPIO.h
@@ -98,4 +98,7 @@ public:
 
     /* return true if USB cable is connected */
     virtual bool    usb_connected(void) = 0;
+
+    // optional timer tick
+    virtual void timer_tick(void) {};
 };

--- a/libraries/AP_HAL_ChibiOS/GPIO.h
+++ b/libraries/AP_HAL_ChibiOS/GPIO.h
@@ -61,6 +61,11 @@ public:
       forever. Return true on pin change, false on timeout
      */
     bool wait_pin(uint8_t pin, INTERRUPT_TRIGGER_TYPE mode, uint32_t timeout_us) override;
+
+#ifndef IOMCU_FW
+    // timer tick
+    void timer_tick(void) override;
+#endif
     
 private:
     bool _usb_connected;

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -19,6 +19,7 @@
 #include "AP_HAL_ChibiOS.h"
 #include "Scheduler.h"
 #include "Util.h"
+#include "GPIO.h"
 
 #include <AP_HAL_ChibiOS/UARTDriver.h>
 #include <AP_HAL_ChibiOS/AnalogIn.h>
@@ -415,6 +416,10 @@ void Scheduler::_monitor_thread(void *arg)
     }
 #endif // HAL_NO_LOGGING
 
+#ifndef IOMCU_FW
+    // setup GPIO interrupt quotas
+    hal.gpio->timer_tick();
+#endif
     }
 }
 #endif // HAL_NO_MONITOR_THREAD

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -55,6 +55,7 @@ void AP_InternalError::errors_as_string(uint8_t *buffer, const uint16_t len) con
         "bad_rotation",
         "stack_ovrflw",  // stack_overflow
         "imu_reset",  // imu_reset
+        "gpio_isr",
     };
 
     static_assert((1U<<(ARRAY_SIZE(error_bit_descriptions))) == uint32_t(AP_InternalError::error_t::__LAST__), "too few descriptions for bits");

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -62,7 +62,8 @@ public:
         bad_rotation                = (1U << 22),  //0x400000  4194304
         stack_overflow              = (1U << 23),  //0x800000  8388608
         imu_reset                   = (1U << 24),  //0x1000000 16777216
-        __LAST__                    = (1U << 25),  // used only for sanity check
+        gpio_isr                    = (1U << 25),  //0x2000000 33554432
+        __LAST__                    = (1U << 26),  // used only for sanity check
     };
 
     // if you've changed __LAST__ to be 32, then you will want to


### PR DESCRIPTION
This implements a max quota of GPIO interrupts per 100ms period to prevent high interrupt counts from consuming all CPU and causing a lockup. The limit is set as 10k interrupts per 0.1s period. That limit should be high enough for all reasonable uses of GPIO interrupt handlers while being below the level that causes significant CPU loads and flight issues

This addresses issue #15384
