### PR TITLE
Add flake8 checking to CI tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,8 @@ ignore =
     # W504 line break after binary operator
     W504,
     # E203 whitespace before ':'
-    E203
+    E203,
+    # E221 multiple spaces before operator
+    E221
 
 max-line-length = 127

--- a/.flake8
+++ b/.flake8
@@ -9,6 +9,8 @@ ignore =
     # E261 at least two spaces before inline comment
     E261,
     # W504 line break after binary operator
-    W504
+    W504,
+    # E203 whitespace before ':'
+    E203
 
 max-line-length = 127

--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,8 @@ ignore =
     # E226: missing whitespace around arithmetic operator
     E226,
     # E261 at least two spaces before inline comment
-    E261
+    E261,
+    # W504 line break after binary operator
+    W504
 
 max-line-length = 127

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -1,4 +1,4 @@
-name: test unit tests
+name: test unit tests and Python cleanliness
 
 on: [push, pull_request, workflow_dispatch]
 # paths:
@@ -17,7 +17,8 @@ jobs:
             clang,
         ]
         config: [
-            unit-tests
+            unit-tests,
+            python-cleanliness
         ]
     steps:
       # git checkout the PR

--- a/Tools/autotest/antennatracker.py
+++ b/Tools/autotest/antennatracker.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 
+'''
+Test AntennaTracker vehicle in SITL
+
+AP_FLAKE8_CLEAN
+
+'''
+
 from __future__ import print_function
 
 import math
@@ -16,13 +23,14 @@ from common import NotAchievedException
 testdir = os.path.dirname(os.path.realpath(__file__))
 SITL_START_LOCATION = mavutil.location(-27.274439, 151.290064, 343, 8.7)
 
+
 class AutoTestTracker(AutoTest):
 
     def log_name(self):
         return "AntennaTracker"
 
     def test_filepath(self):
-         return os.path.realpath(__file__)
+        return os.path.realpath(__file__)
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
@@ -103,7 +111,7 @@ class AutoTestTracker(AutoTest):
         self.change_mode(0) # "MANUAL"
         for chan in 1, 2:
             for pwm in 1200, 1600, 1367:
-                self.set_rc(chan, pwm);
+                self.set_rc(chan, pwm)
                 self.wait_servo_channel_value(chan, pwm)
 
     def SERVOTEST(self):

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
-# Fly ArduPlane in SITL
+'''
+Fly ArduPlane in SITL
+
+AP_FLAKE8_CLEAN
+'''
+
 from __future__ import print_function
 import math
 import os
@@ -557,8 +562,8 @@ class AutoTestPlane(AutoTest):
             0,
             0,
             0,
-            int(loc.lat*1e7),
-            int(loc.lng*1e7),
+            int(loc.lat * 1e7),
+            int(loc.lng * 1e7),
             new_alt,    # alt
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
         )
@@ -567,7 +572,7 @@ class AutoTestPlane(AutoTest):
         self.fly_home_land_and_disarm()
 
     def fly_deepstall(self):
-#        self.fly_deepstall_absolute()
+        # self.fly_deepstall_absolute()
         self.fly_deepstall_relative()
 
     def fly_deepstall_absolute(self):
@@ -634,13 +639,13 @@ class AutoTestPlane(AutoTest):
             0,
             0,
             0,
-            12345, # lat*1e7
-            12345, # lon*1e7
+            12345, # lat* 1e7
+            12345, # lon* 1e7
             100    # alt
         )
         self.delay_sim_time(10)
         self.progress("Ensuring initial speed is known and relatively constant")
-        initial_speed = 21.5;
+        initial_speed = 21.5
         timeout = 10
         tstart = self.get_sim_time()
         while True:
@@ -702,12 +707,14 @@ class AutoTestPlane(AutoTest):
     def fly_home_land_and_disarm(self, timeout=120):
         filename = "flaps.txt"
         self.progress("Using %s to fly home" % filename)
-        num_wp = self.load_mission(filename)
+        self.load_mission(filename)
         self.change_mode("AUTO")
         self.mavproxy.send('wp set 7\n')
         self.drain_mav()
         # TODO: reflect on file to find this magic waypoint number?
-#        self.wait_waypoint(7, num_wp-1, timeout=500) # we tend to miss the final waypoint by a fair bit, and this is probably too noisy anyway?
+        #        self.wait_waypoint(7, num_wp-1, timeout=500) # we
+        #        tend to miss the final waypoint by a fair bit, and
+        #        this is probably too noisy anyway?
         self.wait_disarmed(timeout=timeout)
 
     def fly_flaps(self):
@@ -865,7 +872,8 @@ class AutoTestPlane(AutoTest):
         self.context_collect("HEARTBEAT")
         self.set_parameter("SIM_RC_FAIL", 2) # throttle-to-950
         self.wait_mode('RTL') # long failsafe
-        if (not self.get_mode_from_mode_mapping("CIRCLE") in [x.custom_mode for x in self.context_stop_collecting("HEARTBEAT")]):
+        if (not self.get_mode_from_mode_mapping("CIRCLE") in
+                [x.custom_mode for x in self.context_stop_collecting("HEARTBEAT")]):
             raise NotAchievedException("Did not go via circle mode")
         self.progress("Ensure we've had our throttle squashed to 950")
         self.wait_rc_channel_value(3, 950)
@@ -902,7 +910,8 @@ class AutoTestPlane(AutoTest):
         self.context_collect("HEARTBEAT")
         self.set_parameter("SIM_RC_FAIL", 1) # no-pulses
         self.wait_mode('RTL') # long failsafe
-        if (not self.get_mode_from_mode_mapping("CIRCLE") in [x.custom_mode for x in self.context_stop_collecting("HEARTBEAT")]):
+        if (not self.get_mode_from_mode_mapping("CIRCLE") in
+                [x.custom_mode for x in self.context_stop_collecting("HEARTBEAT")]):
             raise NotAchievedException("Did not go via circle mode")
         self.drain_mav_unparsed()
         m = self.mav.recv_match(type='SYS_STATUS', blocking=True)
@@ -1035,10 +1044,11 @@ class AutoTestPlane(AutoTest):
         m = self.mav.recv_match(type='SYS_STATUS', blocking=True, timeout=1)
         if m is None:
             raise NotAchievedException("Did not receive SYS_STATUS")
-        tests = [ ( "present", present, m.onboard_control_sensors_present ),
-                  ( "enabled", enabled, m.onboard_control_sensors_enabled ),
-                  ( "health", health, m.onboard_control_sensors_health ),
-                  ]
+        tests = [
+            ("present", present, m.onboard_control_sensors_present),
+            ("enabled", enabled, m.onboard_control_sensors_enabled),
+            ("health", health, m.onboard_control_sensors_health),
+        ]
         bit = mavutil.mavlink.MAV_SYS_STATUS_GEOFENCE
         for test in tests:
             (name, want, field) = test
@@ -1119,7 +1129,7 @@ class AutoTestPlane(AutoTest):
             self.load_fence("CMAC-fence.txt")
             m = self.mav.recv_match(type='FENCE_STATUS', blocking=True, timeout=2)
             if m is not None:
-                raise NotAchievedException("Got FENCE_STATUS unexpectedly");
+                raise NotAchievedException("Got FENCE_STATUS unexpectedly")
             self.drain_mav_unparsed()
             self.set_parameter("FENCE_ACTION", mavutil.mavlink.FENCE_ACTION_NONE) # report only
             self.assert_fence_sys_status(False, False, True)
@@ -1130,7 +1140,7 @@ class AutoTestPlane(AutoTest):
             self.assert_fence_sys_status(True, True, True)
             m = self.mav.recv_match(type='FENCE_STATUS', blocking=True, timeout=2)
             if m is None:
-                raise NotAchievedException("Did not get FENCE_STATUS");
+                raise NotAchievedException("Did not get FENCE_STATUS")
             if m.breach_status:
                 raise NotAchievedException("Breached fence unexpectedly (%u)" %
                                            (m.breach_status))
@@ -1192,7 +1202,7 @@ class AutoTestPlane(AutoTest):
                     raise NotAchievedException("Did not breach fence")
                 m = self.mav.recv_match(type='FENCE_STATUS', blocking=True, timeout=2)
                 if m is None:
-                    raise NotAchievedException("Did not get FENCE_STATUS");
+                    raise NotAchievedException("Did not get FENCE_STATUS")
                 if m.breach_status == 0:
                     continue
 
@@ -1367,6 +1377,7 @@ class AutoTestPlane(AutoTest):
         self.simstate = None
         self.last_print = 0
         self.max_divergence = 0
+
         def validate_global_position_int_against_simstate(mav, m):
             if m.get_type() == 'GLOBAL_POSITION_INT':
                 self.gpi = m
@@ -1406,8 +1417,8 @@ class AutoTestPlane(AutoTest):
                 mavutil.mavlink.MAV_DO_REPOSITION_FLAGS_CHANGE_MODE,
                 0,
                 0,
-                int(loc.lat*1e7),
-                int(loc.lng*1e7),
+                int(loc.lat * 1e7),
+                int(loc.lng * 1e7),
                 100,    # alt
                 frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
             )
@@ -1512,7 +1523,9 @@ class AutoTestPlane(AutoTest):
             if gpi is None:
                 raise NotAchievedException("Did not receive GLOBAL_POSITION_INT message")
             if abs(rf.distance - gpi.relative_alt/1000.0) > 3:
-                raise NotAchievedException("rangefinder alt (%s) disagrees with global-position-int.relative_alt (%s)" % (rf.distance, gpi.relative_alt/1000.0))
+                raise NotAchievedException(
+                    "rangefinder alt (%s) disagrees with global-position-int.relative_alt (%s)" %
+                    (rf.distance, gpi.relative_alt/1000.0))
             self.wait_statustext("Auto disarmed", timeout=60)
 
             self.progress("Ensure RFND messages in log")
@@ -1543,7 +1556,6 @@ class AutoTestPlane(AutoTest):
     def test_pid_tuning(self):
         self.change_mode("FBWA") # we don't update PIDs in MANUAL
         super(AutoTestPlane, self).test_pid_tuning()
-
 
     def test_setting_modes_via_auxswitches(self):
         self.set_parameter("FLTMODE1", 1)  # circle
@@ -1590,19 +1602,20 @@ class AutoTestPlane(AutoTest):
 
     def test_adsb_send_threatening_adsb_message(self, here):
         self.progress("Sending ABSD_VEHICLE message")
-        self.mav.mav.adsb_vehicle_send(37, # ICAO address
-                                       int(here.lat * 1e7),
-                                       int(here.lng * 1e7),
-                                       mavutil.mavlink.ADSB_ALTITUDE_TYPE_PRESSURE_QNH,
-                                       int(here.alt*1000 + 10000), # 10m up
-                                       0, # heading in cdeg
-                                       0, # horizontal velocity cm/s
-                                       0, # vertical velocity cm/s
-                                       "bob".encode("ascii"), # callsign
-                                       mavutil.mavlink.ADSB_EMITTER_TYPE_LIGHT,
-                                       1, # time since last communication
-                                       65535, # flags
-                                       17 # squawk
+        self.mav.mav.adsb_vehicle_send(
+            37, # ICAO address
+            int(here.lat * 1e7),
+            int(here.lng * 1e7),
+            mavutil.mavlink.ADSB_ALTITUDE_TYPE_PRESSURE_QNH,
+            int(here.alt*1000 + 10000), # 10m up
+            0, # heading in cdeg
+            0, # horizontal velocity cm/s
+            0, # vertical velocity cm/s
+            "bob".encode("ascii"), # callsign
+            mavutil.mavlink.ADSB_EMITTER_TYPE_LIGHT,
+            1, # time since last communication
+            65535, # flags
+            17 # squawk
         )
 
     def test_adsb(self):
@@ -1633,19 +1646,20 @@ class AutoTestPlane(AutoTest):
             self.wait_mode("RTL")
 
             self.progress("Sending far-away ABSD_VEHICLE message")
-            self.mav.mav.adsb_vehicle_send(37, # ICAO address
-                                           int(here.lat+1 * 1e7),
-                                           int(here.lng * 1e7),
-                                           mavutil.mavlink.ADSB_ALTITUDE_TYPE_PRESSURE_QNH,
-                                           int(here.alt*1000 + 10000), # 10m up
-                                           0, # heading in cdeg
-                                           0, # horizontal velocity cm/s
-                                           0, # vertical velocity cm/s
-                                           "bob".encode("ascii"), # callsign
-                                           mavutil.mavlink.ADSB_EMITTER_TYPE_LIGHT,
-                                           1, # time since last communication
-                                           65535, # flags
-                                           17 # squawk
+            self.mav.mav.adsb_vehicle_send(
+                37, # ICAO address
+                int(here.lat+1 * 1e7),
+                int(here.lng * 1e7),
+                mavutil.mavlink.ADSB_ALTITUDE_TYPE_PRESSURE_QNH,
+                int(here.alt*1000 + 10000), # 10m up
+                0, # heading in cdeg
+                0, # horizontal velocity cm/s
+                0, # vertical velocity cm/s
+                "bob".encode("ascii"), # callsign
+                mavutil.mavlink.ADSB_EMITTER_TYPE_LIGHT,
+                1, # time since last communication
+                65535, # flags
+                17 # squawk
             )
             self.wait_for_collision_threat_to_clear()
             self.change_mode("FBWA")
@@ -1689,8 +1703,8 @@ class AutoTestPlane(AutoTest):
             0, # p2
             0, # p3
             0, # p4
-            int(loc.lat *1e7), # latitude
-            int(loc.lng *1e7), # longitude
+            int(loc.lat * 1e7), # latitude
+            int(loc.lng * 1e7), # longitude
             loc.alt, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         m = self.mav.recv_match(type='MISSION_ACK', blocking=True, timeout=5)
@@ -1713,8 +1727,8 @@ class AutoTestPlane(AutoTest):
             0, # p2
             0, # p3
             0, # p4
-            int(loc.lat *1e7), # latitude
-            int(loc.lng *1e7), # longitude
+            int(loc.lat * 1e7), # latitude
+            int(loc.lng * 1e7), # longitude
             desired_relative_alt, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         m = self.mav.recv_match(type='MISSION_ACK', blocking=True, timeout=5)
@@ -1796,15 +1810,15 @@ class AutoTestPlane(AutoTest):
 
     def fly_soaring(self):
 
-        model="plane-soaring"
+        model = "plane-soaring"
 
-        self.customise_SITL_commandline([],
-                                        model=model,
-                                        defaults_filepath=self.model_defaults_filepath("ArduPlane",model),
-                                        wipe=True)
+        self.customise_SITL_commandline(
+            [],
+            model=model,
+            defaults_filepath=self.model_defaults_filepath("ArduPlane", model),
+            wipe=True)
 
         self.load_mission('CMAC-soar.txt')
-
 
         self.mavproxy.send("wp set 1\n")
         self.change_mode('AUTO')
@@ -1815,21 +1829,21 @@ class AutoTestPlane(AutoTest):
         rc_chan = 0
         for i in range(8):
             rcx_option = self.get_parameter('RC{0}_OPTION'.format(i+1))
-            if rcx_option==88:
-                rc_chan = i+1;
+            if rcx_option == 88:
+                rc_chan = i+1
                 break
 
-        if rc_chan==0:
+        if rc_chan == 0:
             raise NotAchievedException("Did not find soaring enable channel option.")
 
         self.set_rc_from_map({
             rc_chan: 1900,
             3: 1500, # Use trim airspeed.
-        });
+        })
 
         # Wait to detect thermal
         self.progress("Waiting for thermal")
-        self.wait_mode('THERMAL',timeout=600)
+        self.wait_mode('THERMAL', timeout=600)
 
         # Wait to climb to SOAR_ALT_MAX
         self.progress("Waiting for climb to max altitude")
@@ -1842,7 +1856,6 @@ class AutoTestPlane(AutoTest):
 
         # Disable thermals
         self.set_parameter("SIM_THML_SCENARI", 0)
-
 
         # Wait to descend to SOAR_ALT_MIN
         self.progress("Waiting for glide to min altitude")
@@ -1867,7 +1880,7 @@ class AutoTestPlane(AutoTest):
         self.set_parameter("SOAR_ENABLE", 0)
         self.delay_sim_time(10)
 
-        #And reenable. This should force throttle-down
+        # And reenable. This should force throttle-down
         self.set_parameter("SOAR_ENABLE", 1)
         self.delay_sim_time(10)
 
@@ -1888,7 +1901,7 @@ class AutoTestPlane(AutoTest):
 
         # Wait to get back to waypoint before thermal.
         self.progress("Waiting to get back to position")
-        self.wait_current_waypoint(3,timeout=1200)
+        self.wait_current_waypoint(3, timeout=1200)
 
         # Enable soaring with mode changes suppressed)
         self.set_rc(rc_chan, 1500)
@@ -1897,7 +1910,7 @@ class AutoTestPlane(AutoTest):
         self.wait_servo_channel_value(3, 1200, timeout=2, comparator=operator.lt)
 
         self.progress("Waiting for next WP with no thermalling")
-        self.wait_waypoint(4,4,timeout=1200,max_dist=120)
+        self.wait_waypoint(4, 4, timeout=1200, max_dist=120)
 
         # Disarm
         self.disarm_vehicle()
@@ -1933,7 +1946,7 @@ class AutoTestPlane(AutoTest):
         self.reboot_sitl()
         self.progress("Running accelcal")
         self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
-                     0,0,0,0,4,0,0,
+                     0, 0, 0, 0, 4, 0, 0,
                      timeout=5)
 
         self.wait_ready_to_arm()
@@ -2001,20 +2014,20 @@ class AutoTestPlane(AutoTest):
         self.set_parameter("SIM_IMUT_FIXED", 12)
         self.progress("Running accel cal")
         self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
-                     0,0,0,0,4,0,0,
+                     0, 0, 0, 0, 4, 0, 0,
                      timeout=5)
         self.progress("Running gyro cal")
         self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
-                     0,0,0,0,1,0,0,
+                     0, 0, 0, 0, 1, 0, 0,
                      timeout=5)
         self.set_parameters({
-            "SIM_IMUT_FIXED" : 0,
-            "INS_TCAL1_ENABLE" : 2,
-            "INS_TCAL1_TMAX" : 42,
-            "INS_TCAL2_ENABLE" : 2,
-            "INS_TCAL2_TMAX" : 42,
-            "SIM_SPEEDUP" : 200,
-            })
+            "SIM_IMUT_FIXED": 0,
+            "INS_TCAL1_ENABLE": 2,
+            "INS_TCAL1_TMAX": 42,
+            "INS_TCAL2_ENABLE": 2,
+            "INS_TCAL2_TMAX": 42,
+            "SIM_SPEEDUP": 200,
+        })
         self.set_streamrate(1)
         self.set_parameter("LOG_DISARMED", 1)
         self.reboot_sitl()
@@ -2034,7 +2047,7 @@ class AutoTestPlane(AutoTest):
 
         self.progress("Testing with compensation enabled")
 
-        test_temperatures = range(10,45,5)
+        test_temperatures = range(10, 45, 5)
         corrected = {}
         uncorrected = {}
 
@@ -2053,7 +2066,7 @@ class AutoTestPlane(AutoTest):
 
                 accel = self.get_accelvec(m)
                 gyro = self.get_gyrovec(m)
-                accel2 = accel + Vector3(0,0,9.81)
+                accel2 = accel + Vector3(0, 0, 9.81)
 
                 corrected[temperature] = (accel2, gyro)
 
@@ -2081,7 +2094,7 @@ class AutoTestPlane(AutoTest):
                 accel = self.get_accelvec(m)
                 gyro = self.get_gyrovec(m)
 
-                accel2 = accel + Vector3(0,0,9.81)
+                accel2 = accel + Vector3(0, 0, 9.81)
                 uncorrected[temperature] = (accel2, gyro)
 
         for temp in test_temperatures:
@@ -2093,7 +2106,7 @@ class AutoTestPlane(AutoTest):
             (accel, gyro) = uncorrected[temp]
             self.progress("Uncorrected gyro at %.1f %s" % (temp, gyro))
             self.progress("Uncorrected accel at %.1f %s" % (temp, accel))
-            
+
         bad_value = False
         for temp in test_temperatures:
             (accel, gyro) = corrected[temp]
@@ -2113,7 +2126,6 @@ class AutoTestPlane(AutoTest):
         if not bad_value:
             raise NotAchievedException("uncompensated IMUs did not vary enough")
 
-        
     def ekf_lane_switch(self):
 
         self.context_push()
@@ -2139,6 +2151,7 @@ class AutoTestPlane(AutoTest):
         self.reboot_sitl()
 
         self.lane_switches = []
+
         # add an EKF lane switch hook
         def statustext_hook(mav, message):
             if message.get_type() != 'STATUSTEXT':
@@ -2147,7 +2160,7 @@ class AutoTestPlane(AutoTest):
             if not message.text.startswith("EKF3 lane switch "):
                 return
             newlane = int(message.text[-1])
-            self.lane_switches.append(newlane)   
+            self.lane_switches.append(newlane)
         self.install_message_hook(statustext_hook)
 
         # get flying
@@ -2155,14 +2168,18 @@ class AutoTestPlane(AutoTest):
         self.change_mode('CIRCLE')
 
         try:
-            #####################################################################################################################################################
+            ###################################################################
             self.progress("Checking EKF3 Lane Switching trigger from all sensors")
-            #####################################################################################################################################################
+            ###################################################################
             self.start_subtest("ACCELEROMETER: Change z-axis offset")
             # create an accelerometer error by changing the Z-axis offset
             self.context_collect("STATUSTEXT")
             old_parameter = self.get_parameter("INS_ACCOFFS_Z")
-            self.wait_statustext(text="EKF3 lane switch", timeout=30, the_function=self.set_parameter("INS_ACCOFFS_Z", old_parameter + 5), check_context=True)
+            self.wait_statustext(
+                text="EKF3 lane switch",
+                timeout=30,
+                the_function=self.set_parameter("INS_ACCOFFS_Z", old_parameter + 5),
+                check_context=True)
             if self.lane_switches != [1]:
                 raise NotAchievedException("Expected lane switch 1, got %s" % str(self.lane_switches[-1]))
             # Cleanup
@@ -2170,13 +2187,17 @@ class AutoTestPlane(AutoTest):
             self.context_clear_collection("STATUSTEXT")
             self.wait_heading(0, accuracy=10, timeout=60)
             self.wait_heading(180, accuracy=10, timeout=60)
-            #####################################################################################################################################################
+            ###################################################################
             self.start_subtest("BAROMETER: Freeze to last measured value")
             self.context_collect("STATUSTEXT")
             # create a barometer error by inhibiting any pressure change while changing altitude
             old_parameter = self.get_parameter("SIM_BAR2_FREEZE")
             self.set_parameter("SIM_BAR2_FREEZE", 1)
-            self.wait_statustext(text="EKF3 lane switch", timeout=30, the_function=lambda: self.set_rc(2, 2000), check_context=True)
+            self.wait_statustext(
+                text="EKF3 lane switch",
+                timeout=30,
+                the_function=lambda: self.set_rc(2, 2000),
+                check_context=True)
             if self.lane_switches != [1, 0]:
                 raise NotAchievedException("Expected lane switch 0, got %s" % str(self.lane_switches[-1]))
             # Cleanup
@@ -2185,11 +2206,13 @@ class AutoTestPlane(AutoTest):
             self.context_clear_collection("STATUSTEXT")
             self.wait_heading(0, accuracy=10, timeout=60)
             self.wait_heading(180, accuracy=10, timeout=60)
-            #####################################################################################################################################################
+            ###################################################################
             self.start_subtest("GPS: Apply GPS Velocity Error in NED")
             self.context_push()
             self.context_collect("STATUSTEXT")
