### PR TITLE
AP_Terrain: height_asml corrected offset should only apply to home location

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -146,11 +146,10 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
         // remember home altitude as a special case
         home_height = height;
         home_loc = loc;
-    }
-
-    // apply correction which assumes home altitude is at terrain altitude
-    if (corrected) {
-        height += (ahrs.get_home().alt * 0.01f) - home_height;
+        // apply correction which assumes home altitude is at terrain altitude
+        if (corrected) {
+            height += (ahrs.get_home().alt * 0.01f) - home_height;
+        }
     }
 
     return true;

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -93,11 +93,8 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
     // quick access for home altitude
     if (loc.lat == home_loc.lat &&
         loc.lng == home_loc.lng) {
-        height = home_height;
         // apply correction which assumes home altitude is at terrain altitude
-        if (corrected) {
-            height += (ahrs.get_home().alt * 0.01f) - home_height;
-        }
+        height = corrected ? ahrs.get_home().alt * 0.01f : home_height;
         return true;
     }
 
@@ -148,7 +145,7 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
         home_loc = loc;
         // apply correction which assumes home altitude is at terrain altitude
         if (corrected) {
-            height += (ahrs.get_home().alt * 0.01f) - home_height;
+            height = ahrs.get_home().alt * 0.01f;
         }
     }
 


### PR DESCRIPTION
height_asml's corrected offset for the home location should only apply to the home location.  Currently, this adds an offset anytime `Location:get_alt_cm()` is called with a terrain frame. The offset generally would be the interpolation error from the ahrs.get_home().alt and the terrain database.

However, this was found when I accidentally switched height and heading when initializing SITL. I was getting back terrain heights 100s of meters off from what I know from my location. 

Also simplified the corrected height calculation from unnecessary computations. 