### PR TITLE
Copter/Sub/Rover/Plane: HAL_PROXIMITY_ENABLED to disable AP_Proximity

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -10,7 +10,6 @@
 //#define AC_FENCE              DISABLED            // disable fence to save 2k of flash
 //#define CAMERA                DISABLED            // disable camera trigger to save 1k of flash
 //#define RANGEFINDER_ENABLED   DISABLED            // disable rangefinder to save 1k of flash
-//#define PROXIMITY_ENABLED     DISABLED            // disable proximity sensors
 //#define AC_RALLY              DISABLED            // disable rally points library (must also disable terrain which relies on rally)
 //#define AC_AVOID_ENABLED      DISABLED            // disable stop-at-fence library
 //#define AC_OAPATHPLANNER_ENABLED DISABLED         // disable path planning around obstacles

--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -18,7 +18,6 @@
 //#define NAV_GUIDED            DISABLED            // disable external navigation computer ability to control vehicle through MAV_CMD_NAV_GUIDED mission commands
 //#define OPTFLOW               DISABLED            // disable optical flow sensor to save 5K of flash space
 //#define FRSKY_TELEM_ENABLED   DISABLED            // disable FRSky telemetry
-//#define ADSB_ENABLED          DISABLED            // disable ADSB support
 //#define PRECISION_LANDING     DISABLED            // disable precision landing using companion computer or IRLock sensor
 //#define BEACON_ENABLED        DISABLED            // disable beacon support
 //#define SPRAYER_ENABLED       DISABLED            // disable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -477,7 +477,7 @@ bool AP_Arming_Copter::pre_arm_ekf_attitude_check()
 // check nothing is too close to vehicle
 bool AP_Arming_Copter::proximity_checks(bool display_failure) const
 {
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
 
     if (!AP_Arming::proximity_checks(display_failure)) {
         return false;

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -107,7 +107,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if RANGEFINDER_ENABLED == ENABLED
     SCHED_TASK(read_rangefinder,      20,    100),
 #endif
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     SCHED_TASK_CLASS(AP_Proximity,         &copter.g2.proximity,        update,         200,  50),
 #endif
 #if BEACON_ENABLED == ENABLED
@@ -427,7 +427,7 @@ void Copter::ten_hz_logging_loop()
     }
     if (should_log(MASK_LOG_CTUN)) {
         attitude_control->control_monitor_log();
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
         logger.Write_Proximity(g2.proximity);  // Write proximity sensor distances
 #endif
 #if BEACON_ENABLED == ENABLED

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -67,6 +67,7 @@
 #include <AP_Parachute/AP_Parachute.h>
 #include <AC_Sprayer/AC_Sprayer.h>
 #include <AP_ADSB/AP_ADSB.h>
+#include <AP_Proximity/AP_Proximity.h>
 
 // Configuration
 #include "defines.h"
@@ -128,9 +129,6 @@
 #endif
 #if RANGEFINDER_ENABLED == ENABLED
  # include <AP_RangeFinder/AP_RangeFinder.h>
-#endif
-#if PROXIMITY_ENABLED == ENABLED
- # include <AP_Proximity/AP_Proximity.h>
 #endif
 
 #include <AP_Mount/AP_Mount.h>

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -61,7 +61,7 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
     }
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     if (copter.g2.proximity.sensor_present()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_PROXIMITY;
     }
@@ -106,7 +106,7 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         break;
     }
 
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     if (copter.g2.proximity.sensor_enabled()) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_PROXIMITY;
     }
@@ -126,7 +126,7 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
     }
 #endif
 
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     if (!copter.g2.proximity.sensor_failed()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_PROXIMITY;
     }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -821,7 +821,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(beacon, "BCN", 14, ParametersG2, AP_Beacon),
 #endif
 
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     // @Group: PRX
     // @Path: ../libraries/AP_Proximity/AP_Proximity.cpp
     AP_SUBGROUPINFO(proximity, "PRX", 8, ParametersG2, AP_Proximity),
