### PR TITLE
AP_Scripting: allow scripts to control the gimbal mount

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -270,6 +270,9 @@ userdata mavlink_mission_item_int_t field frame uint8_t read write  0 UINT8_MAX
 userdata mavlink_mission_item_int_t field current uint8_t read write  0 UINT8_MAX
 -- userdata mavlink_mission_item_int_t field autocontinue uint8_t read write  0 UINT8_MAX
 
+include AP_Mount/AP_Mount.h
+singleton AP_Mount alias mount
+singleton AP_Mount method set_angle_targets void float -90 90 float -90 90 float -180 180
 
 include AP_RPM/AP_RPM.h
 singleton AP_RPM alias RPM


### PR DESCRIPTION
These changes allow lua scripting to control the gimbal mount, which is important for vehicles which use serial communication with the gimbal (e.g. Basecam gimbals):

Add lua scripting bindings for the method 
`      void set_angle_targets(uint8_t instance, float roll, float tilt, float pan);`
in line 121 in /libraries/AP_Mount/AP_Mount.h

To control the mount in lua use:
`       mount:set_angle_targets(roll, pitch, yaw)`

Prepared with the help of Peter Hall. https://discuss.ardupilot.org/t/is-it-possible-to-change-waypoint-speed-and-camera-mount-pitch/62101/5