### PR TITLE
Plane: add Quadplane windvaning options

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -593,6 +593,8 @@ private:
         OPTION_DELAY_ARMING=(1<<11),
         OPTION_DISABLE_SYNTHETIC_AIRSPEED_ASSIST=(1<<12),
         OPTION_DISABLE_GROUND_EFFECT_COMP=(1<<13),
+        OPTION_WIND_VANE_NOSE_AND_TAIL=(1<<14),
+        OPTION_WIND_VANE_SIDE_ON=(1<<15)
     };
 
     AP_Float takeoff_failure_scalar;


### PR DESCRIPTION
This adds option bits to vane either nose or tail into the wind, or vane to side on. New bits are probably only useful for tail sitters.

https://youtu.be/SS7y0tQfWjg

Fixes #7786
