### PR TITLE
autotest: print exception if caught in test_alt_estimate_prearm

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5430,6 +5430,8 @@ class AutoTestCopter(AutoTest):
             except AutoTestTimeoutException:
                 self.progress("PASS not able to set mode without Position : %s" % "ALT_HOLD")
         except Exception as e:
+            self.progress("Exception caught: %s" % (
+                self.get_exception_stacktrace(e)))
             ex = e
         self.context_pop()
         self.disarm_vehicle(force=True)


### PR DESCRIPTION
Description from Randy:

This adds some additional output to the test_alt_estimate_prearm check to make it easier for developers to figure out why it is failing.  Below is a screenshot of the output

![image](https://user-images.githubusercontent.com/1498098/101567123-98f64c80-3a13-11eb-9256-9b584fe2c2d5.png)

