### PR TITLE
AHRS/EKF: Rover and Plane only fallback from EKF to DCM if EKFs were configured to use GPS

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1254,15 +1254,18 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
         (_vehicle_class == AHRS_VEHICLE_FIXED_WING ||
          _vehicle_class == AHRS_VEHICLE_GROUND) &&
         (_flags.fly_forward || !hal.util->get_soft_armed())) {
+        bool should_use_gps = true;
         nav_filter_status filt_state;
 #if HAL_NAVEKF2_AVAILABLE
         if (ret == EKFType::TWO) {
             EKF2.getFilterStatus(-1,filt_state);
+            should_use_gps = EKF2.configuredToUseGPSForPosXY();
         }
 #endif
 #if HAL_NAVEKF3_AVAILABLE
         if (ret == EKFType::THREE) {
             EKF3.getFilterStatus(-1,filt_state);
+            should_use_gps = EKF3.configuredToUseGPSForPosXY();
         }
 #endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -1273,6 +1276,7 @@ AP_AHRS_NavEKF::EKFType AP_AHRS_NavEKF::active_EKF_type(void) const
         if (hal.util->get_soft_armed() &&
             (!filt_state.flags.using_gps ||
              !filt_state.flags.horiz_pos_abs) &&
+            should_use_gps &&
             AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D) {
             // if the EKF is not fusing GPS or doesn't have a 2D fix
             // and we have a 3D lock, then plane and rover would

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1694,6 +1694,13 @@ bool NavEKF2::isExtNavUsedForYaw() const
     return false;
 }
 
+// check if configured to use GPS for horizontal position estimation
+bool NavEKF2::configuredToUseGPSForPosXY(void) const
+{
+    // 0 = use 3D velocity, 1 = use 2D velocity, 2 = use no velocity, 3 = do not use GPS
+    return  (_fusionModeGPS.get() != 3);
+}
+
 void NavEKF2::requestYawReset(void)
 {
     AP::dal().log_event2(AP_DAL::Event::requestYawReset);

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -362,6 +362,9 @@ public:
     // check if external navigation is being used for yaw observation
     bool isExtNavUsedForYaw(void) const;
 
+    // check if configured to use GPS for horizontal position estimation
+    bool configuredToUseGPSForPosXY(void) const;
+
     // Writes the default equivalent airspeed in m/s to be used in forward flight if a measured airspeed is required and not available.
     void writeDefaultAirSpeed(float airspeed);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1416,6 +1416,13 @@ bool NavEKF3::using_external_yaw(void) const
     return core[primary].using_external_yaw();
 }
 
+// check if configured to use GPS for horizontal position estimation
+bool NavEKF3::configuredToUseGPSForPosXY(void) const
+{
+    // 0 = use 3D velocity, 1 = use 2D velocity, 2 = use no velocity, 3 = do not use GPS
+    return  (sources.getPosXYSource() == AP_NavEKF_Source::SourceXY::GPS);
+}
+
 // write the raw optical flow measurements
 // rawFlowQuality is a measured of quality between 0 and 255, with 255 being the best quality
 // rawFlowRates are the optical flow rates in rad/sec about the X and Y sensor axes.

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -387,7 +387,10 @@ public:
 
     // are we using an external yaw source? This is needed by AHRS attitudes_consistent check
     bool using_external_yaw(void) const;
-    
+
+    // check if configured to use GPS for horizontal position estimation
+    bool configuredToUseGPSForPosXY(void) const;
+
     // Writes the default equivalent airspeed in m/s to be used in forward flight if a measured airspeed is required and not available.
     void writeDefaultAirSpeed(float airspeed);
 


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/15125 which involves a Rover switching to DCM if the GPS is enabled (i.e. GPS_TYPE = 1) but the EKF is not fusing the GPS data.  This can happen when using EKF3 with two sensors sets (i.e. one using GPS, the other using wheel encoders).

The fix is to add a new configuredToUseGPSForPosXY() accessor to EKF2 and EKF3 which returns true if it has been configured to use the GPS.  We then use this in the AP_NavEKF_NavEKF::active_EKF_type() method so that the fallback only happens if the EKF has actually been configured to use the GPS.

This has been tested in SITL in the following ways:

- Rover successfully ran a mission in AUTO using EKF3 using only wheel encoders even though the GPS driver was enabled (i.e. GPS_TYPE = 1)
- Added a temporary commit to EKF3 to disable GPS fusion (by setting gpsDataToFuse = false if rc10 > 1800) and confirmed that the EKF switched back to DCM (on Rover).  Below is a screen shot of the test.
![ekf-fallback-to-dcm-on-rover](https://user-images.githubusercontent.com/1498098/100165009-80a70d80-2efc-11eb-9a1e-6559d63e42b5.png)


Some failures were noted in SITL:

- If using EKF2, Rover rover was unable to navigate a using wheel encoders and GPS.  The behaviour was no better or worse after this PR was applied.  If using wheel encoders we recommend using EKF3 (see [wheel encoder wiki page](https://ardupilot.org/rover/docs/wheel-encoder.html)).

This replaces PR https://github.com/ArduPilot/ardupilot/pull/15148

