### PR TITLE
AC_Avoidance: fixes to work with SCurves

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -113,7 +113,7 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
     } else {
         ground_course_deg = degrees(ground_speed_vec.angle());
     }
-    
+
     bool ret;
     switch (get_type()) {
         case OABendyType::OA_BENDY_VERTICAL:
@@ -128,7 +128,7 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
             ret = search_xy_path(current_loc, destination, ground_course_deg, destination_new, lookahead_step1_dist, lookahead_step2_dist, bearing_to_dest, distance_to_dest, proximity_only);
             bendy_type = OABendyType::OA_BENDY_HORIZONTAL;
     }
-   
+
     return ret;
 }
 
@@ -236,7 +236,7 @@ bool AP_OABendyRuler::search_xy_path(const Location& current_loc, const Location
 }
 
 // Search for path in the vertical directions
-bool AP_OABendyRuler::search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest, bool proximity_only) 
+bool AP_OABendyRuler::search_vertical_path(const Location &current_loc, const Location &destination, Location &destination_new, float lookahead_step1_dist, float lookahead_step2_dist, float bearing_to_dest, float distance_to_dest, bool proximity_only)
 {
     // check OA_BEARING_INC_VERTICAL definition allows checking in all directions
     static_assert(360 % OA_BENDYRULER_BEARING_INC_VERTICAL == 0, "check 360 is a multiple of OA_BEARING_INC_VERTICAL");
@@ -285,7 +285,7 @@ bool AP_OABendyRuler::search_vertical_path(const Location& current_loc, const Lo
                 for (uint8_t j = 0; j < ARRAY_SIZE(test_pitch_step2); j++) {
                     float bearing_test2 = wrap_180(test_pitch_step2[j]);
                     Location test_loc2 = test_loc;
-                    test_loc2.offset_bearing_and_pitch(bearing_to_dest2, bearing_test2 ,distance2);
+                    test_loc2.offset_bearing_and_pitch(bearing_to_dest2, bearing_test2, distance2);
 
                     // calculate minimum margin to fence and obstacles for this scenario
                     float margin2 = calc_avoidance_margin(test_loc, test_loc2, proximity_only);
@@ -309,7 +309,7 @@ bool AP_OABendyRuler::search_vertical_path(const Location& current_loc, const Lo
                         }
                         // project in the chosen direction by the full distance
                         destination_new = current_loc;
-                        destination_new.offset_bearing_and_pitch(bearing_to_dest,pitch_delta, distance_to_dest);
+                        destination_new.offset_bearing_and_pitch(bearing_to_dest, pitch_delta, distance_to_dest);
                         _current_lookahead = MIN(_lookahead, _current_lookahead * 1.1f);
                     
                         Write_OABendyRuler((uint8_t)OABendyType::OA_BENDY_VERTICAL, active, bearing_to_dest, pitch_delta, false, margin, destination, destination_new);

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -79,10 +79,14 @@ AP_OABendyRuler::AP_OABendyRuler()
 
 // run background task to find best path and update avoidance_results
 // returns true and updates origin_new and destination_new if a best path has been found
-bool AP_OABendyRuler::update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new, bool proximity_only)
-{   
+// bendy_type is set to the type of BendyRuler used
+bool AP_OABendyRuler::update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new, OABendyType &bendy_type, bool proximity_only)
+{
     // bendy ruler always sets origin to current_loc
     origin_new = current_loc;
+
+    // init bendy_type returned
+    bendy_type = OABendyType::OA_BENDY_DISABLED;
 
     // calculate bearing and distance to final destination
     const float bearing_to_dest = current_loc.get_bearing_to(destination) * 0.01f;
@@ -115,12 +119,14 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
         case OABendyType::OA_BENDY_VERTICAL:
         #if VERTICAL_ENABLED 
             ret = search_vertical_path(current_loc, destination, destination_new, lookahead_step1_dist, lookahead_step2_dist, bearing_to_dest, distance_to_dest, proximity_only);
+            bendy_type = OABendyType::OA_BENDY_VERTICAL;
             break;
         #endif
 
         case OABendyType::OA_BENDY_HORIZONTAL:
         default:
             ret = search_xy_path(current_loc, destination, ground_course_deg, destination_new, lookahead_step1_dist, lookahead_step2_dist, bearing_to_dest, distance_to_dest, proximity_only);
+            bendy_type = OABendyType::OA_BENDY_HORIZONTAL;
     }
    
     return ret;

--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -40,7 +40,7 @@ private:
     bool search_xy_path(const Location& current_loc, const Location& destination, float ground_course_deg, Location &destination_new, float lookahead_step_1_dist, float lookahead_step_2_dist, float bearing_to_dest, float distance_to_dest, bool proximity_only);
 
     // search for path in the Vertical directions
-    bool search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest, bool proximity_only);
+    bool search_vertical_path(const Location &current_loc, const Location &destination, Location &destination_new, float lookahead_step1_dist, float lookahead_step2_dist, float bearing_to_dest, float distance_to_dest, bool proximity_only);
 
     // calculate minimum distance between a path and any obstacle
     float calc_avoidance_margin(const Location &start, const Location &end, bool proximity_only) const;

--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -19,15 +19,19 @@ public:
     // send configuration info stored in front end parameters
     void set_config(float margin_max) { _margin_max = MAX(margin_max, 0.0f); }
 
-    // run background task to find best path and update avoidance_results
-    // returns true and populates origin_new and destination_new if OA is required.  returns false if OA is not required
-    bool update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new, bool proximity_only);
-
     enum class OABendyType {
         OA_BENDY_DISABLED   = 0,
         OA_BENDY_HORIZONTAL = 1,
         OA_BENDY_VERTICAL   = 2,
     };
