### PR TITLE
EKF3: separate GPS and ExternalNav yaw sources, add GSF source

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2261,7 +2261,7 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("EK3_SRC2_POSZ", 6)  # External Nav
             self.set_parameter("EK3_SRC2_VELXY", 6) # External Nav
             self.set_parameter("EK3_SRC2_VELZ", 6)  # External Nav
-            self.set_parameter("EK3_SRC2_YAW", 2)   # External Nav
+            self.set_parameter("EK3_SRC2_YAW", 6)   # External Nav
             self.set_parameter("RC7_OPTION", 80)    # RC aux switch 7 set to Viso Align
             self.set_parameter("RC8_OPTION", 90)    # RC aux switch 8 set to EKF source selector
             self.reboot_sitl()

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 1_YAW
     // @DisplayName: Yaw Source
     // @Description: Yaw Source
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav, 8:GSF
+    // @Values: 0:None, 1:Compass, 2:GPS, 3:GPS with Compass Fallback, 6:ExternalNav, 8:GSF
     // @User: Advanced
     AP_GROUPINFO("1_YAW", 5, AP_NavEKF_Source, _source_set[0].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::COMPASS),
 
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 2_YAW
     // @DisplayName: Yaw Source (Secondary)
     // @Description: Yaw Source (Secondary)
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav, 8:GSF
+    // @Values: 0:None, 1:Compass, 2:GPS, 3:GPS with Compass Fallback, 6:ExternalNav, 8:GSF
     // @User: Advanced
     AP_GROUPINFO("2_YAW", 10, AP_NavEKF_Source, _source_set[1].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::NONE),
 #endif
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 3_YAW
     // @DisplayName: Yaw Source (Tertiary)
     // @Description: Yaw Source (Tertiary)
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav, 8:GSF
+    // @Values: 0:None, 1:Compass, 2:GPS, 3:GPS with Compass Fallback, 6:ExternalNav, 8:GSF
     // @User: Advanced
     AP_GROUPINFO("3_YAW", 15, AP_NavEKF_Source, _source_set[2].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::NONE),
 #endif
@@ -404,13 +404,13 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
         // check yaw
         switch ((SourceYaw)_source_set[i].yaw.get()) {
         case SourceYaw::NONE:
-        case SourceYaw::EXTERNAL:
+        case SourceYaw::GPS:
             // valid yaw value
             break;
         case SourceYaw::COMPASS:
             // skip compass check for easier user setup of compass-less operation
             break;
-        case SourceYaw::EXTERNAL_COMPASS_FALLBACK:
+        case SourceYaw::GPS_COMPASS_FALLBACK:
             compass_required = true;
             break;
         case SourceYaw::EXTNAV:
@@ -514,14 +514,14 @@ bool AP_NavEKF_Source::wheel_encoder_enabled(void) const
     return false;
 }
 
