### PR TITLE
AP_Logger & GCS_MAVLink: Log smart battery cycle count

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -19,6 +19,7 @@
 #include <AP_Proximity/AP_Proximity.h>
 #include <AP_InertialSensor/AP_InertialSensor_Backend.h>
 #include <AP_Vehicle/ModeReason.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
 
 #include <stdint.h>
 

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -33,7 +33,8 @@ private:
         GIT_VERSIONS,
         SYSTEM_ID,
         PARAM_SPACE_USED,
-        RC_PROTOCOL
+        RC_PROTOCOL,
+        BATT_CYCLES
     };
     Stage stage;
 };

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3482,6 +3482,16 @@ void GCS_MAVLINK::send_banner()
             send_text(MAV_SEVERITY_INFO, "%s", banner_msg);
         }
     }
+
+    // send smart battery cycle count
+    const AP_BattMonitor &battery = AP::battery();
+    for(uint8_t i = 0; i < AP_BATT_MONITOR_MAX_INSTANCES; i++) {
+        uint16_t cycles = 0;  
+        if (battery.get_cycle_count(i, cycles)) {
+            send_text(MAV_SEVERITY_INFO, "BATT%u_MONITOR: Cycles %u",
+                    i + 1, cycles);
+        } 
+    }
 }
 
 


### PR DESCRIPTION
This resolves (#13061). It adds the battery cycle counts to data flash logs and sends a message to the GCS via send_banner() after the firmware version has been sent. 

If someone with more compiler knowledge than I could help with why I had to scope around `case Stage::RC_PROTOCOL` that would be great? I kept getting a jump to case label error.

![DataFlash_Log](https://user-images.githubusercontent.com/69225461/103239699-60fc6e00-491c-11eb-9075-00274cd939c6.png)
![MIssionPlanner_GCS_Log](https://user-images.githubusercontent.com/69225461/103239701-61950480-491c-11eb-8b65-da009d1c892c.png)


