### PR TITLE
Fix dma_resolver's amnesia issue

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2088,6 +2088,7 @@ def process_file(filename):
     except Exception:
         error("Unable to open file %s" % filename)
     for line in f.readlines():
+        line = line.split('#')[0] # ensure we discard the comments
         line = line.strip()
         if len(line) == 0 or line[0] == '#':
             continue


### PR DESCRIPTION
Before:
```
.....Starting lookup for SPI4_TX
........Possibility for SPI4_TX (2, 1, 4)
............ Checking  SPI4_TX (2, 1)
.................... Collision TIM1_CH1 (2, 1)
Trying to Resolve Conflict:  TIM1_CH1(2,1) SPI4_TX(2,1)
............ Checking  TIM1_CH1 (2, 6)
.................... Collision TIM1_CH2 (2, 6)
Trying to Resolve Conflict:  TIM1_CH2(2,6) TIM1_CH1(2,6)
............ Checking  TIM1_CH2 (2, 2)
.................... Collision USART6_RX (2, 2)
Trying to Resolve Conflict:  USART6_RX(2,2) TIM1_CH2(2,2)
............ Checking  USART6_RX (2, 1)
.................... Collision TIM1_CH1 (2, 1)
Trying to Resolve Conflict:  TIM1_CH1(2,1) USART6_RX(2,1)
............ Checking  TIM1_CH1 (2, 6)
.................... Collision TIM1_CH2 (2, 6)
............ Checking  TIM1_CH1 (2, 3)
....................... Solved .......... TIM1_CH1 (2, 3)
....................... Resolving TIM1_CH1 (2, 3)
....................... Resolving USART6_RX (2, 1)
....................... Resolving TIM1_CH2 (2, 2)
....................... Resolving TIM1_CH1 (2, 6)
....................... Setting SPI4_TX (2, 1)
```

After:
```
.....Starting lookup for SPI4_TX
........Possibility for SPI4_TX (2, 1, 4)
............ Checking  SPI4_TX (2, 1) without []
.................... Collision TIM1_CH1 (2, 1)
Trying to Resolve Conflict:  TIM1_CH1(2,1) SPI4_TX(2,1)
............ Checking  TIM1_CH1 (2, 6) without [(2, 1)]
.................... Collision TIM1_CH2 (2, 6)
Trying to Resolve Conflict:  TIM1_CH2(2,6) TIM1_CH1(2,6)
............ Checking  TIM1_CH2 (2, 2) without [(2, 1), (2, 6)]
.................... Collision USART6_RX (2, 2)
Trying to Resolve Conflict:  USART6_RX(2,2) TIM1_CH2(2,2)
....................... UnSolved !!!!!!!! TIM1_CH2 (2, 2)
....................... UnSolved !!!!!!!! TIM1_CH1 (2, 6)
............ Checking  TIM1_CH1 (2, 3) without [(2, 1)]
....................... Solved .......... TIM1_CH1 (2, 3)
....................... Resolving TIM1_CH1 (2, 3)
....................... Setting SPI4_TX (2, 1)
```

Another change which is outside the scope of this issue, but there was this recurse parameter which is always False, its unclear as to what its purpose is. The parameter was added in this commit https://github.com/ArduPilot/ardupilot/commit/cb77b064609b3744b432bbd65c58f37b297ca46c . 
