### PR TITLE
AP_HAL_ChibiOS: fix init serial led with more then one led output per…

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1927,9 +1927,7 @@ bool RCOutput::set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, ou
 
     // we must hold the LED mutex while resizing the array
     WITH_SEMAPHORE(grp->serial_led_mutex);
-    // if already allocated then return
-    if (grp->serial_nleds > 0 || num_leds == 0
-         || (mode != MODE_NEOPIXEL && mode != MODE_PROFILED)) {
+    if (num_leds == 0 || (mode != MODE_NEOPIXEL && mode != MODE_PROFILED)) {
         return false;
     }
 


### PR DESCRIPTION
… DMA group

Fix a bug which came from https://github.com/ArduPilot/ardupilot/commit/3a9107245c7d1defff86bc9be4a8d9712c12f81e which not allow to have more then one led output per DMA group.

https://discuss.ardupilot.org/t/using-two-neopixel-lines-in-one-lua-script/68629