### PR TITLE
AP_VisualOdometry: T265 ignores position and speed for 1 second after position reset

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -279,8 +279,8 @@ public:
                           uint8_t sequence,
                           const RallyLocation &rally_point);
     void Write_VisualOdom(float time_delta, const Vector3f &angle_delta, const Vector3f &position_delta, float confidence);
-    void Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, float roll, float pitch, float yaw, float pos_err, float ang_err, uint8_t reset_counter);
-    void Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, float vel_err, uint8_t reset_counter);
+    void Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, float roll, float pitch, float yaw, float pos_err, float ang_err, uint8_t reset_counter, bool ignored);
+    void Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, float vel_err, uint8_t reset_counter, bool ignored);
     void Write_AOA_SSA(AP_AHRS &ahrs);
     void Write_Beacon(AP_Beacon &beacon);
     void Write_Proximity(AP_Proximity &proximity);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -930,7 +930,7 @@ void AP_Logger::Write_VisualOdom(float time_delta, const Vector3f &angle_delta, 
 }
 
 // Write visual position sensor data.  x,y,z are in meters, angles are in degrees
-void AP_Logger::Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, float roll, float pitch, float yaw, float pos_err, float ang_err, uint8_t reset_counter)
+void AP_Logger::Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, float roll, float pitch, float yaw, float pos_err, float ang_err, uint8_t reset_counter, bool ignored)
 {
     const struct log_VisualPosition pkt_visualpos {
         LOG_PACKET_HEADER_INIT(LOG_VISUALPOS_MSG),
@@ -945,13 +945,14 @@ void AP_Logger::Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, 
         yaw             : yaw,
         pos_err         : pos_err,
         ang_err         : ang_err,
-        reset_counter   : reset_counter
+        reset_counter   : reset_counter,
+        ignored         : (uint8_t)ignored
     };
     WriteBlock(&pkt_visualpos, sizeof(log_VisualPosition));
 }
 
 // Write visual velocity sensor data, velocity in NED meters per second
