### PR TITLE
AP_Compass: Send message to gcs for compass learn

### DIFF
--- a/libraries/AP_Compass/Compass_learn.h
+++ b/libraries/AP_Compass/Compass_learn.h
@@ -52,6 +52,9 @@ private:
     float worst_error;
     bool converged;
 
+    // notification
+    uint32_t last_learn_progress_sent_ms;
+
     void io_timer(void);
     void process_sample(const struct sample &s);
 };


### PR DESCRIPTION
When I used Compass Learn on my boat, I had a problem that it took a long time to finish. After trying several times, I found that it took less than a minute in rivers, but it tended to take longer in the pool. Is it the influence of the metal material of the pool?
I think it is related to this issue(https://github.com/ArduPilot/ardupilot/pull/13710). I wanted to be able to see the internal state.　I thought it would be easier for the user to deal with it if the status was known.