### PR TITLE
Move Simulated ToshibaLed to use I2CRegisters object

### DIFF
--- a/libraries/AP_HAL_SITL/Semaphores.h
+++ b/libraries/AP_HAL_SITL/Semaphores.h
@@ -20,4 +20,7 @@ protected:
     pthread_mutex_t _lock;
     pthread_t owner;
 
+    // keep track the recursion level to ensure we only disown the
+    // semaphore once we're done with it
+    uint8_t take_count;
 };

--- a/libraries/SITL/SIM_I2CDevice.cpp
+++ b/libraries/SITL/SIM_I2CDevice.cpp
@@ -63,12 +63,62 @@ int SITL::I2CRegisters_16Bit::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
         if (data->msgs[0].flags != 0) {
             AP_HAL::panic("Unexpected flags");
         }
+        // FIXME: handle multi-register writes
         const uint8_t reg_addr = data->msgs[0].buf[0];
         if (!writable_registers.get(reg_addr)) {
             AP_HAL::panic("Register 0x%02x is not writable!", reg_addr);
         }
         const uint16_t register_value = data->msgs[0].buf[2] << 8 | data->msgs[0].buf[1];
         word[reg_addr] = register_value;
+        return 0;
+    }
+
+    return -1;
+};
+
+
+
+int SITL::I2CRegisters_8Bit::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
+{
+    if (data->nmsgs == 2) {
+        // data read request
+        if (data->msgs[0].flags != 0) {
+            AP_HAL::panic("Unexpected flags");
+        }
+        if (data->msgs[1].flags != I2C_M_RD) {
+            AP_HAL::panic("Unexpected flags");
+        }
+        const uint8_t reg_base_addr = data->msgs[0].buf[0];
+        uint8_t bytes_copied = 0;
+        while (bytes_copied < data->msgs[1].len) {
+            const uint8_t reg_addr = reg_base_addr + bytes_copied;
+            if (!readable_registers.get(reg_addr)) {
+                // ::printf("Register 0x%02x is not readable!\n", reg_addr);
+                return -1;
+            }
+            const uint8_t register_value = byte[reg_addr];
+            data->msgs[1].buf[bytes_copied++] = register_value;
+        }
+        data->msgs[1].len = bytes_copied;
+        return 0;
+    }
+
+    if (data->nmsgs == 1) {
+        // data write request
+        if (data->msgs[0].flags != 0) {
+            AP_HAL::panic("Unexpected flags");
+        }
+        const uint8_t reg_base_addr = data->msgs[0].buf[0];
+        uint8_t bytes_copied = 0;
+        while (bytes_copied < data->msgs[0].len-1) {
+            const uint8_t reg_addr = reg_base_addr + bytes_copied;
+            if (!writable_registers.get(reg_addr)) {
+                AP_HAL::panic("Register 0x%02x is not writable!", reg_addr);
+            }
+            const uint8_t register_value = data->msgs[0].buf[1+bytes_copied];
+            byte[reg_addr] = register_value;
+            bytes_copied++;
+        }
         return 0;
     }
 

--- a/libraries/SITL/SIM_I2CDevice.h
+++ b/libraries/SITL/SIM_I2CDevice.h
@@ -35,6 +35,20 @@ protected:
     uint16_t word[256];
 };
 
