### PR TITLE
ArduCopter: Don't request EKF yaw reset unless innovations are large

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -859,8 +859,8 @@ private:
     void startup_INS_ground();
     void update_dynamic_notch() override;
     bool position_ok() const;
-    bool ekf_position_ok() const;
-    bool optflow_position_ok() const;
+    bool ekf_has_absolute_position() const;
+    bool ekf_has_relative_position() const;
     bool ekf_alt_ok() const;
     void update_auto_armed();
     bool should_log(uint32_t mask);

--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -23,7 +23,7 @@ void Copter::update_ground_effect_detector(void)
         xy_des_speed_cms = vel_target.length();
     }
 
-    if (position_ok() || optflow_position_ok()) {
+    if (position_ok() || ekf_has_relative_position()) {
         Vector3f vel = inertial_nav.get_velocity();
         vel.z = 0.0f;
         xy_speed_cms = vel.length();
@@ -52,7 +52,7 @@ void Copter::update_ground_effect_detector(void)
     // landing logic
     Vector3f angle_target_rad = attitude_control->get_att_target_euler_cd() * radians(0.01f);
     bool small_angle_request = cosf(angle_target_rad.x)*cosf(angle_target_rad.y) > cosf(radians(7.5f));
-    bool xy_speed_low = (position_ok() || optflow_position_ok()) && xy_speed_cms <= 125.0f;
+    bool xy_speed_low = (position_ok() || ekf_has_relative_position()) && xy_speed_cms <= 125.0f;
     bool xy_speed_demand_low = pos_control->is_active_xy() && xy_des_speed_cms <= 125.0f;
     bool slow_horizontal = xy_speed_demand_low || (xy_speed_low && !pos_control->is_active_xy()) || (control_mode == Mode::Number::ALT_HOLD && small_angle_request);
 
@@ -74,7 +74,7 @@ void Copter::update_ground_effect_detector(void)
 void Copter::update_ekf_terrain_height_stable()
 {
     // set to false if no position estimate
-    if (!position_ok() && !optflow_position_ok()) {
+    if (!position_ok() && !ekf_has_relative_position()) {
         ahrs.set_terrain_hgt_stable(false);
     }
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -325,11 +325,11 @@ bool Copter::position_ok() const
     }
 
     // check ekf position estimate
-    return (ekf_position_ok() || optflow_position_ok());
+    return (ekf_has_absolute_position() || ekf_has_relative_position());
 }
 
-// ekf_position_ok - returns true if the ekf claims it's horizontal absolute position estimate is ok and home position is set
-bool Copter::ekf_position_ok() const
+// ekf_has_absolute_position - returns true if the EKF can provide an absolute WGS-84 position estimate
+bool Copter::ekf_has_absolute_position() const
 {
     if (!ahrs.have_inertial_nav()) {
         // do not allow navigation with dcm position
@@ -348,8 +348,8 @@ bool Copter::ekf_position_ok() const
     }
 }
 
-// optflow_position_ok - returns true if optical flow based position estimate is ok
-bool Copter::optflow_position_ok() const
+// ekf_has_relative_position - returns true if the EKF can provide a position estimate relative to it's starting position
+bool Copter::ekf_has_relative_position() const
 {
     // return immediately if EKF not used
     if (!ahrs.have_inertial_nav()) {


### PR DESCRIPTION
This fixes the issue reported here https://github.com/ArduPilot/ardupilot/issues/15651

This fix:

- Only asks for a yaw reset if the error is caused by large innovations, not loss of navigation due to losing sensor data.
- Uses more descriptive function names.

It has been tested using SITL Copter with the following procedure:

1. Set the following parameters to enable EKF3 use and reboot

param set EK2_ENABLE 0
param set EK3_ENABLE 1
param set AHRS_EKF_TYPE 3

2. Wait for EKF to start using GPS

3. Select loiter mode

mode LOITER

4. Arm, takeoff and climb to 5m

'arm throttle
rc 3 2000
rc 3 1500

5. Push pitch stick forward about 40%

rc 2 1300

6. Stop the GPS

param set GPS_TYPE 0

7. Wait for failsafe into land  mode and release forward stick

rc 2 1500

2020-10-28 22:34:02 EKF3 IMU0 in-flight yaw alignment complete
2020-10-28 22:34:02 Event: DATA_EKF_YAW_RESET
2020-10-28 22:34:22 Error: Subsys EKFCHECK ECode 2 
2020-10-28 22:34:22 EKF variance
2020-10-28 22:34:22 Error: Subsys FAILSAFE_EKFINAV ECode 1 
2020-10-28 22:34:29 EKF3 IMU0 stopped aiding
2020-10-28 22:34:36 SmartRTL deactivated: bad position
2020-10-28 22:34:52 SIM Hit ground at 0.439769 m/s
2020-10-28 22:34:53 Event: DATA_LAND_COMPLETE_MAYBE
2020-10-28 22:34:54 Event: DATA_LAND_COMPLETE
2020-10-28 22:34:54 Event: DATA_DISARMED
2020-10-28 22:34:54 Disarming motors
