### PR TITLE
Plane: control pitch up in VTOL transition with user targets

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -388,7 +388,9 @@ void Plane::stabilize()
           during transition to vtol in a tailsitter try to raise the
           nose rapidly while keeping the wings level
          */
-        nav_pitch_cd = constrain_float((quadplane.tailsitter.transition_angle+5)*100, 5500, 8500),
+        float transition_rate = quadplane.get_tailsitter_transition_angle_vtol()/ float(quadplane.tailsitter.transition_time_vtol_ms/2);
+        uint32_t dt = now - quadplane.transition_start_ms;
+        nav_pitch_cd = constrain_float(quadplane.transition_initial_pitch + (transition_rate * dt)*100, -8500, 8500);
         nav_roll_cd = 0;
     }
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -524,7 +524,9 @@ private:
 
     // tailsitter control variables
     struct {
-        AP_Int8 transition_angle;
+        AP_Int8 transition_angle_fw;
+        AP_Int8 transition_angle_vtol;
+        AP_Int16 transition_time_vtol_ms;
         AP_Int8 input_type;
         AP_Int8 input_mask;
         AP_Int8 input_mask_chan;
@@ -540,6 +542,9 @@ private:
         AP_Int16 gain_scaling_mask;
         AP_Float disk_loading;
     } tailsitter;
+
+    // return the ransition_angle_vtol value
+    int8_t get_tailsitter_transition_angle_vtol(void) const;
 
     // tailsitter speed scaler
     float last_spd_scaler = 1.0f; // used to slew rate limiting with TAILSITTER_GSCL_ATT_THR option

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -250,8 +250,8 @@ bool QuadPlane::tailsitter_transition_fw_complete(void)
     if (roll_cd > 9000) {
         roll_cd = 18000 - roll_cd;
     }
-    if (labs(ahrs_view->pitch_sensor) > tailsitter.transition_angle*100 ||
-        roll_cd > tailsitter.transition_angle*100 ||
+    if (labs(ahrs_view->pitch_sensor) > tailsitter.transition_angle_fw*100 ||
+        labs(roll_cd)> tailsitter.transition_angle_fw*100 ||
         AP_HAL::millis() - transition_start_ms > uint32_t(transition_time_ms)) {
         return true;
     }
@@ -277,9 +277,9 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
             return true;
         }
     }
-    if (labs(plane.ahrs.pitch_sensor) > tailsitter.transition_angle*100 ||
-        labs(plane.ahrs.roll_sensor) > tailsitter.transition_angle*100 ||
-        AP_HAL::millis() - transition_start_ms > 2000) {
+    if (labs(plane.ahrs.pitch_sensor) > get_tailsitter_transition_angle_vtol()*100 ||
+        labs(plane.ahrs.roll_sensor) >  get_tailsitter_transition_angle_vtol()*100 ||
+        AP_HAL::millis() - transition_start_ms > uint32_t( tailsitter.transition_time_vtol_ms)) { 
         return true;
     }
     // still waiting


### PR DESCRIPTION
-creates the same controlled pitch transition as in VTOL->FW
-adds two new params: VTOL transition angle and transition time
-adds getter for angle so that default is the same target as before (transition_angle) even if it was changed by user to something else
-default for VTOL transition time is same as old hard coded value
![new qloiter](https://user-images.githubusercontent.com/6076534/111858034-c3558100-8903-11eb-96a2-465cb68725e4.png)

