### PR TITLE
Copter: Guided mode option to allow arming from transmitter

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -985,6 +985,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_GROUPINFO("AUTO_OPTIONS", 40, ParametersG2, auto_options, 0),
 #endif
 
+#if MODE_GUIDED_ENABLED == ENABLED
+    // @Param: GUIDED_OPTIONS
+    // @DisplayName: Guided mode options
+    // @Description: Options that can be applied to change guided mode behaviour
+    // @Bitmask: 0:Allow Arming from Transmitter
+    // @User: Advanced
+    AP_GROUPINFO("GUIDED_OPTIONS", 41, ParametersG2, guided_options, 0),
+#endif
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -986,12 +986,12 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 #endif
 
 #if MODE_GUIDED_ENABLED == ENABLED
-    // @Param: GUIDED_OPTIONS
+    // @Param: GUID_OPTIONS
     // @DisplayName: Guided mode options
     // @Description: Options that can be applied to change guided mode behaviour
     // @Bitmask: 0:Allow Arming from Transmitter
     // @User: Advanced
-    AP_GROUPINFO("GUIDED_OPTIONS", 41, ParametersG2, guided_options, 0),
+    AP_GROUPINFO("GUID_OPTIONS", 41, ParametersG2, guided_options, 0),
 #endif
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -623,6 +623,10 @@ public:
     AP_Int32 auto_options;
 #endif
 
+#if MODE_GUIDED_ENABLED == ENABLED
+    AP_Int32 guided_options;
+#endif
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -794,7 +794,7 @@ public:
 
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
-    bool allows_arming(bool from_gcs) const override { return from_gcs; }
+    bool allows_arming(bool from_gcs) const override;
     bool is_autopilot() const override { return true; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool in_guided_mode() const override { return true; }
@@ -832,6 +832,11 @@ protected:
     float crosstrack_error() const override;
 
 private:
+
+    // enum for GUIDED_OPTIONS parameter
+    enum class Options : int32_t {
+        AllowArmingFromTX = (1 << 0U),
+    };
 
     void pos_control_start();
     void vel_control_start();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -833,9 +833,9 @@ protected:
 
 private:
 
-    // enum for GUIDED_OPTIONS parameter
+    // enum for GUID_OPTIONS parameter
     enum class Options : int32_t {
-        AllowArmingFromTX = (1 << 0U),
+        AllowArmingFromTX = (1U << 0),
     };
 
     void pos_control_start();
@@ -865,7 +865,6 @@ public:
 
     bool requires_GPS() const override { return false; }
     bool has_manual_throttle() const override { return false; }
-    bool allows_arming(bool from_gcs) const override { return from_gcs; }
     bool is_autopilot() const override { return true; }
 
 protected:

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -59,11 +59,6 @@ bool ModeAuto::init(bool ignore_checks)
     }
 }
 
-bool ModeAuto::allows_arming(bool from_gcs) const
-{
-    return (copter.g2.auto_options & (int32_t)Options::AllowArming) != 0;
-};
-
 // auto_run - runs the auto controller
 //      should be called at 100hz or more
 //      relies on run_autopilot being called at 10hz which handles decision making and non-navigation related commands
@@ -116,6 +111,11 @@ void ModeAuto::run()
         break;
     }
 }
+
+bool ModeAuto::allows_arming(bool from_gcs) const
+{
+    return (copter.g2.auto_options & (int32_t)Options::AllowArming) != 0;
+};
 
 // auto_loiter_start - initialises loitering in auto mode
 //  returns success/failure because this can be called by exit_mission

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -114,7 +114,7 @@ void ModeAuto::run()
 
 bool ModeAuto::allows_arming(bool from_gcs) const
 {
-    return (copter.g2.auto_options & (int32_t)Options::AllowArming) != 0;
+    return (copter.g2.auto_options & (uint32_t)Options::AllowArming) != 0;
 };
 
 // auto_loiter_start - initialises loitering in auto mode

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -466,6 +466,17 @@ void ModeGuided::vel_control_run()
         }
     }
 
