### PR TITLE
HAL_ChibiOS: increase H7 serial buffer sizes

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
@@ -419,7 +419,11 @@
  *          buffers.
  */
 #if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
-#define SERIAL_BUFFERS_SIZE         256
+#if defined(STM32H7)
+#define SERIAL_BUFFERS_SIZE     512
+#else
+#define SERIAL_BUFFERS_SIZE     256
+#endif
 #endif
 
 /*===========================================================================*/
@@ -434,7 +438,11 @@
  *          buffers.
  */
 #if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#if defined(STM32H7)
+#define SERIAL_USB_BUFFERS_SIZE     768
+#else
 #define SERIAL_USB_BUFFERS_SIZE     256
+#endif
 #endif
 
 /**
@@ -442,7 +450,11 @@
  * @note    The default is 2 buffers.
  */
 #if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#if defined(STM32H7)
+#define SERIAL_USB_BUFFERS_NUMBER   4
+#else
 #define SERIAL_USB_BUFFERS_NUMBER   2
+#endif
 #endif
 
 /*===========================================================================*/


### PR DESCRIPTION
this takes better advantage of the new UART code. Log download over
USB gets to 730 kbyte/s on a CubeOrange. For comparison, with the 4.0 code on the same
board we get about 330 kbyte/s