### PR TITLE
Correct use of va_list after va_end has been called on it

### DIFF
--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -226,7 +226,9 @@ void panic(const char *errormsg, ...)
 
     hal.scheduler->delay_microseconds(10000);
     while (1) {
+        va_start(ap, errormsg);
         vprintf(errormsg, ap);
+        va_end(ap);
         hal.scheduler->delay(500);
     }
 #else

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2686,6 +2686,15 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
 
             return MAV_RESULT_FAILED;
         }
+        if (is_equal(packet.param4, 95.0f)) {
+            // the following text is unlikely to make it out...
+            send_text(MAV_SEVERITY_WARNING,"calling AP_HAL::panic(...)");
+
+            AP_HAL::panic("panicing");
+
+            // keep calm and carry on
+            return MAV_RESULT_FAILED;
+        }
     }
 
     if (hal.util->get_soft_armed()) {


### PR DESCRIPTION
... also add the option of paniccing the autopilot with a GCS mavlink message, in the same spirit as hardfault-autopilot and lockup-autopilot.
