### PR TITLE
Allow up-to 32 servos

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -318,8 +318,8 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
         // check we have an ESC present for every SERVOx_FUNCTION = motorx
         // find and report first missing ESC, extra ESCs are OK
         AP_ToshibaCAN *tcan = AP_ToshibaCAN::get_tcan(tcan_index);
-        const uint16_t motors_mask = copter.motors->get_motor_mask();
-        const uint16_t esc_mask = tcan->get_present_mask();
+        const uint32_t motors_mask = copter.motors->get_motor_mask();
+        const uint32_t esc_mask = tcan->get_present_mask();
         uint8_t escs_missing = 0;
         uint8_t first_missing = 0;
         for (uint8_t i = 0; i < 16; i++) {

--- a/ArduCopter/afs_copter.cpp
+++ b/ArduCopter/afs_copter.cpp
@@ -45,7 +45,7 @@ void AP_AdvancedFailsafe_Copter::setup_IO_failsafe(void)
 
 #if FRAME_CONFIG != HELI_FRAME
     // setup AP_Motors outputs for failsafe
-    uint16_t mask = copter.motors->get_motor_mask();
+    uint32_t mask = copter.motors->get_motor_mask();
     hal.rcout->set_failsafe_pwm(mask, copter.motors->get_pwm_output_min());
 #endif
 }

--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -84,7 +84,7 @@ void AP_AdvancedFailsafe_Plane::setup_IO_failsafe(void)
 #if HAL_QUADPLANE_ENABLED
     if (plane.quadplane.available()) {
         // setup AP_Motors outputs for failsafe
-        uint16_t mask = plane.quadplane.motors->get_motor_mask();
+        uint32_t mask = plane.quadplane.motors->get_motor_mask();
         hal.rcout->set_failsafe_pwm(mask, plane.quadplane.motors->get_pwm_output_min());
     }
 #endif

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -711,7 +711,7 @@ bool QuadPlane::setup(void)
 
     // setup the trim of any motors used by AP_Motors so I/O board
     // failsafe will disable motors
-    uint16_t mask = plane.quadplane.motors->get_motor_mask();
+    uint32_t mask = plane.quadplane.motors->get_motor_mask();
     hal.rcout->set_failsafe_pwm(mask, plane.quadplane.motors->get_pwm_output_min());
 
     // default QAssist state as set with Q_OPTIONS

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -985,7 +985,7 @@ void Plane::servos_output(void)
 
     // support MANUAL_RCMASK
     if (g2.manual_rc_mask.get() != 0 && control_mode == &mode_manual) {
-        SRV_Channels::copy_radio_in_out_mask(uint16_t(g2.manual_rc_mask.get()));
+        SRV_Channels::copy_radio_in_out_mask(uint32_t(g2.manual_rc_mask.get()));
     }
 
     SRV_Channels::calc_pwm();

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -49,7 +49,7 @@ void AP_Periph_FW::rcout_init()
         SRV_Channels::set_angle(SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i), 1000);
     }
 
-    uint16_t esc_mask = 0;
+    uint32_t esc_mask = 0;
     for (uint8_t i=0; i<SERVO_OUT_MOTOR_MAX; i++) {
         SRV_Channels::set_range(SRV_Channels::get_motor_function(i), UAVCAN_ESC_MAX_VALUE);
         uint8_t chan;

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -21,7 +21,7 @@
 // Raw ESC command normalized into [-8192, 8191]
 #define UAVCAN_ESC_MAX_VALUE    8191
 
-#define SERVO_OUT_RCIN_MAX      16  // SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16
+#define SERVO_OUT_RCIN_MAX      32  // note that we allow for more than is in the enum
 #define SERVO_OUT_MOTOR_MAX     12  // SRV_Channel::k_motor1 ... SRV_Channel::k_motor8, SRV_Channel::k_motor9 ... SRV_Channel::k_motor12
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     // @Param: MASK
     // @DisplayName: BLHeli Channel Bitmask
     // @Description: Enable of BLHeli pass-thru servo protocol support to specific channels. This mask is in addition to motors enabled using SERVO_BLH_AUTO (if any)
-    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16, 16:Channel 17, 17: Channel 18, 18: Channel 19, 19: Channel 20, 20: Channel 21, 21: Channel 22, 22: Channel 23, 23: Channel 24, 24: Channel 25, 25: Channel 26, 26: Channel 27, 27: Channel 28, 28: Channel 29, 29: Channel 30, 30: Channel 31, 31: Channel 32
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("MASK",  1, AP_BLHeli, channel_mask, 0),
@@ -129,7 +129,7 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     // @Param: 3DMASK
     // @DisplayName: BLHeli bitmask of 3D channels
     // @Description: Mask of channels which are dynamically reversible. This is used to configure ESCs in '3D' mode, allowing for the motor to spin in either direction
-    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16, 16:Channel 17, 17: Channel 18, 18: Channel 19, 19: Channel 20, 20: Channel 21, 21: Channel 22, 22: Channel 23, 23: Channel 24, 24: Channel 25, 25: Channel 26, 26: Channel 27, 27: Channel 28, 28: Channel 29, 29: Channel 30, 30: Channel 31, 31: Channel 32
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("3DMASK",  10, AP_BLHeli, channel_reversible_mask, 0),
@@ -138,7 +138,7 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     // @Param: BDMASK
     // @DisplayName: BLHeli bitmask of bi-directional dshot channels
     // @Description: Mask of channels which support bi-directional dshot. This is used for ESCs which have firmware that supports bi-directional dshot allowing fast rpm telemetry values to be returned for the harmonic notch.
-    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16, 16:Channel 17, 17: Channel 18, 18: Channel 19, 19: Channel 20, 20: Channel 21, 21: Channel 22, 22: Channel 23, 23: Channel 24, 24: Channel 25, 25: Channel 26, 26: Channel 27, 27: Channel 28, 28: Channel 29, 29: Channel 30, 30: Channel 31, 31: Channel 32
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("BDMASK",  11, AP_BLHeli, channel_bidir_dshot_mask, 0),
@@ -146,7 +146,7 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     // @Param: RVMASK
     // @DisplayName: BLHeli bitmask of reversed channels
     // @Description: Mask of channels which are reversed. This is used to configure ESCs in reversed mode
-    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16, 16:Channel 17, 17: Channel 18, 18: Channel 19, 19: Channel 20, 20: Channel 21, 21: Channel 22, 22: Channel 23, 23: Channel 24, 24: Channel 25, 25: Channel 26, 26: Channel 27, 27: Channel 28, 28: Channel 29, 29: Channel 30, 30: Channel 31, 31: Channel 32
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("RVMASK",  12, AP_BLHeli, channel_reversed_mask, 0),
@@ -1333,7 +1333,7 @@ void AP_BLHeli::init(void)
     }
 #endif
 
