### PR TITLE
ArduPlane:Add safety limit on tailsitter VTOL transition throttle

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -84,6 +84,7 @@ void QuadPlane::tailsitter_output(void)
               integrator to the same throttle level
             */
             throttle = motors->get_throttle_hover() * 100;
+            throttle = MAX(throttle,plane.aparm.throttle_cruise.get());
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
             pos_control->get_accel_z_pid().set_integrator(throttle*10);
 


### PR DESCRIPTION
This prevents a stall and crash if you transition from FW to VTOL in a tailsitter if the hover throttle is too low, either due to initial setup being wrong, battery compensation not being setup or improper,  or proper hover throttle not being learned yet .
Instead of using only hover throttle as it pulls up into VTOL stance, it will use TRIM_THROTTLE if it is larger (not the usual case). This would help assure the plane keeps "flying" thru the transition to VTOL stance if hover throttle is wrong (too low). (ask me how I know...)

Tested in SITL