### PR TITLE
README,md: remove APM1 and APM2 as supported boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ for reviewing patches on their specific area.
 
 - [Andrew Tridgell](https://github.com/tridge):
   - ***Vehicle***: Plane, AntennaTracker
-  - ***Board***: APM1, APM2, Pixhawk, Pixhawk2, PixRacer
+  - ***Board***: Pixhawk, Pixhawk2, PixRacer
 - [Francisco Ferreira](https://github.com/oxinarf):
   - ***Bug Master***
 - [Grant Morphett](https://github.com/gmorph):


### PR DESCRIPTION
Pretty sure tridge doesn't want this job any more.
