### PR TITLE
Rover: rename sent_notification to send_notification and fix double notification in Guided

### DIFF
--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -430,7 +430,7 @@ protected:
     bool have_attitude_target;  // true if we have a valid attitude target
     uint32_t _des_att_time_ms;  // system time last call to set_desired_attitude was made (used for timeout)
     float _desired_yaw_rate_cds;// target turn rate centi-degrees per second
-    bool sent_notification;     // used to send one time notification to ground station
+    bool send_notification;     // used to send one time notification to ground station
     float _desired_speed;       // desired speed used only in HeadingAndSpeed submode
 
     // direct steering and throttle control
@@ -553,7 +553,7 @@ protected:
 
     bool _enter() override;
 
-    bool sent_notification; // used to send one time notification to ground station
+    bool send_notification; // used to send one time notification to ground station
     bool _loitering;        // true if loitering at end of RTL
 
 };

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -12,7 +12,7 @@ bool ModeGuided::_enter()
     // initialise waypoint speed
     g2.wp_nav.set_desired_speed_to_default();
 
-    sent_notification = false;
+    send_notification = false;
 
     return true;
 }
@@ -28,8 +28,8 @@ void ModeGuided::update()
                 navigate_to_waypoint();
             } else {
                 // send notification
-                if (!sent_notification) {
-                    sent_notification = true;
+                if (send_notification) {
+                    send_notification = false;
                     rover.gcs().send_mission_item_reached_message(0);
                 }
 
@@ -228,7 +228,7 @@ bool ModeGuided::set_desired_location(const struct Location& destination,
 
         // handle guided specific initialisation and logging
         _guided_mode = ModeGuided::Guided_WP;
-        sent_notification = false;
+        send_notification = true;
         rover.Log_Write_GuidedTarget(_guided_mode, Vector3f(destination.lat, destination.lng, 0), Vector3f(g2.wp_nav.get_desired_speed(), 0.0f, 0.0f));
         return true;
     }

--- a/Rover/mode_rtl.cpp
+++ b/Rover/mode_rtl.cpp
@@ -27,7 +27,7 @@ bool ModeRTL::_enter()
         g2.wp_nav.set_desired_speed_to_default();
     }
 
-    sent_notification = false;
+    send_notification = true;
     _loitering = false;
     return true;
 }
@@ -40,8 +40,8 @@ void ModeRTL::update()
         navigate_to_waypoint();
     } else {
         // send notification
-        if (!sent_notification) {
-            sent_notification = true;
+        if (send_notification) {
+            send_notification = false;
             gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
         }
 


### PR DESCRIPTION
The title says it all but in any case this PR does two things:

- Rename RTL and Guided mode's "sent_notification" member to "send_notification".  This logically flips the variables so wherever it was true it should now be false
- Guided mode's _enter() method (called once when the vehicle first enters Guided mode) initialises this variable to "false" (i.e. do not send notification) which stops the unnecessary, "Reached Destination" message going out as the vehicle drifts to a stop.  The flag will be set to true by **set_desired_location()** when a new target is received

This has been tested in SITL.  Thanks to @jmachuca77 for finding this issue.

![reached-dest-message-before-after](https://user-images.githubusercontent.com/1498098/109755753-eb699280-7c29-11eb-9c10-3484c0de959e.png)