@@ -1065,7 +1065,7 @@ ParametersG2::ParametersG2(void)
 #if BEACON_ENABLED == ENABLED
     , beacon(copter.serial_manager)
 #endif
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     , proximity()
 #endif
 #if ADVANCED_FAILSAFE == ENABLED

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -2,6 +2,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include "RC_Channel.h"
+#include <AP_Proximity/AP_Proximity.h>
 
 #if GRIPPER_ENABLED == ENABLED
  # include <AP_Gripper/AP_Gripper.h>
@@ -520,7 +521,7 @@ public:
     AP_Beacon beacon;
 #endif
 
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     // proximity (aka object avoidance) library
     AP_Proximity proximity;
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -116,13 +116,6 @@
  # define RANGEFINDER_GLITCH_NUM_SAMPLES  3   // number of rangefinder glitches in a row to take new reading
 #endif
 
-//////////////////////////////////////////////////////////////////////////////
-// Proximity sensor
-//
-#ifndef PROXIMITY_ENABLED
- # define PROXIMITY_ENABLED ENABLED
-#endif
-
 #ifndef MAV_SYSTEM_ID
  # define MAV_SYSTEM_ID          1
 #endif
@@ -685,9 +678,6 @@
  #define AC_OAPATHPLANNER_ENABLED   !HAL_MINIMIZE_FEATURES
 #endif
 
-#if AC_AVOID_ENABLED && !PROXIMITY_ENABLED
-  #error AC_Avoidance relies on PROXIMITY_ENABLED which is disabled
-#endif
 #if AC_AVOID_ENABLED && !AC_FENCE
   #error AC_Avoidance relies on AC_FENCE which is disabled
 #endif

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -97,7 +97,7 @@ void Copter::read_rangefinder(void)
 #if MODE_CIRCLE_ENABLED
                 circle_nav->set_rangefinder_alt(rangefinder_state.enabled && wp_nav->rangefinder_used(), rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 #endif
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
                 g2.proximity.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 #endif
             }
@@ -224,7 +224,7 @@ void Copter::accel_cal_update()
 // initialise proximity sensor
 void Copter::init_proximity(void)
 {
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     g2.proximity.init();
 #endif
 }

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -630,7 +630,7 @@ const AP_Param::Info Sub::var_info[] = {
  */
 const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     // @Group: PRX
     // @Path: ../libraries/AP_Proximity/AP_Proximity.cpp
     AP_SUBGROUPINFO(proximity, "PRX", 2, ParametersG2, AP_Proximity),

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -324,7 +324,7 @@ public:
     AP_Gripper gripper;
 #endif
 
-#if PROXIMITY_ENABLED == ENABLED
+#if HAL_PROXIMITY_ENABLED
     // proximity (aka object avoidance) library
     AP_Proximity proximity;
 #endif

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -66,6 +66,7 @@
 #include <AP_JSButton/AP_JSButton.h>   // Joystick/gamepad button function assignment
 #include <AP_LeakDetector/AP_LeakDetector.h> // Leak detector
 #include <AP_TemperatureSensor/TSYS01.h>
+#include <AP_Proximity/AP_Proximity.h>
 
 // Local modules
 #include "defines.h"
@@ -91,10 +92,6 @@
 
 #if GRIPPER_ENABLED == ENABLED
 #include <AP_Gripper/AP_Gripper.h>             // gripper stuff
-#endif
-
-#if PROXIMITY_ENABLED == ENABLED
-#include <AP_Proximity/AP_Proximity.h>
 #endif
 
 #if AVOIDANCE_ENABLED == ENABLED

--- a/ArduSub/config.h
+++ b/ArduSub/config.h
@@ -88,15 +88,8 @@
 # define AVOIDANCE_ENABLED DISABLED
 #endif
 
-#if AVOIDANCE_ENABLED == ENABLED // Avoidance Library relies on Proximity and Fence
-# define PROXIMITY_ENABLED ENABLED
+#if AVOIDANCE_ENABLED == ENABLED // Avoidance Library relies on Fence
 # define FENCE_ENABLED ENABLED
-#endif
-
-// Proximity sensor
-//
-#ifndef PROXIMITY_ENABLED
-# define PROXIMITY_ENABLED DISABLED
 #endif
 
 #ifndef MAV_SYSTEM_ID

--- a/Rover/GCS_Rover.cpp
+++ b/Rover/GCS_Rover.cpp
@@ -28,11 +28,13 @@ bool GCS_Rover::supersimple_input_active() const
 void GCS_Rover::update_vehicle_sensor_status_flags(void)
 {
     // first what sensors/controllers we have
+#if HAL_PROXIMITY_ENABLED
     const AP_Proximity *proximity = AP_Proximity::get_singleton();
     if (proximity && proximity->get_status() > AP_Proximity::Status::NotConnected) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
+#endif
 
     control_sensors_present |=
         MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL |
@@ -62,7 +64,10 @@ void GCS_Rover::update_vehicle_sensor_status_flags(void)
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
     }
+
+#if HAL_PROXIMITY_ENABLED
     if (proximity && proximity->get_status() != AP_Proximity::Status::NoData) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
+#endif
 }

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -496,9 +496,11 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AC_Fence/AC_Fence.cpp
     AP_SUBGROUPINFO(fence, "FENCE_", 17, ParametersG2, AC_Fence),
 
