### PR TITLE
Add checks for MAVLink RangeFinder's min/max fields

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
@@ -56,9 +56,9 @@ bool AP_RangeFinder_Backend::has_data() const {
 void AP_RangeFinder_Backend::update_status()
 {
     // check distance
-    if ((int16_t)state.distance_cm > params.max_distance_cm) {
+    if ((int16_t)state.distance_cm > max_distance_cm()) {
         set_status(RangeFinder::Status::OutOfRangeHigh);
-    } else if ((int16_t)state.distance_cm < params.min_distance_cm) {
+    } else if ((int16_t)state.distance_cm < min_distance_cm()) {
         set_status(RangeFinder::Status::OutOfRangeLow);
     } else {
         set_status(RangeFinder::Status::Good);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -39,8 +39,8 @@ public:
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }
     uint16_t voltage_mv() const { return state.voltage_mv; }
-    int16_t max_distance_cm() const { return params.max_distance_cm; }
-    int16_t min_distance_cm() const { return params.min_distance_cm; }
+    virtual int16_t max_distance_cm() const { return params.max_distance_cm; }
+    virtual int16_t min_distance_cm() const { return params.min_distance_cm; }
     int16_t ground_clearance_cm() const { return params.ground_clearance_cm; }
     MAV_DISTANCE_SENSOR get_mav_distance_sensor_type() const;
     RangeFinder::Status status() const;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
@@ -16,33 +16,6 @@
 #include "AP_RangeFinder_MAVLink.h"
 #include <AP_HAL/AP_HAL.h>
 
-
-
-extern const AP_HAL::HAL& hal;
-
-/*
-   The constructor also initialises the rangefinder. Note that this
-   constructor is not called until detect() returns true, so we
-   already know that we should setup the rangefinder
-*/
-AP_RangeFinder_MAVLink::AP_RangeFinder_MAVLink(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
-    AP_RangeFinder_Backend(_state, _params)
-{
-    state.last_reading_ms = AP_HAL::millis();
-    distance_cm = 0;
-}
-
-/*
-   detect if a MAVLink rangefinder is connected. We'll detect by
-   checking a parameter.
-*/
-bool AP_RangeFinder_MAVLink::detect()
-{
-    // Assume that if the user set the RANGEFINDER_TYPE parameter to MAVLink,
-    // there is an attached MAVLink rangefinder
-    return true;
-}
-
 /*
    Set the distance based on a MAVLINK message
 */

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
@@ -28,8 +28,8 @@ void AP_RangeFinder_MAVLink::handle_msg(const mavlink_message_t &msg)
     if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_270) {
         state.last_reading_ms = AP_HAL::millis();
         distance_cm = packet.current_distance;
+        sensor_type = (MAV_DISTANCE_SENSOR)packet.type;
     }
-    sensor_type = (MAV_DISTANCE_SENSOR)packet.type;
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
@@ -34,6 +34,30 @@ void AP_RangeFinder_MAVLink::handle_msg(const mavlink_message_t &msg)
     }
 }
 
+int16_t AP_RangeFinder_MAVLink::max_distance_cm() const
+{
+    if (_max_distance_cm == 0 && _min_distance_cm == 0) {
+        // we assume if both of these are zero that we ignore both
+        return params.max_distance_cm;
+    }
+
+    if (params.max_distance_cm < _max_distance_cm) {
+        return params.max_distance_cm;
+    }
+    return _max_distance_cm;
+}
+int16_t AP_RangeFinder_MAVLink::min_distance_cm() const
+{
+    if (_max_distance_cm == 0 && _min_distance_cm == 0) {
+        // we assume if both of these are zero that we ignore both
+        return params.min_distance_cm;
+    }
+    if (params.min_distance_cm > _min_distance_cm) {
+        return params.min_distance_cm;
+    }
+    return _min_distance_cm;
+}
+
 /*
    update the state of the sensor
 */

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
@@ -28,6 +28,8 @@ void AP_RangeFinder_MAVLink::handle_msg(const mavlink_message_t &msg)
     if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_270) {
         state.last_reading_ms = AP_HAL::millis();
         distance_cm = packet.current_distance;
+        _max_distance_cm = packet.max_distance;
+        _min_distance_cm = packet.min_distance;
         sensor_type = (MAV_DISTANCE_SENSOR)packet.type;
     }
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
@@ -23,8 +23,8 @@ public:
     // Get update from mavlink
     void handle_msg(const mavlink_message_t &msg) override;
 
-    int16_t max_distance_cm() const override { return _max_distance_cm; }
-    int16_t min_distance_cm() const override { return _min_distance_cm; }
+    int16_t max_distance_cm() const override;
+    int16_t min_distance_cm() const override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
@@ -23,6 +23,9 @@ public:
     // Get update from mavlink
     void handle_msg(const mavlink_message_t &msg) override;
 
+    int16_t max_distance_cm() const override { return _max_distance_cm; }
+    int16_t min_distance_cm() const override { return _min_distance_cm; }
+
 protected:
 
     MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
@@ -30,7 +33,11 @@ protected:
     }
 
 private:
+
+    // stored data from packet:
     uint16_t distance_cm;
+    uint16_t _max_distance_cm;
+    uint16_t _min_distance_cm;
 
     // start a reading
     static bool start_reading(void);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
@@ -11,10 +11,11 @@ class AP_RangeFinder_MAVLink : public AP_RangeFinder_Backend
 
 public:
     // constructor
-    AP_RangeFinder_MAVLink(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
+    using AP_RangeFinder_Backend::AP_RangeFinder_Backend;
 
-    // static detection function
-    static bool detect();
+    // Assume that if the user set the RANGEFINDER_TYPE parameter to MAVLink,
+    // there is an attached MAVLink rangefinder
+    static bool detect() { return true; }
 
     // update state
     void update(void) override;

--- a/libraries/SITL/SIM_RF_MAVLink.cpp
+++ b/libraries/SITL/SIM_RF_MAVLink.cpp
@@ -42,7 +42,7 @@ uint32_t RF_MAVLink::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t bu
     const mavlink_distance_sensor_t distance_sensor{
         time_boot_ms: AP_HAL::millis(),
         min_distance: 10, // cm
-        max_distance: 10, // cm
+        max_distance: 1000, // cm
         current_distance: alt_cm,
         type: 0,
         id: 72, // ID


### PR DESCRIPTION
We consume `DISTANCE_SENSOR` messages in ArduPilot for a "mavlink rangefinder".

At the moment we ignore the `min_distance` and `max_distance` fields in the message.

This PR changes that.

More autotests are added to make sure we honour those parameters.

This replaces https://github.com/ArduPilot/ardupilot/pull/9338/files by @gs-niteesh - @OXINARF had asked for something similar to this (state doesn't hold min/max, so they're held as attributes in the mavlink subclass instead in this PR).
