### PR TITLE
AP_NavEKF3: fix using_external_yaw when using external nav

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -537,16 +537,16 @@ bool NavEKF3_core::use_compass(void) const
 // are we using a yaw source other than the magnetomer?
 bool NavEKF3_core::using_external_yaw(void) const
 {
-#if EK3_FEATURE_EXTERNAL_NAV
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
-    if (yaw_source == AP_NavEKF_Source::SourceYaw::GPS || yaw_source == AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK ||
-        yaw_source == AP_NavEKF_Source::SourceYaw::GSF || !use_compass()) {
-        return imuSampleTime_ms - last_gps_yaw_fusion_ms < 5000 || imuSampleTime_ms - lastSynthYawTime_ms < 5000;
-    }
+#if EK3_FEATURE_EXTERNAL_NAV
     if (yaw_source == AP_NavEKF_Source::SourceYaw::EXTNAV) {
         return ((imuSampleTime_ms - last_extnav_yaw_fusion_ms < 5000) || (imuSampleTime_ms - lastSynthYawTime_ms < 5000));
     }
 #endif
+    if (yaw_source == AP_NavEKF_Source::SourceYaw::GPS || yaw_source == AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK ||
+        yaw_source == AP_NavEKF_Source::SourceYaw::GSF || !use_compass()) {
+        return imuSampleTime_ms - last_gps_yaw_fusion_ms < 5000 || imuSampleTime_ms - lastSynthYawTime_ms < 5000;
+    }
     return false;
 }
 


### PR DESCRIPTION
This PR fixes a bug in EKF3's using_external_yaw() method that lead to users being unable to arm the vehicle when using ExternalNav for yaw (i.e. vicon, T265) if there is no compass on the autopilot even if ARMING_CHECK = 0.

The issue is that in master, "AP_NavEKF3_core::use_compass()" always returned false if EK3_SRCx_YAW = ExtNav.  This meant the 2nd "if" would never be run and so the method would never return true for external nav.  The fix is to move the external nav test higher in the method.

The issue was reproduced in SITL by doing the following:

- Start copter in SITL and [enable vicon as described on the wiki](https://ardupilot.org/dev/docs/using-sitl-for-ardupilot-testing.html#testing-vicon-aka-vision-positioning)
- param set SIM_MAG1_FAIL 1
- param set SIM_MAG2_FAIL 1
- param set SIM_MAG3_FAIL 1
- param set ARMING_CHECK 0
- arm throttle

Before and after results are shown below in SITL
![sitl-before-after](https://user-images.githubusercontent.com/1498098/106884423-a33b7b00-6724-11eb-9269-c0f4c40cae42.png)

The regular case where compass is enabled (but sensor has failed) was also tested and we correctly see the vehicle failed to arm.
![sitl-retest-default-behaviour](https://user-images.githubusercontent.com/1498098/106885734-61133900-6726-11eb-8963-1cfadda0a8bf.png)

This has been tested in SITL and on a real vehicle.

Thanks very much to @Davidsastresas for finding this!
