### PR TITLE
Sub: minor change to guided initialisatsion and autotest

### DIFF
--- a/ArduSub/control_guided.cpp
+++ b/ArduSub/control_guided.cpp
@@ -39,8 +39,7 @@ bool Sub::guided_init(bool ignore_checks)
     if (!position_ok() && !ignore_checks) {
         return false;
     }
-    // initialise yaw
-    set_auto_yaw_mode(get_default_auto_yaw_mode(false));
+
     // start in position control mode
     guided_pos_control_start();
     return true;
@@ -59,8 +58,7 @@ void Sub::guided_pos_control_start()
     // To-Do: set to current location if disarmed?
     // To-Do: set to stopping point altitude?
     Vector3f stopping_point;
-    stopping_point.z = inertial_nav.get_altitude();
-    wp_nav.get_wp_stopping_point_xy(stopping_point);
+    wp_nav.get_wp_stopping_point(stopping_point);
 
     // no need to check return status because terrain data is not used
     wp_nav.set_wp_destination(stopping_point, false);

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -288,7 +288,7 @@ class AutoTestSub(AutoTest):
 
         lat = 5
         lon = 5
-        alt = 10
+        alt = -10
 
         tstart = self.get_sim_time()
         while True:

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -290,29 +290,30 @@ class AutoTestSub(AutoTest):
         lon = 5
         alt = -10
 
+        # send a position-control command
+        self.mav.mav.set_position_target_global_int_send(
+            0, # timestamp
+            1, # target system_id
+            1, # target component id
+            mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+            0b1111111111111000, # mask specifying use-only-lat-lon-alt
+            lat, # lat
+            lon, # lon
+            alt, # alt
+            0, # vx
+            0, # vy
+            0, # vz
+            0, # afx
+            0, # afy
+            0, # afz
+            0, # yaw
+            0, # yawrate
+        )
+
         tstart = self.get_sim_time()
         while True:
             if self.get_sim_time_cached() - tstart > 200:
                 raise NotAchievedException("Did not move far enough")
-            # send a position-control command
-            self.mav.mav.set_position_target_global_int_send(
-                0, # timestamp
-                1, # target system_id
-                1, # target component id
-                mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
-                0b1111111111111000, # mask specifying use-only-lat-lon-alt
-                lat, # lat
-                lon, # lon
-                alt, # alt
-                0, # vx
-                0, # vy
-                0, # vz
-                0, # afx
-                0, # afy
-                0, # afz
-                0, # yaw
-                0, # yawrate
-            )
             pos = self.mav.recv_match(type='GLOBAL_POSITION_INT',
                                       blocking=True)
             delta = self.get_distance_int(startpos, pos)


### PR DESCRIPTION
This PR makes a few small changes to Sub's guided mode and associated autotest called test.Sub.SET_POSITION_TARGET_GLOBAL_INT.

- Guided mode's guided_init() method loses a redundant call to set_auto_yaw_mode().  The exact same line appears within the guided_pos_control_start() method which is called immediately after.
- Guided mode's guided_pos_control_start() uses AC_WPNav's 3D get_wp_stopping_point() method instead of getting the 3D stopping point using a combination of AC_WPNav's 2D get_wp_stopping_point_xy() and the current altitude.  This is a small change (hopefully an improvement) in behaviour because the vehicle will slow to a stop vertically instead of suddenly attempting to stop at the current altitude
- SET_POSITION_TARGET_GLOBAL_INT autotest is changed in two ways:
    - the target destination is only sent once instead of repeatedly.  This makes it consistent with the Copter autotest and resolves a problem for the upcoming s-curve PR because s-curves don't work when the destination is set very rapidly
    - the target destination's altitude is change from +10m (which a sub can never achieve) to -10m

This has been tested in SITL in the following ways:

- vehicle descends quickly in manual mode and is then changed to Guided.  Note "Before" overshoots and recovers while "After" uses a realistic stopping point and avoids the overshoot.
![before-after-stopping-point](https://user-images.githubusercontent.com/1498098/100176763-39c51200-2f14-11eb-9dd8-448b89aee948.png)

- modified autotest run and confirmed it is still working



