### PR TITLE
add failsafe_throttle condition on FS_EKF_ACTION_ALTHOLD

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -165,7 +165,7 @@ void Copter::failsafe_ekf_event()
     switch (g.fs_ekf_action) {
         case FS_EKF_ACTION_ALTHOLD:
             // AltHold
-            if (failsafe.radio || !set_mode(Mode::Number::ALT_HOLD, ModeReason::EKF_FAILSAFE)) {
+            if ((failsafe.radio || g.failsafe_throttle == FS_THR_DISABLED) || !set_mode(Mode::Number::ALT_HOLD, ModeReason::EKF_FAILSAFE)) {
                 set_mode_land_with_pause(ModeReason::EKF_FAILSAFE);
             }
             break;


### PR DESCRIPTION
EKF_ACTION_ALTHOLD can be danger with rc failsafe
if g.failsafe_throttle = FS_THR_DISABLED, ekf action can be change to ALTHOLD without rc.

Add condition to prevent potential risk.

Motivated from https://github.com/ArduPilot/ardupilot/blob/1250f62c885fc2e8b5385455f9f759a9885f12a6/ArduCopter/events.cpp#L63

This issue releated to https://github.com/ArduPilot/ardupilot/issues/15732