### PR TITLE
Fixed NMEA time handling

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -5,6 +5,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
+#include <AP_RTC/AP_RTC.h>
 
 #if HAVE_FILESYSTEM_SUPPORT && CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 
@@ -540,48 +541,6 @@ off_t AP_Filesystem_FATFS::lseek(int fileno, off_t position, int whence)
     return fh->fptr;
 }
 
-/*
-  mktime replacement from Samba
- */
-static time_t replace_mktime(const struct tm *t)
-{
-    time_t  epoch = 0;
-    int n;
-    int mon [] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }, y, m, i;
-    const unsigned MINUTE = 60;
-    const unsigned HOUR = 60*MINUTE;
-    const unsigned DAY = 24*HOUR;
-    const unsigned YEAR = 365*DAY;
-
-    if (t->tm_year < 70) {
-        return (time_t)-1;
-    }
-
-    n = t->tm_year + 1900 - 1;
-    epoch = (t->tm_year - 70) * YEAR +
-            ((n / 4 - n / 100 + n / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400)) * DAY;
-
-    y = t->tm_year + 1900;
-    m = 0;
-
-    for (i = 0; i < t->tm_mon; i++) {
-        epoch += mon [m] * DAY;
-        if (m == 1 && y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
-            epoch += DAY;
-        }
-
-        if (++m > 11) {
-            m = 0;
-            y++;
-        }
-    }
-
-    epoch += (t->tm_mday - 1) * DAY;
-    epoch += t->tm_hour * HOUR + t->tm_min * MINUTE + t->tm_sec;
-
-    return epoch;
-}
-
 static time_t fat_time_to_unix(uint16_t date, uint16_t time)
 {
     struct tm tp;
@@ -595,7 +554,7 @@ static time_t fat_time_to_unix(uint16_t date, uint16_t time)
     tp.tm_mday = (date & 0x1f);
     tp.tm_mon = ((date >> 5) & 0x0f) - 1;
     tp.tm_year = ((date >> 9) & 0x7f) + 80;
-    unix = replace_mktime( &tp );
+    unix = AP::rtc().mktime(&tp);
     return unix;
 }
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -16,6 +16,8 @@
 #include "AP_GPS.h"
 #include "GPS_Backend.h"
 #include <AP_Logger/AP_Logger.h>
+#include <time.h>
+#include <AP_RTC/AP_RTC.h>
 
 #define GPS_BACKEND_DEBUGGING 0
 
@@ -76,34 +78,25 @@ int16_t AP_GPS_Backend::swap_int16(int16_t v) const
  */
 void AP_GPS_Backend::make_gps_time(uint32_t bcd_date, uint32_t bcd_milliseconds)
 {
-    uint8_t year, mon, day, hour, min, sec;
-    uint16_t msec;
+    struct tm tm {};
 
-    year = bcd_date % 100;
-    mon  = (bcd_date / 100) % 100;
-    day  = bcd_date / 10000;
+    tm.tm_year = 100U + bcd_date % 100U;
+    tm.tm_mon  = ((bcd_date / 100U) % 100U)-1;
+    tm.tm_mday = bcd_date / 10000U;
 
     uint32_t v = bcd_milliseconds;
-    msec = v % 1000; v /= 1000;
-    sec  = v % 100; v /= 100;
-    min  = v % 100; v /= 100;
-    hour = v % 100;
+    uint16_t msec = v % 1000U; v /= 1000U;
+    tm.tm_sec = v % 100U; v /= 100U;
+    tm.tm_min = v % 100U; v /= 100U;
+    tm.tm_hour = v % 100U;
 
-    int8_t rmon = mon - 2;
-    if (0 >= rmon) {    
-        rmon += 12;
-        year -= 1;
-    }
-
-    // get time in seconds since unix epoch
-    uint32_t ret = (year/4) - (GPS_LEAPSECONDS_MILLIS / 1000UL) + 367*rmon/12 + day;
-    ret += year*365 + 10501;
-    ret = ret*24 + hour;
-    ret = ret*60 + min;
-    ret = ret*60 + sec;
+    // convert from time structure to unix time
+    time_t unix_time = AP::rtc().mktime(&tm);
 
     // convert to time since GPS epoch
-    ret -= 272764785UL;
+    const uint32_t unix_to_GPS_secs = 315964800UL;
+    const uint16_t leap_seconds_unix = GPS_LEAPSECONDS_MILLIS/1000U;
+    uint32_t ret = unix_time + leap_seconds_unix - unix_to_GPS_secs;
 
     // get GPS week and time
     state.time_week = ret / AP_SEC_PER_WEEK;

--- a/libraries/AP_RTC/AP_RTC.cpp
+++ b/libraries/AP_RTC/AP_RTC.cpp
@@ -3,6 +3,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
+#include <time.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -204,6 +205,48 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
     return static_cast<uint32_t>(total_delay_ms);
 }
 
+
+/*
+  mktime replacement from Samba
+ */
+time_t AP_RTC::mktime(const struct tm *t)
+{
+    time_t epoch = 0;
+    int n;
+    int mon [] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }, y, m, i;
+    const unsigned MINUTE = 60;
+    const unsigned HOUR = 60*MINUTE;
+    const unsigned DAY = 24*HOUR;
+    const unsigned YEAR = 365*DAY;
+
+    if (t->tm_year < 70) {
+        return (time_t)-1;
+    }
+
+    n = t->tm_year + 1900 - 1;
+    epoch = (t->tm_year - 70) * YEAR +
+            ((n / 4 - n / 100 + n / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400)) * DAY;
+
+    y = t->tm_year + 1900;
+    m = 0;
+
+    for (i = 0; i < t->tm_mon; i++) {
+        epoch += mon [m] * DAY;
+        if (m == 1 && y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
+            epoch += DAY;
+        }
+
+        if (++m > 11) {
+            m = 0;
+            y++;
+        }
+    }
+
+    epoch += (t->tm_mday - 1) * DAY;
+    epoch += t->tm_hour * HOUR + t->tm_min * MINUTE + t->tm_sec;
+
+    return epoch;
+}
 
 // singleton instance
 AP_RTC *AP_RTC::_singleton;

--- a/libraries/AP_RTC/AP_RTC.h
+++ b/libraries/AP_RTC/AP_RTC.h
@@ -44,6 +44,9 @@ public:
 
     uint32_t get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms);
 
+    // replacement for mktime()
+    static time_t mktime(const struct tm *t);
+
     // get singleton instance
     static AP_RTC *get_singleton() {
         return _singleton;


### PR DESCRIPTION
Our conversion from BCD time to unix time was off, causing NMEA timestamps to be off by 3 days
Tested using a u-blox F9P in NMEA mode

thanks to @CUAVcaijie  for reporting