### PR TITLE
 AP_Proximity: Check for stray faces and add new param for filter cut off freq

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -166,6 +166,14 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_LOG_RAW", 17, AP_Proximity, _raw_log_enable, 0),
 
+    // @Param: _FILT
+    // @DisplayName: Proximity filter cutoff frequency
+    // @Description: Cutoff frequency for low pass filter applied to each face in the proximity boundary
+    // @Units: Hz
+    // @Range: 0 20
+    // @User: Advanced
+    AP_GROUPINFO("_FILT", 18, AP_Proximity, _filt_freq, 0.25f),
+
     AP_GROUPEND
 };
 
@@ -209,6 +217,7 @@ void AP_Proximity::update(void)
             continue;
         }
         drivers[i]->update();
+        drivers[i]->boundary_3D_checks();
     }
 
     // work out primary instance - first sensor returning good data

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -89,6 +89,7 @@ public:
     // return sensor orientation and yaw correction
     uint8_t get_orientation(uint8_t instance) const;
     int16_t get_yaw_correction(uint8_t instance) const;
+    float get_filter_freq() const { return _filt_freq; }
 
     // return sensor health
     Status get_status(uint8_t instance) const;
@@ -188,6 +189,7 @@ private:
     AP_Int8 _ignore_width_deg[PROXIMITY_MAX_IGNORE];    // width of beam (in degrees) that should be ignored
     AP_Int8 _raw_log_enable;                            // enable logging raw distances
     AP_Int8 _ign_gnd_enable;                           // true if land detection should be enabled
+    AP_Float _filt_freq;                               // cutoff frequency for low pass filter
 
     void detect_instance(uint8_t instance);
 };

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -55,6 +55,21 @@ void AP_Proximity_Backend::set_status(AP_Proximity::Status status)
     state.status = status;
 }
 
+// timeout faces that have not received data recently and update filter frequencies
+void AP_Proximity_Backend::boundary_3D_checks()
+{
+    // set the cutoff freq for low pass filter
+    boundary.set_filter_freq(frontend.get_filter_freq());
+
+    // check if any face has valid distance when it should not
+    const uint32_t now_ms = AP_HAL::millis();
+    // run this check every PROXIMITY_BOUNDARY_3D_TIMEOUT_MS
+    if ((now_ms - _last_timeout_check_ms) > PROXIMITY_BOUNDARY_3D_TIMEOUT_MS) {
+        _last_timeout_check_ms = now_ms;
+        boundary.check_face_timeout();
+    }
+}
+
 // correct an angle (in degrees) based on the orientation and yaw correction parameters
 float AP_Proximity_Backend::correct_angle_for_orientation(float angle_degrees) const
 {

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -24,6 +24,7 @@
 
 #define PROXIMITY_GND_DETECT_THRESHOLD 1.0f // set ground detection threshold to be 1 meters
 #define PROXIMITY_ALT_DETECT_TIMEOUT_MS 500 // alt readings should arrive within this much time
+#define PROXIMITY_BOUNDARY_3D_TIMEOUT_MS 1000 // we should check the 3D boundary faces after every this many ms
 
 class AP_Proximity_Backend
 {
@@ -37,6 +38,9 @@ public:
 
     // update the state structure
     virtual void update() = 0;
+
+    // timeout faces that have not received data recently and update filter frequencies
+    void boundary_3D_checks();
 
     // get maximum and minimum distances (in meters) of sensor
     virtual float distance_max() const = 0;
@@ -107,6 +111,8 @@ protected:
         database_push(angle, 0.0f, distance, timestamp_ms, current_pos, body_to_ned);
     };
     static void database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
+
+    uint32_t _last_timeout_check_ms;  // time when boundary was checked for non-updated valid faces
 
     // used for ground detection
     uint32_t _last_downward_update_ms;


### PR DESCRIPTION
This PR brings two important changes:
1. Gives user the ability to change the cutoff freq of the low pass filter to the faces. I had previously added a fixed cutoff freq, but I have since then realised that different sensors, have different update rates and different filtration needs. Most users can leave at default, but some users might get better performance if they change the value. You can even disable the filter by setting the param 0. 

2. Checks if there are any "stray" valid faces.. This is a long time bug (even in 4.0 series and before I think) where it is possible to send proximity data to a particular sector, and then not update that sector with new data. So it is possible that the copter tries to infinitely avoid the obstacle. 

Reason I have put these two in same PR is so to avoid conflicts when one of the feature would have been merged..