### PR TITLE
SITL: Checking Globally Unique IDs

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -257,6 +257,20 @@ bool AP_Param::duplicate_key(uint16_t vindex, uint16_t key)
     return false;
 }
 
+// check for duplicate group ids
+bool AP_Param::duplicate_id(const struct GroupInfo* group_info)
+{
+    for (uint8_t i=0; group_info[i].type != AP_PARAM_NONE; i++) {
+        for (uint8_t j=i+1; group_info[j].type != AP_PARAM_NONE; j++) {
+            if (group_id(group_info,0,i,0) == group_id(group_info,0,j,0)) {
+                // no duplicate group_ids allowed
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 /*
   get group_info pointer for a group
  */
@@ -299,6 +313,11 @@ bool AP_Param::check_var_info(void)
             if (!check_group_info(group_info, &total_size, 0, strlen(_var_info[i].name))) {
                 return false;
             }
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            if (duplicate_id(group_info)) {
+                return false;
+            }
+#endif
         } else {
             uint8_t size = type_size((enum ap_var_type)type);
             if (size == 0) {

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -593,6 +593,7 @@ private:
     static bool                 check_group_info(const struct GroupInfo *group_info, uint16_t *total_size, 
                                                  uint8_t max_bits, uint8_t prefix_length);
     static bool                 duplicate_key(uint16_t vindex, uint16_t key);
+    static bool                 duplicate_id(const struct GroupInfo *group_info);
 
     static bool adjust_group_offset(uint16_t vindex, const struct GroupInfo &group_info, ptrdiff_t &new_offset);
     static bool get_base(const struct Info &info, ptrdiff_t &base);


### PR DESCRIPTION
I have added some changes to the duplicate key function in the AP_Param.cpp file that was being used to check whether the parameter IDs were unique or not(Issue #5676).Please look into this.Thanks in advanced