### PR TITLE
Privatize AP_InertialSensor Logging

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -98,7 +98,7 @@ void Tracker::one_second_loop()
 void Tracker::ten_hz_logging_loop()
 {
     if (should_log(MASK_LOG_IMU)) {
-        logger.Write_IMU();
+        AP::ins().Write_IMU();
     }
     if (should_log(MASK_LOG_ATTITUDE)) {
         Log_Write_Attitude();

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -423,7 +423,7 @@ void Copter::ten_hz_logging_loop()
         pos_control->write_log();
     }
     if (should_log(MASK_LOG_IMU) || should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {
-        logger.Write_Vibration();
+        AP::ins().Write_Vibration();
     }
     if (should_log(MASK_LOG_CTUN)) {
         attitude_control->control_monitor_log();
@@ -458,7 +458,7 @@ void Copter::twentyfive_hz_logging()
     }
 
     if (should_log(MASK_LOG_IMU)) {
-        logger.Write_IMU();
+        AP::ins().Write_IMU();
     }
 #endif
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -143,7 +143,7 @@ void Plane::ahrs_update()
     ahrs.update();
 
     if (should_log(MASK_LOG_IMU)) {
-        logger.Write_IMU();
+        AP::ins().Write_IMU();
     }
 
     // calculate a scaled roll limit based on current pitch
@@ -207,7 +207,7 @@ void Plane::update_logging1(void)
     }
 
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_IMU))
-        logger.Write_IMU();
+        AP::ins().Write_IMU();
 
     if (should_log(MASK_LOG_ATTITUDE_MED))
         ahrs.Write_AOA_SSA();
@@ -236,7 +236,7 @@ void Plane::update_logging2(void)
         Log_Write_RC();
 
     if (should_log(MASK_LOG_IMU))
-        logger.Write_Vibration();
+        AP::ins().Write_Vibration();
 }
 
 

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -199,7 +199,7 @@ void Sub::ten_hz_logging_loop()
         pos_control.write_log();
     }
     if (should_log(MASK_LOG_IMU) || should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {
-        logger.Write_Vibration();
+        AP::ins().Write_Vibration();
     }
     if (should_log(MASK_LOG_CTUN)) {
         attitude_control.control_monitor_log();
@@ -223,7 +223,7 @@ void Sub::twentyfive_hz_logging()
 
     // log IMU data if we're not already logging at the higher rate
     if (should_log(MASK_LOG_IMU) && !should_log(MASK_LOG_IMU_RAW)) {
-        logger.Write_IMU();
+        AP::ins().Write_IMU();
     }
 }
 

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -253,7 +253,7 @@ void Blimp::ten_hz_logging_loop()
         logger.Write_RCOUT();
     }
     if (should_log(MASK_LOG_IMU) || should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {
-        logger.Write_Vibration();
+        AP::ins().Write_Vibration();
     }
 }
 
@@ -272,7 +272,7 @@ void Blimp::twentyfive_hz_logging()
     }
 
     if (should_log(MASK_LOG_IMU)) {
-        logger.Write_IMU();
+        AP::ins().Write_IMU();
     }
 #endif
 

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -265,7 +265,7 @@ void Rover::ahrs_update()
     }
 
     if (should_log(MASK_LOG_IMU)) {
-        logger.Write_IMU();
+        AP::ins().Write_IMU();
     }
 }
 
@@ -334,7 +334,7 @@ void Rover::update_logging2(void)
     }
 
     if (should_log(MASK_LOG_IMU)) {
-        logger.Write_Vibration();
+        AP::ins().Write_Vibration();
     }
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -281,6 +281,10 @@ public:
     // indicate which bit in LOG_BITMASK indicates raw logging enabled
     void set_log_raw_bit(uint32_t log_raw_bit) { _log_raw_bit = log_raw_bit; }
 
+    // Logging Functions
+    void Write_IMU() const;
+    void Write_Vibration() const;
+
     // calculate vibration levels and check for accelerometer clipping (called by a backends)
     void calc_vibration_and_clipping(uint8_t instance, const Vector3f &accel, float dt);
 
@@ -403,6 +407,10 @@ public:
         bool should_log(uint8_t instance, IMU_SENSOR_TYPE type);
         void push_data_to_log();
 
+        // Logging functions
+        bool Write_ISBH(const float sample_rate_hz) const;
+        bool Write_ISBD() const;
+
         uint64_t measurement_started_us;
 
         bool initialised : 1;
@@ -460,6 +468,9 @@ private:
     // save gyro calibration values to eeprom
     void _save_gyro_calibration();
 
