### PR TITLE
Copter: support MAV_FRAME_LOCAL_NED in MISSION_ITEM for auto mode

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -154,41 +154,48 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
 {
     _mode = Auto_TakeOff;
 
-    Location dest(dest_loc);
+    if (dest_loc.local_frame) {
+        float dest_alt = dest_loc.alt;
+        const Vector3f& curr_pos = inertial_nav.get_position();
+        // no need to check return status because terrain data is not used
+        wp_nav->set_wp_destination(Vector3f(curr_pos.x, curr_pos.y, dest_alt), false);
+    } else {
+        Location dest(dest_loc);
 
-    if (!copter.current_loc.initialised()) {
-        // vehicle doesn't know where it is ATM.  We should not
-        // initialise our takeoff destination without knowing this!
-        return;
-    }
+        if (!copter.current_loc.initialised()) {
+            // vehicle doesn't know where it is ATM.  We should not
+            // initialise our takeoff destination without knowing this!
+            return;
+        }
 
-    // set horizontal target
-    dest.lat = copter.current_loc.lat;
-    dest.lng = copter.current_loc.lng;
+        // set horizontal target
+        dest.lat = copter.current_loc.lat;
+        dest.lng = copter.current_loc.lng;
 
-    // get altitude target
-    int32_t alt_target;
-    if (!dest.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_target)) {
-        // this failure could only happen if take-off alt was specified as an alt-above terrain and we have no terrain data
-        AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
-        // fall back to altitude above current altitude
-        alt_target = copter.current_loc.alt + dest.alt;
-    }
+        // get altitude target
+        int32_t alt_target;
+        if (!dest.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_target)) {
+            // this failure could only happen if take-off alt was specified as an alt-above terrain and we have no terrain data
+            AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
+            // fall back to altitude above current altitude
+            alt_target = copter.current_loc.alt + dest.alt;
+        }
 
-    // sanity check target
-    if (alt_target < copter.current_loc.alt) {
-        dest.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
-    }
-    // Note: if taking off from below home this could cause a climb to an unexpectedly high altitude
-    if (alt_target < 100) {
-        dest.set_alt_cm(100, Location::AltFrame::ABOVE_HOME);
-    }
+        // sanity check target
+        if (alt_target < copter.current_loc.alt) {
+            dest.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
+        }
+        // Note: if taking off from below home this could cause a climb to an unexpectedly high altitude
+        if (alt_target < 100) {
+            dest.set_alt_cm(100, Location::AltFrame::ABOVE_HOME);
+        }
 
-    // set waypoint controller target
-    if (!wp_nav->set_wp_destination(dest)) {
-        // failure to set destination can only be because of missing terrain data
-        copter.failsafe_terrain_on_event();
-        return;
+        // set waypoint controller target
+        if (!wp_nav->set_wp_destination(dest)) {
+            // failure to set destination can only be because of missing terrain data
+            copter.failsafe_terrain_on_event();
+            return;
+        }
     }
 
     // initialise yaw
