### PR TITLE
autotest: reboot after running Copter vibe tests

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2147,6 +2147,8 @@ class AutoTestCopter(AutoTest):
 
         self.context_pop()
 
+        self.reboot_sitl()
+
         if ex is not None:
             raise ex
 


### PR DESCRIPTION
The EKF type (at the very least) requires a reboot to revert to its
original value.