### PR TITLE
DMA Contention Statistics

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -33,6 +33,7 @@ struct SysFileList {
 static const SysFileList sysfs_file_list[] = {
     {"threads.txt", 1024},
     {"tasks.txt", 6500},
+    {"dma.txt", 1024},
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     {"can_log.txt", 1024},
     {"can0_stats.txt", 1024},
@@ -96,6 +97,12 @@ int AP_Filesystem_Sys::open(const char *fname, int flags)
                 free(r.data->data);
                 r.data->data = nullptr;
             }
+        }
+    }
+    if (strcmp(fname, "dma.txt") == 0) {
+        r.data->data = (char *)malloc(max_size);
+        if (r.data->data) {
+            r.data->length = hal.util->dma_info(r.data->data, max_size);
         }
     }
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -185,6 +185,9 @@ public:
     // request information on running threads
     virtual size_t thread_info(char *buf, size_t bufsize) { return 0; }
 
+    // request information on dma contention
+    virtual size_t dma_info(char *buf, size_t bufsize) { return 0; }
+
 protected:
     // we start soft_armed false, so that actuators don't send any
     // values until the vehicle code has fully started

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -25,6 +25,7 @@
 #include "hwdef/common/flash.h"
 #include <AP_ROMFS/AP_ROMFS.h>
 #include "sdcard.h"
+#include "shared_dma.h"
 
 #if HAL_WITH_IO_MCU
 #include <AP_BoardConfig/AP_BoardConfig.h>
@@ -335,3 +336,9 @@ size_t Util::thread_info(char *buf, size_t bufsize)
 }
 #endif // CH_DBG_ENABLE_STACK_CHECK == TRUE
 
+#if CH_CFG_USE_SEMAPHORES
+// request information on dma contention
+size_t Util::dma_info(char *buf, size_t bufsize) {
+    return ChibiOS::Shared_DMA::dma_info(buf, bufsize);
+}
+#endif

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -62,6 +62,10 @@ public:
     // request information on running threads
     size_t thread_info(char *buf, size_t bufsize) override;
 #endif
+#if CH_CFG_USE_SEMAPHORES
+    // request information on dma contention
+    size_t dma_info(char *buf, size_t bufsize) override;
+#endif
     
 private:
 #ifdef HAL_PWM_ALARM

--- a/libraries/AP_HAL_ChibiOS/shared_dma.cpp
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.cpp
@@ -23,8 +23,10 @@
 #if CH_CFG_USE_SEMAPHORES == TRUE
 
 using namespace ChibiOS;
+extern const AP_HAL::HAL& hal;
 
 Shared_DMA::dma_lock Shared_DMA::locks[SHARED_DMA_MAX_STREAM_ID+1];
+volatile Shared_DMA::dma_stats* Shared_DMA::_contention_stats;
 
 void Shared_DMA::init(void)
 {
@@ -148,22 +150,36 @@ bool Shared_DMA::lock_nonblock(void)
         chSysDisable();
         if (locks[stream_id1].obj != nullptr && locks[stream_id1].obj != this) {
             locks[stream_id1].obj->contention = true;
+            if (_contention_stats != nullptr) {
+                _contention_stats[stream_id1].contended_locks++;
+            }
         }
         chSysEnable();
         contention = true;
         return false;
     }
+
+    if (_contention_stats != nullptr) {
+        _contention_stats[stream_id1].uncontended_locks++;
+    }
+
     if (!lock_stream_nonblocking(stream_id2)) {
         unlock_stream(stream_id1);
         chSysDisable();
         if (locks[stream_id2].obj != nullptr && locks[stream_id2].obj != this) {
             locks[stream_id2].obj->contention = true;
+            if (_contention_stats != nullptr) {
+                _contention_stats[stream_id2].contended_locks++;
+            }
         }
         chSysEnable();
         contention = true;
         return false;
     }
     lock_core();
+    if (_contention_stats != nullptr) {
+        _contention_stats[stream_id2].uncontended_locks++;
+    }
     return true;
 }
 
@@ -209,6 +225,53 @@ void Shared_DMA::lock_all(void)
     for (uint8_t i=0; i<SHARED_DMA_MAX_STREAM_ID; i++) {
         lock_stream(i);
     }
+}
+
+// display dma contention statistics as text buffer for @SYS/dma.txt
+size_t Shared_DMA::dma_info(char *buf, size_t bufsize)
+{
+    size_t total = 0;
+
+    // no buffer allocated, start counting
+    if (_contention_stats == nullptr) {
+        _contention_stats = new dma_stats[SHARED_DMA_MAX_STREAM_ID+1];
+        return 0;
+    }
+
+    // a header to allow for machine parsers to determine format
+    int n = hal.util->snprintf(buf, bufsize, "DMAV1\n");
+
+    if (n <= 0) {
+        return 0;
+    }
+
+    buf += n;
+    bufsize -= n;
+    total += n;
+
+    for (uint8_t i = 0; i < SHARED_DMA_MAX_STREAM_ID + 1; i++) {
+        if (locks[i].obj == nullptr) {
+            continue;
+        }
+
+        const char* fmt = "DMA=%1u STRM=%1u ULCK=%8u CLCK=%8u CONT=%4.1f%%\n";
+        float cond_per = 100.0f * float(_contention_stats[i].contended_locks)
+            / (1 + _contention_stats[i].contended_locks + _contention_stats[i].uncontended_locks);
+        n = hal.util->snprintf(buf, bufsize, fmt, i / 8 + 1, i % 8,
+            _contention_stats[i].uncontended_locks, _contention_stats[i].contended_locks, cond_per);
+
+        if (n <= 0) {
+            break;
+        }
+        buf += n;
+        bufsize -= n;
+        total += n;
+
+        _contention_stats[i].contended_locks = 0;
+        _contention_stats[i].uncontended_locks = 0;
+    }
+
+    return total;
 }
 
 #endif // CH_CFG_USE_SEMAPHORES

--- a/libraries/AP_HAL_ChibiOS/shared_dma.h
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.h
@@ -65,6 +65,9 @@ public:
     // lock all shared DMA channels. Used on reboot
     static void lock_all(void);
 
+    // display dma contention statistics as text buffer for @SYS/dma.txt
+    static size_t dma_info(char *buf, size_t bufsize);
+
 private:
     dma_allocate_fn_t allocate;
     dma_allocate_fn_t deallocate;
@@ -103,4 +106,10 @@ private:
         // point to object that holds the allocation, if allocated
         Shared_DMA *obj;
     } locks[SHARED_DMA_MAX_STREAM_ID+1];
+
+    // contention statistics
+    static volatile struct dma_stats {
+        uint32_t contended_locks;
+        uint32_t uncontended_locks;
+    } *_contention_stats;
 };


### PR DESCRIPTION
This adds support for @SYS/dma.txt to display shared DMA contention statistics

```
DMAV1
DMA=1 STRM=1 ULCK=    7430 CLCK=       0 CONT= 0.0%
DMA=1 STRM=3 ULCK=       0 CLCK=       0 CONT= 0.0%
DMA=1 STRM=4 ULCK=       0 CLCK=       0 CONT= 0.0%
DMA=2 STRM=2 ULCK=       0 CLCK=       0 CONT= 0.0%
DMA=2 STRM=3 ULCK=       0 CLCK=       0 CONT= 0.0%
DMA=2 STRM=5 ULCK=       0 CLCK=       0 CONT= 0.0%
DMA=2 STRM=6 ULCK=       0 CLCK=       0 CONT= 0.0%
```