### PR TITLE
Copter: update filtered range finder altitude to AC_WPNav

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -101,7 +101,7 @@
 #endif
 
 #ifndef RANGEFINDER_WPNAV_FILT_HZ
- # define RANGEFINDER_WPNAV_FILT_HZ   0.25f // filter frequency for rangefinder altitude provided to waypoint navigation class
+ # define RANGEFINDER_WPNAV_FILT_HZ   0.5f // filter frequency for rangefinder altitude provided to waypoint navigation class
 #endif
 
 #ifndef RANGEFINDER_TILT_CORRECTION         // by disable tilt correction for use of range finder data by EKF


### PR DESCRIPTION
When using rangefinder with RTL_ALT_TYPE=1, copter always overshoots RTL_ALT a bit.
This happens in both real vehicle and SITL.

I think we have to change also the filter frequency when changing read_rangefinder from 10hz to 20hz,
https://github.com/ArduPilot/ardupilot/commit/5461002eea9592dbb6933fd5a23f0e95e3ec630d

I tested this in SITL.
![image](https://user-images.githubusercontent.com/16643069/103122371-4f6c5980-46c3-11eb-9aea-725fbf29de91.png)
![image](https://user-images.githubusercontent.com/16643069/103122383-5f843900-46c3-11eb-96d1-a60f04cf3671.png)
