### PR TITLE
Plane: 6 servo wing mixing

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1295,6 +1295,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(guidedHeading, "GUIDED_", 28, ParametersG2, AC_PID),
 #endif // OFFBOARD_GUIDED == ENABLED
 
+    // @Param: AIRBRK_SLEWRATE
+    // @DisplayName: Airbrake slew rate
+    // @Description: maximum percentage change in airbrake output per second. A setting of 25 means to not change the airbrake by more than 25% of the full airbrake range in one second. A value of 0 means no rate limiting.
+    // @Units: %/s
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("AIRBRK_SLEWRATE", 29, ParametersG2, airbrake_slewrate, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -586,6 +586,8 @@ public:
 
     // min initial climb in RTL
     AP_Int16        rtl_climb_min;
+
+    AP_Int16 airbrake_slewrate;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1095,6 +1095,11 @@ private:
         Failsafe_Action_Parachute = 5
     };
 
+    void crow_update(void);
+    float airbrake_function_output;
+    float flap_function_output;
+
+
     // list of priorities, highest priority first
     static constexpr int8_t _failsafe_priorities[] = {
                                                       Failsafe_Action_Terminate,

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -144,6 +144,8 @@ public:
         k_scripting15           = 108,
         k_scripting16           = 109,
         k_airbrake              = 110,
+        k_crow_inner            = 111,
+        k_crow_outer            = 112,
         k_LED_neopixel1         = 120,
         k_LED_neopixel2         = 121,
         k_LED_neopixel3         = 122,

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -143,6 +143,8 @@ void SRV_Channel::aux_servo_function_setup(void)
     case k_roll_out:
     case k_pitch_out:
     case k_yaw_out:
+    case k_crow_inner:
+    case k_crow_outer:
         set_angle(4500);
         break;
     case k_throttle:


### PR DESCRIPTION
This is the method used on the K1000ULE for six wing servos, three per wing. These work as follows:

 - The entire trailing edge moves to adjust camber based on manual flap or auto flap.
 - Roll is controlled using the outer servo
 - The inner two servos provide airbrake by moving opposite directions

This is implemented as 
 - Inner servo - new type 111 mixing flap and airbrake
 - Middle servo - new type 112 mixing flap and airbrake
 - Outer servo - existing flaperon type 24/25 mixing flap and aileron

This is a fairly traditional way of actuating a 6 servo wing to get roll, camber and airbrake mixing.

The outputs are all slew-limited based on the FLAP_SLEWRATE and AIRBRK_SLEWRATE parameters. This isn't very clean as I couldn't find a way of accessing the slew-limited channel values from the SRV_Channels library. So the slew limiting had to be duplicated in servos.cpp.

This PR is really for discussion as some of the same functionality has been added by @IamPete1 under the DSPOILER group of functions. This was done around the same time and independently of that. Note that I later added scaling of the deflections on the inner and middle servos using the DSPOILER parameters that serve the same purpose.

I need to figure out if this adds something new or if it can all be achieved using existing functions. 

