### PR TITLE
Rover: support speed control of DO_REPOSITION

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -718,6 +718,12 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_do_reposition(const mavlink_com
         }
     }
 
+    if (is_positive(packet.param1)) {
+        if (!rover.control_mode->set_desired_speed(packet.param1)) {
+            return MAV_RESULT_FAILED;
+        }
+    }
+
     // set the destination
     if (!rover.mode_guided.set_desired_location(request_location)) {
         return MAV_RESULT_FAILED;


### PR DESCRIPTION
This PR allows DO_REPOSITION command to set speed in Rover.
I tested this in SITL.