### PR TITLE
AP_Motors: output mask: do not apply copter spin params and expo

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -761,7 +761,7 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float r
                  apples to either tilted motors or tailsitters
                  */
                 float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
-                set_actuator_with_slew(_actuator[i], thrust_to_actuator(thrust + diff_thrust));
+                set_actuator_with_slew(_actuator[i], thrust + diff_thrust);
                 int16_t pwm_output = pwm_min + pwm_range * _actuator[i];
                 rc_write(i, pwm_output);
             } else {


### PR DESCRIPTION
This fixes something that I thought was a good idea at the time, but I have now decided is not.

The 'output_motor_mask' function is used by tail-sitters and tilt rotors in forward flight.

This change stops applying SPIN_MIN and SPIN_MAX to the throttle and stops applying expo. This will only effect forward flight. SPIN_MIN and MAX make no sense for forward flight, stopping the motors is a legitimate thing that you might what to do. The expo is well outside its intended used case with with the high inflow speeds of forward flight so its basically nonsense. We did get battery scaling but that has since been added to plane directly.