### PR TITLE
 Copter Scripting: add support for posvelacc command 

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -310,6 +310,21 @@ bool Copter::set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& t
     return mode_guided.set_destination_posvel(pos_neu_cm, vel_neu_cms);
 }
 
+// set target position, velocity, and acceleration (for use by scripting)
+bool Copter::set_target_posvelacc_NED(const Vector3f& target_pos, const Vector3f& target_vel, const Vector3f& target_acc)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    const Vector3f pos_neu_cm(target_pos.x * 100.0f, target_pos.y * 100.0f, -target_pos.z * 100.0f);
+    const Vector3f vel_neu_cms(target_vel.x * 100.0f, target_vel.y * 100.0f, -target_vel.z * 100.0f);
+    const Vector3f acc_neu_cmss(target_acc.x * 100.0f, target_acc.y * 100.0f, -target_acc.z * 100.0f);
+
+    return mode_guided.set_destination_posvelacc(pos_neu_cm, vel_neu_cms, acc_neu_cmss);
+}
+
 bool Copter::set_target_velocity_NED(const Vector3f& vel_ned)
 {
     // exit if vehicle is not in Guided mode or Auto-Guided mode

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -647,6 +647,7 @@ private:
     bool start_takeoff(float alt) override;
     bool set_target_location(const Location& target_loc) override;
     bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) override;
+    bool set_target_posvelacc_NED(const Vector3f& target_pos, const Vector3f& target_vel, const Vector3f& target_acc) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) override;
     void rc_loop();
@@ -794,7 +795,7 @@ private:
     void Log_Write_Heli(void);
 #endif
     void Log_Write_Precland();
-    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
+    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target, const Vector3f& acc_target);
     void Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out);
     void Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq, float angle_x, float angle_y, float angle_z, float accel_x, float accel_y, float accel_z);
     void Log_Write_Vehicle_Startup_Messages();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -427,12 +427,15 @@ struct PACKED log_GuidedTarget {
     float vel_target_x;
     float vel_target_y;
     float vel_target_z;
+    float acc_target_x;
+    float acc_target_y;
+    float acc_target_z;
 };
 
 // Write a Guided mode target
 // pos_target is lat, lon, alt OR offset from ekf origin in cm OR roll, pitch, yaw target in centi-degrees
 // vel_target is cm/s
-void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target)
+void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target, const Vector3f& acc_target)
 {
     struct log_GuidedTarget pkt = {
         LOG_PACKET_HEADER_INIT(LOG_GUIDEDTARGET_MSG),
@@ -443,7 +446,10 @@ void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_tar
         pos_target_z    : pos_target.z,
         vel_target_x    : vel_target.x,
         vel_target_y    : vel_target.y,
-        vel_target_z    : vel_target.z
+        vel_target_z    : vel_target.z,
+        acc_target_x    : acc_target.x,
+        acc_target_y    : acc_target.y,
+        acc_target_z    : acc_target.z        
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -609,9 +615,12 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: vX: Target velocity, X-Axis
 // @Field: vY: Target velocity, Y-Axis
 // @Field: vZ: Target velocity, Z-Axis
+// @Field: aX: Target acceleration, X-Axis
+// @Field: aY: Target acceleration, Y-Axis
+// @Field: aZ: Target acceleration, Z-Axis
 
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
-      "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-BBBBBB" },
+      "GUID",  "QBfffffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ,aX,aY,aZ", "s-mmmnnnooo", "F-BBBBBBBBB" },
 };
 
 void Copter::Log_Write_Vehicle_Startup_Messages()
@@ -642,7 +651,7 @@ void Copter::Log_Write_Data(LogDataID id, float value) {}
 void Copter::Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, float tune_min, float tune_max) {}
 void Copter::Log_Sensor_Health() {}
 void Copter::Log_Write_Precland() {}