+    // Logging function
+    void Write_IMU_instance(const uint64_t time_us, const uint8_t imu_instance) const;
+    
     // backend objects
     AP_InertialSensor_Backend *_backends[INS_MAX_BACKENDS];
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -1,0 +1,98 @@
+#include "AP_InertialSensor.h"
+#include "AP_InertialSensor_Backend.h"
+
+#include <AP_Logger/AP_Logger.h>
+
+// Write IMU data packet: raw accel/gyro data
+void AP_InertialSensor::Write_IMU_instance(const uint64_t time_us, const uint8_t imu_instance) const
+{
+    const Vector3f &gyro = get_gyro(imu_instance);
+    const Vector3f &accel = get_accel(imu_instance);
+    const struct log_IMU pkt{
+        LOG_PACKET_HEADER_INIT(LOG_IMU_MSG),
+        time_us : time_us,
+        instance: imu_instance,
+        gyro_x  : gyro.x,
+        gyro_y  : gyro.y,
+        gyro_z  : gyro.z,
+        accel_x : accel.x,
+        accel_y : accel.y,
+        accel_z : accel.z,
+        gyro_error  : get_gyro_error_count(imu_instance),
+        accel_error : get_accel_error_count(imu_instance),
+        temperature : get_temperature(imu_instance),
+        gyro_health : (uint8_t)get_gyro_health(imu_instance),
+        accel_health : (uint8_t)get_accel_health(imu_instance),
+        gyro_rate : get_gyro_rate_hz(imu_instance),
+        accel_rate : get_accel_rate_hz(imu_instance),
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write IMU data packet for all instances
+void AP_InertialSensor::Write_IMU() const
+{
+    const uint64_t time_us = AP_HAL::micros64();
+
+    uint8_t n = MAX(get_accel_count(), get_gyro_count());
+    for (uint8_t i=0; i<n; i++) {
+        Write_IMU_instance(time_us, i);
+    }
+}
+
+// Write VIBE data packet for all instances
+void AP_InertialSensor::Write_Vibration() const
+{
+    const uint64_t time_us = AP_HAL::micros64();
+    for (uint8_t i = 0; i < INS_MAX_INSTANCES; i++) {
+        if (!use_accel(i)) {
+            continue;
+        }
+
+        const Vector3f vibration = get_vibration_levels(i);
+        const struct log_Vibe pkt{
+            LOG_PACKET_HEADER_INIT(LOG_VIBE_MSG),
+            time_us     : time_us,
+            imu         : i,
+            vibe_x      : vibration.x,
+            vibe_y      : vibration.y,
+            vibe_z      : vibration.z,
+            clipping    : get_accel_clip_count(i)
+        };
+        AP::logger().WriteBlock(&pkt, sizeof(pkt));
+    }
+}
+
+// Write information about a series of IMU readings to log:
+bool AP_InertialSensor::BatchSampler::Write_ISBH(const float sample_rate_hz) const
+{
+    const struct log_ISBH pkt{
+        LOG_PACKET_HEADER_INIT(LOG_ISBH_MSG),
+        time_us        : AP_HAL::micros64(),
+        seqno          : isb_seqnum,
+        sensor_type    : (uint8_t)type,
+        instance       : instance,
+        multiplier     : multiplier,
+        sample_count   : (uint16_t)_required_count,
+        sample_us      : measurement_started_us,
+        sample_rate_hz : sample_rate_hz,
+    };
+
+    return AP::logger().WriteBlock_first_succeed(&pkt, sizeof(pkt));
+}
+
+// Write a series of IMU readings to log:
+bool AP_InertialSensor::BatchSampler::Write_ISBD() const
+{
+    struct log_ISBD pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_ISBD_MSG),
+        time_us    : AP_HAL::micros64(),
+        isb_seqno  : isb_seqnum,
+        seqno      : (uint16_t) (data_read_offset/samples_per_msg)
+    };
+    memcpy(pkt.x, &data_x[data_read_offset], sizeof(pkt.x));
+    memcpy(pkt.y, &data_y[data_read_offset], sizeof(pkt.y));
+    memcpy(pkt.z, &data_z[data_read_offset], sizeof(pkt.z));
+
+    return AP::logger().WriteBlock_first_succeed(&pkt, sizeof(pkt));
+}

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -209,27 +209,18 @@ void AP_InertialSensor::BatchSampler::push_data_to_log()
             }
             break;
         }
-        if (!logger->Write_ISBH(isb_seqnum,
-                                       type,
-                                       instance,
-                                       multiplier,
-                                       _required_count,
-                                       measurement_started_us,
-                                       sample_rate)) {
+        if (!Write_ISBH(sample_rate)) {
             // buffer full?
             return;
         }
         isbh_sent = true;
     }
