### PR TITLE
SITL: Support reading from a joystick device directly

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -456,6 +456,11 @@ class sitl(Board):
             if not cfg.check_SFML(env):
                 cfg.fatal("Failed to find SFML libraries")
 
+        if cfg.options.enable_sfml_joystick:
+            if not cfg.check_SFML(env):
+                cfg.fatal("Failed to find SFML libraries")
+            env.CXXFLAGS += ['-DSFML_JOYSTICK']
+
         if cfg.options.sitl_osd:
             env.CXXFLAGS += ['-DWITH_SITL_OSD','-DOSD_ENABLED=1']
             for f in os.listdir('libraries/AP_OSD/fonts'):

--- a/libraries/AP_HAL_SITL/RCInput.cpp
+++ b/libraries/AP_HAL_SITL/RCInput.cpp
@@ -5,6 +5,14 @@
 #include <SITL/SITL.h>
 #include <AP_RCProtocol/AP_RCProtocol.h>
 
+#ifdef SFML_JOYSTICK
+  #ifdef HAVE_SFML_GRAPHICS_HPP
+    #include <SFML/Window/Joystick.hpp>
+  #elif HAVE_SFML_GRAPHIC_H
+    #include <SFML/Window/Joystick.h>
+  #endif
+#endif // SFML_JOYSTICK
+
 using namespace HALSITL;
 
 extern const AP_HAL::HAL& hal;
@@ -39,7 +47,22 @@ uint16_t RCInput::read(uint8_t ch)
     if (ch >= num_channels()) {
         return 0;
     }
+#ifdef SFML_JOYSTICK
+    SITL::SITL *_sitl = AP::sitl();
+    if (_sitl) {
+        const sf::Joystick::Axis axis = sf::Joystick::Axis(_sitl->sfml_joystick_axis[ch].get());
+        const unsigned int stickID = _sitl->sfml_joystick_id;
+        if (sf::Joystick::hasAxis(stickID, axis)) {
+            return (constrain_float(sf::Joystick::getAxisPosition(stickID, axis) + 100, 0, 200) * 5) + 1000;
+        } else {
+            return 0;
+        }
+    } else {
+      return 0;
+    }
+#else
     return _sitlState->pwm_input[ch];
+#endif
 }
 
 uint8_t RCInput::read(uint16_t* periods, uint8_t len)
@@ -60,7 +83,11 @@ uint8_t RCInput::num_channels()
     }
     SITL::SITL *_sitl = AP::sitl();
     if (_sitl) {
+#ifdef SFML_JOYSTICK
+        return (sf::Joystick::isConnected(_sitl->sfml_joystick_id.get())) ? ARRAY_SIZE(_sitl->sfml_joystick_axis) : 0;
+#else
         return MIN(_sitl->rc_chancount.get(), SITL_RC_INPUT_CHANNELS);
+#endif // SFML_JOYSTICK
     }
     return SITL_RC_INPUT_CHANNELS;
 }

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -27,6 +27,14 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Logger/AP_Logger.h>
 
+#ifdef SFML_JOYSTICK
+  #ifdef HAVE_SFML_GRAPHICS_HPP
+    #include <SFML/Window/Joystick.hpp>
+  #elif HAVE_SFML_GRAPHIC_H
+    #include <SFML/Window/Joystick.h>
+  #endif
+#endif // SFML_JOYSTICK
+
 extern const AP_HAL::HAL& hal;
 
 namespace SITL {
@@ -253,6 +261,10 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     // user settable common airspeed parameters
     AP_GROUPINFO("ARSPD_SIGN",    62, SITL,  arspd_signflip, 0),
 
+#ifdef SFML_JOYSTICK
+    AP_SUBGROUPEXTENSION("",      63, SITL,  var_sfml_joystick),
+#endif // SFML_JOYSTICK
+
     AP_GROUPEND
 };
 
@@ -332,6 +344,22 @@ const AP_Param::GroupInfo SITL::var_mag[] = {
 #endif
     AP_GROUPEND
 };
