### PR TITLE
autotest: correct wait_current_waypoint timeout behaviour 

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -525,6 +525,7 @@ class AutoTestPlane(AutoTest):
         """Fly a mission from a file."""
         self.progress("Flying mission %s" % filename)
         num_wp = self.load_mission(filename, strict=strict)-1
+        self.set_current_waypoint(0, check_afterwards=False)
         self.change_mode('AUTO')
         self.wait_waypoint(1, num_wp, max_dist=60)
         self.wait_groundspeed(0, 0.5, timeout=mission_timeout)
@@ -2076,7 +2077,6 @@ class AutoTestPlane(AutoTest):
 
     def fly_terrain_mission(self):
 
-        self.set_current_waypoint(1)
         self.wait_ready_to_arm()
         self.arm_vehicle()
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -694,7 +694,7 @@ class AutoTestPlane(AutoTest):
         self.progress("Using %s to fly home" % filename)
         self.load_mission(filename)
         self.change_mode("AUTO")
-        self.set_current_waypoint(7)
+        self.set_current_waypoint(8)
         self.drain_mav()
         # TODO: reflect on file to find this magic waypoint number?
         #        self.wait_waypoint(7, num_wp-1, timeout=500) # we

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4278,19 +4278,25 @@ class AutoTest(ABC):
                      target_sysid=target_sysid,
                      target_compid=target_compid)
 
-    def set_current_waypoint_using_mission_set_current(self,
-                                                       seq,
-                                                       target_sysid=1,
-                                                       target_compid=1):
+    def set_current_waypoint_using_mission_set_current(
+            self,
+            seq,
+            target_sysid=1,
+            target_compid=1,
+            check_afterwards=True):
         self.mav.mav.mission_set_current_send(target_sysid,
                                               target_compid,
                                               seq)
-        self.wait_current_waypoint(seq, timeout=10)
+        if check_afterwards:
+            self.wait_current_waypoint(seq, timeout=10)
 
-    def set_current_waypoint(self, seq, target_sysid=1, target_compid=1):
-        return self.set_current_waypoint_using_mission_set_current(seq,
-                                                                   target_sysid,
-                                                                   target_compid)
+    def set_current_waypoint(self, seq, target_sysid=1, target_compid=1, check_afterwards=True):
+        return self.set_current_waypoint_using_mission_set_current(
+            seq,
+            target_sysid,
+            target_compid,
+            check_afterwards=check_afterwards
+        )
 
     def verify_parameter_values(self, parameter_stuff, max_delta=0.0):
         bad = ""

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5079,7 +5079,9 @@ class AutoTest(ABC):
 
     def wait_current_waypoint(self, wpnum, timeout=60):
         tstart = self.get_sim_time()
-        while self.get_sim_time() < tstart + timeout:
+        while True:
+            if self.get_sim_time() - tstart > timeout:
+                raise AutoTestTimeoutException("Did not get wanted current waypoint")
             seq = self.mav.waypoint_current()
             self.progress("Waiting for wp=%u current=%u" % (wpnum, seq))
             if seq == wpnum:


### PR DESCRIPTION
A timeout was as good as reaching the waypoint - not good.
