### PR TITLE
AP_Notify: Add armed with errors notification

### DIFF
--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -117,6 +117,7 @@ uint32_t RGBLed::get_colour_sequence(void) const
     // radio and battery failsafe patter: flash yellow
     // gps failsafe pattern : flashing yellow and blue
     // ekf_bad pattern : flashing yellow and red
+   // if any  above occur while armed: flashing red
     if (AP_Notify::flags.failsafe_radio ||
         AP_Notify::flags.failsafe_gcs ||
         AP_Notify::flags.failsafe_battery ||
@@ -124,7 +125,12 @@ uint32_t RGBLed::get_colour_sequence(void) const
         AP_Notify::flags.gps_glitching ||
         AP_Notify::flags.leak_detected) {
 
-        if (AP_Notify::flags.leak_detected) {
+	        
+	if (AP_Notify::flags.armed) {
+            return sequence_armed_error;
+        }
+
+	if (AP_Notify::flags.leak_detected) {
             // purple if leak detected
             return sequence_failsafe_leak;
         } else if (AP_Notify::flags.ekf_bad) {

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -102,6 +102,7 @@ private:
 
     const uint32_t sequence_armed = DEFINE_COLOUR_SEQUENCE_SOLID(GREEN);
     const uint32_t sequence_armed_nogps = DEFINE_COLOUR_SEQUENCE_SOLID(BLUE);
+    const uint32_t sequence_armed_error = DEFINE_COLOUR_SEQUENCE_ALTERNATE(RED,BLACK);
     const uint32_t sequence_prearm_failing = DEFINE_COLOUR_SEQUENCE(YELLOW,YELLOW,BLACK,BLACK,YELLOW,YELLOW,BLACK,BLACK,BLACK,BLACK);
     const uint32_t sequence_disarmed_good_dgps = DEFINE_COLOUR_SEQUENCE_ALTERNATE(GREEN,BLACK);
     const uint32_t sequence_disarmed_good_gps = DEFINE_COLOUR_SEQUENCE_SLOW(GREEN);


### PR DESCRIPTION
adds warning while armed if any fs, bad ekf, or gps glitching as safety measure....otherwise the fact that it may be armed is invisible