+#if HAL_PROXIMITY_ENABLED
     // @Group: PRX
     // @Path: ../libraries/AP_Proximity/AP_Proximity.cpp
     AP_SUBGROUPINFO(proximity, "PRX", 18, ParametersG2, AP_Proximity),
+#endif
 
     // @Group: AVOID_
     // @Path: ../libraries/AC_Avoidance/AC_Avoid.cpp
@@ -701,7 +703,9 @@ ParametersG2::ParametersG2(void)
     wheel_rate_control(wheel_encoder),
     attitude_control(rover.ahrs),
     smart_rtl(),
+#if HAL_PROXIMITY_ENABLED
     proximity(),
+#endif
     avoid(),
     follow(),
     windvane(),

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -329,8 +329,10 @@ public:
     // fence library
     AC_Fence fence;
 
+#if HAL_PROXIMITY_ENABLED
     // proximity library
     AP_Proximity proximity;
+#endif
 
     // avoidance library
     AC_Avoid avoid;

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -56,7 +56,9 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_GPS,              &rover.gps,              update,         50,  300),
     SCHED_TASK_CLASS(AP_Baro,             &rover.barometer,        update,         10,  200),
     SCHED_TASK_CLASS(AP_Beacon,           &rover.g2.beacon,        update,         50,  200),
+#if HAL_PROXIMITY_ENABLED
     SCHED_TASK_CLASS(AP_Proximity,        &rover.g2.proximity,     update,         50,  200),
+#endif
     SCHED_TASK_CLASS(AP_WindVane,         &rover.g2.windvane,      update,         20,  100),
     SCHED_TASK_CLASS(AC_Fence,            &rover.g2.fence,         update,         10,  100),
     SCHED_TASK(update_wheel_encoder,   50,    200),
@@ -300,9 +302,11 @@ void Rover::update_logging1(void)
         Log_Write_Nav_Tuning();
     }
 
+#if HAL_PROXIMITY_ENABLED
     if (should_log(MASK_LOG_RANGEFINDER)) {
         logger.Write_Proximity(g2.proximity);
     }
