### PR TITLE
Remove unused variables

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1021,7 +1021,7 @@ ParametersG2::ParametersG2(void)
     ,mode_systemid_ptr(&copter.mode_systemid)
 #endif
 #if MODE_AUTOROTATE_ENABLED == ENABLED
-    ,arot(copter.inertial_nav)
+    ,arot()
 #endif
     ,button_ptr(&copter.button)
 #if MODE_ZIGZAG_ENABLED == ENABLED

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -119,8 +119,7 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
 };
 
 // Constructor
-AC_Autorotation::AC_Autorotation(AP_InertialNav& inav) :
-    _inav(inav),
+AC_Autorotation::AC_Autorotation() :
     _p_hs(HS_CONTROLLER_HEADSPEED_P),
     _p_fw_vel(AP_FW_VEL_P)
     {

--- a/libraries/AC_Autorotation/AC_Autorotation.h
+++ b/libraries/AC_Autorotation/AC_Autorotation.h
@@ -18,7 +18,7 @@ class AC_Autorotation
 public:
 
     //Constructor
-    AC_Autorotation(AP_InertialNav& inav);
+    AC_Autorotation();
 
     //--------Functions--------
     void init_hs_controller(void);  // Initialise head speed controller
@@ -51,7 +51,6 @@ private:
     float _current_rpm;
     float _collective_out;
     float _head_speed_error;         // Error between target head speed and current head speed.  Normalised by head speed set point RPM.
-    uint16_t _log_counter;
     float _col_cutoff_freq;          // Lowpass filter cutoff frequency (Hz) for collective.
     uint8_t _unhealthy_rpm_counter;  // Counter used to track RPM sensor unhealthy signal.
     uint8_t _healthy_rpm_counter;    // Counter used to track RPM sensor healthy signal.
@@ -61,7 +60,6 @@ private:
 
     float _vel_target;               // Forward velocity target.
     float _pitch_target;             // Pitch angle target.
-    float _vel_error;                // Velocity error.
     float _accel_max;                // Maximum acceleration limit.
     int16_t _speed_forward_last;       // The forward speed calculated in the previous cycle.
     bool _flag_limit_accel;          // Maximum acceleration limit reached flag.
@@ -101,8 +99,4 @@ private:
 
     // low pass filter for collective trim
     LowPassFilterFloat col_trim_lpf;
-
-    //--------References to Other Libraries--------
-    AP_InertialNav&    _inav;
-
 };

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.h
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.h
@@ -138,7 +138,6 @@ private:
     uint32_t        last_packet_GPS_ms;
     uint32_t        last_packet_send_ms;
     MsgTypes_XP     last_packet_type_sent = MsgTypes_XP::INVALID;
-    uint32_t        response_timeout_count;
     uint32_t        baudrate;
 
     uint32_t        last_packet_Operating_ms;

--- a/libraries/AP_Generator/AP_Generator_RichenPower.h
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.h
@@ -180,9 +180,6 @@ private:
     // body_length as appropriate.
     void move_header_in_buffer(uint8_t initial_offset);
 
-    // RC input generator for pilot to specify desired generator state
-    RC_Channel *_rc_channel;
-
     // a simple heat model to avoid the motor moving to run too fast
     // or being stopped before cooldown.  The generator itself does
     // not supply temperature via telemetry, so we fake one based on

--- a/libraries/AP_NavEKF/EKFGSF_yaw.h
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.h
@@ -80,7 +80,6 @@ private:
     float accel_gain;               // gain from accel vector tilt error to rate gyro correction used by AHRS calculation
     Vector3f ahrs_accel;            // filtered body frame specific force vector used by AHRS calculation (m/s/s)
     float ahrs_accel_norm;          // length of body frame specific force vector used by AHRS calculation (m/s/s)
-    bool ahrs_turn_comp_enabled;    // true when compensation for centripetal acceleration in coordinated turns using true airspeed is being used.
     float true_airspeed;            // true airspeed used to correct for centripetal acceleratoin in coordinated turns (m/s)
 
     // Runs quaternion prediction for the selected AHRS using IMU (and optionally true airspeed) data

