### PR TITLE
remove ability to inhibit GPS vertical-velocity use

### DIFF
--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -74,12 +74,6 @@ void LR_MsgHandler_REV2::process_message(uint8_t *msgbytes)
     case AP_DAL::Event::unsetTouchdownExpected:
         ekf2.setTouchdownExpected(false);
         break;
-    case AP_DAL::Event::setInhibitGpsVertVelUse:
-        ekf2.setInhibitGpsVertVelUse(true);
-        break;
-    case AP_DAL::Event::unsetInhibitGpsVertVelUse:
-        ekf2.setInhibitGpsVertVelUse(false);
-        break;
     case AP_DAL::Event::setTerrainHgtStable:
         ekf2.setTerrainHgtStable(true);
         break;
@@ -151,12 +145,6 @@ void LR_MsgHandler_REV3::process_message(uint8_t *msgbytes)
         break;
     case AP_DAL::Event::unsetTouchdownExpected:
         ekf3.setTouchdownExpected(false);
-        break;
-    case AP_DAL::Event::setInhibitGpsVertVelUse:
-        ekf3.setInhibitGpsVertVelUse(true);
-        break;
-    case AP_DAL::Event::unsetInhibitGpsVertVelUse:
-        ekf3.setInhibitGpsVertVelUse(false);
         break;
     case AP_DAL::Event::setTerrainHgtStable:
         ekf3.setTerrainHgtStable(true);

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -41,8 +41,8 @@ public:
         unsetTakeoffExpected      =  4,
         setTouchdownExpected      =  5,
         unsetTouchdownExpected    =  6,
-        setInhibitGpsVertVelUse   =  7,
-        unsetInhibitGpsVertVelUse =  8,
+//        setInhibitGpsVertVelUse   =  7,   no longer used
+//        unsetInhibitGpsVertVelUse =  8,   no longer used
         setTerrainHgtStable       =  9,
         unsetTerrainHgtStable     = 10,
         requestYawReset           = 11,

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1039,18 +1039,6 @@ uint8_t NavEKF2::setInhibitGPS(void)
     return core[primary].setInhibitGPS();
 }
 
-// Set the argument to true to prevent the EKF using the GPS vertical velocity
-// This can be used for situations where GPS velocity errors are causing problems with height accuracy
-void NavEKF2::setInhibitGpsVertVelUse(const bool varIn) {
-    if (varIn) {
-        AP::dal().log_event2(AP_DAL::Event::setInhibitGpsVertVelUse);
-    } else {
-        AP::dal().log_event2(AP_DAL::Event::unsetInhibitGpsVertVelUse);
-    }
-    inhibitGpsVertVelUse = varIn;
-};
-
-
 // return the horizontal speed limit in m/s set by optical flow sensor limits
 // return the scale factor to be applied to navigation velocity gains to compensate for increase in velocity noise with height when using optical flow
 void NavEKF2::getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -122,10 +122,6 @@ public:
     // Returns 2 if attitude, 3D-velocity, vertical position and relative horizontal position will be provided
     uint8_t setInhibitGPS(void);
 
-    // Set the argument to true to prevent the EKF using the GPS vertical velocity
-    // This can be used for situations where GPS velocity errors are causing problems with height accuracy
-    void setInhibitGpsVertVelUse(const bool varIn);
-
     // return the horizontal speed limit in m/s set by optical flow sensor limits
     // return the scale factor to be applied to navigation velocity gains to compensate for increase in velocity noise with height when using optical flow
     void getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const;
@@ -503,8 +499,6 @@ private:
     } pos_down_reset_data;
 
     bool runCoreSelection; // true when the primary core has stabilised and the core selection logic can be started
-
-    bool inhibitGpsVertVelUse;  // true when GPS vertical velocity use is prohibited
 
     // time of last lane switch
     uint32_t lastLaneSwitch_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -569,7 +569,7 @@ void NavEKF2_core::readGpsData()
             }
 
             // Check if GPS can output vertical velocity, if it is allowed to be used, and set GPS fusion mode accordingly
