### PR TITLE
Emit an EKF status report per core

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4485,7 +4485,8 @@ Also, ignores heartbeats not from our target system'''
                           mavutil.mavlink.ESTIMATOR_VELOCITY_HORIZ |
                           mavutil.mavlink.ESTIMATOR_VELOCITY_VERT |
                           mavutil.mavlink.ESTIMATOR_POS_HORIZ_REL |
-                          mavutil.mavlink.ESTIMATOR_PRED_POS_HORIZ_REL)
+                          mavutil.mavlink.ESTIMATOR_PRED_POS_HORIZ_REL |
+                          mavutil.mavlink.EKF_IS_PRIMARY)
         # none of these bits must be set for arming to happen:
         error_bits = (mavutil.mavlink.ESTIMATOR_CONST_POS_MODE |
                       mavutil.mavlink.ESTIMATOR_ACCEL_ERROR)

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1894,7 +1894,7 @@ void AP_AHRS_NavEKF::send_ekf_status_report(mavlink_channel_t chan) const
     switch (ekf_type()) {
     case EKFType::NONE:
         // send zero status report
-        mavlink_msg_ekf_status_report_send(chan, 0, 0, 0, 0, 0, 0, 0);
+        mavlink_msg_ekf_status_report_send(chan, 0, 0, 0, 0, 0, 0, 0, 0);
         break;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -1911,8 +1911,9 @@ void AP_AHRS_NavEKF::send_ekf_status_report(mavlink_channel_t chan) const
         EKF_POS_VERT_AGL | /* Set if EKF's vertical position (above ground) estimate is good. | */
         //EKF_CONST_POS_MODE | /* EKF is in constant position mode and does not know it's absolute or relative position. | */
         EKF_PRED_POS_HORIZ_REL | /* Set if EKF's predicted horizontal position (relative) estimate is good. | */
-        EKF_PRED_POS_HORIZ_ABS; /* Set if EKF's predicted horizontal position (absolute) estimate is good. | */
-        mavlink_msg_ekf_status_report_send(chan, flags, 0, 0, 0, 0, 0, 0);
+        EKF_PRED_POS_HORIZ_ABS | /* Set if EKF's predicted horizontal position (absolute) estimate is good. | */
+        EKF_IS_PRIMARY;  //set if this core is the current primary core
+        mavlink_msg_ekf_status_report_send(chan, flags, 0, 0, 0, 0, 0, 0, 0);
         }
         break;
 #endif

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1370,9 +1370,16 @@ void  NavEKF2::getFilterGpsStatus(int8_t instance, nav_gps_status &status) const
 // send an EKF_STATUS_REPORT message to GCS
 void NavEKF2::send_status_report(mavlink_channel_t chan) const
 {
-    if (core) {
-        core[primary].send_status_report(chan);
+    if (!core) {
+        return;
     }
+    for (uint8_t i=0; i<num_cores; i++) {
+        if (i == primary) {
+            continue;
+        }
+        core[i].send_status_report(chan);
+    }
+    core[primary].send_status_report(chan);
 }
 
 // provides the height limit to be observed by the control loops

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -551,6 +551,12 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan) const
     if (!filterStatus.flags.initalized) {
         flags |= EKF_UNINITIALIZED;
     }
+    if (filterStatus.flags.gps_glitching) {
+        flags |= EKF_GPS_GLITCHING;
+    }
+    if (core_index == frontend->getPrimaryCoreIndex()) {
+        flags |= EKF_IS_PRIMARY;
+    }
 
     // get variances
     float velVar, posVar, hgtVar, tasVar;
@@ -571,7 +577,7 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan) const
     }
 
     // send message
-    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, mag_max, temp, tasVar);
+    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, mag_max, temp, tasVar, core_index);
 }
 
 // report the reason for why the backend is refusing to initialise

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1812,9 +1812,16 @@ void  NavEKF3::getFilterGpsStatus(int8_t instance, nav_gps_status &status) const
 // send an EKF_STATUS_REPORT message to GCS
 void NavEKF3::send_status_report(mavlink_channel_t chan) const
 {
-    if (core) {
-        core[primary].send_status_report(chan);
+    if (!core) {
+        return;
     }
+    for (uint8_t i=0; i<num_cores; i++) {
+        if (i == primary) {
+            continue;
+        }
+        core[i].send_status_report(chan);
+    }
+    core[primary].send_status_report(chan);
 }
 
 // provides the height limit to be observed by the control loops

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -610,7 +610,10 @@ void NavEKF3_core::send_status_report(mavlink_channel_t chan) const
         flags |= EKF_UNINITIALIZED;
     }
     if (filterStatus.flags.gps_glitching) {
-        flags |= (1<<15);
+        flags |= EKF_GPS_GLITCHING;
+    }
+    if (core_index == frontend->getPrimaryCoreIndex()) {
+        flags |= EKF_IS_PRIMARY;
     }
 
     // get variances
@@ -631,7 +634,7 @@ void NavEKF3_core::send_status_report(mavlink_channel_t chan) const
     const float mag_max = fmaxf(fmaxf(magVar.x,magVar.y),magVar.z);
 
     // send message
-    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, mag_max, temp, tasVar);
+    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, mag_max, temp, tasVar, core_index);
 }
 
 // report the reason for why the backend is refusing to initialise


### PR DESCRIPTION
I intend this to replace https://github.com/ArduPilot/ardupilot/pull/11901

One limitation this still has is that it doesn't nominate which EKF the cores belong to.

So if you're running EK3 as ride-along then you won't get its status reports.

We could add another field to the message to nominate the EKF, or permute the core numbers for the inactive estimators.

We emit the primary core last so that it's the last thing you'd see in things like `status EKF_STATUS_REPORT --verbose`