-            # create a GPS velocity error by adding a random 2m/s noise on each axis
+
+            # create a GPS velocity error by adding a random 2m/s
+            # noise on each axis
             def sim_gps_verr():
                 self.set_parameters({
                     "SIM_GPS_VERR_X": self.get_parameter("SIM_GPS_VERR_X") + 2,
@@ -2204,12 +2227,16 @@ class AutoTestPlane(AutoTest):
             self.context_clear_collection("STATUSTEXT")
             self.wait_heading(0, accuracy=10, timeout=60)
             self.wait_heading(180, accuracy=10, timeout=60)
-            #####################################################################################################################################################
+            ###################################################################
             self.start_subtest("MAGNETOMETER: Change X-Axis Offset")
             self.context_collect("STATUSTEXT")
             # create a magnetometer error by changing the X-axis offset
             old_parameter = self.get_parameter("SIM_MAG2_OFS_X")
-            self.wait_statustext(text="EKF3 lane switch", timeout=30, the_function=self.set_parameter("SIM_MAG2_OFS_X", old_parameter + 150), check_context=True)
+            self.wait_statustext(
+                text="EKF3 lane switch",
+                timeout=30,
+                the_function=self.set_parameter("SIM_MAG2_OFS_X", old_parameter + 150),
+                check_context=True)
             if self.lane_switches != [1, 0, 1, 0]:
                 raise NotAchievedException("Expected lane switch 0, got %s" % str(self.lane_switches[-1]))
             # Cleanup
@@ -2217,14 +2244,16 @@ class AutoTestPlane(AutoTest):
             self.context_clear_collection("STATUSTEXT")
             self.wait_heading(0, accuracy=10, timeout=60)
             self.wait_heading(180, accuracy=10, timeout=60)
-            #####################################################################################################################################################
+            ###################################################################
             self.start_subtest("AIRSPEED: Fail to constant value")
             self.context_push()
             self.context_collect("STATUSTEXT")
-            # create an airspeed sensor error by freezing to the current airspeed then changing the groundspeed
+            # create an airspeed sensor error by freezing to the
+            # current airspeed then changing the groundspeed
             old_parameter = self.get_parameter("SIM_ARSPD_FAIL")
             m = self.mav.recv_match(type='VFR_HUD', blocking=True)
             self.set_parameter("SIM_ARSPD_FAIL", m.airspeed)
+
             def change_speed():
                 self.change_mode("GUIDED")
                 self.run_cmd_int(
@@ -2233,8 +2262,8 @@ class AutoTestPlane(AutoTest):
                     0,
                     0,
                     0,
-                    12345, # lat*1e7
-                    12345, # lon*1e7
+                    12345, # lat* 1e7
+                    12345, # lon* 1e7
                     50    # alt
                 )
                 self.delay_sim_time(5)
@@ -2258,21 +2287,25 @@ class AutoTestPlane(AutoTest):
             self.context_clear_collection("STATUSTEXT")
             self.wait_heading(0, accuracy=10, timeout=60)
             self.wait_heading(180, accuracy=10, timeout=60)
-            #####################################################################################################################################################
+            ###################################################################
             self.progress("GYROSCOPE: Change Y-Axis Offset")
             self.context_collect("STATUSTEXT")
             # create a gyroscope error by changing the Y-axis offset
             old_parameter = self.get_parameter("INS_GYR2OFFS_Y")
-            self.wait_statustext(text="EKF3 lane switch", timeout=30, the_function=self.set_parameter("INS_GYR2OFFS_Y", old_parameter + 1), check_context=True)
+            self.wait_statustext(
+                text="EKF3 lane switch",
+                timeout=30,
+                the_function=self.set_parameter("INS_GYR2OFFS_Y", old_parameter + 1),
+                check_context=True)
             if self.lane_switches != [1, 0, 1, 0, 1, 0]:
                 raise NotAchievedException("Expected lane switch 0, got %s" % str(self.lane_switches[-1]))
             # Cleanup
             self.set_parameter("INS_GYR2OFFS_Y", old_parameter)
             self.context_clear_collection("STATUSTEXT")
-            #####################################################################################################################################################
+            ###################################################################
 
             self.disarm_vehicle()
-            
+
         except Exception as e:
             self.progress("Caught exception: %s" % self.get_exception_stacktrace(e))
             ex = e
@@ -2397,8 +2430,8 @@ class AutoTestPlane(AutoTest):
              self.test_large_missions),
 
             ("Soaring",
-            "Test Soaring feature",
-            self.fly_soaring),
+             "Test Soaring feature",
+             self.fly_soaring),
 
             ("Terrain",
              "Test terrain following in mission",
@@ -2407,7 +2440,7 @@ class AutoTestPlane(AutoTest):
             ("ExternalAHRS",
              "Test external AHRS support",
              self.fly_external_AHRS),
-             
+
             ("Deadreckoning",
              "Test deadreckoning support",
              self.deadreckoning),

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
-# Dive ArduSub in SITL
+'''
+Dive ArduSub in SITL
+
+AP_FLAKE8_CLEAN
+'''
+
 from __future__ import print_function
 import os
 import sys
@@ -55,7 +60,7 @@ class AutoTestSub(AutoTest):
         return "ArduSub"
 
     def test_filepath(self):
-         return os.path.realpath(__file__)
+        return os.path.realpath(__file__)
 
     def set_current_test_name(self, name):
         self.current_test_name_directory = "ArduSub_Tests/" + name + "/"
@@ -92,7 +97,9 @@ class AutoTestSub(AutoTest):
                 self.progress('Altitude hold done: %f' % (previous_altitude))
                 return
             if abs(m.alt - previous_altitude) > delta:
-                raise NotAchievedException("Altitude not maintained: want %.2f (+/- %.2f) got=%.2f" % (previous_altitude, delta, m.alt))
+                raise NotAchievedException(
+                    "Altitude not maintained: want %.2f (+/- %.2f) got=%.2f" %
+                    (previous_altitude, delta, m.alt))
 
     def test_alt_hold(self):
         """Test ALT_HOLD mode
@@ -156,7 +163,7 @@ class AutoTestSub(AutoTest):
         self.mavproxy.send('mode POSHOLD\n')
         self.wait_mode('POSHOLD')
 
-        #dive a little 
+        # dive a little
         self.set_rc(Joystick.Throttle, 1300)
         self.delay_sim_time(3)
         self.set_rc(Joystick.Throttle, 1500)
@@ -172,7 +179,7 @@ class AutoTestSub(AutoTest):
         self.delay_sim_time(10)
         distance_m = self.get_distance(start_pos, self.mav.location())
         if distance_m > 1:
-            raise NotAchievedException("Position Hold was unable to keep position in calm waters within 1 meter after 10 seconds, drifted {} meters".format(distance_m))
+            raise NotAchievedException("Position Hold was unable to keep position in calm waters within 1 meter after 10 seconds, drifted {} meters".format(distance_m))  # noqa
 
         # Hold in 1 m/s current
         self.progress("Testing position hold in current")
@@ -181,7 +188,7 @@ class AutoTestSub(AutoTest):
         self.delay_sim_time(10)
         distance_m = self.get_distance(start_pos, self.mav.location())
         if distance_m > 1:
-            raise NotAchievedException("Position Hold was unable to keep position in 1m/s current within 1 meter after 10 seconds, drifted {} meters".format(distance_m))
+            raise NotAchievedException("Position Hold was unable to keep position in 1m/s current within 1 meter after 10 seconds, drifted {} meters".format(distance_m))  # noqa
 
         # Move forward slowly in 1 m/s current
         start_pos = self.mav.location()
@@ -191,7 +198,7 @@ class AutoTestSub(AutoTest):
         distance_m = self.get_distance(start_pos, self.mav.location())
         bearing = self.get_bearing(start_pos, self.mav.location())
         if distance_m < 2 or (bearing > 30 and bearing < 330):
-            raise NotAchievedException("Position Hold was unable to move north 2 meters, moved {} at {} degrees instead".format(distance_m, bearing))
+            raise NotAchievedException("Position Hold was unable to move north 2 meters, moved {} at {} degrees instead".format(distance_m, bearing))  # noqa
         self.disarm_vehicle()
 
     def test_mot_thst_hover_ignore(self):
@@ -207,7 +214,6 @@ class AutoTestSub(AutoTest):
         for value in [0.25, 0.75]:
             self.set_parameter("MOT_THST_HOVER", value)
             self.test_alt_hold()
-
 
     def dive_manual(self):
         self.wait_ready_to_arm()
@@ -267,7 +273,7 @@ class AutoTestSub(AutoTest):
         try:
             try:
                 self.get_parameter("GRIP_ENABLE", timeout=5)
-            except NotAchievedException as e:
+            except NotAchievedException:
                 self.progress("Skipping; Gripper not enabled in config?")
                 return
 
@@ -362,7 +368,7 @@ class AutoTestSub(AutoTest):
                 batt = self.mav.recv_match(type='BATTERY_STATUS',
                                            blocking=True,
                                            timeout=1)
-            except ConnectionResetError as e:
+            except ConnectionResetError:
                 pass
             self.progress("Battery: %s" % str(batt))
             if batt is None:
@@ -379,7 +385,7 @@ class AutoTestSub(AutoTest):
     def disabled_tests(self):
         ret = super(AutoTestSub, self).disabled_tests()
         ret.update({
-            "ConfigErrorLoop": "Sub does not instantiate AP_Stats.  Also see https://github.com/ArduPilot/ardupilot/issues/10247",
+            "ConfigErrorLoop": "Sub does not instantiate AP_Stats.  Also see https://github.com/ArduPilot/ardupilot/issues/10247",  # noqa
         })
         return ret
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1,3 +1,9 @@
+'''
+Common base class for each of the autotest suites
+
+AP_FLAKE8_CLEAN
+
+'''
 from __future__ import print_function
 
 import abc
@@ -25,11 +31,9 @@ from MAVProxy.modules.lib import mp_util
 from pymavlink import mavparm
 from pymavlink import mavwp, mavutil, DFReader
 from pymavlink import mavextra
-from pymavlink import mavparm
 from pymavlink.rotmat import Vector3
 
 from pysim import util, vehicleinfo
-from io import StringIO
 
 try:
     import queue as Queue
@@ -81,6 +85,7 @@ try:
 except ImportError:
     # probably python2
     pass
+
 
 class ErrorException(Exception):
     """Base class for other exceptions"""
@@ -169,9 +174,11 @@ class PreconditionFailedException(ErrorException):
     """Thrown when a precondition for a test is not met"""
     pass
 
+
 class ArmedAtEndOfTestException(ErrorException):
     """Created when test left vehicle armed"""
     pass
+
 
 class Context(object):
     def __init__(self):
@@ -181,6 +188,7 @@ class Context(object):
         self.collections = {}
         self.heartbeat_interval_ms = 1000
         self.original_heartbeat_interval_ms = None
+
 
 # https://stackoverflow.com/questions/616645/how-do-i-duplicate-sys-stdout-to-a-log-file-in-python
 class TeeBoth(object):
@@ -192,6 +200,7 @@ class TeeBoth(object):
         self.mavproxy_logfile.set_fh(self)
         sys.stdout = self
         sys.stderr = self
+
     def close(self):
         sys.stdout = self.stdout
         sys.stderr = self.stderr
@@ -199,29 +208,37 @@ class TeeBoth(object):
         self.mavproxy_logfile = None
         self.file.close()
         self.file = None
+
     def write(self, data):
         self.file.write(data)
         self.stdout.write(data)
+
     def flush(self):
         self.file.flush()
+
 
 class MAVProxyLogFile(object):
     def __init__(self):
         self.fh = None
+
     def close(self):
         pass
+
     def set_fh(self, fh):
         self.fh = fh
+
     def write(self, data):
         if self.fh is not None:
             self.fh.write(data)
         else:
             sys.stdout.write(data)
+
     def flush(self):
         if self.fh is not None:
             self.fh.flush()
         else:
             sys.stdout.flush()
+
 
 class Telem(object):
     def __init__(self, destination_address, progress_function=None, verbose=False):
@@ -251,7 +268,7 @@ class Telem(object):
             if self.port is not None:
                 try:
                     self.port.close() # might be reopening
-                except Exception as e:
+                except Exception:
                     pass
             self.port = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.port.connect(self.destination_address)
@@ -269,7 +286,7 @@ class Telem(object):
         try:
             data = self.port.recv(1024)
         except socket.error as e:
-            if e.errno not in [ errno.EAGAIN, errno.EWOULDBLOCK ]:
+            if e.errno not in [errno.EAGAIN, errno.EWOULDBLOCK]:
                 self.progress("Exception: %s" % str(e))
                 self.connected = False
             return bytes()
@@ -284,7 +301,7 @@ class Telem(object):
         try:
             written = self.port.send(some_bytes)
         except socket.error as e:
-            if e.errno in [ errno.EAGAIN, errno.EWOULDBLOCK ]:
+            if e.errno in [errno.EAGAIN, errno.EWOULDBLOCK]:
                 return 0
             self.progress("Exception: %s" % str(e))
             raise
@@ -296,6 +313,7 @@ class Telem(object):
             if not self.connect():
                 return
         self.update_read()
+
 
 class LTM(Telem):
     def __init__(self, destination_address):
@@ -324,8 +342,10 @@ class LTM(Telem):
 
     def g(self):
         return self.frames.get(self.FRAME_G, None)
+
     def a(self):
         return self.frames.get(self.FRAME_A, None)
+
     def s(self):
         return self.frames.get(self.FRAME_S, None)
 
@@ -348,7 +368,6 @@ class LTM(Telem):
         for c in self.buffer[3:frame_length-1]:
             if sys.version_info.major < 3:
                 c = ord(c)
-            old = crc
             crc ^= c
             count += 1
         buffer_crc = self.buffer[frame_length-1]
@@ -361,16 +380,18 @@ class LTM(Telem):
         class Frame(object):
             def __init__(self, buffer):
                 self.buffer = buffer
+
             def intn(self, offset, count):
                 ret = 0
                 for i in range(offset, offset+count):
-#                    print("byte: %02x" % ord(self.buffer[i]))
                     ret = ret | (ord(self.buffer[i]) << ((i-offset)*8))
                 return ret
+
             def int32(self, offset):
                 t = struct.unpack("<i", self.buffer[offset:offset+4])
                 return t[0]
 #                return self.intn(offset, 4)
+
             def int16(self, offset):
                 t = struct.unpack("<h", self.buffer[offset:offset+2])
                 return t[0]
@@ -379,22 +400,28 @@ class LTM(Telem):
         class FrameG(Frame):
             def __init__(self, buffer):
                 super(FrameG, self,).__init__(buffer)
+
             def lat(self):
                 return self.int32(3)
+
             def lon(self):
                 return self.int32(7)
+
             def gndspeed(self):
                 ret = self.buffer[11]
                 if sys.version_info.major < 3:
                     ret = ord(ret)
                 return ret
+
             def alt(self):
                 return self.int32(12)
+
             def sats(self):
                 s = self.buffer[16]
                 if sys.version_info.major < 3:
                     s = ord(s)
-                return (s>>2)
+                return (s >> 2)
+
             def fix_type(self):
                 s = self.buffer[16]
                 if sys.version_info.major < 3:
@@ -404,12 +431,16 @@ class LTM(Telem):
         class FrameA(Frame):
             def __init__(self, buffer):
                 super(FrameA, self,).__init__(buffer)
+
             def pitch(self):
                 return self.int16(3)
+
             def roll(self):
                 return self.int16(5)
+
             def hdg(self):
                 return self.int16(7)
+
         class FrameS(Frame):
             def __init__(self, buffer):
                 super(FrameS, self,).__init__(buffer)
@@ -459,9 +490,10 @@ class LTM(Telem):
     def get_data(self, dataid):
         try:
             return self.data_by_id[dataid]
-        except KeyError as e:
+        except KeyError:
             pass
         return None
+
 
 class CRSF(Telem):
     def __init__(self, destination_address):
@@ -482,6 +514,7 @@ class CRSF(Telem):
 
     def progress_tag(self):
         return "CRSF"
+
 
 class FRSky(Telem):
     def __init__(self, destination_address):
@@ -505,6 +538,7 @@ class FRSky(Telem):
         self.dataid_GPS_LAT_NS          = 0x23
         self.dataid_CURRENT             = 0x28
         self.dataid_VFAS                = 0x39
+
 
 class FRSkyD(FRSky):
     def __init__(self, destination_address):
@@ -564,7 +598,7 @@ class FRSkyD(FRSky):
                     if ord(self.buffer[1]) == 0x3E:
                         b = self.START_STOP_D
                     elif ord(self.buffer[1]) == 0x3D:
-                        b = self.BYTESTUFF_D;
+                        b = self.BYTESTUFF_D
                     else:
                         raise ValueError("Unknown stuffed byte")
                     consume = 2
@@ -580,7 +614,7 @@ class FRSkyD(FRSky):
     def get_data(self, dataid):
         try:
             return self.data_by_id[dataid]
-        except KeyError as e:
+        except KeyError:
             pass
         return None
 
@@ -589,6 +623,7 @@ class SPortPacket(object):
     def __init__(self):
         self.START_STOP_SPORT = 0x7E
         self.BYTESTUFF_SPORT  = 0x7D
+
 
 class SPortUplinkPacket(SPortPacket):
     def __init__(self, appid0, appid1, data0, data1, data2, data3):
@@ -605,21 +640,22 @@ class SPortUplinkPacket(SPortPacket):
         self.frame = self.SPORT_UPLINK_FRAME
 
     def packed(self):
-        return struct.pack('<BBBBBBBB',
-                           self.uplink_id,
-                           self.frame,
-                           self.appid0 & 0xff,
-                           self.appid1 & 0xff,
-                           self.data0 & 0xff,
-                           self.data1 & 0xff,
-                           self.data2 & 0xff,
-                           self.data3 & 0xff,
+        return struct.pack(
+            '<BBBBBBBB',
+            self.uplink_id,
+            self.frame,
+            self.appid0 & 0xff,
+            self.appid1 & 0xff,
+            self.data0 & 0xff,
+            self.data1 & 0xff,
+            self.data2 & 0xff,
+            self.data3 & 0xff,
         )
 
     def update_checksum(self, byte):
-        self.checksum += byte;
-        self.checksum += self.checksum >> 8;
-        self.checksum &= 0xFF;
+        self.checksum += byte
+        self.checksum += self.checksum >> 8
+        self.checksum &= 0xFF
 
     def checksum(self):
         self.checksum = 0
@@ -630,7 +666,7 @@ class SPortUplinkPacket(SPortPacket):
         self.update_checksum(self.data1 & 0xff)
         self.update_checksum(self.data2 & 0xff)
         self.update_checksum(self.data3 & 0xff)
-        self.checksum = 0xff - ((self.checksum & 0xff) + (self.checksum >> 8));
+        self.checksum = 0xff - ((self.checksum & 0xff) + (self.checksum >> 8))
         return self.checksum & 0xff
 
     def for_wire(self):
@@ -656,10 +692,12 @@ class SPortPollPacket(SPortPacket):
         self.sensor = sensor
 
     def for_wire(self):
-        return struct.pack('<BB',
-                           self.START_STOP_SPORT,
-                           self.sensor & 0xff,
+        return struct.pack(
+            '<BB',
+            self.START_STOP_SPORT,
+            self.sensor & 0xff,
         )
+
 
 class MAVliteMessage(object):
     def __init__(self, msgid, body):
@@ -709,6 +747,7 @@ class MAVliteMessage(object):
             ret.append(packet)
         return ret
 
+
 class SPortToMAVlite(object):
     def __init__(self):
         self.state_WANT_LEN = "want len"
@@ -731,9 +770,9 @@ class SPortToMAVlite(object):
     def checksum_bytes(self, some_bytes):
         checksum = 0
         for b in some_bytes:
-            checksum += b;
-            checksum += checksum >> 8;
-            checksum &= 0xFF;
+            checksum += b
+            checksum += checksum >> 8
+            checksum &= 0xFF
         return checksum
 
     def downlink_handler(self, some_bytes):
@@ -789,11 +828,11 @@ class FRSkySPort(FRSky):
         self.state_WANT_DATA = "want data"
         self.state_WANT_CRC = "want crc"
 
-        self.START_STOP_SPORT = 0x7E
-        self.BYTESTUFF_SPORT  = 0x7D
-        self.SPORT_DATA_FRAME = 0x10
+        self.START_STOP_SPORT     = 0x7E
+        self.BYTESTUFF_SPORT      = 0x7D
+        self.SPORT_DATA_FRAME     = 0x10
         self.SPORT_DOWNLINK_FRAME = 0x32
-        self.SPORT_FRAME_XOR  = 0x20
+        self.SPORT_FRAME_XOR      = 0x20
 
         self.SENSOR_ID_VARIO             = 0x00 # Sensor ID  0
         self.SENSOR_ID_FAS               = 0x22 # Sensor ID  2
@@ -913,7 +952,7 @@ class FRSkySPort(FRSky):
         self.crc &= 0xFF
 
     def next_sensor(self):
-        ret =  self.sensors_to_poll[self.next_sensor_id_to_poll]
+        ret = self.sensors_to_poll[self.next_sensor_id_to_poll]
         self.next_sensor_id_to_poll += 1
         if self.next_sensor_id_to_poll >= len(self.sensors_to_poll):
             self.next_sensor_id_to_poll = 0
@@ -944,7 +983,8 @@ class FRSkySPort(FRSky):
 
     def send_sport_packet(self, packet):
         stuffed = packet.for_wire()
-        self.progress("Sending (%s) (%u)" % (["0x%02x" % x for x in bytearray(stuffed)],len(stuffed)))
+        self.progress("Sending (%s) (%u)" %
+                      (["0x%02x" % x for x in bytearray(stuffed)], len(stuffed)))
         self.port.sendall(stuffed)
 
     def send_mavlite_param_request_read(self, parameter_name):
@@ -970,15 +1010,16 @@ class FRSkySPort(FRSky):
 
         self.send_sport_packets(packets)
 
-    def send_mavlite_command_long(self,
-                                  command,
-                                  p1=None,
-                                  p2=None,
-                                  p3=None,
-                                  p4=None,
-                                  p5=None,
-                                  p6=None,
-                                  p7=None,
+    def send_mavlite_command_long(
+            self,
+            command,
+            p1=None,
+            p2=None,
+            p3=None,
+            p4=None,
+            p5=None,
+            p6=None,
+            p7=None,
     ):
         params = bytearray()
         seen_none = False
@@ -1026,7 +1067,7 @@ class FRSkySPort(FRSky):
                 b = ord(self.buffer[0])
 #            self.progress("Have (%s) bytes state=%s b=0x%02x" % (str(len(self.buffer)), str(self.state), b));
             if self.state == self.state_WANT_FRAME_TYPE:
-                if b in [self.SPORT_DATA_FRAME, self.SPORT_DOWNLINK_FRAME] :
+                if b in [self.SPORT_DATA_FRAME, self.SPORT_DOWNLINK_FRAME]:
                     self.frame = b
                     self.crc = 0
                     self.calc_crc(b)
@@ -1095,9 +1136,10 @@ class FRSkySPort(FRSky):
     def get_data(self, dataid):
         try:
             return self.data_by_id[dataid]
-        except KeyError as e:
+        except KeyError:
             pass
         return None
+
 
 class FRSkyPassThrough(FRSkySPort):
     def __init__(self, destination_address):
@@ -1108,12 +1150,14 @@ class FRSkyPassThrough(FRSkySPort):
     def progress_tag(self):
         return "FRSkyPassthrough"
 
+
 class LocationInt(object):
     def __init__(self, lat, lon, alt, yaw):
         self.lat = lat
         self.lon = lon
         self.alt = alt
         self.yaw = yaw
+
 
 class Test(object):
     '''a test definition - information about a test'''
@@ -1122,6 +1166,7 @@ class Test(object):
         self.description = description
         self.function = function
         self.attempts = attempts
+
 
 class AutoTest(ABC):
     """Base abstract class.
@@ -1208,13 +1253,13 @@ class AutoTest(ABC):
         """Display autotest progress text."""
         global __autotest__
         delta_time = time.time() - __autotest__.start_time
-        formatted_text = "AT-%06.1f: %s" % (delta_time,text)
+        formatted_text = "AT-%06.1f: %s" % (delta_time, text)
         print(formatted_text)
         if (send_statustext and
-            self.mav is not None and
-            self.last_progress_sent_as_statustext != text):
-                self.send_statustext(formatted_text)
-                self.last_progress_sent_as_statustext = text
+                self.mav is not None and
+                self.last_progress_sent_as_statustext != text):
+            self.send_statustext(formatted_text)
+            self.last_progress_sent_as_statustext = text
 
     # following two functions swiped from autotest.py:
     @staticmethod
@@ -1268,11 +1313,12 @@ class AutoTest(ABC):
 
     def mavproxy_options(self):
         """Returns options to be passed to MAVProxy."""
-        ret = ['--sitl=127.0.0.1:5502',
-               '--streamrate=%u' % self.sitl_streamrate(),
-               '--cmd="set heartbeat %u"' % self.speedup,
-               '--target-system=%u' % self.sysid_thismav(),
-               '--target-component=1',
+        ret = [
+            '--sitl=127.0.0.1:5502',
+            '--streamrate=%u' % self.sitl_streamrate(),
+            '--cmd="set heartbeat %u"' % self.speedup,
+            '--target-system=%u' % self.sysid_thismav(),
+            '--target-component=1',
         ]
         if self.viewerip:
             ret.append("--out=%s:14550" % self.viewerip)
@@ -1288,7 +1334,7 @@ class AutoTest(ABC):
         if False:
             return self.repeatedly_apply_parameter_file_mavproxy(filepath)
         parameters = mavparm.MAVParmDict()
-        correct_parameters = set()
+#        correct_parameters = set()
         parameters.load(filepath)
         param_dict = {}
         for p in parameters.keys():
@@ -1313,7 +1359,6 @@ class AutoTest(ABC):
         """Apply parameter file."""
         self.progress("Applying default parameters file")
         # setup test parameters
-        vinfo = vehicleinfo.VehicleInfo()
         if self.params is None:
             self.params = self.model_defaults_filepath(self.vehicleinfo_key(),
                                                        self.frame)
@@ -1438,10 +1483,10 @@ class AutoTest(ABC):
         filepath = os.path.join(testdir, self.current_test_name_directory, filename)
         self.progress("Loading fence from (%s)" % str(filepath))
         locs = []
-        for line in open(filepath,'rb'):
+        for line in open(filepath, 'rb'):
             if len(line) == 0:
                 continue
-            m = re.match("([-\d.]+)\s+([-\d.]+)\s*", line.decode('ascii'))
+            m = re.match(r"([-\d.]+)\s+([-\d.]+)\s*", line.decode('ascii'))
             if m is None:
                 raise ValueError("Did not match (%s)" % line)
             locs.append(mavutil.location(float(m.group(1)), float(m.group(2)), 0, 0))
@@ -1553,8 +1598,13 @@ class AutoTest(ABC):
             if time.time() - tstart > timeout:
                 raise AutoTestTimeoutException("Did not detect reboot")
             try:
-                current_bootcount = self.get_parameter('STAT_BOOTCNT', timeout=1, attempts=1, verbose=True, timeout_in_wallclock=True)
-                self.progress("current=%s required=%u" % (str(current_bootcount), required_bootcount))
+                current_bootcount = self.get_parameter('STAT_BOOTCNT',
+                                                       timeout=1,
+                                                       attempts=1,
+                                                       verbose=True,
+                                                       timeout_in_wallclock=True)
+                self.progress("current=%s required=%u" %
+                              (str(current_bootcount), required_bootcount))
                 if current_bootcount == required_bootcount:
                     break
             except NotAchievedException:
@@ -1631,7 +1681,7 @@ class AutoTest(ABC):
 
     def htree_from_xml(self, xml_filepath):
         '''swiped from mavproxy_param.py'''
-        xml = open(xml_filepath,'rb').read()
+        xml = open(xml_filepath, 'rb').read()
         from lxml import objectify
         objectify.enable_recursive_str()
         tree = objectify.fromstring(xml)
@@ -1701,7 +1751,7 @@ class AutoTest(ABC):
         for line in lines:
             if type(line) == bytes:
                 line = line.decode("utf-8")
-            m = re.match('#define (\w+_(?:LABELS|FMT|UNITS|MULTS))\s+(".*")', line)
+            m = re.match(r'#define (\w+_(?:LABELS|FMT|UNITS|MULTS))\s+(".*")', line)
             if m is None:
                 continue
             (a, b) = (m.group(1), m.group(2))
@@ -1745,17 +1795,17 @@ class AutoTest(ABC):
         linestate = linestate_none
         message_infos = []
         for line in structure_lines:
-#            print("line: %s" % line)
+            #            print("line: %s" % line)
             if type(line) == bytes:
                 line = line.decode("utf-8")
             line = re.sub("//.*", "", line) # trim comments
-            if re.match("\s*$", line):
+            if re.match(r"\s*$", line):
                 # blank line
                 continue
             if state == state_outside:
                 if ("#define LOG_BASE_STRUCTURES" in line or
-                    re.match("#define LOG_STRUCTURE_FROM_.*", line)):
-#                    self.progress("Moving inside")
+                        re.match("#define LOG_STRUCTURE_FROM_.*", line)):
+                    #                    self.progress("Moving inside")
                     state = state_inside
                 continue
             if state == state_inside:
@@ -1769,13 +1819,13 @@ class AutoTest(ABC):
                             allowed = True
                     if allowed:
                         continue
-                    m = re.match("\s*{(.*)},\s*", line)
+                    m = re.match(r"\s*{(.*)},\s*", line)
                     if m is not None:
                         # complete line
-#                        print("Complete line: %s" % str(line))
+                        # print("Complete line: %s" % str(line))
                         message_infos.append(m.group(1))
                         continue
-                    m = re.match("\s*{(.*)[\\\]", line)
+                    m = re.match(r"\s*{(.*)\\", line)
                     if m is None:
                         continue
                     partial_line = m.group(1)
@@ -1801,22 +1851,22 @@ class AutoTest(ABC):
         linestate_none = 89
         linestate_within = 90
         linestate = linestate_none
-        for line in open(filepath,'rb').readlines():
+        for line in open(filepath, 'rb').readlines():
             if type(line) == bytes:
                 line = line.decode("utf-8")
             line = re.sub("//.*", "", line) # trim comments
