### PR TITLE
AP_HAL_ChibiOS: ensure UART driver fully supports 2-stop bits

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -315,7 +315,9 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
             }
             sercfg.irq_cb = rx_irq_cb;
 #endif // HAL_UART_NODMA
-            sercfg.cr2 |= USART_CR2_STOP1_BITS;
+            if (!(sercfg.cr2 & USART_CR2_STOP2_BITS)) {
+                sercfg.cr2 |= USART_CR2_STOP1_BITS;
+            }
             sercfg.ctx = (void*)this;
 
             sdStart((SerialDriver*)sdef.serial, &sercfg);
@@ -1290,12 +1292,15 @@ void UARTDriver::set_stop_bits(int n)
 
     switch (n) {
     case 1:
-        sercfg.cr2 = _cr2_options | USART_CR2_STOP1_BITS;
+        _cr2_options &= ~USART_CR2_STOP2_BITS;
+        _cr2_options |= USART_CR2_STOP1_BITS;
         break;
     case 2:
-        sercfg.cr2 = _cr2_options | USART_CR2_STOP2_BITS;
+        _cr2_options &= ~USART_CR2_STOP1_BITS;
+        _cr2_options |= USART_CR2_STOP2_BITS;
         break;
     }
+    sercfg.cr2 = _cr2_options;
 
     sdStart((SerialDriver*)sdef.serial, &sercfg);
 #ifndef HAL_UART_NODMA

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -988,7 +988,9 @@ void UARTDriver::half_duplex_setup_tx(void)
 #ifdef HAVE_USB_SERIAL
     if (!hd_tx_active) {
         chEvtGetAndClearFlags(&hd_listener);
-        hd_tx_active = true;
+        // half-duplex transmission is done when both the output is empty and the transmission is ended
+        // if we only wait for empty output the line can be setup for receive too soon losing data bits
+        hd_tx_active = CHN_TRANSMISSION_END | CHN_OUTPUT_EMPTY;
         SerialDriver *sd = (SerialDriver*)(sdef.serial);
         sdStop(sd);
         sercfg.cr3 &= ~USART_CR3_HDSEL;
@@ -1008,16 +1010,18 @@ void UARTDriver::_timer_tick(void)
     if (!_initialised) return;
 
 #ifdef HAVE_USB_SERIAL
-    if (hd_tx_active && (chEvtGetAndClearFlags(&hd_listener) & CHN_OUTPUT_EMPTY) != 0) {
-        /*
-          half-duplex transmit has finished. We now re-enable the
-          HDSEL bit for receive
-         */
-        SerialDriver *sd = (SerialDriver*)(sdef.serial);
-        sdStop(sd);
-        sercfg.cr3 |= USART_CR3_HDSEL;
-        sdStart(sd, &sercfg);
-        hd_tx_active = false;
+    if (hd_tx_active) {
+        hd_tx_active &= ~chEvtGetAndClearFlags(&hd_listener);
+        if (!hd_tx_active) {
+            /*
+                half-duplex transmit has finished. We now re-enable the
+                HDSEL bit for receive
+            */
+            SerialDriver *sd = (SerialDriver*)(sdef.serial);
+            sdStop(sd);
+            sercfg.cr3 |= USART_CR3_HDSEL;
+            sdStart(sd, &sercfg);
+        }
     }
 #endif
 
@@ -1414,6 +1418,7 @@ bool UARTDriver::set_options(uint16_t options)
         }
     } else {
         cr2 &= ~USART_CR2_RXINV;
+        _cr2_options &= ~USART_CR2_RXINV;
         if (rx_line != 0) {
             palLineSetPushPull(rx_line, PAL_PUSHPULL_PULLUP);
         }
@@ -1426,6 +1431,7 @@ bool UARTDriver::set_options(uint16_t options)
         }
     } else {
         cr2 &= ~USART_CR2_TXINV;
+        _cr2_options &= ~USART_CR2_TXINV;
         if (tx_line != 0) {
             palLineSetPushPull(tx_line, PAL_PUSHPULL_PULLUP);
         }
@@ -1436,6 +1442,7 @@ bool UARTDriver::set_options(uint16_t options)
         _cr2_options |= USART_CR2_SWAP;
     } else {
         cr2 &= ~USART_CR2_SWAP;
+        _cr2_options &= ~USART_CR2_SWAP;
     }
 #else // STM32F4
     // F4 can do inversion by GPIO if enabled in hwdef.dat, using
@@ -1467,7 +1474,7 @@ bool UARTDriver::set_options(uint16_t options)
             chEvtRegisterMaskWithFlags(chnGetEventSource((SerialDriver*)sdef.serial),
                                        &hd_listener,
                                        EVT_TRANSMIT_END,
-                                       CHN_OUTPUT_EMPTY);
+                                       CHN_OUTPUT_EMPTY | CHN_TRANSMISSION_END);
             half_duplex = true;
         }
 #ifndef HAL_UART_NODMA
@@ -1480,6 +1487,7 @@ bool UARTDriver::set_options(uint16_t options)
         rx_dma_enabled = tx_dma_enabled = false;
     } else {
         cr3 &= ~USART_CR3_HDSEL;
+        _cr3_options &= ~USART_CR3_HDSEL;
     }
 
     set_pushpull(options);

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -208,7 +208,7 @@ private:
 #if CH_CFG_USE_EVENTS == TRUE
     bool half_duplex;
     event_listener_t hd_listener;
-    bool hd_tx_active;
+    eventflags_t hd_tx_active;
     void half_duplex_setup_tx(void);
 #endif
 


### PR DESCRIPTION
It turns out our UART driver fails badly at half-duplex with 2-stop bits. It doesn't preserve the stop bit setting across a begin() and it switches the half-duplex mode too early meaning stop bits get chopped. This is evident when trying to implement SmartAudio which requires these properties.

This PR fixes all these bugs