### PR TITLE
Copter: payload place fixups

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -382,7 +382,6 @@ void ModeAuto::payload_place_start()
 
     // call location specific place start function
     payload_place_start(stopping_point);
-
 }
 
 // returns true if pilot's yaw input should be used to adjust vehicle's heading
@@ -1024,9 +1023,10 @@ void ModeAuto::payload_place_run()
     case PayloadPlaceStateType_Releasing:
     case PayloadPlaceStateType_Released:
     case PayloadPlaceStateType_Ascending_Start:
+        return payload_place_run_loiter();
     case PayloadPlaceStateType_Ascending:
     case PayloadPlaceStateType_Done:
-        return payload_place_run_loiter();
+        return wp_run();
     }
 }
 
@@ -1056,13 +1056,6 @@ void ModeAuto::payload_place_run_loiter()
 {
     // loiter...
     land_run_horizontal_control();
-
-    // run loiter controller
-    loiter_nav->update();
-
-    // call attitude controller
-    const float target_yaw_rate = 0;
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
 
     // call position controller
     pos_control->update_z_controller();
@@ -1593,7 +1586,7 @@ bool ModeAuto::verify_payload_place()
     const uint16_t placed_time = 500; // how long we have to be below a throttle threshold before considering placed
 
     const float current_throttle_level = motors->get_throttle();
-    const uint32_t now =  AP_HAL::millis();
+    const uint32_t now = AP_HAL::millis();
 
     // if we discover we've landed then immediately release the load:
     if (copter.ap.land_complete) {
@@ -1603,7 +1596,7 @@ bool ModeAuto::verify_payload_place()
         case PayloadPlaceStateType_Calibrating_Hover:
         case PayloadPlaceStateType_Descending_Start:
         case PayloadPlaceStateType_Descending:
-            gcs().send_text(MAV_SEVERITY_INFO, "NAV_PLACE: landed");
+            gcs().send_text(MAV_SEVERITY_INFO, "PayloadPlace: landed");
             nav_payload_place.state = PayloadPlaceStateType_Releasing_Start;
             break;
         case PayloadPlaceStateType_Releasing_Start:


### PR DESCRIPTION
This PR makes the following small improvements to Copter's PackagePlace mission command handling:

- Two states "Ascending" and "Done" are handled using wp_run() instead of payload_place_run_loiter().  These two stages are using the wp_nav controller to climb so it is important that wp_nav.update() gets called.
- payload_place_run_loiter() loses a redundant call to loiter_nav->update() and attitude_control.
- message sent to user when vehicle lands is prefixed with "PayloadPlace:" instead of "NAV_PLACE:".  The mission command is "NAV_PAYLOAD_PLACE" so it could be argued either way but I think "PayloadPlace" takes up less room and is closer to the command name.

Below are screenshots of the vehicle's altitude before and after this change using the Copter.PayLoadPlaceMission autotest

![payload-place-before-after](https://user-images.githubusercontent.com/1498098/101116343-40483d80-3628-11eb-889d-7d344fbba599.png)

This issue was discovered as part of the S-Curve PR https://github.com/ArduPilot/ardupilot/pull/15896

As a side note, I really don't think it's good that package place is reusing the land controller.  This could lead to odd behaviour like the pilot cancelling the descent by raising the throttle which could then automatically switch the vehicle to Loiter mode.

Also it's not great that much of the logic is done within the verify_payload_place method.  I'd prefer if verify only does verification of whether the command is complete or not rather than taking responsibility for changing states.  It is better if we keep the state machine all together in the payload_place_run() method.