### PR TITLE
CAN: added CANSensor class for easy CAN sensors

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -898,6 +898,7 @@ bool AP_Arming::can_checks(bool report)
                     check_failed(ARMING_CHECK_SYSTEM, report, "TestCAN: No Arming with TestCAN enabled");
                     break;
                 }
+                case AP_CANManager::Driver_Type_EFI_NWPMU:
                 case AP_CANManager::Driver_Type_None:
                     break;
             }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -899,6 +899,7 @@ bool AP_Arming::can_checks(bool report)
                     break;
                 }
                 case AP_CANManager::Driver_Type_EFI_NWPMU:
+                case AP_CANManager::Driver_Type_USD1:
                 case AP_CANManager::Driver_Type_None:
                     break;
             }

--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
     // @Values{Copter,Plane,Sub}: 0:Disabled,1:UAVCAN,2:KDECAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester
-    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester
+    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, AP_CANManager::Driver_Type_UAVCAN),

--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
     // @Values{Copter,Plane,Sub}: 0:Disabled,1:UAVCAN,2:KDECAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester
-    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU
+    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, AP_CANManager::Driver_Type_UAVCAN),

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -28,6 +28,7 @@
 #include <AP_ToshibaCAN/AP_ToshibaCAN.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_PiccoloCAN/AP_PiccoloCAN.h>
+#include <AP_EFI/AP_EFI_NWPMU.h>
 #include "AP_CANTester.h"
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -58,6 +58,7 @@ public:
         Driver_Type_PiccoloCAN = 4,
         Driver_Type_CANTester = 5,
         Driver_Type_EFI_NWPMU = 6,
+        Driver_Type_USD1 = 7,
     };
 
     void init(void);

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -57,6 +57,7 @@ public:
         Driver_Type_ToshibaCAN = 3,
         Driver_Type_PiccoloCAN = 4,
         Driver_Type_CANTester = 5,
+        Driver_Type_EFI_NWPMU = 6,
     };
 
     void init(void);

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -61,6 +61,9 @@ public:
 
     void init(void);
 
+    // register a new driver
+    bool register_driver(Driver_Type dtype, AP_CANDriver *driver);
+
     // returns number of active CAN Drivers
     uint8_t get_num_drivers(void) const
     {
@@ -139,7 +142,7 @@ private:
     };
 
     CANIface_Params _interfaces[HAL_NUM_CAN_IFACES];
-    AP_CANDriver* _drivers[HAL_MAX_CAN_PROTOCOL_DRIVERS] {};
+    AP_CANDriver* _drivers[HAL_MAX_CAN_PROTOCOL_DRIVERS];
     CANDriver_Params _drv_param[HAL_MAX_CAN_PROTOCOL_DRIVERS];
     Driver_Type _driver_type_cache[HAL_MAX_CAN_PROTOCOL_DRIVERS];
 
@@ -150,6 +153,8 @@ private:
 
     char* _log_buf;
     uint32_t _log_pos;
+
+    HAL_Semaphore _sem;
 };
 
 namespace AP

