### PR TITLE
travis: remove autotest and reorder compilation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,21 +50,25 @@ matrix:
   include:
     - if: type != cron
       compiler: "gcc"
-      env: CI_BUILD_TARGET="sitltest-copter-tests2 sitltest-heli"
-      name: sitltest-copter-tests2 sitltest-heli
-    - if: type != cron
-      compiler: "gcc"
-      env: CI_BUILD_TARGET="sitltest-copter-tests1"
-      name: sitltest-copter-tests1
-    - if: type != cron
-      compiler: "gcc"
-      env: CI_BUILD_TARGET="sitltest-tracker sitltest-quadplane sitltest-plane"
-      name: sitltest-tracker sitltest-quadplane sitltest-plane
+      env: CI_BUILD_TARGET="stm32f7 stm32h7 fmuv2-plane"
+      name: stm32f7 stm32h7 fmuv2-plane
     - if: type != cron
       compiler: "clang"
-      env: CI_BUILD_TARGET="sitltest-rover sitltest-sub sitltest-balancebot navigator unit-tests"
-      name: sitltest-rover sitltest-sub sitltest-balancebot navigator unit-tests
+      env: CI_BUILD_TARGET="stm32f7 stm32h7 fmuv2-plane"
+      name: stm32f7-clang stm32h7-clang fmuv2-plane-clang
+    - if: type != cron
+      compiler: "gcc"
+      env: CI_BUILD_TARGET="navigator periph-build"
+      name: navigator periph-build
     - if: type != cron
       compiler: "clang"
-      env: CI_BUILD_TARGET="revo-bootloader periph-build CubeOrange-bootloader iofirmware stm32f7 stm32h7 fmuv2-plane sitl"
-      name: revo-bootloader periph-build CubeOrange-bootloader iofirmware stm32f7 stm32h7 fmuv2-plane sitl
+      env: CI_BUILD_TARGET="periph-build"
+      name: periph-build-clang
+    - if: type != cron
+      compiler: "gcc"
+      env: CI_BUILD_TARGET="revo-bootloader CubeOrange-bootloader iofirmware"
+      name: revo-bootloader CubeOrange-bootloader iofirmware
+    - if: type != cron
+      compiler: "clang"
+      env: CI_BUILD_TARGET="revo-bootloader CubeOrange-bootloader iofirmware"
+      name: revo-bootloader-clang CubeOrange-bootloader-clang iofirmware-clang


### PR DESCRIPTION
Autotests are covered by github actions now, so I remove them from travis. This will allow faster completion as Travis is the slowest now.

I have reodered the compilation test on travis to profit from the X5 parallelism. 
We may not want to test everything against clang. 
navigator is not test with clang as it use gcc with musl so there is no point to test against clang