### PR TITLE
Arducopter 4.0.7 Release notes and version bump

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,10 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.0.7 22-Feb-2021
+Changes from 4.0.7-rc1
+1) fixed build on Durandal board
+2) multiple fixes for mRo boards: ControlZero*, PixracerPro
+------------------------------------------------------------------
 Copter 4.0.7rc1 6-Feb-2021
 Changes from 4.0.6
 1) added automatic backup/restore of parameters in case of FRAM corruption for F7/H7 boards with 32k FRAM parameter storage

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.0.7rc1"
+#define THISFIRMWARE "ArduCopter V4.0.7"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,0,7,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,0,7,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 0
 #define FW_PATCH 7
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 


### PR DESCRIPTION
@bnsgeyer are you OK with this?
@tridge If this is OK, I can tag it once you merge it.

I labeled it "4.0 Backport" just to make it clear this is targeted at 4.0 branch.