### PR TITLE
SITL: correct SMBus block reads

### DIFF
--- a/libraries/SITL/SIM_BattMonitor_SMBus.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus.cpp
@@ -3,7 +3,7 @@
 #include <AP_Stats/AP_Stats.h>
 
 SITL::SIM_BattMonitor_SMBus::SIM_BattMonitor_SMBus() :
-    I2CRegisters_16Bit()
+    SMBusDevice()
 {
     add_register("Temperature", SMBusBattDevReg::TEMP, O_RDONLY);
     add_register("Voltage", SMBusBattDevReg::VOLTAGE, O_RDONLY);
@@ -13,7 +13,8 @@ SITL::SIM_BattMonitor_SMBus::SIM_BattMonitor_SMBus() :
     add_register("Cycle_Count", SMBusBattDevReg::CYCLE_COUNT, O_RDONLY);
     add_register("Specification Info", SMBusBattDevReg::SPECIFICATION_INFO, O_RDONLY);
     add_register("Serial", SMBusBattDevReg::SERIAL, O_RDONLY);
-    add_register("Manufacture Name", SMBusBattDevReg::MANUFACTURE_NAME, O_RDONLY);
+    add_block("Manufacture Name", SMBusBattDevReg::MANUFACTURE_NAME, O_RDONLY);
+    add_block("Device Name", SMBusBattDevReg::DEVICE_NAME, O_RDONLY);
     add_register("Manufacture Data", SMBusBattDevReg::MANUFACTURE_DATA, O_RDONLY);
 
     set_register(SMBusBattDevReg::TEMP, (int16_t)((15 + 273.15)*10));
@@ -43,24 +44,14 @@ SITL::SIM_BattMonitor_SMBus::SIM_BattMonitor_SMBus() :
 
      set_register(SMBusBattDevReg::SERIAL, (uint16_t)12345);
 
-     // Set MANUFACTURE_NAME
      const char *manufacturer_name = "ArduPilot";
-     set_register(SMBusBattDevReg::MANUFACTURE_NAME, uint16_t(manufacturer_name[0]<<8|strlen(manufacturer_name)));
-     uint8_t i = 1;  // already sent the first byte out....
-     while (i < strlen(manufacturer_name)) {
-         const uint8_t a = manufacturer_name[i++];
-         uint8_t b = 0;
-         if (i < strlen(manufacturer_name)) {
-             b = manufacturer_name[i];
-         }
-         i++;
-         const uint16_t value = b<<8 | a;
-         add_register("Name", SMBusBattDevReg::MANUFACTURE_NAME + i/2, O_RDONLY);
-         set_register(SMBusBattDevReg::MANUFACTURE_NAME + i/2, value);
-     }
+     set_block(SMBusBattDevReg::MANUFACTURE_NAME, manufacturer_name);
+
+     const char *device_name = "SITLBatMon_V0.99";
+     set_block(SMBusBattDevReg::DEVICE_NAME, device_name);
+
      // TODO: manufacturer data
 }
