### PR TITLE
AP_RangeFinder: TeraRangerI2C redefining the output distance logic with OutOfRange cases

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -136,8 +136,8 @@ bool AP_RangeFinder_TeraRangerI2C::process_raw_measure(uint16_t raw_distance, ui
 {
     // Check for error codes
     if (raw_distance == 0xFFFF) {
-        // Too far away is unreliable so we dont enforce max range here
-        return false;
+        // Too far away
+        output_distance_cm = max_distance_cm() + TR_OUT_OF_RANGE_ADD_CM;
     } else if (raw_distance == 0x0000) {
         // Too close
         output_distance_cm = 0;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -28,6 +28,8 @@ extern const AP_HAL::HAL& hal;
 #define TR_WHOAMI  0x01
 #define TR_WHOAMI_VALUE 0xA1
 
+#define TR_OUT_OF_RANGE_ADD_CM 100 //cm
+
 AP_RangeFinder_TeraRangerI2C::AP_RangeFinder_TeraRangerI2C(RangeFinder::RangeFinder_State &_state,
                                                            AP_RangeFinder_Params &_params,
                                                            AP_HAL::OwnPtr<AP_HAL::I2CDevice> i2c_dev)
@@ -132,20 +134,21 @@ bool AP_RangeFinder_TeraRangerI2C::collect_raw(uint16_t &raw_distance)
 // Checks for error code and if correct converts to cm
 bool AP_RangeFinder_TeraRangerI2C::process_raw_measure(uint16_t raw_distance, uint16_t &output_distance_cm)
 {
-  // Check for error codes
-  if (raw_distance == 0xFFFF) {
-      // Too far away is unreliable so we dont enforce max range here
-      return false;
-  } else if (raw_distance == 0x0000) {
-      // Too close
-      return false;
-  } else if (raw_distance == 0x0001) {
-      // Unable to measure
-      return false;
-  } else {
-    output_distance_cm = raw_distance/10; // Conversion to centimeters
+    // Check for error codes
+    if (raw_distance == 0xFFFF) {
+        // Too far away is unreliable so we dont enforce max range here
+        return false;
+    } else if (raw_distance == 0x0000) {
+        // Too close
+        output_distance_cm = 0;
+    } else if (raw_distance == 0x0001) {
+        // Unable to measure
+        // This can also include the sensor pointing to the horizon when used as a proximity sensor
+        output_distance_cm = max_distance_cm() + TR_OUT_OF_RANGE_ADD_CM;
+    } else {
+        output_distance_cm = raw_distance/10; // Conversion to centimeters
+    }
     return true;
-  }
 }
 
 /*


### PR DESCRIPTION
This PR is intended to correct the output distances and status that the TeraRanger sensor should return when used under the I2C protocol. 

It is related to this previous PR: https://github.com/ArduPilot/ardupilot/pull/13376

To add to what @rmackay9 said in the above issue, the way this is currently implemented triggers the sensor as being "unhealthy" whenever the sensor is unable to measure. And this, whether it is "too close" OR "too far" OR "not seeing anything". 

The main reason for this PR is that the TeraRangerI2C driver cannot be used as a simple proximity sensor, and it is expected to use the auxiliary module TeraRangerTower Hub (UART) when one wants to use a single rangefinder as a proximity sensor. Because the sensor is considered "unhealthy", the proximity library blocks (actually, it's more the rangefinder library here) the sensor from being read. Since being out of range is actually quite common when a rangefinder is used as a proximity sensor, the rangefinder constantly triggers the proximity failsafe... (The vehicle even refuses to arm when there is no obstacle seen by the sensor)

- For the 0x0000 error code: I followed what rmackay9 suggested in the previous PR by setting the distance to 0cm. This sets the sensor status to OutOfRange_Low. (I understand that it is a regression to what was decided for the above mentioned PR, so I apologize if it is unwanted);
- Concerning the error code 0x0001: It is unreliable because "being unable to measure" can also imply that the sensor does not see anything. This problem occurs very often when the TeraRangerI2C looks at the horizon or the sky when used as a proximity sensor. For this reason, I think this error code should include the OutOfRange_High case so that the rangefinder remains active when looking at the sky. I based the output distance logic the same way it is implemented for the Benewake driver, by adding an arbitrary value to max_distance() (cf. https://github.com/ArduPilot/ardupilot/pull/9727);
- Finally, regarding the error code 0xFFFF. I didn't touch this case, but I think defining the OutOfRange_High should be appropriate here. However, I am unsure why it is considered to be unreliable in the first place, as I couldn't get the sensor to return this error code. Only the error code 0x0001 was triggered when the obstacle was too far. I would really appreciate an external opinion on this, so I could add the OutOfRange_High case if it is deemed appropriate. (My guess is that it was probably meant for the older version "TeraRanger One").

I consider that for the function "process_raw_measure()", each error code should output a value. Whether the sensor is "healthy" or not should be checked in the above function "collect_raw()" but not when processing the value itself. I originally only wanted to modify the 0x0001 error code, but having found the previous mentioned PR, I decided to modify the whole function, which is probably contraindicated..