### PR TITLE
Copter:Implement LOITER_TURNS in Guided Mode

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -729,6 +729,15 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             return MAV_RESULT_FAILED;
         }
         return MAV_RESULT_ACCEPTED;
+#if MODE_GUIDED_ENABLED == ENABLED
+    case MAV_CMD_NAV_LOITER_TURNS:
+        if (copter.flightmode->in_guided_mode())
+        {
+            copter.mode_guided.do_circle(packet);
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED; 
+#endif
 
     case MAV_CMD_NAV_RETURN_TO_LAUNCH:
         if (!copter.set_mode(Mode::Number::RTL, ModeReason::GCS_COMMAND)) {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -105,6 +105,8 @@ enum GuidedMode {
     Guided_Velocity,
     Guided_PosVel,
     Guided_Angle,
+    Guided_CircleMoveToEdge,
+    Guided_Circle,
 };
 
 // Airmode

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -681,6 +681,15 @@ void Mode::land_run_horizontal_control()
     }
 }
 
+void Mode::circle_start() {
+    // initialise circle controller
+    copter.circle_nav->init(copter.circle_nav->get_center(), copter.circle_nav->center_is_terrain_alt());
+
+    if (auto_yaw.mode() != AUTO_YAW_ROI) {
+        auto_yaw.set_mode(AUTO_YAW_CIRCLE);
+    }
+}
+
 float Mode::throttle_hover() const
 {
     return motors->get_throttle_hover();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -95,6 +95,8 @@ public:
         // this may return bogus data:
         return pos_control->get_desired_velocity();
     }
+    // functions for circular movement
+    void circle_start();
 
 protected:
 
@@ -422,10 +424,12 @@ private:
     void spline_run();
     void land_run();
     void rtl_run();
-    void circle_run();
     void nav_guided_run();
     void loiter_run();
     void loiter_to_alt_run();
+
+    // functions for circular movement
+    void circle_run();
 
     Location loc_from_cmd(const AP_Mission::Mission_Command& cmd) const;
 
@@ -810,7 +814,12 @@ public:
     bool get_wp(Location &loc) override;
     void set_velocity(const Vector3f& velocity, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false, bool log_request = true);
     bool set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
-
+    
+    // functions for circular movement
+    void do_circle(const mavlink_command_long_t &packet); 
+    void circle_movetoedge_start(const Location &circle_center, float radius_m);
+    void circle_start();
+    
     void limit_clear();
     void limit_init_time_and_pos();
     void limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_max_cm, float horiz_max_cm);
@@ -852,8 +861,15 @@ private:
     void posvel_control_run();
     void set_desired_velocity_with_accel_and_fence_limits(const Vector3f& vel_des);
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
-    bool use_pilot_yaw(void) const;
 
+    //functions for circular movement
+    void circle_run();
+    void circle_check(uint8_t count);
+
+    bool use_pilot_yaw(void) const;
+    Location loc_from_param(const mavlink_command_long_t &packet);
+    uint8_t radius_from_param(const mavlink_command_long_t &packet);
+    uint8_t turn_count=0;  
     // controls which controller is run (pos or vel):
     GuidedMode guided_mode = Guided_TakeOff;
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -310,13 +310,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
 void ModeAuto::circle_start()
 {
     _mode = Auto_Circle;
-
-    // initialise circle controller
-    copter.circle_nav->init(copter.circle_nav->get_center(), copter.circle_nav->center_is_terrain_alt());
-
-    if (auto_yaw.mode() != AUTO_YAW_ROI) {
-        auto_yaw.set_mode(AUTO_YAW_CIRCLE);
-    }
+    Mode::circle_start();
 }
 
 // auto_spline_start - initialises waypoint controller to implement flying to a particular destination using the spline controller


### PR DESCRIPTION
Implemented loiter turns in guided mode as stated here #13464
Now the user can send the copter in a circle mode by passing the appropriate command in the Mavproxy
![Terminal](https://user-images.githubusercontent.com/62841337/106447900-08366d00-64a8-11eb-9e09-cc2786d136b2.png)
(Tested on Ubuntu 20.10)
![MAP](https://user-images.githubusercontent.com/62841337/106447987-28662c00-64a8-11eb-9b76-dc3b2c20baa7.png)

The code has been tested on Ubuntu 20.10 and WSL with Ubuntu 16.04 

please do take a look!!
Thanks