### PR TITLE
ARM Authorization 

### DIFF
--- a/Tools/mavproxy_modules/arm_auth.py
+++ b/Tools/mavproxy_modules/arm_auth.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+'''module for testing arm authorization'''
+import time, math
+from pymavlink import mavutil
+from MAVProxy.modules.lib import mp_module
+from MAVProxy.modules.lib.mp_settings import MPSetting
+
+class AuthModule(mp_module.MPModule):
+  def __init__(self, mpstate):
+    super(AuthModule, self).__init__(mpstate, "arm_auth", "arm_authorization_test_module")
+    '''initialisation code'''
+    self.add_command('auth', self.cmd_auth, "Authorization")
+
+  def mavlink_packet(self, m):
+    '''handle a mavlink packet'''
+    if m.get_type() == 'ARM_AUTHORIZATION_REQUEST':
+    	print("ARM Authorisation request received (target_system:%i) (auth_window:%i ms)" % (m.target_system,m.auth_window))
+
+  def cmd_auth(self, args):
+    if len(args) == 0:
+      print("Usage: auth ena|dis (valid_time)")
+      return
+    if args[0] == "ena":
+      if len(args) == 2:
+        auth_time = int(args[1])
+      else:
+        auth_time = 0
+      self.master.mav.arm_authorization_response_send(
+        0, #accepted
+        0,
+        auth_time, #unlimited time
+        self.target_system,
+        self.target_component
+        )
+    elif args[0] == "dis":
+      self.master.mav.arm_authorization_response_send(
+        2, #denied
+        0,
+        0,
+        self.target_system,
+        self.target_component
+        )
+
+def init(mpstate):
+  '''initialise module'''
+  return AuthModule(mpstate)
+

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -131,6 +131,10 @@ protected:
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
     AP_Int32                 _required_mission_items;
+    AP_Int8                 _arm_auth_enabled;
+    AP_Int8                 _arm_auth_sysid;
+    AP_Int16                _arm_auth_request_interval;
+    AP_Int32                _arm_auth_response_window;
 
     // internal members
     bool                    armed;
@@ -235,6 +239,9 @@ private:
     // method that was last used for disarm; invalid unless the
     // vehicle has been disarmed at least once.
     Method _last_disarm_method = Method::UNKNOWN;
+
+    bool arm_authorization_check(bool display_failure);
+    bool arm_authorization_logic(bool display_failure);
 };
 
 namespace AP {

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -418,6 +418,7 @@ protected:
     void handle_setup_signing(const mavlink_message_t &msg);
     virtual MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet);
 
+    void  handle_arm_authorization_response(const mavlink_message_t &msg);
     // reset a message interval via mavlink:
     MAV_RESULT handle_command_set_message_interval(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_get_message_interval(const mavlink_command_long_t &packet);
@@ -919,6 +920,14 @@ public:
     void setup_console();
     void setup_uarts();
 
+    uint32_t arm_authorization_valid_time() const { return _arm_authorization_valid_time; }
+    uint32_t last_arm_authorization_received_time() const {return _last_arm_authorization_received_time; }
+    uint32_t last_arm_authorization_request_time() const {return _last_arm_authorization_request_time; }
+    uint8_t  arm_authorization_denial_reason() const {return _arm_authorization_denial_reason; }
+
+    void request_arm_authorization(uint8_t auth_system_id, uint16_t auth_window_time);
+    void received_arm_authorization(MAV_RESULT result, uint8_t param1, uint8_t param2);
+
     bool out_of_time() const;
 
     // frsky backend
@@ -1025,6 +1034,12 @@ private:
 
     // timer called to implement pass-thru
     void passthru_timer();
+
+    //All times in ms
+    uint32_t _arm_authorization_valid_time;
+    uint32_t _last_arm_authorization_received_time;
+    uint32_t _last_arm_authorization_request_time;
+    MAV_ARM_AUTH_DENIED_REASON _arm_authorization_denial_reason;
 
     // this contains the index of the GCS_MAVLINK backend we will
     // first call update_send on.  It is incremented each time

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3145,6 +3145,12 @@ void GCS_MAVLINK::handle_optical_flow(const mavlink_message_t &msg)
     optflow->handle_msg(msg);
 }
 
