### PR TITLE
Plane: store previous_mode_reason only as a local

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -291,7 +291,6 @@ private:
     Mode *control_mode = &mode_initializing;
     ModeReason control_mode_reason = ModeReason::UNKNOWN;
     Mode *previous_mode = &mode_initializing;
-    ModeReason previous_mode_reason = ModeReason::UNKNOWN;
 
     // time of last mode change
     uint32_t last_mode_change_ms;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -222,13 +222,12 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
     // backup current control_mode and previous_mode
     Mode &old_previous_mode = *previous_mode;
     Mode &old_mode = *control_mode;
-    const ModeReason previous_mode_reason_backup = previous_mode_reason;
 
     // update control_mode assuming success
     // TODO: move these to be after enter() once start_command_callback() no longer checks control_mode
     previous_mode = control_mode;
     control_mode = &new_mode;
-    previous_mode_reason = control_mode_reason;
+    const ModeReason previous_mode_reason = control_mode_reason;
     control_mode_reason = reason;
 
     // attempt to enter new mode
@@ -241,7 +240,6 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
         control_mode = &old_mode;
 
         control_mode_reason = previous_mode_reason;
-        previous_mode_reason = previous_mode_reason_backup;
 
         // currently, only Q modes can fail enter(). This will likely change in the future and all modes
         // should be changed to check dependencies and fail early before depending on changes in Mode::set_mode()
@@ -261,7 +259,6 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
     old_mode.exit();
 
     // record reasons
-    previous_mode_reason = control_mode_reason;
     control_mode_reason = reason;
 
     // log and notify mode change


### PR DESCRIPTION
It's never used outside the mode-changing method.