### PR TITLE
HAL_ChibiOS: fixed a race and null ptr deref in dshot

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1360,8 +1360,11 @@ void RCOutput::dma_unlock(void *p)
     pwm_group *group = (pwm_group *)p;
 
     group->dshot_state = DshotState::IDLE;
-    // tell the waiting process we've done the DMA
-    chEvtSignalI(group->dshot_waiter, group->dshot_event_mask);
+    if (group->dshot_waiter != nullptr) {
+        // tell the waiting process we've done the DMA. Note that
+        // dshot_waiter can be null if we have cancelled the send
+        chEvtSignalI(group->dshot_waiter, group->dshot_event_mask);
+    }
     chSysUnlockFromISR();
 }
 


### PR DESCRIPTION
if a dshot is cancelled then the waiter can be nullptr
note that this implies we are getting dshot timeouts