### PR TITLE
Fix H7 FDCAN driver's filter configuration and other minor fixes

### DIFF
--- a/Tools/AP_Periph/wscript
+++ b/Tools/AP_Periph/wscript
@@ -4,7 +4,7 @@
 import fnmatch
 
 def build(bld):
-    targets = ['f103-*', 'f303-*', 'CUAV_GPS', 'ZubaxGNSS*', 'CubeOrange-periph']
+    targets = ['f103-*', 'f303-*', 'CUAV_GPS', 'ZubaxGNSS*', 'Cube*-periph']
     valid_target = False
     for t in targets:
         if fnmatch.fnmatch(bld.env.BOARD, t):

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -528,7 +528,6 @@ class chibios(Board):
             '-Wfatal-errors',
             '-Werror=uninitialized',
             '-Werror=init-self',
-            '-Wframe-larger-than=1024',
             '-Werror=unused-but-set-variable',
             '-Wno-missing-field-initializers',
             '-Wno-trigraphs',

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -147,24 +147,31 @@ void AP_CANManager::init()
         }
 
         // Initialise the interface we just allocated
-        if (hal.can[i] != nullptr) {
-            if (!hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::NormalMode)) {
-                log_text(AP_CANManager::LOG_ERROR, LOG_TAG, "Failed to initialise CAN Interface %d", i+1);
-                continue;
-            }
-        } else {
+        if (hal.can[i] == nullptr) {
             continue;
         }
         AP_HAL::CANIface* iface = hal.can[i];
+
+        // Find the driver type that we need to allocate and register this interface with
+        Driver_Type drv_type = _driver_type_cache[drv_num] = (Driver_Type) _drv_param[drv_num]._driver_type.get();
+        bool can_initialised = false;
         // Check if this interface need hooking up to slcan passthrough
         // instead of a driver
         if (_slcan_interface.init_passthrough(i)) {
             // we have slcan bridge setup pass that on as can iface
+            can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::NormalMode);
             iface = &_slcan_interface;
+        } else if(drv_type == Driver_Type_UAVCAN) {
+            // We do Message ID filtering when using UAVCAN without SLCAN
+            can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::FilteredMode);
+        } else {
+            can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::NormalMode);
         }
 
-        // Find the driver type that we need to allocate and register this interface with
-        Driver_Type drv_type = _driver_type_cache[drv_num] = (Driver_Type) _drv_param[drv_num]._driver_type.get();
+        if (!can_initialised) {
+            log_text(AP_CANManager::LOG_ERROR, LOG_TAG, "Failed to initialise CAN Interface %d", i+1);
+            continue;
+        }
 
         log_text(AP_CANManager::LOG_INFO, LOG_TAG, "CAN Interface %d initialized well", i + 1);
 
@@ -247,13 +254,19 @@ void AP_CANManager::init()
         if (_drivers[drv_num] == nullptr) {
             continue;
         }
-        if ((_slcan_interface.get_iface_num() >= HAL_NUM_CAN_IFACES ||
-            _slcan_interface.get_iface_num() < 0) ||
-            (_interfaces[_slcan_interface.get_iface_num()]._driver_number != drv_num + 1)) {
-            _drivers[drv_num]->init(drv_num, true);
-        } else {
-            _drivers[drv_num]->init(drv_num, false);
+        bool enable_filter = false;
+        for (uint8_t i = 0; i < HAL_NUM_CAN_IFACES; i++) {
+            if (_interfaces[i]._driver_number == (drv_num+1) &&
+                hal.can[i] != nullptr &&
+                hal.can[i]->get_operating_mode() == AP_HAL::CANIface::FilteredMode) {
+                // Don't worry we don't enable Filters for Normal Ifaces under the driver
+                // this is just to ensure we enable them for the ones we already decided on
+                enable_filter = true;
+                break;
+            }
         }
+
+        _drivers[drv_num]->init(drv_num, enable_filter);
     }
 }
 

--- a/libraries/AP_HAL/CANIface.h
+++ b/libraries/AP_HAL/CANIface.h
@@ -94,8 +94,11 @@ public:
     enum OperatingMode {
         PassThroughMode,
         NormalMode,
-        SilentMode
+        SilentMode,
+        FilteredMode
     };
+
+    OperatingMode get_operating_mode() { return mode_; }
 
     typedef uint16_t CanIOFlags;
     static const CanIOFlags Loopback = 1;
@@ -206,4 +209,7 @@ public:
 
     // return true if init was called and successful
     virtual bool is_initialized() const = 0;
