### PR TITLE
AP_MSP: fix for missing ACK on unsupported MSP messages

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -459,7 +459,8 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_command(uint16_t cmd_msp,
     case MSP_RC:
         return msp_process_out_rc(dst);
     default:
-        return MSP_RESULT_ERROR;
+        // MSP always requires an ACK even for unsupported messages
+        return MSP_RESULT_ACK;
     }
 }
 


### PR DESCRIPTION
MSP requires all messages to be acknowledged even if unsupported, failing to do so can lead to timeouts and slowdowns.

An example of such a slowdown is using ardupilot with the SharkByte OSD, MSP messages 5E,70 and 2002 were not supported and failing to ACK them lead to a timeout and very slow OSD refresh.