### PR TITLE
Copter: ensure send_position_target_global_int alt always absolute

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -96,6 +96,12 @@ void GCS_MAVLINK_Copter::send_position_target_global_int()
     if (!copter.flightmode->get_wp(target)) {
         return;
     }
+
+    // convert altitude frame to AMSL (this may use the terrain database)
+    if (!target.change_alt_frame(Location::AltFrame::ABSOLUTE)) {
+        return;
+    }
+
     mavlink_msg_position_target_global_int_send(
         chan,
         AP_HAL::millis(), // time_boot_ms


### PR DESCRIPTION
This is splitting out a bugfix from the SCurve PR @ https://github.com/ArduPilot/ardupilot/pull/15896/files

Nothing guarantees the altitude frame of what we're being passed in, so canonicalise it.

We can actually do better here and convert the Location alt frame back to the equivalent global frame in mavlink, but that can wait until after s-curve goes in.
