### PR TITLE
Log ap banner

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -481,6 +481,7 @@ void AP_AHRS::Log_Write_Home_And_Origin()
 
     if (home_is_set()) {
         logger->Write_Origin(LogOriginType::ahrs_home, _home);
+        logger->Write_APBanner();
     }
 }
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -296,6 +296,7 @@ public:
     void WriteCritical(const char *name, const char *labels, const char *fmt, ...);
     void WriteCritical(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);
     void WriteV(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, va_list arg_list, bool is_critical=false);
+    void Write_APBanner();
 
     // This structure provides information on the internal member data of a PID for logging purposes
     struct PID_Info {

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -488,6 +488,12 @@ bool AP_Logger_Backend::Write_Message(const char *message)
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
+void AP_Logger::Write_APBanner()
+{
+    static constexpr char ap_banner[18] = {0x55,0x4e,0x4d,0x41,0x4e,0x4e,0x45,0x44,0x20,0x55,0x53,0x45,0x20,0x4f,0x4e,0x4c,0x59,0};
+    Write_Message(ap_banner);
+}
+
 void AP_Logger::Write_Power(void)
 {
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS


### PR DESCRIPTION
As discuss this night.
It write on log a banner, I put it AHRS as this is the componant that will be use by most system. The banner is in hex to not be searchable as string through the codebase.