### PR TITLE
Plane: disallow changing to INITIALISING mode

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -315,6 +315,8 @@ public:
     const char *name() const override { return "INITIALISING"; }
     const char *name4() const override { return "INIT"; }
 
+    bool _enter() override { return false; }
+
     // methods that affect movement of the vehicle in this mode
     void update() override { }
 


### PR DESCRIPTION
At the moment you can change into this mode via mavlink.

That's not good - we won't fly well in this mode.

We already bounce attempts to enter thermal mode, so returning false from entering a mode is already tested.
