### PR TITLE
AP_Notify: Remove indirection on RGBLed of init()->hw_init()

### DIFF
--- a/libraries/AP_Notify/DiscoLED.cpp
+++ b/libraries/AP_Notify/DiscoLED.cpp
@@ -47,7 +47,7 @@ DiscoLED::DiscoLED():
 {
 }
 
-bool DiscoLED::hw_init()
+bool DiscoLED::init()
 {
     /* If led sysfs api is present, use it, else use pwm sysfs api to
        drive Disco leds */

--- a/libraries/AP_Notify/DiscoLED.h
+++ b/libraries/AP_Notify/DiscoLED.h
@@ -28,9 +28,9 @@ class DiscoLED: public RGBLed
 {
 public:
     DiscoLED();
+    bool init(void) override;
 
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:

--- a/libraries/AP_Notify/DiscreteRGBLed.cpp
+++ b/libraries/AP_Notify/DiscreteRGBLed.cpp
@@ -27,7 +27,7 @@ DiscreteRGBLed::DiscreteRGBLed(uint16_t red, uint16_t green, uint16_t blue, bool
 
 }
 
-bool DiscreteRGBLed::hw_init(void)
+bool DiscreteRGBLed::init(void)
 {
     red_pin = hal.gpio->channel(red_pin_number);
     green_pin = hal.gpio->channel(green_pin_number);

--- a/libraries/AP_Notify/DiscreteRGBLed.h
+++ b/libraries/AP_Notify/DiscreteRGBLed.h
@@ -23,9 +23,9 @@
 class DiscreteRGBLed: public RGBLed {
 public:
     DiscreteRGBLed(uint16_t red, uint16_t green, uint16_t blue, bool polarity);
+    bool init(void) override;
 
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) override;
 
 private:

--- a/libraries/AP_Notify/Led_Sysfs.cpp
+++ b/libraries/AP_Notify/Led_Sysfs.cpp
@@ -30,7 +30,7 @@ Led_Sysfs::Led_Sysfs(const char *red, const char *green, const char *blue,
 {
 }
 
-bool Led_Sysfs::hw_init()
+bool Led_Sysfs::init()
 {
     if (red_led.init() && green_led.init() && blue_led.init()) {
         return true;

--- a/libraries/AP_Notify/Led_Sysfs.h
+++ b/libraries/AP_Notify/Led_Sysfs.h
@@ -29,9 +29,9 @@ public:
     Led_Sysfs(const char *red, const char *green, const char *blue,
               uint8_t off_brightness = 0xff , uint8_t low_brightness = 0x00,
               uint8_t medium_brightness = 0x00, uint8_t high_brightness = 0x00);
+    bool init(void) override;
 
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:

--- a/libraries/AP_Notify/NCP5623.cpp
+++ b/libraries/AP_Notify/NCP5623.cpp
@@ -61,7 +61,7 @@ bool NCP5623::write_pwm(uint8_t _rgb[3])
     return true;
 }
 
-bool NCP5623::hw_init(void)
+bool NCP5623::init(void)
 {
     uint8_t addrs[] = { NCP5623_LED_I2C_ADDR, NCP5623_C_LED_I2C_ADDR };
     for (uint8_t i=0; i<ARRAY_SIZE(addrs); i++) {

--- a/libraries/AP_Notify/NCP5623.h
+++ b/libraries/AP_Notify/NCP5623.h
@@ -23,8 +23,8 @@
 class NCP5623 : public RGBLed {
 public:
     NCP5623(uint8_t bus);
+    bool init(void) override;
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 private:
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;

--- a/libraries/AP_Notify/PCA9685LED_I2C.cpp
+++ b/libraries/AP_Notify/PCA9685LED_I2C.cpp
@@ -37,7 +37,7 @@ PCA9685LED_I2C::PCA9685LED_I2C() :
 {
 }
 
-bool PCA9685LED_I2C::hw_init()
+bool PCA9685LED_I2C::init()
 {
     _dev = hal.i2c_mgr->get_device(1, PCA9685_ADDRESS);
 

--- a/libraries/AP_Notify/PCA9685LED_I2C.h
+++ b/libraries/AP_Notify/PCA9685LED_I2C.h
@@ -23,8 +23,8 @@ class PCA9685LED_I2C : public RGBLed
 {
 public:
     PCA9685LED_I2C(void);
+    bool init(void) override;
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:

--- a/libraries/AP_Notify/PixRacerLED.cpp
+++ b/libraries/AP_Notify/PixRacerLED.cpp
@@ -34,7 +34,7 @@ PixRacerLED::PixRacerLED() :
 {
 }
 
-bool PixRacerLED::hw_init(void)
+bool PixRacerLED::init(void)
 {
     // when HAL_GPIO_LED_ON is 0 then we must not use pinMode()
     // as it could remove the OPENDRAIN attribute on the pin
@@ -58,6 +58,6 @@ bool PixRacerLED::hw_set_rgb(uint8_t r, uint8_t g, uint8_t b)
 }
 
 #else
-bool PixRacerLED::hw_init(void) { return true; }
+bool PixRacerLED::init(void) { return true; }
 bool PixRacerLED::hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) { return true; }
 #endif

--- a/libraries/AP_Notify/PixRacerLED.h
+++ b/libraries/AP_Notify/PixRacerLED.h
@@ -23,8 +23,8 @@ class PixRacerLED: public RGBLed
 {
 public:
     PixRacerLED();
+    bool init(void) override;
 
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 };

--- a/libraries/AP_Notify/RCOutputRGBLed.cpp
+++ b/libraries/AP_Notify/RCOutputRGBLed.cpp
@@ -44,7 +44,7 @@ RCOutputRGBLed::RCOutputRGBLed(uint8_t red_channel, uint8_t green_channel,
 {
 }
 
-bool RCOutputRGBLed::hw_init()
+bool RCOutputRGBLed::init()
 {
     hal.rcout->enable_ch(_red_channel);
     hal.rcout->enable_ch(_green_channel);

--- a/libraries/AP_Notify/RCOutputRGBLed.h
+++ b/libraries/AP_Notify/RCOutputRGBLed.h
@@ -9,9 +9,9 @@ public:
                    uint8_t led_medium, uint8_t led_dim);
     RCOutputRGBLed(uint8_t red_channel, uint8_t green_channel,
                    uint8_t blue_channel);
+    bool init() override;
 
 protected:
-    bool hw_init() override;
     virtual bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) override;
     virtual uint16_t get_duty_cycle_for_color(const uint8_t color, const uint16_t usec_period) const;
 

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -32,11 +32,6 @@ RGBLed::RGBLed(uint8_t led_off, uint8_t led_bright, uint8_t led_medium, uint8_t 
 
 }
 
-bool RGBLed::init()
-{
-    return hw_init();
-}
-
 // set_rgb - set color as a combination of red, green and blue values
 void RGBLed::_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
 {

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -26,9 +26,6 @@ class RGBLed: public NotifyDevice {
 public:
     RGBLed(uint8_t led_off, uint8_t led_bright, uint8_t led_medium, uint8_t led_dim);
 
-    // init - initialised the LED
-    virtual bool init(void) override;
-
     // set_rgb - set color as a combination of red, green and blue levels from 0 ~ 15
     virtual void set_rgb(uint8_t red, uint8_t green, uint8_t blue);
 
@@ -45,7 +42,6 @@ public:
 
 protected:
     // methods implemented in hardware specific classes
-    virtual bool hw_init(void) = 0;
     virtual bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) = 0;
 
     // set_rgb - set color as a combination of red, green and blue levels from 0 ~ 15

--- a/libraries/AP_Notify/SITL_SFML_LED.cpp
+++ b/libraries/AP_Notify/SITL_SFML_LED.cpp
@@ -208,7 +208,7 @@ void *SITL_SFML_LED::update_thread_start(void *obj)
     return nullptr;
 }
 
-bool SITL_SFML_LED::hw_init()
+bool SITL_SFML_LED::init()
 {
     pthread_create(&thread, NULL, update_thread_start, this);
 

--- a/libraries/AP_Notify/SITL_SFML_LED.h
+++ b/libraries/AP_Notify/SITL_SFML_LED.h
@@ -33,9 +33,9 @@ class SITL_SFML_LED: public RGBLed
 {
 public:
     SITL_SFML_LED();
+    bool init(void) override;
 
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:

--- a/libraries/AP_Notify/ScriptingLED.h
+++ b/libraries/AP_Notify/ScriptingLED.h
@@ -34,9 +34,10 @@ public:
 
     void get_rgb(uint8_t& red, uint8_t& green, uint8_t& blue);
 
+    bool init() override  {return true;};
+
 protected:
 
-    bool hw_init() override  {return true;};
     bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) override {return true;}
 
 private:

--- a/libraries/AP_Notify/SerialLED.cpp
+++ b/libraries/AP_Notify/SerialLED.cpp
@@ -23,7 +23,7 @@ SerialLED::SerialLED(uint8_t led_off, uint8_t led_bright, uint8_t led_medium, ui
 {
 }
 
-bool SerialLED::hw_init()
+bool SerialLED::init()
 {
     enable_mask = init_ports();
     return true;

--- a/libraries/AP_Notify/SerialLED.h
+++ b/libraries/AP_Notify/SerialLED.h
@@ -28,11 +28,11 @@ public:
         uint8_t g;
     } RGB;
 
+    bool init(void) override;
+
     virtual uint16_t init_ports() { return 0; };
 
 protected:
-
-    bool hw_init(void) override;
 
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 

--- a/libraries/AP_Notify/ToshibaLED_I2C.cpp
+++ b/libraries/AP_Notify/ToshibaLED_I2C.cpp
@@ -44,7 +44,7 @@ ToshibaLED_I2C::ToshibaLED_I2C(uint8_t bus)
 {
 }
 
-bool ToshibaLED_I2C::hw_init(void)
+bool ToshibaLED_I2C::init(void)
 {
     // first look for led on external bus
     _dev = std::move(hal.i2c_mgr->get_device(_bus, TOSHIBA_LED_I2C_ADDR));

--- a/libraries/AP_Notify/ToshibaLED_I2C.h
+++ b/libraries/AP_Notify/ToshibaLED_I2C.h
@@ -23,8 +23,8 @@ class ToshibaLED_I2C : public RGBLed
 {
 public:
     ToshibaLED_I2C(uint8_t bus);
+    bool init(void) override;
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:

--- a/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
+++ b/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
@@ -43,7 +43,7 @@ UAVCAN_RGB_LED::UAVCAN_RGB_LED(uint8_t led_index, uint8_t led_off,
 {
 }
 
-bool UAVCAN_RGB_LED::hw_init()
+bool UAVCAN_RGB_LED::init()
 {
     return true;
 }

--- a/libraries/AP_Notify/UAVCAN_RGB_LED.h
+++ b/libraries/AP_Notify/UAVCAN_RGB_LED.h
@@ -7,9 +7,9 @@ public:
     UAVCAN_RGB_LED(uint8_t led_index, uint8_t led_off, uint8_t led_full,
                    uint8_t led_medium, uint8_t led_dim);
     UAVCAN_RGB_LED(uint8_t led_index);
+    bool init() override;
 
 protected:
-    bool hw_init() override;
     virtual bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) override;
 
 private:

--- a/libraries/AP_Notify/VRBoard_LED.cpp
+++ b/libraries/AP_Notify/VRBoard_LED.cpp
@@ -35,7 +35,7 @@ VRBoard_LED::VRBoard_LED():
 {
 
 }
-bool VRBoard_LED::hw_init(void){
+bool VRBoard_LED::init(void){
     // setup the main LEDs as outputs
     hal.gpio->pinMode(HAL_GPIO_A_LED_PIN, HAL_GPIO_OUTPUT);
     hal.gpio->pinMode(HAL_GPIO_B_LED_PIN, HAL_GPIO_OUTPUT);

--- a/libraries/AP_Notify/VRBoard_LED.h
+++ b/libraries/AP_Notify/VRBoard_LED.h
@@ -26,8 +26,8 @@
 class VRBoard_LED: public RGBLed {
 public:
 	VRBoard_LED();
+  bool init(void) override;
 
 protected:
-    bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 };


### PR DESCRIPTION
Saves a bit of flash, and just makes the code a bit more obvious.