### PR TITLE
Copter: add PSCZ onboard log messages (position controller's Z-axis inputs and outputs)

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -901,8 +901,10 @@ void AC_PosControl::write_log()
     float accel_x, accel_y;
     lean_angles_to_accel(accel_x, accel_y);
 
-   AP::logger().Write_PSC(get_pos_target(), _inav.get_position(), get_vel_target(), _inav.get_velocity(), get_accel_target(), accel_x, accel_y);
-
+    AP::logger().Write_PSC(get_pos_target(), _inav.get_position(), get_vel_target(), _inav.get_velocity(), get_accel_target(), accel_x, accel_y);
+    AP::logger().Write_PSCZ(get_pos_target().z, _inav.get_position().z,
+                            get_desired_velocity().z, get_vel_target().z, _inav.get_velocity().z,
+                            _accel_desired.z, get_accel_target().z, get_z_accel_cmss(), _attitude_control.get_throttle_in());
 }
 
 /// init_vel_controller_xyz - initialise the velocity controller - should be called once before the caller attempts to use the controller

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -629,11 +629,10 @@ void AC_PosControl::run_z_controller()
     _accel_target.z += _accel_desired.z;
 
 
-    // the following section calculates a desired throttle needed to achieve the acceleration target
-    float z_accel_meas;         // actual acceleration
 
     // Calculate Earth Frame Z acceleration
-    z_accel_meas = -(_ahrs.get_accel_ef_blended().z + GRAVITY_MSS) * 100.0f;
+    const float z_accel_meas = get_z_accel_cmss();
+
 
     // ensure imax is always large enough to overpower hover throttle
     if (_motors.get_throttle_hover() * 1000.0f > _pid_accel_z.imax()) {

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -342,6 +342,9 @@ protected:
     //          init_takeoff
     void run_z_controller();
 
+    // get earth-frame Z-axis acceleration with gravity removed in cm/s/s with +ve being up
+    float get_z_accel_cmss() const { return -(_ahrs.get_accel_ef_blended().z + GRAVITY_MSS) * 100.0f; }
+
     ///
     /// xy controller private methods
     ///

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -338,6 +338,7 @@ public:
     void Write_SimpleAvoidance(uint8_t state, const Vector2f& desired_vel, const Vector2f& modified_vel, bool back_up);
     void Write_Winch(bool healthy, bool thread_end, bool moving, bool clutch, uint8_t mode, float desired_length, float length, float desired_rate, uint16_t tension, float voltage, int8_t temp);
     void Write_PSC(const Vector3f &pos_target, const Vector3f &position, const Vector3f &vel_target, const Vector3f &velocity, const Vector3f &accel_target, const float &accel_x, const float &accel_y);
+    void Write_PSCZ(float pos_target_z, float pos_z, float vel_desired_z, float vel_target_z, float vel_z, float accel_desired_z, float accel_target_z, float accel_z, float throttle_out);
 
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -805,3 +805,21 @@ void AP_Logger::Write_PSC(const Vector3f &pos_target, const Vector3f &position, 
     };
     WriteBlock(&pkt, sizeof(pkt));
 }
+
+void AP_Logger::Write_PSCZ(float pos_target_z, float pos_z, float vel_desired_z, float vel_target_z, float vel_z, float accel_desired_z, float accel_target_z, float accel_z, float throttle_out)
+{
+    const struct log_PSCZ pkt{
+        LOG_PACKET_HEADER_INIT(LOG_PSCZ_MSG),
+        time_us         : AP_HAL::micros64(),
+        pos_target_z    : pos_target_z * 0.01f,
+        pos_z           : pos_z * 0.01f,
+        vel_desired_z   : vel_desired_z * 0.01f,
+        vel_target_z    : vel_target_z * 0.01f,
+        vel_z           : vel_z * 0.01f,
+        accel_desired_z : accel_desired_z * 0.01f,
+        accel_target_z  : accel_target_z * 0.01f,
+        accel_z         : accel_z * 0.01f,
+        throttle_out    : throttle_out
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -942,6 +942,21 @@ struct PACKED log_PSC {
     float accel_y;
 };
 
+// position controller z-axis logging
+struct PACKED log_PSCZ {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float pos_target_z;
+    float pos_z;
+    float vel_desired_z;
+    float vel_target_z;
+    float vel_z;
+    float accel_desired_z;
+    float accel_target_z;
+    float accel_z;
+    float throttle_out;
+};
+
 // FMT messages define all message formats other than FMT
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
@@ -1655,6 +1670,19 @@ struct PACKED log_PSC {
 // @Field: AX: Acceleration, X-axis
 // @Field: AY: Acceleration, Y-axis
 
+// @LoggerMessage: PSCZ
+// @Description: Position Control Z-axis
+// @Field: TimeUS: Time since system startup
+// @Field: TPZ: Target position above EKF origin
+// @Field: PZ: Position above EKF origin
+// @Field: DVZ: Desired velocity Z-axis
+// @Field: TVZ: Target velocity Z-axis
+// @Field: VZ: Velocity Z-axis
+// @Field: DAZ: Desired acceleration Z-axis
+// @Field: TAZ: Target acceleration Z-axis
+// @Field: AZ: Acceleration Z-axis
+// @Field: ThO: Throttle output
+
 // messages for all boards
 #define LOG_BASE_STRUCTURES \
     { LOG_FORMAT_MSG, sizeof(log_Format), \
@@ -1792,7 +1820,9 @@ LOG_STRUCTURE_FROM_AHRS \
     { LOG_WINCH_MSG, sizeof(log_Winch), \
       "WINC", "QBBBBBfffHfb", "TimeUS,Heal,ThEnd,Mov,Clut,Mode,DLen,Len,DRate,Tens,Vcc,Temp", "s-----mmn?vO", "F-----000000" }, \
     { LOG_PSC_MSG, sizeof(log_PSC), \
-      "PSC", "Qffffffffffff", "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY", "smmmmnnnnoooo", "F000000000000" }
+      "PSC", "Qffffffffffff", "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY", "smmmmnnnnoooo", "F000000000000" }, \
+    { LOG_PSCZ_MSG, sizeof(log_PSCZ), \
+      "PSCZ", "Qfffffffff", "TimeUS,TPZ,PZ,DVZ,TVZ,VZ,DAZ,TAZ,AZ,ThO", "smmnnnooo%", "F000000002" }
 
 // @LoggerMessage: SBPH
 // @Description: Swift Health Data
@@ -1916,6 +1946,7 @@ enum LogMessages : uint8_t {
     LOG_SIMPLE_AVOID_MSG,
     LOG_WINCH_MSG,
     LOG_PSC_MSG,
+    LOG_PSCZ_MSG,
 
     _LOG_LAST_MSG_
 };


### PR DESCRIPTION
This PR adds PSCZ logging messages which include inputs and outputs from the Position Controller for the Z-axis.

This has been tested in SITL and below is a screen shot of the output.  I've also tested that it has no impact on the position controller's performance by running a simple mission in master vs this PR and confirmed the vehicle's altitude control was unaffected.

![after-pos](https://user-images.githubusercontent.com/1498098/107316506-14d84800-6adc-11eb-932d-2d4b447434cc.png)

The contents of this PR are extracted from the s-curve PR https://github.com/ArduPilot/ardupilot/pull/15896