### PR TITLE
AP_NavEKF3: correct extnav position as it is recalled from the buffer

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1051,7 +1051,8 @@ void NavEKF3_core::writeExtNavVelData(const Vector3f &vel, float err, uint32_t t
     const ext_nav_vel_elements extNavVelNew {
         vel,
         err,
-        timeStamp_ms
+        timeStamp_ms,
+        false
     };
     storedExtNavVel.push(extNavVelNew);
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -339,8 +339,14 @@ void NavEKF3_core::CorrectGPSForAntennaOffset(gps_elements &gps_data) const
 }
 
 // correct external navigation earth-frame position using sensor body-frame offset
-void NavEKF3_core::CorrectExtNavForSensorOffset(Vector3f &ext_position)
+void NavEKF3_core::CorrectExtNavForSensorOffset(ext_nav_elements &ext_nav_data)
 {
+    // return immediately if already corrected
+    if (ext_nav_data.corrected) {
+        return;
+    }
+    ext_nav_data.corrected = true;
+
 #if HAL_VISUALODOM_ENABLED
     AP_VisualOdom *visual_odom = AP::visualodom();
     if (visual_odom == nullptr) {
@@ -351,15 +357,21 @@ void NavEKF3_core::CorrectExtNavForSensorOffset(Vector3f &ext_position)
         return;
     }
     Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
-    ext_position.x -= posOffsetEarth.x;
-    ext_position.y -= posOffsetEarth.y;
-    ext_position.z -= posOffsetEarth.z;
+    ext_nav_data.pos.x -= posOffsetEarth.x;
+    ext_nav_data.pos.y -= posOffsetEarth.y;
+    ext_nav_data.pos.z -= posOffsetEarth.z;
 #endif
 }
 
 // correct external navigation earth-frame velocity using sensor body-frame offset
-void NavEKF3_core::CorrectExtNavVelForSensorOffset(Vector3f &ext_velocity) const
+void NavEKF3_core::CorrectExtNavVelForSensorOffset(ext_nav_vel_elements &ext_nav_vel_data) const
 {
+    // return immediately if already corrected
+    if (ext_nav_vel_data.corrected) {
+        return;
+    }
+    ext_nav_vel_data.corrected = true;
+
 #if HAL_VISUALODOM_ENABLED
     AP_VisualOdom *visual_odom = AP::visualodom();
     if (visual_odom == nullptr) {
@@ -371,7 +383,7 @@ void NavEKF3_core::CorrectExtNavVelForSensorOffset(Vector3f &ext_velocity) const
     }
     // TODO use a filtered angular rate with a group delay that matches the sensor delay
     const Vector3f angRate = imuDataDelayed.delAng * (1.0f/imuDataDelayed.delAngDT);
-    ext_velocity += get_vel_correction_for_sensor_offset(posOffsetBody, prevTnb, angRate);
+    ext_nav_vel_data.vel += get_vel_correction_for_sensor_offset(posOffsetBody, prevTnb, angRate);
 #endif
 }
 
