### PR TITLE
Plane: fixed usage of rangefinder in landing with RNGFND_LANDING=0

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -702,7 +702,9 @@ void Plane::rangefinder_height_update(void)
         if (now - rangefinder_state.last_correction_time_ms > 5000) {
             rangefinder_state.correction = correction;
             rangefinder_state.initial_correction = correction;
-            landing.set_initial_slope();
+            if (g.rangefinder_landing) {
+                landing.set_initial_slope();
+            }
             rangefinder_state.last_correction_time_ms = now;
         } else {
             rangefinder_state.correction = 0.8f*rangefinder_state.correction + 0.2f*correction;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -233,7 +233,8 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
             // ground
             height -= auto_state.terrain_correction;
             return landing.verify_land(prev_WP_loc, next_WP_loc, current_loc,
-                height, auto_state.sink_rate, auto_state.wp_proportion, auto_state.last_flying_ms, arming.is_armed(), is_flying(), rangefinder_state.in_range);
+                                       height, auto_state.sink_rate, auto_state.wp_proportion, auto_state.last_flying_ms, arming.is_armed(), is_flying(),
+                                       g.rangefinder_landing && rangefinder_state.in_range);
         }
 
     case MAV_CMD_NAV_LOITER_UNLIM:


### PR DESCRIPTION
this fixes two places where rangefinder can affect landing when
RNGFND_LANDING=0. If rangefinder data was invalid then this could cause a bad landing slope

This fixes #15608 

Many thanks to @Naterater for reporting!
