### PR TITLE
HAL_ChibiOS: removed SPI devices on f103-periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/f103-GPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f103-GPS/hwdef.dat
@@ -5,10 +5,6 @@ define HAL_CAN_DEFAULT_NODE_ID 0
 
 define CAN_APP_NODE_NAME "org.ardupilot.ap_periph_gps"
 
-# added rm3100 mag on SPI
-SPIDEV rm3100 SPI1 DEVID1 MAG_CS MODE0 1*MHZ 1*MHZ
-COMPASS RM3100 SPI:rm3100 false ROTATION_NONE
-
 # and support all external compass types
 define HAL_PROBE_EXTERNAL_I2C_COMPASSES
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/f103-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f103-periph/hwdef.dat
@@ -50,11 +50,6 @@ PB7 I2C1_SDA I2C1
 
 PB0 MAG_CS CS
 
-# spi bus for compass
-PA5 SPI1_SCK SPI1
-PA6 SPI1_MISO SPI1
-PA7 SPI1_MOSI SPI1
-
 # analog input
 # PA5 VIN5 ADC1
 define HAL_USE_ADC TRUE


### PR DESCRIPTION
these are unused and saves us a couple of k of flash