+    // landed with positive desired climb rate, initiate takeoff
+    if (motors->armed() && copter.ap.auto_armed && copter.ap.land_complete && is_positive(guided_vel_target_cms.z)) {
+        zero_throttle_and_relax_ac();
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+        if (motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
+            set_land_complete(false);
+            set_throttle_takeoff();
+        }
+        return;
+    }
+
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_spool_down();

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -384,6 +384,17 @@ void ModeGuided::run()
     }
  }
 
+bool ModeGuided::allows_arming(bool from_gcs) const
+{
+    // always allow arming from the ground station
+    if (from_gcs) {
+        return true;
+    }
+
+    // optionally allow arming from the transmitter
+    return (copter.g2.guided_options & (int32_t)Options::AllowArmingFromTX) != 0;
+};
+
 // guided_takeoff_run - takeoff in guided mode
 //      called by guided_run at 100hz or more
 void ModeGuided::takeoff_run()

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -339,11 +339,6 @@ void ModeGuided::set_angle(const Quaternion &q, float climb_rate_cms_or_thrust, 
 
     guided_angle_state.update_time_ms = millis();
 
-    // interpret positive climb rate or thrust as triggering take-off
-    if (motors->armed() && !copter.ap.auto_armed && is_positive(climb_rate_cms_or_thrust)) {
-        copter.set_auto_armed(true);
-    }
-
     // log target
     copter.Log_Write_GuidedTarget(guided_mode,
                            Vector3f(guided_angle_state.roll_cd, guided_angle_state.pitch_cd, guided_angle_state.yaw_cd),
@@ -616,6 +611,11 @@ void ModeGuided::angle_control_run()
         climb_rate_cms = 0.0f;
         yaw_rate_in = 0.0f;
         guided_angle_state.use_thrust = false;
+    }
+
+    // interpret positive climb rate or thrust as triggering take-off
+    if (motors->armed() && is_positive(guided_angle_state.use_thrust ? guided_angle_state.thrust : climb_rate_cms)) {
+        copter.set_auto_armed(true);
     }
 
     // if not armed set throttle to zero and exit immediately

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -47,6 +47,50 @@ bool ModeGuided::init(bool ignore_checks)
     return true;
 }
 
+// guided_run - runs the guided controller
+// should be called at 100hz or more
+void ModeGuided::run()
+{
+    // call the correct auto controller
+    switch (guided_mode) {
+
+    case Guided_TakeOff:
+        // run takeoff controller
+        takeoff_run();
+        break;
+
+    case Guided_WP:
+        // run position controller
+        pos_control_run();
+        break;
+
+    case Guided_Velocity:
+        // run velocity controller
+        vel_control_run();
+        break;
+
+    case Guided_PosVel:
+        // run position-velocity controller
+        posvel_control_run();
+        break;
+
+    case Guided_Angle:
+        // run angle controller
+        angle_control_run();
+        break;
+    }
+ }
+
+bool ModeGuided::allows_arming(bool from_gcs) const
+{
+    // always allow arming from the ground station
+    if (from_gcs) {
+        return true;
+    }
+
+    // optionally allow arming from the transmitter
+    return (copter.g2.guided_options & (int32_t)Options::AllowArmingFromTX) != 0;
+};
 
 // do_user_takeoff_start - initialises waypoint controller to implement take-off
 bool ModeGuided::do_user_takeoff_start(float takeoff_alt_cm)
@@ -344,51 +388,6 @@ void ModeGuided::set_angle(const Quaternion &q, float climb_rate_cms_or_thrust, 
                            Vector3f(guided_angle_state.roll_cd, guided_angle_state.pitch_cd, guided_angle_state.yaw_cd),
                            Vector3f(0.0f, 0.0f, climb_rate_cms_or_thrust));
 }
