### PR TITLE
Copter: EKF failsafe only triggers if EKF has ever had a good position estimate

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -552,13 +552,23 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
         }
     }
 
-    // check EKF compass variance is below failsafe threshold
-    float vel_variance, pos_variance, hgt_variance, tas_variance;
-    Vector3f mag_variance;
-    ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance);
-    if (copter.g.fs_ekf_thresh > 0 && mag_variance.length() >= copter.g.fs_ekf_thresh) {
-        check_failed(display_failure, "EKF compass variance");
-        return false;
+    // check EKF's compass, position and velocity variances are below failsafe threshold
+    if (copter.g.fs_ekf_thresh > 0.0f) {
+        float vel_variance, pos_variance, hgt_variance, tas_variance;
+        Vector3f mag_variance;
+        ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance);
+        if (mag_variance.length() >= copter.g.fs_ekf_thresh) {
+            check_failed(display_failure, "EKF compass variance");
+            return false;
+        }
+        if (pos_variance >= copter.g.fs_ekf_thresh) {
+            check_failed(display_failure, "EKF position variance");
+            return false;
+        }
+        if (vel_variance >= copter.g.fs_ekf_thresh) {
+            check_failed(display_failure, "EKF velocity variance");
+            return false;
+        }
     }
 
     // check home and EKF origin are not too far

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -38,8 +38,8 @@ void Copter::ekf_check()
         return;
     }
 
-    // return immediately if motors are not armed, or ekf check is disabled
-    if (!motors->armed() || (g.fs_ekf_thresh <= 0.0f)) {
+    // return immediately if ekf check is disabled
+    if (g.fs_ekf_thresh <= 0.0f) {
         ekf_check_state.fail_count = 0;
         ekf_check_state.bad_variance = false;
         AP_Notify::flags.ekf_bad = ekf_check_state.bad_variance;
@@ -160,6 +160,11 @@ void Copter::failsafe_ekf_event()
     // EKF failsafe event has occurred
     failsafe.ekf = true;
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV, LogErrorCode::FAILSAFE_OCCURRED);
+
+    // if disarmed take no action
+    if (!motors->armed()) {
+        return;
+    }
 
     // sometimes LAND *does* require GPS so ensure we are in non-GPS land
     if (control_mode == Mode::Number::LAND && landing_with_GPS()) {


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/16580 which involves the EKF failsafe triggering soon after the vehicle is armed in Stabilize (or any other non-GPS mode) if it doesn't have a good position estimate.  When the EKF failsafe triggers in a non-GPS mode no action is taken but it still unnecessarily worries the user who sees "EKF Variance" appear on the GCS and also sees the vehicle's LED's flash.

The fix has two parts:

1. The EKF failsafe only triggers if the threshold and position checks have passed at least once since startup.   This resolves the problem seen above
2. The EKF failsafe may trigger while the vehicle is disarmed but will take no action.

The potential downsides of the second change are:

1. The user may see the EKF failsafe trigger (e.g. "EKF Variance" message and flashing LEDs) that they would not have seen before if the EKF momentarily passes the checks but then fails again.
2. It may take 1 second longer for the vehicle to become arm-able in Loiter if the EKF failsafe has triggered while disarmed because once triggered, the EKF failsafe always takes at least 1 second to clear and Copter's arming checks use the "position_ok()" call which in turn checks the EKF failsafe is clear.

This has been lightly tested in SITL and seems to function but needs some more testing especially to be sure the above issues are rare.  If they are not rare we may chose to remove the 2nd change.