### PR TITLE
FETtecOneWire support on top of AP_ESC_Telem backend

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -1,5 +1,5 @@
 #include "Copter.h"
-#include <AP_BLHeli/AP_BLHeli.h>
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
 
 /*****************************************************************************
 *   The init_ardupilot function processes everything we need for an in - air restart
@@ -276,12 +276,12 @@ void Copter::update_dynamic_notch()
             }
             break;
 #endif
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
         case HarmonicNotchDynamicMode::UpdateBLHeli: // BLHeli based tracking
             // set the harmonic notch filter frequency scaled on measured frequency
             if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
-                const uint8_t num_notches = AP_BLHeli::get_singleton()->get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
+                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
 
                 for (uint8_t i = 0; i < num_notches; i++) {
                     notches[i] =  MAX(ref_freq, notches[i]);
@@ -292,7 +292,7 @@ void Copter::update_dynamic_notch()
                     ins.update_harmonic_notch_freq_hz(throttle_freq);
                 }
             } else {
-                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP_BLHeli::get_singleton()->get_average_motor_frequency_hz() * ref));
+                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP::esc_telem().get_average_motor_frequency_hz() * ref));
             }
             break;
 #endif

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -468,12 +468,12 @@ void Plane::update_dynamic_notch()
                 ins.update_harmonic_notch_freq_hz(ref_freq);
             }
             break;
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
         case HarmonicNotchDynamicMode::UpdateBLHeli: // BLHeli based tracking
             // set the harmonic notch filter frequency scaled on measured frequency
             if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
-                const uint8_t num_notches = AP_BLHeli::get_singleton()->get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
+                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
 
                 for (uint8_t i = 0; i < num_notches; i++) {
                     notches[i] =  MAX(ref_freq, notches[i]);
@@ -486,7 +486,7 @@ void Plane::update_dynamic_notch()
                     ins.update_harmonic_notch_freq_hz(ref_freq);
                 }
             } else {
-                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP_BLHeli::get_singleton()->get_average_motor_frequency_hz() * ref));
+                ins.update_harmonic_notch_freq_hz(MAX(ref_freq, AP::esc_telem().get_average_motor_frequency_hz() * ref));
             }
             break;
 #endif

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -106,6 +106,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_WheelEncoder',
     'AP_ExternalAHRS',
     'AP_VideoTX',
+    'AP_FETtecOneWire',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4324,6 +4324,54 @@ class AutoTestCopter(AutoTest):
         if ex is not None:
             raise ex
 
+    def fly_esc_telemetry_notches(self):
+        """Use dynamic harmonic notch to control motor noise via ESC telemetry."""
+        self.progress("Flying with ESC telemetry driven dynamic notches")
+
+        self.set_rc_default()
+        self.set_parameter("AHRS_EKF_TYPE", 10)
+        self.set_parameter("INS_LOG_BAT_MASK", 3)
+        self.set_parameter("INS_LOG_BAT_OPT", 0)
+        # set the gyro filter high so we can observe behaviour
+        self.set_parameter("INS_GYRO_FILTER", 100)
+        self.set_parameter("LOG_BITMASK", 958)
+        self.set_parameter("LOG_DISARMED", 0)
+        self.set_parameter("SIM_VIB_MOT_MAX", 350)
+        self.set_parameter("SIM_GYR1_RND", 20)
+        self.set_parameter("SIM_ESC_TELEM", 1)
+        self.reboot_sitl()
+
+        self.takeoff(10, mode="ALT_HOLD")
+
+        # find a motor peak
+        freq, vfr_hud, peakdb = self.hover_and_check_matched_frequency_with_fft(-15, 200, 300)
+
+        # now add a dynamic notch and check that the peak is squashed
+        self.set_parameter("INS_LOG_BAT_OPT", 2)
+        self.set_parameter("INS_HNTCH_ENABLE", 1)
+        self.set_parameter("INS_HNTCH_FREQ", 80)
+        self.set_parameter("INS_HNTCH_REF", 1.0)
+        # first and third harmonic
+        self.set_parameter("INS_HNTCH_HMNCS", 5)
+        self.set_parameter("INS_HNTCH_ATT", 50)
+        self.set_parameter("INS_HNTCH_BW", 40)
+        self.set_parameter("INS_HNTCH_MODE", 3)
+        self.reboot_sitl()
+
+        freq, vfr_hud, peakdb1 = self.hover_and_check_matched_frequency_with_fft(-10, 20, 350, reverse=True)
+
+        # now add notch-per motor and check that the peak is squashed
+        self.set_parameter("INS_HNTCH_OPTS", 2)
+        self.reboot_sitl()
+
+        freq, vfr_hud, peakdb2 = self.hover_and_check_matched_frequency_with_fft(-15, 20, 350, reverse=True)
+
+        # notch-per-motor should do better, but check for within 5%
+        if peakdb2 * 1.05 > peakdb1:
+            raise NotAchievedException(
+                "Notch-per-motor peak was higher than single-notch peak %fdB > %fdB" %
+                (peakdb2, peakdb1))
+
     def hover_and_check_matched_frequency(self, dblevel=-15, minhz=200, maxhz=300, fftLength=32, peakhz=None):
         # find a motor peak
         self.takeoff(10, mode="ALT_HOLD")
@@ -6767,6 +6815,11 @@ class AutoTestCopter(AutoTest):
                  "Fly Dynamic Notches",
                  self.fly_dynamic_notches,
                  attempts=4),
+
+            Test("DynamicRpmNotches",
+                 "Fly Dynamic Notches driven by ESC Telemetry",
+                 self.fly_esc_telemetry_notches,
+                 attempts=1),
 
             Test("GyroFFT",
                  "Fly Gyro FFT",

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -31,6 +31,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -139,6 +140,8 @@ AP_BLHeli::AP_BLHeli(void)
     AP_Param::setup_object_defaults(this, var_info);
     _singleton = this;
     last_control_port = -1;
+    // register as an ESC telemetry source
+    AP::esc_telem().add_backend(this);
 }
 
 /*
@@ -1303,6 +1306,7 @@ void AP_BLHeli::update(void)
 #ifdef HAL_WITH_BIDIR_DSHOT
     // possibly enable bi-directional dshot
     hal.rcout->set_bidir_dshot_mask(channel_bidir_dshot_mask.get() & mask);
+    hal.rcout->set_motor_poles(motor_poles);
 #endif
     // add motors from channel mask
     for (uint8_t i=0; i<16 && num_motors < max_motors; i++) {
@@ -1337,57 +1341,6 @@ bool AP_BLHeli::get_telem_data(uint8_t esc_index, struct telem_data &td)
     }
     td = last_telem[esc_index];
     return true;
-}
-
-// return the average motor frequency in Hz for dynamic filtering
-float AP_BLHeli::get_average_motor_frequency_hz() const
-{
-    float motor_freq = 0.0f;
-    const uint32_t now = AP_HAL::millis();
-    uint8_t valid_escs = 0;
-    // average the rpm of each motor as reported by BLHeli and convert to Hz
-    for (uint8_t i = 0; i < num_motors; i++) {
-        if (has_bidir_dshot(i)) {
-            uint16_t erpm = hal.rcout->get_erpm(i);
-            if (erpm > 0 && erpm < 0xFFFF) {
-                valid_escs++;
-                motor_freq += (erpm * 200 / motor_poles) / 60.f;
-            }
-        } else if (last_telem[i].timestamp_ms && (now - last_telem[i].timestamp_ms < 1000)) {
-            valid_escs++;
-            // slew the update
-            const float slew = MIN(1.0f, (now - last_telem[i].timestamp_ms) * telem_rate / 1000.0f);
-            motor_freq += (prev_motor_rpm[i] + (last_telem[i].rpm - prev_motor_rpm[i]) * slew) / 60.0f;
-        }
-    }
-    if (valid_escs > 0) {
-        motor_freq /= valid_escs;
-    }
-
-    return motor_freq;
-}
-
-// return all the motor frequencies in Hz for dynamic filtering
-uint8_t AP_BLHeli::get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) const
-{
-    const uint32_t now = AP_HAL::millis();
-    uint8_t valid_escs = 0;
-
-    // average the rpm of each motor as reported by BLHeli and convert to Hz
-    for (uint8_t i = 0; i < num_motors && i < nfreqs; i++) {
-        if (has_bidir_dshot(i)) {
-            uint16_t erpm = hal.rcout->get_erpm(i);
-            if (erpm > 0 && erpm < 0xFFFF) {
-                freqs[valid_escs++] = (erpm * 200 / motor_poles) / 60.f;
-            }
-        } else if (last_telem[i].timestamp_ms && (now - last_telem[i].timestamp_ms < 1000)) {
-            // slew the update
-            const float slew = MIN(1.0f, (now - last_telem[i].timestamp_ms) * telem_rate / 1000.0f);
-            freqs[valid_escs++] = (prev_motor_rpm[i] + (last_telem[i].rpm - prev_motor_rpm[i]) * slew) / 60.0f;
-        }
-    }
-
-    return MIN(valid_escs, nfreqs);
 }
 
 /*
@@ -1435,48 +1388,34 @@ void AP_BLHeli::read_telemetry_packet(void)
     td.rpm = ((buf[7]<<8) | buf[8]) * 200 / motor_poles;
     td.timestamp_ms = AP_HAL::millis();
     // record the previous rpm so that we can slew to the new one
-    prev_motor_rpm[last_telem_esc] = last_telem[last_telem_esc].rpm;
+    update_rpm(last_telem_esc, td.rpm);
+
+    TelemetryData t {
+        .temperature_deg = td.temperature,
+        .voltage_cv = td.voltage,
+        .current_ca = td.current,
+        .consumption_mah = td.consumption,
+    };
+    t.error_rate = hal.rcout->get_erpm_error_rate(last_telem_esc);
+
+    update_telem_data(last_telem_esc, t,
+        AP_ESC_Telem_Backend::TelemetryType::CURRENT
+            | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE
+            | AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION
+            | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE
+            | AP_ESC_Telem_Backend::TelemetryType::ERROR_RATE);
 
     last_telem[last_telem_esc] = td;
     last_telem[last_telem_esc].count++;
     received_telem_data = true;
 
-    AP_Logger *logger = AP_Logger::get_singleton();
-
-    uint16_t trpm = td.rpm;
-    float terr = 0.0f;
-
-    if (logger && logger->logging_enabled()
-        // log at 10Hz
-        && td.timestamp_ms - last_log_ms[last_telem_esc] > 100) {
-
-        if (has_bidir_dshot(last_telem_esc)) {
-            const uint16_t erpm = hal.rcout->get_erpm(last_telem_esc);
-            if (erpm != 0xFFFF) {   // don't log invalid values
-                trpm = erpm * 200 / motor_poles;
-            }
-            terr = hal.rcout->get_erpm_error_rate(last_telem_esc);
-        }
-
-        logger->Write_ESC(uint8_t(last_telem_esc),
-                      AP_HAL::micros64(),
-                      trpm*100U,
-                      td.voltage,
-                      td.current,
-                      td.temperature * 100U,
-                      td.consumption,
-                      0,
-                      terr);
-        last_log_ms[last_telem_esc] = td.timestamp_ms;
-    }
-
     if (debug_level >= 2) {
+        uint16_t trpm = td.rpm;
         if (has_bidir_dshot(last_telem_esc)) {
             trpm = hal.rcout->get_erpm(last_telem_esc);
             if (trpm != 0xFFFF) {
                 trpm = trpm * 200 / motor_poles;
             }
-            terr = hal.rcout->get_erpm_error_rate(last_telem_esc);
         }
         hal.console->printf("ESC[%u] T=%u V=%u C=%u con=%u RPM=%u e=%.1f t=%u\n",
                             last_telem_esc,
@@ -1484,7 +1423,7 @@ void AP_BLHeli::read_telemetry_packet(void)
                             td.voltage,
                             td.current,
                             td.consumption,
-                            trpm, terr, (unsigned)AP_HAL::millis());
+                            trpm, hal.rcout->get_erpm_error_rate(last_telem_esc), (unsigned)AP_HAL::millis());
     }
 }
 
@@ -1493,31 +1432,18 @@ void AP_BLHeli::read_telemetry_packet(void)
  */
 void AP_BLHeli::log_bidir_telemetry(void)
 {
-    AP_Logger *logger = AP_Logger::get_singleton();
-
     uint32_t now = AP_HAL::millis();
 
-    if (logger && logger->logging_enabled()
-        // log at 10Hz
-        && now - last_log_ms[last_telem_esc] > 100) {
-
+    if (debug_level >= 2 && now - last_log_ms[last_telem_esc] > 100) {
         if (has_bidir_dshot(last_telem_esc)) {
             uint16_t trpm = hal.rcout->get_erpm(last_telem_esc);
             const float terr = hal.rcout->get_erpm_error_rate(last_telem_esc);
             if (trpm != 0xFFFF) {    // don't log invalid values as they are never used
                 trpm = trpm * 200 / motor_poles;
-
-                logger->Write_ESC(uint8_t(last_telem_esc),
-                        AP_HAL::micros64(),
-                        trpm*100U,
-                        0, 0, 0, 0,
-                        terr);
-                last_log_ms[last_telem_esc] = now;
             }
 
-            if (debug_level >= 2) {
-                hal.console->printf("ESC[%u] RPM=%u e=%.1f t=%u\n", last_telem_esc, trpm, terr, (unsigned)AP_HAL::millis());
-            }
+            last_log_ms[last_telem_esc] = now;
+            hal.console->printf("ESC[%u] RPM=%u e=%.1f t=%u\n", last_telem_esc, trpm, terr, (unsigned)AP_HAL::millis());
         }
     }
 
@@ -1585,51 +1511,6 @@ void AP_BLHeli::update_telemetry(void)
         uint16_t mask = 1U << motor_map[last_telem_esc];
         hal.rcout->set_telem_request_mask(mask);
         last_telem_request_us = now;
-    }
-}
-
-/*
-  send ESC telemetry messages over MAVLink
- */
-void AP_BLHeli::send_esc_telemetry_mavlink(uint8_t mav_chan)
-{
-    if (num_motors == 0) {
-        return;
-    }
-    uint8_t temperature[4] {};
-    uint16_t voltage[4] {};
-    uint16_t current[4] {};
-    uint16_t totalcurrent[4] {};
-    uint16_t rpm[4] {};
-    uint16_t count[4] {};
-    uint32_t now = AP_HAL::millis();
-    for (uint8_t i=0; i<num_motors; i++) {
-        uint8_t idx = i % 4;
-        if (last_telem[i].timestamp_ms && (now - last_telem[i].timestamp_ms < 1000)) {
-            temperature[idx]  = last_telem[i].temperature;
-            voltage[idx]      = last_telem[i].voltage;
-            current[idx]      = last_telem[i].current;
-            totalcurrent[idx] = last_telem[i].consumption;
-            rpm[idx]          = last_telem[i].rpm;
-            count[idx]        = last_telem[i].count;
-        } else {
-            temperature[idx] = 0;
-            voltage[idx] = 0;
-            current[idx] = 0;
-            totalcurrent[idx] = 0;
-            rpm[idx] = 0;
-            count[idx] = 0;
-        }
-        if (i % 4 == 3 || i == num_motors - 1) {
-            if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
-                return;
-            }
-            if (i < 4) {
-                mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
-            } else {
-                mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
-            }
-        }
     }
 }
 

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1331,21 +1331,6 @@ void AP_BLHeli::update(void)
 }
 
 /*
-  implement the 8 bit CRC used by the BLHeli ESC telemetry protocol
- */
-uint8_t AP_BLHeli::telem_crc8(uint8_t crc, uint8_t crc_seed) const
-{
-    uint8_t crc_u = crc;
-    crc_u ^= crc_seed;
-
-    for (uint8_t i=0; i<8; i++) {
-        crc_u = ( crc_u & 0x80 ) ? 0x7 ^ ( crc_u << 1 ) : ( crc_u << 1 );
-    }
-
-    return crc_u;
-}
-
-/*
   read an ESC telemetry packet
  */
 void AP_BLHeli::read_telemetry_packet(void)
@@ -1359,7 +1344,7 @@ void AP_BLHeli::read_telemetry_packet(void)
     // calculate crc
     uint8_t crc = 0;
     for (uint8_t i=0; i<telem_packet_size-1; i++) {    
-        crc = telem_crc8(buf[i], crc);
+        crc = crc8_telem(buf[i], crc);
     }
 
     if (buf[telem_packet_size-1] != crc) {

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -27,6 +27,11 @@
 #if HAL_SUPPORT_RCOUT_SERIAL
 
 #define HAVE_AP_BLHELI_SUPPORT
+#ifndef HAL_WITH_ESC_TELEM
+#define HAL_WITH_ESC_TELEM TRUE
+#endif
+
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 
 #include <AP_Param/AP_Param.h>
 #include <Filter/LowPassFilter.h>
@@ -35,7 +40,7 @@
 
 #define AP_BLHELI_MAX_ESCS 8
 
-class AP_BLHeli {
+class AP_BLHeli : public AP_ESC_Telem_Backend {
 
 public:
     AP_BLHeli();
@@ -56,19 +61,11 @@ public:
         uint32_t timestamp_ms;
     };
 
-    // number of ESCs configured as BLHeli in channel mask
-    uint8_t get_num_motors(void) { return num_motors;};
     // get the most recent telemetry data packet for a motor
     bool get_telem_data(uint8_t esc_index, struct telem_data &td);
-    // return the average motor frequency in Hz for dynamic filtering
-    float get_average_motor_frequency_hz() const;
-    // return all of the motor frequencies in Hz for dynamic filtering
-    uint8_t get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) const;
 
     // return true if we have received any telemetry data
-    bool have_telem_data(void) const {
-        return received_telem_data;
-    }
+    bool have_telem_data(void) const { return received_telem_data; }
 
     bool has_bidir_dshot(uint8_t esc_index) const {
         return channel_bidir_dshot_mask.get() & (1U << motor_map[esc_index]);
@@ -79,9 +76,6 @@ public:
     static AP_BLHeli *get_singleton(void) {
         return _singleton;
     }
-
-    // send ESC telemetry messages over MAVLink
-    void send_esc_telemetry_mavlink(uint8_t mav_chan);
     
 private:
     static AP_BLHeli *_singleton;
@@ -245,9 +239,6 @@ private:
 
     // last log output to avoid beat frequencies
     uint32_t last_log_ms[max_motors];
-
-    // previous motor rpm so that changes can be slewed
-    float prev_motor_rpm[max_motors];
 
     // have we initialised the interface?
     bool initialised;

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -51,22 +51,6 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    struct telem_data {
-        int8_t temperature;  // degrees C, negative values allowed
-        uint16_t voltage;    // volts * 100
-        uint16_t current;    // amps * 100
-        uint16_t consumption;// mAh
-        uint16_t rpm;        // eRPM
-        uint16_t count;
-        uint32_t timestamp_ms;
-    };
-
-    // get the most recent telemetry data packet for a motor
-    bool get_telem_data(uint8_t esc_index, struct telem_data &td);
-
-    // return true if we have received any telemetry data
-    bool have_telem_data(void) const { return received_telem_data; }
-
     bool has_bidir_dshot(uint8_t esc_index) const {
         return channel_bidir_dshot_mask.get() & (1U << motor_map[esc_index]);
     }
@@ -229,13 +213,10 @@ private:
     
     AP_HAL::UARTDriver *uart;
     AP_HAL::UARTDriver *debug_uart;
-    AP_HAL::UARTDriver *telem_uart;    
-    
+    AP_HAL::UARTDriver *telem_uart;
+
     static const uint8_t max_motors = AP_BLHELI_MAX_ESCS;
     uint8_t num_motors;
-
-    struct telem_data last_telem[max_motors];
-    uint32_t received_telem_data;
 
     // last log output to avoid beat frequencies
     uint32_t last_log_ms[max_motors];

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -279,7 +279,6 @@ private:
     bool BL_VerifyFlash(const uint8_t *buf, uint16_t n);
     void blheli_process_command(void);
     void run_connection_test(uint8_t chan);
-    uint8_t telem_crc8(uint8_t crc, uint8_t crc_seed) const;
     void read_telemetry_packet(void);
     void log_bidir_telemetry(void);
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -347,7 +347,7 @@ void AP_ESC_Telem::update()
                 get_rpm(i, rpm);
 
                 logger->Write_ESC(i, AP_HAL::micros64(),
-                                (int32_t) rpm * 100,
+                                (int32_t) rpm,
                                 _telem_data[i].voltage_cv,
                                 _telem_data[i].current_ca,
                                 _telem_data[i].temperature_deg * 100,

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -350,7 +350,7 @@ void AP_ESC_Telem::update()
                                 (int32_t) rpm * 100,
                                 _telem_data[i].voltage_cv,
                                 _telem_data[i].current_ca,
-                                _telem_data[i].temperature_deg,
+                                _telem_data[i].temperature_deg * 100,
                                 _telem_data[i].consumption_mah,
                                 _telem_data[i].motor_temp_deg,
                                 _telem_data[i].error_rate);

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -340,8 +340,8 @@ void AP_ESC_Telem::update()
     if (logger && logger->logging_enabled()) {
 
         for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
-            if ((_active_escs_mask & (1<<i)) &&  (_last_telem_data_ms[i] >  _last_telem_log_ms[i]
-                || _last_rpm_update_us[i] > _last_telem_log_ms[i] * 1000)) {
+            if ((_active_escs_mask & (1<<i)) &&  (_last_telem_data_ms[i] - _last_telem_log_ms[i] > 100
+                || _last_rpm_update_us[i] - (_last_telem_log_ms[i] * 1000) > 100000)) {
 
                 float rpm = 0.0f;
                 get_rpm(i, rpm);

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -15,6 +15,10 @@
 
 #include "AP_ESC_Telem.h"
 #include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
+
+#if HAL_WITH_ESC_TELEM
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
   #include <AP_CANManager/AP_CANManager.h>
@@ -35,23 +39,335 @@ AP_ESC_Telem::AP_ESC_Telem()
     _singleton = this;
 }
 
-// get an individual ESC's usage time in seconds if available, returns true on success
-bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_id, uint32_t& usage_sec) const
+// return the average motor frequency in Hz for dynamic filtering
+float AP_ESC_Telem::get_average_motor_frequency_hz() const
 {
+    float motor_freq = 0.0f;
+    uint8_t valid_escs = 0;
+
+    // average the rpm of each motor and convert to Hz
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        float rpm;
+        if (get_rpm(i, rpm)) {
+            motor_freq += rpm * (1.0f / 60.0f);
+            valid_escs++;
+        }
+    }
+    if (valid_escs > 0) {
+        motor_freq /= valid_escs;
+    }
+
+    return motor_freq;
+}
+
+// return all the motor frequencies in Hz for dynamic filtering
+uint8_t AP_ESC_Telem::get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) const
+{
+    uint8_t valid_escs = 0;
+
+    // average the rpm of each motor as reported by BLHeli and convert to Hz
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS && i < nfreqs; i++) {
+        float rpm;
+        if (get_rpm(i, rpm)) {
+            freqs[valid_escs++] = rpm * (1.0f / 60.0f);
+        }
+    }
+
+    return MIN(valid_escs, nfreqs);
+}
+
+// return number of active ESCs present
+uint8_t AP_ESC_Telem::get_num_active_escs() const {
+    uint8_t nmotors = 0;
+    uint16_t motor_mask = _active_escs_mask;
+    while (motor_mask) {
+        nmotors += motor_mask & 1;
+        motor_mask >>= 1;
+    }
+    return nmotors;
+}
+
+// get an individual ESC's slewed rpm if available, returns true on success
+bool AP_ESC_Telem::get_rpm(uint8_t esc_index, float& rpm) const
+{
+    if (esc_index > ESC_TELEM_MAX_ESCS
+        || !(_active_escs_mask & (1 << esc_index))
+        || is_zero(_update_rate_hz[esc_index])) {
+        return false;
+    }
+
+    const uint32_t now = AP_HAL::micros();
+    if (_last_rpm_update_us[esc_index] > 0 && (now - _last_rpm_update_us[esc_index] < 1000000)) {
+        const float slew = MIN(1.0f, (now - _last_rpm_update_us[esc_index]) * _update_rate_hz[esc_index] * (1.0f / 1e6f));
+        rpm = (_prev_rpm[esc_index] + (_curr_rpm[esc_index] - _prev_rpm[esc_index]) * slew);
+        return true;
+    }
+    return false;
+}
+
+// get an individual ESC's temperature in degrees if available, returns true on success
+bool AP_ESC_Telem::get_temperature(uint8_t esc_index, int16_t& temp) const
+{
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || AP_HAL::millis() - _last_telem_data_ms[esc_index] > ESC_TELEM_DATA_TIMEOUT_MS
+        || !(_telem_data_mask[esc_index] & AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE)) {
+        return false;
+    }
+    temp = _telem_data[esc_index].temperature_deg;
+    return true;
+}
+
+// get an individual motor's temperature in degrees if available, returns true on success
+bool AP_ESC_Telem::get_motor_temperature(uint8_t esc_index, int16_t& temp) const
+{
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || AP_HAL::millis() - _last_telem_data_ms[esc_index] > ESC_TELEM_DATA_TIMEOUT_MS
+        || !(_telem_data_mask[esc_index] & AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE)) {
+        return false;
+    }
+    temp = _telem_data[esc_index].motor_temp_deg;
+    return true;
+}
+
+// get an individual ESC's current if available, returns true on success
+bool AP_ESC_Telem::get_current_ca(uint8_t esc_index, uint16_t& amps_ca) const
+{
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || AP_HAL::millis() - _last_telem_data_ms[esc_index] > ESC_TELEM_DATA_TIMEOUT_MS
+        || !(_telem_data_mask[esc_index] & AP_ESC_Telem_Backend::TelemetryType::CURRENT)) {
+        return false;
+    }
+    amps_ca = _telem_data[esc_index].current_ca;
+    return true;
+}
+
+// get an individual ESC's current if available, returns true on success
+bool AP_ESC_Telem::get_voltage_cv(uint8_t esc_index, uint16_t& volts_cv) const
+{
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || AP_HAL::millis() - _last_telem_data_ms[esc_index] > ESC_TELEM_DATA_TIMEOUT_MS
+        || !(_telem_data_mask[esc_index] & AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)) {
+        return false;
+    }
+    volts_cv = _telem_data[esc_index].voltage_cv;
+    return true;
+}
+
+// get an individual ESC's current if available, returns true on success
+bool AP_ESC_Telem::get_consumption_mah(uint8_t esc_index, uint16_t& consumption_mah) const
+{
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || AP_HAL::millis() - _last_telem_data_ms[esc_index] > ESC_TELEM_DATA_TIMEOUT_MS
+        || !(_telem_data_mask[esc_index] & AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION)) {
+        return false;
+    }
+    consumption_mah = _telem_data[esc_index].consumption_mah;
+    return true;
+}
+
+// get an individual ESC's data if available, returns true on success
+bool AP_ESC_Telem::get_telem_data(uint8_t esc_index, AP_ESC_Telem_Backend::TelemetryData& data) const
+{
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || AP_HAL::millis() - _last_telem_data_ms[esc_index] > ESC_TELEM_DATA_TIMEOUT_MS) {
+        return false;
+    }
+    data = _telem_data[esc_index];
+    return true;
+}
+
+// get an individual ESC's current if available, returns true on success
+bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_index, uint32_t& usage_s) const
+{
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || AP_HAL::millis() - _last_telem_data_ms[esc_index] > ESC_TELEM_DATA_TIMEOUT_MS
+        || !(_telem_data_mask[esc_index] & AP_ESC_Telem_Backend::TelemetryType::USAGE)) {
+        return false;
+    }
+    usage_s = _telem_data[esc_index].usage_s;
+    return true;
+}
+
+// send ESC telemetry messages over MAVLink
+void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
+{
+    // return immediately if no ESCs have been found
+    if (_active_escs_mask == 0) {
+        return;
+    }
+
+    // loop through 3 groups of 4 ESCs
+    for (uint8_t i = 0; i < 3; i++) {
+
+        // return if no space in output buffer to send mavlink messages
+        if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
+            return;
+        }
+
+        // skip this group of ESCs if no data to send
+        if ((_active_escs_mask & ((uint32_t)0x0F << i*4)) == 0) {
+            continue;
+        }
+
+        // arrays to hold output
+        uint8_t temperature[4] {};
+        uint16_t voltage[4] {};
+        uint16_t current[4] {};
+        uint16_t current_tot[4] {};
+        uint16_t rpm[4] {};
+        uint16_t count[4] {};
+
+        // fill in output arrays
+        for (uint8_t j = 0; j < 4; j++) {
+            const uint8_t esc_id = i * 4 + j;
+            temperature[j] = _telem_data[esc_id].temperature_deg;
+            voltage[j] = _telem_data[esc_id].voltage_cv;
+            current[j] = _telem_data[esc_id].current_ca;
+            current_tot[j] = constrain_float(_telem_data[esc_id].consumption_mah, 0, UINT16_MAX);
+            float rpmf;
+            if (get_rpm(esc_id, rpmf)) {
+                rpm[j] = constrain_float(rpmf, 0, UINT16_MAX);
+            } else {
+                rpm[j] = 0;
+            }
+            count[j] = _telem_data[esc_id].count;
+        }
+
+        // send messages
+        switch (i) {
+            case 0:
+                mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
+                break;
+            case 1:
+                mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
+                break;
+            case 2:
+                mavlink_msg_esc_telemetry_9_to_12_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+// record an update to the telemetry data together with timestamp
+// this should be called by backends when new telemetry values are available
+void AP_ESC_Telem::update_telem_data(uint8_t esc_index, const AP_ESC_Telem_Backend::TelemetryData& new_data, uint8_t data_mask)
+{
+    if (esc_index > ESC_TELEM_MAX_ESCS) {
+        return;
+    }
+
+    _last_telem_data_ms[esc_index] = AP_HAL::millis();
+
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE) {
+        _telem_data[esc_index].temperature_deg = new_data.temperature_deg;
+    }
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE) {
+        _telem_data[esc_index].motor_temp_deg = new_data.motor_temp_deg;
+    }
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::VOLTAGE) {
+        _telem_data[esc_index].voltage_cv = new_data.voltage_cv;
+    }
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::CURRENT) {
+        _telem_data[esc_index].current_ca = new_data.current_ca;
+    }
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION) {
+        _telem_data[esc_index].consumption_mah = new_data.consumption_mah;
+    }
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::USAGE) {
+        _telem_data[esc_index].usage_s = new_data.usage_s;
+    }
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::ERROR_RATE) {
+        _telem_data[esc_index].error_rate = new_data.error_rate;
+    }
+
+    _telem_data[esc_index].count++;
+    _telem_data_mask[esc_index] |= data_mask;
+    _active_escs_mask |= (1 << esc_index);
+}
+
+// record an update to the RPM together with timestamp, this allows the notch values to be slewed
+// this should be called by backends when new telemetry values are available
+void AP_ESC_Telem::update_rpm(uint8_t esc_index, uint16_t new_rpm)
+{
+    if (esc_index > ESC_TELEM_MAX_ESCS) {
+        return;
+    }
+    uint32_t now = AP_HAL::micros();
+
+    _prev_rpm[esc_index] = _curr_rpm[esc_index];
+    _curr_rpm[esc_index] = new_rpm;
+    _update_rate_hz[esc_index] = 1.0e6f / (now -_last_rpm_update_us[esc_index]);
+    _last_rpm_update_us[esc_index] = now;
+    _active_escs_mask |= (1 << esc_index);
+
+#ifdef ESC_TELEM_DEBUG
+    hal.console->printf("RPM: rate=%.1fhz, rpm=%d)\n", _update_rate_hz[esc_index], new_rpm);
+#endif
+}
+
+void AP_ESC_Telem::init(void)
+{
+    if (_initialised) {
+        return;
+    }
+
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     const uint8_t num_drivers = AP::can().get_num_drivers();
     for (uint8_t i = 0; i < num_drivers; i++) {
         if (AP::can().get_driver_type(i) == AP_CANManager::Driver_Type_ToshibaCAN) {
             AP_ToshibaCAN *tcan = AP_ToshibaCAN::get_tcan(i);
             if (tcan != nullptr) {
-                usage_sec = tcan->get_usage_seconds(esc_id);
-                return true;
+                add_backend(tcan);
+                break;
             }
-            return true;
         }
     }
 #endif
-    return false;
+
+    _initialised = true;
+}
+
+// log ESC telemetry at 10Hz
+void AP_ESC_Telem::update()
+{
+    AP_Logger *logger = AP_Logger::get_singleton();
+
+    // Push received telemtry data into the logging system
+    if (logger && logger->logging_enabled()) {
+
+        for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+            if ((_active_escs_mask & (1<<i)) &&  (_last_telem_data_ms[i] >  _last_telem_log_ms[i]
+                || _last_rpm_update_us[i] > _last_telem_log_ms[i] * 1000)) {
+
+                float rpm = 0.0f;
+                get_rpm(i, rpm);
+
+                logger->Write_ESC(i, AP_HAL::micros64(),
+                                (int32_t) rpm * 100,
+                                _telem_data[i].voltage_cv,
+                                _telem_data[i].current_ca,
+                                _telem_data[i].temperature_deg,
+                                _telem_data[i].consumption_mah,
+                                _telem_data[i].motor_temp_deg,
+                                _telem_data[i].error_rate);
+                _last_telem_log_ms[i] = AP_HAL::millis();
+            }
+        }
+    }
+}
+
+bool AP_ESC_Telem::add_backend(AP_ESC_Telem_Backend *backend)
+{
+    if (!backend) {
+        return false;
+    }
+    if (_backend_count == ESC_MAX_BACKENDS) {
+        AP_HAL::panic("Too many ESC backends");
+    }
+    _backends[_backend_count++] = backend;
+    return true;
 }
 
 AP_ESC_Telem *AP_ESC_Telem::_singleton = nullptr;
