### PR TITLE
Copter: Add a redefinition decision

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -44,7 +44,9 @@
 //#define MODE_SYSTEMID_ENABLED DISABLED            // disable system ID mode support
 //#define MODE_THROW_ENABLED    DISABLED            // disable throw mode support
 //#define MODE_ZIGZAG_ENABLED   DISABLED            // disable zigzag mode support
+#ifndef OSD_ENABLED
 //#define OSD_ENABLED           DISABLED            // disable on-screen-display support
+#endif
 //#define BUTTON_ENABLED        DISABLED            // disable button support
 
 // features below are disabled by default on all boards


### PR DESCRIPTION
#16170 recommit.

I know that I can enable and disable the optional features of the copter in APM_Config.h.
I enabled the definition of OSD_ENABLED, since I do not need the OSD feature.
I got a build error.
I learned that I have defined it in config.h.
I will add the definition presence/absence check.

I think only one option function specification file is needed.

[687/748] Compiling ArduCopter/navigation.cpp
In file included from ... /... /ArduCopter/config.h:29:0,
From ... /. /... /ArduCopter/Copter.h:72,
from ... /... /ArduCopter/mode_zigzag.cpp:1:
... /... /ArduCopter/APM_Config.h:47:0: error: "OSD_ENABLED" redefined [-Werror].
#define OSD_ENABLED DISABLED // disable on-screen-display support