-void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}
+void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target, const Vector3f& acc_target) {}
 void Copter::Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out) {}
 void Copter::Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq, float angle_x, float angle_y, float angle_z, float accel_x, float accel_y, float accel_z) {}
 void Copter::Log_Write_Vehicle_Startup_Messages() {}

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -105,6 +105,7 @@ enum GuidedMode {
     Guided_Velocity,
     Guided_PosVel,
     Guided_Angle,
+    Guided_PosVelAcc,
 };
 
 // Airmode

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -826,6 +826,7 @@ public:
     bool get_wp(Location &loc) override;
     void set_velocity(const Vector3f& velocity, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false, bool log_request = true);
     bool set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
+    bool set_destination_posvelacc(const Vector3f& destination, const Vector3f& velocity, const Vector3f& acceleration, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
 
     void limit_clear();
     void limit_init_time_and_pos();
@@ -862,10 +863,12 @@ private:
     void pos_control_start();
     void vel_control_start();
     void posvel_control_start();
+    void posvelacc_control_start();
     void takeoff_run();
     void pos_control_run();
     void vel_control_run();
     void posvel_control_run();
+    void posvelacc_control_run();
     void set_desired_velocity_with_accel_and_fence_limits(const Vector3f& vel_des);
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
     bool use_pilot_yaw(void) const;

--- a/libraries/AP_Scripting/examples/set_target_posvelacc_circle.lua
+++ b/libraries/AP_Scripting/examples/set_target_posvelacc_circle.lua
@@ -1,0 +1,96 @@
+-- Commands copter to fly circle trajectory using posvelacc method in guided mode. 
+-- The trajectory start from the current location
+-- 
+-- CAUTION: This script only works for Copter.
+-- This script start when the in GUIDED mode and above 5 meter.
+--      1) arm and takeoff to above 5 m 
+--      2) switch to GUIDED mode 
+--      3) the vehilce will follow a circle in clockwise direction with increasing speed until ramp_up_time_s time has passed.
+--      4) switch out of and into the GUIDED mode any time to restart the trajectory from the start.
+
+-- Edit these variables
+local rad_xy_m = 6.0   -- circle radius in xy plane in m
+local target_speed_xy_mps = 6.0     -- maximum target speed in m/s
+local ramp_up_time_s = 10.0     -- time to reach target_speed_xy_mps in second
+local sampling_time_s = 0.05    -- sampling time of script
+
+-- Fixed variables
+local omega_radps = target_speed_xy_mps/rad_xy_m
+local copter_guided_mode_num = 4
+local theta = 0.0
+local time = 0.0
+local test_start_location = Vector3f(0.0, 0.0, 0.0)
+
+gcs:send_text(0,"PosVelAcc script started")
+gcs:send_text(0,"Trajectory period: " .. tostring(2 * math.rad(180) / omega_radps))
+
+function circle()
+    local cur_freq = 0
+    -- increase target speed lineary with time until ramp_up_time_s is reached
+    if time <= ramp_up_time_s then 
+        cur_freq = omega_radps*(time/ramp_up_time_s)^2
+    else 
+        cur_freq = omega_radps
+    end
+
+    -- calculate circle reference position and velocity
+    theta = theta + cur_freq*sampling_time_s
+
+    local th_s = math.sin(theta)
+    local th_c = math.cos(theta) 
+
+    local pos = Vector3f()
+    pos:x(rad_xy_m*th_s)
+    pos:y(-rad_xy_m*(th_c-1))
+    pos:z(0)
+
+    local vel = Vector3f()
+    vel:x(cur_freq*rad_xy_m*th_c)
+    vel:y(cur_freq*rad_xy_m*th_s)
+    vel:z(0)
+
+    local acc = Vector3f()
+    acc:x(-cur_freq^2*rad_xy_m*th_s)
+    acc:y(cur_freq^2*rad_xy_m*th_c)
+    acc:z(0)
+
+    return pos, vel, acc
+end
+
+function update()
+    if arming:is_armed() and vehicle:get_mode() == copter_guided_mode_num and -test_start_location:z()>=5 then
+
+        -- calculate current position and velocity for circle trajectory
+        local target_pos = Vector3f()
+        local target_vel = Vector3f()
+        local target_acc = Vector3f()
+        target_pos, target_vel, target_acc = circle()
+
+        -- advance the time
+        time = time + sampling_time_s
+
+        -- send posvelacc request
+        if not vehicle:set_target_posvelacc_NED(target_pos+test_start_location, target_vel, target_acc) then
+            gcs:send_text(0, "Failed to send target posvelacc at " .. tostring(time) .. " seconds")
+        end
+    else
+        -- calculate test starting location in NED
+        local cur_loc = ahrs:get_position()
+        if cur_loc then
+             test_start_location = cur_loc.get_vector_from_origin_NEU(cur_loc)
+             if test_start_location then
+                test_start_location:x(test_start_location:x() * 0.01)
+                test_start_location:y(test_start_location:y() * 0.01)
+                test_start_location:z(-test_start_location:z() * 0.01)
+             end
+        end
+
+        -- reset some variable as soon as we are not in guided mode
+        time = 0
+        theta = 0
+    end
+
+    return update, sampling_time_s * 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -189,6 +189,7 @@ singleton AP_Vehicle method get_time_flying_ms uint32_t
 singleton AP_Vehicle method start_takeoff boolean float (-LOCATION_ALT_MAX_M*100+1) (LOCATION_ALT_MAX_M*100-1)
 singleton AP_Vehicle method set_target_location boolean Location
 singleton AP_Vehicle method set_target_posvel_NED boolean Vector3f Vector3f
