### PR TITLE
AP_Scripting: allow scripting startup with no sdcard

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -132,7 +132,6 @@ void AP_Scripting::init(void) {
     if (AP::FS().mkdir(dir_name)) {
         if (errno != EEXIST) {
             gcs().send_text(MAV_SEVERITY_INFO, "Lua: failed to create (%s)", dir_name);
-            return;
         }
     }
 


### PR DESCRIPTION
as scripts can be in ROMFS we should still create the thread without
the scripts directory