### PR TITLE
GCS_MAVLink: use MAV_SYS_STATUS_PREARM_CHECK

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -7,6 +7,8 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_GPS/AP_GPS.h>
+#include <AP_Arming/AP_Arming.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -190,6 +192,16 @@ void GCS::update_sensor_status_flags()
         }
         if (!fence->sys_status_failed()) {
             control_sensors_health |= MAV_SYS_STATUS_GEOFENCE;
+        }
+    }
+
+    // give GCS status of prearm checks. This is enabled if any arming checks are enabled.
+    // it is healthy if armed or checks are passing
+    control_sensors_present |= MAV_SYS_STATUS_PREARM_CHECK;
+    if (AP::arming().get_enabled_checks()) {
+        control_sensors_enabled |= MAV_SYS_STATUS_PREARM_CHECK;
+        if (hal.util->get_soft_armed() || AP_Notify::flags.pre_arm_check) {
+            control_sensors_health |= MAV_SYS_STATUS_PREARM_CHECK;
         }
     }
 


### PR DESCRIPTION
this allows GCS to continually display prearm check status.

This was originally part of #15227 . I moved it here to make it easier to review an merge.

4 Users at the forum requested this feature. I have been flying this commit for months now and it works fine on top of the Copter-4.0 branch