### PR TITLE
GCS_MAVLink: Notify the maximum number of missions

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -71,6 +71,7 @@ void MissionItemProtocol::handle_mission_count(
     if (packet.count > max_items()) {
         // FIXME: different items take up different storage space!
         send_mission_ack(_link, msg, MAV_MISSION_NO_SPACE);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Only %u items are supported", (unsigned)max_items());
         return;
     }
 


### PR DESCRIPTION
I create a plan with a survey.
I do not know the maximum number of missions for FC.
I can't deal with an error coming back in response.
I want to get the information to know why the error happened.