### PR TITLE
Add average cell voltage OSD item

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -180,6 +180,14 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Path: AP_OSD_ParamScreen.cpp
     AP_SUBGROUPINFO(param_screen[1], "6_", 22, AP_OSD, AP_OSD_ParamScreen),
 #endif
+
+    // @Param: _W_AVGVOLT
+    // @DisplayName: AVGVOLT warn level
+    // @Description: Set level at which AVGVOLT item will flash
+    // @Range: 0 100
+    // @User: Standard
+    AP_GROUPINFO("_W_AVGVOLT", 24, AP_OSD, warn_avgvolt, 3.6f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -135,6 +135,7 @@ private:
 
     AP_OSD_Setting altitude{true, 23, 8};
     AP_OSD_Setting bat_volt{true, 24, 1};
+    AP_OSD_Setting avgvolt{true, 1, 1};
     AP_OSD_Setting rssi{true, 1, 1};
     AP_OSD_Setting current{true, 25, 2};
     AP_OSD_Setting batused{true, 23, 3};
@@ -196,6 +197,7 @@ private:
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);
+    void draw_avgvolt(uint8_t x, uint8_t y);
     void draw_rssi(uint8_t x, uint8_t y);
     void draw_current(uint8_t x, uint8_t y);
     void draw_current(uint8_t instance, uint8_t x, uint8_t y);
@@ -448,6 +450,7 @@ public:
 
     AP_Int8 warn_rssi;
     AP_Int8 warn_nsat;
+    AP_Float warn_avgvolt;
     AP_Float warn_batvolt;
     AP_Float warn_bat2volt;
     AP_Int8 msgtime_s;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1158,7 +1158,7 @@ void AP_OSD_Screen::draw_avgvolt(uint8_t x, uint8_t y)
     float v = battery.voltage();
     uint8_t num_cells = (uint8_t)((v/4.3f) + 1);
     float voltage = v/num_cells;
-    backend->write(x,y, voltage < osd->warn_avgvolt, "%c%2.1f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
+    backend->write(x,y, voltage < osd->warn_avgvolt, "%c%1.2f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
 }
 
 void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -911,6 +911,22 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(vtx_power, "VTX_PWR", 55, AP_OSD_Screen, AP_OSD_Setting),
 
+    // @Param: AVGVOLT_EN
+    // @DisplayName: AVGVOLT_EN
+    // @Description: Displays average cell voltage
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: AVGVOLT_X
+    // @DisplayName: AVGVOLT_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: AVGVOLT_Y
+    // @DisplayName: AVGVOLT_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(avgvolt, "AVGVOLT", 57, AP_OSD_Screen, AP_OSD_Setting),
+
     AP_GROUPEND
 };
 
@@ -1132,6 +1148,17 @@ void AP_OSD_Screen::draw_altitude(uint8_t x, uint8_t y)
     ahrs.get_relative_position_D_home(alt);
     alt = -alt;
     backend->write(x, y, false, "%4d%c", (int)u_scale(ALTITUDE, alt), u_icon(ALTITUDE));
+}
+
+void AP_OSD_Screen::draw_avgvolt(uint8_t x, uint8_t y)
+{
+    AP_BattMonitor &battery = AP::battery();
+    uint8_t pct = battery.capacity_remaining_pct();
+    uint8_t p = (100 - pct) / 16.6;
+    float v = battery.voltage();
+    uint8_t num_cells = (uint8_t)((v/4.3f) + 1);
+    float voltage = v/num_cells;
+    backend->write(x,y, voltage < osd->warn_avgvolt, "%c%2.1f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
 }
 
 void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)
@@ -1871,6 +1898,7 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(waypoint);
     DRAW_SETTING(xtrack_error);
     DRAW_SETTING(bat_volt);
+    DRAW_SETTING(avgvolt);
     DRAW_SETTING(bat2_vlt);
     DRAW_SETTING(rssi);
     DRAW_SETTING(current);


### PR DESCRIPTION
This PR adds two OSD items, `OSD_AVGVOLT` and `OSD_W_AVGVOLT`, which display the average cell voltage based on the number of cells detected from the voltage.