### PR TITLE
AP_Common: Add header in AP_FWVersion to allow binary parser

### DIFF
--- a/Tools/scripts/firmware_version_decoder.py
+++ b/Tools/scripts/firmware_version_decoder.py
@@ -1,0 +1,231 @@
+import enum
+import io
+import sys
+import struct
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from typing import Any
+
+
+class FirmwareVersionType(enum.Enum):
+    Dev = 0
+    Alpha = 64
+    Beta = 128
+    RC = 192
+    Official = 255
+    EnumEnd = 256
+
+
+class VehicleType(enum.Enum):
+    Rover = 1
+    ArduCopter = 2
+    ArduPlane = 3
+    AntennaTracker = 4
+    UNKNOWN = 5
+    Replay = 6
+    ArduSub = 7
+    iofirmware = 8
+    AP_Periph = 9
+
+
+class BoardType(enum.Enum):
+    SITL = 3
+    SMACCM = 4
+    PX4 = 5
+    LINUX = 7
+    VRBRAIN = 8
+    CHIBIOS = 10
+    F4LIGHT = 11
+    EMPTY = 99
+
+
+class BoardSubType(enum.Enum):
+    NONE = 65535
+
+    LINUX_NONE = 1000
+    LINUX_ERLEBOARD = 1001
+    LINUX_PXF = 1002
+    LINUX_NAVIO = 1003
+    LINUX_ZYNQ = 1004
+    LINUX_BBBMINI = 1005
+    LINUX_BEBOP = 1006
+    LINUX_ERLEBRAIN2 = 1009
+    LINUX_BH = 1010
+    LINUX_PXFMINI = 1012
+    LINUX_NAVIO2 = 1013
+    LINUX_DISCO = 1014
+    LINUX_AERO = 1015
+    LINUX_DARK = 1016
+    LINUX_BLUE = 1018
+    LINUX_OCPOC_ZYNQ = 1019
+    LINUX_EDGE = 1020
+    LINUX_RST_ZYNQ = 1021
+    LINUX_POCKET = 1022
+    LINUX_NAVIGATOR = 1023
+
+    CHIBIOS_SKYVIPER_F412 = 5000
+    CHIBIOS_FMUV3 = 5001
+    CHIBIOS_FMUV4 = 5002
+    CHIBIOS_GENERIC = 5009
+    CHIBIOS_FMUV5 = 5013
+    CHIBIOS_VRBRAIN_V51 = 5016
+    CHIBIOS_VRBRAIN_V52 = 5017
+    CHIBIOS_VRUBRAIN_V51 = 5018
+    CHIBIOS_VRCORE_V10 = 5019
+    CHIBIOS_VRBRAIN_V54 = 5020
+
+
+@dataclass
+class FWVersion:
+    header: int = 0x61706677766572FB
+    header_version: bytes = bytes([0, 0])
+    pointer_size: int = 0
+    vehicle_type: int = 0
+    board_type: int = 0
+    board_subtype: int = 0
+    major: int = 0
+    minor: int = 0
+    patch: int = 0
+    firmware_type: FirmwareVersionType = FirmwareVersionType.EnumEnd
+    os_software_version: int = 0
+    firmware_string: str = ""
+    firmware_hash_string: str = ""
+    middleware_name: str = ""
+    middleware_hash_string: str = ""
+    os_name: str = ""
+    os_hash_string: str = ""
+
+    def __str__(self):
+        header = self.header.to_bytes(8, byteorder="big")
+        header_version = self.header_version.to_bytes(2, byteorder="big")
+        firmware_day = self.os_software_version % 100
+        firmware_month = self.os_software_version % 10000 - firmware_day
+        firmware_year = self.os_software_version - firmware_month - firmware_day
+        firmware_month = int(firmware_month / 100)
+        firmware_year = int(firmware_year / 10000)
+        return f"""
+{self.__class__.__name__}:
+    header:
+        magic: {header[0:7].decode("utf-8")}
+        checksum: {hex(header[-1])}
+        version: {header_version[0]}.{header_version[1]}
+        pointer_size: {self.pointer_size}
+    firmware:
+        string: {self.firmware_string}
+        vehicle: {VehicleType(self.vehicle_type).name}
+        board: {BoardType(self.board_type).name}
+        board subtype: {BoardSubType(self.board_subtype).name}
+        hash: {self.firmware_hash_string}
+        version: {self.major}.{self.minor}.{self.patch}
+        type: {FirmwareVersionType(self.firmware_type).name}
+    os:
+        name: {self.os_name}
+        hash: {self.os_hash_string}
+        software_version: {firmware_day}/{firmware_month}/{firmware_year}
+    middleware:
+        name: {self.middleware_name}
+        hash: {self.middleware_hash_string}
+"""
+
+
+class Decoder:
+    def __init__(self) -> None:
+        self.bytesio = io.BytesIO()
+        self.fwversion = FWVersion()
+        self.byteorder = ""
+        self.pointer_size = 0
+
+    def unpack(self, struct_format: str) -> Any:
+        struct_format = f"{self.byteorder}{struct_format}"
+        size = struct.calcsize(struct_format)
+        return struct.unpack(struct_format, self.bytesio.read(size))[0]
+
+    def unpack_string_from_pointer(self) -> str:
+        pointer_format = "Q" if self.pointer_size == 8 else "I"
+        address = self.unpack(pointer_format)
+
+        # nullptr, return empty string
+        if address == 0:
+            return ""
+
+        current_address = self.bytesio.seek(0, io.SEEK_CUR)
+        self.bytesio.seek(address)
+        string = []
+        while True:
+            string += self.bytesio.read(1)
+            if string[-1] == 0:
+                string = string[0 : len(string) - 1]
+                break
+        self.bytesio.seek(current_address)
+        return bytes(string).decode("UTF-8")
+
+    @staticmethod
+    def locate_header(data: bytes, byteorder: str) -> int:
+        return data.find(struct.pack(f"{byteorder}Q", FWVersion.header))
+
+    def unpack_fwversion(self) -> None:
+        assert self.bytesio.read(8) == struct.pack(
+            f"{self.byteorder}Q", FWVersion.header
+        )
+
+        self.fwversion.header_version = self.unpack("H")
+        self.pointer_size = self.unpack("B")
+        self.fwversion.pointer_size = self.pointer_size
+        self.unpack("B")  # reserved
+        self.fwversion.vehicle_type = self.unpack("B")
+        self.fwversion.board_type = self.unpack("B")
+        self.fwversion.board_subtype = self.unpack("H")
+
+        self.fwversion.major = self.unpack("B")
+        self.fwversion.minor = self.unpack("B")
+        self.fwversion.patch = self.unpack("B")
+        self.fwversion.firmware_type = self.unpack("B")
+        self.fwversion.os_software_version = self.unpack("I")
+
+        self.fwversion.firmware_string = self.unpack_string_from_pointer()
+        self.fwversion.firmware_hash_string = self.unpack_string_from_pointer()
+        self.fwversion.middleware_name = self.unpack_string_from_pointer()
+        self.fwversion.middleware_hash_string = self.unpack_string_from_pointer()
+        self.fwversion.os_name = self.unpack_string_from_pointer()
+        self.fwversion.os_hash_string = self.unpack_string_from_pointer()
+
+    def process(self, filename) -> None:
+        with open(filename, "rb") as file:
+            data = file.read()
+
+        if not data:
+            raise RuntimeError("Failed to find FWVersion.")
+
+        # Detect endianness
+        for order in [">", "<"]:
+            position = Decoder.locate_header(data, order)
+            if position != -1:
+                self.byteorder = order
+                self.bytesio = io.BytesIO(data)
+                self.bytesio.seek(position)
+                break
+        else:
+            raise RuntimeError("Failed to find FWVersion.")
+
+        # Unpack struct and print it
+        self.unpack_fwversion()
+        print(self.fwversion)
+
+
+if __name__ == "__main__":
+    assert (
+        sys.version_info.major >= 3 and sys.version_info.minor >= 7
+    ), "Python version should be at least 3.7"
+
+    # Parse arguments
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-f",
+        dest="file",
+        required=True,
+        help="File that contains a valid ardupilot firmware.",
+    )
+    args = parser.parse_args()
+
+    decoder = Decoder()
+    decoder.process(args.file)

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -3,21 +3,35 @@
 #include <stdint.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-class AP_FWVersion {