+#endif
 }
 
 /*

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -67,8 +67,10 @@ void Rover::init_ardupilot()
     // initialise rangefinder
     rangefinder.init(ROTATION_NONE);
 
+#if HAL_PROXIMITY_ENABLED
     // init proximity sensor
     g2.proximity.init();
+#endif
 
     // init beacons used for non-gps position estimation
     g2.beacon.init();

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -361,6 +361,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         }
     }
 
+#if HAL_PROXIMITY_ENABLED
     // get distance from proximity sensor
     float proximity_alt_diff;
     AP_Proximity *proximity = AP::proximity();
@@ -371,6 +372,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
             limit_alt = true;
         }
     }
+#endif
 
     // limit climb rate
     if (limit_alt) {
@@ -1084,6 +1086,7 @@ void AC_Avoid::adjust_velocity_beacon_fence(float kP, float accel_cmss, Vector2f
  */
 void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector3f &desired_vel_cms, Vector3f &backup_vel, float kP_z, float accel_cmss_z, float dt)
 {
+#if HAL_PROXIMITY_ENABLED
     // exit immediately if proximity sensor is not present
     AP_Proximity *proximity = AP::proximity();
     if (!proximity) {
@@ -1211,6 +1214,7 @@ void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector3f &d
     desired_vel_cms = Vector3f{safe_vel_2d.x, safe_vel_2d.y, safe_vel.z};
     const Vector2f backup_vel_xy = _ahrs.body_to_earth2D(desired_back_vel_cms_xy);
     backup_vel = Vector3f{backup_vel_xy.x, backup_vel_xy.y, desired_back_vel_cms_z};
+#endif // HAL_PROXIMITY_ENABLED
 }
 
 /*
@@ -1371,6 +1375,7 @@ float AC_Avoid::distance_to_lean_pct(float dist_m)
 // returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
 void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative)
 {
+#if HAL_PROXIMITY_ENABLED
     AP_Proximity *proximity = AP::proximity();
     if (proximity == nullptr) {
         return;
@@ -1414,6 +1419,7 @@ void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_ne
             }
         }
     }
+#endif // HAL_PROXIMITY_ENABLED
 }
 
 // singleton instance

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -843,6 +843,7 @@ bool AP_Arming::system_checks(bool report)
 // check nothing is too close to vehicle
 bool AP_Arming::proximity_checks(bool report) const
 {
+#if HAL_PROXIMITY_ENABLED
     const AP_Proximity *proximity = AP::proximity();
     // return true immediately if no sensor present
     if (proximity == nullptr) {
@@ -857,6 +858,7 @@ bool AP_Arming::proximity_checks(bool report) const
         check_failed(report, "check proximity sensor");
         return false;
     }
+#endif
 
     return true;
 }

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -330,7 +330,9 @@ public:
                           uint8_t sequence,
                           const RallyLocation &rally_point);
     void Write_Beacon(AP_Beacon &beacon);
+#if HAL_PROXIMITY_ENABLED
     void Write_Proximity(AP_Proximity &proximity);
+#endif
     void Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& point);
     void Write_OABendyRuler(uint8_t type, bool active, float target_yaw, float target_pitch, bool ignore_chg, float margin, const Location &final_dest, const Location &oa_dest);
     void Write_OADijkstra(uint8_t state, uint8_t error_id, uint8_t curr_point, uint8_t tot_points, const Location &final_dest, const Location &oa_dest);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -546,6 +546,7 @@ void AP_Logger::Write_Beacon(AP_Beacon &beacon)
     WriteBlock(&pkt_beacon, sizeof(pkt_beacon));
 }
 
+#if HAL_PROXIMITY_ENABLED
 // Write proximity sensor distances
 void AP_Logger::Write_Proximity(AP_Proximity &proximity)
 {
@@ -608,6 +609,7 @@ void AP_Logger::Write_Proximity(AP_Proximity &proximity)
         }
     }
 }
+#endif
 
 void AP_Logger::Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& breadcrumb)
 {

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -14,6 +14,8 @@
  */
 
 #include "AP_Proximity.h"
+
+#if HAL_PROXIMITY_ENABLED
 #include "AP_Proximity_LightWareSF40C_v09.h"
 #include "AP_Proximity_RPLidarA2.h"
 #include "AP_Proximity_TeraRangerTower.h"
@@ -502,3 +504,5 @@ AP_Proximity *proximity()
 }
 
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -14,8 +14,16 @@
  */
 #pragma once
 
