### PR TITLE
move GSF logging from EKF files into GSF files

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1777,6 +1777,7 @@ class AutoTest(ABC):
                         continue
                     m = re.match("\s*{(.*)[\\\]", line)
                     if m is None:
+                        state = state_outside
                         continue
                     partial_line = m.group(1)
                     linestate = linestate_within

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -121,6 +121,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_NavEKF2/LogStructure.h>
 #include <AP_NavEKF3/LogStructure.h>
 #include <AP_GPS/LogStructure.h>
+#include <AP_NavEKF/LogStructure.h>
 #include <AP_BattMonitor/LogStructure.h>
 #include <AP_AHRS/LogStructure.h>
 #include <AP_Camera/LogStructure.h>
@@ -1508,6 +1509,7 @@ LOG_STRUCTURE_FROM_CAMERA \
 LOG_STRUCTURE_FROM_DAL \
 LOG_STRUCTURE_FROM_NAVEKF2 \
 LOG_STRUCTURE_FROM_NAVEKF3 \
+LOG_STRUCTURE_FROM_NAVEKF \
 LOG_STRUCTURE_FROM_AHRS \
     { LOG_DF_FILE_STATS, sizeof(log_DSF), \
       "DSF", "QIHIIII", "TimeUS,Dp,Blk,Bytes,FMn,FMx,FAv", "s--b---", "F--0---" }, \

--- a/libraries/AP_NavEKF/EKFGSF_Logging.cpp
+++ b/libraries/AP_NavEKF/EKFGSF_Logging.cpp
@@ -1,0 +1,48 @@
+#include "EKFGSF_yaw.h"
+
+#include <AP_Logger/AP_Logger.h>
+
+void EKFGSF_yaw::Log_Write(uint64_t time_us, LogMessages id0, LogMessages id1, uint8_t core_index)
+{
+    if (!vel_fuse_running) {
+        return;
+    }
+
+    static_assert(N_MODELS_EKFGSF >= 5, "Logging will break on <5 EKFGSF models");
+
+    const struct log_KY0 ky0{
+        LOG_PACKET_HEADER_INIT(id0),
+        time_us                 : time_us,
+        core                    : core_index,
+        yaw_composite           : GSF.yaw,
+        yaw_composite_variance  : sqrtf(MAX(GSF.yaw_variance, 0.0f)),
+        yaw0                    : EKF[0].X[2],
+        yaw1                    : EKF[1].X[2],
+        yaw2                    : EKF[2].X[2],
+        yaw3                    : EKF[3].X[2],
+        yaw4                    : EKF[4].X[2],
+        wgt0                    : GSF.weights[0],
+        wgt1                    : GSF.weights[1],
+        wgt2                    : GSF.weights[2],
+        wgt3                    : GSF.weights[3],
+        wgt4                    : GSF.weights[4],
+    };
+    AP::logger().WriteBlock(&ky0, sizeof(ky0));
+
+    const struct log_KY1 ky1{
+        LOG_PACKET_HEADER_INIT(id1),
+        time_us                 : time_us,
+        core                    : core_index,
+        ivn0                    : EKF[0].innov[0],
+        ivn1                    : EKF[1].innov[0],
+        ivn2                    : EKF[2].innov[0],
+        ivn3                    : EKF[3].innov[0],
+        ivn4                    : EKF[4].innov[0],
+        ive0                    : EKF[0].innov[1],
+        ive1                    : EKF[1].innov[1],
+        ive2                    : EKF[2].innov[1],
+        ive3                    : EKF[3].innov[1],
+        ive4                    : EKF[4].innov[1],
+    };
+    AP::logger().WriteBlock(&ky1, sizeof(ky1));
+}

--- a/libraries/AP_NavEKF/EKFGSF_yaw.cpp
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.cpp
@@ -577,22 +577,6 @@ float EKFGSF_yaw::gaussianDensity(const uint8_t mdl_idx) const
     return normDist;
 }
 
