### PR TITLE
AP_Mission: avoid potential read of uninitialised memory

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -625,9 +625,8 @@ bool AP_Mission::read_cmd_from_storage(uint16_t index, Mission_Command& cmd) con
 
     // special handling for command #0 which is home
     if (index == 0) {
-        cmd.index = 0;
+        cmd = {};
         cmd.id = MAV_CMD_NAV_WAYPOINT;
-        cmd.p1 = 0;
         cmd.content.location = AP::ahrs().get_home();
         return true;
     }
@@ -635,6 +634,9 @@ bool AP_Mission::read_cmd_from_storage(uint16_t index, Mission_Command& cmd) con
     if (index >= (unsigned)_cmd_total) {
         return false;
     }
+
+    // ensure all bytes of cmd are zeroed
+    cmd = {};
 
     // Find out proper location in memory by using the start_byte position + the index
     // we can load a command, we don't process it yet


### PR DESCRIPTION
This resolves a potential valgrind issue caused by AP_Mission::read_cmd_from_storage() not setting some bytes of the cmd argument.  This issue does not happen in practice with master but it could theoretically.

This issue was uncovered as part of the SCurve PR which also adds a AP_Mission::Mission_Command operator== method which uses all bytes of the structure.

Below is a screen shot of some SITL testing before and after the fix is applied.  In this test some debug printfs were added to display all bytes of the command in the mission.

![mission-before-and-after-valgrind](https://user-images.githubusercontent.com/1498098/111103309-81d67600-8591-11eb-8d91-dc3692ddfa2c.png)

