### PR TITLE
Tools: Add --autotest-server as ignored parameter to autotest.py

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -794,6 +794,10 @@ if __name__ == "__main__":
         "e.g. autotest.py --debug --gdb build.Tracker test.Tracker # run Tracker under gdb\n"
         "e.g. autotest.py --debug --gdb build.Sub test.Sub.DiveManual # do specific Sub test\n"
     )
+    parser.add_option("--autotest-server",
+                      action='store_true',
+                      default=False,
+                      help='Run in autotest-server mode; dangerous!')
     parser.add_option("--skip",
                       type='string',
                       default='',
@@ -1099,6 +1103,12 @@ if __name__ == "__main__":
                 sys.exit(1)
             matched.extend(matches)
         steps = matched
+    elif opts.autotest_server:
+        # we will be changing this script to give a help message if
+        # --autotest-server isn't given, instead of assuming we want
+        # to do everything that happens on autotest.ardupilot.org,
+        # which includes some significant state-changing actions.
+        print("AutoTest-Server Mode")
 
     # skip steps according to --skip option:
     steps_to_run = [s for s in steps if should_run_step(s)]

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -123,7 +123,7 @@ export BUILD_BINARIES_PATH=$HOME/build/tmp
 # exit on panic so we don't waste time waiting around
 export SITL_PANIC_EXIT=1
 
-timelimit 32000 APM/Tools/autotest/autotest.py --timeout=30000 > buildlogs/autotest-output.txt 2>&1
+timelimit 32000 APM/Tools/autotest/autotest.py --autotest-server --timeout=30000 > buildlogs/autotest-output.txt 2>&1
 
 mkdir -p "buildlogs/history/$hdate"
 


### PR DESCRIPTION
I've always been a little nervous about pointing people at `autotest.py`because of its default behaviour - if run without arguments it does bad things to your development environment.

After this is merged the build shell script (run from cron on autotest) will need to be copied into position (ensuring any local changes on the server are not lost).  Once that is done (and we've verified that autotest is passing in the relevant parameter on its runs) we can change the default action taken by autotest.py when no arguments are passed in to present the help message.

From the change description on autotest.py:
``` 
    This option is currently ignored, but if given allows the script to
    continue normally.
    
    This allows us to change the autotest server to pass the option in - and
    then we can change autotest.py so that unless the option is given we
    spit out a help message rather than completely stuff up the user's
    development environment
```