### PR TITLE
AP_AHRS: take secondary attitude from EKF3 if it is configured

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -608,13 +608,20 @@ bool AP_AHRS_NavEKF::get_secondary_attitude(Vector3f &eulers) const
     switch (active_EKF_type()) {
     case EKFType::NONE:
         // EKF is secondary
-#if HAL_NAVEKF2_AVAILABLE
-        EKF2.getEulerAngles(-1, eulers);
-        return _ekf2_started;
-#else
-        return false;
+        switch ((EKFType)_ekf_type.get()) {
+#if HAL_NAVEKF3_AVAILABLE
+        case EKFType::THREE:
+            EKF3.getEulerAngles(-1, eulers);
+            return _ekf3_started;
 #endif
-
+#if HAL_NAVEKF2_AVAILABLE
+        case EKFType::TWO:
+            EKF2.getEulerAngles(-1, eulers);
+            return _ekf2_started;
+#endif
+        default:
+            return false;
+        }
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
 #endif


### PR DESCRIPTION
If we're using DCM a lot of our boards won't supply a secondary attitude.

This is currently important for logging (`AHR2` until we get `DCM`), but also for reporting to the GCS (unlikely to go anywhere soon).

Tested in SITL by dropping a breakpoint on the function (both `AHRS_EKF_TYPE`==2 and `AHRS_EKF_TYPE`==3)
