### PR TITLE
Holybro Durandal Analog RSSI fix (+ tiny imperfection fix for VSERVO rail and IOMCU 12-bit ADC scaling)

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -41,7 +41,7 @@ extern AP_IOMCU iomcu;
 #define ANLOGIN_DEBUGGING 0
 
 // base voltage scaling for 12 bit 3.3V ADC
-#define VOLTAGE_SCALING (3.3f/(1<<12))
+#define VOLTAGE_SCALING (3.3f/((1<<12) -1))
 
 #if ANLOGIN_DEBUGGING
  # define Debug(fmt, args ...)  do {printf("%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)

--- a/libraries/AP_IOMCU/iofirmware/analog.cpp
+++ b/libraries/AP_IOMCU/iofirmware/analog.cpp
@@ -79,10 +79,10 @@ uint16_t adc_sample_vservo(void)
 }
 
 /*
-  capture VRSSI in mV
+  capture VRSSI in mV  (RSSI is directly connected to ADC input w/o voltage divider)
  */
 uint16_t adc_sample_vrssi(void)
 {
     const uint32_t channel = ADC_SQR3_SQ1_N(ADC_CHANNEL_IN5);
-    return adc_sample_channel(channel) * 9900 / 4096;
+    return adc_sample_channel(channel) * 3300 / 4096;
 }

--- a/libraries/AP_IOMCU/iofirmware/analog.cpp
+++ b/libraries/AP_IOMCU/iofirmware/analog.cpp
@@ -75,7 +75,7 @@ static uint16_t adc_sample_channel(uint32_t channel)
 uint16_t adc_sample_vservo(void)
 {
     const uint32_t channel = ADC_SQR3_SQ1_N(ADC_CHANNEL_IN4);
-    return adc_sample_channel(channel) * 9900 / 4096;
+    return adc_sample_channel(channel) * 9744 / 4095; // ADC full scale is reached with 3.3*(33+16.9)/16.9 = 9744mV ((33K/16K9 voltage divider)
 }
 
 /*
@@ -84,5 +84,5 @@ uint16_t adc_sample_vservo(void)
 uint16_t adc_sample_vrssi(void)
 {
     const uint32_t channel = ADC_SQR3_SQ1_N(ADC_CHANNEL_IN5);
-    return adc_sample_channel(channel) * 3300 / 4096;
+    return adc_sample_channel(channel) * 3300 / 4095;
 }


### PR DESCRIPTION
This fixes the analog RSSI saturation bug on Holybro Durandal.

The second commit in this PR, additionally fixes a small imprecision of servo rail voltage scaling on Holybro Durandal (with voltage divider 9.744V is giving full scale output and not 9.900V) and also additionally fixing 12-bit ADC full scale division. Highest value for 12-bit ADC is 0x0FFF = 4095. To unitize the output (to get 1.000 for the max value), the denominator should be 4095 and not 4096.

The proposed changes are tested successfully on Holybro Durandal hardware. I will attach the schematics of IOMCU of Durandal that Holybro support sent me to show that the proposed changes are based on valid claims.

[HolybroDurandalIOMCUschematics.pdf](https://github.com/ArduPilot/ardupilot/files/6097032/HolybroDurandalIOMCUschematics.pdf)

(This PR recaps #16607 that I closed due to being stale for too long)

Fixes #16451