### PR TITLE
AC_Avoid: Improve reliability of Simple Avoidance

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -475,6 +475,9 @@ void Copter::three_hz_loop()
 
     // update ch6 in flight tuning
     tuning();
+
+    // check if avoidance should be enabled based on alt
+    low_alt_avoidance();
 }
 
 // one_hz_loop - runs at 1Hz

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -665,6 +665,9 @@ private:
     void rotate_body_frame_to_NE(float &x, float &y);
     uint16_t get_pilot_speed_dn();
 
+    // avoidance.cpp
+    void low_alt_avoidance();
+
 #if HAL_ADSB_ENABLED
     // avoidance_adsb.cpp
     void avoidance_adsb_update(void);

--- a/ArduCopter/avoidance.cpp
+++ b/ArduCopter/avoidance.cpp
@@ -1,0 +1,19 @@
+#include "Copter.h"
+
+void Copter::low_alt_avoidance()
+{   
+#if AC_AVOID_ENABLED == ENABLED
+    int32_t alt_cm;
+    if (!get_rangefinder_height_interpolated_cm(alt_cm)) {
+        // enable avoidance if we don't have a valid rangefinder reading
+        avoid.proximity_alt_avoidance_enable(true);
+        return;
+    }
+
+    bool enable_avoidance = true;
+    if (alt_cm < avoid.get_min_alt() * 100.0f) {
+        enable_avoidance = false;
+    }
+    avoid.proximity_alt_avoidance_enable(enable_avoidance);
+#endif 
+}

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -79,6 +79,14 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Range: 0 2
     // @User: Standard
     AP_GROUPINFO("BACKUP_SPD", 6, AC_Avoid, _backup_speed_max, 0.5f),
+    
+    // @Param: ALT_MIN
+    // @DisplayName: Avoidance minimum altitude
+    // @Description: Minimum altitude above which avoidance will start working. This requires a valid downward facing rangefinder reading to work. Set zero to disable
+    // @Units: m
+    // @Range: 0 6
+    // @User: Standard
+    AP_GROUPINFO("ALT_MIN", 7, AC_Avoid, _min_alt, 1.5f),
 
     AP_GROUPEND
 };
@@ -167,7 +175,7 @@ void AC_Avoid::adjust_velocity(Vector3f &desired_vel_cms, bool &backing_up, floa
     float back_vel_down = 0.0f;
     
     // Avoidance in response to proximity sensor
-    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled) {
+    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled && _alt_proximity_enabled) {
         // Store velocity needed to back away from physical obstacles
         Vector3f backup_vel_proximity;
         adjust_velocity_proximity(kP, accel_cmss_limited, desired_vel_cms, backup_vel_proximity, kP_z,accel_cmss_z, dt);

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -88,6 +88,14 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ALT_MIN", 7, AC_Avoid, _min_alt, 1.5f),
 
+    // @Param: ACCEL_MAX
+    // @DisplayName: Avoidance maximum acceleration
+    // @Description: Maximum acceleration per axis with which obstacles will be avoided with. Set zero to disable acceleration limits
+    // @Units: m/s/s
+    // @Range: 0 9
+    // @User: Standard
+    AP_GROUPINFO("ACCEL_MAX", 8, AC_Avoid, _accel_max, 3.0f),
+
     AP_GROUPEND
 };
 
@@ -166,6 +174,9 @@ void AC_Avoid::adjust_velocity(Vector3f &desired_vel_cms, bool &backing_up, floa
         return;
     }
 
+    // make a copy of input velocity, because desired_vel_cms might be changed
+    const Vector3f desired_vel_cms_original = desired_vel_cms;
+
     // limit acceleration
     const float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
@@ -224,6 +235,47 @@ void AC_Avoid::adjust_velocity(Vector3f &desired_vel_cms, bool &backing_up, floa
             }
         }
     }
