### PR TITLE
Tools: make some message catch more robust

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3773,6 +3773,9 @@ class AutoTest(ABC):
                             self.context_get().parameters.append((name, original_values[name]))
                     received.add(name)
                     continue
+                if original_values[name] == autopilot_values[name] and i % 2 == 0:
+                    self.send_get_parameter_direct(name)
+                    self.progress("Requesting (%s) (retry=%u)" % (name, i))
                 self.progress("Sending set (%s) to (%f) (old=%f)" % (name, value, original_values[name]))
                 self.send_set_parameter_direct(name, value)
             for name in received:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4070,7 +4070,7 @@ class AutoTest(ABC):
             m = self.mav.recv_match(type='COMMAND_ACK',
                                     blocking=True,
                                     timeout=0.1)
-            if m is None:
+            if m is None or m.get_srcSystem() != self.target_system:
                 continue
             if not quiet:
                 self.progress("ACK received: %s (%fs)" % (str(m), delta_time))

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5698,7 +5698,9 @@ Also, ignores heartbeats not from our target system'''
                 continue
             m = self.mav.messages.get("HOME_POSITION", None)
             if m is None:
-                continue
+                m = self.mav.recv_match(type='HOME_POSITION', blocking=True, timeout=5)
+                if m is None:
+                    continue
             if old is None:
                 break
             if m._timestamp != old._timestamp:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4036,6 +4036,10 @@ class AutoTest(ABC):
                 target_compid=None,
                 timeout=10,
                 quiet=False):
+        if target_sysid is None:
+            target_sysid = self.target_system
+        if target_compid is None:
+            target_compid = 1
         self.drain_mav_unparsed()
         self.get_sim_time() # required for timeout in run_cmd_get_ack to work
         self.send_cmd(


### PR DESCRIPTION
Some fix and improvement on getting the message on autotest.
I know that we don't do test with multiple systems yet, but those checks are cheap and will help in the future !