+class PACKED AP_FWVersion {
 
 public:
+    /**
+     * @brief Struct to hold infomation about the software version struct
+     *
+     */
+    // First 7 MSBs are a start sequence, LSB is a checksum
+    const uint64_t header;
+    // MSB (major version breaks compatibility), LSB (minor version no compatibility break)
+    const uint16_t header_version;
+    // Pointer size to extract pointer values
+    const uint8_t pointer_size;
 
+    const uint8_t reserved; // padding
+    const uint8_t vehicle_type;
+    const uint8_t board_type;
+    const uint16_t board_subtype;
     const uint8_t major;
     const uint8_t minor;
     const uint8_t patch;
-    const FIRMWARE_VERSION_TYPE fw_type;
+    const uint8_t fw_type; /*FIRMWARE_VERSION_TYPE*/
+    const uint32_t os_sw_version;
     const char *fw_string;
     const char *fw_hash_str;
     const char *middleware_name;
     const char *middleware_hash_str;
     const char *os_name;
     const char *os_hash_str;
-    const uint32_t os_sw_version;
 
     static const AP_FWVersion &get_fwverz() { return fwver; }
 

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -21,12 +21,27 @@
 #endif
 
 #include <AP_Common/AP_FWVersion.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 const AP_FWVersion AP_FWVersion::fwver{
+    // Version header struct
+    .header = 0x61706677766572fb, // First 7 MSBs: "apfwver", LSB is the checksum of the previous string: 0xfb
+    .header_version = 0x0100U, // Major and minor version
+    .pointer_size = static_cast<uint8_t>(sizeof(void*)),
+    .reserved = 0,
+    .vehicle_type = static_cast<uint8_t>(APM_BUILD_DIRECTORY),
+    .board_type = static_cast<uint8_t>(CONFIG_HAL_BOARD),
+    .board_subtype = static_cast<uint16_t>(CONFIG_HAL_BOARD_SUBTYPE),
     .major = FW_MAJOR,
     .minor = FW_MINOR,
     .patch = FW_PATCH,
     .fw_type = FW_TYPE,
+#ifdef BUILD_DATE_YEAR
+    // encode build date in os_sw_version
+   .os_sw_version = (BUILD_DATE_YEAR*100*100) + (BUILD_DATE_MONTH*100) + BUILD_DATE_DAY,
+#else
+   .os_sw_version = 0,
+#endif
 #ifndef GIT_VERSION
     .fw_string = THISFIRMWARE,
     .fw_hash_str = "",
@@ -42,11 +57,5 @@ const AP_FWVersion AP_FWVersion::fwver{
 #else
     .os_name = nullptr,
     .os_hash_str = nullptr,
-#endif
-#ifdef BUILD_DATE_YEAR
-    // encode build date in os_sw_version
-   .os_sw_version = (BUILD_DATE_YEAR*100*100) + (BUILD_DATE_MONTH*100) + BUILD_DATE_DAY,
-#else
-   .os_sw_version = 0,
 #endif
 };

--- a/libraries/AP_Vehicle/AP_Vehicle_Type.h
+++ b/libraries/AP_Vehicle/AP_Vehicle_Type.h
@@ -29,12 +29,12 @@
 #define APM_BUILD_iofirmware     8
 #define APM_BUILD_AP_Periph      9
 
+#ifndef APM_BUILD_DIRECTORY
+#define APM_BUILD_DIRECTORY APM_BUILD_UNKNOWN
+#endif
+
 /*
   using this macro catches cases where we try to check vehicle type on
   build systems that don't support it
  */
-#ifdef APM_BUILD_DIRECTORY
 #define APM_BUILD_TYPE(type) ((type) == APM_BUILD_DIRECTORY)
-#else
-#define APM_BUILD_TYPE(type) ((type) == APM_BUILD_UNKNOWN)
-#endif

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -1,20 +1,16 @@
 #include "GCS.h"
 #include <AP_Common/AP_FWVersion.h>
 
-const AP_FWVersion AP_FWVersion::fwver
-{
-    major: 3,
-    minor: 1,
-    patch: 4,
-    fw_type: FIRMWARE_VERSION_TYPE_DEV,
-    fw_string: "Dummy GCS",
-    fw_hash_str: "",
-    middleware_name: "",
-    middleware_hash_str: "",
-    os_name: "",
-    os_hash_str: "",
-    os_sw_version: 0
-};
+#define THISFIRMWARE "GCSDummy V3.1.4-dev"
+
+#define FW_MAJOR 3
+#define FW_MINOR 1
+#define FW_PATCH 4
+#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
+
+#define FORCE_VERSION_H_INCLUDE
+#include <AP_Common/AP_FWVersionDefine.h>
+#undef FORCE_VERSION_H_INCLUDE
 
 const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] {};
 


### PR DESCRIPTION
This patch allows ArduPilot binaries to be identified without the necessity of any outside encapsulation (such as `apj`) or running the binary. 
In other words, this patch tries to answer the following question: "Given an ArduPilot linux binary, how do you *safely* tell which version, board and vehicle it was built for ?"

Helps #15370 

- Add an `uint64_t` header to allow easy detection of struct in ArduPilot binaries
- Add an `uint16_t` version for the struct
    - MSB is for major release, compatibility break
    - LSB for minor version, no compatibility break
- Add pointer size variable to allow decode of pointers
- Add vehicle type information
- Add board type and subtype to allow hardware identification
- Set type of fw_type to `uint8_t` since enum is declared as int but exist inside `uint8_t` space
- Organize struct to be packed inside 32/64bits system
