### PR TITLE
Plane: move tailsitter to own class

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -383,7 +383,7 @@ void Plane::stabilize()
           during transition to vtol in a tailsitter try to raise the
           nose rapidly while keeping the wings level
          */
-        nav_pitch_cd = constrain_float((quadplane.tailsitter.transition_angle+5)*100, 5500, 8500),
+        nav_pitch_cd = constrain_float((quadplane.tailsitter_vars.transition_angle+5)*100, 5500, 8500),
         nav_roll_cd = 0;
     }
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -89,6 +89,7 @@
 #include "GCS_Mavlink.h"
 #include "GCS_Plane.h"
 #include "quadplane.h"
+#include "tailsitter.h"
 #include "tuning.h"
 
 // Configuration
@@ -127,6 +128,7 @@ public:
     friend class ParametersG2;
     friend class AP_Arming_Plane;
     friend class QuadPlane;
+    friend class tailsitter;
     friend class QAutoTune;
     friend class AP_Tuning_Plane;
     friend class AP_AdvancedFailsafe_Plane;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -778,7 +778,8 @@ private:
     uint32_t rudder_arm_timer;
 
     // support for quadcopter-plane
-    QuadPlane quadplane{ahrs};
+    //QuadPlane quadplane{ahrs};
+    tailsitter quadplane{ahrs};
 
     // support for transmitter tuning
     AP_Tuning_Plane tuning;

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -23,8 +23,8 @@ void ModeQStabilize::update()
     // Scale from normalized input [-1,1] to centidegrees
     if (plane.quadplane.tailsitter_active()) {
         // separate limit for tailsitter roll, if set
-        if (plane.quadplane.tailsitter.max_roll_angle > 0) {
-            roll_limit = plane.quadplane.tailsitter.max_roll_angle * 100.0f;
+        if (plane.quadplane.tailsitter_vars.max_roll_angle > 0) {
+            roll_limit = plane.quadplane.tailsitter_vars.max_roll_angle * 100.0f;
         }
 
         // angle max for tailsitter pitch

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -264,7 +264,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @DisplayName: Tailsitter transition angle
     // @Description: This is the angle at which tailsitter aircraft will change from VTOL control to fixed wing control.
     // @Range: 5 80
-    AP_GROUPINFO("TAILSIT_ANGLE", 48, QuadPlane, tailsitter.transition_angle, 45),
+    AP_GROUPINFO("TAILSIT_ANGLE", 48, QuadPlane, tailsitter_vars.transition_angle, 45),
 
     // @Param: TILT_RATE_DN
     // @DisplayName: Tiltrotor downwards tilt rate
@@ -279,33 +279,33 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @DisplayName: Tailsitter input type bitmask
     // @Description: This controls whether stick input when hovering as a tailsitter follows the conventions for fixed wing hovering or multicopter hovering. When PlaneMode is not enabled (bit0 = 0) the roll stick will roll the aircraft in earth frame and yaw stick will yaw in earth frame. When PlaneMode input is enabled, the roll and yaw sticks are swapped so that the roll stick controls earth-frame yaw and rudder controls earth-frame roll. When body-frame roll is enabled (bit1 = 1), the yaw stick controls earth-frame yaw rate and the roll stick controls roll in the tailsitter's body frame when flying level.
     // @Bitmask: 0:PlaneMode,1:BodyFrameRoll
-    AP_GROUPINFO("TAILSIT_INPUT", 50, QuadPlane, tailsitter.input_type, 0),
+    AP_GROUPINFO("TAILSIT_INPUT", 50, QuadPlane, tailsitter_vars.input_type, 0),
 
     // @Param: TAILSIT_MASK
     // @DisplayName: Tailsitter input mask
     // @Description: This controls what channels have full manual control when hovering as a tailsitter and the Q_TAILSIT_MASKCH channel in high. This can be used to teach yourself to prop-hang a 3D plane by learning one or more channels at a time.
     // @Bitmask: 0:Aileron,1:Elevator,2:Throttle,3:Rudder
-    AP_GROUPINFO("TAILSIT_MASK", 51, QuadPlane, tailsitter.input_mask, 0),
+    AP_GROUPINFO("TAILSIT_MASK", 51, QuadPlane, tailsitter_vars.input_mask, 0),
 
     // @Param: TAILSIT_MASKCH
     // @DisplayName: Tailsitter input mask channel
     // @Description: This controls what input channel will activate the Q_TAILSIT_MASK mask. When this channel goes above 1700 then the pilot will have direct manual control of the output channels specified in Q_TAILSIT_MASK. Set to zero to disable.
     // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
-    AP_GROUPINFO("TAILSIT_MASKCH", 52, QuadPlane, tailsitter.input_mask_chan, 0),
+    AP_GROUPINFO("TAILSIT_MASKCH", 52, QuadPlane, tailsitter_vars.input_mask_chan, 0),
 
     // @Param: TAILSIT_VFGAIN
     // @DisplayName: Tailsitter vector thrust gain in forward flight
     // @Description: This controls the amount of vectored thrust control used in forward flight for a vectored tailsitter
     // @Range: 0 1
     // @Increment: 0.01
-    AP_GROUPINFO("TAILSIT_VFGAIN", 53, QuadPlane, tailsitter.vectored_forward_gain, 0),
+    AP_GROUPINFO("TAILSIT_VFGAIN", 53, QuadPlane, tailsitter_vars.vectored_forward_gain, 0),
 
     // @Param: TAILSIT_VHGAIN
     // @DisplayName: Tailsitter vector thrust gain in hover
     // @Description: This controls the amount of vectored thrust control used in hover for a vectored tailsitter
     // @Range: 0 1
     // @Increment: 0.01
-    AP_GROUPINFO("TAILSIT_VHGAIN", 54, QuadPlane, tailsitter.vectored_hover_gain, 0.5),
+    AP_GROUPINFO("TAILSIT_VHGAIN", 54, QuadPlane, tailsitter_vars.vectored_hover_gain, 0.5),
 
     // @Param: TILT_YAW_ANGLE
     // @DisplayName: Tilt minimum angle for vectored yaw
@@ -318,7 +318,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Description: This controls the amount of extra pitch given to the vectored control when at high pitch errors
     // @Range: 0 4
     // @Increment: 0.1
-    AP_GROUPINFO("TAILSIT_VHPOW", 56, QuadPlane, tailsitter.vectored_hover_power, 2.5),
+    AP_GROUPINFO("TAILSIT_VHPOW", 56, QuadPlane, tailsitter_vars.vectored_hover_power, 2.5),
 
     // @Param: MAV_TYPE
     // @DisplayName: MAVLink type identifier
@@ -358,7 +358,7 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Description: Maximum value of throttle scaling for tailsitter velocity scaling, reduce this value to remove low throttle oscillations
     // @Range: 1 5
     // @User: Standard
-    AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 2),
+    AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter_vars.throttle_scale_max, 2),
 
     // @Param: TRIM_PITCH
     // @DisplayName: Quadplane AHRS trim pitch
@@ -376,7 +376,7 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Units: deg
     // @Range: 0 80
     // @User: Standard
-    AP_GROUPINFO("TAILSIT_RLL_MX", 5, QuadPlane, tailsitter.max_roll_angle, 0),
+    AP_GROUPINFO("TAILSIT_RLL_MX", 5, QuadPlane, tailsitter_vars.max_roll_angle, 0),
 
 #if QAUTOTUNE_ENABLED
     // @Group: AUTOTUNE_
@@ -407,7 +407,7 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Description: Bitmask of motors to remain active in forward flight for a 'copter' tailsitter. Non-zero indicates airframe is a tailsitter which pitches forward 90 degrees in forward flight modes.
     // @User: Standard
     // @Bitmask: 0:Motor 1,1:Motor 2,2:Motor 3,3:Motor 4, 4:Motor 5,5:Motor 6,6:Motor 7,7:Motor 8
-    AP_GROUPINFO("TAILSIT_MOTMX", 9, QuadPlane, tailsitter.motor_mask, 0),
+    AP_GROUPINFO("TAILSIT_MOTMX", 9, QuadPlane, tailsitter_vars.motor_mask, 0),
 
     // @Param: THROTTLE_EXPO
     // @DisplayName: Throttle expo strength
@@ -475,14 +475,14 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Description: Bitmask of gain scaling methods to be applied: BOOST: boost gain at low throttle, ATT_THR: reduce gain at high throttle/tilt
     // @User: Standard
     // @Bitmask: 0:BOOST,1:ATT_THR
