### PR TITLE
AP_VisualOdom: fix T265 criteria for aligning to AHRS

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -135,8 +135,13 @@ bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, 
         return false;
     }
 
-    // if ahrs's yaw is from the compass, wait until it has been initialised
-    if (!AP::ahrs().is_ext_nav_used_for_yaw() && !AP::ahrs().yaw_initialised()) {
+    // do not align to ahrs if it is using us as its yaw source
+    if (AP::ahrs().is_ext_nav_used_for_yaw()) {
+        return false;
+    }
+
+    // do not align until ahrs yaw initialised
+    if (!AP::ahrs().initialised() || !AP::ahrs().yaw_initialised()) {
         return false;
     }
 


### PR DESCRIPTION
This corrects a bug in AP_VisualOdom_IntelT265::align_sensor_to_vehicle() which led to the camera's yaw being aligned to the AHRS too soon after startup and even when the AHRS itself was using external nav for its heading (aka "drinking its own bath water").

Below shows a before and after test in SITL where the EK3_SRC_YAW = 6 (ExtNav) and we see "before" it was being shifted but "after" it is not.
![viso-before](https://user-images.githubusercontent.com/1498098/106890864-45f7f780-672d-11eb-8f80-89cf5dae77b5.png)

Another test was done as well with EK3_SRC_YAW = 1 (compass) and AP_VisualOdom's yaw ended up closer to the compass's because the alignment (which happen automatically soon after startup) took place after the EKF3 had initialised.  This avoided the need for the pilot to re-align the yaw manually before arming and take-off.
![viso-align-prearm-failure](https://user-images.githubusercontent.com/1498098/106891284-d0d8f200-672d-11eb-9092-c910b1dcf886.png)

![viso-align-after](https://user-images.githubusercontent.com/1498098/106891576-37f6a680-672e-11eb-9d05-1e1dcbd65be4.png)


This corrects the 2nd item of issue https://github.com/ArduPilot/ardupilot/issues/13903.