### PR TITLE
AP_HAL_LINUX: RCInput_RPI RPI-4 Support

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -379,12 +379,10 @@ void RCInput_RPI::init_PCM()
     hal.scheduler->delay_microseconds(100);
     clk_reg[RCIN_RPI_PCMCLK_CNTL] = 0x5A000006;                              // Source=PLLD (500MHz)
     hal.scheduler->delay_microseconds(100);
-    if (_version != 4)
-    {
+    if (_version != 4) {
         clk_reg[RCIN_RPI_PCMCLK_DIV] = 0x5A000000 | ((RCIN_RPI_PLL_CLK/RCIN_RPI_SAMPLE_FREQ)<<12);   // Set pcm div for BCM2835 500MHZ clock. If we need to configure DMA frequency.
     }
-    else
-    {
+    else {
         clk_reg[RCIN_RPI_PCMCLK_DIV] = 0x5A000000 | ((RCIN_RPI4_PLL_CLK/RCIN_RPI_SAMPLE_FREQ)<< 12); // Set pcm div for BCM2711 700MHz clock. If we need to configure DMA frequency.
     }
     hal.scheduler->delay_microseconds(100);

--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -102,8 +102,19 @@ static uint16_t RcChnGpioTbl[RCIN_RPI_CHN_NUM] = {
 #define RCIN_RPI_PCM_INT_STC_A   (0x1c/4)
 #define RCIN_RPI_PCM_GRAY        (0x20/4)
 
-#define RCIN_RPI_PCMCLK_CNTL     38
-#define RCIN_RPI_PCMCLK_DIV      39
+#define RCIN_RPI_PCMCLK_CNTL     0x26
+#define RCIN_RPI_PCMCLK_DIV      0x27
+
+#define RCIN_RPI_PLL_CLK         50000
+/*
+*  Defaults to 107.14MHz in the firmware setup. 
+*  The PLL channel that used to generate the 100MHz now runs at 750MHz instead of 500,
+*  so the fw uses 750/7.
+*
+*  see: https://www.raspberrypi.org/forums/viewtopic.php?t=251902
+*/
+#define RCIN_RPI4_PLL_CLK        70000
+
 
 
 extern const AP_HAL::HAL& hal;
@@ -355,23 +366,63 @@ void RCInput_RPI::init_ctrl_data()
     ((dma_cb_t *)con_blocks->get_page(con_blocks->_virt_pages, cbp))->next = (uintptr_t)con_blocks->get_page(con_blocks->_phys_pages, 0);
 }
 
+void RCInput_RPI::init_PCM()
+{
+    if (_version != 4)
+    {
+        init_PCM_BCM2835();
+    }
+    else
+    {
+        init_PCM_BCM2711();
+    }
+}
+
 /*Initialise PCM
   See BCM2835 documentation:
   http://www.raspberrypi.org/wp-content/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
  */
-void RCInput_RPI::init_PCM()
+void RCInput_RPI::init_PCM_BCM2835()
 {
     pcm_reg[RCIN_RPI_PCM_CS_A] = 1;                                          // Disable Rx+Tx, Enable PCM block
     hal.scheduler->delay_microseconds(100);
     clk_reg[RCIN_RPI_PCMCLK_CNTL] = 0x5A000006;                              // Source=PLLD (500MHz)
     hal.scheduler->delay_microseconds(100);
-    clk_reg[RCIN_RPI_PCMCLK_DIV] = 0x5A000000 | ((50000/RCIN_RPI_SAMPLE_FREQ)<<12);   // Set pcm div. If we need to configure DMA frequency.
+    clk_reg[RCIN_RPI_PCMCLK_DIV] = 0x5A000000 | ((RCIN_RPI_PLL_CLK/RCIN_RPI_SAMPLE_FREQ)<<12);   // Set pcm div. If we need to configure DMA frequency.
     hal.scheduler->delay_microseconds(100);
     clk_reg[RCIN_RPI_PCMCLK_CNTL] = 0x5A000016;                              // Source=PLLD and enable
     hal.scheduler->delay_microseconds(100);
     pcm_reg[RCIN_RPI_PCM_TXC_A] = 0<<31 | 1<<30 | 0<<20 | 0<<16;             // 1 channel, 8 bits
     hal.scheduler->delay_microseconds(100);
-    pcm_reg[RCIN_RPI_PCM_MODE_A] = (10 - 1) << 10;                           //PCM mode
+    pcm_reg[RCIN_RPI_PCM_MODE_A] = (10 - 1) << 10;                           //PCM mode 0b0010010000000000
+    hal.scheduler->delay_microseconds(100);
+    pcm_reg[RCIN_RPI_PCM_CS_A] |= 1<<4 | 1<<3;                               // Clear FIFOs
+    hal.scheduler->delay_microseconds(100);
+    pcm_reg[RCIN_RPI_PCM_DREQ_A] = 64<<24 | 64<<8;                           // DMA Req when one slot is free?
+    hal.scheduler->delay_microseconds(100);
+    pcm_reg[RCIN_RPI_PCM_CS_A] |= 1<<9;                                      // Enable DMA
+    hal.scheduler->delay_microseconds(100);
+    pcm_reg[RCIN_RPI_PCM_CS_A] |= 1<<2;                                      // Enable Tx
+    hal.scheduler->delay_microseconds(100);
+}
+
+
+/*Initialise PCM
+  See BCM2711 documentation:
+ */
+void RCInput_RPI::init_PCM_BCM2711()
+{
+    pcm_reg[RCIN_RPI_PCM_CS_A] = 1;                                          // Disable Rx+Tx, Enable PCM block
+    hal.scheduler->delay_microseconds(100);
+    clk_reg[RCIN_RPI_PCMCLK_CNTL] = 0x5A000006;                              // Source=PLLD (700MHz) // https://www.raspberrypi.org/forums/viewtopic.php?t=251902
+    hal.scheduler->delay_microseconds(100);
+    clk_reg[RCIN_RPI_PCMCLK_DIV] = 0x5A000000 | ((RCIN_RPI4_PLL_CLK/RCIN_RPI_SAMPLE_FREQ)<< 12); // 0x5A001900; //0x0x5A001900; //0x5A000000 | ((50000/RCIN_RPI_SAMPLE_FREQ)<< 4);   // Set pcm div. If we need to configure DMA frequency.
+    hal.scheduler->delay_microseconds(100);
+    clk_reg[RCIN_RPI_PCMCLK_CNTL] = 0x5A000016;                              // Source=PLLD and enable
+    hal.scheduler->delay_microseconds(100);
+    pcm_reg[RCIN_RPI_PCM_TXC_A] = 0<<31 | 1<<30 | 0<<20 | 0<<16;             // 1 channel, 8 bits
+    hal.scheduler->delay_microseconds(100);
+    pcm_reg[RCIN_RPI_PCM_MODE_A] = (10 - 1) << 10;                           //PCM mode 0b0010010000000000
     hal.scheduler->delay_microseconds(100);
     pcm_reg[RCIN_RPI_PCM_CS_A] |= 1<<4 | 1<<3;                               // Clear FIFOs
     hal.scheduler->delay_microseconds(100);

--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -64,6 +64,10 @@ static uint16_t RcChnGpioTbl[RCIN_RPI_CHN_NUM] = {
 #endif // CONFIG_HAL_BOARD_SUBTYPE
 
 //Memory Addresses
+#define RCIN_RPI_RPI0_DMA_BASE 0x20007000
+#define RCIN_RPI_RPI0_CLK_BASE 0x20101000
+#define RCIN_RPI_RPI0_PCM_BASE 0x20203000
+
 #define RCIN_RPI_RPI1_DMA_BASE 0x20007000
 #define RCIN_RPI_RPI1_CLK_BASE 0x20101000
 #define RCIN_RPI_RPI1_PCM_BASE 0x20203000
@@ -71,6 +75,14 @@ static uint16_t RcChnGpioTbl[RCIN_RPI_CHN_NUM] = {
 #define RCIN_RPI_RPI2_DMA_BASE 0x3F007000
 #define RCIN_RPI_RPI2_CLK_BASE 0x3F101000
 #define RCIN_RPI_RPI2_PCM_BASE 0x3F203000
+
+#define RCIN_RPI_RPI3_DMA_BASE 0x3F007000
+#define RCIN_RPI_RPI3_CLK_BASE 0x3F101000
+#define RCIN_RPI_RPI3_PCM_BASE 0x3F203000
+
+#define RCIN_RPI_RPI4_DMA_BASE 0xFE007000
+#define RCIN_RPI_RPI4_CLK_BASE 0xFE101000 
+#define RCIN_RPI_RPI4_PCM_BASE 0xFE203000
 
 #define RCIN_RPI_GPIO_LEV0_ADDR  0x7e200034
 #define RCIN_RPI_DMA_LEN         0x1000
@@ -238,16 +250,22 @@ uint32_t Memory_table::get_page_count() const
 }
 
 // Physical addresses of peripheral depends on Raspberry Pi's version
-void RCInput_RPI::set_physical_addresses(int version)
+void RCInput_RPI::set_physical_addresses()
 {
-    if (version == 1) {
+    if (_version == 1) { 
+        // 1 & zero are the same
         dma_base = RCIN_RPI_RPI1_DMA_BASE;
         clk_base = RCIN_RPI_RPI1_CLK_BASE;
         pcm_base = RCIN_RPI_RPI1_PCM_BASE;
-    } else if (version == 2) {
+    } else if (_version == 2) { 
+        // 2 & 3 are the same
         dma_base = RCIN_RPI_RPI2_DMA_BASE;
         clk_base = RCIN_RPI_RPI2_CLK_BASE;
         pcm_base = RCIN_RPI_RPI2_PCM_BASE;
+    } else if (_version == 4) {
+        dma_base = RCIN_RPI_RPI4_DMA_BASE;
+        clk_base = RCIN_RPI_RPI4_CLK_BASE;
+        pcm_base = RCIN_RPI_RPI4_PCM_BASE;
     }
 }
 
@@ -484,7 +502,7 @@ void RCInput_RPI::init()
     _version = UtilRPI::from(hal.util)->get_rpi_version();
 #endif
 
-    set_physical_addresses(_version);
+    set_physical_addresses();
     // Init memory for buffer and for DMA control blocks.
     // See comments in "init_ctrl_data()" to understand values "2" and "15"
     circle_buffer = new Memory_table(RCIN_RPI_BUFFER_LENGTH * 2, _version);

--- a/libraries/AP_HAL_Linux/RCInput_RPI.h
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.h
@@ -131,12 +131,15 @@ private:
     } rc_channels[RCIN_RPI_CHN_NUM];
 
     bool _initialized = false;
-
+    int _version =0;
+    
     void init_dma_cb(dma_cb_t** cbp, uint32_t mode, uint32_t source, uint32_t dest, uint32_t length, uint32_t stride, uint32_t next_cb);
     void* map_peripheral(uint32_t base, uint32_t len);
     void init_registers();
     void init_ctrl_data();
     void init_PCM();
+    void init_PCM_BCM2835();
+    void init_PCM_BCM2711();
     void init_DMA();
     void init_buffer();
     static void stop_dma();

--- a/libraries/AP_HAL_Linux/RCInput_RPI.h
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.h
@@ -143,7 +143,7 @@ private:
     static void stop_dma();
     static void termination_handler(int signum);
     void set_sigaction();
-    void set_physical_addresses(int version);
+    void set_physical_addresses();
     void teardown() override;
 };
 

--- a/libraries/AP_HAL_Linux/RCInput_RPI.h
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.h
@@ -138,8 +138,6 @@ private:
     void init_registers();
     void init_ctrl_data();
     void init_PCM();
-    void init_PCM_BCM2835();
-    void init_PCM_BCM2711();
     void init_DMA();
     void init_buffer();
     static void stop_dma();


### PR DESCRIPTION
GPIO_RPI already supports RPI-4 while RCInput_RPI does not .

changes were mainly in addresses and a single vital change in CLK_DIV based because of clock speed changes.
_"Defaults to 107.14MHz in the firmware setup. The PLL channel that used to generate the 100MHz now runs at 750MHz instead of 500, so the fw uses 750/7."_  https://www.raspberrypi.org/forums/viewtopic.php?t=251902
