### PR TITLE
AP_Frsky_Telem: lua scripting support

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort.cpp
@@ -9,6 +9,8 @@
 
 #include <string.h>
 
+AP_Frsky_SPort *AP_Frsky_SPort::singleton;
+
 /*
  * send telemetry data
  * for FrSky SPort protocol (X-receivers)
@@ -123,6 +125,16 @@ void AP_Frsky_SPort::send(void)
                 }
                 if (++_SPort.various_call > 1) {
                     _SPort.various_call = 0;
+                }
+                break;
+            default:
+                {
+                    // respond to custom user data polling
+                    WITH_SEMAPHORE(_sport_push_buffer.sem);
+                    if (_sport_push_buffer.pending && readbyte == _sport_push_buffer.packet.sensor) {
+                        send_sport_frame(_sport_push_buffer.packet.frame, _sport_push_buffer.packet.appid, _sport_push_buffer.packet.data);
+                        _sport_push_buffer.pending = false;
+                    }
                 }
                 break;
             }
@@ -343,3 +355,93 @@ uint8_t AP_Frsky_SPort::calc_sensor_id(const uint8_t physical_id)
     result += (BIT(physical_id, 0) ^ BIT(physical_id, 2) ^ BIT(physical_id, 4)) << 7;
     return result;
 }
+
+/*
+ * prepare value for transmission through FrSky link
+ * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
+ */
+uint16_t AP_Frsky_SPort::prep_number(int32_t number, uint8_t digits, uint8_t power)
+{
+    uint16_t res = 0;
+    uint32_t abs_number = abs(number);
+
+    if ((digits == 2) && (power == 1)) { // number encoded on 8 bits: 7 bits for digits + 1 for 10^power
+        if (abs_number < 100) {
+            res = abs_number<<1;
+        } else if (abs_number < 1270) {
+            res = ((uint8_t)roundf(abs_number * 0.1f)<<1)|0x1;
+        } else { // transmit max possible value (0x7F x 10^1 = 1270)
+            res = 0xFF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<8;
+        }
+    } else if ((digits == 2) && (power == 2)) { // number encoded on 9 bits: 7 bits for digits + 2 for 10^power
+        if (abs_number < 100) {
+            res = abs_number<<2;
+        } else if (abs_number < 1000) {
+            res = ((uint8_t)roundf(abs_number * 0.1f)<<2)|0x1;
+        } else if (abs_number < 10000) {
+            res = ((uint8_t)roundf(abs_number * 0.01f)<<2)|0x2;
+        } else if (abs_number < 127000) {
+            res = ((uint8_t)roundf(abs_number * 0.001f)<<2)|0x3;
+        } else { // transmit max possible value (0x7F x 10^3 = 127000)
+            res = 0x1FF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<9;
+        }
+    } else if ((digits == 3) && (power == 1)) { // number encoded on 11 bits: 10 bits for digits + 1 for 10^power
+        if (abs_number < 1000) {
+            res = abs_number<<1;
+        } else if (abs_number < 10240) {
+            res = ((uint16_t)roundf(abs_number * 0.1f)<<1)|0x1;
+        } else { // transmit max possible value (0x3FF x 10^1 = 10240)
+            res = 0x7FF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<11;
+        }
+    } else if ((digits == 3) && (power == 2)) { // number encoded on 12 bits: 10 bits for digits + 2 for 10^power
+        if (abs_number < 1000) {
+            res = abs_number<<2;
+        } else if (abs_number < 10000) {
+            res = ((uint16_t)roundf(abs_number * 0.1f)<<2)|0x1;
+        } else if (abs_number < 100000) {
+            res = ((uint16_t)roundf(abs_number * 0.01f)<<2)|0x2;
+        } else if (abs_number < 1024000) {
+            res = ((uint16_t)roundf(abs_number * 0.001f)<<2)|0x3;
+        } else { // transmit max possible value (0x3FF x 10^3 = 127000)
+            res = 0xFFF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<12;
+        }
+    }
+    return res;
+}
+
+/*
+ * Push user data down the telemetry link by responding to sensor polling (sport)
+ * or by using dedicated slots in the scheduler (fport)
+ * for SPort and FPort protocols (X-receivers)
+ */
+bool AP_Frsky_SPort::sport_telemetry_push(uint8_t sensor, uint8_t frame, uint16_t appid, int32_t data)
+{
+    WITH_SEMAPHORE(_sport_push_buffer.sem);
+    if (_sport_push_buffer.pending) {
+        return false;
+    }
+    _sport_push_buffer.packet.sensor = sensor;
+    _sport_push_buffer.packet.frame = frame;
+    _sport_push_buffer.packet.appid = appid;
+    _sport_push_buffer.packet.data = static_cast<uint32_t>(data);
+    _sport_push_buffer.pending = true;
+    return true;
+}
+
+namespace AP {
+    AP_Frsky_SPort *frsky_sport() {
+        return AP_Frsky_SPort::get_singleton();
+    }
+};

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
@@ -7,9 +7,23 @@ class AP_Frsky_SPort : public AP_Frsky_Backend
 
 public:
 
