### PR TITLE
SITL: Add parsing of airspeed to SIM_JSON

### DIFF
--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -283,14 +283,21 @@ void JSON::recv_fdm(const struct sitl_input &input)
         dcm.from_euler(state.attitude[0], state.attitude[1], state.attitude[2]);
     }
 
-    // velocity relative to airmass in body frame
-    velocity_air_bf = dcm.transposed() * velocity_ef;
+    if ((received_bitmask & AIRSPEED)) {
+        // received airspeed directly
+        airspeed = state.airspeed;
 
-    // airspeed
-    airspeed = velocity_air_bf.length();
+        airspeed_pitot = state.airspeed;
+    } else {
+        // velocity relative to airmass in body frame
+        velocity_air_bf = dcm.transposed() * velocity_ef;
 
-    // airspeed as seen by a fwd pitot tube (limited to 120m/s)
-    airspeed_pitot = constrain_float(velocity_air_bf * Vector3f(1.0f, 0.0f, 0.0f), 0.0f, 120.0f);
+        // airspeed
+        airspeed = velocity_air_bf.length();
+
+        // airspeed as seen by a fwd pitot tube (limited to 120m/s)
+        airspeed_pitot = constrain_float(velocity_air_bf * Vector3f(1.0f, 0.0f, 0.0f), 0.0f, 120.0f);
+    }
 
     // Convert from a meters from origin physics to a lat long alt
     update_position();

--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -86,6 +86,7 @@ private:
             float direction;
             float speed;
         } wind_vane_apparent;
+        float airspeed;
     } state;
 
     // table to aid parsing of JSON sensor data
@@ -95,7 +96,7 @@ private:
         void *ptr;
         enum data_type type;
         bool required;
-    } keytable[15] = {
+    } keytable[16] = {
         { "", "timestamp", &state.timestamp_s, DATA_DOUBLE, true },
         { "imu", "gyro",    &state.imu.gyro, DATA_VECTOR3F, true },
         { "imu", "accel_body", &state.imu.accel_body, DATA_VECTOR3F, true },
@@ -111,6 +112,7 @@ private:
         { "", "rng_6", &state.rng[5], DATA_FLOAT, false },
         {"windvane","direction", &state.wind_vane_apparent.direction, DATA_FLOAT, false},
         {"windvane","speed", &state.wind_vane_apparent.speed, DATA_FLOAT, false},
+        {"", "airspeed", &state.airspeed, DATA_FLOAT, false},
     };
 
     // Enum coresponding to the ordering of keys in the keytable.
@@ -130,6 +132,7 @@ private:
         RNG_6       = 1U << 12,
         WIND_DIR    = 1U << 13,
         WIND_SPD    = 1U << 14,
+        AIRSPEED    = 1U << 15,
     };
     uint16_t last_received_bitmask;
 };

--- a/libraries/SITL/examples/JSON/readme.md
+++ b/libraries/SITL/examples/JSON/readme.md
@@ -66,6 +66,12 @@ Apparent wind:
 ```
 for example:```"windvane":{"direction":0,"speed":0}```
 
+Airspeed:
+
+```
+    airspeed (m/s)
+```
+
 When first connecting you will see a message reporting what fields were successfully received. If any of the mandatory fields are missing SITL will stop, however it will run without the optional fields. This message can be used to double check SITL is receiving everything being sent by the physics backend.
 
 For example:


### PR DESCRIPTION
Adds parsing of airspeed in m/s for fixed-wing simulations.