### PR TITLE
Copter: add yaw imbalance check

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -690,6 +690,9 @@ private:
     // crash_check.cpp
     void crash_check();
     void thrust_loss_check();
+    void yaw_imbalance_check();
+    LowPassFilterFloat yaw_I_filt{0.05f};
+    uint32_t last_yaw_warn_ms;
     void parachute_check();
     void parachute_release();
     void parachute_manual_release();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -608,6 +608,12 @@ private:
         RELEASE_GRIPPER                 = (1<<5),   // 32
     };
 
+
+    enum class FlightOptions {
+        DISABLE_THRUST_LOSS_CHECK     = (1<<0),   // 1
+        DISABLE_YAW_IMBALANCE_WARNING = (1<<1),   // 2
+    };
+
     static constexpr int8_t _failsafe_priorities[] = {
                                                       Failsafe_Action_Terminate,
                                                       Failsafe_Action_Land,

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1045,6 +1045,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_GROUPINFO("RTL_OPTIONS", 43, ParametersG2, rtl_options, 0),
 #endif
 
+    // @Param: FLIGHT_OPTIONS
+    // @DisplayName: Flight mode options
+    // @Description: Flight mode specific options
+    // @Bitmask: 0:Disable thrust loss check, 1:Disable yaw imbalance warning
+    // @User: Advanced
+    AP_GROUPINFO("FLIGHT_OPTIONS", 44, ParametersG2, flight_options, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -642,6 +642,8 @@ public:
     AP_Int32 rtl_options;
 #endif
 
+    AP_Int32 flight_options;
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -12,6 +12,11 @@
 #define THRUST_LOSS_CHECK_ANGLE_DEVIATION_CD  1500  // we can't expect to maintain altitude beyond 15 degrees on all aircraft
 #define THRUST_LOSS_CHECK_MINIMUM_THROTTLE    0.9f  // we can expect to maintain altitude above 90 % throttle
 
+// Yaw imbalance check
+#define YAW_IMBALANCE_IMAX_THRESHOLD 0.75f
+#define YAW_IMBALANCE_I_THERSHOLD 0.1f
+#define YAW_IMBALANCE_WARN_MS 10000
+
 // crash_check - disarms motors if a crash has been detected
 // crashes are detected by the vehicle being more than 20 degrees beyond it's angle limits continuously for more than 1 second
 // called at MAIN_LOOP_RATE
@@ -156,6 +161,53 @@ void Copter::thrust_loss_check()
         // enable thrust loss handling
         motors->set_thrust_boost(true);
         // the motors library disables this when it is no longer needed to achieve the commanded output
+    }
+}
+
+// check for a large yaw imbalance, could be due to badly calibrated ESC or misaligned motors
+void Copter::yaw_imbalance_check()
+{
+    // If I is disabled it is unlikely that the issue is not obvious
+    if (!is_positive(attitude_control->get_rate_yaw_pid().kI())) {
+        return;
+    }
+
+    // thrust loss is trigerred, yaw issues are expected
+    if (motors->get_thrust_boost()) {
+        yaw_I_filt.reset(0.0f);
+        return;
+    }
+
+    // return immediately if disarmed
+    if (!motors->armed() || ap.land_complete) {
+        yaw_I_filt.reset(0.0f);
+        return;
+    }
+
+    // exit immediately if in standby
+    if (standby_active) {
+        yaw_I_filt.reset(0.0f);
+        return;
+    }
+
+    // magnitude of low pass filtered I term
+    const float I_term = attitude_control->get_rate_yaw_pid().get_pid_info().I;
+    const float I = fabsf(yaw_I_filt.apply(attitude_control->get_rate_yaw_pid().get_pid_info().I,G_Dt));
+    if (I > fabsf(I_term)) {
+        // never allow to be larger than I
+        yaw_I_filt.reset(I_term);
+    }
+
+    const float I_max = attitude_control->get_rate_yaw_pid().imax();
+    if ((is_positive(I_max) && ((I > YAW_IMBALANCE_IMAX_THRESHOLD * I_max) || (is_equal(I_term,I_max)))) ||
+        (I >YAW_IMBALANCE_I_THERSHOLD)) {
+        // filtered using over precentage of I max or unfiltered = I max
+        // I makes up more than precentage of total available control power
+        const uint32_t now = millis();
+        if (now - last_yaw_warn_ms > YAW_IMBALANCE_WARN_MS) {
+            last_yaw_warn_ms = now;
+            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Yaw Imbalance %0.0f%%", I *100);
+        }
     }
 }
 

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -98,6 +98,11 @@ void Copter::thrust_loss_check()
 {
     static uint16_t thrust_loss_counter;  // number of iterations vehicle may have been crashed
 
+    // no-op if suppresed by flight options param
+    if ((copter.g2.flight_options & uint32_t(FlightOptions::DISABLE_THRUST_LOSS_CHECK)) != 0) {
+        return;
+    }
+
     // exit immediately if thrust boost is already engaged
     if (motors->get_thrust_boost()) {
         return;
@@ -167,6 +172,11 @@ void Copter::thrust_loss_check()
 // check for a large yaw imbalance, could be due to badly calibrated ESC or misaligned motors
 void Copter::yaw_imbalance_check()
 {
+    // no-op if suppresed by flight options param
+    if ((copter.g2.flight_options & uint32_t(FlightOptions::DISABLE_YAW_IMBALANCE_WARNING)) != 0) {
+        return;
+    }
+
     // If I is disabled it is unlikely that the issue is not obvious
     if (!is_positive(attitude_control->get_rate_yaw_pid().kI())) {
         return;

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -27,6 +27,7 @@ void Copter::update_land_and_crash_detectors()
 
     crash_check();
     thrust_loss_check();
+    yaw_imbalance_check();
 }
 
 // update_land_detector - checks if we have landed and updates the ap.land_complete flag


### PR DESCRIPTION
This adds a yaw imbalance check, it prints a warning based on large I term. 

![image](https://user-images.githubusercontent.com/33176108/98449672-3c122880-212d-11eb-8f43-fc28bb86915f.png)

This is something that is often seen in new setups, badly calibrated ESC's or misaligned motors can cause this. Often it goes un-noticed until some looks at the log and knows to check the motor outputs.

This check filters the I term such that the filtered value grow slowly, if the I term falls lower than the filtered value it is reset to the I term.

The warning is displayed if the filtered value is larger than 0.1 or larger than 75% of Imax or if the un-filtered value is equal to Imax. The warning is re-issued every 10 seconds, no action is take except to issue the warning.

It is also possibly to trigger this if you yaw at max rate for quite a long time with a poor tune.



