### PR TITLE
Scripting: add mission DO command

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -299,6 +299,7 @@ bool AP_Mission::verify_command(const Mission_Command& cmd)
     case MAV_CMD_DO_DIGICAM_CONTROL:
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
     case MAV_CMD_DO_PARACHUTE:
+    case MAV_CMD_DO_SEND_SCRIPT_MESSAGE:
     case MAV_CMD_DO_SPRAYER:
     case MAV_CMD_DO_SET_RESUME_REPEAT_DIST:
         return true;
@@ -330,6 +331,8 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
         return start_command_camera(cmd);
     case MAV_CMD_DO_PARACHUTE:
         return start_command_parachute(cmd);
+    case MAV_CMD_DO_SEND_SCRIPT_MESSAGE:
+        return start_command_do_scripting(cmd);
     case MAV_CMD_DO_SPRAYER:
         return start_command_do_sprayer(cmd);
     case MAV_CMD_DO_SET_RESUME_REPEAT_DIST:
@@ -1102,6 +1105,13 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.p1 = packet.param1;                        // action 0=disable, 1=enable
         break;
 
+    case MAV_CMD_DO_SEND_SCRIPT_MESSAGE:
+        cmd.p1 = packet.param1;
+        cmd.content.scripting.p1 = packet.param2;
+        cmd.content.scripting.p2 = packet.param3;
+        cmd.content.scripting.p3 = packet.param4;
+        break;
+
     default:
         // unrecognised command
         return MAV_MISSION_UNSUPPORTED;
@@ -1544,6 +1554,13 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
 
     case MAV_CMD_DO_SET_RESUME_REPEAT_DIST:
         packet.param1 = cmd.p1; // Resume repeat distance (m)
+        break;
+
+    case MAV_CMD_DO_SEND_SCRIPT_MESSAGE:
+        packet.param1 = cmd.p1;
+        packet.param2 = cmd.content.scripting.p1;
+        packet.param3 = cmd.content.scripting.p2;
+        packet.param4 = cmd.content.scripting.p3;
         break;
 
     default:
@@ -2251,6 +2268,8 @@ const char *AP_Mission::Mission_Command::type() const
         return "MountControl";
     case MAV_CMD_DO_WINCH:
         return "Winch";
+    case MAV_CMD_DO_SEND_SCRIPT_MESSAGE:
+        return "Scripting";
 
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -198,6 +198,13 @@ public:
         float release_rate;     // release rate in meters/second
     };
 
+    // Scripting command structure
+    struct PACKED scripting_Command {
+        float p1;
+        float p2;
+        float p3;
+    };
+
     union Content {
         // jump structure
         Jump_Command jump;
@@ -261,6 +268,9 @@ public:
 
         // do-winch
         Winch_Command winch;
+
+        // do scripting
+        scripting_Command scripting;
 
         // location
         Location location{};      // Waypoint location
@@ -698,6 +708,8 @@ private:
     bool command_do_set_repeat_dist(const AP_Mission::Mission_Command& cmd);
 
     bool start_command_do_sprayer(const AP_Mission::Mission_Command& cmd);
+    bool start_command_do_scripting(const AP_Mission::Mission_Command& cmd);
+
 };
 
 namespace AP

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -6,6 +6,7 @@
 #include <AP_Parachute/AP_Parachute.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AC_Sprayer/AC_Sprayer.h>
