### PR TITLE
AP_InertialSensor: fixed y accel bug on ICM-20602

### DIFF
--- a/libraries/AP_HAL/Device.cpp
+++ b/libraries/AP_HAL/Device.cpp
@@ -103,12 +103,13 @@ bool AP_HAL::Device::check_next_register(void)
 
     if (_bank_select) {
         if (!_bank_select(reg.bank)) {
-        // Cannot set bank
+            // Cannot set bank
 #if 0
-        printf("Device 0x%x set bank 0x%02x\n",
-               (unsigned)get_bus_id(),
-               (unsigned)reg.bank);
+            printf("Device 0x%x set bank 0x%02x\n",
+                   (unsigned)get_bus_id(),
+                   (unsigned)reg.bank);
 #endif
+            _checked.last_reg_fail = reg;
             return false;
         }
     }
@@ -123,8 +124,22 @@ bool AP_HAL::Device::check_next_register(void)
                (unsigned)reg.regnum, (unsigned)v, (unsigned)reg.value);
 #endif
         write_register(reg.regnum, reg.value);
+        _checked.last_reg_fail = reg;
+        _checked.last_reg_fail.value = v;
         return false;
     }
     _checked.next = (_checked.next+1) % _checked.n_set;
     return true;
+}
+
+/*
+  check one register value, returning information on the failure
+ */
+bool AP_HAL::Device::check_next_register(struct checkreg &fail)
+{
+    if (check_next_register()) {
+        return true;
+    }
+    fail = _checked.last_reg_fail;
+    return false;
 }

--- a/libraries/AP_HAL/Device.h
+++ b/libraries/AP_HAL/Device.h
@@ -201,6 +201,20 @@ public:
      */
     bool check_next_register(void);
 
+    // checked registers
+    struct checkreg {
+        uint8_t bank;
+        uint8_t regnum;
+        uint8_t value;
+    };
+    
+    /**
+     * check next register value for correctness, with return of
+     * failure value. Return false if value is incorrect or register
+     * checking has not been setup
+     */
+    bool check_next_register(struct checkreg &fail);
+    
     /**
      * Wrapper function over #transfer() to read a sequence of bytes from
      * device. No value is written, differently from the #read_registers()
@@ -390,18 +404,13 @@ protected:
 private:
     BankSelectCb _bank_select;
 
-    // checked registers
-    struct checkreg {
-        uint8_t bank;
-        uint8_t regnum;
-        uint8_t value;
-    };
     struct {
         uint8_t n_allocated;
         uint8_t n_set;
         uint8_t next;
         uint8_t frequency;
         uint8_t counter;
+        struct checkreg last_reg_fail;
         struct checkreg *regs;
     } _checked;
 };

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -19,6 +19,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/system.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_InternalError/AP_InternalError.h>
 #include "hwdef/common/watchdog.h"
 #include "hwdef/common/stm32_util.h"
 
@@ -232,7 +233,8 @@ void init()
 
 void panic(const char *errormsg, ...)
 {
-#ifndef HAL_BOOTLOADER_BUILD
+#if !defined(HAL_BOOTLOADER_BUILD) && !defined(HAL_NO_LOGGING)
+    INTERNAL_ERROR(AP_InternalError::error_t::panic);
     va_list ap;
 
     va_start(ap, errormsg);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
@@ -283,8 +283,10 @@ void AP_InertialSensor_BMI055::read_fifo_accel(void)
             _publish_temperature(accel_instance, temp_degc);
         }
     }
-    
-    if (!dev_accel->check_next_register()) {
+
+    AP_HAL::Device::checkreg reg;
+    if (!dev_accel->check_next_register(reg)) {
+        log_register_change(dev_accel->get_bus_id(), reg);
         _inc_accel_error_count(accel_instance);
     }
 }
@@ -329,7 +331,9 @@ void AP_InertialSensor_BMI055::read_fifo_gyro(void)
         _notify_new_gyro_raw_sample(gyro_instance, gyro);
     }
 
-    if (!dev_gyro->check_next_register()) {
+    AP_HAL::Device::checkreg reg;
+    if (!dev_gyro->check_next_register(reg)) {
+        log_register_change(dev_gyro->get_bus_id(), reg);
         _inc_gyro_error_count(gyro_instance);
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
@@ -402,7 +402,9 @@ void AP_InertialSensor_BMI088::read_fifo_gyro(void)
         _notify_new_gyro_raw_sample(gyro_instance, gyro);
     }
 
+    AP_HAL::Device::checkreg reg;
     if (!dev_gyro->check_next_register()) {
+        log_register_change(dev_gyro->get_bus_id(), reg);
         _inc_gyro_error_count(gyro_instance);
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -621,3 +621,13 @@ bool AP_InertialSensor_Backend::should_log_imu_raw() const
     return true;
 }
 
+// log an unexpected change in a register for an IMU
+void AP_InertialSensor_Backend::log_register_change(uint32_t bus_id, const AP_HAL::Device::checkreg &reg)
+{
+    AP::logger().Write("IREG", "TimeUS,DevID,Bank,Reg,Val", "QUBBB",
+                       AP_HAL::micros64(),
+                       bus_id,
+                       reg.bank,
+                       reg.regnum,
+                       reg.value);
+}

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -329,6 +329,9 @@ protected:
     void notify_accel_fifo_reset(uint8_t instance);
     void notify_gyro_fifo_reset(uint8_t instance);
     
+    // log an unexpected change in a register for an IMU
+    void log_register_change(uint32_t bus_id, const AP_HAL::Device::checkreg &reg);
+
     // note that each backend is also expected to have a static detect()
     // function which instantiates an instance of the backend sensor
     // driver if the sensor is available

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -693,7 +693,9 @@ void AP_InertialSensor_Invensense::_read_fifo()
 check_registers:
     // check next register value for correctness
     _dev->set_speed(AP_HAL::Device::SPEED_LOW);
-    if (!_dev->check_next_register()) {
+    AP_HAL::Device::checkreg reg;
+    if (!_dev->check_next_register(reg)) {
+        log_register_change(_dev->get_bus_id(), reg);
         _inc_gyro_error_count(_gyro_instance);
         _inc_accel_error_count(_accel_instance);
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -98,6 +98,9 @@ private:
     /* Poll for new data (non-blocking) */
     void _poll_data();
 
