### PR TITLE
AP_DAL: add 10k to SITL memory available

### DIFF
--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -103,7 +103,11 @@ public:
     // ramifications of being out of memory are that you don't start
     // the EKF, so the simplicity of having one value for the entire
     // frame is worthwhile.
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    uint32_t available_memory() const { return _RFRN.available_memory + 10240; }
+#else
     uint32_t available_memory() const { return _RFRN.available_memory; }
+#endif
 
     int8_t get_ekf_type(void) const {
         return _RFRN.ekf_type;


### PR DESCRIPTION
this is needed as the SITL data structures are larger than on STM32
due to pointer size. This means we sometimes fail to replay in SITL as
we refuse to allocate an EKF core