### PR TITLE
Create and use an enum-class for Battery Failsafe

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -393,7 +393,7 @@ void AP_BattMonitor::check_failsafes(void)
                 continue;
             }
 
-            const BatteryFailsafe type = drivers[i]->update_failsafes();
+            const Failsafe type = drivers[i]->update_failsafes();
             if (type <= state[i].failsafe) {
                 continue;
             }
@@ -401,13 +401,13 @@ void AP_BattMonitor::check_failsafes(void)
             int8_t action = 0;
             const char *type_str = nullptr;
             switch (type) {
-                case AP_BattMonitor::BatteryFailsafe_None:
+                case Failsafe::None:
                     continue; // should not have been called in this case
-                case AP_BattMonitor::BatteryFailsafe_Low:
+                case Failsafe::Low:
                     action = _params[i]._failsafe_low_action;
                     type_str = "low";
                     break;
-                case AP_BattMonitor::BatteryFailsafe_Critical:
+                case Failsafe::Critical:
                     action = _params[i]._failsafe_critical_action;
                     type_str = "critical";
                     break;
@@ -551,7 +551,7 @@ void AP_BattMonitor::checkPoweringOff(void)
 bool AP_BattMonitor::reset_remaining(uint16_t battery_mask, float percentage)
 {
     bool ret = true;
-    BatteryFailsafe highest_failsafe = BatteryFailsafe_None;
+    Failsafe highest_failsafe = Failsafe::None;
     for (uint8_t i = 0; i < _num_instances; i++) {
         if ((1U<<i) & battery_mask) {
             ret &= drivers[i]->reset_remaining(percentage);
@@ -562,7 +562,7 @@ bool AP_BattMonitor::reset_remaining(uint16_t battery_mask, float percentage)
     }
 
     // If all backends are not in failsafe then set overall failsafe state
-    if (highest_failsafe == BatteryFailsafe_None) {
+    if (highest_failsafe == Failsafe::None) {
         _highest_failsafe_priority = INT8_MAX;
         _has_triggered_failsafe = false;
         // and reset notify flag

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -58,10 +58,10 @@ class AP_BattMonitor
 public:
 
     // battery failsafes must be defined in levels of severity so that vehicles wont fall backwards
-    enum BatteryFailsafe {
-        BatteryFailsafe_None = 0,
-        BatteryFailsafe_Low,
-        BatteryFailsafe_Critical
+    enum class Failsafe : uint8_t {
+        None = 0,
+        Low,
+        Critical
     };
 
     // Battery monitor driver types
@@ -117,7 +117,7 @@ public:
         uint32_t    temperature_time;          // timestamp of the last received temperature message
         float       voltage_resting_estimate;  // voltage with sag removed based on current and resistance estimate in Volt
         float       resistance;                // resistance, in Ohms, calculated by comparing resting voltage vs in flight voltage
-        BatteryFailsafe failsafe;              // stage failsafe the battery is in
+        Failsafe failsafe;                     // stage failsafe the battery is in
         bool        healthy;                   // battery monitor is communicating correctly
         bool        is_powering_off;           // true when power button commands power off
         bool        powerOffNotified;          // only send powering off notification once
@@ -228,7 +228,7 @@ private:
     void convert_params(void);
 
     /// returns the failsafe state of the battery
-    BatteryFailsafe check_failsafe(const uint8_t instance);
+    Failsafe check_failsafe(const uint8_t instance);
     void check_failsafes(void); // checks all batteries failsafes
 
     battery_failsafe_handler_fn_t _battery_failsafe_handler_fn;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -98,7 +98,7 @@ float AP_BattMonitor_Backend::voltage_resting_estimate() const
     return MAX(_state.voltage, _state.voltage_resting_estimate);
 }
 
-AP_BattMonitor::BatteryFailsafe AP_BattMonitor_Backend::update_failsafes(void)
+AP_BattMonitor::Failsafe AP_BattMonitor_Backend::update_failsafes(void)
 {
     const uint32_t now = AP_HAL::millis();
 
@@ -111,7 +111,7 @@ AP_BattMonitor::BatteryFailsafe AP_BattMonitor_Backend::update_failsafes(void)
             _state.critical_voltage_start_ms = now;
         } else if (_params._low_voltage_timeout > 0 &&
                    now - _state.critical_voltage_start_ms > uint32_t(_params._low_voltage_timeout)*1000U) {
-            return AP_BattMonitor::BatteryFailsafe_Critical;
+            return AP_BattMonitor::Failsafe::Critical;
         }
     } else {
         // acceptable voltage so reset timer
@@ -119,7 +119,7 @@ AP_BattMonitor::BatteryFailsafe AP_BattMonitor_Backend::update_failsafes(void)
     }
 
     if (critical_capacity) {
-        return AP_BattMonitor::BatteryFailsafe_Critical;
+        return AP_BattMonitor::Failsafe::Critical;
     }
 
     if (low_voltage) {
@@ -128,7 +128,7 @@ AP_BattMonitor::BatteryFailsafe AP_BattMonitor_Backend::update_failsafes(void)
             _state.low_voltage_start_ms = now;
         } else if (_params._low_voltage_timeout > 0 &&
                    now - _state.low_voltage_start_ms > uint32_t(_params._low_voltage_timeout)*1000U) {
-            return AP_BattMonitor::BatteryFailsafe_Low;
+            return AP_BattMonitor::Failsafe::Low;
         }
     } else {
         // acceptable voltage so reset timer
@@ -136,11 +136,11 @@ AP_BattMonitor::BatteryFailsafe AP_BattMonitor_Backend::update_failsafes(void)
     }
 
     if (low_capacity) {
-        return AP_BattMonitor::BatteryFailsafe_Low;
+        return AP_BattMonitor::Failsafe::Low;
     }
 
     // if we've gotten this far then battery is ok
-    return AP_BattMonitor::BatteryFailsafe_None;
+    return AP_BattMonitor::Failsafe::None;
 }
 
 static bool update_check(size_t buflen, char *buffer, bool failed, const char *message)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -57,7 +57,7 @@ public:
     void update_resistance_estimate();
 
     // updates failsafe timers, and returns what failsafes are active
-    virtual AP_BattMonitor::BatteryFailsafe update_failsafes(void);
+    virtual AP_BattMonitor::Failsafe update_failsafes(void);
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     bool arming_checks(char * buffer, size_t buflen) const;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Generator.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Generator.cpp
@@ -143,9 +143,9 @@ void AP_BattMonitor_Generator_Elec::read()
     _state.last_time_micros = AP_HAL::micros();
 }
 
-AP_BattMonitor::BatteryFailsafe AP_BattMonitor_Generator_Elec::update_failsafes()
+AP_BattMonitor::Failsafe AP_BattMonitor_Generator_Elec::update_failsafes()
 {
-    AP_BattMonitor::BatteryFailsafe failsafe = AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_None;
+    AP_BattMonitor::Failsafe failsafe = AP_BattMonitor::Failsafe::None;
 
     AP_Generator *generator = AP::generator();
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Generator.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Generator.h
@@ -25,7 +25,7 @@ public:
     bool has_consumed_energy(void) const override;
 
     // Override backend update_failsafes.  No point in failsafing twice so generator failsafes are only updated from the electrical instance of the generator drivers
-    AP_BattMonitor::BatteryFailsafe update_failsafes() override;
+    AP_BattMonitor::Failsafe update_failsafes() override;
 };
 
 // Sub class for generator fuel

--- a/libraries/AP_Generator/AP_Generator.cpp
+++ b/libraries/AP_Generator/AP_Generator.cpp
@@ -120,11 +120,11 @@ bool AP_Generator::pre_arm_check(char* failmsg, uint8_t failmsg_len) const
 }
 
 // Tell backend check failsafes