-// return true if ext yaw is enabled on any source
-bool AP_NavEKF_Source::ext_yaw_enabled(void) const
+// return true if GPS yaw is enabled on any source
+bool AP_NavEKF_Source::gps_yaw_enabled(void) const
 {
     for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
         const auto &src = _source_set[i];
         const SourceYaw yaw = SourceYaw(src.yaw.get());
-        if (yaw == SourceYaw::EXTERNAL ||
-            yaw == SourceYaw::EXTERNAL_COMPASS_FALLBACK) {
+        if (yaw == SourceYaw::GPS ||
+            yaw == SourceYaw::GPS_COMPASS_FALLBACK) {
             return true;
         }
     }

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 1_YAW
     // @DisplayName: Yaw Source
     // @Description: Yaw Source
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback
+    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav
     // @User: Advanced
     AP_GROUPINFO("1_YAW", 5, AP_NavEKF_Source, _source_set[0].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::COMPASS),
 
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 2_YAW
     // @DisplayName: Yaw Source (Secondary)
     // @Description: Yaw Source (Secondary)
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback
+    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav
     // @User: Advanced
     AP_GROUPINFO("2_YAW", 10, AP_NavEKF_Source, _source_set[1].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::NONE),
 #endif
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 3_YAW
     // @DisplayName: Yaw Source (Tertiary)
     // @Description: Yaw Source (Tertiary)
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback
+    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav
     // @User: Advanced
     AP_GROUPINFO("3_YAW", 15, AP_NavEKF_Source, _source_set[2].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::NONE),
 #endif
@@ -411,6 +411,9 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
             break;
         case SourceYaw::EXTERNAL_COMPASS_FALLBACK:
             compass_required = true;
+            break;
+        case SourceYaw::EXTNAV:
+            visualodom_required = true;
             break;
         default:
             // invalid yaw value

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -491,6 +491,9 @@ bool AP_NavEKF_Source::ext_nav_enabled(void) const
         if (src.velz == SourceZ::EXTNAV) {
             return true;
         }
+        if (src.yaw == SourceYaw::EXTNAV) {
+            return true;
+        }
     }
     return false;
 }

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 1_YAW
     // @DisplayName: Yaw Source
     // @Description: Yaw Source
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav
+    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav, 8:GSF
     // @User: Advanced
     AP_GROUPINFO("1_YAW", 5, AP_NavEKF_Source, _source_set[0].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::COMPASS),
 
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 2_YAW
     // @DisplayName: Yaw Source (Secondary)
     // @Description: Yaw Source (Secondary)
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav
+    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav, 8:GSF
     // @User: Advanced
     AP_GROUPINFO("2_YAW", 10, AP_NavEKF_Source, _source_set[1].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::NONE),
 #endif
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: 3_YAW
     // @DisplayName: Yaw Source (Tertiary)
     // @Description: Yaw Source (Tertiary)
-    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav
+    // @Values: 0:None, 1:Compass, 2:External, 3:External with Compass Fallback, 6:ExternalNav, 8:GSF
     // @User: Advanced
     AP_GROUPINFO("3_YAW", 15, AP_NavEKF_Source, _source_set[2].yaw, (int8_t)AP_NavEKF_Source::SourceYaw::NONE),
 #endif
@@ -274,7 +274,8 @@ bool AP_NavEKF_Source::usingGPS() const
     return getPosXYSource() == SourceXY::GPS ||
            getPosZSource() == SourceZ::GPS ||
            getVelXYSource() == SourceXY::GPS ||
-           getVelZSource() == SourceZ::GPS;
+           getVelZSource() == SourceZ::GPS ||
+           getYawSource() == SourceYaw::GSF;
 }
 
 // true if some parameters have been configured (used during parameter conversion)
@@ -414,6 +415,9 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
             break;
         case SourceYaw::EXTNAV:
             visualodom_required = true;
+            break;
+        case SourceYaw::GSF:
+            gps_required = true;
             break;
         default:
             // invalid yaw value

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -41,7 +41,8 @@ public:
         NONE = 0,
         COMPASS = 1,
         EXTERNAL = 2,
-        EXTERNAL_COMPASS_FALLBACK = 3
+        EXTERNAL_COMPASS_FALLBACK = 3,
+        EXTNAV = 6
     };
 
     // enum for OPTIONS parameter

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -40,8 +40,8 @@ public:
     enum class SourceYaw : uint8_t {
         NONE = 0,
         COMPASS = 1,
-        EXTERNAL = 2,
-        EXTERNAL_COMPASS_FALLBACK = 3,
+        GPS = 2,
+        GPS_COMPASS_FALLBACK = 3,
         EXTNAV = 6,
         GSF = 8
     };
@@ -95,8 +95,8 @@ public:
     // return true if ext nav is enabled on any source
     bool ext_nav_enabled(void) const;
 
-    // return true if ext yaw is enabled on any source
-    bool ext_yaw_enabled(void) const;
+    // return true if GPS yaw is enabled on any source
+    bool gps_yaw_enabled(void) const;
 
     // return true if wheel encoder is enabled on any source
     bool wheel_encoder_enabled(void) const;

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -42,7 +42,8 @@ public:
         COMPASS = 1,
         EXTERNAL = 2,
         EXTERNAL_COMPASS_FALLBACK = 3,
