### PR TITLE
Plane: maximum altitude for FBWB

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -681,6 +681,13 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     GSCALAR(FBWB_min_altitude_cm,   "ALT_HOLD_FBWCM", ALT_HOLD_FBW_CM),
 
+    // @Param: ALT_FBWCM_MAX
+    // @DisplayName: Maximum altitude for FBWB and CRUISE modes
+    // @Description: This is the maximum altitude in meters that FBWB and CRUISE modes will allow. If you attempt to descend upper this altitude the plane will hold level. A value of zero means no limit.
+    // @Units: m
+    // @User: Standard
+    GSCALAR(FBWB_max_altitude_m,   "ALT_FBWCM_MAX", 0),
+
     // @Param: FLAP_1_PERCNT
     // @DisplayName: Flap 1 percentage
     // @Description: The percentage change in flap position when FLAP_1_SPEED is reached. Use zero to disable flaps

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -686,7 +686,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: This is the maximum altitude in meters that FBWB and CRUISE modes will allow. If you attempt to descend upper this altitude the plane will hold level. A value of zero means no limit.
     // @Units: m
     // @User: Standard
-    GSCALAR(FBWB_max_altitude_m,   "ALT_FBWCM_MAX", 0),
+    GSCALAR(fbwb_max_altitude_m,   "ALT_FBWCM_MAX", 0),
 
     // @Param: FLAP_1_PERCNT
     // @DisplayName: Flap 1 percentage

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -351,6 +351,7 @@ public:
         k_param_gcs5,          // stream rates
         k_param_gcs6,          // stream rates
         k_param_fence,         // vehicle fence
+        k_param_FBWB_max_altitude_m,  // 0=disabled, maximum value for altitude in meters
     };
 
     AP_Int16 format_version;
@@ -402,6 +403,8 @@ public:
     //
     AP_Int8 flybywire_elev_reverse;
     AP_Int8 flybywire_climb_rate;
+    AP_Int16 FBWB_min_altitude_cm;
+    AP_Int16 FBWB_max_altitude_m;
 
     // Throttle
     //
@@ -448,7 +451,6 @@ public:
     AP_Int32 log_bitmask;
     AP_Int32 RTL_altitude_cm;
     AP_Int16 pitch_trim_cd;
-    AP_Int16 FBWB_min_altitude_cm;
     AP_Int8  hil_servos;
 #if HIL_SUPPORT
     AP_Int8  hil_mode;

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -351,7 +351,7 @@ public:
         k_param_gcs5,          // stream rates
         k_param_gcs6,          // stream rates
         k_param_fence,         // vehicle fence
-        k_param_FBWB_max_altitude_m,  // 0=disabled, maximum value for altitude in meters
+        k_param_fbwb_max_altitude_m,  // 0=disabled, maximum value for altitude in meters
     };
 
     AP_Int16 format_version;
@@ -404,7 +404,7 @@ public:
     AP_Int8 flybywire_elev_reverse;
     AP_Int8 flybywire_climb_rate;
     AP_Int16 FBWB_min_altitude_cm;
-    AP_Int16 FBWB_max_altitude_m;
+    AP_Int16 fbwb_max_altitude_m;
 
     // Throttle
     //

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -824,7 +824,7 @@ private:
     void set_target_altitude_proportion(const Location &loc, float proportion);
     void constrain_target_altitude_location(const Location &loc1, const Location &loc2);
     int32_t calc_altitude_error_cm(void);
-    void check_fbwb_minimum_altitude(void);
+    void check_fbwb_altitude(void);
     void reset_offset_altitude(void);
     void set_offset_altitude_location(const Location &loc);
     bool above_location_current(const Location &loc);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -335,7 +335,7 @@ void Plane::constrain_target_altitude_location(const Location &loc1, const Locat
         target_altitude.amsl_cm = constrain_int32(target_altitude.amsl_cm, loc1.alt, loc2.alt);
     }
 }
-
+s
 /*
   return error between target altitude and current altitude
  */
@@ -357,7 +357,7 @@ int32_t Plane::calc_altitude_error_cm(void)
 void Plane::check_fbwb_altitude(void)//check_fbwb_minimum_altitude
 {
     //check for max
-    if (g.FBWB_max_altitude_m != 0)
+    if (g.FBWB_max_altitude_m*1000 > g.FBWB_min_altitude_cm && g.FBWB_max_altitude_m > 0)
     {
         if (target_altitude.amsl_cm > home.alt + g.FBWB_max_altitude_m*1000) {
             target_altitude.amsl_cm = home.alt + g.FBWB_max_altitude_m*1000;

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -335,7 +335,7 @@ void Plane::constrain_target_altitude_location(const Location &loc1, const Locat
         target_altitude.amsl_cm = constrain_int32(target_altitude.amsl_cm, loc1.alt, loc2.alt);
     }
 }
-s
+
 /*
   return error between target altitude and current altitude
  */
@@ -352,15 +352,15 @@ int32_t Plane::calc_altitude_error_cm(void)
 }
 
 /*
-  check for min and max altitude: FBWB_min_altitude_cm and FBWB_max_altitude_m violation
+  check for min and max altitude: FBWB_min_altitude_cm and fbwb_max_altitude_m violation
  */
 void Plane::check_fbwb_altitude(void)//check_fbwb_minimum_altitude
 {
     //check for max
-    if (g.FBWB_max_altitude_m*1000 > g.FBWB_min_altitude_cm && g.FBWB_max_altitude_m > 0)
+    if (g.fbwb_max_altitude_m*1000 > g.FBWB_min_altitude_cm && g.fbwb_max_altitude_m > 0)
     {
-        if (target_altitude.amsl_cm > home.alt + g.FBWB_max_altitude_m*1000) {
-            target_altitude.amsl_cm = home.alt + g.FBWB_max_altitude_m*1000;
+        if (target_altitude.amsl_cm > home.alt + g.fbwb_max_altitude_m*1000) {
+            target_altitude.amsl_cm = home.alt + g.fbwb_max_altitude_m*1000;
         }
     }
 

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -352,10 +352,19 @@ int32_t Plane::calc_altitude_error_cm(void)
 }
 
 /*
-  check for FBWB_min_altitude_cm violation
+  check for min and max altitude: FBWB_min_altitude_cm and FBWB_max_altitude_m violation
  */
-void Plane::check_fbwb_minimum_altitude(void)
+void Plane::check_fbwb_altitude(void)//check_fbwb_minimum_altitude
 {
+    //check for max
+    if (g.FBWB_max_altitude_m != 0)
+    {
+        if (target_altitude.amsl_cm > home.alt + g.FBWB_max_altitude_m*1000) {
+            target_altitude.amsl_cm = home.alt + g.FBWB_max_altitude_m*1000;
+        }
+    }
+
+    //check for min 
     if (g.FBWB_min_altitude_cm == 0) {
         return;
     }

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -363,7 +363,7 @@ void Plane::update_fbwb_speed_height(void)
         target_altitude.last_elevator_input = elevator_input;
     }
 
-    check_fbwb_minimum_altitude();
+    check_fbwb_altitude();
 
     altitude_error_cm = calc_altitude_error_cm();
 


### PR DESCRIPTION
To fix issue #17019: Plane: maximum altitude for FBWB and cruise mode.
Add ALT_FBWCM_MAX param for maximum altitude FBWB. Default (zero) - no limit.