### PR TITLE
Copter: Notify the fence breach at the notification level

### DIFF
--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -23,6 +23,10 @@ void Copter::fence_check()
     // if there is a new breach take action
     if (new_breaches) {
 
+        if (!copter.ap.land_complete) {
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+        }
+
         // if the user wants some kind of response and motors are armed
         uint8_t fence_act = fence.get_action();
         if (fence_act != AC_FENCE_ACTION_REPORT_ONLY ) {


### PR DESCRIPTION
I RTL'd during auto-flight.
I didn't know why I RTL'd.
I know there are multiple fail-safes for RTL.
I want to know what caused the RTL.
I made sure to notify the operator when I BREACH the fence.

APM PLANNER2：
![Screenshot from 2021-02-13 09-28-08](https://user-images.githubusercontent.com/646194/107835950-b4e4e880-6dde-11eb-88f8-81655dafb523.png)

SITL:
![Screenshot from 2021-02-13 09-18-17](https://user-images.githubusercontent.com/646194/107836090-2fae0380-6ddf-11eb-9d46-84311b3e235d.png)
