### PR TITLE
HAL_ChibiOS: fixed build of f3 boards without PWM out

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -346,8 +346,10 @@ void Scheduler::_rcout_thread(void *arg)
     while (!sched->_hal_initialized) {
         sched->delay_microseconds(1000);
     }
+#if HAL_USE_PWM == TRUE
     // trampoline into the rcout thread
     ((RCOutput*)hal.rcout)->rcout_thread();
+#endif
 #endif
 }
 


### PR DESCRIPTION
thanks to @WickedShell for finding this