### PR TITLE
AP_Scripting: add fast param access with Parameter helper class 

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting_helpers.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_helpers.cpp
@@ -1,0 +1,95 @@
+#include "AP_Scripting_helpers.h"
+
+/// Fast param access via pointer helper class
+
+// init by name
+bool Parameter::init(const char *name)
+{
+    vp = AP_Param::find(name, &vtype);
+    if (vp == nullptr) {
+        return false;
+    }
+    return true;
+}
+
+// set a value
+bool Parameter::set(float value)
+{
+    if (vp == nullptr) {
+        return false;
+    }
+    switch (vtype) {
+    case AP_PARAM_INT8:
+        ((AP_Int8 *)vp)->set(value);
+        return true;
+    case AP_PARAM_INT16:
+        ((AP_Int16 *)vp)->set(value);
+        return true;
+    case AP_PARAM_INT32:
+        ((AP_Int32 *)vp)->set(value);
+        return true;
+    case AP_PARAM_FLOAT:
+        ((AP_Float *)vp)->set(value);
+        return true;
+    default:
+        break;
+    }
+    // not a supported type
+    return false;
+}
+
+//  get a value by name
+bool Parameter::get(float &value)
+{
+    if (vp == nullptr) {
+        return false;
+    }
+    switch (vtype) {
+    case AP_PARAM_INT8:
+        value = ((AP_Int8 *)vp)->get();
+        break;
+    case AP_PARAM_INT16:
+        value = ((AP_Int16 *)vp)->get();
+        break;
+
+    case AP_PARAM_INT32:
+        value = ((AP_Int32 *)vp)->get();
+        break;
+
+    case AP_PARAM_FLOAT:
+        value = ((AP_Float *)vp)->get();
+        break;
+
+    default:
+        // not a supported type
+        return false;
+    }
+    return true;
+}
+
+// set and save a value by name
+bool Parameter::set_and_save(float value)
+{
+    if (vp == nullptr) {
+        return false;
+    }
+    switch (vtype) {
+    case AP_PARAM_INT8:
+        ((AP_Int8 *)vp)->set_and_save(value);
+        return true;
+    case AP_PARAM_INT16:
+        ((AP_Int16 *)vp)->set_and_save(value);
+        return true;
+    case AP_PARAM_INT32:
+        ((AP_Int32 *)vp)->set_and_save(value);
+        return true;
+    case AP_PARAM_FLOAT:
+        ((AP_Float *)vp)->set_and_save(value);
+        return true;
+    default:
+        break;
+    }
+    // not a supported type
+    return false;
+}
+

--- a/libraries/AP_Scripting/AP_Scripting_helpers.h
+++ b/libraries/AP_Scripting/AP_Scripting_helpers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+
+/// Fast param access via pointer helper
+class Parameter
+{
+public:
+
+    // init to param by name
+    bool init(const char *name);
+
+    // setters and getters
+    bool set(float value);
+    bool set_and_save(float value);
+    bool get(float &value);
+
+private:
+    enum ap_var_type vtype;
+    AP_Param *vp;
+};
+

--- a/libraries/AP_Scripting/examples/param_get_set_test.lua
+++ b/libraries/AP_Scripting/examples/param_get_set_test.lua
@@ -1,6 +1,19 @@
 -- This script is a test of param set and get
 local count = 0
 
+-- for fast param acess it is better to get a param object,
+-- this saves the code searching for the param by name every time
+local VM_I_Count = Parameter()
+if not VM_I_Count:init('SCR_VM_I_COUNT') then
+  gcs:send_text(6, 'get SCR_VM_I_COUNT failed')
+end
+
+-- returns null if param cant be found
+local fake_param = Parameter()
+if not fake_param:init('FAKE_PARAM') then
+  gcs:send_text(6, 'get FAKE_PARAM failed')
+end
+
 function update() -- this is the loop which periodically runs
 
   -- get and print all the scripting parameters
@@ -37,6 +50,18 @@ function update() -- this is the loop which periodically runs
     end
   else
     gcs:send_text(6, 'LUA: get SCR_HEAP_SIZE failed')
+  end
+
+  
+  -- increment the VM I count by one using direct accsess method
+  local VM_count = VM_I_Count:get()
+  if VM_count then
+    gcs:send_text(6, string.format('LUA: SCR_VM_I_COUNT: %i',VM_count))
+    if not VM_I_Count:set( VM_count + 1) then
+        gcs:send_text(6, string.format('LUA: failed to set SCR_VM_I_COUNT'))
+    end
+  else
+    gcs:send_text(6, 'LUA: read SCR_VM_I_COUNT failed')
   end
 
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -248,6 +248,13 @@ singleton AP_Param method get boolean string float'Null
 singleton AP_Param method set boolean string float -FLT_MAX FLT_MAX
 singleton AP_Param method set_and_save boolean string float -FLT_MAX FLT_MAX
 
+include AP_Scripting/AP_Scripting_helpers.h
+userdata Parameter method init boolean string
+userdata Parameter method get boolean float'Null
+userdata Parameter method set boolean float -FLT_MAX FLT_MAX
+userdata Parameter method set_and_save boolean float -FLT_MAX FLT_MAX
+
+
 include AP_Mission/AP_Mission.h
 singleton AP_Mission alias mission
 singleton AP_Mission scheduler-semaphore


### PR DESCRIPTION
This allows scripting to set/get/set_and_save  param values without having to search by name, this allows fast updating of values, added to example script, also updates param example with asserts.

Lua code example:
```
-- setup
local VM_I_Count = Parameter()
VM_I_Count:init('SCR_VM_I_COUNT')

-- loop
local example = VM_I_Count:get()
VM_I_Count:set(10)
```

also updated the set/get/set_and_save by_name AP_Param methods to use the new helper to save code duplication