-            if re.match("\s*$", line):
+            if re.match(r"\s*$", line):
                 # blank line
                 continue
             if state == state_outside:
                 if ("const LogStructure" in line or
-                    "const struct LogStructure" in line):
-                    state = state_inside;
+                        "const struct LogStructure" in line):
+                    state = state_inside
                 continue
             if state == state_inside:
                 if re.match("};", line):
-                    state = state_outside;
-                    break;
+                    state = state_outside
+                    break
                 if linestate == linestate_none:
                     if "#if FRAME_CONFIG == HELI_FRAME" in line:
                         continue
@@ -1826,13 +1876,13 @@ class AutoTest(ABC):
                         continue
                     if "LOG_COMMON_STRUCTURES" in line:
                         continue
-                    m = re.match("\s*{(.*)},\s*", line)
+                    m = re.match(r"\s*{(.*)},\s*", line)
                     if m is not None:
                         # complete line
-#                        print("Complete line: %s" % str(line))
+                        # print("Complete line: %s" % str(line))
                         message_infos.append(m.group(1))
                         continue
-                    m = re.match("\s*{(.*)", line)
+                    m = re.match(r"\s*{(.*)", line)
                     if m is None:
                         raise NotAchievedException("Bad line %s" % line)
                     partial_line = m.group(1)
@@ -1850,11 +1900,10 @@ class AutoTest(ABC):
         if state == state_inside:
             raise NotAchievedException("Should not be in state_inside at end")
 
-
         for message_info in message_infos:
             for define in defines:
                 message_info = re.sub(define, defines[define], message_info)
-            m = re.match('\s*LOG_\w+\s*,\s*sizeof\([^)]+\)\s*,\s*"(\w+)"\s*,\s*"(\w+)"\s*,\s*"([\w,]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*$', message_info)
+            m = re.match(r'\s*LOG_\w+\s*,\s*sizeof\([^)]+\)\s*,\s*"(\w+)"\s*,\s*"(\w+)"\s*,\s*"([\w,]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*$', message_info)  # noqa
             if m is None:
                 continue
             (name, fmt, labels, units, multipliers) = (m.group(1), m.group(2), m.group(3), m.group(4), m.group(5))
@@ -1887,12 +1936,12 @@ class AutoTest(ABC):
                         # this is the sample file which contains examples...
                         continue
                     count = 0
-                    for line in open(filepath,'rb').readlines():
+                    for line in open(filepath, 'rb').readlines():
                         if type(line) == bytes:
                             line = line.decode("utf-8")
                         if state == state_outside:
-                            if (re.match("\s*AP::logger\(\)[.]Write\(", line) or
-                                re.match("\s*logger[.]Write\(", line)):
+                            if (re.match(r"\s*AP::logger\(\)[.]Write\(", line) or
+                                    re.match(r"\s*logger[.]Write\(", line)):
                                 state = state_inside
                                 line = re.sub("//.*", "", line) # trim comments
                                 log_write_statement = line
@@ -1900,7 +1949,7 @@ class AutoTest(ABC):
                         if state == state_inside:
                             line = re.sub("//.*", "", line) # trim comments
                             log_write_statement += line
-                            if re.match(".*\);", line):
+                            if re.match(r".*\);", line):
                                 log_write_statements.append(log_write_statement)
                                 state = state_outside
                         count += 1
@@ -1908,7 +1957,7 @@ class AutoTest(ABC):
                         raise NotAchievedException("Expected to be outside at end of file")
 #                    print("%s has %u lines" % (f, count))
         # change all whitespace to single space
-        log_write_statements = [re.sub("\s+", " ", x) for x in log_write_statements]
+        log_write_statements = [re.sub(r"\s+", " ", x) for x in log_write_statements]
 #        print("Got log-write-statements: %s" % str(log_write_statements))
         results = []
         for log_write_statement in log_write_statements:
@@ -1916,10 +1965,10 @@ class AutoTest(ABC):
                 log_write_statement = re.sub(define, defines[define], log_write_statement)
             # fair warning: order is important here because of the
             # NKT/XKT special case below....
-            my_re = ' logger[.]Write\(\s*"(\w+)"\s*,\s*"([\w,]+)".*\);'
+            my_re = r' logger[.]Write\(\s*"(\w+)"\s*,\s*"([\w,]+)".*\);'
             m = re.match(my_re, log_write_statement)
             if m is None:
-                my_re = ' AP::logger\(\)[.]Write\(\s*"(\w+)"\s*,\s*"([\w,]+)".*\);'
+                my_re = r' AP::logger\(\)[.]Write\(\s*"(\w+)"\s*,\s*"([\w,]+)".*\);'
                 m = re.match(my_re, log_write_statement)
             if m is None:
                 raise NotAchievedException("Did not match (%s) with (%s)" % (log_write_statement, str(my_re)))
@@ -1974,16 +2023,16 @@ class AutoTest(ABC):
         self.progress("xml file length is %u" % length)
 
         from lxml import objectify
-        xml = open(xml_filepath,'rb').read()
+        xml = open(xml_filepath, 'rb').read()
         objectify.enable_recursive_str()
         tree = objectify.fromstring(xml)
 
         # we allow for no docs for replay messages, as these are not for end-users. They are
         # effectively binary blobs for replay
-        REPLAY_MSGS = [ 'RFRH', 'RFRF', 'REV2', 'RSO2', 'RWA2', 'REV3', 'RSO3', 'RWA3', 'RMGI',
-                        'REY3', 'RFRN', 'RISH', 'RISI', 'RISJ', 'RBRH', 'RBRI', 'RRNH', 'RRNI',
-                        'RGPH', 'RGPI', 'RGPJ', 'RASH', 'RASI', 'RBCH', 'RBCI', 'RVOH', 'RMGH',
-                        'ROFH', 'REPH', 'REVH', 'RWOH', 'RBOH' ]
+        REPLAY_MSGS = ['RFRH', 'RFRF', 'REV2', 'RSO2', 'RWA2', 'REV3', 'RSO3', 'RWA3', 'RMGI',
+                       'REY3', 'RFRN', 'RISH', 'RISI', 'RISJ', 'RBRH', 'RBRI', 'RRNH', 'RRNI',
+                       'RGPH', 'RGPI', 'RGPJ', 'RASH', 'RASI', 'RBCH', 'RBCI', 'RVOH', 'RMGH',
+                       'ROFH', 'REPH', 'REVH', 'RWOH', 'RBOH']
 
         docco_ids = {}
         for thing in tree.logformat:
@@ -1997,14 +2046,14 @@ class AutoTest(ABC):
                     continue
                 raise NotAchievedException("no doc fields for %s" % name)
             for field in thing.fields.field:
-#                print("field: (%s)" % str(field))
+                # print("field: (%s)" % str(field))
                 fieldname = field.get("name")
 #                print("Got (%s.%s)" % (name,str(fieldname)))
                 docco_ids[name]["labels"].append(fieldname)
 
         code_ids = self.all_log_format_ids()
-        #self.progress("Code ids: (%s)" % str(sorted(code_ids.keys())))
-        #self.progress("Docco ids: (%s)" % str(sorted(docco_ids.keys())))
+        # self.progress("Code ids: (%s)" % str(sorted(code_ids.keys())))
+        # self.progress("Docco ids: (%s)" % str(sorted(docco_ids.keys())))
 
         for name in sorted(code_ids.keys()):
             if name not in docco_ids:
@@ -2055,7 +2104,7 @@ class AutoTest(ABC):
                 raise NotAchievedException("Failed to customise")
             try:
                 self.wait_heartbeat(drain_mav=True)
-            except IOError as e:
+            except IOError:
                 pass
             break
         # MAVProxy only checks the streamrates once every 15 seconds.
@@ -2171,7 +2220,7 @@ class AutoTest(ABC):
         self.set_heartbeat_interval_ms(1000.0/rate_hz)
 
     def do_heartbeats(self, force=False):
-#        self.progress("do_heartbeats")
+        # self.progress("do_heartbeats")
         if self.heartbeat_interval_ms() is None and not force:
             return
         x = self.mav.messages.get("SYSTEM_TIME", None)
@@ -2181,16 +2230,15 @@ class AutoTest(ABC):
             self.last_heartbeat_time_ms is None or
             self.last_heartbeat_time_ms < x.time_boot_ms or
             x.time_boot_ms - self.last_heartbeat_time_ms > self.heartbeat_interval_ms() or
-            now_wc - self.last_heartbeat_time_wc_s > 1):
-#            self.progress("Sending heartbeat")
+                now_wc - self.last_heartbeat_time_wc_s > 1):
             if x is not None:
                 self.last_heartbeat_time_ms = x.time_boot_ms
-            self.last_heartbeat_time_wc_s = now_wc
-            self.mav.mav.heartbeat_send(mavutil.mavlink.MAV_TYPE_GCS,
-                                        mavutil.mavlink.MAV_AUTOPILOT_INVALID,
-                                        0,
-                                        0,
-                                        0)
+                self.last_heartbeat_time_wc_s = now_wc
+                self.mav.mav.heartbeat_send(mavutil.mavlink.MAV_TYPE_GCS,
+                                            mavutil.mavlink.MAV_AUTOPILOT_INVALID,
+                                            0,
+                                            0,
+                                            0)
 
     def drain_all_pexpects(self):
         global expect_list
@@ -2313,7 +2361,7 @@ class AutoTest(ABC):
                 continue
             # no component check ATM because we send broadcast...
 #            if m.get_srcComponent() != self.mav.target_component:
-#                self.progress("response from component other than our target (got=%u want=%u)" % (m.get_srcComponent(), self.mav.target_component))
+#                self.progress("response from component other than our target (got=%u want=%u)" % (m.get_srcComponent(), self.mav.target_component))  # noqa
 #                continue
             if not quiet:
                 self.progress("Received TIMESYNC response after %fs" % (now - tstart))
@@ -2343,7 +2391,7 @@ class AutoTest(ABC):
         self.set_parameter("LOG_DISARMED", 0)
         self.reboot_sitl()
         original_log_list = self.log_list()
-        for i in range(0,10):
+        for i in range(0, 10):
             self.wait_ready_to_arm()
             self.arm_vehicle()
             self.delay_sim_time(1)
@@ -2409,8 +2457,7 @@ class AutoTest(ABC):
                                            1, # target component
                                            log_id,
                                            ofs,
-                                           count
-        )
+                                           count)
         m = self.mav.recv_match(type='LOG_DATA',
                                 blocking=True,
                                 timeout=2)
@@ -2488,7 +2535,7 @@ class AutoTest(ABC):
                 raise NotAchievedException("Zero bytes read")
             data_downloaded.extend(m.data[0:m.count])
             bytes_read += m.count
-            #self.progress("Read %u bytes at offset %u" % (m.count, m.ofs))
+            # self.progress("Read %u bytes at offset %u" % (m.count, m.ofs))
             if time.time() - last_print > 10:
                 last_print = time.time()
                 self.progress("Read %u/%u" % (bytes_read, bytes_to_read))
@@ -2544,7 +2591,8 @@ class AutoTest(ABC):
             if bytes_to_fetch > bytes_to_read - bytes_read:
                 bytes_to_fetch = bytes_to_read - bytes_read
             ofs = bytes_to_read - bytes_read - bytes_to_fetch
-            # self.progress("bytes_to_read=%u bytes_read=%u bytes_to_fetch=%u ofs=%d" % (bytes_to_read, bytes_read, bytes_to_fetch, ofs))
+            # self.progress("bytes_to_read=%u bytes_read=%u bytes_to_fetch=%u ofs=%d" %
+            # (bytes_to_read, bytes_read, bytes_to_fetch, ofs))
             self.mav.mav.log_request_data_send(
                 self.sysid_thismav(),
                 1, # target component
@@ -2572,7 +2620,6 @@ class AutoTest(ABC):
         # if len(actual_bytes) != len(backwards_data_downloaded):
         #     raise NotAchievedException("Size delta: actual=%u vs downloaded=%u" %
         #                                (len(actual_bytes), len(backwards_data_downloaded)))
-
 
     #################################################
     # SIM UTILITIES
@@ -2740,7 +2787,9 @@ class AutoTest(ABC):
         self.reboot_sitl()
         restart_list = self.log_list()
         if len(start_list) != len(restart_list):
-            raise NotAchievedException("Unexpected log detected (pre-delay) initial=(%s) restart=(%s)" % (str(sorted(start_list)), str(sorted(restart_list))))
+            raise NotAchievedException(
+                "Unexpected log detected (pre-delay) initial=(%s) restart=(%s)" %
+                (str(sorted(start_list)), str(sorted(restart_list))))
         self.delay_sim_time(20)
         restart_list = self.log_list()
         if len(start_list) != len(restart_list):
@@ -2812,7 +2861,6 @@ class AutoTest(ABC):
         self.onboard_logging_log_disarmed()
         self.onboard_logging_not_log_disarmed()
 
-
     def test_log_download_mavproxy(self, upload_logs=False):
         """Download latest log."""
         filename = "MAVProxy-downloaded-log.BIN"
@@ -2876,8 +2924,8 @@ class AutoTest(ABC):
         if self.mav is None:
             return
         oldlen = len(self.mav.message_hooks)
-        self.mav.message_hooks = list(filter(lambda x : x != hook,
-                                        self.mav.message_hooks))
+        self.mav.message_hooks = list(filter(lambda x: x != hook,
+                                             self.mav.message_hooks))
         if len(self.mav.message_hooks) == oldlen:
             raise NotAchievedException("Failed to remove hook")
 
@@ -2901,8 +2949,8 @@ class AutoTest(ABC):
             lines1 = [x.rstrip() for x in lines1]
             lines2 = [x.rstrip() for x in lines2]
             # remove now-empty lines:
-            lines1 = filter(lambda x : len(x), lines1)
-            lines2 = filter(lambda x : len(x), lines2)
+            lines1 = filter(lambda x: len(x), lines1)
+            lines2 = filter(lambda x: len(x), lines2)
 
         for l1, l2 in zip(lines1, lines2):
             l1 = l1.rstrip("\r\n")
@@ -3018,7 +3066,7 @@ class AutoTest(ABC):
             fields1 = re.split(r"\s+", l1)
             fields2 = re.split(r"\s+", l2)
             # line = int(fields1[0])
-            t = int(fields1[3]) # mission item type
+            # t = int(fields1[3]) # mission item type
             for (count, (i1, i2)) in enumerate(zip(fields1, fields2)):
                 # if count == 2: # frame
                 #     if t in [mavutil.mavlink.MAV_CMD_DO_CHANGE_SPEED,
@@ -3125,7 +3173,7 @@ class AutoTest(ABC):
             self.assert_mission_files_same(path, saved_filepath)
             break
         self.mavproxy.send('wp status\n')
-        self.mavproxy.expect('Have (\d+) of (\d+)')
+        self.mavproxy.expect(r'Have (\d+) of (\d+)')
         status_have = self.mavproxy.match.group(1)
         status_want = self.mavproxy.match.group(2)
         if status_have != status_want:
@@ -3138,7 +3186,7 @@ class AutoTest(ABC):
         num_wp = wploader.count()
         if num_wp != int(status_have):
             raise ValueError("num_wp=%u != status_have=%u" %
-            (num_wp, int(status_have)))
+                             (num_wp, int(status_have)))
         if num_wp == 0:
             raise ValueError("No waypoints loaded?!")
         return num_wp
@@ -3205,7 +3253,6 @@ class AutoTest(ABC):
 
     def rc_thread_main(self):
         chan16 = [1000] * 16
-        last_sent_ms = 0
 
         sitl_output = mavutil.mavudp("127.0.0.1:5501", input=False)
         buf = None
@@ -3222,8 +3269,7 @@ class AutoTest(ABC):
                 map_copy = self.rc_queue.get(timeout=0.02)
 
                 # 16 packed entries:
-                values = []
-                for i in range(1,17):
+                for i in range(1, 17):
                     if i in map_copy:
                         chan16[i-1] = map_copy[i]
 
@@ -3376,17 +3422,21 @@ class AutoTest(ABC):
                      want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED if result else mavutil.mavlink.MAV_RESULT_FAILED,
                      timeout=timeout)
         if expect_msg is not None:
-            self.wait_statustext(expect_msg, timeout=timeout, the_function=lambda: self.send_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
-                                                                                                 1,  # ARM
-                                                                                                 0,
-                                                                                                 0,
-                                                                                                 0,
-                                                                                                 0,
-                                                                                                 0,
-                                                                                                 0,
-                                                                                                 target_sysid=None,
-                                                                                                 target_compid=None,
-                                                                                                 ))
+            self.wait_statustext(
+                expect_msg,
+                timeout=timeout,
+                the_function=lambda: self.send_cmd(
+                    mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                    1,  # ARM
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    target_sysid=None,
+                    target_compid=None,
+                ))
 
     def arm_vehicle(self, timeout=20):
         """Arm vehicle with mavlink arm message."""
@@ -3520,7 +3570,7 @@ class AutoTest(ABC):
             try:
                 self.wait_statustext(want, timeout=0.1, check_context=True, wallclock_timeout=1)
                 break
-            except AutoTestTimeoutException as e:
+            except AutoTestTimeoutException:
                 pass
         self.context_pop()
         # Different scaling for RC input and servo output means the
@@ -3681,8 +3731,7 @@ class AutoTest(ABC):
         return self.send_set_parameter_direct(name, value)
 
     def set_parameter(self, name, value, **kwargs):
-        self.set_parameters({name: value }, **kwargs)
-
+        self.set_parameters({name: value}, **kwargs)
 
     def set_parameters(self, parameters, add_to_context=True, epsilon_pct=0.00001, retries=None, verbose=True):
         """Set parameters from vehicle."""
@@ -3698,6 +3747,7 @@ class AutoTest(ABC):
             retries = (len(want)+1) * 5
 
         param_value_messages = []
+
         def add_param_value(mav, m):
             t = m.get_type()
             if t != "PARAM_VALUE":
@@ -3708,15 +3758,14 @@ class AutoTest(ABC):
 
         original_values = {}
         autopilot_values = {}
-        tstart = self.get_sim_time()
         for i in range(retries):
             self.drain_mav(quiet=True)
             received = set()
             for (name, value) in want.items():
-#                self.progress("%s want=%f autopilot=%s" % (name, value, autopilot_values.get(name, 'None')))
+                # self.progress("%s want=%f autopilot=%s" % (name, value, autopilot_values.get(name, 'None')))
                 if name not in autopilot_values:
                     self.send_get_parameter_direct(name)
-#                    self.progress("Requesting (%s) (retry=%u)" % (name, i))
+                    # self.progress("Requesting (%s) (retry=%u)" % (name, i))
                     continue
                 delta = abs(autopilot_values[name] - value)
                 if delta <= epsilon_pct*0.01*abs(value):
@@ -3744,17 +3793,17 @@ class AutoTest(ABC):
                     #     self.progress("Time wrap detected")
                     # else:
                     #     raise
-            do_fetch_all = False
+#            do_fetch_all = False
             for m in param_value_messages:
                 if m.param_id in want:
                     self.progress("Received wanted PARAM_VALUE %s=%f" %
                                   (str(m.param_id), m.param_value))
                     autopilot_values[m.param_id] = m.param_value
                     if m.param_id not in original_values:
-                        original_values[m.param_id] = m.param_value;
-                        if (self.should_fetch_all_for_parameter_change(m.param_id.upper()) and
-                            m.param_value != 0):
-                            do_fetch_all = True
+                        original_values[m.param_id] = m.param_value
+                        # if (self.should_fetch_all_for_parameter_change(m.param_id.upper()) and
+                        #         m.param_value != 0):
+                        #     do_fetch_all = True
             param_value_messages = []
 #            if do_fetch_all:
 #                self.do_fetch_all()
@@ -3824,7 +3873,7 @@ class AutoTest(ABC):
                 try:
                     # sometimes race conditions garble the MAVProxy output
                     ret = float(self.mavproxy.match.group(1))
-                except ValueError as e:
+                except ValueError:
                     continue
                 return ret
             except pexpect.TIMEOUT:
@@ -3840,6 +3889,7 @@ class AutoTest(ABC):
         context = Context()
         self.contexts.append(context)
         # add a message hook so we can collect messages conveniently:
+
         def mh(mav, m):
             t = m.get_type()
             if t in context.collections:
@@ -3882,8 +3932,10 @@ class AutoTest(ABC):
     class Context(object):
         def __init__(self, testsuite):
             self.testsuite = testsuite
+
         def __enter__(self):
             self.testsuite.context_push()
+
         def __exit__(self, type, value, traceback):
             self.testsuite.context_pop()
             return False # re-raise any exception
@@ -3948,7 +4000,7 @@ class AutoTest(ABC):
             target_compid = 1
         try:
             command_name = mavutil.mavlink.enums["MAV_CMD"][command].name
-        except KeyError as e:
+        except KeyError:
             command_name = "UNKNOWN=%u" % command
         self.progress("Sending COMMAND_LONG to (%u,%u) (%s) (p1=%f p2=%f p3=%f p4=%f p5=%f p6=%f  p7=%f)" %
                       (
@@ -3990,16 +4042,17 @@ class AutoTest(ABC):
                 quiet=False):
         self.drain_mav_unparsed()
         self.get_sim_time() # required for timeout in run_cmd_get_ack to work
-        self.send_cmd(command,
-                      p1,
-                      p2,
-                      p3,
-                      p4,
-                      p5,
-                      p6,
-                      p7,
-                      target_sysid=target_sysid,
-                      target_compid=target_compid,
+        self.send_cmd(
+            command,
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            target_sysid=target_sysid,
+            target_compid=target_compid,
         )
         self.run_cmd_get_ack(command, want_result, timeout, quiet=quiet)
 
@@ -4044,7 +4097,7 @@ class AutoTest(ABC):
     #################################################
     @staticmethod
     def longitude_scale(lat):
-        ret = math.cos(lat * (math.radians(1)));
+        ret = math.cos(lat * (math.radians(1)))
         print("scale=%f" % ret)
         return ret
 
@@ -4129,20 +4182,21 @@ class AutoTest(ABC):
         '''change vehicle flightmode'''
         self.wait_heartbeat()
         self.progress("Changing mode to %s" % mode)
-        self.send_cmd(mavutil.mavlink.MAV_CMD_DO_SET_MODE,
-                     mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
-                     self.get_mode_from_mode_mapping(mode),
-                     0,
-                     0,
-                     0,
-                     0,
-                     0,
+        self.send_cmd(
+            mavutil.mavlink.MAV_CMD_DO_SET_MODE,
+            mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+            self.get_mode_from_mode_mapping(mode),
+            0,
+            0,
+            0,
+            0,
+            0,
         )
         tstart = self.get_sim_time()
         while not self.mode_is(mode):
             custom_num = self.mav.messages['HEARTBEAT'].custom_mode
             self.progress("mav.flightmode=%s Want=%s custom=%u" % (
-                    self.mav.flightmode, mode, custom_num))
+                self.mav.flightmode, mode, custom_num))
             if (timeout is not None and
                     self.get_sim_time_cached() > tstart + timeout):
                 raise WaitModeTimeout("Did not change mode")
@@ -4207,16 +4261,17 @@ class AutoTest(ABC):
                             want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED):
         base_mode = mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
         custom_mode = self.get_mode_from_mode_mapping(mode)
-        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_MODE,
-                     base_mode,
-                     custom_mode,
-                     0,
-                     0,
-                     0,
-                     0,
-                     0,
-                     want_result=want_result,
-                     timeout=timeout
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_SET_MODE,
+            base_mode,
+            custom_mode,
+            0,
+            0,
+            0,
+            0,
+            0,
+            want_result=want_result,
+            timeout=timeout
         )
 
     def do_set_mode_via_command_long(self, mode, timeout=30):
@@ -4312,14 +4367,15 @@ class AutoTest(ABC):
         while True:
             if self.get_sim_time_cached() - tstart > 200:
                 raise NotAchievedException("Did not achieve heading")
-            self.run_cmd(mavutil.mavlink.MAV_CMD_CONDITION_YAW,
-                         heading,  # target angle
-                         10,  # degrees/second
-                         1,  # -1 is counter-clockwise, 1 clockwise
-                         0,  # 1 for relative, 0 for absolute
-                         0,  # p5
-                         0,  # p6
-                         0,  # p7
+            self.run_cmd(
+                mavutil.mavlink.MAV_CMD_CONDITION_YAW,
+                heading,  # target angle
+                10,  # degrees/second
+                1,  # -1 is counter-clockwise, 1 clockwise
+                0,  # 1 for relative, 0 for absolute
+                0,  # p5
+                0,  # p6
+                0,  # p7
             )
             m = self.mav.recv_match(type='VFR_HUD', blocking=True)
             self.progress("heading=%d want=%d" % (m.heading, int(heading)))
@@ -4345,6 +4401,7 @@ class AutoTest(ABC):
         self.mavproxy.send('module load relay\n')
         self.mavproxy.expect("Loaded module relay")
         self.mavproxy.send("relay set %d %d\n" % (relay_num, on_off))
+
     #################################################
     # WAIT UTILITIES
     #################################################
@@ -4407,7 +4464,15 @@ class AutoTest(ABC):
             else:
                 return False
 
-        self.wait_and_maintain(value_name="Groundspeed", target=speed_min, current_value_getter=lambda: get_groundspeed(timeout), accuracy=(speed_max - speed_min), validator=lambda value2, target2: validator(value2, target2), timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="Groundspeed",
+            target=speed_min,
+            current_value_getter=lambda: get_groundspeed(timeout),
+            accuracy=(speed_max - speed_min),
+            validator=lambda value2, target2: validator(value2, target2),
+            timeout=timeout,
+            **kwargs
+        )
 
     def wait_roll(self, roll, accuracy, timeout=30, **kwargs):
         """Wait for a given roll in degrees."""
@@ -4423,7 +4488,15 @@ class AutoTest(ABC):
         def validator(value2, target2):
             return math.fabs((value2 - target2 + 180) % 360 - 180) <= accuracy
 
-        self.wait_and_maintain(value_name="Roll", target=roll, current_value_getter=lambda: get_roll(timeout), validator=lambda value2, target2: validator(value2, target2), accuracy=accuracy, timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="Roll",
+            target=roll,
+            current_value_getter=lambda: get_roll(timeout),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=accuracy,
+            timeout=timeout,
+            **kwargs
+        )
 
     def wait_pitch(self, pitch, accuracy, timeout=30, **kwargs):
         """Wait for a given pitch in degrees."""
@@ -4439,7 +4512,15 @@ class AutoTest(ABC):
         def validator(value2, target2):
             return math.fabs((value2 - target2 + 180) % 360 - 180) <= accuracy
 
-        self.wait_and_maintain(value_name="Pitch", target=pitch, current_value_getter=lambda: get_pitch(timeout), validator=lambda value2, target2: validator(value2, target2), accuracy=accuracy, timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="Pitch",
+            target=pitch,
+            current_value_getter=lambda: get_pitch(timeout),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=accuracy,
+            timeout=timeout,
+            **kwargs
+        )
 
     def wait_and_maintain(self, value_name, target, current_value_getter, validator=None, accuracy=2.0, timeout=30, **kwargs):
         tstart = self.get_sim_time()
@@ -4458,7 +4539,7 @@ class AutoTest(ABC):
         else:
             self.progress("Waiting for %s=%.02f with accuracy %.02f" % (value_name, target, accuracy))
         last_print_time = 0
-        while self.get_sim_time_cached() < tstart + timeout:  # if we failed to received message with the getter the sim time isn't updated
+        while self.get_sim_time_cached() < tstart + timeout:  # if we failed to received message with the getter the sim time isn't updated  # noqa
             last_value = current_value_getter()
             if called_function is not None:
                 called_function(last_value, target)
@@ -4468,7 +4549,7 @@ class AutoTest(ABC):
                                   (value_name, str(last_value), str(target), accuracy))
                 else:
                     self.progress("%s=%0.2f (want %f +- %f)" %
-                                 (value_name, last_value, target, accuracy))
+                                  (value_name, last_value, target, accuracy))
                 last_print_time = self.get_sim_time_cached()
             if validator is not None:
                 is_value_valid = validator(last_value, target)
