### PR TITLE
AP_Airspeed: add dedicated wind max param

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
 
     // @Param: WIND_MAX
     // @DisplayName: Maximum wind
-    // @Description: This sets the maximum allowable difference between ground speed and airspeed. This allows the plane to cope with a failing airspeed sensor. A value of zero means to use the airspeed as is.
+    // @Description: This sets the maximum allowable difference between ground speed and airspeed. This allows the plane to cope with a failing airspeed sensor. A value of zero means to use the airspeed as is. See ARSPD_OPTIONS and ARSPD_MAX_WIND to disable airspeed sensors.
     // @Range: 0 127
     // @Units: m/s
     // @Increment: 1

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -179,7 +179,9 @@ private:
 
     AP_Int8 primary_sensor;
     AP_Int32 _options;    // bitmask options for airspeed
-    
+    AP_Float _wind_max;
+    AP_Float _wind_warn;
+
     struct {
         AP_Float offset;
         AP_Float ratio;
@@ -223,7 +225,7 @@ private:
             uint32_t last_check_ms;
             float health_probability;
             int8_t param_use_backup;
-            bool has_warned;
+            uint32_t last_warn_ms;
         } failures;
     } state[AIRSPEED_MAX_SENSORS];
 

--- a/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
@@ -1,6 +1,5 @@
 #include "AP_Airspeed.h"
 
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Math/AP_Math.h>
@@ -22,71 +21,79 @@ void AP_Airspeed::check_sensor_ahrs_wind_max_failures(uint8_t i)
         // slow the checking rate
         return;
     }
+    state[i].failures.last_check_ms = now_ms;
 
