### PR TITLE
AP_RangeFinder: TFminiPlus: change the frequency setting

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -126,7 +126,7 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::init()
 
     hal.scheduler->delay(100);
 
-    _dev->register_periodic_callback(10000,
+    _dev->register_periodic_callback(20000,
                                      FUNCTOR_BIND_MEMBER(&AP_RangeFinder_Benewake_TFMiniPlus::timer, void));
 
     return true;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -69,11 +69,11 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::init()
     const uint8_t CMD_SYSTEM_RESET[] =       { 0x5A, 0x04, 0x04, 0x62 };
     const uint8_t CMD_OUTPUT_FORMAT_CM[] =   { 0x5A, 0x05, 0x05, 0x01, 0x65 };
     const uint8_t CMD_ENABLE_DATA_OUTPUT[] = { 0x5A, 0x05, 0x07, 0x01, 0x67 };
-    const uint8_t CMD_FRAME_RATE_100HZ[] =   { 0x5A, 0x06, 0x03, 0x64, 0x00, 0xC7 };
+    const uint8_t CMD_FRAME_RATE_250HZ[] =   { 0x5A, 0x06, 0x03, 0xFA, 0x00, 0x5D };
     const uint8_t CMD_SAVE_SETTINGS[] =      { 0x5A, 0x04, 0x11, 0x6F };
     const uint8_t *cmds[] = {
         CMD_OUTPUT_FORMAT_CM,
-        CMD_FRAME_RATE_100HZ,
+        CMD_FRAME_RATE_250HZ,
         CMD_ENABLE_DATA_OUTPUT,
         CMD_SAVE_SETTINGS,
     };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -18,6 +18,7 @@
 
 #include <utility>
 
+#include <GCS_MAVLink/GCS.h>
 #include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;
@@ -101,8 +102,8 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::init()
     }
 
     if (val[5] * 10000 + val[4] * 100 + val[3] < 20003) {
-        hal.console->printf(DRIVER ": minimum required FW version 2.0.3, but version %u.%u.%u found\n",
-                            val[5], val[4], val[3]);
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "TFMini: FW ver %u.%u.%u (need>=2.0.3)",
+                            (unsigned)val[5],(unsigned)val[4],(unsigned)val[3]);
         goto fail;
     }
 


### PR DESCRIPTION
This is the replacement of #13765 and #13300. and this can fix #13411 and #12396.

Benewake says we can set TFminiPlus' frame rate to 250Hz here.
https://github.com/TFmini/TFminiPlus-IIC-Pixhawk/blob/master/Application%20of%20TFmini%20Plus%20IIC%20communication%20in%20Pixhawk.pdf
![image](https://user-images.githubusercontent.com/16643069/102684563-f8770800-421c-11eb-865f-cb85a03ff5b2.png)
So I changed the frame rate from 100Hz to 250Hz.

I also include #13765 and #13300 (a bit modified) for this PR.
I tested using some combination of these rates.
TFmini Plus frame rate: 100Hz, ArduPilot TFmini Plus driver's rate: 100Hz (current master)
TFmini Plus frame rate: 250Hz, ArduPilot TFmini Plus driver's rate: 100Hz
TFmini Plus frame rate: 250Hz, ArduPilot TFmini Plus driver's rate: 80Hz
TFmini Plus frame rate: 250Hz, ArduPilot TFmini Plus driver's rate: 50Hz (This PR)
![image](https://user-images.githubusercontent.com/16643069/102684565-02990680-421d-11eb-9eb8-78518efe8262.png)
And I chose TFmini Plus' frame rate is 250Hz and ArduPilot TFmini Plus driver's rate is 50Hz.
There is no noise.

I tested this code using TFmini Plus version 2.0.3 and 2.1.5.

@lucasdemarchi please review this again if you have the time.