@@ -72,3 +388,5 @@ AP_ESC_Telem &esc_telem()
 }
 
 };
+
+#endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -196,6 +196,8 @@ void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
         return;
     }
 
+    static_assert(ESC_TELEM_MAX_ESCS <= 12, "AP_ESC_Telem::send_esc_telemetry_mavlink() only supports up-to 12 motors");
+
     // loop through 3 groups of 4 ESCs
     for (uint8_t i = 0; i < 3; i++) {
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -141,7 +141,7 @@ bool AP_ESC_Telem::get_current_ca(uint8_t esc_index, uint16_t& amps_ca) const
     return true;
 }
 
-// get an individual ESC's current if available, returns true on success
+// get an individual ESC's voltage if available, returns true on success
 bool AP_ESC_Telem::get_voltage_cv(uint8_t esc_index, uint16_t& volts_cv) const
 {
     if (esc_index >= ESC_TELEM_MAX_ESCS
@@ -153,7 +153,7 @@ bool AP_ESC_Telem::get_voltage_cv(uint8_t esc_index, uint16_t& volts_cv) const
     return true;
 }
 
-// get an individual ESC's current if available, returns true on success
+// get an individual ESC's energy consumption if available, returns true on success
 bool AP_ESC_Telem::get_consumption_mah(uint8_t esc_index, uint16_t& consumption_mah) const
 {
     if (esc_index >= ESC_TELEM_MAX_ESCS
@@ -176,7 +176,7 @@ bool AP_ESC_Telem::get_telem_data(uint8_t esc_index, AP_ESC_Telem_Backend::Telem
     return true;
 }
 
-// get an individual ESC's current if available, returns true on success
+// get an individual ESC's usage time if available, returns true on success
 bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_index, uint32_t& usage_s) const
 {
     if (esc_index >= ESC_TELEM_MAX_ESCS

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -1,9 +1,17 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
+#include "AP_ESC_Telem_Backend.h"
+
+#if HAL_WITH_ESC_TELEM
+
+#define ESC_MAX_BACKENDS 6
+#define ESC_TELEM_MAX_ESCS   12
+#define ESC_TELEM_DATA_TIMEOUT_MS 5000
 
 class AP_ESC_Telem {
 public:
+    friend class AP_ESC_Telem_Backend;
 
     AP_ESC_Telem();
 
@@ -13,15 +21,88 @@ public:
 
     static AP_ESC_Telem *get_singleton();
 
+    // get an individual ESC's rpm if available, returns true on success
+    bool get_rpm(uint8_t esc_index, float& rpm) const;
+
+    // get an individual ESC's temperature in degrees if available, returns true on success
+    bool get_temperature(uint8_t esc_index, int16_t& temp) const;
+
+    // get an individual motor's temperature in degrees if available, returns true on success
+    bool get_motor_temperature(uint8_t esc_index, int16_t& temp) const;
+
+    // get an individual ESC's current in centi-amps if available, returns true on success
+    bool get_current_ca(uint8_t esc_index, uint16_t& amps_ca) const;
+
     // get an individual ESC's usage time in seconds if available, returns true on success
-    bool get_usage_seconds(uint8_t esc_id, uint32_t& usage_sec) const;
+    bool get_usage_seconds(uint8_t esc_index, uint32_t& usage_sec) const;
+
+    // get an individual ESC's voltage in centi-volts if available, returns true on success
+    bool get_voltage_cv(uint8_t esc_index, uint16_t& volts_cv) const;
+
+    // get an individual ESC's consumption in mah if available, returns true on success
+    bool get_consumption_mah(uint8_t esc_index, uint16_t& consumption) const;
+
+    bool get_telem_data(uint8_t esc_index, AP_ESC_Telem_Backend::TelemetryData& data) const;
+
+    // return the average motor frequency in Hz for dynamic filtering
+    float get_average_motor_frequency_hz() const;
+
+    // return all of the motor frequencies in Hz for dynamic filtering
+    uint8_t get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) const;
+
+    // get the mask of valid ESCs indexed by servo number -1
+    uint32_t get_active_escs() const { return _active_escs_mask; }
+
+    // get the number of valid ESCs
+    uint8_t get_num_active_escs() const;
+
+    // return the last time telemetry data was received in ms for the given ESC or 0 if never
+    uint32_t get_last_telem_data_ms(uint8_t esc_index) const {
+        if (esc_index > ESC_TELEM_MAX_ESCS) return 0;
+        return _last_telem_data_ms[esc_index];
+    }
+
+    // send telemetry data to mavlink
+    void send_esc_telemetry_mavlink(uint8_t mav_chan);
+
+    // load backend drivers
+    bool add_backend(AP_ESC_Telem_Backend *backend);
+
+    // udpate at 10Hz to log telemetry
+    void update();
+
+    void init();
 
 private:
+    // callback to update the rpm in the frontend, should be called by the driver when new data is available
+    void update_rpm(uint8_t esc_index, uint16_t new_rpm);
+    // callback to update the data in the frontend, should be called by the driver when new data is available
+    void update_telem_data(uint8_t esc_index, const AP_ESC_Telem_Backend::TelemetryData& new_data, uint8_t data_mask);
+
+    AP_ESC_Telem_Backend* _backends[ESC_MAX_BACKENDS];
+
+    uint8_t _backend_count;
+    bool _initialised;
+
+    // previous motor rpm so that changes can be slewed
+    float _prev_rpm[ESC_TELEM_MAX_ESCS];
+    float _curr_rpm[ESC_TELEM_MAX_ESCS];
+    uint32_t _last_rpm_update_us[ESC_TELEM_MAX_ESCS];
+    float _update_rate_hz[ESC_TELEM_MAX_ESCS];
+    // valid ESCs with RPM info
+    uint32_t _active_escs_mask;
+
+    // telemetry data
+    AP_ESC_Telem_Backend::TelemetryData _telem_data[ESC_TELEM_MAX_ESCS];
+    uint16_t _telem_data_mask[ESC_TELEM_MAX_ESCS];
+    uint32_t _last_telem_data_ms[ESC_TELEM_MAX_ESCS];
+    uint32_t _last_telem_log_ms[ESC_TELEM_MAX_ESCS];
 
     static AP_ESC_Telem *_singleton;
-
 };
 
 namespace AP {
     AP_ESC_Telem &esc_telem();
 };
+
+#endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
@@ -1,0 +1,43 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ESC_Telem_Backend.h"
+#include "AP_ESC_Telem.h"
+#include <AP_HAL/AP_HAL.h>
+
+#if HAL_WITH_ESC_TELEM
+
+#include <AP_Math/AP_Math.h>
+
+extern const AP_HAL::HAL& hal;
+
+AP_ESC_Telem_Backend::AP_ESC_Telem_Backend() {
+    _frontend = AP_ESC_Telem::_singleton;
+    if (_frontend == nullptr) {
+        AP_HAL::panic("No ESC frontend");
+    }
+}
+
+// callback to update the rpm in the frontend, should be called by the driver when new data is available
+void AP_ESC_Telem_Backend::update_rpm(uint8_t esc_index, uint16_t new_rpm) {
+    _frontend->update_rpm(esc_index, new_rpm);
+}
+
+// callback to update the data in the frontend, should be called by the driver when new data is available
+void AP_ESC_Telem_Backend::update_telem_data(uint8_t esc_index, const TelemetryData& new_data, uint8_t data_present_mask) {
+    _frontend->update_telem_data(esc_index, new_data, data_present_mask);
+}
+
+#endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#ifndef HAL_WITH_ESC_TELEM
+#define HAL_WITH_ESC_TELEM 1
+#endif
+
+#if HAL_WITH_ESC_TELEM
+
+class AP_ESC_Telem;
+
+class AP_ESC_Telem_Backend {
+public:
+
+    struct TelemetryData {
+        int16_t temperature_deg;    // degrees C, negative values allowed
+        uint16_t voltage_cv;        // centi-volts
+        uint16_t current_ca;        // centi-amps
+        uint16_t consumption_mah;   // mAh
+        uint32_t usage_s;           // usage seconds
+        float    rpm;               // rpm
+        int16_t motor_temp_deg;     // degrees C, negative values allowed
+        float    error_rate;        // error rate in percent
+        uint16_t count;             // number of times updated
+    };
+
+    enum TelemetryType {
+        TEMPERATURE = 1 << 0,
+        MOTOR_TEMPERATURE  = 1 << 1,
+        VOLTAGE     = 1 << 2,
+        CURRENT     = 1 << 3,
+        CONSUMPTION = 1 << 4,
+        USAGE       = 1 << 5,
+        RPM         = 1 << 6,
+        ERROR_RATE  = 1 << 7
+    };
+
+
+    AP_ESC_Telem_Backend();
+
+    /* Do not allow copies */
+    AP_ESC_Telem_Backend(const AP_ESC_Telem_Backend &other) = delete;
+    AP_ESC_Telem_Backend &operator=(const AP_ESC_Telem_Backend&) = delete;
+
+protected:
+    AP_ESC_Telem* _frontend;
+
+    // callback to update the rpm in the frontend, should be called by the driver when new data is available
+    void update_rpm(uint8_t esc_index, uint16_t new_rpm);
+
+    // callback to update the data in the frontend, should be called by the driver when new data is available
+    void update_telem_data(uint8_t esc_index, const TelemetryData& new_data, uint8_t data_present_mask);
+
+private:
+};
+
+#endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
@@ -14,13 +14,13 @@ class AP_ESC_Telem_Backend {
 public:
 
     struct TelemetryData {
-        int16_t temperature_deg;    // degrees C, negative values allowed
+        int16_t  temperature_deg;   // degrees C, negative values allowed
         uint16_t voltage_cv;        // centi-volts
         uint16_t current_ca;        // centi-amps
         uint16_t consumption_mah;   // mAh
         uint32_t usage_s;           // usage seconds
         float    rpm;               // rpm
-        int16_t motor_temp_deg;     // degrees C, negative values allowed
+        int16_t  motor_temp_deg;    // degrees C, negative values allowed
         float    error_rate;        // error rate in percent
         uint16_t count;             // number of times updated
     };

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
@@ -1,0 +1,49 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_ESC_Telem_SITL.h"
+#include "AP_ESC_Telem.h"
+#include <AP_HAL/AP_HAL.h>
+#include <SITL/SITL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include <AP_Math/AP_Math.h>
+
+extern const AP_HAL::HAL& hal;
+
+AP_ESC_Telem_SITL::AP_ESC_Telem_SITL()
+{
+    AP::esc_telem().add_backend(this);
+}
+
+void AP_ESC_Telem_SITL::update()
+{
+    SITL::SITL* sitl = AP::sitl();
+
+    if (!sitl) {
+        return;
+    }
+
+    if (is_zero(sitl->throttle)) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < sitl->state.num_motors; i++) {
+        update_rpm(i, sitl->state.rpm[sitl->state.vtol_motor_start+i]);
+    }
+}
+
+#endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_ESC_Telem_Backend.h"
+#include <SITL/SITL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+class AP_ESC_Telem_SITL : public AP_ESC_Telem_Backend {
+public:
+    AP_ESC_Telem_SITL();
+
+    void update();
+
+protected:
+
+private:
+};
+
+#endif

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -1,0 +1,761 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Protocol implementation was provided by FETtec */
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_FETtecOneWire.h"
+#include <stdio.h>
+
+// constructor
+AP_FETtecOneWire::AP_FETtecOneWire()
+{
+    FETtecOneWire_ResponseLength[OW_OK] = 1;
+    FETtecOneWire_ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
+    FETtecOneWire_ResponseLength[OW_NOT_OK] = 1;
+    FETtecOneWire_ResponseLength[OW_BL_START_FW] = 0;       // BL only
+    FETtecOneWire_ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    FETtecOneWire_ResponseLength[OW_REQ_TYPE] = 1;
+    FETtecOneWire_ResponseLength[OW_REQ_SN] = 12;
+    FETtecOneWire_ResponseLength[OW_REQ_SW_VER] = 2;
+    FETtecOneWire_ResponseLength[OW_RESET_TO_BL] = 0;
+    FETtecOneWire_ResponseLength[OW_THROTTLE] = 1;
+    FETtecOneWire_ResponseLength[OW_REQ_TLM] = 2;
+    FETtecOneWire_ResponseLength[OW_BEEP] = 0;
+
+    FETtecOneWire_ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_USE_SIN_START] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_USE_SIN_START] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_3D_MODE] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_3D_MODE] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_ID] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_ID] = 1;
+
+/*
+    FETtecOneWire_ResponseLength[OW_GET_LINEAR_THRUST] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    FETtecOneWire_ResponseLength[OW_GET_EEVER] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_PWM_MIN] = 2;
+    FETtecOneWire_ResponseLength[OW_SET_PWM_MIN] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_PWM_MAX] = 2;
+    FETtecOneWire_ResponseLength[OW_SET_PWM_MAX] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_ESC_BEEP] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_ESC_BEEP] = 1;
+
+    FETtecOneWire_ResponseLength[OW_GET_CURRENT_CALIB] = 1;
+    FETtecOneWire_ResponseLength[OW_SET_CURRENT_CALIB] = 1;
+
+    FETtecOneWire_ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
+    FETtecOneWire_ResponseLength[OW_GET_LED_COLOR] = 5;
+    FETtecOneWire_ResponseLength[OW_SET_LED_COLOR] = 1;
+
+    FETtecOneWire_RequestLength[OW_OK] = 1;
+    FETtecOneWire_RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
+    FETtecOneWire_RequestLength[OW_NOT_OK] = 1;
+    FETtecOneWire_RequestLength[OW_BL_START_FW] = 1;        // BL only
+    FETtecOneWire_RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    FETtecOneWire_RequestLength[OW_REQ_TYPE] = 1;
+    FETtecOneWire_RequestLength[OW_REQ_SN] = 1;
+    FETtecOneWire_RequestLength[OW_REQ_SW_VER] = 1;
+    FETtecOneWire_RequestLength[OW_RESET_TO_BL] = 1;
+    FETtecOneWire_RequestLength[OW_THROTTLE] = 1;
+    FETtecOneWire_RequestLength[OW_REQ_TLM] = 1;
+    FETtecOneWire_RequestLength[OW_BEEP] = 2;
+
+    FETtecOneWire_RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
+
+    FETtecOneWire_RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
+    FETtecOneWire_RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_USE_SIN_START] = 1;
+    FETtecOneWire_RequestLength[OW_SET_USE_SIN_START] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_3D_MODE] = 1;
+    FETtecOneWire_RequestLength[OW_SET_3D_MODE] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_ID] = 1;
+    FETtecOneWire_RequestLength[OW_SET_ID] = 1;
+
+/*
+    FETtecOneWire_RequestLength[OW_GET_LINEAR_THRUST] = 1;
+    FETtecOneWire_RequestLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    FETtecOneWire_RequestLength[OW_GET_EEVER] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_PWM_MIN] = 1;
+    FETtecOneWire_RequestLength[OW_SET_PWM_MIN] = 2;
+
+    FETtecOneWire_RequestLength[OW_GET_PWM_MAX] = 1;
+    FETtecOneWire_RequestLength[OW_SET_PWM_MAX] = 2;
+
+    FETtecOneWire_RequestLength[OW_GET_ESC_BEEP] = 1;
+    FETtecOneWire_RequestLength[OW_SET_ESC_BEEP] = 1;
+
+    FETtecOneWire_RequestLength[OW_GET_CURRENT_CALIB] = 1;
+    FETtecOneWire_RequestLength[OW_SET_CURRENT_CALIB] = 1;
+
+    FETtecOneWire_RequestLength[OW_SET_LED_TMP_COLOR] = 4;
+    FETtecOneWire_RequestLength[OW_GET_LED_COLOR] = 1;
+    FETtecOneWire_RequestLength[OW_SET_LED_COLOR] = 5;
+
+}
+
+void AP_FETtecOneWire::init()
+{
+    AP_SerialManager& serial_manager = AP::serialmanager();
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FETtechOneWire, 0);
+    if (_uart) {
+        _uart->begin(2000000);
+    }
+    FETtecOneWire_Init();
+}
+
+void AP_FETtecOneWire::update()
+{
+    if (!initialised) {
+        initialised = true;
+        init();
+        last_send_us = AP_HAL::micros();
+        return;
+    }
+
+    if (_uart == nullptr) {
+        return;
+    }
+
+    uint16_t requestedTelemetry[MOTOR_COUNT] = {0};
+    int8_t TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT, TLM_request);
+    if (TelemetryAvailable != -1) {
+        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+            completeTelemetry[i][TelemetryAvailable] = requestedTelemetry[i];
+        }
+    }
+    if (++TLM_request == 5) {
+        TLM_request = 0;
+    }
+    if (TelemetryAvailable != -1) {
+        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+            printf(" esc: %d", i + 1);
+            printf(" Temperature: %d", completeTelemetry[i][0]);
+            printf(", Voltage: %d", completeTelemetry[i][1]);
+            printf(", Current: %d", completeTelemetry[i][2]);
+            printf(", E-rpm: %d", completeTelemetry[i][3]);
+            printf(", consumption: %d", completeTelemetry[i][4]);
+            printf("\n");
+        }
+    }
+}
+
+/*
+    initialize FETtecOneWire protocol
+*/
+void AP_FETtecOneWire::FETtecOneWire_Init()
+{
+    if (FETtecOneWire_firstInitDone == 0) {
+        FETtecOneWire_FoundESCs = 0;
+        FETtecOneWire_ScanActive = 0;
+        FETtecOneWire_SetupActive = 0;
+        FETtecOneWire_minID = 25;
+        FETtecOneWire_maxID = 0;
+        FETtecOneWire_IDcount = 0;
+        FETtecOneWire_FastThrottleByteCount = 0;
+        for (uint8_t i = 0; i < 25; i++) {
+            FETtecOneWire_activeESC_IDs[i] = 0;
+        }
+    }
+    FETtecOneWire_IgnoreOwnBytes = 0;
+    FETtecOneWire_PullSuccess = 0;
+    FETtecOneWire_PullBusy = 0;
+    FETtecOneWire_firstInitDone = 1;
+}
+
+/*
+    generates used 8 bit CRC
+    crc = byte to be added to CRC
+    crc_seed = CRC where it gets added too
+    returns 8 bit CRC
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed)
+{
+    uint8_t crc_u, i;
+    crc_u = crc;
+    crc_u ^= crc_seed;
+    for (i = 0; i < 8; i++) {
+        crc_u = (crc_u & 0x80) ? 0x7 ^ (crc_u << 1) : (crc_u << 1);
+    }
+    return (crc_u);
+}
+
+/*
+    generates used 8 bit CRC for arrays
+    Buf = 8 bit byte array
+    BufLen = count of bytes that should be used for CRC calculation
+    returns 8 bit CRC
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen)
+{
+    uint8_t crc = 0;
+    for (uint16_t i = 0; i < BufLen; i++) {
+        crc = FETtecOneWire_UpdateCrc8(Buf[i], crc);
+    }
+    return (crc);
+}
+
+/*
+    transmitts a FETtecOneWire frame to a ESC
+    ESC_id = id of the ESC
+    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    Length = length of the Bytes array
+    returns nothing
+*/
+void AP_FETtecOneWire::FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t* Bytes, uint8_t Length)
+{
+    /*
+    a frame lookes like:
+    byte 1 = fremae header (master is always 0x01)
+    byte 2 = target ID (5bit)
+    byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
+    byte 5 = frame length over all bytes
+    byte 6 - X = request type, followed by the payload
+    byte X+1 = 8bit CRC
+    */
+    uint8_t transmitArr[256] = {0x01, ESC_id, 0x00, 0x00};
+    transmitArr[4] = Length + 6;
+    for (uint8_t i = 0; i < Length; i++) {
+        transmitArr[i + 5] = Bytes[i];
+    }
+    transmitArr[Length + 5] = FETtecOneWire_GetCrc8(transmitArr, Length + 5); // crc
+    _uart->write(transmitArr, Length + 6);
+    FETtecOneWire_IgnoreOwnBytes += Length + 6;
+}
+
+/*
+    reads the answer frame of a ESC
+    Bytes = 8 bit byte array, where the received answer gets stored in
+    Length = the expected answer length
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the expected answer frame was there, 0 if dont
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, uint8_t returnFullFrame)
+{
+    /*
+    a frame lookes like:
+    byte 1 = fremae header (0x02 = bootloader, 0x03 = ESC firmware)
+    byte 2 = sender ID (5bit)
+    byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
+    byte 5 = frame length over all bytes
+    byte 6 - X = answer type, followed by the payload
+    byte X+1 = 8bit CRC
+    */
+
+    //ignore own bytes
+    while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
+        FETtecOneWire_IgnoreOwnBytes--;
+        _uart->read();
+    }
+    // look for the real answer
+    if (_uart->available() >= Length + 6u) {
+        // sync to frame starte byte
+        uint8_t testFrameStart = 0;
+        do {
+            testFrameStart = _uart->read();
+        }
+        while (testFrameStart != 0x02 && testFrameStart != 0x03 && _uart->available());
+        // copy message
+        if (_uart->available() >= Length + 5u) {
+            uint8_t ReceiveBuf[20] = {0};
+            ReceiveBuf[0] = testFrameStart;
+            for (uint8_t i = 1; i < Length + 6; i++) {
+                ReceiveBuf[i] = _uart->read();
+            }
+            // check CRC
+            if (FETtecOneWire_GetCrc8(ReceiveBuf, Length + 5) == ReceiveBuf[Length + 5]) {
+                if (!returnFullFrame) {
+                    for (uint8_t i = 0; i < Length; i++) {
+                        Bytes[i] = ReceiveBuf[5 + i];
+                    }
+                } else {
+                    for (uint8_t i = 0; i < Length + 6; i++) {
+                        Bytes[i] = ReceiveBuf[i];
+                    }
+                }
+                return 1;
+            } else {
+                return 0;
+            } // crc missmatch
+        } else {
+            return 0;
+        } // no answer yet
+    } else {
+        return 0;
+    } // no answer yet
+}
+
+/*
+    makes all connected ESC's beep
+    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
+*/
+void AP_FETtecOneWire::FETtecOneWire_Beep(uint8_t beepFreqency)
+{
+    if (FETtecOneWire_IDcount > 0) {
+        uint8_t request[2] = {OW_BEEP, beepFreqency};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
+            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
+            _uart->write(spacer, 2);
+            FETtecOneWire_IgnoreOwnBytes += 2;
+        }
+    }
+}
+
+/*
+    sets the racewire color for all ESC's
+    R, G, B = 8bit colors
+*/
+void AP_FETtecOneWire::FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
+{
+    if (FETtecOneWire_IDcount > 0) {
+        uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
+            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
+            _uart->write(spacer, 2);
+            FETtecOneWire_IgnoreOwnBytes += 2;
+        }
+    }
+}
+
+/*
+    Resets a pending pull request
+    returns nothing
+*/
+void AP_FETtecOneWire::FETtecOneWire_PullReset()
+{
+    FETtecOneWire_PullSuccess = 0;
+    FETtecOneWire_PullBusy = 0;
+}
+
+/*
+    Pulls a complete request between for ESC
+    ESC_id = id of the ESC
+    command = 8bit array containing the command that thould be send including the possible payload
+    response = 8bit array where the response will be stored in
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the request is completed, 0 if dont
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t* command, uint8_t* response,
+        uint8_t returnFullFrame)
+{
+    if (!FETtecOneWire_PullBusy) {
+        FETtecOneWire_PullBusy = 1;
+        FETtecOneWire_PullSuccess = 0;
+        FETtecOneWire_Transmit(ESC_id, command, FETtecOneWire_RequestLength[command[0]]);
+    } else {
+        if (FETtecOneWire_Receive(response, FETtecOneWire_ResponseLength[command[0]], returnFullFrame)) {
+            FETtecOneWire_PullSuccess = 1;
+            FETtecOneWire_PullBusy = 0;
+        }
+    }
+    return FETtecOneWire_PullSuccess;
+}
+
+/*
+    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
+    returns the currend scanned ID
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_ScanESCs()
+{
+    static uint16_t delayLoops = 500;
+    static uint8_t scanID = 0;
+    static uint8_t scanState = 0;
+    static uint8_t scanTimeOut = 0;
+    uint8_t response[18] = {0};
+    uint8_t request[1] = {0};
+    if (FETtecOneWire_ScanActive == 0) {
+        delayLoops = 500;
+        scanID = 0;
+        scanState = 0;
+        scanTimeOut = 0;
+        return FETtecOneWire_ScanActive + 1;
+    }
+    if (delayLoops > 0) {
+        delayLoops--;
+        return FETtecOneWire_ScanActive;
+    }
+    if (scanID < FETtecOneWire_ScanActive) {
+        scanID = FETtecOneWire_ScanActive;
+        scanState = 0;
+        scanTimeOut = 0;
+    }
+    if (scanTimeOut == 3 || scanTimeOut == 6 || scanTimeOut == 9 || scanTimeOut == 12) {
+        FETtecOneWire_PullReset();
+    }
+    if (scanTimeOut < 15) {
+        switch (scanState) {
+        case 0:request[0] = OW_OK;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_FULL_FRAME)) {
+                scanTimeOut = 0;
+                FETtecOneWire_activeESC_IDs[scanID] = 1;
+                FETtecOneWire_FoundESCs++;
+                if (response[0] == 0x02) {
+                    FETtecOneWire_foundESCs[scanID].inBootLoader = 1;
+                } else {
+                    FETtecOneWire_foundESCs[scanID].inBootLoader = 0;
+                }
+                delayLoops = 1;
+                scanState++;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        case 1:request[0] = OW_REQ_TYPE;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
+                scanTimeOut = 0;
+                FETtecOneWire_foundESCs[scanID].ESCtype = response[0];
+                delayLoops = 1;
+                scanState++;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        case 2:request[0] = OW_REQ_SW_VER;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
+                scanTimeOut = 0;
+                FETtecOneWire_foundESCs[scanID].firmWareVersion = response[0];
+                FETtecOneWire_foundESCs[scanID].firmWareSubVersion = response[1];
+                delayLoops = 1;
+                scanState++;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        case 3:request[0] = OW_REQ_SN;
+            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
+                scanTimeOut = 0;
+                for (uint8_t i = 0; i < 12; i++) {
+                    FETtecOneWire_foundESCs[scanID].serialNumber[i] = response[i];
+                }
+                delayLoops = 1;
+                return scanID + 1;
+            } else {
+                scanTimeOut++;
+            }
+            break;
+        }
+    } else {
+        FETtecOneWire_PullReset();
+        return scanID + 1;
+    }
+    return scanID;
+}
+
+/*
+    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
+    returns the current used ID
+*/
+uint8_t AP_FETtecOneWire::FETtecOneWire_InitESCs()
+{
+    static uint8_t delayLoops = 0;
+    static uint8_t activeID = 1;
+    static uint8_t State = 0;
+    static uint8_t TimeOut = 0;
+    static uint8_t wakeFromBL = 1;
+    static uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
+    uint8_t response[18] = {0};
+    uint8_t request[1] = {0};
+    if (FETtecOneWire_SetupActive == 0) {
+        delayLoops = 0;
+        activeID = 1;
+        State = 0;
+        TimeOut = 0;
+        wakeFromBL = 1;
+        return FETtecOneWire_SetupActive + 1;
+    }
+    while (FETtecOneWire_activeESC_IDs[FETtecOneWire_SetupActive] == 0 && FETtecOneWire_SetupActive < 25) {
+        FETtecOneWire_SetupActive++;
+    }
+
+    if (FETtecOneWire_SetupActive == 25 && wakeFromBL == 0) {
+        return FETtecOneWire_SetupActive;
+    } else if (FETtecOneWire_SetupActive == 25 && wakeFromBL) {
+        wakeFromBL = 0;
+        activeID = 1;
+        FETtecOneWire_SetupActive = 1;
+        State = 0;
+        TimeOut = 0;
+
+        FETtecOneWire_minID = 25;
+        FETtecOneWire_maxID = 0;
+        FETtecOneWire_IDcount = 0;
+        for (uint8_t i = 0; i < 25; i++) {
+            if (FETtecOneWire_activeESC_IDs[i] != 0) {
+                FETtecOneWire_IDcount++;
+                if (i < FETtecOneWire_minID) {
+                    FETtecOneWire_minID = i;
+                }
+                if (i > FETtecOneWire_maxID) {
+                    FETtecOneWire_maxID = i;
+                }
+            }
+        }
+
+        if (FETtecOneWire_IDcount == 0
+                || FETtecOneWire_maxID - FETtecOneWire_minID > FETtecOneWire_IDcount - 1) { // loop forever
+            wakeFromBL = 1;
+            return activeID;
+        }
+        FETtecOneWire_FastThrottleByteCount = 1;
+        int8_t bitCount = 12 + (FETtecOneWire_IDcount * 11);
+        while (bitCount > 0) {
+            FETtecOneWire_FastThrottleByteCount++;
+            bitCount -= 8;
+        }
+        setFastCommand[1] = FETtecOneWire_FastThrottleByteCount; // just for older ESC FW versions since 1.0 001 this byte is ignored as the ESC calculates it itself
+        setFastCommand[2] = FETtecOneWire_minID;                 // min ESC id
+        setFastCommand[3] = FETtecOneWire_IDcount;                 // count of ESC's that will get signals
+    }
+
+    if (delayLoops > 0) {
+        delayLoops--;
+        return FETtecOneWire_SetupActive;
+    }
+
+    if (activeID < FETtecOneWire_SetupActive) {
+        activeID = FETtecOneWire_SetupActive;
+        State = 0;
+        TimeOut = 0;
+    }
+
+    if (TimeOut == 3 || TimeOut == 6 || TimeOut == 9 || TimeOut == 12) {
+        FETtecOneWire_PullReset();
+    }
+
+    if (TimeOut < 15) {
+        if (wakeFromBL) {
+            switch (State) {
+            case 0:request[0] = OW_BL_START_FW;
+                if (FETtecOneWire_foundESCs[activeID].inBootLoader == 1) {
+                    FETtecOneWire_Transmit(activeID, request, FETtecOneWire_RequestLength[request[0]]);
+                    delayLoops = 5;
+                } else {
+                    return activeID + 1;
+                }
+                State = 1;
+                break;
+            case 1:request[0] = OW_OK;
+                if (FETtecOneWire_PullCommand(activeID, request, response, OW_RETURN_FULL_FRAME)) {
+                    TimeOut = 0;
+                    if (response[0] == 0x02) {
+                        FETtecOneWire_foundESCs[activeID].inBootLoader = 1;
+                        State = 0;
+                    } else {
+                        FETtecOneWire_foundESCs[activeID].inBootLoader = 0;
+                        delayLoops = 1;
+                        return activeID + 1;
+                    }
+                } else {
+                    TimeOut++;
+                }
+                break;
+            }
+        } else {
+            if (FETtecOneWire_PullCommand(activeID, setFastCommand, response, OW_RETURN_RESPONSE)) {
+                TimeOut = 0;
+                delayLoops = 1;
+                return activeID + 1;
+            } else {
+                TimeOut++;
+            }
+        }
+    } else {
+        FETtecOneWire_PullReset();
+        return activeID + 1;
+    }
+    return activeID;
+}
+
+/*
+    checks if the requested telemetry is available. 
+    Telemetry = 16bit array where the read Telemetry will be stored in. 
+    returns the telemetry request number or -1 if unavailable
+*/
+int8_t AP_FETtecOneWire::FETtecOneWire_CheckForTLM(uint16_t* Telemetry)
+{
+    int8_t return_TLM_request = 0;
+    if (FETtecOneWire_IDcount > 0) {
+        // empty buffer
+        while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
+            _uart->read();
+            FETtecOneWire_IgnoreOwnBytes--;
+        }
+
+        // first two byte are the ESC Telemetry of the first ESC. next two byte of the second....
+        if (_uart->available() == (FETtecOneWire_IDcount * 2) + 1u) {
+            // look if first byte in buffer is equal to last byte of throttle command (crc)
+            if (_uart->read() == FETtecOneWire_lastCRC) {
+                for (uint8_t i = 0; i < FETtecOneWire_IDcount; i++) {
+                    Telemetry[i] = _uart->read() << 8;
+                    Telemetry[i] |= _uart->read();
+                }
+                return_TLM_request = FETtecOneWire_TLM_request;
+            } else {
+                return_TLM_request = -1;
+            }
+        } else {
+            return_TLM_request = -1;
+        }
+    } else {
+        return_TLM_request = -1;
+    }
+    return return_TLM_request;
+}
+
+/*
+    does almost all of the job.
+    scans for ESC's if not already done.
+    initializes the ESC's if not already done.
+    sends fast throttle signals if init is complete.
+    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    Telemetry = 16bit array where the read telemetry will be stored in. 
+    motorCount = the count of motors that should get values send
+    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
+    returns the telemetry request if telemetry was available, -1 if dont
+*/
+int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,
+        uint8_t tlmRequest)
+{
+    int8_t return_TLM_request = -2;
+
+    // init should not be done too fast. as at last the bootloader has some timing requirements with messages. so loop delays must fit more or less
+    if (FETtecOneWire_ScanActive < 25 || FETtecOneWire_SetupActive < 25) {
+        const uint32_t now = AP_HAL::micros();
+        if (now - last_send_us < DELAY_TIME_US) {
+            return 0;
+        } else {
+            last_send_us = now;
+        }
+
+        if (FETtecOneWire_ScanActive < 25) {
+            // scan for all ESC's in onewire bus
+            FETtecOneWire_ScanActive = FETtecOneWire_ScanESCs();
+        } else if (FETtecOneWire_SetupActive < 25) {
+            if (FETtecOneWire_FoundESCs == 0) {
+                FETtecOneWire_ScanActive = 0;
+            } else {
+                // check if in bootloader, start ESC's FW if they are and prepare fast throttle command
+                FETtecOneWire_SetupActive = FETtecOneWire_InitESCs();
+            }
+        }
+    } else {
+        //send fast throttle signals
+        if (FETtecOneWire_IDcount > 0) {
+
+            // check for telemetry
+            return_TLM_request = FETtecOneWire_CheckForTLM(Telemetry);
+            FETtecOneWire_TLM_request = tlmRequest;
+
+            //prepare fast throttle signals
+            uint16_t useSignals[24] = {0};
+            uint8_t OneWireFastThrottleCommand[36] = {0};
+            if (motorCount > FETtecOneWire_IDcount) {
+                motorCount = FETtecOneWire_IDcount;
+            }
+            for (uint8_t i = 0; i < motorCount; i++) {
+                useSignals[i] = constrain_int16(motorValues[i], 0, 2000);
+            }
+
+            uint8_t actThrottleCommand = 0;
+
+            // byte 1:
+            // bit 0 = TLMrequest, bit 1,2,3 = TLM type, bit 4 = first bit of first ESC (11bit)signal, bit 5,6,7 = frame header
+            // so ABBBCDDD
+            // A = TLM request yes or no
+            // B = TLM request type (temp, volt, current, erpm, consumption, debug1, debug2, debug3)
+            // C = first bit from first throttle signal
+            // D = frame header
+            OneWireFastThrottleCommand[0] = 128 | (FETtecOneWire_TLM_request << 4);
+            OneWireFastThrottleCommand[0] |= ((useSignals[actThrottleCommand] >> 10) & 0x01) << 3;
+            OneWireFastThrottleCommand[0] |= 0x01;
+
+            // byte 2:
+            // AAABBBBB
+            // A = next 3 bits from (11bit)throttle signal
+            // B = 5bit target ID
+            OneWireFastThrottleCommand[1] = (((useSignals[actThrottleCommand] >> 7) & 0x07)) << 5;
+            OneWireFastThrottleCommand[1] |= ALL_ID;
+
+            // following bytes are the rest 7 bit of the first (11bit)throttle signal, and all bit from all other signals, followed by the CRC byte
+            uint8_t BitsLeftFromCommand = 7;
+            uint8_t actByte = 2;
+            uint8_t bitsFromByteLeft = 8;
+            uint8_t bitsToAddLeft = (12 + (((FETtecOneWire_maxID - FETtecOneWire_minID) + 1) * 11)) - 16;
+            while (bitsToAddLeft > 0) {
+                if (bitsFromByteLeft >= BitsLeftFromCommand) {
+                    OneWireFastThrottleCommand[actByte] |=
+                            (useSignals[actThrottleCommand] & ((1 << BitsLeftFromCommand) - 1))
+                                    << (bitsFromByteLeft - BitsLeftFromCommand);
+                    bitsToAddLeft -= BitsLeftFromCommand;
+                    bitsFromByteLeft -= BitsLeftFromCommand;
+                    actThrottleCommand++;
+                    BitsLeftFromCommand = 11;
+                    if (bitsToAddLeft == 0) {
+                        actByte++;
+                        bitsFromByteLeft = 8;
+                    }
+                } else {
+                    OneWireFastThrottleCommand[actByte] |=
+                            (useSignals[actThrottleCommand] >> (BitsLeftFromCommand - bitsFromByteLeft))
+                                    & ((1 << bitsFromByteLeft) - 1);
+                    bitsToAddLeft -= bitsFromByteLeft;
+                    BitsLeftFromCommand -= bitsFromByteLeft;
+                    actByte++;
+                    bitsFromByteLeft = 8;
+                    if (BitsLeftFromCommand == 0) {
+                        actThrottleCommand++;
+                        BitsLeftFromCommand = 11;
+                    }
+                }
+            }
+            // empty buffer
+            while (_uart->available()) {
+                _uart->read();
+            }
+
+            // send throttle signal
+            OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1] = FETtecOneWire_GetCrc8(
+                    OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount - 1);
+            _uart->write(OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount);
+            // last byte of signal can be used to make sure the first TLM byte is correct, in case of spike corruption
+            FETtecOneWire_IgnoreOwnBytes = FETtecOneWire_FastThrottleByteCount - 1;
+            FETtecOneWire_lastCRC = OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1];
+            // the ESC's will answer the TLM as 16bit each ESC, so 2byte each ESC.
+        }
+    }
+    return return_TLM_request; // returns the readed tlm as it is 1 loop delayed
+}

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -14,14 +14,36 @@
  */
 
 /* Protocol implementation was provided by FETtec */
