### PR TITLE
AP_Math: Log source line of constrain_float nan's

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1169,6 +1169,7 @@ struct PACKED log_Performance {
     uint32_t max_time;
     uint32_t mem_avail;
     uint16_t load;
+    uint16_t internal_error_last_line;
     uint32_t internal_errors;
     uint32_t internal_error_count;
     uint32_t spi_count;
@@ -2025,11 +2026,12 @@ struct PACKED log_PSC {
 // @Field: Mem: Free memory available
 // @Field: Load: System processor load
 // @Field: IntE: Internal error mask; which internal errors have been detected
-// @Field: IntEC: Internal error count; how many internal errors have been detected
+// @Field: ErrL: Internal error line number; last line number on which a internal error was detected
+// @Field: ErrC: Internal error count; how many internal errors have been detected
 // @Field: SPIC: Number of SPI transactions processed
 // @Field: I2CC: Number of i2c transactions processed
 // @Field: I2CI: Number of i2c interrupts serviced
-// @Field: ExUS: number of microseconds being added to each loop to address scheduler overruns
+// @Field: Ex: number of microseconds being added to each loop to address scheduler overruns
 
 // @LoggerMessage: POS
 // @Description: Canonical vehicle position
@@ -2559,7 +2561,7 @@ struct PACKED log_PSC {
     { LOG_PROXIMITY_MSG, sizeof(log_Proximity), \
       "PRX", "QBfffffffffff", "TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315,DUp,CAn,CDis", "s-mmmmmmmmmhm", "F-00000000000" }, \
     { LOG_PERFORMANCE_MSG, sizeof(log_Performance),                     \
-      "PM",  "QHHIIHIIIIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,IntE,IntEC,SPIC,I2CC,I2CI,ExUS", "s---b%-----s", "F---0A-----F" }, \
+      "PM",  "QHHIIHHIIIIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,ErrL,IntE,ErrC,SPIC,I2CC,I2CI,Ex", "s---b%------s", "F---0A------F" }, \
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
       "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }, \
     { LOG_OA_BENDYRULER_MSG, sizeof(log_OABendyRuler), \

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -260,6 +260,30 @@ template float wrap_2PI<float>(const float radian);
 template float wrap_2PI<double>(const double radian);
 
 template <typename T>
+T constrain_value_line(const T amt, const T low, const T high, uint32_t line)
+{
+    // the check for NaN as a float prevents propagation of floating point
+    // errors through any function that uses constrain_value(). The normal
+    // float semantics already handle -Inf and +Inf
+    if (isnan(amt)) {
+        AP::internalerror().error(AP_InternalError::error_t::constraining_nan, line);
+        return (low + high) / 2;
+    }
+
+    if (amt < low) {
+        return low;
+    }
+
+    if (amt > high) {
+        return high;
+    }
+
+    return amt;
+}
+
+template float constrain_value_line<float>(const float amt, const float low, const float high, uint32_t line);
+
+template <typename T>
 T constrain_value(const T amt, const T low, const T high)
 {
     // the check for NaN as a float prevents propagation of floating point

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -144,10 +144,14 @@ float wrap_2PI(const T radian);
 template <typename T>
 T constrain_value(const T amt, const T low, const T high);
 
-inline float constrain_float(const float amt, const float low, const float high)
-{
-    return constrain_value(amt, low, high);
-}
+template <typename T>
+T constrain_value_line(const T amt, const T low, const T high, uint32_t line);
+
+#if BOARD_FLASH_SIZE > 1024
+  #define constrain_float(amt, low, high) constrain_value_line(float(amt), float(low), float(high), uint32_t(__LINE__))
+#else
+  #define constrain_float(amt, low, high) constrain_value(float(amt), float(low), float(high))
+#endif
 
 inline int16_t constrain_int16(const int16_t amt, const int16_t low, const int16_t high)
 {

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -397,6 +397,7 @@ void AP_Scheduler::Log_Write_Performance()
         max_time         : perf_info.get_max_time(),
         mem_avail        : hal.util->available_memory(),
         load             : (uint16_t)(load_average() * 1000),
+        internal_error_last_line : AP::internalerror().last_error_line(),
         internal_errors  : AP::internalerror().errors(),
         internal_error_count : AP::internalerror().count(),
         spi_count        : pd.spi_count,


### PR DESCRIPTION
This makes tracking down the source of constrain nan internal errors *much* easier. This change causes us to log the line number where we called `constrain_float` rather then the line number inside of the `constrain_float` function, which was never very helpful, as far to many places call that.

This change does try and minimize the flash cost for small boards that are marginal, and only add's the line data on boards with more then 1MB of flash. This is a bit debatable to me, as the utility of this is so high that I think we should probably always be logging this, as if you hit this at the moment on a 1MB board it's very very difficult to diagnose what happened, whereas with this we at least have a good chance to track it down.

This whole PR has been used in anger to help actually track down the source of some constrain_nan errors in real code.

CubeOrange stats:
|Build|Target|          Text|     Data|  BSS|     Total|  
|-|-|-|-|-|-----------------------------------------|
|This PR|bin/arducopter|  1485608|  1520|  129760|  1616888|
|Master|bin/arducopter|  1484016|  1520|  129760|  1615296|
|Delta| |1592|0|0|1592|
