### PR TITLE
Add support for ordering UAVCAN GPS

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -299,9 +299,9 @@ const AP_Param::Info Tracker::var_info[] = {
 #endif
 
     // GPS driver
-    // @Group: GPS_
+    // @Group: GPS
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp
-    GOBJECT(gps, "GPS_", AP_GPS),
+    GOBJECT(gps, "GPS", AP_GPS),
 
     // @Group: NTF_
     // @Path: ../libraries/AP_Notify/AP_Notify.cpp

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -627,9 +627,9 @@ const AP_Param::Info Copter::var_info[] = {
     GOBJECT(barometer, "BARO", AP_Baro),
 
     // GPS driver
-    // @Group: GPS_
+    // @Group: GPS
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp
-    GOBJECT(gps, "GPS_", AP_GPS),
+    GOBJECT(gps, "GPS", AP_GPS),
 
     // @Group: SCHED_
     // @Path: ../libraries/AP_Scheduler/AP_Scheduler.cpp

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -800,9 +800,9 @@ const AP_Param::Info Plane::var_info[] = {
     GOBJECT(barometer, "BARO", AP_Baro),
 
     // GPS driver
-    // @Group: GPS_
+    // @Group: GPS
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp
-    GOBJECT(gps, "GPS_", AP_GPS),
+    GOBJECT(gps, "GPS", AP_GPS),
 
 #if CAMERA == ENABLED
     // @Group: CAM_

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -529,9 +529,9 @@ const AP_Param::Info Sub::var_info[] = {
     GOBJECT(barometer, "BARO", AP_Baro),
 
     // GPS driver
-    // @Group: GPS_
+    // @Group: GPS
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp
-    GOBJECT(gps, "GPS_", AP_GPS),
+    GOBJECT(gps, "GPS", AP_GPS),
 
     // Leak detector
     // @Group: LEAK

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -39,6 +39,11 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
         return true;
     }
 
+    // call parent gps checks
+    if (!AP_Arming::gps_checks(display_failure)) {
+        return false;
+    }
+
     const AP_AHRS &ahrs = AP::ahrs();
 
     // always check if inertial nav has started and is ready
@@ -61,8 +66,7 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
         return false;
     }
 
-    // call parent gps checks
-    return AP_Arming::gps_checks(display_failure);
+    return true;
 }
 
 bool AP_Arming_Rover::pre_arm_checks(bool report)

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -349,9 +349,9 @@ const AP_Param::Info Rover::var_info[] = {
 #endif
 
     // GPS driver
-    // @Group: GPS_
+    // @Group: GPS
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp
-    GOBJECT(gps, "GPS_", AP_GPS),
+    GOBJECT(gps, "GPS", AP_GPS),
 
 #if AP_AHRS_NAVEKF_AVAILABLE
 #if HAL_NAVEKF2_AVAILABLE

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -68,9 +68,9 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 
 #ifdef HAL_PERIPH_ENABLE_GPS
     // GPS driver
-    // @Group: GPS_
+    // @Group: GPS
     // @Path: ../../libraries/AP_GPS/AP_GPS.cpp
-    GOBJECT(gps, "GPS_", AP_GPS),
+    GOBJECT(gps, "GPS", AP_GPS),
 
     // @Param: GPS_PORT
     // @DisplayName: GPS Serial Port

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -78,9 +78,9 @@ const AP_Param::Info ReplayVehicle::var_info[] = {
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
     GOBJECTN(ekf3, NavEKF3, "EK3_", NavEKF3),
 
-    // @Group: GPS_
+    // @Group: GPS
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp
-    GOBJECT(gps, "GPS_", AP_GPS),
+    GOBJECT(gps, "GPS", AP_GPS),
     
     AP_VAREND
 };

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 import copy
 import math
 import os
-import signal
 import shutil
 import time
 import numpy
@@ -2103,35 +2102,73 @@ class AutoTestCopter(AutoTest):
         self.set_parameter("GPS_TYPE", 9)
         self.set_parameter("GPS_TYPE2", 9)
         self.set_parameter("SIM_GPS2_DISABLE", 0)
-        os.kill(self.sup_prog[0].pid, signal.SIGSTOP)
-        os.kill(self.sup_prog[1].pid, signal.SIGSTOP)
+
+        self.context_push()
+        self.set_parameter("ARMING_CHECK", 1 << 3)
+        self.context_collect('STATUSTEXT')
+
         self.reboot_sitl()
         # Test UAVCAN GPS ordering working
-        os.kill(self.sup_prog[0].pid, signal.SIGCONT)
-        gps1_det_text = self.wait_text("GPS 1: specified as UAVCAN")
-        os.kill(self.sup_prog[1].pid, signal.SIGCONT)
-        gps2_det_text = self.wait_text("GPS 2: specified as UAVCAN")
+        gps1_det_text = self.wait_statustext("GPS 1: specified as UAVCAN.*", regex=True, check_context=True)
+        gps2_det_text = self.wait_statustext("GPS 2: specified as UAVCAN.*", regex=True, check_context=True)
         gps1_nodeid = int(gps1_det_text.split('-')[1])
         gps2_nodeid = int(gps2_det_text.split('-')[1])
         if gps1_nodeid is None or gps2_nodeid is None:
             raise NotAchievedException("GPS not ordered per the order of Node IDs")
-        self.set_parameter("GPS1_CAN_OVRIDE", gps2_nodeid)
-        self.set_parameter("GPS2_CAN_OVRIDE", gps1_nodeid)
-        
-        # Reboot the SITL, and shuffle the AP_Periph
-        os.kill(self.sup_prog[0].pid, signal.SIGSTOP)
-        os.kill(self.sup_prog[1].pid, signal.SIGSTOP)
-        self.drain_mav()
-        self.reboot_sitl()
-        try:
-            # order should have changed this time
-            os.kill(self.sup_prog[0].pid, signal.SIGCONT)
-            gps1_det_text = self.wait_text("GPS 2: specified as UAVCAN")
-            os.kill(self.sup_prog[1].pid, signal.SIGCONT)
-            gps2_det_text = self.wait_text("GPS 1: specified as UAVCAN")
-        except:
-            raise NotAchievedException("GPS not ordered as requested")
-        
+
+        self.context_stop_collecting('STATUSTEXT')
+
+        GPS_Order_Tests = [[gps2_nodeid, gps2_nodeid, gps2_nodeid, 0,
+                            "PreArm: Same Node Id {} set for multiple GPS".format(gps2_nodeid)],
+                           [gps1_nodeid, int(gps2_nodeid/2), gps1_nodeid, 0,
+                            "Selected GPS Node {} not set as instance {}".format(int(gps2_nodeid/2), 2)],
+                           [int(gps1_nodeid/2), gps2_nodeid, 0, gps2_nodeid,
+                            "Selected GPS Node {} not set as instance {}".format(int(gps1_nodeid/2), 1)],
+                           [gps1_nodeid, gps2_nodeid, gps1_nodeid, gps2_nodeid, ""],
+                           [gps2_nodeid, gps1_nodeid, gps2_nodeid, gps1_nodeid, ""],
+                           [gps1_nodeid, 0, gps1_nodeid, gps2_nodeid, ""],
+                           [0, gps2_nodeid, gps1_nodeid, gps2_nodeid, ""]]
+        for case in GPS_Order_Tests:
+            self.progress("############################### Trying Case: " + str(case))
+            self.set_parameter("GPS1_CAN_OVRIDE", case[0])
+            self.set_parameter("GPS2_CAN_OVRIDE", case[1])
+            self.drain_mav()
+            self.context_collect('STATUSTEXT')
+            self.reboot_sitl()
+            gps1_det_text = None
+            gps2_det_text = None
+            try:
+                gps1_det_text = self.wait_statustext("GPS 1: specified as UAVCAN.*", regex=True, check_context=True)
+            except AutoTestTimeoutException:
+                pass
+            try:
+                gps2_det_text = self.wait_statustext("GPS 2: specified as UAVCAN.*", regex=True, check_context=True)
+            except AutoTestTimeoutException:
+                pass
+
+            self.context_stop_collecting('STATUSTEXT')
+            self.change_mode('LOITER')
+            if case[2] == 0 and case[3] == 0:
+                if gps1_det_text or gps2_det_text:
+                    raise NotAchievedException("Failed ordering for requested CASE:", case)
+
+            if case[2] == 0 or case[3] == 0:
+                if bool(gps1_det_text is not None) == bool(gps2_det_text is not None):
+                    print(gps1_det_text)
+                    print(gps2_det_text)
+                    raise NotAchievedException("Failed ordering for requested CASE:", case)
+
+            if gps1_det_text:
+                if case[2] != int(gps1_det_text.split('-')[1]):
+                    raise NotAchievedException("Failed ordering for requested CASE:", case)
+            if gps2_det_text:
+                if case[3] != int(gps2_det_text.split('-')[1]):
+                    raise NotAchievedException("Failed ordering for requested CASE:", case)
+            if len(case[4]):
+                self.mavproxy.send('arm throttle\n')
+                self.mavproxy.expect(case[4])
+        self.progress("############################### All GPS Order Cases Tests Passed")
+        self.context_pop()
         self.fly_auto_test()
 
     def fly_motor_fail(self, fail_servo=0, fail_mul=0.0, holdtime=30):

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -465,7 +465,7 @@ def run_step(step):
             supplementary_binaries.append([util.reltopdir(os.path.join('build',
                                                                        config_name,
                                                                        'bin',
-                                                                       binary_name)), 
+                                                                       binary_name)),
                                           '-I {}'.format(instance_num)])
         # we are running in conjunction with a supplementary app
         # can't have speedup

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -368,7 +368,7 @@ tester_class_map = {
 }
 
 suplementary_test_binary_map = {
-    "test.CAN": "sitl_periph_gps.AP_Periph",
+    "test.CAN": ["sitl_periph_gps.AP_Periph", "sitl_periph_gps.AP_Periph.1"],
 }
 
 
