### PR TITLE
AP_GPS: fixed constrained NaN in EKF3 caused by bad GPS blending

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1623,6 +1623,10 @@ bool AP_GPS::calc_blend_weights(void)
         }
     }
 
+    if (!is_positive(sum_of_all_weights)) {
+        return false;
+    }
+
     // calculate an overall weight
     for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
         _blend_weights[i] = (hpos_blend_weights[i] + vpos_blend_weights[i] + spd_blend_weights[i]) / sum_of_all_weights;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1497,6 +1497,11 @@ bool AP_GPS::calc_blend_weights(void)
         if (get_rate_ms(i) > max_rate_ms) {
             max_rate_ms = get_rate_ms(i);
         }
+        if (isinf(state[i].speed_accuracy) ||
+            isinf(state[i].horizontal_accuracy) ||
+            isinf(state[i].vertical_accuracy)) {
+            return false;
+        }
     }
     if ((int32_t)(max_ms - min_ms) < (int32_t)(2 * max_rate_ms)) {
         // data is not too delayed so use the oldest time_stamp to give a chance for data from that receiver to be updated

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -427,6 +427,12 @@ bool AP_GPS_UAVCAN::read(void)
     if (_new_data) {
         _new_data = false;
 
+        // the encoding of accuracies in UAVCAN can result in infinite
+        // values. These cause problems with blending. Use 1000m and 1000m/s instead
+        interim_state.horizontal_accuracy = MIN(interim_state.horizontal_accuracy, 1000.0);
+        interim_state.vertical_accuracy = MIN(interim_state.vertical_accuracy, 1000.0);
+        interim_state.speed_accuracy = MIN(interim_state.speed_accuracy, 1000.0);
+
         state = interim_state;
 
         return true;


### PR DESCRIPTION
if the accuracies reported are very low then we can do a division by
zero and this results in a constraining NaN for GPS vertical velocity
filter in NavEKF3_core::calcGpsGoodToAlign
This was reproduced on CubeBlack and SITL by forcing horizontal and speed accuracies of 0.0005
