### PR TITLE
Copter: run the "point yaw to ROI" controller at full rate (400Hz) in…

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -3,15 +3,9 @@
 Mode::AutoYaw Mode::auto_yaw;
 
 // roi_yaw - returns heading towards location held in roi
-float Mode::AutoYaw::roi_yaw()
+float Mode::AutoYaw::roi_yaw() const
 {
-    roi_yaw_counter++;
-    if (roi_yaw_counter >= 4) {
-        roi_yaw_counter = 0;
-        _roi_yaw = get_bearing_cd(copter.inertial_nav.get_position(), roi);
-    }
-
-    return _roi_yaw;
+    return get_bearing_cd(copter.inertial_nav.get_position(), roi);
 }
 
 float Mode::AutoYaw::look_ahead_yaw()
@@ -73,7 +67,6 @@ void Mode::AutoYaw::set_mode(autopilot_yaw_mode yaw_mode)
 
     case AUTO_YAW_ROI:
         // look ahead until we know otherwise
-        _roi_yaw = copter.ahrs.yaw_sensor;
         break;
 
     case AUTO_YAW_FIXED:

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -210,16 +210,13 @@ public:
     private:
 
         float look_ahead_yaw();
-        float roi_yaw();
+        float roi_yaw() const;
 
         // auto flight mode's yaw mode
         uint8_t _mode = AUTO_YAW_LOOK_AT_NEXT_WP;
 
         // Yaw will point at this location if mode is set to AUTO_YAW_ROI
         Vector3f roi;
-
-        // bearing from current location to the ROI
-        float _roi_yaw;
 
         // yaw used for YAW_FIXED yaw_mode
         int32_t _fixed_yaw;
@@ -232,10 +229,6 @@ public:
 
         // turn rate (in cds) when auto_yaw_mode is set to AUTO_YAW_RATE
         float _rate_cds;
-
-        // used to reduce update rate to 100hz:
-        uint8_t roi_yaw_counter;
-
     };
     static AutoYaw auto_yaw;
 


### PR DESCRIPTION
…stead of 1/4 of full rate (100Hz)

This should improve pointing at ROI and replaces #11172

Removes 14 lines of code