--- a/libraries/AP_CANManager/AP_CANSensor.cpp
+++ b/libraries/AP_CANManager/AP_CANSensor.cpp
@@ -1,0 +1,127 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  generic CAN sensor class, for easy creation of CAN sensors using prioprietary protocols
+ */
+#include <AP_HAL/AP_HAL.h>
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+
+#include <AP_Scheduler/AP_Scheduler.h>
+#include "AP_CANSensor.h"
+
+extern const AP_HAL::HAL& hal;
+
+#define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, _driver_name, fmt, ##args); } while (0)
+
+CANSensor::CANSensor(const char *driver_name, AP_CANManager::Driver_Type dtype, uint16_t stack_size) :
+    _driver_name(driver_name),
+    _stack_size(stack_size)
+{
+    if (!AP::can().register_driver(dtype, this)) {
+        debug_can(AP_CANManager::LOG_ERROR, "Failed to register CANSensor %s", driver_name);
+    } else {
+        debug_can(AP_CANManager::LOG_INFO, "%s: constructed", driver_name);
+    }
+}
+
+void CANSensor::init(uint8_t driver_index, bool enable_filters)
+{
+    _driver_index = driver_index;
+
+    debug_can(AP_CANManager::LOG_INFO, "starting init");
+
+    if (_initialized) {
+        debug_can(AP_CANManager::LOG_ERROR, "already initialized");
+        return;
+    }
+
+    // get CAN manager instance
+    _can_driver = AP::can().get_driver(driver_index);
+
+    if (_can_driver == nullptr) {
+        debug_can(AP_CANManager::LOG_ERROR, "no CAN driver");
+        return;
+    }
+
+    // start thread for receiving and sending CAN frames
+    if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&CANSensor::loop, void), _driver_name, _stack_size, AP_HAL::Scheduler::PRIORITY_CAN, 0)) {
+        debug_can(AP_CANManager::LOG_ERROR, "couldn't create thread");
+        return;
+    }
+
+    _initialized = true;
+
+    debug_can(AP_CANManager::LOG_INFO, "init done");
+
+    return;
+}
+
+bool CANSensor::add_interface(AP_HAL::CANIface* can_iface)
+{
+    if (_can_iface != nullptr) {
+        debug_can(AP_CANManager::LOG_ERROR, "Multiple Interface not supported");
+        return false;
+    }
+
+    _can_iface = can_iface;
+
+    if (_can_iface == nullptr) {
+        debug_can(AP_CANManager::LOG_ERROR, "CAN driver not found");
+        return false;
+    }
+
+    if (!_can_iface->is_initialized()) {
+        debug_can(AP_CANManager::LOG_ERROR, "Driver not initialized");
+        return false;
+    }
+
+    if (!_can_iface->set_event_handle(&_event_handle)) {
+        debug_can(AP_CANManager::LOG_ERROR, "Cannot add event handle");
+        return false;
+    }
+    return true;
+}
+
+void CANSensor::loop()
+{
+    while (!hal.scheduler->is_system_initialized()) {
+        // don't process packets till startup complete
+        hal.scheduler->delay(1);
+    }
+    const uint32_t LOOP_INTERVAL_US = AP::scheduler().get_loop_period_us();
+    while (true) {
+        uint64_t timeout = AP_HAL::micros64() + LOOP_INTERVAL_US;
+
+        // wait to receive frame
+        bool read_select = true;
+        bool write_select = false;
+        bool ret = _can_iface->select(read_select, write_select, nullptr, timeout);
+        if (ret && read_select) {
+            uint64_t time;
+            AP_HAL::CANIface::CanIOFlags flags {};
+
+            AP_HAL::CANFrame frame;
+            int16_t res = _can_iface->receive(frame, time, flags);
+
+            if (res == 1) {
+                handle_frame(frame);
+            }
+        }
+    }
+}
+
+#endif // HAL_MAX_CAN_PROTOCOL_DRIVERS
+

--- a/libraries/AP_CANManager/AP_CANSensor.h
+++ b/libraries/AP_CANManager/AP_CANSensor.h
@@ -1,0 +1,52 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  CANSensor class, for easy creation of CAN sensors using custom CAN protocols
+ */
+ 
+#pragma once
+
+#include "AP_CANManager.h"
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+
+class CANSensor : public AP_CANDriver {
+public:
+    CANSensor(const char *driver_name, AP_CANManager::Driver_Type dtype, uint16_t stack_size=2048);
+    
+    /* Do not allow copies */
+    CANSensor(const CANSensor &other) = delete;
+    CANSensor &operator=(const CANSensor&) = delete;
+
+    void init(uint8_t driver_index, bool enable_filters) override;
+    bool add_interface(AP_HAL::CANIface* can_iface) override;
+
+    // handler for incoming frames
+    virtual void handle_frame(AP_HAL::CANFrame &frame) = 0;
+
+private:
+    void loop();
+
+    const char *const _driver_name;
+    const uint16_t _stack_size;
+    bool _initialized;
+    uint8_t _driver_index;
+    AP_CANDriver *_can_driver;
+    HAL_EventHandle _event_handle;
+    AP_HAL::CANIface* _can_iface;
+};
+
+#endif // HAL_MAX_CAN_PROTOCOL_DRIVERS
+

