### PR TITLE
Copter Scripting: fixed posvel example start location calculation

### DIFF
--- a/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
+++ b/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
@@ -28,7 +28,7 @@ function circle()
     local cur_freq = 0
     -- increase target speed lineary with time until ramp_up_time_s is reached
     if time <= ramp_up_time_s then 
-        cur_freq = omega_radps*time/ramp_up_time_s
+        cur_freq = omega_radps*(time/ramp_up_time_s)^2
     else 
         cur_freq = omega_radps
     end
@@ -69,10 +69,14 @@ function update()
         end
     else 
         -- calculate test starting location in NED
-        local home = ahrs:get_home()
-        local cur_loc = ahrs:get_position()
-        if home and cur_loc then
-            test_start_location = home:get_distance_NED(cur_loc)
+        local cur_loc = ahrs:get_position()        
+        if cur_loc then
+             test_start_location = cur_loc.get_vector_from_origin_NEU(cur_loc)             
+             if test_start_location then
+                test_start_location:x(test_start_location:x() * 0.01) 
+                test_start_location:y(test_start_location:y() * 0.01) 
+                test_start_location:z(-test_start_location:z() * 0.01) 
+             end             
         end
 
         -- reset some variable as soon as we are not in guided mode


### PR DESCRIPTION
I finally flight tested the pr #16955 and found out that the current test start location calculation is not right. Position controller uses current position with respect to EKF origin, not home location. The difference between home and origin can cause rapid movement at the start. I suspect, this is not present in set_target_location and set_target_velocity_NED method, because non of them set the target position, directly. 

I also changed the start frequency calculation to smooth VX command. 

Before:
![image](https://user-images.githubusercontent.com/11930560/112451540-acc98280-8d66-11eb-92df-92d1715ee0c2.png)

After:
![image](https://user-images.githubusercontent.com/11930560/112452100-4e50d400-8d67-11eb-8ea8-0cb473e83afe.png)

This change also makes use of  get_vector_from_origin_NEU binding, which I found to be not used by any other script examples. 