@@ -395,11 +407,11 @@ void NavEKF3_core::SelectVelPosFusion()
     // Check for data at the fusion time horizon
     extNavDataToFuse = storedExtNav.recall(extNavDataDelayed, imuDataDelayed.time_ms);
     if (extNavDataToFuse) {
-        CorrectExtNavForSensorOffset(extNavDataDelayed.pos);
+        CorrectExtNavForSensorOffset(extNavDataDelayed);
     }
     extNavVelToFuse = storedExtNavVel.recall(extNavVelDelayed, imuDataDelayed.time_ms);
     if (extNavVelToFuse) {
-        CorrectExtNavVelForSensorOffset(extNavVelDelayed.vel);
+        CorrectExtNavVelForSensorOffset(extNavVelDelayed);
     }
 
     // Read GPS data from the sensor

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -123,10 +123,8 @@ void NavEKF3_core::ResetPosition(resetDataSource posResetSource)
             lastRngBcnPassTime_ms = imuSampleTime_ms;
         } else if ((imuSampleTime_ms - extNavDataDelayed.time_ms < 250 && posResetSource == resetDataSource::DEFAULT) || posResetSource == resetDataSource::EXTNAV) {
             // use external nav data as the third preference
-            ext_nav_elements extNavCorrected = extNavDataDelayed;
-            CorrectExtNavForSensorOffset(extNavCorrected.pos);
-            stateStruct.position.x = extNavCorrected.pos.x;
-            stateStruct.position.y = extNavCorrected.pos.y;
+            stateStruct.position.x = extNavDataDelayed.pos.x;
+            stateStruct.position.y = extNavDataDelayed.pos.y;
             // set the variances as received from external nav system data
             P[7][7] = P[8][8] = sq(extNavDataDelayed.posErr);
             // clear the timeout flags and counters
@@ -396,6 +394,9 @@ void NavEKF3_core::SelectVelPosFusion()
 
     // Check for data at the fusion time horizon
     extNavDataToFuse = storedExtNav.recall(extNavDataDelayed, imuDataDelayed.time_ms);
+    if (extNavDataToFuse) {
+        CorrectExtNavForSensorOffset(extNavDataDelayed.pos);
+    }
     extNavVelToFuse = storedExtNavVel.recall(extNavVelDelayed, imuDataDelayed.time_ms);
     if (extNavVelToFuse) {
         CorrectExtNavVelForSensorOffset(extNavVelDelayed.vel);
@@ -437,10 +438,6 @@ void NavEKF3_core::SelectVelPosFusion()
         // use external nav system for horizontal position
         extNavUsedForPos = true;
         fusePosData = true;
-
-        // correct for external navigation sensor position
-        CorrectExtNavForSensorOffset(extNavDataDelayed.pos);
-
         velPosObs[3] = extNavDataDelayed.pos.x;
         velPosObs[4] = extNavDataDelayed.pos.y;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -627,12 +627,14 @@ private:
         float           posErr;     // spherical poition measurement error 1-std (m)
         uint32_t        time_ms;    // measurement timestamp (msec)
         bool            posReset;   // true when the position measurement has been reset
+        bool            corrected;  // true when the position has been corrected for sensor position
     };
 
     struct ext_nav_vel_elements {
         Vector3f vel;               // velocity in NED (m/s)
         float err;                  // velocity measurement error (m/s)
         uint32_t time_ms;           // measurement timestamp (msec)
+        bool corrected;             // true when the velocity has been corrected for sensor position
     };
 
     // bias estimates for the IMUs that are enabled but not being used
@@ -944,10 +946,10 @@ private:
     void CorrectGPSForAntennaOffset(gps_elements &gps_data) const;
 
     // correct external navigation earth-frame position using sensor body-frame offset
-    void CorrectExtNavForSensorOffset(Vector3f &ext_position);
+    void CorrectExtNavForSensorOffset(ext_nav_elements &ext_nav_data);
 
     // correct external navigation earth-frame velocity using sensor body-frame offset
-    void CorrectExtNavVelForSensorOffset(Vector3f &ext_velocity) const;
+    void CorrectExtNavVelForSensorOffset(ext_nav_vel_elements &ext_nav_vel_data) const;
 
     // Runs the IMU prediction step for an independent GSF yaw estimator algorithm
     // that uses IMU, GPS horizontal velocity and optionally true airspeed data.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -624,7 +624,7 @@ private:
 
     struct ext_nav_elements {
         Vector3f        pos;        // XYZ position measured in a RH navigation frame (m)
-        float           posErr;     // spherical poition measurement error 1-std (m)
+        float           posErr;     // spherical position measurement error 1-std (m)
         uint32_t        time_ms;    // measurement timestamp (msec)
         bool            posReset;   // true when the position measurement has been reset
         bool            corrected;  // true when the position has been corrected for sensor position


### PR DESCRIPTION
This PR modifies the EKF3 so that external nav position data is corrected for the sensor's position on the frame (i.e. VISO_POS_X,Y,Z) at the moment it is recalled from the buffer instead of being corrected just before it is used.  The advantage of this small change is:

- Reduces the chance of position corrections being missed or being applied twice
- Corrections for position and velocity are done at the same place in the code which slightly reduces complexity
- This probably corrects a small bug in position reset handling where the position corrections were applied twice.  I have not verified this but from inspection SelectVelPosFusion() was directly correcting extNavDataDelayed.pos soon after it was recalled from the buffer.  If PositionReset() was called any time after this (even in a later iteration) it would apply the corrections again.

This has been tested in SITL by doing the following:

- started SITL using EKF3 and [Vicon](https://ardupilot.org/dev/docs/using-sitl-for-ardupilot-testing.html#testing-vicon-aka-vision-positioning)
- param set SIM_VICON_POS_Z 5 (to simulate the sensor being placed 5m below the vehicle)
- param set VISO_POS_Z 5 (to tell ardupilot the sensor is 5m below the vehicle)
- arm in Loiter and takeoff to 10m
- fly forward about 50
- switch to RTL

Here are the resulting position innovations before and after and we see they are very similar although the After has a better initial IPD probably because of the bug fix mentioned above.

![extnav-pos-innov-before](https://user-images.githubusercontent.com/1498098/96571613-c160a500-1306-11eb-8a60-320c9cbe14b8.png)

![extnav-pos-innov-after](https://user-images.githubusercontent.com/1498098/96571625-c45b9580-1306-11eb-8a21-a2469ba7481d.png)

A short SITL test was also performed with VISO_POS_Z = 0 (so AP performed no corrections) and using both master and this new branch an EKF failsafe was triggered soon after takeoff.