--- a/libraries/AP_EFI/AP_EFI.cpp
+++ b/libraries/AP_EFI/AP_EFI.cpp
@@ -18,7 +18,12 @@
 #if EFI_ENABLED
 
 #include "AP_EFI_Serial_MS.h"
+#include "AP_EFI_NWPMU.h"
 #include <AP_Logger/AP_Logger.h>
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+#include <AP_CANManager/AP_CANManager.h>
+#endif
 
 extern const AP_HAL::HAL& hal;
 
@@ -27,7 +32,7 @@ const AP_Param::GroupInfo AP_EFI::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: EFI communication type
     // @Description: What method of communication is used for EFI #1
-    // @Values: 0:None,1:Serial-MS
+    // @Values: 0:None,1:Serial-MS,2:NWPMU
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("_TYPE", 1, AP_EFI, type, 0, AP_PARAM_FLAG_ENABLE),
@@ -68,8 +73,17 @@ void AP_EFI::init(void)
         return;
     }
     // Check for MegaSquirt Serial EFI
-    if (type == EFI_COMMUNICATION_TYPE_SERIAL_MS) {
-        backend = new AP_EFI_Serial_MS(*this);
+    switch (type) {
+        case EFI_COMMUNICATION_TYPE_NONE:
+            break;
+        case EFI_COMMUNICATION_TYPE_SERIAL_MS:
+            backend = new AP_EFI_Serial_MS(*this);
+            break;
+        case EFI_COMMUNICATION_TYPE_NWPMU:
+#if HAL_EFI_NWPWU_ENABLED
+            backend = new AP_EFI_NWPMU(*this);
+#endif
+            break;
     }
 }
 

