### PR TITLE
Plane: failsafes to require armed state to activate

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -307,7 +307,10 @@ void Plane::check_long_failsafe()
     uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if (failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    if (failsafe.state != FAILSAFE_LONG &&
+            failsafe.state != FAILSAFE_GCS &&
+            arming.is_armed() &&
+            flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
         uint32_t radio_timeout_ms = failsafe.last_valid_rc_ms;
         if (failsafe.state == FAILSAFE_SHORT) {
             // time is relative to when short failsafe enabled
@@ -354,6 +357,7 @@ void Plane::check_short_failsafe()
     // -------------------
     if (g.fs_action_short != FS_ACTION_SHORT_DISABLED &&
        failsafe.state == FAILSAFE_NONE &&
+       arming.is_armed() &&
        flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
         // The condition is checked and the flag rc_failsafe is set in radio.cpp
         if(failsafe.rc_failsafe) {


### PR DESCRIPTION
Current implementation allows any failsafe, specifically GCS and RC, to happen after you boot up and are just sitting on the ground.  This is troublesome if the RC transmitter is not yet powered up or the GCS is not yet connected or it. This PR adds a check for armed state before any failsafe can trigger. If you are in the sky while disarmed then a failsafe isn't going to save you anyway :)

A scenario that causes takeoff crashes and unsafe conditions for ground crew:
- Long failsafe occurs while doing ground checks before you takeoff.
- failsafe is configured to trigger RTL, you are no longer in whatever your "INITIAL_MODE" is.
- For the case of Plane with a DO_LAND_JUMP, you instead stay in AUTO but your mission index jumps to your landing.
- Now you "takeoff" and don't notice that your mission index has changed and now you're executing something else when you go to arm and launch.

