### PR TITLE
Copter: Change the specification of the function selection file

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -44,7 +44,9 @@
 //#define MODE_SYSTEMID_ENABLED DISABLED            // disable system ID mode support
 //#define MODE_THROW_ENABLED    DISABLED            // disable throw mode support
 //#define MODE_ZIGZAG_ENABLED   DISABLED            // disable zigzag mode support
+#ifndef OSD_ENABLED
 //#define OSD_ENABLED           DISABLED            // disable on-screen-display support
+#endif
 //#define BUTTON_ENABLED        DISABLED            // disable button support
 //#define LANDING_GEAR_ENABLED  DISABLED            // disable landing gear support
 


### PR DESCRIPTION
I believe that the selection of functions will be done in this file.
I don't use the OSD features.
I have enabled this setting.
I got a redefinition error message in the build.
I dealt with it this way.
If you want to specify the OSD selection in the WAF command, add "If you want to disable this feature, specify it in the WAF parameter" to the definition description.
Or delete this line.

![Screenshot from 2021-03-20 12-16-19](https://user-images.githubusercontent.com/646194/111857707-ac03ab80-8976-11eb-960b-4739f689196c.png)
