### PR TITLE
Copter/AP_Parachute: fix parachute checks for sink rate (attempt 2)

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -517,6 +517,10 @@ void Copter::one_hz_loop()
     adsb.set_is_flying(!ap.land_complete);
 #endif
 
+#if PARACHUTE == ENABLED
+    parachute.set_is_flying(!ap.land_complete);
+#endif
+    
     AP_Notify::flags.flying = !ap.land_complete;
 }
 

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -517,10 +517,6 @@ void Copter::one_hz_loop()
     adsb.set_is_flying(!ap.land_complete);
 #endif
 
-#if PARACHUTE == ENABLED
-    parachute.set_is_flying(!ap.land_complete);
-#endif
-    
     AP_Notify::flags.flying = !ap.land_complete;
 }
 

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -192,6 +192,11 @@ void Copter::parachute_check()
         return;
     }
 
+    if (parachute.release_initiated()) {
+        copter.arming.disarm(AP_Arming::Method::PARACHUTE_RELEASE);
+        return;
+    }
+
     // return immediately if we are not in an angle stabilize flight mode or we are flipping
     if (control_mode == Mode::Number::ACRO || control_mode == Mode::Number::FLIP) {
         control_loss_count = 0;
@@ -209,6 +214,9 @@ void Copter::parachute_check()
         return;
     }
 
+    // pass sink rate to parachute library
+    parachute.set_sink_rate(-inertial_nav.get_velocity_z() * 0.01);
+    
     // check for angle error over 30 degrees
     const float angle_error = attitude_control->get_att_error_angle_deg();
     if (angle_error <= CRASH_CHECK_ANGLE_DEVIATION_DEG) {
@@ -242,9 +250,6 @@ void Copter::parachute_check()
         // release parachute
         parachute_release();
     }
-
-    // pass sink rate to parachute library
-    parachute.set_sink_rate(-inertial_nav.get_velocity_z() * 0.01);
 }
 
 // parachute_release - trigger the release of the parachute, disarm the motors and notify the user

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -178,6 +178,12 @@ void Copter::parachute_check()
         return;
     }
 
+    // pass is_flying to parachute library
+    parachute.set_is_flying(!ap.land_complete);
+
+    // pass sink rate to parachute library
+    parachute.set_sink_rate(-inertial_nav.get_velocity_z() * 0.01f);
+
     // exit immediately if in standby
     if (standby_active) {
         return;
@@ -214,9 +220,9 @@ void Copter::parachute_check()
         return;
     }
 
-    // pass sink rate to parachute library
-    parachute.set_sink_rate(-inertial_nav.get_velocity_z() * 0.01);
-    
+    // trigger parachute release based on sink rate
+    parachute.check_sink_rate();
+
     // check for angle error over 30 degrees
     const float angle_error = attitude_control->get_att_error_angle_deg();
     if (angle_error <= CRASH_CHECK_ANGLE_DEVIATION_DEG) {

--- a/ArduPlane/parachute.cpp
+++ b/ArduPlane/parachute.cpp
@@ -8,6 +8,7 @@ void Plane::parachute_check()
 {
 #if PARACHUTE == ENABLED
     parachute.update();
+    parachute.check_sink_rate();
 #endif
 }
 

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -134,25 +134,25 @@ void AP_Parachute::update()
     // calc time since release
     uint32_t time_diff = AP_HAL::millis() - _release_time;
     uint32_t delay_ms = _delay_ms<=0 ? 0: (uint32_t)_delay_ms;
-    
+
     // check if we should release parachute
     if ((_release_time != 0) && !_release_in_progress) {
         if (time_diff >= delay_ms) {
             if (_release_type == AP_PARACHUTE_TRIGGER_TYPE_SERVO) {
                 // move servo
                 SRV_Channels::set_output_pwm(SRV_Channel::k_parachute_release, _servo_on_pwm);
-            }else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
+            } else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
                 // set relay
                 _relay.on(_release_type);
             }
             _release_in_progress = true;
             _released = true;
         }
-    }else if ((_release_time == 0) || time_diff >= delay_ms + AP_PARACHUTE_RELEASE_DURATION_MS) {
+    } else if ((_release_time == 0) || time_diff >= delay_ms + AP_PARACHUTE_RELEASE_DURATION_MS) {
         if (_release_type == AP_PARACHUTE_TRIGGER_TYPE_SERVO) {
             // move servo back to off position
             SRV_Channels::set_output_pwm(SRV_Channel::k_parachute_release, _servo_off_pwm);
-        }else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
+        } else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
             // set relay back to zero volts
             _relay.off(_release_type);
         }

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -118,19 +118,7 @@ void AP_Parachute::update()
     if (_enabled <= 0) {
         return;
     }
