### PR TITLE
AP_Proximity: Add a temporary boundary class

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -46,6 +46,8 @@ void AP_Proximity_AirSimSITL::update(void)
     const float accuracy_sq = sq(PROXIMITY_ACCURACY);
     bool prev_pos_valid = false;
     Vector2f prev_pos;
+    // clear temp boundary since we have a new message
+    temp_boundary.reset();
 
     for (uint16_t i=0; i<points.length; i++) {
         Vector3f &point = points.data[i];
@@ -60,7 +62,9 @@ void AP_Proximity_AirSimSITL::update(void)
 
             // add distance to the 3D boundary
             const float yaw_angle_deg = wrap_360(degrees(atan2f(point.y, point.x)));
-            boundary.add_distance(yaw_angle_deg, safe_sqrt(distance_sq));
+            const AP_Proximity_Boundary_3D::Face face = boundary.get_face(yaw_angle_deg);
+            // store the min distance in each face in a temp boundary
+            temp_boundary.add_distance(face, yaw_angle_deg, safe_sqrt(distance_sq));
 
             // check distance from previous point to reduce amount of data sent to object database
             if (!prev_pos_valid || ((new_pos - prev_pos).length_squared() >= accuracy_sq)) {
@@ -72,9 +76,8 @@ void AP_Proximity_AirSimSITL::update(void)
             }
         }
     }
-
-    // update middle boundary
-    boundary.update_middle_boundary();
+    // copy temp boundary to real boundary
+    temp_boundary.update_3D_boundary(boundary);
 }
 
 // get maximum and minimum distances (in meters) of primary sensor

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
@@ -41,6 +41,7 @@ public:
 
 private:
     SITL::SITL *sitl = AP::sitl();
+    AP_Proximity_Temp_Boundary temp_boundary;
 
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -23,7 +23,7 @@
 extern const AP_HAL::HAL& hal;
 
 #define PROXIMITY_MAV_TIMEOUT_MS    500 // distance messages must arrive within this many milliseconds
-#define PROXIMITY_3D_MSG_TIMEOUT_MS  50  // boundary will be reset if OBSTACLE_DISTANCE_3D message does not arrive within this many milliseconds
+#define PROXIMITY_TIMESTAMP_MSG_TIMEOUT_MS  50  // boundary will be reset if mavlink message does not arrive within this many milliseconds
 
 // update the state of the sensor
 void AP_Proximity_MAV::update(void)
@@ -73,24 +73,39 @@ void AP_Proximity_MAV::handle_distance_sensor_msg(const mavlink_message_t &msg)
 
     // store distance to appropriate sector based on orientation field
     if (packet.orientation <= MAV_SENSOR_ROTATION_YAW_315) {
+        const uint32_t previous_sys_time = _last_update_ms;
+        _last_update_ms = AP_HAL::millis();
+
+        // time_diff will check if the new message arrived significantly later than the last message
+        const uint32_t time_diff = _last_update_ms - previous_sys_time;
+
+        const uint32_t previous_msg_timestamp = _last_msg_update_timestamp_ms;
+        _last_msg_update_timestamp_ms = packet.time_boot_ms;
+
+        // we will add on to the last fence if the time stamp is the same
+        // provided we got the new obstacle in less than PROXIMITY_TIMESTAMP_MSG_TIMEOUT_MS
+        if ((previous_msg_timestamp != _last_msg_update_timestamp_ms) || (time_diff > PROXIMITY_TIMESTAMP_MSG_TIMEOUT_MS)) {
+            // cleared fence back to defaults since we have a new timestamp
+            boundary.reset();
+            // push data from temp boundary to the main 3-D proximity boundary
+            temp_boundary.update_3D_boundary(boundary);
+            // clear temp boundary for new data
+            temp_boundary.reset();
+        }
+        // store in meters
+        const float distance = packet.current_distance * 0.01f;
         const uint8_t sector = packet.orientation;
         // get the face for this sector
         const float yaw_angle_deg = sector * 45;
         const AP_Proximity_Boundary_3D::Face face = boundary.get_face(yaw_angle_deg);
-        // store in meters
-        const float distance = packet.current_distance * 0.01f;
         _distance_min = packet.min_distance * 0.01f;
         _distance_max = packet.max_distance * 0.01f;
         const bool in_range = distance <= _distance_max && distance >= _distance_min;
         if (in_range && !check_obstacle_near_ground(yaw_angle_deg, distance)) {
-            boundary.set_face_attributes(face, yaw_angle_deg, distance);
+            temp_boundary.add_distance(face, yaw_angle_deg, distance);
             // update OA database
             database_push(yaw_angle_deg, distance);
-        } else {
-            // reset distance for this face
-            boundary.reset_face(face);
         }
-        _last_update_ms = AP_HAL::millis();
     }
 
     // store upward distance
