### PR TITLE
Don't kill file logger if we are in an expected delay

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -1003,7 +1003,7 @@ bool AP_Logger_File::io_thread_alive() const
 {
     // if the io thread hasn't had a heartbeat in a full seconds then it is dead
     // this is enough time for a sdcard remount
-    return (AP_HAL::millis() - _io_timer_heartbeat) < 3000U;
+    return (AP_HAL::millis() - _io_timer_heartbeat) < 3000U || hal.scheduler->in_expected_delay();
 }
 
 bool AP_Logger_File::logging_failed() const


### PR DESCRIPTION
This is the same fix as was applied to the block logger last week. I run into this more with bi-directional dshot but the fix is obviously correct (and fixes the problem for me).