### PR TITLE
Plane: allow reverse thrust in non auto-throttle modes if USE_REVERSE_THRUST=0

### DIFF
--- a/ArduPlane/reverse_thrust.cpp
+++ b/ArduPlane/reverse_thrust.cpp
@@ -25,7 +25,7 @@ bool Plane::allow_reverse_thrust(void) const
     // check if we should allow reverse thrust
     bool allow = false;
 
-    if (g.use_reverse_thrust == USE_REVERSE_THRUST_NEVER || !have_reverse_thrust()) {
+    if (!have_reverse_thrust()) {
         return false;
     }
 


### PR DESCRIPTION
Right now it is not possible to use reverse thrust with MANUAL/FBWA if USE_REVERSE_THRUST is set to 0