### PR TITLE
AP_Param: fixed lockup in scripting due to save queue

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1165,7 +1165,7 @@ void AP_Param::save(bool force_save)
     p.force_save = force_save;
     while (!save_queue.push(p)) {
         // if we can't save to the queue
-        if (hal.util->get_soft_armed()) {
+        if (hal.util->get_soft_armed() || !hal.scheduler->in_main_thread()) {
             // if we are armed then don't sleep, instead we lose the
             // parameter save
             return;


### PR DESCRIPTION
this is a quick fix for a lockup in scripting due to the mission API
holding the scheduler semaphore when it is updating the mission count
parameter. 
Note that this bug is much worse on SITL as the IO thread is in the same thread as main thread. On a real board the impact depends on progress on the IO thread

The problem with this fix is it means the MIS_TOTAL may not be saved, so on reboot it could be wrong

Fixes #15997

some alternative approaches:
 - lose the scheduler semaphore in the save of MIS_TOTAL
 - add a is_owner() API to semaphores, and don't wait if we hold scheduler semaphore