-    AP_GROUPINFO("TAILSIT_GSCMSK", 17, QuadPlane, tailsitter.gain_scaling_mask, TAILSITTER_GSCL_BOOST),
+    AP_GROUPINFO("TAILSIT_GSCMSK", 17, QuadPlane, tailsitter_vars.gain_scaling_mask, TAILSITTER_GSCL_BOOST),
 
     // @Param: TAILSIT_GSCMIN
     // @DisplayName: Minimum gain scaling based on throttle and attitude
     // @Description: Minimum gain scaling at high throttle/tilt angle
     // @Range: 0.1 1
     // @User: Standard
-    AP_GROUPINFO("TAILSIT_GSCMIN", 18, QuadPlane, tailsitter.gain_scaling_min, 0.4),
+    AP_GROUPINFO("TAILSIT_GSCMIN", 18, QuadPlane, tailsitter_vars.gain_scaling_min, 0.4),
 
     // @Param: ASSIST_DELAY
     // @DisplayName: Quadplane assistance delay
@@ -595,7 +595,6 @@ bool QuadPlane::setup(void)
     float loop_delta_t = 1.0 / plane.scheduler.get_loop_rate_hz();
 
     enum AP_Motors::motor_frame_class motor_class;
-    enum Rotation rotation = ROTATION_NONE;
 
     /*
       cope with upgrade from old AP_Motors values for frame_class
@@ -665,35 +664,21 @@ bool QuadPlane::setup(void)
         AP_BoardConfig::config_error("Unknown Q_FRAME_CLASS %u", (unsigned)frame_class.get());
     }
 
-    if (tailsitter.motor_mask == 0) {
-        // this is a normal quadplane
-        switch (motor_class) {
-        case AP_Motors::MOTOR_FRAME_TRI:
-            motors = new AP_MotorsTri(plane.scheduler.get_loop_rate_hz(), rc_speed);
-            motors_var_info = AP_MotorsTri::var_info;
-            break;
-        case AP_Motors::MOTOR_FRAME_TAILSITTER:
-            // this is a duo-motor tailsitter (vectored thrust if tilt.tilt_mask != 0)
-            motors = new AP_MotorsTailsitter(plane.scheduler.get_loop_rate_hz(), rc_speed);
-            motors_var_info = AP_MotorsTailsitter::var_info;
-            if (tilt.tilt_type != TILT_TYPE_BICOPTER) {
-                rotation = ROTATION_PITCH_90;
-            }
-            break;
-        default:
-            motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);
-            motors_var_info = AP_MotorsMatrix::var_info;
-            break;
-        }
-    } else {
-        // this is a copter tailsitter with motor layout specified by frame_class and frame_type
-        // tilting motors are not supported (tiltrotor control variables are ignored)
-        if (tilt.tilt_mask != 0) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Warning: Motor tilt not supported");
-        }
-        rotation = ROTATION_PITCH_90;
+    // this is a normal quadplane
+    switch (motor_class) {
+    case AP_Motors::MOTOR_FRAME_TRI:
+        motors = new AP_MotorsTri(plane.scheduler.get_loop_rate_hz(), rc_speed);
+        motors_var_info = AP_MotorsTri::var_info;
+        break;
+    case AP_Motors::MOTOR_FRAME_TAILSITTER:
+        // this is a duo-motor tilt rotor
+        motors = new AP_MotorsTailsitter(plane.scheduler.get_loop_rate_hz(), rc_speed);
+        motors_var_info = AP_MotorsTailsitter::var_info;
+        break;
+    default:
         motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);
         motors_var_info = AP_MotorsMatrix::var_info;
+        break;
     }
 
     if (!motors) {
@@ -703,7 +688,7 @@ bool QuadPlane::setup(void)
     AP_Param::load_object_from_eeprom(motors, motors_var_info);
 
     // create the attitude view used by the VTOL code
-    ahrs_view = ahrs.create_view(rotation, ahrs_trim_pitch);
+    ahrs_view = ahrs.create_view(ROTATION_NONE, ahrs_trim_pitch);
     if (ahrs_view == nullptr) {
         AP_BoardConfig::config_error("Unable to allocate %s", "ahrs_view");
     }
@@ -789,7 +774,7 @@ void QuadPlane::setup_defaults(void)
     if (motor_class == AP_Motors::MOTOR_FRAME_TAILSITTER) {
         AP_Param::set_defaults_from_table(defaults_table_tailsitter, ARRAY_SIZE(defaults_table_tailsitter));
     }
-    
+
     // reset ESC calibration
     if (esc_calibration != 0) {
         esc_calibration.set_and_save(0);
@@ -837,53 +822,7 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
     check_attitude_relax();
 
     // normal control modes for VTOL and FW flight
-    // tailsitter in transition to VTOL flight is not really in a VTOL mode yet
-    if (in_vtol_mode() && !in_tailsitter_vtol_transition()) {
-
-        // tailsitter-only body-frame roll control options
-        // Angle mode attitude control for pitch and body-frame roll, rate control for euler yaw.
-        if (is_tailsitter() &&
-            (tailsitter.input_type & TAILSITTER_INPUT_BF_ROLL)) {
-
-            if (!(tailsitter.input_type & TAILSITTER_INPUT_PLANE)) {
-                // In multicopter input mode, the roll and yaw stick axes are independent of pitch
-                attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll(false,
-                                                                                plane.nav_roll_cd,
-                                                                                plane.nav_pitch_cd,
-                                                                                yaw_rate_cds);
-                return;
-            } else {
-                // In plane input mode, the roll and yaw sticks are swapped
-                // and their effective axes rotate from yaw to roll and vice versa
-                // as pitch goes from zero to 90.
-                // So it is necessary to also rotate their scaling.
-
-                // Get the roll angle and yaw rate limits
-                int16_t roll_limit = aparm.angle_max;
-                // separate limit for tailsitter roll, if set
-                if (tailsitter.max_roll_angle > 0) {
-                    roll_limit = tailsitter.max_roll_angle * 100.0f;
-                }
-                // Prevent a divide by zero
-                float yaw_rate_limit = ((yaw_rate_max < 1.0f) ? 1 : yaw_rate_max) * 100.0f;
-                float yaw2roll_scale = roll_limit / yaw_rate_limit;
-
-                // Rotate as a function of Euler pitch and swap roll/yaw
-                float euler_pitch = radians(.01f * plane.nav_pitch_cd);
-                float spitch = fabsf(sinf(euler_pitch));
-                float y2r_scale = linear_interpolate(1, yaw2roll_scale, spitch, 0, 1);
-
-                float p_yaw_rate = plane.nav_roll_cd / y2r_scale;
-                float p_roll_angle = -y2r_scale * yaw_rate_cds;
-
-                attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll(true,
-                                                                                p_roll_angle,
-                                                                                plane.nav_pitch_cd,
-                                                                                p_yaw_rate);
-                return;
-            }
-        }
-
+    if (in_vtol_mode()) {
         // use euler angle attitude control
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                       plane.nav_pitch_cd,
@@ -892,12 +831,7 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
         // use the fixed wing desired rates
         float roll_rate = plane.rollController.get_pid_info().target;
         float pitch_rate = plane.pitchController.get_pid_info().target;
-        if (is_tailsitter()) {
-            // tailsitter roll and yaw swapped due to change in reference frame
-            attitude_control->input_rate_bf_roll_pitch_yaw_2(yaw_rate_cds,pitch_rate*100.0f, -roll_rate*100.0f);
-        } else {
-            attitude_control->input_rate_bf_roll_pitch_yaw_2(roll_rate*100.0f, pitch_rate*100.0f, yaw_rate_cds);
-        }
+        attitude_control->input_rate_bf_roll_pitch_yaw_2(roll_rate*100.0f, pitch_rate*100.0f, yaw_rate_cds);
     }
 }
 
@@ -910,18 +844,10 @@ void QuadPlane::hold_stabilize(float throttle_in)
     if ((throttle_in <= 0) && (air_mode == AirMode::OFF)) {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0, true, 0);
-        if (!is_tailsitter()) {
-            // always stabilize with tailsitters so we can do belly takeoffs
-            attitude_control->relax_attitude_controllers();
-        }
+        attitude_control->relax_attitude_controllers();
     } else {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-        bool should_boost = true;
-        if (is_tailsitter() && assisted_flight) {
-            // tailsitters in forward flight should not use angle boost
-            should_boost = false;
-        }
-        attitude_control->set_throttle_out(throttle_in, should_boost, 0);
+        attitude_control->set_throttle_out(throttle_in, true, 0);
     }
 }
 
@@ -945,14 +871,7 @@ void QuadPlane::run_z_controller(void)
 {
     const uint32_t now = AP_HAL::millis();
     if (now - last_pidz_active_ms > 2000) {
-        if (!is_tailsitter()) {
-            // set alt target to current height on transition. This
-            // starts the Z controller off with the right values
-            set_alt_target_current();
-        } else {
-            // tailsitters gain lots of vertical speed in transisison, set target to the stopping point
-            pos_control->set_target_to_stopping_point_z();
-        }
+        init_z_target();
         gcs().send_text(MAV_SEVERITY_INFO, "Reset alt target to %.1f", (double)pos_control->get_alt_target() * 0.01f);
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
 
@@ -971,7 +890,7 @@ void QuadPlane::run_z_controller(void)
         last_pidz_init_ms = now;
     }
     last_pidz_active_ms = now;
-    pos_control->update_z_controller();    
+    pos_control->update_z_controller();
 }
 
 /*
@@ -1088,15 +1007,7 @@ void QuadPlane::control_qacro(void)
         float target_roll = 0;
         float target_pitch = plane.channel_pitch->norm_input() * acro_pitch_rate * 100.0f;
         float target_yaw = 0;
-        if (is_tailsitter()) {
-            // Note that the 90 degree Y rotation for copter mode swaps body-frame roll and yaw
-            target_roll =  plane.channel_rudder->norm_input() * acro_yaw_rate * 100.0f;
-            target_yaw  = -plane.channel_roll->norm_input() * acro_roll_rate * 100.0f;
-        } else {
-            target_roll = plane.channel_roll->norm_input() * acro_roll_rate * 100.0f;
-            target_yaw  = plane.channel_rudder->norm_input() * acro_yaw_rate * 100.0;
-        }
-
+        get_acro_target_roll_yaw(target_roll, target_yaw);
         float throttle_out = get_pilot_throttle();
 
         // run attitude controller
@@ -1110,6 +1021,11 @@ void QuadPlane::control_qacro(void)
         attitude_control->set_throttle_out(throttle_out, false, 10.0f);
     }
 }
+
+void QuadPlane::get_acro_target_roll_yaw(float &target_roll, float &target_yaw) {
+    target_roll = plane.channel_roll->norm_input() * acro_roll_rate * 100.0f;
+    target_yaw  = plane.channel_rudder->norm_input() * acro_yaw_rate * 100.0;
+};
 
 /*
   control QHOVER mode
@@ -1173,9 +1089,6 @@ bool QuadPlane::is_flying(void)
         return true;
     }
     if (motors->get_throttle() > 0.01f && !motors->limit.throttle_lower) {
-        return true;
-    }
-    if (in_tailsitter_vtol_transition()) {
         return true;
     }
     return false;
@@ -1351,13 +1264,7 @@ float QuadPlane::get_pilot_input_yaw_rate_cds(void) const
     }
 
     // add in rudder input
-    float max_rate = yaw_rate_max;
-    if (is_tailsitter() &&
-        tailsitter.input_type & TAILSITTER_INPUT_BF_ROLL) {
-        // must have a non-zero max yaw rate for scaling to work
-        max_rate = (yaw_rate_max < 1.0f) ? 1 : yaw_rate_max;
-    }
-    return plane.channel_rudder->get_control_in() * max_rate / 45;
+    return plane.channel_rudder->get_control_in() * MAX(yaw_rate_max,1.0f) / 45;
 }
 
 /*
@@ -1406,10 +1313,10 @@ void QuadPlane::init_throttle_wait(void)
         plane.is_flying()) {
         throttle_wait = false;
     } else {
-        throttle_wait = true;        
+        throttle_wait = true;
     }
 }
-    
+
 // set motor arming
 void QuadPlane::set_armed(bool armed)
 {
@@ -1467,7 +1374,7 @@ float QuadPlane::desired_auto_yaw_rate_cds(void) const
  */
 bool QuadPlane::assistance_needed(float aspeed, bool have_airspeed)
 {
-    if (assist_speed <= 0 || is_contol_surface_tailsitter()) {
+    if (assist_speed <= 0) {
         // assistance disabled
         in_angle_assist = false;
         angle_error_start_ms = 0;
@@ -1567,7 +1474,7 @@ void QuadPlane::update_transition(void)
         plane.control_mode == &plane.mode_acro ||
         plane.control_mode == &plane.mode_training) {
         // in manual modes quad motors are always off
-        if (!tilt.motors_active && !is_tailsitter()) {
+        if (!tilt.motors_active) {
             motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
             motors->output();
         }
@@ -1594,11 +1501,6 @@ void QuadPlane::update_transition(void)
     float aspeed;
     bool have_airspeed = ahrs.airspeed_estimate(aspeed);
 
-    // tailsitters use angle wait, not airspeed wait
-    if (is_tailsitter() && transition_state == TRANSITION_AIRSPEED_WAIT) {
-        transition_state = TRANSITION_ANGLE_WAIT_FW;
-    }
-
     /*
       see if we should provide some assistance
      */
@@ -1606,30 +1508,18 @@ void QuadPlane::update_transition(void)
         (q_assist_state == Q_ASSIST_STATE_ENUM::Q_ASSIST_ENABLED && assistance_needed(aspeed, have_airspeed)))) {
         // the quad should provide some assistance to the plane
         assisted_flight = true;
-        if (!is_tailsitter()) {
-            // update tansition state for vehicles using airspeed wait
-            if (transition_state != TRANSITION_AIRSPEED_WAIT) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Transition started airspeed %.1f", (double)aspeed);
-            }
-            transition_state = TRANSITION_AIRSPEED_WAIT;
-            if (transition_start_ms == 0) {
-                transition_start_ms = now;
-            }
+        // update tansition state for vehicles using airspeed wait
+        if (transition_state != TRANSITION_AIRSPEED_WAIT) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Transition started airspeed %.1f", (double)aspeed);
+        }
+        transition_state = TRANSITION_AIRSPEED_WAIT;
+        if (transition_start_ms == 0) {
+            transition_start_ms = now;
         }
     } else {
         assisted_flight = false;
     }
 
-    if (is_tailsitter()) {
-        if (transition_state == TRANSITION_ANGLE_WAIT_FW &&
-            tailsitter_transition_fw_complete()) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Transition FW done");
-            transition_state = TRANSITION_DONE;
-            transition_start_ms = 0;
-            transition_low_airspeed_ms = 0;
-        }
-    }
-    
     // if rotors are fully forward then we are not transitioning,
     // unless we are waiting for airspeed to increase (in which case
     // the tilt will decrease rapidly)
