### PR TITLE
Plane: fix bug in reverse thrust

### DIFF
--- a/ArduPlane/reverse_thrust.cpp
+++ b/ArduPlane/reverse_thrust.cpp
@@ -25,7 +25,7 @@ bool Plane::allow_reverse_thrust(void) const
     // check if we should allow reverse thrust
     bool allow = false;
 
-    if (g.use_reverse_thrust == USE_REVERSE_THRUST_NEVER || !have_reverse_thrust()) {
+    if ((g.use_reverse_thrust == USE_REVERSE_THRUST_NEVER && plane.control_mode->does_auto_throttle()) || !have_reverse_thrust()) {
         return false;
     }
 


### PR DESCRIPTION
currently non auto throttle modes do not allow reverse thrust unless the auto throttle bitmask param is set....otherwise you must setup an autothrottle mode to also allow use in non autothrottle modes (except manual)