### PR TITLE
Fixed handling of AHRS trim in calibration

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5639,6 +5639,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
              "Accelerometer Calibration testing",
              self.accelcal),
 
+            ("AHRSTrim",
+             "Accelerometer trim testing",
+             self.ahrstrim),
+             
             ("AP_Proximity_MAV",
              "Test MAV proximity backend",
              self.ap_proximity_mav),

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1112,12 +1112,12 @@ bool AP_InertialSensor::_calculate_trim(const Vector3f &accel_sample, float& tri
     trim_roll = atan2f(-accel_sample.y, -accel_sample.z);
     if (fabsf(trim_roll) > radians(10) ||
         fabsf(trim_pitch) > radians(10)) {
-        hal.console->printf("trim over maximum of 10 degrees\n");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "trim over maximum of 10 degrees");
         return false;
     }
-    hal.console->printf("Trim OK: roll=%.2f pitch=%.2f\n",
-                          (double)degrees(trim_roll),
-                          (double)degrees(trim_pitch));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Trim OK: roll=%.2f pitch=%.2f",
+                  (double)degrees(trim_roll),
+                  (double)degrees(trim_pitch));
     return true;
 }
 
@@ -2198,8 +2198,6 @@ MAV_RESULT AP_InertialSensor::simple_accel_cal()
 
     // flash leds to tell user to keep the IMU still
     AP_Notify::flags.initialising = true;
-
-    hal.console->printf("Simple accel cal");
 
     /*
       we do the accel calibration with no board rotation. This avoids

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1214,8 +1214,6 @@ bool AP_InertialSensor::calibrate_trim(float &trim_roll, float &trim_pitch)
         return false;
     }
 
-    _calibrating_accel = true;
-
     const uint8_t update_dt_milliseconds = (uint8_t)(1000.0f/get_loop_rate_hz()+0.5f);
 
     // wait 100ms for ins filter to rise
@@ -1246,11 +1244,9 @@ bool AP_InertialSensor::calibrate_trim(float &trim_roll, float &trim_pitch)
         goto failed;
     }
 
-    _calibrating_accel = false;
     return true;
 
 failed:
-    _calibrating_accel = false;
     return false;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -111,7 +111,7 @@ void AP_InertialSensor_SITL::generate_accel()
         float freq_variation = 0.12f;
 
         // add in sensor noise
-        accel += Vector3f(rand_float(), rand_float(), rand_float()) * accel_noise;
+        accel += Vector3f{rand_float(), rand_float(), rand_float()} * accel_noise;
 
         bool motors_on = sitl->throttle > sitl->ins_noise_throttle_min;
 
@@ -166,9 +166,7 @@ void AP_InertialSensor_SITL::generate_accel()
             Vector3f centripetal_accel = angular_rate % (angular_rate % pos_offset);
 
             // apply corrections
-            accel.x += lever_arm_accel.x + centripetal_accel.x;
-            accel.y += lever_arm_accel.y + centripetal_accel.y;
-            accel.z += lever_arm_accel.z + centripetal_accel.z;
+            accel += lever_arm_accel + centripetal_accel;
         }
 
         if (fabsf(sitl->accel_fail[accel_instance]) > 1.0e-6f) {

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -386,6 +386,7 @@ const AP_Param::GroupInfo SITL::var_ins[] = {
     AP_GROUPINFO("ACC1_SCAL",    22, SITL, accel_scale[0], 0),
     AP_GROUPINFO("ACC2_SCAL",    23, SITL, accel_scale[1], 0),
     AP_GROUPINFO("ACC3_SCAL",    24, SITL, accel_scale[2], 0),
+    AP_GROUPINFO("ACC_TRIM",     25, SITL, accel_trim, 0),
 
     // the IMUT parameters must be last due to the enable parameters
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SITL, AP_InertialSensor::TCal),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -450,6 +450,7 @@ public:
     AP_Float accel_noise[INS_MAX_INSTANCES]; // in m/s/s
     AP_Vector3f accel_bias[INS_MAX_INSTANCES]; // in m/s/s
     AP_Vector3f accel_scale[INS_MAX_INSTANCES]; // in m/s/s
+    AP_Vector3f accel_trim;
     AP_Float accel_fail[INS_MAX_INSTANCES];  // accelerometer failure value
     // gyro and accel fail masks
     AP_Int8 gyro_fail_mask;


### PR DESCRIPTION
This fixes a bug introduced in the temperature calibration PR that made the AHRS trim values incorrect. The bug happened as we did not apply accel biases during AHRS trim calibration.
I've also added an autotest for AHRS trim, and added trim checking to the existing accel cal test
Many thanks to @Hwurzburg for finding this issue