### PR TITLE
Added support for scripts in ROMFS in 4.0

### DIFF
--- a/libraries/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/AP_Common.cpp
@@ -70,3 +70,16 @@ bool hex_to_uint8(uint8_t a, uint8_t &res)
     }
     return true;
 }
+
+/*
+  strncpy without the warning for not leaving room for nul termination
+ */
+void strncpy_noterm(char *dest, const char *src, size_t n)
+{
+    size_t len = strnlen(src, n);
+    if (len < n) {
+        // include nul term if it fits
+        len++;
+    }
+    memcpy(dest, src, len);
+}

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -138,3 +138,8 @@ template<typename s, size_t t> struct assert_storage_size {
 bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 
 bool hex_to_uint8(uint8_t a, uint8_t &res);  // return the uint8 value of an ascii hex character
+
+/*
+  strncpy without the warning for not leaving room for nul termination
+ */
+void strncpy_noterm(char *dest, const char *src, size_t n);

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -15,9 +15,219 @@
 
 #include "AP_Filesystem.h"
 
-#if HAVE_FILESYSTEM_SUPPORT
-
 static AP_Filesystem fs;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#if HAVE_FILESYSTEM_SUPPORT
+#include "AP_Filesystem_FATFS.h"
+static AP_Filesystem_FATFS fs_local;
+#else
+static AP_Filesystem_Backend fs_local;
+int errno;
+#endif // HAVE_FILESYSTEM_SUPPORT
+#endif // HAL_BOARD_CHIBIOS
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include "AP_Filesystem_posix.h"
+static AP_Filesystem_Posix fs_local;
+#endif
+
+#ifdef HAL_HAVE_AP_ROMFS_EMBEDDED_H
+#include "AP_Filesystem_ROMFS.h"
+static AP_Filesystem_ROMFS fs_romfs;
+#endif
+
+/*
+  mapping from filesystem prefix to backend
+ */
+const AP_Filesystem::Backend AP_Filesystem::backends[] = {
+    { nullptr, fs_local },
+#ifdef HAL_HAVE_AP_ROMFS_EMBEDDED_H
+    { "@ROMFS/", fs_romfs },
+#endif
+};
+
+#define MAX_FD_PER_BACKEND 256U
+#define NUM_BACKENDS ARRAY_SIZE(backends)
+#define LOCAL_BACKEND backends[0]
+#define BACKEND_IDX(backend) (&(backend) - &backends[0])
+
+/*
+  find backend by path
+ */
+const AP_Filesystem::Backend &AP_Filesystem::backend_by_path(const char *&path) const
+{
+    for (uint8_t i=1; i<NUM_BACKENDS; i++) {
+        const uint8_t plen = strlen(backends[i].prefix);
+        if (strncmp(path, backends[i].prefix, plen) == 0) {
+            path += plen;
+            return backends[i];
+        }
+    }
+    // default to local filesystem
+    return LOCAL_BACKEND;
+}
+
+/*
+  return backend by file descriptor
+ */
+const AP_Filesystem::Backend &AP_Filesystem::backend_by_fd(int &fd) const
+{
+    if (fd < 0 || uint32_t(fd) >= NUM_BACKENDS*MAX_FD_PER_BACKEND) {
+        return LOCAL_BACKEND;
+    }
+    const uint8_t idx = uint32_t(fd) / MAX_FD_PER_BACKEND;
+    fd -= idx * MAX_FD_PER_BACKEND;
+    return backends[idx];
+}
+
+int AP_Filesystem::open(const char *fname, int flags)
+{
+    const Backend &backend = backend_by_path(fname);
+    int fd = backend.fs.open(fname, flags);
+    if (fd < 0) {
+        return -1;
+    }
+    if (uint32_t(fd) >= MAX_FD_PER_BACKEND) {
+        backend.fs.close(fd);
+        errno = ERANGE;
+        return -1;
+    }
+    // offset fd so we can recognise the backend
+    const uint8_t idx = (&backend - &backends[0]);
+    fd += idx * MAX_FD_PER_BACKEND;
+    return fd;
+}
+
+int AP_Filesystem::close(int fd)
+{
+    const Backend &backend = backend_by_fd(fd);
+    return backend.fs.close(fd);
+}
+
+int32_t AP_Filesystem::read(int fd, void *buf, uint32_t count)
+{
+    const Backend &backend = backend_by_fd(fd);
+    return backend.fs.read(fd, buf, count);
+}
+
+int32_t AP_Filesystem::write(int fd, const void *buf, uint32_t count)
+{
+    const Backend &backend = backend_by_fd(fd);
+    return backend.fs.write(fd, buf, count);
+}
+
+int AP_Filesystem::fsync(int fd)
+{
+    const Backend &backend = backend_by_fd(fd);
+    return backend.fs.fsync(fd);
+}
+
+int32_t AP_Filesystem::lseek(int fd, int32_t offset, int seek_from)
+{
+    const Backend &backend = backend_by_fd(fd);
+    return backend.fs.lseek(fd, offset, seek_from);
+}
+
+int AP_Filesystem::stat(const char *pathname, struct stat *stbuf)
+{
+    const Backend &backend = backend_by_path(pathname);
+    return backend.fs.stat(pathname, stbuf);
+}
+
+int AP_Filesystem::unlink(const char *pathname)
+{
+    const Backend &backend = backend_by_path(pathname);
+    return backend.fs.unlink(pathname);
+}
+
+int AP_Filesystem::mkdir(const char *pathname)
+{
+    const Backend &backend = backend_by_path(pathname);
+    return backend.fs.mkdir(pathname);
+}
+
+AP_Filesystem::DirHandle *AP_Filesystem::opendir(const char *pathname)
+{
+    const Backend &backend = backend_by_path(pathname);
+    DirHandle *h = new DirHandle;
+    if (!h) {
+        return nullptr;
+    }
+    h->dir = backend.fs.opendir(pathname);
+    if (h->dir == nullptr) {
+        delete h;
+        return nullptr;
+    }
+    h->fs_index = BACKEND_IDX(backend);
+    return h;
+}
+
+struct dirent *AP_Filesystem::readdir(DirHandle *dirp)
+{
+    if (!dirp) {
+        return nullptr;
+    }
+    const Backend &backend = backends[dirp->fs_index];
+    return backend.fs.readdir(dirp->dir);
+}
+
+int AP_Filesystem::closedir(DirHandle *dirp)
+{
+    if (!dirp) {
+        return -1;
+    }
+    const Backend &backend = backends[dirp->fs_index];
+    int ret = backend.fs.closedir(dirp->dir);
+    delete dirp;
+    return ret;
+}
+
+// return free disk space in bytes
+int64_t AP_Filesystem::disk_free(const char *path)
+{
+    const Backend &backend = backend_by_path(path);
+    return backend.fs.disk_free(path);
+}
+
+// return total disk space in bytes
+int64_t AP_Filesystem::disk_space(const char *path)
+{
+    const Backend &backend = backend_by_path(path);
+    return backend.fs.disk_space(path);
+}
+
+
+/*
+  set mtime on a file
+ */
+bool AP_Filesystem::set_mtime(const char *filename, const uint32_t mtime_sec)
+{
+    const Backend &backend = backend_by_path(filename);
+    return backend.fs.set_mtime(filename, mtime_sec);
+}
+
+// if filesystem is not running then try a remount
+bool AP_Filesystem::retry_mount(void)
+{
+    return LOCAL_BACKEND.fs.retry_mount();
+}
+
+// unmount filesystem for reboot
+void AP_Filesystem::unmount(void)
+{
+    return LOCAL_BACKEND.fs.unmount();
+}
+
+/*
+  load a file to memory as a single chunk. Use only for small files
+ */
+FileData *AP_Filesystem::load_file(const char *filename)
+{
+    const Backend &backend = backend_by_path(filename);
+    return backend.fs.load_file(filename);
+}
+
 
 namespace AP
 {
@@ -26,4 +236,4 @@ AP_Filesystem &FS()
     return fs;
 }
 }
