### PR TITLE
AP_Param: greatly speed up param download with disabled parameters

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -210,7 +210,7 @@ static void handle_param_getset(CanardInstance* ins, CanardRxTransfer* transfer)
         strncpy((char *)name, (char *)req.name.data, req.name.len);
         vp = AP_Param::find((char *)name, &ptype);
     } else {
-        AP_Param::ParamToken token;
+        AP_Param::ParamToken token {};
         vp = AP_Param::find_by_index(req.index, &ptype, &token);
         if (vp != nullptr) {
             vp->copy_name_token(token, (char *)name, AP_MAX_NAME_SIZE+1, true);

--- a/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
@@ -355,7 +355,7 @@ void AP_OSD_ParamScreen::modify_configured_parameter(uint8_t number, Event ev)
     } else {
         // going backwards is somewhat convoluted as the param code is geared for going forward
         ap_var_type type = AP_PARAM_NONE, prev_type = AP_PARAM_NONE, prev_prev_type = AP_PARAM_NONE;
-        AP_Param::ParamToken token, prev_token, prev_prev_token;
+        AP_Param::ParamToken token {}, prev_token, prev_prev_token;
 
         for (param = AP_Param::first(&token, &type);
             param && (setting._current_token.key != token.key

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2389,7 +2389,7 @@ uint16_t AP_Param::count_parameters(void)
             _count_marker != _count_marker_done) &&
            limit--) {
         AP_Param  *vp;
-        AP_Param::ParamToken token;
+        AP_Param::ParamToken token {};
         uint16_t count = 0;
         uint16_t marker = _count_marker;
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -210,8 +210,9 @@ public:
     // a token used for first()/next() state
     typedef struct {
         uint32_t key : 9;
-        uint32_t idx : 5; // offset into array types
+        uint32_t idx : 4; // offset into array types
         uint32_t group_element : 18;
+        uint32_t last_disabled : 1;
     } ParamToken;
 
 
@@ -451,7 +452,7 @@ public:
 
     /// Returns the next variable in _var_info, recursing into groups
     /// as needed
-    static AP_Param *      next(ParamToken *token, enum ap_var_type *ptype);
+    static AP_Param *      next(ParamToken *token, enum ap_var_type *ptype, bool skip_disabled=false);
 
     /// Returns the next scalar variable in _var_info, recursing into groups
     /// as needed
@@ -645,14 +646,15 @@ private:
                                     uint16_t ofs,
                                     uint8_t size);
     static AP_Param *           next_group(
-                                    uint16_t vindex, 
+                                    const uint16_t vindex,
                                     const struct GroupInfo *group_info,
                                     bool *found_current,
-                                    uint32_t group_base,
-                                    uint8_t group_shift,
-                                    ptrdiff_t group_offset,
+                                    const uint32_t group_base,
+                                    const uint8_t group_shift,
+                                    const ptrdiff_t group_offset,
                                     ParamToken *token,
-                                    enum ap_var_type *ptype);
+                                    enum ap_var_type *ptype,
+                                    bool skip_disabled);
 
     // find a default value given a pointer to a default value in flash
     static float get_default_value(const AP_Param *object_ptr, const float *def_value_ptr);

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -380,7 +380,7 @@ void GCS_MAVLINK::param_io_timer(void)
     AP_Param *vp;
 
     if (req.param_index != -1) {
-        AP_Param::ParamToken token;
+        AP_Param::ParamToken token {};
         vp = AP_Param::find_by_index(req.param_index, &reply.p_type, &token);
         if (vp == nullptr) {
             return;


### PR DESCRIPTION
allows fast skip over disabled subgroups. This removes a long delay
with param download on a MatekF405-STD where the final parameters
associated with the OSD took 80ms to fetch, causing a long loop delay
Thanks to the bug report by @giacomo892 
This also fixes the display of disabled ENABLE vars for INS_TCALn_ENABLE