### PR TITLE
Plane: Push the TECS to climb in all circumstances

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -507,7 +507,7 @@ void Plane::update_alt()
             // ensure we do the initial climb in RTL. We add an extra
             // 10m in the demanded height to push TECS to climb
             // quickly
-            target_alt = MAX(target_alt, prev_WP_loc.alt + (g2.rtl_climb_min+10)*100);
+            target_alt = MAX(target_alt, prev_WP_loc.alt - home.alt) + (g2.rtl_climb_min+10)*100;
         }
 
         SpdHgt_Controller->update_pitch_throttle(target_alt,


### PR DESCRIPTION
I noticed today that the climb-before-turn climbing issue that I thought was fixed was actually not.

The issue is that, when climbing to RTL altitude to turn, ArduPlane willl actually level off just before reaching the target altitude, and will take a very long time to reach the final few meters, all the while flying away from you.

This PR changes the target altitude so the extra 10m of RTL_CLIMB_MIN are added to climb-before-turn as well, thus instructing the craft to climb to ALT_HOLD_RTL+10m, making it climb the last few meters faster.

In essence, this PR harmonizes the behaviour of the new climb-before-turn feature with the behaviour of RTL_CLIMB_MIN to minimize the amount of time spent flying away from the user.