@@ -204,23 +219,27 @@ void AP_Proximity_MAV::handle_obstacle_distance_3d_msg(const mavlink_message_t &
 
     const uint32_t previous_sys_time = _last_update_ms;
     _last_update_ms = AP_HAL::millis();
-   
+
     // time_diff will check if the new message arrived significantly later than the last message
     const uint32_t time_diff = _last_update_ms - previous_sys_time;
 
-    const uint32_t previous_msg_timestamp = _last_3d_msg_update_ms;
-    _last_3d_msg_update_ms = packet.time_boot_ms;
+    const uint32_t previous_msg_timestamp = _last_msg_update_timestamp_ms;
+    _last_msg_update_timestamp_ms = packet.time_boot_ms;
 
     if (packet.frame != MAV_FRAME_BODY_FRD) {
-        // we do not support this frame of reference yet 
+        // we do not support this frame of reference yet
         return;
     }
 
     // we will add on to the last fence if the time stamp is the same
-    // provided we got the new obstacle in less than PROXIMITY_3D_MSG_TIMEOUT_MS  
-    if ((previous_msg_timestamp != _last_3d_msg_update_ms) || (time_diff > PROXIMITY_3D_MSG_TIMEOUT_MS)) {
+    // provided we got the new obstacle in less than PROXIMITY_TIMESTAMP_MSG_TIMEOUT_MS
+    if ((previous_msg_timestamp != _last_msg_update_timestamp_ms) || (time_diff > PROXIMITY_TIMESTAMP_MSG_TIMEOUT_MS)) {
         // cleared fence back to defaults since we have a new timestamp
         boundary.reset();
+        // push data from temp boundary to the main 3-D proximity boundary
+        temp_boundary.update_3D_boundary(boundary);
+        // clear temp boundary for new data
+        temp_boundary.reset();
     }
 
     _distance_min = packet.min_distance;
@@ -250,13 +269,7 @@ void AP_Proximity_MAV::handle_obstacle_distance_3d_msg(const mavlink_message_t &
 
     // allot to correct layer and sector based on calculated pitch and yaw
     const AP_Proximity_Boundary_3D::Face face = boundary.get_face(pitch, yaw);
-    float face_distance;
-    if (boundary.get_distance(face, face_distance) && (face_distance < obstacle.length())) {
-        // we already have a shorter distance in this layer and sector
-        return;
-    }
-
-    boundary.set_face_attributes(face, yaw, pitch, obstacle.length());
+    temp_boundary.add_distance(face, pitch, yaw, obstacle.length());
 
     if (database_ready) {
         database_push(yaw, pitch, obstacle.length(),_last_update_ms, current_pos, body_to_ned);

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -33,9 +33,11 @@ private:
     // handle mavlink OBSTACLE_DISTANCE_3D messages
     void handle_obstacle_distance_3d_msg(const mavlink_message_t &msg);
 
+   AP_Proximity_Temp_Boundary temp_boundary;
+
     // horizontal distance support
     uint32_t _last_update_ms;   // system time of last mavlink message received
-    uint32_t _last_3d_msg_update_ms;   // last stored OBSTACLE_DISTANCE_3D message timestamp
+    uint32_t _last_msg_update_timestamp_ms;   // last stored mavlink message timestamp
     float _distance_max;        // max range of sensor in meters
     float _distance_min;        // min range of sensor in meters
 


### PR DESCRIPTION
There are a few drivers that have no clue how many obstacles are going to be inserted into the 3D boundary.
So for eg: the LightWare lidars already know when the start of the face is, and when the end is (as we know the angle of the servo), so we only send the smallest distance per face, to the boundary. 

On the contrary, drivers like the OBSTACLE_DISTANCE_3D/DISTANCE_SENSOR ... user can send in 100 distances and we don't know which face the user will send distances to when, for eg:
 first obstacle: {10,0,0} and then  second obstacle: {2,0,0} 
 both of which belong to the same face but we obviously only need the second obstacle since its closer. Storing both these obstacles one by one does two things:
1. Unnecessarily causes the boundary to shift which takes CPU usage
2.  (More imp) makes the newly added low pass filter VERY unhappy since its receiving garbage values

In such a case, we store the smallest distance in a Temporary Boundary (added by this PR) and after we receive all the messages  (decided by timestamp), we copy everything back to the original boundary. 
