### PR TITLE
Plane: re-add check for disarming in auto-throttle mode

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -243,6 +243,14 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method)
             gcs().send_text(MAV_SEVERITY_INFO, "Rudder disarm: disabled");
             return false;
         }
+
+        // if not in a manual throttle mode and not in CRUISE or FBWB
+        // modes then disallow rudder arming/disarming
+        if (plane.auto_throttle_mode &&
+            (plane.control_mode != &plane.mode_cruise && plane.control_mode != &plane.mode_fbwb)) {
+            check_failed(true, "Mode not rudder-disarmable");
+            return false;
+        }
     }
 
     if (!AP_Arming::disarm(method)) {


### PR DESCRIPTION
This check was removed without adequate discussion.

We disallow arming in auto-throttle modes to avoid finger-chopping.

The same wouldn't appear to be true of *disarming* based on rudder; the change in structure allows for different rudderarm/disarm behaviours now, but we shouldn't have changed this behaviour without more discussion.

@Hwurzburg this will actually re-instantiate the behaviour you've raised objections to - not being able to disarm in qacro/qstab IIRC.
