### PR TITLE
AP_Periph for UAVCAN to various RCOUT translations

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -125,9 +125,16 @@ void AP_Periph_FW::init()
     battery.lib.init();
 #endif
 
-#ifdef HAL_PERIPH_NEOPIXEL_COUNT
+#if defined(HAL_PERIPH_NEOPIXEL_COUNT) || defined(HAL_PERIPH_ENABLE_RC_OUT)
     hal.rcout->init();
+#endif
+
+#ifdef HAL_PERIPH_NEOPIXEL_COUNT
     hal.rcout->set_serial_led_num_LEDs(HAL_PERIPH_NEOPIXEL_CHAN, AP_HAL::RCOutput::MODE_NEOPIXEL);
+#endif
+
+#ifdef HAL_PERIPH_ENABLE_RC_OUT
+    rcout_init();
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_ADSB
@@ -271,6 +278,10 @@ void AP_Periph_FW::update()
 
 #ifdef HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_CMD_PORT
         check_for_serial_reboot_cmd(HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_CMD_PORT);
+#endif
+
+#ifdef HAL_PERIPH_ENABLE_RC_OUT
+        SRV_Channels::enable_aux_servos();
 #endif
     }
 

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -46,9 +46,11 @@ public:
     void can_battery_update();
 
     void load_parameters();
+    void prepare_reboot();
 
+#ifdef HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_CMD_PORT
     void check_for_serial_reboot_cmd(const int8_t serial_index);
-    void reboot(bool hold_in_bootloader);
+#endif
 
     AP_SerialManager serial_manager;
 
@@ -133,6 +135,7 @@ public:
     SRV_Channels servo_channels;
 
     void rcout_init();
+    void rcout_init_1Hz();
     void rcout_esc(int16_t *rc, uint8_t num_channels);
     void rcout_srv(const uint8_t actuator_id, const float command_value);
     void rcout_update();

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -5,6 +5,7 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_Baro/AP_Baro.h>
+#include "SRV_Channel/SRV_Channel.h"
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
@@ -127,7 +128,17 @@ public:
     HWESC_Telem hwesc_telem;
     void hwesc_telem_update();
 #endif
-    
+
+#ifdef HAL_PERIPH_ENABLE_RC_OUT
+    SRV_Channels servo_channels;
+
+    void rcout_init();
+    void rcout_esc(int16_t *rc, uint8_t num_channels);
+    void rcout_srv(const uint8_t actuator_id, const float command_value);
+    void rcout_update();
+    void rcout_handle_safety_state(uint8_t safety_state);
+#endif
+
     // setup the var_info table
     AP_Param param_loader{var_info};
 

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -113,6 +113,13 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     GSCALAR(esc_number, "ESC_NUMBER", 0),
 #endif
 
+#ifdef HAL_PERIPH_ENABLE_RC_OUT
+    // Servo driver
+    // @Group: OUT
+    // @Path: ../libraries/SRV_Channel/SRV_Channels.cpp
+    GOBJECT(servo_channels, "OUT",     SRV_Channels),
+#endif
+
     AP_VAREND
 };
 

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -32,6 +32,7 @@ public:
         k_param_debug,
         k_param_serial_number,
         k_param_adsb_port,
+        k_param_servo_channels,
     };
 
     AP_Int16 format_version;

--- a/Tools/AP_Periph/README.md
+++ b/Tools/AP_Periph/README.md
@@ -34,6 +34,7 @@ UAVCAN sensor types. Support is included for:
  - LEDs (GPIO, I2C or WS2812 serial)
  - Safety LED and Safety Switch
  - Buzzer (tonealarm or simple GPIO)
