### PR TITLE
Privatize Logging for AP_AHRS

### DIFF
--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -10,13 +10,13 @@ void Tracker::Log_Write_Attitude()
     Vector3f targets;
     targets.y = nav_status.pitch * 100.0f;
     targets.z = wrap_360_cd(nav_status.bearing * 100.0f);
-    logger.Write_Attitude(targets);
+    ahrs.Write_Attitude(targets);
     AP::ahrs_navekf().Log_Write();
-    logger.Write_AHRS2();
+    ahrs.Write_AHRS2();
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE();
 #endif
-    logger.Write_POS();
+    ahrs.Write_POS();
 }
 
 struct PACKED log_Vehicle_Baro {

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -69,8 +69,8 @@ void Copter::Log_Write_Attitude()
 {
     Vector3f targets = attitude_control->get_att_target_euler_cd();
     targets.z = wrap_360_cd(targets.z);
-    logger.Write_Attitude(targets);
-    logger.Write_Rate(ahrs_view, *motors, *attitude_control, *pos_control);
+    ahrs.Write_Attitude(targets);
+    ahrs_view->Write_Rate(*motors, *attitude_control, *pos_control);
     if (should_log(MASK_LOG_PID)) {
         logger.Write_PID(LOG_PIDR_MSG, attitude_control->get_rate_roll_pid().get_pid_info());
         logger.Write_PID(LOG_PIDP_MSG, attitude_control->get_rate_pitch_pid().get_pid_info());
@@ -83,11 +83,11 @@ void Copter::Log_Write_Attitude()
 void Copter::Log_Write_EKF_POS()
 {
     AP::ahrs_navekf().Log_Write();
-    logger.Write_AHRS2();
+    ahrs.Write_AHRS2();
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE();
 #endif
-    logger.Write_POS();
+    ahrs.Write_POS();
 }
 
 struct PACKED log_MotBatt {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -206,7 +206,7 @@ void Plane::update_logging1(void)
         logger.Write_IMU();
 
     if (should_log(MASK_LOG_ATTITUDE_MED))
-        logger.Write_AOA_SSA(ahrs);
+        ahrs.Write_AOA_SSA();
 }
 
 /*

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -18,9 +18,9 @@ void Plane::Log_Write_Attitude(void)
         // Get them from the quaternion instead:
         quadplane.attitude_control->get_attitude_target_quat().to_euler(targets.x, targets.y, targets.z);
         targets *= degrees(100.0f);
-        logger.Write_AttitudeView(*quadplane.ahrs_view, targets);
+        quadplane.ahrs_view->Write_AttitudeView(targets);
     } else {
-        logger.Write_Attitude(targets);
+        ahrs.Write_Attitude(targets);
     }
     if (quadplane.in_vtol_mode() || quadplane.in_assisted_flight()) {
         // log quadplane PIDs separately from fixed wing PIDs
@@ -37,12 +37,12 @@ void Plane::Log_Write_Attitude(void)
 
 #if AP_AHRS_NAVEKF_AVAILABLE
     AP::ahrs_navekf().Log_Write();
-    logger.Write_AHRS2();
+    ahrs.Write_AHRS2();
 #endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE();
 #endif
-    logger.Write_POS();
+    ahrs.Write_POS();
 }
 
 // do fast logging for plane
@@ -375,14 +375,6 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: Ast: Q assist active state
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
       "QTUN", "QffffffeccffBB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl,Trn,Ast", "s----mmmnn----", "F----00000-0--" },
-
-// @LoggerMessage: AOA
-// @Description: Angle of attack and Side Slip Angle values
-// @Field: TimeUS: Time since system startup
-// @Field: AOA: Angle of Attack calculated from airspeed, wind vector,velocity vector 
-// @Field: SSA: Side Slip Angle calculated from airspeed, wind vector,velocity vector
-    { LOG_AOA_SSA_MSG, sizeof(log_AOA_SSA),
-      "AOA", "Qff", "TimeUS,AOA,SSA", "sdd", "F00" },
 
 // @LoggerMessage: PIQR,PIQP,PIQY,PIQA
 // @Description: QuadPlane Proportional/Integral/Derivative gain values for Roll/Pitch/Yaw/Z

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2206,7 +2206,7 @@ void QuadPlane::motors_output(bool run_rate_controller)
         const uint32_t now = AP_HAL::millis();
 
         // log RATE at main loop rate
-        plane.logger.Write_Rate(ahrs_view, *motors, *attitude_control, *pos_control);
+        ahrs_view->Write_Rate(*motors, *attitude_control, *pos_control);
 
         // log QTUN at 25 Hz
         if (now - last_qtun_log_ms > 40) {

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -178,7 +178,7 @@ void Sub::ten_hz_logging_loop()
     // log attitude data if we're not already logging at the higher rate
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_ATTITUDE_FAST)) {
         Log_Write_Attitude();
-        logger.Write_Rate(&ahrs_view, motors, attitude_control, pos_control);
+        ahrs_view.Write_Rate(motors, attitude_control, pos_control);
         if (should_log(MASK_LOG_PID)) {
             logger.Write_PID(LOG_PIDR_MSG, attitude_control.get_rate_roll_pid().get_pid_info());
             logger.Write_PID(LOG_PIDP_MSG, attitude_control.get_rate_pitch_pid().get_pid_info());
@@ -212,7 +212,7 @@ void Sub::twentyfive_hz_logging()
 {
     if (should_log(MASK_LOG_ATTITUDE_FAST)) {
         Log_Write_Attitude();
-        logger.Write_Rate(&ahrs_view, motors, attitude_control, pos_control);
+        ahrs_view.Write_Rate(motors, attitude_control, pos_control);
         if (should_log(MASK_LOG_PID)) {
             logger.Write_PID(LOG_PIDR_MSG, attitude_control.get_rate_roll_pid().get_pid_info());
             logger.Write_PID(LOG_PIDP_MSG, attitude_control.get_rate_pitch_pid().get_pid_info());

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -55,14 +55,14 @@ void Sub::Log_Write_Attitude()
 {
     Vector3f targets = attitude_control.get_att_target_euler_cd();
     targets.z = wrap_360_cd(targets.z);
-    logger.Write_Attitude(targets);
+    ahrs.Write_Attitude(targets);
 
     AP::ahrs_navekf().Log_Write();
-    logger.Write_AHRS2();
+    ahrs.Write_AHRS2();
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE();
 #endif
-    logger.Write_POS();
+    ahrs.Write_POS();
 }
 
 struct PACKED log_MotBatt {

--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -10,13 +10,13 @@ void Rover::Log_Write_Attitude()
     float desired_pitch_cd = degrees(g2.attitude_control.get_desired_pitch()) * 100.0f;
     const Vector3f targets(0.0f, desired_pitch_cd, 0.0f);
 
-    logger.Write_Attitude(targets);
+    ahrs.Write_Attitude(targets);
 
 #if AP_AHRS_NAVEKF_AVAILABLE
     AP::ahrs_navekf().Log_Write();
-    logger.Write_AHRS2();
+    ahrs.Write_AHRS2();
 #endif
-    logger.Write_POS();
+    ahrs.Write_POS();
 
     // log steering rate controller
     logger.Write_PID(LOG_PIDS_MSG, g2.attitude_control.get_steering_rate_pid().get_pid_info());

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1707,7 +1707,8 @@ class AutoTest(ABC):
                 if ("#define LOG_BASE_STRUCTURES" in line or
                     "#define LOG_STRUCTURE_FROM_DAL" in line or
                     "#define LOG_STRUCTURE_FROM_NAVEKF2" in line or
-                    "#define LOG_STRUCTURE_FROM_NAVEKF3" in line):
+                    "#define LOG_STRUCTURE_FROM_NAVEKF3" in line or
+                    "#define LOG_STRUCTURE_FROM_AHRS" in line):
 #                    self.progress("Moving inside")
                     state = state_inside
                 continue

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -666,7 +666,7 @@ void AC_AutoTune::control_attitude()
 
         // log this iterations lean angle and rotation rate
         Log_Write_AutoTuneDetails(lean_angle, rotation_rate);
-        AP::logger().Write_Rate(ahrs_view, *motors, *attitude_control, *pos_control);
+        ahrs_view->Write_Rate(*motors, *attitude_control, *pos_control);
         log_pids();
         break;
     }

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -475,12 +475,12 @@ void AP_AHRS::Log_Write_Home_And_Origin()
 #if AP_AHRS_NAVEKF_AVAILABLE
     Location ekf_orig;
     if (get_origin(ekf_orig)) {
-        logger->Write_Origin(LogOriginType::ekf_origin, ekf_orig);
+        Write_Origin(LogOriginType::ekf_origin, ekf_orig);
     }
 #endif
 
     if (home_is_set()) {
-        logger->Write_Origin(LogOriginType::ahrs_home, _home);
+        Write_Origin(LogOriginType::ahrs_home, _home);
     }
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -610,6 +610,13 @@ public:
     // for holding parameters
     static const struct AP_Param::GroupInfo var_info[];
 
+    // Logging to disk functions
+    void Write_AHRS2(void) const;
+    void Write_AOA_SSA(void);  // should be const? but it calls update functions
+    void Write_Attitude(const Vector3f &targets) const;
+    void Write_Origin(uint8_t origin_type, const Location &loc) const; 
+    void Write_POS(void) const;
+
 protected:
     void update_nmea_out();
 

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -1,0 +1,141 @@
+#include "AP_AHRS.h"
+#include <AP_Logger/AP_Logger.h>
+
+#include <AC_AttitudeControl/AC_AttitudeControl.h>
+#include <AC_AttitudeControl/AC_PosControl.h>
+
+
+// Write an AHRS2 packet
+void AP_AHRS::Write_AHRS2() const
+{
+    Vector3f euler;
+    struct Location loc;
+    Quaternion quat;
+    if (!get_secondary_attitude(euler) || !get_secondary_position(loc) || !get_secondary_quaternion(quat)) {
+        return;
+    }
+    const struct log_AHRS pkt{
+        LOG_PACKET_HEADER_INIT(LOG_AHR2_MSG),
+        time_us : AP_HAL::micros64(),
+        roll  : (int16_t)(degrees(euler.x)*100),
+        pitch : (int16_t)(degrees(euler.y)*100),
+        yaw   : (uint16_t)(wrap_360_cd(degrees(euler.z)*100)),
+        alt   : loc.alt*1.0e-2f,
+        lat   : loc.lat,
+        lng   : loc.lng,
+        q1    : quat.q1,
+        q2    : quat.q2,
+        q3    : quat.q3,
+        q4    : quat.q4,
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write AOA and SSA
+void AP_AHRS::Write_AOA_SSA(void)
+{
+    const struct log_AOA_SSA aoa_ssa{
+        LOG_PACKET_HEADER_INIT(LOG_AOA_SSA_MSG),
+        time_us         : AP_HAL::micros64(),
+        AOA             : getAOA(),
+        SSA             : getSSA()
+    };
+
+    AP::logger().WriteBlock(&aoa_ssa, sizeof(aoa_ssa));
+}
+
+// Write an attitude packet
+void AP_AHRS::Write_Attitude(const Vector3f &targets) const
+{
+    const struct log_Attitude pkt{
+        LOG_PACKET_HEADER_INIT(LOG_ATTITUDE_MSG),
+        time_us         : AP_HAL::micros64(),
+        control_roll    : (int16_t)targets.x,
+        roll            : (int16_t)roll_sensor,
+        control_pitch   : (int16_t)targets.y,
+        pitch           : (int16_t)pitch_sensor,
+        control_yaw     : (uint16_t)wrap_360_cd(targets.z),
+        yaw             : (uint16_t)wrap_360_cd(yaw_sensor),
+        error_rp        : (uint16_t)(get_error_rp() * 100),
+        error_yaw       : (uint16_t)(get_error_yaw() * 100),
+        active          : get_active_AHRS_type(),
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+void AP_AHRS::Write_Origin(uint8_t origin_type, const Location &loc) const
+{
+    const struct log_ORGN pkt{
+        LOG_PACKET_HEADER_INIT(LOG_ORGN_MSG),
+        time_us     : AP_HAL::micros64(),
+        origin_type : origin_type,
+        latitude    : loc.lat,
+        longitude   : loc.lng,
+        altitude    : loc.alt
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write a POS packet
+void AP_AHRS::Write_POS() const
+{
+    Location loc;
+    if (!get_position(loc)) {
+        return;
+    }
+    float home, origin;
+    get_relative_position_D_home(home);
+    const struct log_POS pkt{
+        LOG_PACKET_HEADER_INIT(LOG_POS_MSG),
+        time_us        : AP_HAL::micros64(),
+        lat            : loc.lat,
+        lng            : loc.lng,
+        alt            : loc.alt*1.0e-2f,
+        rel_home_alt   : -home,
+        rel_origin_alt : get_relative_position_D_origin(origin) ? -origin : AP::logger().quiet_nanf(),
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write an attitude view packet
+void AP_AHRS_View::Write_AttitudeView(const Vector3f &targets) const
+{
+    const struct log_Attitude pkt{
+        LOG_PACKET_HEADER_INIT(LOG_ATTITUDE_MSG),
+        time_us         : AP_HAL::micros64(),
+        control_roll    : (int16_t)targets.x,
+        roll            : (int16_t)roll_sensor,
+        control_pitch   : (int16_t)targets.y,
+        pitch           : (int16_t)pitch_sensor,
+        control_yaw     : (uint16_t)wrap_360_cd(targets.z),
+        yaw             : (uint16_t)wrap_360_cd(yaw_sensor),
+        error_rp        : (uint16_t)(get_error_rp() * 100),
+        error_yaw       : (uint16_t)(get_error_yaw() * 100)
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write a rate packet
+void AP_AHRS_View::Write_Rate(const AP_Motors &motors, const AC_AttitudeControl &attitude_control,
+                                const AC_PosControl &pos_control) const
+{
+    const Vector3f &rate_targets = attitude_control.rate_bf_targets();
+    const Vector3f &accel_target = pos_control.get_accel_target();
+    const struct log_Rate pkt_rate{
+        LOG_PACKET_HEADER_INIT(LOG_RATE_MSG),
+        time_us         : AP_HAL::micros64(),
+        control_roll    : degrees(rate_targets.x),
+        roll            : degrees(get_gyro().x),
+        roll_out        : motors.get_roll(),
+        control_pitch   : degrees(rate_targets.y),
+        pitch           : degrees(get_gyro().y),
+        pitch_out       : motors.get_pitch(),
+        control_yaw     : degrees(rate_targets.z),
+        yaw             : degrees(get_gyro().z),
+        yaw_out         : motors.get_yaw(),
+        control_accel   : (float)accel_target.z,
+        accel           : (float)(-(get_accel_ef_blended().z + GRAVITY_MSS) * 100.0f),
+        accel_out       : motors.get_throttle()
+    };
+    AP::logger().WriteBlock(&pkt_rate, sizeof(pkt_rate));
+}

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -21,6 +21,11 @@
  */
 
 #include "AP_AHRS.h"
+#include <AP_Motors/AP_Motors.h>
+
+// fwd declarations to avoid include errors
+class AC_AttitudeControl;
+class AC_PosControl;
 
 class AP_AHRS_View
 {
@@ -171,6 +176,11 @@ public:
     float get_error_yaw(void) const {
         return ahrs.get_error_yaw();
     }
+
+    // Logging Functions
+    void Write_AttitudeView(const Vector3f &targets) const;    
+    void Write_Rate( const AP_Motors &motors, const AC_AttitudeControl &attitude_control,
+                        const AC_PosControl &pos_control) const;
 
     float roll;
     float pitch;

--- a/libraries/AP_AHRS/LogStructure.h
+++ b/libraries/AP_AHRS/LogStructure.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_AHRS \
+    LOG_AHR2_MSG, \
+    LOG_AOA_SSA_MSG, \
+    LOG_ATTITUDE_MSG, \
+    LOG_ORGN_MSG, \
+    LOG_POS_MSG, \
+    LOG_RATE_MSG
+
+// @LoggerMessage: AHR2
+// @Description: Backup AHRS data
+// @Field: TimeUS: Time since system startup
+// @Field: Roll: Estimated roll
+// @Field: Pitch: Estimated pitch
+// @Field: Yaw: Estimated yaw
+// @Field: Alt: Estimated altitude
+// @Field: Lat: Estimated latitude
+// @Field: Lng: Estimated longitude
+// @Field: Q1: Estimated attitude quaternion component 1
+// @Field: Q2: Estimated attitude quaternion component 2
+// @Field: Q3: Estimated attitude quaternion component 3
+// @Field: Q4: Estimated attitude quaternion component 4
+struct PACKED log_AHRS {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    int16_t roll;
+    int16_t pitch;
+    uint16_t yaw;
+    float alt;
+    int32_t lat;
+    int32_t lng;
+    float q1, q2, q3, q4;
+};
+
+// @LoggerMessage: AOA
+// @Description: Angle of attack and Side Slip Angle values
+// @Field: TimeUS: Time since system startup
+// @Field: AOA: Angle of Attack calculated from airspeed, wind vector,velocity vector 
+// @Field: SSA: Side Slip Angle calculated from airspeed, wind vector,velocity vector
+struct PACKED log_AOA_SSA {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float AOA;
+    float SSA;
+};
+
+// @LoggerMessage: ATT
+// @Description: Canonical vehicle attitude
+// @Field: TimeUS: Time since system startup
+// @Field: DesRoll: vehicle desired roll
+// @Field: Roll: achieved vehicle roll
+// @Field: DesPitch: vehicle desired pitch
+// @Field: Pitch: achieved vehicle pitch
+// @Field: DesYaw: vehicle desired yaw
+// @Field: Yaw: achieved vehicle yaw
+// @Field: ErrRP: lowest estimated gyro drift error
+// @Field: ErrYaw: difference between measured yaw and DCM yaw estimate
+// @Field: AEKF: active EKF type
+struct PACKED log_Attitude {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    int16_t  control_roll;
+    int16_t  roll;
+    int16_t  control_pitch;
+    int16_t  pitch;
+    uint16_t control_yaw;
+    uint16_t yaw;
+    uint16_t error_rp;
+    uint16_t error_yaw;
+    uint8_t  active;
+};
+
+// @LoggerMessage: ORGN
+// @Description: Vehicle navigation origin or other notable position
+// @Field: TimeUS: Time since system startup
+// @Field: Type: Position type
+// @Field: Lat: Position latitude
+// @Field: Lng: Position longitude
+// @Field: Alt: Position altitude
+struct PACKED log_ORGN {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t origin_type;
+    int32_t latitude;
+    int32_t longitude;
+    int32_t altitude;
+};
+
+// @LoggerMessage: POS
+// @Description: Canonical vehicle position
+// @Field: TimeUS: Time since system startup
+// @Field: Lat: Canonical vehicle latitude
+// @Field: Lng: Canonical vehicle longitude
+// @Field: Alt: Canonical vehicle altitude
+// @Field: RelHomeAlt: Canonical vehicle altitude relative to home
+// @Field: RelOriginAlt: Canonical vehicle altitude relative to navigation origin
+struct PACKED log_POS {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    int32_t lat;
+    int32_t lng;
+    float alt;
+    float rel_home_alt;
+    float rel_origin_alt;
+};
+
+// @LoggerMessage: RATE
+// @Description: Desired and achieved vehicle attitude rates
+// @Field: TimeUS: Time since system startup
+// @Field: RDes: vehicle desired roll rate
+// @Field: R: achieved vehicle roll rate
+// @Field: ROut: normalized output for Roll
+// @Field: PDes: vehicle desired pitch rate
+// @Field: P: vehicle pitch rate
+// @Field: POut: normalized output for Pitch
+// @Field: YDes: vehicle desired yaw rate
+// @Field: Y: achieved vehicle yaw rate
+// @Field: YOut: normalized output for Yaw
+// @Field: YDes: vehicle desired yaw rate
+// @Field: Y: achieved vehicle yaw rate
+// @Field: ADes: desired vehicle vertical acceleration
+// @Field: A: achieved vehicle vertical acceleration
+// @Field: AOut: percentage of vertical thrust output current being used
+struct PACKED log_Rate {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float   control_roll;
+    float   roll;
+    float   roll_out;
+    float   control_pitch;
+    float   pitch;
+    float   pitch_out;
+    float   control_yaw;
+    float   yaw;
+    float   yaw_out;
+    float   control_accel;
+    float   accel;
+    float   accel_out;
+};
+
+
+#define LOG_STRUCTURE_FROM_AHRS \
+    { LOG_AHR2_MSG, sizeof(log_AHRS), \
+        "AHR2","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4","sddhmDU????", "FBBB0GG????" }, \
+    { LOG_AOA_SSA_MSG, sizeof(log_AOA_SSA), \
+        "AOA", "Qff", "TimeUS,AOA,SSA", "sdd", "F00" }, \
+    { LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
+        "ATT", "QccccCCCCB", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw,AEKF", "sddddhhdh-", "FBBBBBBBB-" }, \
+    { LOG_ORGN_MSG, sizeof(log_ORGN), \
+        "ORGN","QBLLe","TimeUS,Type,Lat,Lng,Alt", "s-DUm", "F-GGB" }, \
+    { LOG_POS_MSG, sizeof(log_POS), \
+        "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" }, \
+    { LOG_RATE_MSG, sizeof(log_Rate), \
+        "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" },

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -311,8 +311,6 @@ public:
     void Write_Rally();
     void Write_Baro();
     void Write_Power(void);
-    void Write_AHRS2();
-    void Write_POS();
     void Write_Radio(const mavlink_radio_t &packet);
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);
@@ -322,8 +320,6 @@ public:
     void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t esc_temp, uint16_t current_tot, int16_t motor_temp, float error_rate = 0.0f);
     void Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct);
     void Write_ESCStatus(uint64_t time_us, uint8_t id, uint32_t error_count, float voltage, float current, float temperature, int32_t rpm, uint8_t power_pct);
-    void Write_Attitude(const Vector3f &targets);
-    void Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);
     void Write_Current();
     void Write_Compass();
     void Write_Mode(uint8_t mode, const ModeReason reason);
@@ -332,19 +328,13 @@ public:
     void Write_Command(const mavlink_command_int_t &packet, MAV_RESULT result, bool was_command_long=false);
     void Write_Mission_Cmd(const AP_Mission &mission,
                                const AP_Mission::Mission_Command &cmd);
-    void Write_Origin(uint8_t origin_type, const Location &loc);
     void Write_RPM(const AP_RPM &rpm_sensor);
-    void Write_Rate(const AP_AHRS_View *ahrs,
-                        const AP_Motors &motors,
-                        const AC_AttitudeControl &attitude_control,
-                        const AC_PosControl &pos_control);
     void Write_RallyPoint(uint8_t total,
                           uint8_t sequence,
                           const RallyLocation &rally_point);
     void Write_VisualOdom(float time_delta, const Vector3f &angle_delta, const Vector3f &position_delta, float confidence);
     void Write_VisualPosition(uint64_t remote_time_us, uint32_t time_ms, float x, float y, float z, float roll, float pitch, float yaw, float pos_err, float ang_err, uint8_t reset_counter, bool ignored);
     void Write_VisualVelocity(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, float vel_err, uint8_t reset_counter, bool ignored);
-    void Write_AOA_SSA(AP_AHRS &ahrs);
     void Write_Beacon(AP_Beacon &beacon);
     void Write_Proximity(AP_Proximity &proximity);
     void Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& point);

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -121,6 +121,8 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_NavEKF2/LogStructure.h>
 #include <AP_NavEKF3/LogStructure.h>
 