-bool EKFGSF_yaw::getLogData(float &yaw_composite, float &yaw_composite_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) const
-{
-    if (vel_fuse_running) {
-        yaw_composite = GSF.yaw;
-        yaw_composite_variance = GSF.yaw_variance;
-        for (uint8_t mdl_idx = 0; mdl_idx < N_MODELS_EKFGSF; mdl_idx++) {
-            yaw[mdl_idx] = EKF[mdl_idx].X[2];
-            innov_VN[mdl_idx] = EKF[mdl_idx].innov[0];
-            innov_VE[mdl_idx] = EKF[mdl_idx].innov[1];
-            weight[mdl_idx] = GSF.weights[mdl_idx];
-        }
-        return true;
-    }
-    return false;
-}
-
 void EKFGSF_yaw::forceSymmetry(const uint8_t mdl_idx)
 {
     float P01 = 0.5f * (EKF[mdl_idx].P[0][1] + EKF[mdl_idx].P[1][0]);

--- a/libraries/AP_NavEKF/EKFGSF_yaw.h
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.h
@@ -5,6 +5,7 @@
 #include <AP_NavEKF/AP_Nav_Common.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Math/vectorN.h>
+#include <AP_Logger/LogStructure.h>
 
 #define IMU_DT_MIN_SEC 0.001f // Minimum delta time between IMU samples (sec)
 
@@ -30,10 +31,6 @@ public:
     // set the gyro bias in rad/sec
     void setGyroBias(Vector3f &gyroBias);
 
-    // get solution data for logging
-    // return false if yaw estimation is inactive
-    bool getLogData(float &yaw_composite, float &yaw_composite_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) const;
-
     // get yaw estimated and corresponding variance
     // return false if yaw estimation is inactive
     bool getYawData(float &yaw, float &yawVariance) const;
@@ -41,6 +38,10 @@ public:
     // get the length of the weighted average velocity innovation vector
     // return false if not available
     bool getVelInnovLength(float &velInnovLength) const;
+
+    // log EKFGSF data on behalf of an EKF caller.  id0 and id1 are the
+    // IDs of the messages to log, e.g. LOG_NKY0_MSG, LOG_NKY1_MSG
+    void Log_Write(uint64_t time_us, LogMessages id0, LogMessages id1, uint8_t core_index);
 
 private:
 

--- a/libraries/AP_NavEKF/LogStructure.h
+++ b/libraries/AP_NavEKF/LogStructure.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+// @LoggerMessage: XKY0,NKY0
+// @Description: EKF Yaw Estimator States
+// @Field: TimeUS: Time since system startup
+// @Field: C: EKF core this data is for
+// @Field: YC: GSF yaw estimate (rad)
+// @Field: YCS: GSF yaw estimate 1-Sigma uncertainty (rad)
+// @Field: Y0: Yaw estimate from individual EKF filter 0 (rad)
+// @Field: Y1: Yaw estimate from individual EKF filter 1 (rad)
+// @Field: Y2: Yaw estimate from individual EKF filter 2 (rad)
+// @Field: Y3: Yaw estimate from individual EKF filter 3 (rad)
+// @Field: Y4: Yaw estimate from individual EKF filter 4 (rad)
+// @Field: W0: Weighting applied to yaw estimate from individual EKF filter 0
+// @Field: W1: Weighting applied to yaw estimate from individual EKF filter 1
+// @Field: W2: Weighting applied to yaw estimate from individual EKF filter 2
+// @Field: W3: Weighting applied to yaw estimate from individual EKF filter 3
+// @Field: W4: Weighting applied to yaw estimate from individual EKF filter 4
+struct PACKED log_KY0 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t core;
+    float yaw_composite;
+    float yaw_composite_variance;
+    float yaw0;
+    float yaw1;
+    float yaw2;
+    float yaw3;
+    float yaw4;
+    float wgt0;
+    float wgt1;
+    float wgt2;
+    float wgt3;
+    float wgt4;
+};
+
+
+// @LoggerMessage: XKY1,NKY1
+// @Description: EKF Yaw Estimator Innovations
+// @Field: TimeUS: Time since system startup
+// @Field: C: EKF core this data is for
+// @Field: IVN0: North velocity innovation from individual EKF filter 0 (m/s)
+// @Field: IVN1: North velocity innovation from individual EKF filter 1 (m/s)
+// @Field: IVN2: North velocity innovation from individual EKF filter 2 (m/s)
+// @Field: IVN3: North velocity innovation from individual EKF filter 3 (m/s)
+// @Field: IVN4: North velocity innovation from individual EKF filter 4 (m/s)
+// @Field: IVE0: East velocity innovation from individual EKF filter 0 (m/s)
+// @Field: IVE1: East velocity innovation from individual EKF filter 1 (m/s)
+// @Field: IVE2: East velocity innovation from individual EKF filter 2 (m/s)
+// @Field: IVE3: East velocity innovation from individual EKF filter 3 (m/s)
+// @Field: IVE4: East velocity innovation from individual EKF filter 4 (m/s)
+struct PACKED log_KY1 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t core;
+    float ivn0;
+    float ivn1;
+    float ivn2;
+    float ivn3;
+    float ivn4;
+    float ive0;
+    float ive1;
+    float ive2;
+    float ive3;
+    float ive4;
+};
+
+#define KY0_FMT "QBffffffffffff"
+#define KY0_LABELS "TimeUS,C,YC,YCS,Y0,Y1,Y2,Y3,Y4,W0,W1,W2,W3,W4"
+#define KY0_UNITS "s#rrrrrrr-----"
+#define KY0_MULTS "F-000000000000"
+
+#define KY1_FMT "QBffffffffff"
+#define KY1_LABELS "TimeUS,C,IVN0,IVN1,IVN2,IVN3,IVN4,IVE0,IVE1,IVE2,IVE3,IVE4"
+#define KY1_UNITS "s#nnnnnnnnnn"
+#define KY1_MULTS "F-0000000000"
+
+#define LOG_STRUCTURE_FROM_NAVEKF                                       \
+    { LOG_XKY0_MSG, sizeof(log_KY0),                                    \
+            "XKY0", KY0_FMT, KY0_LABELS, KY0_UNITS, KY0_MULTS},      \
+    { LOG_XKY1_MSG, sizeof(log_KY1),                                    \
+            "XKY1", KY1_FMT, KY1_LABELS, KY1_UNITS, KY1_MULTS },     \
+    { LOG_NKY0_MSG, sizeof(log_KY0),                                    \
+            "NKY0", KY0_FMT, KY0_LABELS, KY0_UNITS, KY0_MULTS},      \
+    { LOG_NKY1_MSG, sizeof(log_KY1),                                    \
+            "NKY1", KY1_FMT, KY1_LABELS, KY1_UNITS, KY1_MULTS },

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -326,51 +326,5 @@ void NavEKF2_core::Log_Write_GSF(uint64_t time_us) const
     if (yawEstimator == nullptr) {
         return;
     }
