### PR TITLE
Stop doing periph sitl test if CI is running kernel 5.4.0-1032

### DIFF
--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -96,6 +96,8 @@ jobs:
           sudo apt-get install -y gcc-multilib g++-multilib
       - name: setup can-utils
         run: |
+          kernel_ver=`uname -r`
+          if [ "$kernel_ver" = "5.4.0-1032-azure" ]; then echo "Unsupported Kernel $kernel_ver" && exit 0; fi;
           sudo apt-get update
           sudo apt-get -y install can-utils iproute2 linux-modules-extra-$(uname -r)
           sudo modprobe vcan
@@ -106,5 +108,7 @@ jobs:
           CI_BUILD_TARGET: ${{matrix.config}}
         shell: bash
         run: |
+          kernel_ver=`uname -r`
+          if [ "$kernel_ver" = "5.4.0-1032-azure" ]; then echo "Unsupported Kernel $kernel_ver" && exit 0; fi;
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -97,10 +97,7 @@ jobs:
       - name: setup can-utils
         run: |
           sudo apt-get update
-          echo "Kernel Version: $(uname -r)"
-          kernel_ver=`uname -r`; if [ "$kernel_ver" = "5.4.0-1032-azure" ]; then sudo apt-get -y install linux-modules-extra-5.4.0-1031-azure;else sudo apt-get -y install linux-modules-extra-$(uname -r) ;fi;
-          kernel_ver=`uname -r`; if [ "$kernel_ver" = "5.4.0-1032-azure" ]; then sudo cp -r /lib/modules/5.4.0-1031-azure /lib/modules/5.4.0-1032-azure;fi;
-          sudo apt-get -y install can-utils iproute2
+          sudo apt-get -y install can-utils iproute2 linux-modules-extra-$(uname -r)
           sudo modprobe vcan
           sudo ip link add dev vcan0 type vcan
           sudo ip link set up vcan0


### PR DESCRIPTION
I guess CI machines will eventually move on from this patch level and we will be back to testing this. Until then let's just not do this. We still continue doing the rest of the stuff like building etc. just not the sitl test.