-
-// guided_run - runs the guided controller
-// should be called at 100hz or more
-void ModeGuided::run()
-{
-    // call the correct auto controller
-    switch (guided_mode) {
-
-    case Guided_TakeOff:
-        // run takeoff controller
-        takeoff_run();
-        break;
-
-    case Guided_WP:
-        // run position controller
-        pos_control_run();
-        break;
-
-    case Guided_Velocity:
-        // run velocity controller
-        vel_control_run();
-        break;
-
-    case Guided_PosVel:
-        // run position-velocity controller
-        posvel_control_run();
-        break;
-
-    case Guided_Angle:
-        // run angle controller
-        angle_control_run();
-        break;
-    }
- }
-
-bool ModeGuided::allows_arming(bool from_gcs) const
-{
-    // always allow arming from the ground station
-    if (from_gcs) {
-        return true;
-    }
-
-    // optionally allow arming from the transmitter
-    return (copter.g2.guided_options & (int32_t)Options::AllowArmingFromTX) != 0;
-};
 
 // guided_takeoff_run - takeoff in guided mode
 //      called by guided_run at 100hz or more

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -89,7 +89,7 @@ bool ModeGuided::allows_arming(bool from_gcs) const
     }
 
     // optionally allow arming from the transmitter
-    return (copter.g2.guided_options & (int32_t)Options::AllowArmingFromTX) != 0;
+    return (copter.g2.guided_options & (uint32_t)Options::AllowArmingFromTX) != 0;
 };
 
 // do_user_takeoff_start - initialises waypoint controller to implement take-off

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -613,12 +613,13 @@ void ModeGuided::angle_control_run()
     }
 
     // interpret positive climb rate or thrust as triggering take-off
