### PR TITLE
Copter: cope with race conditioning popping points on SmartRTL return

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1165,6 +1165,10 @@ private:
     void land();
     SmartRTLState smart_rtl_state = SmartRTL_PathFollow;
 
+    // keep track of how long we have failed to get another return
+    // point while following our path home.  If we take too long we
+    // may choose to land the vehicle.
+    uint32_t path_follow_last_pop_fail_ms;
 };
 
 

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -74,6 +74,7 @@ void ModeSmartRTL::wait_cleanup_run()
 
     // check if return path is computed and if yes, begin journey home
     if (g2.smart_rtl.request_thorough_cleanup()) {
+        path_follow_last_pop_fail_ms = 0;
         smart_rtl_state = SmartRTL_PathFollow;
     }
 }
@@ -92,7 +93,10 @@ void ModeSmartRTL::path_follow_run()
     // if we are close to current target point, switch the next point to be our target.
     if (wp_nav->reached_wp_destination()) {
         Vector3f next_point;
+        // this pop_point can fail if the IO task currently has the
+        // path semaphore.
         if (g2.smart_rtl.pop_point(next_point)) {
+            path_follow_last_pop_fail_ms = 0;
             bool fast_waypoint = true;
             if (g2.smart_rtl.get_num_points() == 0) {
                 // this is the very last point, add 2m to the target alt and move to pre-land state
@@ -103,8 +107,18 @@ void ModeSmartRTL::path_follow_run()
             // send target to waypoint controller
             wp_nav->set_wp_destination_NED(next_point);
             wp_nav->set_fast_waypoint(fast_waypoint);
-        } else {
-            // this can only happen if we fail to get the semaphore which should never happen but just in case, land
+        } else if (g2.smart_rtl.get_num_points() == 0) {
+            // We should never get here; should always have at least
+            // two points and the "zero points left" is handled above.
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            smart_rtl_state = SmartRTL_PreLandPosition;
+        } else if (path_follow_last_pop_fail_ms == 0) {
+            // first time we've failed to pop off (ever, or after a success)
+            path_follow_last_pop_fail_ms = AP_HAL::millis();
+        } else if (AP_HAL::millis() - path_follow_last_pop_fail_ms > 10000) {
+            // we failed to pop a point off for 10 seconds.  This is
+            // almost certainly a bug.
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
             smart_rtl_state = SmartRTL_PreLandPosition;
         }
     }


### PR DESCRIPTION
There is a race with the cleanup thread.  While thin, it only has to
happen once.  After this patch the race would have to happen... a lot.

This is an alternative to https://github.com/ArduPilot/ardupilot/pull/14420

I've tested this in SITL using the following commands:
```
mode guided
arm throttle
takeoff 10
mode circle
.
.
.
mode smart_rtl
```

I was using the following test code to simulate not getting the sempahore:

```
diff --git a/libraries/AP_SmartRTL/AP_SmartRTL.cpp b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
index a577cc4989..ac90463ec6 100644
--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -133,6 +133,8 @@ uint16_t AP_SmartRTL::get_num_points() const
     return _path_points_count;
 }
 
+static uint32_t pop_point_start;
+
 // get next point on the path to home, returns true on success
 bool AP_SmartRTL::pop_point(Vector3f& point)
 {
@@ -140,6 +142,17 @@ bool AP_SmartRTL::pop_point(Vector3f& point)
     if (!_active) {
         return false;
     }
+    const uint32_t now = AP_HAL::millis();
+    uint32_t delta = now - pop_point_start;
+    if (pop_point_start == 0) {
+        pop_point_start = now;
+    } else if (now - pop_point_start > 5000 &&
+               now - pop_point_start < 10000) {
+        ::fprintf(stderr, "Failing\n");
+        return false;
+    } else {
+        ::fprintf(stderr, "delta: %u\n", delta);
+    }
 
     // get semaphore
     if (!_path_sem.take_nonblocking()) {
```

(because we use recursive semaphores, and we're single-threaded in SITL, taking the semaphore for prolonged periods of time is useless)

This is what happens if you don't get the semaphore for 5 seconds:
![image](https://user-images.githubusercontent.com/7077857/96943333-81c2d480-1523-11eb-9ac9-cb53d8246b7e.png)

![image](https://user-images.githubusercontent.com/7077857/96943414-ca7a8d80-1523-11eb-975f-702d5d29e48d.png)

![image](https://user-images.githubusercontent.com/7077857/96943439-dd8d5d80-1523-11eb-8976-9aed8298f0ee.png)

So that looks like a smooth stop at the current waypoint until we can get another one.

If we fail to pop for more than 10 seconds, the vehicle will throw an internal error and land :

![image](https://user-images.githubusercontent.com/7077857/96943526-25ac8000-1524-11eb-8cf9-f1d4c3549b4d.png)
