### PR TITLE
Copter: add 6DoF support

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -42,6 +42,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Mission/AP_Mission.h>     // Mission command library
 #include <AC_AttitudeControl/AC_AttitudeControl_Multi.h> // Attitude control library
+#include <AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h> // 6DoF Attitude control library
 #include <AC_AttitudeControl/AC_AttitudeControl_Heli.h> // Attitude control library for traditional helicopter
 #include <AC_AttitudeControl/AC_PosControl.h>      // Position control library
 #include <AP_Motors/AP_Motors.h>          // AP Motors library

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -864,7 +864,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad, 14:Deca, 15:Scripting Matrix
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad, 14:Deca, 15:Scripting Matrix, 16:6DoF Scripting
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, DEFAULT_FRAME_CLASS),

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -484,6 +484,12 @@ void Copter::allocate_motors(void)
             motors = new AP_MotorsTailsitter(copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsTailsitter::var_info;
             break;
+        case AP_Motors::MOTOR_FRAME_6DOF_SCRIPTING:
+#ifdef ENABLE_SCRIPTING
+            motors = new AP_MotorsMatrix_6DoF_Scripting(copter.scheduler.get_loop_rate_hz());
+            motors_var_info = AP_MotorsMatrix_6DoF_Scripting::var_info;
+#endif // ENABLE_SCRIPTING
+            break;
 #else // FRAME_CONFIG == HELI_FRAME
         case AP_Motors::MOTOR_FRAME_HELI_DUAL:
             motors = new AP_MotorsHeli_Dual(copter.scheduler.get_loop_rate_hz());
@@ -518,8 +524,15 @@ void Copter::allocate_motors(void)
     const struct AP_Param::GroupInfo *ac_var_info;
 
 #if FRAME_CONFIG != HELI_FRAME
-    attitude_control = new AC_AttitudeControl_Multi(*ahrs_view, aparm, *motors, scheduler.get_loop_period_s());
-    ac_var_info = AC_AttitudeControl_Multi::var_info;
+    if ((AP_Motors::motor_frame_class)g2.frame_class.get() == AP_Motors::MOTOR_FRAME_6DOF_SCRIPTING) {
+#ifdef ENABLE_SCRIPTING
+        attitude_control = new AC_AttitudeControl_Multi_6DoF(*ahrs_view, aparm, *motors, scheduler.get_loop_period_s());
+        ac_var_info = AC_AttitudeControl_Multi_6DoF::var_info;
+#endif // ENABLE_SCRIPTING
+    } else {
+        attitude_control = new AC_AttitudeControl_Multi(*ahrs_view, aparm, *motors, scheduler.get_loop_period_s());
+        ac_var_info = AC_AttitudeControl_Multi::var_info;
+    }
 #else
     attitude_control = new AC_AttitudeControl_Heli(*ahrs_view, aparm, *motors, scheduler.get_loop_period_s());
     ac_var_info = AC_AttitudeControl_Heli::var_info;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -512,13 +512,13 @@ void Copter::allocate_motors(void)
 #endif
     }
     if (motors == nullptr) {
-        AP_HAL::panic("Unable to allocate FRAME_CLASS=%u", (unsigned)g2.frame_class.get());
+        AP_BoardConfig::config_error("Unable to allocate FRAME_CLASS=%u", (unsigned)g2.frame_class.get());
     }
     AP_Param::load_object_from_eeprom(motors, motors_var_info);
 
     ahrs_view = ahrs.create_view(ROTATION_NONE);
     if (ahrs_view == nullptr) {
-        AP_HAL::panic("Unable to allocate AP_AHRS_View");
+        AP_BoardConfig::config_error("Unable to allocate AP_AHRS_View");
     }
 
     const struct AP_Param::GroupInfo *ac_var_info;
@@ -538,13 +538,13 @@ void Copter::allocate_motors(void)
     ac_var_info = AC_AttitudeControl_Heli::var_info;
 #endif
     if (attitude_control == nullptr) {
-        AP_HAL::panic("Unable to allocate AttitudeControl");
+        AP_BoardConfig::config_error("Unable to allocate AttitudeControl");
     }
     AP_Param::load_object_from_eeprom(attitude_control, ac_var_info);
         
     pos_control = new AC_PosControl(*ahrs_view, inertial_nav, *motors, *attitude_control);
     if (pos_control == nullptr) {
-        AP_HAL::panic("Unable to allocate PosControl");
+        AP_BoardConfig::config_error("Unable to allocate PosControl");
     }
     AP_Param::load_object_from_eeprom(pos_control, pos_control->var_info);
 
