### PR TITLE
NFC: AP_Baro: Change message from AP_Baro to Baro for unification accross …

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -307,7 +307,7 @@ void AP_Baro::calibrate(bool save)
     if (num_calibrated) {
         return;
     }
-    AP_BoardConfig::config_error("AP_Baro: all sensors uncalibrated");
+    AP_BoardConfig::config_error("Baro: all sensors uncalibrated");
 }
 
 /*


### PR DESCRIPTION
…the file

Rework of https://github.com/ArduPilot/ardupilot/pull/13566, just keep the renaming of AP_Baro to Baro