### PR TITLE
PID: log limit flag

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -395,6 +395,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: D: derivative part of PID
 // @Field: FF: controller feed-forward portion of response
 // @Field: Dmod: scaler applied to D gain to reduce limit cycling
+// @Field: Limit: 1 if I term is limited due to output saturation 
     { LOG_PIQR_MSG, sizeof(log_PID),
       "PIQR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
     { LOG_PIQP_MSG, sizeof(log_PID),
@@ -415,6 +416,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: D: derivative part of PID
 // @Field: FF: controller feed-forward portion of response
 // @Field: Dmod: scaler applied to D gain to reduce limit cycling
+// @Field: Limit: 1 if I term is limited due to output saturation 
     { LOG_PIDG_MSG, sizeof(log_PID),
       "PIDG", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS },
 

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -236,6 +236,7 @@ void AC_PID::update_i(bool limit)
         _integrator = 0.0f;
     }
     _pid_info.I = _integrator;
+    _pid_info.limit = limit;
 }
 
 float AC_PID::get_p() const

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -309,6 +309,7 @@ public:
         float D;
         float FF;
         float Dmod;
+        bool  limit;
     };
 
     void Write_PID(uint8_t msg_type, const PID_Info &info);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -785,7 +785,8 @@ void AP_Logger::Write_PID(uint8_t msg_type, const PID_Info &info)
         I               : info.I,
         D               : info.D,
         FF              : info.FF,
-        Dmod            : info.Dmod
+        Dmod            : info.Dmod,
+        limit           : info.limit
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -538,6 +538,7 @@ struct PACKED log_PID {
     float   D;
     float   FF;
     float   Dmod;
+    uint8_t limit;
 };
 
 struct PACKED log_Current {
@@ -1069,10 +1070,10 @@ struct PACKED log_PSC {
 #define ISBD_UNITS  "s--ooo"
 #define ISBD_MULTS  "F--???"
 
-#define PID_LABELS "TimeUS,Tar,Act,Err,P,I,D,FF,Dmod"
-#define PID_FMT    "Qffffffff"
-#define PID_UNITS  "s--------"
-#define PID_MULTS  "F--------"
+#define PID_LABELS "TimeUS,Tar,Act,Err,P,I,D,FF,Dmod,Limit"
+#define PID_FMT    "QffffffffB"
+#define PID_UNITS  "s---------"
+#define PID_MULTS  "F---------"
 
 // @LoggerMessage: ACC
 // @Description: IMU accelerometer data
@@ -1575,6 +1576,7 @@ struct PACKED log_PSC {
 // @Field: D: derivative part of PID
 // @Field: FF: controller feed-forward portion of response
 // @Field: Dmod: scaler applied to D gain to reduce limit cycling
+// @Field: Limit: 1 if I term is limited due to output saturation 
 
 // @LoggerMessage: PM
 // @Description: autopilot system performance and general data dumping ground


### PR DESCRIPTION
This adds logging of the limit flag, this shows if the I term is frozen due to control saturation.

It would be quite nice to move roll pitch and yaw PID logging to the attitude controller. This would keep the PID logs in lock step with the PIDs.