### PR TITLE
AP_Periph: add battery monitor to AP_Periph README

### DIFF
--- a/Tools/AP_Periph/README.md
+++ b/Tools/AP_Periph/README.md
@@ -30,6 +30,7 @@ UAVCAN sensor types. Support is included for:
  - Airspeed sensors (I2C)
  - Rangefinders (UART or I2C)
  - ADSB (Ping ADSB receiver on UART)
+ - Battery Monitor (Analog, I2C/SMBus, UART)
  - LEDs (GPIO, I2C or WS2812 serial)
  - Safety LED and Safety Switch
  - Buzzer (tonealarm or simple GPIO)


### PR DESCRIPTION
Add battery monitor to AP_Periph README as a supported feature. It was merged in PR https://github.com/ArduPilot/ardupilot/pull/15865