### PR TITLE
GCS_MAVLink: send message when MAVFTP init fails

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -63,6 +63,7 @@ failed:
     ftp.requests = nullptr;
     delete ftp.replies;
     ftp.replies = nullptr;
+    gcs().send_text(MAV_SEVERITY_WARNING, "failed to initialize MAVFTP");
 
     return false;
 }


### PR DESCRIPTION
partially addresses https://github.com/ArduPilot/ardupilot/issues/14653
I haven't yet looked at how to clear the capabilities bit; any tips on that?