### PR TITLE
AP_OpticalFlow: fix MAVlink and CXOF drivers, only apply yaw to flowRate

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -186,8 +186,8 @@ void AP_OpticalFlow_CXOF::update(void)
         // copy average body rate to state structure
         state.bodyRate = Vector2f(gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count);
 
+        // we only apply yaw to flowRate as body rate comes from AHRS
         _applyYaw(state.flowRate);
-        _applyYaw(state.bodyRate);
     } else {
         // first frame received in some time so cannot calculate flow values
         state.flowRate.zero();

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
@@ -65,8 +65,8 @@ void AP_OpticalFlow_MAV::update(void)
         // copy average body rate to state structure
         state.bodyRate = { gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count };
 
+        // we only apply yaw to flowRate as body rate comes from AHRS
         _applyYaw(state.flowRate);
-        _applyYaw(state.bodyRate);
     } else {
         // first frame received in some time so cannot calculate flow values
         state.flowRate.zero();


### PR DESCRIPTION
This fixes an issue with MAVLink and CXOF sensors. These drivers apply yaw compensation to both flow and body vectors and do not work correctly unless the sensor is placed in its default position (i.e. FLOW_ORIENT_YAW=0).
The fix is to only apply yaw to flowRate as bodyRate comes from AHRS.

test plan:
- [x] CXOF
- [ ] MAVlink

related PR https://github.com/ArduPilot/ardupilot/pull/16226 for the MSP driver 