### PR TITLE
AP_Mount:Add RC invalid position to RC Targeting

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -392,7 +392,21 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Values: 0:None, 1:Servo, 2:3DR Solo, 3:Alexmos Serial, 4:SToRM32 MAVLink, 5:SToRM32 Serial
     // @User: Standard
     AP_GROUPINFO("2_TYPE",           42, AP_Mount, state[1]._type, 0),
+
+    // @Param: 2_RCINVLD_MODE
+    // @DisplayName: Mount2 RC Invalid Point Position
+    // @Description: Uses the designated mode's target position if RC invalid in RC Targeting mode
+    // @Values: -1:No Change,0:Retracted,1:Neutral
+    // @User: Standard
+    AP_GROUPINFO("2_RCINVLD_MODE", 43, AP_Mount, state[1]._rcinvalid_mode, -1),
 #endif // AP_MOUNT_MAX_INSTANCES > 1
+
+    // @Param: _RCINVLD_MODE
+    // @DisplayName: Mount RC Invalid Point Position
+    // @Description: Uses the designated modes target position if RC invalid in RC Targeting mode
+    // @Values: -1:No Change,0:Retracted,1:Neutral
+    // @User: Standard
+    AP_GROUPINFO("_RCINVLD_MODE", 44, AP_Mount, state[0]._rcinvalid_mode, -1),
 
     AP_GROUPEND
 };
@@ -434,6 +448,7 @@ void AP_Mount::init()
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
         // default instance's state
         state[instance]._mode = (enum MAV_MOUNT_MODE)state[instance]._default_mode.get();
+        state[instance]._rcinvalid_mode = state[instance]._rcinvalid_mode.get();
 
         MountType mount_type = get_mount_type(instance);
 
@@ -742,7 +757,7 @@ void AP_Mount::send_gimbal_report(mavlink_channel_t chan)
         if (_backends[instance] != nullptr) {
             _backends[instance]->send_gimbal_report(chan);
         }
-    }    
+    }
 }
 
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -159,6 +159,7 @@ protected:
         // Parameters
         AP_Int8         _type;              // mount type (None, Servo or MAVLink, see MountType enum)
         AP_Int8         _default_mode;      // default mode on startup and when control is returned from autopilot
+        AP_Int8         _rcinvalid_mode;    // positional mode (no change/retract/neutral position) for invalid RC input (used in RC Targeting mode)
         AP_Int8         _stab_roll;         // 1 = mount should stabilize earth-frame roll axis, 0 = no stabilization
         AP_Int8         _stab_tilt;         // 1 = mount should stabilize earth-frame pitch axis
         AP_Int8         _stab_pan;          // 1 = mount should stabilize earth-frame yaw axis
@@ -183,6 +184,7 @@ protected:
         AP_Float        _pitch_stb_lead;    // pitch lead control gain
 
         MAV_MOUNT_MODE  _mode;              // current mode (see MAV_MOUNT_MODE enum)
+
         struct Location _roi_target;        // roi target location
         bool _roi_target_set;
 

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -63,7 +63,7 @@ public:
 
     // control - control the mount
     virtual void control(int32_t pitch_or_lat, int32_t roll_or_lon, int32_t yaw_or_alt, MAV_MOUNT_MODE mount_mode);
-    
+
     // process MOUNT_CONFIGURE messages received from GCS:
     void handle_mount_configure(const mavlink_mount_configure_t &msg);
 

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -61,9 +61,23 @@ void AP_Mount_Servo::update()
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING:
         {
-            // update targets using pilot's rc inputs
+            // update targets using pilot's rc inputs or go to neutral or retracted targets if no rc
+            if (!rc().has_valid_input()) {
+                switch (_state._rcinvalid_mode.get()) {
+                    case MAV_MOUNT_MODE_RETRACT:
+                       _angle_bf_output_deg = _state._retract_angles.get();
+                       break;
+                    case MAV_MOUNT_MODE_NEUTRAL:
+                       _angle_bf_output_deg = _state._neutral_angles.get();
+                       break;
+                    default:
+                        //do nothing
+                        break;
+                    }
+            } else {
             update_targets_from_rc();
             stabilize();
+            }
             break;
         }
 


### PR DESCRIPTION
Allows mount to move to the neutral or retracted modes direction when in RC targeting mode and have invalid RC (FS)
this allows an option for  the mount to move to front of plane (or wherever) when not stabilizing and being used as a manual pan/tilt in failsafe instead of last good rc position....allows FPV pilot to see in front of vehicle while returning home until RC control is re-established....if under GCS control and link is valid, no change, since this impacts only RC Targeting, although perhaps could be worthwhile in other modes