### PR TITLE
AP_Periph: fixed issue with f303-MatekGPS CAN pkt loss

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -106,7 +106,7 @@ void AP_Periph_FW::init()
     }
 
 #ifdef HAL_PERIPH_ENABLE_GPS
-    if (gps.get_type(0) != AP_GPS::GPS_Type::GPS_TYPE_NONE) {
+    if (gps.get_type(0) != AP_GPS::GPS_Type::GPS_TYPE_NONE && g.gps_port >= 0) {
         serial_manager.set_protocol_and_baud(g.gps_port, AP_SerialManager::SerialProtocol_GPS, AP_SERIALMANAGER_GPS_BAUD);
         gps.init(serial_manager);
     }
@@ -149,7 +149,7 @@ void AP_Periph_FW::init()
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_RANGEFINDER
-    if (rangefinder.get_type(0) != RangeFinder::Type::NONE) {
+    if (rangefinder.get_type(0) != RangeFinder::Type::NONE && g.rangefinder_port >= 0) {
         auto *uart = hal.serial(g.rangefinder_port);
         if (uart != nullptr) {
             uart->begin(g.rangefinder_baud);
@@ -168,7 +168,9 @@ void AP_Periph_FW::init()
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_MSP
-    msp_init(hal.serial(2));
+    if (g.msp_port >= 0) {
+        msp_init(hal.serial(g.msp_port));
+    }
 #endif
     
     start_ms = AP_HAL::native_millis();

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -25,6 +25,10 @@ extern const AP_HAL::HAL &hal;
 #define HAL_PERIPH_ADSB_PORT_DEFAULT 1
 #endif
 
+#ifndef AP_PERIPH_MSP_PORT_DEFAULT
+#define AP_PERIPH_MSP_PORT_DEFAULT 1
+#endif
+
 /*
  *  AP_Periph parameter definitions
  *
@@ -140,6 +144,10 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     GOBJECT(servo_channels, "OUT",     SRV_Channels),
 #endif
 
+#ifdef HAL_PERIPH_ENABLE_MSP
+    GSCALAR(msp_port, "MSP_PORT", AP_PERIPH_MSP_PORT_DEFAULT),
+#endif
+    
     AP_VAREND
 };
 

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -35,6 +35,7 @@ public:
         k_param_servo_channels,
         k_param_rangefinder_port,
         k_param_gps_port,
+        k_param_msp_port,
     };
 
     AP_Int16 format_version;
@@ -76,6 +77,10 @@ public:
     AP_Int8 gps_port;
 #endif
 
+#ifdef HAL_PERIPH_ENABLE_MSP
+    AP_Int8 msp_port;
+#endif
+    
     AP_Int8 debug;
 
     AP_Int32 serial_number;

--- a/Tools/AP_Periph/msp.cpp
+++ b/Tools/AP_Periph/msp.cpp
@@ -9,9 +9,11 @@
 
 void AP_Periph_FW::msp_init(AP_HAL::UARTDriver *_uart)
 {
-    msp.port.uart = _uart;
-    msp.port.msp_version = MSP::MSP_V2_NATIVE;
-    _uart->begin(115200, 512, 512);
+    if (_uart) {
+        msp.port.uart = _uart;
+        msp.port.msp_version = MSP::MSP_V2_NATIVE;
+        _uart->begin(115200, 512, 512);
+    }
 }
 
 

--- a/Tools/AP_Periph/msp.cpp
+++ b/Tools/AP_Periph/msp.cpp
@@ -39,6 +39,9 @@ void AP_Periph_FW::send_msp_packet(uint16_t cmd, void *p, uint16_t size)
  */
 void AP_Periph_FW::msp_sensor_update(void)
 {
+    if (msp.port.uart == nullptr) {
+        return;
+    }
 #ifdef HAL_PERIPH_ENABLE_GPS
     send_msp_GPS();
 #endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/f303-MatekGPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f303-MatekGPS/hwdef.dat
@@ -22,7 +22,7 @@ define HAL_WATCHDOG_ENABLED_DEFAULT true
 # crystal frequency
 OSCILLATOR_HZ 8000000
 
-define CH_CFG_ST_FREQUENCY 100000
+define CH_CFG_ST_FREQUENCY 1000
 define CH_CFG_ST_TIMEDELTA 0
 
 # assume the 256k flash part for now
@@ -83,7 +83,6 @@ define IO_THD_WA_SIZE      512
 
 define HAL_NO_GCS
 define HAL_NO_LOGGING
-define HAL_NO_MONITOR_THREAD
 
 define HAL_MINIMIZE_FEATURES 0
 
@@ -127,8 +126,8 @@ PA2 USART2_TX USART2 SPEED_HIGH NODMA
 PA3 USART2_RX USART2 SPEED_HIGH NODMA
 
 # USART3, for MSP
-PB10  USART3_TX USART3 SPEED_HIGH NODMA
-PB11  USART3_RX USART3 SPEED_HIGH NODMA
+PB10  USART3_TX USART3 SPEED_HIGH
+PB11  USART3_RX USART3 SPEED_HIGH
 
 # use a default node ID so this works with MSP only
 define HAL_CAN_DEFAULT_NODE_ID 112
@@ -150,11 +149,12 @@ define HAL_PERIPH_ENABLE_AIRSPEED
 define HAL_PERIPH_ENABLE_RANGEFINDER
 define HAL_PERIPH_ENABLE_MSP
 
-# allow for rangefinder to be plugged in on "MSP" port
-define HAL_PERIPH_ADSB_PORT_DEFAULT 1
-define HAL_PERIPH_ENABLE_ADSB
-
+# setup for MSP
 define HAL_MSP_ENABLED 1
+define AP_PERIPH_MSP_PORT_DEFAULT 2
+
+# disable rangefinder by default
+define AP_PERIPH_RANGEFINDER_PORT_DEFAULT -1
 
 # the M8 GPS is good at 10Hz, but the M9 is better at 5Hz,
 # so stick to 5Hz as the firmware is shared


### PR DESCRIPTION
This changes the MSP port on f303-MatekGPS to use DMA, and also adds a MSP_PORT parameter which allows MSP to be disabled.
This fixes an issue with CAN pkt corruption. With MSP disabled the pkt corruption stops completely. With MSP left enabled but using DMA the pkt corruption is low enough to not cause a problem with arming.
It would be nice to fix this to the point that having MSP enable doesn't get any CAN pkt corruption, but in the meantime this is an OK workaround
