### PR TITLE
Crossfire: add passthrough telemetry over crossfire

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
@@ -19,6 +19,16 @@ public:
     virtual bool init();
     virtual void send() = 0;
 
+    typedef union {
+        struct PACKED {
+            uint8_t sensor;
+            uint8_t frame;
+            uint16_t appid;
+            uint32_t data;
+        };
+        uint8_t raw[8];
+    } sport_packet_t;
+
     // SPort is at 57600, D overrides this
     virtual uint32_t initial_baud() const
     {
@@ -26,7 +36,7 @@ public:
     }
 
     // get next telemetry data for external consumers of SPort data
-    virtual bool get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data)
+    virtual bool get_telem_data(sport_packet_t* packet_array, uint8_t &packet_count, const uint8_t max_size)
     {
         return false;
     }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
@@ -11,16 +11,6 @@ public:
 
     void send() override;
 
-    typedef union {
-        struct PACKED {
-            uint8_t sensor;
-            uint8_t frame;
-            uint16_t appid;
-            uint32_t data;
-        };
-        uint8_t raw[8];
-    } sport_packet_t;
-
 protected:
 
     void send_sport_frame(uint8_t frame, uint16_t appid, uint32_t data);

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -60,6 +60,8 @@ for FrSky SPort Passthrough
 
 extern const AP_HAL::HAL& hal;
 
+AP_Frsky_SPort_Passthrough *AP_Frsky_SPort_Passthrough::singleton;
+
 bool AP_Frsky_SPort_Passthrough::init()
 {
     if (!AP_RCTelemetry::init()) {
@@ -79,9 +81,9 @@ bool AP_Frsky_SPort_Passthrough::init_serial_port()
 void  AP_Frsky_SPort_Passthrough::send_sport_frame(uint8_t frame, uint16_t appid, uint32_t data)
 {
     if (_use_external_data) {
-        external_data.frame = frame;
-        external_data.appid = appid;
-        external_data.data = data;
+        external_data.packet.frame = frame;
+        external_data.packet.appid = appid;
+        external_data.packet.data = data;
         external_data.pending = true;
         return;
     }
@@ -546,19 +548,53 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_attiandrng(void)
 }
 
 /*
-  fetch Sport data for an external transport, such as FPort
+  fetch Sport data for an external transport, such as FPort or crossfire
+  Note: we need to create a packet array with unique packet types
+  For very big frames we might have to relax the "unique packet type per frame"
+  constraint in order to maximize bandwidth usage
  */
-bool AP_Frsky_SPort_Passthrough::get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data)
+bool AP_Frsky_SPort_Passthrough::get_telem_data(sport_packet_t* packet_array, uint8_t &packet_count, const uint8_t max_size)
 {
-    run_wfq_scheduler();
-    if (!external_data.pending) {
+    if (!_use_external_data) {
         return false;
     }
-    frame = external_data.frame;
-    appid = external_data.appid;
-    data = external_data.data;
-    external_data.pending = false;
-    return true;
+
+    uint8_t idx = 0;
+
+    // max_size >= WFQ_LAST_ITEM
+    // get a packet per enabled type
+    if (max_size >= WFQ_LAST_ITEM) {
+        for (uint8_t i=0; i<WFQ_LAST_ITEM; i++) {
+            if (process_scheduler_entry(i)) {
+                if (external_data.pending) {
+                    packet_array[idx].frame = external_data.packet.frame;
+                    packet_array[idx].appid = external_data.packet.appid;
+                    packet_array[idx].data = external_data.packet.data;
+                    idx++;
+                    external_data.pending = false;
+                }
+            }
+        }
+    } else {
+        // max_size < WFQ_LAST_ITEM
+        // call run_wfq_scheduler(false) enough times to create a packet of up to max_size unique elements
+        uint32_t item_mask = 0;
+        for (uint8_t i=0; i<max_size; i++) {
+            // call the scheduler with the shaper "disabled"
+            const uint8_t item = run_wfq_scheduler(false);
+            if (!BIT_IS_SET(item_mask, item) && external_data.pending) {
+                // ok got some data, flip the bitmask bit to prevent adding the same packet type more than once
+                BIT_SET(item_mask, item);
+                packet_array[idx].frame = external_data.packet.frame;
+                packet_array[idx].appid = external_data.packet.appid;
+                packet_array[idx].data = external_data.packet.data;
+                idx++;
+                external_data.pending = false;
+            }
+        }
+    }
+    packet_count = idx;
+    return idx > 0;
 }
 
 /*
@@ -726,3 +762,11 @@ bool AP_Frsky_SPort_Passthrough::send_message(const AP_Frsky_MAVlite_Message &tx
     return mavlite_to_sport.process(_SPort_bidir.tx_packet_queue, txmsg);
 }
 #endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
+
+namespace AP
+{
+AP_Frsky_SPort_Passthrough *frsky_passthrough_telem()
+{
+    return AP_Frsky_SPort_Passthrough::get_singleton();
+}
+};

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -81,12 +81,15 @@ bool AP_Frsky_Telem::init(bool use_external_data)
     return true;
 }
 
-bool AP_Frsky_Telem::_get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data)
+bool AP_Frsky_Telem::_get_telem_data(AP_Frsky_Backend::sport_packet_t* packet_array, uint8_t &packet_count, const uint8_t max_size)
 {
     if (_backend == nullptr) {
         return false;
     }
-    return _backend->get_telem_data(frame, appid, data);
+    if (packet_array == nullptr) {
+        return false;
+    }
+    return _backend->get_telem_data(packet_array, packet_count, max_size);
 }
 
 #if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
@@ -99,24 +102,28 @@ bool AP_Frsky_Telem::_set_telem_data(uint8_t frame, uint16_t appid, uint32_t dat
 }
 #endif
 
-/*
-  fetch Sport data for an external transport, such as FPort
- */
-bool AP_Frsky_Telem::get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data)
+void AP_Frsky_Telem::try_create_singleton_for_external_data()
 {
+    // try to allocate an AP_Frsky_Telem object only if we are disarmed
     if (!singleton && !hal.util->get_soft_armed()) {
-        // if telem data is requested when we are disarmed and don't
-        // yet have a AP_Frsky_Telem object then try to allocate one
         new AP_Frsky_Telem();
         // initialize the passthrough scheduler
         if (singleton) {
             singleton->init(true);
         }
     }
+}
+
+/*
+  fetch Sport data for an external transport, such as FPort
+ */
+bool AP_Frsky_Telem::get_telem_data(AP_Frsky_Backend::sport_packet_t* packet_array, uint8_t &packet_count, const uint8_t max_size)
+{
+    try_create_singleton_for_external_data();
     if (singleton == nullptr) {
         return false;
     }
-    return singleton->_get_telem_data(frame, appid, data);
+    return singleton->_get_telem_data(packet_array, packet_count, max_size);
 }
 
 #if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
@@ -125,14 +132,7 @@ bool AP_Frsky_Telem::get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &d
  */
 bool AP_Frsky_Telem::set_telem_data(const uint8_t frame, const uint16_t appid, const uint32_t data)
 {
-    if (!singleton && !hal.util->get_soft_armed()) {
-        // if telem data is requested when we are disarmed and don't
-        // yet have a AP_Frsky_Telem object then try to allocate one
-        new AP_Frsky_Telem();
-        if (singleton) {
-            singleton->init(true);
-        }
-    }
+    try_create_singleton_for_external_data();
     if (singleton == nullptr) {
         return false;
     }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "AP_Frsky_Backend.h"
+#include "AP_Frsky_SPort.h"
 
 class AP_Frsky_Parameters;
 
@@ -37,7 +38,7 @@ public:
     }
 
     // get next telemetry data for external consumers of SPort data
-    static bool get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data);
+    static bool get_telem_data(AP_Frsky_Backend::sport_packet_t* packet_array, uint8_t &packet_count, const uint8_t max_size);
 #if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
     // set telemetry data from external producer of SPort data
     static bool set_telem_data(const uint8_t frame,const uint16_t appid, const uint32_t data);
