### PR TITLE
ADSB: create ADS-B backend split and add Sagetech driver

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -20,10 +20,12 @@
     https://en.wikipedia.org/wiki/Automatic_dependent_surveillance_%E2%80%93_broadcast
 */
 
-#include <AP_HAL/AP_HAL.h>
 #include "AP_ADSB.h"
+
 #if HAL_ADSB_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include "AP_ADSB_Sagetech.h"
+#include "AP_ADSB_MAVLink.h"
 #include <stdio.h>  // for sprintf
 #include <limits.h>
 #include <AP_Vehicle/AP_Vehicle.h>
@@ -34,20 +36,12 @@
 #include <AP_AHRS/AP_AHRS.h>
 
 
-#define VEHICLE_TIMEOUT_MS              5000   // if no updates in this time, drop it from the list
+//#define ADSB_STATIC_CALLSIGN            "APM1234"  // 8 ASCII chars of a Callsign. This can be overwritten by MAVLink msg UAVIONIX_ADSB_OUT_CFG
+
+#define VEHICLE_TIMEOUT_MS              5000    // if no updates in this time, drop it from the list
 #define ADSB_VEHICLE_LIST_SIZE_DEFAULT  25
-#define ADSB_VEHICLE_LIST_SIZE_MAX      100
-#define ADSB_CHAN_TIMEOUT_MS            15000
-#define ADSB_SQUAWK_OCTAL_DEFAULT       1200
-
-#define ADSB_BITBASK_RF_CAPABILITIES_UAT_IN         (1 << 0)
-#define ADSB_BITBASK_RF_CAPABILITIES_1090ES_IN      (1 << 1)
-
-#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
-    #define ADSB_LIST_RADIUS_DEFAULT        10000 // in meters
-#else // APM_BUILD_TYPE(APM_BUILD_ArduCopter), Rover, Boat
-    #define ADSB_LIST_RADIUS_DEFAULT        2000 // in meters
-#endif
+#define ADSB_VEHICLE_LIST_SIZE_MAX      100     // This should be hw/ram dependent
+#define ADSB_SQUAWK_OCTAL_DEFAULT       1200    // This is standard VFR in the USA
 
 extern const AP_HAL::HAL& hal;
 
@@ -78,7 +72,7 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @Range: 0 100000
     // @User: Advanced
     // @Units: m
-    AP_GROUPINFO("LIST_RADIUS",   3, AP_ADSB, in_state.list_radius, ADSB_LIST_RADIUS_DEFAULT),
+    AP_GROUPINFO("LIST_RADIUS",   3, AP_ADSB, in_state.list_radius, 0),
 
     // @Param: ICAO_ID
     // @DisplayName: ICAO_ID vehicle identification number
@@ -117,8 +111,8 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
 
     // @Param: RF_SELECT
     // @DisplayName: Transceiver RF selection
-    // @Description: Transceiver RF selection for Rx enable and/or Tx enable. This only effects devices that can Tx and Rx. Rx-only devices override this to always be Rx-only.
-    // @Values: 0:Disabled,1:Rx-Only,2:Tx-Only,3:Rx and Tx Enabled
+    // @Description: Transceiver RF selection for Rx enable and/or Tx enable. This only effects devices that can Tx and/or Rx. Rx-only devices override this to always be Rx-only.
+    // @Bitmask: 0:Rx,1:Tx
     // @User: Advanced
     AP_GROUPINFO("RF_SELECT",   9, AP_ADSB, out_state.cfg.rfSelect, UAVIONIX_ADSB_OUT_RF_SELECT_RX_ENABLED),
 
@@ -166,19 +160,54 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
 AP_ADSB::AP_ADSB()
 {
     AP_Param::setup_object_defaults(this, var_info);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (_singleton != nullptr) {
         AP_HAL::panic("AP_ADSB must be singleton");
     }
+#endif
     _singleton = this;
+
+    // out_state not set by params
+#ifdef ADSB_STATIC_CALLSIGN
+    memcpy(&out_state.cfg.callsign, ADSB_STATIC_CALLSIGN, 8);
+#else
+    memset(&out_state.cfg.callsign, 0, 8);
+#endif
 }
 
 /*
- * Initialize variables and allocate memory for array
+ * Initialize variables and allocate memory for new driver
  */
-void AP_ADSB::init(void)
+void AP_ADSB::hw_init(void)
 {
-    // in_state
+    if (backend != nullptr) {
+        // already initialized
+        return;
+    }
+
+    if (AP_ADSB_Sagetech::detect()) {
+        backend = new AP_ADSB_Sagetech(*this);
+    } else {
+        backend = new AP_ADSB_MAVLink(*this);
+    }
+
+    if (backend != nullptr) {
+        backend->init();
+
+    } else {
+        // disabled ADSB, init failed. If we don't do this it will try to re-init forever
+        _enabled.set_and_notify(false);
+        gcs().send_text(MAV_SEVERITY_INFO, "%sInit failed", GcsHeader);
+    }
+}
+
+
+void AP_ADSB::list_init(void)
+{
+    furthest_vehicle_distance = 0;
+    furthest_vehicle_index = 0;
     in_state.vehicle_count = 0;
+
     if (in_state.vehicle_list == nullptr) {
         if (in_state.list_size_param != constrain_int16(in_state.list_size_param, 1, ADSB_VEHICLE_LIST_SIZE_MAX)) {
             in_state.list_size_param.set_and_notify(ADSB_VEHICLE_LIST_SIZE_DEFAULT);
@@ -186,25 +215,21 @@ void AP_ADSB::init(void)
         }
         in_state.list_size = in_state.list_size_param;
         in_state.vehicle_list = new adsb_vehicle_t[in_state.list_size];
-
-        if (in_state.vehicle_list == nullptr) {
-            // dynamic RAM allocation of _vehicle_list[] failed, disable gracefully
-            hal.console->printf("Unable to initialize ADS-B vehicle list\n");
-            _enabled.set_and_notify(0);
-        }
     }
 
-    furthest_vehicle_distance = 0;
-    furthest_vehicle_index = 0;
 
-    // out_state
-    set_callsign("PING1234", false);
+    if (in_state.vehicle_list == nullptr) {
+        // dynamic RAM allocation of _vehicle_list[] failed, disable gracefully
+        hal.console->printf("Unable to initialize ADS-B vehicle list\n");
+        _enabled.set_and_notify(0);
+        in_state.list_size = 0;
+    }
 }
 
 /*
  * de-initialize and free up some memory
  */
-void AP_ADSB::deinit(void)
+void AP_ADSB::list_deinit(void)
 {
     in_state.vehicle_count = 0;
     if (in_state.vehicle_list != nullptr) {
@@ -213,48 +238,33 @@ void AP_ADSB::deinit(void)
     }
 }
 
-bool AP_ADSB::is_valid_callsign(uint16_t octal)
-{
-    // treat "octal" as decimal and test if any decimal digit is > 7
-    if (octal > 7777) {
-        return false;
-    }
-
-    while (octal != 0) {
-        if (octal % 10 > 7) {
-            return false;
-        }
-        octal /= 10;
-    }
-
-    return true;
-}
-
 /*
  * periodic update to handle vehicle timeouts and trigger collision detection
  */
 void AP_ADSB::update(void)
 {
+    if (!_enabled) {
+        if (in_state.vehicle_list != nullptr) {
+            // we've been enabled before, disable the list
+            list_deinit();
+        }
+        // nothing to do
+        return;
+
+    } else if (in_state.vehicle_list == nullptr || in_state.list_size != in_state.list_size_param) {
+        // list size param changed or is not initialized, reinit the list
+        list_deinit();
+        list_init();
+        return;
+    }
+
+
+    const uint32_t now = AP_HAL::millis();
+
     // update _my_loc
     if (!AP::ahrs().get_position(_my_loc)) {
         _my_loc.zero();
     }
-
-    if (!_enabled) {
-        if (in_state.vehicle_list != nullptr) {
-            deinit();
-        }
-        // nothing to do
-        return;
-    } else if (in_state.vehicle_list == nullptr)  {
-        init();
-        return;
-    } else if (in_state.list_size != in_state.list_size_param) {
-        deinit();
-        return;
-    }
-
-    const uint32_t now = AP_HAL::millis();
 
     // check current list for vehicles that time out
     uint16_t index = 0;
@@ -269,22 +279,11 @@ void AP_ADSB::update(void)
         }
     }
 
-    if (_my_loc.is_zero()) {
-        // if we don't have a GPS lock then there's nothing else to do
-        return;
-    }
-
-    if (out_state.chan < 0) {
-        // if there's no transceiver detected then do not set ICAO and do not service the transceiver
-        return;
-    }
-
-
     if (out_state.cfg.squawk_octal_param != out_state.cfg.squawk_octal) {
         // param changed, check that it's a valid octal
         if (!is_valid_callsign(out_state.cfg.squawk_octal_param)) {
             // invalid, reset it to default
-            out_state.cfg.squawk_octal_param = ADSB_SQUAWK_OCTAL_DEFAULT;
+            out_state.cfg.squawk_octal_param.set_and_notify(ADSB_SQUAWK_OCTAL_DEFAULT);
         }
         out_state.cfg.squawk_octal = (uint16_t)out_state.cfg.squawk_octal_param;
     }
@@ -305,31 +304,37 @@ void AP_ADSB::update(void)
             out_state.cfg.ICAO_id = out_state.cfg.ICAO_id_param;
         }
         out_state.cfg.ICAO_id_param_prev = out_state.cfg.ICAO_id_param;
-        set_callsign("PING", true);
-        gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", (int)out_state.cfg.ICAO_id, out_state.cfg.callsign);
+#ifndef ADSB_STATIC_CALLSIGN
+        set_callsign("APM ", true);
+#endif
+        //gcs().send_text(MAV_SEVERITY_INFO, "%sUsing ICAO_id %d and Callsign %s", GcsHeader, (int)out_state.cfg.ICAO_id, out_state.cfg.callsign);
         out_state.last_config_ms = 0; // send now
     }
 
+    if (backend == nullptr) {
+        hw_init();
+    } else {
+        backend->update();
+    }
 
-    // send static configuration data to transceiver, every 5s
-    if (out_state.chan_last_ms > 0 && now - out_state.chan_last_ms > ADSB_CHAN_TIMEOUT_MS) {
-        // haven't gotten a heartbeat health status packet in a while, assume hardware failure
-        // TODO: reset out_state.chan
-        out_state.chan = -1;
-        gcs().send_text(MAV_SEVERITY_ERROR, "ADSB: Transceiver heartbeat timed out");
-    } else if (out_state.chan < MAVLINK_COMM_NUM_BUFFERS) {
-        const mavlink_channel_t chan = (mavlink_channel_t)(MAVLINK_COMM_0 + out_state.chan);
-        if (now - out_state.last_config_ms >= 5000 && HAVE_PAYLOAD_SPACE(chan, UAVIONIX_ADSB_OUT_CFG)) {
-            out_state.last_config_ms = now;
-            send_configure(chan);
-        } // last_config_ms
+}
 
