### PR TITLE
Copter: use glitch-protected range from rangefinder for precision landing

### DIFF
--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -17,7 +17,7 @@ void Copter::update_precland()
 
     // use range finder altitude if it is valid, otherwise use home alt
     if (rangefinder_alt_ok()) {
-        height_above_ground_cm = rangefinder_state.alt_cm;
+        height_above_ground_cm = rangefinder_state.alt_cm_glitch_protected;
     }
 
     precland.update(height_above_ground_cm, rangefinder_alt_ok());


### PR DESCRIPTION
This PR is in reference to this issue: #15615

Change Copter's precision landing implementation to use the glitch protected result from the rangefinder. This should prevent wild maneuvers due to large spikes from the rangefinder.

Real life results with non-glitch protected range: (PL varies wildly at spike)
![image](https://user-images.githubusercontent.com/20523368/99619198-e7a25f00-29f0-11eb-8ebf-de3ed00f9ef5.png)

Real life results with glitch protected range: (PL appears to ignore spike)
![image](https://user-images.githubusercontent.com/20523368/99619211-f0933080-29f0-11eb-8e85-4d400e6904ab.png)
