### PR TITLE
Create our own RC Thread in autotest

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import time
 import traceback
+import threading
 from distutils.dir_util import copy_tree
 
 import rover
@@ -31,6 +32,7 @@ from pysim import util
 from pymavlink import mavutil
 from pymavlink.generator import mavtemplate
 
+tester = None
 
 def buildlogs_dirpath():
     return os.getenv("BUILDLOGS", util.reltopdir("../buildlogs"))
@@ -237,9 +239,14 @@ def test_prerequisites():
 
 def alarm_handler(signum, frame):
     """Handle test timeout."""
-    global results, opts
+    global results, opts, tester
     try:
         print("Alarm handler called")
+        if tester is not None:
+            if tester.rc_thread is not None:
+                tester.rc_thread_should_quit = True
+                tester.rc_thread.join()
+                tester.rc_thread = None
         results.add('TIMEOUT',
                     '<span class="failed-text">FAILED</span>',
                     opts.timeout)
@@ -360,6 +367,7 @@ def run_specific_test(step, *args, **kwargs):
     (testname, test) = t
 
     tester_class = tester_class_map[testname]
+    global tester
     tester = tester_class(*args, **kwargs)
 
     print("Got %s" % str(tester))
@@ -460,9 +468,13 @@ def run_step(step):
 
     # handle "test.Copter" etc:
     if step in tester_class_map:
-        t = tester_class_map[step](binary, **fly_opts)
-        return (t.autotest(), t)
+        # create an instance of the tester class:
+        global tester
+        tester = tester_class_map[step](binary, **fly_opts)
+        # run the test and return its result and the tester itself
+        return (tester.autotest(), tester)
 
+    # handle "test.Copter.CPUFailsafe" etc:
     specific_test_to_run = find_specific_test_to_run(step)
     if specific_test_to_run is not None:
         return run_specific_test(specific_test_to_run, binary, **fly_opts)
@@ -677,6 +689,14 @@ def run_tests(steps):
                     print("    %s (%s) (see %s)" % (desc, exception, debug_filename))
 
         print("FAILED %u tests: %s" % (len(failed), failed))
+
+    global tester
+    if tester is not None and tester.rc_thread is not None:
+        if passed:
+            print("BAD: RC Thread still alive after tests passed")
+        tester.rc_thread_should_quit = True
+        tester.rc_thread.join()
+        tester.rc_thread = None
 
     util.pexpect_close_all()
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -351,9 +351,7 @@ class AutoTestRover(AutoTest):
         self.load_mission(filename)
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        self.mavproxy.send('switch 4\n')  # auto mode
-        self.set_rc(3, 1500)
-        self.wait_mode('AUTO')
+        self.change_mode('AUTO')
         self.wait_waypoint(1, 4, max_dist=5)
         self.mavproxy.expect("Mission Complete")
         self.disarm_vehicle()
@@ -575,6 +573,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress("Pin mask changed after relay command")
 
     def test_setting_modes_via_mavproxy_switch(self):
+        self.customise_SITL_commandline([
+            "--rc-in-port", "5502",
+        ])
         self.load_mission(self.arming_test_mission())
         self.wait_ready_to_arm()
         fnoo = [(1, 'MANUAL'),
@@ -635,12 +636,12 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.context_push()
         ex = None
         try:
-            self.set_parameter("MODE5", 1)
-            self.mavproxy.send('switch 1\n')  # random mode
-            self.wait_heartbeat()
-            self.change_mode('MANUAL')
-            self.mavproxy.send('switch 5\n')  # acro mode
-            self.wait_mode("ACRO")
+            # from mavproxy_rc.py
+            mapping = [ 0, 1165, 1295, 1425, 1555, 1685, 1815 ]
+            self.set_parameter("MODE1", 1)  # acro
+            self.set_rc(8, mapping[1])
+            self.wait_mode('ACRO')
+
             self.set_rc(9, 1000)
             self.set_rc(10, 1000)
             self.set_parameter("RC9_OPTION", 53) # steering


### PR DESCRIPTION
This removes the dependency on MAVProxy to create RC inputs into SITL for us.

We still actually test MAVProxy's functionality there in the `switch 3` tests

