### PR TITLE
AP_GPS: add Primary param and 'use primary if at least a 3D' fix option

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -101,8 +101,8 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
 #if GPS_MAX_RECEIVERS > 1
     // @Param: AUTO_SWITCH
     // @DisplayName: Automatic Switchover Setting
-    // @Description: Automatic switchover to GPS reporting best lock
-    // @Values: 0:Disabled,1:UseBest,2:Blend,3:UseSecond
+    // @Description: Automatic switchover to GPS reporting best lock, 1:UseBest selects the GPS with highest status, if both are equal the GPS with highest satellite count is used
+    // @Values: 0:Use primary, 1:UseBest, 2:Blend
     // @User: Advanced
     AP_GROUPINFO("AUTO_SWITCH", 3, AP_GPS, _auto_switch, (int8_t)GPSAutoSwitch::USE_BEST),
 #endif
@@ -336,6 +336,16 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
 
 #endif // GPS_MOVING_BASELINE
 
+#if GPS_MAX_RECEIVERS > 1
+    // @Param: PRIMARY
+    // @DisplayName: Primary GPS
+    // @Description: This GPS will be used when GPS_AUTO_SWITCH is 0 and used preferentially with GPS_AUTO_SWITCH = 4.
+    // @Increment: 1
+    // @Values: 0:FirstGPS, 1:SecondGPS
+    // @User: Advanced
+    AP_GROUPINFO("PRIMARY", 27, AP_GPS, _primary, 0),
+#endif
+
     AP_GROUPEND
 };
 
@@ -372,7 +382,11 @@ bool AP_GPS::needs_uart(GPS_Type type) const
 /// Startup initialisation.
 void AP_GPS::init(const AP_SerialManager& serial_manager)
 {
-    primary_instance = 0;
+    // Set new primary param based on old auto_switch use second option
+    if ((_auto_switch.get() == 3) && !_primary.configured()) {
+        _primary.set_and_save(1);
+        _auto_switch.set_and_save(0);
+    }
 
     // search for serial ports with gps protocol
     uint8_t uart_idx = 0;
@@ -903,15 +917,19 @@ void AP_GPS::update_primary(void)
         return;
     }
 
-    if ((GPSAutoSwitch)_auto_switch.get() == GPSAutoSwitch::NONE) {
-        // AUTO_SWITCH is 0 so no switching of GPSs, always use first instance
-        primary_instance = 0;
-        return;
+    // check the primary param is set to possible GPS
+    int8_t primary_param = _primary.get();
+    if ((primary_param < 0) || (primary_param>=GPS_MAX_RECEIVERS)) {
+        primary_param = 0;
+    }
+    // if primary is not enabled try first instance
+    if (get_type(primary_param) == GPS_TYPE_NONE) {
+        primary_param = 0;
     }
 
-    if ((GPSAutoSwitch)_auto_switch.get() == GPSAutoSwitch::USE_SECOND) {
-        // always select the second GPS instance
-        primary_instance = 1;
+    if ((GPSAutoSwitch)_auto_switch.get() == GPSAutoSwitch::NONE) {
+        // No switching of GPSs, always use the primary instance
+        primary_instance = primary_param;
         return;
     }
 
@@ -1779,6 +1797,10 @@ void AP_GPS::calc_blended_state(void)
 bool AP_GPS::is_healthy(uint8_t instance) const
 {
     if (instance >= GPS_MAX_INSTANCES) {
+        return false;
+    }
+
+    if (get_type(_primary.get()) == GPS_TYPE_NONE) {
         return false;
     }
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -522,6 +522,7 @@ protected:
     AP_Int8 _blend_mask;
     AP_Float _blend_tc;
     AP_Int16 _driver_options;
+    AP_Int8 _primary;
 
 #if GPS_MOVING_BASELINE
     MovingBase mb_params[GPS_MAX_RECEIVERS];
@@ -660,6 +661,7 @@ private:
         USE_BEST    = 1,
         BLEND       = 2,
         //USE_SECOND  = 3, deprecated for new primary param
+        USE_PRIMARY_IF_3D_FIX = 4,
     };
 
     // used for flight testing with GPS loss

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -659,7 +659,7 @@ private:
         NONE        = 0,
         USE_BEST    = 1,
         BLEND       = 2,
-        USE_SECOND  = 3,
+        //USE_SECOND  = 3, deprecated for new primary param
     };
 
     // used for flight testing with GPS loss


### PR DESCRIPTION
funded by ARACE

This adds a option to only conservatively switch away from the first GPS. The use case is that you have one 'nice' GPS and a second smaller 'backup' GPS. Unless the first GPS is giving quite a poor reading we should still use it. The current `use best` method is not a good option for different GPS units.

This will use the GPS that is reporting the best fix status as with `use best`. If both are the same status the first will be used unless the second has 4 or more sats than first. As soon as the first has equal or more we switch to it.

The goal is is to prevent unnecessary GPS switching, as this can cause unexpected behavior, especially if it happens at a inopportune time such as take off or landing.

Tested in SITL.

This would prevent the switching seen here,

![image](https://user-images.githubusercontent.com/33176108/95245671-547be400-080b-11eb-9da6-e2ba33573668.png)

