### PR TITLE
AP_Compass: Added support for internal i2c bus to VRBrain-v51

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1246,17 +1246,18 @@ void Compass::_detect_backends(void)
         ADD_BACKEND(DRIVER_BMM150,
                     AP_Compass_BMM150::probe(GET_I2C_DEVICE(0, 0x10), false, ROTATION_NONE));
         break;
-    case AP_BoardConfig::VRX_BOARD_BRAIN54: {
+    case AP_BoardConfig::VRX_BOARD_BRAIN54:
+    case AP_BoardConfig::VRX_BOARD_BRAIN51: {
         // external i2c bus
         ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(1, HAL_COMPASS_HMC5843_I2C_ADDR),
                     true, ROTATION_ROLL_180));
-    }
+
         // internal i2c bus
-    ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(0, HAL_COMPASS_HMC5843_I2C_ADDR),
-                false, ROTATION_YAW_270));
+        ADD_BACKEND(DRIVER_HMC5843, AP_Compass_HMC5843::probe(GET_I2C_DEVICE(0, HAL_COMPASS_HMC5843_I2C_ADDR),
+                    false, ROTATION_YAW_270));
+    }
     break;
 
-    case AP_BoardConfig::VRX_BOARD_BRAIN51:
     case AP_BoardConfig::VRX_BOARD_BRAIN52:
     case AP_BoardConfig::VRX_BOARD_BRAIN52E:
     case AP_BoardConfig::VRX_BOARD_CORE10:


### PR DESCRIPTION
Rework from https://github.com/ArduPilot/ardupilot/pull/11130 this allow the internal compass HMC5883 of the VRBrain-v51 to be correctly recognized.
It was validated by @LukeMike 

I have change tthe driver name to DRIVER_HMC5843 instead of DRIVER_HMC5883 following https://github.com/ArduPilot/ardupilot/pull/11441



