### PR TITLE
Plane: use pure-virtual method for allows_throttle_nudging

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -579,9 +579,6 @@ private:
     // true if we are in an auto-navigation mode, which controls whether control input is ignored
     // with STICK_MIXING=0
     bool auto_navigation_mode:1;
-    
-    // this allows certain flight modes to mix RC input with throttle depending on airspeed_nudge_cm
-    bool throttle_allows_nudging:1;
 
     // this controls throttle suppression in auto modes
     bool throttle_suppressed;

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -83,6 +83,10 @@ public:
     // subclasses override this if they require navigation.
     virtual void navigate() { return; }
 
+    // this allows certain flight modes to mix RC input with throttle
+    // depending on airspeed_nudge_cm
+    virtual bool allows_throttle_nudging() const { return false; }
+
 protected:
 
     // subclasses override this to perform checks before entering the mode
@@ -122,6 +126,8 @@ public:
 
     void navigate() override;
 
+    bool allows_throttle_nudging() const override { return true; }
+
 protected:
 
     bool _enter() override;
@@ -160,6 +166,8 @@ public:
     void navigate() override;
 
     virtual bool is_guided_mode() const override { return true; }
+
+    bool allows_throttle_nudging() const override { return true; }
 
 protected:
 
@@ -234,6 +242,8 @@ public:
 
     void navigate() override;
 
+    bool allows_throttle_nudging() const override { return true; }
+
 protected:
 
     bool _enter() override;
@@ -281,6 +291,8 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override { }
+
+    bool allows_throttle_nudging() const override { return true; }
 
 protected:
 
@@ -381,6 +393,7 @@ public:
     bool is_vtol_mode() const override { return true; }
     bool is_vtol_man_throttle() const override { return true; }
     virtual bool is_vtol_man_mode() const override { return true; }
+    bool allows_throttle_nudging() const override { return true; }
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
@@ -520,6 +533,8 @@ public:
 
     void navigate() override;
 
+    bool allows_throttle_nudging() const override { return true; }
+
     // var_info for holding parameter information
     static const struct AP_Param::GroupInfo var_info[];
     
@@ -552,6 +567,8 @@ public:
     void update_soaring();
 
     void navigate() override;
+
+    bool allows_throttle_nudging() const override { return true; }
 
 protected:
 

