### PR TITLE
Added ExpandingString class for @SYS buffer print

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -39,6 +39,8 @@
 #include <AP_HAL_ChibiOS/CANIface.h>
 #endif
 
+#include <AP_Common/ExpandingString.h>
+
 #define LOG_TAG "CANMGR"
 #define LOG_BUFFER_SIZE 1024
 
@@ -373,15 +375,13 @@ void AP_CANManager::log_text(AP_CANManager::LogLevel loglevel, const char *tag, 
 }
 
 // log retrieve method used by file sys method to report can log
-uint32_t AP_CANManager::log_retrieve(char* data, uint32_t max_size) const
+void AP_CANManager::log_retrieve(ExpandingString &str) const
 {
     if (_log_buf == nullptr) {
         gcs().send_text(MAV_SEVERITY_ERROR, "Log buffer not available");
-        return 0;
+        return;
     }
-    uint32_t read_len = MIN(max_size, _log_pos);
-    memcpy(data, _log_buf, read_len);
-    return read_len;
+    str.append(_log_buf, _log_pos);
 }
 
 AP_CANManager& AP::can()

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -90,7 +90,7 @@ public:
     // Method to log status and debug information for review while debugging
     void log_text(AP_CANManager::LogLevel loglevel, const char *tag, const char *fmt, ...);
 
-    uint32_t log_retrieve(char* data, uint32_t max_size) const;
+    void log_retrieve(ExpandingString &str) const;
 
     // return driver type index i
     Driver_Type get_driver_type(uint8_t i) const

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -536,13 +536,12 @@ uint32_t SLCAN::CANIface::getErrorCount() const
     return 0;
 }
 
-uint32_t SLCAN::CANIface::get_stats(char* data, uint32_t max_size)
+void SLCAN::CANIface::get_stats(ExpandingString &str)
 {
     // When in passthrough mode methods is handled through can iface
     if (_can_iface) {
-        return _can_iface->get_stats(data, max_size);
+        _can_iface->get_stats(str);
     }
-    return 0;
 }
 
 bool SLCAN::CANIface::is_busoff() const

--- a/libraries/AP_CANManager/AP_SLCANIface.h
+++ b/libraries/AP_CANManager/AP_SLCANIface.h
@@ -112,7 +112,7 @@ public:
     bool set_event_handle(AP_HAL::EventHandle* evt_handle) override;
     uint16_t getNumFilters() const override;
     uint32_t getErrorCount() const override;
-    uint32_t get_stats(char* data, uint32_t max_size) override;
+    void get_stats(ExpandingString &) override;
     bool is_busoff() const override;
     bool configureFilters(const CanFilterConfig* filter_configs, uint16_t num_configs) override;
     void flush_tx() override;

--- a/libraries/AP_Common/ExpandingString.cpp
+++ b/libraries/AP_Common/ExpandingString.cpp
@@ -1,0 +1,102 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  expanding string for easy construction of text buffers
+ */
+
+#include "ExpandingString.h"
+
+extern const AP_HAL::HAL& hal;
+
+#define EXPAND_INCREMENT 512
+
+/*
+  expand the string buffer
+ */
+bool ExpandingString::expand(uint32_t min_extra_space_needed)
+{
+    // expand a reasonable amount
+    uint32_t newsize = (5*buflen/4) + EXPAND_INCREMENT;
+    if (newsize - used < min_extra_space_needed) {
+        newsize = used + min_extra_space_needed;
+    }
+    
+    // add one to ensure we are always null terminated
+    void *newbuf = hal.util->std_realloc(buf, newsize+1);
+
+    if (newbuf == nullptr) {
+        allocation_failed = true;
+        return false;
+    }
+
+    buflen = newsize;
+    buf = (char *)newbuf;
+
+    return true;
+}
+
+/*
+  print into the buffer, expanding if needed
+ */
+void ExpandingString::printf(const char *format, ...)
+{
+    if (allocation_failed) {
+        return;
+    }
+    if (buflen == used && !expand(0)) {
+        return;
+    }
+    int n;
+
+    /*
+      print into the buffer, expanding the buffer if needed
+     */
+    while (true) {
+        va_list arg;
+        va_start(arg, format);
+        n = hal.util->vsnprintf(&buf[used], buflen-used, format, arg);
+        va_end(arg);
+        if (n < 0) {
+            return;
+        }
+        if (uint32_t(n) < buflen - used) {
+            break;
+        }
+        if (!expand(n+1)) {            
+            return;
+        }
+    }
+    used += n;
+}
+
+/*
+  print into the buffer, expanding if needed
+ */
+void ExpandingString::append(const char *s, uint32_t len)
+{
+    if (allocation_failed) {
+        return;
+    }
+    if (buflen - used < len && !expand(len)) {
+        return;
+    }
+    memcpy(&buf[used], s, len);
+    used += len;
+}
+
+ExpandingString::~ExpandingString()
+{
+    free(buf);
+}

