### PR TITLE
Reduce invensense FIFO buffer size to reduce DMA contention

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -55,7 +55,7 @@ extern const AP_HAL::HAL& hal;
 #include "AP_InertialSensor_Invensense_registers.h"
 
 #define MPU_SAMPLE_SIZE 14
-#define MPU_FIFO_BUFFER_LEN 16
+#define MPU_FIFO_BUFFER_LEN 8
 
 #define int16_val(v, idx) ((int16_t)(((uint16_t)v[2*idx] << 8) | v[2*idx+1]))
 #define uint16_val(v, idx)(((uint16_t)v[2*idx] << 8) | v[2*idx+1])

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
@@ -51,7 +51,7 @@ static const float GYRO_SCALE = (0.0174532f / 16.4f);
 #include "AP_InertialSensor_Invensensev2_registers.h"
 
 #define INV2_SAMPLE_SIZE 14
-#define INV2_FIFO_BUFFER_LEN 16
+#define INV2_FIFO_BUFFER_LEN 8
 
 #define int16_val(v, idx) ((int16_t)(((uint16_t)v[2*idx] << 8) | v[2*idx+1]))
 #define uint16_val(v, idx)(((uint16_t)v[2*idx] << 8) | v[2*idx+1])


### PR DESCRIPTION
We can reduce the FIFO buffer size to reduce the DMA duty cycle on the IMU.

Tested on:
- Durandal
- OmnibusF4Pro
- Pixhawk1-1M