### PR TITLE
waf board profiles

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -10,6 +10,7 @@ from waflib import Utils
 from waflib.Configure import conf
 
 _board_classes = {}
+_board_profiles = {'racer'}
 _board = None
 
 class BoardMeta(type):
@@ -362,6 +363,9 @@ def get_boards_names():
     add_dynamic_boards()
 
     return sorted(list(_board_classes.keys()), key=str.lower)
+
+def get_profile_names():
+    return sorted(list(_board_profiles))
 
 def get_removed_boards():
     '''list of boards which have been removed'''

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -372,6 +372,9 @@ def generate_hwdef_h(env):
     if env.BOOTLOADER:
         env.HWDEF = os.path.join(env.SRCROOT, 'libraries/AP_HAL_ChibiOS/hwdef/%s/hwdef-bl.dat' % env.BOARD)
         env.BOOTLOADER_OPTION="--bootloader"
+    elif env.PROFILE:
+        env.HWDEF = os.path.join(env.SRCROOT, 'libraries/AP_HAL_ChibiOS/hwdef/%s/hwdef-%s.dat' % (env.BOARD, env.PROFILE))
+        env.BOOTLOADER_OPTION=""
     else:
         env.HWDEF = os.path.join(env.SRCROOT, 'libraries/AP_HAL_ChibiOS/hwdef/%s/hwdef.dat' % env.BOARD)
         env.BOOTLOADER_OPTION=""

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/hwdef-racer.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/hwdef-racer.dat
@@ -1,0 +1,3 @@
+include hwdef.dat
+
+define HAL_WITH_DSP 1

--- a/wscript
+++ b/wscript
@@ -71,6 +71,11 @@ def options(opt):
         default=None,
         help='Target board to build, choices are %s.' % ', '.join(boards_names))
 
+    g.add_option('--board-profile',
+        action='store',
+        default=None,
+        help='Target board profile to build, choices are %s.' % ', '.join(boards.get_profile_names()))
+
     g.add_option('--debug',
         action='store_true',
         default=False,
@@ -280,6 +285,7 @@ def configure(cfg):
 
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug
+    cfg.env.PROFILE = cfg.options.board_profile
     cfg.env.ENABLE_ASSERTS = cfg.options.enable_asserts
     cfg.env.BOOTLOADER = cfg.options.bootloader
     cfg.env.ENABLE_MALLOC_GUARD = cfg.options.enable_malloc_guard
@@ -298,6 +304,8 @@ def configure(cfg):
     cfg.load('ap_library')
 
     cfg.msg('Setting board to', cfg.options.board)
+    if cfg.options.board_profile is not None:
+        cfg.msg('Setting board profile to', cfg.options.board_profile)
     cfg.get_board().configure(cfg)
 
     cfg.load('clang_compilation_database')


### PR DESCRIPTION
This allows the definition of specific board build profiles via the --board-profile argument.
Board profiles allow more targeted custom board configurations supporting specific features sets (e.g. bi-directional dshot)
I have included a example 'racer' profile for the KakuteF7Mini