### PR TITLE
Tools: Replay: Move from uint to uint32_t in MsgHandler

### DIFF
--- a/Tools/Replay/MsgHandler.cpp
+++ b/Tools/Replay/MsgHandler.cpp
@@ -179,7 +179,7 @@ bool MsgHandler::field_value(uint8_t *msg, const char *label, Vector3f &ret)
 }
 
 
-void MsgHandler::string_for_labels(char *buffer, uint bufferlen)
+void MsgHandler::string_for_labels(char *buffer, uint32_t bufferlen)
 {
     memset(buffer, '\0', bufferlen);
     bufferlen--;

--- a/Tools/Replay/MsgHandler.h
+++ b/Tools/Replay/MsgHandler.h
@@ -19,7 +19,7 @@ public:
     MsgHandler(const struct log_Format &f);
 
     // retrieve a comma-separated list of all labels
-    void string_for_labels(char *buffer, uint bufferlen);
+    void string_for_labels(char *buffer, uint32_t bufferlen);
 
     // field_value - retrieve the value of a field from the supplied message
     // these return false if the field was not found


### PR DESCRIPTION
uint is not a fundamental type and does not exist under cstdint

cherry-picked from: https://github.com/ArduPilot/ardupilot/pull/15415

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>