+
+    // run background task to find best path and update avoidance_results
+    // returns true and populates origin_new and destination_new if OA is required.  returns false if OA is not required
+    bool update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new, OABendyType &bendy_type, bool proximity_only);
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
 
     // return type of BendyRuler in use
     OABendyType get_type() const;
@@ -36,11 +40,7 @@ public:
     bool search_xy_path(const Location& current_loc, const Location& destination, float ground_course_deg, Location &destination_new, float lookahead_step_1_dist, float lookahead_step_2_dist, float bearing_to_dest, float distance_to_dest, bool proximity_only);
 
     // search for path in the Vertical directions
-    bool search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest, bool proximity_only); 
-
-    static const struct AP_Param::GroupInfo var_info[];
-
-private:
+    bool search_vertical_path(const Location& current_loc, const Location& destination,Location &destination_new, const float &lookahead_step1_dist, const float &lookahead_step2_dist, const float &bearing_to_dest, const float &distance_to_dest, bool proximity_only);
 
     // calculate minimum distance between a path and any obstacle
     float calc_avoidance_margin(const Location &start, const Location &end, bool proximity_only) const;

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -87,7 +87,9 @@ bool AC_WPNav_OA::update_wpnav()
         Location oa_origin_new, oa_destination_new;
         AP_OAPathPlanner::OAPathPlannerUsed path_planner_used = AP_OAPathPlanner::OAPathPlannerUsed::None;
         const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc, origin_loc, destination_loc, oa_origin_new, oa_destination_new, path_planner_used);
+
         switch (oa_retstate) {
+
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             if (_oa_state != oa_retstate) {
                 // object avoidance has become inactive so reset target to original destination
@@ -95,6 +97,7 @@ bool AC_WPNav_OA::update_wpnav()
                 _oa_state = oa_retstate;
             }
             break;
+
         case AP_OAPathPlanner::OA_PROCESSING:
         case AP_OAPathPlanner::OA_ERROR:
             // during processing or in case of error stop the vehicle
@@ -109,6 +112,7 @@ bool AC_WPNav_OA::update_wpnav()
                 }
             }
             break;
+
         case AP_OAPathPlanner::OA_SUCCESS:
 
             // handling of returned destination depends upon path planner used
@@ -170,8 +174,7 @@ bool AC_WPNav_OA::update_wpnav()
                 return true;
             }
 
-            case AP_OAPathPlanner::OAPathPlannerUsed::BendyRulerVertical:
-            {
+            case AP_OAPathPlanner::OAPathPlannerUsed::BendyRulerVertical: {
                 _oa_state = oa_retstate;
                 _oa_destination = oa_destination_new;
 
@@ -190,14 +193,12 @@ bool AC_WPNav_OA::update_wpnav()
                 // update horizontal position controller (vertical is updated in vehicle code)
                 _pos_control.update_xy_controller();
 
-                // Note: do not update yaw or yaw rate as we do for BendyRuler horizontal
-
                 // return success without calling parent AC_WPNav
                 return true;
             }
 
-            } // case AP_OAPathPlanner::OA_SUCCESS
-        } // switch (oa_retstate)
+            }
+        }
     }
 
     // run the non-OA update

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -1,3 +1,5 @@
+#include <AP_Math/control.h>
+#include <AP_InternalError/AP_InternalError.h>
 #include "AC_WPNav_OA.h"
 
 AC_WPNav_OA::AC_WPNav_OA(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control) :
