### PR TITLE
Tools: param_metadata; stop prettifying XML before emitting

### DIFF
--- a/Tools/autotest/logger_metadata/emit_xml.py
+++ b/Tools/autotest/logger_metadata/emit_xml.py
@@ -45,7 +45,7 @@ class XMLEmitter(emitter.Emitter):
         self.stop()
 
     def stop(self):
-        etree.indent(self.loggermessagefile)
+        # etree.indent(self.loggermessagefile)  # not available on thor, Ubuntu 16.04
         pretty_xml = etree.tostring(self.loggermessagefile, pretty_print=True, encoding='unicode')
         self.fh.write(pretty_xml)
         self.fh.close()

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -21,7 +21,7 @@ class XmlEmit(Emit):
         self.current_element = self.vehicles
 
     def close(self):
-        etree.indent(self.paramfile)
+        # etree.indent(self.paramfile)  # not available on thor, Ubuntu 16.04
         pretty_xml = etree.tostring(self.paramfile, pretty_print=True, encoding='unicode')
         self.f.write(pretty_xml)
         self.f.close()


### PR DESCRIPTION
indent is not available on our documentation server:

[build_parameters.py]
Traceback (most recent call last):
  File "./param_parse.py", line 422, in <module>
    do_emit(XmlEmit())
  File "./param_parse.py", line 415, in do_emit
    emit.close()
  File "/home/wiki/build_wiki/ardupilot/Tools/autotest/param_metadata/xmlemit.py
", line 24, in close
    etree.indent(self.paramfile)
AttributeError: module 'lxml.etree' has no attribute 'indent'