### PR TITLE
Rover: pivot turn and speed nudging fix

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -420,7 +420,7 @@ void Mode::navigate_to_waypoint()
     _distance_to_destination = g2.wp_nav.get_distance_to_destination();
 
     // pass speed to throttle controller after applying nudge from pilot
-    float desired_speed =  g2.wp_nav.get_desired_speed();
+    float desired_speed = g2.wp_nav.get_speed();
     desired_speed = calc_speed_nudge(desired_speed, g2.wp_nav.get_reversed());
     calc_throttle(desired_speed, true);
 

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -115,8 +115,6 @@ private:
     // calculate the crosstrack error (does not rely on L1 controller)
     float calc_crosstrack_error(const Location& current_loc) const;
 
-private:
-
     // parameters
     AP_Float _speed_max;            // target speed between waypoints in m/s
     AP_Float _speed_min;            // target speed minimum in m/s.  Vehicle will not slow below this speed for corners

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -110,7 +110,8 @@ private:
     void update_pivot_active_flag();
 
     // adjust speed to ensure it does not fall below value held in SPEED_MIN
-    void apply_speed_min(float &desired_speed);
+    // desired_speed should always be positive (or zero)
+    void apply_speed_min(float &desired_speed) const;
 
     // calculate the crosstrack error (does not rely on L1 controller)
     float calc_crosstrack_error(const Location& current_loc) const;


### PR DESCRIPTION
This PR resolves two issues:

- pivot turns are fixed by reverting PR https://github.com/ArduPilot/ardupilot/pull/15442.  The difference between these two accessors is:
    - AR_WPNav:get_desired_speed() is the value held in the WP_SPEED parameter (i.e. 2m/s default)
    - AR_WPNav::get_speed() returns the **limited** speed which is the above speed but reduced so that the vehicle slows down before reaching the waypoint or corners.  This is the one that we need to pass into the speed controller.
- speed nudging is changed so that the user's throttle input is converted to a desired speed just like in Acro mode.  If this speed is higher that the AR_WPNav::get_speed() then it is passed into the speed controller.  This removes the "runaway" bug that was the reason for the reverted PR (https://github.com/ArduPilot/ardupilot/pull/15442).  This is a significant change in behaviour but I think users may prefer it because the throttle position and resulting speed is consistent across modes.

This has been lightly tested in SITL and it appears to work correctly.  Below is the pivot turn and we see that the vehicle does a much smaller loop than it would in master.  We could make further improvements by making sure the vehicle does not start turning before it has come to a complete stop but this is out-of-scope for this PR.
![pivot-turn](https://user-images.githubusercontent.com/1498098/100835043-49160380-34b0-11eb-8e25-2aa04602742f.png)

Below is a screen shot from SITL during testing of the nudge behaviour.  The vehicle is reversing around a course and we see the ground speed is changing with the pilot's throttle input.
![rover-reverse-mission-with-nudge](https://user-images.githubusercontent.com/1498098/100835165-8aa6ae80-34b0-11eb-9fb1-cf17669e258a.png)

All feedback is very welcome especially from @IamPete1 and @grodnay.