+
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
+
 #include "AP_FETtecOneWire.h"
+#if HAL_AP_FETTECONEWIRE_ENABLED
 #include <stdio.h>
 
-// constructor
+const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
+    // @Param: MASK
+    // @DisplayName: Channel Bitmask
+    // @Description: Enable of volz servo protocol to specific channels
+    // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @User: Standard
+    AP_GROUPINFO("MASK",  1, AP_FETtecOneWire, motor_mask, 0),
+
+    AP_GROUPEND
+};
+
+AP_FETtecOneWire *AP_FETtecOneWire::_singleton;
+
+static uint8_t FETtecOneWire_ResponseLength[54];
+static uint8_t FETtecOneWire_RequestLength[54];
+
 AP_FETtecOneWire::AP_FETtecOneWire()
 {
+    _singleton = this;
     FETtecOneWire_ResponseLength[OW_OK] = 1;
     FETtecOneWire_ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
     FETtecOneWire_ResponseLength[OW_NOT_OK] = 1;
@@ -127,7 +149,7 @@ AP_FETtecOneWire::AP_FETtecOneWire()
 void AP_FETtecOneWire::init()
 {
     AP_SerialManager& serial_manager = AP::serialmanager();
-    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FETtechOneWire, 0);
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FETtecOneWire, 0);
     if (_uart) {
         _uart->begin(2000000);
     }
@@ -147,18 +169,32 @@ void AP_FETtecOneWire::update()
         return;
     }
 
-    uint16_t requestedTelemetry[MOTOR_COUNT] = {0};
-    int8_t TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT, TLM_request);
+    const uint16_t mask = uint16_t(motor_mask.get());
+
+    // tell SRV_Channels about ESC capabilities
+    SRV_Channels::set_digital_mask(mask);
+    for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+        SRV_Channel* c = SRV_Channels::srv_channel(i);
+        if (c == nullptr) {
+            continue;
+        }
+        motorpwm[i] = c->get_output_pwm();
+    }
+
+    uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
+    TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, TLM_request);
     if (TelemetryAvailable != -1) {
-        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
             completeTelemetry[i][TelemetryAvailable] = requestedTelemetry[i];
+            completeTelemetry[i][5]++;
         }
     }
     if (++TLM_request == 5) {
         TLM_request = 0;
     }
+
     if (TelemetryAvailable != -1) {
-        for (uint8_t i = 0; i < MOTOR_COUNT; i++) {
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
             printf(" esc: %d", i + 1);
             printf(" Temperature: %d", completeTelemetry[i][0]);
             printf(", Voltage: %d", completeTelemetry[i][1]);
@@ -166,6 +202,58 @@ void AP_FETtecOneWire::update()
             printf(", E-rpm: %d", completeTelemetry[i][3]);
             printf(", consumption: %d", completeTelemetry[i][4]);
             printf("\n");
+            AP_Logger *logger = AP_Logger::get_singleton();
+
+            // log at 10Hz
+            const uint32_t now = AP_HAL::millis();
+            if (logger && logger->logging_enabled() && now - last_log_ms > 100) {
+                logger->Write_ESC(i,
+                        AP_HAL::micros64(),
+                        completeTelemetry[i][3] * 100U,
+                        completeTelemetry[i][1],
+                        completeTelemetry[i][2],
+                        completeTelemetry[i][0] * 100U,
+                        completeTelemetry[i][4],
+                        0,
+                        0);
+                last_log_ms = now;
+            }
+        }
+    }
+
+}
+
+/*
+  send ESC telemetry messages over MAVLink
+ */
+void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan)
+{
+    if (TelemetryAvailable == -1) {
+        return;
+    }
+    uint8_t temperature[4] {};
+    uint16_t voltage[4] {};
+    uint16_t current[4] {};
+    uint16_t totalcurrent[4] {};
+    uint16_t rpm[4] {};
+    uint16_t count[4] {};
+    for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
+        uint8_t idx = i % 4;
+        temperature[idx] = completeTelemetry[i][0];
+        voltage[idx] = completeTelemetry[i][1];
+        current[idx] = completeTelemetry[i][2];
+        rpm[idx] = completeTelemetry[i][3];
+        totalcurrent[idx] = completeTelemetry[i][4];
+        count[idx] = completeTelemetry[i][5];
+        if (i % 4 == 3 || i == MOTOR_COUNT_MAX - 1) {
+            if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
+                return;
+            }
+            if (i < 4) {
+                mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
+            } else {
+                mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
+            }
         }
     }
 }
@@ -759,3 +847,4 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
     }
     return return_TLM_request; // returns the readed tlm as it is 1 loop delayed
 }
+#endif  // HAL_AP_FETTECONEWIRE_ENABLED

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -138,12 +138,12 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
     if (_telem_avail == -1) {
         return;
     }
-    uint8_t temperature[4] {};
-    uint16_t voltage[4] {};
-    uint16_t current[4] {};
-    uint16_t totalcurrent[4] {};
-    uint16_t rpm[4] {};
-    uint16_t count[4] {};
+    uint8_t temperature[4] {};   // deg C
+    uint16_t voltage[4] {};      // cV
+    uint16_t current[4] {};      // cA
+    uint16_t totalcurrent[4] {}; // mA.h
+    uint16_t rpm[4] {};          // eRPM
+    uint16_t count[4] {};        // ESC telemetry packets received
     // TODO: take the _telem_semaphore here
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
@@ -157,7 +157,7 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
             if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
                 return;
             }
-            static_assert(MOTOR_COUNT_MAX <= 12, "AP_FETtecOneWire::send_esc_telemetry_mavlink() support 12 or less motors");
+            static_assert(MOTOR_COUNT_MAX <= 12, "AP_FETtecOneWire::send_esc_telemetry_mavlink() only supports up-to 12 motors");
             if (i < 4) {
                 mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
             } else if (i < 8) {

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -180,24 +180,24 @@ void AP_FETtecOneWire::update()
 
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
     _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
-    if (_telem_avail != -1) {
-        // TODO: take the _telem_semaphore here
-        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            _telemetry[i][_telem_avail] = requestedTelemetry[i];
-            _telemetry[i][5]++;
-        }
-    }
+
     if (++_telem_req_type == OW_TLM_DEBUG1) {
         // OW_TLM_DEBUG1, OW_TLM_DEBUG2, OW_TLM_DEBUG3 are ignored
         _telem_req_type = OW_TLM_TEMP;
     }
 
     if (_telem_avail != -1) {
+        // TODO: take the _telem_semaphore here
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+            _telemetry[i][_telem_avail] = requestedTelemetry[i];
+            _telemetry[i][5]++;
+        }
+        // TODO: give back the _telem_semaphore here
+
         AP_Logger *logger = AP_Logger::get_singleton();
         const uint32_t now = AP_HAL::millis();
         // log at 10Hz
         if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
-            // TODO: take the _telem_semaphore here
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -41,106 +41,20 @@ AP_FETtecOneWire *AP_FETtecOneWire::_singleton;
 AP_FETtecOneWire::AP_FETtecOneWire()
 {
     _singleton = this;
+
     _ResponseLength[OW_OK] = 1;
-    _ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
-    _ResponseLength[OW_NOT_OK] = 1;
     _ResponseLength[OW_BL_START_FW] = 0;       // BL only
-    _ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
     _ResponseLength[OW_REQ_TYPE] = 1;
     _ResponseLength[OW_REQ_SN] = 12;
     _ResponseLength[OW_REQ_SW_VER] = 2;
-    _ResponseLength[OW_RESET_TO_BL] = 0;
-    _ResponseLength[OW_THROTTLE] = 1;
-    _ResponseLength[OW_REQ_TLM] = 2;
-    _ResponseLength[OW_BEEP] = 0;
-
     _ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
 
-    _ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
-    _ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
-
-    _ResponseLength[OW_GET_USE_SIN_START] = 1;
-    _ResponseLength[OW_SET_USE_SIN_START] = 1;
-
-    _ResponseLength[OW_GET_3D_MODE] = 1;
-    _ResponseLength[OW_SET_3D_MODE] = 1;
-
-    _ResponseLength[OW_GET_ID] = 1;
-    _ResponseLength[OW_SET_ID] = 1;
-
-/*
-    _ResponseLength[OW_GET_LINEAR_THRUST] = 1;
-    _ResponseLength[OW_SET_LINEAR_THRUST] = 1;
-*/
-
-    _ResponseLength[OW_GET_EEVER] = 1;
-
-    _ResponseLength[OW_GET_PWM_MIN] = 2;
-    _ResponseLength[OW_SET_PWM_MIN] = 1;
-
-    _ResponseLength[OW_GET_PWM_MAX] = 2;
-    _ResponseLength[OW_SET_PWM_MAX] = 1;
-
-    _ResponseLength[OW_GET_ESC_BEEP] = 1;
-    _ResponseLength[OW_SET_ESC_BEEP] = 1;
-
-    _ResponseLength[OW_GET_CURRENT_CALIB] = 1;
-    _ResponseLength[OW_SET_CURRENT_CALIB] = 1;
-
-    _ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
-    _ResponseLength[OW_GET_LED_COLOR] = 5;
-    _ResponseLength[OW_SET_LED_COLOR] = 1;
-
     _RequestLength[OW_OK] = 1;
-    _RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
-    _RequestLength[OW_NOT_OK] = 1;
     _RequestLength[OW_BL_START_FW] = 1;       // BL only
-    _RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
     _RequestLength[OW_REQ_TYPE] = 1;
     _RequestLength[OW_REQ_SN] = 1;
     _RequestLength[OW_REQ_SW_VER] = 1;
-    _RequestLength[OW_RESET_TO_BL] = 1;
-    _RequestLength[OW_THROTTLE] = 1;
-    _RequestLength[OW_REQ_TLM] = 1;
-    _RequestLength[OW_BEEP] = 2;
-
     _RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
-
-    _RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
-    _RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
-
-    _RequestLength[OW_GET_USE_SIN_START] = 1;
-    _RequestLength[OW_SET_USE_SIN_START] = 1;
-
-    _RequestLength[OW_GET_3D_MODE] = 1;
-    _RequestLength[OW_SET_3D_MODE] = 1;
-
-    _RequestLength[OW_GET_ID] = 1;
-    _RequestLength[OW_SET_ID] = 1;
-
-/*
-    _RequestLength[OW_GET_LINEAR_THRUST] = 1;
-    _RequestLength[OW_SET_LINEAR_THRUST] = 1;
-*/
-
-    _RequestLength[OW_GET_EEVER] = 1;
-
-    _RequestLength[OW_GET_PWM_MIN] = 1;
-    _RequestLength[OW_SET_PWM_MIN] = 2;
-
-    _RequestLength[OW_GET_PWM_MAX] = 1;
-    _RequestLength[OW_SET_PWM_MAX] = 2;
-
-    _RequestLength[OW_GET_ESC_BEEP] = 1;
-    _RequestLength[OW_SET_ESC_BEEP] = 1;
-
-    _RequestLength[OW_GET_CURRENT_CALIB] = 1;
-    _RequestLength[OW_SET_CURRENT_CALIB] = 1;
-
-    _RequestLength[OW_SET_LED_TMP_COLOR] = 4;
-    _RequestLength[OW_GET_LED_COLOR] = 1;
-    _RequestLength[OW_SET_LED_COLOR] = 5;
-
 }
 
 void AP_FETtecOneWire::init()

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -28,7 +28,7 @@
 const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
     // @Param: MASK
     // @DisplayName: Channel Bitmask
-    // @Description: Enable of volz servo protocol to specific channels
+    // @Description: Enable of FETtec OneWire ESC protocol to specific channels
     // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
     // @User: Standard
     AP_GROUPINFO("MASK",  1, AP_FETtecOneWire, motor_mask, 0),
@@ -38,111 +38,108 @@ const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
 
 AP_FETtecOneWire *AP_FETtecOneWire::_singleton;
 
-static uint8_t FETtecOneWire_ResponseLength[54];
-static uint8_t FETtecOneWire_RequestLength[54];
-
 AP_FETtecOneWire::AP_FETtecOneWire()
 {
     _singleton = this;
-    FETtecOneWire_ResponseLength[OW_OK] = 1;
-    FETtecOneWire_ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
-    FETtecOneWire_ResponseLength[OW_NOT_OK] = 1;
-    FETtecOneWire_ResponseLength[OW_BL_START_FW] = 0;       // BL only
-    FETtecOneWire_ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
-    FETtecOneWire_ResponseLength[OW_REQ_TYPE] = 1;
-    FETtecOneWire_ResponseLength[OW_REQ_SN] = 12;
-    FETtecOneWire_ResponseLength[OW_REQ_SW_VER] = 2;
-    FETtecOneWire_ResponseLength[OW_RESET_TO_BL] = 0;
-    FETtecOneWire_ResponseLength[OW_THROTTLE] = 1;
-    FETtecOneWire_ResponseLength[OW_REQ_TLM] = 2;
-    FETtecOneWire_ResponseLength[OW_BEEP] = 0;
+    _ResponseLength[OW_OK] = 1;
+    _ResponseLength[OW_BL_PAGE_CORRECT] = 1;   // BL only
+    _ResponseLength[OW_NOT_OK] = 1;
+    _ResponseLength[OW_BL_START_FW] = 0;       // BL only
+    _ResponseLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    _ResponseLength[OW_REQ_TYPE] = 1;
+    _ResponseLength[OW_REQ_SN] = 12;
+    _ResponseLength[OW_REQ_SW_VER] = 2;
+    _ResponseLength[OW_RESET_TO_BL] = 0;
+    _ResponseLength[OW_THROTTLE] = 1;
+    _ResponseLength[OW_REQ_TLM] = 2;
+    _ResponseLength[OW_BEEP] = 0;
 
-    FETtecOneWire_ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
+    _ResponseLength[OW_SET_FAST_COM_LENGTH] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
+    _ResponseLength[OW_GET_ROTATION_DIRECTION] = 1;
+    _ResponseLength[OW_SET_ROTATION_DIRECTION] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_USE_SIN_START] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_USE_SIN_START] = 1;
+    _ResponseLength[OW_GET_USE_SIN_START] = 1;
+    _ResponseLength[OW_SET_USE_SIN_START] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_3D_MODE] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_3D_MODE] = 1;
+    _ResponseLength[OW_GET_3D_MODE] = 1;
+    _ResponseLength[OW_SET_3D_MODE] = 1;
 
-    FETtecOneWire_ResponseLength[OW_GET_ID] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_ID] = 1;
-
-/*
-    FETtecOneWire_ResponseLength[OW_GET_LINEAR_THRUST] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_LINEAR_THRUST] = 1;
-*/
-
-    FETtecOneWire_ResponseLength[OW_GET_EEVER] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_PWM_MIN] = 2;
-    FETtecOneWire_ResponseLength[OW_SET_PWM_MIN] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_PWM_MAX] = 2;
-    FETtecOneWire_ResponseLength[OW_SET_PWM_MAX] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_ESC_BEEP] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_ESC_BEEP] = 1;
-
-    FETtecOneWire_ResponseLength[OW_GET_CURRENT_CALIB] = 1;
-    FETtecOneWire_ResponseLength[OW_SET_CURRENT_CALIB] = 1;
-
-    FETtecOneWire_ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
-    FETtecOneWire_ResponseLength[OW_GET_LED_COLOR] = 5;
-    FETtecOneWire_ResponseLength[OW_SET_LED_COLOR] = 1;
-
-    FETtecOneWire_RequestLength[OW_OK] = 1;
-    FETtecOneWire_RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
-    FETtecOneWire_RequestLength[OW_NOT_OK] = 1;
-    FETtecOneWire_RequestLength[OW_BL_START_FW] = 1;        // BL only
-    FETtecOneWire_RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
-    FETtecOneWire_RequestLength[OW_REQ_TYPE] = 1;
-    FETtecOneWire_RequestLength[OW_REQ_SN] = 1;
-    FETtecOneWire_RequestLength[OW_REQ_SW_VER] = 1;
-    FETtecOneWire_RequestLength[OW_RESET_TO_BL] = 1;
-    FETtecOneWire_RequestLength[OW_THROTTLE] = 1;
-    FETtecOneWire_RequestLength[OW_REQ_TLM] = 1;
-    FETtecOneWire_RequestLength[OW_BEEP] = 2;
-
-    FETtecOneWire_RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
-
-    FETtecOneWire_RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
-    FETtecOneWire_RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
-
-    FETtecOneWire_RequestLength[OW_GET_USE_SIN_START] = 1;
-    FETtecOneWire_RequestLength[OW_SET_USE_SIN_START] = 1;
-
-    FETtecOneWire_RequestLength[OW_GET_3D_MODE] = 1;
-    FETtecOneWire_RequestLength[OW_SET_3D_MODE] = 1;
-
-    FETtecOneWire_RequestLength[OW_GET_ID] = 1;
-    FETtecOneWire_RequestLength[OW_SET_ID] = 1;
+    _ResponseLength[OW_GET_ID] = 1;
+    _ResponseLength[OW_SET_ID] = 1;
 
 /*
-    FETtecOneWire_RequestLength[OW_GET_LINEAR_THRUST] = 1;
-    FETtecOneWire_RequestLength[OW_SET_LINEAR_THRUST] = 1;
+    _ResponseLength[OW_GET_LINEAR_THRUST] = 1;
+    _ResponseLength[OW_SET_LINEAR_THRUST] = 1;
 */
 
-    FETtecOneWire_RequestLength[OW_GET_EEVER] = 1;
+    _ResponseLength[OW_GET_EEVER] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_PWM_MIN] = 1;
-    FETtecOneWire_RequestLength[OW_SET_PWM_MIN] = 2;
+    _ResponseLength[OW_GET_PWM_MIN] = 2;
+    _ResponseLength[OW_SET_PWM_MIN] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_PWM_MAX] = 1;
-    FETtecOneWire_RequestLength[OW_SET_PWM_MAX] = 2;
+    _ResponseLength[OW_GET_PWM_MAX] = 2;
+    _ResponseLength[OW_SET_PWM_MAX] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_ESC_BEEP] = 1;
-    FETtecOneWire_RequestLength[OW_SET_ESC_BEEP] = 1;
+    _ResponseLength[OW_GET_ESC_BEEP] = 1;
+    _ResponseLength[OW_SET_ESC_BEEP] = 1;
 
-    FETtecOneWire_RequestLength[OW_GET_CURRENT_CALIB] = 1;
-    FETtecOneWire_RequestLength[OW_SET_CURRENT_CALIB] = 1;
+    _ResponseLength[OW_GET_CURRENT_CALIB] = 1;
+    _ResponseLength[OW_SET_CURRENT_CALIB] = 1;
 
