### PR TITLE
AP_OSD_Screen: move vspeed decimal switch to 10 m/s

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1457,7 +1457,7 @@ void AP_OSD_Screen::draw_vspeed(uint8_t x, uint8_t y)
         sym = SYM_DOWN_DOWN;
     }
     vs_scaled = u_scale(VSPEED, fabsf(vspd));
-    if (vs_scaled < 5.0f) {
+    if (vs_scaled < 10.0f) {
         backend->write(x, y, false, "%c%2.1f%c", sym, (float)vs_scaled, u_icon(VSPEED));
     } else {
         backend->write(x, y, false, "%c%3d%c", sym, (int)vs_scaled, u_icon(VSPEED));


### PR DESCRIPTION
turns out that having the panel repetetively switch from decimal to integer is quite annoying, so moving this out of common climbrate range. thanks @giacomo892 for pointing this out.