### PR TITLE
Only declare log IO thread dead once initialisation completes

### DIFF
--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -66,7 +66,9 @@ public:
     virtual void     register_timer_failsafe(AP_HAL::Proc,
                                              uint32_t period_us) = 0;
 
-    virtual void     system_initialized() = 0;
+    // check and set the startup state
+    virtual void     set_system_initialized() = 0;
+    virtual bool     is_system_initialized() = 0;
 
     virtual void     reboot(bool hold_in_bootloader) = 0;
 

--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -236,7 +236,7 @@ static void main_loop()
 
     schedulerInstance.watchdog_pat();
 
-    hal.scheduler->system_initialized();
+    hal.scheduler->set_system_initialized();
 
     thread_running = true;
     chRegSetThreadName(SKETCHNAME);

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -565,10 +565,10 @@ void Scheduler::_storage_thread(void* arg)
     }
 }
 
-void Scheduler::system_initialized()
+void Scheduler::set_system_initialized()
 {
     if (_initialized) {
-        AP_HAL::panic("PANIC: scheduler::system_initialized called"
+        AP_HAL::panic("PANIC: scheduler::set_system_initialized called"
                       "more than once");
     }
     _initialized = true;

--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -92,7 +92,8 @@ public:
 
     bool     in_main_thread() const override { return get_main_thread() == chThdGetSelfX(); }
 
-    void     system_initialized() override;
+    void     set_system_initialized() override;
+    bool     is_system_initialized() override { return _initialized; };
     void     hal_initialized() { _hal_initialized = true; }
 
     bool     check_called_boost(void);

--- a/libraries/AP_HAL_Empty/HAL_Empty_Class.cpp
+++ b/libraries/AP_HAL_Empty/HAL_Empty_Class.cpp
@@ -60,7 +60,7 @@ void HAL_Empty::run(int argc, char* const argv[], Callbacks* callbacks) const
     _member->init();
 
     callbacks->setup();
-    scheduler->system_initialized();
+    scheduler->set_system_initialized();
 
     for (;;) {
         callbacks->loop();

--- a/libraries/AP_HAL_Empty/Scheduler.cpp
+++ b/libraries/AP_HAL_Empty/Scheduler.cpp
@@ -28,7 +28,7 @@ void Scheduler::register_io_process(AP_HAL::MemberProc k)
 void Scheduler::register_timer_failsafe(AP_HAL::Proc, uint32_t period_us)
 {}
 
-void Scheduler::system_initialized()
+void Scheduler::set_system_initialized()
 {}
 
 void Scheduler::reboot(bool hold_in_bootloader) {

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -13,7 +13,8 @@ public:
 
     void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us) override;
 
-    void     system_initialized() override;
+    void     set_system_initialized() override;
+    bool     is_system_initialized() override { return true; }
 
     void     reboot(bool hold_in_bootloader) override;
 

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -384,7 +384,7 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
     // NOTE: See commit 9f5b4ffca ("AP_HAL_Linux_Class: Correct
     // deadlock, and infinite loop in setup()") for details about the
     // order of scheduler initialize and setup on Linux.
-    scheduler->system_initialized();
+    scheduler->set_system_initialized();
 
     // possibly load external modules
 #if AP_MODULE_SUPPORTED

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -292,10 +292,10 @@ void Scheduler::_wait_all_threads()
     }
 }
 
-void Scheduler::system_initialized()
+void Scheduler::set_system_initialized()
 {
     if (_initialized) {
-        AP_HAL::panic("PANIC: scheduler::system_initialized called more than once");
+        AP_HAL::panic("PANIC: scheduler::set_system_initialized called more than once");
     }
 
     _initialized = true;

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -36,7 +36,8 @@ public:
 
     void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us) override;
 
-    void     system_initialized() override;
+    void     set_system_initialized() override;
+    bool     is_system_initialized() override { return _initialized; };
 
     void     reboot(bool hold_in_bootloader) override;
 

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -211,7 +211,7 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
     fill_stack_nan();
 
     callbacks->setup();
-    scheduler->system_initialized();
+    scheduler->set_system_initialized();
 
 #ifndef HAL_NO_LOGGING
     if (getenv("SITL_WATCHDOG_RESET")) {

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -143,7 +143,7 @@ void Scheduler::register_timer_failsafe(AP_HAL::Proc failsafe, uint32_t period_u
     _failsafe = failsafe;
 }
 
-void Scheduler::system_initialized() {
+void Scheduler::set_system_initialized() {
     if (_initialized) {
         AP_HAL::panic(
             "PANIC: scheduler system initialized called more than once");

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -28,7 +28,8 @@ public:
     void register_timer_failsafe(AP_HAL::Proc, uint32_t period_us) override;
 
     bool in_main_thread() const override;
-    void system_initialized() override;
+    bool is_system_initialized() override { return _initialized; };
+    void set_system_initialized() override;
 
     void reboot(bool hold_in_bootloader) override;
 

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -827,7 +827,7 @@ bool AP_Logger_Block::logging_failed() const
 bool AP_Logger_Block::io_thread_alive() const
 {
     // if the io thread hasn't had a heartbeat in 3s it is dead
-    return (AP_HAL::millis() - io_timer_heartbeat) < 3000U || hal.scheduler->in_expected_delay();
+    return (AP_HAL::millis() - io_timer_heartbeat) < 3000U || !hal.scheduler->is_system_initialized();
 }
 
 /*

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -1003,7 +1003,7 @@ bool AP_Logger_File::io_thread_alive() const
 {
     // if the io thread hasn't had a heartbeat in a full seconds then it is dead
     // this is enough time for a sdcard remount
-    return (AP_HAL::millis() - _io_timer_heartbeat) < 3000U;
+    return (AP_HAL::millis() - _io_timer_heartbeat) < 3000U || !hal.scheduler->is_system_initialized();
 }
 
 bool AP_Logger_File::logging_failed() const


### PR DESCRIPTION
A lot of things can soak up CPU during initialisation and the logging IO thread is very sensitive to this