### PR TITLE
Fix occasional problems with SPL06

### DIFF
--- a/libraries/AP_Baro/AP_Baro_SPL06.cpp
+++ b/libraries/AP_Baro/AP_Baro_SPL06.cpp
@@ -103,9 +103,20 @@ bool AP_Baro_SPL06::_init()
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     uint8_t whoami;
-    if (!_dev->read_registers(SPL06_REG_CHIP_ID, &whoami, 1)  ||
-        whoami != SPL06_CHIP_ID) {
-        // not a SPL06
+
+// Sometimes SPL06 has init problems, that's due to failure of reading using SPI for the first time. The SPL06 is a dual
+// protocol sensor(I2C and SPI), sometimes it takes one SPI operation to convert it to SPI mode after it starts up.
+    bool is_SPL06 = false;
+
+    for (uint8_t i=0; i<5; i++) {
+        if (_dev->read_registers(SPL06_REG_CHIP_ID, &whoami, 1)  &&
+            whoami == SPL06_CHIP_ID) {
+            is_SPL06=true;
+            break;
+        }
+    }
+    
+    if(!is_SPL06) {
         return false;
     }
 


### PR DESCRIPTION
Sometimes SPL06 has init problems, that's due to failure of reading using SPI for the first time. The SPL06 is a dual protocol sensor(I2C and SPI), sometimes it takes one SPI operation to convert it to SPI mode after it starts up.