--- a/libraries/AP_Common/ExpandingString.h
+++ b/libraries/AP_Common/ExpandingString.h
@@ -1,0 +1,54 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  expanding string for easy construction of text buffers
+ */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+class ExpandingString {
+public:
+
+    const char *get_string(void) const {
+        return buf;
+    }
+    uint32_t get_length(void) const {
+        return used;
+    }
+
+    // print into the string
+    void printf(const char *format, ...) FMT_PRINTF(2,3);
+
+    // append data to the string
+    void append(const char *s, uint32_t len);
+
+    // destructor
+    ~ExpandingString();
+
+    bool has_failed_allocation() const {
+        return allocation_failed;
+    }
+
+private:
+    char *buf;
+    uint32_t buflen;
+    uint32_t used;
+    bool allocation_failed;
+
+    // try to expand the buffer
+    bool expand(uint32_t min_needed) WARN_IF_UNUSED;
+};

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -22,26 +22,22 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_Common/ExpandingString.h>
 
 extern const AP_HAL::HAL& hal;
 
 struct SysFileList {
     const char* name;
-    uint32_t filesize; 
 };
 
 static const SysFileList sysfs_file_list[] = {
-#if HAL_ENABLE_THREAD_STATISTICS
-    {"threads.txt", 2048},
-#else
-    {"threads.txt", 1024},
-#endif
-    {"tasks.txt", 6500},
-    {"dma.txt", 1024},
+    {"threads.txt"},
+    {"tasks.txt"},
+    {"dma.txt"},
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    {"can_log.txt", 1024},
-    {"can0_stats.txt", 1024},
-    {"can1_stats.txt", 1024},
+    {"can_log.txt"},
+    {"can0_stats.txt"},
+    {"can1_stats.txt"},
 #endif
 };
 
@@ -71,51 +67,34 @@ int AP_Filesystem_Sys::open(const char *fname, int flags)
         return -1;
     }
     struct rfile &r = file[idx];
