### PR TITLE
Vagrant: create a bionic64-desktop VM

### DIFF
--- a/Tools/vagrant/initvagrant-desktop.sh
+++ b/Tools/vagrant/initvagrant-desktop.sh
@@ -34,6 +34,7 @@ EOF
 sudo -u "$VAGRANT_USER" dbus-launch gsettings set org.gnome.desktop.session idle-delay 0
 
 # don't show the initial setup crap:
+sudo -u "$VAGRANT_USER" mkdir -p /home/"$VAGRANT_USER"/.config
 echo "yes" | sudo -u "$VAGRANT_USER" dd of=/home/"$VAGRANT_USER"/.config/gnome-initial-setup-done
 
 # start the graphical environment right now:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,6 +120,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  # 18.04 LTS
+  config.vm.define "bionic64-desktop", primary: true do |bionic64|
+    bionic64.vm.box = "ubuntu/bionic64"
+    bionic64.vm.provision :shell, path: "Tools/vagrant/initvagrant-desktop.sh"
+    bionic64.vm.provider "virtualbox" do |vb|
+      vb.name = "ArduPilot (bionic64-desktop)"
+      vb.gui = true
+    end
+  end
+
   # 18.10
   config.vm.define "cosmic32", autostart: false do |cosmic32|
     cosmic32.vm.box = "ubuntu/cosmic32"


### PR DESCRIPTION
The focal-desktop appears to have a problem where directories are
considered to be in-use when being deleted. Not reproduced by me, but
reliably by a Windows user.