### PR TITLE
AP_Scripting: add support for custom frames via AP_MotorsMatrix

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -864,7 +864,6 @@ private:
     bool ekf_alt_ok() const;
     void update_auto_armed();
     bool should_log(uint32_t mask);
-    MAV_TYPE get_frame_mav_type();
     const char* get_frame_string();
     void allocate_motors(void);
     bool is_tradheli() const;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -14,7 +14,10 @@
 
 MAV_TYPE GCS_Copter::frame_type() const
 {
-    return copter.get_frame_mav_type();
+    if (copter.motors == nullptr) {
+        return MAV_TYPE_GENERIC;
+    }
+    return copter.motors->get_frame_mav_type();
 }
 
 MAV_MODE GCS_MAVLINK_Copter::base_mode() const

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -864,7 +864,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad, 14:Deca
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad, 14:Deca, 15:Scripting Matrix
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, DEFAULT_FRAME_CLASS),

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -500,6 +500,7 @@ void Copter::allocate_motors(void)
         case AP_Motors::MOTOR_FRAME_OCTAQUAD:
         case AP_Motors::MOTOR_FRAME_DODECAHEXA:
         case AP_Motors::MOTOR_FRAME_DECA:
+        case AP_Motors::MOTOR_FRAME_SCRIPTING_MATRIX:
         default:
             motors = new AP_MotorsMatrix(copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsMatrix::var_info;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -448,38 +448,6 @@ bool Copter::should_log(uint32_t mask)
 #endif
 }
 
