### PR TITLE
Copter, QuadPlane, Sub: navigation using s-curves

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -76,6 +76,10 @@ void Copter::Log_Write_Attitude()
         logger.Write_PID(LOG_PIDP_MSG, attitude_control->get_rate_pitch_pid().get_pid_info());
         logger.Write_PID(LOG_PIDY_MSG, attitude_control->get_rate_yaw_pid().get_pid_info());
         logger.Write_PID(LOG_PIDA_MSG, pos_control->get_accel_z_pid().get_pid_info() );
+        if (should_log(MASK_LOG_NTUN) && (flightmode->requires_GPS() || landing_with_GPS())) {
+            logger.Write_PID(LOG_PIDN_MSG, pos_control->get_vel_xy_pid().get_pid_info_x());
+            logger.Write_PID(LOG_PIDE_MSG, pos_control->get_vel_xy_pid().get_pid_info_y());
+        }
     }
 }
 

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -215,8 +215,21 @@ float Mode::AutoYaw::yaw()
 // messages (positive is clockwise, negative is counter clockwise)
 float Mode::AutoYaw::rate_cds() const
 {
-    if (_mode == AUTO_YAW_RATE) {
+    switch (_mode) {
+
+    case AUTO_YAW_HOLD:
+    case AUTO_YAW_ROI:
+    case AUTO_YAW_FIXED:
+    case AUTO_YAW_LOOK_AHEAD:
+    case AUTO_YAW_RESETTOARMEDYAW:
+    case AUTO_YAW_CIRCLE:
+        return 0.0f;
+
+    case AUTO_YAW_RATE:
         return _rate_cds;
+
+    case AUTO_YAW_LOOK_AT_NEXT_WP:
+        return copter.wp_nav->get_yaw_rate();
     }
 
     // return zero turn rate (this should never happen)

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -229,7 +229,7 @@ float Mode::AutoYaw::rate_cds() const
         return _rate_cds;
 
     case AUTO_YAW_LOOK_AT_NEXT_WP:
-        return copter.wp_nav->get_yaw_rate();
+        return copter.wp_nav->get_yaw_rate_cds();
     }
 
     // return zero turn rate (this should never happen)

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -91,7 +91,6 @@ enum AutoMode {
     Auto_RTL,
     Auto_CircleMoveToEdge,
     Auto_Circle,
-    Auto_Spline,
     Auto_NavGuided,
     Auto_Loiter,
     Auto_LoiterToAlt,

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -564,7 +564,7 @@ void Mode::land_run_vertical_control(bool pause_descent)
             const float precland_min_descent_speed = 10.0f;
 
             float max_descent_speed = abs(g.land_speed)*0.5f;
-            float land_slowdown = MAX(0.0f, pos_control->get_horizontal_error()*(max_descent_speed/precland_acceptable_error));
+            float land_slowdown = MAX(0.0f, pos_control->get_pos_error_xy()*(max_descent_speed/precland_acceptable_error));
             cmb_rate = MIN(-precland_min_descent_speed, -max_descent_speed+land_slowdown);
         }
 #endif

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -369,8 +369,6 @@ public:
     void land_start(const Vector3f& destination);
     void circle_movetoedge_start(const Location &circle_center, float radius_m);
     void circle_start();
-    void spline_start(const Vector3f& destination, bool stopped_at_start, AC_WPNav::spline_segment_end_type seg_end_type, const Vector3f& next_spline_destination);
-    void spline_start(const Location& destination, bool stopped_at_start, AC_WPNav::spline_segment_end_type seg_end_type, const Location& next_destination);
     void nav_guided_start();
 
     bool is_landing() const override;
@@ -419,7 +417,6 @@ private:
 
     void takeoff_run();
     void wp_run();
-    void spline_run();
     void land_run();
     void rtl_run();
     void circle_run();
@@ -427,7 +424,7 @@ private:
     void loiter_run();
     void loiter_to_alt_run();
 
-    Location loc_from_cmd(const AP_Mission::Mission_Command& cmd) const;
+    Location loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc) const;
 
     void payload_place_start(const Vector3f& destination);
     void payload_place_run();
@@ -442,12 +439,14 @@ private:
 
     void do_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_nav_wp(const AP_Mission::Mission_Command& cmd);
+    bool set_next_wp(const AP_Mission::Mission_Command& current_cmd, const Location &default_loc);
     void do_land(const AP_Mission::Mission_Command& cmd);
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
     void do_circle(const AP_Mission::Mission_Command& cmd);
     void do_loiter_time(const AP_Mission::Mission_Command& cmd);
     void do_loiter_to_alt(const AP_Mission::Mission_Command& cmd);
     void do_spline_wp(const AP_Mission::Mission_Command& cmd);
+    void get_spline_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc, Location& dest_loc, Location& next_dest_loc, bool& next_dest_loc_is_spline);
 #if NAV_GUIDED == ENABLED
     void do_nav_guided_enable(const AP_Mission::Mission_Command& cmd);
     void do_guided_limits(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -415,6 +415,8 @@ private:
     bool verify_command(const AP_Mission::Mission_Command& cmd);
     void exit_mission();
 
+    bool check_for_mission_change();    // detect external changes to mission
+
     void takeoff_run();
     void wp_run();
     void land_run();
@@ -524,6 +526,15 @@ private:
     } nav_payload_place;
 
     bool waiting_to_start;  // true if waiting for vehicle to be armed or EKF origin before starting mission
+
+    // variables to detect mission changes
+    static const uint8_t mis_change_detect_cmd_max = 3;
+    struct {
+        uint32_t last_change_time_ms;       // local copy of last time mission was changed
+        uint16_t curr_cmd_index;            // local copy of AP_Mission's current command index
+        uint8_t cmd_count;                  // number of commands in the cmd array
+        AP_Mission::Mission_Command cmd[mis_change_detect_cmd_max]; // local copy of the next few mission commands
+    } mis_change_detect = {};
 };
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -93,10 +93,6 @@ void ModeAuto::run()
         circle_run();
         break;
 
-    case Auto_Spline:
-        spline_run();
-        break;
-
     case Auto_NavGuided:
 #if NAV_GUIDED == ENABLED
         nav_guided_run();
@@ -190,7 +186,7 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
     }
 
     // set waypoint controller target
-    if (!wp_nav->set_wp_destination(dest)) {
+    if (!wp_nav->set_wp_destination_loc(dest)) {
         // failure to set destination can only be because of missing terrain data
         copter.failsafe_terrain_on_event();
         return;
@@ -212,7 +208,7 @@ void ModeAuto::wp_start(const Location& dest_loc)
     _mode = Auto_WP;
 
     // send target to waypoint controller
-    if (!wp_nav->set_wp_destination(dest_loc)) {
+    if (!wp_nav->set_wp_destination_loc(dest_loc)) {
         // failure to set destination can only be because of missing terrain data
         copter.failsafe_terrain_on_event();
         return;
@@ -293,7 +289,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
         circle_edge.set_alt_cm(circle_center.alt, circle_center.get_alt_frame());
 
         // initialise wpnav to move to edge of circle
-        if (!wp_nav->set_wp_destination(circle_edge)) {
+        if (!wp_nav->set_wp_destination_loc(circle_edge)) {
             // failure to set destination can only be because of missing terrain data
             copter.failsafe_terrain_on_event();
         }
@@ -328,28 +324,6 @@ void ModeAuto::circle_start()
 
     if (auto_yaw.mode() != AUTO_YAW_ROI) {
         auto_yaw.set_mode(AUTO_YAW_CIRCLE);
-    }
-}
-
-// auto_spline_start - initialises waypoint controller to implement flying to a particular destination using the spline controller
-//  seg_end_type can be SEGMENT_END_STOP, SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE.  If Straight or Spline the next_destination should be provided
-void ModeAuto::spline_start(const Location& destination, bool stopped_at_start,
-                               AC_WPNav::spline_segment_end_type seg_end_type, 
-                               const Location& next_destination)
-{
-    _mode = Auto_Spline;
-
-    // initialise wpnav
-    if (!wp_nav->set_spline_destination(destination, stopped_at_start, seg_end_type, next_destination)) {
-        // failure to set destination can only be because of missing terrain data
-        copter.failsafe_terrain_on_event();
-        return;
-    }
-
-    // initialise yaw
-    // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-    if (auto_yaw.mode() != AUTO_YAW_ROI) {
-        auto_yaw.set_mode_to_default(false);
     }
 }
 
@@ -782,47 +756,7 @@ void ModeAuto::wp_run()
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
     } else {
         // roll, pitch from waypoint controller, yaw heading from auto_heading()
-        attitude_control->input_euler_angle_roll_pitch_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.yaw(), true);
-    }
-}
-
-// auto_spline_run - runs the auto spline controller
-//      called by auto_run at 100hz or more
-void ModeAuto::spline_run()
-{
-    // if not armed set throttle to zero and exit immediately
-    if (is_disarmed_or_landed()) {
-        make_safe_spool_down();
-        wp_nav->wp_and_spline_init();
-        return;
-    }
-
-    // process pilot's yaw input
-    float target_yaw_rate = 0;
-    if (!copter.failsafe.radio && use_pilot_yaw()) {
-        // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
-        if (!is_zero(target_yaw_rate)) {
-            auto_yaw.set_mode(AUTO_YAW_HOLD);
-        }
-    }
-
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-
-    // run waypoint controller
-    wp_nav->update_spline();
-
-    // call z-axis position controller (wpnav should have already updated it's alt target)
-    pos_control->update_z_controller();
-
-    // call attitude controller
-    if (auto_yaw.mode() == AUTO_YAW_HOLD) {
-        // roll & pitch from waypoint controller, yaw rate from pilot
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
-    } else {
-        // roll, pitch from waypoint controller, yaw heading from auto_heading()
-        attitude_control->input_euler_angle_roll_pitch_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.yaw(), true);
+        attitude_control->input_euler_angle_roll_pitch_yaw_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), auto_yaw.yaw(), auto_yaw.rate_cds());
     }
 }
 
@@ -1096,25 +1030,25 @@ void ModeAuto::do_takeoff(const AP_Mission::Mission_Command& cmd)
     takeoff_start(cmd.content.location);
 }
 
-Location ModeAuto::loc_from_cmd(const AP_Mission::Mission_Command& cmd) const
+Location ModeAuto::loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc) const
 {
     Location ret(cmd.content.location);
 
     // use current lat, lon if zero
     if (ret.lat == 0 && ret.lng == 0) {
-        ret.lat = copter.current_loc.lat;
-        ret.lng = copter.current_loc.lng;
+        ret.lat = default_loc.lat;
+        ret.lng = default_loc.lng;
     }
     // use current altitude if not provided
     if (ret.alt == 0) {
-        // set to current altitude but in command's alt frame
-        int32_t curr_alt;
-        if (copter.current_loc.get_alt_cm(ret.get_alt_frame(),curr_alt)) {
-            ret.set_alt_cm(curr_alt, ret.get_alt_frame());
+        // set to default_loc's altitude but in command's alt frame
+        // note that this may use the terrain database
+        int32_t default_alt;
+        if (default_loc.get_alt_cm(ret.get_alt_frame(), default_alt)) {
+            ret.set_alt_cm(default_alt, ret.get_alt_frame());
         } else {
-            // default to current altitude as alt-above-home
-            ret.set_alt_cm(copter.current_loc.alt,
-                           copter.current_loc.get_alt_frame());
+            // default to default_loc's altitude and frame
+            ret.set_alt_cm(default_loc.alt, default_loc.get_alt_frame());
         }
     }
     return ret;
@@ -1123,46 +1057,90 @@ Location ModeAuto::loc_from_cmd(const AP_Mission::Mission_Command& cmd) const
 // do_nav_wp - initiate move to next waypoint
 void ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
 {
-    Location target_loc = loc_from_cmd(cmd);
+    // calculate default location used when lat, lon or alt is zero
+    Location default_loc = copter.current_loc;
+    if (wp_nav->is_active() && wp_nav->reached_wp_destination()) {
+        if (!wp_nav->get_wp_destination_loc(default_loc)) {
+            // this should never happen
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+        }
+    }
+
+    // get waypoint's location from command and send to wp_nav
+    const Location dest_loc = loc_from_cmd(cmd, default_loc);
+    if (!wp_nav->set_wp_destination_loc(dest_loc)) {
+        // failure to set destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
+        return;
+    }
+
+    _mode = Auto_WP;
 
     // this will be used to remember the time in millis after we reach or pass the WP.
     loiter_time = 0;
     // this is the delay, stored in seconds
     loiter_time_max = cmd.p1;
 
-    // Set wp navigation target
-    wp_start(target_loc);
-
-    // if no delay as well as not final waypoint set the waypoint as "fast"
-    AP_Mission::Mission_Command temp_cmd;
-    bool fast_waypoint = false;
-    if (loiter_time_max == 0 && mission.get_next_nav_cmd(cmd.index+1, temp_cmd)) {
-
-        // whether vehicle should stop at the target position depends upon the next command
-        switch (temp_cmd.id) {
-            case MAV_CMD_NAV_WAYPOINT:
-            case MAV_CMD_NAV_LOITER_UNLIM:
-            case MAV_CMD_NAV_LOITER_TURNS:
-            case MAV_CMD_NAV_LOITER_TIME:
-            case MAV_CMD_NAV_LAND:
-            case MAV_CMD_NAV_SPLINE_WAYPOINT:
-                // if next command's lat, lon is specified then do not slowdown at this waypoint
-                if ((temp_cmd.content.location.lat != 0) || (temp_cmd.content.location.lng != 0)) {
-                    fast_waypoint = true;
-                }
-                break;
-            case MAV_CMD_NAV_RETURN_TO_LAUNCH:
-                // do not stop for RTL
-                fast_waypoint = true;
-                break;
-            case MAV_CMD_NAV_TAKEOFF:
-            default:
-                // always stop for takeoff commands
-                // for unsupported commands it is safer to stop
-                break;
-        }
-        copter.wp_nav->set_fast_waypoint(fast_waypoint);
+    // set next destination if necessary
+    if (!set_next_wp(cmd, dest_loc)) {
+        // failure to set next destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
+        return;
     }
+
+    // initialise yaw
+    // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
+    if (auto_yaw.mode() != AUTO_YAW_ROI) {
+        auto_yaw.set_mode_to_default(false);
+    }
+}
+
+// checks the next mission command and adds it as a destination if necessary
+// supports both straight line and spline waypoints
+// cmd should be the current command
+// default_loc should be the destination from the current_cmd but corrected for cases where user set lat, lon or alt to zero
+// returns true on success, false on failure which should only happen due to a failure to retrieve terrain data
+bool ModeAuto::set_next_wp(const AP_Mission::Mission_Command& current_cmd, const Location &default_loc)
+{
+    // do not add next wp if current command has a delay meaning the vehicle will stop at the destination
+    if (current_cmd.p1 > 0) {
+        return true;
+    }
+
+    // do not add next wp if there are no more navigation commands
+    AP_Mission::Mission_Command next_cmd;
+    if (!mission.get_next_nav_cmd(current_cmd.index+1, next_cmd)) {
+        return true;
+    }
+
+    // whether vehicle should stop at the target position depends upon the next command
+    switch (next_cmd.id) {
+    case MAV_CMD_NAV_WAYPOINT:
+    case MAV_CMD_NAV_LOITER_UNLIM:
+    case MAV_CMD_NAV_LOITER_TURNS:
+    case MAV_CMD_NAV_LOITER_TIME: {
+        const Location dest_loc = loc_from_cmd(current_cmd, default_loc);
+        const Location next_dest_loc = loc_from_cmd(next_cmd, dest_loc);
+        return wp_nav->set_wp_destination_next_loc(next_dest_loc);
+    }
+    case MAV_CMD_NAV_SPLINE_WAYPOINT: {
+        // get spline's location and next location from command and send to wp_nav
+        Location next_dest_loc, next_next_dest_loc;
+        bool next_next_dest_loc_is_spline;
+        get_spline_from_cmd(next_cmd, default_loc, next_dest_loc, next_next_dest_loc, next_next_dest_loc_is_spline);
+        return wp_nav->set_spline_destination_next_loc(next_dest_loc, next_next_dest_loc, next_next_dest_loc_is_spline);
+    }
+    case MAV_CMD_NAV_LAND:
+        // stop because we may change between rel,abs and terrain alt types
+    case MAV_CMD_NAV_RETURN_TO_LAUNCH:
+    case MAV_CMD_NAV_TAKEOFF:
+        // always stop for RTL and takeoff commands
+    default:
+        // for unsupported commands it is safer to stop
+        break;
+    }
+
+    return true;
 }
 
 // do_land - initiate landing procedure
@@ -1225,7 +1203,7 @@ void ModeAuto::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
 // do_circle - initiate moving in a circle
 void ModeAuto::do_circle(const AP_Mission::Mission_Command& cmd)
 {
-    const Location circle_center = loc_from_cmd(cmd);
+    const Location circle_center = loc_from_cmd(cmd, copter.current_loc);
 
     // calculate radius
     uint8_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
@@ -1276,67 +1254,65 @@ void ModeAuto::do_loiter_to_alt(const AP_Mission::Mission_Command& cmd)
     pos_control->set_max_accel_z(wp_nav->get_accel_z());
     pos_control->set_max_speed_z(wp_nav->get_default_speed_down(),
                                  wp_nav->get_default_speed_up());
-
-    if (pos_control->is_active_z()) {
-        pos_control->freeze_ff_z();
-    }
 }
 
-// do_spline_wp - initiate move to next waypoint
+// do_nav_wp - initiate move to next waypoint
 void ModeAuto::do_spline_wp(const AP_Mission::Mission_Command& cmd)
 {
-    const Location target_loc = loc_from_cmd(cmd);
+    // calculate default location used when lat, lon or alt is zero
+    Location default_loc = copter.current_loc;
+    if (wp_nav->is_active() && wp_nav->reached_wp_destination()) {
+        if (!wp_nav->get_wp_destination_loc(default_loc)) {
+            // this should never happen
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+        }
+    }
+
+    // get spline's location and next location from command and send to wp_nav
+    Location dest_loc, next_dest_loc;
+    bool next_dest_loc_is_spline;
+    get_spline_from_cmd(cmd, default_loc, dest_loc, next_dest_loc, next_dest_loc_is_spline);
+    if (!wp_nav->set_spline_destination_loc(dest_loc, next_dest_loc, next_dest_loc_is_spline)) {
+        // failure to set destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
+        return;
+    }
+
+    _mode = Auto_WP;
 
     // this will be used to remember the time in millis after we reach or pass the WP.
     loiter_time = 0;
     // this is the delay, stored in seconds
     loiter_time_max = cmd.p1;
 
-    // determine segment start and end type
-    bool stopped_at_start = true;
-    AC_WPNav::spline_segment_end_type seg_end_type = AC_WPNav::SEGMENT_END_STOP;
-    AP_Mission::Mission_Command temp_cmd;
-
-    // if previous command was a wp_nav command with no delay set stopped_at_start to false
-    // To-Do: move processing of delay into wp-nav controller to allow it to determine the stopped_at_start value itself?
-    uint16_t prev_cmd_idx = mission.get_prev_nav_cmd_index();
-    if (prev_cmd_idx != AP_MISSION_CMD_INDEX_NONE) {
-        if (mission.read_cmd_from_storage(prev_cmd_idx, temp_cmd)) {
-            if ((temp_cmd.id == MAV_CMD_NAV_WAYPOINT || temp_cmd.id == MAV_CMD_NAV_SPLINE_WAYPOINT) && temp_cmd.p1 == 0) {
-                stopped_at_start = false;
-            }
-        }
+    // set next destination if necessary
+    if (!set_next_wp(cmd, dest_loc)) {
+        // failure to set next destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
+        return;
     }
+
+    // initialise yaw
+    // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
+    if (auto_yaw.mode() != AUTO_YAW_ROI) {
+        auto_yaw.set_mode_to_default(false);
+    }
+}
+
+// get_spline_from_cmd - Calculates the spline type for a given spline waypoint mission command
+void ModeAuto::get_spline_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc, Location& dest_loc, Location& next_dest_loc, bool& next_dest_loc_is_spline)
+{
+    dest_loc = loc_from_cmd(cmd, default_loc);
 
     // if there is no delay at the end of this segment get next nav command
-    Location next_loc;
+    AP_Mission::Mission_Command temp_cmd;
     if (cmd.p1 == 0 && mission.get_next_nav_cmd(cmd.index+1, temp_cmd)) {
-        next_loc = temp_cmd.content.location;
-        // default lat, lon to first waypoint's lat, lon
-        if (next_loc.lat == 0 && next_loc.lng == 0) {
-            next_loc.lat = target_loc.lat;
-            next_loc.lng = target_loc.lng;
-        }
-        // default alt to first waypoint's alt but in next waypoint's alt frame
-        if (next_loc.alt == 0) {
-            int32_t next_alt;
-            if (target_loc.get_alt_cm(next_loc.get_alt_frame(), next_alt)) {
-                next_loc.set_alt_cm(next_alt, next_loc.get_alt_frame());
-            } else {
-                // default to first waypoints altitude
-                next_loc.set_alt_cm(target_loc.alt, target_loc.get_alt_frame());
-            }
-        }
-        // if the next nav command is a waypoint set end type to spline or straight
-        if (temp_cmd.id == MAV_CMD_NAV_WAYPOINT) {
-            seg_end_type = AC_WPNav::SEGMENT_END_STRAIGHT;
-        } else if (temp_cmd.id == MAV_CMD_NAV_SPLINE_WAYPOINT) {
-            seg_end_type = AC_WPNav::SEGMENT_END_SPLINE;
-        }
+        next_dest_loc = loc_from_cmd(temp_cmd, dest_loc);
+        next_dest_loc_is_spline = temp_cmd.id == MAV_CMD_NAV_SPLINE_WAYPOINT;
+    } else {
+        next_dest_loc = dest_loc;
+        next_dest_loc_is_spline = false;
     }
-
-    // set spline navigation target
-    spline_start(target_loc, stopped_at_start, seg_end_type, next_loc);
 }
 
 #if NAV_GUIDED == ENABLED

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -205,14 +205,14 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
 // auto_wp_start - initialises waypoint controller to implement flying to a particular destination
 void ModeAuto::wp_start(const Location& dest_loc)
 {
-    _mode = Auto_WP;
-
     // send target to waypoint controller
     if (!wp_nav->set_wp_destination_loc(dest_loc)) {
         // failure to set destination can only be because of missing terrain data
         copter.failsafe_terrain_on_event();
         return;
     }
+
+    _mode = Auto_WP;
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -789,7 +789,7 @@ uint32_t ModeGuided::wp_distance() const
         return wp_nav->get_wp_distance_to_destination();
         break;
     case Guided_PosVel:
-        return pos_control->get_distance_to_target();
+        return pos_control->get_pos_error_xy();
         break;
     default:
         return 0;

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -116,7 +116,7 @@ bool ModeGuided::do_user_takeoff_start(float takeoff_alt_cm)
     }
     target_loc.set_alt_cm(takeoff_alt_cm, frame);
 
-    if (!wp_nav->set_wp_destination(target_loc)) {
+    if (!wp_nav->set_wp_destination_loc(target_loc)) {
         // failure to set destination can only be because of missing terrain data
         AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         // failure is propagated to GCS with NAK
@@ -296,7 +296,7 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
         pos_control_start();
     }
 
-    if (!wp_nav->set_wp_destination(dest_loc)) {
+    if (!wp_nav->set_wp_destination_loc(dest_loc)) {
         // failure to set destination can only be because of missing terrain data
         AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         // failure is propagated to GCS with NAK

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -18,7 +18,7 @@ bool ModeRTL::init(bool ignore_checks)
         }
     }
     // initialise waypoint and spline controller
-    wp_nav->wp_and_spline_init();
+    wp_nav->wp_and_spline_init(g.rtl_speed_cms);
     _state = RTL_Starting;
     _state_complete = true; // see run() method below
     terrain_following_allowed = !copter.failsafe.terrain;
@@ -116,11 +116,6 @@ void ModeRTL::climb_start()
 {
     _state = RTL_InitialClimb;
     _state_complete = false;
-
-    // RTL_SPEED == 0 means use WPNAV_SPEED
-    if (g.rtl_speed_cms != 0) {
-        wp_nav->set_speed_xy(g.rtl_speed_cms);
-    }
 
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -123,14 +123,13 @@ void ModeRTL::climb_start()
     }
 
     // set the destination
-    if (!wp_nav->set_wp_destination(rtl_path.climb_target)) {
+    if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
         // this should not happen because rtl_build_path will have checked terrain data was available
         gcs().send_text(MAV_SEVERITY_CRITICAL,"RTL: unexpected error setting climb target");
         AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         copter.set_mode(Mode::Number::LAND, ModeReason::TERRAIN_FAILSAFE);
         return;
     }
-    wp_nav->set_fast_waypoint(true);
 
     // hold current yaw during initial climb
     auto_yaw.set_mode(AUTO_YAW_HOLD);
@@ -142,7 +141,7 @@ void ModeRTL::return_start()
     _state = RTL_ReturnHome;
     _state_complete = false;
 
-    if (!wp_nav->set_wp_destination(rtl_path.return_target)) {
+    if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
         // failure must be caused by missing terrain data, restart RTL
         restart_without_terrain();
     }

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -107,6 +107,10 @@ void ModeSmartRTL::path_follow_run()
                 Vector3f next_dest_NED;
                 if (g2.smart_rtl.peek_point(next_dest_NED)) {
                     wp_nav->set_wp_destination_NED(dest_NED);
+                    if (g2.smart_rtl.get_num_points() == 1) {
+                        // this is the very last point, add 2m to the target alt
+                        next_dest_NED.z -= 2.0f;
+                    }
                     wp_nav->set_wp_destination_next_NED(next_dest_NED);
                 } else {
                     // this should never happen but send next point anyway

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -103,7 +103,7 @@ void ModeSmartRTL::path_follow_run()
                 smart_rtl_state = SmartRTL_PreLandPosition;
                 wp_nav->set_wp_destination_NED(dest_NED);
             } else {
-                // peek at the next point
+                // peek at the next point.  this can fail if the IO task currently has the path semaphore
                 Vector3f next_dest_NED;
                 if (g2.smart_rtl.peek_point(next_dest_NED)) {
                     wp_nav->set_wp_destination_NED(dest_NED);
@@ -113,7 +113,8 @@ void ModeSmartRTL::path_follow_run()
                     }
                     wp_nav->set_wp_destination_next_NED(next_dest_NED);
                 } else {
-                    // this should never happen but send next point anyway
+                    // this can only happen if peek failed to take the semaphore
+                    // send next point anyway which will cause the vehicle to slow at the next point
                     wp_nav->set_wp_destination_NED(dest_NED);
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                 }

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -97,16 +97,21 @@ void ModeSmartRTL::path_follow_run()
         // path semaphore.
         if (g2.smart_rtl.pop_point(next_point)) {
             path_follow_last_pop_fail_ms = 0;
-            bool fast_waypoint = true;
             if (g2.smart_rtl.get_num_points() == 0) {
                 // this is the very last point, add 2m to the target alt and move to pre-land state
                 next_point.z -= 2.0f;
                 smart_rtl_state = SmartRTL_PreLandPosition;
-                fast_waypoint = false;
+                wp_nav->set_wp_destination_NED(next_point);
+            } else {
+                // peek at the next point
+                Vector3f next_next_point;
+                if (g2.smart_rtl.peek_point(next_next_point)) {
+                    wp_nav->set_wp_destination_NED(next_point, next_next_point);
+                } else {
+                    // this should never happen but send next point anyway
+                    wp_nav->set_wp_destination_NED(next_point);
+                }
             }
-            // send target to waypoint controller
-            wp_nav->set_wp_destination_NED(next_point);
-            wp_nav->set_fast_waypoint(fast_waypoint);
         } else if (g2.smart_rtl.get_num_points() == 0) {
             // We should never get here; should always have at least
             // two points and the "zero points left" is handled above.

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -288,6 +288,6 @@ bool ModeThrow::throw_height_good()
 bool ModeThrow::throw_position_good()
 {
     // check that our horizontal position error is within 50cm
-    return (pos_control->get_horizontal_error() < 50.0f);
+    return (pos_control->get_pos_error_xy() < 50.0f);
 }
 #endif

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -72,7 +72,7 @@ void Copter::tuning()
         break;
 
     case TUNING_THROTTLE_RATE_KP:
-        pos_control->get_vel_z_p().kP(tuning_value);
+        pos_control->get_vel_z_pid().kP(tuning_value);
         break;
 
     case TUNING_ACCEL_Z_KP:

--- a/ArduPlane/tuning.cpp
+++ b/ArduPlane/tuning.cpp
@@ -155,7 +155,7 @@ AP_Float *AP_Tuning_Plane::get_param_pointer(uint8_t parm)
         return &plane.quadplane.pos_control->get_vel_xy_pid().kI();
 
     case TUNING_VZ_P:
-        return &plane.quadplane.pos_control->get_vel_z_p().kP();
+        return &plane.quadplane.pos_control->get_vel_z_pid().kP();
 
     case TUNING_AZ_P:
         return &plane.quadplane.pos_control->get_accel_z_pid().kP();

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -463,7 +463,6 @@ private:
     void auto_wp_start(const Vector3f& destination);
     void auto_wp_start(const Location& dest_loc);
     void auto_wp_run();
-    void auto_spline_run();
     void auto_circle_movetoedge_start(const Location &circle_center, float radius_m);
     void auto_circle_start();
     void auto_circle_run();
@@ -577,7 +576,6 @@ private:
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
     void do_circle(const AP_Mission::Mission_Command& cmd);
     void do_loiter_time(const AP_Mission::Mission_Command& cmd);
-    void do_spline_wp(const AP_Mission::Mission_Command& cmd);
 #if NAV_GUIDED == ENABLED
     void do_nav_guided_enable(const AP_Mission::Mission_Command& cmd);
     void do_guided_limits(const AP_Mission::Mission_Command& cmd);
@@ -595,13 +593,11 @@ private:
     bool verify_surface(const AP_Mission::Mission_Command& cmd);
     bool verify_RTL(void);
     bool verify_circle(const AP_Mission::Mission_Command& cmd);
-    bool verify_spline_wp(const AP_Mission::Mission_Command& cmd);
 #if NAV_GUIDED == ENABLED
     bool verify_nav_guided_enable(const AP_Mission::Mission_Command& cmd);
 #endif
     bool verify_nav_delay(const AP_Mission::Mission_Command& cmd);
 
-    void auto_spline_start(const Location& destination, bool stopped_at_start, AC_WPNav::spline_segment_end_type seg_end_type, const Location& next_destination);
     void log_init(void);
     void accel_cal_update(void);
     void read_airspeed();

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -55,10 +55,6 @@ bool Sub::start_command(const AP_Mission::Mission_Command& cmd)
         do_loiter_time(cmd);
         break;
 
-    case MAV_CMD_NAV_SPLINE_WAYPOINT:           // 82  Navigate to Waypoint using spline
-        do_spline_wp(cmd);
-        break;
-
 #if NAV_GUIDED == ENABLED
     case MAV_CMD_NAV_GUIDED_ENABLE:             // 92  accept navigation commands from external nav computer
         do_nav_guided_enable(cmd);
@@ -167,9 +163,6 @@ bool Sub::verify_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_NAV_LOITER_TIME:
         return verify_loiter_time();
 
-    case MAV_CMD_NAV_SPLINE_WAYPOINT:
-        return verify_spline_wp(cmd);
-
 #if NAV_GUIDED == ENABLED
     case MAV_CMD_NAV_GUIDED_ENABLE:
         return verify_nav_guided_enable(cmd);
@@ -252,11 +245,6 @@ void Sub::do_nav_wp(const AP_Mission::Mission_Command& cmd)
 
     // Set wp navigation target
     auto_wp_start(target_loc);
-
-    // if no delay set the waypoint as "fast"
-    if (loiter_time_max == 0) {
-        wp_nav.set_fast_waypoint(true);
-    }
 }
 
 // do_surface - initiate surface procedure
@@ -383,79 +371,6 @@ void Sub::do_loiter_time(const AP_Mission::Mission_Command& cmd)
     loiter_time_max = cmd.p1;     // units are (seconds)
 }
 
-// do_spline_wp - initiate move to next waypoint
-void Sub::do_spline_wp(const AP_Mission::Mission_Command& cmd)
-{
-    Location target_loc(cmd.content.location);
-    // use current lat, lon if zero
-    if (target_loc.lat == 0 && target_loc.lng == 0) {
-        target_loc.lat = current_loc.lat;
-        target_loc.lng = current_loc.lng;
-    }
-    // use current altitude if not provided
-    if (target_loc.alt == 0) {
-        // set to current altitude but in command's alt frame
-        int32_t curr_alt;
-        if (current_loc.get_alt_cm(target_loc.get_alt_frame(),curr_alt)) {
-            target_loc.set_alt_cm(curr_alt, target_loc.get_alt_frame());
-        } else {
-            // default to current altitude as alt-above-home
-            target_loc.set_alt_cm(current_loc.alt, current_loc.get_alt_frame());
-        }
-    }
-
-    // this will be used to remember the time in millis after we reach or pass the WP.
-    loiter_time = 0;
-    // this is the delay, stored in seconds
-    loiter_time_max = cmd.p1;
-
-    // determine segment start and end type
-    bool stopped_at_start = true;
-    AC_WPNav::spline_segment_end_type seg_end_type = AC_WPNav::SEGMENT_END_STOP;
-    AP_Mission::Mission_Command temp_cmd;
-
-    // if previous command was a wp_nav command with no delay set stopped_at_start to false
-    // To-Do: move processing of delay into wp-nav controller to allow it to determine the stopped_at_start value itself?
-    uint16_t prev_cmd_idx = mission.get_prev_nav_cmd_index();
-    if (prev_cmd_idx != AP_MISSION_CMD_INDEX_NONE) {
-        if (mission.read_cmd_from_storage(prev_cmd_idx, temp_cmd)) {
-            if ((temp_cmd.id == MAV_CMD_NAV_WAYPOINT || temp_cmd.id == MAV_CMD_NAV_SPLINE_WAYPOINT) && temp_cmd.p1 == 0) {
-                stopped_at_start = false;
-            }
-        }
-    }
-
-    // if there is no delay at the end of this segment get next nav command
-    Location next_loc;
-    if (cmd.p1 == 0 && mission.get_next_nav_cmd(cmd.index+1, temp_cmd)) {
-        next_loc = temp_cmd.content.location;
-        // default lat, lon to first waypoint's lat, lon
-        if (next_loc.lat == 0 && next_loc.lng == 0) {
-            next_loc.lat = target_loc.lat;
-            next_loc.lng = target_loc.lng;
-        }
-        // default alt to first waypoint's alt but in next waypoint's alt frame
-        if (next_loc.alt == 0) {
-            int32_t next_alt;
-            if (target_loc.get_alt_cm(next_loc.get_alt_frame(), next_alt)) {
-                next_loc.set_alt_cm(next_alt, next_loc.get_alt_frame());
-            } else {
-                // default to first waypoints altitude
-                next_loc.set_alt_cm(target_loc.alt, target_loc.get_alt_frame());
-            }
-        }
-        // if the next nav command is a waypoint set end type to spline or straight
-        if (temp_cmd.id == MAV_CMD_NAV_WAYPOINT) {
-            seg_end_type = AC_WPNav::SEGMENT_END_STRAIGHT;
-        } else if (temp_cmd.id == MAV_CMD_NAV_SPLINE_WAYPOINT) {
-            seg_end_type = AC_WPNav::SEGMENT_END_SPLINE;
-        }
-    }
-
-    // set spline navigation target
-    auto_spline_start(target_loc, stopped_at_start, seg_end_type, next_loc);
-}
-
 #if NAV_GUIDED == ENABLED
 // do_nav_guided_enable - initiate accepting commands from external nav computer
 void Sub::do_nav_guided_enable(const AP_Mission::Mission_Command& cmd)
@@ -464,7 +379,7 @@ void Sub::do_nav_guided_enable(const AP_Mission::Mission_Command& cmd)
         // initialise guided limits
         guided_limit_init_time_and_pos();
 
-        // set spline navigation target
+        // set navigation target
         auto_nav_guided_start();
     }
 }
@@ -616,28 +531,6 @@ bool Sub::verify_circle(const AP_Mission::Mission_Command& cmd)
 
     // check if we have completed circling
     return fabsf(circle_nav.get_angle_total()/M_2PI) >= LOWBYTE(cmd.p1);
-}
-
-// verify_spline_wp - check if we have reached the next way point using spline
-bool Sub::verify_spline_wp(const AP_Mission::Mission_Command& cmd)
-{
-    // check if we have reached the waypoint
-    if (!wp_nav.reached_wp_destination()) {
-        return false;
-    }
-
-    // start timer if necessary
-    if (loiter_time == 0) {
-        loiter_time = AP_HAL::millis();
-    }
-
-    // check if timer has run out
-    if (((AP_HAL::millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
-        return true;
-    }
-
-    return false;
 }
 
 #if NAV_GUIDED == ENABLED

--- a/ArduSub/control_auto.cpp
+++ b/ArduSub/control_auto.cpp
@@ -23,7 +23,7 @@ bool Sub::auto_init()
         set_auto_yaw_mode(AUTO_YAW_HOLD);
     }
 
-    // initialise waypoint and spline controller
+    // initialise waypoint controller
     wp_nav.wp_and_spline_init();
 
     // clear guided limits
@@ -51,10 +51,6 @@ void Sub::auto_run()
 
     case Auto_Circle:
         auto_circle_run();
-        break;
-
-    case Auto_Spline:
-        auto_spline_run();
         break;
 
     case Auto_NavGuided:
@@ -94,7 +90,7 @@ void Sub::auto_wp_start(const Location& dest_loc)
     auto_mode = Auto_WP;
 
     // send target to waypoint controller
-    if (!wp_nav.set_wp_destination(dest_loc)) {
+    if (!wp_nav.set_wp_destination_loc(dest_loc)) {
         // failure to set destination can only be because of missing terrain data
         failsafe_terrain_on_event();
         return;
@@ -172,83 +168,6 @@ void Sub::auto_wp_run()
     }
 }
 
-// auto_spline_start - initialises waypoint controller to implement flying to a particular destination using the spline controller
-//  seg_end_type can be SEGMENT_END_STOP, SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE.  If Straight or Spline the next_destination should be provided
-void Sub::auto_spline_start(const Location& destination, bool stopped_at_start,
-                            AC_WPNav::spline_segment_end_type seg_end_type,
-                            const Location& next_destination)
-{
-    auto_mode = Auto_Spline;
-
-    // initialise wpnav
-    if (!wp_nav.set_spline_destination(destination, stopped_at_start, seg_end_type, next_destination)) {
-        // failure to set destination can only be because of missing terrain data
-        failsafe_terrain_on_event();
-        return;
-    }
-
-    // initialise yaw
-    // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-    if (auto_yaw_mode != AUTO_YAW_ROI) {
-        set_auto_yaw_mode(get_default_auto_yaw_mode(false));
-    }
-}
-
-// auto_spline_run - runs the auto spline controller
-//      called by auto_run at 100hz or more
-void Sub::auto_spline_run()
-{
-    // if not armed set throttle to zero and exit immediately
-    if (!motors.armed()) {
-        // To-Do: reset waypoint origin to current location because vehicle is probably on the ground so we don't want it lurching left or right on take-off
-        //    (of course it would be better if people just used take-off)
-        // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
-        return;
-    }
-
-    // process pilot's yaw input
-    float target_yaw_rate = 0;
-    if (!failsafe.pilot_input) {
-        // get pilot's desired yaw rat
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
-        if (!is_zero(target_yaw_rate)) {
-            set_auto_yaw_mode(AUTO_YAW_HOLD);
-        }
-    }
-
-    // set motors to full range
-    motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-
-    // run waypoint controller
-    wp_nav.update_spline();
-
-    float lateral_out, forward_out;
-    translate_wpnav_rp(lateral_out, forward_out);
-
-    // Send to forward/lateral outputs
-    motors.set_lateral(lateral_out);
-    motors.set_forward(forward_out);
-
-    // call z-axis position controller (wpnav should have already updated it's alt target)
-    pos_control.update_z_controller();
-
-    // get pilot desired lean angles
-    float target_roll, target_pitch;
-    get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
-
-    // call attitude controller
-    if (auto_yaw_mode == AUTO_YAW_HOLD) {
-        // roll & pitch from waypoint controller, yaw rate from pilot
-        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
-    } else {
-        // roll, pitch from waypoint controller, yaw heading from auto_heading()
-        attitude_control.input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, get_auto_heading(), true);
-    }
-}
-
 // auto_circle_movetoedge_start - initialise waypoint controller to move to edge of a circle with it's center at the specified location
 //  we assume the caller has set the circle's circle with circle_nav.set_center()
 //  we assume the caller has performed all required GPS_ok checks
