### PR TITLE
Tools: flesh out decode-ICSR tool

### DIFF
--- a/Tools/scripts/decode-ICSR.py
+++ b/Tools/scripts/decode-ICSR.py
@@ -52,21 +52,68 @@ def decoder_m4_vectactive(value):
 
     sys.stdout.write(" (%s)" % exception)
 
+def decoder_m4_retobase(value):
+    if value:
+        out = "no (or no more) active exceptions"
+    else:
+        out = "preempted active exceptions"
+    sys.stdout.write(" (%s)" % out)
 
+def decoder_m4_vectpending(value):
+    return decoder_m4_vectactive(value)
+
+def decoder_m4_isrpending(value):
+    if value:
+        out = "Interrupt pending"
+    else:
+        out = "No pending interupt"
+    sys.stdout.write(" (%s)" % out)
+
+def decoder_m4_pendstclr(value):
+    sys.stdout.write(" (WO clears SysTick exception)")
+
+def decoder_m4_pendstset(value):
+    if value:
+        out = "SysTick pending"
+    else:
+        out = "SysTick not pending"
+    sys.stdout.write(" (%s)" % out)
+
+def decoder_m4_pendsvclr(value):
+    sys.stdout.write(" (WO clears pendsv exception)")
+
+def decoder_m4_pendsvset(value):
+    if value:
+        out = "PendSV pending"
+    else:
+        out = "PendSV not pending"
+    sys.stdout.write(" (%s)" % out)
+
+def decoder_m4_nmipendset(value):
+    if value:
+        out = "NMI pending"
+    else:
+        out = "NMI not pending"
+    sys.stdout.write(" (%s)" % out)
+
+# this ICSR-bit-assignment-table table also looks valid for M7 - page 195 of dm00237416-stm32f7-series-and-stm32h7-series-cortexm7-processor-programming-manual-stmicroelectronics.pdf
 M4_BITS = [
     ("0-8", "VECTACTIVE", decoder_m4_vectactive),
     ("9-10", "RESERVED1", None),
-    ("11", "RETOBASE", None),
-    ("12-18", "VECTPENDING", None),
+    ("11", "RETOBASE", decoder_m4_retobase),
+    ("12-18", "VECTPENDING", decoder_m4_vectpending),
     ("19-21", "RESERVED2", None),
-    ("22", "ISRPENDING", None),
+    ("22", "ISRPENDING", decoder_m4_isrpending),
     ("23-24", "RESERVED3", None),
-    ("25", "PENDSTCLR", None),
-    ("27", "PENDSVCLR", None),
-    ("28", "PENDSVSET", None),
+    ("25", "PENDSTCLR", decoder_m4_pendstclr),
+    ("26", "PENDSTSET", decoder_m4_pendstset),
+    ("27", "PENDSVCLR", decoder_m4_pendsvclr),
+    ("28", "PENDSVSET", decoder_m4_pendstset),
     ("29-30", "RESERVED4", None),
-    ("31", "NMIPENDSET", None),
+    ("31", "NMIPENDSET", decoder_m4_nmipendset),
 ]
+
+complete_mask = 0
 
 for bit in M4_BITS:
     (bits, name, decoder) = bit
@@ -80,8 +127,12 @@ for bit in M4_BITS:
     mask = 0
     for i in range(start_bit, stop_bit+1):
         mask |= (1 << i)
+        complete_mask |= mask
     value = (ICSR & mask) >> start_bit
     sys.stdout.write("%s: %u" % (name, value)),
     if decoder is not None:
         decoder(value)
     print("")
+
+if complete_mask != 0b11111111111111111111111111111111:
+    raise Exception("Mask incomplete")


### PR DESCRIPTION
```
pbarker@bluebottle:~/rc/ardupilot(pr/tools-flesh-out-decode-icsr)$ ./Tools/scripts/decode-ICSR.py 4540419
VECTACTIVE: 3 (Hard fault)
RESERVED1: 0
RETOBASE: 1 (no (or no more) active exceptions)
VECTPENDING: 84 (IRQ68)
RESERVED2: 0
ISRPENDING: 1 (Interrupt pending)
RESERVED3: 0
PENDSTCLR: 0 (WO clears SysTick exception)
PENDSTSET: 0 (SysTick not pending)
PENDSVCLR: 0 (WO clears pendsv exception)
PENDSVSET: 0 (SysTick not pending)
RESERVED4: 0
NMIPENDSET: 0 (NMI not pending)
pbarker@bluebottle:~/rc/ardupilot(pr/tools-flesh-out-decode-icsr)$ 
```