### PR TITLE
AP_Periph: allow uploader.py to reboot AP_Periph

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -46,6 +46,9 @@ public:
 
     void load_parameters();
 
+    void check_for_serial_reboot_cmd(const int8_t serial_index);
+    void reboot(bool hold_in_bootloader);
+
     AP_SerialManager serial_manager;
 
 #ifdef HAL_PERIPH_ENABLE_GPS

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph/hwdef.dat
@@ -67,3 +67,9 @@ MAIN_STACK 0x2000
 PROCESS_STACK 0x6000
 
 define HAL_CAN_DRIVER_DEFAULT 1
+
+# listen for reboot command from uploader.py script
+# undefine to disable. Use -1 to allow on all ports, otherwise serial number index defined in SERIAL_ORDER starting at 0
+define HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_CMD_PORT 0
+ 
+


### PR DESCRIPTION
This allows uploader.py to trigger a reboot in AP_Periph when using ```./waf AP_Periph --upload```

This works as-is but it will work well with PR https://github.com/ArduPilot/ardupilot/pull/16033 