-AP_BattMonitor::BatteryFailsafe AP_Generator::update_failsafes()
+AP_BattMonitor::Failsafe AP_Generator::update_failsafes()
 {
     // Don't invoke a failsafe if driver not assigned
     if (_driver_ptr == nullptr) {
-        return AP_BattMonitor::BatteryFailsafe_None;
+        return AP_BattMonitor::Failsafe::None;
     }
     return _driver_ptr->update_failsafes();
 }

--- a/libraries/AP_Generator/AP_Generator.h
+++ b/libraries/AP_Generator/AP_Generator.h
@@ -39,7 +39,7 @@ public:
 
     bool pre_arm_check(char *failmsg, uint8_t failmsg_len) const;
 
-    AP_BattMonitor::BatteryFailsafe update_failsafes(void);
+    AP_BattMonitor::Failsafe update_failsafes(void);
 
     // Helpers to retrieve measurements
     float get_voltage(void) const { return _voltage; }

--- a/libraries/AP_Generator/AP_Generator_Backend.h
+++ b/libraries/AP_Generator/AP_Generator_Backend.h
@@ -21,8 +21,8 @@ public:
     virtual bool pre_arm_check(char *failmsg, uint8_t failmsg_len) const { return true; }
 
     // Set default to not fail failsafes
