### PR TITLE
AP_AHRS/EKF: replace prearm_healthy() and prearm_failure_reason() with pre_arm_check()

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -511,7 +511,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     const AP_AHRS_NavEKF &ahrs = AP::ahrs_navekf();
     char failure_msg[50] = {};
     if (!ahrs.pre_arm_check(failure_msg, sizeof(failure_msg))) {
-        check_failed(display_failure, "%s", failure_msg);
+        check_failed(display_failure, "AHRS: %s", failure_msg);
         return false;
     }
 

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -509,12 +509,9 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
 {
     // always check if inertial nav has started and is ready
     const AP_AHRS_NavEKF &ahrs = AP::ahrs_navekf();
-    if (!ahrs.prearm_healthy()) {
-        const char *reason = ahrs.prearm_failure_reason();
-        if (reason == nullptr) {
-            reason = "AHRS not healthy";
-        }
-        check_failed(display_failure, "%s", reason);
+    char failure_msg[50] = {};
+    if (!ahrs.pre_arm_check(failure_msg, sizeof(failure_msg))) {
+        check_failed(display_failure, "%s", failure_msg);
         return false;
     }
 
@@ -530,7 +527,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
 
     if (mode_requires_gps) {
         if (!copter.position_ok()) {
-            // There is no need to call prearm_failure_reason again, because prearm_healthy sure be true if we reach here
+            // vehicle level position estimate checks
             check_failed(display_failure, "Need Position Estimate");
             return false;
         }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -126,7 +126,7 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
         (checks_to_perform & ARMING_CHECK_INS)) {
         char failure_msg[50] = {};
         if (!AP::ahrs().pre_arm_check(failure_msg, sizeof(failure_msg))) {
-            check_failed(ARMING_CHECK_INS, display_failure, "%s", failure_msg);
+            check_failed(ARMING_CHECK_INS, display_failure, "AHRS: %s", failure_msg);
             return false;
         }
     }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -124,12 +124,9 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
     // additional plane specific checks
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
-        if (!AP::ahrs().prearm_healthy()) {
-            const char *reason = AP::ahrs().prearm_failure_reason();
-            if (reason == nullptr) {
-                reason = "AHRS not healthy";
-            }
-            check_failed(ARMING_CHECK_INS, display_failure, "%s", reason);
+        char failure_msg[50] = {};
+        if (!AP::ahrs().pre_arm_check(failure_msg, sizeof(failure_msg))) {
+            check_failed(ARMING_CHECK_INS, display_failure, "%s", failure_msg);
             return false;
         }
     }

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -65,12 +65,9 @@ bool AP_Arming_Sub::ins_checks(bool display_failure)
     // additional sub-specific checks
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
-        if (!AP::ahrs().prearm_healthy()) {
-            const char *reason = AP::ahrs().prearm_failure_reason();
-            if (reason == nullptr) {
-                reason = "AHRS not healthy";
-            }
-            check_failed(ARMING_CHECK_INS, display_failure, "%s", reason);
+        char failure_msg[50] = {};
+        if (!AP::ahrs().pre_arm_check(failure_msg, sizeof(failure_msg))) {
+            check_failed(ARMING_CHECK_INS, display_failure, "AHRS: %s", failure_msg);
             return false;
         }
     }

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -42,12 +42,9 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
     const AP_AHRS &ahrs = AP::ahrs();
 
     // always check if inertial nav has started and is ready
-    if (!ahrs.prearm_healthy()) {
-        const char *reason = ahrs.prearm_failure_reason();
-        if (reason == nullptr) {
-            reason = "AHRS not healthy";
-        }
-        check_failed(display_failure, "%s", reason);
+    char failure_msg[50] = {};
+    if (!ahrs.pre_arm_check(failure_msg, sizeof(failure_msg))) {
+        check_failed(display_failure, "AHRS: %s", failure_msg);
         return false;
     }
 
@@ -59,11 +56,8 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
 
     // ensure position esetimate is ok
     if (!rover.ekf_position_ok()) {
-        const char *reason = ahrs.prearm_failure_reason();
-        if (reason == nullptr) {
-            reason = "Need Position Estimate";
-        }
-        check_failed(display_failure, "%s", reason);
+        // vehicle level position estimate checks
+        check_failed(display_failure, "Need Position Estimate");
         return false;
     }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -171,10 +171,8 @@ public:
     // Methods
     virtual void update(bool skip_ins_update=false) = 0;
 
-    // report any reason for why the backend is refusing to initialise
-    virtual const char *prearm_failure_reason(void) const {
-        return nullptr;
-    }
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    virtual bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const = 0;
 
     // check all cores providing consistent attitudes for prearm checks
     virtual bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const { return true; }
@@ -481,8 +479,6 @@ public:
 
     // is the AHRS subsystem healthy?
     virtual bool healthy(void) const = 0;
-
-    virtual bool prearm_healthy(void) const { return healthy(); }
 
     // true if the AHRS has completed initialisation
     virtual bool initialised(void) const {

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1142,3 +1142,12 @@ bool AP_AHRS_DCM::get_velocity_NED(Vector3f &vec) const
     return true;
 }
 
+// returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+bool AP_AHRS_DCM::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
+{
+    if (!healthy()) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "Not healthy");
+        return false;
+    }
+    return true;
+}

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -120,6 +120,9 @@ public:
 
     bool get_velocity_NED(Vector3f &vec) const override;
 
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const override;
+
 private:
     float _ki;
     float _ki_yaw;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -200,7 +200,8 @@ public:
     // is the AHRS subsystem healthy?
     bool healthy() const override;
 
-    bool prearm_healthy() const override;
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const override;
 
     // true if the AHRS has completed initialisation
     bool initialised() const override;
@@ -211,9 +212,6 @@ public:
     // get compass offset estimates
     // true if offsets are valid
     bool getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const;
-
-    // report any reason for why the backend is refusing to initialise
-    const char *prearm_failure_reason(void) const override;
 
     // check all cores providing consistent attitudes for prearm checks
     bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const override;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -906,13 +906,21 @@ bool NavEKF2::healthy(void) const
     return core[primary].healthy();
 }
 
