### PR TITLE
AP_BattMonitor: use of soc in UAVCAN BatteryInfo

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -47,7 +47,7 @@ public:
     virtual bool has_temperature() const { return false; }
 
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
-    uint8_t capacity_remaining_pct() const;
+    virtual uint8_t capacity_remaining_pct() const;
 
     // return true if cycle count can be provided and fills in cycles argument
     virtual bool get_cycle_count(uint16_t &cycles) const { return false; }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -169,6 +169,13 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("BUS", 20, AP_BattMonitor_Params, _i2c_bus, 0),
 
+    // @Param: OPTIONS
+    // @DisplayName: Battery monitor options
+    // @Description: This sets options to change the behaviour of the battery monitor
+    // @Bitmask: 1:IgnoreUAVCAN SoC
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -17,6 +17,9 @@ public:
         BattMonitor_LowVoltageSource_Raw            = 0,
         BattMonitor_LowVoltageSource_SagCompensated = 1
     };
+    enum class Options : uint8_t {
+        Ignore_UAVCAN_SoC = (1U<<0),
+    };
 
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }
 
@@ -40,4 +43,5 @@ public:
     AP_Int32 _arming_minimum_capacity;  /// capacity level required to arm
     AP_Float _arming_minimum_voltage;   /// voltage level required to arm
     AP_Int8  _i2c_bus;                  /// I2C bus number
+    AP_Int32 _options;                  /// Options
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
@@ -24,6 +24,9 @@ public:
     /// Read the battery voltage and current.  Should be called at 10hz
     void read() override;
 
+    /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
+    uint8_t capacity_remaining_pct() const override;
+
     bool has_current() const override {
         return true;
     }
@@ -47,4 +50,5 @@ private:
 
     AP_UAVCAN* _ap_uavcan;
     uint8_t _node_id;
+    uint8_t _soc;
 };


### PR DESCRIPTION
Requires the use of soc in UAVCAN BatteryInfo.