@@ -56,12 +57,12 @@ private:
     AP_Frsky_Parameters* _frsky_parameters;
 
     // get next telemetry data for external consumers of SPort data (internal function)
-    bool _get_telem_data(uint8_t &frame, uint16_t &appid, uint32_t &data);
+    bool _get_telem_data(AP_Frsky_Backend::sport_packet_t* packet_array, uint8_t &packet_count, const uint8_t max_size);
 #if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
     // set telemetry data from external producer of SPort data (internal function)
     bool _set_telem_data(const uint8_t frame, const uint16_t appid, const uint32_t data);
 #endif
-
+    static void try_create_singleton_for_external_data(void);
     static AP_Frsky_Telem *singleton;
 
 };

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -98,7 +98,8 @@ static const char* get_frame_type(uint8_t byte)
 #endif
 
 #define CRSF_MAX_FRAME_TIME_US      1100U // 700us + 400us for potential ad-hoc request
-#define CRSF_INTER_FRAME_TIME_US_150HZ    6667U // At fastest, frames are sent by the transmitter every 6.667 ms, 150 Hz
+#define CRSF_INTER_FRAME_TIME_US_250HZ    4000U // At fastest, frames are sent by the transmitter every 4 ms, 250 Hz
+#define CRSF_INTER_FRAME_TIME_US_150HZ    6667U // At medium, frames are sent by the transmitter every 6.667 ms, 150 Hz
 #define CRSF_INTER_FRAME_TIME_US_50HZ    20000U // At slowest, frames are sent by the transmitter every 20ms, 50 Hz
 #define CSRF_HEADER_LEN     2
 
@@ -230,7 +231,7 @@ void AP_RCProtocol_CRSF::update(void)
 
     // never received RC frames, but have received CRSF frames so make sure we give the telemetry opportunity to run
     uint32_t now = AP_HAL::micros();
-    if (_last_frame_time_us > 0 && !get_rc_frame_count() && now - _last_frame_time_us > CRSF_INTER_FRAME_TIME_US_150HZ) {
+    if (_last_frame_time_us > 0 && !get_rc_frame_count() && now - _last_frame_time_us > CRSF_INTER_FRAME_TIME_US_250HZ) {
         process_telemetry(false);
         _last_frame_time_us = now;
     }

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -187,12 +187,6 @@ void AP_RCProtocol_CRSF::_process_byte(uint32_t timestamp_us, uint8_t byte)
     if (_frame_ofs == _frame.length + CSRF_HEADER_LEN) {
         log_data(AP_RCProtocol::CRSF, timestamp_us, (const uint8_t*)&_frame, _frame_ofs - CSRF_HEADER_LEN);
 
-        if ((timestamp_us - _last_frame_time_us) <= CRSF_INTER_FRAME_TIME_US_150HZ + CRSF_MAX_FRAME_TIME_US) {
-            _fast_telem = true;
-        } else {
-            _fast_telem = false;
-        }
-
         // we consumed the partial frame, reset
         _frame_ofs = 0;
 
@@ -209,9 +203,9 @@ void AP_RCProtocol_CRSF::_process_byte(uint32_t timestamp_us, uint8_t byte)
         _last_frame_time_us = timestamp_us;
         // decode here
         if (decode_csrf_packet()) {
-            add_input(MAX_CHANNELS, _channels, false, _current_rssi);
+            add_input(MAX_CHANNELS, _channels, false, _link_status.rssi);
         }
-    }    
+    }
 }
 
 void AP_RCProtocol_CRSF::update(void)
@@ -328,19 +322,6 @@ bool AP_RCProtocol_CRSF::process_telemetry(bool check_constraint)
         return false;
 #endif
     }
-    /*
-      check that we haven't been too slow in responding to the new
-      UART data. If we respond too late then we will corrupt the next
-      incoming control frame
-     */
-    uint64_t tend = uart->receive_time_constraint_us(1);
-    uint64_t now = AP_HAL::micros64();
-    uint64_t tdelay = now - tend;
-    if (tdelay > CRSF_MAX_FRAME_TIME_US && check_constraint) {
-        // we've been too slow in responding
-        return false;
-    }
-
     write_frame(&_telemetry_frame);
     // get fresh telem_data in the next call
     telem_available = false;
@@ -361,13 +342,15 @@ void AP_RCProtocol_CRSF::process_link_stats_frame(const void* data)
     }
      // AP rssi: -1 for unknown, 0 for no link, 255 for maximum link
     if (rssi_dbm < 50) {
-        _current_rssi = 255;
+        _link_status.rssi = 255;
     } else if (rssi_dbm > 120) {
-        _current_rssi = 0;
+        _link_status.rssi = 0;
     } else {
         // this is an approximation recommended by Remo from TBS
-        _current_rssi = int16_t(roundf((1.0f - (rssi_dbm - 50.0f) / 70.0f) * 255.0f));
+        _link_status.rssi = int16_t(roundf((1.0f - (rssi_dbm - 50.0f) / 70.0f) * 255.0f));
     }
+
+    _link_status.rf_mode = static_cast<RFMode>(MIN(link->rf_mode, 3U));
 }
 
 // process a byte provided by a uart
@@ -397,4 +380,3 @@ namespace AP {
         return AP_RCProtocol_CRSF::get_singleton();
     }
 };
-

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -55,6 +55,9 @@ public:
         CRSF_FRAMETYPE_PARAMETER_READ = 0x2C,
         CRSF_FRAMETYPE_PARAMETER_WRITE = 0x2D,
         CRSF_FRAMETYPE_COMMAND = 0x32,
+        // Custom Telemetry Frames 0x7F,0x80
+        CRSF_FRAMETYPE_AP_CUSTOM_TELEM_LEGACY = 0x7F,   // as suggested by Remo Masina for fw < 4.06
+        CRSF_FRAMETYPE_AP_CUSTOM_TELEM = 0x80,          // reserved for ArduPilot by TBS, requires fw >= 4.06
     };
 
     // Command IDs for CRSF_FRAMETYPE_COMMAND
@@ -116,6 +119,13 @@ public:
         CRSF_COMMAND_RX_BIND = 0x01,
     };
 
+    // SubType IDs for CRSF_FRAMETYPE_CUSTOM_TELEM
+    enum CustomTelemSubTypeID : uint8_t {
+        CRSF_AP_CUSTOM_TELEM_SINGLE_PACKET_PASSTHROUGH = 0xF0,
+        CRSF_AP_CUSTOM_TELEM_STATUS_TEXT = 0xF1,
+        CRSF_AP_CUSTOM_TELEM_MULTI_PACKET_PASSTHROUGH = 0xF2,
+    };
+
     enum DeviceAddress {
         CRSF_ADDRESS_BROADCAST = 0x00,
         CRSF_ADDRESS_USB = 0x10,
@@ -161,6 +171,24 @@ public:
         int8_t downlink_dnr; // ( db )
     } PACKED;
 
+    enum class RFMode : uint8_t {
+        CRSF_RF_MODE_4HZ = 0,
+        CRSF_RF_MODE_50HZ,
+        CRSF_RF_MODE_150HZ,
+        CRSF_RF_MODE_UNKNOWN,
+    };
+
+    struct LinkStatus {
+        int16_t rssi = -1;
+        RFMode rf_mode;
+    };
+
+    // this will be used by AP_CRSF_Telem to access link status data
+    // from within AP_RCProtocol_CRSF thread so no need for cross-thread synch
+    const volatile LinkStatus& get_link_status() const {
+        return _link_status;
+    }
+
 private:
     struct Frame _frame;
     struct Frame _telemetry_frame;
@@ -187,8 +215,8 @@ private:
     uint32_t _last_rx_time_us;
     uint32_t _start_frame_time_us;
     bool telem_available;
