### PR TITLE
Retain GCS FS behavior in pilot control modes when upgrading to 4.0

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1555,6 +1555,11 @@ void Copter::convert_fs_options_params(void)
         AP_Param::set_and_save_by_name("FS_GCS_ENABLE", FS_GCS_ENABLED_ALWAYS_RTL);
     }
 
+    // Retains behavior in Copter 3.6 in that GCS failsafe would never be triggered when in a pilot controlled mode
+    if (g.failsafe_gcs != FS_GCS_DISABLED) {
+        fs_options_converted |= int32_t(FailsafeOption::GCS_CONTINUE_IF_PILOT_CONTROL);
+    }
+
     // Write the new value to FS_OPTIONS
     // AP_Param::set_and_save_by_name("FS_OPTIONS", fs_options_converted);
     fs_opt->set_and_save(fs_options_converted);


### PR DESCRIPTION
This PR maintains copter 3.6 behavior that a GCS failsafe will not be triggered if user is in a pilot controlled flight mode.  The FS_OPTIONS bit is set for Continue in pilot control on Ground Control Station Failsafe regardless of what FS_GCS_ENABLE was in 3.6.  This will force the software to retain the copter 3.6 behavior and the user will have to manually remove the option from FS_OPTIONS to have the GCS failsafe trigger in a pilot controlled flight mode.