@@ -454,19 +454,24 @@ def run_step(step):
     if step.startswith("defaults"):
         vehicle = step[9:]
         return get_default_params(vehicle, binary)
-
+    supplementary_binaries = []
     if step in suplementary_test_binary_map:
-        config_name = suplementary_test_binary_map[step].split('.')[0]
-        binary_name = suplementary_test_binary_map[step].split('.')[1]
-        supplementary_binary = util.reltopdir(os.path.join('build',
-                                                           config_name,
-                                                           'bin',
-                                                           binary_name))
+        for supplementary_test_binary in suplementary_test_binary_map[step]:
+            config_name = supplementary_test_binary.split('.')[0]
+            binary_name = supplementary_test_binary.split('.')[1]
+            instance_num = 0
+            if len(supplementary_test_binary.split('.')) >= 3:
+                instance_num = int(supplementary_test_binary.split('.')[2])
+            supplementary_binaries.append([util.reltopdir(os.path.join('build',
+                                                                       config_name,
+                                                                       'bin',
+                                                                       binary_name)), 
+                                          '-I {}'.format(instance_num)])
         # we are running in conjunction with a supplementary app
         # can't have speedup
         opts.speedup = 1.0
     else:
-        supplementary_binary = None
+        supplementary_binaries = []
     fly_opts = {
         "viewerip": opts.viewerip,
         "use_map": opts.map,
@@ -480,7 +485,7 @@ def run_step(step):
         "_show_test_timings": opts.show_test_timings,
         "force_ahrs_type": opts.force_ahrs_type,
         "logs_dir": buildlogs_dirpath(),
-        "sup_binary": supplementary_binary,
+        "sup_binaries": supplementary_binaries,
     }
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -261,9 +261,10 @@ def start_SITL(binary,
                breakpoints=[],
                disable_breakpoints=False,
                customisations=[],
-               lldb=False):
+               lldb=False,
+               supplementary=False):
 
