### PR TITLE
autotest: Add ability to run MAVProxy in autotest only as required

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -88,6 +88,14 @@ class AutoTestCopter(AutoTest):
     def default_frame(self):
         return "+"
 
+    def apply_defaultfile_parameters(self):
+        # Copter passes in a defaults_filepath in place of applying
+        # parameters afterwards.
+        pass
+
+    def defaults_filepath(self):
+        return self.model_defaults_filepath(self.vehicleinfo_key(), self.frame)
+
     def wait_disarmed_default_wait_time(self):
         return 120
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2725,6 +2725,11 @@ class AutoTestCopter(AutoTest):
         ex = None
         self.context_push()
 
+        # we must start mavproxy here as otherwise we can't get the
+        # terrain database tiles - this leads to random failures in
+        # CI!
+        mavproxy = self.start_mavproxy()
+
         try:
             self.set_analog_rangefinder_parameters()
             self.set_parameter("RC9_OPTION", 10) # rangefinder
@@ -2772,6 +2777,9 @@ class AutoTestCopter(AutoTest):
             self.print_exception_caught(e)
             self.disarm_vehicle(force=True)
             ex = e
+
+        self.stop_mavproxy(mavproxy)
+
         self.context_pop()
         self.reboot_sitl()
         if ex is not None:
@@ -4805,6 +4813,11 @@ class AutoTestCopter(AutoTest):
 
         '''
 
+        # we must start mavproxy here as otherwise we can't get the
+        # terrain database tiles - this leads to random failures in
+        # CI!
+        mavproxy = self.start_mavproxy()
+
         self.set_parameter("FS_GCS_ENABLE", 0)
         self.change_mode('GUIDED')
         self.wait_ready_to_arm()
@@ -4863,6 +4876,8 @@ class AutoTestCopter(AutoTest):
                 (max_post_arming_home_offset_delta_mm, delta_between_original_home_alt_offset_and_new_home_alt_offset_mm))
 
         self.wait_disarmed()
+
+        self.stop_mavproxy(mavproxy)
 
     def fly_precision_companion(self):
         """Use Companion PrecLand backend precision messages to loiter."""

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -408,8 +408,11 @@ class AutoTestCopter(AutoTest):
         self.save_wp()
 
         # save the stored mission to file
-        num_wp = self.save_mission_to_file(os.path.join(testdir,
-                                                        "ch7_mission.txt"))
+        mavproxy = self.start_mavproxy()
+        num_wp = self.save_mission_to_file_using_mavproxy(
+            mavproxy,
+            os.path.join(testdir, "ch7_mission.txt"))
+        self.stop_mavproxy(mavproxy)
         if not num_wp:
             self.fail_list.append("save_mission_to_file")
             self.progress("save_mission_to_file failed")
@@ -5315,13 +5318,15 @@ class AutoTestCopter(AutoTest):
         self.location_offset_ne(new_loc, new_loc_offset_n, new_loc_offset_e)
         self.progress("new_loc: %s" % str(new_loc))
         heading = 0
-        self.mavproxy.send("map icon %f %f greenplane %f\n" %
-                           (new_loc.lat, new_loc.lng, heading))
+        if self.mavproxy is not None:
+            self.mavproxy.send("map icon %f %f greenplane %f\n" %
+                               (new_loc.lat, new_loc.lng, heading))
 
         expected_loc = copy.copy(new_loc)
         self.location_offset_ne(expected_loc, -foll_ofs_x, 0)
-        self.mavproxy.send("map icon %f %f hoop\n" %
-                           (expected_loc.lat, expected_loc.lng))
+        if self.mavproxy is not None:
+            self.mavproxy.send("map icon %f %f hoop\n" %
+                               (expected_loc.lat, expected_loc.lng))
         self.progress("expected_loc: %s" % str(expected_loc))
 
         last_sent = 0

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1291,12 +1291,13 @@ class AutoTestPlane(AutoTest):
                                           0, # "land dir"
                                           0) # flags
             self.delay_sim_time(1)
-            self.mavproxy.send("rally list\n")
+            if self.mavproxy is not None:
+                self.mavproxy.send("rally list\n")
             self.test_fence_breach_circle_at(loc)
         except Exception as e:
             self.print_exception_caught(e)
             ex = e
-        self.mavproxy.send('rally clear\n')
+        self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         if ex is not None:
             raise ex
 
@@ -1419,11 +1420,6 @@ class AutoTestPlane(AutoTest):
     def run_subtest(self, desc, func):
         self.start_subtest(desc)
         func()
-
-    def clear_fence(self):
-        '''Plane doesn't use MissionItemProtocol - yet - so clear it using
-        mavproxy:'''
-        self.clear_fence_using_mavproxy()
 
     def check_attitudes_match(self, a, b):
         '''make sure ahrs2 and simstate and ATTTIUDE_QUATERNION all match'''

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -374,10 +374,10 @@ class AutoTestSub(AutoTest):
                 break
         self.initialise_after_reboot_sitl()
 
-    def apply_defaultfile_parameters(self):
-        super(AutoTestSub, self).apply_defaultfile_parameters()
-        # FIXME:
-        self.set_parameter("FS_GCS_ENABLE", 0)
+    def default_parameter_list(self):
+        ret = super(AutoTestSub, self).default_parameter_list()
+        ret["FS_GCS_ENABLE"] = 0  # FIXME
+        return ret
 
     def disabled_tests(self):
         ret = super(AutoTestSub, self).disabled_tests()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2133,7 +2133,10 @@ class AutoTest(ABC):
             if time.time() - tstart > 30:
                 raise NotAchievedException("Failed to customise")
             try:
-                self.wait_heartbeat(drain_mav=True)
+                m = self.wait_heartbeat(drain_mav=True)
+                if m.type == 0:
+                    self.progress("Bad heartbeat: %s" % str(m))
+                    continue
             except IOError:
                 pass
             break

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2673,6 +2673,7 @@ class AutoTest(ABC):
     #################################################
     def get_sim_time(self, timeout=60):
         """Get SITL time in seconds."""
+        self.drain_mav()
         m = self.mav.recv_match(type='SYSTEM_TIME', blocking=True, timeout=timeout)
         if m is None:
             raise AutoTestTimeoutException("Did not get SYSTEM_TIME message after %f seconds" % timeout)

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7800,6 +7800,11 @@ Also, ignores heartbeats not from our target system'''
         self.wait_ready_to_arm()
         self.arm_vehicle()
 
