### PR TITLE
Fixed remapping of IO lines with BRD_ALT_CONFIG

### DIFF
--- a/libraries/AP_HAL_ChibiOS/GPIO.h
+++ b/libraries/AP_HAL_ChibiOS/GPIO.h
@@ -26,6 +26,17 @@
 #define HAL_GPIO_LED_OFF 1
 #endif
 
+/*
+  pin types for alternative configuration
+ */
+enum class PERIPH_TYPE : uint8_t {
+    UART_RX,
+    UART_TX,
+    I2C_SDA,
+    I2C_SCL,
+    OTHER,
+};
+
 class ChibiOS::GPIO : public AP_HAL::GPIO {
 public:
     GPIO();
@@ -66,7 +77,12 @@ public:
     // timer tick
     void timer_tick(void) override;
 #endif
-    
+
+    /*
+      resolve an ioline to take account of alternative configurations
+     */
+    static ioline_t resolve_alt_config(ioline_t base, PERIPH_TYPE ptype, uint8_t instance);
+
 private:
     bool _usb_connected;
     bool _ext_started;
@@ -75,6 +91,7 @@ private:
     bool _attach_interrupt(ioline_t line, palcallback_t cb, void *p, uint8_t mode);
 #ifdef HAL_PIN_ALT_CONFIG
     void setup_alt_config(void);
+    static uint8_t alt_config;
 #endif
 };
 

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -17,6 +17,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include "Util.h"
+#include "GPIO.h"
 
 #if HAL_USE_I2C == TRUE && defined(HAL_I2C_DEVICE_LIST)
 
