### PR TITLE
Plane: Quadplane disable forward motor assist in Q modes if rangefind…

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3207,8 +3207,9 @@ int8_t QuadPlane::forward_throttle_pct()
         // lidar could cause the aircraft not to be able to
         // approach the landing point when landing below the takeoff point
         vel_forward.last_pct = vel_forward.integrator;
-    } else if (in_vtol_land_final() && motors->limit.throttle_lower) {
-        // we're in the settling phase of landing, disable fwd motor
+    } else if ((in_vtol_land_final() && motors->limit.throttle_lower) ||
+              (plane.g.rangefinder_landing && (plane.rangefinder.status_orient(ROTATION_PITCH_270) == RangeFinder::Status::OutOfRangeLow))) {
+        // we're in the settling phase of landing or using a rangefinder that is out of range low, disable fwd motor
         vel_forward.last_pct = 0;
         vel_forward.integrator = 0;
     } else {


### PR DESCRIPTION
…er is out of range low

This disables the forward motor in Q modes if using the rangefinder and its out of range low.  The edge case in a VTOL landing is already handled (https://github.com/ArduPilot/ardupilot/pull/12267). We might what to make that fix in `relative_ground_altitude` more general, but that function is used in lots of places.

Should only effect Qloiter ~and Qautotune~, other position control modes that can use the forward throttle should already be setting the landing flag correctly and avoiding this issue. ~(We might want to disable forward throttle in Qautotune altogether in any case.)~

Funded by ARACE