### PR TITLE
Answer to the ultimate question of life, the universe and everything ...

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -610,6 +610,7 @@ def write_fullresults():
     results.addglob('DataFlash Log', '*-log.bin')
     results.addglob("MAVLink log", '*.tlog')
     results.addglob("GPX track", '*.gpx')
+    results.addfile('Firmware sizes', 'firmware_sizes.json')
 
     # results common to all vehicles:
     vehicle_files = [('{vehicle} defaults', '{vehicle}-defaults.parm'),

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -710,7 +710,7 @@ is bob we will attempt to checkout bob-AVR'''
 
 
     def generate_manifest(self):
-        '''generate manigest files for GCS to download'''
+        '''generate manifest files for GCS to download'''
         self.progress("Generating manifest")
         base_url = 'https://firmware.ardupilot.org'
         generator = generate_manifest.ManifestGenerator(self.binaries,
@@ -736,6 +736,17 @@ is bob we will attempt to checkout bob-AVR'''
         gen_stable.make_all_stable(self.binaries)
         self.progress("Generate stable releases done")
 
+    def generate_firmware_size_json(self):
+        """Generate firmware size json file to download."""
+        self.progress("Generating firmware_size.json")
+        binaries_json_filepath = os.path.join(self.buildlogs_dirpath(),
+                                              "firmware_sizes.json")
+        githash = self.run_git(["rev-parse", "HEAD"]).rstrip()
+        # remove previous file
+        if os.path.isfile(binaries_json_filepath):
+            os.remove(binaries_json_filepath)
+        self.history.generate_firmware_size_json(binaries_json_filepath, githash)
+        self.progress("firmware_size.json generation successful")
 
     def validate(self):
         '''run pre-run validation checks'''
@@ -826,6 +837,7 @@ is bob we will attempt to checkout bob-AVR'''
             shutil.rmtree(self.tmpdir)
 
         self.generate_manifest()
+        self.generate_firmware_size_json()
 
         for error_string in self.error_strings:
             self.progress("%s" % error_string)

--- a/Tools/scripts/diff_size_master.py
+++ b/Tools/scripts/diff_size_master.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+import os
+import json
+from argparse import ArgumentParser
+import requests
+from tabulate import tabulate
+
+
+parser = ArgumentParser(description="Print binary size difference with master.")
+parser.add_argument("-b", "--board", dest='board', type=str, help="Board type to use", required=True)
+
+args = parser.parse_args()
+
+
+def buildlogs_dirpath():
+    return os.getenv("BUILDLOGS",
+                     os.path.join(os.getcwd(), "..", "buildlogs"))
+
+
+def get_board_json():
+    print("Looking for board build result into the file ...")
+    if args.board.lower() in master_json[0]:
+        print("Find %s firmware sizes" % args.board)
+        return [master_json[0].get(args.board.lower())]
+    else:
+        raise Exception("Cannot find %s firmware sizes" % args.board)
+
+
+def sizes_for_file(filepath):
+    cmd = "size %s" % (filepath,)
+    stuff = os.popen(cmd).read()
+    lines = stuff.splitlines()[1:]
+    l = []
+    for line in lines:
+        row = line.strip().split()
+        l.append(dict(
+            text=int(row[0]),
+            data=int(row[1]),
+            bss=int(row[2]),
+            total=int(row[3]),
+        ))
+    return l
+
+
+def print_table(summary_data_list, summary_data_list_master):
+    print_data = []
+    print(summary_data_list)
+    print(summary_data_list_master)
+    for name in summary_data_list[0]:
+        for master_name in summary_data_list_master[0]:
+            if name == master_name:
+                col_data = [name]
+                for key in ["text", "data", "bss", "total"]:
+                    bvalue = summary_data_list[0][name].get(key)
+                    mvalue = summary_data_list_master[0][name].get(key)
+                    if key == "total" and mvalue is None:
+                        mvalue = summary_data_list_master[0][name].get("text") + summary_data_list_master[0][name].get("data") + summary_data_list_master[0][name].get("bss")
+                    diff = (bvalue - mvalue) * 100.0 / mvalue
+                    signum = "+" if diff > 0.0 else ""
+                    print_diff = signum + "%0.4f%%" % diff
+                    col_data.append(print_diff)
+                print_data.append(col_data)
+    print(tabulate(print_data, headers=["Binary", "text", "data", "bss", "total"]))
+
+
+master_json = None
+board_json = []
+
+url = "https://autotest.ardupilot.org/firmware_sizes.json"
+local_url = os.path.join(buildlogs_dirpath(), "firmware_sizes.json")
+
+print("Try to get firmware_size.json from autotest.ardupilot.org...")
+result = requests.get(url)
+if result.status_code == requests.codes.ok:
+    print("Success !")
+    master_json = result.json()
+    board_json = get_board_json()
+else:
+    print("Failed !")
+    print("Try to get firmware_size.json from local buildlogs directory")
+    if os.path.isfile(local_url):
+        print("Success !")
+        with open(local_url, "r+") as summary_json:
+            master_json = json.load(summary_json)
+        board_json = get_board_json()
+    else:
+        print("Failed !")
+        print("No firmware_size.json present, diff is not possible")
+        exit(2)
+
+scripts_dir = os.path.dirname(os.path.realpath(__file__))
+root_dir = os.path.realpath(os.path.join(scripts_dir, '../..'))
+binary_basedir = "build/%s/bin/" % args.board
+vehicle_binary = os.path.join(root_dir, binary_basedir)
+
+# Try to look if that is a debug build
+print("Looking for %s build directory ..." % args.board)
+with open(vehicle_binary + "../compile_commands.json", "r") as searchfile:
+    print("Success !")
+    for line in searchfile:
+        if "-DHAL_DEBUG_BUILD=1" in line:
+            print("Cannot be used with debug build")
+            exit(2)
+
+
+print("Extracting %s build summary ..." % args.board)
+binaries_list = []
+for file in os.listdir(vehicle_binary):
+    fileNoExt = os.path.splitext(file)[0]
+    binaries_list.append(fileNoExt)
+binaries_list = list(dict.fromkeys(binaries_list))
+
+build_json = None
+for binaries in binaries_list:
+    path = vehicle_binary + binaries
+    parsed = sizes_for_file(path)
+    if build_json is None:
+        build_json = [{binaries.lower(): parsed[0]}]
+    else:
+        build_json[0].update({binaries.lower(): parsed[0]})
+print("Success !")
+
+print_table(build_json, board_json)


### PR DESCRIPTION
... and the build size diff with master is 

This PR allow to automate the diff size reporting with master branch for CI and local build.

It uses the build.binaries from autotest to fill a `firmware_sizes.json` that contains each vehicle build summary and serves it on autotest.ardupilot.org. The json file is create on same time as our database file.
It got the following schema : 
```
        build_json = [{
            board.lower(): {vehicle.lower(): {"text": text, "data": data, "bss": bss}},
        }]
```

A script is added : `diff_size_master.py` 
It allow to print diff size with master for a board. It tries to get the `firmware_sizes.json` from autotest.ardupilot.org first, on failure, it tries to look on the local buildlogs directory for the `firmware_sizes.json` file. With the data from master, it makes a size diff with the data from the board binaries that should be in build/BOARD_NAME/bin.

Testing: 
This PR can be tested by using 
`Tools/scripts/build_binaries.py --tags latest` to create the `firmware_sizes.json` locally into the buildlogs directory. Then using 
`Tools/scripts/diff_size_master.py -b fmuv2` for fmuv2 for example, and it should print something like : 
```
Binary           text    data    bss     total
---------------  ------  ------  ------  -------
arducopter-heli  +0.42%  0.00%   0.00%   +0.35%
ardusub          +1.62%  0.00%   +0.00%  +1.32%
arduplane        +0.48%  0.00%   -0.00%  +0.39%
ardurover        +0.63%  0.00%   -0.00%  +0.51%
antennatracker   +0.57%  0.00%   0.00%   +0.45%
arducopter       +0.41%  0.00%   0.00%   +0.34%
```
You can also test the remote json downloading by using a simple file server from the buildlogs directory : 
```
cd PATH_TO_Buildlogs_directory
python3 -m http.server 8888
```
 to create a local server for the buildlogs directory on port 8888
Then replace the url in `Tools/scripts/diff_size_master.py` by "http://localhost:8888/firmware_sizes.json"
and launch back `Tools/scripts/diff_size_master.py -b fmuv2`

Once this will be on our server, the next step will be to allow some CI build to use the diff script to report the diff size.

Mitigation:
This solution will increase the traffic on our server if CI use it, but it shouldn't be much as the json file will be small (a few kb). To further improve traffic, we could gz the json file and downloading it only once on CI startup phase to prevent multiple download.

Another solution would be to put the json file for each board/vehicle into https://firmware.ardupilot.org/Rover/latest/ for example. That would reduce the traffic as the downloaded json would be minimal.

We got a build database but I don't feel safe to allow remote access to it to get the lastest build summary. It could be done securely on CI with secret but would leave an open door on our server and need proper database management