### PR TITLE
autotest: loosen time constraint on mavlink messages in magcal

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5917,7 +5917,7 @@ Also, ignores heartbeats not from our target system'''
             while True:
                 if self.get_sim_time_cached() - tstart > timeout:
                     raise NotAchievedException("Cannot receive enough MAG_CAL_PROGRESS")
-                m = self.mav.recv_match(type=["MAG_CAL_PROGRESS", "MAG_CAL_REPORT"], blocking=True, timeout=5)
+                m = self.mav.recv_match(type=["MAG_CAL_PROGRESS", "MAG_CAL_REPORT"], blocking=True, timeout=10)
                 if m.get_type() == "MAG_CAL_REPORT":
                     if report_get[m.compass_id] == 0:
                         self.progress("Report: %s" % str(m))


### PR DESCRIPTION
Saw an error where we didn't get one of these in 5 seconds.

That sounds like too much.  But we'll loosen the constrain anyway

https://pipelines.actions.githubusercontent.com/4bSYDuWgW7QWp7XoLwrDsGYdL1OYQSygZbXR4yNYg2nuNM1iaD/_apis/pipelines/1/runs/32135/signedlogcontent/34?urlExpires=2021-02-09T03%3A33%3A45.7296176Z&urlSigningMethod=HMACV1&urlSignature=yLRief%2Bst755e4K6u496YoVhn04EJxMeRl6HsKPK9VY%3D
