### PR TITLE
Tools: Change Cygwin default install location to C:\Cygwin64

### DIFF
--- a/Tools/autotest/win_sitl/RunCopter.bat
+++ b/Tools/autotest/win_sitl/RunCopter.bat
@@ -2,8 +2,8 @@ rem File run APM:Copter SITL
 SETLOCAL enableextensions
 @echo off
 
-rem Assumes a Cgywin install at C:\cygwin
-if "%CYGWIN_LOCATION%" == "" (set "CYGWIN_LOCATION=C:\cygwin")
+rem Assumes a Cgywin install at C:\cygwin64
+if "%CYGWIN_LOCATION%" == "" (set "CYGWIN_LOCATION=C:\cygwin64")
 
 rem get current dir for Cygwin
 set pth=%CD:~2,99%

--- a/Tools/autotest/win_sitl/RunPlane.bat
+++ b/Tools/autotest/win_sitl/RunPlane.bat
@@ -2,8 +2,8 @@ rem File run APM:Plane SITL
 SETLOCAL enableextensions
 @echo off
 
-rem Assumes a Cgywin install at C:\cygwin
-if "%CYGWIN_LOCATION%" == "" (set "CYGWIN_LOCATION=C:\cygwin")
+rem Assumes a Cgywin install at C:\cygwin64
+if "%CYGWIN_LOCATION%" == "" (set "CYGWIN_LOCATION=C:\cygwin64")
 
 rem get current dir for Cygwin
 set pth=%CD:~2,99%

--- a/Tools/autotest/win_sitl/RunRover.bat
+++ b/Tools/autotest/win_sitl/RunRover.bat
@@ -2,8 +2,8 @@ rem File run APM:Rover SITL
 SETLOCAL enableextensions
 @echo off
 
-rem Assumes a Cgywin install at C:\cygwin
-if "%CYGWIN_LOCATION%" == "" (set "CYGWIN_LOCATION=C:\cygwin")
+rem Assumes a Cgywin install at C:\cygwin64
+if "%CYGWIN_LOCATION%" == "" (set "CYGWIN_LOCATION=C:\cygwin64")
 
 rem get current dir for Cygwin
 set pth=%CD:~2,99%

--- a/Tools/autotest/win_sitl/UpdateAPMSource.bat
+++ b/Tools/autotest/win_sitl/UpdateAPMSource.bat
@@ -2,6 +2,9 @@ rem File to update the APM source
 rem Assumes a Cgywin install at C:\cygwin
 @echo off
 
+rem Assumes a Cgywin install at C:\cygwin64
+if "%CYGWIN_LOCATION%" == "" (set "CYGWIN_LOCATION=C:\cygwin64")
+
 rem get current dir for Cygwin
 set pth=%CD:~2,99%
 set pth=%pth:\=/%
@@ -9,9 +12,9 @@ set drv=%CD:~0,1%
 set "fullpath=/cygdrive/%drv%%pth%"
 
 rem update the source
-C:\cygwin\bin\bash.exe --login -i -c "cd ""%fullpath%"" && cd ../../../ && git pull && git submodule update --init --recursive"
+%CYGWIN_LOCATION%\bin\bash.exe --login -i -c "cd ""%fullpath%"" && cd ../../../ && git pull && git submodule update --init --recursive"
 
 rem re-configure build config
-C:\cygwin\bin\bash.exe --login -i -c "cd ""%fullpath%"" && cd ../../../ && ./modules/waf/waf-light configure --board=sitl"
+%CYGWIN_LOCATION%\bin\bash.exe --login -i -c "cd ""%fullpath%"" && cd ../../../ && ./modules/waf/waf-light configure --board=sitl"
 
 pause

--- a/Tools/autotest/win_sitl/readme.txt
+++ b/Tools/autotest/win_sitl/readme.txt
@@ -15,4 +15,4 @@ To continue with the current EEPROM, run:
 To update the APM code with the latest of Github, run UpdateAPMSource.bat. Note this is bleeding-edge source code and some bugs may be present.
 Deleting the SITL environment
 
-To uninstall/delete the SITL environment, simply delete the "cygwin" folder in the C:\ drive.
+To uninstall/delete the SITL environment, simply delete the "cygwin64" folder in the C:\ drive.


### PR DESCRIPTION
This updates the default cygwin install location of these scripts to match the location in the install-preqs-windows scripts. 