### PR TITLE
Rover/EKF: fix for vehicle moving when GPS_TYPE=0

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -43,7 +43,7 @@ AP_AHRS_NavEKF::AP_AHRS_NavEKF(uint8_t flags) :
     AP_AHRS_DCM(),
     _ekf_flags(flags)
 {
-#if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduSub)
+#if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduSub) || APM_BUILD_TYPE(APM_BUILD_Rover)
     // Copter and Sub force the use of EKF
     _ekf_flags |= AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF;
 #endif


### PR DESCRIPTION
This PR provides a fix for the bug that was reported here #14279.Thanks!
![ekf-rover](https://user-images.githubusercontent.com/62841337/107266050-ff770580-6a6a-11eb-8c6c-0f2a254baffc.png)
