### PR TITLE
Plane: tailsitters in VTOL transition use FW rates

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -848,7 +848,8 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
     check_attitude_relax();
 
     // normal control modes for VTOL and FW flight
-    if (in_vtol_mode()) {
+    // tailsitter in transition to VTOL flight is not really in a VTOL mode yet
+    if (in_vtol_mode() && !in_tailsitter_vtol_transition()) {
 
         // tailsitter-only body-frame roll control options
         // Angle mode attitude control for pitch and body-frame roll, rate control for euler yaw.


### PR DESCRIPTION
This fixes a bug for tailsitters using Qassist transitioning to forward flight. The current code the motors immediately fall under control of the VTOL code and try to jump to level as quickly as possible, meanwhile the forward flight controller is trying to neatly pitch up. This change leaves the motors under control of the forward flight control until the transition to VTOL flight is complete.

The code path is extremely confusing. Qasisst is enabled for tailsitters in VTOL transition here:
https://github.com/ArduPilot/ardupilot/blob/774c8583b199de8c742041f8be29b76506f750aa/ArduPlane/quadplane.cpp#L1851

And the throttle output is done here:
https://github.com/ArduPilot/ardupilot/blob/774c8583b199de8c742041f8be29b76506f750aa/ArduPlane/tailsitter.cpp#L118

