### PR TITLE
Plane: tailsitter disk theory gain scaling

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -473,10 +473,10 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
 
     // @Param: TAILSIT_GSCMSK
     // @DisplayName: Tailsitter gain scaling mask
-    // @Description: Bitmask of gain scaling methods to be applied: BOOST: boost gain at low throttle, ATT_THR: reduce gain at high throttle/tilt
+    // @Description: Bitmask of gain scaling methods to be applied: Throttle: scale gains with throttle, ATT_THR: reduce gain at high throttle/tilt, 2:Disk theory velocity calculation, requires Q_TAILSIT_DSKLD to be set, ATT_THR must not be set, 3:Altitude correction, scale with air density
     // @User: Standard
-    // @Bitmask: 0:BOOST,1:ATT_THR
-    AP_GROUPINFO("TAILSIT_GSCMSK", 17, QuadPlane, tailsitter.gain_scaling_mask, TAILSITTER_GSCL_BOOST),
+    // @Bitmask: 0:Throttle,1:ATT_THR,2:Disk Theory,3:Altitude correction
+    AP_GROUPINFO("TAILSIT_GSCMSK", 17, QuadPlane, tailsitter.gain_scaling_mask, TAILSITTER_GSCL_THROTTLE),
 
     // @Param: TAILSIT_GSCMIN
     // @DisplayName: Minimum gain scaling based on throttle and attitude
@@ -500,6 +500,14 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Range: 0 100
     // @RebootRequired: False
     AP_GROUPINFO("FWD_MANTHR_MAX", 20, QuadPlane, fwd_thr_max, 0),
+
+    // @Param: TAILSIT_DSKLD
+    // @DisplayName: Tailsitter disk loading
+    // @Description: This is the vehicle weight in kg divided by the total disk area of all propellers in m^2. Only used with Q_TAILSIT_GSCMSK = 4
+    // @Units: kg/m.m
+    // @Range: 0 50
+    // @User: Standard
+    AP_GROUPINFO("TAILSIT_DSKLD", 21, QuadPlane, tailsitter.disk_loading, 0),
 
     AP_GROUPEND
 };

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -354,12 +354,12 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Path: ../libraries/AC_WPNav/AC_Loiter.cpp
     AP_SUBGROUPPTR(loiter_nav, "LOIT_",  2, QuadPlane, AC_Loiter),
 
-    // @Param: TAILSIT_THSCMX
-    // @DisplayName: Maximum control throttle scaling value
-    // @Description: Maximum value of throttle scaling for tailsitter velocity scaling, reduce this value to remove low throttle oscillations
+    // @Param: TAILSIT_GSCMAX
+    // @DisplayName: Maximum tailsitter gain scaling
+    // @Description: Maximum gain scaling for tailsitter Q_TAILSIT_GSCMSK options
     // @Range: 1 5
     // @User: Standard
-    AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 2),
+    AP_GROUPINFO("TAILSIT_GSCMAX", 3, QuadPlane, tailsitter.throttle_scale_max, 2),
 
     // @Param: TRIM_PITCH
     // @DisplayName: Quadplane AHRS trim pitch
@@ -479,8 +479,8 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     AP_GROUPINFO("TAILSIT_GSCMSK", 17, QuadPlane, tailsitter.gain_scaling_mask, TAILSITTER_GSCL_THROTTLE),
 
     // @Param: TAILSIT_GSCMIN
-    // @DisplayName: Minimum gain scaling based on throttle and attitude
-    // @Description: Minimum gain scaling at high throttle/tilt angle
+    // @DisplayName: Minimum tailsitter gain scaling
+    // @Description: Minimum gain scaling for tailsitter Q_TAILSIT_GSCMSK options
     // @Range: 0.1 1
     // @User: Standard
     AP_GROUPINFO("TAILSIT_GSCMIN", 18, QuadPlane, tailsitter.gain_scaling_min, 0.4),

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -507,8 +507,10 @@ private:
     };
 
     enum tailsitter_gscl_mask {
-        TAILSITTER_GSCL_BOOST   = (1U<<0),
+        TAILSITTER_GSCL_THROTTLE = (1U<<0),
         TAILSITTER_GSCL_ATT_THR = (1U<<1),
+        TAILSITTER_GSCL_DISK_THEORY = (1U<<2),
+        TAILSITTER_GSCL_ALTITUDE = (1U<<3),
     };
 
     // tailsitter control variables
@@ -527,6 +529,7 @@ private:
         AP_Float scaling_speed_min;
         AP_Float scaling_speed_max;
         AP_Int16 gain_scaling_mask;
