### PR TITLE
AP_NavEKF3: shorten buffer size send_text message length

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -166,7 +166,7 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
     if(!storedOutput.init(imu_buffer_length)) {
         return false;
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u buffs IMU=%u OBS=%u OF=%u EN:%u, dt=%.4f",
+    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u buffs IMU=%u OBS=%u OF=%u EN:%u dt=%.4f",
                     (unsigned)imu_index,
                     (unsigned)imu_buffer_length,
                     (unsigned)obs_buffer_length,


### PR DESCRIPTION
This shortens the "EKF3 IMUx buffs" message to be one character smaller which allows it to be displayed on a single line in the ground stations.  It probably saves a tiny bit of bandwidth as well because the message is not split into two.

Below is a before vs after screen shot of the change
![image](https://user-images.githubusercontent.com/1498098/94392034-20ad1880-0192-11eb-96c2-c48f404f2939.png)
