### PR TITLE
AP_Frsky_Telem: added new "capabilities" param to frame 0x5007

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -404,10 +404,19 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_param(void)
         break;
     case BATT_CAPACITY_1:
         param_value = (uint32_t)roundf(AP::battery().pack_capacity_mah(0)); // battery pack capacity in mAh
-        _paramID = AP::battery().num_instances() > 1 ? BATT_CAPACITY_2 : FRAME_TYPE;
+        _paramID = AP::battery().num_instances() > 1 ? BATT_CAPACITY_2 : TELEMETRY_FEATURES;
         break;
     case BATT_CAPACITY_2:
         param_value = (uint32_t)roundf(AP::battery().pack_capacity_mah(1)); // battery pack capacity in mAh
+        _paramID = TELEMETRY_FEATURES;
+        break;
+    case TELEMETRY_FEATURES:
+#if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
+        BIT_SET(param_value,PassthroughFeatures::BIDIR);
+#endif
+#ifdef ENABLE_SCRIPTING
+        BIT_SET(param_value,PassthroughFeatures::SCRIPTING);
+#endif
         _paramID = FRAME_TYPE;
         break;
     }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
@@ -84,11 +84,12 @@ private:
     AP_Frsky_Parameters *&_frsky_parameters;
 
     enum PassthroughParam : uint8_t {
+        NONE =                0,
         FRAME_TYPE =          1,
         BATT_FS_VOLTAGE =     2,
         BATT_FS_CAPACITY =    3,
         BATT_CAPACITY_1 =     4,
-        BATT_CAPACITY_2 =     5
+        BATT_CAPACITY_2 =     5,
     };
 
     // methods to convert flight controller data to FrSky SPort Passthrough (OpenTX) format

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
@@ -90,6 +90,12 @@ private:
         BATT_FS_CAPACITY =    3,
         BATT_CAPACITY_1 =     4,
         BATT_CAPACITY_2 =     5,
+        TELEMETRY_FEATURES =  6
+    };
+
+    enum PassthroughFeatures : uint8_t {
+        BIDIR =                 0,
+        SCRIPTING =             1,
     };
 
     // methods to convert flight controller data to FrSky SPort Passthrough (OpenTX) format


### PR DESCRIPTION
This adds an extra param to frame 0x5007 to allow frsky consumers to get the "capabilities" of the frsky library being used such as bidir support and scripting support. It's a bitmask.