### PR TITLE
Fix compilation issue if HAL_MINIMIZE_FEATURES is defined

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -952,7 +952,7 @@ bool AP_Arming::camera_checks(bool display_failure)
 
 bool AP_Arming::osd_checks(bool display_failure) const
 {
-#if OSD_ENABLED
+#if OSD_PARAM_ENABLED && OSD_ENABLED 
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_CAMERA)) {
         const AP_OSD *osd = AP::osd();
         if (osd == nullptr) {


### PR DESCRIPTION
Fixing compilation on boards which have HAL_MINIMIZE_FEATURES defined
@andyp1per I think it is due to one of you commits, so you should take a look to this, thanks