@@ -4481,7 +4562,9 @@ class AutoTest(ABC):
                     achieving_duration_start = self.get_sim_time_cached()
                 if self.get_sim_time_cached() - achieving_duration_start >= minimum_duration:
                     if type(target) is Vector3:
-                        self.progress("Attained %s=%s" % (value_name, str(sum_of_achieved_values * (1.0 / count_of_achieved_values))))
+                        self.progress("Attained %s=%s" % (
+                            value_name,
+                            str(sum_of_achieved_values * (1.0 / count_of_achieved_values))))
                     else:
                         self.progress("Attained %s=%f" % (value_name, sum_of_achieved_values / count_of_achieved_values))
                     return True
@@ -4492,7 +4575,11 @@ class AutoTest(ABC):
                 else:
                     sum_of_achieved_values = 0.0
                 count_of_achieved_values = 0
-        raise AutoTestTimeoutException("Failed to attain %s want %s, reached %s" % (value_name, str(target), str(sum_of_achieved_values * (1.0 / count_of_achieved_values)) if count_of_achieved_values != 0 else str(last_value)))
+        raise AutoTestTimeoutException(
+            "Failed to attain %s want %s, reached %s" %
+            (value_name,
+             str(target),
+             str(sum_of_achieved_values / count_of_achieved_values) if count_of_achieved_values != 0 else str(last_value)))
 
     def wait_heading(self, heading, accuracy=5, timeout=30, **kwargs):
         """Wait for a given heading."""
@@ -4505,7 +4592,15 @@ class AutoTest(ABC):
         def validator(value2, target2):
             return math.fabs((value2 - target2 + 180) % 360 - 180) <= accuracy
 
-        self.wait_and_maintain(value_name="Heading", target=heading, current_value_getter=lambda: get_heading_wrapped(timeout), validator=lambda value2, target2: validator(value2, target2), accuracy=accuracy, timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="Heading",
+            target=heading,
+            current_value_getter=lambda: get_heading_wrapped(timeout),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=accuracy,
+            timeout=timeout,
+            **kwargs
+        )
 
     def wait_yaw_speed(self, yaw_speed, accuracy=0.1, timeout=30, **kwargs):
         """Wait for a given yaw speed in radians per second."""
@@ -4518,7 +4613,15 @@ class AutoTest(ABC):
         def validator(value2, target2):
             return math.fabs(value2 - target2) <= accuracy
 
-        self.wait_and_maintain(value_name="YawSpeed", target=yaw_speed, current_value_getter=lambda: get_yawspeed(timeout), validator=lambda value2, target2: validator(value2, target2), accuracy=accuracy, timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="YawSpeed",
+            target=yaw_speed,
+            current_value_getter=lambda: get_yawspeed(timeout),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=accuracy,
+            timeout=timeout,
+            **kwargs
+        )
 
     def wait_speed_vector(self, speed_vector, accuracy=0.2, timeout=30, **kwargs):
         """Wait for a given speed vector."""
@@ -4533,7 +4636,15 @@ class AutoTest(ABC):
                     math.fabs(value2.y - target2.y) <= accuracy and
                     math.fabs(value2.z - target2.z) <= accuracy)
 
-        self.wait_and_maintain(value_name="SpeedVector", target=speed_vector, current_value_getter=lambda: get_speed_vector(timeout), validator=lambda value2, target2: validator(value2, target2), accuracy=accuracy, timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="SpeedVector",
+            target=speed_vector,
+            current_value_getter=lambda: get_speed_vector(timeout),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=accuracy,
+            timeout=timeout,
+            **kwargs
+        )
 
     def get_body_frame_velocity(self):
         gri = self.mav.recv_match(type='GPS_RAW_INT', blocking=True, timeout=1)
@@ -4574,7 +4685,15 @@ class AutoTest(ABC):
         def validator(value2, target2):
             return math.fabs(value2 - target2) <= accuracy
 
-        self.wait_and_maintain(value_name="Distance", target=distance, current_value_getter=lambda: get_distance(), validator=lambda value2, target2: validator(value2, target2), accuracy=accuracy, timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="Distance",
+            target=distance,
+            current_value_getter=lambda: get_distance(),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=accuracy,
+            timeout=timeout,
+            **kwargs
+        )
 
     def wait_distance_to_location(self, location, distance_min, distance_max, timeout=30, **kwargs):
         """Wait for flight of a given distance."""
@@ -4586,7 +4705,14 @@ class AutoTest(ABC):
         def validator(value2, target2=None):
             return distance_min <= value2 <= distance_max
 
-        self.wait_and_maintain(value_name="Distance", target=distance_min, current_value_getter=lambda: get_distance(), validator=lambda value2, target2: validator(value2, target2), accuracy=(distance_max - distance_min), timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="Distance",
+            target=distance_min,
+            current_value_getter=lambda: get_distance(),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=(distance_max - distance_min), timeout=timeout,
+            **kwargs
+        )
 
     def wait_distance_to_home(self, distance_min, distance_max, timeout=10, use_cached_home=True, **kwargs):
         """Wait for distance to home to be within specified bounds."""
@@ -4598,7 +4724,14 @@ class AutoTest(ABC):
         def validator(value2, target2=None):
             return distance_min <= value2 <= distance_max
 
-        self.wait_and_maintain(value_name="Distance to home", target=distance_min, current_value_getter=lambda: get_distance(), validator=lambda value2, target2: validator(value2, target2), accuracy=(distance_max - distance_min), timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name="Distance to home",
+            target=distance_min,
+            current_value_getter=lambda: get_distance(),
+            validator=lambda value2, target2: validator(value2, target2),
+            accuracy=(distance_max - distance_min), timeout=timeout,
+            **kwargs
+        )
 
     def wait_distance_to_nav_target(self,
                                     distance_min,
@@ -4704,7 +4837,15 @@ class AutoTest(ABC):
         debug_text = "Distance to Location (%.4f, %.4f) " % (loc.lat, loc.lng)
         if target_altitude is not None:
             debug_text += ",at altitude %.1f height_accuracy=%.1f, d" % (target_altitude, height_accuracy)
-        self.wait_and_maintain(value_name=debug_text, target=0, current_value_getter=lambda: get_distance_to_loc(), accuracy=accuracy, validator=lambda value2, target2: validator(value2, None), timeout=timeout, **kwargs)
+        self.wait_and_maintain(
+            value_name=debug_text,
+            target=0,
+            current_value_getter=lambda: get_distance_to_loc(),
+            accuracy=accuracy,
+            validator=lambda value2, target2: validator(value2, None),
+            timeout=timeout,
+            **kwargs
+        )
 
     def wait_current_waypoint(self, wpnum, timeout=60):
         tstart = self.get_sim_time()
@@ -4776,7 +4917,7 @@ class AutoTest(ABC):
             self.wait_heartbeat(drain_mav=drain_mav)
         try:
             return self.get_mode_from_mode_mapping(self.mav.flightmode) == self.get_mode_from_mode_mapping(mode)
-        except Exception as e:
+        except Exception:
             pass
         # assume this is a number....
         return self.mav.messages['HEARTBEAT'].custom_mode == mode
@@ -4788,7 +4929,7 @@ class AutoTest(ABC):
         while not self.mode_is(mode, drain_mav=False):
             custom_num = self.mav.messages['HEARTBEAT'].custom_mode
             self.progress("mav.flightmode=%s Want=%s custom=%u" % (
-                    self.mav.flightmode, mode, custom_num))
+                self.mav.flightmode, mode, custom_num))
             if (timeout is not None and
                     self.get_sim_time_cached() > tstart + timeout):
                 raise WaitModeTimeout("Did not change mode")
@@ -4883,7 +5024,7 @@ class AutoTest(ABC):
                 self.arm_vehicle()
                 raise AutoTestTimeoutException("Prearm bit never went true")
             if self.sensor_has_state(mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK, True, True, True):
-               break
+                break
 
     def wait_ready_to_arm(self, timeout=120, require_absolute=True, check_prearm_bit=True):
         # wait for EKF checks to pass
@@ -5032,6 +5173,7 @@ Also, ignores heartbeats not from our target system'''
 
         global statustext_found
         statustext_found = False
+
         def mh(mav, m):
             global statustext_found
             if m.get_type() != "STATUSTEXT":
@@ -5058,7 +5200,7 @@ Also, ignores heartbeats not from our target system'''
                                                    text.lower())
                 if the_function is not None:
                     the_function()
-                m = self.mav.recv_match(type='STATUSTEXT', blocking=True, timeout=0.1)
+                self.mav.recv_match(type='STATUSTEXT', blocking=True, timeout=0.1)
         finally:
             self.remove_message_hook(mh)
 
@@ -5071,12 +5213,12 @@ Also, ignores heartbeats not from our target system'''
                 robust_parsing=True,
                 source_system=250,
                 source_component=250,
-                autoreconnect = True,
+                autoreconnect=True,
                 dialect="ardupilotmega",  # if we don't pass this in we end up with the wrong mavlink version...
             )
         except Exception as msg:
             self.progress("Failed to start mavlink connection on %s: %s" %
-                          (connection_string, msg,))
+                          (self.autotest_connection_string_to_ardupilot(), msg,))
             raise
         self.mav.message_hooks.append(self.message_hook)
         self.mav.mav.set_send_callback(self.send_message_hook, self)
@@ -5099,14 +5241,14 @@ Also, ignores heartbeats not from our target system'''
         for desc, test_time in sorted(self.test_timings.items(),
                                       key=self.show_test_timings_key_sorter):
             fmt = "%" + str(longest) + "s: %.2fs"
-            tests_total_time += test_time;
+            tests_total_time += test_time
             self.progress(fmt % (desc, test_time))
         self.progress(fmt % ("**--tests_total_time--**", tests_total_time))
 
     def send_statustext(self, text):
         if sys.version_info.major >= 3 and not isinstance(text, bytes):
             text = bytes(text, "ascii")
-        elif type(text) == unicode:
+        elif 'unicode' in str(type(text)):
             text = text.encode('ascii')
         self.mav.mav.statustext_send(mavutil.mavlink.MAV_SEVERITY_WARNING, text)
 
@@ -5220,7 +5362,7 @@ Also, ignores heartbeats not from our target system'''
             passed = False
 
         if passed:
-#            self.remove_bin_logs() # can't do this as one of the binlogs is probably open for writing by the SITL process.  If we force a rotate before running tests then we can do this.
+#            self.remove_bin_logs() # can't do this as one of the binlogs is probably open for writing by the SITL process.  If we force a rotate before running tests then we can do this.  # noqa
             pass
         else:
             if self.logs_dir is not None:
@@ -5276,7 +5418,7 @@ Also, ignores heartbeats not from our target system'''
 
         # determine a good pexpect timeout for reading MAVProxy's
         # output; some regmes may require longer timeouts.
-        pexpect_timeout=60
+        pexpect_timeout = 60
         if self.valgrind:
             pexpect_timeout *= 10
 
@@ -5285,7 +5427,7 @@ Also, ignores heartbeats not from our target system'''
             logfile=self.mavproxy_logfile,
             options=self.mavproxy_options(),
             pexpect_timeout=pexpect_timeout)
-        self.mavproxy.expect('Telemetry log: (\S+)\r\n')
+        self.mavproxy.expect(r'Telemetry log: (\S+)\r\n')
         self.logfile = self.mavproxy.match.group(1)
         self.progress("LOGFILE %s" % self.logfile)
         self.try_symlink_tlog()
@@ -5307,7 +5449,7 @@ Also, ignores heartbeats not from our target system'''
         }
         start_sitl_args.update(**sitl_args)
         if ("defaults_filepath" not in start_sitl_args or
-            start_sitl_args["defaults_filepath"] is None):
+                start_sitl_args["defaults_filepath"] is None):
             start_sitl_args["defaults_filepath"] = self.defaults_filepath()
 
         if "model" not in start_sitl_args or start_sitl_args["model"] is None:
@@ -5398,9 +5540,9 @@ Also, ignores heartbeats not from our target system'''
 
             if m.get_type() == 'MISSION_ACK':
                 if (m.target_system == 255 and
-                    m.target_component == 0 and
-                    m.type == 1 and
-                    m.mission_type == 0):
+                        m.target_component == 0 and
+                        m.type == 1 and
+                        m.mission_type == 0):
                     # this is just MAVProxy trying to screw us up
                     continue
                 else:
@@ -5425,7 +5567,8 @@ Also, ignores heartbeats not from our target system'''
             if items[m.seq].target_component != target_component:
                 raise NotAchievedException("supplied item not of correct target component")
             if items[m.seq].seq != m.seq:
-                raise NotAchievedException("supplied item has incorrect sequence number (%u vs %u)" % (items[m.seq].seq, m.seq))
+                raise NotAchievedException("supplied item has incorrect sequence number (%u vs %u)" %
+                                           (items[m.seq].seq, m.seq))
 
             items[m.seq].pack(self.mav.mav)
             self.mav.mav.send(items[m.seq])
@@ -5534,7 +5677,7 @@ Also, ignores heartbeats not from our target system'''
                     0,
                     0,
                     quiet=quiet)
-            except ValueError as e:
+            except ValueError:
                 continue
             m = self.mav.messages.get("HOME_POSITION", None)
             if m is None:
@@ -5647,13 +5790,13 @@ Also, ignores heartbeats not from our target system'''
         got_home_longitude = home.longitude
         got_home_altitude = home.altitude
         if (got_home_latitude != new_x or
-            got_home_longitude != new_y or
-            abs(got_home_altitude - new_z) > 100): # float-conversion issues
+                got_home_longitude != new_y or
+                abs(got_home_altitude - new_z) > 100): # float-conversion issues
             self.reboot_sitl()
             raise NotAchievedException(
                 "Home mismatch got=(%f, %f, %f) set=(%f, %f, %f)" %
                 (got_home_latitude, got_home_longitude, got_home_altitude,
-                new_x, new_y, new_z))
+                 new_x, new_y, new_z))
 
         self.progress("monitoring home to ensure it doesn't drift at all")
         tstart = self.get_sim_time()
@@ -5661,8 +5804,8 @@ Also, ignores heartbeats not from our target system'''
             home = self.poll_home_position(quiet=True)
             self.progress("home: %s" % str(home))
             if (home.latitude != got_home_latitude or
-                home.longitude != got_home_longitude or
-                home.altitude != got_home_altitude): # float-conversion issues
+                    home.longitude != got_home_longitude or
+                    home.altitude != got_home_altitude): # float-conversion issues
                 self.reboot_sitl()
                 raise NotAchievedException("home is drifting")
 
@@ -5758,7 +5901,7 @@ Also, ignores heartbeats not from our target system'''
                 [("SIM_MAG%d_OFS_X" % count, "COMPASS_OFS%d_X" % count, 0),
                  ("SIM_MAG%d_OFS_Y" % count, "COMPASS_OFS%d_Y" % count, 0),
                  ("SIM_MAG%d_OFS_Z" % count, "COMPASS_OFS%d_Z" % count, 0), ],
-                ]
+            ]
         self.check_zero_mag_parameters(params)
 
     def forty_two_mag_dia_odi_parameters(self, compass_count=3):
@@ -5810,7 +5953,9 @@ Also, ignores heartbeats not from our target system'''
                 if "DIA" in _out or "ODI" in _out:
                     max += 42.0
                 if abs(got_value) > max:
-                    raise NotAchievedException("%s/%s not within 15%%; got %f want=%f" % (_in, _out, got_value, 0.0 if max > 1 else 42.0))
+                    raise NotAchievedException(
+                        "%s/%s not within 15%%; got %f want=%f" %
+                        (_in, _out, got_value, 0.0 if max > 1 else 42.0))
 
     def check_zeros_mag_orient(self, compass_count=3):
         self.progress("zeroed mag parameters")
@@ -6034,7 +6179,9 @@ Also, ignores heartbeats not from our target system'''
                         if m.cal_status == mavutil.mavlink.MAG_CAL_SUCCESS:
                             threshold = 95
                             if reached_pct[m.compass_id] < threshold:
