### PR TITLE
Sub/Copter/Plane: remove Log_Write_Performance which is not called anywhere

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -782,7 +782,6 @@ private:
 
     // Log.cpp
     void Log_Write_Control_Tuning();
-    void Log_Write_Performance();
     void Log_Write_Attitude();
     void Log_Write_EKF_POS();
     void Log_Write_MotBatt();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -631,7 +631,6 @@ void Copter::log_init(void)
 #else // LOGGING_ENABLED
 
 void Copter::Log_Write_Control_Tuning() {}
-void Copter::Log_Write_Performance() {}
 void Copter::Log_Write_Attitude(void) {}
 void Copter::Log_Write_EKF_POS() {}
 void Copter::Log_Write_MotBatt() {}

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -527,7 +527,6 @@ void Plane::log_init(void)
 
 void Plane::Log_Write_Attitude(void) {}
 void Plane::Log_Write_Fast(void) {}
-void Plane::Log_Write_Performance() {}
 void Plane::Log_Write_Startup(uint8_t type) {}
 void Plane::Log_Write_Control_Tuning() {}
 void Plane::Log_Write_OFG_Guided() {}

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -862,7 +862,6 @@ private:
     // Log.cpp
     void Log_Write_Fast(void);
     void Log_Write_Attitude(void);
-    void Log_Write_Performance();
     void Log_Write_Startup(uint8_t type);
     void Log_Write_Control_Tuning();
     void Log_Write_OFG_Guided();

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -346,7 +346,6 @@ void Sub::log_init()
 #else // LOGGING_ENABLED
 
 void Sub::Log_Write_Control_Tuning() {}
-void Sub::Log_Write_Performance() {}
 void Sub::Log_Write_Attitude(void) {}
 void Sub::Log_Write_MotBatt() {}
 void Sub::Log_Write_Data(LogDataID id, int32_t value) {}

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -428,7 +428,6 @@ private:
     void rpm_update();
 #endif
     void Log_Write_Control_Tuning();
-    void Log_Write_Performance();
     void Log_Write_Attitude();
     void Log_Write_MotBatt();
     void Log_Write_Data(LogDataID id, int32_t value);


### PR DESCRIPTION
This logging was all moved into AP_Scheduler
