### PR TITLE
waf: set NDEBUG define to avoid assert issues

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -618,7 +618,8 @@ class chibios(Board):
             '--specs=nosys.specs',
             '-DCHIBIOS_BOARD_NAME="%s"' % self.name,
             '-D__USE_CMSIS',
-            '-Werror=deprecated-declarations'
+            '-Werror=deprecated-declarations',
+            '-DNDEBUG=1'
         ]
         if not cfg.options.Werror:
             env.CFLAGS += [


### PR DESCRIPTION
this avoids future assert() calls from affecting STM32 HAL_ChibiOS
builds