### PR TITLE
Copter: mission.update called from Auto's run()

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -794,8 +794,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 
 #if MODE_AUTO_ENABLED == ENABLED
     case MAV_CMD_MISSION_START:
-        if (copter.motors->armed() &&
-            copter.set_mode(Mode::Number::AUTO, ModeReason::GCS_COMMAND)) {
+        if (copter.set_mode(Mode::Number::AUTO, ModeReason::GCS_COMMAND)) {
             copter.set_auto_armed(true);
             if (copter.mode_auto.mission.state() != AP_Mission::MISSION_RUNNING) {
                 copter.mode_auto.mission.start_or_resume();

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -406,12 +406,6 @@ void Copter::notify_flight_mode() {
     notify.set_flight_mode_str(flightmode->name4());
 }
 
-void Mode::update_navigation()
-{
-    // run autopilot to make high level decisions about control modes
-    run_autopilot();
-}
-
 // get_pilot_desired_angle - transform pilot's roll or pitch input into a desired lean angle
 // returns desired angle in centi-degrees
 void Mode::get_pilot_desired_lean_angles(float &roll_out, float &pitch_out, float angle_max, float angle_limit) const

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -77,8 +77,6 @@ public:
     virtual uint32_t wp_distance() const { return 0; }
     virtual float crosstrack_error() const { return 0.0f;}
 
-    void update_navigation();
-
     int32_t get_alt_above_ground_cm(void);
 
     // pilot input processing
@@ -97,9 +95,6 @@ public:
     }
 
 protected:
-
-    // navigation support functions
-    virtual void run_autopilot() {}
 
     // helper functions
     bool is_disarmed_or_landed() const;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -394,7 +394,6 @@ protected:
     int32_t wp_bearing() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
     bool get_wp(Location &loc) override;
-    void run_autopilot() override;
 
 private:
 
@@ -517,7 +516,7 @@ private:
         float descend_max; // centimetres
     } nav_payload_place;
 
-    bool waiting_for_origin;    // true if waiting for origin before starting mission
+    bool waiting_to_start;  // true if waiting for vehicle to be armed or EKF origin before starting mission
 };
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/navigation.cpp
+++ b/ArduCopter/navigation.cpp
@@ -6,8 +6,6 @@
 void Copter::run_nav_updates(void)
 {
     update_super_simple_bearing(false);
-
-    flightmode->update_navigation();
 }
 
 // distance between vehicle and home in cm


### PR DESCRIPTION
This PR makes the following changes:

- Mission verify commands are run at the full update rate instead of 50hz.  This has a small CPU cost but also means slightly less delay between a mission command completing and the next one starting.
- Auto missions can be restarted while the vehicle is disarmed (maybe resolves issue: https://github.com/ArduPilot/ardupilot/issues/16805)
- Autotest added to ensure this behaviour remains unbroken (replaces PR https://github.com/ArduPilot/ardupilot/pull/16807)

This has been lightly tested in SITL