### PR TITLE
Tools: add psutil used by kill_tasks_psutil for sim_vehicle.py

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -98,7 +98,7 @@ if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then
 fi
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 # python-wxgtk packages are added to SITL_PKGS below
-SITL_PKGS="libtool libxml2-dev libxslt1-dev ${PYTHON_V}-dev ${PYTHON_V}-pip ${PYTHON_V}-setuptools ${PYTHON_V}-numpy ${PYTHON_V}-pyparsing"
+SITL_PKGS="libtool libxml2-dev libxslt1-dev ${PYTHON_V}-dev ${PYTHON_V}-pip ${PYTHON_V}-setuptools ${PYTHON_V}-numpy ${PYTHON_V}-pyparsing ${PYTHON_V}-psutil"
 # add some packages required for commonly-used MAVProxy modules:
 if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   SITL_PKGS="$SITL_PKGS xterm ${PYTHON_V}-matplotlib ${PYTHON_V}-serial ${PYTHON_V}-scipy ${PYTHON_V}-opencv libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION} ${PYTHON_V}-yaml"


### PR DESCRIPTION
If you kill one while using multiple instances, the other MAVProxys will lose connectivity. This is because an ImportError occurred and kill_task_pkill function was called when killing the task.
I have tested in Ubuntu18/20 on WSL/WSL2. I think it should work fine in native ubuntu.

No psutil
![image](https://user-images.githubusercontent.com/22985371/103182148-7bb6ee80-48ec-11eb-9921-720ace82f4ba.png)

After install psutil
![image](https://user-images.githubusercontent.com/22985371/103182157-8ec9be80-48ec-11eb-8fa1-22d6c6aa2f3b.png)
