### PR TITLE
AP_HAL_ChibiOS: RCOuput: LED setup re-work

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -268,6 +268,7 @@ private:
         // serial LED support
         volatile uint8_t serial_nleds;
         uint8_t clock_mask;
+        enum output_mode led_mode;
         volatile bool serial_led_pending;
         volatile bool prepared_send;
         HAL_Semaphore serial_led_mutex;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -510,11 +510,12 @@ private:
     void dma_cancel(pwm_group& group);
     bool mode_requires_dma(enum output_mode mode) const;
     bool setup_group_DMA(pwm_group &group, uint32_t bitrate, uint32_t bit_width, bool active_high,
-      const uint16_t buffer_length, bool choose_high, uint32_t pulse_time_us);
+    const uint16_t buffer_length, bool choose_high, uint32_t pulse_time_us);
     void send_pulses_DMAR(pwm_group &group, uint32_t buffer_length);
     void set_group_mode(pwm_group &group);
     static bool is_dshot_protocol(const enum output_mode mode);
     static uint32_t protocol_bitrate(const enum output_mode mode);
+    void print_group_setup_error(pwm_group &group, const char* error_string);
 
     /*
       Support for bi-direction dshot


### PR DESCRIPTION
This is a re-work of the LED setup code that delays the actual DMA setup until the first attempt to set the color of a LED. This means that you do not have to understand the channel allocation and ask for the largest number of LEDs you could possibly need the first time. You can now assign the number of LEDs to each channel, AP will then work out how many you need for each group. As soon as you set a colour that number is then 'locked' and cant be changed.

The disadvantage of this is that you no longer get direct feedback if the DMA allocation fails, but we were not checking those returns in most cases anyway.

I'm still having trouble getting LEDs working across multiple groups. The order that `set_serial_led_num_LEDs` is called in seems to matter, a one group before the other and it works, the other way round and it fails. I have no idea....