-        // send dynamic data to transceiver at 5Hz
-        if (now - out_state.last_report_ms >= 200 && HAVE_PAYLOAD_SPACE(chan, UAVIONIX_ADSB_OUT_DYNAMIC)) {
-            out_state.last_report_ms = now;
-            send_dynamic_out(chan);
-        } // last_report_ms
-    } // chan_last_ms
+
+bool AP_ADSB::is_valid_callsign(uint16_t octal)
+{
+    // treat "octal" as decimal and test if any decimal digit is > 7
+    if (octal > 7777) {
+        return false;
+    }
+
+    while (octal != 0) {
+        if (octal % 10 > 7) {
+            return false;
+        }
+        octal /= 10;
+    }
+
+    return true;
 }
 
 /*
@@ -518,7 +523,63 @@ void AP_ADSB::set_vehicle(const uint16_t index, const adsb_vehicle_t &vehicle)
         // out of range
         return;
     }
-    in_state.vehicle_list[index] = vehicle;
+
+    uint16_t flags = vehicle.info.flags;
+
+    if (flags == 0) {
+        // if no flags set, assume everything
+        flags = ADSB_FLAGS_VALID_COORDS |
+                ADSB_FLAGS_VALID_ALTITUDE |
+                ADSB_FLAGS_VALID_HEADING |
+                ADSB_FLAGS_VALID_VELOCITY |
+                ADSB_FLAGS_VALID_CALLSIGN |
+                ADSB_FLAGS_VALID_SQUAWK |
+                ADSB_FLAGS_VERTICAL_VELOCITY_VALID |
+                ADSB_FLAGS_BARO_VALID;
+                // all flags set except ADSB_FLAGS_SOURCE_UAT and ADSB_FLAGS_SIMULATED
+    }
+
+    in_state.vehicle_list[index].last_update_ms = vehicle.last_update_ms;
+
+    // use |= so we allow partial sets and those don't override previous valid settings
+    in_state.vehicle_list[index].info.flags |= flags;
+
+    in_state.vehicle_list[index].info.ICAO_address = vehicle.info.ICAO_address;
+    in_state.vehicle_list[index].info.emitter_type = vehicle.info.emitter_type;
+    in_state.vehicle_list[index].info.tslc = vehicle.info.tslc;
+
+    if (flags & ADSB_FLAGS_VALID_COORDS) {
+        in_state.vehicle_list[index].info.lat = vehicle.info.lat;
+        in_state.vehicle_list[index].info.lon = vehicle.info.lon;
+    }
+    if (flags & ADSB_FLAGS_VALID_ALTITUDE) {
+        in_state.vehicle_list[index].info.altitude_type = vehicle.info.altitude_type;
+        in_state.vehicle_list[index].info.altitude = vehicle.info.altitude;
+    }
+    if (flags & ADSB_FLAGS_VALID_HEADING) {
+        in_state.vehicle_list[index].info.heading = vehicle.info.heading;
+    }
+    if (flags & ADSB_FLAGS_VALID_VELOCITY) {
+        in_state.vehicle_list[index].info.hor_velocity = vehicle.info.hor_velocity;
+    }
+    if (flags & ADSB_FLAGS_VALID_SQUAWK) {
+        in_state.vehicle_list[index].info.squawk = vehicle.info.squawk;
+    }
+    if (flags & ADSB_FLAGS_SIMULATED) {
+        // do we care about this? Maybe have a mode where we
+    }
+    if (flags & ADSB_FLAGS_VERTICAL_VELOCITY_VALID) {
+        in_state.vehicle_list[index].info.ver_velocity = vehicle.info.ver_velocity;
+    }
+    if (flags & ADSB_FLAGS_VALID_CALLSIGN) {
+        memcpy(in_state.vehicle_list[index].info.callsign, vehicle.info.callsign, sizeof(vehicle.info.callsign));
+    }
+    if (flags & ADSB_FLAGS_BARO_VALID) {
+        // what do we do with this? Does it invalid ADSB_FLAGS_VALID_ALTITUDE with altitude_type == ADSB_ALTITUDE_TYPE_PRESSURE_QNH(0)?
+    }
+    if (flags & ADSB_FLAGS_SOURCE_UAT) {
+        // don't care
+    }
 
     write_log(vehicle);
 }
@@ -565,251 +626,6 @@ void AP_ADSB::send_adsb_vehicle(const mavlink_channel_t chan)
 }
 
 
-void AP_ADSB::send_dynamic_out(const mavlink_channel_t chan)
-{
-    const AP_GPS &gps = AP::gps();
-    const Vector3f &gps_velocity = gps.velocity();
-
-    const int32_t latitude = _my_loc.lat;
-    const int32_t longitude = _my_loc.lng;
-    const int32_t altGNSS = _my_loc.alt * 10; // convert cm to mm
-    const int16_t velVert = gps_velocity.z * 1E2; // convert m/s to cm/s
-    const int16_t nsVog = gps_velocity.x * 1E2; // convert m/s to cm/s
-    const int16_t ewVog = gps_velocity.y * 1E2; // convert m/s to cm/s
-    const uint8_t fixType = gps.status(); // this lines up perfectly with our enum
-    const uint8_t emStatus = 0; // TODO: implement this ENUM. no emergency = 0
-    const uint8_t numSats = gps.num_sats();
-    const uint16_t squawk = out_state.cfg.squawk_octal;
-
-    uint32_t accHoriz = UINT_MAX;
-    float accHoriz_f;
-    if (gps.horizontal_accuracy(accHoriz_f)) {
-        accHoriz = accHoriz_f * 1E3; // convert m to mm
-    }
-
-    uint16_t accVert = USHRT_MAX;
-    float accVert_f;
-    if (gps.vertical_accuracy(accVert_f)) {
-        accVert = accVert_f * 1E2; // convert m to cm
-    }
-
-    uint16_t accVel = USHRT_MAX;
-    float accVel_f;
-    if (gps.speed_accuracy(accVel_f)) {
-        accVel = accVel_f * 1E3; // convert m/s to mm/s
-    }
-
-    uint16_t state = 0;
-    if (out_state._is_in_auto_mode) {
-        state |= UAVIONIX_ADSB_OUT_DYNAMIC_STATE_AUTOPILOT_ENABLED;
-    }
-    if (!out_state.is_flying) {
-        state |= UAVIONIX_ADSB_OUT_DYNAMIC_STATE_ON_GROUND;
-    }
-
-    // TODO: confirm this sets utcTime correctly
-    const uint64_t gps_time = gps.time_epoch_usec();
-    const uint32_t utcTime = gps_time / 1000000ULL;
-
-    const AP_Baro &baro = AP::baro();
-    int32_t altPres = INT_MAX;
-    if (baro.healthy()) {
-        // Altitude difference between sea level pressure and current pressure. Result in millimeters
-        altPres = baro.get_altitude_difference(SSL_AIR_PRESSURE, baro.get_pressure()) * 1E3; // convert m to mm;
-    }
-
-
-
-    mavlink_msg_uavionix_adsb_out_dynamic_send(
-            chan,
-            utcTime,
-            latitude,
-            longitude,
-            altGNSS,
-            fixType,
-            numSats,
-            altPres,
-            accHoriz,
-            accVert,
-            accVel,
-            velVert,
-            nsVog,
-            ewVog,
-            emStatus,
-            state,
-            squawk);
-}
-
-
-/*
- * To expand functionality in their HW, uAvionix has extended a few of the unused MAVLink bits to pack in more new features
- * This function will override the MSB byte of the 24bit ICAO address. To ensure an invalid >24bit ICAO is never broadcasted,
- * this function is used to create the encoded verison without ever writing to the actual ICAO number. It's created on-demand
- */
-uint32_t AP_ADSB::get_encoded_icao(void)
-{
-    // utilize the upper unused 8bits of the icao with special flags.
-    // This encoding is required for uAvionix devices that break the MAVLink spec.
-
-    // ensure the user assignable icao is 24 bits
-    uint32_t encoded_icao = (uint32_t)out_state.cfg.ICAO_id & 0x00FFFFFF;
-
-    encoded_icao &= ~0x20000000;    // useGnssAltitude should always be FALSE
-    encoded_icao |=  0x10000000;    // csidLogic       should always be TRUE
-
-    //SIL/SDA are special fields that should be set to 0 with only expert user adjustment
-    encoded_icao &= ~0x03000000;    // SDA should always be FALSE
-    encoded_icao &= ~0x0C000000;    // SIL should always be FALSE
-
-    return encoded_icao;
-}
-
-/*
- * To expand functionality in their HW, uAvionix has extended a few of the unused MAVLink bits to pack in more new features
- * This function will override the usually-null ending char of the callsign. It always encodes the last byte [8], even if
- * the callsign string is less than 9 chars and there are other zero-padded nulls.
- */
-uint8_t AP_ADSB::get_encoded_callsign_null_char()
-{
-//  Encoding of the 8bit null char
-//  (LSB) - knots
-//  bit.1 - knots
-//  bit.2 - knots
-//  bit.3 - (unused)
-//  bit.4 - flag - ADSB_BITBASK_RF_CAPABILITIES_1090ES_IN
-//  bit.5 - flag - ADSB_BITBASK_RF_CAPABILITIES_UAT_IN
-//  bit.6 - flag - 0 = callsign is treated as callsign, 1 = callsign is treated as flightPlanID/Squawk
-//  (MSB) - (unused)
-
-    uint8_t encoded_null = 0;
-
-    if (out_state.cfg.maxAircraftSpeed_knots <= 0) {
-        // not set or unknown. no bits set
-    } else if (out_state.cfg.maxAircraftSpeed_knots <= 75) {
-        encoded_null |= 0x01;
-    } else if (out_state.cfg.maxAircraftSpeed_knots <= 150) {
-        encoded_null |= 0x02;
-    } else if (out_state.cfg.maxAircraftSpeed_knots <= 300) {
-        encoded_null |= 0x03;
-    } else if (out_state.cfg.maxAircraftSpeed_knots <= 600) {
-        encoded_null |= 0x04;
-    } else if (out_state.cfg.maxAircraftSpeed_knots <= 1200) {
-        encoded_null |= 0x05;
-    } else {
-        encoded_null |= 0x06;
-    }
-
-
-    if (out_state.cfg.rf_capable & ADSB_BITBASK_RF_CAPABILITIES_1090ES_IN) {
-        encoded_null |= 0x10;
-    }
-    if (out_state.cfg.rf_capable & ADSB_BITBASK_RF_CAPABILITIES_UAT_IN) {
-        encoded_null |= 0x20;
-    }
-
-
-    /*
-    If the user has an 8 digit flightPlanID assigned from a filed flight plan, this should be assigned to FlightPlanID, (assigned by remote app)
-    else if the user has an assigned squawk code from ATC this should be converted from 4 digit octal to 4 character alpha string and assigned to FlightPlanID,
-    else if a tail number is known it should be set to the tail number of the aircraft, (assigned by remote app)
-    else it should be left blank (all 0's)
-     */
-
-    // using the above logic, we must always assign the squawk. once we get configured
-    // externally then get_encoded_callsign_null_char() stops getting called
-    snprintf(out_state.cfg.callsign, 5, "%04d", unsigned(out_state.cfg.squawk_octal) & 0x1FFF);
-    memset(&out_state.cfg.callsign[4], 0, 5); // clear remaining 5 chars
-    encoded_null |= 0x40;
-
-    return encoded_null;
-}
-
-/*
- * handle incoming packet UAVIONIX_ADSB_OUT_CFG.
- * This allows a GCS to send cfg info through the autopilot to the ADSB hardware.
- * This is done indirectly by reading and storing the packet and then another mechanism sends it out periodically
- */
-void AP_ADSB::handle_out_cfg(const mavlink_message_t &msg)
-{
-    mavlink_uavionix_adsb_out_cfg_t packet {};
-    mavlink_msg_uavionix_adsb_out_cfg_decode(&msg, &packet);
-
-    out_state.cfg.was_set_externally = true;
-
-    out_state.cfg.ICAO_id = packet.ICAO;
-    out_state.cfg.ICAO_id_param = out_state.cfg.ICAO_id_param_prev = packet.ICAO & 0x00FFFFFFFF;
-
-    // May contain a non-null value at the end so accept it as-is with memcpy instead of strcpy
-    memcpy(out_state.cfg.callsign, packet.callsign, sizeof(out_state.cfg.callsign));
-
-    out_state.cfg.emitterType = packet.emitterType;
-    out_state.cfg.lengthWidth = packet.aircraftSize;
-    out_state.cfg.gpsLatOffset = packet.gpsOffsetLat;
-    out_state.cfg.gpsLonOffset = packet.gpsOffsetLon;
-    out_state.cfg.rfSelect = packet.rfSelect;
-    out_state.cfg.stall_speed_cm = packet.stallSpeed;
-
-    // guard against string with non-null end char
-    const char c = out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1];
-    out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = 0;
-    gcs().send_text(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", (int)out_state.cfg.ICAO_id, out_state.cfg.callsign);
-    out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = c;
-
-    // send now
-    out_state.last_config_ms = 0;
-}
-
-/*
- * populate and send MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG
- */
-void AP_ADSB::send_configure(const mavlink_channel_t chan)
-{
-    // MAVLink spec says the 9 byte callsign field is 8 byte string with 9th byte as null.
-    // Here we temporarily set some flags in that null char to signify the callsign
-    // may be a flightplanID instead
-    int8_t callsign[sizeof(out_state.cfg.callsign)];
-    uint32_t icao;
-
-    memcpy(callsign, out_state.cfg.callsign, sizeof(out_state.cfg.callsign));
-
-    if (out_state.cfg.was_set_externally) {
-        // take values as-is
-        icao = out_state.cfg.ICAO_id;
-    } else {
-        callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = (int8_t)get_encoded_callsign_null_char();
-        icao = get_encoded_icao();
-    }
-
-    mavlink_msg_uavionix_adsb_out_cfg_send(
-            chan,
-            icao,
-            (const char*)callsign,
-            (uint8_t)out_state.cfg.emitterType,
-            (uint8_t)out_state.cfg.lengthWidth,
-            (uint8_t)out_state.cfg.gpsLatOffset,
-            (uint8_t)out_state.cfg.gpsLonOffset,
-            out_state.cfg.stall_speed_cm,
-            (uint8_t)out_state.cfg.rfSelect);
-}
-
-/*
- * this is a message from the transceiver reporting it's health. Using this packet
- * we determine which channel is on so we don't have to send out_state to all channels
- */
-
-void AP_ADSB::handle_transceiver_report(const mavlink_channel_t chan, const mavlink_message_t &msg)
-{
-    mavlink_uavionix_adsb_transceiver_health_report_t packet {};
-    mavlink_msg_uavionix_adsb_transceiver_health_report_decode(&msg, &packet);
-
-    if (out_state.chan != chan) {
-        gcs().send_text(MAV_SEVERITY_DEBUG, "ADSB: Found transceiver on channel %d", chan);
-    }
-
-    out_state.chan_last_ms = AP_HAL::millis();
-    out_state.chan = chan;
-    out_state.status = (UAVIONIX_ADSB_RF_HEALTH)packet.rfHealth;
-}
 
 /*
  @brief Generates pseudorandom ICAO from gps time, lat, and lon.
@@ -836,6 +652,9 @@ uint32_t AP_ADSB::genICAO(const Location &loc)
 // assign a string to out_state.cfg.callsign but ensure it's null terminated
 void AP_ADSB::set_callsign(const char* str, const bool append_icao)
 {
+    if (out_state.cfg.was_set_externally) {
+        return;
+    }
     bool zero_char_pad = false;
 
     // clean slate
@@ -896,21 +715,60 @@ void AP_ADSB::handle_message(const mavlink_channel_t chan, const mavlink_message
     case MAVLINK_MSG_ID_ADSB_VEHICLE:
         handle_vehicle(msg);
         break;
-    case MAVLINK_MSG_ID_UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT:
-        handle_transceiver_report(chan, msg);
-        break;
-
-    case MAVLINK_MSG_ID_UAVIONIX_ADSB_OUT_CFG:
-        handle_out_cfg(msg);
-        break;
-
     case MAVLINK_MSG_ID_UAVIONIX_ADSB_OUT_DYNAMIC:
         // unhandled, this is an outbound packet only
+        break;
+
+    case MAVLINK_MSG_ID_UAVIONIX_ADSB_OUT_CFG: {
+            mavlink_uavionix_adsb_out_cfg_t packet {};
+            mavlink_msg_uavionix_adsb_out_cfg_decode(&msg, &packet);
+            handle_out_cfg(packet);
+        }
+        break;
+
+    case MAVLINK_MSG_ID_UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT:
     default:
+        if (backend != nullptr) {
+            backend->handle_msg(chan, msg);
+        }
         break;
     }
-
 }
+
+
+/*
+ * handle incoming packet UAVIONIX_ADSB_OUT_CFG.
+ * This allows a GCS to send cfg info through the autopilot to the ADSB hardware.
+ * This is done indirectly by reading and storing the packet and then another mechanism sends it out periodically
+ */
+void AP_ADSB::handle_out_cfg(const mavlink_uavionix_adsb_out_cfg_t &packet)
+{
+    out_state.cfg.was_set_externally = true;
+
+    out_state.cfg.ICAO_id = packet.ICAO;
+    out_state.cfg.ICAO_id_param = out_state.cfg.ICAO_id_param_prev = packet.ICAO & 0x00FFFFFFFF;
+
+    // May contain a non-null value at the end so accept it as-is with memcpy instead of strcpy
+    memcpy(out_state.cfg.callsign, packet.callsign, sizeof(out_state.cfg.callsign));
+
+    out_state.cfg.emitterType = packet.emitterType;
+    out_state.cfg.lengthWidth = packet.aircraftSize;
+    out_state.cfg.gpsLatOffset = packet.gpsOffsetLat;
+    out_state.cfg.gpsLonOffset = packet.gpsOffsetLon;
+    out_state.cfg.rfSelect = packet.rfSelect;
+    out_state.cfg.stall_speed_cm = packet.stallSpeed;
+
+    // guard against string with non-null end char
+    const char c = out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1];
+    out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = 0;
+    gcs().send_text(MAV_SEVERITY_INFO, "%sUsing ICAO_id %d and Callsign %s", GcsHeader, (int)out_state.cfg.ICAO_id, out_state.cfg.callsign);
+    out_state.cfg.callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = c;
+
+    // send now
+    out_state.last_config_ms = 0;
+}
+
+
 
 // If that ICAO is found in the database then return true with a fully populated vehicle
 bool AP_ADSB::get_vehicle_by_ICAO(const uint32_t icao, adsb_vehicle_t &vehicle) const

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -23,25 +23,39 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_Common/AP_Common.h>
-#include <AP_Param/AP_Param.h>
-#include <AP_Common/Location.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef HAL_ADSB_ENABLED
 #define HAL_ADSB_ENABLED !HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024
 #endif
 
 #if HAL_ADSB_ENABLED
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Common/Location.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+
+#define ADSB_BITBASK_RF_CAPABILITIES_UAT_IN         (1 << 0)
+#define ADSB_BITBASK_RF_CAPABILITIES_1090ES_IN      (1 << 1)
+
+class AP_ADSB_Backend;
 
 class AP_ADSB {
 public:
+    friend class AP_ADSB_Backend;
+
     // constructor
     AP_ADSB();
 
     /* Do not allow copies */
     AP_ADSB(const AP_ADSB &other) = delete;
     AP_ADSB &operator=(const AP_ADSB&) = delete;
+
+    // get singleton instance
+    static AP_ADSB *get_singleton(void) {
+        return _singleton;
+    }
+
+    const char* GcsHeader = "ADSB: ";
 
     struct adsb_vehicle_t {
         mavlink_adsb_vehicle_t info; // the whole mavlink struct with all the juicy details. sizeof() == 38
@@ -59,11 +73,16 @@ public:
     // send ADSB_VEHICLE mavlink message, usually as a StreamRate
     void send_adsb_vehicle(mavlink_channel_t chan);
 
-    void set_stall_speed_cm(const uint16_t stall_speed_cm) { out_state.cfg.stall_speed_cm = stall_speed_cm; }
+    void set_stall_speed_cm(const uint16_t stall_speed_cm) {
+        if (!out_state.cfg.was_set_externally) {
+            out_state.cfg.stall_speed_cm = MAX(0,stall_speed_cm);
+        }
+    }
+
     void set_max_speed(int16_t max_speed) {
         if (!out_state.cfg.was_set_externally) {
             // convert m/s to knots
-            out_state.cfg.maxAircraftSpeed_knots = (float)max_speed * 1.94384f;
+            out_state.cfg.maxAircraftSpeed_knots = (float)MAX(0,max_speed) * 1.94384f;
         }
     }
 
@@ -96,58 +115,6 @@ public:
     // confirm a value is a valid callsign
     static bool is_valid_callsign(uint16_t octal) WARN_IF_UNUSED;
 
-    // get singleton instance
-    static AP_ADSB *get_singleton(void) {
-        return _singleton;
-    }
-
-private:
-    static AP_ADSB *_singleton;
-
-    // initialize _vehicle_list
-    void init();
-
-    // free _vehicle_list
-    void deinit();
-
-    // compares current vector against vehicle_list to detect threats
-    void determine_furthest_aircraft(void);
-
-    // return index of given vehicle if ICAO_ADDRESS matches. return -1 if no match
-    bool find_index(const adsb_vehicle_t &vehicle, uint16_t *index) const;
-
-    // remove a vehicle from the list
-    void delete_vehicle(const uint16_t index);
-
-    void set_vehicle(const uint16_t index, const adsb_vehicle_t &vehicle);
-
-    // Generates pseudorandom ICAO from gps time, lat, and lon
-    uint32_t genICAO(const Location &loc);
-
-    // set callsign: 8char string (plus null termination) then optionally append last 4 digits of icao
-    void set_callsign(const char* str, const bool append_icao);
-
-    // send static and dynamic data to ADSB transceiver
-    void send_configure(const mavlink_channel_t chan);
-    void send_dynamic_out(const mavlink_channel_t chan);
-
-    // special helpers for uAvionix workarounds
-    uint32_t get_encoded_icao(void);
-    uint8_t get_encoded_callsign_null_char(void);
-
-    // add or update vehicle_list from inbound mavlink msg
-    void handle_vehicle(const mavlink_message_t &msg);
-
-    // handle ADS-B transceiver report for ping2020
-    void handle_transceiver_report(mavlink_channel_t chan, const mavlink_message_t &msg);
-
-    void handle_out_cfg(const mavlink_message_t &msg);
-
-    AP_Int8     _enabled;
-
-    Location  _my_loc;
-
-
     // ADSB-IN state. Maintains list of external vehicles
     struct {
         // list management
@@ -168,8 +135,6 @@ private:
     struct {
         uint32_t    last_config_ms; // send once every 10s
         uint32_t    last_report_ms; // send at 5Hz
-        int8_t      chan = -1; // channel that contains an ADS-b Transceiver. -1 means transceiver is not detected
-        uint32_t    chan_last_ms;
         UAVIONIX_ADSB_RF_HEALTH status;     // transceiver status
         bool        is_flying;
         bool        _is_in_auto_mode;
@@ -195,6 +160,43 @@ private:
 
     } out_state;
 
+    AP_Int8     _enabled;
+
+    Location     _my_loc;
+
+private:
+
+    static AP_ADSB *_singleton;
+
+    // initialize driver
+    void hw_init();
+
+    // free/load _vehicle_list
+    void list_init();
+    void list_deinit();
+
+    // compares current vector against vehicle_list to detect threats
+    void determine_furthest_aircraft(void);
+
+    // return index of given vehicle if ICAO_ADDRESS matches. return -1 if no match
+    bool find_index(const adsb_vehicle_t &vehicle, uint16_t *index) const;
+
+    // remove a vehicle from the list
+    void delete_vehicle(const uint16_t index);
+
+    void set_vehicle(const uint16_t index, const adsb_vehicle_t &vehicle);
+
+    // Generates pseudorandom ICAO from gps time, lat, and lon
+    uint32_t genICAO(const Location &loc);
+
+    // set callsign: 8char string (plus null termination) then optionally append last 4 digits of icao
+    void set_callsign(const char* str, const bool append_icao);
+
+    // add or update vehicle_list from inbound mavlink msg
+    void handle_vehicle(const mavlink_message_t &msg);
+
+    // configure ADSB-out transceivers
+    void handle_out_cfg(const mavlink_uavionix_adsb_out_cfg_t &packet);
 
     // index of and distance to furthest vehicle in list
     uint16_t    furthest_vehicle_index;
@@ -217,6 +219,9 @@ private:
         SPECIAL_ONLY    = 1,
         ALL             = 2
     };
+
+    // reference to backend
+    AP_ADSB_Backend *backend;
 
 
 };

--- a/libraries/AP_ADSB/AP_ADSB_Backend.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Backend.cpp
@@ -1,0 +1,26 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ADSB_Backend.h"
+
+/*
+  base class constructor.
+  This incorporates initialisation as well.
+*/
+AP_ADSB_Backend::AP_ADSB_Backend(AP_ADSB &_frontend) :
+    frontend(_frontend)
+{
+}
+

--- a/libraries/AP_ADSB/AP_ADSB_Backend.h
+++ b/libraries/AP_ADSB/AP_ADSB_Backend.h
@@ -1,0 +1,45 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "AP_ADSB.h"
+
+#if HAL_ADSB_ENABLED
+class AP_ADSB_Backend
+{
+public:
+    // constructor. This incorporates initialization as well.
+    AP_ADSB_Backend(AP_ADSB &_frontend);
+
+
+    virtual void init() = 0;
+
+    virtual void update() = 0;
+
+    // handle mavlink messages
+    virtual void handle_msg(const mavlink_channel_t chan, const mavlink_message_t &msg) {}
+protected:
+
+    // references
+    AP_ADSB &frontend;
+
+
+    // semaphore for access to shared frontend data
+    //HAL_Semaphore _sem;
+
+private:
+
+};
+#endif // HAL_ADSB_ENABLED

--- a/libraries/AP_ADSB/AP_ADSB_MAVLink.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_MAVLink.cpp
@@ -1,0 +1,278 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ADSB_MAVLink.h"
+
+#if HAL_ADSB_ENABLED
+#include <limits.h>
+#include <AP_Vehicle/AP_Vehicle.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
+#include <AP_GPS/AP_GPS.h>
+#include <AP_Baro/AP_Baro.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+extern const AP_HAL::HAL& hal;
+
+#define ADSB_CHAN_TIMEOUT_MS            15000
+
+// constructor
+AP_ADSB_MAVLink::AP_ADSB_MAVLink(AP_ADSB &adsb) :
+        AP_ADSB_Backend(adsb)
+{
+}
+
+void AP_ADSB_MAVLink::update()
+{
+    const uint32_t now_ms = AP_HAL::millis();
+
+    // send static configuration data to transceiver, every 5s
+    if (_chan_last_ms > 0 && now_ms - _chan_last_ms > ADSB_CHAN_TIMEOUT_MS) {
+        // haven't gotten a heartbeat health status packet in a while, assume hardware failure
+        // TODO: reset out_state.chan
+        _chan = -1;
+        gcs().send_text(MAV_SEVERITY_ERROR, "%sTransceiver heartbeat timed out", frontend.GcsHeader);
+    } else if (_chan >= 0 && _chan < MAVLINK_COMM_NUM_BUFFERS) {
+        if (now_ms - frontend.out_state.last_config_ms >= 5000 && HAVE_PAYLOAD_SPACE((mavlink_channel_t)_chan, UAVIONIX_ADSB_OUT_CFG)) {
+            frontend.out_state.last_config_ms = now_ms;
+            send_configure();
+        } // last_config_ms
+
+        // send dynamic data to transceiver at 5Hz
+        if (now_ms - frontend.out_state.last_report_ms >= 200 && HAVE_PAYLOAD_SPACE((mavlink_channel_t)_chan, UAVIONIX_ADSB_OUT_DYNAMIC)) {
+            frontend.out_state.last_report_ms = now_ms;
+            send_dynamic_out();
+        } // last_report_ms
+    } // chan_last_ms
+}
+
+
+void AP_ADSB_MAVLink::handle_msg(const mavlink_channel_t chan, const mavlink_message_t &msg) {
+    switch (msg.msgid) {
+    case MAVLINK_MSG_ID_UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT:
+        {
+            _chan = (int8_t)chan;
+            mavlink_uavionix_adsb_transceiver_health_report_t packet {};
+            mavlink_msg_uavionix_adsb_transceiver_health_report_decode(&msg, &packet);
+            handle_transceiver_report(packet);
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+/*
+ * this is a message from the transceiver reporting it's health. Using this packet
+ * we determine which channel is on so we don't have to send out_state to all channels
+ */
+
+void AP_ADSB_MAVLink::handle_transceiver_report(const mavlink_uavionix_adsb_transceiver_health_report_t &packet)
+{
+    _chan_last_ms = AP_HAL::millis();
+    frontend.out_state.status = (UAVIONIX_ADSB_RF_HEALTH)packet.rfHealth;
+}
+
+/*
+ * populate and send MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG
+ */
+void AP_ADSB_MAVLink::send_configure()
+{
+    // MAVLink spec says the 9 byte callsign field is 8 byte string with 9th byte as null.
+    // Here we temporarily set some flags in that null char to signify the callsign
+    // may be a flightplanID instead
+    int8_t callsign[sizeof(frontend.out_state.cfg.callsign)];
+    uint32_t icao;
+
+    memcpy(callsign, frontend.out_state.cfg.callsign, sizeof(frontend.out_state.cfg.callsign));
+
+    if (frontend.out_state.cfg.was_set_externally) {
+        // take values as-is
+        icao = frontend.out_state.cfg.ICAO_id;
+    } else {
+        callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN-1] = (int8_t)get_encoded_callsign_null_char();
+        icao = get_encoded_icao();
+    }
+
+    mavlink_msg_uavionix_adsb_out_cfg_send(
+            (mavlink_channel_t)_chan,
+            icao,
+            (const char*)callsign,
+            (uint8_t)frontend.out_state.cfg.emitterType,
+            (uint8_t)frontend.out_state.cfg.lengthWidth,
+            (uint8_t)frontend.out_state.cfg.gpsLatOffset,
+            (uint8_t)frontend.out_state.cfg.gpsLonOffset,
+            frontend.out_state.cfg.stall_speed_cm,
+            (uint8_t)frontend.out_state.cfg.rfSelect);
+}
+
+void AP_ADSB_MAVLink::send_dynamic_out()
+{
+    const AP_GPS &gps = AP::gps();
+    const Vector3f &gps_velocity = gps.velocity();
+
+    const int32_t latitude = frontend._my_loc.lat;
+    const int32_t longitude = frontend._my_loc.lng;
+    const int32_t altGNSS = frontend._my_loc.alt * 10; // convert cm to mm
+    const int16_t velVert = gps_velocity.z * 1E2; // convert m/s to cm/s
+    const int16_t nsVog = gps_velocity.x * 1E2; // convert m/s to cm/s
+    const int16_t ewVog = gps_velocity.y * 1E2; // convert m/s to cm/s
+    const uint8_t fixType = gps.status(); // this lines up perfectly with our enum
+    const uint8_t emStatus = 0; // TODO: implement this ENUM. no emergency = 0
+    const uint8_t numSats = gps.num_sats();
+    const uint16_t squawk = frontend.out_state.cfg.squawk_octal;
+
+    uint32_t accHoriz = UINT_MAX;
+    float accHoriz_f;
+    if (gps.horizontal_accuracy(accHoriz_f)) {
+        accHoriz = accHoriz_f * 1E3; // convert m to mm
+    }
+
+    uint16_t accVert = USHRT_MAX;
+    float accVert_f;
+    if (gps.vertical_accuracy(accVert_f)) {
+        accVert = accVert_f * 1E2; // convert m to cm
+    }
+
+    uint16_t accVel = USHRT_MAX;
+    float accVel_f;
+    if (gps.speed_accuracy(accVel_f)) {
+        accVel = accVel_f * 1E3; // convert m/s to mm/s
+    }
+
+    uint16_t state = 0;
+    if (frontend.out_state._is_in_auto_mode) {
+        state |= UAVIONIX_ADSB_OUT_DYNAMIC_STATE_AUTOPILOT_ENABLED;
+    }
+    if (!frontend.out_state.is_flying) {
+        state |= UAVIONIX_ADSB_OUT_DYNAMIC_STATE_ON_GROUND;
+    }
+
+    // TODO: confirm this sets utcTime correctly
+    const uint64_t gps_time = gps.time_epoch_usec();
+    const uint32_t utcTime = gps_time / 1000000ULL;
+
+    const AP_Baro &baro = AP::baro();
+    int32_t altPres = INT_MAX;
+    if (baro.healthy()) {
+        // Altitude difference between sea level pressure and current pressure. Result in millimeters
+        altPres = baro.get_altitude_difference(SSL_AIR_PRESSURE, baro.get_pressure()) * 1E3; // convert m to mm;
+    }
+
+    mavlink_msg_uavionix_adsb_out_dynamic_send(
+            (mavlink_channel_t)_chan,
+            utcTime,
+            latitude,
+            longitude,
+            altGNSS,
+            fixType,
+            numSats,
+            altPres,
+            accHoriz,
+            accVert,
+            accVel,
+            velVert,
+            nsVog,
+            ewVog,
+            emStatus,
+            state,
+            squawk);
+}
+
+/*
+ * To expand functionality in their HW, uAvionix has extended a few of the unused MAVLink bits to pack in more new features
+ * This function will override the usually-null ending char of the callsign. It always encodes the last byte [8], even if
+ * the callsign string is less than 9 chars and there are other zero-padded nulls.
+ */
+uint8_t AP_ADSB_MAVLink::get_encoded_callsign_null_char()
+{
+//  Encoding of the 8bit null char
+//  (LSB) - knots
+//  bit.1 - knots
+//  bit.2 - knots
+//  bit.3 - (unused)
+//  bit.4 - flag - ADSB_BITBASK_RF_CAPABILITIES_1090ES_IN
+//  bit.5 - flag - ADSB_BITBASK_RF_CAPABILITIES_UAT_IN
+//  bit.6 - flag - 0 = callsign is treated as callsign, 1 = callsign is treated as flightPlanID/Squawk
+//  (MSB) - (unused)
+
+    uint8_t encoded_null = 0;
+
+    if (frontend.out_state.cfg.maxAircraftSpeed_knots <= 0) {
+        // not set or unknown. no bits set
+    } else if (frontend.out_state.cfg.maxAircraftSpeed_knots <= 75) {
+        encoded_null |= 0x01;
+    } else if (frontend.out_state.cfg.maxAircraftSpeed_knots <= 150) {
+        encoded_null |= 0x02;
+    } else if (frontend.out_state.cfg.maxAircraftSpeed_knots <= 300) {
+        encoded_null |= 0x03;
+    } else if (frontend.out_state.cfg.maxAircraftSpeed_knots <= 600) {
+        encoded_null |= 0x04;
+    } else if (frontend.out_state.cfg.maxAircraftSpeed_knots <= 1200) {
+        encoded_null |= 0x05;
+    } else {
+        encoded_null |= 0x06;
+    }
+
+
+    if (frontend.out_state.cfg.rf_capable & ADSB_BITBASK_RF_CAPABILITIES_1090ES_IN) {
+        encoded_null |= 0x10;
+    }
+    if (frontend.out_state.cfg.rf_capable & ADSB_BITBASK_RF_CAPABILITIES_UAT_IN) {
+        encoded_null |= 0x20;
+    }
+
+
+    /*
+    If the user has an 8 digit flightPlanID assigned from a filed flight plan, this should be assigned to FlightPlanID, (assigned by remote app)
+    else if the user has an assigned squawk code from ATC this should be converted from 4 digit octal to 4 character alpha string and assigned to FlightPlanID,
+    else if a tail number is known it should be set to the tail number of the aircraft, (assigned by remote app)
+    else it should be left blank (all 0's)
+     */
+
+    // using the above logic, we must always assign the squawk. once we get configured
+    // externally then get_encoded_callsign_null_char() stops getting called
+    snprintf(frontend.out_state.cfg.callsign, 5, "%04d", unsigned(frontend.out_state.cfg.squawk_octal) & 0x1FFF);
+    memset(&frontend.out_state.cfg.callsign[4], 0, 5); // clear remaining 5 chars
+    encoded_null |= 0x40;
+
+    return encoded_null;
+}
+
+/*
+ * To expand functionality in their HW, uAvionix has extended a few of the unused MAVLink bits to pack in more new features
+ * This function will override the MSB byte of the 24bit ICAO address. To ensure an invalid >24bit ICAO is never broadcasted,
+ * this function is used to create the encoded verison without ever writing to the actual ICAO number. It's created on-demand
+ */
+uint32_t AP_ADSB_MAVLink::get_encoded_icao(void)
+{
+    // utilize the upper unused 8bits of the icao with special flags.
+    // This encoding is required for uAvionix devices that break the MAVLink spec.
+
+    // ensure the user assignable icao is 24 bits
+    uint32_t encoded_icao = (uint32_t)frontend.out_state.cfg.ICAO_id & 0x00FFFFFF;
+
+    encoded_icao &= ~0x20000000;    // useGnssAltitude should always be FALSE
+    encoded_icao |=  0x10000000;    // csidLogic       should always be TRUE
+
+    //SIL/SDA are special fields that should be set to 0 with only expert user adjustment
+    encoded_icao &= ~0x03000000;    // SDA should always be FALSE
+    encoded_icao &= ~0x0C000000;    // SIL should always be FALSE
+
+    return encoded_icao;
+}
+
+#endif // HAL_ADSB_ENABLED

--- a/libraries/AP_ADSB/AP_ADSB_MAVLink.h
+++ b/libraries/AP_ADSB/AP_ADSB_MAVLink.h
@@ -1,0 +1,48 @@
+#pragma once
+
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ADSB_Backend.h"
+
+#if HAL_ADSB_ENABLED
+class AP_ADSB_MAVLink : public AP_ADSB_Backend {
+public:
+    // constructor
+    AP_ADSB_MAVLink(AP_ADSB &adsb);
+
+    void init() override {}
+    void update() override;
+
+    void handle_msg(const mavlink_channel_t chan, const mavlink_message_t &msg) override;
+
+private:
+
+    // send static and dynamic data to ADSB transceiver
+    void send_configure();
+    void send_dynamic_out();
+
+    // mavlink handler
+    void handle_transceiver_report(const mavlink_uavionix_adsb_transceiver_health_report_t &packet);
+
+    // special helpers for uAvionix workarounds
+    uint32_t get_encoded_icao(void);
+    uint8_t get_encoded_callsign_null_char();
+
+    uint32_t            _chan_last_ms;
+    int8_t              _chan = -1;
+};
+#endif // HAL_ADSB_ENABLED
+

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
@@ -1,0 +1,746 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ADSB_Sagetech.h"
+
+#if HAL_ADSB_ENABLED
+#include <GCS_MAVLink/GCS.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_RTC/AP_RTC.h>
+#include <stdio.h>
+#include <time.h>
+#include <string.h>
+#include <AP_Math/bitwise.h>
+
+extern const AP_HAL::HAL& hal;
+
+#define SAGETECH_SCALER_LATLNG              (1.0f/2.145767E-5f)     //   180/(2^23)
+#define SAGETECH_SCALER_KNOTS_TO_CM         ((KNOTS_TO_M_PER_SEC/0.125f) * 100.0f)
+#define SAGETECH_SCALER_ALTITUDE            (1.0f/0.015625f)
+#define SAGETECH_SCALER_HEADING_CM          ((360.0f/256.0f) * 100.0f)
+
+#define SAGETECH_VALIDFLAG_LATLNG           (1<<0)
+#define SAGETECH_VALIDFLAG_ALTITUDE         (1<<1)
+#define SAGETECH_VALIDFLAG_VELOCITY         (1<<2)
+#define SAGETECH_VALIDFLAG_GND_SPEED        (1<<3)
+#define SAGETECH_VALIDFLAG_HEADING          (1<<4)
+#define SAGETECH_VALIDFLAG_V_RATE_GEO       (1<<5)
+#define SAGETECH_VALIDFLAG_V_RATE_BARO      (1<<6)
+#define SAGETECH_VALIDFLAG_EST_LATLNG       (1<<7)
+#define SAGETECH_VALIDFLAG_EST_VELOCITY     (1<<8)
+
+#define SAGETECH_ENFORCE_ACKS               0
+#define SAGETECH_DEBUG_ACK_TIMEOUTS         0
+#define SAGETECH_DEBUG_TX_ID_ONLY           0
+#define SAGETECH_DEBUG_TX_ID_PAYLOAD        0
+#define SAGETECH_DEBUG_TX_ALL_RAW           0
+#define SAGETECH_DEBUG_RX                   0
+#define SAGETECH_DEBUG_RX_ACK               0
+
+// constructor
+AP_ADSB_Sagetech::AP_ADSB_Sagetech(AP_ADSB &adsb) :
+        AP_ADSB_Backend(adsb)
+{
+    uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Sagetech, 0);
+    if (uart != nullptr) {
+        baudrate = AP::serialmanager().find_baudrate(AP_SerialManager::SerialProtocol_Sagetech, 0);
+        uart->begin(baudrate);
+
+        // no sagtech hardware have flow control pins exposed
+        uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
+    }
+}
+
+// detect if a sensor is connected by looking for a configured serial port
+bool AP_ADSB_Sagetech::detect()
+{
+    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Sagetech, 0) != nullptr;
+}
+
+void AP_ADSB_Sagetech::init()
+{
+    if (uart == nullptr) {
+        gcs().send_text(MAV_SEVERITY_DEBUG, "%sInit failed, check SERIALx_PROTOCOL cfg", frontend.GcsHeader);
+    }
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (uart != nullptr) {
+        gcs().send_text(MAV_SEVERITY_DEBUG, "%sUART Init successful", frontend.GcsHeader);
+    }
+#endif
+}
+
+void AP_ADSB_Sagetech::update()
+{
+    const uint32_t now_ms = AP_HAL::millis();
+
+    // -----------------------------
+    // read any available data on serial port
+    // -----------------------------
+    int32_t nbytes = 0;
+    if (uart != nullptr) {
+        nbytes = uart->available();
+    }
+    while (nbytes-- > 0) {
+        const uint8_t data = (uint8_t)uart->read();
+
+        switch (protocol) {
+        default:
+        case AP_ADSB_Sagetech::Protocol::NONE:
+            // parse all protocols until we find one that works
+            if (parse_byte_XP(data)) {
+                protocol = AP_ADSB_Sagetech::Protocol::XP;
+                parse_packet_XP(message_in_xp.packet);
+            }
+            if (parse_byte_MX(data)) {
+                protocol = AP_ADSB_Sagetech::Protocol::MX;
+                parse_packet_MX();
+            }
+            break;
+
+        case AP_ADSB_Sagetech::Protocol::XP:
+            if (parse_byte_XP(data)) {
+                parse_packet_XP(message_in_xp.packet);
+            }
+            break;
+
+        case AP_ADSB_Sagetech::Protocol::MX:
+            if (parse_byte_MX(data)) {
+                parse_packet_MX();
+            }
+            break;
+        }
+    }
+
+
+    // -----------------------------
+    // handle timers for generating data
+    // -----------------------------
+#if SAGETECH_ENFORCE_ACKS
+    if (last_packet_type_sent != MsgTypes_XP::INVALID) {
+        // we're expecting an ACK
+        if (now_ms - last_packet_send_ms >= 1000) {
+            response_timeout_count++;
+#if SAGETECH_DEBUG_ACK_TIMEOUTS
+            gcs().send_text(MAV_SEVERITY_DEBUG, "%sACK Timeout type=%u, cnt=%u", frontend.GcsHeader, (unsigned)last_packet_type_sent, (unsigned)response_timeout_count);
+#endif
+            // retry forever until we get an ACK
+            send_packet(last_packet_type_sent);
+        }
+    } else
+#endif
+    {
+
+        //if (!last_packet_initialize_ms) {
+        if (!last_packet_initialize_ms || (now_ms - last_packet_initialize_ms >= 5000)) {
+            last_packet_initialize_ms = now_ms;
+            send_packet(MsgTypes_XP::Installation_Set);
+
+
+        //} else if (last_packet_PreFlight_ms == 0) {
+        } else if (!last_packet_PreFlight_ms || (now_ms - last_packet_PreFlight_ms >= 8200)) {
+            // send once, for now..
+            last_packet_PreFlight_ms = now_ms;
+            // TODO: allow callsign to not require a reboot
+            send_packet(MsgTypes_XP::Preflight_Set);
+
+        } else if (now_ms - last_packet_Operating_ms >= 1000 && (
+                last_packet_Operating_ms == 0 || // send once at boot
+                // send as data changes
+                last_operating_squawk != frontend.out_state.cfg.squawk_octal ||
+                abs(last_operating_alt - frontend._my_loc.alt) > 1555 ||      // 1493cm == 49ft. The output resolution is 100ft per bit
+                last_operating_rf_select != frontend.out_state.cfg.rfSelect))
+        {
+            last_packet_Operating_ms = now_ms;
+            last_operating_squawk = frontend.out_state.cfg.squawk_octal;
+            last_operating_alt = frontend._my_loc.alt;
+            last_operating_rf_select = frontend.out_state.cfg.rfSelect;
+            send_packet(MsgTypes_XP::Operating_Set);
+
+        } else if (now_ms - last_packet_GPS_ms >= (frontend.out_state.is_flying ? 200 : 1000)) {
+            // 1Hz when not flying, 5Hz when flying
+            last_packet_GPS_ms = now_ms;
+            send_packet(MsgTypes_XP::GPS_Set);
+        }
+    }
+}
+
+void AP_ADSB_Sagetech::send_packet(const MsgTypes_XP type)
+{
+    switch (type) {
+    case MsgTypes_XP::Installation_Set:
+        send_Installation();
+        break;
+    case MsgTypes_XP::Preflight_Set:
+        send_PreFlight();
+        break;
+    case MsgTypes_XP::Operating_Set:
+        send_Operating();
+        break;
+    case MsgTypes_XP::GPS_Set:
+        send_GPS();
+        break;
+    default:
+        break;
+    }
+}
+
+void AP_ADSB_Sagetech::request_packet(const MsgTypes_XP type)
+{
+    Packet_XP pkt {};
+
+    pkt.type = MsgTypes_XP::Request;
+    pkt.id = 0;
+    pkt.payload_length = 4;
+
+    pkt.payload[0] = static_cast<uint8_t>(type);
+
+    send_msg(pkt);
+}
+
+
+void AP_ADSB_Sagetech::parse_packet_XP(const Packet_XP &msg)
+{
+#if SAGETECH_DEBUG_RX
+    gcs().send_text(MAV_SEVERITY_DEBUG, "%sRX type=%u, id=%d", frontend.GcsHeader, (unsigned)msg.type, msg.id);
+#endif
+
+    switch (msg.type) {
+    case MsgTypes_XP::ACK: {
+        // ACK received!
+        const uint8_t system_state = msg.payload[2];
+        transponder_type = (Transponder_Type)msg.payload[6];
+
+        const char* rfmode = "RF mode: ";
+        const uint8_t prev_transponder_mode = last_ack_transponder_mode;
+        last_ack_transponder_mode = (system_state >> 6) & 0x03;
+        if (prev_transponder_mode != last_ack_transponder_mode) {
+            switch (last_ack_transponder_mode) {
+            case 0: gcs().send_text(MAV_SEVERITY_INFO, "%s%sOFF",   frontend.GcsHeader, rfmode); break;
+            case 1: gcs().send_text(MAV_SEVERITY_INFO, "%s%sSTBY",  frontend.GcsHeader, rfmode); break;
+            case 2: gcs().send_text(MAV_SEVERITY_INFO, "%s%sON",    frontend.GcsHeader, rfmode); break;
+            case 3: gcs().send_text(MAV_SEVERITY_INFO, "%s%sON-ALT",frontend.GcsHeader, rfmode); break;
+            default:  break;
+            }
+        }
+
+#if SAGETECH_DEBUG_RX_ACK
+        const uint8_t acked_type = msg.payload[0];
+        const uint8_t acked_id = msg.payload[1];
+        const int32_t pres_altitude = (int32_t)fetchU32(&msg.payload[3]);
+        const uint16_t squawk = fetchU16(&msg.payload[7]);
+
+        gcs().send_text(MAV_SEVERITY_DEBUG, "%sACK %u, %u, 0x%02X, %d, %u, %u %u", frontend.GcsHeader,
+                acked_type,
+                acked_id,
+                system_state,
+                pres_altitude,
+                transponder_type,
+                squawk,
+                last_ack_transponder_mode); // mode
+
+        for (uint8_t i=0; i<6; i++) {
+            const uint8_t stateBits = (system_state & (1<< i));
+            if (stateBits != 0 && stateBits != SystemStateBits::Altitidue_Source) {
+                gcs().send_text(MAV_SEVERITY_DEBUG, "%sACK status: %s", frontend.GcsHeader, systemStatsBits_to_str((SystemStateBits)stateBits));
+            }
+        }
+#endif
+        }
+        break;
+
+    case MsgTypes_XP::Installatioin_Response:
+    case MsgTypes_XP::Preflight_Response:
+    case MsgTypes_XP::Status_Response:
+        // TODO add support for these
+        break;
+
+    case MsgTypes_XP::ADSB_StateVector_Report:
+    case MsgTypes_XP::ADSB_ModeStatus_Report:
+    case MsgTypes_XP::TISB_StateVector_Report:
+    case MsgTypes_XP::TISB_ModeStatus_Report:
+    case MsgTypes_XP::TISB_CorasePos_Report:
+    case MsgTypes_XP::TISB_ADSB_Mgr_Report:
+        handle_adsb_in_msg(msg);
+        break;
+
+    case MsgTypes_XP::Installation_Set:
+    case MsgTypes_XP::Preflight_Set:
+    case MsgTypes_XP::Operating_Set:
+    case MsgTypes_XP::GPS_Set:
+    case MsgTypes_XP::Request:
+        // these are out-bound only and are not expected to be received
+        FALLTHROUGH;
+
+    default:
+        last_packet_type_sent = INVALID;
+        break;
+
+    }
+}
+
+void AP_ADSB_Sagetech::handle_adsb_in_msg(const Packet_XP &msg)
+{
+    AP_ADSB::adsb_vehicle_t vehicle {};
+    const uint32_t now = AP_HAL::millis();
+
+    vehicle.last_update_ms = now;
+    uint16_t validFlags;
+
+    switch (msg.type) {
+    case MsgTypes_XP::ADSB_StateVector_Report:  // 0x91
+        validFlags = fetchU16(&msg.payload[8]);
+        vehicle.info.ICAO_address = fetchU24(&msg.payload[10]);
+
+        if (validFlags & SAGETECH_VALIDFLAG_LATLNG) {
+            vehicle.info.lat = ((int32_t)fetchU24(&msg.payload[20])) * SAGETECH_SCALER_LATLNG;
+            vehicle.info.lon = ((int32_t)fetchU24(&msg.payload[23])) * SAGETECH_SCALER_LATLNG;
+            vehicle.info.flags |= ADSB_FLAGS_VALID_COORDS;
+        }
+
+        if (validFlags & SAGETECH_VALIDFLAG_ALTITUDE) {
+            vehicle.info.altitude = (int32_t)fetchU24(&msg.payload[26]);
+            vehicle.info.flags |= ADSB_FLAGS_VALID_ALTITUDE;
+        }
+
+        if (validFlags & SAGETECH_VALIDFLAG_VELOCITY) {
+            const float velNS = ((int32_t)fetchU16(&msg.payload[29])) * SAGETECH_SCALER_KNOTS_TO_CM;
+            const float velEW = ((int32_t)fetchU16(&msg.payload[31])) * SAGETECH_SCALER_KNOTS_TO_CM;
+            vehicle.info.hor_velocity = Vector2f(velEW, velNS).angle();
+            vehicle.info.flags |= ADSB_FLAGS_VALID_VELOCITY;
+        }
+
+        if (validFlags & SAGETECH_VALIDFLAG_HEADING) {
+            vehicle.info.heading = ((float)msg.payload[29]) * SAGETECH_SCALER_HEADING_CM;
+            vehicle.info.flags |= ADSB_FLAGS_VALID_HEADING;
+        }
+
+        if ((validFlags & SAGETECH_VALIDFLAG_V_RATE_GEO) || (validFlags & SAGETECH_VALIDFLAG_V_RATE_BARO)) {
+            vehicle.info.ver_velocity = (int16_t)fetchU16(&msg.payload[38]);
+            vehicle.info.flags |= ADSB_FLAGS_VERTICAL_VELOCITY_VALID;
+        }
+
+        if (vehicle.info.flags != 0) {
+            frontend.handle_adsb_vehicle(vehicle);
+        }
+        break;
+
+    case MsgTypes_XP::ADSB_ModeStatus_Report:   // 0x92
+        validFlags = msg.payload[8];
+        vehicle.info.ICAO_address = fetchU24(&msg.payload[9]);
+
+        if (msg.payload[16] != 0) {
+            // if string is non-null, consider it valid
+            memcpy(&vehicle.info, &msg.payload[16], 8);
+            vehicle.info.flags |= ADSB_FLAGS_VALID_CALLSIGN;
+        }
+
+        if (vehicle.info.flags != 0) {
+            frontend.handle_adsb_vehicle(vehicle);
+        }
+        break;
+
+    case MsgTypes_XP::TISB_StateVector_Report:
+    case MsgTypes_XP::TISB_ModeStatus_Report:
+    case MsgTypes_XP::TISB_CorasePos_Report:
+    case MsgTypes_XP::TISB_ADSB_Mgr_Report:
+        // TODO
+        return;
+
+    default:
+        return;
+    }
+
+}
+
+
+bool AP_ADSB_Sagetech::parse_byte_XP(const uint8_t data)
+{
+    switch (message_in_xp.state) {
+        default:
+        case ParseState::WaitingFor_Start:
+            if (data == 0xA5) {
+                message_in_xp.state = ParseState::WaitingFor_AssmAddr;
+            }
+            break;
+        case ParseState::WaitingFor_AssmAddr:
+            message_in_xp.state = (data == 0x01) ? ParseState::WaitingFor_MsgType : ParseState::WaitingFor_Start;
+            break;
+        case ParseState::WaitingFor_MsgType:
+            message_in_xp.packet.type = static_cast<MsgTypes_XP>(data);
+            message_in_xp.state = ParseState::WaitingFor_MsgId;
+            break;
+        case ParseState::WaitingFor_MsgId:
+            message_in_xp.packet.id = data;
+            message_in_xp.state = ParseState::WaitingFor_PayloadLen;
+            break;
+        case ParseState::WaitingFor_PayloadLen:
+            message_in_xp.packet.payload_length = data;
+            message_in_xp.index = 0;
+            message_in_xp.state = (data == 0) ? ParseState::WaitingFor_ChecksumFletcher : ParseState::WaitingFor_PayloadContents;
+            break;
+
+        case ParseState::WaitingFor_PayloadContents:
+            message_in_xp.packet.payload[message_in_xp.index++] = data;
+            if (message_in_xp.index >= message_in_xp.packet.payload_length) {
+                message_in_xp.state = ParseState::WaitingFor_ChecksumFletcher;
+                message_in_xp.index = 0;
+            }
+            break;
+
+        case ParseState::WaitingFor_ChecksumFletcher:
+            message_in_xp.packet.checksumFletcher = data;
+            message_in_xp.state = ParseState::WaitingFor_Checksum;
+            break;
+        case ParseState::WaitingFor_Checksum:
+            message_in_xp.packet.checksum = data;
+            message_in_xp.state = ParseState::WaitingFor_End;
+            if (checksum_XP(message_in_xp.packet)) {
+                parse_packet_XP(message_in_xp.packet);
+            }
+            break;
+
+        case ParseState::WaitingFor_End:
+            // we don't care if the end value matches
+            message_in_xp.state = ParseState::WaitingFor_Start;
+            break;
+    }
+    return false;
+}
+
+// compute Sum and FletcherSum and write them into msg.
+// returns true if the values in msg were already the correct ones
+//
+// this allows a single function to tell you if inbound msg is correct wirh true result, and ignore result for outbound
+bool AP_ADSB_Sagetech::checksum_XP(Packet_XP &msg)
+{
+    uint8_t sum = 0;
+    uint8_t sumFletcher = 0;
+
+    const uint8_t header_message_format[5] = {
+            0xA5,   // start
+            0x01,   // assembly address
+            static_cast<uint8_t>(msg.type),
+            msg.id,
+            msg.payload_length
+    };
+
+    for (uint8_t i=0; i<5; i++) {
+        sum += header_message_format[i];
+        sumFletcher += sum;
+    }
+    for (uint8_t i=0; i<msg.payload_length; i++) {
+        sum += msg.payload[i];
+        sumFletcher += sum;
+    }
+
+    // the calculated sums already match the values in the msg
+    if ((sum == msg.checksum) && (sumFletcher == msg.checksumFletcher)) {
+        return true;
+    }
+
+    msg.checksum = sum;
+    msg.checksumFletcher = sumFletcher;
+    return false;
+}
+
+
+void AP_ADSB_Sagetech::send_msg(Packet_XP &msg)
+{
+    // generate and populate checksums.
+    checksum_XP(msg);
+
+    const uint8_t message_format_header[5] = {
+            0xA5,   // start
+            0x01,   // assembly address
+            static_cast<uint8_t>(msg.type),
+            msg.id,
+            msg.payload_length
+    };
+    const uint8_t message_format_tail[3] = {
+            msg.checksumFletcher,
+            msg.checksum,
+            0x5A    // end
+    };
+
+    if (uart != nullptr) {
+        uart->write(message_format_header, sizeof(message_format_header));
+        uart->write(msg.payload, msg.payload_length);
+        uart->write(message_format_tail, sizeof(message_format_tail));
+    }
+
+    last_packet_type_sent = msg.type;
+    last_packet_send_ms = AP_HAL::millis();
+
+
+#if SAGETECH_DEBUG_TX_ALL_RAW
+    gcs().send_text(MAV_SEVERITY_DEBUG, "%s-------", frontend.GcsHeader);
+    for (uint8_t i=0; i<sizeof(message_format_header); i++) {
+        gcs().send_text(MAV_SEVERITY_DEBUG, "%shead[%2u] = 0x%02x", frontend.GcsHeader, i, message_format_header[i]);
+    }
+#endif
+#if SAGETECH_DEBUG_TX_ID_ONLY
+    gcs().send_text(MAV_SEVERITY_DEBUG, "%sTx type=%d %s", frontend.GcsHeader, static_cast<uint8_t>(msg.type), type_to_str(msg.type));
+#endif
+#if SAGETECH_DEBUG_TX_ID_PAYLOAD || SAGETECH_DEBUG_TX_ALL_RAW
+    #if SAGETECH_DEBUG_TX_ID_PAYLOAD
+    gcs().send_text(MAV_SEVERITY_DEBUG, "%sTx type=%u, payload.len=%u", frontend.GcsHeader, (unsigned)msg.type, (unsigned)msg.payload_length);
+    #endif
+    for (uint8_t i=0; i<msg.payload_length; i++) {
+        const uint8_t data = msg.payload[i];
+        if (isalnum(data) || data == '.' || data == '-' || data == ' ') {
+            gcs().send_text(MAV_SEVERITY_DEBUG, "%sdata[%2u] = 0x%02x  %c", frontend.GcsHeader, i, data, (char)data);
+        } else {
+            gcs().send_text(MAV_SEVERITY_DEBUG, "%sdata[%2u] = 0x%02x", frontend.GcsHeader, i, data);
+        }
+    }
+#endif
+
+#if SAGETECH_DEBUG_TX_ALL_RAW
+    for (uint8_t i=0; i<sizeof(message_format_tail); i++) {
+        gcs().send_text(MAV_SEVERITY_DEBUG, "%stail[%2u] = 0x%02x", frontend.GcsHeader, (unsigned)(i + sizeof(message_format_header) + msg.payload_length), message_format_tail[i]);
+    }
+#endif
+}
+
+
+
+
+
+void AP_ADSB_Sagetech::send_Installation()
+{
+    uint8_t adsb_in_vehicles_per_second = 0;
+    uint8_t baud_value = 0;
+
+    switch (baudrate) {
+    case 2400:
+        baud_value = 1;
+        adsb_in_vehicles_per_second = 0;
+        break;
+    case 4800:
+        baud_value = 2;
+        adsb_in_vehicles_per_second = 0;
+        break;
+    case 9600:
+        baud_value = 3;
+        adsb_in_vehicles_per_second = 5;
+        break;
+    case 19200:
+        baud_value = 4;
+        adsb_in_vehicles_per_second = 10;
+        break;
+    case 38:
+    case 38400:
+        baud_value = 5;
+        adsb_in_vehicles_per_second = 20;
+        break;
+    default:
+    case 57:
+    case 57600:
+        baud_value = 0;
+        adsb_in_vehicles_per_second = 30;
+        break;
+    case 115:
+    case 115000:
+    case 115200:
+        baud_value = 6;
+        adsb_in_vehicles_per_second = 60;
+        break;
+    case 230:
+    case 230000:
+    case 230400:
+        baud_value = 7;
+        adsb_in_vehicles_per_second = 100;
+        break;
+    case 460:
+    case 460000:
+    case 460800:
+        baud_value = 8;
+        adsb_in_vehicles_per_second = 100;
+        break;
+    }
+
+    Packet_XP pkt {};
+
+    pkt.type = MsgTypes_XP::Installation_Set;
+    pkt.payload_length = 28; // 28== 0x1C
+
+    // Mode C = 3, Mode S = 0
+    pkt.id = (transponder_type == Transponder_Type::Mode_C) ? 3 : 0;
+
+
+
+
+//    // convert a decimal 123456 to 0x123456
+    // TODO: do a proper conversion. The param contains "131313" but what gets transmitted over the air is 0x200F1.
+    const uint32_t icao_hex = convertMathBase(16, 10, frontend.out_state.cfg.ICAO_id_param);
+    loadUint(&pkt.payload[0], icao_hex, 24);
+
+    memcpy(&pkt.payload[3], &frontend.out_state.cfg.callsign, 8);
+
+    pkt.payload[11] = 0;   // airspeed MAX
+
+    pkt.payload[12] = baud_value;   // COM Port 0 baud
+    pkt.payload[13] = 0;            // COM Port 1 baud, fixed at 57600
+    pkt.payload[14] = 0;            // COM Port 2 baud, fixed at 57600
+
+    pkt.payload[15] = 1;   // GPS from COM port 0 (this port)
+    pkt.payload[16] = 1;   // GPS Integrity
+
+    pkt.payload[17] = frontend.out_state.cfg.emitterType / 8;   // Emitter Set
+    pkt.payload[18] = frontend.out_state.cfg.emitterType & 0x0F;   // Emitter Type
+
+    pkt.payload[19] = frontend.out_state.cfg.lengthWidth;   // Aircraft Size
+
+    pkt.payload[20] = 0;   // Altitude Encoder Offset
+    pkt.payload[21] = 0;   // Altitude Encoder Offset
+
+    pkt.payload[22] = 0x07;   // ADSB In Control, enable reading everything
+    pkt.payload[23] = adsb_in_vehicles_per_second; // ADSB In Report max length COM Port 0 (this one)
+    pkt.payload[24] = 0;   // ADSB In Report max length COM Port 1
+
+    send_msg(pkt);
+}
+
+void AP_ADSB_Sagetech::send_PreFlight()
+{
+    Packet_XP pkt {};
+
+    pkt.type = MsgTypes_XP::Preflight_Set;
+    pkt.id = 0;
+    pkt.payload_length = 10;
+
+    memcpy(&pkt.payload[0], &frontend.out_state.cfg.callsign, 8);
+
+    memset(&pkt.payload[8], 0, 2);
+
+    send_msg(pkt);
+}
+
+void AP_ADSB_Sagetech::send_Operating()
+{
+    Packet_XP pkt {};
+
+    pkt.type = MsgTypes_XP::Operating_Set;
+    pkt.id = 0;
+    pkt.payload_length = 8;
+
+    // squawk
+    // param is saved as native octal so we need convert back to
+    // decimal because Sagetech will convert it back to octal
+    uint16_t squawk = convertMathBase(8, 10, last_operating_squawk);
+    loadUint(&pkt.payload[0], squawk, 16);
+
+    // altitude
+    if (frontend.out_state.cfg.rf_capable & 0x01) {
+        const float alt_meters = last_operating_alt * 0.01f;
+        const int32_t alt_feet = (int32_t)(alt_meters * FEET_TO_METERS);
+        const int16_t alt_feet_adj = (alt_feet + 50) / 100; // 1 = 100 feet, 1 = 149 feet, 5 = 500 feet
+        loadUint(&pkt.payload[2], alt_feet_adj, 16);
+
+    } else {
+        // use integrated altitude - recommend by sagetech
+        pkt.payload[2] = 0x80;
+        pkt.payload[3] = 0x00;
+    }
+
+
+    // RF mode
+    pkt.payload[4] = last_operating_rf_select;
+
+    send_msg(pkt);
+}
+
+void AP_ADSB_Sagetech::send_GPS()
+{
+    Packet_XP pkt {};
+
+    pkt.type = MsgTypes_XP::GPS_Set;
+    pkt.payload_length = 52;
+    pkt.id = 0;
+
+    const int32_t longitude = frontend._my_loc.lng;
+    const int32_t latitude =  frontend._my_loc.lat;
+
+    // longitude and latitude
+    // NOTE: these MUST be done in double or else we get roundoff in the maths
+    const double lon_deg = longitude * (double)1.0e-7 * (longitude < 0 ? -1 : 1);
+    const double lon_minutes = (lon_deg - int(lon_deg)) * 60;
+    snprintf((char*)&pkt.payload[0], 12, "%03u%02u.%05u", (unsigned)lon_deg, (unsigned)lon_minutes, unsigned((lon_minutes - (int)lon_minutes) * 1.0E5));
+
+    const double lat_deg = latitude * (double)1.0e-7 * (latitude < 0 ? -1 : 1);
+    const double lat_minutes = (lat_deg - int(lat_deg)) * 60;
+    snprintf((char*)&pkt.payload[11], 11, "%02u%02u.%05u", (unsigned)lat_deg, (unsigned)lat_minutes, unsigned((lat_minutes - (int)lat_minutes) * 1.0E5));
+
+    // ground speed
+    const Vector2f speed = AP::ahrs().groundspeed_vector();
+    float speed_knots = norm(speed.x, speed.y) * M_PER_SEC_TO_KNOTS;
+    snprintf((char*)&pkt.payload[21], 7, "%03u.%02u", (unsigned)speed_knots, unsigned((speed_knots - (int)speed_knots) * 1.0E2));
+
+    // heading
+    //float heading = wrap_360(degrees(atan2f(speed.x, speed.y)));
+    float heading = wrap_360(degrees(speed.angle()));
+    snprintf((char*)&pkt.payload[27], 10, "%03u.%04u", unsigned(heading), unsigned((heading - (int)heading) * 1.0E4));
+
+    // hemisphere
+    uint8_t hemisphere = 0;
+    hemisphere |= (latitude >= 0) ? 0x01 : 0;   // isNorth
+    hemisphere |= (longitude >= 0) ? 0x02 : 0;  // isEast
+    hemisphere |= (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) ? 0x80 : 0;  // isInvalid
+    pkt.payload[35] = hemisphere;
+
+    // time
+    uint64_t time_usec;
+    if (!AP::rtc().get_utc_usec(time_usec)) {
+        memset(&pkt.payload[36],' ', 10);
+    } else {
+        // not completely accurate, our time includes leap seconds and time_t should be without
+        const time_t time_sec = time_usec / 1000000;
+        struct tm* tm = gmtime(&time_sec);
+
+        // format time string
+        snprintf((char*)&pkt.payload[36], 11, "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
+
+    }
+
+    send_msg(pkt);
+}
+
+const char* AP_ADSB_Sagetech::type_to_str(const uint8_t type)
+{
+    switch (type) {
+    case 0x01: return "Install";
+    case 0x02: return "PreFlight";
+    case 0x03: return "Operate";
+    case 0x04: return "GPS Data";
+    case 0x05: return "DataReq";
+    default:   return "Unknown";
+    }
+}
+
+const char* AP_ADSB_Sagetech::systemStatsBits_to_str(const SystemStateBits systemStateBits)
+{
+    switch (systemStateBits) {
+    case SystemStateBits::Error_Transponder: return "Error_Transponder";
+    case SystemStateBits::Altitidue_Source: return "Altitidue_Source";
+    case SystemStateBits::Error_GPS: return "Error_GPS";
+    case SystemStateBits::Error_ICAO: return "Error_ICAO";
+    case SystemStateBits::Error_Over_Temperature: return "Error_Over_Temperature";
+    case SystemStateBits::Error_Extended_Squitter: return "Error_Extended_Squitter";
+    default: return "Unknown";
+    }
+}
+
+#endif // HAL_ADSB_ENABLED

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.h
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.h
@@ -1,0 +1,152 @@
+#pragma once
+
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ADSB_Backend.h"
+
+#if HAL_ADSB_ENABLED
+
+class AP_ADSB_Sagetech : public AP_ADSB_Backend {
+public:
+    // constructor
+    AP_ADSB_Sagetech(AP_ADSB &adsb);
+
+    void init() override;
+    void update() override;
+
+    // static detection function
+    static bool detect();
+
+private:
+
+    static const uint8_t PAYLOAD_XP_MAX_SIZE  = 52;
+    //static const uint8_t PAYLOAD_MX_MAX_SIZE  = 250;
+
+    enum SystemStateBits {
+        Error_Transponder       = (1<<0),
+        Altitidue_Source        = (1<<1),
+        Error_GPS               = (1<<2),
+        Error_ICAO              = (1<<3),
+        Error_Over_Temperature  = (1<<4),
+        Error_Extended_Squitter = (1<<5),
+        Mode_Transponder        = (3<<6),   // 2 bit status:
+    };
+
+    enum Transponder_Type {
+        Mode_C                  = 0x00,
+        Mode_S_ADSB_OUT         = 0x01,
+        Mode_S_ADSB_OUT_and_IN  = 0x02,
+        Unknown                 = 0xFF,
+    };
+
+    enum MsgTypes_XP {
+        INVALID                 = 0,
+        Installation_Set        = 0x01,
+        Preflight_Set           = 0x02,
+        Operating_Set           = 0x03,
+        GPS_Set                 = 0x04,
+        Request                 = 0x05,
+
+        ACK                     = 0x80,
+        Installatioin_Response  = 0x81,
+        Preflight_Response      = 0x82,
+        Status_Response         = 0x83,
+        ADSB_StateVector_Report = 0x91,
+        ADSB_ModeStatus_Report  = 0x92,
+        TISB_StateVector_Report = 0x93,
+        TISB_ModeStatus_Report  = 0x94,
+        TISB_CorasePos_Report   = 0x95,
+        TISB_ADSB_Mgr_Report    = 0x96,
+    };
+
+    enum Protocol {
+        NONE        = 0,
+        XP          = 1,
+        MX          = 2,
+    } protocol;
+
+    enum ParseState {
+        WaitingFor_Start,
+        WaitingFor_AssmAddr,
+        WaitingFor_MsgType,
+        WaitingFor_MsgId,
+        WaitingFor_PayloadLen,
+        WaitingFor_PayloadContents,
+        WaitingFor_ChecksumFletcher,
+        WaitingFor_Checksum,
+        WaitingFor_End,
+    };
+
+    struct Packet_XP {
+        const uint8_t   start = 0xA5;
+        const uint8_t   assemAddr = 0x01;
+        MsgTypes_XP  type;
+        uint8_t         id;
+        uint8_t         payload_length;
+        uint8_t         payload[PAYLOAD_XP_MAX_SIZE];
+        uint8_t         checksumFletcher;
+        uint8_t         checksum;
+        const uint8_t   end = 0x5A;
+    };
+
+    struct {
+        ParseState      state;
+        uint8_t         index;
+        Packet_XP       packet;
+    } message_in_xp;
+
+    // protocol XP
+    bool checksum_XP(Packet_XP &msg);
+    bool parse_byte_XP(const uint8_t data);
+    void parse_packet_XP(const Packet_XP &msg);
+    void send_msg(Packet_XP &msg);
+
+    // protocol MX
+    bool parse_byte_MX(const uint8_t data) { return false; }
+    void parse_packet_MX() {}
+
+
+    void handle_adsb_in_msg(const Packet_XP &msg);
+
+    void send_Installation();
+    void send_PreFlight();
+    void send_Operating();
+    void send_GPS();
+
+    void send_packet(const MsgTypes_XP type);
+    void request_packet(const MsgTypes_XP type);
+
+    const char* type_to_str(const uint8_t type);
+    const char* systemStatsBits_to_str(const SystemStateBits systemStateBits);
+
+    AP_HAL::UARTDriver *uart;
+    uint32_t        last_packet_initialize_ms;
+    uint32_t        last_packet_PreFlight_ms;
+    uint32_t        last_packet_GPS_ms;
+    uint32_t        last_packet_send_ms;
+    MsgTypes_XP     last_packet_type_sent = MsgTypes_XP::INVALID;
+    uint32_t        baudrate;
+
+    uint32_t        last_packet_Operating_ms;
+    uint16_t        last_operating_squawk;
+    int32_t         last_operating_alt;
+    uint8_t         last_operating_rf_select;
+    uint8_t         last_ack_transponder_mode;
+
+    Transponder_Type transponder_type = Transponder_Type::Unknown;
+};
+
+#endif // HAL_ADSB_ENABLED

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -128,6 +128,23 @@ float throttle_curve(float thr_mid, float alpha, float thr_in)
     return thr_out;
 }
 
+/*
+ * Convert any base number to any base number. Example octal(8) to decimal(10)
+ * baseIn: base of input number
+ * baseOut: base of output number
+ * inputNumber: value currently in base "baseIn" to be converted to base "baseOut"
+ */
+uint32_t convertMathBase(const uint8_t baseIn, const uint8_t baseOut, uint32_t inputNumber)
+{
+    uint32_t outputNumber = 0;
+
+    for (uint8_t i=0; inputNumber != 0; i++) {
+        outputNumber += (inputNumber % baseOut) * powf(float(baseIn), i);
+        inputNumber /= baseOut;
+    }
+    return outputNumber;
+}
+
 template <typename T>
 T wrap_180(const T angle)
 {

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -265,6 +265,9 @@ constexpr float expo_curve(float alpha, float input);
  */
 float throttle_curve(float thr_mid, float alpha, float thr_in);
 
+// Convert any base number to any base number. Example octal(8) to decimal(10)
+uint32_t convertMathBase(const uint8_t baseIn, const uint8_t baseOut, uint32_t inputNumber);
+
 /* simple 16 bit random number generator */
 uint16_t get_random16(void);
 

--- a/libraries/AP_Math/bitwise.cpp
+++ b/libraries/AP_Math/bitwise.cpp
@@ -1,0 +1,59 @@
+/*
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+  collection of bitwise and array-wise operations.
+ */
+
+
+#include "bitwise.h"
+
+void loadUint(uint8_t *b, uint16_t v, uint8_t bitCount, bool MSBfirst)
+{
+    const uint8_t last = bitCount/8;
+
+//    count = 32
+//    last = 4
+//    MSBfirst = 1;
+
+    for (uint8_t i=0; i<last; i++) {
+        const uint8_t idx = MSBfirst ? last-1-i : i;
+//        idx = 4-1-0
+        b[i] = v >> (8*idx);
+    }
+}
+
+uint16_t fetchU16(const uint8_t *v, bool MSBfirst)
+{
+    if (MSBfirst) {
+        return v[1] | (v[0]<<8);
+    }
+    return v[0] | (v[1]<<8);
+}
+
+uint32_t fetchU24(const uint8_t *v, bool MSBfirst)
+{
+    if (MSBfirst) {
+        return v[2] | (v[1]<<8) | (v[0]<<16);
+    }
+    return v[0] | (v[1]<<8) | (v[2]<<16);
+}
+
+uint32_t fetchU32(const uint8_t *v, bool MSBfirst)
+{
+    if (MSBfirst) {
+        return v[3] | (v[2]<<8) | (v[1]<<16) | (v[0]<<24);
+    }
+    return v[0] | (v[1]<<8) | (v[2]<<16) | (v[3]<<24);
+}

--- a/libraries/AP_Math/bitwise.cpp
+++ b/libraries/AP_Math/bitwise.cpp
@@ -19,17 +19,11 @@
 
 #include "bitwise.h"
 
-void loadUint(uint8_t *b, uint16_t v, uint8_t bitCount, bool MSBfirst)
+void loadUint(uint8_t *b, uint32_t v, uint8_t bitCount, bool MSBfirst)
 {
     const uint8_t last = bitCount/8;
-
-//    count = 32
-//    last = 4
-//    MSBfirst = 1;
-
     for (uint8_t i=0; i<last; i++) {
         const uint8_t idx = MSBfirst ? last-1-i : i;
-//        idx = 4-1-0
         b[i] = v >> (8*idx);
     }
 }

--- a/libraries/AP_Math/bitwise.h
+++ b/libraries/AP_Math/bitwise.h
@@ -1,0 +1,31 @@
+/*
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+  interfaces to ArduPilot collection of bitwise and arraywise operations
+ */
+#pragma once
+
+#include <stdint.h>
+
+void loadUint(uint8_t *b, uint16_t v, uint8_t bitCount, bool MSBfirst = true);
+
+//void loadU16(uint8_t *b, uint16_t v, bool MSBfirst = true) { loadUx(b, v, 16, MSBfirst); }
+//void loadU24(uint8_t *b, uint32_t v, bool MSBfirst = true) { loadUx(b, v, 24, MSBfirst); }
+//void loadU32(uint8_t *b, uint32_t v, bool MSBfirst = true) { loadUx(b, v, 32, MSBfirst); }
+uint16_t fetchU16(const uint8_t *v, bool MSBfirst = true);
+uint32_t fetchU24(const uint8_t *v, bool MSBfirst = true);
+uint32_t fetchU32(const uint8_t *v, bool MSBfirst = true);
+
+

--- a/libraries/AP_Math/bitwise.h
+++ b/libraries/AP_Math/bitwise.h
@@ -19,11 +19,8 @@
 
 #include <stdint.h>
 
-void loadUint(uint8_t *b, uint16_t v, uint8_t bitCount, bool MSBfirst = true);
+void loadUint(uint8_t *b, uint32_t v, uint8_t bitCount, bool MSBfirst = true);
 
-//void loadU16(uint8_t *b, uint16_t v, bool MSBfirst = true) { loadUx(b, v, 16, MSBfirst); }
-//void loadU24(uint8_t *b, uint32_t v, bool MSBfirst = true) { loadUx(b, v, 24, MSBfirst); }
-//void loadU32(uint8_t *b, uint32_t v, bool MSBfirst = true) { loadUx(b, v, 32, MSBfirst); }
 uint16_t fetchU16(const uint8_t *v, bool MSBfirst = true);
 uint32_t fetchU24(const uint8_t *v, bool MSBfirst = true);
 uint32_t fetchU32(const uint8_t *v, bool MSBfirst = true);

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -92,7 +92,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:Sagetech
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink2),
@@ -109,7 +109,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:Sagetech
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SERIAL2_PROTOCOL),
@@ -126,7 +126,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:Sagetech
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SERIAL3_PROTOCOL),
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:Sagetech
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SERIAL4_PROTOCOL),
@@ -160,7 +160,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:Sagetech
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
@@ -179,7 +179,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 6_PROTOCOL
     // @DisplayName: Serial6 protocol selection
     // @Description: Control what protocol Serial6 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:Sagetech
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("6_PROTOCOL",  12, AP_SerialManager, state[6].protocol, SERIAL6_PROTOCOL),
@@ -278,7 +278,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 7_PROTOCOL
     // @DisplayName: Serial7 protocol selection
     // @Description: Control what protocol Serial7 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:Sagetech
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("7_PROTOCOL",  23, AP_SerialManager, state[7].protocol, SERIAL7_PROTOCOL),
@@ -461,6 +461,12 @@ void AP_SerialManager::init()
                                          AP_SERIALMANAGER_ROBOTIS_BUFSIZE_TX);
                     state[i].uart->set_unbuffered_writes(true);
                     state[i].uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
