### PR TITLE
Remove externally-unused getFilterTimeout methods 

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1325,27 +1325,6 @@ void NavEKF2::getFilterFaults(int8_t instance, uint16_t &faults) const
 }
 
 /*
-  return filter timeout status as a bitmasked integer
-  0 = position measurement timeout
-  1 = velocity measurement timeout
-  2 = height measurement timeout
-  3 = magnetometer measurement timeout
-  4 = unassigned
-  5 = unassigned
-  6 = unassigned
-  7 = unassigned
-*/
-void NavEKF2::getFilterTimeouts(int8_t instance, uint8_t &timeouts) const
-{
-    if (instance < 0 || instance >= num_cores) instance = primary;
-    if (core) {
-        core[instance].getFilterTimeouts(timeouts);
-    } else {
-        timeouts = 0;
-    }
-}
-
-/*
   return filter status flags
 */
 void NavEKF2::getFilterStatus(int8_t instance, nav_filter_status &status) const

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -228,20 +228,6 @@ public:
     void  getFilterFaults(int8_t instance, uint16_t &faults) const;
 
     /*
-    return filter timeout status as a bitmasked integer for the specified instance
-    An out of range instance (eg -1) returns data for the primary instance
-     0 = position measurement timeout
-     1 = velocity measurement timeout
-     2 = height measurement timeout
-     3 = magnetometer measurement timeout
-     4 = unassigned
-     5 = unassigned
-     6 = unassigned
-     7 = unassigned
-    */
-    void  getFilterTimeouts(int8_t instance, uint8_t &timeouts) const;
-
-    /*
     return filter gps quality check status for the specified instance
     An out of range instance (eg -1) returns data for the primary instance
     */

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -119,13 +119,18 @@ void NavEKF2_core::Log_Write_NKF4(uint64_t time_us) const
     float tasVar = 0;
     Vector2f offset;
     uint16_t _faultStatus=0;
-    uint8_t timeoutStatus=0;
+    const uint8_t timeoutStatus =
+        posTimeout<<0 |
+        velTimeout<<1 |
+        hgtTimeout<<2 |
+        magTimeout<<3 |
+        tasTimeout<<4;
+
     nav_filter_status solutionStatus {};
     nav_gps_status gpsStatus {};
     getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
     float tempVar = fmaxf(fmaxf(magVar.x,magVar.y),magVar.z);
     getFilterFaults(_faultStatus);
-    getFilterTimeouts(timeoutStatus);
     getFilterStatus(solutionStatus);
     getFilterGpsStatus(gpsStatus);
     float tiltError;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -477,15 +477,6 @@ return filter timeout status as a bitmasked integer
  6 = unassigned
  7 = unassigned
 */
-void  NavEKF2_core::getFilterTimeouts(uint8_t &timeouts) const
-{
-    timeouts = (posTimeout<<0 |
-                velTimeout<<1 |
-                hgtTimeout<<2 |
-                magTimeout<<3 |
-                tasTimeout<<4);
-}
-
 // Return the navigation filter status message
 void  NavEKF2_core::getFilterStatus(nav_filter_status &status) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -241,19 +241,6 @@ public:
     void  getFilterFaults(uint16_t &faults) const;
 
     /*
-    return filter timeout status as a bitmasked integer
-     0 = position measurement timeout
-     1 = velocity measurement timeout
-     2 = height measurement timeout
-     3 = magnetometer measurement timeout
-     5 = unassigned
-     6 = unassigned
-     7 = unassigned
-     7 = unassigned
-    */
-    void  getFilterTimeouts(uint8_t &timeouts) const;
-
-    /*
     return filter gps quality check status
     */
     void  getFilterGpsStatus(nav_gps_status &status) const;