+protected:
+    uint32_t bitrate_;
+    OperatingMode mode_;
 };

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -281,7 +281,7 @@ int16_t CANIface::send(const AP_HAL::CANFrame& frame, uint64_t tx_deadline,
                        CanIOFlags flags)
 {
     stats.tx_requests++;
-    if (frame.isErrorFrame() || frame.dlc > 8) {
+    if (frame.isErrorFrame() || frame.dlc > 8 || !initialised_) {
         stats.tx_rejected++;
         return -1;
     }
@@ -344,7 +344,7 @@ int16_t CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& out_timestamp_u
 {
     CriticalSectionLocker lock;
     CanRxItem rx_item;
-    if (!rx_queue_.pop(rx_item)) {
+    if (!rx_queue_.pop(rx_item) || !initialised_) {
         return 0;
     }
     out_frame    = rx_item.frame;
@@ -356,13 +356,13 @@ int16_t CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& out_timestamp_u
 bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
                                 uint16_t num_configs)
 {
-    // TODO: We have a fix in the works, this is a stop gap solution
-    // so as to not block users from using normal CAN on H7
-    return false;
-#if 0
     uint32_t num_extid = 0, num_stdid = 0;
     uint32_t total_available_list_size = MAX_FILTER_LIST_SIZE;
     uint32_t* filter_ptr;
+    if (initialised_ || mode_ != FilteredMode) {
+        // we are already initialised can't do anything here
+        return false;
+    }
     //count number of frames of each type
     for (uint8_t i = 0; i < num_configs; i++) {
         const CanFilterConfig* const cfg = filter_configs + i;
@@ -372,12 +372,7 @@ bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
             num_stdid++;
         }
     }
-
     CriticalSectionLocker lock;
-    can_->CCCR |= FDCAN_CCCR_INIT; // Request init
-    while ((can_->CCCR & FDCAN_CCCR_INIT) == 0) {}
-    can_->CCCR |= FDCAN_CCCR_CCE; //Enable Config change
-
     //Allocate Message RAM for Standard ID Filter List
     if (num_stdid == 0) { //No Frame with Standard ID is to be accepted
         can_->GFC |= 0x2; //Reject All Standard ID Frames
@@ -389,6 +384,7 @@ bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
         can_->GFC |= (0x3U << 4); //Reject non matching Standard frames
     } else {    //The List is too big, return fail
         can_->CCCR &= ~FDCAN_CCCR_INIT; // Leave init mode
+        while ((can_->CCCR & FDCAN_CCCR_INIT) == 1) {}
         return false;
     }
 
@@ -419,9 +415,10 @@ bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
         can_->XIDFC = (FDCANMessageRAMOffset_ << 2) | (num_extid << 16);
         MessageRam_.ExtendedFilterSA = SRAMCAN_BASE + (FDCANMessageRAMOffset_ * 4U);
         FDCANMessageRAMOffset_ += num_extid*2;
-        can_->GFC = (0x3U << 2); // Reject non matching Extended frames
+        can_->GFC |= (0x3U << 2); // Reject non matching Extended frames
     } else {    //The List is too big, return fail
         can_->CCCR &= ~FDCAN_CCCR_INIT; // Leave init mode
+        while ((can_->CCCR & FDCAN_CCCR_INIT) == 1) {}
         return false;
     }
 
@@ -436,8 +433,8 @@ bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
             if ((cfg->id & AP_HAL::CANFrame::FlagEFF) || !(cfg->mask & AP_HAL::CANFrame::FlagEFF)) {
                 id   = (cfg->id   & AP_HAL::CANFrame::MaskExtID);
                 mask = (cfg->mask & AP_HAL::CANFrame::MaskExtID);
-                filter_ptr[num_extid*2]       = 0x1U << 29 | id; // Classic CAN Filter
-                filter_ptr[num_extid*2 + 1]   = 0x2U << 30 | mask; //Store in Rx FIFO0 if filter matches
+                filter_ptr[num_extid*2]       = 0x1U << 29 | id; //Store in Rx FIFO0 if filter matches
+                filter_ptr[num_extid*2 + 1]   = 0x2U << 30 | mask; // Classic CAN Filter
                 num_extid++;
             }
         }
@@ -449,9 +446,11 @@ bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
         AP_HAL::panic("CANFDIface: Message RAM Overflow!");
     }
 
+    // Finally get out of Config Mode
     can_->CCCR &= ~FDCAN_CCCR_INIT; // Leave init mode
-    return 0;
-#endif
+    while ((can_->CCCR & FDCAN_CCCR_INIT) == 1) {}
+    initialised_ = true;
+    return true;
 }
 
 uint16_t CANIface::getNumFilters() const
@@ -474,6 +473,9 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
 #endif
     }
 