@@ -554,20 +554,20 @@ void Copter::allocate_motors(void)
     wp_nav = new AC_WPNav(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
 #endif
     if (wp_nav == nullptr) {
-        AP_HAL::panic("Unable to allocate WPNav");
+        AP_BoardConfig::config_error("Unable to allocate WPNav");
     }
     AP_Param::load_object_from_eeprom(wp_nav, wp_nav->var_info);
 
     loiter_nav = new AC_Loiter(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
     if (loiter_nav == nullptr) {
-        AP_HAL::panic("Unable to allocate LoiterNav");
+        AP_BoardConfig::config_error("Unable to allocate LoiterNav");
     }
     AP_Param::load_object_from_eeprom(loiter_nav, loiter_nav->var_info);
 
 #if MODE_CIRCLE_ENABLED == ENABLED
     circle_nav = new AC_Circle(inertial_nav, *ahrs_view, *pos_control);
     if (circle_nav == nullptr) {
-        AP_HAL::panic("Unable to allocate CircleNav");
+        AP_BoardConfig::config_error("Unable to allocate CircleNav");
     }
     AP_Param::load_object_from_eeprom(circle_nav, circle_nav->var_info);
 #endif

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -212,6 +212,11 @@ void AC_AttitudeControl::reset_rate_controller_I_terms_smoothly()
 // Command a Quaternion attitude with feedforward and smoothing
 void AC_AttitudeControl::input_quaternion(Quaternion attitude_desired_quat)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // this function is not currently used, this is a reminder that we need to add a 6DoF implementation
+    AP_HAL::panic("input_quaternion not implemented AC_AttitudeControl_Multi_6DoF");
+#endif
+
     // calculate the attitude target euler angles
     _attitude_target_quat.to_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -133,7 +133,7 @@ public:
     void inertial_frame_reset();
 
     // Command a Quaternion attitude with feedforward and smoothing
-    void input_quaternion(Quaternion attitude_desired_quat);
+    virtual void input_quaternion(Quaternion attitude_desired_quat);
 
     // Command an euler roll and pitch angle and an euler yaw rate with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
@@ -147,16 +147,16 @@ public:
         float euler_pitch_angle_cd, float euler_yaw_rate_cds) {}
 
     // Command an euler roll, pitch, and yaw rate with angular velocity feedforward and smoothing
-    void input_euler_rate_roll_pitch_yaw(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds);
+    virtual void input_euler_rate_roll_pitch_yaw(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds);
 
     // Command an angular velocity with angular velocity feedforward and smoothing
     virtual void input_rate_bf_roll_pitch_yaw(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
 
     // Command an angular velocity with angular velocity feedforward and smoothing
-    void input_rate_bf_roll_pitch_yaw_2(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
+    virtual void input_rate_bf_roll_pitch_yaw_2(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
 
     // Command an angular velocity with angular velocity smoothing using rate loops only with integrated rate error stabilization
-    void input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
+    virtual void input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
 
     // Command an angular step (i.e change) in body frame angle
     virtual void input_angle_step_bf_roll_pitch_yaw(float roll_angle_step_bf_cd, float pitch_angle_step_bf_cd, float yaw_angle_step_bf_cd);
@@ -260,7 +260,7 @@ public:
     float angle_boost() const { return _angle_boost; }
 
     // Return tilt angle limit for pilot input that prioritises altitude hold over lean angle
-    float get_althold_lean_angle_max() const;
+    virtual float get_althold_lean_angle_max() const;
 
     // Return configured tilt angle limit in centidegrees
     float lean_angle_max() const { return _aparm.angle_max; }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
@@ -124,6 +124,20 @@ void AC_AttitudeControl_Multi_6DoF::input_angle_step_bf_roll_pitch_yaw(float rol
     AC_AttitudeControl_Multi::input_angle_step_bf_roll_pitch_yaw(roll_angle_step_bf_cd, pitch_angle_step_bf_cd, yaw_angle_step_bf_cd);
 }
 
+// Command a Quaternion attitude with feedforward and smoothing
+// not used anywhere in current code, panic in SITL so this implementaiton is not overlooked
+void AC_AttitudeControl_Multi_6DoF::input_quaternion(Quaternion attitude_desired_quat) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    AP_HAL::panic("input_quaternion not implemented AC_AttitudeControl_Multi_6DoF");
+#endif
+
+    _motors.set_lateral(0.0f);
+    _motors.set_forward(0.0f);
+
+    AC_AttitudeControl_Multi::input_quaternion(attitude_desired_quat);
+}
+
+
 AC_AttitudeControl_Multi_6DoF *AC_AttitudeControl_Multi_6DoF::_singleton = nullptr;
 
 #endif // ENABLE_SCRIPTING

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
@@ -1,0 +1,129 @@
+#ifdef ENABLE_SCRIPTING
+
+#include "AC_AttitudeControl_Multi_6DoF.h"
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+
+// 6DoF control is extracted from the existing copter code by treating desired angles as thrust angles rather than vehicle attitude.
+// Vehicle attitude is then set separately, typically the vehicle would matain 0 roll and pitch.
+// rate commands result in the vehicle behaving as a ordinary copter.
+
+// run lowest level body-frame rate controller and send outputs to the motors
+void AC_AttitudeControl_Multi_6DoF::rate_controller_run() {
+
+    // pass current offsets to motors and run baseclass controller
+    // motors require the offsets to know which way is up
+    float roll_deg = roll_offset_deg;
+    float pitch_deg = pitch_offset_deg;
+    // if 6DoF control, always point directly up
+    // this stops horizontal drift due to error between target and true attitude
+    if (lateral_enable) {
+        roll_deg = degrees(AP::ahrs().get_roll());
+    }
+    if (forward_enable) {
+        pitch_deg = degrees(AP::ahrs().get_pitch());
+    }
+    _motors.set_roll_pitch(roll_deg,pitch_deg);
+
+    AC_AttitudeControl_Multi::rate_controller_run();
+}
+
+/*
+    override all input to the attitude controller and convert desired angles into thrust angles and substitute
+*/
+
+// Command an euler roll and pitch angle and an euler yaw rate with angular velocity feedforward and smoothing
+void AC_AttitudeControl_Multi_6DoF::input_euler_angle_roll_pitch_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds) {
+
+    set_forward_lateral(euler_pitch_angle_cd, euler_roll_angle_cd);
+
+    AC_AttitudeControl_Multi::input_euler_angle_roll_pitch_euler_rate_yaw(euler_roll_angle_cd, euler_pitch_angle_cd, euler_yaw_rate_cds);
+}
+
+// Command an euler roll, pitch and yaw angle with angular velocity feedforward and smoothing
+void AC_AttitudeControl_Multi_6DoF::input_euler_angle_roll_pitch_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, bool slew_yaw) {
+
+    set_forward_lateral(euler_pitch_angle_cd, euler_roll_angle_cd);
+
+    AC_AttitudeControl_Multi::input_euler_angle_roll_pitch_yaw(euler_roll_angle_cd, euler_pitch_angle_cd, euler_yaw_angle_cd, slew_yaw);
+}
+
+void AC_AttitudeControl_Multi_6DoF::set_forward_lateral(float &euler_pitch_angle_cd, float &euler_roll_angle_cd)
+{
+    // pitch/forward
+    if (forward_enable) {
+        _motors.set_forward(-sinf(radians(euler_pitch_angle_cd * 0.01f)));
+        euler_pitch_angle_cd = pitch_offset_deg * 100.0f;
+    } else {
+        _motors.set_forward(0.0f);
+        euler_pitch_angle_cd += pitch_offset_deg * 100.0f;
+    }
+    euler_pitch_angle_cd = wrap_180_cd(euler_pitch_angle_cd);
+
+    // roll/lateral
+    if (lateral_enable) {
+        _motors.set_lateral(sinf(radians(euler_roll_angle_cd * 0.01f)));
+        euler_roll_angle_cd = roll_offset_deg * 100.0f;
+    } else {
+        _motors.set_lateral(0.0f);
+        euler_roll_angle_cd += roll_offset_deg * 100.0f;
+    }
+    euler_roll_angle_cd = wrap_180_cd(euler_roll_angle_cd);
+}
+
+/*
+    all other input functions should zero thrust vectoring
+*/
+
+// Command euler yaw rate and pitch angle with roll angle specified in body frame
+// (used only by tailsitter quadplanes)
+void AC_AttitudeControl_Multi_6DoF::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds) {
+    _motors.set_lateral(0.0f);
+    _motors.set_forward(0.0f);
+
+    AC_AttitudeControl_Multi::input_euler_rate_yaw_euler_angle_pitch_bf_roll(plane_controls, euler_roll_angle_cd, euler_pitch_angle_cd, euler_yaw_rate_cds);
+}
+
+// Command an euler roll, pitch, and yaw rate with angular velocity feedforward and smoothing
+void AC_AttitudeControl_Multi_6DoF::input_euler_rate_roll_pitch_yaw(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds) {
+    _motors.set_lateral(0.0f);
+    _motors.set_forward(0.0f);
+
+    AC_AttitudeControl_Multi::input_euler_rate_roll_pitch_yaw(euler_roll_rate_cds, euler_pitch_rate_cds, euler_yaw_rate_cds);
+}
+
+// Command an angular velocity with angular velocity feedforward and smoothing
+void AC_AttitudeControl_Multi_6DoF::input_rate_bf_roll_pitch_yaw(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds) {
+    _motors.set_lateral(0.0f);
+    _motors.set_forward(0.0f);
+
+    AC_AttitudeControl_Multi::input_rate_bf_roll_pitch_yaw(roll_rate_bf_cds, pitch_rate_bf_cds, yaw_rate_bf_cds);
+}
+
+// Command an angular velocity with angular velocity feedforward and smoothing
+void AC_AttitudeControl_Multi_6DoF::input_rate_bf_roll_pitch_yaw_2(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds) {
+    _motors.set_lateral(0.0f);
+    _motors.set_forward(0.0f);
+
+    AC_AttitudeControl_Multi::input_rate_bf_roll_pitch_yaw_2(roll_rate_bf_cds, pitch_rate_bf_cds, yaw_rate_bf_cds);
+}
+
+// Command an angular velocity with angular velocity smoothing using rate loops only with integrated rate error stabilization
+void AC_AttitudeControl_Multi_6DoF::input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds) {
+    _motors.set_lateral(0.0f);
+    _motors.set_forward(0.0f);
+
+    AC_AttitudeControl_Multi::input_rate_bf_roll_pitch_yaw_3(roll_rate_bf_cds, pitch_rate_bf_cds, yaw_rate_bf_cds);
+}
+
+// Command an angular step (i.e change) in body frame angle
+void AC_AttitudeControl_Multi_6DoF::input_angle_step_bf_roll_pitch_yaw(float roll_angle_step_bf_cd, float pitch_angle_step_bf_cd, float yaw_angle_step_bf_cd) {
+    _motors.set_lateral(0.0f);
+    _motors.set_forward(0.0f);
+
+    AC_AttitudeControl_Multi::input_angle_step_bf_roll_pitch_yaw(roll_angle_step_bf_cd, pitch_angle_step_bf_cd, yaw_angle_step_bf_cd);
+}
+
+AC_AttitudeControl_Multi_6DoF *AC_AttitudeControl_Multi_6DoF::_singleton = nullptr;
+
+#endif // ENABLE_SCRIPTING

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
@@ -1,0 +1,96 @@
+#pragma once
+#ifdef ENABLE_SCRIPTING
+
+#include "AC_AttitudeControl_Multi.h"
+
+class AC_AttitudeControl_Multi_6DoF : public AC_AttitudeControl_Multi {
+public:
+    AC_AttitudeControl_Multi_6DoF(AP_AHRS_View &ahrs, const AP_Vehicle::MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt):
+        AC_AttitudeControl_Multi(ahrs,aparm,motors,dt) {
+
+        if (_singleton != nullptr) {
+            AP_HAL::panic("Can only be one AC_AttitudeControl_Multi_6DoF");
+        }
+        _singleton = this;
+    }
+
+    static AC_AttitudeControl_Multi_6DoF *get_singleton() {
+        return _singleton;
+    }
+
+    // Command a Quaternion attitude with feedforward and smoothing
+    // not used anywhere in current code, panic so this implementaiton is not overlooked
+    void input_quaternion(Quaternion attitude_desired_quat) override {
+        AP_HAL::panic("input_quaternion not implemented AC_AttitudeControl_Multi_6DoF");
+    }
+
+    /*
+        override input functions to attitude controller and convert desired angles into thrust angles and substitute for osset angles
+    */
+
+    // Command an euler roll and pitch angle and an euler yaw rate with angular velocity feedforward and smoothing
+    void input_euler_angle_roll_pitch_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds)  override;
+
+    // Command an euler roll, pitch and yaw angle with angular velocity feedforward and smoothing
+    void input_euler_angle_roll_pitch_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, bool slew_yaw) override;
+
+    /*
+        all other input functions should zero thrust vectoring and behave as a normal copter
+    */
+
+    // Command euler yaw rate and pitch angle with roll angle specified in body frame
+    // (used only by tailsitter quadplanes)
+    void input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool plane_controls, float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds) override;
+
+    // Command an euler roll, pitch, and yaw rate with angular velocity feedforward and smoothing
+    void input_euler_rate_roll_pitch_yaw(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds) override;
+
+     // Command an angular velocity with angular velocity feedforward and smoothing
+    void input_rate_bf_roll_pitch_yaw(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds) override;
+
+    // Command an angular velocity with angular velocity feedforward and smoothing
+    void input_rate_bf_roll_pitch_yaw_2(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds) override;
+
+    // Command an angular velocity with angular velocity smoothing using rate loops only with integrated rate error stabilization
+    void input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds) override;
+
+    // Command an angular step (i.e change) in body frame angle
+    void input_angle_step_bf_roll_pitch_yaw(float roll_angle_step_bf_cd, float pitch_angle_step_bf_cd, float yaw_angle_step_bf_cd) override;
+
+    // run lowest level body-frame rate controller and send outputs to the motors
+    void rate_controller_run() override;
+
+    // limiting lean angle based on throttle makes no sense for 6DoF, always allow 90 deg, return in centi-degrees
+    float get_althold_lean_angle_max() const override { return 9000.0f; }
+
+    // set the attitude that will be used in 6DoF flight
+    void set_offset_roll_pitch(float roll_deg, float pitch_deg) {
+        roll_offset_deg = roll_deg;
+        pitch_offset_deg = pitch_deg;
+    }
+
+    // these flags enable or disable lateral or forward thrust, with both disabled the vehicle acts like a traditional copter
+    // it will roll and pitch to move, its also possible to enable only forward or lateral to suit the vehicle configuration.
+    // by default the vehicle is full 6DoF, these can be set in flight via scripting
+    void set_forward_enable(bool b) {
+        forward_enable = b;
+    }
+    void set_lateral_enable(bool b) {
+        lateral_enable = b;
+    }
+
+private:
+
+    void set_forward_lateral(float &euler_pitch_angle_cd, float &euler_roll_angle_cd);
+
+    float roll_offset_deg;
+    float pitch_offset_deg;
+
+    bool forward_enable = true;
+    bool lateral_enable = true;
+
+    static AC_AttitudeControl_Multi_6DoF *_singleton;
+
+};
+
+#endif // ENABLE_SCRIPTING

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
@@ -20,10 +20,7 @@ public:
 
     // Command a Quaternion attitude with feedforward and smoothing
     // not used anywhere in current code, panic so this implementaiton is not overlooked
