### PR TITLE
AP_NavEKF3: param conversion loses config_error

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1592,8 +1592,8 @@ void NavEKF3::convert_parameters()
             break;
         case 3:
         default:
-            // EK3_GPS_TYPE == 3 (No GPS) we don't know what to do, could be optical flow or external nav
-            AP_BoardConfig::config_error("Configure EK3_SRC1_POSXY and _VELXY");
+            // EK3_GPS_TYPE == 3 (No GPS) we don't know what to do, could be optical flow, beacon or external nav
+            sources.mark_configured_in_storage();
             break;
         }
     } else {


### PR DESCRIPTION
This resolves an issue in which the autopilot would constantly reboot because of the call to AP_BoardConfig::config_error within the parameter conversion code of the EKF3 (added recently as part of the EKF source PR)

In place of the config_error we leave EK2_SRC1_POSXY, VELXY and VELZ at their default values and call mark_configured_in_storage to ensure the param conversion doesn't run again.  We will add a note as part of the release notes telling EKF3+Non-GPS users they must manually update these params.

PR https://github.com/ArduPilot/ardupilot/pull/15901 also stops the endless reboot cycle but @tridge @peterbarker and I discussed and decided that both fixes should be implemented.

This has been tested on a real board that was rebooting and the rebooting stopped.