### PR TITLE
Plane: added FLIGHT_OPTIONS bit 4 for THR_MIN behaviour

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -401,7 +401,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: THR_MIN
     // @DisplayName: Minimum Throttle
-    // @Description: Minimum throttle percentage used in all modes except manual, provided THR_PASS_STAB is not set. Negative values allow reverse thrust if hardware supports it.
+    // @Description: Minimum throttle percentage used in all modes except manual, provided THR_PASS_STAB is not set. Negative values allow reverse thrust if hardware supports it. You can also apply this min throttle to all armed modes by setting FLIGHT_OPTIONS bit 4 to 1.
     // @Units: %
     // @Range: -100 100
     // @Increment: 1
@@ -1177,7 +1177,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4:Use THR_MIN instead of zero throttle when armed
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1044,6 +1044,7 @@ private:
     void set_servos_old_elevons(void);
     void set_servos_flaps(void);
     void set_landing_gear(void);
+    void set_min_throttle(void);
     void dspoiler_update(void);
     void airbrake_update(void);
     void servo_output_mixers(void);

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -152,6 +152,7 @@ enum FlightOptions {
     CRUISE_TRIM_THROTTLE = (1 << 1),
     DISABLE_TOFF_ATTITUDE_CHK = (1 << 2),
     CRUISE_TRIM_AIRSPEED = (1 << 3),
+    USE_THR_MIN_ZERO = (1 << 4),
 };
 
 enum CrowFlapOptions {

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -72,7 +72,7 @@ void ModeAuto::update()
 
         if (plane.landing.is_throttle_suppressed()) {
             // if landing is considered complete throttle is never allowed, regardless of landing type
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
+            plane.set_min_throttle();
         } else {
             plane.calc_throttle();
         }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -523,7 +523,8 @@ void Plane::set_servos_controlled(void)
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, 0);
         }
     } else if (suppress_throttle()) {
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0 ); // default
+        // throttle is suppressed in auto mode
+        set_min_throttle();
         // throttle is suppressed (above) to zero in final flare in auto mode, but we allow instead thr_min if user prefers, eg turbines:
         if (landing.is_flaring() && landing.use_thr_min_during_flare() ) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, aparm.throttle_min.get());
@@ -539,7 +540,7 @@ void Plane::set_servos_controlled(void)
                control_mode == &mode_autotune) {
         // a manual throttle mode
         if (failsafe.throttle_counter) {
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
+            set_min_throttle();
         } else if (g.throttle_passthru_stabilize) {
             // manual pass through of throttle while in FBWA or
             // STABILIZE mode with THR_PASS_STAB set
@@ -1008,4 +1009,18 @@ void Plane::servos_auto_trim(void)
         g2.servo_channels.save_trim();
     }
     
+}
+
+/*
+  set min output throttle. The value depends if we are armed
+ */
+void Plane::set_min_throttle(void)
+{
+    int8_t thr = 0;
+    if (hal.util->get_soft_armed() && (g2.flight_options & FlightOptions::USE_THR_MIN_ZERO)) {
+        // use THR_MIN if armed. This is needed for engines that need
+        // some throttle to stay running
+        thr = MAX(0, aparm.throttle_min.get());
+    }
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, thr);
 }


### PR DESCRIPTION
This option enables use of THR_MIN in all modes when armed. For motors
that need a min throttle to stay running (eg. some turbines) we need
to make sure we don't drop to zero on initial failsafe