### PR TITLE
Plane:  always log tailsitter speed scaling and remove unused option

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -472,9 +472,9 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
 
     // @Param: TAILSIT_GSCMSK
     // @DisplayName: Tailsitter gain scaling mask
-    // @Description: Bitmask of gain scaling methods to be applied: BOOST: boost gain at low throttle, ATT_THR: reduce gain at high throttle/tilt, INTERP: interpolate between fixed-wing and copter controls
+    // @Description: Bitmask of gain scaling methods to be applied: BOOST: boost gain at low throttle, ATT_THR: reduce gain at high throttle/tilt
     // @User: Standard
-    // @Bitmask: 0:BOOST,1:ATT_THR,2:INTERP
+    // @Bitmask: 0:BOOST,1:ATT_THR
     AP_GROUPINFO("TAILSIT_GSCMSK", 17, QuadPlane, tailsitter.gain_scaling_mask, TAILSITTER_GSCL_BOOST),
 
     // @Param: TAILSIT_GSCMIN

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2943,7 +2943,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
         target_climb_rate   : target_climb_rate_cms,
         climb_rate          : int16_t(inertial_nav.get_velocity_z()),
         throttle_mix        : attitude_control->get_throttle_mix(),
-        speed_scaler        : last_spd_scaler,
+        speed_scaler        : log_spd_scaler,
         transition_state    : static_cast<uint8_t>(transition_state)
     };
     plane.logger.WriteBlock(&pkt, sizeof(pkt));

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -515,7 +515,8 @@ private:
     } tailsitter;
 
     // tailsitter speed scaler
-    float last_spd_scaler = 1.0f;
+    float last_spd_scaler = 1.0f; // used to slew rate limiting with TAILSITTER_GSCL_ATT_THR option
+    float log_spd_scaler; // for QTUN log
 
     // the attitude view of the VTOL attitude controller
     AP_AHRS_View *ahrs_view;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -494,7 +494,6 @@ private:
     enum tailsitter_gscl_mask {
         TAILSITTER_GSCL_BOOST   = (1U<<0),
         TAILSITTER_GSCL_ATT_THR = (1U<<1),
-        TAILSITTER_GSCL_INTERP  = (1U<<2),
     };
 
     // tailsitter control variables

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -338,6 +338,9 @@ void QuadPlane::tailsitter_speed_scaling(void)
         }
     }
 
+    // record for QTUN log
+    log_spd_scaler = spd_scaler;
+
     const SRV_Channel::Aux_servo_function_t functions[] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,


### PR DESCRIPTION
This removes the unused `Q_TAILSIT_GSCMSK` option `2:INTERP`

~~It constrains the max sailing in `ATT_THR` to that set with `Q_TAILSIT_THSCMX`~~

And it always logs the speed scale factor rather than only in  `ATT_THR` mode.

Should be no functional change