### PR TITLE
3D Simple Avoidance and Extend Proximity mini-fence to 3D 

### DIFF
--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -93,11 +93,7 @@ void ModeFollow::run()
 
         // slow down horizontally as we approach target (use 1/2 of maximum deceleration for gentle slow down)
         const float dist_to_target_xy = Vector2f(dist_vec_offs_neu.x, dist_vec_offs_neu.y).length();
-        copter.avoid.limit_velocity(pos_control->get_pos_xy_p().kP().get(), pos_control->get_max_accel_xy() * 0.5f, desired_velocity_xy_cms, dir_to_target_xy, dist_to_target_xy, copter.G_Dt);
-
-        // limit the horizontal velocity to prevent fence violations
-        copter.avoid.adjust_velocity(pos_control->get_pos_xy_p().kP().get(), pos_control->get_max_accel_xy(), desired_velocity_xy_cms, G_Dt);
-
+        copter.avoid.limit_velocity_2D(pos_control->get_pos_xy_p().kP().get(), pos_control->get_max_accel_xy() * 0.5f, desired_velocity_xy_cms, dir_to_target_xy, dist_to_target_xy, copter.G_Dt);
         // copy horizontal velocity limits back to 3d vector
         desired_velocity_neu_cms.x = desired_velocity_xy_cms.x;
         desired_velocity_neu_cms.y = desired_velocity_xy_cms.y;
@@ -106,8 +102,8 @@ void ModeFollow::run()
         const float des_vel_z_max = copter.avoid.get_max_speed(pos_control->get_pos_z_p().kP().get(), pos_control->get_max_accel_z() * 0.5f, fabsf(dist_vec_offs_neu.z), copter.G_Dt);
         desired_velocity_neu_cms.z = constrain_float(desired_velocity_neu_cms.z, -des_vel_z_max, des_vel_z_max);
 
-        // get avoidance adjusted climb rate
-        desired_velocity_neu_cms.z = get_avoidance_adjusted_climbrate(desired_velocity_neu_cms.z);
+        // limit the velocity for obstacle/fence avoidance
+        copter.avoid.adjust_velocity(desired_velocity_neu_cms, pos_control->get_pos_xy_p().kP().get(), pos_control->get_max_accel_xy(), pos_control->get_pos_z_p().kP().get(), pos_control->get_max_accel_z(), G_Dt);
 
         // calculate vehicle heading
         switch (g2.follow.get_yaw_behave()) {

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -679,10 +679,8 @@ void ModeGuided::set_desired_velocity_with_accel_and_fence_limits(const Vector3f
     curr_vel_des.z += constrain_float(vel_delta.z, -vel_delta_z_max, vel_delta_z_max);
 
 #if AC_AVOID_ENABLED
-    // limit the velocity to prevent fence violations
-    copter.avoid.adjust_velocity(pos_control->get_pos_xy_p().kP(), pos_control->get_max_accel_xy(), curr_vel_des, G_Dt);
-    // get avoidance adjusted climb rate
-    curr_vel_des.z = get_avoidance_adjusted_climbrate(curr_vel_des.z);
+    // limit the velocity for obstacle/fence avoidance
+    copter.avoid.adjust_velocity(curr_vel_des, pos_control->get_pos_xy_p().kP(), pos_control->get_max_accel_xy(), pos_control->get_pos_z_p().kP(), pos_control->get_max_accel_z(), G_Dt);
 #endif
 
     // update position controller with new target

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -27,6 +27,12 @@
  # define AP_AVOID_BEHAVE_DEFAULT AC_Avoid::BehaviourType::BEHAVIOR_SLIDE
 #endif
 
+#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+    # define AP_AVOID_ENABLE_Z          1
+#else
+    # define AP_AVOID_ENABLE_Z          0
+#endif
+
 const AP_Param::GroupInfo AC_Avoid::var_info[] = {
 
     // @Param: ENABLE
@@ -87,17 +93,17 @@ AC_Avoid::AC_Avoid()
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel_cms, bool &backing_up,float dt)
-{
-    // exit immediately if disabled
-    if (_enabled == AC_AVOID_DISABLED) {
-        return;
-    }
-
+/*
+* This method limits velocity and calculates backaway velocity from various supported fences
+* Also limits vertical velocity using adjust_velocity_z method
+*/
+void AC_Avoid::adjust_velocity_fence(float kP, float accel_cmss, Vector3f &desired_vel_cms, Vector3f &backup_vel, float kP_z, float accel_cmss_z, float dt)
+{   
+    // Only horizontal component needed for most fences, since fences are 2D
+    Vector2f desired_velocity_xy{desired_vel_cms.x, desired_vel_cms.y};
+    
     // limit acceleration
     const float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
-    // make a copy of desired velocity since the one that is passed will be modified 
-    const Vector2f desired_vel_orig = desired_vel_cms;
 
     // maximum component of desired  backup velocity in each quadrant 
     Vector2f quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel;
@@ -106,40 +112,80 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel
         // Store velocity needed to back away from fence
         Vector2f backup_vel_fence;
 
-        adjust_velocity_circle_fence(kP, accel_cmss_limited, desired_vel_cms, backup_vel_fence, dt);
+        adjust_velocity_circle_fence(kP, accel_cmss_limited, desired_velocity_xy, backup_vel_fence, dt);
         find_max_quadrant_velocity(backup_vel_fence, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
         
         // backup_vel_fence is set to zero after each fence incase the velocity is unset from previous methods
         backup_vel_fence.zero();
-        adjust_velocity_inclusion_and_exclusion_polygons(kP, accel_cmss_limited, desired_vel_cms, backup_vel_fence, dt);
+        adjust_velocity_inclusion_and_exclusion_polygons(kP, accel_cmss_limited, desired_velocity_xy, backup_vel_fence, dt);
         find_max_quadrant_velocity(backup_vel_fence, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
         
         backup_vel_fence.zero();
-        adjust_velocity_inclusion_circles(kP, accel_cmss_limited, desired_vel_cms, backup_vel_fence, dt);
+        adjust_velocity_inclusion_circles(kP, accel_cmss_limited, desired_velocity_xy, backup_vel_fence, dt);
         find_max_quadrant_velocity(backup_vel_fence, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
         
         backup_vel_fence.zero();
-        adjust_velocity_exclusion_circles(kP, accel_cmss_limited, desired_vel_cms, backup_vel_fence, dt);
+        adjust_velocity_exclusion_circles(kP, accel_cmss_limited, desired_velocity_xy, backup_vel_fence, dt);
         find_max_quadrant_velocity(backup_vel_fence, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
     }
 
     if ((_enabled & AC_AVOID_STOP_AT_BEACON_FENCE) > 0) {
         // Store velocity needed to back away from beacon fence
         Vector2f backup_vel_beacon;
-        adjust_velocity_beacon_fence(kP, accel_cmss_limited, desired_vel_cms, backup_vel_beacon, dt);
+        adjust_velocity_beacon_fence(kP, accel_cmss_limited, desired_velocity_xy, backup_vel_beacon, dt);
         find_max_quadrant_velocity(backup_vel_beacon, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
     }
 
-    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled) {
-        // Store velocity needed to back away from physical obstacles
-        Vector2f backup_vel_proximity;
-        adjust_velocity_proximity(kP, accel_cmss_limited, desired_vel_cms, backup_vel_proximity, dt);
-        find_max_quadrant_velocity(backup_vel_proximity, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
-    }
+    // check for vertical fence
+    float desired_velocity_z = desired_vel_cms.z;
+    float desired_backup_vel_z = 0.0f;
+    adjust_velocity_z(kP_z, accel_cmss_z, desired_velocity_z, desired_backup_vel_z, dt);
 
     // Desired backup velocity is sum of maximum velocity component in each quadrant 
-    Vector2f desired_backup_vel = quad_1_back_vel + quad_2_back_vel + quad_3_back_vel + quad_4_back_vel;
+    const Vector2f desired_backup_vel_xy = quad_1_back_vel + quad_2_back_vel + quad_3_back_vel + quad_4_back_vel;
+    backup_vel = Vector3f{desired_backup_vel_xy.x, desired_backup_vel_xy.y, desired_backup_vel_z};
+    desired_vel_cms = Vector3f{desired_velocity_xy.x, desired_velocity_xy.y, desired_velocity_z};
+}
+
+/*
+* Adjusts the desired velocity so that the vehicle can stop
+* before the fence/object.
+* kP, accel_cmss are for the horizontal axis
+* kP_z, accel_cmss_z are for vertical axis
+*/
+void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel_cms, float kP_z, float accel_cmss_z, bool &backing_up, float dt)
+{
+    // exit immediately if disabled
+    if (_enabled == AC_AVOID_DISABLED) {
+        return;
+    }
+
+    // limit acceleration
+    const float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
+
+    // maximum component of horizontal desired  backup velocity in each quadrant 
+    Vector2f quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel;
+    float back_vel_up = 0.0f;
+    float back_vel_down = 0.0f;
     
+    // Avoidance in response to proximity sensor
+    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled) {
+        // Store velocity needed to back away from physical obstacles
+        Vector3f backup_vel_proximity;
+        adjust_velocity_proximity(kP, accel_cmss_limited, desired_vel_cms, backup_vel_proximity, kP_z,accel_cmss_z, dt);
+        find_max_quadrant_velocity_3D(backup_vel_proximity, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, back_vel_up, back_vel_down);
+    }
+    
+    // Avoidance in response to various fences 
+    Vector3f backup_vel_fence;
+    adjust_velocity_fence(kP, accel_cmss, desired_vel_cms, backup_vel_fence, kP_z, accel_cmss_z, dt);
+    find_max_quadrant_velocity_3D(backup_vel_fence , quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, back_vel_up, back_vel_down);
+    
+    // Desired backup velocity is sum of maximum velocity component in each quadrant
+    const Vector2f desired_backup_vel_xy = quad_1_back_vel + quad_2_back_vel + quad_3_back_vel + quad_4_back_vel;
+    const float desired_backup_vel_z = back_vel_down + back_vel_up;
+    Vector3f desired_backup_vel{desired_backup_vel_xy.x, desired_backup_vel_xy.y, desired_backup_vel_z};
+
     const float max_back_spd_cms = _backup_speed_max * 100.0f;
     if (!desired_backup_vel.is_zero() && is_positive(max_back_spd_cms)) {
         backing_up = true;
@@ -147,38 +193,31 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel
         if (desired_backup_vel.length() > max_back_spd_cms) {
             desired_backup_vel = desired_backup_vel.normalized() * max_back_spd_cms;
         }
+        
         if ((AC_Avoid::BehaviourType)_behavior.get() == BEHAVIOR_SLIDE) {
-            // project desired velocity towards backup velocity 
-            Vector2f projected_vel = desired_vel_cms.projected(desired_backup_vel);
+            // project desired velocity towards backup velocity horizontally 
+            const Vector2f backup_vel_xy{desired_backup_vel.x, desired_backup_vel.y};
+            Vector2f projected_vel; 
+            if (!backup_vel_xy.is_zero()) {
+               projected_vel = Vector2f{desired_vel_cms.x, desired_vel_cms.y}.projected(Vector2f{desired_backup_vel.x, desired_backup_vel.y});
+            }
             // subtract this projection since we are already going in that direction
-            desired_vel_cms -= projected_vel;
-            desired_vel_cms += desired_backup_vel;
+            desired_vel_cms -= Vector3f{projected_vel.x, projected_vel.y, 0.0f};
+            desired_vel_cms += Vector3f{desired_backup_vel.x, desired_backup_vel.y, 0.0f};
+            // let user take control vertically if they are backing away at a greater speed than what we have calculated based on limits
+            if (!is_negative(desired_backup_vel.z)) {
+                desired_vel_cms.z = MAX(desired_vel_cms.z, desired_backup_vel.z);
+            } else {
+                desired_vel_cms.z = MIN(desired_vel_cms.z, desired_backup_vel.z);
+            }
         } else {
             // back away to stopping position
             desired_vel_cms = desired_backup_vel;
         }
     }
-
-    // only log results if velocity has been modified to avoid fence/obstacle
-    if (desired_vel_orig != desired_vel_cms) {
-        // log at not more than 10hz (adjust_velocity method can be potentially called at 400hz!)
-        uint32_t now = AP_HAL::millis();
-        if ((now - _last_log_ms) > 100) {
-            _last_log_ms = now;
-            AP::logger().Write_SimpleAvoidance(true, desired_vel_orig, desired_vel_cms, backing_up);
-        }
-    }
 }
 
-// convenience function to accept Vector3f.  Only x and y are adjusted
-void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel_cms, float dt)
-{
-    Vector2f des_vel_xy(desired_vel_cms.x, desired_vel_cms.y);
-    adjust_velocity(kP, accel_cmss, des_vel_xy, dt);
-    desired_vel_cms.x = des_vel_xy.x;
-    desired_vel_cms.y = des_vel_xy.y;
-}
-
+// This method is used in most Rover modes and not in Copter
 // adjust desired horizontal speed so that the vehicle stops before the fence or object
 // accel (maximum acceleration/deceleration) is in m/s/s
 // heading is in radians
@@ -187,12 +226,15 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel
 void AC_Avoid::adjust_speed(float kP, float accel, float heading, float &speed, float dt)
 {
     // convert heading and speed into velocity vector
-    Vector2f vel_xy;
-    vel_xy.x = cosf(heading) * speed * 100.0f;
-    vel_xy.y = sinf(heading) * speed * 100.0f;
+    Vector3f vel{
+        cosf(heading) * speed * 100.0f,
+        sinf(heading) * speed * 100.0f,
+        0.0f
+    };
 
     bool backing_up  = false;
-    adjust_velocity(kP, accel * 100.0f, vel_xy, backing_up, dt);
+    adjust_velocity(kP, accel * 100.0f, vel, 0, 0, backing_up, dt);
+    const Vector2f vel_xy{vel.x, vel.y};
 
     if (backing_up) {
         // back up
@@ -214,13 +256,15 @@ void AC_Avoid::adjust_speed(float kP, float accel, float heading, float &speed, 
 }
 
 // adjust vertical climb rate so vehicle does not break the vertical fence
-void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_cms, float dt)
+void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_cms, float& backup_speed, float dt)
 {
     // exit immediately if disabled
     if (_enabled == AC_AVOID_DISABLED) {
         return;
     }
-
+    if (!AP_AVOID_ENABLE_Z) {
+        return;
+    }
     // do not adjust climb_rate if level or descending
     if (climb_rate_cms <= 0.0f) {
         return;
@@ -275,6 +319,8 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         // do not allow climbing if we've breached the safe altitude
         if (alt_diff <= 0.0f) {
             climb_rate_cms = MIN(climb_rate_cms, 0.0f);
+            // also calculate backup speed that will get us back to safe altitude
+            backup_speed = -1*(get_max_speed(kP, accel_cmss_limited, -alt_diff*100.0f, dt));
             return;
         }
 
@@ -334,13 +380,14 @@ void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float veh_angle_max)
 }
 
 /*
+ * Note: This method is used to limit velocity horizontally only 
  * Limits the component of desired_vel_cms in the direction of the unit vector
  * limit_direction to be at most the maximum speed permitted by the limit_distance_cm.
  *
  * Uses velocity adjustment idea from Randy's second email on this thread:
  * https://groups.google.com/forum/#!searchin/drones-discuss/obstacle/drones-discuss/QwUXz__WuqY/qo3G8iTLSJAJ
  */
-void AC_Avoid::limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel_cms, const Vector2f& limit_direction, float limit_distance_cm, float dt)
+void AC_Avoid::limit_velocity_2D(float kP, float accel_cmss, Vector2f &desired_vel_cms, const Vector2f& limit_direction, float limit_distance_cm, float dt)
 {
     const float max_speed = get_max_speed(kP, accel_cmss, limit_distance_cm, dt);
     // project onto limit direction
@@ -353,12 +400,67 @@ void AC_Avoid::limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel_
 }
 
 /*
- * Compute the back away velocity required to avoid breaching margin
+ * Note: This method is used to limit velocity horizontally and vertically given a 3D desired velocity vector 
+ * Limits the component of desired_vel_cms in the direction of the obstacle_vector based on the passed value of "margin"
+ */
+void AC_Avoid::limit_velocity_3D(float kP, float accel_cmss, Vector3f &desired_vel_cms, const Vector3f& obstacle_vector, float margin_cm, float kP_z, float accel_cmss_z, float dt)
+{  
+    if (desired_vel_cms.is_zero()) {
+        // nothing to limit
+        return;
+    }
+    // create a margin_cm length vector in the direction of desired_vel_cms
+    // this will create larger margin towards the direction vehicle is traveling in
+    const Vector3f margin_vector = desired_vel_cms.normalized() * margin_cm;
+    
+    Vector2f velocity_xy{desired_vel_cms.x, desired_vel_cms.y};
+    const Vector2f limit_direction_xy{obstacle_vector.x, obstacle_vector.y};
+    float distance_from_fence_xy = MAX((limit_direction_xy.length() - Vector2f{margin_vector.x, margin_vector.y}.length()), 0.0f);
+    if (!limit_direction_xy.is_zero()) {
+        limit_velocity_2D(kP, accel_cmss, velocity_xy, limit_direction_xy.normalized(), distance_from_fence_xy, dt);
+        desired_vel_cms.x = velocity_xy.x;
+        desired_vel_cms.y = velocity_xy.y;
+    }
+    
+    if (is_zero(desired_vel_cms.z)) {
+        // nothing to limit vertically 
+        return;
+    }
+
+    if (is_negative(desired_vel_cms.z * obstacle_vector.z)) {
+        // why limit velocity vertically when we are going the opposite direction
+        return;
+    }
+    
+    // to check if Z velocity changes
+    const float velocity_z_original = desired_vel_cms.z;
+    const float z_speed = fabsf(desired_vel_cms.z);
+    // check if z velocity is positive or negative
+    const float velocity_z_sign = z_speed/desired_vel_cms.z;
+    const float dist_z = MAX(fabsf(obstacle_vector.z - margin_vector.z), 0.0f); 
+    if (is_zero(dist_z)) {
+        // eliminate any vertical velocity 
+        desired_vel_cms.z = 0.0f;
+    } else {
+        const float max_z_speed = get_max_speed(kP_z, accel_cmss_z, dist_z, dt);
+        desired_vel_cms.z = MIN(max_z_speed, z_speed);
+    }
+    // make sure the direction of the Z velocity did not change
+    // we are only limiting speed here, not changing directions 
+    desired_vel_cms.z = fabsf(desired_vel_cms.z) * velocity_z_sign;
+
+    if (!is_equal(desired_vel_cms.z, velocity_z_original)) {
+        _last_limit_time = AP_HAL::millis();
+    }
+}
+
+/*
+ * Compute the back away horizontal velocity required to avoid breaching margin
  * INPUT: This method requires the breach in margin distance (back_distance_cm), direction towards the breach (limit_direction)
  *        It then calculates the desired backup velocity and passes it on to "find_max_quadrant_velocity" method to distribute the velocity vectors into respective quadrants
- * OUTPUT: The method then outputs four velocities (quad1/2/3/4_back_vel_cms), which correspond to the maximum final desired backup velocity in each quadrant
+ * OUTPUT: The method then outputs four velocities (quad1/2/3/4_back_vel_cms), which correspond to the maximum horizontal desired backup velocity in each quadrant
  */
-void AC_Avoid::calc_backup_velocity(float kP, float accel_cmss, Vector2f &quad1_back_vel_cms, Vector2f &quad2_back_vel_cms, Vector2f &quad3_back_vel_cms, Vector2f &quad4_back_vel_cms, float back_distance_cm, Vector2f limit_direction, float dt)
+void AC_Avoid::calc_backup_velocity_2D(float kP, float accel_cmss, Vector2f &quad1_back_vel_cms, Vector2f &quad2_back_vel_cms, Vector2f &quad3_back_vel_cms, Vector2f &quad4_back_vel_cms, float back_distance_cm, Vector2f limit_direction, float dt)
 {      
     if (limit_direction.is_zero()) {
         // protect against divide by zero
@@ -374,6 +476,38 @@ void AC_Avoid::calc_backup_velocity(float kP, float accel_cmss, Vector2f &quad1_
     Vector2f back_direction_vel = limit_direction * (-back_speed);
     // divide the vector into quadrants, find maximum velocity component in each quadrant 
     find_max_quadrant_velocity(back_direction_vel, quad1_back_vel_cms, quad2_back_vel_cms, quad3_back_vel_cms, quad4_back_vel_cms);
+}
+
+/*
+* Compute the back away velocity required to avoid breaching margin, including vertical component
+* min_z_vel is <= 0, and stores the greatest velocity in the donwards direction
+* max_z_vel is >= 0, and stores the greatest velocity in the upwards direction
+* eventually max_z_vel + min_z_vel will give the final desired Z backaway velocity
+*/
+void AC_Avoid::calc_backup_velocity_3D(float kP, float accel_cmss, Vector2f &quad1_back_vel_cms, Vector2f &quad2_back_vel_cms, Vector2f &quad3_back_vel_cms, Vector2f &quad4_back_vel_cms, float back_distance_cm, Vector3f limit_direction, float kp_z, float accel_cmss_z, float back_distance_z, float& min_z_vel, float& max_z_vel, float dt)
+{   
+    // backup horizontally 
+    if (is_positive(back_distance_cm)) {
+        Vector2f limit_direction_2d{limit_direction.x, limit_direction.y};
+        calc_backup_velocity_2D(kP, accel_cmss, quad1_back_vel_cms, quad2_back_vel_cms, quad3_back_vel_cms, quad4_back_vel_cms, back_distance_cm, limit_direction_2d, dt);
+    }
+
+    // backup vertically 
+    if (!is_zero(back_distance_z)) {
+        float back_speed_z = get_max_speed(kp_z, 0.4f * accel_cmss_z, fabsf(back_distance_z), dt);
+        // Down is positive
+        if (is_positive(back_distance_z)) {
+            back_speed_z *= -1.0f;
+        } 
+
+        // store the z backup speed into min or max z if possible
+        if (back_speed_z < min_z_vel) {
+            min_z_vel = back_speed_z;  
+        }
+        if (back_speed_z > max_z_vel) {
+            max_z_vel = back_speed_z;
+        }
+    }
 }
 
 /*
@@ -402,6 +536,24 @@ void AC_Avoid::find_max_quadrant_velocity(Vector2f &desired_vel, Vector2f &quad1
     // fourth quadrant: +ve x, -ve y direction
     if (is_positive(desired_vel.x) && is_negative(desired_vel.y)) {
         quad4_vel = Vector2f{MAX(quad4_vel.x, desired_vel.x), MIN(quad4_vel.y,desired_vel.y)};
+    }
+}
+
+/*
+Calculate maximum velocity vector that can be formed in each quadrant and separately store max & min of vertical components
+*/
+void AC_Avoid::find_max_quadrant_velocity_3D(Vector3f &desired_vel, Vector2f &quad1_vel, Vector2f &quad2_vel, Vector2f &quad3_vel, Vector2f &quad4_vel, float &max_z_vel, float &min_z_vel)
+{   
+    // split into horizontal and vertical components 
+    Vector2f velocity_xy{desired_vel.x, desired_vel.y};
+    find_max_quadrant_velocity(velocity_xy, quad1_vel, quad2_vel, quad3_vel, quad4_vel);
+    
+    // store maximum and minimum of z 
+    if (is_positive(desired_vel.z) && (desired_vel.z > max_z_vel)) {
+        max_z_vel = desired_vel.z;
+    }
+    if (is_negative(desired_vel.z) && (desired_vel.z < min_z_vel)) {
+        min_z_vel = desired_vel.z;
     }
 }
 
@@ -479,7 +631,7 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
     
     // back away if vehicle has breached margin
     if (is_negative(distance_to_boundary - margin_cm)) {     
-        calc_backup_velocity(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_cm - distance_to_boundary, position_xy, dt);
+        calc_backup_velocity_2D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_cm - distance_to_boundary, position_xy, dt);
     }
     // desired backup velocity is sum of maximum velocity component in each quadrant 
     backup_vel = quad_1_back_vel + quad_2_back_vel + quad_3_back_vel + quad_4_back_vel;
@@ -557,7 +709,7 @@ void AC_Avoid::adjust_velocity_inclusion_and_exclusion_polygons(float kP, float 
         const Vector2f* boundary = fence->polyfence().get_inclusion_polygon(i, num_points);
         Vector2f backup_vel_inc;
         // adjust velocity
-        adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, backup_vel_inc, boundary, num_points, true, fence->get_margin(), dt, true);
+        adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, backup_vel_inc, boundary, num_points, fence->get_margin(), dt, true);
         find_max_quadrant_velocity(backup_vel_inc, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
     }
 
@@ -568,7 +720,7 @@ void AC_Avoid::adjust_velocity_inclusion_and_exclusion_polygons(float kP, float 
         const Vector2f* boundary = fence->polyfence().get_exclusion_polygon(i, num_points);
         Vector2f backup_vel_exc;
         // adjust velocity
-        adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, backup_vel_exc, boundary, num_points, true, fence->get_margin(), dt, false);
+        adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, backup_vel_exc, boundary, num_points, fence->get_margin(), dt, false);
         find_max_quadrant_velocity(backup_vel_exc, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel);
     }
     // desired backup velocity is sum of maximum velocity component in each quadrant 
@@ -650,7 +802,7 @@ void AC_Avoid::adjust_velocity_inclusion_circles(float kP, float accel_cmss, Vec
             const float margin_breach = radius_with_margin - safe_sqrt(dist_sq_cm);
             // back away if vehicle has breached margin
             if (is_negative(margin_breach)) {
-                calc_backup_velocity(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_breach, position_NE_rel, dt);
+                calc_backup_velocity_2D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_breach, position_NE_rel, dt);
             }
             if (is_zero(desired_speed)) {
                 // no avoidance necessary when desired speed is zero
@@ -780,7 +932,7 @@ void AC_Avoid::adjust_velocity_exclusion_circles(float kP, float accel_cmss, Vec
             const float dist_to_boundary = vector_to_center.length() - radius_cm;
             // back away if vehicle has breached margin
             if (is_negative(dist_to_boundary - margin_cm)) {
-                calc_backup_velocity(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_cm - dist_to_boundary, vector_to_center, dt);
+                calc_backup_velocity_2D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_cm - dist_to_boundary, vector_to_center, dt);
             }
             if (is_zero(desired_speed)) {
                 // no avoidance necessary when desired speed is zero
@@ -803,7 +955,7 @@ void AC_Avoid::adjust_velocity_exclusion_circles(float kP, float accel_cmss, Vec
                     }
                     // vehicle is outside the circle, adjust velocity to stay outside
                     limit_direction.normalize();
-                    limit_velocity(kP, accel_cmss, desired_vel_cms, limit_direction, MAX(limit_distance_cm - margin_cm, 0.0f), dt);
+                    limit_velocity_2D(kP, accel_cmss, desired_vel_cms, limit_direction, MAX(limit_distance_cm - margin_cm, 0.0f), dt);
                 }
                 break;
                 case BEHAVIOR_STOP: {
@@ -863,13 +1015,13 @@ void AC_Avoid::adjust_velocity_beacon_fence(float kP, float accel_cmss, Vector2f
     if (AP::fence()) {
         margin = AP::fence()->get_margin();
     }
-    adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, backup_vel, boundary, num_points, true, margin, dt, true);
+    adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, backup_vel, boundary, num_points, margin, dt, true);
 }
 
 /*
  * Adjusts the desired velocity based on output from the proximity sensor
  */
-void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &desired_vel_cms, Vector2f &backup_vel, float dt)
+void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector3f &desired_vel_cms, Vector3f &backup_vel, float kP_z, float accel_cmss_z, float dt)
 {
     // exit immediately if proximity sensor is not present
     AP_Proximity *proximity = AP::proximity();
@@ -882,17 +1034,112 @@ void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &d
     if (_proximity.get_status() != AP_Proximity::Status::Good) {
         return;
     }
+    
+    const AP_AHRS &_ahrs = AP::ahrs();
+    
+    // Safe_vel will be adjusted to stay away from Proximity Obstacles
+    Vector3f safe_vel{desired_vel_cms};
+    Vector2f desired_back_vel_cms_xy;
 
-    // get boundary from proximity sensor
-    uint16_t num_points = 0;
-    const Vector2f *boundary = _proximity.get_boundary_points(num_points);
-    adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, backup_vel, boundary, num_points, false, _margin, dt, true);
+    // for backing away
+    Vector2f quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel;
+    float max_back_vel_z = 0.0f;
+    float min_back_vel_z = 0.0f; 
+
+    // rotate velocity vector from earth frame to body-frame since obstacles are in body-frame
+    Vector2f safe_vel_2d = _ahrs.earth_to_body2D(Vector2f{desired_vel_cms.x, desired_vel_cms.y});
+    safe_vel = Vector3f{safe_vel_2d.x, safe_vel_2d.y, desired_vel_cms.z};
+        
+    // calc margin in cm
+    const float margin_cm = MAX(_margin * 100.0f, 0.0f);
+    Vector3f stopping_point_plus_margin; 
+    if (!desired_vel_cms.is_zero()) {
+        // for stopping
+        const float speed = safe_vel.length();
+        stopping_point_plus_margin = safe_vel*((2.0f + margin_cm + get_stopping_distance(kP, accel_cmss, speed))/speed);
+    }
+    
+    // get total number of obstacles
+    const uint8_t obstacle_num = _proximity.get_obstacle_count();
+    if (obstacle_num == 0) {
+        // no obstacles
+        return;
+    }
+ 
+    for (uint8_t i = 0; i<obstacle_num; i++) {
+        // get obstacle from proximity library
+        Vector3f vector_to_obstacle;
+        _proximity.get_obstacle(i, vector_to_obstacle);
+        const float dist_to_boundary = vector_to_obstacle.length();
+        if (is_zero(dist_to_boundary)) {
+            continue;
+        }
+
+        // back away if vehicle has breached margin
+        if (is_negative(dist_to_boundary - margin_cm)) {
+            const float breach_dist = margin_cm - dist_to_boundary;
+            // this vector will help us divide how much we have to back away horizontally and vertically
+            const Vector3f margin_vector = vector_to_obstacle.normalized() * breach_dist;
+            const float xy_back_dist = norm(margin_vector.x, margin_vector.y);
+            const float z_back_dist = margin_vector.z;
+            calc_backup_velocity_3D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, xy_back_dist, vector_to_obstacle, kP_z, accel_cmss_z, z_back_dist, min_back_vel_z, max_back_vel_z, dt);
+        }
+        
+        if (desired_vel_cms.is_zero()) {
+            // cannot limit velocity if there is nothing to limit
+            // backing up (if needed) has already been done
+            continue;
+        }
+
+        if ((AC_Avoid::BehaviourType)_behavior.get() == BEHAVIOR_SLIDE) {
+            Vector3f limit_direction = vector_to_obstacle;
+            // distance to closest point
+            const float limit_distance_cm = limit_direction.length();
+            if (!is_zero(limit_distance_cm)) {
+                // Adjust velocity to not violate margin.
+                limit_velocity_3D(kP, accel_cmss, safe_vel, limit_direction, margin_cm, kP_z, accel_cmss_z, dt);
+            } else {
+                // We are exactly on the edge, this should ideally never be possible
+                // i.e. do not adjust velocity.
+                continue;
+            }
+        } else {
+            // vector from current position to obstacle
+            Vector3f limit_direction;
+            // find intersection with line segment
+            const float limit_distance_cm = _proximity.distance_to_obstacle(i, Vector3f{0.0f, 0.0f, 0.0f}, stopping_point_plus_margin, limit_direction);
+            if (!is_zero(limit_distance_cm)) {
+                if (limit_distance_cm <= margin_cm) {
+                    // we are within the margin so stop vehicle
+                    safe_vel.zero();
+                } else {
+                    // vehicle inside the given edge, adjust velocity to not violate this edge
+                    limit_velocity_3D(kP, accel_cmss, safe_vel, limit_direction, margin_cm, kP_z, accel_cmss_z, dt);
+                }
+            } else {
+                // We are exactly on the edge, this should ideally never be possible
+                // i.e. do not adjust velocity.
+                return;
+            }
+        }
+    }
+
+    // desired backup velocity is sum of maximum velocity component in each quadrant 
+    desired_back_vel_cms_xy = quad_1_back_vel + quad_2_back_vel + quad_3_back_vel + quad_4_back_vel;
+    const float desired_back_vel_cms_z = max_back_vel_z + min_back_vel_z;
+
+    // set modified desired velocity vector and back away velocity vector
+    // vectors were in body-frame, rotate resulting vector back to earth-frame
+    safe_vel_2d = _ahrs.body_to_earth2D(Vector2f{safe_vel.x, safe_vel.y});
+    desired_vel_cms = Vector3f{safe_vel_2d.x, safe_vel_2d.y, safe_vel.z};
+    const Vector2f backup_vel_xy = _ahrs.body_to_earth2D(desired_back_vel_cms_xy);
+    backup_vel = Vector3f{backup_vel_xy.x, backup_vel_xy.y, desired_back_vel_cms_z};
 }
 
 /*
  * Adjusts the desired velocity for the polygon fence.
  */
