### PR TITLE
autotest: use get_parameter in place of mav's param object

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -8565,7 +8565,7 @@ switch value'''
             for (ins_prefix, sim_prefix, pre_value, post_value) in param_map:
                 for axis in axes:
                     pname = ins_prefix+"_"+axis
-                    v = self.mav.param(pname)
+                    v = self.get_parameter(pname)
                     expected_v = getattr(post_value, axis.lower())
                     if v == expected_v:
                         continue


### PR DESCRIPTION
This is the only place in the code that does this