@@ -279,7 +198,7 @@ void Sub::auto_circle_movetoedge_start(const Location &circle_center, float radi
         circle_edge.set_alt_cm(circle_center.alt, circle_center.get_alt_frame());
 
         // initialise wpnav to move to edge of circle
-        if (!wp_nav.set_wp_destination(circle_edge)) {
+        if (!wp_nav.set_wp_destination_loc(circle_edge)) {
             // failure to set destination can only be because of missing terrain data
             failsafe_terrain_on_event();
         }
@@ -362,15 +281,12 @@ bool Sub::auto_loiter_start()
     }
     auto_mode = Auto_Loiter;
 
-    Vector3f origin = inertial_nav.get_position();
-
     // calculate stopping point
     Vector3f stopping_point;
-    pos_control.get_stopping_point_xy(stopping_point);
-    pos_control.get_stopping_point_z(stopping_point);
+    wp_nav.get_wp_stopping_point(stopping_point);
 
     // initialise waypoint controller target to stopping point
-    wp_nav.set_wp_origin_and_destination(origin, stopping_point);
+    wp_nav.set_wp_destination(stopping_point);
 
     // hold yaw at current heading
     set_auto_yaw_mode(AUTO_YAW_HOLD);

--- a/ArduSub/control_auto.cpp
+++ b/ArduSub/control_auto.cpp
@@ -514,9 +514,12 @@ float Sub::get_auto_heading()
         float track_bearing = get_bearing_cd(wp_nav.get_wp_origin(), wp_nav.get_wp_destination());
 
         // Bearing from current position towards intermediate position target (centidegrees)
-        float desired_angle = pos_control.get_bearing_to_target();
-
-        float angle_error = wrap_180_cd(desired_angle - track_bearing);
+        const Vector2f target_vel_xy{pos_control.get_vel_target().x, pos_control.get_vel_target().y};
+        float angle_error = 0.0f;
+        if (target_vel_xy.length() >= pos_control.get_max_speed_xy() * 0.1f) {
+            const float desired_angle_cd = degrees(target_vel_xy.angle()) * 100.0f;
+            angle_error = wrap_180_cd(desired_angle_cd - track_bearing);
+        }
         float angle_limited = constrain_float(angle_error, -g.xtrack_angle_limit * 100.0f, g.xtrack_angle_limit * 100.0f);
         return wrap_360_cd(track_bearing + angle_limited);
     }

--- a/ArduSub/control_guided.cpp
+++ b/ArduSub/control_guided.cpp
@@ -51,7 +51,7 @@ void Sub::guided_pos_control_start()
     // set to position control mode
     guided_mode = Guided_WP;
 
-    // initialise waypoint and spline controller
+    // initialise waypoint controller
     wp_nav.wp_and_spline_init();
 
     // initialise wpnav to stopping point at current altitude
@@ -181,7 +181,7 @@ bool Sub::guided_set_destination(const Location& dest_loc)
     }
 #endif
 
-    if (!wp_nav.set_wp_destination(dest_loc)) {
+    if (!wp_nav.set_wp_destination_loc(dest_loc)) {
         // failure to set destination can only be because of missing terrain data
         AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         // failure is propagated to GCS with NAK
@@ -386,7 +386,7 @@ void Sub::guided_vel_control_run()
     }
 }
 
-// guided_posvel_control_run - runs the guided spline controller
+// guided_posvel_control_run - runs the guided posvel controller
 // called from guided_run
 void Sub::guided_posvel_control_run()
 {

--- a/ArduSub/defines.h
+++ b/ArduSub/defines.h
@@ -60,7 +60,6 @@ enum AutoMode {
     Auto_WP,
     Auto_CircleMoveToEdge,
     Auto_Circle,
-    Auto_Spline,
     Auto_NavGuided,
     Auto_Loiter,
     Auto_TerrainRecover

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2585,7 +2585,7 @@ class AutoTestCopter(AutoTest):
         self.change_mode('AUTO')
         self.wait_groundspeed(0-tolerance, 0+tolerance)
         self.wait_groundspeed(wpnav_speed_ms-tolerance, wpnav_speed_ms+tolerance)
-        self.monitor_groundspeed(wpnav_speed_ms, timeout=5)
+        self.monitor_groundspeed(wpnav_speed_ms, tolerance=0.6, timeout=5)
         self.do_RTL()
 
     def fly_nav_delay(self):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -398,7 +398,7 @@ class AutoTestCopter(AutoTest):
         # descend to 10m
         self.progress("Descend to 10m in Loiter")
         self.change_mode('LOITER')
-        self.set_rc(3, 1300)
+        self.set_rc(3, 1200)
         time_left = timeout - (self.get_sim_time() - tstart)
         self.progress("timeleft = %u" % time_left)
         if time_left < 20:

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2608,7 +2608,7 @@ class AutoTestCopter(AutoTest):
         last_seq = None
         while self.armed(): # we RTL at end of mission
             now = self.get_sim_time_cached()
-            if now - tstart > 120:
+            if now - tstart > 200:
                 raise AutoTestTimeoutException("Did not disarm as expected")
             m = self.mav.recv_match(type='MISSION_CURRENT', blocking=True)
             at_delay_item = ""

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -299,6 +299,67 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_euler_rate_yaw(float euler
     attitude_controller_run_quat();
 }
 
+// Command an euler roll pitch and yaw angle and an euler yaw rate for use with input shaped commands
+void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float euler_yaw_rate_cds)
+{
+    // Convert from centidegrees on public interface to radians
+    float euler_roll_angle = radians(euler_roll_angle_cd * 0.01f);
+    float euler_pitch_angle = radians(euler_pitch_angle_cd * 0.01f);
+    float euler_yaw_angle = radians(euler_yaw_angle_cd * 0.01f);
+    float euler_yaw_rate = radians(euler_yaw_rate_cds * 0.01f);
+
+    // calculate the attitude target euler angles
+    _attitude_target_quat.to_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
+
+    // Add roll trim to compensate tail rotor thrust in heli (will return zero on multirotors)
+    euler_roll_angle += get_roll_trim_rad();
+
+    if (_rate_bf_ff_enabled) {
+        // translate the roll pitch and yaw acceleration limits to the euler axis
+        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f(get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()));
+
+        // When acceleration limiting and feedforward are enabled, the sqrt controller is used to compute an euler
+        // angular velocity that will cause the euler angle to smoothly stop at the input angle with limited deceleration
+        // and an exponential decay specified by _input_tc at the end.
+        _attitude_correction_euler_rate.x = input_shaping_angle(wrap_PI(euler_roll_angle - _attitude_target_euler_angle.x), 0.0f, euler_accel.x, _attitude_correction_euler_rate.x, _dt);
+        _attitude_correction_euler_rate.y = input_shaping_angle(wrap_PI(euler_pitch_angle - _attitude_target_euler_angle.y), 0.0f, euler_accel.y, _attitude_correction_euler_rate.y, _dt);
+        _attitude_correction_euler_rate.z = input_shaping_angle(wrap_PI(euler_yaw_angle - _attitude_target_euler_angle.z), _input_tc, euler_accel.z, _attitude_correction_euler_rate.z, _dt);
+        _attitude_correction_euler_rate.z = constrain_float(_attitude_correction_euler_rate.z, -get_slew_yaw_rads(), get_slew_yaw_rads());
+        _attitude_target_euler_rate = _attitude_correction_euler_rate;
+
+        // When yaw acceleration limiting is enabled, the yaw input shaper constrains angular acceleration about the yaw axis, slewing
+        // the output rate towards the input rate.
+        _attitude_desired_euler_rate.z = input_shaping_ang_vel(_attitude_desired_euler_rate.z, euler_yaw_rate, euler_accel.z, _dt);
+        _attitude_target_euler_rate.z += _attitude_desired_euler_rate.z;
+        _attitude_target_euler_rate.z = constrain_float(_attitude_target_euler_rate.z, -get_slew_yaw_rads(), get_slew_yaw_rads());
+
+
+        // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
+        euler_rate_to_ang_vel(_attitude_target_euler_angle, _attitude_target_euler_rate, _attitude_target_ang_vel);
+        // Limit the angular velocity
+        ang_vel_limit(_attitude_target_ang_vel, radians(_ang_vel_roll_max), radians(_ang_vel_pitch_max), radians(_ang_vel_yaw_max));
+        // Convert body-frame angular velocity into euler angle derivative of desired attitude
+        ang_vel_to_euler_rate(_attitude_target_euler_angle, _attitude_target_ang_vel, _attitude_target_euler_rate);
+    } else {
+        // When feedforward is not enabled, the target euler angle is input into the target and the feedforward rate is zeroed.
+        _attitude_target_euler_angle.x = euler_roll_angle;
+        _attitude_target_euler_angle.y = euler_pitch_angle;
+        // Compute constrained angle error
+        float angle_error = constrain_float(wrap_PI(euler_yaw_angle - _attitude_target_euler_angle.z), -get_slew_yaw_rads() * _dt, get_slew_yaw_rads() * _dt);
+        // Update attitude target from constrained angle error
+        _attitude_target_euler_angle.z = wrap_PI(angle_error + _attitude_target_euler_angle.z);
+        // Compute quaternion target attitude
+        _attitude_target_quat.from_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
+
+        // Set rate feedforward requests to zero
+        _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
+        _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+    }
+
+    // Call quaternion attitude controller
+    attitude_controller_run_quat();
+}
+
 // Command an euler roll, pitch and yaw angle with angular velocity feedforward and smoothing
 void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, bool slew_yaw)
 {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -240,8 +240,8 @@ void AC_AttitudeControl::input_quaternion(Quaternion attitude_desired_quat)
         _attitude_target_quat = attitude_desired_quat;
 
         // Set rate feedforward requests to zero
-        _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-        _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+        _attitude_target_euler_rate.zero();
+        _attitude_target_ang_vel.zero();
     }
 
     // Call quaternion attitude controller
@@ -264,7 +264,7 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_euler_rate_yaw(float euler
 
     if (_rate_bf_ff_enabled) {
         // translate the roll pitch and yaw acceleration limits to the euler axis
-        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f(get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()));
+        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f{get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()});
 
         // When acceleration limiting and feedforward are enabled, the sqrt controller is used to compute an euler
         // angular velocity that will cause the euler angle to smoothly stop at the input angle with limited deceleration
@@ -291,8 +291,8 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_euler_rate_yaw(float euler
         _attitude_target_quat.from_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
 
         // Set rate feedforward requests to zero
-        _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-        _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+        _attitude_target_euler_rate.zero();
+        _attitude_target_ang_vel.zero();
     }
 
     // Call quaternion attitude controller
@@ -316,7 +316,7 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw_euler_rate_yaw(float e
 
     if (_rate_bf_ff_enabled) {
         // translate the roll pitch and yaw acceleration limits to the euler axis
-        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f(get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()));
+        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f{get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()});
 
         // When acceleration limiting and feedforward are enabled, the sqrt controller is used to compute an euler
         // angular velocity that will cause the euler angle to smoothly stop at the input angle with limited deceleration
@@ -352,8 +352,8 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw_euler_rate_yaw(float e
         _attitude_target_quat.from_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
 
         // Set rate feedforward requests to zero
-        _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-        _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+        _attitude_target_euler_rate.zero();
+        _attitude_target_ang_vel.zero();
     }
 
     // Call quaternion attitude controller
@@ -376,7 +376,7 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw(float euler_roll_angle
 
     if (_rate_bf_ff_enabled) {
         // translate the roll pitch and yaw acceleration limits to the euler axis
-        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f(get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()));
+        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f{get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()});
 
         // When acceleration limiting and feedforward are enabled, the sqrt controller is used to compute an euler
         // angular velocity that will cause the euler angle to smoothly stop at the input angle with limited deceleration
@@ -410,8 +410,8 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw(float euler_roll_angle
         _attitude_target_quat.from_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
 
         // Set rate feedforward requests to zero
-        _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-        _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+        _attitude_target_euler_rate.zero();
+        _attitude_target_ang_vel.zero();
     }
 
     // Call quaternion attitude controller
@@ -431,7 +431,7 @@ void AC_AttitudeControl::input_euler_rate_roll_pitch_yaw(float euler_roll_rate_c
 
     if (_rate_bf_ff_enabled) {
         // translate the roll pitch and yaw acceleration limits to the euler axis
-        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f(get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()));
+        const Vector3f euler_accel = euler_accel_limit(_attitude_target_euler_angle, Vector3f{get_accel_roll_max_radss(), get_accel_pitch_max_radss(), get_accel_yaw_max_radss()});
 
         // When acceleration limiting is enabled, the input shaper constrains angular acceleration, slewing
         // the output rate towards the input rate.
@@ -449,8 +449,8 @@ void AC_AttitudeControl::input_euler_rate_roll_pitch_yaw(float euler_roll_rate_c
         _attitude_target_euler_angle.z = wrap_2PI(_attitude_target_euler_angle.z + euler_yaw_rate * _dt);
 
         // Set rate feedforward requests to zero
-        _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-        _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+        _attitude_target_euler_rate.zero();
+        _attitude_target_ang_vel.zero();
 
         // Compute quaternion target attitude
         _attitude_target_quat.from_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
@@ -489,8 +489,8 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw(float roll_rate_bf_cds, fl
         _attitude_target_quat.normalize();
 
         // Set rate feedforward requests to zero
-        _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-        _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+        _attitude_target_euler_rate.zero();
+        _attitude_target_ang_vel.zero();
     }
 
     // Call quaternion attitude controller
@@ -592,8 +592,8 @@ void AC_AttitudeControl::input_angle_step_bf_roll_pitch_yaw(float roll_angle_ste
     _attitude_target_quat.to_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
 
     // Set rate feedforward requests to zero
-    _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-    _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+    _attitude_target_euler_rate.zero();
+    _attitude_target_ang_vel.zero();
 
     // Call quaternion attitude controller
     attitude_controller_run_quat();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -105,6 +105,15 @@ public:
     // Sets and saves the yaw acceleration limit in centidegrees/s/s
     void save_accel_yaw_max(float accel_yaw_max) { _accel_yaw_max.set_and_save(accel_yaw_max); }
 
+    // get the roll angular velocity limit in radians/s
+    float get_ang_vel_roll_max_radss() const { return _ang_vel_roll_max; }
+
+    // get the pitch angular velocity limit in radians/s
+    float get_ang_vel_pitch_max_radss() const { return _ang_vel_pitch_max; }
+
+    // get the rate control input smoothing time constant
+    float get_input_tc() const { return _input_tc; }
+
     // set the rate control input smoothing time constant
     void set_input_tc(float input_tc) { _input_tc = constrain_float(input_tc, 0.0f, 1.0f); }
 
@@ -137,6 +146,9 @@ public:
 
     // Command an euler roll and pitch angle and an euler yaw rate with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
+
+    // Command an euler roll and pitch angle and an euler yaw rate with angular velocity feedforward and smoothing
+    virtual void input_euler_angle_roll_pitch_yaw_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float euler_yaw_rate_cds);
 
     // Command an euler roll, pitch and yaw angle with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, bool slew_yaw);
@@ -390,6 +402,9 @@ protected:
     // the attitude controller as 321-intrinsic euler angle derivatives, in radians per
     // second.
     Vector3f            _attitude_target_euler_rate;
+
+    Vector3f            _attitude_desired_euler_rate;
+    Vector3f            _attitude_correction_euler_rate;
 
     // This represents a quaternion rotation in NED frame to the target (setpoint)
     // attitude used in the attitude controller.

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -9,6 +9,9 @@ extern const AP_HAL::HAL& hal;
  // default gains for Plane
  # define POSCONTROL_POS_Z_P                    1.0f    // vertical position controller P gain default
  # define POSCONTROL_VEL_Z_P                    5.0f    // vertical velocity controller P gain default
+ # define POSCONTROL_VEL_Z_IMAX                 1000.0f // vertical velocity controller IMAX gain default
+ # define POSCONTROL_VEL_Z_FILT_HZ              5.0f    // vertical velocity controller input filter
+ # define POSCONTROL_VEL_Z_FILT_D_HZ            5.0f    // vertical velocity controller input filter for D
  # define POSCONTROL_ACC_Z_P                    0.3f    // vertical acceleration controller P gain default
  # define POSCONTROL_ACC_Z_I                    1.0f    // vertical acceleration controller I gain default
  # define POSCONTROL_ACC_Z_D                    0.0f    // vertical acceleration controller D gain default
@@ -26,6 +29,9 @@ extern const AP_HAL::HAL& hal;
  // default gains for Sub
  # define POSCONTROL_POS_Z_P                    3.0f    // vertical position controller P gain default
  # define POSCONTROL_VEL_Z_P                    8.0f    // vertical velocity controller P gain default
+ # define POSCONTROL_VEL_Z_IMAX                 1000.0f // vertical velocity controller IMAX gain default
+ # define POSCONTROL_VEL_Z_FILT_HZ              5.0f    // vertical velocity controller input filter
+ # define POSCONTROL_VEL_Z_FILT_D_HZ            5.0f    // vertical velocity controller input filter for D
  # define POSCONTROL_ACC_Z_P                    0.5f    // vertical acceleration controller P gain default
  # define POSCONTROL_ACC_Z_I                    0.1f    // vertical acceleration controller I gain default
  # define POSCONTROL_ACC_Z_D                    0.0f    // vertical acceleration controller D gain default
@@ -43,6 +49,9 @@ extern const AP_HAL::HAL& hal;
  // default gains for Copter / TradHeli
  # define POSCONTROL_POS_Z_P                    1.0f    // vertical position controller P gain default
  # define POSCONTROL_VEL_Z_P                    5.0f    // vertical velocity controller P gain default
+ # define POSCONTROL_VEL_Z_IMAX                 1000.0f // vertical velocity controller IMAX gain default
+ # define POSCONTROL_VEL_Z_FILT_HZ              5.0f    // vertical velocity controller input filter
+ # define POSCONTROL_VEL_Z_FILT_D_HZ            5.0f    // vertical velocity controller input filter for D
  # define POSCONTROL_ACC_Z_P                    0.5f    // vertical acceleration controller P gain default
  # define POSCONTROL_ACC_Z_I                    1.0f    // vertical acceleration controller I gain default
  # define POSCONTROL_ACC_Z_D                    0.0f    // vertical acceleration controller D gain default
@@ -79,14 +88,55 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Description: Position (vertical) controller P gain.  Converts the difference between the desired altitude and actual altitude into a climb or descent rate which is passed to the throttle rate controller
     // @Range: 1.000 3.000
     // @User: Standard
-    AP_SUBGROUPINFO(_p_pos_z, "_POSZ_", 2, AC_PosControl, AC_P),
+    AP_SUBGROUPINFO(_p_pos_z, "_POSZ_", 2, AC_PosControl, AC_P_1D),
 
     // @Param: _VELZ_P
     // @DisplayName: Velocity (vertical) controller P gain
     // @Description: Velocity (vertical) controller P gain.  Converts the difference between desired vertical speed and actual speed into a desired acceleration that is passed to the throttle acceleration controller
     // @Range: 1.000 8.000
     // @User: Standard
-    AP_SUBGROUPINFO(_p_vel_z, "_VELZ_", 3, AC_PosControl, AC_P),
+
+    // @Param: _VELZ_I
+    // @DisplayName: Velocity (vertical) controller I gain
+    // @Description: Velocity (vertical) controller I gain.  Corrects long-term difference in desired velocity to a target acceleration
+    // @Range: 0.02 1.00
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _VELZ_IMAX
+    // @DisplayName: Velocity (vertical) controller I gain maximum
+    // @Description: Velocity (vertical) controller I gain maximum.  Constrains the target acceleration that the I gain will output
+    // @Range: 1.000 8.000
+    // @User: Standard
+
+    // @Param: _VELZ_D
+    // @DisplayName: Velocity (vertical) controller D gain
+    // @Description: Velocity (vertical) controller D gain.  Corrects short-term changes in velocity
+    // @Range: 0.00 1.00
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _VELZ_FF
+    // @DisplayName: Velocity (vertical) controller Feed Forward gain
+    // @Description: Velocity (vertical) controller Feed Forward gain.  Produces an output that is proportional to the magnitude of the target
+    // @Range: 0 1
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _VELZ_FLTE
+    // @DisplayName: Velocity (vertical) error filter
+    // @Description: Velocity (vertical) error filter.  This filter (in hz) is applied to the input for P and I terms
+    // @Range: 0 100
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _VELZ_FLTD
+    // @DisplayName: Velocity (vertical) input filter for D term
+    // @Description: Velocity (vertical) input filter for D term.  This filter (in hz) is applied to the input for D terms
+    // @Range: 0 100
+    // @Units: Hz
+    // @User: Advanced
+    AP_SUBGROUPINFO(_pid_vel_z, "_VELZ_", 3, AC_PosControl, AC_PID_Basic),
 
     // @Param: _ACCZ_P
     // @DisplayName: Acceleration (vertical) controller P gain
@@ -159,18 +209,18 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Description: Position controller P gain.  Converts the distance (in the latitude direction) to the target location into a desired speed which is then passed to the loiter latitude rate controller
     // @Range: 0.500 2.000
     // @User: Standard
-    AP_SUBGROUPINFO(_p_pos_xy, "_POSXY_", 5, AC_PosControl, AC_P),
+    AP_SUBGROUPINFO(_p_pos_xy, "_POSXY_", 5, AC_PosControl, AC_P_2D),
 
     // @Param: _VELXY_P
     // @DisplayName: Velocity (horizontal) P gain
-    // @Description: Velocity (horizontal) P gain.  Converts the difference between desired velocity to a target acceleration
+    // @Description: Velocity (horizontal) P gain.  Converts the difference between desired and actual velocity to a target acceleration
     // @Range: 0.1 6.0
     // @Increment: 0.1
     // @User: Advanced
 
     // @Param: _VELXY_I
     // @DisplayName: Velocity (horizontal) I gain
-    // @Description: Velocity (horizontal) I gain.  Corrects long-term difference in desired velocity to a target acceleration
+    // @Description: Velocity (horizontal) I gain.  Corrects long-term difference between desired and actual velocity to a target acceleration
     // @Range: 0.02 1.00
     // @Increment: 0.01
     // @User: Advanced
@@ -203,6 +253,13 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
+
+    // @Param: _VELXY_FF
+    // @DisplayName: Velocity (horizontal) feed forward gains
+    // @Description: Velocity (horizontal) feed forward gain.  Converts the difference between desired velocity to a target acceleration
+    // @Range: 0 6
+    // @Increment: 0.01
+    // @User: Advanced
     AP_SUBGROUPINFO(_pid_vel_xy, "_VELXY_", 6, AC_PosControl, AC_PID_2D),
 
     // @Param: _ANGLE_MAX
@@ -227,11 +284,11 @@ AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
     _inav(inav),
     _motors(motors),
     _attitude_control(attitude_control),
-    _p_pos_z(POSCONTROL_POS_Z_P),
-    _p_vel_z(POSCONTROL_VEL_Z_P),
-    _pid_accel_z(POSCONTROL_ACC_Z_P, POSCONTROL_ACC_Z_I, POSCONTROL_ACC_Z_D, 0.0f, POSCONTROL_ACC_Z_IMAX, 0.0f, POSCONTROL_ACC_Z_FILT_HZ, 0.0f, POSCONTROL_ACC_Z_DT),
-    _p_pos_xy(POSCONTROL_POS_XY_P),
-    _pid_vel_xy(POSCONTROL_VEL_XY_P, POSCONTROL_VEL_XY_I, POSCONTROL_VEL_XY_D, POSCONTROL_VEL_XY_IMAX, POSCONTROL_VEL_XY_FILT_HZ, POSCONTROL_VEL_XY_FILT_D_HZ, POSCONTROL_DT_50HZ),
+    _p_pos_z(POSCONTROL_POS_Z_P, POSCONTROL_DT_400HZ),
+    _pid_vel_z(POSCONTROL_VEL_Z_P, 0.0f, 0.0f, 0.0f, POSCONTROL_VEL_Z_IMAX, POSCONTROL_VEL_Z_FILT_HZ, POSCONTROL_VEL_Z_FILT_D_HZ, POSCONTROL_DT_400HZ),
+    _pid_accel_z(POSCONTROL_ACC_Z_P, POSCONTROL_ACC_Z_I, POSCONTROL_ACC_Z_D, 0.0f, POSCONTROL_ACC_Z_IMAX, 0.0f, POSCONTROL_ACC_Z_FILT_HZ, 0.0f, POSCONTROL_DT_400HZ),
+    _p_pos_xy(POSCONTROL_POS_XY_P, POSCONTROL_DT_400HZ),
+    _pid_vel_xy(POSCONTROL_VEL_XY_P, POSCONTROL_VEL_XY_I, POSCONTROL_VEL_XY_D, 0.0f, POSCONTROL_VEL_XY_IMAX, POSCONTROL_VEL_XY_FILT_HZ, POSCONTROL_VEL_XY_FILT_D_HZ, POSCONTROL_DT_400HZ),
     _dt(POSCONTROL_DT_400HZ),
     _speed_down_cms(POSCONTROL_SPEED_DOWN),
     _speed_up_cms(POSCONTROL_SPEED_UP),
@@ -251,8 +308,6 @@ AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
     _flags.reset_desired_vel_to_pos = true;
     _flags.reset_accel_to_lean_xy = true;
     _flags.reset_rate_to_accel_z = true;
-    _flags.freeze_ff_z = true;
-    _flags.use_desvel_ff_z = true;
     _limit.pos_up = true;
     _limit.pos_down = true;
     _limit.vel_up = true;
@@ -270,7 +325,10 @@ void AC_PosControl::set_dt(float delta_sec)
     _dt = delta_sec;
 
     // update PID controller dt
+    _p_pos_z.set_dt(_dt);
+    _pid_vel_z.set_dt(_dt);
     _pid_accel_z.set_dt(_dt);
+    _p_pos_xy.set_dt(_dt);
     _pid_vel_xy.set_dt(_dt);
 
     // update rate z-axis velocity error and accel error filters
@@ -318,20 +376,14 @@ void AC_PosControl::set_max_accel_z(float accel_cmss)
 void AC_PosControl::set_alt_target_with_slew(float alt_cm, float dt)
 {
     float alt_change = alt_cm - _pos_target.z;
-
-    // do not use z-axis desired velocity feed forward
-    _flags.use_desvel_ff_z = false;
+    _vel_desired.z = 0.0f;
 
     // adjust desired alt if motors have not hit their limits
     if ((alt_change < 0 && !_motors.limit.throttle_lower) || (alt_change > 0 && !_motors.limit.throttle_upper)) {
         if (!is_zero(dt)) {
             float climb_rate_cms = constrain_float(alt_change / dt, _speed_down_cms, _speed_up_cms);
             _pos_target.z += climb_rate_cms * dt;
-            _vel_desired.z = climb_rate_cms;  // recorded for reporting purposes
         }
-    } else {
-        // recorded for reporting purposes
-        _vel_desired.z = 0.0f;
     }
 
     // do not let target get too far from current altitude
@@ -353,8 +405,7 @@ void AC_PosControl::set_alt_target_from_climb_rate(float climb_rate_cms, float d
 
     // do not use z-axis desired velocity feed forward
     // vel_desired set to desired climb rate for reporting and land-detector
-    _flags.use_desvel_ff_z = false;
-    _vel_desired.z = climb_rate_cms;
+    _vel_desired.z = 0.0f;
 }
 
 /// set_alt_target_from_climb_rate_ff - adjusts target up or down using a climb rate in cm/s using feed-forward
@@ -377,14 +428,23 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
     // jerk_z is calculated to reach full acceleration in 1000ms.
     float jerk_z = accel_z_cms * POSCONTROL_JERK_RATIO;
 
-    float accel_z_max = MIN(accel_z_cms, safe_sqrt(2.0f * fabsf(_vel_desired.z - climb_rate_cms) * jerk_z));
+    float accel_z_max = MIN(accel_z_cms, safe_sqrt(2.0f * fabsf(climb_rate_cms - _vel_desired.z) * jerk_z));
 
+    // jerk limit the acceleration increase
     _accel_last_z_cms += jerk_z * dt;
-    _accel_last_z_cms = MIN(accel_z_max, _accel_last_z_cms);
+    // jerk limit the decrease as zero error is approached
+    _accel_last_z_cms = MIN(_accel_last_z_cms, accel_z_max);
+    // remove overshoot during last time step
+    _accel_last_z_cms = MIN(_accel_last_z_cms, fabsf(climb_rate_cms- _vel_desired.z) / dt);
+
+    if (is_positive(climb_rate_cms- _vel_desired.z)){
+        _accel_desired.z = _accel_last_z_cms;
+    } else {
+        _accel_desired.z = -_accel_last_z_cms;
+    }
 
     float vel_change_limit = _accel_last_z_cms * dt;
     _vel_desired.z = constrain_float(climb_rate_cms, _vel_desired.z - vel_change_limit, _vel_desired.z + vel_change_limit);
-    _flags.use_desvel_ff_z = true;
 
     // adjust desired alt if motors have not hit their limits
     // To-Do: add check of _limit.pos_down?
@@ -405,11 +465,6 @@ void AC_PosControl::add_takeoff_climb_rate(float climb_rate_cms, float dt)
 void AC_PosControl::shift_alt_target(float z_cm)
 {
     _pos_target.z += z_cm;
-
-    // freeze feedforward to avoid jump
-    if (!is_zero(z_cm)) {
-        freeze_ff_z();
-    }
 }
 
 /// relax_alt_hold_controllers - set all desired and targets to measured
@@ -417,9 +472,7 @@ void AC_PosControl::relax_alt_hold_controllers(float throttle_setting)
 {
     _pos_target.z = _inav.get_altitude();
     _vel_desired.z = 0.0f;
-    _flags.use_desvel_ff_z = false;
     _vel_target.z = _inav.get_velocity_z();
-    _vel_last.z = _inav.get_velocity_z();
     _accel_desired.z = 0.0f;
     _accel_last_z_cms = 0.0f;
     _flags.reset_rate_to_accel_z = true;
@@ -454,10 +507,7 @@ void AC_PosControl::get_stopping_point_z(Vector3f& stopping_point) const
 
     // if position controller is active add current velocity error to avoid sudden jump in acceleration
     if (is_active_z()) {
-        curr_vel_z += _vel_error.z;
-        if (_flags.use_desvel_ff_z) {
-            curr_vel_z -= _vel_desired.z;
-        }
+        curr_vel_z -= _vel_desired.z;
     }
 
     // avoid divide by zero by using current position if kP is very low or acceleration is zero
@@ -489,9 +539,6 @@ void AC_PosControl::init_takeoff()
     const Vector3f& curr_pos = _inav.get_position();
 
     _pos_target.z = curr_pos.z;
-
-    // freeze feedforward to avoid jump
-    freeze_ff_z();
 
     // shift difference between last motor out and hover throttle into accelerometer I
     _pid_accel_z.set_integrator((_attitude_control.get_throttle_in() - _motors.get_throttle_hover()) * 1000.0f);
@@ -546,124 +593,66 @@ void AC_PosControl::calc_leash_length_z()
 // vel_up_max, vel_down_max should have already been set before calling this method
 void AC_PosControl::run_z_controller()
 {
+    // Position Controller
+
     float curr_alt = _inav.get_altitude();
-
-    // clear position limit flags
-    _limit.pos_up = false;
-    _limit.pos_down = false;
-
-    // calculate altitude error
-    _pos_error.z = _pos_target.z - curr_alt;
-
-    // do not let target altitude get too far from current altitude
-    if (_pos_error.z > _leash_up_z) {
-        _pos_target.z = curr_alt + _leash_up_z;
-        _pos_error.z = _leash_up_z;
-        _limit.pos_up = true;
-    }
-    if (_pos_error.z < -_leash_down_z) {
-        _pos_target.z = curr_alt - _leash_down_z;
-        _pos_error.z = -_leash_down_z;
-        _limit.pos_down = true;
-    }
-
-    // calculate _vel_target.z using from _pos_error.z using sqrt controller
-    _vel_target.z = sqrt_controller(_pos_error.z, _p_pos_z.kP(), _accel_z_cms, _dt);
-
-    // check speed limits
-    // To-Do: check these speed limits here or in the pos->rate controller
-    _limit.vel_up = false;
-    _limit.vel_down = false;
-    if (_vel_target.z < _speed_down_cms) {
-        _vel_target.z = _speed_down_cms;
-        _limit.vel_down = true;
-    }
-    if (_vel_target.z > _speed_up_cms) {
-        _vel_target.z = _speed_up_cms;
-        _limit.vel_up = true;
-    }
-
+    // define maximum position error and maximum first and second differential limits
+    _p_pos_z.set_limits_error(-fabsf(_leash_down_z), _leash_up_z, -fabsf(_speed_down_cms), _speed_up_cms);
+    // calculate the target velocity correction
+    _vel_target.z = _p_pos_z.update_all(_pos_target.z, curr_alt, _limit.pos_down, _limit.pos_up);
     // add feed forward component
-    if (_flags.use_desvel_ff_z) {
-        _vel_target.z += _vel_desired.z;
-    }
+    _vel_target.z += constrain_float(_vel_desired.z, -fabsf(_speed_down_cms), _speed_up_cms);
 
-    // the following section calculates acceleration required to achieve the velocity target
+    // Velocity Controller
 
     const Vector3f& curr_vel = _inav.get_velocity();
-
-    // TODO: remove velocity derivative calculation
-    // reset last velocity target to current target
-    if (_flags.reset_rate_to_accel_z) {
-        _vel_last.z = _vel_target.z;
-    }
-
-    // feed forward desired acceleration calculation
-    if (_dt > 0.0f) {
-        if (!_flags.freeze_ff_z) {
-            _accel_desired.z = (_vel_target.z - _vel_last.z) / _dt;
-        } else {
-            // stop the feed forward being calculated during a known discontinuity
-            _flags.freeze_ff_z = false;
-        }
-    } else {
-        _accel_desired.z = 0.0f;
-    }
-
-    // store this iteration's velocities for the next iteration
-    _vel_last.z = _vel_target.z;
-
-    // reset velocity error and filter if this controller has just been engaged
-    if (_flags.reset_rate_to_accel_z) {
-        // Reset Filter
-        _vel_error.z = 0;
-        _vel_error_filter.reset(0);
-        _flags.reset_rate_to_accel_z = false;
-    } else {
-        // calculate rate error and filter with cut off frequency of 2 Hz
-        _vel_error.z = _vel_error_filter.apply(_vel_target.z - curr_vel.z, _dt);
-    }
-
-    _accel_target.z = _p_vel_z.get_p(_vel_error.z);
-
+    _accel_target.z = _pid_vel_z.update_all(_vel_target.z, curr_vel.z);
     _accel_target.z += _accel_desired.z;
 
-
+    // Acceleration Controller
 
     // Calculate Earth Frame Z acceleration
     const float z_accel_meas = get_z_accel_cmss();
-
 
     // ensure imax is always large enough to overpower hover throttle
     if (_motors.get_throttle_hover() * 1000.0f > _pid_accel_z.imax()) {
         _pid_accel_z.imax(_motors.get_throttle_hover() * 1000.0f);
     }
-
     float thr_out;
     if (_vibe_comp_enabled) {
-        _flags.freeze_ff_z = true;
-        _accel_desired.z = 0.0f;
-        const float thr_per_accelz_cmss = _motors.get_throttle_hover() / (GRAVITY_MSS * 100.0f);
-        // during vibration compensation use feed forward with manually calculated gain
-        // ToDo: clear pid_info P, I and D terms for logging
-        if (!(_motors.limit.throttle_lower || _motors.limit.throttle_upper) || ((is_positive(_pid_accel_z.get_i()) && is_negative(_vel_error.z)) || (is_negative(_pid_accel_z.get_i()) && is_positive(_vel_error.z)))) {
-            _pid_accel_z.set_integrator(_pid_accel_z.get_i() + _dt * thr_per_accelz_cmss * 1000.0f * _vel_error.z * _p_vel_z.kP() * POSCONTROL_VIBE_COMP_I_GAIN);
-        }
-        thr_out = POSCONTROL_VIBE_COMP_P_GAIN * thr_per_accelz_cmss * _accel_target.z + _pid_accel_z.get_i() * 0.001f;
+        thr_out = get_throttle_with_vibration_override();
     } else {
         thr_out = _pid_accel_z.update_all(_accel_target.z, z_accel_meas, (_motors.limit.throttle_lower || _motors.limit.throttle_upper)) * 0.001f;
+        thr_out += _pid_accel_z.get_ff() * 0.001f;
     }
     thr_out += _motors.get_throttle_hover();
+
+    // Actuator commands
 
     // send throttle to attitude controller with angle boost
     _attitude_control.set_throttle_out(thr_out, true, POSCONTROL_THROTTLE_CUTOFF_FREQ);
 
+    // Check for vertical controller health
+
     // _speed_down_cms is checked to be non-zero when set
     float error_ratio = _vel_error.z/_speed_down_cms;
-
     _vel_z_control_ratio += _dt*0.1f*(0.5-error_ratio);
     _vel_z_control_ratio = constrain_float(_vel_z_control_ratio, 0.0f, 2.0f);
 }
+
+// get throttle using vibration resistant calculation (uses feed forward with manually calculated gain)
+float AC_PosControl::get_throttle_with_vibration_override()
+{
+    _accel_desired.z = 0.0f;
+    const float thr_per_accelz_cmss = _motors.get_throttle_hover() / (GRAVITY_MSS * 100.0f);
+    // during vibration compensation use feed forward with manually calculated gain
+    // ToDo: clear pid_info P, I and D terms for logging
+    if (!(_motors.limit.throttle_lower || _motors.limit.throttle_upper) || ((is_positive(_pid_accel_z.get_i()) && is_negative(_vel_error.z)) || (is_negative(_pid_accel_z.get_i()) && is_positive(_vel_error.z)))) {
+        _pid_accel_z.set_integrator(_pid_accel_z.get_i() + _dt * thr_per_accelz_cmss * 1000.0f * _vel_error.z * _pid_vel_z.kP() * POSCONTROL_VIBE_COMP_I_GAIN);
+    }
+    return POSCONTROL_VIBE_COMP_P_GAIN * thr_per_accelz_cmss * _accel_target.z + _pid_accel_z.get_i() * 0.001f;
+}
+
 
 ///
 /// lateral position controller
@@ -698,13 +687,19 @@ void AC_PosControl::set_max_speed_xy(float speed_cms)
 void AC_PosControl::set_pos_target(const Vector3f& position)
 {
     _pos_target = position;
-
-    _flags.use_desvel_ff_z = false;
     _vel_desired.z = 0.0f;
     // initialise roll and pitch to current roll and pitch.  This avoids a twitch between when the target is set and the pos controller is first run
     // To-Do: this initialisation of roll and pitch targets needs to go somewhere between when pos-control is initialised and when it completes it's first cycle
     //_roll_target = constrain_int32(_ahrs.roll_sensor,-_attitude_control.lean_angle_max(),_attitude_control.lean_angle_max());
     //_pitch_target = constrain_int32(_ahrs.pitch_sensor,-_attitude_control.lean_angle_max(),_attitude_control.lean_angle_max());
+}
+
+/// set position, velocity and acceleration targets
+void AC_PosControl::set_pos_vel_accel_target(const Vector3f& pos, const Vector3f& vel, const Vector3f& accel)
+{
+    _pos_target = pos;
+    _vel_desired = vel;
+    _accel_desired = accel;
 }
 
 /// set_xy_target in cm from home
@@ -1007,36 +1002,20 @@ void AC_PosControl::run_xy_controller(float dt)
     float ekfGndSpdLimit, ekfNavVelGainScaler;
     AP::ahrs_navekf().getEkfControlLimits(ekfGndSpdLimit, ekfNavVelGainScaler);
 
-    Vector3f curr_pos = _inav.get_position();
-    float kP = ekfNavVelGainScaler * _p_pos_xy.kP(); // scale gains to compensate for noisy optical flow measurement in the EKF
+    // Position Controller
 
-    // avoid divide by zero
-    if (kP <= 0.0f) {
-        _vel_target.x = 0.0f;
-        _vel_target.y = 0.0f;
-    } else {
-        // calculate distance error
-        _pos_error.x = _pos_target.x - curr_pos.x;
-        _pos_error.y = _pos_target.y - curr_pos.y;
-
-        // Constrain _pos_error and target position
-        // Constrain the maximum length of _vel_target to the maximum position correction velocity
-        // TODO: replace the leash length with a user definable maximum position correction
-        if (limit_vector_length(_pos_error.x, _pos_error.y, _leash)) {
-            _pos_target.x = curr_pos.x + _pos_error.x;
-            _pos_target.y = curr_pos.y + _pos_error.y;
-        }
-
-        _vel_target = sqrt_controller_3D(_pos_error, kP, _accel_cms);
-    }
+    const Vector3f &curr_pos = _inav.get_position();
+    Vector2f vel_target = _p_pos_xy.update_all(_pos_target.x, _pos_target.y, curr_pos, _leash, _accel_cms);
 
     // add velocity feed-forward
+    vel_target *= ekfNavVelGainScaler;
+    _vel_target.x = vel_target.x;
+    _vel_target.y = vel_target.y;
+    // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
     _vel_target.x += _vel_desired.x;
     _vel_target.y += _vel_desired.y;
 
-    // the following section converts desired velocities in lat/lon directions to accelerations in lat/lon frame
-
-    Vector2f accel_target, vel_xy_p, vel_xy_i, vel_xy_d;
+    // Velocity Controller
 
     // check if vehicle velocity is being overridden
     if (_flags.vehicle_horiz_vel_override) {
@@ -1045,36 +1024,13 @@ void AC_PosControl::run_xy_controller(float dt)
         _vehicle_horiz_vel.x = _inav.get_velocity().x;
         _vehicle_horiz_vel.y = _inav.get_velocity().y;
     }
-
-    // calculate velocity error
-    _vel_error.x = _vel_target.x - _vehicle_horiz_vel.x;
-    _vel_error.y = _vel_target.y - _vehicle_horiz_vel.y;
-    // TODO: constrain velocity error and velocity target
-
-    // call pi controller
-    _pid_vel_xy.set_input(_vel_error);
-
-    // get p
-    vel_xy_p = _pid_vel_xy.get_p();
-
-    // update i term if we have not hit the accel or throttle limits OR the i term will reduce
-    // TODO: move limit handling into the PI and PID controller
-    if (!_limit.accel_xy && !_motors.limit.throttle_upper) {
-        vel_xy_i = _pid_vel_xy.get_i();
-    } else {
-        vel_xy_i = _pid_vel_xy.get_i_shrink();
-    }
-
-    // get d
-    vel_xy_d = _pid_vel_xy.get_d();
-
+    Vector2f accel_target = _pid_vel_xy.update_all(Vector2f(_vel_target.x, _vel_target.y), _vehicle_horiz_vel, _limit.accel_xy);
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
-    accel_target.x = (vel_xy_p.x + vel_xy_i.x + vel_xy_d.x) * ekfNavVelGainScaler;
-    accel_target.y = (vel_xy_p.y + vel_xy_i.y + vel_xy_d.y) * ekfNavVelGainScaler;
+    accel_target *= ekfNavVelGainScaler;
 
     // reset accel to current desired acceleration
     if (_flags.reset_accel_to_lean_xy) {
-        _accel_target_filter.reset(Vector2f(accel_target.x, accel_target.y));
+        _accel_target_filter.reset(accel_target);
         _flags.reset_accel_to_lean_xy = false;
     }
 
@@ -1090,7 +1046,7 @@ void AC_PosControl::run_xy_controller(float dt)
     _accel_target.x += _accel_desired.x;
     _accel_target.y += _accel_desired.y;
 
-    // the following section converts desired accelerations provided in lat/lon frame to roll/pitch angles
+    // Acceleration Controller
 
     // limit acceleration using maximum lean angles
     float angle_max = MIN(_attitude_control.get_althold_lean_angle_max(), get_lean_angle_max_cd());
@@ -1204,24 +1160,18 @@ bool AC_PosControl::pre_arm_checks(const char *param_prefix,
                                    char *failure_msg,
                                    const uint8_t failure_msg_len)
 {
-    // validate AC_P members:
-    const struct {
-        const char *pid_name;
-        AC_P &p;
-    } ps[] = {
-        { "POSXY", get_pos_xy_p() },
-        { "POSZ", get_pos_z_p() },
-        { "VELZ", get_vel_z_p() },
-    };
-    for (uint8_t i=0; i<ARRAY_SIZE(ps); i++) {
-        // all AC_P's must have a positive P value:
-        if (!is_positive(ps[i].p.kP())) {
-            hal.util->snprintf(failure_msg, failure_msg_len, "%s_%s_P must be > 0", param_prefix, ps[i].pid_name);
-            return false;
-        }
+    if (!is_positive(get_pos_xy_p().kP())) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "%s_POSXY_P must be > 0", param_prefix);
+        return false;
     }
-
-    // z-axis acceleration control PID doesn't use FF, so P and I must be positive
+    if (!is_positive(get_pos_z_p().kP())) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "%s_POSZ_P must be > 0", param_prefix);
+        return false;
+    }
+    if (!is_positive(get_vel_z_pid().kP())) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "%s_VELZ_P must be > 0", param_prefix);
+        return false;
+    }
     if (!is_positive(get_accel_z_pid().kP())) {
         hal.util->snprintf(failure_msg, failure_msg_len, "%s_ACCZ_P must be > 0", param_prefix);
         return false;

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1200,23 +1200,6 @@ void AC_PosControl::check_for_ekf_z_reset()
     }
 }
 
