### PR TITLE
AP_CANManager: return max number of drivers for get_num_drivers

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -64,7 +64,7 @@ public:
     // returns number of active CAN Drivers
     uint8_t get_num_drivers(void) const
     {
-        return _num_drivers;
+        return HAL_MAX_CAN_PROTOCOL_DRIVERS;
     }
 
     // return driver for index i


### PR DESCRIPTION
We were missing the second protocol driver, in case only second protocol driver was initialised. By returning MAX_CAN_PROTOCOL_DRIVERS we ensure that we scan through all protocol drivers. If uninitialised, the get_driver returns Driver_Type_None, and if driver specific calls like get_kdecan get called nullptr is returned, and handled accordingly.
