### PR TITLE
AP_Notify: don't do startup tone on AP_Periph devices

### DIFF
--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -127,7 +127,9 @@ bool AP_ToneAlarm::init()
     }
 #endif
 
+#ifndef HAL_BUILD_AP_PERIPH
     play_tone(AP_NOTIFY_TONE_STARTUP);
+#endif
     return true;
 }
 


### PR DESCRIPTION
getting the startup tone twice on every boot is annoying
tested with a CUAV_GPS, it fixes the 2nd beep we get