### PR TITLE
AP_ROMFS: Added crc32 to ROMFS decompression

### DIFF
--- a/libraries/AP_ROMFS/AP_ROMFS.h
+++ b/libraries/AP_ROMFS/AP_ROMFS.h
@@ -25,11 +25,12 @@ public:
 
 private:
     // find an embedded file
-    static const uint8_t *find_file(const char *name, uint32_t &size);
+    static const uint8_t *find_file(const char *name, uint32_t &size, uint32_t &crc);
 
     struct embedded_file {
         const char *filename;
         uint32_t size;
+        uint32_t crc;
         const uint8_t *contents;
     };
     static const struct embedded_file files[];

--- a/libraries/AP_ROMFS/tinflate.cpp
+++ b/libraries/AP_ROMFS/tinflate.cpp
@@ -353,7 +353,7 @@ static int tinf_decode_trees(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
 
       /* special code length 16-18 are handled here */
       length = tinf_read_bits(d, lbits, lbase);
-      if (num + length >= hlimit) return TINF_DATA_ERROR;
+      if (num + length > hlimit) return TINF_DATA_ERROR;
       for (; length; --length)
       {
          lengths[num++] = fill_value;


### PR DESCRIPTION
After finding a bug in the decompression code I think it is a good idea to validate the decompressed data with a CRC to ensure that any future bugs are caught quickly
Note that the tinflate bug was already fixed in the original:
https://github.com/pfalcon/uzlib/blob/master/src/tinflate.c#L374
This bug was caught when a valid IO firmware could not be de-compressed to be loaded on the IOMCU