### PR TITLE
GPS: Improve the SBF detection and configuration loop

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -68,11 +68,15 @@ private:
     uint32_t _init_blob_time;
     char *_initial_sso;
     const char* _sso_normal = ", PVTGeodetic+DOP+ReceiverStatus+VelCovGeodetic+BaseVectorGeod, msec100\n";
-    const char* _initialisation_blob[4] = {
+    static constexpr const char* _initialisation_blob[] = {
     "srd, Moderate, UAV\n",
     "sem, PVT, 5\n",
     "spm, Rover, all\n",
-    "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, msec100\n"};
+    "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, msec100\n",
+#if defined (GPS_SBF_EXTRA_CONFIG)
+    GPS_SBF_EXTRA_CONFIG
+#endif
+    };
     uint32_t _config_last_ack_time;
 
     const char* _port_enable = "\nSSSSSSSSSS\n";
@@ -239,4 +243,9 @@ private:
         INVALIDCONFIG = (1 << 10),  // set if one or more configuration file (permission or channel configuration) is invalid or absent.
         OUTOFGEOFENCE = (1 << 11),  // set if the receiver is currently out of its permitted region of operation (geo-fencing).
     };
+
+    static constexpr const char *portIdentifiers[] = { "COM", "USB", "IP1", "NTR", "IPS", "IPR" };
+    char portIdentifier[5];
+    uint8_t portLength;
+    bool readyForCommand;
 };

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -153,11 +153,9 @@ void AP_GPS_Backend::_detection_message(char *buffer, const uint8_t buflen) cons
 
 void AP_GPS_Backend::broadcast_gps_type() const
 {
-#ifndef HAL_NO_GCS
     char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     _detection_message(buffer, sizeof(buffer));
-    gcs().send_text(MAV_SEVERITY_INFO, "%s", buffer);
-#endif
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s", buffer);
 }
 
 void AP_GPS_Backend::Write_AP_Logger_Log_Startup_messages() const

--- a/libraries/AP_HAL_ChibiOS/hwdef/HitecMosaic/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HitecMosaic/hwdef.dat
@@ -172,4 +172,5 @@ define HAL_PERIPH_ENABLE_BARO
 define HAL_GPS_TYPE_DEFAULT 10
 define HAL_GPS_COM_PORT_DEFAULT 3
 define GPS_SBF_STREAM_NUMBER 3
+define GPS_SBF_EXTRA_CONFIG "sdfa, DSK1, DeleteOldest\n", "sfn, DSK1, Incremental, Mosaic\n", "sfno, off\n"
 


### PR DESCRIPTION
This reworks the SBF configuration loop to not send any configuration until we get the prompt from the GPS unit which indicates that it is ready to handle data. This also allows us to shorten the delay between sending each one of these commands and leads to a faster configuration loop. I tested this by hard resetting a the GPS receiver. Without this the HitecMosaic for example would fail to ever redetect the GPS.

At the same time we can now pass an additional set of hwdef specific commands to the SBF configuration loop, which allows us to do things like ensure the GPS SD card logging is setup appropriately. I've included an example of this in the HitecMosaic hwdef. (Except for the log name I think these are actually the better ways to be running your GPS logging).

@amilcarlucas I think this removes the need for #8253 if you have a setup to test with that would be great. One potential change we might need is to unset the `readyForCommand` flag whenever we inject data, but I don't have a good setup at the moment to test with.