### PR TITLE
Use terrain singleton in WPNav and Location

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -13,7 +13,6 @@
 //#define AC_RALLY              DISABLED            // disable rally points library (must also disable terrain which relies on rally)
 //#define AC_AVOID_ENABLED      DISABLED            // disable stop-at-fence library
 //#define AC_OAPATHPLANNER_ENABLED DISABLED         // disable path planning around obstacles
-//#define AC_TERRAIN            DISABLED            // disable terrain library
 //#define PARACHUTE             DISABLED            // disable parachute release to save 1k of flash
 //#define NAV_GUIDED            DISABLED            // disable external navigation computer ability to control vehicle through MAV_CMD_NAV_GUIDED mission commands
 //#define OPTFLOW               DISABLED            // disable optical flow sensor to save 5K of flash space

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -248,7 +248,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
                 }
                 break;
             case AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE:
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
                 if (!copter.terrain.enabled()) {
                     check_failed(ARMING_CHECK_PARAMETERS, display_failure, failure_template, "terrain disabled");
                     return false;

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -175,7 +175,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if ADVANCED_FAILSAFE == ENABLED
     SCHED_TASK(afs_fs_check,          10,    100),
 #endif
-#if AC_TERRAIN == ENABLED
+#if AP_TERRAIN_AVAILABLE
     SCHED_TASK(terrain_update,        10,    100),
 #endif
 #if GRIPPER_ENABLED == ENABLED

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -120,7 +120,7 @@
 #if AC_FENCE == ENABLED
  # include <AC_Fence/AC_Fence.h>
 #endif
-#if AC_TERRAIN == ENABLED
+#if AP_TERRAIN_AVAILABLE
  # include <AP_Terrain/AP_Terrain.h>
 #endif
 #if OPTFLOW == ENABLED
@@ -516,7 +516,7 @@ private:
 #endif
 
     // terrain handling
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN && MODE_AUTO_ENABLED == ENABLED
+#if AP_TERRAIN_AVAILABLE && MODE_AUTO_ENABLED == ENABLED
     AP_Terrain terrain{mode_auto.mission};
 #endif
 

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -134,7 +134,7 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
     }
 #endif
 
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     switch (copter.terrain.status()) {
     case AP_Terrain::TerrainStatusDisabled:
         break;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -287,7 +287,7 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
     switch(id) {
 
     case MSG_TERRAIN:
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
         CHECK_PAYLOAD_SIZE(TERRAIN_REQUEST);
         copter.terrain.send_request(chan);
 #endif
@@ -469,7 +469,7 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_WIND,
     MSG_RANGEFINDER,
     MSG_DISTANCE_SENSOR,
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     MSG_TERRAIN,
 #endif
     MSG_BATTERY2,
@@ -1249,7 +1249,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
 
     case MAVLINK_MSG_ID_TERRAIN_DATA:
     case MAVLINK_MSG_ID_TERRAIN_CHECK:
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
         copter.terrain.handle_data(chan, msg);
 #endif
         break;
@@ -1329,7 +1329,7 @@ uint64_t GCS_MAVLINK_Copter::capabilities() const
             MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT |
             MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION |
             MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET |
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
             (copter.terrain.enabled() ? MAV_PROTOCOL_CAPABILITY_TERRAIN : 0) |
 #endif
             GCS_MAVLINK::capabilities());

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -27,7 +27,7 @@ void Copter::Log_Write_Control_Tuning()
 {
     // get terrain altitude
     float terr_alt = 0.0f;
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     if (!terrain.height_above_terrain(terr_alt, true)) {
         terr_alt = logger.quiet_nan();
     }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -700,7 +700,7 @@ const AP_Param::Info Copter::var_info[] = {
     GOBJECT(rangefinder,   "RNGFND", RangeFinder),
 #endif
 
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     // @Group: TERRAIN_
     // @Path: ../libraries/AP_Terrain/AP_Terrain.cpp
     GOBJECT(terrain,                "TERRAIN_", AP_Terrain),

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -658,11 +658,7 @@
  #define AC_RALLY   ENABLED
 #endif
 
-#ifndef AC_TERRAIN
- #define AC_TERRAIN ENABLED
-#endif
-
-#if AC_TERRAIN && !AC_RALLY
+#if AP_TERRAIN_AVAILABLE && !AC_RALLY
  #error Terrain relies on Rally which is disabled
 #endif
 
@@ -694,7 +690,7 @@
   #error ModeAuto requires ModeRTL which is disabled
 #endif
 
-#if AC_TERRAIN && !MODE_AUTO_ENABLED
+#if AP_TERRAIN_AVAILABLE && !MODE_AUTO_ENABLED
   #error Terrain requires ModeAuto which is disabled
 #endif
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -107,7 +107,7 @@ void Copter::init_ardupilot()
     AP::compass().init();
 
     // init Location class
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     Location::set_terrain(&terrain);
     wp_nav->set_terrain(&terrain);
 #endif

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -106,12 +106,6 @@ void Copter::init_ardupilot()
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 
-    // init Location class
-#if AP_TERRAIN_AVAILABLE
-    Location::set_terrain(&terrain);
-    wp_nav->set_terrain(&terrain);
-#endif
-
 #if AC_OAPATHPLANNER_ENABLED == ENABLED
     g2.oa.init();
 #endif

--- a/ArduCopter/terrain.cpp
+++ b/ArduCopter/terrain.cpp
@@ -3,7 +3,7 @@
 // update terrain data
 void Copter::terrain_update()
 {
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     terrain.update();
 
     // tell the rangefinder our height, so it can go into power saving
@@ -20,7 +20,7 @@ void Copter::terrain_update()
 // log terrain data - should be called at 1hz
 void Copter::terrain_logging()
 {
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     if (should_log(MASK_LOG_GPS)) {
         terrain.log_terrain_data();
     }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -790,9 +790,6 @@ bool QuadPlane::setup(void)
         AP_BoardConfig::config_error("Unable to allocate %s", "wp_nav");
     }
     AP_Param::load_object_from_eeprom(wp_nav, wp_nav->var_info);
-#if AP_TERRAIN_AVAILABLE
-    wp_nav->set_terrain(&plane.terrain);
-#endif
 
     loiter_nav = new AC_Loiter(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
     if (!loiter_nav) {

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -146,11 +146,6 @@ void Plane::init_ardupilot()
 #if AC_FENCE == ENABLED
     fence.init();
 #endif
-
-#if AP_TERRAIN_AVAILABLE
-    Location::set_terrain(&terrain);
-#endif
-
 }
 
 //********************************************************************************

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -226,7 +226,7 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
         break;
 
     case MSG_TERRAIN:
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
         CHECK_PAYLOAD_SIZE(TERRAIN_REQUEST);
         sub.terrain.send_request(chan);
 #endif
@@ -361,7 +361,7 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_SYSTEM_TIME,
     MSG_RANGEFINDER,
     MSG_DISTANCE_SENSOR,
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     MSG_TERRAIN,
 #endif
     MSG_BATTERY2,
@@ -709,7 +709,7 @@ void GCS_MAVLINK_Sub::handleMessage(const mavlink_message_t &msg)
 
     case MAVLINK_MSG_ID_TERRAIN_DATA:
     case MAVLINK_MSG_ID_TERRAIN_CHECK:
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
         sub.terrain.handle_data(chan, msg);
 #endif
         break;
@@ -761,7 +761,7 @@ uint64_t GCS_MAVLINK_Sub::capabilities() const
             MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED |
             MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT |
             MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION |
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
             (sub.terrain.enabled() ? MAV_PROTOCOL_CAPABILITY_TERRAIN : 0) |
 #endif
             MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET |

--- a/ArduSub/GCS_Sub.cpp
+++ b/ArduSub/GCS_Sub.cpp
@@ -67,7 +67,7 @@ void GCS_Sub::update_vehicle_sensor_status_flags()
     }
 #endif
 
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     switch (sub.terrain.status()) {
     case AP_Terrain::TerrainStatusDisabled:
         break;

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -27,7 +27,7 @@ void Sub::Log_Write_Control_Tuning()
 {
     // get terrain altitude
     float terr_alt = 0.0f;
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     terrain.height_above_terrain(terr_alt, true);
 #endif
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -593,7 +593,7 @@ const AP_Param::Info Sub::var_info[] = {
     GOBJECT(rangefinder,   "RNGFND", RangeFinder),
 #endif
 
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     // @Group: TERRAIN_
     // @Path: ../libraries/AP_Terrain/AP_Terrain.cpp
     GOBJECT(terrain,                "TERRAIN_", AP_Terrain),

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -376,7 +376,7 @@ private:
 #endif
 
     // terrain handling
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     AP_Terrain terrain{mission};
 #endif
 

--- a/ArduSub/config.h
+++ b/ArduSub/config.h
@@ -244,7 +244,3 @@
 #ifndef AC_RALLY
 #define AC_RALLY   DISABLED
 #endif
-
-#ifndef AC_TERRAIN
-#define AC_TERRAIN DISABLED // Requires Rally enabled as well
-#endif

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -83,12 +83,6 @@ void Sub::init_ardupilot()
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 
-    // init Location class
-#if AP_TERRAIN_AVAILABLE
-    Location::set_terrain(&terrain);
-    wp_nav.set_terrain(&terrain);
-#endif
-
 #if OPTFLOW == ENABLED
     // initialise optical flow sensor
     optflow.init(MASK_LOG_OPTFLOW);

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -84,7 +84,7 @@ void Sub::init_ardupilot()
     AP::compass().init();
 
     // init Location class
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     Location::set_terrain(&terrain);
     wp_nav.set_terrain(&terrain);
 #endif

--- a/ArduSub/terrain.cpp
+++ b/ArduSub/terrain.cpp
@@ -3,7 +3,7 @@
 // update terrain data
 void Sub::terrain_update()
 {
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     terrain.update();
 
     // tell the rangefinder our height, so it can go into power saving
@@ -20,7 +20,7 @@ void Sub::terrain_update()
 // log terrain data - should be called at 1hz
 void Sub::terrain_logging()
 {
-#if AP_TERRAIN_AVAILABLE && AC_TERRAIN
+#if AP_TERRAIN_AVAILABLE
     if (should_log(MASK_LOG_GPS)) {
         terrain.log_terrain_data();
     }

--- a/Tools/autotest/build-with-disabled-features.py
+++ b/Tools/autotest/build-with-disabled-features.py
@@ -19,7 +19,7 @@ lckfile='/home/pbarker/rc/buildlogs/autotest.lck'
 >>>> PASSED STEP: build.ArduCopter at Thu Feb 22 09:46:43 2018
 check step:  build.ArduCopter
 BWFD: ADVANCED_FAILSAFE OK
-BWFD: Successes: ['MOUNT', 'AUTOTUNE_ENABLED', 'AC_FENCE', 'CAMERA', 'RANGEFINDER_ENABLED', 'PROXIMITY_ENABLED', 'AC_RALLY', 'AC_AVOID_ENABLED', 'AC_TERRAIN', 'PARACHUTE', 'NAV_GUIDED', 'OPTFLOW', 'VISUAL_ODOMETRY_ENABLED', 'FRSKY_TELEM_ENABLED', 'ADSB_ENABLED', 'PRECISION_LANDING', 'SPRAYER', 'WINCH_ENABLED', 'ADVANCED_FAILSAFE']
+BWFD: Successes: ['MOUNT', 'AUTOTUNE_ENABLED', 'AC_FENCE', 'CAMERA', 'RANGEFINDER_ENABLED', 'PROXIMITY_ENABLED', 'AC_RALLY', 'AC_AVOID_ENABLED', 'PARACHUTE', 'NAV_GUIDED', 'OPTFLOW', 'VISUAL_ODOMETRY_ENABLED', 'FRSKY_TELEM_ENABLED', 'ADSB_ENABLED', 'PRECISION_LANDING', 'SPRAYER', 'WINCH_ENABLED', 'ADVANCED_FAILSAFE']
 BWFD: Failures: ['LOGGING_ENABLED']
 pbarker@bluebottle:~/rc/ardupilot(build-with-disabled-features)$ q
 
@@ -194,8 +194,8 @@ class BuilderCopter(Builder):
         return ret
 
 
-# read reverse dep "MODE_AUTO_ENABLED": ["AC_TERRAIN", "MODE_GUIDED"] thusly:
-# "if mode-auto is disabled then you must also disable terrain and guided mode"
+# read reverse dep "MODE_AUTO_ENABLED": ["MODE_GUIDED"] thusly:
+# "if mode-auto is disabled then you must also disable guided mode"
 
 specs = [
     {
@@ -205,13 +205,11 @@ specs = [
         "reverse-deps": {
             "AC_FENCE": ["AC_AVOID_ENABLED", "MODE_FOLLOW_ENABLED"],
             "PROXIMITY_ENABLED": ["AC_AVOID_ENABLED", "MODE_FOLLOW_ENABLED"],
-            "AC_RALLY": ["AC_TERRAIN"],
-            "MODE_AUTO_ENABLED": ["AC_TERRAIN", "MODE_GUIDED", "ADVANCED_FAILSAFE"],
-            "MODE_RTL_ENABLED": ["MODE_AUTO_ENABLED", "AC_TERRAIN", "MODE_SMARTRTL_ENABLED"],
+            "MODE_AUTO_ENABLED": ["MODE_GUIDED", "ADVANCED_FAILSAFE"],
+            "MODE_RTL_ENABLED": ["MODE_AUTO_ENABLED", "MODE_SMARTRTL_ENABLED"],
             "BEACON_ENABLED": ["AC_AVOID_ENABLED", "MODE_FOLLOW_ENABLED"],
-            "MODE_CIRCLE_ENABLED": ["MODE_AUTO_ENABLED", "AC_TERRAIN"],
+            "MODE_CIRCLE_ENABLED": ["MODE_AUTO_ENABLED", "AP_TERRAIN_AVAILABLE"],
             "MODE_GUIDED_ENABLED": ["MODE_AUTO_ENABLED",
-                                    "AC_TERRAIN",
                                     "ADSB_ENABLED",
                                     "MODE_FOLLOW_ENABLED",
                                     "MODE_GUIDED_NOGPS_ENABLED"],
@@ -228,13 +226,11 @@ specs = [
         "reverse-deps": {
             "AC_FENCE": ["AC_AVOID_ENABLED", "MODE_FOLLOW_ENABLED"],
             "PROXIMITY_ENABLED": ["AC_AVOID_ENABLED", "MODE_FOLLOW_ENABLED"],
-            "AC_RALLY": ["AC_TERRAIN"],
-            "MODE_AUTO_ENABLED": ["AC_TERRAIN", "MODE_GUIDED", "ADVANCED_FAILSAFE"],
-            "MODE_RTL_ENABLED": ["MODE_AUTO_ENABLED", "AC_TERRAIN", "MODE_SMARTRTL_ENABLED"],
+            "MODE_AUTO_ENABLED": ["MODE_GUIDED", "ADVANCED_FAILSAFE"],
+            "MODE_RTL_ENABLED": ["MODE_AUTO_ENABLED", "MODE_SMARTRTL_ENABLED"],
             "BEACON_ENABLED": ["AC_AVOID_ENABLED", "MODE_FOLLOW_ENABLED"],
-            "MODE_CIRCLE_ENABLED": ["MODE_AUTO_ENABLED", "AC_TERRAIN"],
+            "MODE_CIRCLE_ENABLED": ["MODE_AUTO_ENABLED"],
             "MODE_GUIDED_ENABLED": ["MODE_AUTO_ENABLED",
-                                    "AC_TERRAIN",
                                     "ADSB_ENABLED",
                                     "MODE_FOLLOW_ENABLED",
                                     "MODE_GUIDED_NOGPS_ENABLED"],
@@ -260,7 +256,6 @@ specs = [
         "reverse-deps": {
             "AC_FENCE": ["AVOIDANCE_ENABLED"],
             "PROXIMITY_ENABLED": ["AVOIDANCE_ENABLED"],
-            "AC_RALLY": ["AC_TERRAIN"],
         },
     }, {
         "config": 'AntennaTracker/config.h',

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -103,7 +103,8 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
         return AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER;
     }
 #if AP_TERRAIN_AVAILABLE
-    if ((_terrain != nullptr) && _terrain->enabled()) {
+    const AP_Terrain *terrain = AP::terrain();
+    if (terrain != nullptr && terrain->enabled()) {
         return AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE;
     } else {
         return AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE;
@@ -575,7 +576,9 @@ bool AC_WPNav::get_terrain_offset(float& offset_cm)
     case AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE:
 #if AP_TERRAIN_AVAILABLE
         float terr_alt = 0.0f;
-        if (_terrain != nullptr && _terrain->height_above_terrain(terr_alt, true)) {
+        AP_Terrain *terrain = AP::terrain();
+        if (terrain != nullptr &&
+            terrain->height_above_terrain(terr_alt, true)) {
             offset_cm = _inav.get_altitude() - (terr_alt * 100.0f);
             return true;
         }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -31,9 +31,6 @@ public:
     /// Constructor
     AC_WPNav(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
 
-    /// provide pointer to terrain database
-    void set_terrain(AP_Terrain* terrain_ptr) { _terrain = terrain_ptr; }
-
     /// provide rangefinder altitude
     void set_rangefinder_alt(bool use, bool healthy, float alt_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_alt_cm = alt_cm; }
 
@@ -232,7 +229,6 @@ protected:
     const AP_AHRS_View&     _ahrs;
     AC_PosControl&          _pos_control;
     const AC_AttitudeControl& _attitude_control;
-    AP_Terrain              *_terrain;
 
     // parameters
     AP_Float    _wp_speed_cms;          // default maximum horizontal speed in cm/s during missions

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -7,8 +7,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Terrain/AP_Terrain.h>
 
-AP_Terrain *Location::_terrain = nullptr;
-
 /// constructors
 Location::Location()
 {
@@ -122,7 +120,11 @@ bool Location::get_alt_cm(AltFrame desired_frame, int32_t &ret_alt_cm) const
     float alt_terr_cm = 0;
     if (frame == AltFrame::ABOVE_TERRAIN || desired_frame == AltFrame::ABOVE_TERRAIN) {
 #if AP_TERRAIN_AVAILABLE
-        if (_terrain == nullptr || !_terrain->height_amsl(*this, alt_terr_cm, true)) {
+        AP_Terrain *terrain = AP::terrain();
+        if (terrain == nullptr) {
+            return false;
+        }
+        if (!terrain->height_amsl(*this, alt_terr_cm, true)) {
             return false;
         }
         // convert terrain alt to cm

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -2,8 +2,6 @@
 
 #include <AP_Math/AP_Math.h>
 
-class AP_Terrain;
-
 #define LOCATION_ALT_MAX_M  83000   // maximum altitude (in meters) that can be fit into Location structure's alt field
 
 class Location
@@ -33,8 +31,6 @@ public:
     Location();
     Location(int32_t latitude, int32_t longitude, int32_t alt_in_cm, AltFrame frame);
     Location(const Vector3f &ekf_offset_neu, AltFrame frame);
-
-    static void set_terrain(AP_Terrain* terrain) { _terrain = terrain; }
 
     // set altitude
     void set_alt_cm(int32_t alt_cm, AltFrame frame);
@@ -128,7 +124,6 @@ public:
     static int32_t diff_longitude(int32_t lon1, int32_t lon2);
     
 private:
-    static AP_Terrain *_terrain;
 
     // scaling factor from 1e-7 degrees to meters at equator
     // == 1.0e-7 * DEG_TO_RAD * RADIUS_OF_EARTH

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -185,6 +185,7 @@ TEST(Location, Tests)
     EXPECT_EQ(Location::AltFrame::ABOVE_TERRAIN, test_location3.get_alt_frame());
 
     // No TERRAIN, NO HOME, NO ORIGIN
+    AP::terrain()->set_enabled(false);
     for (auto current_frame = Location::AltFrame::ABSOLUTE;
          current_frame <= Location::AltFrame::ABOVE_TERRAIN;
          current_frame = static_cast<Location::AltFrame>(
@@ -240,7 +241,7 @@ TEST(Location, Tests)
         }
     }
     // NO Origin
-    Location::set_terrain(&vehicle.terrain);
+    AP::terrain()->set_enabled(true);
     for (auto current_frame = Location::AltFrame::ABSOLUTE;
          current_frame <= Location::AltFrame::ABOVE_TERRAIN;
          current_frame = static_cast<Location::AltFrame>(

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -30,6 +30,12 @@ extern const AP_HAL::HAL& hal;
 
 AP_Terrain *AP_Terrain::singleton;
 
+#if APM_BUILD_TYPE(APM_BUILD_ArduSub)
+#define TERRAIN_ENABLE_DEFAULT 0
+#else
+#define TERRAIN_ENABLE_DEFAULT 1
+#endif
+
 // table of user settable parameters
 const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Param: ENABLE
@@ -37,7 +43,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Description: enable terrain data. This enables the vehicle storing a database of terrain data on the SD card. The terrain data is requested from the ground station as needed, and stored for later use on the SD card. To be useful the ground station must support TERRAIN_REQUEST messages and have access to a terrain database, such as the SRTM database.
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Terrain, enable, 1, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Terrain, enable, TERRAIN_ENABLE_DEFAULT, AP_PARAM_FLAG_ENABLE),
 
     // @Param: SPACING
     // @DisplayName: Terrain grid spacing

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -19,10 +19,12 @@
 #include <AP_Common/Location.h>
 #include <AP_Filesystem/AP_Filesystem_Available.h>
 
+#ifndef AP_TERRAIN_AVAILABLE
 #if HAVE_FILESYSTEM_SUPPORT && defined(HAL_BOARD_TERRAIN_DIRECTORY)
 #define AP_TERRAIN_AVAILABLE 1
 #else
 #define AP_TERRAIN_AVAILABLE 0
+#endif
 #endif
 
 #if AP_TERRAIN_AVAILABLE

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -103,6 +103,7 @@ public:
     void update(void);
 
     bool enabled() const { return enable; }
+    void set_enabled(bool _enable) { enable = _enable; }
 
     // return status enum for health reporting
     enum TerrainStatus status(void) const { return system_status; }

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -33,6 +33,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Declination/AP_Declination.h>
+#include <AP_Terrain/AP_Terrain.h>
 
 using namespace SITL;
 
@@ -63,8 +64,6 @@ Aircraft::Aircraft(const char *frame_str) :
         sitl->ahrs_rotation_inv = sitl->ahrs_rotation.transposed();
     }
 
-    terrain = AP::terrain();
-
     // init rangefinder array to -1 to signify no data
     for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++){
         rangefinder_m[i] = -1.0f;
@@ -94,14 +93,18 @@ void Aircraft::set_start_location(const Location &start_loc, const float start_y
 */
 float Aircraft::ground_height_difference() const
 {
+#if AP_TERRAIN_AVAILABLE
+    AP_Terrain *terrain = AP::terrain();
     float h1, h2;
     if (sitl &&
-        sitl->terrain_enable && terrain &&
+        terrain != nullptr &&
+        sitl->terrain_enable &&
         terrain->height_amsl(home, h1, false) &&
         terrain->height_amsl(location, h2, false)) {
         h2 += local_ground_level;
         return h2 - h1;
     }
+#endif
     return local_ground_level;
 }
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -22,7 +22,6 @@
 
 #include "SITL.h"
 #include "SITL_Input.h"
-#include <AP_Terrain/AP_Terrain.h>
 #include "SIM_Sprayer.h"
 #include "SIM_Gripper_Servo.h"
 #include "SIM_Gripper_EPM.h"
@@ -243,7 +242,6 @@ protected:
 
     bool use_smoothing;
 
-    AP_Terrain *terrain;
     float ground_height_difference() const;
 
     virtual bool on_ground() const;

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -174,21 +174,15 @@ void ShipSim::send_report(void)
     Location loc = home;
     loc.offset(ship.position.x, ship.position.y);
 
-    int32_t alt;
-    bool have_alt = false;
+    int32_t alt = home.alt;  // assume home altitude
 
 #if AP_TERRAIN_AVAILABLE
     auto terrain = AP::terrain();
     float height;
     if (terrain != nullptr && terrain->enabled() && terrain->height_amsl(loc, height, true)) {
         alt = height * 1000;
-        have_alt = true;
     }
 #endif
-    if (!have_alt) {
-        // assume home altitude
-        alt = home.alt;
-    }
 
     Vector2f vel(ship.speed, 0);
     vel.rotate(radians(ship.heading_deg));

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -174,13 +174,13 @@ void ShipSim::send_report(void)
     Location loc = home;
     loc.offset(ship.position.x, ship.position.y);
 
-    int32_t alt = home.alt;  // assume home altitude
+    int32_t alt_mm = home.alt * 10;  // assume home altitude
 
 #if AP_TERRAIN_AVAILABLE
     auto terrain = AP::terrain();
     float height;
     if (terrain != nullptr && terrain->enabled() && terrain->height_amsl(loc, height, true)) {
-        alt = height * 1000;
+        alt_mm = height * 1000;
     }
 #endif
 
@@ -194,7 +194,7 @@ void ShipSim::send_report(void)
                                               now,
                                               loc.lat,
                                               loc.lng,
-                                              alt,
+                                              alt_mm,
                                               0,
                                               vel.x*100,
                                               vel.y*100,


### PR DESCRIPTION
... instead of having the vehicles shove the terrain pointer in.

This is a significant change on Plane as it never used to set this pointer.  This might have affected terrain-relative missions in quadplanes while doing VTOL flight as Location would not be able to convert terrain-relative to home-relative-altitude, for example.

TODO: write an autotest for quadplanes doing terrain-relative VTOL flight
