### PR TITLE
Support CRSF Parameter Requests

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -141,7 +141,7 @@
  # include <AP_Button/AP_Button.h>
 #endif
 
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
  #include <AP_OSD/AP_OSD.h>
 #endif
 
@@ -442,7 +442,7 @@ private:
                            FUNCTOR_BIND_MEMBER(&Copter::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
 
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     AP_OSD osd;
 #endif
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -709,7 +709,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(rtl_alt_type, "RTL_ALT_TYPE", 0),
 
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     // @Group: OSD
     // @Path: ../libraries/AP_OSD/AP_OSD.cpp
     GOBJECT(osd, "OSD", AP_OSD),

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1085,7 +1085,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: ../libraries/AP_Landing/AP_Landing.cpp
     GOBJECT(landing, "LAND_", AP_Landing),
 
-#if OSD_ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     // @Group: OSD
     // @Path: ../libraries/AP_OSD/AP_OSD.cpp
     GOBJECT(osd, "OSD", AP_OSD),

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -253,7 +253,7 @@ private:
     // Rally Ponints
     AP_Rally rally;
 
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     AP_OSD osd;
 #endif
     
@@ -974,7 +974,7 @@ private:
     void update_control_mode(void);
     void update_flight_stage();
     void set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs);
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     void publish_osd_info();
 #endif
 

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -369,7 +369,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Path: Parameters.cpp
     GOBJECT(g2, "",  ParametersG2),
 
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     // @Group: OSD
     // @Path: ../libraries/AP_OSD/AP_OSD.cpp
     GOBJECT(osd, "OSD", AP_OSD),

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -165,7 +165,7 @@ private:
     OpticalFlow optflow;
 #endif
 
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     AP_OSD osd;
 #endif
 
@@ -390,7 +390,7 @@ private:
     bool should_log(uint32_t mask);
     bool is_boat() const;
 
-#if OSD_ENABLED == ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
     void publish_osd_info();
 #endif
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -19,7 +19,7 @@
 
 #include "AP_OSD.h"
 
-#if OSD_ENABLED
+#if OSD_ENABLED || OSD_PARAM_ENABLED
 
 #include "AP_OSD_MAX7456.h"
 #ifdef WITH_SITL_OSD
@@ -38,12 +38,13 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
 
     // @Param: _TYPE
     // @DisplayName: OSD type
-    // @Description: OSD type
-    // @Values: 0:None,1:MAX7456,2:SITL,3:MSP
+    // @Description: OSD type. TXONLY makes the OSD parameter selection available to other modules even if there is no native OSD support on the board, for instance CRSF.
+    // @Values: 0:None,1:MAX7456,2:SITL,3:MSP,4:TXONLY
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("_TYPE", 1, AP_OSD, osd_type, 0, AP_PARAM_FLAG_ENABLE),
 
+#if OSD_ENABLED
     // @Param: _CHAN
     // @DisplayName: Screen switch transmitter channel
     // @Description: This sets the channel used to switch different OSD screens.
@@ -167,7 +168,10 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Range: 0 3000
     // @User: Advanced
     AP_GROUPINFO("_BTN_DELAY", 20, AP_OSD, button_delay_ms, 300),
+#endif
 
+#endif
+#if OSD_PARAM_ENABLED
     // @Group: 5_
     // @Path: AP_OSD_ParamScreen.cpp
     AP_SUBGROUPINFO(param_screen[0], "5_", 21, AP_OSD, AP_OSD_ParamScreen),
@@ -190,16 +194,18 @@ AP_OSD::AP_OSD()
         AP_HAL::panic("AP_OSD must be singleton");
     }
     AP_Param::setup_object_defaults(this, var_info);
+#if OSD_ENABLED
     // default first screen enabled
     screen[0].enabled = 1;
+    previous_pwm_screen = -1;
+#endif
 #ifdef WITH_SITL_OSD
-    osd_type.set_default(2);
+    osd_type.set_default(OSD_SITL);
 #endif
 
 #ifdef HAL_OSD_TYPE_DEFAULT
     osd_type.set_default(HAL_OSD_TYPE_DEFAULT);
 #endif
-    previous_pwm_screen = -1;
     _singleton = this;
 }
 
@@ -207,6 +213,7 @@ void AP_OSD::init()
 {
     switch ((enum osd_types)osd_type.get()) {
     case OSD_NONE:
+    case OSD_TXONLY:
     default:
         break;
 
@@ -244,12 +251,15 @@ void AP_OSD::init()
         break;
     }
     }
+#if OSD_ENABLED
     if (backend != nullptr && (enum osd_types)osd_type.get() != OSD_MSP) {
         // create thread as higher priority than IO for all backends but MSP which has its own
         hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_OSD::osd_thread, void), "OSD", 1024, AP_HAL::Scheduler::PRIORITY_IO, 1);
     }
+#endif
 }
 
