### PR TITLE
AP_NavEKF3: pos timeout or glitch does not reset vel if fusing succes…

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -306,7 +306,7 @@ void NavEKF3_core::setAidingMode()
              } else if (posAidLossCritical) {
                 // if the loss of position is critical, declare all sources of position aiding as being timed out
                 posTimeout = true;
-                velTimeout = true;
+                velTimeout = !optFlowUsed && !gpsVelUsed && !bodyOdmUsed;
                 rngBcnTimeout = true;
                 gpsNotAvailable = true;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -710,11 +710,8 @@ void NavEKF3_core::FuseVelPosNED()
                 if (posTimeout || ((P[8][8] + P[7][7]) > sq(float(frontend->_gpsGlitchRadiusMax)))) {
                     // reset the position to the current external sensor position
                     ResetPosition(resetDataSource::DEFAULT);
-                    // reset the velocity to the external sensor velocity
-                    ResetVelocity(resetDataSource::DEFAULT);
                     // don't fuse external sensor data on this time step
                     fusePosData = false;
-                    fuseVelData = false;
                     // Reset the position variances and corresponding covariances to a value that will pass the checks
                     zeroRows(P,7,8);
                     zeroCols(P,7,8);
@@ -722,7 +719,13 @@ void NavEKF3_core::FuseVelPosNED()
                     P[8][8] = P[7][7];
                     // Reset the normalised innovation to avoid failing the bad fusion tests
                     posTestRatio = 0.0f;
-                    velTestRatio = 0.0f;
+                    // also reset velocity if it has timed out
+                    if (velTimeout) {
+                        // reset the velocity to the external sensor velocity
+                        ResetVelocity(resetDataSource::DEFAULT);
+                        fuseVelData = false;
+                        velTestRatio = 0.0f;
+                    }
                 }
             } else {
                 posHealth = false;


### PR DESCRIPTION
This PR improves the recovery from optical flow to GPS by **not** resetting the EKF's velocity estimate if the GPS's velocity, optical flow, visual odometry or wheel encoders are successfully being fused.  This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/15646

Below are before and after shots from SITL of the EKF's velocity estimates.  In the before we see that the velocities are constantly being reset which leads to the vehicle's pitch twitching constantly.

![gps-re-enabled-before](https://user-images.githubusercontent.com/1498098/97129073-51787180-1781-11eb-88e5-6d95a9411da8.png)

![gps-re-enabled-after](https://user-images.githubusercontent.com/1498098/97129083-55a48f00-1781-11eb-9655-5296127bea84.png)

I also tested GPS Glitch and loss of GPS in master vs this new branch and there are some differences as shown below.  In particular in master it does not seem to recover the velocity estimate until the vehicle nearly stops.  The green line shows when the pilot has the pitch stick pressed forward (low = forward).  Note that in master the GPS velocity only recovers once the pilot returns the pitch stick to center.  I think this PR performs better than master in this case as well.

![master-gps-glitch-test](https://user-images.githubusercontent.com/1498098/97132210-96a0a180-1789-11eb-8ab7-7c9257af2dbe.png)

![new-gps-glitch-test](https://user-images.githubusercontent.com/1498098/97132214-9a342880-1789-11eb-8292-ce771d601de0.png)


