### PR TITLE
AP_NavEKF3: allow easier arming without compass

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5533,7 +5533,7 @@ class AutoTestCopter(AutoTest):
 
             self.context_push()
             self.start_subtest("missing required yaw source")
-            self.set_parameter("EK3_SRC3_YAW", 1)
+            self.set_parameter("EK3_SRC3_YAW", 3) # External Yaw with Compass Fallback
             self.set_parameter("COMPASS_USE", 0)
             self.set_parameter("COMPASS_USE2", 0)
             self.set_parameter("COMPASS_USE3", 0)

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -213,6 +213,17 @@ bool AP_NavEKF_Source::haveVelZSource() const
     return false;
 }
 
+// get yaw source
+AP_NavEKF_Source::SourceYaw AP_NavEKF_Source::getYawSource() const
+{
+    // check for special case of disabled compasses
+    if ((_source_set[active_source_set].yaw == SourceYaw::COMPASS) && (AP::dal().compass().get_num_enabled() == 0)) {
+        return SourceYaw::NONE;
+    }
+
+    return _source_set[active_source_set].yaw;
+}
+
 // align position of inactive sources to ahrs
 void AP_NavEKF_Source::align_inactive_sources()
 {

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -153,11 +153,11 @@ void AP_NavEKF_Source::init()
     }
 
     // initialise active sources
-    _active_source_set.posxy = (SourceXY)_source_set[0].posxy.get();
-    _active_source_set.velxy = (SourceXY)_source_set[0].velxy.get();
-    _active_source_set.posz = (SourceZ)_source_set[0].posz.get();
-    _active_source_set.velz = (SourceZ)_source_set[0].velz.get();
-    _active_source_set.yaw = (SourceYaw)_source_set[0].yaw.get();
+    _active_source_set.posxy = _source_set[0].posxy;
+    _active_source_set.velxy = _source_set[0].velxy;
+    _active_source_set.posz = _source_set[0].posz;
+    _active_source_set.velz = _source_set[0].velz;
+    _active_source_set.yaw = _source_set[0].yaw;
 
     initialised = true;
 }
@@ -173,11 +173,11 @@ void AP_NavEKF_Source::setPosVelYawSourceSet(uint8_t source_set_idx)
         return;
     }
 
-    _active_source_set.posxy = (SourceXY)_source_set[source_set_idx].posxy.get();
-    _active_source_set.velxy = (SourceXY)_source_set[source_set_idx].velxy.get();
-    _active_source_set.posz = (SourceZ)_source_set[source_set_idx].posz.get();
-    _active_source_set.velz = (SourceZ)_source_set[source_set_idx].velz.get();
-    _active_source_set.yaw = (SourceYaw)_source_set[source_set_idx].yaw.get();
+    _active_source_set.posxy = _source_set[source_set_idx].posxy;
+    _active_source_set.velxy = _source_set[source_set_idx].velxy;
+    _active_source_set.posz = _source_set[source_set_idx].posz;
+    _active_source_set.velz = _source_set[source_set_idx].velz;
+    _active_source_set.yaw = _source_set[source_set_idx].yaw;
 }
 
 // true/false of whether velocity source should be used
