### PR TITLE
autotest: extend time allowed for RTL for simplemode test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1558,7 +1558,7 @@ class AutoTestCopter(AutoTest):
         # hover in place
         self.hover()
 
-        self.do_RTL()
+        self.do_RTL(timeout=500)
 
     # fly_super_simple - flies a circle around home for 45 seconds
     def fly_super_simple(self, timeout=45):


### PR DESCRIPTION
One failure was too many.
