### PR TITLE
Copter: Add the name of the GCS that has the GCS number

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -52,7 +52,7 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Param: SYSID_MYGCS
     // @DisplayName: My ground station number
-    // @Description: Allows restricting radio overrides to only come from my ground station
+    // @Description: Allows restricting radio overrides to only come from my ground station. 255:Mission Planner and DroidPlanner, 252:APM Planner2
     // @Range: 1 255
     // @User: Advanced
     GSCALAR(sysid_my_gcs,   "SYSID_MYGCS",     255),


### PR DESCRIPTION
I use Mission Planner and APM PLANNER2.
I think it would be good to have a description of the GCS to which you are assigning the GCS number.
Without this description, you may end up assigning the same number to different GCSs.
I use the number of the GCS to change the process.
I am aware that MissionPlanner and APM PLANNER2 support different messages.