@@ -1738,34 +1628,11 @@ void QuadPlane::update_transition(void)
         break;
     }
 
-    case TRANSITION_ANGLE_WAIT_FW: {
-        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-        assisted_flight = true;
-        // calculate transition rate in degrees per
-        // millisecond. Assume we want to get to the transition angle
-        // in half the transition time
-        float transition_rate = tailsitter.transition_angle / float(transition_time_ms/2);
-        uint32_t dt = now - transition_start_ms;
-        float pitch_cd;
-        pitch_cd = constrain_float((-transition_rate * dt)*100, -8500, 0);
-        // if already pitched forward at start of transition, wait until curve catches up
-        plane.nav_pitch_cd = (pitch_cd > transition_initial_pitch)? transition_initial_pitch : pitch_cd;
-        plane.nav_roll_cd = 0;
-        check_attitude_relax();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
-                                                                      plane.nav_pitch_cd,
-                                                                      0);
-        // set throttle at either hover throttle or current throttle, whichever is higher, through the transition
-        attitude_control->set_throttle_out(MAX(motors->get_throttle_hover(),attitude_control->get_throttle_in()), true, 0);
-        break;
-    }
-
+    case TRANSITION_ANGLE_WAIT_FW:
     case TRANSITION_ANGLE_WAIT_VTOL:
-        // nothing to do, this is handled in the fw attitude controller
-        return;
-
+        return; // should never hit this on a normal Quadplane
     case TRANSITION_DONE:
-        if (!tilt.motors_active && !is_tailsitter()) {
+        if (!tilt.motors_active) {
             motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
             motors->output();
         }
@@ -1810,13 +1677,7 @@ void QuadPlane::update(void)
         /*
           make sure we don't have any residual control from previous flight stages
          */
-        if (is_tailsitter()) {
-            // tailsitters only relax I terms, to make ground testing easier
-            attitude_control->reset_rate_controller_I_terms();
-        } else {
-            // otherwise full relax
-            attitude_control->relax_attitude_controllers();
-        }
+        attitude_control->relax_attitude_controllers();
         pos_control->relax_alt_hold_controllers(0);
     }
     
