### PR TITLE
autotest: remove useless mavproxy set heartbeat directive

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1349,7 +1349,6 @@ class AutoTest(ABC):
         ret = [
             '--sitl=127.0.0.1:5502',
             '--streamrate=%u' % self.sitl_streamrate(),
-            '--cmd="set heartbeat %u"' % self.speedup,
             '--target-system=%u' % self.sysid_thismav(),
             '--target-component=1',
         ]


### PR DESCRIPTION
This has never actually worked:

```
2021-03-24T04:53:03.7594996Z AT-0040.3: Starting MAVProxy
2021-03-24T04:53:03.7595674Z PYTHONPATH: /__w/ardupilot/ardupilot/Tools/mavproxy_modules
2021-03-24T04:53:05.8106006Z Running: "mavproxy.py" "--master" "tcp:127.0.0.1:5762" "--aircraft" "test.ArduCopter" "--sitl=127.0.0.1:5502" "--streamrate=5" "--cmd="set heartbeat 8"" "--target-system=1" "--target-component=1" "--quadcopter" "--default-modules" "misc,terrain,wp,rally,fence,param,arm,mode,rc,cmdlong,output"
2021-03-24T04:53:05.8108569Z ERROR LOADING MAVNATIVE - falling back to python implementation
2021-03-24T04:53:05.8109340Z Connect tcp:127.0.0.1:5762 source_system=255
2021-03-24T04:53:05.8109962Z no script test.ArduCopter/mavinit.scr
2021-03-24T04:53:05.8110739Z Unknown command '"set heartbeat 8"'
```