-#include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef HAL_PROXIMITY_ENABLED
+#define HAL_PROXIMITY_ENABLED (!HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024)
+#endif
+
+#if HAL_PROXIMITY_ENABLED
+
+#include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
@@ -187,3 +195,5 @@ private:
 namespace AP {
     AP_Proximity *proximity();
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -13,9 +13,11 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_Proximity_AirSimSITL.h"
+
+#if HAL_PROXIMITY_ENABLED
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <AP_HAL/AP_HAL.h>
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
@@ -93,4 +95,6 @@ bool AP_Proximity_AirSimSITL::get_upward_distance(float &distance) const
     return false;
 }
 
-#endif // CONFIG_HAL_BOARD
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.h
@@ -15,8 +15,9 @@
 
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend.h"
+
+#if HAL_PROXIMITY_ENABLED
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
@@ -43,3 +44,5 @@ private:
 
 };
 #endif // CONFIG_HAL_BOARD
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -13,13 +13,13 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AP_Proximity_Backend.h"
+
+#if HAL_PROXIMITY_ENABLED
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AC_Avoidance/AP_OADatabase.h>
-#include <AP_HAL/AP_HAL.h>
-#include "AP_Proximity.h"
-#include "AP_Proximity_Backend.h"
 #include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;
@@ -205,3 +205,5 @@ void AP_Proximity_Backend::database_push(float angle, float pitch, float distanc
 
     oaDb->queue_push(temp_pos, timestamp_ms, distance);
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -14,9 +14,11 @@
  */
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include "AP_Proximity_Boundary_3D.h"
 
@@ -118,3 +120,5 @@ protected:
     // Methods to manipulate 3D boundary in this class
     AP_Proximity_Boundary_3D boundary;
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
@@ -15,6 +15,7 @@
 
 #include "AP_Proximity_Backend_Serial.h"
 
+#if HAL_PROXIMITY_ENABLED
 #include <AP_SerialManager/AP_SerialManager.h>
 
 /*
@@ -41,3 +42,4 @@ bool AP_Proximity_Backend_Serial::detect()
     return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
 }
 
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend_Serial.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend_Serial.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend.h"
+
+#if HAL_PROXIMITY_ENABLED
 
 class AP_Proximity_Backend_Serial : public AP_Proximity_Backend
 {
@@ -16,3 +17,5 @@ protected:
 
     AP_HAL::UARTDriver *_uart;              // uart for communicating with sensor
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.cpp
@@ -1,5 +1,22 @@
-#include "AP_Proximity_Backend.h"
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "AP_Proximity_Boundary_3D.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include "AP_Proximity_Backend.h"
 
 /*
   Constructor. 
@@ -357,3 +374,5 @@ bool AP_Proximity_Boundary_3D::get_layer_distances(uint8_t layer_number, float d
 
     return valid_distances;
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
@@ -15,6 +15,10 @@
 
 #pragma once
 
+#include "AP_Proximity.h"
+
+#if HAL_PROXIMITY_ENABLED
+
 #include <Filter/LowPassFilter.h>
 
 #define PROXIMITY_NUM_SECTORS         8       // number of sectors
@@ -156,3 +160,4 @@ private:
     LowPassFilterFloat _filtered_distance[PROXIMITY_NUM_LAYERS][PROXIMITY_NUM_SECTORS]; // low pass filter
 };
 
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -13,11 +13,13 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AP_Proximity_LightWareSF40C.h"
+
+#if HAL_PROXIMITY_ENABLED
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/crc.h>
-#include "AP_Proximity_LightWareSF40C.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -418,3 +420,5 @@ uint16_t AP_Proximity_LightWareSF40C::buff_to_uint16(uint8_t b0, uint8_t b1) con
     uint16_t leval = (uint16_t)b0 | (uint16_t)b1 << 8;
     return leval;
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend_Serial.h"
+
+#if HAL_PROXIMITY_ENABLED
 
 #define PROXIMITY_SF40C_TIMEOUT_MS            200   // requests timeout after 0.2 seconds
 #define PROXIMITY_SF40C_PAYLOAD_LEN_MAX       256   // maximum payload size we can accept (in some configurations sensor may send as large as 1023)
@@ -150,3 +151,5 @@ private:
     uint32_t buff_to_uint32(uint8_t b0, uint8_t b1, uint8_t b2, uint8_t b3) const;
     uint16_t buff_to_uint16(uint8_t b0, uint8_t b1) const;
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.cpp
@@ -13,8 +13,10 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_LightWareSF40C_v09.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include <AP_HAL/AP_HAL.h>
 #include <ctype.h>
 #include <stdio.h>
 
@@ -360,3 +362,5 @@ void AP_Proximity_LightWareSF40C_v09::clear_buffers()
     element_num = 0;
     memset(element_buf, 0, sizeof(element_buf));
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C_v09.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend_Serial.h"
 
+#if HAL_PROXIMITY_ENABLED
 #define PROXIMITY_SF40C_TIMEOUT_MS            200                               // requests timeout after 0.2 seconds
 
 class AP_Proximity_LightWareSF40C_v09 : public AP_Proximity_Backend_Serial
@@ -88,3 +88,5 @@ private:
     uint8_t _motor_direction = 99;      // motor direction as reported by lidar
     int16_t _forward_direction = 999;   // forward direction as reported by lidar
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
@@ -16,10 +16,12 @@
    http://support.lightware.co.za/sf45/#/commands
  */
 
+#include "AP_Proximity_LightWareSF45B.h"
+#if HAL_PROXIMITY_ENABLED
+
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
-#include "AP_Proximity_LightWareSF45B.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -197,3 +199,5 @@ uint8_t AP_Proximity_LightWareSF45B::convert_angle_to_minisector(float angle_deg
 {
     return wrap_360(angle_deg + (PROXIMITY_SF45B_COMBINE_READINGS_DEG * 0.5f)) / PROXIMITY_SF45B_COMBINE_READINGS_DEG;
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <Filter/Filter.h>
-#include "AP_Proximity.h"
 #include "AP_Proximity_LightWareSerial.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include <Filter/Filter.h>
 
 class AP_Proximity_LightWareSF45B : public AP_Proximity_LightWareSerial
 {
@@ -100,3 +101,5 @@ private:
     } _sensor_state;
 
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSerial.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSerial.cpp
@@ -13,11 +13,13 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AP_Proximity_LightWareSerial.h"
+
+#if HAL_PROXIMITY_ENABLED
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/crc.h>
-#include "AP_Proximity_LightWareSerial.h"
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
@@ -138,3 +140,5 @@ bool AP_Proximity_LightWareSerial::parse_byte(uint8_t b)
 
     return false;
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSerial.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSerial.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend_Serial.h"
 
+#if HAL_PROXIMITY_ENABLED
 #define PROXIMITY_LIGHTWARE_PAYLOAD_LEN_MAX 256 // maximum payload size we can accept (in some configurations sensor may send as large as 1023)
 
 class AP_Proximity_LightWareSerial : public AP_Proximity_Backend_Serial
@@ -48,3 +48,5 @@ protected:
         uint8_t crc_high;       // crc high byte
     } _msg;
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -13,8 +13,10 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_MAV.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include <AP_HAL/AP_HAL.h>
 #include <ctype.h>
 #include <stdio.h>
 
@@ -261,3 +263,5 @@ void AP_Proximity_MAV::handle_obstacle_distance_3d_msg(const mavlink_message_t &
     }
     return;
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend.h"
+
+#if HAL_PROXIMITY_ENABLED
 
 class AP_Proximity_MAV : public AP_Proximity_Backend
 {
@@ -42,3 +43,5 @@ private:
     uint32_t _last_upward_update_ms;    // system time of last update of upward distance
     float _distance_upward;             // upward distance in meters
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -26,8 +26,10 @@
  *
  */
 
-#include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_RPLidarA2.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include <AP_HAL/AP_HAL.h>
 #include <ctype.h>
 #include <stdio.h>
 
@@ -358,3 +360,5 @@ void AP_Proximity_RPLidarA2::parse_response_data()
             break;
     }
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -29,10 +29,9 @@
 
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend_Serial.h"
-#include <AP_HAL/AP_HAL.h>                   ///< for UARTDriver
 
+#if HAL_PROXIMITY_ENABLED
 
 class AP_Proximity_RPLidarA2 : public AP_Proximity_Backend_Serial
 {
@@ -121,3 +120,5 @@ private:
         _sensor_health sensor_health;
     } payload;
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -13,8 +13,10 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_RangeFinder.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include <AP_HAL/AP_HAL.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
@@ -90,3 +92,5 @@ bool AP_Proximity_RangeFinder::get_upward_distance(float &distance) const
     }
     return false;
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend.h"
+
+#if HAL_PROXIMITY_ENABLED
 
 #define PROXIMITY_RANGEFIDER_TIMEOUT_MS 200 // requests timeout after 0.2 seconds
 
