### PR TITLE
Tools: make build installation script compatible with most Linux distros - 2

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -85,15 +85,26 @@ elif [ ${RELEASE_CODENAME} == 'trusty' ]; then
     SITLFML_VERSION="2"
     SITLCFML_VERSION="2"
 else
-    # Extract the floating point number that is the version of the libcsfml package.
-    SITLCFML_VERSION=`dpkg-query --search libcsfml-audio | cut -d":" -f1 | grep libcsfml-audio | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?'`
-    # And same for libsfml-audio.
-    SITLFML_VERSION=`dpkg-query --search libsfml-audio | cut -d":" -f1 | grep libsfml-audio | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?'`
+    # We assume APT based system, so let's try with apt-cache first.
+    SITLCFML_VERSION=$(apt-cache search -n '^libcsfml-audio' | cut -d" " -f1 | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?')
+    SITLFML_VERSION=$(apt-cache search -n '^libsfml-audio' | cut -d" " -f1 | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?')
+    # If we cannot retrieve the number with apt-cache, try a last time with dpkg-query
+    re='^[+-]?[0-9]+([.][0-9]+)?$'
+    if ! [[ $SITLCFML_VERSION =~ $re ]] || ! [[ $SITLFML_VERSION =~ $re ]] ; then
+        # Extract the floating point number that is the version of the libcsfml package.
+        SITLCFML_VERSION=$(dpkg-query --search libcsfml-audio | cut -d":" -f1 | grep libcsfml-audio | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?')
+        # And same for libsfml-audio.
+        SITLFML_VERSION=$(dpkg-query --search libsfml-audio | cut -d":" -f1 | grep libsfml-audio | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?')
+    fi
 fi
 
 # Check whether the specific ARM pkg-config package is available or whether we should emulate the effect of installing it.
-ARM_PKG_CONFIG_NOT_PRESENT=`dpkg-query --search pkg-config-arm-linux-gnueabihf |& grep -c "no path found matching pattern"`
-if [ $ARM_PKG_CONFIG_NOT_PRESENT -eq 1 ]; then
+# Check if we need to manually install libtool-bin
+ARM_PKG_CONFIG_NOT_PRESENT=0
+if [ -z "$(apt-cache search -n '^pkg-config-arm-linux-gnueabihf')" ]; then
+    ARM_PKG_CONFIG_NOT_PRESENT=$(dpkg-query --search pkg-config-arm-linux-gnueabihf |& grep -c "dpkg-query:")
+fi
+if [ "$ARM_PKG_CONFIG_NOT_PRESENT" -eq 1 ]; then
     INSTALL_PKG_CONFIG=""
     # No need to install Ubuntu's pkg-config-arm-linux-gnueabihf, instead install the base pkg-config.
     sudo apt-get install pkg-config
@@ -115,7 +126,6 @@ PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8"
 if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then
   PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"
 fi
-# Check for
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 # python-wxgtk packages are added to SITL_PKGS below
 SITL_PKGS="libtool libxml2-dev libxslt1-dev ${PYTHON_V}-dev ${PYTHON_V}-pip ${PYTHON_V}-setuptools ${PYTHON_V}-numpy ${PYTHON_V}-pyparsing"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -85,8 +85,27 @@ elif [ ${RELEASE_CODENAME} == 'trusty' ]; then
     SITLFML_VERSION="2"
     SITLCFML_VERSION="2"
 else
-    SITLFML_VERSION="2.4"
-    SITLCFML_VERSION="2.4"
+    # Extract the floating point number that is the version of the libcsfml package.
+    SITLCFML_VERSION=`dpkg-query --search libcsfml-audio | cut -d":" -f1 | grep libcsfml-audio | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?'`
+    # And same for libsfml-audio.
+    SITLFML_VERSION=`dpkg-query --search libsfml-audio | cut -d":" -f1 | grep libsfml-audio | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?'`
+fi
+
+# Check whether the specific ARM pkg-config package is available or whether we should emulate the effect of installing it.
+ARM_PKG_CONFIG_NOT_PRESENT=`dpkg-query --search pkg-config-arm-linux-gnueabihf |& grep -c "no path found matching pattern"`
+if [ $ARM_PKG_CONFIG_NOT_PRESENT -eq 1 ]; then
+    INSTALL_PKG_CONFIG=""
+    # No need to install Ubuntu's pkg-config-arm-linux-gnueabihf, instead install the base pkg-config.
+    sudo apt-get install pkg-config
+    if [ -f /usr/share/pkg-config-crosswrapper ]; then
+        # We are on non-Ubuntu so simulate effect of installing pkg-config-arm-linux-gnueabihf.
+        sudo ln -s /usr/share/pkg-config-crosswrapper /usr/bin/arm-linux-gnueabihf-pkg-config
+    else
+        echo "Warning: unable to link to pkg-config-crosswrapper"
+    fi
+else
+    # Package is available so install it later.
+    INSTALL_PKG_CONFIG="pkg-config-arm-linux-gnueabihf"
 fi
 
 # Lists of packages to install
@@ -96,7 +115,8 @@ PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8"
 if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then
   PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"
 fi
-ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
+# Check for
+ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 # python-wxgtk packages are added to SITL_PKGS below
 SITL_PKGS="libtool libxml2-dev libxslt1-dev ${PYTHON_V}-dev ${PYTHON_V}-pip ${PYTHON_V}-setuptools ${PYTHON_V}-numpy ${PYTHON_V}-pyparsing"
 # add some packages required for commonly-used MAVProxy modules:

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -51,7 +51,7 @@ function heading() {
 }
 
 # Install lsb-release as it is needed to check Ubuntu version
-if package_is_installed "lsb-release" -eq 1; then
+if ! package_is_installed "lsb-release"; then
     heading "Installing lsb-release"
     $APT_GET install lsb-release
     echo "Done!"
@@ -229,7 +229,7 @@ if [[ -z "${DO_AP_STM_ENV}" ]] && maybe_prompt_user "Install ArduPilot STM32 too
 fi
 
 heading "Removing modemmanager package that could conflict with firmware uploading"
-if package_is_installed "modemmanager" -eq 1; then
+if package_is_installed "modemmanager"; then
     $APT_GET remove modemmanager
 fi
 echo "Done!"


### PR DESCRIPTION
Rework from https://github.com/ArduPilot/ardupilot/pull/15726

use apt-cache first as it is recommended on Ubuntu based system and the dpkg-query can return wrongly false.

Fix lsb_release check.

Tested on Ubuntu 18.04/20.04/20.10 and Debian buster