-
-    float yaw_composite;
-    float yaw_composite_variance;
-    float yaw[N_MODELS_EKFGSF];
-    float ivn[N_MODELS_EKFGSF];
-    float ive[N_MODELS_EKFGSF];
-    float wgt[N_MODELS_EKFGSF];
-
-    if (!yawEstimator->getLogData(yaw_composite, yaw_composite_variance, yaw, ivn, ive, wgt)) {
-        return;
-    }
-
-    const struct log_NKY0 nky0{
-        LOG_PACKET_HEADER_INIT(LOG_NKY0_MSG),
-        time_us                 : time_us,
-        core                    : DAL_CORE(core_index),
-        yaw_composite           : yaw_composite,
-        yaw_composite_variance  : sqrtf(MAX(yaw_composite_variance, 0.0f)),
-        yaw0                    : yaw[0],
-        yaw1                    : yaw[1],
-        yaw2                    : yaw[2],
-        yaw3                    : yaw[3],
-        yaw4                    : yaw[4],
-        wgt0                    : wgt[0],
-        wgt1                    : wgt[1],
-        wgt2                    : wgt[2],
-        wgt3                    : wgt[3],
-        wgt4                    : wgt[4],
-    };
-    AP::logger().WriteBlock(&nky0, sizeof(nky0));
-
-    const struct log_NKY1 nky1{
-        LOG_PACKET_HEADER_INIT(LOG_NKY1_MSG),
-        time_us                 : time_us,
-        core                    : DAL_CORE(core_index),
-        ivn0                    : ivn[0],
-        ivn1                    : ivn[1],
-        ivn2                    : ivn[2],
-        ivn3                    : ivn[3],
-        ivn4                    : ivn[4],
-        ive0                    : ive[0],
-        ive1                    : ive[1],
-        ive2                    : ive[2],
-        ive3                    : ive[3],
-        ive4                    : ive[4],
-    };
-    AP::logger().WriteBlock(&nky1, sizeof(nky1));
+    yawEstimator->Log_Write(time_us, LOG_NKY0_MSG, LOG_NKY1_MSG, DAL_CORE(core_index));
 }

