### PR TITLE
EKF: save memory and cpu 

### DIFF
--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -110,24 +110,24 @@ void AP_DAL::init_sensors(void)
       at the time we startup the EKF
      */
 
-    auto *rangefinder = AP::rangefinder();
-    if (rangefinder && rangefinder->num_sensors() > 0) {
+    auto *rng = AP::rangefinder();
+    if (rng && rng->num_sensors() > 0) {
         alloc_failed |= (_rangefinder = new AP_DAL_RangeFinder) == nullptr;
     }
 
-    auto *airspeed = AP::airspeed();
-    if (airspeed != nullptr && airspeed->get_num_sensors() > 0) {
+    auto *aspeed = AP::airspeed();
+    if (aspeed != nullptr && aspeed->get_num_sensors() > 0) {
         alloc_failed |= (_airspeed = new AP_DAL_Airspeed) == nullptr;
     }
 
-    auto *beacon = AP::beacon();
-    if (beacon != nullptr && beacon->enabled()) {
+    auto *bcn = AP::beacon();
+    if (bcn != nullptr && bcn->enabled()) {
         alloc_failed |= (_beacon = new AP_DAL_Beacon) == nullptr;
     }
 
 #if HAL_VISUALODOM_ENABLED
-    auto *visualodom = AP::visualodom();
-    if (visualodom != nullptr && visualodom->enabled()) {
+    auto *vodom = AP::visualodom();
+    if (vodom != nullptr && vodom->enabled()) {
         alloc_failed |= (_visualodom = new AP_DAL_VisualOdom) == nullptr;
     }
 #endif

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -121,24 +121,19 @@ public:
     AP_DAL_InertialSensor &ins() { return _ins; }
     AP_DAL_Baro &baro() { return _baro; }
     AP_DAL_GPS &gps() { return _gps; }
+
     AP_DAL_RangeFinder *rangefinder() {
-        if (_RFRN.rangefinder_ptr_is_null) {
-            return nullptr;
-        }
-        return &_rangefinder;
+        return _rangefinder;
     }
     AP_DAL_Airspeed *airspeed() {
-        if (_RFRN.airspeed_ptr_is_null) {
-            return nullptr;
-        }
-        return &_airspeed;
+        return _airspeed;
     }
     AP_DAL_Beacon *beacon() {
-        return _beacon.beacon();
+        return _beacon;
     }
 #if HAL_VISUALODOM_ENABLED
     AP_DAL_VisualOdom *visualodom() {
-        return _visualodom.visualodom();
+        return _visualodom;
     }
 #endif
 
@@ -230,10 +225,16 @@ public:
     }
 
     void handle_message(const log_RASH &msg) {
-        _airspeed.handle_message(msg);
+        if (_airspeed == nullptr) {
+            _airspeed = new AP_DAL_Airspeed;
+        }
+        _airspeed->handle_message(msg);
     }
     void handle_message(const log_RASI &msg) {
-        _airspeed.handle_message(msg);
+        if (_airspeed == nullptr) {
+            _airspeed = new AP_DAL_Airspeed;
+        }
+        _airspeed->handle_message(msg);
     }
 
     void handle_message(const log_RBRH &msg) {
@@ -244,10 +245,16 @@ public:
     }
 
     void handle_message(const log_RRNH &msg) {
-        _rangefinder.handle_message(msg);
+        if (_rangefinder == nullptr) {
+            _rangefinder = new AP_DAL_RangeFinder;
+        }
+        _rangefinder->handle_message(msg);
     }
     void handle_message(const log_RRNI &msg) {
-        _rangefinder.handle_message(msg);
+        if (_rangefinder == nullptr) {
+            _rangefinder = new AP_DAL_RangeFinder;
+        }
+        _rangefinder->handle_message(msg);
     }
 
     void handle_message(const log_RGPH &msg) {
@@ -268,14 +275,23 @@ public:
     }
 
     void handle_message(const log_RBCH &msg) {
-        _beacon.handle_message(msg);
+        if (_beacon == nullptr) {
+            _beacon = new AP_DAL_Beacon;
+        }
+        _beacon->handle_message(msg);
     }
     void handle_message(const log_RBCI &msg) {
-        _beacon.handle_message(msg);
+        if (_beacon == nullptr) {
+            _beacon = new AP_DAL_Beacon;
+        }
+        _beacon->handle_message(msg);
     }
     void handle_message(const log_RVOH &msg) {
 #if HAL_VISUALODOM_ENABLED
-        _visualodom.handle_message(msg);
+        if (_visualodom == nullptr) {
+            _visualodom = new AP_DAL_VisualOdom;
+        }
+        _visualodom->handle_message(msg);
 #endif
     }
     void handle_message(const log_ROFH &msg, NavEKF2 &ekf2, NavEKF3 &ekf3);
@@ -318,12 +334,12 @@ private:
     AP_DAL_InertialSensor _ins;
     AP_DAL_Baro _baro;
     AP_DAL_GPS _gps;
-    AP_DAL_RangeFinder _rangefinder;
+    AP_DAL_RangeFinder *_rangefinder;
     AP_DAL_Compass _compass;
-    AP_DAL_Airspeed _airspeed;
-    AP_DAL_Beacon _beacon;
+    AP_DAL_Airspeed *_airspeed;
+    AP_DAL_Beacon *_beacon;
 #if HAL_VISUALODOM_ENABLED
-    AP_DAL_VisualOdom _visualodom;
+    AP_DAL_VisualOdom *_visualodom;
 #endif
 
     static bool logging_started;
@@ -331,6 +347,9 @@ private:
 
     bool ekf2_init_done;
     bool ekf3_init_done;
+
+    void init_sensors(void);
+    bool init_done;
 };
 
 #define WRITE_REPLAY_BLOCK(sname,v) AP_DAL::WriteLogMessage(LOG_## sname ##_MSG, &v, nullptr, offsetof(log_ ##sname, _end))

--- a/libraries/AP_DAL/AP_DAL_Beacon.cpp
+++ b/libraries/AP_DAL/AP_DAL_Beacon.cpp
@@ -17,7 +17,6 @@ void AP_DAL_Beacon::start_frame()
     const auto *bcon = AP::beacon();
 
     const log_RBCH old = _RBCH;
-    _RBCH.ptr_is_nullptr = (bcon == nullptr);
     if (bcon != nullptr) {
         _RBCH.count = bcon->count();
         _RBCH.get_vehicle_position_ned_returncode = bcon->get_vehicle_position_ned(_RBCH.vehicle_position_ned, _RBCH.accuracy_estimate);

--- a/libraries/AP_DAL/AP_DAL_Beacon.cpp
+++ b/libraries/AP_DAL/AP_DAL_Beacon.cpp
@@ -7,9 +7,13 @@
 
 AP_DAL_Beacon::AP_DAL_Beacon()
 {
+#if !APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone) && !APM_BUILD_TYPE(APM_BUILD_Replay)
+    const auto *bcon = AP::beacon();
+    _RBCH.count = bcon->count();
     for (uint8_t i=0; i<ARRAY_SIZE(_RBCI); i++) {
         _RBCI[i].instance = i;
     }
+#endif
 }
 
 void AP_DAL_Beacon::start_frame()
@@ -18,9 +22,7 @@ void AP_DAL_Beacon::start_frame()
 
     const log_RBCH old = _RBCH;
     if (bcon != nullptr) {
-        _RBCH.count = bcon->count();
         _RBCH.get_vehicle_position_ned_returncode = bcon->get_vehicle_position_ned(_RBCH.vehicle_position_ned, _RBCH.accuracy_estimate);
-
         Location loc;
         _RBCH.get_origin_returncode = bcon->get_origin(loc);
         _RBCH.enabled = bcon->enabled();

--- a/libraries/AP_DAL/AP_DAL_Beacon.h
+++ b/libraries/AP_DAL/AP_DAL_Beacon.h
@@ -58,9 +58,6 @@ public:
     AP_DAL_Beacon();
 
     AP_DAL_Beacon *beacon() {
-        if (_RBCH.ptr_is_nullptr) {
-            return nullptr;
-        }
         return this;
     }
 

--- a/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
@@ -73,6 +73,8 @@ void AP_DAL_RangeFinder::start_frame()
     _RRNH.ground_clearance_cm = rangefinder->ground_clearance_cm_orient(ROTATION_PITCH_270);
     _RRNH.max_distance_cm = rangefinder->max_distance_cm_orient(ROTATION_PITCH_270);
 
+    WRITE_REPLAY_BLOCK_IFCHANGED(RRNH, _RRNH, old);
+
     for (uint8_t i=0; i<_RRNH.num_sensors; i++) {
         auto *backend = rangefinder->get_backend(i);
         if (backend == nullptr) {
@@ -80,8 +82,6 @@ void AP_DAL_RangeFinder::start_frame()
         }
         _backend[i]->start_frame(backend);
     }
-
-    WRITE_REPLAY_BLOCK_IFCHANGED(RRNH, _RRNH, old);
 }
 
 

--- a/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
@@ -4,17 +4,31 @@
 
 #include <AP_RangeFinder/AP_RangeFinder_Backend.h>
 #include "AP_DAL.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 AP_DAL_RangeFinder::AP_DAL_RangeFinder()
 {
-    for (uint8_t i=0; i<ARRAY_SIZE(_RRNI); i++) {
+#if !APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone) && !APM_BUILD_TYPE(APM_BUILD_Replay)
+    _RRNH.num_sensors = AP::rangefinder()->num_sensors();
+    _RRNI = new log_RRNI[_RRNH.num_sensors];
+    _backend = new AP_DAL_RangeFinder_Backend *[_RRNH.num_sensors];
+    if (!_RRNI || !_backend) {
+        goto failed;
+    }
+    for (uint8_t i=0; i<_RRNH.num_sensors; i++) {
         _RRNI[i].instance = i;
     }
-
-    for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
+    for (uint8_t i=0; i<_RRNH.num_sensors; i++) {
         // this avoids having to discard a const....
         _backend[i] = new AP_DAL_RangeFinder_Backend(_RRNI[i]);
+        if (!_backend[i]) {
+            goto failed;
+        }
     }
+    return;
+failed:
+    AP_BoardConfig::config_error("Unable to allocate DAL backends");
+#endif
 }
 
 int16_t AP_DAL_RangeFinder::ground_clearance_cm_orient(enum Rotation orientation) const
@@ -58,14 +72,12 @@ void AP_DAL_RangeFinder::start_frame()
     // EKF only asks for this *down*.
     _RRNH.ground_clearance_cm = rangefinder->ground_clearance_cm_orient(ROTATION_PITCH_270);
     _RRNH.max_distance_cm = rangefinder->max_distance_cm_orient(ROTATION_PITCH_270);
-    _RRNH.backend_mask = 0;
 
-    for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
+    for (uint8_t i=0; i<_RRNH.num_sensors; i++) {
         auto *backend = rangefinder->get_backend(i);
         if (backend == nullptr) {
             break;
         }
-        _RRNH.backend_mask |= (1U<<i);
         _backend[i]->start_frame(backend);
     }
 
@@ -92,7 +104,7 @@ void AP_DAL_RangeFinder_Backend::start_frame(AP_RangeFinder_Backend *backend) {
 // return true if we have a range finder with the specified orientation
 bool AP_DAL_RangeFinder::has_orientation(enum Rotation orientation) const
 {
-    for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
+    for (uint8_t i=0; i<_RRNH.num_sensors; i++) {
         if (_RRNI[i].orientation == orientation) {
             return true;
         }
@@ -103,14 +115,29 @@ bool AP_DAL_RangeFinder::has_orientation(enum Rotation orientation) const
 
 AP_DAL_RangeFinder_Backend *AP_DAL_RangeFinder::get_backend(uint8_t id) const
 {
-   if (id > RANGEFINDER_MAX_INSTANCES) {
+   if (id >= RANGEFINDER_MAX_INSTANCES) {
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         return nullptr;
     }
 
-   if ((_RRNH.backend_mask & (1U<<id)) == 0) {
-       return nullptr;
-   }
-
    return _backend[id];
+}
+
+void AP_DAL_RangeFinder::handle_message(const log_RRNH &msg)
+{
+    _RRNH = msg;
+    if (_RRNH.num_sensors > 0 && _RRNI == nullptr) {
+        _RRNI = new log_RRNI[_RRNH.num_sensors];
+        _backend = new AP_DAL_RangeFinder_Backend *[_RRNH.num_sensors];
+    }
+}
+
+void AP_DAL_RangeFinder::handle_message(const log_RRNI &msg)
+{
+    if (_RRNI != nullptr && msg.instance < _RRNH.num_sensors) {
+        _RRNI[msg.instance] = msg;
+        if (_backend != nullptr && _backend[msg.instance] == nullptr) {
+            _backend[msg.instance] = new AP_DAL_RangeFinder_Backend(_RRNI[msg.instance]);
+        }
+    }
 }

--- a/libraries/AP_DAL/AP_DAL_RangeFinder.h
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.h
@@ -33,19 +33,14 @@ public:
 
     class AP_DAL_RangeFinder_Backend *get_backend(uint8_t id) const;
 
-    void handle_message(const log_RRNH &msg) {
-        _RRNH = msg;
-    }
-    void handle_message(const log_RRNI &msg) {
-        _RRNI[msg.instance] = msg;
-    }
+    void handle_message(const log_RRNH &msg);
+    void handle_message(const log_RRNI &msg);
 
 private:
 
     struct log_RRNH _RRNH;
-    struct log_RRNI _RRNI[RANGEFINDER_MAX_INSTANCES];
-
-    AP_DAL_RangeFinder_Backend *_backend[RANGEFINDER_MAX_INSTANCES];
+    struct log_RRNI *_RRNI;
+    AP_DAL_RangeFinder_Backend **_backend;
 };
 
 

--- a/libraries/AP_DAL/AP_DAL_VisualOdom.cpp
+++ b/libraries/AP_DAL/AP_DAL_VisualOdom.cpp
@@ -25,7 +25,6 @@ void AP_DAL_VisualOdom::start_frame()
     const auto *vo = AP::visualodom();
 
     const log_RVOH old = RVOH;
-    RVOH.ptr_is_nullptr = (vo == nullptr);
     if (vo != nullptr) {
         RVOH.pos_offset = vo->get_pos_offset();
         RVOH.delay_ms = vo->get_delay_ms();

--- a/libraries/AP_DAL/AP_DAL_VisualOdom.h
+++ b/libraries/AP_DAL/AP_DAL_VisualOdom.h
@@ -33,13 +33,6 @@ public:
     // should only be called when this library is not being used as the position source
     void align_position_to_ahrs(bool align_xy, bool align_z);
 
-    AP_DAL_VisualOdom *visualodom() {
-        if (RVOH.ptr_is_nullptr) {
-            return nullptr;
-        }
-        return this;
-    }
-
     void start_frame();
 
     void handle_message(const log_RVOH &msg) {

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -156,7 +156,7 @@ struct log_RRNH {
     // this is rotation-pitch-270!
     int16_t ground_clearance_cm;
     int16_t max_distance_cm;
-    uint16_t backend_mask;
+    uint8_t num_sensors;
     uint8_t _end;
 };
 
@@ -386,7 +386,7 @@ struct log_RBOH {
     { LOG_RBRI_MSG, RLOG_SIZE(RBRI),                                   \
       "RBRI", "IfBB", "LastUpdate,Alt,H,I", "---#", "----" }, \
     { LOG_RRNH_MSG, RLOG_SIZE(RRNH),                                   \
-      "RRNH", "hhH", "GCl,MaxD,BMask", "???", "???" },  \
+      "RRNH", "hhB", "GCl,MaxD,NumSensors", "???", "???" },  \
     { LOG_RRNI_MSG, RLOG_SIZE(RRNI),                                   \
       "RRNI", "fffHBBB", "PX,PY,PZ,Dist,Orient,Status,I", "------#", "-------" }, \
     { LOG_RGPH_MSG, RLOG_SIZE(RGPH),                                   \

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -62,9 +62,7 @@ struct log_RFRN {
     uint8_t vehicle_class;
     uint8_t ekf_type;
     uint8_t armed:1;
-    uint8_t rangefinder_ptr_is_null:1;
     uint8_t get_compass_is_null:1;
-    uint8_t airspeed_ptr_is_null:1;
     uint8_t fly_forward:1;
     uint8_t ahrs_airspeed_sensor_enabled:1;
     uint8_t opticalflow_enabled:1;
@@ -269,7 +267,6 @@ struct log_RBCH {
     uint8_t get_vehicle_position_ned_returncode:1;
     uint8_t get_origin_returncode:1;
     uint8_t enabled:1;
-    uint8_t ptr_is_nullptr:1;
     uint8_t count;
     uint8_t _end;
 };
@@ -292,7 +289,6 @@ struct log_RVOH {
     uint32_t delay_ms;
     uint8_t healthy;
     bool enabled;
-    uint8_t ptr_is_nullptr;
     uint8_t _end;
 };
 
@@ -408,7 +404,7 @@ struct log_RBOH {
     { LOG_RBCI_MSG, RLOG_SIZE(RBCI),                                   \
       "RBCI", "IffffBB", "LU,PX,PY,PZ,Dist,H,I", "smmmm-#", "?0000--" }, \
     { LOG_RVOH_MSG, RLOG_SIZE(RVOH),                                   \
-      "RVOH", "fffIBBB", "OX,OY,OZ,Del,H,Ena,NPtr", "-------", "-------" }, \
+      "RVOH", "fffIBB", "OX,OY,OZ,Del,H,Ena", "------", "------" }, \
     { LOG_ROFH_MSG, RLOG_SIZE(ROFH),                                   \
       "ROFH", "ffffIfffB", "FX,FY,GX,GY,Tms,PX,PY,PZ,Qual", "---------", "---------" }, \
     { LOG_REPH_MSG, RLOG_SIZE(REPH),                                   \

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -477,3 +477,50 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
 
     return true;
 }
+
+// return true if ext nav is enabled on any source
+bool AP_NavEKF_Source::ext_nav_enabled(void) const
+{
+    for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
+        const auto &src = _source_set[i];
+        if (SourceXY(src.posxy.get()) == SourceXY::EXTNAV) {
+            return true;
+        }
+        if (SourceZ(src.posz.get()) == SourceZ::EXTNAV) {
+            return true;
+        }
+        if (SourceXY(src.velxy.get()) == SourceXY::EXTNAV) {
+            return true;
+        }
+        if (SourceZ(src.velz.get()) == SourceZ::EXTNAV) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// return true if wheel encoder is enabled on any source
+bool AP_NavEKF_Source::wheel_encoder_enabled(void) const
+{
+    for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
+        const auto &src = _source_set[i];
+        if (SourceXY(src.velxy.get()) == SourceXY::WHEEL_ENCODER) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// return true if ext yaw is enabled on any source
+bool AP_NavEKF_Source::ext_yaw_enabled(void) const
+{
+    for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
+        const auto &src = _source_set[i];
+        const SourceYaw yaw = SourceYaw(src.yaw.get());
+        if (yaw == SourceYaw::EXTERNAL ||
+            yaw == SourceYaw::EXTERNAL_COMPASS_FALLBACK) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -93,10 +93,19 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+    // return true if ext nav is enabled on any source
+    bool ext_nav_enabled(void) const;
+
+    // return true if ext yaw is enabled on any source
+    bool ext_yaw_enabled(void) const;
+    
+    // return true if wheel encoder is enabled on any source
+    bool wheel_encoder_enabled(void) const;
+    
 private:
 
     // Parameters
-    struct {
+    struct SourceSet {
         AP_Int8 posxy;  // xy position source
         AP_Int8 velxy;  // xy velocity source
         AP_Int8 posz;   // position z (aka altitude or height) source

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -217,7 +217,7 @@ void NavEKF3_core::Log_Write_Beacon(uint64_t time_us)
         return;
     }
 
-    if (!statesInitialised || N_beacons == 0) {
+    if (!statesInitialised || N_beacons == 0 || rngBcnFusionReport == nullptr) {
         return;
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -838,7 +838,6 @@ void NavEKF3_core::readRngBcnData()
 {
     // check that arrays are large enough
     static_assert(ARRAY_SIZE(lastTimeRngBcn_ms) >= AP_BEACON_MAX_BEACONS, "lastTimeRngBcn_ms should have at least AP_BEACON_MAX_BEACONS elements");
-    static_assert(ARRAY_SIZE(rngBcnFusionReport) >= AP_BEACON_MAX_BEACONS, "rngBcnFusionReport should have at least AP_BEACON_MAX_BEACONS elements");
 
     // get the location of the beacon data
     const AP_DAL_Beacon *beacon = dal.beacon();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -260,11 +260,13 @@ void NavEKF3_core::FuseRngBcn()
         }
 
         // Update the fusion report
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].beaconPosNED = rngBcnDataDelayed.beacon_posNED;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innov = innovRngBcn;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innovVar = varInnovRngBcn;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].rng = rngBcnDataDelayed.rng;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].testRatio = rngBcnTestRatio;
+        if (rngBcnFusionReport && rngBcnDataDelayed.beacon_ID < dal.beacon()->count()) {
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].beaconPosNED = rngBcnDataDelayed.beacon_posNED;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innov = innovRngBcn;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innovVar = varInnovRngBcn;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].rng = rngBcnDataDelayed.rng;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].testRatio = rngBcnTestRatio;
+        }
     }
 }
 
@@ -496,11 +498,13 @@ void NavEKF3_core::FuseRngBcnStatic()
             rngBcnAlignmentCompleted = true;
         }
         // Update the fusion report
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].beaconPosNED = rngBcnDataDelayed.beacon_posNED;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innov = innovRngBcn;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innovVar = varInnovRngBcn;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].rng = rngBcnDataDelayed.rng;
-        rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].testRatio = rngBcnTestRatio;
+        if (rngBcnFusionReport && rngBcnDataDelayed.beacon_ID < dal.beacon()->count()) {
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].beaconPosNED = rngBcnDataDelayed.beacon_posNED;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innov = innovRngBcn;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].innovVar = varInnovRngBcn;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].rng = rngBcnDataDelayed.rng;
+            rngBcnFusionReport[rngBcnDataDelayed.beacon_ID].testRatio = rngBcnTestRatio;
+        }
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -113,33 +113,34 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
     if(!storedBaro.init(obs_buffer_length)) {
         return false;
     }
-    if(!storedTAS.init(obs_buffer_length)) {
+    if(dal.airspeed() && !storedTAS.init(obs_buffer_length)) {
         return false;
     }
-    if (!storedOF.init(flow_buffer_length)) {
+    if(dal.opticalflow_enabled() && !storedOF.init(flow_buffer_length)) {
         return false;
     }
-    if(!storedBodyOdm.init(obs_buffer_length)) {
+    if(frontend->sources.ext_nav_enabled() && !storedBodyOdm.init(obs_buffer_length)) {
         return false;
     }
-    if(!storedWheelOdm.init(imu_buffer_length)) { // initialise to same length of IMU to allow for multiple wheel sensors
+    if(frontend->sources.wheel_encoder_enabled() && !storedWheelOdm.init(imu_buffer_length)) {
+        // initialise to same length of IMU to allow for multiple wheel sensors
         return false;
     }
-    if(!storedYawAng.init(yaw_angle_buffer_length)) {
+    if(frontend->sources.ext_yaw_enabled() && !storedYawAng.init(yaw_angle_buffer_length)) {
         return false;
     }
     // Note: the use of dual range finders potentially doubles the amount of data to be stored
-    if(!storedRange.init(MIN(2*obs_buffer_length , imu_buffer_length))) {
+    if(dal.rangefinder() && !storedRange.init(MIN(2*obs_buffer_length , imu_buffer_length))) {
         return false;
     }
     // Note: range beacon data is read one beacon at a time and can arrive at a high rate
-    if(!storedRangeBeacon.init(imu_buffer_length+1)) {
+    if(dal.beacon() && !storedRangeBeacon.init(imu_buffer_length+1)) {
         return false;
     }
-    if (!storedExtNav.init(extnav_buffer_length)) {
+    if (frontend->sources.ext_nav_enabled() && !storedExtNav.init(extnav_buffer_length)) {
         return false;
     }
-    if (!storedExtNavVel.init(extnav_buffer_length)) {
+    if (frontend->sources.ext_nav_enabled() && !storedExtNavVel.init(extnav_buffer_length)) {
         return false;
     }
     if(!storedIMU.init(imu_buffer_length)) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -363,7 +363,11 @@ void NavEKF3_core::InitialiseVariables()
     bcnPosOffsetMinVar = 0.0f;
     minOffsetStateChangeFilt = 0.0f;
     rngBcnFuseDataReportIndex = 0;
-    memset(&rngBcnFusionReport, 0, sizeof(rngBcnFusionReport));
+    if (dal.beacon()) {
+        if (rngBcnFusionReport == nullptr) {
+            rngBcnFusionReport = new rngBcnFusionReport_t[dal.beacon()->count()];
+        }
+    }
     bcnPosOffsetNED.zero();
     bcnOriginEstInit = false;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1263,7 +1263,7 @@ private:
         float innovVar;     // innovation variance (m^2)
         float testRatio;    // innovation consistency test ratio
         Vector3f beaconPosNED; // beacon NED position
-    } rngBcnFusionReport[4];
+    } *rngBcnFusionReport;
 
     // height source selection logic
     AP_NavEKF_Source::SourceZ activeHgtSource;  // active height source

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -313,16 +313,22 @@ void RangeFinder::update(void)
 #endif
 }
 
-bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend)
+bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend, uint8_t instance)
 {
     if (!backend) {
         return false;
     }
-    if (num_instances == RANGEFINDER_MAX_INSTANCES) {
+    if (instance >= RANGEFINDER_MAX_INSTANCES) {
         AP_HAL::panic("Too many RANGERS backends");
     }
+    if (drivers[instance] != nullptr) {
+        // we've allocated the same instance twice
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+    }
 
-    drivers[num_instances++] = backend;
+    drivers[instance] = backend;
+    num_instances = MAX(num_instances, instance+1);
+
     return true;
 }
 
@@ -337,7 +343,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::PLI2CV3:
     case Type::PLI2CV3HP:
         FOREACH_I2C(i) {
-            if (_add_backend(AP_RangeFinder_PulsedLightLRF::detect(i, state[instance], params[instance], _type))) {
+            if (_add_backend(AP_RangeFinder_PulsedLightLRF::detect(i, state[instance], params[instance], _type),
+                             instance)) {
                 break;
             }
         }
@@ -345,7 +352,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::MBI2C:
         FOREACH_I2C(i) {
             if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
-                                                                  hal.i2c_mgr->get_device(i, AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR)))) {
+                                                                  hal.i2c_mgr->get_device(i, AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR)),
+                             instance)) {
                 break;
             }
         }
@@ -358,11 +366,13 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
             }
 #ifdef HAL_RANGEFINDER_LIGHTWARE_I2C_BUS
             _add_backend(AP_RangeFinder_LightWareI2C::detect(state[instance], params[instance],
-                hal.i2c_mgr->get_device(HAL_RANGEFINDER_LIGHTWARE_I2C_BUS, params[instance].address)));
+                                                             hal.i2c_mgr->get_device(HAL_RANGEFINDER_LIGHTWARE_I2C_BUS, params[instance].address)),
+                                                             instance);
 #else
             FOREACH_I2C(i) {
                 if (_add_backend(AP_RangeFinder_LightWareI2C::detect(state[instance], params[instance],
-                                                                     hal.i2c_mgr->get_device(i, params[instance].address)))) {
+                                                                     hal.i2c_mgr->get_device(i, params[instance].address)),
+                                 instance)) {
                     break;
                 }
             }
