### PR TITLE
Change avoidance related default params

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -78,7 +78,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Units: m/s
     // @Range: 0 2
     // @User: Standard
-    AP_GROUPINFO("BACKUP_SPD", 6, AC_Avoid, _backup_speed_max, 0.5f),
+    AP_GROUPINFO("BACKUP_SPD", 6, AC_Avoid, _backup_speed_max, 0.75f),
 
     // @Param: ALT_MIN
     // @DisplayName: Avoidance minimum altitude
@@ -86,7 +86,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Units: m
     // @Range: 0 6
     // @User: Standard
-    AP_GROUPINFO("ALT_MIN", 7, AC_Avoid, _alt_min, 2.0f),
+    AP_GROUPINFO("ALT_MIN", 7, AC_Avoid, _alt_min, 0.0f),
 
     // @Param: ACCEL_MAX
     // @DisplayName: Avoidance maximum acceleration

--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -100,7 +100,7 @@ const AP_Param::GroupInfo AP_OADatabase::var_info[] = {
     // @Units: m
     // @Range: 0 4
     // @User: Advanced
-    AP_GROUPINFO_FRAME("ALT_MIN", 8, AP_OADatabase, _min_alt, 2.0f, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
+    AP_GROUPINFO_FRAME("ALT_MIN", 8, AP_OADatabase, _min_alt, 0.0f, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -157,7 +157,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Description: Ignore proximity data that is within 1 meter of the ground below the vehicle. This requires a downward facing rangefinder
     // @Values: 0:Disabled, 1:Enabled
     // @User: Standard
-    AP_GROUPINFO_FRAME("_IGN_GND", 16, AP_Proximity, _ign_gnd_enable, 1, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
+    AP_GROUPINFO_FRAME("_IGN_GND", 16, AP_Proximity, _ign_gnd_enable, 0, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
 
     // @Param: _LOG_RAW
     // @DisplayName: Proximity raw distances log


### PR DESCRIPTION
I have added a lot of parameters in the past few months.  When these were merged to master, most of the param defaults were based on my testing from SITL.
However, I have been flying a lot of these features (in preparation for 4.1) and have realised that someone of them can be potentially dangerous. 
For eg. A user who has a downward facing rangefinder configured from 4.0 will find that after he upgrades to 4.1, suddenly Simple Avoidance doesn't under 2 meters (due to "ALT_MIN" param).. which can be dangerous. Its best if the user sets the param himself as per needs (Although I am sure most users are going to find that param very helpful, but it should come from them, rather than us forcing it) 

I have also increased the backup speed defaults. We can actually safely increase it to much more than this also. This is because of the acceleration limits that I have put a while back, that has made backing away very smooth and safe. 