### PR TITLE
AP_CRSF_Telem: enable custom telemetry tuning only when using the RC driver

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -33,6 +33,7 @@ public:
     void process_byte(uint8_t byte, uint32_t baudrate) override;
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void update(void) override;
+    bool is_standalone() const { return _uart != nullptr;};
     // get singleton instance
     static AP_RCProtocol_CRSF* get_singleton() {
         return _singleton;


### PR DESCRIPTION
This fixes an issue reported by @andyp1per when CRSF is instantiated by the serial manager.
We should not announce RF mode changes or try to get the RX firmware version since there is no RX.