### PR TITLE
build: Update Ubuntu in Docker container to resolve bootloader build errors. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 WORKDIR /ardupilot
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Before this change when attempting to build a target with the `--bootloader` flag I would get the follow error: 

```
ardupilot@6223ce2f1ef8:/ardupilot$ ./waf copter
Waf: Entering directory `/ardupilot/build/MatekH743'
Checking for env.py
env added BOARD_FLASH_SIZE=2048
env added PROCESS_STACK=0x1C00
env added APJ_BOARD_TYPE=STM32H743xx
env added PERIPH_FW=0
env added USBID=0x1209/0x5741
env added MAIN_STACK=0x600
env added APJ_BOARD_ID=1013
env added CORTEX=cortex-m7
env added FLASH_TOTAL=131072
env added FLASH_RESERVE_START_KB=0
env added CHIBIOS_BUILD_FLAGS=USE_FATFS=no MCU=cortex-m7 CHIBIOS_PLATFORM_MK=os/hal/ports/STM32/STM32H7xx/platform.mk CHIBIOS_STARTUP_MK=os/common/startup/ARMCMx/compilers/GCC/mk/startup_stm32h7xx.mk
env appended CPU_FLAGS=['-mcpu=cortex-m7', '-mfpu=fpv5-d16', '-mfloat-abi=hard']
env added IOMCU_FW=0
env added DISABLE_SCRIPTING=True
Padded 12 bytes for bootloader.bin to 17472
Embedding file bootloader.bin:/ardupilot/Tools/bootloaders/MatekH743_bl.bin
Embedding file hwdef.dat:/ardupilot/build/MatekH743/hw.dat
[8/9] Running python3 ${SRCROOT}/modules/libcanard/dsdl_compiler/libcanard_dsdlc --header_only --outdir ${BUILDROOT}/modules/libcanard/dsdlc_generated ${SRCROOT}/modules/uavcan/dsdl/uavcan ${SRCROOT}/libraries/AP_UAVCAN/dsdl/ardupilot ${SRCROOT}/libraries/AP_UAVCAN/dsdl/com
Traceback (most recent call last):
  File "/ardupilot/modules/libcanard/dsdl_compiler/libcanard_dsdlc", line 63, in <module>
    from libcanard_dsdl_compiler import run as dsdlc_run
  File "/ardupilot/modules/libcanard/dsdl_compiler/libcanard_dsdl_compiler/__init__.py", line 21, in <module>
    from uavcan import dsdl
  File "/ardupilot/modules/libcanard/dsdl_compiler/pyuavcan/uavcan/__init__.py", line 19, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

After updating the Ubuntu version I'm not able to compile without issue: 

```
ardupilot@1885d294b873:/ardupilot$ ./waf copter
Waf: Entering directory `/ardupilot/build/MatekH743'
Checking for env.py
env added DISABLE_SCRIPTING=True
env added PROCESS_STACK=0x1C00
env added MAIN_STACK=0x600
env added IOMCU_FW=0
env added PERIPH_FW=0
env added BOARD_FLASH_SIZE=2048
env appended CPU_FLAGS=['-mcpu=cortex-m7', '-mfpu=fpv5-d16', '-mfloat-abi=hard']
env added CORTEX=cortex-m7
env added APJ_BOARD_ID=1013
env added APJ_BOARD_TYPE=STM32H743xx
env added USBID=0x1209/0x5741
env added FLASH_RESERVE_START_KB=0
env added FLASH_TOTAL=131072
env added CHIBIOS_BUILD_FLAGS=USE_FATFS=no CHIBIOS_STARTUP_MK=os/common/startup/ARMCMx/compilers/GCC/mk/startup_stm32h7xx.mk CHIBIOS_PLATFORM_MK=os/hal/ports/STM32/STM32H7xx/platform.mk MCU=cortex-m7
Padded 12 bytes for bootloader.bin to 17472
Embedding file bootloader.bin:/ardupilot/Tools/bootloaders/MatekH743_bl.bin
Embedding file hwdef.dat:/ardupilot/build/MatekH743/hw.dat
[3/9] Creating build/MatekH743/hwdef.h
[4/9] Creating build/MatekH743/modules/ChibiOS/include_dirs
[5/9] Compiling libraries/AP_Scripting/generator/src/main.c
[6/9] Creating build/MatekH743/ap_version.h
[7/9] Running python3 ${SRCROOT}/modules/libcanard/dsdl_compiler/libcanard_dsdlc --header_only --outdir ${BUILDROOT}/modules/libcanard/dsdlc_generated ${SRCROOT}/modules/uavcan/dsdl/uavcan ${SRCROOT}/libraries/AP_UAVCAN/dsdl/ardupilot ${SRCROOT}/libraries/AP_UAVCAN/dsdl/com
Setup for MCU STM32H743xx
Writing hwdef setup in /ardupilot/build/MatekH743/hwdef.h
MCU Flags: cortex-m7 ['-mcpu=cortex-m7', '-mfpu=fpv5-d16', '-mfloat-abi=hard']
Writing DMA map
Generating ldscript.ld

[8/9] Processing /ardupilot/build/MatekH743/libraries/AP_Scripting/lua_generated_bindings.cpp,/ardupilot/build/MatekH743/libraries/AP_Scripting/lua_generated_bindings.h: libraries/AP_Scripting/generator/description/bindings.desc build/MatekH743/gen-bindings -> build/MatekH743/libraries/AP_Scripting/lua_generated_bindings.cpp build/MatekH743/libraries/AP_Scripting/lua_generated_bindings.h
[9/9] Linking build/MatekH743/modules/ChibiOS/libch.a
```