### PR TITLE
Moved init_safety call to AP_Vehicle and delay for one loop

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -92,9 +92,6 @@ void Tracker::init_ardupilot()
         // for some servos)
         prepare_servos();
     }
-
-    // disable safety if requested
-    BoardConfig.init_safety();    
 }
 
 /*

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -216,9 +216,6 @@ void Copter::init_ardupilot()
         enable_motor_output();
     }
 
-    // disable safety if requested
-    BoardConfig.init_safety();
-
     // flag that initialisation has completed
     ap.initialised = true;
 }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -157,9 +157,6 @@ void Plane::init_ardupilot()
 #if GRIPPER_ENABLED == ENABLED
     g2.gripper.init();
 #endif
-
-    // disable safety if requested
-    BoardConfig.init_safety();
 }
 
 //********************************************************************************

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -177,9 +177,6 @@ void Sub::init_ardupilot()
 
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
-    // disable safety if requested
-    BoardConfig.init_safety();
-
     // flag that initialisation has completed
     ap.initialised = true;
 }

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -122,9 +122,6 @@ void Rover::init_ardupilot()
 
     rover.g2.sailboat.init();
 
-    // disable safety if requested
-    BoardConfig.init_safety();
-
     // flag that initialisation has completed
     initialised = true;
 }

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -148,6 +148,18 @@ void AP_Vehicle::loop()
 {
     scheduler.loop();
     G_Dt = scheduler.get_loop_period_s();
+
+    if (!done_safety_init) {
+        /*
+          disable safety if requested. This is delayed till after the
+          first loop has run to ensure that all servos have received
+          an update for their initial values. Otherwise we may end up
+          briefly driving a servo to a position out of the configured
+          range which could damage hardware
+        */
+        done_safety_init = true;
+        BoardConfig.init_safety();
+    }
 }
 
 /*

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -307,6 +307,8 @@ private:
     uint32_t _last_flying_ms;   // time when likely_flying last went true
 
     static AP_Vehicle *_singleton;
+
+    bool done_safety_init;
 };
 
 namespace AP {


### PR DESCRIPTION
This delays init_safety till after the first loop has run to ensure that all servos have received an update for their initial values. Otherwise we may end up briefly driving a servo to a position out of the configured range which could damage hardware. This is particularly an issue for quadplanes with tilt arms, where the arms may be driven into the wing, but it could happen with any vehicle, so this PR solves it for all vehicles.

Thanks to Kris for reporting

