### PR TITLE
AP_KDECAN: map channel to motors directly

### DIFF
--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -573,10 +573,8 @@ void AP_KDECAN::update()
                 continue;
             }
 
-            SRV_Channel::Aux_servo_function_t motor_function = SRV_Channels::get_motor_function(i);
-
-            if (SRV_Channels::function_assigned(motor_function)) {
-                float norm_output = SRV_Channels::get_output_norm(motor_function);
+            if (SRV_Channels::channel_function(i)) {
+                float norm_output = hal.rcout->scale_esc_to_unity(SRV_Channels::srv_channel(i)->get_output_pwm());
                 _scaled_output[i] = uint16_t((norm_output + 1.0f) / 2.0f * 2000.0f);
             } else {
                 _scaled_output[i] = 0;

--- a/libraries/AP_KDECAN/AP_KDECAN.h
+++ b/libraries/AP_KDECAN/AP_KDECAN.h
@@ -104,7 +104,7 @@ private:
 
 
     union frame_id_t {
-        struct {
+        struct PACKED {
             uint8_t object_address;
             uint8_t destination_id;
             uint8_t source_id;


### PR DESCRIPTION
Fix issue which doesn't let KDECAN work with Plane Firmware