-    if model is None:
+    if model is None and not supplementary:
         raise ValueError("model must not be None")
 
     """Launch a SITL instance."""
@@ -333,27 +334,28 @@ def start_SITL(binary,
             raise RuntimeError("DISPLAY was not set")
 
     cmd.append(binary)
-    if wipe:
-        cmd.append('-w')
-    if synthetic_clock:
-        cmd.append('-S')
-    if home is not None:
-        cmd.extend(['--home', home])
-    cmd.extend(['--model', model])
-    if speedup != 1:
-        cmd.extend(['--speedup', str(speedup)])
-    if defaults_filepath is not None:
-        if type(defaults_filepath) == list:
-            if len(defaults_filepath):
-                cmd.extend(['--defaults', ",".join(defaults_filepath)])
-        else:
-            cmd.extend(['--defaults', defaults_filepath])
-    if unhide_parameters:
-        cmd.extend(['--unhide-groups'])
-    cmd.extend(customisations)
+    if not supplementary:
+        if wipe:
+            cmd.append('-w')
+        if synthetic_clock:
+            cmd.append('-S')
+        if home is not None:
+            cmd.extend(['--home', home])
+        cmd.extend(['--model', model])
+        if speedup != 1:
+            cmd.extend(['--speedup', str(speedup)])
+        if defaults_filepath is not None:
+            if type(defaults_filepath) == list:
+                if len(defaults_filepath):
+                    cmd.extend(['--defaults', ",".join(defaults_filepath)])
+            else:
+                cmd.extend(['--defaults', defaults_filepath])
+        if unhide_parameters:
+            cmd.extend(['--unhide-groups'])
+        # somewhere for MAVProxy to connect to:
+        cmd.append('--uartC=tcp:2')
 
-    # somewhere for MAVProxy to connect to:
-    cmd.append('--uartC=tcp:2')
+    cmd.extend(customisations)
 
     if (gdb or lldb) and sys.platform == "darwin" and os.getenv('DISPLAY'):
         global windowID

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -463,6 +463,18 @@ bool AP_Arming::gps_checks(bool report)
     const AP_GPS &gps = AP::gps();
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS)) {
 
+        // Any failure messages from GPS backends
+        if ((checks_to_perform & ARMING_CHECK_ALL) ||
+            (checks_to_perform & ARMING_CHECK_GPS)) {
+            char failure_msg[50] = {};
+            if (!AP::gps().backends_healthy(failure_msg, ARRAY_SIZE(failure_msg))) {
+                if (failure_msg[0] != '\0') {
+                    check_failed(ARMING_CHECK_GPS, report, "%s", failure_msg);
+                }
+                return false;
+            }
+        }
+
         //GPS OK?
         if (!AP::ahrs().home_is_set() ||
             gps.status() < AP_GPS::GPS_OK_FIX_3D) {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -78,138 +78,138 @@ AP_GPS *AP_GPS::_singleton;
 
 // table of user settable parameters
 const AP_Param::GroupInfo AP_GPS::var_info[] = {
-    // @Param: TYPE
+    // @Param: _TYPE
     // @DisplayName: GPS type
     // @Description: GPS type
     // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO("TYPE",    0, AP_GPS, _type[0], HAL_GPS_TYPE_DEFAULT),
+    AP_GROUPINFO("_TYPE",    0, AP_GPS, _type[0], HAL_GPS_TYPE_DEFAULT),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: TYPE2
+    // @Param: _TYPE2
     // @DisplayName: 2nd GPS type
     // @Description: GPS type of 2nd GPS
     // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO("TYPE2",   1, AP_GPS, _type[1], 0),
+    AP_GROUPINFO("_TYPE2",   1, AP_GPS, _type[1], 0),
 #endif
 
-    // @Param: NAVFILTER
+    // @Param: _NAVFILTER
     // @DisplayName: Navigation filter setting
     // @Description: Navigation filter engine setting
     // @Values: 0:Portable,2:Stationary,3:Pedestrian,4:Automotive,5:Sea,6:Airborne1G,7:Airborne2G,8:Airborne4G
     // @User: Advanced
-    AP_GROUPINFO("NAVFILTER", 2, AP_GPS, _navfilter, GPS_ENGINE_AIRBORNE_4G),
+    AP_GROUPINFO("_NAVFILTER", 2, AP_GPS, _navfilter, GPS_ENGINE_AIRBORNE_4G),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: AUTO_SWITCH
+    // @Param: _AUTO_SWITCH
     // @DisplayName: Automatic Switchover Setting
     // @Description: Automatic switchover to GPS reporting best lock, 1:UseBest selects the GPS with highest status, if both are equal the GPS with highest satellite count is used 4:Use primary if 3D fix or better, will revert over 'UseBest' behaviour if 3D fix is lost on primary
     // @Values: 0:Use primary, 1:UseBest, 2:Blend, 4:Use primary if 3D fix or better
     // @User: Advanced
-    AP_GROUPINFO("AUTO_SWITCH", 3, AP_GPS, _auto_switch, (int8_t)GPSAutoSwitch::USE_BEST),
+    AP_GROUPINFO("_AUTO_SWITCH", 3, AP_GPS, _auto_switch, (int8_t)GPSAutoSwitch::USE_BEST),
 #endif
 
-    // @Param: MIN_DGPS
+    // @Param: _MIN_DGPS
     // @DisplayName: Minimum Lock Type Accepted for DGPS
     // @Description: Sets the minimum type of differential GPS corrections required before allowing to switch into DGPS mode.
     // @Values: 0:Any,50:FloatRTK,100:IntegerRTK
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("MIN_DGPS", 4, AP_GPS, _min_dgps, 100),
+    AP_GROUPINFO("_MIN_DGPS", 4, AP_GPS, _min_dgps, 100),
 
-    // @Param: SBAS_MODE
+    // @Param: _SBAS_MODE
     // @DisplayName: SBAS Mode
     // @Description: This sets the SBAS (satellite based augmentation system) mode if available on this GPS. If set to 2 then the SBAS mode is not changed in the GPS. Otherwise the GPS will be reconfigured to enable/disable SBAS. Disabling SBAS may be worthwhile in some parts of the world where an SBAS signal is available but the baseline is too long to be useful.
     // @Values: 0:Disabled,1:Enabled,2:NoChange
     // @User: Advanced
-    AP_GROUPINFO("SBAS_MODE", 5, AP_GPS, _sbas_mode, 2),
+    AP_GROUPINFO("_SBAS_MODE", 5, AP_GPS, _sbas_mode, 2),
 
-    // @Param: MIN_ELEV
+    // @Param: _MIN_ELEV
     // @DisplayName: Minimum elevation
     // @Description: This sets the minimum elevation of satellites above the horizon for them to be used for navigation. Setting this to -100 leaves the minimum elevation set to the GPS modules default.
     // @Range: -100 90
     // @Units: deg
     // @User: Advanced
-    AP_GROUPINFO("MIN_ELEV", 6, AP_GPS, _min_elevation, -100),
+    AP_GROUPINFO("_MIN_ELEV", 6, AP_GPS, _min_elevation, -100),
 
-    // @Param: INJECT_TO
+    // @Param: _INJECT_TO
     // @DisplayName: Destination for GPS_INJECT_DATA MAVLink packets
     // @Description: The GGS can send raw serial packets to inject data to multiple GPSes.
     // @Values: 0:send to first GPS,1:send to 2nd GPS,127:send to all
     // @User: Advanced
-    AP_GROUPINFO("INJECT_TO",   7, AP_GPS, _inject_to, GPS_RTK_INJECT_TO_ALL),
+    AP_GROUPINFO("_INJECT_TO",   7, AP_GPS, _inject_to, GPS_RTK_INJECT_TO_ALL),
 
-    // @Param: SBP_LOGMASK
+    // @Param: _SBP_LOGMASK
     // @DisplayName: Swift Binary Protocol Logging Mask
     // @Description: Masked with the SBP msg_type field to determine whether SBR1/SBR2 data is logged
     // @Values: 0:None (0x0000),-1:All (0xFFFF),-256:External only (0xFF00)
     // @User: Advanced
-    AP_GROUPINFO("SBP_LOGMASK", 8, AP_GPS, _sbp_logmask, -256),
+    AP_GROUPINFO("_SBP_LOGMASK", 8, AP_GPS, _sbp_logmask, -256),
 
-    // @Param: RAW_DATA
+    // @Param: _RAW_DATA
     // @DisplayName: Raw data logging
     // @Description: Handles logging raw data; on uBlox chips that support raw data this will log RXM messages into logger; on Septentrio this will log on the equipment's SD card and when set to 2, the autopilot will try to stop logging after disarming and restart after arming
     // @Values: 0:Ignore,1:Always log,2:Stop logging when disarmed (SBF only),5:Only log every five samples (uBlox only)
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO("RAW_DATA", 9, AP_GPS, _raw_data, 0),
+    AP_GROUPINFO("_RAW_DATA", 9, AP_GPS, _raw_data, 0),
 
-    // @Param: GNSS_MODE
+    // @Param: _GNSS_MODE
     // @DisplayName: GNSS system configuration
     // @Description: Bitmask for what GNSS system to use on the first GPS (all unchecked or zero to leave GPS as configured)
     // @Values: 0:Leave as currently configured, 1:GPS-NoSBAS, 3:GPS+SBAS, 4:Galileo-NoSBAS, 6:Galileo+SBAS, 8:Beidou, 51:GPS+IMES+QZSS+SBAS (Japan Only), 64:GLONASS, 66:GLONASS+SBAS, 67:GPS+GLONASS+SBAS
     // @Bitmask: 0:GPS,1:SBAS,2:Galileo,3:Beidou,4:IMES,5:QZSS,6:GLOSNASS
     // @User: Advanced
-    AP_GROUPINFO("GNSS_MODE", 10, AP_GPS, _gnss_mode[0], 0),
+    AP_GROUPINFO("_GNSS_MODE", 10, AP_GPS, _gnss_mode[0], 0),
 
-    // @Param: SAVE_CFG
+    // @Param: _SAVE_CFG
     // @DisplayName: Save GPS configuration
     // @Description: Determines whether the configuration for this GPS should be written to non-volatile memory on the GPS. Currently working for UBlox 6 series and above.
     // @Values: 0:Do not save config,1:Save config,2:Save only when needed
     // @User: Advanced
-    AP_GROUPINFO("SAVE_CFG", 11, AP_GPS, _save_config, 2),
+    AP_GROUPINFO("_SAVE_CFG", 11, AP_GPS, _save_config, 2),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: GNSS_MODE2
+    // @Param: _GNSS_MODE2
     // @DisplayName: GNSS system configuration
     // @Description: Bitmask for what GNSS system to use on the second GPS (all unchecked or zero to leave GPS as configured)
     // @Values: 0:Leave as currently configured, 1:GPS-NoSBAS, 3:GPS+SBAS, 4:Galileo-NoSBAS, 6:Galileo+SBAS, 8:Beidou, 51:GPS+IMES+QZSS+SBAS (Japan Only), 64:GLONASS, 66:GLONASS+SBAS, 67:GPS+GLONASS+SBAS
     // @Bitmask: 0:GPS,1:SBAS,2:Galileo,3:Beidou,4:IMES,5:QZSS,6:GLOSNASS
     // @User: Advanced
-    AP_GROUPINFO("GNSS_MODE2", 12, AP_GPS, _gnss_mode[1], 0),
+    AP_GROUPINFO("_GNSS_MODE2", 12, AP_GPS, _gnss_mode[1], 0),
 #endif
 
-    // @Param: AUTO_CONFIG
+    // @Param: _AUTO_CONFIG
     // @DisplayName: Automatic GPS configuration
     // @Description: Controls if the autopilot should automatically configure the GPS based on the parameters and default settings
     // @Values: 0:Disables automatic configuration,1:Enable automatic configuration
     // @User: Advanced
-    AP_GROUPINFO("AUTO_CONFIG", 13, AP_GPS, _auto_config, 1),
+    AP_GROUPINFO("_AUTO_CONFIG", 13, AP_GPS, _auto_config, 1),
 
-    // @Param: RATE_MS
+    // @Param: _RATE_MS
     // @DisplayName: GPS update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz(default) is not allowed. Raising the rate above 5Hz usually provides little benefit and for some GPS (eg Ublox M9N) can severely impact performance.
     // @Units: ms
     // @Values: 100:10Hz,125:8Hz,200:5Hz
     // @Range: 50 200
     // @User: Advanced
-    AP_GROUPINFO("RATE_MS", 14, AP_GPS, _rate_ms[0], 200),
+    AP_GROUPINFO("_RATE_MS", 14, AP_GPS, _rate_ms[0], 200),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: RATE_MS2
+    // @Param: _RATE_MS2
     // @DisplayName: GPS 2 update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz(default) is not allowed. Raising the rate above 5Hz usually provides little benefit and for some GPS (eg Ublox M9N) can severely impact performance.
     // @Units: ms
     // @Values: 100:10Hz,125:8Hz,200:5Hz
     // @Range: 50 200
     // @User: Advanced
-    AP_GROUPINFO("RATE_MS2", 15, AP_GPS, _rate_ms[1], 200),
+    AP_GROUPINFO("_RATE_MS2", 15, AP_GPS, _rate_ms[1], 200),
 #endif
 
-    // @Param: POS1_X
+    // @Param: _POS1_X
     // @DisplayName: Antenna X position offset
     // @Description: X position of the first GPS antenna in body frame. Positive X is forward of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
@@ -217,7 +217,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
 
-    // @Param: POS1_Y
+    // @Param: _POS1_Y
     // @DisplayName: Antenna Y position offset
     // @Description: Y position of the first GPS antenna in body frame. Positive Y is to the right of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
@@ -225,17 +225,17 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
 
-    // @Param: POS1_Z
+    // @Param: _POS1_Z
     // @DisplayName: Antenna Z position offset
     // @Description: Z position of the first GPS antenna in body frame. Positive Z is down from the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @Range: -5 5
     // @Increment: 0.01
     // @User: Advanced
-    AP_GROUPINFO("POS1", 16, AP_GPS, _antenna_offset[0], 0.0f),
+    AP_GROUPINFO("_POS1", 16, AP_GPS, _antenna_offset[0], 0.0f),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: POS2_X
+    // @Param: _POS2_X
     // @DisplayName: Antenna X position offset
     // @Description: X position of the second GPS antenna in body frame. Positive X is forward of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
@@ -243,7 +243,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
 
-    // @Param: POS2_Y
+    // @Param: _POS2_Y
     // @DisplayName: Antenna Y position offset
     // @Description: Y position of the second GPS antenna in body frame. Positive Y is to the right of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
@@ -251,104 +251,104 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
 
-    // @Param: POS2_Z
+    // @Param: _POS2_Z
     // @DisplayName: Antenna Z position offset
     // @Description: Z position of the second GPS antenna in body frame. Positive Z is down from the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @Range: -5 5
     // @Increment: 0.01
     // @User: Advanced
-    AP_GROUPINFO("POS2", 17, AP_GPS, _antenna_offset[1], 0.0f),
+    AP_GROUPINFO("_POS2", 17, AP_GPS, _antenna_offset[1], 0.0f),
 #endif
 
-    // @Param: DELAY_MS
+    // @Param: _DELAY_MS
     // @DisplayName: GPS delay in milliseconds
     // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
     // @Units: ms
     // @Range: 0 250
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("DELAY_MS", 18, AP_GPS, _delay_ms[0], 0),
+    AP_GROUPINFO("_DELAY_MS", 18, AP_GPS, _delay_ms[0], 0),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: DELAY_MS2
+    // @Param: _DELAY_MS2
     // @DisplayName: GPS 2 delay in milliseconds
     // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
     // @Units: ms
     // @Range: 0 250
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),
+    AP_GROUPINFO("_DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),
 #endif
 
 #if defined(GPS_BLENDED_INSTANCE)
-    // @Param: BLEND_MASK
+    // @Param: _BLEND_MASK
     // @DisplayName: Multi GPS Blending Mask
     // @Description: Determines which of the accuracy measures Horizontal position, Vertical Position and Speed are used to calculate the weighting on each GPS receiver when soft switching has been selected by setting GPS_AUTO_SWITCH to 2(Blend)
     // @Bitmask: 0:Horiz Pos,1:Vert Pos,2:Speed
     // @User: Advanced
-    AP_GROUPINFO("BLEND_MASK", 20, AP_GPS, _blend_mask, 5),
+    AP_GROUPINFO("_BLEND_MASK", 20, AP_GPS, _blend_mask, 5),
 
-    // @Param: BLEND_TC
+    // @Param: _BLEND_TC
     // @DisplayName: Blending time constant
     // @Description: Controls the slowest time constant applied to the calculation of GPS position and height offsets used to adjust different GPS receivers for steady state position differences.
     // @Units: s
     // @Range: 5.0 30.0
     // @User: Advanced
-    AP_GROUPINFO("BLEND_TC", 21, AP_GPS, _blend_tc, 10.0f),
+    AP_GROUPINFO("_BLEND_TC", 21, AP_GPS, _blend_tc, 10.0f),
 #endif
 
 #if GPS_MOVING_BASELINE
-    // @Param: DRV_OPTIONS
+    // @Param: _DRV_OPTIONS
     // @DisplayName: driver options
     // @Description: Additional backend specific options
     // @Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF
     // @User: Advanced
-    AP_GROUPINFO("DRV_OPTIONS", 22, AP_GPS, _driver_options, 0),
+    AP_GROUPINFO("_DRV_OPTIONS", 22, AP_GPS, _driver_options, 0),
 #endif
 
-    // @Param: COM_PORT
+    // @Param: _COM_PORT
     // @DisplayName: GPS physical COM port
     // @Description: The physical COM port on the connected device, currently only applies to SBF GPS
     // @Range: 0 10
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("COM_PORT", 23, AP_GPS, _com_port[0], HAL_GPS_COM_PORT_DEFAULT),
+    AP_GROUPINFO("_COM_PORT", 23, AP_GPS, _com_port[0], HAL_GPS_COM_PORT_DEFAULT),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: COM_PORT2
+    // @Param: _COM_PORT2
     // @DisplayName: GPS physical COM port
     // @Description: The physical COM port on the connected device, currently only applies to SBF GPS
     // @Range: 0 10
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("COM_PORT2", 24, AP_GPS, _com_port[1], HAL_GPS_COM_PORT_DEFAULT),
+    AP_GROUPINFO("_COM_PORT2", 24, AP_GPS, _com_port[1], HAL_GPS_COM_PORT_DEFAULT),
 #endif
 
 #if GPS_MOVING_BASELINE
 
-    // @Group: MB1_
+    // @Group: _MB1_
     // @Path: MovingBase.cpp
-    AP_SUBGROUPINFO(mb_params[0], "MB1_", 25, AP_GPS, MovingBase),
+    AP_SUBGROUPINFO(mb_params[0], "_MB1_", 25, AP_GPS, MovingBase),
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Group: MB2_
+    // @Group: _MB2_
     // @Path: MovingBase.cpp
-    AP_SUBGROUPINFO(mb_params[1], "MB2_", 26, AP_GPS, MovingBase),
+    AP_SUBGROUPINFO(mb_params[1], "_MB2_", 26, AP_GPS, MovingBase),
 #endif // GPS_MAX_RECEIVERS > 1
 
 #endif // GPS_MOVING_BASELINE
 
 #if GPS_MAX_RECEIVERS > 1
-    // @Param: PRIMARY
+    // @Param: _PRIMARY
     // @DisplayName: Primary GPS
     // @Description: This GPS will be used when GPS_AUTO_SWITCH is 0 and used preferentially with GPS_AUTO_SWITCH = 4.
     // @Increment: 1
     // @Values: 0:FirstGPS, 1:SecondGPS
     // @User: Advanced
-    AP_GROUPINFO("PRIMARY", 27, AP_GPS, _primary, 0),
+    AP_GROUPINFO("_PRIMARY", 27, AP_GPS, _primary, 0),
 #endif
 
 #if GPS_MAX_RECEIVERS > 1 && HAL_ENABLE_LIBUAVCAN_DRIVERS

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -351,6 +351,34 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     AP_GROUPINFO("PRIMARY", 27, AP_GPS, _primary, 0),
 #endif
 
+#if GPS_MAX_RECEIVERS > 1 && HAL_ENABLE_LIBUAVCAN_DRIVERS
+    // @Param: _CAN_NODEID1
+    // @DisplayName: GPS Node ID 1
+    // @Description: GPS Node id for discovered first.
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("_CAN_NODEID1", 28, AP_GPS, _node_id[0], 0),
+
+    // @Param: _CAN_NODEID2
+    // @DisplayName: GPS Node ID 2
+    // @Description: GPS Node id for discovered second.
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("_CAN_NODEID2", 29, AP_GPS, _node_id[1], 0),
+
+    // @Param: 1_CAN_OVRIDE
+    // @DisplayName: First UAVCAN GPS NODE ID
+    // @Description: GPS Node id for first GPS. If 0 the gps will be automatically selected on first come basis.
+    // @User: Advanced
+    AP_GROUPINFO("1_CAN_OVRIDE", 30, AP_GPS, _override_node_id[0], 0),
+
+    // @Param: 2_CAN_OVRIDE
+    // @DisplayName: Second UAVCAN GPS NODE ID
+    // @Description: GPS Node id for second GPS. If 0 the gps will be automatically selected on first come basis.
+    // @User: Advanced
+    AP_GROUPINFO("2_CAN_OVRIDE", 31, AP_GPS, _override_node_id[1], 0),
+#endif
+
     AP_GROUPEND
 };
 
@@ -1892,6 +1920,19 @@ bool AP_GPS::prepare_for_arming(void) {
         }
     }
     return all_passed;
+}
+
+bool AP_GPS::backends_healthy(char failure_msg[], uint16_t failure_msg_len) {
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+    for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
+        if (_type[i] == GPS_TYPE_UAVCAN) {
+            if (!AP_GPS_UAVCAN::backends_healthy(failure_msg, failure_msg_len)) {
+                return false;
+            }
+        }
+    }
+#endif
+    return true;
 }
 
 bool AP_GPS::logging_failed(void) const {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -78,6 +78,7 @@ class AP_GPS
     friend class AP_GPS_SIRF;
     friend class AP_GPS_UBLOX;
     friend class AP_GPS_Backend;
+    friend class AP_GPS_UAVCAN;
 
 public:
     AP_GPS();
@@ -498,6 +499,10 @@ public:
     // returns true if all GPS instances have passed all final arming checks/state changes
     bool prepare_for_arming(void);
 
+    // returns true if all GPS backend drivers haven't seen any failure
+    // this is for backends to be able to spout pre arm error messages
+    bool backends_healthy(char failure_msg[], uint16_t failure_msg_len);
+
     // returns false if any GPS drivers are not performing their logging appropriately
     bool logging_failed(void) const;
 
@@ -552,7 +557,10 @@ protected:
     AP_Float _blend_tc;
     AP_Int16 _driver_options;
     AP_Int8 _primary;
-
+#if GPS_MAX_RECEIVERS > 1 && HAL_ENABLE_LIBUAVCAN_DRIVERS
+    AP_Int32 _node_id[GPS_MAX_RECEIVERS];
+    AP_Int32 _override_node_id[GPS_MAX_RECEIVERS];
+#endif
 #if GPS_MOVING_BASELINE
     MovingBase mb_params[GPS_MAX_RECEIVERS];
 #endif // GPS_MOVING_BASELINE

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.h
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.h
@@ -44,7 +44,7 @@ public:
 
     bool is_configured(void) const override;
 
-    const char *name() const override { return "UAVCAN"; }
+    const char *name() const override { return _name; }
 
     static void subscribe_msgs(AP_UAVCAN* ap_uavcan);
     static AP_GPS_Backend* probe(AP_GPS &_gps, AP_GPS::GPS_State &_state);
@@ -55,6 +55,7 @@ public:
     static void handle_heading_msg_trampoline(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HeadingCb &cb);
     static void handle_status_msg_trampoline(AP_UAVCAN* ap_uavcan, uint8_t node_id, const StatusCb &cb);
 
+    static bool backends_healthy(char failure_msg[], uint16_t failure_msg_len);
     void inject_data(const uint8_t *data, uint16_t len) override;
 
     bool get_error_codes(uint32_t &error_codes) const override { error_codes = error_code; return seen_status; };
@@ -84,11 +85,13 @@ private:
     bool healthy;
     uint32_t status_flags;
     uint32_t error_code;
+    char _name[15];
 
     // Module Detection Registry
     static struct DetectedModules {
         AP_UAVCAN* ap_uavcan;
         uint8_t node_id;
+        uint8_t instance;
         AP_GPS_UAVCAN* driver;
     } _detected_modules[GPS_MAX_RECEIVERS];
 

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -18,13 +18,38 @@
 #include <AP_Param/AP_Param.h>
 #include <SITL/SIM_JSBSim.h>
 #include <AP_HAL/utility/Socket.h>
+#include <AP_HAL/utility/getopt_cpp.h>
 
 extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
 
 void SITL_State::init(int argc, char * const argv[]) {
+    int opt;
+    const struct GetOptLong::option options[] = {
+        {"help",            false,  0, 'h'},
+        {"instance",        true,   0, 'I'},
+    };
 
+    setvbuf(stdout, (char *)0, _IONBF, 0);
+    setvbuf(stderr, (char *)0, _IONBF, 0);
+
+    GetOptLong gopt(argc, argv, "hI:",
+                    options);
+
+    while((opt = gopt.getoption()) != -1) {
+        switch (opt) {
+            case 'I':
+                _instance = atoi(gopt.optarg);
+                break;
+            default:
+                printf("Options:\n"
+                    "\t--help|-h                display this help information\n"
+                    "\t--instance|-I N          set instance of SITL Periph\n");
+                exit(1);
+        }
+    }
+    printf("Running Instance: %d\n", _instance);
 }
 
 void SITL_State::wait_clock(uint64_t wait_time_usec) {

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.h
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.h
@@ -55,14 +55,17 @@ public:
     uint16_t current2_pin_value;  // pin 14
     // paths for UART devices
     const char *_uart_path[7] {
-        "tcp:5860",
-        "fifo:/tmp/ap_gps0",
-        "tcp:5861",
-        "tcp:5862",
-        "fifo:/tmp/ap_gps0",
-        "tcp:5863",
-        "tcp:5864",
+        "none:0",
+        "fifo:gps",
+        "none:1",
+        "none:2",
+        "none:3",
+        "none:4",
+        "none:5",
     };
+
+    uint8_t get_instance() const { return _instance; }
+
 private:
 
     void wait_clock(uint64_t wait_time_usec);
@@ -70,6 +73,8 @@ private:
     uint16_t _base_port;
 
     const char *defaults_path = HAL_PARAM_DEFAULTS_PATH;
+
+    uint8_t _instance;
 };
 
 #endif

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -124,6 +124,8 @@ public:
                                 Location &loc,
                                 float &yaw_degrees);
     
