### PR TITLE
Revert "autotest: ensure defaults files don't set already-default-val…

### DIFF
--- a/Tools/autotest/antennatracker.py
+++ b/Tools/autotest/antennatracker.py
@@ -149,12 +149,10 @@ class AutoTestTracker(AutoTest):
                                           comparator=operator.le)
 
     def disabled_tests(self):
-        ret = super(AutoTestTracker, self).disabled_tests()
-        ret.update({
+        return {
             "ArmFeatures": "See https://github.com/ArduPilot/ardupilot/issues/10652",
             "CPUFailsafe": " tracker doesn't have a CPU failsafe",
-        })
-        return ret
+        }
 
     def tests(self):
         '''return list of all tests'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6347,13 +6347,11 @@ class AutoTestCopter(AutoTest):
         return ret
 
     def disabled_tests(self):
-        ret = super(AutoTestCopter, self).disabled_tests()
-        ret.update({
+        return {
             "Parachute": "See https://github.com/ArduPilot/ardupilot/issues/4702",
             "HorizontalAvoidFence": "See https://github.com/ArduPilot/ardupilot/issues/11525",
             "AltEstimation": "See https://github.com/ArduPilot/ardupilot/issues/15191",
-        })
-        return ret
+        }
 
 class AutoTestHeli(AutoTestCopter):
 
@@ -6652,11 +6650,9 @@ class AutoTestHeli(AutoTestCopter):
         return ret
 
     def disabled_tests(self):
-        ret = super(AutoTestHeli, self).disabled_tests()
-        ret.update({
+        return {
             "SplineWaypoint": "See https://github.com/ArduPilot/ardupilot/issues/14593",
-        })
-        return ret
+        }
 
 class AutoTestCopterTests1(AutoTestCopter):
     def tests(self):

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2204,7 +2204,5 @@ class AutoTestPlane(AutoTest):
         return ret
 
     def disabled_tests(self):
-        ret = super(AutoTestPlane, self).disabled_tests()
-        ret.update({
-        })
-        return ret
+        return {
+        }

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -342,7 +342,6 @@ class AutoTestSub(AutoTest):
         ret = super(AutoTestSub, self).disabled_tests()
         ret.update({
             "ConfigErrorLoop": "Sub does not instantiate AP_Stats.  Also see https://github.com/ArduPilot/ardupilot/issues/10247",
-            "FrameDefaults": "Sub maintainers want all values in files",
         })
         return ret
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7828,9 +7828,7 @@ switch value'''
         self.test_parameters_download()
 
     def disabled_tests(self):
-        return {
-            "FrameDefaults": "Time constraints say we might not want to run this",
-        }
+        return {}
 
     def test_parameter_checks_poscontrol(self, param_prefix):
         self.wait_ready_to_arm()
@@ -8985,56 +8983,6 @@ switch value'''
         if ex is not None:
             raise ex
 
-    def check_frame_defaults(self, model):
-        '''check each of the entries in VehicleInfo to see if they override
-        parameters they shouldn't'''
-
-        defaults_filepath = self.model_defaults_filepath(self.vehicleinfo_key(), model)
-        # we start the model but without passing through the defaults:
-        self.customise_SITL_commandline(
-            [],
-            model=model,
-            defaults_filepath=[],
-            wipe=True)
-        failed = []
-        for filepath in defaults_filepath:
-            parameters = mavparm.MAVParmDict()
-            if not os.path.exists(filepath):
-#                raise NotAchievedException("Bad parameter file referenced: %s" % str(filepath))
-                failed.append("Bad parameter file referenced: %s" % str(filepath))
-            parameters.load(filepath)
-            for (file_param_name, file_param_value) in parameters.items():
-                try:
-                    current_value = self.get_parameter(file_param_name, verbose=False)
-                except NotAchievedException as e:
-                    failed.append("%s in (%s) but not in firmware" %
-                                  (filepath, file_param_name))
-                    continue
-                if current_value == parameters[file_param_name]:
-                    failed.append("%s has same value (%f) in (%s) and in firmware" %
-                                  (filepath, current_value, file_param_name))
-                    continue
-        if len(failed):
-            self.progress("Frame (%s) failed:" % (model, ))
-            for i in failed:
-                self.progress("        %s" % i)
-            return False
-        return True
-
-    def check_frames_defaults(self):
-        vinfo = vehicleinfo.VehicleInfo()
-        success = True
-        frames = vinfo.options[self.vehicleinfo_key()]["frames"]
-        for frame in frames:
-            if frames[frame].get("external_model", False):
-                continue
-            self.progress("Checking frame (%s)" % str(frame))
-            if not self.check_frame_defaults(frame):
-                success = False
-        self.customise_SITL_commandline(["--unhide-groups"])
-        if not success:
-            raise NotAchievedException("Defaults files validation failed")
-
     def tests(self):
         return [
             ("PIDTuning",
@@ -9074,10 +9022,6 @@ switch value'''
             ("InitialMode",
              "Test initial mode switching",
              self.test_initial_mode),
-
-            ("FrameDefaults",
-             "Test Frame defaults file",
-             self.check_frames_defaults),
         ]
 
     def post_tests_announcements(self):
@@ -9112,7 +9056,6 @@ switch value'''
         return ret
 
     def mavfft_fttd(self, sensor_type, sensor_instance, since, until):
-
         '''display fft for raw ACC data in current logfile'''
 
         '''object to store data about a single FFT plot'''

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -106,19 +106,16 @@ class VehicleInfo(object):
             "IrisRos": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": "default_params/copter.parm",
-                "external_model": True,
             },
             "gazebo-iris": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": ["default_params/copter.parm",
                                             "default_params/gazebo-iris.parm"],