-
 
 void SITL::SIM_BattMonitor_SMBus::update(const class Aircraft &aircraft)
 {

--- a/libraries/SITL/SIM_BattMonitor_SMBus.h
+++ b/libraries/SITL/SIM_BattMonitor_SMBus.h
@@ -1,10 +1,10 @@
-#include "SIM_I2CDevice.h"
+#include "SIM_SMBusDevice.h"
 
 #pragma once
 
 namespace SITL {
 
-class SMBusBattDevReg : public I2CRegEnum {
+class SMBusBattDevReg : public SMBusRegEnum {
 public:
     static const uint8_t TEMP = 0x08;                 // Temperature
     static const uint8_t VOLTAGE = 0x09;              // Voltage
@@ -15,20 +15,17 @@ public:
     static const uint8_t SPECIFICATION_INFO = 0x1A;   // Specification Info
     static const uint8_t SERIAL = 0x1C;               // Serial Number
     static const uint8_t MANUFACTURE_NAME = 0x20;     // Manufacture Name
+    static const uint8_t DEVICE_NAME = 0x21;          // Device Name
     static const uint8_t MANUFACTURE_DATA = 0x23;     // Manufacture Data
 };
 
-class SIM_BattMonitor_SMBus : public I2CDevice, protected I2CRegisters_16Bit
+class SIM_BattMonitor_SMBus : public SMBusDevice
 {
 public:
 
     SIM_BattMonitor_SMBus();
 
     virtual void update(const class Aircraft &aircraft) override;
-
-    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override {
-        return I2CRegisters_16Bit::rdwr(data);
-    }
 
 private:
 

--- a/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
@@ -16,6 +16,7 @@ void SITL::Rotoye::update(const class Aircraft &aircraft)
     const uint32_t now = AP_HAL::millis();
     if (now - last_temperature_update_ms > 1000) {
         last_temperature_update_ms = now;
-        set_register(SMBusBattRotoyeDevReg::TEMP_EXT, int16_t(be16toh(word[SMBusBattRotoyeDevReg::TEMP]) + 100));  // it's a little warmer inside.... (10 degrees here)
+        int16_t outside_temp = get_reg_value(SMBusBattRotoyeDevReg::TEMP);
+        set_register(SMBusBattRotoyeDevReg::TEMP_EXT, int16_t(outside_temp + 100));  // it's a little warmer inside.... (10 degrees here)
     }
 }

--- a/libraries/SITL/SIM_I2CDevice.h
+++ b/libraries/SITL/SIM_I2CDevice.h
@@ -30,6 +30,10 @@ public:
     void set_register(uint8_t reg, uint16_t value);
     void set_register(uint8_t reg, int16_t value);
 
+    uint16_t get_reg_value(uint8_t reg) {
+        return be16toh(word[reg]);
+    }
+
 protected:
 
     uint16_t word[256];

--- a/libraries/SITL/SIM_SMBusDevice.cpp
+++ b/libraries/SITL/SIM_SMBusDevice.cpp
@@ -1,0 +1,67 @@
+#include "SIM_SMBusDevice.h"
+
+int SITL::SMBusDevice::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
+{
+    // see if this is a block...
+    const uint8_t addr = data->msgs[0].buf[0];
+    if (blockname[addr] == nullptr) {
+        // not a block
+        return I2CRegisters_16Bit::rdwr(data);
+    }
+
+    // it is a block.
+    if (data->nmsgs == 2) {
+        // data read request
+        if (data->msgs[0].flags != 0) {
+            AP_HAL::panic("Unexpected flags");
+        }
+        if (data->msgs[1].flags != I2C_M_RD) {
+            AP_HAL::panic("Unexpected flags");
+        }
+
+        data->msgs[1].buf[0] = value_lengths[addr];
+        const uint8_t to_copy = MIN(data->msgs[1].len-1, value_lengths[addr]);
+        memcpy(&data->msgs[1].buf[1], values[addr], to_copy);
+        data->msgs[1].len = to_copy + 1;
+        return 0;
+    }
+
+    if (data->nmsgs == 1) {
+        // data write request
+        if (data->msgs[0].flags != 0) {
+            AP_HAL::panic("Unexpected flags");
+        }
+        AP_HAL::panic("block writes not implemented");
+    }
+
+    return -1;
+}
+
+void SITL::SMBusDevice::add_block(const char *name, uint8_t reg, int8_t mode)
+{
+    // ::fprintf(stderr, "Adding block %u (0x%02x) (%s)\n", reg, reg, name);
+    blockname[reg] = name;
+    if (mode == O_RDONLY || mode == O_RDWR) {
+        readable_blocks.set((uint8_t)reg);
+    }
+    if (mode == O_WRONLY || mode == O_RDWR) {
+        writable_blocks.set((uint8_t)reg);
+    }
+}
+
+void SITL::SMBusDevice::set_block(uint8_t block, uint8_t *value, uint8_t valuelen)
+{
+    if (blockname[block] == nullptr) {
+        AP_HAL::panic("Setting un-named block %u", block);
+    }
+    // ::fprintf(stderr, "Setting %u (0x%02x) (%s) to 0x%02x (%c)\n", (unsigned)reg, (unsigned)reg, regname[reg], (unsigned)value, value);
+    if (valuelen == 0) {
+        AP_HAL::panic("Zero-length values not permitted by spec");
+    }
+    if (values[block] != nullptr) {
+        free(values[block]);
+    }
+    values[block] = (char*)malloc(valuelen);
+    memcpy(values[block], value, valuelen);
+    value_lengths[block] = valuelen;
+}

--- a/libraries/SITL/SIM_SMBusDevice.h
+++ b/libraries/SITL/SIM_SMBusDevice.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "SIM_I2CDevice.h"
+
+namespace SITL {
+
+class SMBusRegEnum : public I2CRegEnum {
+};
+
+class SMBusDevice : public I2CDevice, private I2CRegisters_16Bit {
+public:
+
+    SMBusDevice() :
+        I2CDevice(),
+        I2CRegisters_16Bit()
+        { }
+
+    void set_register(uint8_t reg, uint16_t value) {
+        I2CRegisters_16Bit::set_register(reg, value);
+    }
+    void set_register(uint8_t reg, int16_t value) {
+        I2CRegisters_16Bit::set_register(reg, value);
+    }
+
+    uint16_t get_reg_value(uint8_t reg) {
+        return I2CRegisters_16Bit::get_reg_value(reg);
+    }
+
+
+protected:
+
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
+
+    void set_block(uint8_t block, uint8_t *value, uint8_t valuelen);
+    void add_block(const char *name, uint8_t reg, int8_t mode);
+
+    void set_block(uint8_t block, const char *value) {
+        set_block(block, (uint8_t*)value, strlen(value));
+    }
+
+
+    void add_register(const char *name, uint8_t reg, int8_t mode) {
+        I2CRegisters_16Bit::add_register(name, reg, mode);
+    }
+
+private:
+
+    const char *blockname[256];
+    Bitmask<256> writable_blocks;
+    Bitmask<256> readable_blocks;
+
+    // 256 pointers-to-malloced-values:
+    char *values[256];
+    uint8_t value_lengths[256];
+};
+
+} // namespace SITL


### PR DESCRIPTION
While testing https://github.com/ArduPilot/ardupilot/pull/16167/commits I discovered that the simulated SMBus device infrastructure wasn't up to scratch.  It's not a linear address model - much more like a function call interface.  At some stage I really should actually read the specs.

I've tested this with some crappy hacks in the existing code - hopefully @hendjoshsr71 's patches will bare this more cleanly and in a way which can be autotested.

```
diff --git a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
index a077052d9d..a8f7461f9e 100644
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -27,6 +27,7 @@ public:
         BATTMONITOR_SMBUS_SPECIFICATION_INFO = 0x1A,   // Specification Info
         BATTMONITOR_SMBUS_SERIAL = 0x1C,               // Serial Number
         BATTMONITOR_SMBUS_MANUFACTURE_NAME = 0x20,     // Manufacture Name
+        BATTMONITOR_SMBUS_PRODUCT_NAME = 0x21,     // Manufacture Name
         BATTMONITOR_SMBUS_MANUFACTURE_DATA = 0x23,     // Manufacture Data
     };
 
diff --git a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp b/libra
ries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
index 169dab3a35..6d2f064b62 100644
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
@@ -5,6 +5,8 @@
 #include "AP_BattMonitor_SMBus_Generic.h"
 #include <utility>
 
+#include <stdio.h>
+
 uint8_t smbus_cell_ids[] = { 0x3f,  // cell 1
                              0x3e,  // cell 2
                              0x3d,  // cell 3
@@ -172,6 +174,18 @@ bool AP_BattMonitor_SMBus_Generic::check_pec_support()
         return true;
     }
 
+    // check manufacturer name
+    uint8_t buff[SMBUS_READ_BLOCK_MAXIMUM_TRANSFER + 1];
+    if (read_block(BATTMONITOR_SMBUS_MANUFACTURE_NAME, buff, true)) {
+        // Hitachi maxell batteries do not support PEC
+        ::fprintf(stderr, "manufacturer: %s\n", buff);
+    }
+
+    // check product name
+    if (read_block(BATTMONITOR_SMBUS_PRODUCT_NAME, buff, true)) {
+        ::fprintf(stderr, "product: %s\n", buff);
+    }
+
     // specification info
     uint16_t data;
     if (!read_word(BATTMONITOR_SMBUS_SPECIFICATION_INFO, data)) {
@@ -189,7 +203,6 @@ bool AP_BattMonitor_SMBus_Generic::check_pec_support()
     }
 
     // check manufacturer name
-    uint8_t buff[SMBUS_READ_BLOCK_MAXIMUM_TRANSFER + 1];
     if (read_block(BATTMONITOR_SMBUS_MANUFACTURE_NAME, buff, true)) {
         // Hitachi maxell batteries do not support PEC
         if (strcmp((char*)buff, "Hitachi maxell") == 0) {
```

![image](https://user-images.githubusercontent.com/7077857/103601888-c1b02a00-4f5e-11eb-87f0-4789b97e7b39.png)
