### PR TITLE
AP_Mount: apply MNT_DEFLT_MODE at startup

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -471,6 +471,7 @@ void AP_Mount::init()
         // init new instance
         if (_backends[instance] != nullptr) {
             _backends[instance]->init();
+            set_mode_to_default(instance);
             if (!primary_set) {
                 _primary = instance;
                 primary_set = true;


### PR DESCRIPTION
This allows it to command RETRACT on boot if that's the default. Since there is no invalid/unknown enum value for this mode, the bootup value (0) matches mode RETRACTED. The logic in update will only set the mode if there's a mode change.

Scenario:
- Set param MNT_DEFLT_MODE = 0 (Retract on startup)
- deploy gimbal (set mode to >0)
- reboot
- system does not automatically retract