### PR TITLE
AP_BattMonitor: Limit the scope of possible corruption if the NeoDesigns gets a bad cell count

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.cpp
@@ -24,7 +24,7 @@ void AP_BattMonitor_SMBus_NeoDesign::timer()
     // Get the cell count once, it's not likely to change in flight
     if (_cell_count == 0) {
         if (read_word(BATTMONITOR_ND_CELL_COUNT, data)) {
-            _cell_count = data;
+            _cell_count = MIN(data, max_cell_count); // never read in more cells then we can store
         } else {
             return; // something wrong, don't try anything else
         }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.h
@@ -15,4 +15,6 @@ private:
     void timer(void) override;
 
     uint8_t _cell_count;
+
+    static const constexpr uint8_t max_cell_count = 10;
 };


### PR DESCRIPTION
This was found by inspection. If cell count was read wrong for any reason (data corruption, or just bad data in the other end) we would read up to that many cell's of data in, which could lead to us attempting to read 255 cells worth of data, which would significantly overwrite other memory (as well as obviously read incorrect addresses due to wrapping). This clamps us so that we don't read to many.

~Ideally we'd limit this to the maximum possible number of cells the driver actually supports, however I don't have any documentation for that.~ I've been sent the correct cell count now, so I've updated it.