-    FETtecOneWire_RequestLength[OW_SET_LED_TMP_COLOR] = 4;
-    FETtecOneWire_RequestLength[OW_GET_LED_COLOR] = 1;
-    FETtecOneWire_RequestLength[OW_SET_LED_COLOR] = 5;
+    _ResponseLength[OW_SET_LED_TMP_COLOR] = 0;
+    _ResponseLength[OW_GET_LED_COLOR] = 5;
+    _ResponseLength[OW_SET_LED_COLOR] = 1;
+
+    _RequestLength[OW_OK] = 1;
+    _RequestLength[OW_BL_PAGE_CORRECT] = 1; // BL only
+    _RequestLength[OW_NOT_OK] = 1;
+    _RequestLength[OW_BL_START_FW] = 1;       // BL only
+    _RequestLength[OW_BL_PAGES_TO_FLASH] = 1; // BL only
+    _RequestLength[OW_REQ_TYPE] = 1;
+    _RequestLength[OW_REQ_SN] = 1;
+    _RequestLength[OW_REQ_SW_VER] = 1;
+    _RequestLength[OW_RESET_TO_BL] = 1;
+    _RequestLength[OW_THROTTLE] = 1;
+    _RequestLength[OW_REQ_TLM] = 1;
+    _RequestLength[OW_BEEP] = 2;
+
+    _RequestLength[OW_SET_FAST_COM_LENGTH] = 4;
+
+    _RequestLength[OW_GET_ROTATION_DIRECTION] = 1;
+    _RequestLength[OW_SET_ROTATION_DIRECTION] = 1;
+
+    _RequestLength[OW_GET_USE_SIN_START] = 1;
+    _RequestLength[OW_SET_USE_SIN_START] = 1;
+
+    _RequestLength[OW_GET_3D_MODE] = 1;
+    _RequestLength[OW_SET_3D_MODE] = 1;
+
+    _RequestLength[OW_GET_ID] = 1;
+    _RequestLength[OW_SET_ID] = 1;
+
+/*
+    _RequestLength[OW_GET_LINEAR_THRUST] = 1;
+    _RequestLength[OW_SET_LINEAR_THRUST] = 1;
+*/
+
+    _RequestLength[OW_GET_EEVER] = 1;
+
+    _RequestLength[OW_GET_PWM_MIN] = 1;
+    _RequestLength[OW_SET_PWM_MIN] = 2;
+
+    _RequestLength[OW_GET_PWM_MAX] = 1;
+    _RequestLength[OW_SET_PWM_MAX] = 2;
+
+    _RequestLength[OW_GET_ESC_BEEP] = 1;
+    _RequestLength[OW_SET_ESC_BEEP] = 1;
+
+    _RequestLength[OW_GET_CURRENT_CALIB] = 1;
+    _RequestLength[OW_SET_CURRENT_CALIB] = 1;
+
+    _RequestLength[OW_SET_LED_TMP_COLOR] = 4;
+    _RequestLength[OW_GET_LED_COLOR] = 1;
+    _RequestLength[OW_SET_LED_COLOR] = 5;
 
 }
 
@@ -153,15 +150,15 @@ void AP_FETtecOneWire::init()
     if (_uart) {
         _uart->begin(2000000);
     }
-    FETtecOneWire_Init();
+    Init();
 }
 
 void AP_FETtecOneWire::update()
 {
-    if (!initialised) {
-        initialised = true;
+    if (!_initialised) {
+        _initialised = true;
         init();
-        last_send_us = AP_HAL::micros();
+        _last_send_us = AP_HAL::micros();
         return;
     }
 
@@ -178,57 +175,60 @@ void AP_FETtecOneWire::update()
         if (c == nullptr) {
             continue;
         }
-        motorpwm[i] = c->get_output_pwm();
+        _motorpwm[i] = c->get_output_pwm();
     }
 
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
-    TelemetryAvailable = FETtecOneWire_ESCsSetValues(motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, TLM_request);
-    if (TelemetryAvailable != -1) {
+    _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
+    if (_telem_avail != -1) {
         for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            completeTelemetry[i][TelemetryAvailable] = requestedTelemetry[i];
-            completeTelemetry[i][5]++;
+            _telemetry[i][_telem_avail] = requestedTelemetry[i];
+            _telemetry[i][5]++;
         }
     }
-    if (++TLM_request == 5) {
-        TLM_request = 0;
+    if (++_telem_req_type == OW_TLM_DEBUG1) {
+        // OW_TLM_DEBUG1, OW_TLM_DEBUG2, OW_TLM_DEBUG3 are ignored
+        _telem_req_type = OW_TLM_TEMP;
     }
 
-    if (TelemetryAvailable != -1) {
-        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            printf(" esc: %d", i + 1);
-            printf(" Temperature: %d", completeTelemetry[i][0]);
-            printf(", Voltage: %d", completeTelemetry[i][1]);
-            printf(", Current: %d", completeTelemetry[i][2]);
-            printf(", E-rpm: %d", completeTelemetry[i][3]);
-            printf(", consumption: %d", completeTelemetry[i][4]);
-            printf("\n");
-            AP_Logger *logger = AP_Logger::get_singleton();
+    if (_telem_avail != -1) {
+        AP_Logger *logger = AP_Logger::get_singleton();
+        const uint32_t now = AP_HAL::millis();
+        // log at 10Hz
+        if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
+            for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+                // TODO: remove printfs
+                printf(" esc: %d", i + 1);
+                printf(" Temperature: %d", _telemetry[i][OW_TLM_TEMP]);
+                printf(", Voltage: %d", _telemetry[i][OW_TLM_VOLT]);
+                printf(", Current: %d", _telemetry[i][OW_TLM_CURRENT]);
+                printf(", E-rpm: %d", _telemetry[i][OW_TLM_ERPM]);
+                printf(", consumption: %d", _telemetry[i][OW_TLM_CONSUMPTION]);
+                printf("\n");
 
-            // log at 10Hz
-            const uint32_t now = AP_HAL::millis();
-            if (logger && logger->logging_enabled() && now - last_log_ms > 100) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
-                        completeTelemetry[i][3] * 100U,
-                        completeTelemetry[i][1],
-                        completeTelemetry[i][2],
-                        completeTelemetry[i][0] * 100U,
-                        completeTelemetry[i][4],
+                        _telemetry[i][OW_TLM_ERPM] * 100U,
+                        _telemetry[i][OW_TLM_VOLT],
+                        _telemetry[i][OW_TLM_CURRENT],
+                        _telemetry[i][OW_TLM_TEMP] * 100U,
+                        _telemetry[i][OW_TLM_CONSUMPTION],
                         0,
                         0);
-                last_log_ms = now;
             }
+            _last_log_ms = now;
         }
     }
 
 }
 
-/*
+/**
   send ESC telemetry messages over MAVLink
+  @param mav_chan mavlink channel
  */
-void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan)
+void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
 {
-    if (TelemetryAvailable == -1) {
+    if (_telem_avail == -1) {
         return;
     }
     uint8_t temperature[4] {};
@@ -239,56 +239,62 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan)
     uint16_t count[4] {};
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
-        temperature[idx] = completeTelemetry[i][0];
-        voltage[idx] = completeTelemetry[i][1];
-        current[idx] = completeTelemetry[i][2];
-        rpm[idx] = completeTelemetry[i][3];
-        totalcurrent[idx] = completeTelemetry[i][4];
-        count[idx] = completeTelemetry[i][5];
-        if (i % 4 == 3 || i == MOTOR_COUNT_MAX - 1) {
+        temperature[idx] = _telemetry[i][OW_TLM_TEMP];
+        voltage[idx] = _telemetry[i][OW_TLM_VOLT];
+        current[idx] = _telemetry[i][OW_TLM_CURRENT];
+        rpm[idx] = _telemetry[i][OW_TLM_ERPM];
+        totalcurrent[idx] = _telemetry[i][OW_TLM_CONSUMPTION];
+        count[idx] = _telemetry[i][5];
+        if (idx == 3 || i == MOTOR_COUNT_MAX - 1) {
             if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
                 return;
             }
+            static_assert(MOTOR_COUNT_MAX <= 12, "AP_FETtecOneWire::send_esc_telemetry_mavlink() support 12 or less motors");
             if (i < 4) {
                 mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
-            } else {
+            } else if (i < 8) {
                 mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
+            } else {
+                mavlink_msg_esc_telemetry_9_to_12_send((mavlink_channel_t)mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
             }
         }
     }
 }
 
-/*
+/**
     initialize FETtecOneWire protocol
 */
-void AP_FETtecOneWire::FETtecOneWire_Init()
+void AP_FETtecOneWire::Init()
 {
-    if (FETtecOneWire_firstInitDone == 0) {
-        FETtecOneWire_FoundESCs = 0;
-        FETtecOneWire_ScanActive = 0;
-        FETtecOneWire_SetupActive = 0;
-        FETtecOneWire_minID = 25;
-        FETtecOneWire_maxID = 0;
-        FETtecOneWire_IDcount = 0;
-        FETtecOneWire_FastThrottleByteCount = 0;
-        for (uint8_t i = 0; i < 25; i++) {
-            FETtecOneWire_activeESC_IDs[i] = 0;
+    // TODO: move this entire code inside AP_FETtecOneWire::init()
+    if (_firstInitDone == 0) {
+        _FoundESCs = 0;
+        _ScanActive = 0;
+        _SetupActive = 0;
+        _minID = MOTOR_COUNT_MAX;
+        _maxID = 0;
+        _IDcount = 0;
+        _FastThrottleByteCount = 0;
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+            _activeESC_IDs[i] = 0;
         }
     }
-    FETtecOneWire_IgnoreOwnBytes = 0;
-    FETtecOneWire_PullSuccess = 0;
-    FETtecOneWire_PullBusy = 0;
-    FETtecOneWire_firstInitDone = 1;
+    _IgnoreOwnBytes = 0;
+    _PullSuccess = 0;
+    _PullBusy = 0;
+    _firstInitDone = 1;
 }
 
-/*
+/**
     generates used 8 bit CRC
-    crc = byte to be added to CRC
-    crc_seed = CRC where it gets added too
-    returns 8 bit CRC
+    @param crc byte to be added to CRC
+    @param crc_seed CRC where it gets added too
+    @return 8 bit CRC
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed)
+uint8_t AP_FETtecOneWire::Update_crc8(uint8_t crc, uint8_t crc_seed) const
 {
+    // TODO: is there a similar CRC function in the ArduPilot codebase already?
+    // If yes, remove this one and use that instead
     uint8_t crc_u, i;
     crc_u = crc;
     crc_u ^= crc_seed;
@@ -298,33 +304,32 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed
     return (crc_u);
 }
 
-/*
+/**
     generates used 8 bit CRC for arrays
-    Buf = 8 bit byte array
-    BufLen = count of bytes that should be used for CRC calculation
-    returns 8 bit CRC
+    @param Buf 8 bit byte array
+    @param BufLen count of bytes that should be used for CRC calculation
+    @return 8 bit CRC
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen)
+uint8_t AP_FETtecOneWire::Get_crc8(uint8_t* Buf, uint16_t BufLen) const
 {
     uint8_t crc = 0;
     for (uint16_t i = 0; i < BufLen; i++) {
-        crc = FETtecOneWire_UpdateCrc8(Buf[i], crc);
+        crc = Update_crc8(Buf[i], crc);
     }
     return (crc);
 }
 
-/*
+/**
     transmitts a FETtecOneWire frame to a ESC
-    ESC_id = id of the ESC
-    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
-    Length = length of the Bytes array
-    returns nothing
+    @param ESC_id id of the ESC
+    @param Bytes 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    @param Length length of the Bytes array
 */
-void AP_FETtecOneWire::FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t* Bytes, uint8_t Length)
+void AP_FETtecOneWire::Transmit(uint8_t ESC_id, uint8_t* Bytes, uint8_t Length)
 {
     /*
-    a frame lookes like:
-    byte 1 = fremae header (master is always 0x01)
+    a frame looks like:
+    byte 1 = frame header (master is always 0x01)
     byte 2 = target ID (5bit)
     byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
     byte 5 = frame length over all bytes
@@ -336,23 +341,23 @@ void AP_FETtecOneWire::FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t* Bytes, ui
     for (uint8_t i = 0; i < Length; i++) {
         transmitArr[i + 5] = Bytes[i];
     }
-    transmitArr[Length + 5] = FETtecOneWire_GetCrc8(transmitArr, Length + 5); // crc
+    transmitArr[Length + 5] = Get_crc8(transmitArr, Length + 5); // crc
     _uart->write(transmitArr, Length + 6);
-    FETtecOneWire_IgnoreOwnBytes += Length + 6;
+    _IgnoreOwnBytes += Length + 6;
 }
 
-/*
+/**
     reads the answer frame of a ESC
-    Bytes = 8 bit byte array, where the received answer gets stored in
-    Length = the expected answer length
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the expected answer frame was there, 0 if dont
+    @param Bytes 8 bit byte array, where the received answer gets stored in
+    @param Length the expected answer length
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the expected answer frame was there, 0 if dont
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, uint8_t returnFullFrame)
+uint8_t AP_FETtecOneWire::Receive(uint8_t* Bytes, uint8_t Length, uint8_t returnFullFrame)
 {
     /*
-    a frame lookes like:
-    byte 1 = fremae header (0x02 = bootloader, 0x03 = ESC firmware)
+    a frame looks like:
+    byte 1 = frame header (0x02 = bootloader, 0x03 = ESC firmware)
     byte 2 = sender ID (5bit)
     byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
     byte 5 = frame length over all bytes
@@ -361,8 +366,8 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, 
     */
 
     //ignore own bytes
-    while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
-        FETtecOneWire_IgnoreOwnBytes--;
+    while (_IgnoreOwnBytes > 0 && _uart->available()) {
+        _IgnoreOwnBytes--;
         _uart->read();
     }
     // look for the real answer
@@ -381,7 +386,7 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, 
                 ReceiveBuf[i] = _uart->read();
             }
             // check CRC
