### PR TITLE
AP_HAL_ChibiOS: H7 set SRAM4 to no cache and allow DMA

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
@@ -235,6 +235,15 @@ void __early_init(void) {
 #if defined(HAL_DISABLE_DCACHE)
   SCB_DisableDCache();
 #endif
+#if defined(STM32H7)
+  // disable cache on SRAM4 so we can use it for DMA
+  mpuConfigureRegion(MPU_REGION_5,
+                     0x38000000U,
+                     MPU_RASR_ATTR_AP_RW_RW |
+                     MPU_RASR_ATTR_NON_CACHEABLE |
+                     MPU_RASR_SIZE_64K |
+                     MPU_RASR_ENABLE);
+#endif
 }
 
 void __late_init(void) {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -62,7 +62,7 @@
  */
 #define STM32_NOCACHE_MPU_REGION            MPU_REGION_6
 #define STM32_NOCACHE_SRAM1_SRAM2           FALSE
-#define STM32_NOCACHE_SRAM3                 TRUE
+#define STM32_NOCACHE_SRAM3                 FALSE
 
 /*
  * PWR system settings.

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
@@ -14,6 +14,16 @@ mcu = {
     # location of MCU serial number
     'UDID_START' : 0x1FF1E800,
 
+    # DMA peripheral capabilities:
+    # - can't use ITCM or DTCM for any DMA
+    # - SPI1 to SPI5 can use AXI SRAM, SRAM1 to SRAM3 and SRAM4 for DMA
+    # - SPI6, I2C4 and ADC3 can use SRAM4 on BDMA (I didn't actually test ADC3)
+    # - UARTS can use AXI SRAM, SRAM1 to SRAM3 and SRAM4 for DMA
+    # - I2C1, I2C2 and I2C3 can use AXI SRAM, SRAM1 to SRAM3 and SRAM4 with DMA
+    # - timers can use AXI SRAM, SRAM1 to SRAM3 and SRAM4 with DMA
+    # - ADC12 can use AXI SRAM, SRAM1 to SRAM3 and SRAM4
+    # - SDMMC can use AXI SRAM, SRAM1 to SRAM3 with IDMA (cannot use SRAM4)
+
     # ram map, as list of (address, size-kb, flags)
     # flags of 1 means DMA-capable (DMA and BDMA)
     # flags of 2 means faster memory for CPU intensive work
@@ -23,8 +33,8 @@ mcu = {
         (0x30000000, 256, 0), # SRAM1, SRAM2
         (0x24000000, 512, 4), # AXI SRAM. Use this for SDMMC IDMA ops
         (0x00000400,  63, 2), # ITCM (first 1k removed, to keep address 0 unused)
+        (0x30040000,  32, 0), # SRAM3.
         (0x38000000,  64, 1), # SRAM4.
-        (0x30040000,  32, 1), # SRAM3. This supports both DMA and BDMA ops.
     ],
 
     'EXPECTED_CLOCK' : 400000000,

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
@@ -21,9 +21,9 @@ mcu = {
     'RAM_MAP' : [
         (0x20000000, 128, 2), # DTCM, tightly coupled, no DMA, fast
         (0x30000000, 256, 0), # SRAM1, SRAM2
-        (0x38000000,  64, 0), # SRAM4.
         (0x24000000, 512, 4), # AXI SRAM. Use this for SDMMC IDMA ops
         (0x00000400,  63, 2), # ITCM (first 1k removed, to keep address 0 unused)
+        (0x38000000,  64, 1), # SRAM4.
         (0x30040000,  32, 1), # SRAM3. This supports both DMA and BDMA ops.
     ],
 


### PR DESCRIPTION
This is a change to mark SRAM4 as no cache and allow DMA. This allows lots of LEDs again. I have not tested all output types. H7 boards only.