### PR TITLE
Tools/scripts/build_binaries.py - Add FlywooF745

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -632,6 +632,7 @@ is bob we will attempt to checkout bob-AVR'''
                 "QioTekZealotF427",
                 "BeastH7",
                 "BeastF7",
+                "FlywooF745",
                 # SITL targets
                 "SITL_x86_64_linux_gnu",
                 "SITL_arm_linux_gnueabihf",


### PR DESCRIPTION
As requested by Tridge - adding FlywooF745 to the build_binaries.py script.