### PR TITLE
AP_HAL_SITL: stop setting of pull-up resistors affecting SIM_PIN_MASK

### DIFF
--- a/libraries/AP_HAL_SITL/GPIO.cpp
+++ b/libraries/AP_HAL_SITL/GPIO.cpp
@@ -11,7 +11,16 @@ void GPIO::init()
 {}
 
 void GPIO::pinMode(uint8_t pin, uint8_t output)
-{}
+{
+    if (pin > 7) {
+        return;
+    }
+    if (output) {
+        pin_mode_is_write |= (1U<<pin);
+    } else {
+        pin_mode_is_write &= ~(1U<<pin);
+    }
+}
 
 uint8_t GPIO::read(uint8_t pin)
 {
@@ -32,6 +41,13 @@ void GPIO::write(uint8_t pin, uint8_t value)
 {
     if (!_sitlState->_sitl) {
         return;
+    }
+
+    if (pin < 8) {
+        if (!(pin_mode_is_write & (1U<<pin))) {
+            // ignore setting of pull-up resistors
+            return;
+        }
     }
     uint16_t mask = static_cast<uint16_t>(_sitlState->_sitl->pin_mask.get());
     uint16_t new_mask = mask;

--- a/libraries/AP_HAL_SITL/GPIO.h
+++ b/libraries/AP_HAL_SITL/GPIO.h
@@ -19,6 +19,8 @@ public:
 
 private:
     SITL_State *_sitlState;
+
+    uint8_t pin_mode_is_write;
 };
 
 class HALSITL::DigitalSource : public AP_HAL::DigitalSource {


### PR DESCRIPTION
e.g. AP_Button attempts to set the pull-up-resistor by writing `1` to the GPIO - that directly changes `SIM_PIN_MASK`, which is really annoying.