-    bool _fast_telem; // is 150Hz telemetry active
-    int16_t _current_rssi = -1;
+
+    volatile struct LinkStatus _link_status;
 
     AP_HAL::UARTDriver *_uart;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -175,6 +175,7 @@ public:
         CRSF_RF_MODE_4HZ = 0,
         CRSF_RF_MODE_50HZ,
         CRSF_RF_MODE_150HZ,
+        CRSF_RF_MODE_250HZ,
         CRSF_RF_MODE_UNKNOWN,
     };
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -148,11 +148,12 @@ void AP_RCProtocol_FPort::decode_downlink(const FPort_Frame &frame)
       status text messages
      */
     if (!telem_data.available) {
-        if (!AP_Frsky_Telem::get_telem_data(telem_data.frame, telem_data.appid, telem_data.data)) {
+        uint8_t packet_count;
+        if (!AP_Frsky_Telem::get_telem_data(&telem_data.packet, packet_count, 1)) {
             // nothing to send, send a null frame
-            telem_data.frame = 0x00; 
-            telem_data.appid = 0x00; 
-            telem_data.data = 0x00;
+            telem_data.packet.frame = 0x00;
+            telem_data.packet.appid = 0x00;
+            telem_data.packet.data = 0x00;
         }
         telem_data.available = true;
     }
@@ -172,10 +173,10 @@ void AP_RCProtocol_FPort::decode_downlink(const FPort_Frame &frame)
 
     buf[0] = 0x08;
     buf[1] = 0x81;
-    buf[2] = telem_data.frame;
-    buf[3] = telem_data.appid & 0xFF;
-    buf[4] = telem_data.appid >> 8;
-    memcpy(&buf[5], &telem_data.data, 4);
+    buf[2] = telem_data.packet.frame;
+    buf[3] = telem_data.packet.appid & 0xFF;
+    buf[4] = telem_data.packet.appid >> 8;
+    memcpy(&buf[5], &telem_data.packet.data, 4);
     buf[9] = crc_sum8(&buf[0], 9);
 
     // perform byte stuffing per FPort spec

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <AP_Frsky_Telem/AP_Frsky_SPort.h>
+
 #include "AP_RCProtocol.h"
 #include "SoftSerial.h"
 
@@ -50,9 +52,7 @@ private:
 
     struct {
         bool available = false;
-        uint32_t data;
-        uint16_t appid;
-        uint8_t frame;
+        AP_Frsky_SPort::sport_packet_t packet;
     } telem_data;
 
     // receiver sends 0x10 when ready to receive telemetry frames (R-XSR)

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
@@ -137,10 +137,11 @@ void AP_RCProtocol_FPort2::decode_downlink(const FPort2_Frame &frame)
          send it in the next call, this prevents corruption of status text messages
         */
         if (!telem_data.available) {
-            if (!AP_Frsky_Telem::get_telem_data(telem_data.frame, telem_data.appid, telem_data.data)) {
-                telem_data.frame = 0x00;
-                telem_data.appid = 0x00;
-                telem_data.data = 0x00;
+            uint8_t packet_count;
+            if (!AP_Frsky_Telem::get_telem_data(&telem_data.packet, packet_count, 1)) {
+                telem_data.packet.frame = 0x00;
+                telem_data.packet.appid = 0x00;
+                telem_data.packet.data = 0x00;
             }
             telem_data.available = true;
         }
@@ -169,10 +170,10 @@ void AP_RCProtocol_FPort2::decode_downlink(const FPort2_Frame &frame)
     buf[1] = frame.type;
     // do not consume telemetry data for invalid downlink frames, i.e. incoming prim == 0x00
     if (frame.downlink.prim != FPORT2_PRIM_NULL) {
-        buf[2] = telem_data.frame;
-        buf[3] = telem_data.appid & 0xFF;
-        buf[4] = telem_data.appid >> 8;
-        memcpy(&buf[5], &telem_data.data, 4);
+        buf[2] = telem_data.packet.frame;
+        buf[3] = telem_data.packet.appid & 0xFF;
+        buf[4] = telem_data.packet.appid >> 8;
+        memcpy(&buf[5], &telem_data.packet.data, 4);
         // get fresh telem_data in the next call
         telem_data.available = false;
     }

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <AP_Frsky_Telem/AP_Frsky_SPort.h>
+
 #include "AP_RCProtocol.h"
 #include "SoftSerial.h"
 
@@ -53,8 +55,6 @@ private:
 
     struct {
         bool available;
-        uint32_t data;
-        uint16_t appid;
-        uint8_t frame;
+        AP_Frsky_SPort::sport_packet_t packet;
     } telem_data;
 };

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -26,6 +26,7 @@
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_OSD/AP_OSD.h>
+#include <AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -73,26 +74,218 @@ void AP_CRSF_Telem::setup_wfq_scheduler(void)
 
     // CSRF telemetry rate is 150Hz (4ms) max, so these rates must fit
     add_scheduler_entry(50, 100);   // heartbeat        10Hz
-    add_scheduler_entry(200, 50);   // parameters       20Hz (generally not active unless requested by the TX)
+    add_scheduler_entry(50, 50);    // parameters       20Hz (generally not active unless requested by the TX)
     add_scheduler_entry(50, 120);   // Attitude and compass 8Hz
     add_scheduler_entry(200, 1000); // VTX parameters    1Hz
     add_scheduler_entry(1300, 500); // battery           2Hz
     add_scheduler_entry(550, 280);  // GPS               3Hz
     add_scheduler_entry(550, 500);  // flight mode       2Hz
+    add_scheduler_entry(5000, 100); // passthrough       max 10Hz
+    add_scheduler_entry(5000, 500); // status text       max 2Hz
+}
+
+void AP_CRSF_Telem::setup_custom_telemetry()
+{
+    if (_custom_telem.init_done) {
+        return;
+    }
+
+    if (!rc().crsf_custom_telemetry()) {
+        return;
+    }
+
+    // we need crossfire firmware version
+    if (_crsf_version.pending) {
+        return;
+    }
+
+    AP_Frsky_SPort_Passthrough* passthrough = AP::frsky_passthrough_telem();
+    if (passthrough == nullptr) {
+        return;
+    }
+
+    // setup the frsky scheduler for crossfire
+    passthrough->disable_scheduler_entry(AP_Frsky_SPort_Passthrough::GPS_LAT);
+    passthrough->disable_scheduler_entry(AP_Frsky_SPort_Passthrough::GPS_LON);
+    passthrough->disable_scheduler_entry(AP_Frsky_SPort_Passthrough::TEXT);
+    passthrough->set_scheduler_entry_min_period(AP_Frsky_SPort_Passthrough::ATTITUDE, 350); // 3Hz
+
+    // setup the crossfire scheduler for custom telemetry
+    set_scheduler_entry(BATTERY, 1000, 1000);       // 1Hz
+    set_scheduler_entry(ATTITUDE, 1000, 1000);      // 1Hz
+    set_scheduler_entry(FLIGHT_MODE, 1200, 2000);   // 0.5Hz
+    set_scheduler_entry(HEARTBEAT, 2000, 5000);     // 0.2Hz
+
+    _telem_rf_mode = get_rf_mode();
+    // setup custom telemetry for current rf_mode
+    update_custom_telemetry_rates(_telem_rf_mode);
+
+    gcs().send_text(MAV_SEVERITY_DEBUG,"CRSF: custom telem init done, fw %d.%02d", _crsf_version.major, _crsf_version.minor);
+    _custom_telem.init_done = true;
+}
+
+void AP_CRSF_Telem::update_custom_telemetry_rates(AP_RCProtocol_CRSF::RFMode rf_mode)
+{
+    // ignore rf mode changes if we are processing parameter packets
+    if (_custom_telem.params_mode_active) {
+        return;
+    }
+
+    if (is_high_speed_telemetry(rf_mode)) {
+        // custom telemetry for high data rates
+        set_scheduler_entry(GPS, 550, 500);           // 2.0Hz
+        set_scheduler_entry(PASSTHROUGH, 100, 100);   // 10Hz
+        set_scheduler_entry(STATUS_TEXT, 200, 750);   // 1.5Hz
+    } else {
+        // custom telemetry for low data rates
+        set_scheduler_entry(GPS, 550, 1000);              // 1.0Hz
+        set_scheduler_entry(PASSTHROUGH, 500, 3000);      // 0.3Hz
+        set_scheduler_entry(STATUS_TEXT, 600, 2000);      // 0.5Hz
+    }
+}
+
+void AP_CRSF_Telem::process_rf_mode_changes()
+{
+    const AP_RCProtocol_CRSF::RFMode current_rf_mode = get_rf_mode();
+    if ( _telem_rf_mode != current_rf_mode) {
+        gcs().send_text(MAV_SEVERITY_INFO, "CRSF: rf mode change %d->%d, rate is %dHz", (uint8_t)_telem_rf_mode, (uint8_t)current_rf_mode, _scheduler.avg_packet_rate);
+        update_custom_telemetry_rates(current_rf_mode);
+        _telem_rf_mode = current_rf_mode;
+    }
+}
+
+// return custom frame id based on fw version
+uint8_t AP_CRSF_Telem::get_custom_telem_frame_id() const
+{
+    if (!_crsf_version.pending && _crsf_version.major >= 4 && _crsf_version.minor >= 6) {
+        return AP_RCProtocol_CRSF::CRSF_FRAMETYPE_AP_CUSTOM_TELEM;
+    }
+    return AP_RCProtocol_CRSF::CRSF_FRAMETYPE_AP_CUSTOM_TELEM_LEGACY;
+}
+
+AP_RCProtocol_CRSF::RFMode AP_CRSF_Telem::get_rf_mode() const
+{
+    AP_RCProtocol_CRSF* crsf = AP::crsf();
+    if (crsf == nullptr) {
+        return AP_RCProtocol_CRSF::RFMode::CRSF_RF_MODE_UNKNOWN;
+    }
+
+    if (!_crsf_version.pending && _crsf_version.use_rf_mode) {
+        return crsf->get_link_status().rf_mode;
+    }
+
+    /*
+     Note:
+     - rf mode 2 on UARTS with DMA runs @160Hz
+     - rf mode 2 on UARTS with no DMA runs @70Hz
+    */
+    if (get_avg_packet_rate() < 40U) {
+        // no DMA rf mode 1
+        return AP_RCProtocol_CRSF::RFMode::CRSF_RF_MODE_50HZ;
+    }
+    if (get_avg_packet_rate() > 120U) {
+        // DMA rf mode 2
+        return AP_RCProtocol_CRSF::RFMode::CRSF_RF_MODE_150HZ;
+    }
+    if (get_max_packet_rate() < 120U) {
+        // no DMA rf mode 2
+        return AP_RCProtocol_CRSF::RFMode::CRSF_RF_MODE_150HZ;
+    }
+    return AP_RCProtocol_CRSF::RFMode::CRSF_RF_MODE_50HZ;
+}
+
+bool AP_CRSF_Telem::is_high_speed_telemetry(const AP_RCProtocol_CRSF::RFMode rf_mode) const
+{
+    return rf_mode == AP_RCProtocol_CRSF::RFMode::CRSF_RF_MODE_150HZ;
+}
+
+void AP_CRSF_Telem::queue_message(MAV_SEVERITY severity, const char *text)
+{
+    // no need to queue status text messages when crossfire
+    // custom telemetry is not enabled
+    if (!rc().crsf_custom_telemetry()) {
+        return;
+    }
+    AP_RCTelemetry::queue_message(severity, text);
+}
+
+void AP_CRSF_Telem::enter_scheduler_params_mode()
+{
+    set_scheduler_entry(HEARTBEAT, 50, 100);            // heartbeat        10Hz
+    set_scheduler_entry(ATTITUDE, 50, 120);             // Attitude and compass 8Hz
+    set_scheduler_entry(BATTERY, 1300, 500);            // battery           2Hz
+    set_scheduler_entry(GPS, 550, 280);                 // GPS               3Hz
+    set_scheduler_entry(FLIGHT_MODE, 550, 500);         // flight mode       2Hz
+
+    disable_scheduler_entry(PASSTHROUGH);
+    disable_scheduler_entry(STATUS_TEXT);
+}
+
+void AP_CRSF_Telem::exit_scheduler_params_mode()
+{
+    // setup the crossfire scheduler for custom telemetry
+    set_scheduler_entry(BATTERY, 1000, 1000);       // 1Hz
+    set_scheduler_entry(ATTITUDE, 1000, 1000);      // 1Hz
+    set_scheduler_entry(FLIGHT_MODE, 1200, 2000);   // 0.5Hz
+    set_scheduler_entry(HEARTBEAT, 2000, 5000);     // 0.2Hz
+
+    enable_scheduler_entry(PASSTHROUGH);
+    enable_scheduler_entry(STATUS_TEXT);
+
+    update_custom_telemetry_rates(_telem_rf_mode);
 }
 
 void AP_CRSF_Telem::adjust_packet_weight(bool queue_empty)
 {
+    uint32_t now_ms = AP_HAL::millis();
+    setup_custom_telemetry();
+
+    /*
+     whenever we detect a pending request we configure the scheduler
+     to allow faster parameters processing.
+     We start a "fast parameter window" that we close after 5sec
+    */
+    bool expired = (now_ms - _custom_telem.params_mode_start_ms) > 5000;
+    if (!_custom_telem.params_mode_active && _pending_request.frame_type > 0) {
+        // fast window start
+        _custom_telem.params_mode_start_ms = now_ms;
+        _custom_telem.params_mode_active = true;
+        enter_scheduler_params_mode();
+    } else if (expired && _custom_telem.params_mode_active) {
+        // fast window stop
+        _custom_telem.params_mode_active = false;
+        exit_scheduler_params_mode();
+    }
 }
 
 // WFQ scheduler
 bool AP_CRSF_Telem::is_packet_ready(uint8_t idx, bool queue_empty)
 {
+    process_rf_mode_changes();
+
     switch (idx) {
     case PARAMETERS:
-        return _request_pending > 0;
+        // to get crossfire firmware version we send an RX device ping until we get a response
+        // but only if there are no other requests pending
+        if (_crsf_version.pending && _pending_request.frame_type == 0) {
+            if (_crsf_version.retry_count++ > CRSF_RX_DEVICE_PING_MAX_RETRY) {
+                _crsf_version.pending = false;
+                _crsf_version.minor = 0;
+                _crsf_version.major = 0;
+                gcs().send_text(MAV_SEVERITY_DEBUG,"CRSF: RX device ping failed");
+            } else {
+                _pending_request.destination = AP_RCProtocol_CRSF::CRSF_ADDRESS_CRSF_RECEIVER;
+                _pending_request.frame_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_INFO;
+                gcs().send_text(MAV_SEVERITY_DEBUG,"CRSF: requesting RX device info");
+            }
+        }
+        return _pending_request.frame_type > 0;
     case VTX_PARAMETERS:
         return AP::vtx().have_params_changed() ||_vtx_power_change_pending || _vtx_freq_change_pending || _vtx_options_change_pending;
+    case PASSTHROUGH:
+        return rc().crsf_custom_telemetry();
+    case STATUS_TEXT:
+        return rc().crsf_custom_telemetry() && !queue_empty;
     default:
         return _enable_telemetry;
     }
@@ -123,6 +316,20 @@ void AP_CRSF_Telem::process_packet(uint8_t idx)
             break;
         case FLIGHT_MODE: // GPS
             calc_flight_mode();
+            break;
+        case PASSTHROUGH:
+            if (is_high_speed_telemetry(_telem_rf_mode)) {
+                // on fast links we have 1:1 ratio between
+                // passthrough frames and crossfire frames
+                get_single_packet_passthrough_telem_data();
+            } else {
+                // on slower links we pack many passthrough
+                // frames in a single crossfire one (up to 9)
+                get_multi_packet_passthrough_telem_data();
+            }
+            break;
+        case STATUS_TEXT:
+            calc_status_text();
             break;
         default:
             break;
@@ -157,6 +364,10 @@ bool AP_CRSF_Telem::_process_frame(AP_RCProtocol_CRSF::FrameType frame_type, voi
 
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_WRITE:
         process_param_write_frame((ParameterSettingsWriteFrame*)data);
+        break;
+
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_INFO:
+        process_device_info_frame((ParameterDeviceInfoFrame*)data);
         break;
 
     default:
@@ -245,7 +456,45 @@ void AP_CRSF_Telem::process_ping_frame(ParameterPingFrame* ping)
     }
 
     _param_request.origin = ping->origin;
-    _request_pending = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING;
+    _pending_request.frame_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING;
+}
+
+// request for device info
+void AP_CRSF_Telem::process_device_info_frame(ParameterDeviceInfoFrame* info)
+{
+    debug("process_device_info_frame: %d -> %d", info->origin, info->destination);
+    if (info->destination != 0 && info->destination != AP_RCProtocol_CRSF::CRSF_ADDRESS_FLIGHT_CONTROLLER) {
+        return; // request was not for us
+    }
+
+    // we are only interested in RC device info for firmware version detection
+    if (info->origin != 0 && info->origin != AP_RCProtocol_CRSF::CRSF_ADDRESS_CRSF_RECEIVER) {
+        return;
+    }
+    /*
+        Payload size is 58:
+        char[] Device name ( Null-terminated string, max len is 42 )
+        uint32_t Serial number
+        uint32_t Hardware ID
+        uint32_t Firmware ID (0x00:0x00:0xAA:0xBB AA=major, BB=minor)
+        uint8_t Parameters count
+        uint8_t Parameter version number
+    */
+    // get the terminator of the device name string
+    const uint8_t offset = strnlen((char*)info->payload,42U);
+    /*
+        fw major ver = offset + terminator (8bits) + serial (32bits) + hw id (32bits) + 3rd byte of sw id = 11bytes
+        fw minor ver = offset + terminator (8bits) + serial (32bits) + hw id (32bits) + 4th byte of sw id = 12bytes
+    */
+    _crsf_version.major = info->payload[offset+11];
+    _crsf_version.minor = info->payload[offset+12];
+
+    // should we use rf_mode reported by link statistics?
+    if (_crsf_version.major >= 3 && _crsf_version.minor >= 72) {
+        _crsf_version.use_rf_mode = true;
+    }
+
+    _crsf_version.pending = false;
 }
 
 void AP_CRSF_Telem::process_param_read_frame(ParameterSettingsReadFrame* read_frame)
