### PR TITLE
Backport: AP_Proximity: Check for valid reading before pushing to OA DB

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -174,7 +174,7 @@ void AP_Proximity_Backend::update_boundary_for_sector(const uint8_t sector, cons
         return;
     }
 
-    if (push_to_OA_DB) {
+    if (push_to_OA_DB && _distance_valid[sector]) {
         database_push(_angle[sector], _distance[sector]);
     }
 


### PR DESCRIPTION
This is a commit from: https://github.com/ArduPilot/ardupilot/pull/14793
This will help a lot of 4.0 users use BendyRuler with RangeFinders.
Currently we are pushing invalid data to the OA DB which is stored as obstacle. 

As we approach Copter 4.1, it'll be good to leave the 4.0 as bug free as we can :)