### PR TITLE
EKF: fixed memory corruption on startup

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Buffer.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Buffer.h
@@ -85,6 +85,9 @@ public:
     */
     inline void push(element_type element)
     {
+        if (buffer == nullptr) {
+            return;
+        }
         // Advance head to next available index
         _head = (_head+1)%_size;
         // New data is written at the head

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Buffer.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Buffer.h
@@ -85,6 +85,9 @@ public:
     */
     inline void push(element_type element)
     {
+        if (buffer == nullptr) {
+            return;
+        }
         // Advance head to next available index
         _head = (_head+1)%_size;
         // New data is written at the head


### PR DESCRIPTION
This fixes a memory corruption bug in EKF3 where VISION_SPEED_ESTIMATE messages come in before the lag is available and thus before the ring buffers are initialised. This memory corruption resulted in a watchdog.
Also changed in EKF2 to avoid other possible code paths to push() without buffers.