-/// Proportional controller with piecewise sqrt sections to constrain second derivative
-Vector3f AC_PosControl::sqrt_controller_3D(const Vector3f& error, float p, float second_ord_lim)
-{
-    if (second_ord_lim < 0.0f || is_zero(second_ord_lim) || is_zero(p)) {
-        return Vector3f(error.x * p, error.y * p, error.z);
-    }
-
-    float linear_dist = second_ord_lim / sq(p);
-    float error_length = norm(error.x, error.y);
-    if (error_length > linear_dist) {
-        float first_order_scale = safe_sqrt(2.0f * second_ord_lim * (error_length - (linear_dist * 0.5f))) / error_length;
-        return Vector3f(error.x * first_order_scale, error.y * first_order_scale, error.z);
-    } else {
-        return Vector3f(error.x * p, error.y * p, error.z);
-    }
-}
-
 bool AC_PosControl::pre_arm_checks(const char *param_prefix,
                                    char *failure_msg,
                                    const uint8_t failure_msg_len)

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -780,12 +780,6 @@ void AC_PosControl::get_stopping_point_xy(Vector3f &stopping_point) const
     stopping_point.y = curr_pos.y + (stopping_dist * curr_vel.y / vel_total);
 }
 
-/// get_distance_to_target - get horizontal distance to target position in cm
-float AC_PosControl::get_distance_to_target() const
-{
-    return norm(_pos_error.x, _pos_error.y);
-}
-
 /// get_bearing_to_target - get bearing to target position in centi-degrees
 int32_t AC_PosControl::get_bearing_to_target() const
 {
@@ -952,11 +946,6 @@ void AC_PosControl::update_vel_controller_xyz()
 
     // run z-axis position controller
     update_z_controller();
-}
-
-float AC_PosControl::get_horizontal_error() const
-{
-    return norm(_pos_error.x, _pos_error.y);
 }
 
 ///

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -365,9 +365,6 @@ protected:
     /// calc_leash_length - calculates the horizontal leash length given a maximum speed, acceleration and position kP gain
     float calc_leash_length(float speed_cms, float accel_cms, float kP) const;
 
-    /// Proportional controller with piecewise sqrt sections to constrain second derivative
-    static Vector3f sqrt_controller_3D(const Vector3f& error, float p, float second_ord_lim);
-
     /// initialise and check for ekf position resets
     void init_ekf_xy_reset();
     void check_for_ekf_xy_reset();

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -131,9 +131,6 @@ public:
 
     /// get_vel_z_error_ratio - returns the proportion of error relative to the maximum request
     float get_vel_z_control_ratio() const { return constrain_float(_vel_z_control_ratio, 0.0f, 1.0f); }
-    
-    // returns horizontal error in cm
-    float get_horizontal_error() const;
 
     /// set_target_to_stopping_point_z - sets altitude target to reasonable stopping altitude in cm above home
     void set_target_to_stopping_point_z();
@@ -252,8 +249,11 @@ public:
     ///     set_leash_length() should have been called before this method
     void get_stopping_point_xy(Vector3f &stopping_point) const;
 
-    /// get_distance_to_target - get horizontal distance to position target in cm (used for reporting)
-    float get_distance_to_target() const;
+    /// get_pos_error - get position error vector between the current and target position
+    const Vector3f get_pos_error() const { return _pos_target - _inav.get_position(); }
+
+    /// get_pos_error_xy - get the length of the position error vector in the xy plane
+    float get_pos_error_xy() const { return norm(_pos_target.x - _inav.get_position().x, _pos_target.y - _inav.get_position().y); }
 
     /// get_bearing_to_target - get bearing to target position in centi-degrees
     int32_t get_bearing_to_target() const;
@@ -410,7 +410,6 @@ protected:
 
     // position controller internal variables
     Vector3f    _pos_target;            // target location in cm from home
-    Vector3f    _pos_error;             // error between desired and actual position in cm
     Vector3f    _vel_desired;           // desired velocity in cm/s
     Vector3f    _vel_target;            // velocity target in cm/s calculated by pos_to_rate step
     Vector3f    _vel_error;             // error between desired and actual acceleration in cm/s

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -340,7 +340,7 @@ protected:
     //          init_takeoff
     void run_z_controller();
 
-    // get throttle using vibration resistant calculation (uses feed forward with manually calculated gain)
+    // get throttle using vibration-resistant calculation (uses feed forward with manually calculated gain)
     float get_throttle_with_vibration_override();
 
     // get earth-frame Z-axis acceleration with gravity removed in cm/s/s with +ve being up

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -33,8 +33,7 @@ void AC_PosControl_Sub::set_alt_target_from_climb_rate(float climb_rate_cms, flo
 
     // do not use z-axis desired velocity feed forward
     // vel_desired set to desired climb rate for reporting and land-detector
-    _flags.use_desvel_ff_z = false;
-    _vel_desired.z = climb_rate_cms;
+    _vel_desired.z = 0.0f;
 }
 
 /// set_alt_target_from_climb_rate_ff - adjusts target up or down using a climb rate in cm/s using feed-forward
@@ -64,7 +63,6 @@ void AC_PosControl_Sub::set_alt_target_from_climb_rate_ff(float climb_rate_cms, 
 
     float vel_change_limit = _accel_last_z_cms * dt;
     _vel_desired.z = constrain_float(climb_rate_cms, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
-    _flags.use_desvel_ff_z = true;
 
     // adjust desired alt if motors have not hit their limits
     // To-Do: add check of _limit.pos_down?
@@ -94,9 +92,7 @@ void AC_PosControl_Sub::relax_alt_hold_controllers()
 {
     _pos_target.z = _inav.get_altitude();
     _vel_desired.z = 0.0f;
-    _flags.use_desvel_ff_z = false;
     _vel_target.z = _inav.get_velocity_z();
-    _vel_last.z = _inav.get_velocity_z();
     _accel_desired.z = 0.0f;
     _accel_last_z_cms = 0.0f;
     _flags.reset_rate_to_accel_z = true;

--- a/libraries/AC_PID/AC_P.h
+++ b/libraries/AC_PID/AC_P.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file	AC_PD.h
-/// @brief	Generic PID algorithm, with EEPROM-backed storage of constants.
+/// @brief	Generic P controller with EEPROM-backed storage of constants.
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -23,13 +23,13 @@ const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
     // @Param: IMAX
     // @DisplayName: PID Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
-    AP_GROUPINFO("IMAX", 2, AC_PID_2D, _imax, 0),
+    AP_GROUPINFO("IMAX", 2, AC_PID_2D, _kimax, 0),
 
     // @Param: FILT
     // @DisplayName: PID Input filter frequency in Hz
     // @Description: Input filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FILT", 3, AC_PID_2D, _filt_hz, AC_PID_2D_FILT_HZ_DEFAULT),
+    AP_GROUPINFO("FILT", 3, AC_PID_2D, _filt_E_hz, AC_PID_2D_FILT_HZ_DEFAULT),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
@@ -40,173 +40,105 @@ const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
     // @DisplayName: D term filter frequency in Hz
     // @Description: D term filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("D_FILT", 5, AC_PID_2D, _filt_d_hz, AC_PID_2D_FILT_D_HZ_DEFAULT),
+    AP_GROUPINFO("D_FILT", 5, AC_PID_2D, _filt_D_hz, AC_PID_2D_FILT_D_HZ_DEFAULT),
+
+    // @Param: FF
+    // @DisplayName: PID Feed Forward Gain
+    // @Description: FF Gain which produces an output that is proportional to the magnitude of the target
+    AP_GROUPINFO("FF",    6, AC_PID_2D, _kff, 0),
 
     AP_GROUPEND
 };
 
 // Constructor
-AC_PID_2D::AC_PID_2D(float initial_p, float initial_i, float initial_d, float initial_imax, float initial_filt_hz, float initial_filt_d_hz, float dt) :
+AC_PID_2D::AC_PID_2D(float initial_kP, float initial_kI, float initial_kD, float initial_kFF, float initial_imax, float initial_filt_E_hz, float initial_filt_D_hz, float dt) :
     _dt(dt)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
 
-    _kp = initial_p;
-    _ki = initial_i;
-    _kd = initial_d;
-    _imax = fabsf(initial_imax);
-    filt_hz(initial_filt_hz);
-    filt_d_hz(initial_filt_d_hz);
+    _kp = initial_kP;
+    _ki = initial_kI;
+    _kd = initial_kD;
+    _kff = initial_kFF;
+    _kimax = fabsf(initial_imax);
+    filt_E_hz(initial_filt_E_hz);
+    filt_D_hz(initial_filt_D_hz);
 
-    // reset input filter to first value received and derivitive to zero
-    reset_filter();
+    // reset input filter to first value received
+    _reset_filter = true;
 }
 
-// set_dt - set time step in seconds
-void AC_PID_2D::set_dt(float dt)
-{
-    // set dt and calculate the input filter alpha
-    _dt = dt;
-    calc_filt_alpha();
-    calc_filt_alpha_d();
-}
-
-// filt_hz - set input filter hz
-void AC_PID_2D::filt_hz(float hz)
-{
-    _filt_hz.set(fabsf(hz));
-
-    // sanity check _filt_hz
-    _filt_hz = MAX(_filt_hz, AC_PID_2D_FILT_HZ_MIN);
-
-    // calculate the input filter alpha
-    calc_filt_alpha();
-}
-
-// filt_d_hz - set input filter hz
-void AC_PID_2D::filt_d_hz(float hz)
-{
-    _filt_d_hz.set(fabsf(hz));
-
-    // sanity check _filt_hz
-    _filt_d_hz = MAX(_filt_d_hz, AC_PID_2D_FILT_D_HZ_MIN);
-
-    // calculate the input filter alpha
-    calc_filt_alpha_d();
-}
-
-// set_input - set input to PID controller
-//  input is filtered before the PID controllers are run
-//  this should be called before any other calls to get_p, get_i or get_d
-void AC_PID_2D::set_input(const Vector2f &input)
+//  update_all - set target and measured inputs to PID controller and calculate outputs
+//  target and error are filtered
+//  the derivative is then calculated and filtered
+//  the integral is then updated based on the setting of the limit flag
+Vector2f AC_PID_2D::update_all(const Vector2f &target, const Vector2f &measurement, bool limit)
 {
     // don't process inf or NaN
-    if (!isfinite(input.x) || !isfinite(input.y)) {
-        return;
+    if (target.is_nan() || target.is_inf() ||
+        measurement.is_nan() || measurement.is_inf()) {
+        return Vector2f{};
     }
+
+    _target = target;
 
     // reset input filter to value received
-    if (_flags._reset_filter) {
-        _flags._reset_filter = false;
-        _input = input;
-    }
+    if (_reset_filter) {
+        _reset_filter = false;
+        _error = _target - measurement;
+        _derivative.zero();
+    } else {
+        Vector2f error_last{_error};
+        _error += ((_target - measurement) - _error) * get_filt_E_alpha();
 
-    // update filter and calculate derivative
-    const Vector2f input_delta = (input - _input) * _filt_alpha;
-    _input += input_delta;
-
-    set_input_filter_d(input_delta);
-}
-
-// set_input_filter_d - set input to PID controller
-//  only input to the D portion of the controller is filtered
-//  this should be called before any other calls to get_p, get_i or get_d
-void AC_PID_2D::set_input_filter_d(const Vector2f& input_delta)
-{
-    // don't process inf or NaN
-    if (!isfinite(input_delta.x) && !isfinite(input_delta.y)) {
-        return;
-    }
-
-    // update filter and calculate derivative
-    if (is_positive(_dt)) {
-        const Vector2f derivative = input_delta / _dt;
-        const Vector2f delta_derivative = (derivative - _derivative) * _filt_alpha_d;
-        _derivative += delta_derivative;
-    }
-}
-
-Vector2f AC_PID_2D::get_p() const
-{
-    return (_input * _kp);
-}
-
-Vector2f AC_PID_2D::get_i()
-{
-    if (!is_zero(_ki) && !is_zero(_dt)) {
-        _integrator += (_input * _ki) * _dt;
-        const float integrator_length = _integrator.length();
-        if ((integrator_length > _imax) && is_positive(integrator_length)) {
-            _integrator *= (_imax / integrator_length);
+        // calculate and filter derivative
+        if (_dt > 0.0f) {
+            const Vector2f derivative{(_error - error_last) / _dt};
+            _derivative += (derivative - _derivative) * get_filt_D_alpha();
         }
-        return _integrator;
     }
-    return Vector2f();
+
+    // update I term
+    update_i(limit);
+
+    _pid_info_x.target = _target.x;
+    _pid_info_x.actual = measurement.x;
+    _pid_info_x.error = _error.x;
+    _pid_info_x.P = _error.x * _kp;
+    _pid_info_x.I = _integrator.x;
+    _pid_info_x.D = _derivative.x * _kd;
+    _pid_info_x.FF = _target.x * _kff;
+
+    _pid_info_y.target = _target.y;
+    _pid_info_y.actual = measurement.y;
+    _pid_info_y.error = _error.y;
+    _pid_info_y.P = _error.y * _kp;
+    _pid_info_y.I = _integrator.y;
+    _pid_info_y.D = _derivative.y * _kd;
+    _pid_info_y.FF = _target.y * _kff;
+
+    return _error * _kp + _integrator + _derivative * _kd + _target * _kff;
 }
 
-// get_i_shrink - get_i but do not allow integrator to grow in length (it may shrink)
-Vector2f AC_PID_2D::get_i_shrink()
+Vector2f AC_PID_2D::update_all(const Vector3f &target, const Vector3f &measurement, bool limit)
 {
-    if (!is_zero(_ki) && !is_zero(_dt)) {
-        const float integrator_length_orig = MIN(_integrator.length(), _imax);
-        _integrator += (_input * _ki) * _dt;
-        const float integrator_length_new = _integrator.length();
-        if ((integrator_length_new > integrator_length_orig) && is_positive(integrator_length_new)) {
-            _integrator *= (integrator_length_orig / integrator_length_new);
-        }
-        return _integrator;
+    return update_all(Vector2f{target.x, target.y}, Vector2f{measurement.x, measurement.y}, limit);
+}
+
+//  update_i - update the integral
+//  If the limit flag is set the integral is only allowed to shrink
+void AC_PID_2D::update_i(bool limit)
+{
+    float integrator_length_orig = _kimax;
+    if (limit) {
+        integrator_length_orig = MIN(integrator_length_orig, _integrator.length());
     }
-    return Vector2f();
-}
-
-Vector2f AC_PID_2D::get_d()
-{
-    // derivative component
-    return Vector2f(_kd * _derivative.x, _kd * _derivative.y);
-}
-
-Vector2f AC_PID_2D::get_pid()
-{
-    return get_p() + get_i() + get_d();
-}
-
-void AC_PID_2D::reset_I()
-{
-    _integrator.zero();
-}
-
-void AC_PID_2D::reset_filter()
-{
-    _flags._reset_filter = true;
-    _derivative.x = 0.0f;
-    _derivative.y = 0.0f;
-    _integrator.zero();
-}
-
-void AC_PID_2D::load_gains()
-{
-    _kp.load();
-    _ki.load();
-    _kd.load();
-    _imax.load();
-    _imax = fabsf(_imax);
-    _filt_hz.load();
-    _filt_d_hz.load();
-
-    // calculate the input filter alpha
-    calc_filt_alpha();
-    calc_filt_alpha_d();
+    _integrator += (_error * _ki) * _dt;
+    const float integrator_length_new = _integrator.length();
+    if (integrator_length_new > integrator_length_orig) {
+        _integrator *= (integrator_length_orig / integrator_length_new);
+    }
 }
 
 // save_gains - save gains to eeprom
@@ -215,33 +147,40 @@ void AC_PID_2D::save_gains()
     _kp.save();
     _ki.save();
     _kd.save();
-    _imax.save();
-    _filt_hz.save();
-    _filt_d_hz.save();
+    _kff.save();
+    _kimax.save();
+    _filt_E_hz.save();
+    _filt_D_hz.save();
 }
 
-// calc_filt_alpha - recalculate the input filter alpha
-void AC_PID_2D::calc_filt_alpha()
+// get the target filter alpha
+float AC_PID_2D::get_filt_E_alpha() const
 {
-    if (is_zero(_filt_hz)) {
-        _filt_alpha = 1.0f;
-        return;
-    }
-  
-    // calculate alpha
-    const float rc = 1/(M_2PI*_filt_hz);
-    _filt_alpha = _dt / (_dt + rc);
+    return calc_lowpass_alpha_dt(_dt, _filt_E_hz);
 }
 
-// calc_filt_alpha - recalculate the input filter alpha
-void AC_PID_2D::calc_filt_alpha_d()
+// get the derivative filter alpha
+float AC_PID_2D::get_filt_D_alpha() const
 {
-    if (is_zero(_filt_d_hz)) {
-        _filt_alpha_d = 1.0f;
-        return;
-    }
-
-    // calculate alpha
-    const float rc = 1/(M_2PI*_filt_d_hz);
-    _filt_alpha_d = _dt / (_dt + rc);
+    return calc_lowpass_alpha_dt(_dt, _filt_D_hz);
 }
+
+void AC_PID_2D::set_integrator(const Vector2f& target, const Vector2f& measurement, const Vector2f& i)
+{
+    set_integrator(target - measurement, i);
+}
+
+void AC_PID_2D::set_integrator(const Vector2f& error, const Vector2f& i)
+{
+    set_integrator(i - error * _kp);
+}
+
+void AC_PID_2D::set_integrator(const Vector2f& i)
+{
+    _integrator = i;
+    const float integrator_length = _integrator.length();
+    if (integrator_length > _kimax) {
+        _integrator *= (_kimax / integrator_length);
+    }
+}
+

--- a/libraries/AC_PID/AC_PID_2D.h
+++ b/libraries/AC_PID/AC_PID_2D.h
@@ -7,6 +7,7 @@
 #include <AP_Param/AP_Param.h>
 #include <stdlib.h>
 #include <cmath>
+#include <AP_Logger/AP_Logger.h>
 
 /// @class	AC_PID_2D
 /// @brief	Copter PID control class
@@ -14,91 +15,88 @@ class AC_PID_2D {
 public:
 
     // Constructor for PID
-    AC_PID_2D(float initial_p, float initial_i, float initial_d, float initial_imax, float initial_filt_hz, float initial_filt_d_hz, float dt);
+    AC_PID_2D(float initial_kP, float initial_kI, float initial_kD, float initial_kFF, float initial_imax, float initial_filt_hz, float initial_filt_d_hz, float dt);
 
-    // set_dt - set time step in seconds
-    void        set_dt(float dt);
+    // set time step in seconds
+    void set_dt(float dt) { _dt = dt; }
 
-    // set_input - set input to PID controller
-    //  input is filtered before the PID controllers are run
-    //  this should be called before any other calls to get_p, get_i or get_d
-    void        set_input(const Vector2f &input);
-    void        set_input(const Vector3f &input) { set_input(Vector2f(input.x, input.y)); }
+    // update_all - set target and measured inputs to PID controller and calculate outputs
+    // target and error are filtered
+    // the derivative is then calculated and filtered
+    // the integral is then updated based on the setting of the limit flag
+    Vector2f update_all(const Vector2f &target, const Vector2f &measurement, bool limit = false);
+    Vector2f update_all(const Vector3f &target, const Vector3f &measurement, bool limit = false);
 
-    // get_pi - get results from pid controller
-    Vector2f    get_pid();
-    Vector2f    get_p() const;
-    Vector2f    get_i();
-    Vector2f    get_i_shrink();   // get_i but do not allow integrator to grow (it may shrink)
-    Vector2f    get_d();
+    // update the integral
+    // if the limit flag is set the integral is only allowed to shrink
+    void update_i(bool limit);
 
-    // reset_I - reset the integrator
-    void        reset_I();
+    // get results from pid controller
+    Vector2f get_p() const;
+    Vector2f get_i() const;
+    Vector2f get_d() const;
+    Vector2f get_ff();
+
+    // reset the integrator
+    void reset_I() { _integrator.zero(); };
 
     // reset_filter - input and D term filter will be reset to the next value provided to set_input()
-    void        reset_filter();
-
-    // load gain from eeprom
-    void        load_gains();
+    void reset_filter() { _reset_filter = true; }
 
     // save gain to eeprom
-    void        save_gains();
+    void save_gains();
 
     // get accessors
-    AP_Float   &kP() { return _kp; }
-    AP_Float   &kI() { return _ki; }
-    float       imax() const { return _imax.get(); }
-    float       filt_hz() const { return _filt_hz.get(); }
-    float       get_filt_alpha() const { return _filt_alpha; }
-    float       filt_d_hz() const { return _filt_d_hz.get(); }
-    float       get_filt_alpha_D() const { return _filt_alpha_d; }
+    AP_Float &kP() { return _kp; }
+    AP_Float &kI() { return _ki; }
+    AP_Float &kD() { return _kd; }
+    AP_Float &ff() { return _kff;}
+    AP_Float &filt_E_hz() { return _filt_E_hz; }
+    AP_Float &filt_D_hz() { return _filt_D_hz; }
+    float imax() const { return _kimax.get(); }
+    float get_filt_E_alpha() const;
+    float get_filt_D_alpha() const;
 
     // set accessors
-    void        kP(const float v) { _kp.set(v); }
-    void        kI(const float v) { _ki.set(v); }
-    void        kD(const float v) { _kd.set(v); }
-    void        imax(const float v) { _imax.set(fabsf(v)); }
-    void        filt_hz(const float v);
-    void        filt_d_hz(const float v);
+    void kP(float v) { _kp.set(v); }
+    void kI(float v) { _ki.set(v); }
+    void kD(float v) { _kd.set(v); }
+    void ff(float v) { _kff.set(v); }
+    void imax(float v) { _kimax.set(fabsf(v)); }
+    void filt_E_hz(float hz) { _filt_E_hz.set(fabsf(hz)); }
+    void filt_D_hz(float hz) { _filt_D_hz.set(fabsf(hz)); }
 
-    Vector2f    get_integrator() const { return _integrator; }
-    void        set_integrator(const Vector2f &i) { _integrator = i; }
-    void        set_integrator(const Vector3f &i) { _integrator.x = i.x; _integrator.y = i.y; }
+    // integrator setting functions
+    void set_integrator(const Vector2f& target, const Vector2f& measurement, const Vector2f& i);
+    void set_integrator(const Vector2f& error, const Vector2f& i);
+    void set_integrator(const Vector3f& i) { set_integrator(Vector2f(i.x, i.y)); }
+    void set_integrator(const Vector2f& i);
+
+    const AP_Logger::PID_Info& get_pid_info_x(void) const { return _pid_info_x; }
+    const AP_Logger::PID_Info& get_pid_info_y(void) const { return _pid_info_y; }
 
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:
 
-    // set_input_filter_d - set input to PID controller
-    //  only input to the D portion of the controller is filtered
-    //  this should be called before any other calls to get_p, get_i or get_d
-    void        set_input_filter_d(const Vector2f& input_delta);
-
-    // calc_filt_alpha - recalculate the input filter alpha
-    void        calc_filt_alpha();
-
-    // calc_filt_alpha - recalculate the input filter alpha
-    void        calc_filt_alpha_d();
-
     // parameters
-    AP_Float        _kp;
-    AP_Float        _ki;
-    AP_Float        _kd;
-    AP_Float        _imax;
-    AP_Float        _filt_hz;                   // PID Input filter frequency in Hz
-    AP_Float        _filt_d_hz;                 // D term filter frequency in Hz
-
-    // flags
-    struct ac_pid_flags {
-        bool        _reset_filter : 1;    // true when input filter should be reset during next call to set_input
-    } _flags;
+    AP_Float _kp;
+    AP_Float _ki;
+    AP_Float _kd;
+    AP_Float _kff;
+    AP_Float _kimax;
+    AP_Float _filt_E_hz;         // PID error filter frequency in Hz
+    AP_Float _filt_D_hz;         // PID derivative filter frequency in Hz
 
     // internal variables
-    float           _dt;            // timestep in seconds
-    float           _filt_alpha;    // input filter alpha
-    float           _filt_alpha_d;  // input filter alpha
-    Vector2f        _integrator;    // integrator value
-    Vector2f        _input;         // last input for derivative
-    Vector2f        _derivative;    // last derivative for low-pass filter
+    float       _dt;            // timestep in seconds
+    Vector2f    _target;        // target value to enable filtering
+    Vector2f    _error;         // error value to enable filtering
+    Vector2f    _derivative;    // last derivative from low-pass filter
+    Vector2f    _integrator;    // integrator value
+    bool        _reset_filter;  // true when input filter should be reset during next call to update_all
+
+    AP_Logger::PID_Info _pid_info_x;
+    AP_Logger::PID_Info _pid_info_y;
 };

--- a/libraries/AC_PID/AC_PID_Basic.cpp
+++ b/libraries/AC_PID/AC_PID_Basic.cpp
@@ -1,0 +1,179 @@
+/// @file	AC_PID_Basic.cpp
+/// @brief	Generic PID algorithm
+
+#include <AP_Math/AP_Math.h>
+#include <AP_InternalError/AP_InternalError.h>
+#include "AC_PID_Basic.h"
+
+#define AC_PID_Basic_FILT_E_HZ_DEFAULT 20.0f   // default input filter frequency
+#define AC_PID_Basic_FILT_E_HZ_MIN     0.01f   // minimum input filter frequency
+#define AC_PID_Basic_FILT_D_HZ_DEFAULT 10.0f   // default input filter frequency
+#define AC_PID_Basic_FILT_D_HZ_MIN     0.005f  // minimum input filter frequency
+
+const AP_Param::GroupInfo AC_PID_Basic::var_info[] = {
+    // @Param: P
+    // @DisplayName: PID Proportional Gain
+    // @Description: P Gain which produces an output value that is proportional to the current error value
+    AP_GROUPINFO("P",    0, AC_PID_Basic, _kp, 0),
+
+    // @Param: I
+    // @DisplayName: PID Integral Gain
+    // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
+    AP_GROUPINFO("I",    1, AC_PID_Basic, _ki, 0),
+
+    // @Param: IMAX
+    // @DisplayName: PID Integral Maximum
+    // @Description: The maximum/minimum value that the I term can output
+    AP_GROUPINFO("IMAX", 2, AC_PID_Basic, _kimax, 0),
+
+    // @Param: FLTE
+    // @DisplayName: PID Error filter frequency in Hz
+    // @Description: Error filter frequency in Hz
+    // @Units: Hz
+    AP_GROUPINFO("FLTE", 3, AC_PID_Basic, _filt_E_hz, AC_PID_Basic_FILT_E_HZ_DEFAULT),
+
+    // @Param: D
+    // @DisplayName: PID Derivative Gain
+    // @Description: D Gain which produces an output that is proportional to the rate of change of the error
+    AP_GROUPINFO("D",    4, AC_PID_Basic, _kd, 0),
+
+    // @Param: FLTD
+    // @DisplayName: D term filter frequency in Hz
+    // @Description: D term filter frequency in Hz
+    // @Units: Hz
+    AP_GROUPINFO("FLTD", 5, AC_PID_Basic, _filt_D_hz, AC_PID_Basic_FILT_D_HZ_DEFAULT),
+
+    // @Param: FF
+    // @DisplayName: PID Feed Forward Gain
+    // @Description: FF Gain which produces an output that is proportional to the magnitude of the target
+    AP_GROUPINFO("FF",   6, AC_PID_Basic, _kff, 0),
+
+    AP_GROUPEND
+};
+
+// Constructor
+AC_PID_Basic::AC_PID_Basic(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_E_hz, float initial_filt_D_hz, float dt) :
+    _dt(dt)
+{
+    // load parameter values from eeprom
+    AP_Param::setup_object_defaults(this, var_info);
+
+    _kp = initial_p;
+    _ki = initial_i;
+    _kd = initial_d;
+    _kff = initial_ff;
+    _kimax = fabsf(initial_imax);
+    filt_E_hz(initial_filt_E_hz);
+    filt_D_hz(initial_filt_D_hz);
+
+    // reset input filter to first value received
+    _reset_filter = true;
+}
+
+float AC_PID_Basic::update_all(float target, float measurement, bool limit)
+{
+    return update_all(target, measurement, (limit && is_negative(_integrator)), (limit && is_positive(_integrator)));
+}
+
+//  update_all - set target and measured inputs to PID controller and calculate outputs
+//  target and error are filtered
+//  the derivative is then calculated and filtered
+//  the integral is then updated based on the setting of the limit flag
+float AC_PID_Basic::update_all(float target, float measurement, bool limit_neg, bool limit_pos)
+{
+    // don't process inf or NaN
+    if (!isfinite(target) || isnan(target) ||
+        !isfinite(measurement) || isnan(measurement)) {
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        return 0.0f;
+    }
+
+    _target = target;
+
+    // reset input filter to value received
+    if (_reset_filter) {
+        _reset_filter = false;
+        _error = _target - measurement;
+        _derivative = 0.0f;
+    } else {
+        float error_last = _error;
+        _error += get_filt_E_alpha() * ((_target - measurement) - _error);
+
+        // calculate and filter derivative
+        if (is_positive(_dt)) {
+            float derivative = (_error - error_last) / _dt;
+            _derivative += get_filt_D_alpha() * (derivative - _derivative);
+        }
+    }
+
+    // update I term
+    update_i(limit_neg, limit_pos);
+
+    const float P_out = _error * _kp;
+    const float D_out = _derivative * _kd;
+
+    _pid_info.target = _target;
+    _pid_info.actual = measurement;
+    _pid_info.error = _error;
+    _pid_info.P = _error * _kp;
+    _pid_info.I = _integrator;
+    _pid_info.D = _derivative * _kd;
+    _pid_info.FF = _target * _kff;
+
+    return P_out + _integrator + D_out + _target * _kff;
+}
+
+//  update_i - update the integral
+//  if limit_neg is true, the integral can only increase
+//  if limit_pos is true, the integral can only decrease
+void AC_PID_Basic::update_i(bool limit_neg, bool limit_pos)
+{
+    if (!is_zero(_ki)) {
+        // Ensure that integrator can only be reduced if the output is saturated
+        if (!((limit_neg && is_negative(_error)) || (limit_pos && is_positive(_error)))) {
+            _integrator += ((float)_error * _ki) * _dt;
+            _integrator = constrain_float(_integrator, -_kimax, _kimax);
+        }
+    } else {
+        _integrator = 0.0f;
+    }
+}
+
+// save_gains - save gains to eeprom
+void AC_PID_Basic::save_gains()
+{
+    _kp.save();
+    _ki.save();
+    _kd.save();
+    _kff.save();
+    _kimax.save();
+    _filt_E_hz.save();
+    _filt_D_hz.save();
+}
+
+// get_filt_T_alpha - get the target filter alpha
+float AC_PID_Basic::get_filt_E_alpha() const
+{
+    return calc_lowpass_alpha_dt(_dt, _filt_E_hz);
+}
+
+// get_filt_D_alpha - get the derivative filter alpha
+float AC_PID_Basic::get_filt_D_alpha() const
+{
+    return calc_lowpass_alpha_dt(_dt, _filt_D_hz);
+}
+
+void AC_PID_Basic::set_integrator(float target, float measurement, float i)
+{
+    set_integrator(target - measurement, i);
+}
+
+void AC_PID_Basic::set_integrator(float error, float i)
+{
+    set_integrator(i - error * _kp);
+}
+
+void AC_PID_Basic::set_integrator(float i)
+{
+    _integrator = constrain_float(i, -_kimax, _kimax);
+}

--- a/libraries/AC_PID/AC_PID_Basic.h
+++ b/libraries/AC_PID/AC_PID_Basic.h
@@ -1,0 +1,97 @@
+#pragma once
+
+/// @file	AC_PID_Basic.h
+/// @brief	Generic PID algorithm, with EEPROM-backed storage of constants.
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Logger/AP_Logger.h>
+
+/// @class	AC_PID_Basic
+/// @brief	Copter PID control class
+class AC_PID_Basic {
+public:
+
+    // Constructor for PID
+    AC_PID_Basic(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_E_hz, float initial_filt_D_hz, float dt);
+
+    // set time step in seconds
+    void set_dt(float dt) { _dt = dt; }
+
+    // set target and measured inputs to PID controller and calculate outputs
+    // target and error are filtered
+    // the derivative is then calculated and filtered
+    // the integral is then updated based on the setting of the limit flag
+    float update_all(float target, float measurement, bool limit = false) WARN_IF_UNUSED;
+    float update_all(float target, float measurement, bool limit_neg, bool limit_pos) WARN_IF_UNUSED;
+
+    // update the integral
+    // if the limit flags are set the integral is only allowed to shrink
+    void update_i(bool limit_neg, bool limit_pos);
+
+    // get results from pid controller
+    float get_p() const WARN_IF_UNUSED { return _error * _kp; }
+    float get_i() const WARN_IF_UNUSED { return _integrator; }
+    float get_d() const WARN_IF_UNUSED { return _derivative * _kd; }
+    float get_ff() const WARN_IF_UNUSED { return _target * _kff; }
+
+    // reset the integrator
+    void reset_I() { _integrator = 0.0f; }
+
+    // input and D term filter will be reset to the next value provided to set_input()
+    void reset_filter() { _reset_filter = true; }
+
+    // save gain to eeprom
+    void save_gains();
+
+    // get accessors
+    AP_Float &kP() WARN_IF_UNUSED { return _kp; }
+    AP_Float &kI() WARN_IF_UNUSED { return _ki; }
+    AP_Float &kD() WARN_IF_UNUSED { return _kd; }
+    AP_Float &ff() WARN_IF_UNUSED { return _kff;}
+    AP_Float &filt_E_hz() WARN_IF_UNUSED { return _filt_E_hz; }
+    AP_Float &filt_D_hz() WARN_IF_UNUSED { return _filt_D_hz; }
+    float imax() const WARN_IF_UNUSED { return _kimax.get(); }
+    float get_filt_E_alpha() const WARN_IF_UNUSED;
+    float get_filt_D_alpha() const WARN_IF_UNUSED;
+
+    // set accessors
+    void kP(float v) { _kp.set(v); }
+    void kI(float v) { _ki.set(v); }
+    void kD(float v) { _kd.set(v); }
+    void ff(float v) { _kff.set(v); }
+    void imax(float v) { _kimax.set(fabsf(v)); }
+    void filt_E_hz(float hz) { _filt_E_hz.set(fabsf(hz)); }
+    void filt_D_hz(float hz) { _filt_D_hz.set(fabsf(hz)); }
+
+    // integrator setting functions
+    void set_integrator(float target, float measurement, float i);
+    void set_integrator(float error, float i);
+    void set_integrator(float i);
+
+    const AP_Logger::PID_Info& get_pid_info(void) const WARN_IF_UNUSED { return _pid_info; }
+
+    // parameter var table
+    static const struct AP_Param::GroupInfo var_info[];
+
+protected:
+
+    // parameters
+    AP_Float _kp;
+    AP_Float _ki;
+    AP_Float _kd;
+    AP_Float _kff;
+    AP_Float _kimax;
+    AP_Float _filt_E_hz;         // PID error filter frequency in Hz
+    AP_Float _filt_D_hz;         // PID derivative filter frequency in Hz
+
+    // internal variables
+    float _dt;          // timestep in seconds
+    float _target;      // target value to enable filtering
+    float _error;       // error value to enable filtering
+    float _derivative;  // last derivative for low-pass filter
+    float _integrator;  // integrator value
+    bool _reset_filter; // true when input filter should be reset during next call to set_input
+
+    AP_Logger::PID_Info _pid_info;
+};

--- a/libraries/AC_PID/AC_PI_2D.cpp
+++ b/libraries/AC_PID/AC_PI_2D.cpp
@@ -1,27 +1,27 @@
 /// @file	AC_PI_2D.cpp
-/// @brief	Generic PID algorithm
+/// @brief	2-axis PI controller
 
 #include <AP_Math/AP_Math.h>
 #include "AC_PI_2D.h"
 
 const AP_Param::GroupInfo AC_PI_2D::var_info[] = {
     // @Param: P
-    // @DisplayName: PID Proportional Gain
+    // @DisplayName: PI Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
     AP_GROUPINFO("P",    0, AC_PI_2D, _kp, 0),
 
     // @Param: I
-    // @DisplayName: PID Integral Gain
+    // @DisplayName: PI Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
     AP_GROUPINFO("I",    1, AC_PI_2D, _ki, 0),
 
     // @Param: IMAX
-    // @DisplayName: PID Integral Maximum
+    // @DisplayName: PI Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
     AP_GROUPINFO("IMAX", 2, AC_PI_2D, _imax, 0),
 
     // @Param: FILT_HZ
-    // @DisplayName: PID Input filter frequency in Hz
+    // @DisplayName: PI Input filter frequency in Hz
     // @Description: Input filter frequency in Hz
     // @Units: Hz
     AP_GROUPINFO("FILT_HZ", 3, AC_PI_2D, _filt_hz, AC_PI_2D_FILT_HZ_DEFAULT),
@@ -101,7 +101,7 @@ Vector2f AC_PI_2D::get_i()
         }
         return _integrator;
     }
-    return Vector2f();
+    return Vector2f{};
 }
 
 // get_i_shrink - get_i but do not allow integrator to grow in length (it may shrink)
@@ -116,7 +116,7 @@ Vector2f AC_PI_2D::get_i_shrink()
         }
         return _integrator;
     }
