### PR TITLE
Plane: VTOL: remove motors config error

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -762,10 +762,6 @@ bool QuadPlane::setup(void)
 
     motors->init(frame_class, frame_type);
 
-    if (!motors->initialised_ok()) {
-        AP_BoardConfig::config_error("init failed: Q_FRAME_CLASS=%u Q_FRAME_TYPE=%u", frame_class, frame_type);
-    }
-
     tilt.is_vectored = tilt.tilt_mask != 0 && tilt.tilt_type == TILT_TYPE_VECTORED_YAW;
 
     if (motors_var_info == AP_MotorsMatrix::var_info && tilt.is_vectored) {


### PR DESCRIPTION
This removes the config error loop for quadplane motors failure to config. If using the scripting matrix motors back-end we hit this error before scripting comes up and has a chance to init motors. This makes the scripting back end pointless on plane.

We already have a arming check for motors so we will still catch a motors init fail:
https://github.com/ArduPilot/ardupilot/blob/1018801522f94b03623fdf33aa0c60c91492114d/ArduPlane/AP_Arming.cpp#L80 

A alternate would be to just skip this error loop when the scripting matrix back-end param is selected, but hopefully there will be more scripting motors back-ends in the future....