### PR TITLE
AP_Motors: Check to see if the setting is positive first

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -482,6 +482,10 @@ int16_t AP_MotorsMulticopter::get_pwm_output_max() const
 // parameter checks for MOT_PWM_MIN/MAX, returns true if parameters are valid
 bool AP_MotorsMulticopter::check_mot_pwm_params() const
 {
+    // negative values are out-of-range:
+    if (_pwm_min < 0 || _pwm_max < 0) {
+        return false;
+    }
     // both must be zero or both non-zero:
     if (_pwm_min == 0 && _pwm_max != 0) {
         return false;
@@ -491,10 +495,6 @@ bool AP_MotorsMulticopter::check_mot_pwm_params() const
     }
     // sanity says that minimum should be less than maximum:
     if (_pwm_min != 0 && _pwm_min >= _pwm_max) {
-        return false;
-    }
-    // negative values are out-of-range:
-    if (_pwm_min < 0 || _pwm_max < 0) {
         return false;
     }
     return true;


### PR DESCRIPTION
I am aware that the PWM value is positive.
I enable the other checks by first checking that the set value is positive.