### PR TITLE
AP_Scripting: Add setmetatable back to the lua sandbox

### DIFF
--- a/libraries/AP_Scripting/lua/src/lbaselib.c
+++ b/libraries/AP_Scripting/lua/src/lbaselib.c
@@ -474,7 +474,7 @@ static const luaL_Reg base_funcs[] = {
 //  {"rawget", luaB_rawget},
 //  {"rawset", luaB_rawset},
 //  {"select", luaB_select},
-//  {"setmetatable", luaB_setmetatable},
+  {"setmetatable", luaB_setmetatable},
   {"tonumber", luaB_tonumber},
   {"tostring", luaB_tostring},
   {"type", luaB_type},


### PR DESCRIPTION
This enables proper OOP implementation in Lua. `setmetatable` is much safer then I had been thinking (I had mentally swapped it with what you can do with `debug.setmetatable` which is unsafe. This allows us to do proper OOP stuff such as what's depicted [here](http://lua-users.org/wiki/ObjectOrientationTutorial). This replaces the sytle shown here: #14350. The significant win of this is that this enabled object oriented usage without using nearly as much memory for each object.