### PR TITLE
AP_Common: Add missing const in AP_FWVersion variables

### DIFF
--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -7,10 +7,10 @@ class AP_FWVersion {
 
 public:
 
-    uint8_t major;
-    uint8_t minor;
-    uint8_t patch;
-    FIRMWARE_VERSION_TYPE fw_type;
+    const uint8_t major;
+    const uint8_t minor;
+    const uint8_t patch;
+    const FIRMWARE_VERSION_TYPE fw_type;
     const char *fw_string;
     const char *fw_hash_str;
     const char *middleware_name;


### PR DESCRIPTION
I've cherry-picked this out of @patrickelectric 's https://github.com/ArduPilot/ardupilot/pull/15415 as a good stand-alone fix.

Tested on a CubeBlack.