+    uint8_t get_instance() const { return _instance; }
+
 private:
     void _parse_command_line(int argc, char * const argv[]);
     void _set_param_default(const char *parm);
@@ -310,6 +312,7 @@ private:
     const char *defaults_path = HAL_PARAM_DEFAULTS_PATH;
 
     const char *_home_str;
+    char *_gps_fifo[2];
 };
 
 #endif // defined(HAL_BUILD_AP_PERIPH)

--- a/libraries/AP_HAL_SITL/Storage.cpp
+++ b/libraries/AP_HAL_SITL/Storage.cpp
@@ -13,6 +13,8 @@
 #ifndef HAL_STORAGE_FILE
 #if APM_BUILD_TYPE(APM_BUILD_Replay)
 #define HAL_STORAGE_FILE "eeprom-replay.bin"
+#elif APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+#define HAL_STORAGE_FILE "eeprom-periph.bin"
 #else
 #define HAL_STORAGE_FILE "eeprom.bin"
 #endif

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -104,6 +104,9 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
             _uart_baudrate = baudrate;
             _uart_start_connection();
         } else if (strcmp(devtype, "fifo") == 0) {
+            if(strcmp(args1, "gps") == 0) {
+                UNUSED_RESULT(asprintf(&args1, "/tmp/gps_fifo%d", (int)_sitlState->get_instance()));
+            }
             ::printf("Reading FIFO file @ %s\n", args1);
             _fd = ::open(args1, O_RDONLY | O_NONBLOCK);
             if (_fd >= 0) {
@@ -134,6 +137,9 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
                 ::printf("UDP multicast connection %s:%u\n", ip, port);
                 _udp_start_multicast(ip, port);
             }
+        } else if (strcmp(devtype,"none") == 0) {
+            // skipping port
+            ::printf("Skipping port %s\n", args1);
         } else {
             AP_HAL::panic("Invalid device path: %s", path);
         }

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -51,6 +51,7 @@ bool HALSITL::Util::get_system_id_unformatted(uint8_t buf[], uint8_t &len)
             *p = 0;
         }
         len = strnlen(cbuf, len);