+
+#ifdef SFML_JOYSTICK
+const AP_Param::GroupInfo SITL::var_sfml_joystick[] = {
+    AP_GROUPINFO("SF_JS_STICK",    1, SITL,  sfml_joystick_id,   0),
+    AP_GROUPINFO("SF_JS_AXIS1",    2, SITL,  sfml_joystick_axis[0], sf::Joystick::Axis::X),
+    AP_GROUPINFO("SF_JS_AXIS2",    3, SITL,  sfml_joystick_axis[1], sf::Joystick::Axis::Y),
+    AP_GROUPINFO("SF_JS_AXIS3",    4, SITL,  sfml_joystick_axis[2], sf::Joystick::Axis::Z),
+    AP_GROUPINFO("SF_JS_AXIS4",    5, SITL,  sfml_joystick_axis[3], sf::Joystick::Axis::U),
+    AP_GROUPINFO("SF_JS_AXIS5",    6, SITL,  sfml_joystick_axis[4], sf::Joystick::Axis::V),
+    AP_GROUPINFO("SF_JS_AXIS6",    7, SITL,  sfml_joystick_axis[5], sf::Joystick::Axis::R),
+    AP_GROUPINFO("SF_JS_AXIS7",    8, SITL,  sfml_joystick_axis[6], sf::Joystick::Axis::PovX),
+    AP_GROUPINFO("SF_JS_AXIS8",    9, SITL,  sfml_joystick_axis[7], sf::Joystick::Axis::PovY),
+    AP_GROUPEND
+};
+
+#endif //SFML_JOYSTICK
     
 /* report SITL state via MAVLink */
 void SITL::simstate_send(mavlink_channel_t chan)

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -95,6 +95,9 @@ public:
         AP_Param::setup_object_defaults(this, var_info3);
         AP_Param::setup_object_defaults(this, var_gps);
         AP_Param::setup_object_defaults(this, var_mag);
+#ifdef SFML_JOYSTICK
+        AP_Param::setup_object_defaults(this, var_sfml_joystick);
+#endif // SFML_JOYSTICK
         if (_singleton != nullptr) {
             AP_HAL::panic("Too many SITL instances");
         }
@@ -143,6 +146,9 @@ public:
     static const struct AP_Param::GroupInfo var_info3[];
     static const struct AP_Param::GroupInfo var_gps[];
     static const struct AP_Param::GroupInfo var_mag[];
+#ifdef SFML_JOYSTICK
+    static const struct AP_Param::GroupInfo var_sfml_joystick[];
+#endif //SFML_JOYSTICK
 
     // Board Orientation (and inverse)
     Matrix3f ahrs_rotation;
@@ -223,6 +229,11 @@ public:
     AP_Int32 mag_devid[MAX_CONNECTED_MAGS]; // Mag devid
     AP_Float buoyancy; // submarine buoyancy in Newtons
     AP_Int16 loop_rate_hz;
+
+#ifdef SFML_JOYSTICK
+    AP_Int8 sfml_joystick_id;
+    AP_Int8 sfml_joystick_axis[8];
+#endif
 
     // EFI type
     enum EFIType {

--- a/wscript
+++ b/wscript
@@ -188,6 +188,10 @@ configuration in order to save typing.
                  default=False,
                  help="Enable SFML graphics library")
 
+    g.add_option('--enable-sfml-joystick', action='store_true',
+                 default=False,
+                 help="Enable SFML joystick input library")
+
     g.add_option('--enable-sfml-audio', action='store_true',
                  default=False,
                  help="Enable SFML audio library")


### PR DESCRIPTION
This uses SFML to allow you to directly read a joystick device connected to your computer, without needing a GCS like MAVProxy to send data to a UDP port. This is particularly helpful when trying to test failsafes or any interaction with SITL that requires the GCS to be completely killed.

This was tested using a FrSky X-Lite Pro transmitter connected via USB and setup as a joystick, as well as with a XBox One controller over USB, but this should work with any HID joystick. (It's actually quite nice to be able to use the same Tx you normally fly with directly over USB).

This currently does require a window of some form to be made in order to grab joystick input, so the --enable-sfml-joystick option should be combined with either the simmed OSD or status light to ensure a window was created. For reference this was the command I used for testing:
``` bash
sim_vehicle.py --no-mavproxy --waf-configure-arg=--enable-sfml-joystick --osd
```