### PR TITLE
Copter: GCS notification if ekf2 and ekf3 are selected

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -64,6 +64,7 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
         & gcs_failsafe_check(display_failure)
         & winch_checks(display_failure)
         & alt_checks(display_failure)
+        & ekf_checks(display_failure)
         & AP_Arming::pre_arm_checks(display_failure);
 }
 
@@ -615,6 +616,30 @@ bool AP_Arming_Copter::alt_checks(bool display_failure)
     if (!copter.flightmode->has_manual_throttle() && !copter.ekf_alt_ok()) {
         check_failed(display_failure, "Need Alt Estimate");
         return false;
+    }
+
+    return true;
+}
+
+/**
+ * ekf enable checks
+ * 
+ * @retval true passed
+ * @retval false failed
+ * @note If the CPU clock is FMUV6 class or higher, EKF2 and EKF3 can be used.<BR>
+ * ex: Cube Orange, Durandal
+ */
+bool AP_Arming_Copter::ekf_checks(bool display_failure)
+{
+    const AP_AHRS_NavEKF &ahrs = AP::ahrs_navekf();
+    if (ahrs.EKF2.isEnable() && ahrs.EKF2.isEnable()) {
+        check_failed(display_failure, "EKF2 and EKF3 is Enabled");
+        switch (AP_BoardConfig::get_board_type()) {
+        case AP_BoardConfig::PX4_BOARD_FMUV6:
+            return true;
+        default:
+            return false;
+        }
     }
 
     return true;

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -52,6 +52,7 @@ protected:
     bool gcs_failsafe_check(bool display_failure);
     bool winch_checks(bool display_failure) const;
     bool alt_checks(bool display_failure);
+    bool ekf_checks(bool display_failure);
 
     void set_pre_arm_check(bool b);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -313,6 +313,9 @@ public:
     // Writes the default equivalent airspeed in m/s to be used in forward flight if a measured airspeed is required and not available.
     void writeDefaultAirSpeed(float airspeed);
 
+    // EKF2 selected
+    bool isEnable(void) const { return _enable != 0; } 
+
 private:
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -371,6 +371,9 @@ public:
     // parameter conversion
     void convert_parameters();
 
+    // EKF3 selected
+    bool isEnable(void) const { return _enable != 0; } 
+
 private:
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core


### PR DESCRIPTION
I read Randy's comment.
I am more likely to recognize a misconfiguration by notifying me via message.

AFTER:
![Screenshot from 2021-01-23 06-57-36](https://user-images.githubusercontent.com/646194/105554208-37333d00-5d4a-11eb-8725-43d859c3f87c.png)

Randy commens:
It is best not to enable both EKF2 and EKF3 at the same time because it could overload the CPU on some autopilots. It is unlikely to crash but it may fly badly.

https://discuss.ardupilot.org/t/ardupilot-latest-switched-to-use-ekf3-by-default/66334
