### PR TITLE
Scripting: added RCIN valid API, and force arm API

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -86,6 +86,7 @@ public:
     // these functions should not be used by Copter which holds the armed state in the motors library
     Required arming_required();
     virtual bool arm(AP_Arming::Method method, bool do_arming_checks=true);
+    virtual bool arm_force(AP_Arming::Method method) { return arm(method, false); }
     virtual bool disarm(AP_Arming::Method method);
     bool is_armed();
 

--- a/libraries/AP_Scripting/examples/RCIN_test.lua
+++ b/libraries/AP_Scripting/examples/RCIN_test.lua
@@ -8,6 +8,9 @@ function update()
   pwm2 = rc:get_pwm(2)
   pwm3 = rc:get_pwm(3)
   pwm4 = rc:get_pwm(4)
+  if not rc:has_valid_input() then
+     gcs:send_text(0, "RCIN INVALID")
+  end
   gcs:send_text(0, "RCIN 1:" .. tostring(pwm1) .. " 2:" .. tostring(pwm2).. " 3:" .. tostring(pwm3).. " 4:" .. tostring(pwm4))
 
   -- read normalized input from designated scripting RCx_OPTION

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -214,6 +214,7 @@ include RC_Channel/RC_Channel.h
 singleton RC_Channels alias rc
 singleton RC_Channels method get_pwm boolean uint8_t 1 NUM_RC_CHANNELS uint16_t'Null
 singleton RC_Channels method find_channel_for_option RC_Channel RC_Channel::AUX_FUNC'enum 0 UINT16_MAX
+singleton RC_Channels method has_valid_input boolean
 
 include AP_SerialManager/AP_SerialManager.h
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -47,6 +47,7 @@ singleton AP_Arming alias arming
 singleton AP_Arming method disarm boolean AP_Arming::Method::SCRIPTING'literal
 singleton AP_Arming method is_armed boolean
 singleton AP_Arming method arm boolean AP_Arming::Method::SCRIPTING'literal
+singleton AP_Arming method arm_force boolean AP_Arming::Method::SCRIPTING'literal
 singleton AP_Arming method get_aux_auth_id boolean uint8_t'Null
 singleton AP_Arming method set_aux_auth_passed void uint8_t 0 UINT8_MAX
 singleton AP_Arming method set_aux_auth_failed void uint8_t 0 UINT8_MAX string


### PR DESCRIPTION
This allows scripts to check if RC input is valid, so they don't use invalid data. Note that there is a narrow race in this - RC input could become invalid between the check and the call to read the channel. Not sure what we want to do about that.
It also adds a forced arm call for Lua. I have a use case where it is critical to be able to arm with no checks (a plane being dropped from another plane, if it doesn't arm then it will definitely crash)