+        # we must start mavproxy here as otherwise we can't get the
+        # terrain database tiles - this leads to random failures in
+        # CI!
+        mavproxy = self.start_mavproxy()
+
         if self.is_copter() or self.is_heli():
             self.user_takeoff(alt_min=50)
 
@@ -8002,6 +8007,9 @@ Also, ignores heartbeats not from our target system'''
                 self.wait_yaw_speed(target_rate, timeout=timeout,
                                     called_function=lambda plop, empty: send_yaw_rate(
                                         target_rate, None), minimum_duration=5)
+
+        self.stop_mavproxy(mavproxy)
+
         self.start_test("Getting back to home and disarm")
         self.do_RTL(distance_min=0, distance_max=wp_accuracy)
         self.disarm_vehicle()
@@ -8022,6 +8030,11 @@ Also, ignores heartbeats not from our target system'''
         self.change_mode("GUIDED")
         self.wait_ready_to_arm()
         self.arm_vehicle()
+
+        # we must start mavproxy here as otherwise we can't get the
+        # terrain database tiles - this leads to random failures in
+        # CI!
+        mavproxy = self.start_mavproxy()
 
         if self.is_copter() or self.is_heli():
             self.user_takeoff(alt_min=50)
@@ -8366,6 +8379,9 @@ Also, ignores heartbeats not from our target system'''
                                                                    frame),
                     minimum_duration=2
                 )
+
+        self.stop_mavproxy(mavproxy)
+
         self.start_test("Getting back to home and disarm")
         self.do_RTL(distance_min=0, distance_max=wp_accuracy)
         self.disarm_vehicle()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7786,6 +7786,7 @@ Also, ignores heartbeats not from our target system'''
     def test_set_position_global_int(self, timeout=100):
         """Test set position message in guided mode."""
         # Disable heading and yaw test on rover type
+
         if self.is_rover():
             test_alt = False
             test_heading = False
@@ -7795,15 +7796,15 @@ Also, ignores heartbeats not from our target system'''
             test_heading = True
             test_yaw_rate = True
 
-        self.set_parameter("FS_GCS_ENABLE", 0)
-        self.change_mode("GUIDED")
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-
         # we must start mavproxy here as otherwise we can't get the
         # terrain database tiles - this leads to random failures in
         # CI!
         mavproxy = self.start_mavproxy()
+
+        self.set_parameter("FS_GCS_ENABLE", 0)
+        self.change_mode("GUIDED")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
 
         if self.is_copter() or self.is_heli():
             self.user_takeoff(alt_min=50)
@@ -8026,15 +8027,15 @@ Also, ignores heartbeats not from our target system'''
             test_heading = True
             test_yaw_rate = True
 