--- a/ArduPlane/mode_acro.cpp
+++ b/ArduPlane/mode_acro.cpp
@@ -3,7 +3,6 @@
 
 bool ModeAcro::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = false;
     plane.auto_navigation_mode = false;
     plane.acro_state.locked_roll = false;

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -3,7 +3,6 @@
 
 bool ModeAuto::_enter()
 {
-    plane.throttle_allows_nudging = true;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = true;
     if (plane.quadplane.available() && plane.quadplane.enable == 2) {

--- a/ArduPlane/mode_autotune.cpp
+++ b/ArduPlane/mode_autotune.cpp
@@ -3,7 +3,6 @@
 
 bool ModeAutoTune::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = false;
     plane.auto_navigation_mode = false;
     plane.autotune_start();

--- a/ArduPlane/mode_circle.cpp
+++ b/ArduPlane/mode_circle.cpp
@@ -4,7 +4,6 @@
 bool ModeCircle::_enter()
 {
     // the altitude to circle at is taken from the current altitude
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = true;
     plane.next_WP_loc.alt = plane.current_loc.alt;

--- a/ArduPlane/mode_cruise.cpp
+++ b/ArduPlane/mode_cruise.cpp
@@ -3,7 +3,6 @@
 
 bool ModeCruise::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = false;
     locked_heading = false;

--- a/ArduPlane/mode_fbwa.cpp
+++ b/ArduPlane/mode_fbwa.cpp
@@ -3,7 +3,6 @@
 
 bool ModeFBWA::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = false;
     plane.auto_navigation_mode = false;
 

--- a/ArduPlane/mode_fbwb.cpp
+++ b/ArduPlane/mode_fbwb.cpp
@@ -3,7 +3,6 @@
 
 bool ModeFBWB::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = false;
 

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -3,7 +3,6 @@
 
 bool ModeGuided::_enter()
 {
-    plane.throttle_allows_nudging = true;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = true;
     plane.guided_throttle_passthru = false;

--- a/ArduPlane/mode_initializing.cpp
+++ b/ArduPlane/mode_initializing.cpp
@@ -3,7 +3,6 @@
 
 bool ModeInitializing::_enter()
 {
-    plane.throttle_allows_nudging = true;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = false;
 

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -3,7 +3,6 @@
 
 bool ModeLoiter::_enter()
 {
-    plane.throttle_allows_nudging = true;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = true;
     plane.do_loiter_at_location();

--- a/ArduPlane/mode_manual.cpp
+++ b/ArduPlane/mode_manual.cpp
@@ -3,7 +3,6 @@
 
 bool ModeManual::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = false;
     plane.auto_navigation_mode = false;
 

--- a/ArduPlane/mode_qacro.cpp
+++ b/ArduPlane/mode_qacro.cpp
@@ -3,7 +3,6 @@
 
 bool ModeQAcro::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_navigation_mode = false;
     if (!plane.quadplane.init_mode() && plane.previous_mode != nullptr) {
         plane.control_mode = plane.previous_mode;

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -3,7 +3,6 @@
 
 bool ModeQStabilize::_enter()
 {
-    plane.throttle_allows_nudging = true;
     plane.auto_navigation_mode = false;
     if (!plane.quadplane.init_mode() && plane.previous_mode != nullptr) {
         plane.control_mode = plane.previous_mode;

--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -3,7 +3,6 @@
 
 bool ModeRTL::_enter()
 {
-    plane.throttle_allows_nudging = true;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = true;
     plane.prev_WP_loc = plane.current_loc;

--- a/ArduPlane/mode_stabilize.cpp
+++ b/ArduPlane/mode_stabilize.cpp
@@ -3,7 +3,6 @@
 
 bool ModeStabilize::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = false;
     plane.auto_navigation_mode = false;
 

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -52,7 +52,6 @@ ModeTakeoff::ModeTakeoff()
 bool ModeTakeoff::_enter()
 {
     // the altitude to circle at is taken from the current altitude
-    plane.throttle_allows_nudging = true;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = true;
 

--- a/ArduPlane/mode_thermal.cpp
+++ b/ArduPlane/mode_thermal.cpp
@@ -9,7 +9,6 @@ bool ModeThermal::_enter()
         return false;
     }
 
-    plane.throttle_allows_nudging = true;
     plane.auto_throttle_mode = true;
     plane.auto_navigation_mode = true;
     plane.do_loiter_at_location();

--- a/ArduPlane/mode_training.cpp
+++ b/ArduPlane/mode_training.cpp
@@ -3,7 +3,6 @@
 
 bool ModeTraining::_enter()
 {
-    plane.throttle_allows_nudging = false;
     plane.auto_throttle_mode = false;
     plane.auto_navigation_mode = false;
 

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -221,7 +221,7 @@ void Plane::calc_airspeed_errors()
 #endif
 
     // Bump up the target airspeed based on throttle nudging
-    if (throttle_allows_nudging && airspeed_nudge_cm > 0) {
+    if (control_mode->allows_throttle_nudging() && airspeed_nudge_cm > 0) {
         target_airspeed_cm += airspeed_nudge_cm;
     }
 


### PR DESCRIPTION
In place of a state variable which could become stale


This resolves a problem where the boolean value `throttle_allows_nudging` can become true in modes where it shouldn't be.

Starting with `./Tools/autotest/sim_vehicle.py -v ArduPlane --gdb --debug -f quadplane --map --console`, a `mode qautotune` straight away is sufficient to put the vehicle into the weird state.

This is only one of two variables which are becoming stale.   There will be a follow-up PR for that one.

This does make the build 140 bytes larger.
