### PR TITLE
Compensate AK09916 on CubeOrange for magnetic impact of heater

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -189,6 +189,11 @@ public:
 
 #if HAL_HAVE_IMU_HEATER
     void set_imu_temp(float current_temp_c);
+
+    // heater duty cycle is as a percentage (0 to 100)
+    float get_heater_duty_cycle(void) const {
+        return heater.output;
+    }
 #endif
 
 private:

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <AP_InertialSensor/AP_InertialSensor_Invensensev2.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -287,6 +288,19 @@ void AP_Compass_AK09916::_update()
 
     _make_adc_sensitivity_adjustment(raw_field);
     raw_field *= AK09916_MILLIGAUSS_SCALE;
+
+#ifdef HAL_AK09916_HEATER_OFFSET
+    /*
+      the internal AK09916 can be impacted by the magnetic field from
+      a heater. We use the heater duty cycle to correct for the error
+     */
+    if (AP_HAL::Device::devid_get_bus_type(_bus->get_bus_id()) == AP_HAL::Device::BUS_TYPE_SPI) {
+        auto *bc = AP::boardConfig();
+        if (bc) {
+            raw_field += HAL_AK09916_HEATER_OFFSET * bc->get_heater_duty_cycle() * 0.01;
+        }
+    }
+#endif
 
     accumulate_sample(raw_field, _compass_instance, 10);
 }

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
@@ -281,6 +281,10 @@ COMPASS AK8963:probe_mpu9250 1 ROTATION_YAW_270
 # compass as part of ICM20948 on newer cubes
 COMPASS AK09916:probe_ICM20948 0 ROTATION_ROLL_180_YAW_90
 
+# offset the internal compass for EM impact of the IMU heater
+# this is in sensor frame mGauss
+define HAL_AK09916_HEATER_OFFSET Vector3f(30,10,235)
+
 # also probe for external compasses
 define HAL_PROBE_EXTERNAL_I2C_COMPASSES
 


### PR DESCRIPTION
This adds an offset to the internal AK09916 compass based on the heater duty cycle. It is needed as the heater produces a strong magnetic field.
This still leaves the internal compass as quite noisy, but the average is good which is what really matters for the EKF
Without correction:
![image](https://user-images.githubusercontent.com/831867/107174372-2529ed80-6a1e-11eb-95f7-51fdb1b9306f.png)
with correction:
![image](https://user-images.githubusercontent.com/831867/107174409-396dea80-6a1e-11eb-8476-24faf08e7ec1.png)
