### PR TITLE
Use instance-number for IMU,BARO,MAG,GYR,ACC messages

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -278,9 +278,10 @@ void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sa
     }
     if (should_log_imu_raw()) {
         uint64_t now = AP_HAL::micros64();
-        struct log_GYRO pkt = {
-            LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GYR1_MSG+instance)),
+        const struct log_GYR pkt{
+            LOG_PACKET_HEADER_INIT(LOG_GYR_MSG),
             time_us   : now,
+            instance  : instance,
             sample_us : sample_us?sample_us:now,
             GyrX      : gyro.x,
             GyrY      : gyro.y,
@@ -433,9 +434,10 @@ void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t s
     }
     if (should_log_imu_raw()) {
         uint64_t now = AP_HAL::micros64();
-        struct log_ACCEL pkt = {
-            LOG_PACKET_HEADER_INIT((uint8_t)(LOG_ACC1_MSG+instance)),
+        const struct log_ACC pkt {
+            LOG_PACKET_HEADER_INIT(LOG_ACC_MSG),
             time_us   : now,
+            instance  : instance,
             sample_us : sample_us?sample_us:now,
             AccX      : accel.x,
             AccY      : accel.y,

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -453,9 +453,7 @@ private:
     bool seen_nonzero_rcin15_or_rcin16;
 
     void Write_Baro_instance(uint64_t time_us, uint8_t baro_instance, enum LogMessages type);
-    void Write_IMU_instance(uint64_t time_us,
-                                uint8_t imu_instance,
-                                enum LogMessages type);
+    void Write_IMU_instance(uint64_t time_us, uint8_t imu_instance);
     void Write_Compass_instance(uint64_t time_us,
                                     uint8_t mag_instance,
                                     enum LogMessages type);

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -454,9 +454,7 @@ private:
 
     void Write_Baro_instance(uint64_t time_us, uint8_t baro_instance);
     void Write_IMU_instance(uint64_t time_us, uint8_t imu_instance);
-    void Write_Compass_instance(uint64_t time_us,
-                                    uint8_t mag_instance,
-                                    enum LogMessages type);
+    void Write_Compass_instance(uint64_t time_us, uint8_t mag_instance);
     void Write_Current_instance(uint64_t time_us, uint8_t battery_instance);
     void Write_IMUDT_instance(uint64_t time_us,
                                   uint8_t imu_instance,

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -452,7 +452,7 @@ private:
     // state to help us not log unneccesary RCIN values:
     bool seen_nonzero_rcin15_or_rcin16;
 
-    void Write_Baro_instance(uint64_t time_us, uint8_t baro_instance, enum LogMessages type);
+    void Write_Baro_instance(uint64_t time_us, uint8_t baro_instance);
     void Write_IMU_instance(uint64_t time_us, uint8_t imu_instance);
     void Write_Compass_instance(uint64_t time_us,
                                     uint8_t mag_instance,

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -713,16 +713,17 @@ void AP_Logger::Write_Current()
     }
 }
 
-void AP_Logger::Write_Compass_instance(const uint64_t time_us, const uint8_t mag_instance, const enum LogMessages type)
+void AP_Logger::Write_Compass_instance(const uint64_t time_us, const uint8_t mag_instance)
 {
     const Compass &compass = AP::compass();
 
     const Vector3f &mag_field = compass.get_field(mag_instance);
     const Vector3f &mag_offsets = compass.get_offsets(mag_instance);
     const Vector3f &mag_motor_offsets = compass.get_motor_offsets(mag_instance);
-    const struct log_Compass pkt{
-        LOG_PACKET_HEADER_INIT(type),
+    const struct log_MAG pkt{
+        LOG_PACKET_HEADER_INIT(LOG_MAG_MSG),
         time_us         : time_us,
+        instance        : mag_instance,
         mag_x           : (int16_t)mag_field.x,
         mag_y           : (int16_t)mag_field.y,
         mag_z           : (int16_t)mag_field.z,
@@ -745,16 +746,8 @@ void AP_Logger::Write_Compass(uint64_t time_us)
         time_us = AP_HAL::micros64();
     }
     const Compass &compass = AP::compass();
-    if (compass.get_count() > 0) {
-        Write_Compass_instance(time_us, 0, LOG_COMPASS_MSG);
-    }
-
-    if (compass.get_count() > 1) {
-        Write_Compass_instance(time_us, 1, LOG_COMPASS2_MSG);
-    }
-
-    if (compass.get_count() > 2) {
-        Write_Compass_instance(time_us, 2, LOG_COMPASS3_MSG);
+    for (uint8_t i=0; i<compass.get_count(); i++) {
+        Write_Compass_instance(time_us, i);
     }
 }
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -302,14 +302,15 @@ void AP_Logger::Write_Baro(uint64_t time_us)
     }
 }
 
-void AP_Logger::Write_IMU_instance(const uint64_t time_us, const uint8_t imu_instance, const enum LogMessages type)
+void AP_Logger::Write_IMU_instance(const uint64_t time_us, const uint8_t imu_instance)
 {
     const AP_InertialSensor &ins = AP::ins();
     const Vector3f &gyro = ins.get_gyro(imu_instance);
     const Vector3f &accel = ins.get_accel(imu_instance);
     const struct log_IMU pkt{
-        LOG_PACKET_HEADER_INIT(type),
+        LOG_PACKET_HEADER_INIT(LOG_IMU_MSG),
         time_us : time_us,
+        instance: imu_instance,
         gyro_x  : gyro.x,
         gyro_y  : gyro.y,
         gyro_z  : gyro.z,
@@ -334,18 +335,10 @@ void AP_Logger::Write_IMU()
 
     const AP_InertialSensor &ins = AP::ins();
 
-    Write_IMU_instance(time_us, 0, LOG_IMU_MSG);
-    if (ins.get_gyro_count() < 2 && ins.get_accel_count() < 2) {
-        return;
+    uint8_t n = MAX(ins.get_accel_count(), ins.get_gyro_count());
+    for (uint8_t i=0; i<n; i++) {
+        Write_IMU_instance(time_us, i);
     }
-
-    Write_IMU_instance(time_us, 1, LOG_IMU2_MSG);
-
-    if (ins.get_gyro_count() < 3 && ins.get_accel_count() < 3) {
-        return;
-    }
-
-    Write_IMU_instance(time_us, 2, LOG_IMU3_MSG);
 }
 
 // Write an accel/gyro delta time data packet

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -265,15 +265,16 @@ void AP_Logger::Write_RSSI()
     WriteBlock(&pkt, sizeof(pkt));
 }
 
-void AP_Logger::Write_Baro_instance(uint64_t time_us, uint8_t baro_instance, enum LogMessages type)
+void AP_Logger::Write_Baro_instance(uint64_t time_us, uint8_t baro_instance)
 {
     AP_Baro &baro = AP::baro();
     float climbrate = baro.get_climb_rate();
     float drift_offset = baro.get_baro_drift_offset();
     float ground_temp = baro.get_ground_temperature();
     const struct log_BARO pkt{
-        LOG_PACKET_HEADER_INIT(type),
+        LOG_PACKET_HEADER_INIT(LOG_BARO_MSG),
         time_us       : time_us,
+        instance      : baro_instance,
         altitude      : baro.get_altitude(baro_instance),
         pressure      : baro.get_pressure(baro_instance),
         temperature   : (int16_t)(baro.get_temperature(baro_instance) * 100 + 0.5f),
@@ -293,12 +294,8 @@ void AP_Logger::Write_Baro(uint64_t time_us)
         time_us = AP_HAL::micros64();
     }
     const AP_Baro &baro = AP::baro();
-    Write_Baro_instance(time_us, 0, LOG_BARO_MSG);
-    if (baro.num_instances() > 1) {
-        Write_Baro_instance(time_us, 1, LOG_BAR2_MSG);
-    }
-    if (baro.num_instances() > 2) {
-        Write_Baro_instance(time_us, 2, LOG_BAR3_MSG);
+    for (uint8_t i=0; i< baro.num_instances(); i++) {
+        Write_Baro_instance(time_us, i);
     }
 }
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -353,6 +353,7 @@ struct PACKED log_RSSI {
 struct PACKED log_BARO {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t instance;
     float   altitude;
     float   pressure;
     int16_t temperature;
@@ -1299,12 +1300,6 @@ struct PACKED log_PSC {
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
 
-// see "struct sensor" in AP_Baro.h and "Write_Baro":
-#define BARO_LABELS "TimeUS,Alt,Press,Temp,CRt,SMS,Offset,GndTemp,Health"
-#define BARO_FMT   "QffcfIffB"
-#define BARO_UNITS "smPOnsmO-"
-#define BARO_MULTS "F00B0C?0-"
-
 #define GPA_LABELS "TimeUS,VDop,HAcc,VAcc,SAcc,YAcc,VV,SMS,Delta"
 #define GPA_FMT   "QCCCCfBIH"
 #define GPA_UNITS "smmmnd-ss"
@@ -1419,9 +1414,10 @@ struct PACKED log_PSC {
 // @Field: ErrRP: lowest estimated gyro drift error
 // @Field: ErrYaw: difference between measured yaw and DCM yaw estimate
 
-// @LoggerMessage: BARO,BAR2,BAR3
+// @LoggerMessage: BARO
 // @Description: Gathered Barometer data
 // @Field: TimeUS: Time since system startup
+// @Field: I: barometer sensor instance number
 // @Field: Alt: calculated altitude
 // @Field: Press: measured atmospheric pressure
 // @Field: Temp: measured atmospheric temperature
@@ -2518,7 +2514,7 @@ struct PACKED log_PSC {
     { LOG_RSSI_MSG, sizeof(log_RSSI), \
       "RSSI",  "Qf",     "TimeUS,RXRSSI", "s-", "F-"  }, \
     { LOG_BARO_MSG, sizeof(log_BARO), \
-      "BARO",  BARO_FMT, BARO_LABELS, BARO_UNITS, BARO_MULTS }, \
+      "BARO",  "QBffcfIffB", "TimeUS,I,Alt,Press,Temp,CRt,SMS,Offset,GndTemp,Health", "s#mPOnsmO-", "F-00B0C?0-" }, \
     { LOG_POWR_MSG, sizeof(log_POWR), \
       "POWR","QffHHB","TimeUS,Vcc,VServo,Flags,AccFlags,Safety", "svv---", "F00---" },  \
     { LOG_CMD_MSG, sizeof(log_Cmd), \
@@ -2639,10 +2635,6 @@ struct PACKED log_PSC {
       "PIDS", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
     { LOG_DSTL_MSG, sizeof(log_DSTL), \
       "DSTL", "QBfLLeccfeffff", "TimeUS,Stg,THdg,Lat,Lng,Alt,XT,Travel,L1I,Loiter,Des,P,I,D", "s??DUm--------", "F??000--------" }, \
-    { LOG_BAR2_MSG, sizeof(log_BARO), \
-      "BAR2",  BARO_FMT, BARO_LABELS, BARO_UNITS, BARO_MULTS }, \
-    { LOG_BAR3_MSG, sizeof(log_BARO), \
-      "BAR3",  BARO_FMT, BARO_LABELS, BARO_UNITS, BARO_MULTS }, \
     { LOG_VIBE_MSG, sizeof(log_Vibe), \
       "VIBE", "QBfffI",     "TimeUS,IMU,VibeX,VibeY,VibeZ,Clip", "s#----", "F-----" }, \
     { LOG_IMUDT_MSG, sizeof(log_IMUDT), \
@@ -2767,7 +2759,6 @@ enum LogMessages : uint8_t {
     LOG_ESC_MSG,
     LOG_CSRV_MSG,
     LOG_CESC_MSG,
-    LOG_BAR2_MSG,
     LOG_ARSP_MSG,
     LOG_ATTITUDE_MSG,
     LOG_CURRENT_MSG,
@@ -2803,7 +2794,6 @@ enum LogMessages : uint8_t {
     LOG_GPA2_MSG,
     LOG_GPAB_MSG,
     LOG_RFND_MSG,
-    LOG_BAR3_MSG,
     LOG_MAV_STATS,
     LOG_FORMAT_UNITS_MSG,
     LOG_UNIT_MSG,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -827,9 +827,10 @@ struct PACKED log_Current_Cells {
     uint16_t cell_voltages[12];
 };
 
-struct PACKED log_Compass {
+struct PACKED log_MAG {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t  instance;
     int16_t  mag_x;
     int16_t  mag_y;
     int16_t  mag_z;
@@ -1326,11 +1327,6 @@ struct PACKED log_PSC {
 #define ISBD_UNITS  "s--ooo"
 #define ISBD_MULTS  "F--???"
 
-#define MAG_LABELS "TimeUS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health,S"
-#define MAG_FMT   "QhhhhhhhhhBI"
-#define MAG_UNITS "sGGGGGGGGG-s"
-#define MAG_MULTS "FCCCCCCCCC-F"
-
 #define PID_LABELS "TimeUS,Tar,Act,Err,P,I,D,FF,Dmod"
 #define PID_FMT    "Qffffffff"
 #define PID_UNITS  "s--------"
@@ -1748,18 +1744,19 @@ struct PACKED log_PSC {
 // @Field: LandingGear: Current landing gear state
 // @Field: WeightOnWheels: True if there is weight on wheels
 
-// @LoggerMessage: MAG,MAG2,MAG3
+// @LoggerMessage: MAG
 // @Description: Information received from compasses
 // @Field: TimeUS: Time since system startup
+// @Field: I: magnetometer sensor instance number
 // @Field: MagX: magnetic field strength in body frame
 // @Field: MagY: magnetic field strength in body frame
 // @Field: MagZ: magnetic field strength in body frame
 // @Field: OfsX: magnetic field offset in body frame
 // @Field: OfsY: magnetic field offset in body frame
 // @Field: OfsZ: magnetic field offset in body frame
-// @Field: MOfsX: motor interference magnetic field offset in body frame
-// @Field: MOfsY: motor interference magnetic field offset in body frame
-// @Field: MOfsZ: motor interference magnetic field offset in body frame
+// @Field: MOX: motor interference magnetic field offset in body frame
+// @Field: MOY: motor interference magnetic field offset in body frame
+// @Field: MOZ: motor interference magnetic field offset in body frame
 // @Field: Health: true if the compass is considered healthy
 // @Field: S: time measurement was taken
 
@@ -2535,8 +2532,8 @@ struct PACKED log_PSC {
       "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" }, \
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw", "sddddhhdh", "FBBBBBBBB" }, \
-    { LOG_COMPASS_MSG, sizeof(log_Compass), \
-      "MAG", MAG_FMT,    MAG_LABELS, MAG_UNITS, MAG_MULTS }, \
+    { LOG_MAG_MSG, sizeof(log_MAG), \
+      "MAG", "QBhhhhhhhhhBI",    "TimeUS,I,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOX,MOY,MOZ,Health,S", "s#GGGGGGGGG-s", "F-CCCCCCCCC-F" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
@@ -2615,10 +2612,6 @@ struct PACKED log_PSC {
       "CSRV","QBfffB","TimeUS,Id,Pos,Force,Speed,Pow", "s#---%", "F-0000" }, \
     { LOG_CESC_MSG, sizeof(log_CESC), \
       "CESC","QBIfffiB","TimeUS,Id,ECnt,Voltage,Curr,Temp,RPM,Pow", "s#-vAOq%", "F-000000" }, \
-    { LOG_COMPASS2_MSG, sizeof(log_Compass), \
-      "MAG2",MAG_FMT,    MAG_LABELS, MAG_UNITS, MAG_MULTS }, \
-    { LOG_COMPASS3_MSG, sizeof(log_Compass), \
-      "MAG3",MAG_FMT,    MAG_LABELS, MAG_UNITS, MAG_MULTS }, \
     { LOG_ACC_MSG, sizeof(log_ACC), \
       "ACC", "QBQfff",        "TimeUS,I,SampleUS,AccX,AccY,AccZ", "s#sooo", "F-F000" }, \
     { LOG_GYR_MSG, sizeof(log_GYR), \
@@ -2763,9 +2756,7 @@ enum LogMessages : uint8_t {
     LOG_ATTITUDE_MSG,
     LOG_CURRENT_MSG,
     LOG_CURRENT_CELLS_MSG,
-    LOG_COMPASS_MSG,
-    LOG_COMPASS2_MSG,
-    LOG_COMPASS3_MSG,
+    LOG_MAG_MSG,
     LOG_MODE_MSG,
     LOG_GPS_RAW_MSG,
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -238,6 +238,7 @@ struct PACKED log_Message {
 struct PACKED log_IMU {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t instance;
     float gyro_x, gyro_y, gyro_z;
     float accel_x, accel_y, accel_z;
     uint32_t gyro_error, accel_error;
@@ -991,16 +992,18 @@ struct PACKED log_AIRSPEED {
     uint8_t primary;
 };
 
-struct PACKED log_ACCEL {
+struct PACKED log_ACC {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t instance;
     uint64_t sample_us;
     float AccX, AccY, AccZ;
 };
 
-struct PACKED log_GYRO {
+struct PACKED log_GYR {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t instance;
     uint64_t sample_us;
     float GyrX, GyrY, GyrZ;
 };
@@ -1296,11 +1299,6 @@ struct PACKED log_PSC {
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
 
-#define ACC_LABELS "TimeUS,SampleUS,AccX,AccY,AccZ"
-#define ACC_FMT   "QQfff"
-#define ACC_UNITS "ssooo"
-#define ACC_MULTS "FF000"
-
 // see "struct sensor" in AP_Baro.h and "Write_Baro":
 #define BARO_LABELS "TimeUS,Alt,Press,Temp,CRt,SMS,Offset,GndTemp,Health"
 #define BARO_FMT   "QffcfIffB"
@@ -1318,11 +1316,6 @@ struct PACKED log_PSC {
 #define GPS_UNITS "s---SmDUmnhnh-"
 #define GPS_MULTS "F---0BGGB000--"
 
-#define GYR_LABELS "TimeUS,SampleUS,GyrX,GyrY,GyrZ"
-#define GYR_FMT    "QQfff"
-#define GYR_UNITS  "ssEEE"
-#define GYR_MULTS  "FF000"
-
 #define IMT_LABELS "TimeUS,DelT,DelvT,DelaT,DelAX,DelAY,DelAZ,DelVX,DelVY,DelVZ"
 #define IMT_FMT    "Qfffffffff"
 #define IMT_UNITS  "ssssrrrnnn"
@@ -1337,11 +1330,6 @@ struct PACKED log_PSC {
 #define ISBD_FMT    "QHHaaa"
 #define ISBD_UNITS  "s--ooo"
 #define ISBD_MULTS  "F--???"
-
-#define IMU_LABELS "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,EG,EA,T,GH,AH,GHz,AHz"
-#define IMU_FMT   "QffffffIIfBBHH"
-#define IMU_UNITS "sEEEooo--O--zz"
-#define IMU_MULTS "F000000-----00"
 
 #define MAG_LABELS "TimeUS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health,S"
 #define MAG_FMT   "QhhhhhhhhhBI"
@@ -1363,9 +1351,10 @@ struct PACKED log_PSC {
 #define ARSP_UNITS "snPOPP----"
 #define ARSP_MULTS "F00B00----"
 
-// @LoggerMessage: ACC1,ACC2,ACC3
+// @LoggerMessage: ACC
 // @Description: IMU accelerometer data
 // @Field: TimeUS: Time since system startup
+// @Field: I: accelerometer sensor instance number
 // @Field: SampleUS: time since system startup this sample was taken
 // @Field: AccX: acceleration along X axis
 // @Field: AccY: acceleration along Y axis
@@ -1717,9 +1706,10 @@ struct PACKED log_PSC {
 // @Field: doD: estimated Doppler measurement standard deviation
 // @Field: trk: tracking status bitfield
 
-// @LoggerMessage: GYR1,GYR2,GYR3
+// @LoggerMessage: GYR
 // @Description: IMU gyroscope data
 // @Field: TimeUS: Time since system startup
+// @Field: I: gyroscope sensor instance number
 // @Field: SampleUS: time since system startup this sample was taken
 // @Field: GyrX: measured rotation rate about X axis
 // @Field: GyrY: measured rotation rate about Y axis
@@ -1738,9 +1728,10 @@ struct PACKED log_PSC {
 // @Field: DelVY: Accumulated delta velocity Y
 // @Field: DelVZ: Accumulated delta velocity Z
 
-// @LoggerMessage: IMU,IMU2,IMU3
+// @LoggerMessage: IMU
 // @Description: Inertial Measurement Unit data
 // @Field: TimeUS: Time since system startup
+// @Field: I: IMU sensor instance number
 // @Field: GyrX: measured rotation rate about X axis
 // @Field: GyrY: measured rotation rate about Y axis
 // @Field: GyrZ: measured rotation rate about Z axis
@@ -2515,7 +2506,7 @@ struct PACKED log_PSC {
     { LOG_GPAB_MSG, sizeof(log_GPA), \
       "GPAB", GPA_FMT, GPA_LABELS, GPA_UNITS, GPA_MULTS }, \
     { LOG_IMU_MSG, sizeof(log_IMU), \
-      "IMU",  IMU_FMT,     IMU_LABELS, IMU_UNITS, IMU_MULTS }, \
+      "IMU",  "QBffffffIIfBBHH",     "TimeUS,I,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,EG,EA,T,GH,AH,GHz,AHz", "s#EEEooo--O--zz", "F-000000-----00" }, \
     { LOG_MESSAGE_MSG, sizeof(log_Message), \
       "MSG",  "QZ",     "TimeUS,Message", "s-", "F-"}, \
     { LOG_RCIN_MSG, sizeof(log_RCIN), \
@@ -2570,10 +2561,6 @@ struct PACKED log_PSC {
       "OADJ","QBBBBLLLL","TimeUS,State,Err,CurrPoint,TotPoints,DLat,DLng,OALat,OALng", "sbbbbDUDU", "F----GGGG" }, \
     { LOG_SIMPLE_AVOID_MSG, sizeof(log_SimpleAvoid), \
       "SA",  "QBffffB","TimeUS,State,DVelX,DVelY,MVelX,MVelY,Back", "sbnnnnb", "F------"}, \
-    { LOG_IMU2_MSG, sizeof(log_IMU), \
-      "IMU2",  IMU_FMT,     IMU_LABELS, IMU_UNITS, IMU_MULTS }, \
-    { LOG_IMU3_MSG, sizeof(log_IMU), \
-      "IMU3",  IMU_FMT,     IMU_LABELS, IMU_UNITS, IMU_MULTS }, \
     { LOG_AHR2_MSG, sizeof(log_AHRS), \
       "AHR2","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4","sddhmDU????", "FBBB0GG????" }, \
     { LOG_POS_MSG, sizeof(log_POS), \
@@ -2636,18 +2623,10 @@ struct PACKED log_PSC {
       "MAG2",MAG_FMT,    MAG_LABELS, MAG_UNITS, MAG_MULTS }, \
     { LOG_COMPASS3_MSG, sizeof(log_Compass), \
       "MAG3",MAG_FMT,    MAG_LABELS, MAG_UNITS, MAG_MULTS }, \
-    { LOG_ACC1_MSG, sizeof(log_ACCEL), \
-      "ACC1", ACC_FMT,        ACC_LABELS, ACC_UNITS, ACC_MULTS }, \
-    { LOG_ACC2_MSG, sizeof(log_ACCEL), \
-      "ACC2", ACC_FMT,        ACC_LABELS, ACC_UNITS, ACC_MULTS }, \
-    { LOG_ACC3_MSG, sizeof(log_ACCEL), \
-      "ACC3", ACC_FMT,        ACC_LABELS, ACC_UNITS, ACC_MULTS }, \
-    { LOG_GYR1_MSG, sizeof(log_GYRO), \
-      "GYR1", GYR_FMT,        GYR_LABELS, GYR_UNITS, GYR_MULTS }, \
-    { LOG_GYR2_MSG, sizeof(log_GYRO), \
-      "GYR2", GYR_FMT,        GYR_LABELS, GYR_UNITS, GYR_MULTS }, \
-    { LOG_GYR3_MSG, sizeof(log_GYRO), \
-      "GYR3", GYR_FMT,        GYR_LABELS, GYR_UNITS, GYR_MULTS }, \
+    { LOG_ACC_MSG, sizeof(log_ACC), \
+      "ACC", "QBQfff",        "TimeUS,I,SampleUS,AccX,AccY,AccZ", "s#sooo", "F-F000" }, \
+    { LOG_GYR_MSG, sizeof(log_GYR), \
+      "GYR", "QBQfff",        "TimeUS,I,SampleUS,GyrX,GyrY,GyrZ", "s#sEEE", "F-F000" }, \
     { LOG_PIDR_MSG, sizeof(log_PID), \
       "PIDR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
     { LOG_PIDP_MSG, sizeof(log_PID), \
@@ -2773,7 +2752,6 @@ enum LogMessages : uint8_t {
     LOG_RCIN2_MSG,
     LOG_RCOUT_MSG,
     LOG_RSSI_MSG,
-    LOG_IMU2_MSG,
     LOG_BARO_MSG,
     LOG_POWR_MSG,
     LOG_AHR2_MSG,
@@ -2783,7 +2761,6 @@ enum LogMessages : uint8_t {
     LOG_RADIO_MSG,
     LOG_ATRP_MSG,
     LOG_CAMERA_MSG,
-    LOG_IMU3_MSG,
     LOG_TERRAIN_MSG,
     LOG_GPS_UBX1_MSG,
     LOG_GPS_UBX2_MSG,
@@ -2807,12 +2784,8 @@ enum LogMessages : uint8_t {
     LOG_FORMAT_MSG = 128, // this must remain #128
 
     LOG_GPS_RAWS_MSG,
-    LOG_ACC1_MSG,
-    LOG_ACC2_MSG,
-    LOG_ACC3_MSG,
-    LOG_GYR1_MSG,
-    LOG_GYR2_MSG,
-    LOG_GYR3_MSG,
+    LOG_ACC_MSG,
+    LOG_GYR_MSG,
     LOG_POS_MSG,
     LOG_PIDR_MSG,
     LOG_PIDP_MSG,


### PR DESCRIPTION
Tested in SITL.

I've also changed from log_Compass to log_MAG - we have a trend towards using the message name for these things.
