### PR TITLE
Copter: Get the flight mode name from the name method

### DIFF
--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -169,13 +169,13 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
                 // store point A
                 dest_A.x = curr_pos.x;
                 dest_A.y = curr_pos.y;
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: point A stored");
+                gcs().send_text(MAV_SEVERITY_INFO, "%s: point A stored", name());
                 AP::logger().Write_Event(LogEvent::ZIGZAG_STORE_A);
             } else {
                 // store point B
                 dest_B.x = curr_pos.x;
                 dest_B.y = curr_pos.y;
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: point B stored");
+                gcs().send_text(MAV_SEVERITY_INFO, "%s: point B stored", name());
                 AP::logger().Write_Event(LogEvent::ZIGZAG_STORE_B);
             }
             // if both A and B have been stored advance state
@@ -203,10 +203,10 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
                     spray(true);
                     reach_wp_time_ms = 0;
                     if (is_auto == false || line_num == ZIGZAG_LINE_INFINITY) {
-                        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", (ab_dest == Destination::A) ? "A" : "B");
+                        gcs().send_text(MAV_SEVERITY_INFO, "%s: moving to %s", name(), (ab_dest == Destination::A) ? "A" : "B");
                     } else {
                         line_count++;
-                        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s (line %d/%d)", (ab_dest == Destination::A) ? "A" : "B", line_count, line_num);
+                        gcs().send_text(MAV_SEVERITY_INFO, "%s: moving to %s (line %d/%d)", name(), (ab_dest == Destination::A) ? "A" : "B", line_count, line_num);
                     }
                 }
             }
@@ -228,7 +228,7 @@ void ModeZigZag::move_to_side()
                 current_terr_alt = terr_alt;
                 reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
+                gcs().send_text(MAV_SEVERITY_INFO, "%s: moving to %s", name(), dir[(uint8_t)zigzag_direction]);
             }
         }
     }
@@ -251,7 +251,7 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
             loiter_nav->init_target();
         }
         is_auto = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: manual control");
+        gcs().send_text(MAV_SEVERITY_INFO, "%s: manual control", name());
     }
 }
 
@@ -548,7 +548,7 @@ void ModeZigZag::run_auto()
                 stage = AUTO;
                 reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
+                gcs().send_text(MAV_SEVERITY_INFO, "%s: moving to %s", name(), dir[(uint8_t)zigzag_direction]);
             }
         }
     } else {


### PR DESCRIPTION
I know that there is a method to get the flight mode name for each flight mode.
The flight mode name is written directly in the message.
I think it's better to use this method.