### PR TITLE
AC_Avoid: Improve reliability of Simple Avoidance 

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -475,6 +475,9 @@ void Copter::three_hz_loop()
 
     // update ch6 in flight tuning
     tuning();
+
+    // check if avoidance should be enabled based on alt
+    low_alt_avoidance();
 }
 
 // one_hz_loop - runs at 1Hz

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -665,6 +665,9 @@ private:
     void rotate_body_frame_to_NE(float &x, float &y);
     uint16_t get_pilot_speed_dn() const;
 
+    // avoidance.cpp
+    void low_alt_avoidance();
+
 #if HAL_ADSB_ENABLED
     // avoidance_adsb.cpp
     void avoidance_adsb_update(void);

--- a/ArduCopter/avoidance.cpp
+++ b/ArduCopter/avoidance.cpp
@@ -1,0 +1,20 @@
+#include "Copter.h"
+
+// check if proximity type Simple Avoidance should be enabled based on alt
+void Copter::low_alt_avoidance()
+{
+#if AC_AVOID_ENABLED == ENABLED
+    int32_t alt_cm;
+    if (!get_rangefinder_height_interpolated_cm(alt_cm)) {
+        // enable avoidance if we don't have a valid rangefinder reading
+        avoid.proximity_alt_avoidance_enable(true);
+        return;
+    }
+
+    bool enable_avoidance = true;
+    if (alt_cm < avoid.get_min_alt() * 100.0f) {
+        enable_avoidance = false;
+    }
+    avoid.proximity_alt_avoidance_enable(enable_avoidance);
+#endif
+}

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -80,6 +80,14 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("BACKUP_SPD", 6, AC_Avoid, _backup_speed_max, 0.5f),
 
+    // @Param: ALT_MIN
+    // @DisplayName: Avoidance minimum altitude
+    // @Description: Minimum altitude above which proximity based avoidance will start working. This requires a valid downward facing rangefinder reading to work. Set zero to disable
+    // @Units: m
+    // @Range: 0 6
+    // @User: Standard
+    AP_GROUPINFO("ALT_MIN", 7, AC_Avoid, _alt_min, 2.0f),
+
     AP_GROUPEND
 };
 
@@ -167,7 +175,7 @@ void AC_Avoid::adjust_velocity(Vector3f &desired_vel_cms, bool &backing_up, floa
     float back_vel_down = 0.0f;
     
     // Avoidance in response to proximity sensor
-    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled) {
+    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled && _proximity_alt_enabled) {
         // Store velocity needed to back away from physical obstacles
         Vector3f backup_vel_proximity;
         adjust_velocity_proximity(kP, accel_cmss_limited, desired_vel_cms, backup_vel_proximity, kP_z,accel_cmss_z, dt);

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -20,6 +20,7 @@
 
 #define AC_AVOID_ACTIVE_LIMIT_TIMEOUT_MS    500     // if limiting is active if last limit is happend in the last x ms
 #define AC_AVOID_MIN_BACKUP_BREACH_DIST     10.0f   // vehicle will backaway if breach is greater than this distance in cm
+#define AC_AVOID_ACCEL_TIMEOUT_MS           200     // stored velocity used to calculate acceleration will be reset if avoidance is active after this many ms
 
 /*
  * This class prevents the vehicle from leaving a polygon fence or hitting proximity-based obstacles
@@ -121,6 +122,7 @@ private:
 
     /*
      * Limit acceleration so that change of velocity output by avoidance library is controlled
+     * This helps reduce jerks and sudden movements in the vehicle
      */
     void limit_accel(const Vector3f &original_vel, Vector3f &modified_vel, float dt);
 
@@ -216,6 +218,7 @@ private:
     bool _proximity_alt_enabled = true; // true if proximity sensor based avoidance is enabled based on altitude
     uint32_t _last_limit_time;      // the last time a limit was active
     uint32_t _last_log_ms;          // the last time simple avoidance was logged
+    Vector3f _prev_avoid_vel;       // copy of avoidance adjusted velocity
 
     static AC_Avoid *_singleton;
 };

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -106,6 +106,7 @@ public:
 
     // return minimum alt (in meters) above which avoidance will be active
     float get_min_alt() const { return _alt_min; }
+
     // return true if limiting is active
     bool limits_active() const {return (AP_HAL::millis() - _last_limit_time) < AC_AVOID_ACTIVE_LIMIT_TIMEOUT_MS;};
 
@@ -117,6 +118,11 @@ private:
         BEHAVIOR_SLIDE = 0,
         BEHAVIOR_STOP = 1
     };
+
+    /*
+     * Limit acceleration so that change of velocity output by avoidance library is controlled
+     */
+    void limit_accel(const Vector3f &original_vel, Vector3f &modified_vel, float dt);
 
     /*
      * Adjusts the desired velocity for the circular fence.
@@ -204,6 +210,7 @@ private:
     AP_Int8 _behavior;          // avoidance behaviour (slide or stop)
     AP_Float _backup_speed_max; // Maximum speed that will be used to back away (in m/s)
     AP_Float _alt_min;          // alt below which Proximity based avoidance is turned off
+    AP_Float _accel_max;        // maximum accelration while simple avoidance is active
 
     bool _proximity_enabled = true; // true if proximity sensor based avoidance is enabled (used to allow pilot to enable/disable)
     bool _proximity_alt_enabled = true; // true if proximity sensor based avoidance is enabled based on altitude

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -82,6 +82,7 @@ public:
     // enable/disable proximity based avoidance
     void proximity_avoidance_enable(bool on_off) { _proximity_enabled = on_off; }
     bool proximity_avoidance_enabled() const { return _proximity_enabled; }
+    void proximity_alt_avoidance_enable(bool on_off) { _proximity_alt_enabled = on_off; }
 
     // helper functions
 
@@ -103,6 +104,8 @@ public:
     // return margin (in meters) that the vehicle should stay from objects
     float get_margin() const { return _margin; }
 
+    // return minimum alt (in meters) above which avoidance will be active
+    float get_min_alt() const { return _alt_min; }
     // return true if limiting is active
     bool limits_active() const {return (AP_HAL::millis() - _last_limit_time) < AC_AVOID_ACTIVE_LIMIT_TIMEOUT_MS;};
 
@@ -200,8 +203,10 @@ private:
     AP_Float _margin;           // vehicle will attempt to stay this distance (in meters) from objects while in GPS modes
     AP_Int8 _behavior;          // avoidance behaviour (slide or stop)
     AP_Float _backup_speed_max; // Maximum speed that will be used to back away (in m/s)
+    AP_Float _alt_min;          // alt below which Proximity based avoidance is turned off
 
     bool _proximity_enabled = true; // true if proximity sensor based avoidance is enabled (used to allow pilot to enable/disable)
+    bool _proximity_alt_enabled = true; // true if proximity sensor based avoidance is enabled based on altitude
     uint32_t _last_limit_time;      // the last time a limit was active
     uint32_t _last_log_ms;          // the last time simple avoidance was logged
 


### PR DESCRIPTION
This PR adds two new feature which should go a long way in improving the reliability of Simple Avoidance:

Adds a param: AVOID_ALT_MIN. If a down facing range finder is availble, it will switch OFF proximity avoidance below ALT_MIN
Adds a param: AVOID_ACCEL_MAX. This limits the maximum allowed change in velocity that avoidance can make (per axis)
This is a very important new addition which will make the avoidnace experience much more smoother, here is an example of what happens:
https://youtu.be/UkRMf8cIDjY