### PR TITLE
CI: added upload of failed tests to artifacts

### DIFF
--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{ matrix.toolchain }}-${{matrix.config}}
+           name: fail-${{ matrix.toolchain }}-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -108,18 +108,18 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{matrix.config}}
+           name: fail-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14
 
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v2
         with:
-           name: BIN-files-for-${{matrix.config}}
+           name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
-
 
   build-gcc-heli:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -207,14 +207,15 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{matrix.config}}
+           name: fail-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14
 
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v2
         with:
-           name: BIN-files-for-${{matrix.config}}
+           name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -103,15 +103,16 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{matrix.config}}
+           name: fail-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14
 
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v2
         with:
-           name: BIN-files-for-${{matrix.config}}
+           name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
 

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -103,15 +103,16 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{matrix.config}}
+           name: fail-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14
 
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v2
         with:
-           name: BIN-files-for-${{matrix.config}}
+           name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
 

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -102,15 +102,16 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{matrix.config}}
+           name: fail-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14
 
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v2
         with:
-           name: BIN-files-for-${{matrix.config}}
+           name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
 

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -102,15 +102,16 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{matrix.config}}
+           name: fail-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14
 
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v2
         with:
-           name: BIN-files-for-${{matrix.config}}
+           name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
 

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
-           name: buildlogs-for-${{ matrix.toolchain }}-${{matrix.config}}
+           name: fail-${{ matrix.toolchain }}-${{matrix.config}}
            path: /tmp/buildlogs
            retention-days: 14


### PR DESCRIPTION
This fixes upload of test failures. The key is you need to use the "if: failure()" syntax. If you don't then the step is skipped when the previous steps have failed
Here is an example of a deliberate failure:
https://github.com/ArduPilot/ardupilot/actions/runs/549263974
![image](https://user-images.githubusercontent.com/831867/107284398-e04f9680-6ab1-11eb-963f-f84342dc1e67.png)
the fail-* link gives a zip file with the logs from /tmp/buildlogs for the failure