### PR TITLE
AP_Logger: OABR correct altitude logging frame and specifier 

### DIFF
--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -602,6 +602,10 @@ void AP_Logger::Write_SRTL(bool active, uint16_t num_points, uint16_t max_points
 
 void AP_Logger::Write_OABendyRuler(uint8_t type, bool active, float target_yaw, float target_pitch, bool resist_chg, float margin, const Location &final_dest, const Location &oa_dest)
 {
+    int32_t oa_dest_alt, final_alt;
+    bool got_oa_dest = oa_dest.get_alt_cm(Location::AltFrame::ABOVE_ORIGIN, oa_dest_alt);
+    bool got_final_dest = final_dest.get_alt_cm(Location::AltFrame::ABOVE_ORIGIN, final_alt);
+    
     const struct log_OABendyRuler pkt{
         LOG_PACKET_HEADER_INIT(LOG_OA_BENDYRULER_MSG),
         time_us     : AP_HAL::micros64(),
@@ -614,10 +618,10 @@ void AP_Logger::Write_OABendyRuler(uint8_t type, bool active, float target_yaw, 
         margin      : margin,
         final_lat   : final_dest.lat,
         final_lng   : final_dest.lng,
-        final_alt   : final_dest.alt,
+        final_alt   : got_final_dest ? final_alt : final_dest.alt,
         oa_lat      : oa_dest.lat,
         oa_lng      : oa_dest.lng,
-        oa_alt      : oa_dest.alt
+        oa_alt      : got_oa_dest ? oa_dest_alt : oa_dest.alt
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1134,10 +1134,10 @@ struct PACKED log_PSCZ {
 // @Field: Mar: Margin from path to obstacle on best yaw chosen
 // @Field: DLt: Destination latitude
 // @Field: DLg: Destination longitude
-// @Field: DAlt: Desired alt
+// @Field: DAlt: Desired alt above EKF Origin
 // @Field: OLt: Intermediate location chosen for avoidance
 // @Field: OLg: Intermediate location chosen for avoidance
-// @Field: OAlt: Intermediate alt chosen for avoidance
+// @Field: OAlt: Intermediate alt chosen for avoidance above EKF origin
 
 // @LoggerMessage: OADJ
 // @Description: Object avoidance (Dijkstra) diagnostics
@@ -1469,7 +1469,7 @@ LOG_STRUCTURE_FROM_CAMERA \
     { LOG_SRTL_MSG, sizeof(log_SRTL), \
       "SRTL", "QBHHBfff", "TimeUS,Active,NumPts,MaxPts,Action,N,E,D", "s----mmm", "F----000" }, \
     { LOG_OA_BENDYRULER_MSG, sizeof(log_OABendyRuler), \
-      "OABR","QBBHHHBfLLfLLf","TimeUS,Type,Act,DYaw,Yaw,DP,RChg,Mar,DLt,DLg,DAlt,OLt,OLg,OAlt", "s-bddd-mDUmDUm", "F-------GGBGGB" }, \
+      "OABR","QBBHHHBfLLiLLi","TimeUS,Type,Act,DYaw,Yaw,DP,RChg,Mar,DLt,DLg,DAlt,OLt,OLg,OAlt", "s-bddd-mDUmDUm", "F-------GGBGGB" }, \
     { LOG_OA_DIJKSTRA_MSG, sizeof(log_OADijkstra), \
       "OADJ","QBBBBLLLL","TimeUS,State,Err,CurrPoint,TotPoints,DLat,DLng,OALat,OALng", "sbbbbDUDU", "F----GGGG" }, \
     { LOG_SIMPLE_AVOID_MSG, sizeof(log_SimpleAvoid), \


### PR DESCRIPTION
Fixes OABR log message to use the correct int32 specifier for the altitudes.

Added: ensure altitude in reported in EFK origin frame

**Tested in SITL Master** (Altitudes =0)
![master_OABR_logging](https://user-images.githubusercontent.com/69225461/109283340-ab9b4900-77ec-11eb-9e3b-72164b320c77.png)

**After PR**
![pr_fix_OABR_logging](https://user-images.githubusercontent.com/69225461/109283036-4a737580-77ec-11eb-875e-0488f2e5affa.png)
