### PR TITLE
AP_Logger: allow each backend to be compiled out

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -297,8 +297,12 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     while (!is_replay && (opt = gopt.getoption()) != -1) {
         switch (opt) {
         case 'w':
+#if HAL_LOGGING_FILESYSTEM_ENABLED
             AP_Param::erase_all();
+#endif
+#if HAL_LOGGING_SITL_ENABLED
             unlink(AP_Logger_SITL::filename);
+#endif
             break;
         case 'u':
             AP_Param::set_hide_disabled_groups(false);

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -45,10 +45,14 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 #ifndef HAL_LOGGING_BACKENDS_DEFAULT
-# ifdef HAL_LOGGING_DATAFLASH
+# if HAL_LOGGING_DATAFLASH_ENABLED
 #  define HAL_LOGGING_BACKENDS_DEFAULT Backend_Type::BLOCK
-# else
+# elif HAL_LOGGING_FILESYSTEM_ENABLED
 #  define HAL_LOGGING_BACKENDS_DEFAULT Backend_Type::FILESYSTEM
+# elif HAL_LOGGING_MAVLINK_ENABLED
+#  define HAL_LOGGING_BACKENDS_DEFAULT Backend_Type::MAVLINK
+# else
+#  define HAL_LOGGING_BACKENDS_DEFAULT 0
 # endif
 #endif
 
@@ -146,7 +150,7 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
     _num_types = num_types;
     _structures = structures;
 
-#if defined(HAL_BOARD_LOG_DIRECTORY) && HAVE_FILESYSTEM_SUPPORT
+#if HAL_LOGGING_FILESYSTEM_ENABLED
     if (_params.backend_types & uint8_t(Backend_Type::FILESYSTEM)) {
         LoggerMessageWriter_DFLogStart *message_writer =
             new LoggerMessageWriter_DFLogStart();
@@ -163,9 +167,9 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
             _next_backend++;
         }
     }
-#endif // HAVE_FILESYSTEM_SUPPORT
+#endif // HAL_LOGGING_FILESYSTEM_ENABLED
 
-#ifdef HAL_LOGGING_DATAFLASH
+#if HAL_LOGGING_DATAFLASH_ENABLED
     if (_params.backend_types & uint8_t(Backend_Type::BLOCK)) {
         if (_next_backend == LOGGER_MAX_BACKENDS) {
             AP_HAL::panic("Too many backends");
@@ -186,7 +190,7 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
     }
 #endif
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if HAL_LOGGING_SITL_ENABLED
     if (_params.backend_types & uint8_t(Backend_Type::BLOCK)) {
         if (_next_backend == LOGGER_MAX_BACKENDS) {
             AP_HAL::panic("Too many backends");
@@ -207,7 +211,7 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
     }
 #endif
     // the "main" logging type needs to come before mavlink so that index 0 is correct
-#if LOGGER_MAVLINK_SUPPORT
+#if HAL_LOGGING_MAVLINK_ENABLED
     if (_params.backend_types & uint8_t(Backend_Type::MAVLINK)) {
         if (_next_backend == LOGGER_MAX_BACKENDS) {
             AP_HAL::panic("Too many backends");

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -3,6 +3,70 @@
 /* ************************************************************ */
 #pragma once
 
+#include <AP_Filesystem/AP_Filesystem_Available.h>
+
+#ifndef HAL_LOGGING_DATAFLASH
+    #define HAL_LOGGING_DATAFLASH 0
+#endif
+
+// set default for HAL_LOGGING_DATAFLASH_ENABLED
+#ifndef HAL_LOGGING_DATAFLASH_ENABLED
+    #if HAL_LOGGING_DATAFLASH
+        #define HAL_LOGGING_DATAFLASH_ENABLED 1
+    #else
+        #define HAL_LOGGING_DATAFLASH_ENABLED 0
+    #endif
+#endif
+
+#ifndef HAL_LOGGING_MAVLINK_ENABLED
+    #define HAL_LOGGING_MAVLINK_ENABLED 1
+#endif
+
+#ifndef HAL_LOGGING_FILESYSTEM_ENABLED
+    #if HAVE_FILESYSTEM_SUPPORT
+        #define HAL_LOGGING_FILESYSTEM_ENABLED 1
+    #else
+        #define HAL_LOGGING_FILESYSTEM_ENABLED 0
+    #endif
+#endif
+
+#ifndef HAL_LOGGING_SITL_ENABLED
+    #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        #define HAL_LOGGING_SITL_ENABLED 1
+    #else
+        #define HAL_LOGGING_SITL_ENABLED 0
+    #endif
+#endif
+
+#if HAL_LOGGING_SITL_ENABLED || HAL_LOGGING_DATAFLASH_ENABLED
+    #define HAL_LOGGING_BLOCK_ENABLED 1
+#else
+    #define HAL_LOGGING_BLOCK_ENABLED 0
+#endif
+
+// sanity checks:
+#if HAL_LOGGING_DATAFLASH && !HAL_LOGGING_DATAFLASH_ENABLED
+#error Can not default to dataflash if it is not enabled
+#endif
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    #if HAL_LOGGING_DATAFLASH_ENABLED
+        #error DATAFLASH not supported on SITL; you probably mean SITL
+    #endif
+#endif
+
+#if HAL_LOGGING_FILESYSTEM_ENABLED
+
+#if !defined (HAL_BOARD_LOG_DIRECTORY)
+#error Need HAL_BOARD_LOG_DIRECTORY for filesystem backend support
+#endif
+
+#if !defined (HAVE_FILESYSTEM_SUPPORT)
+#error Need HAVE_FILESYSTEM_SUPPORT for filesystem backend support
+#endif
+
+#endif
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_AHRS/AP_AHRS_DCM.h>
@@ -23,6 +87,7 @@
 #include <stdint.h>
 
 #include "LoggerMessageWriter.h"
+
 
 class AP_Logger_Backend;
 class AP_AHRS;

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -5,13 +5,9 @@
 
 #include <AP_Filesystem/AP_Filesystem_Available.h>
 
-#ifndef HAL_LOGGING_DATAFLASH
-    #define HAL_LOGGING_DATAFLASH 0
-#endif
-
 // set default for HAL_LOGGING_DATAFLASH_ENABLED
 #ifndef HAL_LOGGING_DATAFLASH_ENABLED
-    #if HAL_LOGGING_DATAFLASH
+    #ifdef HAL_LOGGING_DATAFLASH
         #define HAL_LOGGING_DATAFLASH_ENABLED 1
     #else
         #define HAL_LOGGING_DATAFLASH_ENABLED 0
@@ -45,7 +41,7 @@
 #endif
 
 // sanity checks:
-#if HAL_LOGGING_DATAFLASH && !HAL_LOGGING_DATAFLASH_ENABLED
+#if defined(HAL_LOGGING_DATAFLASH) && !HAL_LOGGING_DATAFLASH_ENABLED
 #error Can not default to dataflash if it is not enabled
 #endif
 

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -4,6 +4,8 @@
 
 #include "AP_Logger_Block.h"
 
+#if HAL_LOGGING_BLOCK_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <stdio.h>
 #include <AP_RTC/AP_RTC.h>
@@ -921,3 +923,4 @@ void AP_Logger_Block::write_log_page()
     df_Write_FilePage++;
 }
 
+#endif // HAL_LOGGING_BLOCK_ENABLED

--- a/libraries/AP_Logger/AP_Logger_Block.h
+++ b/libraries/AP_Logger/AP_Logger_Block.h
@@ -5,6 +5,8 @@
 
 #include "AP_Logger_Backend.h"
 
+#if HAL_LOGGING_BLOCK_ENABLED
+
 #define BLOCK_LOG_VALIDATE 0
 
 class AP_Logger_Block : public AP_Logger_Backend {
@@ -160,3 +162,5 @@ private:
     bool io_thread_alive() const;
     void write_log_page();
 };
+
+#endif  // HAL_LOGGING_BLOCK_ENABLED

--- a/libraries/AP_Logger/AP_Logger_DataFlash.cpp
+++ b/libraries/AP_Logger/AP_Logger_DataFlash.cpp
@@ -5,9 +5,10 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#ifdef HAL_LOGGING_DATAFLASH
-
 #include "AP_Logger_DataFlash.h"
+
+#if HAL_LOGGING_DATAFLASH_ENABLED
+
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
@@ -324,4 +325,4 @@ void AP_Logger_DataFlash::flash_test()
     }
 }
 
-#endif // HAL_LOGGING_DATAFLASH
+#endif // HAL_LOGGING_DATAFLASH_ENABLED

--- a/libraries/AP_Logger/AP_Logger_DataFlash.h
+++ b/libraries/AP_Logger/AP_Logger_DataFlash.h
@@ -5,10 +5,9 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#ifdef HAL_LOGGING_DATAFLASH
-#include "AP_Logger_Backend.h"
 #include "AP_Logger_Block.h"
 
+#if HAL_LOGGING_DATAFLASH_ENABLED
 
 class AP_Logger_DataFlash : public AP_Logger_Block {
 public:
@@ -43,4 +42,4 @@ private:
     bool use_32bit_address;
 };
 
-#endif // HAL_LOGGING_DATAFLASH
+#endif // HAL_LOGGING_DATAFLASH_ENABLED

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -13,8 +13,9 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 
-#if HAVE_FILESYSTEM_SUPPORT
 #include "AP_Logger_File.h"
+
+#if HAL_LOGGING_FILESYSTEM_ENABLED
 
 #include <AP_Common/AP_Common.h>
 #include <AP_InternalError/AP_InternalError.h>
@@ -984,5 +985,5 @@ bool AP_Logger_File::logging_failed() const
     return false;
 }
 
-#endif // HAVE_FILESYSTEM_SUPPORT
+#endif // HAL_LOGGING_FILESYSTEM_ENABLED
 

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -8,10 +8,10 @@
 
 #include <AP_Filesystem/AP_Filesystem.h>
 
-#if HAVE_FILESYSTEM_SUPPORT
-
 #include <AP_HAL/utility/RingBuffer.h>
 #include "AP_Logger_Backend.h"
+
+#if HAL_LOGGING_FILESYSTEM_ENABLED
 
 #ifndef HAL_LOGGER_WRITE_CHUNK_SIZE
 #define HAL_LOGGER_WRITE_CHUNK_SIZE 4096
@@ -129,5 +129,4 @@ private:
     const char *last_io_operation = "";
 };
 
