### PR TITLE
AP_Mount: allow all mount types to control gimbal deploy/retract servo

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -11,6 +11,7 @@
 #include "AP_Mount_SToRM32.h"
 #include "AP_Mount_SToRM32_serial.h"
 #include <AP_Math/location.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 const AP_Param::GroupInfo AP_Mount::var_info[] = {
 
@@ -486,6 +487,13 @@ void AP_Mount::update()
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
         if (_backends[instance] != nullptr) {
             _backends[instance]->update();
+
+            // assign retract/deploy servo channel
+            const SRV_Channel::Aux_servo_function_t retract_ch = (instance == 0) ? SRV_Channel::Aux_servo_function_t::k_mount_open : SRV_Channel::Aux_servo_function_t::k_mount2_open;
+            if (SRV_Channels::function_assigned(retract_ch)) {
+                const int16_t deploy_percent = (state[instance]._mode == MAV_MOUNT_MODE_RETRACT) ? 0 : 100;
+                SRV_Channels::set_output_scaled(retract_ch, deploy_percent);
+            }
         }
     }
 }

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -38,7 +38,9 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
 // maximum number of mounts
+#ifndef AP_MOUNT_MAX_INSTANCES
 #define AP_MOUNT_MAX_INSTANCES          1
+#endif
 
 // declare backend classes
 class AP_Mount_Backend;

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -10,13 +10,11 @@ void AP_Mount_Servo::init()
         _roll_idx = SRV_Channel::k_mount_roll;
         _tilt_idx = SRV_Channel::k_mount_tilt;
         _pan_idx  = SRV_Channel::k_mount_pan;
-        _open_idx = SRV_Channel::k_mount_open;
     } else {
         // this must be the 2nd mount
         _roll_idx = SRV_Channel::k_mount2_roll;
         _tilt_idx = SRV_Channel::k_mount2_tilt;
         _pan_idx  = SRV_Channel::k_mount2_pan;
-        _open_idx = SRV_Channel::k_mount2_open;
     }
 
     // check which servos have been assigned
@@ -26,8 +24,6 @@ void AP_Mount_Servo::init()
 // update mount position - should be called periodically
 void AP_Mount_Servo::update()
 {
-    static bool mount_open = 0;     // 0 is closed
-
     // check servo map every three seconds to allow users to modify parameters
     uint32_t now = AP_HAL::millis();
     if (now - _last_check_servo_map_ms > 3000) {
@@ -100,13 +96,6 @@ void AP_Mount_Servo::update()
         default:
             //do nothing
             break;
-    }
-
-    // move mount to a "retracted position" into the fuselage with a fourth servo
-    bool mount_open_new = (get_mode() == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
-    if (mount_open != mount_open_new) {
-        mount_open = mount_open_new;
-        move_servo(_open_idx, mount_open_new, 0, 1);
     }
 
     // write the results to the servos

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -16,11 +16,7 @@ class AP_Mount_Servo : public AP_Mount_Backend
 public:
     // Constructor
     AP_Mount_Servo(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance):
-        AP_Mount_Backend(frontend, state, instance),
-        _roll_idx(SRV_Channel::k_none),
-        _tilt_idx(SRV_Channel::k_none),
-        _pan_idx(SRV_Channel::k_none),
-        _open_idx(SRV_Channel::k_none)
+        AP_Mount_Backend(frontend, state, instance)
     {
     }
 
@@ -65,7 +61,6 @@ private:
     SRV_Channel::Aux_servo_function_t    _roll_idx;  // SRV_Channel mount roll function index
     SRV_Channel::Aux_servo_function_t    _tilt_idx;  // SRV_Channel mount tilt function index
     SRV_Channel::Aux_servo_function_t    _pan_idx;   // SRV_Channel mount pan  function index
-    SRV_Channel::Aux_servo_function_t    _open_idx;  // SRV_Channel mount open function index
 
     Vector3f _angle_bf_output_deg;  // final body frame output angle in degrees
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -100,6 +100,8 @@ void SRV_Channel::aux_servo_function_setup(void)
     case k_flap:
     case k_flap_auto:
     case k_egg_drop:
+    case k_mount_open:
+    case k_mount2_open:
         set_range(100);
         break;
     case k_heli_rsc:


### PR DESCRIPTION
Allow all mount types to control gimbal deploy/retract servo