### PR TITLE
Copter: current_loc keeps last known location

### DIFF
--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -8,9 +8,10 @@ void Copter::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_position(loc);
-    current_loc.lat = loc.lat;
-    current_loc.lng = loc.lng;
+    if (ahrs.get_position(loc)) {
+        current_loc.lat = loc.lat;
+        current_loc.lng = loc.lng;
+    }
 
     // exit immediately if we do not have an altitude estimate
     if (!inertial_nav.get_filter_status().flags.vert_pos) {


### PR DESCRIPTION
This ensures that Copter's current_loc holds the last known location (lat and lng) even if the ahrs stops providing a good position.  Without this change it could jump to 0,0.

In practice, in master, current_loc never jumps back to 0,0 because (it seems) ahrs.get_position() always returns true and returns the last known position.

If PR https://github.com/ArduPilot/ardupilot/pull/15810 is merged though the "AP_NavEKF3: Fix LLH reporting bug" commit changes this behaviour so that if the GPS is disabled, after 10 seconds or so, get_position() can return false and not update loc.

This has been tested in SITL.