### PR TITLE
autotest: remove pointless fetch_parameters call

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1511,10 +1511,6 @@ class AutoTest(ABC):
                 locs
             ])
 
-    def fetch_parameters(self):
-        self.mavproxy.send("param fetch\n")
-        self.mavproxy.expect("Received [0-9]+ parameters")
-
     def send_reboot_command(self):
         self.mav.mav.command_long_send(self.sysid_thismav(),
                                        1,
@@ -8575,7 +8571,6 @@ switch value'''
                 self.mavproxy.expect("sitl_accelcal: attitude detected, please press any key..", timeout=timeout)
                 self.mavproxy.send("\n")
             self.mavproxy.expect("APM: Calibration successful", timeout=timeout)
-            self.fetch_parameters()
             self.drain_mav()
 
             self.progress("Checking results")
@@ -8634,7 +8629,6 @@ switch value'''
                                        mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, 0,
                                        0, 0, 0, 0, 2, 0, 0)
         self.wait_statustext('Trim OK')
-        self.fetch_parameters()
         self.drain_mav()
 
         self.progress("Checking results")

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5664,6 +5664,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if ex is not None:
             raise ex
 
+    def test_mavproxy_param(self):
+        self.mavproxy.send("param fetch\n")
+        self.mavproxy.expect("Received [0-9]+ parameters")
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestRover, self).tests()
@@ -5777,6 +5781,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             ("Offboard",
              "Test Offboard Control",
              self.test_offboard),
+
+            ("MAVProxyParam",
+             "Test MAVProxy parameter handling",
+             self.test_mavproxy_param),
 
             ("GCSFence",
              "Upload and download of fence",


### PR DESCRIPTION
And the entire method, replace with equivalent test