-    return Vector2f();
+    return Vector2f{};
 }
 
 Vector2f AC_PI_2D::get_pi()

--- a/libraries/AC_PID/AC_PI_2D.h
+++ b/libraries/AC_PID/AC_PI_2D.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file	AC_PI_2D.h
-/// @brief	Generic PID algorithm, with EEPROM-backed storage of constants.
+/// @brief	2-axis PI controller with EEPROM-backed storage of constants.
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -12,18 +12,18 @@
 #define AC_PI_2D_FILT_HZ_MIN      0.01f   // minimum input filter frequency
 
 /// @class	AC_PI_2D
-/// @brief	Copter PID control class
+/// @brief	2-axis PI controller
 class AC_PI_2D {
 public:
 
-    // Constructor for PID
+    // constructor
     AC_PI_2D(float initial_p, float initial_i, float initial_imax, float initial_filt_hz, float dt);
 
     // set time step in seconds
     void set_dt(float dt);
 
-    // set_input - set input to PID controller
-    //  input is filtered before the PID controllers are run
+    // set_input - set input to PI controller
+    //  input is filtered before the PI controllers are run
     //  this should be called before any other calls to get_p, get_i or get_d
     void set_input(const Vector2f &input);
     void set_input(const Vector3f &input) { set_input(Vector2f(input.x, input.y)); }
@@ -78,7 +78,7 @@ private:
     AP_Float _kp;
     AP_Float _ki;
     AP_Float _imax;
-    AP_Float _filt_hz;  // PID Input filter frequency in Hz
+    AP_Float _filt_hz;  // PI Input filter frequency in Hz
 
     // flags
     struct ac_pid_flags {

--- a/libraries/AC_PID/AC_P_1D.cpp
+++ b/libraries/AC_PID/AC_P_1D.cpp
@@ -1,0 +1,65 @@
+/// @file	AC_P_1D.cpp
+/// @brief	Generic P algorithm
+
+#include <AP_Math/AP_Math.h>
+#include "AC_P_1D.h"
+
+const AP_Param::GroupInfo AC_P_1D::var_info[] = {
+    // @Param: P
+    // @DisplayName: P Proportional Gain
+    // @Description: P Gain which produces an output value that is proportional to the current error value
+    AP_GROUPINFO("P",    0, AC_P_1D, _kp, 0),
+    AP_GROUPEND
+};
+
+// Constructor
+AC_P_1D::AC_P_1D(float initial_p, float dt) :
+    _dt(dt)
+{
+    // load parameter values from eeprom
+    AP_Param::setup_object_defaults(this, var_info);
+
+    _kp = initial_p;
+    _lim_D_Out = 10.0f;     // maximum first differential of output
+}
+
+// update_all - set target and measured inputs to P controller and calculate outputs
+// target and measurement are filtered
+// if measurement is further than error_min or error_max (see set_limits_error method)
+//   the target is moved closer to the measurement and limit_min or limit_max will be set true
+float AC_P_1D::update_all(float &target, float measurement, bool &limit_min, bool &limit_max)
+{
+    limit_min = false;
+    limit_max = false;
+
+    // calculate distance _error
+    float error = target - measurement;
+
+    if (error < _lim_err_min) {
+        error = _lim_err_min;
+        target = measurement + error;
+        limit_min = true;
+    } else if (error > _lim_err_max) {
+        error = _lim_err_max;
+        target = measurement + error;
+        limit_max = true;
+    }
+
+    // ToDo: Replace sqrt_controller with optimal acceleration and jerk limited curve
+    // MIN(_Dxy_max, _D2xy_max / _kxy_P) limits the max accel to the point where max jerk is exceeded
+    return sqrt_controller(error, _kp, _lim_D_Out, _dt);
+}
+
+// set limits on error, output and output from D term
+// in normal use the lim_err_min and lim_out_min will be negative
+// when using for a position controller, lim_err will be position error, lim_out will be correction velocity, lim_D will be acceleration, lim_D2 will be jerk
+void AC_P_1D::set_limits_error(float lim_err_min, float lim_err_max, float lim_out_min, float lim_out_max, float lim_D_Out, float lim_D2_Out)
+{
+    _lim_D_Out = lim_D_Out;
+    if (is_positive(lim_D2_Out)) {
+        // limit the first derivative so as not to exceed the second derivative
+        _lim_D_Out = MIN(_lim_D_Out, lim_D2_Out / _kp);
+    }
+    _lim_err_min = MAX(inv_sqrt_controller(lim_out_min, _kp, _lim_D_Out), lim_err_min);
+    _lim_err_max = MAX(inv_sqrt_controller(lim_out_max, _kp, _lim_D_Out), lim_err_max);
+}

--- a/libraries/AC_PID/AC_P_1D.h
+++ b/libraries/AC_PID/AC_P_1D.h
@@ -1,0 +1,50 @@
+#pragma once
+
+/// @file	AC_P_1D.h
+/// @brief	Generic P controller, with EEPROM-backed storage of constants.
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+
+/// @class	AC_P_1D
+/// @brief	Object managing one P controller
+class AC_P_1D {
+public:
+
+    // constructor
+    AC_P_1D(float initial_p, float dt);
+
+    // set time step in seconds
+    void set_dt(float dt) { _dt = dt; }
+
+    // update_all - set target and measured inputs to P controller and calculate outputs
+    // target and measurement are filtered
+    // if measurement is further than error_min or error_max (see set_limits_error method)
+    //   the target is moved closer to the measurement and limit_min or limit_max will be set true
+    float update_all(float &target, float measurement, bool &limit_min, bool &limit_max) WARN_IF_UNUSED;
+
+    // save gain to eeprom
+    void save_gains() { _kp.save(); }
+
+    // set limits on error, output and output from D term
+    void set_limits_error(float error_min, float error_max, float output_min, float output_max, float D_Out_max = 0.0f, float D2_Out_max = 0.0f);
+
+    // accessors
+    AP_Float &kP() WARN_IF_UNUSED { return _kp; }
+    const AP_Float &kP() const WARN_IF_UNUSED { return _kp; }
+    void kP(float v) { _kp.set(v); }
+
+    // parameter var table
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+
+    // parameters
+    AP_Float _kp;
+
+    // internal variables
+    float _dt;          // time step in seconds
+    float _lim_err_min; // error limit in negative direction
+    float _lim_err_max; // error limit in positive direction
+    float _lim_D_Out;   // maximum first differential of output
+};

--- a/libraries/AC_PID/AC_P_2D.cpp
+++ b/libraries/AC_PID/AC_P_2D.cpp
@@ -1,0 +1,41 @@
+/// @file   AC_P_2D.cpp
+/// @brief  2-axis P controller
+
+#include <AP_Math/AP_Math.h>
+#include "AC_P_2D.h"
+
+const AP_Param::GroupInfo AC_P_2D::var_info[] = {
+    // @Param: P
+    // @DisplayName: Proportional Gain
+    // @Description: P Gain which produces an output value that is proportional to the current error value
+    AP_GROUPINFO("P",    0, AC_P_2D, _kp, 0),
+    AP_GROUPEND
+};
+
+// Constructor
+AC_P_2D::AC_P_2D(float initial_p, float dt) :
+    _dt(dt)
+{
+    // load parameter values from eeprom
+    AP_Param::setup_object_defaults(this, var_info);
+
+    _kp = initial_p;
+}
+
+//  set target and measured inputs to P controller and calculate outputs
+Vector2f AC_P_2D::update_all(float &target_x, float &target_y, const Vector2f &measurement, float error_max, float D2_max)
+{
+    // calculate distance _error
+    Vector2f error = Vector2f(target_x, target_y) - measurement;
+
+    // Constrain _error and target position
+    // Constrain the maximum length of _vel_target to the maximum position correction velocity
+    if (error.limit_length(error_max)) {
+        target_x = measurement.x + error.x;
+        target_y = measurement.y + error.y;
+    }
+
+    // MIN(_Dmax, _D2max / _kp) limits the max accel to the point where max jerk is exceeded
+    // return sqrt_controller(Vector2f(_error.x, _error.y), _kp, MIN(_D_max, _D2_max / _kp), _dt);
+    return sqrt_controller(error, _kp, D2_max, _dt);
+}

--- a/libraries/AC_PID/AC_P_2D.h
+++ b/libraries/AC_PID/AC_P_2D.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/// @file   AC_P_2D.h
+/// @brief  2-axis P controller with EEPROM-backed storage of constants.
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+
+/// @class  AC_P_2D
+/// @brief  2-axis P controller
+class AC_P_2D {
+public:
+
+    // constructor
+    AC_P_2D(float initial_p, float dt);
+
+    // set time step in seconds
+    void set_dt(float dt) { _dt = dt; }
+
+    // set target and measured inputs to P controller and calculate outputs
+    Vector2f update_all(float &target_x, float &target_y, const Vector2f &measurement, float error_max, float D2_max) WARN_IF_UNUSED;
+
+    // set target and measured inputs to P controller and calculate outputs
+    // measurement is provided as 3-axis vector but only x and y are used
+    Vector2f update_all(float &target_x, float &target_y, const Vector3f &measurement, float error_max, float D2_max) WARN_IF_UNUSED {
+        return update_all(target_x, target_y, Vector2f(measurement.x, measurement.y), error_max, D2_max);
+    }
+
+    // get accessors
+    AP_Float &kP() WARN_IF_UNUSED { return _kp; }
+    const AP_Float &kP() const WARN_IF_UNUSED { return _kp; }
+
+    // set accessor
+    void kP(float v) { _kp.set(v); }
+
+    // parameter var table
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+    // parameters
+    AP_Float    _kp;
+
+    // internal variables
+    float _dt;          // time step in seconds
+};

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -80,7 +80,7 @@ public:
     void get_closest_point_on_circle(Vector3f &result) const;
 
     /// get horizontal distance to loiter target in cm
-    float get_distance_to_target() const { return _pos_control.get_distance_to_target(); }
+    float get_distance_to_target() const { return _pos_control.get_pos_error_xy(); }
 
     /// get bearing to target in centi-degrees
     int32_t get_bearing_to_target() const { return _pos_control.get_bearing_to_target(); }

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -39,7 +39,7 @@ public:
     void get_stopping_point_xy(Vector3f& stopping_point) const;
 
     /// get horizontal distance to loiter target in cm
-    float get_distance_to_target() const { return _pos_control.get_distance_to_target(); }
+    float get_distance_to_target() const { return _pos_control.get_pos_error_xy(); }
 
     /// get bearing to target in centi-degrees
     int32_t get_bearing_to_target() const { return _pos_control.get_bearing_to_target(); }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -237,14 +237,19 @@ bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
     return set_wp_destination_next(dest_neu, terr_alt);
 }
 
+// get destination as a location.  Altitude frame will be absolute (AMSL) or above terrain
+// returns false if unable to return a destination (for example if origin has not yet been set)
 bool AC_WPNav::get_wp_destination_loc(Location& destination) const
 {
-    Vector3f dest = get_wp_destination();
     if (!AP::ahrs().get_origin(destination)) {
         return false;
     }
-    destination.offset(dest.x*0.01f, dest.y*0.01f);
-    destination.alt += dest.z;
+    destination.offset(_destination.x*0.01f, _destination.y*0.01f);
+    if (_terrain_alt) {
+        destination.set_alt_cm(_destination.z, Location::AltFrame::ABOVE_TERRAIN);
+    } else {
+        destination.alt += _destination.z;
+    }
     return true;
 }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -67,6 +67,14 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RFND_USE",   10, AC_WPNav, _rangefinder_use, 1),
 
+    // @Param: JERK
+    // @DisplayName: Waypoint Jerk
+    // @Description: Defines the horizontal jerk in m/s/s used during missions
+    // @Units: m/s/s
+    // @Range: 1 20
+    // @User: Standard
+    AP_GROUPINFO("JERK",   11, AC_WPNav, _wp_jerk, 1.0f),
+
     AP_GROUPEND
 };
 