@@ -33,3 +34,5 @@ private:
     uint32_t _last_upward_update_ms;    // system time of last update distance
     float _distance_upward = -1;        // upward distance in meters, negative if the last reading was out of range
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -13,11 +13,14 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AP_Proximity_SITL.h"
 
+#if HAL_PROXIMITY_ENABLED
 #include <AP_HAL/AP_HAL.h>
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <AP_Param/AP_Param.h>
-#include "AP_Proximity_SITL.h"
+
 #include <AC_Fence/AC_Fence.h>
 #include <stdio.h>
 
@@ -124,3 +127,5 @@ bool AP_Proximity_SITL::get_upward_distance(float &distance) const
 }
 
 #endif // CONFIG_HAL_BOARD
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "AP_Proximity.h"
+
+#if HAL_PROXIMITY_ENABLED
 #include "AP_Proximity_Backend.h"
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
@@ -37,3 +39,5 @@ private:
 
 };
 #endif // CONFIG_HAL_BOARD
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -13,8 +13,10 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_TeraRangerTower.h"
+
+#if HAL_PROXIMITY_ENABLED
+#include <AP_HAL/AP_HAL.h>
 #include <AP_Math/crc.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -103,3 +105,5 @@ void AP_Proximity_TeraRangerTower::update_sector_data(int16_t angle_deg, uint16_
     }
     _last_distance_received_ms = AP_HAL::millis();
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "AP_Proximity.h"
 #include "AP_Proximity_Backend_Serial.h"
 