-    const float aspeed = get_airspeed();
-    const float wind_max = AP::ahrs().get_max_wind();
-
-    if (aspeed <= 0 || wind_max <= 0) {
-        // invalid estimates
+    if (!is_positive(_wind_max)) {
+        // nothing to do
         return;
     }
 
-    state[i].failures.last_check_ms = now_ms;
-
-    // update state[i].failures.health_probability via LowPassFilter
-    float speed_accuracy;
-    const AP_GPS &gps = AP::gps();
-    if (gps.speed_accuracy(speed_accuracy)) {
-        const float gnd_speed = gps.ground_speed();
-
-        if (aspeed > (gnd_speed + wind_max) || aspeed < (gnd_speed - wind_max)) {
-            // bad, decay fast
-            const float probability_coeff = 0.90f;
-            //state[i].failures.health_probability = probability_coeff*state[i].failures.health_probability + (1.0f-probability_coeff)*0.0f;
-            state[i].failures.health_probability = probability_coeff*state[i].failures.health_probability; // equivalent
-
-        } else if (aspeed < (gnd_speed + wind_max) && aspeed > (gnd_speed - wind_max)) {
-            // good, grow slow
-            const float probability_coeff = 0.98f;
-            state[i].failures.health_probability = probability_coeff*state[i].failures.health_probability + (1.0f-probability_coeff)*1.0f;
-        }
+    const float aspeed = get_airspeed();
+    if (aspeed <= 0) {
+        // invalid estimate
+        return;
     }
 
+    const AP_GPS &gps = AP::gps();
+    if (gps.status() < AP_GPS::GPS_Status::GPS_OK_FIX_3D) {
+        // GPS speed can't be trusted, re-enable airspeed as a fallback
+        if ((param[i].use == 0) && (state[i].failures.param_use_backup == 1)) {
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Airspeed sensor %d, Re-enabled as GPS fall-back", i+1);
+            param[i].use.set_and_notify(state[i].failures.param_use_backup); 
+            state[i].failures.param_use_backup = -1;
+        }
+        return;
+    }
+    const float speed_diff = fabsf(aspeed-gps.ground_speed());
+
+    // update health_probability with LowPassFilter
+    if (speed_diff > _wind_max) {
+        // bad, decay fast
+        const float probability_coeff = 0.90f;
+        state[i].failures.health_probability = probability_coeff*state[i].failures.health_probability;
+
+    } else {
+        // good, grow slow
+        const float probability_coeff = 0.98f;
+        state[i].failures.health_probability = probability_coeff*state[i].failures.health_probability + (1.0f-probability_coeff)*1.0f;
+    }
 
     // Now check if we need to disable or enable the sensor
 
     // here are some probability thresholds
     static const float DISABLE_PROB_THRESH_CRIT = 0.1f;
-    static const float DISABLE_PROB_THRESH_WARN = 0.5f;
     static const float RE_ENABLE_PROB_THRESH_OK = 0.95f;
 
-    // if "disable" option is allowed and sensor is enabled
-    if (param[i].use > 0 && (AP_Airspeed::OptionsMask::ON_FAILURE_AHRS_WIND_MAX_DO_DISABLE & _options)) {
-        // and is probably not healthy
-        if (state[i].failures.health_probability < DISABLE_PROB_THRESH_CRIT) {
+    if (param[i].use > 0) {
+        if (((AP_Airspeed::OptionsMask::ON_FAILURE_AHRS_WIND_MAX_DO_DISABLE & _options) != 0) &&
+                (state[i].failures.health_probability < DISABLE_PROB_THRESH_CRIT)) {
+            // if "disable" option is allowed and sensor is enabled and is probably not healthy
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Airspeed sensor %d failure. Disabling", i+1);
             state[i].failures.param_use_backup = param[i].use;
             param[i].use.set_and_notify(0);
             state[i].healthy = false;
+        }
 
-        // and is probably getting close to not healthy
-        } else if ((state[i].failures.health_probability < DISABLE_PROB_THRESH_WARN) && !state[i].failures.has_warned) {
-            state[i].failures.has_warned = true;
-            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Airspeed sensor %d warning", i+1);
+        // Warn if necessary
 
-        } else if (state[i].failures.health_probability > RE_ENABLE_PROB_THRESH_OK) {
-            state[i].failures.has_warned = false;
+        // set warn to max if not set or larger than max
+        float wind_warn = _wind_warn;
+        if (!is_positive(wind_warn) || (wind_warn > _wind_max)) {
+            wind_warn = _wind_max;
+        }
+
+        if ((speed_diff > wind_warn) && ((now_ms - state[i].failures.last_warn_ms) > 15000)) {
+            state[i].failures.last_warn_ms = now_ms;
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Airspeed %d warning %0.1fm/s air to gnd speed diff", i+1, speed_diff);
         }
 
     // if Re-Enable options is allowed, and sensor is disabled but was previously enabled, and is probably healthy
-    } else if (param[i].use == 0 &&
-        (AP_Airspeed::OptionsMask::ON_FAILURE_AHRS_WIND_MAX_RECOVERY_DO_REENABLE & _options) &&
-        state[i].failures.param_use_backup > 0 &&
-        state[i].failures.health_probability > RE_ENABLE_PROB_THRESH_OK) {
+    } else if (((AP_Airspeed::OptionsMask::ON_FAILURE_AHRS_WIND_MAX_RECOVERY_DO_REENABLE & _options) != 0) &&
+                (state[i].failures.param_use_backup > 0) && 
+                (state[i].failures.health_probability > RE_ENABLE_PROB_THRESH_OK)) {
 
         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Airspeed sensor %d now OK. Re-enabled", i+1);
         param[i].use.set_and_notify(state[i].failures.param_use_backup); // resume
         state[i].failures.param_use_backup = -1; // set to invalid so we don't use it
-        state[i].failures.has_warned = false;
     }
 }


### PR DESCRIPTION
funded by ARACE

This replaces https://github.com/ArduPilot/ardupilot/pull/15437 and adds a dedicated param for airspeed wind max. If its not set then AHRS_WIND_MAX is used as before.

This also is a slight tidy up of `Airspeed_Health.cpp`.

If using the new dedicated param you will always get a waning if the health is bad no matter if its allowed to disable or not. 

Tested in SITL