### PR TITLE
AP_GPS: Supplementary explanation of configuration parameters (NFC)

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -79,8 +79,8 @@ AP_GPS *AP_GPS::_singleton;
 // table of user settable parameters
 const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: _TYPE
-    // @DisplayName: GPS type
-    // @Description: GPS type
+    // @DisplayName: 1st GPS type
+    // @Description: GPS type of 1st GPS
     // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS
     // @RebootRequired: True
     // @User: Advanced


### PR DESCRIPTION
I'll go with the GPS2 explanation.
I felt that GPS1's explanation was lacking.

![Screenshot from 2021-03-13 08-05-09](https://user-images.githubusercontent.com/646194/111008257-067b9580-83d4-11eb-8f81-dfc6fa71f64c.png)