### PR TITLE
AC_Fence: remove timeout for waiting on fence semaphore, make nonblocking

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -617,12 +617,12 @@ bool AC_PolyFence_loader::load_from_eeprom()
         return false;
     }
 
-    _load_attempted = true;
-
     // find indexes of each fence:
-    if (!get_loaded_fence_semaphore().take(1)) {
+    if (!get_loaded_fence_semaphore().take_nonblocking()) {
         return false;
     }
+
+    _load_attempted = true;
 
     unload();
 


### PR DESCRIPTION
Also move where we indicate we've attempted a load.

This works because we call this method @10Hz


Tested in SITL with the following patches:

```
pbarker@bluebottle:~/rc/ardupilot(pr/polyfence-loader-semaphore)$ git diff | catdiff --git a/libraries/AC_Avoidance/AP_OADijkstra.cpp b/libraries/AC_Avoidance/AP_OADijkstra.cpp
index ee9ef9c766..8d6f799e3c 100644
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -16,9 +16,10 @@
 #include "AP_OADijkstra.h"
 
 #include <AC_Fence/AC_Fence.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
+#include <AP_Filesystem/AP_Filesystem.h>
+
 #define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  32      // expanding arrays for fence points and paths to destination will grow in increments of 20 elements
 #define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX        255     // index use to indicate we do not have a tentative short path for a node
 #define OA_DIJKSTRA_ERROR_REPORTING_INTERVAL_MS         5000    // failure messages sent to GCS every 5 seconds
@@ -39,6 +40,29 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
 {
     WITH_SEMAPHORE(AP::fence()->polyfence().get_loaded_fence_semaphore());
 
+    static uint32_t last_sent;
+    const uint32_t now = AP_HAL::millis();
+    bool notify = false;
+    if (now - last_sent > 1000) {
+        notify = true;
+        last_sent = now;
+    }
+
+    while (true) {
+        int fascinator_fd = AP::FS().open("oa-fascinator.txt", O_RDONLY);
+        if (fascinator_fd == -1) {
+            break;
+        }
+        if (notify) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "%u Oooh!  Pretty!", now);
+        }
+        AP::FS().close(fascinator_fd);
+    }
+
+    if (notify) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "%u dijkstra update", now);
+    }
+
     // avoidance is not required if no fences
     if (!some_fences_enabled()) {
         AP::logger().Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, 0, destination, destination);
diff --git a/libraries/AC_Fence/AC_PolyFence_loader.cpp b/libraries/AC_Fence/AC_PolyFence_loader.cpp
index de83f38fbe..622db26956 100644
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -619,9 +619,16 @@ bool AC_PolyFence_loader::load_from_eeprom()
 
     // find indexes of each fence:
     if (!get_loaded_fence_semaphore().take_nonblocking()) {
+        static uint32_t last_sent;
+        const uint32_t now = AP_HAL::millis();
+        if (now - last_sent > 1000) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "%u no lock", now);
+            last_sent = now;
+        }
         return false;
     }
 
+    gcs().send_text(MAV_SEVERITY_WARNING, "%u got lock", AP_HAL::millis());
     _load_attempted = true;
 
     unload();
pbarker@bluebottle:~/rc/ardupilot(pr/polyfence-loader-semaphore)$ 
```
