### PR TITLE
HAL_ChibiOS: don't start rout ticks till after full system init

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -321,7 +321,9 @@ void Scheduler::_timer_thread(void *arg)
         sched->_run_timers();
 
         // process any pending RC output requests
-        hal.rcout->timer_tick();
+        if (sched->is_system_initialized()) {
+            hal.rcout->timer_tick();
+        }
 
         if (sched->in_expected_delay()) {
             sched->watchdog_pat();


### PR DESCRIPTION
this prevents an occasional boot hang on systems with DShot
enabled. We shouldn't be starting DShot output till after setup() is
complete as the outputs are still being configured
thanks to @giacomo892 and @shellixyz for reporting