-    using AP_Frsky_Backend::AP_Frsky_Backend;
+    AP_Frsky_SPort(AP_HAL::UARTDriver *port) : AP_Frsky_Backend(port) {
+        singleton = this;
+    }
+
+    /* Do not allow copies */
+    AP_Frsky_SPort(const AP_Frsky_SPort &other) = delete;
+    AP_Frsky_SPort &operator=(const AP_Frsky_SPort&) = delete;
 
     void send() override;
+    // send an sport packet by responding to the specified polled sensor
+    bool sport_telemetry_push(const uint8_t sensor, const uint8_t frame, const uint16_t appid, const int32_t data);
+    // utility method to pack numbers in a compact size
+    uint16_t prep_number(int32_t const number, const uint8_t digits, const uint8_t power);
+    
+    static AP_Frsky_SPort *get_singleton(void) {
+        return singleton;
+    }
 
 protected:
 
@@ -22,8 +36,13 @@ protected:
     } _passthrough;
 
     uint32_t calc_gps_latlng(bool &send_latitude);
-
     static uint8_t calc_sensor_id(const uint8_t physical_id);
+
+    struct {
+        sport_packet_t packet;
+        bool pending = false;
+        HAL_Semaphore sem;
+    } _sport_push_buffer;
 
 private:
 
@@ -36,4 +55,11 @@ private:
         uint8_t vario_call;
         uint8_t various_call;
     } _SPort;
+
+    static AP_Frsky_SPort *singleton;
+
+};
+
+namespace AP {
+    AP_Frsky_SPort *frsky_sport();
 };

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
@@ -13,10 +13,7 @@
 #include "AP_Frsky_MAVlite_MAVliteToSPort.h"
 #include "AP_Frsky_MAVliteMsgHandler.h"
 
-#define FRSKY_WFQ_TIME_SLOT_MAX     12U
 #define SPORT_TX_PACKET_DUPLICATES          1   // number of duplicates packets we send (fport only)
-#else
-#define FRSKY_WFQ_TIME_SLOT_MAX     11U
 #endif
 
 class AP_Frsky_SPort_Passthrough : public AP_Frsky_SPort, public AP_RCTelemetry
@@ -25,7 +22,7 @@ public:
 
     AP_Frsky_SPort_Passthrough(AP_HAL::UARTDriver *port, bool use_external_data, AP_Frsky_Parameters *&frsky_parameters) :
         AP_Frsky_SPort(port),
-        AP_RCTelemetry(FRSKY_WFQ_TIME_SLOT_MAX),
+        AP_RCTelemetry(WFQ_LAST_ITEM),
         _use_external_data(use_external_data),
         _frsky_parameters(frsky_parameters)
     {
@@ -70,8 +67,9 @@ public:
         BATT_2 =        8,  // 0x5008 Battery 2 status
         BATT_1 =        9,  // 0x5008 Battery 1 status
         PARAM =         10, // 0x5007 parameters
+        UDATA =         11, // user data
 #if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
-        MAV =           11,  // mavlite
+        MAV =           12, // mavlite
 #endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
         WFQ_LAST_ITEM       // must be last
     };
@@ -151,7 +149,6 @@ private:
     uint8_t _paramID;
 
     uint32_t calc_gps_status(void);
-    uint16_t prep_number(int32_t number, uint8_t digits, uint8_t power);
 
     static AP_Frsky_SPort_Passthrough *singleton;
 };