+#include <AP_AHRS/LogStructure.h>
+
 // structure used to define logging format
 struct LogStructure {
     uint8_t msg_type;
@@ -374,28 +376,6 @@ struct PACKED log_Optflow {
     float body_y;
 };
 
-struct PACKED log_AHRS {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    int16_t roll;
-    int16_t pitch;
-    uint16_t yaw;
-    float alt;
-    int32_t lat;
-    int32_t lng;
-    float q1, q2, q3, q4;
-};
-
-struct PACKED log_POS {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    int32_t lat;
-    int32_t lng;
-    float alt;
-    float rel_home_alt;
-    float rel_origin_alt;
-};
-
 struct PACKED log_POWR {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -512,20 +492,6 @@ struct PACKED log_Camera {
     int16_t  roll;
     int16_t  pitch;
     uint16_t yaw;
-};
-
-struct PACKED log_Attitude {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    int16_t  control_roll;
-    int16_t  roll;
-    int16_t  control_pitch;
-    int16_t  pitch;
-    uint16_t control_yaw;
-    uint16_t yaw;
-    uint16_t error_rp;
-    uint16_t error_yaw;
-    uint8_t  active;
 };
 
 struct PACKED log_PID {
@@ -791,37 +757,11 @@ struct PACKED log_MAV_Stats {
     // uint8_t state_retry_max;
 };
 
-struct PACKED log_ORGN {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t origin_type;
-    int32_t latitude;
-    int32_t longitude;
-    int32_t altitude;
-};
-
 struct PACKED log_RPM {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     float rpm1;
     float rpm2;
-};
-
-struct PACKED log_Rate {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    float   control_roll;
-    float   roll;
-    float   roll_out;
-    float   control_pitch;
-    float   pitch;
-    float   pitch_out;
-    float   control_yaw;
-    float   yaw;
-    float   yaw_out;
-    float   control_accel;
-    float   accel;
-    float   accel_out;
 };
 
 struct PACKED log_SbpLLH {
@@ -885,13 +825,6 @@ struct PACKED log_Rally {
     int32_t latitude;
     int32_t longitude;
     int16_t altitude;
-};
-
-struct PACKED log_AOA_SSA {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    float AOA;
-    float SSA;
 };
 
 struct PACKED log_Beacon {
@@ -1097,20 +1030,6 @@ struct PACKED log_PSC {
 // @Field: Ver_vel: Vehicle vertical velocity
 // @Field: Squark: Transponder squawk code
 
-// @LoggerMessage: AHR2
-// @Description: Backup AHRS data
-// @Field: TimeUS: Time since system startup
-// @Field: Roll: Estimated roll
-// @Field: Pitch: Estimated pitch
-// @Field: Yaw: Estimated yaw
-// @Field: Alt: Estimated altitude
-// @Field: Lat: Estimated latitude
-// @Field: Lng: Estimated longitude
-// @Field: Q1: Estimated attitude quaternion component 1
-// @Field: Q2: Estimated attitude quaternion component 2
-// @Field: Q3: Estimated attitude quaternion component 3
-// @Field: Q4: Estimated attitude quaternion component 4
-
 // @LoggerMessage: ARM
 // @Description: Arming status changes
 // @Field: TimeUS: Time since system startup
@@ -1132,19 +1051,6 @@ struct PACKED log_PSC {
 // @Field: H: True if sensor is healthy
 // @Field: Hfp: Probability sensor has failed
 // @Field: Pri: True if sensor is the primary sensor
-
-// @LoggerMessage: ATT
-// @Description: Canonical vehicle attitude
-// @Field: TimeUS: Time since system startup
-// @Field: DesRoll: vehicle desired roll
-// @Field: Roll: achieved vehicle roll
-// @Field: DesPitch: vehicle desired pitch
-// @Field: Pitch: achieved vehicle pitch
-// @Field: DesYaw: vehicle desired yaw
-// @Field: Yaw: achieved vehicle yaw
-// @Field: ErrRP: lowest estimated gyro drift error
-// @Field: ErrYaw: difference between measured yaw and DCM yaw estimate
-// @Field: AEKF: active EKF type
 
 // @LoggerMessage: BARO
 // @Description: Gathered Barometer data
@@ -1553,14 +1459,6 @@ struct PACKED log_PSC {
 // @Field: bodyX: derived velocity, X-axis
 // @Field: bodyY: derived velocity, Y-axis
 
-// @LoggerMessage: ORGN
-// @Description: Vehicle navigation origin or other notable position
-// @Field: TimeUS: Time since system startup
-// @Field: Type: Position type
-// @Field: Lat: Position latitude
-// @Field: Lng: Position longitude
-// @Field: Alt: Position altitude
-
 // @LoggerMessage: PARM
 // @Description: parameter value
 // @Field: TimeUS: Time since system startup
@@ -1595,15 +1493,6 @@ struct PACKED log_PSC {
 // @Field: I2CC: Number of i2c transactions processed
 // @Field: I2CI: Number of i2c interrupts serviced
 // @Field: Ex: number of microseconds being added to each loop to address scheduler overruns
-
-// @LoggerMessage: POS
-// @Description: Canonical vehicle position
-// @Field: TimeUS: Time since system startup
-// @Field: Lat: Canonical vehicle latitude
-// @Field: Lng: Canonical vehicle longitude
-// @Field: Alt: Canonical vehicle altitude
-// @Field: RelHomeAlt: Canonical vehicle altitude relative to home
-// @Field: RelOriginAlt: Canonical vehicle altitude relative to navigation origin
 
 // @LoggerMessage: POWR
 // @Description: System power information
@@ -1649,24 +1538,6 @@ struct PACKED log_PSC {
 // @Field: Lat: latitude of rally point
 // @Field: Lng: longitude of rally point
 // @Field: Alt: altitude of rally point
-
-// @LoggerMessage: RATE
-// @Description: Desired and achieved vehicle attitude rates
-// @Field: TimeUS: Time since system startup
-// @Field: RDes: vehicle desired roll rate
-// @Field: R: achieved vehicle roll rate
-// @Field: ROut: normalized output for Roll
-// @Field: PDes: vehicle desired pitch rate
-// @Field: P: vehicle pitch rate
-// @Field: POut: normalized output for Pitch
-// @Field: YDes: vehicle desired yaw rate
-// @Field: Y: achieved vehicle yaw rate
-// @Field: YOut: normalized output for Yaw
-// @Field: YDes: vehicle desired yaw rate
-// @Field: Y: achieved vehicle yaw rate
-// @Field: ADes: desired vehicle vertical acceleration
-// @Field: A: achieved vehicle vertical acceleration
-// @Field: AOut: percentage of vertical thrust output current being used
 
 // @LoggerMessage: RCIN
 // @Description: RC input channels to vehicle
@@ -1936,8 +1807,6 @@ struct PACKED log_PSC {
       "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "s#vvAiJOw", "F-000!/?0" },  \
     { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
       "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" }, \
-	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
-      "ATT", "QccccCCCCB", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw,AEKF", "sddddhhdh-", "FBBBBBBBB-" }, \
     { LOG_MAG_MSG, sizeof(log_MAG), \
       "MAG", "QBhhhhhhhhhBI",    "TimeUS,I,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOX,MOY,MOZ,Health,S", "s#GGGGGGGGG-s", "F-CCCCCCCCC-F" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
@@ -1960,10 +1829,6 @@ struct PACKED log_PSC {
       "OADJ","QBBBBLLLL","TimeUS,State,Err,CurrPoint,TotPoints,DLat,DLng,OALat,OALng", "sbbbbDUDU", "F----GGGG" }, \
     { LOG_SIMPLE_AVOID_MSG, sizeof(log_SimpleAvoid), \
       "SA",  "QBffffB","TimeUS,State,DVelX,DVelY,MVelX,MVelY,Back", "sbnnnnb", "F------"}, \
-    { LOG_AHR2_MSG, sizeof(log_AHRS), \
-      "AHR2","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4","sddhmDU????", "FBBB0GG????" }, \
-    { LOG_POS_MSG, sizeof(log_POS), \
-      "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" }, \
     { LOG_SIMSTATE_MSG, sizeof(log_AHRS), \
       "SIM","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4", "sddhmDU????", "FBBB0GG????" }, \
     { LOG_TERRAIN_MSG, sizeof(log_TERRAIN), \
@@ -2006,17 +1871,14 @@ struct PACKED log_PSC {
       "ISBH",ISBH_FMT,ISBH_LABELS,ISBH_UNITS,ISBH_MULTS },  \
     { LOG_ISBD_MSG, sizeof(log_ISBD), \
       "ISBD",ISBD_FMT,ISBD_LABELS, ISBD_UNITS, ISBD_MULTS }, \
-    { LOG_ORGN_MSG, sizeof(log_ORGN), \
-      "ORGN","QBLLe","TimeUS,Type,Lat,Lng,Alt", "s-DUm", "F-GGB" },   \
 LOG_STRUCTURE_FROM_DAL \
 LOG_STRUCTURE_FROM_NAVEKF2 \
 LOG_STRUCTURE_FROM_NAVEKF3 \
+LOG_STRUCTURE_FROM_AHRS \
     { LOG_DF_FILE_STATS, sizeof(log_DSF), \
       "DSF", "QIHIIII", "TimeUS,Dp,Blk,Bytes,FMn,FMx,FAv", "s--b---", "F--0---" }, \
     { LOG_RPM_MSG, sizeof(log_RPM), \
       "RPM",  "Qff", "TimeUS,rpm1,rpm2", "sqq", "F00" }, \
-    { LOG_RATE_MSG, sizeof(log_Rate), \
-      "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" }, \
     { LOG_RALLY_MSG, sizeof(log_Rally), \
       "RALY", "QBBLLh", "TimeUS,Tot,Seq,Lat,Lng,Alt", "s--DUm", "F--GGB" },  \
     { LOG_MAV_MSG, sizeof(log_MAV),   \
@@ -2090,7 +1952,7 @@ enum LogMessages : uint8_t {
     LOG_RSSI_MSG,
     LOG_BARO_MSG,
     LOG_POWR_MSG,
-    LOG_AHR2_MSG,
+    LOG_IDS_FROM_AHRS,
     LOG_SIMSTATE_MSG,
     LOG_CMD_MSG,
     LOG_MAVLINK_COMMAND_MSG,
@@ -2104,7 +1966,6 @@ enum LogMessages : uint8_t {
     LOG_CSRV_MSG,
     LOG_CESC_MSG,
     LOG_ARSP_MSG,
-    LOG_ATTITUDE_MSG,
     LOG_CURRENT_MSG,
     LOG_CURRENT_CELLS_MSG,
     LOG_MAG_MSG,
@@ -2121,7 +1982,6 @@ enum LogMessages : uint8_t {
     LOG_GPS_RAWS_MSG,
     LOG_ACC_MSG,
     LOG_GYR_MSG,
-    LOG_POS_MSG,
     LOG_PIDR_MSG,
     LOG_PIDP_MSG,
     LOG_PIDY_MSG,
@@ -2129,7 +1989,6 @@ enum LogMessages : uint8_t {
     LOG_PIDS_MSG,
     LOG_DSTL_MSG,
     LOG_VIBE_MSG,
-    LOG_ORGN_MSG,
     LOG_RPM_MSG,
     LOG_GPA_MSG,
     LOG_RFND_MSG,
@@ -2148,11 +2007,9 @@ enum LogMessages : uint8_t {
     LOG_MSG_SBPEVENT,
     LOG_TRIGGER_MSG,
 
-    LOG_RATE_MSG,
     LOG_RALLY_MSG,
     LOG_VISUALODOM_MSG,
     LOG_VISUALPOS_MSG,
-    LOG_AOA_SSA_MSG,
     LOG_BEACON_MSG,
     LOG_PROXIMITY_MSG,
     LOG_DF_FILE_STATS,


### PR DESCRIPTION
This moves AHRS logging functions out of AP_Logging/Logging.cpp into AP_AHRS as discussed here. https://github.com/ArduPilot/ardupilot/pull/16257#issuecomment-757053472

I could make the AHRS logging functions private and have one main logging function but have left it for later. 

@peterbarker 