### PR TITLE
EKF: Fixed use of airspeed sensor when unhealthy

### DIFF
--- a/libraries/AP_DAL/AP_DAL_Airspeed.h
+++ b/libraries/AP_DAL/AP_DAL_Airspeed.h
@@ -15,6 +15,10 @@ public:
     bool healthy(uint8_t i) const {
         return _RASI[i].healthy;
     }
+    // return health status of primary sensor
+    bool healthy() const {
+        return healthy(get_primary());
+    }
 
     // return true if airspeed is enabled, and airspeed use is set
     bool use(uint8_t i) const {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -755,8 +755,9 @@ void NavEKF2_core::readAirSpdData()
     // know a new measurement is available
     const auto *aspeed = dal.airspeed();
     if (aspeed &&
-            aspeed->use() &&
-            aspeed->last_update_ms() != timeTasReceived_ms) {
+        aspeed->use() &&
+        aspeed->healthy() &&
+        aspeed->last_update_ms() != timeTasReceived_ms) {
         tasDataNew.tas = aspeed->get_airspeed() * dal.get_EAS2TAS();
         timeTasReceived_ms = aspeed->last_update_ms();
         tasDataNew.time_ms = timeTasReceived_ms - frontend->tasDelay_ms;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -815,6 +815,7 @@ void NavEKF3_core::readAirSpdData()
     const auto *airspeed = dal.airspeed();
     if (airspeed &&
         airspeed->use(selected_airspeed) &&
+        airspeed->healthy(selected_airspeed) &&
         (airspeed->last_update_ms(selected_airspeed) - timeTasReceived_ms) > frontend->sensorIntervalMin_ms) {
         tasDataNew.tas = airspeed->get_airspeed(selected_airspeed) * dal.get_EAS2TAS();
         timeTasReceived_ms = airspeed->last_update_ms(selected_airspeed);


### PR DESCRIPTION
if the sensor died completely we could keep fusing the stale value, as the last_update_ms() is the time of the attempted read, not the time of the valid value
thanks to @giacomo892 for noticing this!
