### PR TITLE
Copter: takeoff relaxes wpnav and pos control during spool up

### DIFF
--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -164,7 +164,14 @@ void Mode::auto_takeoff_run()
     if (motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
         set_land_complete(false);
     } else {
+        // motors have not completed spool up yet so relax navigation and position controllers
         wp_nav->shift_wp_origin_to_current_pos();
+        pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
+        pos_control->update_z_controller();
+        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
+        return;
     }
 
     // check if we are not navigating because of low altitude


### PR DESCRIPTION
This is a partial fix to improve takeoffs in Auto and Guided mode for helicopters and large multirotors that have a long spool up time.  The underlying issue is that during takeoff the waypoint navigation controller is running while the motors are still spooling up.  This leads to the altitude target climbing before the vehicle can actually get off the ground.

The fix is to relax the navigation, position and attitude controllers (yaw angle and reset rate I-terms) until the motors have completed spooling up.  These calls are very close to what is used in other modes including Loiter's **AltHold_Landed_Pre_Takeoff** submode. 

Below is a screen shot from SITL of before and after.  Note that in the **before** image the altitude target (in green) climbs before "spool up" completes while in the **after** image the target climbs as "spool up" completes.
![copter-smoother-takeoff](https://user-images.githubusercontent.com/1498098/95431424-1b1cb300-0988-11eb-8541-94de011bb4ce.png)

This still needs testing on a real vehicle.

This is an alternative to PR: https://github.com/ArduPilot/ardupilot/pull/15207 (Copter: fix tradheli guided mode takeoff bug)