-                                raise NotAchievedException("Mag calibration report SUCCESS without >=%f%% completion (got %f%%)" % (threshold, reached_pct[m.compass_id]))
+                                raise NotAchievedException(
+                                    "Mag calibration report SUCCESS without >=%f%% completion (got %f%%)" %
+                                    (threshold, reached_pct[m.compass_id]))
                             report_get[m.compass_id] = 1
                         else:
                             raise NotAchievedException(
@@ -6142,12 +6289,10 @@ Also, ignores heartbeats not from our target system'''
         '''transforms ought to be read as, "take all the parameter values from
         the first compass parameters and shove them into the second indicating
         compass parameters'''
-                               # create a set of mappings from one
-                               # parameter name to another
-                               # e.g. COMPASS_OFS_X => COMPASS_OFS2_X
-                               # if the transform is [(1,2)].
-                               # [(1,2),(2,1)] should swap the compass
-                               # values
+
+        # create a set of mappings from one parameter name to another
+        # e.g. COMPASS_OFS_X => COMPASS_OFS2_X if the transform is
+        # [(1,2)].  [(1,2),(2,1)] should swap the compass values
 
         parameter_mappings = {}
         for key in values.keys():
@@ -6273,7 +6418,9 @@ Also, ignores heartbeats not from our target system'''
 
                 self.reboot_sitl()
 
-                self.test_mag_reordering_assert_mag_transform(originals, [(2,1),(3,2),(1,3)])
+                self.test_mag_reordering_assert_mag_transform(originals, [(2, 1),
+                                                                          (3, 2),
+                                                                          (1, 3)])
 
             except Exception as e:
                 self.progress("Caught exception: %s" %
@@ -6415,7 +6562,7 @@ Also, ignores heartbeats not from our target system'''
                     last_status = now
                     self.mavproxy.send('dataflash_logger status\n')
                     # seen on autotest: Active Rate(3s):97.790kB/s Block:164 Missing:0 Fixed:0 Abandoned:0
-                    self.mavproxy.expect("Active Rate\([0-9]+s\):([0-9]+[.][0-9]+)")
+                    self.mavproxy.expect(r"Active Rate\([0-9]+s\):([0-9]+[.][0-9]+)")
                     rate = float(self.mavproxy.match.group(1))
                     self.progress("Rate: %f" % rate)
                     if rate < 50:
@@ -6502,6 +6649,7 @@ Also, ignores heartbeats not from our target system'''
                 self._stderr = sys.stderr
                 sys.stderr = self._stringio = StringIO.StringIO()
                 return self
+
             def __exit__(self, *args):
                 self.extend(self._stringio.getvalue().splitlines())
                 del self._stringio    # free up some memory
@@ -6926,7 +7074,7 @@ Also, ignores heartbeats not from our target system'''
 
         if m.interval_us != want:
             raise NotAchievedException("Did not read same interval back from autopilot: want=%d got=%d)" %
-            (want, m.interval_us))
+                                       (want, m.interval_us))
         m = self.mav.recv_match(type='COMMAND_ACK', blocking=True)
         if m.result != mavutil.mavlink.MAV_RESULT_ACCEPTED:
             raise NotAchievedException("Expected ACCEPTED for reading message interval")
@@ -6961,7 +7109,6 @@ Also, ignores heartbeats not from our target system'''
                 self.progress("Want=%u got=%u" % (want_rate, rate))
                 if rate != want_rate:
                     raise NotAchievedException("Did not get expected rate (want=%u got=%u" % (want_rate, rate))
-
 
             self.progress("try at the main loop rate")
             # have to reset the speedup as MAVProxy can't keep up otherwise
@@ -7074,7 +7221,6 @@ Also, ignores heartbeats not from our target system'''
         if mission_type == mavutil.mavlink.MAV_MISSION_TYPE_MISSION:
             self.last_wp_load = time.time()
 
-
     def clear_fence_using_mavproxy(self, timeout=10):
         self.mavproxy.send("fence clear\n")
         tstart = self.get_sim_time_cached()
@@ -7113,9 +7259,9 @@ Also, ignores heartbeats not from our target system'''
                 self.progress("Disarming tracker")
                 self.disarm_vehicle(force=True)
 
-            self.reboot_sitl(required_bootcount=1);
+            self.reboot_sitl(required_bootcount=1)
             self.progress("Waiting for 'Config error'")
-            self.wait_statustext("Config error");
+            self.wait_statustext("Config error")
             self.progress("Setting %s to %f" % (parameter_name, new_parameter_value))
             self.set_parameter(parameter_name, new_parameter_value)
         except Exception as e:
@@ -7130,7 +7276,7 @@ Also, ignores heartbeats not from our target system'''
             self.disarm_vehicle(force=True)
 
         self.progress("Calling reboot-sitl ")
-        self.reboot_sitl(required_bootcount=2);
+        self.reboot_sitl(required_bootcount=2)
 
         if ex is not None:
             raise ex
@@ -7539,46 +7685,72 @@ Also, ignores heartbeats not from our target system'''
             frame_name = mavutil.mavlink.enums["MAV_FRAME"][frame].name
             self.start_test("Testing Set Velocity in %s" % frame_name)
             self.start_subtest("Changing Vx speed")
-            self.wait_speed_vector(target_speed, timeout=timeout,
-                                   called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2)
+            self.wait_speed_vector(
+                target_speed,
+                timeout=timeout,
+                called_function=lambda plop, empty: send_speed_vector(target_speed, frame),
+                minimum_duration=2
+            )
 
             self.start_subtest("Add Vy speed")
             target_speed.y = 1.0
-            self.wait_speed_vector(target_speed, timeout=timeout,
-                                   called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2)
+            self.wait_speed_vector(
+                target_speed,
+                timeout=timeout,
+                called_function=lambda plop, empty: send_speed_vector(target_speed, frame),
+                minimum_duration=2)
 
             self.start_subtest("Add Vz speed")
             if test_vz:
                 target_speed.z = 1.0
             else:
                 target_speed.z = 0.0
-            self.wait_speed_vector(target_speed, timeout=timeout,
-                                   called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2)
+            self.wait_speed_vector(
+                target_speed,
+                timeout=timeout,
+                called_function=lambda plop, empty: send_speed_vector(target_speed, frame),
+                minimum_duration=2
+            )
 
             self.start_subtest("Invert Vz speed")
             if test_vz:
                 target_speed.z = -1.0
             else:
                 target_speed.z = 0.0
-            self.wait_speed_vector(target_speed, timeout=timeout,
-                                   called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2)
+            self.wait_speed_vector(
+                target_speed,
+                timeout=timeout,
+                called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2
+            )
 
             self.start_subtest("Invert Vx speed")
             target_speed.x = -1.0
-            self.wait_speed_vector(target_speed, timeout=timeout,
-                                   called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2)
+            self.wait_speed_vector(
+                target_speed,
+                timeout=timeout,
+                called_function=lambda plop, empty: send_speed_vector(target_speed, frame),
+                minimum_duration=2
+            )
 
             self.start_subtest("Invert Vy speed")
             target_speed.y = -1.0
-            self.wait_speed_vector(target_speed, timeout=timeout,
-                                   called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2)
+            self.wait_speed_vector(
+                target_speed,
+                timeout=timeout,
+                called_function=lambda plop, empty: send_speed_vector(target_speed, frame),
+                minimum_duration=2
+            )
 
             self.start_subtest("Set Speed to zero")
             target_speed.x = 0.0
             target_speed.y = 0.0
             target_speed.z = 0.0
-            self.wait_speed_vector(target_speed, timeout=timeout,
-                                   called_function=lambda plop, empty: send_speed_vector(target_speed, frame), minimum_duration=2)
+            self.wait_speed_vector(
+                target_speed,
+                timeout=timeout,
+                called_function=lambda plop, empty: send_speed_vector(target_speed, frame),
+                minimum_duration=2
+            )
 
             if test_heading:
                 self.start_test("Testing Yaw targetting in %s" % frame_name)
@@ -7648,10 +7820,20 @@ Also, ignores heartbeats not from our target system'''
 
                 self.start_subtest("Add Vx, Vy, Vz speed and target a fixed Heading")
                 target_yaw = 42.0
-                self.wait_heading(target_yaw, minimum_duration=5, timeout=timeout,
-                                  called_function=lambda plop, empty: send_yaw_target_vel(target_yaw, target_speed, frame))
-                self.wait_speed_vector(target_speed,
-                                       called_function=lambda plop, empty: send_yaw_target_vel(target_yaw, target_speed, frame))
+                self.wait_heading(
+                    target_yaw,
+                    minimum_duration=5,
+                    timeout=timeout,
+                    called_function=lambda p, e: send_yaw_target_vel(target_yaw,
+                                                                     target_speed,
+                                                                     frame)
+                )
+                self.wait_speed_vector(
+                    target_speed,
+                    called_function=lambda p, e: send_yaw_target_vel(target_yaw,
+                                                                     target_speed,
+                                                                     frame)
+                )
 
                 self.start_subtest("Stop Vx, Vy, Vz speed and target zero Heading")
                 target_yaw = 0.0
@@ -7660,8 +7842,14 @@ Also, ignores heartbeats not from our target system'''
                 target_speed.z = 0.0
                 self.wait_heading(target_yaw, minimum_duration=5, timeout=timeout,
                                   called_function=lambda plop, empty: send_yaw_target_vel(target_yaw, target_speed, frame))
-                self.wait_speed_vector(target_speed, timeout=timeout,
-                                       called_function=lambda plop, empty: send_yaw_target_vel(target_yaw, target_speed, frame), minimum_duration=2)
+                self.wait_speed_vector(
+                    target_speed,
+                    timeout=timeout,
+                    called_function=lambda p, ee: send_yaw_target_vel(target_yaw,
+                                                                      target_speed,
+                                                                      frame),
+                    minimum_duration=2
+                )
 
             if test_yaw_rate:
                 self.start_test("Testing Yaw Rate targetting in %s" % frame_name)
@@ -7736,10 +7924,21 @@ Also, ignores heartbeats not from our target system'''
 
                 self.start_subtest("Set Yaw Rate and Vx, Vy, Vz speed")
                 target_rate = 1.0
-                self.wait_yaw_speed(target_rate,
-                                    called_function=lambda plop, empty: send_yaw_rate_vel(target_rate, target_speed, frame), minimum_duration=2)
-                self.wait_speed_vector(target_speed, timeout=timeout,
-                                       called_function=lambda plop, empty: send_yaw_rate_vel(target_rate, target_speed, frame), minimum_duration=2)
+                self.wait_yaw_speed(
+                    target_rate,
+                    called_function=lambda p, e: send_yaw_rate_vel(target_rate,
+                                                                   target_speed,
+                                                                   frame),
+                    minimum_duration=2
+                )
+                self.wait_speed_vector(
+                    target_speed,
+                    timeout=timeout,
+                    called_function=lambda p, e: send_yaw_rate_vel(target_rate,
+                                                                   target_speed,
+                                                                   frame),
+                    minimum_duration=2
+                )
 
                 target_rate = -1.0
                 target_speed.x = -1.0
@@ -7749,20 +7948,44 @@ Also, ignores heartbeats not from our target system'''
                 else:
                     target_speed.z = 0.0
                 self.start_subtest("Invert Vx, Vy, Vz speed")
-                self.wait_yaw_speed(target_rate, timeout=timeout,
-                                    called_function=lambda plop, empty: send_yaw_rate_vel(target_rate, target_speed, frame), minimum_duration=2)
-                self.wait_speed_vector(target_speed, timeout=timeout,
-                                       called_function=lambda plop, empty: send_yaw_rate_vel(target_rate, target_speed, frame), minimum_duration=2)
+                self.wait_yaw_speed(
+                    target_rate,
+                    timeout=timeout,
+                    called_function=lambda p, e: send_yaw_rate_vel(target_rate,
+                                                                   target_speed,
+                                                                   frame),
+                    minimum_duration=2
+                )
+                self.wait_speed_vector(
+                    target_speed,
+                    timeout=timeout,
+                    called_function=lambda p, e: send_yaw_rate_vel(target_rate,
+                                                                   target_speed,
+                                                                   frame),
+                    minimum_duration=2
+                )
 
                 target_rate = 0.0
                 target_speed.x = 0.0
                 target_speed.y = 0.0
                 target_speed.z = 0.0
                 self.start_subtest("Stop Yaw rate and all speed")
-                self.wait_yaw_speed(target_rate, timeout=timeout,
-                                    called_function=lambda plop, empty: send_yaw_rate_vel(target_rate, target_speed, frame), minimum_duration=2)
-                self.wait_speed_vector(target_speed, timeout=timeout,
-                                       called_function=lambda plop, empty: send_yaw_rate_vel(target_rate, target_speed, frame), minimum_duration=2)
+                self.wait_yaw_speed(
+                    target_rate,
+                    timeout=timeout,
+                    called_function=lambda p, e: send_yaw_rate_vel(target_rate,
+                                                                   target_speed,
+                                                                   frame),
+                    minimum_duration=2
+                )
+                self.wait_speed_vector(
+                    target_speed,
+                    timeout=timeout,
+                    called_function=lambda p, e: send_yaw_rate_vel(target_rate,
+                                                                   target_speed,
+                                                                   frame),
+                    minimum_duration=2
+                )
         self.start_test("Getting back to home and disarm")
         self.do_RTL(distance_min=0, distance_max=wp_accuracy)
         self.disarm_vehicle()
@@ -7822,8 +8045,8 @@ Also, ignores heartbeats not from our target system'''
                     0, # p2
                     0, # p3
                     0, # p4
-                    int(locs["loc"].lat *1e7), # latitude
-                    int(locs["loc"].lng *1e7), # longitude
+                    int(locs["loc"].lat * 1e7), # latitude
+                    int(locs["loc"].lng * 1e7), # longitude
                     33.0000, # altitude
                     mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
                 seq += 1
@@ -7843,8 +8066,8 @@ Also, ignores heartbeats not from our target system'''
                     0, # p2
                     0, # p3
                     0, # p4
-                    int(loc.lat *1e7), # latitude
-                    int(loc.lng *1e7), # longitude
+                    int(loc.lat * 1e7), # latitude
+                    int(loc.lng * 1e7), # longitude
                     33.0000, # altitude
                     mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
                 seq += 1
@@ -7921,7 +8144,7 @@ switch value'''
 
     def dfreader_for_current_onboard_log(self):
         return DFReader.DFReader_binary(self.current_onboard_log_filepath(),
-                                        zero_time_base=True);
+                                        zero_time_base=True)
 
     def current_onboard_log_contains_message(self, messagetype):
         dfreader = self.dfreader_for_current_onboard_log()
@@ -7988,7 +8211,7 @@ switch value'''
         for key in dict2.keys():
             try:
                 del fred[key]
-            except:
+            except KeyError:
                 pass
         return fred
 
@@ -7997,7 +8220,6 @@ switch value'''
     # times.
     def download_parameters(self, target_system, target_component):
         # try a simple fetch-all:
-        tstart = self.get_sim_time_cached()
         last_parameter_received = 0
         attempt_count = 0
         start_done = False
@@ -8121,7 +8343,7 @@ switch value'''
 
     def test_parameters(self):
         '''general small tests for parameter system'''
-        self.test_parameter_documentation();
+        self.test_parameter_documentation()
         self.test_parameters_mis_total()
         self.test_parameters_download()
 
@@ -8210,14 +8432,15 @@ switch value'''
             self.set_parameter("AFS_MAX_GPS_LOSS", 0)
             self.set_parameter("AFS_TERMINATE", 0)
 
-            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION,
-                          1,  # terminate
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
+            self.run_cmd(
+                mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION,
+                1,  # terminate
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
             )
             self.wait_statustext("Terminating due to GCS request", check_context=True)
 
@@ -8231,7 +8454,7 @@ switch value'''
     def drain_mav_seconds(self, seconds):
         tstart = self.get_sim_time_cached()
         while self.get_sim_time_cached() - tstart < seconds:
-            self.drain_mav();
+            self.drain_mav()
             self.delay_sim_time(0.5)
 
     def wait_gps_fix_type_gte(self, fix_type, timeout=30):
@@ -8299,19 +8522,19 @@ switch value'''
                       Vector3(1.11, 0.98, 0.96)]
             atrim = Vector3(0.05, -0.03, 0)
             pre_atrim = Vector3(-0.02, 0.04, 0)
-            param_map = [("INS_ACCOFFS",  "SIM_ACC1_BIAS", pre_aofs[0], aofs[0]),
+            param_map = [("INS_ACCOFFS", "SIM_ACC1_BIAS", pre_aofs[0], aofs[0]),
                          ("INS_ACC2OFFS", "SIM_ACC2_BIAS", pre_aofs[1], aofs[1]),
-                         ("INS_ACCSCAL",  "SIM_ACC1_SCAL", pre_ascale[0], ascale[0]),
+                         ("INS_ACCSCAL", "SIM_ACC1_SCAL", pre_ascale[0], ascale[0]),
                          ("INS_ACC2SCAL", "SIM_ACC2_SCAL", pre_ascale[1], ascale[1]),
-                         ("AHRS_TRIM",    "SIM_ACC_TRIM", pre_atrim, atrim)]
-            axes = ['X','Y','Z']
+                         ("AHRS_TRIM", "SIM_ACC_TRIM", pre_atrim, atrim)]
+            axes = ['X', 'Y', 'Z']
 
             # form the pre-calibration params
             initial_params = {}
             for (ins_prefix, sim_prefix, pre_value, post_value) in param_map:
                 for axis in axes:
-                    initial_params[ins_prefix+"_"+axis] = getattr(pre_value,axis.lower())
-                    initial_params[sim_prefix+"_"+axis] = getattr(post_value,axis.lower())
+                    initial_params[ins_prefix + "_" + axis] = getattr(pre_value, axis.lower())
+                    initial_params[sim_prefix + "_" + axis] = getattr(post_value, axis.lower())
             self.set_parameters(initial_params)
             self.customise_SITL_commandline(["-M", "calibration"])
             self.mavproxy_load_module("sitl_calibration")
@@ -8320,13 +8543,14 @@ switch value'''
             self.mavproxy.send("sitl_accelcal\n")
             self.mavproxy.send("accelcal\n")
             self.mavproxy.expect("Calibrated")
-            for wanted in [ "level",
-                            "on its LEFT side",
-                            "on its RIGHT side",
-                            "nose DOWN",
-                            "nose UP",
-                            "on its BACK",
-                            ]:
+            for wanted in [
+                    "level",
+                    "on its LEFT side",
+                    "on its RIGHT side",
+                    "nose DOWN",
+                    "nose UP",
+                    "on its BACK",
+            ]:
                 timeout = 2
                 self.mavproxy.expect("Place vehicle %s and press any key." % wanted, timeout=timeout)
                 self.mavproxy.expect("sitl_accelcal: sending attitude, please wait..", timeout=timeout)
@@ -8342,12 +8566,14 @@ switch value'''
                 for axis in axes:
                     pname = ins_prefix+"_"+axis
                     v = self.mav.param(pname)
-                    expected_v = getattr(post_value,axis.lower())
+                    expected_v = getattr(post_value, axis.lower())
                     if v == expected_v:
                         continue
                     error_pct = 100.0 * abs(v - expected_v) / abs(expected_v)
                     if error_pct > accuracy_pct:
-                        raise NotAchievedException("Incorrect value %.6f for %s should be %.6f error %.2f%%" % (v, pname, expected_v, error_pct))
+                        raise NotAchievedException(
+                            "Incorrect value %.6f for %s should be %.6f error %.2f%%" %
+                            (v, pname, expected_v, error_pct))
                     else:
                         self.progress("Correct value %.4f for %s error %.2f%%" % (v, pname, error_pct))
         except Exception as e:
@@ -8363,26 +8589,26 @@ switch value'''
     def ahrstrim(self):
         # setup with non-zero accel offsets
         self.set_parameters({
-            "INS_ACCOFFS_X" : 0.7,
-            "INS_ACCOFFS_Y" : -0.3,
-            "INS_ACCOFFS_Z" : 1.8,
-            "INS_ACC2OFFS_X" : -2.1,
-            "INS_ACC2OFFS_Y" : 1.9,
-            "INS_ACC2OFFS_Z" : 2.3,
-            "SIM_ACC1_BIAS_X" : 0.7,
-            "SIM_ACC1_BIAS_Y" : -0.3,
-            "SIM_ACC1_BIAS_Z" : 1.8,
-            "SIM_ACC2_BIAS_X" : -2.1,
-            "SIM_ACC2_BIAS_Y" : 1.9,
-            "SIM_ACC2_BIAS_Z" : 2.3,
-            "AHRS_TRIM_X"    : 0.05,
-            "AHRS_TRIM_Y"    : -0.03,
-            "SIM_ACC_TRIM_X" : -0.04,
-            "SIM_ACC_TRIM_Y" : 0.05,
-            })
+            "INS_ACCOFFS_X": 0.7,
+            "INS_ACCOFFS_Y": -0.3,
+            "INS_ACCOFFS_Z": 1.8,
+            "INS_ACC2OFFS_X": -2.1,
+            "INS_ACC2OFFS_Y": 1.9,
+            "INS_ACC2OFFS_Z": 2.3,
+            "SIM_ACC1_BIAS_X": 0.7,
+            "SIM_ACC1_BIAS_Y": -0.3,
+            "SIM_ACC1_BIAS_Z": 1.8,
+            "SIM_ACC2_BIAS_X": -2.1,
+            "SIM_ACC2_BIAS_Y": 1.9,
+            "SIM_ACC2_BIAS_Z": 2.3,
+            "AHRS_TRIM_X": 0.05,
+            "AHRS_TRIM_Y": -0.03,
+            "SIM_ACC_TRIM_X": -0.04,
+            "SIM_ACC_TRIM_Y": 0.05,
+        })
         expected_parms = {
-            "AHRS_TRIM_X" : -0.04,
-            "AHRS_TRIM_Y" : 0.05,
+            "AHRS_TRIM_X": -0.04,
+            "AHRS_TRIM_Y": 0.05,
         }
 
         self.progress("Starting ahrstrim")
@@ -8402,8 +8628,11 @@ switch value'''
                 continue
             error_pct = 100.0 * abs(v - expected_v) / abs(expected_v)
             if error_pct > accuracy_pct:
-                raise NotAchievedException("Incorrect value %.6f for %s should be %.6f error %.2f%%" % (v, pname, expected_v, error_pct))
-            self.progress("Correct value %.4f for %s error %.2f%%" % (v, pname, error_pct))
+                raise NotAchievedException(
+                    "Incorrect value %.6f for %s should be %.6f error %.2f%%" %
+                    (v, pname, expected_v, error_pct))
+            self.progress("Correct value %.4f for %s error %.2f%%" %
+                          (v, pname, error_pct))
 
     def test_button(self):
         self.set_parameter("SIM_PIN_MASK", 0)
@@ -8419,7 +8648,7 @@ switch value'''
             # should not get a button-changed event here.  The pins
             # are simulated pull-down
             raise NotAchievedException("Received BUTTON_CHANGE event")
-        mask = 1<<pin
+        mask = 1 << pin
         self.set_parameter("SIM_PIN_MASK", mask)
         m = self.mav.recv_match(type='BUTTON_CHANGE', blocking=True, timeout=1)
         if m is None:
@@ -8466,7 +8695,7 @@ switch value'''
             # set the function:
             self.set_parameter("BTN_FUNC%u" % btn, 31)
             # invert the sense of the pin, so eStop is asserted when pin is low:
-            self.set_parameter("BTN_OPTIONS%u" % btn, 1<<1)
+            self.set_parameter("BTN_OPTIONS%u" % btn, 1 << 1)
             self.reboot_sitl()
             # assert the pin:
             self.set_parameter("SIM_PIN_MASK", mask)
@@ -8478,15 +8707,16 @@ switch value'''
             self.delay_sim_time(1)  # 5Hz update rate on Button library
             self.context_collect("STATUSTEXT")
             # try to arm the vehicle:
-            self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
-                         1,  # ARM
-                         0,
-                         0,
-                         0,
-                         0,
-                         0,
-                         0,
-                         want_result=mavutil.mavlink.MAV_RESULT_FAILED
+            self.run_cmd(
+                mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                1,  # ARM
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                want_result=mavutil.mavlink.MAV_RESULT_FAILED
             )
             self.wait_statustext("PreArm: Motors Emergency Stopped", check_context=True)
             self.context_pop()
@@ -8495,17 +8725,17 @@ switch value'''
     def compare_number_percent(self, num1, num2, percent):
         if num1 == 0 and num2 == 0:
             return True
-        if abs(num1-num2)/max(abs(num1),abs(num2)) <= percent*0.01:
+        if abs(num1 - num2) / max(abs(num1), abs(num2)) <= percent * 0.01:
             return True
         return False
 
-    def bit_extract(self,number,offset,length):
+    def bit_extract(self, number, offset, length):
         mask = 0
-        for i in range(offset,offset+length):
+        for i in range(offset, offset+length):
             mask |= 1 << i
         return (number & mask) >> offset
 
-    def tf_encode_gps_latitude(self,lat):
+    def tf_encode_gps_latitude(self, lat):
         value = 0
         if lat < 0:
             value = ((abs(lat)//100)*6) | 0x40000000
@@ -8529,64 +8759,64 @@ switch value'''
             return True
         return False
 
-    def tfp_prep_number(self,number,digits,power):
+    def tfp_prep_number(self, number, digits, power):
         res = 0
         abs_number = abs(number)
         if digits == 2 and power == 1: # number encoded on 8 bits: 7 bits for digits + 1 for 10^power
             if abs_number < 100:
-                res = abs_number<<1
+                res = abs_number << 1
             elif abs_number < 1270:
-                res = (round(abs_number * 0.1)<<1)|0x1
+                res = (round(abs_number * 0.1) << 1) | 0x1
             else: # transmit max possible value (0x7F x 10^1 = 1270)
                 res = 0xFF
             if number < 0:  # if number is negative, add sign bit in front
-                res |= 0x1<<8
+                res |= 0x1 << 8
         elif digits == 2 and power == 2: # number encoded on 9 bits: 7 bits for digits + 2 for 10^power
             if abs_number < 100:
-                res = abs_number<<2
+                res = abs_number << 2
             elif abs_number < 1000:
-                res = (round(abs_number * 0.1)<<2)|0x1
+                res = (round(abs_number * 0.1) << 2) | 0x1
             elif abs_number < 10000:
-                res = (round(abs_number * 0.01)<<2)|0x2
+                res = (round(abs_number * 0.01) << 2) | 0x2
             elif abs_number < 127000:
-                res = (round(abs_number * 0.001)<<2)|0x3
+                res = (round(abs_number * 0.001) << 2) | 0x3
             else: # transmit max possible value (0x7F x 10^3 = 127000)
                 res = 0x1FF
             if number < 0: # if number is negative, add sign bit in front
-                res |= 0x1<<9
+                res |= 0x1 << 9
         elif digits == 3 and power == 1: # number encoded on 11 bits: 10 bits for digits + 1 for 10^power
             if abs_number < 1000:
-                res = abs_number<<1
+                res = abs_number << 1
             elif abs_number < 10240:
-                res = (round(abs_number * 0.1)<<1)|0x1
+                res = (round(abs_number * 0.1) << 1) | 0x1
             else: # transmit max possible value (0x3FF x 10^1 = 10240)
                 res = 0x7FF
             if number < 0: # if number is negative, add sign bit in front
-                res |= 0x1<<11
+                res |= 0x1 << 11
         elif digits == 3 and power == 2: # number encoded on 12 bits: 10 bits for digits + 2 for 10^power
             if abs_number < 1000:
-                res = abs_number<<2
+                res = abs_number << 2
             elif abs_number < 10000:
-                res = (round(abs_number * 0.1)<<2)|0x1
+                res = (round(abs_number * 0.1) << 2) | 0x1
             elif abs_number < 100000:
-                res = (round(abs_number * 0.01)<<2)|0x2
+                res = (round(abs_number * 0.01) << 2) | 0x2
             elif abs_number < 1024000:
-                res = (round(abs_number * 0.001)<<2)|0x3
+                res = (round(abs_number * 0.001) << 2) | 0x3
             else: # transmit max possible value (0x3FF x 10^3 = 127000)
                 res = 0xFFF
             if number < 0: # if number is negative, add sign bit in front
-                res |= 0x1<<12
+                res |= 0x1 << 12
         return res
 
     def tfp_validate_ap_status(self, value): # 0x5001
         self.progress("validating ap_status(0x%02x)" % value)
