### PR TITLE
Remove assert() calls

### DIFF
--- a/Tools/AP_Bootloader/can.cpp
+++ b/Tools/AP_Bootloader/can.cpp
@@ -310,7 +310,6 @@ static void handle_allocation_response(CanardInstance* ins, CanardRxTransfer* tr
     uint8_t received_unique_id[UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_UNIQUE_ID_MAX_LENGTH];
     uint8_t received_unique_id_len = 0;
     for (; received_unique_id_len < (transfer->payload_len - (UniqueIDBitOffset / 8U)); received_unique_id_len++) {
-        assert(received_unique_id_len < UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_UNIQUE_ID_MAX_LENGTH);
         const uint8_t bit_offset = (uint8_t)(UniqueIDBitOffset + received_unique_id_len * 8U);
         (void) canardDecodeScalar(transfer, bit_offset, 8, false, &received_unique_id[received_unique_id_len]);
     }
@@ -333,7 +332,6 @@ static void handle_allocation_response(CanardInstance* ins, CanardRxTransfer* tr
         // Allocation complete - copying the allocated node ID from the message
         uint8_t allocated_node_id = 0;
         (void) canardDecodeScalar(transfer, 0, 7, false, &allocated_node_id);
-        assert(allocated_node_id <= 127);
 
         canardSetLocalNodeID(ins, allocated_node_id);
     }

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -417,7 +417,6 @@ static void handle_allocation_response(CanardInstance* ins, CanardRxTransfer* tr
     uint8_t received_unique_id[UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_UNIQUE_ID_MAX_LENGTH];
     uint8_t received_unique_id_len = 0;
     for (; received_unique_id_len < (transfer->payload_len - (UniqueIDBitOffset / 8U)); received_unique_id_len++) {
-        assert(received_unique_id_len < UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_UNIQUE_ID_MAX_LENGTH);
         const uint8_t bit_offset = (uint8_t)(UniqueIDBitOffset + received_unique_id_len * 8U);
         (void) canardDecodeScalar(transfer, bit_offset, 8, false, &received_unique_id[received_unique_id_len]);
     }
@@ -443,7 +442,6 @@ static void handle_allocation_response(CanardInstance* ins, CanardRxTransfer* tr
         // Allocation complete - copying the allocated node ID from the message
         uint8_t allocated_node_id = 0;
         (void) canardDecodeScalar(transfer, 0, 7, false, &allocated_node_id);
-        assert(allocated_node_id <= 127);
 
         canardSetLocalNodeID(ins, allocated_node_id);
         printf("Node ID allocated: %d\n", allocated_node_id);
@@ -1211,12 +1209,6 @@ static void can_wait_node_id(void)
         {
             uid_size = MaxLenOfUniqueIDInRequest;
         }
-
-        // Paranoia time
-        assert(node_id_allocation_unique_id_offset < UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_UNIQUE_ID_MAX_LENGTH);
-        assert(uid_size <= MaxLenOfUniqueIDInRequest);
-        assert(uid_size > 0);
-        assert((uid_size + node_id_allocation_unique_id_offset) <= UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_UNIQUE_ID_MAX_LENGTH);
 
         memmove(&allocation_request[1], &my_unique_id[node_id_allocation_unique_id_offset], uid_size);
 

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -391,7 +391,9 @@ bool AP_AK09916_BusDriver_Auxiliary::block_read(uint8_t reg, uint8_t *buf, uint3
          * We can only read a block when reading the block of sample values -
          * calling with any other value is a mistake
          */
-        assert(reg == REG_ST1);
+        if (reg != REG_ST1) {
+            return false;
+        }
 
         int n = _slave->read(buf);
         return n == static_cast<int>(size);

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -328,7 +328,9 @@ bool AP_AK8963_BusDriver_Auxiliary::block_read(uint8_t reg, uint8_t *buf, uint32
          * We can only read a block when reading the block of sample values -
          * calling with any other value is a mistake
          */
-        assert(reg == AK8963_HXL);
+        if (reg != AK8963_HXL) {
+            return false;
+        }
 
         int n = _slave->read(buf);
         return n == static_cast<int>(size);

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -521,7 +521,9 @@ bool AP_HMC5843_BusDriver_Auxiliary::block_read(uint8_t reg, uint8_t *buf, uint3
          * We can only read a block when reading the block of sample values -
          * calling with any other value is a mistake
          */
-        assert(reg == HMC5843_REG_DATA_OUTPUT_X_MSB);
+        if (reg != HMC5843_REG_DATA_OUTPUT_X_MSB) {
+            return false;
+        }
 
         int n = _slave->read(buf);
         return n == static_cast<int>(size);

--- a/libraries/AP_HAL/HAL.cpp
+++ b/libraries/AP_HAL/HAL.cpp
@@ -8,8 +8,6 @@ HAL::FunCallbacks::FunCallbacks(void (*setup_fun)(void), void (*loop_fun)(void))
     : _setup(setup_fun)
     , _loop(loop_fun)
 {
-    assert(setup_fun);
-    assert(loop_fun);
 }
 
 }

--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -300,7 +300,6 @@ void HAL_ChibiOS::run(int argc, char * const argv[], Callbacks* callbacks) const
     sdStart((SerialDriver*)&HAL_STDOUT_SERIAL, &stdoutcfg);
 #endif
 
-    assert(callbacks);
     g_callbacks = callbacks;
 
     //Takeover main

--- a/libraries/AP_HAL_Empty/HAL_Empty_Class.cpp
+++ b/libraries/AP_HAL_Empty/HAL_Empty_Class.cpp
@@ -50,8 +50,6 @@ HAL_Empty::HAL_Empty() :
 
 void HAL_Empty::run(int argc, char* const argv[], Callbacks* callbacks) const
 {
-    assert(callbacks);
-
     /* initialize all drivers and private members here.
      * up to the programmer to do this in the correct order.
      * Scheduler should likely come first. */

--- a/libraries/AP_HAL_Linux/GPIO_RPI.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.cpp
@@ -198,7 +198,6 @@ void GPIO_RPI::pinMode(uint8_t pin, uint8_t output)
 
 void GPIO_RPI::pinMode(uint8_t pin, uint8_t output, uint8_t alt)
 {
-    assert(alt < 6);
     if (output == HAL_GPIO_INPUT) {
         set_gpio_mode_in(pin);
     } else if (output == HAL_GPIO_ALT) {

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -296,8 +296,6 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
     const char *module_path = AP_MODULE_DEFAULT_DIRECTORY;
 #endif
     
-    assert(callbacks);
-
     int opt;
     const struct GetOptLong::option options[] = {
         {"uartA",         true,  0, 'A'},

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -162,8 +162,6 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
     struct i2c_msg msgs[2] = { };
     unsigned nmsgs = 0;
 
-    assert(_bus.fd >= 0);
-
     if (send && send_len != 0) {
         msgs[nmsgs].addr = _address;
         msgs[nmsgs].flags = 0;
@@ -389,8 +387,6 @@ I2CDeviceManager::_create_device(I2CBus &b, uint8_t address) const
 
 void I2CDeviceManager::_unregister(I2CBus &b)
 {
-    assert(b.ref > 0);
-
     if (--b.ref > 0) {
         return;
     }

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -274,8 +274,6 @@ bool SPIDevice::transfer(const uint8_t *send, uint32_t send_len,
     unsigned nmsgs = 0;
     int fd = _bus.fd[_desc.subdev];
 
-    assert(fd >= 0);
-
     if (send && send_len != 0) {
         msgs[nmsgs].tx_buf = (uint64_t) send;
         msgs[nmsgs].rx_buf = 0;
@@ -354,8 +352,6 @@ bool SPIDevice::transfer_fullduplex(const uint8_t *send, uint8_t *recv,
 {
     struct spi_ioc_transfer msgs[1] = { };
     int fd = _bus.fd[_desc.subdev];
-
-    assert(fd >= 0);
 
     if (!send || !recv || len == 0) {
         return false;

--- a/libraries/AP_HAL_SITL/DSP.cpp
+++ b/libraries/AP_HAL_SITL/DSP.cpp
@@ -84,7 +84,9 @@ void DSP::step_hanning(FFTWindowStateSITL* fft, FloatBuffer& samples, uint16_t a
     // apply hanning window to gyro samples and store result in _freq_bins
     // hanning starts and ends with 0, could be skipped for minor speed improvement
     uint32_t read_window = samples.peek(&fft->_freq_bins[0], fft->_window_size);
-    assert(read_window == fft->_window_size);
+    if (read_window != fft->_window_size) {
+        return;
+    }
     samples.advance(advance);
     mult_f32(&fft->_freq_bins[0], &fft->_hanning_window[0], &fft->_freq_bins[0], fft->_window_size);
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -774,7 +774,6 @@ void AP_InertialSensor::_start_backends()
 /* Find the N instance of the backend that has already been successfully detected */
 AP_InertialSensor_Backend *AP_InertialSensor::_find_backend(int16_t backend_id, uint8_t instance)
 {
-    assert(_backends_detected);
     uint8_t found = 0;
 
     for (uint8_t i = 0; i < _backend_count; i++) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -1049,8 +1049,6 @@ int AP_Invensense_AuxiliaryBusSlave::_set_passthrough(uint8_t reg, uint8_t size,
 int AP_Invensense_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *buf,
                                                    uint8_t size)
 {
-    assert(buf);
-
     if (_registered) {
         hal.console->printf("Error: can't passthrough when slave is already configured\n");
         return -1;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
@@ -772,8 +772,6 @@ int AP_Invensensev2_AuxiliaryBusSlave::_set_passthrough(uint8_t reg, uint8_t siz
 int AP_Invensensev2_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *buf,
                                                    uint8_t size)
 {
-    assert(buf);
-
     if (_registered) {
         hal.console->printf("Error: can't passthrough when slave is already configured\n");
         return -1;

--- a/libraries/AP_InertialSensor/AuxiliaryBus.cpp
+++ b/libraries/AP_InertialSensor/AuxiliaryBus.cpp
@@ -85,9 +85,6 @@ AuxiliaryBusSlave *AuxiliaryBus::request_next_slave(uint8_t addr)
 int AuxiliaryBus::register_periodic_read(AuxiliaryBusSlave *slave, uint8_t reg,
                                          uint8_t size)
 {
-    assert(slave->_instance == _n_slaves);
-    assert(_n_slaves < _max_slaves);
-
     int r = _configure_periodic_read(slave, reg, size);
     if (r < 0)
         return r;

--- a/libraries/AP_Math/AP_GeodesicGrid.cpp
+++ b/libraries/AP_Math/AP_GeodesicGrid.cpp
@@ -420,8 +420,6 @@ int AP_GeodesicGrid::_triangle_index(const Vector3f &v, bool inclusive)
         break;
     }
 
-    assert(umbrella >= 0);
-
     switch (umbrella % 3) {
     case 0:
         w.z = -w.z;


### PR DESCRIPTION
These assert() calls are useless in anything but SITL, and just consume flash space without doing anything useful. They also cause builds to be different on build server from locally due to the embedding of the path.
