### PR TITLE
AP_HAL_ChibiOS: Tweak sorting to be py2/py3 compatible

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/af_parse.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/af_parse.py
@@ -8,6 +8,7 @@ This assumes a csv file extracted from the datasheet using tablula:
 '''
 
 import sys, csv, os
+from functools import cmp_to_key
 
 def is_pin(str):
     '''see if a string is a valid pin name'''
@@ -88,7 +89,7 @@ parse_af_table(sys.argv[1], table)
 sys.stdout.write("AltFunction_map = {\n");
 sys.stdout.write('\t# format is PIN:FUNCTION : AFNUM\n')
 sys.stdout.write('\t# extracted from %s\n' % os.path.basename(sys.argv[1]))
-for k in sorted(table.keys(), cmp=pin_compare):
+for k in sorted(table.keys(), key=cmp_to_key(pin_compare)):
     s = '"' + k + '"'
     sys.stdout.write('\t%-20s\t:\t%s,\n' % (s, table[k]))
 sys.stdout.write("}\n");


### PR DESCRIPTION
Cherry-picked from https://github.com/ArduPilot/ardupilot/pull/15778

This patch makes the output consistent on a sample CSV for me, master py2/py3 and this PR py2/py3

Tweaked the commit message (prepended `AP_`)
