### PR TITLE
Plane: tailsitter: do not run throttle when disarmed in Q modes

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -24,6 +24,11 @@
 *****************************************/
 void Plane::throttle_slew_limit(SRV_Channel::Aux_servo_function_t func)
 {
+    if (!(control_mode->does_auto_throttle() || quadplane.in_assisted_flight() || quadplane.in_vtol_mode())) {
+        // only do throttle slew limiting in modes where throttle control is automatic
+        return;
+    }
+
     uint8_t slewrate = aparm.throttle_slewrate;
     if (control_mode == &mode_auto) {
         if (auto_state.takeoff_complete == false && g.takeoff_throttle_slewrate != 0) {
@@ -836,13 +841,8 @@ void Plane::set_servos(void)
     // set airbrake outputs
     airbrake_update();
 
-    if (control_mode->does_auto_throttle() ||
-        quadplane.in_assisted_flight() ||
-        quadplane.in_vtol_mode()) {
-        /* only do throttle slew limiting in modes where throttle
-         *  control is automatic */
-        throttle_slew_limit(SRV_Channel::k_throttle);
-    }
+    // slew rate limit throttle
+    throttle_slew_limit(SRV_Channel::k_throttle);
 
     if (!arming.is_armed()) {
         //Some ESCs get noisy (beep error msgs) if PWM == 0.

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -169,11 +169,8 @@ void QuadPlane::tailsitter_output(void)
     SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, (motors->get_roll())*SERVO_MAX);
 
     if (hal.util->get_soft_armed()) {
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, motors->thrust_to_actuator(motors->get_throttle()) * 100);
         // scale surfaces for throttle
         tailsitter_speed_scaling();
-    } else {
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, motors->get_throttle() * 100);
     }
 
     tilt_left = 0.0f;

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -86,23 +86,30 @@ void AP_MotorsTailsitter::output_to_motors()
 
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, get_pwm_output_min());
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, get_pwm_output_min());
+            _actuator[0] = 0.0f;
+            _actuator[1] = 0.0f;
+            _actuator[2] = 0.0f;
             break;
         case SpoolState::GROUND_IDLE:
+            set_actuator_with_slew(_actuator[0], actuator_spin_up_to_ground_idle());
             set_actuator_with_slew(_actuator[1], actuator_spin_up_to_ground_idle());
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, output_to_pwm(actuator_spin_up_to_ground_idle()));
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, output_to_pwm(actuator_spin_up_to_ground_idle()));
+            set_actuator_with_slew(_actuator[2], actuator_spin_up_to_ground_idle());
             break;
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
         case SpoolState::SPOOLING_DOWN:
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, output_to_pwm(thrust_to_actuator(_thrust_left)));
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, output_to_pwm(thrust_to_actuator(_thrust_right)));
+            set_actuator_with_slew(_actuator[0], thrust_to_actuator(_thrust_left));
+            set_actuator_with_slew(_actuator[1], thrust_to_actuator(_thrust_right));
+            set_actuator_with_slew(_actuator[2], thrust_to_actuator(_throttle));
             break;
     }
 
-    // Always output to tilt servos
+    SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, output_to_pwm(_actuator[0]));
+    SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, output_to_pwm(_actuator[1]));
+
+    // use set scaled to allow a different PWM range on plane forward throttle, throttle range is 0 to 100
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, _actuator[2]*100);
+
     SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, _tilt_left*SERVO_OUTPUT_RANGE);
     SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, _tilt_right*SERVO_OUTPUT_RANGE);
 


### PR DESCRIPTION
This fixes a issue with forward throttle being set to spin min on tailsitters when disarmed, slipped through the cracks because its a very unusual config. The bug was added by me in https://github.com/ArduPilot/ardupilot/pull/15811.

The fix is to output throttle from AP motors so we can abide by the spool state.

As a drive by have also added slew rate limiting of outputs to tailsitters inline with the other motors backends.

This also includes the new autotest from https://github.com/ArduPilot/ardupilot/pull/16890

