### PR TITLE
AP_UAVCAN - Allow sending negative values to ESCs over UAVCAN 

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -99,6 +99,13 @@ const AP_Param::GroupInfo AP_UAVCAN::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SRV_RT", 4, AP_UAVCAN, _servo_rate_hz, 50),
 
+    // @Param: ESCREVBM
+    // @DisplayName: Bitmask for ESCs that allow reverse by sending negative values over UAVCAN
+    // @Description: Bitmask with one set for channel that allows reverse negative values command over UAVCAN
+    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16
+    // @User: Advanced
+    AP_GROUPINFO("ESCREVBM", 5, AP_UAVCAN, _esc_rev_bm, 0),
+
     AP_GROUPEND
 };
 
@@ -475,12 +482,21 @@ void AP_UAVCAN::SRV_send_esc(void)
 
         for (uint8_t i = 0; i < max_esc_num && k < 20; i++) {
             if ((((uint32_t) 1) << i) & _esc_bm) {
-                // TODO: ESC negative scaling for reverse thrust and reverse rotation
-                float scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
+                // If ESC allows negative values, scale the output accordingly
+                float scaled = 0;
+                if ((((uint32_t) 1) << i) & _esc_rev_bm) {
+                    scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse));
+                } else {
+                    scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
+                    scaled = constrain_float(scaled, 0, cmd_max);
+                }
 
-                scaled = constrain_float(scaled, 0, cmd_max);
-
-                esc_msg.cmd.push_back(static_cast<int>(scaled));
+                // This check is needed to stop sending values when disarmed
+                if (_SRV_conf[i].pulse != 0) {
+                    esc_msg.cmd.push_back(static_cast<int>(scaled));
+                } else  {
+                    esc_msg.cmd.push_back(static_cast<int>(0));
+                }
             } else {
                 esc_msg.cmd.push_back(static_cast<unsigned>(0));
             }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -169,6 +169,7 @@ private:
     AP_Int8 _uavcan_node;
     AP_Int32 _servo_bm;
     AP_Int32 _esc_bm;
+    AP_Int32 _esc_rev_bm;
     AP_Int16 _servo_rate_hz;
 
     uavcan::Node<0> *_node;


### PR DESCRIPTION
This is a very rough draft to allow sending negative values over UAVCAN to allow reverse. This is needed in skid steer rovers to allow in place turning and reverse. 

This PR removes a constrain to only send positive values, and scales the output from 1000 (full reverse), 1500 (stop), 2000 (full forward), to a value between -cmd_max to +cmd_max to the ESC.

This was tested on a VESC with very good results. 