### PR TITLE
Plane: Tailsitter: fix Qassist in back transition, log assist state

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -371,9 +371,10 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: CRt: climb rate
 // @Field: TMix: transition throttle mix value
 // @Field: Sscl: speed scalar for tailsitter control surfaces
-// @Field: Trans: Transistion state
+// @Field: Trn: Transistion state
+// @Field: Ast: Q assist active state
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
-      "QTUN", "QffffffeccffB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl,Trans", "s----mmmnn---", "F----00000-0-" },
+      "QTUN", "QffffffeccffBB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl,Trn,Ast", "s----mmmnn----", "F----00000-0--" },
 
 // @LoggerMessage: AOA
 // @Description: Angle of attack and Side Slip Angle values

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2946,7 +2946,8 @@ void QuadPlane::Log_Write_QControl_Tuning()
         climb_rate          : int16_t(inertial_nav.get_velocity_z()),
         throttle_mix        : attitude_control->get_throttle_mix(),
         speed_scaler        : log_spd_scaler,
-        transition_state    : static_cast<uint8_t>(transition_state)
+        transition_state    : static_cast<uint8_t>(transition_state),
+        assist              : assisted_flight,
     };
     plane.logger.WriteBlock(&pkt, sizeof(pkt));
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -952,6 +952,10 @@ void QuadPlane::run_z_controller(void)
         } else {
             // tailsitters gain lots of vertical speed in transisison, set target to the stopping point
             pos_control->set_target_to_stopping_point_z();
+            // make sure stopping point is above current alt
+            if (pos_control->get_alt_target() < inertial_nav.get_altitude()) {
+                set_alt_target_current();
+            }
         }
         gcs().send_text(MAV_SEVERITY_INFO, "Reset alt target to %.1f", (double)pos_control->get_alt_target() * 0.01f);
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -163,6 +163,7 @@ public:
         float    throttle_mix;
         float    speed_scaler;
         uint8_t  transition_state;
+        uint8_t  assist;
     };
 
     MAV_TYPE get_mav_type(void) const;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -114,7 +114,8 @@ void QuadPlane::tailsitter_output(void)
     // handle Copter controller
     // the MultiCopter rate controller has already been run in an earlier call
     // to motors_output() from quadplane.update(), unless we are in assisted flight
-    if (assisted_flight && is_tailsitter_in_fw_flight()) {
+    // tailsitter in TRANSITION_ANGLE_WAIT_FW is not really in assisted flight, its still in a VTOL mode
+    if (assisted_flight && (transition_state != TRANSITION_ANGLE_WAIT_FW)) {
         hold_stabilize(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * 0.01f);
         motors_output(true);
 


### PR DESCRIPTION
This fixes a big I introduced in https://github.com/ArduPilot/ardupilot/pull/15567. Qassist in transition to VTOL flight was broken because of this line:
https://github.com/ArduPilot/ardupilot/blob/248ef92ed7a529883d2ef2acf89153856e0fe0f4/ArduPlane/tailsitter.cpp#L117

The old call to `tailsitter_transition_fw_complete()` was true in VTOL modes where as the new `is_tailsitter_in_fw_flight()` is not. This now always assists if not in angle wait. The Asssit state is correct except for that case where we are in a forward flight mode but have not yet transitioned form the copter controller.

This also adds logging of the Qassist state to QTUN, this was helpful to confirm the above was working as expected.

The final change is to ensure that the target altitude is never bellow the current thanks to the new stopping point calcs introduced in https://github.com/ArduPilot/ardupilot/pull/15692. This can happen if the forward flight part of the transition completely fails to pull up from some reason (Qassist not working for example).

This tail-sitter stuff is quite the mine-field, some auto tests are probably in order. I might try and resurrect https://github.com/ArduPilot/ardupilot/pull/10966