-void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &desired_vel_cms, Vector2f &backup_vel, const Vector2f* boundary, uint16_t num_points, bool earth_frame, float margin, float dt, bool stay_inside)
+void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &desired_vel_cms, Vector2f &backup_vel, const Vector2f* boundary, uint16_t num_points, float margin, float dt, bool stay_inside)
 {
     // exit if there are no points
     if (boundary == nullptr || num_points == 0) {
@@ -903,14 +1150,13 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
 
     // do not adjust velocity if vehicle is outside the polygon fence
     Vector2f position_xy;
-    if (earth_frame) {
-        if (!_ahrs.get_relative_position_NE_origin(position_xy)) {
-            // boundary is in earth frame but we have no idea
-            // where we are
-            return;
-        }
-        position_xy = position_xy * 100.0f;  // m to cm
+    if (!_ahrs.get_relative_position_NE_origin(position_xy)) {
+        // boundary is in earth frame but we have no idea
+        // where we are
+        return;
     }
+    position_xy = position_xy * 100.0f;  // m to cm
+
 
     // return if we have already breached polygon
     const bool inside_polygon = !Polygon_outside(position_xy, boundary, num_points);
@@ -923,12 +1169,6 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
     // e.g. if we are exactly on the boundary.
     Vector2f safe_vel(desired_vel_cms);
     Vector2f desired_back_vel_cms;
-
-    // if boundary points are in body-frame, rotate velocity vector from earth frame to body-frame
-    if (!earth_frame) {
-        safe_vel.x = desired_vel_cms.y * _ahrs.sin_yaw() + desired_vel_cms.x * _ahrs.cos_yaw(); // right
-        safe_vel.y = desired_vel_cms.y * _ahrs.cos_yaw() - desired_vel_cms.x * _ahrs.sin_yaw(); // forward
-    }
 
     // calc margin in cm
     const float margin_cm = MAX(margin * 100.0f, 0.0f);
@@ -954,7 +1194,7 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
         Vector2f vector_to_boundary = Vector2f::closest_point(position_xy, start, end) - position_xy;
         // back away if vehicle has breached margin
         if (is_negative(vector_to_boundary.length() - margin_cm)) {
-            calc_backup_velocity(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_cm-vector_to_boundary.length(), vector_to_boundary, dt);
+            calc_backup_velocity_2D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, margin_cm-vector_to_boundary.length(), vector_to_boundary, dt);
         }
         
         // exit immediately if no desired velocity
@@ -971,7 +1211,7 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
                 // We are strictly inside the given edge.
                 // Adjust velocity to not violate this edge.
                 limit_direction /= limit_distance_cm;
-                limit_velocity(kP, accel_cmss, safe_vel, limit_direction, MAX(limit_distance_cm - margin_cm, 0.0f), dt);
+                limit_velocity_2D(kP, accel_cmss, safe_vel, limit_direction, MAX(limit_distance_cm - margin_cm, 0.0f), dt);
             } else {
                 // We are exactly on the edge - treat this as a fence breach.
                 // i.e. do not adjust velocity.
@@ -991,7 +1231,7 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
                     } else {
                         // vehicle inside the given edge, adjust velocity to not violate this edge
                         limit_direction /= limit_distance_cm;
-                        limit_velocity(kP, accel_cmss, safe_vel, limit_direction, MAX(limit_distance_cm - margin_cm, 0.0f), dt);
+                        limit_velocity_2D(kP, accel_cmss, safe_vel, limit_direction, MAX(limit_distance_cm - margin_cm, 0.0f), dt);
                     }
                 } else {
                     // We are exactly on the edge - treat this as a fence breach.
@@ -1005,16 +1245,8 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
     desired_back_vel_cms = quad_1_back_vel + quad_2_back_vel + quad_3_back_vel + quad_4_back_vel;
 
     // set modified desired velocity vector or back away velocity vector
-    if (earth_frame) {
-        desired_vel_cms = safe_vel;
-        backup_vel = desired_back_vel_cms;
-    } else {
-        // if points were in body-frame, rotate resulting vector back to earth-frame
-        desired_vel_cms.x = safe_vel.x * _ahrs.cos_yaw() - safe_vel.y * _ahrs.sin_yaw();
-        desired_vel_cms.y = safe_vel.x * _ahrs.sin_yaw() + safe_vel.y * _ahrs.cos_yaw();
-        backup_vel.x = desired_back_vel_cms.x * _ahrs.cos_yaw() - desired_back_vel_cms.y * _ahrs.sin_yaw();
-        backup_vel.y = desired_back_vel_cms.x * _ahrs.sin_yaw() + desired_back_vel_cms.y * _ahrs.cos_yaw();
-    }
+    desired_vel_cms = safe_vel;
+    backup_vel = desired_back_vel_cms;
 }
 
 /*

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -193,26 +193,29 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel
         if (desired_backup_vel.length() > max_back_spd_cms) {
             desired_backup_vel = desired_backup_vel.normalized() * max_back_spd_cms;
         }
-        
-        if ((AC_Avoid::BehaviourType)_behavior.get() == BEHAVIOR_SLIDE) {
-            // project desired velocity towards backup velocity horizontally 
-            const Vector2f backup_vel_xy{desired_backup_vel.x, desired_backup_vel.y};
-            Vector2f projected_vel; 
-            if (!backup_vel_xy.is_zero()) {
-               projected_vel = Vector2f{desired_vel_cms.x, desired_vel_cms.y}.projected(Vector2f{desired_backup_vel.x, desired_backup_vel.y});
+    
+        // let user take control if they are backing away at a greater speed than what we have calculated
+        // this has to be done for x,y,z seperately. For eg, user is doing fine in "x" direction but might need backing up in "y".
+        if (!is_zero(desired_backup_vel.x)) {
+            if (is_positive(desired_backup_vel.x)) {
+                desired_vel_cms.x = MAX(desired_vel_cms.x, desired_backup_vel.x);
+            } else {
+                desired_vel_cms.x = MIN(desired_vel_cms.x, desired_backup_vel.x);
             }
-            // subtract this projection since we are already going in that direction
-            desired_vel_cms -= Vector3f{projected_vel.x, projected_vel.y, 0.0f};
-            desired_vel_cms += Vector3f{desired_backup_vel.x, desired_backup_vel.y, 0.0f};
-            // let user take control vertically if they are backing away at a greater speed than what we have calculated based on limits
-            if (!is_negative(desired_backup_vel.z)) {
+        }
+        if (!is_zero(desired_backup_vel.y)) {
+            if (is_positive(desired_backup_vel.y)) {
+                desired_vel_cms.y = MAX(desired_vel_cms.y, desired_backup_vel.y);
+            } else {
+                desired_vel_cms.y = MIN(desired_vel_cms.y, desired_backup_vel.y);
+            }
+        }
+        if (!is_zero(desired_backup_vel.z)) {
+            if (is_positive(desired_backup_vel.z)) {
                 desired_vel_cms.z = MAX(desired_vel_cms.z, desired_backup_vel.z);
             } else {
                 desired_vel_cms.z = MIN(desired_vel_cms.z, desired_backup_vel.z);
             }
-        } else {
-            // back away to stopping position
-            desired_vel_cms = desired_backup_vel;
         }
     }
 }

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -1072,7 +1072,10 @@ void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector3f &d
     for (uint8_t i = 0; i<obstacle_num; i++) {
         // get obstacle from proximity library
         Vector3f vector_to_obstacle;
-        _proximity.get_obstacle(i, vector_to_obstacle);
+        if (!_proximity.get_obstacle(i, vector_to_obstacle)) {
+            // this one is not valid
+            continue;
+        }
         const float dist_to_boundary = vector_to_obstacle.length();
         if (is_zero(dist_to_boundary)) {
             continue;

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -1078,13 +1078,17 @@ void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector3f &d
         // back away if vehicle has breached margin
         if (is_negative(dist_to_boundary - margin_cm)) {
             const float breach_dist = margin_cm - dist_to_boundary;
-            // this vector will help us divide how much we have to back away horizontally and vertically
-            const Vector3f margin_vector = vector_to_obstacle.normalized() * breach_dist;
-            const float xy_back_dist = norm(margin_vector.x, margin_vector.y);
-            const float z_back_dist = margin_vector.z;
-            calc_backup_velocity_3D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, xy_back_dist, vector_to_obstacle, kP_z, accel_cmss_z, z_back_dist, min_back_vel_z, max_back_vel_z, dt);
+            // add a deadzone so that the vehicle doesn't backup and go forward again and again
+            // the deadzone is hardcoded to be 10cm
+            if (breach_dist > AC_AVOID_MIN_BACKUP_BREACH_DIST) {
+                // this vector will help us divide how much we have to back away horizontally and vertically
+                const Vector3f margin_vector = vector_to_obstacle.normalized() * breach_dist;
+                const float xy_back_dist = norm(margin_vector.x, margin_vector.y);
+                const float z_back_dist = margin_vector.z;
+                calc_backup_velocity_3D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, xy_back_dist, vector_to_obstacle, kP_z, accel_cmss_z, z_back_dist, min_back_vel_z, max_back_vel_z, dt);
+            }        
         }
-        
+
         if (desired_vel_cms.is_zero()) {
             // cannot limit velocity if there is nothing to limit
             // backing up (if needed) has already been done

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -22,8 +22,7 @@
 #define AC_AVOID_MIN_BACKUP_BREACH_DIST     10.0f   // vehicle will backaway if breach is greater than this distance in cm
 
 /*
- * This class prevents the vehicle from leaving a polygon fence in
- * 2 dimensions by limiting velocity (adjust_velocity).
+ * This class prevents the vehicle from leaving a polygon fence or avoiding proximity based obstacles
  * Additionally the vehicle may back up if the margin to obstacle is breached
  */
 class AC_Avoid {

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -19,6 +19,7 @@
 #define AC_AVOID_ANGLE_MAX_PERCENT          0.75f   // object avoidance max lean angle as a percentage (expressed in 0 ~ 1 range) of total vehicle max lean angle
 
 #define AC_AVOID_ACTIVE_LIMIT_TIMEOUT_MS    500     // if limiting is active if last limit is happend in the last x ms
+#define AC_AVOID_MIN_BACKUP_BREACH_DIST     10.0f   // vehicle will backaway if breach is greater than this distance in cm
 
 /*
  * This class prevents the vehicle from leaving a polygon fence in

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -22,7 +22,7 @@
 #define AC_AVOID_MIN_BACKUP_BREACH_DIST     10.0f   // vehicle will backaway if breach is greater than this distance in cm
 
 /*
- * This class prevents the vehicle from leaving a polygon fence or avoiding proximity based obstacles
+ * This class prevents the vehicle from leaving a polygon fence or hitting proximity-based obstacles
  * Additionally the vehicle may back up if the margin to obstacle is breached
  */
 class AC_Avoid {
@@ -45,10 +45,10 @@ public:
     // before the fence/object.
     // kP, accel_cmss are for the horizontal axis
     // kP_z, accel_cmss_z are for vertical axis
-    void adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel_cms, float kP_z, float accel_cmss_z, bool &backing_up, float dt);
-    void adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel_cms, float kP_z, float accel_cmss_z, float dt) {
+    void adjust_velocity(Vector3f &desired_vel_cms, bool &backing_up, float kP, float accel_cmss, float kP_z, float accel_cmss_z, float dt);
+    void adjust_velocity(Vector3f &desired_vel_cms, float kP, float accel_cmss, float kP_z, float accel_cmss_z, float dt) {
         bool backing_up = false;
-        adjust_velocity(kP, accel_cmss, desired_vel_cms, kP_z, accel_cmss_z, backing_up, dt);
+        adjust_velocity(desired_vel_cms, backing_up, kP, accel_cmss, kP_z, accel_cmss_z, dt);
     }
 
     // This method limits velocity and calculates backaway velocity from various supported fences
@@ -143,7 +143,7 @@ private:
 
     /*
      * Adjusts the desired velocity given an array of boundary points
-     * The boundary is expected to be always in Earth Frame
+     * The boundary must be in Earth Frame
      * margin is the distance (in meters) that the vehicle should stop short of the polygon
      * stay_inside should be true for fences, false for exclusion polygons
      */
@@ -164,11 +164,11 @@ private:
     
     /*
     * Compute the back away velocity required to avoid breaching margin, including vertical component
-    * min_z_vel is <= 0, and stores the greatest velocity in the donwards direction
+    * min_z_vel is <= 0, and stores the greatest velocity in the downwards direction
     * max_z_vel is >= 0, and stores the greatest velocity in the upwards direction
     * eventually max_z_vel + min_z_vel will give the final desired Z backaway velocity
     */
-    void calc_backup_velocity_3D(float kP, float accel_cmss, Vector2f &quad1_back_vel_cms, Vector2f &quad2_back_vel_cms, Vector2f &quad3_back_vel_cms, Vector2f &quad4_back_vel_cms, float back_distance_cm, Vector3f limit_direction, float kp_z, float accel_cmss_z, float back_distance_z, float& min_z_vel, float& max_z_vel, float dt);
+    void calc_backup_velocity_3D(float kP, float accel_cmss, Vector2f &quad1_back_vel_cms, Vector2f &quad2_back_vel_cms, Vector2f &quad3_back_vel_cms, Vector2f &quad4_back_vel_cms, float back_distance_cms, Vector3f limit_direction, float kp_z, float accel_cmss_z, float back_distance_z, float& min_z_vel, float& max_z_vel, float dt);
    
    /*
     * Calculate maximum velocity vector that can be formed in each quadrant 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -307,7 +307,9 @@ void AC_Loiter::calc_desired_velocity(float nav_dt)
     // TODO: We need to also limit the _desired_accel
     AC_Avoid *_avoid = AP::ac_avoid();
     if (_avoid != nullptr) {
-        _avoid->adjust_velocity(_pos_control.get_pos_xy_p().kP(), _accel_cmss, desired_vel, nav_dt);
+        Vector3f avoidance_vel_3d{desired_vel.x, desired_vel.y, 0.0f};
+        _avoid->adjust_velocity(avoidance_vel_3d, _pos_control.get_pos_xy_p().kP(), _accel_cmss, _pos_control.get_pos_z_p().kP(), _pos_control.get_max_accel_z(), nav_dt);
+        desired_vel = Vector2f{avoidance_vel_3d.x, avoidance_vel_3d.y};
     }
 
     // send adjusted feed forward acceleration and velocity back to the Position Controller

--- a/libraries/AP_Math/tests/test_3d_lines.cpp
+++ b/libraries/AP_Math/tests/test_3d_lines.cpp
@@ -1,0 +1,46 @@
+#include <AP_gtest.h>
+
+#include <AP_Math/vector2.h>
+#include <AP_Math/vector3.h>
+#include <AP_Math/AP_Math.h>
+
+// check if two vector3f are equal 
+#define EXPECT_VECTOR3F_EQ(v1, v2)              \
+    do {                                        \
+        EXPECT_FLOAT_EQ(v1[0], v2[0]);          \
+        EXPECT_FLOAT_EQ(v1[1], v2[1]);          \
+        EXPECT_FLOAT_EQ(v1[2], v2[2]);          \
+    } while (false);
+
+
+TEST(Lines3dTests, ClosestDistBetweenLinePoint)
+{   
+    // check if the 2-d and 3-d variant of this method is same if the third-dimension is zero
+    float dist_3d = Vector3f::closest_distance_between_line_and_point(Vector3f{0.0f, 1.0f, 0.0f}, Vector3f{0.0f, 10.0f, 0.0f}, Vector3f{6.0f, 5.0f, 0.0f});
+    float dist_2d = Vector2f::closest_distance_between_line_and_point(Vector2f{0.0f, 1.0f}, Vector2f{0.0f, 10.0f}, Vector2f{6.0f, 5.0f});
+    EXPECT_FLOAT_EQ(dist_2d, dist_3d);
+
+    // random point test
+    const Vector3f intersection = Vector3f::point_on_line_closest_to_other_point(Vector3f{}, Vector3f{0.0f, 10.0f, 10.0f}, Vector3f{0.0f, 5.0f, 5.0f});
+    EXPECT_VECTOR3F_EQ((Vector3f{0.0f, 5.0f, 5.0f}), intersection);
+}
+
+TEST(Lines3dTests, SegmentToSegmentDistance)
+{   
+    // random segments test
+    Vector3f intersection;
+    float dist = Vector3f::segment_to_segment_dist(Vector3f{-10.0f,0.0f,0.0f}, Vector3f{10.0f,0.0f,0.0f}, Vector3f{0.0f, -5.0f, 1.0}, Vector3f{0.0f, 5.0f, 1.0f}, intersection);
+    EXPECT_FLOAT_EQ(dist, 1.0f);
+    EXPECT_VECTOR3F_EQ(intersection, (Vector3f{0.0f, 0.0f, 1.0f}));
+
+    // check for intersecting segments. Verify with the 2-d variant
+    dist = Vector3f::segment_to_segment_dist(Vector3f{}, Vector3f{10.0f,10.0f,0.0f}, Vector3f{2.0f, -10.0f, 0.0}, Vector3f{3.0f, 10.0f, 0.0f}, intersection);
+    Vector2f intersection_2d;
+    const bool result = Vector2f::segment_intersection(Vector2f{}, Vector2f{10.0f,10.0}, Vector2f{2.0f, -10.0f}, Vector2f{3.0f, 10.0f}, intersection_2d);
+    EXPECT_EQ(true, result); 
+    EXPECT_FLOAT_EQ(dist, 0.0f);
+    EXPECT_VECTOR3F_EQ(intersection, (Vector3f(intersection_2d.x, intersection_2d.y, 0.0f)));
+}
+
+AP_GTEST_MAIN()
+int hal = 0; //weirdly the build will fail without this

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -454,9 +454,18 @@ float Vector3<T>::distance_to_segment(const Vector3<T> &seg_start, const Vector3
 }
 
 // Shortest distance between point(p) to a point contained in the line segment defined by w1,w2
-// this is based on the explanation given here: www.fundza.com/vectors/point2line/index.html
 template <typename T>
 float Vector3<T>::closest_distance_between_line_and_point(const Vector3<T> &w1, const Vector3<T> &w2, const Vector3<T> &p)
+{    
+    const Vector3<T> nearest = point_on_line_closest_to_other_point(w1, w2, p);
+    const float dist = (nearest - p).length();
+    return dist;
+}
+
+// Point in the line segment defined by w1,w2 which is closest to point(p)
+// this is based on the explanation given here: www.fundza.com/vectors/point2line/index.html
+template <typename T>
+Vector3<T> Vector3<T>::point_on_line_closest_to_other_point(const Vector3<T> &w1, const Vector3<T> &w2, const Vector3<T> &p)
 {   
     const Vector3<T> line_vec = w2-w1;
     const Vector3<T> p_vec = p - w1;
@@ -464,7 +473,7 @@ float Vector3<T>::closest_distance_between_line_and_point(const Vector3<T> &w1, 
     const float line_vec_len = line_vec.length();
     // protection against divide by zero
     if(::is_zero(line_vec_len)) {
-        return 0.0f;
+        return {0.0f, 0.0f, 0.0f};
     }
 
     const float scale = 1/line_vec_len;
@@ -474,9 +483,88 @@ float Vector3<T>::closest_distance_between_line_and_point(const Vector3<T> &w1, 
     float dot_product = unit_vec * scaled_p_vec;
     dot_product = constrain_float(dot_product,0.0f,1.0f); 
  
-    const Vector3<T> nearest = line_vec * dot_product;
-    const float dist = (nearest - p_vec).length();
-    return dist;
+    const Vector3<T> closest_point = line_vec * dot_product;
+    return (closest_point + w1);
+}
+
+// Shortest distance between two line segments
+// This implementation is borrowed from: http://geomalgorithms.com/a07-_distance.html
+// INPUT: 4 points corresponding to start and end of two line segments
+// OUTPUT: shortest distance, and closest point on segment 2, from segment 1, gets passed on reference as "intersection" 
+template <typename T>
+float Vector3<T>::segment_to_segment_dist(const Vector3<T>& seg1_start, const Vector3<T>& seg1_end, const Vector3<T>& seg2_start, const Vector3<T>& seg2_end, Vector3<T>& intersection)
+{
+    // direction vectors
+    const Vector3<T> line1 = seg1_end - seg1_start;
+    const Vector3<T> line2 = seg2_end - seg2_start;
+
+    const Vector3<T> diff = seg1_start - seg2_start;
+
+    const float a = line1*line1;
+    const float b = line1*line2;
+    const float c = line2*line2;
+    const float d = line1*diff;
+    const float e = line2*diff;
+
+    const float discriminant = (a*c) - (b*b);
+    float sc, sN, sD = discriminant;       // sc = sN / sD, default sD = D >= 0
+    float tc, tN, tD = discriminant;       // tc = tN / tD, default tD = D >= 0 
+    
+    if (discriminant < FLT_EPSILON) {
+        sN = 0.0;         // force using point seg1_start on line 1
+        sD = 1.0;         // to prevent possible division by 0.0 later
+        tN = e;
+        tD = c;
+    } else {                 
+        // get the closest points on the infinite lines
+        sN = (b*e - c*d);
+        tN = (a*e - b*d);
+        if (sN < 0.0) {        
+            // sc < 0 => the s=0 edge is visible
+            sN = 0.0;
+            tN = e;
+            tD = c;
+        } else if (sN > sD) {  
+            // sc > 1  => the s=1 edge is visible
+            sN = sD;
+            tN = e + b;
+            tD = c;
+        }
+    }
+
+    if (tN < 0.0) {            
+        // tc < 0 => the t=0 edge is visible
+        tN = 0.0;
+        // recompute sc for this edge
+        if (-d < 0.0) {
+            sN = 0.0;
+        } else if (-d > a) {
+            sN = sD;
+        } else {
+            sN = -d;
+            sD = a;
+        }
+    } else if (tN > tD) {      
+        // tc > 1  => the t=1 edge is visible
+        tN = tD;
+        // recompute sc for this edge
+        if ((-d + b) < 0.0) {
+            sN = 0;
+        } else if ((-d + b) > a) {
+            sN = sD;
+        } else {
+            sN = (-d +  b);
+            sD = a;
+        }
+    }
+    // finally do the division to get sc and tc
+    sc = (fabsf(sN) < FLT_EPSILON ? 0.0 : sN / sD);
+    tc = (fabsf(tN) < FLT_EPSILON ? 0.0 : tN / tD);
+
+    const Vector3<T> closest_line_segment = diff + (line1*sc) - (line2*tc);
+    const float len = closest_line_segment.length();
+    intersection = seg2_start + line2*tc;
+    return len;
 }
 
 // define for float and double

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -418,6 +418,15 @@ Matrix3<T> Vector3<T>::mul_rowcol(const Vector3<T> &v2) const
                       v1.z * v2.x, v1.z * v2.y, v1.z * v2.z);
 }
 
+// extrapolate position given bearing and pitch (in degrees) and distance
+template <typename T>
+void Vector3<T>::offset_bearing(float bearing, float pitch, float distance)
+{
+    y += cosf(radians(pitch)) * sinf(radians(bearing)) * distance;
+    x += cosf(radians(pitch)) * cosf(radians(bearing)) * distance;
+    z += sinf(radians(pitch)) * distance;
+}
+
 // distance from the tip of this vector to a line segment specified by two vectors
 template <typename T>
 float Vector3<T>::distance_to_segment(const Vector3<T> &seg_start, const Vector3<T> &seg_end) const

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -244,6 +244,9 @@ public:
     // distance from the tip of this vector to a line segment specified by two vectors
     float distance_to_segment(const Vector3<T> &seg_start, const Vector3<T> &seg_end) const;
 
+    // extrapolate position given bearing and pitch (in degrees) and distance
+    void offset_bearing(float bearing, float pitch, float distance);
+    
     // given a position p1 and a velocity v1 produce a vector
     // perpendicular to v1 maximising distance from p1.  If p1 is the
     // zero vector the return from the function will always be the

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -265,6 +265,14 @@ public:
 
     // Shortest distance between point(p) to a point contained in the line segment defined by w1,w2
     static float closest_distance_between_line_and_point(const Vector3<T> &w1, const Vector3<T> &w2, const Vector3<T> &p);
+
+    // Point in the line segment defined by w1,w2 which is closest to point(p)
+    static Vector3<T> point_on_line_closest_to_other_point(const Vector3<T> &w1, const Vector3<T> &w2, const Vector3<T> &p);
+
+    // This implementation is borrowed from: http://geomalgorithms.com/a07-_distance.html
+    // INPUT: 4 points corresponding to start and end of two line segments
+    // OUTPUT: shortest distance between segments, and closest point on segment 2, from segment 1, gets passed on reference as "intersection" 
+    static float segment_to_segment_dist(const Vector3<T>& seg1_start, const Vector3<T>& seg1_end, const Vector3<T>& seg2_start, const Vector3<T>& seg2_end, Vector3<T>& intersection) WARN_IF_UNUSED;
 };
 
 typedef Vector3<int16_t>                Vector3i;

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -359,21 +359,32 @@ bool AP_Proximity::get_horizontal_distances(Proximity_Distance_Array &prx_dist_a
     return drivers[primary_instance]->get_horizontal_distances(prx_dist_array);
 }
 
-// get boundary points around vehicle for use by avoidance
-//   returns nullptr and sets num_points to zero if no boundary can be returned
-const Vector2f* AP_Proximity::get_boundary_points(uint8_t instance, uint16_t& num_points) const
-{
-    if (!valid_instance(instance)) {
-        num_points = 0;
-        return nullptr;
+// get total number of obstacles, used in GPS based Simple Avoidance
+uint8_t AP_Proximity::get_obstacle_count() const
+{   
+    if (!valid_instance(primary_instance)) {
+        return 0;
     }
-    // get boundary from backend
-    return drivers[instance]->get_boundary_points(num_points);
+    return drivers[primary_instance]->get_obstacle_count();
 }
 
-const Vector2f* AP_Proximity::get_boundary_points(uint16_t& num_points) const
+// get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance
+void AP_Proximity::get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const
 {
-    return get_boundary_points(primary_instance, num_points);
+    if (!valid_instance(primary_instance)) {
+        return;
+    }
+    return drivers[primary_instance]->get_obstacle(obstacle_num, vec_to_obstacle);
+}
+
+// returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
+// used in GPS based Simple Avoidance
+float AP_Proximity::distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const
+{
+    if (!valid_instance(primary_instance)) {
+        return FLT_MAX;
+    }
+    return drivers[primary_instance]->distance_to_obstacle(obstacle_num, seg_start, seg_end, closest_point);
 }
 
 // get distance and angle to closest object (used for pre-arm check)
@@ -394,7 +405,7 @@ uint8_t AP_Proximity::get_object_count() const
         return 0;
     }
     // get count from backend
-    return drivers[primary_instance]->get_object_count();
+    return drivers[primary_instance]->get_horizontal_object_count();
 }
 
 // get an object's angle and distance, used for non-GPS avoidance
@@ -405,7 +416,7 @@ bool AP_Proximity::get_object_angle_and_distance(uint8_t object_number, float& a
         return false;
     }
     // get angle and distance from backend
-    return drivers[primary_instance]->get_object_angle_and_distance(object_number, angle_deg, distance);
+    return drivers[primary_instance]->get_horizontal_object_angle_and_distance(object_number, angle_deg, distance);
 }
 
 // get maximum and minimum distances (in meters) of primary sensor

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -369,10 +369,10 @@ uint8_t AP_Proximity::get_obstacle_count() const
 }
 
 // get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance
-void AP_Proximity::get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const
+bool AP_Proximity::get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const
 {
     if (!valid_instance(primary_instance)) {
-        return;
+        return false;
     }
     return drivers[primary_instance]->get_obstacle(obstacle_num, vec_to_obstacle);
 }

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -24,7 +24,6 @@
 #define PROXIMITY_MAX_IGNORE                6   // up to six areas can be ignored
 #define PROXIMITY_MAX_DIRECTION 8
 #define PROXIMITY_SENSOR_ID_START 10
-#define PROXIMITY_NUM_LAYERS 5
 
 class AP_Proximity_Backend;
 

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -24,6 +24,7 @@
 #define PROXIMITY_MAX_IGNORE                6   // up to six areas can be ignored
 #define PROXIMITY_MAX_DIRECTION 8
 #define PROXIMITY_SENSOR_ID_START 10
+#define PROXIMITY_NUM_LAYERS 5
 
 class AP_Proximity_Backend;
 
@@ -88,10 +89,14 @@ public:
     // get distances in PROXIMITY_MAX_DIRECTION directions. used for sending distances to ground station
     bool get_horizontal_distances(Proximity_Distance_Array &prx_dist_array) const;
 
-    // get boundary points around vehicle for use by avoidance
-    //   returns nullptr and sets num_points to zero if no boundary can be returned
-    const Vector2f* get_boundary_points(uint8_t instance, uint16_t& num_points) const;
-    const Vector2f* get_boundary_points(uint16_t& num_points) const;
+    // get total number of obstacles, used in GPS based Simple Avoidance
+    uint8_t get_obstacle_count() const;
+    
+    // get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance
+    void get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const;
+    
+    // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
+    float distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;
 
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -92,7 +92,7 @@ public:
     uint8_t get_obstacle_count() const;
     
     // get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance
-    void get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const;
+    bool get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const;
     
     // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
     float distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -95,6 +95,7 @@ public:
     bool get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const;
     
     // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
+    // returns FLT_MAX if it's an invalid instance.
     float distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;
 
     // get distance and angle to closest object (used for pre-arm check)

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -21,7 +21,7 @@
 extern const AP_HAL::HAL& hal;
 
 #define PROXIMITY_MAX_RANGE 100.0f
-#define PROXIMITY_ACCURACY  0.1f        // minimum distance between objects sent to object database
+#define PROXIMITY_ACCURACY  0.1f        // minimum distance (in meters) between objects sent to object database
 
 // update the state of the sensor
 void AP_Proximity_AirSimSITL::update(void)
@@ -52,7 +52,7 @@ void AP_Proximity_AirSimSITL::update(void)
         }
 
         // calculate distance to point and check larger than min distance
-        const Vector2f new_pos = Vector2f(point.x, point.y);
+        const Vector2f new_pos = Vector2f{point.x, point.y};
         const float distance_sq = new_pos.length_squared();
         if (distance_sq > distance_min_sq) {
 

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
@@ -41,9 +41,5 @@ public:
 private:
     SITL::SITL *sitl = AP::sitl();
 
-    // sector related variables
-    float _angle_deg_last;
-    float _distance_m_last;
-    uint8_t _last_sector;
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -29,50 +29,6 @@ AP_Proximity_Backend::AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity
         frontend(_frontend),
         state(_state)
 {
-    // initialise sector edge vector used for building the boundary fence
-    init_boundary();
-}
-
-// get distance and angle to closest object (used for pre-arm check)
-//   returns true on success, false if no valid readings
-bool AP_Proximity_Backend::get_closest_object(float& angle_deg, float &distance) const
-{
-    bool sector_found = false;
-    uint8_t sector = 0;
-
-    // check all sectors for shorter distance
-    for (uint8_t i=0; i<PROXIMITY_NUM_SECTORS; i++) {
-        if (_distance_valid[i]) {
-            if (!sector_found || (_distance[i] < _distance[sector])) {
-                sector = i;
-                sector_found = true;
-            }
-        }
-    }
-
-    if (sector_found) {
-        angle_deg = _angle[sector];
-        distance = _distance[sector];
-    }
-    return sector_found;
-}
-
-// get number of objects, used for non-GPS avoidance
-uint8_t AP_Proximity_Backend::get_object_count() const
-{
-    return PROXIMITY_NUM_SECTORS;
-}
-
-// get an object's angle and distance, used for non-GPS avoidance
-// returns false if no angle or distance could be returned for some reason
-bool AP_Proximity_Backend::get_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const
-{
-    if (object_number < PROXIMITY_NUM_SECTORS && _distance_valid[object_number]) {
-        angle_deg = _angle[object_number];
-        distance = _distance[object_number];
-        return true;
-    }
-    return false;
 }
 
 // get distances in PROXIMITY_MAX_DIRECTION directions. used for sending distances to ground station
@@ -83,113 +39,16 @@ bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Dist
     bool valid_distances = false;
     for (uint8_t i=0; i<PROXIMITY_MAX_DIRECTION; i++) {
         prx_dist_array.orientation[i] = i;
-        if (_distance_valid[i]) {
+        const boundary_location bnd_loc{i};
+        if (boundary.check_distance_valid(bnd_loc)) {
             valid_distances = true;
-            prx_dist_array.distance[i] = _distance[i];
+            prx_dist_array.distance[i] = boundary.get_distance(bnd_loc);
         } else {
             prx_dist_array.distance[i] = distance_max();
         }
     }
 
     return valid_distances;
-}
-
-// get boundary points around vehicle for use by avoidance
-//   returns nullptr and sets num_points to zero if no boundary can be returned
-const Vector2f* AP_Proximity_Backend::get_boundary_points(uint16_t& num_points) const
-{
-    // high-level status check
-    if (state.status != AP_Proximity::Status::Good) {
-        num_points = 0;
-        return nullptr;
-    }
-
-    // check at least one sector has valid data, if not, exit
-    bool some_valid = false;
-    for (uint8_t i=0; i<PROXIMITY_NUM_SECTORS; i++) {
-        if (_distance_valid[i]) {
-            some_valid = true;
-            break;
-        }
-    }
-    if (!some_valid) {
-        num_points = 0;
-        return nullptr;
-    }
-
-    // return boundary points
-    num_points = PROXIMITY_NUM_SECTORS;
-    return _boundary_point;
-}
-
-// initialise the boundary and sector_edge_vector array used for object avoidance
-//   should be called if the sector_middle_deg or _setor_width_deg arrays are changed
-void AP_Proximity_Backend::init_boundary()
-{
-    for (uint8_t sector=0; sector < PROXIMITY_NUM_SECTORS; sector++) {
-        float angle_rad = radians((float)_sector_middle_deg[sector]+(PROXIMITY_SECTOR_WIDTH_DEG/2.0f));
-        _sector_edge_vector[sector].x = cosf(angle_rad) * 100.0f;
-        _sector_edge_vector[sector].y = sinf(angle_rad) * 100.0f;
-        _boundary_point[sector] = _sector_edge_vector[sector] * PROXIMITY_BOUNDARY_DIST_DEFAULT;
-    }
-}
-
-// update boundary points used for object avoidance based on a single sector's distance changing
-//   the boundary points lie on the line between sectors meaning two boundary points may be updated based on a single sector's distance changing
-//   the boundary point is set to the shortest distance found in the two adjacent sectors, this is a conservative boundary around the vehicle
-void AP_Proximity_Backend::update_boundary_for_sector(const uint8_t sector, const bool push_to_OA_DB)
-{
-    // sanity check
-    if (sector >= PROXIMITY_NUM_SECTORS) {
-        return;
-    }
-
-    if (push_to_OA_DB && _distance_valid[sector]) {
-        database_push(_angle[sector], _distance[sector]);
-    }
-
-    // find adjacent sector (clockwise)
-    uint8_t next_sector = sector + 1;
-    if (next_sector >= PROXIMITY_NUM_SECTORS) {
-        next_sector = 0;
-    }
-
-    // boundary point lies on the line between the two sectors at the shorter distance found in the two sectors
-    float shortest_distance = PROXIMITY_BOUNDARY_DIST_DEFAULT;
-    if (_distance_valid[sector] && _distance_valid[next_sector]) {
-        shortest_distance = MIN(_distance[sector], _distance[next_sector]);
-    } else if (_distance_valid[sector]) {
-        shortest_distance = _distance[sector];
-    } else if (_distance_valid[next_sector]) {
-        shortest_distance = _distance[next_sector];
-    }
-    if (shortest_distance < PROXIMITY_BOUNDARY_DIST_MIN) {
-        shortest_distance = PROXIMITY_BOUNDARY_DIST_MIN;
-    }
-    _boundary_point[sector] = _sector_edge_vector[sector] * shortest_distance;
-
-    // if the next sector (clockwise) has an invalid distance, set boundary to create a cup like boundary
-    if (!_distance_valid[next_sector]) {
-        _boundary_point[next_sector] = _sector_edge_vector[next_sector] * shortest_distance;
-    }
-
-    // repeat for edge between sector and previous sector
-    uint8_t prev_sector = (sector == 0) ? PROXIMITY_NUM_SECTORS-1 : sector-1;
-    shortest_distance = PROXIMITY_BOUNDARY_DIST_DEFAULT;
-    if (_distance_valid[prev_sector] && _distance_valid[sector]) {
-        shortest_distance = MIN(_distance[prev_sector], _distance[sector]);
-    } else if (_distance_valid[prev_sector]) {
-        shortest_distance = _distance[prev_sector];
-    } else if (_distance_valid[sector]) {
-        shortest_distance = _distance[sector];
-    }
-    _boundary_point[prev_sector] = _sector_edge_vector[prev_sector] * shortest_distance;
-
-    // if the sector counter-clockwise from the previous sector has an invalid distance, set boundary to create a cup like boundary
-    uint8_t prev_sector_ccw = (prev_sector == 0) ? PROXIMITY_NUM_SECTORS - 1 : prev_sector - 1;
-    if (!_distance_valid[prev_sector_ccw]) {
-        _boundary_point[prev_sector_ccw] = _sector_edge_vector[prev_sector_ccw] * shortest_distance;
-    }
 }
 
 // set status and update valid count
@@ -203,12 +62,6 @@ float AP_Proximity_Backend::correct_angle_for_orientation(float angle_degrees) c
 {
     const float angle_sign = (frontend.get_orientation(state.instance) == 1) ? -1.0f : 1.0f;
     return wrap_360(angle_degrees * angle_sign + frontend.get_yaw_correction(state.instance));
-}
-
-// find which sector a given angle falls into
-uint8_t AP_Proximity_Backend::convert_angle_to_sector(float angle_degrees) const
-{
-    return wrap_360(angle_degrees + (PROXIMITY_SECTOR_WIDTH_DEG * 0.5f)) / 45.0f;
 }
 
 // check if a reading should be ignored because it falls into an ignore area
@@ -254,19 +107,17 @@ void AP_Proximity_Backend::database_push(float angle, float distance)
 }
 
 // update Object Avoidance database with Earth-frame point
-void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned)
+// pitch can be optionally provided if needed
+void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned, float pitch)
 {
     AP_OADatabase *oaDb = AP::oadatabase();
     if (oaDb == nullptr || !oaDb->healthy()) {
         return;
     }
     
-    //Assume object is angle bearing and distance meters away from the vehicle 
-    Vector2f object_2D = {0.0f,0.0f};
-    object_2D.offset_bearing(wrap_180(angle), distance);	
-    
-    //rotate that vector to a 3D vector in NED frame
-    const Vector3f object_3D = {object_2D.x,object_2D.y,0.0f};
+    //Assume object is angle and pitch bearing and distance meters away from the vehicle 
+    Vector3f object_3D;
+    object_3D.offset_bearing(wrap_180(angle), wrap_180(pitch), distance);	
     const Vector3f rotated_object_3D = body_to_ned * object_3D;
     
     //Calculate the position vector from origin

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -107,7 +107,7 @@ void AP_Proximity_Backend::database_push(float angle, float distance)
 
 // update Object Avoidance database with Earth-frame point
 // pitch can be optionally provided if needed
-void AP_Proximity_Backend::database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned, float pitch)
+void AP_Proximity_Backend::database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned)
 {
     AP_OADatabase *oaDb = AP::oadatabase();
     if (oaDb == nullptr || !oaDb->healthy()) {

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -31,7 +31,7 @@ AP_Proximity_Backend::AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity
 {
 }
 
-// get distances in PROXIMITY_MAX_DIRECTION directions. used for sending distances to ground station
+// get distances in PROXIMITY_MAX_DIRECTION directions horizontally. used for sending distances to ground station
 bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const
 {
     // cycle through all sectors filling in distances and orientations
@@ -39,10 +39,9 @@ bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Dist
     bool valid_distances = false;
     for (uint8_t i=0; i<PROXIMITY_MAX_DIRECTION; i++) {
         prx_dist_array.orientation[i] = i;
-        const boundary_location bnd_loc{i};
-        if (boundary.check_distance_valid(bnd_loc)) {
+        const AP_Proximity_Boundary_3D::Face face(PROXIMITY_MIDDLE_LAYER, i);
+        if (boundary.get_distance(face, prx_dist_array.distance[i])) {
             valid_distances = true;
-            prx_dist_array.distance[i] = boundary.get_distance(bnd_loc);
         } else {
             prx_dist_array.distance[i] = distance_max();
         }

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -18,11 +18,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity.h"
 #include <AP_Common/Location.h>
-
-#define PROXIMITY_NUM_SECTORS           8       // number of sectors
-#define PROXIMITY_SECTOR_WIDTH_DEG      45.0f   // width of sectors in degrees
-#define PROXIMITY_BOUNDARY_DIST_MIN 0.6f    // minimum distance for a boundary point.  This ensures the object avoidance code doesn't think we are outside the boundary.
-#define PROXIMITY_BOUNDARY_DIST_DEFAULT 100 // if we have no data for a sector, boundary is placed 100m out
+#include "AP_Proximity_Boundary_3D.h"
 
 class AP_Proximity_Backend
 {
@@ -47,17 +43,23 @@ public:
     // handle mavlink DISTANCE_SENSOR messages
     virtual void handle_msg(const mavlink_message_t &msg) {}
 
-    // get boundary points around vehicle for use by avoidance
-    //   returns nullptr and sets num_points to zero if no boundary can be returned
-    const Vector2f* get_boundary_points(uint16_t& num_points) const;
+    // get total number of obstacles, used in GPS based Simple Avoidance
+    uint8_t get_obstacle_count() { return boundary.get_obstacle_count(); }
+    
+    // get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance
+    void get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const { return boundary.get_obstacle(obstacle_num, vec_to_obstacle); }
+    
+    // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
+    // used in GPS based Simple Avoidance
+    float distance_to_obstacle(const uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const { return boundary.distance_to_obstacle(obstacle_num , seg_start, seg_end, closest_point); } 
 
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings
-    bool get_closest_object(float& angle_deg, float &distance) const;
+    bool get_closest_object(float& angle_deg, float &distance) const { return boundary.get_closest_object(angle_deg, distance); }
 
     // get number of objects, angle and distance - used for non-GPS avoidance
-    uint8_t get_object_count() const;
-    bool get_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const;
+    uint8_t get_horizontal_object_count() const {return boundary.get_horizontal_object_count(); }
+    bool get_horizontal_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const { return boundary.get_horizontal_object_angle_and_distance(object_number, angle_deg, distance); }
 
     // get distances in 8 directions. used for sending distances to ground station
     bool get_horizontal_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const;
@@ -69,39 +71,20 @@ protected:
 
     // correct an angle (in degrees) based on the orientation and yaw correction parameters
     float correct_angle_for_orientation(float angle_degrees) const;
-
-    // find which sector a given angle falls into
-    uint8_t convert_angle_to_sector(float angle_degrees) const;
-
-    // initialise the boundary and sector_edge_vector array used for object avoidance
-    //   should be called if the sector_middle_deg or _setor_width_deg arrays are changed
-    void init_boundary();
-
-    // update boundary points used for object avoidance based on a single sector's distance changing
-    //   the boundary points lie on the line between sectors meaning two boundary points may be updated based on a single sector's distance changing
-    //   the boundary point is set to the shortest distance found in the two adjacent sectors, this is a conservative boundary around the vehicle
-    void update_boundary_for_sector(const uint8_t sector, const bool push_to_OA_DB);
-
+    
     // check if a reading should be ignored because it falls into an ignore area
     // angles should be in degrees and in the range of 0 to 360
     bool ignore_reading(uint16_t angle_deg) const;
 
-    // database helpers.  all angles are in degrees
-    bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);
-    void database_push(float angle, float distance);
-    void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
+    // database helpers. All angles are in degrees
+    static bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);
+    // Note: "angle" refers to yaw (in body frame) towards the obstacle
+    static void database_push(float angle, float distance);
+    static void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned, float pitch = 0.0f);
+        
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
 
-    // sectors
-    const uint16_t _sector_middle_deg[PROXIMITY_NUM_SECTORS] = {0, 45, 90, 135, 180, 225, 270, 315};    // middle angle of each sector
-
-    // sensor data
-    float _angle[PROXIMITY_NUM_SECTORS];            // angle to closest object within each sector
-    float _distance[PROXIMITY_NUM_SECTORS];         // distance to closest object within each sector
-    bool _distance_valid[PROXIMITY_NUM_SECTORS];    // true if a valid distance received for each sector
-
-    // fence boundary
-    Vector2f _sector_edge_vector[PROXIMITY_NUM_SECTORS];    // vector for right-edge of each sector, used to speed up calculation of boundary
-    Vector2f _boundary_point[PROXIMITY_NUM_SECTORS];        // bounding polygon around the vehicle calculated conservatively for object avoidance
+    // Methods to manipulate 3D boundary in this class
+    AP_Proximity_Boundary_3D boundary;
 };

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -80,8 +80,11 @@ protected:
     static bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);
     // Note: "angle" refers to yaw (in body frame) towards the obstacle
     static void database_push(float angle, float distance);
-    static void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned, float pitch = 0.0f);
-        
+    static void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned) {
+        database_push(angle, 0.0f, distance, timestamp_ms, current_pos, body_to_ned);
+    };
+    static void database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
+
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
 

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -47,7 +47,7 @@ public:
     uint8_t get_obstacle_count() { return boundary.get_obstacle_count(); }
     
     // get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance
-    void get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const { return boundary.get_obstacle(obstacle_num, vec_to_obstacle); }
+    bool get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const { return boundary.get_obstacle(obstacle_num, vec_to_obstacle); }
     
     // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
     // used in GPS based Simple Avoidance

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
@@ -1,0 +1,262 @@
+#include "AP_Proximity_Backend.h"
+#include "AP_Proximity_Boundary_3D.h"
+
+/*
+  Constructor. 
+  This incorporates initialisation as well.
+*/
+AP_Proximity_Boundary_3D::AP_Proximity_Boundary_3D() 
+{
+    // initialise sector edge vector used for building the boundary fence
+    init_boundary();
+}
+
+// initialise the boundary and sector_edge_vector array used for object avoidance
+//   should be called if the sector_middle_deg or _sector_width_deg arrays are changed
+void AP_Proximity_Boundary_3D::init_boundary()
+{
+    for (uint8_t stack = 0; stack < PROXIMITY_NUM_LAYERS; stack ++) {
+        for (uint8_t sector=0; sector < PROXIMITY_NUM_SECTORS; sector++) {
+            float angle_rad = ((float)_sector_middle_deg[sector]+(PROXIMITY_SECTOR_WIDTH_DEG/2.0f));
+            float pitch = ((float)_pitch_middle_deg[stack]);
+            _sector_edge_vector[sector][stack].offset_bearing(angle_rad, pitch, 100.0f);
+            _boundary_points[sector][stack] = _sector_edge_vector[sector][stack] * PROXIMITY_BOUNDARY_DIST_DEFAULT;
+        }
+    }
+}
+
+// returns Boundary_Location object consisting of appropriate stack and sector corresponding to the yaw and pitch.
+// Pitch defaults to zero if only yaw is passed to this method
+// Yaw is the horizontal body-frame angle the detected object makes with the vehicle
+// Pitch is the vertical body-frame angle the detected object makes with the vehicle 
+boundary_location AP_Proximity_Boundary_3D::get_sector(float yaw, float pitch) 
+{   
+    const uint8_t sector = wrap_360(yaw + (PROXIMITY_SECTOR_WIDTH_DEG * 0.5f)) / 45.0f;
+    const float pitch_degrees = constrain_float(pitch, -75.0f, 74.9f);
+    const uint8_t stack = (pitch_degrees + 75.0f)/PROXIMITY_PITCH_WIDTH_DEG;
+    return boundary_location{sector, stack};
+}
+
+// Set the actual body-frame angle(yaw), pitch, and distance of the detected object.
+// This method will also mark the sector and stack to be "valid", so this distance can be used for Obstacle Avoidance
+void AP_Proximity_Boundary_3D::set_attributes(const Boundary_Location& bnd_loc, float angle, float pitch, float distance)
+{   
+    const uint8_t sector = bnd_loc.sector;
+    const uint8_t stack = bnd_loc.stack;
+    _angle[sector][stack] = angle;
+    _pitch[sector][stack] = pitch;
+    _distance[sector][stack] = distance;    
+    _distance_valid[sector][stack] = true;
+}
+
+// update boundary points used for object avoidance based on a single sector and pitch distance changing
+//   the boundary points lie on the line between sectors meaning two boundary points may be updated based on a single sector's distance changing
+//   the boundary point is set to the shortest distance found in the two adjacent sectors, this is a conservative boundary around the vehicle
+void AP_Proximity_Boundary_3D::update_boundary(const Boundary_Location& bnd_loc) 
+{
+    const uint8_t sector = bnd_loc.sector;
+    const uint8_t layer = bnd_loc.stack;
+
+    // sanity check
+    if (sector >= PROXIMITY_NUM_SECTORS) {
+        return;
+    }
+
+    // find adjacent sector (clockwise)
+    uint8_t next_sector = sector + 1;
+    if (next_sector >= PROXIMITY_NUM_SECTORS) {
+        next_sector = 0;
+    }
+
+    // boundary point lies on the line between the two sectors at the shorter distance found in the two sectors
+    float shortest_distance = PROXIMITY_BOUNDARY_DIST_DEFAULT;
+    if (_distance_valid[sector][layer] && _distance_valid[next_sector][layer]) {
+        shortest_distance = MIN(_distance[sector][layer], _distance[next_sector][layer]);
+    } else if (_distance_valid[sector][layer]) {
+        shortest_distance = _distance[sector][layer];
+    } else if (_distance_valid[next_sector][layer]) {
+        shortest_distance = _distance[next_sector][layer];
+    }
+    if (shortest_distance < PROXIMITY_BOUNDARY_DIST_MIN) {
+        shortest_distance = PROXIMITY_BOUNDARY_DIST_MIN;
+    }
+    _boundary_points[sector][layer] = _sector_edge_vector[sector][layer] * shortest_distance;
+
+    // if the next sector (clockwise) has an invalid distance, set boundary to create a cup like boundary
+    if (!_distance_valid[next_sector][layer]) {
+        _boundary_points[next_sector][layer] = _sector_edge_vector[next_sector][layer] * shortest_distance;
+    }
+
+    // repeat for edge between sector and previous sector
+    uint8_t prev_sector = (sector == 0) ? PROXIMITY_NUM_SECTORS-1 : sector-1;
+    shortest_distance = PROXIMITY_BOUNDARY_DIST_DEFAULT;
+    if (_distance_valid[prev_sector][layer] && _distance_valid[sector][layer]) {
+        shortest_distance = MIN(_distance[prev_sector][layer], _distance[sector][layer]);
+    } else if (_distance_valid[prev_sector][layer]) {
+        shortest_distance = _distance[prev_sector][layer];
+    } else if (_distance_valid[sector][layer]) {
+        shortest_distance = _distance[sector][layer];
+    }
+    _boundary_points[prev_sector][layer] = _sector_edge_vector[prev_sector][layer] * shortest_distance;
+
+    // if the sector counter-clockwise from the previous sector has an invalid distance, set boundary to create a cup like boundary
+    uint8_t prev_sector_ccw = (prev_sector == 0) ? PROXIMITY_NUM_SECTORS - 1 : prev_sector - 1;
+    if (!_distance_valid[prev_sector_ccw][layer]) {
+        _boundary_points[prev_sector_ccw][layer] = _sector_edge_vector[prev_sector_ccw][layer] * shortest_distance;
+    }
+}
+
+// Reset this location, specified by Boundary_Location object, back to default
+// i.e Distance is marked as not-valid, and set to a large number.
+void AP_Proximity_Boundary_3D::reset_sector(const Boundary_Location& bnd_loc)
+{
+    _distance[bnd_loc.sector][bnd_loc.stack] = DISTANCE_MAX;
+    _distance_valid[bnd_loc.sector][bnd_loc.stack] = false;
+}
+
+// Reset all horizontal sectors
+// i.e Distance is marked as not-valid, and set to a large number for all horizontal sectors.
+void AP_Proximity_Boundary_3D::reset_all_horizontal_sectors()
+{
+    for (uint8_t i=0; i < PROXIMITY_NUM_SECTORS; i++) {
+        const Boundary_Location bnd_loc{i};
+        reset_sector(bnd_loc);
+    }
+}
+
+// Reset all stacks and sectors
+// i.e Distance is marked as not-valid, and set to a large number for all stacks and sectors.
+void AP_Proximity_Boundary_3D::reset_all_sectors_and_stacks()
+{
+    for (uint8_t j=0; j < PROXIMITY_NUM_LAYERS; j++) {
+        for (uint8_t i=0; i < PROXIMITY_NUM_SECTORS; i++) {
+            const Boundary_Location bnd_loc{i, j};
+            reset_sector(bnd_loc);
+        }
+    }
+}
+
+// get the total number of obstacles 
+// this method iterates through the entire 3-D boundary and checks which layer has atleast one valid distance
+uint8_t AP_Proximity_Boundary_3D::get_obstacle_count()
+{
+    uint8_t obstacle_count = 0;
+    // reset entire array to false
+    memset(_active_layer, 0, sizeof(_active_layer));
+    // check if this layer has atleast one valid sector
+    for (uint8_t j=0; j<PROXIMITY_NUM_LAYERS; j++) {
+        for (uint8_t i=0; i<PROXIMITY_NUM_SECTORS; i++ ) {
+            if (_distance_valid[i][j]) {
+                _active_layer[j] = true;
+                obstacle_count += PROXIMITY_NUM_SECTORS;
+                break;
+            }
+        }
+    }
+    return obstacle_count;
+}
+
+// Converts obstacle_num passed from avoidance library into appropriate stack and sector
+// This is packed into a Boundary Location object and returned 
+boundary_location AP_Proximity_Boundary_3D::convert_obstacle_num_to_boundary_loc(uint8_t obstacle_num) const
+{
+    const uint8_t active_layer = obstacle_num / PROXIMITY_NUM_SECTORS;
+    uint8_t layer_count = 0;
+    uint8_t stack = 0;
+    for (uint8_t i=0; i < PROXIMITY_NUM_LAYERS; i++) {
+        if (_active_layer[i]) {
+            layer_count++;
+        }
+        if (layer_count == (active_layer + 1)) {
+            stack = i;
+            break;
+        }
+    }
+    const uint8_t sector = obstacle_num % PROXIMITY_NUM_SECTORS;
+
+    return boundary_location{sector, stack};
+}
+
+// WARNING: This requires get_obstacle_count() to be called before calling this method
+// Appropriate stack and sector are found from the passed obstacle_num
+// This function then draws a line between this sector, and sector + 1 at the given stack 
+// Then returns the closest point on this line from vehicle, in body-frame. 
+// Used by GPS based Simple Avoidance  
+void AP_Proximity_Boundary_3D::get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const
+{   
+    const boundary_location bnd_loc = convert_obstacle_num_to_boundary_loc(obstacle_num);
+    const uint8_t sector_end = bnd_loc.sector;
+    uint8_t sector_start = bnd_loc.sector + 1;
+    if (sector_start >= PROXIMITY_NUM_SECTORS) {
+        sector_start = 0;
+    }
+    const Vector3f start = _boundary_points[sector_start][bnd_loc.stack];
+    const Vector3f end = _boundary_points[sector_end][bnd_loc.stack];
+    vec_to_obstacle = Vector3f::closest_point_between_line_and_point(start, end, Vector3f{0.0f, 0.0f, 0.0f});
+}
+
+// WARNING: This requires get_obstacle_count() to be called before calling this method
+// Appropriate stack and sector are found from the passed obstacle_num
+// This function then draws a line between this sector, and sector + 1 at the given stack  
+// Then returns the closest point on this line from the segment that was passed, in body-frame.
+// Used by GPS based Simple Avoidance  - for "brake mode" 
+float AP_Proximity_Boundary_3D::distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const
+{   
+    const boundary_location bnd_loc = convert_obstacle_num_to_boundary_loc(obstacle_num);
+    const uint8_t sector_end = bnd_loc.sector;
+    uint8_t sector_start = bnd_loc.sector + 1;
+    if (sector_start >= PROXIMITY_NUM_SECTORS) {
+        sector_start = 0;
+    }
+    const Vector3f start = _boundary_points[sector_start][bnd_loc.stack];
+    const Vector3f end = _boundary_points[sector_end][bnd_loc.stack];
+    return Vector3f::segment_to_segment_dist(seg_start, seg_end, start, end, closest_point);
+}
+
+// get distance and angle to closest object (used for pre-arm check)
+//   returns true on success, false if no valid readings
+bool AP_Proximity_Boundary_3D::get_closest_object(float& angle_deg, float &distance) const
+{
+    bool sector_found = false;
+    uint8_t sector = 0;
+    uint8_t stack = 0;
+
+    // check boundary for shortest distance
+    // only check for middle layers and higher
+    // lower layers might contain ground, which will give false pre-arm failure
+    for (uint8_t j=PROXIMITY_MIDDLE_LAYER; j<PROXIMITY_NUM_LAYERS; j++) {
+        for (uint8_t i=0; i<PROXIMITY_NUM_SECTORS; i++) {
+            if (_distance_valid[i][j]) {
+                if (!sector_found || (_distance[i][j] < _distance[sector][stack])) {
+                    sector = i;
+                    stack = j;
+                    sector_found = true;
+                }
+            }
+        }
+    }
+
+    if (sector_found) {
+        angle_deg = _angle[sector][stack];
+        distance = _distance[sector][stack];
+    }
+    return sector_found;
+}
+
+// get number of objects, used for non-GPS avoidance
+uint8_t AP_Proximity_Boundary_3D::get_horizontal_object_count() const
+{
+    return PROXIMITY_NUM_SECTORS;
+}
+
+// get an object's angle and distance, used for non-GPS avoidance
+// returns false if no angle or distance could be returned for some reason
+bool AP_Proximity_Boundary_3D::get_horizontal_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const
+{
+    if (object_number < PROXIMITY_NUM_SECTORS && _distance_valid[object_number][PROXIMITY_MIDDLE_LAYER]) {
+        angle_deg = _angle[object_number][PROXIMITY_MIDDLE_LAYER];
+        distance = _distance[object_number][PROXIMITY_MIDDLE_LAYER];
+        return true;
+    }
+    return false;
+}

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
@@ -8,59 +8,74 @@
 AP_Proximity_Boundary_3D::AP_Proximity_Boundary_3D() 
 {
     // initialise sector edge vector used for building the boundary fence
-    init_boundary();
+    init();
 }
 
 // initialise the boundary and sector_edge_vector array used for object avoidance
 //   should be called if the sector_middle_deg or _sector_width_deg arrays are changed
-void AP_Proximity_Boundary_3D::init_boundary()
+void AP_Proximity_Boundary_3D::init()
 {
-    for (uint8_t stack = 0; stack < PROXIMITY_NUM_LAYERS; stack ++) {
+    for (uint8_t layer=0; layer < PROXIMITY_NUM_LAYERS; layer++) {
         for (uint8_t sector=0; sector < PROXIMITY_NUM_SECTORS; sector++) {
             float angle_rad = ((float)_sector_middle_deg[sector]+(PROXIMITY_SECTOR_WIDTH_DEG/2.0f));
-            float pitch = ((float)_pitch_middle_deg[stack]);
-            _sector_edge_vector[sector][stack].offset_bearing(angle_rad, pitch, 100.0f);
-            _boundary_points[sector][stack] = _sector_edge_vector[sector][stack] * PROXIMITY_BOUNDARY_DIST_DEFAULT;
+            float pitch = ((float)_pitch_middle_deg[layer]);
+            _sector_edge_vector[layer][sector].offset_bearing(angle_rad, pitch, 100.0f);
+            _boundary_points[layer][sector] = _sector_edge_vector[layer][sector] * PROXIMITY_BOUNDARY_DIST_DEFAULT;
         }
     }
 }
 
-// returns Boundary_Location object consisting of appropriate stack and sector corresponding to the yaw and pitch.
-// Pitch defaults to zero if only yaw is passed to this method
-// Yaw is the horizontal body-frame angle the detected object makes with the vehicle
-// Pitch is the vertical body-frame angle the detected object makes with the vehicle 
-boundary_location AP_Proximity_Boundary_3D::get_sector(float yaw, float pitch) 
+// returns face corresponding to the provided yaw and (optionally) pitch
+// pitch is the vertical body-frame angle (in degrees) to the obstacle (0=directly ahead, 90 is above the vehicle?)
+// yaw is the horizontal body-frame angle (in degrees) to the obstacle (0=directly ahead of the vehicle, 90 is to the right of the vehicle)
+AP_Proximity_Boundary_3D::Face AP_Proximity_Boundary_3D::get_face(float pitch, float yaw) const
 {   
     const uint8_t sector = wrap_360(yaw + (PROXIMITY_SECTOR_WIDTH_DEG * 0.5f)) / 45.0f;
-    const float pitch_degrees = constrain_float(pitch, -75.0f, 74.9f);
-    const uint8_t stack = (pitch_degrees + 75.0f)/PROXIMITY_PITCH_WIDTH_DEG;
-    return boundary_location{sector, stack};
+    const float pitch_limited = constrain_float(pitch, -75.0f, 74.9f);
+    const uint8_t layer = (pitch_limited + 75.0f)/PROXIMITY_PITCH_WIDTH_DEG;
+    return Face(layer, sector);
 }
 
 // Set the actual body-frame angle(yaw), pitch, and distance of the detected object.
-// This method will also mark the sector and stack to be "valid", so this distance can be used for Obstacle Avoidance
-void AP_Proximity_Boundary_3D::set_attributes(const Boundary_Location& bnd_loc, float angle, float pitch, float distance)
-{   
-    const uint8_t sector = bnd_loc.sector;
-    const uint8_t stack = bnd_loc.stack;
-    _angle[sector][stack] = angle;
-    _pitch[sector][stack] = pitch;
-    _distance[sector][stack] = distance;    
-    _distance_valid[sector][stack] = true;
+// This method will also mark the sector and layer to be "valid", so this distance can be used for Obstacle Avoidance
+void AP_Proximity_Boundary_3D::set_face_attributes(Face face, float angle, float pitch, float distance)
+{
+    if (!face.valid()) {
+        return;
+    }
+
+    _angle[face.layer][face.sector] = angle;
+    _pitch[face.layer][face.sector] = pitch;
+    _distance[face.layer][face.sector] = distance;
+    _distance_valid[face.layer][face.sector] = true;
+
+    // update boundary used for simple avoidance
+    update_boundary(face);
+}
+
+// add a distance to the boundary if it is shorter than any other provided distance since the last time the boundary was reset
+// pitch and yaw are in degrees, distance is in meters
+void AP_Proximity_Boundary_3D::add_distance(float pitch, float yaw, float distance)
+{
+    Face face = get_face(pitch, yaw);
+    if (!_distance_valid[face.layer][face.sector] || (distance < _distance[face.layer][face.sector])) {
+        _distance[face.layer][face.sector] = distance;
+        _distance_valid[face.layer][face.sector] = true;
+    }
 }
 
 // update boundary points used for object avoidance based on a single sector and pitch distance changing
 //   the boundary points lie on the line between sectors meaning two boundary points may be updated based on a single sector's distance changing
 //   the boundary point is set to the shortest distance found in the two adjacent sectors, this is a conservative boundary around the vehicle
-void AP_Proximity_Boundary_3D::update_boundary(const Boundary_Location& bnd_loc) 
+void AP_Proximity_Boundary_3D::update_boundary(const Face face)
 {
-    const uint8_t sector = bnd_loc.sector;
-    const uint8_t layer = bnd_loc.stack;
-
     // sanity check
-    if (sector >= PROXIMITY_NUM_SECTORS) {
+    if (!face.valid()) {
         return;
     }
+
+    const uint8_t layer = face.layer;
+    const uint8_t sector = face.sector;
 
     // find adjacent sector (clockwise)
     uint8_t next_sector = sector + 1;
@@ -70,84 +85,100 @@ void AP_Proximity_Boundary_3D::update_boundary(const Boundary_Location& bnd_loc)
 
     // boundary point lies on the line between the two sectors at the shorter distance found in the two sectors
     float shortest_distance = PROXIMITY_BOUNDARY_DIST_DEFAULT;
-    if (_distance_valid[sector][layer] && _distance_valid[next_sector][layer]) {
-        shortest_distance = MIN(_distance[sector][layer], _distance[next_sector][layer]);
-    } else if (_distance_valid[sector][layer]) {
-        shortest_distance = _distance[sector][layer];
-    } else if (_distance_valid[next_sector][layer]) {
-        shortest_distance = _distance[next_sector][layer];
+    if (_distance_valid[layer][sector] && _distance_valid[layer][next_sector]) {
+        shortest_distance = MIN(_distance[layer][sector], _distance[layer][next_sector]);
+    } else if (_distance_valid[layer][sector]) {
+        shortest_distance = _distance[layer][sector];
+    } else if (_distance_valid[layer][next_sector]) {
+        shortest_distance = _distance[layer][next_sector];
     }
     if (shortest_distance < PROXIMITY_BOUNDARY_DIST_MIN) {
         shortest_distance = PROXIMITY_BOUNDARY_DIST_MIN;
     }
-    _boundary_points[sector][layer] = _sector_edge_vector[sector][layer] * shortest_distance;
+    _boundary_points[layer][sector] = _sector_edge_vector[layer][sector] * shortest_distance;
 
     // if the next sector (clockwise) has an invalid distance, set boundary to create a cup like boundary
-    if (!_distance_valid[next_sector][layer]) {
-        _boundary_points[next_sector][layer] = _sector_edge_vector[next_sector][layer] * shortest_distance;
+    if (!_distance_valid[layer][next_sector]) {
+        _boundary_points[layer][next_sector] = _sector_edge_vector[layer][next_sector] * shortest_distance;
     }
 
     // repeat for edge between sector and previous sector
     uint8_t prev_sector = (sector == 0) ? PROXIMITY_NUM_SECTORS-1 : sector-1;
     shortest_distance = PROXIMITY_BOUNDARY_DIST_DEFAULT;
-    if (_distance_valid[prev_sector][layer] && _distance_valid[sector][layer]) {
-        shortest_distance = MIN(_distance[prev_sector][layer], _distance[sector][layer]);
-    } else if (_distance_valid[prev_sector][layer]) {
-        shortest_distance = _distance[prev_sector][layer];
-    } else if (_distance_valid[sector][layer]) {
-        shortest_distance = _distance[sector][layer];
+    if (_distance_valid[layer][prev_sector] && _distance_valid[layer][sector]) {
+        shortest_distance = MIN(_distance[layer][prev_sector], _distance[layer][sector]);
+    } else if (_distance_valid[layer][prev_sector]) {
+        shortest_distance = _distance[layer][prev_sector];
+    } else if (_distance_valid[layer][sector]) {
+        shortest_distance = _distance[layer][sector];
     }
-    _boundary_points[prev_sector][layer] = _sector_edge_vector[prev_sector][layer] * shortest_distance;
+    _boundary_points[layer][prev_sector] = _sector_edge_vector[layer][prev_sector] * shortest_distance;
 
     // if the sector counter-clockwise from the previous sector has an invalid distance, set boundary to create a cup like boundary
     uint8_t prev_sector_ccw = (prev_sector == 0) ? PROXIMITY_NUM_SECTORS - 1 : prev_sector - 1;
-    if (!_distance_valid[prev_sector_ccw][layer]) {
-        _boundary_points[prev_sector_ccw][layer] = _sector_edge_vector[prev_sector_ccw][layer] * shortest_distance;
+    if (!_distance_valid[layer][prev_sector_ccw]) {
+        _boundary_points[layer][prev_sector_ccw] = _sector_edge_vector[layer][prev_sector_ccw] * shortest_distance;
     }
 }
 
-// Reset this location, specified by Boundary_Location object, back to default
-// i.e Distance is marked as not-valid, and set to a large number.
-void AP_Proximity_Boundary_3D::reset_sector(const Boundary_Location& bnd_loc)
+// update middle layer boundary points
+void AP_Proximity_Boundary_3D::update_middle_boundary()
 {
-    _distance[bnd_loc.sector][bnd_loc.stack] = DISTANCE_MAX;
-    _distance_valid[bnd_loc.sector][bnd_loc.stack] = false;
-}
-
-// Reset all horizontal sectors
-// i.e Distance is marked as not-valid, and set to a large number for all horizontal sectors.
-void AP_Proximity_Boundary_3D::reset_all_horizontal_sectors()
-{
-    for (uint8_t i=0; i < PROXIMITY_NUM_SECTORS; i++) {
-        const Boundary_Location bnd_loc{i};
-        reset_sector(bnd_loc);
+    for (uint8_t sector=0; sector < PROXIMITY_NUM_SECTORS; sector++) {
+        update_boundary(Face(PROXIMITY_MIDDLE_LAYER, sector));
     }
 }
 
-// Reset all stacks and sectors
-// i.e Distance is marked as not-valid, and set to a large number for all stacks and sectors.
-void AP_Proximity_Boundary_3D::reset_all_sectors_and_stacks()
+// reset boundary.  marks all distances as invalid
+void AP_Proximity_Boundary_3D::reset()
 {
-    for (uint8_t j=0; j < PROXIMITY_NUM_LAYERS; j++) {
-        for (uint8_t i=0; i < PROXIMITY_NUM_SECTORS; i++) {
-            const Boundary_Location bnd_loc{i, j};
-            reset_sector(bnd_loc);
+    for (uint8_t layer=0; layer < PROXIMITY_NUM_LAYERS; layer++) {
+        for (uint8_t sector=0; sector < PROXIMITY_NUM_SECTORS; sector++) {
+            _distance_valid[layer][sector] = false;
         }
     }
 }
 
+// Reset this location, specified by Face object, back to default
+// i.e Distance is marked as not-valid, and set to a large number.
+void AP_Proximity_Boundary_3D::reset_face(Face face)
+{
+    if (!face.valid()) {
+        return;
+    }
+    _distance_valid[face.layer][face.sector] = false;
+
+    // update simple avoidance boundary
+    update_boundary(face);
+}
+
+// get distance for a face.  returns true on success and fills in distance argument with distance in meters
+bool AP_Proximity_Boundary_3D::get_distance(Face face, float &distance) const
+{
+    if (!face.valid()) {
+        return false;
+    }
+
+    if (_distance_valid[face.layer][face.sector]) {
+        distance = _distance[face.layer][face.sector];
+        return true;
+    }
+
+    return false;
+}
+
 // get the total number of obstacles 
-// this method iterates through the entire 3-D boundary and checks which layer has atleast one valid distance
+// this method iterates through the entire 3-D boundary and checks which layer has at least one valid distance
 uint8_t AP_Proximity_Boundary_3D::get_obstacle_count()
 {
     uint8_t obstacle_count = 0;
     // reset entire array to false
     memset(_active_layer, 0, sizeof(_active_layer));
     // check if this layer has atleast one valid sector
-    for (uint8_t j=0; j<PROXIMITY_NUM_LAYERS; j++) {
-        for (uint8_t i=0; i<PROXIMITY_NUM_SECTORS; i++ ) {
-            if (_distance_valid[i][j]) {
-                _active_layer[j] = true;
+    for (uint8_t layer=0; layer<PROXIMITY_NUM_LAYERS; layer++) {
+        for (uint8_t sector=0; sector<PROXIMITY_NUM_SECTORS; sector++ ) {
+            if (_distance_valid[layer][sector]) {
+                _active_layer[layer] = true;
                 obstacle_count += PROXIMITY_NUM_SECTORS;
                 break;
             }
@@ -156,60 +187,60 @@ uint8_t AP_Proximity_Boundary_3D::get_obstacle_count()
     return obstacle_count;
 }
 
-// Converts obstacle_num passed from avoidance library into appropriate stack and sector
+// Converts obstacle_num passed from avoidance library into appropriate layer and sector
 // This is packed into a Boundary Location object and returned 
-boundary_location AP_Proximity_Boundary_3D::convert_obstacle_num_to_boundary_loc(uint8_t obstacle_num) const
+AP_Proximity_Boundary_3D::Face AP_Proximity_Boundary_3D::convert_obstacle_num_to_face(uint8_t obstacle_num) const
 {
     const uint8_t active_layer = obstacle_num / PROXIMITY_NUM_SECTORS;
     uint8_t layer_count = 0;
-    uint8_t stack = 0;
+    uint8_t layer = 0;
     for (uint8_t i=0; i < PROXIMITY_NUM_LAYERS; i++) {
         if (_active_layer[i]) {
             layer_count++;
         }
         if (layer_count == (active_layer + 1)) {
-            stack = i;
+            layer = i;
             break;
         }
     }
     const uint8_t sector = obstacle_num % PROXIMITY_NUM_SECTORS;
 
-    return boundary_location{sector, stack};
+    return AP_Proximity_Boundary_3D::Face(layer, sector);
 }
 
 // WARNING: This requires get_obstacle_count() to be called before calling this method
-// Appropriate stack and sector are found from the passed obstacle_num
-// This function then draws a line between this sector, and sector + 1 at the given stack 
+// Appropriate layer and sector are found from the passed obstacle_num
+// This function then draws a line between this sector, and sector + 1 at the given layer
 // Then returns the closest point on this line from vehicle, in body-frame. 
 // Used by GPS based Simple Avoidance  
 void AP_Proximity_Boundary_3D::get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const
-{   
-    const boundary_location bnd_loc = convert_obstacle_num_to_boundary_loc(obstacle_num);
-    const uint8_t sector_end = bnd_loc.sector;
-    uint8_t sector_start = bnd_loc.sector + 1;
+{
+    const AP_Proximity_Boundary_3D::Face face = convert_obstacle_num_to_face(obstacle_num);
+    const uint8_t sector_end = face.sector;
+    uint8_t sector_start = face.sector + 1;
     if (sector_start >= PROXIMITY_NUM_SECTORS) {
         sector_start = 0;
     }
-    const Vector3f start = _boundary_points[sector_start][bnd_loc.stack];
-    const Vector3f end = _boundary_points[sector_end][bnd_loc.stack];
+    const Vector3f start = _boundary_points[face.layer][sector_start];
+    const Vector3f end = _boundary_points[face.layer][sector_end];
     vec_to_obstacle = Vector3f::closest_point_between_line_and_point(start, end, Vector3f{0.0f, 0.0f, 0.0f});
 }
 
 // WARNING: This requires get_obstacle_count() to be called before calling this method
-// Appropriate stack and sector are found from the passed obstacle_num
-// This function then draws a line between this sector, and sector + 1 at the given stack  
+// Appropriate layer and sector are found from the passed obstacle_num
+// This function then draws a line between this sector, and sector + 1 at the given layer
 // Then returns the closest point on this line from the segment that was passed, in body-frame.
 // Used by GPS based Simple Avoidance  - for "brake mode" 
 float AP_Proximity_Boundary_3D::distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const
 {   
-    const boundary_location bnd_loc = convert_obstacle_num_to_boundary_loc(obstacle_num);
-    const uint8_t sector_end = bnd_loc.sector;
-    uint8_t sector_start = bnd_loc.sector + 1;
+    const AP_Proximity_Boundary_3D::Face face = convert_obstacle_num_to_face(obstacle_num);
+    const uint8_t sector_end = face.sector;
+    uint8_t sector_start = face.sector + 1;
     if (sector_start >= PROXIMITY_NUM_SECTORS) {
         sector_start = 0;
     }
-    const Vector3f start = _boundary_points[sector_start][bnd_loc.stack];
-    const Vector3f end = _boundary_points[sector_end][bnd_loc.stack];
+    const Vector3f start = _boundary_points[face.layer][sector_start];
+    const Vector3f end = _boundary_points[face.layer][sector_end];
     return Vector3f::segment_to_segment_dist(seg_start, seg_end, start, end, closest_point);
 }
 
@@ -217,30 +248,30 @@ float AP_Proximity_Boundary_3D::distance_to_obstacle(uint8_t obstacle_num, const
 //   returns true on success, false if no valid readings
 bool AP_Proximity_Boundary_3D::get_closest_object(float& angle_deg, float &distance) const
 {
-    bool sector_found = false;
-    uint8_t sector = 0;
-    uint8_t stack = 0;
+    bool closest_found = false;
+    uint8_t closest_sector = 0;
+    uint8_t closest_layer = 0;
 
     // check boundary for shortest distance
     // only check for middle layers and higher
     // lower layers might contain ground, which will give false pre-arm failure
-    for (uint8_t j=PROXIMITY_MIDDLE_LAYER; j<PROXIMITY_NUM_LAYERS; j++) {
-        for (uint8_t i=0; i<PROXIMITY_NUM_SECTORS; i++) {
-            if (_distance_valid[i][j]) {
-                if (!sector_found || (_distance[i][j] < _distance[sector][stack])) {
-                    sector = i;
-                    stack = j;
-                    sector_found = true;
+    for (uint8_t layer=PROXIMITY_MIDDLE_LAYER; layer<PROXIMITY_NUM_LAYERS; layer++) {
+        for (uint8_t sector=0; sector<PROXIMITY_NUM_SECTORS; sector++) {
+            if (_distance_valid[layer][sector]) {
+                if (!closest_found || (_distance[layer][sector] < _distance[closest_layer][closest_sector])) {
+                    closest_layer = layer;
+                    closest_sector = sector;
+                    closest_found = true;
                 }
             }
         }
     }
 
-    if (sector_found) {
-        angle_deg = _angle[sector][stack];
-        distance = _distance[sector][stack];
+    if (closest_found) {
+        angle_deg = _angle[closest_layer][closest_sector];
+        distance = _distance[closest_layer][closest_sector];
     }
-    return sector_found;
+    return closest_found;
 }
 
 // get number of objects, used for non-GPS avoidance
@@ -253,9 +284,9 @@ uint8_t AP_Proximity_Boundary_3D::get_horizontal_object_count() const
 // returns false if no angle or distance could be returned for some reason
 bool AP_Proximity_Boundary_3D::get_horizontal_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const
 {
-    if (object_number < PROXIMITY_NUM_SECTORS && _distance_valid[object_number][PROXIMITY_MIDDLE_LAYER]) {
-        angle_deg = _angle[object_number][PROXIMITY_MIDDLE_LAYER];
-        distance = _distance[object_number][PROXIMITY_MIDDLE_LAYER];
+    if ((object_number < PROXIMITY_NUM_SECTORS) && _distance_valid[PROXIMITY_MIDDLE_LAYER][object_number]) {
+        angle_deg = _angle[PROXIMITY_MIDDLE_LAYER][object_number];
+        distance = _distance[PROXIMITY_MIDDLE_LAYER][object_number];
         return true;
     }
     return false;

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
@@ -1,0 +1,132 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define PROXIMITY_NUM_SECTORS         8       // number of sectors
+#define PROXIMITY_NUM_LAYERS          5       // num of stacks in a sector
+#define PROXIMITY_MIDDLE_LAYER        2       // middle stack 
+#define PROXIMITY_PITCH_WIDTH_DEG     30      // width between each stack in degrees
+#define PROXIMITY_SECTOR_WIDTH_DEG    45.0f   // width of sectors in degrees
+#define PROXIMITY_BOUNDARY_DIST_MIN   0.6f    // minimum distance for a boundary point.  This ensures the object avoidance code doesn't think we are outside the boundary.
+#define PROXIMITY_BOUNDARY_DIST_DEFAULT 100   // if we have no data for a sector, boundary is placed 100m out
+#define DISTANCE_MAX               999999.0f  // arbritary "large" distance 
+
+class AP_Proximity_Boundary_3D 
+{ 
+public:
+    // constructor. This incorporates initialisation as well.
+	AP_Proximity_Boundary_3D();
+
+    // This class is used to store the stack and sector as a single packet to access and modify the 3-D boundary 
+    class Boundary_Location
+    {   
+    public:
+        // constructor when both stack and sector are passed
+        Boundary_Location(uint8_t Sector, uint8_t Stack) { sector = Sector; stack = Stack; }
+        // constructor defaults to "middle(horizontal) layer" if only sector is passed
+        Boundary_Location(uint8_t Sector) { sector = Sector; stack = PROXIMITY_MIDDLE_LAYER; }
+        
+        uint8_t stack; // vertical "steps" on the 3D Boundary 
+        uint8_t sector; // horizontal "steps" on the 3D Boundary
+    }; 
+    
+    // returns Boundary_Location object consisting of appropriate stack and sector
+    // corresponding to the yaw and pitch.
+    // Pitch defaults to zero if only yaw is passed to this method
+    // Yaw is the horizontal body-frame angle the detected object makes with the vehicle
+    // Pitch is the vertical body-frame angle the detected object makes with the vehicle 
+    Boundary_Location get_sector(float yaw, float pitch = 0.0f);
+
+    // Set the actual body-frame angle(yaw), pitch, and distance of the detected object.
+    // This method will also mark the sector and stack to be "valid"
+    // This distance can then be used for Obstacle Avoidance
+    void set_attributes(const Boundary_Location& bnd_loc, float angle, float pitch, float distance);
+    
+    // Set the actual body-frame angle(yaw), pitch, and distance of the detected object.
+    // This method will also mark the sector and stack to be "valid", 
+    // This distance can then be used for Obstacle Avoidance
+    // Assume detected obstacle is horizontal (zero pitch), if no pitch is passed 
+    void set_attributes(const Boundary_Location& bnd_loc, float angle, float distance) { set_attributes(bnd_loc, angle, 0.0f, distance); }
+
+    // update boundary points used for object avoidance based on a single sector and pitch distance changing
+    //   the boundary points lie on the line between sectors meaning two boundary points may be updated based on a single sector's distance changing
+    //   the boundary point is set to the shortest distance found in the two adjacent sectors, this is a conservative boundary around the vehicle
+    void update_boundary(const Boundary_Location& bnd_loc);
+
+    // Reset this location, specified by Boundary_Location object, back to default
+    // i.e Distance is marked as not-valid, and set to a large number.
+    void reset_sector(const Boundary_Location& bnd_loc);
+    // Reset all horizontal sectors
+    void reset_all_horizontal_sectors();
+    // Reset all stacks and sectors
+    void reset_all_sectors_and_stacks();
+
+    // Get values given the stack and sector as a Boundary_Location object
+    float get_angle(const Boundary_Location& bnd_loc) const { return _angle[bnd_loc.sector][bnd_loc.stack]; }
+    float get_pitch(const Boundary_Location& bnd_loc) const { return _pitch[bnd_loc.sector][bnd_loc.stack]; }
+    float get_distance(const Boundary_Location& bnd_loc) const { return _distance[bnd_loc.sector][bnd_loc.stack]; }
+    bool check_distance_valid(const Boundary_Location& bnd_loc) const { return _distance_valid[bnd_loc.sector][bnd_loc.stack]; }
+   
+    // Get the total number of obstacles 
+    // This method iterates through the entire 3-D boundary and checks which layer has atleast one valid distance
+    uint8_t get_obstacle_count();
+
+    // WARNING: This requires get_obstacle_count() to be called before calling this method
+    // Appropriate stack and sector are found from the passed obstacle_num
+    // This function then draws a line between this sector, and sector + 1 at the given stack 
+    // Then returns the closest point on this line from vehicle, in body-frame. 
+    void get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_boundary) const;
+
+    // WARNING: This requires get_obstacle_count() to be called before calling this method
+    // Appropriate stack and sector are found from the passed obstacle_num
+    // This function then draws a line between this sector, and sector + 1 at the given stack  
+    // Then returns the closest point on this line from the segment that was passed, in body-frame.
+    // Used by GPS based Simple Avoidance  - for "brake mode" 
+    float distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;
+
+    // get distance and angle to closest object (used for pre-arm check)
+    //   returns true on success, false if no valid readings
+    bool get_closest_object(float& angle_deg, float &distance) const;
+
+    // get number of objects, angle and distance - used for non-GPS avoidance
+    uint8_t get_horizontal_object_count() const;
+    bool get_horizontal_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const;
+
+    // sectors
+    const uint16_t _sector_middle_deg[PROXIMITY_NUM_SECTORS] {0, 45, 90, 135, 180, 225, 270, 315};    // middle angle of each sector
+    // layers
+    const int16_t _pitch_middle_deg[PROXIMITY_NUM_LAYERS] {-60, -30, 0, 30, 60};
+
+private:
+    // initialise the boundary and sector_edge_vector array used for object avoidance
+    void init_boundary();
+
+    // Converts obstacle_num passed from avoidance library into appropriate stack and sector
+    // This is packed into a Boundary Location object and returned 
+    Boundary_Location convert_obstacle_num_to_boundary_loc(uint8_t obstacle_num) const;
+
+    Vector3f _sector_edge_vector[PROXIMITY_NUM_SECTORS][PROXIMITY_NUM_LAYERS];
+    Vector3f _boundary_points[PROXIMITY_NUM_SECTORS][PROXIMITY_NUM_LAYERS];
+    
+    // sensor data
+    float _angle[PROXIMITY_NUM_SECTORS][PROXIMITY_NUM_LAYERS];            // angle to closest object within each sector and stack
+    float _pitch[PROXIMITY_NUM_SECTORS][PROXIMITY_NUM_LAYERS];            // pitch to the closest object within each sector and stack
+    float _distance[PROXIMITY_NUM_SECTORS][PROXIMITY_NUM_LAYERS];         // distance to closest object within each sector and stack
+    bool _distance_valid[PROXIMITY_NUM_SECTORS][PROXIMITY_NUM_LAYERS];    // true if a valid distance received for each sector and stack
+    bool _active_layer[PROXIMITY_NUM_LAYERS];                             // layers which have atleast one valid distance are marked true
+};
+
+typedef AP_Proximity_Boundary_3D::Boundary_Location boundary_location;

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
@@ -86,16 +86,13 @@ public:
     bool get_distance(Face face, float &distance) const;
 
     // Get the total number of obstacles 
-    // This method iterates through the entire 3-D boundary and checks which layer has at least one valid distance
-    uint8_t get_obstacle_count();
+    uint8_t get_obstacle_count() const;
 
-    // WARNING: This requires get_obstacle_count() to be called before calling this method
     // Appropriate layer and sector are found from the passed obstacle_num
     // This function then draws a line between this sector, and sector + 1 at the given layer
     // Then returns the closest point on this line from vehicle, in body-frame. 
-    void get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_boundary) const;
+    bool get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_boundary) const;
 
-    // WARNING: This requires get_obstacle_count() to be called before calling this method
     // Appropriate layer and sector are found from the passed obstacle_num
     // This function then draws a line between this sector, and sector + 1 at the given layer
     // Then returns the closest point on this line from the segment that was passed, in body-frame.
@@ -120,8 +117,18 @@ private:
     // initialise the boundary and sector_edge_vector array used for object avoidance
     void init();
 
-    // Converts obstacle_num passed from avoidance library into appropriate face
-    Face convert_obstacle_num_to_face(uint8_t obstacle_num) const;
+    // get the next sector which is CW to the passed sector
+    uint8_t get_next_sector(uint8_t sector) const {return ((sector >= PROXIMITY_NUM_SECTORS-1) ? 0 : sector+1); }
+    
+    // get the prev sector which is CCW to the passed sector 
+    uint8_t get_prev_sector(uint8_t sector) const {return ((sector <= 0) ? PROXIMITY_NUM_SECTORS-1 : sector-1); }
+
+    // Converts obstacle_num passed from avoidance library into appropriate face of the boundary
+    // Returns false if the face is invalid
+    // "update_boundary" method manipulates two sectors ccw and one sector cw from any valid face.
+    // Any boundary that does not fall into these manipulated faces are useless, and will be marked as false
+    // The resultant is packed into a Boundary Location object and returned by reference as "face"
+    bool convert_obstacle_num_to_face(uint8_t obstacle_num, Face& face) const;
 
     Vector3f _sector_edge_vector[PROXIMITY_NUM_LAYERS][PROXIMITY_NUM_SECTORS];
     Vector3f _boundary_points[PROXIMITY_NUM_LAYERS][PROXIMITY_NUM_SECTORS];
@@ -130,6 +137,5 @@ private:
     float _pitch[PROXIMITY_NUM_LAYERS][PROXIMITY_NUM_SECTORS];          // pitch angle in degrees to the closest object within each sector and layer
     float _distance[PROXIMITY_NUM_LAYERS][PROXIMITY_NUM_SECTORS];       // distance to closest object within each sector and layer
     bool _distance_valid[PROXIMITY_NUM_LAYERS][PROXIMITY_NUM_SECTORS];  // true if a valid distance received for each sector and layer
-    bool _active_layer[PROXIMITY_NUM_LAYERS];                           // layers which have at least one valid distance are marked true
 };
 

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -48,9 +48,6 @@ void AP_Proximity_LightWareSF40C::update(void)
 // initialise sensor
 void AP_Proximity_LightWareSF40C::initialise()
 {
-    // initialise boundary
-    init_boundary();
-
     // exit immediately if we've sent initialisation requests in the last second
     uint32_t now_ms = AP_HAL::millis();
     if ((now_ms - _last_request_ms) < 1000) {
@@ -321,18 +318,20 @@ void AP_Proximity_LightWareSF40C::process_message()
             const uint16_t idx = 14 + (i * 2);
             const int16_t dist_cm = (int16_t)buff_to_uint16(_msg.payload[idx], _msg.payload[idx+1]);
             const float angle_deg = wrap_360((point_start_index + i) * angle_inc_deg * angle_sign + angle_correction);
-            const uint8_t sector = convert_angle_to_sector(angle_deg);
-
+            // Get location on 3-D boundary based on angle to the object
+            const boundary_location bnd_loc = boundary.get_sector(angle_deg);
+            const uint8_t sector = bnd_loc.sector;
             // if we've entered a new sector then finish off previous sector
             if (sector != _last_sector) {
                 // update boundary used for avoidance
                 if (_last_sector != UINT8_MAX) {
-                    update_boundary_for_sector(_last_sector, false);
+                    // create a location package
+                    const boundary_location last_loc{_last_sector};
+                    boundary.update_boundary(last_loc);
                 }
                 // init for new sector
                 _last_sector = sector;
-                _distance[sector] = INT16_MAX;
-                _distance_valid[sector] = false;
+                boundary.reset_sector(bnd_loc);
             }
 
             // check reading is not within an ignore zone
@@ -342,10 +341,8 @@ void AP_Proximity_LightWareSF40C::process_message()
                     const float dist_m = dist_cm * 0.01f;
 
                     // update shortest distance for this sector
-                    if (dist_m < _distance[sector]) {
-                        _angle[sector] = angle_deg;
-                        _distance[sector] = dist_m;
-                        _distance_valid[sector] = true;
+                    if (dist_m < boundary.get_distance(bnd_loc)) {
+                        boundary.set_attributes(bnd_loc, angle_deg, dist_m);
                     }
 
                     // calculate shortest of last few readings

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -109,7 +109,10 @@ private:
     uint32_t _last_reply_ms;                // system time of last valid reply
     uint32_t _last_restart_ms;              // system time we restarted the sensor
     uint32_t _last_distance_received_ms;    // system time of last distance measurement received from sensor
-    uint8_t _last_sector = UINT8_MAX;       // sector of last distance_cm
+    AP_Proximity_Boundary_3D::Face _face;   // face of _face_distance
+    float _face_distance;                   // shortest distance (in meters) on face
+    float _face_yaw_deg;                    // yaw angle (in degrees) of shortest distance on face
+    bool _face_distance_valid;              // true if face has at least one valid distance
 
     // state of sensor
     struct {

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
@@ -327,16 +327,15 @@ bool AP_Proximity_LightWareSF40C_v09::process_reply()
                 _last_distance_received_ms = AP_HAL::millis();
                 success = true;
                 // Get location on 3-D boundary based on angle to the object
-                const boundary_location bnd_loc = boundary.get_sector(angle_deg);
-                // reset this sector back to default, so that it can be filled with the fresh sensor data
-                boundary.reset_sector(bnd_loc);
+                const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle_deg);
                 if (is_positive(distance_m)) {
-                    boundary.set_attributes(bnd_loc, angle_deg, distance_m);
+                    boundary.set_face_attributes(face, angle_deg, distance_m);
                     // update OA database
                     database_push(angle_deg, distance_m);
+                } else {
+                    // invalidate distance of face
+                    boundary.reset_face(face);
                 }
-                // update boundary used for avoidance
-                boundary.update_boundary(bnd_loc);
             }
             break;
         }

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
@@ -79,9 +79,6 @@ bool AP_Proximity_LightWareSF40C_v09::initialise()
         return false;
     }
 
-    // initialise sectors
-    init_boundary();
-
     return true;
 }
 
@@ -205,7 +202,7 @@ bool AP_Proximity_LightWareSF40C_v09::send_request_for_distance()
     char request_str[16];
     snprintf(request_str, sizeof(request_str), "?TS,%u,%u\r\n",
              (unsigned int)PROXIMITY_SECTOR_WIDTH_DEG,
-             _sector_middle_deg[_last_sector]);
+             boundary._sector_middle_deg[_last_sector]);
     _uart->write(request_str);
 
 
@@ -327,14 +324,19 @@ bool AP_Proximity_LightWareSF40C_v09::process_reply()
             float angle_deg = strtof(element_buf[0], NULL);
             float distance_m = strtof(element_buf[1], NULL);
             if (!ignore_reading(angle_deg)) {
-                const uint8_t sector = convert_angle_to_sector(angle_deg);
-                _angle[sector] = angle_deg;
-                _distance[sector] = distance_m;
-                _distance_valid[sector] = is_positive(distance_m);
                 _last_distance_received_ms = AP_HAL::millis();
                 success = true;
+                // Get location on 3-D boundary based on angle to the object
+                const boundary_location bnd_loc = boundary.get_sector(angle_deg);
+                // reset this sector back to default, so that it can be filled with the fresh sensor data
+                boundary.reset_sector(bnd_loc);
+                if (is_positive(distance_m)) {
+                    boundary.set_attributes(bnd_loc, angle_deg, distance_m);
+                    // update OA database
+                    database_push(angle_deg, distance_m);
+                }
                 // update boundary used for avoidance
-                update_boundary_for_sector(sector, true);
+                boundary.update_boundary(bnd_loc);
             }
             break;
         }

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
@@ -69,9 +69,6 @@ void AP_Proximity_LightWareSF45B::initialise()
 
     // request stream rate and contents
     request_stream_start();
-
-    // initialise boundary
-    init_boundary();
 }
 
 // request start of streaming of distances
@@ -141,16 +138,21 @@ void AP_Proximity_LightWareSF45B::process_message()
         const float angle_deg = correct_angle_for_orientation((int16_t)UINT16_VALUE(_msg.payload[3], _msg.payload[2]) * 0.01f);
 
         // if distance is from a new sector then update distance, angle and boundary for previous sector
-        const uint8_t sector = convert_angle_to_sector(angle_deg);
-        if (sector != _sector) {
+        // Get location on 3-D boundary based on angle to the object
+        const boundary_location bnd_loc = boundary.get_sector(angle_deg);
+        if (bnd_loc.sector != _sector) {
             if (_sector != UINT8_MAX) {
-                _angle[_sector] = _sector_angle;
-                _distance[_sector] = _sector_distance;
-                _distance_valid[_sector] = _sector_distance_valid;
-                update_boundary_for_sector(_sector, false);
+                // create a location packet
+                const boundary_location loc{_sector};
+                boundary.reset_sector(loc);
+                if (_sector_distance_valid) {
+                    boundary.set_attributes(loc, _sector_angle, _sector_distance);
+                } 
+                // update boundary used for Obstacle Avoidance
+                boundary.update_boundary(loc);
             }
             // init for new sector
-            _sector = sector;
+            _sector = bnd_loc.sector;
             _sector_angle = 0;
             _sector_distance = INT16_MAX;
             _sector_distance_valid = false;

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
@@ -80,11 +80,11 @@ private:
     bool _init_complete;                    // true once sensor initialisation is complete
     ModeFilterInt16_Size5 _distance_filt{2};// mode filter to reduce glitches
 
-    // sector (45 degrees) angles and distances (used to build mini fence for simple avoidance)
-    uint8_t _sector = UINT8_MAX;            // sector number (from 0 to 7) of most recently received distance
-    float _sector_distance;                 // shortest distance (in meters) in sector
-    float _sector_angle;                    // angle (in degrees) of shortest distance in sector
-    bool _sector_distance_valid;            // true if sector has at least one valid distance
+    // 3D boundary face and distance for latest readings
+    AP_Proximity_Boundary_3D::Face _face;   // face of most recently received distance
+    float _face_distance;                   // shortest distance (in meters) on face
+    float _face_yaw_deg;                    // yaw angle (in degrees) of shortest distance on face
+    bool _face_distance_valid;              // true if face has at least one valid distance
 
     // mini sector (5 degrees) angles and distances (used to populate obstacle database for path planning)
     uint8_t _minisector = UINT8_MAX;        // mini sector number (from 0 to 71) of most recently received distance

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -45,186 +45,208 @@ bool AP_Proximity_MAV::get_upward_distance(float &distance) const
     return false;
 }
 
-// handle mavlink DISTANCE_SENSOR messages
+// handle mavlink messages
 void AP_Proximity_MAV::handle_msg(const mavlink_message_t &msg)
-{
-    if (msg.msgid == MAVLINK_MSG_ID_DISTANCE_SENSOR) {
-        mavlink_distance_sensor_t packet;
-        mavlink_msg_distance_sensor_decode(&msg, &packet);
+{   
+    switch (msg.msgid) {
+        case (MAVLINK_MSG_ID_DISTANCE_SENSOR):
+            handle_distance_sensor_msg(msg);
+            break;
 
-        // store distance to appropriate sector based on orientation field
-        if (packet.orientation <= MAV_SENSOR_ROTATION_YAW_315) {
-            const uint8_t sector = packet.orientation;
-            // get the face for this sector
-            const float yaw_angle_deg = sector * 45;
-            const AP_Proximity_Boundary_3D::Face face = boundary.get_face(yaw_angle_deg);
-            // store in meters
-            const uint16_t distance = packet.current_distance * 0.01f;
-            _distance_min = packet.min_distance * 0.01f;
-            _distance_max = packet.max_distance * 0.01f;
-            if (distance <= _distance_max && distance >= _distance_max) {
-                boundary.set_face_attributes(face, yaw_angle_deg, distance);
-                // update OA database
-                database_push(yaw_angle_deg, distance);
-            } else {
-                // reset distance for this face
-                boundary.reset_face(face);
-            }
-            _last_update_ms = AP_HAL::millis();
-        }
+        case (MAVLINK_MSG_ID_OBSTACLE_DISTANCE):
+            handle_obstacle_distance_msg(msg);
+            break;
 
-        // store upward distance
-        if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_90) {
-            _distance_upward = packet.current_distance * 0.01f;
-            _last_upward_update_ms = AP_HAL::millis();
-        }
-        return;
+        case (MAVLINK_MSG_ID_OBSTACLE_DISTANCE_3D):
+            handle_obstacle_distance_3d_msg(msg);
+            break;    
     }
+}
 
-    if (msg.msgid == MAVLINK_MSG_ID_OBSTACLE_DISTANCE) {
-        mavlink_obstacle_distance_t packet;
-        mavlink_msg_obstacle_distance_decode(&msg, &packet);
+// handle mavlink DISTANCE_SENSOR messages
+void AP_Proximity_MAV::handle_distance_sensor_msg(const mavlink_message_t &msg)
+{
+    mavlink_distance_sensor_t packet;
+    mavlink_msg_distance_sensor_decode(&msg, &packet);
 
-        // check increment (message's sector width)
-        float increment;
-        if (!is_zero(packet.increment_f)) {
-            // use increment float
-            increment = packet.increment_f;
-        } else if (packet.increment != 0) {
-            // use increment uint8_t
-            increment = packet.increment;
-        } else {
-            // invalid increment
-            return;
-        }
-
-        const uint8_t total_distances = MIN(((360.0f / fabsf(increment)) + 0.5f), MAVLINK_MSG_OBSTACLE_DISTANCE_FIELD_DISTANCES_LEN); // usually 72
-
-        // set distance min and max
+    // store distance to appropriate sector based on orientation field
+    if (packet.orientation <= MAV_SENSOR_ROTATION_YAW_315) {
+        const uint8_t sector = packet.orientation;
+        // get the face for this sector
+        const float yaw_angle_deg = sector * 45;
+        const AP_Proximity_Boundary_3D::Face face = boundary.get_face(yaw_angle_deg);
+        // store in meters
+        const float distance = packet.current_distance * 0.01f;
         _distance_min = packet.min_distance * 0.01f;
         _distance_max = packet.max_distance * 0.01f;
-        _last_update_ms = AP_HAL::millis();
-
-        // get user configured yaw correction from front end
-        const float param_yaw_offset = constrain_float(frontend.get_yaw_correction(state.instance), -360.0f, +360.0f);
-        const float yaw_correction = wrap_360(param_yaw_offset + packet.angle_offset);
-        if (frontend.get_orientation(state.instance) != 0) {
-            increment *= -1;
-        }
-
-        Vector3f current_pos;
-        Matrix3f body_to_ned;
-        const bool database_ready = database_prepare_for_push(current_pos, body_to_ned);
-
-        // variables to calculate closest angle and distance for each face
-        AP_Proximity_Boundary_3D::Face face;
-        float face_distance;
-        float face_yaw_deg;
-        bool face_distance_valid = false;
-
-        // iterate over message's sectors
-        for (uint8_t j = 0; j < total_distances; j++) {
-            const uint16_t distance_cm = packet.distances[j];
-            if (distance_cm == 0 ||
-                distance_cm == 65535 ||
-                distance_cm < packet.min_distance ||
-                distance_cm > packet.max_distance)
-            {
-                // sanity check failed, ignore this distance value
-                continue;
-            }
-
-            const float packet_distance_m = distance_cm * 0.01f;
-            const float mid_angle = wrap_360((float)j * increment + yaw_correction);
-
-            // get face for this latest reading
-            AP_Proximity_Boundary_3D::Face latest_face = boundary.get_face(mid_angle);
-            if (latest_face != face) {
-                // store previous face
-                if (face_distance_valid) {
-                    boundary.set_face_attributes(face, face_yaw_deg, face_distance);
-                } else {
-                    boundary.reset_face(face);
-                }
-                // init for latest face
-                face = latest_face;
-                face_distance_valid = false;
-            }
-
-            // update minimum distance found so far
-            if (!face_distance_valid || (packet_distance_m < face_distance)) {
-                face_yaw_deg = mid_angle;
-                face_distance = packet_distance_m;
-                face_distance_valid = true;
-            }
-
-            // update Object Avoidance database with Earth-frame point
-            if (database_ready) {
-                database_push(mid_angle, packet_distance_m, _last_update_ms, current_pos, body_to_ned);
-            }
-        }
-
-        // process the last face
-        if (face_distance_valid) {
-            boundary.set_face_attributes(face, face_yaw_deg, face_distance);
+        if (distance <= _distance_max && distance >= _distance_min) {
+            boundary.set_face_attributes(face, yaw_angle_deg, distance);
+            // update OA database
+            database_push(yaw_angle_deg, distance);
         } else {
+            // reset distance for this face
             boundary.reset_face(face);
         }
+        _last_update_ms = AP_HAL::millis();
+    }
+
+    // store upward distance
+    if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_90) {
+        _distance_upward = packet.current_distance * 0.01f;
+        _last_upward_update_ms = AP_HAL::millis();
+    }
+    return;
+}
+
+// handle mavlink OBSTACLE_DISTANCE messages
+void AP_Proximity_MAV::handle_obstacle_distance_msg(const mavlink_message_t &msg)
+{
+    mavlink_obstacle_distance_t packet;
+    mavlink_msg_obstacle_distance_decode(&msg, &packet);
+
+    // check increment (message's sector width)
+    float increment;
+    if (!is_zero(packet.increment_f)) {
+        // use increment float
+        increment = packet.increment_f;
+    } else if (packet.increment != 0) {
+        // use increment uint8_t
+        increment = packet.increment;
+    } else {
+        // invalid increment
         return;
     }
 
-    if (msg.msgid == MAVLINK_MSG_ID_OBSTACLE_DISTANCE_3D) {
-        mavlink_obstacle_distance_3d_t packet;
-        mavlink_msg_obstacle_distance_3d_decode(&msg, &packet);
+    const uint8_t total_distances = MIN(((360.0f / fabsf(increment)) + 0.5f), MAVLINK_MSG_OBSTACLE_DISTANCE_FIELD_DISTANCES_LEN); // usually 72
 
-        const uint32_t previous_sys_time = _last_update_ms;
-        _last_update_ms = AP_HAL::millis();
-        // time_diff will check if the new message arrived significantly later than the last message
-        const uint32_t time_diff = _last_update_ms - previous_sys_time;
+    // set distance min and max
+    _distance_min = packet.min_distance * 0.01f;
+    _distance_max = packet.max_distance * 0.01f;
+    _last_update_ms = AP_HAL::millis();
 
-        const uint32_t previous_msg_timestamp = _last_3d_msg_update_ms;
-        _last_3d_msg_update_ms = packet.time_boot_ms;
-        bool clear_fence = false;
+    // get user configured yaw correction from front end
+    const float param_yaw_offset = constrain_float(frontend.get_yaw_correction(state.instance), -360.0f, +360.0f);
+    const float yaw_correction = wrap_360(param_yaw_offset + packet.angle_offset);
+    if (frontend.get_orientation(state.instance) != 0) {
+        increment *= -1;
+    }
 
-        // we will add on to the last fence if the time stamp is the same
-        // provided we got the new obstacle in less than PROXIMITY_3D_MSG_TIMEOUT_MS  
-        if ((previous_msg_timestamp != _last_3d_msg_update_ms) || (time_diff > PROXIMITY_3D_MSG_TIMEOUT_MS)) {
-            clear_fence = true;
+    Vector3f current_pos;
+    Matrix3f body_to_ned;
+    const bool database_ready = database_prepare_for_push(current_pos, body_to_ned);
+
+    // variables to calculate closest angle and distance for each face
+    AP_Proximity_Boundary_3D::Face face;
+    float face_distance;
+    float face_yaw_deg;
+    bool face_distance_valid = false;
+
+    // iterate over message's sectors
+    for (uint8_t j = 0; j < total_distances; j++) {
+        const uint16_t distance_cm = packet.distances[j];
+        if (distance_cm == 0 ||
+            distance_cm == 65535 ||
+            distance_cm < packet.min_distance ||
+            distance_cm > packet.max_distance)
+        {
+            // sanity check failed, ignore this distance value
+            continue;
         }
 
-        _distance_min = packet.min_distance;
-        _distance_max = packet.max_distance;
+        const float packet_distance_m = distance_cm * 0.01f;
+        const float mid_angle = wrap_360((float)j * increment + yaw_correction);
 
-        Vector3f current_pos;
-        Matrix3f body_to_ned;
-        const bool database_ready = database_prepare_for_push(current_pos, body_to_ned);
-
-        if (clear_fence) {
-            // cleared fence back to defaults since we have a new timestamp
-            boundary.reset();
+        // get face for this latest reading
+        AP_Proximity_Boundary_3D::Face latest_face = boundary.get_face(mid_angle);
+        if (latest_face != face) {
+            // store previous face
+            if (face_distance_valid) {
+                boundary.set_face_attributes(face, face_yaw_deg, face_distance);
+            } else {
+                boundary.reset_face(face);
+            }
+            // init for latest face
+            face = latest_face;
+            face_distance_valid = false;
         }
 
-        const Vector3f obstacle(packet.x, packet.y, packet.z);
-        if (obstacle.length() < _distance_min || obstacle.length() > _distance_max || obstacle.is_zero()) {
-            // message isn't healthy
-            return;
-        }
-        // extract yaw and pitch from Obstacle Vector
-        const float yaw = wrap_360(degrees(atan2f(obstacle.y, obstacle.x)));
-        const float pitch = wrap_180(degrees(M_PI_2 - atan2f(norm(obstacle.x, obstacle.y), obstacle.z))); 
-
-        // allot them correct layer and sector based on calculated pitch and yaw
-        const AP_Proximity_Boundary_3D::Face face = boundary.get_face(pitch, yaw);
-        float face_distance;
-        if (boundary.get_distance(face, face_distance) && (face_distance < obstacle.length())) {
-            // we already have a shorter distance in this layer and sector
-            return;
+        // update minimum distance found so far
+        if (!face_distance_valid || (packet_distance_m < face_distance)) {
+            face_yaw_deg = mid_angle;
+            face_distance = packet_distance_m;
+            face_distance_valid = true;
         }
 
-        boundary.set_face_attributes(face, yaw, pitch, obstacle.length());
-
+        // update Object Avoidance database with Earth-frame point
         if (database_ready) {
-            database_push(yaw, obstacle.length(),_last_update_ms, current_pos, body_to_ned, pitch);
+            database_push(mid_angle, packet_distance_m, _last_update_ms, current_pos, body_to_ned);
         }
     }
+
+    // process the last face
+    if (face_distance_valid) {
+        boundary.set_face_attributes(face, face_yaw_deg, face_distance);
+    } else {
+        boundary.reset_face(face);
+    }
+    return;
+}
+
+// handle mavlink OBSTACLE_DISTANCE_3D messages
+void AP_Proximity_MAV::handle_obstacle_distance_3d_msg(const mavlink_message_t &msg)
+{
+    mavlink_obstacle_distance_3d_t packet;
+    mavlink_msg_obstacle_distance_3d_decode(&msg, &packet);
+
+    const uint32_t previous_sys_time = _last_update_ms;
+    _last_update_ms = AP_HAL::millis();
+   
+    // time_diff will check if the new message arrived significantly later than the last message
+    const uint32_t time_diff = _last_update_ms - previous_sys_time;
+
+    const uint32_t previous_msg_timestamp = _last_3d_msg_update_ms;
+    _last_3d_msg_update_ms = packet.time_boot_ms;
+
+    if (packet.frame != MAV_FRAME_BODY_FRD) {
+        // we do not support this frame of reference yet 
+        return;
+    }
+
+    // we will add on to the last fence if the time stamp is the same
+    // provided we got the new obstacle in less than PROXIMITY_3D_MSG_TIMEOUT_MS  
+    if ((previous_msg_timestamp != _last_3d_msg_update_ms) || (time_diff > PROXIMITY_3D_MSG_TIMEOUT_MS)) {
+        // cleared fence back to defaults since we have a new timestamp
+        boundary.reset();
+    }
+
+    _distance_min = packet.min_distance;
+    _distance_max = packet.max_distance;
+
+    Vector3f current_pos;
+    Matrix3f body_to_ned;
+    const bool database_ready = database_prepare_for_push(current_pos, body_to_ned);
+
+    const Vector3f obstacle(packet.x, packet.y, packet.z * -1.0f);
+    if (obstacle.length() < _distance_min || obstacle.length() > _distance_max || obstacle.is_zero()) {
+        // message isn't healthy
+        return;
+    }
+    // extract yaw and pitch from Obstacle Vector
+    const float yaw = wrap_360(degrees(atan2f(obstacle.y, obstacle.x)));
+    const float pitch = wrap_180(degrees(M_PI_2 - atan2f(norm(obstacle.x, obstacle.y), obstacle.z))); 
+
+    // allot to correct layer and sector based on calculated pitch and yaw
+    const AP_Proximity_Boundary_3D::Face face = boundary.get_face(pitch, yaw);
+    float face_distance;
+    if (boundary.get_distance(face, face_distance) && (face_distance < obstacle.length())) {
+        // we already have a shorter distance in this layer and sector
+        return;
+    }
+
+    boundary.set_face_attributes(face, yaw, pitch, obstacle.length());
+
+    if (database_ready) {
+        database_push(yaw, pitch, obstacle.length(),_last_update_ms, current_pos, body_to_ned);
+    }
+    return;
 }

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -20,16 +20,17 @@ public:
     // get distance upwards in meters. returns true on success
     bool get_upward_distance(float &distance) const override;
 
-    // handle mavlink DISTANCE_SENSOR messages
+    // handle mavlink messages
     void handle_msg(const mavlink_message_t &msg) override;
 
 private:
     // horizontal distance support
-    uint32_t _last_update_ms;   // system time of last DISTANCE_SENSOR message received
+    uint32_t _last_update_ms;   // system time of last mavlink message received
+    uint32_t _last_3d_msg_update_ms;   // last stored OBSTACLE_DISTANCE_3D message timestamp
     float _distance_max;        // max range of sensor in meters
     float _distance_min;        // min range of sensor in meters
 
     // upward distance support
-    uint32_t _last_upward_update_ms;    // system time of last update distance
+    uint32_t _last_upward_update_ms;    // system time of last update of upward distance
     float _distance_upward;             // upward distance in meters
 };

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -24,6 +24,14 @@ public:
     void handle_msg(const mavlink_message_t &msg) override;
 
 private:
+
+    // handle mavlink DISTANCE_SENSOR messages
+    void handle_distance_sensor_msg(const mavlink_message_t &msg);
+    // handle mavlink OBSTACLE_DISTANCE messages
+    void handle_obstacle_distance_msg(const mavlink_message_t &msg);
+    // handle mavlink OBSTACLE_DISTANCE_3D messages
+    void handle_obstacle_distance_3d_msg(const mavlink_message_t &msg);
+
     // horizontal distance support
     uint32_t _last_update_ms;   // system time of last mavlink message received
     uint32_t _last_3d_msg_update_ms;   // last stored OBSTACLE_DISTANCE_3D message timestamp

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -91,14 +91,15 @@ private:
     // request related variables
     enum ResponseType _response_type;         ///< response from the lidar
     enum rp_state _rp_state;
-    uint8_t   _last_sector;                   ///< last sector requested
     uint32_t  _last_request_ms;               ///< system time of last request
     uint32_t  _last_distance_received_ms;     ///< system time of last distance measurement received from sensor
     uint32_t  _last_reset_ms;
 
-    // sector related variables
-    float _angle_deg_last;
-    float _distance_m_last;
+    // face related variables
+    AP_Proximity_Boundary_3D::Face _last_face;///< last face requested
+    float _last_angle_deg;                    ///< yaw angle (in degrees) of _last_distance_m
+    float _last_distance_m;                   ///< shortest distance for _last_face
+    bool _last_distance_valid;                ///< true if _last_distance_m is valid
 
     struct PACKED _sensor_scan {
         uint8_t startbit      : 1;            ///< on the first revolution 1 else 0

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -42,22 +42,20 @@ void AP_Proximity_RangeFinder::update(void)
             // check for horizontal range finders
             if (sensor->orientation() <= ROTATION_YAW_315) {
                 const uint8_t sector = (uint8_t)sensor->orientation();
-                const boundary_location bnd_loc{sector};
-                boundary.reset_sector(bnd_loc);
+                const float angle = sector * 45;
+                const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle);
                 // distance in meters
                 const float distance_m = sensor->distance_cm() * 0.01f;
                 _distance_min = sensor->min_distance_cm() * 0.01f;
                 _distance_max = sensor->max_distance_cm() * 0.01f;
-
                 if ((distance_m <= _distance_max) && (distance_m >= _distance_min)) {
-                    const float angle = sector * 45;
-                    boundary.set_attributes(bnd_loc, angle, distance_m);
+                    boundary.set_face_attributes(face, angle, distance_m);
                     // update OA database
                     database_push(angle, distance_m);
+                } else {
+                    boundary.reset_face(face);
                 }
-                
                 _last_update_ms = now;
-                boundary.update_boundary(bnd_loc);
             }
             // check upward facing range finder
             if (sensor->orientation() == ROTATION_PITCH_90) {

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -53,13 +53,15 @@ void AP_Proximity_SITL::update(void)
     }
     if (AP::fence()->polyfence().inclusion_boundary_available()) {
         // update distance in one sector
-        if (get_distance_to_fence(_sector_middle_deg[last_sector], _distance[last_sector])) {
+        boundary_location bnd_loc{last_sector};
+        boundary.reset_sector(bnd_loc);
+        float fence_distance;
+        if (get_distance_to_fence(boundary._sector_middle_deg[last_sector], fence_distance)) {
             set_status(AP_Proximity::Status::Good);
-            _distance_valid[last_sector] = true;
-            _angle[last_sector] = _sector_middle_deg[last_sector];
-            update_boundary_for_sector(last_sector, true);
-        } else {
-            _distance_valid[last_sector] = false;
+            boundary.set_attributes(bnd_loc, boundary._sector_middle_deg[last_sector], fence_distance);
+            boundary.update_boundary(bnd_loc);
+            // update OA database
+            database_push(boundary._sector_middle_deg[last_sector], fence_distance);
         }
         last_sector++;
         if (last_sector >= PROXIMITY_NUM_SECTORS) {

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -52,20 +52,19 @@ void AP_Proximity_SITL::update(void)
         // only called to prompt polyfence to reload fence if required
     }
     if (AP::fence()->polyfence().inclusion_boundary_available()) {
-        // update distance in one sector
-        boundary_location bnd_loc{last_sector};
-        boundary.reset_sector(bnd_loc);
-        float fence_distance;
-        if (get_distance_to_fence(boundary._sector_middle_deg[last_sector], fence_distance)) {
-            set_status(AP_Proximity::Status::Good);
-            boundary.set_attributes(bnd_loc, boundary._sector_middle_deg[last_sector], fence_distance);
-            boundary.update_boundary(bnd_loc);
-            // update OA database
-            database_push(boundary._sector_middle_deg[last_sector], fence_distance);
-        }
-        last_sector++;
-        if (last_sector >= PROXIMITY_NUM_SECTORS) {
-            last_sector = 0;
+        // update distance in each sector
+        for (uint8_t sector=0; sector < PROXIMITY_NUM_SECTORS; sector++) {
+            const float yaw_angle_deg = sector * 45.0f;
+            AP_Proximity_Boundary_3D::Face face = boundary.get_face(yaw_angle_deg);
+            float fence_distance;
+            if (get_distance_to_fence(yaw_angle_deg, fence_distance)) {
+                set_status(AP_Proximity::Status::Good);
+                boundary.set_face_attributes(face, yaw_angle_deg, fence_distance);
+                // update OA database
+                database_push(yaw_angle_deg, fence_distance);
+            } else {
+                boundary.reset_face(face);
+            }
         }
     } else {
         set_status(AP_Proximity::Status::NoData);

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -91,12 +91,16 @@ bool AP_Proximity_TeraRangerTower::read_sensor_data()
 
 // process reply
 void AP_Proximity_TeraRangerTower::update_sector_data(int16_t angle_deg, uint16_t distance_cm)
-{
-    const uint8_t sector = convert_angle_to_sector(angle_deg);
-    _angle[sector] = angle_deg;
-    _distance[sector] = ((float) distance_cm) / 1000;
-    _distance_valid[sector] = distance_cm != 0xffff;
+{   
+    // Get location on 3-D boundary based on angle to the object
+    const boundary_location bnd_loc = boundary.get_sector(angle_deg);
+    boundary.reset_sector(bnd_loc);
+    if (distance_cm != 0xffff) {
+        boundary.set_attributes(bnd_loc, angle_deg, ((float) distance_cm) / 1000);
+        // update OA database
+        database_push(angle_deg, ((float) distance_cm) / 1000);
+    }
     _last_distance_received_ms = AP_HAL::millis();
     // update boundary used for avoidance
-    update_boundary_for_sector(sector, true);
+    boundary.update_boundary(bnd_loc);  
 }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -93,14 +93,13 @@ bool AP_Proximity_TeraRangerTower::read_sensor_data()
 void AP_Proximity_TeraRangerTower::update_sector_data(int16_t angle_deg, uint16_t distance_cm)
 {   
     // Get location on 3-D boundary based on angle to the object
-    const boundary_location bnd_loc = boundary.get_sector(angle_deg);
-    boundary.reset_sector(bnd_loc);
+    const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle_deg);
     if (distance_cm != 0xffff) {
-        boundary.set_attributes(bnd_loc, angle_deg, ((float) distance_cm) / 1000);
+        boundary.set_face_attributes(face, angle_deg, ((float) distance_cm) / 1000);
         // update OA database
         database_push(angle_deg, ((float) distance_cm) / 1000);
+    } else {
+        boundary.reset_face(face);
     }
     _last_distance_received_ms = AP_HAL::millis();
-    // update boundary used for avoidance
-    boundary.update_boundary(bnd_loc);  
 }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -144,18 +144,17 @@ bool AP_Proximity_TeraRangerTowerEvo::read_sensor_data()
 
 // process reply
 void AP_Proximity_TeraRangerTowerEvo::update_sector_data(int16_t angle_deg, uint16_t distance_cm)
-{   
+{
     // Get location on 3-D boundary based on angle to the object
-    const boundary_location bnd_loc = boundary.get_sector(angle_deg);
+    const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle_deg);
     //check for target too far, target too close and sensor not connected
     const bool valid = distance_cm != 0xffff && distance_cm != 0x0000 && distance_cm != 0x0001;
-    boundary.reset_sector(bnd_loc);
     if (valid) {
-        boundary.set_attributes(bnd_loc, angle_deg, ((float) distance_cm) / 1000);
+        boundary.set_face_attributes(face, angle_deg, ((float) distance_cm) / 1000);
         // update OA database
         database_push(angle_deg, ((float) distance_cm) / 1000);
+    } else {
+        boundary.reset_face(face);
     }
     _last_distance_received_ms = AP_HAL::millis();
-    // update boundary used for avoidance
-    boundary.update_boundary(bnd_loc);
 }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -144,14 +144,18 @@ bool AP_Proximity_TeraRangerTowerEvo::read_sensor_data()
 
 // process reply
 void AP_Proximity_TeraRangerTowerEvo::update_sector_data(int16_t angle_deg, uint16_t distance_cm)
-{
-    const uint8_t sector = convert_angle_to_sector(angle_deg);
-    _angle[sector] = angle_deg;
-    _distance[sector] = ((float) distance_cm) / 1000;
-
+{   
+    // Get location on 3-D boundary based on angle to the object
+    const boundary_location bnd_loc = boundary.get_sector(angle_deg);
     //check for target too far, target too close and sensor not connected
-    _distance_valid[sector] = distance_cm != 0xffff && distance_cm != 0x0000 && distance_cm != 0x0001;
+    const bool valid = distance_cm != 0xffff && distance_cm != 0x0000 && distance_cm != 0x0001;
+    boundary.reset_sector(bnd_loc);
+    if (valid) {
+        boundary.set_attributes(bnd_loc, angle_deg, ((float) distance_cm) / 1000);
+        // update OA database
+        database_push(angle_deg, ((float) distance_cm) / 1000);
+    }
     _last_distance_received_ms = AP_HAL::millis();
     // update boundary used for avoidance
-    update_boundary_for_sector(sector, true);
+    boundary.update_boundary(bnd_loc);
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -396,6 +396,7 @@ protected:
 
     void handle_distance_sensor(const mavlink_message_t &msg);
     void handle_obstacle_distance(const mavlink_message_t &msg);
+    void handle_obstacle_distance_3d(const mavlink_message_t &msg);
 
     void handle_osd_param_config(const mavlink_message_t &msg);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3224,6 +3224,14 @@ void GCS_MAVLINK::handle_obstacle_distance(const mavlink_message_t &msg)
     }
 }
 
+void GCS_MAVLINK::handle_obstacle_distance_3d(const mavlink_message_t &msg)
+{
+    AP_Proximity *proximity = AP::proximity();
+    if (proximity != nullptr) {
+        proximity->handle_msg(msg);
+    }
+}
+
 void GCS_MAVLINK::handle_osd_param_config(const mavlink_message_t &msg)
 {
 #if OSD_PARAM_ENABLED
@@ -3418,6 +3426,10 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
 
     case MAVLINK_MSG_ID_OBSTACLE_DISTANCE:
         handle_obstacle_distance(msg);
+        break;
+    
+    case MAVLINK_MSG_ID_OBSTACLE_DISTANCE_3D:
+        handle_obstacle_distance_3d(msg);
         break;
 
     case MAVLINK_MSG_ID_OSD_PARAM_CONFIG:


### PR DESCRIPTION
This PR aims to do the following:

- Add new Mavlink message to support 3-D obstacle messages which can be seen [here](https://github.com/ArduPilot/mavlink/pull/148)

- Convert Proximity libraries Mini - Fence to a 3D sphere-ish shape, which looks something like this:
![image](https://user-images.githubusercontent.com/36970042/95688332-1e819a00-0c27-11eb-8f8c-d31976b6ca67.png)
This also involves a changing each and every proximity driver, and how it interacts with the Boundary 

- Convert Simple Avoidance to 3-D, which includes backing up in 3D. So if a user was to approach an obstacle from below the vehicle... The copter would climb up. A live demonstration of this can be seen here: 
https://youtu.be/vGSLFTKbvTc
Also some (funny) morse simulation: https://youtu.be/a6idKp2I8dU

Backing up from alt Fence (which is a new addition in this PR) can be seen here on SITL: https://youtu.be/EQ1dzg05SoQ

Things that are left:

- [x] "Stop mode" for proximity avoidance

- [x] Clean up debug code and formatting errors amongst other trivial things

- [ ] Convert AC_Loiter to spit out a 3D velocity vector. Currently it only does 2D and Z velocity is handled at the vehicle level.

- [x] Lots and lots of testing to make sure nothing is broken  

- [ ] Fix Simple Avoidance logging and covert it to 3D
