### PR TITLE
AP_NavEKF_Source: remove unused setVelZSource

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -62,7 +62,6 @@ public:
     // get/set velocity source
     SourceXY getVelXYSource() const { return _active_source_set.velxy; }
     SourceZ getVelZSource() const { return _active_source_set.velz; }
-    void setVelZSource(SourceZ source) { _active_source_set.velz = source; }
 
     // true/false of whether velocity source should be used
     bool useVelXYSource(SourceXY velxy_source) const;


### PR DESCRIPTION
This is a follow-up to PR https://github.com/ArduPilot/ardupilot/pull/15815 and removes the now unused AP_NavEKF_Source::setVelZSource() method.

This method was used to allow the EKF to set the VelZ source to None if the GPS couldn't provide the vertical velocity.