### PR TITLE
Tools: ardupilotwaf: fix scripting inclusion on build_binaries.py

### DIFF
--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -64,7 +64,7 @@ def _depends_on_vehicle(bld, source_node):
 
     if not bld.env.BUILDROOT:
         bld.env.BUILDROOT = bld.bldnode.make_node('').abspath()
-    if path.startswith(bld.env.BUILDROOT) or path.startswith("build/"):
+    if path.startswith(bld.env.BUILDROOT) or path.startswith("build/") or path.startswith("build.tmp.binaries/"):
         _depends_on_vehicle_cache[path] = False
 
     if path not in _depends_on_vehicle_cache:


### PR DESCRIPTION
Prevent build error when using `Tools/scripts/build_binaries.py --tags latest`

```
BB-WAF: Traceback (most recent call last):
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Scripting.py", line 158, in waf_entry_point
BB-WAF:     run_commands()
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Scripting.py", line 251, in run_commands
BB-WAF:     ctx = run_command(cmd_name)
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Scripting.py", line 235, in run_command
BB-WAF:     ctx.execute()
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Build.py", line 1272, in execute
BB-WAF:     self.recurse([self.run_dir])
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Context.py", line 286, in recurse
BB-WAF:     user_function(self)
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/wscript", line 582, in build
BB-WAF:     _build_common_taskgens(bld)
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/wscript", line 469, in _build_common_taskgens
BB-WAF:     bld.ap_stlib(
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Configure.py", line 316, in fun
BB-WAF:     return f(*k, **kw)
BB-WAF:   File "Tools/ardupilotwaf/ardupilotwaf.py", line 304, in ap_stlib
BB-WAF:     bld.ap_library(l, kw['ap_vehicle'])
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Configure.py", line 316, in fun
BB-WAF:     return f(*k, **kw)
BB-WAF:   File "Tools/ardupilotwaf/ap_library.py", line 115, in ap_library
BB-WAF:     source=[s for s in src if not _depends_on_vehicle(bld, s)],
BB-WAF:   File "Tools/ardupilotwaf/ap_library.py", line 115, in <listcomp>
BB-WAF:     source=[s for s in src if not _depends_on_vehicle(bld, s)],
BB-WAF:   File "Tools/ardupilotwaf/ap_library.py", line 71, in _depends_on_vehicle
BB-WAF:     s = _remove_comments(source_node.read())
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Node.py", line 185, in read
BB-WAF:     return Utils.readf(self.abspath(), flags, encoding)
BB-WAF:   File "/home/khancyr/Workspace/ardupilot/modules/waf/waflib/Utils.py", line 231, in readf
BB-WAF:     with open(fname, m) as f:
BB-WAF: FileNotFoundError: [Errno 2] No such file or directory: '/home/khancyr/Workspace/ardupilot/build.tmp.binaries/binaries.build/CUAV-Nora/libraries/AP_Scripting/lua_generated_bindings.cpp'
```
it appends on a lot of target