+    // debug function to watch for register changes
+    void _check_register_change(void);
+
     /* Read and write functions taking the differences between buses into
      * account */
     bool _block_read(uint8_t reg, uint8_t *buf, uint32_t size);
@@ -129,6 +132,12 @@ private:
     uint8_t reset_count;
 
     enum Rotation _rotation;
+
+    // enable checking of unexpected resets of offsets
+    bool _enable_offset_checking;
+
+    // ICM-20602 y offset register. See usage for explanation
+    uint8_t _saved_y_ofs_high;
 
     AP_HAL::DigitalSource *_drdy_pin;
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense_registers.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense_registers.h
@@ -146,6 +146,17 @@
 #define MPUREG_FIFO_R_W                             0x74
 #define MPUREG_WHOAMI                               0x75
 
+// accelerometer offsets, valid on ICM-2xxxx and MPU-9250. These hold
+// factory calibrated offsets. We need to ensure these do not change
+// in flight. There is a bug in at least the ICM-26002 that can cause
+// these to change value in flight.
+#define MPUREG_ACC_OFF_X_H            0x77
+#define MPUREG_ACC_OFF_X_L            0x78
+#define MPUREG_ACC_OFF_Y_H            0x7a
+#define MPUREG_ACC_OFF_Y_L            0x7b
+#define MPUREG_ACC_OFF_Z_H            0x7d
+#define MPUREG_ACC_OFF_Z_L            0x7e
+
 // ICM20608 specific registers
 #define ICMREG_ACCEL_CONFIG2          0x1D
 #define ICM_ACC_DLPF_CFG_1046HZ_NOLPF 0x00

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
@@ -523,7 +523,9 @@ void AP_InertialSensor_Invensensev2::_read_fifo()
 check_registers:
     // check next register value for correctness
     _dev->set_speed(AP_HAL::Device::SPEED_LOW);
-    if (!_dev->check_next_register()) {
+    AP_HAL::Device::checkreg reg;
+    if (!_dev->check_next_register(reg)) {
+        log_register_change(_dev->get_bus_id(), reg);
         _inc_gyro_error_count(_gyro_instance);
         _inc_accel_error_count(_accel_instance);
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -280,7 +280,9 @@ void AP_InertialSensor_Invensensev3::read_fifo()
 check_registers:
     // check next register value for correctness
     dev->set_speed(AP_HAL::Device::SPEED_LOW);
-    if (!dev->check_next_register()) {
+    AP_HAL::Device::checkreg reg;
+    if (!dev->check_next_register(reg)) {
+        log_register_change(dev->get_bus_id(), reg);
         _inc_gyro_error_count(gyro_instance);
         _inc_accel_error_count(accel_instance);
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -695,10 +695,13 @@ void AP_InertialSensor_LSM9DS0::_poll_data()
     }
 
     // check next register value for correctness
-    if (!_dev_gyro->check_next_register()) {
+    AP_HAL::Device::checkreg reg;
+    if (!_dev_gyro->check_next_register(reg)) {
+        log_register_change(_dev_gyro->get_bus_id(), reg);
         _inc_gyro_error_count(_gyro_instance);
     }
-    if (!_dev_accel->check_next_register()) {
+    if (!_dev_accel->check_next_register(reg)) {
+        log_register_change(_dev_accel->get_bus_id(), reg);
         _inc_accel_error_count(_accel_instance);
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
@@ -426,7 +426,9 @@ void AP_InertialSensor_LSM9DS1::_poll_data()
     }
 
     // check next register value for correctness
-    if (!_dev->check_next_register()) {
+    AP_HAL::Device::checkreg reg;
+    if (!_dev->check_next_register(reg)) {
+        log_register_change(_dev->get_bus_id(), reg);
         _inc_accel_error_count(_accel_instance);
     }
 }

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -37,7 +37,7 @@ void AP_InternalError::errors_as_string(uint8_t *buffer, const uint16_t len) con
         "write_mssfmt",  // logger_logwrite_missingfmt
         "many_deletes",  // logger_too_many_deletions
         "bad_getfile",  // logger_bad_getfilename
-        "unused1",
+        "panic",
         "flush_no_sem",  // logger_flushing_without_sem
         "bad_curr_blk",  // logger_bad_current_block
         "blkcnt_bad",  // logger_blockcount_mismatch

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -42,7 +42,7 @@ public:
         logger_logwrite_missingfmt  = (1U <<  2),  // 0x00004  4
         logger_too_many_deletions   = (1U <<  3),  // 0x00008  8
         logger_bad_getfilename      = (1U <<  4),  // 0x00010  16
-        unused1                     = (1U <<  5),  // 0x00020  32
+        panic                       = (1U <<  5),  // 0x00020  32
         logger_flushing_without_sem = (1U <<  6),  // 0x00040  64
         logger_bad_current_block    = (1U <<  7),  // 0x00080  128
         logger_blockcount_mismatch  = (1U <<  8),  // 0x00100  256


### PR DESCRIPTION
The ICM-20602 can unexpectedly change its Y accel offset (the factory offset). This catches that and fixes the value. It also logs any unexpected register changes in our IMU drivers
