### PR TITLE
APM_Control: prevent divide by zero on YawController

### DIFF
--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -152,6 +152,9 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
     }
 	
     // Scale the integration limit
+    if (is_zero(scaler)) {
+        scaler = 1.0f;
+    }
     float intLimScaled = _imax * 0.01f / (_K_D * scaler * scaler);
 
     // Constrain the integrator state


### PR DESCRIPTION
Append with XPlane see https://discuss.ardupilot.org/t/arduplane-sitl-floating-point-exception/64241
I am not sure of my solution. Better fix welcome.