### PR TITLE
autotest: ensure RC thread is killed after each run_test

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -704,6 +704,15 @@ def run_tests(steps):
             results.add(step,
                         '<span class="failed-text">FAILED</span>',
                         time.time() - t1)
+
+        global tester
+        if tester is not None and tester.rc_thread is not None:
+            if passed:
+                print("BAD: RC Thread still alive after run_step")
+            tester.rc_thread_should_quit = True
+            tester.rc_thread.join()
+            tester.rc_thread = None
+
     if not passed:
         keys = failed_testinstances.keys()
         if len(keys):
@@ -716,14 +725,6 @@ def run_tests(steps):
                     print("    %s (%s) (see %s)" % (desc, exception, debug_filename))
 
         print("FAILED %u tests: %s" % (len(failed), failed))
-
-    global tester
-    if tester is not None and tester.rc_thread is not None:
-        if passed:
-            print("BAD: RC Thread still alive after tests passed")
-        tester.rc_thread_should_quit = True
-        tester.rc_thread.join()
-        tester.rc_thread = None
 
     util.pexpect_close_all()
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1274,7 +1274,7 @@ class AutoTest(ABC):
 
     def __del__(self):
         if self.rc_thread is not None:
-            self.progress("Joining thread in __del__")
+            self.progress("Joining RC thread in __del__")
             self.rc_thread_should_quit = True
             self.rc_thread.join()
             self.rc_thread = None
@@ -3474,6 +3474,7 @@ class AutoTest(ABC):
                 continue
             bad_channels = ""
             for chan in map_copy:
+                self.progress("RC values good")
                 chan_pwm = getattr(m, "chan" + str(chan) + "_raw")
                 if chan_pwm != map_copy[chan]:
                     bad_channels += " (ch=%u want=%u got=%u)" % (chan, map_copy[chan], chan_pwm)
@@ -8616,7 +8617,7 @@ switch value'''
                     self.check_logs("FRAMEWORK")
 
         if self.rc_thread is not None:
-            self.progress("Joining thread")
+            self.progress("Joining RC thread")
             self.rc_thread_should_quit = True
             self.rc_thread.join()
             self.rc_thread = None


### PR DESCRIPTION
Every run_test starts a thread.  del is not being called.  So clean it
up in the caller