-    if (motors->armed() && is_positive(guided_angle_state.use_thrust ? guided_angle_state.thrust : climb_rate_cms)) {
+    const bool positive_thrust_or_climbrate = is_positive(guided_angle_state.use_thrust ? guided_angle_state.thrust : climb_rate_cms);
+    if (motors->armed() && positive_thrust_or_climbrate) {
         copter.set_auto_armed(true);
     }
 
     // if not armed set throttle to zero and exit immediately
-    if (!motors->armed() || !copter.ap.auto_armed || (copter.ap.land_complete && (guided_angle_state.climb_rate_cms <= 0.0f))) {
+    if (!motors->armed() || !copter.ap.auto_armed || (copter.ap.land_complete && !positive_thrust_or_climbrate)) {
         make_safe_spool_down();
         return;
     }

--- a/libraries/AP_Scripting/examples/copter-wall-climber.lua
+++ b/libraries/AP_Scripting/examples/copter-wall-climber.lua
@@ -1,0 +1,223 @@
+-- command a Copter to climb a wall at a specific distance
+--
+-- CAUTION: This script only works for Copter
+--    a) waits for the vehicle to be switched to Guided mode (does nothing)
+--    b) accepts pilot roll, pitch, throttle and yaw input
+--    c) manual mode
+--        - roll and pitch cause vehicle to fly horizontally in body frame at up to WP_SPEED
+--        - yaw controls turn rate
+--        - throttle controls climb/descent rate at up to PILOT_SPEED_UP/DOWN?  (WP_SPEED_UP, WPNAV_SPEED_DN?)
+--    d) autonomous mode
+--        - roll is unchanged from manual mode
+--        - yaw is unchanged from manual mode
+--        - pitch controls target distance to wall (limited to no less than 2m, no more than 8m)
+--        - throttle input causes vehicle to switch back to manual mode
+--        - climbs at 50cm/s (need parameter?) stopping at 2m intervals
+--    e) switch controls switching in and out of auto mode (use ZigZag switch?)
+
+-- constants
+local update_rate_ms = 10           -- script updates at 100hz
+local update_rate_dt = update_rate_ms / 1000.0 -- update rate in seconds
+local copter_guided_mode_num = 4    -- Copter's guided flight mode is mode 4
+local aux_switch_function = 61      -- auxiliary switch function controlling mode.  61 is ZIGZAG_SaveWP
+local climb_accel_max = 0.25         -- climb rate acceleration max in m/s/s
+local climb_rate_max = 2            -- climb rate max in m/s
+local climb_rate_chg_max = climb_accel_max * update_rate_dt -- max change in climb rate in a single iteration
+local roll_pitch_speed_max = 2      -- horizontal speed max in m/s
+local roll_pitch_accel_max = 0.25      -- horizontal acceleration max in m/s/s
+local roll_pitch_speed_chg_max = roll_pitch_accel_max * update_rate_dt  -- max change in roll or pitch speed in a single iteration
+local rc_roll_ch = 1                -- RC input channel for roll
+local rc_pitch_ch = 2               -- RC input channel for pitch
+local rc_throttle_ch = 3            -- RC input channel for throttle
+local rc_pwm_dz = 50                -- RC input deadzone in pwm
+local wall_pitch_speed_max = roll_pitch_speed_max / 2.0 -- wall control will never overpower pilot
+local wall_dist_to_speed_P = 0.5    -- P gain for converting distance to wall to forward speed
+local climb_pause_sec = 3           -- pause for this many seconds during each interval
+local climb_pause_counter_max = climb_pause_sec / update_rate_dt -- pause control's loop counter's initial value
+
+-- user parmeters
+local climb_dist_max = 10           -- vehicle moves to next lane at this many meters above home
+local climb_stop_interval = 1       -- vehicle stops after climbing this many meters
+local lane_width = 2                -- each lane is 2m apart horizontally
+
+-- lane variables
+local lane_number = 0               -- current lane number
+local lane_shift_roll_speed = 1     -- vehicle moves right at this speed in m/s
+local lane_shift_counter_max = lane_width / (lane_shift_roll_speed * update_rate_dt)
+local lane_shift_counter = 0        -- current lane shift counter value
+local lane_climb_rate = climb_rate_max / 2.0 -- autonomous climb is always 1/2 maximum
+
+-- global variables
+local aux_sw_pos_prev = 0           -- aux switch previous position
+local climb_mode = 0                -- 0:manual, 1:automatic climb
+local climb_rate = 0                -- current climb rate (negative is down, positive is up)
+local climb_total = 0               -- total number of meters above home
+local climb_interval_total = 0      -- meters climbed since last stop
+local climb_pause_counter = 0       -- current pause counter value
+local roll_speed = 0                -- target horizontal roll speed in m/s
+local pitch_speed = 0               -- target horizontal pitch speed in m/s
+local wall_dist_target = 5          -- target distance to wall
+
+-- the main update function that uses the takeoff and velocity controllers to fly a rough square pattern
+function update()
+
+  -- reset state when disarmed
+  if not arming:is_armed() then
+    climb_mode = 0
+    climb_rate = 0
+    climb_total = 0
+    climb_pause_counter = 0
+    climb_interval_total = 0
+    roll_speed = 0
+    pitch_speed = 0
+    lane_number = 0
+    lane_shift_counter = 0
+    lane_climb_rate = math.abs(lane_climb_rate)
+    return update, update_rate_ms
+  end
+
+  -- if not in Guided mode do nothing
+  if vehicle:get_mode() ~= copter_guided_mode_num then
+    return update, update_rate_ms
+  end
+
+  -- read switch input from RCx_FUNCTION
+  local aux_switch = rc:find_channel_for_option(aux_switch_function)
+  if aux_switch then
+    local sw_pos = aux_switch:get_aux_switch_pos()
+    if (sw_pos ~= aux_sw_pos_prev) then
+      -- only process input if switch position changed
+      aux_sw_pos_prev = sw_pos
+      if (sw_pos == 0) then
+        -- pilot has selected manual mode
+        if (climb_mode ~= 0) then
+          gcs:send_text(0, "WallClimb: pilot switch to Manual")
+          climb_mode = 0
+        end
+      elseif (sw_pos == 2) then
+        -- pilot has selected auto mode
+        if (climb_mode ~= 1) then
+          gcs:send_text(0, "WallClimb: pilot switch to Auto")
+          climb_mode = 1
+        end
+      end
+    end
+  end
+
+  -- read normalised roll, pitch and throttle input
+  local roll_input = 0
+  local rc_roll_pwm = rc:get_pwm(rc_roll_ch)
+  if (rc_roll_pwm and rc_roll_pwm >= 1000 and rc_roll_pwm <= 2000 and (math.abs(rc_roll_pwm - 1500) > rc_pwm_dz)) then
+    roll_input = (rc_roll_pwm - 1500) / 500.0
+  end
+  local pitch_input = 0
+  local rc_pitch_pwm = rc:get_pwm(rc_pitch_ch)
+  if (rc_pitch_pwm and rc_pitch_pwm >= 1000 and rc_pitch_pwm <= 2000 and (math.abs(rc_pitch_pwm - 1500) > rc_pwm_dz)) then
+    pitch_input = (rc_pitch_pwm - 1500) / 500.0
+  end
+  local throttle_input = 0
+  local rc_throttle_pwm = rc:get_pwm(rc_throttle_ch)
+  if (rc_throttle_pwm and rc_throttle_pwm >= 1000 and rc_throttle_pwm <= 2000 and (math.abs(rc_throttle_pwm - 1500) > rc_pwm_dz)) then
+    throttle_input = (rc_throttle_pwm - 1500) / 500.0
+  end
+
+  -- manual mode
+  if (climb_mode == 0) then
+    -- update target climb rate
+    local climb_rate_target = throttle_input * climb_rate_max
+    climb_rate = math.min(climb_rate_target, climb_rate + climb_rate_chg_max, climb_rate_max)
+    climb_rate = math.max(climb_rate_target, climb_rate - climb_rate_chg_max, -climb_rate_max)
+  end
+
+  -- autonomous mode
+  local wall_pitch_speed = 0
+  local wall_roll_speed = 0
+  if (climb_mode == 1) then
+    -- convert rangefinder distance to pitch speed
+    if rangefinder:has_data_orient(0) then
+      local distance_m = rangefinder:distance_cm_orient(0) * 0.01
+      wall_pitch_speed = (distance_m - wall_dist_target) * wall_dist_to_speed_P
+      wall_pitch_speed = math.min(wall_pitch_speed, wall_pitch_speed_max)
+      wall_pitch_speed = math.max(wall_pitch_speed, -wall_pitch_speed_max)
+    end
+
+    -- switch to manual if pilot provides throttle input
+    if (math.abs(throttle_input) ~= 0) then
+      gcs:send_text(0, "WallClimb: throttle input, switch to Manual")
+      climb_mode = 0
+    else
+      -- update distance climbed
+      local climb_chg = climb_rate * update_rate_dt
+      climb_interval_total = climb_interval_total + climb_chg
+      climb_total = climb_total + climb_chg
+
+      -- determine if we should pause
+      if (math.abs(climb_interval_total) >= climb_stop_interval) then
+        gcs:send_text(0, "WallClimb: pausing at " .. tostring(climb_total) .. "m")
+        climb_pause_counter = climb_pause_counter_max
+        climb_interval_total = 0
+
+        -- determine if we should move to next lane
+        if ((climb_total > climb_dist_max) or (climb_total <= 0)) then
+          lane_number = lane_number + 1
+          lane_climb_rate = -lane_climb_rate
+          lane_shift_counter = lane_shift_counter_max
+          gcs:send_text(0, "WallClimb: starting lane " .. tostring(lane_number))
+        end
+      end
+
+      -- default target climb rate to lane climb rate
+      local climb_rate_target = lane_climb_rate
+
+      -- if paused set target climb rate to zero
+      if (climb_pause_counter > 0) then
+        climb_pause_counter = climb_pause_counter - 1
+        climb_rate_target = 0
+        if (climb_pause_counter == 0) then
+          gcs:send_text(0, "WallClimb: restarting")
+        end
+      end
+
+      -- if shifting lanes pause climb and roll right
+      if (lane_shift_counter > 0) then
+        lane_shift_counter = lane_shift_counter - 1
+        wall_roll_speed = lane_shift_roll_speed
+        climb_rate_target = 0
+        -- if completing lane shift trigger another pause
+        if (lane_shift_counter == 0) then
+          climb_pause_counter = climb_pause_counter_max
+        end
+      end
+
+      -- calculate acceleration limited climb rate
+      climb_rate = math.min(climb_rate_target, climb_rate + climb_rate_chg_max, climb_rate_max)
+      climb_rate = math.max(climb_rate_target, climb_rate - climb_rate_chg_max, -climb_rate_max)
+    end
+  end
+
+  -- update target roll using both pilot and autonomous control (+ve right, -ve left)
+  local roll_speed_target = roll_input * roll_pitch_speed_max + wall_roll_speed
+  roll_speed = math.min(roll_speed_target, roll_speed + roll_pitch_speed_chg_max, roll_pitch_speed_max)
+  roll_speed = math.max(roll_speed_target, roll_speed - roll_pitch_speed_chg_max, -roll_pitch_speed_max)
+
+  -- update target pitch using both pilot and autonomous control (+ve forward, -ve backwards)
+  local pitch_speed_target = -pitch_input * roll_pitch_speed_max + wall_pitch_speed
+  pitch_speed = math.min(pitch_speed_target, pitch_speed + roll_pitch_speed_chg_max, roll_pitch_speed_max)
+  pitch_speed = math.max(pitch_speed_target, pitch_speed - roll_pitch_speed_chg_max, -roll_pitch_speed_max)
+
+  -- convert targets from body to earth frame and send to guided mode velocity controller
+  local yaw_rad = ahrs:get_yaw()
+  yaw_cos = math.cos(yaw_rad)
+  yaw_sin = math.sin(yaw_rad)
+  local target_vel_ned = Vector3f()
+  target_vel_ned:x(pitch_speed * yaw_cos - roll_speed * yaw_sin)
+  target_vel_ned:y(pitch_speed * yaw_sin + roll_speed * yaw_cos)
+  target_vel_ned:z(-climb_rate)
+  if not (vehicle:set_target_velocity_NED(target_vel_ned)) then
+    gcs:send_text(0, "failed to execute velocity command")
+  end
+
+  return update, update_rate_ms
+end
+
+return update()


