### PR TITLE
Copter: path planning fix when using terrain altitudes

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -112,7 +112,8 @@ bool AC_WPNav_OA::update_wpnav()
                 // convert Location to offset from EKF origin
                 Vector3f dest_NEU;
                 if (_oa_destination.get_vector_from_origin_NEU(dest_NEU)) {
-                    if (oa_ptr -> get_bendy_type() == AP_OABendyRuler::OABendyType::OA_BENDY_HORIZONTAL || oa_ptr -> get_bendy_type() == AP_OABendyRuler::OABendyType::OA_BENDY_DISABLED) {
+                    if ((oa_ptr->get_bendy_type() == AP_OABendyRuler::OABendyType::OA_BENDY_HORIZONTAL) ||
+                        (oa_ptr->get_bendy_type() == AP_OABendyRuler::OABendyType::OA_BENDY_DISABLED)) {
                         // calculate target altitude by calculating OA adjusted destination's distance along the original track
                         // and then linear interpolate using the original track's origin and destination altitude
                         const float dist_along_path = constrain_float(oa_destination_new.line_path_proportion(origin_loc, destination_loc), 0.0f, 1.0f);

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -76,6 +76,7 @@ bool AC_WPNav_OA::update_wpnav()
         if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
             _origin_oabak = _origin;
             _destination_oabak = _destination;
+            _terrain_alt_oabak = _terrain_alt;
         }
 
         // convert origin and destination to Locations and pass into oa
@@ -87,7 +88,7 @@ bool AC_WPNav_OA::update_wpnav()
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             if (_oa_state != oa_retstate) {
                 // object avoidance has become inactive so reset target to original destination
-                set_wp_destination(_destination_oabak, _terrain_alt);
+                set_wp_destination(_destination_oabak, _terrain_alt_oabak);
                 _oa_state = oa_retstate;
             }
             break;
@@ -119,7 +120,7 @@ bool AC_WPNav_OA::update_wpnav()
                         const float dist_along_path = constrain_float(oa_destination_new.line_path_proportion(origin_loc, destination_loc), 0.0f, 1.0f);
                         dest_NEU.z = linear_interpolate(_origin_oabak.z, _destination_oabak.z, dist_along_path, 0.0f, 1.0f);
                     }       
-                    if (set_wp_destination(dest_NEU, _terrain_alt)) {
+                    if (set_wp_destination(dest_NEU, _terrain_alt_oabak)) {
                         _oa_state = oa_retstate;
                     }
                 }

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -40,5 +40,6 @@ protected:
     AP_OAPathPlanner::OA_RetState _oa_state;    // state of object avoidance, if OA_SUCCESS we use _oa_destination to avoid obstacles
     Vector3f    _origin_oabak;          // backup of _origin so it can be restored when oa completes
     Vector3f    _destination_oabak;     // backup of _destination so it can be restored when oa completes
+    bool        _terrain_alt_oabak;     // true if backup origin and destination z-axis are terrain altitudes
     Location    _oa_destination;        // intermediate destination during avoidance
 };


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/16479 by fixing BendyRuler's compatibility with missions using terrain altitudes.

Below are before and after screenshots from SITL showing how the vehicle now correctly follows the terrain.
![oa-terr-before](https://user-images.githubusercontent.com/1498098/111143690-71da8880-85c9-11eb-8fde-7579bfd48b07.png)
![oa-terr-after](https://user-images.githubusercontent.com/1498098/111143701-756e0f80-85c9-11eb-8e3e-b20bf63d1214.png)


This has been lightly tested in SITL