### PR TITLE
Plane: tailsitter: remove VTOL transition race condition and use stopping point to init alt

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -377,7 +377,8 @@ void Plane::stabilize()
     }
     float speed_scaler = get_speed_scaler();
 
-    if (quadplane.in_tailsitter_vtol_transition()) {
+    uint32_t now = AP_HAL::millis();
+    if (quadplane.in_tailsitter_vtol_transition(now)) {
         /*
           during transition to vtol in a tailsitter try to raise the
           nose rapidly while keeping the wings level
@@ -386,7 +387,6 @@ void Plane::stabilize()
         nav_roll_cd = 0;
     }
 
-    uint32_t now = AP_HAL::millis();
     if (now - last_stabilize_ms > 2000) {
         // if we haven't run the rate controllers for 2 seconds then
         // reset the integrators
@@ -411,7 +411,7 @@ void Plane::stabilize()
                 control_mode == &mode_qrtl ||
                 control_mode == &mode_qacro ||
                 control_mode == &mode_qautotune) &&
-               !quadplane.in_tailsitter_vtol_transition()) {
+               !quadplane.in_tailsitter_vtol_transition(now)) {
         quadplane.control_run();
     } else {
         if (g.stick_mixing == STICK_MIXING_FBW && control_mode != &mode_stabilize) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -956,10 +956,15 @@ void QuadPlane::run_z_controller(void)
 {
     const uint32_t now = AP_HAL::millis();
     if (now - last_pidz_active_ms > 2000) {
-        // set alt target to current height on transition. This
-        // starts the Z controller off with the right values
-        gcs().send_text(MAV_SEVERITY_INFO, "Reset alt target to %.1f", (double)inertial_nav.get_altitude() / 100);
-        set_alt_target_current();
+        if (!is_tailsitter()) {
+            // set alt target to current height on transition. This
+            // starts the Z controller off with the right values
+            set_alt_target_current();
+        } else {
+            // tailsitters gain lots of vertical speed in transisison, set target to the stopping point
+            pos_control->set_target_to_stopping_point_z();
+        }
+        gcs().send_text(MAV_SEVERITY_INFO, "Reset alt target to %.1f", (double)pos_control->get_alt_target() * 0.01f);
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
 
         // initialize vertical speeds and leash lengths

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -83,8 +83,8 @@ public:
     /*
       return true if we are a tailsitter transitioning to VTOL flight
     */
-    bool in_tailsitter_vtol_transition(void) const;
-    
+    bool in_tailsitter_vtol_transition(uint32_t now = 0) const;
+
     bool handle_do_vtol_transition(enum MAV_VTOL_STATE state);
 
     bool do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -262,9 +262,19 @@ void QuadPlane::tailsitter_check_input(void)
 /*
   return true if we are a tailsitter transitioning to VTOL flight
  */
-bool QuadPlane::in_tailsitter_vtol_transition(void) const
+bool QuadPlane::in_tailsitter_vtol_transition(uint32_t now) const
 {
-    return is_tailsitter() && in_vtol_mode() && transition_state == TRANSITION_ANGLE_WAIT_VTOL;
+    if (!is_tailsitter() || !in_vtol_mode()) {
+        return false;
+    }
+    if (transition_state == TRANSITION_ANGLE_WAIT_VTOL) {
+        return true;
+    }
+    if ((now != 0) && ((now - last_vtol_mode_ms) > 1000)) {
+        // only just come out of forward flight
+        return true;
+    }
+    return false;
 }
 
 /*


### PR DESCRIPTION
This removes a race condition that causes the target altitude to be set early (and runs the motor for one loop when the shouldn't). This was due to being in a VTOL mode for one run of `Plane::stabilize()` before `QuadPlane::update(void)` has a chance to set the transition state. 

Before:
![before](https://user-images.githubusercontent.com/33176108/97764913-191dbe00-1b08-11eb-8f3a-12e25e47dc62.png)

After:
![image](https://user-images.githubusercontent.com/33176108/97764965-479b9900-1b08-11eb-8977-ad46bb43be87.png)

This also removes the unnecessary function `QuadPlane::set_alt_target_current(void)` and uses the identical `pos_control->set_alt_target_to_current_alt()` call instead.

Finally this uses `pos_control->set_target_to_stopping_point_z()` when entering a VTOL mode for tailsitters, this better deals with the high vertical speed they often have.