### PR TITLE
AP_Proximity: reject invalid frames for OBSTACLE_DISTANCE

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -105,6 +105,11 @@ void AP_Proximity_MAV::handle_obstacle_distance_msg(const mavlink_message_t &msg
     mavlink_obstacle_distance_t packet;
     mavlink_msg_obstacle_distance_decode(&msg, &packet);
 
+    if (packet.frame != MAV_FRAME_BODY_FRD) {
+        // we do not support this frame of reference yet 
+        return;
+    }
+
     // check increment (message's sector width)
     float increment;
     if (!is_zero(packet.increment_f)) {


### PR DESCRIPTION
MAVLink's obstacle distance message supports the value of MAV_FRAME_BODY_FRD for the MAV_FRAME parameter (see https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE). Currently, `handle_obstacle_distance_msg` ignores this option. I updated `handle_obstacle_distance_msg` to behave the same as `handle_obstacle_distance_3d_msg` when given a MAV_FRAME_BODY_FRD frame.