### PR TITLE
SITL: Correct bus number in read-side part of rdwr transaction

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1905,7 +1905,8 @@ class AutoTestPlane(AutoTest):
         self.progress("Mission OK")
 
     def test_airspeed_drivers(self):
-        self.set_parameter("ARSPD2_TYPE", 7)
+        self.set_parameter("ARSPD_BUS", 2)
+        self.set_parameter("ARSPD_TYPE", 7)  # DLVR
         self.reboot_sitl()
         self.wait_ready_to_arm()
         self.arm_vehicle()

--- a/libraries/AP_HAL_SITL/I2CDevice.cpp
+++ b/libraries/AP_HAL_SITL/I2CDevice.cpp
@@ -172,6 +172,7 @@ bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
     }
 
     if (recv && recv_len != 0) {
+        msgs[nmsgs].bus = _bus.bus;
         msgs[nmsgs].addr = _address;
         msgs[nmsgs].flags = I2C_M_RD;
         msgs[nmsgs].buf = recv;


### PR DESCRIPTION
Also make DLVR the only sensor available during airspeed sensor test.