-                "external_model": True,
             },
             "airsim-copter": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": ["default_params/copter.parm",
                                             "default_params/airsim-quadX.parm"],
-                "external_model": True,
             },
             # HELICOPTER
             "heli": {
@@ -132,7 +129,6 @@ class VehicleInfo(object):
             },
             "heli-compound": {
                 "waf_target": "bin/arducopter-heli",
-                "default_params_filename": ["default_params/copter-heli.parm"],
             },
             "singlecopter": {
                 "waf_target": "bin/arducopter",
@@ -146,11 +142,9 @@ class VehicleInfo(object):
             "scrimmage-copter" : {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": "default_params/copter.parm",
-                "external_model": True,
             },
             "calibration": {
                 "extra_mavlink_cmds": "module load sitl_calibration;",
-                "default_params_filename": [],
             },
             "Callisto": {
                 "model": "octa-quad:@ROMFS/models/Callisto.json",
@@ -276,17 +270,14 @@ class VehicleInfo(object):
                 "waf_target": "bin/ardurover",
                 "default_params_filename": ["default_params/rover.parm",
                                             "default_params/rover-skid.parm"],
-                "external_model": True,
             },
             "airsim-rover": {
                 "waf_target": "bin/ardurover",
                 "default_params_filename": ["default_params/rover.parm",
                                             "default_params/airsim-rover.parm"],
-                "external_model": True,
             },
             "calibration": {
                 "extra_mavlink_cmds": "module load sitl_calibration;",
-                "default_params_filename": [],
             },
         },
     },
@@ -312,7 +303,6 @@ class VehicleInfo(object):
         "frames": {
             "tracker": {
                 "waf_target": "bin/antennatracker",
-                "default_params_filename": [],
             },
         },
     },

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -567,13 +567,11 @@ class AutoTestQuadPlane(AutoTest):
         return "MANUAL"
 
     def disabled_tests(self):
-        ret = super(AutoTestQuadPlane, self).disabled_tests()
-        ret.update({
+        return {
             "QAutoTune": "See https://github.com/ArduPilot/ardupilot/issues/10411",
             "FRSkyPassThrough": "Currently failing",
             "CPUFailsafe": "servo channel values not scaled like ArduPlane",
-        })
-        return ret
+        }
 
     def test_pilot_yaw(self):
         self.takeoff(10, mode="QLOITER")

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5640,12 +5640,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         return ret
 
     def disabled_tests(self):
-        ret = super(AutoTestRover, self).disabled_tests()
-        ret.update({
+        return {
             "DriveMaxRCIN": "currently triggers Arithmetic Exception",
             "SlewRate": "got timing report failure on CI",
-        })
-        return ret
+        }
 
     def rc_defaults(self):
         ret = super(AutoTestRover, self).rc_defaults()


### PR DESCRIPTION
…ues"

This reverts commit 3d431cd4f17dfe8462e7b8935e090e0ae74fd59d.

It breaks MissionPlanner SITL. We can re-apply once MissionPlanner
copes with external_model.
