### PR TITLE
Sub: use set_default_by_name for GND_EXT_BUS

### DIFF
--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -42,6 +42,9 @@ void Sub::init_ardupilot()
     case AP_BoardConfig::PX4_BOARD_PIXHAWK2:
         AP_Param::set_default_by_name("GND_EXT_BUS", 0);
         break;
+    case AP_BoardConfig::PX4_BOARD_PIXHAWK:
+        AP_Param::set_by_name("GND_EXT_BUS", 1);
+        break;
     default:
         AP_Param::set_default_by_name("GND_EXT_BUS", 1);
         break;

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -19,23 +19,6 @@ void Sub::init_ardupilot()
     can_mgr.init();
 #endif
 
-#if AP_FEATURE_BOARD_DETECT
-    // Detection won't work until after BoardConfig.init()
-    switch (AP_BoardConfig::get_board_type()) {
-    case AP_BoardConfig::PX4_BOARD_PIXHAWK2:
-        AP_Param::set_default_by_name("GND_EXT_BUS", 0);
-        celsius.init(0);
-        break;
-    default:
-        AP_Param::set_default_by_name("GND_EXT_BUS", 1);
-        celsius.init(1);
-        break;
-    }
-#else
-    AP_Param::set_default_by_name("GND_EXT_BUS", 1);
-    celsius.init(1);
-#endif
-
     // init cargo gripper
 #if GRIPPER_ENABLED == ENABLED
     g2.gripper.init();
@@ -52,6 +35,21 @@ void Sub::init_ardupilot()
     battery.init();
 
     barometer.init();
+
+#if AP_FEATURE_BOARD_DETECT
+    // Detection won't work until after BoardConfig.init()
+    switch (AP_BoardConfig::get_board_type()) {
+    case AP_BoardConfig::PX4_BOARD_PIXHAWK2:
+        AP_Param::set_default_by_name("GND_EXT_BUS", 0);
+        break;
+    default:
+        AP_Param::set_default_by_name("GND_EXT_BUS", 1);
+        break;
+    }
+#else
+    AP_Param::set_default_by_name("GND_EXT_BUS", 1);
+#endif
+    celsius.init(barometer.external_bus());
 
     // setup telem slots with serial ports
     gcs().setup_uarts();

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -23,11 +23,11 @@ void Sub::init_ardupilot()
     // Detection won't work until after BoardConfig.init()
     switch (AP_BoardConfig::get_board_type()) {
     case AP_BoardConfig::PX4_BOARD_PIXHAWK2:
-        AP_Param::set_by_name("GND_EXT_BUS", 0);
+        AP_Param::set_default_by_name("GND_EXT_BUS", 0);
         celsius.init(0);
         break;
     default:
-        AP_Param::set_by_name("GND_EXT_BUS", 1);
+        AP_Param::set_default_by_name("GND_EXT_BUS", 1);
         celsius.init(1);
         break;
     }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -92,6 +92,9 @@ public:
     float get_altitude(void) const { return get_altitude(_primary); }
     float get_altitude(uint8_t instance) const { return sensors[instance].altitude; }
 
+    // returns which i2c bus is considered "the" external bus
+    uint8_t external_bus() const { return _ext_bus; }
+
     // get altitude difference in meters relative given a base
     // pressure in Pascal
     float get_altitude_difference(float base_pressure, float pressure) const;

--- a/libraries/AP_Baro/AP_Baro_KellerLD.cpp
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.cpp
@@ -166,7 +166,7 @@ bool AP_Baro_KellerLD::_init()
 bool AP_Baro_KellerLD::_read()
 {
     uint8_t data[5];
-    if (!_dev->transfer(nullptr, 1, data, sizeof(data))) {
+    if (!_dev->transfer(nullptr, 0, data, sizeof(data))) {
         Debug("Keller LD read failed!");
         return false;
     }


### PR DESCRIPTION
This allows boards that only have a single i2c bus to use external barometers.

It sets the default instead of the value, allowing users to override it.