-        self.set_parameter("FS_GCS_ENABLE", 0)
-        self.change_mode("GUIDED")
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-
         # we must start mavproxy here as otherwise we can't get the
         # terrain database tiles - this leads to random failures in
         # CI!
         mavproxy = self.start_mavproxy()
+
+        self.set_parameter("FS_GCS_ENABLE", 0)
+        self.change_mode("GUIDED")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
 
         if self.is_copter() or self.is_heli():
             self.user_takeoff(alt_min=50)

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1389,14 +1389,6 @@ class AutoTest(ABC):
                                                        self.frame)
         for x in self.params:
             self.repeatedly_apply_parameter_file(os.path.join(testdir, x))
-        self.set_parameter('LOG_DISARMED', 1)
-        if self.force_ahrs_type is not None:
-            if self.force_ahrs_type == 2:
-                self.set_parameter("EK2_ENABLE", 1)
-            if self.force_ahrs_type == 3:
-                self.set_parameter("EK3_ENABLE", 1)
-            self.set_parameter("AHRS_EKF_TYPE", self.force_ahrs_type)
-        self.reboot_sitl()
 
     def count_lines_in_filepath(self, filepath):
         return len([i for i in open(filepath)])
@@ -2152,12 +2144,32 @@ class AutoTest(ABC):
             self.valgrind_restart_defaults_filepath = defaults_filepath
             self.valgrind_restart_customisations = customisations
 
+    def default_parameter_list(self):
+        ret = {
+            'LOG_DISARMED': 1,
+        }
+        if self.force_ahrs_type is not None:
+            if self.force_ahrs_type == 2:
+                ret["EK2_ENABLE"] = 1
+            if self.force_ahrs_type == 3:
+                ret["EK3_ENABLE"] = 1
+            ret["AHRS_EKF_TYPE"] = self.force_ahrs_type
+        return ret
+
+    def apply_default_parameter_list(self):
+        self.set_parameters(self.default_parameter_list())
+
+    def apply_default_parameters(self):
+        self.apply_defaultfile_parameters()
+        self.apply_default_parameter_list()
+        self.reboot_sitl()
+
     def reset_SITL_commandline(self):
         self.progress("Resetting SITL commandline to default")
         self.stop_SITL()
         self.start_SITL(wipe=True)
         self.set_streamrate(self.sitl_streamrate())
-        self.apply_defaultfile_parameters()
+        self.apply_default_parameters()
         try:
             del self.valgrind_restart_customisations
         except Exception:
@@ -5802,7 +5814,7 @@ Also, ignores heartbeats not from our target system'''
         # you do this!
         self.wait_heartbeat()
         self.progress("Sim time: %f" % (self.get_sim_time(),))
-        self.apply_defaultfile_parameters()
+        self.apply_default_parameters()
 
         if not self.sitl_is_running():
             # we run this just to make sure exceptions are likely to

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -284,8 +284,8 @@ class AutoTestQuadPlane(AutoTest):
         self.load_mission(filename)
         if fence is not None:
             self.load_fence(fence)
-        self.mavproxy.send('wp list\n')
-        self.mavproxy.expect('Requesting [0-9]+ waypoints')
+        if self.mavproxy is not None:
+            self.mavproxy.send('wp list\n')
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.change_mode('AUTO')
@@ -544,8 +544,8 @@ class AutoTestQuadPlane(AutoTest):
             # Step 4: take off as a copter land as a plane, make sure we track
             self.progress("Flying with gyro FFT - vtol to plane")
             self.load_mission("quadplane-gyro-mission.txt")
-            self.mavproxy.send('wp list\n')
-            self.mavproxy.expect('Requesting [0-9]+ waypoints')
+            if self.mavproxy is not None:
+                self.mavproxy.send('wp list\n')
             self.change_mode('AUTO')
             self.wait_ready_to_arm()
             self.arm_vehicle()


### PR DESCRIPTION
Only possible in AntennaTracker and Sub ATM.

Saves a lot of CPU time as MAVProxy doesn't have to decode all of the packets from the autopilot
