### PR TITLE
Copter: Notify the user that there is no log function

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -61,6 +61,8 @@ void Copter::init_ardupilot()
 
 #if LOGGING_ENABLED == ENABLED
     log_init();
+#else
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "No log function is built in.");
 #endif
 
     // update motor interlock state


### PR DESCRIPTION
I disabled the logging feature in LOGGING_ENABLED.
I saw the logger parameter in the config parameter.
I can't tell that the logging feature is disabled.
I think I can recognize it by notifying me that the log function is disabled.

CONFIG PARAMETERS
![Screenshot from 2020-12-30 23-17-06](https://user-images.githubusercontent.com/646194/103357617-f81d1d80-4af6-11eb-9056-4226850c5a15.png)

ADDED MESSAGE
![Screenshot from 2020-12-30 23-17-27](https://user-images.githubusercontent.com/646194/103357662-1551ec00-4af7-11eb-8a6e-000304d40a4c.png)