@@ -29,6 +30,7 @@
 
 static const struct I2CInfo {
     struct I2CDriver *i2c;
+    uint8_t instance;
     uint8_t dma_channel_rx;
     uint8_t dma_channel_tx;
     ioline_t scl_line;
@@ -90,13 +92,17 @@ void I2CBus::clear_bus(uint8_t busidx)
 {
 #if HAL_I2C_CLEAR_ON_TIMEOUT
     const struct I2CInfo &info = I2CD[busidx];
-    const iomode_t mode_saved = palReadLineMode(info.scl_line);
-    palSetLineMode(info.scl_line, PAL_MODE_OUTPUT_PUSHPULL);
+    const ioline_t scl_line = GPIO::resolve_alt_config(info.scl_line, PERIPH_TYPE::I2C_SCL, info.instance);
+    if (scl_line == 0) {
+        return;
+    }
+    const iomode_t mode_saved = palReadLineMode(scl_line);
+    palSetLineMode(scl_line, PAL_MODE_OUTPUT_PUSHPULL);
     for(uint8_t j = 0; j < 20; j++) {
-        palToggleLine(info.scl_line);
+        palToggleLine(scl_line);
         hal.scheduler->delay_microseconds(10);
     }
-    palSetLineMode(info.scl_line, mode_saved);
+    palSetLineMode(scl_line, mode_saved);
 #endif
 }
 
@@ -107,10 +113,14 @@ void I2CBus::clear_bus(uint8_t busidx)
 uint8_t I2CBus::read_sda(uint8_t busidx)
 {
     const struct I2CInfo &info = I2CD[busidx];
-    const iomode_t mode_saved = palReadLineMode(info.sda_line);
-    palSetLineMode(info.sda_line, PAL_MODE_INPUT);
-    uint8_t ret = palReadLine(info.sda_line);
-    palSetLineMode(info.sda_line, mode_saved);
+    const ioline_t sda_line = GPIO::resolve_alt_config(info.sda_line, PERIPH_TYPE::I2C_SDA, info.instance);
+    if (sda_line == 0) {
+        return 0;
+    }
+    const iomode_t mode_saved = palReadLineMode(sda_line);
+    palSetLineMode(sda_line, PAL_MODE_INPUT);
+    uint8_t ret = palReadLine(sda_line);
+    palSetLineMode(sda_line, mode_saved);
     return ret;
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1346,17 +1346,17 @@ uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 void UARTDriver::set_pushpull(uint16_t options)
 {
 #if HAL_USE_SERIAL == TRUE && !defined(STM32F1)
-    if ((options & OPTION_PULLDOWN_RX) && sdef.rx_line) {
-        palLineSetPushPull(sdef.rx_line, PAL_PUSHPULL_PULLDOWN);
+    if ((options & OPTION_PULLDOWN_RX) && arx_line) {
+        palLineSetPushPull(arx_line, PAL_PUSHPULL_PULLDOWN);
     }
-    if ((options & OPTION_PULLDOWN_TX) && sdef.tx_line) {
-        palLineSetPushPull(sdef.tx_line, PAL_PUSHPULL_PULLDOWN);
+    if ((options & OPTION_PULLDOWN_TX) && atx_line) {
+        palLineSetPushPull(atx_line, PAL_PUSHPULL_PULLDOWN);
     }
-    if ((options & OPTION_PULLUP_RX) && sdef.rx_line) {
-        palLineSetPushPull(sdef.rx_line, PAL_PUSHPULL_PULLUP);
+    if ((options & OPTION_PULLUP_RX) && arx_line) {
+        palLineSetPushPull(arx_line, PAL_PUSHPULL_PULLUP);
     }
-    if ((options & OPTION_PULLUP_TX) && sdef.tx_line) {
-        palLineSetPushPull(sdef.tx_line, PAL_PUSHPULL_PULLUP);
+    if ((options & OPTION_PULLUP_TX) && atx_line) {
+        palLineSetPushPull(atx_line, PAL_PUSHPULL_PULLUP);
     }
 #endif
 }
@@ -1378,10 +1378,29 @@ bool UARTDriver::set_options(uint16_t options)
     uint32_t cr3 = sd->usart->CR3;
     bool was_enabled = (sd->usart->CR1 & USART_CR1_UE);
 
+#ifdef HAL_PIN_ALT_CONFIG
+    /*
+      allow for RX and TX pins to be remapped via BRD_ALT_CONFIG
+     */
+    arx_line = GPIO::resolve_alt_config(sdef.rx_line, PERIPH_TYPE::UART_RX, sdef.instance);
+    atx_line = GPIO::resolve_alt_config(sdef.tx_line, PERIPH_TYPE::UART_TX, sdef.instance);
+#else
+    arx_line = sdef.rx_line;
+    atx_line = sdef.tx_line;
+#endif
+
 #if defined(STM32F7) || defined(STM32H7) || defined(STM32F3)
     // F7 has built-in support for inversion in all uarts
-    ioline_t rx_line = (options & OPTION_SWAP)?sdef.tx_line:sdef.rx_line;
-    ioline_t tx_line = (options & OPTION_SWAP)?sdef.rx_line:sdef.tx_line;
+    ioline_t rx_line = (options & OPTION_SWAP)?atx_line:arx_line;
+    ioline_t tx_line = (options & OPTION_SWAP)?arx_line:atx_line;
+
+    // if we are half-duplex then treat either inversion option as
+    // both being enabled. This is easier to understand for users, who
+    // can be confused as to which pin is the one that needs inversion
+    if ((options & OPTION_HDPLEX) && (options & (OPTION_TXINV|OPTION_RXINV)) != 0) {
+        options |= OPTION_TXINV|OPTION_RXINV;
+    }
+
     if (options & OPTION_RXINV) {
         cr2 |= USART_CR2_RXINV;
         _cr2_options |= USART_CR2_RXINV;

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -68,6 +68,7 @@ public:
 
     struct SerialDef {
         BaseSequentialStream* serial;
+        uint8_t instance;
         bool is_usb;
 #ifndef HAL_UART_NODMA
         bool dma_rx;
@@ -127,6 +128,12 @@ private:
     bool rx_dma_enabled;
     bool tx_dma_enabled;
 
+    /*
+      copy of rx_line and tx_line with alternative configs resolved
+     */
+    ioline_t atx_line;
+    ioline_t arx_line;
+    
     // thread used for all UARTs
     static thread_t *uart_thread_ctx;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
@@ -116,7 +116,11 @@ void AP_RCProtocol_FPort2::decode_downlink(const FPort2_Frame &frame)
      */
     if (!telem_data.available) {
         if (!AP_Frsky_Telem::get_telem_data(telem_data.frame, telem_data.appid, telem_data.data)) {
-            return;
+            // nothing to send, send a null frame. This ensures the
+            // receiver keeps requesting data from us at the full rate
+            telem_data.frame = 0x00; 
+            telem_data.appid = 0x00; 
+            telem_data.data = 0x00;
         }
         telem_data.available = true;
     }


### PR DESCRIPTION
When a peripheral is made available via BRD_ALT_CONFIG we need to remap the existing ioline_t in the UART and I2C drivers to use the new  pin.
This fixes an issue with half-duplex, inverted, swapped UART pins for protocols like FPort and FPort2, as we were not setting them up with the right pullup/pulldown due to the incorrect rx_line and tx_line being setup in the UART config table.
This PR also fixes a related issue with FPort2 where we need to send nul packets to tell the receiver we are still interested in using a given ID

