### PR TITLE
autotest: ignore type=0 heartbeat packets on SITL start

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2132,7 +2132,10 @@ class AutoTest(ABC):
             if time.time() - tstart > 30:
                 raise NotAchievedException("Failed to customise")
             try:
-                self.wait_heartbeat(drain_mav=True)
+                m = self.wait_heartbeat(drain_mav=True)
+                if m.type == 0:
+                    self.progress("Bad heartbeat: %s" % str(m))
+                    continue
             except IOError:
                 pass
             break


### PR DESCRIPTION
Until ArduCopter allocates its motors backend we emit a generic type,
for which there is no mode map in pymavlink.

So don't consider the reboot complete until we see a valid heartbeat.