### PR TITLE
More auto completion

### DIFF
--- a/Tools/completion/bash/_ap_autotest
+++ b/Tools/completion/bash/_ap_autotest
@@ -5,42 +5,16 @@ _ap_autotest() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD - 1]}"
+  # don't complet =
+  _init_completion -n = || return
 
-  case "$cur" in
-  -*)
-    # TODO: generate for waf help
-    opts="--help -h"
-    opts+=" -j"
-    opts+=" --skip"
-    opts+=" --list"
-    opts+=" --list-subtests"
-    opts+=" --viewerip"
-    opts+=" --map"
-    opts+=" --experimental"
-    opts+=" --timeout"
-    opts+=" --frame"
-    opts+=" --show-test-timings"
-    opts+=" --validate-parameters"
-    opts+=" --no-configure"
-    opts+=" --waf-configure-args"
-    opts+=" --no-clean"
-    opts+=" --debug"
-    opts+=" --speedup"
-    opts+=" --valgrind"
-    opts+=" --gdb"
-    opts+=" --gdbserver"
-    opts+=" --lldb"
-    opts+=" -B --breakpoint"
-    opts+=" --disable-breakpoints"
-    ;;
-  *)
-    # get the calling program, remove anything after the space == all commands arguments
-    local caller
-    caller=$(echo $@ | sed 's/ .*//g')
-    opts=$($caller --list)
-    ;;
-    # TODO: add completion for subtests and skip list
-  esac
+  # get the calling program, remove anything after the space == all commands arguments
+  local caller
+  caller=$(echo $@ | sed 's/ .*//g')
+  opts=$($caller --list | sed -n -e '/^build/p' -e '/^test/p' -e '/^run/p')
+  tests=$($caller --list-vehicles-test | sed -n '/Copter/p')
+  opts+=$(compgen -W "${tests}" -P "test.")
+
   # Prevent word reuse
   lim=$((COMP_CWORD - 1))
   for i in $(seq 0 $lim); do
@@ -49,7 +23,35 @@ _ap_autotest() {
       opts=${opts//--${COMP_WORDS[i]}/}
     fi
   done
-  COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+
+  case $cur in
+    test.*.*)
+      local supported_vehicle_list
+      supported_vehicle_list=$($caller --list-vehicles | sed -n '/Copter/p')
+      local vehicle
+      # get the part before the last dot
+      lcur=${cur%.*}
+      # search for the right vehicle name in the list
+      # TODO : just extract the caracters between the two dot with bash and use python to extract the right subtests
+      for v in $supported_vehicle_list
+      do
+        if [[ ${lcur} == *"$v"* ]]
+        then
+          vehicle=$v
+          break
+        fi
+      done
+      azr=$($caller --list-subtests-for-vehicle "${vehicle}")
+      # append back the last dot
+      lcur="${lcur}."
+      opts=$(compgen -W "${azr}" -P "${lcur}")
+      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+      ;;
+  esac
+
+  COMPREPLY=( $(compgen -W '$(_parse_help "$1")' -- "$cur") $(compgen -W "${opts}" -- ${cur}) )
+  [[ ${COMPREPLY-} == *. ]] && compopt -o nospace
+  [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 }
 
 complete -F _ap_autotest autotest.py

--- a/Tools/completion/bash/_ap_bin
+++ b/Tools/completion/bash/_ap_bin
@@ -7,37 +7,16 @@ _ap_bin()
     cur="${COMP_WORDS[COMP_CWORD]}"
 
     opts="--help -h"
-	  opts+=" --wipe -w"
+    opts+=" --wipe -w"
     opts+=" --unhide-groups -u"
-    opts+=" --speedup -s SPEEDUP"
+    opts+=" --speedup -s"
     opts+=" --rate -r"
     opts+=" --console -C"
     opts+=" --instance -I"
     opts+=" --synthetic-clock -S"
     opts+=" --home -O"
     opts+=" --model -M"
-    opts+=" --config"
     opts+=" --fg -F"
-    opts+=" --disable-fgview"
-    opts+=" --gimbal"
-    opts+=" --autotest-dir"
-    opts+=" --defaults"
-    opts+=" --uartA"
-    opts+=" --uartB"
-    opts+=" --uartC"
-    opts+=" --uartD"
-    opts+=" --uartE"
-    opts+=" --uartF"
-    opts+=" --uartG"
-    opts+=" --uartH"
-    opts+=" --uartI"
-    opts+=" --rtscts"
-    opts+=" --base-port"
-    opts+=" --rc-in-port"
-    opts+=" --sim-address"
-    opts+=" --sim-port-in"
-    opts+=" --sim-port-out"
-    opts+=" --irlock-port"
     # Prevent word reuse
     lim=$((COMP_CWORD - 1))
     for i in $(seq 0 $lim); do
@@ -46,7 +25,7 @@ _ap_bin()
         opts=${opts//--${COMP_WORDS[i]}/}
       fi
     done
-    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    COMPREPLY=( $(compgen -W '$(_parse_help "$1")' -- "$cur") $(compgen -W "${opts}" -- ${cur}) )
 }
 
 

--- a/Tools/completion/bash/_sim_vehicle
+++ b/Tools/completion/bash/_sim_vehicle
@@ -5,6 +5,8 @@ _sim_vehicle() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD - 1]}"
+  # don't complet =
+  _init_completion -n = || return
 
   # TODO: generate for waf help
   opts="--help -h"
