### PR TITLE
Replay: adjust lost message threshold

### DIFF
--- a/Tools/Replay/check_replay.py
+++ b/Tools/Replay/check_replay.py
@@ -69,7 +69,7 @@ def check_log(logfile, progress, ekf2_only=False, ekf3_only=False, verbose=False
     if verbose:
         for mtype in counts.keys():
             progress("%s %u/%u %d" % (mtype, counts[mtype], base_counts[mtype], base_counts[mtype]-counts[mtype]))
-    if count == 0 or abs(count - base_count) > 30:
+    if count == 0 or abs(count - base_count) > 100:
         failure += 1
     if failure != 0 or errors != 0:
         return False


### PR DESCRIPTION
this needs to be a bit higher to cope with truncated logs (if SITL
ends in the middle of an EKF log write then we end up with a mismatch
in log msg counts)