### PR TITLE
Rover: Ground speed of 0 can be set

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -718,10 +718,8 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_do_reposition(const mavlink_com
         }
     }
 
-    if (is_positive(packet.param1)) {
-        if (!rover.control_mode->set_desired_speed(packet.param1)) {
-            return MAV_RESULT_FAILED;
-        }
+    if (!rover.control_mode->set_desired_speed(packet.param1)) {
+        return MAV_RESULT_FAILED;
     }
 
     // set the destination


### PR DESCRIPTION
I think it would be better to match the MAVLINK specification.
Also, if a value less than 0 is set, I use the set_desired_speed method in each class to check the value.

MAVLINK SPEC:
https://mavlink.io/en/messages/common.html#MAV_CMD_DO_REPOSITION