+    // limit acceleration
+    limit_accel(desired_vel_cms_original, desired_vel_cms, dt);
+}
+
+// Limit acceleration so that change of velocity output by avoidance library is controlled
+void AC_Avoid::limit_accel(const Vector3f &original_vel, Vector3f &modified_vel, float dt)
+{
+    if (original_vel == modified_vel || is_zero(_accel_max) || is_zero(dt)) {
+        // we can't limit accel if any of these conditions are true
+        return;
+    }
+    // max accel in cm
+    const float max_accel_cm = _accel_max * 100.0f;
+    // accel desired by avoidance library
+    const Vector3f accel = (modified_vel - original_vel)/dt;
+    // max velocity allowed in this time period
+    const float max_vel_diff = max_accel_cm * dt;
+
+    // check if acceleration in any axis is greater than the maximum allowed
+    if (fabsf(accel.x) > max_accel_cm && !is_zero(accel.x)) {
+        float direction = 1.0f;
+        if (is_negative(accel.x)) {
+            direction = -1.0f;
+        }
+        modified_vel.x = (max_vel_diff * direction) + original_vel.x;
+    }
+    if (fabsf(accel.y) > max_accel_cm && !is_zero(accel.y)) {
+        float direction = 1.0f;
+        if (is_negative(accel.y)) {
+            direction = -1.0f;
+        }
+        modified_vel.y = (max_vel_diff * direction) + original_vel.y;
+    }
+    if (fabsf(accel.z) > max_accel_cm && !is_zero(accel.z)) {
+        float direction = 1.0f;
+        if (is_negative(accel.z)) {
+            direction = -1.0f;
+        }
+        modified_vel.z = (max_vel_diff * direction) + original_vel.z;
+    }
+    return;
 }
 
 // This method is used in most Rover modes and not in Copter

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -120,6 +120,11 @@ private:
     };
 
     /*
+     * Limit acceleration so that change of velocity output by avoidance library is controlled
+     */
+    void limit_accel(const Vector3f &original_vel, Vector3f &modified_vel, float dt);
+
+    /*
      * Adjusts the desired velocity for the circular fence.
      */
     void adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f &desired_vel_cms, Vector2f &backup_vel, float dt);
@@ -205,6 +210,7 @@ private:
     AP_Int8 _behavior;          // avoidance behaviour (slide or stop)
     AP_Float _backup_speed_max; // Maximum speed that will be used to back away (in m/s)
     AP_Float _min_alt;          // alt below which Proximity based avoidance is turned off
+    AP_Float _accel_max;        // maximum accelration while simple avoidance is active
 
     bool _proximity_enabled = true; // true if proximity sensor based avoidance is enabled (used to allow pilot to enable/disable)
     bool _alt_proximity_enabled = true; // true if proximity sensor based avoidance is enabled based on altitude

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -82,6 +82,7 @@ public:
     // enable/disable proximity based avoidance
     void proximity_avoidance_enable(bool on_off) { _proximity_enabled = on_off; }
     bool proximity_avoidance_enabled() { return _proximity_enabled; }
+    void proximity_alt_avoidance_enable(bool on_off) { _alt_proximity_enabled = on_off; }
 
     // helper functions
 
@@ -102,6 +103,9 @@ public:
 
     // return margin (in meters) that the vehicle should stay from objects
     float get_margin() const { return _margin; }
+
+    // return minimum alt (in meters) above which avoidance will be active
+    float get_min_alt() const { return _min_alt; }
 
     // return true if limiting is active
     bool limits_active() const {return (AP_HAL::millis() - _last_limit_time) < AC_AVOID_ACTIVE_LIMIT_TIMEOUT_MS;};
@@ -200,8 +204,10 @@ private:
     AP_Float _margin;           // vehicle will attempt to stay this distance (in meters) from objects while in GPS modes
     AP_Int8 _behavior;          // avoidance behaviour (slide or stop)
     AP_Float _backup_speed_max; // Maximum speed that will be used to back away (in m/s)
+    AP_Float _min_alt;          // alt below which Proximity based avoidance is turned off
 
     bool _proximity_enabled = true; // true if proximity sensor based avoidance is enabled (used to allow pilot to enable/disable)
+    bool _alt_proximity_enabled = true; // true if proximity sensor based avoidance is enabled based on altitude
     uint32_t _last_limit_time;      // the last time a limit was active
     uint32_t _last_log_ms;          // the last time simple avoidance was logged
 


### PR DESCRIPTION
This PR adds two new feature which should go a long way in improving the reliability of Simple Avoidance:
1. Adds a param: AVOID_ALT_MIN. If a down facing range finder is availble, it will switch OFF proximity avoidance below ALT_MIN 
2. Adds a param: AVOID_ACCEL_MAX. This limits the maximum allowed change in velocity that avoidance can make (per axis)
This is a very important new addition which will make the avoidnace experience much more smoother, here is an example of what happens:
https://youtu.be/UkRMf8cIDjY