### PR TITLE
Tools: AP_Bootloader: Add AP_HW_SWBOOMBOARD_PERIPH identifier

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -116,3 +116,4 @@ AP_HW_BEASTF7                        1026
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401
 AP_HW_PIXRACER_PERIPH                1402
+AP_HW_SWBOOMBOARD_PERIPH             1403


### PR DESCRIPTION
SpektreWorks Boom Board AP_Periph device