-    // pack and send a data packet:
-    if (!logger->Write_ISBD(isb_seqnum,
-                                   data_read_offset/samples_per_msg,
-                                   &data_x[data_read_offset],
-                                   &data_y[data_read_offset],
-                                   &data_z[data_read_offset])) {
+    // pack a nd send a data packet:
+    if (!Write_ISBD()) {
         // maybe later?!
         return;
     }
+
     data_read_offset += samples_per_msg;
     last_sent_ms = AP_HAL::millis();
     if (data_read_offset >= _required_count) {

--- a/libraries/AP_InertialSensor/LogStructure.h
+++ b/libraries/AP_InertialSensor/LogStructure.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_INERTIALSENSOR \
+    LOG_IMU_MSG, \
+    LOG_ISBH_MSG, \
+    LOG_ISBD_MSG, \
+    LOG_VIBE_MSG
+
+// @LoggerMessage: IMU
+// @Description: Inertial Measurement Unit data
+// @Field: TimeUS: Time since system startup
+// @Field: I: IMU sensor instance number
+// @Field: GyrX: measured rotation rate about X axis
+// @Field: GyrY: measured rotation rate about Y axis
+// @Field: GyrZ: measured rotation rate about Z axis
+// @Field: AccX: acceleration along X axis
+// @Field: AccY: acceleration along Y axis
+// @Field: AccZ: acceleration along Z axis
+// @Field: EG: gyroscope error count
+// @Field: EA: accelerometer error count
+// @Field: T: IMU temperature
+// @Field: GH: gyroscope health
+// @Field: AH: accelerometer health
+// @Field: GHz: gyroscope measurement rate
+// @Field: AHz: accelerometer measurement rate
+struct PACKED log_IMU {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    float gyro_x, gyro_y, gyro_z;
+    float accel_x, accel_y, accel_z;
+    uint32_t gyro_error, accel_error;
+    float temperature;
+    uint8_t gyro_health, accel_health;
+    uint16_t gyro_rate, accel_rate;
+};
+
+struct PACKED log_ISBH {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint16_t seqno;
+    uint8_t sensor_type; // e.g. GYRO or ACCEL
+    uint8_t instance;
+    uint16_t multiplier;
+    uint16_t sample_count;
+    uint64_t sample_us;
+    float sample_rate_hz;
+};
+static_assert(sizeof(log_ISBH) < 256, "log_ISBH is over-size");
+
+struct PACKED log_ISBD {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint16_t isb_seqno;
+    uint16_t seqno; // seqno within isb_seqno
+    int16_t x[32];
+    int16_t y[32];
+    int16_t z[32];
+};
+static_assert(sizeof(log_ISBD) < 256, "log_ISBD is over-size");
+
+// @LoggerMessage: VIBE
+// @Description: Processed (acceleration) vibration information
+// @Field: TimeUS: Time since system startup
+// @Field: IMU: Vibration instance number
+// @Field: VibeX: Primary accelerometer filtered vibration, x-axis
+// @Field: VibeY: Primary accelerometer filtered vibration, y-axis
+// @Field: VibeZ: Primary accelerometer filtered vibration, z-axis
+// @Field: Clip: Number of clipping events on 1st accelerometer
+struct PACKED log_Vibe {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t imu;
+    float vibe_x, vibe_y, vibe_z;
+    uint32_t clipping;
+};
+
+#define LOG_STRUCTURE_FROM_INERTIALSENSOR        \
+    { LOG_IMU_MSG, sizeof(log_IMU), \
+      "IMU",  "QBffffffIIfBBHH", "TimeUS,I,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,EG,EA,T,GH,AH,GHz,AHz", "s#EEEooo--O--zz", "F-000000-----00" }, \
+    { LOG_VIBE_MSG, sizeof(log_Vibe), \
+      "VIBE", "QBfffI", "TimeUS,IMU,VibeX,VibeY,VibeZ,Clip", "s#----", "F-----" }, \
+    { LOG_ISBH_MSG, sizeof(log_ISBH), \
+      "ISBH", "QHBBHHQf", "TimeUS,N,type,instance,mul,smp_cnt,SampleUS,smp_rate", "s-----sz", "F-----F-" },  \
+    { LOG_ISBD_MSG, sizeof(log_ISBD), \
+      "ISBD", "QHHaaa", "TimeUS,N,seqno,x,y,z", "s--ooo", "F--???" },

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -69,7 +69,6 @@
 #include <AP_AHRS/AP_AHRS_NavEKF.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Logger/LogStructure.h>
@@ -77,7 +76,6 @@
 #include <AP_Rally/AP_Rally.h>
 #include <AP_Beacon/AP_Beacon.h>
 #include <AP_Proximity/AP_Proximity.h>
-#include <AP_InertialSensor/AP_InertialSensor_Backend.h>
 #include <AP_Vehicle/ModeReason.h>
 
 #include <stdint.h>
@@ -265,6 +263,10 @@ public:
 
     /* Write a block of data at current offset */
     void WriteBlock(const void *pBuffer, uint16_t size);
+
+    /* Write block of data at current offset and return true if first backend succeeds*/
+    bool WriteBlock_first_succeed(const void *pBuffer, uint16_t size);
+
     /* Write an *important* block of data at current offset */
     void WriteCriticalBlock(const void *pBuffer, uint16_t size);
 
@@ -289,20 +291,6 @@ public:
     void Write_Event(LogEvent id);
     void Write_Error(LogErrorSubsystem sub_system,
                      LogErrorCode error_code);
-    void Write_IMU();
-    bool Write_ISBH(uint16_t seqno,
-                        AP_InertialSensor::IMU_SENSOR_TYPE sensor_type,
-                        uint8_t instance,
-                        uint16_t multiplier,
-                        uint16_t sample_count,
-                        uint64_t sample_us,
-                        float sample_rate_hz);
-    bool Write_ISBD(uint16_t isb_seqno,
-                        uint16_t seqno,
-                        const int16_t x[32],
-                        const int16_t y[32],
-                        const int16_t z[32]);
-    void Write_Vibration();
     void Write_RCIN(void);
     void Write_RCOUT(void);
     void Write_RSSI();
@@ -509,7 +497,6 @@ private:
     // state to help us not log unneccesary RCIN values:
     bool seen_nonzero_rcin15_or_rcin16;
 
-    void Write_IMU_instance(uint64_t time_us, uint8_t imu_instance);
     void Write_Compass_instance(uint64_t time_us, uint8_t mag_instance);
 
     void backend_starting_new_log(const AP_Logger_Backend *backend);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -207,68 +207,6 @@ void AP_Logger::Write_RSSI()
     WriteBlock(&pkt, sizeof(pkt));
 }
 
-void AP_Logger::Write_IMU_instance(const uint64_t time_us, const uint8_t imu_instance)
-{
-    const AP_InertialSensor &ins = AP::ins();
-    const Vector3f &gyro = ins.get_gyro(imu_instance);
-    const Vector3f &accel = ins.get_accel(imu_instance);
-    const struct log_IMU pkt{
-        LOG_PACKET_HEADER_INIT(LOG_IMU_MSG),
-        time_us : time_us,
-        instance: imu_instance,
-        gyro_x  : gyro.x,
-        gyro_y  : gyro.y,
-        gyro_z  : gyro.z,
-        accel_x : accel.x,
-        accel_y : accel.y,
-        accel_z : accel.z,
-        gyro_error  : ins.get_gyro_error_count(imu_instance),
-        accel_error : ins.get_accel_error_count(imu_instance),
-        temperature : ins.get_temperature(imu_instance),
-        gyro_health : (uint8_t)ins.get_gyro_health(imu_instance),
-        accel_health : (uint8_t)ins.get_accel_health(imu_instance),
-        gyro_rate : ins.get_gyro_rate_hz(imu_instance),
-        accel_rate : ins.get_accel_rate_hz(imu_instance),
-    };
-    WriteBlock(&pkt, sizeof(pkt));
-}
-
-// Write an raw accel/gyro data packet
-void AP_Logger::Write_IMU()
-{
-    const uint64_t time_us = AP_HAL::micros64();
-
-    const AP_InertialSensor &ins = AP::ins();
-
-    uint8_t n = MAX(ins.get_accel_count(), ins.get_gyro_count());
-    for (uint8_t i=0; i<n; i++) {
-        Write_IMU_instance(time_us, i);
-    }
-}
-
-void AP_Logger::Write_Vibration()
-{
-    const AP_InertialSensor &ins = AP::ins();
-    const uint64_t time_us = AP_HAL::micros64();
-    for (uint8_t i = 0; i < INS_MAX_INSTANCES; i++) {
-        if (!ins.use_accel(i)) {
-            continue;
-        }
-
-        const Vector3f vibration = ins.get_vibration_levels(i);
-        const struct log_Vibe pkt{
-            LOG_PACKET_HEADER_INIT(LOG_VIBE_MSG),
-            time_us     : time_us,
-            imu         : i,
-            vibe_x      : vibration.x,
-            vibe_y      : vibration.y,
-            vibe_z      : vibration.z,
-            clipping  : ins.get_accel_clip_count(i)
-        };
-        WriteBlock(&pkt, sizeof(pkt));
-    }
-}
-
 void AP_Logger::Write_Command(const mavlink_command_int_t &packet,
                               const MAV_RESULT result,
                               bool was_command_long)


### PR DESCRIPTION
ISBD & ISBH logging :

Added a function into AP_Logger for writing blocks to replicate the previous functionality. I've left the previous code in the `write_ISBD()` function commented out for easier review for the moment. 

Documentation: I tried adding documentation fields for these messages, but I couldn't figure out the autotest generation component. Doc fields with arrays, `x[32]`, aren't handled? And my poor attempt at only changing the regex wasn't very successful.