### PR TITLE
Mavftp disable option

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -270,7 +270,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Board options
     // @Description: Board specific option flags
-    // @Bitmask: 0:Enable hardware watchdog
+    // @Bitmask: 0:Enable hardware watchdog, 1:Disable MAVftp
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 19, AP_BoardConfig, _options, HAL_BRD_OPTIONS_DEFAULT),
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -164,7 +164,13 @@ public:
 
     enum board_options {
         BOARD_OPTION_WATCHDOG = (1 << 0),
+        DISABLE_FTP = (1<<1),
     };
+
+    // return true if ftp is disabled
+    static bool ftp_disabled(void) {
+        return _singleton?(_singleton->_options & DISABLE_FTP)!=0:1;
+    }
 
     // return true if watchdog enabled
     static bool watchdog_enabled(void) {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5062,8 +5062,10 @@ uint64_t GCS_MAVLINK::capabilities() const
         ret |= MAV_PROTOCOL_CAPABILITY_MISSION_FENCE;
     }
 
-    ret |= MAV_PROTOCOL_CAPABILITY_FTP;
-
+    if (!AP_BoardConfig::ftp_disabled()){  //if ftp disable board option is not set
+        ret |= MAV_PROTOCOL_CAPABILITY_FTP;
+    }
+ 
     return ret;
 }
 

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -20,6 +20,7 @@
 
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_HAL/utility/sparse-endian.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -29,7 +30,14 @@ struct GCS_MAVLINK::ftp_state GCS_MAVLINK::ftp;
 #define FTP_SESSION_TIMEOUT 3000
 
 bool GCS_MAVLINK::ftp_init(void) {
+
+    // check if ftp is disabled for memory savings
+    if (AP_BoardConfig::ftp_disabled()) {
+        goto failed;
+    }
+
     // we can simply check if we allocated everything we need
+
     if (ftp.requests != nullptr) {
         return true;
     }


### PR DESCRIPTION
Allows user to disable MAVftp and reclaim 13.2K of RAM....the F4 1MB boards are getting low again on RAM....
Master with defaults is only 18.9K...add several backends and you can run out of memory and start getting watchdogs...I did playing with servo gimbal stuff on the bench with a naked OmnibusF4pro....


tested on OmnibusF4pro with master, stable, and Tridges font PR code...

PS. not sure if I did the accessor correctly but it works...