-bool NavEKF2::all_cores_healthy(void) const
+// returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+bool NavEKF2::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
 {
     if (!core) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "no EKF2 cores");
         return false;
     }
     for (uint8_t i = 0; i < num_cores; i++) {
         if (!core[i].healthy()) {
+            const char *failure = core[primary].prearm_failure_reason();
+            if (failure != nullptr) {
+                hal.util->snprintf(failure_msg, failure_msg_len, failure);
+            } else {
+                hal.util->snprintf(failure_msg, failure_msg_len, "EKF2 core %d unhealthy", (int)i);
+            }
             return false;
         }
     }
@@ -1517,21 +1525,6 @@ uint32_t NavEKF2::getLastVelNorthEastReset(Vector2f &vel) const
         return 0;
     }
     return core[primary].getLastVelNorthEastReset(vel);
-}
-
-// report the reason for why the backend is refusing to initialise
-const char *NavEKF2::prearm_failure_reason(void) const
-{
-    if (!core) {
-        return initFailureReason[int(initFailure)];
-    }
-    for (uint8_t i = 0; i < num_cores; i++) {
-        const char * failure = core[i].prearm_failure_reason();
-        if (failure != nullptr) {
-            return failure;
-        }
-    }
-    return nullptr;
 }
 
 // Returns the amount of vertical position change due to the last reset or core switch in metres

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -61,8 +61,9 @@ public:
     
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
-    // Ensure that all started cores are considered healthy
-    bool all_cores_healthy(void) const;
+
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const;
 
     // returns the index of the primary core
     // return -1 if no primary core selected
@@ -312,9 +313,6 @@ public:
     // return the amount of vertical position change due to the last reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosDownReset(float &posDelta);
-
-    // report any reason for why the backend is refusing to initialise
-    const char *prearm_failure_reason(void) const;
 
     // set and save the _baroAltNoise parameter
     void set_baro_alt_noise(float noise) { _baroAltNoise.set_and_save(noise); };

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -13,7 +13,7 @@ extern const AP_HAL::HAL& hal;
    Monitor magnetometer innovations to see if the heading is good enough to use GPS
    Return true if all criteria pass for 10 seconds
 
-   We also record the failure reason so that prearm_failure_reason()
+   We also record the failure reason so that pre_arm_check()
    can give a good report to the user on why arming is failing
 
    This sets gpsGoodToAlign class variable

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1030,13 +1030,21 @@ bool NavEKF3::healthy(void) const
     return core[primary].healthy();
 }
 
-bool NavEKF3::all_cores_healthy(void) const
+// returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+bool NavEKF3::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
 {
     if (!core) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "no EKF3 cores");
         return false;
     }
     for (uint8_t i = 0; i < num_cores; i++) {
         if (!core[i].healthy()) {
+            const char *failure = core[primary].prearm_failure_reason();
+            if (failure != nullptr) {
+                hal.util->snprintf(failure_msg, failure_msg_len, failure);
+            } else {
+                hal.util->snprintf(failure_msg, failure_msg_len, "EKF3 core %d unhealthy", (int)i);
+            }
             return false;
         }
     }
