### PR TITLE
AP_NavEKF_Source: optimise configured_in_storage

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -293,10 +293,16 @@ bool AP_NavEKF_Source::usingGPS() const
 }
 
 // true if some parameters have been configured (used during parameter conversion)
-bool AP_NavEKF_Source::configured_in_storage() const
+bool AP_NavEKF_Source::configured_in_storage()
 {
+    if (config_in_storage) {
+        return true;
+    }
+
     // first source parameter is used to determine if configured or not
-    return _source_set[0].posxy.configured_in_storage();
+    config_in_storage = _source_set[0].posxy.configured_in_storage();
+
+    return config_in_storage;
 }
 
 // mark parameters as configured in storage (used to ensure parameter conversion is only done once)

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -83,7 +83,7 @@ public:
     bool usingGPS() const;
 
     // true if source parameters have been configured (used for parameter conversion)
-    bool configured_in_storage() const;
+    bool configured_in_storage();
 
     // mark parameters as configured in storage (used to ensure parameter conversion is only done once)
     void mark_configured_in_storage();
@@ -115,4 +115,5 @@ private:
         SourceYaw yaw;      // current yaw source
     } _active_source_set;
     bool initialised;       // true once init has been run
+    bool config_in_storage; // true once configured in storage has returned true
 };


### PR DESCRIPTION
This small CPU optimisation takes advantage of the fact that once configured in storage is true it will always remain true.  

Below is a screen shot showing that during startup 402 checks are avoided.
![image](https://user-images.githubusercontent.com/1498098/99923352-a73c3b80-2d78-11eb-8838-680bb8a9c208.png)

I'm not sure how important this is but I heard from @tridge that these configured_in_storage() calls can be expensive especially on small boards.