### PR TITLE
Plane: ensure wp_nav::wp_and_spline_init is called at least once

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -774,12 +774,12 @@ bool QuadPlane::setup(void)
         motors->disable_yaw_torque();
     }
 
-
     motors->set_throttle_range(thr_min_pwm, thr_max_pwm);
     motors->set_update_rate(rc_speed);
     motors->set_interlock(true);
     pos_control->set_dt(loop_delta_t);
     attitude_control->parameter_sanity_check();
+    wp_nav->wp_and_spline_init();
 
     // TODO: update this if servo function assignments change
     // used by relax_attitude_control() to control special behavior for vectored tailsitters


### PR DESCRIPTION
During development and testing of the S-Curves PR https://github.com/ArduPilot/ardupilot/pull/15896 we found that QuadPlane was never calling [WPNav's init](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AC_WPNav/AC_WPNav.cpp#L123) function.

Ideally this init method should be called just before the library is used but this PR calls [AC_WPNav's init method](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AC_WPNav/AC_WPNav.cpp#L123) as part of QuadPlane::setup() so that it is called at least once before use.

This has been tested in SITL as part of the s-curve PR https://github.com/ArduPilot/ardupilot/pull/15896
