### PR TITLE
autotest: bump default speedups for Plane, Tracker and Sub 

### DIFF
--- a/Tools/autotest/antennatracker.py
+++ b/Tools/autotest/antennatracker.py
@@ -29,6 +29,10 @@ class AutoTestTracker(AutoTest):
     def log_name(self):
         return "AntennaTracker"
 
+    def default_speedup(self):
+        '''Tracker seems to be race-free'''
+        return 100
+
     def test_filepath(self):
         return os.path.realpath(__file__)
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6936,6 +6936,10 @@ class AutoTestHeli(AutoTestCopter):
     def sitl_start_location(self):
         return SITL_START_LOCATION_AVC
 
+    def default_speedup(self):
+        '''Heli seems to be race-free'''
+        return 100
+
     def is_heli(self):
         return True
 

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -59,6 +59,10 @@ class AutoTestSub(AutoTest):
     def log_name(self):
         return "ArduSub"
 
+    def default_speedup(self):
+        '''Sub seems to be race-free'''
+        return 100
+
     def test_filepath(self):
         return os.path.realpath(__file__)
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4682,8 +4682,8 @@ class AutoTest(ABC):
         tstart = self.get_sim_time()
         tnow = tstart
         r = "Delaying %f seconds"
-        if reason is None:
-            r += "for %s" % reason
+        if reason is not None:
+            r += " for %s" % reason
         self.progress(r % (seconds_to_wait,))
         while tstart + seconds_to_wait > tnow:
             tnow = self.get_sim_time()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1199,7 +1199,7 @@ class AutoTest(ABC):
                  binary,
                  valgrind=False,
                  gdb=False,
-                 speedup=8,
+                 speedup=None,
                  frame=None,
                  params=None,
                  gdbserver=False,
@@ -1230,6 +1230,8 @@ class AutoTest(ABC):
         self.breakpoints = breakpoints
         self.disable_breakpoints = disable_breakpoints
         self.speedup = speedup
+        if self.speedup is None:
+            self.speedup = self.default_speedup()
         self.sup_binaries = sup_binaries
 
         self.mavproxy = None
@@ -1276,6 +1278,9 @@ class AutoTest(ABC):
             self.rc_thread_should_quit = True
             self.rc_thread.join()
             self.rc_thread = None
+
+    def default_speedup(self):
+        return 8
 
     def progress(self, text, send_statustext=True):
         """Display autotest progress text."""

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -55,6 +55,10 @@ class AutoTestQuadPlane(AutoTest):
     def sitl_start_location(self):
         return SITL_START_LOCATION
 
+    def default_speedup(self):
+        '''QuadPlane seems to be race-free'''
+        return 100
+
     def log_name(self):
         return "QuadPlane"
 


### PR DESCRIPTION
~This is based on https://github.com/ArduPilot/ardupilot/pull/16655 - it will be rebased a lot before being merged.~ That was merged

This will probably need https://github.com/ArduPilot/ardupilot/pull/16938 to be reliable; faster the speedup the shorter the timeout we allow on write calls if the write is in a thread.
