### PR TITLE
Reduce vulnerability of EKF-GSF yaw estimator to GPS glitches

### DIFF
--- a/libraries/AP_NavEKF/EKFGSF_yaw.cpp
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.cpp
@@ -642,6 +642,18 @@ bool EKFGSF_yaw::getYawData(float &yaw, float &yawVariance)
     return true;
 }
 
+bool EKFGSF_yaw::getVelInnovLength(float &velInnovLength)
+{
+    if (!vel_fuse_running) {
+        return false;
+    }
+    velInnovLength = 0.0f;
+    for (uint8_t mdl_idx = 0; mdl_idx < N_MODELS_EKFGSF; mdl_idx ++) {
+        velInnovLength += GSF.weights[mdl_idx] * sqrtf((sq(EKF[mdl_idx].innov[0]) + sq(EKF[mdl_idx].innov[1])));
+    }
+    return true;
+}
+
 void EKFGSF_yaw::setGyroBias(Vector3f &gyroBias)
 {
     for (uint8_t mdl_idx = 0; mdl_idx < N_MODELS_EKFGSF; mdl_idx++) {

--- a/libraries/AP_NavEKF/EKFGSF_yaw.h
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.h
@@ -38,6 +38,10 @@ public:
     // return false if yaw estimation is inactive
     bool getYawData(float &yaw, float &yawVariance);
 
+    // get the length of the weighted average velocity innovation vector
+    // return false if not available
+    bool getVelInnovLength(float &velInnovLength);
+
 private:
 
     typedef float ftype;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -466,6 +466,7 @@ private:
     const uint16_t gndEffectTimeout_ms = 1000;     // time in msec that ground effect mode is active after being activated
     const float gndEffectBaroScaler = 4.0f;        // scaler applied to the barometer observation variance when ground effect mode is active
     const uint8_t fusionTimeStep_ms = 10;          // The minimum time interval between covariance predictions and measurement fusions in msec
+    const float maxYawEstVelInnov = 2.0f;          // Maximum acceptable length of the velocity innovation returned by the EKF-GSF yaw estimator (m/s)
 
     // origin set by one of the cores
     struct Location common_EKF_origin;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -557,7 +557,7 @@ void NavEKF2_core::runYawEstimatorPrediction()
 
 void NavEKF2_core::runYawEstimatorCorrection()
 {
-    if (yawEstimator != nullptr && frontend->_fusionModeGPS <= 1) {
+    if (yawEstimator != nullptr && frontend->_fusionModeGPS <= 1 && EKFGSF_run_filterbank) {
         if (gpsDataToFuse) {
             Vector2f gpsVelNE = Vector2f(gpsDataDelayed.vel.x, gpsDataDelayed.vel.y);
             float gpsVelAcc = fmaxf(gpsSpdAccuracy, frontend->_gpsHorizVelNoise);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -781,10 +781,11 @@ void NavEKF2_core::fuseEulerYaw()
             measured_yaw =  euler321.z;
         } else {
             if (imuSampleTime_ms - prevBetaStep_ms > 1000 && yawEstimator != nullptr) {
-                float gsfYaw, gsfYawVariance;
+                float gsfYaw, gsfYawVariance, velInnovLength;
                 if (yawEstimator->getYawData(gsfYaw, gsfYawVariance) &&
                     is_positive(gsfYawVariance) &&
-                    gsfYawVariance < sq(radians(15.0f))) {
+                    gsfYawVariance < sq(radians(15.0f)) &&
+                    (assume_zero_sideslip() || (yawEstimator->getVelInnovLength(velInnovLength) && velInnovLength < frontend->maxYawEstVelInnov))) {
                         measured_yaw = gsfYaw;
                         R_YAW = gsfYawVariance;
                 } else {
@@ -841,10 +842,11 @@ void NavEKF2_core::fuseEulerYaw()
             measured_yaw =  euler312.z;
         } else {
             if (imuSampleTime_ms - prevBetaStep_ms > 1000 && yawEstimator != nullptr) {
-                float gsfYaw, gsfYawVariance;
+                float gsfYaw, gsfYawVariance, velInnovLength;
                 if (yawEstimator->getYawData(gsfYaw, gsfYawVariance) &&
                     is_positive(gsfYawVariance) &&
-                    gsfYawVariance < sq(radians(15.0f))) {
+                    gsfYawVariance < sq(radians(15.0f)) &&
+                    (assume_zero_sideslip() || (yawEstimator->getVelInnovLength(velInnovLength) && velInnovLength < frontend->maxYawEstVelInnov))) {
                         measured_yaw = gsfYaw;
                         R_YAW = gsfYawVariance;
                 } else {
@@ -1166,8 +1168,11 @@ bool NavEKF2_core::EKFGSF_resetMainFilterYaw()
         return false;
     };
 
-    float yawEKFGSF, yawVarianceEKFGSF;
-    if (yawEstimator->getYawData(yawEKFGSF, yawVarianceEKFGSF) && is_positive(yawVarianceEKFGSF) && yawVarianceEKFGSF < sq(radians(15.0f))) {
+    float yawEKFGSF, yawVarianceEKFGSF, velInnovLength;
+    if (yawEstimator->getYawData(yawEKFGSF, yawVarianceEKFGSF) &&
+        is_positive(yawVarianceEKFGSF) &&
+        yawVarianceEKFGSF < sq(radians(15.0f)) &&
+        (assume_zero_sideslip() || (yawEstimator->getVelInnovLength(velInnovLength) && velInnovLength < frontend->maxYawEstVelInnov))) {
 
         // keep roll and pitch and reset yaw
         resetQuatStateYawOnly(yawEKFGSF, yawVarianceEKFGSF, false);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -391,11 +391,11 @@ void NavEKF2_core::detectFlight()
     }
 
     // handle reset of counters used to control how many times we will try to reset the yaw to the EKF-GSF value per flight
-    if (!prevOnGround && onGround) {
-        // landed so disable filter bank
+    if ((!prevOnGround && onGround) || !gpsAccuracyGood) {
+        // disable filter bank
         EKFGSF_run_filterbank = false;
-    } else if (yawEstimator != nullptr && !prevInFlight && inFlight) {
-        // started flying so reset counters and enable filter bank
+    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && inFlight && gpsAccuracyGood) {
+        // flying so reset counters and enable filter bank when GPS is good
         EKFGSF_yaw_reset_ms = 0;
         EKFGSF_yaw_reset_request_ms = 0;
         EKFGSF_yaw_reset_count = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -524,6 +524,7 @@ private:
     const uint8_t sensorIntervalMin_ms = 50;       // The minimum allowed time between measurements from any non-IMU sensor (msec)
     const uint8_t flowIntervalMin_ms = 20;         // The minimum allowed time between measurements from optical flow sensors (msec)
     const uint8_t extNavIntervalMin_ms = 20;       // The minimum allowed time between measurements from external navigation sensors (msec)
+    const float maxYawEstVelInnov = 2.0f;          // Maximum acceptable length of the velocity innovation returned by the EKF-GSF yaw estimator (m/s)
 
     // time at start of current filter update
     uint64_t imuSampleTime_us;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -638,7 +638,7 @@ void NavEKF3_core::runYawEstimatorPrediction()
 
 void NavEKF3_core::runYawEstimatorCorrection()
 {
-    if (yawEstimator != nullptr && frontend->_fusionModeGPS <= 1) {
+    if (yawEstimator != nullptr && frontend->_fusionModeGPS <= 1 && EKFGSF_run_filterbank) {
         if (gpsDataToFuse) {
             Vector2f gpsVelNE = Vector2f(gpsDataDelayed.vel.x, gpsDataDelayed.vel.y);
             float gpsVelAcc = fmaxf(gpsSpdAccuracy, frontend->_gpsHorizVelNoise);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -646,8 +646,11 @@ void NavEKF3_core::runYawEstimatorCorrection()
 
             // after velocity data has been fused the yaw variance esitmate will have been refreshed and
             // is used maintain a history of validity
-            float yawEKFGSF, yawVarianceEKFGSF;
-            bool canUseEKFGSF = yawEstimator->getYawData(yawEKFGSF, yawVarianceEKFGSF) && is_positive(yawVarianceEKFGSF) && yawVarianceEKFGSF < sq(radians(GSF_YAW_ACCURACY_THRESHOLD_DEG));
+            float yawEKFGSF, yawVarianceEKFGSF, velInnovLength;
+            bool canUseEKFGSF = yawEstimator->getYawData(yawEKFGSF, yawVarianceEKFGSF) &&
+                                is_positive(yawVarianceEKFGSF) &&
+                                yawVarianceEKFGSF < sq(radians(GSF_YAW_ACCURACY_THRESHOLD_DEG)) &&
+                                (assume_zero_sideslip() || (yawEstimator->getVelInnovLength(velInnovLength) && velInnovLength < frontend->maxYawEstVelInnov));
             if (canUseEKFGSF) {
                 if (EKFGSF_yaw_valid_count <  GSF_YAW_VALID_HISTORY_THRESHOLD) {
                     EKFGSF_yaw_valid_count++;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -402,11 +402,11 @@ void NavEKF3_core::detectFlight()
     updateTouchdownExpected();
 
     // handle reset of counters used to control how many times we will try to reset the yaw to the EKF-GSF value per flight
-    if (!prevOnGround && onGround) {
-        // landed so disable filter bank
+    if ((!prevOnGround && onGround) || !gpsAccuracyGood) {
+        // disable filter bank
         EKFGSF_run_filterbank = false;
-    } else if (yawEstimator && !EKFGSF_run_filterbank && ((!prevInFlight && inFlight) || expectTakeoff)) {
-        // started flying so reset counters and enable filter bank
+    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && (inFlight || expectTakeoff) && gpsAccuracyGood) {
+        // flying or about to fly so reset counters and enable filter bank when GPS is good
         EKFGSF_yaw_reset_ms = 0;
         EKFGSF_yaw_reset_request_ms = 0;
         EKFGSF_yaw_reset_count = 0;


### PR DESCRIPTION
Improves behaviour reported here https://github.com/ArduPilot/ardupilot/issues/15813

Replay of log provided with issue shows the EKF-GSF stops updating its yaw estimate during a higher period of reported GPS velocity error and resets the yaw estimation when the glitch finishes:

Before:
<img width="1049" alt="Screen Shot 2020-11-16 at 12 22 28 pm" src="https://user-images.githubusercontent.com/3596952/99203438-af3f2d00-2806-11eb-99f3-e667b9c3ebeb.png">

After:
<img width="1048" alt="Screen Shot 2020-11-16 at 12 22 42 pm" src="https://user-images.githubusercontent.com/3596952/99203451-b403e100-2806-11eb-9883-830c42d860df.png">

GPS reported velocity accuracy:
<img width="1018" alt="Screen Shot 2020-11-16 at 12 22 57 pm" src="https://user-images.githubusercontent.com/3596952/99203470-c1b96680-2806-11eb-9be3-2851aefabf77.png">

The second layer of protection added is use of a velocity innovation magnitude from the bank of EKF's in the yaw estimator that is obtained using the same weightings that are used to derive the yaw estimate. For operation with non fly forward vehicle types, this needs to be below 2 m/s which has been set to be just over the value achieved by this log with noisy GPS when not glitching, eg:

<img width="1045" alt="Screen Shot 2020-11-16 at 12 30 18 pm" src="https://user-images.githubusercontent.com/3596952/99203766-b0bd2500-2807-11eb-8221-015c548ad363.png">

Checking another copter log with a good GPS and where yaw was aligned by flying away from the pilot shows that a value of  below 1.0 is achieved during the initial convergence, so the value of 2 will be OK for now and can be adjusted later.
<img width="1033" alt="Screen Shot 2020-11-16 at 12 34 11 pm" src="https://user-images.githubusercontent.com/3596952/99204001-60929280-2808-11eb-983c-5432329735a8.png">

TODO: testing of EKF2 changes.

