### PR TITLE
AP_Periph: switched to 1kHz clock for f303-periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/f303-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f303-periph/hwdef.dat
@@ -22,7 +22,7 @@ define HAL_WATCHDOG_ENABLED_DEFAULT true
 # crystal frequency
 OSCILLATOR_HZ 8000000
 
-define CH_CFG_ST_FREQUENCY 100000
+define CH_CFG_ST_FREQUENCY 1000
 define CH_CFG_ST_TIMEDELTA 0
 
 # assume the 256k flash part for now
@@ -107,7 +107,6 @@ define IO_THD_WA_SIZE      512
 
 define HAL_NO_GCS
 define HAL_NO_LOGGING
-//define HAL_NO_MONITOR_THREAD
 
 define HAL_MINIMIZE_FEATURES 0
 
@@ -140,4 +139,4 @@ RAM_RESERVE_START 256
 env ROMFS_UNCOMPRESSED True
 
 # reduce the number of CAN RX Buffer
-define HAL_CAN_RX_QUEUE_SIZE 32
+define HAL_CAN_RX_QUEUE_SIZE 64


### PR DESCRIPTION
and use CAN RX buffer size of 64.

This makes for more efficient CPU usage on f3, and fixes an issue with
lost CAN parameter replies causing timeouts in the CAN parameter
download protocol

