### PR TITLE
AP_OSD: get wind speed from wind vane on rover

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -215,7 +215,7 @@ private:
 #endif
 
     //helper functions
-    void draw_speed_vector(uint8_t x, uint8_t y, Vector2f v, int32_t yaw);
+    void draw_speed(uint8_t x, uint8_t y, float angle_rad, float magnitude);
     void draw_distance(uint8_t x, uint8_t y, float distance);
 
 #ifdef HAVE_AP_BLHELI_SUPPORT


### PR DESCRIPTION
This allows plotting of apparent wind from the wind vane on rover. 

Because its possible to have wind direction but not speed, there is a little funny business to get the arrow to draw with a short vector. There is a nice long comment explaining this.

![image](https://user-images.githubusercontent.com/33176108/94369429-8f7e6900-00e1-11eb-8ebd-372d17afd0cc.png)