### PR DESCRIPTION
This PR adds a GUIDED_OPTIONS parameter with a single option (for the moment) that allows the pilot to arm using the transmitter.  This is useful if Lua scripts are used to create a new flight mode based on Guided mode.  I.e. the vehicle is in Guided mode but the pilot can control the vehicle using the transmitter via a Lua script.

This change has been tested using a "[wall climber](https://github.com/rmackay9/rmackay9-ardupilot/blob/copter-wall-climber/libraries/AP_Scripting/examples/copter-wall-climber.lua)" script that is basically a vertical ZigZag mode.  The script commands the vehicle (using velocity commands sent while the vehicle is in Guided mode) to climb up and down the side of a building at a specified distance.  The pilot can easily re-take control by moving the roll, pitch or throttle sticks.

This PR is somewhat similar to @WickedShell's PR https://github.com/ArduPilot/ardupilot/pull/15424 that added support for arming (from the transmitter or GCS) in Auto mode.

This PR also includes these changes:

- External controllers (including lua scripts) can takeoff in Guided mode by providing a positive climb rate to the velocity controller
- Guided mode already allows taking off using the angle controller.  This feature is moved from the function that accepts the external angle target to the "run" method.  This is a non-functional change but keeps more of the logic together in the "run" function.
- Guided and Auto mode implementations are moved around in the .cpp file so they match the order in the .h file

The GUIDED_OPTIONS parameter change and takeoff using the velocity controller has been tested in SITL and on a real vehicle.  The takeoff in angle control mode has also been tested in SITL.