### PR TITLE
Privatize Logging for AP_BattMonitor and Quit Logging Unallocated Backends

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -285,24 +285,30 @@ void AP_BattMonitor::convert_params(void) {
     _params[0]._type.save(true);
 }
 
-// read - read the voltage and current for all instances
-void
-AP_BattMonitor::read()
+// read - For all active instances read voltage & current; log BAT, BCL, POWR
+void AP_BattMonitor::read()
 {
+#ifndef HAL_BUILD_AP_PERIPH
+    AP_Logger *logger = AP_Logger::get_singleton();
+    if (logger != nullptr && logger->should_log(_log_battery_bit)) {
+        logger->Write_Power();
+    }
+#endif
+
     for (uint8_t i=0; i<_num_instances; i++) {
         if (drivers[i] != nullptr && get_type(i) != Type::NONE) {
             drivers[i]->read();
             drivers[i]->update_resistance_estimate();
+            
+#ifndef HAL_BUILD_AP_PERIPH
+            if (logger != nullptr && logger->should_log(_log_battery_bit)) {
+                const uint64_t time_us = AP_HAL::micros64();
+                drivers[i]->Log_Write_BAT(i, time_us);
+                drivers[i]->Log_Write_BCL(i, time_us);
+            }
+#endif
         }
     }
-
-#ifndef HAL_BUILD_AP_PERIPH
-    AP_Logger *logger = AP_Logger::get_singleton();
-    if (logger != nullptr && logger->should_log(_log_battery_bit)) {
-        logger->Write_Current();
-        logger->Write_Power();
-    }
-#endif
 
     check_failsafes();
     

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -488,12 +488,13 @@ const AP_BattMonitor::cells & AP_BattMonitor::get_cell_voltages(const uint8_t in
 // returns true if there is a temperature reading
 bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance) const
 {
-    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES) {
+    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES || drivers[instance] == nullptr) {
         return false;
-    } else {
-        temperature = state[instance].temperature;
-        return (AP_HAL::millis() - state[instance].temperature_time) <= AP_BATT_MONITOR_TIMEOUT;
-    }
+    } 
+    
+    temperature = state[instance].temperature;
+
+    return drivers[instance]->has_temperature();
 }
 
 // return true if cycle count can be provided and fills in cycles argument

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -43,6 +43,9 @@ public:
     // returns true if battery monitor provides individual cell voltages
     virtual bool has_cell_voltages() const { return false; }
 
+    // returns true if battery monitor provides temperature
+    virtual bool has_temperature() const { return false; }
+
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     uint8_t capacity_remaining_pct() const;
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -68,6 +68,10 @@ public:
     // reset remaining percentage to given value
     virtual bool reset_remaining(float percentage);
 
