### PR TITLE
AP_NavEKF3: correct GPS for position as it is recalled from buffer

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -581,6 +581,9 @@ void NavEKF3_core::readGpsData()
             // read the NED velocity from the GPS
             gpsDataNew.vel = gps.velocity(selected_gps);
 
+            // position and velocity are not yet corrected for sensor position
+            gpsDataNew.corrected = false;
+
             // Use the speed and position accuracy from the GPS if available, otherwise set it to zero.
             // Apply a decaying envelope filter with a 5 second time constant to the raw accuracy data
             float alpha = constrain_float(0.0002f * (lastTimeGpsReceived_ms - secondLastGpsTime_ms),0.0f,1.0f);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -327,13 +327,13 @@ void NavEKF3_core::CorrectGPSForAntennaOffset(gps_elements &gps_data) const
     if (posOffsetBody.is_zero()) {
         return;
     }
-    if (fuseVelData) {
-        // TODO use a filtered angular rate with a group delay that matches the GPS delay
-        Vector3f angRate = imuDataDelayed.delAng * (1.0f/imuDataDelayed.delAngDT);
-        Vector3f velOffsetBody = angRate % posOffsetBody;
-        Vector3f velOffsetEarth = prevTnb.mul_transpose(velOffsetBody);
-        gps_data.vel -= velOffsetEarth;
-    }
+
+    // TODO use a filtered angular rate with a group delay that matches the GPS delay
+    Vector3f angRate = imuDataDelayed.delAng * (1.0f/imuDataDelayed.delAngDT);
+    Vector3f velOffsetBody = angRate % posOffsetBody;
+    Vector3f velOffsetEarth = prevTnb.mul_transpose(velOffsetBody);
+    gps_data.vel -= velOffsetEarth;
+
     Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
     gps_data.pos.x -= posOffsetEarth.x;
     gps_data.pos.y -= posOffsetEarth.y;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -406,6 +406,9 @@ void NavEKF3_core::SelectVelPosFusion()
 
     // get data that has now fallen behind the fusion time horizon
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);
+    if (gpsDataToFuse) {
+        CorrectGPSForAntennaOffset(gpsDataDelayed);
+    }
 
     // initialise all possible data we may fuse
     fusePosData = false;
@@ -423,7 +426,6 @@ void NavEKF3_core::SelectVelPosFusion()
         fusePosData = true;
         extNavUsedForPos = false;
 
-        CorrectGPSForAntennaOffset(gpsDataDelayed);
 
         // copy corrected GPS data to observation vector
         if (fuseVelData) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -323,6 +323,12 @@ bool NavEKF3_core::resetHeightDatum(void)
  */
 void NavEKF3_core::CorrectGPSForAntennaOffset(gps_elements &gps_data) const
 {
+    // return immediately if already corrected
+    if (gps_data.corrected) {
+        return;
+    }
+    gps_data.corrected = true;
+
     const Vector3f &posOffsetBody = AP::gps().get_antenna_offset(gps_data.sensor_idx) - accelPosOffset;
     if (posOffsetBody.is_zero()) {
         return;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -560,6 +560,7 @@ private:
         Vector3f    vel;            // velocity of the GPS antenna in local NED earth frame (m/sec)
         uint32_t    time_ms;        // measurement timestamp (msec)
         uint8_t     sensor_idx;     // unique integer identifying the GPS sensor
+        bool        corrected;      // true when the position and velocity have been corrected for sensor position
     };
 
     struct mag_elements {


### PR DESCRIPTION
This PR makes two small changes to when EKF3 corrects the GPS position and velocity for antenna position.  These changes have been broken out from the EKF active source PR https://github.com/ArduPilot/ardupilot/pull/14803 in order to reduce its complexity.

1. gpsDataDelayed is corrected immediately after it is recalled from the buffer instead of a few lines lower down.  The functional impact is that the delayed GPS data is always corrected even if it is not fused.  This is important for the larger PR because the GPS is more likely to be enabled but not used.  More broadly though this reduces the chance that uncorrected GPS data could be used for altitude or heading
2. CorrectGPSForAntennaOffset always corrects the velocity data instead of only when **fuseVelData** is true.

  - The advantage is that this allows the GPS velocities to be used (for yaw or whatever) even if they are not being fused into the EKF's velocity estimate.  Also **fuseVelData** can be true when we are fusing ExtNav velocities.
  - This also reduces the chance of errors by callers who are not aware of this hidden **fuseVelData** check within the function.  For example ResetVelocity() uses the method to correct **gpsDataNew**.
  - The danger is that some parts of the code rely on the GPS velocity values being zero as a way to know whether the GPS provides velocity instead of checking "frontend->_fusionModeGPS <= 1" (Note: 0 = use 3D velocity, 1 = use 2D velocity, 2 = use no velocity).  [realignYawGPS()](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp#L139) is the only case I found where this **could** be a problem but I don't think it actually is because it checks for a velocity of 5m/s which is quite a large velocity to be caused by an attitude change.

This change has been tested in SITL:

- AHRS_EKF_TYPE=3, EK3_ENABLE=1, EK2_ENABLE=0 (to enabled EKF3)
- param set SIM_GPS_POS1_Z 5 (to simulate GPS placed 5m below frame)
- param set GPS_POS1_Z 5 (to configure AP to know the GPS is placed 5m below frame)
- Loiter
- arm throttle
- rc 3 2000 (to climb to 10m)
- rc 3 1500 (to hover)
- rc 2 1200 (to fly foward quickly about 50m)
- rc 2 1500 (to level out)
- RTL (to complete the test)

Below are screeshots of the resulting "before" and "after" NED velocity innovations and we see they are very similar.  Perhaps "after" is slightly better but this is likely just "environment" factors because the tests were run manually so inevitably the vehicle reached a slightly different speed, etc.
![before-after](https://user-images.githubusercontent.com/1498098/96806339-c9c3f780-144e-11eb-9d94-b3e3841fe3ee.png)

These changes have also been tested on a real vehicle as part of the larger active EKF source PR https://github.com/ArduPilot/ardupilot/pull/14803