-            if (FETtecOneWire_GetCrc8(ReceiveBuf, Length + 5) == ReceiveBuf[Length + 5]) {
+            if (Get_crc8(ReceiveBuf, Length + 5) == ReceiveBuf[Length + 5]) {
                 if (!returnFullFrame) {
                     for (uint8_t i = 0; i < Length; i++) {
                         Bytes[i] = ReceiveBuf[5 + i];
@@ -403,315 +408,268 @@ uint8_t AP_FETtecOneWire::FETtecOneWire_Receive(uint8_t* Bytes, uint8_t Length, 
     } // no answer yet
 }
 
-/*
-    makes all connected ESC's beep
-    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
-*/
-void AP_FETtecOneWire::FETtecOneWire_Beep(uint8_t beepFreqency)
-{
-    if (FETtecOneWire_IDcount > 0) {
-        uint8_t request[2] = {OW_BEEP, beepFreqency};
-        uint8_t spacer[2] = {0, 0};
-        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
-            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
-            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
-            _uart->write(spacer, 2);
-            FETtecOneWire_IgnoreOwnBytes += 2;
-        }
-    }
-}
-
-/*
-    sets the racewire color for all ESC's
-    R, G, B = 8bit colors
-*/
-void AP_FETtecOneWire::FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
-{
-    if (FETtecOneWire_IDcount > 0) {
-        uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
-        uint8_t spacer[2] = {0, 0};
-        for (uint8_t i = FETtecOneWire_minID; i < FETtecOneWire_maxID + 1; i++) {
-            FETtecOneWire_Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
-            // add two zeros to make sure all ESC's can catch their command as we dont wait for a response here
-            _uart->write(spacer, 2);
-            FETtecOneWire_IgnoreOwnBytes += 2;
-        }
-    }
-}
-
-/*
+/**
     Resets a pending pull request
-    returns nothing
 */
-void AP_FETtecOneWire::FETtecOneWire_PullReset()
+void AP_FETtecOneWire::PullReset()
 {
-    FETtecOneWire_PullSuccess = 0;
-    FETtecOneWire_PullBusy = 0;
+    _PullSuccess = 0;
+    _PullBusy = 0;
 }
 
-/*
+/**
     Pulls a complete request between for ESC
-    ESC_id = id of the ESC
-    command = 8bit array containing the command that thould be send including the possible payload
-    response = 8bit array where the response will be stored in
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the request is completed, 0 if dont
+    @param ESC_id  id of the ESC
+    @param command 8bit array containing the command that should be send including the possible payload
+    @param response 8bit array where the response will be stored in
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the request is completed, 0 if dont
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t* command, uint8_t* response,
+uint8_t AP_FETtecOneWire::PullCommand(uint8_t ESC_id, uint8_t* command, uint8_t* response,
         uint8_t returnFullFrame)
 {
-    if (!FETtecOneWire_PullBusy) {
-        FETtecOneWire_PullBusy = 1;
-        FETtecOneWire_PullSuccess = 0;
-        FETtecOneWire_Transmit(ESC_id, command, FETtecOneWire_RequestLength[command[0]]);
+    if (!_PullBusy) {
+        _PullBusy = 1;
+        _PullSuccess = 0;
+        Transmit(ESC_id, command, _RequestLength[command[0]]);
     } else {
-        if (FETtecOneWire_Receive(response, FETtecOneWire_ResponseLength[command[0]], returnFullFrame)) {
-            FETtecOneWire_PullSuccess = 1;
-            FETtecOneWire_PullBusy = 0;
+        if (Receive(response, _ResponseLength[command[0]], returnFullFrame)) {
+            _PullSuccess = 1;
+            _PullBusy = 0;
         }
     }
-    return FETtecOneWire_PullSuccess;
+    return _PullSuccess;
 }
 
-/*
-    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
-    returns the currend scanned ID
+/**
+    scans for ESCs in bus. should be called until _ScanActive >= MOTOR_COUNT_MAX
+    @return the current scanned ID
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_ScanESCs()
+uint8_t AP_FETtecOneWire::ScanESCs()
 {
-    static uint16_t delayLoops = 500;
-    static uint8_t scanID = 0;
-    static uint8_t scanState = 0;
-    static uint8_t scanTimeOut = 0;
     uint8_t response[18] = {0};
     uint8_t request[1] = {0};
-    if (FETtecOneWire_ScanActive == 0) {
-        delayLoops = 500;
-        scanID = 0;
-        scanState = 0;
-        scanTimeOut = 0;
-        return FETtecOneWire_ScanActive + 1;
+    if (_ScanActive == 0) {
+        _ss.delayLoops = 500;
+        _ss.scanID = 0;
+        _ss.scanState = 0;
+        _ss.scanTimeOut = 0;
+        return _ScanActive + 1;
     }
-    if (delayLoops > 0) {
-        delayLoops--;
-        return FETtecOneWire_ScanActive;
+    if (_ss.delayLoops > 0) {
+        _ss.delayLoops--;
+        return _ScanActive;
     }
-    if (scanID < FETtecOneWire_ScanActive) {
-        scanID = FETtecOneWire_ScanActive;
-        scanState = 0;
-        scanTimeOut = 0;
+    if (_ss.scanID < _ScanActive) {
+        _ss.scanID = _ScanActive;
+        _ss.scanState = 0;
+        _ss.scanTimeOut = 0;
     }
-    if (scanTimeOut == 3 || scanTimeOut == 6 || scanTimeOut == 9 || scanTimeOut == 12) {
-        FETtecOneWire_PullReset();
+    if (_ss.scanTimeOut == 3 || _ss.scanTimeOut == 6 || _ss.scanTimeOut == 9 || _ss.scanTimeOut == 12) {
+        PullReset();
     }
-    if (scanTimeOut < 15) {
-        switch (scanState) {
+    if (_ss.scanTimeOut < 15) {
+        switch (_ss.scanState) {
         case 0:request[0] = OW_OK;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_FULL_FRAME)) {
-                scanTimeOut = 0;
-                FETtecOneWire_activeESC_IDs[scanID] = 1;
-                FETtecOneWire_FoundESCs++;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_FULL_FRAME)) {
+                _ss.scanTimeOut = 0;
+                _activeESC_IDs[_ss.scanID] = 1;
+                _FoundESCs++;
                 if (response[0] == 0x02) {
-                    FETtecOneWire_foundESCs[scanID].inBootLoader = 1;
+                    _foundESCs[_ss.scanID].inBootLoader = 1;
                 } else {
-                    FETtecOneWire_foundESCs[scanID].inBootLoader = 0;
+                    _foundESCs[_ss.scanID].inBootLoader = 0;
                 }
-                delayLoops = 1;
-                scanState++;
+                _ss.delayLoops = 1;
+                _ss.scanState++;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         case 1:request[0] = OW_REQ_TYPE;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
-                scanTimeOut = 0;
-                FETtecOneWire_foundESCs[scanID].ESCtype = response[0];
-                delayLoops = 1;
-                scanState++;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
+                _ss.scanTimeOut = 0;
+                _foundESCs[_ss.scanID].ESCtype = response[0];
+                _ss.delayLoops = 1;
+                _ss.scanState++;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         case 2:request[0] = OW_REQ_SW_VER;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
-                scanTimeOut = 0;
-                FETtecOneWire_foundESCs[scanID].firmWareVersion = response[0];
-                FETtecOneWire_foundESCs[scanID].firmWareSubVersion = response[1];
-                delayLoops = 1;
-                scanState++;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
+                _ss.scanTimeOut = 0;
+                _foundESCs[_ss.scanID].firmWareVersion = response[0];
+                _foundESCs[_ss.scanID].firmWareSubVersion = response[1];
+                _ss.delayLoops = 1;
+                _ss.scanState++;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         case 3:request[0] = OW_REQ_SN;
-            if (FETtecOneWire_PullCommand(scanID, request, response, OW_RETURN_RESPONSE)) {
-                scanTimeOut = 0;
+            if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
+                _ss.scanTimeOut = 0;
                 for (uint8_t i = 0; i < 12; i++) {
-                    FETtecOneWire_foundESCs[scanID].serialNumber[i] = response[i];
+                    _foundESCs[_ss.scanID].serialNumber[i] = response[i];
                 }
-                delayLoops = 1;
-                return scanID + 1;
+                _ss.delayLoops = 1;
+                return _ss.scanID + 1;
             } else {
-                scanTimeOut++;
+                _ss.scanTimeOut++;
             }
             break;
         }
     } else {
-        FETtecOneWire_PullReset();
-        return scanID + 1;
+        PullReset();
+        return _ss.scanID + 1;
     }
-    return scanID;
+    return _ss.scanID;
 }
 
-/*
-    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
-    returns the current used ID
+/**
+    starts all ESCs in bus and prepares them for receiving the fast throttle command should be called until _SetupActive >= MOTOR_COUNT_MAX
+    @return the current used ID
 */
-uint8_t AP_FETtecOneWire::FETtecOneWire_InitESCs()
+uint8_t AP_FETtecOneWire::InitESCs()
 {
-    static uint8_t delayLoops = 0;
-    static uint8_t activeID = 1;
-    static uint8_t State = 0;
-    static uint8_t TimeOut = 0;
-    static uint8_t wakeFromBL = 1;
-    static uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
     uint8_t response[18] = {0};
     uint8_t request[1] = {0};
-    if (FETtecOneWire_SetupActive == 0) {
-        delayLoops = 0;
-        activeID = 1;
-        State = 0;
-        TimeOut = 0;
-        wakeFromBL = 1;
-        return FETtecOneWire_SetupActive + 1;
+    if (_SetupActive == 0) {
+        _is.delayLoops = 0;
+        _is.activeID = 1;
+        _is.State = 0;
+        _is.TimeOut = 0;
+        _is.wakeFromBL = 1;
+        return _SetupActive + 1;
     }
-    while (FETtecOneWire_activeESC_IDs[FETtecOneWire_SetupActive] == 0 && FETtecOneWire_SetupActive < 25) {
-        FETtecOneWire_SetupActive++;
+    while (_activeESC_IDs[_SetupActive] == 0 && _SetupActive < MOTOR_COUNT_MAX) {
+        _SetupActive++;
     }
 
-    if (FETtecOneWire_SetupActive == 25 && wakeFromBL == 0) {
-        return FETtecOneWire_SetupActive;
-    } else if (FETtecOneWire_SetupActive == 25 && wakeFromBL) {
-        wakeFromBL = 0;
-        activeID = 1;
-        FETtecOneWire_SetupActive = 1;
-        State = 0;
-        TimeOut = 0;
+    if (_SetupActive == MOTOR_COUNT_MAX && _is.wakeFromBL == 0) {
+        return _SetupActive;
+    } else if (_SetupActive == MOTOR_COUNT_MAX && _is.wakeFromBL) {
+        _is.wakeFromBL = 0;
+        _is.activeID = 1;
+        _SetupActive = 1;
+        _is.State = 0;
+        _is.TimeOut = 0;
 
-        FETtecOneWire_minID = 25;
-        FETtecOneWire_maxID = 0;
-        FETtecOneWire_IDcount = 0;
-        for (uint8_t i = 0; i < 25; i++) {
-            if (FETtecOneWire_activeESC_IDs[i] != 0) {
-                FETtecOneWire_IDcount++;
-                if (i < FETtecOneWire_minID) {
-                    FETtecOneWire_minID = i;
+        _minID = MOTOR_COUNT_MAX;
+        _maxID = 0;
+        _IDcount = 0;
+        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
+            if (_activeESC_IDs[i] != 0) {
+                _IDcount++;
+                if (i < _minID) {
+                    _minID = i;
                 }
-                if (i > FETtecOneWire_maxID) {
-                    FETtecOneWire_maxID = i;
+                if (i > _maxID) {
+                    _maxID = i;
                 }
             }
         }
 
-        if (FETtecOneWire_IDcount == 0
-                || FETtecOneWire_maxID - FETtecOneWire_minID > FETtecOneWire_IDcount - 1) { // loop forever
-            wakeFromBL = 1;
-            return activeID;
+        if (_IDcount == 0
+                || _maxID - _minID > _IDcount - 1) { // loop forever
+            _is.wakeFromBL = 1;
+            return _is.activeID;
         }
-        FETtecOneWire_FastThrottleByteCount = 1;
-        int8_t bitCount = 12 + (FETtecOneWire_IDcount * 11);
+        _FastThrottleByteCount = 1;
+        int8_t bitCount = 12 + (_IDcount * 11);
         while (bitCount > 0) {
-            FETtecOneWire_FastThrottleByteCount++;
+            _FastThrottleByteCount++;
             bitCount -= 8;
         }
-        setFastCommand[1] = FETtecOneWire_FastThrottleByteCount; // just for older ESC FW versions since 1.0 001 this byte is ignored as the ESC calculates it itself
-        setFastCommand[2] = FETtecOneWire_minID;                 // min ESC id
-        setFastCommand[3] = FETtecOneWire_IDcount;                 // count of ESC's that will get signals
+        _is.setFastCommand[1] = _FastThrottleByteCount; // just for older ESC FW versions since 1.0 001 this byte is ignored as the ESC calculates it itself
+        _is.setFastCommand[2] = _minID;                 // min ESC id
+        _is.setFastCommand[3] = _IDcount;               // count of ESCs that will get signals
     }
 
-    if (delayLoops > 0) {
-        delayLoops--;
-        return FETtecOneWire_SetupActive;
+    if (_is.delayLoops > 0) {
+        _is.delayLoops--;
+        return _SetupActive;
     }
 
-    if (activeID < FETtecOneWire_SetupActive) {
-        activeID = FETtecOneWire_SetupActive;
-        State = 0;
-        TimeOut = 0;
+    if (_is.activeID < _SetupActive) {
+        _is.activeID = _SetupActive;
+        _is.State = 0;
+        _is.TimeOut = 0;
     }
 
-    if (TimeOut == 3 || TimeOut == 6 || TimeOut == 9 || TimeOut == 12) {
-        FETtecOneWire_PullReset();
+    if (_is.TimeOut == 3 || _is.TimeOut == 6 || _is.TimeOut == 9 || _is.TimeOut == 12) {
+        PullReset();
     }
 
-    if (TimeOut < 15) {
-        if (wakeFromBL) {
-            switch (State) {
+    if (_is.TimeOut < 15) {
+        if (_is.wakeFromBL) {
+            switch (_is.State) {
             case 0:request[0] = OW_BL_START_FW;
-                if (FETtecOneWire_foundESCs[activeID].inBootLoader == 1) {
-                    FETtecOneWire_Transmit(activeID, request, FETtecOneWire_RequestLength[request[0]]);
-                    delayLoops = 5;
+                if (_foundESCs[_is.activeID].inBootLoader == 1) {
+                    Transmit(_is.activeID, request, _RequestLength[request[0]]);
+                    _is.delayLoops = 5;
                 } else {
-                    return activeID + 1;
+                    return _is.activeID + 1;
                 }
-                State = 1;
+                _is.State = 1;
                 break;
             case 1:request[0] = OW_OK;
-                if (FETtecOneWire_PullCommand(activeID, request, response, OW_RETURN_FULL_FRAME)) {
-                    TimeOut = 0;
+                if (PullCommand(_is.activeID, request, response, OW_RETURN_FULL_FRAME)) {
+                    _is.TimeOut = 0;
                     if (response[0] == 0x02) {
-                        FETtecOneWire_foundESCs[activeID].inBootLoader = 1;
-                        State = 0;
+                        _foundESCs[_is.activeID].inBootLoader = 1;
+                        _is.State = 0;
                     } else {
-                        FETtecOneWire_foundESCs[activeID].inBootLoader = 0;
-                        delayLoops = 1;
-                        return activeID + 1;
+                        _foundESCs[_is.activeID].inBootLoader = 0;
+                        _is.delayLoops = 1;
+                        return _is.activeID + 1;
                     }
                 } else {
-                    TimeOut++;
+                    _is.TimeOut++;
                 }
                 break;
             }
         } else {
-            if (FETtecOneWire_PullCommand(activeID, setFastCommand, response, OW_RETURN_RESPONSE)) {
-                TimeOut = 0;
-                delayLoops = 1;
-                return activeID + 1;
+            if (PullCommand(_is.activeID, _is.setFastCommand, response, OW_RETURN_RESPONSE)) {
+                _is.TimeOut = 0;
+                _is.delayLoops = 1;
+                return _is.activeID + 1;
             } else {
-                TimeOut++;
+                _is.TimeOut++;
             }
         }
     } else {
-        FETtecOneWire_PullReset();
-        return activeID + 1;
+        PullReset();
+        return _is.activeID + 1;
     }
-    return activeID;
+    return _is.activeID;
 }
 
-/*
+/**
     checks if the requested telemetry is available. 
-    Telemetry = 16bit array where the read Telemetry will be stored in. 
-    returns the telemetry request number or -1 if unavailable
+    @param Telemetry 16bit array where the read Telemetry will be stored in.
+    @return the telemetry request number or -1 if unavailable
 */
-int8_t AP_FETtecOneWire::FETtecOneWire_CheckForTLM(uint16_t* Telemetry)
+int8_t AP_FETtecOneWire::CheckForTLM(uint16_t* Telemetry)
 {
     int8_t return_TLM_request = 0;
-    if (FETtecOneWire_IDcount > 0) {
+    if (_IDcount > 0) {
         // empty buffer
-        while (FETtecOneWire_IgnoreOwnBytes > 0 && _uart->available()) {
+        while (_IgnoreOwnBytes > 0 && _uart->available()) {
             _uart->read();
-            FETtecOneWire_IgnoreOwnBytes--;
+            _IgnoreOwnBytes--;
         }
 
         // first two byte are the ESC Telemetry of the first ESC. next two byte of the second....
-        if (_uart->available() == (FETtecOneWire_IDcount * 2) + 1u) {
+        if (_uart->available() == (_IDcount * 2) + 1u) {
             // look if first byte in buffer is equal to last byte of throttle command (crc)
-            if (_uart->read() == FETtecOneWire_lastCRC) {
-                for (uint8_t i = 0; i < FETtecOneWire_IDcount; i++) {
+            if (_uart->read() == _lastCRC) {
+                for (uint8_t i = 0; i < _IDcount; i++) {
                     Telemetry[i] = _uart->read() << 8;
                     Telemetry[i] |= _uart->read();
                 }
-                return_TLM_request = FETtecOneWire_TLM_request;
+                return_TLM_request = _TLM_request;
             } else {
                 return_TLM_request = -1;
             }
@@ -724,55 +682,55 @@ int8_t AP_FETtecOneWire::FETtecOneWire_CheckForTLM(uint16_t* Telemetry)
     return return_TLM_request;
 }
 
-/*
+/**
     does almost all of the job.
-    scans for ESC's if not already done.
-    initializes the ESC's if not already done.
+    scans for ESCs if not already done.
+    initializes the ESCs if not already done.
     sends fast throttle signals if init is complete.
-    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
-    Telemetry = 16bit array where the read telemetry will be stored in. 
-    motorCount = the count of motors that should get values send
-    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
-    returns the telemetry request if telemetry was available, -1 if dont
+    @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    @param Telemetry 16bit array where the read telemetry will be stored in.
+    @param motorCount the count of motors that should get values send
+    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @return the telemetry request if telemetry was available, -1 if dont
 */
-int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,
+int8_t AP_FETtecOneWire::ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,
         uint8_t tlmRequest)
 {
     int8_t return_TLM_request = -2;
 
     // init should not be done too fast. as at last the bootloader has some timing requirements with messages. so loop delays must fit more or less
-    if (FETtecOneWire_ScanActive < 25 || FETtecOneWire_SetupActive < 25) {
+    if (_ScanActive < MOTOR_COUNT_MAX || _SetupActive < MOTOR_COUNT_MAX) {
         const uint32_t now = AP_HAL::micros();
-        if (now - last_send_us < DELAY_TIME_US) {
+        if (now - _last_send_us < DELAY_TIME_US) {
             return 0;
         } else {
-            last_send_us = now;
+            _last_send_us = now;
         }
 
-        if (FETtecOneWire_ScanActive < 25) {
-            // scan for all ESC's in onewire bus
-            FETtecOneWire_ScanActive = FETtecOneWire_ScanESCs();
-        } else if (FETtecOneWire_SetupActive < 25) {
-            if (FETtecOneWire_FoundESCs == 0) {
-                FETtecOneWire_ScanActive = 0;
+        if (_ScanActive < MOTOR_COUNT_MAX) {
+            // scan for all ESCs in onewire bus
+            _ScanActive = ScanESCs();
+        } else if (_SetupActive < MOTOR_COUNT_MAX) {
+            if (_FoundESCs == 0) {
+                _ScanActive = 0;
             } else {
-                // check if in bootloader, start ESC's FW if they are and prepare fast throttle command
-                FETtecOneWire_SetupActive = FETtecOneWire_InitESCs();
+                // check if in bootloader, start ESCs FW if they are and prepare fast throttle command
+                _SetupActive = InitESCs();
             }
         }
     } else {
         //send fast throttle signals
-        if (FETtecOneWire_IDcount > 0) {
+        if (_IDcount > 0) {
 
             // check for telemetry
-            return_TLM_request = FETtecOneWire_CheckForTLM(Telemetry);
-            FETtecOneWire_TLM_request = tlmRequest;
+            return_TLM_request = CheckForTLM(Telemetry);
+            _TLM_request = tlmRequest;
 
             //prepare fast throttle signals
             uint16_t useSignals[24] = {0};
             uint8_t OneWireFastThrottleCommand[36] = {0};
-            if (motorCount > FETtecOneWire_IDcount) {
-                motorCount = FETtecOneWire_IDcount;
+            if (motorCount > _IDcount) {
+                motorCount = _IDcount;
             }
             for (uint8_t i = 0; i < motorCount; i++) {
                 useSignals[i] = constrain_int16(motorValues[i], 0, 2000);
@@ -787,7 +745,7 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
             // B = TLM request type (temp, volt, current, erpm, consumption, debug1, debug2, debug3)
             // C = first bit from first throttle signal
             // D = frame header
-            OneWireFastThrottleCommand[0] = 128 | (FETtecOneWire_TLM_request << 4);
+            OneWireFastThrottleCommand[0] = 128 | (_TLM_request << 4);
             OneWireFastThrottleCommand[0] |= ((useSignals[actThrottleCommand] >> 10) & 0x01) << 3;
             OneWireFastThrottleCommand[0] |= 0x01;
 
@@ -798,11 +756,11 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
             OneWireFastThrottleCommand[1] = (((useSignals[actThrottleCommand] >> 7) & 0x07)) << 5;
             OneWireFastThrottleCommand[1] |= ALL_ID;
 
-            // following bytes are the rest 7 bit of the first (11bit)throttle signal, and all bit from all other signals, followed by the CRC byte
+            // following bytes are the rest 7 bit of the first (11bit) throttle signal, and all bit from all other signals, followed by the CRC byte
             uint8_t BitsLeftFromCommand = 7;
             uint8_t actByte = 2;
             uint8_t bitsFromByteLeft = 8;
-            uint8_t bitsToAddLeft = (12 + (((FETtecOneWire_maxID - FETtecOneWire_minID) + 1) * 11)) - 16;
+            uint8_t bitsToAddLeft = (12 + (((_maxID - _minID) + 1) * 11)) - 16;
             while (bitsToAddLeft > 0) {
                 if (bitsFromByteLeft >= BitsLeftFromCommand) {
                     OneWireFastThrottleCommand[actByte] |=
@@ -836,15 +794,15 @@ int8_t AP_FETtecOneWire::FETtecOneWire_ESCsSetValues(uint16_t* motorValues, uint
             }
 
             // send throttle signal
-            OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1] = FETtecOneWire_GetCrc8(
-                    OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount - 1);
-            _uart->write(OneWireFastThrottleCommand, FETtecOneWire_FastThrottleByteCount);
+            OneWireFastThrottleCommand[_FastThrottleByteCount - 1] = Get_crc8(
+                    OneWireFastThrottleCommand, _FastThrottleByteCount - 1);
+            _uart->write(OneWireFastThrottleCommand, _FastThrottleByteCount);
             // last byte of signal can be used to make sure the first TLM byte is correct, in case of spike corruption
-            FETtecOneWire_IgnoreOwnBytes = FETtecOneWire_FastThrottleByteCount - 1;
-            FETtecOneWire_lastCRC = OneWireFastThrottleCommand[FETtecOneWire_FastThrottleByteCount - 1];
-            // the ESC's will answer the TLM as 16bit each ESC, so 2byte each ESC.
+            _IgnoreOwnBytes = _FastThrottleByteCount - 1;
+            _lastCRC = OneWireFastThrottleCommand[_FastThrottleByteCount - 1];
+            // the ESCs will answer the TLM as 16bit each ESC, so 2byte each ESC.
         }
     }
-    return return_TLM_request; // returns the readed tlm as it is 1 loop delayed
+    return return_TLM_request; // returns the read tlm as it is 1 loop delayed
 }
 #endif  // HAL_AP_FETTECONEWIRE_ENABLED

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -197,15 +197,6 @@ void AP_FETtecOneWire::update()
         // log at 10Hz
         if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-                // TODO: remove printfs
-                printf(" esc: %d", i + 1);
-                printf(" Temperature: %d", _telemetry[i][OW_TLM_TEMP]);
-                printf(", Voltage: %d", _telemetry[i][OW_TLM_VOLT]);
-                printf(", Current: %d", _telemetry[i][OW_TLM_CURRENT]);
-                printf(", E-rpm: %d", _telemetry[i][OW_TLM_ERPM]);
-                printf(", consumption: %d", _telemetry[i][OW_TLM_CONSUMPTION]);
-                printf("\n");
-
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
                         _telemetry[i][OW_TLM_ERPM] * 100U,

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -181,9 +181,9 @@ void AP_FETtecOneWire::update()
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
     _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
 
-    if (++_telem_req_type == OW_TLM_DEBUG1) {
-        // OW_TLM_DEBUG1, OW_TLM_DEBUG2, OW_TLM_DEBUG3 are ignored
-        _telem_req_type = OW_TLM_TEMP;
+    if (++_telem_req_type == telem_type::DEBUG1) {
+        // telem_type::DEBUG1, telem_type::DEBUG2, telem_type::DEBUG3 are ignored
+        _telem_req_type = telem_type::TEMP;
     }
 
     if (_telem_avail != -1) {
@@ -201,11 +201,11 @@ void AP_FETtecOneWire::update()
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
-                        _telemetry[i][OW_TLM_ERPM] * 100U,
-                        _telemetry[i][OW_TLM_VOLT],
-                        _telemetry[i][OW_TLM_CURRENT],
-                        _telemetry[i][OW_TLM_TEMP] * 100U,
-                        _telemetry[i][OW_TLM_CONSUMPTION],
+                        _telemetry[i][telem_type::ERPM] * 100U,
+                        _telemetry[i][telem_type::VOLT],
+                        _telemetry[i][telem_type::CURRENT],
+                        _telemetry[i][telem_type::TEMP] * 100U,
+                        _telemetry[i][telem_type::CONSUMPTION],
                         0,
                         0);
             }
@@ -233,11 +233,11 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
     // TODO: take the _telem_semaphore here
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
-        temperature[idx] = _telemetry[i][OW_TLM_TEMP];
-        voltage[idx] = _telemetry[i][OW_TLM_VOLT];
-        current[idx] = _telemetry[i][OW_TLM_CURRENT];
-        rpm[idx] = _telemetry[i][OW_TLM_ERPM];
-        totalcurrent[idx] = _telemetry[i][OW_TLM_CONSUMPTION];
+        temperature[idx] = _telemetry[i][telem_type::TEMP];
+        voltage[idx] = _telemetry[i][telem_type::VOLT];
+        current[idx] = _telemetry[i][telem_type::CURRENT];
+        rpm[idx] = _telemetry[i][telem_type::ERPM];
+        totalcurrent[idx] = _telemetry[i][telem_type::CONSUMPTION];
         count[idx] = _telemetry[i][5];
         if (idx == 3 || i == MOTOR_COUNT_MAX - 1) {
             if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
@@ -684,7 +684,7 @@ int8_t AP_FETtecOneWire::CheckForTLM(uint16_t* Telemetry)
     @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
     @param Telemetry 16bit array where the read telemetry will be stored in.
     @param motorCount the count of motors that should get values send
-    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @param tlmRequest the requested telemetry type (telem_type::XXXXX)
     @return the telemetry request if telemetry was available, -1 if dont
 */
 int8_t AP_FETtecOneWire::ESCsSetValues(uint16_t* motorValues, uint16_t* Telemetry, uint8_t motorCount,

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -181,6 +181,7 @@ void AP_FETtecOneWire::update()
     uint16_t requestedTelemetry[MOTOR_COUNT_MAX] = {0};
     _telem_avail = ESCsSetValues(_motorpwm, requestedTelemetry, MOTOR_COUNT_MAX, _telem_req_type);
     if (_telem_avail != -1) {
+        // TODO: take the _telem_semaphore here
         for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
             _telemetry[i][_telem_avail] = requestedTelemetry[i];
             _telemetry[i][5]++;
@@ -196,6 +197,7 @@ void AP_FETtecOneWire::update()
         const uint32_t now = AP_HAL::millis();
         // log at 10Hz
         if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
+            // TODO: take the _telem_semaphore here
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
                 logger->Write_ESC(i,
                         AP_HAL::micros64(),
@@ -228,6 +230,7 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
     uint16_t totalcurrent[4] {};
     uint16_t rpm[4] {};
     uint16_t count[4] {};
+    // TODO: take the _telem_semaphore here
     for (uint8_t i=0; i<MOTOR_COUNT_MAX; i++) {
         uint8_t idx = i % 4;
         temperature[idx] = _telemetry[i][OW_TLM_TEMP];

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -194,25 +194,6 @@ void AP_FETtecOneWire::Init()
 }
 
 /**
-    generates used 8 bit CRC
-    @param crc byte to be added to CRC
-    @param crc_seed CRC where it gets added too
-    @return 8 bit CRC
-*/
-uint8_t AP_FETtecOneWire::Update_crc8(uint8_t crc, uint8_t crc_seed) const
-{
-    // TODO: is there a similar CRC function in the ArduPilot codebase already?
-    // If yes, remove this one and use that instead
-    uint8_t crc_u, i;
-    crc_u = crc;
-    crc_u ^= crc_seed;
-    for (i = 0; i < 8; i++) {
-        crc_u = (crc_u & 0x80) ? 0x7 ^ (crc_u << 1) : (crc_u << 1);
-    }
-    return (crc_u);
-}
-
-/**
     generates used 8 bit CRC for arrays
     @param Buf 8 bit byte array
     @param BufLen count of bytes that should be used for CRC calculation
@@ -222,7 +203,7 @@ uint8_t AP_FETtecOneWire::Get_crc8(uint8_t* Buf, uint16_t BufLen) const
 {
     uint8_t crc = 0;
     for (uint16_t i = 0; i < BufLen; i++) {
-        crc = Update_crc8(Buf[i], crc);
+        crc = crc8_telem(Buf[i], crc);
     }
     return (crc);
 }

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -64,7 +64,6 @@ void AP_FETtecOneWire::init()
     if (_uart) {
         _uart->begin(2000000);
     }
-    Init();
 }
 
 void AP_FETtecOneWire::update()
@@ -134,30 +133,6 @@ void AP_FETtecOneWire::update()
             esc_mask <<= 1;
         }
     }
-}
-
-/**
-    initialize FETtecOneWire protocol
-*/
-void AP_FETtecOneWire::Init()
-{
-    // TODO: move this entire code inside AP_FETtecOneWire::init()
-    if (_firstInitDone == 0) {
-        _FoundESCs = 0;
-        _ScanActive = 0;
-        _SetupActive = 0;
-        _minID = MOTOR_COUNT_MAX;
-        _maxID = 0;
-        _IDcount = 0;
-        _FastThrottleByteCount = 0;
-        for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            _activeESC_IDs[i] = 0;
-        }
-    }
-    _IgnoreOwnBytes = 0;
-    _PullSuccess = 0;
-    _PullBusy = 0;
-    _firstInitDone = 1;
 }
 
 /**

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -30,6 +30,7 @@ const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
     // @DisplayName: Channel Bitmask
     // @Description: Enable of FETtec OneWire ESC protocol to specific channels
     // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
+    // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO("MASK",  1, AP_FETtecOneWire, motor_mask, 0),
 

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
     // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO("MASK",  1, AP_FETtecOneWire, motor_mask, 0),
-    AP_GROUPINFO("POLES",  2, AP_FETtecOneWire, pole_count, 0),
+    AP_GROUPINFO("POLES",  2, AP_FETtecOneWire, pole_count, 14),
     
     AP_GROUPEND
 };
@@ -123,7 +123,10 @@ void AP_FETtecOneWire::update()
                     break;
 
                 case telem_type::ERPM:
-                    update_rpm(i, requestedTelemetry[i]*100/(pole_count/2));
+                if (pole_count <2){ //If Parameter is invalid use 14 Poles
+                    pole_count = 14;
+                }
+                    update_rpm(i, requestedTelemetry[i]*100/(pole_count.get()/2));
                     break;
 
                 case telem_type::CONSUMPTION:

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -107,7 +107,7 @@ void AP_FETtecOneWire::update()
             if (mask & esc_mask) { // only update telemetry of enabled ESCs
                 switch(_telem_avail) {
                 case telem_type::TEMP:
-                    t.temperature_deg = requestedTelemetry[i],
+                    t.temperature_deg = int16_t(requestedTelemetry[i]),
                     update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
                     break;
 

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -102,32 +102,36 @@ void AP_FETtecOneWire::update()
 
     if (_telem_avail != -1) {
         TelemetryData t {};
+        uint16_t esc_mask = 1;
         for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
-            switch(_telem_avail) {
-            case telem_type::TEMP:
-                t.temperature_deg = requestedTelemetry[i],
-                update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
-                break;
+            if (mask & esc_mask) { // only update telemetry of enabled ESCs
+                switch(_telem_avail) {
+                case telem_type::TEMP:
+                    t.temperature_deg = requestedTelemetry[i],
+                    update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
+                    break;
 
-            case telem_type::VOLT:
-                t.voltage_cv = requestedTelemetry[i];
-                update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::VOLTAGE);
-                break;
+                case telem_type::VOLT:
+                    t.voltage_cv = requestedTelemetry[i];
+                    update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::VOLTAGE);
+                    break;
 
-            case telem_type::CURRENT:
-                t.current_ca = requestedTelemetry[i];
-                update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::CURRENT);
-                break;
+                case telem_type::CURRENT:
+                    t.current_ca = requestedTelemetry[i];
+                    update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::CURRENT);
+                    break;
 
-            case telem_type::ERPM:
-                update_rpm(i, requestedTelemetry[i]);
-                break;
+                case telem_type::ERPM:
+                    update_rpm(i, requestedTelemetry[i]);
+                    break;
 
-            case telem_type::CONSUMPTION:
-                t.consumption_mah = requestedTelemetry[i];
-                update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION);
-                break;
+                case telem_type::CONSUMPTION:
+                    t.consumption_mah = requestedTelemetry[i];
+                    update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION);
+                    break;
+                }
             }
+            esc_mask <<= 1;
         }
     }
 }

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -33,7 +33,8 @@ const AP_Param::GroupInfo AP_FETtecOneWire::var_info[] = {
     // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO("MASK",  1, AP_FETtecOneWire, motor_mask, 0),
-
+    AP_GROUPINFO("POLES",  2, AP_FETtecOneWire, pole_count, 0),
+    
     AP_GROUPEND
 };
 
@@ -107,7 +108,7 @@ void AP_FETtecOneWire::update()
             if (mask & esc_mask) { // only update telemetry of enabled ESCs
                 switch(_telem_avail) {
                 case telem_type::TEMP:
-                    t.temperature_deg = int16_t(requestedTelemetry[i]),
+                    t.temperature_deg = int16_t(requestedTelemetry[i]);
                     update_telem_data(i, t, AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
                     break;
 
@@ -122,7 +123,7 @@ void AP_FETtecOneWire::update()
                     break;
 
                 case telem_type::ERPM:
-                    update_rpm(i, requestedTelemetry[i]);
+                    update_rpm(i, requestedTelemetry[i]*100/(pole_count/2));
                     break;
 
                 case telem_type::CONSUMPTION:

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -321,7 +321,9 @@ uint8_t AP_FETtecOneWire::ScanESCs()
         case 1:request[0] = OW_REQ_TYPE;
             if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
                 _ss.scanTimeOut = 0;
+#if HAL_AP_FETTECONEWIRE_GET_STATIC_INFO
                 _foundESCs[_ss.scanID].ESCtype = response[0];
+#endif
                 _ss.delayLoops = 1;
                 _ss.scanState++;
             } else {
@@ -331,8 +333,10 @@ uint8_t AP_FETtecOneWire::ScanESCs()
         case 2:request[0] = OW_REQ_SW_VER;
             if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
                 _ss.scanTimeOut = 0;
+#if HAL_AP_FETTECONEWIRE_GET_STATIC_INFO
                 _foundESCs[_ss.scanID].firmWareVersion = response[0];
                 _foundESCs[_ss.scanID].firmWareSubVersion = response[1];
+#endif
                 _ss.delayLoops = 1;
                 _ss.scanState++;
             } else {
@@ -342,9 +346,11 @@ uint8_t AP_FETtecOneWire::ScanESCs()
         case 3:request[0] = OW_REQ_SN;
             if (PullCommand(_ss.scanID, request, response, OW_RETURN_RESPONSE)) {
                 _ss.scanTimeOut = 0;
+#if HAL_AP_FETTECONEWIRE_GET_STATIC_INFO
                 for (uint8_t i = 0; i < 12; i++) {
                     _foundESCs[_ss.scanID].serialNumber[i] = response[i];
                 }
+#endif
                 _ss.delayLoops = 1;
                 return _ss.scanID + 1;
             } else {

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -1,0 +1,256 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+    /* Protocol implementation was provided by FETtec */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#ifndef HAL_AP_FETTECONEWIRE_ENABLED
+#define HAL_AP_FETTECONEWIRE_ENABLED !HAL_MINIMIZE_FEATURES && !defined(HAL_BUILD_AP_PERIPH) && BOARD_FLASH_SIZE > 1024
+#endif
+
+#if HAL_AP_FETTECONEWIRE_ENABLED
+
+class AP_FETtecOneWire {
+public:
+    AP_FETtecOneWire();
+
+    void update();
+private:
+    void init();
+    bool initialised;
+    AP_HAL::UARTDriver *_uart;
+    uint32_t last_send_us;
+    static constexpr uint32_t DELAY_TIME_US = 700;
+    static constexpr uint8_t DETECT_ESC_COUNT = 4;  // TODO needed ?
+    static constexpr uint8_t MOTOR_COUNT = 4;
+    uint16_t completeTelemetry[MOTOR_COUNT][5] = {0};
+    uint16_t motorpwm[MOTOR_COUNT] = {1000};
+    uint8_t TLM_request = 0;
+    /*
+    initialize FETtecOneWire protocol
+*/
+    void FETtecOneWire_Init(void);
+
+/*
+    deinitialize FETtecOneWire protocol
+*/
+    void FETtecOneWire_DeInit(void);
+
+/*
+    generates used 8 bit CRC
+    crc = byte to be added to CRC
+    crc_seed = CRC where it gets added too
+    returns 8 bit CRC
+*/
+    uint8_t FETtecOneWire_Update_crc8(uint8_t crc, uint8_t crc_seed);
+
+/*
+    generates used 8 bit CRC for arrays
+    Buf = 8 bit byte array
+    BufLen = count of bytes that should be used for CRC calculation
+    returns 8 bit CRC
+*/
+    uint8_t FETtecOneWire_Get_crc8(uint8_t *Buf, uint16_t BufLen);
+
+/*
+    transmitts a FETtecOneWire frame to a ESC
+    ESC_id = id of the ESC
+    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    Length = length of the Bytes array
+    returns nothing
+*/
+    void FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t *Bytes, uint8_t Length);
+
+/*
+    reads the answer frame of a ESC
+    Bytes = 8 bit byte array, where the received answer gets stored in
+    Length = the expected answer length
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the expected answer frame was there, 0 if dont
+*/
+    uint8_t FETtecOneWire_Receive(uint8_t *Bytes, uint8_t Length, uint8_t returnFullFrame);
+
+/*
+    makes all connected ESC's beep
+    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
+*/
+    void FETtecOneWire_Beep(uint8_t beepFreqency);
+
+/*
+    sets the racewire color for all ESC's
+    R, G, B = 8bit colors
+*/
+    void FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B);
+
+/*
+    Resets a pending pull request
+    returns nothing
+*/
+    void FETtecOneWire_PullReset(void);
+
+/*
+    Pulls a complete request between for ESC
+    ESC_id = id of the ESC
+    command = 8bit array containing the command that thould be send including the possible payload
+    response = 8bit array where the response will be stored in
+    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    returns 1 if the request is completed, 0 if dont
+*/
+    uint8_t FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t *command, uint8_t *response, uint8_t returnFullFrame);
+
+/*
+    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
+    returns the current scanned ID
+*/
+    uint8_t FETtecOneWire_ScanESCs(void);
+
+/*
+    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
+    returns the current used ID
+*/
+    uint8_t FETtecOneWire_InitESCs(void);
+
+/*
+    checks if the requested telemetry is available.
+    Telemetry = 16bit array where the read Telemetry will be stored in.
+    returns the telemetry request number or -1 if unavailable
+*/
+    int8_t FETtecOneWire_CheckForTLM(uint16_t *Telemetry);
+
+/*
+    does almost all of the job.
+    scans for ESC's if not already done.
+    initializes the ESC's if not already done.
+    sends fast throttle signals if init is complete.
+    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    Telemetry = 16bit array where the read telemetry will be stored in.
+    motorCount = the count of motors that should get values send
+    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
+    returns the telemetry request if telemetry was available, -1 if dont
+*/
+    int8_t FETtecOneWire_ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
+
+    uint8_t FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed);  //TODO remove
+    uint8_t FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen);
+    static constexpr uint8_t ALL_ID = 0x1F;
+    typedef struct FETtecOneWireESC
+    {
+      uint8_t inBootLoader;
+      uint8_t firmWareVersion;
+      uint8_t firmWareSubVersion;
+      uint8_t ESCtype;
+      uint8_t serialNumber[12];
+    } FETtecOneWireESC_t;
+
+    uint8_t FETtecOneWire_activeESC_IDs[25] = {0};
+    FETtecOneWireESC_t FETtecOneWire_foundESCs[25];
+    uint8_t FETtecOneWire_FoundESCs = 0;
+    uint8_t FETtecOneWire_ScanActive = 0;
+    uint8_t FETtecOneWire_SetupActive = 0;
+    uint8_t FETtecOneWire_IgnoreOwnBytes = 0;
+    int8_t FETtecOneWire_minID = 25;
+    int8_t FETtecOneWire_maxID = 0;
+    uint8_t FETtecOneWire_IDcount = 0;
+    uint8_t FETtecOneWire_FastThrottleByteCount = 0;
+    uint8_t FETtecOneWire_PullSuccess = 0;
+    uint8_t FETtecOneWire_PullBusy = 0;
+    uint8_t FETtecOneWire_TLM_request = 0;
+    uint8_t FETtecOneWire_lastCRC = 0;
+    uint8_t FETtecOneWire_firstInitDone = 0;
+
+
+    enum
+    {
+      OW_RETURN_RESPONSE,
+      OW_RETURN_FULL_FRAME
+    };
+
+    enum
+    {
+      OW_OK,
+      OW_BL_PAGE_CORRECT,   // BL only
+      OW_NOT_OK,
+      OW_BL_START_FW,       // BL only
+      OW_BL_PAGES_TO_FLASH, // BL only
+      OW_REQ_TYPE,
+      OW_REQ_SN,
+      OW_REQ_SW_VER
+    };
+
+    enum
+    {
+      OW_RESET_TO_BL = 10,
+      OW_THROTTLE = 11,
+      OW_REQ_TLM = 12,
+      OW_BEEP = 13,
+
+      OW_SET_FAST_COM_LENGTH = 26,
+
+      OW_GET_ROTATION_DIRECTION = 28,
+      OW_SET_ROTATION_DIRECTION = 29,
+
+      OW_GET_USE_SIN_START = 30,
+      OW_SET_USE_SIN_START = 31,
+
+      OW_GET_3D_MODE = 32,
+      OW_SET_3D_MODE = 33,
+
+      OW_GET_ID = 34,
+      OW_SET_ID = 35,
+
+/*
+    OW_GET_LINEAR_THRUST = 36,
+    OW_SET_LINEAR_THRUST = 37,
+*/
+
+      OW_GET_EEVER = 38,
+
+      OW_GET_PWM_MIN = 39,
+      OW_SET_PWM_MIN = 40,
+
+      OW_GET_PWM_MAX = 41,
+      OW_SET_PWM_MAX = 42,
+
+      OW_GET_ESC_BEEP = 43,
+      OW_SET_ESC_BEEP = 44,
+
+      OW_GET_CURRENT_CALIB = 45,
+      OW_SET_CURRENT_CALIB = 46,
+
+      OW_SET_LED_TMP_COLOR = 51,
+      OW_GET_LED_COLOR = 52,
+      OW_SET_LED_COLOR = 53
+
+    };
+
+    enum
+    {
+      OW_TLM_TEMP,
+      OW_TLM_VOLT,
+      OW_TLM_CURRENT,
+      OW_TLM_ERPM,
+      OW_TLM_CONSUMPTION,
+      OW_TLM_DEBUG1,
+      OW_TLM_DEBUG2,
+      OW_TLM_DEBUG3
+    };
+    static uint8_t FETtecOneWire_ResponseLength[54];
+    static uint8_t FETtecOneWire_RequestLength[54];
+};
+#endif // HAL_AP_FETTECONEWIRE_ENABLED
+

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -200,53 +200,10 @@ private:
       OW_BL_PAGES_TO_FLASH, // BL only
       OW_REQ_TYPE,
       OW_REQ_SN,
-      OW_REQ_SW_VER
-    };
-
-    enum
-    {
-      OW_RESET_TO_BL = 10,
-      OW_THROTTLE = 11,
-      OW_REQ_TLM = 12,
+      OW_REQ_SW_VER,
       OW_BEEP = 13,
-
       OW_SET_FAST_COM_LENGTH = 26,
-
-      OW_GET_ROTATION_DIRECTION = 28,
-      OW_SET_ROTATION_DIRECTION = 29,
-
-      OW_GET_USE_SIN_START = 30,
-      OW_SET_USE_SIN_START = 31,
-
-      OW_GET_3D_MODE = 32,
-      OW_SET_3D_MODE = 33,
-
-      OW_GET_ID = 34,
-      OW_SET_ID = 35,
-
-/*
-    OW_GET_LINEAR_THRUST = 36,
-    OW_SET_LINEAR_THRUST = 37,
-*/
-
-      OW_GET_EEVER = 38,
-
-      OW_GET_PWM_MIN = 39,
-      OW_SET_PWM_MIN = 40,
-
-      OW_GET_PWM_MAX = 41,
-      OW_SET_PWM_MAX = 42,
-
-      OW_GET_ESC_BEEP = 43,
-      OW_SET_ESC_BEEP = 44,
-
-      OW_GET_CURRENT_CALIB = 45,
-      OW_SET_CURRENT_CALIB = 46,
-
       OW_SET_LED_TMP_COLOR = 51,
-      OW_GET_LED_COLOR = 52,
-      OW_SET_LED_COLOR = 53
-
     };
 
     enum telem_type
@@ -281,8 +238,8 @@ private:
       uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
     } _is;
 
-    uint8_t _ResponseLength[54];
-    uint8_t _RequestLength[54];
+    uint8_t _ResponseLength[OW_SET_FAST_COM_LENGTH+1]; // OW_SET_LED_TMP_COLOR is ignored here
+    uint8_t _RequestLength[OW_SET_FAST_COM_LENGTH+1];  // OW_SET_LED_TMP_COLOR is ignored here
 
 };
 #endif // HAL_AP_FETTECONEWIRE_ENABLED

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -66,7 +66,7 @@ private:
     ///  - _telemetry[i][5] -> count[idx]
     uint16_t _telemetry[MOTOR_COUNT_MAX][6] = {0};
     uint16_t _motorpwm[MOTOR_COUNT_MAX] = {1000};
-    uint8_t _telem_req_type; /// the requested telemetry type (OW_TLM_XXXXX)
+    uint8_t _telem_req_type; /// the requested telemetry type (telem_type::XXXXX)
 
 /**
     initialize FETtecOneWire protocol
@@ -154,7 +154,7 @@ private:
     @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
     @param Telemetry 16bit array where the read telemetry will be stored in.
     @param motorCount the count of motors that should get values send
-    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @param tlmRequest the requested telemetry type (telem_type::XXXXX)
     @return the telemetry request if telemetry was available, -1 if dont
 */
     int8_t ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
@@ -185,14 +185,13 @@ private:
     uint8_t _lastCRC;
     uint8_t _firstInitDone;
 
-
-    enum
+    enum return_type
     {
       OW_RETURN_RESPONSE,
       OW_RETURN_FULL_FRAME
     };
 
-    enum
+    enum msg_type
     {
       OW_OK,
       OW_BL_PAGE_CORRECT,   // BL only
@@ -250,16 +249,16 @@ private:
 
     };
 
-    enum
+    enum telem_type
     {
-      OW_TLM_TEMP,
-      OW_TLM_VOLT,
-      OW_TLM_CURRENT,
-      OW_TLM_ERPM,
-      OW_TLM_CONSUMPTION,
-      OW_TLM_DEBUG1,
-      OW_TLM_DEBUG2,
-      OW_TLM_DEBUG3
+      TEMP,
+      VOLT,
+      CURRENT,
+      ERPM,
+      CONSUMPTION,
+      DEBUG1,
+      DEBUG2,
+      DEBUG3
     };
 
     /// presistent scan state data (only used inside ScanESCs() function)

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -34,139 +34,131 @@ class AP_FETtecOneWire {
 public:
     AP_FETtecOneWire();
 
-    /* Do not allow copies */
+    /// Do not allow copies
     AP_FETtecOneWire(const AP_FETtecOneWire &other) = delete;
     AP_FETtecOneWire &operator=(const AP_FETtecOneWire&) = delete;
 
     static const struct AP_Param::GroupInfo var_info[];
 
     void update();
-    void send_esc_telemetry_mavlink(uint8_t mav_chan);
+    void send_esc_telemetry_mavlink(uint8_t mav_chan) const;
     static AP_FETtecOneWire *get_singleton() {
         return _singleton;
     }
 private:
     void init();
     static AP_FETtecOneWire *_singleton;
-    bool initialised;
+    bool _initialised;
     AP_HAL::UARTDriver *_uart;
     AP_Int32 motor_mask;
 
-    uint32_t last_send_us;
-    uint32_t last_log_ms;
+    uint32_t _last_send_us;
+    uint32_t _last_log_ms;
     static constexpr uint32_t DELAY_TIME_US = 700;
-    static constexpr uint8_t DETECT_ESC_COUNT = 4;  // TODO needed ?
-    static constexpr uint8_t MOTOR_COUNT_MAX = 8;
-    int8_t TelemetryAvailable = -1;
-    uint16_t completeTelemetry[MOTOR_COUNT_MAX][6] = {0};
-    uint16_t motorpwm[MOTOR_COUNT_MAX] = {1000};
-    uint8_t TLM_request = 0;
-    /*
+    static constexpr uint8_t MOTOR_COUNT_MAX = 12; /// OneWire supports up-to 25 ESCs, but Ardupilot only supports 12
+    int8_t _telem_avail = -1;
+    /// contains 6 fields per ESC:
+    ///  - _telemetry[i][0] -> temperature[idx]
+    ///  - _telemetry[i][1] -> voltage[idx]
+    ///  - _telemetry[i][2] -> current[idx]
+    ///  - _telemetry[i][3] -> rpm[idx]
+    ///  - _telemetry[i][4] -> totalcurrent[idx]
+    ///  - _telemetry[i][5] -> count[idx]
+    uint16_t _telemetry[MOTOR_COUNT_MAX][6] = {0};
+    uint16_t _motorpwm[MOTOR_COUNT_MAX] = {1000};
+    uint8_t _telem_req_type; /// the requested telemetry type (OW_TLM_XXXXX)
+
+/**
     initialize FETtecOneWire protocol
 */
-    void FETtecOneWire_Init(void);
+    void Init();
 
-/*
+/**
     deinitialize FETtecOneWire protocol
+    TODO: remove it? it is not used anywhere
 */
-    void FETtecOneWire_DeInit(void);
+    void DeInit();
 
-/*
+/**
     generates used 8 bit CRC
-    crc = byte to be added to CRC
-    crc_seed = CRC where it gets added too
-    returns 8 bit CRC
+    @param crc byte to be added to CRC
+    @param crc_seed CRC where it gets added too
+    @return 8 bit CRC
 */
-    uint8_t FETtecOneWire_Update_crc8(uint8_t crc, uint8_t crc_seed);
+    uint8_t Update_crc8(uint8_t crc, uint8_t crc_seed) const;
 
-/*
+/**
     generates used 8 bit CRC for arrays
-    Buf = 8 bit byte array
-    BufLen = count of bytes that should be used for CRC calculation
-    returns 8 bit CRC
+    @param Buf 8 bit byte array
+    @param BufLen count of bytes that should be used for CRC calculation
+    @return 8 bit CRC
 */
-    uint8_t FETtecOneWire_Get_crc8(uint8_t *Buf, uint16_t BufLen);
+    uint8_t Get_crc8(uint8_t *Buf, uint16_t BufLen) const;
 
-/*
+/**
     transmitts a FETtecOneWire frame to a ESC
-    ESC_id = id of the ESC
-    Bytes = 8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
-    Length = length of the Bytes array
-    returns nothing
+    @param ESC_id id of the ESC
+    @param Bytes  8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
+    @param Length length of the Bytes array
 */
-    void FETtecOneWire_Transmit(uint8_t ESC_id, uint8_t *Bytes, uint8_t Length);
+    void Transmit(uint8_t ESC_id, uint8_t *Bytes, uint8_t Length);
 
-/*
+/**
     reads the answer frame of a ESC
-    Bytes = 8 bit byte array, where the received answer gets stored in
-    Length = the expected answer length
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the expected answer frame was there, 0 if dont
+    @param Bytes 8 bit byte array, where the received answer gets stored in
+    @param Length the expected answer length
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the expected answer frame was there, 0 if dont
 */
-    uint8_t FETtecOneWire_Receive(uint8_t *Bytes, uint8_t Length, uint8_t returnFullFrame);
+    uint8_t Receive(uint8_t *Bytes, uint8_t Length, uint8_t returnFullFrame);
 
-/*
-    makes all connected ESC's beep
-    beepFreqency = a 8 bit value from 0-255. higher make a higher beep
-*/
-    void FETtecOneWire_Beep(uint8_t beepFreqency);
-
-/*
-    sets the racewire color for all ESC's
-    R, G, B = 8bit colors
-*/
-    void FETtecOneWire_RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B);
-
-/*
+/**
     Resets a pending pull request
-    returns nothing
 */
-    void FETtecOneWire_PullReset(void);
+    void PullReset();
 
-/*
+/**
     Pulls a complete request between for ESC
-    ESC_id = id of the ESC
-    command = 8bit array containing the command that thould be send including the possible payload
-    response = 8bit array where the response will be stored in
-    returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
-    returns 1 if the request is completed, 0 if dont
+    @param ESC_id id of the ESC
+    @param command 8bit array containing the command that should be send including the possible payload
+    @param response 8bit array where the response will be stored in
+    @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
+    @return 1 if the request is completed, 0 if dont
 */
-    uint8_t FETtecOneWire_PullCommand(uint8_t ESC_id, uint8_t *command, uint8_t *response, uint8_t returnFullFrame);
+    uint8_t PullCommand(uint8_t ESC_id, uint8_t *command, uint8_t *response, uint8_t returnFullFrame);
 
-/*
-    scans for ESC's in bus. should be called intill FETtecOneWire_ScanActive >= 25
-    returns the current scanned ID
+/**
+    scans for ESCs in bus. should be called until _ScanActive >= MOTOR_COUNT_MAX
+    @return the current scanned ID
 */
-    uint8_t FETtecOneWire_ScanESCs(void);
+    uint8_t ScanESCs();
 
-/*
-    starts all ESC's in bus and prepares them for receiving teh fast throttle command should be called untill FETtecOneWire_SetupActive >= 25
-    returns the current used ID
+/**
+    starts all ESCs in bus and prepares them for receiving teh fast throttle command should be called until _SetupActive >= MOTOR_COUNT_MAX
+    @return the current used ID
 */
-    uint8_t FETtecOneWire_InitESCs(void);
+    uint8_t InitESCs();
 
-/*
+/**
     checks if the requested telemetry is available.
-    Telemetry = 16bit array where the read Telemetry will be stored in.
-    returns the telemetry request number or -1 if unavailable
+    @param Telemetry 16bit array where the read Telemetry will be stored in.
+    @param return the telemetry request number or -1 if unavailable
 */
-    int8_t FETtecOneWire_CheckForTLM(uint16_t *Telemetry);
+    int8_t CheckForTLM(uint16_t *Telemetry);
 
-/*
+/**
     does almost all of the job.
-    scans for ESC's if not already done.
-    initializes the ESC's if not already done.
+    scans for ESCs if not already done.
+    initializes the ESCs if not already done.
     sends fast throttle signals if init is complete.
-    motorValues = a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
-    Telemetry = 16bit array where the read telemetry will be stored in.
-    motorCount = the count of motors that should get values send
-    tlmRequest = the requested telemetry type (OW_TLM_XXXXX)
-    returns the telemetry request if telemetry was available, -1 if dont
+    @param motorValues a 16bit array containing the throttle signals that should be sent to the motors. 0-2000 where 1001-2000 is positive rotation and 999-0 reversed rotation
+    @param Telemetry 16bit array where the read telemetry will be stored in.
+    @param motorCount the count of motors that should get values send
+    @param tlmRequest the requested telemetry type (OW_TLM_XXXXX)
+    @return the telemetry request if telemetry was available, -1 if dont
 */
-    int8_t FETtecOneWire_ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
+    int8_t ESCsSetValues(uint16_t *motorValues, uint16_t *Telemetry, uint8_t motorCount, uint8_t tlmRequest);
 
-    uint8_t FETtecOneWire_UpdateCrc8(uint8_t crc, uint8_t crc_seed);  //TODO remove
-    uint8_t FETtecOneWire_GetCrc8(uint8_t* Buf, uint16_t BufLen);
     static constexpr uint8_t ALL_ID = 0x1F;
     typedef struct FETtecOneWireESC
     {
@@ -177,21 +169,21 @@ private:
       uint8_t serialNumber[12];
     } FETtecOneWireESC_t;
 
-    uint8_t FETtecOneWire_activeESC_IDs[25] = {0};
-    FETtecOneWireESC_t FETtecOneWire_foundESCs[25];
-    uint8_t FETtecOneWire_FoundESCs = 0;
-    uint8_t FETtecOneWire_ScanActive = 0;
-    uint8_t FETtecOneWire_SetupActive = 0;
-    uint8_t FETtecOneWire_IgnoreOwnBytes = 0;
-    int8_t FETtecOneWire_minID = 25;
-    int8_t FETtecOneWire_maxID = 0;
-    uint8_t FETtecOneWire_IDcount = 0;
-    uint8_t FETtecOneWire_FastThrottleByteCount = 0;
-    uint8_t FETtecOneWire_PullSuccess = 0;
-    uint8_t FETtecOneWire_PullBusy = 0;
-    uint8_t FETtecOneWire_TLM_request = 0;
-    uint8_t FETtecOneWire_lastCRC = 0;
-    uint8_t FETtecOneWire_firstInitDone = 0;
+    uint8_t _activeESC_IDs[MOTOR_COUNT_MAX] = {0};
+    FETtecOneWireESC_t _foundESCs[MOTOR_COUNT_MAX];
+    uint8_t _FoundESCs;
+    uint8_t _ScanActive;
+    uint8_t _SetupActive;
+    uint8_t _IgnoreOwnBytes;
+    int8_t _minID = MOTOR_COUNT_MAX;
+    int8_t _maxID;
+    uint8_t _IDcount;
+    uint8_t _FastThrottleByteCount;
+    uint8_t _PullSuccess;
+    uint8_t _PullBusy;
+    uint8_t _TLM_request;
+    uint8_t _lastCRC;
+    uint8_t _firstInitDone;
 
 
     enum
@@ -269,6 +261,30 @@ private:
       OW_TLM_DEBUG2,
       OW_TLM_DEBUG3
     };
+
+    /// presistent scan state data (only used inside ScanESCs() function)
+    struct scan_state
+    {
+      uint16_t delayLoops = 500;
+      uint8_t scanID = 0;
+      uint8_t scanState = 0;
+      uint8_t scanTimeOut = 0;
+    } _ss;
+
+    /// presistent init state data (only used inside InitESCs() function)
+    struct init_state
+    {
+      uint8_t delayLoops = 0;
+      uint8_t activeID = 1;
+      uint8_t State = 0;
+      uint8_t TimeOut = 0;
+      uint8_t wakeFromBL = 1;
+      uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
+    } _is;
+
+    uint8_t _ResponseLength[54];
+    uint8_t _RequestLength[54];
+
 };
 #endif // HAL_AP_FETTECONEWIRE_ENABLED
 

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -80,14 +80,6 @@ private:
     void DeInit();
 
 /**
-    generates used 8 bit CRC
-    @param crc byte to be added to CRC
-    @param crc_seed CRC where it gets added too
-    @return 8 bit CRC
-*/
-    uint8_t Update_crc8(uint8_t crc, uint8_t crc_seed) const;
-
-/**
     generates used 8 bit CRC for arrays
     @param Buf 8 bit byte array
     @param BufLen count of bytes that should be used for CRC calculation

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -19,6 +19,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 
 #ifndef HAL_AP_FETTECONEWIRE_ENABLED
 #define HAL_AP_FETTECONEWIRE_ENABLED !HAL_MINIMIZE_FEATURES && !defined(HAL_BUILD_AP_PERIPH) && BOARD_FLASH_SIZE > 1024
@@ -30,7 +31,7 @@
 
 
 
-class AP_FETtecOneWire {
+class AP_FETtecOneWire : public AP_ESC_Telem_Backend {
 public:
     AP_FETtecOneWire();
 
@@ -41,7 +42,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     void update();
-    void send_esc_telemetry_mavlink(uint8_t mav_chan) const;
     static AP_FETtecOneWire *get_singleton() {
         return _singleton;
     }
@@ -53,18 +53,9 @@ private:
     AP_Int32 motor_mask;
 
     uint32_t _last_send_us;
-    uint32_t _last_log_ms;
     static constexpr uint32_t DELAY_TIME_US = 700;
     static constexpr uint8_t MOTOR_COUNT_MAX = 12; /// OneWire supports up-to 25 ESCs, but Ardupilot only supports 12
     int8_t _telem_avail = -1;
-    /// contains 6 fields per ESC:
-    ///  - _telemetry[i][0] -> temperature[idx]
-    ///  - _telemetry[i][1] -> voltage[idx]
-    ///  - _telemetry[i][2] -> current[idx]
-    ///  - _telemetry[i][3] -> rpm[idx]
-    ///  - _telemetry[i][4] -> totalcurrent[idx]
-    ///  - _telemetry[i][5] -> count[idx]
-    uint16_t _telemetry[MOTOR_COUNT_MAX][6] = {0};
     uint16_t _motorpwm[MOTOR_COUNT_MAX] = {1000};
     uint8_t _telem_req_type; /// the requested telemetry type (telem_type::XXXXX)
 

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -46,6 +46,7 @@ public:
         return _singleton;
     }
 private:
+    /// initialize FETtecOneWire protocol
     void init();
     static AP_FETtecOneWire *_singleton;
     bool _initialised;
@@ -58,17 +59,6 @@ private:
     int8_t _telem_avail = -1;
     uint16_t _motorpwm[MOTOR_COUNT_MAX] = {1000};
     uint8_t _telem_req_type; /// the requested telemetry type (telem_type::XXXXX)
-
-/**
-    initialize FETtecOneWire protocol
-*/
-    void Init();
-
-/**
-    deinitialize FETtecOneWire protocol
-    TODO: remove it? it is not used anywhere
-*/
-    void DeInit();
 
 /**
     generates used 8 bit CRC for arrays
@@ -166,7 +156,6 @@ private:
     uint8_t _PullBusy;
     uint8_t _TLM_request;
     uint8_t _lastCRC;
-    uint8_t _firstInitDone;
 
     enum return_type
     {

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -56,6 +56,7 @@ private:
     bool _initialised;
     AP_HAL::UARTDriver *_uart;
     AP_Int32 motor_mask;
+    AP_Int8 pole_count;
 
     uint32_t _last_send_us;
     static constexpr uint32_t DELAY_TIME_US = 700;

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -69,7 +69,7 @@ private:
     uint8_t Get_crc8(uint8_t *Buf, uint16_t BufLen) const;
 
 /**
-    transmitts a FETtecOneWire frame to a ESC
+    transmits a FETtec OneWire frame to an ESC
     @param ESC_id id of the ESC
     @param Bytes  8 bit array of bytes. Where byte 1 contains the command, and all following bytes can be the payload
     @param Length length of the Bytes array
@@ -77,7 +77,7 @@ private:
     void Transmit(uint8_t ESC_id, uint8_t *Bytes, uint8_t Length);
 
 /**
-    reads the answer frame of a ESC
+    reads the FETtec OneWire answer frame of an ESC
     @param Bytes 8 bit byte array, where the received answer gets stored in
     @param Length the expected answer length
     @param returnFullFrame can be OW_RETURN_RESPONSE or OW_RETURN_FULL_FRAME
@@ -91,7 +91,7 @@ private:
     void PullReset();
 
 /**
-    Pulls a complete request between for ESC
+    Pulls a complete request between flight controller and ESC
     @param ESC_id id of the ESC
     @param command 8bit array containing the command that should be send including the possible payload
     @param response 8bit array where the response will be stored in

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -25,6 +25,10 @@
 #define HAL_AP_FETTECONEWIRE_ENABLED !HAL_MINIMIZE_FEATURES && !defined(HAL_BUILD_AP_PERIPH) && BOARD_FLASH_SIZE > 1024
 #endif
 
+#ifndef HAL_AP_FETTECONEWIRE_GET_STATIC_INFO
+#define HAL_AP_FETTECONEWIRE_GET_STATIC_INFO 0
+#endif
+
 #if HAL_AP_FETTECONEWIRE_ENABLED
 
 #include <AP_Param/AP_Param.h>
@@ -136,10 +140,12 @@ private:
     typedef struct FETtecOneWireESC
     {
       uint8_t inBootLoader;
+#if HAL_AP_FETTECONEWIRE_GET_STATIC_INFO
       uint8_t firmWareVersion;
       uint8_t firmWareSubVersion;
       uint8_t ESCtype;
       uint8_t serialNumber[12];
+#endif
     } FETtecOneWireESC_t;
 
     uint8_t _activeESC_IDs[MOTOR_COUNT_MAX] = {0};

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -199,20 +199,20 @@ private:
     /// presistent scan state data (only used inside ScanESCs() function)
     struct scan_state
     {
-      uint16_t delayLoops = 500;
-      uint8_t scanID = 0;
-      uint8_t scanState = 0;
-      uint8_t scanTimeOut = 0;
+      uint16_t delayLoops;
+      uint8_t scanID;
+      uint8_t scanState;
+      uint8_t scanTimeOut;
     } _ss;
 
     /// presistent init state data (only used inside InitESCs() function)
     struct init_state
     {
-      uint8_t delayLoops = 0;
-      uint8_t activeID = 1;
-      uint8_t State = 0;
-      uint8_t TimeOut = 0;
-      uint8_t wakeFromBL = 1;
+      uint8_t delayLoops;
+      uint8_t activeID;
+      uint8_t State;
+      uint8_t TimeOut;
+      uint8_t wakeFromBL;
       uint8_t setFastCommand[4] = {OW_SET_FAST_COM_LENGTH, 0, 0, 0};
     } _is;
 

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -1,0 +1,102 @@
+==============
+FETtec OneWire
+==============
+
+This is a half duplex serial protocol with a 2Mbit/s Baudrate created by Felix Niessen (former Flyduino KISS developer) from `FETtec <https://fettec.net/>`_.
+
+
+Ardupilot to ESC protocol
+=========================
+
+How many bytes per message?
+Which CRC? What proprieties has this CRC?
+How many ESCs are supported? At which Rate?
+What is the pause time between messages?
+What can we configure in the ESCs?
+What is the signal resolution?
+Can the motors rotate in both directions? How is that done ?
+
+ESC to Ardupilot protocol
+=========================
+
+How many bytes per message?
+Which CRC? What proprieties has this CRC?
+
+It supports ESC telemetry, so information from the ESC status can be sent back to the autopilot:
+
+- Electronic rotations per minute (RPM) (must be divided by number of motor poles to translate to propeller RPM)
+- Input voltage (V)
+- Current draw (A)
+- Power consumption (W)
+- Temperature (°C)
+
+At which Rate?
+
+This information allows the autopilot to:
+
+- dynamically change the center frequency of the notch filters used to reduce frame vibration noise in the gyros
+- log the status of each ESC to the SDCard or internal Flash, for post flight analysis
+- send the status of each ESC to the Ground Station or companion computer for real-time monitoring
+
+
+Extra features
+==============
+
+The ESC can beep and have lights. To control this you must add this code snippet to the header file:
+
+```
+public:
+/**
+    makes all connected ESCs beep
+    @param beepFrequency a 8 bit value from 0-255. higher make a higher beep
+*/
+    void Beep(uint8_t beepFrequency);
+
+/**
+    sets the racewire color for all ESCs
+    R, G, B = 8bit colors
+*/
+    void RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B);
+```
+
+And this code snippet to the .cpp file:
+
+```
+/**
+    makes all connected ESCs beep
+    @param beepFrequency a 8 bit value from 0-255. higher make a higher beep
+*/
+void AP_FETtecOneWire::Beep(uint8_t beepFrequency)
+{
+    if (_IDcount > 0) {
+        uint8_t request[2] = {OW_BEEP, beepFrequency};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = _minID; i < _maxID + 1; i++) {
+            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
+            _uart->write(spacer, 2);
+            _IgnoreOwnBytes += 2;
+        }
+    }
+}
+
+/**
+    sets the racewire color for all ESCs
+    @param R red brightness
+    @param G green brightness
+    @param B blue brightness
+*/
+void AP_FETtecOneWire::RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
+{
+    if (_IDcount > 0) {
+        uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
+        uint8_t spacer[2] = {0, 0};
+        for (uint8_t i = _minID; i < _maxID + 1; i++) {
+            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
+            _uart->write(spacer, 2);
+            _IgnoreOwnBytes += 2;
+        }
+    }
+}
+```

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -9,35 +9,66 @@ Ardupilot to ESC protocol
 =========================
 
 How many bytes per message?
+There are two types of messages:
+	- Configuration message consists of six frame bytes + payload bytes.
+	Byte 0 is the transfer direction(e.g. 0x01 Master to Slave)
+	Byte 1 is the ID
+	Byte 2 is the frame type (Low byte)
+	Byte 3 is the frame type (High byte)
+	Byte 4 is the frame length
+	Byte 5-254 is the payload
+	Byte 6-255 is CRC (last Byte after the Payload)
+	
+	- Fast Throttle Signal
+	The signal is used to transfer the eleven bit throttle signals with as few bytes as possible
+	The structure is a bit more complex. In the first two bytes are frame header and telemetry request as well as the first parts of the throttle
+	signal. The following bytes are transmitting the throttle signals for the ESCs (11bit per ESC) followed by the CRC. 
+	
+	If telemetry is requested the ESCs will answer them in the ESC-ID order. See comments in onewire.c for details.
+	
 Which CRC? What proprieties has this CRC?
-How many ESCs are supported? At which Rate?
-What is the pause time between messages?
-What can we configure in the ESCs?
-What is the signal resolution?
-Can the motors rotate in both directions? How is that done ?
+	The CRC is a well known bytewise 8bit CRC not bitwise as DSHOT is. 
 
+
+How many ESCs are supported? At which Rate?
+	Four ESCs need 90uS for the throttle request and telemetry receiption. With four ESCs 11kHz are possible. As each additional ESC adds 11bits
+	and 16 telemetry bits the rate is lowered by each ESC. 
+	
+	8 ESCs need 160uS including telemetry response, so 5.8kHz are possible. 
+	
+	
+What is the pause time between messages?
+	250ms then the Motors will disarm.
+	
+What can we configure in the ESCs?
+	Every setting that the ESCs offer. The FETtec configurator uses OneWire too. Even the firmware updater bootloader uses onewire. 
+	
+What is the signal resolution?
+	11bits per throttle signal, 16 bits per telemetry type.
+	
+Can the motors rotate in both directions? How is that done ?
+	yes this is standard. (1020-2000 is throttle forward, 980-0 is throttle backward)
+	
+	
 ESC to Ardupilot protocol
 =========================
 
-How many bytes per message?
-Which CRC? What proprieties has this CRC?
-
 It supports ESC telemetry, so information from the ESC status can be sent back to the autopilot:
 
-- Electronic rotations per minute (RPM) (must be divided by number of motor poles to translate to propeller RPM)
-- Input voltage (V)
-- Current draw (A)
-- Power consumption (W)
+- Electronic rotations per minute (eRPM) (must be divided by number of motor poles to translate to propeller RPM)
+- Input voltage (V/10)
+- Current draw (A/10)
+- Power consumption (mAh)
 - Temperature (°C)
 
 At which Rate?
-
+ As described above. 
 This information allows the autopilot to:
 
 - dynamically change the center frequency of the notch filters used to reduce frame vibration noise in the gyros
 - log the status of each ESC to the SDCard or internal Flash, for post flight analysis
 - send the status of each ESC to the Ground Station or companion computer for real-time monitoring
-
+- 
 
 Extra features
 ==============
@@ -100,3 +131,15 @@ void AP_FETtecOneWire::RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
     }
 }
 ```
+
+Connection and Halfduplex with STM
+==================================
+Normally halfduplex can be used for the communication. 
+To have reliable 2Mbit/s Baudrate the GPIO should be set to PushPull.
+On STM it is a special mode that is initialized like:
+
+gpioInit.mode = LL_GPIO_MODE_ALTERNATE;
+gpioInit.Pull = LL_GPIO_MODE_ALTERNATE;
+gpio.Pull = LL_GPIO_PULL_UP;
+gpioInit.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+gpioInit.Alternate = LL_GPIO_AF_1;

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -100,10 +100,11 @@ And this code snippet to the .cpp file:
 void AP_FETtecOneWire::Beep(uint8_t beepFrequency)
 {
     if (_IDcount > 0) {
-        uint8_t request[2] = {OW_BEEP, beepFrequency};
-        uint8_t spacer[2] = {0, 0};
+        const uint8_t request[2] = {OW_BEEP, beepFrequency};
+        const uint8_t request_len[1] = {2};
+        const uint8_t spacer[2] = {0, 0};
         for (uint8_t i = _minID; i < _maxID + 1; i++) {
-            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            Transmit(i, request, request_len);
             // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
             _uart->write(spacer, 2);
             _IgnoreOwnBytes += 2;
@@ -120,10 +121,11 @@ void AP_FETtecOneWire::Beep(uint8_t beepFrequency)
 void AP_FETtecOneWire::RW_LEDcolor(uint8_t R, uint8_t G, uint8_t B)
 {
     if (_IDcount > 0) {
-        uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
-        uint8_t spacer[2] = {0, 0};
+        const uint8_t request[4] = {OW_SET_LED_TMP_COLOR, R, G, B};
+        const uint8_t request_len[1] = {4};
+        const uint8_t spacer[2] = {0, 0};
         for (uint8_t i = _minID; i < _maxID + 1; i++) {
-            Transmit(i, request, FETtecOneWire_RequestLength[request[0]]);
+            Transmit(i, request, request_len);
             // add two zeros to make sure all ESCs can catch their command as we don't wait for a response here
             _uart->write(spacer, 2);
             _IgnoreOwnBytes += 2;

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -143,3 +143,38 @@ gpioInit.Pull = LL_GPIO_MODE_ALTERNATE;
 gpio.Pull = LL_GPIO_PULL_UP;
 gpioInit.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
 gpioInit.Alternate = LL_GPIO_AF_1;
+
+
+
+FullDuplex with Diode
+==================================
+If halfduplex is not available or working there is a workaround with a diode using the normal full duplex.
+This is also working with other "non-halfduplex" Controller like ESP32.
+
+The TLM-Pin (ESC) and RX (FC) connects to the anode (black side) of the diode.
+TX (FC) connects to cathode (white striped side) of the diode.
+
+ (TX --|<-- RX, TLM)
+ 
+ 
+OneWire Configuration:
+==================================
+This settings have to be changed under CONFIG -> Full Parameter List to get it working.
+MOT_PWM_MAX 2000
+MOT_PWM_MIN 1000
+Serial2_OPTIONS 160 #FOR full duplex - Use with diode
+Serial2_OPTIONS 164 #FOR half duplex - Use without diode -> TX from FC to TLM of FETtec ESC
+
+#FOR QUADCOPTER -> Sum of binary values
+SERVO_FTW_MASK 15 
+MOTOR 		1 | 2 | 3 | 4 | 5 | 6  ...
+BIN VAL	    1 | 2 | 4 | 8 | 16| 32 ...
+ACTIV		X | X | X | X | 0 | 0  ...
+SUM     	1 + 2 + 4 + 8 = 15
+
+Change SERVO*_FUNCTION to 33-38 according to the needed motor order e.g.:
+SERVO1_FUNCTION 33
+SERVO2_FUNCTION 34
+SERVO3_FUNCTION 35
+SERVO4_FUNCTION 36
+

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -212,6 +212,11 @@ public:
     virtual void set_bidir_dshot_mask(uint16_t mask) {}
 
     /*
+      set the number of motor poles to be used in rpm calculations
+     */
+    virtual void set_motor_poles(uint8_t poles) {}
+
+    /*
       setup serial led output for a given channel number, with
       the given max number of LEDs in the chain.
      */

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -113,6 +113,10 @@ void RCOutput::init()
     hal.gpio->pinMode(57, 1);
 #endif
 
+#ifdef HAL_WITH_BIDIR_DSHOT
+    AP::esc_telem().add_backend(this);
+#endif
+
     _initialised = true;
 }
 
@@ -1218,9 +1222,17 @@ void RCOutput::dshot_send(pwm_group &group)
     for (uint8_t i=0; i<4; i++) {
         uint8_t chan = group.chan[i];
         if (chan != CHAN_DISABLED) {
+#ifdef HAL_WITH_BIDIR_DSHOT
             // retrieve the last erpm values
-            _bdshot.erpm[chan] = group.bdshot.erpm[i];
+            const uint16_t erpm = group.bdshot.erpm[i];
 
+            // update the ESC telemetry data
+            if (erpm < 0xFFFF) {
+                update_rpm(chan, erpm * 200 / _bdshot.motor_poles);
+            }
+
+            _bdshot.erpm[chan] = erpm;
+#endif
             uint16_t pwm = period[chan];
 
             if (safety_on && !(safety_mask & (1U<<(chan+chan_offset)))) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -18,6 +18,8 @@
 
 #include "AP_HAL_ChibiOS.h"
 #include <AP_HAL/Semaphores.h>
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
+
 #include "shared_dma.h"
 #include "ch.h"
 #include "hal.h"
@@ -30,7 +32,11 @@
 
 #define RCOU_DSHOT_TIMING_DEBUG 0
 
-class ChibiOS::RCOutput : public AP_HAL::RCOutput {
+class ChibiOS::RCOutput : public AP_HAL::RCOutput
+#ifdef HAL_WITH_BIDIR_DSHOT
+  , AP_ESC_Telem_Backend
+#endif
+{
 public:
     void     init() override;
     void     set_freq(uint32_t chmask, uint16_t freq_hz) override;
@@ -148,6 +154,8 @@ public:
       with DShot to get telemetry feedback
      */
     void set_bidir_dshot_mask(uint16_t mask) override;
+
+    void set_motor_poles(uint8_t poles) override { _bdshot.motor_poles = poles; }
 #endif
 
     /*
@@ -411,6 +419,7 @@ private:
         uint16_t erpm_errors[max_channels];
         uint16_t erpm_clean_frames[max_channels];
         uint32_t erpm_last_stats_ms[max_channels];
+        uint8_t motor_poles;
 #endif
     } _bdshot;
 

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -85,6 +85,7 @@ void RCOutput::push(void)
         memcpy(_sitlState->pwm_output, _pending, SITL_NUM_CHANNELS * sizeof(uint16_t));
         _corked = false;
     }
+    esc_telem.update();
 }
 
 /*

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -3,6 +3,7 @@
 #include <AP_HAL/AP_HAL.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
 #include "AP_HAL_SITL.h"
+#include <AP_ESC_Telem/AP_ESC_Telem_SITL.h>
 
 class HALSITL::RCOutput : public AP_HAL::RCOutput {
 public:
@@ -36,6 +37,8 @@ public:
     
 private:
     SITL_State *_sitlState;
+    AP_ESC_Telem_SITL esc_telem;
+
     uint16_t _freq_hz;
     uint16_t _enable_mask;
     bool _corked;

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -450,12 +450,27 @@ void AP_KDECAN::loop()
                                 break;
                             }
 
-                            _telemetry[id.source_id - ESC_NODE_ID_FIRST].time = rx_time;
-                            _telemetry[id.source_id - ESC_NODE_ID_FIRST].voltage = frame.data[0] << 8 | frame.data[1];
-                            _telemetry[id.source_id - ESC_NODE_ID_FIRST].current = frame.data[2] << 8 | frame.data[3];
-                            _telemetry[id.source_id - ESC_NODE_ID_FIRST].rpm = frame.data[4] << 8 | frame.data[5];
-                            _telemetry[id.source_id - ESC_NODE_ID_FIRST].temp = frame.data[6];
-                            _telemetry[id.source_id - ESC_NODE_ID_FIRST].new_data = true;
+                            const uint8_t idx = id.source_id - ESC_NODE_ID_FIRST;
+                            _telemetry[idx].time = rx_time;
+                            _telemetry[idx].voltage = frame.data[0] << 8 | frame.data[1];
+                            _telemetry[idx].current = frame.data[2] << 8 | frame.data[3];
+                            _telemetry[idx].rpm = frame.data[4] << 8 | frame.data[5];
+                            _telemetry[idx].temp = frame.data[6];
+                            _telemetry[idx].new_data = true;
+
+                            uint8_t num_poles = _num_poles > 0 ? _num_poles : DEFAULT_NUM_POLES;
+                            update_rpm(idx, _telemetry[idx].rpm * 60UL * 2 / num_poles * 100);
+
+                            TelemetryData t {
+                                .temperature_deg =_telemetry[idx].temp,
+                                .voltage_cv = _telemetry[idx].voltage,
+                                .current_ca = uint16_t(_telemetry[idx].current),
+                            };
+                            update_telem_data(idx, t,
+                                AP_ESC_Telem_Backend::TelemetryType::CURRENT
+                                    | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE
+                                    | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
+
                             _telem_sem.give();
                             break;
                         }
@@ -588,41 +603,6 @@ void AP_KDECAN::update()
     } else {
         debug_can(AP_CANManager::LOG_DEBUG, "failed to get PWM semaphore on write");
     }
-
-    AP_Logger *logger = AP_Logger::get_singleton();
-
-    if (logger == nullptr || !logger->should_log(0xFFFFFFFF)) {
-        return;
-    }
-
-    if (!_telem_sem.take(1)) {
-        debug_can(AP_CANManager::LOG_DEBUG, "failed to get telemetry semaphore on DF read");
-        return;
-    }
-
-    telemetry_info_t telem_buffer[KDECAN_MAX_NUM_ESCS] {};
-
-    for (uint8_t i = 0; i < _esc_max_node_id; i++) {
-        if (_telemetry[i].new_data) {
-            telem_buffer[i] = _telemetry[i];
-            _telemetry[i].new_data = false;
-        }
-    }
-
-    _telem_sem.give();
-
-    uint8_t num_poles = _num_poles > 0 ? _num_poles : DEFAULT_NUM_POLES;
-
-    // log ESC telemetry data
-    for (uint8_t i = 0; i < _esc_max_node_id; i++) {
-        if (telem_buffer[i].new_data) {
-            logger->Write_ESC(i, telem_buffer[i].time,
-                          int32_t(telem_buffer[i].rpm * 60UL * 2 / num_poles * 100),
-                          telem_buffer[i].voltage,
-                          telem_buffer[i].current,
-                          int16_t(telem_buffer[i].temp * 100U), 0, 0);
-        }
-    }
 }
 
 bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
@@ -667,54 +647,6 @@ bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
     }
 
     return true;
-}
-
-void AP_KDECAN::send_mavlink(uint8_t chan)
-{
-    if (!_telem_sem.take(1)) {
-        debug_can(AP_CANManager::LOG_DEBUG, "failed to get telemetry semaphore on MAVLink read");
-        return;
-    }
-
-    telemetry_info_t telem_buffer[KDECAN_MAX_NUM_ESCS];
-    memcpy(telem_buffer, _telemetry, sizeof(telemetry_info_t) * KDECAN_MAX_NUM_ESCS);
-    _telem_sem.give();
-
-    uint16_t voltage[4] {};
-    uint16_t current[4] {};
-    uint16_t rpm[4] {};
-    uint8_t temperature[4] {};
-    uint16_t totalcurrent[4] {};
-    uint16_t count[4] {};
-    uint8_t num_poles = _num_poles > 0 ? _num_poles : DEFAULT_NUM_POLES;
-    uint64_t now = AP_HAL::micros64();
-
-    for (uint8_t i = 0; i < _esc_max_node_id && i < 8; i++) {
-        uint8_t idx = i % 4;
-        if (telem_buffer[i].time && (now - telem_buffer[i].time < 1000000)) {
-            voltage[idx]      = telem_buffer[i].voltage;
-            current[idx]      = telem_buffer[i].current;
-            rpm[idx]          = uint16_t(telem_buffer[i].rpm  * 60UL * 2 / num_poles);
-            temperature[idx]  = telem_buffer[i].temp;
-        } else {
-            voltage[idx] = 0;
-            current[idx] = 0;
-            rpm[idx] = 0;
-            temperature[idx] = 0;
-        }
-
-        if (idx == 3 || i == _esc_max_node_id - 1) {
-            if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)chan, ESC_TELEMETRY_1_TO_4)) {
-                return;
-            }
-
-            if (i < 4) {
-                mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)chan, temperature, voltage, current, totalcurrent, rpm, count);
-            } else {
-                mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)chan, temperature, voltage, current, totalcurrent, rpm, count);
-            }
-        }
-    }
 }
 
 bool AP_KDECAN::run_enumeration(bool start_stop)

--- a/libraries/AP_KDECAN/AP_KDECAN.h
+++ b/libraries/AP_KDECAN/AP_KDECAN.h
@@ -89,18 +89,6 @@ private:
     std::atomic<bool> _new_output;
     uint16_t _scaled_output[KDECAN_MAX_NUM_ESCS];
 
-    // telemetry input
-    HAL_Semaphore _telem_sem;
-    struct telemetry_info_t {
-        uint64_t time;
-        uint16_t voltage;
-        uint16_t current;
-        uint16_t rpm;
-        uint8_t temp;
-        bool new_data;
-    } _telemetry[KDECAN_MAX_NUM_ESCS];
-
-
     union frame_id_t {
         struct {
             uint8_t object_address;

--- a/libraries/AP_KDECAN/AP_KDECAN.h
+++ b/libraries/AP_KDECAN/AP_KDECAN.h
@@ -27,13 +27,14 @@
 #include <AP_HAL/Semaphores.h>
 
 #include <AP_Param/AP_Param.h>
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 
 #include <atomic>
 
 // there are 12 motor functions in SRV_Channel but CAN driver can't keep up
 #define KDECAN_MAX_NUM_ESCS 8
 
-class AP_KDECAN : public AP_CANDriver {
+class AP_KDECAN : public AP_CANDriver, public AP_ESC_Telem_Backend {
 public:
     AP_KDECAN();
     
@@ -54,9 +55,6 @@ public:
     
     // check that arming can happen
     bool pre_arm_check(char* reason, uint8_t reason_len);
-
-    // send MAVLink telemetry packets
-    void send_mavlink(uint8_t chan);
 
     // caller checks that vehicle isn't armed
     // start_stop: true to start, false to stop

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -426,10 +426,10 @@ bool AP_Logger_Backend::Write_Mode(uint8_t mode, const ModeReason reason)
 // Write ESC status messages
 //   id starts from 0
 //   rpm is eRPM (rpm * 100)
-//   voltage is in centi-volts
-//   current is in centi-amps
+//   voltage is in centi-Volt
+//   current is in centi-Ampere
 //   temperature is in centi-degrees Celsius
-//   current_tot is in centi-amp hours
+//   current_tot is in centi-Ampere hours
 void AP_Logger::Write_ESC(uint8_t instance, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t esc_temp, uint16_t current_tot, int16_t motor_temp, float error_rate)
 {
     const struct log_Esc pkt{

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -45,6 +45,7 @@ const struct UnitStructure log_Units[] = {
     { '-', "" },              // no units e.g. Pi, or a string
     { '?', "UNKNOWN" },       // Units which haven't been worked out yet....
     { 'A', "A" },             // Ampere
+    { 'a', "Ah" },            // Ampere hours
     { 'd', "deg" },           // of the angular variety, -180 to 180
     { 'b', "B" },             // bytes
     { 'k', "deg/s" },         // degrees per second. Degrees are NOT SI, but is some situations more user-friendly than radians
@@ -1479,7 +1480,7 @@ LOG_STRUCTURE_FROM_CAMERA \
     { LOG_TERRAIN_MSG, sizeof(log_TERRAIN), \
       "TERR","QBLLHffHH","TimeUS,Status,Lat,Lng,Spacing,TerrH,CHeight,Pending,Loaded", "s-DU-mm--", "F-GG-00--" }, \
     { LOG_ESC_MSG, sizeof(log_Esc), \
-      "ESC",  "QBeCCcHcf", "TimeUS,Instance,RPM,Volt,Curr,Temp,CTot,MotTemp,Err", "s#qvAO-O%", "F-BBBB-B-" }, \
+      "ESC",  "QBeCCcHcf", "TimeUS,Instance,RPM,Volt,Curr,Temp,CTot,MotTemp,Err", "s#qvAOaO%", "F-BBBB-B-" }, \
     { LOG_CSRV_MSG, sizeof(log_CSRV), \
       "CSRV","QBfffB","TimeUS,Id,Pos,Force,Speed,Pow", "s#---%", "F-0000" }, \
     { LOG_CESC_MSG, sizeof(log_CESC), \

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -17,7 +17,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
-#include <AP_BLHeli/AP_BLHeli.h>
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_GPS/AP_GPS.h>
@@ -65,7 +65,7 @@ void AP_MSP_Telem_Backend::setup_wfq_scheduler(void)
     set_scheduler_entry(ALTITUDE, 250, 250);          // 4Hz  altitude(cm) and velocity(cm/s)
     set_scheduler_entry(ANALOG, 250, 250);            // 4Hz  rssi + batt
     set_scheduler_entry(BATTERY_STATE, 500, 500);     // 2Hz  battery
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
     set_scheduler_entry(ESC_SENSOR_DATA, 500, 500);   // 2Hz  ESC telemetry
 #endif
     set_scheduler_entry(RTC_DATETIME, 1000, 1000);    // 1Hz  RTC
@@ -113,7 +113,7 @@ bool AP_MSP_Telem_Backend::is_packet_ready(uint8_t idx, bool queue_empty)
     case ALTITUDE:          // Altitude and Vario
     case ANALOG:            // Rssi, Battery, mAh, Current
     case BATTERY_STATE:     // voltage, capacity, current, mAh
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
     case ESC_SENSOR_DATA:   // esc temp + rpm
 #endif
     case RTC_DATETIME:      // RTC
@@ -450,7 +450,7 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_command(uint16_t cmd_msp,
         return msp_process_out_battery_state(dst);
     case MSP_UID:
         return msp_process_out_uid(dst);
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
     case MSP_ESC_SENSOR_DATA:
         return msp_process_out_esc_sensor_data(dst);
 #endif
@@ -884,16 +884,18 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_battery_state(sbuf_t *dst
 
 MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_esc_sensor_data(sbuf_t *dst)
 {
-#ifdef HAVE_AP_BLHELI_SUPPORT
-    AP_BLHeli *blheli = AP_BLHeli::get_singleton();
-    if (blheli && blheli->have_telem_data()) {
-        const uint8_t num_motors = blheli->get_num_motors();
+#if HAL_WITH_ESC_TELEM
+    AP_ESC_Telem& telem = AP::esc_telem();
+    if (telem.get_last_telem_data_ms(0)) {
+        const uint8_t num_motors = telem.get_num_active_escs();
         sbuf_write_u8(dst, num_motors);
         for (uint8_t i = 0; i < num_motors; i++) {
-            AP_BLHeli::telem_data td {};
-            blheli->get_telem_data(i, td);
-            sbuf_write_u8(dst, td.temperature);        // deg
-            sbuf_write_u16(dst, td.rpm / 100);
+            int16_t temp = 0;
+            float rpm = 0.0f;
+            telem.get_rpm(i, rpm);
+            telem.get_temperature(i, temp);
+            sbuf_write_u8(dst, uint8_t(temp));        // deg
+            sbuf_write_u16(dst, uint16_t(rpm * 0.1));
         }
     }
 #endif

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.h
@@ -89,7 +89,7 @@ protected:
         ALTITUDE,
         ANALOG,
         BATTERY_STATE,
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
         ESC_SENSOR_DATA,
 #endif
         RTC_DATETIME,
@@ -106,7 +106,7 @@ protected:
         MSP_ALTITUDE,
         MSP_ANALOG,
         MSP_BATTERY_STATE,
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
         MSP_ESC_SENSOR_DATA,
 #endif
         MSP_RTC

--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -347,3 +347,16 @@ uint8_t crc_sum8(const uint8_t *p, uint8_t len)
     sum = 0xff - ((sum & 0xff) + (sum >> 8));
     return sum;
 }
+
+/// 8 bit CRC used by the BLHeli and FETtec ESC telemetry protocols
+uint8_t crc8_telem(uint8_t crc, uint8_t crc_seed)
+{
+    uint8_t crc_u = crc;
+    crc_u ^= crc_seed;
+
+    for (uint8_t i=0; i<8; i++) {
+        crc_u = ( crc_u & 0x80 ) ? 0x7 ^ ( crc_u << 1 ) : ( crc_u << 1 );
+    }
+
+    return crc_u;
+}

--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -35,6 +35,9 @@ uint8_t crc_sum8(const uint8_t *p, uint8_t len);
 // Contact: Fergus Noble <fergus@swift-nav.com>
 uint16_t crc16_ccitt(const uint8_t *buf, uint32_t len, uint16_t crc);
 
+/// 8 bit CRC used by the BLHeli and FETtec ESC telemetry protocols
+uint8_t crc8_telem(uint8_t crc, uint8_t crc_seed);
+
 uint16_t calc_crc_modbus(uint8_t *buf, uint16_t len);
 
 // generate 64bit FNV1a hash from buffer

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -19,7 +19,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_BLHeli/AP_BLHeli.h>
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS.h>
@@ -152,13 +152,11 @@ private:
     AP_OSD_Setting aspd1{false, 0, 0};
     AP_OSD_Setting aspd2{false, 0, 0};
     AP_OSD_Setting vspeed{true, 24, 9};
-
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
     AP_OSD_Setting blh_temp {false, 24, 13};
     AP_OSD_Setting blh_rpm{false, 22, 12};
     AP_OSD_Setting blh_amps{false, 24, 14};
 #endif
-
     AP_OSD_Setting gps_latitude{true, 9, 13};
     AP_OSD_Setting gps_longitude{true, 9, 14};
     AP_OSD_Setting roll_angle{false, 0, 0};
@@ -222,13 +220,11 @@ private:
     //helper functions
     void draw_speed(uint8_t x, uint8_t y, float angle_rad, float magnitude);
     void draw_distance(uint8_t x, uint8_t y, float distance);
-
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
     void draw_blh_temp(uint8_t x, uint8_t y);
     void draw_blh_rpm(uint8_t x, uint8_t y);
     void draw_blh_amps(uint8_t x, uint8_t y);
 #endif
-
     void draw_gps_latitude(uint8_t x, uint8_t y);
     void draw_gps_longitude(uint8_t x, uint8_t y);
     void draw_roll_angle(uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -341,8 +341,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     AP_SUBGROUPINFO(vspeed, "VSPEED", 20, AP_OSD_Screen, AP_OSD_Setting),
-
-#ifdef HAVE_AP_BLHELI_SUPPORT
+#if HAL_WITH_ESC_TELEM
     // @Param: BLHTEMP_EN
     // @DisplayName: BLHTEMP_EN
     // @Description: Displays first esc's temp
@@ -391,7 +390,6 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(blh_amps, "BLHAMPS", 23, AP_OSD_Screen, AP_OSD_Setting),
 #endif
-
     // @Param: GPSLAT_EN
     // @DisplayName: GPSLAT_EN
     // @Description: Displays GPS latitude
@@ -1503,52 +1501,40 @@ void AP_OSD_Screen::draw_vspeed(uint8_t x, uint8_t y)
     }
 }
 
-#ifdef HAVE_AP_BLHELI_SUPPORT
-
+#if HAL_WITH_ESC_TELEM
 void AP_OSD_Screen::draw_blh_temp(uint8_t x, uint8_t y)
 {
-    AP_BLHeli *blheli = AP_BLHeli::get_singleton();
-    if (blheli) {
-        AP_BLHeli::telem_data td;
-        // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
-        if (!blheli->get_telem_data(0, td)) {
-            return;
-        }
-
-        // AP_BLHeli & blh = AP_BLHeli::AP_BLHeli();
-        uint8_t esc_temp = td.temperature;
-        backend->write(x, y, false, "%3d%c", (int)u_scale(TEMPERATURE, esc_temp), u_icon(TEMPERATURE));
+    int16_t etemp;
+    // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
+    if (!AP::esc_telem().get_temperature(0, etemp)) {
+        return;
     }
+
+    uint8_t esc_temp = uint8_t(etemp);
+    backend->write(x, y, false, "%3d%c", (int)u_scale(TEMPERATURE, esc_temp), u_icon(TEMPERATURE));
 }
 
 void AP_OSD_Screen::draw_blh_rpm(uint8_t x, uint8_t y)
 {
-    AP_BLHeli *blheli = AP_BLHeli::get_singleton();
-    if (blheli) {
-        AP_BLHeli::telem_data td;
-        // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
-        if (!blheli->get_telem_data(0, td)) {
-            return;
-        }
-        backend->write(x, y, false, "%5d%c", td.rpm, SYM_RPM);
+    float rpm;
+    // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
+    if (!AP::esc_telem().get_rpm(0, rpm)) {
+        return;
     }
+    backend->write(x, y, false, "%5d%c", uint16_t(rpm), SYM_RPM);
 }
 
 void AP_OSD_Screen::draw_blh_amps(uint8_t x, uint8_t y)
 {
-    AP_BLHeli *blheli = AP_BLHeli::get_singleton();
-    if (blheli) {
-        AP_BLHeli::telem_data td;
-        // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
-        if (!blheli->get_telem_data(0, td)) {
-            return;
-        }
-
-        float esc_amps = td.current * 0.01;
-        backend->write(x, y, false, "%4.1f%c", esc_amps, SYM_AMP);
+    uint16_t amps_ca;
+    // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
+    if (!AP::esc_telem().get_current_ca(0, amps_ca)) {
+        return;
     }
+    float esc_amps = amps_ca * 0.01;
+    backend->write(x, y, false, "%4.1f%c", esc_amps, SYM_AMP);
 }
-#endif  //HAVE_AP_BLHELI_SUPPORT
+#endif
 
 void AP_OSD_Screen::draw_gps_latitude(uint8_t x, uint8_t y)
 {

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -245,8 +245,6 @@ bool AP_PiccoloCAN::read_frame(AP_HAL::CANFrame &recv_frame, uint64_t timeout)
 // called from SRV_Channels
 void AP_PiccoloCAN::update()
 {
-    uint64_t timestamp = AP_HAL::micros64();
-
     /* Read out the ESC commands from the channel mixer */
     for (uint8_t i = 0; i < PICCOLO_CAN_MAX_NUM_ESC; i++) {
 
@@ -263,105 +261,7 @@ void AP_PiccoloCAN::update()
             }
         }
     }
-
-    AP_Logger *logger = AP_Logger::get_singleton();
-
-    // Push received telemtry data into the logging system
-    if (logger && logger->logging_enabled()) {
-
-        WITH_SEMAPHORE(_telem_sem);
-
-        for (uint8_t i = 0; i < PICCOLO_CAN_MAX_NUM_ESC; i++) {
-
-            PiccoloESC_Info_t &esc = _esc_info[i];
-
-            if (esc.newTelemetry) {
-
-                logger->Write_ESC(i, timestamp,
-                                  (int32_t) esc.rpm * 100,
-                                  esc.voltage,
-                                  esc.current,
-                                  (int16_t) esc.fetTemperature,
-                                  0,  // TODO - Accumulated current
-                                  (int16_t) esc.motorTemperature);
-
-                esc.newTelemetry = false;
-            }
-        }
-    }
 }
-
-// send ESC telemetry messages over MAVLink
-void AP_PiccoloCAN::send_esc_telemetry_mavlink(uint8_t mav_chan)
-{
-    // Arrays to store ESC telemetry data
-    uint8_t temperature[4] {};
-    uint16_t voltage[4] {};
-    uint16_t rpm[4] {};
-    uint16_t count[4] {};
-    uint16_t current[4] {};
-    uint16_t totalcurrent[4] {};
-
-    bool dataAvailable = false;
-
-    uint8_t idx = 0;
-
-    WITH_SEMAPHORE(_telem_sem);
-
-    for (uint8_t ii = 0; ii < PICCOLO_CAN_MAX_NUM_ESC; ii++) {
-
-        // Calculate index within storage array
-        idx = (ii % 4);
-
-        PiccoloESC_Info_t &esc = _esc_info[idx];
-
-        // Has the ESC been heard from recently?
-        if (is_esc_present(ii)) {
-            dataAvailable = true;
-
-            temperature[idx] = esc.fetTemperature;
-            voltage[idx] = esc.voltage;
-            current[idx] = esc.current;
-            totalcurrent[idx] = 0;
-            rpm[idx] = esc.rpm;
-            count[idx] = 0;
-        } else {
-            temperature[idx] = 0;
-            voltage[idx] = 0;
-            current[idx] = 0;
-            totalcurrent[idx] = 0;
-            rpm[idx] = 0;
-            count[idx] = 0;
-        }
-
-        // Send ESC telemetry in groups of 4
-        if ((ii % 4) == 3) {
-
-            if (dataAvailable) {
-                if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t) mav_chan, ESC_TELEMETRY_1_TO_4)) {
-                    continue;
-                }
-
-                switch (ii) {
-                case 3:
-                    mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t) mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
-                    break;
-                case 7:
-                    mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t) mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
-                    break;
-                case 11:
-                    mavlink_msg_esc_telemetry_9_to_12_send((mavlink_channel_t) mav_chan, temperature, voltage, current, totalcurrent, rpm, count);
-                    break;
-                default:
-                    break;
-                }
-            }
-
-            dataAvailable = false;
-        }
-    }
-}
-
 
 // send ESC messages over CAN
 void AP_PiccoloCAN::send_esc_messages(void)
@@ -483,6 +383,7 @@ bool AP_PiccoloCAN::handle_esc_message(AP_HAL::CANFrame &frame)
     // Throw the packet against each decoding routine
     if (decodeESC_StatusAPacket(&frame, &esc.mode, &esc.status, &esc.setpoint, &esc.rpm)) {
         esc.newTelemetry = true;
+        update_rpm(addr, esc.rpm);
     } else if (decodeESC_LegacyStatusAPacket(&frame, &esc.mode, &legacyStatus, &legacyWarnings, &legacyErrors, &esc.setpoint, &esc.rpm)) {
         // The status / warning / error bits need to be converted to modern values
         // Note: Not *all* of the modern status bits are available in the Gen-1 packet
@@ -507,8 +408,22 @@ bool AP_PiccoloCAN::handle_esc_message(AP_HAL::CANFrame &frame)
 
         // There are no common error bits between the Gen-1 and Gen-2 ICD
     } else if (decodeESC_StatusBPacket(&frame, &esc.voltage, &esc.current, &esc.dutyCycle, &esc.escTemperature, &esc.motorTemperature)) {
+        TelemetryData t {
+            .temperature_deg = esc.escTemperature,
+            .voltage_cv = esc.voltage,
+            .current_ca = uint16_t(esc.current),
+        };
+        update_telem_data(addr, t,
+            AP_ESC_Telem_Backend::TelemetryType::CURRENT
+                | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE
+                | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
+
         esc.newTelemetry = true;
     } else if (decodeESC_StatusCPacket(&frame, &esc.fetTemperature, &esc.pwmFrequency, &esc.timingAdvance)) {
+        TelemetryData t { };
+        t.motor_temp_deg = esc.fetTemperature;
+        update_telem_data(addr, t, AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE);
+
         esc.newTelemetry = true;
     } else if (decodeESC_WarningErrorStatusPacket(&frame, &esc.warnings, &esc.errors)) {
         esc.newTelemetry = true;
@@ -529,7 +444,6 @@ bool AP_PiccoloCAN::handle_esc_message(AP_HAL::CANFrame &frame)
 
     return result;
 }
-
 
 /**
  * Check if a given ESC channel is "active" (has been configured correctly)
@@ -555,13 +469,13 @@ bool AP_PiccoloCAN::is_esc_channel_active(uint8_t chan)
 /**
  * Determine if an ESC is present on the CAN bus (has telemetry data been received)
  */
-bool AP_PiccoloCAN::is_esc_present(uint8_t chan, uint64_t timeout_ms)
+bool AP_PiccoloCAN::is_esc_present(uint8_t chan, uint64_t timeout_ms) const
 {
     if (chan >= PICCOLO_CAN_MAX_NUM_ESC) {
         return false;
     }
 
-    PiccoloESC_Info_t &esc = _esc_info[chan];
+    const PiccoloESC_Info_t &esc = _esc_info[chan];
 
     // No messages received from this ESC
     if (esc.last_rx_msg_timestamp == 0) {

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
@@ -22,6 +22,7 @@
 #include <AP_HAL/Semaphores.h>
 
 #include <AP_Param/AP_Param.h>
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 
 #include "piccolo_protocol/ESCPackets.h"
 #include "piccolo_protocol/LegacyESCPackets.h"
@@ -40,7 +41,7 @@
 #define PICCOLO_MSG_RATE_HZ_MAX 500
 #define PICCOLO_MSG_RATE_HZ_DEFAULT 50
 
-class AP_PiccoloCAN : public AP_CANDriver
+class AP_PiccoloCAN : public AP_CANDriver, public AP_ESC_Telem_Backend
 {
 public:
     AP_PiccoloCAN();
@@ -79,14 +80,11 @@ public:
     // called from SRV_Channels
     void update();
 
-    // send ESC telemetry messages over MAVLink
-    void send_esc_telemetry_mavlink(uint8_t mav_chan);
-
     // return true if a particular ESC is 'active' on the Piccolo interface
     bool is_esc_channel_active(uint8_t chan);
 
     // return true if a particular ESC has been detected
-    bool is_esc_present(uint8_t chan, uint64_t timeout_ms = 2000);
+    bool is_esc_present(uint8_t chan, uint64_t timeout_ms = 2000) const;
 
     // return true if a particular ESC is enabled
     bool is_esc_enabled(uint8_t chan);

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36: AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36: AHRS, 37: SmartAudio, 38: FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink2),
@@ -144,7 +144,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SERIAL2_PROTOCOL),
@@ -161,7 +161,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SERIAL3_PROTOCOL),
@@ -178,7 +178,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SERIAL4_PROTOCOL),
@@ -195,7 +195,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
@@ -214,7 +214,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 6_PROTOCOL
     // @DisplayName: Serial6 protocol selection
     // @Description: Control what protocol Serial6 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("6_PROTOCOL",  12, AP_SerialManager, state[6].protocol, SERIAL6_PROTOCOL),
@@ -313,7 +313,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 7_PROTOCOL
     // @DisplayName: Serial7 protocol selection
     // @Description: Control what protocol Serial7 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("7_PROTOCOL",  23, AP_SerialManager, state[7].protocol, SERIAL7_PROTOCOL),
@@ -338,7 +338,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 8_PROTOCOL
     // @DisplayName: Serial8 protocol selection
     // @Description: Control what protocol Serial8 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37: SmartAudio, 38:FETtecOneWire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("8_PROTOCOL",  26, AP_SerialManager, state[8].protocol, SERIAL8_PROTOCOL),

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -151,6 +151,7 @@ public:
         SerialProtocol_ADSB = 35,
         SerialProtocol_AHRS = 36,
         SerialProtocol_SmartAudio = 37,
+        SerialProtocol_FETtecOneWire = 38,
         SerialProtocol_NumProtocols                    // must be the last value
     };
 

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -305,25 +305,18 @@ void AP_ToshibaCAN::loop()
                     // store response in telemetry array
                     const uint8_t esc_id = recv_frame.id - MOTOR_DATA1;
                     if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
-                        WITH_SEMAPHORE(_telem_sem);
-                        _telemetry[esc_id].rpm = (int16_t)be16toh(reply_data.rpm);
-                        _telemetry[esc_id].current_ca = MAX((int16_t)be16toh(reply_data.current_ma), 0) * (4.0f * 0.1f);    // milli-amps to centi-amps
-                        _telemetry[esc_id].voltage_cv = be16toh(reply_data.voltage_mv) * 0.1f;  // millivolts to centi-volts
-                        _telemetry[esc_id].count++;
-                        _telemetry[esc_id].new_data = true;
-
-                        update_rpm(esc_id, _telemetry[esc_id].rpm);
+                        update_rpm(esc_id, (int16_t)be16toh(reply_data.rpm));
 
                         // update total current
                         const uint32_t now_ms = AP_HAL::native_millis();
                         const uint32_t diff_ms = now_ms - _telemetry[esc_id].last_update_ms;
-                        if (diff_ms <= 1000) {
-                            // convert centi-amps miiliseconds to mAh
-                            _telemetry[esc_id].current_tot_mah += _telemetry[esc_id].current_ca * diff_ms * centiamp_ms_to_mah;
-                        }
                         TelemetryData t {};
-                        t.voltage_cv = _telemetry[esc_id].voltage_cv;
-                        t.current_ca = _telemetry[esc_id].current_ca;
+                        t.voltage_cv = be16toh(reply_data.voltage_mv) * 0.1f;  // millivolts to centi-volts
+                        t.current_ca = MAX((int16_t)be16toh(reply_data.current_ma), 0) * (4.0f * 0.1f); // milli-amps to centi-amps
+                        if (diff_ms <= 1000) {
+                            // convert centi-amps miliseconds to mAh
+                            _telemetry[esc_id].current_tot_mah += t.current_ca * diff_ms * centiamp_ms_to_mah;
+                        }
                         t.consumption_mah = uint16_t(_telemetry[esc_id].current_tot_mah);
                         update_telem_data(esc_id, t,
                             AP_ESC_Telem_Backend::TelemetryType::CURRENT
@@ -352,15 +345,14 @@ void AP_ToshibaCAN::loop()
                     // store response in telemetry array
                     uint8_t esc_id = recv_frame.id - MOTOR_DATA2;
                     if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
-                        WITH_SEMAPHORE(_telem_sem);
-                        _telemetry[esc_id].esc_temp = temp_max < 100 ? 0 : temp_max / 5 - 20;
-                        _telemetry[esc_id].motor_temp = motor_temp < 100 ? 0 : motor_temp / 5 - 20;
+                        const int16_t esc_temp = temp_max < 100 ? 0 : temp_max / 5 - 20;
+                        const int16_t motor_temp_deg = motor_temp < 100 ? 0 : motor_temp / 5 - 20;
                         _esc_present_bitmask_recent |= ((uint32_t)1 << esc_id);
 
                         TelemetryData t {
-                            .temperature_deg = int16_t(_telemetry[esc_id].esc_temp)
+                            .temperature_deg = esc_temp
                         };
-                        t.motor_temp_deg = int16_t(_telemetry[esc_id].motor_temp);
+                        t.motor_temp_deg = motor_temp_deg;
                         update_telem_data(esc_id, t, AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE |
                             AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
                     }
@@ -377,12 +369,10 @@ void AP_ToshibaCAN::loop()
                     // store response in telemetry array
                     uint8_t esc_id = recv_frame.id - MOTOR_DATA3;
                     if (esc_id < TOSHIBACAN_MAX_NUM_ESCS) {
-                        WITH_SEMAPHORE(_telem_sem);
-                        _telemetry[esc_id].usage_sec = usage_sec;
                         _esc_present_bitmask_recent |= ((uint32_t)1 << esc_id);
 
                         TelemetryData t {};
-                        t.usage_s = _telemetry[esc_id].usage_sec;
+                        t.usage_s = usage_sec;
                         update_telem_data(esc_id, t, AP_ESC_Telem_Backend::TelemetryType::USAGE);
                     }
                 }

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -311,6 +311,9 @@ void AP_ToshibaCAN::loop()
                         _telemetry[esc_id].voltage_cv = be16toh(reply_data.voltage_mv) * 0.1f;  // millivolts to centi-volts
                         _telemetry[esc_id].count++;
                         _telemetry[esc_id].new_data = true;
+
+                        update_rpm(esc_id, _telemetry[esc_id].rpm);
+
                         // update total current
                         const uint32_t now_ms = AP_HAL::native_millis();
                         const uint32_t diff_ms = now_ms - _telemetry[esc_id].last_update_ms;
@@ -318,6 +321,15 @@ void AP_ToshibaCAN::loop()
                             // convert centi-amps miiliseconds to mAh
                             _telemetry[esc_id].current_tot_mah += _telemetry[esc_id].current_ca * diff_ms * centiamp_ms_to_mah;
                         }
+                        TelemetryData t {};
+                        t.voltage_cv = _telemetry[esc_id].voltage_cv;
+                        t.current_ca = _telemetry[esc_id].current_ca;
+                        t.consumption_mah = uint16_t(_telemetry[esc_id].current_tot_mah);
+                        update_telem_data(esc_id, t,
+                            AP_ESC_Telem_Backend::TelemetryType::CURRENT
+                                | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE
+                                | AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION);
+
                         _telemetry[esc_id].last_update_ms = now_ms;
                         _esc_present_bitmask_recent |= ((uint32_t)1 << esc_id);
                     }
@@ -344,6 +356,13 @@ void AP_ToshibaCAN::loop()
                         _telemetry[esc_id].esc_temp = temp_max < 100 ? 0 : temp_max / 5 - 20;
                         _telemetry[esc_id].motor_temp = motor_temp < 100 ? 0 : motor_temp / 5 - 20;
                         _esc_present_bitmask_recent |= ((uint32_t)1 << esc_id);
+
+                        TelemetryData t {
+                            .temperature_deg = int16_t(_telemetry[esc_id].esc_temp)
+                        };
+                        t.motor_temp_deg = int16_t(_telemetry[esc_id].motor_temp);
+                        update_telem_data(esc_id, t, AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE |
+                            AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
                     }
                 }
 
@@ -361,6 +380,10 @@ void AP_ToshibaCAN::loop()
                         WITH_SEMAPHORE(_telem_sem);
                         _telemetry[esc_id].usage_sec = usage_sec;
                         _esc_present_bitmask_recent |= ((uint32_t)1 << esc_id);
+
+                        TelemetryData t {};
+                        t.usage_s = _telemetry[esc_id].usage_sec;
+                        update_telem_data(esc_id, t, AP_ESC_Telem_Backend::TelemetryType::USAGE);
                     }
                 }
             }
@@ -456,102 +479,6 @@ void AP_ToshibaCAN::update()
         }
         update_count++;
     }
-
-    // log ESCs telemetry info
-    AP_Logger *logger = AP_Logger::get_singleton();
-    if (logger && logger->logging_enabled()) {
-        WITH_SEMAPHORE(_telem_sem);
-
-        // log if any new data received.  Logging only supports up to 8 ESCs
-        const uint64_t time_us = AP_HAL::native_micros64();
-        for (uint8_t i = 0; i < MIN(TOSHIBACAN_MAX_NUM_ESCS, 8); i++) {
-            if (_telemetry[i].new_data) {
-                logger->Write_ESC(i, time_us,
-                              _telemetry[i].rpm * 100U,
-                              _telemetry[i].voltage_cv,
-                              _telemetry[i].current_ca,
-                              _telemetry[i].esc_temp * 100U,
-                              constrain_float(_telemetry[i].current_tot_mah, 0, UINT16_MAX),
-                              _telemetry[i].motor_temp * 100U);
-                _telemetry[i].new_data = false;
-            }
-        }
-    }
-}
-
-// send ESC telemetry messages over MAVLink
-void AP_ToshibaCAN::send_esc_telemetry_mavlink(uint8_t mav_chan)
-{
-    // compile time check this method handles the correct number of motors
-    static_assert(TOSHIBACAN_MAX_NUM_ESCS == 12, "update AP_ToshibaCAN::send_esc_telemetry_mavlink only handles 12 motors");
-
-    // return immediately if no ESCs have been found
-    if (_esc_present_bitmask == 0) {
-        return;
-    }
-
-    // output telemetry messages
-    {
-        // take semaphore to access telemetry data
-        WITH_SEMAPHORE(_telem_sem);
-
-        // loop through 3 groups of 4 ESCs
-        for (uint8_t i = 0; i < 3; i++) {
-
-            // return if no space in output buffer to send mavlink messages
-            if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)mav_chan, ESC_TELEMETRY_1_TO_4)) {
-                return;
-            }
-
-            // skip this group of ESCs if no data to send
-            if ((_esc_present_bitmask & ((uint32_t)0x0F << i*4)) == 0) {
-                continue;
-            }
-
-            // arrays to hold output
-            uint8_t temperature[4] {};
-            uint16_t voltage[4] {};
-            uint16_t current[4] {};
-            uint16_t current_tot[4] {};
-            uint16_t rpm[4] {};
-            uint16_t count[4] {};
-
-            // fill in output arrays
-            for (uint8_t j = 0; j < 4; j++) {
-                uint8_t esc_id = i * 4 + j;
-                temperature[j] = _telemetry[esc_id].esc_temp;
-                voltage[j] = _telemetry[esc_id].voltage_cv;
-                current[j] = _telemetry[esc_id].current_ca;
-                current_tot[j] = constrain_float(_telemetry[esc_id].current_tot_mah, 0, UINT16_MAX);
-                rpm[j] = abs(_telemetry[esc_id].rpm);   // mavlink message only accepts positive rpm values
-                count[j] = _telemetry[esc_id].count;
-            }
-
-            // send messages
-            switch (i) {
-                case 0:
-                    mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
-                    break;
-                case 1:
-                    mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
-                    break;
-                case 2:
-                    mavlink_msg_esc_telemetry_9_to_12_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
-                    break;
-                default:
-                    break;
-            }
-        }
-    }
-}
-
-// return total usage time in seconds
-uint32_t AP_ToshibaCAN::get_usage_seconds(uint8_t esc_id) const
-{
-    if (esc_id >= TOSHIBACAN_MAX_NUM_ESCS) {
-        return 0;
-    }
-    return _telemetry[esc_id].usage_sec;
 }
 
 // helper function to create motor_request_data_cmd_t

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -96,19 +96,9 @@ private:
     uint16_t update_count_sent;     // counter of outputs successfully sent
     uint8_t send_stage;             // stage of sending algorithm (each stage sends one frame to ESCs)
 
-    // telemetry data (rpm, voltage)
-    HAL_Semaphore _telem_sem;
     struct telemetry_info_t {
-        int16_t rpm;                // rpm
-        uint16_t voltage_cv;        // voltage in centi-volts
-        uint16_t current_ca;        // current in centi-amps
-        uint16_t esc_temp;          // esc temperature in degrees
-        uint16_t motor_temp;        // motor temperature in degrees
-        uint16_t count;             // total number of packets sent
-        uint32_t usage_sec;         // motor's total usage in seconds
         uint32_t last_update_ms;    // system time telemetry was last update (used to calc total current)
         float current_tot_mah;      // total current in mAh
-        bool new_data;              // true if new telemetry data has been filled in but not logged yet
     } _telemetry[TOSHIBACAN_MAX_NUM_ESCS];
     uint32_t _telemetry_req_ms;     // system time (in milliseconds) to request data from escs (updated at 10hz)
     uint8_t _telemetry_temp_req_counter;    // counter used to trigger temp data requests from ESCs (10x slower than other telem data)

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 #include <AP_CANManager/AP_CANDriver.h>
 #include <AP_HAL/Semaphores.h>
 
@@ -22,7 +23,7 @@
 
 class CANTester;
 
-class AP_ToshibaCAN : public AP_CANDriver {
+class AP_ToshibaCAN : public AP_CANDriver, public AP_ESC_Telem_Backend {
     friend class CANTester;
 public:
     AP_ToshibaCAN();
@@ -42,14 +43,8 @@ public:
     // called from SRV_Channels
     void update();
 
-    // send ESC telemetry messages over MAVLink
-    void send_esc_telemetry_mavlink(uint8_t mav_chan);
-
     // return a bitmask of escs that are "present" which means they are responding to requests.  Bitmask matches RC outputs
     uint16_t get_present_mask() const { return _esc_present_bitmask; }
-
-    // return total usage time in seconds
-    uint32_t get_usage_seconds(uint8_t esc_id) const;
 
 private:
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -349,79 +349,6 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
 }
 #pragma GCC diagnostic pop
 
-// send ESC telemetry messages over MAVLink
-void AP_UAVCAN::send_esc_telemetry_mavlink(uint8_t mav_chan)
-{
-#ifndef HAL_NO_GCS
-    static const uint8_t MAV_ESC_GROUPS = 3;
-    static const uint8_t MAV_ESC_PER_GROUP = 4;
-
-    for (uint8_t i = 0; i < MAV_ESC_GROUPS; i++) {
-
-        // arrays to hold output
-        uint8_t temperature[MAV_ESC_PER_GROUP] {};
-        uint16_t voltage[MAV_ESC_PER_GROUP] {};
-        uint16_t current[MAV_ESC_PER_GROUP] {};
-        uint16_t current_tot[MAV_ESC_PER_GROUP] {};
-        uint16_t rpm[MAV_ESC_PER_GROUP] {};
-        uint16_t count[MAV_ESC_PER_GROUP] {};
-
-        // if at least one of the ESCs in the group is availabe, the group
-        // is considered to be available too, and will be sent over MAVlink
-        bool group_available = false;
-
-        // fill in output arrays of ESCs sensors with available data.
-        for (uint8_t j = 0; j < MAV_ESC_PER_GROUP; j++) {
-            const uint8_t esc_idx = i * MAV_ESC_PER_GROUP + j;
-            
-            if (!is_esc_data_index_valid(esc_idx)) {
-                return;
-            }
-
-            WITH_SEMAPHORE(_telem_sem);
-            
-            if (!_escs_data[esc_idx].available) {
-                continue;
-            } 
-
-            _escs_data[esc_idx].available = false;
-
-            temperature[j] = _escs_data[esc_idx].temp;
-            voltage[j] = _escs_data[esc_idx].voltage;
-            current[j] = _escs_data[esc_idx].current;
-            current_tot[j] = 0; // currently not implemented
-            rpm[j] = _escs_data[esc_idx].rpm;
-            count[j] = _escs_data[esc_idx].count;
-
-            group_available = true;
-        }
-
-        if (!group_available) {
-            continue;
-        }
-
-        if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t) mav_chan, ESC_TELEMETRY_1_TO_4)) {
-            return;
-        }
-
-        // send messages
-        switch (i) {
-            case 0:
-                mavlink_msg_esc_telemetry_1_to_4_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
-                break;
-            case 1:
-                mavlink_msg_esc_telemetry_5_to_8_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
-                break;
-            case 2:
-                mavlink_msg_esc_telemetry_9_to_12_send((mavlink_channel_t)mav_chan, temperature, voltage, current, current_tot, rpm, count);
-                break;
-            default:
-                break;
-        }
-    }
-#endif // HAL_NO_GCS
-}
-
 void AP_UAVCAN::loop(void)
 {
     while (true) {
@@ -891,6 +818,17 @@ void AP_UAVCAN::handle_ESC_status(AP_UAVCAN* ap_uavcan, uint8_t node_id, const E
     esc.rpm = cb.msg->rpm;
     esc.count++;
 
+    TelemetryData t {
+        .temperature_deg = esc.temp,
+        .voltage_cv = esc.voltage,
+        .current_ca = esc.current,
+    };
+
+    ap_uavcan->update_rpm(esc_index, esc.rpm);
+    ap_uavcan->update_telem_data(esc_index, t,
+        AP_ESC_Telem_Backend::TelemetryType::CURRENT
+            | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE
+            | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
 }
 
 bool AP_UAVCAN::is_esc_data_index_valid(const uint8_t index) {

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -72,7 +72,7 @@ class DebugCb;
 
 /*
     Frontend Backend-Registry Binder: Whenever a message of said DataType_ from new node is received,
-    the Callback will invoke registery to register the node as separate backend.
+    the Callback will invoke registry to register the node as separate backend.
 */
 #define UC_REGISTRY_BINDER(ClassName_, DataType_) \
     class ClassName_ : public AP_UAVCAN::RegistryBinder<DataType_> { \
@@ -123,7 +123,7 @@ public:
 
     public:
         RegistryBinder() :
-        	_uc(),
+            _uc(),
             _ffunc(),
             msg() {}
 
@@ -224,18 +224,6 @@ private:
 
     static HAL_Semaphore _telem_sem;
 
-    struct esc_data {
-        uint8_t temp;
-        uint16_t voltage;
-        uint16_t current;
-        uint16_t total_current;
-        uint16_t rpm;
-        uint16_t count; //count of telemetry packets received (wraps at 65535).
-        bool available;
-    };
-
-    static esc_data _escs_data[UAVCAN_SRV_NUMBER];
-    
     // safety status send state
     uint32_t _last_safety_state_ms;
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -27,6 +27,7 @@
 #include <AP_CANManager/AP_CANDriver.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 
 #include <uavcan/helpers/heap_based_pool_allocator.hpp>
 
@@ -84,7 +85,7 @@ class DebugCb;
             DISABLE_W_CAST_FUNCTION_TYPE_POP \
     }
 
-class AP_UAVCAN : public AP_CANDriver {
+class AP_UAVCAN : public AP_CANDriver, public AP_ESC_Telem_Backend {
 public:
     AP_UAVCAN();
     ~AP_UAVCAN();
@@ -96,9 +97,6 @@ public:
 
     void init(uint8_t driver_index, bool enable_filters) override;
     bool add_interface(AP_HAL::CANIface* can_iface) override;
-
-    // send ESC telemetry messages over MAVLink
-    void send_esc_telemetry_mavlink(uint8_t mav_chan);
     
     uavcan::Node<0>* get_node() { return _node; }
     uint8_t get_driver_index() const { return _driver_index; }
@@ -237,7 +235,6 @@ private:
     };
 
     static esc_data _escs_data[UAVCAN_SRV_NUMBER];
-
     
     // safety status send state
     uint32_t _last_safety_state_ms;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -163,7 +163,7 @@ void AP_Vehicle::setup()
 
 #if HAL_WITH_ESC_TELEM
     // initialise ESC Telemetry right before we start pushing to the motors
-    AP::esc_telem().init();
+    esc_telem.init();
 #endif
 }
 
@@ -211,6 +211,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
     SCHED_TASK(update_dynamic_notch,                   200,    200),
     SCHED_TASK_CLASS(AP_VideoTX,   &vehicle.vtx,            update,                    2, 100),
     SCHED_TASK(send_watchdog_reset_statustext,         0.1,     20),
+#if HAL_WITH_ESC_TELEM
+    SCHED_TASK_CLASS(AP_ESC_Telem, &vehicle.esc_telem,      update,                   10,  50),
+#endif
 #if GENERATOR_ENABLED
     SCHED_TASK_CLASS(AP_Generator, &vehicle.generator,      update,                   10,  50),
 #endif

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -160,6 +160,11 @@ void AP_Vehicle::setup()
 #if GENERATOR_ENABLED
     generator.init();
 #endif
+
+#if HAL_WITH_ESC_TELEM
+    // initialise ESC Telemetry right before we start pushing to the motors
+    AP::esc_telem().init();
+#endif
 }
 
 void AP_Vehicle::loop()

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -306,7 +306,9 @@ protected:
     AP_VisualOdom visual_odom;
 #endif
 
+#if HAL_WITH_ESC_TELEM
     AP_ESC_Telem esc_telem;
+#endif
 
 #if HAL_MSP_ENABLED
     AP_MSP msp;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4914,60 +4914,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         send_autopilot_version();
         break;
 
-    case MSG_ESC_TELEMETRY: {
-#ifdef HAVE_AP_BLHELI_SUPPORT
-        CHECK_PAYLOAD_SIZE(ESC_TELEMETRY_1_TO_4);
-        AP_BLHeli *blheli = AP_BLHeli::get_singleton();
-        if (blheli) {
-            blheli->send_esc_telemetry_mavlink(uint8_t(chan));
-        }
-#endif
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-        uint8_t num_drivers = AP::can().get_num_drivers();
-
-        for (uint8_t i = 0; i < num_drivers; i++) {
-            switch (AP::can().get_driver_type(i)) {
-                case AP_CANManager::Driver_Type_KDECAN: {
-// To be replaced with macro saying if KDECAN library is included
-#if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_ArduSub)
-                    AP_KDECAN *ap_kdecan = AP_KDECAN::get_kdecan(i);
-                    if (ap_kdecan != nullptr) {
-                        ap_kdecan->send_mavlink(uint8_t(chan));
-                    }
-#endif
-                    break;
-                }
-                case AP_CANManager::Driver_Type_ToshibaCAN: {
-                    AP_ToshibaCAN *ap_tcan = AP_ToshibaCAN::get_tcan(i);
-                    if (ap_tcan != nullptr) {
-                        ap_tcan->send_esc_telemetry_mavlink(uint8_t(chan));
-                    }
-                    break;
-                }
-#if HAL_PICCOLO_CAN_ENABLE
-                case AP_CANManager::Driver_Type_PiccoloCAN: {
-                    AP_PiccoloCAN *ap_pcan = AP_PiccoloCAN::get_pcan(i);
-                    if (ap_pcan != nullptr) {
-                        ap_pcan->send_esc_telemetry_mavlink(uint8_t(chan));
-                    }
-                    break;
-                }
-#endif
-                case AP_CANManager::Driver_Type_UAVCAN: {
-                    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(i);
-                    if (ap_uavcan != nullptr) {
-                        ap_uavcan->send_esc_telemetry_mavlink(uint8_t(chan));
-                    }
-                    break;
-                }
-                case AP_CANManager::Driver_Type_None:
-                default:
-                    break;
-            }
-        }
+    case MSG_ESC_TELEMETRY:
+#ifdef HAL_WITH_ESC_TELEM
+        AP::esc_telem().send_esc_telemetry_mavlink(uint8_t(chan));
 #endif
         break;
-    }
 
     case MSG_EFI_STATUS: {
 #if EFI_ENABLED

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -226,6 +226,7 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     AP_SUBGROUPINFO(baro[1], "BAR2_", 35, SITL, SITL::BaroParm),
     AP_SUBGROUPINFO(baro[2], "BAR3_", 36, SITL, SITL::BaroParm),
 
+    AP_GROUPINFO("ESC_TELEM", 40, SITL, esc_telem, 1),
 
     // user settable parameters for the 1st airspeed sensor
     AP_GROUPINFO("ARSPD_RND",     50, SITL,  arspd_noise[0], 2.0),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -409,6 +409,9 @@ public:
     RichenPower richenpower_sim;
     IntelligentEnergy24 ie24_sim;
 
+    // ESC telemetry
+    AP_Int8 esc_telem;
+
     struct {
         // LED state, for serial LED emulation
         struct {

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -20,6 +20,7 @@
 #include <AP_RobotisServo/AP_RobotisServo.h>
 #include <AP_SBusOut/AP_SBusOut.h>
 #include <AP_BLHeli/AP_BLHeli.h>
+#include <AP_FETtecOneWire/AP_FETtecOneWire.h>
 
 #if !defined(NUM_SERVO_CHANNELS) && defined(HAL_BUILD_AP_PERIPH) && defined(HAL_PWM_COUNT) && (HAL_PWM_COUNT >= 1)
     #define NUM_SERVO_CHANNELS HAL_PWM_COUNT
@@ -547,6 +548,11 @@ private:
     AP_BLHeli blheli;
     static AP_BLHeli *blheli_ptr;
 #endif
+
+#if HAL_AP_FETTECONEWIRE_ENABLED
+    AP_FETtecOneWire fetteconwire;
+    static AP_FETtecOneWire *fetteconwire_ptr;
+#endif  // HAL_AP_FETTECONEWIRE_ENABLED
 #endif // HAL_BUILD_AP_PERIPH
 
     static uint16_t disabled_mask;

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -43,6 +43,9 @@ SRV_Channels *SRV_Channels::_singleton;
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
 AP_SBusOut *SRV_Channels::sbus_ptr;
 AP_RobotisServo *SRV_Channels::robotis_ptr;
+#if HAL_AP_FETTECONEWIRE_ENABLED
+AP_FETtecOneWire *SRV_Channels::fetteconwire_ptr;
+#endif
 #endif // HAL_BUILD_AP_PERIPH
 
 uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
@@ -193,6 +196,13 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Group: _ROB_
     // @Path: ../AP_RobotisServo/AP_RobotisServo.cpp
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
+
+#if HAL_AP_FETTECONEWIRE_ENABLED
+    // @Group: _FTW_
+    // @Path: ../AP_FETtecOneWire/AP_FETtecOneWire.cpp
+    AP_SUBGROUPINFO(fetteconwire, "_FTW_",  23, SRV_Channels, AP_FETtecOneWire),
+#endif
+
 #endif // HAL_BUILD_AP_PERIPH
 
     AP_GROUPEND
@@ -218,6 +228,9 @@ SRV_Channels::SRV_Channels(void)
     volz_ptr = &volz;
     sbus_ptr = &sbus;
     robotis_ptr = &robotis;
+#if HAL_AP_FETTECONEWIRE_ENABLED
+    fetteconwire_ptr = &fetteconwire;
+#endif
 #if HAL_SUPPORT_RCOUT_SERIAL
     blheli_ptr = &blheli;
 #endif
@@ -315,7 +328,11 @@ void SRV_Channels::push()
 
     // give robotis library a chance to update
     robotis_ptr->update();
-    
+
+#if HAL_AP_FETTECONEWIRE_ENABLED
+    fetteconwire_ptr->update();
+#endif
+
 #if HAL_SUPPORT_RCOUT_SERIAL
     // give blheli telemetry a chance to update
     blheli_ptr->update_telemetry();


### PR DESCRIPTION
This one is based on top of #16725 with https://github.com/andyp1per/ardupilot/pull/14 on top of it.

requires #16725

It uses a very different approach from my other FETtec PR (#14678) . #14678 has been flight tested, this one is still wip.

- [x] feature complete:
- control motor speed
- copy ESC telemetry data into MAVLink telemetry
- save ESC telemetry data in Dataflash logs
- use RPM telemetry for dynamic notch filter frequencies
- sum the current telemetry info from all ESCs and use it as virtual battery current monitor sensor
- average the voltage telemetry info and use it as virtual battery voltage monitor sensor
- [x] passes CI
- [x] [addressed all TODOs](https://ardupilot.org/dev/docs/editing-prs.html) in the code:
- https://github.com/ArduPilot/ardupilot/pull/16850/files#diff-e4e0df6b1a14c8042ee98aa009d835584310eb2b116051b83a8c6813fa756a5eR69
- https://github.com/ArduPilot/ardupilot/pull/16850/files#diff-224165226fc822e0d28dc499f19997946ec00db384651687ed5f4e4cc0f2d8d3R144
- [ ] flight tested with a Hex frame using the last 6 channels (FETtec ID 7 to 12) 1 to 6 are unused/unassigned
- [ ] mavlink telemetry works (analyzed a TLOG to see that [ESC_TELEMETRY_1_TO_4](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_1_TO_4) and [ESC_TELEMETRY_5_TO_8](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_5_TO_8) messages are present or that [ESC_TELEMETRY_5_TO_8](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_5_TO_8) and [ESC_TELEMETRY_9_TO_12](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_9_TO_12) messages are present and their contents correct)
- [ ] dataflash logs have ESC telemetry data in ESC7..12
- [x] flight tested with a Hex frame using the first 6 channels (FETtec ID 1 to 6)
- [ ] mavlink telemetry works (analyzed a TLOG to see that [ESC_TELEMETRY_1_TO_4](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_1_TO_4) and [ESC_TELEMETRY_5_TO_8](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_5_TO_8) messages are present and their contents correct)
- [x] dataflash logs have ESC telemetry data in ESC1..6
- [ ] six independent [notch filters](https://ardupilot.org/copter/docs/common-imu-notch-filtering.html) work (used a hex for testing) 
- INS_HNTCH_ENABLE = 1,
- [INS_HNTCH_MODE](https://ardupilot.org/copter/docs/parameters.html#ins-hntch-mode-harmonic-notch-filter-dynamic-frequency-tracking-mode) = 3 (ESC telemetry),
- [INS_HNTCH_OPTS](https://ardupilot.org/copter/docs/parameters.html#ins-hntch-opts-harmonic-notch-filter-options) = 2 (dynamic notch)
- [INS_HNTCH_REF](https://ardupilot.org/copter/docs/parameters.html#ins-hntch-ref) = 1
- [ ] [IMU noise levels](https://ardupilot.org/copter/docs/common-imu-fft.html) measured before [notch filtering](https://ardupilot.org/copter/docs/common-imu-notch-filtering.html)
- [INS_LOG_BAT_MASK](https://ardupilot.org/copter/docs/parameters.html#ins-log-bat-mask) = 1
- [INS_LOG_BAT_OPT](https://ardupilot.org/copter/docs/parameters.html#ins-log-bat-opt-batch-logging-options-mask) = 0
- @teezeefpv please add a  [MissionPlanner FFT picture](https://ardupilot.org/planner/docs/common-measuring-vibration.html) here like described in the [noise analysis page](https://ardupilot.org/copter/docs/common-imu-batchsampling.html)
- [ ] [IMU noise levels](https://ardupilot.org/copter/docs/common-imu-fft.html) measured after [notch filtering](https://ardupilot.org/copter/docs/common-imu-notch-filtering.html)
- [INS_LOG_BAT_OPT](https://ardupilot.org/copter/docs/parameters.html#ins-log-bat-opt-batch-logging-options-mask) = 2
- @teezeefpv please add a [MissionPlanner FFT picture](https://ardupilot.org/planner/docs/common-measuring-vibration.html) here like described in the [noise analysis page](https://ardupilot.org/copter/docs/common-imu-batchsampling.html)
- [x] voltage and current measurements replace the need for power monitoring hardware:
- [BATT_MONITOR](https://ardupilot.org/copter/docs/parameters.html#batt-monitor-battery-monitoring) = 9 (BLHeli ESC)
- [ ] protocol is documented in the README.md file in the same location as the .cpp implementation file
- [ ] [configuration instructions](/ArduPilot/ardupilot_wiki/pull/3335) are on the ardupilot wiki

@khancyr @Linjieqiang can you help us test this?

Compared to master this PR needs just 480 bytes for ArduCopter on a Durandal flight controller :)

I also [backported most of this to ArduCopter-4.0.7](https://github.com/ArduPilot/ardupilot/pull/16874)