### PR TITLE
Copter: remove more variables if RTL is disabled

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -158,6 +158,13 @@ const AP_Param::Info Copter::var_info[] = {
     // @Increment: 1000
     // @User: Standard
     GSCALAR(rtl_loiter_time,      "RTL_LOIT_TIME",    RTL_LOITER_TIME),
+
+    // @Param: RTL_ALT_TYPE
+    // @DisplayName: RTL mode altitude type
+    // @Description: RTL altitude type.  Set to 1 for Terrain following during RTL and then set WPNAV_RFND_USE=1 to use rangefinder or WPNAV_RFND_USE=0 to use Terrain database
+    // @Values: 0:Relative to Home, 1:Terrain
+    // @User: Standard
+    GSCALAR(rtl_alt_type, "RTL_ALT_TYPE", 0),
 #endif
 
 #if RANGEFINDER_ENABLED == ENABLED
@@ -734,13 +741,6 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(throw_motor_start, "THROW_MOT_START", (float)ModeThrow::PreThrowMotorState::STOPPED),
 #endif
-
-    // @Param: RTL_ALT_TYPE
-    // @DisplayName: RTL mode altitude type
-    // @Description: RTL altitude type.  Set to 1 for Terrain following during RTL and then set WPNAV_RFND_USE=1 to use rangefinder or WPNAV_RFND_USE=0 to use Terrain database
-    // @Values: 0:Relative to Home, 1:Terrain
-    // @User: Standard
-    GSCALAR(rtl_alt_type, "RTL_ALT_TYPE", 0),
 
 #if OSD_ENABLED || OSD_PARAM_ENABLED
     // @Group: OSD

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -392,9 +392,16 @@ public:
     AP_Int16        throttle_behavior;
     AP_Float        pilot_takeoff_alt;
 
+#if MODE_RTL_ENABLED == ENABLED
     AP_Int16        rtl_altitude;
     AP_Int16        rtl_speed_cms;
     AP_Float        rtl_cone_slope;
+    AP_Int16        rtl_alt_final;
+    AP_Int16        rtl_climb_min;              // rtl minimum climb in cm
+    AP_Int32        rtl_loiter_time;
+    AP_Int8         rtl_alt_type;
+#endif
+
 #if RANGEFINDER_ENABLED == ENABLED
     AP_Float        rangefinder_gain;
 #endif
@@ -403,8 +410,6 @@ public:
     AP_Int16        gps_hdop_good;              // GPS Hdop value at or below this value represent a good position
 
     AP_Int8         super_simple;
-    AP_Int16        rtl_alt_final;
-    AP_Int16        rtl_climb_min;              // rtl minimum climb in cm
 
     AP_Int8         wp_yaw_behavior;            // controls how the autopilot controls yaw during missions
 
@@ -415,7 +420,6 @@ public:
 
     // Waypoints
     //
-    AP_Int32        rtl_loiter_time;
     AP_Int16        land_speed;
     AP_Int16        land_speed_high;
     AP_Int16        pilot_speed_up;    // maximum vertical ascending velocity the pilot may request
@@ -456,8 +460,6 @@ public:
 #if MODE_THROW_ENABLED == ENABLED
     AP_Enum<ModeThrow::PreThrowMotorState>         throw_motor_start;
 #endif
-
-    AP_Int8         rtl_alt_type;
 
     AP_Int16                rc_speed; // speed of fast RC Channels in Hz
 

--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -144,6 +144,16 @@ void AP_Avoidance_Copter::set_mode_else_try_RTL_else_LAND(Mode::Number mode)
     }
 }
 
+int16_t AP_Avoidance_Copter::get_altitude_minimum() const
+{
+#if MODE_RTL_ENABLED == ENABLED
+    // do not descend if below RTL alt
+    return copter.g.rtl_altitude;
+#else
+    return 0;
+#endif
+}
+
 // check flight mode is avoid_adsb
 bool AP_Avoidance_Copter::check_flightmode(bool allow_mode_change)
 {
@@ -179,8 +189,8 @@ bool AP_Avoidance_Copter::handle_avoidance_vertical(const AP_Avoidance::Obstacle
         velocity_neu.z = copter.wp_nav->get_default_speed_up();
     } else {
         velocity_neu.z = -copter.wp_nav->get_default_speed_down();
-        // do not descend if below RTL alt
-        if (copter.current_loc.alt < copter.g.rtl_altitude) {
+        // do not descend if below minimum altitude
+        if (copter.current_loc.alt < get_altitude_minimum()) {
             velocity_neu.z = 0.0f;
         }
     }
@@ -238,8 +248,8 @@ bool AP_Avoidance_Copter::handle_avoidance_perpendicular(const AP_Avoidance::Obs
             velocity_neu.z *= copter.wp_nav->get_default_speed_up();
         } else {
             velocity_neu.z *= copter.wp_nav->get_default_speed_down();
-            // do not descend if below RTL alt
-            if (copter.current_loc.alt < copter.g.rtl_altitude) {
+            // do not descend if below minimum altitude
+            if (copter.current_loc.alt < get_altitude_minimum()) {
                 velocity_neu.z = 0.0f;
             }
         }

--- a/ArduCopter/avoidance_adsb.h
+++ b/ArduCopter/avoidance_adsb.h
@@ -19,6 +19,9 @@ private:
     // helper function to set modes and always succeed
     void set_mode_else_try_RTL_else_LAND(Mode::Number mode);
 
+    // get minimum limit altitude allowed on descend
+    int16_t get_altitude_minimum() const;
+
 protected:
     // override avoidance handler
     MAV_COLLISION_ACTION handle_avoidance(const AP_Avoidance::Obstacle *obstacle, MAV_COLLISION_ACTION requested_action) override;


### PR DESCRIPTION
This PR removes RTL_ALT_TYPE parameter and rtl_* variables for RTL_* parameter when RTL is disabled.
I confirmed these with RTL disable option:
 1. no RTL_* parameters exist
 2. This change doesn't change the behavior of ADSB avoidance