--- a/libraries/AP_Notify/AP_BoardLED.h
+++ b/libraries/AP_Notify/AP_BoardLED.h
@@ -29,6 +29,9 @@ public:
     void update(void) override;
 
 private:
+#if (defined(HAL_GPIO_A_LED_PIN) && defined(HAL_GPIO_B_LED_PIN) && \
+     defined(HAL_GPIO_C_LED_PIN))
     // counter incremented at 50Hz
     uint8_t _counter;
+#endif
 };

--- a/libraries/AP_Notify/AP_BoardLED2.h
+++ b/libraries/AP_Notify/AP_BoardLED2.h
@@ -33,7 +33,9 @@ public:
 private:
     // counter incremented at 50Hz
     uint8_t _counter;
+#if defined(HAL_GPIO_A_LED_PIN) && defined(HAL_GPIO_B_LED_PIN)
     uint16_t _sat_cnt;
     uint8_t save_trim_counter;
     uint8_t arm_counter = 0;
+#endif
 };

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
@@ -48,11 +48,11 @@ private:
 
     const uint8_t BINARY_MODE[4] = {(uint8_t)0x00, (uint8_t)0x11, (uint8_t)0x02, (uint8_t)0x4C};
     const uint8_t TOWER_MODE[4] = {(uint8_t)0x00, (uint8_t)0x31, (uint8_t)0x03, (uint8_t)0xE5};
-    const uint8_t SEQUENCE_MODE[4] = {(uint8_t)0x00, (uint8_t)0x31, (uint8_t)0x02, (uint8_t)0xE2};
+//    const uint8_t SEQUENCE_MODE[4] = {(uint8_t)0x00, (uint8_t)0x31, (uint8_t)0x02, (uint8_t)0xE2};
     const uint8_t ACTIVATE_STREAM[5] = {(uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x02, (uint8_t)0x01, (uint8_t)0xDF};
-    const uint8_t REFRESH_50_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x02, (uint8_t)0xC3};
+//    const uint8_t REFRESH_50_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x02, (uint8_t)0xC3};
     const uint8_t REFRESH_100_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x03, (uint8_t)0xC4};
-    const uint8_t REFRESH_250_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x04, (uint8_t)0xD1};
-    const uint8_t REFRESH_500_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x05, (uint8_t)0xD6};
-    const uint8_t REFRESH_600_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x06, (uint8_t)0xDF};
+//    const uint8_t REFRESH_250_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x04, (uint8_t)0xD1};
+//    const uint8_t REFRESH_500_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x05, (uint8_t)0xD6};
+//    const uint8_t REFRESH_600_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x06, (uint8_t)0xDF};
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.h
@@ -33,7 +33,6 @@ private:
     uint32_t last_distance_cm;     // last distance reported (used to prevent glitches in measurement)
     uint8_t glitch_count;           // glitch counter
 
-    int8_t last_warn_echo_pin;
     AP_HAL::PWMSource pwm_source;
 
     uint32_t last_ping_ms;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
@@ -44,8 +44,6 @@ protected:
 
 private:
 
-    int8_t last_warn_pin; // last pin used for reading pwm (used to recognise change in pin assignment)
-
     bool check_pin();
     void check_stop_pin();
     bool check_pins();

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -55,7 +55,6 @@ class SoaringController {
     float McCready(float alt);
 
     float _thermalability;
-    float _expected_sink;
 
     LowPassFilter<float> _position_x_filter;
     LowPassFilter<float> _position_y_filter;

--- a/libraries/AP_Soaring/Variometer.h
+++ b/libraries/AP_Soaring/Variometer.h
@@ -21,14 +21,9 @@ class Variometer {
     // store time of last update
     uint64_t _prev_update_time;
 
-    float _last_alt;
-
     float _aspd_filt;
     float _aspd_filt_constrained;
 
-    float _last_aspd;
-    float _last_roll;
-    float _last_total_E;
     float _expected_thermalling_sink;
 
     // declares a 5point average filter using floats


### PR DESCRIPTION
clang++ warns about these, potentially obscuring more serious warnings.