### PR TITLE
sim_vehicle fix

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -1274,7 +1274,7 @@ if cmd_opts.hil:
 
 else:
     if not cmd_opts.no_rebuild:  # i.e. we should rebuild
-        do_build(vehicle_dir, cmd_opts, frame_infos)
+        do_build(cmd_opts, frame_infos)
 
     if cmd_opts.fresh_params:
         do_build_parameters(cmd_opts.vehicle)


### PR DESCRIPTION
This fix fixes this error:

```
$ sim_vehicle.py -v ArduPlane -L Snarbyeidet --console --map --osd
SIM_VEHICLE: Start
SIM_VEHICLE: Killing tasks
SIM_VEHICLE: Starting up at [69.775839, 19.548929, 87.0, 170.0] (Snarbyeidet)
Traceback (most recent call last):
  File "/home/andre/prog/ardupilot/Tools/autotest/sim_vehicle.py", line 1277, in <module>
    do_build(vehicle_dir, cmd_opts, frame_infos)
TypeError: do_build() takes 2 positional arguments but 3 were given
SIM_VEHICLE: Killing tasks

```

It is hard to comprehend why this has been an issue for so long, or why others do not seem to be affected by it. - maybe ther eis more to it.