### PR TITLE
AP_Proximity: Add a low pass filter to faces

### DIFF
--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -554,34 +554,59 @@ void AP_Logger::Write_Proximity(AP_Proximity &proximity)
         return;
     }
 
-    AP_Proximity::Proximity_Distance_Array dist_array {};
-    proximity.get_horizontal_distances(dist_array);
+    AP_Proximity::Proximity_Distance_Array dist_array{}; // raw distances stored here
+    AP_Proximity::Proximity_Distance_Array filt_dist_array{}; //filtered distances stored here
+    for (uint8_t i = 0; i < proximity.get_num_layers(); i++) {
+        const bool active = proximity.get_active_layer_distances(i, dist_array, filt_dist_array);
+        if (!active) {
+            // nothing on this layer
+            continue;
+        }
+        float dist_up;
+        if (!proximity.get_upward_distance(dist_up)) {
+            dist_up = 0.0f;
+        }
 
-    float dist_up;
-    if (!proximity.get_upward_distance(dist_up)) {
-        dist_up = 0.0f;
+        float closest_ang = 0.0f;
+        float closest_dist = 0.0f;
+        proximity.get_closest_object(closest_ang, closest_dist);
+
+        const struct log_Proximity pkt_proximity{
+                LOG_PACKET_HEADER_INIT(LOG_PROXIMITY_MSG),
+                time_us         : AP_HAL::micros64(),
+                instance        : i,
+                health          : (uint8_t)proximity.get_status(),
+                dist0           : filt_dist_array.distance[0],
+                dist45          : filt_dist_array.distance[1],
+                dist90          : filt_dist_array.distance[2],
+                dist135         : filt_dist_array.distance[3],
+                dist180         : filt_dist_array.distance[4],
+                dist225         : filt_dist_array.distance[5],
+                dist270         : filt_dist_array.distance[6],
+                dist315         : filt_dist_array.distance[7],
+                distup          : dist_up,
+                closest_angle   : closest_ang,
+                closest_dist    : closest_dist
+        };
+        WriteBlock(&pkt_proximity, sizeof(pkt_proximity));
+
+        if (proximity.get_raw_log_enable()) {
+            const struct log_Proximity_raw pkt_proximity_raw{
+                LOG_PACKET_HEADER_INIT(LOG_RAW_PROXIMITY_MSG),
+                time_us         : AP_HAL::micros64(),
+                instance        : i,
+                raw_dist0       : dist_array.distance[0],
+                raw_dist45      : dist_array.distance[1],
+                raw_dist90      : dist_array.distance[2],
+                raw_dist135     : dist_array.distance[3],
+                raw_dist180     : dist_array.distance[4],
+                raw_dist225     : dist_array.distance[5],
+                raw_dist270     : dist_array.distance[6],
+                raw_dist315     : dist_array.distance[7],
+            };
+            WriteBlock(&pkt_proximity_raw, sizeof(pkt_proximity_raw));
+        }
     }
-
-    float close_ang = 0.0f, close_dist = 0.0f;
-    proximity.get_closest_object(close_ang, close_dist);
-
-    const struct log_Proximity pkt_proximity{
-            LOG_PACKET_HEADER_INIT(LOG_PROXIMITY_MSG),
-            time_us         : AP_HAL::micros64(),
-            health          : (uint8_t)proximity.get_status(),
-            dist0           : dist_array.distance[0],
-            dist45          : dist_array.distance[1],
-            dist90          : dist_array.distance[2],
-            dist135         : dist_array.distance[3],
-            dist180         : dist_array.distance[4],
-            dist225         : dist_array.distance[5],
-            dist270         : dist_array.distance[6],
-            dist315         : dist_array.distance[7],
-            distup          : dist_up,
-            closest_angle   : close_ang,
-            closest_dist    : close_dist
-    };
-    WriteBlock(&pkt_proximity, sizeof(pkt_proximity));
 }
 
 void AP_Logger::Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& breadcrumb)

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -657,6 +657,7 @@ struct PACKED log_Beacon {
 struct PACKED log_Proximity {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t instance;
     uint8_t health;
     float dist0;
     float dist45;
@@ -669,6 +670,19 @@ struct PACKED log_Proximity {
     float distup;
     float closest_angle;
     float closest_dist;
+};
+struct PACKED log_Proximity_raw {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    float raw_dist0;
+    float raw_dist45;
+    float raw_dist90;
+    float raw_dist135;
+    float raw_dist180;
+    float raw_dist225;
+    float raw_dist270;
+    float raw_dist315;
 };
 
 struct PACKED log_Performance {
@@ -1205,9 +1219,10 @@ struct PACKED log_PSCZ {
 // @Field: Safety: Hardware Safety Switch status
 
 // @LoggerMessage: PRX
-// @Description: Proximity sensor data
+// @Description: Proximity Filtered sensor data
 // @Field: TimeUS: Time since system startup
-// @Field: Health: True if proximity sensor is healthy
+// @Field: Layer: Pitch(instance) at which the obstacle is at. 0th layer {-75,-45} degrees. 1st layer {-45,-15} degrees. 2nd layer {-15, 15} degrees. 3rd layer {15, 45} degrees. 4th layer {45,75} degrees. Minimum distance in each layer will be logged.
+// @Field: He: True if proximity sensor is healthy
 // @Field: D0: Nearest object in sector surrounding 0-degrees
 // @Field: D45: Nearest object in sector surrounding 45-degrees
 // @Field: D90: Nearest object in sector surrounding 90-degrees
@@ -1219,6 +1234,19 @@ struct PACKED log_PSCZ {
 // @Field: DUp: Nearest object in upwards direction
 // @Field: CAn: Angle to closest object
 // @Field: CDis: Distance to closest object
+
+// @LoggerMessage: PRXR
+// @Description: Proximity Raw sensor data
+// @Field: TimeUS: Time since system startup
+// @Field: Layer: Pitch(instance) at which the obstacle is at. 0th layer {-75,-45} degrees. 1st layer {-45,-15} degrees. 2nd layer {-15, 15} degrees. 3rd layer {15, 45} degrees. 4th layer {45,75} degrees. Minimum distance in each layer will be logged.
+// @Field: D0: Nearest object in sector surrounding 0-degrees
+// @Field: D45: Nearest object in sector surrounding 45-degrees
+// @Field: D90: Nearest object in sector surrounding 90-degrees
+// @Field: D135: Nearest object in sector surrounding 135-degrees
+// @Field: D180: Nearest object in sector surrounding 180-degrees
+// @Field: D225: Nearest object in sector surrounding 225-degrees
+// @Field: D270: Nearest object in sector surrounding 270-degrees
+// @Field: D315: Nearest object in sector surrounding 315-degrees
 
 // @LoggerMessage: RAD
 // @Description: Telemetry radio statistics
@@ -1463,7 +1491,9 @@ LOG_STRUCTURE_FROM_CAMERA \
     { LOG_BEACON_MSG, sizeof(log_Beacon), \
       "BCN", "QBBfffffff",  "TimeUS,Health,Cnt,D0,D1,D2,D3,PosX,PosY,PosZ", "s--mmmmmmm", "F--0000000" }, \
     { LOG_PROXIMITY_MSG, sizeof(log_Proximity), \
-      "PRX", "QBfffffffffff", "TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315,DUp,CAn,CDis", "s-mmmmmmmmmhm", "F-00000000000" }, \
+      "PRX", "QBBfffffffffff", "TimeUS,Layer,He,D0,D45,D90,D135,D180,D225,D270,D315,DUp,CAn,CDis", "s#-mmmmmmmmmhm", "F--00000000000" }, \
+    { LOG_RAW_PROXIMITY_MSG, sizeof(log_Proximity_raw), \
+      "PRXR", "QBffffffff", "TimeUS,Layer,D0,D45,D90,D135,D180,D225,D270,D315", "s#mmmmmmmm", "F-00000000" }, \
     { LOG_PERFORMANCE_MSG, sizeof(log_Performance),                     \
       "PM",  "QHHIIHHIIIIII", "TimeUS,NLon,NLoop,MaxT,Mem,Load,ErrL,IntE,ErrC,SPIC,I2CC,I2CI,Ex", "s---b%------s", "F---0A------F" }, \
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
@@ -1655,6 +1685,7 @@ enum LogMessages : uint8_t {
     LOG_WINCH_MSG,
     LOG_PSC_MSG,
     LOG_PSCZ_MSG,
+    LOG_RAW_PROXIMITY_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -175,6 +175,13 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     AP_GROUPINFO("2_YAW_CORR", 18, AP_Proximity, _yaw_correction[1], 0),
 #endif
 
+    // @Param: _LOG_RAW
+    // @DisplayName: Proximity raw distances log
+    // @Description: Set this parameter to one if logging unfiltered(raw) distances from sensor should be enabled
+    // @Values: 0:Off, 1:On
+    // @User: Advanced
+    AP_GROUPINFO("_LOG_RAW", 19, AP_Proximity, _raw_log_enable, 0),
+
     AP_GROUPEND
 };
 
@@ -359,6 +366,16 @@ bool AP_Proximity::get_horizontal_distances(Proximity_Distance_Array &prx_dist_a
     return drivers[primary_instance]->get_horizontal_distances(prx_dist_array);
 }
 
+// get raw and filtered distances in 8 directions per layer. used for logging
+bool AP_Proximity::get_active_layer_distances(uint8_t layer, AP_Proximity::Proximity_Distance_Array &prx_dist_array, AP_Proximity::Proximity_Distance_Array &prx_filt_dist_array) const
+{
+    if (!valid_instance(primary_instance)) {
+        return false;
+    }
+    // get distances from backend
+    return drivers[primary_instance]->get_active_layer_distances(layer, prx_dist_array, prx_filt_dist_array);
+}
+
 // get total number of obstacles, used in GPS based Simple Avoidance
 uint8_t AP_Proximity::get_obstacle_count() const
 {   
@@ -366,6 +383,15 @@ uint8_t AP_Proximity::get_obstacle_count() const
         return 0;
     }
     return drivers[primary_instance]->get_obstacle_count();
+}
+
+// get number of layers.
+uint8_t AP_Proximity::get_num_layers() const
+{
+    if (!valid_instance(primary_instance)) {
+        return 0;
+    }
+    return drivers[primary_instance]->get_num_layers();
 }
 
 // get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -94,6 +94,9 @@ public:
     // get distances in PROXIMITY_MAX_DIRECTION directions. used for sending distances to ground station
     bool get_horizontal_distances(Proximity_Distance_Array &prx_dist_array) const;
 
+    // get raw and filtered distances in 8 directions per layer. used for logging
+    bool get_active_layer_distances(uint8_t layer, AP_Proximity::Proximity_Distance_Array &prx_dist_array, AP_Proximity::Proximity_Distance_Array &prx_filt_dist_array) const;
+
     // get total number of obstacles, used in GPS based Simple Avoidance
     uint8_t get_obstacle_count() const;
     
@@ -111,6 +114,9 @@ public:
     // get number of objects, angle and distance - used for non-GPS avoidance
     uint8_t get_object_count() const;
     bool get_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const;
+
+    // get number of layers
+    uint8_t get_num_layers() const;
 
     // get maximum and minimum distances (in meters) of primary sensor
     float distance_max() const;
@@ -134,6 +140,9 @@ public:
     bool get_upward_distance(float &distance) const;
 
     Type get_type(uint8_t instance) const;
+
+    // true if raw distances should be logged
+    bool get_raw_log_enable() const { return _raw_log_enable; }
 
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
@@ -166,6 +175,7 @@ private:
     AP_Int16 _yaw_correction[PROXIMITY_MAX_INSTANCES];
     AP_Int16 _ignore_angle_deg[PROXIMITY_MAX_IGNORE];   // angle (in degrees) of area that should be ignored by sensor (i.e. leg shows up)
     AP_Int8 _ignore_width_deg[PROXIMITY_MAX_IGNORE];    // width of beam (in degrees) that should be ignored
+    AP_Int8 _raw_log_enable;                            // enable logging raw distances
 
     void detect_instance(uint8_t instance);
 };

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -37,22 +37,13 @@ static_assert(PROXIMITY_MAX_DIRECTION <= 8,
 // get distances in PROXIMITY_MAX_DIRECTION directions horizontally. used for sending distances to ground station
 bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const
 {
-    // cycle through all sectors filling in distances and orientations
-    // see MAV_SENSOR_ORIENTATION for orientations (0 = forward, 1 = 45 degree clockwise from north, etc)
-    bool valid_distances = false;
-    prx_dist_array.offset_valid = 0;
-    for (uint8_t i=0; i<PROXIMITY_MAX_DIRECTION; i++) {
-        prx_dist_array.orientation[i] = i;
-        const AP_Proximity_Boundary_3D::Face face(PROXIMITY_MIDDLE_LAYER, i);
-        if (boundary.get_distance(face, prx_dist_array.distance[i])) {
-            prx_dist_array.offset_valid |= (1U << i);
-            valid_distances = true;
-        } else {
-            prx_dist_array.distance[i] = distance_max();
-        }
-    }
-
-    return valid_distances;
+    AP_Proximity::Proximity_Distance_Array prx_filt_dist_array; // unused
+    return boundary.get_layer_distances(PROXIMITY_MIDDLE_LAYER, distance_max(), prx_dist_array, prx_filt_dist_array);
+}
+// get distances in PROXIMITY_MAX_DIRECTION directions at a layer. used for logging
+bool AP_Proximity_Backend::get_active_layer_distances(uint8_t layer, AP_Proximity::Proximity_Distance_Array &prx_dist_array, AP_Proximity::Proximity_Distance_Array &prx_filt_dist_array) const
+{
+    return boundary.get_layer_distances(layer, distance_max(), prx_dist_array, prx_filt_dist_array);
 }
 
 // set status and update valid count

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -64,6 +64,12 @@ public:
     // get distances in 8 directions. used for sending distances to ground station
     bool get_horizontal_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const;
 
+    // get raw and filtered distances in 8 directions per layer. used for logging
+    bool get_active_layer_distances(uint8_t layer, AP_Proximity::Proximity_Distance_Array &prx_dist_array, AP_Proximity::Proximity_Distance_Array &prx_filt_dist_array) const;
+
+    // get number of layers
+    uint8_t get_num_layers() const { return boundary.get_num_layers(); }
+
 protected:
 
     // set status and update valid_count


### PR DESCRIPTION
This PR adds a low pass filter to each "face". Its an atempt to reduce the reaction of glitches on Simple Avoidance. What often happens is that (as reported by several logs on the forums) there is no filtiration in the current sensor drivers, and any noise gets passed down as obstacles. This gives a sudden jerky response by the vehicle, which may even lead to crash. 
To see the filteration in action, please see this video: https://youtu.be/wmGKrU0iFSw
Here is an image from onboard logs tested on Cube Orange + Intel RealSense cameras:
![image](https://user-images.githubusercontent.com/36970042/107749264-4b160180-6d40-11eb-9f9a-09aa31854d8c.png)

Red line is the filtered distances, green line is the raw distances. A mode filter instead of low pass filter was also tested, but the "smothness" that comes with the low pass filter is desired. 

Additional param is also added to enable "raw distance" logging for debugging purposses. Normally it will be turned off. 