### PR TITLE
Add support for intermeshing rotor in Heli_Dual

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -43,7 +43,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
 
     // @Param: DCP_YAW
     // @DisplayName: Differential-Collective-Pitch Yaw Mixing
-    // @Description: Feed-forward compensation to automatically add yaw input when differential collective pitch is applied.
+    // @Description: Feed-forward compensation to automatically add yaw input when differential collective pitch is applied.  Disabled for intermeshing mode.
     // @Range: -10 10
     // @Increment: 0.1
     // @User: Standard
@@ -586,11 +586,14 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     if (_servo_mode == SERVO_CONTROL_MODE_AUTOMATED) {
         // add differential collective pitch yaw compensation
         float yaw_compensation = 0.0f;
-        if (_dual_mode == AP_MOTORS_HELI_DUAL_MODE_INTERMESHING && _yaw_rev_expo > 0.01f) {
+
+        if (_dual_mode == AP_MOTORS_HELI_DUAL_MODE_INTERMESHING) {
             // for intermeshing, reverse yaw in negative collective region and smoothen transition near zero collective
-            // yaw_compensation range: (-1,1) S-shaped curve (Logistic Model) 1/(1 + e^kt)
-            yaw_compensation = 1.0f - (2.0f / (1.0f + powf(2.7182818f , _yaw_rev_expo * (collective_out-_collective_mid_pct))));
-            yaw_out = yaw_out * yaw_compensation;
+            if (_yaw_rev_expo > 0.01f) {
+                // yaw_compensation range: (-1,1) S-shaped curve (Logistic Model) 1/(1 + e^kt)
+                yaw_compensation = 1.0f - (2.0f / (1.0f + powf(2.7182818f , _yaw_rev_expo * (collective_out-_collective_mid_pct))));
+                yaw_out = yaw_out * yaw_compensation;
+            }
         } else {
             if (_dual_mode == AP_MOTORS_HELI_DUAL_MODE_TRANSVERSE) {
                 yaw_compensation = _dcp_yaw_effect * roll_out;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -15,6 +15,7 @@
 // tandem modes
 #define AP_MOTORS_HELI_DUAL_MODE_TANDEM                0 // tandem mode (rotors front and aft)
 #define AP_MOTORS_HELI_DUAL_MODE_TRANSVERSE            1 // transverse mode (rotors side by side)
+#define AP_MOTORS_HELI_DUAL_MODE_INTERMESHING          2 // intermeshing mode (rotors side by side)
 
 // tandem modes
 #define AP_MOTORS_HELI_DUAL_SWASH_AXIS_PITCH           0 // swashplate pitch tilt axis
@@ -133,6 +134,7 @@ protected:
     AP_Float        _dcp_yaw_effect;                // feed-forward compensation to automatically add yaw input when differential collective pitch is applied.
     AP_Float        _yaw_scaler;                    // scaling factor applied to the yaw mixing
     AP_Float        _dcp_trim;                      // used to easily trim dcp axis
+    AP_Float        _yaw_rev_expo;                  // yaw reverser smoothing exponent, for intermeshing mode only.
 
     // internal variables
     float           _collective2_mid_pct = 0.0f;      // collective mid parameter value for rear swashplate converted to 0 ~ 1 range


### PR DESCRIPTION
This commit adds new rotor configuration called "intermeshing rotor" to Heli_Dual (in addition to tandem and transverse).
Example aircrafts are Kaman K-Max and HH-43 Huskie.

Based on my project 3 years ago
https://discuss.ardupilot.org/t/synchropter-project/19430/1

This is my very first pull request, let me know if there is something missing.