### PR TITLE
gitignore: ignore .pydevproject from Eclipse Python plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 .built
 .context
 .cproject
+.pydevproject
 .depend
 .directory
 .metadata/


### PR DESCRIPTION
gitignore: ignore .pydevproject from Eclipse Python plugin