### PR TITLE
autotest: re-raise KeyboardInterrupt after closing pexpects

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -1040,8 +1040,9 @@ if __name__ == "__main__":
         if not run_tests(steps_to_run):
             sys.exit(1)
     except KeyboardInterrupt:
+        print("KeyboardInterrupt caught; closing pexpect connections")
         util.pexpect_close_all()
-        sys.exit(1)
+        raise
     except Exception:
         # make sure we kill off any children
         util.pexpect_close_all()


### PR DESCRIPTION
this gives a stack trace, which is handy if the tests get caught
indefinitely somewhere