### PR TITLE
AP_DAL: move structure used for location references into cpp

### DIFF
--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -3,12 +3,24 @@
 #include <AP_Logger/AP_Logger.h>
 #include "AP_DAL.h"
 
+// we use a static here as the "location" accessor wants to be const
+static Location tmp_location[GPS_MAX_INSTANCES];
+
 AP_DAL_GPS::AP_DAL_GPS()
 {
     for (uint8_t i=0; i<ARRAY_SIZE(_RGPI); i++) {
         _RGPI[i].instance = i;
         _RGPJ[i].instance = i;
     }
+}
+
+const Location &AP_DAL_GPS::location(uint8_t instance) const
+{
+    Location &loc = tmp_location[instance];
+    loc.lat = _RGPJ[instance].lat;
+    loc.lng = _RGPJ[instance].lng;
+    loc.alt = _RGPJ[instance].alt;
+    return loc;
 }
 
 void AP_DAL_GPS::start_frame()

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -6,8 +6,6 @@
 
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
-static Location tmp_location[GPS_MAX_INSTANCES];
-
 class AP_DAL_GPS {
 public:
 
@@ -30,13 +28,7 @@ public:
     GPS_Status status() const {
         return status(primary_sensor());
     }
-    const Location &location(uint8_t instance) const {
-        Location &loc = tmp_location[instance];
-        loc.lat = _RGPJ[instance].lat;
-        loc.lng = _RGPJ[instance].lng;
-        loc.alt = _RGPJ[instance].alt;
-        return loc;
-    }
+    const Location &location(uint8_t instance) const;
     bool have_vertical_velocity(uint8_t instance) const {
         return _RGPI[instance].have_vertical_velocity;
     }


### PR DESCRIPTION
Outside we get a copy per compilation unit.

Thanks to @WickedShell for spotting this