+#include <AP_Scripting/AP_Scripting.h>
 
 bool AP_Mission::start_command_do_gripper(const AP_Mission::Mission_Command& cmd)
 {
@@ -166,4 +167,20 @@ bool AP_Mission::start_command_do_sprayer(const AP_Mission::Mission_Command& cmd
 #else
     return false;
 #endif // HAL_SPRAYER_ENABLED
+}
+
+bool AP_Mission::start_command_do_scripting(const AP_Mission::Mission_Command& cmd)
+{
+#ifdef ENABLE_SCRIPTING
+    AP_Scripting *scripting = AP_Scripting::get_singleton();
+    if (scripting == nullptr) {
+        return false;
+    }
+
+    scripting->handle_mission_command(cmd);
+
+    return true;
+#else
+    return false;
+#endif // ENABLE_SCRIPTING
 }

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -206,6 +206,30 @@ void AP_Scripting::thread(void) {
     gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting has stopped");
 }
 
+void AP_Scripting::handle_mission_command(const AP_Mission::Mission_Command& cmd_in)
+{
+    if (!_enable) {
+        return;
+    }
+
+    if (mission_data == nullptr) {
+        // load buffer
+        mission_data = new ObjectBuffer<struct AP_Scripting::scripting_mission_cmd>(mission_cmd_queue_size);
+        if (mission_data == nullptr) {
+            gcs().send_text(MAV_SEVERITY_INFO, "scripting: unable to receive mission command");
+            return;
+        }
+    }
+
+    struct scripting_mission_cmd cmd {cmd_in.p1,
+                                      cmd_in.content.scripting.p1,
+                                      cmd_in.content.scripting.p2,
+                                      cmd_in.content.scripting.p3,
+                                      AP_HAL::millis()};
+
+    mission_data->push(cmd);
+}
+
 AP_Scripting *AP_Scripting::_singleton = nullptr;
 
 namespace AP {

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -46,6 +46,8 @@ public:
 
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
 
+    void handle_mission_command(const AP_Mission::Mission_Command& cmd);
+
    // User parameters for inputs into scripts 
    AP_Float _user[4]; 
 
@@ -64,6 +66,17 @@ public:
     // the number of and storage for i2c devices
     uint8_t num_i2c_devices;
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> *_i2c_dev[SCRIPTING_MAX_NUM_I2C_DEVICE];
+
+    // mission item buffer
+    static const int mission_cmd_queue_size = 5;
+    struct scripting_mission_cmd {
+        uint16_t p1;
+        float content_p1;
+        float content_p2;
+        float content_p3;
+        uint32_t time_ms;
+    };
+    ObjectBuffer<struct scripting_mission_cmd> * mission_data;
 
 private:
 

--- a/libraries/AP_Scripting/examples/Mission_test.lua
+++ b/libraries/AP_Scripting/examples/Mission_test.lua
@@ -4,6 +4,12 @@ local last_mission_index = mission:get_current_nav_index()
 
 function update() -- this is the loop which periodically runs
 
+  -- check for scripting DO commands in the mission
+  local time_ms, param1, param2, param3, param4 = mission_receive()
+  if time_ms then
+    gcs:send_text(0, string.format("Scripting CMD @ %u ms, %i, %0.2f, %0.2f, %0.2f", time_ms:tofloat(), param1, param2, param3, param4))
+  end
+
   local mission_state = mission:state()
 
   -- make sure the mission is running

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -47,10 +47,39 @@ static int lua_micros(lua_State *L) {
     return 1;
 }
 
+static int lua_mission_receive(lua_State *L) {
+    check_arguments(L, 0, "mission_receive");
+
+    ObjectBuffer<struct AP_Scripting::scripting_mission_cmd> *input = AP::scripting()->mission_data;
+
+    if (input == nullptr) {
+        // no mission items ever received
+        return 0;
+    }
+
+    struct AP_Scripting::scripting_mission_cmd cmd;
+
+    if (!input->pop(cmd)) {
+        // no new item
+        return 0;
+    }
+
+    new_uint32_t(L);
+    *check_uint32_t(L, -1) = cmd.time_ms;
+
+    lua_pushinteger(L, cmd.p1);
+    lua_pushnumber(L, cmd.content_p1);
+    lua_pushnumber(L, cmd.content_p2);
+    lua_pushnumber(L, cmd.content_p3);
+
+    return 5;
+}
+
 static const luaL_Reg global_functions[] =
 {
     {"millis", lua_millis},
     {"micros", lua_micros},
+    {"mission_receive", lua_mission_receive},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
This adds a DO command that can pass 3 floats to scripting allong with a timestamp. Of course the script has to sit there and keep check if it has a command. 

This is implemented in the same way as https://github.com/ArduPilot/ardupilot/pull/13660

Don't merge until the MAVLink change is in.