### PR TITLE
AP_Scripting: add binding for ahrs::get_variances

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -556,8 +556,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     // check EKF compass variance is below failsafe threshold
     float vel_variance, pos_variance, hgt_variance, tas_variance;
     Vector3f mag_variance;
-    Vector2f offset;
-    ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance, offset);
+    ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance);
     if (copter.g.fs_ekf_thresh > 0 && mag_variance.length() >= copter.g.fs_ekf_thresh) {
         check_failed(display_failure, "EKF compass variance");
         return false;

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -108,8 +108,7 @@ bool Copter::ekf_over_threshold()
     // use EKF to get variance
     float position_variance, vel_variance, height_variance, tas_variance;
     Vector3f mag_variance;
-    Vector2f offset;
-    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance, offset);
+    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance);
 
     const float mag_max = fmaxf(fmaxf(mag_variance.x,mag_variance.y),mag_variance.z);
 
@@ -237,8 +236,7 @@ void Copter::check_vibration()
     // check if vertical velocity variance is at least 1 (NK4.SV >= 1.0)
     float position_variance, vel_variance, height_variance, tas_variance;
     Vector3f mag_variance;
-    Vector2f offset;
-    if (!ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance, offset)) {
+    if (!ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance)) {
         checks_succeeded = false;
     }
 

--- a/ArduPlane/ekf_check.cpp
+++ b/ArduPlane/ekf_check.cpp
@@ -110,8 +110,7 @@ bool Plane::ekf_over_threshold()
     // A value above 1.0 means the EKF has rejected that sensor data
     float position_variance, vel_variance, height_variance, tas_variance;
     Vector3f mag_variance;
-    Vector2f offset;
-    if (!ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance, offset)) {
+    if (!ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance)) {
         return false;
     };
 

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -110,10 +110,9 @@ void Sub::failsafe_ekf_check()
 
     float posVar, hgtVar, tasVar;
     Vector3f magVar;
-    Vector2f offset;
     float compass_variance;
     float vel_variance;
-    ahrs.get_variances(vel_variance, posVar, hgtVar, magVar, tasVar, offset);
+    ahrs.get_variances(vel_variance, posVar, hgtVar, magVar, tasVar);
     compass_variance = magVar.length();
 
     if (compass_variance < g.fs_ekf_thresh && vel_variance < g.fs_ekf_thresh) {

--- a/Rover/ekf_check.cpp
+++ b/Rover/ekf_check.cpp
@@ -94,8 +94,7 @@ bool Rover::ekf_over_threshold()
     // use EKF to get variance
     float position_variance, vel_variance, height_variance, tas_variance;
     Vector3f mag_variance;
-    Vector2f offset;
-    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance, offset);
+    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance);
 
     // return true if two of compass, velocity and position variances are over the threshold
     uint8_t over_thresh_count = 0;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -528,7 +528,7 @@ public:
     // indicates perfect consistency between the measurement and the EKF solution and a value of of 1 is the maximum
     // inconsistency that will be accepted by the filter
     // boolean false is returned if variances are not available
