### PR TITLE
AP_RPM: don't present RPM2_PIN parameter if RPM_MAX_INSTANCES <=1

### DIFF
--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -79,7 +79,6 @@ const AP_Param::GroupInfo AP_RPM::var_info[] = {
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("2_SCALING", 11, AP_RPM, _scaling[1], 1.0f),
-#endif
 
     // @Param: 2_PIN
     // @DisplayName: RPM2 input pin number
@@ -87,7 +86,8 @@ const AP_Param::GroupInfo AP_RPM::var_info[] = {
     // @Values: -1:Disabled,50:PixhawkAUX1,51:PixhawkAUX2,52:PixhawkAUX3,53:PixhawkAUX4,54:PixhawkAUX5,55:PixhawkAUX6
     // @User: Standard
     AP_GROUPINFO("2_PIN",    12, AP_RPM, _pin[1], -1),
-    
+#endif
+
     AP_GROUPEND
 };
 


### PR DESCRIPTION
Tested this by changing `RPM_MAX_INSTANCES` to 1.

We already don't compile if that define is zero....
