### PR TITLE
Plane: tail-sitter only change shown AHRS View once transition is complete, and log transmission state

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -123,7 +123,7 @@ void GCS_MAVLINK_Plane::send_attitude() const
     float p = ahrs.pitch - radians(plane.g.pitch_trim_cd*0.01f);
     float y = ahrs.yaw;
     
-    if (plane.quadplane.in_vtol_mode()) {
+    if (plane.quadplane.show_vtol_view()) {
         r = plane.quadplane.ahrs_view->roll;
         p = plane.quadplane.ahrs_view->pitch;
         y = plane.quadplane.ahrs_view->yaw;

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -375,8 +375,9 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: CRt: climb rate
 // @Field: TMix: transition throttle mix value
 // @Field: Sscl: speed scalar for tailsitter control surfaces
+// @Field: Trans: Transistion state
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
-      "QTUN", "Qffffffeccff", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl", "s----mmmnn--", "F----00000-0" },
+      "QTUN", "QffffffeccffB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl,Trans", "s----mmmnn---", "F----00000-0-" },
 
 // @LoggerMessage: AOA
 // @Description: Angle of attack and Side Slip Angle values

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -8,14 +8,7 @@ void Plane::Log_Write_Attitude(void)
     Vector3f targets;       // Package up the targets into a vector for commonality with Copter usage of Log_Wrote_Attitude
     targets.x = nav_roll_cd;
     targets.y = nav_pitch_cd;
-
-    if (quadplane.in_vtol_mode() || quadplane.in_assisted_flight()) {
-        // when VTOL active log the copter target yaw
-        targets.z = wrap_360_cd(quadplane.attitude_control->get_att_target_euler_cd().z);
-    } else {
-        //Plane does not have the concept of navyaw. This is a placeholder.
-        targets.z = 0;
-    }
+    targets.z = 0; //Plane does not have the concept of navyaw. This is a placeholder.
 
     if (quadplane.show_vtol_view()) {
         // we need the attitude targets from the AC_AttitudeControl controller, as they

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -17,7 +17,7 @@ void Plane::Log_Write_Attitude(void)
         targets.z = 0;
     }
 
-    if (quadplane.tailsitter_active() || quadplane.in_vtol_mode()) {
+    if (quadplane.show_vtol_view()) {
         // we need the attitude targets from the AC_AttitudeControl controller, as they
         // account for the acceleration limits.
         // Also, for bodyframe roll input types, _attitude_target_euler_angle is not maintained

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3380,3 +3380,23 @@ bool QuadPlane::in_vtol_land_sequence(void) const
 {
     return in_vtol_land_approach() || in_vtol_land_descent() || in_vtol_land_final();
 }
+
+// return true if we should show VTOL view
+bool QuadPlane::show_vtol_view() const
+{
+    bool show_vtol = in_vtol_mode();
+
+    if (is_tailsitter() && hal.util->get_soft_armed()) {
+        if (show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_VTOL)) {
+            // in a vtol mode but still transitioning from forward flight
+            return false;
+        }
+
+        if (!show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_FW)) {
+            // not in VTOL mode but still transitioning from VTOL
+            return true;
+        }
+    }
+
+    return show_vtol;
+}

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2941,6 +2941,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
         climb_rate          : int16_t(inertial_nav.get_velocity_z()),
         throttle_mix        : attitude_control->get_throttle_mix(),
         speed_scaler        : last_spd_scaler,
+        transition_state    : static_cast<uint8_t>(transition_state)
     };
     plane.logger.WriteBlock(&pkt, sizeof(pkt));
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -159,6 +159,7 @@ public:
         int16_t  climb_rate;
         float    throttle_mix;
         float    speed_scaler;
+        uint8_t  transition_state;
     };
 
     MAV_TYPE get_mav_type(void) const;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -95,6 +95,7 @@ public:
     bool in_vtol_mode(void) const;
     bool in_vtol_posvel_mode(void) const;
     void update_throttle_hover();
+    bool show_vtol_view() const;
 
     // vtol help for is_flying()
     bool is_flying(void);


### PR DESCRIPTION
Currently the ATT log switched on mode change, this mean that you get a inaccurate log due to Euler angles at 90 deg. 
![ATT before](https://user-images.githubusercontent.com/33176108/94316953-38f81a00-ff7d-11ea-8d27-39aa1c892f74.png)

This chances to switch when the transition is complete, by default this is at 45 deg (or after a timeout). This avoids any euler angle funny business (and looks neater)
![image](https://user-images.githubusercontent.com/33176108/94317482-58dc0d80-ff7e-11ea-9a3b-7330f2f35f5a.png)
![image](https://user-images.githubusercontent.com/33176108/94317507-68f3ed00-ff7e-11ea-9ba6-aadfc7e13888.png)

This also makes the same change for the attitude reported over MAVLink, this takes a little more getting used to But is, I think, a more intuitive way to understand what is happening in the transition.

This also adds logging of the transmission state to the QTUN message. This is usefull for AUTO mode where the it is much less clear what is going on.

![image](https://user-images.githubusercontent.com/33176108/94317376-13b7db80-ff7e-11ea-9627-a025cb180ee9.png)

