### PR TITLE
Added force calibration mavlink command

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -2020,6 +2020,17 @@ void Compass::handle_external(const AP_ExternalAHRS::mag_data_message_t &pkt)
 }
 #endif // HAL_EXTERNAL_AHRS_ENABLED
 
+// force save of current calibration as valid
+void Compass::force_save_calibration(void)
+{
+    for (StateIndex i(0); i<COMPASS_MAX_INSTANCES; i++) {
+        if (_state[i].dev_id != 0) {
+            _state[i].dev_id.save();
+        }
+    }
+}
+
+
 // singleton instance
 Compass *Compass::_singleton;
 

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -354,7 +354,10 @@ public:
 #if HAL_EXTERNAL_AHRS_ENABLED
     void handle_external(const AP_ExternalAHRS::mag_data_message_t &pkt);
 #endif
-    
+
+    // force save of current calibration as valid
+    void force_save_calibration(void);
+
 private:
     static Compass *_singleton;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -2382,6 +2382,20 @@ void AP_InertialSensor::handle_external(const AP_ExternalAHRS::ins_data_message_
 }
 #endif // HAL_EXTERNAL_AHRS_ENABLED
 
+// force save of current calibration as valid
+void AP_InertialSensor::force_save_calibration(void)
+{
+    for (uint8_t i=0; i<_accel_count; i++) {
+        if (_accel_id[i] != 0) {
+            _accel_id[i].save();
+            // we also save the scale as the default of 1.0 may be
+            // over a stored value of 0.0
+            _accel_scale[i].save();
+            _accel_id_ok[i] = true;
+        }
+    }
+}
+
 namespace AP {
 
 AP_InertialSensor &ins()

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -441,6 +441,9 @@ public:
     void get_persistent_params(ExpandingString &str) const;
 #endif
 
+    // force save of current calibration as valid
+    void force_save_calibration(void);
+
 private:
     // load backend drivers
     bool _add_backend(AP_InertialSensor_Backend *backend);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3670,7 +3670,25 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_comm
         return AP::ins().simple_accel_cal();
     }
 
-    return MAV_RESULT_UNSUPPORTED;
+    /*
+      allow GCS to force an existing calibration of accel and/or
+      compass to be written as valid. This is useful when reloading
+      parameters after a full parameter erase
+     */
+    MAV_RESULT ret = MAV_RESULT_UNSUPPORTED;
+    if (is_equal(packet.param5,76.0f)) {
+        // force existing accel calibration to be accepted as valid
+        AP::ins().force_save_calibration();
+        ret = MAV_RESULT_ACCEPTED;
+    }
+
+    if (is_equal(packet.param2,76.0f)) {
+        // force existing compass calibration to be accepted as valid
+        AP::compass().force_save_calibration();
+        ret = MAV_RESULT_ACCEPTED;
+    }
+    
+    return ret;
 }
 
 MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_command_long_t &packet)


### PR DESCRIPTION
This allows calibration to be force saved, which allows for reloading of parameters and bypassing the devid saved checks when parameters are wiped

MAVProxy implementation here: https://github.com/ArduPilot/MAVProxy/pull/865

In a preflight-calibration command sending:
 - param2 = 76 means force save of compass cal params
 - param5 = 76 means force save of accel cal commands

both can be sent in one command if wanted
