### PR TITLE
AP_RangeFinder: increase lightware I2C timeout to 0.2 sec

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -21,7 +21,7 @@ extern const AP_HAL::HAL& hal;
 #define LIGHTWARE_DISTANCE_READ_REG 0
 #define LIGHTWARE_LOST_SIGNAL_TIMEOUT_READ_REG 22
 #define LIGHTWARE_LOST_SIGNAL_TIMEOUT_WRITE_REG 23
-#define LIGHTWARE_TIMEOUT_REG_DESIRED_VALUE 5
+#define LIGHTWARE_TIMEOUT_REG_DESIRED_VALUE 20      // number of lost signal confirmations for legacy protocol only
 
 #define LIGHTWARE_OUT_OF_RANGE_ADD_CM   100
 


### PR DESCRIPTION
This PR is based upon a request from Lightware to increase the Lightware I2C driver's timeout because they have received a significant number of calls from clients reporting that they are seeing distance spikes most likely based on the lidar timing out.

This change makes the timeout consistent with the lightware serial driver.

For reference here are timeouts for some other lidar:

- NMEA: 3sec
- Maxsonar SerialLV 0.5sec
- LeddarVu8: 0.5sec
- BLPing: 1sec
- BackendSerial: 0.2sec