--- a/libraries/AP_EFI/AP_EFI.h
+++ b/libraries/AP_EFI/AP_EFI.h
@@ -70,7 +70,8 @@ public:
     // Backend driver types
     enum EFI_Communication_Type {
         EFI_COMMUNICATION_TYPE_NONE      = 0,
-        EFI_COMMUNICATION_TYPE_SERIAL_MS = 1
+        EFI_COMMUNICATION_TYPE_SERIAL_MS = 1,
+        EFI_COMMUNICATION_TYPE_NWPMU     = 2,
     };
 
     static AP_EFI *get_singleton(void) {

--- a/libraries/AP_EFI/AP_EFI_NWPMU.cpp
+++ b/libraries/AP_EFI/AP_EFI_NWPMU.cpp
@@ -1,0 +1,127 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/utility/sparse-endian.h>
+#include <AP_Math/AP_Math.h>
+
+#include "AP_EFI_NWPMU.h"
+
+#if HAL_EFI_NWPWU_ENABLED
+
+extern const AP_HAL::HAL& hal;
+
+AP_EFI_NWPMU::AP_EFI_NWPMU(AP_EFI &_frontend) :
+    CANSensor("NWPMU", AP_CANManager::Driver_Type_EFI_NWPMU),
+    AP_EFI_Backend(_frontend)
+{
+}
+
+void AP_EFI_NWPMU::handle_frame(AP_HAL::CANFrame &frame)
+{
+    const uint32_t id =  frame.id & AP_HAL::CANFrame::MaskExtID;
+
+    WITH_SEMAPHORE(sem);
+
+    switch ((NWPMU_ID)id) {
+    case NWPMU_ID::ECU_1: {
+        internal_state.last_updated_ms = AP_HAL::millis();
+        struct ecu_1 *data = (struct ecu_1 *)frame.data;
+        internal_state.engine_speed_rpm = data->rpm;
+        internal_state.throttle_position_percent = data->tps * 0.1f;
+        internal_state.cylinder_status[0].ignition_timing_deg = data->ignition_angle * 0.1f;
+        break;
+    }
+
+    case NWPMU_ID::ECU_2: {
+        internal_state.last_updated_ms = AP_HAL::millis();
+        struct ecu_2 *data = (struct ecu_2 *)frame.data;
+        switch ((NWPMU_PRESSURE_TYPE)data->pressure_type) {
+        case NWPMU_PRESSURE_TYPE::kPa:
+            internal_state.atmospheric_pressure_kpa = data->baro * 0.01f;
+            internal_state.intake_manifold_pressure_kpa = data->baro * 0.01f;
+            break;
+        case NWPMU_PRESSURE_TYPE::psi:
+            internal_state.atmospheric_pressure_kpa = data->baro * 0.0689476f;
+            internal_state.intake_manifold_pressure_kpa = data->baro * 0.0689476f;
+            break;
+        default:
+            break;
+        }
+        internal_state.cylinder_status[0].lambda_coefficient = data->lambda * 0.01f;
+        break;
+    }
+
+    case NWPMU_ID::ECU_4: {
+        internal_state.last_updated_ms = AP_HAL::millis();
+        struct ecu_4 *data = (struct ecu_4 *)frame.data;
+        // remap the analog input for fuel pressure, 0.5 V == 0 PSI, 4.5V == 100 PSI
+        internal_state.fuel_pressure = linear_interpolate(0, 689.476,
+                                                          data->analog_fuel_pres * 0.001,
+                                                          0.5f,4.5f);
+        break;
+    }
+
+    case NWPMU_ID::ECU_5: {
+        internal_state.last_updated_ms = AP_HAL::millis();
+        struct ecu_5 *data = (struct ecu_5 *)frame.data;
+        switch((NWPMU_TEMPERATURE_TYPE)data->temp_type) {
+        case NWPMU_TEMPERATURE_TYPE::C:
+            internal_state.coolant_temperature = data->coolant_temp * 0.1f + C_TO_KELVIN;
+            internal_state.cylinder_status[0].cylinder_head_temperature = data->coolant_temp * 0.1f + C_TO_KELVIN;
+            break;
+        case NWPMU_TEMPERATURE_TYPE::F:
+            internal_state.coolant_temperature = ((data->coolant_temp * 0.1f) - 32 * 5/9) + C_TO_KELVIN;
+            internal_state.cylinder_status[0].cylinder_head_temperature = ((data->coolant_temp * 0.1f) - 32 * 5/9) + C_TO_KELVIN;
+            break;
+        default:
+            break;
+        }
+        break;
+    }
+
+    case NWPMU_ID::ECU_6: {
+        internal_state.last_updated_ms = AP_HAL::millis();
+        struct ecu_6 *data = (struct ecu_6 *)frame.data;
+        if (!_emitted_version && (AP_HAL::millis() > 10000)) { // don't emit a version early in the boot process
+            gcs().send_text(MAV_SEVERITY_INFO, "NWPMU Version: %d.%d.%d",
+                            data->firmware_major,
+                            data->firmware_minor,
+                            data->firmware_build);
+            _emitted_version = true;
+        }
+        break;
+    }
+    case NWPMU_ID::GCU:
+    case NWPMU_ID::ECU_3:
+    case NWPMU_ID::ECU_7:
+    case NWPMU_ID::ECU_8:
+    case NWPMU_ID::ECU_9:
+    case NWPMU_ID::ECU_10:
+    case NWPMU_ID::ECU_11:
+    case NWPMU_ID::ECU_12:
+        break;
+    }
+}
+
+void AP_EFI_NWPMU::update()
+{
+    // copy the data to the front end
+    copy_to_frontend();
+}
+
+#endif // HAL_EFI_NWPWU_ENABLED

--- a/libraries/AP_EFI/AP_EFI_NWPMU.h
+++ b/libraries/AP_EFI/AP_EFI_NWPMU.h
@@ -1,0 +1,115 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * AP_EFI_NWPMU.h
+ *
+ *      Author: Michael Du Breuil
+ */
+ 
+#pragma once
+
+#include "AP_EFI.h"
+#include "AP_EFI_Backend.h"
+#include <AP_CANManager/AP_CANSensor.h>
+
+#ifndef HAL_EFI_NWPWU_ENABLED
+#define HAL_EFI_NWPWU_ENABLED HAL_MAX_CAN_PROTOCOL_DRIVERS && BOARD_FLASH_SIZE > 1024
+#endif
+
+#if HAL_EFI_NWPWU_ENABLED
+
+class AP_EFI_NWPMU : public CANSensor, public AP_EFI_Backend {
+public:
+    AP_EFI_NWPMU(AP_EFI &_frontend);
+    
+    void update() override;
+
+private:
+    void handle_frame(AP_HAL::CANFrame &frame) override;
+
+    bool _emitted_version;
+
+    enum class NWPMU_ID {
+        GCU    = 0x0006C000, // output voltage and current consumption
+        ECU_1  = 0x0CFFF048, // rpm, tps, fuel open, ignition angle
+        ECU_2  = 0x0CFFF148, // baro, MAP, lambda, pressure type
+        ECU_3  = 0x0CFFF248, // analog input 1-4
+        ECU_4  = 0x0CFFF348, // analog input 5-8
+        ECU_5  = 0x0CFFF548, // battery voltage, air temp, coolant temp, temp type
+        ECU_6  = 0x0CFFF648, // analog input 5, 7, version
+        ECU_7  = 0x0CFFF848, // measured lambda 1-2, target lambda
+        ECU_8  = 0x0CFFF948, // PWM ACHT, Blank, Fuel
+        ECU_9  = 0x0CFFFB48, // ignition compensation, cut precent
+        ECU_10 = 0x0CFFFD48, // Fuel comp (accel, starting, air temp, coolant temp)
+        ECU_11 = 0x0CFFFE48, // Fuel comp (baro, MAP)
+        ECU_12 = 0x0CFFD048, // Ignition comp (air temp, cooland temp, MAP)
+    };
+
+    enum class NWPMU_PRESSURE_TYPE {
+        psi = 0,
+        kPa = 1,
+    };
+
+    enum class NWPMU_TEMPERATURE_TYPE {
+        F = 0,
+        C = 1,
+    };
+
+    struct ecu_1 {
+        uint16_t rpm;
+        uint16_t tps;
+        uint16_t fuel_open_time; // 0.01 per bit (ms)
+        uint16_t ignition_angle; // 0.01 per bit (deg)
+    };
+
+    struct ecu_2 {
+        uint16_t baro;   // 0.01 per bit
+        uint16_t map;    // 0.01 per bit
+        uint16_t lambda; // 0.01 per bit
+        uint8_t pressure_type; // bit 1 is set if kPa, otherwise is PSI
+    };
+
+    struct ecu_3 {
+        uint16_t analog_1; // 0.001 per bit (v)
+        uint16_t analog_2; // 0.001 per bit (v)
+        uint16_t analog_afr; // 0.001 per bit (v)
+        uint16_t analog_blank; // 0.001 per bit (v)
+    };
+
+    struct ecu_4 {
+        uint16_t analog_gen_temp;   // 0.001 per bit
+        uint16_t analog_fuel_pres;  // 0.001 per bit
+        uint16_t analog_fuel_level; // 0.001 per bit
+        uint16_t analog_baro_pres;  // 0.001 per bit
+    };
+
+    struct ecu_5 {
+        uint16_t batt_volt; // 0.01 per bit (v)
+        uint16_t air_temp;  // 0.1 per bit
+        uint16_t coolant_temp; // 0.1 per bit
+        uint8_t  temp_type; // 0 F, 1 C
+    };
+
+    struct ecu_6 {
+        uint16_t analog_5; // 0.1 per bit
+        uint16_t analog_7; // 0.1 per bit
+        uint8_t firmware_major;
+        uint8_t firmware_minor;
+        uint8_t firmware_build;
+    };
+};
+
+#endif // HAL_EFI_NWPWU_ENABLED
+

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -47,6 +47,7 @@
 #include "AP_RangeFinder_LeddarVu8.h"
 #include "AP_RangeFinder_SITL.h"
 #include "AP_RangeFinder_MSP.h"
+#include "AP_RangeFinder_USD1_CAN.h"
 
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
@@ -564,7 +565,13 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 #endif // HAL_MSP_RANGEFINDER_ENABLED
         break;
 
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+    case Type::USD1_CAN:
+        _add_backend(new AP_RangeFinder_USD1_CAN(state[instance], params[instance]), instance);
+        break;
+#endif
     case Type::NONE:
+    default:
         break;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -87,6 +87,7 @@ public:
         HC_SR04 = 30,
         GYUS42v2 = 31,
         MSP = 32,
+        USD1_CAN = 33,
         SITL = 100,
     };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -6,7 +6,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,100:SITL
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,100:SITL
     // @User: Standard
     AP_GROUPINFO_FLAGS("TYPE", 1, AP_RangeFinder_Params, type, 0, AP_PARAM_FLAG_ENABLE),
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.cpp
@@ -1,0 +1,39 @@
+#include <AP_HAL/AP_HAL.h>
+#include "AP_RangeFinder_USD1_CAN.h"
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+
+/*
+  constructor
+ */
+AP_RangeFinder_USD1_CAN::AP_RangeFinder_USD1_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
+    CANSensor("USD1", AP_CANManager::Driver_Type_USD1),
+    AP_RangeFinder_Backend(_state, _params)
+{
+}
+
+// update state
+void AP_RangeFinder_USD1_CAN::update(void)
+{
+    WITH_SEMAPHORE(_sem);
+    if ((AP_HAL::millis() - _last_reading_ms) > 500) {
+        // if data is older than 500ms, report NoData
+        set_status(RangeFinder::Status::NoData);
+    } else if (new_data) {
+        state.distance_cm = _distance_cm;
+        state.last_reading_ms = _last_reading_ms;
+        update_status();
+        new_data = false;
+    }
+}
+
+// handler for incoming frames
+void AP_RangeFinder_USD1_CAN::handle_frame(AP_HAL::CANFrame &frame)
+{
+    WITH_SEMAPHORE(_sem);
+    _distance_cm = (frame.data[0]<<8) | frame.data[1];
+    _last_reading_ms = AP_HAL::millis();
+    new_data = true;
+}
+
+#endif // HAL_MAX_CAN_PROTOCOL_DRIVERS

--- a/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "AP_RangeFinder_Backend.h"
+#include <AP_CANManager/AP_CANSensor.h>
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+
+class AP_RangeFinder_USD1_CAN : public CANSensor, public AP_RangeFinder_Backend {
+public:
+    AP_RangeFinder_USD1_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
+
+    void update() override;
+
+    // handler for incoming frames
+    void handle_frame(AP_HAL::CANFrame &frame) override;
+    
+protected:
+    virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_RADAR;
+    }
+private:
+    bool new_data;
+    uint16_t _distance_cm;
+    uint32_t _last_reading_ms;
+};
+#endif //HAL_MAX_CAN_PROTOCOL_DRIVERS
+


### PR DESCRIPTION
This adds a CANSensor class which makes writing drivers for simple CAN protocols very easy.
This also adds two such drivers:
 - an EFI CAN driver, based on a driver originally written by @WickedShell 
 - a CAN driver for the USD1 radar