+class I2CRegisters_8Bit : public I2CRegisters {
+public:
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
+    void set_register(uint8_t reg, uint8_t value);
+    void set_register(uint8_t reg, int8_t value);
+
+    uint8_t get_register(uint8_t num) {
+        return byte[(uint8_t)num];
+    }
+
+protected:
+
+    uint8_t byte[256];
+};
 
 class I2CDevice {
 public:

--- a/libraries/SITL/SIM_ToshibaLED.cpp
+++ b/libraries/SITL/SIM_ToshibaLED.cpp
@@ -2,45 +2,18 @@
 
 #include <stdio.h>
 
-#define TOSHIBA_LED_PWM0    0x01    // pwm0 register
-#define TOSHIBA_LED_PWM1    0x02    // pwm1 register
-#define TOSHIBA_LED_PWM2    0x03    // pwm2 register
-#define TOSHIBA_LED_ENABLE  0x04    // enable register
-
-int SITL::ToshibaLED::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
+void SITL::ToshibaLED::update(const class Aircraft &aircraft)
 {
-    if (data->nmsgs != 1) {
-        // this is really just because it is unexpected from the
-        // ArduPilot code, rather than being incorrect from a
-        // simulated device perspective.
-        AP_HAL::panic("Reading from Toshiba LED?!");
+    if (last_print_pwm0 == get_register(ToshibaLEDDevReg::PWM0) &&
+        last_print_pwm1 == get_register(ToshibaLEDDevReg::PWM1) &&
+        last_print_pwm2 == get_register(ToshibaLEDDevReg::PWM2) &&
+        last_print_enable == get_register(ToshibaLEDDevReg::ENABLE)) {
+        return;
     }
-    const struct I2C::i2c_msg &msg = data->msgs[0];
-    const uint8_t reg = msg.buf[0];
-    const uint8_t val = msg.buf[1];
-    switch(reg) {
-    case TOSHIBA_LED_PWM0:
-        // ::fprintf(stderr, "ToshibaLED: pwm0=%u %u %u\n", msg.buf[1], msg.buf[2], msg.buf[3]);
-        _pwm0 = val;
-        break;
-    case TOSHIBA_LED_PWM1:
-        // ::fprintf(stderr, "ToshibaLED: pwm1=%u\n", val);
-        _pwm1 = val;
-        break;
-    case TOSHIBA_LED_PWM2:
-        // ::fprintf(stderr, "ToshibaLED: pwm2=%u\n", val);
-        _pwm2 = val;
-        break;
-    case TOSHIBA_LED_ENABLE:
-        if (val != 0x03) {
-            AP_HAL::panic("Unexpected enable value (%u)", val);
-        }
-        // ::fprintf(stderr, "ToshibaLED: enabling\n");
-        _enabled = true;
-        break;
-    default:
-        AP_HAL::panic("Unexpected register (%u)", reg);
-    }
-    // kill(0, SIGTRAP);
-    return -1;
+
+    last_print_pwm0 = get_register(ToshibaLEDDevReg::PWM0);
+    last_print_pwm1 = get_register(ToshibaLEDDevReg::PWM1);
+    last_print_pwm2 = get_register(ToshibaLEDDevReg::PWM2);
+    last_print_enable = get_register(ToshibaLEDDevReg::ENABLE);
+    // gcs().send_text(MAV_SEVERITY_INFO, "SIM_ToshibaLED: PWM0=%u PWM1=%u PWM2=%u ENABLE=%u", last_print_pwm0, last_print_pwm1, last_print_pwm2, last_print_enable);
 }

--- a/libraries/SITL/SIM_ToshibaLED.h
+++ b/libraries/SITL/SIM_ToshibaLED.h
@@ -2,18 +2,35 @@
 
 namespace SITL {
 
-class ToshibaLED : public I2CDevice
+class ToshibaLEDDevReg : public I2CRegEnum {
+public:
+    static constexpr uint8_t PWM0 = 0x01;
+    static constexpr uint8_t PWM1 = 0x02;
+    static constexpr uint8_t PWM2 = 0x03;
+    static constexpr uint8_t ENABLE = 0x04;
+};
+
+class ToshibaLED : public I2CDevice, protected I2CRegisters_8Bit
 {
 public:
-    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
-    // void update(const struct sitl_input input) override;
+    void init() override {
+        add_register("PWM0", ToshibaLEDDevReg::PWM0, O_WRONLY);
+        add_register("PWM1", ToshibaLEDDevReg::PWM1, O_WRONLY);
+        add_register("PWM2", ToshibaLEDDevReg::PWM2, O_WRONLY);
+        add_register("ENABLE", ToshibaLEDDevReg::ENABLE, O_WRONLY);
+    }
+
+    void update(const class Aircraft &aircraft) override;
+
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override {
+        return I2CRegisters_8Bit::rdwr(data);
+    }
+
 private:
-    bool _enabled;
-    bool _pwm0; // FIXME: just an array of register values?!
-    bool _pwm1;
-    bool _pwm2;
-    bool _pwm3;
-    uint32_t last_internal_clock_update_ms;
+    uint8_t last_print_pwm0;
+    uint8_t last_print_pwm1;
+    uint8_t last_print_pwm2;
+    uint8_t last_print_enable;
 };
 
 } // namespace SITL


### PR DESCRIPTION
Simple register-based devices don't need to implement rdwr themselves.

Tested by using --rgbled in SITL and making sure the printf-output (when enabled) matches the blinkenlights.
