### PR TITLE
Copter: decrease default ANGLE_MAX, increase WPNAV_SPEED and ACCEL

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -559,7 +559,7 @@
  # define ROLL_PITCH_YAW_INPUT_MAX      4500        // roll, pitch and yaw input range
 #endif
 #ifndef DEFAULT_ANGLE_MAX
- # define DEFAULT_ANGLE_MAX         4500            // ANGLE_MAX parameters default value
+ # define DEFAULT_ANGLE_MAX         3000            // ANGLE_MAX parameters default value
 #endif
 #ifndef ANGLE_RATE_MAX
  # define ANGLE_RATE_MAX            18000           // default maximum rotation rate in roll/pitch axis requested by angle controller used in stabilize, loiter, rtl, auto flight modes

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -544,6 +544,8 @@ static const struct AP_Param::defaults_table_struct defaults_table[] = {
     { "Q_LOIT_BRK_ACCEL", 50.0 },
     { "Q_LOIT_BRK_JERK",  250 },
     { "Q_LOIT_SPEED",     500 },
+    { "Q_WP_SPEED",       500 },
+    { "Q_WP_ACCEL",       100 },
 };
 
 /*

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4896,7 +4896,7 @@ class AutoTestCopter(AutoTest):
         self.takeoff(10)
 
         tstart = self.get_sim_time_cached()
-        want_pitch_degrees = -20
+        want_pitch_degrees = -12
         while True:
             if self.get_sim_time_cached() - tstart > 10:
                 raise AutoTestTimeoutException("Did not reach pitch")

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -11,10 +11,10 @@
 #include <AC_Avoidance/AC_Avoid.h>                 // Stop at fence library
 
 // maximum velocities and accelerations
-#define WPNAV_ACCELERATION              100.0f      // defines the default velocity vs distant curve.  maximum acceleration in cm/s/s that position controller asks for from acceleration controller
+#define WPNAV_ACCELERATION              250.0f      // maximum horizontal acceleration in cm/s/s that wp navigation will request
 #define WPNAV_ACCELERATION_MIN           50.0f      // minimum acceleration in cm/s/s - used for sanity checking _wp_accel parameter
 
-#define WPNAV_WP_SPEED                  500.0f      // default horizontal speed between waypoints in cm/s
+#define WPNAV_WP_SPEED                 1000.0f      // default horizontal speed between waypoints in cm/s
 #define WPNAV_WP_SPEED_MIN               20.0f      // minimum horizontal speed between waypoints in cm/s
 #define WPNAV_WP_TRACK_SPEED_MIN         50.0f      // minimum speed along track of the target point the vehicle is chasing in cm/s (used as target slows down before reaching destination)
 #define WPNAV_WP_RADIUS                 200.0f      // default waypoint radius in cm


### PR DESCRIPTION
This PR tries to set a few important defaults to better values for most users:

- ANGLE_MAX (vehicle's maximum lean angle) is decreased from **45deg** to **30deg** because the vast majority of vehicles cannot maintain altitude at a 45 lean angle.  This will reduce the max horizontal acceleration in Stabilize, AltHold, PosHold from about 9.81m/s/s to 5.6m/s/s which improves safety.  This will **not** reduce the vehicle's maximum speed which most vehicle achieve at about 20deg lean angle.
- WPNAV_SPEED is increased from 5m/s to 10m/s (affects Loiter, RTL, Guided)
- WPNAV_ACCEL is increased from 1m/s/s to 2.5m/s/s (affects Loiter, RTL, Guided)

This PR also includes a minor change to the MANUAL_CONTROL autotest to account for the reduce lean angle

These changes were made in discussion with @lthall.  Independently @peterbarker also mentioned the defaults were too low during recent SCurve testing.
