### PR TITLE
AP_Logger: only log Battery Status for active monitors

### DIFF
--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -655,10 +655,13 @@ void AP_Logger::Write_Current_instance(const uint64_t time_us,
 // Write an Current data packet
 void AP_Logger::Write_Current()
 {
+    AP_BattMonitor &battery = AP::battery();
     const uint64_t time_us = AP_HAL::micros64();
     const uint8_t num_instances = AP::battery().num_instances();
     for (uint8_t i = 0; i < num_instances; i++) {
-        Write_Current_instance(time_us, i);
+        if (battery.get_type(i) != AP_BattMonitor::Type::NONE) {
+            Write_Current_instance(time_us, i);
+        }
     }
 }
 


### PR DESCRIPTION
While adding more info. to the mavlink battery status message I saw that we are logging for all batter monitor instances even if they are not active.

Below is a before and after of a dataflash log
![BAT dataflash messages1](https://user-images.githubusercontent.com/69225461/103734685-85aab280-4fba-11eb-94f2-bb67978740e8.PNG)
![BAT dataflash messages2](https://user-images.githubusercontent.com/69225461/103734686-85aab280-4fba-11eb-95aa-dfbd2603f8c5.PNG)
