### PR TITLE
AP_Notify: UAVCAN_RGB_LED: don't init if no UAVCAN backends

### DIFF
--- a/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
+++ b/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
@@ -45,7 +45,15 @@ UAVCAN_RGB_LED::UAVCAN_RGB_LED(uint8_t led_index, uint8_t led_off,
 
 bool UAVCAN_RGB_LED::init()
 {
-    return true;
+    const uint8_t can_num_drivers = AP::can().get_num_drivers();
+    for (uint8_t i = 0; i < can_num_drivers; i++) {
+        AP_UAVCAN *uavcan = AP_UAVCAN::get_uavcan(i);
+        if (uavcan != nullptr) {
+            return true;
+        }
+    }
+    // no UAVCAN drivers
+    return false;
 }
 
 


### PR DESCRIPTION
This allows us to consider enabling UAVCAN_RGB_LED as a more general
default, as it won't consume one of our limited backend slots if UAVCAN
is not enabled.

This helps allow us to consider #8848, as well as generally saving some CPU time/RAM/notify backend slots if you aren't using CAN, but have the LED type enabled.

Tested with a CubeOrange and a Here2, with some extra debug prints to show how many backends were instantiated.