### PR TITLE
Plane: add label and fix handling of Aux::Airbrake

### DIFF
--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -146,6 +146,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
 {
     switch(ch_option) {
     // the following functions do not need to be initialised:
+    case AUX_FUNC::AIRBRAKE:
     case AUX_FUNC::AUTO:
     case AUX_FUNC::CIRCLE:
     case AUX_FUNC::FLAP:
@@ -241,6 +242,7 @@ bool RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const AuxSwit
         do_aux_function_soaring_3pos(ch_flag);
         break;
 
+    case AUX_FUNC::AIRBRAKE:
     case AUX_FUNC::FLAP:
     case AUX_FUNC::FBWA_TAILDRAGGER:
         break; // input labels, nothing to do

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -574,6 +574,8 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::CAM_MODE_TOGGLE,"CamModeToggle"},
     { AUX_FUNC::GENERATOR,"Generator"},
     { AUX_FUNC::ARSPD_CALIBRATE,"Calibrate Airspeed"},
+    { AUX_FUNC::FLAP,"Flaps"},
+    { AUX_FUNC::AIRBRAKE,"Airbrake"},
 };
 
 /* lookup the announcement for switch change */


### PR DESCRIPTION
Add label and fix handling of Aux::Airbrake. Without this local Plane handler, the RC library handles it and spams the GCS with an error about an invalid Aux_Func assignment.

This also adds a string label to Aux_Func::Flap which was also missing.