### PR TITLE
AP_Control: apply pitch rate limit to turn coordination

### DIFF
--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -301,19 +301,16 @@ int32_t AP_PitchController::get_servo_out(int32_t angle_err, float scaler, bool 
 	// as the rates will be tuned when upright, and it is common that
 	// much higher rates are needed inverted	
 	if (!inverted) {
+        desired_rate += rate_offset;
         if (gains.rmax_neg && desired_rate < -gains.rmax_neg) {
             desired_rate = -gains.rmax_neg;
         } else if (gains.rmax_pos && desired_rate > gains.rmax_pos) {
             desired_rate = gains.rmax_pos;
 		}
+    } else {
+        // Make sure not to invert the turn coordination offset
+        desired_rate = -desired_rate + rate_offset;
 	}
-	
-	if (inverted) {
-		desired_rate = -desired_rate;
-	}
-
-	// Apply the turn correction offset
-	desired_rate = desired_rate + rate_offset;
 
     /*
       when we are past the users defined roll limit for the aircraft


### PR DESCRIPTION
At high bank angles, for example when rolling to/from inverted, an unrealistically large turn coordination pitch rate offset is requested. Before this patch, this offset was not subject to the configured pitch rate limit, which could result in pitch controller integrator windup. This is especially problematic because the turn coordination offset will wind up the integrator much faster than it can later be unwound by the normal pitch controller (which is subject to the pitch rate limit), resulting in a very slow recovery.

This is the first step in fixing the issues that caused the crash I described here: https://discuss.ardupilot.org/t/dive-after-roll-from-inverted-to-uninverted/68694. It is an incomplete fix because it doesn't even change anything when then plane is inverted, and doesn't address the root issue that we probably shouldn't be trying to make a coordinated turn while rolling the plane to/from inverted.

I'd appreciate some feedback on that forum post, as I haven't been able to come up with a satisfactory fix for the turn coordination issue.