### PR TITLE
AP_Filesystem: fixed stat call for @SYS files

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -226,7 +226,7 @@ int AP_Filesystem_Sys::stat(const char *pathname, struct stat *stbuf)
         stbuf->st_size = 0; // just a placeholder value
         return 0;
     }
-    int8_t pos = file_in_sysfs(&pathname[1]);
+    int8_t pos = file_in_sysfs(pathname);
     if (pos < 0) {
         errno = ENOENT;
         return -1;


### PR DESCRIPTION
trivial fix for stat. Note that listing in @SYS does not work in mavproxy even with this fix