@@ -257,7 +506,7 @@ void AP_CRSF_Telem::process_param_read_frame(ParameterSettingsReadFrame* read_fr
     }
 
     _param_request = *read_frame;
-    _request_pending = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ;
+    _pending_request.frame_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ;
 }
 
 // process any changed settings and schedule for transmission
@@ -268,12 +517,15 @@ void AP_CRSF_Telem::update()
 void AP_CRSF_Telem::update_params()
 {
     // handle general parameter requests
-    switch (_request_pending) {
+    switch (_pending_request.frame_type) {
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING:
         calc_device_info();
         break;
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ:
         calc_parameter();
+        break;
+    case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_INFO:
+        calc_device_ping();
         break;
     default:
         break;
@@ -495,9 +747,22 @@ void AP_CRSF_Telem::calc_device_info() {
     _telem_size = n + 2;
     _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_INFO;
 
-    _request_pending = 0;
+    _pending_request.frame_type = 0;
     _telem_pending = true;
 #endif
+}
+
+// send a device ping
+void AP_CRSF_Telem::calc_device_ping() {
+    _telem.ext.ping.destination = _pending_request.destination;
+    _telem.ext.ping.origin = AP_RCProtocol_CRSF::CRSF_ADDRESS_FLIGHT_CONTROLLER;
+    _telem_size = 2;
+    _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING;
+
+    _pending_request.destination = AP_RCProtocol_CRSF::CRSF_ADDRESS_BROADCAST;
+    _pending_request.frame_type = 0;
+
+    _telem_pending = true;
 }
 
 // return parameter information
@@ -601,7 +866,7 @@ void AP_CRSF_Telem::calc_parameter() {
     _telem_size = sizeof(AP_CRSF_Telem::ParameterSettingsEntryHeader) + 1 + idx;
     _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY;
 
-    _request_pending = 0;
+    _pending_request.frame_type = 0;
     _telem_pending = true;
 #endif
 }
@@ -750,7 +1015,7 @@ void AP_CRSF_Telem::calc_text_selection(AP_OSD_ParamSetting* param, uint8_t chun
     _telem_size = sizeof(AP_CRSF_Telem::ParameterSettingsEntryHeader) + chunker.bytes_written();
     _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY;
 
-    _request_pending = 0;
+    _pending_request.frame_type = 0;
     _telem_pending = true;
 }
 #endif
@@ -826,6 +1091,86 @@ void AP_CRSF_Telem::process_param_write_frame(ParameterSettingsWriteFrame* write
 #endif
 }
 
+// get status text data
+void AP_CRSF_Telem::calc_status_text()
+{
+    if (!_statustext.available) {
+        WITH_SEMAPHORE(_statustext.sem);
+        // check link speed
+        if (!is_high_speed_telemetry(_telem_rf_mode)) {
+            // keep only warning/error/critical/alert/emergency status text messages
+            bool got_message = false;
+            while (_statustext.queue.pop(_statustext.next)) {
+                if (_statustext.next.severity <= MAV_SEVERITY_WARNING) {
+                    got_message = true;
+                    break;
+                }
+            }
+            if (!got_message) {
+                return;
+            }
+        } else if (!_statustext.queue.pop(_statustext.next)) {
+            return;
+        }
+        _statustext.available = true;
+    }
+
+    _telem_type = get_custom_telem_frame_id();
+    _telem.bcast.custom_telem.status_text.sub_type = AP_RCProtocol_CRSF::CustomTelemSubTypeID::CRSF_AP_CUSTOM_TELEM_STATUS_TEXT;
+    _telem.bcast.custom_telem.status_text.severity = _statustext.next.severity;
+    strncpy_noterm(_telem.bcast.custom_telem.status_text.text, _statustext.next.text, PASSTHROUGH_STATUS_TEXT_FRAME_MAX_SIZE);
+    // add a potentially missing terminator
+    _telem.bcast.custom_telem.status_text.text[PASSTHROUGH_STATUS_TEXT_FRAME_MAX_SIZE-1] = 0;
+    _telem_size = 2 + PASSTHROUGH_STATUS_TEXT_FRAME_MAX_SIZE; // sub_type(1) + severity(1) + text(50)
+    _telem_pending = true;
+    _statustext.available = false;
+}
+
+/*
+ Get 1 packet of passthrough telemetry data
+*/
+void AP_CRSF_Telem::get_single_packet_passthrough_telem_data()
+{
+    _telem_pending = false;
+    uint8_t packet_count;
+    AP_Frsky_SPort::sport_packet_t packet;
+    if (!AP_Frsky_Telem::get_telem_data(&packet, packet_count, 1)) {
+        return;
+    }
+    _telem.bcast.custom_telem.single_packet_passthrough.sub_type = AP_RCProtocol_CRSF::CustomTelemSubTypeID::CRSF_AP_CUSTOM_TELEM_SINGLE_PACKET_PASSTHROUGH;
+    _telem.bcast.custom_telem.single_packet_passthrough.appid = packet.appid;
+    _telem.bcast.custom_telem.single_packet_passthrough.data = packet.data;
+    _telem_size = sizeof(AP_CRSF_Telem::PassthroughSinglePacketFrame);
+    _telem_type = get_custom_telem_frame_id();
+    _telem_pending = true;
+}
+
+/*
+ Get up to PASSTHROUGH_MULTI_PACKET_FRAME_MAX_SIZE packets of passthrough telemetry data (for slow links)
+ Note: we have 2 distinct frame types (single packet vs multi packet) because
+ whenever possible we use smaller frames for they have a higher "chance"
+ of being transmitted by the crossfire RX scheduler.
+*/
+void AP_CRSF_Telem::get_multi_packet_passthrough_telem_data()
+{
+    _telem_pending = false;
+    uint8_t count = 0;
+    AP_Frsky_SPort::sport_packet_t buffer[PASSTHROUGH_MULTI_PACKET_FRAME_MAX_SIZE] {};
+    // we request a PASSTHROUGH_MULTI_PACKET_FRAME_MAX_SIZE packet array, i.e. 9 packets
+    if (!AP_Frsky_Telem::get_telem_data(buffer, count, ARRAY_SIZE(buffer))) {
+        return;
+    }
+    _telem.bcast.custom_telem.multi_packet_passthrough.sub_type = AP_RCProtocol_CRSF::CustomTelemSubTypeID::CRSF_AP_CUSTOM_TELEM_MULTI_PACKET_PASSTHROUGH;
+    for (uint8_t idx=0; idx<count; idx++) {
+        _telem.bcast.custom_telem.multi_packet_passthrough.frames[idx].appid = buffer[idx].appid;
+        _telem.bcast.custom_telem.multi_packet_passthrough.frames[idx].data = buffer[idx].data;
+    }
+    _telem.bcast.custom_telem.multi_packet_passthrough.size = count;
+    _telem_size = sizeof(AP_CRSF_Telem::PassthroughMultiPacketFrame);
+    _telem_type = get_custom_telem_frame_id();
+    _telem_pending = true;
+}
+
 /*
   fetch CRSF frame data
  */
@@ -842,7 +1187,6 @@ bool AP_CRSF_Telem::_get_telem_data(AP_RCProtocol_CRSF::Frame* data)
     data->type = _telem_type;
 
     _telem_pending = false;
-
     return true;
 }
 

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -148,10 +148,10 @@ void AP_CRSF_Telem::process_rf_mode_changes()
 {
     const AP_RCProtocol_CRSF::RFMode current_rf_mode = get_rf_mode();
     uint32_t now = AP_HAL::millis();
-    if ( _telem_rf_mode != current_rf_mode
-        // report a change of more than 10Hz if we haven't done so in the last 5s
-        || (now - _telem_last_report_ms > 5000 && abs(int16_t(_telem_last_avg_rate) - int16_t(_scheduler.avg_packet_rate)) > 10)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "CRSF: rf mode change %d->%d, rate is %dHz", (uint8_t)_telem_rf_mode, (uint8_t)current_rf_mode, _scheduler.avg_packet_rate);
+    // report a change in RF mode or a chnage of more than 10Hz if we haven't done so in the last 5s
+    if ((now - _telem_last_report_ms > 5000) &&
+        (_telem_rf_mode != current_rf_mode || abs(int16_t(_telem_last_avg_rate) - int16_t(_scheduler.avg_packet_rate)) > 25)) {
+        gcs().send_text(MAV_SEVERITY_INFO, "CRSF: RF mode %d, rate is %dHz", (uint8_t)current_rf_mode, _scheduler.avg_packet_rate);
         update_custom_telemetry_rates(current_rf_mode);
         _telem_rf_mode = current_rf_mode;
         _telem_last_avg_rate = _scheduler.avg_packet_rate;

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -162,7 +162,7 @@ void AP_CRSF_Telem::process_rf_mode_changes()
 // return custom frame id based on fw version
 uint8_t AP_CRSF_Telem::get_custom_telem_frame_id() const
 {
-    if (!_crsf_version.pending && _crsf_version.major >= 4 && _crsf_version.minor >= 6) {
+    if (!_crsf_version.pending && (_crsf_version.major > 4 || (_crsf_version.major == 4 && _crsf_version.minor >= 6))) {
         return AP_RCProtocol_CRSF::CRSF_FRAMETYPE_AP_CUSTOM_TELEM;
     }
     return AP_RCProtocol_CRSF::CRSF_FRAMETYPE_AP_CUSTOM_TELEM_LEGACY;

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -307,6 +307,9 @@ private:
     uint8_t _telem_size;
     uint8_t _telem_type;
     AP_RCProtocol_CRSF::RFMode _telem_rf_mode;
+    // reporting telemetry rate
+    uint32_t _telem_last_report_ms;
+    uint16_t _telem_last_avg_rate;
 
     bool _telem_pending;
     bool _enable_telemetry;
@@ -321,6 +324,7 @@ private:
         uint8_t major;
         uint8_t retry_count;
         bool use_rf_mode;
+        bool is_tracer;
         bool pending = true;
     } _crsf_version;
 

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -49,29 +49,34 @@ public:
     virtual bool init() override;
 
     static AP_CRSF_Telem *get_singleton(void);
+    void queue_message(MAV_SEVERITY severity, const char *text) override;
+
+    static const uint8_t PASSTHROUGH_STATUS_TEXT_FRAME_MAX_SIZE = 50U;
+    static const uint8_t PASSTHROUGH_MULTI_PACKET_FRAME_MAX_SIZE = 9U;
+    static const uint8_t CRSF_RX_DEVICE_PING_MAX_RETRY = 50U;
 
     // Broadcast frame definitions courtesy of TBS
-    struct GPSFrame {   // curious fact, calling this GPS makes sizeof(GPS) return 1!
+    struct PACKED GPSFrame {   // curious fact, calling this GPS makes sizeof(GPS) return 1!
         int32_t latitude; // ( degree / 10`000`000 )
         int32_t longitude; // (degree / 10`000`000 )
         uint16_t groundspeed; // ( km/h / 100 )
         uint16_t gps_heading; // ( degree / 100 )
         uint16_t altitude; // ( meter - 1000m offset )
         uint8_t satellites; // in use ( counter )
-    } PACKED;
+    };
 
     struct HeartbeatFrame {
         uint8_t origin; // Device addres
     };
 
-    struct BatteryFrame {
+    struct PACKED BatteryFrame {
         uint16_t voltage; // ( mV * 100 )
         uint16_t current; // ( mA * 100 )
         uint8_t capacity[3]; // ( mAh )
         uint8_t remaining; // ( percent )
-    } PACKED;
+    };
 
-    struct VTXFrame {
+    struct PACKED VTXFrame {
 #if __BYTE_ORDER != __LITTLE_ENDIAN
 #error "Only supported on little-endian architectures"
 #endif
@@ -88,45 +93,45 @@ public:
         uint16_t user_frequency;
         uint8_t power : 4;              // 25mW = 0, 200mW = 1, 500mW = 2, 800mW = 3
         uint8_t pitmode : 4;            // off = 0, In_Band = 1, Out_Band = 2;
-    } PACKED;
+    };
 
-    struct VTXTelemetryFrame {
+    struct PACKED VTXTelemetryFrame {
         uint8_t origin; // address
         uint8_t power;              // power in dBm
         uint16_t frequency;         // frequency in Mhz
         uint8_t pitmode;            // disable 0, enable 1
-    } PACKED;
+    };
 
-    struct AttitudeFrame {
+    struct PACKED AttitudeFrame {
         int16_t pitch_angle; // ( rad * 10000 )
         int16_t roll_angle; // ( rad * 10000 )
         int16_t yaw_angle; // ( rad * 10000 )
-    } PACKED;
+    };
 
-    struct FlightModeFrame {
+    struct PACKED FlightModeFrame {
         char flight_mode[16]; // ( Null-terminated string )
-    } PACKED;
+    };
 
     // CRSF_FRAMETYPE_COMMAND
-    struct CommandFrame {
+    struct PACKED CommandFrame {
         uint8_t destination;
         uint8_t origin;
         uint8_t command_id;
         uint8_t payload[9]; // 8 maximum for LED command + crc8
-    } PACKED;
+    };
 
     // CRSF_FRAMETYPE_PARAM_DEVICE_PING
-    struct ParameterPingFrame {
+    struct PACKED ParameterPingFrame {
         uint8_t destination;
         uint8_t origin;
-    } PACKED;
+    };
 
     // CRSF_FRAMETYPE_PARAM_DEVICE_INFO
-    struct ParameterDeviceInfoFrame {
+    struct PACKED ParameterDeviceInfoFrame {
         uint8_t destination;
         uint8_t origin;
         uint8_t payload[58];   // largest possible frame is 60
-    } PACKED;
+    };
 
     enum ParameterType : uint8_t
     {
@@ -144,57 +149,90 @@ public:
     };
 
     // CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY
-    struct ParameterSettingsEntryHeader {
+    struct PACKED ParameterSettingsEntryHeader {
         uint8_t destination;
         uint8_t origin;
         uint8_t param_num;
         uint8_t chunks_left;
-    } PACKED;
+    };
 
     // CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY
-    struct ParameterSettingsEntry {
+    struct PACKED ParameterSettingsEntry {
         ParameterSettingsEntryHeader header;
         uint8_t payload[56];   // largest possible frame is 60
-    } PACKED;
+    };
 
     // CRSF_FRAMETYPE_PARAMETER_READ
-    struct ParameterSettingsReadFrame {
+    struct PACKED ParameterSettingsReadFrame {
         uint8_t destination;
         uint8_t origin;
         uint8_t param_num;
         uint8_t param_chunk;
-    } PACKED _param_request;
+    } _param_request;
 
     // CRSF_FRAMETYPE_PARAMETER_WRITE
-    struct ParameterSettingsWriteFrame {
+    struct PACKED ParameterSettingsWriteFrame {
         uint8_t destination;
         uint8_t origin;
         uint8_t param_num;
         uint8_t payload[57];   // largest possible frame is 60
-    } PACKED;
+    };
 
-    union BroadcastFrame {
+    // Frame to hold passthrough telemetry
+    struct PACKED PassthroughSinglePacketFrame {
+        uint8_t sub_type;
+        uint16_t appid;
+        uint32_t data;
+    };
+
+    // Frame to hold passthrough telemetry
+    struct PACKED PassthroughMultiPacketFrame {
+        uint8_t sub_type;
+        uint8_t size;
+        struct PACKED {
+            uint16_t appid;
+            uint32_t data;
+        } frames[PASSTHROUGH_MULTI_PACKET_FRAME_MAX_SIZE];
+    };
+
+    // Frame to hold status text message
+    struct PACKED StatusTextFrame {
+        uint8_t sub_type;
+        uint8_t severity;
+        char text[PASSTHROUGH_STATUS_TEXT_FRAME_MAX_SIZE];  // ( Null-terminated string )
+    };
+
+    // ardupilot frametype container
+    union PACKED APCustomTelemFrame {
+        PassthroughSinglePacketFrame single_packet_passthrough;
+        PassthroughMultiPacketFrame multi_packet_passthrough;
+        StatusTextFrame status_text;
+    };
+
+
+    union PACKED BroadcastFrame {
         GPSFrame gps;
         HeartbeatFrame heartbeat;
         BatteryFrame battery;
         VTXFrame vtx;
         AttitudeFrame attitude;
         FlightModeFrame flightmode;
-    } PACKED;
+        APCustomTelemFrame custom_telem;
+    };
 
-    union ExtendedFrame {
+    union PACKED ExtendedFrame {
         CommandFrame command;
         ParameterPingFrame ping;
         ParameterDeviceInfoFrame info;
         ParameterSettingsEntry param_entry;
         ParameterSettingsReadFrame param_read;
         ParameterSettingsWriteFrame param_write;
-    } PACKED;
+    };
 
-    union TelemetryPayload {
+    union PACKED TelemetryPayload {
         BroadcastFrame bcast;
         ExtendedFrame ext;
-    } PACKED;
+    };
 
     // Process a frame from the CRSF protocol decoder
     static bool process_frame(AP_RCProtocol_CRSF::FrameType frame_type, void* data);
@@ -213,6 +251,8 @@ private:
         BATTERY,
         GPS,
         FLIGHT_MODE,
+        PASSTHROUGH,
+        STATUS_TEXT,
         NUM_SENSORS
     };
 
@@ -220,6 +260,8 @@ private:
     bool is_packet_ready(uint8_t idx, bool queue_empty) override;
     void process_packet(uint8_t idx) override;
     void adjust_packet_weight(bool queue_empty) override;
+    void setup_custom_telemetry();
+    void update_custom_telemetry_rates(AP_RCProtocol_CRSF::RFMode rf_mode);
 
     void calc_parameter_ping();
     void calc_heartbeat();
@@ -228,33 +270,65 @@ private:
     void calc_attitude();
     void calc_flight_mode();
     void calc_device_info();
+    void calc_device_ping();
     void calc_parameter();
 #if HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED
     void calc_text_selection( AP_OSD_ParamSetting* param, uint8_t chunk);
 #endif
     void update_params();
     void update_vtx_params();
+    void get_single_packet_passthrough_telem_data();
+    void get_multi_packet_passthrough_telem_data();
+    void calc_status_text();
+    void process_rf_mode_changes();
+    uint8_t get_custom_telem_frame_id() const;
+    AP_RCProtocol_CRSF::RFMode get_rf_mode() const;
+    bool is_high_speed_telemetry(const AP_RCProtocol_CRSF::RFMode rf_mode) const;
 
     void process_vtx_frame(VTXFrame* vtx);
     void process_vtx_telem_frame(VTXTelemetryFrame* vtx);
     void process_ping_frame(ParameterPingFrame* ping);
     void process_param_read_frame(ParameterSettingsReadFrame* read);
     void process_param_write_frame(ParameterSettingsWriteFrame* write);
+    void process_device_info_frame(ParameterDeviceInfoFrame* info);
 
-     // setup ready for passthrough operation
+    // setup ready for passthrough operation
     void setup_wfq_scheduler(void) override;
 
-     // get next telemetry data for external consumers
+    // setup the scheduler for parameters download
+    void enter_scheduler_params_mode();
+    void exit_scheduler_params_mode();
+
+    // get next telemetry data for external consumers
     bool _get_telem_data(AP_RCProtocol_CRSF::Frame* data);
     bool _process_frame(AP_RCProtocol_CRSF::FrameType frame_type, void* data);
 
     TelemetryPayload _telem;
     uint8_t _telem_size;
     uint8_t _telem_type;
+    AP_RCProtocol_CRSF::RFMode _telem_rf_mode;
 
     bool _telem_pending;
     bool _enable_telemetry;
-    uint8_t _request_pending;
+
+    struct {
+        uint8_t destination = AP_RCProtocol_CRSF::CRSF_ADDRESS_BROADCAST;
+        uint8_t frame_type;
+    } _pending_request;
+
+    struct {
+        uint8_t minor;
+        uint8_t major;
+        uint8_t retry_count;
+        bool use_rf_mode;
+        bool pending = true;
+    } _crsf_version;
+
+    struct {
+        bool init_done;
+        uint32_t params_mode_start_ms;
+        bool params_mode_active;
+    } _custom_telem;
 
     // vtx state
     bool _vtx_freq_update;  // update using the frequency method or not

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.h
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.h
@@ -17,6 +17,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AP_Math/AP_Math.h>
 
 #define TELEM_PAYLOAD_STATUS_CAPACITY          5 // size of the message buffer queue (max number of messages waiting to be sent)
 
@@ -34,23 +35,66 @@ public:
     AP_RCTelemetry &operator=(const AP_RCTelemetry&) = delete;
 
     // add statustext message to message queue
-    void queue_message(MAV_SEVERITY severity, const char *text);
+    virtual void queue_message(MAV_SEVERITY severity, const char *text);
+
+    // scheduler entry helpers
+    void enable_scheduler_entry(const uint8_t slot) {
+        if (slot >= TELEM_TIME_SLOT_MAX) {
+            return;
+        }
+        BIT_CLEAR(_disabled_scheduler_entries_bitmask, slot);
+    }
+    void disable_scheduler_entry(const uint8_t slot) {
+        if (slot >= TELEM_TIME_SLOT_MAX) {
+            return;
+        }
+        BIT_SET(_disabled_scheduler_entries_bitmask, slot);
+    }
+    void set_scheduler_entry_min_period(const uint8_t slot, const uint32_t min_period_ms)
+    {
+        if (slot >= TELEM_TIME_SLOT_MAX) {
+            return;
+        }
+        _scheduler.packet_min_period[slot] = min_period_ms;
+    }
+    bool is_scheduler_entry_enabled(const uint8_t slot) const {
+        if (slot >= TELEM_TIME_SLOT_MAX) {
+            return false;
+        }
+        return !BIT_IS_SET(_disabled_scheduler_entries_bitmask, slot);
+    }
+    // each derived class might provide a way to reset telemetry rates to default
+    virtual void reset_scheduler_entry_min_periods() {}
 
     // update error mask of sensors and subsystems. The mask uses the
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
     // indicates that the sensor or subsystem is present but not
     // functioning correctly
     uint32_t sensor_status_flags() const;
+    uint16_t get_avg_packet_rate() const {
+        return _scheduler.avg_packet_rate;
+    }
+    uint16_t get_max_packet_rate() const {
+        return _scheduler.max_packet_rate;
+    }
 
 protected:
-    void run_wfq_scheduler();
+    uint8_t run_wfq_scheduler(const bool use_shaper = true);
+    // process a specific entry
+    bool process_scheduler_entry(const uint8_t slot );
     // set an entry in the scheduler table
     void set_scheduler_entry(uint8_t slot, uint32_t weight, uint32_t min_period_ms) {
+        if (slot >= TELEM_TIME_SLOT_MAX) {
+            return;
+        }
         _scheduler.packet_weight[slot] = weight;
         _scheduler.packet_min_period[slot] = min_period_ms;
     }
     // add an entry to the scheduler table
     void add_scheduler_entry(uint32_t weight, uint32_t min_period_ms) {
+        if (_time_slots >= TELEM_TIME_SLOT_MAX) {
+            return;
+        }
         set_scheduler_entry(_time_slots++, weight, min_period_ms);
     }
     // setup ready for passthrough operation
@@ -65,7 +109,8 @@ protected:
         uint32_t packet_timer[TELEM_TIME_SLOT_MAX];
         uint32_t packet_weight[TELEM_TIME_SLOT_MAX];
         uint32_t packet_min_period[TELEM_TIME_SLOT_MAX];
-        uint8_t avg_packet_rate;
+        uint16_t avg_packet_rate;
+        uint16_t max_packet_rate;
 #ifdef TELEM_DEBUG
         uint8_t packet_rate[TELEM_TIME_SLOT_MAX];
 #endif
@@ -81,6 +126,7 @@ protected:
 private:
     uint32_t check_sensor_status_timer;
     uint32_t check_ekf_status_timer;
+    uint32_t _disabled_scheduler_entries_bitmask;
 
     // passthrough WFQ scheduler
     virtual void setup_wfq_scheduler() = 0;
@@ -88,8 +134,17 @@ private:
     virtual bool is_packet_ready(uint8_t idx, bool queue_empty) { return true; }
     virtual void process_packet(uint8_t idx) = 0;
     virtual void adjust_packet_weight(bool queue_empty) {};
+    bool check_scheduler_entry_time_constraints(const uint32_t now, uint8_t slot, const bool use_shaper) const {
+        if (!use_shaper) {
+            return true;
+        }
+        return ((now - _scheduler.packet_timer[slot]) >= _scheduler.packet_min_period[slot]);
+    }
 
     void update_avg_packet_rate();
+    void update_max_packet_rate() {
+        _scheduler.max_packet_rate = MAX(_scheduler.avg_packet_rate, _scheduler.max_packet_rate);
+    }
 
     // methods to convert flight controller data to FrSky SPort Passthrough (OpenTX) format
     void check_sensor_status_flags(void);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -45,6 +45,7 @@
 #include <AP_Scripting/AP_Scripting.h>
 #include <AP_Winch/AP_Winch.h>
 #include <AP_OSD/AP_OSD.h>
+#include <AP_RCTelemetry/AP_CRSF_Telem.h>
 
 #include <stdio.h>
 
@@ -1945,6 +1946,12 @@ void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, u
     AP_Spektrum_Telem* spektrum = AP::spektrum_telem();
     if (spektrum != nullptr) {
         spektrum->queue_message(severity, first_piece_of_text);
+    }
+#endif
+#if HAL_CRSF_TELEM_ENABLED
+    AP_CRSF_Telem* crsf = AP::crsf_telem();
+    if (crsf != nullptr) {
+        crsf->queue_message(severity, first_piece_of_text);
     }
 #endif
     AP_Notify *notify = AP_Notify::get_singleton();

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -403,6 +403,11 @@ public:
         return get_singleton() != nullptr && (_options & uint32_t(Option::FPORT_PAD));
     }
 
+    // returns true if we should pass through data for crsf telemetry
+    bool crsf_custom_telemetry(void) const {
+        return get_singleton() != nullptr && (_options & uint32_t(Option::CRSF_CUSTOM_TELEMETRY));
+    }
+
     // should a channel reverse option affect aux switches
     bool switch_reverse_allowed(void) const {
         return get_singleton() != nullptr && (_options & uint32_t(Option::ALLOW_SWITCH_REV));
@@ -464,14 +469,15 @@ public:
 protected:
 
     enum class Option {
-        IGNORE_RECEIVER       = (1 << 0), // RC receiver modules
-        IGNORE_OVERRIDES      = (1 << 1), // MAVLink overrides
-        IGNORE_FAILSAFE       = (1 << 2), // ignore RC failsafe bits
-        FPORT_PAD             = (1 << 3), // pad fport telem output
-        LOG_DATA              = (1 << 4), // log rc input bytes
-        ARMING_CHECK_THROTTLE = (1 << 5), // run an arming check for neutral throttle
-        ARMING_SKIP_CHECK_RPY = (1 << 6), // skip the an arming checks for the roll/pitch/yaw channels
-        ALLOW_SWITCH_REV      = (1 << 7), // honor the reversed flag on switches
+        IGNORE_RECEIVER         = (1U << 0), // RC receiver modules
+        IGNORE_OVERRIDES        = (1U << 1), // MAVLink overrides
+        IGNORE_FAILSAFE         = (1U << 2), // ignore RC failsafe bits
+        FPORT_PAD               = (1U << 3), // pad fport telem output
+        LOG_DATA                = (1U << 4), // log rc input bytes
+        ARMING_CHECK_THROTTLE   = (1U << 5), // run an arming check for neutral throttle
+        ARMING_SKIP_CHECK_RPY   = (1U << 6), // skip the an arming checks for the roll/pitch/yaw channels
+        ALLOW_SWITCH_REV        = (1U << 7), // honor the reversed flag on switches
+        CRSF_CUSTOM_TELEMETRY   = (1U << 8), // use passthrough data for crsf telemetry
     };
 
     void new_override_received() {

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks, 7:Allow Switch reverse
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE),
 
     // @Param: _PROTOCOLS


### PR DESCRIPTION
this add passthrough telemetry using crossfire as a transport.
Main features:
- supports both legacy crossfire telemetry along passthrough at the same time
- supports both rf mode 1 (slow) and rf mode 2 (fast)
- uses a dedicated frame for status text messages
- when in rf mode 1 packs multiple passthrough packets in a single big frame to save bandwidth
- detects crossfire fw version to get supported features

More info [here](https://discuss.ardupilot.org/t/passthrough-telemetry-over-crsf-crossfire/62668)