### PR TITLE
Report offsets

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -448,8 +448,9 @@ void AP_Airspeed::update_calibration(uint8_t i, float raw_pressure)
         if (state[i].cal.count == 0) {
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Airspeed %u unhealthy", i + 1);
         } else {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Airspeed %u calibrated", i + 1);
-            param[i].offset.set_and_save(state[i].cal.sum / state[i].cal.count);
+            float offset = state[i].cal.sum / state[i].cal.count;
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Airspeed %u calibrated, offset %4.0f", i + 1, offset);
+            param[i].offset.set_and_save(offset);
         }
         state[i].cal.start_ms = 0;
         return;


### PR DESCRIPTION
1. adds reports of offset cal values after ground start
2. adds report of changes to arspd ratios during autocal
3. adds option to autocal only when in LOITER allowing autocal to be always on with minimal risk
4. moved conditional compile of autocal out of library and into into vehicle....where I think it makes better sense...I dont think any other vehicles would build that library when not using it....but I might misunderstand how things work...if so, easy reversal

I have tested in SITL, and seems to work fine (the reporting stuff I am flying...but not the LOITER option....yet), however, I am not sure how SITL actually handles autocaling...it seems to converge to about 1.75 or so from the default param start value