### PR TITLE
Copter: poshold clears wind est when disarmed or landed

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -973,6 +973,7 @@ private:
     void update_pilot_lean_angle(float &lean_angle_filtered, float &lean_angle_raw);
     float mix_controls(float mix_ratio, float first_control, float second_control);
     void update_brake_angle_from_velocity(float &brake_angle, float velocity);
+    void init_wind_comp_estimate();
     void update_wind_comp_estimate();
     void get_wind_comp_lean_angles(float &roll_angle, float &pitch_angle);
     void roll_controller_to_pilot_override();

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -59,10 +59,7 @@ bool ModePosHold::init(bool ignore_checks)
     loiter_nav->init_target();
 
     // initialise wind_comp each time PosHold is switched on
-    wind_comp_ef.zero();
-    wind_comp_timer = 0;
-    wind_comp_roll = 0.0f;
-    wind_comp_pitch = 0.0f;
+    init_wind_comp_estimate();
 
     return true;
 }
@@ -118,6 +115,9 @@ void ModePosHold::run()
         // set poshold state to pilot override
         roll_mode = RPMode::PILOT_OVERRIDE;
         pitch_mode = RPMode::PILOT_OVERRIDE;
+
+        // initialise wind compensation estimate
+        init_wind_comp_estimate();
         break;
 
     case AltHold_Takeoff:
@@ -151,6 +151,7 @@ void ModePosHold::run()
         loiter_nav->init_target();
         loiter_nav->update();
         attitude_control->set_yaw_target_to_current_heading();
+        init_wind_comp_estimate();
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:
@@ -560,6 +561,15 @@ void ModePosHold::update_brake_angle_from_velocity(float &brake_angle, float vel
 
     // constrain final brake_angle
     brake_angle = constrain_float(brake_angle, -(float)g.poshold_brake_angle_max, (float)g.poshold_brake_angle_max);
+}
+
+// initialise wind compensation estimate back to zero
+void ModePosHold::init_wind_comp_estimate()
+{
+    wind_comp_ef.zero();
+    wind_comp_timer = 0;
+    wind_comp_roll = 0.0f;
+    wind_comp_pitch = 0.0f;
 }
 
 // update_wind_comp_estimate - updates wind compensation estimate


### PR DESCRIPTION
This fixes issue https://github.com/ArduPilot/ardupilot/issues/15678 which involves Copter's PosHold mode maintaining a desired roll and/or pitch angle even after it has been disarmed and re-armed.

This desired lean angle comes from the wind estimator which is only cleared when the vehicle first enters PosHold mode.  This PR resolves this by resetting the wind estimate whenever the vehicle's AltHold state is "MotorsStopped" or "Landed_Ground_Idle".  These are the states the vehicle is in when it is landed and the pilot has not (yet) raised the throttle above neutral.

The issue can be recreated in SITL by doing the following:

- poshold
- param set SIM_WIND_SPD 15 (to increase simluated wind speed to 15m/s)
- arm throttle
- rc 3 1800 (to cause the vehicle to climb)
- rc 3 1500 (to level out at 10m)
- rc 2 1450 (to move forward slowly.  this causes the wind estimate to be calculated)
- rc 3 1000 (to descend quickly)
- disarm (to disarm vehicle once it has landed)
- param set SIM_WIND_SPD 0 (to clear wind estimate)
- rc 2 1500 (to center pitch stick)
- arm throttle
- rc 3 1800 (to cause the vehicle to climb)
- LAND (to cause the vehicle to switch to Land mode after it reaches 10m)

Below are before and after screen shots from SITL showing the vehicle's desired and actual roll angle (in red and green respectively) and altitude (in blue) during the above test.

The ugly thing we see is PosHold's **desired roll angle** climbs dramatically when it reaches the ground if the pilot is still pushing the **pitch** stick forward.  The vehicle is in "BRAKE_READY_TO_LOITER" mode and what has happened is that before landing the velocity controller and wind-estimates were pulling in different directions.  As the vehicle lands, the velocity controller finds it doesn't need to do anything and reduces its contribution to the desired roll-angle leaving only the larger wind-speed component.  This fix does not attempt to resolve this larger issue but at least it clears it the wind estimate once the vehicle decides it has landed.  Previously it would stick around and cause troubles when the pilot next tried to takeoff (see sudden twitch around 31000 in the **before** image vs the much smaller twitch in the **after**)

![before-after](https://user-images.githubusercontent.com/1498098/98317175-5b229480-201f-11eb-8e23-2e2374a4fade.png)
