### PR TITLE
Plane: added Q_PRETRANS_TIME for pre-transition time

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -481,6 +481,9 @@ private:
         // are we headed to the land approach waypoint? Works for any nav type
         bool wp_is_land_approach;
 
+        // are we headed to the vtol land approach waypoint?
+        bool wp_is_vtol_land_approach;
+        
         // should we fly inverted?
         bool inverted_flight;
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -31,6 +31,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         const uint16_t next_index = mission.get_current_nav_index() + 1;
         auto_state.wp_is_land_approach = mission.get_next_nav_cmd(next_index, next_nav_cmd) && (next_nav_cmd.id == MAV_CMD_NAV_LAND) &&
             !quadplane.is_vtol_land(next_nav_cmd.id);
+        auto_state.wp_is_vtol_land_approach = mission.get_next_nav_cmd(next_index, next_nav_cmd) && quadplane.is_vtol_land(next_nav_cmd.id);
     }
 
     switch(cmd.id) {

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -369,6 +369,9 @@ private:
     AP_Float acro_pitch_rate;
     AP_Float acro_yaw_rate;
 
+    // time before transition that we start motors
+    AP_Float pre_transition_time;
+
     // time we last got an EKF yaw reset
     uint32_t ekfYawReset_ms;
 
@@ -424,6 +427,9 @@ private:
 
     // are we in a guided takeoff?
     bool guided_takeoff:1;
+
+    // true when in pre-transition assist
+    bool in_pre_assist:1;
     
     struct {
         // time when motors reached lower limit


### PR DESCRIPTION
this allows for a pre-transition enabling of the VTOL motors. This is
useful to allow a pilot to pre-check the operation of the VTOL motors
before committing to a landing