### PR TITLE
Tools: Correct checks for realpath and libtool-bin

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -180,13 +180,13 @@ fi
 
 # Check if we need to manually install realpath
 RP=$(apt-cache search -n '^realpath$')
-if [ -n "$RP" ]; then
+if [ -z "$RP" ]; then
     BASE_PKGS+=" realpath"
 fi
 
 # Check if we need to manually install libtool-bin
 LBTBIN=$(apt-cache search -n '^libtool-bin')
-if [ -n "$LBTBIN" ]; then
+if [ -z "$LBTBIN" ]; then
     SITL_PKGS+=" libtool-bin"
 fi
 


### PR DESCRIPTION
Conditional logic was opposite of what it should be. This fixes that so that the script doesn't try to install realpath or libtool when they're already present.

Fixes #16286