### PR TITLE
Copter/AC_Loit: Remove avoidance from pos hold

### DIFF
--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -110,7 +110,7 @@ void ModePosHold::run()
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-        loiter_nav->update();
+        loiter_nav->update(false);
 
         // set poshold state to pilot override
         roll_mode = RPMode::PILOT_OVERRIDE;
@@ -135,7 +135,7 @@ void ModePosHold::run()
         // init and update loiter although pilot is controlling lean angles
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-        loiter_nav->update();
+        loiter_nav->update(false);
 
         // set position controller targets
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);
@@ -149,7 +149,7 @@ void ModePosHold::run()
     case AltHold_Landed_Ground_Idle:
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-        loiter_nav->update();
+        loiter_nav->update(false);
         attitude_control->set_yaw_target_to_current_heading();
         init_wind_comp_estimate();
         FALLTHROUGH;
@@ -165,11 +165,6 @@ void ModePosHold::run()
 
     case AltHold_Flying:
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-
-#if AC_AVOID_ENABLED == ENABLED
-        // apply avoidance
-        copter.avoid.adjust_roll_pitch(target_roll, target_pitch, copter.aparm.angle_max);
-#endif
 
         // adjust climb rate using rangefinder
         if (copter.rangefinder_alt_ok()) {
@@ -424,7 +419,7 @@ void ModePosHold::run()
                 update_brake_angle_from_velocity(brake_pitch, -vel_fw);
 
                 // run loiter controller
-                loiter_nav->update();
+                loiter_nav->update(false);
 
                 // calculate final roll and pitch output by mixing loiter and brake controls
                 roll = mix_controls(brake_to_loiter_mix, brake_roll + wind_comp_roll, loiter_nav->get_roll());
@@ -455,7 +450,7 @@ void ModePosHold::run()
 
             case RPMode::LOITER:
                 // run loiter controller
-                loiter_nav->update();
+                loiter_nav->update(false);
 
                 // set roll angle based on loiter controller outputs
                 roll = loiter_nav->get_roll();

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -207,7 +207,7 @@ float AC_Loiter::get_angle_max_cd() const
 }
 
 /// run the loiter controller
-void AC_Loiter::update()
+void AC_Loiter::update(bool avoidance_on)
 {
     // calculate dt
     float dt = _pos_control.time_since_last_xy_update();
@@ -219,7 +219,7 @@ void AC_Loiter::update()
     _pos_control.set_max_speed_xy(_speed_cms);
     _pos_control.set_max_accel_xy(_accel_cmss);
 
-    calc_desired_velocity(dt);
+    calc_desired_velocity(dt, avoidance_on);
     _pos_control.update_xy_controller();
 }
 
@@ -232,7 +232,7 @@ void AC_Loiter::sanity_check_params()
 
 /// calc_desired_velocity - updates desired velocity (i.e. feed forward) with pilot requested acceleration and fake wind resistance
 ///		updated velocity sent directly to position controller
-void AC_Loiter::calc_desired_velocity(float nav_dt)
+void AC_Loiter::calc_desired_velocity(float nav_dt, bool avoidance_on)
 {
     float ekfGndSpdLimit, ekfNavVelGainScaler;
     AP::ahrs_navekf().getEkfControlLimits(ekfGndSpdLimit, ekfNavVelGainScaler);
@@ -303,13 +303,15 @@ void AC_Loiter::calc_desired_velocity(float nav_dt)
         desired_vel.y = desired_vel.y * gnd_speed_limit_cms / horizSpdDem;
     }
 
-    // Limit the velocity to prevent fence violations
-    // TODO: We need to also limit the _desired_accel
-    AC_Avoid *_avoid = AP::ac_avoid();
-    if (_avoid != nullptr) {
-        Vector3f avoidance_vel_3d{desired_vel.x, desired_vel.y, 0.0f};
-        _avoid->adjust_velocity(avoidance_vel_3d, _pos_control.get_pos_xy_p().kP(), _accel_cmss, _pos_control.get_pos_z_p().kP(), _pos_control.get_max_accel_z(), nav_dt);
-        desired_vel = Vector2f{avoidance_vel_3d.x, avoidance_vel_3d.y};
+    if (avoidance_on) {
+        // Limit the velocity to prevent fence violations
+        // TODO: We need to also limit the _desired_accel
+        AC_Avoid *_avoid = AP::ac_avoid();
+        if (_avoid != nullptr) {
+            Vector3f avoidance_vel_3d{desired_vel.x, desired_vel.y, 0.0f};
+            _avoid->adjust_velocity(avoidance_vel_3d, _pos_control.get_pos_xy_p().kP(), _accel_cmss, _pos_control.get_pos_z_p().kP(), _pos_control.get_max_accel_z(), nav_dt);
+            desired_vel = Vector2f{avoidance_vel_3d.x, avoidance_vel_3d.y};
+        }
     }
 
     // send adjusted feed forward acceleration and velocity back to the Position Controller

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -48,7 +48,7 @@ public:
     float get_angle_max_cd() const;
 
     /// run the loiter controller
-    void update();
+    void update(bool avoidance_on = true);
 
     /// get desired roll, pitch which should be fed into stabilize controllers
     float get_roll() const { return _pos_control.get_roll(); }
@@ -63,7 +63,7 @@ protected:
 
     /// updates desired velocity (i.e. feed forward) with pilot requested acceleration and fake wind resistance
     ///		updated velocity sent directly to position controller
-    void calc_desired_velocity(float nav_dt);
+    void calc_desired_velocity(float nav_dt, bool avoidance_on = true);
 
     // references and pointers to external libraries
     const AP_InertialNav&   _inav;


### PR DESCRIPTION
This PR makes it optional to run Simple Avoidance when running loiter controller (By default it will still run avoidance unless you pass an argument)
We are then using that to run loiter controller in pos hold without avoidance. 
Pos hold mixes both lean angle control and velocity control and it was found both the types of avoidance methods were being run simultaneously. Therefore it it was decided that this mode should not use avoidance at all as it was getting messy from avoidance POV.