### PR TITLE
Save some bytes in AP_GPS on f103-Periph

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -67,7 +67,13 @@ const uint32_t AP_GPS::_baudrates[] = {9600U, 115200U, 4800U, 19200U, 38400U, 57
 
 // initialisation blobs to send to the GPS to try to get it into the
 // right mode
-const char AP_GPS::_initialisation_blob[] = UBLOX_SET_BINARY_230400 MTK_SET_BINARY SIRF_SET_BINARY;
+const char AP_GPS::_initialisation_blob[] =
+    UBLOX_SET_BINARY_230400
+#ifndef HAL_BUILD_AP_PERIPH
+    MTK_SET_BINARY
+    SIRF_SET_BINARY
+#endif
+    ;
 
 AP_GPS *AP_GPS::_singleton;
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -607,7 +607,9 @@ void AP_GPS::detect_instance(uint8_t instance)
 
         if (_auto_config == GPS_AUTO_CONFIG_ENABLE && new_gps == nullptr) {
             if (_type[instance] == GPS_TYPE_HEMI) {
+#ifndef HAL_BUILD_AP_PERIPH
                 send_blob_start(instance, AP_GPS_NMEA_HEMISPHERE_INIT_STRING, strlen(AP_GPS_NMEA_HEMISPHERE_INIT_STRING));
+#endif
             } else if (_type[instance] == GPS_TYPE_UBLOX_RTK_BASE ||
                        _type[instance] == GPS_TYPE_UBLOX_RTK_ROVER) {
                 static const char blob[] = UBLOX_SET_BINARY_460800;


### PR DESCRIPTION
Saves ~160 bytes.

Tested only on a PixRacer to make sure it still found and configured a uBlox.

*not* tested on f103-GPS