-    virtual bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const {
+    virtual bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const {
         return false;
     }
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -2051,7 +2051,7 @@ bool AP_AHRS_NavEKF::get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vec
 // indicates prefect consistency between the measurement and the EKF solution and a value of of 1 is the maximum
 // inconsistency that will be accpeted by the filter
 // boolean false is returned if variances are not available
-bool AP_AHRS_NavEKF::get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const
+bool AP_AHRS_NavEKF::get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const
 {
     switch (ekf_type()) {
     case EKFType::NONE:
@@ -2059,17 +2059,21 @@ bool AP_AHRS_NavEKF::get_variances(float &velVar, float &posVar, float &hgtVar, 
         return false;
 
 #if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
+    case EKFType::TWO: {
         // use EKF to get variance
-        EKF2.getVariances(-1,velVar, posVar, hgtVar, magVar, tasVar, offset);
+        Vector2f offset;
+        EKF2.getVariances(-1, velVar, posVar, hgtVar, magVar, tasVar, offset);
         return true;
+    }
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
+    case EKFType::THREE: {
         // use EKF to get variance
-        EKF3.getVariances(-1,velVar, posVar, hgtVar, magVar, tasVar, offset);
+        Vector2f offset;
+        EKF3.getVariances(-1, velVar, posVar, hgtVar, magVar, tasVar, offset);
         return true;
+    }
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -2079,7 +2083,6 @@ bool AP_AHRS_NavEKF::get_variances(float &velVar, float &posVar, float &hgtVar, 
         hgtVar = 0;
         magVar.zero();
         tasVar = 0;
-        offset.zero();
         return true;
 #endif
     }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -264,7 +264,7 @@ public:
     // indicates perfect consistency between the measurement and the EKF solution and a value of of 1 is the maximum
     // inconsistency that will be accepted by the filter
     // boolean false is returned if variances are not available
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const override;
+    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override;
 
     // returns the expected NED magnetic field
     bool get_mag_field_NED(Vector3f& ret) const;

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.cpp
@@ -216,11 +216,10 @@ void AP_RCTelemetry::check_ekf_status(void)
     bool get_variance;
     float velVar, posVar, hgtVar, tasVar;
     Vector3f magVar;
-    Vector2f offset;
     {
         AP_AHRS &_ahrs = AP::ahrs();
         WITH_SEMAPHORE(_ahrs.get_semaphore());
-        get_variance = _ahrs.get_variances(velVar, posVar, hgtVar, magVar, tasVar, offset);
+        get_variance = _ahrs.get_variances(velVar, posVar, hgtVar, magVar, tasVar);
     }
     if (get_variance) {
         uint32_t now = AP_HAL::millis();

--- a/libraries/AP_Scripting/examples/ahrs-print-variances.lua
+++ b/libraries/AP_Scripting/examples/ahrs-print-variances.lua
@@ -1,0 +1,17 @@
+-- This script displays the ahrs variances at 1hz
+-- get_variances provides the innovations normalised using the innovation variance
+-- a value of 0 indicates perfect consistency between the measurement and the EKF solution
+-- a value of 1 is the maximum inconsistency that will be accepted by the filter
+-- nil is returned for all arguments if variances are not available
+
+function update() -- this is the loop which periodically runs)
+  vel_variance, pos_variance, height_variance, mag_variance, airspeed_variance = ahrs:get_variances()
+  if vel_variance then
+    gcs:send_text(0, string.format("Variances Pos:%.1f Vel:%.1f Hgt:%.1f Mag:%.1f", pos_variance, vel_variance, height_variance, mag_variance:length()))
+  else
+    gcs:send_text(0, string.format("Failed to retrieve variances"))
+  end
+  return update, 1000 -- reschedules the loop
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -40,6 +40,7 @@ singleton AP_AHRS method get_vibration Vector3f
 singleton AP_AHRS method earth_to_body Vector3f Vector3f
 singleton AP_AHRS method body_to_earth Vector3f Vector3f
 singleton AP_AHRS method get_EAS2TAS float
+singleton AP_AHRS method get_variances boolean float'Null float'Null float'Null Vector3f'Null float'Null
 
 include AP_Arming/AP_Arming.h
 


### PR DESCRIPTION
This adds a binding for lua scripting so that the EKF's variances can be retrieved.  A project I'm working on required this so that a script controlling the vehicle in Guided mode could pause the movement of the vehicle if it seemed to be losing control.

This has been tested in SITL and will likely be tested on a real vehicle tomorrow.

Below is a screen shot (from SITL) of the variances being printed.  I tested that the position and compass variances changed by modifying SIM_GPS_GLITCH_X and SIM_MAG_SCALING parameters.
![scripting-ahrs-binding-tests](https://user-images.githubusercontent.com/1498098/96114586-c5647f80-0f20-11eb-875a-0f4bc66bb79a.png)
