### PR TITLE
Plane: remove unnecessary ::cork() in init

### DIFF
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -105,8 +105,6 @@ void Plane::init_rc_out_aux()
 {
     SRV_Channels::enable_aux_servos();
 
-    SRV_Channels::cork();
-    
     servos_output();
     
     // setup PWM values to send if the FMU firmware dies


### PR DESCRIPTION
void Plane::init_rc_out_aux() calls cork() then calls servos_output() where the first thing that does is ::cork()