--- a/libraries/AP_Scripting/examples/frsky_rpm.lua
+++ b/libraries/AP_Scripting/examples/frsky_rpm.lua
@@ -1,0 +1,56 @@
+--[[
+  Simple example that sends rpm info down the frsky link
+  it works with SPort using SERIAL_PROTOCOL=4,10 and with
+  FPort using SERIAL_PROTOCOL=23.
+  
+  We'll be using OpenTX genuine RPM data IDs (https://github.com/opentx/opentx/blob/2.3/radio/src/telemetry/frsky.h)
+  
+  RPM_FIRST_ID  0x0500
+  RPM_LAST_ID   0x050F
+  
+  and we'll be responding to unused sensor IDs.
+  This is a list of IDs we can't use:
+  - serial protocol 4 uses IDs 0,2,3 and 6
+  - serial protocol 10 uses ID 7,13,20,27
+  - serial protocol 23, no IDs used
+  
+  For this test we'll use sensor ID 4 (0xE4), 
+  Note: 4 is the index, 0xE4 is the actual ID
+--]]
+
+local loop_time = 250 -- number of ms between runs
+local sport_data_frame = 0x10
+local sensor_id = 0xE4
+--[[
+  we use the last 2 data ids so we hopefully don't interfere with pre existing sensors
+  this is a suggestion but if we know our RPM sensors are going to be
+  the only RPM sensors on the bus we can use 0x0500 and 0x0501
+--]]
+local data_ids = {
+  [0] = 0x050E,
+  [1] = 0x050F,
+}
+
+local function rpm_data_sent(instance, rpm)
+  gcs:send_text(7, string.format("rpm_data_sent() %d: %s", instance, tostring(rpm)))
+end
+
+local function send_rpm_data(instance, callback)
+  local rpm = RPM:get_rpm(instance)
+  gcs:send_text(7,string.format("send_rpm_data() %d, %s", instance, tostring(rpm)))
+  if rpm ~= nil then
+    if frsky_sport:sport_telemetry_push(sensor_id, sport_data_frame, data_ids[instance], rpm) then
+      callback(instance, rpm)
+    end
+  end
+end
+
+local rpm_idx = 0
+
+function update()
+    send_rpm_data(rpm_idx, rpm_data_sent)
+    rpm_idx = (rpm_idx+1)%2
+    return update, loop_time
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/examples/frsky_wp.lua
+++ b/libraries/AP_Scripting/examples/frsky_wp.lua
@@ -1,0 +1,113 @@
+--[[
+  This example adds a new passthrough packet type for waypoints.
+  Waypoint data is packet into 32bits and sent down the frsky bus with a DIY appid of 0x5009.
+
+  - 10 bits for current waypoint index, max 1023
+  - 12 bits for the distance in meters encoded with AP_Frsky_SPort::prep_number(distance, 3, 2) max is 102.3Km
+  - 6 bits for xtrack error (5 bits + sign) encoded with prep_5bits
+  - 3 bits for bearing from COG with a 45° resolution
+
+  We'll be responding to an unused sensor ID
+
+  This is a list of IDs we can't use:
+  - serial protocol 4 uses IDs 0,2,3 and 6
+  - serial protocol 10 uses ID 7,13,20,27
+  - serial protocol 23, no IDs used
+
+  For this test we'll use sensor ID 17 (0x71),
+  Note: 17 is the index, 0x71 is the actual ID
+--]]
+
+local loop_time = 1000 -- number of ms between runs
+
+local WP_OFFSET_DISTANCE 	= 10
+local WP_OFFSET_BEARING 	= 29
+local WP_OFFSET_XTRACK 		= 22
+
+local WP_LIMIT_COUNT    = 0x3FF   -- 1023
+local WP_LIMIT_XTRACK   = 0x7F    -- 127m
+local WP_LIMIT_DISTANCE = 0x18F9C -- 102.3Km
+local WP_ARROW_COUNT    = 8       -- 8 possible directions
+
+local wp_bearing = 0
+local wp_index = 0
+local wp_distance = 0
+local wp_xtrack = 0
+
+function wrap_360(angle)
+    local res = angle % 360
+    if res < 0 then
+      res = res + 360
+    end
+    return res
+end
+
+function prep_5bits(num)
+    local res = 0
+    local abs_num = math.floor(math.abs(num) + 0.5)
+    if abs_num < 10 then
+      res = abs_num << 1
+    elseif abs_num < 150 then
+      res = ( math.floor((abs_num * 0.1)+0.5) << 1) | 0x1
+    else
+      res = 0x1F
+    end
+    if num < 0 then
+      res = res | 0x1 << 5
+    end
+    return res
+end
+
+function wp_pack(index, distance, bearing, xtrack)
+    local wp_dword = uint32_t()
+    wp_dword = math.min(index,WP_LIMIT_COUNT)
+    wp_dword = wp_dword | frsky_sport:prep_number(math.min(math.floor(distance+0.5),WP_LIMIT_DISTANCE),3,2) << WP_OFFSET_DISTANCE
+    wp_dword = wp_dword | prep_5bits(math.min(xtrack,WP_LIMIT_XTRACK)) << WP_OFFSET_XTRACK
+    if gps:status(0)  >= gps.GPS_OK_FIX_2D then
+      local cog = gps:ground_course(0)      -- deg
+      local angle = wrap_360(bearing - cog) -- deg
+      local interval = 360 / WP_ARROW_COUNT -- 45 deg
+      -- hint from OSD code to avoid unreliable bearing at small distances
+      if distance < 2 then
+        angle = 0
+      end
+      -- bearing expressed as offset from cog as multiple of 45° ( 8 sectors) encoded as 3bits
+      wp_dword = wp_dword | ((math.floor(((angle + interval/2) / interval)) % WP_ARROW_COUNT) & 0x7) << WP_OFFSET_BEARING
+    end
+
+    return wp_dword & 0xFFFFFFFF
+end
+
+function update_wp_info()
+  local index = mission:get_current_nav_index()
+  local distance = vehicle:get_wp_distance_m()
+  local bearing = vehicle:get_wp_bearing_deg()
+  local xtrack = vehicle:get_wp_crosstrack_error_m()
+
+  if index ~= nil and distance ~= nil and bearing ~= nil and xtrack ~= nil then
+    wp_index = index
+    wp_bearing = bearing
+    wp_distance = distance
+    wp_xtrack = xtrack
+    return true
+  end
+  return false
+end
+
+function update()
+    local gps_status = gps.status(0,0)
+
+    if not update_wp_info() then
+      return update, loop_time
+    end
+
+    local sensor_id = 0x71
+    local wp_dword = uint32_t()
+
+    wp_dword = wp_pack(wp_index, wp_distance, wp_bearing, wp_xtrack)
+    frsky_sport:sport_telemetry_push(sensor_id, 0x10, 0x5009, wp_dword)
+
+    return update, loop_time
+end
+
+return update() , 1000

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -261,7 +261,7 @@ singleton AP_Mission scheduler-semaphore
 singleton AP_Mission enum MISSION_STOPPED MISSION_RUNNING MISSION_COMPLETE
 singleton AP_Mission method state uint8_t
 singleton AP_Mission method get_current_nav_index uint16_t
