### PR TITLE
Tools: Generate bootloader hex using waf

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -179,10 +179,20 @@ class build_abin(Task.Task):
     def __str__(self):
         return self.outputs[0].path_from(self.generator.bld.bldnode)
 
-class build_intel_hex(Task.Task):
-    '''build an intel hex file for upload with DFU'''
+class build_ardupilot_intel_hex(Task.Task):
+    '''build an intel hex file of the ArduPilot binary for upload with DFU'''
     color='CYAN'
     run_str='${TOOLS_SCRIPTS}/make_intel_hex.py ${SRC} ${FLASH_RESERVE_START_KB}'
+    always_run = True
+    def keyword(self):
+        return "Generating"
+    def __str__(self):
+        return self.outputs[0].path_from(self.generator.bld.bldnode)
+
+class build_bootloader_intel_hex(Task.Task):
+    '''build an intel hex file of the Bootloader binary for upload with DFU'''
+    color='CYAN'
+    run_str='${TOOLS_SCRIPTS}/bin2hex.py --offset=0x08000000 ${SRC} ${TGT}'
     always_run = True
     def keyword(self):
         return "Generating"
@@ -211,11 +221,16 @@ def chibios_firmware(self):
         abin_task = self.create_task('build_abin', src=link_output, tgt=abin_target)
         abin_task.set_run_after(generate_apj_task)
 
-    bootloader_bin = self.bld.srcnode.make_node("Tools/bootloaders/%s_bl.bin" % self.env.BOARD)
-    if self.bld.env.HAVE_INTEL_HEX:
-        if os.path.exists(bootloader_bin.abspath()):
+    if self.env.BOOTLOADER:
+        if self.bld.env.HAVE_INTEL_HEX:
             hex_target = self.bld.bldnode.find_or_declare('bin/' + link_output.change_ext('.hex').name)
-            hex_task = self.create_task('build_intel_hex', src=[bin_target, bootloader_bin], tgt=hex_target)
+            hex_task = self.create_task('build_bootloader_intel_hex', src=bin_target, tgt=hex_target)
+            hex_task.set_run_after(generate_bin_task)
+    else:
+        bootloader_bin = self.bld.srcnode.make_node("Tools/bootloaders/%s_bl.bin" % self.env.BOARD)
+        if os.path.exists(bootloader_bin.abspath()) and self.bld.env.HAVE_INTEL_HEX:
+            hex_target = self.bld.bldnode.find_or_declare('bin/' + link_output.change_ext('.hex').name)
+            hex_task = self.create_task('build_ardupilot_intel_hex', src=[bin_target, bootloader_bin], tgt=hex_target)
             hex_task.set_run_after(generate_bin_task)
         else:
             print("Not embedding bootloader; %s does not exist" % bootloader_bin)

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -246,7 +246,7 @@ def chibios_firmware(self):
         if self.env.BOOTLOADER:
             hex_target = self.bld.bldnode.find_or_declare('bin/' + link_output.change_ext('.hex').name)
             hex_task = self.create_task('build_bootloader_intel_hex', src=bin_target, tgt=hex_target)
-            hex_task.set_run_after(generate_apj_task)
+            hex_task.set_run_after(generate_bin_task)
             # copy hex
             copy_hex_target = self.bld.srcnode.make_node("Tools/bootloaders/%s_bl.hex" % self.env.BOARD)
             copy_hex_task = self.create_task('copy_and_rename', src=hex_target, tgt=copy_hex_target)

--- a/Tools/scripts/build_bootloaders.py
+++ b/Tools/scripts/build_bootloaders.py
@@ -55,9 +55,7 @@ for board in get_board_list():
         failed_boards.add(board)
         continue
     shutil.copy('build/%s/bin/AP_Bootloader.bin' % board, 'Tools/bootloaders/%s_bl.bin' % board)
-    if not run_program(["Tools/scripts/bin2hex.py", "--offset", "0x08000000", 'Tools/bootloaders/%s_bl.bin' % board, 'Tools/bootloaders/%s_bl.hex' % board]):
-        failed_boards.add(board)
-        continue
+    shutil.copy('build/%s/bin/AP_Bootloader.hex' % board, 'Tools/bootloaders/%s_bl.hex' % board)
     shutil.copy('build/%s/bootloader/AP_Bootloader' % board, 'Tools/bootloaders/%s_bl.elf' % board)
 
 if len(failed_boards):

--- a/Tools/scripts/build_bootloaders.py
+++ b/Tools/scripts/build_bootloaders.py
@@ -54,9 +54,6 @@ for board in get_board_list():
     if not build_board(board):
         failed_boards.add(board)
         continue
-    shutil.copy('build/%s/bin/AP_Bootloader.bin' % board, 'Tools/bootloaders/%s_bl.bin' % board)
-    shutil.copy('build/%s/bin/AP_Bootloader.hex' % board, 'Tools/bootloaders/%s_bl.hex' % board)
-    shutil.copy('build/%s/bootloader/AP_Bootloader' % board, 'Tools/bootloaders/%s_bl.elf' % board)
 
 if len(failed_boards):
     print("Failed boards: %s" % list(failed_boards))


### PR DESCRIPTION
The following workflow:
```
./waf configure --board <board> --bootloader
./waf bootloader
./waf configure --board <board>
./waf plane
```

will generate a new bootloader binary, but the new bootloader binary won't get copied to the `/Tools/bootloaders/` directory. As a result, the new bootloader binary _won't_ be combined with the plane binary. The required workflow is:
```
./Tools/scripts/build_bootloaders.py <board>
./waf configure --board <board>
./waf plane
```

This PR changes the `chibios.py` and `build_bootloaders.py` scripts so the two workflows are equivalent. 