@@ -1794,21 +1802,6 @@ uint32_t NavEKF3::getLastVelNorthEastReset(Vector2f &vel) const
         return 0;
     }
     return core[primary].getLastVelNorthEastReset(vel);
-}
-
-// report the reason for why the backend is refusing to initialise
-const char *NavEKF3::prearm_failure_reason(void) const
-{
-    if (!core) {
-        return "no EKF3 cores";
-    }
-    for (uint8_t i = 0; i < num_cores; i++) {
-        const char * failure = core[primary].prearm_failure_reason();
-        if (failure != nullptr) {
-            return failure;
-        }
-    }
-    return nullptr;
 }
 
 // Returns the amount of vertical position change due to the last reset or core switch in metres

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -59,8 +59,8 @@ public:
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
 
-    // Check that all cores are started and healthy
-    bool all_cores_healthy(void) const;
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const;
 
     // Update instance error scores for all available cores 
     float updateCoreErrorScores(void);
@@ -397,9 +397,6 @@ public:
     // return the amount of vertical position change due to the last reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosDownReset(float &posDelta);
-
-    // report any reason for why the backend is refusing to initialise
-    const char *prearm_failure_reason(void) const;
 
     // set and save the _baroAltNoise parameter
     void set_baro_alt_noise(float noise) { _baroAltNoise.set_and_save(noise); };

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -13,7 +13,7 @@ extern const AP_HAL::HAL& hal;
    Monitor magnetometer innovations to see if the heading is good enough to use GPS
    Return true if all criteria pass for 10 seconds
 
-   We also record the failure reason so that prearm_failure_reason()
+   We also record the failure reason so that pre_arm_check()
    can give a good report to the user on why arming is failing
 */
 void NavEKF3_core::calcGpsGoodToAlign(void)

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -34,7 +34,7 @@ singleton AP_AHRS method groundspeed_vector Vector2f
 singleton AP_AHRS method get_velocity_NED boolean Vector3f'Null
 singleton AP_AHRS method get_relative_position_NED_home boolean Vector3f'Null
 singleton AP_AHRS method home_is_set boolean
-singleton AP_AHRS method prearm_healthy boolean
+singleton AP_AHRS method healthy boolean
 singleton AP_AHRS method airspeed_estimate boolean float'Null
 singleton AP_AHRS method get_vibration Vector3f
 singleton AP_AHRS method earth_to_body Vector3f Vector3f


### PR DESCRIPTION
This PR enhances the AP_AHRS, DCM and EKF libraries' pre-arm check implementation consistent with other libraries.  This is a pre-requisite for my EKF position source PR: https://github.com/ArduPilot/ardupilot/pull/14803 which needs this change in order to cleanly handle pre-arm failures from multiple AHRS subsystems (i.e. EKF vs sensor source control library).  If someone wanted to add GSF specific pre-arm failure messages, this change should make that much easier.

The changes include:

- AP_AHRS::prearm_healthy() and AP_AHRS::prearm_failure_reason() methods are replaced with a single AP_AHRS::pre_arm_check() which is more consistent with prearm checks in other libraries.  It also removes the possibily of a mismatch between the results of the two calls.
- AP_AHRS_DCM implements the prearm_failure_reason and may return "AHRS not healthy" so there is no change in behaviour.  Previously DCM relied on the default implementation of prearm_healthy and did not implement the prearm_failure_reason.
- AP_AHRS_NavEKF logic is slighlty modified so it **could** (but rarely does) display one of these messages:
    - "AHRS: EKF2 not started"
    - "AHRS: EKF3 not started"
    - "AHRS: invalid EKF type" 
- EKF2 and EKF3 replace all_cores_healthy() and prearm_failure_reason() with pre_arm_check().  The change is the error message will be prefixed with "AHRS: " and these new messages may appear:
   - "AHRS: no EKFx cores"
   - "AHRS: EKFx core y unhealthy"

I don't mind removing the "AHRS: " prefix from EKF failures if people would prefer.

This has been lightly tested on Plane, Copter and Rover.
![image](https://user-images.githubusercontent.com/1498098/95036677-a33e5680-0703-11eb-994f-a1b54bd000cd.png)

![image](https://user-images.githubusercontent.com/1498098/95035445-1d6cdc00-0700-11eb-8432-bee8e74c9189.png)

![image](https://user-images.githubusercontent.com/1498098/95036036-a8020b00-0701-11eb-8899-c060c1d3a0e0.png)
