### PR TITLE
AP_Param: remove confusing comment

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1468,8 +1468,6 @@ bool AP_Param::load_all()
     
     while (ofs < _storage.size()) {
         _storage.read_block(&phdr, ofs, sizeof(phdr));
-        // note that this is an || not an && for robustness
-        // against power off while adding a variable
         if (is_sentinal(phdr)) {
             // we've reached the sentinal
             sentinal_offset = ofs;


### PR DESCRIPTION
The code refered to is within is_sentinel - and it has a copy of the
comment