### PR TITLE
AC_WPNav: Fix Terrain Following with Obstacle Avoidance On

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -365,10 +365,22 @@ void AC_WPNav::get_wp_stopping_point_xy(Vector3f& stopping_point) const
 }
 
 /// get_wp_stopping_point - returns vector to stopping point based on 3D position and velocity
-void AC_WPNav::get_wp_stopping_point(Vector3f& stopping_point) const
+///     terrain_alt should be true if stopping_point should be altitude above terrain (false if it is alt-above-ekf-origin)
+bool AC_WPNav::get_wp_stopping_point(Vector3f& stopping_point, bool terrain_alt) const
 {
     _pos_control.get_stopping_point_xy(stopping_point);
     _pos_control.get_stopping_point_z(stopping_point);
+
+    // convert origin to alt-above-terrain
+    if (terrain_alt) {
+        float origin_terr_offset;
+        if (!get_terrain_offset(origin_terr_offset)) {
+            return false;
+        }
+        stopping_point.z -= origin_terr_offset;
+    }
+
+    return true;
 }
 
 /// advance_wp_target_along_track - move target location along track from origin to destination

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -1016,7 +1016,7 @@ void AC_WPNav::calc_spline_pos_vel(float spline_time, Vector3f& position, Vector
 }
 
 // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
-bool AC_WPNav::get_terrain_offset(float& offset_cm)
+bool AC_WPNav::get_terrain_offset(float& offset_cm) const
 {
     // calculate offset based on source (rangefinder or terrain database)
     switch (get_terrain_source()) {

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -283,7 +283,7 @@ protected:
     void calc_spline_pos_vel(float spline_time, Vector3f& position, Vector3f& velocity);
 
     // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
-    bool get_terrain_offset(float& offset_cm);
+    bool get_terrain_offset(float& offset_cm) const;
 
     // convert location to vector from ekf origin.  terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
     //      returns false if conversion failed (likely because terrain data was not available)

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -151,7 +151,7 @@ public:
     /// get_wp_stopping_point_xy - calculates stopping point based on current position, velocity, waypoint acceleration
     ///		results placed in stopping_position vector
     void get_wp_stopping_point_xy(Vector3f& stopping_point) const;
-    void get_wp_stopping_point(Vector3f& stopping_point) const;
+    bool get_wp_stopping_point(Vector3f& stopping_point, bool terrain_alt = false) const;
 
     /// get_wp_distance_to_destination - get horizontal distance to destination in cm
     virtual float get_wp_distance_to_destination() const;


### PR DESCRIPTION
This attempts to address terrain following not working with Object Avoidance. Issue #16479 

@Huibean in #15223 identified the location of where the `_terrain_alt` flag was being set to false. This causes `_terrain_alt` to be set false, for the duration of each waypoint, after the following the code executes.
https://github.com/ArduPilot/ardupilot/blob/b450740fb0e5cfb814636704a15e8ae19497a24a/libraries/AC_WPNav/AC_WPNav.cpp#L248

To fix this `get_wp_stopping_point(stopping_point)` should set the altitude in the terrain frame. Without doing this an extra `origin_terrain_offset` would be added to commands.

Issue found with OABR log messages incorrectly logging altitudes due to wrong format specifier. PR #16750

Below are SITL Testing Logs:
**Master Terrain Following ON: OA OFF** (Terrains following works)
![master_OA_off_terrain_follow](https://user-images.githubusercontent.com/69225461/109280039-7bea4200-77e8-11eb-95be-d841bf5b5821.png)

**Master Terrain Following ON: OA Bendy ON** (Terrain following fails)
![master_OA_on_terrain_follow](https://user-images.githubusercontent.com/69225461/109280353-eb603180-77e8-11eb-9f26-780fdfb2b8c5.png)

**PR Terrain Following On: OA Bendy ON**
![modifications_to_master_with_stopping_adaptation3_no_speed_graph](https://user-images.githubusercontent.com/69225461/109280314-dbe0e880-77e8-11eb-9b2a-970a83a72e26.png)

