### PR TITLE
Sub 4.0: do not report remaining battery percentage

### DIFF
--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -40,7 +40,7 @@ protected:
 
     uint64_t capabilities() const override;
 
-    uint8_t get_battery_remaining_percentage() override { return -1; };
+    uint8_t get_battery_remaining_percentage(uint8_t instance) const override { return -1; };
 
 private:
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -431,7 +431,7 @@ protected:
     virtual float vfr_hud_airspeed() const;
     virtual int16_t vfr_hud_throttle() const { return 0; }
     virtual float vfr_hud_alt() const;
-    virtual uint8_t get_battery_remaining_percentage();
+    virtual uint8_t get_battery_remaining_percentage(uint8_t instance=0) const;
 
     static constexpr const float magic_force_arm_value = 2989.0f;
     static constexpr const float magic_force_disarm_value = 21196.0f;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4662,9 +4662,9 @@ void GCS_MAVLINK::manual_override(RC_Channel *c, int16_t value_in, const uint16_
     c->set_override(override_value, tnow);
 }
 
-uint8_t GCS_MAVLINK::get_battery_remaining_percentage() {
+uint8_t GCS_MAVLINK::get_battery_remaining_percentage(uint8_t instance) const {
     const AP_BattMonitor &battery = AP::battery();
-    return battery.capacity_remaining_pct();
+    return battery.capacity_remaining_pct(instance);
 }
 
 GCS &gcs()

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -233,7 +233,7 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
                                     current,      // current in centiampere
                                     consumed_mah, // total consumed current in milliampere.hour
                                     consumed_wh,  // consumed energy in hJ (hecto-Joules)
-                                    battery.capacity_remaining_pct(instance),
+                                    get_battery_remaining_percentage(instance),
                                     0, // time remaining, seconds (not provided)
                                     MAV_BATTERY_CHARGE_STATE_UNDEFINED);
 }


### PR DESCRIPTION
This makes sub 4.0 no longer report the remaining battery percentage in BATTERY_STATUS messages.

The reasoning behind it is that it can often be wrong, specially in Sub, where one battery can easily last for multiple flights. With a battery plugged in half-charged, the percentage may mislead users to over-discharge their batteries. This change forces GCS to display voltage instead.