### PR TITLE
AP_Arming: pre-arm check if compass1 is disabled but 2 or 3 are enabled

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -414,6 +414,12 @@ bool AP_Arming::compass_checks(bool report)
     if ((checks_to_perform) & ARMING_CHECK_ALL ||
         (checks_to_perform) & ARMING_CHECK_COMPASS) {
 
+        // check for first compass being disabled but 2nd or 3rd being enabled
+        if (!_compass.use_for_yaw(0) && (_compass.get_num_enabled() > 0)) {
+            check_failed(ARMING_CHECK_COMPASS, report, "Compass1 disabled but others enabled");
+            return false;
+        }
+
         // avoid Compass::use_for_yaw(void) as it implicitly calls healthy() which can
         // incorrectly skip the remaining checks, pass the primary instance directly
         if (!_compass.use_for_yaw(0)) {

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1725,12 +1725,6 @@ uint8_t Compass::get_num_enabled(void) const
 }
 
 void
-Compass::set_use_for_yaw(uint8_t i, bool use)
-{
-    _use_for_yaw[Priority(i)].set(use);
-}
-
-void
 Compass::set_declination(float radians, bool save_to_eeprom)
 {
     if (save_to_eeprom) {

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -212,8 +212,6 @@ public:
     bool use_for_yaw(uint8_t i) const;
     bool use_for_yaw(void) const;
 
-    void set_use_for_yaw(uint8_t i, bool use);
-
     /// Sets the local magnetic field declination.
     ///
     /// @param  radians             Local field declination.


### PR DESCRIPTION
This PR adds a pre-arm check to reduce the chance of users accidentally disabling all compasses when they only intended to disable the first one.  See issue https://github.com/ArduPilot/ardupilot/issues/16509.

The issue can happen (and has happened) because users assume that they can disable the first compass but keep on using the 2nd or 3rd compass if they set params like this:

- COMPASS_USE = 0
- COMPASS_USE2 = 1
- COMPASS_USE3 = 1

Since the compass prioritisation changes however this results in the EKF not using any compasses which is unexpected and potentially dangerous.

The potential downside of this change is that users who wish to disable use of the compass completely will need to set 3 parameters instead of just one.

This has been lightly tested in SITL and seems to do what we need.

This is on the Copter-4.1 blockers list. https://github.com/ArduPilot/ardupilot/issues/16478

P.S. this PR also includes a drive-by change to remove the unused "Compass::set_use_for_yaw()" method.
