### PR TITLE
AP_Scripting: fixed max argument to GPS bindings

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -78,23 +78,23 @@ singleton AP_GPS alias gps
 singleton AP_GPS enum NO_GPS NO_FIX GPS_OK_FIX_2D GPS_OK_FIX_3D GPS_OK_FIX_3D_DGPS GPS_OK_FIX_3D_RTK_FLOAT GPS_OK_FIX_3D_RTK_FIXED
 singleton AP_GPS method num_sensors uint8_t
 singleton AP_GPS method primary_sensor uint8_t
-singleton AP_GPS method status uint8_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method location Location uint8_t 0 ud->num_sensors()
-singleton AP_GPS method speed_accuracy boolean uint8_t 0 ud->num_sensors() float'Null
-singleton AP_GPS method horizontal_accuracy boolean uint8_t 0 ud->num_sensors() float'Null
-singleton AP_GPS method vertical_accuracy boolean uint8_t 0 ud->num_sensors() float'Null
-singleton AP_GPS method velocity Vector3f uint8_t 0 ud->num_sensors()
-singleton AP_GPS method ground_speed float uint8_t 0 ud->num_sensors()
-singleton AP_GPS method ground_course float uint8_t 0 ud->num_sensors()
-singleton AP_GPS method num_sats uint8_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method time_week uint16_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method time_week_ms uint32_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method get_hdop uint16_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method get_vdop uint16_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method last_fix_time_ms uint32_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method last_message_time_ms uint32_t uint8_t 0 ud->num_sensors()
-singleton AP_GPS method have_vertical_velocity boolean uint8_t 0 ud->num_sensors()
-singleton AP_GPS method get_antenna_offset Vector3f uint8_t 0 ud->num_sensors()
+singleton AP_GPS method status uint8_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method location Location uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method speed_accuracy boolean uint8_t 0 GPS_MAX_INSTANCES-1 float'Null
+singleton AP_GPS method horizontal_accuracy boolean uint8_t 0 GPS_MAX_INSTANCES-1 float'Null
+singleton AP_GPS method vertical_accuracy boolean uint8_t 0 GPS_MAX_INSTANCES-1 float'Null
+singleton AP_GPS method velocity Vector3f uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method ground_speed float uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method ground_course float uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method num_sats uint8_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method time_week uint16_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method time_week_ms uint32_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method get_hdop uint16_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method get_vdop uint16_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method last_fix_time_ms uint32_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method last_message_time_ms uint32_t uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method have_vertical_velocity boolean uint8_t 0 GPS_MAX_INSTANCES-1
+singleton AP_GPS method get_antenna_offset Vector3f uint8_t 0 GPS_MAX_INSTANCES-1
 singleton AP_GPS method first_unconfigured_gps boolean uint8_t'Null
 
 include AP_Math/AP_Math.h


### PR DESCRIPTION
we should not be faulting if we ask for status for GPS2 when we have
only found one GPS. Otherwise the script may die if it is checking if
2nd GPS is alive and it isn't