### PR TITLE
Copter: Add pre-arm check for velocity innovation less than 1m/s

### DIFF
--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -52,7 +52,7 @@ protected:
     bool gcs_failsafe_check(bool display_failure);
     bool winch_checks(bool display_failure) const;
     bool alt_checks(bool display_failure);
-
+    bool vel_innovation_check() const;
     void set_pre_arm_check(bool b);
 
 private:


### PR DESCRIPTION
Adds a pre-arm check so that vertical velocity innovation is less than 1m/s, as mentioned here #14881.Thanks !