### PR TITLE
AP_Scripting: add battery reset binding

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -555,7 +555,7 @@ void AP_BattMonitor::checkPoweringOff(void)
   reset battery remaining percentage for batteries that integrate to
   calculate percentage remaining
 */
-bool AP_BattMonitor::reset_remaining(uint16_t battery_mask, float percentage)
+bool AP_BattMonitor::reset_remaining_mask(uint16_t battery_mask, float percentage)
 {
     bool ret = true;
     Failsafe highest_failsafe = Failsafe::None;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -208,7 +208,8 @@ public:
     void checkPoweringOff(void);
 
     // reset battery remaining percentage
-    bool reset_remaining(uint16_t battery_mask, float percentage);
+    bool reset_remaining_mask(uint16_t battery_mask, float percentage);
+    bool reset_remaining(uint8_t instance, float percentage) { return reset_remaining_mask(1U<<instance, percentage);}
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -71,6 +71,7 @@ singleton AP_BattMonitor method has_failsafed boolean
 singleton AP_BattMonitor method overpower_detected boolean uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method get_temperature boolean float'Null uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method get_cycle_count boolean uint8_t 0 ud->num_instances() uint16_t'Null
+singleton AP_BattMonitor method reset_remaining boolean uint8_t 0 ud->num_instances() float 0 100
 
 include AP_GPS/AP_GPS.h
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3833,7 +3833,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_battery_reset(const mavlink_command_long_
 {
     const uint16_t battery_mask = packet.param1;
     const float percentage = packet.param2;
-    if (AP::battery().reset_remaining(battery_mask, percentage)) {
+    if (AP::battery().reset_remaining_mask(battery_mask, percentage)) {
         return MAV_RESULT_ACCEPTED;
     }
     return MAV_RESULT_FAILED;


### PR DESCRIPTION
This adds battery helper function and binding to allow per-instance battery percentage resets from scirpting.

Tested in SITL with the REPL.