### PR TITLE
Tools: add CubeBlack to list of AP_Periph supported boards

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -637,6 +637,7 @@ is bob we will attempt to checkout bob-AVR'''
                 "CUAV_GPS",
                 "ZubaxGNSS",
                 "CubeOrange-periph",
+                "CubeBlack-periph",
                 ]
 
     def build_arducopter(self, tag):


### PR DESCRIPTION
Tools: add CubeBlack to list of AP_Periph supported boards for building binaries