+#if HAL_PROXIMITY_ENABLED
 #define PROXIMITY_TRTOWER_TIMEOUT_MS            300                               // requests timeout after 0.3 seconds
 
 class AP_Proximity_TeraRangerTower : public AP_Proximity_Backend_Serial
@@ -32,3 +32,5 @@ private:
     // request related variables
     uint32_t _last_distance_received_ms;    // system time of last distance measurement received from sensor
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -15,6 +15,8 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity_TeraRangerTowerEvo.h"
+
+#if HAL_PROXIMITY_ENABLED
 #include <AP_Math/crc.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -158,3 +160,5 @@ void AP_Proximity_TeraRangerTowerEvo::update_sector_data(int16_t angle_deg, uint
     }
     _last_distance_received_ms = AP_HAL::millis();
 }
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "AP_Proximity.h"
+
+#if HAL_PROXIMITY_ENABLED
 #include "AP_Proximity_Backend_Serial.h"
 
 #define PROXIMITY_TRTOWER_TIMEOUT_MS            300                               // requests timeout after 0.3 seconds
@@ -56,3 +58,5 @@ private:
 //    const uint8_t REFRESH_500_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x05, (uint8_t)0xD6};
 //    const uint8_t REFRESH_600_HZ[5] = { (uint8_t)0x00, (uint8_t)0x52, (uint8_t)0x03, (uint8_t)0x06, (uint8_t)0xDF};
 };
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -131,6 +131,7 @@ singleton AP_Notify method handle_rgb void uint8_t 0 UINT8_MAX uint8_t 0 UINT8_M
 
 include AP_Proximity/AP_Proximity.h
 
