### PR TITLE
Copter Scripting: add support for posvel command

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -296,6 +296,20 @@ bool Copter::set_target_location(const Location& target_loc)
     return mode_guided.set_destination(target_loc);
 }
 
+// set target position and velocity (for use by scripting)
+bool Copter::set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    const Vector3f pos_neu_cm(target_pos.x * 100.0f, target_pos.y * 100.0f, -target_pos.z * 100.0f);
+    const Vector3f vel_neu_cms(target_vel.x * 100.0f, target_vel.y * 100.0f, -target_vel.z * 100.0f);
+
+    return mode_guided.set_destination_posvel(pos_neu_cm, vel_neu_cms);
+}
+
 bool Copter::set_target_velocity_NED(const Vector3f& vel_ned)
 {
     // exit if vehicle is not in Guided mode or Auto-Guided mode

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -648,6 +648,7 @@ private:
     void fast_loop() override;
     bool start_takeoff(float alt) override;
     bool set_target_location(const Location& target_loc) override;
+    bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) override;
     void rc_loop();

--- a/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
+++ b/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
@@ -1,0 +1,86 @@
+-- Commands copter to fly circle trajectory using posvel method in guided mode. 
+-- The trajectory start from the current location
+-- 
+-- CAUTION: This script only works for Copter.
+-- This script start when the in GUIDED mode and above 5 meter.
+--      1) arm and takeoff to above 5 m 
+--      2) switch to GUIDED mode 
+--      3) the vehilce will follow a circle in clockwise direction with increasing speed until ramp_up_time_s time has passed.
+--      4) switch out of and into the GUIDED mode any time to restart the trajectory from the start.
+
+-- Edit these variables
+local rad_xy_m = 10.0   -- circle radius in xy plane in m
+local target_speed_xy_mps = 5.0     -- maximum target speed in m/s
+local ramp_up_time_s = 10.0     -- time to reach target_speed_xy_mps in second
+local sampling_time_s = 0.05    -- sampling time of script
+
+-- Fixed variables
+local omega_radps = target_speed_xy_mps/rad_xy_m
+local copter_guided_mode_num = 4
+local theta = 0.0
+local time = 0.0
+local test_start_location = Vector3f(0.0, 0.0, 0.0)
+
+gcs:send_text(0,"Script started")
+gcs:send_text(0,"Trajectory period: " .. tostring(2 * math.rad(180) / omega_radps))
+
+function circle()
+    local cur_freq = 0
+    -- increase target speed lineary with time until ramp_up_time_s is reached
+    if time <= ramp_up_time_s then 
+        cur_freq = omega_radps*time/ramp_up_time_s
+    else 
+        cur_freq = omega_radps
+    end
+
+    -- calculate circle reference position and velocity
+    theta = theta + cur_freq*sampling_time_s
+
+    local th_s = math.sin(theta)
+    local th_c = math.cos(theta) 
+
+    local pos = Vector3f()
+    pos:x(rad_xy_m*th_s)
+    pos:y(-rad_xy_m*(th_c-1))
+    pos:z(0)
+
+    local vel = Vector3f()
+    vel:x(cur_freq*rad_xy_m*th_c)
+    vel:y(cur_freq*rad_xy_m*th_s)
+    vel:z(0)
+
+    return pos, vel
+end
+
+function update()
+    if arming:is_armed() and vehicle:get_mode() == copter_guided_mode_num and -test_start_location:z()>=5 then
+
+        -- calculate current position and velocity for circle trajectory
+        local target_pos = Vector3f()
+        local target_vel = Vector3f()
+        target_pos, target_vel = circle()
+
+        -- advance the time
+        time = time + sampling_time_s
+
+        -- send posvel request
+        if not vehicle:set_target_posvel_NED(target_pos+test_start_location, target_vel) then
+            gcs:send_text(0, "Failed to send target posvel at " .. tostring(time) .. " seconds")
+        end
+    else 
+        -- calculate test starting location in NED
+        local home = ahrs:get_home()
+        local cur_loc = ahrs:get_position()
+        if home and cur_loc then
+            test_start_location = home:get_distance_NED(cur_loc)
+        end
+
+        -- reset some variable as soon as we are not in guided mode
+        time = 0
+        theta = 0
+    end
+
+    return update, sampling_time_s * 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -185,6 +185,7 @@ singleton AP_Vehicle method get_likely_flying boolean
 singleton AP_Vehicle method get_time_flying_ms uint32_t
 singleton AP_Vehicle method start_takeoff boolean float (-LOCATION_ALT_MAX_M*100+1) (LOCATION_ALT_MAX_M*100-1)
 singleton AP_Vehicle method set_target_location boolean Location
+singleton AP_Vehicle method set_target_posvel_NED boolean Vector3f Vector3f
 singleton AP_Vehicle method get_control_output boolean AP_Vehicle::ControlOutput'enum AP_Vehicle::ControlOutput::Roll ((uint32_t)AP_Vehicle::ControlOutput::Last_ControlOutput-1) float'Null
 singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -183,6 +183,7 @@ public:
     */
     virtual bool start_takeoff(float alt) { return false; }
     virtual bool set_target_location(const Location& target_loc) { return false; }
+    virtual bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) { return false; }
     virtual bool set_target_velocity_NED(const Vector3f& vel_ned) { return false; }
     virtual bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) { return false; }
 


### PR DESCRIPTION
This scripts add support for target position+velocity command.  set target location and set target velocity methods are already supported. I am planning to use this functionality to evaluate trajectory tracking performance for different trajectories(circle, lemniscate etc.) without needing the onboard computer.

This has only been tested in SITL. I will try to flight test it this week.

To run the example script, 
 1) wait for vehicle to obtain position estimate
 2) arm and takeoff above 5 meter 
 3) switch to GUIDED mode to start the circle trajectory
 4) switch out of and into GUIDED mode any time to restart the circle trajectory from the current location. 

Example script allows three parameters to be set by the user. The circle radius, maximum speed, and the time it takes to reach maximum speed.

Here is the result of SITL simulation. In the example flight, the vehicle is armed and takeoff above 5 m in GUIDED. The vehicle switched out of and into GUIDED mode multiple times including the one when the vehicle is below 5 meter.
![image](https://user-images.githubusercontent.com/11930560/111918134-b4ea9f00-8a94-11eb-8eb7-2e73fb82a368.png)