-        EXTNAV = 6
+        EXTNAV = 6,
+        GSF = 8
     };
 
     // enum for OPTIONS parameter

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1070,7 +1070,7 @@ bool NavEKF3::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
     // check if using compass (i.e. EK3_SRCn_YAW) with deprecated MAG_CAL values (5 was EXTERNAL_YAW, 6 was EXTERNAL_YAW_FALLBACK)
     const int8_t magCalParamVal = _magCal.get();
     const AP_NavEKF_Source::SourceYaw yaw_source = sources.getYawSource();
-    if (((magCalParamVal == 5) || (magCalParamVal == 6)) && (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL)) {
+    if (((magCalParamVal == 5) || (magCalParamVal == 6)) && (yaw_source != AP_NavEKF_Source::SourceYaw::GPS)) {
         // yaw source is configured to use compass but MAG_CAL valid is deprecated
         AP::dal().snprintf(failure_msg, failure_msg_len, "EK3_MAG_CAL and EK3_SRC1_YAW inconsistent");
         return false;
@@ -1672,11 +1672,11 @@ void NavEKF3::convert_parameters()
     switch (_magCal.get()) {
     case 5:
         // EK3_MAG_CAL = 5 (External Yaw sensor).  We rely on effective_magCal to interpret old "5" values as "Never"
-        AP_Param::set_and_save_by_name("EK3_SRC1_YAW", (int8_t)AP_NavEKF_Source::SourceYaw::EXTERNAL);
+        AP_Param::set_and_save_by_name("EK3_SRC1_YAW", (int8_t)AP_NavEKF_Source::SourceYaw::GPS);
         break;
     case 6:
         // EK3_MAG_CAL = 6 (ExtYaw with Compass fallback).  We rely on effective_magCal to interpret old "6" values as "When Flying"
-        AP_Param::set_and_save_by_name("EK3_SRC1_YAW", (int8_t)AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK);
+        AP_Param::set_and_save_by_name("EK3_SRC1_YAW", (int8_t)AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK);
         break;
     default:
         // do nothing

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -513,7 +513,7 @@ bool NavEKF3_core::use_compass(void) const
 {
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
     if ((yaw_source != AP_NavEKF_Source::SourceYaw::COMPASS) &&
-        (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK)) {
+        (yaw_source != AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK)) {
         // not using compass as a yaw source
         return false;
     }
@@ -528,7 +528,7 @@ bool NavEKF3_core::use_compass(void) const
 bool NavEKF3_core::using_external_yaw(void) const
 {
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
-    if (yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL || yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK ||
+    if (yaw_source == AP_NavEKF_Source::SourceYaw::GPS || yaw_source == AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK ||
         yaw_source == AP_NavEKF_Source::SourceYaw::GSF || !use_compass()) {
         return imuSampleTime_ms - last_gps_yaw_fusion_ms < 5000 || imuSampleTime_ms - lastSynthYawTime_ms < 5000;
     }
@@ -599,7 +599,7 @@ void NavEKF3_core::checkGyroCalStatus(void)
     // check delta angle bias variances
     const float delAngBiasVarMax = sq(radians(0.15f * dtEkfAvg));
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
-    if (!use_compass() && (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL) && (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK) &&
+    if (!use_compass() && (yaw_source != AP_NavEKF_Source::SourceYaw::GPS) && (yaw_source != AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK) &&
         (yaw_source != AP_NavEKF_Source::SourceYaw::EXTNAV)) {
         // rotate the variances into earth frame and evaluate horizontal terms only as yaw component is poorly observable without a yaw reference
         // which can make this check fail

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -531,6 +531,9 @@ bool NavEKF3_core::using_external_yaw(void) const
     if (yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL || yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK || !use_compass()) {
         return imuSampleTime_ms - last_gps_yaw_fusion_ms < 5000 || imuSampleTime_ms - lastSynthYawTime_ms < 5000;
     }
+    if (yaw_source == AP_NavEKF_Source::SourceYaw::EXTNAV) {
+        return ((imuSampleTime_ms - last_extnav_yaw_fusion_ms < 5000) || (imuSampleTime_ms - lastSynthYawTime_ms < 5000));
+    }
     return false;
 }
 
@@ -595,7 +598,8 @@ void NavEKF3_core::checkGyroCalStatus(void)
     // check delta angle bias variances
     const float delAngBiasVarMax = sq(radians(0.15f * dtEkfAvg));
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
-    if (!use_compass() && (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL) && (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK)) {
+    if (!use_compass() && (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL) && (yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK) &&
+        (yaw_source != AP_NavEKF_Source::SourceYaw::EXTNAV)) {
         // rotate the variances into earth frame and evaluate horizontal terms only as yaw component is poorly observable without a yaw reference
         // which can make this check fail
         Vector3f delAngBiasVarVec = Vector3f(P[10][10],P[11][11],P[12][12]);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -528,7 +528,8 @@ bool NavEKF3_core::use_compass(void) const
 bool NavEKF3_core::using_external_yaw(void) const
 {
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
-    if (yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL || yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK || !use_compass()) {
+    if (yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL || yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK ||
+        yaw_source == AP_NavEKF_Source::SourceYaw::GSF || !use_compass()) {
         return imuSampleTime_ms - last_gps_yaw_fusion_ms < 5000 || imuSampleTime_ms - lastSynthYawTime_ms < 5000;
     }
     if (yaw_source == AP_NavEKF_Source::SourceYaw::EXTNAV) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -1075,12 +1075,10 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
     }
 
     case yawFusionMethod::GPS:
-        // both external sensor yaw and last yaw when static are stored in yawAngDataDelayed.yawAng
         innovYaw = wrap_PI(yawAngPredicted - yawAngDataDelayed.yawAng);
         break;
 
     case yawFusionMethod::STATIC:
-        // both external sensor yaw and last yaw when static are stored in yawAngDataDelayed.yawAng
         innovYaw = wrap_PI(yawAngPredicted - yawAngDataStatic.yawAng);
         break;
 
@@ -1094,7 +1092,6 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
         break;
 
     case yawFusionMethod::EXTNAV:
-        // both external sensor yaw and last yaw when static are stored in yawAngDataDelayed.yawAng
         innovYaw = wrap_PI(yawAngPredicted - extNavYawAngDataDelayed.yawAng);
         break;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -219,12 +219,13 @@ void NavEKF3_core::SelectMagFusion()
         yawAngDataStatic.time_ms = imuDataDelayed.time_ms;
     }
 
-    // Handle case where we are not using a yaw sensor of any type and and attempt to reset the yaw in
+    // Handle case where we are not using a yaw sensor of any type and attempt to reset the yaw in
     // flight using the output from the GSF yaw estimator.
-    if (!use_compass() &&
-        yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL &&
-        yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK &&
-        yaw_source != AP_NavEKF_Source::SourceYaw::EXTNAV) {
+    if ((yaw_source == AP_NavEKF_Source::SourceYaw::GSF) ||
+        (!use_compass() &&
+         yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL &&
+         yaw_source != AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK &&
+         yaw_source != AP_NavEKF_Source::SourceYaw::EXTNAV)) {
 
         // because this type of reset event is not as time critical, require a continuous history of valid estimates
         if ((!yawAlignComplete || yaw_source_reset) && EKFGSF_yaw_valid_count >= GSF_YAW_VALID_HISTORY_THRESHOLD) {
@@ -1518,7 +1519,8 @@ bool NavEKF3_core::EKFGSF_resetMainFilterYaw()
         EKFGSF_yaw_reset_ms = imuSampleTime_ms;
         EKFGSF_yaw_reset_count++;
 
-        if (!use_compass() || dal.compass().get_num_enabled() == 0) {
+        if ((frontend->sources.getYawSource() == AP_NavEKF_Source::SourceYaw::GSF) ||
+            !use_compass() || (dal.compass().get_num_enabled() == 0)) {
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u yaw aligned using GPS",(unsigned)imu_index);
         } else {
             GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 IMU%u emergency yaw reset",(unsigned)imu_index);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1291,7 +1291,7 @@ void NavEKF3_core::updateMovementCheck(void)
 {
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
     const bool runCheck = onGround && (yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL || yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK ||
-                                       yaw_source == AP_NavEKF_Source::SourceYaw::EXTNAV || !use_compass());
+                                       yaw_source == AP_NavEKF_Source::SourceYaw::EXTNAV || yaw_source == AP_NavEKF_Source::SourceYaw::GSF || !use_compass());
     if (!runCheck)
     {
         onGroundNotMoving = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1290,7 +1290,7 @@ float NavEKF3_core::MagDeclination(void) const
 void NavEKF3_core::updateMovementCheck(void)
 {
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
-    const bool runCheck = onGround && (yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL || yaw_source == AP_NavEKF_Source::SourceYaw::EXTERNAL_COMPASS_FALLBACK ||
+    const bool runCheck = onGround && (yaw_source == AP_NavEKF_Source::SourceYaw::GPS || yaw_source == AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK ||
                                        yaw_source == AP_NavEKF_Source::SourceYaw::EXTNAV || yaw_source == AP_NavEKF_Source::SourceYaw::GSF || !use_compass());
     if (!runCheck)
     {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -123,7 +123,7 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
         // initialise to same length of IMU to allow for multiple wheel sensors
         return false;
     }
-    if(frontend->sources.ext_yaw_enabled() && !storedYawAng.init(obs_buffer_length)) {
+    if(frontend->sources.gps_yaw_enabled() && !storedYawAng.init(obs_buffer_length)) {
         return false;
     }
     // Note: the use of dual range finders potentially doubles the amount of data to be stored

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -101,9 +101,6 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
     // calculate buffer size for external nav data
     const uint8_t extnav_buffer_length = MIN((ekf_delay_ms / frontend->extNavIntervalMin_ms) + 1, imu_buffer_length);
 
-    // buffer size for external yaw
-    const uint8_t yaw_angle_buffer_length = MAX(obs_buffer_length, extnav_buffer_length);
-
     if(!storedGPS.init(obs_buffer_length)) {
         return false;
     }
@@ -126,7 +123,7 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
         // initialise to same length of IMU to allow for multiple wheel sensors
         return false;
     }
-    if(frontend->sources.ext_yaw_enabled() && !storedYawAng.init(yaw_angle_buffer_length)) {
+    if(frontend->sources.ext_yaw_enabled() && !storedYawAng.init(obs_buffer_length)) {
         return false;
     }
     // Note: the use of dual range finders potentially doubles the amount of data to be stored
@@ -141,6 +138,9 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
         return false;
     }
     if (frontend->sources.ext_nav_enabled() && !storedExtNavVel.init(extnav_buffer_length)) {
+        return false;
+    }
+    if(frontend->sources.ext_nav_enabled() && !storedExtNavYawAng.init(extnav_buffer_length)) {
         return false;
     }
     if(!storedIMU.init(imu_buffer_length)) {
@@ -452,6 +452,7 @@ void NavEKF3_core::InitialiseVariablesMag()
     magFieldLearned = false;
     storedMag.reset();
     storedYawAng.reset();
+    storedExtNavYawAng.reset();
     needMagBodyVarReset = false;
     needEarthBodyVarReset = false;
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -621,7 +621,7 @@ private:
     // specifies the method to be used when fusing yaw observations
     enum class yawFusionMethod {
 	    MAGNETOMETER=0,
-	    EXTERNAL=1,
+	    GPS=1,
         GSF=2,
         STATIC=3,
         PREDICTED=4,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -625,6 +625,7 @@ private:
         GSF=2,
         STATIC=3,
         PREDICTED=4,
+        EXTNAV=5,
     };
 
     // update the navigation filter status
@@ -747,8 +748,8 @@ private:
 
     // initialise the earth magnetic field states using declination and current attitude and magnetometer measurements
 
-    // align the yaw angle for the quaternion states using the external yaw sensor
-    void alignYawAngle();
+    // align the yaw angle for the quaternion states to the given yaw angle which should be at the fusion horizon
+    void alignYawAngle(const yaw_elements &yawAngData);
 
     // update mag field states and associated variances using magnetomer and declination data
     void resetMagFieldStates();
@@ -1344,6 +1345,9 @@ private:
     Vector3f extNavVelInnov;            // external nav velocity innovations
     Vector3f extNavVelVarInnov;         // external nav velocity innovation variances
     uint32_t extNavVelInnovTime_ms;     // system time that external nav velocity innovations were recorded (to detect timeouts)
+    EKF_obs_buffer_t<yaw_elements> storedExtNavYawAng;  // external navigation yaw angle buffer
+    yaw_elements extNavYawAngDataDelayed;   // external navigation yaw angle at the fusion time horizon
+    uint32_t last_extnav_yaw_fusion_ms; // system time that external nav yaw was last fused
 
     // flags indicating severe numerical errors in innovation variance calculation for different fusion operations
     struct {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1223,13 +1223,12 @@ private:
     EKF_obs_buffer_t<wheel_odm_elements> storedWheelOdm;    // body velocity data buffer
     wheel_odm_elements wheelOdmDataDelayed;   // Body  frame odometry data at the fusion time horizon
 
-    // yaw sensor fusion
-    uint32_t yawMeasTime_ms;
-    EKF_obs_buffer_t<yaw_elements> storedYawAng;
-    yaw_elements yawAngDataNew;
-    yaw_elements yawAngDataDelayed;
-    yaw_elements yawAngDataStatic;
-
+    // GPS yaw sensor fusion
+    uint32_t yawMeasTime_ms;            // system time GPS yaw angle was last input to the data buffer
+    EKF_obs_buffer_t<yaw_elements> storedYawAng;    // GPS yaw angle buffer
+    yaw_elements yawAngDataNew;         // GPS yaw angle at the current time horizon
+    yaw_elements yawAngDataDelayed;     // GPS yaw angle at the fusion time horizon
+    yaw_elements yawAngDataStatic;      // yaw angle (regardless of yaw source) when the vehicle was last on ground and not moving
 
     // Range Beacon Sensor Fusion
     EKF_obs_buffer_t<rng_bcn_elements> storedRangeBeacon; // Beacon range buffer


### PR DESCRIPTION
This PR gives the user more control over EKF3's yaw source:

- EK3_SRCn_YAW's "EXTERNAL" is separated into "GPS" and "ExternalNav"
- EK3_SRCn_YAW's "EXTERNAL" and "EXTERNAL_WITH_COMPASS" are renamed to "GPS" and "GPS_WITH_COMPASS"
- EK3_SRCn_YAW gets a new "GSF" option to allow flying with no compass, using GSF's estimated yaw

Beyond the regular autotests this PR has been lightly tested in SITL:

- Copter can be flown with only Vicon
- Copter can be flown with new EK3_SRC1_YAW = GSF (8) option although the compass needed to be temporarily enabled before takeoff to allow EKF3's attitude to be initialised
- GSF's emergency yaw reset was triggered when compass orientation was set to incorrect value before takeoff

The following questions should be answered before merging:

- [x] should NavEKF3_core::checkGyroCalStatus check AP_NavEKF_Source::SourceYaw::GSF?
    - **Tridge thinks that it is OK as-is**
- [x] users would previously "specify" they wanted to use GSF by setting EK3_SRCn_YAW = None (0) and/or setting COMPASS_USE/2/3 = 0.  This still works but I think we should steer users towards explicitly specifying they wish to use GSF if this is what they really want.  This would allow users to use None (0) to really mean they only want to use gyros.     
    - **Tridge agrees users should be encouraged to set the EK3_SRCn_YAW to GSF. We should leave GSF enabled when users select None because they can then use other EK3_GSF_xxx parameters to enable/disable GSF**
- [x] should we add a pre-arm check that if the user selects GPS (formerly EXTERNAL) or GPS_WITH_COMPASS that the GPS is capable of providing a yaw estimate?
    - **Tridge says Yes as a follow-up PR.  The setup of GPS-for-Yaw is challenging so a pre-arm check could help**
- [x] are we happy that ExternalNav does not have an automatic fall back to compass?  I think we are.
    - **Tridge says, Yes, we shouldn't hold up this PR in order to provide fallback to compass from ExtNav**
- [X] do we want flying with GSF fully functional on Copter before merging the new GSF source?  If "yes" then I may separate out the GSF commit into a new PR leaving only the separation of EXTERNAL into GPS and ExternalNav.
     - **Tridge says it should be possible for Copter to arm and takeoff in AltHold, Stabilize and Acro.  Let's address this as a follow-up PR**

Below is a screenshot of the GSF yaw reset test:
![gsf-yaw-reset-test](https://user-images.githubusercontent.com/1498098/102883178-ea322180-4492-11eb-866a-55b159acb5be.png)
