### PR TITLE
Use non-cachable SRAM3 for DMA or "It's a kind of magic"

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -34,6 +34,7 @@ static const SysFileList sysfs_file_list[] = {
     {"threads.txt"},
     {"tasks.txt"},
     {"dma.txt"},
+    {"memory.txt"},
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     {"can_log.txt"},
     {"can0_stats.txt"},
@@ -93,6 +94,9 @@ int AP_Filesystem_Sys::open(const char *fname, int flags)
     }
     if (strcmp(fname, "dma.txt") == 0) {
         hal.util->dma_info(*r.str);
+    }
+    if (strcmp(fname, "memory.txt") == 0) {
+        hal.util->mem_info(*r.str);
     }
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     int8_t can_stats_num = -1;

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -190,6 +190,9 @@ public:
     // request information on dma contention
     virtual void dma_info(ExpandingString &str) {}
 
+    // request information on memory allocation
+    virtual void mem_info(ExpandingString &str) {}
+
     // load persistent parameters from bootloader sector
     virtual bool load_persistent_params(ExpandingString &str) const { return false; }
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -378,6 +378,28 @@ void Util::dma_info(ExpandingString &str)
 }
 #endif
 
+#if CH_CFG_USE_HEAP == TRUE
+/*
+  return information on heap usage
+ */
+void Util::mem_info(ExpandingString &str)
+{
+    memory_heap_t *heaps;
+    const struct memory_region *regions;
+    uint8_t num_heaps = malloc_get_heaps(&heaps, &regions);
+
+    str.printf("MemInfoV1\n");
+    for (uint8_t i=0; i<num_heaps; i++) {
+        size_t totalp=0, largest=0;
+        // get memory available on main heap
+        chHeapStatus(i == 0 ? nullptr : &heaps[i], &totalp, &largest);
+        str.printf("START=0x%08x LEN=%3uk FREE=%6u LRG=%6u TYPE=%1u\n",
+                   unsigned(regions[i].address), unsigned(regions[i].size/1024),
+                   unsigned(totalp), unsigned(largest), unsigned(regions[i].flags));
+    }
+}
+#endif
+
 #if HAL_ENABLE_SAVE_PERSISTENT_PARAMS
 
 static const char *persistent_header = "{{PERSISTENT_START_V1}}\n";
@@ -485,6 +507,4 @@ void Util::apply_persistent_params(void) const
                       unsigned(count), unsigned(errors));
     }
 }
-
 #endif // HAL_ENABLE_SAVE_PERSISTENT_PARAMS
-

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -75,6 +75,9 @@ public:
     // request information on dma contention
     void dma_info(ExpandingString &str) override;
 #endif
+#if CH_CFG_USE_HEAP == TRUE
+    void mem_info(ExpandingString &str) override;
+#endif
 
 #if HAL_ENABLE_SAVE_PERSISTENT_PARAMS
     // apply persistent parameters to current parameters

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -40,16 +40,11 @@
 #define MEM_REGION_FLAG_FAST   2
 #define MEM_REGION_FLAG_SDCARD 4
 
-static const struct memory_region {
-    void *address;
-    uint32_t size;
-    uint32_t flags;
-} memory_regions[] = { HAL_MEMORY_REGIONS };
-
 #ifdef HAL_CHIBIOS_ENABLE_MALLOC_GUARD
 static mutex_t mem_mutex;
 #endif
 
+static const struct memory_region memory_regions[] = { HAL_MEMORY_REGIONS };
 // the first memory region is already setup as the ChibiOS
 // default heap, so we will index from 1 in the allocators
 #define NUM_MEMORY_REGIONS (sizeof(memory_regions)/sizeof(memory_regions[0]))
@@ -448,6 +443,16 @@ thread_t *thread_create_alloc(size_t size,
         }
     }
     return NULL;
+}
+
+/*
+  return heap information
+ */
+uint8_t malloc_get_heaps(memory_heap_t **_heaps, const struct memory_region **regions)
+{
+    *_heaps = &heaps[0];
+    *regions = &memory_regions[0];
+    return NUM_MEMORY_REGIONS;
 }
 
 #endif // CH_CFG_USE_HEAP

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
@@ -35,6 +35,15 @@ void *malloc_sdcard_dma(size_t size);
 void *malloc_fastmem(size_t size);
 thread_t *thread_create_alloc(size_t size, const char *name, tprio_t prio, tfunc_t pf, void *arg);
 
+struct memory_region {
+    void *address;
+    uint32_t size;
+    uint32_t flags;
+};
+#if CH_CFG_USE_HEAP == TRUE
+uint8_t malloc_get_heaps(memory_heap_t **_heaps, const struct memory_region **regions);
+#endif
+
 // flush all dcache
 void memory_flush_all(void);
     

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
@@ -20,10 +20,11 @@ mcu = {
     # flags of 4 means memory can be used for SDMMC DMA
     'RAM_MAP' : [
         (0x20000000, 128, 2), # DTCM, tightly coupled, no DMA, fast
-        (0x30000000, 288, 0), # SRAM1, SRAM2, SRAM3
-        (0x38000000,  64, 1), # SRAM4. This supports both DMA and BDMA ops
+        (0x30000000, 256, 0), # SRAM1, SRAM2
+        (0x38000000,  64, 0), # SRAM4.
         (0x24000000, 512, 4), # AXI SRAM. Use this for SDMMC IDMA ops
         (0x00000400,  63, 2), # ITCM (first 1k removed, to keep address 0 unused)
+        (0x30040000,  32, 1), # SRAM3. This supports both DMA and BDMA ops.
     ],
 
     'EXPECTED_CLOCK' : 400000000,


### PR DESCRIPTION
SRAM3 is already defined as non-cachable in the ChibiOS configuration through the use of
```
STM32_NOCACHE_SRAM3        =         TRUE
```
It is 16k starting at 0x30040000. We can use this to make DMA buffers non-cachable which we already do on F7 by using DTCM memory and which the STM32 application note tells us is the right thing to do:
"_Always better to use non-cacheable regions for DMA buffers. The software can use the MPU to set up a
non-cacheable memory block to use as a shared memory between the CPU and DMA._" in AN4839 section 4

This magically makes data corruption issues on my BeastH7 go away

Also @tridge has added support for @SYS/memory.txt:
```
MemInfoV1
START=0x20000000 LEN=128k FREE=   376 LRG=   376 TYPE=2
START=0x30000000 LEN=256k FREE=  4440 LRG=  3096 TYPE=0
START=0x38000000 LEN= 64k FREE= 35640 LRG= 35640 TYPE=0
START=0x24000000 LEN=512k FREE=520168 LRG=520152 TYPE=4
START=0x00000400 LEN= 63k FREE= 54160 LRG= 54160 TYPE=2
START=0x30040000 LEN= 32k FREE= 24456 LRG= 23896 TYPE=1
```
