### PR TITLE
Add concept of bus ownership to SITL i2c simulation

### DIFF
--- a/libraries/AP_HAL/Semaphores.h
+++ b/libraries/AP_HAL/Semaphores.h
@@ -8,6 +8,13 @@
 
 class AP_HAL::Semaphore {
 public:
+
+    Semaphore() {}
+
+    // do not allow copying
+    Semaphore(const Semaphore &other) = delete;
+    Semaphore &operator=(const Semaphore&) = delete;
+
     virtual bool take(uint32_t timeout_ms) WARN_IF_UNUSED = 0 ;
     virtual bool take_nonblocking() WARN_IF_UNUSED = 0;
 

--- a/libraries/AP_HAL_Empty/Semaphores.h
+++ b/libraries/AP_HAL_Empty/Semaphores.h
@@ -4,7 +4,7 @@
 
 class Empty::Semaphore : public AP_HAL::Semaphore {
 public:
-    Semaphore() : _taken(false) {}
+
     bool give() override;
     bool take(uint32_t timeout_ms) override;
     bool take_nonblocking() override;

--- a/libraries/AP_HAL_SITL/Semaphores.h
+++ b/libraries/AP_HAL_SITL/Semaphores.h
@@ -13,6 +13,11 @@ public:
     bool give() override;
     bool take(uint32_t timeout_ms) override;
     bool take_nonblocking() override;
+
+    void check_owner();  // asserts that current thread owns semaphore
+
 protected:
     pthread_mutex_t _lock;
+    pthread_t owner;
+
 };


### PR DESCRIPTION
The bus ownership check isn't *that* useful ATM as we don't run separate threads for the buses in SITL.  It will catch cases where a driver being initialised doesn't take the bus semaphore, however.

Also initialise the simulated i2c bus count (not used from a technical perspective ATM)

Also don't allow copies of Semaphore objects to be created.

Correct taking copy of SITL I2C bus when iterating through the list.
