### PR TITLE
AP_Scripting: user defined params 

### DIFF
--- a/libraries/AP_Scripting/examples/param_load.lua
+++ b/libraries/AP_Scripting/examples/param_load.lua
@@ -1,0 +1,23 @@
+params.add(270,0,'SCR_TEST',4,3.14,'SCR_TEST2',4,42)
+
+local count = 0
+
+function update()
+
+  if count == 5 then
+    count = 0
+    param:set('SCR_TEST',param:get('SCR_TEST') + 5)
+  end
+
+  local value = param:get('SCR_TEST')
+  if not value then
+    gcs:send_text(0, 'get SCR_TEST failed')
+  else
+    gcs:send_text(0, string.format('SCR_TEST: %0.1f', value))
+  end
+
+  count = count + 1
+  return update, 5000
+end
+
+return update, 5000

--- a/libraries/AP_Scripting/examples/param_load.lua
+++ b/libraries/AP_Scripting/examples/param_load.lua
@@ -1,4 +1,17 @@
-params.add(270,0,'SCR_TEST',4,3.14,'SCR_TEST2',4,42)
+
+-- available types:
+-- AP_PARAM_FLOAT
+-- AP_PARAM_INT32
+-- AP_PARAM_INT16
+-- AP_PARAM_INT8
+
+-- can also do flags:
+-- AP_PARAM_FLAG_ENABLE
+-- AP_PARAM_FLAG_INTERNAL_USE_ONLY
+
+params.add(270,0,{{'SCR_TEST',AP_PARAM_FLOAT,3.14},
+                  {'SCR_TEST2',AP_PARAM_FLOAT,3.14*2},
+                  {'SCR_TEST2',AP_PARAM_FLOAT,3.14*3}})
 
 local count = 0
 

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -276,7 +276,7 @@ static int add_param(lua_State *L) {
         lua_pushinteger(L, i+1); // lua is 1 indexed
         lua_gettable(L,-2);
         if (lua_type(L, -1) != LUA_TTABLE) {
-            delete info;
+            delete[] info;
             return luaL_error(L, "expected table in param table index %u", i+1);
         }
 
@@ -315,7 +315,7 @@ static int add_param(lua_State *L) {
         lua_pop (L, 1); // this pops the outer table index
 
         if (strlen(name) > 16) {
-            delete info;
+            delete[] info;
             // should also delete the params from inside the table
             return luaL_error(L, "param name %s must be 16 chars or fewer",name);
         }
@@ -335,28 +335,28 @@ static int add_param(lua_State *L) {
                 param = new AP_Float;
                 break;
             default:
-                delete info;
+                delete[] info;
                 // should also delete the params from inside the table
                 return luaL_error(L, "param type error");
         }
 
-        AP_Param::Info tmp_info = {type, name, index, param, {def_value:default_val}, flag};
+        AP_Param::Info tmp_info = {static_cast<uint8_t>(type), name, index, param, {def_value:default_val}, flag};
 
         memcpy(&info[i], &tmp_info, sizeof(tmp_info));
 
         index++;
     }
 
-    // add the end table footer
-    AP_Param::Info tmp_info = {AP_PARAM_NONE, "", index, nullptr, {group_info:nullptr}, 0 };
+    // add the table footer
+    AP_Param::Info tmp_info = {static_cast<uint8_t>(AP_PARAM_NONE), "", index, nullptr, {group_info:nullptr}, 0 };
     memcpy(&info[num_params], &tmp_info, sizeof(tmp_info));
 
     struct AP_Param::var_table *table = new AP_Param::var_table;
     table->var_info = info;
 
     if (!AP_Param::load_param_info(table)) {
-        delete info;
-        delete table;
+        delete[] info;
+        delete[] table;
         // should also delete the params from inside the table
         return luaL_error(L, "Failed to load param var_table");
     }

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -271,6 +271,10 @@ static int add_param(lua_State *L) {
 
     AP_Param::Info *info = (AP_Param::Info *)hal.util->malloc_type(sizeof(AP_Param::Info)*(num_params+1), AP_HAL::Util::Memory_Type::MEM_FAST);
     struct AP_Param::var_table *table = new AP_Param::var_table;
+    if (info == nullptr || table == nullptr) {
+        gcs().send_text(MAV_SEVERITY_ERROR,"Lua: failed to create var tables");
+        goto failed_load;
+    }
 
     for (uint8_t i=0; i<num_params; i++) {
 
@@ -372,6 +376,11 @@ static int add_param(lua_State *L) {
             default:
                 gcs().send_text(MAV_SEVERITY_ERROR,"Lua: unknown param type");
                 goto failed_load;
+        }
+
+        if (param == nullptr) {
+            gcs().send_text(MAV_SEVERITY_ERROR,"Lua: failed to create param");
+            goto failed_load;
         }
 
         new (&info[i]) AP_Param::Info {static_cast<uint8_t>(type), name, index, param, {def_value:default_val}, flag};


### PR DESCRIPTION
This adds the ability to define params in a script and have them show up in the full list. For example:

```
local test_param = AP_Float()
-- param, name, index, default
-- don't delete test_param, param_info or param_table
local param_info, param_table = params.add(test_param, 'SCR_TEST', 270, 3.14)
```

This works in SITL, not yet tested IRL. Totally possible to hit segfaults and such. Known issues:

- [ ] bugs and segfaults
- [x] Currently its only possible to add one param at a time, only 'top level' no groups.
- [ ] No checking for conflicting k_param indexs
- [x] AP_Float only
- [x] No checking of new binding inputs, ie string < 16 chars long
- [ ] No ordering of linked lists by index
- [ ] No method to check for valid value, add hidden '.KEY` param for each added group
- [x] No way do deal with a script crashing and breaking the linked list..... not actually sure how to solve this one
- [x] allow flags, enable, read only ect.