### PR TITLE
AP_Scheduler: add the fast loop to task statistics

### DIFF
--- a/libraries/AP_Scheduler/PerfInfo.cpp
+++ b/libraries/AP_Scheduler/PerfInfo.cpp
@@ -22,6 +22,9 @@ void AP::PerfInfo::reset()
     long_running = 0;
     sigma_time = 0;
     sigmasquared_time = 0;
+    if (_task_info != nullptr) {
+        memset(_task_info, 0, (_num_tasks + 1) * sizeof(TaskInfo));
+    }
 }
 
 // ignore_loop - ignore this loop from performance measurements (used to reduce false positive when arming)
@@ -33,7 +36,7 @@ void AP::PerfInfo::ignore_this_loop()
 // allocate the array of task statistics for use by @SYS/tasks.txt
 void AP::PerfInfo::allocate_task_info(uint8_t num_tasks)
 {
-    _task_info = new TaskInfo[num_tasks];
+    _task_info = new TaskInfo[num_tasks + 1];   // add an extra slot for the fast_loop
     if (_task_info == nullptr) {
         hal.console->printf("Unable to allocate scheduler TaskInfo\n");
         _num_tasks = 0;
@@ -56,7 +59,7 @@ void AP::PerfInfo::update_task_info(uint8_t task_index, uint16_t task_time_us, b
         return;
     }
 
-    if (task_index >= _num_tasks) {
+    if (task_index > _num_tasks) {
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         return;
     }

--- a/libraries/AP_Scheduler/PerfInfo.h
+++ b/libraries/AP_Scheduler/PerfInfo.h
@@ -43,13 +43,13 @@ public:
     bool has_task_info() { return _task_info != nullptr; }
     // return a task info
     const TaskInfo* get_task_info(uint8_t task_index) const {
-        return (_task_info && task_index < _num_tasks) ? &_task_info[task_index] : nullptr;
+        return (_task_info && task_index <= _num_tasks) ? &_task_info[task_index] : nullptr;
     }
     // called after each run of a task to update its statistics based on measurements taken by the scheduler
     void update_task_info(uint8_t task_index, uint16_t task_time_us, bool overrun);
     // record that a task slipped
     void task_slipped(uint8_t task_index) {
-        if (_task_info && task_index < _num_tasks) {
+        if (_task_info && task_index <= _num_tasks) {
             _task_info[task_index].overrun_count++;
         }
     }


### PR DESCRIPTION
Adds the fast loop info to the end of tasks.txt:
```
AP_VideoTX::update               MIN=  2 MAX=  6 AVG=  2 OVR=  0 SLP=  0, TOT= 0.0%
AP_Vehicle::send_watchdog_reset_ MIN=  2 MAX=  2 AVG=  2 OVR=  0 SLP=  0, TOT= 0.0%
fast_loop                        MIN=356 MAX=999 AVG=524 OVR=  0 SLP=  0, TOT=72.8%
```