### PR TITLE
Smalls fixs on building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ segv_*out
 /ArduSub/scripts/
 persistent.dat
 dumpstack_*out
+build.tmp.binaries/

--- a/Tools/ardupilotwaf/build_summary.py
+++ b/Tools/ardupilotwaf/build_summary.py
@@ -136,7 +136,7 @@ def _build_summary(bld):
             if not t:
                 continue
             n = t.outputs[0]
-            tg.build_summary['binary'] = n
+            tg.build_summary['binary'] = str(n)
 
         nodes.append(n)
         filtered_taskgens.append(tg)

--- a/Tools/scripts/build_binaries_history.py
+++ b/Tools/scripts/build_binaries_history.py
@@ -35,9 +35,10 @@ class BuildBinariesHistory():
         text = int(sizes[0])
         data = int(sizes[1])
         bss = int(sizes[2])
-        print("text=%u" % text)
-        print("data=%u" % data)
-        print("bss=%u" % bss)
+        self.progress("Binary size of %s:" % filepath)
+        self.progress("text=%u" % text)
+        self.progress("data=%u" % data)
+        self.progress("bss=%u" % bss)
         return (text, data, bss)
 
     def assure_db_present(self):


### PR DESCRIPTION
Put  build.tmp.binaries/  into gitignore list to not pollute everything
make binary a string in the build_summary. That allow to have a json : 
`[{"target": "bin/ardurover", "binary": "/home/khancyr/Workspace/ardupilot/build/sitl/bin/ardurover", "binary_path": "bin/ardurover", "size_text": 2749044, "size_data": 118691, "size_bss": 88448, "size_total": 2956183}]`

make size output more pretty on build_binaries_history.py, passing from 

```
Binary size of /ardupilot/build.tmp.binaries/binaries.build/airbotf4/bin/arducopter-heli:
text=883396
data=1116
bss=130036
```

to 
```
BBHIST: Binary size of /ardupilot/build.tmp.binaries/binaries.build/airbotf4/bin/arducopter-heli:
BBHIST: text=883396
BBHIST: data=1116
BBHIST: bss=130036
```
