### PR TITLE
Tradheli: New integrator management implementation

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -38,7 +38,6 @@ float Copter::get_pilot_desired_yaw_rate(int16_t stick_angle)
 //  called at 100hz
 void Copter::update_throttle_hover()
 {
-#if FRAME_CONFIG != HELI_FRAME
     // if not armed or landed exit
     if (!motors->armed() || ap.land_complete) {
         return;
@@ -57,16 +56,15 @@ void Copter::update_throttle_hover()
     // get throttle output
     float throttle = motors->get_throttle();
 
-    // calc average throttle if we are in a level hover
+    // calc average throttle if we are in a level hover.  accounts for heli hover roll trim
     if (throttle > 0.0f && fabsf(inertial_nav.get_velocity_z()) < 60 &&
-        labs(ahrs.roll_sensor) < 500 && labs(ahrs.pitch_sensor) < 500) {
+        labs(ahrs.roll_sensor-attitude_control->get_roll_trim_cd()) < 500 && labs(ahrs.pitch_sensor) < 500) {
         // Can we set the time constant automatically
         motors->update_throttle_hover(0.01f);
 #if HAL_GYROFFT_ENABLED
         gyro_fft.update_freq_hover(0.01f, motors->get_throttle_out());
 #endif
     }
-#endif
 }
 
 // get_pilot_desired_climb_rate - transform pilot's throttle input to climb rate in cm/s

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -74,7 +74,14 @@ void Copter::check_dynamic_flight(void)
 void Copter::update_heli_control_dynamics(void)
 {
     // Use Leaky_I if we are not moving fast
-    attitude_control->use_leaky_i(!heli_flags.dynamic_flight);
+//    attitude_control->use_leaky_i(!heli_flags.dynamic_flight);
+    attitude_control->use_leaky_i(false);
+
+    if (ap.land_complete || ap.land_complete_maybe) {
+        motors->set_land_complete(true);
+    } else {
+        motors->set_land_complete(false);
+    }
 
     if (ap.land_complete || (is_zero(motors->get_desired_rotor_speed()))){
         // if we are landed or there is no rotor power demanded, decrement slew scalar

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -73,13 +73,18 @@ void Copter::check_dynamic_flight(void)
 // should be run between the rate controller and the servo updates.
 void Copter::update_heli_control_dynamics(void)
 {
-    // Use Leaky_I if we are not moving fast
-//    attitude_control->use_leaky_i(!heli_flags.dynamic_flight);
-    attitude_control->use_leaky_i(false);
 
-    if (ap.land_complete || ap.land_complete_maybe) {
-        motors->set_land_complete(true);
+    if (!motors->using_leaky_integrator()) {
+        //turn off leaky_I
+        attitude_control->use_leaky_i(false);
+        if (ap.land_complete || ap.land_complete_maybe) {
+            motors->set_land_complete(true);
+        } else {
+            motors->set_land_complete(false);
+        }
     } else {
+        // Use Leaky_I if we are not moving fast
+        attitude_control->use_leaky_i(!heli_flags.dynamic_flight);
         motors->set_land_complete(false);
     }
 

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -60,8 +60,8 @@ void Copter::update_land_detector()
     } else {
 
 #if FRAME_CONFIG == HELI_FRAME
-        // check that collective pitch is on lower limit (should be constrained by LAND_COL_MIN)
-        bool motor_at_lower_limit = motors->limit.throttle_lower;
+        // check that collective pitch is below mid collective (zero thrust) position
+        bool motor_at_lower_limit = (motors->get_below_mid_collective() && fabsf(ahrs.get_roll()) < M_PI/2.0f);
 #else
         // check that the average throttle output is near minimum (less than 12.5% hover throttle)
         bool motor_at_lower_limit = motors->limit.throttle_lower && attitude_control->is_throttle_mix_min();

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -47,7 +47,7 @@ void Copter::update_land_detector()
     } else if (ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME
         // if rotor speed and collective pitch are high then clear landing flag
-        if (motors->get_throttle() > get_non_takeoff_throttle() && !motors->limit.throttle_lower && motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
+        if (motors->get_takeoff_collective() && motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
 #else
         // if throttle output is high then clear landing flag
         if (motors->get_throttle() > get_non_takeoff_throttle()) {

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -502,7 +502,7 @@ void Mode::make_safe_spool_down()
     case AP_Motors::SpoolState::SHUT_DOWN:
     case AP_Motors::SpoolState::GROUND_IDLE:
         // relax controllers during idle states
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         attitude_control->set_yaw_target_to_current_heading();
         break;
 

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -34,7 +34,7 @@ void ModeAcro::run()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
         attitude_control->set_attitude_target_to_current_attitude();
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         break;
 
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -49,16 +49,16 @@ void ModeAcro_Heli::run()
         attitude_control->reset_rate_controller_I_terms();
         break;
     case AP_Motors::SpoolState::GROUND_IDLE:
-        // Landed
-        if (motors->init_targets_on_arming()) {
+        // If aircraft is landed, set target heading to current and reset the integrator
+        // Otherwise motors could be at ground idle for practice autorotation
+        if (copter.ap.land_complete) {
             attitude_control->set_attitude_target_to_current_attitude();
             attitude_control->reset_rate_controller_I_terms();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
-        // clear landing flag above zero throttle
-        if (!motors->limit.throttle_lower) {
-            set_land_complete(false);
+        if (copter.ap.land_complete) {
+            attitude_control->reset_rate_controller_I_terms();
         }
         break;
     case AP_Motors::SpoolState::SPOOLING_UP:

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -53,12 +53,12 @@ void ModeAcro_Heli::run()
         // Otherwise motors could be at ground idle for practice autorotation
         if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
             attitude_control->set_attitude_target_to_current_attitude();
-            attitude_control->reset_rate_controller_I_terms();
+            attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
         if (copter.ap.land_complete && !motors->using_leaky_integrator()) {
-            attitude_control->reset_rate_controller_I_terms();
+            attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;
     case AP_Motors::SpoolState::SPOOLING_UP:

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -51,13 +51,13 @@ void ModeAcro_Heli::run()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
-        if (copter.ap.land_complete) {
+        if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
             attitude_control->set_attitude_target_to_current_attitude();
             attitude_control->reset_rate_controller_I_terms();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
-        if (copter.ap.land_complete) {
+        if (copter.ap.land_complete && !motors->using_leaky_integrator()) {
             attitude_control->reset_rate_controller_I_terms();
         }
         break;

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -58,7 +58,7 @@ void ModeAltHold::run()
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         break;
 

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -60,7 +60,7 @@ void AutoTune::run()
         } else {
             copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
         }
-        copter.attitude_control->reset_rate_controller_I_terms();
+        copter.attitude_control->reset_rate_controller_I_terms_smoothly();
         copter.attitude_control->set_yaw_target_to_current_heading();
 
         float target_roll, target_pitch, target_yaw_rate;

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -98,7 +98,7 @@ void ModeDrift::run()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
         attitude_control->set_yaw_target_to_current_heading();
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         break;
 
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -298,7 +298,7 @@ void ModeFlowHold::run()
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         break;
 

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -154,7 +154,7 @@ void ModeLoiter::run()
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         loiter_nav->init_target();
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -155,7 +155,7 @@ void ModePosHold::run()
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
 
         // set poshold state to pilot override

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -106,7 +106,7 @@ void ModeSport::run()
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         break;
 

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -38,7 +38,7 @@ void ModeStabilize::run()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
         attitude_control->set_yaw_target_to_current_heading();
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         break;
 
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -58,12 +58,12 @@ void ModeStabilize_Heli::run()
         // Otherwise motors could be at ground idle for practice autorotation
         if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
             attitude_control->set_yaw_target_to_current_heading();
-            attitude_control->reset_rate_controller_I_terms();
+            attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
         if (copter.ap.land_complete && !motors->using_leaky_integrator()) {
-            attitude_control->reset_rate_controller_I_terms();
+            attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;
     case AP_Motors::SpoolState::SPOOLING_UP:

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -54,16 +54,16 @@ void ModeStabilize_Heli::run()
         attitude_control->reset_rate_controller_I_terms();
         break;
     case AP_Motors::SpoolState::GROUND_IDLE:
-        // Landed
-        if (motors->init_targets_on_arming()) {
+        // If aircraft is landed, set target heading to current and reset the integrator
+        // Otherwise motors could be at ground idle for practice autorotation
+        if (copter.ap.land_complete) {
             attitude_control->set_yaw_target_to_current_heading();
             attitude_control->reset_rate_controller_I_terms();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
-        // clear landing flag above zero throttle
-        if (!motors->limit.throttle_lower) {
-            set_land_complete(false);
+        if (copter.ap.land_complete) {
+            attitude_control->reset_rate_controller_I_terms();
         }
         break;
     case AP_Motors::SpoolState::SPOOLING_UP:

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -56,13 +56,13 @@ void ModeStabilize_Heli::run()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
-        if (copter.ap.land_complete) {
+        if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
             attitude_control->set_yaw_target_to_current_heading();
             attitude_control->reset_rate_controller_I_terms();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
-        if (copter.ap.land_complete) {
+        if (copter.ap.land_complete && !motors->using_leaky_integrator()) {
             attitude_control->reset_rate_controller_I_terms();
         }
         break;

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -141,7 +141,7 @@ void ModeSystemId::run()
         // init_targets_on_arming is always set true for multicopter.
         if (motors->init_targets_on_arming()) {
             attitude_control->set_yaw_target_to_current_heading();
-            attitude_control->reset_rate_controller_I_terms();
+            attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -364,7 +364,7 @@ void ModeZigZag::manual_control()
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->reset_rate_controller_I_terms_smoothly();
         loiter_nav->init_target();
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -179,6 +179,14 @@ void AC_AttitudeControl::reset_rate_controller_I_terms()
     get_rate_yaw_pid().reset_I();
 }
 
+// reset rate controller I terms smoothly to zero in 0.5 seconds
+void AC_AttitudeControl::reset_rate_controller_I_terms_smoothly()
+{
+    get_rate_roll_pid().reset_I_smoothly();
+    get_rate_pitch_pid().reset_I_smoothly();
+    get_rate_yaw_pid().reset_I_smoothly();
+}
+
 // The attitude controller works around the concept of the desired attitude, target attitude
 // and measured attitude. The desired attitude is the attitude input into the attitude controller
 // that expresses where the higher level code would like the aircraft to move to. The target attitude is moved

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -114,6 +114,9 @@ public:
     // reset rate controller I terms
     void reset_rate_controller_I_terms();
 
+    // reset rate controller I terms smoothly to zero in 0.5 seconds
+    void reset_rate_controller_I_terms_smoothly();
+
     // Sets attitude target to vehicle attitude
     void set_attitude_target_to_current_attitude() { _ahrs.get_quat_body_to_ned(_attitude_target_quat); }
 
@@ -312,6 +315,10 @@ public:
 
     // set_hover_roll_scalar - scales Hover Roll Trim parameter. To be used by vehicle code according to vehicle condition.
     virtual void set_hover_roll_trim_scalar(float scalar) {}
+
+    // Return angle in centidegrees to be added to roll angle for hover collective learn. Used by heli to counteract
+    // tail rotor thrust in hover. Overloaded by AC_Attitude_Heli to return angle.
+    virtual float get_roll_trim_cd() { return 0;}
 
     // passthrough_bf_roll_pitch_rate_yaw - roll and pitch are passed through directly, body-frame rate target for yaw
     virtual void passthrough_bf_roll_pitch_rate_yaw(float roll_passthrough, float pitch_passthrough, float yaw_rate_bf_cds) {};

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -386,13 +386,13 @@ void AC_AttitudeControl_Heli::rate_bf_to_motor_roll_pitch(const Vector3f &rate_r
     if (_flags_heli.leaky_i) {
         _pid_rate_roll.update_leaky_i(AC_ATTITUDE_HELI_RATE_INTEGRATOR_LEAK_RATE);
     }
-    float roll_pid = _pid_rate_roll.update_all(rate_roll_target_rads, rate_rads.x, _flags_heli.limit_roll) + _actuator_sysid.x;
+    float roll_pid = _pid_rate_roll.update_all(rate_roll_target_rads, rate_rads.x,  _motors.limit.roll) + _actuator_sysid.x;
 
     if (_flags_heli.leaky_i) {
         _pid_rate_pitch.update_leaky_i(AC_ATTITUDE_HELI_RATE_INTEGRATOR_LEAK_RATE);
     }
 
-    float pitch_pid = _pid_rate_pitch.update_all(rate_pitch_target_rads, rate_rads.y, _flags_heli.limit_pitch) + _actuator_sysid.y;
+    float pitch_pid = _pid_rate_pitch.update_all(rate_pitch_target_rads, rate_rads.y,  _motors.limit.pitch) + _actuator_sysid.y;
 
     // use pid library to calculate ff
     float roll_ff = _pid_rate_roll.get_ff();
@@ -448,7 +448,7 @@ float AC_AttitudeControl_Heli::rate_target_to_motor_yaw(float rate_yaw_actual_ra
         _pid_rate_yaw.update_leaky_i(AC_ATTITUDE_HELI_RATE_INTEGRATOR_LEAK_RATE);
     }
 
-    float pid = _pid_rate_yaw.update_all(rate_target_rads, rate_yaw_actual_rads, _flags_heli.limit_yaw) + _actuator_sysid.z;
+    float pid = _pid_rate_yaw.update_all(rate_target_rads, rate_yaw_actual_rads,  _motors.limit.yaw) + _actuator_sysid.z;
 
     // use pid library to calculate ff
     float vff = _pid_rate_yaw.get_ff()*_feedforward_scalar;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -89,6 +89,9 @@ public:
     // set_hover_roll_scalar - scales Hover Roll Trim parameter. To be used by vehicle code according to vehicle condition.
     void set_hover_roll_trim_scalar(float scalar) override {_hover_roll_trim_scalar = constrain_float(scalar, 0.0f, 1.0f);}
 
+    // get_roll_trim - angle in centi-degrees to be added to roll angle for learn hover collective. Used by helicopter to counter tail rotor thrust in hover
+    float get_roll_trim_cd() override { return constrain_float(_hover_roll_trim_scalar * _hover_roll_trim, -1000.0f,1000.0f);}
+
     // Set output throttle
     void set_throttle_out(float throttle_in, bool apply_angle_boost, float filt_cutoff) override;
 

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -264,6 +264,23 @@ void AC_PID::reset_I()
     _integrator = 0;
 }
 
+void AC_PID::reset_I_smoothly()
+{
+    float reset_time = AC_PID_RESET_TC * 3.0f;
+    uint64_t now = AP_HAL::micros64();
+
+    if ((now - _reset_last_update) > 5e5 ) {
+        _reset_counter = 0;
+    }
+    if ((float)_reset_counter < (reset_time/_dt)) {
+        _integrator = _integrator - (_dt / (_dt + AC_PID_RESET_TC)) * _integrator;
+        _reset_counter++;
+    } else {
+        _integrator = 0;
+    }
+    _reset_last_update = now;
+}
+
 void AC_PID::load_gains()
 {
     _kp.load();

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -13,6 +13,7 @@
 #define AC_PID_TFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_EFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_DFILT_HZ_DEFAULT  20.0f   // default input filter frequency
+#define AC_PID_RESET_TC          0.16f   // Time constant for integrator reset decay to zero
 
 /// @class	AC_PID
 /// @brief	Copter PID control class
@@ -54,6 +55,9 @@ public:
 
     // reset_I - reset the integrator
     void reset_I();
+
+    // reset_I - reset the integrator smoothly to zero within 0.5 seconds
+    void reset_I_smoothly();
 
     // reset_filter - input filter will be reset to the next value provided to set_input()
     void reset_filter() {
@@ -139,6 +143,8 @@ protected:
     float _target;            // target value to enable filtering
     float _error;             // error value to enable filtering
     float _derivative;        // derivative value to enable filtering
+    uint16_t _reset_counter;  // loop counter for reset decay
+    uint64_t _reset_last_update; //time in microseconds of last update to reset_I
 
     AP_Logger::PID_Info _pid_info;
 };

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -110,6 +110,14 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("HOVER_LEARN", 27, AP_MotorsHeli, _collective_hover_learn, HOVER_LEARN_AND_SAVE),
 
+    // @Param: OPTIONS
+    // @DisplayName: Heli_Options
+    // @Description: Bitmask of heli options.  Bit 0 changes how the pitch, roll, and yaw axis integrator term is managed for low speed and takeoff/landing. In AC 4.0 and earlier, scheme uses a leaky integrator for ground speeds less than 5 m/s and won't let the steady state integrator build above ILMI. The integrator is allowed to build to the ILMI value when it is landed.  The other integrator management scheme bases integrator limiting on takeoff and landing.  Whenever the aircraft is landed the integrator is set to zero.  When the aicraft is airborne, the integrator is only limited by IMAX. 
+    // @Values: 0:I term management based landed state, 1:Leaky I(4.0 and earlier)
+    // @Bitmask: 0:Use Leaky I
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 28, AP_MotorsHeli, _heli_options, (uint8_t)HeliOption::USE_LEAKY_I),
+
     AP_GROUPEND
 };
 
@@ -168,9 +176,7 @@ void AP_MotorsHeli::output_min()
     update_motor_control(ROTOR_CONTROL_STOP);
 
     // override limits flags
-    limit.roll = true;
-    limit.pitch = true;
-    limit.yaw = true;
+    set_limit_flag_pitch_roll_yaw(true);
     limit.throttle_lower = true;
     limit.throttle_upper = false;
 }
@@ -316,9 +322,11 @@ void AP_MotorsHeli::output_logic()
             // Servos set to their trim values or in a test condition.
 
             // set limits flags
-            limit.roll = true;
-            limit.pitch = true;
-            limit.yaw = true;
+            if (!using_leaky_integrator()) {
+                set_limit_flag_pitch_roll_yaw(true);
+            } else {
+                set_limit_flag_pitch_roll_yaw(false);
+            }
 
             // make sure the motors are spooling in the correct direction
             if (_spool_desired != DesiredSpoolState::SHUT_DOWN) {
@@ -331,14 +339,10 @@ void AP_MotorsHeli::output_logic()
         case SpoolState::GROUND_IDLE: {
             // Motors should be stationary or at ground idle.
             // set limits flags
-            if (_heliflags.land_complete) {
-                limit.roll = true;
-                limit.pitch = true;
-                limit.yaw = true;
+            if (_heliflags.land_complete && !using_leaky_integrator()) {
+                set_limit_flag_pitch_roll_yaw(true);
             } else {
-                limit.roll = false;
-                limit.pitch = false;
-                limit.yaw = false;
+                set_limit_flag_pitch_roll_yaw(false);
             }
 
             // Servos should be moving to correct the current attitude.
@@ -357,14 +361,10 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete) {
-                limit.roll = true;
-                limit.pitch = true;
-                limit.yaw = true;
+            if (_heliflags.land_complete && !using_leaky_integrator()) {
+                set_limit_flag_pitch_roll_yaw(true);
             } else {
-                limit.roll = false;
-                limit.pitch = false;
-                limit.yaw = false;
+                set_limit_flag_pitch_roll_yaw(false);
             }
 
             // make sure the motors are spooling in the correct direction
@@ -383,14 +383,10 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete) {
-                limit.roll = true;
-                limit.pitch = true;
-                limit.yaw = true;
+            if (_heliflags.land_complete && !using_leaky_integrator()) {
+                set_limit_flag_pitch_roll_yaw(true);
             } else {
-                limit.roll = false;
-                limit.pitch = false;
-                limit.yaw = false;
+                set_limit_flag_pitch_roll_yaw(false);
             }
 
             // make sure the motors are spooling in the correct direction
@@ -407,14 +403,10 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete) {
-                limit.roll = true;
-                limit.pitch = true;
-                limit.yaw = true;
+            if (_heliflags.land_complete && !using_leaky_integrator()) {
+                set_limit_flag_pitch_roll_yaw(true);
             } else {
-                limit.roll = false;
-                limit.pitch = false;
-                limit.yaw = false;
+                set_limit_flag_pitch_roll_yaw(false);
             }
 
             // make sure the motors are spooling in the correct direction
@@ -530,7 +522,7 @@ void AP_MotorsHeli::update_throttle_hover(float dt)
             curr_collective = _collective_mid_pct;
         }
 
-        // we have chosen to constrain the hover throttle to be within the range reachable by the third order expo polynomial.
+        // we have chosen to constrain the hover collective to be within the range reachable by the third order expo polynomial.
         _collective_hover = constrain_float(_collective_hover + (dt / (dt + AP_MOTORS_HELI_COLLECTIVE_HOVER_TC)) * (curr_collective - _collective_hover), AP_MOTORS_HELI_COLLECTIVE_HOVER_MIN, AP_MOTORS_HELI_COLLECTIVE_HOVER_MAX);
     }
 }
@@ -543,3 +535,20 @@ void AP_MotorsHeli::save_params_on_disarm()
         _collective_hover.save();
     }
 }
+
+// updates the takeoff collective flag
+void AP_MotorsHeli::update_takeoff_collective_flag(float coll_out)
+{
+    if (coll_out > _collective_mid_pct + 0.5f * (_collective_hover - _collective_mid_pct)) {
+        _heliflags.takeoff_collective = true;
+    } else {
+        _heliflags.takeoff_collective = false;
+    }
+}
+
+// Determines if _heli_options bit is set
+bool AP_MotorsHeli::heli_option(HeliOption opt) const
+{
+    return (_heli_options & (uint8_t)opt);
+}
+

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -96,6 +96,20 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @Path: AP_MotorsHeli_RSC.cpp
     AP_SUBGROUPINFO(_main_rotor, "RSC_", 25, AP_MotorsHeli, AP_MotorsHeli_RSC),
 
+    // @Param: COLL_HOVER
+    // @DisplayName: Collective Hover Value
+    // @Description: Collective needed to hover expressed as a number from 0 to 1 where 0 is H_COL_MIN and 1 is H_COL_MAX
+    // @Range: 0.3 0.8
+    // @User: Advanced
+    AP_GROUPINFO("COLL_HOVER", 26, AP_MotorsHeli, _collective_hover, AP_MOTORS_HELI_COLLECTIVE_HOVER_DEFAULT),
+
+    // @Param: HOVER_LEARN
+    // @DisplayName: Hover Value Learning
+    // @Description: Enable/Disable automatic learning of hover collective
+    // @Values: 0:Disabled, 1:Learn, 2:Learn and Save
+    // @User: Advanced
+    AP_GROUPINFO("HOVER_LEARN", 27, AP_MotorsHeli, _collective_hover_learn, HOVER_LEARN_AND_SAVE),
+
     AP_GROUPEND
 };
 
@@ -301,6 +315,11 @@ void AP_MotorsHeli::output_logic()
             // Motors should be stationary.
             // Servos set to their trim values or in a test condition.
 
+            // set limits flags
+            limit.roll = true;
+            limit.pitch = true;
+            limit.yaw = true;
+
             // make sure the motors are spooling in the correct direction
             if (_spool_desired != DesiredSpoolState::SHUT_DOWN) {
                 _spool_state = SpoolState::GROUND_IDLE;
@@ -311,6 +330,17 @@ void AP_MotorsHeli::output_logic()
 
         case SpoolState::GROUND_IDLE: {
             // Motors should be stationary or at ground idle.
+            // set limits flags
+            if (_heliflags.land_complete) {
+                limit.roll = true;
+                limit.pitch = true;
+                limit.yaw = true;
+            } else {
+                limit.roll = false;
+                limit.pitch = false;
+                limit.yaw = false;
+            }
+
             // Servos should be moving to correct the current attitude.
             if (_spool_desired == DesiredSpoolState::SHUT_DOWN){
                 _spool_state = SpoolState::SHUT_DOWN;
@@ -325,6 +355,17 @@ void AP_MotorsHeli::output_logic()
         case SpoolState::SPOOLING_UP:
             // Maximum throttle should move from minimum to maximum.
             // Servos should exhibit normal flight behavior.
+
+            // set limits flags
+            if (_heliflags.land_complete) {
+                limit.roll = true;
+                limit.pitch = true;
+                limit.yaw = true;
+            } else {
+                limit.roll = false;
+                limit.pitch = false;
+                limit.yaw = false;
+            }
 
             // make sure the motors are spooling in the correct direction
             if (_spool_desired != DesiredSpoolState::THROTTLE_UNLIMITED ){
@@ -341,6 +382,17 @@ void AP_MotorsHeli::output_logic()
             // Throttle should exhibit normal flight behavior.
             // Servos should exhibit normal flight behavior.
 
+            // set limits flags
+            if (_heliflags.land_complete) {
+                limit.roll = true;
+                limit.pitch = true;
+                limit.yaw = true;
+            } else {
+                limit.roll = false;
+                limit.pitch = false;
+                limit.yaw = false;
+            }
+
             // make sure the motors are spooling in the correct direction
             if (_spool_desired != DesiredSpoolState::THROTTLE_UNLIMITED) {
                 _spool_state = SpoolState::SPOOLING_DOWN;
@@ -353,6 +405,17 @@ void AP_MotorsHeli::output_logic()
         case SpoolState::SPOOLING_DOWN:
             // Maximum throttle should move from maximum to minimum.
             // Servos should exhibit normal flight behavior.
+
+            // set limits flags
+            if (_heliflags.land_complete) {
+                limit.roll = true;
+                limit.pitch = true;
+                limit.yaw = true;
+            } else {
+                limit.roll = false;
+                limit.pitch = false;
+                limit.yaw = false;
+            }
 
             // make sure the motors are spooling in the correct direction
             if (_spool_desired == DesiredSpoolState::THROTTLE_UNLIMITED) {
@@ -456,3 +519,27 @@ void AP_MotorsHeli::rc_write_swash(uint8_t chan, float swash_in)
     SRV_Channels::set_output_pwm_trimmed(function, pwm);
 }
 
+// update the collective input filter.  should be called at 100hz
+void AP_MotorsHeli::update_throttle_hover(float dt)
+{
+    if (_collective_hover_learn != HOVER_LEARN_DISABLED) {
+
+        // Don't let _collective_hover go below H_COLL_MID
+        float curr_collective = get_throttle();
+        if (curr_collective < _collective_mid_pct) {
+            curr_collective = _collective_mid_pct;
+        }
+
+        // we have chosen to constrain the hover throttle to be within the range reachable by the third order expo polynomial.
+        _collective_hover = constrain_float(_collective_hover + (dt / (dt + AP_MOTORS_HELI_COLLECTIVE_HOVER_TC)) * (curr_collective - _collective_hover), AP_MOTORS_HELI_COLLECTIVE_HOVER_MIN, AP_MOTORS_HELI_COLLECTIVE_HOVER_MAX);
+    }
+}
+
+// save parameters as part of disarming
+void AP_MotorsHeli::save_params_on_disarm()
+{
+    // save hover throttle
+    if (_collective_hover_learn == HOVER_LEARN_AND_SAVE) {
+        _collective_hover.save();
+    }
+}

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -130,6 +130,9 @@ public:
     // accessor to get the takeoff collective flag signifying that current collective is greater than collective required to indicate takeoff
     bool get_takeoff_collective() const { return _heliflags.takeoff_collective; }
 
+    // accessor to get the takeoff collective flag signifying that current collective is greater than collective required to indicate takeoff
+    bool get_below_mid_collective() const { return _heliflags.below_mid_collective; }
+
     // support passing init_targets_on_arming flag to greater code
     bool init_targets_on_arming() const override { return _heliflags.init_targets_on_arming; }
 
@@ -241,6 +244,7 @@ protected:
         uint8_t servo_test_running      : 1;    // true if servo_test is running
         uint8_t land_complete           : 1;    // true if aircraft is landed
         uint8_t takeoff_collective      : 1;    // true if collective is above 30% between H_COL_MID and H_COL_MAX
+        uint8_t below_mid_collective    : 1;    // true if collective is below H_COL_MID
     } _heliflags;
 
     // parameters

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -127,6 +127,7 @@ public:
     void update_throttle_hover(float dt);
     float get_throttle_hover() const override { return _collective_hover; }
 
+    // accessor to get the takeoff collective flag signifying that current collective is greater than collective required to indicate takeoff
     bool get_takeoff_collective() const { return _heliflags.takeoff_collective; }
 
     // support passing init_targets_on_arming flag to greater code
@@ -143,6 +144,14 @@ public:
 
     // set land complete flag
     void set_land_complete(bool landed) { _heliflags.land_complete = landed; }
+    
+    // enum for heli optional features
+    enum class HeliOption {
+        USE_LEAKY_I                     = (1<<0),   // 1
+    };
+
+    // use leaking integrator management scheme
+    bool using_leaky_integrator() const { return heli_option(HeliOption::USE_LEAKY_I); }
     
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
@@ -207,6 +216,12 @@ protected:
     // save parameters as part of disarming
     void save_params_on_disarm() override;
 
+    // Determines if _heli_options bit is set
+    bool heli_option(HeliOption opt) const;
+
+    // updates the takeoff collective flag indicating that current collective is greater than collective required to indicate takeoff.
+    void update_takeoff_collective_flag(float coll_out);
+
     // enum values for HOVER_LEARN parameter
     enum HoverLearn {
         HOVER_LEARN_DISABLED = 0,
@@ -237,6 +252,7 @@ protected:
     AP_Int8         _servo_test;                // sets number of cycles to test servo movement on bootup
     AP_Float        _collective_hover;          // estimated collective required to hover throttle in the range 0 ~ 1
     AP_Int8         _collective_hover_learn;    // enable/disabled hover collective learning
+    AP_Int8         _heli_options;              // bitmask for optional features
 
     // internal variables
     float           _collective_mid_pct = 0.0f;      // collective mid parameter value converted to 0 ~ 1 range

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -573,11 +573,8 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
         limit.throttle_lower = true;
     }
 
-    if (collective_out > _collective_mid_pct + 0.5f * (_collective_hover - _collective_mid_pct)) {
-        _heliflags.takeoff_collective = true;
-    } else {
-        _heliflags.takeoff_collective = false;
-    }
+    // updates takeoff collective flag based on 50% hover collective
+    update_takeoff_collective_flag(collective_out);
 
     // Set rear collective to midpoint if required
     float collective2_out = collective_out;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -573,6 +573,13 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
         limit.throttle_lower = true;
     }
 
+    // updates below mid collective flag
+    if (collective_out <= _collective_mid_pct) {
+        _heliflags.below_mid_collective = true;
+    } else {
+        _heliflags.below_mid_collective = false;
+    }
+
     // updates takeoff collective flag based on 50% hover collective
     update_takeoff_collective_flag(collective_out);
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -527,9 +527,6 @@ void AP_MotorsHeli_Dual::update_motor_control(RotorControlState state)
 void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
 {
     // initialize limits flag
-    limit.roll = false;
-    limit.pitch = false;
-    limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;
 
@@ -574,6 +571,12 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     if (_heliflags.landing_collective && collective_out < _collective_mid_pct) {
         collective_out = _collective_mid_pct;
         limit.throttle_lower = true;
+    }
+
+    if (collective_out > _collective_mid_pct + 0.5f * (_collective_hover - _collective_mid_pct)) {
+        _heliflags.takeoff_collective = true;
+    } else {
+        _heliflags.takeoff_collective = false;
     }
 
     // Set rear collective to midpoint if required

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -223,9 +223,6 @@ void AP_MotorsHeli_Quad::update_motor_control(RotorControlState state)
 void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
 {
     // initialize limits flag
-    limit.roll = false;
-    limit.pitch = false;
-    limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;
 
@@ -244,6 +241,12 @@ void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float c
     if (_heliflags.landing_collective && collective_out < _collective_mid_pct) {
         collective_out = _collective_mid_pct;
         limit.throttle_lower = true;
+    }
+
+    if (collective_out > _collective_mid_pct + 0.5f * (_collective_hover - _collective_mid_pct)) {
+        _heliflags.takeoff_collective = true;
+    } else {
+        _heliflags.takeoff_collective = false;
     }
 
     float collective_range = (_collective_max - _collective_min) * 0.001f;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -243,11 +243,8 @@ void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float c
         limit.throttle_lower = true;
     }
 
-    if (collective_out > _collective_mid_pct + 0.5f * (_collective_hover - _collective_mid_pct)) {
-        _heliflags.takeoff_collective = true;
-    } else {
-        _heliflags.takeoff_collective = false;
-    }
+    // updates takeoff collective flag based on 50% hover collective
+    update_takeoff_collective_flag(collective_out);
 
     float collective_range = (_collective_max - _collective_min) * 0.001f;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -243,6 +243,13 @@ void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float c
         limit.throttle_lower = true;
     }
 
+    // updates below mid collective flag
+    if (collective_out <= _collective_mid_pct) {
+        _heliflags.below_mid_collective = true;
+    } else {
+        _heliflags.below_mid_collective = false;
+    }
+
     // updates takeoff collective flag based on 50% hover collective
     update_takeoff_collective_flag(collective_out);
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -408,9 +408,6 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     float yaw_offset = 0.0f;
 
     // initialize limits flag
-    limit.roll = false;
-    limit.pitch = false;
-    limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;
 
@@ -447,6 +444,12 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     if (_heliflags.landing_collective && collective_out < _collective_mid_pct && !_heliflags.in_autorotation) {
         collective_out = _collective_mid_pct;
         limit.throttle_lower = true;
+    }
+
+    if (collective_out > _collective_mid_pct + 0.5f * (_collective_hover - _collective_mid_pct)) {
+        _heliflags.takeoff_collective = true;
+    } else {
+        _heliflags.takeoff_collective = false;
     }
 
     // if servo output not in manual mode and heli is not in autorotation, process pre-compensation factors

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -444,6 +444,14 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     if (_heliflags.landing_collective && collective_out < _collective_mid_pct && !_heliflags.in_autorotation) {
         collective_out = _collective_mid_pct;
         limit.throttle_lower = true;
+
+    }
+
+    // updates below mid collective flag
+    if (collective_out <= _collective_mid_pct) {
+        _heliflags.below_mid_collective = true;
+    } else {
+        _heliflags.below_mid_collective = false;
     }
 
     // updates takeoff collective flag based on 50% hover collective

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -446,11 +446,8 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
         limit.throttle_lower = true;
     }
 
-    if (collective_out > _collective_mid_pct + 0.5f * (_collective_hover - _collective_mid_pct)) {
-        _heliflags.takeoff_collective = true;
-    } else {
-        _heliflags.takeoff_collective = false;
-    }
+    // updates takeoff collective flag based on 50% hover collective
+    update_takeoff_collective_flag(collective_out);
 
     // if servo output not in manual mode and heli is not in autorotation, process pre-compensation factors
     if (_servo_mode == SERVO_CONTROL_MODE_AUTOMATED && !_heliflags.in_autorotation) {

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -171,6 +171,14 @@ void AP_Motors::add_motor_num(int8_t motor_num)
     }
 }
 
+    // set limit flag for pitch, roll and yaw
+void AP_Motors::set_limit_flag_pitch_roll_yaw(bool flag)
+{
+    limit.roll = flag;
+    limit.pitch = flag;
+    limit.yaw = flag;
+}
+
 namespace AP {
     AP_Motors *motors()
     {

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -149,6 +149,9 @@ public:
         uint8_t throttle_upper  : 1; // we have reached throttle's upper limit
     } limit;
 
+    // set limit flag for pitch, roll and yaw
+    void set_limit_flag_pitch_roll_yaw(bool flag);
+
     //
     // virtual functions that should be implemented by child classes
     //


### PR DESCRIPTION
This PR provides a selectable option for a new integrator management scheme for the Pitch, Roll, and Yaw axes.  The existing scheme is retained as default.  The new scheme uses collective and the landing detector as the triggers for releasing and resetting the integrator.  As this relies heavily on the landing detector, this was provided as an option initially to allow users to test the feature and disable it if they were seeing issues with the landing detector.

What has changed:
-New integrator scheme no longer uses leaky I implementation or minimum leak (ILMI) for the integrator when the vehicle speed is less than 5 m/s.
-IMAX is only integrator limit but growth is managed for takeoff/landing.
-Hover collective learning was added based off of multicopter hover throttle learning
-Takeoff
        - integrator is reset until liftoff is detected
        - lift off is detected using collective output (in motors class).  Must be greater than 50% of hover collective
        - hover collective is either manually specified through new parameter or determined by hover collective learning

-Landing
        - when landing the integrator is frozen when land_complete_maybe flag is set
        - integrator is smoothly reset to zero over 0.5 seconds once landing_complete flag is set
        - integrator remains reset until takeoff condition is met above

The new integrator scheme was tested both in the sim and on an actual helicopter.  My recent addition of making it selectable still needs a little more testing to ensure nothing was broken.
