### PR TITLE
Get Tracker passing under valgrind

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1672,6 +1672,9 @@ class AutoTest(ABC):
         ])
 
         (parameters, seq_id) = self.download_parameters(target_system, target_component)
+
+        self.reset_SITL_commandline()
+
         fail = False
         for param in parameters.keys():
             if param.startswith("SIM_"):

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -8264,7 +8264,7 @@ switch value'''
             raise NotAchievedException("Did not receive GPS_RAW_INT")
         tstart = self.get_sim_time()
         while True:
-            now = self.get_sim_time()
+            now = self.get_sim_time_cached()
             if now - tstart > 20:
                 raise NotAchievedException("NMEA output not updating?!")
             gps2 = self.mav.recv_match(type="GPS2_RAW", blocking=True, timeout=1)


### PR DESCRIPTION
These weren't actually memcheck bugs - just a race condition and a valgrind-environment-specific bug that Valgrind made clear.
