### PR TITLE
AP_Scripting: Add proximity status binding

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -132,6 +132,7 @@ singleton AP_Notify method handle_rgb void uint8_t 0 UINT8_MAX uint8_t 0 UINT8_M
 include AP_Proximity/AP_Proximity.h
 
 singleton AP_Proximity alias proximity
+singleton AP_Proximity method get_status uint8_t
 singleton AP_Proximity method num_sensors uint8_t
 singleton AP_Proximity method get_object_count uint8_t
 singleton AP_Proximity method get_closest_object boolean float'Null float'Null


### PR DESCRIPTION
We probably shouldn't call any proximity methods before we know the status of them