### PR TITLE
AP_GPS: Remove unused enum

### DIFF
--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -145,10 +145,6 @@ public:
         GPS_ENGINE_AIRBORNE_4G = 8
     };
 
-    enum GPS_Config {
-       GPS_ALL_CONFIGURED = 255
-    };
-
     // role for auto-config
     enum GPS_Role {
         GPS_ROLE_NORMAL,


### PR DESCRIPTION
This enum is unused as far as I can tell, it's a bit of a drive by, but if it's unused let's remove it.