+    // logging functions 
+    void Log_Write_BAT(const uint8_t instance, const uint64_t time_us) const;
+    void Log_Write_BCL(const uint8_t instance, const uint64_t time_us) const;
+
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Logging.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Logging.cpp
@@ -1,0 +1,47 @@
+#include "AP_BattMonitor_Backend.h"
+#include <AP_Logger/AP_Logger.h>
+
+extern const AP_HAL::HAL& hal;
+
+// Write BAT data packet(s)
+void AP_BattMonitor_Backend::Log_Write_BAT(const uint8_t instance, const uint64_t time_us) const
+{
+    bool has_curr = has_current();
+
+    const struct log_BAT pkt{
+        LOG_PACKET_HEADER_INIT(LOG_BAT_MSG),
+        time_us             : time_us,
+        instance            : instance,
+        voltage             : _state.voltage,
+        voltage_resting     : _state.voltage_resting_estimate,
+        current_amps        : has_curr ? _state.current_amps : AP::logger().quiet_nanf(),
+        current_total       : has_curr ? _state.consumed_mah : AP::logger().quiet_nanf(),
+        consumed_wh         : has_curr ? _state.consumed_wh : AP::logger().quiet_nanf(),
+        temperature         : (int16_t) ( has_temperature() ? _state.temperature * 100 : 0),
+        resistance          : _state.resistance
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write BCL data packet if has_cell_voltages
+void AP_BattMonitor_Backend::Log_Write_BCL(const uint8_t instance, const uint64_t time_us) const
+{
+    if (!has_cell_voltages()) {
+        return;
+    }
+    
+    struct log_BCL cell_pkt{
+        LOG_PACKET_HEADER_INIT(LOG_BCL_MSG),
+        time_us             : time_us,
+        instance            : instance,
+        voltage             : _state.voltage
+    };
+    for (uint8_t i = 0; i < ARRAY_SIZE(_state.cell_voltages.cells); i++) {
+        cell_pkt.cell_voltages[i] = _state.cell_voltages.cells[i] + 1;
+    }
+    AP::logger().WriteBlock(&cell_pkt, sizeof(cell_pkt));
+
+    // check battery structure can hold all cells  
+    static_assert(ARRAY_SIZE(_state.cell_voltages.cells) == ARRAY_SIZE(cell_pkt.cell_voltages),
+                    "Battery cell number doesn't match in library and log structure");
+}

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -84,10 +84,14 @@ bool AP_BattMonitor_SMBus::read_temp(void)
 {
     uint16_t data;
     if (read_word(BATTMONITOR_SMBUS_TEMP, data)) {
+        _has_temperature = (AP_HAL::millis() - _state.temperature_time) <= AP_BATT_MONITOR_TIMEOUT;
+
         _state.temperature_time = AP_HAL::millis();
         _state.temperature = ((float)(data - 2731)) * 0.1f;
         return true;
     }
+    
+    _has_temperature = false;
 
     return false;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -41,6 +41,8 @@ public:
 
     bool has_cell_voltages() const override { return _has_cell_voltages; }
 
+    bool has_temperature() const override { return _has_temperature; }
+
     // all smart batteries are expected to provide current
     bool has_current() const override { return true; }
 
@@ -95,6 +97,7 @@ protected:
     bool _has_cell_voltages;        // smbus backends flag this as true once they have received a valid cell voltage report
     uint16_t _cycle_count = 0;      // number of cycles the battery has experienced. An amount of discharge approximately equal to the value of DesignCapacity.
     bool _has_cycle_count;          // true if cycle count has been retrieved from the battery
+    bool _has_temperature;
 
     virtual void timer(void) = 0;   // timer function to read from the battery
 

--- a/libraries/AP_BattMonitor/LogStructure.h
+++ b/libraries/AP_BattMonitor/LogStructure.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_BATTMONITOR \
+    LOG_BAT_MSG, \
+    LOG_BCL_MSG
+
+// @LoggerMessage: BAT
+// @Description: Gathered battery data
+// @Field: TimeUS: Time since system startup
+// @Field: Instance: battery instance number
+// @Field: Volt: measured voltage
+// @Field: VoltR: estimated resting voltage
+// @Field: Curr: measured current
+// @Field: CurrTot: current * time
+// @Field: EnrgTot: energy this battery has produced
+// @Field: Temp: measured temperature
+// @Field: Res: estimated battery resistance
+struct PACKED log_BAT {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t  instance;
+    float    voltage;
+    float    voltage_resting;
+    float    current_amps;
+    float    current_total;
+    float    consumed_wh;
+    int16_t  temperature; // degrees C * 100
+    float    resistance;
+};
+
+// @LoggerMessage: BCL
+// @Description: Battery cell voltage information
+// @Field: TimeUS: Time since system startup
+// @Field: Instance: battery instance number
+// @Field: Volt: battery voltage
+// @Field: V1: first cell voltage
+// @Field: V2: second cell voltage
+// @Field: V3: third cell voltage
+// @Field: V4: fourth cell voltage
+// @Field: V5: fifth cell voltage
+// @Field: V6: sixth cell voltage
+// @Field: V7: seventh cell voltage
+// @Field: V8: eighth cell voltage
+// @Field: V9: ninth cell voltage
+// @Field: V10: tenth cell voltage
+// @Field: V11: eleventh cell voltage
+// @Field: V12: twelfth cell voltage
+struct PACKED log_BCL {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t  instance;
+    float    voltage;
+    uint16_t cell_voltages[12];
+};
+
+#define LOG_STRUCTURE_FROM_BATTMONITOR        \
+    { LOG_BAT_MSG, sizeof(log_BAT), \
+        "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "s#vvAiJOw", "F-000!/?0" },  \
+    { LOG_BCL_MSG, sizeof(log_BCL), \
+        "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" },

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -320,7 +320,6 @@ public:
     void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t esc_temp, uint16_t current_tot, int16_t motor_temp, float error_rate = 0.0f);
     void Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct);
     void Write_ESCStatus(uint64_t time_us, uint8_t id, uint32_t error_count, float voltage, float current, float temperature, int32_t rpm, uint8_t power_pct);
-    void Write_Current();
     void Write_Compass();
     void Write_Mode(uint8_t mode, const ModeReason reason);
 
@@ -518,7 +517,6 @@ private:
     void Write_Baro_instance(uint64_t time_us, uint8_t baro_instance);
     void Write_IMU_instance(uint64_t time_us, uint8_t imu_instance);
     void Write_Compass_instance(uint64_t time_us, uint8_t mag_instance);
-    void Write_Current_instance(uint64_t time_us, uint8_t battery_instance);
 
     void backend_starting_new_log(const AP_Logger_Backend *backend);
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -120,6 +120,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_DAL/LogStructure.h>
 #include <AP_NavEKF2/LogStructure.h>
 #include <AP_NavEKF3/LogStructure.h>
+#include <AP_BattMonitor/LogStructure.h>
 
 #include <AP_AHRS/LogStructure.h>
 
@@ -508,19 +509,6 @@ struct PACKED log_PID {
     uint8_t limit;
 };
 
-struct PACKED log_Current {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t  instance;
-    float    voltage;
-    float    voltage_resting;
-    float    current_amps;
-    float    current_total;
-    float    consumed_wh;
-    int16_t  temperature; // degrees C * 100
-    float    resistance;
-};
-
 struct PACKED log_WheelEncoder {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -541,14 +529,6 @@ struct PACKED log_ADSB {
     uint16_t hor_velocity;
     int16_t ver_velocity;
     uint16_t squawk;
-};
-
-struct PACKED log_Current_Cells {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t  instance;
-    float    voltage;
-    uint16_t cell_voltages[12];
 };
 
 struct PACKED log_MAG {
@@ -1064,36 +1044,6 @@ struct PACKED log_PSC {
 // @Field: Offset: raw adjustment of barometer altitude, zeroed on calibration, possibly set by GCS
 // @Field: GndTemp: temperature on ground, specified by parameter or measured while on ground
 // @Field: Health: true if barometer is considered healthy
-
-// @LoggerMessage: BAT
-// @Description: Gathered battery data
-// @Field: TimeUS: Time since system startup
-// @Field: Instance: battery instance number
-// @Field: Volt: measured voltage
-// @Field: VoltR: estimated resting voltage
-// @Field: Curr: measured current
-// @Field: CurrTot: current * time
-// @Field: EnrgTot: energy this battery has produced
-// @Field: Temp: measured temperature
-// @Field: Res: estimated battery resistance
-
-// @LoggerMessage: BCL
-// @Description: Battery cell voltage information
-// @Field: TimeUS: Time since system startup
-// @Field: Instance: battery instance number
-// @Field: Volt: battery voltage
-// @Field: V1: first cell voltage
-// @Field: V2: second cell voltage
-// @Field: V3: third cell voltage
-// @Field: V4: fourth cell voltage
-// @Field: V5: fifth cell voltage
-// @Field: V6: sixth cell voltage
-// @Field: V7: seventh cell voltage
-// @Field: V8: eighth cell voltage
-// @Field: V9: ninth cell voltage
-// @Field: V10: tenth cell voltage
-// @Field: V11: eleventh cell voltage
-// @Field: V12: twelfth cell voltage
 
 // @LoggerMessage: BCN
 // @Description: Beacon informtaion
@@ -1803,10 +1753,7 @@ struct PACKED log_PSC {
     { LOG_TRIGGER_MSG, sizeof(log_Camera), \
       "TRIG", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw", "s--DUmmmddd", "F--GGBBBBBB" }, \
     { LOG_ARSP_MSG, sizeof(log_ARSP), "ARSP",  "QBffcffBBfB", "TimeUS,I,Airspeed,DiffPress,Temp,RawPress,Offset,U,H,Hfp,Pri", "s#nPOPP----", "F-00B00----" }, \
-    { LOG_CURRENT_MSG, sizeof(log_Current),                     \
-      "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "s#vvAiJOw", "F-000!/?0" },  \
-    { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
-      "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" }, \
+    LOG_STRUCTURE_FROM_BATTMONITOR \
     { LOG_MAG_MSG, sizeof(log_MAG), \
       "MAG", "QBhhhhhhhhhBI",    "TimeUS,I,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOX,MOY,MOZ,Health,S", "s#GGGGGGGGG-s", "F-CCCCCCCCC-F" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
@@ -1966,8 +1913,7 @@ enum LogMessages : uint8_t {
     LOG_CSRV_MSG,
     LOG_CESC_MSG,
     LOG_ARSP_MSG,
-    LOG_CURRENT_MSG,
-    LOG_CURRENT_CELLS_MSG,
+    LOG_IDS_FROM_BATTMONITOR,
     LOG_MAG_MSG,
     LOG_MODE_MSG,
     LOG_GPS_RAW_MSG,


### PR DESCRIPTION
This privatizes the AP_BattMonitor logging for BAT, BCL, and POW functions as suggested here (https://github.com/ArduPilot/ardupilot/pull/16240#pullrequestreview-562351664) by @peterbarker. 

Suggestions welcome for making the `#ifndef` blocks prettier?

Also not sure the connection between the POWR message and BattMonitor? But added it into here as suggested.