### PR TITLE
Copter: move implementation of get_pilot_desired_yaw_rate into mode.cpp

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -1,35 +1,5 @@
 #include "Copter.h"
 
-// transform pilot's yaw input into a desired yaw rate
-// returns desired yaw rate in centi-degrees per second
-float Copter::get_pilot_desired_yaw_rate(int16_t stick_angle)
-{
-    // throttle failsafe check
-    if (failsafe.radio || !ap.rc_receiver_present) {
-        return 0.0f;
-    }
-    float yaw_request;
-
-    // range check expo
-    g2.acro_y_expo = constrain_float(g2.acro_y_expo, 0.0f, 1.0f);
-
-    // calculate yaw rate request
-    if (is_zero(g2.acro_y_expo)) {
-        yaw_request = stick_angle * g.acro_yaw_p;
-    } else {
-        // expo variables
-        float y_in, y_in3, y_out;
-
-        // yaw expo
-        y_in = float(stick_angle)/ROLL_PITCH_YAW_INPUT_MAX;
-        y_in3 = y_in*y_in*y_in;
-        y_out = (g2.acro_y_expo * y_in3) + ((1.0f - g2.acro_y_expo) * y_in);
-        yaw_request = ROLL_PITCH_YAW_INPUT_MAX * y_out * g.acro_yaw_p;
-    }
-    // convert pilot input to the desired yaw rate
-    return yaw_request;
-}
-
 /*************************************************************
  *  throttle control
  ****************************************************************/

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -666,7 +666,6 @@ private:
     void update_altitude();
 
     // Attitude.cpp
-    float get_pilot_desired_yaw_rate(int16_t stick_angle);
     void update_throttle_hover();
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_non_takeoff_throttle();

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -250,7 +250,7 @@ void ModeFlowHold::run()
     target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), copter.g.pilot_speed_up);
 
     // get pilot's desired yaw rate
-    float target_yaw_rate = copter.get_pilot_desired_yaw_rate(copter.channel_yaw->get_control_in());
+    float target_yaw_rate = get_pilot_desired_yaw_rate(copter.channel_yaw->get_control_in());
 
     // Flow Hold State Machine Determination
     AltHoldModeState flowhold_state = get_alt_hold_state(target_climb_rate);


### PR DESCRIPTION
This just removed a shim which was added when we did the mode refactor.

It moves the implementation from one file to the other.
