### PR TITLE
Move get_frame_string from Copter to AP_Motors

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -865,7 +865,6 @@ private:
     void update_auto_armed();
     bool should_log(uint32_t mask);
     MAV_TYPE get_frame_mav_type();
-    const char* get_frame_string();
     void allocate_motors(void);
     bool is_tradheli() const;
 

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -9,7 +9,7 @@ uint8_t GCS_Copter::sysid_this_mav() const
 
 const char* GCS_Copter::frame_string() const
 {
-    return copter.get_frame_string();
+    return copter.motors->get_frame_string();
 }
 
 bool GCS_Copter::simple_input_active() const

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -529,7 +529,7 @@ bool GCS_MAVLINK_Copter::params_ready() const
 void GCS_MAVLINK_Copter::send_banner()
 {
     GCS_MAVLINK::send_banner();
-    send_text(MAV_SEVERITY_INFO, "Frame: %s", copter.get_frame_string());
+    send_text(MAV_SEVERITY_INFO, "Frame: %s", copter.motors->get_frame_string());
 }
 
 // a RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -617,7 +617,7 @@ const struct LogStructure Copter::log_structure[] = {
 void Copter::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by AP_Logger
-    logger.Write_MessageF("Frame: %s", get_frame_string());
+    logger.Write_MessageF("Frame: %s, Type: %s", motors->get_frame_string(), motors->get_type_string());
     logger.Write_Mode((uint8_t)control_mode, control_mode_reason);
     ahrs.Log_Write_Home_And_Origin();
     gps.Write_AP_Logger_Log_Startup_messages();

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -42,7 +42,7 @@ void Copter::init_rc_in()
 void Copter::init_rc_out()
 {
     motors->set_loop_rate(scheduler.get_loop_rate_hz());
-    motors->init((AP_Motors::motor_frame_class)g2.frame_class.get(), (AP_Motors::motor_frame_type)g.frame_type.get());
+    motors->initialise((AP_Motors::motor_frame_class)g2.frame_class.get(), (AP_Motors::motor_frame_type)g.frame_type.get());
 
     // enable aux servos to cope with multiple output channels per motor
     SRV_Channels::enable_aux_servos();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -478,42 +478,6 @@ MAV_TYPE Copter::get_frame_mav_type()
     return MAV_TYPE_GENERIC;
 }
 
-// return string corresponding to frame_class
-const char* Copter::get_frame_string()
-{
-    switch ((AP_Motors::motor_frame_class)g2.frame_class.get()) {
-        case AP_Motors::MOTOR_FRAME_QUAD:
-            return "QUAD";
-        case AP_Motors::MOTOR_FRAME_HEXA:
-            return "HEXA";
-        case AP_Motors::MOTOR_FRAME_Y6:
-            return "Y6";
-        case AP_Motors::MOTOR_FRAME_OCTA:
-            return "OCTA";
-        case AP_Motors::MOTOR_FRAME_OCTAQUAD:
-            return "OCTA_QUAD";
-        case AP_Motors::MOTOR_FRAME_HELI:
-            return "HELI";
-        case AP_Motors::MOTOR_FRAME_HELI_DUAL:
-            return "HELI_DUAL";
-        case AP_Motors::MOTOR_FRAME_HELI_QUAD:
-            return "HELI_QUAD";
-        case AP_Motors::MOTOR_FRAME_TRI:
-            return "TRI";
-        case AP_Motors::MOTOR_FRAME_SINGLE:
-            return "SINGLE";
-        case AP_Motors::MOTOR_FRAME_COAX:
-            return "COAX";
-        case AP_Motors::MOTOR_FRAME_TAILSITTER:
-            return "TAILSITTER";
-        case AP_Motors::MOTOR_FRAME_DODECAHEXA:
-            return "DODECA_HEXA";
-        case AP_Motors::MOTOR_FRAME_UNDEFINED:
-        default:
-            return "UNKNOWN";
-    }
-}
-
 /*
   allocate the motors class
  */

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -511,6 +511,10 @@ void Plane::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by AP_Logger
     Log_Write_Startup(TYPE_GROUNDSTART_MSG);
