### PR TITLE
AC_Avoid/AP_Proximity: Bug fixes

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -113,16 +113,16 @@ void AP_Proximity_Backend::database_push(float angle, float pitch, float distanc
     if (oaDb == nullptr || !oaDb->healthy()) {
         return;
     }
-    
+
     //Assume object is angle and pitch bearing and distance meters away from the vehicle 
     Vector3f object_3D;
-    object_3D.offset_bearing(wrap_180(angle), wrap_180(pitch), distance);	
+    object_3D.offset_bearing(wrap_180(angle), wrap_180(pitch * -1.0f), distance);
     const Vector3f rotated_object_3D = body_to_ned * object_3D;
-    
+
     //Calculate the position vector from origin
     Vector3f temp_pos = current_pos + rotated_object_3D;
     //Convert the vector to a NEU frame from NED
     temp_pos.z = temp_pos.z * -1.0f;
-    
+
     oaDb->queue_push(temp_pos, timestamp_ms, distance);
 }

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
@@ -189,11 +189,11 @@ bool AP_Proximity_Boundary_3D::convert_obstacle_num_to_face(uint8_t obstacle_num
     face.sector = sector;
     face.layer = layer;
 
-    uint8_t valid_sector = sector; 
+    uint8_t valid_sector = sector;
     // check for 3 adjacent sectors
-    for (uint8_t i=0; i < 2; i++) {
+    for (uint8_t i=0; i < 3; i++) {
         if (_distance_valid[layer][valid_sector]) {
-            // update boundary has manipulated this face 
+            // update boundary has manipulated this face
             return true;
         }
         valid_sector = get_next_sector(valid_sector);


### PR DESCRIPTION
This is a important PR to fix some of the bugs that were present in the Simple Avoidance related code:

**1. Changes to AP_Proximity_Boundary_3D:**
This was a bug introduced by my PR here: #15553 . We weren't sending down all the faces, down to the Avoidance code.
As a result, when backing away, even while the obstacle was in front of us, the vehicle was shifting horizontally.
Master: 
![image](https://user-images.githubusercontent.com/36970042/107616270-bd6ce000-6c73-11eb-9a90-dd71a3da72cf.png)

This PR:
![image](https://user-images.githubusercontent.com/36970042/107616287-c65db180-6c73-11eb-8edd-55480b22314b.png)


**2. Changes to AP_Proximity_Backend:**
The rotation matrix requires Z to be positive in the downards direction. However, by convention, "pitch" is positive for obstacle appearing above the horizon. Therefore before multiplying it with the rotation matrix, I am inverting the pitch. This makes sure the obstacle is rotated correctly.

**3. Change to AC_Avoidance:**
When we multiply the velocity vector from body back to earth frame, there is a small floating point error. Therefore, even if there is no obstacles/the obstacles are far away, the input vs output velocity of avoidance differ at the 10th decimal place, making it seem like avoidance is active, when its not. An early return fixes this issue.
