### PR TITLE
Copter: do-mount-control commands ignored if no mount

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1452,9 +1452,12 @@ void ModeAuto::do_roi(const AP_Mission::Mission_Command& cmd)
 void ModeAuto::do_mount_control(const AP_Mission::Mission_Command& cmd)
 {
 #if HAL_MOUNT_ENABLED
-    if (!copter.camera_mount.has_pan_control()) {
-        auto_yaw.set_fixed_yaw(cmd.content.mount_control.yaw,0.0f,0,0);
+    // if vehicle has a camera mount but it doesn't do pan control then yaw the entire vehicle instead
+    if ((copter.camera_mount.get_mount_type() != copter.camera_mount.MountType::Mount_Type_None) &&
+        !copter.camera_mount.has_pan_control()) {
+        auto_yaw.set_fixed_yaw(cmd.content.mount_control.yaw,0.0f,0,false);
     }
+    // pass the target angles to the camera mount
     copter.camera_mount.set_angle_targets(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw);
 #endif
 }


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/16744 by changing Copter to ignore the do-mount-control commands if the vehicle has no mount.  This applies both to real-time commands received via mavlink and mission commands.

I've added [srirajshukla](https://github.com/srirajshukla)   @YashMaxy as Co-authors because they contributed to this solution. Thanks!