@@ -85,9 +93,6 @@ AC_WPNav::AC_WPNav(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosC
     // init flags
     _flags.reached_destination = false;
     _flags.fast_waypoint = false;
-    _flags.slowing_down = false;
-    _flags.recalc_wp_leash = false;
-    _flags.new_wp_destination = false;
     _flags.segment_type = SEGMENT_STRAIGHT;
 
     // sanity check some parameters
@@ -118,9 +123,10 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 ///
 
 /// wp_and_spline_init - initialise straight line and spline waypoint controllers
+///     speed_cms should be a positive value or left at zero to use the default speed
 ///     updates target roll, pitch targets and I terms based on vehicle lean angles
 ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
-void AC_WPNav::wp_and_spline_init()
+void AC_WPNav::wp_and_spline_init(float speed_cms)
 {
     // check _wp_accel_cmss is reasonable
     if (_wp_accel_cmss <= 0) {
@@ -130,24 +136,48 @@ void AC_WPNav::wp_and_spline_init()
     // initialise position controller
     _pos_control.set_desired_accel_xy(0.0f,0.0f);
     _pos_control.init_xy_controller();
-    _pos_control.clear_desired_velocity_ff_z();
 
     // initialise feed forward velocity to zero
     _pos_control.set_desired_velocity_xy(0.0f, 0.0f);
 
     // initialize the desired wp speed if not already done
-    _wp_desired_speed_xy_cms = _wp_speed_cms;
+    _wp_desired_speed_xy_cms = is_positive(speed_cms) ? speed_cms : _wp_speed_cms;
 
     // initialise position controller speed and acceleration
-    _pos_control.set_max_speed_xy(_wp_speed_cms);
+    _pos_control.set_max_speed_xy(_wp_desired_speed_xy_cms);
     _pos_control.set_max_accel_xy(_wp_accel_cmss);
     _pos_control.set_max_speed_z(-_wp_speed_down_cms, _wp_speed_up_cms);
     _pos_control.set_max_accel_z(_wp_accel_z_cmss);
     _pos_control.calc_leash_length_xy();
     _pos_control.calc_leash_length_z();
 
-    // initialise yaw heading to current heading target
+    // calculate scurve jerk and jerk time
+    if (!is_positive(_wp_jerk)) {
+        _wp_jerk = _wp_accel_cmss;
+    }
+    calc_scurve_jerk_and_jerk_time();
+
+    _scurve_prev_leg.init();
+    _scurve_this_leg.init();
+    _scurve_next_leg.init();
+    _track_scalar_dt = 1.0f;
+
+    // reset input shaped terrain offsets
+    _pos_terrain_offset = 0.0f;
+    _vel_terrain_offset = 0.0f;
+    _accel_terrain_offset = 0.0f;
+
+    // set flag so get_yaw() returns current heading target
     _flags.wp_yaw_set = false;
+    _flags.reached_destination = false;
+    _flags.fast_waypoint = false;
+
+    // initialise origin and destination to stopping point
+    Vector3f stopping_point;
+    get_wp_stopping_point(stopping_point);
+    _origin = _destination = stopping_point;
+    _terrain_alt = false;
+    _this_leg_is_spline = false;
 }
 
 /// set_speed_xy - allows main code to pass target horizontal velocity for wp navigation
@@ -156,6 +186,8 @@ void AC_WPNav::set_speed_xy(float speed_cms)
     // range check target speed
     if (speed_cms >= WPNAV_WP_SPEED_MIN) {
         _wp_desired_speed_xy_cms = speed_cms;
+        _pos_control.set_max_speed_xy(_wp_desired_speed_xy_cms);
+        update_track_with_speed_accel_limits();
     }
 }
 
@@ -163,21 +195,19 @@ void AC_WPNav::set_speed_xy(float speed_cms)
 void AC_WPNav::set_speed_up(float speed_up_cms)
 {
     _pos_control.set_max_speed_z(_pos_control.get_max_speed_down(), speed_up_cms);
-    // flag that wp leash must be recalculated
-    _flags.recalc_wp_leash = true;
+    update_track_with_speed_accel_limits();
 }
 
 /// set current target descent rate during wp navigation
 void AC_WPNav::set_speed_down(float speed_down_cms)
 {
     _pos_control.set_max_speed_z(speed_down_cms, _pos_control.get_max_speed_up());
-    // flag that wp leash must be recalculated
-    _flags.recalc_wp_leash = true;
+    update_track_with_speed_accel_limits();
 }
 
 /// set_wp_destination waypoint using location class
 ///     returns false if conversion from location to vector from ekf origin cannot be calculated
-bool AC_WPNav::set_wp_destination(const Location& destination)
+bool AC_WPNav::set_wp_destination_loc(const Location& destination)
 {
     bool terr_alt;
     Vector3f dest_neu;
@@ -191,7 +221,23 @@ bool AC_WPNav::set_wp_destination(const Location& destination)
     return set_wp_destination(dest_neu, terr_alt);
 }
 
-bool AC_WPNav::get_wp_destination(Location& destination) const
+/// set next destination using location class
+///     returns false if conversion from location to vector from ekf origin cannot be calculated
+bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
+{
+    bool terr_alt;
+    Vector3f dest_neu;
+
+    // convert destination location to vector
+    if (!get_vector_NEU(destination, dest_neu, terr_alt)) {
+        return false;
+    }
+
+    // set target as vector from EKF origin
+    return set_wp_destination_next(dest_neu, terr_alt);
+}
+
+bool AC_WPNav::get_wp_destination_loc(Location& destination) const
 {
     Vector3f dest = get_wp_destination();
     if (!AP::ahrs().get_origin(destination)) {
@@ -202,32 +248,103 @@ bool AC_WPNav::get_wp_destination(Location& destination) const
     return true;
 }
 
-/// set_wp_destination waypoint using position vector (distance from home in cm)
-///     terrain_alt should be true if destination.z is a desired altitude above terrain
+/// set_wp_destination - set destination waypoints using position vectors (distance from ekf origin in cm)
+///     terrain_alt should be true if destination.z is an altitude above terrain (false if alt-above-ekf-origin)
+///     returns false on failure (likely caused by missing terrain data)
 bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
 {
-	Vector3f origin;
-
-    // if waypoint controller is active use the existing position target as the origin
-    if ((AP_HAL::millis() - _wp_last_update) < 1000) {
-        origin = _pos_control.get_pos_target();
-    } else {
-        // if waypoint controller is not active, set origin to reasonable stopping point (using curr pos and velocity)
-        _pos_control.get_stopping_point_xy(origin);
-        _pos_control.get_stopping_point_z(origin);
+    // re-initialise if previous destination has been interrupted
+    if (!is_active() || !_flags.reached_destination) {
+        wp_and_spline_init(_wp_desired_speed_xy_cms);
     }
 
-    // convert origin to alt-above-terrain
-    if (terrain_alt) {
+    _scurve_prev_leg.init();
+    float origin_speed = 0.0f;
+
+    // use previous destination as origin
+    _origin = _destination;
+
+    if (terrain_alt == _terrain_alt) {
+        if (_this_leg_is_spline) {
+            // if previous leg was a spline we can use current target velocity vector for origin velocity vector
+            Vector3f target_velocity = _pos_control.get_desired_velocity();
+            target_velocity.z -= _vel_terrain_offset;
+            origin_speed = target_velocity.length();
+        } else {
+            // store previous leg
+            _scurve_prev_leg = _scurve_this_leg;
+        }
+    } else {
+
+        // get current alt above terrain
         float origin_terr_offset;
         if (!get_terrain_offset(origin_terr_offset)) {
             return false;
         }
-        origin.z -= origin_terr_offset;
+
+        // convert origin to alt-above-terrain if necessary
+        if (terrain_alt) {
+            // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
+            _origin.z -= origin_terr_offset;
+            _pos_terrain_offset += origin_terr_offset;
+        } else {
+            // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
+            _origin.z += origin_terr_offset;
+            _pos_terrain_offset -= origin_terr_offset;
+        }
     }
 
-    // set origin and destination
-    return set_wp_origin_and_destination(origin, destination, terrain_alt);
+    // update destination
+    _destination = destination;
+    _terrain_alt = terrain_alt;
+
+    if (_flags.fast_waypoint && !_this_leg_is_spline && !_next_leg_is_spline && !_scurve_next_leg.finished()) {
+        _scurve_this_leg = _scurve_next_leg;
+    } else {
+        _scurve_this_leg.calculate_track(_origin, _destination,
+                                         _pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down(),
+                                         _wp_accel_cmss, _wp_accel_z_cmss,
+                                         _scurve_jerk_time, _scurve_jerk * 100.0f);
+        if (!is_zero(origin_speed)) {
+            // rebuild start of scurve if we have a non-zero origin speed
+            _scurve_this_leg.set_origin_speed_max(origin_speed);
+        }
+    }
+
+    _this_leg_is_spline = false;
+    _scurve_next_leg.init();
+    _flags.fast_waypoint = false;   // default waypoint back to slow
+    _flags.reached_destination = false;
+    _flags.wp_yaw_set = false;
+
+    return true;
+}
+
+/// set next destination using position vector (distance from ekf origin in cm)
+///     terrain_alt should be true if destination.z is a desired altitude above terrain
+///     provide next_destination
+bool AC_WPNav::set_wp_destination_next(const Vector3f& destination, bool terrain_alt)
+{
+    // do not add next point if alt types don't match
+    if (terrain_alt != _terrain_alt) {
+        return true;
+    }
+
+    _scurve_next_leg.calculate_track(_destination, destination,
+                                     _pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down(),
+                                     _wp_accel_cmss, _wp_accel_z_cmss,
+                                     _scurve_jerk_time, _scurve_jerk * 100.0f);
+    if (_this_leg_is_spline) {
+        const float this_leg_dest_speed_max = _spline_this_leg.get_destination_speed_max();
+        const float next_leg_origin_speed_max = _scurve_next_leg.set_origin_speed_max(this_leg_dest_speed_max);
+        _spline_this_leg.set_destination_speed_max(next_leg_origin_speed_max);
+    }
+    _next_leg_is_spline = false;
+
+    // next destination provided so fast waypoint
+    _flags.fast_waypoint = true;
+
+    return true;
 }
 
 /// set waypoint destination using NED position vector from ekf origin in meters
@@ -237,58 +354,11 @@ bool AC_WPNav::set_wp_destination_NED(const Vector3f& destination_NED)
     return set_wp_destination(Vector3f(destination_NED.x * 100.0f, destination_NED.y * 100.0f, -destination_NED.z * 100.0f), false);
 }
 
-/// set_origin_and_destination - set origin and destination waypoints using position vectors (distance from home in cm)
-///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if these are alt-above-ekf-origin)
-///     returns false on failure (likely caused by missing terrain data)
-bool AC_WPNav::set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt)
+/// set waypoint destination using NED position vector from ekf origin in meters
+bool AC_WPNav::set_wp_destination_next_NED(const Vector3f& destination_NED)
 {
-    // store origin and destination locations
-    _origin = origin;
-    _destination = destination;
-    _terrain_alt = terrain_alt;
-    Vector3f pos_delta = _destination - _origin;
-
-    _track_length = pos_delta.length(); // get track length
-    _track_length_xy = safe_sqrt(sq(pos_delta.x)+sq(pos_delta.y));  // get horizontal track length (used to decide if we should update yaw)
-
-    // calculate each axis' percentage of the total distance to the destination
-    if (is_zero(_track_length)) {
-        // avoid possible divide by zero
-        _pos_delta_unit.x = 0;
-        _pos_delta_unit.y = 0;
-        _pos_delta_unit.z = 0;
-    }else{
-        _pos_delta_unit = pos_delta/_track_length;
-    }
-
-    // calculate leash lengths
-    calculate_wp_leash_length();
-
-    // get origin's alt-above-terrain
-    float origin_terr_offset = 0.0f;
-    if (terrain_alt) {
-        if (!get_terrain_offset(origin_terr_offset)) {
-            return false;
-        }
-    }
-
-    // initialise intermediate point to the origin
-    _pos_control.set_pos_target(origin + Vector3f(0,0,origin_terr_offset));
-    _track_desired = 0;             // target is at beginning of track
-    _flags.reached_destination = false;
-    _flags.fast_waypoint = false;   // default waypoint back to slow
-    _flags.slowing_down = false;    // target is not slowing down yet
-    _flags.segment_type = SEGMENT_STRAIGHT;
-    _flags.new_wp_destination = true;   // flag new waypoint so we can freeze the pos controller's feed forward and smooth the transition
-    _flags.wp_yaw_set = false;
-
-    // initialise the limited speed to current speed along the track
-    const Vector3f &curr_vel = _inav.get_velocity();
-    // get speed along track (note: we convert vertical speed into horizontal speed equivalent)
-    float speed_along_track = curr_vel.x * _pos_delta_unit.x + curr_vel.y * _pos_delta_unit.y + curr_vel.z * _pos_delta_unit.z;
-    _limited_speed_xy_cms = constrain_float(speed_along_track, 0, _pos_control.get_max_speed_xy());
-
-    return true;
+    // convert NED to NEU and do not use terrain following
+    return set_wp_destination_next(Vector3f(destination_NED.x * 100.0f, destination_NED.y * 100.0f, -destination_NED.z * 100.0f), false);
 }
 
 /// shift_wp_origin_to_current_pos - shifts the origin and destination so the origin starts at the current position
@@ -314,7 +384,6 @@ void AC_WPNav::shift_wp_origin_to_current_pos()
 
     // move pos controller target and disable feed forward
     _pos_control.set_pos_target(curr_pos);
-    _pos_control.freeze_ff_z();
 }
 
 /// shifts the origin and destination horizontally to the current position
@@ -374,156 +443,132 @@ void AC_WPNav::get_wp_stopping_point(Vector3f& stopping_point) const
 /// advance_wp_target_along_track - move target location along track from origin to destination
 bool AC_WPNav::advance_wp_target_along_track(float dt)
 {
-    float track_covered;        // distance (in cm) along the track that the vehicle has traveled.  Measured by drawing a perpendicular line from the track to the vehicle.
-    Vector3f track_error;       // distance error (in cm) from the track_covered position (i.e. closest point on the line to the vehicle) and the vehicle
-    float track_desired_max;    // the farthest distance (in cm) along the track that the leash will allow
-    float track_leash_slack;    // additional distance (in cm) along the track from our track_covered position that our leash will allow
-    bool reached_leash_limit = false;   // true when track has reached leash limit and we need to slow down the target point
-
-    // get current location
-    const Vector3f &curr_pos = _inav.get_position();
-
     // calculate terrain adjustments
     float terr_offset = 0.0f;
     if (_terrain_alt && !get_terrain_offset(terr_offset)) {
         return false;
     }
 
-    // calculate 3d vector from segment's origin
-    Vector3f curr_delta = (curr_pos - Vector3f(0,0,terr_offset)) - _origin;
+    // get current position and adjust altitude to origin and destination's frame (i.e. _frame)
+    const Vector3f &curr_pos = _inav.get_position() - Vector3f{0, 0, terr_offset};
 
-    // calculate how far along the track we are
-    track_covered = curr_delta.x * _pos_delta_unit.x + curr_delta.y * _pos_delta_unit.y + curr_delta.z * _pos_delta_unit.z;
+    // target position, velocity and acceleration from straight line or spline calculators
+    Vector3f target_pos, target_vel, target_accel;
+    bool s_finished;
 
-    // calculate the point closest to the vehicle on the segment from origin to destination
-    Vector3f track_covered_pos = _pos_delta_unit * track_covered;
+    // Use _track_scalar_dt to slow down S-Curve time to prevent target moving too far in front of aircraft
+    Vector3f target_velocity = _pos_control.get_desired_velocity();
+    target_velocity.z -= _vel_terrain_offset;
 
-    // calculate the distance vector from the vehicle to the closest point on the segment from origin to destination
-    track_error = curr_delta - track_covered_pos;
-
-    // calculate the horizontal error
-    _track_error_xy = norm(track_error.x, track_error.y);
-
-    // calculate the vertical error
-    float track_error_z = fabsf(track_error.z);
-
-    // get up leash if we are moving up, down leash if we are moving down
-    float leash_z = track_error.z >= 0 ? _pos_control.get_leash_up_z() : _pos_control.get_leash_down_z();
-
-    // use pythagoras's theorem calculate how far along the track we could move the intermediate target before reaching the end of the leash
-    //   track_desired_max is the distance from the vehicle to our target point along the track.  It is the "hypotenuse" which we want to be no longer than our leash (aka _track_leash_length)
-    //   track_error is the line from the vehicle to the closest point on the track.  It is the "opposite" side
-    //   track_leash_slack is the line from the closest point on the track to the target point.  It is the "adjacent" side.  We adjust this so the track_desired_max is no longer than the leash
-    float track_leash_length_abs = fabsf(_track_leash_length);
-    float track_error_max_abs = MAX(_track_leash_length*track_error_z/leash_z, _track_leash_length*_track_error_xy/_pos_control.get_leash_xy());
-    track_leash_slack = (track_leash_length_abs > track_error_max_abs) ? safe_sqrt(sq(_track_leash_length) - sq(track_error_max_abs)) : 0;
-    track_desired_max = track_covered + track_leash_slack;
-
-    // check if target is already beyond the leash
-    if (_track_desired > track_desired_max) {
-        reached_leash_limit = true;
-    }
-
-    // get current velocity
-    const Vector3f &curr_vel = _inav.get_velocity();
-    // get speed along track
-    float speed_along_track = curr_vel.x * _pos_delta_unit.x + curr_vel.y * _pos_delta_unit.y + curr_vel.z * _pos_delta_unit.z;
-
-    // calculate point at which velocity switches from linear to sqrt
-    float linear_velocity = _pos_control.get_max_speed_xy();
-    float kP = _pos_control.get_pos_xy_p().kP();
-    if (is_positive(kP)) {   // avoid divide by zero
-        linear_velocity = _track_accel/kP;
-    }
-
-    // let the limited_speed_xy_cms be some range above or below current velocity along track
-    if (speed_along_track < -linear_velocity) {
-        // we are traveling fast in the opposite direction of travel to the waypoint so do not move the intermediate point
-        _limited_speed_xy_cms = 0;
-    }else{
-        // increase intermediate target point's velocity if not yet at the leash limit
-        if(dt > 0 && !reached_leash_limit) {
-            _limited_speed_xy_cms += 2.0f * _track_accel * dt;
+    float track_error = 0.0f;
+    float track_velocity = 0.0f;
+    float track_scaler_dt = 1.0f;
+    // check target velocity is non-zero
+    if (is_positive(target_velocity.length())) {
+        Vector3f track_direction = target_velocity.normalized();
+        track_error = _pos_control.get_pos_error().dot(track_direction);
+        track_velocity = _inav.get_velocity().dot(track_direction);
+        // set time scaler to be consistent with the achievable aircraft speed with a 5% buffer for short term variation.
+        track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_xy_p().kP() * track_error) / target_velocity.length(), 0.1f, 1.0f);
+        // set time scaler to not exceed the maximum vertical velocity during terrain following.
+        if (is_positive(target_velocity.z)) {
+            track_scaler_dt = MIN(track_scaler_dt, fabsf(_wp_speed_up_cms / target_velocity.z));
+        } else if (is_negative(target_velocity.z)) {
+            track_scaler_dt = MIN(track_scaler_dt, fabsf(_wp_speed_down_cms / target_velocity.z));
         }
-        // do not allow speed to be below zero or over top speed
-        _limited_speed_xy_cms = constrain_float(_limited_speed_xy_cms, 0.0f, _track_speed);
-
-        // check if we should begin slowing down
-        if (!_flags.fast_waypoint) {
-            float dist_to_dest = _track_length - _track_desired;
-            if (!_flags.slowing_down && dist_to_dest <= _slow_down_dist) {
-                _flags.slowing_down = true;
-            }
-            // if target is slowing down, limit the speed
-            if (_flags.slowing_down) {
-                _limited_speed_xy_cms = MIN(_limited_speed_xy_cms, get_slow_down_speed(dist_to_dest, _track_accel));
-            }
-        }
-
-        // if our current velocity is within the linear velocity range limit the intermediate point's velocity to be no more than the linear_velocity above or below our current velocity
-        if (fabsf(speed_along_track) < linear_velocity) {
-            _limited_speed_xy_cms = constrain_float(_limited_speed_xy_cms,speed_along_track-linear_velocity,speed_along_track+linear_velocity);
-        }
-    }
-    // advance the current target
-    if (!reached_leash_limit) {
-    	_track_desired += _limited_speed_xy_cms * dt;
-
-    	// reduce speed if we reach end of leash
-        if (_track_desired > track_desired_max) {
-        	_track_desired = track_desired_max;
-        	_limited_speed_xy_cms -= 2.0f * _track_accel * dt;
-        	if (_limited_speed_xy_cms < 0.0f) {
-        	    _limited_speed_xy_cms = 0.0f;
-        	}
-    	}
-    }
-
-    // do not let desired point go past the end of the track unless it's a fast waypoint
-    if (!_flags.fast_waypoint) {
-        _track_desired = constrain_float(_track_desired, 0, _track_length);
     } else {
-        _track_desired = constrain_float(_track_desired, 0, _track_length + WPNAV_WP_FAST_OVERSHOOT_MAX);
+        track_scaler_dt = 1.0f;
+    }
+    // change s-curve time speed with a time constant of maximum acceleration / maximum jerk
+    float track_scaler_tc = 0.01f * _wp_accel_cmss/_wp_jerk;
+    if (!is_zero(_wp_jerk)) {
+        track_scaler_tc = 0.01f * _wp_accel_cmss/_wp_jerk;
+    } else {
+        track_scaler_tc = 1.0f;
+    }
+    _track_scalar_dt += (track_scaler_dt - _track_scalar_dt) * (dt / track_scaler_tc);
+
+    if (!_this_leg_is_spline) {
+        // update target position, velocity and acceleration
+        target_pos = _origin;
+        s_finished = _scurve_this_leg.advance_target_along_track(_scurve_prev_leg, _scurve_next_leg, _wp_radius_cm, _flags.fast_waypoint, _track_scalar_dt * dt, target_pos, target_vel, target_accel);
+    } else {
+        // splinetarget_vel
+        target_vel = target_velocity;
+        _spline_this_leg.advance_target_along_track(_track_scalar_dt * dt, target_pos, target_vel);
+        s_finished = _spline_this_leg.reached_destination();
     }
 
-    // recalculate the desired position
-    Vector3f final_target = _origin + _pos_delta_unit * _track_desired;
+    // input shape the terrain offset
+    shape_pos_vel(terr_offset, 0.0f, _pos_terrain_offset, _vel_terrain_offset, _accel_terrain_offset, 0.0f, 0.0f, _pos_control.get_max_accel_z()*4.0f, 0.05f, _track_scalar_dt * dt);
+    update_pos_vel_accel(_pos_terrain_offset, _vel_terrain_offset, _accel_terrain_offset, _track_scalar_dt * dt);
+
     // convert final_target.z to altitude above the ekf origin
-    final_target.z += terr_offset;
-    _pos_control.set_pos_target(final_target);
+    target_pos.z += _pos_terrain_offset;
+    target_vel.z += _vel_terrain_offset;
+    target_accel.z += _accel_terrain_offset;
+
+    // pass new target to the position controller
+    _pos_control.set_pos_vel_accel_target(target_pos, target_vel, target_accel);
 
     // check if we've reached the waypoint
-    if( !_flags.reached_destination ) {
-        if( _track_desired >= _track_length ) {
+    if (!_flags.reached_destination) {
+        if (s_finished) {
             // "fast" waypoints are complete once the intermediate point reaches the destination
             if (_flags.fast_waypoint) {
                 _flags.reached_destination = true;
-            }else{
+            } else {
                 // regular waypoints also require the copter to be within the waypoint radius
-                Vector3f dist_to_dest = (curr_pos - Vector3f(0,0,terr_offset)) - _destination;
-                if( dist_to_dest.length() <= _wp_radius_cm ) {
+                const Vector3f dist_to_dest = curr_pos - _destination;
+                if (dist_to_dest.length() <= _wp_radius_cm) {
                     _flags.reached_destination = true;
                 }
             }
         }
     }
 
-    // update the target yaw if origin and destination are at least 2m apart horizontally
-    if (_track_length_xy >= WPNAV_YAW_DIST_MIN) {
-        if (_pos_control.get_leash_xy() < WPNAV_YAW_DIST_MIN) {
-            // if the leash is short (i.e. moving slowly) and destination is at least 2m horizontally, point along the segment from origin to destination
-            set_yaw_cd(get_bearing_cd(_origin, _destination));
-        } else {
-            Vector3f horiz_leash_xy = final_target - curr_pos;
-            horiz_leash_xy.z = 0;
-            if (horiz_leash_xy.length() > MIN(WPNAV_YAW_DIST_MIN, _pos_control.get_leash_xy()*WPNAV_YAW_LEASH_PCT_MIN)) {
-                set_yaw_cd(RadiansToCentiDegrees(atan2f(horiz_leash_xy.y,horiz_leash_xy.x)));
-            }
+    // Calculate the turn rate
+    float turn_rate = 0.0f;
+    const float target_vel_xy_len = Vector2f(target_vel.x, target_vel.y).length();
+    if (is_positive(target_vel_xy_len)) {
+        const float accel_forward = (target_accel.x * target_vel.x + target_accel.y * target_vel.y + target_accel.z * target_vel.z)/target_vel.length();
+        const Vector3f accel_turn = target_accel - target_vel * accel_forward / target_vel.length();
+        const float accel_turn_xy_len = Vector2f(accel_turn.x, accel_turn.y).length();
+        turn_rate = accel_turn_xy_len / target_vel_xy_len;
+        if ((accel_turn.y * target_vel.x - accel_turn.x * target_vel.y) < 0.0) {
+            turn_rate *= -1.0f;
         }
+    }
+
+    // update the target yaw if origin and destination are at least 2m apart horizontally
+    const Vector2f target_vel_xy(target_vel.x, target_vel.y);
+    if (target_vel_xy.length() > WPNAV_YAW_VEL_MIN) {
+        set_yaw_cd(degrees(target_vel_xy.angle()) * 100.0f);
+        set_yaw_rate_cds(turn_rate*degrees(100.0f));
     }
 
     // successfully advanced along track
     return true;
+}
+
+/// recalculate path with update speed and/or acceleration limits
+void AC_WPNav::update_track_with_speed_accel_limits()
+{
+    // update this leg
+    if (_this_leg_is_spline) {
+        _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down(),
+                                         _wp_accel_cmss, _wp_accel_z_cmss);
+    } else {
+        _scurve_this_leg.set_speed_max(_pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down());
+    }
+
+    // update next leg
+    if (_next_leg_is_spline) {
+        _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down(),
+                                         _wp_accel_cmss, _wp_accel_z_cmss);
+    } else {
+        _scurve_next_leg.set_speed_max(_pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down());
+    }
 }
 
 /// get_wp_distance_to_destination - get horizontal distance to destination in cm
@@ -553,80 +598,23 @@ bool AC_WPNav::update_wpnav()
     _pos_control.set_max_accel_xy(_wp_accel_cmss);
     _pos_control.set_max_accel_z(_wp_accel_z_cmss);
 
-    // wp_speed_update - update _pos_control.set_max_speed_xy if speed change has been requested
-    wp_speed_update(dt);
-
     // advance the target if necessary
     if (!advance_wp_target_along_track(dt)) {
         // To-Do: handle inability to advance along track (probably because of missing terrain data)
         ret = false;
     }
 
-    // freeze feedforwards during known discontinuities
-    if (_flags.new_wp_destination) {
-        _flags.new_wp_destination = false;
-        _pos_control.freeze_ff_z();
-    }
-
     _pos_control.update_xy_controller();
-    check_wp_leash_length();
 
     _wp_last_update = AP_HAL::millis();
 
     return ret;
 }
 
-// check_wp_leash_length - check if waypoint leash lengths need to be recalculated
-//  should be called after _pos_control.update_xy_controller which may have changed the position controller leash lengths
-void AC_WPNav::check_wp_leash_length()
+// returns true if update_wpnav has been run very recently
+bool AC_WPNav::is_active() const
 {
-    // exit immediately if recalc is not required
-    if (_flags.recalc_wp_leash) {
-        calculate_wp_leash_length();
-    }
-}
-
-/// calculate_wp_leash_length - calculates horizontal and vertical leash lengths for waypoint controller
-void AC_WPNav::calculate_wp_leash_length()
-{
-    // length of the unit direction vector in the horizontal
-    float pos_delta_unit_xy = norm(_pos_delta_unit.x, _pos_delta_unit.y);
-    float pos_delta_unit_z = fabsf(_pos_delta_unit.z);
-
-    float speed_z;
-    float leash_z;
-    if (_pos_delta_unit.z >= 0.0f) {
-        speed_z = _pos_control.get_max_speed_up();
-        leash_z = _pos_control.get_leash_up_z();
-    }else{
-        speed_z = fabsf(_pos_control.get_max_speed_down());
-        leash_z = _pos_control.get_leash_down_z();
-    }
-
-    // calculate the maximum acceleration, maximum velocity, and leash length in the direction of travel
-    if(is_zero(pos_delta_unit_z) && is_zero(pos_delta_unit_xy)){
-        _track_accel = 0;
-        _track_speed = 0;
-        _track_leash_length = WPNAV_LEASH_LENGTH_MIN;
-    }else if(is_zero(_pos_delta_unit.z)){
-        _track_accel = _wp_accel_cmss/pos_delta_unit_xy;
-        _track_speed = _pos_control.get_max_speed_xy() / pos_delta_unit_xy;
-        _track_leash_length = _pos_control.get_leash_xy()/pos_delta_unit_xy;
-    }else if(is_zero(pos_delta_unit_xy)){
-        _track_accel = _wp_accel_z_cmss/pos_delta_unit_z;
-        _track_speed = speed_z/pos_delta_unit_z;
-        _track_leash_length = leash_z/pos_delta_unit_z;
-    }else{
-        _track_accel = MIN(_wp_accel_z_cmss/pos_delta_unit_z, _wp_accel_cmss/pos_delta_unit_xy);
-        _track_speed = MIN(speed_z/pos_delta_unit_z, _pos_control.get_max_speed_xy() / pos_delta_unit_xy);
-        _track_leash_length = MIN(leash_z/pos_delta_unit_z, _pos_control.get_leash_xy()/pos_delta_unit_xy);
-    }
-
-    // calculate slow down distance (the distance from the destination when the target point should begin to slow down)
-    calc_slow_down_distance(_track_speed, _track_accel);
-
-    // set recalc leash flag to false
-    _flags.recalc_wp_leash = false;
+    return (AP_HAL::millis() - _wp_last_update) < 200;
 }
 
 // returns target yaw in centi-degrees (used for wp and spline navigation)
@@ -640,6 +628,17 @@ float AC_WPNav::get_yaw() const
     }
 }
 
+// returns target yaw rate in centi-degrees / second (used for wp and spline navigation)
+float AC_WPNav::get_yaw_rate() const
+{
+    if (_flags.wp_yaw_set) {
+        return _yaw_rate;
+    }
+
+    // if yaw has not been set return zero turn rate
+    return 0.0f;
+}
+
 // set heading used for spline and waypoint navigation
 void AC_WPNav::set_yaw_cd(float heading_cd)
 {
@@ -647,360 +646,10 @@ void AC_WPNav::set_yaw_cd(float heading_cd)
     _flags.wp_yaw_set = true;
 }
 
-///
-/// spline methods
-///
-
-/// set_spline_destination waypoint using location class
-///     returns false if conversion from location to vector from ekf origin cannot be calculated
-///     stopped_at_start should be set to true if vehicle is stopped at the origin
-///     seg_end_type should be set to stopped, straight or spline depending upon the next segment's type
-///     next_destination should be set to the next segment's destination if the seg_end_type is SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE
-bool AC_WPNav::set_spline_destination(const Location& destination, bool stopped_at_start, spline_segment_end_type seg_end_type, Location next_destination)
+// set yaw rate used for spline and waypoint navigation
+void AC_WPNav::set_yaw_rate_cds(float yaw_rate_cds)
 {
-    // convert destination location to vector
-    Vector3f dest_neu;
-    bool dest_terr_alt;
-    if (!get_vector_NEU(destination, dest_neu, dest_terr_alt)) {
-        return false;
-    }
-
-    Vector3f next_dest_neu; // left uninitialised for valgrind
-    if (seg_end_type == SEGMENT_END_STRAIGHT ||
-        seg_end_type == SEGMENT_END_SPLINE) {
-        // make altitude frames consistent
-        if (!next_destination.change_alt_frame(destination.get_alt_frame())) {
-            return false;
-        }
-
-        // convert next destination to vector
-        bool next_dest_terr_alt;
-        if (!get_vector_NEU(next_destination, next_dest_neu, next_dest_terr_alt)) {
-            return false;
-        }
-    }
-
-    // set target as vector from EKF origin
-    return set_spline_destination(dest_neu, dest_terr_alt, stopped_at_start, seg_end_type, next_dest_neu);
-}
-
-/// set_spline_destination waypoint using position vector (distance from home in cm)
-///     returns false if conversion from location to vector from ekf origin cannot be calculated
-///     terrain_alt should be true if destination.z is a desired altitudes above terrain (false if its desired altitudes above ekf origin)
-///     stopped_at_start should be set to true if vehicle is stopped at the origin
-///     seg_end_type should be set to stopped, straight or spline depending upon the next segment's type
-///     next_destination should be set to the next segment's destination if the seg_end_type is SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE
-bool AC_WPNav::set_spline_destination(const Vector3f& destination, bool terrain_alt, bool stopped_at_start, spline_segment_end_type seg_end_type, const Vector3f& next_destination)
-{
-    Vector3f origin;
-
-    // if waypoint controller is active and copter has reached the previous waypoint use current pos target as the origin
-    if ((AP_HAL::millis() - _wp_last_update) < 1000) {
-        origin = _pos_control.get_pos_target();
-    }else{
-        // otherwise calculate origin from the current position and velocity
-        _pos_control.get_stopping_point_xy(origin);
-        _pos_control.get_stopping_point_z(origin);
-    }
-
-    // convert origin to alt-above-terrain
-    if (terrain_alt) {
-        float terr_offset;
-        if (!get_terrain_offset(terr_offset)) {
-            return false;
-        }
-        origin.z -= terr_offset;
-    }
-
-    // set origin and destination
-    return set_spline_origin_and_destination(origin, destination, terrain_alt, stopped_at_start, seg_end_type, next_destination);
-}
-
-/// set_spline_origin_and_destination - set origin and destination waypoints using position vectors (distance from home in cm)
-///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if desired altitudes above ekf origin)
-///     seg_type should be calculated by calling function based on the mission
-bool AC_WPNav::set_spline_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt, bool stopped_at_start, spline_segment_end_type seg_end_type, const Vector3f& next_destination)
-{
-    // mission is "active" if wpnav has been called recently and vehicle reached the previous waypoint
-    bool prev_segment_exists = (_flags.reached_destination && ((AP_HAL::millis() - _wp_last_update) < 1000));
-
-    // get dt from pos controller
-    float dt = _pos_control.get_dt();
-
-    // check _wp_accel_cmss is reasonable to avoid divide by zero
-    if (_wp_accel_cmss <= 0) {
-        _wp_accel_cmss.set_and_save(WPNAV_ACCELERATION);
-    }
-
-    // segment start types
-    // stop - vehicle is not moving at origin
-    // straight-fast - vehicle is moving, previous segment is straight.  vehicle will fly straight through the waypoint before beginning it's spline path to the next wp
-    //     _flag.segment_type holds whether prev segment is straight vs spline but we don't know if it has a delay
-    // spline-fast - vehicle is moving, previous segment is splined, vehicle will fly through waypoint but previous segment should have it flying in the correct direction (i.e. exactly parallel to position difference vector from previous segment's origin to this segment's destination)
-
-    // calculate spline velocity at origin
-    if (stopped_at_start || !prev_segment_exists) {
-    	// if vehicle is stopped at the origin, set origin velocity to 0.02 * distance vector from origin to destination
-    	_spline_origin_vel = (destination - origin) * dt;
-    	_spline_time = 0.0f;
-    	_spline_vel_scaler = 0.0f;
-    }else{
-    	// look at previous segment to determine velocity at origin
-        if (_flags.segment_type == SEGMENT_STRAIGHT) {
-            // previous segment is straight, vehicle is moving so vehicle should fly straight through the origin
-            // before beginning it's spline path to the next waypoint. Note: we are using the previous segment's origin and destination
-            _spline_origin_vel = (_destination - _origin);
-            _spline_time = 0.0f;	// To-Do: this should be set based on how much overrun there was from straight segment?
-            _spline_vel_scaler = _pos_control.get_vel_target().length();    // start velocity target from current target velocity
-        }else{
-            // previous segment is splined, vehicle will fly through origin
-            // we can use the previous segment's destination velocity as this segment's origin velocity
-            // Note: previous segment will leave destination velocity parallel to position difference vector
-            //       from previous segment's origin to this segment's destination)
-            _spline_origin_vel = _spline_destination_vel;
-            if (_spline_time > 1.0f && _spline_time < 1.1f) {    // To-Do: remove hard coded 1.1f
-                _spline_time -= 1.0f;
-            }else{
-                _spline_time = 0.0f;
-            }
-            // Note: we leave _spline_vel_scaler as it was from end of previous segment
-        }
-    }
-
-    // calculate spline velocity at destination
-    switch (seg_end_type) {
-
-    case SEGMENT_END_STOP:
-        // if vehicle stops at the destination set destination velocity to 0.02 * distance vector from origin to destination
-        _spline_destination_vel = (destination - origin) * dt;
-        _flags.fast_waypoint = false;
-        break;
-
-    case SEGMENT_END_STRAIGHT:
-        // if next segment is straight, vehicle's final velocity should face along the next segment's position
-        _spline_destination_vel = (next_destination - destination);
-        _flags.fast_waypoint = true;
-        break;
-
-    case SEGMENT_END_SPLINE:
-        // if next segment is splined, vehicle's final velocity should face parallel to the line from the origin to the next destination
-        _spline_destination_vel = (next_destination - origin);
-        _flags.fast_waypoint = true;
-        break;
-    }
-
-    // code below ensures we don't get too much overshoot when the next segment is short
-    float vel_len = _spline_origin_vel.length() + _spline_destination_vel.length();
-    float pos_len = (destination - origin).length() * 4.0f;
-    if (vel_len > pos_len) {
-        // if total start+stop velocity is more than twice position difference
-        // use a scaled down start and stop velocityscale the  start and stop velocities down
-        float vel_scaling = pos_len / vel_len;
-        // update spline calculator
-        update_spline_solution(origin, destination, _spline_origin_vel * vel_scaling, _spline_destination_vel * vel_scaling);
-    }else{
-        // update spline calculator
-        update_spline_solution(origin, destination, _spline_origin_vel, _spline_destination_vel);
-    }
-
-    // store origin and destination locations
-    _origin = origin;
-    _destination = destination;
-    _terrain_alt = terrain_alt;
-
-    // calculate slow down distance
-    calc_slow_down_distance(_pos_control.get_max_speed_xy(), _wp_accel_cmss);
-
-    // get alt-above-terrain
-    float terr_offset = 0.0f;
-    if (terrain_alt) {
-        if (!get_terrain_offset(terr_offset)) {
-            return false;
-        }
-    }
-
-    // initialise intermediate point to the origin
-    _pos_control.set_pos_target(origin + Vector3f(0,0,terr_offset));
-    _flags.reached_destination = false;
-    _flags.segment_type = SEGMENT_SPLINE;
-    _flags.new_wp_destination = true;   // flag new waypoint so we can freeze the pos controller's feed forward and smooth the transition
-    _flags.wp_yaw_set = false;
-
-    // initialise yaw related variables
-    _track_length_xy = safe_sqrt(sq(_destination.x - _origin.x)+sq(_destination.y - _origin.y));  // horizontal track length (used to decide if we should update yaw)
-
-    return true;
-}
-
-/// update_spline - update spline controller
-bool AC_WPNav::update_spline()
-{
-    // exit immediately if this is not a spline segment
-    if (_flags.segment_type != SEGMENT_SPLINE) {
-        return false;
-    }
-
-    bool ret = true;
-
-    // get dt from pos controller
-    float dt = _pos_control.get_dt();
-
-    // wp_speed_update - update _pos_control.set_max_speed_xy if speed change has been requested
-    wp_speed_update(dt);
-
-    // advance the target if necessary
-    if (!advance_spline_target_along_track(dt)) {
-        // To-Do: handle failure to advance along track (due to missing terrain data)
-        ret = false;
-    }
-
-    // freeze feedforwards during known discontinuities
-    if (_flags.new_wp_destination) {
-        _flags.new_wp_destination = false;
-        _pos_control.freeze_ff_z();
-    }
-
-    // run horizontal position controller
-    _pos_control.update_xy_controller();
-
-    _wp_last_update = AP_HAL::millis();
-
-    return ret;
-}
-
-/// update_spline_solution - recalculates hermite_spline_solution grid
-///		relies on _spline_origin_vel, _spline_destination_vel and _origin and _destination
-void AC_WPNav::update_spline_solution(const Vector3f& origin, const Vector3f& dest, const Vector3f& origin_vel, const Vector3f& dest_vel)
-{
-    _hermite_spline_solution[0] = origin;
-    _hermite_spline_solution[1] = origin_vel;
-    _hermite_spline_solution[2] = -origin*3.0f -origin_vel*2.0f + dest*3.0f - dest_vel;
-    _hermite_spline_solution[3] = origin*2.0f + origin_vel -dest*2.0f + dest_vel;
- }
-
-/// advance_spline_target_along_track - move target location along track from origin to destination
-bool AC_WPNav::advance_spline_target_along_track(float dt)
-{
-    if (!_flags.reached_destination) {
-        Vector3f target_pos, target_vel;
-
-        // update target position and velocity from spline calculator
-        calc_spline_pos_vel(_spline_time, target_pos, target_vel);
-
-        // if target velocity is zero the origin and destination must be the same
-        // so flag reached destination (and protect against divide by zero)
-        float target_vel_length = target_vel.length();
-        if (is_zero(target_vel_length)) {
-            _flags.reached_destination = true;
-            return true;
-        }
-
-        _pos_delta_unit = target_vel / target_vel_length;
-        calculate_wp_leash_length();
-
-        // get current location
-        const Vector3f &curr_pos = _inav.get_position();
-
-        // get terrain altitude offset for origin and current position (i.e. change in terrain altitude from a position vs ekf origin)
-        float terr_offset = 0.0f;
-        if (_terrain_alt && !get_terrain_offset(terr_offset)) {
-            return false;
-        }
-
-        // calculate position error
-        Vector3f track_error = curr_pos - target_pos;
-        track_error.z -= terr_offset;
-
-        // calculate the horizontal error
-        _track_error_xy = norm(track_error.x, track_error.y);
-
-        // calculate the vertical error
-        float track_error_z = fabsf(track_error.z);
-
-        // get position control leash lengths
-        float leash_xy = _pos_control.get_leash_xy();
-        float leash_z;
-        if (track_error.z >= 0) {
-            leash_z = _pos_control.get_leash_up_z();
-        }else{
-            leash_z = _pos_control.get_leash_down_z();
-        }
-
-        // calculate how far along the track we could move the intermediate target before reaching the end of the leash
-        float track_leash_slack = MIN(_track_leash_length*(leash_z-track_error_z)/leash_z, _track_leash_length*(leash_xy-_track_error_xy)/leash_xy);
-        if (track_leash_slack < 0.0f) {
-            track_leash_slack = 0.0f;
-        }
-
-        // update velocity
-        float spline_dist_to_wp = (_destination - target_pos).length();
-        float vel_limit = _pos_control.get_max_speed_xy();
-        if (!is_zero(dt)) {
-            vel_limit = MIN(vel_limit, track_leash_slack/dt);
-        }
-
-        // if within the stopping distance from destination, set target velocity to sqrt of distance * 2 * acceleration
-        if (!_flags.fast_waypoint && spline_dist_to_wp < _slow_down_dist) {
-            _spline_vel_scaler = safe_sqrt(spline_dist_to_wp * 2.0f * _wp_accel_cmss);
-        }else if(_spline_vel_scaler < vel_limit) {
-            // increase velocity using acceleration
-            _spline_vel_scaler += _wp_accel_cmss * dt;
-        }
-
-        // constrain target velocity
-        _spline_vel_scaler = constrain_float(_spline_vel_scaler, 0.0f, vel_limit);
-
-        // scale the spline_time by the velocity we've calculated vs the velocity that came out of the spline calculator
-        _spline_time_scale = _spline_vel_scaler / target_vel_length;
-
-        // update target position
-        target_pos.z += terr_offset;
-        _pos_control.set_pos_target(target_pos);
-
-        // update the target yaw if origin and destination are at least 2m apart horizontally
-        if (_track_length_xy >= WPNAV_YAW_DIST_MIN) {
-            if (_pos_control.get_leash_xy() < WPNAV_YAW_DIST_MIN) {
-                // if the leash is very short (i.e. flying at low speed) use the target point's velocity along the track
-                if (!is_zero(target_vel.x) && !is_zero(target_vel.y)) {
-                    set_yaw_cd(RadiansToCentiDegrees(atan2f(target_vel.y,target_vel.x)));
-                }
-            } else {
-                // point vehicle along the leash (i.e. point vehicle towards target point on the segment from origin to destination)
-                float track_error_xy_length = safe_sqrt(sq(track_error.x)+sq(track_error.y));
-                if (track_error_xy_length > MIN(WPNAV_YAW_DIST_MIN, _pos_control.get_leash_xy()*WPNAV_YAW_LEASH_PCT_MIN)) {
-                    // To-Do: why is track_error sign reversed?
-                    set_yaw_cd(RadiansToCentiDegrees(atan2f(-track_error.y,-track_error.x)));
-                }
-            }
-        }
-
-        // advance spline time to next step
-        _spline_time += _spline_time_scale*dt;
-
-        // we will reach the next waypoint in the next step so set reached_destination flag
-        // To-Do: is this one step too early?
-        if (_spline_time >= 1.0f) {
-            _flags.reached_destination = true;
-        }
-    }
-    return true;
-}
-
-// calc_spline_pos_vel_accel - calculates target position, velocity and acceleration for the given "spline_time"
-/// 	relies on update_spline_solution being called when the segment's origin and destination were set
-void AC_WPNav::calc_spline_pos_vel(float spline_time, Vector3f& position, Vector3f& velocity)
-{
-    float spline_time_sqrd = spline_time * spline_time;
-    float spline_time_cubed = spline_time_sqrd * spline_time;
-
-    position = _hermite_spline_solution[0] + \
-               _hermite_spline_solution[1] * spline_time + \
-               _hermite_spline_solution[2] * spline_time_sqrd + \
-               _hermite_spline_solution[3] * spline_time_cubed;
-
-    velocity = _hermite_spline_solution[1] + \
-               _hermite_spline_solution[2] * 2.0f * spline_time + \
-               _hermite_spline_solution[3] * 3.0f * spline_time_sqrd;
+    _yaw_rate = yaw_rate_cds;
 }
 
 // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
@@ -1029,6 +678,191 @@ bool AC_WPNav::get_terrain_offset(float& offset_cm)
 
     // we should never get here but just in case
     return false;
+}
+
+///
+/// spline methods
+///
+
+/// set_spline_destination waypoint using location class
+///     returns false if conversion from location to vector from ekf origin cannot be calculated
+///     next_destination should be the next segment's destination
+///     next_is_spline should be true if path to next_destination should be a spline
+bool AC_WPNav::set_spline_destination_loc(const Location& destination, const Location& next_destination, bool next_is_spline)
+{
+    // convert destination location to vector
+    Vector3f dest_neu;
+    bool dest_terr_alt;
+    if (!get_vector_NEU(destination, dest_neu, dest_terr_alt)) {
+        return false;
+    }
+
+    // convert next destination to vector
+    Vector3f next_dest_neu;
+    bool next_dest_terr_alt;
+    if (!get_vector_NEU(next_destination, next_dest_neu, next_dest_terr_alt)) {
+        return false;
+    }
+
+    // set target as vector from EKF origin
+    return set_spline_destination(dest_neu, dest_terr_alt, next_dest_neu, next_dest_terr_alt, next_is_spline);
+}
+
+/// set next destination (e.g. the one after the current destination) as a spline segment specified as a location
+///     returns false if conversion from location to vector from ekf origin cannot be calculated
+///     next_next_destination should be the next segment's destination
+bool AC_WPNav::set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline)
+{
+    // convert next_destination location to vector
+    Vector3f next_dest_neu;
+    bool next_dest_terr_alt;
+    if (!get_vector_NEU(next_destination, next_dest_neu, next_dest_terr_alt)) {
+        return false;
+    }
+
+    // convert next_next_destination to vector
+    Vector3f next_next_dest_neu;
+    bool next_next_dest_terr_alt;
+    if (!get_vector_NEU(next_next_destination, next_next_dest_neu, next_next_dest_terr_alt)) {
+        return false;
+    }
+
+    // set target as vector from EKF origin
+    return set_spline_destination_next(next_dest_neu, next_dest_terr_alt, next_next_dest_neu, next_next_dest_terr_alt, next_next_is_spline);
+}
+
+/// set_spline_destination waypoint using position vector (distance from ekf origin in cm)
+///     terrain_alt should be true if destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+///     next_destination should be set to the next segment's destination
+///     next_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+///     next_destination.z  must be in the same "frame" as destination.z (i.e. if destination is a alt-above-terrain, next_destination should be too)
+bool AC_WPNav::set_spline_destination(const Vector3f& destination, bool terrain_alt, const Vector3f& next_destination, bool next_terrain_alt, bool next_is_spline)
+{
+    // re-initialise if previous destination has been interrupted
+    if (!is_active() || !_flags.reached_destination) {
+        wp_and_spline_init(_wp_desired_speed_xy_cms);
+    }
+
+    // update spline calculators speeds, accelerations and leash lengths
+    _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down(),
+                                     _pos_control.get_max_accel_xy(), _pos_control.get_max_accel_z());
+
+    // calculate origin and origin velocity vector
+    Vector3f origin_vector;
+    if (terrain_alt == _terrain_alt && _flags.fast_waypoint) {
+        // calculate origin vector
+        if (_this_leg_is_spline) {
+            // if previous leg was a spline we can use destination velocity vector for origin velocity vector
+            origin_vector = _spline_this_leg.get_destination_vel();
+        } else {
+            // use direction of the previous straight line segment
+            origin_vector = _destination - _origin;
+        }
+
+        // use previous destination as origin
+        _origin = _destination;
+    } else {
+
+        // use previous destination as origin
+        _origin = _destination;
+
+        // get current alt above terrain
+        float origin_terr_offset;
+        if (!get_terrain_offset(origin_terr_offset)) {
+            return false;
+        }
+
+        // convert origin to alt-above-terrain if necessary
+        if (terrain_alt) {
+            // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
+            _origin.z -= origin_terr_offset;
+            _pos_terrain_offset += origin_terr_offset;
+        } else {
+            // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
+            _origin.z += origin_terr_offset;
+            _pos_terrain_offset -= origin_terr_offset;
+        }
+    }
+
+    // store destination location
+    _destination = destination;
+    _terrain_alt = terrain_alt;
+
+    // calculate destination velocity vector
+    Vector3f destination_vector;
+    if (terrain_alt == next_terrain_alt) {
+        if (next_is_spline) {
+            // leave this segment moving parallel to vector from origin to next destination
+            destination_vector = next_destination - _origin;
+        } else {
+            // leave this segment moving parallel to next segment
+            destination_vector = next_destination - _destination;
+        }
+    }
+    _flags.fast_waypoint = !destination_vector.is_zero();
+
+    // setup spline leg
+    _spline_this_leg.set_origin_and_destination(_origin, _destination, origin_vector, destination_vector);
+    _this_leg_is_spline = true;
+    _flags.reached_destination = false;
+    _flags.wp_yaw_set = false;
+
+    return true;
+}
+
+/// set next destination (e.g. the one after the current destination) as an offset (in cm, NEU frame) from the EKF origin
+///     next_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+///     next_next_destination should be set to the next segment's destination
+///     next_next_terrain_alt should be true if next_next_destination.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
+///     next_next_destination.z  must be in the same "frame" as destination.z (i.e. if next_destination is a alt-above-terrain, next_next_destination should be too)
+bool AC_WPNav::set_spline_destination_next(const Vector3f& next_destination, bool next_terrain_alt, const Vector3f& next_next_destination, bool next_next_terrain_alt, bool next_next_is_spline)
+{
+    // do not add next point if alt types don't match
+    if (next_terrain_alt != _terrain_alt) {
+        return true;
+    }
+
+    // calculate origin and origin velocity vector
+    Vector3f origin_vector;
+    if (_this_leg_is_spline) {
+        // if previous leg was a spline we can use destination velocity vector for origin velocity vector
+        origin_vector = _spline_this_leg.get_destination_vel();
+    } else {
+        // use the direction of the previous straight line segment
+        origin_vector = _destination - _origin;
+    }
+
+    // calculate destination velocity vector
+    Vector3f destination_vector;
+    if (next_terrain_alt == next_next_terrain_alt) {
+        if (next_next_is_spline) {
+            // leave this segment moving parallel to vector from this leg's origin (i.e. prev leg's destination) to next next destination
+            destination_vector = next_next_destination - _destination;
+        } else {
+            // leave this segment moving parallel to next segment
+            destination_vector = next_next_destination - next_destination;
+        }
+    }
+
+    // update spline calculators speeds and accelerations
+    _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_xy(), _pos_control.get_max_speed_up(), _pos_control.get_max_speed_down(),
+                                     _pos_control.get_max_accel_xy(), _pos_control.get_max_accel_z());
+
+    // setup next spline leg.  Note this could be made local
+    _spline_next_leg.set_origin_and_destination(_destination, next_destination, origin_vector, destination_vector);
+    _next_leg_is_spline = true;
+
+    // next destination provided so fast waypoint
+    _flags.fast_waypoint = true;
+
+    // update this_leg's final velocity to match next spline leg
+    if (!_this_leg_is_spline) {
+        _scurve_this_leg.set_destination_speed_max(_spline_next_leg.get_origin_speed_max());
+    } else {
+        _spline_this_leg.set_destination_speed_max(_spline_next_leg.get_origin_speed_max());
+    }
+
+    return true;
 }
 
 // convert location to vector from ekf origin.  terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
@@ -1066,68 +900,26 @@ bool AC_WPNav::get_vector_NEU(const Location &loc, Vector3f &vec, bool &terrain_
     return true;
 }
 