@@ -373,7 +383,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         if (params[instance].address) {
             FOREACH_I2C(i) {
                 if (_add_backend(AP_RangeFinder_TeraRangerI2C::detect(state[instance], params[instance],
-                                                                      hal.i2c_mgr->get_device(i, params[instance].address)))) {
+                                                                      hal.i2c_mgr->get_device(i, params[instance].address)),
+                                 instance)) {
                     break;
                 }
             }
@@ -383,13 +394,15 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::VL53L1X_Short:
             FOREACH_I2C(i) {
                 if (_add_backend(AP_RangeFinder_VL53L0X::detect(state[instance], params[instance],
-                                                                 hal.i2c_mgr->get_device(i, params[instance].address)))) {
+                                                                hal.i2c_mgr->get_device(i, params[instance].address)),
+                        instance)) {
                     break;
                 }
                 if (_add_backend(AP_RangeFinder_VL53L1X::detect(state[instance], params[instance],
                                                                 hal.i2c_mgr->get_device(i, params[instance].address),
                                                                 _type == Type::VL53L1X_Short ?  AP_RangeFinder_VL53L1X::DistanceMode::Short :
-                                                                                                AP_RangeFinder_VL53L1X::DistanceMode::Long))) {
+                                                                AP_RangeFinder_VL53L1X::DistanceMode::Long),
+                                 instance)) {
                     break;
                 }
             }
