### PR TITLE
AC_Avoidance: set Dijkstra origin_new altitude and simplify

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -140,18 +140,14 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         Vector2f origin_pos;
         if ((_path_idx_returned > 0) && get_shortest_path_point(_path_idx_returned-1, origin_pos)) {
             // convert offset from ekf origin to Location
-            Location temp_loc(Vector3f(origin_pos.x, origin_pos.y, 0.0f), Location::AltFrame::ABOVE_ORIGIN);
-            origin_new = temp_loc;
+            origin_new = Location(Vector3f(origin_pos.x, origin_pos.y, current_loc.alt), current_loc.get_alt_frame());
         } else {
             // for first point use current loc as origin
             origin_new = current_loc;
         }
 
         // convert offset from ekf origin to Location
-        Location temp_loc(Vector3f(dest_pos.x, dest_pos.y, 0.0f), Location::AltFrame::ABOVE_ORIGIN);
-        destination_new = destination;
-        destination_new.lat = temp_loc.lat;
-        destination_new.lng = temp_loc.lng;
+        destination_new = Location(Vector3f(dest_pos.x, dest_pos.y, destination.alt), destination.get_alt_frame());
 
         // check if we should advance to next point for next iteration
         const bool near_oa_wp = current_loc.get_distance(destination_new) <= 2.0f;

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -80,8 +80,8 @@ bool AC_WPNav_OA::update_wpnav()
         }
 
         // convert origin and destination to Locations and pass into oa
-        const Location origin_loc(_origin_oabak, _terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
-        const Location destination_loc(_destination_oabak, _terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+        const Location origin_loc(_origin_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+        const Location destination_loc(_destination_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         Location oa_origin_new, oa_destination_new;
         const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc, origin_loc, destination_loc, oa_origin_new, oa_destination_new);
         switch (oa_retstate) {


### PR DESCRIPTION
While fixing and retesting a small error in a previous PR of mine here #17058, I found a continual climb between waypoints when using terrain following, bendy-vertical, and dijkstras together. This climb occurs until the next waypoint and the altitude then comes back to the desired terrain following altitude before moving to the next waypoint. 

From what I could find with the combo of bendy-vert + djikstras there was a spot where the `origin_new.alt` was not being set like it was for `destination_new`.  

I still think there might be an issue here for further investigation with this combination and the altitudes in the transition between bendy and dijkstras. In the graph below with my fix to Dijkstra's the spot where the vehicle climbs above the desired 50m terrain altitude is along the fence. This seems like reasonable behavior?

I will try to put together an autotest to hit all of the combos of OA and terrain following for a later PR. 

**Climb between waypoints without setting origin_new.alt**
![no_dijkstra_origin_new_set](https://user-images.githubusercontent.com/69225461/112945081-ccafcc00-9101-11eb-87be-44183576ec2a.png)

**Climb limited to along the fence waypoints with setting origin_new.alt**
![djikstra_origin_alt_set](https://user-images.githubusercontent.com/69225461/112945463-53fd3f80-9102-11eb-914c-bde4b4a8768b.png)

**Mission profile used for SITL testing**
![test_scenario](https://user-images.githubusercontent.com/69225461/112945451-4e9ff500-9102-11eb-8e9a-a4d79c64693d.PNG)