-    uint16_t mask = uint16_t(channel_mask.get());
+    uint32_t mask = uint32_t(channel_mask.get());
 
     /*
       allow mode override - this makes it possible to use DShot for
@@ -1359,7 +1359,7 @@ void AP_BLHeli::init(void)
         break;
     }
 
-    uint16_t digital_mask = 0;
+    uint32_t digital_mask = 0;
     // setting the digital mask changes the min/max PWM values
     // it's important that this is NOT done for non-digital channels as otherwise
     // PWM min can result in motors turning. set for individual overrides first
@@ -1386,15 +1386,15 @@ void AP_BLHeli::init(void)
     }
 #endif
     // tell SRV_Channels about ESC capabilities
-    SRV_Channels::set_digital_outputs(digital_mask, uint16_t(channel_reversible_mask.get()) & digital_mask);
+    SRV_Channels::set_digital_outputs(digital_mask, uint32_t(channel_reversible_mask.get()) & digital_mask);
     // the dshot ESC type is required in order to send the reversed/reversible dshot command correctly
     hal.rcout->set_dshot_esc_type(SRV_Channels::get_dshot_esc_type());
-    hal.rcout->set_reversible_mask(uint16_t(channel_reversible_mask.get()) & digital_mask);
-    hal.rcout->set_reversed_mask(uint16_t(channel_reversed_mask.get()) & digital_mask);
+    hal.rcout->set_reversible_mask(uint32_t(channel_reversible_mask.get()) & digital_mask);
+    hal.rcout->set_reversed_mask(uint32_t(channel_reversed_mask.get()) & digital_mask);
 #ifdef HAL_WITH_BIDIR_DSHOT
     // possibly enable bi-directional dshot
     hal.rcout->set_motor_poles(motor_poles);
-    hal.rcout->set_bidir_dshot_mask(uint16_t(channel_bidir_dshot_mask.get()) & digital_mask);
+    hal.rcout->set_bidir_dshot_mask(uint32_t(channel_bidir_dshot_mask.get()) & digital_mask);
 #endif
     // add motors from channel mask
     for (uint8_t i=0; i<16 && num_motors < max_motors; i++) {
@@ -1404,7 +1404,7 @@ void AP_BLHeli::init(void)
         }
     }
     motor_mask = mask;
-    debug("ESC: %u motors mask=0x%04x", num_motors, mask);
+    debug("ESC: %u motors mask=0x%08lx", num_motors, mask);
 
     // check if we have a combination of reversable and normal
     mixed_type = (mask != (mask & channel_reversible_mask.get())) && (channel_reversible_mask.get() != 0);

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1377,7 +1377,7 @@ void AP_BLHeli::init(void)
     AP_Motors *motors = AP::motors();
 #endif
     if (motors) {
-        uint16_t motormask = motors->get_motor_mask();
+        uint32_t motormask = motors->get_motor_mask();
         // set the rest of the digital channels
         if (motors->is_digital_pwm_type()) {
             digital_mask |= motormask;
@@ -1580,7 +1580,7 @@ void AP_BLHeli::update_telemetry(void)
                 break;
             }
         }
-        uint16_t mask = 1U << motor_map[idx];
+        uint32_t mask = 1U << motor_map[idx];
         if (SRV_Channels::have_digital_outputs(mask)) {
             hal.rcout->set_telem_request_mask(mask);
             last_telem_esc = idx;

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -242,7 +242,7 @@ private:
 
     // mapping from BLHeli motor numbers to RC output channels
     uint8_t motor_map[max_motors];
-    uint16_t motor_mask;
+    uint32_t motor_mask;
 
     // convert between servo number and FMU channel number for ESC telemetry
     uint8_t chan_offset;

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -53,7 +53,7 @@ public:
         return channel_bidir_dshot_mask.get() & (1U << motor_map[esc_index]);
     }
 
-    uint16_t get_bidir_dshot_mask() const { return channel_bidir_dshot_mask.get(); }
+    uint32_t get_bidir_dshot_mask() const { return channel_bidir_dshot_mask.get(); }
 
     static AP_BLHeli *get_singleton(void) {
         return _singleton;
@@ -232,7 +232,7 @@ private:
     // have we disabled motor outputs?
     bool motors_disabled;
     // mask of channels that should normally be disabled
-    uint16_t motors_disabled_mask;
+    uint32_t motors_disabled_mask;
 
     // have we locked the UART?
     bool uart_locked;

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -373,7 +373,7 @@ void AP_BoardConfig::init()
 }
 
 // set default value for BRD_SAFETY_MASK
-void AP_BoardConfig::set_default_safety_ignore_mask(uint16_t mask)
+void AP_BoardConfig::set_default_safety_ignore_mask(uint32_t mask)
 {
 #if HAL_HAVE_SAFETY_SWITCH
     state.ignore_safety_channels.set_default(mask);

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -100,7 +100,7 @@ public:
     };
 
     // set default value for BRD_SAFETY_MASK
-    void set_default_safety_ignore_mask(uint16_t mask);
+    void set_default_safety_ignore_mask(uint32_t mask);
 
     static enum px4_board_type get_board_type(void) {
 #if AP_FEATURE_BOARD_DETECT
@@ -141,7 +141,7 @@ public:
     // return the value of BRD_SAFETY_MASK
     uint16_t get_safety_mask(void) const {
 #if AP_FEATURE_BOARD_DETECT || defined(AP_FEATURE_BRD_PWM_COUNT_PARAM)
-        return uint16_t(state.ignore_safety_channels.get());
+        return uint32_t(state.ignore_safety_channels.get());
 #else
         return 0;
 #endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -76,8 +76,8 @@ uint8_t AP_ESC_Telem::get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) con
 
 // get mask of ESCs that sent valid telemetry data in the last
 // ESC_TELEM_DATA_TIMEOUT_MS
-uint16_t AP_ESC_Telem::get_active_esc_mask() const {
-    uint16_t ret = 0;
+uint32_t AP_ESC_Telem::get_active_esc_mask() const {
+    uint32_t ret = 0;
     const uint32_t now = AP_HAL::millis();
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
         if (now - _telem_data[i].last_update_ms >= ESC_TELEM_DATA_TIMEOUT_MS) {
@@ -94,7 +94,7 @@ uint16_t AP_ESC_Telem::get_active_esc_mask() const {
 
 // return number of active ESCs present
 uint8_t AP_ESC_Telem::get_num_active_escs() const {
-    uint16_t active = get_active_esc_mask();
+    uint32_t active = get_active_esc_mask();
     return __builtin_popcount(active);
 }
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -68,7 +68,7 @@ public:
 
     // get mask of ESCs that sent valid telemetry data in the last
     // ESC_TELEM_DATA_TIMEOUT_MS
-    uint16_t get_active_esc_mask() const;
+    uint32_t get_active_esc_mask() const;
 
     // return the last time telemetry data was received in ms for the given ESC or 0 if never
     uint32_t get_last_telem_data_ms(uint8_t esc_index) const {

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -26,6 +26,20 @@
 #define CH_16 15
 #define CH_17 16
 #define CH_18 17
+#define CH_19 18
+#define CH_20 19
+#define CH_21 20
+#define CH_22 21
+#define CH_23 22
+#define CH_24 23
+#define CH_25 24
+#define CH_26 25
+#define CH_27 26
+#define CH_28 27
+#define CH_29 28
+#define CH_30 29
+#define CH_31 30
+#define CH_32 31
 #define CH_NONE 255
 #endif
 
@@ -57,15 +71,15 @@ public:
      * so that output scaling can be performed correctly. The chanmask passed is added (ORed) into any existing mask.
      * The mask uses servo channel numbering
      */
-    virtual void     set_reversible_mask(uint16_t chanmask) {}
+    virtual void     set_reversible_mask(uint32_t chanmask) {}
     
     /*
      * mark the channels in chanmask as reversed.
      * The chanmask passed is added (ORed) into any existing mask.
      * The mask uses servo channel numbering
      */
-    virtual void     set_reversed_mask(uint16_t chanmask) {}
-    virtual uint16_t get_reversed_mask() { return 0; }
+    virtual void     set_reversed_mask(uint32_t chanmask) {}
+    virtual uint32_t get_reversed_mask() { return 0; }
 
     /*
      * Update channel masks at 1Hz allowing for actions such as dshot commands to be sent
@@ -165,7 +179,7 @@ public:
       as those in the same channel timer groups) may also be stopped,
       depending on the implementation
      */
-    virtual bool serial_setup_output(uint8_t chan, uint32_t baudrate, uint16_t chanmask) { return false; }
+    virtual bool serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t chanmask) { return false; }
 
     /*
       write a set of bytes to an ESC, using settings from
@@ -242,7 +256,7 @@ public:
       DSHOT_ESC_BLHELI = 1
     };
 
-    virtual void    set_output_mode(uint16_t mask, enum output_mode mode) {}
+    virtual void    set_output_mode(uint32_t mask, enum output_mode mode) {}
 
     /*
      * get output mode banner to inform user of how outputs are configured
@@ -263,18 +277,18 @@ public:
       enable telemetry request for a mask of channels. This is used
       with DShot to get telemetry feedback
      */
-    virtual void set_telem_request_mask(uint16_t mask) {}
+    virtual void set_telem_request_mask(uint32_t mask) {}
 
     /*
       enable bi-directional telemetry request for a mask of channels. This is used
       with DShot to get telemetry feedback
      */
-    virtual void set_bidir_dshot_mask(uint16_t mask) {}
+    virtual void set_bidir_dshot_mask(uint32_t mask) {}
 
     /*
       mark escs as active for the purpose of sending dshot commands
      */
-    virtual void set_active_escs_mask(uint16_t mask) {}
+    virtual void set_active_escs_mask(uint32_t mask) {}
 
     /*
       Set the dshot rate as a multiple of the loop rate
@@ -304,7 +318,7 @@ public:
       setup serial led output for a given channel number, with
       the given max number of LEDs in the chain.
      */
-    virtual bool set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode = MODE_PWM_NONE, uint16_t clock_mask = 0) { return false; }
+    virtual bool set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode = MODE_PWM_NONE, uint32_t clock_mask = 0) { return false; }
 
     /*
       setup serial led output data for a given output channel

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -266,7 +266,7 @@ public:
     /*
      * return mask of channels that must be disabled because they share a group with a digital channel
      */
-    virtual uint16_t get_disabled_channels(uint16_t digital_mask) { return 0; }
+    virtual uint32_t get_disabled_channels(uint32_t digital_mask) { return 0; }
 
     /*
       set default update rate

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -999,7 +999,7 @@ void RCOutput::set_group_mode(pwm_group &group)
 /*
   setup output mode
  */
