### PR TITLE
rc_protocols_mask must be set before bootstrap occurs

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -274,7 +274,9 @@ void AP_RCProtocol::check_added_uart(void)
         added.uart->begin(added.baudrate, 128, 128);
         added.last_baud_change_ms = AP_HAL::millis();
     }
-
+#ifndef IOMCU_FW
+    rc_protocols_mask = rc().enabled_protocols();
+#endif
     process_handshake(added.baudrate);
 
     uint32_t n = added.uart->available();


### PR DESCRIPTION
There is currently a bug in the bootstrap process for SRXL2 which means that bootstrap *always* occurs regardless of the setting of RC_PROTOCOLS. This is because rc_protocols_mask is set lazily in process_byte() rather than earlier (when it shoudl).