@@ -1126,15 +1133,19 @@ Location ModeAuto::loc_from_cmd(const AP_Mission::Mission_Command& cmd) const
 // do_nav_wp - initiate move to next waypoint
 void ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
 {
-    Location target_loc = loc_from_cmd(cmd);
 
     // this will be used to remember the time in millis after we reach or pass the WP.
     loiter_time = 0;
     // this is the delay, stored in seconds
     loiter_time_max = cmd.p1;
 
-    // Set wp navigation target
-    wp_start(target_loc);
+    if (cmd.content.location.local_frame) {
+        wp_start(Vector3f(cmd.content.location.lat, cmd.content.location.lng, cmd.content.location.alt));
+    } else {
+        Location target_loc = loc_from_cmd(cmd);
+        // Set wp navigation target
+        wp_start(target_loc);
+    }
 
     // if no delay as well as not final waypoint set the waypoint as "fast"
     AP_Mission::Mission_Command temp_cmd;

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -15,6 +15,7 @@ public:
     uint8_t terrain_alt  : 1;           // this altitude is above terrain
     uint8_t origin_alt   : 1;           // this altitude is above ekf origin
     uint8_t loiter_xtrack : 1;          // 0 to crosstrack from center of waypoint, 1 to crosstrack from tangent exit location
+    uint8_t local_frame :1;             // 1 if lat/lng is N/E postion vector in centimeters relative to ekf origin
 
     // note that mission storage only stores 24 bits of altitude (~ +/- 83km)
     int32_t alt;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -6,6 +6,8 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_AHRS/AP_AHRS.h>
 
+#define LOCAL_FRAME_INDICATE_OFFSET (190 * 10000000)
+
 const AP_Param::GroupInfo AP_Mission::var_info[] = {
 
     // @Param: TOTAL
@@ -667,8 +669,22 @@ bool AP_Mission::read_cmd_from_storage(uint16_t index, Mission_Command& cmd) con
         cmd.content.location.origin_alt = packed_content.location.flags.origin_alt;
         cmd.content.location.loiter_xtrack = packed_content.location.flags.loiter_xtrack;
         cmd.content.location.alt = packed_content.location.alt;
-        cmd.content.location.lat = packed_content.location.lat;
-        cmd.content.location.lng = packed_content.location.lng;
+        if (packed_content.location.lat >= LOCAL_FRAME_INDICATE_OFFSET) {
+            cmd.content.location.lat = packed_content.location.lat - LOCAL_FRAME_INDICATE_OFFSET;
+            cmd.content.location.local_frame = 1;
+        } else if (packed_content.location.lat < -LOCAL_FRAME_INDICATE_OFFSET) {
+            cmd.content.location.lat = packed_content.location.lat + LOCAL_FRAME_INDICATE_OFFSET;
+            cmd.content.location.local_frame = 1;
+        } else {
+            cmd.content.location.local_frame = 0;
+            cmd.content.location.lat = packed_content.location.lat;
+            cmd.content.location.lng = packed_content.location.lng;
+        }
+        if (packed_content.location.lng >= LOCAL_FRAME_INDICATE_OFFSET) {
+            cmd.content.location.lng = packed_content.location.lng - LOCAL_FRAME_INDICATE_OFFSET;
+        } else if (packed_content.location.lng < -LOCAL_FRAME_INDICATE_OFFSET) {
+            cmd.content.location.lng = packed_content.location.lng + LOCAL_FRAME_INDICATE_OFFSET;
+        }
     } else {
         // all other options in Content are assumed to be packed:
         static_assert(sizeof(cmd.content) >= 12,
@@ -731,8 +747,21 @@ bool AP_Mission::write_cmd_to_storage(uint16_t index, const Mission_Command& cmd
         packed.location.flags.origin_alt = cmd.content.location.origin_alt;
         packed.location.flags.loiter_xtrack = cmd.content.location.loiter_xtrack;
         packed.location.alt = cmd.content.location.alt;
-        packed.location.lat = cmd.content.location.lat;
-        packed.location.lng = cmd.content.location.lng;
+        if (cmd.content.location.local_frame == 1) {
+            if (cmd.content.location.lat >= 0) {
+                packed.location.lat += LOCAL_FRAME_INDICATE_OFFSET;
+            } else {
+                packed.location.lat -= LOCAL_FRAME_INDICATE_OFFSET;
+            }
+            if (cmd.content.location.lng >= 0) {
+                packed.location.lng += LOCAL_FRAME_INDICATE_OFFSET;
+            } else {
+                packed.location.lng -= LOCAL_FRAME_INDICATE_OFFSET;
+            }
+        } else {
+            packed.location.lat = cmd.content.location.lat;
+            packed.location.lng = cmd.content.location.lng;
+        }
     } else {
         // all other options in Content are assumed to be packed:
         static_assert(sizeof(packed.bytes) >= 12,
@@ -819,6 +848,7 @@ MAV_MISSION_RESULT AP_Mission::sanity_check_params(const mavlink_mission_item_in
 //  return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure
 MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_item_int_t& packet, AP_Mission::Mission_Command& cmd)
 {
+    bool local_frame_supported = false;
     // command's position in mission list and mavlink id
     cmd.index = packet.seq;
     cmd.id = packet.command;
@@ -837,6 +867,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         return MAV_MISSION_INVALID;
 
     case MAV_CMD_NAV_WAYPOINT: {                        // MAV ID: 16
+
+#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+        local_frame_supported = true;
+#endif
         /*
           the 15 byte limit means we can't fit both delay and radius
           in the cmd structure. When we expand the mission structure
@@ -889,6 +923,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
 
     case MAV_CMD_NAV_TAKEOFF:                           // MAV ID: 22
         cmd.p1 = packet.param1;                         // minimum pitch (plane only)
+#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+        local_frame_supported = true;
+#endif
         break;
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30
@@ -1116,7 +1153,18 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.location.alt = packet.z * 100.0f;       // convert packet's alt (m) to cmd alt (cm)
 
         switch (packet.frame) {
-
+        case MAV_FRAME_LOCAL_NED:
+            if (local_frame_supported) {
+                cmd.content.location.alt = -cmd.content.location.alt;
+                //mavlink spec MISSION_ITEM_INT states local: position in meters * 1e4"
+                cmd.content.location.lat = packet.x * 0.01f; //convert to cm
+                cmd.content.location.lng = packet.y * 0.01f;
+                cmd.content.location.local_frame = 1;
+                cmd.content.location.origin_alt = 1;
+            } else {
+                return MAV_MISSION_UNSUPPORTED_FRAME;
+            }
+            break;
         case MAV_FRAME_MISSION:
         case MAV_FRAME_GLOBAL:
         case MAV_FRAME_GLOBAL_INT:
@@ -1182,16 +1230,22 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_to_MISSION_ITEM_INT(const ma
         break;
 
     default:
-        // all other commands use x and y as lat/lon. We need to
-        // multiply by 1e7 to convert to int32_t
-        if (!check_lat(packet.x)) {
-            return MAV_MISSION_INVALID_PARAM5_X;
+        if (packet.frame == MAV_FRAME_LOCAL_NED) {
+            //mavlink spec MISSION_ITEM_INT states local: position in meters * 1e4"
+            mav_cmd.x = packet.x * 10000;
+            mav_cmd.y = packet.y * 10000;
+        } else {
+            // all other commands use x and y as lat/lon. We need to
+            // multiply by 1e7 to convert to int32_t
+            if (!check_lat(packet.x)) {
+                return MAV_MISSION_INVALID_PARAM5_X;
+            }
+            if (!check_lng(packet.y)) {
+                return MAV_MISSION_INVALID_PARAM6_Y;
+            }
+            mav_cmd.x = packet.x * 1.0e7f;
+            mav_cmd.y = packet.y * 1.0e7f;
         }
-        if (!check_lng(packet.y)) {
-            return MAV_MISSION_INVALID_PARAM6_Y;
-        }
-        mav_cmd.x = packet.x * 1.0e7f;
-        mav_cmd.y = packet.y * 1.0e7f;
         break;
     }
 
@@ -1223,15 +1277,21 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_INT_to_MISSION_ITEM(const ma
         break;
 
     default:
-        // all other commands use x and y as lat/lon. We need to
-        // multiply by 1e-7 to convert to float
-        item.x = item_int.x * 1.0e-7f;
-        item.y = item_int.y * 1.0e-7f;
-        if (!check_lat(item.x)) {
-            return MAV_MISSION_INVALID_PARAM5_X;
-        }
-        if (!check_lng(item.y)) {
-            return MAV_MISSION_INVALID_PARAM6_Y;
+        if (item.frame == MAV_FRAME_LOCAL_NED) {
+            //mavlink spec MISSION_ITEM_INT states local: position in meters * 1e4"
+            item.x = item_int.x * 10000;
+            item.y = item_int.y * 10000;
+        } else {
+            // all other commands use x and y as lat/lon. We need to
+            // multiply by 1e-7 to convert to float
+            item.x = item_int.x * 1.0e-7f;
+            item.y = item_int.y * 1.0e-7f;
+            if (!check_lat(item.x)) {
+                return MAV_MISSION_INVALID_PARAM5_X;
+            }
+            if (!check_lng(item.y)) {
+                return MAV_MISSION_INVALID_PARAM6_Y;
+            }
         }
         break;
     }
@@ -1538,14 +1598,22 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
 
     // copy location from mavlink to command
     if (stored_in_location(cmd.id)) {
-        packet.x = cmd.content.location.lat;
-        packet.y = cmd.content.location.lng;
-
-        packet.z = cmd.content.location.alt / 100.0f;   // cmd alt in cm to m
-        if (cmd.content.location.relative_alt) {
-            packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        if (cmd.content.location.local_frame) {
+            //position in meters * 1e4
+            packet.x = cmd.content.location.lat * 100;
+            packet.y = cmd.content.location.lng * 100;
+            packet.z = cmd.content.location.alt * -0.01f;
+            packet.frame = MAV_FRAME_LOCAL_NED;
         } else {
-            packet.frame = MAV_FRAME_GLOBAL;
+            packet.x = cmd.content.location.lat;
+            packet.y = cmd.content.location.lng;
+
+            packet.z = cmd.content.location.alt / 100.0f;   // cmd alt in cm to m
+            if (cmd.content.location.relative_alt) {
+                packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+            } else {
+                packet.frame = MAV_FRAME_GLOBAL;
+            }
         }
 #if AP_TERRAIN_AVAILABLE
         if (cmd.content.location.terrain_alt) {


### PR DESCRIPTION
This is based on #16259

This fix the problem raised by @tridge in https://github.com/ArduPilot/ardupilot/pull/16259#discussion_r555427967

> this changes the binary format of our mission storage. I am concerned that this could break existing missions in storage on stm32 or linux boards to re-interpret

Instead of add a new field in Packed_Location_Option_Flags, it add offset to lat/lng when writing to storage. Because valid value 
 range of lat/lng is -180 ~ 180, it add or subtract 190 when local_frame is used