### PR TITLE
AP_NavEKF3: Fix bug preventing yaw alignment to EKF-GSF estimate

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -718,14 +718,14 @@ void NavEKF3_core::runYawEstimatorCorrection()
             } else {
                 EKFGSF_yaw_valid_count = 0;
             }
-        } else {
-            EKFGSF_yaw_valid_count = 0;
         }
 
         // action an external reset request
         if (EKFGSF_yaw_reset_request_ms > 0 && imuSampleTime_ms - EKFGSF_yaw_reset_request_ms < YAW_RESET_TO_GSF_TIMEOUT_MS) {
             EKFGSF_resetMainFilterYaw();
         }
+    } else {
+        EKFGSF_yaw_valid_count = 0;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/ArduPilot/ardupilot/issues/15860

Verified using replay of log provided in issue. The following plots show the original behaviour [0] and the replay behaviour [100]

Velocity Innovations (velocity innovations become non zero and smallafter successful yaw alignment)

<img width="1048" alt="Screen Shot 2020-11-21 at 11 44 00 am" src="https://user-images.githubusercontent.com/3596952/99862762-1128d980-2bef-11eb-865d-b7d15ff3fb88.png">

Position Innovations (position innovations become very small after successful yaw reset

<img width="1029" alt="Screen Shot 2020-11-21 at 11 44 40 am" src="https://user-images.githubusercontent.com/3596952/99862778-230a7c80-2bef-11eb-9d04-5daec24f3805.png">

EKF-GSF yaw estimates (no change as expected)

<img width="1023" alt="Screen Shot 2020-11-21 at 11 44 06 am" src="https://user-images.githubusercontent.com/3596952/99862819-551bde80-2bef-11eb-85c6-ce0cac6cf119.png">