-///
-/// shared methods
-///
-
-/// calc_slow_down_distance - calculates distance before waypoint that target point should begin to slow-down assuming it is travelling at full speed
-void AC_WPNav::calc_slow_down_distance(float speed_cms, float accel_cmss)
+// helper function to calculate scurve jerk and jerk_time values
+// updates _scurve_jerk and _scurve_jerk_time
+void AC_WPNav::calc_scurve_jerk_and_jerk_time()
 {
-	// protect against divide by zero
-	if (accel_cmss <= 0.0f) {
-		_slow_down_dist = 0.0f;
-		return;
-	}
-    // To-Do: should we use a combination of horizontal and vertical speeds?
-    // To-Do: update this automatically when speed or acceleration is changed
-    _slow_down_dist = speed_cms * speed_cms / (4.0f*accel_cmss);
-}
-
-/// get_slow_down_speed - returns target speed of target point based on distance from the destination (in cm)
-float AC_WPNav::get_slow_down_speed(float dist_from_dest_cm, float accel_cmss)
-{
-    // return immediately if distance is zero (or less)
-    if (dist_from_dest_cm <= 0) {
-        return WPNAV_WP_TRACK_SPEED_MIN;
-    }
-
-    // calculate desired speed near destination
-    float target_speed = safe_sqrt(dist_from_dest_cm * 4.0f * accel_cmss);
-
-    // ensure desired speed never becomes too low
-    if (target_speed < WPNAV_WP_TRACK_SPEED_MIN) {
-        return WPNAV_WP_TRACK_SPEED_MIN;
+    // calculate jerk
+    _scurve_jerk = MIN(_attitude_control.get_ang_vel_roll_max_radss() * GRAVITY_MSS, _attitude_control.get_ang_vel_pitch_max_radss() * GRAVITY_MSS);
+    if (is_zero(_scurve_jerk)) {
+        _scurve_jerk = _wp_jerk;
     } else {
-        return target_speed;
-    }
-}
-
-/// wp_speed_update - calculates how to handle speed change requests
-void AC_WPNav::wp_speed_update(float dt)
-{
-    // return if speed has not changed
-    float curr_max_speed_xy_cms = _pos_control.get_max_speed_xy();
-    if (is_equal(_wp_desired_speed_xy_cms, curr_max_speed_xy_cms)) {
-        return;
-    }
-    // calculate speed change
-    if (_wp_desired_speed_xy_cms > curr_max_speed_xy_cms) {
-        // speed up is requested so increase speed within limit set by WPNAV_ACCEL
-        curr_max_speed_xy_cms += _wp_accel_cmss * dt;
-        if (curr_max_speed_xy_cms > _wp_desired_speed_xy_cms) {
-            curr_max_speed_xy_cms = _wp_desired_speed_xy_cms;
-        }
-    } else if (_wp_desired_speed_xy_cms < curr_max_speed_xy_cms) {
-        // slow down is requested so reduce speed within limit set by WPNAV_ACCEL
-        curr_max_speed_xy_cms -= _wp_accel_cmss * dt;
-        if (curr_max_speed_xy_cms < _wp_desired_speed_xy_cms) {
-            curr_max_speed_xy_cms = _wp_desired_speed_xy_cms;
-        }
+        _scurve_jerk = MIN(_scurve_jerk, _wp_jerk);
     }
 
-    // update position controller speed
-    _pos_control.set_max_speed_xy(curr_max_speed_xy_cms);
-    
-    // flag that wp leash must be recalculated
-    _flags.recalc_wp_leash = true;
+    // calculate jerk time
+    // jounce (the rate of change of jerk) uses the attitude control input time constant because multicopters
+    // lean to accelerate meaning the change in angle is equivalent to the change in acceleration
+    const float jounce = MIN(_attitude_control.get_accel_roll_max() * GRAVITY_MSS, _attitude_control.get_accel_pitch_max() * GRAVITY_MSS);
+    if (is_positive(jounce)) {
+        _scurve_jerk_time = MAX(_attitude_control.get_input_tc(), 0.5f * _scurve_jerk * M_PI / jounce);
+    } else {
+        _scurve_jerk_time = MAX(_attitude_control.get_input_tc(), 0.1f);
+    }
+    _scurve_jerk_time *= 2.0f;
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -62,7 +62,7 @@ public:
     ///
 
     /// wp_and_spline_init - initialise straight line and spline waypoint controllers
-    ///     speed_cms is the desired max speed to travel between waypoints.  should be a positive value or left at zero to use the default speed
+    ///     speed_cms is the desired max speed to travel between waypoints.  should be a positive value or omitted to use the default speed
     ///     updates target roll, pitch targets and I terms based on vehicle lean angles
     ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
     void wp_and_spline_init(float speed_cms = 0.0f);
@@ -170,7 +170,7 @@ public:
 
     // get target yaw in centi-degrees (used for wp and spline navigation)
     float get_yaw() const;
-    float get_yaw_rate() const;
+    float get_yaw_rate_cds() const;
 
     /// set_spline_destination waypoint using location class
     ///     returns false if conversion from location to vector from ekf origin cannot be calculated
@@ -262,14 +262,14 @@ protected:
     AP_Float    _wp_speed_up_cms;       // default maximum climb rate in cm/s
     AP_Float    _wp_speed_down_cms;     // default maximum descent rate in cm/s
     AP_Float    _wp_radius_cm;          // distance from a waypoint in cm that, when crossed, indicates the wp has been reached
-    AP_Float    _wp_accel_cmss;          // horizontal acceleration in cm/s/s during missions
-    AP_Float    _wp_accel_z_cmss;        // vertical acceleration in cm/s/s during missions
-    AP_Float    _wp_jerk;               // maximum jerk used to generate s-curve trajectories in m/s/s/s
+    AP_Float    _wp_accel_cmss;         // horizontal acceleration in cm/s/s during missions
+    AP_Float    _wp_accel_z_cmss;       // vertical acceleration in cm/s/s during missions
+    AP_Float    _wp_jerk;               // maximum jerk used to generate scurve trajectories in m/s/s/s
 
     // scurve
-    SCurve _scurve_prev_leg;            // previous spline trajectory used to blend with current s-curve trajectory
-    SCurve _scurve_this_leg;            // current spline trajectory
-    SCurve _scurve_next_leg;            // next spline trajectory used to blend with current s-curve trajectory
+    SCurve _scurve_prev_leg;            // previous scurve trajectory used to blend with current scurve trajectory
+    SCurve _scurve_this_leg;            // current scurve trajectory
+    SCurve _scurve_next_leg;            // next scurve trajectory used to blend with current scurve trajectory
     float _scurve_jerk;                 // scurve jerk max in m/s/s/s
     float _scurve_jerk_time;            // scurve jerk time (time in seconds for jerk to increase from zero _scurve_jerk)
 
@@ -290,7 +290,7 @@ protected:
     float       _track_desired;         // our desired distance along the track in cm
     float       _track_scalar_dt;       // time compression multiplier to slow the progress along the track
     float       _yaw;                   // current yaw heading in centi-degrees based on track direction
-    float       _yaw_rate;              // current yaw rate in centi-degrees/second based on track curvature
+    float       _yaw_rate_cds;          // current yaw rate in centi-degrees/second based on track curvature
 
     // terrain following variables
     bool        _terrain_alt;   // true if origin and destination.z are alt-above-terrain, false if alt-above-ekf-origin

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -106,9 +106,8 @@ public:
     bool set_wp_destination_loc(const Location& destination);
     bool set_wp_destination_next_loc(const Location& destination);
 
-    // returns wp location using location class.
-    // returns false if unable to convert from target vector to global
-    // coordinates
+    // get destination as a location.  Altitude frame will be absolute (AMSL) or above terrain
+    // returns false if unable to return a destination (for example if origin has not yet been set)
     bool get_wp_destination_loc(Location& destination) const;
 
     // returns object avoidance adjusted destination which is always the same as get_wp_destination

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -3,6 +3,8 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Math/SCurve.h>
+#include <AP_Math/SplineCurve.h>
 #include <AP_Common/Location.h>
 #include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_AttitudeControl/AC_PosControl.h>      // Position control library
@@ -12,11 +14,8 @@
 
 // maximum velocities and accelerations
 #define WPNAV_ACCELERATION              250.0f      // maximum horizontal acceleration in cm/s/s that wp navigation will request
-#define WPNAV_ACCELERATION_MIN           50.0f      // minimum acceleration in cm/s/s - used for sanity checking _wp_accel parameter
-
 #define WPNAV_WP_SPEED                 1000.0f      // default horizontal speed between waypoints in cm/s
 #define WPNAV_WP_SPEED_MIN               20.0f      // minimum horizontal speed between waypoints in cm/s
-#define WPNAV_WP_TRACK_SPEED_MIN         50.0f      // minimum speed along track of the target point the vehicle is chasing in cm/s (used as target slows down before reaching destination)
 #define WPNAV_WP_RADIUS                 200.0f      // default waypoint radius in cm
 #define WPNAV_WP_RADIUS_MIN               5.0f      // minimum waypoint radius in cm
 
@@ -24,15 +23,7 @@
 #define WPNAV_WP_SPEED_DOWN             150.0f      // default maximum descent velocity
 
 #define WPNAV_WP_ACCEL_Z_DEFAULT        100.0f      // default vertical acceleration between waypoints in cm/s/s
-
-#define WPNAV_LEASH_LENGTH_MIN          100.0f      // minimum leash lengths in cm
-
-#define WPNAV_WP_FAST_OVERSHOOT_MAX     200.0f      // 2m overshoot is allowed during fast waypoints to allow for smooth transitions to next waypoint
-
-#define WPNAV_YAW_DIST_MIN                 200      // minimum track length which will lead to target yaw being updated to point at next waypoint.  Under this distance the yaw target will be frozen at the current heading
-#define WPNAV_YAW_LEASH_PCT_MIN         0.134f      // target point must be at least this distance from the vehicle (expressed as a percentage of the maximum distance it can be from the vehicle - i.e. the leash length)
-
-#define WPNAV_RANGEFINDER_FILT_Z         0.25f      // range finder distance filtered at 0.25hz
+#define WPNAV_YAW_VEL_MIN                   10      // target velocity must be at least 10cm/s for vehicle's yaw to change
 
 class AC_WPNav
 {
@@ -71,9 +62,10 @@ public:
     ///
 
     /// wp_and_spline_init - initialise straight line and spline waypoint controllers
+    ///     speed_cms is the desired max speed to travel between waypoints.  should be a positive value or left at zero to use the default speed
     ///     updates target roll, pitch targets and I terms based on vehicle lean angles
     ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
-    void wp_and_spline_init();
+    void wp_and_spline_init(float speed_cms = 0.0f);
 
     /// set current target horizontal speed during wp navigation
     void set_speed_xy(float speed_cms);
@@ -109,29 +101,29 @@ public:
     bool origin_and_destination_are_terrain_alt() const { return _terrain_alt; }
 
     /// set_wp_destination waypoint using location class
+    ///     provide the next_destination if known
     ///     returns false if conversion from location to vector from ekf origin cannot be calculated
-    bool set_wp_destination(const Location& destination);
+    bool set_wp_destination_loc(const Location& destination);
+    bool set_wp_destination_next_loc(const Location& destination);
 
     // returns wp location using location class.
     // returns false if unable to convert from target vector to global
     // coordinates
-    bool get_wp_destination(Location& destination) const;
+    bool get_wp_destination_loc(Location& destination) const;
 
     // returns object avoidance adjusted destination which is always the same as get_wp_destination
     // having this function unifies the AC_WPNav_OA and AC_WPNav interfaces making vehicle code simpler
-    virtual bool get_oa_wp_destination(Location& destination) const { return get_wp_destination(destination); }
+    virtual bool get_oa_wp_destination(Location& destination) const { return get_wp_destination_loc(destination); }
 
     /// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
     ///     terrain_alt should be true if destination.z is a desired altitude above terrain
-    bool set_wp_destination(const Vector3f& destination, bool terrain_alt = false);
+    virtual bool set_wp_destination(const Vector3f& destination, bool terrain_alt = false);
+    bool set_wp_destination_next(const Vector3f& destination, bool terrain_alt = false);
 
     /// set waypoint destination using NED position vector from ekf origin in meters
+    ///     provide next_destination_NED if known
     bool set_wp_destination_NED(const Vector3f& destination_NED);
-
-    /// set_wp_origin_and_destination - set origin and destination waypoints using position vectors (distance from ekf origin in cm)
-    ///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if these are alt-above-ekf-origin)
-    ///     returns false on failure (likely caused by missing terrain data)
-    virtual bool set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt = false);
+    bool set_wp_destination_next_NED(const Vector3f& destination_NED);
 
     /// shift_wp_origin_to_current_pos - shifts the origin and destination so the origin starts at the current position
     ///     used to reset the position just before takeoff
@@ -167,63 +159,47 @@ public:
         return get_wp_distance_to_destination() < _wp_radius_cm;
     }
 
-    /// set_fast_waypoint - set to true to ignore the waypoint radius and consider the waypoint 'reached' the moment the intermediate point reaches it
-    void set_fast_waypoint(bool fast) { _flags.fast_waypoint = fast; }
-
     /// update_wpnav - run the wp controller - should be called at 100hz or higher
     virtual bool update_wpnav();
 
-    // check_wp_leash_length - check recalc_wp_leash flag and calls calculate_wp_leash_length() if necessary
-    //  should be called after _pos_control.update_xy_controller which may have changed the position controller leash lengths
-    void check_wp_leash_length();
-
-    /// calculate_wp_leash_length - calculates track speed, acceleration and leash lengths for waypoint controller
-    void calculate_wp_leash_length();
+    // returns true if update_wpnav has been run very recently
+    bool is_active() const;
 
     ///
     /// spline methods
     ///
 
-    // segment start types
-    // stop - vehicle is not moving at origin
-    // straight-fast - vehicle is moving, previous segment is straight.  vehicle will fly straight through the waypoint before beginning it's spline path to the next wp
-    //     _flag.segment_type holds whether prev segment is straight vs spline but we don't know if it has a delay
-    // spline-fast - vehicle is moving, previous segment is splined, vehicle will fly through waypoint but previous segment should have it flying in the correct direction (i.e. exactly parallel to position difference vector from previous segment's origin to this segment's destination)
-
-    // segment end types
-    // stop - vehicle is not moving at destination
-    // straight-fast - next segment is straight, vehicle's destination velocity should be directly along track from this segment's destination to next segment's destination
-    // spline-fast - next segment is spline, vehicle's destination velocity should be parallel to position difference vector from previous segment's origin to this segment's destination
-
     // get target yaw in centi-degrees (used for wp and spline navigation)
     float get_yaw() const;
+    float get_yaw_rate() const;
 
     /// set_spline_destination waypoint using location class
     ///     returns false if conversion from location to vector from ekf origin cannot be calculated
-    ///     terrain_alt should be true if destination.z is a desired altitude above terrain (false if its desired altitude above ekf origin)
-    ///     stopped_at_start should be set to true if vehicle is stopped at the origin
-    ///     seg_end_type should be set to stopped, straight or spline depending upon the next segment's type
-    ///     next_destination should be set to the next segment's destination if the seg_end_type is SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE
-    bool set_spline_destination(const Location& destination, bool stopped_at_start, spline_segment_end_type seg_end_type, Location next_destination);
+    ///     next_destination should be the next segment's destination
+    ///     next_is_spline should be true if next_destination is a spline segment
+    bool set_spline_destination_loc(const Location& destination, const Location& next_destination, bool next_is_spline);
+
+    /// set next destination (e.g. the one after the current destination) as a spline segment specified as a location
+    ///     returns false if conversion from location to vector from ekf origin cannot be calculated
+    ///     next_next_destination should be the next segment's destination
+    ///     next_next_is_spline should be true if next_next_destination is a spline segment
+    bool set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline);
 
     /// set_spline_destination waypoint using position vector (distance from ekf origin in cm)
-    ///     returns false if conversion from location to vector from ekf origin cannot be calculated
-    ///     terrain_alt should be true if destination.z is a desired altitudes above terrain (false if its desired altitudes above ekf origin)
-    ///     stopped_at_start should be set to true if vehicle is stopped at the origin
-    ///     seg_end_type should be set to stopped, straight or spline depending upon the next segment's type
-    ///     next_destination should be set to the next segment's destination if the seg_end_type is SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE
-    ///     next_destination.z  must be in the same "frame" as destination.z (i.e. if destination is a alt-above-terrain, next_destination should be too)
-    bool set_spline_destination(const Vector3f& destination, bool terrain_alt, bool stopped_at_start, spline_segment_end_type seg_end_type, const Vector3f& next_destination);
+    ///     terrain_alt should be true if destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+    ///     next_destination is the next segment's destination
+    ///     next_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+    ///     next_destination.z must be in the same "frame" as destination.z (i.e. if destination is a alt-above-terrain, next_destination must be too)
+    ///     next_is_spline should be true if next_destination is a spline segment
+    bool set_spline_destination(const Vector3f& destination, bool terrain_alt, const Vector3f& next_destination, bool next_terrain_alt, bool next_is_spline);
 
-    /// set_spline_origin_and_destination - set origin and destination waypoints using position vectors (distance from ekf origin in cm)
-    ///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if desired altitudes above ekf origin)
-    ///     stopped_at_start should be set to true if vehicle is stopped at the origin
-    ///     seg_end_type should be set to stopped, straight or spline depending upon the next segment's type
-    ///     next_destination should be set to the next segment's destination if the seg_end_type is SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE
-    bool set_spline_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt, bool stopped_at_start, spline_segment_end_type seg_end_type, const Vector3f& next_destination);
-
-    /// update_spline - update spline controller
-    bool update_spline();
+    /// set next destination (e.g. the one after the current destination) as an offset (in cm, NEU frame) from the EKF origin
+    ///     next_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+    ///     next_next_destination is the next segment's destination
+    ///     next_next_terrain_alt should be true if next_next_destination.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
+    ///     next_next_destination.z must be in the same "frame" as destination.z (i.e. if next_destination is a alt-above-terrain, next_next_destination must be too)
+    ///     next_next_is_spline should be true if next_next_destination is a spline segment
+    bool set_spline_destination_next(const Vector3f& next_destination, bool next_terrain_alt, const Vector3f& next_next_destination, bool next_next_terrain_alt, bool next_next_is_spline);
 
     ///
     /// shared methods
@@ -235,6 +211,9 @@ public:
 
     /// advance_wp_target_along_track - move target location along track from origin to destination
     bool advance_wp_target_along_track(float dt);
+
+    /// recalculate path with update speed and/or acceleration limits
+    void update_track_with_speed_accel_limits();
 
     /// return the crosstrack_error - horizontal error of the actual position vs the desired position
     float crosstrack_error() const { return _track_error_xy;}
@@ -253,34 +232,9 @@ protected:
     struct wpnav_flags {
         uint8_t reached_destination     : 1;    // true if we have reached the destination
         uint8_t fast_waypoint           : 1;    // true if we should ignore the waypoint radius and consider the waypoint complete once the intermediate target has reached the waypoint
-        uint8_t slowing_down            : 1;    // true when target point is slowing down before reaching the destination
-        uint8_t recalc_wp_leash         : 1;    // true if we need to recalculate the leash lengths because of changes in speed or acceleration
-        uint8_t new_wp_destination      : 1;    // true if we have just received a new destination.  allows us to freeze the position controller's xy feed forward
         SegmentType segment_type        : 1;    // active segment is either straight or spline
         uint8_t wp_yaw_set              : 1;    // true if yaw target has been set
     } _flags;
-
-    /// calc_slow_down_distance - calculates distance before waypoint that target point should begin to slow-down assuming it is traveling at full speed
-    void calc_slow_down_distance(float speed_cms, float accel_cmss);
-
-    /// get_slow_down_speed - returns target speed of target point based on distance from the destination (in cm)
-    float get_slow_down_speed(float dist_from_dest_cm, float accel_cmss);
-    
-    /// wp_speed_update - calculates how to change speed when changes are requested
-    void wp_speed_update(float dt);
-
-    /// spline protected functions
-
-    /// update_spline_solution - recalculates hermite_spline_solution grid
-    void update_spline_solution(const Vector3f& origin, const Vector3f& dest, const Vector3f& origin_vel, const Vector3f& dest_vel);
-
-    /// advance_spline_target_along_track - move target location along track from origin to destination
-    ///     returns false if it is unable to advance (most likely because of missing terrain data)
-    bool advance_spline_target_along_track(float dt);
-
-    /// calc_spline_pos_vel - update position and velocity from given spline time
-    /// 	relies on update_spline_solution being called since the previous
-    void calc_spline_pos_vel(float spline_time, Vector3f& position, Vector3f& velocity);
 
     // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
     bool get_terrain_offset(float& offset_cm);
@@ -291,6 +245,11 @@ protected:
 
     // set heading used for spline and waypoint navigation
     void set_yaw_cd(float heading_cd);
+    void set_yaw_rate_cds(float yaw_rate_cds);
+
+    // helper function to calculate scurve jerk and jerk_time values
+    // updates _scurve_jerk and _scurve_jerk_time
+    void calc_scurve_jerk_and_jerk_time();
 
     // references and pointers to external libraries
     const AP_InertialNav&   _inav;
@@ -306,36 +265,44 @@ protected:
     AP_Float    _wp_radius_cm;          // distance from a waypoint in cm that, when crossed, indicates the wp has been reached
     AP_Float    _wp_accel_cmss;          // horizontal acceleration in cm/s/s during missions
     AP_Float    _wp_accel_z_cmss;        // vertical acceleration in cm/s/s during missions
+    AP_Float    _wp_jerk;               // maximum jerk used to generate s-curve trajectories in m/s/s/s
+
+    // scurve
+    SCurve _scurve_prev_leg;            // previous spline trajectory used to blend with current s-curve trajectory
+    SCurve _scurve_this_leg;            // current spline trajectory
+    SCurve _scurve_next_leg;            // next spline trajectory used to blend with current s-curve trajectory
+    float _scurve_jerk;                 // scurve jerk max in m/s/s/s
+    float _scurve_jerk_time;            // scurve jerk time (time in seconds for jerk to increase from zero _scurve_jerk)
+
+    // spline curves
+    SplineCurve _spline_this_leg;      // spline curve for current segment
+    SplineCurve _spline_next_leg;      // spline curve for next segment
+
+    // the type of this leg
+    bool _this_leg_is_spline;           // true if this leg is a spline
+    bool _next_leg_is_spline;           // true if the next leg is a spline
 
     // waypoint controller internal variables
     uint32_t    _wp_last_update;        // time of last update_wpnav call
     float       _wp_desired_speed_xy_cms;   // desired wp speed in cm/sec
     Vector3f    _origin;                // starting point of trip to next waypoint in cm from ekf origin
     Vector3f    _destination;           // target destination in cm from ekf origin
-    Vector3f    _pos_delta_unit;        // each axis's percentage of the total track from origin to destination
     float       _track_error_xy;        // horizontal error of the actual position vs the desired position
-    float       _track_length;          // distance in cm between origin and destination
-    float       _track_length_xy;       // horizontal distance in cm between origin and destination
     float       _track_desired;         // our desired distance along the track in cm
-    float       _limited_speed_xy_cms;  // horizontal speed in cm/s used to advance the intermediate target towards the destination.  used to limit extreme acceleration after passing a waypoint
-    float       _track_accel;           // acceleration along track
-    float       _track_speed;           // speed in cm/s along track
-    float       _track_leash_length;    // leash length along track
-    float       _slow_down_dist;        // vehicle should begin to slow down once it is within this distance from the destination
-
-    // spline variables
-    float       _spline_time;           // current spline time between origin and destination
-    float       _spline_time_scale;     // current spline time between origin and destination
-    Vector3f    _spline_origin_vel;     // the target velocity vector at the origin of the spline segment
-    Vector3f    _spline_destination_vel;// the target velocity vector at the destination point of the spline segment
-    Vector3f    _hermite_spline_solution[4]; // array describing spline path between origin and destination
-    float       _spline_vel_scaler;	    //
-    float       _yaw;                   // heading according to yaw
+    float       _track_scalar_dt;       // time compression multiplier to slow the progress along the track
+    float       _yaw;                   // current yaw heading in centi-degrees based on track direction
+    float       _yaw_rate;              // current yaw rate in centi-degrees/second based on track curvature
 
     // terrain following variables
     bool        _terrain_alt;   // true if origin and destination.z are alt-above-terrain, false if alt-above-ekf-origin
-    bool        _rangefinder_available;
-    AP_Int8     _rangefinder_use;
-    bool        _rangefinder_healthy;
-    float       _rangefinder_alt_cm;
+    bool        _rangefinder_available; // true if rangefinder is enabled (user switch can turn this true/false)
+    AP_Int8     _rangefinder_use;       // parameter that specifies if the range finder should be used for terrain following commands
+    bool        _rangefinder_healthy;   // true if rangefinder distance is healthy (i.e. between min and maximum)
+    float       _rangefinder_alt_cm;    // latest distance from the rangefinder
+
+    // position, velocity and acceleration targets passed to position controller
+    float       _pos_terrain_offset;
+    float       _vel_terrain_offset;
+    float       _accel_terrain_offset;
+
 };

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -11,7 +11,7 @@ bool AC_WPNav_OA::get_oa_wp_destination(Location& destination) const
 {
     // if oa inactive return unadjusted location
     if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
-        return get_wp_destination(destination);
+        return get_wp_destination_loc(destination);
     }
 
     // return latest destination provided by oa path planner
@@ -19,12 +19,12 @@ bool AC_WPNav_OA::get_oa_wp_destination(Location& destination) const
     return true;
 }
 
-/// set_origin_and_destination - set origin and destination waypoints using position vectors (distance from home in cm)
-///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if these are alt-above-ekf-origin)
+/// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
+///     terrain_alt should be true if destination.z is a desired altitude above terrain
 ///     returns false on failure (likely caused by missing terrain data)
-bool AC_WPNav_OA::set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt)
+bool AC_WPNav_OA::set_wp_destination(const Vector3f& destination, bool terrain_alt)
 {
-    const bool ret = AC_WPNav::set_wp_origin_and_destination(origin, destination, terrain_alt);
+    const bool ret = AC_WPNav::set_wp_destination(destination, terrain_alt);
 
     if (ret) {
         // reset object avoidance state

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -15,10 +15,10 @@ public:
     // returns false if unable to convert from target vector to global coordinates
     bool get_oa_wp_destination(Location& destination) const override;
 
-    /// set origin and destination waypoints using position vectors (distance from ekf origin in cm)
-    ///     terrain_alt should be true if origin.z and destination.z are desired altitudes above terrain (false if these are alt-above-ekf-origin)
+    /// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
+    ///     terrain_alt should be true if destination.z is a desired altitude above terrain
     ///     returns false on failure (likely caused by missing terrain data)
-    bool set_wp_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool terrain_alt = false) override;
+    bool set_wp_destination(const Vector3f& destination, bool terrain_alt = false) override;
 
     /// get horizontal distance to destination in cm
     /// always returns distance to final destination (i.e. does not use oa adjusted destination)

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -61,6 +61,7 @@ void AP_InternalError::errors_as_string(uint8_t *buffer, const uint16_t len) con
         "mem_guard",
         "dma_fail",
         "params_restored",
+        "invalid arguments",
     };
 
     static_assert((1U<<(ARRAY_SIZE(error_bit_descriptions))) == uint32_t(AP_InternalError::error_t::__LAST__), "too few descriptions for bits");

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -66,7 +66,8 @@ public:
         mem_guard                   = (1U << 26),  //0x4000000 67108864
         dma_fail                    = (1U << 27),  //0x8000000 134217728
         params_restored             = (1U << 28),  //0x10000000 268435456
