### PR TITLE
Tradheli: fix guided mode takeoff

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -390,11 +390,7 @@ void Copter::update_auto_armed()
         if(flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio) {
             set_auto_armed(false);
         }
-        // if helicopters are on the ground, and the motor is switched off, auto-armed should be false
-        // so that rotor runup is checked again before attempting to take-off
-        if(ap.land_complete && motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED && ap.using_interlock) {
-            set_auto_armed(false);
-        }
+
     }else{
         // arm checks
         

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -36,7 +36,7 @@ bool Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
     }
 
     // Helicopters should return false if MAVlink takeoff command is received while the rotor is not spinning
-    if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED && copter.ap.using_interlock) {
+    if (!motors->get_interlock() && copter.ap.using_interlock) {
         return false;
     }
 


### PR DESCRIPTION
This PR includes just the first commit from PR https://github.com/ArduPilot/ardupilot/pull/15826 and resolves the most critical issue which is that tradheli's cannot takeoff in Guided mode.

This has been tested in SITL by doing the following:

- started tradheli in SITL (Tools/autotest/sim_vehicle.py -f heli --map --console)
- param set DISARM_DELAY 0 (to stop the vehicle from disarming automatically)
- graph SERVO_OUTPUT_RAW.servo8_raw (to how the main rotor output)
- GUIDED (to switch the vehicle to guided mode)
- rc 8 1000 (to disable interlock)
- arm throttle
- rc 8 2000 (to allow the motors to spin-up)
- takeoff 10 (to command a takeoff to 10m)

In master the final takeoff command listed above fails. With this PR applied the vehicle can takeoff.