### PR TITLE
RC_Channel: reserve AUX_FUNC for MISSION_RELATIVE

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -191,6 +191,7 @@ public:
         EKF_POS_SOURCE =      90, // change EKF position source between primary, secondary and tertiary sources
         ARSPD_CALIBRATE=      91, // calibrate airspeed ratio 
         FBWA =                92, // Fly-By-Wire-A
+        RELOCATE_MISSION =    93, // used in separate branch MISSION_RELATIVE
 
         // entries from 100 onwards are expected to be developer
         // options used for testing


### PR DESCRIPTION
Just to reserve an AUX_FUNC for use in separate branch as discussed on DevCallEU on 20.01.2021