-singleton AP_Mission method set_current_cmd boolean uint16_t 0 (ud->num_commands()-1) 
+singleton AP_Mission method set_current_cmd boolean uint16_t 0 (ud->num_commands()-1)
 singleton AP_Mission method get_prev_nav_cmd_id uint16_t
 singleton AP_Mission method get_current_nav_id uint16_t
 singleton AP_Mission method get_current_do_cmd_id uint16_t
@@ -294,7 +294,6 @@ include AP_Button/AP_Button.h
 singleton AP_Button alias button
 singleton AP_Button method get_button_state boolean uint8_t 1 AP_BUTTON_NUM_PINS
 
-
 include AP_Notify/ScriptingLED.h
 singleton ScriptingLED alias LED
 singleton ScriptingLED method get_rgb void uint8_t'Ref uint8_t'Ref uint8_t'Ref
@@ -305,7 +304,12 @@ singleton QuadPlane depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)
 singleton QuadPlane method in_vtol_mode boolean
 
 include AP_Motors/AP_MotorsMatrix.h
-singleton AP_MotorsMatrix depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter) 
+singleton AP_MotorsMatrix depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 singleton AP_MotorsMatrix alias MotorsMatrix
 singleton AP_MotorsMatrix method init boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
 singleton AP_MotorsMatrix method add_motor_raw void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
+
+include AP_Frsky_Telem/AP_Frsky_SPort.h
+singleton AP_Frsky_SPort alias frsky_sport
+singleton AP_Frsky_SPort method sport_telemetry_push boolean uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX uint16_t 0 UINT16_MAX int32_t -INT32_MAX INT32_MAX
+singleton AP_Frsky_SPort method prep_number uint16_t int32_t INT32_MIN INT32_MAX uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX


### PR DESCRIPTION
This adds support for sending telemetry data to OpenTX  from lua scripting for both sport and fport.

An example lua script is provided that shows how to send RPM data as "fake" sensors that would be discoverable by OpenTX just like real ones.

Note: not sure about using a semaphore for synchronization, I use a boolean to check if data is pending so atomic access to a boolean should be all I need.