-#endif // HAVE_FILESYSTEM_SUPPORT
-
+#endif // HAL_LOGGING_FILESYSTEM_ENABLED

--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -4,7 +4,7 @@
 
 #include "AP_Logger_MAVLink.h"
 
-#if LOGGER_MAVLINK_SUPPORT
+#if HAL_LOGGING_MAVLINK_ENABLED
 
 #include "LogStructure.h"
 

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -5,13 +5,11 @@
  */
 #pragma once
 
-#define LOGGER_MAVLINK_SUPPORT 1
-
-#if LOGGER_MAVLINK_SUPPORT
-
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_Logger_Backend.h"
+
+#if HAL_LOGGING_MAVLINK_ENABLED
 
 extern const AP_HAL::HAL& hal;
 
@@ -180,4 +178,4 @@ private:
     HAL_Semaphore semaphore;
 };
 
-#endif // LOGGER_MAVLINK_SUPPORT
+#endif // HAL_LOGGING_MAVLINK_ENABLED

--- a/libraries/AP_Logger/AP_Logger_SITL.cpp
+++ b/libraries/AP_Logger/AP_Logger_SITL.cpp
@@ -6,7 +6,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if HAL_LOGGING_SITL_ENABLED
 
 #include <unistd.h>
 #include <stdlib.h>
@@ -105,5 +105,4 @@ bool AP_Logger_SITL::InErase()
     return false;
 }
 
-#endif // HAL_BOARD_SITL
-
+#endif // HAL_LOGGING_SITL_ENABLED

--- a/libraries/AP_Logger/AP_Logger_SITL.h
+++ b/libraries/AP_Logger/AP_Logger_SITL.h
@@ -6,9 +6,9 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-
 #include "AP_Logger_Block.h"
+
+#if HAL_LOGGING_SITL_ENABLED
 
 class AP_Logger_SITL : public AP_Logger_Block {
 public:
@@ -30,4 +30,4 @@ private:
     uint32_t erase_started_ms;
 };
 
-#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#endif // HAL_LOGGING_SITL_ENABLED


### PR DESCRIPTION
I've tested this extensively in SITL, compiling out all backends, in all backends and one-at-a-time.

I've also tested this on KakuteF4 and KakuteF7 - one proves dataflash and the other filesystem.  Both work for dataflash-over-mavlink.
