### PR TITLE
Battery_Status Message: Add battery charge_state

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -582,6 +582,31 @@ bool AP_BattMonitor::reset_remaining_mask(uint16_t battery_mask, float percentag
     return ret;
 }
 
+// Returns the mavlink charge state. The following mavlink charge states are not used
+// MAV_BATTERY_CHARGE_STATE_EMERGENCY , MAV_BATTERY_CHARGE_STATE_FAILED
+// MAV_BATTERY_CHARGE_STATE_UNHEALTHY, MAV_BATTERY_CHARGE_STATE_CHARGING
+MAV_BATTERY_CHARGE_STATE AP_BattMonitor::get_mavlink_charge_state(const uint8_t instance) const 
+{
+    if (instance >= _num_instances) {
+        return MAV_BATTERY_CHARGE_STATE_UNDEFINED;
+    }
+
+    switch (state[instance].failsafe) {
+
+    case Failsafe::None:
+        return MAV_BATTERY_CHARGE_STATE_OK;
+
+    case Failsafe::Low:
+        return MAV_BATTERY_CHARGE_STATE_LOW;
+
+    case Failsafe::Critical:
+        return MAV_BATTERY_CHARGE_STATE_CRITICAL;
+    }
+
+    // Should not reach this
+    return MAV_BATTERY_CHARGE_STATE_UNDEFINED;
+}
+
 namespace AP {
 
 AP_BattMonitor &battery()

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -211,6 +211,9 @@ public:
     bool reset_remaining_mask(uint16_t battery_mask, float percentage);
     bool reset_remaining(uint8_t instance, float percentage) { return reset_remaining_mask(1U<<instance, percentage);}
 
+    // Returns mavlink charge state
+    MAV_BATTERY_CHARGE_STATE get_mavlink_charge_state(const uint8_t instance) const;
+
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -268,7 +268,7 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
                                     consumed_wh,  // consumed energy in hJ (hecto-Joules)
                                     battery.capacity_remaining_pct(instance),
                                     0, // time remaining, seconds (not provided)
-                                    MAV_BATTERY_CHARGE_STATE_UNDEFINED,
+                                    battery.get_mavlink_charge_state(instance), // battery charge state
                                     cell_volts_ext); // Cell 11..14 voltages
 }
 


### PR DESCRIPTION
This adds the battery_charge state into the Battery_Status mavlink message. 

Fixes part of #15098 for QGS charge_state reporting. Tested in QGC and alerts to low and critical battery states for all instances.

Also not sure what is desired for the following charge states? Could add more parameters but low and critical might cover the need well enough.

MAV_BATTERY_CHARGE_STATE_EMERGENCY , MAV_BATTERY_CHARGE_STATE_FAILED
MAV_BATTERY_CHARGE_STATE_UNHEALTHY, MAV_BATTERY_CHARGE_STATE_CHARGING

![QGC_Battery_Failsafe](https://user-images.githubusercontent.com/69225461/103732943-893c3a80-4fb6-11eb-8053-20e28e9435df.PNG)
