### PR TITLE
AP_ICEngine: make it obvious that update_idle_gov does nothing while disabled

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -383,6 +383,9 @@ bool AP_ICEngine::engine_control(float start_control, float cold_start, float he
 */
 void AP_ICEngine::update_idle_governor(int8_t &min_throttle)
 {
+    if (!enable) {
+        return;
+    }
     const int8_t min_throttle_base = min_throttle;
 
     // Initialize idle point to min_throttle on the first run


### PR DESCRIPTION
This makes it obvious that AP_ICEngine::update_idle_governor() does nothing while ICE disabled. This is a non-behavior change, just makes it easier to see that this doesn't do anything to the throttle while disabled which is the usual case.