### PR TITLE
Copter Mode enum class

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -84,17 +84,18 @@ enum tuning_func {
 #define WP_YAW_BEHAVIOR_LOOK_AHEAD                    3   // auto pilot will look ahead during missions and rtl (primarily meant for traditional helicopters)
 
 // Auto modes
-enum AutoMode {
-    Auto_TakeOff,
-    Auto_WP,
-    Auto_Land,
-    Auto_RTL,
-    Auto_CircleMoveToEdge,
-    Auto_Circle,
-    Auto_NavGuided,
-    Auto_Loiter,
-    Auto_LoiterToAlt,
-    Auto_NavPayloadPlace,
+enum class AutoMode : uint8_t {
+    TAKEOFF,
+    WP,
+    LAND,
+    RTL,
+    CIRCLE_MOVE_TO_EDGE,
+    CIRCLE,
+    SPLINE,
+    NAVGUIDED,
+    LOITER,
+    LOITER_TO_ALT,
+    NAV_PAYLOAD_PLACE,
 };
 
 // Airmode

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -106,12 +106,12 @@ enum class AirMode {
 };
 
 // Safe RTL states
-enum SmartRTLState {
-    SmartRTL_WaitForPathCleanup,
-    SmartRTL_PathFollow,
-    SmartRTL_PreLandPosition,
-    SmartRTL_Descend,
-    SmartRTL_Land
+enum class SmartRTLState : uint8_t {
+    WAIT_FOR_PATH_CLEANUP,
+    PATH_FOLLOW,
+    PRELAND_POSITION,
+    DESCEND,
+    LAND
 };
 
 enum PayloadPlaceStateType {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -83,20 +83,6 @@ enum tuning_func {
 #define WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL    2   // auto pilot will face next waypoint except when doing RTL at which time it will stay in it's last
 #define WP_YAW_BEHAVIOR_LOOK_AHEAD                    3   // auto pilot will look ahead during missions and rtl (primarily meant for traditional helicopters)
 
-// Auto modes
-enum class AutoMode : uint8_t {
-    TAKEOFF,
-    WP,
-    LAND,
-    RTL,
-    CIRCLE_MOVE_TO_EDGE,
-    CIRCLE,
-    SPLINE,
-    NAVGUIDED,
-    LOITER,
-    LOITER_TO_ALT,
-    NAV_PAYLOAD_PLACE,
-};
 
 // Airmode
 enum class AirMode {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -91,15 +91,6 @@ enum class AirMode {
     AIRMODE_ENABLED,
 };
 
-// Safe RTL states
-enum class SmartRTLState : uint8_t {
-    WAIT_FOR_PATH_CLEANUP,
-    PATH_FOLLOW,
-    PRELAND_POSITION,
-    DESCEND,
-    LAND
-};
-
 enum PayloadPlaceStateType {
     PayloadPlaceStateType_FlyToLocation,
     PayloadPlaceStateType_Calibrating_Hover_Start,

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1239,7 +1239,7 @@ private:
     void path_follow_run();
     void pre_land_position_run();
     void land();
-    SmartRTLState smart_rtl_state = SmartRTL_PathFollow;
+    SmartRTLState smart_rtl_state = SmartRTLState::PATH_FOLLOW;
 
     // keep track of how long we have failed to get another return
     // point while following our path home.  If we take too long we

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1116,13 +1116,13 @@ public:
     bool get_wp(Location &loc) override;
 
     // RTL states
-    enum RTLState {
-        RTL_Starting,
-        RTL_InitialClimb,
-        RTL_ReturnHome,
-        RTL_LoiterAtHome,
-        RTL_FinalDescent,
-        RTL_Land
+    enum class RTLState : uint8_t {
+        STARTING,
+        INITIAL_CLIMB,
+        RETURN_HOME,
+        LOITER_AT_HOME,
+        FINAL_DESCENT,
+        LAND
     };
     RTLState state() { return _state; }
 
@@ -1167,7 +1167,7 @@ private:
     void build_path();
     void compute_return_target();
 
-    RTLState _state = RTL_InitialClimb;  // records state of rtl (initial climb, returning home, etc)
+    RTLState _state = RTLState::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1237,7 +1237,7 @@ public:
     bool is_landing() const override;
 
     // Safe RTL states
-    enum class SmartRTLState : uint8_t {
+    enum class SubMode : uint8_t {
         WAIT_FOR_PATH_CLEANUP,
         PATH_FOLLOW,
         PRELAND_POSITION,
@@ -1262,7 +1262,7 @@ private:
     void path_follow_run();
     void pre_land_position_run();
     void land();
-    SmartRTLState smart_rtl_state = SmartRTLState::PATH_FOLLOW;
+    SubMode smart_rtl_state = SubMode::PATH_FOLLOW;
 
     // keep track of how long we have failed to get another return
     // point while following our path home.  If we take too long we

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -358,7 +358,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override;
     bool is_autopilot() const override { return true; }
-    bool in_guided_mode() const override { return mode() == Auto_NavGuided; }
+    bool in_guided_mode() const override { return mode() == AutoMode::NAVGUIDED; }
 
     // Auto
     AutoMode mode() const { return _mode; }
@@ -437,7 +437,7 @@ private:
     void payload_place_run_descend();
     void payload_place_run_release();
 
-    AutoMode _mode = Auto_TakeOff;   // controls which auto controller is run
+    AutoMode _mode = AutoMode::TAKEOFF;   // controls which auto controller is run
 
     Location terrain_adjusted_location(const AP_Mission::Mission_Command& cmd) const;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -358,17 +358,16 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override;
     bool is_autopilot() const override { return true; }
-    bool in_guided_mode() const override { return mode() == AutoMode::NAVGUIDED; }
+    bool in_guided_mode() const override { return mode() == SubMode::NAVGUIDED; }
 
     // Auto modes
-    enum class AutoMode : uint8_t {
+    enum class SubMode : uint8_t {
         TAKEOFF,
         WP,
         LAND,
         RTL,
         CIRCLE_MOVE_TO_EDGE,
         CIRCLE,
-        SPLINE,
         NAVGUIDED,
         LOITER,
         LOITER_TO_ALT,
@@ -376,7 +375,7 @@ public:
     };
 
     // Auto
-    AutoMode mode() const { return _mode; }
+    SubMode mode() const { return _mode; }
 
     bool loiter_start();
     void rtl_start();
@@ -452,7 +451,7 @@ private:
     void payload_place_run_descend();
     void payload_place_run_release();
 
-    AutoMode _mode = AutoMode::TAKEOFF;   // controls which auto controller is run
+    SubMode _mode = SubMode::TAKEOFF;   // controls which auto controller is run
 
     Location terrain_adjusted_location(const AP_Mission::Mission_Command& cmd) const;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -360,6 +360,21 @@ public:
     bool is_autopilot() const override { return true; }
     bool in_guided_mode() const override { return mode() == AutoMode::NAVGUIDED; }
 
+    // Auto modes
+    enum class AutoMode : uint8_t {
+        TAKEOFF,
+        WP,
+        LAND,
+        RTL,
+        CIRCLE_MOVE_TO_EDGE,
+        CIRCLE,
+        SPLINE,
+        NAVGUIDED,
+        LOITER,
+        LOITER_TO_ALT,
+        NAV_PAYLOAD_PLACE,
+    };
+
     // Auto
     AutoMode mode() const { return _mode; }
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1130,7 +1130,7 @@ public:
     bool get_wp(Location &loc) override;
 
     // RTL states
-    enum class RTLState : uint8_t {
+    enum class SubMode : uint8_t {
         STARTING,
         INITIAL_CLIMB,
         RETURN_HOME,
@@ -1138,7 +1138,7 @@ public:
         FINAL_DESCENT,
         LAND
     };
-    RTLState state() { return _state; }
+    SubMode state() { return _state; }
 
     // this should probably not be exposed
     bool state_complete() const { return _state_complete; }
@@ -1181,7 +1181,7 @@ private:
     void build_path();
     void compute_return_target();
 
-    RTLState _state = RTLState::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)
+    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1237,6 +1237,15 @@ public:
 
     bool is_landing() const override;
 
+    // Safe RTL states
+    enum class SmartRTLState : uint8_t {
+        WAIT_FOR_PATH_CLEANUP,
+        PATH_FOLLOW,
+        PRELAND_POSITION,
+        DESCEND,
+        LAND
+    };
+
 protected:
 
     const char *name() const override { return "SMARTRTL"; }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -23,7 +23,7 @@
 bool ModeAuto::init(bool ignore_checks)
 {
     if (mission.num_commands() > 1 || ignore_checks) {
-        _mode = Auto_Loiter;
+        _mode = AutoMode::LOITER;
 
         // reject switching to auto mode if landed with motors armed but first command is not a takeoff (reduce chance of flips)
         if (motors->armed() && copter.ap.land_complete && !mission.starts_with_takeoff_cmd()) {
@@ -86,7 +86,7 @@ void ModeAuto::run()
         // check for mission changes
         if (check_for_mission_change()) {
             // if mission is running restart the current command if it is a waypoint or spline command
-            if ((copter.mode_auto.mission.state() == AP_Mission::MISSION_RUNNING) && (_mode == Auto_WP)) {
+            if ((copter.mode_auto.mission.state() == AP_Mission::MISSION_RUNNING) && (_mode == AutoMode::WP)) {
                 if (mission.restart_current_nav_cmd()) {
                     gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto mission changed, restarted command");
                 } else {
@@ -102,42 +102,42 @@ void ModeAuto::run()
     // call the correct auto controller
     switch (_mode) {
 
-    case Auto_TakeOff:
+    case AutoMode::TAKEOFF:
         takeoff_run();
         break;
 
-    case Auto_WP:
-    case Auto_CircleMoveToEdge:
+    case AutoMode::WP:
+    case AutoMode::CIRCLE_MOVE_TO_EDGE:
         wp_run();
         break;
 
-    case Auto_Land:
+    case AutoMode::LAND:
         land_run();
         break;
 
-    case Auto_RTL:
+    case AutoMode::RTL:
         rtl_run();
         break;
 
-    case Auto_Circle:
+    case AutoMode::CIRCLE:
         circle_run();
         break;
 
-    case Auto_NavGuided:
+    case AutoMode::NAVGUIDED:
 #if NAV_GUIDED == ENABLED
         nav_guided_run();
 #endif
         break;
 
-    case Auto_Loiter:
+    case AutoMode::LOITER:
         loiter_run();
         break;
 
-    case Auto_LoiterToAlt:
+    case AutoMode::LOITER_TO_ALT:
         loiter_to_alt_run();
         break;
 
-    case Auto_NavPayloadPlace:
+    case AutoMode::NAV_PAYLOAD_PLACE:
         payload_place_run();
         break;
     }
@@ -156,7 +156,7 @@ bool ModeAuto::loiter_start()
     if (!copter.position_ok()) {
         return false;
     }
-    _mode = Auto_Loiter;
+    _mode = AutoMode::LOITER;
 
     // calculate stopping point
     Vector3f stopping_point;
@@ -174,7 +174,7 @@ bool ModeAuto::loiter_start()
 // auto_rtl_start - initialises RTL in AUTO flight mode
 void ModeAuto::rtl_start()
 {
-    _mode = Auto_RTL;
+    _mode = AutoMode::RTL;
 
     // call regular rtl flight mode initialisation and ask it to ignore checks
     copter.mode_rtl.init(true);
@@ -183,7 +183,7 @@ void ModeAuto::rtl_start()
 // auto_takeoff_start - initialises waypoint controller to implement take-off
 void ModeAuto::takeoff_start(const Location& dest_loc)
 {
-    _mode = Auto_TakeOff;
+    _mode = AutoMode::TAKEOFF;
 
     Location dest(dest_loc);
 
@@ -242,7 +242,7 @@ void ModeAuto::wp_start(const Location& dest_loc)
         return;
     }
 
-    _mode = Auto_WP;
+    _mode = AutoMode::WP;
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
@@ -265,7 +265,7 @@ void ModeAuto::land_start()
 // auto_land_start - initialises controller to implement a landing
 void ModeAuto::land_start(const Vector3f& destination)
 {
-    _mode = Auto_Land;
+    _mode = AutoMode::LAND;
 
     // initialise loiter target destination
     loiter_nav->init_target(destination);
@@ -310,7 +310,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
     // if more than 3m then fly to edge
     if (dist_to_edge > 300.0f) {
         // set the state to move to the edge of the circle
-        _mode = Auto_CircleMoveToEdge;
+        _mode = AutoMode::CIRCLE_MOVE_TO_EDGE;
 
         // convert circle_edge_neu to Location
         Location circle_edge(circle_edge_neu, Location::AltFrame::ABOVE_ORIGIN);
@@ -347,7 +347,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
 //   assumes that circle_nav object has already been initialised with circle center and radius
 void ModeAuto::circle_start()
 {
-    _mode = Auto_Circle;
+    _mode = AutoMode::CIRCLE;
 
     // initialise circle controller
     copter.circle_nav->init(copter.circle_nav->get_center(), copter.circle_nav->center_is_terrain_alt());
@@ -361,7 +361,7 @@ void ModeAuto::circle_start()
 // auto_nav_guided_start - hand over control to external navigation controller in AUTO mode
 void ModeAuto::nav_guided_start()
 {
-    _mode = Auto_NavGuided;
+    _mode = AutoMode::NAVGUIDED;
 
     // call regular guided flight mode initialisation
     copter.mode_guided.init(true);
@@ -374,9 +374,9 @@ void ModeAuto::nav_guided_start()
 bool ModeAuto::is_landing() const
 {
     switch(_mode) {
-    case Auto_Land:
+    case AutoMode::LAND:
         return true;
-    case Auto_RTL:
+    case AutoMode::RTL:
         return copter.mode_rtl.is_landing();
     default:
         return false;
@@ -386,7 +386,7 @@ bool ModeAuto::is_landing() const
 
 bool ModeAuto::is_taking_off() const
 {
-    return ((_mode == Auto_TakeOff) && !wp_nav->reached_wp_destination());
+    return ((_mode == AutoMode::TAKEOFF) && !wp_nav->reached_wp_destination());
 }
 
 // auto_payload_place_start - initialises controller to implement a placing
@@ -608,7 +608,7 @@ bool ModeAuto::check_for_mission_change()
 bool ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 {
     // only process guided waypoint if we are in guided mode
-    if (copter.flightmode->mode_number() != Mode::Number::GUIDED && !(copter.flightmode->mode_number() == Mode::Number::AUTO && mode() == Auto_NavGuided)) {
+    if (copter.flightmode->mode_number() != Mode::Number::GUIDED && !(copter.flightmode->mode_number() == Mode::Number::AUTO && mode() == AutoMode::NAVGUIDED)) {
         return false;
     }
 
@@ -637,10 +637,10 @@ bool ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 uint32_t ModeAuto::wp_distance() const
 {
     switch (_mode) {
-    case Auto_Circle:
+    case AutoMode::CIRCLE:
         return copter.circle_nav->get_distance_to_target();
-    case Auto_WP:
-    case Auto_CircleMoveToEdge:
+    case AutoMode::WP:
+    case AutoMode::CIRCLE_MOVE_TO_EDGE:
     default:
         return wp_nav->get_wp_distance_to_destination();
     }
@@ -649,10 +649,10 @@ uint32_t ModeAuto::wp_distance() const
 int32_t ModeAuto::wp_bearing() const
 {
     switch (_mode) {
-    case Auto_Circle:
+    case AutoMode::CIRCLE:
         return copter.circle_nav->get_bearing_to_target();
-    case Auto_WP:
-    case Auto_CircleMoveToEdge:
+    case AutoMode::WP:
+    case AutoMode::CIRCLE_MOVE_TO_EDGE:
     default:
         return wp_nav->get_wp_bearing_to_destination();
     }
@@ -661,11 +661,11 @@ int32_t ModeAuto::wp_bearing() const
 bool ModeAuto::get_wp(Location& destination)
 {
     switch (_mode) {
-    case Auto_NavGuided:
+    case AutoMode::NAVGUIDED:
         return copter.mode_guided.get_wp(destination);
-    case Auto_WP:
+    case AutoMode::WP:
         return wp_nav->get_oa_wp_destination(destination);
-    case Auto_RTL:
+    case AutoMode::RTL:
         return copter.mode_rtl.get_wp(destination);
     default:
         return false;
@@ -955,7 +955,7 @@ void ModeAuto::loiter_to_alt_run()
     if (!loiter_to_alt.loiter_start_done) {
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-        _mode = Auto_LoiterToAlt;
+        _mode = AutoMode::LOITER_TO_ALT;
         loiter_to_alt.loiter_start_done = true;
     }
     const float alt_error_cm = copter.current_loc.alt - loiter_to_alt.alt;
@@ -989,7 +989,7 @@ void ModeAuto::loiter_to_alt_run()
 // auto_payload_place_start - initialises controller to implement placement of a load
 void ModeAuto::payload_place_start(const Vector3f& destination)
 {
-    _mode = Auto_NavPayloadPlace;
+    _mode = AutoMode::NAV_PAYLOAD_PLACE;
     nav_payload_place.state = PayloadPlaceStateType_Calibrating_Hover_Start;
 
     // initialise loiter target destination
@@ -1153,7 +1153,7 @@ void ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
         return;
     }
 
-    _mode = Auto_WP;
+    _mode = AutoMode::WP;
 
     // this will be used to remember the time in millis after we reach or pass the WP.
     loiter_time = 0;
@@ -1309,7 +1309,7 @@ void ModeAuto::do_loiter_to_alt(const AP_Mission::Mission_Command& cmd)
 {
     // re-use loiter unlimited
     do_loiter_unlimited(cmd);
-    _mode = Auto_LoiterToAlt;
+    _mode = AutoMode::LOITER_TO_ALT;
 
     // if we aren't navigating to a location then we have to adjust
     // altitude for current location
@@ -1357,7 +1357,7 @@ void ModeAuto::do_spline_wp(const AP_Mission::Mission_Command& cmd)
         return;
     }
 
-    _mode = Auto_WP;
+    _mode = AutoMode::WP;
 
     // this will be used to remember the time in millis after we reach or pass the WP.
     loiter_time = 0;
@@ -1903,7 +1903,7 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 bool ModeAuto::verify_circle(const AP_Mission::Mission_Command& cmd)
 {
     // check if we've reached the edge
-    if (mode() == Auto_CircleMoveToEdge) {
+    if (mode() == AutoMode::CIRCLE_MOVE_TO_EDGE) {
         if (copter.wp_nav->reached_wp_destination()) {
             // start circling
             circle_start();

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1832,7 +1832,7 @@ bool ModeAuto::verify_loiter_to_alt() const
 bool ModeAuto::verify_RTL()
 {
     return (copter.mode_rtl.state_complete() && 
-            (copter.mode_rtl.state() == ModeRTL::RTLState::FINAL_DESCENT || copter.mode_rtl.state() == ModeRTL::RTLState::LAND) &&
+            (copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT || copter.mode_rtl.state() == ModeRTL::SubMode::LAND) &&
             (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
 }
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1832,7 +1832,7 @@ bool ModeAuto::verify_loiter_to_alt() const
 bool ModeAuto::verify_RTL()
 {
     return (copter.mode_rtl.state_complete() && 
-            (copter.mode_rtl.state() == ModeRTL::RTL_FinalDescent || copter.mode_rtl.state() == ModeRTL::RTL_Land) &&
+            (copter.mode_rtl.state() == ModeRTL::RTLState::FINAL_DESCENT || copter.mode_rtl.state() == ModeRTL::RTLState::LAND) &&
             (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
 }
 

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -19,7 +19,7 @@ bool ModeRTL::init(bool ignore_checks)
     }
     // initialise waypoint and spline controller
     wp_nav->wp_and_spline_init(g.rtl_speed_cms);
-    _state = RTLState::STARTING;
+    _state = SubMode::STARTING;
     _state_complete = true; // see run() method below
     terrain_following_allowed = !copter.failsafe.terrain;
     return true;
@@ -30,7 +30,7 @@ void ModeRTL::restart_without_terrain()
 {
     AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::RESTARTED_RTL);
     terrain_following_allowed = false;
-    _state = RTLState::STARTING;
+    _state = SubMode::STARTING;
     _state_complete = true;
     gcs().send_text(MAV_SEVERITY_CRITICAL,"Restarting RTL - Terrain data missing");
 }
@@ -55,27 +55,27 @@ void ModeRTL::run(bool disarm_on_land)
     // check if we need to move to next state
     if (_state_complete) {
         switch (_state) {
-        case RTLState::STARTING:
+        case SubMode::STARTING:
             build_path();
             climb_start();
             break;
-        case RTLState::INITIAL_CLIMB:
+        case SubMode::INITIAL_CLIMB:
             return_start();
             break;
-        case RTLState::RETURN_HOME:
+        case SubMode::RETURN_HOME:
             loiterathome_start();
             break;
-        case RTLState::LOITER_AT_HOME:
+        case SubMode::LOITER_AT_HOME:
             if (rtl_path.land || copter.failsafe.radio) {
                 land_start();
             }else{
                 descent_start();
             }
             break;
-        case RTLState::FINAL_DESCENT:
+        case SubMode::FINAL_DESCENT:
             // do nothing
             break;
-        case RTLState::LAND:
+        case SubMode::LAND:
             // do nothing - rtl_land_run will take care of disarming motors
             break;
         }
@@ -84,28 +84,28 @@ void ModeRTL::run(bool disarm_on_land)
     // call the correct run function
     switch (_state) {
 
-    case RTLState::STARTING:
+    case SubMode::STARTING:
         // should not be reached:
-        _state = RTLState::INITIAL_CLIMB;
+        _state = SubMode::INITIAL_CLIMB;
         FALLTHROUGH;
 
-    case RTLState::INITIAL_CLIMB:
+    case SubMode::INITIAL_CLIMB:
         climb_return_run();
         break;
 
-    case RTLState::RETURN_HOME:
+    case SubMode::RETURN_HOME:
         climb_return_run();
         break;
 
-    case RTLState::LOITER_AT_HOME:
+    case SubMode::LOITER_AT_HOME:
         loiterathome_run();
         break;
 
-    case RTLState::FINAL_DESCENT:
+    case SubMode::FINAL_DESCENT:
         descent_run();
         break;
 
-    case RTLState::LAND:
+    case SubMode::LAND:
         land_run(disarm_on_land);
         break;
     }
@@ -114,7 +114,7 @@ void ModeRTL::run(bool disarm_on_land)
 // rtl_climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
-    _state = RTLState::INITIAL_CLIMB;
+    _state = SubMode::INITIAL_CLIMB;
     _state_complete = false;
 
     // set the destination
@@ -133,7 +133,7 @@ void ModeRTL::climb_start()
 // rtl_return_start - initialise return to home
 void ModeRTL::return_start()
 {
-    _state = RTLState::RETURN_HOME;
+    _state = SubMode::RETURN_HOME;
     _state_complete = false;
 
     if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
@@ -190,7 +190,7 @@ void ModeRTL::climb_return_run()
 // loiterathome_start - initialise return to home
 void ModeRTL::loiterathome_start()
 {
-    _state = RTLState::LOITER_AT_HOME;
+    _state = SubMode::LOITER_AT_HOME;
     _state_complete = false;
     _loiter_start_time = millis();
 
@@ -257,7 +257,7 @@ void ModeRTL::loiterathome_run()
 // rtl_descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
-    _state = RTLState::FINAL_DESCENT;
+    _state = SubMode::FINAL_DESCENT;
     _state_complete = false;
 
     // Set wp navigation target to above home
@@ -349,7 +349,7 @@ void ModeRTL::descent_run()
 // land_start - initialise controllers to loiter over home
 void ModeRTL::land_start()
 {
-    _state = RTLState::LAND;
+    _state = SubMode::LAND;
     _state_complete = false;
 
     // Set wp navigation target to above home
@@ -377,7 +377,7 @@ void ModeRTL::land_start()
 
 bool ModeRTL::is_landing() const
 {
-    return _state == RTLState::LAND;
+    return _state == SubMode::LAND;
 }
 
 // land_run - run the landing controllers to put the aircraft on the ground
@@ -546,13 +546,13 @@ bool ModeRTL::get_wp(Location& destination)
 {
     // provide target in states which use wp_nav
     switch (_state) {
-    case RTLState::STARTING:
-    case RTLState::INITIAL_CLIMB:
-    case RTLState::RETURN_HOME:
-    case RTLState::LOITER_AT_HOME:
-    case RTLState::FINAL_DESCENT:
+    case SubMode::STARTING:
+    case SubMode::INITIAL_CLIMB:
+    case SubMode::RETURN_HOME:
+    case SubMode::LOITER_AT_HOME:
+    case SubMode::FINAL_DESCENT:
         return wp_nav->get_oa_wp_destination(destination);
-    case RTLState::LAND:
+    case SubMode::LAND:
         return false;
     }
 

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -25,7 +25,7 @@ bool ModeSmartRTL::init(bool ignore_checks)
         auto_yaw.set_mode_to_default(true);
 
         // wait for cleanup of return path
-        smart_rtl_state = SmartRTL_WaitForPathCleanup;
+        smart_rtl_state = SmartRTLState::WAIT_FOR_PATH_CLEANUP;
         return true;
     }
 
@@ -41,19 +41,19 @@ void ModeSmartRTL::exit()
 void ModeSmartRTL::run()
 {
     switch (smart_rtl_state) {
-        case SmartRTL_WaitForPathCleanup:
+        case SmartRTLState::WAIT_FOR_PATH_CLEANUP:
             wait_cleanup_run();
             break;
-        case SmartRTL_PathFollow:
+        case SmartRTLState::PATH_FOLLOW:
             path_follow_run();
             break;
-        case SmartRTL_PreLandPosition:
+        case SmartRTLState::PRELAND_POSITION:
             pre_land_position_run();
             break;
-        case SmartRTL_Descend:
+        case SmartRTLState::DESCEND:
             descent_run(); // Re-using the descend method from normal rtl mode.
             break;
-        case SmartRTL_Land:
+        case SmartRTLState::LAND:
             land_run(true); // Re-using the land method from normal rtl mode.
             break;
     }
@@ -61,7 +61,7 @@ void ModeSmartRTL::run()
 
 bool ModeSmartRTL::is_landing() const
 {
-    return smart_rtl_state == SmartRTL_Land;
+    return smart_rtl_state == SmartRTLState::LAND;
 }
 
 void ModeSmartRTL::wait_cleanup_run()
@@ -75,7 +75,7 @@ void ModeSmartRTL::wait_cleanup_run()
     // check if return path is computed and if yes, begin journey home
     if (g2.smart_rtl.request_thorough_cleanup()) {
         path_follow_last_pop_fail_ms = 0;
-        smart_rtl_state = SmartRTL_PathFollow;
+        smart_rtl_state = SmartRTLState::PATH_FOLLOW;
     }
 }
 
@@ -100,7 +100,7 @@ void ModeSmartRTL::path_follow_run()
             if (g2.smart_rtl.get_num_points() == 0) {
                 // this is the very last point, add 2m to the target alt and move to pre-land state
                 dest_NED.z -= 2.0f;
-                smart_rtl_state = SmartRTL_PreLandPosition;
+                smart_rtl_state = SmartRTLState::PRELAND_POSITION;
                 wp_nav->set_wp_destination_NED(dest_NED);
             } else {
                 // peek at the next point.  this can fail if the IO task currently has the path semaphore
@@ -123,7 +123,7 @@ void ModeSmartRTL::path_follow_run()
             // We should never get here; should always have at least
             // two points and the "zero points left" is handled above.
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-            smart_rtl_state = SmartRTL_PreLandPosition;
+            smart_rtl_state = SmartRTLState::PRELAND_POSITION;
         } else if (path_follow_last_pop_fail_ms == 0) {
             // first time we've failed to pop off (ever, or after a success)
             path_follow_last_pop_fail_ms = AP_HAL::millis();
@@ -131,7 +131,7 @@ void ModeSmartRTL::path_follow_run()
             // we failed to pop a point off for 10 seconds.  This is
             // almost certainly a bug.
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-            smart_rtl_state = SmartRTL_PreLandPosition;
+            smart_rtl_state = SmartRTLState::PRELAND_POSITION;
         }
     }
 
@@ -157,11 +157,11 @@ void ModeSmartRTL::pre_land_position_run()
         // choose descend and hold, or land based on user parameter rtl_alt_final
         if (g.rtl_alt_final <= 0 || copter.failsafe.radio) {
             land_start();
-            smart_rtl_state = SmartRTL_Land;
+            smart_rtl_state = SmartRTLState::LAND;
         } else {
             set_descent_target_alt(copter.g.rtl_alt_final);
             descent_start();
-            smart_rtl_state = SmartRTL_Descend;
+            smart_rtl_state = SmartRTLState::DESCEND;
         }
     }
 
@@ -184,12 +184,12 @@ bool ModeSmartRTL::get_wp(Location& destination)
 {
     // provide target in states which use wp_nav
     switch (smart_rtl_state) {
-    case SmartRTL_WaitForPathCleanup:
-    case SmartRTL_PathFollow:
-    case SmartRTL_PreLandPosition:
-    case SmartRTL_Descend:
+    case SmartRTLState::WAIT_FOR_PATH_CLEANUP:
+    case SmartRTLState::PATH_FOLLOW:
+    case SmartRTLState::PRELAND_POSITION:
+    case SmartRTLState::DESCEND:
         return wp_nav->get_wp_destination_loc(destination);
-    case SmartRTL_Land:
+    case SmartRTLState::LAND:
         return false;
     }
 


### PR DESCRIPTION
This change Copter mode enum to enum class and move them to the mode class to limit their scope.

This is mostly a renaming, that doesn't bring changes. The enum class bring scope and type safety on compile time. The move into the class scope should reduce compile time.

Those change are covered by the compiler and autotest