### PR TITLE
Bugfix: Implement roll control on Solo gimbal

### DIFF
--- a/libraries/AP_Mount/SoloGimbal.h
+++ b/libraries/AP_Mount/SoloGimbal.h
@@ -83,7 +83,7 @@ private:
     void update_joint_angle_est();
 
     Vector3f get_ang_vel_dem_yaw(const Quaternion &quatEst);
-    Vector3f get_ang_vel_dem_tilt(const Quaternion &quatEst);
+    Vector3f get_ang_vel_dem_roll_tilt(const Quaternion &quatEst);
     Vector3f get_ang_vel_dem_feedforward(const Quaternion &quatEst);
     Vector3f get_ang_vel_dem_gyro_bias();
     Vector3f get_ang_vel_dem_body_lock();


### PR DESCRIPTION
I was testing https://github.com/ArduPilot/ardupilot/pull/15878 and noticed that Solo was not changing the roll angle of the gimbal according to what was commanded. Upon inspecting the code, I saw that it just ignored the roll input, despite the vehicle's capability of processing the command.

This fixes the lack of roll control for Solo, making it compliant with the mavlink DO_MOUNT_CONTROL specification.