### PR TITLE
Plane: added constrain on vectored yaw

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -386,8 +386,8 @@ void QuadPlane::tiltrotor_vectored_yaw(void)
             yaw_out /= plane.channel_rudder->get_range();
             float yaw_range = zero_out;
 
-            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft,  1000 * (base_output + yaw_out * yaw_range));
-            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 1000 * (base_output - yaw_out * yaw_range));
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft,  1000 * constrain_float(base_output + yaw_out * yaw_range,0,1));
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 1000 * constrain_float(base_output - yaw_out * yaw_range,0,1));
         }
         return;
     }


### PR DESCRIPTION
prevents a wrap on extreme values

Co-authored-by: Kris <kris968658@gmail.com>