### PR TITLE
AP_Scripting: add DIR_DISABLE param to disable loading scripts from given directory

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -101,6 +101,14 @@ const AP_Param::GroupInfo AP_Scripting::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("USER4", 8, AP_Scripting, _user[3], 0.0),
 
+    // @Param: DIR_DISABLE
+    // @DisplayName: Directory disable
+    // @Description: This will stop scripts being loaded from the given locations
+    // @Bitmask: 0:ROMFS, 1:APM/scripts
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("DIR_DISABLE", 9, AP_Scripting, _dir_disable, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -50,6 +50,12 @@ public:
         bool session;
     } terminal;
 
+    enum class SCR_DIR {
+        ROMFS = 1 << 0,
+        SCRIPTS = 1 << 1,
+    };
+    uint16_t get_disabled_dir() { return uint16_t(_dir_disable.get());}
+
 private:
 
     bool repl_start(void);
@@ -63,6 +69,7 @@ private:
     AP_Int32 _script_vm_exec_count;
     AP_Int32 _script_heap_size;
     AP_Int8 _debug_level;
+    AP_Int16 _dir_disable;
 
     bool _init_failed;  // true if memory allocation failed
 


### PR DESCRIPTION
This allows to disable loading scripts from a directory based on a bit mask param. The use-case being if you have a script loaded in ROMFS that you don't want to run but you do need to run one off the SD card.

~~Fixes https://github.com/ArduPilot/ardupilot/issues/14644#~~