@@ -190,7 +190,7 @@ bool AP_NavEKF_Source::useVelXYSource(SourceXY velxy_source) const
     // check for fuse all velocities
     if (_options.get() & (uint16_t)(SourceOptions::FUSE_ALL_VELOCITIES)) {
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
-            if ((SourceXY)_source_set[i].velxy.get() == velxy_source) {
+            if (_source_set[i].velxy == velxy_source) {
                 return true;
             }
         }
@@ -209,7 +209,7 @@ bool AP_NavEKF_Source::useVelZSource(SourceZ velz_source) const
     // check for fuse all velocities
     if (_options.get() & (uint16_t)(SourceOptions::FUSE_ALL_VELOCITIES)) {
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
-            if ((SourceZ)_source_set[i].velz.get() == velz_source) {
+            if (_source_set[i].velz == velz_source) {
                 return true;
             }
         }
@@ -229,7 +229,7 @@ bool AP_NavEKF_Source::haveVelZSource() const
     // check for fuse all velocities
     if (_options.get() & (uint16_t)(SourceOptions::FUSE_ALL_VELOCITIES)) {
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
-            if ((SourceZ)_source_set[i].velz.get() != SourceZ::NONE) {
+            if (_source_set[i].velz != SourceZ::NONE) {
                 return true;
             }
         }
@@ -256,7 +256,7 @@ void AP_NavEKF_Source::align_inactive_sources()
         (getPosXYSource() == SourceXY::BEACON)) {
         // only align position if active source is GPS or Beacon
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
-            if ((SourceXY)_source_set[i].posxy.get() == SourceXY::EXTNAV) {
+            if (_source_set[i].posxy == SourceXY::EXTNAV) {
                 // ExtNav could potentially be used, so align it
                 align_posxy = true;
                 break;
@@ -272,7 +272,7 @@ void AP_NavEKF_Source::align_inactive_sources()
         (getPosZSource() == SourceZ::BEACON)) {
         // ExtNav is not the active source; we do not want to align active source!
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
-            if ((SourceZ)_source_set[i].posz.get() == SourceZ::EXTNAV) {
+            if (_source_set[i].posz == SourceZ::EXTNAV) {
                 // ExtNav could potentially be used, so align it
                 align_posz = true;
                 break;
@@ -489,16 +489,16 @@ bool AP_NavEKF_Source::ext_nav_enabled(void) const
 {
     for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
         const auto &src = _source_set[i];
-        if (SourceXY(src.posxy.get()) == SourceXY::EXTNAV) {
+        if (src.posxy == SourceXY::EXTNAV) {
             return true;
         }
-        if (SourceZ(src.posz.get()) == SourceZ::EXTNAV) {
+        if (src.posz == SourceZ::EXTNAV) {
             return true;
         }
-        if (SourceXY(src.velxy.get()) == SourceXY::EXTNAV) {
+        if (src.velxy == SourceXY::EXTNAV) {
             return true;
         }
-        if (SourceZ(src.velz.get()) == SourceZ::EXTNAV) {
+        if (src.velz == SourceZ::EXTNAV) {
             return true;
         }
     }
@@ -510,7 +510,7 @@ bool AP_NavEKF_Source::wheel_encoder_enabled(void) const
 {
     for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
         const auto &src = _source_set[i];
-        if (SourceXY(src.velxy.get()) == SourceXY::WHEEL_ENCODER) {
+        if (src.velxy == SourceXY::WHEEL_ENCODER) {
             return true;
         }
     }

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -145,45 +145,19 @@ AP_NavEKF_Source::AP_NavEKF_Source()
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-void AP_NavEKF_Source::init()
-{
-    // ensure init is only run once
-    if (initialised) {
-        return;
-    }
-
-    // initialise active sources
-    _active_source_set.posxy = _source_set[0].posxy;
-    _active_source_set.velxy = _source_set[0].velxy;
-    _active_source_set.posz = _source_set[0].posz;
-    _active_source_set.velz = _source_set[0].velz;
-    _active_source_set.yaw = _source_set[0].yaw;
-
-    initialised = true;
-}
-
 // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
 void AP_NavEKF_Source::setPosVelYawSourceSet(uint8_t source_set_idx)
 {
-    // ensure init has been run
-    init();
-
     // sanity check source idx
-    if (source_set_idx >= AP_NAKEKF_SOURCE_SET_MAX) {
-        return;
+    if (source_set_idx < AP_NAKEKF_SOURCE_SET_MAX) {
+        active_source_set = source_set_idx;
     }
-
-    _active_source_set.posxy = _source_set[source_set_idx].posxy;
-    _active_source_set.velxy = _source_set[source_set_idx].velxy;
-    _active_source_set.posz = _source_set[source_set_idx].posz;
-    _active_source_set.velz = _source_set[source_set_idx].velz;
-    _active_source_set.yaw = _source_set[source_set_idx].yaw;
 }
 
 // true/false of whether velocity source should be used
 bool AP_NavEKF_Source::useVelXYSource(SourceXY velxy_source) const
 {
-    if (velxy_source == _active_source_set.velxy) {
+    if (velxy_source == _source_set[active_source_set].velxy) {
         return true;
     }
 
@@ -202,7 +176,7 @@ bool AP_NavEKF_Source::useVelXYSource(SourceXY velxy_source) const
 
 bool AP_NavEKF_Source::useVelZSource(SourceZ velz_source) const
 {
-    if (velz_source == _active_source_set.velz) {
+    if (velz_source == _source_set[active_source_set].velz) {
         return true;
     }
 
@@ -222,7 +196,7 @@ bool AP_NavEKF_Source::useVelZSource(SourceZ velz_source) const
 // true if a velocity source is configured
 bool AP_NavEKF_Source::haveVelZSource() const
 {
-    if (_active_source_set.velz != SourceZ::NONE) {
+    if (_source_set[active_source_set].velz != SourceZ::NONE) {
         return true;
     }
 

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -407,6 +407,8 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
             // valid yaw value
             break;
         case SourceYaw::COMPASS:
+            // skip compass check for easier user setup of compass-less operation
+            break;
         case SourceYaw::EXTERNAL_COMPASS_FALLBACK:
             compass_required = true;
             break;

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -90,17 +90,17 @@ public:
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const;
 
-    static const struct AP_Param::GroupInfo var_info[];
-
     // return true if ext nav is enabled on any source
     bool ext_nav_enabled(void) const;
 
     // return true if ext yaw is enabled on any source
     bool ext_yaw_enabled(void) const;
-    
+
     // return true if wheel encoder is enabled on any source
     bool wheel_encoder_enabled(void) const;
-    
+
+    static const struct AP_Param::GroupInfo var_info[];
+
 private:
 
     // Parameters

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -71,7 +71,7 @@ public:
     bool haveVelZSource() const;
 
     // get yaw source
-    SourceYaw getYawSource() const { return _source_set[active_source_set].yaw; }
+    SourceYaw getYawSource() const;
 
     // align position of inactive sources to ahrs
     void align_inactive_sources();

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -53,15 +53,15 @@ public:
     void init();
 
     // get current position source
-    SourceXY getPosXYSource() const { return _active_source_set.posxy; }
-    SourceZ getPosZSource() const { return _active_source_set.posz; }
+    SourceXY getPosXYSource() const { return _source_set[active_source_set].posxy; }
+    SourceZ getPosZSource() const { return _source_set[active_source_set].posz; }
 
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
     void setPosVelYawSourceSet(uint8_t source_set_idx);
 
     // get/set velocity source
-    SourceXY getVelXYSource() const { return _active_source_set.velxy; }
-    SourceZ getVelZSource() const { return _active_source_set.velz; }
+    SourceXY getVelXYSource() const { return _source_set[active_source_set].velxy; }
+    SourceZ getVelZSource() const { return _source_set[active_source_set].velz; }
 
     // true/false of whether velocity source should be used
     bool useVelXYSource(SourceXY velxy_source) const;
@@ -71,7 +71,7 @@ public:
     bool haveVelZSource() const;
 
     // get yaw source
-    SourceYaw getYawSource() const { return _active_source_set.yaw; }
+    SourceYaw getYawSource() const { return _source_set[active_source_set].yaw; }
 
     // align position of inactive sources to ahrs
     void align_inactive_sources();
@@ -114,14 +114,6 @@ private:
 
     AP_Int16 _options;      // source options bitmask
 
-    // active sources
-    struct {
-        SourceXY posxy;     // current xy position source
-        SourceZ posz;       // current z position source
-        SourceXY velxy;     // current xy velocity source
-        SourceZ velz;       // current z velocity source
-        SourceYaw yaw;      // current yaw source
-    } _active_source_set;
-    bool initialised;       // true once init has been run
+    uint8_t active_source_set; // index of active source set
     bool config_in_storage; // true once configured in storage has returned true
 };

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -15,7 +15,7 @@ public:
     AP_NavEKF_Source(const AP_NavEKF_Source &other) = delete;
     AP_NavEKF_Source &operator=(const AP_NavEKF_Source&) = delete;
 
-    enum class SourceXY {
+    enum class SourceXY : uint8_t {
         NONE = 0,
         // BARO = 1 (not applicable)
         // RANGEFINDER = 2 (not applicable)
@@ -26,7 +26,7 @@ public:
         WHEEL_ENCODER = 7
     };
 
-    enum class SourceZ {
+    enum class SourceZ : uint8_t {
         NONE = 0,
         BARO = 1,
         RANGEFINDER = 2,
@@ -37,7 +37,7 @@ public:
         // WHEEL_ENCODER = 7 (not applicable)
     };
 
-    enum class SourceYaw {
+    enum class SourceYaw : uint8_t {
         NONE = 0,
         COMPASS = 1,
         EXTERNAL = 2,
@@ -105,11 +105,11 @@ private:
 
     // Parameters
     struct SourceSet {
-        AP_Int8 posxy;  // xy position source
-        AP_Int8 velxy;  // xy velocity source
-        AP_Int8 posz;   // position z (aka altitude or height) source
-        AP_Int8 velz;   // velocity z source
-        AP_Int8 yaw;    // yaw source
+        AP_Enum<SourceXY>  posxy;  // xy position source
+        AP_Enum<SourceXY>  velxy;  // xy velocity source
+        AP_Enum<SourceZ>   posz;   // position z (aka altitude or height) source
+        AP_Enum<SourceZ>   velz;   // velocity z source
+        AP_Enum<SourceYaw> yaw;    // yaw source
     } _source_set[AP_NAKEKF_SOURCE_SET_MAX];
 
     AP_Int16 _options;      // source options bitmask

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -723,9 +723,6 @@ bool NavEKF3::InitialiseFilter(void)
     convert_parameters();
 #endif
 
-    // initialise sources
-    sources.init();
-
 #if APM_BUILD_TYPE(APM_BUILD_Replay)
     if (ins.get_accel_count() == 0) {
         return false;


### PR DESCRIPTION
This is an alternative to PR https://github.com/ArduPilot/ardupilot/pull/16061 and its primary purpose is to make it easier for users (of all vehicles) to arm without a compass by only setting COMPASS_USE/2/3 = 0.  Previously users would also have had to set EK3_SRC1_YAW = 0.

Changes included in this PR are:

- original PR's change to the parameters to make them enums removing the need for casting (non-functional change)
- the active_source_set structure is replaced with a simple uint8_t index.  This also allows the init() function to be removed (non-functional change)
- AP_NavEKF_Source::getYawSource() now returns None if EK3_SRCx_YAW == Compass but COMPASS_USE/2/3 == 0.  This makes the setup for no-compass users easier because they don't need to modify any EK3_ parameters.  The pre-arm check that would trigger is also disabled.

This has been lightly tested on a real autopilot to confirm that users can arm with EK3_SRCx_YAW == Compass and COMPASS_USE/2/3 == 0.
![randy-no-compass-arming-test](https://user-images.githubusercontent.com/1498098/102483569-474f6100-40a8-11eb-9cd6-2e50bdcd7ebd.png)

As mentioned this applies to all vehicles which means we are essentially condoning Copter to fly without a compass.  When I actually tried to fly without a compass, even in Stabilize mode, I found the EKF failsafe triggered immediately.  I wonder if we can hear from @andyp1per what the requirements are to fly a copter with no compass.