@@ -1830,58 +1691,22 @@ void QuadPlane::update(void)
         // output to motors
         motors_output();
 
-        if (now - last_vtol_mode_ms > 1000 && is_tailsitter()) {
-            /*
-              we are just entering a VTOL mode as a tailsitter, set
-              our transition state so the fixed wing controller brings
-              the nose up before we start trying to fly as a
-              multicopter
-             */
-            transition_state = TRANSITION_ANGLE_WAIT_VTOL;
-            transition_start_ms = now;
-        } else if (is_tailsitter() &&
-                   transition_state == TRANSITION_ANGLE_WAIT_VTOL) {
-            float aspeed;
-            bool have_airspeed = ahrs.airspeed_estimate(aspeed);
-            // provide asistance in forward flight portion of tailsitter transision
-            if (assistance_safe() && (q_assist_state == Q_ASSIST_STATE_ENUM::Q_ASSIST_FORCE ||
-                (q_assist_state == Q_ASSIST_STATE_ENUM::Q_ASSIST_ENABLED && assistance_needed(aspeed, have_airspeed)))) {
-                assisted_flight = true;
-            }
-            if (tailsitter_transition_vtol_complete()) {
-                /*
-                  we have completed transition to VTOL as a tailsitter,
-                  setup for the back transition when needed
-                */
-                gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done");
-                transition_state = TRANSITION_ANGLE_WAIT_FW;
-                transition_start_ms = now;
-            }
+        /*
+            setup the transition state appropriately for next time we go into a non-VTOL mode
+        */
+        transition_start_ms = 0;
+        transition_low_airspeed_ms = 0;
+        if (throttle_wait && !plane.is_flying()) {
+            transition_state = TRANSITION_DONE;
         } else {
             /*
-              setup the transition state appropriately for next time we go into a non-VTOL mode
+                setup for airspeed wait for later
             */
-            transition_start_ms = 0;
-            transition_low_airspeed_ms = 0;
-            if (throttle_wait && !plane.is_flying()) {
-                transition_state = TRANSITION_DONE;
-            } else if (is_tailsitter()) {
-                /*
-                  setup for the transition back to fixed wing for later
-                 */
-                transition_state = TRANSITION_ANGLE_WAIT_FW;
-                transition_start_ms = now;
-                transition_initial_pitch= constrain_float(ahrs_view->pitch_sensor,-8500,0);
-            } else {
-                /*
-                  setup for airspeed wait for later
-                 */
-                transition_state = TRANSITION_AIRSPEED_WAIT;
-            }
-            last_throttle = motors->get_throttle();
+            transition_state = TRANSITION_AIRSPEED_WAIT;
         }
-            
-        last_vtol_mode_ms = now;        
+        last_throttle = motors->get_throttle();
+
+        last_vtol_mode_ms = now;
     }
 
     // disable throttle_wait when throttle rises above 10%
@@ -2068,7 +1893,6 @@ void QuadPlane::motors_output(bool run_rate_controller)
     if (motors->get_throttle() > 0.01f || tilt.motors_active) {
         last_motors_active_ms = AP_HAL::millis();
     }
-    
 }
 
 /*
@@ -3382,19 +3206,5 @@ bool QuadPlane::in_vtol_land_sequence(void) const
 // return true if we should show VTOL view
 bool QuadPlane::show_vtol_view() const
 {
-    bool show_vtol = in_vtol_mode();
-
-    if (is_tailsitter() && hal.util->get_soft_armed()) {
-        if (show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_VTOL)) {
-            // in a vtol mode but still transitioning from forward flight
-            return false;
-        }
-
-        if (!show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_FW)) {
-            // not in VTOL mode but still transitioning from VTOL
-            return true;
-        }
-    }
-
-    return show_vtol;
+    return in_vtol_mode();
 }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -27,6 +27,7 @@ public:
     friend class AP_Arming_Plane;
     friend class RC_Channel_Plane;
     friend class RC_Channel;
+    friend class tailsitter;
 
     friend class Mode;
     friend class ModeAuto;
@@ -50,7 +51,7 @@ public:
     void control_run(void);
     void control_auto(void);
     bool init_mode(void);
-    bool setup(void);
+    virtual bool setup(void);
 
     void vtol_position_controller(void);
     void setup_target_position(void);
@@ -60,7 +61,7 @@ public:
     void update_throttle_mix(void);
     
     // update transition handling
-    void update(void);
+    virtual void update(void);
 
     // set motor arming
     void set_armed(bool armed);
@@ -83,7 +84,7 @@ public:
     /*
       return true if we are a tailsitter transitioning to VTOL flight
     */
-    bool in_tailsitter_vtol_transition(uint32_t now = 0) const;
+    virtual bool in_tailsitter_vtol_transition(uint32_t now = 0) const {return false;}
 
     bool handle_do_vtol_transition(enum MAV_VTOL_STATE state);
 
@@ -95,10 +96,10 @@ public:
     bool in_vtol_mode(void) const;
     bool in_vtol_posvel_mode(void) const;
     void update_throttle_hover();
-    bool show_vtol_view() const;
+    virtual bool show_vtol_view() const;
 
     // vtol help for is_flying()
-    bool is_flying(void);
+    virtual bool is_flying(void);
 
     // return current throttle as a percentate
     uint8_t throttle_percentage(void) const {
@@ -113,32 +114,18 @@ public:
     bool is_flying_vtol(void) const;
 
     // return true when tailsitter frame configured
-    bool is_tailsitter(void) const;
-
-    // return true when flying a control surface only tailsitter tailsitter
-    bool is_contol_surface_tailsitter(void) const;
+    virtual bool is_tailsitter(void) const {return false;}
 
     // return true when flying a tailsitter in VTOL
-    bool tailsitter_active(void);
-    
-    // create outputs for tailsitters
-    void tailsitter_output(void);
+    virtual bool tailsitter_active(void) const {return false;}
 
-    // handle different tailsitter input types
-    void tailsitter_check_input(void);
-    
-    // check if we have completed transition to fixed wing
-    bool tailsitter_transition_fw_complete(void);
+    // create servo outputs
+    virtual void output(void) {};
 
+    // handle different input types
+    virtual void check_input(void) {};
     // return true if we are a tailsitter in FW flight
-    bool is_tailsitter_in_fw_flight(void) const;
-
-    // check if we have completed transition to vtol
-    bool tailsitter_transition_vtol_complete(void) const;
-
-    // account for control surface speed scaling in VTOL modes
-    void tailsitter_speed_scaling(void);
-
+    virtual bool is_tailsitter_in_fw_flight(void) const {return false;}
     // user initiated takeoff for guided mode
     bool do_user_takeoff(float takeoff_altitude);
 
@@ -201,13 +188,13 @@ private:
     AirMode air_mode;
 
     // check for quadplane assistance needed
-    bool assistance_needed(float aspeed, bool have_airspeed);
+    virtual bool assistance_needed(float aspeed, bool have_airspeed);
 
     // check if it is safe to provide assistance
     bool assistance_safe();
 
     // update transition handling
-    void update_transition(void);
+    virtual void update_transition(void);
 
     // check for an EKF yaw reset
     void check_yaw_reset(void);
@@ -216,7 +203,7 @@ private:
     void hold_hover(float target_climb_rate);    
 
     // hold stabilize (for transition)
-    void hold_stabilize(float throttle_in);    
+    virtual void hold_stabilize(float throttle_in);
 
     // get pilot desired yaw rate in cd/s
     float get_pilot_input_yaw_rate_cds(void) const;
@@ -231,7 +218,7 @@ private:
     void init_throttle_wait();
 
     // use multicopter rate controller
-    void multicopter_attitude_rate_update(float yaw_rate_cds);
+    virtual void multicopter_attitude_rate_update(float yaw_rate_cds);
     
     // main entry points for VTOL flight modes
     void init_stabilize(void);
@@ -241,6 +228,7 @@ private:
     void init_qacro(void);
     float get_pilot_throttle(void);
     void control_qacro(void);
+    virtual void get_acro_target_roll_yaw(float &target_roll, float &target_yaw);
     void init_hover(void);
     void control_hover(void);
 
@@ -273,6 +261,7 @@ private:
     void update_throttle_suppression(void);
 
     void run_z_controller(void);
+    virtual void init_z_target() {set_alt_target_current();}
 
     void setup_defaults(void);
 
@@ -512,7 +501,7 @@ private:
         AP_Float scaling_speed_min;
         AP_Float scaling_speed_max;
         AP_Int16 gain_scaling_mask;
-    } tailsitter;
+    } tailsitter_vars;
 
     // tailsitter speed scaler
     float last_spd_scaler = 1.0f; // used to slew rate limiting with TAILSITTER_GSCL_ATT_THR option

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -226,7 +226,7 @@ void Plane::read_radio()
     rudder_arm_disarm_check();
 
     // potentially swap inputs for tailsitters
