### PR TITLE
AP_Math: fix LoadUint() to allow 32bit values

### DIFF
--- a/libraries/AP_Math/bitwise.cpp
+++ b/libraries/AP_Math/bitwise.cpp
@@ -19,17 +19,11 @@
 
 #include "bitwise.h"
 
-void loadUint(uint8_t *b, uint16_t v, uint8_t bitCount, bool MSBfirst)
+void loadUint(uint8_t *b, uint32_t v, uint8_t bitCount, bool MSBfirst)
 {
     const uint8_t last = bitCount/8;
-
-//    count = 32
-//    last = 4
-//    MSBfirst = 1;
-
     for (uint8_t i=0; i<last; i++) {
         const uint8_t idx = MSBfirst ? last-1-i : i;
-//        idx = 4-1-0
         b[i] = v >> (8*idx);
     }
 }

--- a/libraries/AP_Math/bitwise.h
+++ b/libraries/AP_Math/bitwise.h
@@ -19,11 +19,8 @@
 
 #include <stdint.h>
 
-void loadUint(uint8_t *b, uint16_t v, uint8_t bitCount, bool MSBfirst = true);
+void loadUint(uint8_t *b, uint32_t v, uint8_t bitCount, bool MSBfirst = true);
 
-//void loadU16(uint8_t *b, uint16_t v, bool MSBfirst = true) { loadUx(b, v, 16, MSBfirst); }
-//void loadU24(uint8_t *b, uint32_t v, bool MSBfirst = true) { loadUx(b, v, 24, MSBfirst); }
-//void loadU32(uint8_t *b, uint32_t v, bool MSBfirst = true) { loadUx(b, v, 32, MSBfirst); }
 uint16_t fetchU16(const uint8_t *v, bool MSBfirst = true);
 uint32_t fetchU24(const uint8_t *v, bool MSBfirst = true);
 uint32_t fetchU32(const uint8_t *v, bool MSBfirst = true);


### PR DESCRIPTION
The current design was limited to 8 and 16 bit shift operations. This adds 24 and 32bit. Useful for the ADSB driver.
