### PR TITLE
.github: fix example error on CI

### DIFF
--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -58,6 +58,9 @@ jobs:
             export CC=clang-7
             export CXX=clang++-7
           fi
+          if [[${{matrix.config}} = "examples" ]]; then
+            python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+          fi
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh
 


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959
we should Turn off O_NONBLOCK to prevent the
BlockingIOError: [Errno 11] write could not complete without blocking