@@ -87,7 +89,8 @@ _sim_vehicle() {
     ;;
   esac
 
-  COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+  COMPREPLY=( $(compgen -W '$(_parse_help "$1")' -- "$cur") $(compgen -W "${opts}" -- ${cur}) )
+  [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 }
 
 complete -F _sim_vehicle sim_vehicle.py

--- a/Tools/completion/bash/_waf
+++ b/Tools/completion/bash/_waf
@@ -6,22 +6,13 @@ _waf()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
+    # don't complet =
+    _init_completion -n = || return
 
     # TODO: generate for waf help
-    opts="--help -h"
-    opts+=" -j --jobs"
-    opts+=" -v --verbose"
-    opts+=" --debug"
-    opts+=" --bootloader"
-    opts+=" --default-parameters"
-    opts+=" --enable-sfml"
-    opts+=" --enable-sfml-audio"
-    opts+=" --sitl-osd"
-    opts+=" --sitl-rgbled"
-    opts+=" --build-dates"
-    opts+=" --sitl-flash-storage"
-    opts+=" --upload"
-    opts+=" --board"
+    opts="-h"
+    opts+=" -j "
+    opts+=" -v "
 
     opts+=" AP_Periph"
     opts+=" copter"
@@ -59,7 +50,18 @@ _waf()
         ;;
     esac
 
-    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    case $cur in
+      --targets=*)
+        cur=${cur#*=}
+        # list target without color, remove Lua embedding, remove empty and space only line, remove objs/*, remove path for lua binding, remove trailing spaces, change line return for space
+        opts=$(./waf list -c no | sed  -e '/^Embedding/d' -e '/^ *$/d' -e '/objs\//d' -e '$d' -e '/^\//d' | tr -d " " | tr '\n' ' ')
+        COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+        return 0
+        ;;
+    esac
+
+    COMPREPLY=( $(compgen -W '$(_parse_help "$1")' -- "$cur") $(compgen -W "${opts}" -- ${cur}) )
+    [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 }
 
 

--- a/Tools/completion/zsh/_waf
+++ b/Tools/completion/zsh/_waf
@@ -31,6 +31,7 @@ _waf() {
           '--sitl-flash-storage[Building SITL with flash storage emulation.]' \
           '--upload[Upload applicable targets to a connected device]' \
           '--board[Board name]:board:_waf_boards' \
+          '--target=[Target name]:target:_waf_targets' \
           '*:: :->args' \
         && ret=0
       ;;
@@ -41,6 +42,13 @@ _waf() {
 _waf_boards() {
   local boards; boards=( $(./waf list_boards | sed -e '$d'))
   _describe -t boards 'board' boards "$@" && ret=0
+}
+
+(( $+functions[_waf_targets] )) ||
+_waf_targets() {
+  # list target without color, remove Lua embedding, remove empty and space only line, remove objs/*, remove path for lua binding, remove trailing spaces, change line return for space
+  local targets; targets=( $(./waf list -c no | sed  -e '/^Embedding/d' -e '/^ *$/d' -e '/objs\//d' -e '$d' -e '/^\//d' | tr -d " " | tr '\n' ' '))
+  _describe -t targets 'target' targets "$@" && ret=0
 }
 
 # TODO generate with regex from waf help


### PR DESCRIPTION
this add completion for :
--targets on waf for bash and zsh
named test for autotest.py on bash
better completion on bash for waf, autotest.py, sim_vehicle.py, binaries

On bash more option are displayed but not always followed by suggestion like directory path. It would come another time.
Completion can be a little long on waf --targets= ... I am looking at improving this.