### PR TITLE
Notify motor malfunction in SYS_STATUS health flags

### DIFF
--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -150,4 +150,12 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         break;
     }
 #endif
+
+    control_sensors_present |= MAV_SYS_STATUS_SENSOR_PROPULSION;
+    control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_PROPULSION;
+    // only mark propulsion healthy if all of the motors are producing
+    // nominal thrust
+    if (!copter.motors->get_thrust_boost()) {
+        control_sensors_health |= MAV_SYS_STATUS_SENSOR_PROPULSION;
+    }
 }


### PR DESCRIPTION
Let mavros (and/or GCS) find out that one or more motor malfunction, so that mavros can notify a human operator to do maintenance and what kind of maintenance it is.

Requires ArduPilot/mavlink#198
Requires #16717