### PR TITLE
AP_ParticleMatter: Add I2C driver for Panasonic SN-GCJA5

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -164,6 +164,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if RPM_ENABLED == ENABLED
     SCHED_TASK(rpm_update,            40,    200),
 #endif
+    SCHED_TASK_CLASS(AP_PM_SNGCJA5,       &copter.sngcja5,          update,          1,  100),
     SCHED_TASK(compass_cal_update,   100,    100),
     SCHED_TASK(accel_cal_update,      10,    100),
     SCHED_TASK_CLASS(AP_TempCalibration,   &copter.g2.temp_calibration, update,          10, 100),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -67,6 +67,8 @@
 #include <AP_Parachute/AP_Parachute.h>
 #include <AC_Sprayer/AC_Sprayer.h>
 #include <AP_ADSB/AP_ADSB.h>
+#include <AP_ParticleMatter/AP_PM_SNGCJA5.h>        // Particle Matter Sensor
+
 
 // Configuration
 #include "defines.h"
@@ -550,6 +552,9 @@ private:
     // setup the var_info table
     AP_Param param_loader;
 
+    // AP_Particle_Matter Sensor
+    AP_PM_SNGCJA5 sngcja5;
+    
 #if FRAME_CONFIG == HELI_FRAME
     // Mode filter to reject RC Input glitches.  Filter size is 5, and it draws the 4th element, so it can reject 3 low glitches,
     // and 1 high glitch.  This is because any "off" glitches can be highly problematic for a helicopter running an ESC

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -178,6 +178,9 @@ void Copter::init_ardupilot()
     rpm_sensor.init();
 #endif
 
+    // Initialize Particle Matter Sensor
+    sngcja5.init();
+
 #if MODE_AUTO_ENABLED == ENABLED
     // initialise mission library
     mode_auto.mission.init();

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -17,6 +17,7 @@ def build(bld):
             'AP_IRLock',
             'AP_InertialNav',
             'AP_Motors',
+            'AP_ParticleMatter',
             'AP_RCMapper',
             'AP_Avoidance',
             'AP_AdvancedFailsafe',

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -68,6 +68,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(one_second_loop,         1,    400),
     SCHED_TASK(check_long_failsafe,     3,    400),
     SCHED_TASK(rpm_update,             10,    100),
+    SCHED_TASK_CLASS(AP_PM_SNGCJA5,            &plane.sngcja5,       update,      1,  100),
 #if AP_AIRSPEED_AUTOCAL_ENABLE
     SCHED_TASK(airspeed_ratio_update,   1,    100),
 #endif // AP_AIRSPEED_AUTOCAL_ENABLE

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -85,6 +85,7 @@
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_Landing/AP_Landing.h>
 #include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library
+#include <AP_ParticleMatter/AP_PM_SNGCJA5.h>
 
 #include "GCS_Mavlink.h"
 #include "GCS_Plane.h"
@@ -285,6 +286,8 @@ private:
 #if HAL_SOARING_ENABLED
     ModeThermal mode_thermal;
 #endif
+
+    AP_PM_SNGCJA5 sngcja5;
 
     // This is the state of the flight control system
     // There are multiple states defined such as MANUAL, FBW-A, AUTO

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -75,6 +75,8 @@ void Plane::init_ardupilot()
     osd.init();
 #endif
 
+    sngcja5.init();
+
 #if LOGGING_ENABLED == ENABLED
     log_init();
 #endif

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -21,6 +21,7 @@ def build(bld):
             'AC_WPNav',
             'AC_AttitudeControl',
             'AP_Motors',
+            'AP_ParticleMatter',
             'AP_Landing',
             'AP_Beacon',
             'PID',

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -74,6 +74,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Gripper,          &rover.g2.gripper,      update,         10,   75),
 #endif
     SCHED_TASK(rpm_update,             10,    100),
+    SCHED_TASK_CLASS(AP_PM_SNGCJA5,       &rover.sngcja5,          update,          1,  100),
 #if HAL_MOUNT_ENABLED
     SCHED_TASK_CLASS(AP_Mount,            &rover.camera_mount,     update,         50,  200),
 #endif

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -44,6 +44,7 @@
 #include <AP_Navigation/AP_Navigation.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>          // Optical Flow library
 #include <AP_Param/AP_Param.h>
