### PR TITLE
AP_Periph: add BRD_SERIAL_NUM and append CAN_APP_NODE_NAME

### DIFF
--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -41,6 +41,8 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 
     GSCALAR(debug, "DEBUG", 0),
 
+    GSCALAR(serial_number, "BRD_SERIAL_NUM", 0),
+
 #ifdef HAL_PERIPH_ENABLE_BUZZER
     GSCALAR(buzz_volume,     "BUZZER_VOLUME", 100),
 #endif

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -30,6 +30,7 @@ public:
         k_param_esc_number,
         k_param_battery,
         k_param_debug,
+        k_param_serial_number,
     };
 
     AP_Int16 format_version;
@@ -66,6 +67,8 @@ public:
 #endif
 
     AP_Int8 debug;
+
+    AP_Int32 serial_number;
 
     Parameters() {}
 };

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -155,10 +155,14 @@ static void handle_get_node_info(CanardInstance* ins,
     pkt.hardware_version.major = APJ_BOARD_ID >> 8;
     pkt.hardware_version.minor = APJ_BOARD_ID & 0xFF;
 
-    char name[strlen(CAN_APP_NODE_NAME)+1];
-    strcpy(name, CAN_APP_NODE_NAME);
-    pkt.name.len = strlen(CAN_APP_NODE_NAME);
-    pkt.name.data = (uint8_t *)name;
+    char text[UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_NAME_MAX_LENGTH+1];
+    if (periph.g.serial_number > 0) {
+        hal.util->snprintf(text, sizeof(text), "%s(%u)", CAN_APP_NODE_NAME, (unsigned)periph.g.serial_number);
+    } else {
+        hal.util->snprintf(text, sizeof(text), "%s", CAN_APP_NODE_NAME);
+    }
+    pkt.name.len = strlen(text);
+    pkt.name.data = (uint8_t *)text;
 
     uint16_t total_size = uavcan_protocol_GetNodeInfoResponse_encode(&pkt, buffer);
 


### PR DESCRIPTION
This adds a new param BRD_SERIAL_NUM with default = 0 which does nothing, just like in Plane, except if it is >0 then the number will be appended to your CAN_APP_NODE_NAME. This is helpful when dealing with multiple nodes all with the same hardware and firmware.