### PR TITLE
Copter:Pre-arm check for first cmd to be takeoff

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -650,6 +650,13 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         return false;
     }
 
+    // always check if the takeoff is the first command for a mission in auto mode
+    if (copter.get_mode() == (uint8_t)Mode::Number::AUTO) {
+      if (!copter.mode_auto.mode_auto_pre_arm_check()) {
+        check_failed(true, "First command should be Takeoff");
+        return false;
+      }
+    }
     // always check motors
     if (!motor_checks(true)) {
         return false;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -371,6 +371,7 @@ public:
 
     bool requires_terrain_failsafe() const override { return true; }
 
+    bool mode_auto_pre_arm_check();
     // return true if this flight mode supports user takeoff
     //  must_nagivate is true if mode must also control horizontal position
     virtual bool has_user_takeoff(bool must_navigate) const override { return false; }
@@ -1424,7 +1425,7 @@ protected:
     uint32_t last_log_ms;   // system time of last time desired velocity was logging
 };
 
-class ModeZigZag : public Mode {        
+class ModeZigZag : public Mode {
 
 public:
     ModeZigZag(void);
@@ -1559,7 +1560,7 @@ private:
         FLARE,
         TOUCH_DOWN,
         BAIL_OUT } phase_switch;
-        
+
     enum class Navigation_Decision {
         USER_CONTROL_STABILISED,
         STRAIGHT_AHEAD,

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -327,7 +327,7 @@ void ModeAuto::circle_start()
 // auto_spline_start - initialises waypoint controller to implement flying to a particular destination using the spline controller
 //  seg_end_type can be SEGMENT_END_STOP, SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE.  If Straight or Spline the next_destination should be provided
 void ModeAuto::spline_start(const Location& destination, bool stopped_at_start,
-                               AC_WPNav::spline_segment_end_type seg_end_type, 
+                               AC_WPNav::spline_segment_end_type seg_end_type,
                                const Location& next_destination)
 {
     _mode = Auto_Spline;
@@ -493,7 +493,7 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
         // point the camera to a specified angle
         do_mount_control(cmd);
         break;
-    
+
     case MAV_CMD_DO_FENCE_ENABLE:
 #if AC_FENCE == ENABLED
         if (cmd.p1 == 0) { //disable
@@ -849,7 +849,7 @@ void ModeAuto::land_run()
 
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-    
+
     land_run_horizontal_control();
     land_run_vertical_control();
 }
@@ -1777,7 +1777,7 @@ bool ModeAuto::verify_loiter_to_alt() const
 // returns true with RTL has completed successfully
 bool ModeAuto::verify_RTL()
 {
-    return (copter.mode_rtl.state_complete() && 
+    return (copter.mode_rtl.state_complete() &&
             (copter.mode_rtl.state() == ModeRTL::RTL_FinalDescent || copter.mode_rtl.state() == ModeRTL::RTL_Land) &&
             (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
 }
@@ -1907,3 +1907,8 @@ bool ModeAuto::verify_nav_delay(const AP_Mission::Mission_Command& cmd)
 }
 
 #endif
+
+// returns a boolean to make sure the first command is takeoff command
+bool ModeAuto::mode_auto_pre_arm_check() {
+  return (mission.starts_with_takeoff_cmd());
+}


### PR DESCRIPTION
This PR tries to solve the issue that was raised in #16809. User can now arm in auto mode but an additional pre-arm check prevents the copter to be armed without a takeoff command.Thanks in advance. 
1.) Uploading a mission
![Screenshot from 2021-03-14 20-16-08](https://user-images.githubusercontent.com/62841337/111072928-b18a6d00-8502-11eb-9e3e-c2f6b59a2402.png)
2.) Mission undertaken successfully
![Screenshot from 2021-03-14 20-16-40](https://user-images.githubusercontent.com/62841337/111072971-e72f5600-8502-11eb-93a5-35c46ad443d4.png)
3.)Same mission without takeoff cmd
![Screenshot from 2021-03-14 20-18-33](https://user-images.githubusercontent.com/62841337/111073000-04642480-8503-11eb-96fb-27862331bc00.png)

For reference PR(#16808) can be viewed