### PR TITLE
AC_Fence: Changed the judgment of the maximum/minimum altitude value

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -264,12 +264,12 @@ bool AC_Fence::pre_arm_check_circle(const char* &fail_msg) const
 // additional checks for the alt fence:
 bool AC_Fence::pre_arm_check_alt(const char* &fail_msg) const
 {
-    if (_alt_max < 0.0f) {
+    if (!is_positive(_alt_max)) {
         fail_msg = "Invalid FENCE_ALT_MAX value";
         return false;
     }
 
-    if (_alt_min < -100.0f) {
+    if (is_zero(_alt_min)) {
         fail_msg = "Invalid FENCE_ALT_MIN value";
         return false;
     }


### PR DESCRIPTION
There is a place in Japan with an altitude of -170 meters above sea level.
The location is the Hachinohe Mine.
This location is registered in the locations.txt file.
I think the minimum altitude limit of -100 meters is NG.
I think the illegal value is 0 meters.
Also change the decision of the maximum altitude.
I think 0 meter is also an illegal value.