### PR TITLE
Plane: mark q modes as not having auto-throttle control

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -153,14 +153,11 @@ bool AP_Arming_Plane::arm_checks(AP_Arming::Method method)
             check_failed(true, "Non-zero throttle");
             return false;
         }
+    }
 
-        // if not in a manual throttle mode and not in CRUISE or FBWB
-        // modes then disallow rudder arming/disarming
-        if (plane.control_mode->does_auto_throttle() &&
-            (plane.control_mode != &plane.mode_cruise && plane.control_mode != &plane.mode_fbwb)) {
-            check_failed(true, "Mode not rudder-armable");
-            return false;
-        }
+    if (!plane.control_mode->allows_arming()) {
+        check_failed(true, "Mode does not allow arming");
+        return false;
     }
 
     //are arming checks disabled?

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -63,6 +63,9 @@ public:
     // returns a string for this flightmode, exactly 4 bytes
     virtual const char *name4() const = 0;
 
+    // returns true if the vehicle can be armed in this mode
+    virtual bool allows_arming() const { return true; }
+
     //
     // methods that sub classes should override to affect movement of the vehicle in this mode
     //
@@ -318,6 +321,8 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override { }
 
+    bool allows_arming() const override { return false; }
+
     bool allows_throttle_nudging() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
@@ -486,6 +491,8 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
+    bool allows_arming() const override { return false; }
+
 protected:
 
     bool _enter() override;
@@ -503,6 +510,8 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    bool allows_arming() const override { return false; }
 
 protected:
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -449,8 +449,6 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
-    bool does_auto_throttle() const override { return true; }
-
 protected:
 
     bool _enter() override;
@@ -470,8 +468,6 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
-    bool does_auto_throttle() const override { return true; }
-
 protected:
 
     bool _enter() override;
@@ -490,8 +486,6 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
-    bool does_auto_throttle() const override { return true; }
-
 protected:
 
     bool _enter() override;
@@ -509,8 +503,6 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
-
-    bool does_auto_throttle() const override { return true; }
 
 protected:
 
@@ -550,8 +542,6 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
-
-    bool does_auto_throttle() const override { return true; }
 
 protected:
 

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -528,10 +528,9 @@ class AutoTestQuadPlane(AutoTest):
             self.load_mission("quadplane-gyro-mission.txt")
             self.mavproxy.send('wp list\n')
             self.mavproxy.expect('Requesting [0-9]+ waypoints')
+            self.change_mode('AUTO')
             self.wait_ready_to_arm()
             self.arm_vehicle()
-            self.mavproxy.send('mode AUTO\n')
-            self.wait_mode('AUTO')
             self.wait_waypoint(1, 7, max_dist=60, timeout=1200)
             self.wait_disarmed(timeout=120) # give quadplane a long time to land
 


### PR DESCRIPTION
Reverts part of 6baaf03c8c7e563db00e60ca79e54289c8770fac

AvoidADSB was NOT marked as AutoThrottle before that commit but was
marked as such in that commit.