-    r.data = new file_data;
-    if (r.data == nullptr) {
+    r.str = new ExpandingString;
+    if (r.str == nullptr) {
         errno = ENOMEM;
         return -1;
     }
 
     // This ensure that whenever new sys file is added its also added to list above
     int8_t pos = file_in_sysfs(fname);
-    uint32_t max_size = 0;
-    if (pos >= 0) {
-        max_size = sysfs_file_list[pos].filesize;
-    } else {
+    if (pos < 0) {
+        delete r.str;
+        r.str = nullptr;
         errno = ENOENT;
         return -1;
     }
 
     if (strcmp(fname, "threads.txt") == 0) {
-        r.data->data = (char *)malloc(max_size);
-        if (r.data->data) {
-            r.data->length = hal.util->thread_info(r.data->data, max_size);
-        }
+        hal.util->thread_info(*r.str);
     }
     if (strcmp(fname, "tasks.txt") == 0) {
-        r.data->data = (char *)malloc(max_size);
-        if (r.data->data) {
-            r.data->length = AP::scheduler().task_info(r.data->data, max_size);
-            if (r.data->length == 0) { // the feature may be disabled
-                free(r.data->data);
-                r.data->data = nullptr;
-            }
-        }
+        AP::scheduler().task_info(*r.str);
     }
     if (strcmp(fname, "dma.txt") == 0) {
-        r.data->data = (char *)malloc(max_size);
-        if (r.data->data) {
-            r.data->length = hal.util->dma_info(r.data->data, max_size);
-        }
+        hal.util->dma_info(*r.str);
     }
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     int8_t can_stats_num = -1;
     if (strcmp(fname, "can_log.txt") == 0) {
-        r.data->data = (char *)malloc(max_size);
-        if (r.data->data) {
-            r.data->length = AP::can().log_retrieve(r.data->data, max_size);
-        }
+        AP::can().log_retrieve(*r.str);
     } else if (strcmp(fname, "can0_stats.txt") == 0) {
         can_stats_num = 0;
     } else if (strcmp(fname, "can1_stats.txt") == 0) {
@@ -123,16 +102,14 @@ int AP_Filesystem_Sys::open(const char *fname, int flags)
     }
     if (can_stats_num != -1 && can_stats_num < HAL_NUM_CAN_IFACES) {
         if (hal.can[can_stats_num] != nullptr) {
-            r.data->data = (char *)malloc(max_size);
-            if (r.data->data) {
-                r.data->length = hal.can[can_stats_num]->get_stats(r.data->data, max_size);
-            }
+            hal.can[can_stats_num]->get_stats(*r.str);
         }
     }
 #endif
-    if (r.data->data == nullptr) {
-        delete r.data;
-        errno = ENOENT;
+    if (r.str->get_length() == 0) {
+        errno = r.str->has_failed_allocation()?ENOMEM:ENOENT;
+        delete r.str;
+        r.str = nullptr;
         return -1;
     }
     r.file_ofs = 0;
@@ -148,8 +125,8 @@ int AP_Filesystem_Sys::close(int fd)
     }
     struct rfile &r = file[fd];
     r.open = false;
-    free(r.data->data);
-    delete r.data;
+    delete r.str;
+    r.str = nullptr;
     return 0;
 }
 
@@ -160,8 +137,8 @@ int32_t AP_Filesystem_Sys::read(int fd, void *buf, uint32_t count)
         return -1;
     }
     struct rfile &r = file[fd];
-    count = MIN(count, r.data->length - r.file_ofs);
-    memcpy(buf, &r.data->data[r.file_ofs], count);
+    count = MIN(count, r.str->get_length() - r.file_ofs);
+    memcpy(buf, &r.str->get_string()[r.file_ofs], count);
     r.file_ofs += count;
     return count;
 }
@@ -175,10 +152,10 @@ int32_t AP_Filesystem_Sys::lseek(int fd, int32_t offset, int seek_from)
     struct rfile &r = file[fd];
     switch (seek_from) {
     case SEEK_SET:
-        r.file_ofs = MIN(offset, int32_t(r.data->length));
+        r.file_ofs = MIN(offset, int32_t(r.str->get_length()));
         break;
     case SEEK_CUR:
-        r.file_ofs = MIN(r.data->length, offset+r.file_ofs);
+        r.file_ofs = MIN(r.str->get_length(), offset+r.file_ofs);
         break;
     case SEEK_END:
         errno = EINVAL;
@@ -246,6 +223,8 @@ int AP_Filesystem_Sys::stat(const char *pathname, struct stat *stbuf)
         errno = ENOENT;
         return -1;
     }
-    stbuf->st_size = sysfs_file_list[pos].filesize;
+    // give a fixed size for stat. It is too expensive to
+    // read every file for a directory listing
+    stbuf->st_size = 100000;
     return 0;
 }

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.h
@@ -17,6 +17,8 @@
 
 #include "AP_Filesystem_backend.h"
 