-    quadplane.tailsitter_check_input();
+    quadplane.check_input();
 
     // check for transmitter tuning changes
     tuning.check_input(control_mode->mode_number());

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -915,7 +915,7 @@ void Plane::servos_output(void)
     servos_twin_engine_mix();
 
     // cope with tailsitters and bicopters
-    quadplane.tailsitter_output();
+    quadplane.output();
     quadplane.tiltrotor_bicopter();
 
     // support forced flare option

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -21,29 +21,479 @@
 #include <math.h>
 #include "Plane.h"
 
-/*
-  return true when flying a tailsitter
- */
-bool QuadPlane::is_tailsitter(void) const
+bool tailsitter::setup()
 {
-    return available()
-        && ((frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) || (tailsitter.motor_mask != 0))
-        && (tilt.tilt_type != TILT_TYPE_BICOPTER);
+    if (initialised) {
+        return true;
+    }
+    if (!enable || hal.util->get_soft_armed()) {
+        return false;
+    }
+    float loop_delta_t = 1.0 / plane.scheduler.get_loop_rate_hz();
+
+    if (hal.util->available_memory() <
+        4096 + sizeof(*motors) + sizeof(*attitude_control) + sizeof(*pos_control) + sizeof(*wp_nav) + sizeof(*ahrs_view) + sizeof(*loiter_nav)) {
+        AP_BoardConfig::config_error("Not enough memory for quadplane");
+    }
+
+    /*
+      dynamically allocate the key objects for quadplane. This ensures
+      that the objects don't affect the vehicle unless enabled and
+      also saves memory when not in use
+     */
+    enum AP_Motors::motor_frame_class motor_class = (enum AP_Motors::motor_frame_class)frame_class.get();
+    switch (motor_class) {
+    case AP_Motors::MOTOR_FRAME_QUAD:
+        setup_default_channels(4);
+        break;
+    case AP_Motors::MOTOR_FRAME_HEXA:
+        setup_default_channels(6);
+        break;
+    case AP_Motors::MOTOR_FRAME_OCTA:
+    case AP_Motors::MOTOR_FRAME_OCTAQUAD:
+        setup_default_channels(8);
+        break;
+    case AP_Motors::MOTOR_FRAME_Y6:
+        setup_default_channels(7);
+        break;
+    case AP_Motors::MOTOR_FRAME_TRI:
+        SRV_Channels::set_default_function(CH_5, SRV_Channel::k_motor1);
+        SRV_Channels::set_default_function(CH_6, SRV_Channel::k_motor2);
+        SRV_Channels::set_default_function(CH_8, SRV_Channel::k_motor4);
+        SRV_Channels::set_default_function(CH_11, SRV_Channel::k_motor7);
+        AP_Param::set_frame_type_flags(AP_PARAM_FRAME_TRICOPTER);
+        break;
+    case AP_Motors::MOTOR_FRAME_TAILSITTER:
+        break;
+    default:
+        AP_BoardConfig::config_error("Unknown Q_FRAME_CLASS %u", (unsigned)frame_class.get());
+    }
+
+    if (tailsitter_vars.motor_mask == 0) {
+        // this is a duo-motor tailsitter (vectored thrust if tilt.tilt_mask != 0)
+        motors = new AP_MotorsTailsitter(plane.scheduler.get_loop_rate_hz(), rc_speed);
+        motors_var_info = AP_MotorsTailsitter::var_info;
+
+    } else {
+        // this is a copter tailsitter with motor layout specified by frame_class and frame_type
+        motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);
+        motors_var_info = AP_MotorsMatrix::var_info;
+    }
+
+    if (!motors) {
+        AP_BoardConfig::config_error("Unable to allocate %s", "motors");
+    }
+
+    AP_Param::load_object_from_eeprom(motors, motors_var_info);
+
+    // create the attitude view used by the VTOL code
+    ahrs_view = ahrs.create_view(ROTATION_PITCH_90, ahrs_trim_pitch);
+    if (ahrs_view == nullptr) {
+        AP_BoardConfig::config_error("Unable to allocate %s", "ahrs_view");
+    }
+
+    attitude_control = new AC_AttitudeControl_Multi(*ahrs_view, aparm, *motors, loop_delta_t);
+    if (!attitude_control) {
+        AP_BoardConfig::config_error("Unable to allocate %s", "attitude_control");
+    }
+    AP_Param::load_object_from_eeprom(attitude_control, attitude_control->var_info);
+    pos_control = new AC_PosControl(*ahrs_view, inertial_nav, *motors, *attitude_control);
+    if (!pos_control) {
+        AP_BoardConfig::config_error("Unable to allocate %s", "pos_control");
+    }
+    AP_Param::load_object_from_eeprom(pos_control, pos_control->var_info);
+    wp_nav = new AC_WPNav(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
+    if (!wp_nav) {
+        AP_BoardConfig::config_error("Unable to allocate %s", "wp_nav");
+    }
+    AP_Param::load_object_from_eeprom(wp_nav, wp_nav->var_info);
+
+    loiter_nav = new AC_Loiter(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
+    if (!loiter_nav) {
+        AP_BoardConfig::config_error("Unable to allocate %s", "loiter_nav");
+    }
+    AP_Param::load_object_from_eeprom(loiter_nav, loiter_nav->var_info);
+
+    motors->init((AP_Motors::motor_frame_class)frame_class.get(), (AP_Motors::motor_frame_type)frame_type.get());
+
+    if (!motors->initialised_ok()) {
+        AP_BoardConfig::config_error("unknown Q_FRAME_TYPE %u", (unsigned)frame_type.get());
+    }
+    motors->set_throttle_range(thr_min_pwm, thr_max_pwm);
+    motors->set_update_rate(rc_speed);
+    motors->set_interlock(true);
+    pos_control->set_dt(loop_delta_t);
+    attitude_control->parameter_sanity_check();
+
+    // setup the trim of any motors used by AP_Motors so I/O board
+    // failsafe will disable motors
+    for (uint8_t i=0; i<8; i++) {
+        SRV_Channel::Aux_servo_function_t func = SRV_Channels::get_motor_function(i);
+        SRV_Channels::set_failsafe_pwm(func, thr_min_pwm);
+    }
+
+    transition_state = TRANSITION_DONE;
+
+    // default QAssist state as set with Q_OPTIONS
+    if ((options & OPTION_Q_ASSIST_FORCE_ENABLE) != 0) {
+        q_assist_state = Q_ASSIST_STATE_ENUM::Q_ASSIST_FORCE;
+    }
+
+    setup_defaults();
+
+    // param count will have changed
+    AP_Param::invalidate_count();
+
+    gcs().send_text(MAV_SEVERITY_INFO, "QuadPlane initialised");
+    initialised = true;
+    return true;
+}
+
+/*
+  ask the multicopter attitude control to match the roll and pitch rates being demanded by the
+  fixed wing controller if not in a pure VTOL mode
+ */
+void tailsitter::multicopter_attitude_rate_update(float yaw_rate_cds)
+{
+    check_attitude_relax();
+
+    // normal control modes for VTOL and FW flight
+    // tailsitter in transition to VTOL flight is not really in a VTOL mode yet
+    if (in_vtol_mode() && !in_tailsitter_vtol_transition()) {
+
+        // tailsitter-only body-frame roll control options
+        // Angle mode attitude control for pitch and body-frame roll, rate control for euler yaw.
+        if (tailsitter_vars.input_type & TAILSITTER_INPUT_BF_ROLL) {
+
+            if (!(tailsitter_vars.input_type & TAILSITTER_INPUT_PLANE)) {
+                // In multicopter input mode, the roll and yaw stick axes are independent of pitch
+                attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll(false,
+                                                                                plane.nav_roll_cd,
+                                                                                plane.nav_pitch_cd,
+                                                                                yaw_rate_cds);
+            } else {
+                // In plane input mode, the roll and yaw sticks are swapped
+                // and their effective axes rotate from yaw to roll and vice versa
+                // as pitch goes from zero to 90.
+                // So it is necessary to also rotate their scaling.
+
+                // Get the roll angle and yaw rate limits
+                int16_t roll_limit = aparm.angle_max;
+                // separate limit for tailsitter roll, if set
+                if (tailsitter_vars.max_roll_angle > 0) {
+                    roll_limit = tailsitter_vars.max_roll_angle * 100.0f;
+                }
+                // Prevent a divide by zero
+                float yaw_rate_limit = ((yaw_rate_max < 1.0f) ? 1 : yaw_rate_max) * 100.0f;
+                float yaw2roll_scale = roll_limit / yaw_rate_limit;
+
+                // Rotate as a function of Euler pitch and swap roll/yaw
+                float euler_pitch = radians(.01f * plane.nav_pitch_cd);
+                float spitch = fabsf(sinf(euler_pitch));
+                float y2r_scale = linear_interpolate(1, yaw2roll_scale, spitch, 0, 1);
+
+                float p_yaw_rate = plane.nav_roll_cd / y2r_scale;
+                float p_roll_angle = -y2r_scale * yaw_rate_cds;
+
+                attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll(true,
+                                                                                p_roll_angle,
+                                                                                plane.nav_pitch_cd,
+                                                                                p_yaw_rate);
+            }
+            return;
+        }
+
+        // use euler angle attitude control
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
+                                                                      plane.nav_pitch_cd,
+                                                                      yaw_rate_cds);
+    } else {
+        // use the fixed wing desired rates
+        float roll_rate = plane.rollController.get_pid_info().target;
+        float pitch_rate = plane.pitchController.get_pid_info().target;
+        // tailsitter roll and yaw swapped due to change in reference frame
+        attitude_control->input_rate_bf_roll_pitch_yaw_2(yaw_rate_cds,pitch_rate*100.0f, -roll_rate*100.0f);
+    }
+}
+
+// hold in stabilize with given throttle
+void tailsitter::hold_stabilize(float throttle_in)
+{
+    // call attitude controller
+    multicopter_attitude_rate_update(get_desired_yaw_rate_cds());
+
+    if ((throttle_in <= 0) && (air_mode == AirMode::OFF)) {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+        attitude_control->set_throttle_out(0, true, 0);
+    } else {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+        bool should_boost = true;
+        if (assisted_flight) {
+            // tailsitters in forward flight should not use angle boost
+            should_boost = false;
+        }
+        attitude_control->set_throttle_out(throttle_in, should_boost, 0);
+    }
+}
+
+void tailsitter::get_acro_target_roll_yaw(float &target_roll, float &target_yaw) {
+    // Note that the 90 degree Y rotation for copter mode swaps body-frame roll and yaw
+    target_roll =  plane.channel_rudder->norm_input() * acro_yaw_rate * 100.0f;
+    target_yaw  = -plane.channel_roll->norm_input() * acro_roll_rate * 100.0f;
+};
+
+bool tailsitter::is_flying()
+{
+    if (!available()) {
+        return false;
+    }
+    return QuadPlane::is_flying() || in_tailsitter_vtol_transition();
+}
+
+bool tailsitter::assistance_needed(float aspeed, bool have_airspeed)
+{
+    if (is_contol_surface_tailsitter()) {
+        // assistance disabled
+        in_angle_assist = false;
+        angle_error_start_ms = 0;
+        return false;
+    }
+    return QuadPlane::assistance_needed(aspeed,have_airspeed);
+};
+
+/*
+  update for transition from quadplane to fixed wing mode
+ */
+void tailsitter::update_transition(void)
+{
+    if (plane.control_mode == &plane.mode_manual ||
+        plane.control_mode == &plane.mode_acro ||
+        plane.control_mode == &plane.mode_training) {
+        transition_state = TRANSITION_DONE;
+        transition_start_ms = 0;
+        transition_low_airspeed_ms = 0;
+        assisted_flight = false;
+        return;
+    }
+
+    const uint32_t now = millis();
+
+    if (!hal.util->get_soft_armed()) {
+        // reset the failure timer if we haven't started transitioning
+        transition_start_ms = now;
+    }
+
+    float aspeed;
+    bool have_airspeed = ahrs.airspeed_estimate(aspeed);
+
+    // tailsitters use angle wait, not airspeed wait
+    if (transition_state == TRANSITION_AIRSPEED_WAIT) {
+        transition_state = TRANSITION_ANGLE_WAIT_FW;
+    }
+
+    /*
+      see if we should provide some assistance
+     */
+    if (assistance_safe() && (q_assist_state == Q_ASSIST_STATE_ENUM::Q_ASSIST_FORCE ||
+        (q_assist_state == Q_ASSIST_STATE_ENUM::Q_ASSIST_ENABLED && assistance_needed(aspeed, have_airspeed)))) {
+        // the quad should provide some assistance to the plane
+        assisted_flight = true;
+    } else {
+        assisted_flight = false;
+    }
+
+    if (transition_state == TRANSITION_ANGLE_WAIT_FW && tailsitter_transition_fw_complete()) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Transition FW done");
+        transition_state = TRANSITION_DONE;
+        transition_start_ms = 0;
+        transition_low_airspeed_ms = 0;
+    }
+
+    if (transition_state < TRANSITION_DONE) {
+        plane.TECS_controller.set_pitch_max_limit((transition_pitch_max+1)*2);
+    }
+    if (transition_state < TRANSITION_DONE) {
+        // during transition we ask TECS to use a synthetic
+        // airspeed. Otherwise the pitch limits will throw off the
+        // throttle calculation which is driven by pitch
+        plane.TECS_controller.use_synthetic_airspeed();
+    }
+    
+    switch (transition_state) {
+    case TRANSITION_AIRSPEED_WAIT:
+    case TRANSITION_TIMER:
+        break; // should never hit this on a tailsitter
+
+    case TRANSITION_ANGLE_WAIT_FW: {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+        assisted_flight = true;
+        // calculate transition rate in degrees per
+        // millisecond. Assume we want to get to the transition angle
+        // in half the transition time
+        float transition_rate = tailsitter_vars.transition_angle / float(transition_time_ms/2);
+        uint32_t dt = now - transition_start_ms;
+        float pitch_cd;
+        pitch_cd = constrain_float((-transition_rate * dt)*100, -8500, 0);
+        // if already pitched forward at start of transition, wait until curve catches up
+        plane.nav_pitch_cd = (pitch_cd > transition_initial_pitch)? transition_initial_pitch : pitch_cd;
+        plane.nav_roll_cd = 0;
+        check_attitude_relax();
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
+                                                                      plane.nav_pitch_cd,
+                                                                      0);
+        // set throttle at either hover throttle or current throttle, whichever is higher, through the transition
+        attitude_control->set_throttle_out(MAX(motors->get_throttle_hover(),attitude_control->get_throttle_in()), true, 0);
+        break;
+    }
+
+    case TRANSITION_ANGLE_WAIT_VTOL: // nothing to do, this is handled in the fw attitude controller
+    case TRANSITION_DONE:
+        return;
+    }
+
+    motors_output();
+}
+
+/*
+  update motor output for quadplane
+ */
+void tailsitter::update(void)
+{
+    if (!setup()) {
+        return;
+    }
+
+    if ((ahrs_view != NULL) && !is_equal(_last_ahrs_trim_pitch, ahrs_trim_pitch.get())) {
+        _last_ahrs_trim_pitch = ahrs_trim_pitch.get();
+        ahrs_view->set_pitch_trim(_last_ahrs_trim_pitch);
+    }
+
+#if ADVANCED_FAILSAFE == ENABLED
+    if (plane.afs.should_crash_vehicle() && !plane.afs.terminating_vehicle_via_landing()) {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
+        motors->output();
+        return;
+    }
+#endif
+    
+    if (motor_test.running) {
+        motor_test_output();
+        return;
+    }
+
+    if (SRV_Channels::get_emergency_stop()) {
+        attitude_control->reset_rate_controller_I_terms();
+    }
+
+    if (!hal.util->get_soft_armed()) {
+        /*
+          make sure we don't have any residual control from previous flight stages
+         */
+        // tailsitters only relax I terms, to make ground testing easier
+        attitude_control->reset_rate_controller_I_terms();
+        pos_control->relax_alt_hold_controllers(0);
+    }
+    
+    if (!in_vtol_mode()) {
+        update_transition();
+    } else {
+        const uint32_t now = AP_HAL::millis();
+
+        assisted_flight = false;
+
+        // output to motors
+        motors_output();
+
+        if (now - last_vtol_mode_ms > 1000) {
+            /*
+              we are just entering a VTOL mode as a tailsitter, set
+              our transition state so the fixed wing controller brings
+              the nose up before we start trying to fly as a
+              multicopter
+             */
+            transition_state = TRANSITION_ANGLE_WAIT_VTOL;
+            transition_start_ms = now;
+        } else if (transition_state == TRANSITION_ANGLE_WAIT_VTOL) {
+            float aspeed;
+            bool have_airspeed = ahrs.airspeed_estimate(aspeed);
+            // provide asistance in forward flight portion of tailsitter transision
+            if (assistance_safe() && (q_assist_state == Q_ASSIST_STATE_ENUM::Q_ASSIST_FORCE ||
+                (q_assist_state == Q_ASSIST_STATE_ENUM::Q_ASSIST_ENABLED && assistance_needed(aspeed, have_airspeed)))) {
+                assisted_flight = true;
+            }
+            if (tailsitter_transition_vtol_complete()) {
+                /*
+                  we have completed transition to VTOL as a tailsitter,
+                  setup for the back transition when needed
+                */
+                gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done");
+                transition_state = TRANSITION_ANGLE_WAIT_FW;
+                transition_start_ms = now;
+            }
+        } else {
+            /*
+              setup the transition state appropriately for next time we go into a non-VTOL mode
+            */
+            transition_start_ms = 0;
+            transition_low_airspeed_ms = 0;
+            if (throttle_wait && !plane.is_flying()) {
+                transition_state = TRANSITION_DONE;
+            } else {
+                /*
+                  setup for the transition back to fixed wing for later
+                 */
+                transition_state = TRANSITION_ANGLE_WAIT_FW;
+                transition_start_ms = now;
+                transition_initial_pitch= constrain_float(ahrs_view->pitch_sensor,-8500,0);
+            }
+            last_throttle = motors->get_throttle();
+        }
+
+        last_vtol_mode_ms = now;
+    }
+
+    // disable throttle_wait when throttle rises above 10%
+    if (throttle_wait &&
+        (plane.get_throttle_input() > 10 ||
+         plane.failsafe.rc_failsafe ||
+         plane.failsafe.throttle_counter>0)) {
+        throttle_wait = false;
+    }
+}
+
+// return true if we should show VTOL view
+bool tailsitter::show_vtol_view() const
+{
+    bool show_vtol = in_vtol_mode();
+
+    if (hal.util->get_soft_armed()) {
+        if (show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_VTOL)) {
+            // in a vtol mode but still transitioning from forward flight
+            return false;
+        }
+
+        if (!show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_FW)) {
+            // not in VTOL mode but still transitioning from VTOL
+            return true;
+        }
+    }
+
+    return show_vtol;
 }
 
 /*
   return true when flying a control surface only tailsitter tailsitter
  */
