### PR TITLE
EKF3: allow alt from other sources when using ExtNav

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -407,6 +407,10 @@ void NavEKF3_core::SelectVelPosFusion()
     // get data that has now fallen behind the fusion time horizon
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);
 
+    // initialise all possible data we may fuse
+    fusePosData = false;
+    fuseVelData = false;
+
     // Determine if we need to fuse position and velocity data on this time step
     if (gpsDataToFuse && (PV_AidingMode == AID_ABSOLUTE) && (frontend->_fusionModeGPS != 3)) {
 
@@ -433,7 +437,6 @@ void NavEKF3_core::SelectVelPosFusion()
         // use external nav system for position
         extNavUsedForPos = true;
         activeHgtSource = HGT_SOURCE_EXTNAV;
-        fuseVelData = false;
         fuseHgtData = true;
         fusePosData = true;
 
@@ -443,9 +446,6 @@ void NavEKF3_core::SelectVelPosFusion()
         velPosObs[3] = extNavDataDelayed.pos.x;
         velPosObs[4] = extNavDataDelayed.pos.y;
         velPosObs[5] = extNavDataDelayed.pos.z;
-    } else {
-        fuseVelData = false;
-        fusePosData = false;
     }
 
     // fuse external navigation velocity data if available

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -992,6 +992,7 @@ void NavEKF3_core::selectHeightForFusion()
     baroDataToFuse = storedBaro.recall(baroDataDelayed, imuDataDelayed.time_ms);
 
     bool rangeFinderDataIsFresh = (imuSampleTime_ms - rngValidMeaTime_ms < 500);
+    const bool extNavDataIsFresh = (imuSampleTime_ms - extNavMeasTime_ms < 500);
     // select height source
     if (extNavUsedForPos && (frontend->_altSource == 4)) {
         // always use external navigation as the height source if using for position.
@@ -1043,14 +1044,14 @@ void NavEKF3_core::selectHeightForFusion()
         activeHgtSource = HGT_SOURCE_GPS;
     } else if ((frontend->_altSource == 3) && validOrigin && rngBcnGoodToAlign) {
         activeHgtSource = HGT_SOURCE_BCN;
-    } else if ((frontend->_altSource == 4) && ((imuSampleTime_ms - extNavMeasTime_ms) < 500)) {
+    } else if ((frontend->_altSource == 4) && extNavDataIsFresh) {
         activeHgtSource = HGT_SOURCE_EXTNAV;
     }
 
     // Use Baro alt as a fallback if we lose range finder, GPS, external nav or Beacon
     bool lostRngHgt = ((activeHgtSource == HGT_SOURCE_RNG) && !rangeFinderDataIsFresh);
     bool lostGpsHgt = ((activeHgtSource == HGT_SOURCE_GPS) && ((imuSampleTime_ms - lastTimeGpsReceived_ms) > 2000));
-    bool lostExtNavHgt = ((activeHgtSource == HGT_SOURCE_EXTNAV) && ((imuSampleTime_ms - extNavMeasTime_ms) > 2000));
+    bool lostExtNavHgt = ((activeHgtSource == HGT_SOURCE_EXTNAV) && !extNavDataIsFresh);
     bool lostRngBcnHgt = ((activeHgtSource == HGT_SOURCE_BCN) && ((imuSampleTime_ms - rngBcnDataDelayed.time_ms) > 2000));
     if (lostRngHgt || lostGpsHgt || lostExtNavHgt || lostRngBcnHgt) {
         activeHgtSource = HGT_SOURCE_BARO;


### PR DESCRIPTION
This PR allows the EKF's altitude source to come from another source (baro, rangefinder, etc) when using external nav as the horizontal position source.  This is useful especially for users of the T265 which can lose its position and altitude estimate due to high vibration.  Because multicopter Z-axis vibrations tend to be particularly high, the camera normally loses its altitude estimate first.  Allowing the user to rely on barometer is generally a safer option.

This PR is part of the EKF position source PR: https://github.com/ArduPilot/ardupilot/pull/14803.  I've extracted it here to simplify the other PR.

This has been tested in SITL and extensively on a real vehicle.  Below is a screen shot of a SITL test in which EK3_ALT_SOURCE = 0 (Baro) but the [vicon is enabled](https://ardupilot.org/dev/docs/using-sitl-for-ardupilot-testing.html#testing-vicon-aka-vision-positioning).  We see that a glitch in the External Nav's Z-axis position has no impact on the EKF's altitude.
![ek3-alt-source-baro](https://user-images.githubusercontent.com/1498098/96443996-71bba400-1248-11eb-9c5b-592443b9215e.png)

This is the same test again but with EK3_ALT_SOURCE = 4 (ExtNav) and the EKF's altitude is affected by a glitch in the External Nav's Z-axis position.
![ek3-alt-source-extnav](https://user-images.githubusercontent.com/1498098/96444041-7e3ffc80-1248-11eb-92c6-c6eaf1b0c598.png)

The ExtNav altitude can also be used with GPS (or other horizontal position source).  I tested this in SITL as well and it worked as expected.

