### PR TITLE
AP_GPS: correct logging in dual-ublox setups

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -705,7 +705,7 @@ void AP_GPS_UBLOX::log_mon_hw(void)
         return;
     }
     struct log_Ubx1 pkt = {
-        LOG_PACKET_HEADER_INIT(_ubx_msg_log_index(LOG_GPS_UBX1_MSG)),
+        LOG_PACKET_HEADER_INIT(LOG_GPS_UBX1_MSG),
         time_us    : AP_HAL::micros64(),
         instance   : state.instance,
         noisePerMS : _buffer.mon_hw_60.noisePerMS,
@@ -732,7 +732,7 @@ void AP_GPS_UBLOX::log_mon_hw2(void)
     }
 
     struct log_Ubx2 pkt = {
-        LOG_PACKET_HEADER_INIT(_ubx_msg_log_index(LOG_GPS_UBX2_MSG)),
+        LOG_PACKET_HEADER_INIT(LOG_GPS_UBX2_MSG),
         time_us   : AP_HAL::micros64(),
         instance  : state.instance,
         ofsI      : _buffer.mon_hw2.ofsI,

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -51,7 +51,6 @@
 #define UBLOX_GNSS_SETTINGS 1
 
 #define UBLOX_MAX_GNSS_CONFIG_BLOCKS 7
-#define UBX_MSG_TYPES 2
 
 #define UBX_TIMEGPS_VALID_WEEK_MASK 0x2
 
@@ -731,11 +730,6 @@ private:
     void log_mon_hw2(void);
     void log_rxm_raw(const struct ubx_rxm_raw &raw);
     void log_rxm_rawx(const struct ubx_rxm_rawx &raw);
-
-    // Calculates the correct log message ID based on what GPS instance is being logged
-    uint8_t _ubx_msg_log_index(uint8_t ubx_msg) {
-        return (uint8_t)(ubx_msg + (state.instance * UBX_MSG_TYPES));
-    }
 
 #if GPS_MOVING_BASELINE
     // see if we should use uart2 for moving baseline config


### PR DESCRIPTION
This corrects an logging issue discovered by @rmackay9 in which "ESC" and "CSRV" logging messages were appearing and the log was corrupt.  The vehicle used had two GPSs.

The bug is in GPS UBX1, UBX2 logging code that was adding the GPS instance number to the log message id.  This was most likely a mistake introduced when we switched these log message to use instance fields instead of separate messages.