### PR TITLE
AP_GPS: Force the baudrate on SBF

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -63,16 +63,21 @@ private:
     static const uint8_t SBF_PREAMBLE1 = '$';
     static const uint8_t SBF_PREAMBLE2 = '@';
 
-    bool _validated_initial_sso;
     uint8_t _init_blob_index;
     uint32_t _init_blob_time;
-    char *_initial_sso;
-    const char* _sso_normal = ", PVTGeodetic+DOP+ReceiverStatus+VelCovGeodetic+BaseVectorGeod, msec100\n";
+    enum class Config_State {
+        Baud_Rate,
+        SSO,
+        Blob,
+        Complete
+    };
+    Config_State config_step;
+    char *config_string;
     static constexpr const char* _initialisation_blob[] = {
-    "srd, Moderate, UAV\n",
-    "sem, PVT, 5\n",
-    "spm, Rover, all\n",
-    "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, msec100\n",
+    "srd,Moderate,UAV",
+    "sem,PVT,5",
+    "spm,Rover,all",
+    "sso,Stream2,Dsk1,postprocess+event+comment+ReceiverStatus,msec100",
 #if defined (GPS_SBF_EXTRA_CONFIG)
     GPS_SBF_EXTRA_CONFIG
 #endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/HitecMosaic/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HitecMosaic/hwdef.dat
@@ -172,5 +172,5 @@ define HAL_PERIPH_ENABLE_BARO
 define HAL_GPS_TYPE_DEFAULT 10
 define HAL_GPS_COM_PORT_DEFAULT 3
 define GPS_SBF_STREAM_NUMBER 3
-define GPS_SBF_EXTRA_CONFIG "sdfa, DSK1, DeleteOldest\n", "sfn, DSK1, Incremental, Mosaic\n", "sfno, off\n"
+define GPS_SBF_EXTRA_CONFIG "sdfa, DSK1, DeleteOldest", "sfn, DSK1, Incremental, Mosaic", "sfno, off"
 


### PR DESCRIPTION
This rewrites the SBF config loop to force the baudrate on the GPS rather then trusting whatever it was detected at (which prevents us from sticking with a GPS at 9600 baud, which is guaranteed to not work correctly). It also pushes the typical SBF unit up from 115200 to 230400, which has the general benefit of reducing lag on the data, and allowing us to get RTCM corrections to the unit faster (if doing moving baseline this is essential).

Other incidental notes with this:
 - whitespace trimming the config strings saves about 16 bytes
 - the config loop now allocates and add's the `\n` character for each string as needed, this both saves some space, but more importantly actually significantly simplified the deallocation of those strings we have to make on the fly

This was tested upon a HitecMosaic.