### PR TITLE
NFC: AR_WPNav: Add note to WP_PIVOT_ANGLE

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AR_WPNav::var_info[] = {
 
     // @Param: PIVOT_ANGLE
     // @DisplayName: Waypoint Pivot Angle
-    // @Description: Pivot when the difference between the vehicle's heading and its target heading is more than this many degrees.  Set to zero to disable pivot turns
+    // @Description: Pivot when the difference between the vehicle's heading and its target heading is more than this many degrees. Set to zero to disable pivot turns. Note: This parameter should be greater than 10 degrees for pivot turns to work.
     // @Units: deg
     // @Range: 0 360
     // @Increment: 1


### PR DESCRIPTION
This comes after there have been confusion regarding this parameter from users at Discord and Discussion Forums. 
We have a fixed "Exit Angle" for pivot turns which happens to be 10 degrees. So WP_PIVOT_ANGLE less than 10 deg is naturally ignored in the code. And people try and set the angle to be as little as 5 degrees ... 
I guess a better fix would be to include another parameter that actaully gives the user the power to set the "Exit Angle" which I did long back here: https://github.com/ArduPilot/ardupilot/pull/13686 Then we can add a note saying WP_PIVOT_ANGLE > WP_PIVOT_EXIT_ANGLE or something.
But in the short term this should also help.