### PR TITLE
Plane: Auto takeoff roll-limits to use TKOFF_LVL_ALT

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -737,12 +737,12 @@ public:
     // var_info for holding parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
+    AP_Int16 target_alt;
+    AP_Int16 level_alt;
     AP_Float ground_pitch;
 
 protected:
-    AP_Int16 target_alt;
     AP_Int16 target_dist;
-    AP_Int16 level_alt;
     AP_Int8 level_pitch;
 
     bool takeoff_started;

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -16,12 +16,12 @@ const AP_Param::GroupInfo ModeTakeoff::var_info[] = {
 
     // @Param: LVL_ALT
     // @DisplayName: Takeoff mode altitude level altitude
-    // @Description: This is the altitude below which wings are held level for TAKEOFF mode
+    // @Description: This is the altitude below which the wings are held level for TAKEOFF and AUTO modes. Below this altitude, roll demand is restricted to LEVEL_ROLL_LIMIT. Normal-flight roll restriction resumes above TKOFF_LVL_ALT*2 or TKOFF_ALT, whichever is lower. Roll limits are scaled while between those altitudes for a smooth transition.
     // @Range: 0 50
     // @Increment: 1
     // @Units: m
     // @User: Standard
-    AP_GROUPINFO("LVL_ALT", 2, ModeTakeoff, level_alt, 20),
+    AP_GROUPINFO("LVL_ALT", 2, ModeTakeoff, level_alt, 5),
 
     // @Param: LVL_PITCH
     // @DisplayName: Takeoff mode altitude initial pitch


### PR DESCRIPTION
This is another step closer to unifying AUTO-takeoff and Mode TAKEOFF so that the params are shared and, thus, less confusing.

Existing behavior:
Mode TAKEOFF:
- On takeoff, keep wings level until you reach TKOFF_LVL_ALT (default 20) or if altitude is completed when reaching TKOFF_ALT.
- Desired Roll restriction is removed immediately.
Mode AUTO-takeoff
- Keep wings level until 5m.
- Allow normal full roll range at 15m.
- Scale the limit between those altitudes

New behavior that mode methods will share:
- Keep wings level until TKOFF_LVL_ALT (default 5).
- Allow normal full range at MIN(TKOFF_LVL_ALT*3,TKOFF_ALT).
- Scale the limit between those altitudes
 