### PR TITLE
Correctly allow mixing of bi-dir and non-bi-dir channels

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1079,8 +1079,8 @@ void RCOutput::dshot_send(pwm_group &group, bool blocking)
     // assume that we won't be able to get the input capture lock
     group.bdshot.enabled = false;
 
-    // now grab the input capture lock if we are able
-    if ((_bdshot.mask & (1 << group.chan[group.bdshot.curr_telem_chan])) && group.has_ic()) {
+    // now grab the input capture lock if we are able, we can only enable bi-dir on a group basis
+    if (((_bdshot.mask & group.ch_mask) == group.ch_mask) && group.has_ic()) {
         if (group.has_shared_ic_up_dma()) {
             // no locking required
             group.bdshot.enabled = true;
@@ -1163,7 +1163,7 @@ void RCOutput::dshot_send(pwm_group &group, bool blocking)
             }
 
             bool request_telemetry = (telem_request_mask & chan_mask)?true:false;
-            uint16_t packet = create_dshot_packet(value, request_telemetry, _bdshot.mask);
+            uint16_t packet = create_dshot_packet(value, request_telemetry, group.bdshot.enabled);
             if (request_telemetry) {
                 telem_request_mask &= ~chan_mask;
             }


### PR DESCRIPTION
This is my solution to the fact that I cannot get bi-dir to work on TIM1 on the BeastH7. Since TIM3 works great its simple enough to allow the BDMASK to be set to 9 and thus use bi-dir on two channels and regular dshot on the other two. Since this is driving notches, two gives us better fidelity than the FFT or throttle.