-bool QuadPlane::is_contol_surface_tailsitter(void) const
+bool tailsitter::is_contol_surface_tailsitter(void) const
 {
     return frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER
-           && ( is_zero(tailsitter.vectored_hover_gain) || !SRV_Channels::function_assigned(SRV_Channel::k_tiltMotorLeft));
+           && ( is_zero(tailsitter_vars.vectored_hover_gain) || !SRV_Channels::function_assigned(SRV_Channel::k_tiltMotorLeft));
 }
 
 /*
   check if we are flying as a tailsitter
  */
-bool QuadPlane::tailsitter_active(void)
+bool tailsitter::tailsitter_active(void) const
 {
     if (!is_tailsitter()) {
         return false;
@@ -52,16 +502,16 @@ bool QuadPlane::tailsitter_active(void)
         return true;
     }
     // check if we are in ANGLE_WAIT fixed wing transition
-    if (transition_state == TRANSITION_ANGLE_WAIT_FW) {
-        return true;
-    }
+   // if (transition_state == TRANSITION_ANGLE_WAIT_FW) {
+   //     return true;
+   // }
     return false;
 }
 
 /*
   run output for tailsitters
  */
-void QuadPlane::tailsitter_output(void)
+void tailsitter::output(void)
 {
     if (!is_tailsitter() || motor_test.running) {
         // if motor test is running we don't want to overwrite it with output_motor_mask or motors_output
@@ -95,15 +545,15 @@ void QuadPlane::tailsitter_output(void)
 
         if (!assisted_flight) {
             // set AP_MotorsMatrix throttles for forward flight
-            motors->output_motor_mask(throttle * 0.01f, tailsitter.motor_mask, plane.rudder_dt);
+            motors->output_motor_mask(throttle * 0.01f, tailsitter_vars.motor_mask, plane.rudder_dt);
 
             // in forward flight: set motor tilt servos and throttles using FW controller
-            if (tailsitter.vectored_forward_gain > 0) {
+            if (tailsitter_vars.vectored_forward_gain > 0) {
                 // thrust vectoring in fixed wing flight
                 float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
                 float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
-                tilt_left  = (elevator + aileron) * tailsitter.vectored_forward_gain;
-                tilt_right = (elevator - aileron) * tailsitter.vectored_forward_gain;
+                tilt_left  = (elevator + aileron) * tailsitter_vars.vectored_forward_gain;
+                tilt_right = (elevator - aileron) * tailsitter_vars.vectored_forward_gain;
             }
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
@@ -124,9 +574,9 @@ void QuadPlane::tailsitter_output(void)
             attitude_control->reset_rate_controller_I_terms();
 
             // output tilt motors
-            if (tailsitter.vectored_hover_gain > 0) {
-                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft) * tailsitter.vectored_hover_gain);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight) * tailsitter.vectored_hover_gain);
+            if (tailsitter_vars.vectored_hover_gain > 0) {
+                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft) * tailsitter_vars.vectored_hover_gain);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight) * tailsitter_vars.vectored_hover_gain);
             }
 
             // skip remainder of the function that overwrites plane control surface outputs with copter
