### PR TITLE
AP_Mission: options parameter description per vehicle

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -28,6 +28,8 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @DisplayName: Mission options bitmask
     // @Description: Bitmask of what options to use in missions.
     // @Bitmask: 0:Clear Mission on reboot, 1:Use distance to land calc on battery failsafe,2:ContinueAfterLand
+    // @Bitmask{Copter}: 0:Clear Mission on reboot, 2:ContinueAfterLand
+    // @Bitmask{Rover, Sub}: 0:Clear Mission on reboot
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),
 


### PR DESCRIPTION
This hides some of the MIS_OPTIONS parameter bits for vehicles where they don't apply.

As a side note, I feel that most of these options are vehicle specific and might be better placed inside of AUTO_OPTIONS on the individual vehicles but that discussion is for another day.