### PR TITLE
AP_IOMCU: Fix for 12-bit ADC scaling for RSSI and VSERVO (fixes IOMCU RSSI saturation bug)

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -41,7 +41,7 @@ extern AP_IOMCU iomcu;
 #define ANLOGIN_DEBUGGING 0
 
 // base voltage scaling for 12 bit 3.3V ADC
-#define VOLTAGE_SCALING (3.3f/(1<<12))
+#define VOLTAGE_SCALING (3.3f/((1<<12) - 1))
 
 #if ANLOGIN_DEBUGGING
  # define Debug(fmt, args ...)  do {printf("%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)

--- a/libraries/AP_IOMCU/iofirmware/analog.cpp
+++ b/libraries/AP_IOMCU/iofirmware/analog.cpp
@@ -75,14 +75,14 @@ static uint16_t adc_sample_channel(uint32_t channel)
 uint16_t adc_sample_vservo(void)
 {
     const uint32_t channel = ADC_SQR3_SQ1_N(ADC_CHANNEL_IN4);
-    return adc_sample_channel(channel) * 9900 / 4096;
+    return adc_sample_channel(channel) * 9744 / 4095; // ADC full scale is reached with 3.3*(33+16.9)/16.9 = 9744mV ((33K/16K9 voltage divider)
 }
 
 /*
-  capture VRSSI in mV
+  capture VRSSI in mV (direct input, w/o voltage divider)
  */
 uint16_t adc_sample_vrssi(void)
 {
     const uint32_t channel = ADC_SQR3_SQ1_N(ADC_CHANNEL_IN5);
-    return adc_sample_channel(channel) * 9900 / 4096;
+    return adc_sample_channel(channel) * 3300 / 4095;
 }


### PR DESCRIPTION
Fixes #16451. Plus fix for servo rail conversion and also tiny beautyfix by the scaling division with 4095, instead of 4096, as max value with 12-bit ADC is 4095.

Checked with Holybro Durandal schematics - VSERVO rail has 33K/16K9 voltage divider circuit in-between STM32F100 pin PA4 and VDD_SERVO rail, thus ADC full scale is reached with 3.3*(33+16.9)/16.9 = 9.744V.
Whereas analog RSSI signal is directly sampled with PA5 pin (just 10K protective resistor between), thus the scaling multiplicator should be 3300 instead of 9900 to get correct mV output. As described in #16451, the present state (*9900) saturated the RSSI already at 1.36V (when scaled with 3.3V in AP settings).

Closes #16600