### PR TITLE
Plane: fix GUIDED mode speed to adhere to live TRIM_AIRSPEED_CM changes

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -521,7 +521,7 @@ private:
 
 #if OFFBOARD_GUIDED == ENABLED
         // airspeed adjustments
-        float target_airspeed_cm = -1;  // don't default to zero here, as zero is a valid speed.
+        float target_airspeed_cm = -1.0f;  // don't default to zero here, as zero is a valid speed.
         float target_airspeed_accel;
         uint32_t target_airspeed_time_ms;
 

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -166,7 +166,7 @@ void Plane::calc_airspeed_errors()
                                   get_throttle_input()) + ((int32_t)aparm.airspeed_min * 100);
         }
 #if OFFBOARD_GUIDED == ENABLED
-    } else if (control_mode == &mode_guided && !is_zero(guided_state.target_airspeed_cm)) {
+    } else if (control_mode == &mode_guided && guided_state.target_airspeed_cm >=  0.0) {
         // offboard airspeed demanded
         uint32_t now = AP_HAL::millis();
         float delta = 1e-3f * (now - guided_state.target_airspeed_time_ms);


### PR DESCRIPTION
MdB, before I redo the DO_CHANGE_SPEED PR for variable name and add its ability to change guided mode, I thought I should fix the current master behavior which is not what you described as being able to change guided speed with trim_airspeed param...the offboard guided mode stuff hosed that up..guided mode speed is set to whatever the entry current target from the last mode was..unless an offboard mav cmd speed change is used...this fixes it to work again like you described that it did....