@@ -83,7 +85,8 @@ bool AC_WPNav_OA::update_wpnav()
         const Location origin_loc(_origin_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         const Location destination_loc(_destination_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         Location oa_origin_new, oa_destination_new;
-        const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc, origin_loc, destination_loc, oa_origin_new, oa_destination_new);
+        AP_OAPathPlanner::OAPathPlannerUsed path_planner_used = AP_OAPathPlanner::OAPathPlannerUsed::None;
+        const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc, origin_loc, destination_loc, oa_origin_new, oa_destination_new, path_planner_used);
         switch (oa_retstate) {
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             if (_oa_state != oa_retstate) {
@@ -107,26 +110,94 @@ bool AC_WPNav_OA::update_wpnav()
             }
             break;
         case AP_OAPathPlanner::OA_SUCCESS:
-            // if oa destination has become active or destination has changed update wpnav
-            if ((_oa_state != AP_OAPathPlanner::OA_SUCCESS) || !oa_destination_new.same_latlon_as(_oa_destination)) {
-                _oa_destination = oa_destination_new;
-                // convert Location to offset from EKF origin
-                Vector3f dest_NEU;
-                if (_oa_destination.get_vector_from_origin_NEU(dest_NEU)) {
-                    if ((oa_ptr->get_bendy_type() == AP_OABendyRuler::OABendyType::OA_BENDY_HORIZONTAL) ||
-                        (oa_ptr->get_bendy_type() == AP_OABendyRuler::OABendyType::OA_BENDY_DISABLED)) {
-                        // calculate target altitude by calculating OA adjusted destination's distance along the original track
-                        // and then linear interpolate using the original track's origin and destination altitude
-                        const float dist_along_path = constrain_float(oa_destination_new.line_path_proportion(origin_loc, destination_loc), 0.0f, 1.0f);
-                        dest_NEU.z = linear_interpolate(_origin_oabak.z, _destination_oabak.z, dist_along_path, 0.0f, 1.0f);
-                    }       
-                    if (set_wp_destination(dest_NEU, _terrain_alt_oabak)) {
-                        _oa_state = oa_retstate;
+
+            // handling of returned destination depends upon path planner used
+            switch (path_planner_used) {
+
+            case AP_OAPathPlanner::OAPathPlannerUsed::None:
+                // this should never happen.  this means the path planner has returned success but has failed to set the path planner used
+                INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+                return false;
+
+            case AP_OAPathPlanner::OAPathPlannerUsed::Dijkstras:
+                // Dijkstra's.  Action is only needed if path planner has just became active or the target destination's lat or lon has changed
+                if ((_oa_state != AP_OAPathPlanner::OA_SUCCESS) || !oa_destination_new.same_latlon_as(_oa_destination)) {
+                    Location origin_oabak_loc(_origin_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+                    Location destination_oabak_loc(_destination_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+                    oa_destination_new.linearly_interpolate_alt(origin_oabak_loc, destination_oabak_loc);
+                    if (!set_wp_destination_loc(oa_destination_new)) {
+                        // trigger terrain failsafe
+                        return false;
                     }
+                    // if new target set successfully, update oa state and destination
+                    _oa_state = oa_retstate;
+                    _oa_destination = oa_destination_new;
                 }
+                break;
+
+            case AP_OAPathPlanner::OAPathPlannerUsed::BendyRulerHorizontal: {
+                _oa_state = oa_retstate;
+                _oa_destination = oa_destination_new;
+
+                // altitude target interpolated from current_loc's distance along the original path
+                Location target_alt_loc = current_loc;
+                target_alt_loc.linearly_interpolate_alt(origin_loc, destination_loc);
+
+                // correct target_alt_loc's alt-above-ekf-origin if using terrain altitudes
+                // positive terr_offset means terrain below vehicle is above ekf origin's altitude
+                float terr_offset = 0;
+                if (_terrain_alt_oabak && !get_terrain_offset(terr_offset)) {
+                    // trigger terrain failsafe
+                    return false;
+                }
+
+                // calculate final destination as an offset from EKF origin in NEU
+                Vector2f dest_NE;
+                if (!_oa_destination.get_vector_xy_from_origin_NE(dest_NE)) {
+                    // this should never happen because we can only get here if we have an EKF origin
+                    INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+                    return false;
+                }
+                Vector3p dest_NEU{dest_NE.x, dest_NE.y, (float)target_alt_loc.alt};
+
+                // pass the desired position directly to the position controller
+                _pos_control.input_pos_xyz(dest_NEU, terr_offset, 1000.0);
+
+                // update horizontal position controller (vertical is updated in vehicle code)
+                _pos_control.update_xy_controller();
+
+                // return success without calling parent AC_WPNav
+                return true;
             }
-            break;
-        }
+
+            case AP_OAPathPlanner::OAPathPlannerUsed::BendyRulerVertical:
+            {
+                _oa_state = oa_retstate;
+                _oa_destination = oa_destination_new;
+
+                // calculate final destination as an offset from EKF origin in NEU
+                Vector3f dest_NEU;
+                if (!_oa_destination.get_vector_from_origin_NEU(dest_NEU)) {
+                    // this should never happen because we can only get here if we have an EKF origin
+                    INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+                    return false;
+                }
+
+                // pass the desired position directly to the position controller as an offset from EKF origin in NEU
+                Vector3p dest_NEU_p{dest_NEU.x, dest_NEU.y, dest_NEU.z};
+                _pos_control.input_pos_xyz(dest_NEU_p, 0, 1000.0);
+
+                // update horizontal position controller (vertical is updated in vehicle code)
+                _pos_control.update_xy_controller();
+
+                // Note: do not update yaw or yaw rate as we do for BendyRuler horizontal
+
+                // return success without calling parent AC_WPNav
+                return true;
+            }
+
+            } // case AP_OAPathPlanner::OA_SUCCESS
+        } // switch (oa_retstate)
     }
 
     // run the non-OA update

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -461,3 +461,13 @@ int32_t Location::limit_lattitude(int32_t lat)
     }
     return lat;
 }
+
+// update altitude and alt-frame base on this location's horizontal position between point1 and point2
+// this location's lat,lon is used to calculate the alt of the closest point on the line between point1 and point2
+// origin and destination's altitude frames must be the same
+// this alt-frame will be updated to match the destination alt frame
+void Location::linearly_interpolate_alt(const Location &point1, const Location &point2)
+{
+    // new target's distance along the original track and then linear interpolate between the original origin and destination altitudes
+    set_alt_cm(point1.alt + (point2.alt - point1.alt) * constrain_float(line_path_proportion(point1, point2), 0.0f, 1.0f), point2.get_alt_frame());
+}

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -118,6 +118,12 @@ public:
      */
     float line_path_proportion(const Location &point1, const Location &point2) const;
 
+    // update altitude and alt-frame base on this location's horizontal position between point1 and point2
+    // this location's lat,lon is used to calculate the alt of the closest point on the line between point1 and point2
+    // origin and destination's altitude frames must be the same
+    // this alt-frame will be updated to match the destination alt frame
+    void linearly_interpolate_alt(const Location &point1, const Location &point2);
+
     bool initialised() const { return (lat !=0 || lng != 0 || alt != 0); }
 
     // wrap longitude at -180e7 to 180e7

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -2,6 +2,8 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/AP_HAL_Boards.h>
+#include "vector2.h"
+#include "vector3.h"
 
 #ifndef HAL_WITH_POSTYPE_DOUBLE
 #define HAL_WITH_POSTYPE_DOUBLE BOARD_FLASH_SIZE > 1024

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -34,6 +34,7 @@
 #endif
 
 #include <cmath>
+#include <float.h>
 #include <AP_Common/AP_Common.h>
 #include "ftype.h"
 

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -128,7 +128,8 @@ void AR_WPNav::update(float dt)
 
     AP_OAPathPlanner *oa = AP_OAPathPlanner::get_singleton();
     if (oa != nullptr) {
-        const AP_OAPathPlanner::OA_RetState oa_retstate = oa->mission_avoidance(current_loc, _origin, _destination, _oa_origin, _oa_destination);
+        AP_OAPathPlanner::OAPathPlannerUsed path_planner_used;
+        const AP_OAPathPlanner::OA_RetState oa_retstate = oa->mission_avoidance(current_loc, _origin, _destination, _oa_origin, _oa_destination, path_planner_used);
         switch (oa_retstate) {
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             _oa_active = false;


### PR DESCRIPTION
This PR builds on the SCurves PR https://github.com/ArduPilot/ardupilot/pull/15896 to fixup Dijkstra's and BendyRuler's performance when using SCurves.


- Location::linear_interpolate_alt to allow setting this's alt to a linear interpolation of the lat from and origin and destination.  This is used with BendyRuler which only works horizontally.
- BendyRuler and PathPlanner are enhanced so the caller knows which path planner was used (previously the caller didn't need to know, they would just pass whatever destination was returned into AC_WPNav)
- WPNav_OA is enhanced so that it handles a destination from BendyRuler differently than a destination from Dikstra's.  Dijkstra's destinations continue to be passed into AC_WPNav (and SCurves) while BendyRuler's results go into the position controller

There are also some changes to formatting and spelling.

This has been tested in SITL but the following issues remain.  It is possible we could resolve these in a follow-up PR.

- BendyRuler can return a position outside the fence (this is an existing issue) meaning the vehicle may stray outside the fence
- BendyRuler's LOOKAHEAD distance can be shorter than the vehicle's stopping distance (which comes from WPNAV_ACCEL and WPNAV_SPEED)