+#include <AP_ParticleMatter/AP_PM_SNGCJA5.h>        // Particle Matter Sensor
 #include <AP_RangeFinder/AP_RangeFinder.h>          // Range finder library
 #include <AP_RCMapper/AP_RCMapper.h>                // RC input mapping library
 #include <AP_Scheduler/AP_Scheduler.h>              // main loop scheduler
@@ -263,6 +264,9 @@ private:
     ModeFollow mode_follow;
     ModeSimple mode_simple;
 
+    // AP_Particle_Matter Sensor
+    AP_PM_SNGCJA5 sngcja5;
+    
     // cruise throttle and speed learning
     typedef struct {
         LowPassFilterFloat speed_filt = LowPassFilterFloat(2.0f);

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -40,6 +40,9 @@ void Rover::init_ardupilot()
     // Initialise RPM sensor
     rpm_sensor.init();
 
+    // Initialize Particle Matter Sensor
+    sngcja5.init();
+
     rssi.init();
 
     g2.airspeed.init();

--- a/Rover/wscript
+++ b/Rover/wscript
@@ -17,6 +17,7 @@ def build(bld):
             'AP_Beacon',
             'AP_AdvancedFailsafe',
             'AP_WheelEncoder',
+            'AP_ParticleMatter',
             'AP_SmartRTL',
             'AC_Fence',
             'AC_AttitudeControl',

--- a/libraries/AP_ParticleMatter/AP_PM_SNGCJA5.cpp
+++ b/libraries/AP_ParticleMatter/AP_PM_SNGCJA5.cpp
@@ -1,0 +1,135 @@
+#include <AP_HAL/AP_HAL.h>
+#include "AP_PM_SNGCJA5.h"
+#include <stdio.h>
+#include <utility>
+#include <AP_HAL/I2CDevice.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Common/Location.h>
+#include <AP_Vehicle/AP_Vehicle.h>      
+#include <AP_Logger/AP_Logger.h>  
+
+extern const AP_HAL::HAL& hal;
+
+#define SNGCJA5_I2C_ADDRESS 0x33
+
+#define SNGCJA5_STATUS 0x26
+
+#define SNGCJA5_PM1_0_LL 0x00
+#define SNGCJA5_PM1_0_LH 0x01
+#define SNGCJA5_PM1_0_HL 0x02
+#define SNGCJA5_PM1_0_HH 0x03
+
+#define SNGCJA5_PM2_5_LL 0x04
+#define SNGCJA5_PM2_5_LH 0x05
+#define SNGCJA5_PM2_5_HL 0x06
+#define SNGCJA5_PM2_5_HH 0x07
+
+#define SNGCJA5_PM10_0_LL 0x08
+#define SNGCJA5_PM10_0_LH 0x09
+#define SNGCJA5_PM10_0_HL 0x0A
+#define SNGCJA5_PM10_0_HH 0x0B
+
+#define SNGCJA5_PC_0_5_L 0x0C
+#define SNGCJA5_PC_0_5_H 0x0D
+
+#define SNGCJA5_PC_1_0_L 0x0E
+#define SNGCJA5_PC_1_0_H 0x0F
+
+#define SNGCJA5_PC_2_5_L 0x10
+#define SNGCJA5_PC_2_5_H 0x11
+
+#define SNGCJA5_PC_5_0_L 0x14
+#define SNGCJA5_PC_5_0_H 0x15
+
+#define SNGCJA5_PC_7_5_L 0x16
+#define SNGCJA5_PC_7_5_H 0x17
+
+#define SNGCJA5_PC_10_0_L 0x18
+#define SNGCJA5_PC_10_0_H 0x19
+
+void AP_PM_SNGCJA5::init()
+{
+    FOREACH_I2C(i) {
+        if (init(i)) {
+            return;
+        }
+    }
+    gcs().send_text(MAV_SEVERITY_INFO, "No SNGCJA5 found");
+}
+
+bool AP_PM_SNGCJA5::init(int8_t bus)
+{
+    dev = std::move(hal.i2c_mgr->get_device(bus, SNGCJA5_I2C_ADDRESS));
+    if (!dev) {
+        return false;
+    }
+
+    // read at 1Hz
+    printf("Starting Particle Matter Sensor on I2C\n");
+
+    dev->register_periodic_callback(1000000, FUNCTOR_BIND_MEMBER(&AP_PM_SNGCJA5::read_frames, void));
+    return true;
+}
+
+void AP_PM_SNGCJA5::read_frames(void)
+{
+    WITH_SEMAPHORE(dev->get_semaphore());
+
+    uint8_t val[1];
+    if (!dev->read_registers(SNGCJA5_STATUS, val, sizeof(val))) {
+        return;
+    }
+
+    uint8_t ALL_REGS[24];
+    if (!dev->read_registers(SNGCJA5_PM1_0_LL, ALL_REGS, sizeof(ALL_REGS))) {
+        return;
+    }
+    double  PM1_0  = (ALL_REGS[0] | ALL_REGS[1] << 8 | ALL_REGS[2] << 16 | ALL_REGS[3] << 24);
+    double  PM2_5  = (ALL_REGS[4] | ALL_REGS[5] << 8 | ALL_REGS[6] << 16 | ALL_REGS[7] << 24);
+    double  PM10_0 = (ALL_REGS[8] | ALL_REGS[9] << 8 | ALL_REGS[10] << 16 | ALL_REGS[11] << 24);
+    int     PC0_5  = (ALL_REGS[12] | ALL_REGS[13] << 8);
+    int     PC1_0  = (ALL_REGS[14] | ALL_REGS[15] << 8);
+    int     PC2_5  = (ALL_REGS[16] | ALL_REGS[17] << 8);
+    int     PC5_0  = (ALL_REGS[18] | ALL_REGS[19] << 8);
+    int     PC7_5  = (ALL_REGS[20] | ALL_REGS[21] << 8);
+    int     PC10_0 = (ALL_REGS[22] | ALL_REGS[23] << 8);
+
+    // get current location from EKF
+    Location current_loc;
+    AP::ahrs_navekf().get_location(current_loc);
+
+    AP::logger().Write("PM1", "TimeUS,lat,lon,alt,Status,PM1_0,PM2_5,PM10_0", "QLLfIfff",
+                                            AP_HAL::micros64(),
+                                            current_loc.lat,
+                                            current_loc.lng,
+                                            (double)current_loc.alt*1.0e-2f,
+                                            val[0],
+                                            (double)PM1_0*1.0e-3f,
+                                            (double)PM2_5*1.0e-3f,
+                                            (double)PM10_0*1.0e-3f
+                                            );
+                                        
+    AP::logger().Write("PM2", "TimeUS,lat,lon,alt,PC0_5,PC1_0,PC2_5,PC5_0,PC7_5,PC10_0", "QLLfIIIIII",
+                                            AP_HAL::micros64(),
+                                            current_loc.lat,
+                                            current_loc.lng,
+                                            (double)current_loc.alt*1.0e-2f,
+                                            PC0_5,
+                                            PC1_0,
+                                            PC2_5,
+                                            PC5_0,
+                                            PC7_5,
+                                            PC10_0
+                                            );
+                                            
+
+    // gcs().send_text(MAV_SEVERITY_INFO,"PS Status: %u", (unsigned)val[0]);
+    // gcs().send_text(MAV_SEVERITY_INFO,"PS Lat: %d, Lon: %d, PC0.5: %d, PC1.0: %d, PC2.5: %d, PC5.0: %d, PC7.5: %d, PC10.0: %d", current_loc.lat, current_loc.lng, PC0_5, PC1_0, PC2_5, PC5_0, PC7_5, PC10_0);
+    // gcs().send_text(MAV_SEVERITY_INFO,"PS PM1.0: %0.0lf, PM2.5: %0.0lf, PM10.0: %0.0lf", PM1_0, PM2_5, PM10_0);
+}
+
+// periodically called from vehicle code
+void AP_PM_SNGCJA5::update()
+{
+    read_frames();
+}

--- a/libraries/AP_ParticleMatter/AP_PM_SNGCJA5.h
+++ b/libraries/AP_ParticleMatter/AP_PM_SNGCJA5.h
@@ -1,0 +1,26 @@
+/*
+* AP_PM_SNGCJA5.h
+ *
+ */
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+class AP_PM_SNGCJA5 {
+    public:
+        // init - initialize sensor library
+        void init();
+
+        // retrieve latest sensor data - returns true if new data is available
+        void update();
+
+    private:
+        AP_HAL::OwnPtr<AP_HAL::Device> dev;
+
+        void read_frames(void);
+
+        uint32_t _last_read_ms;
+
+        // init(bus) - attempt to initialise sensor on bus
+        bool init(int8_t bus);
+};

--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -21,6 +21,7 @@
 #include <SITL/SITL.h>
 
 #include "SIM_I2C.h"
+#include "SIM_SN_GCJA5.h"
 #include "SIM_ToshibaLED.h"
 #include "SIM_MaxSonarI2CXL.h"
 #include "SIM_BattMonitor_SMBus_Maxell.h"
@@ -54,6 +55,7 @@ static Rotoye rotoye;
 static Airspeed_DLVR airspeed_dlvr;
 static TSYS01 tsys01;
 static ICM40609 icm40609;
+static SN_GCJA5 sn_gcja5;
 
 struct i2c_device_at_address {
     uint8_t bus;
@@ -63,6 +65,7 @@ struct i2c_device_at_address {
     { 0, 0x70, maxsonari2cxl },
     { 0, 0x71, maxsonari2cxl_2 },
     { 1, 0x01, icm40609 },
+    { 1, 0x33, sn_gcja5 },  // SN-GCJA5 particle matter sensor
     { 1, 0x55, toshibaled },
     { 1, 0x38, ignored }, // NCP5623
     { 1, 0x39, ignored }, // NCP5623C

--- a/libraries/SITL/SIM_SN_GCJA5.cpp
+++ b/libraries/SITL/SIM_SN_GCJA5.cpp
@@ -1,0 +1,32 @@
+#include "SIM_SN_GCJA5.h"
+
+#include <SITL/SITL.h>
+#include <SITL/SIM_Aircraft.h>
+
+#include <stdio.h>
+int SITL::SN_GCJA5::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
+{
+    if (data->nmsgs == 2) {
+        // return sensor state here - don't update the state.
+        if (data->msgs[0].flags != 0) {
+            AP_HAL::panic("Unexpected flags");
+        }
+        if (data->msgs[1].flags != I2C_M_RD) {
+            AP_HAL::panic("Unexpected flags");
+        }
+        data->msgs[1].buf[0] = _status.byte;
+        return 0;
+    }
+
+    if (data->nmsgs == 1) {
+        AP_HAL::panic("No writable registers");
+    }
+
+    return -1;
+};
+
+void SITL::SN_GCJA5::update(const Aircraft &aircraft)
+{
+    // called rapidly; update the sensor state here
+    // gcs().send_text(MAV_SEVERITY_INFO, "Called");
+}

--- a/libraries/SITL/SIM_SN_GCJA5.h
+++ b/libraries/SITL/SIM_SN_GCJA5.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "SIM_I2CDevice.h"
+
+namespace SITL {
+
+class SN_GCJA5 : public I2CDevice
+{
+public:
+
+    SN_GCJA5() :
+        I2CDevice() {
+        // _status.sensor_status = 3;
+        // _status.pd_status = 1;
+        // _status.ld_operational_status = 0;
+        // _status.fan_status = 0;
+        _status.byte = 77;
+    }
+
+    void update(const class Aircraft &aircraft) override;
+
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
+
+private:
+    uint32_t cmd_take_reading_received_ms;
+
+    union PACKED {
+        uint8_t byte;
+        struct {
+            uint8_t sensor_status : 2;
+            uint8_t pd_status : 2;
+            uint8_t ld_operational_status : 2;
+            uint8_t fan_status : 2;
+        };
+    } _status;
+
+
+};
+
+} // namespace SITL


### PR DESCRIPTION
This PR add support for the [Panasonic SN-GCJA5](https://www.sparkfun.com/products/17123) Laser Type Particle Matter sensor. It adds a log message to log the readings from the sensor so that it can be used in surveys.
![17123-Particle_Sensor_-_SN-GCJA5-01](https://user-images.githubusercontent.com/1664405/107984090-5ce7e680-6f84-11eb-9fa6-aa813800e72f.jpg)

This has been flight tested by Oliver Wolkman on plane and rover.
