### PR TITLE
Plane: correct return code from qstab-enter

### DIFF
--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -3,14 +3,15 @@
 
 bool ModeQStabilize::_enter()
 {
-    plane.throttle_allows_nudging = true;
-    plane.auto_navigation_mode = false;
     if (!plane.quadplane.init_mode() && plane.previous_mode != nullptr) {
         plane.control_mode = plane.previous_mode;
-    } else {
-        plane.auto_throttle_mode = false;
-        plane.auto_state.vtol_mode = true;
+        return false;
     }
+
+    plane.throttle_allows_nudging = true;
+    plane.auto_navigation_mode = false;
+    plane.auto_throttle_mode = false;
+    plane.auto_state.vtol_mode = true;
 
     return true;
 }


### PR DESCRIPTION
@Hwurzburg this is the qstab-enter-fails-but-returns-accepted thing.

This is all completely bogus in terms of structure - we have something reverting to the previous mode when it didn't make the change, that sort of thing.  that leaves all sorts of related variables un-reverted and stuff.

I'm also not sure about the changing of auto-throttle and whatnot...

It's all bad....