--- a/libraries/AP_NavEKF2/LogStructure.h
+++ b/libraries/AP_NavEKF2/LogStructure.h
@@ -283,73 +283,6 @@ struct PACKED log_NKT {
     float delVelDT_max;
 };
 
-
-// @LoggerMessage: NKY0
-// @Description: EKF2 Yaw Estimator States
-// @Field: TimeUS: Time since system startup
-// @Field: C: EKF2 core this data is for
-// @Field: YC: GSF yaw estimate (rad)
-// @Field: YCS: GSF yaw estimate 1-Sigma uncertainty (rad)
-// @Field: Y0: Yaw estimate from individual EKF filter 0 (rad)
-// @Field: Y1: Yaw estimate from individual EKF filter 1 (rad)
-// @Field: Y2: Yaw estimate from individual EKF filter 2 (rad)
-// @Field: Y3: Yaw estimate from individual EKF filter 3 (rad)
-// @Field: Y4: Yaw estimate from individual EKF filter 4 (rad)
-// @Field: W0: Weighting applied to yaw estimate from individual EKF filter 0
-// @Field: W1: Weighting applied to yaw estimate from individual EKF filter 1
-// @Field: W2: Weighting applied to yaw estimate from individual EKF filter 2
-// @Field: W3: Weighting applied to yaw estimate from individual EKF filter 3
-// @Field: W4: Weighting applied to yaw estimate from individual EKF filter 4
-struct PACKED log_NKY0 {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t core;
-    float yaw_composite;
-    float yaw_composite_variance;
-    float yaw0;
-    float yaw1;
-    float yaw2;
-    float yaw3;
-    float yaw4;
-    float wgt0;
-    float wgt1;
-    float wgt2;
-    float wgt3;
-    float wgt4;
-};
-
-
-// @LoggerMessage: NKY1
-// @Description: EKF2 Yaw Estimator Innovations
-// @Field: TimeUS: Time since system startup
-// @Field: C: EKF2 core this data is for
-// @Field: IVN0: North velocity innovation from individual EKF filter 0 (m/s)
-// @Field: IVN1: North velocity innovation from individual EKF filter 1 (m/s)
-// @Field: IVN2: North velocity innovation from individual EKF filter 2 (m/s)
-// @Field: IVN3: North velocity innovation from individual EKF filter 3 (m/s)
-// @Field: IVN4: North velocity innovation from individual EKF filter 4 (m/s)
-// @Field: IVE0: East velocity innovation from individual EKF filter 0 (m/s)
-// @Field: IVE1: East velocity innovation from individual EKF filter 1 (m/s)
-// @Field: IVE2: East velocity innovation from individual EKF filter 2 (m/s)
-// @Field: IVE3: East velocity innovation from individual EKF filter 3 (m/s)
-// @Field: IVE4: East velocity innovation from individual EKF filter 4 (m/s)
-struct PACKED log_NKY1 {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t core;
-    float ivn0;
-    float ivn1;
-    float ivn2;
-    float ivn3;
-    float ivn4;
-    float ive0;
-    float ive1;
-    float ive2;
-    float ive3;
-    float ive4;
-};
-
-
 #define LOG_STRUCTURE_FROM_NAVEKF2        \
     { LOG_NKF0_MSG, sizeof(log_NKF0), \
       "NKF0","QBBccCCcccccccc","TimeUS,C,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL,OFN,OFE,OFD", "s#-m---mmmmmmmm", "F--B---BBBBBBBB" }, \
