### PR TITLE
AP_CANManager: fixed use of CANSensor on multiple ports

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -186,8 +186,7 @@ void AP_CANManager::init()
             continue;
         }
 
-        _num_drivers++;
-        if (_num_drivers > HAL_MAX_CAN_PROTOCOL_DRIVERS) {
+        if (_num_drivers >= HAL_MAX_CAN_PROTOCOL_DRIVERS) {
             // We are exceeding number of drivers,
             // this can't be happening time to panic
             AP_BoardConfig::config_error("Max number of CAN Drivers exceeded\n\r");
@@ -246,6 +245,8 @@ void AP_CANManager::init()
         } else {
             continue;
         }
+
+        _num_drivers++;
 
         // Hook this interface to the selected Driver Type
         _drivers[drv_num]->add_interface(iface);


### PR DESCRIPTION
we should not increment _num_drivers if we don't have a driver yet