### PR TITLE
AC_AttitudeControl: tailsitter sets target rates more efficiently

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
@@ -120,8 +120,8 @@ void AC_AttitudeControl_TS::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool 
     //    _attitude_target_euler_angle.y = euler_pitch;
 
     // Set rate feedforward requests to zero
-    _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
-    _attitude_target_ang_vel = Vector3f(0.0f, 0.0f, 0.0f);
+    _attitude_target_euler_rate.zero();
+    _attitude_target_ang_vel.zero();
 
     // Compute attitude error
     error_quat = attitude_vehicle_quat.inverse() * _attitude_target_quat;


### PR DESCRIPTION
This PR makes the Tailsitter specific AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll method slightly more efficient by skipping the creation of the Vector3fs and directly setting x, y and z members to zero.

This small issue was picked up during the review of the S-Curve PR: https://github.com/ArduPilot/ardupilot/pull/15896.

I have not tested this beyond the regular autotests but surely this is correct.