-    void input_quaternion(Quaternion attitude_desired_quat) override {
-        AP_HAL::panic("input_quaternion not implemented AC_AttitudeControl_Multi_6DoF");
-    }
-
+    void input_quaternion(Quaternion attitude_desired_quat) override;
     /*
         override input functions to attitude controller and convert desired angles into thrust angles and substitute for osset angles
     */

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -11,3 +11,4 @@
 #include "AP_MotorsCoax.h"
 #include "AP_MotorsTailsitter.h"
 #include "AP_Motors6DOF.h"
+#include "AP_MotorsMatrix_6DoF_Scripting.h"

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -89,8 +89,6 @@ bool AP_MotorsMatrix::init(uint8_t expected_num_motors)
 
     set_update_rate(_speed_hz);
 
-    set_initialised_ok(true);
-
     return true;
 }
 #endif // ENABLE_SCRIPTING

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -34,7 +34,7 @@ public:
 
 #ifdef ENABLE_SCRIPTING
     // Init to be called from scripting
-    bool                init(uint8_t expected_num_motors);
+    virtual bool        init(uint8_t expected_num_motors);
 #endif // ENABLE_SCRIPTING
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -1,0 +1,325 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef ENABLE_SCRIPTING
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_MotorsMatrix_6DoF_Scripting.h"
+#include <AP_Vehicle/AP_Vehicle.h>
+
+extern const AP_HAL::HAL& hal;
+
+void AP_MotorsMatrix_6DoF_Scripting::output_to_motors()
+{
+    switch (_spool_state) {
+        case SpoolState::SHUT_DOWN:
+        case SpoolState::GROUND_IDLE:
+        {
+            // no output, cant spin up for ground idle because we don't know which way motors should be spining
+            for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+                if (motor_enabled[i]) {
+                    _actuator[i] = 0.0f;
+                }
+            }
+            break;
+        }
+        case SpoolState::SPOOLING_UP:
+        case SpoolState::THROTTLE_UNLIMITED:
+        case SpoolState::SPOOLING_DOWN:
+            // set motor output based on thrust requests
+            for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+                if (motor_enabled[i]) {
+                    if (_reversible[i]) {
+                        // revesible motor can provide both positive and negative thrust, +- spin max, spin min does not apply
+                        if (is_positive(_thrust_rpyt_out[i])) { 
+                            _actuator[i] = apply_thrust_curve_and_volt_scaling(_thrust_rpyt_out[i]) * _spin_max;
+
+                        } else if (is_negative(_thrust_rpyt_out[i])) {
+                            _actuator[i] = -apply_thrust_curve_and_volt_scaling(-_thrust_rpyt_out[i]) * _spin_max;
+
+                        } else {
+                            _actuator[i] = 0.0f;
+                        }
+                    } else {
+                        // motor can only provide trust in a single direction, spin min to spin max as 'normal' copter
+                         _actuator[i] = thrust_to_actuator(_thrust_rpyt_out[i]);
+                    }
+                }
+            }
+            break;
+    }
+
+    // Send to each motor
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            SRV_Channels::set_output_scaled(SRV_Channels::get_motor_function(i), _actuator[i] * 4500);
+        }
+    }
+}
+
+// output_armed - sends commands to the motors
+void AP_MotorsMatrix_6DoF_Scripting::output_armed_stabilizing()
+{
+    uint8_t i;                          // general purpose counter
+    float   roll_thrust;                // roll thrust input value, +/- 1.0
+    float   pitch_thrust;               // pitch thrust input value, +/- 1.0
+    float   yaw_thrust;                 // yaw thrust input value, +/- 1.0
+    float   throttle_thrust;            // throttle thrust input value, 0.0 - 1.0
+    float   forward_thrust;             // forward thrust input value, +/- 1.0
+    float   right_thrust;               // right thrust input value, +/- 1.0
+
+    // note that the throttle, forwards and right inputs are not in bodyframe, they are in the frame of the 'normal' 4DoF copter were pretending to be
+
+    // apply voltage and air pressure compensation
+    const float compensation_gain = get_compensation_gain(); // compensation for battery voltage and altitude
+    roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
+    pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
+    yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;
+    throttle_thrust = get_throttle() * compensation_gain;
+
+    // scale horizontal thrust with throttle, this mimics a normal copter
+    // so we don't break the lean angle proportional acceleration assumption made by the position controller
+    forward_thrust = get_forward() * throttle_thrust;
+    right_thrust = get_lateral() * throttle_thrust;
+
+
+    // set throttle limit flags
+    if (throttle_thrust <= 0) {
+        throttle_thrust = 0;
+        // we cant thrust down, the vehicle can do it, but it would break a lot of assumptions further up the control stack
+        // 1G decent probably plenty anyway....
+        limit.throttle_lower = true;
+    }
+    if (throttle_thrust >= 1) {
+        throttle_thrust = 1;
+        limit.throttle_upper = true;
+    }
+
+    // rotate the thrust into bodyframe
+    Matrix3f rot;
+    Vector3f thrust_vec;
+    rot.from_euler312(_roll_offset, _pitch_offset, 0.0f);
+
+
+    /*
+        upwards thrust, independent of orientation
+    */
+    thrust_vec.x = 0.0f;
+    thrust_vec.y = 0.0f;
+    thrust_vec.z = throttle_thrust;
+    thrust_vec = rot * thrust_vec;
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            _thrust_rpyt_out[i] =  thrust_vec.x * _forward_factor[i];
+            _thrust_rpyt_out[i] += thrust_vec.y * _right_factor[i];
+            _thrust_rpyt_out[i] += thrust_vec.z * _throttle_factor[i];
+
+            if (fabsf(_thrust_rpyt_out[i]) >= 1) {
+                // if we hit this the mixer is probably scaled incorrectly
+                limit.throttle_upper = true;
+            }
+            _thrust_rpyt_out[i] = constrain_float(_thrust_rpyt_out[i],-1.0f,1.0f);
+        }
+    }
+
+
+    /*
+        rotations: roll, pitch and yaw
+    */
+    float rpy_ratio = 1.0f;  // scale factor, output will be scaled by this ratio so it can all fit evenly
+    float thrust[AP_MOTORS_MAX_NUM_MOTORS];
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            thrust[i] =  roll_thrust * _roll_factor[i];
+            thrust[i] += pitch_thrust * _pitch_factor[i];
+            thrust[i] += yaw_thrust * _yaw_factor[i];
+            float total_thrust = _thrust_rpyt_out[i] + thrust[i];
+            // control input will be limited by motor range
+            if (total_thrust > 1.0f) {
+                rpy_ratio = MIN(rpy_ratio,(1.0f - _thrust_rpyt_out[i]) / thrust[i]);
+            } else if (total_thrust < -1.0f) {
+                rpy_ratio = MIN(rpy_ratio,(-1.0f -_thrust_rpyt_out[i]) / thrust[i]);
+            }
+        }
+    }
+
+    // set limit flags if output is being scaled
+    if (rpy_ratio < 1) {
+        limit.roll = true;
+        limit.pitch = true;
+        limit.yaw = true;
+    }
+
+    // scale back rotations evenly so it will all fit
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            _thrust_rpyt_out[i] = constrain_float(_thrust_rpyt_out[i] + thrust[i] * rpy_ratio,-1.0f,1.0f);
+        }
+    }
+
+    /*
+        forward and lateral, independent of orentaiton
+    */
+    thrust_vec.x = forward_thrust;
+    thrust_vec.y = right_thrust;
+    thrust_vec.z = 0.0f;
+    thrust_vec = rot * thrust_vec;
+
+    float horz_ratio = 1.0f; 
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            thrust[i] =  thrust_vec.x * _forward_factor[i];
+            thrust[i] += thrust_vec.y * _right_factor[i];
+            thrust[i] += thrust_vec.z * _throttle_factor[i];
+            float total_thrust = _thrust_rpyt_out[i] + thrust[i];
+            // control input will be limited by motor range
+            if (total_thrust > 1.0f) {
+                horz_ratio = MIN(horz_ratio,(1.0f - _thrust_rpyt_out[i]) / thrust[i]);
+            } else if (total_thrust < -1.0f) {
+                horz_ratio = MIN(horz_ratio,(-1.0f -_thrust_rpyt_out[i]) / thrust[i]);
+            }
+        }
+    }
+
+    // scale back evenly so it will all fit
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            _thrust_rpyt_out[i] = constrain_float(_thrust_rpyt_out[i] + thrust[i] * horz_ratio,-1.0f,1.0f);
+        }
+    }
+
+    /*
+        apply deadzone to revesible motors, this stops motors from reversing direction too often
+        re-use yaw headroom param for deadzone, constain to a max of 25%
+    */
+    const float deadzone = constrain_float(_yaw_headroom.get() * 0.001f,0.0f,0.25f);
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i] && _reversible[i]) {
+            if (is_negative(_thrust_rpyt_out[i])) {
+                if ((_thrust_rpyt_out[i] > -deadzone) && is_positive(_last_thrust_out[i])) {
+                    _thrust_rpyt_out[i] = 0.0f;
+                } else {
+                    _last_thrust_out[i] = _thrust_rpyt_out[i];
+                }
+            } else if (is_positive(_thrust_rpyt_out[i])) {
+                if ((_thrust_rpyt_out[i] < deadzone) && is_negative(_last_thrust_out[i])) {
+                    _thrust_rpyt_out[i] = 0.0f;
+                } else {
+                    _last_thrust_out[i] = _thrust_rpyt_out[i];
+                }
+            }
+        }
+    }
+
+}
+
+// sets the roll and pitch offset, this rotates the thrust vector in body frame
+// these are typically set such that the throttle thrust vector is earth frame up
+void AP_MotorsMatrix_6DoF_Scripting::set_roll_pitch(float roll_deg, float pitch_deg)
+{
+    _roll_offset = radians(roll_deg);
+    _pitch_offset = radians(pitch_deg);
+}
+
+// add_motor, take roll, pitch, yaw, throttle(up), forward, right factors along with a bool if the motor is reversible and the testing order, called from scripting
+void AP_MotorsMatrix_6DoF_Scripting::add_motor(int8_t motor_num, float roll_factor, float pitch_factor, float yaw_factor, float throttle_factor, float forward_factor, float right_factor, bool reversible, uint8_t testing_order)
+{
+    if (initialised_ok()) {
+        // don't allow matrix to be changed after init
+        return;
+    }
+
+    // ensure valid motor number is provided
+    if (motor_num >= 0 && motor_num < AP_MOTORS_MAX_NUM_MOTORS) {
+        motor_enabled[motor_num] = true;
+
+        _roll_factor[motor_num] = roll_factor;
+        _pitch_factor[motor_num] = pitch_factor;
+        _yaw_factor[motor_num] = yaw_factor;
+
+        _throttle_factor[motor_num] = throttle_factor;
+        _forward_factor[motor_num] = forward_factor;
+        _right_factor[motor_num] = right_factor;
+
+        // set order that motor appears in test
+        _test_order[motor_num] = testing_order;
+
+        // ensure valid motor number is provided
+        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
+        SRV_Channels::set_aux_channel_default(function, motor_num);
+
+        uint8_t chan;
+        if (!SRV_Channels::find_channel(function, chan)) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
+            return;
+        }
+
+        _reversible[motor_num] = reversible;
+        if (_reversible[motor_num]) {
+            // reversible, set to angle type hard code trim to 1500
+            SRV_Channels::set_angle(function, 4500);
+            SRV_Channels::set_trim_to_pwm_for(function, 1500);
+        } else {
+            SRV_Channels::set_range(function, 4500);
+        }
+        SRV_Channels::set_output_min_max(function, get_pwm_output_min(), get_pwm_output_max());
+    }
+}
+
+bool AP_MotorsMatrix_6DoF_Scripting::init(uint8_t expected_num_motors) {
+    uint8_t num_motors = 0;
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            num_motors++;
+        }
+    }
+
+    set_initialised_ok(expected_num_motors == num_motors);
+
+    if (!initialised_ok()) {
+        _mav_type = MAV_TYPE_GENERIC;
+        return false;
+    }
+
+    switch (num_motors) {
+        case 3:
+            _mav_type = MAV_TYPE_TRICOPTER;
+            break;
+        case 4:
+            _mav_type = MAV_TYPE_QUADROTOR;
+            break;
+        case 6:
+            _mav_type = MAV_TYPE_HEXAROTOR;
+            break;
+        case 8:
+            _mav_type = MAV_TYPE_OCTOROTOR;
+            break;
+        case 10:
+            _mav_type = MAV_TYPE_DECAROTOR;
+            break;
+        case 12:
+            _mav_type = MAV_TYPE_DODECAROTOR;
+            break;
+        default:
+            _mav_type = MAV_TYPE_GENERIC;
+    }
+
+    return true;
+}
+
+// singleton instance
+AP_MotorsMatrix_6DoF_Scripting *AP_MotorsMatrix_6DoF_Scripting::_singleton;
+
+#endif // ENABLE_SCRIPTING

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h
@@ -1,0 +1,66 @@
+#pragma once
+#ifdef ENABLE_SCRIPTING
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include <RC_Channel/RC_Channel.h>
+#include "AP_MotorsMatrix.h"
+
+class AP_MotorsMatrix_6DoF_Scripting : public AP_MotorsMatrix {
+public:
+
+    /// Constructor
+    AP_MotorsMatrix_6DoF_Scripting(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_MotorsMatrix(loop_rate, speed_hz)
+    {
+        if (_singleton != nullptr) {
+            AP_HAL::panic("AP_MotorsMatrix 6DoF must be singleton");
+        }
+        _singleton = this;
+    };
+
+    // get singleton instance
+    static AP_MotorsMatrix_6DoF_Scripting *get_singleton() {
+        return _singleton;
+    }
+
+    // output_to_motors - sends minimum values out to the motors
+    void output_to_motors() override;
+
+    // sets the roll and pitch offset, this rotates the thrust vector in body frame
+    // these are typically set such that the throttle thrust vector is earth frame up
+    void set_roll_pitch(float roll_deg, float pitch_deg) override;
+
+    // add_motor using raw roll, pitch, throttle and yaw factors, to be called from scripting
+    void add_motor(int8_t motor_num, float roll_factor, float pitch_factor, float yaw_factor, float throttle_factor, float forward_factor, float right_factor, bool reversible, uint8_t testing_order);
+
+    // if the expected number of motors have been setup then set as initalized
+    bool init(uint8_t expected_num_motors) override;
+
+protected:
+    // output - sends commands to the motors
+    void output_armed_stabilizing() override;
+
+    // nothing to do for setup, scripting will mark as initalized when done
+    void setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override {};
+
+    float _throttle_factor[AP_MOTORS_MAX_NUM_MOTORS];     // each motors contribution to up thrust
+    float _forward_factor[AP_MOTORS_MAX_NUM_MOTORS];      // each motors contribution to forward thrust
+    float _right_factor[AP_MOTORS_MAX_NUM_MOTORS];        // each motors contribution to right thrust
+
+    // true if motor is revesible, it can go from -Spin max to +Spin max, if false motor is can go from Spin min to Spin max
+    bool _reversible[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // store last values to allow deadzone
+    float _last_thrust_out[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // Current offset angles, radians
+    float _roll_offset;
+    float _pitch_offset;
+
+private:
+    static AP_MotorsMatrix_6DoF_Scripting *_singleton;
+
+};
+
+#endif // ENABLE_SCRIPTING

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h
@@ -37,6 +37,8 @@ public:
     // if the expected number of motors have been setup then set as initalized
     bool init(uint8_t expected_num_motors) override;
 
+    const char* get_frame_string() const override { return "6DoF scripting"; }
+
 protected:
     // output - sends commands to the motors
     void output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -46,6 +46,7 @@ public:
         MOTOR_FRAME_HELI_QUAD = 13,
         MOTOR_FRAME_DECA = 14,
         MOTOR_FRAME_SCRIPTING_MATRIX = 15,
+        MOTOR_FRAME_6DOF_SCRIPTING = 16,
     };
 
     // return string corresponding to frame_class
@@ -105,6 +106,9 @@ public:
     void                set_throttle_filter_cutoff(float filt_hz) { _throttle_filter.set_cutoff_frequency(filt_hz); }
     void                set_forward(float forward_in) { _forward_in = forward_in; }; // range -1 ~ +1
     void                set_lateral(float lateral_in) { _lateral_in = lateral_in; };     // range -1 ~ +1
+
+    // for 6DoF vehicles, sets the roll and pitch offset, this rotates the thrust vector in body frame
+    virtual void        set_roll_pitch(float roll_deg, float pitch_deg) {};
 
     // accessors for roll, pitch, yaw and throttle inputs to motors
     float               get_roll() const { return _roll_in; }

--- a/libraries/AP_Scripting/examples/6DoF_roll_pitch.lua
+++ b/libraries/AP_Scripting/examples/6DoF_roll_pitch.lua
@@ -1,0 +1,60 @@
+-- A script for controlling the roll and pitch of 6DoF vehicles
+-- The script sets the target roll and pitch to the current value when arming or when E-stop is removed
+-- this allows the vehicle to be placed upside-down on the ground and to take off as normal
+-- its is also possible to setup a switch with option 300 to use either 4 or 6DoF control
+
+-- make sure the vehicle is capable of 6DoF control
+assert(param:get('FRAME_CLASS') == 16, "script requires a 6DoF vehicle")
+
+local e_stop = rc:find_channel_for_option(31)
+local sw = rc:find_channel_for_option(300)
+local motors_spinning = false
+
+function update() -- this is the loop which periodically runs
+
+  -- motor state
+  local current_motors_spinning = false
+
+  if arming:is_armed() then
+    -- if armed then motors are spinning
+    current_motors_spinning = true
+  end
+
+  if e_stop then
+    -- if E-stop switch is setup
+    if e_stop:get_aux_switch_pos() == 2 then
+      -- E-stop on, motors stopped
+      current_motors_spinning = false
+    end
+  end
+
+  if not motors_spinning and current_motors_spinning then
+    -- Just armed or removed E-stop
+    -- set offsets to current attitude
+    local roll = math.deg(ahrs:get_roll())
+    local pitch = math.deg(ahrs:get_pitch())
+    attitude_control:set_offset_roll_pitch(roll,pitch)
+    gcs:send_text(0, string.format("Set Offsets Roll: %0.1f, Pitch: %0.1f",roll,pitch))
+
+    if sw then
+      if sw:get_aux_switch_pos() == 2 then
+        -- switch to 'normal' 4 DoF attitude control
+        gcs:send_text(0, "4 DoF attitude control")
+        attitude_control:set_lateral_enable(false)
+        attitude_control:set_forward_enable(false)
+
+      else
+        -- 6DoF attutude control
+        gcs:send_text(0, "6 DoF attitude control")
+        attitude_control:set_lateral_enable(true)
+        attitude_control:set_forward_enable(true)
+      end
+    end
+
+  end
+  motors_spinning = current_motors_spinning
+
+  return update, 100 -- 10hz
+end
+
+return update()

--- a/libraries/AP_Scripting/examples/Motors_6DoF_LynchPin.lua
+++ b/libraries/AP_Scripting/examples/Motors_6DoF_LynchPin.lua
@@ -1,0 +1,10 @@
+-- This script loads the 6DoF mixer matrix for the LynchPin frame
+
+Motors_6DoF:add_motor(0,  0.012558,  0.391064,  0.069463,  0.867789,  0.507225, -0.015613, true, 1)
+Motors_6DoF:add_motor(1, -0.385797, -0.187969,  0.106479,  0.782773, -0.243803,  0.479664, true, 2)
+Motors_6DoF:add_motor(2,  0.373240, -0.203095, -0.105312,  0.865451, -0.263422, -0.464051, true, 3)
+Motors_6DoF:add_motor(3, -0.153922, -0.166480, -0.345955,  0.003411,  0.908383, -0.456939, true, 4)
+Motors_6DoF:add_motor(4, -0.210017, -0.010839,  0.379773, -0.056142, -0.014059, -1.035508, true, 5)
+Motors_6DoF:add_motor(5,  0.142076, -0.202427,  0.347056, -0.030879,  0.861758,  0.471667, true, 6)
+
+assert(Motors_6DoF:init(6),'unable to setup 6 motors')

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -304,7 +304,7 @@ singleton QuadPlane alias quadplane
 singleton QuadPlane depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)
 singleton QuadPlane method in_vtol_mode boolean
 
-include AP_Motors/AP_MotorsMatrix.h
+include AP_Motors/AP_MotorsMatrix.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 singleton AP_MotorsMatrix depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 singleton AP_MotorsMatrix alias MotorsMatrix
 singleton AP_MotorsMatrix method init boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
@@ -314,3 +314,11 @@ include AP_Frsky_Telem/AP_Frsky_SPort.h
 singleton AP_Frsky_SPort alias frsky_sport
 singleton AP_Frsky_SPort method sport_telemetry_push boolean uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX uint16_t 0 UINT16_MAX int32_t -INT32_MAX INT32_MAX
 singleton AP_Frsky_SPort method prep_number uint16_t int32_t INT32_MIN INT32_MAX uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX
+
+include AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h depends APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+singleton AC_AttitudeControl_Multi_6DoF depends APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+singleton AC_AttitudeControl_Multi_6DoF alias attitude_control
+singleton AC_AttitudeControl_Multi_6DoF method set_lateral_enable void boolean
+singleton AC_AttitudeControl_Multi_6DoF method set_forward_enable void boolean
+singleton AC_AttitudeControl_Multi_6DoF method set_offset_roll_pitch void float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX
+

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -322,3 +322,9 @@ singleton AC_AttitudeControl_Multi_6DoF method set_lateral_enable void boolean
 singleton AC_AttitudeControl_Multi_6DoF method set_forward_enable void boolean
 singleton AC_AttitudeControl_Multi_6DoF method set_offset_roll_pitch void float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX
 
+
+include AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h  depends APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+singleton AP_MotorsMatrix_6DoF_Scripting depends APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+singleton AP_MotorsMatrix_6DoF_Scripting alias Motors_6DoF
+singleton AP_MotorsMatrix_6DoF_Scripting method init boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
+singleton AP_MotorsMatrix_6DoF_Scripting method add_motor void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)


### PR DESCRIPTION
This adds support for copters that can fly in any direction and at any orientation.

https://youtu.be/CXIlZ8mCfGM

This adds a new attitude control and motor back-end and scripting bindings for each. Scripting can be used to set the true vehicle attitude while the existing navigation 'attitude' is used for the thrust vector. Scripting is also used to set the 6DoF matrix for the mixer. I did spend a some time trying to calculate the mixer directly from motor positions and trust vectors, but it all got too complex. The ideal mixer can be found and then loaded with the script. For my demo I used a PSO in MATLAB to find the mix matrix, the mix is not included.

Fixes #10117
