### PR TITLE
AP_Airspeed: remove bit 0 of OPTIONS

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -159,7 +159,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: Airspeed options bitmask
     // @Description: Bitmask of options to use with airspeed.
-    // @Bitmask: 0:Disable on sensor failure,1:Re-enable on sensor recovery
+    // @Bitmask: 1:Re-enable on sensor recovery
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS", 21, AP_Airspeed, _options, 0),
 #endif

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -138,7 +138,7 @@ public:
                             PITOT_TUBE_ORDER_AUTO     = 2 };
 
     enum OptionsMask {
-        ON_FAILURE_AHRS_WIND_MAX_DO_DISABLE                   = (1<<0),   // If set then use airspeed failure check
+        //ON_FAILURE_AHRS_WIND_MAX_DO_DISABLE (No longer used)= (1<<0),   // If set then use airspeed failure check
         ON_FAILURE_AHRS_WIND_MAX_RECOVERY_DO_REENABLE         = (1<<1),   // If set then automatically enable the airspeed sensor use when healthy again.
     };
 

--- a/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
@@ -61,7 +61,7 @@ void AP_Airspeed::check_sensor_ahrs_wind_max_failures(uint8_t i)
     static const float RE_ENABLE_PROB_THRESH_OK = 0.95f;
 
     // if "disable" option is allowed and sensor is enabled
-    if (param[i].use > 0 && (AP_Airspeed::OptionsMask::ON_FAILURE_AHRS_WIND_MAX_DO_DISABLE & _options)) {
+    if (param[i].use > 0) {
         // and is probably not healthy
         if (state[i].failures.health_probability < DISABLE_PROB_THRESH_CRIT) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Airspeed sensor %d failure. Disabling", i+1);


### PR DESCRIPTION
` 0:Disable on sensor failure` requires the user to have set `AHRS_WIND_MAX` this says `This sets the maximum allowable difference between ground speed and airspeed. This allows the plane to cope with a failing airspeed sensor. A value of zero means to use the airspeed as is.` That is wrong because in current master the user must also have set `ARSPD_OPTIONS = 1`. 

Basically there are two param to set to enable one thing, people set just `AHRS_WIND_MAX` and assume there good to go.

This is a change in behavior.

