### PR TITLE
UAVCAN: added logging of CAN devices

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -580,6 +580,8 @@ void AP_Logger::Write_MessageF(const char *fmt, ...)
 
 void AP_Logger::backend_starting_new_log(const AP_Logger_Backend *backend)
 {
+    _log_start_count++;
+
     for (uint8_t i=0; i<_next_backend; i++) {
         if (backends[i] == backend) { // pointer comparison!
             // reset sent masks

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -408,6 +408,11 @@ public:
     // output a FMT message for each backend if not already done so
     void Safe_Write_Emit_FMT(log_write_fmt *f);
 
+    // get count of number of times we have started logging
+    uint8_t get_log_start_count(void) const {
+        return _log_start_count;
+    }
+
 protected:
 
     const struct LogStructure *_structures;
@@ -530,6 +535,10 @@ private:
 
     // last time arming failed, for backends
     uint32_t _last_arming_failure_ms;
+
+    // count of number of times we've started logging
+    // can be used by other subsystems to detect if they should log data
+    uint8_t _log_start_count;
 
     bool should_handle_log_message();
     void handle_log_message(class GCS_MAVLINK &, const mavlink_message_t &msg);

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -323,7 +323,9 @@ bool AP_Logger_Backend::Write(const uint8_t msg_type, va_list arg_list, bool is_
         }
         if (charlen != 0) {
             char *tmp = va_arg(arg_list, char*);
-            memcpy(&buffer[offset], tmp, charlen);
+            uint8_t len = strnlen(tmp, charlen);
+            memcpy(&buffer[offset], tmp, len);
+            memset(&buffer[offset+len], 0, charlen-len);
             offset += charlen;
         }
     }

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
@@ -37,6 +37,9 @@ class AP_UAVCAN_DNA_Server
     Bitmask<128> occupation_mask;
     Bitmask<128> verified_mask;
     Bitmask<128> node_seen_mask;
+    Bitmask<128> logged;
+
+    uint8_t last_logging_count;
 
     //Error State
     enum ServerState server_state;
@@ -115,7 +118,7 @@ public:
     //Callbacks
     void handleAllocation(uint8_t driver_index, uint8_t node_id, const AllocationCb &cb);
     void handleNodeStatus(uint8_t node_id, const NodeStatusCb &cb);
-    void handleNodeInfo(uint8_t node_id, uint8_t unique_id[], char name[]);
+    void handleNodeInfo(uint8_t node_id, uint8_t unique_id[], char name[], uint8_t major, uint8_t minor, uint32_t vcs_commit);
 
     //Run through the list of seen node ids for verification
     void verify_nodes(AP_UAVCAN *ap_uavcan);


### PR DESCRIPTION
This logs all UAVCAN devices, giving name, major/minor, unique ID and the vcs_commit.

This will be useful for knowing what firmware is running on a CAN sensor

CAND {TimeUS : 20397740, NodeId : 125, UID1 : 6359459866467565600, UID2 : 540358451, Name : org.ardupilot.HitecMosaic, Major : 1, Minor : 1, Version : 3489790103}

The Version field is the git hash for AP_Periph devices 
3489790103 == 0xD001F897

@peterbarker note change to semantics of string logging in this PR