### PR TITLE
AP_BoardConfig: added an EXPECT_DELAY_MS to config_error

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -402,6 +402,7 @@ void AP_BoardConfig::config_error(const char *fmt, ...)
         gcs().update_receive();
         gcs().update_send();
 #endif
+        EXPECT_DELAY_MS(10);
         hal.scheduler->delay(5);
     }
 }


### PR DESCRIPTION
this prevents a config_error called after setup() has complete from
causing a watchdog. That is a bit more friendly