### PR TITLE
autotest: fix Heli spline waypoint test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7060,7 +7060,7 @@ class AutoTestHeli(AutoTestCopter):
 
     def fly_spline_waypoint(self, timeout=600):
         """ensure basic spline functionality works"""
-        self.load_mission("copter_spline_mission.txt")
+        self.load_mission("copter_spline_mission.txt", strict=False)
         self.change_mode("LOITER")
         self.wait_ready_to_arm()
         self.arm_vehicle()


### PR DESCRIPTION
Mission isn't round-tripped so make it non-strict

Test is disabled by default, only happens when explicitly running test.
