### PR TITLE
AP_AHRS: mark get_hagl as WARN_IF_UNUSED

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -254,7 +254,7 @@ public:
     virtual bool get_position(struct Location &loc) const = 0;
 
     // get latest altitude estimate above ground level in meters and validity flag
-    virtual bool get_hagl(float &height) const { return false; }
+    virtual bool get_hagl(float &height) const WARN_IF_UNUSED { return false; }
 
     // return a wind estimation vector, in m/s
     virtual Vector3f wind_estimate(void) const = 0;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -83,7 +83,7 @@ public:
     bool get_position(struct Location &loc) const override;
 
     // get latest altitude estimate above ground level in meters and validity flag
-    bool get_hagl(float &hagl) const override;
+    bool get_hagl(float &hagl) const override WARN_IF_UNUSED;
 
     // status reporting of estimated error
     float           get_error_rp() const override;


### PR DESCRIPTION
Replaces https://github.com/ArduPilot/ardupilot/pull/13197

Only one caller, and it checks.   Well, that and a scripting binding...
