### PR TITLE
autotest: correct get_parameter_direct attempts decrement

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3608,6 +3608,7 @@ class AutoTest(ABC):
 
     def get_parameter_direct(self, name, attempts=1, timeout=60, verbose=True, timeout_in_wallclock=False):
         while attempts > 0:
+            attempts -= 1
             if verbose:
                 self.progress("Sending param_request_read for (%s)" % name)
             # we MUST parse here or collections fail where we need
@@ -3641,7 +3642,6 @@ class AutoTest(ABC):
                     return m.param_value
                 if verbose:
                     self.progress("(%s) != (%s)" % (m.param_id, name,))
-            attempts -= 1
         raise NotAchievedException("Failed to retrieve parameter (%s)" % name)
 
     def get_parameter_mavproxy(self, name, attempts=1, timeout=60):


### PR DESCRIPTION
There's a `continue` in there!
