### PR TITLE
AP_MSP: fix to allow vehicle to complete setup() before accessing AP_RSSI data

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -26,6 +26,7 @@
 #include <AP_RSSI/AP_RSSI.h>
 #include <AP_RTC/AP_RTC.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Vehicle/AP_Vehicle.h>
 
 #include "AP_MSP.h"
 #include "AP_MSP_Telem_Backend.h"
@@ -102,6 +103,16 @@ void AP_MSP_Telem_Backend::process_outgoing_data()
 bool AP_MSP_Telem_Backend::is_packet_ready(uint8_t idx, bool queue_empty)
 {
     switch (idx) {
+    case ANALOG:            // Rssi, Battery, mAh, Current
+        {
+            // need to wait for vehicle initialization to be complete
+            // before accessing rssi info from analog pins
+            AP_Vehicle* vehicle = AP::vehicle();
+            if (vehicle == nullptr) {
+                return false;
+            }
+            return vehicle->setup_done();
+        }
     case EMPTY_SLOT:        // empty slot
     case NAME:              // used for status_text messages
     case STATUS:            // flightmode
@@ -110,7 +121,6 @@ bool AP_MSP_Telem_Backend::is_packet_ready(uint8_t idx, bool queue_empty)
     case COMP_GPS:          // home dir,dist
     case ATTITUDE:          // Attitude
     case ALTITUDE:          // Altitude and Vario
-    case ANALOG:            // Rssi, Battery, mAh, Current
     case BATTERY_STATE:     // voltage, capacity, current, mAh
 #ifdef HAVE_AP_BLHELI_SUPPORT
     case ESC_SENSOR_DATA:   // esc temp + rpm

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -132,6 +132,8 @@ void AP_Vehicle::setup()
 #endif
 
     send_watchdog_reset_statustext();
+    
+    _setup_done = true;
 }
 
 void AP_Vehicle::loop()

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -209,7 +209,10 @@ public:
 
     // zeroing the RC outputs can prevent unwanted motor movement:
     virtual bool should_zero_rc_outputs_on_reboot() const { return false; }
-
+    
+    // true if the vehicle has gone thru the entire setup sequence
+    bool setup_done() const { return _setup_done; };
+    
     // reboot the vehicle in an orderly manner, doing various cleanups
     // and flashing LEDs as appropriate
     void reboot(bool hold_in_bootloader);
@@ -307,6 +310,7 @@ private:
     uint32_t _last_flying_ms;   // time when likely_flying last went true
 
     static AP_Vehicle *_singleton;
+    bool _setup_done;
 };
 
 namespace AP {


### PR DESCRIPTION
When MSP baro and compass sensors support was added, msp.init() inside AP_Vehicle::setup() was moved before init_ardupilot() to let the latter access MSP sensors data during initialization, but this led to the issue reported here https://github.com/ArduPilot/ardupilot/issues/15824.

Right after serial ports initialization the MSP library with MSP_OPTIONS=1 immediately tries to pack and send telemetry data, when the scheduler prepares the MSP_ANALOG message it reads RSSI data with AP_RSSI::get_receiver_rssi() which stalls (RSSI_TYPE=1) because init_ardupilot() inside AP_Vehicle::setup() is not done yet.

My attempt to fix this was adding a variable to hold the setup state of AP_Vehicle and wait for AP_Vehicle::setup() to be done before letting MSP access rssi data.

related issue https://github.com/ArduPilot/ardupilot/issues/15824