### PR TITLE
AP_HAL_SITL: avoid nullptr dereference in Replay

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -606,7 +606,9 @@ void SITL_State::_fdm_input_local(void)
     struct sitl_input input;
 
     // check for direct RC input
-    _check_rc_input();
+    if (_sitl != nullptr) {
+        _check_rc_input();
+    }
 
     // construct servos structure for FDM
     _simulator_servos(input);


### PR DESCRIPTION
We don't initialise the SITL pointer in Replay.

```
#5  0x000056551967b61d in HALSITL::SITL_State::_read_rc_sitl_input (this=0x5655199bab40 <sitlState>) at ../../libraries/AP_HAL_SITL/SITL_State.cpp:540
        pwm = 0
        i = 0 '\000'
        pwm_pkt = {pwm = {1500, 1500, 1900, 1500, 1800, 1500 <repeats 11 times>}}
        size = 32
#6  0x000056551967b55b in HALSITL::SITL_State::_check_rc_input (this=0x5655199bab40 <sitlState>) at ../../libraries/AP_HAL_SITL/SITL_State.cpp:516
        count = 0
#7  0x000056551967ba3c in HALSITL::SITL_State::_fdm_input_local (this=0x5655199bab40 <sitlState>) at ../../libraries/AP_HAL_SITL/SITL_State.cpp:609
        input = {servos = {1500, 1500, 1000, 1500, 1000 <repeats 12 times>}, wind = {speed = 0, direction = 0, turbulence = 0, dir_z = 0}}
#8  0x0000565519679673 in HALSITL::SITL_State::_fdm_input_step (this=0x5655199bab40 <sitlState>) at ../../libraries/AP_HAL_SITL/SITL_State.cpp:153
        last_pwm_input = 0
#9  0x0000565519679a55 in HALSITL::SITL_State::wait_clock (this=0x5655199bab40 <sitlState>, wait_time_usec=3001) at ../../libraries/AP_HAL_SITL/SITL_State.cpp:208
No locals.
#10 0x000056551967d486 in HALSITL::Scheduler::delay_microseconds (this=0x5655199bf280 <sitlScheduler>, usec=1000) at ../../libraries/AP_HAL_SITL/Scheduler.cpp:94
        dtime = 0
        start = 2001
#11 0x000056551967d4c8 in HALSITL::Scheduler::delay (this=0x5655199bf280 <sitlScheduler>, ms=1) at ../../libraries/AP_HAL_SITL/Scheduler.cpp:103
        start = 2
        now = 2
#12 0x0000565519638cfd in GCS_MAVLINK::init (this=0x56551a739ea0, instance=0 '\000') at ../../libraries/GCS_MAVLink/GCS_Common.cpp:131
        i = 2 '\002'
```
