### PR TITLE
AP_Compass: removed error on BMM150

### DIFF
--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -236,7 +236,6 @@ bool AP_Compass_BMM150::init()
     return true;
 
 bus_error:
-    hal.console->printf("BMM150: Bus communication error\n");
     _dev->get_semaphore()->give();
     return false;
 }


### PR DESCRIPTION
it may be probed at multiple addresses, don't throw lots of errors