### PR TITLE
Pass Copter default parameters on SITL commandline rather than setting them

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -88,6 +88,14 @@ class AutoTestCopter(AutoTest):
     def default_frame(self):
         return "+"
 
+    def apply_defaultfile_parameters(self):
+        # Copter passes in a defaults_filepath in place of applying
+        # parameters afterwards.
+        pass
+
+    def defaults_filepath(self):
+        return self.model_defaults_filepath(self.vehicleinfo_key(), self.frame)
+
     def wait_disarmed_default_wait_time(self):
         return 120
 

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -374,10 +374,10 @@ class AutoTestSub(AutoTest):
                 break
         self.initialise_after_reboot_sitl()
 
-    def apply_defaultfile_parameters(self):
-        super(AutoTestSub, self).apply_defaultfile_parameters()
-        # FIXME:
-        self.set_parameter("FS_GCS_ENABLE", 0)
+    def default_parameter_list(self):
+        ret = super(AutoTestSub, self).default_parameter_list()
+        ret["FS_GCS_ENABLE"] = 0  # FIXME
+        return ret
 
     def disabled_tests(self):
         ret = super(AutoTestSub, self).disabled_tests()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2132,7 +2132,10 @@ class AutoTest(ABC):
             if time.time() - tstart > 30:
                 raise NotAchievedException("Failed to customise")
             try:
-                self.wait_heartbeat(drain_mav=True)
+                m = self.wait_heartbeat(drain_mav=True)
+                if m.type == 0:
+                    self.progress("Bad heartbeat: %s" % str(m))
+                    continue
             except IOError:
                 pass
             break


### PR DESCRIPTION
We're now waiting for the vehicle simulation to provide us a heartbeat
for a non-generic frame before considering it good to fly.

Unfortunately, Copter relies on the parameter file to tell it which
frame to use - and we don't apply parameters from parameter files until
after we've checked the heartbeat.

Passing the file into ArduPilot on the commandline means we don't have
this problem.
