### PR TITLE
AP_Arming: Determine if a compass is available first

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -415,7 +415,7 @@ bool AP_Arming::compass_checks(bool report)
         (checks_to_perform) & ARMING_CHECK_COMPASS) {
 
         // check for first compass being disabled but 2nd or 3rd being enabled
-        if (!_compass.use_for_yaw(0) && (_compass.get_num_enabled() > 0)) {
+        if ((_compass.get_num_enabled() && !_compass.use_for_yaw(0) > 0)) {
             check_failed(ARMING_CHECK_COMPASS, report, "Compass1 disabled but others enabled");
             return false;
         }


### PR DESCRIPTION
I know that I can use more than one compass.
I think it's better to check first whether you have a compass or not, so you don't make any unnecessary decisions.
The STM32 does not do parallel processing.
In this case, processing is done from the left.