### PR TITLE
Deal correctly with LED and DMA configuration changing

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -246,7 +246,6 @@ private:
         Shared_DMA *dma_handle;
         uint32_t *dma_buffer;
         uint16_t dma_buffer_len;
-        bool have_lock;
         bool pwm_started;
         uint32_t bit_width_mul;
         uint32_t rc_frequency;
@@ -475,7 +474,8 @@ private:
     static void dma_up_irq_callback(void *p, uint32_t flags);
     static void dma_unlock(void *p);
     bool mode_requires_dma(enum output_mode mode) const;
-    bool setup_group_DMA(pwm_group &group, uint32_t bitrate, uint32_t bit_width, bool active_high, const uint16_t buffer_length, bool choose_high);
+    bool setup_group_DMA(pwm_group &group, uint32_t bitrate, uint32_t bit_width, bool active_high,
+      const uint16_t buffer_length, bool choose_high, uint32_t pulse_time_us);
     void send_pulses_DMAR(pwm_group &group, uint32_t buffer_length);
     void set_group_mode(pwm_group &group);
     static bool is_dshot_protocol(const enum output_mode mode);

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -480,7 +480,10 @@ void RCOutput::dma_up_irq_callback(void *p, uint32_t flags)
         TOGGLE_PIN_DEBUG(55);
     } else {
         // non-bidir case
-        chVTSetI(&group->dma_timeout, chTimeUS2I(group->dshot_pulse_time_us + 40), dma_unlock, p);
+        // this prevents us ever having two dshot pulses too close together
+        // dshot mandates a minimum pulse separation of 40us, WS2812 mandates 50us so we
+        // pick the higher value
+        chVTSetI(&group->dma_timeout, chTimeUS2I(50), dma_unlock, p);
     }
 
     chSysUnlockFromISR();

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -188,6 +188,7 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Description: The number of Serial LED's to use for notifications (NeoPixel's and ProfiLED)
     // @Range: 1 32
     // @User: Advanced
+    // @RebootRequired: True
     AP_GROUPINFO("LED_LEN", 9, AP_Notify, _led_len, NOTIFY_LED_LEN_DEFAULT),
 
     AP_GROUPEND

--- a/libraries/AP_Notify/SerialLED.cpp
+++ b/libraries/AP_Notify/SerialLED.cpp
@@ -25,20 +25,8 @@ SerialLED::SerialLED(uint8_t led_off, uint8_t led_bright, uint8_t led_medium, ui
 
 bool SerialLED::hw_init()
 {
-    init_ports();
-    hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&SerialLED::timer, void));
+    enable_mask = init_ports();
     return true;
-}
-
-void SerialLED::timer()
-{
-    WITH_SEMAPHORE(_sem);
-
-    const uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - _last_init_ms >= 1000) {
-        _last_init_ms = now_ms;
-        enable_mask = init_ports();
-    }
 }
 
 bool SerialLED::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)

--- a/libraries/AP_Notify/SerialLED.h
+++ b/libraries/AP_Notify/SerialLED.h
@@ -39,11 +39,5 @@ protected:
 private:
     uint16_t enable_mask;
 
-    // perdiodic tick to re-init
-    uint32_t    _last_init_ms;
-
-    // periodic callback
-    void timer();
-
     HAL_Semaphore _sem;
 };


### PR DESCRIPTION
Four bugs for the price of one:

- Removes the unnecessary extra pulse timeout that was set on the DMA completion IRQ. This is now just a straight 40us. This prevents us waiting twice as long as we need to.
- Calculates the LED timeout correctly preventing us waiting 4 times as long as we need to
- Always re-configures DMA in set_output_mode if DMA is being used, this prevents weird DMA overruns
- Re-allocates the LED buffers correctly when they change