### PR TITLE
AP_Bootloader: respect HAL_BOOTLOADER_TIMEOUT when CAN and SERIAL/USB…

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -90,11 +90,14 @@ int main(void)
         // bad firmware CRC, don't try and boot
         timeout = 0;
         try_boot = false;
-    } else if (timeout != 0) {
+    }
+#ifndef BOOTLOADER_DEV_LIST
+    else if (timeout != 0) {
         // fast boot for good firmware
         try_boot = true;
         timeout = 1000;
     }
+#endif
     if (was_watchdog && m != RTC_BOOT_FWOK) {
         // we've had a watchdog within 30s of booting main CAN
         // firmware. We will stay in bootloader to allow the user to


### PR DESCRIPTION
This only effects targets that have USB or Serial port defined in hwdef-bl.dat.

Respect HAL_BOOTLOADER_TIMEOUT when both CAN and SERIAL/USB is enabled. Currently, if CAN is enabled and a valid App was found then it overrides the timeout to 1000ms and then immediately jumps to the App before the uarts are even initialized, which also ignores the 1000ms override.

This PR respects the HAL_BOOTLOADER_TIMEOUT so that USB/Serial devices have a chance to boot up and be checked before the App runs. Default value for HAL_BOOTLOADER_TIMEOUT is 5000 and most-periph devices override this to 1000 (which is currently being ignored).
