### PR TITLE
Make the number of modes configurable

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -515,6 +515,42 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     GSCALAR(flight_mode6,           "FLTMODE6",       FLIGHT_MODE_6),
 
+#if FLIGHT_MODE_COUNT >= 7
+    // @Param: FLTMODE7
+    // @DisplayName: FlightMode7
+    // @Description: Flight mode for switch position 7 (1750 to 2049)
+    // @Values: 0:Manual,1:CIRCLE,2:STABILIZE,3:TRAINING,4:ACRO,5:FBWA,6:FBWB,7:CRUISE,8:AUTOTUNE,10:Auto,11:RTL,12:Loiter,13:TAKEOFF,14:AVOID_ADSB,15:Guided,17:QSTABILIZE,18:QHOVER,19:QLOITER,20:QLAND,21:QRTL,22:QAUTOTUNE,23:QACRO,24:THERMAL
+    // @User: Standard
+    GSCALAR(flight_mode7,           "FLTMODE7",       FLIGHT_MODE_7),
+#endif
+
+#if FLIGHT_MODE_COUNT >= 8
+    // @Param: FLTMODE8
+    // @DisplayName: FlightMode8
+    // @Description: Flight mode for switch position 8 (1750 to 2049)
+    // @Values: 0:Manual,1:CIRCLE,2:STABILIZE,3:TRAINING,4:ACRO,5:FBWA,6:FBWB,7:CRUISE,8:AUTOTUNE,10:Auto,11:RTL,12:Loiter,13:TAKEOFF,14:AVOID_ADSB,15:Guided,17:QSTABILIZE,18:QHOVER,19:QLOITER,20:QLAND,21:QRTL,22:QAUTOTUNE,23:QACRO,24:THERMAL
+    // @User: Standard
+    GSCALAR(flight_mode8,           "FLTMODE8",       FLIGHT_MODE_8),
+#endif
+
+#if FLIGHT_MODE_COUNT >= 9
+    // @Param: FLTMODE9
+    // @DisplayName: FlightMode9
+    // @Description: Flight mode for switch position 9 (1750 to 2049)
+    // @Values: 0:Manual,1:CIRCLE,2:STABILIZE,3:TRAINING,4:ACRO,5:FBWA,6:FBWB,7:CRUISE,8:AUTOTUNE,10:Auto,11:RTL,12:Loiter,13:TAKEOFF,14:AVOID_ADSB,15:Guided,17:QSTABILIZE,18:QHOVER,19:QLOITER,20:QLAND,21:QRTL,22:QAUTOTUNE,23:QACRO,24:THERMAL
+    // @User: Standard
+    GSCALAR(flight_mode9,           "FLTMODE9",       FLIGHT_MODE_9),
+#endif
+
+#if FLIGHT_MODE_COUNT >= 10
+    // @Param: FLTMODE10
+    // @DisplayName: FlightMode10
+    // @Description: Flight mode for switch position 10 (1750 to 2049)
+    // @Values: 0:Manual,1:CIRCLE,2:STABILIZE,3:TRAINING,4:ACRO,5:FBWA,6:FBWB,7:CRUISE,8:AUTOTUNE,10:Auto,11:RTL,12:Loiter,13:TAKEOFF,14:AVOID_ADSB,15:Guided,17:QSTABILIZE,18:QHOVER,19:QLOITER,20:QLAND,21:QRTL,22:QAUTOTUNE,23:QACRO,24:THERMAL
+    // @User: Standard
+    GSCALAR(flight_mode10,           "FLTMODE10",       FLIGHT_MODE_10),
+#endif
+
     // @Param: INITIAL_MODE
     // @DisplayName: Initial flight mode
     // @Description: This selects the mode to start in on boot. This is useful for when you want to start in AUTO mode on boot without a receiver.

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -298,6 +298,18 @@ public:
         k_param_flight_mode4,
         k_param_flight_mode5,
         k_param_flight_mode6,
+#if FLIGHT_MODE_COUNT >= 7
+        k_param_flight_mode7,
+#endif
+#if FLIGHT_MODE_COUNT >= 8
+        k_param_flight_mode8,
+#endif
+#if FLIGHT_MODE_COUNT >= 9
+        k_param_flight_mode9,
+#endif
+#if FLIGHT_MODE_COUNT >= 10
+        k_param_flight_mode10,
+#endif
         k_param_initial_mode,
         k_param_land_slope_recalc_shallow_threshold,    // unused - moved to AP_Landing
         k_param_land_slope_recalc_steep_threshold_to_abort, // unused - moved to AP_Landing
@@ -428,6 +440,18 @@ public:
     AP_Int8 flight_mode4;
     AP_Int8 flight_mode5;
     AP_Int8 flight_mode6;
+#if FLIGHT_MODE_COUNT >= 7
+    AP_Int8 flight_mode7;
+#endif
+#if FLIGHT_MODE_COUNT >= 8
+    AP_Int8 flight_mode8;
+#endif
+#if FLIGHT_MODE_COUNT >= 9
+    AP_Int8 flight_mode9;
+#endif
+#if FLIGHT_MODE_COUNT >= 10
+    AP_Int8 flight_mode10;
+#endif
     AP_Int8 initial_mode;
 
     // Navigational maneuvering limits

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -78,6 +78,12 @@
  # error XXX
 #endif
 
+#ifndef FLIGHT_MODE_COUNT
+// Anything less than 6 will define 6 modes, and you can define up to
+// 10 modes here.
+#define FLIGHT_MODE_COUNT  6
+#endif
+
 #if !defined(FLIGHT_MODE_1)
  # define FLIGHT_MODE_1                  Mode::Number::RTL
 #endif
@@ -95,6 +101,18 @@
 #endif
 #if !defined(FLIGHT_MODE_6)
  # define FLIGHT_MODE_6                  Mode::Number::MANUAL
+#endif
+#if !defined(FLIGHT_MODE_7)
+ # define FLIGHT_MODE_7                  Mode::Number::MANUAL
+#endif
+#if !defined(FLIGHT_MODE_8)
+ # define FLIGHT_MODE_8                  Mode::Number::MANUAL
+#endif
+#if !defined(FLIGHT_MODE_9)
+ # define FLIGHT_MODE_9                  Mode::Number::MANUAL
+#endif
+#if !defined(FLIGHT_MODE_10)
+ # define FLIGHT_MODE_10                  Mode::Number::MANUAL
 #endif
 
 

--- a/ArduPlane/control_modes.cpp
+++ b/ArduPlane/control_modes.cpp
@@ -161,6 +161,8 @@ uint8_t Plane::readSwitch(void) const
 #else
     // All bets are off.
 
+    if (pulsewidth <= 900 || pulsewidth >= 2200) return 255;            // This is an error condition
+
     uint8_t range_per_mode = 1000 / FLIGHT_MODE_COUNT;
     for (uint8_t i=1; i<FLIGHT_MODE_COUNT; i++) {
         if (pulsewidth < 1000 + (i * range_per_mode)) {


### PR DESCRIPTION
This PR makes the number of modes configurable, being careful to leave the default at 6 and the ranges the same for backwards compatibility.