### PR TITLE
Plane: added fixed wing tilt vectoring for tilt quadplanes

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -509,6 +509,22 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Standard
     AP_GROUPINFO("TAILSIT_DSKLD", 21, QuadPlane, tailsitter.disk_loading, 0),
 
+    // @Param: TILT_FIX_ANGLE
+    // @DisplayName: Fixed wing tiltrotor angle
+    // @Description: This is the angle the motors tilt down when at maximum output for forward flight. Set this to a non-zero value to enable vectoring for roll/pitch in forward flight on tilt-vectored aircraft
+    // @Units: deg
+    // @Range: 0 30
+    // @User: Standard
+    AP_GROUPINFO("TILT_FIX_ANGLE", 22, QuadPlane, tilt.fixed_angle, 0),
+
+    // @Param: TILT_FIX_GAIN
+    // @DisplayName: Fixed wing tiltrotor gain
+    // @Description: This is the gain for use of tilting motors in fixed wing flight for tilt vectored quadplanes
+    // @Range: 0 1
+    // @User: Standard
+    AP_GROUPINFO("TILT_FIX_GAIN", 23, QuadPlane, tilt.fixed_gain, 0),
+
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -485,6 +485,8 @@ private:
         AP_Int8  max_angle_deg;
         AP_Int8  tilt_type;
         AP_Float tilt_yaw_angle;
+        AP_Float fixed_angle;
+        AP_Float fixed_gain;
         float current_tilt;
         float current_throttle;
         bool motors_active:1;
@@ -554,8 +556,9 @@ private:
     void tiltrotor_update(void);
     void tiltrotor_continuous_update(void);
     void tiltrotor_binary_update(void);
-    void tiltrotor_vectored_yaw(void);
+    void tiltrotor_vectoring(void);
     void tiltrotor_bicopter(void);
+    float tilt_throttle_scaling(void);
     void tilt_compensate_angle(float *thrust, uint8_t num_motors, float non_tilted_mul, float tilted_mul);
     void tilt_compensate(float *thrust, uint8_t num_motors);
     bool is_motor_tilting(uint8_t motor) const {

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -108,11 +108,13 @@ void QuadPlane::tailsitter_output(void)
 
             // in forward flight: set motor tilt servos and throttles using FW controller
             if (tailsitter.vectored_forward_gain > 0) {
+                // remove scaling from surface speed scaling and apply throttle scaling
+                const float scaler = plane.control_mode == &plane.mode_manual?1:(tilt_throttle_scaling() / plane.get_speed_scaler());
                 // thrust vectoring in fixed wing flight
                 float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
                 float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
-                tilt_left  = (elevator + aileron) * tailsitter.vectored_forward_gain;
-                tilt_right = (elevator - aileron) * tailsitter.vectored_forward_gain;
+                tilt_left  = (elevator + aileron) * tailsitter.vectored_forward_gain * scaler;
+                tilt_right = (elevator - aileron) * tailsitter.vectored_forward_gain * scaler;
             }
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -616,6 +616,9 @@ void SRV_Channels::adjust_trim(SRV_Channel::Aux_servo_function_t function, float
         }
         float change = c.reversed?-v:v;
         uint16_t new_trim = c.servo_trim;
+        if (c.servo_max <= c.servo_min) {
+            continue;
+        }
         float trim_scaled = float(c.servo_trim - c.servo_min) / (c.servo_max - c.servo_min);
         if (change > 0 && trim_scaled < 0.6f) {
             new_trim++;


### PR DESCRIPTION
This adds Q_TILT_FIX_ANGLE and Q_TILT_FIX_GAIN for control of tilt vectoring in tilt vectored quadplanes. This is based on the feature developed by @kris000 
The tilt is scaled inversely with throttle and also inversely with the fixed wing speed scaler to remove the impact of surface speed scaling from the plane roll/pitch controllers
