### PR TITLE
SITL: fix copter sitl build on macos

### DIFF
--- a/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
@@ -1,4 +1,5 @@
 #include "SIM_BattMonitor_SMBus_Rotoye.h"
+#include <AP_HAL/utility/sparse-endian.h>
 
 SITL::Rotoye::Rotoye() :
     SIM_BattMonitor_SMBus_Generic()

--- a/libraries/SITL/SIM_I2CDevice.cpp
+++ b/libraries/SITL/SIM_I2CDevice.cpp
@@ -1,4 +1,5 @@
 #include "SIM_I2CDevice.h"
+#include <AP_HAL/utility/sparse-endian.h>
 
 void SITL::I2CRegisters::add_register(const char *name, uint8_t reg, int8_t mode)
 {


### PR DESCRIPTION
fix copter SITL build error on Mac OS
```
fatal error: use of undeclared identifier 'be16toh'
```
same way with this PR https://github.com/ArduPilot/ardupilot/pull/14773/files