+        AP_Float disk_loading;
     } tailsitter;
 
     // tailsitter speed scaler

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -134,6 +134,8 @@ void QuadPlane::tailsitter_output(void)
             attitude_control->reset_rate_controller_I_terms();
 
             // output tilt motors
+            tilt_left = 0.0f;
+            tilt_right = 0.0f;
             if (tailsitter.vectored_hover_gain > 0) {
                 const float hover_throttle = motors->get_throttle_hover();
                 const float throttle = motors->get_throttle();
@@ -141,10 +143,12 @@ void QuadPlane::tailsitter_output(void)
                 if (is_positive(throttle)) {
                     throttle_scaler = constrain_float(hover_throttle / throttle, tailsitter.gain_scaling_min, tailsitter.throttle_scale_max);
                 }
-
-                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft) * tailsitter.vectored_hover_gain * throttle_scaler);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight) * tailsitter.vectored_hover_gain * throttle_scaler);
+                tilt_left = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft) * tailsitter.vectored_hover_gain * throttle_scaler;
+                tilt_right = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight) * tailsitter.vectored_hover_gain * throttle_scaler;
             }
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
+
 
             // skip remainder of the function that overwrites plane control surface outputs with copter
             return;
@@ -168,6 +172,8 @@ void QuadPlane::tailsitter_output(void)
         tailsitter_speed_scaling();
     }
 
+    tilt_left = 0.0f;
+    tilt_right = 0.0f;
     if (tailsitter.vectored_hover_gain > 0) {
         // thrust vectoring VTOL modes
         tilt_left = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft);
@@ -187,9 +193,9 @@ void QuadPlane::tailsitter_output(void)
         }
         tilt_left  = extra_elevator + tilt_left * tailsitter.vectored_hover_gain;
         tilt_right = extra_elevator + tilt_right * tailsitter.vectored_hover_gain;
-        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
-        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
     }
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
 
     // Check for saturated limits
     bool tilt_lim = (labs(SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t::k_tiltMotorLeft)) == SERVO_MAX) || (labs(SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t::k_tiltMotorRight)) == SERVO_MAX);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -135,8 +135,15 @@ void QuadPlane::tailsitter_output(void)
 
             // output tilt motors
             if (tailsitter.vectored_hover_gain > 0) {
-                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft) * tailsitter.vectored_hover_gain);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight) * tailsitter.vectored_hover_gain);
+                const float hover_throttle = motors->get_throttle_hover();
+                const float throttle = motors->get_throttle();
+                float throttle_scaler = tailsitter.throttle_scale_max;
+                if (is_positive(throttle)) {
+                    throttle_scaler = constrain_float(hover_throttle / throttle, tailsitter.gain_scaling_min, tailsitter.throttle_scale_max);
+                }
+
+                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft) * tailsitter.vectored_hover_gain * throttle_scaler);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight) * tailsitter.vectored_hover_gain * throttle_scaler);
             }
 
             // skip remainder of the function that overwrites plane control surface outputs with copter

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -108,6 +108,7 @@ known_units = {
              'octal'   : 'octal'                 ,
              'RPM'     : 'Revolutions Per Minute',
              'kg/m/m'  : 'kilograms per square meter', # metre is the SI unit name, meter is the american spelling of it
+             'kg/m.m'  : 'kilogram per meter squared'
              }
 
 required_param_fields = [

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -138,8 +138,8 @@ void AP_MotorsTailsitter::output_armed_stabilizing()
     // apply voltage and air pressure compensation
     const float compensation_gain = get_compensation_gain();
     roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
-    pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
-    yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;
+    pitch_thrust = _pitch_in + _pitch_in_ff;
+    yaw_thrust = _yaw_in + _yaw_in_ff;
     throttle_thrust = get_throttle() * compensation_gain;
 
     // sanity check throttle is above zero and below current limited throttle


### PR DESCRIPTION
Inspired by https://github.com/ArduPilot/ardupilot/pull/15613 this adds a disk theory based method for scaling tailsitter control surface gains. Requires that one set the disk loading of the vehicle with a new param. The disk loading equates how much airflow comes from the props vs the airspeed, if only half your control surface is behind the prop the disk loading should be set to half the true value ect. Lower disk loading = lower airflow from prop = less gain scaling. 

Hopefully this will be a significant improvement over the current methods.

Needs testing in SITL and on real vehicles.

This also re-instates the <1 values of the throttle bases 'boost' scaling, not sure when that got lost.