-void RCOutput::set_output_mode(uint16_t mask, const enum output_mode mode)
+void RCOutput::set_output_mode(uint32_t mask, const enum output_mode mode)
 {
     for (auto &group : pwm_group_list) {
         enum output_mode thismode = mode;
@@ -1660,7 +1660,7 @@ void RCOutput::dma_cancel(pwm_group& group)
   While serial output is active normal output to the channel group is
   suspended.
 */
-bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint16_t chanmask)
+bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t chanmask)
 {
     // account for IOMCU channels
     chan -= chan_offset;
@@ -2122,7 +2122,7 @@ uint32_t RCOutput::protocol_bitrate(const enum output_mode mode)
   setup serial led output for a given channel number, with
   the given max number of LEDs in the chain.
 */
-bool RCOutput::set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode, uint16_t clock_mask)
+bool RCOutput::set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode, uint32_t clock_mask)
 {
     if (!_initialised || num_leds == 0) {
         return false;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -500,10 +500,10 @@ RCOutput::pwm_group *RCOutput::find_chan(uint8_t chan, uint8_t &group_idx)
 /*
  * return mask of channels that must be disabled because they share a group with a digital channel
  */
-uint16_t RCOutput::get_disabled_channels(uint16_t digital_mask)
+uint32_t RCOutput::get_disabled_channels(uint32_t digital_mask)
 {
-    uint16_t dmask = (digital_mask >> chan_offset);
-    uint16_t disabled_chan_mask = 0;
+    uint32_t dmask = (digital_mask >> chan_offset);
+    uint32_t disabled_chan_mask = 0;
     for (auto &group : pwm_group_list) {
         bool digital_group = false;
         for (uint8_t j = 0; j < 4; j++) {
@@ -615,7 +615,7 @@ void RCOutput::push_local(void)
     if (active_fmu_channels == 0) {
         return;
     }
-    uint16_t outmask = (1U<<active_fmu_channels)-1;
+    uint32_t outmask = (1U<<active_fmu_channels)-1;
     outmask &= en_mask;
 
     uint16_t widest_pulse = 0;
@@ -1383,7 +1383,7 @@ void RCOutput::dshot_send(pwm_group &group, uint32_t time_out_us)
     // assume that we won't be able to get the input capture lock
     group.bdshot.enabled = false;
 
-    uint16_t active_channels = group.ch_mask & group.en_mask;
+    uint32_t active_channels = group.ch_mask & group.en_mask;
     // now grab the input capture lock if we are able, we can only enable bi-dir on a group basis
     if (((_bdshot.mask & active_channels) == active_channels) && group.has_ic()) {
         if (group.has_shared_ic_up_dma()) {
@@ -1456,7 +1456,7 @@ void RCOutput::dshot_send(pwm_group &group, uint32_t time_out_us)
                 continue;
             }
 
-            const uint16_t chan_mask = (1U<<chan);
+            const uint32_t chan_mask = (1U<<chan);
 
             pwm = constrain_int16(pwm, 1000, 2000);
             uint16_t value = MIN(2 * (pwm - 1000), 1999);

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -74,7 +74,7 @@ public:
     /*
      * return mask of channels that must be disabled because they share a group with a digital channel
      */
-    uint16_t get_disabled_channels(uint16_t digital_mask) override;
+    uint32_t get_disabled_channels(uint32_t digital_mask) override;
 
     float scale_esc_to_unity(uint16_t pwm) override {
         return 2.0 * ((float) pwm - _esc_pwm_min) / (_esc_pwm_max - _esc_pwm_min) - 1.0;

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -41,7 +41,7 @@ extern const AP_HAL::HAL& hal;
  * enable bi-directional telemetry request for a mask of channels. This is used
  * with DShot to get telemetry feedback
  */
-void RCOutput::set_bidir_dshot_mask(uint16_t mask)
+void RCOutput::set_bidir_dshot_mask(uint32_t mask)
 {
     _bdshot.mask = (mask >> chan_offset);
     // we now need to reconfigure the DMA channels since they are affected by the value of the mask

--- a/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
@@ -50,7 +50,7 @@ bool RCOutput::dshot_send_command(pwm_group& group, uint8_t command, uint8_t cha
     group.dshot_waiter = rcout_thread_ctx;
     bool bdshot_telem = false;
 #ifdef HAL_WITH_BIDIR_DSHOT
-    uint16_t active_channels = group.ch_mask & group.en_mask;
+    uint32_t active_channels = group.ch_mask & group.en_mask;
     // no need to get the input capture lock
     group.bdshot.enabled = false;
     if ((_bdshot.mask & active_channels) == active_channels) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
@@ -123,14 +123,14 @@ void RCOutput::send_dshot_command(uint8_t command, uint8_t chan, uint32_t comman
 // Set the dshot outputs that should be reversed (as opposed to 3D)
 // The chanmask passed is added (ORed) into any existing mask.
 // The mask uses servo channel numbering
-void RCOutput::set_reversed_mask(uint16_t chanmask) {
+void RCOutput::set_reversed_mask(uint32_t chanmask) {
     _reversed_mask |= (chanmask >> chan_offset);
 }
 
 // Set the dshot outputs that should be reversible/3D
 // The chanmask passed is added (ORed) into any existing mask.
 // The mask uses servo channel numbering
-void RCOutput::set_reversible_mask(uint16_t chanmask) {
+void RCOutput::set_reversible_mask(uint32_t chanmask) {
     _reversible_mask |= (chanmask >> chan_offset);
 }
 

--- a/libraries/AP_HAL_ESP32/RCOutput.h
+++ b/libraries/AP_HAL_ESP32/RCOutput.h
@@ -86,7 +86,7 @@ public:
     /*
        set safety mask for IOMCU
        */
-    void set_safety_mask(uint16_t mask)
+    void set_safety_mask(uint32_t mask)
     {
         safety_mask = mask;
     }
@@ -126,7 +126,7 @@ private:
     uint8_t safety_press_count; // 0.1s units
 
     // mask of channels to allow when safety on
-    uint16_t safety_mask;
+    uint32_t safety_mask;
 
     // update safety switch and LED
     void safety_update(void);

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
@@ -48,7 +48,7 @@ private:
     bool _corking = false;
     uint8_t _channel_offset;
     int16_t _oe_pin_number;
-    uint16_t _pending_write_mask;
+    uint32_t _pending_write_mask;
 };
 
 }

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -106,7 +106,7 @@ void RCOutput::push(void)
 /*
   Serial LED emulation
 */
-bool RCOutput::set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode, uint16_t clock_mask)
+bool RCOutput::set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode, uint32_t clock_mask)
 {
     if (chan > 15 || num_leds > 64) {
         return false;

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -31,7 +31,7 @@ public:
     /*
       Serial LED emulation
      */
-    bool set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode = MODE_PWM_NONE, uint16_t clock_mask = 0) override;
+    bool set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode = MODE_PWM_NONE, uint32_t clock_mask = 0) override;
     void set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) override;
     void serial_led_send(const uint16_t chan) override;
     
@@ -40,7 +40,7 @@ private:
     AP_ESC_Telem_SITL *esc_telem;
 
     uint16_t _freq_hz;
-    uint16_t _enable_mask;
+    uint32_t _enable_mask;
     bool _corked;
     uint16_t _pending[SITL_NUM_CHANNELS];
 };

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -606,7 +606,7 @@ bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
 
     _enum_sem.give();
 
-    uint16_t motors_mask = 0;
+    uint32_t motors_mask = 0;
     AP_Motors *motors = AP_Motors::get_singleton();
 
     if (motors) {

--- a/libraries/AP_KDECAN/AP_KDECAN.h
+++ b/libraries/AP_KDECAN/AP_KDECAN.h
@@ -72,7 +72,7 @@ private:
     AP_Int8 _num_poles;
 
     // ESC detected information
-    uint16_t _esc_present_bitmask;
+    uint32_t _esc_present_bitmask;
     uint8_t _esc_max_node_id;
 
     // enumeration

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -178,58 +178,66 @@ void AP_Logger::Write_RCIN(void)
 // Write an SERVO packet
 void AP_Logger::Write_RCOUT(void)
 {
-    const struct log_RCOUT pkt{
-        LOG_PACKET_HEADER_INIT(LOG_RCOUT_MSG),
-        time_us       : AP_HAL::micros64(),
-        chan1         : hal.rcout->read(0),
-        chan2         : hal.rcout->read(1),
-        chan3         : hal.rcout->read(2),
-        chan4         : hal.rcout->read(3),
-        chan5         : hal.rcout->read(4),
-        chan6         : hal.rcout->read(5),
-        chan7         : hal.rcout->read(6),
-        chan8         : hal.rcout->read(7),
-        chan9         : hal.rcout->read(8),
-        chan10        : hal.rcout->read(9),
-        chan11        : hal.rcout->read(10),
-        chan12        : hal.rcout->read(11),
-        chan13        : hal.rcout->read(12),
-        chan14        : hal.rcout->read(13)
-    };
-    WriteBlock(&pkt, sizeof(pkt));
+    const uint32_t enabled_mask = ~SRV_Channels::get_output_channel_mask(SRV_Channel::k_GPIO);
+
+    if ((enabled_mask & 0x3FFF) != 0) {
+        const struct log_RCOUT pkt{
+            LOG_PACKET_HEADER_INIT(LOG_RCOUT_MSG),
+            time_us       : AP_HAL::micros64(),
+            chan1         : hal.rcout->read(0),
+            chan2         : hal.rcout->read(1),
+            chan3         : hal.rcout->read(2),
+            chan4         : hal.rcout->read(3),
+            chan5         : hal.rcout->read(4),
+            chan6         : hal.rcout->read(5),
+            chan7         : hal.rcout->read(6),
+            chan8         : hal.rcout->read(7),
+            chan9         : hal.rcout->read(8),
+            chan10        : hal.rcout->read(9),
+            chan11        : hal.rcout->read(10),
+            chan12        : hal.rcout->read(11),
+            chan13        : hal.rcout->read(12),
+            chan14        : hal.rcout->read(13)
+        };
+        WriteBlock(&pkt, sizeof(pkt));
+    }
 
 #if NUM_SERVO_CHANNELS >= 15
-    const struct log_RCOUT2 pkt2{
-        LOG_PACKET_HEADER_INIT(LOG_RCOUT2_MSG),
-        time_us       : AP_HAL::micros64(),
-        chan15         : hal.rcout->read(14),
-        chan16         : hal.rcout->read(15),
-        chan17         : hal.rcout->read(16),
-        chan18         : hal.rcout->read(17),
-    };
-    WriteBlock(&pkt2, sizeof(pkt2));
+    if ((enabled_mask & 0x3C000) != 0) {
+        const struct log_RCOUT2 pkt2{
+            LOG_PACKET_HEADER_INIT(LOG_RCOUT2_MSG),
+            time_us       : AP_HAL::micros64(),
+            chan15         : hal.rcout->read(14),
+            chan16         : hal.rcout->read(15),
+            chan17         : hal.rcout->read(16),
+            chan18         : hal.rcout->read(17),
+        };
+        WriteBlock(&pkt2, sizeof(pkt2));
+    }
 #endif
 
 #if NUM_SERVO_CHANNELS >= 19
-    const struct log_RCOUT pkt3{
-        LOG_PACKET_HEADER_INIT(LOG_RCOUT3_MSG),
-        time_us       : AP_HAL::micros64(),
-        chan1         : hal.rcout->read(18),
-        chan2         : hal.rcout->read(19),
-        chan3         : hal.rcout->read(20),
-        chan4         : hal.rcout->read(21),
-        chan5         : hal.rcout->read(22),
-        chan6         : hal.rcout->read(23),
-        chan7         : hal.rcout->read(24),
-        chan8         : hal.rcout->read(25),
-        chan9         : hal.rcout->read(26),
-        chan10        : hal.rcout->read(27),
-        chan11        : hal.rcout->read(28),
-        chan12        : hal.rcout->read(29),
-        chan13        : hal.rcout->read(30),
-        chan14        : hal.rcout->read(31)
-    };
-    WriteBlock(&pkt3, sizeof(pkt3));
+    if ((enabled_mask & 0xFFFC0000) != 0) {
+        const struct log_RCOUT pkt3{
+            LOG_PACKET_HEADER_INIT(LOG_RCOUT3_MSG),
+            time_us       : AP_HAL::micros64(),
+            chan1         : hal.rcout->read(18),
+            chan2         : hal.rcout->read(19),
+            chan3         : hal.rcout->read(20),
+            chan4         : hal.rcout->read(21),
+            chan5         : hal.rcout->read(22),
+            chan6         : hal.rcout->read(23),
+            chan7         : hal.rcout->read(24),
+            chan8         : hal.rcout->read(25),
+            chan9         : hal.rcout->read(26),
+            chan10        : hal.rcout->read(27),
+            chan11        : hal.rcout->read(28),
+            chan12        : hal.rcout->read(29),
+            chan13        : hal.rcout->read(30),
+            chan14        : hal.rcout->read(31)
+        };
+        WriteBlock(&pkt3, sizeof(pkt3));
+    }
 #endif
 
 }

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -197,6 +197,41 @@ void AP_Logger::Write_RCOUT(void)
         chan14        : hal.rcout->read(13)
     };
     WriteBlock(&pkt, sizeof(pkt));
+
+#if NUM_SERVO_CHANNELS >= 15
+    const struct log_RCOUT2 pkt2{
+        LOG_PACKET_HEADER_INIT(LOG_RCOUT2_MSG),
+        time_us       : AP_HAL::micros64(),
+        chan15         : hal.rcout->read(14),
+        chan16         : hal.rcout->read(15),
+        chan17         : hal.rcout->read(16),
+        chan18         : hal.rcout->read(17),
+    };
+    WriteBlock(&pkt2, sizeof(pkt2));
+#endif
+
+#if NUM_SERVO_CHANNELS >= 19
+    const struct log_RCOUT pkt3{
+        LOG_PACKET_HEADER_INIT(LOG_RCOUT3_MSG),
+        time_us       : AP_HAL::micros64(),
+        chan1         : hal.rcout->read(18),
+        chan2         : hal.rcout->read(19),
+        chan3         : hal.rcout->read(20),
+        chan4         : hal.rcout->read(21),
+        chan5         : hal.rcout->read(22),
+        chan6         : hal.rcout->read(23),
+        chan7         : hal.rcout->read(24),
+        chan8         : hal.rcout->read(25),
+        chan9         : hal.rcout->read(26),
+        chan10        : hal.rcout->read(27),
+        chan11        : hal.rcout->read(28),
+        chan12        : hal.rcout->read(29),
+        chan13        : hal.rcout->read(30),
+        chan14        : hal.rcout->read(31)
+    };
+    WriteBlock(&pkt3, sizeof(pkt3));
+#endif
+
 }
 
 // Write an RSSI packet

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -284,6 +284,15 @@ struct PACKED log_RCOUT {
     uint16_t chan14;
 };
 
+struct PACKED log_RCOUT2 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint16_t chan15;
+    uint16_t chan16;
+    uint16_t chan17;
+    uint16_t chan18;
+};
+
 struct PACKED log_MAV {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1001,7 +1010,7 @@ struct PACKED log_VER {
 // @Field: C14: channel 14 input
 
 // @LoggerMessage: RCOU
-// @Description: Servo channel output values
+// @Description: Servo channel output values 1 to 14
 // @Field: TimeUS: Time since system startup
 // @Field: C1: channel 1 output
 // @Field: C2: channel 2 output
@@ -1017,6 +1026,32 @@ struct PACKED log_VER {
 // @Field: C12: channel 12 output
 // @Field: C13: channel 13 output
 // @Field: C14: channel 14 output
+
+// @LoggerMessage: RCO2
+// @Description: Servo channel output values 15 to 18
+// @Field: TimeUS: Time since system startup
+// @Field: C15: channel 15 output
+// @Field: C16: channel 16 output
+// @Field: C17: channel 17 output
+// @Field: C18: channel 18 output
+
+// @LoggerMessage: RCO3
+// @Description: Servo channel output values 19 to 32
+// @Field: TimeUS: Time since system startup
+// @Field: C19: channel 19 output
+// @Field: C20: channel 20 output
+// @Field: C21: channel 21 output
+// @Field: C22: channel 22 output
+// @Field: C23: channel 23 output
+// @Field: C24: channel 24 output
+// @Field: C25: channel 25 output
+// @Field: C26: channel 26 output
+// @Field: C27: channel 27 output
+// @Field: C28: channel 28 output
+// @Field: C29: channel 29 output
+// @Field: C30: channel 30 output
+// @Field: C31: channel 31 output
+// @Field: C32: channel 32 output
 
 // @LoggerMessage: RFND
 // @Description: Rangefinder sensor information
@@ -1188,6 +1223,10 @@ LOG_STRUCTURE_FROM_GPS \
       "RCI2",  "QHHH",     "TimeUS,C15,C16,OMask", "sYY-", "F---", true }, \
     { LOG_RCOUT_MSG, sizeof(log_RCOUT), \
       "RCOU",  "QHHHHHHHHHHHHHH",     "TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14", "sYYYYYYYYYYYYYY", "F--------------", true  }, \
+    { LOG_RCOUT2_MSG, sizeof(log_RCOUT2), \
+      "RCO2",  "QHHHH",     "TimeUS,C15,C16,C17,C18", "sYYYY", "F----", true  }, \
+    { LOG_RCOUT3_MSG, sizeof(log_RCOUT), \
+      "RCO3",  "QHHHHHHHHHHHHHH",     "TimeUS,C19,C20,C21,C22,C23,C24,C25,C26,C27,C28,C29,C30,C31,C32", "sYYYYYYYYYYYYYY", "F--------------", true  }, \
     { LOG_RSSI_MSG, sizeof(log_RSSI), \
       "RSSI",  "Qff",     "TimeUS,RXRSSI,RXLQ", "s--", "F--", true  }, \
 LOG_STRUCTURE_FROM_BARO \
@@ -1369,6 +1408,8 @@ enum LogMessages : uint8_t {
     LOG_VIDEO_STABILISATION_MSG,
     LOG_MOTBATT_MSG,
     LOG_VER_MSG,
+    LOG_RCOUT2_MSG,
+    LOG_RCOUT3_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -100,12 +100,12 @@ void AP_MotorsCoax::output_to_motors()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsCoax::get_motor_mask()
+uint32_t AP_MotorsCoax::get_motor_mask()
 {
     uint32_t motor_mask =
         1U << AP_MOTORS_MOT_5 |
         1U << AP_MOTORS_MOT_6;
-    uint16_t mask = motor_mask_to_srv_channel_mask(motor_mask);
+    uint32_t mask = motor_mask_to_srv_channel_mask(motor_mask);
 
     // add parent's mask
     mask |= AP_MotorsMulticopter::get_motor_mask();

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -42,7 +42,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    uint16_t            get_motor_mask() override;
+    uint32_t            get_motor_mask() override;
 
 protected:
     // output - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -111,7 +111,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    virtual uint16_t get_motor_mask() override = 0;
+    virtual uint32_t get_motor_mask() override = 0;
 
     virtual void set_acro_tail(bool set) {}
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -215,7 +215,7 @@ void AP_MotorsHeli_Dual::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // setup fast channels
-    uint16_t mask = 0;
+    uint32_t mask = 0;
     for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
         mask |= 1U << (AP_MOTORS_MOT_1+i);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -473,10 +473,10 @@ float AP_MotorsHeli_Dual::get_swashplate (int8_t swash_num, int8_t swash_axis, f
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsHeli_Dual::get_motor_mask()
+uint32_t AP_MotorsHeli_Dual::get_motor_mask()
 {
     // dual heli uses channels 1,2,3,4,5,6 and 8
-    uint16_t mask = 0;
+    uint32_t mask = 0;
     for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
         mask |= 1U << (AP_MOTORS_MOT_1+i);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -78,7 +78,7 @@ public:
     void calculate_armed_scalars() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
-    uint16_t get_motor_mask() override;
+    uint32_t get_motor_mask() override;
 
     // has_flybar - returns true if we have a mechical flybar
     bool has_flybar() const  override { return AP_MOTORS_HELI_NOFLYBAR; }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -183,9 +183,9 @@ void AP_MotorsHeli_Quad::calculate_roll_pitch_collective_factors()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsHeli_Quad::get_motor_mask()
+uint32_t AP_MotorsHeli_Quad::get_motor_mask()
 {
-    uint16_t mask = 0;
+    uint32_t mask = 0;
     for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
         mask |= 1U << (AP_MOTORS_MOT_1+i);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -57,7 +57,7 @@ public:
     void calculate_armed_scalars() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
-    uint16_t get_motor_mask() override;
+    uint32_t get_motor_mask() override;
 
     // has_flybar - returns true if we have a mechanical flybar
     bool has_flybar() const  override { return AP_MOTORS_HELI_NOFLYBAR; }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -355,7 +355,7 @@ void AP_MotorsHeli_Single::calculate_scalars()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsHeli_Single::get_motor_mask()
+uint32_t AP_MotorsHeli_Single::get_motor_mask()
 {
     // heli uses channels 1,2,3,4 and 8
     // setup fast channels

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -79,7 +79,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    uint16_t get_motor_mask() override;
+    uint32_t get_motor_mask() override;
 
     // ext_gyro_gain - set external gyro gain in range 0 ~ 1000
     void ext_gyro_gain(float gain)  override { if (gain >= 0 && gain <= 1000) { _ext_gyro_gain_std = gain; }}

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -117,7 +117,7 @@ void AP_MotorsMatrix::set_update_rate(uint16_t speed_hz)
     // record requested speed
     _speed_hz = speed_hz;
 
-    uint16_t mask = 0;
+    uint32_t mask = 0;
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             mask |= 1U << i;

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -184,15 +184,15 @@ void AP_MotorsMatrix::output_to_motors()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsMatrix::get_motor_mask()
+uint32_t AP_MotorsMatrix::get_motor_mask()
 {
-    uint16_t motor_mask = 0;
+    uint32_t motor_mask = 0;
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             motor_mask |= 1U << i;
         }
     }
-    uint16_t mask = motor_mask_to_srv_channel_mask(motor_mask);
+    uint32_t mask = motor_mask_to_srv_channel_mask(motor_mask);
 
     // add parent's mask
     mask |= AP_MotorsMulticopter::get_motor_mask();

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -60,7 +60,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    uint16_t            get_motor_mask() override;
+    uint32_t            get_motor_mask() override;
 
     // return number of motor that has failed.  Should only be called if get_thrust_boost() returns true
     uint8_t             get_lost_motor() const override { return _motor_lost_index; }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -777,7 +777,7 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float r
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsMulticopter::get_motor_mask()
+uint32_t AP_MotorsMulticopter::get_motor_mask()
 {
     return SRV_Channels::get_output_channel_mask(SRV_Channel::k_boost_throttle);
 }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -68,7 +68,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    virtual uint16_t    get_motor_mask() override;
+    virtual uint32_t    get_motor_mask() override;
 
     // get minimum or maximum pwm value that can be output to motors
     int16_t             get_pwm_output_min() const { return _pwm_min; }

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -103,7 +103,7 @@ void AP_MotorsSingle::output_to_motors()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsSingle::get_motor_mask()
+uint32_t AP_MotorsSingle::get_motor_mask()
 {
     uint32_t motor_mask =
         1U << AP_MOTORS_MOT_1 |
@@ -113,7 +113,7 @@ uint16_t AP_MotorsSingle::get_motor_mask()
         1U << AP_MOTORS_MOT_5 |
         1U << AP_MOTORS_MOT_6;
 
-    uint16_t mask = motor_mask_to_srv_channel_mask(motor_mask);
+    uint32_t mask = motor_mask_to_srv_channel_mask(motor_mask);
 
     // add parent's mask
     mask |= AP_MotorsMulticopter::get_motor_mask();

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -42,7 +42,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    uint16_t            get_motor_mask() override;
+    uint32_t            get_motor_mask() override;
 
 protected:
     // output - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -113,7 +113,7 @@ void AP_MotorsTailsitter::output_to_motors()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsTailsitter::get_motor_mask()
+uint32_t AP_MotorsTailsitter::get_motor_mask()
 {
     uint32_t motor_mask = 0;
     uint8_t chan;

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -28,7 +28,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    uint16_t get_motor_mask() override;
+    uint32_t get_motor_mask() override;
 
     // Set by tailsitters using diskloading minumum outflow velocity limit
     void set_min_throttle(float val) {_external_min_throttle = val;}

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -127,13 +127,13 @@ void AP_MotorsTri::output_to_motors()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint16_t AP_MotorsTri::get_motor_mask()
+uint32_t AP_MotorsTri::get_motor_mask()
 {
     // tri copter uses channels 1,2,4 and 7
-    uint16_t motor_mask = (1U << AP_MOTORS_MOT_1) |
+    uint32_t motor_mask = (1U << AP_MOTORS_MOT_1) |
                           (1U << AP_MOTORS_MOT_2) |
                           (1U << AP_MOTORS_MOT_4);
-    uint16_t mask = motor_mask_to_srv_channel_mask(motor_mask);
+    uint32_t mask = motor_mask_to_srv_channel_mask(motor_mask);
 
     // add parent's mask
     mask |= AP_MotorsMulticopter::get_motor_mask();

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -37,7 +37,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    uint16_t            get_motor_mask() override;
+    uint32_t            get_motor_mask() override;
 
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -309,10 +309,10 @@ protected:
     float               _air_density_ratio;     // air density / sea level density - decreases in altitude
 
     // mask of what channels need fast output
-    uint16_t            _motor_fast_mask;
+    uint32_t            _motor_fast_mask;
 
     // mask of what channels need to use SERVOn_MIN/MAX for output mapping
-    uint16_t            _motor_pwm_range_mask;
+    uint32_t            _motor_pwm_range_mask;
     
     // pass through variables
     float _roll_radio_passthrough;     // roll input from pilot in -1 ~ +1 range.  used for setup and providing servo feedback while landed

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -221,7 +221,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    virtual uint16_t    get_motor_mask() = 0;
+    virtual uint32_t    get_motor_mask() = 0;
 
     // pilot input in the -1 ~ +1 range for roll, pitch and yaw. 0~1 range for throttle
     void                set_radio_passthrough(float roll_input, float pitch_input, float throttle_input, float yaw_input);

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -57,7 +57,7 @@ const AP_Param::GroupInfo AP_PiccoloCAN::var_info[] = {
     // @Param: ESC_BM
     // @DisplayName: ESC channels
     // @Description: Bitmask defining which ESC (motor) channels are to be transmitted over Piccolo CAN
-    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16
+    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16, 16: ESC 17, 17: ESC 18, 18: ESC 19, 19: ESC 20, 20: ESC 21, 21: ESC 22, 22: ESC 23, 23: ESC 24, 24: ESC 25, 25: ESC 26, 26: ESC 27, 27: ESC 28, 28: ESC 29, 29: ESC 30, 30: ESC 31, 31: ESC 32
     // @User: Advanced
     AP_GROUPINFO("ESC_BM", 1, AP_PiccoloCAN, _esc_bm, 0xFFFF),
 

--- a/libraries/AP_RobotisServo/AP_RobotisServo.cpp
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.cpp
@@ -340,7 +340,7 @@ void AP_RobotisServo::process_packet(const uint8_t *pkt, uint8_t length)
         // easier
         return;
     }
-    uint16_t id_mask = (1U<<(id-1));
+    uint32_t id_mask = (1U<<(id-1));
     if (!(id_mask & servo_mask)) {
         // mark the servo as present
         servo_mask |= id_mask;

--- a/libraries/AP_RobotisServo/AP_RobotisServo.h
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.h
@@ -58,7 +58,7 @@ private:
     void configure_servos(void);
 
     // auto-detected mask of available servos, from a broadcast ping
-    uint16_t servo_mask;
+    uint32_t servo_mask;
     uint8_t detection_count;
     uint8_t configured_servos;
     bool initialised;

--- a/libraries/AP_SerialLED/AP_SerialLED.cpp
+++ b/libraries/AP_SerialLED/AP_SerialLED.cpp
@@ -38,7 +38,7 @@ bool AP_SerialLED::set_num_profiled(uint8_t chan, uint8_t num_leds)
 {
     if (chan >= 1 && chan <= 16 && num_leds <= AP_SERIALLED_MAX_LEDS - 2) {
         // must have a clock
-        uint16_t Clock_mask = 0;
+        uint32_t Clock_mask = 0;
         if (!SRV_Channels::function_assigned((SRV_Channel::Aux_servo_function_t)((uint8_t)SRV_Channel::k_ProfiLED_Clock))) {
             return false;
         }

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -44,7 +44,7 @@ public:
     void update();
 
     // return a bitmask of escs that are "present" which means they are responding to requests.  Bitmask matches RC outputs
-    uint16_t get_present_mask() const { return _esc_present_bitmask; }
+    uint32_t get_present_mask() const { return _esc_present_bitmask; }
 
 private:
 
@@ -106,8 +106,8 @@ private:
     const float amp_ms_to_mah = 1.0f / 3600.0f;  // for converting amp milliseconds to mAh
 
     // variables for updating bitmask of responsive escs
-    uint16_t _esc_present_bitmask;      // bitmask of which escs seem to be present
-    uint16_t _esc_present_bitmask_recent;   // bitmask of escs that have responded in the last second
+    uint32_t _esc_present_bitmask;      // bitmask of which escs seem to be present
+    uint32_t _esc_present_bitmask_recent;   // bitmask of escs that have responded in the last second
     uint32_t _esc_present_update_ms;    // system time _esc_present_bitmask was last updated
 
     // structure for sending motor lock command to ESC

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -105,14 +105,15 @@ const AP_Param::GroupInfo AP_UAVCAN::var_info[] = {
     // @Param: SRV_BM
     // @DisplayName: Output channels to be transmitted as servo over UAVCAN
     // @Description: Bitmask with one set for channel to be transmitted as a servo command over UAVCAN
-    // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8, 8: Servo 9, 9: Servo 10, 10: Servo 11, 11: Servo 12, 12: Servo 13, 13: Servo 14, 14: Servo 15
+    // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8, 8: Servo 9, 9: Servo 10, 10: Servo 11, 11: Servo 12, 12: Servo 13, 13: Servo 14, 14: Servo 15, 15: Servo 16, 16: Servo 17, 17: Servo 18, 18: Servo 19, 19: Servo 20, 20: Servo 21, 21: Servo 22, 22: Servo 23, 23: Servo 24, 24: Servo 25, 25: Servo 26, 26: Servo 27, 27: Servo 28, 28: Servo 29, 29: Servo 30, 30: Servo 31, 31: Servo 32
+
     // @User: Advanced
     AP_GROUPINFO("SRV_BM", 2, AP_UAVCAN, _servo_bm, 0),
 
     // @Param: ESC_BM
     // @DisplayName: Output channels to be transmitted as ESC over UAVCAN
     // @Description: Bitmask with one set for channel to be transmitted as a ESC command over UAVCAN
-    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16
+    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16, 16: ESC 17, 17: ESC 18, 18: ESC 19, 19: ESC 20, 20: ESC 21, 21: ESC 22, 22: ESC 23, 23: ESC 24, 24: ESC 25, 25: ESC 26, 26: ESC 27, 27: ESC 28, 28: ESC 29, 29: ESC 30, 30: ESC 31, 31: ESC 32
     // @User: Advanced
     AP_GROUPINFO("ESC_BM", 3, AP_UAVCAN, _esc_bm, 0),
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -580,7 +580,7 @@ void AP_UAVCAN::SRV_push_servos()
 
     for (uint8_t i = 0; i < UAVCAN_SRV_NUMBER; i++) {
         // Check if this channels has any function assigned
-        if (SRV_Channels::channel_function(i) > SRV_Channel::k_none) {
+        if (SRV_Channels::channel_function(i) >= SRV_Channel::k_none) {
             _SRV_conf[i].pulse = SRV_Channels::srv_channel(i)->get_output_pwm();
             _SRV_conf[i].esc_pending = true;
             _SRV_conf[i].servo_pending = true;

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -31,11 +31,11 @@
 #include <uavcan/protocol/param/GetSet.hpp>
 #include <uavcan/protocol/param/ExecuteOpcode.hpp>
 #include <uavcan/helpers/heap_based_pool_allocator.hpp>
-
+#include <SRV_Channel/SRV_Channel.h>
 
 
 #ifndef UAVCAN_SRV_NUMBER
-#define UAVCAN_SRV_NUMBER 18
+#define UAVCAN_SRV_NUMBER NUM_SERVO_CHANNELS
 #endif
 
 #define AP_UAVCAN_SW_VERS_MAJOR 1

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
@@ -19,7 +19,7 @@ const AP_Param::GroupInfo AP_Volz_Protocol::var_info[] = {
     // @Param: MASK
     // @DisplayName: Channel Bitmask
     // @Description: Enable of volz servo protocol to specific channels
-    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16,16:Channel17,17:Channel18,18:Channel19,19:Channel20,20:Channel21,21:Channel22,22:Channel23,23:Channel24,24:Channel25,25:Channel26,26:Channel27,28:Channel29,29:Channel30,30:Channel31,31:Channel32
     // @User: Standard
     AP_GROUPINFO("MASK",  1, AP_Volz_Protocol, bitmask, 0),
 
@@ -66,7 +66,7 @@ void AP_Volz_Protocol::update()
     uint8_t i;
     uint16_t value;
 
-    // loop for all 16 channels
+    // loop for all channels
     for (i=0; i<NUM_SERVO_CHANNELS; i++) {
         // check if current channel is needed for Volz protocol
         if (last_used_bitmask & (1U<<i)) {

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -107,7 +107,7 @@ public:
     bool pre_arm_check(bool report) const;
 
     // return the motor mask
-    uint16_t get_motor_mask() const { return _motor_mask; }
+    uint32_t get_motor_mask() const { return _motor_mask; }
 
     // returns true if the configured PWM type is digital and should have fixed endpoints
     bool is_digital_pwm_type() const;
@@ -216,7 +216,7 @@ private:
     float   _mainsail;  // requested mainsail input as a value from 0 to 100
     float   _wingsail;  // requested wing sail input as a value in the range +- 100
     float   _mast_rotation;  // requested mast rotation input as a value in the range +- 100
-    uint16_t _motor_mask;   // mask of motors configured with pwm_type
+    uint32_t _motor_mask;   // mask of motors configured with pwm_type
     frame_type _frame_type; // frame type requested at initialisation
 
     // omni variables

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2718,22 +2718,47 @@ bool GCS_MAVLINK::telemetry_delayed() const
  */
 void GCS_MAVLINK::send_servo_output_raw()
 {
-    uint16_t values[16] {};
-    hal.rcout->read(values, 16);
+    const uint32_t enabled_mask = ~SRV_Channels::get_output_channel_mask(SRV_Channel::k_GPIO);
+    if (enabled_mask == 0) {
+        return;
+    }
 
-    for (uint8_t i=0; i<16; i++) {
+#if NUM_SERVO_CHANNELS >= 17
+    static const uint8_t max_channels = 32;
+#else
+    static const uint8_t max_channels = 16;
+#endif
+
+    uint16_t values[max_channels] {};
+    hal.rcout->read(values, max_channels);
+    for (uint8_t i=0; i<max_channels; i++) {
         if (values[i] == 65535) {
             values[i] = 0;
         }
-    }    
-    mavlink_msg_servo_output_raw_send(
-            chan,
-            AP_HAL::micros(),
-            0,     // port
-            values[0],  values[1],  values[2],  values[3],
-            values[4],  values[5],  values[6],  values[7],
-            values[8],  values[9],  values[10], values[11],
-            values[12], values[13], values[14], values[15]);
+    }
+    if ((enabled_mask & 0xFFFF) != 0) {
+        mavlink_msg_servo_output_raw_send(
+                chan,
+                AP_HAL::micros(),
+                0,     // port
+                values[0],  values[1],  values[2],  values[3],
+                values[4],  values[5],  values[6],  values[7],
+                values[8],  values[9],  values[10], values[11],
+                values[12], values[13], values[14], values[15]);
+    }
+
+#if NUM_SERVO_CHANNELS >= 17
+    if ((enabled_mask & 0xFFFF0000) != 0) {
+        mavlink_msg_servo_output_raw_send(
+                chan,
+                AP_HAL::micros(),
+                1,     // port
+                values[16],  values[17],  values[18],  values[19],
+                values[20],  values[21],  values[22],  values[23],
+                values[24],  values[25],  values[26], values[27],
+                values[28], values[29], values[30], values[31]);
+    }
+#endif
 }
 
 

--- a/libraries/SITL/SIM_JSON_Master.cpp
+++ b/libraries/SITL/SIM_JSON_Master.cpp
@@ -159,7 +159,7 @@ void JSON_Master::receive(struct sitl_input &input)
 
         if (list->instance == master_instance) {
             // Use the servo outs from this instance
-            memcpy(input.servos,buffer.pwm,sizeof(input.servos));
+            memcpy(input.servos,buffer.pwm,sizeof(buffer.pwm));
         }
     }
 }

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -90,7 +90,7 @@ struct sitl_fdm {
 };
 
 // number of rc output channels
-#define SITL_NUM_CHANNELS 16
+#define SITL_NUM_CHANNELS 32
 
 class SIM {
 public:

--- a/libraries/SITL/SITL_Input.h
+++ b/libraries/SITL/SITL_Input.h
@@ -7,7 +7,7 @@
   microseconds
 */
 struct sitl_input {
-    uint16_t servos[16];
+    uint16_t servos[32];
     struct {
         float speed;      // m/s
         float direction;  // degrees 0..360

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -80,7 +80,7 @@ SRV_Channel::SRV_Channel(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
     // start with all pwm at zero
-    have_pwm_mask = ~uint16_t(0);
+    have_pwm_mask = ~uint32_t(0);
 }
 
 // convert a 0..range_max to a pwm

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -29,7 +29,7 @@
 #elif defined(HAL_BUILD_AP_PERIPH)
     #define NUM_SERVO_CHANNELS 0
 #else
-    #if !HAL_MINIMIZE_FEATURES
+    #if !HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024
         #define NUM_SERVO_CHANNELS 32
     #else
         #define NUM_SERVO_CHANNELS 16

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -641,6 +641,9 @@ private:
     AP_Int8 dshot_rate;
     AP_Int8 dshot_esc_type;
     AP_Int32 gpio_mask;
+#if NUM_SERVO_CHANNELS >= 17
+    AP_Int8 enable_32_channels;
+#endif
 
     // return true if passthrough is disabled
     static bool passthrough_disabled(void) {

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -620,6 +620,9 @@ private:
     // mask of outputs which are digitally reversible (eg. DShot-3D)
     static uint32_t reversible_mask;
 
+    // mask of channels with invalid funtions, eg GPIO
+    static uint32_t invalid_mask;
+
     SRV_Channel obj_channels[NUM_SERVO_CHANNELS];
 
     // override loop counter

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -29,9 +29,14 @@
 #elif defined(HAL_BUILD_AP_PERIPH)
     #define NUM_SERVO_CHANNELS 0
 #else
-    #define NUM_SERVO_CHANNELS 16
+    #if !HAL_MINIMIZE_FEATURES
+        #define NUM_SERVO_CHANNELS 32
+    #else
+        #define NUM_SERVO_CHANNELS 16
+    #endif
 #endif
 #endif
+static_assert(NUM_SERVO_CHANNELS <= 32, "More than 32 servos not supported");
 
 class SRV_Channels;
 
@@ -319,7 +324,7 @@ private:
     float get_output_norm(void);
 
     // a bitmask type wide enough for NUM_SERVO_CHANNELS
-    typedef uint16_t servo_mask_t;
+    typedef uint32_t servo_mask_t;
 
     // mask of channels where we have a output_pwm value. Cleared when a
     // scaled value is written. 
@@ -383,8 +388,8 @@ public:
     static void set_output_norm(SRV_Channel::Aux_servo_function_t function, float value);
 
     // get output channel mask for a function
-    static uint16_t get_output_channel_mask(SRV_Channel::Aux_servo_function_t function);
-    
+    static uint32_t get_output_channel_mask(SRV_Channel::Aux_servo_function_t function);
+
     // limit slew rate to given limit in percent per second
     static void set_slew_rate(SRV_Channel::Aux_servo_function_t function, float slew_rate, uint16_t range, float dt);
 
@@ -434,8 +439,8 @@ public:
     static void copy_radio_in_out(SRV_Channel::Aux_servo_function_t function, bool do_input_output=false);
 
     // copy radio_in to servo_out by channel mask
-    static void copy_radio_in_out_mask(uint16_t mask);
-    
+    static void copy_radio_in_out_mask(uint32_t mask);
+
     // setup failsafe for an auxiliary channel function, by pwm
     static void set_failsafe_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t pwm);
 
@@ -456,7 +461,7 @@ public:
     static void enable_aux_servos(void);
 
     // enable channels by mask
-    static void enable_by_mask(uint16_t mask);
+    static void enable_by_mask(uint32_t mask);
 
     // return the current function for a channel
     static SRV_Channel::Aux_servo_function_t channel_function(uint8_t channel);
@@ -520,14 +525,14 @@ public:
     static void push();
 
     // disable PWM output to a set of channels given by a mask. This is used by the AP_BLHeli code
-    static void set_disabled_channel_mask(uint16_t mask) { disabled_mask = mask; }
-    static uint16_t get_disabled_channel_mask() { return disabled_mask; }
+    static void set_disabled_channel_mask(uint32_t mask) { disabled_mask = mask; }
+    static uint32_t get_disabled_channel_mask() { return disabled_mask; }
 
     // add to mask of outputs which use digital (non-PWM) output and optionally can reverse thrust, such as DShot
-    static void set_digital_outputs(uint16_t dig_mask, uint16_t rev_mask);
+    static void set_digital_outputs(uint32_t dig_mask, uint32_t rev_mask);
 
     // return true if all of the outputs in mask are digital
-    static bool have_digital_outputs(uint16_t mask) { return mask != 0 && (mask & digital_mask) == mask; }
+    static bool have_digital_outputs(uint32_t mask) { return mask != 0 && (mask & digital_mask) == mask; }
 
     // return true if any of the outputs are digital
     static bool have_digital_outputs() { return digital_mask != 0; }
@@ -606,14 +611,14 @@ private:
 #endif  // AP_FETTEC_ONEWIRE_ENABLED
 
     // mask of disabled channels
-    static uint16_t disabled_mask;
+    static uint32_t disabled_mask;
 
     // mask of outputs which use a digital output protocol, not
     // PWM (eg. DShot)
-    static uint16_t digital_mask;
+    static uint32_t digital_mask;
     
     // mask of outputs which are digitally reversible (eg. DShot-3D)
-    static uint16_t reversible_mask;
+    static uint32_t reversible_mask;
 
     SRV_Channel obj_channels[NUM_SERVO_CHANNELS];
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -76,7 +76,13 @@ void SRV_Channel::output_ch(void)
  */
 void SRV_Channels::output_ch_all(void)
 {
-    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
+    uint8_t max_chan = NUM_SERVO_CHANNELS;
+#if NUM_SERVO_CHANNELS >= 17
+    if (_singleton != nullptr && _singleton->enable_32_channels.get() <= 0) {
+        max_chan = 16;
+    }
+#endif
+    for (uint8_t i = 0; i < max_chan; i++) {
         channels[i].output_ch();
     }
 }

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -178,10 +178,12 @@ void SRV_Channels::update_aux_servo_function(void)
     for (uint16_t i = 0; i < SRV_Channel::k_nr_aux_servo_functions; i++) {
         functions[i].channel_mask = 0;
     }
+    invalid_mask = 0;
 
     // set auxiliary ranges
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         if (!channels[i].valid_function()) {
+            invalid_mask |= 1U<<i;
             continue;
         }
         const uint16_t function = channels[i].function.get();
@@ -595,7 +597,7 @@ uint32_t SRV_Channels::get_output_channel_mask(SRV_Channel::Aux_servo_function_t
     if (SRV_Channel::valid_function(function)) {
         return functions[function].channel_mask;
     }
-    return 0;
+    return invalid_mask;
 }
 
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -244,7 +244,7 @@ void SRV_Channels::enable_aux_servos()
     set TRIM to either 1000 or 1500 depending on whether the channel
     is reversible
 */
-void SRV_Channels::set_digital_outputs(uint16_t dig_mask, uint16_t rev_mask) {
+void SRV_Channels::set_digital_outputs(uint32_t dig_mask, uint32_t rev_mask) {
     digital_mask |= dig_mask;
     reversible_mask |= rev_mask;
 
@@ -284,7 +284,7 @@ void SRV_Channels::set_digital_outputs(uint16_t dig_mask, uint16_t rev_mask) {
 }
 
 /// enable output channels using a channel mask
-void SRV_Channels::enable_by_mask(uint16_t mask)
+void SRV_Channels::enable_by_mask(uint32_t mask)
 {
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         if (mask & (1U<<i)) {
@@ -378,7 +378,7 @@ SRV_Channels::copy_radio_in_out(SRV_Channel::Aux_servo_function_t function, bool
   copy radio_in to radio_out for a channel mask
  */
 void
-SRV_Channels::copy_radio_in_out_mask(uint16_t mask)
+SRV_Channels::copy_radio_in_out_mask(uint32_t mask)
 {
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         if ((1U<<i) & mask) {
@@ -587,7 +587,7 @@ float SRV_Channels::get_slew_limited_output_scaled(SRV_Channel::Aux_servo_functi
 /*
   get mask of output channels for a function
  */
-uint16_t SRV_Channels::get_output_channel_mask(SRV_Channel::Aux_servo_function_t function)
+uint32_t SRV_Channels::get_output_channel_mask(SRV_Channel::Aux_servo_function_t function)
 {
     if (!initialised) {
         update_aux_servo_function();
@@ -824,7 +824,7 @@ void SRV_Channels::upgrade_parameters(void)
 // set RC output frequency on a function output
 void SRV_Channels::set_rc_frequency(SRV_Channel::Aux_servo_function_t function, uint16_t frequency_hz)
 {
-    uint16_t mask = 0;
+    uint32_t mask = 0;
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         SRV_Channel &c = channels[i];
         if (c.function == function) {

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -242,7 +242,16 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("_GPIO_MASK",  26, SRV_Channels, gpio_mask, 0),
-    
+
+#if (NUM_SERVO_CHANNELS >= 17)
+    // @Param: _32_ENABLE
+    // @DisplayName: Enable outputs 17 to 31
+    // @Description: This allows for up to 32 outputs, enabling parameters for outputs above 16
+    // @User: Advanced
+    // @Values: 0:Disabled,1:Enabled
+    AP_GROUPINFO_FLAGS("_32_ENABLE", 43, SRV_Channels, enable_32_channels, 0, AP_PARAM_FLAG_ENABLE),
+#endif
+
 #if (NUM_SERVO_CHANNELS >= 17)
     // @Group: 17_
     // @Path: SRV_Channel.cpp

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -68,6 +68,7 @@ AP_BLHeli *SRV_Channels::blheli_ptr;
 uint32_t SRV_Channels::disabled_mask;
 uint32_t SRV_Channels::digital_mask;
 uint32_t SRV_Channels::reversible_mask;
+uint32_t SRV_Channels::invalid_mask;
 
 bool SRV_Channels::disabled_passthrough;
 bool SRV_Channels::initialised;

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -356,6 +356,12 @@ SRV_Channels::SRV_Channels(void)
     // setup ch_num on channels
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         channels[i].ch_num = i;
+#if NUM_SERVO_CHANNELS > 16
+        if (i >= 16) {
+            // default to GPIO, this disables the pin and stops logging
+            channels[i].function.set_default(SRV_Channel::k_GPIO);
+        }
+#endif
     }
 
 #if AP_FETTEC_ONEWIRE_ENABLED

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -65,9 +65,9 @@ uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
 AP_BLHeli *SRV_Channels::blheli_ptr;
 #endif
 
-uint16_t SRV_Channels::disabled_mask;
-uint16_t SRV_Channels::digital_mask;
-uint16_t SRV_Channels::reversible_mask;
+uint32_t SRV_Channels::disabled_mask;
+uint32_t SRV_Channels::digital_mask;
+uint32_t SRV_Channels::reversible_mask;
 
 bool SRV_Channels::disabled_passthrough;
 bool SRV_Channels::initialised;
@@ -236,12 +236,108 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
 
     // @Param: _GPIO_MASK
     // @DisplayName: Servo GPIO mask
-    // @Description: This sets a bitmask of outputs which will be available as GPIOs. Any auxiliary output with either the function set to -1 or with the corresponding bit set in this mask will be available for use as a GPIO pin
-    // @Bitmask: 0:Servo 1, 1:Servo 2, 2:Servo 3, 3:Servo 4, 4:Servo 5, 5:Servo 6, 6:Servo 7, 7:Servo 8, 8:Servo 9, 9:Servo 10, 10:Servo 11, 11:Servo 12, 12:Servo 13, 13:Servo 14, 14:Servo 15, 15:Servo 16
+    // @Description: This sets a bitmask of outputs which will be available as GPIOs. Any auxillary output with either the function set to -1 or with the corresponding bit set in this mask will be available for use as a GPIO pin
+    // @Bitmask: 0:Servo 1, 1:Servo 2, 2:Servo 3, 3:Servo 4, 4:Servo 5, 5:Servo 6, 6:Servo 7, 7:Servo 8, 8:Servo 9, 9:Servo 10, 10:Servo 11, 11:Servo 12, 12:Servo 13, 13:Servo 14, 14:Servo 15, 15:Servo 16, 16:Servo 17, 17:Servo 18, 18:Servo 19, 19:Servo 20, 20:Servo 21, 21:Servo 22, 22:Servo 23, 23:Servo 24, 24:Servo 25, 25:Servo 26, 26:Servo 27, 27:Servo 28, 28:Servo 29, 29:Servo 30, 30:Servo 31, 31:Servo 32
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("_GPIO_MASK",  26, SRV_Channels, gpio_mask, 0),
     
+#if (NUM_SERVO_CHANNELS >= 17)
+    // @Group: 17_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[16], "17_",  27, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 18)
+    // @Group: 18_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[17], "18_", 28, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 19)
+    // @Group: 19_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[18], "19_",  29, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 20)
+    // @Group: 20_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[19], "20_",  30, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 21)
+    // @Group: 21_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[20], "21_",  31, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 22)
+    // @Group: 22_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[21], "22_",  32, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 23)
+    // @Group: 23_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[22], "23_",  33, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 24)
+    // @Group: 24_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[23], "24_",  34, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 25)
+    // @Group: 25_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[24], "25_",  35, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 26)
+    // @Group: 26_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[25], "26_",  36, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 27)
+    // @Group: 27_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[26], "27_",  37, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 28)
+    // @Group: 28_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[27], "28_",  38, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 29)
+    // @Group: 29_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[28], "29_",  39, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 30)
+    // @Group: 30_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[29], "30_",  40, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 31)
+    // @Group: 31_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[30], "31_",  41, SRV_Channels, SRV_Channel),
+#endif
+
+#if (NUM_SERVO_CHANNELS >= 32)
+    // @Group: 32_
+    // @Path: SRV_Channel.cpp
+    AP_SUBGROUPINFO(obj_channels[31], "32_",  42, SRV_Channels, SRV_Channel),
+#endif
+
     AP_GROUPEND
 };
 

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -237,7 +237,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
 
     // @Param: _GPIO_MASK
     // @DisplayName: Servo GPIO mask
-    // @Description: This sets a bitmask of outputs which will be available as GPIOs. Any auxillary output with either the function set to -1 or with the corresponding bit set in this mask will be available for use as a GPIO pin
+    // @Description: This sets a bitmask of outputs which will be available as GPIOs. Any auxiliary output with either the function set to -1 or with the corresponding bit set in this mask will be available for use as a GPIO pin
     // @Bitmask: 0:Servo 1, 1:Servo 2, 2:Servo 3, 3:Servo 4, 4:Servo 5, 5:Servo 6, 6:Servo 7, 7:Servo 8, 8:Servo 9, 9:Servo 10, 10:Servo 11, 11:Servo 12, 12:Servo 13, 13:Servo 14, 14:Servo 15, 15:Servo 16, 16:Servo 17, 17:Servo 18, 18:Servo 19, 19:Servo 20, 20:Servo 21, 21:Servo 22, 22:Servo 23, 23:Servo 24, 24:Servo 25, 25:Servo 26, 26:Servo 27, 27:Servo 28, 28:Servo 29, 29:Servo 30, 30:Servo 31, 31:Servo 32
     // @User: Advanced
     // @RebootRequired: True


### PR DESCRIPTION
This allows up to 32 servo outs, it also adds logging for servos 15-32. Tested in SITL by assigning functions and looking in at the new log.

No doubt I have missed some bitmasks somewhere, unfortunately since we have no hardware that supports more than 16 direct outs atm its hard to test the HAL changes. 

Main use case would be for CAN/Sbus servos (although we need to add a second sbus out range for this) so you can free up the physical servo outs.