@@ -365,8 +298,4 @@ struct PACKED log_NKY1 {
       "NKF5","QBBhhhcccCCfff","TimeUS,C,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,eAng,eVel,ePos", "s#----m???mrnm", "F-----BBBBB000" }, \
     { LOG_NKQ_MSG, sizeof(log_NKQ), "NKQ", "QBffff", "TimeUS,C,Q1,Q2,Q3,Q4", "s#????", "F-????" }, \
     { LOG_NKT_MSG, sizeof(log_NKT),   \
-      "NKT", "QBIffffffff", "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax", "s#sssssssss", "F-000000000"}, \
-    { LOG_NKY0_MSG, sizeof(log_NKY0),                         \
-      "NKY0", "QBffffffffffff", "TimeUS,C,YC,YCS,Y0,Y1,Y2,Y3,Y4,W0,W1,W2,W3,W4", "s#rrrrrrr-----", "F-000000000000"}, \
-    { LOG_NKY1_MSG, sizeof(log_NKY1),                         \
-      "NKY1", "QBffffffffff", "TimeUS,C,IVN0,IVN1,IVN2,IVN3,IVN4,IVE0,IVE1,IVE2,IVE3,IVE4", "s#nnnnnnnnnn", "F-0000000000"},
+      "NKT", "QBIffffffff", "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax", "s#sssssssss", "F-000000000"},

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -423,51 +423,5 @@ void NavEKF3_core::Log_Write_GSF(uint64_t time_us)
     if (yawEstimator == nullptr) {
         return;
     }
-
-    float yaw_composite;
-    float yaw_composite_variance;
-    float yaw[N_MODELS_EKFGSF];
-    float ivn[N_MODELS_EKFGSF];
-    float ive[N_MODELS_EKFGSF];
-    float wgt[N_MODELS_EKFGSF];
-
-    if (!yawEstimator->getLogData(yaw_composite, yaw_composite_variance, yaw, ivn, ive, wgt)) {
-        return;
-    }
-
-    const struct log_XKY0 xky0{
-        LOG_PACKET_HEADER_INIT(LOG_XKY0_MSG),
-        time_us                 : time_us,
-        core                    : DAL_CORE(core_index),
-        yaw_composite           : yaw_composite,
-        yaw_composite_variance  : sqrtf(MAX(yaw_composite_variance, 0.0f)),
-        yaw0                    : yaw[0],
-        yaw1                    : yaw[1],
-        yaw2                    : yaw[2],
-        yaw3                    : yaw[3],
-        yaw4                    : yaw[4],
-        wgt0                    : wgt[0],
-        wgt1                    : wgt[1],
-        wgt2                    : wgt[2],
-        wgt3                    : wgt[3],
-        wgt4                    : wgt[4],
-    };
-    AP::logger().WriteBlock(&xky0, sizeof(xky0));
-
-    const struct log_XKY1 xky1{
-        LOG_PACKET_HEADER_INIT(LOG_XKY1_MSG),
-        time_us                 : time_us,
-        core                    : DAL_CORE(core_index),
-        ivn0                    : ivn[0],
-        ivn1                    : ivn[1],
-        ivn2                    : ivn[2],
-        ivn3                    : ivn[3],
-        ivn4                    : ivn[4],
-        ive0                    : ive[0],
-        ive1                    : ive[1],
-        ive2                    : ive[2],
-        ive3                    : ive[3],
-        ive4                    : ive[4],
-    };
-    AP::logger().WriteBlock(&xky1, sizeof(xky1));
+    yawEstimator->Log_Write(time_us, LOG_XKY0_MSG, LOG_XKY1_MSG, DAL_CORE(core_index));
 }

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -418,73 +418,6 @@ struct PACKED log_XKV {
     float v11;
 };
 
