### PR TITLE
GCS_MAVLink: Change invalid code to valid code

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -874,7 +874,7 @@ bool GCS_MAVLINK::should_send_message_in_delay_callback(const ap_message id) con
     case MSG_AUTOPILOT_VERSION:
         return true;
     default:
-        return false;
+        break;
     }
 
     return false;


### PR DESCRIPTION
I discovered code that would not run forever.
I believe that code needs to have a meaning.
I make the default process a break, so that the subsequent return statement makes sense.