-    // check if the plane is sinking too fast for more than a second and release parachute
-    uint32_t time = AP_HAL::millis();
-    if((_critical_sink > 0) && (_sink_rate > _critical_sink) && !_release_initiated && _is_flying) {
-        if(_sink_time == 0) {
-            _sink_time = AP_HAL::millis();
-        }
-        if((time - _sink_time) >= 1000) {
-            release();
-        }
-    } else {
-        _sink_time = 0;
-    }
-    
+
     // calc time since release
     uint32_t time_diff = AP_HAL::millis() - _release_time;
     uint32_t delay_ms = _delay_ms<=0 ? 0: (uint32_t)_delay_ms;
@@ -161,6 +149,41 @@ void AP_Parachute::update()
         _release_time = 0;
         // update AP_Notify
         AP_Notify::flags.parachute_release = 0;
+    }
+}
+
+// set_sink_rate - set vehicle sink rate
+void AP_Parachute::set_sink_rate(float sink_rate)
+{
+    // reset sink time if critical sink rate check is disabled or vehicle is not flying
+    if ((_critical_sink <= 0) || !_is_flying) {
+        _sink_time_ms = 0;
+        return;
+    }
+
+    // reset sink_time if vehicle is not sinking too fast
+    if (sink_rate <= _critical_sink) {
+        _sink_time_ms = 0;
+        return;
+    }
+
+    // start time when sinking too fast
+    if (_sink_time_ms == 0) {
+        _sink_time_ms = AP_HAL::millis();
+    }
+}
+
+// trigger parachute release if sink_rate is below critical_sink_rate for 1sec
+void AP_Parachute::check_sink_rate()
+{
+    // return immediately if parachute is being released or vehicle is not flying
+    if (_release_initiated || !_is_flying) {
+        return;
+    }
+
+    // if vehicle is sinking too fast for more than a second release parachute
+    if ((_sink_time_ms > 0) && ((AP_HAL::millis() - _sink_time_ms) > 1000)) {
+        release();
     }
 }
 

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -63,13 +63,13 @@ public:
 
     /// released - true if the parachute has been released (or release is in progress)
     bool released() const { return _released; }
-    
+
     /// release_initiated - true if the parachute release sequence has been initiated (may wait before actual release)
     bool release_initiated() const { return _release_initiated; }
 
     /// release_in_progress - true if the parachute release sequence is in progress
     bool release_in_progress() const { return _release_in_progress; }
-    
+
     /// update - shuts off the trigger should be called at about 10hz
     void update();
     

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -72,9 +72,6 @@ public:
 
     /// update - shuts off the trigger should be called at about 10hz
     void update();
-    
-    /// critical_sink - returns the configured maximum sink rate to trigger emergency release
-    float critical_sink() const { return _critical_sink; }
 
     /// alt_min - returns the min altitude above home the vehicle should have before parachute is released
     ///   0 = altitude check disabled
@@ -84,7 +81,10 @@ public:
     void set_is_flying(const bool is_flying) { _is_flying = is_flying; }
 
     // set_sink_rate - set vehicle sink rate
-    void set_sink_rate(float sink_rate) { _sink_rate = sink_rate; }
+    void set_sink_rate(float sink_rate);
+
+    // trigger parachute release if sink_rate is below critical_sink_rate for 1sec
+    void check_sink_rate();
 
     static const struct AP_Param::GroupInfo        var_info[];
 
@@ -109,8 +109,7 @@ private:
     bool        _release_in_progress:1;  // true if the parachute release is in progress
     bool        _released:1;             // true if the parachute has been released
     bool        _is_flying:1;            // true if the vehicle is flying
-    float       _sink_rate;              // vehicle sink rate in m/s
-    uint32_t    _sink_time;              // time that the vehicle exceeded critical sink rate
+    uint32_t    _sink_time_ms;           // system time that the vehicle exceeded critical sink rate
 };
 
 namespace AP {


### PR DESCRIPTION
This is a modified version of PR: https://github.com/ArduPilot/ardupilot/pull/14984

This PR (like the previous one) fixes Copter's parachute feature so that it deploys the parachute and disarms the vehicle if the vehicle's descent rate falls below the CHUTE_CRT_SINK parameter value.

The current issue in master (and presumably Copter-4.0.x) can be reproduced by doing the following:

- start SITL copter
- param set CHUTE_ENABLE 1
- param set CHUTE_TYPE 10 (Servo)
- param set CHUTE_CRT_SINK 5 (m/s)
- param set SERVO10_FUNCTION 27 (parachute release)
- arm and fly the vehicle in stabilize mode to a reasonable altitude
- rc 3 1100 to reduce throttle to near zero

In master the vehicle will maintain it's attitude but will fall rapidly and the parachute is **not** deployed.

With this PR applied, the parachute is deployed and the vehicle is disarmed.

Below are before vs after screen shots of testing in SITL
![chute-before](https://user-images.githubusercontent.com/1498098/94683260-2c026e80-0361-11eb-93d3-009dbfbce52e.png)

![chute-after](https://user-images.githubusercontent.com/1498098/94683270-30c72280-0361-11eb-8547-fb4d3ff26c66.png)

@tridge would you be able to re-test with Plane to ensure it is OK?  This should be a non-functional change for Plane but just to be sure.
