### PR TITLE
Allow PWM input for buttons / attach auxillary functions to buttons

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7140,6 +7140,50 @@ switch value'''
                                        (new_mask, m3.state))
         self.progress("correct BUTTON_CHANGE event received")
 
+        if self.is_tracker():
+            # tracker starts armed, which is annoying
+            self.progress("Skipping arm/disarm tests for tracker")
+            return
+
+        self.wait_ready_to_arm()
+        self.set_parameter("BTN_FUNC%u" % btn, 41)  # ARM/DISARM
+        self.set_parameter("SIM_PIN_MASK", mask)
+        self.wait_armed()
+        self.set_parameter("SIM_PIN_MASK", 0)
+        self.wait_disarmed()
+
+        if self.is_rover():
+            self.context_push()
+            # arming should be inhibited while e-STOP is in use:
+            # set the function:
+            self.set_parameter("BTN_FUNC%u" % btn, 31)
+            # invert the sense of the pin, so eStop is asserted when pin is low:
+            self.set_parameter("BTN_OPTIONS%u" % btn, 1<<1)
+            self.reboot_sitl()
+            # assert the pin:
+            self.set_parameter("SIM_PIN_MASK", mask)
+            self.wait_ready_to_arm()
+            self.arm_vehicle()
+            self.disarm_vehicle()
+            # de-assert the pin:
+            self.set_parameter("SIM_PIN_MASK", 0)
+            self.delay_sim_time(1)  # 5Hz update rate on Button library
+            self.context_collect("STATUSTEXT")
+            # try to arm the vehicle:
+            self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                         1,  # ARM
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         want_result=mavutil.mavlink.MAV_RESULT_FAILED
+            )
+            self.wait_statustext("PreArm: Motors Emergency Stopped", check_context=True)
+            self.context_pop()
+            self.reboot_sitl()
+
     def compare_number_percent(self, num1, num2, percent):
         if num1 == 0 and num2 == 0:
             return True

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -4457,7 +4457,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                      0, # p6 - test order (see MOTOR_TEST_ORDER)
                      0, # p7
         )
-        self.mav.motors_armed_wait()
+        self.wait_armed()
         self.progress("Waiting for magic throttle value")
         self.wait_servo_channel_value(3, magic_throttle_value)
         self.wait_servo_channel_value(3, self.get_parameter("RC3_TRIM", 5), timeout=10)

--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -56,6 +56,11 @@ private:
     bool is_pwm_input(uint8_t n) const {
         return ((uint8_t)options[n].get() & (1U<<0)) != 0;
     }
+    bool is_input_inverted(uint8_t n) const {
+        return ((uint8_t)options[n].get() & (1U<<1)) != 0;
+    }
+
+    AP_Int16 pin_func[AP_BUTTON_NUM_PINS];  // from the RC_Channel functions
 
     // number of seconds to send change notifications
     AP_Int16 report_send_time;
@@ -75,10 +80,25 @@ private:
     // pwm sources are used when using PWM on the input
     AP_HAL::PWMSource pwm_pin_source[AP_BUTTON_NUM_PINS];
 
+    // state from the timer interrupt:
+    HAL_Semaphore last_debounced_change_ms_sem;
+    // last time GPIO pins were debounced:
     uint64_t last_debounced_change_ms;
+
+    // time at least last debounce changes across both PWM and GPIO
+    // pins was detected:
+    uint64_t last_debounce_ms;
 
     // when the mask last changed
     uint64_t last_change_time_ms;
+
+    // when button change events were last actioned
+    uint64_t last_action_time_ms;
+
+    // true if allocated aux functions have been initialised
+    bool aux_functions_initialised;
+    // call init_aux_function for all used functions
+    void run_aux_functions(bool force);
 
     // time of last report
     uint32_t last_report_ms;

--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -51,6 +51,11 @@ private:
 
     AP_Int8 enable;
     AP_Int8 pin[AP_BUTTON_NUM_PINS];
+    AP_Int8 options[AP_BUTTON_NUM_PINS];  // if a pin's bit is set then it uses PWM assertion
+
+    bool is_pwm_input(uint8_t n) const {
+        return ((uint8_t)options[n].get() & (1U<<0)) != 0;
+    }
 
     // number of seconds to send change notifications
     AP_Int16 report_send_time;
@@ -60,6 +65,17 @@ private:
 
     // debounced button press mask
     uint8_t debounce_mask;
+
+    // current state of PWM pins:
+    uint8_t pwm_state;
+
+    // mask indicating which action was most recent taken for pins
+    uint8_t state_actioned_mask;
+
+    // pwm sources are used when using PWM on the input
+    AP_HAL::PWMSource pwm_pin_source[AP_BUTTON_NUM_PINS];
+
+    uint64_t last_debounced_change_ms;
 
     // when the mask last changed
     uint64_t last_change_time_ms;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -529,6 +529,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::RETRACT_MOUNT,"RetractMount"},
     { AUX_FUNC::RELAY,"Relay1"},
     { AUX_FUNC::LANDING_GEAR,"Landing"},
+    { AUX_FUNC::MOTOR_ESTOP,"MotorEStop"},
     { AUX_FUNC::MOTOR_INTERLOCK,"MotorInterlock"},
     { AUX_FUNC::RELAY2,"Relay2"},
     { AUX_FUNC::RELAY3,"Relay3"},

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -238,6 +238,11 @@ public:
     const char *string_for_aux_function(AUX_FUNC function) const;
 #endif
 
+    // pwm value above which the option will be invoked:
+    static const uint16_t AUX_PWM_TRIGGER_HIGH = 1800;
+    // pwm value below which the option will be disabled:
+    static const uint16_t AUX_PWM_TRIGGER_LOW = 1200;
+
 protected:
 
     virtual void init_aux_function(aux_func_t ch_option, AuxSwitchPos);
@@ -291,11 +296,6 @@ private:
 
     int16_t pwm_to_angle() const;
     int16_t pwm_to_angle_dz(uint16_t dead_zone) const;
-
-    // pwm value above which the option will be invoked:
-    static const uint16_t AUX_PWM_TRIGGER_HIGH = 1800;
-    // pwm value below which the option will be disabled:
-    static const uint16_t AUX_PWM_TRIGGER_LOW = 1200;
 
     // Structure used to detect and debounce switch changes
     struct {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -234,6 +234,10 @@ public:
 
     virtual void do_aux_function(aux_func_t ch_option, AuxSwitchPos);
 
+#if !HAL_MINIMIZE_FEATURES
+    const char *string_for_aux_function(AUX_FUNC function) const;
+#endif
+
 protected:
 
     virtual void init_aux_function(aux_func_t ch_option, AuxSwitchPos);
@@ -312,7 +316,6 @@ private:
     };
 
     static const LookupTable lookuptable[];
-    const char *string_for_aux_function(AUX_FUNC function) const;
 #endif
 };
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -232,10 +232,11 @@ public:
     bool read_3pos_switch(AuxSwitchPos &ret) const WARN_IF_UNUSED;
     AuxSwitchPos get_aux_switch_pos() const;
 
+    virtual void do_aux_function(aux_func_t ch_option, AuxSwitchPos);
+
 protected:
 
     virtual void init_aux_function(aux_func_t ch_option, AuxSwitchPos);
-    virtual void do_aux_function(aux_func_t ch_option, AuxSwitchPos);
 
     virtual void do_aux_function_armdisarm(const AuxSwitchPos ch_flag);
     void do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag);

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -158,6 +158,9 @@ public:
         k_ProfiLED_3            = 131,
         k_ProfiLED_Clock        = 132,
         k_winch_clutch          = 133,
+        k_min                   = 134,  // always outputs SERVOn_MIN
+        k_trim                  = 135,  // always outputs SERVOn_TRIM
+        k_max                   = 136,  // always outputs SERVOn_MAX
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
     } Aux_servo_function_t;
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -197,6 +197,19 @@ void SRV_Channels::enable_aux_servos()
             hal.rcout->enable_ch(c.ch_num);
         }
 
+        // output some servo functions before we fiddle with the
+        // parameter values:
+        if (c.function.get() == SRV_Channel::k_min) {
+            c.set_output_pwm(c.servo_min);
+            c.output_ch();
+        } else if (c.function.get() == SRV_Channel::k_trim) {
+            c.set_output_pwm(c.servo_trim);
+            c.output_ch();
+        } else if (c.function.get() == SRV_Channel::k_max) {
+            c.set_output_pwm(c.servo_max);
+            c.output_ch();
+        }
+
         /*
           for channels which have been marked as digital output then the
           MIN/MAX/TRIM values have no meaning for controlling output, as


### PR DESCRIPTION
There are five distinct parts to this PR:
 - SERVO_CHANNELS gets servo-channel-functions to emit MIN/TRIM or MAX
 - `AP_Button` gets an OPTIONS parameter bitmask
 - `AP_Button` gets an OPTIONS bit to indicate a PIN should look for PWM input rather than a logic level
 - `AP_Button` gets an OPTIONS bit to indicate that the button level should be inverted vs its actual input
 - `AP_Button` gets an additional parameter allowing an auxiliary function to be triggered.

The intent here is to have motor-interlock available on a physical switch.

This work has been sponsored by Aion Robotics.
