### PR TITLE
GCS_MAVLink: Change to leave the lower 16 bits.

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1062,7 +1062,7 @@ void GCS_MAVLINK::update_send()
 #endif
 
     const uint32_t start = AP_HAL::millis();
-    const uint16_t start16 = AP_HAL::millis16();
+    const uint16_t start16 = start & 0xFFFF;
     while (AP_HAL::millis() - start < 5) { // spend a max of 5ms sending messages.  This should never trigger - out_of_time() should become true
         if (gcs().out_of_time()) {
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS


### PR DESCRIPTION
I think it's better to create a 32 bit start time and a 16 bit start time from a 32 bit start time.
Sometimes the lower 16 bits of 32 bits and 16 bit times are not the same.
I would prefer to use the first time you get to use the first time to reduce the processing time.
Also, the lower 16 bits will have the same value.