### PR TITLE
autotest: automatically reboot sitl on context pop

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1870,7 +1870,6 @@ class AutoTestCopter(AutoTest):
     # fly_optical_flow_limits - test EKF navigation limiting
     def fly_optical_flow_limits(self):
         ex = None
-        self.context_push()
         try:
 
             self.set_parameter("SIM_FLOW_ENABLE", 1)
@@ -1933,9 +1932,7 @@ class AutoTestCopter(AutoTest):
             ex = e
 
         self.set_rc(2, 1500)
-        self.context_pop()
         self.disarm_vehicle(force=True)
-        self.reboot_sitl()
 
         if ex is not None:
             raise ex
@@ -3872,7 +3869,6 @@ class AutoTestCopter(AutoTest):
 
     def test_mount(self):
         ex = None
-        self.context_push()
         old_srcSystem = self.mav.mav.srcSystem
         self.mav.mav.srcSystem = 250
         self.set_parameter("DISARM_DELAY", 0)
@@ -4292,11 +4288,9 @@ class AutoTestCopter(AutoTest):
         except Exception as e:
             self.print_exception_caught(e)
             ex = e
-        self.context_pop()
 
         self.mav.mav.srcSystem = old_srcSystem
         self.disarm_vehicle(force=True)
-        self.reboot_sitl() # to handle MNT_TYPE changing
 
         if ex is not None:
             raise ex
@@ -4916,8 +4910,6 @@ class AutoTestCopter(AutoTest):
     def fly_precision_companion(self):
         """Use Companion PrecLand backend precision messages to loiter."""
 
-        self.context_push()
-
         ex = None
         try:
             self.set_parameter("PLND_ENABLED", 1)
@@ -4965,10 +4957,9 @@ class AutoTestCopter(AutoTest):
             self.print_exception_caught(e)
             ex = e
 
-        self.context_pop()
         self.zero_throttle()
         self.disarm_vehicle(force=True)
-        self.reboot_sitl()
+
         self.progress("All done")
 
         if ex is not None:
@@ -5313,9 +5304,8 @@ class AutoTestCopter(AutoTest):
             self.progress("Caught exception: %s" %
                           self.get_exception_stacktrace(e))
             ex = e
-        self.context_pop()
         self.disarm_vehicle(force=True)
-        self.reboot_sitl()
+        self.context_pop()
         if ex is not None:
             raise ex
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7048,12 +7048,22 @@ Also, ignores heartbeats not from our target system'''
             if numlogs != 2 or log_num != 1 or size <= 0:
                 raise NotAchievedException("Unexpected log information %d %d %d" % (log_num, numlogs, lastlog))
             self.progress("Log size: %d" % size)
+            self.progress("LOG_DISARMED is %f" % self.get_parameter("LOG_DISARMED"))
             self.reboot_sitl()
             # This starts a new log with a time of 0, wait for arm so that we can insert the correct time
             self.wait_ready_to_arm()
             # Third log created here
             mavproxy.send("log list\n")
-            mavproxy.expect("Log 1  numLogs 3 lastLog 3 size")
+            mavproxy.expect("Log ([0-9]+)  numLogs ([0-9]+) lastLog ([0-9]+) size ([0-9]+)", timeout=120)
+            log_num = int(mavproxy.match.group(1))
+            numlogs = int(mavproxy.match.group(2))
+            lastlog = int(mavproxy.match.group(3))
+            if log_num != 1:
+                raise NotAchievedException("Wanted log_num == 1 got %u" % log_num)
+            if numlogs != 3:
+                raise NotAchievedException("Wanted numlogs == 3 got %u" % numlogs)
+            if lastlog != 3:
+                raise NotAchievedException("Wanted lastlog == 3 got %u" % lastlog)
 
             # Download second and third logs
             mavproxy.send("log download 2 logs/dataflash-log-002.BIN\n")

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -235,7 +235,6 @@ class AutoTestRover(AutoTest):
 
     def test_sprayer(self):
         """Test sprayer functionality."""
-        self.context_push()
         ex = None
         try:
             rc_ch = 5
@@ -342,13 +341,12 @@ class AutoTestRover(AutoTest):
             self.wait_servo_channel_value(pump_ch, pump_ch_min)
             self.set_rc(3, 1000) # start driving forward
 
+            self.disarm_vehicle(force=True)
+
             self.progress("Sprayer OK")
         except Exception as e:
             self.print_exception_caught(e)
             ex = e
-        self.context_pop()
-        self.disarm_vehicle(force=True)
-        self.reboot_sitl()
         if ex:
             raise ex
 
@@ -570,7 +568,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress("RTL Mission OK (%fm)" % home_distance)
 
     def drive_fence_ac_avoidance(self):
-        self.context_push()
         ex = None
         try:
             self.load_fence("rover-fence-ac-avoid.txt")
@@ -595,13 +592,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             # watch for speed zero
             self.wait_groundspeed(0, 0.2, timeout=120)
 
+            self.disarm_vehicle(force=True)
+
         except Exception as e:
             self.print_exception_caught(e)
             ex = e
-        self.context_pop()
-        self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
-        self.disarm_vehicle(force=True)
-        self.reboot_sitl()
         if ex:
             raise ex
 
@@ -803,7 +798,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.disarm_vehicle()
 
     def test_rc_overrides(self):
-        self.context_push()
         self.set_parameter("SYSID_MYGCS", self.mav.source_system)
         ex = None
         try:
@@ -1034,6 +1028,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 if self.get_rc_channel_value(ch) != ch_override_value:
                     raise NotAchievedException("Did not maintain value")
 
+            self.disarm_vehicle()
+
             self.context_pop()
 
             self.end_subtest("Checking higher-channel semantics")
@@ -1042,15 +1038,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.print_exception_caught(e)
             ex = e
 
-        self.context_pop()
-        self.disarm_vehicle()
-        self.reboot_sitl()
-
         if ex is not None:
             raise ex
 
     def test_manual_control(self):
-        self.context_push()
         self.set_parameter("SYSID_MYGCS", self.mav.source_system)
         ex = None
         try:
@@ -1127,13 +1118,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.progress("Waiting for RC to revert to normal RC input")
             self.wait_rc_channel_value(3, normal_rc_throttle, timeout=10)
 
+            self.disarm_vehicle()
+
         except Exception as e:
             self.print_exception_caught(e)
             ex = e
-
-        self.context_pop()
-        self.disarm_vehicle()
-        self.reboot_sitl()
 
         if ex is not None:
             raise ex


### PR DESCRIPTION
If we reboot SITL while a context is open then when we close it we will
also reboot SITL after reverting the parameters.

This will fix some common classes of bugs in SITL tests, and may let us
get rid of a lot of contexts.