### PR TITLE
AHRS: pre_arm_check accepts requires_position argument to allow disabling some checks

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -511,16 +511,16 @@ bool AP_Arming_Copter::proximity_checks(bool display_failure) const
 // performs mandatory gps checks.  returns true if passed
 bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
 {
+    // check if flight mode requires GPS
+    bool mode_requires_gps = copter.flightmode->requires_GPS();
+
     // always check if inertial nav has started and is ready
     const AP_AHRS_NavEKF &ahrs = AP::ahrs_navekf();
     char failure_msg[50] = {};
-    if (!ahrs.pre_arm_check(failure_msg, sizeof(failure_msg))) {
+    if (!ahrs.pre_arm_check(mode_requires_gps, failure_msg, sizeof(failure_msg))) {
         check_failed(display_failure, "AHRS: %s", failure_msg);
         return false;
     }
-
-    // check if flight mode requires GPS
-    bool mode_requires_gps = copter.flightmode->requires_GPS();
 
     // check if fence requires GPS
     bool fence_requires_gps = false;

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -125,7 +125,7 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
         char failure_msg[50] = {};
-        if (!AP::ahrs().pre_arm_check(failure_msg, sizeof(failure_msg))) {
+        if (!AP::ahrs().pre_arm_check(true, failure_msg, sizeof(failure_msg))) {
             check_failed(ARMING_CHECK_INS, display_failure, "AHRS: %s", failure_msg);
             return false;
         }

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -66,7 +66,7 @@ bool AP_Arming_Sub::ins_checks(bool display_failure)
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
         char failure_msg[50] = {};
-        if (!AP::ahrs().pre_arm_check(failure_msg, sizeof(failure_msg))) {
+        if (!AP::ahrs().pre_arm_check(false, failure_msg, sizeof(failure_msg))) {
             check_failed(ARMING_CHECK_INS, display_failure, "AHRS: %s", failure_msg);
             return false;
         }

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -43,7 +43,7 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
 
     // always check if inertial nav has started and is ready
     char failure_msg[50] = {};
-    if (!ahrs.pre_arm_check(failure_msg, sizeof(failure_msg))) {
+    if (!ahrs.pre_arm_check(true, failure_msg, sizeof(failure_msg))) {
         check_failed(display_failure, "AHRS: %s", failure_msg);
         return false;
     }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -164,7 +164,8 @@ public:
     virtual void update(bool skip_ins_update=false) = 0;
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-    virtual bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const = 0;
+    // requires_position should be true if horizontal position configuration should be checked
+    virtual bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const = 0;
 
     // check all cores providing consistent attitudes for prearm checks
     virtual bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const { return true; }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1152,7 +1152,8 @@ bool AP_AHRS_DCM::get_velocity_NED(Vector3f &vec) const
 }
 
 // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-bool AP_AHRS_DCM::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
+// requires_position should be true if horizontal position configuration should be checked (not used)
+bool AP_AHRS_DCM::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
 {
     if (!healthy()) {
         hal.util->snprintf(failure_msg, failure_msg_len, "Not healthy");

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -121,7 +121,8 @@ public:
     bool get_velocity_NED(Vector3f &vec) const override;
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const override;
+    // requires_position should be true if horizontal position configuration should be checked (not used)
+    bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
 
 private:
     float _ki;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1668,7 +1668,8 @@ bool AP_AHRS_NavEKF::healthy(void) const
 }
 
 // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-bool AP_AHRS_NavEKF::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
+// requires_position should be true if horizontal position configuration should be checked
+bool AP_AHRS_NavEKF::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
 {
     bool ret = true;
     if (!healthy()) {
@@ -1705,7 +1706,7 @@ bool AP_AHRS_NavEKF::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) c
             hal.util->snprintf(failure_msg, failure_msg_len, "EKF3 not started");
             return false;
         }
-        return EKF3.pre_arm_check(failure_msg, failure_msg_len) && ret;
+        return EKF3.pre_arm_check(requires_position, failure_msg, failure_msg_len) && ret;
 #endif
     }
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -203,7 +203,8 @@ public:
     bool healthy() const override;
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const override;
+    // requires_position should be true if horizontal position configuration should be checked
+    bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
 
     // true if the AHRS has completed initialisation
     bool initialised() const override;

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -299,7 +299,8 @@ void AP_NavEKF_Source::mark_configured_in_storage()
 }
 
 // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
+// requires_position should be true if horizontal position configuration should be checked
+bool AP_NavEKF_Source::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
 {
     auto &dal = AP::dal();
     bool baro_required = false;
@@ -314,91 +315,93 @@ bool AP_NavEKF_Source::pre_arm_check(char *failure_msg, uint8_t failure_msg_len)
     // check source params are valid
     for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
 
-        // check posxy
-        switch ((SourceXY)_source_set[i].posxy.get()) {
-        case SourceXY::NONE:
-            break;
-        case SourceXY::GPS:
-            gps_required = true;
-            break;
-        case SourceXY::BEACON:
-            beacon_required = true;
-            break;
-        case SourceXY::EXTNAV:
-            visualodom_required = true;
-            break;
-        case SourceXY::OPTFLOW:
-        case SourceXY::WHEEL_ENCODER:
-        default:
-            // invalid posxy value
-            hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_POSXY", (int)i+1);
-            return false;
-        }
+        if (requires_position) {
+            // check posxy
+            switch ((SourceXY)_source_set[i].posxy.get()) {
+            case SourceXY::NONE:
+                break;
+            case SourceXY::GPS:
+                gps_required = true;
+                break;
+            case SourceXY::BEACON:
+                beacon_required = true;
+                break;
+            case SourceXY::EXTNAV:
+                visualodom_required = true;
+                break;
+            case SourceXY::OPTFLOW:
+            case SourceXY::WHEEL_ENCODER:
+            default:
+                // invalid posxy value
+                hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_POSXY", (int)i+1);
+                return false;
+            }
 
-        // check velxy
-        switch ((SourceXY)_source_set[i].velxy.get()) {
-        case SourceXY::NONE:
-            break;
-        case SourceXY::GPS:
-            gps_required = true;
-            break;
-        case SourceXY::OPTFLOW:
-            optflow_required = true;
-            break;
-        case SourceXY::EXTNAV:
-            visualodom_required = true;
-            break;
-        case SourceXY::WHEEL_ENCODER:
-            wheelencoder_required = true;
-            break;
-        case SourceXY::BEACON:
-        default:
-            // invalid velxy value
-            hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_VELXY", (int)i+1);
-            return false;
-        }
+            // check velxy
+            switch ((SourceXY)_source_set[i].velxy.get()) {
+            case SourceXY::NONE:
+                break;
+            case SourceXY::GPS:
+                gps_required = true;
+                break;
+            case SourceXY::OPTFLOW:
+                optflow_required = true;
+                break;
+            case SourceXY::EXTNAV:
+                visualodom_required = true;
+                break;
+            case SourceXY::WHEEL_ENCODER:
+                wheelencoder_required = true;
+                break;
+            case SourceXY::BEACON:
+            default:
+                // invalid velxy value
+                hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_VELXY", (int)i+1);
+                return false;
+            }
 
-        // check posz
-        switch ((SourceZ)_source_set[i].posz.get()) {
-        case SourceZ::BARO:
-            baro_required = true;
-            break;
-        case SourceZ::RANGEFINDER:
-            rangefinder_required = true;
-            break;
-        case SourceZ::GPS:
-            gps_required = true;
-            break;
-        case SourceZ::BEACON:
-            beacon_required = true;
-            break;
-        case SourceZ::EXTNAV:
-            visualodom_required = true;
-            break;
-        case SourceZ::NONE:
-        default:
-            // invalid posz value
-            hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_POSZ", (int)i+1);
-            return false;
-        }
+            // check posz
+            switch ((SourceZ)_source_set[i].posz.get()) {
+            case SourceZ::BARO:
+                baro_required = true;
+                break;
+            case SourceZ::RANGEFINDER:
+                rangefinder_required = true;
+                break;
+            case SourceZ::GPS:
+                gps_required = true;
+                break;
+            case SourceZ::BEACON:
+                beacon_required = true;
+                break;
+            case SourceZ::EXTNAV:
+                visualodom_required = true;
+                break;
+            case SourceZ::NONE:
+            default:
+                // invalid posz value
+                hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_POSZ", (int)i+1);
+                return false;
+            }
 
-        // check velz
-        switch ((SourceZ)_source_set[i].velz.get()) {
-        case SourceZ::NONE:
-            break;
-        case SourceZ::GPS:
-            gps_required = true;
-            break;
-        case SourceZ::EXTNAV:
-            visualodom_required = true;
-            break;
-        case SourceZ::BARO:
-        case SourceZ::RANGEFINDER:
-        case SourceZ::BEACON:
-        default:
-            // invalid velz value
-            hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_VELZ", (int)i+1);
-            return false;
+            // check velz
+            switch ((SourceZ)_source_set[i].velz.get()) {
+            case SourceZ::NONE:
+                break;
+            case SourceZ::GPS:
+                gps_required = true;
+                break;
+            case SourceZ::EXTNAV:
+                visualodom_required = true;
+                break;
+            case SourceZ::BARO:
+            case SourceZ::RANGEFINDER:
+            case SourceZ::BEACON:
+            default:
+                // invalid velz value
+                hal.util->snprintf(failure_msg, failure_msg_len, "Check EK3_SRC%d_VELZ", (int)i+1);
+                return false;
+            }
         }
 
         // check yaw

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -90,7 +90,8 @@ public:
     void mark_configured_in_storage();
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const;
+    // requires_position should be true if horizontal position configuration should be checked
+    bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const;
 
     // return true if ext nav is enabled on any source
     bool ext_nav_enabled(void) const;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1060,10 +1060,11 @@ bool NavEKF3::healthy(void) const
 }
 
 // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-bool NavEKF3::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
+// requires_position should be true if horizontal position configuration should be checked
+bool NavEKF3::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
 {
     // check source configuration
-    if (!sources.pre_arm_check(failure_msg, failure_msg_len)) {
+    if (!sources.pre_arm_check(requires_position, failure_msg, failure_msg_len)) {
         return false;
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -56,7 +56,8 @@ public:
     bool healthy(void) const;
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-    bool pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const;
+    // requires_position should be true if horizontal position configuration should be checked
+    bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const;
 
     // returns the index of the primary core
     // return -1 if no primary core selected


### PR DESCRIPTION
This PR allows vehicles to skip the EKF3 source parameter checks for horizontal and vertical position and velocity checks.  In particular this allows Copters to arm in Stabilize, Acro, AltHold and Sport even if EK3_SRCx_POSXY, VELXY, VELZ or POSZ are set to GPS but no GPS if found (can be caused by GPS being disconnected or GPS_TYPE = 0).

This has been lightly tested in SITL for Copter and appears to work.  Below are before and after screens shots when attempting to arm in Stabilize mode with GPS_TYPE = 0.

![ekf3-arming-checks](https://user-images.githubusercontent.com/1498098/105311246-bb79a900-5c00-11eb-8173-57ee4bc2fcc8.png)


This resolves issue: https://github.com/ArduPilot/ardupilot/issues/16017

FYI @tridge @andyp1per 