### PR TITLE
AP_CANManager:Ensure that the can transmission interval is greater than 1ms

### DIFF
--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -673,6 +673,10 @@ int16_t SLCAN::CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& rx_time,
         }
     }
     if (rx_queue_.available()) {
+        if ( intervals > AP_HAL::micros64()) {
+            return 0;
+        }
+        intervals = AP_HAL::micros64() + 1000;
         // if we already have something in buffer transmit it
         CanRxItem frm;
         if (!rx_queue_.pop(frm)) {

--- a/libraries/AP_CANManager/AP_SLCANIface.h
+++ b/libraries/AP_CANManager/AP_SLCANIface.h
@@ -82,6 +82,7 @@ class CANIface: public AP_HAL::CANIface
     AP_HAL::CANIface* _can_iface; // Can interface to be used for interaction by SLCAN interface
     HAL_Semaphore port_sem;
     bool _set_by_sermgr;
+    uint64_t intervals = 0;
 public:
     CANIface():
         rx_queue_(HAL_CAN_RX_QUEUE_SIZE)


### PR DESCRIPTION
> Problem reproduced: 

Reappear the environment:
Ground station: 
Mission Planner1.3.74 
Firmware version：
34a52e9cfe8e2a3f7b0c74e9dd2fc7386aef7fae
Reproduce Process ：
![image](https://user-images.githubusercontent.com/30532769/109623646-5064b000-7b78-11eb-9cf5-f26d9cc9d18f.png)
Stuck at downloading firmware 
![image](https://user-images.githubusercontent.com/30532769/109623699-5fe3f900-7b78-11eb-85e4-1dadcf229021.png)
Analysis using UAVCAN GUI Tool 
![image](https://user-images.githubusercontent.com/30532769/109623750-6d00e800-7b78-11eb-9315-ea9211301cc6.png)
![image](https://user-images.githubusercontent.com/30532769/109623768-70946f00-7b78-11eb-8b4e-e2f1f0c5a66d.png)

> Search error:

file：libraries/AP_CANManager/AP_SLCANIface.cpp 
Line 692 in the file，（_can_iface->send(out_frame, AP_HAL::native_micros64() + 1000, out_flags);）
The return value is 0. It means that TX's sending mailbox is full

> resolvent:

Increase the interval time of can transmission. 