+ - RC Output (All standard RCOutput protocols)
 
 An AP_Periph UAVCAN firmware supports these UAVCAN features:
 

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -451,10 +451,13 @@ static void handle_allocation_response(CanardInstance* ins, CanardRxTransfer* tr
 /*
   fix value of a float for canard float16 format
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 static void fix_float16(float &f)
 {
     *(uint16_t *)&f = canardConvertNativeFloatToFloat16(f);
 }
+#pragma GCC diagnostic pop
 
 
 #ifdef HAL_PERIPH_ENABLE_BUZZER

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -389,6 +389,7 @@ static void handle_begin_firmware_update(CanardInstance* ins, CanardRxTransfer* 
 
     // instant reboot, with backup register used to give bootloader
     // the node_id
+    periph.prepare_reboot();
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     set_fast_reboot((rtc_boot_magic)(RTC_BOOT_CANBL | canardGetLocalNodeID(ins)));
     NVIC_SystemReset();
@@ -772,6 +773,7 @@ static void onTransferReceived(CanardInstance* ins,
     case UAVCAN_PROTOCOL_RESTARTNODE_ID:
         printf("RestartNode\n");
         hal.scheduler->delay(10);
+        periph.prepare_reboot();
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
         NVIC_SystemReset();
 #elif CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -1,0 +1,100 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_HAL/AP_HAL.h>
+#ifdef HAL_PERIPH_ENABLE_RC_OUT
+#include "AP_Periph.h"
+
+// magic value from UAVCAN driver packet
+// dsdl/uavcan/equipment/esc/1030.RawCommand.uavcan
+// Raw ESC command normalized into [-8192, 8191]
+#define UAVCAN_ESC_MAX_VALUE    8191
+
+#define SERVO_OUT_RCIN_MAX      16  // SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16
+#define SERVO_OUT_MOTOR_MAX     12  // SRV_Channel::k_motor1 ... SRV_Channel::k_motor8, SRV_Channel::k_motor9 ... SRV_Channel::k_motor12
+
+#if HAL_PWM_COUNT == 0
+    #error "You must define a PWM output in your hwdef.dat"
+#endif
+
+static bool has_new_data_to_update;
+
+extern const AP_HAL::HAL &hal;
+
+void AP_Periph_FW::rcout_init()
+{
+    for (uint8_t i=0; i<HAL_PWM_COUNT; i++) {
+        servo_channels.set_default_function(i, SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i));
+    }
+
+    for (uint8_t i=0; i<SERVO_OUT_RCIN_MAX; i++) {
+        SRV_Channels::set_angle(SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i), 1000);
+    }
+    for (uint8_t i=0; i<SERVO_OUT_MOTOR_MAX; i++) {
+        SRV_Channels::set_angle(SRV_Channels::get_motor_function(i), UAVCAN_ESC_MAX_VALUE);
+    }
+}
+
+void AP_Periph_FW::rcout_esc(int16_t *rc, uint8_t num_channels)
+{
+    if (rc == nullptr) {
+        return;
+    }
+
+    const uint8_t channel_count = MIN(num_channels, SERVO_OUT_MOTOR_MAX);
+    for (uint8_t i=0; i<channel_count; i++) {
+        SRV_Channels::set_output_scaled(SRV_Channels::get_motor_function(i), rc[i]);
+    }
+
+    has_new_data_to_update = true;
+}
+
+void AP_Periph_FW::rcout_srv(uint8_t actuator_id, const float command_value)
+{
+    if ((actuator_id == 0) || (actuator_id > HAL_PWM_COUNT)) {
+        // not supported or out of range
+        return;
+    }
+
+    const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + actuator_id - 1);
+    SRV_Channels::set_output_norm(function, command_value);
+
+    has_new_data_to_update = true;
+}
+
+void AP_Periph_FW::rcout_handle_safety_state(uint8_t safety_state)
+{
+    if (safety_state == 255) {
+        hal.rcout->force_safety_off();
+    } else {
+        hal.rcout->force_safety_on();
+    }
+    has_new_data_to_update = true;
+}
+
+void AP_Periph_FW::rcout_update()
+{
+    if (!has_new_data_to_update) {
+        return;
+    }
+    has_new_data_to_update = false;
+
+    SRV_Channels::calc_pwm();
+    SRV_Channels::cork();
+    SRV_Channels::output_ch_all();
+    SRV_Channels::push();
+}
+
+#endif // HAL_PERIPH_ENABLE_RC_OUT
+

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -34,6 +34,9 @@ extern const AP_HAL::HAL &hal;
 
 void AP_Periph_FW::rcout_init()
 {
+    // start up with safety enabled. This disables the pwm output until we receive an packet from the rempte system
+    hal.rcout->force_safety_on();
+
     for (uint8_t i=0; i<HAL_PWM_COUNT; i++) {
         servo_channels.set_default_function(i, SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i));
     }
@@ -43,6 +46,19 @@ void AP_Periph_FW::rcout_init()
     }
     for (uint8_t i=0; i<SERVO_OUT_MOTOR_MAX; i++) {
         SRV_Channels::set_angle(SRV_Channels::get_motor_function(i), UAVCAN_ESC_MAX_VALUE);
+    }
+
+    // run this once and at 1Hz to configure aux and esc ranges
+    rcout_init_1Hz();
+}
+
+void AP_Periph_FW::rcout_init_1Hz()
+{
+    // this runs at 1Hz to allow for run-time param changes
+    SRV_Channels::enable_aux_servos();
+
+    for (uint8_t i=0; i<SERVO_OUT_MOTOR_MAX; i++) {
+        servo_channels.set_esc_scaling_for(SRV_Channels::get_motor_function(i));
     }
 }
 

--- a/Tools/AP_Periph/wscript
+++ b/Tools/AP_Periph/wscript
@@ -37,6 +37,7 @@ def build(bld):
         'AP_RangeFinder',
         'AP_ROMFS',
         'AP_MSP',
+        'SRV_Channel',
         ],
         exclude_src=[
             'libraries/AP_HAL_ChibiOS/Storage.cpp'

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef.dat
@@ -29,6 +29,7 @@ define HAL_BUILD_AP_PERIPH
 define HAL_PERIPH_ENABLE_GPS
 define HAL_PERIPH_ENABLE_MAG
 define HAL_PERIPH_ENABLE_BARO
+define HAL_PERIPH_ENABLE_RC_OUT
 
 # use the app descriptor needed by MissionPlanner for CAN upload
 env APP_DESCRIPTOR MissionPlanner

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph/hwdef.dat
@@ -22,6 +22,7 @@ define HAL_BUILD_AP_PERIPH
 define HAL_PERIPH_ENABLE_GPS
 define HAL_PERIPH_ENABLE_MAG
 define HAL_PERIPH_ENABLE_BARO
+define HAL_PERIPH_ENABLE_RC_OUT
 
 # use the app descriptor needed by MissionPlanner for CAN upload
 env APP_DESCRIPTOR MissionPlanner

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1374,6 +1374,7 @@ def write_PWM_config(f):
                 if p.type not in pwm_timers:
                     pwm_timers.append(p.type)
 
+    f.write('#define HAL_PWM_COUNT %u\n' % len(pwm_out))
     if not pwm_out and not alarm:
         print("No PWM output defined")
         f.write('''

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -21,7 +21,11 @@
 #include <AP_SBusOut/AP_SBusOut.h>
 #include <AP_BLHeli/AP_BLHeli.h>
 
-#define NUM_SERVO_CHANNELS 16
+#if !defined(NUM_SERVO_CHANNELS) && defined(HAL_BUILD_AP_PERIPH) && defined(HAL_PWM_COUNT) && (HAL_PWM_COUNT >= 1)
+    #define NUM_SERVO_CHANNELS HAL_PWM_COUNT
+#else
+    #define NUM_SERVO_CHANNELS 16
+#endif
 
 class SRV_Channels;
 
@@ -525,6 +529,7 @@ private:
     static SRV_Channel *channels;
     static SRV_Channels *_singleton;
 
+#ifndef HAL_BUILD_AP_PERIPH
     // support for Volz protocol
     AP_Volz_Protocol volz;
     static AP_Volz_Protocol *volz_ptr;
@@ -542,6 +547,8 @@ private:
     AP_BLHeli blheli;
     static AP_BLHeli *blheli_ptr;
 #endif
+#endif // HAL_BUILD_AP_PERIPH
+
     static uint16_t disabled_mask;
 
     // mask of outputs which use a digital output protocol, not

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -26,6 +26,7 @@ extern const AP_HAL::HAL& hal;
 /// map a function to a servo channel and output it
 void SRV_Channel::output_ch(void)
 {
+#ifndef HAL_BUILD_AP_PERIPH
     int8_t passthrough_from = -1;
 
     // take care of special function cases
@@ -59,6 +60,8 @@ void SRV_Channel::output_ch(void)
             }
         }
     }
+#endif // HAL_BUILD_AP_PERIPH
+
     if (!(SRV_Channels::disabled_mask & (1U<<ch_num))) {
         hal.rcout->write(ch_num, output_pwm);
     }

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -38,9 +38,13 @@ extern const AP_HAL::HAL& hal;
 
 SRV_Channel *SRV_Channels::channels;
 SRV_Channels *SRV_Channels::_singleton;
+
+#ifndef HAL_BUILD_AP_PERIPH
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
 AP_SBusOut *SRV_Channels::sbus_ptr;
 AP_RobotisServo *SRV_Channels::robotis_ptr;
+#endif // HAL_BUILD_AP_PERIPH
+
 uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
 
 #if HAL_SUPPORT_RCOUT_SERIAL
@@ -58,76 +62,110 @@ Bitmask<SRV_Channel::k_nr_aux_servo_functions> SRV_Channels::function_mask;
 SRV_Channels::srv_function SRV_Channels::functions[SRV_Channel::k_nr_aux_servo_functions];
 
 const AP_Param::GroupInfo SRV_Channels::var_info[] = {
+#if (NUM_SERVO_CHANNELS >= 1)
     // @Group: 1_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[0], "1_",  1, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 2)
     // @Group: 2_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[1], "2_",  2, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 3)
     // @Group: 3_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[2], "3_",  3, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 4)
     // @Group: 4_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[3], "4_",  4, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 5)
     // @Group: 5_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[4], "5_",  5, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 6)
     // @Group: 6_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[5], "6_",  6, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 7)
     // @Group: 7_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[6], "7_",  7, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 8)
     // @Group: 8_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[7], "8_",  8, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 9)
     // @Group: 9_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[8], "9_",  9, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 10)
     // @Group: 10_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[9], "10_",  10, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 11)
     // @Group: 11_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[10], "11_",  11, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 12)
     // @Group: 12_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[11], "12_",  12, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 13)
     // @Group: 13_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[12], "13_",  13, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 14)
     // @Group: 14_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[13], "14_",  14, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 15)
     // @Group: 15_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[14], "15_",  15, SRV_Channels, SRV_Channel),
+#endif
 
+#if (NUM_SERVO_CHANNELS >= 16)
     // @Group: 16_
     // @Path: SRV_Channel.cpp
     AP_SUBGROUPINFO(obj_channels[15], "16_",  16, SRV_Channels, SRV_Channel),
+#endif
 
+#ifndef  HAL_BUILD_AP_PERIPH
     // @Param{Plane}: _AUTO_TRIM
     // @DisplayName: Automatic servo trim
     // @Description: This enables automatic servo trim in flight. Servos will be trimed in stabilized flight modes when the aircraft is close to level. Changes to servo trim will be saved every 10 seconds and will persist between flights. The automatic trim won't go more than 20% away from a centered trim.
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
     AP_GROUPINFO_FRAME("_AUTO_TRIM",  17, SRV_Channels, auto_trim, 0, AP_PARAM_FRAME_PLANE),
+#endif
 
     // @Param: _RATE
     // @DisplayName: Servo default output rate
@@ -137,6 +175,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Units: Hz
     AP_GROUPINFO("_RATE",  18, SRV_Channels, default_rate, 50),
 
+#ifndef HAL_BUILD_AP_PERIPH
     // @Group: _VOLZ_
     // @Path: ../AP_Volz_Protocol/AP_Volz_Protocol.cpp
     AP_SUBGROUPINFO(volz, "_VOLZ_",  19, SRV_Channels, AP_Volz_Protocol),
@@ -154,6 +193,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Group: _ROB_
     // @Path: ../AP_RobotisServo/AP_RobotisServo.cpp
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
+#endif // HAL_BUILD_AP_PERIPH
 
     AP_GROUPEND
 };
@@ -174,12 +214,14 @@ SRV_Channels::SRV_Channels(void)
         channels[i].ch_num = i;
     }
 
+#ifndef HAL_BUILD_AP_PERIPH
     volz_ptr = &volz;
     sbus_ptr = &sbus;
     robotis_ptr = &robotis;
 #if HAL_SUPPORT_RCOUT_SERIAL
     blheli_ptr = &blheli;
 #endif
+#endif // HAL_BUILD_AP_PERIPH
 }
 
 /*
@@ -264,6 +306,7 @@ void SRV_Channels::push()
 {
     hal.rcout->push();
 
+#ifndef HAL_BUILD_AP_PERIPH
     // give volz library a chance to update
     volz_ptr->update();
 
@@ -277,6 +320,7 @@ void SRV_Channels::push()
     // give blheli telemetry a chance to update
     blheli_ptr->update_telemetry();
 #endif
+#endif // HAL_BUILD_AP_PERIPH
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     // push outputs to CAN


### PR DESCRIPTION
How to use the latest version:

Actuator UAVCAN msgs id 1 - 16 will get mapped to OUTn_FUNCTION = 51-66 (rcin1 - rc16)
Example: Actuator id 2 will always map to FUNCTION = 52 (RCin2)

ESC RawArray UAVCAN msgs index 0 - 11 get mapped to:
OUTn_FUNCTION = 33 - 40, and 82 - 85 (motor1 motor 8, motor 9 - motor 12)

So, set up whatever "OUTn" to whatever ESC/Actuator you want. You can even do duplicates, such as set multiple servos to 51 and they will all move when the input changes, but also you can set different min/max/trims so you actually get different outputs all scaled to that same input. Fancy!

We'll need to figure out a way to document this so people know how to set the OUTn_FUNCTION values correctly.