### PR TITLE
autotest: add debug for reboot-detection bug

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1623,6 +1623,9 @@ class AutoTest(ABC):
             required_bootcount = old_bootcount + 1
         while True:
             if time.time() - tstart > timeout:
+                self.progress("Didn't get a reboot, but here are some variables")
+                for p in ['LOG_DISARMED']:
+                    self.progress("%s=%f" % (p, self.get_parameter(p)))
                 raise AutoTestTimeoutException("Did not detect reboot")
             try:
                 current_bootcount = self.get_parameter('STAT_BOOTCNT',

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1570,6 +1570,16 @@ class AutoTest(ABC):
 
     def reboot_sitl_mav(self, required_bootcount=None):
         """Reboot SITL instance using mavlink and wait for it to reconnect."""
+        # we must make sure that stats have been reset - otherwise
+        # when we reboot we'll reset statistics again and lose our
+        # STAT_BOOTCNT increment:
+        tstart = time.time()
+        while True:
+            if time.time() - tstart > 30:
+                raise NotAchievedException("STAT_RESET did not go non-zero")
+            if self.get_parameter('STAT_RESET') != 0:
+                break
+
         old_bootcount = self.get_parameter('STAT_BOOTCNT')
         # ardupilot SITL may actually NAK the reboot; replace with
         # run_cmd when we don't do that.

--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -3,6 +3,8 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_RTC/AP_RTC.h>
 
+#include <GCS_MAVLink/GCS.h>
+
 const extern AP_HAL::HAL& hal;
 
 // table of user settable parameters
@@ -61,6 +63,7 @@ void AP_Stats::copy_variables_from_parameters()
 void AP_Stats::init()
 {
     params.bootcount.set_and_save(params.bootcount+1);
+    gcs().send_text(MAV_SEVERITY_INFO, "bootcount bumped to %u", (unsigned)params.bootcount+1);
 
     // initialise our variables from parameters:
     copy_variables_from_parameters();

--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -107,6 +107,7 @@ void AP_Stats::update()
     }
     const uint32_t params_reset = params.reset;
     if (params_reset != reset || params_reset == 0) {
+        gcs().send_text(MAV_SEVERITY_INFO, "stats reset (%u %u)", (unsigned)params_reset, (unsigned)reset);
         params.bootcount.set_and_save_ifchanged(params_reset == 0 ? 1 : 0);
         params.flttime.set_and_save_ifchanged(0);
         params.runtime.set_and_save_ifchanged(0);

--- a/libraries/AP_Stats/AP_Stats.h
+++ b/libraries/AP_Stats/AP_Stats.h
@@ -29,6 +29,8 @@ public:
     // call at least 1Hz
     void update();
 
+    // called by main code to indicate the vehicle is flying (or not).
+    // Used to determine whether we update the flight-time statistic
     void set_flying(bool b);
 
     // accessor for is_flying
@@ -57,6 +59,11 @@ private:
         AP_Int32 reset;
     } params;
 
+    // copy current values of parameters into normal variables.  These
+    // normal variables are frobbed by the codebase, and are
+    // periodically copied back into the parameter variables with
+    // set_and_save_ifchanged.  This is designed so we don't do too
+    // many writes to storage which has caused issues in the past
     void copy_variables_from_parameters();
 
     uint64_t last_flush_ms; // in terms of system uptime


### PR DESCRIPTION
This is some debug to try to find out why `STAT_BOOTCOUNT` isn't acting as a reliable reboot indicator.

I'm hoping the bug will reproduce on this PR and I won't need to merge it.