-        flight_mode = self.bit_extract(value,0,5) - 1 # first mode is 1 not 0 :-)
-        simple_mode = self.bit_extract(value,5,2)
-        is_flying = not self.bit_extract(value,7,1)
-        status_armed = self.bit_extract(value,8,1)
-        batt_failsafe = self.bit_extract(value,9,1)
-        ekf_failsafe = self.bit_extract(value,10,2)
-        imu_temp = self.bit_extract(value,26,6) + 19 # IMU temperature: 0 means temp =< 19, 63 means temp => 82
+        flight_mode = self.bit_extract(value, 0, 5) - 1 # first mode is 1 not 0 :-)
+        # simple_mode = self.bit_extract(value, 5, 2)
+        # is_flying = not self.bit_extract(value, 7, 1)
+        # status_armed = self.bit_extract(value, 8, 1)
+        # batt_failsafe = self.bit_extract(value, 9, 1)
+        # ekf_failsafe = self.bit_extract(value, 10, 2)
+        # imu_temp = self.bit_extract(value, 26, 6) + 19 # IMU temperature: 0 means temp =< 19, 63 means temp => 82
         heartbeat = self.mav.recv_match(
             type='HEARTBEAT',
             blocking=True,
@@ -8604,9 +8834,9 @@ switch value'''
 
     def tfp_validate_attitude(self, value):
         self.progress("validating attitude(0x%02x)" % value)
-        roll = (min(self.bit_extract(value,0,11),1800) - 900) * 0.2 # roll [0,1800] ==> [-180,180]
-        pitch = (min(self.bit_extract(value,11,10),900) - 450) * 0.2 # pitch [0,900] ==> [-90,90]
-        rng_cm = self.bit_extract(value,22,10) * (10^self.bit_extract(value,21,1)) # cm
+        roll = (min(self.bit_extract(value, 0, 11), 1800) - 900) * 0.2 # roll [0,1800] ==> [-180,180]
+        pitch = (min(self.bit_extract(value, 11, 10), 900) - 450) * 0.2 # pitch [0,900] ==> [-90,90]
+#        rng_cm = self.bit_extract(value, 22, 10) * (10 ^ self.bit_extract(value, 21, 1)) # cm
         atti = self.mav.recv_match(
             type='ATTITUDE',
             blocking=True,
@@ -8616,16 +8846,20 @@ switch value'''
             raise NotAchievedException("Did not get ATTITUDE message")
         atti_roll = round(atti.roll)
         self.progress("ATTITUDE roll==%f frsky==%f" % (atti_roll, roll))
-        if abs(atti_roll - roll) < 5:
-            return True
+        if abs(atti_roll - roll) >= 5:
+            return False
+        atti_pitch = round(atti.pitch)
+        self.progress("ATTITUDE pitch==%f frsky==%f" % (atti_pitch, pitch))
+        if abs(atti_pitch - pitch) >= 5:
+            return False
             # FIXME: need to check other values as well
-        return False
+        return True
 
     def tfp_validate_home_status(self, value):
         self.progress("validating home status(0x%02x)" % value)
-        home_dist_m = self.bit_extract(value,2,10) * (10^self.bit_extract(value,0,2))
-        home_alt_dm = self.bit_extract(value,14,10) * (10^self.bit_extract(value,12,2)) * 0.1 * (self.bit_extract(value,24,1) == 1 and -1 or 1)
-        home_angle_d = self.bit_extract(value, 25,  7) * 3
+#        home_dist_m = self.bit_extract(value,2,10) * (10^self.bit_extract(value,0,2))
+        home_alt_dm = self.bit_extract(value, 14, 10) * (10 ^ self.bit_extract(value, 12, 2)) * 0.1 * (self.bit_extract(value, 24, 1) == 1 and -1 or 1)  # noqa
+        # home_angle_d = self.bit_extract(value, 25,  7) * 3
         gpi = self.mav.recv_match(
             type='GLOBAL_POSITION_INT',
             blocking=True,
@@ -8642,10 +8876,10 @@ switch value'''
 
     def tfp_validate_gps_status(self, value):
         self.progress("validating gps status(0x%02x)" % value)
-        num_sats = self.bit_extract(value,0,4)
-        gps_status = self.bit_extract(value,4,2) + self.bit_extract(value,14,2)
-        gps_hdop = self.bit_extract(value,7,7) * (10^self.bit_extract(value,6,1)) # dm
-        gps_alt = self.bit_extract(value,24,7) * (10^self.bit_extract(value,22,2)) * (self.bit_extract(value,31,1) == 1 and -1 or 1) # dm
+#        num_sats = self.bit_extract(value, 0, 4)
+        gps_status = self.bit_extract(value, 4, 2) + self.bit_extract(value, 14, 2)
+#        gps_hdop = self.bit_extract(value, 7, 7) * (10 ^ self.bit_extract(value, 6, 1)) # dm
+#        gps_alt = self.bit_extract(value, 24, 7) * (10 ^ self.bit_extract(value, 22, 2)) * (self.bit_extract(value, 31, 1) == 1 and -1 or 1) # dm  # noqa
         gri = self.mav.recv_match(
             type='GPS_RAW_INT',
             blocking=True,
@@ -8662,9 +8896,9 @@ switch value'''
 
     def tfp_validate_vel_and_yaw(self, value): # 0x5005
         self.progress("validating vel_and_yaw(0x%02x)" % value)
-        z_vel_dm_per_second = self.bit_extract(value,1,7) * (10^self.bit_extract(value,0,1)) * (self.bit_extract(value,8,1) == 1 and -1 or 1)
-        xy_vel = self.bit_extract(value,10,7) * (10^self.bit_extract(value,9,1))
-        yaw = self.bit_extract(value,17,11) * 0.2
+        z_vel_dm_per_second = self.bit_extract(value, 1, 7) * (10 ^ self.bit_extract(value, 0, 1)) * (self.bit_extract(value, 8, 1) == 1 and -1 or 1)  # noqa
+        xy_vel = self.bit_extract(value, 10, 7) * (10 ^ self.bit_extract(value, 9, 1))
+        yaw = self.bit_extract(value, 17, 11) * 0.2
         gpi = self.mav.recv_match(
             type='GLOBAL_POSITION_INT',
             blocking=True,
@@ -8675,17 +8909,17 @@ switch value'''
         self.progress(" yaw=%u gpi=%u" % (yaw, gpi.hdg*0.01))
         self.progress(" xy_vel=%u" % xy_vel)
         self.progress(" z_vel_dm_per_second=%u" % z_vel_dm_per_second)
-        if self.compare_number_percent(gpi.hdg*0.01,yaw,10):
+        if self.compare_number_percent(gpi.hdg*0.01, yaw, 10):
             self.progress("Yaw match")
             return True
-              # FIXME: need to be under way to check the velocities, really....
+        # FIXME: need to be under way to check the velocities, really....
         return False
 
     def tfp_validate_battery1(self, value):
         self.progress("validating battery1 (0x%02x)" % value)
-        voltage = self.bit_extract(value,0,9) #dV
-        current = self.bit_extract(value,10,7) * (10^self.bit_extract(value,9,1))
-        mah = self.bit_extract(value,17,15)
+        voltage = self.bit_extract(value, 0, 9)  # dV
+        # current = self.bit_extract(value, 10, 7) * (10 ^ self.bit_extract(value, 9, 1))
+        # mah = self.bit_extract(value, 17, 15)
         voltage = value * 0.1
         batt = self.mav.recv_match(
             type='BATTERY_STATUS',
@@ -8703,8 +8937,8 @@ switch value'''
         return True
 
     def tfp_validate_params(self, value):
-        param_id = self.bit_extract(value,24,4)
-        param_value = self.bit_extract(value,0,24)
+        param_id = self.bit_extract(value, 24, 4)
+        param_value = self.bit_extract(value, 0, 24)
         self.progress("received param (0x%02x) (id=%u value=%u)" %
                       (value, param_id, param_value))
         frame_type = param_value
@@ -8726,7 +8960,7 @@ switch value'''
 
     def tfp_validate_rpm(self, value):
         self.progress("validating rpm (0x%02x)" % value)
-        tf_rpm = self.bit_extract(value,0,16)
+        tf_rpm = self.bit_extract(value, 0, 16)
         rpm = self.mav.recv_match(
             type='RPM',
             blocking=True,
@@ -8740,12 +8974,11 @@ switch value'''
             return False
         return True
 
-
     def test_frsky_passthrough_do_wants(self, frsky, wants):
 
         tstart = self.get_sim_time_cached()
         while len(wants):
-            self.progress("Still wanting (%s)" % ",".join([ ("0x%02x" % x) for x in wants.keys()]))
+            self.progress("Still wanting (%s)" % ",".join([("0x%02x" % x) for x in wants.keys()]))
             wants_copy = copy.copy(wants)
             t2 = self.get_sim_time_cached()
             if t2 - tstart > 300:
@@ -8793,14 +9026,15 @@ switch value'''
                 # have to wait this long or our message gets squelched....
                 sent_request = True
 #                                self.mavproxy.send("param fetch\n")
-                self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
-                             0, #p1
-                             0, #p2
-                             1, #p3, baro
-                             0, #p4
-                             0, #p5
-                             0, #p6
-                             0, #p7
+                self.run_cmd(
+                    mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
+                    0, # p1
+                    0, # p2
+                    1, # p3, baro
+                    0, # p4
+                    0, # p5
+                    0, # p6
+                    0, # p7
                 )
             frsky.update()
             data = frsky.get_data(0x5000) # no timestamping on this data, so we can't catch legitimate repeats.
@@ -8823,8 +9057,6 @@ switch value'''
                 if (x & 0x7f) == 0x00:
                     last = True
             if last:
-                # we used to do a 'param fetch' and expect this back, but the params-via-ftp thing broke it.
-#                m = re.match("Ardu(Plane|Copter|Rover|Tracker|Sub) V[345]", text)
                 m = re.match("Updating barometer calibration", text)
                 if m is not None:
                     want_sev = mavutil.mavlink.MAV_SEVERITY_INFO
@@ -8842,14 +9074,14 @@ switch value'''
         # This, at least makes sure we're getting some of each
         # message.  These are ordered according to the wfq scheduler
         wants = {
-            0x5000: lambda xx : True,
+            0x5000: lambda xx: True,
             0x5006: self.tfp_validate_attitude,
-            0x800:  self.tf_validate_gps,
+            0x0800: self.tf_validate_gps,
             0x5005: self.tfp_validate_vel_and_yaw,
             0x5001: self.tfp_validate_ap_status,
             0x5002: self.tfp_validate_gps_status,
             0x5004: self.tfp_validate_home_status,
-            #0x5008: lambda x : True, # no second battery, so this doesn't arrive
+            # 0x5008: lambda x : True, # no second battery, so this doesn't arrive
             0x5003: self.tfp_validate_battery1,
             0x5007: self.tfp_validate_params,
         }
@@ -8860,7 +9092,7 @@ switch value'''
             self.set_autodisarm_delay(0)
             if not self.arm_vehicle():
                 raise NotAchievedException("Failed to ARM")
-            self.set_rc(3,1050)
+            self.set_rc(3, 1050)
             wants = {
                 0x500A: self.tfp_validate_rpm,
             }
@@ -8868,7 +9100,6 @@ switch value'''
             self.zero_throttle()
             if not self.disarm_vehicle():
                 raise NotAchievedException("Failed to DISARM")
-
 
         self.progress("Counts of sensor_id polls sent:")
         frsky.dump_sensor_id_poll_counts_as_progress_messages()
@@ -8883,7 +9114,7 @@ switch value'''
 
     def decode_mavlite_command_ack(self, message):
         '''returns a tuple of parameter name, value'''
-        (command,result) = struct.unpack("<HB", message)
+        (command, result) = struct.unpack("<HB", message)
         return (command, result)
 
     def read_message_via_mavlite(self, frsky, sport_to_mavlite):
@@ -8919,13 +9150,12 @@ switch value'''
             return value
 
     def get_parameter_via_mavlite(self, frsky, sport_to_mavlite, name):
-#        self.progress("########## Sending request")
+        # self.progress("########## Sending request")
         frsky.send_mavlite_param_request_read(name)
         return self.read_parameter_via_mavlite(frsky, sport_to_mavlite, name)
 
     def set_parameter_via_mavlite(self, frsky, sport_to_mavlite, name, value):
-        tstart = self.get_sim_time_cached()
-#        self.progress("########## Sending request")
+        # self.progress("########## Sending request")
         frsky.send_mavlite_param_set(name, value)
         # new value is echoed back immediately:
         got_val = self.read_parameter_via_mavlite(frsky, sport_to_mavlite, name)
@@ -8944,19 +9174,21 @@ switch value'''
                             p6=None,
                             p7=None,
                             want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED):
-        frsky.send_mavlite_command_long(command,
-                                        p1=p1,
-                                        p2=p2,
-                                        p3=p3,
-                                        p4=p4,
-                                        p5=p5,
-                                        p6=p6,
-                                        p7=p7,
+        frsky.send_mavlite_command_long(
+            command,
+            p1=p1,
+            p2=p2,
+            p3=p3,
+            p4=p4,
+            p5=p5,
+            p6=p6,
+            p7=p7,
         )
-        self.run_cmd_via_mavlite_get_ack(frsky,
-                                         sport_to_mavlite,
-                                         command,
-                                         want_result
+        self.run_cmd_via_mavlite_get_ack(
+            frsky,
+            sport_to_mavlite,
+            command,
+            want_result
         )
 
     def run_cmd_via_mavlite_get_ack(self, frsky, sport_to_mavlite, command, want_result):
@@ -8966,9 +9198,13 @@ switch value'''
             raise NotAchievedException("Expected a command-ack, got a %u" % msg.msgid)
         (got_command, got_result) = self.decode_mavlite_command_ack(msg.body)
         if got_command != command:
-            raise NotAchievedException("Did not receive expected command in command_ack; want=%u got=%u" % (command, got_command))
+            raise NotAchievedException(
+                "Did not receive expected command in command_ack; want=%u got=%u" %
+                (command, got_command))
         if got_result != want_result:
-            raise NotAchievedException("Did not receive expected result in command_ack; want=%u got=%u" % (want_result, got_result))
+            raise NotAchievedException(
+                "Did not receive expected result in command_ack; want=%u got=%u" %
+                (want_result, got_result))
 
     def test_frsky_mavlite(self):
         self.set_parameter("SERIAL5_PROTOCOL", 10) # serial5 is FRSky passthrough
@@ -9007,12 +9243,13 @@ switch value'''
         self.start_subtest("Calibrate Baro via MAVLite")
         self.context_push()
         self.context_collect("STATUSTEXT")
-        self.run_cmd_via_mavlite(frsky,
-                                 sport_to_mavlite,
-                                 mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
-                                 p1=0,
-                                 p2=0,
-                                 p3=1.0,
+        self.run_cmd_via_mavlite(
+            frsky,
+            sport_to_mavlite,
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
+            p1=0,
+            p2=0,
+            p3=1.0,
         )
         self.wait_statustext("Updating barometer calibration", check_context=True)
         self.context_pop()
@@ -9020,27 +9257,30 @@ switch value'''
 
         self.start_subtest("Change mode via MAVLite")
         #  FIXME: currently plane-specific
-        self.run_cmd_via_mavlite(frsky,
-                                 sport_to_mavlite,
-                                 mavutil.mavlink.MAV_CMD_DO_SET_MODE,
-                                 p1=mavutil.mavlink.PLANE_MODE_MANUAL,
+        self.run_cmd_via_mavlite(
+            frsky,
+            sport_to_mavlite,
+            mavutil.mavlink.MAV_CMD_DO_SET_MODE,
+            p1=mavutil.mavlink.PLANE_MODE_MANUAL,
         )
         self.wait_mode("MANUAL")
-        self.run_cmd_via_mavlite(frsky,
-                                 sport_to_mavlite,
-                                 mavutil.mavlink.MAV_CMD_DO_SET_MODE,
-                                 p1=mavutil.mavlink.PLANE_MODE_FLY_BY_WIRE_A,
+        self.run_cmd_via_mavlite(
+            frsky,
+            sport_to_mavlite,
+            mavutil.mavlink.MAV_CMD_DO_SET_MODE,
+            p1=mavutil.mavlink.PLANE_MODE_FLY_BY_WIRE_A,
         )
         self.wait_mode("FBWA")
         self.end_subtest("Change mode via MAVLite")
 
         self.start_subtest("Enable fence via MAVlite")
         #  FIXME: currently plane-specific
-        self.run_cmd_via_mavlite(frsky,
-                                 sport_to_mavlite,
-                                 mavutil.mavlink.MAV_CMD_DO_FENCE_ENABLE,
-                                 p1=1,
-                                 want_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,
+        self.run_cmd_via_mavlite(
+            frsky,
+            sport_to_mavlite,
+            mavutil.mavlink.MAV_CMD_DO_FENCE_ENABLE,
+            p1=1,
+            want_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,
         )
         self.end_subtest("Enable fence via MAVlite")
 
@@ -9054,9 +9294,9 @@ switch value'''
         )
         if gpi is None:
             raise NotAchievedException("Did not get GLOBAL_POSITION_INT message")
-        gpi_alt = round(gpi.alt*0.001)
+        gpi_alt = round(gpi.alt * 0.001)
         self.progress("GLOBAL_POSITION_INT alt==%f frsky==%f" % (gpi_alt, alt))
-        if self.compare_number_percent(gpi_alt,alt,10):
+        if self.compare_number_percent(gpi_alt, alt, 10):
             return True
         return False
 
@@ -9070,7 +9310,7 @@ switch value'''
         )
         if gpi is None:
             raise NotAchievedException("Did not get GLOBAL_POSITION_INT message")
-        gpi_alt_m = round(gpi.relative_alt*0.001)
+        gpi_alt_m = round(gpi.relative_alt * 0.001)
         self.progress("GLOBAL_POSITION_INT relative_alt==%f frsky==%f" % (gpi_alt_m, alt_m))
         if abs(gpi_alt_m - alt_m) < 1:
             return True
@@ -9088,7 +9328,7 @@ switch value'''
             raise NotAchievedException("Did not get VFR_HUD message")
         vfr_hud_speed = round(vfr_hud.groundspeed)
         self.progress("VFR_HUD groundspeed==%f frsky==%f" % (vfr_hud_speed, speed))
-        if self.compare_number_percent(vfr_hud_speed,speed,10):
+        if self.compare_number_percent(vfr_hud_speed, speed, 10):
             return True
         return False
 
@@ -9104,7 +9344,7 @@ switch value'''
             raise NotAchievedException("Did not get VFR_HUD message")
         vfr_hud_yaw = round(vfr_hud.heading)
         self.progress("VFR_HUD heading==%f frsky==%f" % (vfr_hud_yaw, yaw))
-        if self.compare_number_percent(vfr_hud_yaw,yaw,10):
+        if self.compare_number_percent(vfr_hud_yaw, yaw, 10):
             return True
         return False
 
@@ -9120,7 +9360,7 @@ switch value'''
             raise NotAchievedException("Did not get VFR_HUD message")
         vfr_hud_vspeed = round(vfr_hud.climb)
         self.progress("VFR_HUD climb==%f frsky==%f" % (vfr_hud_vspeed, vspeed))
-        if self.compare_number_percent(vfr_hud_vspeed,vspeed,10):
+        if self.compare_number_percent(vfr_hud_vspeed, vspeed, 10):
             return True
         return False
 
@@ -9137,12 +9377,12 @@ switch value'''
             raise NotAchievedException("Did not get BATTERY_STATUS message")
         battery_status_value = batt.voltages[0]/1000.0
         self.progress("BATTERY_STATUS volatge==%f frsky==%f" % (battery_status_value, voltage))
-        if self.compare_number_percent(battery_status_value,voltage,10):
+        if self.compare_number_percent(battery_status_value, voltage, 10):
             return True
         return False
 
     def tfs_validate_current1(self, value):
-        ### test frsky current vs BATTERY_STATUS
+        # test frsky current vs BATTERY_STATUS
         self.progress("validating battery1 (0x%02x)" % value)
         current = value*0.1
         batt = self.mav.recv_match(
@@ -9155,7 +9395,7 @@ switch value'''
             raise NotAchievedException("Did not get BATTERY_STATUS message")
         battery_status_current = batt.current_battery*0.01
         self.progress("BATTERY_STATUS current==%f frsky==%f" % (battery_status_current, current))
-        if self.compare_number_percent(battery_status_current,current,10):
+        if self.compare_number_percent(battery_status_current, current, 10):
             return True
         return False
 
@@ -9172,7 +9412,7 @@ switch value'''
             raise NotAchievedException("Did not get BATTERY_STATUS message")
         battery_status_fuel = batt.battery_remaining
         self.progress("BATTERY_STATUS fuel==%f frsky==%f" % (battery_status_fuel, fuel))
-        if self.compare_number_percent(battery_status_fuel,fuel,10):
+        if self.compare_number_percent(battery_status_fuel, fuel, 10):
             return True
         return False
 
@@ -9238,26 +9478,26 @@ switch value'''
             self.set_autodisarm_delay(0)
             if not self.arm_vehicle():
                 raise NotAchievedException("Failed to ARM")
-            self.set_rc(3,1050)
+            self.set_rc(3, 1050)
 
         self.drain_mav_unparsed()
         # anything with a lambda in here needs a proper test written.
         # This, at least makes sure we're getting some of each
         # message.
         wants = {
-            0x01:  self.tfs_validate_gps_alt, # gps altitude integer m
-            0x02:  self.tfs_validate_tmp1, # Tmp1
-            0x04:  self.tfs_validate_fuel, # fuel
-            0x05:  self.tfs_validate_tmp2, # Tmp2
-            0x09:  lambda x : True, # gps altitude decimal cm
-            0x10:  self.tfs_validate_baro_alt, # baro alt integer m
-            0x11:  self.tfs_validate_gps_speed, # gps speed integer m/s
-            0x14:  self.tfs_validate_yaw, # yaw in degrees
-            0x19:  lambda x : True, # gps speed decimal cm/s
-            0x21:  lambda x : True, # altitude decimal m
-            0x28:  self.tfs_validate_current1, # current A
-            0x30:  self.tfs_validate_vspeed, # vertical speed m/s
-            0x39:  self.tfs_validate_battery1, # battery 1 voltage
+            0x01: self.tfs_validate_gps_alt, # gps altitude integer m
+            0x02: self.tfs_validate_tmp1, # Tmp1
+            0x04: self.tfs_validate_fuel, # fuel
+            0x05: self.tfs_validate_tmp2, # Tmp2
+            0x09: lambda x: True, # gps altitude decimal cm
+            0x10: self.tfs_validate_baro_alt, # baro alt integer m
+            0x11: self.tfs_validate_gps_speed, # gps speed integer m/s
+            0x14: self.tfs_validate_yaw, # yaw in degrees
+            0x19: lambda x: True, # gps speed decimal cm/s
+            0x21: lambda x: True, # altitude decimal m
+            0x28: self.tfs_validate_current1, # current A
+            0x30: self.tfs_validate_vspeed, # vertical speed m/s
+            0x39: self.tfs_validate_battery1, # battery 1 voltage
             0x800: self.tf_validate_gps, # gps lat/lon
             0x50E: self.tfs_validate_rpm, # rpm 1
         }
@@ -9266,7 +9506,8 @@ switch value'''
         while len(wants):
             now = self.get_sim_time()
             if now - last_wanting_print > 1:
-                self.progress("Still wanting (%s)" % ",".join([ ("0x%02x" % x) for x in wants.keys()]))
+                self.progress("Still wanting (%s)" %
+                              ",".join([("0x%02x" % x) for x in wants.keys()]))
                 last_wanting_print = now
             wants_copy = copy.copy(wants)
             if now - tstart > 300:
@@ -9394,7 +9635,7 @@ switch value'''
         m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True, timeout=1)
         if m is None:
             raise NotAchievedException("Did not receive GLOBAL_POSITION_INT")
-        gpi_abs_alt = int(m.alt / 1000) # mm -> m
+        # gpi_abs_alt = int(m.alt / 1000) # mm -> m
 
         wants = {
             "g": self.test_ltm_g,
@@ -9405,7 +9646,7 @@ switch value'''
         tstart = self.get_sim_time_cached()
         while True:
             self.progress("Still wanting (%s)" %
-                          ",".join([ ("%s" % x) for x in wants.keys()]))
+                          ",".join([("%s" % x) for x in wants.keys()]))
             if len(wants) == 0:
                 break
             now = self.get_sim_time_cached()
@@ -9420,8 +9661,6 @@ switch value'''
                 if wants[want](ltm):
                     self.progress("  Fulfilled")
                     del wants[want]
-
-
 
     def test_crsf(self):
         self.context_push()
@@ -9570,21 +9809,26 @@ switch value'''
             msg_type = m.get_type()
             if msg_type == "ISBH":
                 if messagedata is not None:
-                    if messagedata.sensor_type == sensor_type and messagedata.instance == sensor_instance and messagedata.sample_us > since and messagedata.sample_us < until:
+                    if (messagedata.sensor_type == sensor_type and
+                            messagedata.instance == sensor_instance and
+                            messagedata.sample_us > since and
+                            messagedata.sample_us < until):
                         messages.append(messagedata)
                 messagedata = MessageData(m)
                 continue
 
             if msg_type == "ISBD":
-                if messagedata is not None and messagedata.sensor_type == sensor_type and messagedata.instance == sensor_instance:
+                if (messagedata is not None and
+                        messagedata.sensor_type == sensor_type and
+                        messagedata.instance == sensor_instance):
                     messagedata.add_fftd(m)
 
         fft_len = len(messages[0].data["X"])
         sum_fft = {
-                "X": numpy.zeros(int(fft_len/2+1)),
-                "Y": numpy.zeros(int(fft_len/2+1)),
-                "Z": numpy.zeros(int(fft_len/2+1)),
-            }
+            "X": numpy.zeros(int(fft_len / 2 + 1)),
+            "Y": numpy.zeros(int(fft_len / 2 + 1)),
+            "Z": numpy.zeros(int(fft_len / 2 + 1)),
+        }
         sample_rate = 0
         counts = 0
         window = numpy.hanning(fft_len)
@@ -9594,7 +9838,7 @@ switch value'''
         S2 = numpy.inner(window, window)
 
         for message in messages:
-            for axis in [ "X","Y","Z" ]:
+            for axis in ["X", "Y", "Z"]:
                 # normalize data and convert to dps in order to produce more meaningful magnitudes
                 if message.sensor_type == 1:
                     d = numpy.array(numpy.degrees(message.data[axis])) / float(message.multiplier)
@@ -9616,12 +9860,12 @@ switch value'''
             sample_rate = message.sample_rate_hz
             counts += 1
 
-        numpy.seterr(divide = 'ignore')
+        numpy.seterr(divide='ignore')
         psd = {}
-        for axis in [ "X","Y","Z" ]:
+        for axis in ["X", "Y", "Z"]:
             # normalize output to averaged PSD
             psd[axis] = 2 * (sum_fft[axis] / counts) / (sample_rate * S2)
-            psd[axis] = 10 * numpy.log10 (psd[axis])
+            psd[axis] = 10 * numpy.log10(psd[axis])
 
         psd["F"] = freqmap
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 
-# Drive Rover in SITL
+'''
+Drive Rover in SITL
+
+AP_FLAKE8_CLEAN
+
+'''
+
 from __future__ import print_function
 
 import copy
@@ -13,7 +19,6 @@ import time
 
 from common import AutoTest
 from pysim import util
-from pysim import vehicleinfo
 
 from common import AutoTestTimeoutException
 from common import MsgRcvTimeoutException
@@ -57,7 +62,7 @@ class AutoTestRover(AutoTest):
         return "Rover"
 
     def test_filepath(self):
-         return os.path.realpath(__file__)
+        return os.path.realpath(__file__)
 
     def set_current_test_name(self, name):
         self.current_test_name_directory = "ArduRover_Tests/" + name + "/"
@@ -320,8 +325,8 @@ class AutoTestRover(AutoTest):
                          0,  # p4
                          0,  # p5
                          0,  # p6
-                         0,  # p7
-            );
+                         0)  # p7
+
             self.progress("Testing speed-ramping")
             self.set_rc(3, 1700) # start driving forward
             self.wait_servo_channel_value(pump_ch, 1690, timeout=60, comparator=operator.gt)
@@ -333,8 +338,7 @@ class AutoTestRover(AutoTest):
                          0,  # p4
                          0,  # p5
                          0,  # p6
-                         0,  # p7
-            );
+                         0)  # p7
             self.wait_servo_channel_value(pump_ch, pump_ch_min)
             self.set_rc(3, 1000) # start driving forward
 
@@ -531,7 +535,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             if m.seq == 3:
                 break
 
-        self.drain_mav();
+        self.drain_mav()
 
         m = self.mav.recv_match(type='NAV_CONTROLLER_OUTPUT',
                                 blocking=True,
@@ -566,7 +570,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 (home_distance, home_distance_min, home_distance_max))
         self.disarm_vehicle()
         self.progress("RTL Mission OK (%fm)" % home_distance)
-
 
     def drive_fence_ac_avoidance(self):
         self.context_push()
@@ -680,7 +683,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         ex = None
         try:
             # from mavproxy_rc.py
-            mapping = [ 0, 1165, 1295, 1425, 1555, 1685, 1815 ]
+            mapping = [0, 1165, 1295, 1425, 1555, 1685, 1815]
             self.set_parameter("MODE1", 1)  # acro
             self.set_rc(8, mapping[1])
             self.wait_mode('ACRO')
@@ -957,9 +960,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 channel_field = "chan%u_raw" % ch
                 m_value = getattr(m, channel_field)
                 if m_value != ch_override_value:
-                    raise NotAchievedException("Value reverted after %f seconds when it should not have (got=%u) (want=%u)" % (delta, m_value, ch_override_value))
+                    raise NotAchievedException("Value reverted after %f seconds when it should not have (got=%u) (want=%u)" % (delta, m_value, ch_override_value))  # noqa
             self.set_parameter("RC_OVERRIDE_TIME", old)
-
 
             self.delay_sim_time(10)
 
@@ -991,7 +993,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 *channels
             )
             self.wait_rc_channel_value(ch, rc_value, timeout=10)
-
 
             channels[ch-1] = ch_override_value
             self.progress("Sending override message ch%u=%u" % (ch, ch_override_value))
@@ -1025,7 +1026,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.context_pop()
 
             self.end_subtest("Checking higher-channel semantics")
-
 
         except Exception as e:
             self.progress("Exception caught: %s" %
@@ -1083,7 +1083,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 if m.groundspeed < want_speed and m.throttle == expected_throttle:
                     break
 
-            self.progress("now override to stop - but set the switch on the RC transmitter to deny overrides; this should send the speed back up to 5 metres/second")
+            self.progress("now override to stop - but set the switch on the RC transmitter to deny overrides; this should send the speed back up to 5 metres/second")  # noqa
             self.set_rc(12, 1000)
 
             throttle_override_normalized = 500
@@ -1282,9 +1282,14 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 return True
             if (f1 == pair[1] and f2 == pair[0]):
                 return True
-        return f1 == f2;
+        return f1 == f2
 
-    def check_mission_items_same(self, check_atts, want, got, epsilon=None,skip_first_item=False):
+    def check_mission_items_same(self,
+                                 check_atts,
+                                 want,
+                                 got,
+                                 epsilon=None,
+                                 skip_first_item=False):
         self.progress("Checking mission items same")
         if epsilon is None:
             epsilon = 1
@@ -1338,7 +1343,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         downloaded_items = self.download_using_mission_protocol(mission_type)
         self.progress("Downloaded items: (%s)" % str(downloaded_items))
         if len(items) != len(downloaded_items):
-            raise NotAchievedException("Did not download same number of items as uploaded want=%u got=%u" % (len(items), len(downloaded_items)))
+            raise NotAchievedException("Did not download same number of items as uploaded want=%u got=%u" %
+                                       (len(items), len(downloaded_items)))
         if mission_type == mavutil.mavlink.MAV_MISSION_TYPE_FENCE:
             self.check_fence_items_same(items, downloaded_items)
         elif mission_type == mavutil.mavlink.MAV_MISSION_TYPE_MISSION:
@@ -1372,8 +1378,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0017 *1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # latitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -1392,8 +1398,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0017 *1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # latitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -1412,8 +1418,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0017 *1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # latitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -1432,8 +1438,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0017 *1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # latitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1448,8 +1454,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0017 *1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # latitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -1469,7 +1475,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p3
                 0, # p4
                 int(100 * 1e7), # bad latitude. bad.
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -1489,7 +1495,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p3
                 0, # p4
                 int(1.0 * 1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1505,7 +1511,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p3
                 0, # p4
                 int(2.0 * 1e7), # latitude
-                int(2.0017 *1e7), # longitude
+                int(2.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -1526,22 +1532,38 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p3
                 0, # p4
                 int(1.0 * 1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             )
         return ret
 
     def fences_which_should_not_upload(self, target_system=1, target_component=1):
-        return [ ("Bad Frame", self.fence_with_bad_frame(target_system=target_system, target_component=target_component)),
-                 ("Zero Vertex Count", self.fence_with_zero_vertex_count(target_system=target_system, target_component=target_component)),
-                 ("Wrong Vertex Count", self.fence_with_wrong_vertex_count(target_system=target_system, target_component=target_component)),
-                 ("Multiple return points", self.fence_with_multiple_return_points(target_system=target_system, target_component=target_component)),
-                 ("Invalid lat/lon", self.fence_with_invalid_latlon(target_system=target_system, target_component=target_component)),
-                 ("Multiple Return points with bad sequence numbers", self.fence_with_multiple_return_points_with_bad_sequence_numbers(target_system=target_system, target_component=target_component)),
-                 ("Fence which exceeds storage space", self.fence_which_exceeds_storage_space(target_system=target_system, target_component=target_component)),
-                 ]
-
+        return [
+            ("Bad Frame", self.fence_with_bad_frame(
+                target_system=target_system,
+                target_component=target_component)),
+            ("Zero Vertex Count", self.fence_with_zero_vertex_count(
+                target_system=target_system,
+                target_component=target_component)),
+            ("Wrong Vertex Count", self.fence_with_wrong_vertex_count(
+                target_system=target_system,
+                target_component=target_component)),
+            ("Multiple return points", self.fence_with_multiple_return_points(
+                target_system=target_system,
+                target_component=target_component)),
+            ("Invalid lat/lon", self.fence_with_invalid_latlon(
+                target_system=target_system,
+                target_component=target_component)),
+            ("Multiple Return points with bad sequence numbers",
+                 self.fence_with_multiple_return_points_with_bad_sequence_numbers(  # noqa
+                     target_system=target_system,
+                     target_component=target_component)),
+            ("Fence which exceeds storage space",
+             self.fence_which_exceeds_storage_space(
+                 target_system=target_system,
+                 target_component=target_component)),
+        ]
 
     def fence_with_single_return_point(self, target_system=1, target_component=1):
         return [
@@ -1557,12 +1579,15 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0017 *1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # latitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
-    def fence_with_single_return_point_and_5_vertex_inclusion(self, target_system=1, target_component=1):
+
+    def fence_with_single_return_point_and_5_vertex_inclusion(self,
+                                                              target_system=1,
+                                                              target_component=1):
         return [
             self.mav.mav.mission_item_int_encode(
                 target_system,
@@ -1576,8 +1601,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0017 *1e7), # latitude
-                int(1.0017 *1e7), # longitude
+                int(1.0017 * 1e7), # latitude
+                int(1.0017 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1592,8 +1617,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0000 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0000 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1608,8 +1633,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0001 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0001 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 32.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1624,8 +1649,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0001 *1e7), # latitude
-                int(1.0001 *1e7), # longitude
+                int(1.0001 * 1e7), # latitude
+                int(1.0001 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1640,8 +1665,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0002 *1e7), # latitude
-                int(1.0002 *1e7), # longitude
+                int(1.0002 * 1e7), # latitude
+                int(1.0002 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1656,8 +1681,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0002 *1e7), # latitude
-                int(1.0003 *1e7), # longitude
+                int(1.0002 * 1e7), # latitude
+                int(1.0003 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -1679,8 +1704,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(lat_deg *1e7), # latitude
-                int(lng_deg *1e7), # longitude
+                int(lat_deg * 1e7), # latitude
+                int(lng_deg * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
             ret.append(item)
@@ -1689,7 +1714,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def fence_with_many_exclusion_polyfences(self, target_system=1, target_component=1):
         ret = []
         seq = 0
-        for fencenum in range(0,4):
+        for fencenum in range(0, 4):
             pointcount = fencenum + 6
             for p in range(0, pointcount):
                 lat_deg = 1.0003 + p/10 + fencenum/100
@@ -1706,8 +1731,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     0, # p2
                     0, # p3
                     0, # p4
-                    int(lat_deg *1e7), # latitude
-                    int(lng_deg *1e7), # longitude
+                    int(lat_deg * 1e7), # latitude
+                    int(lng_deg * 1e7), # longitude
                     33.0000, # altitude
                     mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
                 ret.append(item)
@@ -1716,13 +1741,24 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def fences_which_should_upload(self, target_system=1, target_component=1):
         return [
-            ("Single Return Point", self.fence_with_single_return_point(target_system=target_system, target_component=target_component)),
-            ( "Return and 5-vertex-inclusion", self.fence_with_single_return_point_and_5_vertex_inclusion(target_system=target_system, target_component=target_component) ),
-            ( "Many exclusion circles", self.fence_with_many_exclusion_circles(target_system=target_system, target_component=target_component) ),
-            ( "Many exclusion polyfences", self.fence_with_many_exclusion_polyfences(target_system=target_system, target_component=target_component) ),
-            ( "Empty fence", [] ),
-            ]
-
+            ("Single Return Point",
+             self.fence_with_single_return_point(
+                 target_system=target_system,
+                 target_component=target_component)),
+            ("Return and 5-vertex-inclusion",
+             self.fence_with_single_return_point_and_5_vertex_inclusion(
+                 target_system=target_system,
+                 target_component=target_component)),
+            ("Many exclusion circles",
+             self.fence_with_many_exclusion_circles(
+                 target_system=target_system,
+                 target_component=target_component)),
+            ("Many exclusion polyfences",
+             self.fence_with_many_exclusion_polyfences(
+                 target_system=target_system,
+                 target_component=target_component)),
+            ("Empty fence", []),
+        ]
 
     def assert_fence_does_not_upload(self, fence, target_system=1, target_component=1):
         self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
@@ -1740,7 +1776,15 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             raise NotAchievedException("Uploaded fence when should not be possible")
         self.progress("Fence rightfully bounced")
 
-    def send_fencepoint_expect_statustext(self, offset, count, lat, lng, statustext_fragment, target_system=1, target_component=1, timeout=10):
+    def send_fencepoint_expect_statustext(self,
+                                          offset,
+                                          count,
+                                          lat,
+                                          lng,
+                                          statustext_fragment,
+                                          target_system=1,
+                                          target_component=1,
+                                          timeout=10):
         self.mav.mav.fence_point_send(target_system,
                                       target_component,
                                       offset,
@@ -1775,7 +1819,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if abs(centroid.lng - want_lng) > 0.000001:
             raise NotAchievedException("Centroid lng not as expected (want=%f got=%f)" % (want_lng, centroid.lng))
 
-
     def test_gcs_fence_update_fencepoint(self, target_system=1, target_component=1):
         self.start_subtest("Ensuring we can move a fencepoint")
         items = self.test_gcs_fence_boring_triangle(
@@ -1783,7 +1826,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             target_component=target_component)
         self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
                                            items)
-        downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
+#        downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         item_seq = 2
         item = items[item_seq]
         print("item is (%s)" % str(item))
@@ -1822,8 +1865,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0000 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0000 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1838,8 +1881,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0001 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0001 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 32.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1854,8 +1897,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0001 *1e7), # latitude
-                int(1.0001 *1e7), # longitude
+                int(1.0001 * 1e7), # latitude
+                int(1.0001 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1870,8 +1913,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.00015 *1e7), # latitude
-                int(1.00015 *1e7), # longitude
+                int(1.00015 * 1e7), # latitude
+                int(1.00015 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ])
@@ -1890,8 +1933,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0000 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0000 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1906,8 +1949,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0002 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0002 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 32.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1922,8 +1965,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0002 *1e7), # latitude
-                int(1.0001 *1e7), # longitude
+                int(1.0002 * 1e7), # latitude
+                int(1.0001 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -1938,8 +1981,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0000 *1e7), # latitude
-                int(1.0001 *1e7), # longitude
+                int(1.0000 * 1e7), # latitude
+                int(1.0001 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ])
@@ -1967,8 +2010,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             0, # p2
             0, # p3
             0, # p4
-            int(1.0017 *1e7), # latitude
-            int(1.0017 *1e7), # longitude
+            int(1.0017 * 1e7), # latitude
+            int(1.0017 * 1e7), # longitude
             0.0000, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         print("item is (%s)" % str(item))
@@ -1992,8 +2035,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             0, # p2
             0, # p3
             0, # p4
-            int(1.0017 *1e7), # latitude
-            int(1.0017 *1e7), # longitude
+            int(1.0017 * 1e7), # latitude
+            int(1.0017 * 1e7), # longitude
             0.0000, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         self.click_location_from_item(item2)
@@ -2012,14 +2055,16 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.delay_sim_time(5)
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         if len(downloaded_items) != pointcount:
-            raise NotAchievedException("Did not get expected number of points returned (want=%u got=%u)" % (pointcount, len(downloaded_items)))
+            raise NotAchievedException("Did not get expected number of points returned (want=%u got=%u)" %
+                                       (pointcount, len(downloaded_items)))
         self.end_subsubtest("fence addpoly")
 
         self.start_subsubtest("fence movepolypoint")
         self.mavproxy.send("fence clear\n")
         self.delay_sim_time(1)
-        triangle = self.test_gcs_fence_boring_triangle(target_system=target_system,
-                                                   target_component=target_component)
+        triangle = self.test_gcs_fence_boring_triangle(
+            target_system=target_system,
+            target_component=target_component)
         self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
                                            triangle)
         self.mavproxy.send("fence list\n")
@@ -2040,7 +2085,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.mavproxy.expect("fence disabled")
         self.end_subsubtest("fence enable and disable")
 
-#        MANUAL> usage: fence <addcircle|addpoly|changealt|clear|disable|draw|enable|list|load|move|movemulti|movepolypoint|param|remove|save|savecsv|savelocal|show|status|undo|update>
+#        MANUAL> usage: fence <addcircle|addpoly|changealt|clear|disable|draw|enable|list|load|move|movemulti|movepolypoint|param|remove|save|savecsv|savelocal|show|status|undo|update>  # noqa
 
     def test_gcs_fence(self):
         target_system = 1
@@ -2049,13 +2094,13 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress("Testing FENCE_POINT protocol")
 
         self.start_subtest("FENCE_TOTAL manipulation")
-        self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE);
+        self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         self.assert_parameter_value("FENCE_TOTAL", 0)
 
         self.set_parameter("FENCE_TOTAL", 5)
         self.assert_parameter_value("FENCE_TOTAL", 5)
 
-        self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE);
+        self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         self.assert_parameter_value("FENCE_TOTAL", 0)
 
         self.progress("sending out-of-range fencepoint")
@@ -2098,11 +2143,21 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 raise NotAchievedException("Unexpected lat/lon in fencepoint")
 
         self.progress("Storing a return point")
-        self.roundtrip_fencepoint_protocol(0, 5, 1.2345, 5.4321, target_system=target_system, target_component=target_component)
+        self.roundtrip_fencepoint_protocol(0,
+                                           5,
+                                           1.2345,
+                                           5.4321,
+                                           target_system=target_system,
+                                           target_component=target_component)
 
         lat = 2.345
         lng = 4.321
-        self.roundtrip_fencepoint_protocol(0, 5, lat, lng, target_system=target_system, target_component=target_component)
+        self.roundtrip_fencepoint_protocol(0,
+                                           5,
+                                           lat,
+                                           lng,
+                                           target_system=target_system,
+                                           target_component=target_component)
 
         if not self.mavproxy_can_do_mision_item_protocols():
             self.progress("MAVProxy too old to do fence point protocols")
@@ -2113,11 +2168,15 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if len(items) != 1:
             raise NotAchievedException("Unexpected fencepoint count (want=%u got=%u)" % (1, len(items)))
         if items[0].command != mavutil.mavlink.MAV_CMD_NAV_FENCE_RETURN_POINT:
-            raise NotAchievedException("Fence return point not of correct type expected (%u) got %u" % (items[0].command, mavutil.mavlink.MAV_CMD_NAV_FENCE_RETURN_POINT))
+            raise NotAchievedException(
+                "Fence return point not of correct type expected (%u) got %u" %
+                (items[0].command,
+                 mavutil.mavlink.MAV_CMD_NAV_FENCE_RETURN_POINT))
         if items[0].frame != mavutil.mavlink.MAV_FRAME_GLOBAL:
-            raise NotAchievedException("Unexpected frame want=%s got=%s," %
-                                       (self.string_for_frame(mavutil.mavlink.MAV_FRAME_GLOBAL),
-                                        self.string_for_frame(items[0].frame)))
+            raise NotAchievedException(
+                "Unexpected frame want=%s got=%s," %
+                (self.string_for_frame(mavutil.mavlink.MAV_FRAME_GLOBAL),
+                 self.string_for_frame(items[0].frame)))
         got_lat = items[0].x
         want_lat = lat * 1e7
         if abs(got_lat - want_lat) > 1:
@@ -2140,7 +2199,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if len(downloaded_items) != len(items):
             raise NotAchievedException("Did not download expected number of items (wanted=%u got=%u)" %
                                        (len(items), len(downloaded_items)))
-        self.assert_parameter_value("FENCE_TOTAL", len(items) +1)  # +1 for closing
+        self.assert_parameter_value("FENCE_TOTAL", len(items) + 1)  # +1 for closing
         self.progress("Ensuring fence items match what we sent up")
         self.check_fence_items_same(items, downloaded_items)
 
@@ -2157,8 +2216,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                            target_component=target_component)
         self.progress("Checking count post-nuke")
         self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
-                                  target_system=target_system,
-                                  target_component=target_component)
+                           target_system=target_system,
+                           target_component=target_component)
         self.assert_mission_count_on_link(self.mav,
                                           0,
                                           target_system,
@@ -2336,14 +2395,17 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             raise NotAchievedException("Unexpected target system %u want=%u" %
                                        (m.target_system, mav.mav.srcSystem))
         if m.seq != item:
-            raise NotAchievedException("Incorrect sequence number on received item got=%u want=%u" %
-            (m.seq, item))
+            raise NotAchievedException(
+                "Incorrect sequence number on received item got=%u want=%u" %
+                (m.seq, item))
         if m.mission_type != mission_type:
-            raise NotAchievedException("Mission type incorrect on received item (want=%u got=%u)" %
-                                       (mission_type, m.mission_type))
+            raise NotAchievedException(
+                "Mission type incorrect on received item (want=%u got=%u)" %
+                (mission_type, m.mission_type))
         if m.target_component != mav.mav.srcComponent:
-            raise NotAchievedException("Unexpected target component %u want=%u" %
-                                       (m.target_component, mav.mav.srcComponent))
+            raise NotAchievedException(
+                "Unexpected target component %u want=%u" %
+                (m.target_component, mav.mav.srcComponent))
         return m
 
     def get_mission_item_on_link(self, item, mav, target_system, target_component, mission_type):
@@ -2362,7 +2424,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                        (m.target_system, mav.mav.srcSystem))
         if m.seq != item:
             raise NotAchievedException("Incorrect sequence number on received item_int got=%u want=%u" %
-            (m.seq, item))
+                                       (m.seq, item))
         if m.mission_type != mission_type:
             raise NotAchievedException("Mission type incorrect on received item_int (want=%u got=%u)" %
                                        (mission_type, m.mission_type))
@@ -2423,7 +2485,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def mavproxy_can_do_mision_item_protocols(self):
         return False
-        mavproxy_version = self.mavproxy_version()
         if not self.mavproxy_version_gt(1, 8, 12):
             self.progress("MAVProxy is too old; skipping tests")
             return False
@@ -2476,12 +2537,12 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if len(downloaded_items) != 1:
             raise NotAchievedException("Unexpected count (got=%u want=1)" %
                                        (len(downloaded_items), ))
-        if (downloaded_items[0].x - int(lat *1e7)) > 1:
+        if (downloaded_items[0].x - int(lat * 1e7)) > 1:
             raise NotAchievedException("Bad rally lat.  Want=%d got=%d" %
-                                       (int(lat*1e7), downloaded_items[0].x))
-        if (downloaded_items[0].y - int(lng *1e7)) > 1:
+                                       (int(lat * 1e7), downloaded_items[0].x))
+        if (downloaded_items[0].y - int(lng * 1e7)) > 1:
             raise NotAchievedException("Bad rally lng.  Want=%d got=%d" %
-                                       (int(lng*1e7), downloaded_items[0].y))
+                                       (int(lng * 1e7), downloaded_items[0].y))
         if (downloaded_items[0].z - int(90)) > 1:
             raise NotAchievedException("Bad rally alt.  Want=90 got=%d" %
                                        (downloaded_items[0].y))
@@ -2490,7 +2551,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.start_subsubtest("rally list")
         util.pexpect_drain(self.mavproxy)
         self.mavproxy.send('rally list\n')
-        self.mavproxy.expect("Saved 1 rally items to ([^\s]*)\s")
+        self.mavproxy.expect(r"Saved 1 rally items to ([^\s]*)\s")
         filename = self.mavproxy.match.group(1)
         self.assert_rally_filepath_content(filename, '''QGC WPL 110
 0	0	3	5100	0.000000	0.000000	0.000000	0.000000	-5.678900	98.234100	90.000000	0
@@ -2501,7 +2562,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         util.pexpect_drain(self.mavproxy)
         save_tmppath = self.buildlogs_path("rally-testing-tmp.txt")
         self.mavproxy.send('rally save %s\n' % save_tmppath)
-        self.mavproxy.expect("Saved 1 rally items to ([^\s]*)\s")
+        self.mavproxy.expect(r"Saved 1 rally items to ([^\s]*)\s")
         filename = self.mavproxy.match.group(1)
         if filename != save_tmppath:
             raise NotAchievedException("Bad save filepath; want=%s got=%s" % (save_tmppath, filename))
@@ -2509,7 +2570,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 0	0	3	5100	0.000000	0.000000	0.000000	0.000000	-5.678900	98.234100	90.000000	0
 ''')
         self.end_subsubtest("rally save")
-
 
         self.start_subsubtest("rally savecsv")
         util.pexpect_drain(self.mavproxy)
@@ -2540,15 +2600,17 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # warning: uses file saved from previous test
         self.start_subtest("Check rally load from filepath")
         self.mavproxy.send('rally load %s\n' % save_tmppath)
-        self.mavproxy.expect("Loaded 1 rally items from ([^\s]*)\s")
+        self.mavproxy.expect(r"Loaded 1 rally items from ([^\s]*)\s")
         self.mavproxy.expect("Sent all .* rally items") # notional race condition here
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         if len(downloaded_items) != 1:
             raise NotAchievedException("Unexpected item count (%u)" % len(downloaded_items))
-        if abs(int(downloaded_items[0].x) - int(lat*1e7)) > 3:
-            raise NotAchievedException("Expected lat=%d got=%d" % (lat*1e7, downloaded_items[0].x))
-        if abs(int(downloaded_items[0].y) - int(lng*1e7)) > 10:
-            raise NotAchievedException("Expected lng=%d got=%d" % (lng*1e7, downloaded_items[0].y))
+        if abs(int(downloaded_items[0].x) - int(lat * 1e7)) > 3:
+            raise NotAchievedException("Expected lat=%d got=%d" %
+                                       (lat * 1e7, downloaded_items[0].x))
+        if abs(int(downloaded_items[0].y) - int(lng * 1e7)) > 10:
+            raise NotAchievedException("Expected lng=%d got=%d" %
+                                       (lng * 1e7, downloaded_items[0].y))
         self.end_subsubtest("rally load")
 
         self.start_subsubtest("rally changealt")
@@ -2579,19 +2641,19 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         if len(downloaded_items) != 2:
             raise NotAchievedException("Unexpected item count (%u)" % len(downloaded_items))
-        if abs(int(downloaded_items[0].x) - int(1*1e7)) > 3:
-            raise NotAchievedException("Expected lat=%d got=%d" % (1*1e7, downloaded_items[0].x))
-        if abs(int(downloaded_items[0].y) - int(1*1e7)) > 10:
-            raise NotAchievedException("Expected lng=%d got=%d" % (1*1e7, downloaded_items[0].y))
+        if abs(int(downloaded_items[0].x) - int(1 * 1e7)) > 3:
+            raise NotAchievedException("Expected lat=%d got=%d" % (1 * 1e7, downloaded_items[0].x))
+        if abs(int(downloaded_items[0].y) - int(1 * 1e7)) > 10:
+            raise NotAchievedException("Expected lng=%d got=%d" % (1 * 1e7, downloaded_items[0].y))
         # at some stage ArduPilot will stop rounding altitude.  This
         # will break then.
         if abs(int(downloaded_items[0].z) - int(17.6)) > 0.0001:
             raise NotAchievedException("Expected alt=%f got=%f" % (17.6, downloaded_items[0].z))
 
-        if abs(int(downloaded_items[1].x) - int(2*1e7)) > 3:
-            raise NotAchievedException("Expected lat=%d got=%d" % (2*1e7, downloaded_items[0].x))
-        if abs(int(downloaded_items[1].y) - int(2*1e7)) > 10:
-            raise NotAchievedException("Expected lng=%d got=%d" % (2*1e7, downloaded_items[0].y))
+        if abs(int(downloaded_items[1].x) - int(2 * 1e7)) > 3:
+            raise NotAchievedException("Expected lat=%d got=%d" % (2 * 1e7, downloaded_items[0].x))
+        if abs(int(downloaded_items[1].y) - int(2 * 1e7)) > 10:
+            raise NotAchievedException("Expected lng=%d got=%d" % (2 * 1e7, downloaded_items[0].y))
         # at some stage ArduPilot will stop rounding altitude.  This
         # will break then.
         if abs(int(downloaded_items[1].z) - int(19.1)) > 0.0001:
@@ -2606,19 +2668,19 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if len(downloaded_items) != 2:
             raise NotAchievedException("Unexpected item count (%u)" % len(downloaded_items))
 
-        if abs(int(downloaded_items[0].x) - int(1*1e7)) > 3:
-            raise NotAchievedException("Expected lat=%d got=%d" % (1*1e7, downloaded_items[0].x))
-        if abs(int(downloaded_items[0].y) - int(1*1e7)) > 10:
-            raise NotAchievedException("Expected lng=%d got=%d" % (1*1e7, downloaded_items[0].y))
+        if abs(int(downloaded_items[0].x) - int(1 * 1e7)) > 3:
+            raise NotAchievedException("Expected lat=%d got=%d" % (1 * 1e7, downloaded_items[0].x))
+        if abs(int(downloaded_items[0].y) - int(1 * 1e7)) > 10:
+            raise NotAchievedException("Expected lng=%d got=%d" % (1 * 1e7, downloaded_items[0].y))
         # at some stage ArduPilot will stop rounding altitude.  This
         # will break then.
         if abs(int(downloaded_items[0].z) - int(17.3)) > 0.0001:
             raise NotAchievedException("Expected alt=%f got=%f" % (17.3, downloaded_items[0].z))
 
-        if abs(int(downloaded_items[1].x) - int(2*1e7)) > 3:
-            raise NotAchievedException("Expected lat=%d got=%d" % (2*1e7, downloaded_items[0].x))
-        if abs(int(downloaded_items[1].y) - int(2*1e7)) > 10:
-            raise NotAchievedException("Expected lng=%d got=%d" % (2*1e7, downloaded_items[0].y))
+        if abs(int(downloaded_items[1].x) - int(2 * 1e7)) > 3:
+            raise NotAchievedException("Expected lat=%d got=%d" % (2 * 1e7, downloaded_items[0].x))
+        if abs(int(downloaded_items[1].y) - int(2 * 1e7)) > 10:
+            raise NotAchievedException("Expected lng=%d got=%d" % (2 * 1e7, downloaded_items[0].y))
         # at some stage ArduPilot will stop rounding altitude.  This
         # will break then.
         if abs(int(downloaded_items[1].z) - int(17.3)) > 0.0001:
@@ -2851,7 +2913,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.start_subsubtest("rally update")
         self.click_three_in(target_system=target_system, target_component=target_component)
         pure_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
-        rally_update_tmpfilepath= self.buildlogs_path("rally-tmp-update.txt")
+        rally_update_tmpfilepath = self.buildlogs_path("rally-tmp-update.txt")
         self.mavproxy.send("rally save %s\n" % rally_update_tmpfilepath)
         self.delay_sim_time(5)
         self.progress("Moving waypoint")
@@ -2882,7 +2944,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.end_subsubtest("rally update")
 
-# MANUAL> usage: rally <add|alt|changealt|clear|list|load|move|movemulti|param|remove|save|savecsv|savelocal|show|status|undo|update>
+# MANUAL> usage: rally <add|alt|changealt|clear|list|load|move|movemulti|param|remove|save|savecsv|savelocal|show|status|undo|update>  # noqa
 
     def test_gcs_rally(self):
         target_system = 1
@@ -2905,7 +2967,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.mavproxy.expect("Unloaded module wp")
         self.drain_mav()
         try:
-            item1_lat = int(2.0000 *1e7)
+            item1_lat = int(2.0000 * 1e7)
             items = [
                 self.mav.mav.mission_item_int_encode(
                     target_system,
@@ -2919,8 +2981,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     0, # p2
                     0, # p3
                     0, # p4
-                    int(1.0000 *1e7), # latitude
-                    int(1.0000 *1e7), # longitude
+                    int(1.0000 * 1e7), # latitude
+                    int(1.0000 * 1e7), # longitude
                     31.0000, # altitude
                     mavutil.mavlink.MAV_MISSION_TYPE_RALLY),
                 self.mav.mav.mission_item_int_encode(
@@ -2936,7 +2998,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     0, # p3
                     0, # p4
                     item1_lat, # latitude
-                    int(2.0000 *1e7), # longitude
+                    int(2.0000 * 1e7), # longitude
                     32.0000, # altitude
                     mavutil.mavlink.MAV_MISSION_TYPE_RALLY),
                 self.mav.mav.mission_item_int_encode(
@@ -2951,8 +3013,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     0, # p2
                     0, # p3
                     0, # p4
-                    int(3.0000 *1e7), # latitude
-                    int(3.0000 *1e7), # longitude
+                    int(3.0000 * 1e7), # latitude
+                    int(3.0000 * 1e7), # longitude
                     33.0000, # altitude
                     mavutil.mavlink.MAV_MISSION_TYPE_RALLY),
             ]
@@ -2961,36 +3023,45 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             downloaded = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             print("Got items (%s)" % str(items))
             if len(downloaded) != len(items):
-                raise NotAchievedException("Did not download correct number of items want=%u got=%u" % (len(downloaded), len(items)))
+                raise NotAchievedException(
+                    "Did not download correct number of items want=%u got=%u" %
+                    (len(downloaded), len(items)))
 
             rally_total = self.get_parameter("RALLY_TOTAL")
             if rally_total != len(downloaded):
-                raise NotAchievedException("Unexpected rally point count: want=%u got=%u" % (len(items), rally_total))
+                raise NotAchievedException(
+                    "Unexpected rally point count: want=%u got=%u" %
+                    (len(items), rally_total))
 
             self.progress("Pruning count by setting parameter (urgh)")
             self.set_parameter("RALLY_TOTAL", 2)
             downloaded = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             if len(downloaded) != 2:
-                raise NotAchievedException("Failed to prune rally points by setting parameter.  want=%u got=%u" % (2, len(downloaded)))
+                raise NotAchievedException(
+                    "Failed to prune rally points by setting parameter.  want=%u got=%u" %
+                    (2, len(downloaded)))
 
             self.progress("Uploading a third item using old protocol")
-            new_item2_lat = int(6.0 *1e7)
+            new_item2_lat = int(6.0 * 1e7)
             self.set_parameter("RALLY_TOTAL", 3)
             self.mav.mav.rally_point_send(target_system,
                                           target_component,
                                           2, # sequence number
                                           3, # total count
                                           new_item2_lat,
-                                          int(7.0 *1e7),
+                                          int(7.0 * 1e7),
                                           15,
                                           0, # "break" alt?!
                                           0, # "land dir"
                                           0) # flags
             downloaded = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             if len(downloaded) != 3:
-                raise NotAchievedException("resetting rally point count didn't change items returned")
+                raise NotAchievedException(
+                    "resetting rally point count didn't change items returned")
             if downloaded[2].x != new_item2_lat:
-                raise NotAchievedException("Bad lattitude in downloaded item: want=%u got=%u" % (new_item2_lat, downloaded[2].x))
+                raise NotAchievedException(
+                    "Bad lattitude in downloaded item: want=%u got=%u" %
+                    (new_item2_lat, downloaded[2].x))
 
             self.progress("Grabbing original item 1 using original protocol")
             self.mav.mav.rally_fetch_point_send(target_system,
@@ -2998,7 +3069,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                                 1)
             m = self.mav.recv_match(type="RALLY_POINT", blocking=True, timeout=1)
             if m.target_system != self.mav.source_system:
-                raise NotAchievedException("Bad target_system on received rally point (want=%u got=%u)" % (255, m.target_system))
+                raise NotAchievedException(
+                    "Bad target_system on received rally point (want=%u got=%u)" %
+                    (255, m.target_system))
             if m.target_component != self.mav.source_component: # autotest's component ID
                 raise NotAchievedException("Bad target_component on received rally point")
             if m.lat != item1_lat:
@@ -3041,7 +3114,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     break
                 if self.get_sim_time_cached() - tstart > 100:
                     raise NotAchievedException("Did not get both ack and statustext")
-                m = self.mav.recv_match(type=['STATUSTEXT','MISSION_ACK'], blocking=True, timeout=1)
+                m = self.mav.recv_match(type=['STATUSTEXT', 'MISSION_ACK'],
+                                        blocking=True,
+                                        timeout=1)
                 if m is None:
                     continue
                 self.progress("Got (%s)" % str(m))
@@ -3078,7 +3153,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.reboot_sitl()
             mav2 = mavutil.mavlink_connection("tcp:localhost:5763",
                                               robust_parsing=True,
-                                              source_system = 7,
+                                              source_system=7,
                                               source_component=7)
             mav2.mav.mission_request_list_send(target_system,
                                                target_component,
@@ -3094,13 +3169,33 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.set_parameter("SERIAL2_PROTOCOL", 2)
             expected_count = 3
             self.progress("Assert mission count on new link")
-            self.assert_mission_count_on_link(mav2, expected_count, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            self.assert_mission_count_on_link(
+                mav2,
+                expected_count,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             self.progress("Assert mission count on original link")
-            self.assert_mission_count_on_link(self.mav, expected_count, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            self.assert_mission_count_on_link(
+                self.mav,
+                expected_count,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             self.progress("Get first item on new link")
-            m2 = self.get_mission_item_int_on_link(2, mav2, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            m2 = self.get_mission_item_int_on_link(
+                2,
+                mav2,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             self.progress("Get first item on original link")
-            m = self.get_mission_item_int_on_link(2, self.mav, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            m = self.get_mission_item_int_on_link(
+                2,
+                self.mav,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             if m2.x != m.x:
                 raise NotAchievedException("mission items do not match (%d vs %d)" % (m2.x, m.x))
             self.get_mission_item_on_link(2, self.mav, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
@@ -3217,8 +3312,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.1000 *1e7), # latitude
-                int(1.2000 *1e7), # longitude
+                int(1.1000 * 1e7), # latitude
+                int(1.2000 * 1e7), # longitude
                 321.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
             self.assert_receive_mission_item_request(mavutil.mavlink.MAV_MISSION_TYPE_MISSION, 1)
@@ -3257,8 +3352,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.1000 *1e7), # latitude
-                int(1.2000 *1e7), # longitude
+                int(1.1000 * 1e7), # latitude
+                int(1.2000 * 1e7), # longitude
                 321.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
             self.assert_receive_mission_item_request(mavutil.mavlink.MAV_MISSION_TYPE_MISSION, 2)
@@ -3277,8 +3372,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.1000 *1e7), # latitude
-                int(1.2000 *1e7), # longitude
+                int(1.1000 * 1e7), # latitude
+                int(1.2000 * 1e7), # longitude
                 321.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
             self.assert_receive_mission_ack(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
@@ -3335,8 +3430,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.1000 *1e7), # latitude
-                int(1.2000 *1e7), # longitude
+                int(1.1000 * 1e7), # latitude
+                int(1.2000 * 1e7), # longitude
                 321.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_RALLY),
             self.assert_receive_mission_ack(mavutil.mavlink.MAV_MISSION_TYPE_RALLY,
@@ -3356,15 +3451,15 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.1000 *1e7), # latitude
-                int(1.2000 *1e7), # longitude
+                int(1.1000 * 1e7), # latitude
+                int(1.2000 * 1e7), # longitude
                 321.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_RALLY),
             self.assert_receive_mission_ack(mavutil.mavlink.MAV_MISSION_TYPE_RALLY,
                                             want_type=mavutil.mavlink.MAV_MISSION_INVALID_SEQUENCE)
 
             self.progress("Now provide correct item")
-            item1_latitude = int(1.2345*1e7)
+            item1_latitude = int(1.2345 * 1e7)
             self.drain_mav(unparsed=True)
             self.mav.mav.mission_item_int_send(
                 target_system,
@@ -3379,7 +3474,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p3
                 0, # p4
                 item1_latitude, # latitude
-                int(1.2000 *1e7), # longitude
+                int(1.2000 * 1e7), # longitude
                 321.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_RALLY),
             self.assert_receive_mission_item_request(mavutil.mavlink.MAV_MISSION_TYPE_RALLY, 2)
@@ -3391,18 +3486,48 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.progress("TODO: ensure partial mission write was good")
 
             self.start_subtest("clear mission types")
-            self.assert_mission_count_on_link(self.mav, 3, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
-            self.assert_mission_count_on_link(self.mav, 3, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
+            self.assert_mission_count_on_link(
+                self.mav,
+                3,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            self.assert_mission_count_on_link(
+                self.mav,
+                3,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
             self.drain_mav(unparsed=True)
             self.mav.mav.mission_clear_all_send(target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
             self.assert_receive_mission_ack(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
-            self.assert_mission_count_on_link(self.mav, 0, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
-            self.assert_mission_count_on_link(self.mav, 3, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
+            self.assert_mission_count_on_link(
+                self.mav,
+                0,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            self.assert_mission_count_on_link(
+                self.mav,
+                3,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
             self.drain_mav(unparsed=True)
             self.mav.mav.mission_clear_all_send(target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
             self.assert_receive_mission_ack(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
-            self.assert_mission_count_on_link(self.mav, 0, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
-            self.assert_mission_count_on_link(self.mav, 0, target_system, target_component, mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
+            self.assert_mission_count_on_link(
+                self.mav,
+                0,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
+            self.assert_mission_count_on_link(
+                self.mav,
+                0,
+                target_system,
+                target_component,
+                mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
 
             self.start_subtest("try sending out-of-range counts")
             self.drain_mav(unparsed=True)
@@ -3457,12 +3582,12 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.start_subsubtest("wp changealt")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         changealt_item = 1
-        oldalt = downloaded_items[changealt_item].z
+#        oldalt = downloaded_items[changealt_item].z
         want_newalt = 37.2
         self.mavproxy.send('wp changealt %u %f\n' % (changealt_item, want_newalt))
         self.delay_sim_time(5)
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
-        if abs(downloaded_items[changealt_item].z -  want_newalt) > 0.0001:
+        if abs(downloaded_items[changealt_item].z - want_newalt) > 0.0001:
             raise NotAchievedException(
                 "changealt didn't (want=%f got=%f)" %
                 (want_newalt, downloaded_items[changealt_item].z))
@@ -3511,8 +3636,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0 *1e7), # latitude
-                int(1.0 *1e7), # longitude
+                int(1.0 * 1e7), # latitude
+                int(1.0 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
             self.mav.mav.mission_item_int_encode(
@@ -3527,8 +3652,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(2.0 *1e7), # latitude
-                int(2.0 *1e7), # longitude
+                int(2.0 * 1e7), # latitude
+                int(2.0 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
         ]
@@ -3560,8 +3685,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.5 *1e7), # latitude
-                int(1.5 *1e7), # longitude
+                int(1.5 * 1e7), # latitude
+                int(1.5 * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
             items[2],
@@ -3570,7 +3695,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.check_mission_waypoint_items_same(items_with_split_in,
                                                downloaded_items)
 
-        # MANUAL> usage: wp <changealt|clear|draw|editor|list|load|loop|move|movemulti|noflyadd|param|remove|save|savecsv|savelocal|set|sethome|show|slope|split|status|undo|update>
+        # MANUAL> usage: wp <changealt|clear|draw|editor|list|load|loop|move|movemulti|noflyadd|param|remove|save|savecsv|savelocal|set|sethome|show|slope|split|status|undo|update>  # noqa
 
     def wait_location_sending_target(self, loc, target_system=1, target_component=1, timeout=60, max_delta=2):
         tstart = self.get_sim_time()
@@ -3599,8 +3724,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     target_component,
                     mavutil.mavlink.MAV_FRAME_GLOBAL_INT,
                     type_mask,
-                    int(loc.lat*1.0e7),
-                    int(loc.lng*1.0e7),
+                    int(loc.lat * 1.0e7),
+                    int(loc.lng * 1.0e7),
                     0, # alt
                     0, # x-ve
                     0, # y-vel
@@ -3620,8 +3745,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 self.progress("Target: (%s)" % str(m), send_statustext=False)
             elif t == "GLOBAL_POSITION_INT":
                 self.progress("Position: (%s)" % str(m), send_statustext=False)
-                delta = self.get_distance(mavutil.location(m.lat*1e-7, m.lon*1e-7, 0, 0),
-                                          loc)
+                delta = self.get_distance(
+                    mavutil.location(m.lat * 1e-7, m.lon * 1e-7, 0, 0),
+                    loc)
                 self.progress("delta: %s" % str(delta), send_statustext=False)
                 if delta < max_delta:
                     self.progress("Reached destination")
@@ -3653,8 +3779,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     target_component,
                     mavutil.mavlink.MAV_FRAME_GLOBAL_INT,
                     type_mask,
-                    int(loc.lat*1.0e7),
-                    int(loc.lng*1.0e7),
+                    int(loc.lat * 1.0e7),
+                    int(loc.lng * 1.0e7),
                     0, # alt
                     0, # x-ve
                     0, # y-vel
@@ -3694,7 +3820,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                          timeout=120):
         tstart = self.get_sim_time()
         last_sent = 0
-        seen_fence_breach = False
 
         type_mask = (mavutil.mavlink.POSITION_TARGET_TYPEMASK_VX_IGNORE +
                      mavutil.mavlink.POSITION_TARGET_TYPEMASK_VY_IGNORE +
@@ -3719,8 +3844,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     target_component,
                     mavutil.mavlink.MAV_FRAME_GLOBAL_INT,
                     type_mask,
-                    int(loc.lat*1.0e7),
-                    int(loc.lng*1.0e7),
+                    int(loc.lat * 1.0e7),
+                    int(loc.lng * 1.0e7),
                     0, # alt
                     0, # x-ve
                     0, # y-vel
@@ -3740,8 +3865,12 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 print("Target: (%s)" % str(m))
             elif t == "GLOBAL_POSITION_INT":
                 print("Position: (%s)" % str(m))
-                delta = self.get_distance(mavutil.location(m.lat*1e-7, m.lon*1e-7, 0, 0),
-                                          mavutil.location(expected_stopping_point.lat, expected_stopping_point.lng, 0, 0))
+                delta = self.get_distance(
+                    mavutil.location(m.lat * 1e-7, m.lon * 1e-7, 0, 0),
+                    mavutil.location(expected_stopping_point.lat,
+                                     expected_stopping_point.lng,
+                                     0,
+                                     0))
                 print("delta: %s want_delta<%f" % (str(delta), expected_distance_epsilon))
                 at_stopping_point = delta < expected_distance_epsilon
             elif t == "VFR_HUD":
@@ -3816,8 +3945,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(here.lat*1e7), # latitude
-                int(here.lng*1e7), # longitude
+                int(here.lat * 1e7), # latitude
+                int(here.lng * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -3832,8 +3961,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(self.offset_location_ne(here, 100, 100).lat*1e7), # latitude
-                int(here.lng*1e7), # longitude
+                int(self.offset_location_ne(here, 100, 100).lat * 1e7), # latitude
+                int(here.lng * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
         ]
@@ -3868,8 +3997,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(here.lat*1e7), # latitude
-                int(here.lng*1e7), # longitude
+                int(here.lat * 1e7), # latitude
+                int(here.lng * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
             self.mav.mav.mission_item_int_encode(
@@ -3884,11 +4013,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(self.offset_location_ne(here, 100, 100).lat*1e7), # latitude
-                int(here.lng*1e7), # longitude
+                int(self.offset_location_ne(here, 100, 100).lat * 1e7), # latitude
+                int(here.lng * 1e7), # longitude
                 33.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_FENCE),
-        ];
+        ]
         self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
                                            items)
         self.delay_sim_time(5) # ArduPilot only checks for breaches @1Hz
@@ -4050,7 +4179,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if m.target_component != self.mav.mav.srcComponent:
             raise NotAchievedException("Incorrect target component in MISSION_REQUEST")
 
-
     def test_fence_upload_timeouts_2(self, target_system=1, target_component=1):
         self.start_subtest("fence upload timeouts 2")
         self.progress("Telling victim there will be two items coming")
@@ -4078,8 +4206,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             0, # p2
             0, # p3
             0, # p4
-            int(1.1 *1e7), # latitude
-            int(1.2 *1e7), # longitude
+            int(1.1 * 1e7), # latitude
+            int(1.2 * 1e7), # longitude
             33.0000, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         self.expect_request_for_item(item)
@@ -4099,8 +4227,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             0, # p2
             0, # p3
             0, # p4
-            int(1.1 *1e7), # latitude
-            int(1.2 *1e7), # longitude
+            int(1.1 * 1e7), # latitude
+            int(1.2 * 1e7), # longitude
             33.0000, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
 
@@ -4252,7 +4380,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 self.offset_location_ne(here, 50, 40), # tr
                 self.offset_location_ne(here, -50, 40), # tl,
                 self.offset_location_ne(here, -50, 20), # closing point
-                ])
+            ])
         self.roundtrip_fence_using_fencepoint_protocol(
             [
                 self.offset_location_ne(here, 0, 0), # bl // return point
@@ -4260,7 +4388,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 self.offset_location_ne(here, 50, 20), # br
                 self.offset_location_ne(here, -50, 40), # tl,
                 self.offset_location_ne(here, -50, 20), # closing point
-                ])
+            ])
         self.roundtrip_fence_using_fencepoint_protocol(
             [
                 self.offset_location_ne(here, 0, 0), # bl // return point
@@ -4269,7 +4397,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 self.offset_location_ne(here, 50, 40), # tr
                 self.offset_location_ne(here, -50, 40), # tl,
                 self.offset_location_ne(here, -50, 20), # closing point
-                ])
+            ])
 
     def test_poly_fence_reboot_survivability(self):
         here = self.mav.location()
@@ -4326,7 +4454,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.test_poly_fence_reboot_survivability()
 
-
     def test_poly_fence_inclusion_overlapping_inclusion_circles(self, here, target_system=1, target_component=1):
         self.start_subtest("Overlapping circular inclusion")
         self.upload_fences_from_locations(
@@ -4361,7 +4488,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def test_poly_fence_inclusion(self, here, target_system=1, target_component=1):
         self.progress("Circle and Polygon inclusion")
-        self.test_poly_fence_inclusion_overlapping_inclusion_circles(here, target_system=target_system, target_component=target_component)
+        self.test_poly_fence_inclusion_overlapping_inclusion_circles(
+            here,
+            target_system=target_system,
+            target_component=target_component)
 
         self.upload_fences_from_locations(
             mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION,
@@ -4476,7 +4606,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                                      target_system=target_system,
                                                      target_component=target_component)
 
-
     def drive_smartrtl(self):
         self.change_mode("STEERING")
         self.wait_ready_to_arm()
@@ -4511,14 +4640,15 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def test_motor_test(self):
         '''AKA run-rover-run'''
         magic_throttle_value = 1812
-        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST,
-                     1, # p1 - motor instance
-                     mavutil.mavlink.MOTOR_TEST_THROTTLE_PWM, # p2 - throttle type
-                     magic_throttle_value, # p3 - throttle
-                     5, # p4 - timeout
-                     1, # p5 - motor count
-                     0, # p6 - test order (see MOTOR_TEST_ORDER)
-                     0, # p7
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST,
+            1, # p1 - motor instance
+            mavutil.mavlink.MOTOR_TEST_THROTTLE_PWM, # p2 - throttle type
+            magic_throttle_value, # p3 - throttle
+            5, # p4 - timeout
+            1, # p5 - motor count
+            0, # p6 - test order (see MOTOR_TEST_ORDER)
+            0, # p7
         )
         self.wait_armed()
         self.progress("Waiting for magic throttle value")
@@ -4570,7 +4700,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             raise ex
 
     def send_guided_mission_item(self, loc, target_system=1, target_component=1):
-        self.mav.mav.mission_item_send (
+        self.mav.mav.mission_item_send(
             target_system,
             target_component,
             0,
@@ -4795,8 +4925,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def test_poly_fence_object_avoidance_bendy_ruler_easier(self, target_system=1, target_component=1):
         if not self.mavproxy_can_do_mision_item_protocols():
             return
-        self.test_poly_fence_object_avoidance_auto_bendy_ruler_easier(target_system=target_system, target_component=target_component)
-        self.test_poly_fence_object_avoidance_guided_bendy_ruler_easier(target_system=target_system, target_component=target_component)
+        self.test_poly_fence_object_avoidance_auto_bendy_ruler_easier(
+            target_system=target_system, target_component=target_component)
+        self.test_poly_fence_object_avoidance_guided_bendy_ruler_easier(
+            target_system=target_system, target_component=target_component)
 
     def test_poly_fence_object_avoidance_guided_bendy_ruler_easier(self, target_system=1, target_component=1):
         '''finish-line issue means we can't complete the harder one.  This
@@ -4936,6 +5068,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         ex = None
         example_script = "simple_loop.lua"
         messages = []
+
         def my_message_hook(mav, message):
             if message.get_type() != 'STATUSTEXT':
                 return
@@ -4970,10 +5103,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def test_scripting_internal_test(self):
         self.start_subtest("Scripting internal test")
         ex = None
-        test_scripts = ["scripting_test.lua","math.lua","strings.lua"]
-        success_text = ["Internal tests passed","Math tests passed","String tests passed"]
+        test_scripts = ["scripting_test.lua", "math.lua", "strings.lua"]
+        success_text = ["Internal tests passed", "Math tests passed", "String tests passed"]
 
         messages = []
+
         def my_message_hook(mav, message):
             if message.get_type() != 'STATUSTEXT':
                 return
@@ -5010,7 +5144,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     script_success = True
             success = script_success and success
         self.progress("Success")
-        if not success :
+        if not success:
             raise NotAchievedException("Scripting internal test failed")
 
     def test_scripting_hello_world(self):
@@ -5094,8 +5228,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0000 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0000 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
             self.mav.mav.mission_item_int_encode(
@@ -5110,8 +5244,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # p2
                 0, # p3
                 0, # p4
-                int(1.0000 *1e7), # latitude
-                int(1.0000 *1e7), # longitude
+                int(1.0000 * 1e7), # latitude
+                int(1.0000 * 1e7), # longitude
                 31.0000, # altitude
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
         ]
@@ -5154,7 +5288,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             increment_f,
             data["angle_offset"],
             mavutil.mavlink.MAV_FRAME_BODY_FRD
-        );
+        )
 
     def send_obstacle_distances_expect_distance_sensor_messages(self, obstacle_distances_in, expect_distance_sensor_messages):
         self.delay_sim_time(11)  # allow obstacles to time out
@@ -5185,7 +5319,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     self.progress("Marking message as found")
                     expected_distance_sensor_message["__found__"] = True
                 if (m.current_distance - expected_distance_sensor_message["distance"] > 1):
-                    raise NotAchievedException("Bad distance for orient=%u want=%u got=%u" % (orientation, expected_distance_sensor_message["distance"], m.current_distance))
+                    raise NotAchievedException(
+                        "Bad distance for orient=%u want=%u got=%u" %
+                        (orientation, expected_distance_sensor_message["distance"], m.current_distance))
                 break
             if not found:
                 raise NotAchievedException("Got unexpected DISTANCE_SENSOR message")
@@ -5211,32 +5347,31 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             # 1 laser pointing straight forward:
             self.send_obstacle_distances_expect_distance_sensor_messages(
                 {
-                    "distances": [ 234 ],
+                    "distances": [234],
                     "increment_f": 10,
                     "angle_offset": 0.0,
                     "min_distance": 0,
                     "max_distance": 1000, # cm
                 }, [
-                { "orientation": 0, "distance": 234 },
-            ])
-
+                    {"orientation": 0, "distance": 234},
+                ])
 
             # 5 lasers at front of vehicle, spread over 40 degrees:
             self.send_obstacle_distances_expect_distance_sensor_messages(
                 {
-                    "distances": [ 111, 222, 333, 444, 555 ],
+                    "distances": [111, 222, 333, 444, 555],
                     "increment_f": 10,
                     "angle_offset": -20.0,
                     "min_distance": 0,
                     "max_distance": 1000, # cm
                 }, [
-                { "orientation": 0, "distance": 111 },
-            ])
+                    {"orientation": 0, "distance": 111},
+                ])
 
             # lots of dense readings (e.g. vision camera:
             distances = [0] * 72
             for i in range(0, 72):