-#endif
+

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -24,15 +24,37 @@
 
 #include "AP_Filesystem_Available.h"
 
-#if HAVE_FILESYSTEM_SUPPORT
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#if HAVE_FILESYSTEM_SUPPORT
 #include "AP_Filesystem_FATFS.h"
 #endif
+#define DT_REG 0
+#define DT_DIR 1
+#if defined(FF_MAX_LFN) && FF_USE_LFN != 0
+#define MAX_NAME_LEN FF_MAX_LFN 
+#else
+#define MAX_NAME_LEN 13
+#endif
+struct dirent {
+   char    d_name[MAX_NAME_LEN]; /* filename */
+   uint8_t d_type;
+};
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+#endif // HAL_BOARD_CHIBIOS
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_Filesystem_posix.h"
 #endif
 
+#include "AP_Filesystem_backend.h"
+
 class AP_Filesystem {
+private:
+    struct DirHandle {
+        uint8_t fs_index;
+        void *dir;
+    };
 
 public:
     AP_Filesystem() {}
@@ -40,16 +62,17 @@ public:
     // functions that closely match the equivalent posix calls
     int open(const char *fname, int flags);
     int close(int fd);
-    ssize_t read(int fd, void *buf, size_t count);
-    ssize_t write(int fd, const void *buf, size_t count);
+    int32_t read(int fd, void *buf, uint32_t count);
+    int32_t write(int fd, const void *buf, uint32_t count);
     int fsync(int fd);
-    off_t lseek(int fd, off_t offset, int whence);
+    int32_t lseek(int fd, int32_t offset, int whence);
     int stat(const char *pathname, struct stat *stbuf);
     int unlink(const char *pathname);
     int mkdir(const char *pathname);
-    DIR *opendir(const char *pathname);
-    struct dirent *readdir(DIR *dirp);
-    int closedir(DIR *dirp);
+
+    DirHandle *opendir(const char *pathname);
+    struct dirent *readdir(DirHandle *dirp);
+    int closedir(DirHandle *dirp);
 
     // return free disk space in bytes, -1 on error
     int64_t disk_free(const char *path);
@@ -58,10 +81,38 @@ public:
     int64_t disk_space(const char *path);
 
     // set modification time on a file
-    bool set_mtime(const char *filename, const time_t mtime_sec);
+    bool set_mtime(const char *filename, const uint32_t mtime_sec);
+
+    // if filesystem is not running then try a remount. Return true if fs is mounted
+    bool retry_mount(void);
+
+    // unmount filesystem for reboot
+    void unmount(void);
+
+    /*
+      load a full file. Use delete to free the data
+     */
+    FileData *load_file(const char *filename);
+    
+private:
+    struct Backend {
+        const char *prefix;
+        AP_Filesystem_Backend &fs;
+    };
+    static const struct Backend backends[];
+
+    /*
+      find backend by path
+     */
+    const Backend &backend_by_path(const char *&path) const;
+
+    /*
+      find backend by open fd
+     */
+    const Backend &backend_by_fd(int &fd) const;
 };
 
 namespace AP {
     AP_Filesystem &FS();
 };
-#endif // HAVE_FILESYSTEM_SUPPORT
+

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -5,6 +5,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
+#include <AP_RTC/AP_RTC.h>
 
 #if HAVE_FILESYSTEM_SUPPORT && CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 
@@ -31,7 +32,7 @@ static bool remount_needed;
 // use a semaphore to ensure that only one filesystem operation is
 // happening at a time. A recursive semaphore is used to cope with the
 // mkdir() inside sdcard_retry()
