### PR TITLE
Rover: Change delay method to hal scheduler delay

### DIFF
--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -298,9 +298,6 @@ private:
     bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
     void update_home();
 
-    // compat.cpp
-    void delay(uint32_t ms);
-
     // crash_check.cpp
     void crash_check();
 

--- a/Rover/compat.cpp
+++ b/Rover/compat.cpp
@@ -1,6 +1,0 @@
-#include "Rover.h"
-
-void Rover::delay(uint32_t ms)
-{
-    hal.scheduler->delay(ms);
-}

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -137,7 +137,7 @@ void Rover::startup_ground(void)
 
     #if(GROUND_START_DELAY > 0)
         gcs().send_text(MAV_SEVERITY_NOTICE, "<startup_ground> With delay");
-        delay(GROUND_START_DELAY * 1000);
+        hal.scheduler->delay(GROUND_START_DELAY * 1000);
     #endif
 
     // IMU ground start


### PR DESCRIPTION
There are two types of Delay in Rover.
The original Delay can be changed to the HAL scheduler Delay.
I deleted the file and changed the Delay.