### PR TITLE
AP_RangeFinder: Change rangefinder number 10 to A

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -761,7 +761,7 @@ bool RangeFinder::prearm_healthy(char *failure_msg, const uint8_t failure_msg_le
 {
     for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
         if (((Type)params[i].type.get() != Type::NONE) && (drivers[i] == nullptr)) {
-          hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %d was not detected", i + 1);
+          hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %X was not detected", i + 1);
           return false;
         }
     }


### PR DESCRIPTION
I can't find the rangefinder 10 in 10.
I find the RNGFND A in QGC, MP.
I got a comment a long time ago that this A was a hexadecimal.
I think the indication of hexadecimal is good because the parameter name RNGFND 1 to A.

![Screenshot from 2020-11-17 01-11-07](https://user-images.githubusercontent.com/646194/99277954-cff09c80-2871-11eb-9c02-a49b2ac13ce8.png)
