### PR TITLE
AC_Fence: Allows manual recovery time to be set

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -78,6 +78,13 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @User: Standard
     AP_GROUPINFO_FRAME("ALT_MIN",     7,  AC_Fence,   _alt_min,       AC_FENCE_ALT_MIN_DEFAULT, AP_PARAM_FRAME_SUB),
 
+    // @Param: RECO_TIME
+    // @DisplayName: manual recovery time
+    // @Description: manual recovery time
+    // @Range: 0 10000
+    // @User: Standard
+    AP_GROUPINFO("RECO_TIME",   8,  AC_Fence,   _reco_time, AC_FENCE_MANUAL_RECOVERY_TIME_MIN),
+
     AP_GROUPEND
 };
 
@@ -338,8 +345,8 @@ uint8_t AC_Fence::check()
 
     // check if pilot is attempting to recover manually
     if (_manual_recovery_start_ms != 0) {
-        // we ignore any fence breaches during the manual recovery period which is about 10 seconds
-        if ((AP_HAL::millis() - _manual_recovery_start_ms) < AC_FENCE_MANUAL_RECOVERY_TIME_MIN) {
+        // we ignore any fence breaches during the manual recovery period which is about 10(default) seconds
+        if ((AP_HAL::millis() - _manual_recovery_start_ms) < uint32_t(_reco_time)) {
             return 0;
         }
         // recovery period has passed so reset manual recovery time

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -150,6 +150,7 @@ private:
     AP_Float        _circle_radius;         // circle fence radius in meters
     AP_Float        _margin;                // distance in meters that autopilot's should maintain from the fence to avoid a breach
     AP_Int8         _total;                 // number of polygon points saved in eeprom
+    AP_Int16        _reco_time;             // manual recovery time
 
     // backup fences
     float           _alt_max_backup;        // backup altitude upper limit in meters used to refire the breach if the vehicle continues to move further away


### PR DESCRIPTION
I want the manual recovery time to be configurable.
I don't know what background 10 seconds was decided on.
I know there are more experienced operators and less experienced operators.
I think it would be better to be able to change, depending on the experience of the operator.
I know someone who flies the ArduPilot with only the config parameters set.
I think the grace time varies from country to country.
I live in Japan.
Most Japanese use the number 3 a lot.
In Japan, we have a phrase "the 3 second rule".