-static HAL_Semaphore_Recursive sem;
+static HAL_Semaphore sem;
 
 typedef struct {
     FIL *fh;
@@ -41,7 +42,7 @@ typedef struct {
 #define MAX_FILES 16
 static FAT_FILE *file_table[MAX_FILES];
 
-static bool isatty(int fileno)
+static int isatty_(int fileno)
 {
     if (fileno >= 0 && fileno <= 2) {
         return true;
@@ -59,7 +60,7 @@ static int new_file_descriptor(const char *pathname)
     FIL *fh;
 
     for (i=0; i<MAX_FILES; ++i) {
-        if (isatty(i)) {
+        if (isatty_(i)) {
             continue;
         }
         if ( file_table[i] == NULL) {
@@ -114,7 +115,7 @@ static int free_file_descriptor(int fileno)
     FAT_FILE *stream;
     FIL *fh;
 
-    if (isatty( fileno )) {
+    if (isatty_( fileno )) {
         errno = EBADF;
         return -1;
     }
@@ -144,7 +145,7 @@ static FIL *fileno_to_fatfs(int fileno)
     FAT_FILE *stream;
     FIL *fh;
 
-    if (isatty( fileno )) {
+    if (isatty_( fileno )) {
         errno = EBADF;
         return nullptr;
     }
@@ -276,7 +277,7 @@ static bool remount_file_system(void)
     return true;
 }
 
-int AP_Filesystem::open(const char *pathname, int flags)
+int AP_Filesystem_FATFS::open(const char *pathname, int flags)
 {
     int fileno;
     int fatfs_modes;
@@ -352,7 +353,7 @@ int AP_Filesystem::open(const char *pathname, int flags)
     return fileno;
 }
 
-int AP_Filesystem::close(int fileno)
+int AP_Filesystem_FATFS::close(int fileno)
 {
     FAT_FILE *stream;
     FIL *fh;
@@ -382,7 +383,7 @@ int AP_Filesystem::close(int fileno)
     return 0;
 }
 
-ssize_t AP_Filesystem::read(int fd, void *buf, size_t count)
+int32_t AP_Filesystem_FATFS::read(int fd, void *buf, uint32_t count)
 {
     UINT bytes = count;
     int res;
@@ -414,7 +415,10 @@ ssize_t AP_Filesystem::read(int fd, void *buf, size_t count)
             errno = fatfs_to_errno((FRESULT)res);
             return -1;
         }
-        if (size > n || size == 0) {
+        if (size == 0) {
+            break;
+        }
+        if (size > n) {
             errno = EIO;
             return -1;
         }
@@ -428,7 +432,7 @@ ssize_t AP_Filesystem::read(int fd, void *buf, size_t count)
     return (ssize_t)total;
 }
 
-ssize_t AP_Filesystem::write(int fd, const void *buf, size_t count)
+int32_t AP_Filesystem_FATFS::write(int fd, const void *buf, uint32_t count)
 {
     UINT bytes = count;
     FRESULT res;
@@ -476,7 +480,7 @@ ssize_t AP_Filesystem::write(int fd, const void *buf, size_t count)
     return (ssize_t)total;
 }
 
-int AP_Filesystem::fsync(int fileno)
+int AP_Filesystem_FATFS::fsync(int fileno)
 {
     FAT_FILE *stream;
     FIL *fh;
@@ -505,7 +509,7 @@ int AP_Filesystem::fsync(int fileno)
     return 0;
 }
 
-off_t AP_Filesystem::lseek(int fileno, off_t position, int whence)
+off_t AP_Filesystem_FATFS::lseek(int fileno, off_t position, int whence)
 {
     FRESULT res;
     FIL *fh;
@@ -519,7 +523,7 @@ off_t AP_Filesystem::lseek(int fileno, off_t position, int whence)
         errno = EMFILE;
         return -1;
     }
-    if (isatty(fileno)) {
+    if (isatty_(fileno)) {
         return -1;
     }
 
@@ -537,48 +541,6 @@ off_t AP_Filesystem::lseek(int fileno, off_t position, int whence)
     return fh->fptr;
 }
 
-/*
-  mktime replacement from Samba
- */
-static time_t replace_mktime(const struct tm *t)
-{
-    time_t  epoch = 0;
-    int n;
-    int mon [] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }, y, m, i;
-    const unsigned MINUTE = 60;
-    const unsigned HOUR = 60*MINUTE;
-    const unsigned DAY = 24*HOUR;
-    const unsigned YEAR = 365*DAY;
-
-    if (t->tm_year < 70) {
-        return (time_t)-1;
-    }
-
-    n = t->tm_year + 1900 - 1;
-    epoch = (t->tm_year - 70) * YEAR +
-            ((n / 4 - n / 100 + n / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400)) * DAY;
-
-    y = t->tm_year + 1900;
-    m = 0;
-
-    for (i = 0; i < t->tm_mon; i++) {
-        epoch += mon [m] * DAY;
-        if (m == 1 && y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
-            epoch += DAY;
-        }
-
-        if (++m > 11) {
-            m = 0;
-            y++;
-        }
-    }
-
-    epoch += (t->tm_mday - 1) * DAY;
-    epoch += t->tm_hour * HOUR + t->tm_min * MINUTE + t->tm_sec;
-
-    return epoch;
-}
-
 static time_t fat_time_to_unix(uint16_t date, uint16_t time)
 {
     struct tm tp;
@@ -592,11 +554,11 @@ static time_t fat_time_to_unix(uint16_t date, uint16_t time)
     tp.tm_mday = (date & 0x1f);
     tp.tm_mon = ((date >> 5) & 0x0f) - 1;
     tp.tm_year = ((date >> 9) & 0x7f) + 80;
-    unix = replace_mktime( &tp );
+    unix = AP::rtc().mktime(&tp);
     return unix;
 }
 
-int AP_Filesystem::stat(const char *name, struct stat *buf)
+int AP_Filesystem_FATFS::stat(const char *name, struct stat *buf)
 {
     FILINFO info;
     int res;
@@ -664,7 +626,7 @@ int AP_Filesystem::stat(const char *name, struct stat *buf)
     return 0;
 }
 
-int AP_Filesystem::unlink(const char *pathname)
+int AP_Filesystem_FATFS::unlink(const char *pathname)
 {
     WITH_SEMAPHORE(sem);
 
@@ -677,7 +639,7 @@ int AP_Filesystem::unlink(const char *pathname)
     return 0;
 }
 
-int AP_Filesystem::mkdir(const char *pathname)
+int AP_Filesystem_FATFS::mkdir(const char *pathname)
 {
     WITH_SEMAPHORE(sem);
 
@@ -700,7 +662,7 @@ struct DIR_Wrapper {
     struct dirent de;
 };
 
-DIR *AP_Filesystem::opendir(const char *pathdir)
+void *AP_Filesystem_FATFS::opendir(const char *pathdir)
 {
     WITH_SEMAPHORE(sem);
 
@@ -727,9 +689,10 @@ DIR *AP_Filesystem::opendir(const char *pathdir)
     return &ret->d;
 }
 
-struct dirent *AP_Filesystem::readdir(DIR *dirp)
+struct dirent *AP_Filesystem_FATFS::readdir(void *dirp_void)
 {
     WITH_SEMAPHORE(sem);
+    DIR *dirp = (DIR *)dirp_void;
 
     struct DIR_Wrapper *d = (struct DIR_Wrapper *)dirp;
     if (!d) {
@@ -741,13 +704,13 @@ struct dirent *AP_Filesystem::readdir(DIR *dirp)
     int res;
 
     d->de.d_name[0] = 0;
-    res = f_readdir ( dirp, &fno );
+    res = f_readdir(dirp, &fno);
     if (res != FR_OK || fno.fname[0] == 0) {
         errno = fatfs_to_errno((FRESULT)res);
         return nullptr;
     }
     len = strlen(fno.fname);
-    strncpy(d->de.d_name,fno.fname,len);
+    strncpy_noterm(d->de.d_name,fno.fname,len);
     d->de.d_name[len] = 0;
     if (fno.fattrib & AM_DIR) {
         d->de.d_type = DT_DIR;
@@ -757,8 +720,9 @@ struct dirent *AP_Filesystem::readdir(DIR *dirp)
     return &d->de;
 }
 
-int AP_Filesystem::closedir(DIR *dirp)
+int AP_Filesystem_FATFS::closedir(void *dirp_void)
 {
+    DIR *dirp = (DIR *)dirp_void;
     WITH_SEMAPHORE(sem);
 
     struct DIR_Wrapper *d = (struct DIR_Wrapper *)dirp;
@@ -777,7 +741,7 @@ int AP_Filesystem::closedir(DIR *dirp)
 }
 
 // return free disk space in bytes
-int64_t AP_Filesystem::disk_free(const char *path)
+int64_t AP_Filesystem_FATFS::disk_free(const char *path)
 {
     WITH_SEMAPHORE(sem);
 
@@ -798,7 +762,7 @@ int64_t AP_Filesystem::disk_free(const char *path)
 }
 
 // return total disk space in bytes
-int64_t AP_Filesystem::disk_space(const char *path)
+int64_t AP_Filesystem_FATFS::disk_space(const char *path)
 {
     WITH_SEMAPHORE(sem);
 
@@ -838,7 +802,7 @@ static void unix_time_to_fat(time_t epoch, uint16_t &date, uint16_t &time)
 /*
   set mtime on a file
  */
-bool AP_Filesystem::set_mtime(const char *filename, const time_t mtime_sec)
+bool AP_Filesystem_FATFS::set_mtime(const char *filename, const uint32_t mtime_sec)
 {
     FILINFO fno;
     uint16_t fdate, ftime;
@@ -851,6 +815,24 @@ bool AP_Filesystem::set_mtime(const char *filename, const time_t mtime_sec)
     WITH_SEMAPHORE(sem);
 
     return f_utime(filename, (FILINFO *)&fno) == FR_OK;
+}
+
+/*
+  retry mount of filesystem if needed
+*/
+bool AP_Filesystem_FATFS::retry_mount(void)
+{
+    WITH_SEMAPHORE(sem);
+    return sdcard_retry();
+}
+
+/*
+  unmount filesystem for reboot
+*/
+void AP_Filesystem_FATFS::unmount(void)
+{
+    WITH_SEMAPHORE(sem);
+    return sdcard_stop();
 }
 
 /*

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
@@ -2,12 +2,15 @@
   FATFS backend for AP_Filesystem
  */
 
+#pragma once
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stddef.h>
 #include <ff.h>
+#include "AP_Filesystem_backend.h"
 
 // Seek offset macros
 #define SEEK_SET 0
@@ -20,10 +23,35 @@
 #define MAX_NAME_LEN 13
 #endif
 
-#define DT_REG 0
-#define DT_DIR 1
+class AP_Filesystem_FATFS : public AP_Filesystem_Backend
+{
+public:
+    // functions that closely match the equivalent posix calls
+    int open(const char *fname, int flags) override;
+    int close(int fd) override;
+    int32_t read(int fd, void *buf, uint32_t count) override;
+    int32_t write(int fd, const void *buf, uint32_t count) override;
+    int fsync(int fd) override;
+    int32_t lseek(int fd, int32_t offset, int whence) override;
+    int stat(const char *pathname, struct stat *stbuf) override;
+    int unlink(const char *pathname) override;
+    int mkdir(const char *pathname) override;
+    void *opendir(const char *pathname) override;
+    struct dirent *readdir(void *dirp) override;
+    int closedir(void *dirp) override;
 
-struct dirent {
-   char           d_name[MAX_NAME_LEN]; /* filename */
-   uint8_t d_type;
+    // return free disk space in bytes, -1 on error
+    int64_t disk_free(const char *path) override;
+
+    // return total disk space in bytes, -1 on error
+    int64_t disk_space(const char *path) override;
+
+    // set modification time on a file
+    bool set_mtime(const char *filename, const uint32_t mtime_sec) override;
+
+    // retry mount of filesystem if needed
+    bool retry_mount(void) override;
+
+    // unmount filesystem for reboot
+    void unmount(void) override;
 };

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
@@ -1,0 +1,239 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  ArduPilot filesystem interface for ROMFS
+ */
+#include "AP_Filesystem.h"
+#include "AP_Filesystem_ROMFS.h"
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_ROMFS/AP_ROMFS.h>
+
+#if defined(HAL_HAVE_AP_ROMFS_EMBEDDED_H)
+
+int AP_Filesystem_ROMFS::open(const char *fname, int flags)
+{
+    if ((flags & O_ACCMODE) != O_RDONLY) {
+        errno = EROFS;
+        return -1;
+    }
+    uint8_t idx;
+    for (idx=0; idx<max_open_file; idx++) {
+        if (file[idx].data == nullptr) {
+            break;
+        }
+    }
+    if (idx == max_open_file) {
+        errno = ENFILE;
+        return -1;
+    }
+    if (file[idx].data != nullptr) {
+        errno = EBUSY;
+        return -1;
+    }
+    file[idx].data = AP_ROMFS::find_decompress(fname, file[idx].size);
+    if (file[idx].data == nullptr) {
+        errno = ENOENT;
+        return -1;
+    }
+    file[idx].ofs = 0;
+    return idx;
+}
+
+int AP_Filesystem_ROMFS::close(int fd)
+{
+    if (fd < 0 || fd >= max_open_file || file[fd].data == nullptr) {
+        errno = EBADF;
+        return -1;
+    }
+    AP_ROMFS::free(file[fd].data);
+    file[fd].data = nullptr;
+    return 0;
+}
+
+int32_t AP_Filesystem_ROMFS::read(int fd, void *buf, uint32_t count)
+{
+    if (fd < 0 || fd >= max_open_file || file[fd].data == nullptr) {
+        errno = EBADF;
+        return -1;
+    }
+    count = MIN(file[fd].size - file[fd].ofs, count);
+    if (count == 0) {
+        return 0;
+    }
+    memcpy(buf, &file[fd].data[file[fd].ofs], count);
+    file[fd].ofs += count;
+    return count;
+}
+
+int32_t AP_Filesystem_ROMFS::write(int fd, const void *buf, uint32_t count)
+{
+    errno = EROFS;
+    return -1;
+}
+
+int AP_Filesystem_ROMFS::fsync(int fd)
+{
+    return 0;
+}
+
+int32_t AP_Filesystem_ROMFS::lseek(int fd, int32_t offset, int seek_from)
+{
+    if (fd < 0 || fd >= max_open_file || file[fd].data == nullptr) {
+        errno = EBADF;
+        return -1;
+    }
+    switch (seek_from) {
+    case SEEK_SET:
+        if (offset < 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        file[fd].ofs = MIN(file[fd].size, (uint32_t)offset);
+        break;
+    case SEEK_CUR:
+        file[fd].ofs = MIN(file[fd].size, offset+file[fd].ofs);
+        break;
+    case SEEK_END:
+        file[fd].ofs = file[fd].size;
+        break;
+    }
+    return file[fd].ofs;
+}
+
+int AP_Filesystem_ROMFS::stat(const char *name, struct stat *stbuf)
+{
+    uint32_t size;
+    const uint8_t *data = AP_ROMFS::find_decompress(name, size);
+    if (data == nullptr) {
+        errno = ENOENT;
+        return -1;
+    }
+    AP_ROMFS::free(data);
+    memset(stbuf, 0, sizeof(*stbuf));
+    stbuf->st_size = size;
+    return 0;
+}
+
+int AP_Filesystem_ROMFS::unlink(const char *pathname)
+{
+    errno = EROFS;
+    return -1;
+}
+
+int AP_Filesystem_ROMFS::mkdir(const char *pathname)
+{
+    errno = EROFS;
+    return -1;
+}
+
+void *AP_Filesystem_ROMFS::opendir(const char *pathname)
+{
+    uint8_t idx;
+    for (idx=0; idx<max_open_dir; idx++) {
+        if (dir[idx].path == nullptr) {
+            break;
+        }
+    }
+    if (idx == max_open_dir) {
+        errno = ENFILE;
+        return nullptr;
+    }
+    dir[idx].ofs = 0;
+    dir[idx].path = strdup(pathname);
+    if (!dir[idx].path) {
+        return nullptr;
+    }
+    return (void*)&dir[idx];
+}
+
+struct dirent *AP_Filesystem_ROMFS::readdir(void *dirp)
+{
+    uint32_t idx = ((rdir*)dirp) - &dir[0];
+    if (idx >= max_open_dir) {
+        errno = EBADF;
+        return nullptr;
+    }
+    const char *name = AP_ROMFS::dir_list(dir[idx].path, dir[idx].ofs);
+    if (!name) {
+        return nullptr;
+    }
+    const uint32_t plen = strlen(dir[idx].path);
+    if (strncmp(name, dir[idx].path, plen) != 0 || name[plen] != '/') {
+        return nullptr;
+    }
+    name += plen + 1;
+    dir[idx].de.d_type = DT_REG;
+    strncpy(dir[idx].de.d_name, name, sizeof(dir[idx].de.d_name));
+    return &dir[idx].de;
+}
+
+int AP_Filesystem_ROMFS::closedir(void *dirp)
+{
+    uint32_t idx = ((rdir *)dirp) - &dir[0];
+    if (idx >= max_open_dir) {
+        errno = EBADF;
+        return -1;
+    }
+    free(dir[idx].path);
+    dir[idx].path = nullptr;
+    return 0;
+}
+
+// return free disk space in bytes
+int64_t AP_Filesystem_ROMFS::disk_free(const char *path)
+{
+    return 0;
+}
+
+// return total disk space in bytes
+int64_t AP_Filesystem_ROMFS::disk_space(const char *path)
+{
+    return 0;
+}
+
+/*
+  set mtime on a file
+ */
+bool AP_Filesystem_ROMFS::set_mtime(const char *filename, const uint32_t mtime_sec)
+{
+    return false;
+}
+
+/*
+  load a full file. Use delete to free the data
+  we override this in ROMFS to avoid taking twice the memory
+*/
+FileData *AP_Filesystem_ROMFS::load_file(const char *filename)
+{
+    FileData *fd = new FileData(this);
+    if (!fd) {
+        return nullptr;
+    }
+    fd->data = AP_ROMFS::find_decompress(filename, fd->length);
+    if (fd->data == nullptr) {
+        delete fd;
+        return nullptr;
+    }
+    return fd;
+}
+
+// unload data from load_file()
+void AP_Filesystem_ROMFS::unload_file(FileData *fd)
+{
+    AP_ROMFS::free(fd->data);
+}
+
+#endif // HAL_HAVE_AP_ROMFS_EMBEDDED_H

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
@@ -15,17 +15,9 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <dirent.h>
-#include <unistd.h>
-#include <errno.h>
 #include "AP_Filesystem_backend.h"
 
-class AP_Filesystem_Posix : public AP_Filesystem_Backend
+class AP_Filesystem_ROMFS : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
@@ -50,5 +42,29 @@ public:
 
     // set modification time on a file
     bool set_mtime(const char *filename, const uint32_t mtime_sec) override;
-};
 
+    /*
+      load a full file. Use delete to free the data
+     */
+    FileData *load_file(const char *filename) override;
+
+    // unload data from load_file()
+    void unload_file(FileData *fd) override;
+    
+private:
+    // only allow up to 4 files at a time
+    static constexpr uint8_t max_open_file = 4;
+    static constexpr uint8_t max_open_dir = 4;
+    struct rfile {
+        const uint8_t *data;
+        uint32_t size;
+        uint32_t ofs;
+    } file[max_open_file];
+
+    // allow up to 4 directory opens
+    struct rdir {
+        char *path;
+        uint16_t ofs;
+        struct dirent de;
+    } dir[max_open_dir];
+};

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
@@ -1,0 +1,73 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Filesystem.h"
+
+/*
+  load a full file. Use delete to free the data
+*/
+FileData *AP_Filesystem_Backend::load_file(const char *filename)
+{
+    struct stat st;
+    if (stat(filename, &st) != 0) {
+        return nullptr;
+    }
+    FileData *fd = new FileData(this);
+    if (fd == nullptr) {
+        return nullptr;
+    }
+    void *data = malloc(st.st_size);
+    if (data == nullptr) {
+        delete fd;
+        return nullptr;
+    }
+    int d = open(filename, O_RDONLY);
+    if (d == -1) {
+        free(data);
+        delete fd;
+        return nullptr;
+    }
+    if (read(d, data, st.st_size) != st.st_size) {
+        close(d);
+        free(data);
+        delete fd;
+        return nullptr;
+    }
+    close(d);
+    fd->length = st.st_size;
+    fd->data = (const uint8_t *)data;
+    return fd;
+}
+
+/*
+  unload a FileData object
+*/
+void AP_Filesystem_Backend::unload_file(FileData *fd)
+{
+    if (fd->data != nullptr) {
+        free(const_cast<uint8_t *>(fd->data));
+        fd->data = nullptr;
+    }
+}
+
+/*
+  destructor for FileData
+ */
+FileData::~FileData()
+{
+    if (backend != nullptr) {
+        ((AP_Filesystem_Backend *)backend)->unload_file(this);
+    }
+}

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -1,0 +1,81 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  ArduPilot filesystem backend interface.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#include "AP_Filesystem_Available.h"
+
+// returned structure from a load_file() call
+class FileData {
+public:
+    uint32_t length;
+    const uint8_t *data;
+
+    FileData(void *_backend) :
+        backend(_backend) {}
+    
+    // destructor to free data
+    ~FileData();
+private:
+    const void *backend;
+};
+
+class AP_Filesystem_Backend {
+
+public:
+    // functions that closely match the equivalent posix calls
+    virtual int open(const char *fname, int flags) {
+        return -1;
+    }
+    virtual int close(int fd) { return -1; }
+    virtual int32_t read(int fd, void *buf, uint32_t count) { return -1; }
+    virtual int32_t write(int fd, const void *buf, uint32_t count) { return -1; }
+    virtual int fsync(int fd) { return 0; }
+    virtual int32_t lseek(int fd, int32_t offset, int whence) { return -1; }
+    virtual int stat(const char *pathname, struct stat *stbuf) { return -1; }
+    virtual int unlink(const char *pathname) { return -1; }
+    virtual int mkdir(const char *pathname) { return -1; }
+    virtual void *opendir(const char *pathname) { return nullptr; }
+    virtual struct dirent *readdir(void *dirp) { return nullptr; }
+    virtual int closedir(void *dirp) { return -1; }
+
+    // return free disk space in bytes, -1 on error
+    virtual int64_t disk_free(const char *path) { return 0; }
+
+    // return total disk space in bytes, -1 on error
+    virtual int64_t disk_space(const char *path) { return 0; }
+
+    // set modification time on a file
+    virtual bool set_mtime(const char *filename, const uint32_t mtime_sec) { return false; }
+
+    // retry mount of filesystem if needed
+    virtual bool retry_mount(void) { return true; }
+
+    // unmount filesystem for reboot
+    virtual void unmount(void) {}
+
+    /*
+      load a full file. Use delete to free the data
+     */
+    virtual FileData *load_file(const char *filename);
+
+    // unload data from load_file()
+    virtual void unload_file(FileData *fd);
+};

--- a/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
@@ -17,6 +17,7 @@
  */
 #include "AP_Filesystem.h"
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 
@@ -29,44 +30,66 @@
 
 extern const AP_HAL::HAL& hal;
 
-int AP_Filesystem::open(const char *fname, int flags)
+/*
+  map a filename for SITL so operations are relative to the current directory
+ */
+static const char *map_filename(const char *fname)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !APM_BUILD_TYPE(APM_BUILD_Replay)
+    // on SITL only allow paths under subdirectory. Users can still
+    // escape with .. if they want to
+    if (strcmp(fname, "/") == 0) {
+        return ".";
+    }
+    if (*fname == '/') {
+        fname++;
+    }
+#endif
+    // on Linux allow original name
+    return fname;
+}
+
+int AP_Filesystem_Posix::open(const char *fname, int flags)
+{
+    fname = map_filename(fname);
     // we automatically add O_CLOEXEC as we always want it for ArduPilot FS usage
     return ::open(fname, flags | O_CLOEXEC, 0644);
 }
 
-int AP_Filesystem::close(int fd)
+int AP_Filesystem_Posix::close(int fd)
 {
     return ::close(fd);
 }
 
-ssize_t AP_Filesystem::read(int fd, void *buf, size_t count)
+int32_t AP_Filesystem_Posix::read(int fd, void *buf, uint32_t count)
 {
     return ::read(fd, buf, count);
 }
 
-ssize_t AP_Filesystem::write(int fd, const void *buf, size_t count)
+int32_t AP_Filesystem_Posix::write(int fd, const void *buf, uint32_t count)
 {
     return ::write(fd, buf, count);
 }
 
-int AP_Filesystem::fsync(int fd)
+int AP_Filesystem_Posix::fsync(int fd)
 {
     return ::fsync(fd);
 }
 
-off_t AP_Filesystem::lseek(int fd, off_t offset, int seek_from)
+int32_t AP_Filesystem_Posix::lseek(int fd, int32_t offset, int seek_from)
 {
     return ::lseek(fd, offset, seek_from);
 }
 
-int AP_Filesystem::stat(const char *pathname, struct stat *stbuf)
+int AP_Filesystem_Posix::stat(const char *pathname, struct stat *stbuf)
 {
+    pathname = map_filename(pathname);
     return ::stat(pathname, stbuf);
 }
 
-int AP_Filesystem::unlink(const char *pathname)
+int AP_Filesystem_Posix::unlink(const char *pathname)
 {
+    pathname = map_filename(pathname);
     // we match the FATFS interface and use unlink
     // for both files and directories
     int ret = ::rmdir(pathname);
@@ -76,29 +99,32 @@ int AP_Filesystem::unlink(const char *pathname)
     return ret;
 }
 
-int AP_Filesystem::mkdir(const char *pathname)
+int AP_Filesystem_Posix::mkdir(const char *pathname)
 {
+    pathname = map_filename(pathname);
     return ::mkdir(pathname, 0775);
 }
 
-DIR *AP_Filesystem::opendir(const char *pathname)
+void *AP_Filesystem_Posix::opendir(const char *pathname)
 {
-    return ::opendir(pathname);
+    pathname = map_filename(pathname);
+    return (void*)::opendir(pathname);
 }
 
-struct dirent *AP_Filesystem::readdir(DIR *dirp)
+struct dirent *AP_Filesystem_Posix::readdir(void *dirp)
 {
-    return ::readdir(dirp);
+    return ::readdir((DIR *)dirp);
 }
 
-int AP_Filesystem::closedir(DIR *dirp)
+int AP_Filesystem_Posix::closedir(void *dirp)
 {
-    return ::closedir(dirp);
+    return ::closedir((DIR *)dirp);
 }
 
 // return free disk space in bytes
-int64_t AP_Filesystem::disk_free(const char *path)
+int64_t AP_Filesystem_Posix::disk_free(const char *path)
 {
+    path = map_filename(path);
     struct statfs stats;
     if (::statfs(path, &stats) < 0) {
         return -1;
@@ -107,8 +133,9 @@ int64_t AP_Filesystem::disk_free(const char *path)
 }
 
 // return total disk space in bytes
-int64_t AP_Filesystem::disk_space(const char *path)
+int64_t AP_Filesystem_Posix::disk_space(const char *path)
 {
+    path = map_filename(path);
     struct statfs stats;
     if (::statfs(path, &stats) < 0) {
         return -1;
@@ -120,8 +147,9 @@ int64_t AP_Filesystem::disk_space(const char *path)
 /*
   set mtime on a file
  */
-bool AP_Filesystem::set_mtime(const char *filename, const time_t mtime_sec)
+bool AP_Filesystem_Posix::set_mtime(const char *filename, const uint32_t mtime_sec)
 {
+    filename = map_filename(filename);
     struct utimbuf times {};
     times.actime = mtime_sec;
     times.modtime = mtime_sec;

--- a/libraries/AP_Filesystem/posix_compat.cpp
+++ b/libraries/AP_Filesystem/posix_compat.cpp
@@ -107,7 +107,10 @@ int apfs_fprintf(APFS_FILE *stream, const char *fmt, ...)
 int apfs_fflush(APFS_FILE *stream)
 {
     CHECK_STREAM(stream, EOF);
-    return 0;
+    if (AP::FS().fsync(stream->fd) == 0) {
+        return 0;
+    }
+    return EOF;
 }
 
 size_t apfs_fread(void *ptr, size_t size, size_t nmemb, APFS_FILE *stream)

--- a/libraries/AP_Filesystem/posix_compat.h
+++ b/libraries/AP_Filesystem/posix_compat.h
@@ -49,6 +49,8 @@ int apfs_feof(APFS_FILE *stream);
 long apfs_ftell(APFS_FILE *stream);
 APFS_FILE *apfs_freopen(const char *pathname, const char *mode, APFS_FILE *stream);
 int apfs_remove(const char *pathname);
+int apfs_rename(const char *oldpath, const char *newpath);
+char *tmpnam(char *s);
 
 #undef stdin
 #undef stdout
@@ -87,6 +89,7 @@ int apfs_remove(const char *pathname);
 #define ftell(stream) apfs_ftell(stream)
 #define freopen(pathname, mode, stream) apfs_freopen(pathname, mode, stream)
 #define remove(pathname) apfs_remove(pathname)
+#define rename(oldpath, newpath) apfs_rename(oldpath, newpath)
 #if !defined(__APPLE__)
 int sprintf(char *str, const char *format, ...);
 #endif

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -225,7 +225,7 @@ uint16_t AP_Logger_File::find_oldest_log()
     // relying on the min_avail_space_percent feature we could end up
     // doing a *lot* of asprintf()s and stat()s
     EXPECT_DELAY_MS(3000);
-    DIR *d = AP::FS().opendir(_log_directory);
+    auto *d = AP::FS().opendir(_log_directory);
     if (d == nullptr) {
         // SD card may have died?  On linux someone may have rm-rf-d
         return 0;

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -47,13 +47,14 @@ const uint8_t *AP_ROMFS::find_file(const char *name, uint32_t &size)
 */
 const uint8_t *AP_ROMFS::find_decompress(const char *name, uint32_t &size)
 {
-    uint32_t compressed_size;
+    uint32_t compressed_size = 0;
     const uint8_t *compressed_data = find_file(name, compressed_size);
     if (!compressed_data) {
         return nullptr;
     }
 
 #ifdef HAL_ROMFS_UNCOMPRESSED
+    size = compressed_size;
     return compressed_data;
 #else
     // last 4 bytes of gzip file are length of decompressed data
@@ -111,4 +112,22 @@ void AP_ROMFS::free(const uint8_t *data)
 #ifndef HAL_ROMFS_UNCOMPRESSED
     ::free(const_cast<uint8_t *>(data));
 #endif
+}
+
+/*
+  directory listing interface. Start with ofs=0. Returns pathnames
+  that match dirname prefix. Ends with nullptr return when no more
+  files found
+*/
+const char *AP_ROMFS::dir_list(const char *dirname, uint16_t &ofs)
+{
+    const size_t dlen = strlen(dirname);
+    for ( ; ofs < ARRAY_SIZE(files); ofs++) {
+        if (strncmp(dirname, files[ofs].filename, dlen) == 0 &&
+            files[ofs].filename[dlen] == '/') {
+            // found one
+            return files[ofs++].filename;
+        }
+    }
+    return nullptr;
 }

--- a/libraries/AP_ROMFS/AP_ROMFS.h
+++ b/libraries/AP_ROMFS/AP_ROMFS.h
@@ -16,6 +16,13 @@ public:
     // free returned data
     static void free(const uint8_t *data);
 
+    /*
+      directory listing interface. Start with ofs=0. Returns pathnames
+      that match dirname prefix. Ends with nullptr return when no more
+      files found
+    */
+    static const char *dir_list(const char *dirname, uint16_t &ofs);
+
 private:
     // find an embedded file
     static const uint8_t *find_file(const char *name, uint32_t &size);

--- a/libraries/AP_RTC/AP_RTC.cpp
+++ b/libraries/AP_RTC/AP_RTC.cpp
@@ -3,6 +3,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
+#include <time.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -63,6 +64,7 @@ void AP_RTC::set_utc_usec(uint64_t time_utc_usec, source_type type)
         // can't allow time to go backwards, ever
         return;
     }
+    WITH_SEMAPHORE(rsem);
 
     rtc_shift = tmp;
 
@@ -73,8 +75,10 @@ void AP_RTC::set_utc_usec(uint64_t time_utc_usec, source_type type)
 
     rtc_source_type = type;
 
+#ifndef HAL_NO_GCS
     // update signing timestamp
     GCS_MAVLINK::update_signing_timestamp(time_utc_usec);
+#endif
 }
 
 bool AP_RTC::get_utc_usec(uint64_t &usec) const
@@ -86,7 +90,7 @@ bool AP_RTC::get_utc_usec(uint64_t &usec) const
     return true;
 }
 
-bool AP_RTC::get_system_clock_utc(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms)
+bool AP_RTC::get_system_clock_utc(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms) const
 {
      // get time of day in ms
     uint64_t time_ms = 0;
@@ -109,7 +113,7 @@ bool AP_RTC::get_system_clock_utc(uint8_t &hour, uint8_t &min, uint8_t &sec, uin
     return true;
 }
 
-bool AP_RTC::get_local_time(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms)
+bool AP_RTC::get_local_time(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms) const
 {
      // get local time of day in ms
     uint64_t time_ms = 0;
@@ -201,6 +205,48 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
     return static_cast<uint32_t>(total_delay_ms);
 }
 
+
+/*
+  mktime replacement from Samba
+ */
+time_t AP_RTC::mktime(const struct tm *t)
+{
+    time_t epoch = 0;
+    int n;
+    int mon [] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }, y, m, i;
+    const unsigned MINUTE = 60;
+    const unsigned HOUR = 60*MINUTE;
+    const unsigned DAY = 24*HOUR;
+    const unsigned YEAR = 365*DAY;
+
+    if (t->tm_year < 70) {
+        return (time_t)-1;
+    }
+
+    n = t->tm_year + 1900 - 1;
+    epoch = (t->tm_year - 70) * YEAR +
+            ((n / 4 - n / 100 + n / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400)) * DAY;
+
+    y = t->tm_year + 1900;
+    m = 0;
+
+    for (i = 0; i < t->tm_mon; i++) {
+        epoch += mon [m] * DAY;
+        if (m == 1 && y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
+            epoch += DAY;
+        }
+
+        if (++m > 11) {
+            m = 0;
+            y++;
+        }
+    }
+
+    epoch += (t->tm_mday - 1) * DAY;
+    epoch += t->tm_hour * HOUR + t->tm_min * MINUTE + t->tm_sec;
+
+    return epoch;
+}
 
 // singleton instance
 AP_RTC *AP_RTC::_singleton;

--- a/libraries/AP_RTC/AP_RTC.h
+++ b/libraries/AP_RTC/AP_RTC.h
@@ -3,6 +3,7 @@
 #include <AP_Param/AP_Param.h>
 
 #include <stdint.h>
+#include <time.h>
 
 class AP_RTC {
 
@@ -38,20 +39,29 @@ public:
     /*
       get time in UTC hours, minutes, seconds and milliseconds
      */
-    bool get_system_clock_utc(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms);
+    bool get_system_clock_utc(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms) const;
     
-    bool get_local_time(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms);
+    bool get_local_time(uint8_t &hour, uint8_t &min, uint8_t &sec, uint16_t &ms) const;
 
     uint32_t get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms);
+
+    // replacement for mktime()
+    static time_t mktime(const struct tm *t);
 
     // get singleton instance
     static AP_RTC *get_singleton() {
         return _singleton;
     }
 
+    // allow threads to lock against RTC update
+    HAL_Semaphore &get_semaphore(void) {
+        return rsem;
+    }
+    
 private:
 
     static AP_RTC *_singleton;
+    HAL_Semaphore rsem;
 
     source_type rtc_source_type = SOURCE_NONE;
     int64_t rtc_shift;

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -114,7 +114,7 @@ void lua_scripts::load_all_scripts_in_dir(lua_State *L, const char *dirname) {
         return;
     }
 
-    DIR *d = AP::FS().opendir(dirname);
+    auto *d = AP::FS().opendir(dirname);
     if (d == nullptr) {
         gcs().send_text(MAV_SEVERITY_INFO, "Lua: Could not find a scripts directory");
         return;
@@ -348,6 +348,7 @@ void lua_scripts::run(void) {
 
     // Scan the filesystem in an appropriate manner and autostart scripts
     load_all_scripts_in_dir(L, SCRIPTING_DIRECTORY);
+    load_all_scripts_in_dir(L, "@ROMFS/scripts");
 
     while (AP_Scripting::get_singleton()->enabled()) {
 #if defined(AP_SCRIPTING_CHECKS) && AP_SCRIPTING_CHECKS >= 1

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -545,7 +545,7 @@ void GCS_MAVLINK::ftp_list_dir(struct pending_ftp &request, struct pending_ftp &
     request.data[sizeof(request.data) - 1] = 0; // ensure the path is null terminated
 
     // open the dir
-    DIR *dir = AP::FS().opendir((char *)request.data);
+    auto *dir = AP::FS().opendir((char *)request.data);
     if (dir == nullptr) {
         ftp_error(response, FTP_ERROR::FailErrno);
         AP::FS().closedir(dir);


### PR DESCRIPTION
I don't think this will be merged for 4.0, but the PR is here for vendors who need this feature.
Deploying critical lua scripts in production without ROMFS support is really not safe
