### PR TITLE
Sub 4.0.3 update

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -703,7 +703,6 @@ void Sub::load_parameters()
     AP_Param::set_default_by_name("MNT_JSTICK_SPD", 100);
     AP_Param::set_by_name("MNT_RC_IN_PAN", 7);
     AP_Param::set_by_name("MNT_RC_IN_TILT", 8);
-    AP_Param::set_default_by_name("RNGFND1_TYPE", RangeFinder::RangeFinder_TYPE_MAVLink);
 }
 
 void Sub::convert_old_parameters()

--- a/ArduSub/ReleaseNotes.txt
+++ b/ArduSub/ReleaseNotes.txt
@@ -1,6 +1,13 @@
 APM:Sub Release Notes:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sub 4.0.3 5-March-2021
+
+ - No longer report battery percentage
+ - Do not override RNGFND1_TYPE
+ - Relax position controller when entering Depth Hold mode
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sub 4.0.2 21-September-2020
 
  - Fix critical error on preflight calibration

--- a/ArduSub/control_althold.cpp
+++ b/ArduSub/control_althold.cpp
@@ -16,7 +16,7 @@ bool Sub::althold_init()
     // sets the maximum speed up and down returned by position controller
     pos_control.set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
     pos_control.set_max_accel_z(g.pilot_accel_z);
-
+    pos_control.relax_alt_hold_controllers();
     pos_control.set_target_to_stopping_point_z();
     holding_depth = true;
 

--- a/ArduSub/version.h
+++ b/ArduSub/version.h
@@ -6,12 +6,12 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduSub V4.0.2"
+#define THISFIRMWARE "ArduSub V4.0.3"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,0,2,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,0,3,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 0
-#define FW_PATCH 2
+#define FW_PATCH 3
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL


### PR DESCRIPTION
 - No longer report battery percentage (already in the branch, not part of this PR)
 - Do not override RNGFND1_TYPE
 - Relax position controller when entering Depth Hold mode