### PR TITLE
autotest: reduce race condition in fly_square mission

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -323,7 +323,7 @@ class AutoTestCopter(AutoTest):
     # fly a square in alt_hold mode
     def fly_square(self, side=50, timeout=300):
 
-        self.takeoff(10, mode="ALT_HOLD")
+        self.takeoff(20, mode="ALT_HOLD")
 
         """Fly a square, flying N then E ."""
         tstart = self.get_sim_time()


### PR DESCRIPTION
We end up where we started, so when we start to play the mission back we
might immediately be at the first waypoint.  That's a problem as we may
never see the NAV_CONTROLLER_OUTPUT mention waypoint 1 and thus we
fail the test