@@ -397,7 +410,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::BenewakeTFminiPlus:
         FOREACH_I2C(i) {
             if (_add_backend(AP_RangeFinder_Benewake_TFMiniPlus::detect(state[instance], params[instance],
-                                                                        hal.i2c_mgr->get_device(i, params[instance].address)))) {
+                                                                        hal.i2c_mgr->get_device(i, params[instance].address)),
+                    instance)) {
                 break;
             }
         }
@@ -408,7 +422,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         // to ease moving from PX4 to ChibiOS we'll lie a little about
         // the backend driver...
         if (AP_RangeFinder_PWM::detect()) {
-            drivers[instance] = new AP_RangeFinder_PWM(state[instance], params[instance], estimated_terrain_height);
+            _add_backend(new AP_RangeFinder_PWM(state[instance], params[instance], estimated_terrain_height), instance);
         }
 #endif
 #endif
@@ -416,50 +430,50 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::BBB_PRU:
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
         if (AP_RangeFinder_BBB_PRU::detect()) {
-            drivers[instance] = new AP_RangeFinder_BBB_PRU(state[instance], params[instance]);
+            _add_backend(new AP_RangeFinder_BBB_PRU(state[instance], params[instance]), instance);
         }
 #endif
         break;
     case Type::LWSER:
         if (AP_RangeFinder_LightWareSerial::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_LightWareSerial(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_LightWareSerial(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::LEDDARONE:
         if (AP_RangeFinder_LeddarOne::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_LeddarOne(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_LeddarOne(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::ULANDING:
         if (AP_RangeFinder_uLanding::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_uLanding(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_uLanding(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::BEBOP:
 #if (CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP || \
      CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO) && defined(HAVE_LIBIIO)
         if (AP_RangeFinder_Bebop::detect()) {
-            drivers[instance] = new AP_RangeFinder_Bebop(state[instance], params[instance]);
+            _add_backend(new AP_RangeFinder_Bebop(state[instance], params[instance]), instance);
         }
 #endif
         break;
     case Type::MAVLink:
 #ifndef HAL_BUILD_AP_PERIPH
         if (AP_RangeFinder_MAVLink::detect()) {
-            drivers[instance] = new AP_RangeFinder_MAVLink(state[instance], params[instance]);
+            _add_backend(new AP_RangeFinder_MAVLink(state[instance], params[instance]), instance);
         }
 #endif
         break;
     case Type::MBSER:
         if (AP_RangeFinder_MaxsonarSerialLV::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_MaxsonarSerialLV(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_MaxsonarSerialLV(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::ANALOG:
 #ifndef HAL_BUILD_AP_PERIPH
         // note that analog will always come back as present if the pin is valid
         if (AP_RangeFinder_analog::detect(params[instance])) {
-            drivers[instance] = new AP_RangeFinder_analog(state[instance], params[instance]);
+            _add_backend(new AP_RangeFinder_analog(state[instance], params[instance]), instance);
         }
 #endif
         break;
@@ -467,55 +481,55 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 #ifndef HAL_BUILD_AP_PERIPH
         // note that this will always come back as present if the pin is valid
         if (AP_RangeFinder_HC_SR04::detect(params[instance])) {
-            drivers[instance] = new AP_RangeFinder_HC_SR04(state[instance], params[instance]);
+            _add_backend(new AP_RangeFinder_HC_SR04(state[instance], params[instance]), instance);
         }
 #endif
         break;
     case Type::NMEA:
         if (AP_RangeFinder_NMEA::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_NMEA(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_NMEA(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::WASP:
         if (AP_RangeFinder_Wasp::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Wasp(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_Wasp(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::BenewakeTF02:
         if (AP_RangeFinder_Benewake_TF02::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Benewake_TF02(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_Benewake_TF02(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::BenewakeTFmini:
         if (AP_RangeFinder_Benewake_TFMini::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Benewake_TFMini(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_Benewake_TFMini(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::BenewakeTF03:
         if (AP_RangeFinder_Benewake_TF03::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Benewake_TF03(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_Benewake_TF03(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::PWM:
 #ifndef HAL_BUILD_AP_PERIPH
         if (AP_RangeFinder_PWM::detect()) {
-            drivers[instance] = new AP_RangeFinder_PWM(state[instance], params[instance], estimated_terrain_height);
+            _add_backend(new AP_RangeFinder_PWM(state[instance], params[instance], estimated_terrain_height), instance);
         }
 #endif
         break;
     case Type::BLPing:
         if (AP_RangeFinder_BLPing::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_BLPing(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_BLPing(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::Lanbao:
         if (AP_RangeFinder_Lanbao::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_Lanbao(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_Lanbao(state[instance], params[instance], serial_instance++), instance);
         }
         break;
     case Type::LeddarVu8_Serial:
         if (AP_RangeFinder_LeddarVu8::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_LeddarVu8(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_LeddarVu8(state[instance], params[instance], serial_instance++), instance);
         }
         break;
 
@@ -532,20 +546,20 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 
     case Type::GYUS42v2:
         if (AP_RangeFinder_GYUS42v2::detect(serial_instance)) {
-            drivers[instance] = new AP_RangeFinder_GYUS42v2(state[instance], params[instance], serial_instance++);
+            _add_backend(new AP_RangeFinder_GYUS42v2(state[instance], params[instance], serial_instance++), instance);
         }
         break;
 
     case Type::SITL:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        drivers[instance] = new AP_RangeFinder_SITL(state[instance], params[instance], instance);
+        _add_backend(new AP_RangeFinder_SITL(state[instance], params[instance], instance), instance);
 #endif
         break;
 
     case Type::MSP:
 #if HAL_MSP_RANGEFINDER_ENABLED
         if (AP_RangeFinder_MSP::detect()) {
-            drivers[instance] = new AP_RangeFinder_MSP(state[instance], params[instance]);
+            _add_backend(new AP_RangeFinder_MSP(state[instance], params[instance]), instance);
         }
 #endif // HAL_MSP_RANGEFINDER_ENABLED
         break;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -122,7 +122,12 @@ public:
 
     void set_log_rfnd_bit(uint32_t log_rfnd_bit) { _log_rfnd_bit = log_rfnd_bit; }
 
-    // Return the number of range finder instances
+    /*
+      Return the number of range finder instances. Note that if users
+      sets up rangefinders with a gap in the types then this is the
+      index of the maximum sensor ID plus one, so this gives the value
+      that should be used when iterating over all sensors
+    */
     uint8_t num_sensors(void) const {
         return num_instances;
     }
@@ -204,7 +209,7 @@ private:
 
     void detect_instance(uint8_t instance, uint8_t& serial_instance);
 
-    bool _add_backend(AP_RangeFinder_Backend *driver);
+    bool _add_backend(AP_RangeFinder_Backend *driver, uint8_t instance);
 
     uint32_t _log_rfnd_bit = -1;
     void Log_RFND();


### PR DESCRIPTION
This saves memory on backends that we don't have enabled, and saves some CPU in the rangefinder backend by only looping over the number of rangefinders we have.
It assumes that by the time the EKF starts we have allocated these sensors:
 - airspeed
 - rangefinder
 - beacon
 - visualodom

and that new sensors of these types won't be added

Update: I've now updated this to avoid the init of the ring buffers that are not enabled in EK3 sources. This saves a lot of memory, but assumes that we don't change the EK3_SRC params to add new source types at runtime.
Total memory savings for EK3 on CubeBlack with default sensors is over 8k, for a flash cost of 232 bytes

Flight log here:
http://uav.tridgell.net/HolyQuad2/00000016.BIN
(just backyard test, some of it indoors)
