### PR TITLE
AP_NavEKF3: constify EKFGSF_getYaw and add missing breaks to case

### DIFF
--- a/libraries/AP_NavEKF/EKFGSF_yaw.cpp
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.cpp
@@ -577,7 +577,7 @@ float EKFGSF_yaw::gaussianDensity(const uint8_t mdl_idx) const
     return normDist;
 }
 
-bool EKFGSF_yaw::getLogData(float &yaw_composite, float &yaw_composite_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF])
+bool EKFGSF_yaw::getLogData(float &yaw_composite, float &yaw_composite_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) const
 {
     if (vel_fuse_running) {
         yaw_composite = GSF.yaw;
@@ -604,7 +604,7 @@ void EKFGSF_yaw::forceSymmetry(const uint8_t mdl_idx)
 }
 
 // Apply a body frame delta angle to the body to earth frame rotation matrix using a small angle approximation
-Matrix3f EKFGSF_yaw::updateRotMat(const Matrix3f &R, const Vector3f &g)
+Matrix3f EKFGSF_yaw::updateRotMat(const Matrix3f &R, const Vector3f &g) const
 {
     Matrix3f ret = R;
     ret[0][0] += R[0][1] * g[2] - R[0][2] * g[1];
@@ -632,7 +632,7 @@ Matrix3f EKFGSF_yaw::updateRotMat(const Matrix3f &R, const Vector3f &g)
     return ret;
 }
 
-bool EKFGSF_yaw::getYawData(float &yaw, float &yawVariance)
+bool EKFGSF_yaw::getYawData(float &yaw, float &yawVariance) const
 {
     if (!vel_fuse_running) {
         return false;
@@ -642,7 +642,7 @@ bool EKFGSF_yaw::getYawData(float &yaw, float &yawVariance)
     return true;
 }
 
-bool EKFGSF_yaw::getVelInnovLength(float &velInnovLength)
+bool EKFGSF_yaw::getVelInnovLength(float &velInnovLength) const
 {
     if (!vel_fuse_running) {
         return false;

--- a/libraries/AP_NavEKF/EKFGSF_yaw.h
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.h
@@ -32,15 +32,15 @@ public:
 
     // get solution data for logging
     // return false if yaw estimation is inactive
-    bool getLogData(float &yaw_composite, float &yaw_composite_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]);
+    bool getLogData(float &yaw_composite, float &yaw_composite_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) const;
 
     // get yaw estimated and corresponding variance
     // return false if yaw estimation is inactive
-    bool getYawData(float &yaw, float &yawVariance);
+    bool getYawData(float &yaw, float &yawVariance) const;
 
     // get the length of the weighted average velocity innovation vector
     // return false if not available
-    bool getVelInnovLength(float &velInnovLength);
+    bool getVelInnovLength(float &velInnovLength) const;
 
 private:
 
@@ -90,7 +90,7 @@ private:
     void predictAHRS(const uint8_t mdl_idx);
 
     // Applies a body frame delta angle to a body to earth frame rotation matrix using a small angle approximation
-    Matrix3f updateRotMat(const Matrix3f &R, const Vector3f &g);
+    Matrix3f updateRotMat(const Matrix3f &R, const Vector3f &g) const;
 
     // Initialises the tilt (roll and pitch) for all AHRS using IMU acceleration data
     void alignTilt();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -872,7 +872,7 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
     case yawFusionMethod::PREDICTED:
     default:
         R_YAW = sq(frontend->_yawNoise);
-
+        break;
     }
 
     // determine if a 321 or 312 Euler sequence is best
@@ -892,7 +892,7 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
     default:
         // determined automatically
         order = (fabsf(prevTnb[0][2]) < fabsf(prevTnb[1][2])) ? rotationOrder::TAIT_BRYAN_321 : rotationOrder::TAIT_BRYAN_312;
-
+        break;
     }
 
     // calculate observation jacobian, predicted yaw and zero yaw body to earth rotation matrix

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -1509,7 +1509,7 @@ bool NavEKF3_core::EKFGSF_resetMainFilterYaw()
 }
 
 // returns true on success and populates yaw (in radians) and yawVariance (rad^2)
-bool NavEKF3_core::EKFGSF_getYaw(float& yaw, float& yawVariance)
+bool NavEKF3_core::EKFGSF_getYaw(float &yaw, float &yawVariance) const
 {
     // return immediately if no yaw estimator
     if (yawEstimator == nullptr) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -623,7 +623,7 @@ private:
 	    MAGNETOMETER=0,
 	    EXTERNAL=1,
         GSF=2,
-	    STATIC=3,
+        STATIC=3,
         PREDICTED=4,
     };
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -957,7 +957,7 @@ private:
     bool EKFGSF_resetMainFilterYaw();
 
     // returns true on success and populates yaw (in radians) and yawVariance (rad^2)
-    bool EKFGSF_getYaw(float &yaw, float &yawVariance);
+    bool EKFGSF_getYaw(float &yaw, float &yawVariance) const;
 
     // Fusion of body frame X and Y axis drag specific forces for multi-rotor wind estimation
     void FuseDragForces();


### PR DESCRIPTION
These are a few non-functional changes to EKF3 and AP_NavEKF noticed during the review of PR: https://github.com/ArduPilot/ardupilot/pull/16055

The changes are:

- tab replaced by spaces in the new yawFusionMethod enum
- added two missing breaks from the refactored fuseEulerYaw() method's case statements
- newly added AP_NavEKF3::EKFGSF_getYaw made const
- AP_NavEKF's EKFGSF_yaw members also made const

This has not been tested beyond the regular autotests but from inspection I think it should be clear that they all have no impact.