### PR TITLE
Plane: Surpress speed scaling without AS sensor on auto takeoffs

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -46,6 +46,11 @@ float Plane::get_speed_scaler(void)
         // no speed estimate and not armed, use a unit scaling
         speed_scaler = 1;
     }
+    if (!plane.ahrs.airspeed_sensor_enabled()  && 
+        (plane.g2.flight_options & FlightOptions::SURPRESS_TKOFF_SCALING) &&
+        (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF)) { //scaling is surpressed during climb phase of automatic takeoffs with no airspeed sensor being used due to problems with inaccurate airspeed estimates
+        return MIN(speed_scaler, 1.0f) ;
+    }
     return speed_scaler;
 }
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1120,7 +1120,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5:Enable yaw damper in acro mode
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5: Enable yaw damper in acro mode, 6: Surpress speed scaling during auto takeoffs to be 1 or less to prevent oscillations without airpseed sensor.
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -154,6 +154,7 @@ enum FlightOptions {
     CRUISE_TRIM_AIRSPEED = (1 << 3),
     CLIMB_BEFORE_TURN = (1 << 4),
     ACRO_YAW_DAMPER = (1 << 5),
+    SURPRESS_TKOFF_SCALING = (1<<6),
 };
 
 enum CrowFlapOptions {


### PR DESCRIPTION
without AS sensor, airspeed estimates are often wildly wrong for auto mode or takeoff mode takeoffs ...scaling error can be 2X due to high wind or just landing, picking up, and re-launching without a disarm to reset the still running estimate, resulting in oscillations until ground speed and estimated airspeed catch up, especially since most users are not even aware of the SCALING_SPEED parameter (need put something in the wiki tuning section on this!) when setting up for tuning PIDs...
this will force scaling to 1 during NAV_TAKEOFF and climbing phase of MODE TAKEOFF

tested , including interrupting/resuming these modes, in SITL for MODE TAKEOFFs and AUTO takeoffs..