### PR TITLE
Increase logger stack and priority

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -28,7 +28,7 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 #ifndef HAL_LOGGING_STACK_SIZE
-#define HAL_LOGGING_STACK_SIZE 512
+#define HAL_LOGGING_STACK_SIZE 768
 #endif
 
 #ifndef HAL_LOGGING_MAV_BUFSIZE
@@ -1280,7 +1280,7 @@ void AP_Logger::start_io_thread(void)
         return;
     }
 
-    if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_Logger::io_thread, void), "log_io", HAL_LOGGING_STACK_SIZE, AP_HAL::Scheduler::PRIORITY_IO, 0)) {
+    if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_Logger::io_thread, void), "log_io", HAL_LOGGING_STACK_SIZE, AP_HAL::Scheduler::PRIORITY_IO, 1)) {
         AP_HAL::panic("Failed to start Logger IO thread");
     }
 


### PR DESCRIPTION
The logging thread does not quite have enough stack for the omnibusf4pro.

The logging thread is competing for CPU with the FTP thread such that an FTP transfer can prevent the logging thread getting CPU and cause it to die.