### PR TITLE
Fixed EKF yaw reset bug

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1693,7 +1693,7 @@ bool NavEKF2::isExtNavUsedForYaw() const
 void NavEKF2::requestYawReset(void)
 {
     for (uint8_t i = 0; i < num_cores; i++) {
-        core[primary].EKFGSF_requestYawReset();
+        core[i].EKFGSF_requestYawReset();
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -978,7 +978,7 @@ void NavEKF3::checkLaneSwitch(void)
 void NavEKF3::requestYawReset(void)
 {
     for (uint8_t i = 0; i < num_cores; i++) {
-        core[primary].EKFGSF_requestYawReset();
+        core[i].EKFGSF_requestYawReset();
     }
 }
 


### PR DESCRIPTION
This will affect yaw reset when nearing end of EKF failsafe counter in copter

Bug reported here:
https://discuss.ardupilot.org/t/something-fishy-in-the-yaw-reset-code/63355
thanks to Alex Burka for noticing this!

Note that the bug won't have a significant impact, as primary code is reset, and that is the one we're using