### PR TITLE
Copter: fix nav_delay

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1368,7 +1368,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
 {
     nav_delay_time_start_ms = millis();
 
-    if (cmd.content.nav_delay.seconds > 0) {
+    if (cmd.content.nav_delay.seconds >= 0) {
         // relative delay
         nav_delay_time_max_ms = cmd.content.nav_delay.seconds * 1000; // convert seconds to milliseconds
     } else {


### PR DESCRIPTION
In https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_DELAY, it states "-1 to enable time-of-day fields" in the field Delay. In current codes. a MAV_CMD_NAV_DELAY with all field 0 will make copter to wait until 00:00:00, instead of a 0s delay