### PR TITLE
Fix potential nullptr use in upgrade path for Plane using AC_Fence

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1496,7 +1496,13 @@ void Plane::load_parameters(void)
             enum ap_var_type ptype_fence_enable;
             AP_Int8 *fence_enable = (AP_Int8*)AP_Param::find("FENCE_ENABLE", &ptype_fence_enable);
             // fences were used if there was a count, and the old fence action was not zero
-            bool fences_exist = AP::fence()->polyfence().total_fence_count() > 0;
+            AC_Fence *ap_fence = AP::fence();
+            bool fences_exist = false;
+            if (ap_fence) {
+                // If the fence library is present, attempt to read the fence count
+                fences_exist = ap_fence->polyfence().total_fence_count() > 0;
+            }
+            
             bool fences_used = fence_action_old.get() != 0;
             if (fence_enable && !fence_enable->configured()) {
                 // The fence enable parameter exists, so now set it accordingly

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5253,7 +5253,6 @@ uint64_t GCS_MAVLINK::capabilities() const
     }
 
     if (AP::fence()) {
-        // FIXME: plane also supports this...
         ret |= MAV_PROTOCOL_CAPABILITY_MISSION_FENCE;
     }
 


### PR DESCRIPTION
Fixes the only instance where I forgot to check for nullptr usage. This could potentially occur when `#define AC_FENCE DISABLED` is specified in config.