### PR TITLE
AP_BoardConfig: Change to ENUM member name

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -63,7 +63,7 @@ public:
     // valid types for BRD_TYPE: these values need to be in sync with the
     // values from the param description
     enum px4_board_type {
-        BOARD_TYPE_UNKNOWN = -1,
+        PX4_BOARD_UNKNOWN = -1,
         PX4_BOARD_AUTO     = 0,
         PX4_BOARD_PX4V1    = 1,
         PX4_BOARD_PIXHAWK  = 2,
@@ -96,7 +96,7 @@ public:
 #if AP_FEATURE_BOARD_DETECT
         return px4_configured_board;
 #else
-        return BOARD_TYPE_UNKNOWN;
+        return PX4_BOARD_UNKNOWN;
 #endif
     }
 


### PR DESCRIPTION
I'd like to go with "PX4 board unknown" because that's the member definition regarding PX4 board type.
Or better yet, you should be a class member.