### PR TITLE
Copter: verify land and payload place record flow-of-control internal error

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1558,7 +1558,7 @@ bool ModeAuto::verify_land()
 
         default:
             // this should never happen
-            // TO-DO: log an error
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
             retval = true;
             break;
     }
@@ -1720,7 +1720,7 @@ bool ModeAuto::verify_payload_place()
         return true;
     default:
         // this should never happen
-        // TO-DO: log an error
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         return true;
     }
     // should never get here


### PR DESCRIPTION
This tiny PR clears up to ToDo items in Copter by recording an flow-of-control internal error when two supposedly impossible things happen.

It is very unlikely these will ever happen but if they do for some reason this will help us catch the issue and correct it.

This main reason to raise this PR is it every-so-slightly reduces the complexity of the s-curves PR: https://github.com/ArduPilot/ardupilot/pull/15896