+        buf[0] += sitlState->get_instance();
         return true;
     }
 
@@ -58,7 +59,10 @@ bool HALSITL::Util::get_system_id_unformatted(uint8_t buf[], uint8_t &len)
     if (gethostname(cbuf, len) != 0) {
         // use a default name so this always succeeds. Without it we can't
         // implement some features (such as UAVCAN)
-        strncpy(cbuf, "sitl-unknown", len);
+        snprintf(cbuf, len, "sitl-unknown-%d", sitlState->get_instance());
+    } else {
+        // To ensure separate ids for each instance
+        cbuf[0] += sitlState->get_instance();
     }
     len = strnlen(cbuf, len);
     return true;


### PR DESCRIPTION
Aim of this PR is to allow multiple GPSes on UAVCAN, and them appearing on fixed order. This is achieved by:
* Adding parameters `GPS_CAN_NODEID1` and `GPS_CAN_NODEID2` which are set in order of appearance of GPS on the CAN Bus with there Node IDs.
* `GPS1_CAN_OVRIDE` and `GPS2_CAN_OVRIDE` make the selection on which GPS NodeID will be treated as GPS1 and which GPS2.
* By default the values of `GPS1_CAN_OVRIDE` and `GPS2_CAN_OVRIDE` are 0 and GPS1 and GPS2 are set in order of appearance.
* Refering the values in `GPS_CAN_NODEID1` and `GPS_CAN_NODEID2`, user/GCS can set `GPS1_CAN_OVRIDE` and `GPS2_CAN_OVRIDE`.
* Once set in case the desired GPS NODEID doesn't appear, pre-arm error is generated, which also specifies the NodeID that was not found.
* There is also addition of dynamic naming of UAVCAN GPS which also contains the Node ID `GPS 1: specified as UAVCAN0-122` for better visibility to user. 0 being the instance of UAVCAN and 122 being the node id
* In SITL, changes are made to allow 2 AP_Periph GPS per ardupilot instance for development and testing of this.

- [x] Test on real hardware
- [ ] Mission Planner Implementation
- [x] Add autotest for the correct behaviour