### PR TITLE
AP_InertialSensor: fix temperature sensor on LSM9DS0

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -387,7 +387,7 @@ AP_InertialSensor_LSM9DS0::AP_InertialSensor_LSM9DS0(AP_InertialSensor &imu,
     , _rotation_a(rotation_a)
     , _rotation_g(rotation_g)
     , _rotation_gH(rotation_gH)
-    , _temp_filter(80, 1)
+    , _temp_filter(400, 1)
 {
 }
 
@@ -742,7 +742,7 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_a()
     _notify_new_accel_raw_sample(_accel_instance, accel_data, AP_HAL::micros64());
 
     // read temperature every 10th sample
-    if (_temp_counter == 10) {
+    if (_temp_counter++ >= 10) {
         int16_t traw;
         const uint8_t regtemp = OUT_TEMP_L_XM | 0xC0;
         _temp_counter = 0;


### PR DESCRIPTION
I noticed that there is no temperature data of IMU2 with CubeBlack.
I fixed it by referring to the comment here.
https://github.com/ArduPilot/ardupilot/pull/16262#discussion_r559925464

I also change the filter's sample rate from 80Hz to 400Hz.
This is the test result with CubeBlack.
80Hz
![image](https://user-images.githubusercontent.com/16643069/110407634-87cae380-80c7-11eb-9050-0e28df509a1f.png)
400Hz
![image](https://user-images.githubusercontent.com/16643069/110407703-ac26c000-80c7-11eb-8f65-aedf25b340e0.png)

reference:
https://github.com/ArduPilot/ardupilot/commit/d2f6a514b98b30918fac460e642a6be2f8566cfd