-void AP_Logger::Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, float vel_err, uint8_t reset_counter)
+void AP_Logger::Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, float vel_err, uint8_t reset_counter, bool ignored)
 {
     const struct log_VisualVelocity pkt_visualvel {
         LOG_PACKET_HEADER_INIT(LOG_VISUALVEL_MSG),
@@ -962,7 +963,8 @@ void AP_Logger::Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, 
         vel_y           : vel.y,
         vel_z           : vel.z,
         vel_err         : vel_err,
-        reset_counter   : reset_counter
+        reset_counter   : reset_counter,
+        ignored         : (uint8_t)ignored
     };
     WriteBlock(&pkt_visualvel, sizeof(log_VisualVelocity));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -648,6 +648,7 @@ struct PACKED log_VisualPosition {
     float pos_err;  // meters
     float ang_err;  // radians
     uint8_t reset_counter;
+    uint8_t ignored;
 };
 
 struct PACKED log_VisualVelocity {
@@ -660,6 +661,7 @@ struct PACKED log_VisualVelocity {
     float vel_z;
     float vel_err;
     uint8_t reset_counter;
+    uint8_t ignored;
 };
 
 struct PACKED log_ekfBodyOdomDebug {
@@ -2268,7 +2270,8 @@ struct PACKED log_PSC {
 // @Field: Yaw: Yaw angle
 // @Field: PErr: Position estimate error
 // @Field: AErr: Attitude estimate error
-// @Field: RstCnt: Position reset counter
+// @Field: Rst: Position reset counter
+// @Field: Ign: Ignored
 
 // @LoggerMessage: VISV
 // @Description: Vision Velocity
@@ -2279,7 +2282,8 @@ struct PACKED log_PSC {
 // @Field: VY: Velocity Y-axis (East-West)
 // @Field: VZ: Velocity Z-axis (Down-Up)
 // @Field: VErr: Velocity estimate error
-// @Field: RstCnt: Velocity reset counter
+// @Field: Rst: Velocity reset counter
+// @Field: Ign: Ignored
 
 // @LoggerMessage: WENC
 // @Description: Wheel encoder measurements
@@ -2685,9 +2689,9 @@ struct PACKED log_PSC {
     { LOG_VISUALODOM_MSG, sizeof(log_VisualOdom), \
       "VISO", "Qffffffff", "TimeUS,dt,AngDX,AngDY,AngDZ,PosDX,PosDY,PosDZ,conf", "ssrrrmmm-", "FF000000-" }, \
     { LOG_VISUALPOS_MSG, sizeof(log_VisualPosition), \
-      "VISP", "QQIffffffffB", "TimeUS,RTimeUS,CTimeMS,PX,PY,PZ,Roll,Pitch,Yaw,PErr,AErr,RstCnt", "sssmmmddhmd-", "FFC00000000-" }, \
+      "VISP", "QQIffffffffBB", "TimeUS,RTimeUS,CTimeMS,PX,PY,PZ,Roll,Pitch,Yaw,PErr,AErr,Rst,Ign", "sssmmmddhmd--", "FFC00000000--" }, \
     { LOG_VISUALVEL_MSG, sizeof(log_VisualVelocity), \
-      "VISV", "QQIffffB", "TimeUS,RTimeUS,CTimeMS,VX,VY,VZ,VErr,RstCnt", "sssnnnn-", "FFC0000-" }, \
+      "VISV", "QQIffffBB", "TimeUS,RTimeUS,CTimeMS,VX,VY,VZ,VErr,Rst,Ign", "sssnnnn--", "FFC0000--" }, \
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \
       "OF",   "QBffff",   "TimeUS,Qual,flowX,flowY,bodyX,bodyY", "s-EEnn", "F-0000" }, \
     { LOG_WHEELENCODER_MSG, sizeof(log_WheelEncoder), \

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
@@ -37,6 +37,11 @@ protected:
     // use sensor provided position and attitude to calculate rotation to align sensor with AHRS/EKF attitude
     bool align_sensor_to_vehicle(const Vector3f &position, const Quaternion &attitude);
 
+    // returns true if sensor data should be consumed, false if it should be ignored
+    // set vision_position_estimate to true if reset_counter is from the VISION_POSITION_ESTIMATE source, false otherwise
+    // only the VISION_POSITION_ESTIMATE message's reset_counter is used to determine if sensor data should be ignored
+    bool should_consume_sensor_data(bool vision_position_estimate, uint8_t reset_counter);
+
     float _yaw_trim;                            // yaw angle trim (in radians) to align camera's yaw to ahrs/EKF's
     Quaternion _yaw_rotation;                   // earth-frame yaw rotation to align heading of sensor with vehicle.  use when _yaw_trim is non-zero
     Quaternion _att_rotation;                   // body-frame rotation corresponding to ORIENT parameter.  use when get_orientation != NONE
@@ -47,6 +52,8 @@ protected:
     bool _align_camera = true;                  // true if camera should be aligned to AHRS/EKF
     bool _error_orientation;                    // true if the orientation is not supported
     Quaternion _attitude_last;                  // last attitude received from camera (used for arming checks)
+    uint8_t _pos_reset_counter_last;            // last vision-position-estimate reset counter value
+    uint32_t _pos_reset_ignore_start_ms;        // system time we start ignoring sensor information, 0 if sensor data is not being ignored
 };
 
 #endif

--- a/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp
@@ -47,7 +47,7 @@ void AP_VisualOdom_MAV::handle_vision_position_estimate(uint64_t remote_time_us,
     attitude.to_euler(roll, pitch, yaw);
 
     // log sensor data
-    AP::logger().Write_VisualPosition(remote_time_us, time_ms, pos.x, pos.y, pos.z, degrees(roll), degrees(pitch), degrees(yaw), posErr, angErr, reset_counter);
+    AP::logger().Write_VisualPosition(remote_time_us, time_ms, pos.x, pos.y, pos.z, degrees(roll), degrees(pitch), degrees(yaw), posErr, angErr, reset_counter, false);
 
     // record time for health monitoring
     _last_update_ms = AP_HAL::millis();
@@ -61,7 +61,7 @@ void AP_VisualOdom_MAV::handle_vision_speed_estimate(uint64_t remote_time_us, ui
     // record time for health monitoring
     _last_update_ms = AP_HAL::millis();
 
-    AP::logger().Write_VisualVelocity(remote_time_us, time_ms, vel, _frontend.get_vel_noise(), reset_counter);
+    AP::logger().Write_VisualVelocity(remote_time_us, time_ms, vel, _frontend.get_vel_noise(), reset_counter, false);
 }
 
 #endif


### PR DESCRIPTION
This PR improves robustness of the Intel RealSense T265 visual odometry library by ignoring the sensors position and speed after a position reset.  Below shows a screenshot of a real flight test in which the camera's position and speed estimate went bad because of some bright lights shining into the camera's lens during the indoor portion of the test.  [The entire log can be found here](https://www.dropbox.com/s/8i73oh2mc52fska/t265-position-jumps.BIN?dl=0).

![t265-resets-and-ignore](https://user-images.githubusercontent.com/1498098/94980555-c0d5b980-0565-11eb-9876-c319c0ca6ca0.png)


Despite this PR's improvement the EKF was not happy and the pilot had to takeoff in stabilize mode.  Still, it likely would have been worse without this change.

I suspect the longer-term solution is to improve the EKF's glitch detection to work better with the T265.  At the moment this glitch detection doesn't seem to trigger quickly enough, maybe because of the T265's high update rate.