### PR TITLE
EKF yaw recovery bug fix

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -381,10 +381,10 @@ void NavEKF2_core::detectFlight()
     }
 
     // handle reset of counters used to control how many times we will try to reset the yaw to the EKF-GSF value per flight
-    if ((!prevOnGround && onGround) || !gpsAccuracyGood) {
+    if ((!prevOnGround && onGround) || !gpsSpdAccPass) {
         // disable filter bank
         EKFGSF_run_filterbank = false;
-    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && inFlight && gpsAccuracyGood) {
+    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && inFlight && gpsSpdAccPass) {
         // flying so reset counters and enable filter bank when GPS is good
         EKFGSF_yaw_reset_ms = 0;
         EKFGSF_yaw_reset_request_ms = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -392,10 +392,10 @@ void NavEKF3_core::detectFlight()
     updateTouchdownExpected();
 
     // handle reset of counters used to control how many times we will try to reset the yaw to the EKF-GSF value per flight
-    if ((!prevOnGround && onGround) || !gpsAccuracyGood) {
+    if ((!prevOnGround && onGround) || !gpsSpdAccPass) {
         // disable filter bank
         EKFGSF_run_filterbank = false;
-    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && (inFlight || expectTakeoff) && gpsAccuracyGood) {
+    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && (inFlight || expectTakeoff) && gpsSpdAccPass) {
         // flying or about to fly so reset counters and enable filter bank when GPS is good
         EKFGSF_yaw_reset_ms = 0;
         EKFGSF_yaw_reset_request_ms = 0;


### PR DESCRIPTION
This fixes a behaviour reported by @rmackay9 where if  GPS is being used for yaw and started reporting a bad yaw  angle in flight, the reset of the yaw to the EKFGSF would an excessive amount of time and the vehicle would go into land mode before the reset.

Before this change, an error in GPS yaw angle would result in the yaw eventually following the bad yaw measurement, causing EKF GPS innovations to be high and resulting in gpsAccuracyGood going false, stopping operation of the EKFGSF yaw estimator with the EKF unable to reset to the EKFGSF yaw estimate when required. See below:

![image](https://user-images.githubusercontent.com/3596952/107607619-d84c4e00-6c8d-11eb-9752-c49d043dc264.png)

![image](https://user-images.githubusercontent.com/3596952/107607768-48f36a80-6c8e-11eb-975c-c4391a6bf900.png)

The logic used to set EKFGSF_run_filterbank should use gpsSpdAccPass not gpsAccuracyGood because the latter will be false if the EKF's GPS innovations are large, which if caused by bad yaw is when we need the EKFGSF to be running.  After the change the EKFGSF estimation continues and the yaw is reset correctly

<img width="1028" alt="Screen Shot 2021-02-11 at 5 30 00 pm" src="https://user-images.githubusercontent.com/3596952/107607983-c7500c80-6c8e-11eb-987b-cfe85caa0c84.png">

<img width="1064" alt="Screen Shot 2021-02-11 at 5 30 39 pm" src="https://user-images.githubusercontent.com/3596952/107608027-ddf66380-6c8e-11eb-99f4-2e8c24b525fa.png">
