### PR TITLE
AP_InterialSensor: Run vibration monitoring on all instances

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -7,6 +7,8 @@
 #define AP_INERTIAL_SENSOR_ACCEL_VIBE_FILT_HZ           2.0f    // accel vibration filter hz
 #define AP_INERTIAL_SENSOR_ACCEL_PEAK_DETECT_TIMEOUT_MS 500     // peak-hold detector timeout
 
+#include <AP_HAL/AP_HAL.h>
+
 /**
    maximum number of INS instances available on this platform. If more
    than 1 then redundant sensors may be available
@@ -14,7 +16,13 @@
 #define INS_MAX_INSTANCES 3
 #define INS_MAX_BACKENDS  6
 #define INS_MAX_NOTCHES 4
-#define INS_VIBRATION_CHECK_INSTANCES 2
+#ifndef INS_VIBRATION_CHECK_INSTANCES
+  #if HAL_MEM_CLASS >= HAL_MEM_CLASS_300
+    #define INS_VIBRATION_CHECK_INSTANCES INS_MAX_INSTANCES
+  #else
+    #define INS_VIBRATION_CHECK_INSTANCES 1
+  #endif
+#endif
 #define XYZ_AXIS_COUNT    3
 // The maximum we need to store is gyro-rate / loop-rate, worst case ArduCopter with BMI088 is 2000/400
 #define INS_MAX_GYRO_WINDOW_SAMPLES 8


### PR DESCRIPTION
We currently only check vibration on the first two IMU's. This is fine until the third IMU becomes the primary for any reason (any easy way to do this is to just set `INS_USE` to 0 for all but the third instance, however you could also get this if we lose comms with the first 2 instances). If this happens we lose all meaningful logging of the VIBE message (we still log 0's however), and it breaks the reporting to the GCS. This also starts to matter as it breaks stuff like the failsafe VTOL example script which attempts to monitor vibration levels.

Is there some reason I've missed why this is to expensive to enable?

I've test flown this on a slightly older copter stable release using a cube orange, and it behaves well.