### PR TITLE
Remove separate calls to get delta-times for vel and ang

### DIFF
--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -369,7 +369,8 @@ void ModeFlowHold::update_height_estimate(void)
 
     // get delta velocity in body frame
     Vector3f delta_vel;
-    if (!copter.ins.get_delta_velocity(delta_vel)) {
+    float delta_vel_dt;
+    if (!copter.ins.get_delta_velocity(delta_vel, delta_vel_dt)) {
         return;
     }
 

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -275,15 +275,13 @@ void ModeSystemId::run()
 // log system id and attitude
 void ModeSystemId::log_data() const
 {
-    uint8_t index = copter.ahrs.get_primary_gyro_index();
     Vector3f delta_angle;
-    copter.ins.get_delta_angle(index, delta_angle);
-    float delta_angle_dt = copter.ins.get_delta_angle_dt(index);
+    float delta_angle_dt;
+    copter.ins.get_delta_angle(delta_angle, delta_angle_dt);
 
-    index = copter.ahrs.get_primary_accel_index();
     Vector3f delta_velocity;
-    copter.ins.get_delta_velocity(index, delta_velocity);
-    float delta_velocity_dt = copter.ins.get_delta_velocity_dt(index);
+    float delta_velocity_dt;
+    copter.ins.get_delta_velocity(delta_velocity, delta_velocity_dt);
 
     if (is_positive(delta_angle_dt) && is_positive(delta_velocity_dt)) {
         copter.Log_Write_SysID_Data(waveform_time, waveform_sample, waveform_freq_rads / (2 * M_PI), degrees(delta_angle.x / delta_angle_dt), degrees(delta_angle.y / delta_angle_dt), degrees(delta_angle.z / delta_angle_dt), delta_velocity.x / delta_velocity_dt, delta_velocity.y / delta_velocity_dt, delta_velocity.z / delta_velocity_dt);

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -545,9 +545,7 @@ public:
     // Retrieves the corrected NED delta velocity in use by the inertial navigation
     virtual void getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const {
         ret.zero();
-        const AP_InertialSensor &_ins = AP::ins();
-        _ins.get_delta_velocity(ret);
-        dt = _ins.get_delta_velocity_dt();
+        AP::ins().get_delta_velocity(ret, dt);
     }
 
     // create a view

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -150,7 +150,8 @@ AP_AHRS_DCM::matrix_update(float _G_Dt)
     for (uint8_t i=0; i<_ins.get_gyro_count(); i++) {
         if (_ins.use_gyro(i) && healthy_count < 2) {
             Vector3f dangle;
-            if (_ins.get_delta_angle(i, dangle)) {
+            float dangle_dt;
+            if (_ins.get_delta_angle(i, dangle, dangle_dt)) {
                 healthy_count++;
                 delta_angle += dangle;
             }
@@ -652,8 +653,8 @@ AP_AHRS_DCM::drift_correction(float deltat)
               each sensor, which prevents an aliasing effect
              */
             Vector3f delta_velocity;
-            _ins.get_delta_velocity(i, delta_velocity);
-            const float delta_velocity_dt = _ins.get_delta_velocity_dt(i);
+            float delta_velocity_dt;
+            _ins.get_delta_velocity(i, delta_velocity, delta_velocity_dt);
             if (delta_velocity_dt > 0) {
                 _accel_ef[i] = _dcm_matrix * (delta_velocity / delta_velocity_dt);
                 // integrate the accel vector in the earth frame between GPS readings

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1946,9 +1946,7 @@ void AP_AHRS_NavEKF::getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) cons
         return;
     }
     ret.zero();
-    const AP_InertialSensor &_ins = AP::ins();
-    _ins.get_delta_velocity((uint8_t)imu_idx, ret);
-    dt = _ins.get_delta_velocity_dt((uint8_t)imu_idx);
+    AP::ins().get_delta_velocity((uint8_t)imu_idx, ret, dt);
     ret -= accel_bias*dt;
     ret = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * ret;
     ret.z += GRAVITY_MSS*dt;

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
@@ -32,15 +32,13 @@ void AP_DAL_InertialSensor::start_frame()
         // accel data
         RISI.use_accel = ins.use_accel(i);
         if (RISI.use_accel) {
-            RISI.get_delta_velocity_ret = ins.get_delta_velocity(i, RISI.delta_velocity);
-            RISI.delta_velocity_dt = ins.get_delta_velocity_dt(i);
+            RISI.get_delta_velocity_ret = ins.get_delta_velocity(i, RISI.delta_velocity, RISI.delta_velocity_dt);
         }
 
         // gryo data
         RISI.use_gyro = ins.use_gyro(i);
         if (RISI.use_gyro) {
-            RISI.delta_angle_dt = ins.get_delta_angle_dt(i);
-            RISI.get_delta_angle_ret = ins.get_delta_angle(i, RISI.delta_angle);
+            RISI.get_delta_angle_ret = ins.get_delta_angle(i, RISI.delta_angle, RISI.delta_angle_dt);
         }
 
         update_filtered(i);

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.h
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.h
@@ -24,12 +24,10 @@ public:
 
     bool use_accel(uint8_t instance) const { return _RISI[instance].use_accel; }
     const Vector3f     &get_accel(uint8_t i) const { return accel_filtered[i]; }
-    bool get_delta_velocity(uint8_t i, Vector3f &delta_velocity) const {
+    bool get_delta_velocity(uint8_t i, Vector3f &delta_velocity, float &delta_velocity_dt) const {
         delta_velocity = _RISI[i].delta_velocity;
+        delta_velocity_dt = _RISI[i].delta_velocity_dt;
         return _RISI[i].get_delta_velocity_ret;
-    }
-    float get_delta_velocity_dt(uint8_t i) const {
-        return _RISI[i].delta_velocity_dt;
     }
 
     // gyro stuff
@@ -39,11 +37,11 @@ public:
     bool use_gyro(uint8_t instance) const { return _RISI[instance].use_gyro; }
     const Vector3f     &get_gyro(uint8_t i) const { return gyro_filtered[i]; }
     const Vector3f     &get_gyro() const { return get_gyro(_primary_gyro); }
-    bool get_delta_angle(uint8_t i, Vector3f &delta_angle) const {
+    bool get_delta_angle(uint8_t i, Vector3f &delta_angle, float &delta_angle_dt) const {
         delta_angle = _RISI[i].delta_angle;
+        delta_angle_dt = _RISI[i].delta_angle_dt;
         return _RISI[i].get_delta_angle_ret;
     }
-    float get_delta_angle_dt(uint8_t i) const { return _RISI[i].delta_angle_dt; }
 
     // return the main loop delta_t in seconds
     float get_loop_delta_t(void) const { return _RISH.loop_delta_t; }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1748,8 +1748,15 @@ check_sample:
 /*
   get delta angles
  */
-bool AP_InertialSensor::get_delta_angle(uint8_t i, Vector3f &delta_angle) const
+bool AP_InertialSensor::get_delta_angle(uint8_t i, Vector3f &delta_angle, float &delta_angle_dt) const
 {
+    if (_delta_angle_valid[i] && _delta_angle_dt[i] > 0) {
+        delta_angle_dt = _delta_angle_dt[i];
+    } else {
+        delta_angle_dt = get_delta_time();
+    }
+    delta_angle_dt = MIN(delta_angle_dt, _loop_delta_t_max);
+
     if (_delta_angle_valid[i]) {
         delta_angle = _delta_angle[i];
         return true;
@@ -1765,8 +1772,15 @@ bool AP_InertialSensor::get_delta_angle(uint8_t i, Vector3f &delta_angle) const
 /*
   get delta velocity if available
 */
-bool AP_InertialSensor::get_delta_velocity(uint8_t i, Vector3f &delta_velocity) const
+bool AP_InertialSensor::get_delta_velocity(uint8_t i, Vector3f &delta_velocity, float &delta_velocity_dt) const
 {
+    if (_delta_velocity_valid[i]) {
+        delta_velocity_dt = _delta_velocity_dt[i];
+    } else {
+        delta_velocity_dt = get_delta_time();
+    }
+    delta_velocity_dt = MIN(delta_velocity_dt, _loop_delta_t_max);
+
     if (_delta_velocity_valid[i]) {
         delta_velocity = _delta_velocity[i];
         return true;
@@ -1776,37 +1790,6 @@ bool AP_InertialSensor::get_delta_velocity(uint8_t i, Vector3f &delta_velocity) 
     }
     return false;
 }
-
-/*
-  return delta_time for the delta_velocity
- */
-float AP_InertialSensor::get_delta_velocity_dt(uint8_t i) const
-{
-    float ret;
-    if (_delta_velocity_valid[i]) {
-        ret = _delta_velocity_dt[i];
-    } else {
-        ret = get_delta_time();
-    }
-    ret = MIN(ret, _loop_delta_t_max);
-    return ret;
-}
-
-/*
-  return delta_time for the delta_angle
- */
-float AP_InertialSensor::get_delta_angle_dt(uint8_t i) const
-{
-    float ret;
-    if (_delta_angle_valid[i] && _delta_angle_dt[i] > 0) {
-        ret = _delta_angle_dt[i];
-    } else {
-        ret = get_delta_time();
-    }
-    ret = MIN(ret, _loop_delta_t_max);
-    return ret;
-}
-
 
 /*
   support for setting accel and gyro vectors, for use by HIL

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -132,18 +132,16 @@ public:
     const Vector3f &get_gyro_offsets(void) const { return get_gyro_offsets(_primary_gyro); }
 
     //get delta angle if available
-    bool get_delta_angle(uint8_t i, Vector3f &delta_angle) const;
-    bool get_delta_angle(Vector3f &delta_angle) const { return get_delta_angle(_primary_gyro, delta_angle); }
-
-    float get_delta_angle_dt(uint8_t i) const;
-    float get_delta_angle_dt() const { return get_delta_angle_dt(_primary_gyro); }
+    bool get_delta_angle(uint8_t i, Vector3f &delta_angle, float &delta_angle_dt) const;
+    bool get_delta_angle(Vector3f &delta_angle, float &delta_angle_dt) const {
+        return get_delta_angle(_primary_gyro, delta_angle, delta_angle_dt);
+    }
 
     //get delta velocity if available
-    bool get_delta_velocity(uint8_t i, Vector3f &delta_velocity) const;
-    bool get_delta_velocity(Vector3f &delta_velocity) const { return get_delta_velocity(_primary_accel, delta_velocity); }
-
-    float get_delta_velocity_dt(uint8_t i) const;
-    float get_delta_velocity_dt() const { return get_delta_velocity_dt(_primary_accel); }
+    bool get_delta_velocity(uint8_t i, Vector3f &delta_velocity, float &delta_velocity_dt) const;
+    bool get_delta_velocity(Vector3f &delta_velocity, float &delta_velocity_dt) const {
+        return get_delta_velocity(_primary_accel, delta_velocity, delta_velocity_dt);
+    }
 
     /// Fetch the current accelerometer values
     ///

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -221,7 +221,8 @@ void SoloGimbal::readVehicleDeltaAngle(uint8_t ins_index, Vector3f &dAng) {
     const AP_InertialSensor &ins = AP::ins();
 
     if (ins_index < ins.get_gyro_count()) {
-        if (!ins.get_delta_angle(ins_index,dAng)) {
+        float dAng_dt;
+        if (!ins.get_delta_angle(ins_index,dAng, dAng_dt)) {
             dAng = ins.get_gyro(ins_index) / ins.get_loop_rate_hz();
         }
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -475,8 +475,8 @@ bool NavEKF2_core::readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &d
     const auto &ins = dal.ins();
 
     if (ins_index < ins.get_accel_count()) {
-        ins.get_delta_velocity(ins_index,dVel);
-        dVel_dt = MAX(ins.get_delta_velocity_dt(ins_index),1.0e-4f);
+        ins.get_delta_velocity(ins_index,dVel, dVel_dt);
+        dVel_dt = MAX(dVel_dt,1.0e-4f);
         dVel_dt = MIN(dVel_dt,1.0e-1f);
         return true;
     }
@@ -647,8 +647,8 @@ bool NavEKF2_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng
     const auto &ins = dal.ins();
 
     if (ins_index < ins.get_gyro_count()) {
-        ins.get_delta_angle(ins_index,dAng);
-        dAng_dt = MAX(ins.get_delta_angle_dt(ins_index),1.0e-4f);
+        ins.get_delta_angle(ins_index, dAng, dAng_dt);
+        dAng_dt = MAX(dAng_dt,1.0e-4f);
         dAng_dt = MIN(dAng_dt,1.0e-1f);
         return true;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -431,8 +431,8 @@ void NavEKF3_core::readIMUData()
     imuDataNew.accel_index = accel_index_active;
     
     // Get delta angle data from primary gyro or primary if not available
-    readDeltaAngle(gyro_index_active, imuDataNew.delAng);
-    imuDataNew.delAngDT = MAX(ins.get_delta_angle_dt(gyro_index_active),1.0e-4f);
+    readDeltaAngle(gyro_index_active, imuDataNew.delAng, imuDataNew.delAngDT);
+    imuDataNew.delAngDT = MAX(imuDataNew.delAngDT, 1.0e-4f);
     imuDataNew.gyro_index = gyro_index_active;
 
     // Get current time stamp
@@ -530,8 +530,8 @@ bool NavEKF3_core::readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &d
     const auto &ins = dal.ins();
 
     if (ins_index < ins.get_accel_count()) {
-        ins.get_delta_velocity(ins_index,dVel);
-        dVel_dt = MAX(ins.get_delta_velocity_dt(ins_index),1.0e-4f);
+        ins.get_delta_velocity(ins_index,dVel,dVel_dt);
+        dVel_dt = MAX(dVel_dt,1.0e-4f);
         return true;
     }
     return false;
@@ -710,11 +710,11 @@ void NavEKF3_core::readGpsData()
 
 // read the delta angle and corresponding time interval from the IMU
 // return false if data is not available
-bool NavEKF3_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng) {
+bool NavEKF3_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAngDT) {
     const auto &ins = dal.ins();
 
     if (ins_index < ins.get_gyro_count()) {
-        ins.get_delta_angle(ins_index,dAng);
+        ins.get_delta_angle(ins_index, dAng, dAngDT);
         return true;
     }
     return false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -680,7 +680,7 @@ private:
 
     // helper functions for readIMUData
     bool readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &dVel_dt);
-    bool readDeltaAngle(uint8_t ins_index, Vector3f &dAng);
+    bool readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng_dt);
 
     // helper functions for correcting IMU data
     void correctDeltaAngle(Vector3f &delAng, float delAngDT, uint8_t gyro_index);


### PR DESCRIPTION
It is almost always going to be an error to use the delta-angle without the corresponding delta-angle-dt, so make the caller get both.

This shows up places where we *aren't* using both; the AP_AHRS_DCM case is interesting as we *do* use the delta-velocity-dt but don't use the delta-angle-dt.  We should probably be dividing by dellta_angle_dt then multipling by our own _dt (or similar).

I just moved the logic from the time-getters into the value-getters.

I haven't fixed any of the callers as this should be essentially NFC.