+void GCS_MAVLINK::handle_arm_authorization_response(const mavlink_message_t &msg)
+{
+    mavlink_arm_authorization_response_t packet;
+    mavlink_msg_arm_authorization_response_decode(&msg, &packet);
+    gcs().received_arm_authorization( (MAV_RESULT)packet.result, packet.result_param1, packet.result_param2); 
+}
 
 /*
   handle MAV_CMD_FIXED_MAG_CAL_YAW
@@ -3379,6 +3385,11 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_OSD_PARAM_SHOW_CONFIG:
         handle_osd_param_config(msg);
         break;
+
+    case MAVLINK_MSG_ID_ARM_AUTHORIZATION_RESPONSE:
+        handle_arm_authorization_response(msg);
+        break; 
+
     }
 
 }


### PR DESCRIPTION
This PR continues from https://github.com/ArduPilot/ardupilot/pull/7315 and implements two mavlink messages for arm authorization, as it decided when the original PR was closed.
definitions try to follow the arm authorization metod defined in mavlink, but adds the posibility to get authorization without explicit request.

Mavlink Commands

**ARM_AUTHORIZATION_REQUEST**
-	Target system – system ID of the authorizer, can be used in environments where there are multiple control stations
-	Authorization window – Time window for getting authorization in milliseconds. Authorizations after this time will not accepted, this prevents unwanted arming in long authorization processes.

**ARM_AUTHORIZATION_RESPONSE**
-	Result – MAV_RESULT_ACCEPTED, MAV_RESULT_TEMPORARILY_REJECTED or MAV_RESULT_DENIED 
-	Param1 - if result is TEMPORARILY_REJECTED or DENIED the reason should be set MAV_ARM_AUTH_DENIED_REASON otherwise it should be set as 0
-	Param2 - if result is ACCEPTED then it should be set with the time in seconds that this authorization is valid otherwise an additional information about why it was denied should be set. example: for Param1=MAV_ARM_AUTH_DENIED_REASON_INVALID_WAYPOINT or MAV_ARM_AUTH_DENIED_REASON_AIRSPACE_IN_USE it may have the index of the waypoint that caused it to be denied.
-	Target System – system id of the drone
-	Target Component – component id on the drone receiving authorization

**Parameters**
**ARMING_AUTH** - Enables arm authorization. If enabled, vehicle will arm only if a valid arm authorization response is received.
**ARMING_AUTHINT** - Seconds between arming auth requests sent out by the vehicle. 0 means no request is send (but incoming authorizations are processed if ARMAUTH is 1)
**ARMING_AUTHWIND** - Time window for autorization response (in millisec), authorization responses after this time will not accepted, 0 means there is no time window, authorizations are accepted at any time.
**ARMING_AUTHSID** - Contains the system_id of remote system where the authorization request is meant to go, you can leave it 0 in simple environments

Use cases

1.	External authorization without explicit request from the drone. 
If ARMAUTH = 1, AUTHINT = 0, AUTHWND = 0
ARM can be authorized by the GCS without explicit request from the drone. Authorization can be valid for undefined time (next reboot) or for a given time (param2 in RESPONSE)

2.	External authorization based on a request from the drone
ARMAUTH = 1, AUTHINT > 0, AUTHWND >=0
Drone issues authorization requests periodically (AUTHINT seconds) and accepts authorization responses. If AUTHWND > 0 then the response is accepted only within AUTHWND milliseconds after the request sent.  Once a valid authorization is received, drone will suspend sending out auth requests till authorization expired.
Disarming vehicle does not invalidate a still valid arm authorization, so it can be rearmed. But if the authorization expires during flight, vehicle cannot rearmed without new authorization.
**(Q: what about in-flight watchdog resets ?)**

```
PR:
BUILD SUMMARY
Build directory: /home/sefi/ardupilot/build/CubeBlack
Target          Text     Data  BSS     Total
----------------------------------------------
bin/arducopter  1491864  2820  194000  1688684


Master:
BUILD SUMMARY
Build directory: /home/sefi/ardupilot/build/CubeBlack
Target          Text     Data  BSS     Total
----------------------------------------------
bin/arducopter  1490984  2820  194000  1687804
```