### PR TITLE
autotest: reboot after moving from EKF type 10 to EKF type 2

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4553,6 +4553,9 @@ class AutoTestCopter(AutoTest):
 
         self.context_pop()
 
+        # must reboot after we move away from EKF type 10 to EKF2 or EKF3
+        self.reboot_sitl()
+
         if ex is not None:
             raise ex
 


### PR DESCRIPTION
Bad things happen with home set but origin not