### PR TITLE
OSD: Allow loading of fonts from filesystem

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -228,6 +228,16 @@ void AP_Filesystem::unmount(void)
     return LOCAL_BACKEND.fs.unmount();
 }
 
+/*
+  load a file to memory as a single chunk. Use only for small files
+ */
+FileData *AP_Filesystem::load_file(const char *filename)
+{
+    const Backend &backend = backend_by_path(filename);
+    return backend.fs.load_file(filename);
+}
+
+
 namespace AP
 {
 AP_Filesystem &FS()

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -88,6 +88,11 @@ public:
 
     // unmount filesystem for reboot
     void unmount(void);
+
+    /*
+      load a full file. Use delete to free the data
+     */
+    FileData *load_file(const char *filename);
     
 private:
     struct Backend {

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
@@ -212,4 +212,28 @@ bool AP_Filesystem_ROMFS::set_mtime(const char *filename, const uint32_t mtime_s
     return false;
 }
 
+/*
+  load a full file. Use delete to free the data
+  we override this in ROMFS to avoid taking twice the memory
+*/
+FileData *AP_Filesystem_ROMFS::load_file(const char *filename)
+{
+    FileData *fd = new FileData(this);
+    if (!fd) {
+        return nullptr;
+    }
+    fd->data = AP_ROMFS::find_decompress(filename, fd->length);
+    if (fd->data == nullptr) {
+        delete fd;
+        return nullptr;
+    }
+    return fd;
+}
+
+// unload data from load_file()
+void AP_Filesystem_ROMFS::unload_file(FileData *fd)
+{
+    AP_ROMFS::free(fd->data);
+}
+
 #endif // HAL_HAVE_AP_ROMFS_EMBEDDED_H

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
@@ -43,6 +43,14 @@ public:
     // set modification time on a file
     bool set_mtime(const char *filename, const uint32_t mtime_sec) override;
 
+    /*
+      load a full file. Use delete to free the data
+     */
+    FileData *load_file(const char *filename) override;
+
+    // unload data from load_file()
+    void unload_file(FileData *fd) override;
+    
 private:
     // only allow up to 4 files at a time
     static constexpr uint8_t max_open_file = 4;

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
@@ -1,0 +1,73 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Filesystem.h"
+
+/*
+  load a full file. Use delete to free the data
+*/
+FileData *AP_Filesystem_Backend::load_file(const char *filename)
+{
+    struct stat st;
+    if (stat(filename, &st) != 0) {
+        return nullptr;
+    }
+    FileData *fd = new FileData(this);
+    if (fd == nullptr) {
+        return nullptr;
+    }
+    void *data = malloc(st.st_size);
+    if (data == nullptr) {
+        delete fd;
+        return nullptr;
+    }
+    int d = open(filename, O_RDONLY);
+    if (d == -1) {
+        free(data);
+        delete fd;
+        return nullptr;
+    }
+    if (read(d, data, st.st_size) != st.st_size) {
+        close(d);
+        free(data);
+        delete fd;
+        return nullptr;
+    }
+    close(d);
+    fd->length = st.st_size;
+    fd->data = (const uint8_t *)data;
+    return fd;
+}
+
+/*
+  unload a FileData object
+*/
+void AP_Filesystem_Backend::unload_file(FileData *fd)
+{
+    if (fd->data != nullptr) {
+        free(const_cast<uint8_t *>(fd->data));
+        fd->data = nullptr;
+    }
+}
+
+/*
+  destructor for FileData
+ */
+FileData::~FileData()
+{
+    if (backend != nullptr) {
+        ((AP_Filesystem_Backend *)backend)->unload_file(this);
+    }
+}

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -22,6 +22,21 @@
 
 #include "AP_Filesystem_Available.h"
 
+// returned structure from a load_file() call
+class FileData {
+public:
+    uint32_t length;
+    const uint8_t *data;
+
+    FileData(void *_backend) :
+        backend(_backend) {}
+    
+    // destructor to free data
+    ~FileData();
+private:
+    const void *backend;
+};
+
 class AP_Filesystem_Backend {
 
 public:
@@ -55,4 +70,12 @@ public:
 
     // unmount filesystem for reboot
     virtual void unmount(void) {}
+
+    /*
+      load a full file. Use delete to free the data
+     */
+    virtual FileData *load_file(const char *filename);
+
+    // unload data from load_file()
+    virtual void unload_file(FileData *fd);
 };

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -549,15 +549,10 @@ uint16_t AP_Logger_File::find_last_log()
         return ret;
     }
     EXPECT_DELAY_MS(3000);
-    int fd = AP::FS().open(fname, O_RDONLY);
-    free(fname);
-    if (fd != -1) {
-        char buf[10];
-        memset(buf, 0, sizeof(buf));
-        if (AP::FS().read(fd, buf, sizeof(buf)-1) > 0) {
-            ret = strtol(buf, NULL, 10);
-        }
-        AP::FS().close(fd);
+    FileData *fd = AP::FS().load_file(fname);
+    if (fd != nullptr) {
+        ret = strtol((const char *)fd->data, NULL, 10);
+        delete fd;
     }
     return ret;
 }

--- a/libraries/AP_OSD/AP_OSD_Backend.cpp
+++ b/libraries/AP_OSD/AP_OSD_Backend.cpp
@@ -51,3 +51,26 @@ void AP_OSD_Backend::write(uint8_t x, uint8_t y, bool blink, const char *fmt, ..
     va_end(ap);
 #endif
 }
+
+/*
+  load a font from sdcard or ROMFS
+ */
+FileData *AP_OSD_Backend::load_font_data(uint8_t font_num)
+{
+    FileData *fd;
+
+    // first try from microSD
+    char fontname[] = "font0.bin";
+    fontname[4] = font_num + '0';
+
+    fd = AP::FS().load_file(fontname);
+    if (fd == nullptr) {
+        char fontname_romfs[] = "@ROMFS/font0.bin";
+        fontname_romfs[7+4] = font_num + '0';
+        fd = AP::FS().load_file(fontname_romfs);
+    }
+    if (fd == nullptr) {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "OSD: Failed to load font %u", font_num);
+    }
+    return fd;
+}

