### PR TITLE
Copter: CTUN log msg's ThI, ABst, ThO, ThH fields changed to percentage

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -513,7 +513,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: Value: Value
 
     { LOG_CONTROL_TUNING_MSG, sizeof(log_Control_Tuning),
-      "CTUN", "Qffffffefffhh", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DSAlt,SAlt,TAlt,DCRt,CRt", "s----mmmmmmnn", "F----00B000BB" },
+      "CTUN", "Qffffffefffhh", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DSAlt,SAlt,TAlt,DCRt,CRt", "s%%%%mmmmmmnn", "F222200B000BB" },
     
 // @LoggerMessage: MOTB
 // @Description: Battery information


### PR DESCRIPTION
This small PR changes the CTUN onboard log message to report ThI (throttle in), ABst (Angle Boost), ThO (throttle output) and ThH (hover throttle) to be displayed as percentages instead of numbers between 0 ~ 1.

This makes the fields match the new PSCZ message added in PR https://github.com/ArduPilot/ardupilot/pull/16568

Below are before/after pictures from SITL of these fields.
![ctun-before-after](https://user-images.githubusercontent.com/1498098/107334368-f97c3580-6af9-11eb-9f35-7445296019c7.png)
