### PR TITLE
AC_Avoid: support stop-at-fence in poshold and althold

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -164,7 +164,9 @@ private:
     float distance_to_lean_pct(float dist_m);
 
     // returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
-    void get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
+    bool get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
+
+    bool get_fence_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
 
     // parameters
     AP_Int8 _enabled;


### PR DESCRIPTION
fix #14876

It is tested on mRo Pixracer Pro (indoor, motion capture system)