@@ -151,7 +601,7 @@ void QuadPlane::tailsitter_output(void)
         tailsitter_speed_scaling();
     }
 
-    if (tailsitter.vectored_hover_gain > 0) {
+    if (tailsitter_vars.vectored_hover_gain > 0) {
         // thrust vectoring VTOL modes
         tilt_left = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft);
         tilt_right = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight);
@@ -166,10 +616,10 @@ void QuadPlane::tailsitter_output(void)
         float extra_sign = extra_pitch > 0?1:-1;
         float extra_elevator = 0;
         if (!is_zero(extra_pitch) && in_vtol_mode()) {
-            extra_elevator = extra_sign * powf(fabsf(extra_pitch), tailsitter.vectored_hover_power) * SERVO_MAX;
+            extra_elevator = extra_sign * powf(fabsf(extra_pitch), tailsitter_vars.vectored_hover_power) * SERVO_MAX;
         }
-        tilt_left  = extra_elevator + tilt_left * tailsitter.vectored_hover_gain;
-        tilt_right = extra_elevator + tilt_right * tailsitter.vectored_hover_gain;
+        tilt_left  = extra_elevator + tilt_left * tailsitter_vars.vectored_hover_gain;
+        tilt_right = extra_elevator + tilt_right * tailsitter_vars.vectored_hover_gain;
         if (fabsf(tilt_left) >= SERVO_MAX || fabsf(tilt_right) >= SERVO_MAX) {
             // prevent integrator windup
             motors->limit.roll = 1;
@@ -181,20 +631,20 @@ void QuadPlane::tailsitter_output(void)
     }
 
 
-    if (tailsitter.input_mask_chan > 0 &&
-        tailsitter.input_mask > 0 &&
-        RC_Channels::get_radio_in(tailsitter.input_mask_chan-1) > 1700) {
+    if (tailsitter_vars.input_mask_chan > 0 &&
+        tailsitter_vars.input_mask > 0 &&
+        RC_Channels::get_radio_in(tailsitter_vars.input_mask_chan-1) > 1700) {
         // the user is learning to prop-hang
-        if (tailsitter.input_mask & TAILSITTER_MASK_AILERON) {
+        if (tailsitter_vars.input_mask & TAILSITTER_MASK_AILERON) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, plane.channel_roll->get_control_in_zero_dz());
         }
-        if (tailsitter.input_mask & TAILSITTER_MASK_ELEVATOR) {
+        if (tailsitter_vars.input_mask & TAILSITTER_MASK_ELEVATOR) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, plane.channel_pitch->get_control_in_zero_dz());
         }
-        if (tailsitter.input_mask & TAILSITTER_MASK_THROTTLE) {
+        if (tailsitter_vars.input_mask & TAILSITTER_MASK_THROTTLE) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.get_throttle_input(true));
         }
