### PR TITLE
AP_Airspeed: remove size warning on SDP3X crc function.

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -310,7 +310,7 @@ bool AP_Airspeed_SDP3X::get_temperature(float &temperature)
 /*
   check CRC for a set of bytes
  */
-bool AP_Airspeed_SDP3X::_crc(const uint8_t data[], unsigned size, uint8_t checksum)
+bool AP_Airspeed_SDP3X::_crc(const uint8_t data[], uint8_t size, uint8_t checksum)
 {
     uint8_t crc_value = 0xff;
 

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
@@ -49,7 +49,7 @@ public:
 private:
     void _timer();
     bool _send_command(uint16_t cmd);
-    bool _crc(const uint8_t data[], unsigned size, uint8_t checksum);
+    bool _crc(const uint8_t data[], uint8_t size, uint8_t checksum);
     float _correct_pressure(float press);
 
     float _temp;


### PR DESCRIPTION
Clang-Tidy: Loop variable has narrower type 'uint8_t' (aka 'unsigned char') than iteration's upper bound 'unsigned int'

The change is safe as the max value for this parameter is 2