### PR TITLE
AP_BattMonitor: fix constexpr-and-MIN don't get along bug

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.cpp
@@ -19,14 +19,16 @@ AP_BattMonitor_SMBus_NeoDesign::AP_BattMonitor_SMBus_NeoDesign(AP_BattMonitor &m
 void AP_BattMonitor_SMBus_NeoDesign::timer()
 {
     uint16_t data;
-    uint32_t tnow = AP_HAL::micros();
-
     // Get the cell count once, it's not likely to change in flight
     if (_cell_count == 0) {
-        if (read_word(BATTMONITOR_ND_CELL_COUNT, data)) {
-            _cell_count = MIN(data, max_cell_count); // never read in more cells then we can store
-        } else {
+        if (!read_word(BATTMONITOR_ND_CELL_COUNT, data)) {
             return; // something wrong, don't try anything else
+        }
+        // constrain maximum cellcount in case of i2c corruption
+        if (data > max_cell_count) {
+            _cell_count = max_cell_count;
+        } else {
+            _cell_count = data;
         }
     }
 
@@ -39,6 +41,8 @@ void AP_BattMonitor_SMBus_NeoDesign::timer()
             read_all_cells = false;
         }
     }
+
+    const uint32_t tnow = AP_HAL::micros();
 
     if (read_all_cells && (_cell_count > 0)) {
         uint32_t summed = 0;


### PR DESCRIPTION
lib/libArduCopter_libs.a(AP_BattMonitor_SMBus_NeoDesign.cpp.0.o): In function `AP_BattMonitor_SMBus_NeoDesign::timer()':
/home/pbarker/rc/ardupilot/build/sitl/../../libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.cpp:27: undefined reference to `AP_BattMonitor_SMBus_NeoDesign::max_cell_count'
collect2: error: ld returned 1 exit status