### PR TITLE
Add Smart_RTL options to alter yaw behaviours

### DIFF
--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -82,7 +82,7 @@ void ModeSmartRTL::wait_cleanup_run()
 void ModeSmartRTL::path_follow_run()
 {
     float target_yaw_rate = 0.0f;
-    if (!copter.failsafe.radio) {
+    if (!copter.failsafe.radio && g2.smart_rtl.use_pilot_yaw()) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {

--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -36,6 +36,13 @@ const AP_Param::GroupInfo AP_SmartRTL::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("POINTS", 1, AP_SmartRTL, _points_max, SMARTRTL_POINTS_DEFAULT),
 
+    // @Param: OPTIONS
+    // @DisplayName: SmartRTL options
+    // @Description: Bitmask of SmartRTL options.
+    // @Bitmask: 2:Ignore pilot yaw
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 2, AP_SmartRTL, _options, 0),
+
     AP_GROUPEND
 };
 
@@ -861,3 +868,10 @@ bool AP_SmartRTL::loops_overlap(const prune_loop_t &loop1, const prune_loop_t &l
     // if we got here, no overlap
     return false;
 }
+
+// returns true if pilot's yaw input should be used to adjust vehicle's heading
+bool AP_SmartRTL::use_pilot_yaw(void) const
+{
+    return (_options.get() & uint32_t(Options::IgnorePilotYaw)) == 0;
+}
+

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -74,6 +74,9 @@ public:
     // run background cleanup - should be run regularly from the IO thread
     void run_background_cleanup();
 
+    // returns true if pilot's yaw input should be used to adjust vehicle's heading
+    bool use_pilot_yaw(void) const;
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -92,6 +95,12 @@ private:
         SRTL_DEACTIVATED_BAD_POSITION_TIMEOUT,
         SRTL_DEACTIVATED_PATH_FULL_TIMEOUT,
         SRTL_DEACTIVATED_PROGRAM_ERROR,
+    };
+
+    // enum for SRTL_OPTIONS parameter
+    enum class Options : int32_t {
+        // bits 1 and 2 are still available, pilot yaw was mapped to bit 2 for symmetry with auto
+        IgnorePilotYaw    = (1U << 2),
     };
 
     // add point to end of path
@@ -164,6 +173,7 @@ private:
     // parameters
     AP_Float _accuracy;
     AP_Int16 _points_max;
+    AP_Int32 _options;
 
     // SmartRTL State Variables
     bool _active;       // true if SmartRTL is usable.  may become unusable if the path becomes too long to keep in memory, and too convoluted to be cleaned up, SmartRTL will be permanently deactivated (for the remainder of the flight)


### PR DESCRIPTION
SRTL_OPTIONS parameter has been added.

Two options now available:
- 0: If no pilot input has been received on yaw in the last 5 seconds, give control back to auto_yaw.  Current behaviour is to never return control back to auto_yaw if a pilot input is received.
- 2: Ignore pilot yaw input commands whilst 'rewinding' the breadcrumb trial.   This is on bit 2 to align with AUTO_OPTIONS, RTL_OPTIONS, and GUID_OPTIONS.

A couple of notes:
- The ignore pilot yaw bit does not effect once the copter is within the 2m of home (see pre_land_position_run() in mode_smart_rtl.cpp).  I am not sure if 2 m above landing is high enough.  Should we make this 2m from home in xy and ignore alt, so that pilots can have control on the whole decent even with the bit set?
- I have set the bitmask default such that control is given back to auto yaw if there has been no pilot input for 5 s.  I think this is the 'expected' behaviour for those that have not used SRTL before, as operators will likely expect to see the same as in way point missions (whereby auto_yaw is given control again upon accepting the new way point).  But, this is just my opinion so I am interested in what others think.

Testing:
- Give control back to auto_yaw bit has been tested in sitl only.
- ignore pilot yaw bit has been tested in sitl and on a real vehicle.