+    if (quadplane.initialised) {
+        logger.Write_MessageF("QuadPlane Frame: %s, Type: %s", quadplane.motors->get_frame_string(),
+                                                               quadplane.motors->get_type_string());
+    }
     logger.Write_Mode(control_mode->mode_number(), control_mode_reason);
     ahrs.Log_Write_Home_And_Origin();
     gps.Write_AP_Logger_Log_Startup_messages();

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -283,9 +283,9 @@ float AP_Motors6DOF::get_current_limit_max_throttle()
 // ToDo calculate headroom for rpy to be added for stabilization during full throttle/forward/lateral commands
 void AP_Motors6DOF::output_armed_stabilizing()
 {
-    if ((sub_frame_t)_last_frame_class == SUB_FRAME_VECTORED) {
+    if ((sub_frame_t)_active_frame_class == SUB_FRAME_VECTORED) {
         output_armed_stabilizing_vectored();
-    } else if ((sub_frame_t)_last_frame_class == SUB_FRAME_VECTORED_6DOF) {
+    } else if ((sub_frame_t)_active_frame_class == SUB_FRAME_VECTORED_6DOF) {
         output_armed_stabilizing_vectored_6dof();
     } else {
         uint8_t i;                          // general purpose counter

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -29,6 +29,30 @@ public:
         SUB_FRAME_CUSTOM
     } sub_frame_t;
 
+    virtual const char* get_frame_string() override
+    {
+        switch ((sub_frame_t)_active_frame_class) {
+            case sub_frame_t::SUB_FRAME_BLUEROV1:
+                return "BLUEROV1";
+            case sub_frame_t::SUB_FRAME_VECTORED:
+                return "VECTORED";
+            case sub_frame_t::SUB_FRAME_VECTORED_6DOF:
+                return "VECTORED_6DOF";
+            case sub_frame_t::SUB_FRAME_VECTORED_6DOF_90DEG:
+                return "VECTORED_6DOF_90DEG";
+            case sub_frame_t::SUB_FRAME_SIMPLEROV_3:
+                return "SIMPLEROV_3";
+            case sub_frame_t::SUB_FRAME_SIMPLEROV_4:
+                return "SIMPLEROV_4";
+            case sub_frame_t::SUB_FRAME_SIMPLEROV_5:
+                return "SIMPLEROV_5";
+            case sub_frame_t::SUB_FRAME_CUSTOM:
+                return "CUSTOM";
+            default:
+                return "UNKNOWN";
+        }
+    };
+
     // Override parent
     void setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -23,8 +23,8 @@ extern const AP_HAL::HAL& hal;
 void AP_MotorsMatrix::init(motor_frame_class frame_class, motor_frame_type frame_type)
 {
     // record requested frame class and type
-    _last_frame_class = frame_class;
-    _last_frame_type = frame_type;
+    _active_frame_class = frame_class;
+    _active_frame_type = frame_type;
 
     // setup the motors
     setup_motors(frame_class, frame_type);
@@ -52,11 +52,11 @@ void AP_MotorsMatrix::set_update_rate(uint16_t speed_hz)
 void AP_MotorsMatrix::set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type)
 {
     // exit immediately if armed or no change
-    if (armed() || (frame_class == _last_frame_class && _last_frame_type == frame_type)) {
+    if (armed() || (frame_class == _active_frame_class && _active_frame_type == frame_type)) {
         return;
     }
-    _last_frame_class = frame_class;
-    _last_frame_type = frame_type;
+    _active_frame_class = frame_class;
+    _active_frame_type = frame_type;
 
     // setup the motors
     setup_motors(frame_class, frame_type);

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -88,8 +88,6 @@ protected:
     float               _yaw_factor[AP_MOTORS_MAX_NUM_MOTORS];  // each motors contribution to yaw (normally 1 or -1)
     float               _thrust_rpyt_out[AP_MOTORS_MAX_NUM_MOTORS]; // combined roll, pitch, yaw and throttle outputs to motors in 0~1 range
     uint8_t             _test_order[AP_MOTORS_MAX_NUM_MOTORS];  // order of the motors in the test sequence
-    motor_frame_class   _last_frame_class; // most recently requested frame class (i.e. quad, hexa, octa, etc)
-    motor_frame_type    _last_frame_type; // most recently requested frame type (i.e. plus, x, v, etc)
 
     // motor failure handling
     float               _thrust_rpyt_out_filt[AP_MOTORS_MAX_NUM_MOTORS];    // filtered thrust outputs with 1 second time constant

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -47,9 +47,9 @@ public:
     };
 
     // return string corresponding to frame_class
-    virtual const char* get_frame_string()
+    const char* get_frame_string()
     {
-        switch (_active_frame_class) {
+        switch (_last_frame_class) {
             case AP_Motors::MOTOR_FRAME_QUAD:
                 return "QUAD";
             case AP_Motors::MOTOR_FRAME_HEXA:
@@ -99,13 +99,12 @@ public:
         MOTOR_FRAME_TYPE_NYT_PLUS = 16, // plus frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_NYT_X = 17, // X frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_BF_X_REV = 18, // X frame, betaflight ordering, reversed motors
-        MOTOR_FRAME_TYPE_UNUSED
     };
 
     // return string corresponding to frame_type
     const char* get_type_string()
     {
-        switch(_active_frame_type) {
+        switch(_last_frame_type) {
             case MOTOR_FRAME_TYPE_PLUS:
                 return "PLUS";
             case MOTOR_FRAME_TYPE_X:
@@ -138,8 +137,6 @@ public:
                 return "NYT_X";
             case MOTOR_FRAME_TYPE_BF_X_REV:
                 return "BF_X_REV";
-            case MOTOR_FRAME_TYPE_UNUSED:
-                return "UNUSED";
             default:
                 return "UNKNOWN";
         }
@@ -237,10 +234,11 @@ public:
     virtual void        set_update_rate( uint16_t speed_hz ) { _speed_hz = speed_hz; }
 
     // init
-    void                initialise(motor_frame_class frame_class, motor_frame_type frame_type)
+    virtual void        init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
+    void                _init_(motor_frame_class frame_class, motor_frame_type frame_type)
     {
-        _active_frame_class = frame_class;
-        _active_frame_type = frame_type;
+        _last_frame_class = frame_class;
+        _last_frame_type = frame_type;
         init(frame_class, frame_type);
     }
 
@@ -294,10 +292,8 @@ protected:
     virtual void        rc_set_freq(uint32_t mask, uint16_t freq_hz);
     virtual uint32_t    rc_map_mask(uint32_t mask) const;
 
-    motor_frame_class   _active_frame_class; // active frame class (i.e. quad, hexa, octa, etc)
-    motor_frame_type    _active_frame_type;  // active frame type (i.e. plus, x, v, etc)
-
-    virtual void init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
+    motor_frame_class   _last_frame_class; // active frame class (i.e. quad, hexa, octa, etc)
+    motor_frame_type    _last_frame_type;  // active frame type (i.e. plus, x, v, etc)
 
     // add a motor to the motor map
     void add_motor_num(int8_t motor_num);

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -45,6 +45,43 @@ public:
         MOTOR_FRAME_DODECAHEXA = 12,
         MOTOR_FRAME_HELI_QUAD = 13,
     };
+
+    // return string corresponding to frame_class
+    virtual const char* get_frame_string()
+    {
+        switch (_active_frame_class) {
+            case AP_Motors::MOTOR_FRAME_QUAD:
+                return "QUAD";
+            case AP_Motors::MOTOR_FRAME_HEXA:
+                return "HEXA";
+            case AP_Motors::MOTOR_FRAME_Y6:
+                return "Y6";
+            case AP_Motors::MOTOR_FRAME_OCTA:
+                return "OCTA";
+            case AP_Motors::MOTOR_FRAME_OCTAQUAD:
+                return "OCTA_QUAD";
+            case AP_Motors::MOTOR_FRAME_HELI:
+                return "HELI";
+            case AP_Motors::MOTOR_FRAME_HELI_DUAL:
+                return "HELI_DUAL";
+            case AP_Motors::MOTOR_FRAME_HELI_QUAD:
+                return "HELI_QUAD";
+            case AP_Motors::MOTOR_FRAME_TRI:
+                return "TRI";
+            case AP_Motors::MOTOR_FRAME_SINGLE:
+                return "SINGLE";
+            case AP_Motors::MOTOR_FRAME_COAX:
+                return "COAX";
+            case AP_Motors::MOTOR_FRAME_TAILSITTER:
+                return "TAILSITTER";
+            case AP_Motors::MOTOR_FRAME_DODECAHEXA:
+                return "DODECA_HEXA";
+            case AP_Motors::MOTOR_FRAME_UNDEFINED:
+            default:
+                return "UNKNOWN";
+        }
+    };
+
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,
         MOTOR_FRAME_TYPE_X = 1,
@@ -62,6 +99,50 @@ public:
         MOTOR_FRAME_TYPE_NYT_PLUS = 16, // plus frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_NYT_X = 17, // X frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_BF_X_REV = 18, // X frame, betaflight ordering, reversed motors
+        MOTOR_FRAME_TYPE_UNUSED
+    };
+
+    // return string corresponding to frame_type
+    const char* get_type_string()
+    {
+        switch(_active_frame_type) {
+            case MOTOR_FRAME_TYPE_PLUS:
+                return "PLUS";
+            case MOTOR_FRAME_TYPE_X:
+                return "X";
+            case MOTOR_FRAME_TYPE_V:
+                return "V";
+            case MOTOR_FRAME_TYPE_H:
+                return "H";
+            case MOTOR_FRAME_TYPE_VTAIL:
+                return "VTAIL";
+            case MOTOR_FRAME_TYPE_ATAIL:
+                return "ATAIL";
+            case MOTOR_FRAME_TYPE_PLUSREV:
+                return "PLUSREV";
+            case MOTOR_FRAME_TYPE_Y6B:
+                return "Y6B";
+            case MOTOR_FRAME_TYPE_Y6F:
+                return "Y6F";
+            case MOTOR_FRAME_TYPE_BF_X:
+                return "BF_X";
+            case MOTOR_FRAME_TYPE_DJI_X:
+                return "DJI_X";
+            case MOTOR_FRAME_TYPE_CW_X:
+                return "CW_X";
+            case MOTOR_FRAME_TYPE_I:
+                return "I";
+            case MOTOR_FRAME_TYPE_NYT_PLUS:
+                return "NYT_PLUS";
+            case MOTOR_FRAME_TYPE_NYT_X:
+                return "NYT_X";
+            case MOTOR_FRAME_TYPE_BF_X_REV:
+                return "BF_X_REV";
+            case MOTOR_FRAME_TYPE_UNUSED:
+                return "UNUSED";
+            default:
+                return "UNKNOWN";
+        }
     };
 
     // Constructor
@@ -156,7 +237,12 @@ public:
     virtual void        set_update_rate( uint16_t speed_hz ) { _speed_hz = speed_hz; }
 
     // init
-    virtual void        init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
+    void                initialise(motor_frame_class frame_class, motor_frame_type frame_type)
+    {
+        _active_frame_class = frame_class;
+        _active_frame_type = frame_type;
+        init(frame_class, frame_type);
+    }
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     virtual void        set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
@@ -207,6 +293,11 @@ protected:
     virtual void        rc_write_angle(uint8_t chan, int16_t angle_cd);
     virtual void        rc_set_freq(uint32_t mask, uint16_t freq_hz);
     virtual uint32_t    rc_map_mask(uint32_t mask) const;
+
+    motor_frame_class   _active_frame_class; // active frame class (i.e. quad, hexa, octa, etc)
+    motor_frame_type    _active_frame_type;  // active frame type (i.e. plus, x, v, etc)
+
+    virtual void init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
 
     // add a motor to the motor map
     void add_motor_num(int8_t motor_num);


### PR DESCRIPTION
first 2 commits move the copter-only frame_string enum to AP_Motors_class.h
and add a new static string method get_frame_type().
The first plane commit switches to using the class and type strings.
Second plane commit changes from gcs().send_text to hal.console->printf since the gcs never receives those messages. I was using sitl/mavproxy to test this, but perhaps I was doing something wrong?
 Third plane commit adds a log message for quadplane which is similar to copter's.