+class ExpandingString;
+
 class AP_Filesystem_Sys : public AP_Filesystem_Backend
 {
 public:
@@ -35,11 +37,6 @@ private:
     static constexpr uint8_t max_open_file = 4;
     int8_t file_in_sysfs(const char *fname);
 
-    struct file_data {
-        char *data;
-        size_t length;
-    };
-
     struct DirReadTracker {
         size_t file_offset;
         struct dirent curr_file;
@@ -48,6 +45,6 @@ private:
     struct rfile {
         bool open;
         uint32_t file_ofs;
-        struct file_data *data;
+        ExpandingString *str;
     } file[max_open_file];
 };

--- a/libraries/AP_HAL/CANIface.h
+++ b/libraries/AP_HAL/CANIface.h
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include "AP_HAL_Namespace.h"
 
+class ExpandingString;
+
 /**
  * Raw CAN frame, as passed to/from the CAN driver.
  */
@@ -191,10 +193,7 @@ public:
     }
 
     //Get status info of the interface
-    virtual uint32_t get_stats(char* data, uint32_t max_size)
-    {
-        return 0;
-    }
+    virtual void get_stats(ExpandingString &str) {}
 
     // return true if busoff was detected and not cleared
     virtual bool is_busoff() const

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -3,6 +3,8 @@
 #include <stdarg.h>
 #include "AP_HAL_Namespace.h"
 
