### PR TITLE
HAL_ChibiOS: fixed flash space on 16k bl boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -345,7 +345,7 @@ bool Scheduler::in_expected_delay(void) const
             return true;
         }
     }
-#ifndef HAL_NO_FLASH_SUPPORT
+#if !defined(HAL_NO_FLASH_SUPPORT) && !defined(HAL_BOOTLOADER_BUILD)
     if (stm32_flash_recent_erase()) {
         return true;
     }

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
@@ -335,7 +335,9 @@ bool stm32_flash_ispageerased(uint32_t page)
     return true;
 }
 
+#ifndef HAL_BOOTLOADER_BUILD
 static uint32_t last_erase_ms;
+#endif
 
 /*
   erase a page
@@ -346,7 +348,9 @@ bool stm32_flash_erasepage(uint32_t page)
         return false;
     }
 
+#ifndef HAL_BOOTLOADER_BUILD
     last_erase_ms = hrt_millis32();
+#endif
 
 #if STM32_FLASH_DISABLE_ISR
     syssts_t sts = chSysGetStatusAndLockX();
@@ -407,7 +411,9 @@ bool stm32_flash_erasepage(uint32_t page)
     chSysRestoreStatusX(sts);
 #endif
 
+#ifndef HAL_BOOTLOADER_BUILD
     last_erase_ms = hrt_millis32();
+#endif
 
     return stm32_flash_ispageerased(page);
 }
@@ -663,6 +669,7 @@ void stm32_flash_keep_unlocked(bool set)
     }
 }
 
+#ifndef HAL_BOOTLOADER_BUILD
 /*
   return true if we had a recent erase
  */
@@ -670,6 +677,7 @@ bool stm32_flash_recent_erase(void)
 {
     return hrt_millis32() - last_erase_ms < 3000U;
 }
+#endif
 
 #endif // HAL_NO_FLASH_SUPPORT
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
@@ -27,7 +27,9 @@ bool stm32_flash_erasepage(uint32_t page);
 bool stm32_flash_write(uint32_t addr, const void *buf, uint32_t count);
 void stm32_flash_keep_unlocked(bool set);
 bool stm32_flash_ispageerased(uint32_t page);
+#ifndef HAL_BOOTLOADER_BUILD
 bool stm32_flash_recent_erase(void);
+#endif
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
this avoids the stm32_flash_recent_erase() function which added around
800 bytes to the bootloader. It is not needed