### PR TITLE
Make sure BDMA channels are not adjacent

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -226,7 +226,7 @@ def generate_DMAMUX_map(peripheral_list, noshare_list, dma_exclude):
     # use neighboring channels then we sometimes lose a BDMA completion interrupt. To
     # avoid this we set the BDMA available mask to 0x33, which forces the channels not to be
     # adjacent. This issue was found on a CUAV-X7, with H743 RevV.
-    map2 = generate_DMAMUX_map_mask(dmamux2_peripherals, 0x33, noshare_list, dma_exclude)
+    map2 = generate_DMAMUX_map_mask(dmamux2_peripherals, 0x55, noshare_list, dma_exclude)
     # translate entries from map2 to "DMA controller 3", which is used for BDMA
     for p in map2.keys():
         streams = []


### PR DESCRIPTION
The magic tridge fix. This squashed some spurious SPI errors for me at startup on a Durandal but could just be happenstance.