### PR TITLE
.github: Disable examples tests

### DIFF
--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
         config: [
             unit-tests,
             python-cleanliness,
-            examples,
+            # examples,
         ]
     steps:
       # git checkout the PR


### PR DESCRIPTION
Those are failing on CI with 
````
  File "Tools/autotest/autotest.py", line 672, in run_tests
    success = run_step(step)
  File "Tools/autotest/autotest.py", line 511, in run_step
    return examples.run_examples(debug=opts.debug, valgrind=False, gdb=False)
  File "/__w/ardupilot/ardupilot/Tools/autotest/examples.py", line 76, in run_examples
    run_example(filepath, valgrind=valgrind, gdb=gdb)
  File "/__w/ardupilot/ardupilot/Tools/autotest/examples.py", line 28, in run_example
    print("retcode: %s" % str(retcode))
BlockingIOError: [Errno 11] write could not complete without blocking
FAILED 1 tests: ['run.examples']
Error: Process completed with exit code 1.
````
That is related to the CI environment...
Trying to disable O_NONBLOCK doesn't work, see : https://github.com/ArduPilot/ardupilot/pull/16817