+                    break;
+
+                case SerialProtocol_Sagetech:
+                    state[i].uart->begin(state[i].baud,
+                                         AP_SERIALMANAGER_SAGETECH_BUFSIZE_RX,
+                                         AP_SERIALMANAGER_SAGETECH_BUFSIZE_TX);
                     break;
 
                 case SerialProtocol_SLCAN:

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -84,6 +84,9 @@
 #define AP_SERIALMANAGER_ROBOTIS_BUFSIZE_RX  128
 #define AP_SERIALMANAGER_ROBOTIS_BUFSIZE_TX  128
 
+#define AP_SERIALMANAGER_SAGETECH_BUFSIZE_RX    128
+#define AP_SERIALMANAGER_SAGETECH_BUFSIZE_TX    128
+
 // MegaSquirt EFI protocol
 #define AP_SERIALMANAGER_EFI_MS_BAUD           115
 #define AP_SERIALMANAGER_EFI_MS_BUFSIZE_RX     512
@@ -147,6 +150,7 @@ public:
         SerialProtocol_Winch = 31,
         SerialProtocol_MSP = 32,
         SerialProtocol_DJI_FPV = 33,
+        SerialProtocol_Sagetech = 34,
         SerialProtocol_NumProtocols                    // must be the last value
     };
 


### PR DESCRIPTION
This adds a driver for the Sagetech ADSB transceiver. The ADSB wiki page is getting a little out of date so I plan to update that as well.

- Created ADSB_Backend
- abstracted MAVink specific handling into it's own AP_ADSB_MAVLink driver for existing MAVLink hardware (uAvionix)
- Added Sagetech driver for the XP protocol. There is an MX protocol for newer products that is also available but not yet implemented.
- adds math library of byte parsing to load arrays
- adds math library to convert math bases (example: dec 12345 to 0x12345)

This backend split is needed because there is already a Sagetech MX protocol and uAvionix GDL90/UCP protocol in the pipeline.

This is a re-do of PR https://github.com/ArduPilot/ardupilot/pull/15123