### PR TITLE
AC_PosControl: const local vars and remove todo

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1115,12 +1115,9 @@ void AC_PosControl::run_xy_controller(float dt)
 // get_lean_angles_to_accel - convert roll, pitch lean angles to lat/lon frame accelerations in cm/s/s
 void AC_PosControl::accel_to_lean_angles(float accel_x_cmss, float accel_y_cmss, float& roll_target, float& pitch_target) const
 {
-    float accel_right, accel_forward;
-
     // rotate accelerations into body forward-right frame
-    // todo: this should probably be based on the desired heading not the current heading
-    accel_forward = accel_x_cmss * _ahrs.cos_yaw() + accel_y_cmss * _ahrs.sin_yaw();
-    accel_right = -accel_x_cmss * _ahrs.sin_yaw() + accel_y_cmss * _ahrs.cos_yaw();
+    const float accel_forward = accel_x_cmss * _ahrs.cos_yaw() + accel_y_cmss * _ahrs.sin_yaw();
+    const float accel_right = -accel_x_cmss * _ahrs.sin_yaw() + accel_y_cmss * _ahrs.cos_yaw();
 
     // update angle targets that will be passed to stabilize controller
     pitch_target = atanf(-accel_forward / (GRAVITY_MSS * 100.0f)) * (18000.0f / M_PI);


### PR DESCRIPTION
This trivial change is not really worth a PR but it is a tiny step towards getting s-curves in and helps me ensure we haven't forgotten any changes.

This PR slightly modifies the accel-to-lean-angles method to make two local variables const and it also removes a "todo" comment in the code that @lthall thinks that we should no longer do because it would actually make performance worse.

It seems that when converting from desired acceleration to lean angles we should use the current AHRS's estimates of roll and pitch (which is what master does) and **not** use our targets.  If we used our targets then yaw control errors could affect our navigation.

This has been tested as part of the larger S-Curve PR. https://github.com/ArduPilot/ardupilot/pull/15896
