### PR TITLE
GCS_MAVLink: invalidate param count on set of ENABLE param

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -296,6 +296,10 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
     // save the change
     vp->save(force_save);
 
+    if (force_save && (parameter_flags & AP_PARAM_FLAG_ENABLE)) {
+        AP_Param::invalidate_count();
+    }
+    
     AP_Logger *logger = AP_Logger::get_singleton();
     if (logger != nullptr) {
         logger->Write_Parameter(key, vp->cast_to_float(var_type));


### PR DESCRIPTION
This fixes a very annoying bug