### PR TITLE
AP_Scripting: add do_aux_function binding

### DIFF
--- a/libraries/AP_Scripting/examples/RCIN_test.lua
+++ b/libraries/AP_Scripting/examples/RCIN_test.lua
@@ -2,6 +2,7 @@
 
 local scripting_rc_1 = rc:find_channel_for_option(300)
 local scripting_rc_2 = rc:find_channel_for_option(301)
+local flip_flop = 0
 
 function update()
   pwm1 = rc:get_pwm(1)
@@ -26,6 +27,17 @@ function update()
       gcs:send_text(0, "Scripting switch is high")
     end
   end
+
+  -- we can also call functions that are available to RC switches
+  -- 28 is Relay one
+  rc:run_aux_function(28, flip_flop)
+
+  if (flip_flop == 0) then
+    flip_flop = 2 -- switch high
+  else
+    flip_flop = 0 -- switch low
+  end
+
 
   return update, 1000 -- reschedules the loop
 end

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -224,8 +224,10 @@ ap_object RC_Channel method norm_input_ignore_trim float
 
 include RC_Channel/RC_Channel.h
 singleton RC_Channels alias rc
+singleton RC_Channels scheduler-semaphore
 singleton RC_Channels method get_pwm boolean uint8_t 1 NUM_RC_CHANNELS uint16_t'Null
 singleton RC_Channels method find_channel_for_option RC_Channel RC_Channel::AUX_FUNC'enum 0 UINT16_MAX
+singleton RC_Channels method run_aux_function boolean RC_Channel::AUX_FUNC'enum 0 UINT16_MAX RC_Channel::AuxSwitchPos'enum RC_Channel::AuxSwitchPos::LOW RC_Channel::AuxSwitchPos::HIGH RC_Channel::AuxFuncTriggerSource::SCRIPTING'literal
 
 include AP_SerialManager/AP_SerialManager.h
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -244,6 +244,7 @@ public:
         BUTTON,
         MAVLINK,
         MISSION,
+        SCRIPTING,
     };
 
     bool read_3pos_switch(AuxSwitchPos &ret) const WARN_IF_UNUSED;


### PR DESCRIPTION
This adds a binding so scripting can call RC_Channel do_aux_function. This small change means scripts can now do everything that can be done from the RC Switches (except modes)

Easier than adding new bindings for each thing, although we do have access to some of the capability directly already (modes arming, relay ect).