-                distances[i] = 1000 + 10*abs(36-i);
+                distances[i] = 1000 + 10*abs(36-i)
 
             self.send_obstacle_distances_expect_distance_sensor_messages(
                 {
@@ -5246,10 +5381,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     "min_distance": 0,
                     "max_distance": 2000, # cm
                 }, [
-                { "orientation": 0, "distance": 1000 },
-                { "orientation": 1, "distance": 1190 },
-                { "orientation": 7, "distance": 1190 },
-            ])
+                    {"orientation": 0, "distance": 1000},
+                    {"orientation": 1, "distance": 1190},
+                    {"orientation": 7, "distance": 1190},
+                ])
 
         except Exception as e:
             self.progress("Caught exception: %s" %
@@ -5306,7 +5441,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.customise_SITL_commandline([],
                                         model=model,
-                                        defaults_filepath=self.model_defaults_filepath("Rover",model))
+                                        defaults_filepath=self.model_defaults_filepath("Rover", model))
 
         self.change_mode("MANUAL")
         self.wait_ready_to_arm()
@@ -5601,7 +5736,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
              self.test_do_set_mode_via_command_long),
 
             ("MAVProxy_DO_SET_MODE",
-            "Set mode via MAV_COMMAND_DO_SET_MODE with MAVProxy",
+             "Set mode via MAV_COMMAND_DO_SET_MODE with MAVProxy",
              self.test_mavproxy_do_set_mode_via_command_long),
 
             ("ServoRelayEvents",
@@ -5752,7 +5887,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             ("AHRSTrim",
              "Accelerometer trim testing",
              self.ahrstrim),
-             
+
             ("AP_Proximity_MAV",
              "Test MAV proximity backend",
              self.ap_proximity_mav),
@@ -5764,7 +5899,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             ("LogUpload",
              "Upload logs",
              self.log_upload),
-            ])
+        ])
         return ret
 
     def disabled_tests(self):

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -91,7 +91,7 @@ fi
 
 # Lists of packages to install
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
-PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"
+PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8"
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:
 if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then
   PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"

