### PR TITLE
autotest: fix and re-enable button test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5599,7 +5599,6 @@ class AutoTestCopter(AutoTest):
             "Parachute": "See https://github.com/ArduPilot/ardupilot/issues/4702",
             "HorizontalAvoidFence": "See https://github.com/ArduPilot/ardupilot/issues/11525",
             "AltEstimation": "See https://github.com/ArduPilot/ardupilot/issues/15191",
-            "Button": "See https://github.com/ArduPilot/ardupilot/issues/15259",
         }
 
 class AutoTestHeli(AutoTestCopter):

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2134,5 +2134,4 @@ class AutoTestPlane(AutoTest):
 
     def disabled_tests(self):
         return {
-            "Button": "See https://github.com/ArduPilot/ardupilot/issues/15259",
         }

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5455,7 +5455,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def disabled_tests(self):
         return {
             "DriveMaxRCIN": "currently triggers Arithmetic Exception",
-            "Button": "See https://github.com/ArduPilot/ardupilot/issues/15259",
         }
 
     def rc_defaults(self):


### PR DESCRIPTION
A recent commit to fix the setting-of-pullup-resistors in SITL makes it
possible to re-enable this.

Closes #15259