+class ExpandingString;
+
 class AP_HAL::Util {
 public:
     int snprintf(char* str, size_t size,
@@ -183,10 +185,10 @@ public:
     virtual bool trap() const { return false; }
 
     // request information on running threads
-    virtual size_t thread_info(char *buf, size_t bufsize) { return 0; }
+    virtual void thread_info(ExpandingString &str) {}
 
     // request information on dma contention
-    virtual size_t dma_info(char *buf, size_t bufsize) { return 0; }
+    virtual void dma_info(ExpandingString &str) {}
 
 protected:
     // we start soft_armed false, so that actuators don't send any

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -46,6 +46,8 @@
 #include <AP_Math/AP_Math.h>
 # include <hal.h>
 #include <AP_CANManager/AP_CANManager.h>
+#include <AP_Common/ExpandingString.h>
+
 # if defined(STM32H7XX)
 #include "CANFDIface.h"
 
@@ -929,34 +931,29 @@ bool CANIface::select(bool &read, bool &write,
 }
 
 #if !defined(HAL_BUILD_AP_PERIPH) && !defined(HAL_BOOTLOADER_BUILD)
-uint32_t CANIface::get_stats(char* data, uint32_t max_size)
+void CANIface::get_stats(ExpandingString &str)
 {
-    if (data == nullptr) {
-        return 0;
-    }
     CriticalSectionLocker lock;
-    uint32_t ret = snprintf(data, max_size,
-                            "tx_requests:    %lu\n"
-                            "tx_rejected:    %lu\n"
-                            "tx_success:     %lu\n"
-                            "tx_timedout:    %lu\n"
-                            "tx_abort:       %lu\n"
-                            "rx_received:    %lu\n"
-                            "rx_overflow:    %lu\n"
-                            "rx_errors:      %lu\n"
-                            "num_busoff_err: %lu\n"
-                            "num_events:     %lu\n",
-                            stats.tx_requests,
-                            stats.tx_rejected,
-                            stats.tx_success,
-                            stats.tx_timedout,
-                            stats.tx_abort,
-                            stats.rx_received,
-                            stats.rx_overflow,
-                            stats.rx_errors,
-                            stats.num_busoff_err,
-                            stats.num_events);
-    return ret;
+    str.printf("tx_requests:    %lu\n"
+               "tx_rejected:    %lu\n"
+               "tx_success:     %lu\n"
+               "tx_timedout:    %lu\n"
+               "tx_abort:       %lu\n"
+               "rx_received:    %lu\n"
+               "rx_overflow:    %lu\n"
+               "rx_errors:      %lu\n"
+               "num_busoff_err: %lu\n"
+               "num_events:     %lu\n",
+               stats.tx_requests,
+               stats.tx_rejected,
+               stats.tx_success,
+               stats.tx_timedout,
+               stats.tx_abort,
+               stats.rx_received,
+               stats.rx_overflow,
+               stats.rx_errors,
+               stats.num_busoff_err,
+               stats.num_events);
 }
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.h
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.h
@@ -219,7 +219,7 @@ public:
 
     // fetch stats text and return the size of the same,
     // results available via @SYS/can0_stats.txt or @SYS/can1_stats.txt 
-    uint32_t get_stats(char* data, uint32_t max_size) override;
+    void get_stats(ExpandingString &str) override;
 #endif
     /************************************
      * Methods used inside interrupt    *

--- a/libraries/AP_HAL_ChibiOS/CANIface.h
+++ b/libraries/AP_HAL_ChibiOS/CANIface.h
@@ -220,7 +220,7 @@ public:
 
     // fetch stats text and return the size of the same,
     // results available via @SYS/can0_stats.txt or @SYS/can1_stats.txt 
-    uint32_t get_stats(char* data, uint32_t max_size) override;
+    void get_stats(ExpandingString &str) override;
 #endif
     /************************************
      * Methods used inside interrupt    *

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -46,6 +46,7 @@
 #include <AP_Math/AP_Math.h>
 # include <hal.h>
 #include <AP_CANManager/AP_CANManager.h>
+#include <AP_Common/ExpandingString.h>
 
 # if !defined(STM32H7XX)
 #include "CANIface.h"
@@ -902,35 +903,30 @@ bool CANIface::init(const uint32_t bitrate, const CANIface::OperatingMode mode)
 }
 
 #if !defined(HAL_BUILD_AP_PERIPH) && !defined(HAL_BOOTLOADER_BUILD)
-uint32_t CANIface::get_stats(char* data, uint32_t max_size)
+void CANIface::get_stats(ExpandingString &str)
 {
-    if (data == nullptr) {
-        return 0;
-    }
     CriticalSectionLocker lock;
-    uint32_t ret = snprintf(data, max_size,
-                            "tx_requests:    %lu\n"
-                            "tx_rejected:    %lu\n"
-                            "tx_success:     %lu\n"
-                            "tx_timedout:    %lu\n"
-                            "tx_abort:       %lu\n"
-                            "rx_received:    %lu\n"
-                            "rx_overflow:    %lu\n"
-                            "rx_errors:      %lu\n"
-                            "num_busoff_err: %lu\n"
-                            "num_events:     %lu\n",
-                            stats.tx_requests,
-                            stats.tx_rejected,
-                            stats.tx_success,
-                            stats.tx_timedout,
-                            stats.tx_abort,
-                            stats.rx_received,
-                            stats.rx_overflow,
-                            stats.rx_errors,
-                            stats.num_busoff_err,
-                            stats.num_events);
+    str.printf("tx_requests:    %lu\n"
+               "tx_rejected:    %lu\n"
+               "tx_success:     %lu\n"
+               "tx_timedout:    %lu\n"
+               "tx_abort:       %lu\n"
+               "rx_received:    %lu\n"
+               "rx_overflow:    %lu\n"
+               "rx_errors:      %lu\n"
+               "num_busoff_err: %lu\n"
+               "num_events:     %lu\n",
+               stats.tx_requests,
+               stats.tx_rejected,
+               stats.tx_success,
+               stats.tx_timedout,
+               stats.tx_abort,
+               stats.rx_received,
+               stats.rx_overflow,
+               stats.rx_errors,
+               stats.num_busoff_err,
+               stats.num_events);
     memset(&stats, 0, sizeof(stats));
-    return ret;
 }
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -24,6 +24,7 @@
 #include "hwdef/common/watchdog.h"
 #include "hwdef/common/flash.h"
 #include <AP_ROMFS/AP_ROMFS.h>
+#include <AP_Common/ExpandingString.h>
 #include "sdcard.h"
 #include "shared_dma.h"
 
@@ -299,20 +300,14 @@ bool Util::was_watchdog_reset() const
 /*
   display stack usage as text buffer for @SYS/threads.txt
  */
-size_t Util::thread_info(char *buf, size_t bufsize)
+void Util::thread_info(ExpandingString &str)
 {
-  size_t total = 0;
-
   // a header to allow for machine parsers to determine format
   const uint32_t isr_stack_size = uint32_t((const uint8_t *)&__main_stack_end__ - (const uint8_t *)&__main_stack_base__);
-  int n = snprintf(buf, bufsize, "ThreadsV2\nISR           PRI=255 sp=%p STACK=%u/%u\n",
-                   &__main_stack_base__, stack_free(&__main_stack_base__), isr_stack_size);
-  if (n <= 0) {
-      return 0;
-  }
-  buf += n;
-  bufsize -= n;
-  total += n;
+  str.printf("ThreadsV2\nISR           PRI=255 sp=%p STACK=%u/%u\n",
+             &__main_stack_base__,
+             unsigned(stack_free(&__main_stack_base__)),
+             unsigned(isr_stack_size));
 
   for (thread_t *tp = chRegFirstThread(); tp; tp = chRegNextThread(tp)) {
       uint32_t total_stack;
@@ -324,35 +319,26 @@ size_t Util::thread_info(char *buf, size_t bufsize)
           // above the stack top
           total_stack = uint32_t(tp) - uint32_t(tp->wabase);
       }
-      if (bufsize > 0) {
 #if HAL_ENABLE_THREAD_STATISTICS
-          n = snprintf(buf, bufsize, "%-13.13s PRI=%3u sp=%p STACK=%4u/%4u MIN=%4u AVG=%4u MAX=%4u\n",
-                        tp->name, unsigned(tp->prio), tp->wabase,
-                        stack_free(tp->wabase), total_stack, RTC2US(STM32_HSECLK, tp->stats.best),
-                        RTC2US(STM32_HSECLK, uint32_t(tp->stats.cumulative / uint64_t(tp->stats.n))),
-                        RTC2US(STM32_HSECLK, tp->stats.worst));
-          chTMObjectInit(&tp->stats); // reset counters to zero
+      str.printf("%-13.13s PRI=%3u sp=%p STACK=%4u/%4u MIN=%4u AVG=%4u MAX=%4u\n",
+                 tp->name, unsigned(tp->prio), tp->wabase,
+                 stack_free(tp->wabase), total_stack, RTC2US(STM32_HSECLK, tp->stats.best),
+                 RTC2US(STM32_HSECLK, uint32_t(tp->stats.cumulative / uint64_t(tp->stats.n))),
+                 RTC2US(STM32_HSECLK, tp->stats.worst));
+      chTMObjectInit(&tp->stats); // reset counters to zero
 #else
-          n = snprintf(buf, bufsize, "%-13.13s PRI=%3u sp=%p STACK=%u/%u\n",
-                       tp->name, unsigned(tp->prio), tp->wabase,
-                       stack_free(tp->wabase), total_stack);
+      str.printf("%-13.13s PRI=%3u sp=%p STACK=%u/%u\n",
+                 tp->name, unsigned(tp->prio), tp->wabase,
+                 unsigned(stack_free(tp->wabase)), unsigned(total_stack));
 #endif
-          if (n > bufsize) {
-              n = bufsize;
-          }
-          buf += n;
-          bufsize -= n;
-          total += n;
-      }
   }
-
-  return total;
 }
 #endif // CH_DBG_ENABLE_STACK_CHECK == TRUE
 
 #if CH_CFG_USE_SEMAPHORES
 // request information on dma contention
-size_t Util::dma_info(char *buf, size_t bufsize) {
-    return ChibiOS::Shared_DMA::dma_info(buf, bufsize);
+void Util::dma_info(ExpandingString &str)
+{
+    ChibiOS::Shared_DMA::dma_info(str);
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -60,11 +60,11 @@ public:
 
 #if CH_DBG_ENABLE_STACK_CHECK == TRUE
     // request information on running threads
-    size_t thread_info(char *buf, size_t bufsize) override;
+    void thread_info(ExpandingString &str) override;
 #endif
 #if CH_CFG_USE_SEMAPHORES
     // request information on dma contention
-    size_t dma_info(char *buf, size_t bufsize) override;
+    void dma_info(ExpandingString &str) override;
 #endif
     
 private:

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -474,3 +474,4 @@ define STORAGE_FLASH_PAGE 1
 # is "ROMFS ROMFS-filename source-filename". Paths are relative to the
 # ardupilot root
 ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_highpolh.bin
+

--- a/libraries/AP_HAL_ChibiOS/shared_dma.h
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.h
@@ -66,7 +66,7 @@ public:
     static void lock_all(void);
 
     // display dma contention statistics as text buffer for @SYS/dma.txt
-    static size_t dma_info(char *buf, size_t bufsize);
+    static void dma_info(ExpandingString &str);
 
 private:
     dma_allocate_fn_t allocate;

--- a/libraries/AP_HAL_Linux/CANSocketIface.cpp
+++ b/libraries/AP_HAL_Linux/CANSocketIface.cpp
@@ -39,6 +39,8 @@
 #include <cstring>
 #include "Scheduler.h"
 #include <AP_CANManager/AP_CANManager.h>
+#include <AP_Common/ExpandingString.h>
+
 extern const AP_HAL::HAL& hal;
 
 using namespace Linux;
@@ -571,41 +573,36 @@ bool CANIface::CANSocketEventSource::wait(uint64_t duration, AP_HAL::EventHandle
     return true;
 }
 
-uint32_t CANIface::get_stats(char* data, uint32_t max_size)
+void CANIface::get_stats(ExpandingString &str)
 {
-    if (data == nullptr) {
-        return 0;
-    }
-    uint32_t ret = snprintf(data, max_size,
-                            "tx_requests:    %u\n"
-                            "tx_write_fail:  %u\n"
-                            "tx_full:        %u\n"
-                            "tx_confirmed:   %u\n"
-                            "tx_success:     %u\n"
-                            "tx_timedout:    %u\n"
-                            "rx_received:    %u\n"
-                            "rx_errors:      %u\n"
-                            "num_downs:      %u\n"
-                            "num_rx_poll_req:  %u\n"
-                            "num_tx_poll_req:  %u\n"
-                            "num_poll_waits:   %u\n"
-                            "num_poll_tx_events: %u\n"
-                            "num_poll_rx_events: %u\n",
-                            stats.tx_requests,
-                            stats.tx_write_fail,
-                            stats.tx_full,
-                            stats.tx_confirmed,
-                            stats.tx_success,
-                            stats.tx_timedout,
-                            stats.rx_received,
-                            stats.rx_errors,
-                            stats.num_downs,
-                            stats.num_rx_poll_req,
-                            stats.num_tx_poll_req,
-                            stats.num_poll_waits,
-                            stats.num_poll_tx_events,
-                            stats.num_poll_rx_events);
-    return ret;
+    str.printf("tx_requests:    %u\n"
+               "tx_write_fail:  %u\n"
+               "tx_full:        %u\n"
+               "tx_confirmed:   %u\n"
+               "tx_success:     %u\n"
+               "tx_timedout:    %u\n"
+               "rx_received:    %u\n"
+               "rx_errors:      %u\n"
+               "num_downs:      %u\n"
+               "num_rx_poll_req:  %u\n"
+               "num_tx_poll_req:  %u\n"
+               "num_poll_waits:   %u\n"
+               "num_poll_tx_events: %u\n"
+               "num_poll_rx_events: %u\n",
+               stats.tx_requests,
+               stats.tx_write_fail,
+               stats.tx_full,
+               stats.tx_confirmed,
+               stats.tx_success,
+               stats.tx_timedout,
+               stats.rx_received,
+               stats.rx_errors,
+               stats.num_downs,
+               stats.num_rx_poll_req,
+               stats.num_tx_poll_req,
+               stats.num_poll_waits,
+               stats.num_poll_tx_events,
+               stats.num_poll_rx_events);
 }
 
 #endif

--- a/libraries/AP_HAL_Linux/CANSocketIface.h
+++ b/libraries/AP_HAL_Linux/CANSocketIface.h
@@ -113,7 +113,7 @@ public:
 
     // fetch stats text and return the size of the same,
     // results available via @SYS/can0_stats.txt or @SYS/can1_stats.txt 
-    uint32_t get_stats(char* data, uint32_t max_size) override;
+    void get_stats(ExpandingString &str) override;
 
     class CANSocketEventSource : public AP_HAL::EventSource {
         friend class CANIface;

--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -39,6 +39,8 @@
 #include <cstring>
 #include "Scheduler.h"
 #include <AP_CANManager/AP_CANManager.h>
+#include <AP_Common/ExpandingString.h>
+
 extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
@@ -576,41 +578,36 @@ bool CANIface::CANSocketEventSource::wait(uint64_t duration, AP_HAL::EventHandle
     return true;
 }
 
-uint32_t CANIface::get_stats(char* data, uint32_t max_size)
+void CANIface::get_stats(ExpandingString &str)
 {
-    if (data == nullptr) {
-        return 0;
-    }
-    uint32_t ret = snprintf(data, max_size,
-                            "tx_requests:    %u\n"
-                            "tx_write_fail:  %u\n"
-                            "tx_full:        %u\n"
-                            "tx_confirmed:   %u\n"
-                            "tx_success:     %u\n"
-                            "tx_timedout:    %u\n"
-                            "rx_received:    %u\n"
-                            "rx_errors:      %u\n"
-                            "num_downs:      %u\n"
-                            "num_rx_poll_req:  %u\n"
-                            "num_tx_poll_req:  %u\n"
-                            "num_poll_waits:   %u\n"
-                            "num_poll_tx_events: %u\n"
-                            "num_poll_rx_events: %u\n",
-                            stats.tx_requests,
-                            stats.tx_write_fail,
-                            stats.tx_full,
-                            stats.tx_confirmed,
-                            stats.tx_success,
-                            stats.tx_timedout,
-                            stats.rx_received,
-                            stats.rx_errors,
-                            stats.num_downs,
-                            stats.num_rx_poll_req,
-                            stats.num_tx_poll_req,
-                            stats.num_poll_waits,
-                            stats.num_poll_tx_events,
-                            stats.num_poll_rx_events);
-    return ret;
+    str.printf("tx_requests:    %u\n"
+               "tx_write_fail:  %u\n"
+               "tx_full:        %u\n"
+               "tx_confirmed:   %u\n"
+               "tx_success:     %u\n"
+               "tx_timedout:    %u\n"
+               "rx_received:    %u\n"
+               "rx_errors:      %u\n"
+               "num_downs:      %u\n"
+               "num_rx_poll_req:  %u\n"
+               "num_tx_poll_req:  %u\n"
+               "num_poll_waits:   %u\n"
+               "num_poll_tx_events: %u\n"
+               "num_poll_rx_events: %u\n",
+               stats.tx_requests,
+               stats.tx_write_fail,
+               stats.tx_full,
+               stats.tx_confirmed,
+               stats.tx_success,
+               stats.tx_timedout,
+               stats.rx_received,
+               stats.rx_errors,
+               stats.num_downs,
+               stats.num_rx_poll_req,
+               stats.num_tx_poll_req,
+               stats.num_poll_waits,
+               stats.num_poll_tx_events,
+               stats.num_poll_rx_events);
 }
 
 #endif

--- a/libraries/AP_HAL_SITL/CANSocketIface.h
+++ b/libraries/AP_HAL_SITL/CANSocketIface.h
@@ -113,7 +113,7 @@ public:
 
     // fetch stats text and return the size of the same,
     // results available via @SYS/can0_stats.txt or @SYS/can1_stats.txt 
-    uint32_t get_stats(char* data, uint32_t max_size) override;
+    void get_stats(ExpandingString &str) override;
 
     class CANSocketEventSource : public AP_HAL::EventSource {
         friend class CANIface;

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -156,7 +156,7 @@ public:
 
     HAL_Semaphore &get_semaphore(void) { return _rsem; }
 
-    size_t task_info(char *buf, size_t bufsize);
+    void task_info(ExpandingString &str);
 
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
This makes writing @SYS filesystem output handlers much easier, and removes our current arbitrary limits on the max size of these files

this also saves 236 bytes of flash on CubeOrange for plane
