### PR TITLE
Add option to param_parse.py to emit SITL-only parameters

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -621,6 +621,8 @@ const AP_Param::Info Copter::var_info[] = {
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // @Group: SIM_
+    // @Path: ../libraries/SITL/SITL.cpp
     GOBJECT(sitl, "SIM_", SITL::SITL),
 #endif
 

--- a/Tools/autotest/param_metadata/emit.py
+++ b/Tools/autotest/param_metadata/emit.py
@@ -7,8 +7,8 @@ import re
 
 
 class Emit:
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, sitl=False):
+        self.sitl = sitl
 
     prog_values_field = re.compile(r"\s*(-?\w+:\w+)+,*")
 

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -12,6 +12,8 @@ except Exception:
 # Emit docs in a RST format
 class RSTEmit(Emit):
     def blurb(self):
+        if self.sitl:
+            return """SITL parameters"""
         return """This is a complete list of the parameters which can be set (e.g. via the MAVLink protocol) to control vehicle behaviour. They are stored in persistent storage on the vehicle.
 
 This list is automatically generated from the latest ardupilot source code, and so may contain parameters which are not yet in the stable released versions of the code.
@@ -26,6 +28,11 @@ This list is automatically generated from the latest ardupilot source code, and 
         self.f = open(output_fname, mode='w')
         self.spacer = re.compile("^", re.MULTILINE)
         self.rstescape = re.compile("([^a-zA-Z0-9\n 	])")
+        if self.sitl:
+            parameterlisttype = "SITL Parameter List"
+        else:
+             parameterlisttype = "Complete Parameter List"
+        parameterlisttype += "\n" + "=" * len(parameterlisttype)
         self.preamble = """.. Dynamically generated list of documented parameters
 .. This page was generated using {toolname}
 
@@ -34,12 +41,12 @@ This list is automatically generated from the latest ardupilot source code, and 
 
 .. _parameters:
 
-Complete Parameter List
-=======================
+{parameterlisttype}
 
 {blurb}
 
 """.format(blurb=self.escape(self.blurb()),
+           parameterlisttype=parameterlisttype,
            toolname=self.escape(self.toolname()))
         self.t = ''
 

--- a/Tools/scripts/build_parameters.sh
+++ b/Tools/scripts/build_parameters.sh
@@ -27,6 +27,22 @@ generate_parameters() {
     fi
 }
 
+generate_sitl_parameters() {
+    VEHICLE="ArduCopter"
+
+    # generate Parameters.html, Parameters.rst etc etc:
+    ./Tools/autotest/param_metadata/param_parse.py --sitl --vehicle $VEHICLE
+
+    # stash some of the results away:
+    VEHICLE_PARAMS_DIR="$PARAMS_DIR/SITL"
+    mkdir -p "$VEHICLE_PARAMS_DIR"
+    /bin/cp Parameters.html *.pdef.xml "$VEHICLE_PARAMS_DIR/"
+    gzip -9 <"$VEHICLE_PARAMS_DIR"/apm.pdef.xml >"$VEHICLE_PARAMS_DIR"/apm.pdef.xml.gz.new && mv "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.gz.new "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.gz
+    xz -e <"$VEHICLE_PARAMS_DIR"/apm.pdef.xml >"$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz.new && mv "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz.new "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz
+    if [ -e "Parameters.rst" ]; then
+	/bin/cp Parameters.rst "$VEHICLE_PARAMS_DIR/"
+    fi
+}
 
 generate_parameters ArduPlane
 
@@ -37,3 +53,5 @@ generate_parameters Rover
 generate_parameters ArduSub
 
 generate_parameters AntennaTracker
+
+generate_sitl_parameters

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -226,6 +226,18 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     AP_SUBGROUPINFO(baro[1], "BAR2_", 35, SITL, SITL::BaroParm),
     AP_SUBGROUPINFO(baro[2], "BAR3_", 36, SITL, SITL::BaroParm),
 
+    // user settable parameters for the 1st barometer
+    // @Param: BARO_RND, BAR2_RND, BAR3_RND
+    // @DisplayName: Baro Noise
+    // @Description: amount of (evenly-distributed) noise injected into the 1st baro
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: BARO_GLITCH,BAR2_GLITCH, BAR3_GLITCH
+    // @DisplayName: Baro Glitch
+    // @Description: user-settable 1st-barometer glitch
+    // @Units: m
+    // @User: Advanced
 
     // user settable parameters for the 1st airspeed sensor
     AP_GROUPINFO("ARSPD_RND",     50, SITL,  arspd_noise[0], 2.0),


### PR DESCRIPTION
Our SITL parameter documentation (essentially anything under `SIM_`) is very poor.

Partly this is due to poor tooling (but mostly due to apathy).

This is an attempt to fix the former, given recent fixes for the latter.

It adds a "--sitl" option to `param_parse.py`.  If that is not set then the tool's output is byte-for-byte for current master's.

If it *is* set then we skip any parameter which doesn't have an annotation of `  // @HAL: SITL` as one of its fields, and we end up with an (JSON) output file like this:

```
{
  "Copter": {
    "SIM_BARO_GLITCH": {
      "Description": "user-settable 1st-barometer glitch",
      "DisplayName": "Baro Glitch",
      "HAL": "SITL",
      "Units": "m",
      "User": "Advanced"
    },
    "SIM_BARO_RND": {
      "Description": "amount of (evenly-distributed) noise injected into the 1st baro",
      "DisplayName": "Baro Noise",
      "HAL": "SITL",
      "Units": "m",
      "User": "Advanced"
    },
    "SIM_GRPE_ENABLE": {
      "Description": "Allows you to enable (1) or disable (0) the gripper servo simulation",
      "DisplayName": "Gripper servo Sim enable/disable",
      "HAL": "SITL",
      "User": "Advanced",
      "Values": {
        "0": "Disabled",
        "1": "Enabled"
      }
    },
    "SIM_GRPE_PIN": {
      "Description": "The pin number that the gripper emp is connected to. (start at 1)",
      "DisplayName": "Gripper emp pin",
      "HAL": "SITL",
      "Range": {
        "high": "15",
        "low": "0"
      },
```

This might be suitable for including in the "wiki" at https://ardupilot.org/dev/docs/simulation-2.html

I have a slight preference here for NOT adding this argument to `param_parse.py`, and simply including the extra information in the metadata.  This has the advantage of simplicity, but has the disadvantage that until tools catch up the user interfaces might be cluttered by the extra parameters.  For example, in MAVProxy we might need to filter out ` // HAL: SITL` parameters unless `--sitl` has been passed on the command-line.  Another example would be the Wiki, which would need to do the splitting as part of building the Wiki.  At the moment Tracker's Wiki actually does have some SITL parameters in it: https://ardupilot.org/antennatracker/docs/parameters.html#sim-grpe-parameters

@brunoolivieri what do you think about the concept of splitting the parameter data based on `HAL`?

@meee1 how would this work in with MP?  I'm guessing you'd prefer everything in the one file with the extra annotations?