-// return MAV_TYPE corresponding to frame class
-MAV_TYPE Copter::get_frame_mav_type()
-{
-    switch ((AP_Motors::motor_frame_class)g2.frame_class.get()) {
-        case AP_Motors::MOTOR_FRAME_QUAD:
-        case AP_Motors::MOTOR_FRAME_UNDEFINED:
-            return MAV_TYPE_QUADROTOR;
-        case AP_Motors::MOTOR_FRAME_HEXA:
-        case AP_Motors::MOTOR_FRAME_Y6:
-            return MAV_TYPE_HEXAROTOR;
-        case AP_Motors::MOTOR_FRAME_OCTA:
-        case AP_Motors::MOTOR_FRAME_OCTAQUAD:
-            return MAV_TYPE_OCTOROTOR;
-        case AP_Motors::MOTOR_FRAME_HELI:
-        case AP_Motors::MOTOR_FRAME_HELI_DUAL:
-        case AP_Motors::MOTOR_FRAME_HELI_QUAD:
-            return MAV_TYPE_HELICOPTER;
-        case AP_Motors::MOTOR_FRAME_TRI:
-            return MAV_TYPE_TRICOPTER;
-        case AP_Motors::MOTOR_FRAME_SINGLE:
-        case AP_Motors::MOTOR_FRAME_COAX:
-        case AP_Motors::MOTOR_FRAME_TAILSITTER:
-            return MAV_TYPE_COAXIAL;
-        case AP_Motors::MOTOR_FRAME_DODECAHEXA:
-            return MAV_TYPE_DODECAROTOR;
-        case AP_Motors::MOTOR_FRAME_DECA:
-            return MAV_TYPE_DECAROTOR;
-    }
-    // unknown frame so return generic
-    return MAV_TYPE_GENERIC;
-}
-
 // return string corresponding to frame_class
 const char* Copter::get_frame_string()
 {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -139,7 +139,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 7:Tri, 10: TailSitter
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 7:Tri, 10: TailSitter, 12:DodecaHexa, 14:Deca, 15:Scripting Matrix
     // @User: Standard
     AP_GROUPINFO("FRAME_CLASS", 46, QuadPlane, frame_class, 1),
 

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -37,6 +37,8 @@ void AP_MotorsCoax::init(motor_frame_class frame_class, motor_frame_type frame_t
         SRV_Channels::set_angle(SRV_Channels::get_motor_function(i), AP_MOTORS_COAX_SERVO_INPUT_RANGE);
     }
 
+    _mav_type = MAV_TYPE_COAXIAL;
+
     // record successful initialisation if what we setup was the desired frame_class
     set_initialised_ok(frame_class == MOTOR_FRAME_COAX);
 }

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -159,6 +159,7 @@ void AP_MotorsHeli::init(motor_frame_class frame_class, motor_frame_type frame_t
     // set flag to true so targets are initialized once aircraft is armed for first time
     _heliflags.init_targets_on_arming = true;
 
+    _mav_type = MAV_TYPE_HELICOPTER;
 }
 
 // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -492,6 +492,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
     switch (frame_class) {
 
         case MOTOR_FRAME_QUAD:
+            _mav_type = MAV_TYPE_QUADROTOR;
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
                     add_motor(AP_MOTORS_MOT_1,  90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
@@ -618,6 +619,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             break;  // quad
 
         case MOTOR_FRAME_HEXA:
+            _mav_type = MAV_TYPE_HEXAROTOR;
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
                     add_motor(AP_MOTORS_MOT_1,   0, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
@@ -668,6 +670,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             break;
 
         case MOTOR_FRAME_OCTA:
+            _mav_type = MAV_TYPE_OCTOROTOR;
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
                     add_motor(AP_MOTORS_MOT_1,    0,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
@@ -747,6 +750,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             break;
 
         case MOTOR_FRAME_OCTAQUAD:
+            _mav_type = MAV_TYPE_OCTOROTOR;
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
                     add_motor(AP_MOTORS_MOT_1,    0, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
@@ -807,6 +811,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             break;
 
         case MOTOR_FRAME_DODECAHEXA: {
+            _mav_type = MAV_TYPE_DODECAROTOR;
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
                     add_motor(AP_MOTORS_MOT_1,     0, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);  // forward-top
@@ -844,6 +849,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             break;
 
         case MOTOR_FRAME_Y6:
+            _mav_type = MAV_TYPE_HEXAROTOR;
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_Y6B:
                     // Y6 motor definition with all top motors spinning clockwise, all bottom motors counter clockwise
@@ -875,6 +881,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             break;
 
         case MOTOR_FRAME_DECA:
+            _mav_type = MAV_TYPE_DECAROTOR;
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
                     add_motor(AP_MOTORS_MOT_1,     0, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  1);
@@ -910,6 +917,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
         default:
             // matrix doesn't support the configured class
             success = false;
+            _mav_type = MAV_TYPE_GENERIC;
             break;
     } // switch frame_class
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -17,10 +17,25 @@ public:
     /// Constructor
     AP_MotorsMatrix(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
         AP_MotorsMulticopter(loop_rate, speed_hz)
-    {};
+    {
+        if (_singleton != nullptr) {
+            AP_HAL::panic("AP_MotorsMatrix must be singleton");
+        }
+        _singleton = this;
+    };
+
+    // get singleton instance
+    static AP_MotorsMatrix *get_singleton() {
+        return _singleton;
+    }
 
     // init
     void                init(motor_frame_class frame_class, motor_frame_type frame_type) override;
+
+#ifdef ENABLE_SCRIPTING
+    // Init to be called from scripting
+    bool                init(uint8_t expected_num_motors);
+#endif // ENABLE_SCRIPTING
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     void                set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
@@ -59,15 +74,15 @@ public:
     // as vectoring is used for yaw control
     void                disable_yaw_torque(void) override;
 
+    // add_motor using raw roll, pitch, throttle and yaw factors
+    void                add_motor_raw(int8_t motor_num, float roll_fac, float pitch_fac, float yaw_fac, uint8_t testing_order);
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;
 
     // check for failed motor
     void                check_for_failed_motor(float throttle_thrust_best);
-
-    // add_motor using raw roll, pitch, throttle and yaw factors
-    void                add_motor_raw(int8_t motor_num, float roll_fac, float pitch_fac, float yaw_fac, uint8_t testing_order);
 
     // add_motor using just position and yaw_factor (or prop direction)
     void                add_motor(int8_t motor_num, float angle_degrees, float yaw_factor, uint8_t testing_order);
@@ -98,4 +113,7 @@ protected:
     // motor failure handling
     float               _thrust_rpyt_out_filt[AP_MOTORS_MAX_NUM_MOTORS];    // filtered thrust outputs with 1 second time constant
     uint8_t             _motor_lost_index;  // index number of the lost motor
+
+private:
+    static AP_MotorsMatrix *_singleton;
 };

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -37,6 +37,8 @@ void AP_MotorsSingle::init(motor_frame_class frame_class, motor_frame_type frame
         SRV_Channels::set_angle(SRV_Channels::get_motor_function(i), AP_MOTORS_SINGLE_SERVO_INPUT_RANGE);
     }
 
+    _mav_type = MAV_TYPE_COAXIAL;
+
     // record successful initialisation if what we setup was the desired frame_class
     set_initialised_ok(frame_class == MOTOR_FRAME_SINGLE);
 }

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -53,6 +53,8 @@ void AP_MotorsTailsitter::init(motor_frame_class frame_class, motor_frame_type f
     SRV_Channels::set_aux_channel_default(SRV_Channel::k_tiltMotorLeft, CH_4);
     SRV_Channels::set_angle(SRV_Channel::k_tiltMotorLeft, SERVO_OUTPUT_RANGE);
 
+    _mav_type = MAV_TYPE_COAXIAL;
+
     // record successful initialisation if what we setup was the desired frame_class
     set_initialised_ok(frame_class == MOTOR_FRAME_TAILSITTER);
 }

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -54,6 +54,8 @@ void AP_MotorsTri::init(motor_frame_class frame_class, motor_frame_type frame_ty
         _pitch_reversed = true;
     }
 
+    _mav_type = MAV_TYPE_TRICOPTER;
+
     // record successful initialisation if what we setup was the desired frame_class
     set_initialised_ok(frame_class == MOTOR_FRAME_TRI);
 }

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -45,6 +45,7 @@ public:
         MOTOR_FRAME_DODECAHEXA = 12,
         MOTOR_FRAME_HELI_QUAD = 13,
         MOTOR_FRAME_DECA = 14,
+        MOTOR_FRAME_SCRIPTING_MATRIX = 15,
     };
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -204,6 +204,8 @@ public:
                     PWM_TYPE_DSHOT1200  = 7};
     pwm_type            get_pwm_type(void) const { return (pwm_type)_pwm_type.get(); }
 
+    MAV_TYPE get_frame_mav_type() const { return _mav_type; }
+
 protected:
     // output functions that should be overloaded by child classes
     virtual void        output_armed_stabilizing() = 0;
@@ -264,6 +266,8 @@ protected:
     bool                _thrust_boost;          // true if thrust boost is enabled to handle motor failure
     bool                _thrust_balanced;       // true when output thrust is well balanced
     float               _thrust_boost_ratio;    // choice between highest and second highest motor output for output mixing (0 ~ 1). Zero is normal operation
+
+    MAV_TYPE _mav_type; // MAV_TYPE_GENERIC = 0;
 
 private:
 

--- a/libraries/AP_Scripting/examples/MotorMatrix_setup.lua
+++ b/libraries/AP_Scripting/examples/MotorMatrix_setup.lua
@@ -1,0 +1,9 @@
+-- This script is an example setting up a custom motor matrix mix
+
+-- duplicate the standard + Quad mix
+MotorsMatrix:add_motor_raw(0,-1, 0, 1, 2)
+MotorsMatrix:add_motor_raw(1, 1, 0, 1, 4)
+MotorsMatrix:add_motor_raw(2, 0, 1,-1, 1)
+MotorsMatrix:add_motor_raw(3, 0,-1,-1, 3)
+
+assert(MotorsMatrix:init(4), "Failed to init MotorsMatrix")

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -303,3 +303,9 @@ include ../ArduPlane/quadplane.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)
 singleton QuadPlane alias quadplane
 singleton QuadPlane depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)
 singleton QuadPlane method in_vtol_mode boolean
+
+include AP_Motors/AP_MotorsMatrix.h
+singleton AP_MotorsMatrix depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter) 
+singleton AP_MotorsMatrix alias MotorsMatrix
+singleton AP_MotorsMatrix method init boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
+singleton AP_MotorsMatrix method add_motor_raw void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)


### PR DESCRIPTION
This is my take on https://github.com/ArduPilot/ardupilot/pull/13693

This add some additional checks, for example the script cannot setup motors if a frame type is already setup. The script must set the correct number of motors to match the FRAME_CLASS. If the script does not setup the motors there will be a pre-arm warning.

Possibly we might want to add also a custom frame class so the script can setup as many motors as it likes.