### PR TITLE
AP_ARMING: Allow bypass of baro check for arm in no baro bds

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -75,7 +75,7 @@ extern const AP_HAL::HAL& hal;
 const AP_Param::GroupInfo AP_Arming::var_info[] = {
 
     // @Param{Plane, Rover}: REQUIRE
-    // @DisplayName: Require Arming Motors 
+    // @DisplayName: Require Arming Motors
     // @Description: Arming disabled until some requirements are met. If 0, there are no requirements (arm immediately).  If 1, require rudder stick or GCS arming before arming motors and sends the minimum throttle PWM value to the throttle channel when disarmed.  If 2, require rudder stick or GCS arming and send 0 PWM to throttle channel when disarmed. See the ARMING_CHECK_* parameters to see what checks are done before arming. Note, if setting this parameter to 0 a reboot is required to arm the plane.  Also note, even with this parameter at 0, if ARMING_CHECK parameter is not also zero the plane may fail to arm throttle at boot due to a pre-arm check failure.
     // @Values: 0:Disabled,1:THR_MIN PWM when disarmed,2:0 PWM when disarmed
     // @User: Advanced
@@ -344,7 +344,7 @@ bool AP_Arming::ins_checks(bool report)
             check_failed(ARMING_CHECK_INS, report, "3D Accel calibration needed");
             return false;
         }
-        
+
         //check if accelerometers have calibrated and require reboot
         if (ins.accel_cal_requires_reboot()) {
             check_failed(ARMING_CHECK_INS, report, "Accels calibrated requires reboot");
@@ -525,7 +525,7 @@ bool AP_Arming::battery_checks(bool report)
     return true;
 }
 
-bool AP_Arming::hardware_safety_check(bool report) 
+bool AP_Arming::hardware_safety_check(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_SWITCH)) {
@@ -954,7 +954,7 @@ bool AP_Arming::camera_checks(bool display_failure)
 
 bool AP_Arming::osd_checks(bool display_failure) const
 {
-#if OSD_PARAM_ENABLED && OSD_ENABLED 
+#if OSD_PARAM_ENABLED && OSD_ENABLED
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_CAMERA)) {
         const AP_OSD *osd = AP::osd();
         if (osd == nullptr) {
@@ -1116,7 +1116,9 @@ bool AP_Arming::pre_arm_checks(bool report)
 #endif
 
     return hardware_safety_check(report)
+#ifndef HAL_BARO_ALLOW_INIT_NO_BARO
         &  barometer_checks(report)
+#endif
         &  ins_checks(report)
         &  compass_checks(report)
         &  gps_checks(report)
@@ -1161,7 +1163,7 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
             return false;
         }
     }
-    
+
     // note that this will prepare AP_Logger to start logging
     // so should be the last check to be done before arming
 
@@ -1232,7 +1234,7 @@ bool AP_Arming::disarm(const AP_Arming::Method method, bool do_disarm_checks)
     return true;
 }
 
-AP_Arming::Required AP_Arming::arming_required() 
+AP_Arming::Required AP_Arming::arming_required()
 {
     return (AP_Arming::Required)require.get();
 }


### PR DESCRIPTION
to allow arming of boards with no baro...still must change all EKF POSZ source to GPS, however..

sorry for the existing extraneous whitespace deletions, my editor does that automatically...

change to allow DCM  to use GPS alt is still needed for safety....but this should allow flight testing of GPS only setups with the boards that do not include a baro...this would allow many multiquad boards to be ported to ArduPilot