### PR TITLE
Azure: fix autotest

### DIFF
--- a/.azure/autotest_template.yml
+++ b/.azure/autotest_template.yml
@@ -10,15 +10,17 @@ jobs:
   steps:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
-  - script: choco install gcc-g++ python36 python36-devel python36-future python36-lxml python36-pip python36-pexpect python36-numpy git gettext libcrypt-devel --source cygwin
+  - script: choco install gcc-g++ python36 python36-devel python36-future python36-lxml python36-pip python36-setuptools python36-wheel python36-pexpect python36-numpy git gettext libcrypt-devel --source cygwin
     displayName: 'Install Cygwin packages'
   - script: git submodule update --recursive --init modules/mavlink
     displayName: Initialize MAVLink submodule
   - script: git submodule update --recursive --init modules/uavcan
     displayName: 'Initialize UAVCAN submodule'
-  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%')/modules/mavlink/pymavlink && python3 setup.py build install --user"
+  - script: C:\Cygwin\bin\bash --login -c "ln -sf /usr/bin/python3.6 /usr/bin/python && ln -sf /usr/bin/pip3.6 /usr/bin/pip"
+    displayName: 'Make Python 3.6 the default Python'
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%')/modules/mavlink/pymavlink && python setup.py build install --user"
     displayName: 'Install pymavlink from submodule'
-  - script: C:\Cygwin\bin\bash --login -c "pip3 install MAVProxy"
+  - script: C:\Cygwin\bin\bash --login -c "pip install MAVProxy"
     displayName: 'Install MAVProxy in Cygwin'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && Tools/autotest/autotest.py ${{ format('build.{0} {1}.{2}', parameters.build_target, parameters.action, parameters.action_target) }}"
     displayName: ${{ format('Run {0} autotest', parameters.name) }}

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
   parameters:
     name: 'Copter'
     build_target: 'ArduCopter'
-    action_target: 'ArduCopter'
+    action_target: 'ArduCopterTests1'
 
 - template: autotest_template.yml
   parameters:


### PR DESCRIPTION
python3 is missing thus we need to rely on the python symlink we made

following https://github.com/ArduPilot/ardupilot/pull/16165

Credit to @OXINARF to notice it.