### PR TITLE
AP_GPS: Fix negative message delta time.

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -808,7 +808,16 @@ void AP_GPS::update_instance(uint8_t instance)
             state[instance].uart_timestamp_ms = 0;
         }
         // delta will only be correct after parsing two messages
-        timing[instance].delta_time_ms = tnow - timing[instance].last_message_time_ms;
+        // Make sure that the delta_time is not negative if time is not monotonic
+        if(tnow >= timing[instance].last_message_time_ms)
+        {
+            timing[instance].delta_time_ms = tnow - timing[instance].last_message_time_ms;
+        }
+        else
+        {
+            timing[instance].delta_time_ms = 0;
+        }
+
         timing[instance].last_message_time_ms = tnow;
         // if GPS disabled for flight testing then don't update fix timing value
         if (state[instance].status >= GPS_OK_FIX_2D && !_force_disable_gps) {


### PR DESCRIPTION
Buf fix for https://github.com/ArduPilot/ardupilot/issues/14702.

The GPS UART timestamp correction algorithm is sometime causing non-monotonic timestamp leading to negative delta times (unsigned underflow). This bug fix ensures that in any case the computed delta time is never negative.