### PR TITLE
autotest: further loosen constraint on receiving statustext

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -9037,7 +9037,7 @@ switch value'''
         sent_request = False
         while True:
             now = self.get_sim_time()
-            if now - tstart > 60: # it can take a *long* time to get these messages down!
+            if now - tstart > 120: # it can take a *long* time to get these messages down!
                 raise NotAchievedException("Did not get statustext in time")
             if now - tstart > 30 and not sent_request:
                 # have to wait this long or our message gets squelched....


### PR DESCRIPTION
The more thing we add to the list the long it takes to receive these
statustexts.


Saw this fail in autotest.  We've recently made changes which could explain this being slower.

Still seems off to require 2 minutes to get this - any ideas @yaapu ?
