### PR TITLE
AP_GPS: Change the range to 5 Hz only(NFC)

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -188,8 +188,8 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @DisplayName: GPS update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz(default) is not allowed. Raising the rate above 5Hz usually provides little benefit and for some GPS (eg Ublox M9N) can severely impact performance.
     // @Units: ms
-    // @Values: 100:10Hz,125:8Hz,200:5Hz
-    // @Range: 50 200
+    // @Values: 200:5Hz
+    // @Range: 200 200
     // @User: Advanced
     AP_GROUPINFO("RATE_MS", 14, AP_GPS, _rate_ms[0], 200),
 
@@ -198,8 +198,8 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @DisplayName: GPS 2 update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz(default) is not allowed. Raising the rate above 5Hz usually provides little benefit and for some GPS (eg Ublox M9N) can severely impact performance.
     // @Units: ms
-    // @Values: 100:10Hz,125:8Hz,200:5Hz
-    // @Range: 50 200
+    // @Values: 200:5Hz
+    // @Range: 200 200
     // @User: Advanced
     AP_GROUPINFO("RATE_MS2", 15, AP_GPS, _rate_ms[1], 200),
 #endif


### PR DESCRIPTION
I know of a device with a GNSS update cycle of 10Hz and 20Hz.
I looked at the description and understood that it makes no sense, except for 5Hz.
I let the UI warn me if I choose or set anything other than 5Hz.
