### PR TITLE
Plane: tailsitter: ask for FW state don't check

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -88,14 +88,12 @@ bool Mode::enter()
 
 bool Mode::is_vtol_man_throttle() const
 {
-    if (!plane.quadplane.in_vtol_mode() &&
-        plane.quadplane.is_tailsitter() && 
-        plane.quadplane.tailsitter_transition_fw_complete() && 
+    if (plane.quadplane.is_tailsitter_in_fw_flight() &&
         plane.quadplane.assisted_flight) {
-        // a tailsitter that has fully transisisoned to Q-assisted forward flight
-        // in this case the forward throttle directly drives the vertical throttle
+        // We are a tailsitter that has fully transitioned to Q-assisted forward flight.
+        // In this case the forward throttle directly drives the vertical throttle so
         // set vertical throttle state to match the forward throttle state. Confusingly the booleans are inverted,
-        // forward throttle uses 'auto_throttle_mode' whereas vertical used 'is_vtol_man_throttle'
+        // forward throttle uses 'auto_throttle_mode' whereas vertical uses 'is_vtol_man_throttle'.
         return !plane.auto_throttle_mode;
     }
     return false;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -130,6 +130,9 @@ public:
     // check if we have completed transition to fixed wing
     bool tailsitter_transition_fw_complete(void);
 
+    // return true if we are a tailsitter in FW flight
+    bool is_tailsitter_in_fw_flight(void) const;
+
     // check if we have completed transition to vtol
     bool tailsitter_transition_vtol_complete(void) const;
 

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -114,7 +114,7 @@ void QuadPlane::tailsitter_output(void)
     // handle Copter controller
     // the MultiCopter rate controller has already been run in an earlier call
     // to motors_output() from quadplane.update(), unless we are in assisted flight
-    if (assisted_flight && tailsitter_transition_fw_complete()) {
+    if (assisted_flight && is_tailsitter_in_fw_flight()) {
         hold_stabilize(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * 0.01f);
         motors_output(true);
 
@@ -265,6 +265,14 @@ void QuadPlane::tailsitter_check_input(void)
 bool QuadPlane::in_tailsitter_vtol_transition(void) const
 {
     return is_tailsitter() && in_vtol_mode() && transition_state == TRANSITION_ANGLE_WAIT_VTOL;
+}
+
+/*
+  return true if we are a tailsitter in FW flight
+ */
+bool QuadPlane::is_tailsitter_in_fw_flight(void) const
+{
+    return is_tailsitter() && !in_vtol_mode() && transition_state == TRANSITION_DONE;
 }
 
 /*


### PR DESCRIPTION
This fixes some more bugs added by me. We should check the current state rather than using the function that decides if we should change the state. This adds a new function `in_tailsitter_fw_flight` that is then used in place of `tailsitter_transition_fw_complete`. `tailsitter_transition_fw_complete` is still used to update the transition state. It has a timer and checks roll and pitch angles, it should not have been used as a generic function to tell what state we are in, I just grabbed it based on the function name and did not check what it actually did.

Should be no functional change, tested in SITL but hopefully removes some weird edge cases that you could have possibly hit if you were switching in and out of vtol modes very rapidly.