### PR TITLE
Plane: instantly switch from RTL to QRTL if within radius

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -281,6 +281,11 @@ public:
 protected:
 
     bool _enter() override;
+
+private:
+
+    // Switch to QRTL if enabled and within radius
+    bool switch_QRTL();
 };
 
 class ModeStabilize : public Mode

--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -7,6 +7,8 @@ bool ModeRTL::_enter()
     plane.do_RTL(plane.get_RTL_altitude());
     plane.rtl.done_climb = false;
 
+    switch_QRTL();
+
     return true;
 }
 
@@ -33,22 +35,8 @@ void ModeRTL::update()
 
 void ModeRTL::navigate()
 {
-    uint16_t qrtl_radius = abs(plane.g.rtl_radius);
-    if (qrtl_radius == 0) {
-        qrtl_radius = abs(plane.aparm.loiter_radius);
-    }
 
-    if (plane.quadplane.available() && plane.quadplane.rtl_mode == 1 &&
-        (plane.nav_controller->reached_loiter_target() ||
-         plane.current_loc.past_interval_finish_line(plane.prev_WP_loc, plane.next_WP_loc) ||
-         plane.auto_state.wp_distance < MAX(qrtl_radius, plane.quadplane.stopping_distance())) &&
-        AP_HAL::millis() - plane.last_mode_change_ms > 1000) {
-        /*
-          for a quadplane in RTL mode we switch to QRTL when we
-          are within the maximum of the stopping distance and the
-          RTL_RADIUS
-         */
-        plane.set_mode(plane.mode_qrtl, ModeReason::RTL_COMPLETE_SWITCHING_TO_VTOL_LAND_RTL);
+    if ((AP_HAL::millis() - plane.last_mode_change_ms > 1000) && switch_QRTL()) {
         return;
     }
 
@@ -88,3 +76,30 @@ void ModeRTL::navigate()
     plane.update_loiter(radius);
 }
 
+
+// Switch to QRTL if enabled and within radius
+bool ModeRTL::switch_QRTL()
+{
+    if (!plane.quadplane.available() || (plane.quadplane.rtl_mode != 1)) {
+        return false;
+    }
+
+    uint16_t qrtl_radius = abs(plane.g.rtl_radius);
+    if (qrtl_radius == 0) {
+        qrtl_radius = abs(plane.aparm.loiter_radius);
+    }
+
+    if (plane.nav_controller->reached_loiter_target() ||
+         plane.current_loc.past_interval_finish_line(plane.prev_WP_loc, plane.next_WP_loc) ||
+         plane.auto_state.wp_distance < MAX(qrtl_radius, plane.quadplane.stopping_distance())) {
+        /*
+          for a quadplane in RTL mode we switch to QRTL when we
+          are within the maximum of the stopping distance and the
+          RTL_RADIUS
+         */
+        plane.set_mode(plane.mode_qrtl, ModeReason::RTL_COMPLETE_SWITCHING_TO_VTOL_LAND_RTL);
+        return true;
+    }
+
+    return false;
+}


### PR DESCRIPTION
Fixes #15753

Current code will go into forward flight for 1 second if switched into RTL within the QRTL radius. Even if we remove the 1 second timeout you still get some forward flight throttle for a loop. The only way to prevent (that I have found) is to check in the enter function. 

[second report the forum](https://discuss.ardupilot.org/t/quadplane-rtl-qrtl-behavior-at-low-altitude-danger/66897?u=iampete)