### PR TITLE
AP_Notify: Change division to multiplication

### DIFF
--- a/libraries/AP_Notify/MMLPlayer.cpp
+++ b/libraries/AP_Notify/MMLPlayer.cpp
@@ -114,7 +114,7 @@ float MMLPlayer::rest_duration(uint32_t rest_length, uint8_t dots) const
     }
 
     float rest_period = whole_note_period/rest_length;
-    float dot_extension = rest_period/2;
+    float dot_extension = rest_period * 0.5f;
 
     while (dots--) {
         rest_period += dot_extension;
@@ -299,7 +299,7 @@ void MMLPlayer::next_action()
     }
     note_period -= _silence_duration;
 
-    float dot_extension = note_period/2;
+    float dot_extension = note_period * 0.5f;
     uint8_t dots = next_dots();
     while (dots--) {
         note_period += dot_extension;


### PR DESCRIPTION
The STM32 requires less CPU clock for multiplication than for division.
I use multiplication for the same operation in other processes.
I think it is better to adapt it to other processes.