### PR TITLE
AP_NavEKF3: remove redundant extnav code

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -986,10 +986,7 @@ void NavEKF3_core::selectHeightForFusion()
     bool rangeFinderDataIsFresh = (imuSampleTime_ms - rngValidMeaTime_ms < 500);
     const bool extNavDataIsFresh = (imuSampleTime_ms - extNavMeasTime_ms < 500);
     // select height source
-    if (extNavUsedForPos && (frontend->sources.getPosZSource() == AP_NavEKF_Source::SourceZ::EXTNAV)) {
-        // always use external navigation as the height source if using for position.
-        activeHgtSource = AP_NavEKF_Source::SourceZ::EXTNAV;
-    } else if ((frontend->sources.getPosZSource() == AP_NavEKF_Source::SourceZ::RANGEFINDER) && _rng && rangeFinderDataIsFresh) {
+    if ((frontend->sources.getPosZSource() == AP_NavEKF_Source::SourceZ::RANGEFINDER) && _rng && rangeFinderDataIsFresh) {
         // user has specified the range finder as a primary height source
         activeHgtSource = AP_NavEKF_Source::SourceZ::RANGEFINDER;
     } else if ((frontend->_useRngSwHgt > 0) && ((frontend->sources.getPosZSource() == AP_NavEKF_Source::SourceZ::BARO) || (frontend->sources.getPosZSource() == AP_NavEKF_Source::SourceZ::GPS)) && _rng && rangeFinderDataIsFresh) {


### PR DESCRIPTION
It is redundant with following code

https://github.com/ArduPilot/ardupilot/blob/957842f7ebf16268fad9fad3c7cd1e1af8de6cdf/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp#L1039-L1041

flight test log
[29 2021-1-11 02-57-18.zip](https://github.com/ArduPilot/ardupilot/files/5794369/29.2021-1-11.02-57-18.zip)
