### PR TITLE
AP_HAL_ChibiOS: disable HAL_SUPPORT_RCOUT_SERIAL

### DIFF
--- a/libraries/AP_HAL/board/chibios.h
+++ b/libraries/AP_HAL/board/chibios.h
@@ -105,7 +105,7 @@
 
 // we support RC serial for BLHeli pass-thru
 #ifndef HAL_SUPPORT_RCOUT_SERIAL
-#define HAL_SUPPORT_RCOUT_SERIAL 1
+#define HAL_SUPPORT_RCOUT_SERIAL !defined(HAL_BUILD_AP_PERIPH)
 #endif
 
 // by default assume first I2C bus is internal

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-periph/hwdef.dat
@@ -54,8 +54,6 @@ define HAL_BARO_ALLOW_INIT_NO_BARO
 
 define HAL_PERIPH_ENABLE_BATTERY
 
-define HAL_SUPPORT_RCOUT_SERIAL 0
-
 define HAL_CAN_DEFAULT_NODE_ID 0
 
 define CAN_APP_NODE_NAME "org.ardupilot.CubeBlack-periph"

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph/hwdef.dat
@@ -47,8 +47,6 @@ define HAL_BARO_ALLOW_INIT_NO_BARO
 
 define HAL_PERIPH_ENABLE_BATTERY
 
-define HAL_SUPPORT_RCOUT_SERIAL 0
-
 define HAL_CAN_DEFAULT_NODE_ID 0
 
 define CAN_APP_NODE_NAME "org.ardupilot.CubeOrange-periph"


### PR DESCRIPTION
Any AP_Periph that is using ```HAL_PERIPH_ENABLE_BATTERY``` also needs to disable HAL_SUPPORT_RCOUT_SERIAL because it uses BL_Heli which is not yet supported and currently kills the build. This PR makes that as the default for all AP_Periph and also removes the define in CubeBlack/Orange-periph.

When support is added to AP_Peroph in the future, this PR makes it easier to enable-to-all or enable per-target which are both better than what we have now (enable for all, which breaks it)