### PR TITLE
Fix Quadplane duplicate units

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -504,7 +504,7 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Param: TAILSIT_DSKLD
     // @DisplayName: Tailsitter disk loading
     // @Description: This is the vehicle weight in kg divided by the total disk area of all propellers in m^2. Only used with Q_TAILSIT_GSCMSK = 4
-    // @Units: kg/m.m
+    // @Units: kg/m/m
     // @Range: 0 50
     // @User: Standard
     AP_GROUPINFO("TAILSIT_DSKLD", 21, QuadPlane, tailsitter.disk_loading, 0),

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -108,7 +108,6 @@ known_units = {
              'octal'   : 'octal'                 ,
              'RPM'     : 'Revolutions Per Minute',
              'kg/m/m'  : 'kilograms per square meter', # metre is the SI unit name, meter is the american spelling of it
-             'kg/m.m'  : 'kilogram per meter squared'
              }
 
 required_param_fields = [


### PR DESCRIPTION
comming from https://github.com/ArduPilot/ardupilot/pull/15719 the unit kg/m.m (kg per meter squared) is wrongly written and is duplicating kg/m/m