### PR TITLE
Increase CH_CFG_ST_TIMEDELTA on BeastH7 and disable ISR during flash updates

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef.dat
@@ -12,6 +12,7 @@ APJ_BOARD_ID 1025
 OSCILLATOR_HZ 8000000
 
 FLASH_SIZE_KB 2048
+env OPTIMIZE -O2
 
 # bootloader takes first sector
 FLASH_RESERVE_START_KB 128
@@ -137,3 +138,7 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 define BOARD_PWM_COUNT_DEFAULT 5
 define STM32_PWM_USE_ADVANCED TRUE
+# on this board we appear to get long timeout callbacks/ISRs occasionally
+# increasing CH_CFG_ST_TIMEDELTA prevents this having bad effects
+define CH_CFG_ST_TIMEDELTA 4
+define STM32_FLASH_DISABLE_ISR 1


### PR DESCRIPTION
Without these changes the BeastH7 will continuously watchdog