### PR TITLE
Add UAVCAN GNSS status message

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1917,6 +1917,15 @@ uint32_t AP_GPS::get_itow(uint8_t instance) const
     return drivers[instance]->get_last_itow();
 }
 
+bool AP_GPS::get_error_codes(uint8_t instance, uint32_t &error_codes) const
+{
+    if (instance >= GPS_MAX_RECEIVERS || drivers[instance] == nullptr) {
+        return false;
+    }
+
+    return drivers[instance]->get_error_codes(error_codes);
+}
+
 // Logging support:
 // Write an GPS packet
 void AP_GPS::Write_GPS(uint8_t i)

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -529,6 +529,9 @@ public:
     // get iTOW, if supported, zero otherwie
     uint32_t get_itow(uint8_t instance) const;
 
+    bool get_error_codes(uint8_t instance, uint32_t &error_codes) const;
+    bool get_error_codes(uint32_t &error_codes) const { return get_error_codes(primary_instance, error_codes); }
+
 protected:
 
     // configuration parameters

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -535,7 +535,7 @@ void AP_GPS_SBF::broadcast_configuration_failure_reason(void) const
     }
 }
 
-bool AP_GPS_SBF::is_configured (void) {
+bool AP_GPS_SBF::is_configured (void) const {
     return (gps._auto_config == AP_GPS::GPS_AUTO_CONFIG_DISABLE ||
              _init_blob_index >= ARRAY_SIZE(_initialisation_blob));
 }

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -39,7 +39,7 @@ public:
 
     const char *name() const override { return "SBF"; }
 
-    bool is_configured (void) override;
+    bool is_configured (void) const override;
 
     void broadcast_configuration_failure_reason(void) const override;
 
@@ -54,6 +54,7 @@ public:
 
     bool prepare_for_arming(void) override;
 
+    bool get_error_codes(uint32_t &error_codes) const override { error_codes = RxError; return true; };
 
 private:
 

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.h
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.h
@@ -29,6 +29,7 @@ class FixCb;
 class Fix2Cb;
 class AuxCb;
 class HeadingCb;
+class StatusCb;
 
 class AP_GPS_UAVCAN : public AP_GPS_Backend {
 public:
@@ -36,6 +37,12 @@ public:
     ~AP_GPS_UAVCAN();
 
     bool read() override;
+
+    bool is_healthy(void) const override;
+
+    bool logging_healthy(void) const override;
+
+    bool is_configured(void) const override;
 
     const char *name() const override { return "UAVCAN"; }
 
@@ -46,14 +53,18 @@ public:
     static void handle_fix2_msg_trampoline(AP_UAVCAN* ap_uavcan, uint8_t node_id, const Fix2Cb &cb);
     static void handle_aux_msg_trampoline(AP_UAVCAN* ap_uavcan, uint8_t node_id, const AuxCb &cb);
     static void handle_heading_msg_trampoline(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HeadingCb &cb);
+    static void handle_status_msg_trampoline(AP_UAVCAN* ap_uavcan, uint8_t node_id, const StatusCb &cb);
 
     void inject_data(const uint8_t *data, uint16_t len) override;
+
+    bool get_error_codes(uint32_t &error_codes) const override { error_codes = error_code; return seen_status; };
 
 private:
     void handle_fix_msg(const FixCb &cb);
     void handle_fix2_msg(const Fix2Cb &cb);
     void handle_aux_msg(const AuxCb &cb);
     void handle_heading_msg(const HeadingCb &cb);
+    void handle_status_msg(const StatusCb &cb);
 
     static bool take_registry();
     static void give_registry();
@@ -68,6 +79,11 @@ private:
     bool seen_message;
     bool seen_fix2;
     bool seen_aux;
+    bool seen_status;
+
+    bool healthy;
+    uint32_t status_flags;
+    uint32_t error_code;
 
     // Module Detection Registry
     static struct DetectedModules {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -117,7 +117,7 @@ public:
 
     static bool _detect(struct UBLOX_detect_state &state, uint8_t data);
 
-    bool is_configured(void) override {
+    bool is_configured(void) const override {
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
         if (!gps._auto_config) {
             return true;

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -40,7 +40,7 @@ public:
     // Allows external system to identify type of receiver connected.
     virtual AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D; }
 
-    virtual bool is_configured(void) { return true; }
+    virtual bool is_configured(void) const { return true; }
 
     virtual void inject_data(const uint8_t *data, uint16_t len);
 
@@ -76,6 +76,8 @@ public:
     // optional support for retrieving RTCMv3 data from a moving baseline base
     virtual bool get_RTCMV3(const uint8_t *&bytes, uint16_t &len) { return false; }
     virtual void clear_RTCMV3(void) {};
+
+    virtual bool get_error_codes(uint32_t &error_codes) const { return false; }
 
     // return iTOW of last message, or zero if not supported
     uint32_t get_last_itow(void) const {

--- a/libraries/AP_UAVCAN/dsdl/ardupilot/gnss/20003.Status.uavcan
+++ b/libraries/AP_UAVCAN/dsdl/ardupilot/gnss/20003.Status.uavcan
@@ -1,0 +1,10 @@
+# Node specific GNSS error codes, primarily available for logging and diagnostics
+uint32 error_codes
+
+# GNSS system is self assesd as healthy
+bool healthy
+
+# Status is actually a bitmask, due to encoding issues pretend it's just a field, and leave it up to the application do decode it)
+uint23 STATUS_LOGGING = 1  # GNSS system is doing any onboard logging
+uint23 STATUS_ARMABLE = 2  # GNSS system is in a reasonable state to allow the system to arm
+uint23 status


### PR DESCRIPTION
This adds a new ArduPilot DSDL message for the GNSS status. It's primary purpose is to start encoding if a GPS on a node is fully configured, if it's healthy, or is currently logging. It also allows us to transport device specific error bits from the device.

There's a drive by change to make `GPS_Backend::is_configured` const, as it always should have been.

~@tridge the comment by the change in the HitecMosaic hwdef is almost certainly wrong, but the entire change was the bare minimum to get me building again, so I'd appreciate some input on what I should have done here.~

There's a bit  more to do with the device error bits, I might push it into this PR or do it as a separate follow up. I wanted to start the discussion with what's here, which is working on my desk on a CubeOrange + HitecMosaic.