### PR TITLE
AP_NavEKF3: don't accept ExtNavVelData until initialised

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1032,6 +1032,10 @@ void NavEKF3_core::writeExtNavVelData(const Vector3f &vel, float err, uint32_t t
         return;
     }
 
+    if (!statesInitialised) {
+        return;
+    }
+
     if ((timeStamp_ms - extNavVelMeasTime_ms) < frontend->extNavIntervalMin_ms) {
         return;
     }


### PR DESCRIPTION
This same code is in the other write methods for external data.
