### PR TITLE
Copter: Add AUTO_OPTIONS and support arming and throttle bypass

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -976,6 +976,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_GROUPINFO("ACRO_OPTIONS", 39, ParametersG2, acro_options, 0),
 #endif
 
+#if MODE_AUTO_ENABLED == ENABLED
+    // @Param: AUTO_OPTIONS
+    // @DisplayName: Auto mode options
+    // @Description: A range of options that can be applied to change auto mode behaviour. Allow arming allows the copter to be armed while in auto. Allow taking off without throttle to takeoff allows the copter to takeoff without having to raise the throttle.
+    // @Bitmask: 0:Allow arming,1:Allow taking off without throttle
+    // @User: Advanced
+    AP_GROUPINFO("AUTO_OPTIONS", 40, ParametersG2, auto_options, 0),
+#endif
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -619,6 +619,10 @@ public:
     AP_Int8 acro_options;
 #endif
 
+#if MODE_AUTO_ENABLED == ENABLED
+    AP_Int32 auto_options;
+#endif
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -353,7 +353,7 @@ public:
 
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
-    bool allows_arming(bool from_gcs) const override { return false; };
+    bool allows_arming(bool from_gcs) const override;
     bool is_autopilot() const override { return true; }
     bool in_guided_mode() const override { return mode() == Auto_NavGuided; }
 
@@ -404,6 +404,11 @@ protected:
     void run_autopilot() override;
 
 private:
+
+    enum class Options : int32_t {
+        AllowArming    = (1 << 0U),
+        BypassThrottle = (1 << 1U),
+    };
 
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);
@@ -515,6 +520,8 @@ private:
         float descend_start_altitude;
         float descend_max; // centimetres
     } nav_payload_place;
+
+    bool waiting_for_origin;
 };
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -43,13 +43,30 @@ bool ModeAuto::init(bool ignore_checks)
         // clear guided limits
         copter.mode_guided.limit_clear();
 
-        // start/resume the mission (based on MIS_RESTART parameter)
-        mission.start_or_resume();
+        // don't start the mission until we have an origin
+        Location loc;
+        if (copter.ahrs.get_origin(loc)) {
+            // start/resume the mission (based on MIS_RESTART parameter)
+            mission.start_or_resume();
+            waiting_for_origin = false;
+        } else {
+            waiting_for_origin = true;
+        }
+
+        // if the user doesn't want to raise the throttle we can set it automatically
+        if ((copter.g2.auto_options & (int32_t)Options::BypassThrottle) != 0) {
+            copter.set_auto_armed(true);
+        }
         return true;
     } else {
         return false;
     }
 }
+
+bool ModeAuto::allows_arming(bool from_gcs) const
+{
+    return (copter.g2.auto_options & (int32_t)Options::AllowArming) != 0;
+};
 
 // auto_run - runs the auto controller
 //      should be called at 100hz or more
@@ -592,7 +609,16 @@ bool ModeAuto::get_wp(Location& destination)
 // update mission
 void ModeAuto::run_autopilot()
 {
-    mission.update();
+    Location loc;
+    if (waiting_for_origin) {
+        if (copter.ahrs.get_origin(loc)) {
+            // start/resume the mission (based on MIS_RESTART parameter)
+            mission.start_or_resume();
+            waiting_for_origin = false;
+        }
+    } else {
+        mission.update();
+    }
 }
 
 /*******************************************************************************
@@ -714,6 +740,11 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 //      called by auto_run at 100hz or more
 void ModeAuto::takeoff_run()
 {
+    // if the user doesn't want to raise the throttle we can set it automatically
+    // note that this can defeat the disarm check on takeoff
+    if ((copter.g2.auto_options & (int32_t)Options::BypassThrottle) != 0) {
+        copter.set_auto_armed(true);
+    }
     auto_takeoff_run();
 }
 


### PR DESCRIPTION
This allows you to arm the copter without any extra GCS commands while
in auto, and can be done from both the GCS, or the RC Tx. This is useful
for creating a simpler workflow.

This also allows you to set the auto_armed flag internally, which
bypasses the need to raise the throttle stick for the copter to start a
takeoff.

This exposed a problem where we would start running the controllers
before the EKF was at all initialized, if you switched into auto to
early. This now has a check that prevents us from running the mission
state machine until after the origin has been set. This was a suggestion
from @rmackay9.

When combined these options allow you to have the vehicle on the ground,
disarmed in auto with a takeoff waypoint loaded, then just arm the
aircraft and watch it takeoff. This is a feature we've had on quadplanes
for quite awhile now, and it has proven to be very nice for operators.

I've only SITL tested this thus far, I'll take it out for a real test either later this week, or early next week, but I wanted to give people a quick chance to look over it for anything to objectionable before I do that.