### PR TITLE
AP_NavEKF3: Judge in order of priority

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -219,7 +219,8 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
     }
 
     // record time of pass or fail
-    if (gpsSpdAccFail || numSatsFail || hdopFail || hAccFail || vAccFail || yawFail || gpsDriftFail || gpsVertVelFail || gpsHorizVelFail) {
+    // Judge in order of priority.
+    if (yawFail || numSatsFail || hdopFail || gpsSpdAccFail || vAccFail || hAccFail || gpsHorizVelFail || gpsVertVelFail || gpsDriftFail) { 
         lastGpsVelFail_ms = imuSampleTime_ms;
     } else {
         lastGpsVelPass_ms = imuSampleTime_ms;


### PR DESCRIPTION
This method is doing multiple checks.
This method is overriding the fail message.
The message signals the end.
I know that conditions in if statements are processed from the left.
I write the messages in the order in which they are notified.