### PR TITLE
Rover: EKF failsafe message is displayed only when action triggered

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -158,9 +158,9 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: FS_EKF_ACTION
     // @DisplayName: EKF Failsafe Action
     // @Description: Controls the action that will be taken when an EKF failsafe is invoked
-    // @Values: 0:Disabled,1:Hold
+    // @Values: 0:Disabled,1:Hold,2:ReportOnly
     // @User: Advanced
-    GSCALAR(fs_ekf_action, "FS_EKF_ACTION", 1),
+    GSCALAR(fs_ekf_action, "FS_EKF_ACTION", FS_EFK_HOLD),
 
     // @Param: FS_EKF_THRESH
     // @DisplayName: EKF failsafe variance threshold

--- a/Rover/defines.h
+++ b/Rover/defines.h
@@ -85,7 +85,8 @@ enum fs_crash_action {
 
 enum fs_ekf_action {
     FS_EKF_DISABLE = 0,
-    FS_EFK_HOLD = 1
+    FS_EFK_HOLD = 1,
+    FS_EFK_REPORT_ONLY = 2,
 };
 
 #define DISTANCE_HOME_MINCHANGE 0.5f  // minimum distance to adjust home location

--- a/Rover/ekf_check.cpp
+++ b/Rover/ekf_check.cpp
@@ -163,6 +163,8 @@ void Rover::failsafe_ekf_event()
         case FS_EKF_DISABLE:
             // do nothing
             return;
+        case FS_EFK_REPORT_ONLY:
+            break;
         case FS_EFK_HOLD:
         default:
             set_mode(mode_hold, ModeReason::EKF_FAILSAFE);

--- a/Rover/ekf_check.cpp
+++ b/Rover/ekf_check.cpp
@@ -152,7 +152,6 @@ void Rover::failsafe_ekf_event()
     failsafe.ekf = true;
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV,
                              LogErrorCode::FAILSAFE_OCCURRED);
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF failsafe!");
 
     // does this mode require position?
     if (!control_mode->requires_position()) {
@@ -163,12 +162,14 @@ void Rover::failsafe_ekf_event()
     switch ((enum fs_ekf_action)g.fs_ekf_action.get()) {
         case FS_EKF_DISABLE:
             // do nothing
-            break;
+            return;
         case FS_EFK_HOLD:
         default:
             set_mode(mode_hold, ModeReason::EKF_FAILSAFE);
             break;
     }
+
+    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF failsafe");
 }
 
 // failsafe_ekf_off_event - actions to take when EKF failsafe is cleared


### PR DESCRIPTION
EKF failsafe message was displayed even when driving in MANUAL mode.
This PR makes EKF failsafe message only displaye when the action is triggered.
If the EKF action is disabled, the message will not be displayed.

I tested it using SIM_GPS_DISABLE parameter in sitl:
 1. EKF failsafe message is not displayed in MANUAL mode
 2. EKF failsafe message is displayed in AUTO mode
 3. EKF failsafe message is not displayed in AUTO mode with FS_EKF_ACTION=0