### PR TITLE
AR_AttitudeControl: reset speed filter and I term when stopped

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -634,6 +634,11 @@ float AR_AttitudeControl::get_throttle_out_stop(bool motor_limit_low, bool motor
         _stop_last_ms = now;
         // set last time speed controller was run so accelerations are limited
         _speed_last_ms = now;
+        // reset filters and I-term
+        _throttle_speed_pid.reset_filter();
+        _throttle_speed_pid.reset_I();
+        // ensure desired speed is zero
+        _desired_speed = 0.0f;
         return 0.0f;
     }
 


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/16759 which involved the throttle spiking after a vehicle was switched into Acro mode (or any other mode using speed control) because the speed controller's I-term wasn't being cleared properly.

This has been tested in SITL and below are before and after pictures of the results.
![throttle-jump-before-vs-after](https://user-images.githubusercontent.com/1498098/109748390-25339c80-7c1c-11eb-96a6-e233adb7ba43.png)


