### PR TITLE
Rover: implement lateral acceleration limiting for waypoint navigation

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -409,7 +409,8 @@ float Mode::calc_speed_nudge(float target_speed, bool reversed)
     }
 }
 
-// calculate the lateral acceleration limited turn rate
+// calculate the lateral acceleration limited turn rate in rad/s
+// desired_turn_rate is in rad/s
 //
 // - lateral acceleration limiting has similar effect to motor speed scaling
 //   (MOT_SPD_SCA_BASE) as both parameters modify (decrease) the turn rate.
@@ -454,11 +455,11 @@ void Mode::navigate_to_waypoint()
         // sailboats use heading controller when tacking upwind
         desired_heading_cd = g2.sailboat.calc_heading(desired_heading_cd);
         // use pivot turn rate for tacks
-        const float desired_turn_rate = g2.sailboat.tacking() ? g2.wp_nav.get_pivot_rate() : 0.0f;
+        const float desired_turn_rate = g2.sailboat.tacking() ? radians(g2.wp_nav.get_pivot_rate()) : 0.0f;
         const float turn_rate = calc_accel_limited_turn_rate(desired_turn_rate);
 
         // call heading steering controller
-        calc_steering_to_heading(desired_heading_cd, turn_rate);
+        calc_steering_to_heading(desired_heading_cd, degrees(turn_rate));
     } else {
         const float desired_turn_rate = g2.wp_nav.get_turn_rate_rads();
         const float turn_rate = calc_accel_limited_turn_rate(desired_turn_rate);

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -191,7 +191,7 @@ protected:
     //  reversed should be true if the vehicle is intentionally backing up which allows the pilot to increase the backing up speed by pulling the throttle stick down
     float calc_speed_nudge(float target_speed, bool reversed);
 
-    // calculate the lateral acceleration limited turn rate
+    // calculate the lateral acceleration limited turn rate in rad/s
     // desired_turn_rate should be in rad/s
     float calc_accel_limited_turn_rate(float desired_turn_rate) const;
 

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -191,6 +191,10 @@ protected:
     //  reversed should be true if the vehicle is intentionally backing up which allows the pilot to increase the backing up speed by pulling the throttle stick down
     float calc_speed_nudge(float target_speed, bool reversed);
 
+    // calculate the lateral acceleration limited turn rate
+    // desired_turn_rate should be in rad/s
+    float calc_accel_limited_turn_rate(float desired_turn_rate) const;
+
 protected:
 
     // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments


### PR DESCRIPTION
This PR implements lateral acceleration (g-force) limiting for the Rover waypoint navigation mode.

The acceleration limit is determined by the parameter TURN_MAX_G which is currently applied in Rover steering mode. The change makes the code consistent with the wiki entry [Tuning Navigation](https://ardupilot.org/rover/docs/rover-tuning-navigation.html#other-parameters) which indicates that TURN_MAX_G should also be effective for the L1 controller.

The code has the following behaviours:

- limiting is disabled if TURN_MAX_G is not positive
- limiting is not applied if the forward speed is zero

Testing:

Tools/scripts/build_all.sh runs clean on Ubuntu 18.04.5 LTS (VM).

Simulation:

The code was tested in simulation using SITL / Gazebo with a land yacht rover. The attached zip file contains screenshots of the simulation for a variety of parameter settings. For sailing vehicles increasing the wind speed is equivalent to increasing drive motor output and simulation exhibits the behaviours:

- at constant TURN_MAX_G the turning radius increases as wind speed increases
- at constant wind speed the turning radius decreases as TURN_MAX_G increases

![max_turn_g=0 6_wind=8 0](https://user-images.githubusercontent.com/24916364/104729351-3853e100-5730-11eb-8875-e636b4dd6e64.jpg)

[max_turn_g_tests.zip](https://github.com/ArduPilot/ardupilot/files/5820567/max_turn_g_tests.zip)