### PR TITLE
Plane: Constrain roll until TKOFF_ROTATE_SPD is reached

### DIFF
--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -137,7 +137,7 @@ void Plane::takeoff_calc_roll(void)
     const float lim1 = 5;    
     // at 15m allow for full roll
     const float lim2 = 15;
-    if (baro_alt < auto_state.baro_takeoff_alt+lim1) {
+    if ((baro_alt < auto_state.baro_takeoff_alt+lim1) || (auto_state.highest_airspeed < g.takeoff_rotate_speed)) {
         roll_limit = g.level_roll_limit;
     } else if (baro_alt < auto_state.baro_takeoff_alt+lim2) {
         float proportion = (baro_alt - (auto_state.baro_takeoff_alt+lim1)) / (lim2 - lim1);


### PR DESCRIPTION
This constrains roll until rotation is started. This is a safety net against excessive rolling if altitude-based constraints on roll become ineffective e.g. due to baro drift or change of position prior to starting takeoff run.