### PR TITLE
Copter: Prearm check MOT_THST_HOVER isn't set too high mistakenly

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -748,6 +748,12 @@ bool AP_Arming_Copter::mandatory_checks(bool display_failure)
         result = false;
     }
 
+    // check MOT_THST_HOVER is sensible
+    if (copter.motors->get_throttle_hover() > 1.0f) {
+        check_failed(display_failure, "MOT_THST_HOVER is too high");
+        result = false;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
User can set mistakenly MOT_THST_HOVER to a dangerously high value, example 35 instead of 0.35
So then after switching to altitude-controlled flight mode vehicle will go into the sky.  