### PR TITLE
autotest: fix nav delay

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2904,7 +2904,7 @@ class AutoTestCopter(AutoTest):
                 command, # command
                 0, # current
                 1, # autocontinue
-                0, # p1 (relative seconds)
+                -1, # p1 (relative seconds)
                 hours, # p2
                 mins, # p3
                 secs, # p4


### PR DESCRIPTION
In https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_DELAY, it states "-1 to enable time-of-day fields" in the field Delay. This is for #16320 and does not affect current tests