### PR TITLE
GCS_MAVLink: Strictly check extensions.

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -295,7 +295,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                         put_le32_ptr(reply.data, (uint32_t)file_size);
 
                         // provide compatibility with old protocol banner download
-                        if (strncmp((const char *)request.data, "@PARAM/param.pck", 16) == 0) {
+                        if (strlen((const char *)request.data) == 16 && (strncmp((const char *)request.data, "@PARAM/param.pck", 16) == 0)) {
                             ftp.need_banner_send_mask |= 1U<<reply.chan;
                         }
                         break;


### PR DESCRIPTION
I'm missing a check when comparing strings by character count.
For example, strncmp("@PARAM/param.pck1", "@PARAM/param.pck", 16) will be equal.
Therefore, you need to make sure that they are the same string.