### PR TITLE
AP_Logger: remove Prep and NeedPrep functions

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -233,8 +233,6 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
         backends[i]->Init();
     }
 
-    Prep();
-
     start_io_thread();
 
     EnableWrites(true);
@@ -729,10 +727,6 @@ bool AP_Logger::CardInserted(void) {
         }
     }
     return false;
-}
-
-void AP_Logger::Prep() {
-    FOR_EACH_BACKEND(Prep());
 }
 
 void AP_Logger::StopLogging()

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -490,9 +490,6 @@ private:
     bool labels_string_is_good(const char *labels) const;
 #endif
 
-    // possibly expensive calls to start log system:
-    void Prep();
-
     bool _writes_enabled:1;
     bool _force_log_disarmed:1;
 

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -22,8 +22,6 @@ public:
     // erase handling
     virtual void EraseAll() = 0;
 
-    virtual void Prep() = 0;
-
     /* Write a block of data at current offset */
     bool WriteBlock(const void *pBuffer, uint16_t size) {
         return WritePrioritisedBlock(pBuffer, size, false);

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -57,6 +57,12 @@ void AP_Logger_Block::Init(void)
     }
 
     WITH_SEMAPHORE(sem);
+
+    if (NeedErase()) {
+        EraseAll();
+    } else {
+        validate_log_structure();
+    }
 }
 
 uint32_t AP_Logger_Block::bufferspace_available()
@@ -341,22 +347,6 @@ void AP_Logger_Block::periodic_10Hz(const uint32_t now)
     // EraseAll should only set this in the main thread
     if (new_log_pending) {
         start_new_log();
-    }
-}
-
-void AP_Logger_Block::Prep()
-{
-    if (hal.util->get_soft_armed()) {
-        // do not want to do any filesystem operations while we are e.g. flying
-        return;
-    }
-
-    WITH_SEMAPHORE(sem);
-
-    if (NeedErase()) {
-        EraseAll();
-    } else {
-        validate_log_structure();
     }
 }
 

--- a/libraries/AP_Logger/AP_Logger_Block.h
+++ b/libraries/AP_Logger/AP_Logger_Block.h
@@ -17,8 +17,6 @@ public:
     // erase handling
     void EraseAll() override;
 
-    void Prep() override;
-
     // high level interface
     uint16_t find_last_log() override;
     void get_log_boundaries(uint16_t list_entry, uint32_t & start_page, uint32_t & end_page) override;

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -28,9 +28,6 @@ public:
     // erase handling
     void EraseAll() override;
 
-    // possibly time-consuming preparation handling:
-    void Prep() override;
-
     /* Write a block of data at current offset */
     bool _WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical) override;
     uint32_t bufferspace_available() override;
@@ -90,7 +87,6 @@ private:
     int64_t disk_space();
 
     void ensure_log_directory_exists();
-    bool NeedPrep();
 
     bool file_exists(const char *filename) const;
     bool log_exists(const uint16_t lognum) const;

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -50,7 +50,6 @@ public:
     void EraseAll() override {}
 
     void PrepForArming() override {}
-    void Prep() override { }
 
     // high level interface
     uint16_t find_last_log(void) override { return 0; }


### PR DESCRIPTION
These were only being called directly after Init(), so just tacked them
onto the end of those functions.

The checks in NeedPrep turned out to be mostly redundant.

This will clear space for users who have `REQUIRE_ARMING` at 0.

watchdog resets should be unaffected, but perhaps `AP_Logger_Block` should skip checks in that case (new PR for that!).