-        if (tailsitter.input_mask & TAILSITTER_MASK_RUDDER) {
+        if (tailsitter_vars.input_mask & TAILSITTER_MASK_RUDDER) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, plane.channel_rudder->get_control_in_zero_dz());
         }
     }
@@ -204,7 +654,7 @@ void QuadPlane::tailsitter_output(void)
 /*
   return true when we have completed enough of a transition to switch to fixed wing control
  */
-bool QuadPlane::tailsitter_transition_fw_complete(void)
+bool tailsitter::tailsitter_transition_fw_complete(void)
 {
     if (plane.fly_inverted()) {
         // transition immediately
@@ -214,8 +664,8 @@ bool QuadPlane::tailsitter_transition_fw_complete(void)
     if (roll_cd > 9000) {
         roll_cd = 18000 - roll_cd;
     }
-    if (labs(ahrs_view->pitch_sensor) > tailsitter.transition_angle*100 ||
-        roll_cd > tailsitter.transition_angle*100 ||
+    if (labs(ahrs_view->pitch_sensor) > tailsitter_vars.transition_angle*100 ||
+        roll_cd > tailsitter_vars.transition_angle*100 ||
         AP_HAL::millis() - transition_start_ms > uint32_t(transition_time_ms)) {
         return true;
     }
@@ -227,14 +677,14 @@ bool QuadPlane::tailsitter_transition_fw_complete(void)
 /*
   return true when we have completed enough of a transition to switch to VTOL control
  */
-bool QuadPlane::tailsitter_transition_vtol_complete(void) const
+bool tailsitter::tailsitter_transition_vtol_complete(void) const
 {
     if (plane.fly_inverted()) {
         // transition immediately
         return true;
     }
-    if (labs(plane.ahrs.pitch_sensor) > tailsitter.transition_angle*100 ||
-        labs(plane.ahrs.roll_sensor) > tailsitter.transition_angle*100 ||
+    if (labs(plane.ahrs.pitch_sensor) > tailsitter_vars.transition_angle*100 ||
+        labs(plane.ahrs.roll_sensor) > tailsitter_vars.transition_angle*100 ||
         AP_HAL::millis() - transition_start_ms > 2000) {
         return true;
     }
@@ -244,10 +694,10 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
 }
 
 // handle different tailsitter input types
-void QuadPlane::tailsitter_check_input(void)
+void tailsitter::check_input(void)
 {
     if (tailsitter_active() &&
-        (tailsitter.input_type & TAILSITTER_INPUT_PLANE)) {
+        (tailsitter_vars.input_type & TAILSITTER_INPUT_PLANE)) {
         // the user has asked for body frame controls when tailsitter
         // is active. We switch around the control_in value for the
         // channels to do this, as that ensures the value is
@@ -262,14 +712,14 @@ void QuadPlane::tailsitter_check_input(void)
 /*
   return true if we are a tailsitter transitioning to VTOL flight
  */
-bool QuadPlane::in_tailsitter_vtol_transition(uint32_t now) const
+bool tailsitter::in_tailsitter_vtol_transition(uint32_t now) const
 {
     if (!is_tailsitter() || !in_vtol_mode()) {
         return false;
     }
-    if (transition_state == TRANSITION_ANGLE_WAIT_VTOL) {
-        return true;
-    }
+    //if (transition_state == TRANSITION_ANGLE_WAIT_VTOL) {
+    //    return true;
+   // }
     if ((now != 0) && ((now - last_vtol_mode_ms) > 1000)) {
         // only just come out of forward flight
         return true;
@@ -280,7 +730,7 @@ bool QuadPlane::in_tailsitter_vtol_transition(uint32_t now) const
 /*
   return true if we are a tailsitter in FW flight
  */
-bool QuadPlane::is_tailsitter_in_fw_flight(void) const
+bool tailsitter::is_tailsitter_in_fw_flight(void) const
 {
     return is_tailsitter() && !in_vtol_mode() && transition_state == TRANSITION_DONE;
 }
@@ -288,18 +738,18 @@ bool QuadPlane::is_tailsitter_in_fw_flight(void) const
 /*
   account for speed scaling of control surfaces in VTOL modes
 */
-void QuadPlane::tailsitter_speed_scaling(void)
+void tailsitter::tailsitter_speed_scaling(void)
 {
     const float hover_throttle = motors->get_throttle_hover();
     const float throttle = motors->get_throttle();
     float spd_scaler = 1.0f;
 
-    if (tailsitter.gain_scaling_mask & TAILSITTER_GSCL_ATT_THR) {
+    if (tailsitter_vars.gain_scaling_mask & TAILSITTER_GSCL_ATT_THR) {
         // reduce gains when flying at high speed in Q modes:
 
         // critical parameter: violent oscillations if too high
         // sudden loss of attitude control if too low
-        const float min_scale = tailsitter.gain_scaling_min;
+        const float min_scale = tailsitter_vars.gain_scaling_min;
         float tthr = 1.25f * hover_throttle;
 
         // reduce control surface throws at large tilt
@@ -339,12 +789,12 @@ void QuadPlane::tailsitter_speed_scaling(void)
     }
 
     // if gain attenuation isn't active and boost is enabled
-    if ((spd_scaler >= 1.0f) && (tailsitter.gain_scaling_mask & TAILSITTER_GSCL_BOOST)) {
+    if ((spd_scaler >= 1.0f) && (tailsitter_vars.gain_scaling_mask & TAILSITTER_GSCL_BOOST)) {
         // boost gains at low throttle
         if (is_zero(throttle)) {
-            spd_scaler = tailsitter.throttle_scale_max;
+            spd_scaler = tailsitter_vars.throttle_scale_max;
         } else {
-            spd_scaler = constrain_float(hover_throttle / throttle, 1.0f, tailsitter.throttle_scale_max);
+            spd_scaler = constrain_float(hover_throttle / throttle, 1.0f, tailsitter_vars.throttle_scale_max);
         }
     }
 

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -1,0 +1,91 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "quadplane.h"
+
+/*
+  tailsitter specific functionality
+ */
+class tailsitter : public QuadPlane {
+
+public:
+
+    tailsitter(AP_AHRS_NavEKF &_ahrs) :
+        QuadPlane(_ahrs)
+    {
+    };
+
+    bool setup() override;
+
+    // use multicopter rate controller
+    void multicopter_attitude_rate_update(float yaw_rate_cds) override;
+
+    void hold_stabilize(float throttle_in) override;
+
+    void init_z_target() override {
+        // tailsitters gain lots of vertical speed in transisison, set target to the stopping point
+        pos_control->set_target_to_stopping_point_z();
+    };
+
+    void get_acro_target_roll_yaw(float &target_roll, float &target_yaw) override;
+
+    // vtol help for is_flying()
+    bool is_flying(void) override;
+
+    bool assistance_needed(float aspeed, bool have_airspeed) override;
+
+    // update transition handling
+    void update_transition(void) override;
+
+    // update transition handling
+    void update(void) override;
+
+    // return true when tailsitter frame configured
+    bool is_tailsitter(void) const override {return available();}
+
+    // return true when flying a control surface only tailsitter tailsitter
+    bool is_contol_surface_tailsitter(void) const;
+
+    // return true when flying a tailsitter in VTOL
+    bool tailsitter_active(void) const override;
+    
+    // create outputs for tailsitters
+    void output(void) override;
+
+    // handle different tailsitter input types
+    void check_input(void) override;
+    
+    // check if we have completed transition to fixed wing
+    bool tailsitter_transition_fw_complete(void);
+
+    // return true if we are a tailsitter in FW flight
+    bool is_tailsitter_in_fw_flight(void) const override;
+
+    // check if we have completed transition to vtol
+    bool tailsitter_transition_vtol_complete(void) const;
+
+    bool show_vtol_view() const override;
+
+    // account for control surface speed scaling in VTOL modes
+    void tailsitter_speed_scaling(void);
+
+    /*
+      return true if we are a tailsitter transitioning to VTOL flight
+    */
+    bool in_tailsitter_vtol_transition(uint32_t now = 0) const override;
+
+
+};


### PR DESCRIPTION
This is very WIP!

This moves tail sitters to there own class which overrides quad-plane. At the moment this is more of a experiment to see if it would be worth it rather than a realistic PR.

This gains 1.6K on Cube Orange, so is it worth it?

Lots more work to do, moving over params and such but I would expect the flash cost to stay about the same.

This also means you could compile without tailsitters and save at least ~3k.

Still a few special tailsitter cases dotted about the rest of the plane code. But I don't really see any path to remove those short of a new vehicle type.