--- a/libraries/AP_OSD/AP_OSD_Backend.cpp
+++ b/libraries/AP_OSD/AP_OSD_Backend.cpp
@@ -71,6 +71,12 @@ FileData *AP_OSD_Backend::load_font_data(uint8_t font_num)
     }
     if (fd == nullptr) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "OSD: Failed to load font %u", font_num);
+        if (font_num != 0) {
+            // fallback to font0.bin. This allows us to reduce the
+            // number of fonts we include in flash without breaking
+            // user setups
+            return load_font_data(0);
+        }
     }
     return fd;
 }

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -18,6 +18,7 @@
 
 #include <AP_HAL/HAL.h>
 #include <AP_OSD/AP_OSD.h>
+#include <AP_Filesystem/AP_Filesystem.h>
 
 
 class AP_OSD_Backend
@@ -71,6 +72,9 @@ protected:
     {
         return (_osd.options & option) != 0;
     }
+
+    // load a font from sdcard or ROMFS
+    FileData *load_font_data(uint8_t font_num);
 
     int8_t blink_phase;
 

--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -22,7 +22,8 @@
 #include <AP_HAL/Util.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_HAL/Scheduler.h>
-#include <AP_ROMFS/AP_ROMFS.h>
+#include <AP_Filesystem/AP_Filesystem.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include <utility>
 
@@ -157,13 +158,19 @@ bool AP_OSD_MAX7456::init()
 
 bool AP_OSD_MAX7456::update_font()
 {
-    uint32_t font_size;
     uint8_t updated_chars = 0;
-    char fontname[] = "font0.bin";
     last_font = get_font_num();
-    fontname[4] = last_font + '0';
-    const uint8_t *font_data = AP_ROMFS::find_decompress(fontname, font_size);
-    if (font_data == nullptr || font_size != NVM_RAM_SIZE * 256) {
+    FileData *fd = load_font_data(last_font);
+
+    if (fd == nullptr) {
+        return false;
+    }
+
+    const uint8_t *font_data = fd->data;
+    uint32_t font_size = fd->length;
+    if (font_size != NVM_RAM_SIZE * 256) {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "AP_OSD: bad font size %u\n", unsigned(font_size));
+        delete fd;
         return false;
     }
 
@@ -173,18 +180,13 @@ bool AP_OSD_MAX7456::update_font()
         if (!check_font_char(chr, chr_font_data)) {
             //update char inside max7456 NVM
             if (!update_font_char(chr, chr_font_data)) {
-                hal.console->printf("AP_OSD: error during font char update\n");
-                AP_ROMFS::free(font_data);
+                delete fd;
                 return false;
             }
             updated_chars++;
         }
     }
-    if (updated_chars > 0) {
-        hal.console->printf("AP_OSD: updated %d symbols.\n", updated_chars);
-    }
-    hal.console->printf("AP_OSD: osd font is up to date.\n");
-    AP_ROMFS::free(font_data);
+    delete fd;
     return true;
 }
 

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1777,17 +1777,15 @@ void AP_OSD_Screen::draw_callsign(uint8_t x, uint8_t y)
 #if HAVE_FILESYSTEM_SUPPORT
     if (!callsign_data.load_attempted) {
         callsign_data.load_attempted = true;
-        int fd = AP::FS().open("callsign.txt", O_RDONLY);
-        if (fd != -1) {
-            char s[20] {};
-            int32_t len = AP::FS().read(fd, s, sizeof(s)-1);
+        FileData *fd = AP::FS().load_file("callsign.txt");
+        if (fd != nullptr) {
+            uint32_t len = fd->length;
             // trim off whitespace
-            while (len > 0 && isspace(s[len-1])) {
-                s[len-1] = 0;
+            while (len > 0 && isspace(fd->data[len-1])) {
                 len--;
             }
-            AP::FS().close(fd);
-            callsign_data.str = strdup(s);
+            callsign_data.str = strndup((const char *)fd->data, len);
+            delete fd;
         }
     }
     if (callsign_data.str != nullptr) {


### PR DESCRIPTION
This allows users to load fonts from their microSD. They can either replace an existing font number or add a new font number from 0 to 9.
For example, here I have put the chinese font from #15668 as font5.bin on the microSD, and set OSD_FONT to 5.
This also adds a general load_file() API to AP_Filesystem which makes loading small files into memory easy.

![image](https://user-images.githubusercontent.com/831867/99012007-8702c480-25a1-11eb-902f-5f3ab13ccc29.png)

This will also allow us to free up flash by only including one font