### PR TITLE
AutoTune: tighten wait-for-level criteria for Copters

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -43,8 +43,13 @@
 
 #define AUTOTUNE_PILOT_OVERRIDE_TIMEOUT_MS  500     // restart tuning if pilot has left sticks in middle for 2 seconds
 #define AUTOTUNE_TESTING_STEP_TIMEOUT_MS   1000U    // timeout for tuning mode's testing step
-#define AUTOTUNE_LEVEL_ANGLE_CD             500     // angle which qualifies as level
-#define AUTOTUNE_LEVEL_RATE_RP_CD          1000     // rate which qualifies as level for roll and pitch
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+ # define AUTOTUNE_LEVEL_ANGLE_CD           500     // angle which qualifies as level (Plane uses more relaxed 5deg)
+ # define AUTOTUNE_LEVEL_RATE_RP_CD        1000     // rate which qualifies as level for roll and pitch (Plane uses more relaxed 10deg/sec)
+#else
+ # define AUTOTUNE_LEVEL_ANGLE_CD           250     // angle which qualifies as level
+ # define AUTOTUNE_LEVEL_RATE_RP_CD         500     // rate which qualifies as level for roll and pitch
+#endif
 #define AUTOTUNE_LEVEL_RATE_Y_CD            750     // rate which qualifies as level for yaw
 #define AUTOTUNE_REQUIRED_LEVEL_TIME_MS     500     // time we require the aircraft to be level
 #define AUTOTUNE_LEVEL_TIMEOUT_MS          2000     // time out for level

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -258,13 +258,13 @@ void AC_AutoTune::send_step_string()
     }
     switch (step) {
     case WAITING_FOR_LEVEL:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: WFL (%s) (%f > %f)", level_issue_string(), (double)(level_problem.current*0.01f), (double)(level_problem.maximum*0.01f));
+        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Leveling (%s %4.1f > %4.1f)", level_issue_string(), (double)(level_problem.current*0.01f), (double)(level_problem.maximum*0.01f));
         return;
     case UPDATE_GAINS:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: UPDATING_GAINS");
+        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Updating Gains");
         return;
     case TWITCHING:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: TWITCHING");
+        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Twitching");
         return;
     }
     gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: unknown step");
@@ -397,7 +397,7 @@ void AC_AutoTune::run()
     }
     if (pilot_override) {
         if (now - last_pilot_override_warning > 1000) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AUTOTUNE: pilot overrides active");
+            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: pilot overrides active");
             last_pilot_override_warning = now;
         }
     }

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -179,6 +179,7 @@ private:
     float    test_angle_max;                        // the maximum angle achieved during TESTING_ANGLE step
     uint32_t step_start_time_ms;                    // start time of current tuning step (used for timeout checks)
     uint32_t level_start_time_ms;                   // start time of waiting for level
+    uint32_t level_fail_warning_time_ms;            // last time level failure warning message was sent to GCS
     uint32_t step_time_limit_ms;                    // time limit of current autotune process
     int8_t   counter;                               // counter for tuning gains
     float    target_rate, start_rate;               // target and start rate


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/16461 by making the following changes:

- during the wait-for-level step, the criteria is made more strict by decreasing the max angle error to 2.5deg and decreasing max rate error to 5deg/sec.  This only applies to Copter, Plane remains at the more relaxed rates of 5deg and 10deg/sec
- if wait-for-level fails for 5 seconds a mesage is displayed, "AutoTune: failing to level, manual tune may be required"
- minor improvements to reporting including using mixed case (instead of all upper case) and reducing the accuracy of floats displayed

In addition Leonard suggested these improvements which are already in master:

- [x] increase these limits up to a factor of 2 after 2 seconds to help poorly tuned aircraft get a starting tune.   **already implemented in master (see use of AUTOTUNE_LEVEL_TIMEOUT_MS)**.
- [x] it may also be worth putting up an error message in the event that the sticks are lot centred for more than 5 seconds. "Autotune waiting for sticks to be centred" or something similar.

Below are some screen shots of SITL testing.  In the shot below I tested that Copter's wait-for-level was using an angle of 2.5deg.  I also confirmed that QuadPlane was still using an angle of 5deg
![image](https://user-images.githubusercontent.com/1498098/106409582-31dd9d00-6484-11eb-9250-5e4856d73f8e.png)

Below shows the modified output ("WFL" becomes "Leveling", number of decimals is reduced).
![image](https://user-images.githubusercontent.com/1498098/106409714-8bde6280-6484-11eb-92f4-9b9fdeaea2ca.png)

Below shows the failure message when wait-for-level fails for 5sec.  The message is printed every 5 sec.
![image](https://user-images.githubusercontent.com/1498098/106409776-aca6b800-6484-11eb-83ec-23ffb05d491a.png)


