### PR TITLE
Use buffered writes for CRSF telemetry

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -266,7 +266,6 @@ void AP_RCProtocol::check_added_uart(void)
             added.uart->configure_parity(0);
             added.uart->set_stop_bits(1);
             added.uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
-            added.uart->set_unbuffered_writes(true);
             added.uart->set_blocking_writes(false);
             added.uart->set_options(added.uart->get_options() & ~AP_HAL::UARTDriver::OPTION_RXINV);
             break;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -370,7 +370,6 @@ void AP_RCProtocol_CRSF::start_uart()
     _uart->configure_parity(0);
     _uart->set_stop_bits(1);
     _uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
-    _uart->set_unbuffered_writes(true);
     _uart->set_blocking_writes(false);
     _uart->set_options(_uart->get_options() & ~AP_HAL::UARTDriver::OPTION_RXINV);
     _uart->begin(CRSF_BAUDRATE, 128, 128);


### PR DESCRIPTION
Our use of unbuffered writes in CRSF puts a lot of pressure on the calling thread and is an inefficient use of the UART and DMA channel. This PR switches off unbuffered writes. I verified that I still get 250Hz telemetry on a tracer setup.