### PR TITLE
Tools: disable QuadPlane.GyroFFT autotest

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -588,6 +588,7 @@ class AutoTestQuadPlane(AutoTest):
             "QAutoTune": "See https://github.com/ArduPilot/ardupilot/issues/10411",
             "FRSkyPassThrough": "Currently failing",
             "CPUFailsafe": "servo channel values not scaled like ArduPlane",
+            "GyroFFT": "flapping test",
         }
 
     def test_pilot_yaw(self):


### PR DESCRIPTION
This test is very regularly failing to the point that it is likely doing more harm than good