### PR TITLE
AP_Periph: Prevent main loop stuck internal error when flashing bootloader

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -919,6 +919,7 @@ static void process1HzTasks(uint64_t timestamp_usec)
             fptr gptr = (fptr) (void *) foo;
             gptr();
         }
+        EXPECT_DELAY_MS(2000);
         hal.scheduler->delay(1000);
         AP_HAL::Util::FlashBootloader res = hal.util->flash_bootloader();
         switch (res) {

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -35,6 +35,7 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include "hwdef/common/stm32_util.h"
+#include "hwdef/common/flash.h"
 #include "hwdef/common/watchdog.h"
 #include <AP_Filesystem/AP_Filesystem.h>
 #include "shared_dma.h"
@@ -344,6 +345,11 @@ bool Scheduler::in_expected_delay(void) const
             return true;
         }
     }
+#ifndef HAL_NO_FLASH_SUPPORT
+    if (stm32_flash_recent_erase()) {
+        return true;
+    }
+#endif
     return false;
 }
 
@@ -393,7 +399,7 @@ void Scheduler::_monitor_thread(void *arg)
                 }
 #endif
         }
-        if (loop_delay >= 500) {
+        if (loop_delay >= 500 && !sched->in_expected_delay()) {
             // at 500ms we declare an internal error
             INTERNAL_ERROR(AP_InternalError::error_t::main_loop_stuck);
         }

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
@@ -27,6 +27,7 @@ bool stm32_flash_erasepage(uint32_t page);
 bool stm32_flash_write(uint32_t addr, const void *buf, uint32_t count);
 void stm32_flash_keep_unlocked(bool set);
 bool stm32_flash_ispageerased(uint32_t page);
+bool stm32_flash_recent_erase(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
We expect the whole CPU to stop when erasing a page, so always expect a delay