### PR TITLE
Rover: simple mode handles two paddle input

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -163,8 +163,16 @@ void Mode::get_pilot_desired_lateral(float &lateral_out)
 void Mode::get_pilot_desired_heading_and_speed(float &heading_out, float &speed_out)
 {
     // get steering and throttle in the -1 to +1 range
-    const float desired_steering = constrain_float(rover.channel_steer->norm_input_dz(), -1.0f, 1.0f);
-    const float desired_throttle = constrain_float(rover.channel_throttle->norm_input_dz(), -1.0f, 1.0f);
+    float desired_steering = constrain_float(rover.channel_steer->norm_input_dz(), -1.0f, 1.0f);
+    float desired_throttle = constrain_float(rover.channel_throttle->norm_input_dz(), -1.0f, 1.0f);
+
+    // handle two paddle input
+    if ((enum pilot_steer_type_t)rover.g.pilot_steer_type.get() == PILOT_STEER_TYPE_TWO_PADDLES) {
+        const float left_paddle = desired_steering;
+        const float right_paddle = desired_throttle;
+        desired_steering = (left_paddle - right_paddle) * 0.5f;
+        desired_throttle = (left_paddle + right_paddle) * 0.5f;
+    }
 
     // calculate angle of input stick vector
     heading_out = wrap_360_cd(atan2f(desired_steering, desired_throttle) * DEGX100);


### PR DESCRIPTION
This PR improves support for two paddle input in [simple mode](https://ardupilot.org/rover/docs/simple-mode.html) and resolves issue https://github.com/ArduPilot/ardupilot/issues/15949.

With the more common separate steering+throttle inputs, simple mode is quite intuitive but with two paddle input the controls are like this:

- both paddles forward: vehicles moves away from pilot
- both paddles back: vehicles returns towards pilot
- left paddle at full, right paddle in center: moves diagonally away and right
- left paddle at full, right paddle pulled back: moves right
- left paddle at center, right paddle at full: moves diagonally away and left
- left paddle pulled back, right paddle at full: moves left

This is quite an edge case that no users have noticed but as part of PR https://github.com/ArduPilot/ardupilot/issues/15950 I noticed the issue.  two-paddle input in simple mode is unintuitive but this is still an improvement over what is in master.

This has been tested in SITL successfully.