### PR TITLE
Plane: fixed bug in RC_Channel::has_valid_input

### DIFF
--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -18,7 +18,7 @@ int8_t RC_Channels_Plane::flight_mode_channel_number() const
 
 bool RC_Channels_Plane::has_valid_input() const
 {
-    if (plane.failsafe.rc_failsafe) {
+    if (plane.rc_failsafe_active() || plane.failsafe.rc_failsafe) {
         return false;
     }
     if (plane.failsafe.throttle_counter != 0) {


### PR DESCRIPTION
needs to go false when no RCIN and THR_FAILSAFE=2. This prevents ICE
library from using RC input