### PR TITLE
Push SITL reboot ACK out before exec'ing

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -334,6 +334,11 @@ void AP_Vehicle::reboot(bool hold_in_bootloader)
     // do not process incoming mavlink messages while we delay:
     hal.scheduler->register_delay_callback(nullptr, 5);
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // need to ensure the ack goes out:
+    hal.serial(0)->flush();
+#endif
+
     // delay to give the ACK a chance to get out, the LEDs to flash,
     // the IO board safety to be forced on, the parameters to flush, ...
     hal.scheduler->delay(200);


### PR DESCRIPTION
I've seen instances where the process goes away before the ACK arrives at the autotest process.  Try really hard to make sure it's been sent.