+
+    bitrate_ = bitrate;
+    mode_ = mode;
     //Only do it once
     //Doing it second time will reset the previously initialised bus
     if (!clock_init_) {
@@ -532,6 +534,7 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
 
     if (!computeTimings(bitrate, timings)) {
         can_->CCCR &= ~FDCAN_CCCR_INIT;
+        while ((can_->CCCR & FDCAN_CCCR_INIT) == 1) {}
         return false;
     }
     Debug("Timings: presc=%u sjw=%u bs1=%u bs2=%u\n",
@@ -557,7 +560,7 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
     can_->IE =  FDCAN_IE_TCE |  // Transmit Complete interrupt enable
                 FDCAN_IE_BOE |  // Bus off Error Interrupt enable
                 FDCAN_IE_RF0NE |  // RX FIFO 0 new message
-                FDCAN_IE_RF0FE |  // Rx FIFO 1 FIFO Full
+                FDCAN_IE_RF0FE |  // Rx FIFO 0 FIFO Full
                 FDCAN_IE_RF1NE |  // RX FIFO 1 new message
                 FDCAN_IE_RF1FE;   // Rx FIFO 1 FIFO Full
     can_->ILS = FDCAN_ILS_TCL | FDCAN_ILS_BOE;  //Set Line 1 for Transmit Complete Event Interrupt and Bus Off Interrupt
@@ -565,11 +568,15 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
     can_->TXBTIE = 0xFFFFFFFF;
     can_->ILE = 0x3;
 
-    //Leave Init
-    can_->CCCR &= ~FDCAN_CCCR_INIT; // Leave init mode
+    // If mode is Filtered then we finish the initialisation in configureFilter method
+    // otherwise we finish here
+    if (mode != FilteredMode) {
+        can_->CCCR &= ~FDCAN_CCCR_INIT; // Leave init mode
+        while ((can_->CCCR & FDCAN_CCCR_INIT) == 1) {}
 
-    //initialised
-    initialised_ = true;
+        //initialised
+        initialised_ = true;
+    }
     return true;
 }
 

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -366,6 +366,9 @@ int16_t CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& out_timestamp_u
 bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
                                 uint16_t num_configs)
 {
+    if (mode_ != FilteredMode) {
+        return false;
+    }
     if (num_configs <= NumFilters && filter_configs != nullptr) {
         CriticalSectionLocker lock;
 
@@ -779,6 +782,9 @@ bool CANIface::init(const uint32_t bitrate, const CANIface::OperatingMode mode)
         hal.can[self_index_] = this;
 #endif
     }
+
+    bitrate_ = bitrate;
+    mode_ = mode;
 
     if (can_ifaces[0] == nullptr) {
         can_ifaces[0] = new CANIface(0);

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef-bl.dat
@@ -1,0 +1,70 @@
+# hw definition file for processing by chibios_hwdef.py
+# for F4 bootloader
+
+# MCU class and specific type
+MCU STM32F4xx STM32F427xx
+
+# crystal frequency
+OSCILLATOR_HZ 24000000
+
+# board ID for firmware load
+APJ_BOARD_ID 1401
+
+FLASH_SIZE_KB 2048
+
+# setup build for a peripheral firmware
+env AP_PERIPH 1
+
+# bootloader is installed at zero offset
+FLASH_RESERVE_START_KB 0
+
+# the location where the bootloader will put the firmware
+# we use first 32k
+FLASH_BOOTLOADER_LOAD_KB 32
+
+define HAL_LED_ON 0
+
+# order of UARTs (and USB)
+SERIAL_ORDER OTG1 UART7
+
+# UART7 maps to uartF in the HAL (serial5 in SERIALn_ parameters).
+PE7 UART7_RX UART7
+PE8 UART7_TX UART7
+
+# Pin for PWM Voltage Selection
+PB4 PWM_VOLT_SEL OUTPUT HIGH
+
+PA11 OTG_FS_DM OTG1
+PA12 OTG_FS_DP OTG1
+
+PA13 JTMS-SWDIO SWD
+PA14 JTCK-SWCLK SWD
+
+define HAL_USE_EMPTY_STORAGE 1
+define HAL_STORAGE_SIZE 16384
+
+# Add CS pins to ensure they are high in bootloader
+PC1 MAG_CS CS
+PC2 MPU_CS CS
+PC13 GYRO_EXT_CS CS
+PC14 BARO_EXT_CS CS
+PC15 ACCEL_EXT_CS CS
+PD7 BARO_CS CS
+PE4 MPU_EXT_CS CS
+PD10 FRAM_CS CS SPEED_VERYLOW
+
+# the first CAN bus
+PD0 CAN1_RX CAN1
+PD1 CAN1_TX CAN1
+
+# This defines the pins for the 2nd CAN interface, if available.
+PB6 CAN2_TX CAN2
+PB12 CAN2_RX CAN2
+
+# reserve 256 bytes for comms between app and bootloader
+RAM_RESERVE_START 256
+
+# use DNA
+define HAL_CAN_DEFAULT_NODE_ID 0
+
+define CAN_APP_NODE_NAME "org.ardupilot.CubeBlack-periph"

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef.dat
@@ -1,0 +1,74 @@
+include ../CubeBlack/hwdef.dat
+
+undef COMPASS
+undef IOMCU_UART
+undef USART6
+undef ROMFS
+undef HAL_HAVE_SAFETY_SWITCH
+undef IMU
+undef HAL_CHIBIOS_ARCH_FMUV3
+undef BOOTLOADER_DEV_LIST
+undef HAL_OS_FATFS_IO
+undef SDIO
+undef FLASH_RESERVE_START_KB
+# the location where the bootloader will put the firmware
+# we use first 32k
+FLASH_RESERVE_START_KB 32
+
+
+# board ID for firmware load
+APJ_BOARD_ID 1401
+
+# setup build for a peripheral firmware
+env AP_PERIPH 1
+
+define PERIPH_FW TRUE
+
+define HAL_BUILD_AP_PERIPH
+
+define HAL_PERIPH_ENABLE_GPS
+define HAL_PERIPH_ENABLE_MAG
+define HAL_PERIPH_ENABLE_BARO
+
+# use the app descriptor needed by MissionPlanner for CAN upload
+env APP_DESCRIPTOR MissionPlanner
+
+# single GPS and compass for peripherals
+define GPS_MAX_RECEIVERS 1
+define GPS_MAX_INSTANCES 1
+define HAL_COMPASS_MAX_SENSORS 1
+
+define HAL_NO_GCS
+define HAL_NO_LOGGING
+define HAL_NO_MONITOR_THREAD
+
+define HAL_DISABLE_LOOP_DELAY
+
+define HAL_USE_RTC FALSE
+define DISABLE_SERIAL_ESC_COMM TRUE
+define NO_DATAFLASH TRUE
+
+define HAL_NO_RCIN_THREAD
+
+define HAL_BARO_ALLOW_INIT_NO_BARO
+
+define HAL_USE_ADC FALSE
+define STM32_ADC_USE_ADC1 FALSE
+define HAL_DISABLE_ADC_DRIVER TRUE
+
+define HAL_CAN_DEFAULT_NODE_ID 0
+
+define CAN_APP_NODE_NAME "org.ardupilot.CubeBlack-periph"
+
+# reserve 256 bytes for comms between app and bootloader
+RAM_RESERVE_START 256
+
+env DISABLE_SCRIPTING 1
+
+# use blue LED
+define HAL_GPIO_PIN_LED HAL_GPIO_PIN_FMU_LED_AMBER
+
+MAIN_STACK 0x2000
+PROCESS_STACK 0x6000
+
+define HAL_CAN_DRIVER_DEFAULT 1

--- a/libraries/AP_HAL_Linux/CANSocketIface.cpp
+++ b/libraries/AP_HAL_Linux/CANSocketIface.cpp
@@ -213,7 +213,7 @@ void CANIface::_poll(bool read, bool write)
 bool CANIface::configureFilters(const CanFilterConfig* const filter_configs,
                               const std::uint16_t num_configs)
 {
-    if (filter_configs == nullptr) {
+    if (filter_configs == nullptr || mode_ != FilteredMode) {
         return false;
     }
     _hw_filters_container.clear();
@@ -447,7 +447,8 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
     if (_initialized) {
         return _initialized;
     }
-
+    bitrate_ = bitrate;
+    mode_ = mode;
     // TODO: Add possibility change bitrate
     _fd = _openSocket(iface_name);
     Debug("Socket opened iface_name: %s fd: %d", iface_name, _fd);

--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -213,7 +213,7 @@ void CANIface::_poll(bool read, bool write)
 bool CANIface::configureFilters(const CanFilterConfig* const filter_configs,
                               const std::uint16_t num_configs)
 {
-    if (filter_configs == nullptr) {
+    if (filter_configs == nullptr || mode_ != FilteredMode) {
         return false;
     }
     _hw_filters_container.clear();
@@ -443,7 +443,8 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
 {
     char iface_name[16];
     sprintf(iface_name, "vcan%u", _self_index);
-
+    bitrate_ = bitrate;
+    mode_ = mode;
     if (_initialized) {
         return _initialized;
     }


### PR DESCRIPTION
Tested with and without SLCAN on both CubeBlack and CubeOrange.

The failure was happening when we were trying to put H7 FDCAN in init mode, this was a truly bizarre issue, and I wasn't able to find out why that was happening. As a workaround for cases where we enable filters I don't finish initialisation until configure Filter is called. That seems to fix the issue, and also tested that filter is working.

But still there is an unknown as to why we can't put FDCAN in init mode the second time.

testing:
 - [x] H7 ardupilot
 - [x] F7 ardupilot
 - [x] F4 ardupilot
 - [x] F3 AP_Periph
 - [x] F1 AP_Periph
 - [x] F4 AP_Periph
 - [x] H7 AP_Periph 