+#if OSD_ENABLED
 void AP_OSD::osd_thread()
 {
     while (true) {
@@ -424,6 +434,7 @@ void AP_OSD::set_nav_info(NavInfo &navinfo)
     // do this without a lock for now
     nav_info = navinfo;
 }
+#endif // OSD_ENABLED
 
 // handle OSD parameter configuration
 void AP_OSD::handle_msg(const mavlink_message_t &msg, const GCS_MAVLINK& link)
@@ -475,4 +486,4 @@ AP_OSD *AP::osd() {
     return AP_OSD::get_singleton();
 }
 
-#endif // OSD_ENABLED
+#endif // OSD_ENABLED || OSD_PARAM_ENABLED

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -30,11 +30,11 @@
 #endif
 
 #ifndef HAL_WITH_OSD_BITMAP
-#define HAL_WITH_OSD_BITMAP defined(HAL_WITH_SPI_OSD) || defined(WITH_SITL_OSD)
+#define HAL_WITH_OSD_BITMAP OSD_ENABLED && (defined(HAL_WITH_SPI_OSD) || defined(WITH_SITL_OSD))
 #endif
 
 #ifndef OSD_PARAM_ENABLED
-#define OSD_PARAM_ENABLED HAL_WITH_OSD_BITMAP && !HAL_MINIMIZE_FEATURES
+#define OSD_PARAM_ENABLED !HAL_MINIMIZE_FEATURES
 #endif
 
 class AP_OSD_Backend;
@@ -102,6 +102,7 @@ protected:
     AP_OSD *osd;
 };
 
+#if OSD_ENABLED
 /*
   class to hold one screen of settings
  */
@@ -243,6 +244,7 @@ private:
     void draw_bat2used(uint8_t x, uint8_t y);
     void draw_clk(uint8_t x, uint8_t y);
 };
