### PR TITLE
HAL_ChibiOS: switch boards to 32k FRAM

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -429,7 +429,7 @@ define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
 
 # we need to tell HAL_ChibiOS/Storage.cpp how much storage is
 # available (in bytes)
-define HAL_STORAGE_SIZE 16384
+define HAL_STORAGE_SIZE 32768
 
 # allow to have have a dedicated safety switch pin
 define HAL_HAVE_SAFETY_SWITCH 1

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv5/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv5/hwdef.dat
@@ -290,7 +290,7 @@ define HAL_GPIO_LED_ON 0
 
 
 # enable RAMTROM parameter storage
-define HAL_STORAGE_SIZE 16384
+define HAL_STORAGE_SIZE 32768
 define HAL_WITH_RAMTRON 1
 
 # allow to have have a dedicated safety switch pin

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroClassic/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroClassic/hwdef.dat
@@ -33,7 +33,7 @@ env OPTIMIZE -O2
 FLASH_RESERVE_START_KB 128
 
 # use FRAM for storage
-define HAL_STORAGE_SIZE 16384
+define HAL_STORAGE_SIZE 32768
 
 # Enable RAMTROM parameter storage.
 define HAL_WITH_RAMTRON 1

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroF7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroF7/hwdef.dat
@@ -39,7 +39,7 @@ env OPTIMIZE -O2
 FLASH_RESERVE_START_KB 96
 
 # use FRAM for storage
-define HAL_STORAGE_SIZE 16384
+define HAL_STORAGE_SIZE 32768
 define HAL_WITH_RAMTRON 1
 
 # fallback storage in case FRAM is not populated

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroOEMH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoControlZeroOEMH7/hwdef.dat
@@ -32,7 +32,7 @@ env OPTIMIZE -O2
 # start on 2th sector (1st sector for bootloader)
 FLASH_RESERVE_START_KB 128
 
-define HAL_STORAGE_SIZE 16384
+define HAL_STORAGE_SIZE 32768
 
 # USB setup
 USB_STRING_MANUFACTURER "mRo"

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoX21-777/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoX21-777/hwdef.dat
@@ -392,7 +392,7 @@ define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
 
 # we need to tell HAL_ChibiOS/Storage.cpp how much storage is
 # available (in bytes)
-define HAL_STORAGE_SIZE 16384
+define HAL_STORAGE_SIZE 32768
 
 # allow to have have a dedicated safety switch pin
 define HAL_HAVE_SAFETY_SWITCH 1


### PR DESCRIPTION
this enables the parameter backup/restore on those boards, as well as
more waypoints

This is in response to a report that CUAVv5 boards can suffer from the
parameter reset issue