### PR TITLE
Fixed deadlock in sdcard mount/unmount

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -23,6 +23,7 @@
 #include <AP_RTC/AP_RTC.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Filesystem/AP_Filesystem.h>
 
 #include <stdio.h>
 
@@ -337,7 +338,7 @@ void AP_BoardConfig::init()
     uint8_t slowdown = constrain_int16(_sdcard_slowdown.get(), 0, 32);
     const uint8_t max_slowdown = 8;
     do {
-        if (hal.util->fs_init()) {
+        if (AP::FS().retry_mount()) {
             break;
         }
         slowdown++;

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -57,7 +57,7 @@ const AP_Filesystem::Backend AP_Filesystem::backends[] = {
 
 #define MAX_FD_PER_BACKEND 256U
 #define NUM_BACKENDS ARRAY_SIZE(backends)
-#define LOCAL_BACKEND backends[0];
+#define LOCAL_BACKEND backends[0]
 #define BACKEND_IDX(backend) (&(backend) - &backends[0])
 
 /*
@@ -213,6 +213,18 @@ bool AP_Filesystem::set_mtime(const char *filename, const uint32_t mtime_sec)
 {
     const Backend &backend = backend_by_path(filename);
     return backend.fs.set_mtime(filename, mtime_sec);
+}
+
+// if filesystem is not running then try a remount
+bool AP_Filesystem::retry_mount(void)
+{
+    return LOCAL_BACKEND.fs.retry_mount();
+}
+
+// unmount filesystem for reboot
+void AP_Filesystem::unmount(void)
+{
+    return LOCAL_BACKEND.fs.unmount();
 }
 
 namespace AP

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -83,6 +83,12 @@ public:
     // set modification time on a file
     bool set_mtime(const char *filename, const uint32_t mtime_sec);
 
+    // if filesystem is not running then try a remount. Return true if fs is mounted
+    bool retry_mount(void);
+
+    // unmount filesystem for reboot
+    void unmount(void);
+    
 private:
     struct Backend {
         const char *prefix;

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -818,6 +818,24 @@ bool AP_Filesystem_FATFS::set_mtime(const char *filename, const uint32_t mtime_s
 }
 
 /*
+  retry mount of filesystem if needed
+*/
+bool AP_Filesystem_FATFS::retry_mount(void)
+{
+    WITH_SEMAPHORE(sem);
+    return sdcard_retry();
+}
+
+/*
+  unmount filesystem for reboot
+*/
+void AP_Filesystem_FATFS::unmount(void)
+{
+    WITH_SEMAPHORE(sem);
+    return sdcard_stop();
+}
+
+/*
   convert POSIX errno to text with user message.
 */
 char *strerror(int errnum)

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
@@ -48,4 +48,10 @@ public:
 
     // set modification time on a file
     bool set_mtime(const char *filename, const uint32_t mtime_sec) override;
+
+    // retry mount of filesystem if needed
+    bool retry_mount(void) override;
+
+    // unmount filesystem for reboot
+    void unmount(void) override;
 };

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -49,4 +49,10 @@ public:
 
     // set modification time on a file
     virtual bool set_mtime(const char *filename, const uint32_t mtime_sec) { return false; }
+
+    // retry mount of filesystem if needed
+    virtual bool retry_mount(void) { return true; }
+
+    // unmount filesystem for reboot
+    virtual void unmount(void) {}
 };

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -179,11 +179,6 @@ public:
      */
     virtual uint32_t available_memory(void) { return 4096; }
 
-    /*
-      initialise (or re-initialise) filesystem storage
-     */
-    virtual bool fs_init(void) { return false; }
-
     // attempt to trap the processor, presumably to enter an attached debugger
     virtual bool trap() const { return false; }
 

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -22,7 +22,6 @@
 #include "Scheduler.h"
 #include "hwdef/common/flash.h"
 #include <AP_Filesystem/AP_Filesystem.h>
-#include "sdcard.h"
 #include <stdio.h>
 
 using namespace ChibiOS;
@@ -88,7 +87,7 @@ void Storage::_storage_open(void)
         }
 
         // use microSD based storage
-        if (sdcard_retry()) {
+        if (AP::FS().retry_mount()) {
             log_fd = AP::FS().open(HAL_STORAGE_FILE, O_RDWR|O_CREAT);
             if (log_fd == -1) {
                 ::printf("open failed of " HAL_STORAGE_FILE "\n");
@@ -145,7 +144,7 @@ void Storage::_save_backup(void)
     // We want to do this desperately,
     // So we keep trying this for a second
     uint32_t start_millis = AP_HAL::millis();
-    while(!sdcard_retry() && (AP_HAL::millis() - start_millis) < 1000) {
+    while(!AP::FS().retry_mount() && (AP_HAL::millis() - start_millis) < 1000) {
         hal.scheduler->delay(1);        
     }
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -288,16 +288,6 @@ bool Util::get_system_id_unformatted(uint8_t buf[], uint8_t &len)
     return true;
 }
 
-#ifdef USE_POSIX
-/*
-  initialise filesystem
- */
-bool Util::fs_init(void)
-{
-    return sdcard_retry();
-}
-#endif
-
 // return true if the reason for the reboot was a watchdog reset
 bool Util::was_watchdog_reset() const
 {

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -55,13 +55,6 @@ public:
     void toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms) override;
 #endif
 
-#ifdef USE_POSIX
-    /*
-      initialise (or re-initialise) filesystem storage
-     */
-    bool fs_init(void) override;
-#endif
-
     // return true if the reason for the reboot was a watchdog reset
     bool was_watchdog_reset() const override;
 

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -80,8 +80,6 @@ bool sdcard_init()
         }
         printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
 
-        // Create APM Directory if needed
-        AP::FS().mkdir("/APM");
         sdcard_running = true;
         return true;
     }
@@ -124,9 +122,6 @@ bool sdcard_init()
             continue;
         }
         printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
-
-        // Create APM Directory if needed
-        AP::FS().mkdir("/APM");
         return true;
     }
 #endif
@@ -163,7 +158,10 @@ bool sdcard_retry(void)
 {
 #ifdef USE_POSIX
     if (!sdcard_running) {
-        sdcard_init();
+        if (sdcard_init()) {
+            // create APM directory
+            AP::FS().mkdir("/APM");
+        }
     }
     return sdcard_running;
 #endif


### PR DESCRIPTION
This fixes a deadlock (and watchdog reset) for the following situation:
 - LOG_DISARMED=1 while disarmed
 - boot with sdcard inserted
 - remove sdcard after boot
 - wait more than 3s
 - re-insert sdcard
 - request a log list using mavlink

The underlying problem is that FATFS f_* APIs were being called without the AP_Filesystem semaphore held. The fix is to always do mount/unmount operations via AP_Filesystem

Note that while this can cause a watchdog, I don't believe it can happen when armed, so it isn't flight critical