### PR TITLE
.semaphore: add base semaphore.yml

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,104 @@
+version: v1.0
+name: ArduPilot Semaphore CI
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+# Auto-cancel both running and queued pipelines on a new push
+auto_cancel:
+  running:
+    when: "true"
+
+# Shared accross all tasks
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - git submodule update --init --recursive --depth 1 --no-single-branch
+      - virtualenv --python=python2.7 --system-site-packages python2-env
+      - VIRTUAL_ENV_DISABLE_PROMPT=1 source python2-env/bin/activate
+      - sudo apt-get update && sudo apt-get install --no-install-recommends -y lsb-release software-properties-common && sudo apt purge -y gcc g++
+      - export SKIP_AP_EXT_ENV=1
+      - export SKIP_AP_GRAPHIC_ENV=1 
+      - export SKIP_AP_COV_ENV=1 
+      - export SKIP_AP_GIT_CHECK=1
+      - ./Tools/environment_install/install-prereqs-ubuntu.sh -y
+      - mkdir -p ~/.ccache
+      - echo "base_dir = /home/semaphore/${SEMAPHORE_GIT_DIR}" > ~/.ccache/ccache.conf
+      - echo "compression = true" >> ~/.ccache/ccache.conf
+      - echo "compression_level = 6" >> ~/.ccache/ccache.conf
+      - echo "max_size = 400M" >> ~/.ccache/ccache.conf
+      - PATH="/home/semaphore/.local/bin:$PATH"
+
+  epilogue:
+    always:
+      commands:
+        - git submodule deinit --force .
+
+blocks:
+  - name: "Building"
+    task:
+      jobs:
+        - name: "Linux_boards-1"
+          commands:
+            - source /home/semaphore/.profile
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1,ccache-master-$SEMAPHORE_JOB_NAME-1
+            - CI_BUILD_TARGET="navio" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2,ccache-master-$SEMAPHORE_JOB_NAME-2
+            - CI_BUILD_TARGET="bbbmini" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3,ccache-master-$SEMAPHORE_JOB_NAME-3
+            - CI_BUILD_TARGET="bhat" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3 ~/.ccache
+
+        - name: "SITL"
+          commands:
+            - source /home/semaphore/.profile
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1,ccache-master-$SEMAPHORE_JOB_NAME-1
+            - CI_BUILD_TARGET="sitl" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2,ccache-master-$SEMAPHORE_JOB_NAME-2
+            - CI_BUILD_TARGET="configure-all" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2 ~/.ccache
+
+        - name: "Linux_boards-2"
+          commands:
+            - source /home/semaphore/.profile
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1,ccache-master-$SEMAPHORE_JOB_NAME-1
+            - CI_BUILD_TARGET="bebop" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2,ccache-master-$SEMAPHORE_JOB_NAME-2
+            - CI_BUILD_TARGET="linux" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3,ccache-master-$SEMAPHORE_JOB_NAME-3
+            - CI_BUILD_TARGET="navio2" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3 ~/.ccache
+
+        - name: "Linux_boards-3"
+          commands:
+            - source /home/semaphore/.profile
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1,ccache-master-$SEMAPHORE_JOB_NAME-1
+            - CI_BUILD_TARGET="erlebrain2" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2,ccache-master-$SEMAPHORE_JOB_NAME-2
+            - CI_BUILD_TARGET="pxfmini" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3,ccache-master-$SEMAPHORE_JOB_NAME-3
+            - CI_BUILD_TARGET="pxf" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3 ~/.ccache
+
+        - name: "Chibios_boards"
+          commands:
+            - source /home/semaphore/.profile
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1,ccache-master-$SEMAPHORE_JOB_NAME-1
+            - CI_BUILD_TARGET="fmuv3" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-1 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2,ccache-master-$SEMAPHORE_JOB_NAME-2
+            - CI_BUILD_TARGET="revo-mini" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-2 ~/.ccache
+            - cache restore ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3,ccache-master-$SEMAPHORE_JOB_NAME-3
+            - CI_BUILD_TARGET="MatekF405-Wing" ./Tools/scripts/build_ci.sh
+            - cache store ccache-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_JOB_NAME-3 ~/.ccache


### PR DESCRIPTION
Add semaphoreCI 2.0 rules.
The main advantages against classic semaphore are :
- we can have a .yml to define the workflows
- we can have better usage of caching for faster build like on Github CI
- it shouldn't crash anymore on tagging

![image](https://user-images.githubusercontent.com/705341/111454173-a60e9000-8714-11eb-91fd-568ff5c59dd5.png)