+#endif // OSD_ENABLED
 
 #if OSD_PARAM_ENABLED
 /*
@@ -291,7 +293,13 @@ public:
 
     // initialize the setting from the configured information
     void update();
-
+    // grab the parameter name
+    void copy_name(char* name, size_t len) {
+        _param->copy_name_token(_current_token, name, len);
+        if (len > 16) name[16] = 0;
+    }
+    // copy the name converting FOO_BAR_BAZ to FooBarBaz
+    void copy_name_camel_case(char* name, size_t len);
     // set the ranges from static metadata
     bool set_from_metadata();
     bool set_by_name(const char* name, uint8_t config_type, float pmin=0, float pmax=0, float pincr=0);
@@ -333,10 +341,13 @@ public:
     static const uint8_t NUM_PARAMS = 9;
     static const uint8_t SAVE_PARAM = NUM_PARAMS + 1;
 
+#if HAL_WITH_OSD_BITMAP
     void draw(void) override;
+#endif
     void handle_write_msg(const mavlink_osd_param_config_t& packet, const GCS_MAVLINK& link);
     void handle_read_msg(const mavlink_osd_param_show_config_t& packet, const GCS_MAVLINK& link);
-
+    // get a setting and associated metadata
+    AP_OSD_ParamSetting* get_setting(uint8_t param_idx);
     // Save button co-ordinates
     AP_Int8 save_x;
     AP_Int8 save_y;
@@ -347,17 +358,17 @@ public:
 private:
     AP_OSD_ParamSetting params[NUM_PARAMS] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
+    void save_parameters();
+#if OSD_ENABLED
     void update_state_machine();
     void draw_parameter(uint8_t param_number, uint8_t x, uint8_t y);
     void modify_parameter(uint8_t number, Event ev);
     void modify_configured_parameter(uint8_t number, Event ev);
-    void save_parameters();
 
     Event map_rc_input_to_event() const;
     RC_Channel::AuxSwitchPos get_channel_pos(uint8_t rcmapchan) const;
 
     uint8_t _selected_param = 1;
-    uint16_t _requires_save;
     MenuState _menu_state = MenuState::PARAM_SELECT;
     Event _last_rc_event = Event::NONE;
 
@@ -367,9 +378,11 @@ private:
     uint32_t _transition_timeout_ms;
     // number of consecutive times the current transition has happened
     uint32_t _transition_count;
+#endif
+    uint16_t _requires_save;
 };
 
-#endif
+#endif // OSD_PARAM_ENABLED
 
 class AP_OSD
 {
@@ -402,6 +415,7 @@ public:
         OSD_MAX7456=1,
         OSD_SITL=2,
         OSD_MSP=3,
+        OSD_TXONLY=4
     };
     enum switch_method {
         TOGGLE=0,
@@ -410,9 +424,12 @@ public:
     };
 
     AP_Int8 osd_type;
+    AP_Int8 font_num;
+    AP_Int32 options;
+
+#if OSD_ENABLED
     AP_Int8 rc_channel;
     AP_Int8 sw_method;
-    AP_Int8 font_num;
 
     AP_Int8 v_offset;
     AP_Int8 h_offset;
@@ -433,8 +450,6 @@ public:
         OPTION_INVERTED_AH_ROLL = 1U<<2,
     };
 
-    AP_Int32 options;
-
     enum {
         UNITS_METRIC=0,
         UNITS_IMPERIAL=1,
@@ -446,9 +461,7 @@ public:
     AP_Int8 units;
 
     AP_OSD_Screen screen[AP_OSD_NUM_DISPLAY_SCREENS];
-#if OSD_PARAM_ENABLED
-    AP_OSD_ParamScreen param_screen[AP_OSD_NUM_PARAM_SCREENS] { 0, 1 };
-#endif
+
     struct NavInfo {
         float wp_distance;
         int32_t wp_bearing;
@@ -478,16 +491,27 @@ public:
     // Check whether arming is allowed
     bool pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) const;
     bool is_readonly_screen() const { return current_screen < AP_OSD_NUM_DISPLAY_SCREENS; }
+#endif // OSD_ENABLED
+#if OSD_PARAM_ENABLED
+    AP_OSD_ParamScreen param_screen[AP_OSD_NUM_PARAM_SCREENS] { 0, 1 };
+    // return a setting for use by TX based OSD
+    AP_OSD_ParamSetting* get_setting(uint8_t screen_idx, uint8_t param_idx) {
+        if (screen_idx >= AP_OSD_NUM_PARAM_SCREENS) {
+            return nullptr;
+        }
+        return param_screen[screen_idx].get_setting(param_idx);
+    }
+#endif
     // handle OSD parameter configuration
     void handle_msg(const mavlink_message_t &msg, const GCS_MAVLINK& link);
 
 private:
     void osd_thread();
+#if OSD_ENABLED
     void update_osd();
     void stats();
     void update_current_screen();
     void next_screen();
-    AP_OSD_Backend *backend;
 
     //variables for screen switching
     uint8_t current_screen;
@@ -508,6 +532,8 @@ private:
     float max_speed_mps;
     float max_current_a;
     float avg_current_a;
+#endif
+    AP_OSD_Backend *backend;
 
     static AP_OSD *_singleton;
 };

--- a/libraries/AP_OSD/AP_OSD_Backend.cpp
+++ b/libraries/AP_OSD/AP_OSD_Backend.cpp
@@ -25,6 +25,7 @@ extern const AP_HAL::HAL& hal;
 
 void AP_OSD_Backend::write(uint8_t x, uint8_t y, bool blink, const char *fmt, ...)
 {
+#if OSD_ENABLED
     if (blink && (blink_phase < 2)) {
         return;
     }
@@ -48,4 +49,5 @@ void AP_OSD_Backend::write(uint8_t x, uint8_t y, bool blink, const char *fmt, ..
         write(x, y, buff);
     }
     va_end(ap);
+#endif
 }

--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -18,6 +18,7 @@
 
 #include <AP_OSD/AP_OSD_MAX7456.h>
 
+#if HAL_WITH_OSD_BITMAP
 #include <AP_HAL/Util.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_HAL/Scheduler.h>
@@ -478,3 +479,4 @@ float AP_OSD_MAX7456::get_aspect_ratio_correction() const
         return 1.0f;
     };
 }
+#endif // HAL_WITH_OSD_BITMAP

--- a/libraries/AP_OSD/AP_OSD_MAX7456.h
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.h
@@ -18,6 +18,7 @@
 #include <AP_OSD/AP_OSD_Backend.h>
 #include <AP_Common/Bitmask.h>
 
+#if HAL_WITH_OSD_BITMAP
 class AP_OSD_MAX7456 : public AP_OSD_Backend
 {
 
@@ -88,3 +89,4 @@ private:
 
     uint16_t video_lines;
 };
+#endif // HAL_WITH_OSD_BITMAP

--- a/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
@@ -71,10 +71,13 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM1_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM1
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[0], "PARAM1", 4, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
     
     // @Param: PARAM2_EN
-    // @DisplayName: PARAM21_EN
+    // @DisplayName: PARAM2_EN
     // @Description: Enables display of parameter 2
     // @Values: 0:Disabled,1:Enabled
 
@@ -87,6 +90,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM2_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM2
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[1], "PARAM2", 5, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: PARAM3_EN
@@ -103,6 +109,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM3_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM3
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[2], "PARAM3", 6, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: PARAM4_EN
@@ -119,6 +128,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM4_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM4
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[3], "PARAM4", 7, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: PARAM5_EN
@@ -135,6 +147,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM5_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM5
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[4], "PARAM5", 8, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: PARAM6_EN
@@ -151,6 +166,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM6_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM6
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[5], "PARAM6", 9, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: PARAM7_EN
@@ -167,6 +185,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM7_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM7
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[6], "PARAM7", 10, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: PARAM8_EN
@@ -183,6 +204,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM8_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM8
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[7], "PARAM8", 11, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: PARAM9_EN
@@ -199,6 +223,9 @@ const AP_Param::GroupInfo AP_OSD_ParamScreen::var_info[] = {
     // @DisplayName: PARAM9_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
+
+    // @Group: PARAM9
+    // @Path: AP_OSD_ParamSetting.cpp
     AP_SUBGROUPINFO(params[8], "PARAM9", 12, AP_OSD_ParamScreen, AP_OSD_ParamSetting),
 
     // @Param: SAVE_X
@@ -297,6 +324,16 @@ AP_OSD_ParamScreen::AP_OSD_ParamScreen(uint8_t index)
     AP_Param::setup_object_defaults(this, var_info);
 }
 
+AP_OSD_ParamSetting* AP_OSD_ParamScreen::get_setting(uint8_t param_idx)
+{
+    if (param_idx >= NUM_PARAMS) {
+        return nullptr;
+    }
+    params[param_idx].update(); // make sure we are fresh
+    return &params[param_idx];
+}
+
+#if OSD_ENABLED
 void AP_OSD_ParamScreen::draw_parameter(uint8_t number, uint8_t x, uint8_t y)
 {
     bool param_blink = false;
@@ -328,8 +365,7 @@ void AP_OSD_ParamScreen::draw_parameter(uint8_t number, uint8_t x, uint8_t y)
     if (p != nullptr) {
         // grab the name of the parameter
         char name[17];
-        p->copy_name_token(setting._current_token, name, 16);
-        name[16] = 0;
+        setting.copy_name(name, 17);
 
         const AP_OSD_ParamSetting::ParamMetadata* metadata = setting.get_custom_metadata();
 
@@ -437,7 +473,7 @@ void AP_OSD_ParamScreen::modify_parameter(uint8_t number, Event ev)
     }
 }
 
-// modify which parameter is configued for the given selection
+// modify which parameter is configured for the given selection
 void AP_OSD_ParamScreen::modify_configured_parameter(uint8_t number, Event ev)
 {
     if (number > NUM_PARAMS) {
@@ -485,25 +521,6 @@ void AP_OSD_ParamScreen::modify_configured_parameter(uint8_t number, Event ev)
         setting._current_token.idx = 0;
         setting._current_token.group_element = 0;
     }
-}
-
-// save all of the parameters
-void AP_OSD_ParamScreen::save_parameters()
-{
-    if (!_requires_save) {
-        return;
-    }
-
-    for (uint8_t i = 0; i < NUM_PARAMS; i++) {
-        if (params[i].enabled && (_requires_save & (1 << i))) {
-            AP_Param* p = params[i]._param;
-            if (p != nullptr) {
-                p->save();
-            }
-            params[i].save_as_new();
-        }
-    }
-    _requires_save = 0;
 }
 
 // return radio values as LOW, MIDDLE, HIGH
@@ -710,6 +727,40 @@ void AP_OSD_ParamScreen::draw(void)
     draw_parameter(SAVE_PARAM, save_x, save_y);
 }
 
+// pre_arm_check - returns true if all pre-takeoff checks have completed successfully
+bool AP_OSD::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) const
+{
+    // currently in the OSD menu, do not allow arming
+    if (!is_readonly_screen()) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "In OSD menu");
+        return false;
+    }
+
+    // if we got this far everything must be ok
+    return true;
+}
+
+#endif // OSD_ENABLED
+
+// save all of the parameters
+void AP_OSD_ParamScreen::save_parameters()
+{
+    if (!_requires_save) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < NUM_PARAMS; i++) {
+        if (params[i].enabled && (_requires_save & (1 << i))) {
+            AP_Param* p = params[i]._param;
+            if (p != nullptr) {
+                p->save();
+            }
+            params[i].save_as_new();
+        }
+    }
+    _requires_save = 0;
+}
+
 // handle OSD configuration messages
 void AP_OSD_ParamScreen::handle_write_msg(const mavlink_osd_param_config_t& packet, const GCS_MAVLINK& link)
 {
@@ -751,16 +802,3 @@ void AP_OSD_ParamScreen::handle_read_msg(const mavlink_osd_param_show_config_t& 
 }
 
 #endif // OSD_PARAM_ENABLED
-
-// pre_arm_check - returns true if all pre-takeoff checks have completed successfully
-bool AP_OSD::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) const
-{
-    // currently in the OSD menu, do not allow arming
-    if (!is_readonly_screen()) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "In OSD menu");
-        return false;
-    }
-
-    // if we got this far everything must be ok
-    return true;
-}

--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -24,6 +24,7 @@
 #include "AP_OSD.h"
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <ctype.h>
 
 #if OSD_PARAM_ENABLED
 
@@ -366,7 +367,7 @@ void AP_OSD_ParamSetting::guess_ranges(bool force)
             }
             incr = MAX(1, powf(10, digits - 2));
             max = powf(10, digits + 1);
-            debug("Guessing range for value %d as %f -> %f, %f\n", p->get(), min, max, incr);
+            debug("Guessing range for value %d as %f -> %f, %f\n", int(p->get()), min, max, incr);
             break;
         }
         case AP_PARAM_FLOAT: {
@@ -411,6 +412,23 @@ void AP_OSD_ParamSetting::guess_ranges(bool force)
         }
         if (force || !_param_incr.configured()) {
             _param_incr = incr;
+        }
+    }
+}
+
+// copy the name converting FOO_BAR_BAZ to FooBarBaz
+void AP_OSD_ParamSetting::copy_name_camel_case(char* name, size_t len)
+{
+    char buf[17];
+    _param->copy_name_token(_current_token, buf, 17);
+    buf[16] = 0;
+    name[0] = buf[0];
+    for (uint8_t i = 1, n = 1; i < len; i++, n++) {
+        if (buf[i] == '_') {
+            name[n] = buf[i+1];
+            i++;
+        } else {
+            name[n] = tolower(buf[i]);
         }
     }
 }

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -22,6 +22,7 @@
 #include "AP_OSD.h"
 #include "AP_OSD_Backend.h"
 
+#if OSD_ENABLED
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Util.h>
 #include <AP_AHRS/AP_AHRS.h>
@@ -1809,3 +1810,4 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(eff);
 }
 #endif
+#endif // OSD_ENABLED

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -80,11 +80,14 @@ static const char* get_frame_type(uint8_t byte)
         return "ATTITUDE";
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_FLIGHT_MODE:
         return "FLIGHT_MODE";
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_INFO:
+        return "DEVICE_INFO";
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ:
+        return "PARAM_READ";
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY:
+        return "SETTINGS_ENTRY";
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_LINK_STATISTICS:
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_RC_CHANNELS_PACKED:
-    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_INFO:
-    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY:
-    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ:
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_WRITE:
         return "UNKNOWN";
     }
@@ -259,7 +262,12 @@ void AP_RCProtocol_CRSF::write_frame(Frame* frame)
 #ifdef CRSF_DEBUG
     hal.console->printf("CRSF: writing %s:", get_frame_type(frame->type));
     for (uint8_t i = 0; i < frame->length + 2; i++) {
-        hal.console->printf(" 0x%x", ((uint8_t*)frame)[i]);
+        uint8_t val = ((uint8_t*)frame)[i];
+        if (val >= 32 && val <= 126) {
+            hal.console->printf(" 0x%x '%c'", val, (char)val);
+        } else {
+            hal.console->printf(" 0x%x", val);
+        }
     }
     hal.console->printf("\n");
 #endif

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -24,6 +24,8 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Notify/AP_Notify.h>
+#include <AP_Common/AP_FWVersion.h>
+#include <AP_OSD/AP_OSD.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -71,8 +73,9 @@ void AP_CRSF_Telem::setup_wfq_scheduler(void)
 
     // CSRF telemetry rate is 150Hz (4ms) max, so these rates must fit
     add_scheduler_entry(50, 100);   // heartbeat        10Hz
+    add_scheduler_entry(200, 50);   // parameters       20Hz (generally not active unless requested by the TX)
     add_scheduler_entry(50, 120);   // Attitude and compass 8Hz
-    add_scheduler_entry(200, 1000); // parameters        1Hz
+    add_scheduler_entry(200, 1000); // VTX parameters    1Hz
     add_scheduler_entry(1300, 500); // battery           2Hz
     add_scheduler_entry(550, 280);  // GPS               3Hz
     add_scheduler_entry(550, 500);  // flight mode       2Hz
@@ -87,6 +90,8 @@ bool AP_CRSF_Telem::is_packet_ready(uint8_t idx, bool queue_empty)
 {
     switch (idx) {
     case PARAMETERS:
+        return _request_pending > 0;
+    case VTX_PARAMETERS:
         return AP::vtx().have_params_changed() ||_vtx_power_change_pending || _vtx_freq_change_pending || _vtx_options_change_pending;
     default:
         return _enable_telemetry;
@@ -101,11 +106,14 @@ void AP_CRSF_Telem::process_packet(uint8_t idx)
         case HEARTBEAT: // HEARTBEAT
             calc_heartbeat();
             break;
+        case PARAMETERS: // update parameter settings
+            update_params();
+            break;
         case ATTITUDE:
             calc_attitude();
             break;
-        case PARAMETERS: // update various parameters
-            update_params();
+        case VTX_PARAMETERS: // update various VTX parameters
+            update_vtx_params();
             break;
         case BATTERY: // BATTERY
             calc_battery();
@@ -137,6 +145,18 @@ bool AP_CRSF_Telem::_process_frame(AP_RCProtocol_CRSF::FrameType frame_type, voi
 
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_VTX_TELEM:
         process_vtx_telem_frame((VTXTelemetryFrame*)data);
+        break;
+
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING:
+        process_ping_frame((ParameterPingFrame*)data);
+        break;
+
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ:
+        process_param_read_frame((ParameterSettingsReadFrame*)data);
+        break;
+
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_WRITE:
+        process_param_write_frame((ParameterSettingsWriteFrame*)data);
         break;
 
     default:
@@ -216,12 +236,51 @@ void AP_CRSF_Telem::process_vtx_telem_frame(VTXTelemetryFrame* vtx) {
     _vtx_power_change_pending = _vtx_freq_change_pending = _vtx_options_change_pending = false;
 }
 
+// request for device info
+void AP_CRSF_Telem::process_ping_frame(ParameterPingFrame* ping)
+{
+    debug("process_ping_frame: %d -> %d", ping->origin, ping->destination);
+    if (ping->destination != 0 && ping->destination != AP_RCProtocol_CRSF::CRSF_ADDRESS_FLIGHT_CONTROLLER) {
+        return; // request was not for us
+    }
+
+    _param_request.origin = ping->origin;
+    _request_pending = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING;
+}
+
+void AP_CRSF_Telem::process_param_read_frame(ParameterSettingsReadFrame* read_frame)
+{
+    //debug("process_param_read_frame: %d -> %d for %d[%d]", read_frame->origin, read_frame->destination,
+    //    read_frame->param_number, read_frame->param_chunk);
+    if (read_frame->destination != 0 && read_frame->destination != AP_RCProtocol_CRSF::CRSF_ADDRESS_FLIGHT_CONTROLLER) {
+        return; // request was not for us
+    }
+
+    _param_request = *read_frame;
+    _request_pending = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ;
+}
+
 // process any changed settings and schedule for transmission
 void AP_CRSF_Telem::update()
 {
 }
 
 void AP_CRSF_Telem::update_params()
+{
+    // handle general parameter requests
+    switch (_request_pending) {
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING:
+        calc_device_info();
+        break;
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ:
+        calc_parameter();
+        break;
+    default:
+        break;
+    }
+}
+
+void AP_CRSF_Telem::update_vtx_params()
 {
     AP_VideoTX& vtx = AP::vtx();
 
@@ -404,6 +463,367 @@ void AP_CRSF_Telem::calc_flight_mode()
         _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_FLIGHT_MODE;
         _telem_pending = true;
     }
+}
+
+// return device information about ArduPilot
+void AP_CRSF_Telem::calc_device_info() {
+#if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+    _telem.ext.info.destination = _param_request.origin;
+    _telem.ext.info.origin = AP_RCProtocol_CRSF::CRSF_ADDRESS_FLIGHT_CONTROLLER;
+
+    const AP_FWVersion &fwver = AP::fwversion();
+    // write out the name with version, max width is 60 - 18 = the meaning of life
+    int32_t n = strlen(fwver.fw_string);
+    strncpy((char*)_telem.ext.info.payload, fwver.fw_string, 41);
+    n = MIN(n + 1, 42);
+
+    put_be32_ptr(&_telem.ext.info.payload[n], // serial number
+        uint32_t(fwver.major) << 24 | uint32_t(fwver.minor) << 16 | uint32_t(fwver.patch) << 8 | uint32_t(fwver.fw_type));
+    n += 4;
+    put_be32_ptr(&_telem.ext.info.payload[n], // hardware id
+        uint32_t(fwver.vehicle_type) << 24 | uint32_t(fwver.board_type) << 16 | uint32_t(fwver.board_subtype));
+    n += 4;
+    put_be32_ptr(&_telem.ext.info.payload[n], fwver.os_sw_version);   // software id
+    n += 4;
+#if OSD_PARAM_ENABLED
+    _telem.ext.info.payload[n++] = AP_OSD_ParamScreen::NUM_PARAMS * AP_OSD_NUM_PARAM_SCREENS; // param count
+#else
+    _telem.ext.info.payload[n++] = 0; // param count
+#endif
+    _telem.ext.info.payload[n++] = 0;   // param version
+
+    _telem_size = n + 2;
+    _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_INFO;
+
+    _request_pending = 0;
+    _telem_pending = true;
+#endif
+}
+
+// return parameter information
+void AP_CRSF_Telem::calc_parameter() {
+#if OSD_PARAM_ENABLED
+    AP_OSD* osd = AP::osd();
+
+    if (osd == nullptr) {
+        return;
+    }
+
+    _telem.ext.param_entry.header.destination = _param_request.origin;
+    _telem.ext.param_entry.header.origin = AP_RCProtocol_CRSF::CRSF_ADDRESS_FLIGHT_CONTROLLER;
+
+    AP_OSD_ParamSetting* param = osd->get_setting((_param_request.param_num - 1) / AP_OSD_ParamScreen::NUM_PARAMS,
+        (_param_request.param_num - 1) % AP_OSD_ParamScreen::NUM_PARAMS);
+
+    if (param == nullptr) {
+        return;
+    }
+
+    _telem.ext.param_entry.header.param_num = _param_request.param_num;
+#if HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED
+    if (param->get_custom_metadata() != nullptr) {
+        calc_text_selection(param, _param_request.param_chunk);
+        return;
+    }
+#endif
+    size_t idx = 0;
+    _telem.ext.param_entry.header.chunks_left = 0;
+    _telem.ext.param_entry.payload[idx++] = 0; // parent folder
+    idx++;  // leave a gap for the type
+    param->copy_name_camel_case((char*)&_telem.ext.param_entry.payload[idx], 17);
+    idx += strnlen((char*)&_telem.ext.param_entry.payload[idx], 16) + 1;
+
+    switch (param->_param_type) {
+    case AP_PARAM_INT8: {
+        AP_Int8* p = (AP_Int8*)param->_param;
+        _telem.ext.param_entry.payload[1] = ParameterType::INT8;
+        _telem.ext.param_entry.payload[idx] = p->get();  // value
+        _telem.ext.param_entry.payload[idx+1] = int8_t(param->_param_min);  // min
+        _telem.ext.param_entry.payload[idx+2] = int8_t(param->_param_max); // max
+        _telem.ext.param_entry.payload[idx+3] = int8_t(0);  // default
+        idx += 4;
+        break;
+    }
+    case AP_PARAM_INT16: {
+        AP_Int16* p = (AP_Int16*)param->_param;
+        _telem.ext.param_entry.payload[1] = ParameterType::INT16;
+        put_be16_ptr(&_telem.ext.param_entry.payload[idx], p->get());  // value
+        put_be16_ptr(&_telem.ext.param_entry.payload[idx+2], param->_param_min);  // min
+        put_be16_ptr(&_telem.ext.param_entry.payload[idx+4], param->_param_max); // max
+        put_be16_ptr(&_telem.ext.param_entry.payload[idx+6], 0);  // default
+        idx += 8;
+        break;
+    }
+    case AP_PARAM_INT32: {
+        AP_Int32* p = (AP_Int32*)param->_param;
+        _telem.ext.param_entry.payload[1] = ParameterType::FLOAT;
+#define FLOAT_ENCODE(f) (int32_t(roundf(f)))
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx], p->get());  // value
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+4], FLOAT_ENCODE(param->_param_min));  // min
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+8], FLOAT_ENCODE(param->_param_max)); // max
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+12], FLOAT_ENCODE(0.0f));  // default
+#undef FLOAT_ENCODE
+        _telem.ext.param_entry.payload[idx+16] = 0; // decimal point
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+17], 1);  // step size
+        idx += 21;
+        break;
+    }
+    case AP_PARAM_FLOAT: {
+        AP_Float* p = (AP_Float*)param->_param;
+        _telem.ext.param_entry.payload[1] = ParameterType::FLOAT;
+        uint8_t digits = 0;
+        const float incr = MAX(0.001f, param->_param_incr); // a bug in OpenTX prevents this going any smaller
+
+        for (float floatp = incr; floatp < 1.0f; floatp *= 10) {
+            digits++;
+        }
+        const float mult = powf(10, digits);
+#define FLOAT_ENCODE(f) (int32_t(roundf(mult * f)))
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx], FLOAT_ENCODE(p->get()));  // value
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+4], FLOAT_ENCODE(param->_param_min));  // min
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+8], FLOAT_ENCODE(param->_param_max)); // max
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+12], FLOAT_ENCODE(0.0f));  // default
+        _telem.ext.param_entry.payload[idx+16] = digits; // decimal point
+        put_be32_ptr(&_telem.ext.param_entry.payload[idx+17], FLOAT_ENCODE(incr));  // step size
+#undef FLOAT_ENCODE
+        //debug("Encoding param %f(%f -> %f, %f) as %d(%d) (%d -> %d, %d)", p->get(),
+        //    param->_param_min.get(), param->_param_max.get(), param->_param_incr.get(),
+        //    int(FLOAT_ENCODE(p->get())), digits, int(FLOAT_ENCODE(param->_param_min)),
+        //    int(FLOAT_ENCODE(param->_param_max)), int(FLOAT_ENCODE(param->_param_incr)));
+        idx += 21;
+        break;
+    }
+    default:
+        return;
+    }
+    _telem.ext.param_entry.payload[idx] = 0; // units
+
+    _telem_size = sizeof(AP_CRSF_Telem::ParameterSettingsEntryHeader) + 1 + idx;
+    _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY;
+
+    _request_pending = 0;
+    _telem_pending = true;
+#endif
+}
+
+#if HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED
+// class that spits out a chunk of data from a larger stream of contiguous chunks
+// the caller describes which chunk it needs and provides this class with all of the data
+// data is not written until the start position is reached and after a whole chunk
+// is accumulated the rest of the data is skipped in order to determine how many chunks
+// are left to be sent
+class BufferChunker {
+public:
+    BufferChunker(uint8_t* buf, uint16_t chunk_size, uint16_t start_chunk) :
+        _buf(buf), _idx(0), _start_chunk(start_chunk), _chunk_size(chunk_size), _chunk(0), _bytes(0) {
+    }
+
+    // accumulate a string, writing to the underlying buffer as required
+    void put_string(const char* str, uint16_t str_len) {
+        // skip over data we have already written or have yet to write
+        if (_chunk != _start_chunk) {
+            if (skip_bytes(str_len)) {
+                // partial write
+                strncpy((char*)_buf, &str[str_len - _idx], _idx);
+                _bytes += _idx;
+            }
+            return;
+        }
+
+        uint16_t rem = remaining();
+        if (rem > str_len) {
+            strncpy((char*)&_buf[_idx], str, str_len);
+            _idx += str_len;
+            _bytes += str_len;
+        } else {
+            strncpy((char*)&_buf[_idx], str, rem);
+            _chunk++;
+            _idx += str_len;
+            _bytes += rem;
+            _idx %= _chunk_size;
+        }
+    }
+
+    // accumulate a byte, writing to the underlying buffer as required
+    void put_byte(uint8_t b) {
+        if (_chunk != _start_chunk) {
+            if (skip_bytes(1)) {
+                _buf[0] = b;
+                _bytes++;
+            }
+            return;
+        }
+        if (remaining() > 0) {
+            _buf[_idx++] = b;
+            _bytes++;
+        } else {
+            _chunk++;
+            _idx = 0;
+        }
+    }
+
+    uint8_t chunks_remaining() const { return _chunk - _start_chunk; }
+    uint8_t bytes_written() const { return _bytes; }
+
+private:
+    uint16_t remaining() const { return _chunk_size - _bytes; }
+
+    // skip over the requested number of bytes
+    // returns true if we overflow into a chunk that needs to be written
+    bool skip_bytes(uint16_t len) {
+        _idx += len;
+        if (_idx >= _chunk_size) {
+            _chunk++;
+            _idx %= _chunk_size;
+            // partial write
+            if (_chunk == _start_chunk && _idx > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    uint8_t* _buf;
+    uint16_t _idx;
+    uint16_t _bytes;
+    uint8_t _chunk;
+    const uint16_t _start_chunk;
+    const uint16_t _chunk_size;
+};
+
+// provide information about a text selection, possibly over multiple chunks
+void AP_CRSF_Telem::calc_text_selection(AP_OSD_ParamSetting* param, uint8_t chunk)
+{
+    const uint8_t CHUNK_SIZE = 56;
+    const AP_OSD_ParamSetting::ParamMetadata* metadata = param->get_custom_metadata();
+
+    // chunk the output
+    BufferChunker chunker(_telem.ext.param_entry.payload, CHUNK_SIZE, chunk);
+
+    chunker.put_byte(0);  // parent folder
+    chunker.put_byte(ParameterType::TEXT_SELECTION);  // parameter type
+
+    char name[17];
+    param->copy_name_camel_case(name, 17);
+    chunker.put_string(name, strnlen(name, 16)); // parameter name
+    chunker.put_byte(0);  // trailing null
+
+    for (uint8_t i = 0; i < metadata->values_max; i++) {
+        uint8_t len = strnlen(metadata->values[i], 16);
+        if (len == 0) {
+            chunker.put_string("---", 3);
+        } else {
+            chunker.put_string(metadata->values[i], len);
+        }
+        if (i == metadata->values_max - 1) {
+            chunker.put_byte(0);
+        } else {
+            chunker.put_byte(';');
+        }
+    }
+
+    int32_t val = -1;
+    switch (param->_param_type) {
+    case AP_PARAM_INT8:
+        val = ((AP_Int8*)param->_param)->get();
+        break;
+    case AP_PARAM_INT16:
+        val = ((AP_Int16*)param->_param)->get();
+        break;
+    case AP_PARAM_INT32:
+        val = ((AP_Int32*)param->_param)->get();
+        break;
+    default:
+        return;
+    }
+
+    // out of range values really confuse the TX
+    val = constrain_int16(val, 0, metadata->values_max - 1);
+    chunker.put_byte(val);  // value
+    chunker.put_byte(0);  // min
+    chunker.put_byte(metadata->values_max); // max
+    chunker.put_byte(0);  // default
+    chunker.put_byte(0); // units
+
+    _telem.ext.param_entry.header.chunks_left = chunker.chunks_remaining();
+
+    _telem_size = sizeof(AP_CRSF_Telem::ParameterSettingsEntryHeader) + chunker.bytes_written();
+    _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY;
+
+    _request_pending = 0;
+    _telem_pending = true;
+}
+#endif
+
+// write parameter information back into AP - assumes we already know the encoding for floats
+void AP_CRSF_Telem::process_param_write_frame(ParameterSettingsWriteFrame* write_frame)
+{
+    debug("process_param_write_frame: %d -> %d", write_frame->origin, write_frame->destination);
+    if (write_frame->destination != AP_RCProtocol_CRSF::CRSF_ADDRESS_FLIGHT_CONTROLLER) {
+        return; // request was not for us
+    }
+#if OSD_PARAM_ENABLED
+    AP_OSD* osd = AP::osd();
+
+    if (osd == nullptr) {
+        return;
+    }
+
+    AP_OSD_ParamSetting* param = osd->get_setting((write_frame->param_num - 1) / AP_OSD_ParamScreen::NUM_PARAMS,
+        (write_frame->param_num - 1) % AP_OSD_ParamScreen::NUM_PARAMS);
+
+    if (param == nullptr) {
+        return;
+    }
+
+#if HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED
+    bool text_selection = param->get_custom_metadata() != nullptr;
+#else
+    bool text_selection = false;
+#endif
+
+    switch (param->_param_type) {
+    case AP_PARAM_INT8: {
+        AP_Int8* p = (AP_Int8*)param->_param;
+        p->set_and_save(write_frame->payload[0]);
+        break;
+    }
+    case AP_PARAM_INT16: {
+        AP_Int16* p = (AP_Int16*)param->_param;
+        if (text_selection) {
+            // if we have custom metadata then the parameter is a text selection
+            p->set_and_save(write_frame->payload[0]);
+        } else {
+            p->set_and_save(be16toh_ptr(write_frame->payload));
+        }
+        break;
+    }
+    case AP_PARAM_INT32: {
+        AP_Int32* p = (AP_Int32*)param->_param;
+        if (text_selection) {
+            // if we have custom metadata then the parameter is a text selection
+            p->set_and_save(write_frame->payload[0]);
+        } else {
+            p->set_and_save(be32toh_ptr(write_frame->payload));
+        }
+        break;
+    }
+    case AP_PARAM_FLOAT: {
+        AP_Float* p = (AP_Float*)param->_param;
+        const int32_t val = be32toh_ptr(write_frame->payload);
+        uint8_t digits = 0;
+        const float incr = MAX(0.001f, param->_param_incr); // a bug in OpenTX prevents this going any smaller
+
+        for (float floatp = incr; floatp < 1.0f; floatp *= 10) {
+            digits++;
+        }
+        p->set_and_save(float(val) / powf(10, digits));
+        break;
+    }
+    default:
+        break;
+    }
+#endif
 }
 
 /*

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3163,7 +3163,7 @@ void GCS_MAVLINK::handle_obstacle_distance(const mavlink_message_t &msg)
 
 void GCS_MAVLINK::handle_osd_param_config(const mavlink_message_t &msg)
 {
-#if OSD_ENABLED
+#if OSD_PARAM_ENABLED
     AP_OSD *osd = AP::osd();
     if (osd != nullptr) {
         osd->handle_msg(msg, *this);


### PR DESCRIPTION
CRSF supports the notion of getting and setting parameters which we can wire into ArduPilot's parameter system.
In order to confirm to the constraints of the available protocol and to provide a better user experience I have wired this up to the OSD parameter metadata so that you can:

- Configure through the OSD setup what you see on the Crossfire setup screen
- Use text selections for important parameters

![IMG_2899](https://user-images.githubusercontent.com/2893260/97489022-ed0f0b00-1956-11eb-84b7-07a11d02cfde.jpg)

![IMG_2900](https://user-images.githubusercontent.com/2893260/97489037-f1d3bf00-1956-11eb-8be5-fd5023e8b853.jpg)

![IMG_2901](https://user-images.githubusercontent.com/2893260/97489050-f5ffdc80-1956-11eb-892d-e72d348edb10.jpg)
