### PR TITLE
AP_Avoidance: update the description of AVD_F_ALT_MIN

### DIFF
--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -118,7 +118,7 @@ const AP_Param::GroupInfo AP_Avoidance::var_info[] = {
     
     // @Param: F_ALT_MIN
     // @DisplayName: ADS-B avoidance minimum altitude
-    // @Description: Minimum altitude for ADS-B avoidance. If the vehicle is below this altitude, no avoidance action will take place. Useful to prevent ADS-B avoidance from activating while below the tree line or around structures. Default of 0 is no minimum.
+    // @Description: Minimum AMSL (above mean sea level) altitude for ADS-B avoidance. If the vehicle is below this altitude, no avoidance action will take place. Useful to prevent ADS-B avoidance from activating while below the tree line or around structures. Default of 0 is no minimum.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("F_ALT_MIN",    12, AP_Avoidance, _fail_altitude_minimum, 0),


### PR DESCRIPTION
I noticed that get_position is altitude above mean sea level.
I think it should use the relative altitude.

I tested this in SITL.
![image](https://user-images.githubusercontent.com/16643069/104079602-51a7e980-5267-11eb-8861-606fe788433e.png)
AVD_F_ACTION=2 (Climb Or Descend)
AVD_F_ALT_MIN=30 (m)