-        __LAST__                    = (1U << 29),  // used only for sanity check
+        invalid_arg_or_result       = (1U << 29),  //0x20000000 536870912
+        __LAST__                    = (1U << 30),  // used only for sanity check
     };
 
     // if you've changed __LAST__ to be 32, then you will want to

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1528,6 +1528,10 @@ LOG_STRUCTURE_FROM_CAMERA \
       "PIDA", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
     { LOG_PIDS_MSG, sizeof(log_PID), \
       "PIDS", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
+    { LOG_PIDN_MSG, sizeof(log_PID), \
+      "PIDN", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
+    { LOG_PIDE_MSG, sizeof(log_PID), \
+      "PIDE", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
     { LOG_DSTL_MSG, sizeof(log_DSTL), \
       "DSTL", "QBfLLeccfeffff", "TimeUS,Stg,THdg,Lat,Lng,Alt,XT,Travel,L1I,Loiter,Des,P,I,D", "s??DUm--------", "F??000--------" }, \
     { LOG_VIBE_MSG, sizeof(log_Vibe), \
@@ -1645,6 +1649,8 @@ enum LogMessages : uint8_t {
     LOG_PIDY_MSG,
     LOG_PIDA_MSG,
     LOG_PIDS_MSG,
+    LOG_PIDN_MSG,
+    LOG_PIDE_MSG,
     LOG_DSTL_MSG,
     LOG_VIBE_MSG,
     LOG_RPM_MSG,

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -1,0 +1,971 @@
+/*
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_Math/AP_Math.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_InternalError/AP_InternalError.h>
+#include "SCurve.h"
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <stdio.h>
+#endif
+
+extern const AP_HAL::HAL &hal;
+
+#define SEG_INIT                0
+#define SEG_ACCEL_MAX           4
+#define SEG_ACCEL_END           7
+#define SEG_SPEED_CHANGE_END    14
+#define SEG_CONST               15
+#define SEG_DECEL_END           22
+
+// constructor
+SCurve::SCurve()
+{
+    init();
+}
+
+// initialise and clear the path
+void SCurve::init()
+{
+    jerk_time = 0.0f;
+    jerk_max = 0.0f;
+    accel_max = 0.0f;
+    vel_max = 0.0f;
+    time = 0.0f;
+    num_segs = SEG_INIT;
+    add_segment(num_segs, 0.0f, SegmentType::CONSTANT_JERK, 0.0f, 0.0f, 0.0f, 0.0f);
+    track.zero();
+    delta_unit.zero();
+    position_sq = 0.0f;
+}
+
+// generate a trigonometric track in 3D space that moves over a straight line
+// between two points defined by the origin and destination
+void SCurve::calculate_track(const Vector3f &origin, const Vector3f &destination,
+                             float speed_xy, float speed_up, float speed_down,
+                             float accel_xy, float accel_z,
+                             float jerk_time_sec, float jerk_maximum)
+{
+    init();
+
+    // leave track as zero length if origin and destination are the same
+    if (origin == destination) {
+        return;
+    }
+
+    // set jerk time and jerk max
+    jerk_time = jerk_time_sec;
+    jerk_max = jerk_maximum;
+
+    // update speed and acceleration limits along path
+    set_kinematic_limits(origin, destination,
+                         speed_xy, speed_up, speed_down,
+                         accel_xy, accel_z);
+
+    // avoid divide-by zeros. Path will be left as a zero length path
+    if (!is_positive(jerk_time) || !is_positive(jerk_max) || !is_positive(accel_max) || !is_positive(vel_max)) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::calculate_track created zero length path\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        return;
+    }
+
+    track = destination - origin;
+    const float track_length = track.length();
+    if (is_zero(track_length)) {
+        // avoid possible divide by zero
+        delta_unit.zero();
+    } else {
+        delta_unit = track.normalized();
+        add_segments(track_length);
+    }
+
+    // catch calculation errors
+    if (!valid()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::calculate_track invalid path\n");
+        debug();
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
+    }
+}
+
+// set maximum velocity and re-calculate the path using these limits
+void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
+{
+    // return immediately if zero length path
+    if (num_segs != segments_max) {
+        return;
+    }
+
+    // segment accelerations can not be changed after segment creation.
+    const float track_speed_max = kinematic_limit(delta_unit, speed_xy, speed_up, fabsf(speed_down));
+
+    if (is_equal(vel_max, track_speed_max)) {
+        // new speed is equal to current speed maximum so no need to change anything
+        return;
+    }
+
+    if (is_zero(track_speed_max)) {
+        // new speed is zero which is not supported
+        return;
+    }
+    vel_max = track_speed_max;
+
+    if (time >= segment[SEG_CONST].end_time) {
+        return;
+    }
+
+    // re-calculate the s-curve path based on update speeds
+
+    const float Pend = segment[SEG_DECEL_END].end_pos;
+    float Vend = MIN(vel_max, segment[SEG_DECEL_END].end_vel);
+
+    if (is_zero(time)) {
+        // path has not started so we can recompute the path
+        const float Vstart = MIN(vel_max, segment[SEG_INIT].end_vel);
+        num_segs = SEG_INIT;
+        add_segment(num_segs, 0.0f, SegmentType::CONSTANT_JERK, 0.0f, 0.0f, 0.0f, 0.0f);
+        add_segments(Pend);
+        set_origin_speed_max(Vstart);
+        set_destination_speed_max(Vend);
+        return;
+    }
+
+    if ((time >= segment[SEG_ACCEL_END].end_time) && (time <= segment[SEG_SPEED_CHANGE_END].end_time)) {
+        // in the speed change phase
+        // move speed change phase to acceleration phase to provide room for further speed adjustments
+
+        // set initial segment to last acceleration segment
+        segment[SEG_INIT].seg_type = SegmentType::CONSTANT_JERK;
+        segment[SEG_INIT].jerk_ref = 0.0f;
+        segment[SEG_INIT].end_time = segment[SEG_ACCEL_END].end_time;
+        segment[SEG_INIT].end_accel = segment[SEG_ACCEL_END].end_accel;
+        segment[SEG_INIT].end_vel = segment[SEG_ACCEL_END].end_vel;
+        segment[SEG_INIT].end_pos = segment[SEG_ACCEL_END].end_pos;
+
+        // move speed change segments to acceleration segments
+        for (uint8_t i = SEG_INIT+1; i <= SEG_ACCEL_END; i++) {
+            segment[i] = segment[i+7];
+        }
+
+        // set change segments to last acceleration speed
+        for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_SPEED_CHANGE_END; i++) {
+            segment[i].seg_type = SegmentType::CONSTANT_JERK;
+            segment[i].jerk_ref = 0.0f;
+            segment[i].end_time = segment[SEG_ACCEL_END].end_time;
+            segment[i].end_accel = 0.0f;
+            segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
+            segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
+        }
+
+    } else if ((time > segment[SEG_SPEED_CHANGE_END].end_time) && (time <= segment[SEG_CONST].end_time)) {
+        // in the constant speed phase
+        // overwrite the acceleration and speed change phases with the current position and velocity
+
+        // set initial segment to last acceleration segment
+        segment[SEG_INIT].seg_type = SegmentType::CONSTANT_JERK;
+        segment[SEG_INIT].jerk_ref = 0.0f;
+        segment[SEG_INIT].end_time = segment[SEG_SPEED_CHANGE_END].end_time;
+        segment[SEG_INIT].end_accel = 0.0f;
+        segment[SEG_INIT].end_vel = segment[SEG_SPEED_CHANGE_END].end_vel;
+        segment[SEG_INIT].end_pos = segment[SEG_SPEED_CHANGE_END].end_pos;
+
+        // set acceleration and change segments to current constant speed
+        float Jt_out, At_out, Vt_out, Pt_out;
+        get_jerk_accel_vel_pos_at_time(time, Jt_out, At_out, Vt_out, Pt_out);
+        for (uint8_t i = SEG_INIT+1; i <= SEG_SPEED_CHANGE_END; i++) {
+            segment[i].seg_type = SegmentType::CONSTANT_JERK;
+            segment[i].jerk_ref = 0.0f;
+            segment[i].end_time = time;
+            segment[i].end_accel = 0.0f;
+            segment[i].end_vel = Vt_out;
+            segment[i].end_pos = Pt_out;
+        }
+    }
+
+    // adjust the INIT and ACCEL segments for new speed
+    if ((time <= segment[SEG_ACCEL_MAX].end_time) && is_positive(segment[SEG_ACCEL_MAX].end_time - segment[SEG_ACCEL_MAX-1].end_time) && (vel_max < segment[SEG_ACCEL_END].end_vel) && is_positive(segment[SEG_ACCEL_MAX].end_accel) ) {
+        // path has not finished constant positive acceleration segment
+        // reduce velocity as close to target velocity as possible
+
+        const float Vstart = segment[SEG_INIT].end_vel;
+
+        // minimum velocity that can be obtained by shortening SEG_ACCEL_MAX
+        const float Vmin = segment[SEG_ACCEL_END].end_vel - segment[SEG_ACCEL_MAX].end_accel * (segment[SEG_ACCEL_MAX].end_time - MAX(time, segment[SEG_ACCEL_MAX-1].end_time));
+
+        float Jm, t2, t4, t6;
+        calculate_path(jerk_time, jerk_max, Vstart, accel_max, MAX(Vmin, vel_max), Pend * 0.5f, Jm, t2, t4, t6);
+
+        uint8_t seg = SEG_INIT+1;
+        add_segments_jerk(seg, jerk_time, Jm, t2);
+        add_segment_const_jerk(seg, t4, 0.0f);
+        add_segments_jerk(seg, jerk_time, -Jm, t6);
+
+        // remove numerical errors
+        segment[SEG_ACCEL_END].end_accel = 0.0f;
+
+        // add empty speed adjust segments
+        for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_CONST; i++) {
+            segment[i].seg_type = SegmentType::CONSTANT_JERK;
+            segment[i].jerk_ref = 0.0f;
+            segment[i].end_time = segment[SEG_ACCEL_END].end_time;
+            segment[i].end_accel = 0.0f;
+            segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
+            segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
+        }
+
+        calculate_path(jerk_time, jerk_max, 0.0f, accel_max, MAX(Vmin, vel_max), Pend * 0.5f, Jm, t2, t4, t6);
+
+        seg = SEG_CONST + 1;
+        add_segments_jerk(seg, jerk_time, -Jm, t6);
+        add_segment_const_jerk(seg, t4, 0.0f);
+        add_segments_jerk(seg, jerk_time, Jm, t2);
+
+        // remove numerical errors
+        segment[SEG_DECEL_END].end_accel = 0.0f;
+        segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
+
+        // add to constant velocity segment to end at the correct position
+        const float dP = MAX(0.0f, Pend - segment[SEG_DECEL_END].end_pos);
+        const float t15 =  dP / segment[SEG_CONST].end_vel;
+        for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
+            segment[i].end_time += t15;
+            segment[i].end_pos += dP;
+        }
+    }
+
+    // adjust the speed change segments (8 to 14) for new speed
+    // start with empty speed adjust segments
+    for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_SPEED_CHANGE_END; i++) {
+        segment[i].seg_type = SegmentType::CONSTANT_JERK;
+        segment[i].jerk_ref = 0.0f;
+        segment[i].end_time = segment[SEG_ACCEL_END].end_time;
+        segment[i].end_accel = 0.0f;
+        segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
+        segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
+    }
+    if (!is_equal(vel_max, segment[SEG_ACCEL_END].end_vel)) {
+        // add velocity adjustment
+        // check there is enough time to make velocity change
+        // we use the approximation that the time will be distance/max_vel and 8 jerk segments
+        const float L = segment[SEG_CONST].end_pos - segment[SEG_ACCEL_END].end_pos;
+        float Jm = 0;
+        float t2 = 0;
+        float t4 = 0;
+        float t6 = 0;
+        if ((vel_max < segment[SEG_ACCEL_END].end_vel) && (jerk_time*12.0f < L/segment[SEG_ACCEL_END].end_vel)) {
+            // we have a problem here with small segments.
+            calculate_path(jerk_time, jerk_max, vel_max, accel_max, segment[SEG_ACCEL_END].end_vel, L * 0.5f, Jm, t6, t4, t2);
+            Jm = -Jm;
+
+        } else if ((vel_max > segment[SEG_ACCEL_END].end_vel) && (L/(jerk_time*12.0f) > segment[SEG_ACCEL_END].end_vel)) {
+            float Vm = MIN(vel_max, L/(jerk_time*12.0f));
+            calculate_path(jerk_time, jerk_max, segment[SEG_ACCEL_END].end_vel, accel_max, Vm, L * 0.5f, Jm, t2, t4, t6);
+        }
+
+        uint8_t seg = SEG_ACCEL_END + 1;
+        if (!is_zero(Jm) && !is_negative(t2) && !is_negative(t4) && !is_negative(t6)) {
+            add_segments_jerk(seg, jerk_time, Jm, t2);
+            add_segment_const_jerk(seg, t4, 0.0f);
+            add_segments_jerk(seg, jerk_time, -Jm, t6);
+
+            // remove numerical errors
+            segment[SEG_SPEED_CHANGE_END].end_accel = 0.0f;
+        }
+    }
+
+    // add deceleration segments
+    // earlier check should ensure that we should always have sufficient time to stop
+    uint8_t seg = SEG_CONST;
+    Vend = MIN(Vend, segment[SEG_SPEED_CHANGE_END].end_vel);
+    add_segment_const_jerk(seg, 0.0f, 0.0f);
+    if (Vend < segment[SEG_SPEED_CHANGE_END].end_vel) {
+        float Jm, t2, t4, t6;
+        calculate_path(jerk_time, jerk_max, Vend, accel_max, segment[SEG_CONST].end_vel, Pend - segment[SEG_CONST].end_pos, Jm, t2, t4, t6);
+        add_segments_jerk(seg, jerk_time, -Jm, t6);
+        add_segment_const_jerk(seg, t4, 0.0f);
+        add_segments_jerk(seg, jerk_time, Jm, t2);
+    } else {
+        // No deceleration is required
+        for (uint8_t i = SEG_CONST+1; i <= SEG_DECEL_END; i++) {
+            segment[i].seg_type = SegmentType::CONSTANT_JERK;
+            segment[i].jerk_ref = 0.0f;
+            segment[i].end_time = segment[SEG_CONST].end_time;
+            segment[i].end_accel = 0.0f;
+            segment[i].end_vel = segment[SEG_CONST].end_vel;
+            segment[i].end_pos = segment[SEG_CONST].end_pos;
+        }
+    }
+
+    // remove numerical errors
+    segment[SEG_DECEL_END].end_accel = 0.0f;
+    segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
+
+    // add to constant velocity segment to end at the correct position
+    const float dP = MAX(0.0f, Pend - segment[SEG_DECEL_END].end_pos);
+    const float t15 =  dP / segment[SEG_CONST].end_vel;
+    for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
+        segment[i].end_time += t15;
+        segment[i].end_pos += dP;
+    }
+
+    // catch calculation errors
+    if (!valid()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::set_speed_max invalid path\n");
+        debug();
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
+    }
+}
+
+// set the maximum vehicle speed at the origin
+// returns the expected speed at the origin which will always be equal or lower than speed
+float SCurve::set_origin_speed_max(float speed)
+{
+    // if path is zero length then start speed must be zero
+    if (num_segs != segments_max) {
+        return 0.0f;
+    }
+
+    // avoid re-calculating if unnecessary
+    if (is_equal(segment[SEG_INIT].end_vel, speed)) {
+        return speed;
+    }
+
+    const float Vm = segment[SEG_ACCEL_END].end_vel;
+    const float track_length = track.length();
+    speed = MIN(speed, Vm);
+
+    float Jm, t2, t4, t6;
+    calculate_path(jerk_time, jerk_max, speed, accel_max, Vm, track_length * 0.5f, Jm, t2, t4, t6);
+
+    uint8_t seg = SEG_INIT;
+    add_segment(seg, 0.0f, SegmentType::CONSTANT_JERK, 0.0f, 0.0f, speed, 0.0f);
+    add_segments_jerk(seg, jerk_time, Jm, t2);
+    add_segment_const_jerk(seg, t4, 0.0f);
+    add_segments_jerk(seg, jerk_time, -Jm, t6);
+
+    // remove numerical errors
+    segment[SEG_ACCEL_END].end_accel = 0.0f;
+
+    // offset acceleration segment if we can't fit it all into half the original length
+    const float dPstart = MIN(0.0f, track_length * 0.5f - segment[SEG_ACCEL_END].end_pos);
+    const float dt =  dPstart / segment[SEG_ACCEL_END].end_vel;
+    for (uint8_t i = SEG_INIT; i <= SEG_ACCEL_END; i++) {
+        segment[i].end_time += dt;
+        segment[i].end_pos += dPstart;
+    }
+
+    // add empty speed change segments and constant speed segment
+    for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_SPEED_CHANGE_END; i++) {
+        segment[i].seg_type = SegmentType::CONSTANT_JERK;
+        segment[i].jerk_ref = 0.0f;
+        segment[i].end_time = segment[SEG_ACCEL_END].end_time;
+        segment[i].end_accel = 0.0f;
+        segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
+        segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
+    }
+
+    seg = SEG_CONST;
+    add_segment_const_jerk(seg, 0.0f, 0.0f);
+
+    calculate_path(jerk_time, jerk_max, 0.0f, accel_max, segment[SEG_CONST].end_vel, track_length * 0.5f, Jm, t2, t4, t6);
+
+    add_segments_jerk(seg, jerk_time, -Jm, t6);
+    add_segment_const_jerk(seg, t4, 0.0f);
+    add_segments_jerk(seg, jerk_time, Jm, t2);
+
+    // remove numerical errors
+    segment[SEG_DECEL_END].end_accel = 0.0f;
+    segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
+
+    // add to constant velocity segment to end at the correct position
+    const float dP = MAX(0.0f, track_length - segment[SEG_DECEL_END].end_pos);
+    const float t15 =  dP / segment[SEG_CONST].end_vel;
+    for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
+        segment[i].end_time += t15;
+        segment[i].end_pos += dP;
+    }
+
+    // catch calculation errors
+    if (!valid()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::set_origin_speed_max invalid path\n");
+        debug();
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
+        return 0.0f;
+    }
+
+    return speed;
+}
+
+// set the maximum vehicle speed at the destination
+void SCurve::set_destination_speed_max(float speed)
+{
+    // if path is zero length then all speeds must be zero
+    if (num_segs != segments_max) {
+        return;
+    }
+
+    // avoid re-calculating if unnecessary
+    if (is_equal(segment[segments_max-1].end_vel, speed)) {
+        return;
+    }
+
+    const float Vm = segment[SEG_CONST].end_vel;
+    const float track_length = track.length();
+    speed = MIN(speed, Vm);
+
+    float Jm, t2, t4, t6;
+    calculate_path(jerk_time, jerk_max, speed, accel_max, Vm, track_length * 0.5f, Jm, t2, t4, t6);
+
+    uint8_t seg = SEG_CONST;
+    add_segment_const_jerk(seg, 0.0f, 0.0f);
+
+    add_segments_jerk(seg, jerk_time, -Jm, t6);
+    add_segment_const_jerk(seg, t4, 0.0f);
+    add_segments_jerk(seg, jerk_time, Jm, t2);
+
+    // remove numerical errors
+    segment[SEG_DECEL_END].end_accel = 0.0f;
+    segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
+
+    // add to constant velocity segment to end at the correct position
+    const float dP = MAX(0.0f, track_length - segment[SEG_DECEL_END].end_pos);
+    const float t15 =  dP / segment[SEG_CONST].end_vel;
+    for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
+        segment[i].end_time += t15;
+        segment[i].end_pos += dP;
+    }
+
+    // catch calculation errors
+    if (!valid()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::set_destination_speed_max invalid path\n");
+        debug();
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
+    }
+}
+
+// move target location along path from origin to destination
+// prev_leg and next_leg are the paths before and after this path
+// wp_radius is max distance from the waypoint at the apex of the turn
+// fast_waypoint should be true if vehicle will not stop at end of this leg
+// dt is the time increment the vehicle will move along the path
+// target_pos should be set to this segment's origin and it will be updated to the current position target
+// target_vel and target_accel are updated with new targets
+// returns true if vehicle has passed the apex of the corner
+bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, float wp_radius, bool fast_waypoint, float dt, Vector3f &target_pos, Vector3f &target_vel, Vector3f &target_accel)
+{
+    prev_leg.move_to_pos_vel_accel(dt, target_pos, target_vel, target_accel);
+    move_from_pos_vel_accel(dt, target_pos, target_vel, target_accel);
+    bool s_finished = finished();
+
+    // check for change of leg on fast waypoint
+    const float time_to_destination = get_time_remaining();
+    if (fast_waypoint && braking() && is_zero(next_leg.get_time_elapsed()) && (time_to_destination <= next_leg.get_accel_finished_time())) {
+        Vector3f turn_pos = -get_track();
+        Vector3f turn_vel, turn_accel;
+        move_from_time_pos_vel_accel(get_time_elapsed() + time_to_destination * 0.5f, turn_pos, turn_vel, turn_accel);
+        next_leg.move_from_time_pos_vel_accel(time_to_destination * 0.5f, turn_pos, turn_vel, turn_accel);
+        const float speed_min = MIN(get_speed_along_track(), next_leg.get_speed_along_track());
+        const float accel_min = MIN(get_accel_along_track(), next_leg.get_accel_along_track());
+        if ((get_time_remaining() < next_leg.time_end() * 0.5f) && (turn_pos.length() < wp_radius) &&
+             (Vector2f(turn_vel.x, turn_vel.y).length() < speed_min) &&
+             (Vector2f(turn_accel.x, turn_accel.y).length() < 2.0f*accel_min)) {
+            next_leg.move_from_pos_vel_accel(dt, target_pos, target_vel, target_accel);
+        }
+    } else if (!is_zero(next_leg.get_time_elapsed())) {
+        next_leg.move_from_pos_vel_accel(dt, target_pos, target_vel, target_accel);
+        if (next_leg.get_time_elapsed() >= get_time_remaining()) {
+            s_finished = true;
+        }
+    }
+
+    return s_finished;
+}
+
+// time has reached the end of the sequence
+bool SCurve::finished() const
+{
+    return ((time >= time_end()) || (position_sq >= track.length_squared()));
+}
+
+// increment time pointer and return the position, velocity and acceleration vectors relative to the origin
+void SCurve::move_from_pos_vel_accel(float dt, Vector3f &pos, Vector3f &vel, Vector3f &accel)
+{
+    advance_time(dt);
+    float scurve_P1 = 0.0f;
+    float scurve_V1, scurve_A1, scurve_J1;
+    get_jerk_accel_vel_pos_at_time(time, scurve_J1, scurve_A1, scurve_V1, scurve_P1);
+    pos += delta_unit * scurve_P1;
+    vel += delta_unit * scurve_V1;
+    accel += delta_unit * scurve_A1;
+    position_sq = sq(scurve_P1);
+}
+
+// increment time pointer and return the position, velocity and acceleration vectors relative to the destination
+void SCurve::move_to_pos_vel_accel(float dt, Vector3f &pos, Vector3f &vel, Vector3f &accel)
+{
+    advance_time(dt);
+    float scurve_P1 = 0.0f;
+    float scurve_V1, scurve_A1, scurve_J1;
+    get_jerk_accel_vel_pos_at_time(time, scurve_J1, scurve_A1, scurve_V1, scurve_P1);
+    pos += delta_unit * scurve_P1;
+    vel += delta_unit * scurve_V1;
+    accel += delta_unit * scurve_A1;
+    position_sq = sq(scurve_P1);
+    pos -= track;
+}
+
+// return the position, velocity and acceleration vectors relative to the origin at a specified time along the path
+void SCurve::move_from_time_pos_vel_accel(float time_now, Vector3f &pos, Vector3f &vel, Vector3f &accel)
+{
+    float scurve_P1 = 0.0f;
+    float scurve_V1, scurve_A1, scurve_J1;
+    get_jerk_accel_vel_pos_at_time(time_now, scurve_J1, scurve_A1, scurve_V1, scurve_P1);
+    pos += delta_unit * scurve_P1;
+    vel += delta_unit * scurve_V1;
+    accel += delta_unit * scurve_A1;
+}
+
+// time at the end of the sequence
+float SCurve::time_end() const
+{
+    if (num_segs != segments_max) {
+        return 0.0f;
+    }
+    return segment[SEG_DECEL_END].end_time;
+}
+
+// time left before sequence will complete
+float SCurve::get_time_remaining() const
+{
+    if (num_segs != segments_max) {
+        return 0.0f;
+    }
+    return segment[SEG_DECEL_END].end_time - time;
+}
+
+// time when acceleration section of the sequence will complete
+float SCurve::get_accel_finished_time() const
+{
+    if (num_segs != segments_max) {
+        return 0.0f;
+    }
+    return segment[SEG_ACCEL_END].end_time;
+}
+
+// return true if the sequence is braking to a stop
+bool SCurve::braking() const
+{
+    if (num_segs != segments_max) {
+        return true;
+    }
+    return time >= segment[SEG_CONST].end_time;
+}
+
+// increment the internal time
+void SCurve::advance_time(float dt)
+{
+    time = MIN(time+dt, time_end());
+}
+
+// calculate the jerk, acceleration, velocity and position at the provided time
+void SCurve::get_jerk_accel_vel_pos_at_time(float time_now, float &Jt_out, float &At_out, float &Vt_out, float &Pt_out) const
+{
+    if ((num_segs != segments_max) || !is_positive(jerk_time)) {
+        Jt_out = 0;
+        At_out = 0;
+        Vt_out = 0;
+        Pt_out = 0;
+        return;
+    }
+
+    SegmentType Jtype;
+    uint8_t pnt = num_segs;
+    float Jm, T0, A0, V0, P0;
+
+    // find active segment at time_now
+    for (uint8_t i = 0; i < num_segs; i++) {
+        if (time_now < segment[num_segs - 1 - i].end_time) {
+            pnt = num_segs - 1 - i;
+        }
+    }
+    if (pnt == 0) {
+        Jtype = SegmentType::CONSTANT_JERK;
+        Jm = 0.0f;
+        T0 = segment[pnt].end_time;
+        A0 = segment[pnt].end_accel;
+        V0 = segment[pnt].end_vel;
+        P0 = segment[pnt].end_pos;
+    } else if (pnt == num_segs) {
+        Jtype = SegmentType::CONSTANT_JERK;
+        Jm = 0.0f;
+        T0 = segment[pnt - 1].end_time;
+        A0 = segment[pnt - 1].end_accel;
+        V0 = segment[pnt - 1].end_vel;
+        P0 = segment[pnt - 1].end_pos;
+    } else {
+        Jtype = segment[pnt].seg_type;
+        Jm = segment[pnt].jerk_ref;
+        T0 = segment[pnt - 1].end_time;
+        A0 = segment[pnt - 1].end_accel;
+        V0 = segment[pnt - 1].end_vel;
+        P0 = segment[pnt - 1].end_pos;
+    }
+
+    switch (Jtype) {
+    case SegmentType::CONSTANT_JERK:
+        calc_javp_for_segment_const_jerk(time_now - T0, Jm, A0, V0, P0, Jt_out, At_out, Vt_out, Pt_out);
+        break;
+    case SegmentType::POSITIVE_JERK:
+        calc_javp_for_segment_incr_jerk(time_now - T0, jerk_time, Jm, A0, V0, P0, Jt_out, At_out, Vt_out, Pt_out);
+        break;
+    case SegmentType::NEGATIVE_JERK:
+        calc_javp_for_segment_decr_jerk(time_now - T0, jerk_time, Jm, A0, V0, P0, Jt_out, At_out, Vt_out, Pt_out);
+        break;
+    }
+    Pt_out = MAX(0.0f, Pt_out);
+}
+
+// calculate the jerk, acceleration, velocity and position at time time_now when running the constant jerk time segment
+void SCurve::calc_javp_for_segment_const_jerk(float time_now, float J0, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const
+{
+    Jt = J0;
+    At = A0 + J0 * time_now;
+    Vt = V0 + A0 * time_now + 0.5f * J0 * (time_now * time_now);
+    Pt = P0 + V0 * time_now + 0.5f * A0 * (time_now * time_now) + (1.0f / 6.0f) * J0 * (time_now * time_now * time_now);
+}
+
+// Calculate the jerk, acceleration, velocity and position at time time_now when running the increasing jerk magnitude time segment based on a raised cosine profile
+void SCurve::calc_javp_for_segment_incr_jerk(float time_now, float tj, float Jm, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const
+{
+    const float Alpha = Jm * 0.5f;
+    const float Beta = M_PI / tj;
+    Jt = Alpha * (1.0f - cosf(Beta * time_now));
+    At = A0 + Alpha * time_now - (Alpha / Beta) * sinf(Beta * time_now);
+    Vt = V0 + A0 * time_now + (Alpha * 0.5f) * (time_now * time_now) + (Alpha / (Beta * Beta)) * cosf(Beta * time_now) - Alpha / (Beta * Beta);
+    Pt = P0 + V0 * time_now + 0.5f * A0 * (time_now * time_now) + (-Alpha / (Beta * Beta)) * time_now + Alpha * (time_now * time_now * time_now) / 6.0f + (Alpha / (Beta * Beta * Beta)) * sinf(Beta * time_now);
+}
+
+// Calculate the jerk, acceleration, velocity and position at time time_now when running the decreasing jerk magnitude time segment based on a raised cosine profile
+void SCurve::calc_javp_for_segment_decr_jerk(float time_now, float tj, float Jm, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const
+{
+    const float Alpha = Jm * 0.5f;
+    const float Beta = M_PI / tj;
+    const float AT = Alpha * tj;
+    const float VT = Alpha * ((tj * tj) * 0.5f - 2.0f / (Beta * Beta));
+    const float PT = Alpha * ((-1.0f / (Beta * Beta)) * tj + (1.0f / 6.0f) * (tj * tj * tj));
+    Jt = Alpha * (1.0f - cosf(Beta * (time_now + tj)));
+    At = (A0 - AT) + Alpha * (time_now + tj) - (Alpha / Beta) * sinf(Beta * (time_now + tj));
+    Vt = (V0 - VT) + (A0 - AT) * time_now + 0.5f * Alpha * (time_now + tj) * (time_now + tj) + (Alpha / (Beta * Beta)) * cosf(Beta * (time_now + tj)) - Alpha / (Beta * Beta);
+    Pt = (P0 - PT) + (V0 - VT) * time_now + 0.5f * (A0 - AT) * (time_now * time_now) + (-Alpha / (Beta * Beta)) * (time_now + tj) + (Alpha / 6.0f) * (time_now + tj) * (time_now + tj) * (time_now + tj) + (Alpha / (Beta * Beta * Beta)) * sinf(Beta * (time_now + tj));
+}
+
+// generate the segments for a path of length L
+// the path consists of 23 segments
+// 1 initial segment
+// 7 segments forming the acceleration S-Curve
+// 7 segments forming the velocity change S-Curve
+// 1 constant velocity S-Curve
+// 7 segments forming the deceleration S-Curve
+void SCurve::add_segments(float L)
+{
+    if (is_zero(L)) {
+        return;
+    }
+
+    float Jm, t2, t4, t6;
+    calculate_path(jerk_time, jerk_max, 0.0f, accel_max, vel_max, L * 0.5f, Jm, t2, t4, t6);
+
+    add_segments_jerk(num_segs, jerk_time, Jm, t2);
+    add_segment_const_jerk(num_segs, t4, 0.0f);
+    add_segments_jerk(num_segs, jerk_time, -Jm, t6);
+
+    // remove numerical errors
+    segment[SEG_ACCEL_END].end_accel = 0.0f;
+
+    // add empty speed adjust segments
+    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+
+    const float t15 = MAX(0.0f, (L - 2.0f * segment[SEG_SPEED_CHANGE_END].end_pos) / segment[SEG_SPEED_CHANGE_END].end_vel);
+    add_segment_const_jerk(num_segs, t15, 0.0f);
+
+    add_segments_jerk(num_segs, jerk_time, -Jm, t6);
+    add_segment_const_jerk(num_segs, t4, 0.0f);
+    add_segments_jerk(num_segs, jerk_time, Jm, t2);
+
+    // remove numerical errors
+    segment[SEG_DECEL_END].end_accel = 0.0f;
+    segment[SEG_DECEL_END].end_vel = 0.0f;
+}
+
+// calculate the segment times for the trigonometric S-Curve path defined by:
+// tj - duration of the raised cosine jerk profile
+// Jm - maximum value of the raised cosine jerk profile
+// V0 - initial velocity magnitude
+// Am - maximum constant acceleration
+// Vm - maximum constant velocity
+// L - Length of the path
+// t2_out, t4_out, t6_out are the segment durations needed to achieve the kinimatic path specified by the input variables
+void SCurve::calculate_path(float tj, float Jm, float V0, float Am, float Vm, float L, float &Jm_out, float &t2_out, float &t4_out, float &t6_out) const
+{
+    // init outputs
+    Jm_out = 0.0f;
+    t2_out = 0.0f;
+    t4_out = 0.0f;
+    t6_out = 0.0f;
+
+    // check for invalid arguments
+    if (!is_positive(tj) || !is_positive(Jm) || !is_positive(Am) || !is_positive(Vm) || !is_positive(L)) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::calculate_path invalid inputs\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        return;
+    }
+
+    if (V0 >= Vm) {
+        // no velocity change so all segments as zero length
+        return;
+    }
+
+    Am = MIN(MIN(Am, (Vm - V0) / (2.0f * tj)), (L + 4.0f * V0 * tj) / (4.0f * sq(tj)));
+    if (fabsf(Am) < Jm * tj) {
+        Jm = Am / tj;
+        if ((Vm <= V0 + 2.0f * Am * tj) || (L <= 4.0f * V0 * tj + 4.0f * Am * sq(tj))) {
+            // solution = 0 - t6 t4 t2 = 0 0 0
+            t2_out = 0.0f;
+            t4_out = 0.0f;
+            t6_out = 0.0f;
+        } else {
+            // solution = 2 - t6 t4 t2 = 0 1 0
+            t2_out = 0.0f;
+            t4_out = MIN(-(V0 - Vm + Am * tj + (Am * Am) / Jm) / Am, MAX(((Am * Am) * (-3.0f / 2.0f) + safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm), ((Am * Am) * (-3.0f / 2.0f) - safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm)));
+            t6_out = 0.0f;
+        }
+    } else {
+        if ((Vm < V0 + Am * tj + (Am * Am) / Jm) || (L < 1.0f / (Jm * Jm) * (Am * Am * Am + Am * Jm * (V0 * 2.0f + Am * tj * 2.0f)) + V0 * tj * 2.0f + Am * (tj * tj))) {
+            // solution = 5 - t6 t4 t2 = 1 0 1
+            Am = MIN(MIN(Am, MAX(Jm * (tj + safe_sqrt((V0 * -4.0f + Vm * 4.0f + Jm * (tj * tj)) / Jm)) * (-1.0f / 2.0f), Jm * (tj - safe_sqrt((V0 * -4.0f + Vm * 4.0f + Jm * (tj * tj)) / Jm)) * (-1.0f / 2.0f))), Jm * tj * (-2.0f / 3.0f) + ((Jm * Jm) * (tj * tj) * (1.0f / 9.0f) - Jm * V0 * (2.0f / 3.0f)) * 1.0f / powf(safe_sqrt(powf(- (Jm * Jm) * L * (1.0f / 2.0f) + (Jm * Jm * Jm) * (tj * tj * tj) * (8.0f / 2.7E1f) - Jm * tj * ((Jm * Jm) * (tj * tj) + Jm * V0 * 2.0f) * (1.0f / 3.0f) + (Jm * Jm) * V0 * tj, 2.0f) - powf((Jm * Jm) * (tj * tj) * (1.0f / 9.0f) - Jm * V0 * (2.0f / 3.0f), 3.0f)) + (Jm * Jm) * L * (1.0f / 2.0f) - (Jm * Jm * Jm) * (tj * tj * tj) * (8.0f / 2.7E1f) + Jm * tj * ((Jm * Jm) * (tj * tj) + Jm * V0 * 2.0f) * (1.0f / 3.0f) - (Jm * Jm) * V0 * tj, 1.0f / 3.0f) + powf(safe_sqrt(powf(- (Jm * Jm) * L * (1.0f / 2.0f) + (Jm * Jm * Jm) * (tj * tj * tj) * (8.0f / 2.7E1f) - Jm * tj * ((Jm * Jm) * (tj * tj) + Jm * V0 * 2.0f) * (1.0f / 3.0f) + (Jm * Jm) * V0 * tj, 2.0f) - powf((Jm * Jm) * (tj * tj) * (1.0f / 9.0f) - Jm * V0 * (2.0f / 3.0f), 3.0f)) + (Jm * Jm) * L * (1.0f / 2.0f) - (Jm * Jm * Jm) * (tj * tj * tj) * (8.0f / 2.7E1f) + Jm * tj * ((Jm * Jm) * (tj * tj) + Jm * V0 * 2.0f) * (1.0f / 3.0f) - (Jm * Jm) * V0 * tj, 1.0f / 3.0f));
+            t2_out = Am / Jm - tj;
+            t4_out = 0.0f;
+            t6_out = t2_out;
+        } else {
+            // solution = 7 - t6 t4 t2 = 1 1 1
+            t2_out = Am / Jm - tj;
+            t4_out = MIN(-(V0 - Vm + Am * tj + (Am * Am) / Jm) / Am, MAX(((Am * Am) * (-3.0f / 2.0f) + safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm), ((Am * Am) * (-3.0f / 2.0f) - safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm)));
+            t6_out = t2_out;
+        }
+    }
+    Jm_out = Jm;
+
+    // check outputs and reset back to zero if necessary
+    if (!isfinite(Jm_out) || is_negative(Jm_out) ||
+        !isfinite(t2_out) || is_negative(t2_out) ||
+        !isfinite(t4_out) || is_negative(t4_out) ||
+        !isfinite(t6_out) || is_negative(t6_out)) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::calculate_path invalid outputs\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        Jm_out = 0.0f;
+        t2_out = 0.0f;
+        t4_out = 0.0f;
+        t6_out = 0.0f;
+    }
+}
+
+// generate three consecutive segments forming a jerk profile
+// the index variable is the position within the path array that this jerk profile should be added
+// the index is incremented to reference the next segment in the array after the jerk profile
+void SCurve::add_segments_jerk(uint8_t &index, float tj, float Jm, float Tcj)
+{
+    add_segment_incr_jerk(index, tj, Jm);
+    add_segment_const_jerk(index, Tcj, Jm);
+    add_segment_decr_jerk(index, tj, Jm);
+}
+
+// generate constant jerk time segment
+// calculate the information needed to populate the constant jerk segment from the segment duration tj and jerk J0
+// the index variable is the position of this segment in the path array and is incremented to reference the next segment in the array
+void SCurve::add_segment_const_jerk(uint8_t &index, float tj, float J0)
+{
+    // if no time increase copy previous segment
+    if (is_zero(tj)) {
+        add_segment(index, segment[index - 1].end_time,
+                    SegmentType::CONSTANT_JERK,
+                    J0,
+                    segment[index - 1].end_accel,
+                    segment[index - 1].end_vel,
+                    segment[index - 1].end_pos);
+        return;
+    }
+
+    const float J = J0;
+    const float T = segment[index - 1].end_time + tj;
+    const float A = segment[index - 1].end_accel + J0 * tj;
+    const float V = segment[index - 1].end_vel + segment[index - 1].end_accel * tj + 0.5f * J0 * sq(tj);
+    const float P = segment[index - 1].end_pos + segment[index - 1].end_vel * tj + 0.5f * segment[index - 1].end_accel * sq(tj) + (1.0f / 6.0f) * J0 * powf(tj, 3.0f);
+    add_segment(index, T, SegmentType::CONSTANT_JERK, J, A, V, P);
+}
+
+// generate increasing jerk magnitude time segment based on a raised cosine profile
+// calculate the information needed to populate the increasing jerk magnitude segment from the segment duration tj and jerk magnitude Jm
+// the index variable is the position of this segment in the path array and is incremented to reference the next segment in the array
+void SCurve::add_segment_incr_jerk(uint8_t &index, float tj, float Jm)
+{
+    const float Beta = M_PI / tj;
+    const float Alpha = Jm * 0.5f;
+    const float AT = Alpha * tj;
+    const float VT = Alpha * (sq(tj) * 0.5f - 2.0f / sq(Beta));
+    const float PT = Alpha * ((-1.0f / sq(Beta)) * tj + (1.0f / 6.0f) * powf(tj, 3.0f));
+
+    const float J = Jm;
+    const float T = segment[index - 1].end_time + tj;
+    const float A = segment[index - 1].end_accel + AT;
+    const float V = segment[index - 1].end_vel + segment[index - 1].end_accel * tj + VT;
+    const float P = segment[index - 1].end_pos + segment[index - 1].end_vel * tj + 0.5f * segment[index - 1].end_accel * sq(tj) + PT;
+    add_segment(index, T, SegmentType::POSITIVE_JERK, J, A, V, P);
+}
+
+// generate decreasing jerk magnitude time segment based on a raised cosine profile
+// calculate the information needed to populate the decreasing jerk magnitude segment from the segment duration tj and jerk magnitude Jm
+// the index variable is the position of this segment in the path and is incremented to reference the next segment in the array
+void SCurve::add_segment_decr_jerk(uint8_t &index, float tj, float Jm)
+{
+    const float Beta = M_PI / tj;
+    const float Alpha = Jm * 0.5f;
+    const float AT = Alpha * tj;
+    const float VT = Alpha * (sq(tj) * 0.5f - 2.0f / sq(Beta));
+    const float PT = Alpha * ((-1.0f / sq(Beta)) * tj + (1.0f / 6.0f) * powf(tj, 3.0f));
+    const float A2T = Jm * tj;
+    const float V2T = Jm * sq(tj);
+    const float P2T = Alpha * ((-1.0f / sq(Beta)) * 2.0f * tj + (4.0f / 3.0f) * powf(tj, 3.0f));
+
+    const float J = Jm;
+    const float T = segment[index - 1].end_time + tj;
+    const float A = (segment[index - 1].end_accel - AT) + A2T;
+    const float V = (segment[index - 1].end_vel - VT) + (segment[index - 1].end_accel - AT) * tj + V2T;
+    const float P = (segment[index - 1].end_pos - PT) + (segment[index - 1].end_vel - VT) * tj + 0.5f * (segment[index - 1].end_accel - AT) * sq(tj) + P2T;
+    add_segment(index, T, SegmentType::NEGATIVE_JERK, J, A, V, P);
+}
+
+// add single S-Curve segment
+// populate the information for the segment specified in the path by the index variable.
+// the index variable is incremented to reference the next segment in the array
+void SCurve::add_segment(uint8_t &index, float end_time, SegmentType seg_type, float jerk_ref, float end_accel, float end_vel, float end_pos)
+{
+    segment[index].end_time = end_time;
+    segment[index].seg_type = seg_type;
+    segment[index].jerk_ref = jerk_ref;
+    segment[index].end_accel = end_accel;
+    segment[index].end_vel = end_vel;
+    segment[index].end_pos = end_pos;
+    index++;
+}
+
+// set speed and acceleration limits for the path
+// origin and destination are offsets from EKF origin
+// speed and acceleration parameters are given in horizontal, up and down.
+void SCurve::set_kinematic_limits(const Vector3f &origin, const Vector3f &destination,
+                                  float speed_xy, float speed_up, float speed_down,
+                                  float accel_xy, float accel_z)
+{
+    // ensure arguments are positive
+    speed_xy = fabsf(speed_xy);
+    speed_up = fabsf(speed_up);
+    speed_down = fabsf(speed_down);
+    accel_xy = fabsf(accel_xy);
+    accel_z = fabsf(accel_z);
+
+    Vector3f direction = destination - origin;
+    const float track_speed_max = kinematic_limit(direction, speed_xy, speed_up, speed_down);
+    const float track_accel_max = kinematic_limit(direction, accel_xy, accel_z, accel_z);
+
+    vel_max = track_speed_max;
+    accel_max = track_accel_max;
+}
+
+// return true if the curve is valid.  Used to identify and protect against code errors
+bool SCurve::valid() const
+{
+    // check number of segments
+    if (num_segs != segments_max) {
+        return false;
+    }
+
+    for (uint8_t i = 0; i < num_segs; i++) {
+        // jerk_ref should be finite (i.e. not NaN or infinity)
+        // time, accel, vel and pos should finite and not negative
+        if (!isfinite(segment[i].jerk_ref) ||
+            !isfinite(segment[i].end_time) ||
+            !isfinite(segment[i].end_accel) ||
+            !isfinite(segment[i].end_vel) || is_negative(segment[i].end_vel) ||
+            !isfinite(segment[i].end_pos)) {
+            return false;
+        }
+
+        // time and pos should be increasing
+        if (i >= 1) {
+            if (is_negative(segment[i].end_time - segment[i-1].end_time) ||
+                is_negative(segment[i].end_pos - segment[i-1].end_pos)) {
+                return false;
+            }
+        }
+    }
+
+    // last segment should have zero acceleration
+    if (!is_zero(segment[num_segs-1].end_accel)) {
+        return false;
+    }
+
+    // if we get this far then the curve must be valid
+    return true;
+}
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+// debugging messages
+void SCurve::debug() const
+{
+    ::printf("num_segs:%u, time:%4.2f, jerk_time:%4.2f, jerk_max:%4.2f, accel_max:%4.2f, vel_max:%4.2f\n",
+                        (unsigned)num_segs, (double)time, (double)jerk_time, (double)jerk_max, (double)accel_max, (double)vel_max);
+    ::printf("T, Jt, J, A, V, P \n");
+    for (uint8_t i = 0; i < num_segs; i++) {
+        ::printf("i:%u, T:%4.2f, Jtype:%4.2f, J:%4.2f, A:%4.2f, V: %4.2f, P: %4.2f\n",
+                            (unsigned)i, (double)segment[i].end_time, (double)segment[i].seg_type, (double)segment[i].jerk_ref,
+                            (double)segment[i].end_accel, (double)segment[i].end_vel, (double)segment[i].end_pos);
+    }
+    ::printf("track x:%4.2f, y:%4.2f, z:%4.2f\n", (double)track.x, (double)track.y, (double)track.z);
+    ::printf("delta_unit x:%4.2f, y:%4.2f, z:%4.2f\n", (double)delta_unit.x, (double)delta_unit.y, (double)delta_unit.z);
+}
+#endif

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -1,0 +1,211 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+
+/*
+ * SCurves calculate paths between waypoints (including the corners) using specified speed, acceleration and jerk limits
+ *
+ * How to use:
+ *  1. create three SCurve objects called something like "prev_leg", "this_leg" and "next_leg"
+ *  2. call this_leg.calculate_track() to calculate the path from the origin to the destination for the given speed, accel and jerk limits
+ *  3. if the vehicle will fly past the destination to another "next destination":
+ *        a) call next_leg.calculate_track() with the appropriate arguments
+ *        b) set a "fast_waypoint" boolean to true.  this will be passed into "advance_target_along_track()" in the next step
+ *     if there is no "next destination"
+ *        a) call next_leg.init()
+ *        b) set the "fast_waypoint" boolean to false
+ *  4. call this_leg.advance_target_along_track() with a small "dt" value and retrieve the resulting target position, velocity and acceleration
+ *     Note: the target_pos should be set to the segments's earth frame origin before this function is called
+ *  5. pass the target position, velocity and acceleration into the position controller
+ *  6. repeat steps 4 and 5 until finished() returns true
+ *  7. promote the legs:
+ *        a) set prev_leg = this_leg
+ *        b) set this_leg = next_leg
+ *        c) jump back to step 3
+ *
+ * Other features:
+ *  1. set_speed_max() allows changing the max speeds mid path.  The path will be recalculated
+ *  2. set_origin_speed_max() and set_destination_speed_max() allows setting the speed along the path at the beginning and end of the leg
+ *     this is used to smoothly integrate with spline segments
+ *
+ * This library works with any units (meters, cm, etc) as long as they are used consistently.
+ *    e.g. if origin and destination are meters, speeds should be in m/s, accel in m/s/s, etc.
+ *
+ * Terminology:
+ *    position: a point in space
+ *    velocity: rate of change of position.  aka speed
+ *    acceleration: rate of change of speed
+ *    jerk: rate of change of acceleration
+ *    jerk time: the time (in seconds) for jerk to increase from zero to its maximum value
+ *    jounce: rate of change of jerk
+ *    track: 3D path that the vehicle will follow
+ *    path: position, velocity, accel and jerk kinematic profile that this library generates
+ */
+
+class SCurve {
+
+public:
+
+    // constructor
+    SCurve();
+
+    // initialise and clear the path
+    void init();
+
+    // generate a trigonometric track in 3D space that moves over a straight line
+    // between two points defined by the origin and destination
+    void calculate_track(const Vector3f &origin, const Vector3f &destination,
+                         float speed_xy, float speed_up, float speed_down,
+                         float accel_xy, float accel_z,
+                         float jerk_time_sec, float jerk_maximum);
+
+    // set maximum velocity and re-calculate the path using these limits
+    void set_speed_max(float speed_xy, float speed_up, float speed_down);
+
+    // set the maximum vehicle speed at the origin
+    // returns the expected speed at the origin which will always be equal or lower than speed
+    float set_origin_speed_max(float speed);
+
+    // set the maximum vehicle speed at the destination
+    void set_destination_speed_max(float speed);
+
+    // move target location along path from origin to destination
+    // prev_leg and next_leg are the paths before and after this path
+    // wp_radius is max distance from the waypoint at the apex of the turn
+    // fast_waypoint should be true if vehicle will not stop at end of this leg
+    // dt is the time increment the vehicle will move along the path
+    // target_pos should be set to this segment's origin and it will be updated to the current position target
+    // target_vel and target_accel are updated with new targets
+    // returns true if vehicle has passed the apex of the corner
+    bool advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, float wp_radius, bool fast_waypoint, float dt, Vector3f &target_pos, Vector3f &target_vel, Vector3f &target_accel) WARN_IF_UNUSED;
+
+    // time has reached the end of the sequence
+    bool finished() const WARN_IF_UNUSED;
+
+private:
+
+    // increment time and return the position, velocity and acceleration vectors relative to the origin
+    void move_from_pos_vel_accel(float dt, Vector3f &pos, Vector3f &vel, Vector3f &accel);
+
+    // increment time and return the position, velocity and acceleration vectors relative to the destination
+    void move_to_pos_vel_accel(float dt, Vector3f &pos, Vector3f &vel, Vector3f &accel);
+
+    // return the position, velocity and acceleration vectors relative to the origin at a specified time along the path
+    void move_from_time_pos_vel_accel(float t, Vector3f &pos, Vector3f &vel, Vector3f &accel);
+
+    // get desired maximum speed along track
+    float get_speed_along_track() const WARN_IF_UNUSED { return vel_max; }
+
+    // get desired maximum acceleration along track
+    float get_accel_along_track() const WARN_IF_UNUSED { return accel_max; }
+
+    // return the change in position from origin to destination
+    const Vector3f& get_track() const WARN_IF_UNUSED { return track; };
+
+    // return the current time elapsed
+    float get_time_elapsed() const WARN_IF_UNUSED { return time; }
+
+    // time at the end of the sequence
+    float time_end() const WARN_IF_UNUSED;
+
+    // time left before sequence will complete
+    float get_time_remaining() const WARN_IF_UNUSED;
+
+    // time when acceleration section of the sequence will complete
+    float get_accel_finished_time() const WARN_IF_UNUSED;
+
+    // return true if the sequence is braking to a stop
+    bool braking() const WARN_IF_UNUSED;
+
+    // increment the internal time
+    void advance_time(float dt);
+
+    // calculate the jerk, acceleration, velocity and position at time t
+    void get_jerk_accel_vel_pos_at_time(float time_now, float &Jt_out, float &At_out, float &Vt_out, float &Pt_out) const;
+
+    // calculate the jerk, acceleration, velocity and position at time t when running the constant jerk time segment
+    void calc_javp_for_segment_const_jerk(float time_now, float J0, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const;
+
+    // Calculate the jerk, acceleration, velocity and position at time t when running the increasing jerk magnitude time segment based on a raised cosine profile
+    void calc_javp_for_segment_incr_jerk(float time_now, float tj, float Jm, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const;
+
+    // Calculate the jerk, acceleration, velocity and position at time t when running the decreasing jerk magnitude time segment based on a raised cosine profile
+    void calc_javp_for_segment_decr_jerk(float time_now, float tj, float Jm, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const;
+
+    // generate time segments for straight segment
+    void add_segments(float L);
+
+    // calculate the segment times for the trigonometric S-Curve path defined by:
+    // tj - duration of the raised cosine jerk profile (aka jerk time)
+    // Jm - maximum value of the raised cosine jerk profile (aka jerk max)
+    // V0 - initial velocity magnitude
+    // Am - maximum constant acceleration
+    // Vm - maximum constant velocity
+    // L - Length of the path
+    void calculate_path(float tj, float Jm, float V0, float Am, float Vm, float L, float &Jm_out, float &t2_out, float &t4_out, float &t6_out) const;
+
+    // generate three time segments forming the jerk profile
+    void add_segments_jerk(uint8_t &seg_pnt, float tj, float Jm, float Tcj);
+
+    // generate constant jerk time segment
+    void add_segment_const_jerk(uint8_t &seg_pnt, float tin, float J0);
+
+    // generate increasing jerk magnitude time segment based on a raised cosine profile
+    void add_segment_incr_jerk(uint8_t &seg_pnt, float tj, float Jm);
+
+    // generate decreasing jerk magnitude time segment based on a raised cosine profile
+    void add_segment_decr_jerk(uint8_t &seg_pnt, float tj, float Jm);
+
+    // set speed and acceleration limits for the path
+    // origin and destination are offsets from EKF origin
+    // speed and acceleration parameters are given in horizontal, up and down.
+    void set_kinematic_limits(const Vector3f &origin, const Vector3f &destination,
+                              float speed_xy, float speed_up, float speed_down,
+                              float accel_xy, float accel_z);
+
+    // return true if the curve is valid.  Used to identify and protect against code errors
+    bool valid() const WARN_IF_UNUSED;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // debugging messages
+    void debug() const;
+#endif
+
+    // segment types
+    enum class SegmentType {
+        CONSTANT_JERK,
+        POSITIVE_JERK,
+        NEGATIVE_JERK
+    };
+
+    // add single segment
+    void add_segment(uint8_t &seg_pnt, float end_time, SegmentType seg_type, float jerk_ref, float end_accel, float end_vel, float end_pos);
+
+    // members
+    float jerk_time;    // duration of jerk raised cosine time segment
+    float jerk_max;     // maximum jerk magnitude
+    float accel_max;    // maximum acceleration magnitude
+    float vel_max;      // maximum velocity magnitude
+    float time;         // time that defines position on the path
+    float position_sq;  // position (squared) on the path at the last time step (used to detect finish)
+
+    // segment 0 is the initial segment and holds the vehicle's initial position and velocity
+    // segments 1 to 7 are the acceleration segments
+    // segments 8 to 14 are the speed change segments
+    // segment 15 is the constant velocity segment
+    // segment 16 to 22 is the deceleration segment
+    const static uint8_t segments_max = 23; // maximum number of time segments
+
+    uint8_t num_segs;       // number of time segments being used
+    struct {
+        float jerk_ref;     // jerk reference value for time segment (the jerk at the beginning, middle or end depending upon the segment type)
+        SegmentType seg_type;   // segment type (jerk is constant, increasing or decreasing)
+        float end_time;     // final time value for segment
+        float end_accel;    // final acceleration value for segment
+        float end_vel;      // final velocity value for segment
+        float end_pos;      // final position value for segment
+    } segment[segments_max];
+
+    Vector3f track;       // total change in position from origin to destination
+    Vector3f delta_unit;  // reference direction vector for path
+};

--- a/libraries/AP_Math/SplineCurve.cpp
+++ b/libraries/AP_Math/SplineCurve.cpp
@@ -1,0 +1,252 @@
+/*
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_InternalError/AP_InternalError.h>
+#include "SplineCurve.h"
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <stdio.h>
+#endif
+
+extern const AP_HAL::HAL &hal;
+
+#define SPLINE_FACTOR           4.0f    // defines shape of curves.  larger numbers result in longer spline curves, lower numbers take a direct path
+#define TANGENTIAL_ACCEL_SCALER 0.5f    // the proportion of the maximum accel that can be used for tangential acceleration (aka in the direction of travel along the track)
+#define LATERAL_ACCEL_SCALER    1.0f    // the proportion of the maximum accel that can be used for lateral acceleration (aka crosstrack acceleration)
+
+// limit the maximum speed along the track to that which will achieve a cornering (aka lateral) acceleration of LATERAL_SPEED_SCALER * acceleration limit
+
+// set maximum speed and acceleration
+void SplineCurve::set_speed_accel(float speed_xy, float speed_up, float speed_down,
+                                  float accel_xy, float accel_z)
+{
+    _speed_xy = fabsf(speed_xy);
+    _speed_up = fabsf(speed_up);
+    _speed_down = fabsf(speed_down);
+    _accel_xy = fabsf(accel_xy);
+    _accel_z = fabsf(accel_z);
+}
+
+// set origin and destination using position vectors (offset from EKF origin)
+// origin_vel is vehicle velocity at origin (in NEU frame)
+// destination_vel is vehicle velocity at destination (in NEU frame)
+// time is reset to zero
+void SplineCurve::set_origin_and_destination(const Vector3f &origin, const Vector3f &destination, const Vector3f &origin_vel, const Vector3f &destination_vel)
+{
+    // store origin and destination locations
+    _origin = origin;
+    _destination = destination;
+
+    // handle zero length track
+    _zero_length = is_zero((destination - origin).length_squared());
+    if (_zero_length) {
+        _time = 1.0f;
+        _origin_vel.zero();
+        _destination_vel.zero();
+        _reached_destination = true;
+        _origin_speed_max = 0.0f;
+        _destination_speed_max = 0.0f;
+        return;
+    }
+
+    _origin_vel = origin_vel;
+    _destination_vel = destination_vel;
+    _reached_destination = false;
+
+    // reset time
+    // Note: _time could include left-over from previous waypoint
+    _time = 0.0f;
+
+    // code below ensures we don't get too much overshoot when the next segment is short
+    const float vel_len = _origin_vel.length() + _destination_vel.length();
+    const float pos_len = (_destination - _origin).length() * SPLINE_FACTOR;
+    if (vel_len > pos_len) {
+        // if total start+stop velocity is more than four times the position difference
+        // use a scaled down start and stop velocity
+        const float vel_scaling = pos_len / vel_len;
+        // update spline calculator
+        update_solution(_origin, _destination, _origin_vel * vel_scaling, _destination_vel * vel_scaling);
+    } else {
+        // update spline calculator
+        update_solution(_origin, _destination, _origin_vel, _destination_vel);
+    }
+    Vector3f target_pos;
+    Vector3f spline_vel_unit;
+    float spline_dt;
+    float accel_max;
+    calc_dt_speed_max(0.0f, 0.0f, spline_dt, target_pos, spline_vel_unit, _origin_speed_max, accel_max);
+    if (_destination_vel.is_zero()) {
+        _destination_speed_max = 0.0f;
+    } else {
+        calc_dt_speed_max(1.0f, 0.0f, spline_dt, target_pos, spline_vel_unit, _destination_speed_max, accel_max);
+    }
+}
+
+// move target location along track from origin to destination
+// target_pos is updated with the target position from EKF origin in NEU frame
+// target_vel is updated with the target velocity in NEU frame
+void SplineCurve::advance_target_along_track(float dt, Vector3f &target_pos, Vector3f &target_vel)
+{
+    // handle zero length track
+    if (_zero_length) {
+        target_pos = _destination;
+        target_vel.zero();
+        return;
+    }
+
+    // calculate target position and velocity using spline calculator
+    float speed_cms = target_vel.length();
+    const float distance_delta = speed_cms * dt;
+    float spline_dt;
+    Vector3f spline_vel_unit;
+    float speed_max;
+    float accel_max;
+
+    calc_dt_speed_max(_time, distance_delta, spline_dt, target_pos, spline_vel_unit, speed_max, accel_max);
+    speed_cms = constrain_float(speed_max, speed_cms - accel_max * dt, speed_cms + accel_max * dt);
+    target_vel = spline_vel_unit * speed_cms;
+
+    _time += spline_dt;
+
+    // we will reach the destination in the next step so set reached_destination flag
+    if (_time >= 1.0f) {
+        _time = 1.0f;
+        _reached_destination = true;
+    }
+}
+
+// calculate the spline delta time for a given delta distance
+// returns the spline position and velocity and maximum speed and acceleration the vehicle can travel without exceeding acceleration limits
+void SplineCurve::calc_dt_speed_max(float time, float distance_delta, float &spline_dt, Vector3f &target_pos, Vector3f &spline_vel_unit, float &speed_max, float &accel_max)
+{
+    // initialise outputs
+    spline_dt = 0.0f;
+    spline_vel_unit.zero();
+    speed_max = 0.0f;
+    accel_max = 0.0f;
+
+    // calculate target position and velocity using spline calculator
+    Vector3f spline_vel;
+    Vector3f spline_accel;
+    Vector3f spline_jerk;
+
+    calc_target_pos_vel(time, target_pos, spline_vel, spline_accel, spline_jerk);
+
+    // vel, accel and jerk should never all be zero
+    if (spline_vel.is_zero() && spline_accel.is_zero() && spline_jerk.is_zero()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SplineCurve::calc_dt_speed_max vel, accel and jerk are all zero\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        _reached_destination = true;
+        return;
+    }
+
+    // aircraft velocity and acceleration along the spline will be defined based on the aircraft kinematic limits
+    // aircraft velocity along the spline should be reduced to ensure normal accelerations do not exceed kinematic limits
+    const float spline_vel_length = spline_vel.length();
+    if (is_zero(spline_vel_length)) {
+        // if spline velocity is zero then direction must be defined by acceleration or jerk
+        if (is_zero(spline_accel.length_squared())) {
+            // if acceleration is zero then direction must be defined by jerk
+            spline_vel_unit = spline_jerk.normalized();
+            spline_dt = powf(6.0f * distance_delta / spline_jerk.length(), 1.0f/3.0f);
+        } else {
+            // all spline acceleration is in the direction of travel
+            spline_vel_unit = spline_accel.normalized();
+            spline_dt = safe_sqrt(2.0f * distance_delta / spline_accel.length());
+        }
+    } else {
+        spline_vel_unit = spline_vel.normalized();
+        spline_dt = distance_delta / spline_vel_length;
+    }
+
+    // calculate acceleration normal to the direction of travel
+    const float spline_accel_tangent_length = spline_accel.dot(spline_vel_unit);
+    Vector3f spline_accel_norm = spline_accel - (spline_vel_unit * spline_accel_tangent_length);
+    const float spline_accel_norm_length = spline_accel_norm.length();
+
+    // limit the maximum speed along the track to that which will achieve a cornering (aka lateral) acceleration of LATERAL_SPEED_SCALER * acceleration limit
+    const float tangential_speed_max = kinematic_limit(spline_vel_unit, _speed_xy, _speed_up, _speed_down);
+    const float accel_norm_max = LATERAL_ACCEL_SCALER * kinematic_limit(spline_accel_norm, _accel_xy, _accel_z, _accel_z);
+
+    // sanity check to avoid divide by zero
+    if (is_zero(tangential_speed_max)) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SplineCurve::calc_dt_speed_max tangential_speed_max is zero\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        _reached_destination = true;
+        return;
+    }
+
+    if ((is_positive(accel_norm_max)) && is_positive(spline_accel_norm_length) && is_positive(spline_vel_length) &&
+         ((spline_accel_norm_length/accel_norm_max) > sq(spline_vel_length/tangential_speed_max))) {
+        speed_max = spline_vel_length / safe_sqrt(spline_accel_norm_length/accel_norm_max);
+    } else {
+        speed_max = tangential_speed_max;
+    }
+
+    // calculate accel max and sanity check
+    accel_max = TANGENTIAL_ACCEL_SCALER * kinematic_limit(spline_vel_unit, _accel_xy, _accel_z, _accel_z);
+    if (is_zero(accel_max)) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SplineCurve::calc_dt_speed_max accel_max is zero\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        _reached_destination = true;
+        return;
+    }
+    const float dist = (_destination - target_pos).length();
+    speed_max = MIN(speed_max, safe_sqrt(2.0f * accel_max * (dist + sq(_destination_speed_max) / (2.0f*accel_max))));
+}
+
+// recalculate hermite_solution grid
+//     relies on _origin_vel, _destination_vel and _origin and _destination
+void SplineCurve::update_solution(const Vector3f &origin, const Vector3f &dest, const Vector3f &origin_vel, const Vector3f &dest_vel)
+{
+    _hermite_solution[0] = origin;
+    _hermite_solution[1] = origin_vel;
+    _hermite_solution[2] = -origin*3.0f -origin_vel*2.0f + dest*3.0f - dest_vel;
+    _hermite_solution[3] = origin*2.0f + origin_vel -dest*2.0f + dest_vel;
+}
+
+// calculate target position and velocity from given spline time
+// time is a value from 0 to 1
+// position is updated with target position as an offset from EKF origin in NEU frame
+// velocity is updated with the unscaled velocity
+// relies on set_origin_and_destination having been called to update_solution
+void SplineCurve::calc_target_pos_vel(float time, Vector3f &position, Vector3f &velocity, Vector3f &acceleration, Vector3f &jerk)
+{
+    const float time_sq = sq(time);
+    const float time_cubed = time_sq * time;
+
+    position = _hermite_solution[0] + \
+               _hermite_solution[1] * time + \
+               _hermite_solution[2] * time_sq + \
+               _hermite_solution[3] * time_cubed;
+
+    velocity = _hermite_solution[1] + \
+               _hermite_solution[2] * 2.0f * time + \
+               _hermite_solution[3] * 3.0f * time_sq;
+
+    acceleration = _hermite_solution[2] * 2.0f + \
+               _hermite_solution[3] * 6.0f * time;
+
+    jerk = _hermite_solution[3] * 6.0f;
+}
+

--- a/libraries/AP_Math/SplineCurve.h
+++ b/libraries/AP_Math/SplineCurve.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+
+class SplineCurve {
+
+public:
+
+    // set maximum speed and acceleration
+    void set_speed_accel(float speed_xy, float speed_up, float speed_down,
+                         float accel_xy, float accel_z);
+
+    // set origin and destination using position vectors (offset from EKF origin)
+    // origin_vel is vehicle velocity at origin (in NEU frame)
+    // destination_vel is vehicle velocity at destination (in NEU frame)
+    void set_origin_and_destination(const Vector3f &origin, const Vector3f &destination, const Vector3f &origin_vel, const Vector3f &destination_vel);
+
+    // move target location along track from origin to destination
+    // target_pos is updated with the target position from EKF origin in NEU frame
+    // target_vel is updated with the target velocity in NEU frame
+    void advance_target_along_track(float dt, Vector3f &target_pos, Vector3f &target_vel);
+
+    // returns true if vehicle has reached destination
+    bool reached_destination() const WARN_IF_UNUSED { return _reached_destination; }
+
+    // returns the unscaled destination velocity vector
+    const Vector3f& get_destination_vel() WARN_IF_UNUSED { return _destination_vel; }
+
+    // returns maximum speed at origin
+    float get_origin_speed_max() const WARN_IF_UNUSED { return _origin_speed_max; }
+
+    // get or set maximum speed at destination
+    float get_destination_speed_max() const WARN_IF_UNUSED { return _destination_speed_max; }
+    void set_destination_speed_max(float destination_speed_max) { _destination_speed_max = MIN(_destination_speed_max, destination_speed_max); }
+
+private:
+
+    // calculate the spline delta time for a given delta distance
+    // returns the spline position and velocity and maximum speed and acceleration the vehicle can travel without exceeding acceleration limits
+    void calc_dt_speed_max(float time, float distance_delta, float &spline_dt, Vector3f &target_pos, Vector3f &spline_vel_unit, float &speed_max, float &accel_max);
+
+    // recalculate hermite_spline_solution grid
+    void update_solution(const Vector3f &origin, const Vector3f &dest, const Vector3f &origin_vel, const Vector3f &dest_vel);
+
+    // calculate target position and velocity from given spline time
+    // time is a value from 0 to 1
+    // position is updated with target position as an offset from EKF origin in NEU frame
+    // velocity is updated with the unscaled velocity
+    // relies on set_origin_and_destination having been called to update_solution
+    void calc_target_pos_vel(float time, Vector3f &position, Vector3f &velocity, Vector3f &acceleration, Vector3f &jerk);
+
+    // interval variables
+    Vector3f    _origin;                // origin offset (in NEU frame) from EKF
+    Vector3f    _destination;           // destination offset (in NEU frame) from EKF
+    Vector3f    _origin_vel;            // the target velocity vector in NEU frame at the origin of the spline segment
+    Vector3f    _destination_vel;       // the target velocity vector in NEU frame at the destination point of the spline segment
+    Vector3f    _hermite_solution[4];   // array describing path between origin and destination
+    float       _time;                  // current spline time (between 0 and 1) between origin and destination
+    float       _speed_xy;              // maximum horizontal speed
+    float       _speed_up;              // maximum speed upwards
+    float       _speed_down;            // maximum speed downwards
+    float       _accel_xy;              // maximum horizontal acceleration
+    float       _accel_z;               // maximum vertical acceleration
+    float       _origin_speed_max;      // maximum speed at origin
+    float       _destination_speed_max; // maximum speed at destination
+    bool        _reached_destination;   // true once vehicle has reached destination
+    bool        _zero_length;           // true if spline is zero length
+};

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -23,7 +23,114 @@
 #include "vector2.h"
 #include "vector3.h"
 
-// Proportional controller with piecewise sqrt sections to constrain second derivative
+// control default definitions
+#define CONTROL_TIME_CONSTANT_RATIO 4.0f   // minimum horizontal acceleration in cm/s/s - used for sanity checking acceleration in leash length calculation
+
+// update_pos_vel_accel - single axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
+void update_pos_vel_accel(float& pos, float& vel, float accel, float dt)
+{
+    // move position and velocity forward by dt.
+    pos = pos + vel * dt + accel * 0.5f * sq(dt);
+    vel = vel + accel * dt;
+}
+
+/* shape_vel and shape_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
+ The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
+ The kinematic path is constrained by :
+     maximum velocity - vel_max,
+     maximum acceleration - accel_max,
+     time constant - tc.
+ The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
+ The time constant also defines the time taken to achieve the maximum acceleration.
+ The time constant must be positive.
+ The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+ The accel_max limit can be removed by setting it to zero.
+*/
+void shape_vel(float& vel_input, float vel, float& accel, float accel_max, float tc, float dt)
+{
+    // sanity check tc
+    if (!is_positive(tc)) {
+        return;
+    }
+
+    // Calculate time constants and limits to ensure stable operation
+    const float KPa = 1.0 / tc;
+    const float jerk_max = accel_max * KPa;
+
+    // velocity error to be corrected
+    float vel_error = vel_input - vel;
+
+    // acceleration to correct velocity
+    const float accel_target = vel_error * KPa;
+
+    // jerk limit acceleration change
+    float accel_delta = accel_target - accel;
+    if (is_positive(jerk_max)) {
+        accel_delta = constrain_float(accel_delta, -jerk_max * dt, jerk_max * dt);
+    }
+    accel += accel_delta;
+
+    // limit acceleration to accel_max
+    if (is_positive(accel_max)) {
+        accel = constrain_float(accel, -accel_max, accel_max);
+    }
+
+    // Calculate maximum pos_input and vel_input based on limited system
+    vel_error = accel / KPa;
+    vel_input = vel_error + vel;
+}
+
+
+/* shape_pos_vel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
+ The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
+ The kinematic path is constrained by :
+     maximum velocity - vel_max,
+     maximum acceleration - accel_max,
+     time constant - tc.
+ The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
+ The time constant also defines the time taken to achieve the maximum acceleration.
+ The time constant must be positive.
+ The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
+ The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
+*/
+void shape_pos_vel(float& pos_input, float vel_input, float pos, float vel, float& accel, float vel_max, float vel_correction_max, float accel_max, float tc, float dt)
+{
+    // sanity check tc
+    if (!is_positive(tc)) {
+        return;
+    }
+
+    // Calculate time constants and limits to ensure stable operation
+    const float KPv = 1.0 / (CONTROL_TIME_CONSTANT_RATIO*tc);
+    const float accel_tc_max = accel_max*(1-1.0f/CONTROL_TIME_CONSTANT_RATIO);
+
+    // position error to be corrected
+    float pos_error = pos_input - pos;
+
+    // velocity to correct position
+    float vel_target = sqrt_controller(pos_error, KPv, accel_tc_max, dt);
+
+    // limit velocity correction to vel_correction_max
+    if (is_positive(vel_correction_max)) {
+        vel_target = constrain_float(vel_target, -vel_correction_max, vel_correction_max);
+    }
+
+    // velocity correction with input velocity
+    vel_target += vel_input;
+
+    // limit velocity to vel_max
+    if (is_positive(vel_max)) {
+        vel_target = constrain_float(vel_target, -vel_max, vel_max);
+    }
+
+    shape_vel(vel_target, vel, accel, accel_max, tc, dt);
+
+    vel_target -= vel_input;
+    pos_error = stopping_distance(vel_target, KPv, accel_tc_max);
+    pos_input = pos_error + pos;
+}
+
+// proportional controller with piecewise sqrt sections to constrain second derivative
 float sqrt_controller(float error, float p, float second_ord_lim, float dt)
 {
     float correction_rate;
@@ -41,7 +148,7 @@ float sqrt_controller(float error, float p, float second_ord_lim, float dt)
         }
     } else {
         // Both the P and second order limit have been defined.
-        float linear_dist = second_ord_lim / sq(p);
+        const float linear_dist = second_ord_lim / sq(p);
         if (error > linear_dist) {
             correction_rate = safe_sqrt(2.0f * second_ord_lim * (error - (linear_dist / 2.0f)));
         } else if (error < -linear_dist) {
@@ -58,6 +165,80 @@ float sqrt_controller(float error, float p, float second_ord_lim, float dt)
     }
 }
 
+// proportional controller with piecewise sqrt sections to constrain second derivative
+Vector2f sqrt_controller(const Vector2f& error, float p, float second_ord_lim, float dt)
+{
+    const float error_length = error.length();
+    const float correction_length = sqrt_controller(error_length, p, second_ord_lim, dt);
+    if (is_positive(error_length)) {
+        return error * (correction_length / error_length);
+    } else {
+        return Vector2f(0.0f, 0.0f);
+    }
+}
+
+// inverse of the sqrt controller.  calculates the input (aka error) to the sqrt_controller required to achieve a given output
+float inv_sqrt_controller(float output, float p, float D_max)
+{
+    if (!is_positive(D_max) && is_zero(p)) {
+        return 0.0f;
+    }
+
+    if (!is_positive(D_max)) {
+        // second order limit is zero or negative.
+        return output / p;
+    }
+
+    if (is_zero(p)) {
+        // P term is zero but we have a second order limit.
+        if (is_positive(D_max)) {
+            return sq(output)/(2*D_max);
+        } else {
+            return -sq(output)/(2*D_max);
+        }
+    }
+
+    // both the P and second order limit have been defined.
+    float linear_out = D_max / p;
+    if (output > linear_out) {
+        if (is_positive(D_max)) {
+            return sq(output)/(2*D_max) + D_max/(4*sq(p));
+        } else {
+            return -sq(output)/(2*D_max) + D_max/(4*sq(p));
+        }
+    }
+
+    return output / p;
+}
+
+// calculate the stopping distance for the square root controller based deceleration path
+float stopping_distance(float velocity, float p, float accel_max)
+{
+    if (is_positive(accel_max) && is_zero(p)) {
+        return (velocity * velocity) / (2.0f * accel_max);
+    } else if ((is_negative(accel_max) || is_zero(accel_max)) && !is_zero(p)) {
+        return velocity / p;
+    } else if ((is_negative(accel_max) || is_zero(accel_max)) && is_zero(p)) {
+        return 0.0f;
+    }
+
+    // calculate the velocity at which we switch from calculating the stopping point using a linear function to a sqrt function
+    const float linear_velocity = accel_max / p;
+
+    if (fabsf(velocity) < linear_velocity) {
+        // if our current velocity is below the cross-over point we use a linear function
+        return velocity / p;
+    } else {
+        const float linear_dist = accel_max / sq(p);
+        const float stopping_dist = (linear_dist * 0.5f) + sq(velocity) / (2.0f * accel_max);
+        if (is_positive(velocity)) {
+            return stopping_dist;
+        } else {
+            return -stopping_dist;
+        }
+    }
+}
+
 // limit vector to a given length, returns true if vector was limited
 bool limit_vector_length(float &vector_x, float &vector_y, float max_length)
 {
@@ -68,4 +249,46 @@ bool limit_vector_length(float &vector_x, float &vector_y, float max_length)
         return true;
     }
     return false;
+}
+
+// calculate the maximum acceleration or velocity in a given direction
+// based on horizontal and vertical limits.
+float kinematic_limit(Vector3f direction, float max_xy, float max_z_pos, float max_z_neg)
+{
+    max_xy = fabsf(max_xy);
+    max_z_pos = fabsf(max_z_pos);
+    max_z_neg = fabsf(max_z_neg);
+
+    if (is_zero(direction.length_squared())) {
+        return 0.0f;
+    }
+
+    direction.normalize();
+    const float xy_length = Vector2f{direction.x, direction.y}.length();
+
+    if (is_zero(xy_length)) {
+        if (is_positive(direction.z)) {
+            return max_z_pos;
+        } else {
+            return max_z_neg;
+        }
+    } else if (is_zero(direction.z)) {
+        return max_xy;
+    } else {
+        const float slope = direction.z/xy_length;
+        if (is_positive(slope)) {
+            if (fabsf(slope) < max_z_pos/max_xy) {
+                return max_xy/xy_length;
+            } else {
+                return fabsf(max_z_pos/direction.z);
+            }
+        } else {
+            if (fabsf(slope) < max_z_neg/max_xy) {
+                return max_xy/xy_length;
+            } else {
+                return fabsf(max_z_neg/direction.z);
+            }
+        }
+    }
+    return 0.0f;
 }

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -4,8 +4,51 @@
   common controller helper functions
  */
 
-// Proportional controller with piecewise sqrt sections to constrain second derivative
+// update_pos_vel_accel projects the position and velocity, pos and vel, forward in time based on a time step of dt and acceleration of accel.
+// update_pos_vel_accel - single axis projection.
+void update_pos_vel_accel(float& pos, float& vel, float accel, float dt);
+
+/* shape_vel calculates a jerk limited path from the current position, velocity and acceleration to an input velocity.
+ The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
+ The kinematic path is constrained by :
+     maximum velocity - vel_max,
+     maximum acceleration - accel_max,
+     time constant - tc.
+ The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
+ The time constant also defines the time taken to achieve the maximum acceleration.
+ The time constant must be positive.
+ The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+*/
+void shape_vel(float& vel_input, float vel, float& accel, float accel_max, float tc, float dt);
+
+/* shape_pos_vel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
+ The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
+ The kinematic path is constrained by :
+     maximum velocity - vel_max,
+     maximum acceleration - accel_max,
+     time constant - tc.
+ The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
+ The time constant also defines the time taken to achieve the maximum acceleration.
+ The time constant must be positive.
+ The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
+*/
+void shape_pos_vel(float& pos_input, float vel_input, float pos, float vel, float& accel, float vel_max, float vel_correction_max, float accel_max, float tc, float dt);
+
+// proportional controller with piecewise sqrt sections to constrain second derivative
 float sqrt_controller(float error, float p, float second_ord_lim, float dt);
+
+// proportional controller with piecewise sqrt sections to constrain second derivative
+Vector2f sqrt_controller(const Vector2f& error, float p, float second_ord_lim, float dt);
+
+// inverse of the sqrt controller.  calculates the input (aka error) to the sqrt_controller required to achieve a given output
+float inv_sqrt_controller(float output, float p, float D_max);
+
+// calculate the stopping distance for the square root controller based deceleration path
+float stopping_distance(float velocity, float p, float accel_max);
 
 // limit vector to a given length, returns true if vector was limited
 bool limit_vector_length(float &vector_x, float &vector_y, float max_length);
+
+// calculate the maximum acceleration or velocity in a given direction
+// based on horizontal and vertical limits.
+float kinematic_limit(Vector3f direction, float max_xy, float max_z_pos, float max_z_neg);

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -46,9 +46,6 @@ float inv_sqrt_controller(float output, float p, float D_max);
 // calculate the stopping distance for the square root controller based deceleration path
 float stopping_distance(float velocity, float p, float accel_max);
 
-// limit vector to a given length, returns true if vector was limited
-bool limit_vector_length(float &vector_x, float &vector_y, float max_length);
-
 // calculate the maximum acceleration or velocity in a given direction
 // based on horizontal and vertical limits.
 float kinematic_limit(Vector3f direction, float max_xy, float max_z_pos, float max_z_neg);

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -32,6 +32,19 @@ float Vector2<T>::length(void) const
     return norm(x, y);
 }
 
+// limit vector to a given length. returns true if vector was limited
+template <typename T>
+bool Vector2<T>::limit_length(float max_length)
+{
+    const float len = length();
+    if ((len > max_length) && is_positive(len)) {
+        x *= (max_length / len);
+        y *= (max_length / len);
+        return true;
+    }
+    return false;
+}
+
 // dot product
 template <typename T>
 T Vector2<T>::operator *(const Vector2<T> &v) const

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -138,6 +138,9 @@ struct Vector2
     // gets the length of this vector
     float length(void) const;
 
+    // limit vector to a given length. returns true if vector was limited
+    bool limit_length(float max_length);
+
     // normalizes this vector
     void normalize();
 

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -303,6 +303,19 @@ float Vector3<T>::length(void) const
     return norm(x, y, z);
 }
 
+// limit xy component vector to a given length. returns true if vector was limited
+template <typename T>
+bool Vector3<T>::limit_length_xy(float max_length)
+{
+    const float length_xy = norm(x, y);
+    if ((length_xy > max_length) && is_positive(length_xy)) {
+        x *= (max_length / length_xy);
+        y *= (max_length / length_xy);
+        return true;
+    }
+    return false;
+}
+
 template <typename T>
 Vector3<T> &Vector3<T>::operator *=(const T num)
 {

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -195,6 +195,9 @@ public:
     // gets the length of this vector
     float length(void) const;
 
+    // limit xy component vector to a given length. returns true if vector was limited
+    bool limit_length_xy(float max_length);
+
     // normalizes this vector
     void normalize()
     {

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -511,6 +511,24 @@ bool AP_Mission::set_current_cmd(uint16_t index, bool rewind)
     return true;
 }
 
+// restart current navigation command.  Used to handle external changes to mission
+// returns true on success, false if mission is not running or current nav command is invalid
+bool AP_Mission::restart_current_nav_cmd()
+{
+    // return immediately if mission is not running
+    if (_flags.state != MISSION_RUNNING) {
+        return false;
+    }
+
+    // return immediately if nav command index is invalid
+    const uint16_t nav_cmd_index = get_current_nav_index();
+    if ((nav_cmd_index == 0) || (nav_cmd_index >= num_commands())) {
+        return false;
+    }
+
+    return set_current_cmd(_nav_cmd.index);
+}
+
 // returns false on any issue at all.
 bool AP_Mission::set_item(uint16_t index, mavlink_mission_item_int_t& src_packet)
 {

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -275,6 +275,10 @@ public:
 
         // return a human-readable interpretation of the ID stored in this command
         const char *type() const;
+
+        // comparison operator (relies on all bytes in the structure even if they may not be used)
+        bool operator ==(const Mission_Command &b) const { return (memcmp(this, &b, sizeof(Mission_Command)) == 0); }
+        bool operator !=(const Mission_Command &b) const { return !operator==(b); }
     };
 
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -475,6 +475,10 @@ public:
     // set_current_cmd - jumps to command specified by index
     bool set_current_cmd(uint16_t index, bool rewind = false);
 
+    // restart current navigation command.  Used to handle external changes to mission
+    // returns true on success, false if current nav command has been deleted
+    bool restart_current_nav_cmd();
+
     /// load_cmd_from_storage - load command from storage
     ///     true is return if successful
     bool read_cmd_from_storage(uint16_t index, Mission_Command& cmd) const;

--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -170,6 +170,33 @@ bool AP_SmartRTL::pop_point(Vector3f& point)
     return true;
 }
 
+// peek at next point on the path without removing it form the path. Returns true on success
+bool AP_SmartRTL::peek_point(Vector3f& point)
+{
+    // check we are active
+    if (!_active) {
+        return false;
+    }
+
+    // get semaphore
+    if (!_path_sem.take_nonblocking()) {
+        log_action(SRTL_PEEK_FAILED_NO_SEMAPHORE);
+        return false;
+    }
+
+    // check we have another point
+    if (_path_points_count == 0) {
+        _path_sem.give();
+        return false;
+    }
+
+    // return last point
+    point = _path[_path_points_count-1];
+
+    _path_sem.give();
+    return true;
+}
+
 // clear return path and set home location.  This should be called as part of the arming procedure
 void AP_SmartRTL::set_home(bool position_ok)
 {

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -43,6 +43,10 @@ public:
     // get next point on the path to home, returns true on success
     bool pop_point(Vector3f& point);
 
+    // peek at next point on the path without removing it form the path. Returns true on success
+    // this may fail if the IO thread has taken the path semaphore
+    bool peek_point(Vector3f& point);
+
     // clear return path and set return location if position_ok is true.  This should be called as part of the arming procedure
     // if position_ok is false, SmartRTL will not be available.
     // example sketches use the method that allows providing vehicle position directly
@@ -90,6 +94,7 @@ private:
         SRTL_ADD_FAILED_NO_SEMAPHORE,
         SRTL_ADD_FAILED_PATH_FULL,
         SRTL_POP_FAILED_NO_SEMAPHORE,
+        SRTL_PEEK_FAILED_NO_SEMAPHORE,
         SRTL_DEACTIVATED_INIT_FAILED,
         SRTL_DEACTIVATED_BAD_POSITION,
         SRTL_DEACTIVATED_BAD_POSITION_TIMEOUT,


### PR DESCRIPTION
This PR replaces AC_WPNav's "leash" based navigation with "S-Curves".  @lthall is the expert on this but the fundamental difference is that the vehicle's target position, velocity and acceleration are essentially precalculated using the vehicle's speed and acceleration limits.  This results in the following improvements:

- The shape of the path does not change based on the vehicle's speed
- The vehicle cuts the corners less and the entry and exit path from the corner is symmetrical

Issues reported by testers:
  - [x] Vehicle kept flying past waytpoint (reported by PeterB,Tridge)
  - [x] WPNAV_SPEED does not take effect immediately (reported by PeterB, Tridge) -- same behaviour in master
  - [x] Verticle BendyRuler broken (reported by Rishabh)
  - [x] Horizon BendyRuler is twitchy (reported by Rishabh).  Follow-up PR: https://github.com/ArduPilot/ardupilot/pull/17003

Some known issues:
  - [x] S-Curves do not work if the target position is updated at a high rate
  - [x] Spline curves take a very different path than before and are less curved because they are made up of 4 straight paths
  - [x] Target point does not slow if vehicle cannot keep up
  - [x] Terrain following missions are not maintaining correct altitude if terrain is very steep
  - [x] do-change-speed has no effect (use "setspeed" command in SITL)
  - [x] SmartRTL returns home very slowly (about 1.5m/s)
  - [x] ROI during missions is likely broken

This has been tested extensively in SITL and the autotests should pass.

This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/6194

To-Do before merging:
   - [x] detailed peer review
   - [x] extract some commits into separate PRs including:
      - [x] Copter: payload place fixups (see PR https://github.com/ArduPilot/ardupilot/pull/15970)
      - [x] Tools: sub set-position-target uses negative altitude (PR: https://github.com/ArduPilot/ardupilot/pull/15895)
      - [x] some Autotest changes
   - [ ] SITL test all affected Copter modes:
      - [ ] Auto
      - [ ] Guided
      - [ ] RTL
      - [ ] SmartRTL
      - [ ] ZigZag
   - [x] terrain following tests -- FAIL (is not following terrain if terrain is very steep)
   - [ ] flight test all affected vehicles:
      - [ ] Copter
      - [ ] TradHeli
      - [x] QuadPlane
   - [ ] retest that param conversions from change in PID controllers works

Video: https://youtu.be/7brBRf0FZSk