### PR TITLE
Regularize DShot output rates

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -212,6 +212,11 @@ public:
     virtual void set_bidir_dshot_mask(uint16_t mask) {}
 
     /*
+      Set the dshot rate as a multiple of the loop rate
+     */
+    virtual void set_dshot_rate(uint8_t dshot_rate, uint16_t loop_rate_hz) {}
+
+    /*
       setup serial led output for a given channel number, with
       the given max number of LEDs in the chain.
      */

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -143,8 +143,8 @@ void RCOutput::rcout_thread()
     uint32_t cal_cycles = 5000000UL / 300UL;
     _dshot_calibrating = true;
     const uint32_t cycle_time_us = _dshot_period_us;
-    // while calibrating run at 3Khz to allow arming
-    _dshot_period_us = 300;
+    // while calibrating run at 2.5Khz to allow arming, this is the fastest rate that dshot150 can manage
+    _dshot_period_us = 400;
 
     // prime the pump for calibration
     chEvtSignal(rcout_thread_ctx, EVT_PWM_SYNTHETIC_SEND);

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -425,6 +425,8 @@ private:
     uint8_t _dshot_rate;
     // dshot periods since the last push()
     uint8_t _dshot_cycle;
+    // in the very even pulse calibration step
+    bool _dshot_calibrating;
     // virtual timer for post-push() pulses
     virtual_timer_t _dshot_rate_timer;
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -499,6 +499,7 @@ private:
     void dshot_send_groups(uint32_t time_out_us);
     void dshot_send(pwm_group &group, uint32_t time_out_us);
     static void dshot_update_tick(void* p);
+    static void dshot_send_next_group(void* p);
     // release locks on the groups that are pending in reverse order
     void dshot_collect_dma_locks(uint32_t last_run_us);
     static void dma_up_irq_callback(void *p, uint32_t flags);

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -151,6 +151,11 @@ public:
 #endif
 
     /*
+      Set the dshot rate as a multiple of the loop rate
+     */
+    void set_dshot_rate(uint8_t dshot_rate, uint16_t loop_rate_hz) override;
+
+    /*
       get safety switch state, used by Util.cpp
     */
     AP_HAL::Util::safety_state _safety_switch_state(void);
@@ -414,6 +419,15 @@ private:
 #endif
     } _bdshot;
 
+    // dshot period
+    uint32_t _dshot_period_us;
+    // dshot rate as a multiple of loop rate or 0 for 1Khz
+    uint8_t _dshot_rate;
+    // dshot periods since the last push()
+    uint8_t _dshot_cycle;
+    // virtual timer for post-push() pulses
+    virtual_timer_t _dshot_rate_timer;
+
     uint16_t safe_pwm[max_channels]; // pwm to use when safety is on
     bool corked;
     // mask of channels that are running in high speed
@@ -482,8 +496,9 @@ private:
     uint16_t create_dshot_packet(const uint16_t value, bool telem_request, bool bidir_telem);
     void fill_DMA_buffer_dshot(uint32_t *buffer, uint8_t stride, uint16_t packet, uint16_t clockmul);
 
