### PR TITLE
Plane: tailsitter: use true hover throttle for VTOL transition and report in VFR_HUD 

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -434,7 +434,7 @@ bool Plane::should_log(uint32_t mask)
  */
 int8_t Plane::throttle_percentage(void)
 {
-    if (quadplane.in_vtol_mode()) {
+    if (quadplane.in_vtol_mode() && !quadplane.in_tailsitter_vtol_transition()) {
         return quadplane.throttle_percentage();
     }
     float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -82,16 +82,24 @@ void QuadPlane::tailsitter_output(void)
               during transitions to vtol mode set the throttle to
               hover thrust, center the rudder and set the altitude controller
               integrator to the same throttle level
+              convert the hover throttle to the same output that would result if used via AP_Motors
+              apply expo, battery scaling and SPIN min/max. 
             */
-            throttle = motors->get_throttle_hover() * 100;
+            throttle = motors->thrust_to_actuator(motors->get_throttle_hover()) * 100;
             throttle = MAX(throttle,plane.aparm.throttle_cruise.get());
+
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
             pos_control->get_accel_z_pid().set_integrator(throttle*10);
 
             // override AP_MotorsTailsitter throttles during back transition
+
+            // apply PWM min and MAX to throttle left and right, just as via AP_Motors
+            uint16_t throttle_pwm = motors->get_pwm_output_min() + (motors->get_pwm_output_max() - motors->get_pwm_output_min()) * throttle * 0.01f;
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, throttle_pwm);
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, throttle_pwm);
+
+            // throttle output is not used by AP_Motors so might have diffrent PWM range, set scaled
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
         }
 
         if (!assisted_flight) {
@@ -146,7 +154,7 @@ void QuadPlane::tailsitter_output(void)
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, (motors->get_yaw())*-SERVO_MAX);
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, (motors->get_pitch())*SERVO_MAX);
     SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, (motors->get_roll())*SERVO_MAX);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, (motors->get_throttle()) * 100);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, motors->thrust_to_actuator(motors->get_throttle()) * 100);
 
     if (hal.util->get_soft_armed()) {
         // scale surfaces for throttle

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -87,6 +87,9 @@ public:
     // parameter check for MOT_PWM_MIN/MAX, returns true if parameters are valid
     bool check_mot_pwm_params() const;
 
+    // converts desired thrust to linearized actuator output in a range of 0~1
+    float               thrust_to_actuator(float thrust_in);
+
     // set thrust compensation callback
     FUNCTOR_TYPEDEF(thrust_compensation_fn_t, void, float *, uint8_t);
     void                set_thrust_compensation_callback(thrust_compensation_fn_t callback) {
@@ -121,9 +124,6 @@ protected:
 
     // convert actuator output (0~1) range to pwm range
     int16_t             output_to_pwm(float _actuator_output);
-
-    // converts desired thrust to linearized actuator output in a range of 0~1
-    float               thrust_to_actuator(float thrust_in);
 
     // adds slew rate limiting to actuator output if MOT_SLEW_TIME > 0 and not shutdown
     void                set_actuator_with_slew(float& actuator_output, float input);


### PR DESCRIPTION
Fixes #15798

This changes to calculate the true hover throttle in back transition, the current behavior is to directly apply the hover percentage. This percentage is only the valid hover throttle when the copter expo, spin and pwm min and max are applied. To allow this `AP_Motors` function `thrust_to_actuator()` is moved to public.

This is a example transition on master. Transitions to mid stick Qstab should be the hover throttle. Showing the left and right throttle output PWM

![THrottle hover before](https://user-images.githubusercontent.com/33176108/99147782-93f3e680-267b-11eb-9d13-f9d4674c60bb.png)

The small step is direct application of hover throttle percentage. The large step is the change to the true hover throttle in Qstab.

Now with this patch.

![THrottle hover after](https://user-images.githubusercontent.com/33176108/99147810-bede3a80-267b-11eb-8600-396a0a0b10f2.png)

The throttle jumps directly to the true hover throttle for the transition, there is then a small step due to the throttle position in Qstab.

This also fixes the throttle value sent back over VFR_HUD, current master does not update the throttle value during transition, your just left with the last valve from a VTOL mode.

Master (the square dip):
![VFR-hud before](https://user-images.githubusercontent.com/33176108/99147882-3e6c0980-267c-11eb-8610-14ce599d0baa.png)

This patch:
![VFR-hud after](https://user-images.githubusercontent.com/33176108/99147884-43c95400-267c-11eb-9b1f-25fccf69340d.png)

The big jump is due to the above patch, were reporting as the true throttle output because its not going via AP_Motors, once AP_Motors is active the throttle drops again.

