### PR TITLE
autotest: added copter-bfx params

### DIFF
--- a/Tools/autotest/default_params/copter-bfx.parm
+++ b/Tools/autotest/default_params/copter-bfx.parm
@@ -1,0 +1,1 @@
+FRAME_TYPE     12


### PR DESCRIPTION
this is in the vehicle list but missing params
thanks to @peterbarker for noticing