-    void dshot_send_groups();
-    void dshot_send(pwm_group &group);
+    void dshot_send_groups(uint32_t time_out_us);
+    void dshot_send(pwm_group &group, uint32_t time_out_us);
+    static void dshot_update_tick(void* p);
     // release locks on the groups that are pending in reverse order
     void dshot_collect_dma_locks(uint32_t last_run_us);
     static void dma_up_irq_callback(void *p, uint32_t flags);

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -63,6 +63,11 @@ void RCOutput::set_bidir_dshot_mask(uint16_t mask)
 
 bool RCOutput::bdshot_setup_group_ic_DMA(pwm_group &group)
 {
+    // check if already allocated
+    if (group.has_ic_dma()) {
+        return true;
+    }
+
     bool set_curr_chan = false;
 
     for (uint8_t i = 0; i < 4; i++) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -191,6 +191,8 @@ void RCOutput::bdshot_ic_dma_deallocate(Shared_DMA *ctx)
 
 // see https://github.com/betaflight/betaflight/pull/8554#issuecomment-512507625
 // called from the interrupt
+#pragma GCC push_options
+#pragma GCC optimize("O2")
 void RCOutput::bdshot_receive_pulses_DMAR(pwm_group* group)
 {
     // make sure the transaction finishes or times out, this function takes a little time to run so the most
@@ -584,6 +586,7 @@ uint32_t RCOutput::bdshot_decode_telemetry_packet(uint32_t* buffer, uint32_t cou
     uint32_t ret = (1000000 * 60 / 100 + decodedValue / 2) / decodedValue;
     return ret;
 }
+#pragma GCC pop_options
 
 
 #endif // HAL_WITH_BIDIR_DSHOT

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -130,6 +130,7 @@ void AP_Vehicle::setup()
     init_ardupilot();
     gcs().send_text(MAV_SEVERITY_INFO, "ArduPilot Ready");
 
+    SRV_Channels::init();
     // gyro FFT needs to be initialized really late
 #if HAL_GYROFFT_ENABLED
     gyro_fft.init(AP::scheduler().get_loop_period_us());

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -516,6 +516,9 @@ public:
 
     static void zero_rc_outputs();
 
+    // initialize before any call to push
+    static void init();
+
 private:
 
     static bool disabled_passthrough;
@@ -573,6 +576,7 @@ private:
 
     AP_Int8 auto_trim;
     AP_Int16 default_rate;
+    AP_Int8 dshot_rate;
 
     // return true if passthrough is disabled
     static bool passthrough_disabled(void) {

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -195,6 +195,13 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
 #endif // HAL_BUILD_AP_PERIPH
 
+    // @Param: _DSHOT_RATE
+    // @DisplayName: Servo DShot output rate
+    // @Description: This sets the DShot output rate for all outputs as a multiple of the loop rate. 0 sets the output rate to be fixed at 1Khz for low loop rates. This value should never be set below 500Hz.
+    // @Values: 0:1Khz,1:loop-rate,2:double loop-rate,3:triple loop-rate,4:quadruple loop rate
+    // @User: Advanced
+    AP_GROUPINFO("_DSHOT_RATE",  23, SRV_Channels, dshot_rate, 0),
+
     AP_GROUPEND
 };
 
@@ -222,6 +229,13 @@ SRV_Channels::SRV_Channels(void)
     blheli_ptr = &blheli;
 #endif
 #endif // HAL_BUILD_AP_PERIPH
+
+}
+
+// SRV_Channels initialization
+void SRV_Channels::init(void)
+{
+    hal.rcout->set_dshot_rate(_singleton->dshot_rate, AP::scheduler().get_loop_rate_hz());
 }
 
 /*


### PR DESCRIPTION
This fixes a problem observed in dshot where our irregular output (some triggered by push() and others by a 1Khz timeout) and bitrate timing variation leads to erratic ESC behavior, including motors not turning and telemetry not being returned. Betaflight outputs very regular DShot pulses and this appears to be what many ESCs expect.

See https://github.com/ArduPilot/ardupilot/issues/16786 for details

This gives me the following @1Khz:

|Type|DS150|DS300|DS600|DS1200|BDS150|BDS300|BDS600|BDS1200|
|---|---|---|---|---|---|---|---|---|
|BLHeli_S 16.7| 🟢 | 🟢 | 🟢 | 🔴   | N/A | N/A | N/A | N/A |
|BLHeli_S 16.73 (JM)| 🔴   | 🟢 | 🟢 | 🔴   | 🔴 | 🟢 | 🟢 | 🔴 |
|BLHeli32 32.7/8| 🟢  | 🟢 | 🟢 | 🟢 | 🟢 | 🟢  | 🟢 | 🟢 |

It seems bi-directional dshot is incredibly sensitive to variations in the bitrate and  BLHeli_S is incredibly sensitive to timing variations so I was not able to get BLHeli_S to work for very slow or fast rates - but Betaflight is the same. Its the same on master with regular dshot.

This also appears to make BLHeli passthrough more reliable

Here is a trace with BDshot300 and this change @1Khz:

![image](https://user-images.githubusercontent.com/2893260/110158054-d2571200-7de0-11eb-9973-488f724f5378.png)

and at rate 3 (800Hzx3 = 2.4Khz):

![image](https://user-images.githubusercontent.com/2893260/110158408-41cd0180-7de1-11eb-8166-f02598ef6bc3.png)

This also fixes RPM telemetry for the BeastH7 on TIM1 by using MID1 GPIO speed which avoid glitching when changing from output to input

On some boards BDS300 will only work at higher output rates


