### PR TITLE
AP_Baro: Add retries for initializing DPS280 and DPS310

### DIFF
--- a/libraries/AP_Baro/AP_Baro_DPS280.cpp
+++ b/libraries/AP_Baro/AP_Baro_DPS280.cpp
@@ -155,7 +155,7 @@ bool AP_Baro_DPS280::init()
     if (!dev) {
         return false;
     }
-    dev->get_semaphore()->take_blocking();
+    WITH_SEMAPHORE(dev->get_semaphore());
 
     // setup to allow reads on SPI
     if (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
@@ -165,14 +165,25 @@ bool AP_Baro_DPS280::init()
     dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     uint8_t whoami=0;
-    if (!dev->read_registers(DPS280_REG_PID, &whoami, 1) ||
-        whoami != DPS280_WHOAMI) {
-        dev->get_semaphore()->give();
+    bool found = false;
+    uint8_t retries;
+    for (retries = 0; retries < 5; retries++) {
+        if (dev->read_registers(DPS280_REG_PID, &whoami, 1) &&
+            whoami == DPS280_WHOAMI) {
+            found = true;
+            break;
+        }
+    }
+
+    if(!found) {
         return false;
+    }
+    
+    if (retries > 0) {
+        hal.console->printf("%s: read took %u retries\n", is_dps310 ? "DPS310" : "DPS280", retries);
     }
 
     if (!read_calibration()) {
-        dev->get_semaphore()->give();
         return false;
     }
 
@@ -185,8 +196,6 @@ bool AP_Baro_DPS280::init()
     dev->set_device_type(DEVTYPE_BARO_DPS280);
     set_bus_id(instance, dev->get_bus_id());
     
-    dev->get_semaphore()->give();
-
     // request 64Hz update. New data will be available at 32Hz
     dev->register_periodic_callback((1000 / 64) * AP_USEC_PER_MSEC, FUNCTOR_BIND_MEMBER(&AP_Baro_DPS280::timer, void));
 


### PR DESCRIPTION
This is a very similar fix as to what was implemented for the SPL06 (#16964).

I found the **Pixracer Pro** could not cannot reliably initialize the Baro driver, and so performing retries was necessary. The problem results in no further progression through the startup process, and it appears to get stuck outputting the lines:
```
APM: Config Error: fix problem then reboot
Config error: Baro: unable to initialise driver
APM: Config error: Baro: unable to initialise driver
```

If this is acceptable, is the print for number of retries required? A similar print is in `AP_InertialSensor_BMI088::setup_accel_config` for the number of tries it took to setup accel config.

I'll post the logs in separate comments for distinct separation.
Before changeset:
```
Mode(0)> 
Mode(0)> 
Mode(0)> APM: Config Error: fix problem then reboot
Config error: Baro: unable to initialise driver
APM: Config error: Baro: unable to initialise driver
reboot
Mode(0)> Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: ACCEPTED
Device /dev/serial/by-id/usb-mRo_mRoPixracerPro_3E0039000951303035343937-if00 is dead
Device /dev/serial/by-id/usb-mRo_mRoPixracerPro_3E0039000951303035343937-if00 reopened OK
Mode(0)> no link
link 1 down
Mode(0)> no link
AP_Logger_File: buffer size=204800
link 1 OK
heartbeat OK
APM: Initialising ArduPilot
disabling flow control on serial 2
disabling flow control on serial 3
BMI088: accel config OK (1 tries)
BMI088: found accel
BMI088: found gyro
APM: Calibrating barometer
APM: Barometer 1 calibration complete
Init Gyro***
APM: ArduPilot Ready
APM: AHRS: DCM active
APM: EKF3 IMU0 buffs IMU=19 OBS=7 OF=17 EN:17 dt=0.0120
APM: EKF3 IMU1 buffs IMU=19 OBS=7 OF=17 EN:17 dt=0.0120
reboot
Mode(0)> Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: ACCEPTED
Device /dev/serial/by-id/usb-mRo_mRoPixracerPro_3E0039000951303035343937-if00 is dead
Device /dev/serial/by-id/usb-mRo_mRoPixracerPro_3E0039000951303035343937-if00 reopened OK
no link
link 1 down
no link
Config error: Baro: unable to initialise driver
APM: Config error: Baro: unable to initialise driver
link 1 OK
heartbeat OK
APM: Config Error: fix problem then reboot
APM: Config Error: fix problem then reboot
Config error: Baro: unable to initialise driver
APM: Config error: Baro: unable to initialise driver
Mode(0)> APM: Config Error: fix problem then reboot
Config error: Baro: unable to initialise driver
APM: Config error: Baro: unable to initialise driver
```