--- a/libraries/AP_NavEKF2/LogStructure.h
+++ b/libraries/AP_NavEKF2/LogStructure.h
@@ -178,7 +178,7 @@ struct PACKED log_NKF3 {
 // @Field: OFN: Most recent position recent magnitude (North component)
 // @Field: OFE: Most recent position recent magnitude (East component)
 // @Field: FS: Filter fault status
-// @Field: TS: Filter timeout status
+// @Field: TS: Filter timeout status bitmask (0:position measurement, 1:velocity measurement, 2:height measurement, 3:magnetometer measurement, 4:airspeed measurement)
 // @Field: SS: Filter solution status
 // @Field: GPS: Filter GPS status
 // @Field: PI: Primary core index

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1767,27 +1767,6 @@ void NavEKF3::getFilterFaults(int8_t instance, uint16_t &faults) const
 }
 
 /*
-  return filter timeout status as a bitmasked integer
-  0 = position measurement timeout
-  1 = velocity measurement timeout
-  2 = height measurement timeout
-  3 = magnetometer measurement timeout
-  4 = unassigned
-  5 = unassigned
-  6 = unassigned
-  7 = unassigned
-*/
-void NavEKF3::getFilterTimeouts(int8_t instance, uint8_t &timeouts) const
-{
-    if (instance < 0 || instance >= num_cores) instance = primary;
-    if (core) {
-        core[instance].getFilterTimeouts(timeouts);
-    } else {
-        timeouts = 0;
-    }
-}
-
-/*
   return filter status flags
 */
 void NavEKF3::getFilterStatus(int8_t instance, nav_filter_status &status) const

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -305,20 +305,6 @@ public:
     void getFilterFaults(int8_t instance, uint16_t &faults) const;
 
     /*
-    return filter timeout status as a bitmasked integer for the specified instance
-    An out of range instance (eg -1) returns data for the primary instance
-     0 = position measurement timeout
-     1 = velocity measurement timeout
-     2 = height measurement timeout
-     3 = magnetometer measurement timeout
-     4 = unassigned
-     5 = unassigned
-     6 = unassigned
-     7 = unassigned
-    */
-    void getFilterTimeouts(int8_t instance, uint8_t &timeouts) const;
-
-    /*
     return filter gps quality check status for the specified instance
     An out of range instance (eg -1) returns data for the primary instance
     */

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -138,13 +138,18 @@ void NavEKF3_core::Log_Write_XKF4(uint64_t time_us) const
     float tasVar = 0;
     uint16_t _faultStatus=0;
     Vector2f offset;
-    uint8_t timeoutStatus=0;
+    const uint8_t timeoutStatus =
+        posTimeout<<0 |
+        velTimeout<<1 |
+        hgtTimeout<<2 |
+        magTimeout<<3 |
+        tasTimeout<<4;
+
     nav_filter_status solutionStatus {};
     nav_gps_status gpsStatus {};
     getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
     float tempVar = fmaxf(fmaxf(magVar.x,magVar.y),magVar.z);
     getFilterFaults(_faultStatus);
-    getFilterTimeouts(timeoutStatus);
     getFilterStatus(solutionStatus);
     getFilterGpsStatus(gpsStatus);
     float tiltError;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -524,26 +524,6 @@ void  NavEKF3_core::getFilterFaults(uint16_t &faults) const
               !statesInitialised<<7);
 }
 
-/*
-return filter timeout status as a bitmasked integer
- 0 = position measurement timeout
- 1 = velocity measurement timeout
- 2 = height measurement timeout
- 3 = magnetometer measurement timeout
- 4 = true airspeed measurement timeout
- 5 = unassigned
- 6 = unassigned
- 7 = unassigned
-*/
-void  NavEKF3_core::getFilterTimeouts(uint8_t &timeouts) const
-{
-    timeouts = (posTimeout<<0 |
-                velTimeout<<1 |
-                hgtTimeout<<2 |
-                magTimeout<<3 |
-                tasTimeout<<4);
-}
-
 // Return the navigation filter status message
 void  NavEKF3_core::getFilterStatus(nav_filter_status &status) const
 {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -324,19 +324,6 @@ public:
     void getFilterFaults(uint16_t &faults) const;
 
     /*
-    return filter timeout status as a bitmasked integer
-     0 = position measurement timeout
-     1 = velocity measurement timeout
-     2 = height measurement timeout
-     3 = magnetometer measurement timeout
-     5 = unassigned
-     6 = unassigned
-     7 = unassigned
-     7 = unassigned
-    */
-    void getFilterTimeouts(uint8_t &timeouts) const;
-
-    /*
     return filter gps quality check status
     */
     void getFilterGpsStatus(nav_gps_status &status) const;

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -185,7 +185,7 @@ struct PACKED log_XKF3 {
 // @Field: OFN: Most recent position recent magnitude (North component)
 // @Field: OFE: Most recent position recent magnitude (East component)
 // @Field: FS: Filter fault status
-// @Field: TS: Filter timeout status
+// @Field: TS: Filter timeout status bitmask (0:position measurement, 1:velocity measurement, 2:height measurement, 3:magnetometer measurement, 4:airspeed measurement)
 // @Field: SS: Filter solution status
 // @Field: GPS: Filter GPS status
 // @Field: PI: Primary core index


### PR DESCRIPTION
These were used for logging - but we've moved that to within the EKFs now.

Also corrects the documentation (moved it into the logger metadata)