--- a/Tools/gittools/pre-commit.py
+++ b/Tools/gittools/pre-commit.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+'''
+A script suitable for use as a git pre-commit hook to ensure your
+files are flake8-compliant before committing them.
+
+Use this by copying it to a file called $ARDUPILOT_ROOT/.git/hooks/pre-commit
+
+ AP_FLAKE8_CLEAN
+'''
+
+import os
+import re
+import sys
+import subprocess
+
+
+class PreCommitFlake8(object):
+
+    def __init__(self):
+        pass
+
+    def progress(self, message):
+        print("***** %s" % (message, ))
+
+    def check_file(self, filepath):
+        content = open(filepath).read()
+        if "AP_FLAKE8_CLEAN" not in content:
+            return True
+        self.progress("Checking (%s)" % filepath)
+        retcode = subprocess.call(["flake8", filepath])
+        if retcode != 0:
+            self.progress("File (%s) failed with retcode (%s)" %
+                          (filepath, retcode))
+            return False
+        return True
+
+    def split_git_diff_output(self, output):
+        '''split output from git-diff into a list of (status, filepath) tuples'''
+        ret = []
+        if type(output) == bytes:
+            output = output.decode('utf-8')
+        for line in output.split("\n"):
+            if len(line) == 0:
+                continue
+            ret.append(re.split(r"\s+", line))
+        return ret
+
+    def run(self):
+        # generate a list of files which have changes not marked for commit
+        output = subprocess.check_output([
+            "git", "diff", "--name-status"])
+        dirty_list = self.split_git_diff_output(output)
+        dirty = set()
+        for (status, dirty_filepath) in dirty_list:
+            dirty.add(dirty_filepath)
+
+        # check files marked for commit:
+        output = subprocess.check_output([
+            "git", "diff", "--cached", "--name-status"])
+        output_tuples = self.split_git_diff_output(output)
+        self.retcode = 0
+        for output_tuple in output_tuples:
+            if len(output_tuple) > 2:
+                if output_tuple[0].startswith('R'):
+                    # rename, check destination
+                    (status, filepath) = (output_tuple[0], output_tuple[2])
+                else:
+                    raise ValueError("Unknown status %s" % str(output_tuple[0]))
+            else:
+                (status, filepath) = output_tuple
+            if filepath in dirty:
+                self.progress("WARNING: (%s) has unstaged changes" % filepath)
+            if status == 'D':
+                # don't check deleted files
+                continue
+            (base, extension) = os.path.splitext(filepath)
+            if extension != ".py":
+                continue
+            if not self.check_file(filepath):
+                self.retcode = 1
+        return self.retcode
+
+
+if __name__ == '__main__':
+    precommit = PreCommitFlake8()
+    sys.exit(precommit.run())

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -259,6 +259,12 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "python-cleanliness" ]; then
+        echo "Checking Python code cleanliness"
+        ./Tools/scripts/run_flake8.py
+        continue
+    fi
+
     if [ "$t" == "configure-all" ]; then
         echo "Checking configure of all boards"
         ./Tools/scripts/configure_all.py

--- a/Tools/scripts/run_flake8.py
+++ b/Tools/scripts/run_flake8.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+"""
+Runs flake8 over Python files which contain a marker indicating
+they are clean, ensures that they actually are
+
+ AP_FLAKE8_CLEAN
+"""
+
+import os
+import subprocess
+import sys
+
+import argparse
+
+os.environ['PYTHONUNBUFFERED'] = '1'
+
+
+class Flake8Checker(object):
+    def __init__(self):
+        self.retcode = 0
+
+    def progress(self, string):
+        print("****** %s" % (string,))
+
+    def check(self, filepath):
+        self.progress("Checking (%s)" % filepath)
+        retcode = subprocess.call(["flake8", filepath])
+        if retcode != 0:
+            self.progress("File (%s) failed with retcode (%s)" %
+                          (filepath, retcode))
+            self.retcode = 1
+
+    def run(self):
+        for (dirpath, dirnames, filenames) in os.walk("Tools"):
+            for filename in filenames:
+                if os.path.splitext(filename)[1] != ".py":
+                    continue
+                filepath = os.path.join(dirpath, filename)
+                content = open(filepath).read()
+                if "AP_FLAKE8_CLEAN" not in content:
+                    continue
+                self.check(filepath)
+        return self.retcode
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Check all Python files for flake8 cleanliness')
+    # parser.add_argument('--build', action='store_true', default=False, help='build as well as configure')
+    args = parser.parse_args()
+
+    checker = Flake8Checker()
+    sys.exit(checker.run())


### PR DESCRIPTION
This adds a step in our CI testing that checks Python files pass flake8 tests.

Only files including a special `AP_FLAKE8_CLEAN` marker are checked for cleanliness.

I've added `AP_FLAKE8_CLEAN` to the new CI script itself(!), and to `autotest.py` after tidying it up (again).  I expect more to grow this marker as they're cleaned up.

I've also added a script here which can be used as a git pre-commit hook.  It checks `.py` files which are staged (for either create or modify) with flake8 and fails the commit if they are not compliant.  This can stop bad Python getting into your commits in the first place.

Note that we already have some flake8 tests (supposedly?) running on Semaphore, so the use of the pre-commit hook could already save aggravation.