-
-// @LoggerMessage: XKY0
-// @Description: EKF3 Yaw Estimator States
-// @Field: TimeUS: Time since system startup
-// @Field: C: EKF3 core this data is for
-// @Field: YC: GSF yaw estimate (rad)
-// @Field: YCS: GSF yaw estimate 1-Sigma uncertainty (rad)
-// @Field: Y0: Yaw estimate from individual EKF filter 0 (rad)
-// @Field: Y1: Yaw estimate from individual EKF filter 1 (rad)
-// @Field: Y2: Yaw estimate from individual EKF filter 2 (rad)
-// @Field: Y3: Yaw estimate from individual EKF filter 3 (rad)
-// @Field: Y4: Yaw estimate from individual EKF filter 4 (rad)
-// @Field: W0: Weighting applied to yaw estimate from individual EKF filter 0
-// @Field: W1: Weighting applied to yaw estimate from individual EKF filter 1
-// @Field: W2: Weighting applied to yaw estimate from individual EKF filter 2
-// @Field: W3: Weighting applied to yaw estimate from individual EKF filter 3
-// @Field: W4: Weighting applied to yaw estimate from individual EKF filter 4
-struct PACKED log_XKY0 {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t core;
-    float yaw_composite;
-    float yaw_composite_variance;
-    float yaw0;
-    float yaw1;
-    float yaw2;
-    float yaw3;
-    float yaw4;
-    float wgt0;
-    float wgt1;
-    float wgt2;
-    float wgt3;
-    float wgt4;
-};
-
-
-// @LoggerMessage: XKY1
-// @Description: EKF3 Yaw Estimator Innovations
-// @Field: TimeUS: Time since system startup
-// @Field: C: EKF3 core this data is for
-// @Field: IVN0: North velocity innovation from individual EKF filter 0 (m/s)
-// @Field: IVN1: North velocity innovation from individual EKF filter 1 (m/s)
-// @Field: IVN2: North velocity innovation from individual EKF filter 2 (m/s)
-// @Field: IVN3: North velocity innovation from individual EKF filter 3 (m/s)
-// @Field: IVN4: North velocity innovation from individual EKF filter 4 (m/s)
-// @Field: IVE0: East velocity innovation from individual EKF filter 0 (m/s)
-// @Field: IVE1: East velocity innovation from individual EKF filter 1 (m/s)
-// @Field: IVE2: East velocity innovation from individual EKF filter 2 (m/s)
-// @Field: IVE3: East velocity innovation from individual EKF filter 3 (m/s)
-// @Field: IVE4: East velocity innovation from individual EKF filter 4 (m/s)
-struct PACKED log_XKY1 {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t core;
-    float ivn0;
-    float ivn1;
-    float ivn2;
-    float ivn3;
-    float ivn4;
-    float ive0;
-    float ive1;
-    float ive2;
-    float ive3;
-    float ive4;
-};
-
-
 #define LOG_STRUCTURE_FROM_NAVEKF3        \
     { LOG_XKF0_MSG, sizeof(log_XKF0), \
       "XKF0","QBBccCCcccccccc","TimeUS,C,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL,OFN,OFE,OFD", "s#-m---mmmmmmmm", "F--B---BBBBBBBB" }, \
@@ -509,10 +442,6 @@ struct PACKED log_XKY1 {
       "XKT", "QBIffffffff", "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax", "s#sssssssss", "F-000000000"}, \
     { LOG_XKTV_MSG, sizeof(log_XKTV),                         \
       "XKTV", "QBff", "TimeUS,C,TVS,TVD", "s#rr", "F-00"}, \
-    { LOG_XKY0_MSG, sizeof(log_XKY0),                         \
-      "XKY0", "QBffffffffffff", "TimeUS,C,YC,YCS,Y0,Y1,Y2,Y3,Y4,W0,W1,W2,W3,W4", "s#rrrrrrr-----", "F-000000000000"}, \
-    { LOG_XKY1_MSG, sizeof(log_XKY1),                         \
-      "XKY1", "QBffffffffff", "TimeUS,C,IVN0,IVN1,IVN2,IVN3,IVN4,IVE0,IVE1,IVE2,IVE3,IVE4", "s#nnnnnnnnnn", "F-0000000000"}, \
     { LOG_XKV1_MSG, sizeof(log_XKV), \
       "XKV1","QBffffffffffff","TimeUS,C,V00,V01,V02,V03,V04,V05,V06,V07,V08,V09,V10,V11", "s#------------", "F-------------" }, \
     { LOG_XKV2_MSG, sizeof(log_XKV), \


### PR DESCRIPTION
Passing the data back to the EKFs is just painful; far easier to pass the relevant numbers into the common function.

This will allow us to add more logging to the GSF and get both EKFs at once.