+singleton AP_Vehicle method set_target_posvelacc_NED boolean Vector3f Vector3f Vector3f
 singleton AP_Vehicle method get_control_output boolean AP_Vehicle::ControlOutput'enum AP_Vehicle::ControlOutput::Roll ((uint32_t)AP_Vehicle::ControlOutput::Last_ControlOutput-1) float'Null
 singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -184,6 +184,7 @@ public:
     virtual bool start_takeoff(float alt) { return false; }
     virtual bool set_target_location(const Location& target_loc) { return false; }
     virtual bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) { return false; }
+    virtual bool set_target_posvelacc_NED(const Vector3f& target_pos, const Vector3f& target_vel, const Vector3f& target_acc) { return false; }
     virtual bool set_target_velocity_NED(const Vector3f& vel_ned) { return false; }
     virtual bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) { return false; }
 


### PR DESCRIPTION
This pr is the continuation of the pr #16955 and #17010. This pr adds support for target position+velocity+acceleration command. Currently, this functionality is not supported through mavlink. SITL test and real flight results are given below. 
The test procedure for the example lua script is the same as the previous pr. 

SITL results for circle with 6 meters radius and 6 m/s speed were flown. The comparison between posvel and posvelacc commands are also given.
POSVEL
![Screenshot from 2021-03-31 23-12-05](https://user-images.githubusercontent.com/11930560/113205161-a5c6d680-9276-11eb-9ca3-bcfb499cd4db.png)

POSVELACC
![Screenshot from 2021-03-31 23-10-44](https://user-images.githubusercontent.com/11930560/113204994-6b5d3980-9276-11eb-9c5a-48ae55ee244b.png)

In SITL the square root of XY axis tracking error dropped from 5.5 meters to 3 meters. 

Real flight tests were conducted with the 250 mm racer frame. The circle radius is 6 meters and the speed is 6 m/s.
POSVEL
![Screenshot from 2021-03-31 23-26-04](https://user-images.githubusercontent.com/11930560/113206846-a06a8b80-9278-11eb-97b8-945d1a767a5f.png)

POSVELACC
![Screenshot from 2021-03-31 23-31-16](https://user-images.githubusercontent.com/11930560/113207376-369eb180-9279-11eb-8e3f-ffe35f91bcd4.png)

Similiar tracking error reduction can also be seen in real flight tests. 