### PR TITLE
Remove yaw rate wrapping in guided mode.

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -591,7 +591,7 @@ void ModeGuided::angle_control_run()
 
     // wrap yaw request
     float yaw_in = wrap_180_cd(guided_angle_state.yaw_cd);
-    float yaw_rate_in = wrap_180_cd(guided_angle_state.yaw_rate_cds);
+    float yaw_rate_in = guided_angle_state.yaw_rate_cds;
 
     float climb_rate_cms = 0.0f;
     if (!guided_angle_state.use_thrust) {


### PR DESCRIPTION
A requested yaw _rate_ shouldn't be wrapped at 180 deg/s as is the case with a requested yaw _angle_.
As an example: Currently, in Guided mode a requested 6 rad/s over mavros will result in a clockwise rotation at a lower angular rate than a requested 3 rad/s which will make it spin counterclockwise.

Removing the wrapping on the rate request results in the expected behavior in SITL:

![image](https://user-images.githubusercontent.com/34745547/108747915-49b5b780-753e-11eb-8a1a-9b96bcaf34a5.png)
 