### PR TITLE
Vagrant: add desktop to Vagrant

### DIFF
--- a/Tools/vagrant/initvagrant-desktop.sh
+++ b/Tools/vagrant/initvagrant-desktop.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+echo "---------- $0 start ----------"
+
+set -e
+set -x
+
+/vagrant/Tools/vagrant/initvagrant.sh
+
+VAGRANT_USER=ubuntu
+if [ -e /home/vagrant ]; then
+    # prefer vagrant user
+    VAGRANT_USER=vagrant
+fi
+
+apt-get update
+
+apt-get install -y ubuntu-desktop
+
+GDB_CONF="/etc/gdm3/custom.conf"
+perl -pe 's/#  AutomaticLoginEnable = true/AutomaticLoginEnable = true/'  -i "$GDB_CONF"
+perl -pe 's/#  AutomaticLogin = user1/AutomaticLogin = vagrant/' -i "$GDB_CONF"
+
+cat >>/etc/xdg/autostart/open-gnome-terminal.desktop <<EOF
+[Desktop Entry]
+Type=Application
+Name=Start gnome terminal
+TryExec=gnome-terminal
+Exec=gnome-terminal
+
+X-GNOME-Autostart-Phase=Application
+EOF
+
+# disable the screensaver:
+sudo -u "$VAGRANT_USER" dbus-launch gsettings set org.gnome.desktop.session idle-delay 0
+
+# don't show the initial setup crap:
+echo "yes" | sudo -u "$VAGRANT_USER" dd of=/home/"$VAGRANT_USER"/.config/gnome-initial-setup-done
+
+# start the graphical environment right now:
+systemctl isolate graphical.target
+
+echo "---------- $0 end ----------"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -167,6 +167,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     focal.vm.boot_timeout = 1200
   end
 
+  # 20.04 LTS
+  config.vm.define "focal-desktop", autostart: false do |focal|
+    focal.vm.box = "ubuntu/focal64"
+    focal.vm.provision :shell, path: "Tools/vagrant/initvagrant-desktop.sh"
+    focal.vm.provider "virtualbox" do |vb|
+      vb.name = "ArduPilot (focal-desktop)"
+      vb.gui = true
+    end
+    focal.vm.boot_timeout = 1500
+  end
+
   # 20.10
   config.vm.define "groovy", autostart: false do |groovy|
     groovy.vm.box = "ubuntu/groovy64"


### PR DESCRIPTION
This will open up a GUI which people can use as a Linux desktop for developing ArduPilot.

 - logs vagrant in automatically
 - disabled the screensaver
 - opens a terminal

No instructions are given on how to run the environment like we have in the normal UI.  Not sure how to present those - maybe in a gedit that's opened on boot too?