+singleton AP_Proximity depends HAL_PROXIMITY_ENABLED == 1
 singleton AP_Proximity alias proximity
 singleton AP_Proximity method get_status uint8_t
 singleton AP_Proximity method num_sensors uint8_t

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -326,6 +326,8 @@ void GCS_MAVLINK::send_distance_sensor()
     // sending them here, and allow the later proximity code to manage
     // them
     bool filter_possible_proximity_sensors = false;
+
+#if HAL_PROXIMITY_ENABLED
     AP_Proximity *proximity = AP_Proximity::get_singleton();
     if (proximity != nullptr) {
         for (uint8_t i = 0; i < proximity->num_sensors(); i++) {
@@ -334,6 +336,7 @@ void GCS_MAVLINK::send_distance_sensor()
             }
         }
     }
+#endif
 
     for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
         if (!HAVE_PAYLOAD_SPACE(chan, DISTANCE_SENSOR)) {
@@ -371,6 +374,7 @@ void GCS_MAVLINK::send_rangefinder() const
 
 void GCS_MAVLINK::send_proximity()
 {
+#if HAL_PROXIMITY_ENABLED
     AP_Proximity *proximity = AP_Proximity::get_singleton();
     if (proximity == nullptr) {
         return; // this is wrong, but pretend we sent data and don't requeue
@@ -428,6 +432,7 @@ void GCS_MAVLINK::send_proximity()
                 0,                                                        // Measurement covariance in centimeters, 0 for unknown / invalid readings
                 0, 0, nullptr, 0);
     }
+#endif // HAL_PROXIMITY_ENABLED
 }
 
 // report AHRS2 state
@@ -3239,26 +3244,32 @@ void GCS_MAVLINK::handle_distance_sensor(const mavlink_message_t &msg)
         rangefinder->handle_msg(msg);
     }
 
+#if HAL_PROXIMITY_ENABLED
     AP_Proximity *proximity = AP::proximity();
     if (proximity != nullptr) {
         proximity->handle_msg(msg);
     }
+#endif
 }
 
 void GCS_MAVLINK::handle_obstacle_distance(const mavlink_message_t &msg)
 {
+#if HAL_PROXIMITY_ENABLED
     AP_Proximity *proximity = AP::proximity();
     if (proximity != nullptr) {
         proximity->handle_msg(msg);
     }
+#endif
 }
 
 void GCS_MAVLINK::handle_obstacle_distance_3d(const mavlink_message_t &msg)
 {
+#if HAL_PROXIMITY_ENABLED
     AP_Proximity *proximity = AP::proximity();
     if (proximity != nullptr) {
         proximity->handle_msg(msg);
     }
+#endif
 }
 
 void GCS_MAVLINK::handle_osd_param_config(const mavlink_message_t &msg) const


### PR DESCRIPTION
This PR allows the AP_Proximity library to be compiled out saving flash (about 20k) on boards with less than 1MB of flash.  This allows the SCurves PR https://github.com/ArduPilot/ardupilot/pull/15896 to be merged without breaking the build for these boards:

- BeastF7
- FlywooF745
- KakuteF7Mini
- OMNIBUSF7V2-bdshot
- omnibusf4
- omnibusf4pro
- skyviper-f412-rev1
- skyviper-journey

Comparison before/after for KakuteF7Mini
Target          Text    Data  BSS     Total
bin/arducopter  **936520**  2092  260136  1198748
bin/arducopter  **917236**  2092  260140  1179468


Another structural improvement we could make is to move the AP_Proximity logging from AP_Logger to AP_Proximity.

This has not been properly tested yet.

Thanks to @peterbarker for help creating this PR!

