### PR TITLE
Tools: relax fly_guided_stop climb rate tolerance to 1cm/s (was 0.1cm/s)

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3143,7 +3143,7 @@ class AutoTestCopter(AutoTest):
     def fly_guided_stop(self,
                         timeout=20,
                         groundspeed_tolerance=0.05,
-                        climb_tolerance=0.001):
+                        climb_tolerance=0.01):
         """stop the vehicle moving in guided mode"""
         self.progress("Stopping vehicle")
         tstart = self.get_sim_time()


### PR DESCRIPTION
The Copter.GuidedSubModeChange autotest is quite unreliable and is failing with the message, "Vehicle did not stop".  This PR attempts to improve its reliability.

I investigated this test as part of the S-Curves PR https://github.com/ArduPilot/ardupilot/pull/15896 and found that the fly_guided_stop() function's "climb_tolerance" is only 0.001m/s (i.e. 0.1cm/s) which seems extremely tight.  This PR relaxes the tolerance to 0.01m/s (1cm/s) which is still quite tight but in my tests was enough to make it pass reliably.