### PR TITLE
AP_NavEKF3: add pre-arm check that wheel encoders are enabled

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -103,6 +103,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_Generator',
     'AP_MSP',
     'AP_OLC',
+    'AP_WheelEncoder',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -5,6 +5,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
+#include <AP_WheelEncoder/AP_WheelEncoder.h>
 
 #if APM_BUILD_TYPE(APM_BUILD_Replay)
 #include <AP_NavEKF2/AP_NavEKF2.h>
@@ -65,6 +66,7 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.available_memory = hal.util->available_memory();
     _RFRN.ahrs_trim = ahrs.get_trim();
     _RFRN.opticalflow_enabled = AP::opticalflow() && AP::opticalflow()->enabled();
+    _RFRN.wheelencoder_enabled = AP::wheelencoder() && (AP::wheelencoder()->num_sensors() > 0);
     WRITE_REPLAY_BLOCK_IFCHANGED(RFRN, _RFRN, old);
 
     // update body conversion

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -192,6 +192,10 @@ public:
         return _RFRN.opticalflow_enabled;
     }
 
+    bool wheelencoder_enabled(void) const {
+        return _RFRN.wheelencoder_enabled;
+    }
+
     // log optical flow data
     void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
 

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -66,6 +66,7 @@ struct log_RFRN {
     uint8_t fly_forward:1;
     uint8_t ahrs_airspeed_sensor_enabled:1;
     uint8_t opticalflow_enabled:1;
+    uint8_t wheelencoder_enabled:1;
     uint8_t _end;
 };
 

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -323,6 +323,7 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
     bool rangefinder_required = false;
     bool visualodom_required = false;
     bool optflow_required = false;
+    bool wheelencoder_required = false;
 
     // check source params are valid
     for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
@@ -362,7 +363,7 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
             visualodom_required = true;
             break;
         case SourceXY::WHEEL_ENCODER:
-            // ToDo: add wheelencoder_required and test below
+            wheelencoder_required = true;
             break;
         case SourceXY::BEACON:
         default:
@@ -473,6 +474,11 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
             hal.util->snprintf(failure_msg, failure_msg_len, ekf_requires_msg, "VisualOdom");
             return false;
         }
+    }
+
+    if (wheelencoder_required && !dal.wheelencoder_enabled()) {
+        hal.util->snprintf(failure_msg, failure_msg_len, ekf_requires_msg, "WheelEncoder");
+        return false;
     }
 
     return true;

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -151,6 +151,8 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
 
 AP_WheelEncoder::AP_WheelEncoder(void)
 {
+    _singleton = this;
+
     AP_Param::setup_object_defaults(this, var_info);
 }
 
@@ -346,4 +348,16 @@ uint32_t AP_WheelEncoder::get_last_reading_ms(uint8_t instance) const
         return 0;
     }
     return state[instance].last_reading_ms;
+}
+
+// singleton instance
+AP_WheelEncoder *AP_WheelEncoder::_singleton;
+
+namespace AP {
+
+AP_WheelEncoder *wheelencoder()
+{
+    return AP_WheelEncoder::get_singleton();
+}
+
 }

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -39,6 +39,11 @@ public:
     AP_WheelEncoder(const AP_WheelEncoder &other) = delete;
     AP_WheelEncoder &operator=(const AP_WheelEncoder&) = delete;
 
+    // get singleton instance
+    static AP_WheelEncoder *get_singleton() {
+        return _singleton;
+    }
+
     // WheelEncoder driver types
     enum WheelEncoder_Type : uint8_t {
         WheelEncoder_TYPE_NONE             =   0,
@@ -121,4 +126,12 @@ protected:
     AP_WheelEncoder_Backend *drivers[WHEELENCODER_MAX_INSTANCES];
     uint8_t num_instances;
     Vector3f pos_offset_zero;   // allows returning position offsets of zero for invalid requests
+
+private:
+
+    static AP_WheelEncoder *_singleton;
 };
+
+namespace AP {
+    AP_WheelEncoder *wheelencoder();
+}


### PR DESCRIPTION
This resolves a To-Do in the AP_NavEKF_Source library to check that wheel encoders have been enabled if the user has set EK3_SRCn_VELXY = 7 (Wheel Encoder).  I actually bumped into this issue myself while testing GPS+wheel encoders after forgetting to enable the wheel encoder library.

This has been lightly tested in SITL to ensure the pre-arm fails correctly.

Below is a screen shot of the pre-arm failure when EK3_SRC2_VELXY = 7 and WENC_TYPE = 0.
![wenc-pre-arm-failure](https://user-images.githubusercontent.com/1498098/100428765-b48a5a80-30d7-11eb-92bc-b01f1fb76cb9.png)

The failure message disappeared once either EK3_SRC2_VELXY = 0 (i.e. no plans to use wheel encoders) or WENC_TYPE = 1 (one wheel encoder enabled, reboot was required)

I've followed the pattern used for opticalflow_enabled but I'm slightly unsure if any other changes are required in the DAL (I don't think so) or if there are any issues with the change to the logging format (I think not because we're are just using one more bit)