-            if (gps.have_vertical_velocity() && frontend->_fusionModeGPS == 0 && !frontend->inhibitGpsVertVelUse) {
+            if (gps.have_vertical_velocity() && frontend->_fusionModeGPS == 0) {
                 useGpsVertVel = true;
             } else {
                 useGpsVertVel = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -219,7 +219,7 @@ void NavEKF2_core::ResetHeight(void)
 
     // Reset the vertical velocity state using GPS vertical velocity if we are airborne
     // Check that GPS vertical velocity data is available and can be used
-    if (inFlight && !gpsNotAvailable && frontend->_fusionModeGPS == 0 && !frontend->inhibitGpsVertVelUse) {
+    if (inFlight && !gpsNotAvailable && frontend->_fusionModeGPS == 0) {
         stateStruct.velocity.z =  gpsDataNew.vel.z;
     } else if (inFlight && useExtNavVel) {
         stateStruct.velocity.z = extNavVelNew.vel.z;
@@ -705,7 +705,7 @@ void NavEKF2_core::FuseVelPosNED()
             // test velocity measurements
             uint8_t imax = 2;
             // Don't fuse vertical velocity observations if inhibited by the user or if we are using synthetic data
-            if (!useExtNavVel && (frontend->_fusionModeGPS > 0 || PV_AidingMode != AID_ABSOLUTE || frontend->inhibitGpsVertVelUse)) {
+            if (!useExtNavVel && (frontend->_fusionModeGPS > 0 || PV_AidingMode != AID_ABSOLUTE)) {
                 imax = 1;
             }
             float innovVelSumSq = 0; // sum of squares of velocity innovations

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -119,10 +119,6 @@ public:
     // Returns 1 if command accepted
     uint8_t setInhibitGPS(void);
 
-    // Set the argument to true to prevent the EKF using the GPS vertical velocity
-    // This can be used for situations where GPS velocity errors are causing problems with height accuracy
-    void setInhibitGpsVertVelUse(const bool varIn) { inhibitGpsVertVelUse = varIn; };
-
     // return the horizontal speed limit in m/s set by optical flow sensor limits
     // return the scale factor to be applied to navigation velocity gains to compensate for increase in velocity noise with height when using optical flow
     void getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const;
@@ -542,8 +538,6 @@ private:
     float coreRelativeErrors[MAX_EKF_CORES];        // relative errors of cores with respect to primary
     float coreErrorScores[MAX_EKF_CORES];           // the instance error values used to update relative core error
     uint64_t coreLastTimePrimary_us[MAX_EKF_CORES]; // last time we were using this core as primary
-
-    bool inhibitGpsVertVelUse;  // true when GPS vertical velocity use is prohibited
 
     // origin set by one of the cores
     struct Location common_EKF_origin;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -616,7 +616,7 @@ void NavEKF3_core::readGpsData()
             }
 
             // Check if GPS can output vertical velocity, vertical velocity use is permitted and set GPS fusion mode accordingly
-            if (gps.have_vertical_velocity(selected_gps) && frontend->sources.useVelZSource(AP_NavEKF_Source::SourceZ::GPS) && !frontend->inhibitGpsVertVelUse) {
+            if (gps.have_vertical_velocity(selected_gps) && frontend->sources.useVelZSource(AP_NavEKF_Source::SourceZ::GPS)) {
                 useGpsVertVel = true;
             } else {
                 useGpsVertVel = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -245,7 +245,7 @@ void NavEKF3_core::ResetHeight(void)
 
     // Reset the vertical velocity state using GPS vertical velocity if we are airborne
     // Check that GPS vertical velocity data is available and can be used
-    if (inFlight && !gpsNotAvailable && frontend->sources.useVelZSource(AP_NavEKF_Source::SourceZ::GPS) && !frontend->inhibitGpsVertVelUse) {
+    if (inFlight && !gpsNotAvailable && frontend->sources.useVelZSource(AP_NavEKF_Source::SourceZ::GPS)) {
         stateStruct.velocity.z =  gpsDataNew.vel.z;
     } else if (inFlight && useExtNavVel && (activeHgtSource == AP_NavEKF_Source::SourceZ::EXTNAV)) {
         stateStruct.velocity.z = extNavVelDelayed.vel.z;
@@ -720,7 +720,7 @@ void NavEKF3_core::FuseVelPosNED()
             // test velocity measurements
             uint8_t imax = 2;
             // Don't fuse vertical velocity observations if inhibited by the user or if we are using synthetic data
-            if ((!frontend->sources.haveVelZSource() || PV_AidingMode != AID_ABSOLUTE || frontend->inhibitGpsVertVelUse) && !useExtNavVel) {
+            if ((!frontend->sources.haveVelZSource() || PV_AidingMode != AID_ABSOLUTE) && !useExtNavVel) {
                 imax = 1;
             }
             float innovVelSumSq = 0; // sum of squares of velocity innovations


### PR DESCRIPTION
There were no callers to the set method.  It could never be true.

This is somewhat like another recent commit where setInhibitGPS was removed.
