### PR TITLE
AP_Periph: migrate GPS and Rangefinder to use Serial Port as param

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -107,6 +107,7 @@ void AP_Periph_FW::init()
 
 #ifdef HAL_PERIPH_ENABLE_GPS
     if (gps.get_type(0) != AP_GPS::GPS_Type::GPS_TYPE_NONE) {
+        serial_manager.set_protocol_and_baud(g.gps_port, AP_SerialManager::SerialProtocol_GPS, AP_SERIALMANAGER_GPS_BAUD);
         gps.init(serial_manager);
     }
 #endif
@@ -149,10 +150,12 @@ void AP_Periph_FW::init()
 
 #ifdef HAL_PERIPH_ENABLE_RANGEFINDER
     if (rangefinder.get_type(0) != RangeFinder::Type::NONE) {
-        const uint8_t sernum = 3; // uartB
-        hal.serial(3)->begin(g.rangefinder_baud);
-        serial_manager.set_protocol_and_baud(sernum, AP_SerialManager::SerialProtocol_Rangefinder, g.rangefinder_baud);
-        rangefinder.init(ROTATION_NONE);
+        auto *uart = hal.serial(g.rangefinder_port);
+        if (uart != nullptr) {
+            uart->begin(g.rangefinder_baud);
+            serial_manager.set_protocol_and_baud(g.rangefinder_port, AP_SerialManager::SerialProtocol_Rangefinder, g.rangefinder_baud);
+            rangefinder.init(ROTATION_NONE);
+        }
     }
 #endif
 

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -6,6 +6,18 @@ extern const AP_HAL::HAL &hal;
 #define AP_PERIPH_LED_BRIGHT_DEFAULT 100
 #endif
 
+#ifndef AP_PERIPH_RANGEFINDER_BAUDRATE_DEFAULT
+#define AP_PERIPH_RANGEFINDER_BAUDRATE_DEFAULT 115200
+#endif
+
+#ifndef AP_PERIPH_RANGEFINDER_PORT_DEFAULT
+#define AP_PERIPH_RANGEFINDER_PORT_DEFAULT 3
+#endif
+
+#ifndef HAL_PERIPH_GPS_PORT_DEFAULT
+#define HAL_PERIPH_GPS_PORT_DEFAULT 3
+#endif
+
 #ifndef HAL_PERIPH_ADSB_BAUD_DEFAULT
 #define HAL_PERIPH_ADSB_BAUD_DEFAULT 57600
 #endif
@@ -55,6 +67,15 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Group: GPS_
     // @Path: ../../libraries/AP_GPS/AP_GPS.cpp
     GOBJECT(gps, "GPS_", AP_GPS),
+
+    // @Param: GPS_PORT
+    // @DisplayName: GPS Serial Port
+    // @Description: This is the serial port number where SERIALx_PROTOCOL will be set to GPS.
+    // @Range: 0 10
+    // @Increment: 1
+    // @User: Advanced
+    // @RebootRequired: True
+    GSCALAR(gps_port, "GPS_PORT", HAL_PERIPH_GPS_PORT_DEFAULT),
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_BATTERY
@@ -89,10 +110,9 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_RANGEFINDER
-    GSCALAR(rangefinder_baud, "RNGFND_BAUDRATE", 115200),
-#endif
+    GSCALAR(rangefinder_baud, "RNGFND_BAUDRATE", AP_PERIPH_RANGEFINDER_BAUDRATE_DEFAULT),
+    GSCALAR(rangefinder_port, "RNGFND_PORT", AP_PERIPH_RANGEFINDER_PORT_DEFAULT),
 
-#ifdef HAL_PERIPH_ENABLE_RANGEFINDER
     // Rangefinder driver
     // @Group: RNGFND
     // @Path: ../../libraries/AP_RangeFinder/Rangefinder.cpp

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -33,6 +33,8 @@ public:
         k_param_serial_number,
         k_param_adsb_port,
         k_param_servo_channels,
+        k_param_rangefinder_port,
+        k_param_gps_port,
     };
 
     AP_Int16 format_version;
@@ -53,6 +55,7 @@ public:
 
 #ifdef HAL_PERIPH_ENABLE_RANGEFINDER
     AP_Int32 rangefinder_baud;
+    AP_Int8 rangefinder_port;
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_ADSB
@@ -67,6 +70,10 @@ public:
 
 #ifdef HAL_PERIPH_ENABLE_HWESC
     AP_Int8 esc_number;
+#endif
+
+#ifdef HAL_PERIPH_ENABLE_GPS
+    AP_Int8 gps_port;
 #endif
 
     AP_Int8 debug;

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1175,7 +1175,9 @@ void AP_Periph_FW::can_start()
         PreferredNodeID = g.can_node;
     }
 
+#if !defined(HAL_NO_FLASH_SUPPORT) && !defined(HAL_NO_ROMFS_SUPPORT)
     periph.g.flash_bootloader.set_and_save_ifchanged(0);
+#endif
 
     can_iface.init(1000000, AP_HAL::CANIface::NormalMode);
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/f103-RangeFinder/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f103-RangeFinder/hwdef.dat
@@ -10,7 +10,7 @@ define AIRSPEED_MAX_SENSORS 1
 
 define HAL_PERIPH_ENABLE_RANGEFINDER
 
-define HAL_SERIAL3_PROTOCOL SerialProtocol_Rangefinder
+define AP_PERIPH_RANGEFINDER_PORT_DEFAULT 3
 
 # we're too low on flash with old compiler for bootloader
 define HAL_NO_ROMFS_SUPPORT

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -78,6 +78,33 @@ extern const AP_HAL::HAL& hal;
 #define SERIAL8_BAUD HAL_SERIAL8_BAUD
 #endif
 
+#ifdef HAL_BUILD_AP_PERIPH
+/*
+  AP_Periph doesn't include the SERIAL parameter tree, instead each
+  supported serial device type has it's own parameter within AP_Periph
+  for which port is used.
+ */
+#undef SERIAL0_PROTOCOL
+#undef SERIAL1_PROTOCOL
+#undef SERIAL2_PROTOCOL
+#undef SERIAL3_PROTOCOL
+#undef SERIAL4_PROTOCOL
+#undef SERIAL5_PROTOCOL
+#undef SERIAL6_PROTOCOL
+#undef SERIAL7_PROTOCOL
+#undef SERIAL8_PROTOCOL
+#define SERIAL0_PROTOCOL SerialProtocol_None
+#define SERIAL1_PROTOCOL SerialProtocol_None
+#define SERIAL2_PROTOCOL SerialProtocol_None
+#define SERIAL3_PROTOCOL SerialProtocol_None
+#define SERIAL4_PROTOCOL SerialProtocol_None
+#define SERIAL5_PROTOCOL SerialProtocol_None
+#define SERIAL6_PROTOCOL SerialProtocol_None
+#define SERIAL7_PROTOCOL SerialProtocol_None
+#define SERIAL8_PROTOCOL SerialProtocol_None
+#endif // HAL_BUILD_AP_PERIPH
+
+
 const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
 #if SERIALMANAGER_NUM_PORTS > 0
     // @Param: 0_BAUD


### PR DESCRIPTION
Current GPS and Rangefinders have hardcoded serial port numbers, forcing hwdef.dat authors to oddly adjust their SERIAL_ORDER to make it work. Now it's a param!

This also fixes a compile bug in f103-rangefinder (or any target) that defined HAL_NO_ROMFS_SUPPORT. It was missing an ifdef wrap.
