### PR TITLE
Plane: correct logger Message spelling error

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -307,7 +307,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: ThD: demanded speed-height-controller throttle
 // @Field: As: airspeed estimate (or measurement if airspeed sensor healthy and ARSPD_USE>0)
 // @Field: SAs: synthetic airspeed measurement derived from non-airspeed sensors, NaN if not available
-// @Field: E2T: equivelent to true airspeed ratio
+// @Field: E2T: equivalent to true airspeed ratio
 
     { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
       "CTUN", "Qcccchhhfff",    "TimeUS,NavRoll,Roll,NavPitch,Pitch,ThO,RdrOut,ThD,As,SAs,E2T", "sdddd---nn-", "FBBBB---00-" },


### PR DESCRIPTION
Corrects a spelling error introduced by me.

Not sure why the VSCode spell checker missed this one, my PRs only make a sense at all because that usually does quite a good job.