### PR TITLE
Copter: don't report initial mode switch as failsafe mode change

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -216,13 +216,11 @@ void Copter::init_ardupilot()
         enable_motor_output();
     }
 
-    // attempt to switch to RTL, if this fails then switch to Land
+    // attempt to set the intial_mode, else set to STABILIZE
     if (!set_mode((enum Mode::Number)g.initial_mode.get(), ModeReason::INITIALISED)) {
         // set mode to STABILIZE will trigger mode change notification to pilot
         set_mode(Mode::Number::STABILIZE, ModeReason::UNAVAILABLE);
-    } else {
-        // alert pilot to mode change
-        AP_Notify::events.failsafe_mode_change = 1;
+        AP_Notify::events.user_mode_change_failed = 1;
     }
 
     // flag that initialisation has completed


### PR DESCRIPTION
If you didn't change the initial_mode value then we go through the else cause and trigger 
AP_Notify::events.failsafe_mode_change = 1; that use a tone at start ... we definitely don't want that at start.

This can be checked on SITL with --tonealarm