-    virtual AP_BattMonitor::BatteryFailsafe update_failsafes(void) const {
-        return AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_None;
+    virtual AP_BattMonitor::Failsafe update_failsafes(void) const {
+        return AP_BattMonitor::Failsafe::None;
     }
 
     virtual bool healthy(void) const = 0;

--- a/libraries/AP_Generator/AP_Generator_IE_2400.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.cpp
@@ -120,19 +120,19 @@ void AP_Generator_IE_2400::decode_latest_term()
 }
 
 // Check for failsafes
-AP_BattMonitor::BatteryFailsafe AP_Generator_IE_2400::update_failsafes() const
+AP_BattMonitor::Failsafe AP_Generator_IE_2400::update_failsafes() const
 {
     // Check for error codes that lead to critical action battery monitor failsafe
     if (is_critical_error(_err_code)) {
-        return AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_Critical;
+        return AP_BattMonitor::Failsafe::Critical;
     }
 
     // Check for error codes that lead to low action battery monitor failsafe
     if (is_low_error(_err_code)) {
-        return AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_Low;
+        return AP_BattMonitor::Failsafe::Low;
     }
 
-    return AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_None;
+    return AP_BattMonitor::Failsafe::None;
 }
 
 // Check for error codes that are deemed critical

--- a/libraries/AP_Generator/AP_Generator_IE_2400.h
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.h
@@ -13,7 +13,7 @@ public:
 
     void init(void) override;
 
-    AP_BattMonitor::BatteryFailsafe update_failsafes() const override;
+    AP_BattMonitor::Failsafe update_failsafes() const override;
 
 private:
 

--- a/libraries/AP_Generator/AP_Generator_IE_650_800.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_650_800.cpp
@@ -107,19 +107,19 @@ bool AP_Generator_IE_650_800::check_for_err_code(char* msg_txt, uint8_t msg_len)
 }
 
 // Check for failsafes
-AP_BattMonitor::BatteryFailsafe AP_Generator_IE_650_800::update_failsafes() const
+AP_BattMonitor::Failsafe AP_Generator_IE_650_800::update_failsafes() const
 {
     // Check if we are in a critical failsafe
     if ((_err_code & fs_crit_mask) != 0) {
-        return  AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_Critical;
+        return  AP_BattMonitor::Failsafe::Critical;
     }
 
     // Check if we are in a low failsafe
     if ((_err_code & fs_low_mask) != 0) {
-        return  AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_Low;
+        return  AP_BattMonitor::Failsafe::Low;
     }
 
-    return AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_None;
+    return AP_BattMonitor::Failsafe::None;
 }
 
 #endif

--- a/libraries/AP_Generator/AP_Generator_IE_650_800.h
+++ b/libraries/AP_Generator/AP_Generator_IE_650_800.h
@@ -13,7 +13,7 @@ public:
 
     void init(void) override;
 
-    AP_BattMonitor::BatteryFailsafe update_failsafes() const override;
+    AP_BattMonitor::Failsafe update_failsafes() const override;
 
 private:
 


### PR DESCRIPTION
Because `AP_BattMonitor::BatteryFailsafe::BatteryFailsafe_None` is... yeah.
