### PR TITLE
AP_Filesystem: allow transfer of mission/fence/rally/param with mavftp

### DIFF
--- a/libraries/AP_Common/ExpandingString.cpp
+++ b/libraries/AP_Common/ExpandingString.cpp
@@ -43,6 +43,7 @@ bool ExpandingString::expand(uint32_t min_extra_space_needed)
 
     buflen = newsize;
     buf = (char *)newbuf;
+    memset(&buf[used], 0, newsize-used);
 
     return true;
 }

--- a/libraries/AP_Common/ExpandingString.cpp
+++ b/libraries/AP_Common/ExpandingString.cpp
@@ -84,16 +84,19 @@ void ExpandingString::printf(const char *format, ...)
 /*
   print into the buffer, expanding if needed
  */
-void ExpandingString::append(const char *s, uint32_t len)
+bool ExpandingString::append(const char *s, uint32_t len)
 {
     if (allocation_failed) {
-        return;
+        return false;
     }
     if (buflen - used < len && !expand(len)) {
-        return;
+        return false;
     }
-    memcpy(&buf[used], s, len);
+    if (s != nullptr) {
+        memcpy(&buf[used], s, len);
+    }
     used += len;
+    return true;
 }
 
 ExpandingString::~ExpandingString()

--- a/libraries/AP_Common/ExpandingString.h
+++ b/libraries/AP_Common/ExpandingString.h
@@ -36,8 +36,8 @@ public:
     // print into the string
     void printf(const char *format, ...) FMT_PRINTF(2,3);
 
-    // append data to the string
-    void append(const char *s, uint32_t len);
+    // append data to the string. s can be null for zero fill
+    bool append(const char *s, uint32_t len);
 
     // destructor
     ~ExpandingString();

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -43,6 +43,9 @@ static AP_Filesystem_Param fs_param;
 #include "AP_Filesystem_Sys.h"
 static AP_Filesystem_Sys fs_sys;
 
+#include "AP_Filesystem_Mission.h"
+static AP_Filesystem_Mission fs_mission;
+
 /*
   mapping from filesystem prefix to backend
  */
@@ -54,6 +57,7 @@ const AP_Filesystem::Backend AP_Filesystem::backends[] = {
     { "@PARAM/", fs_param },
     { "@SYS/", fs_sys },
     { "@SYS", fs_sys },
+    { "@MISSION/", fs_mission },
 };
 
 #define MAX_FD_PER_BACKEND 256U

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
@@ -337,7 +337,7 @@ bool AP_Filesystem_Mission::all_zero(const uint8_t *b, uint8_t len) const
 bool AP_Filesystem_Mission::finish_upload(const rfile &r)
 {
     const uint32_t flen = r.writebuf->get_length();
-    uint8_t *b = (uint8_t *)r.writebuf->get_writeable_string();
+    const uint8_t *b = (const uint8_t *)r.writebuf->get_string();
     struct header hdr;
     if (flen < sizeof(hdr)) {
         return false;

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
@@ -1,0 +1,247 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  ArduPilot filesystem interface for mission/fence/rally
+ */
+#include "AP_Filesystem.h"
+#include "AP_Filesystem_Mission.h"
+#include <AP_Mission/AP_Mission.h>
+#include <AC_Fence/AC_Fence.h>
+#include <AP_Rally/AP_Rally.h>
+#include <GCS_MAVLink/MissionItemProtocol_Rally.h>
+#include <GCS_MAVLink/MissionItemProtocol_Fence.h>
+
+extern const AP_HAL::HAL& hal;
+extern int errno;
+
+int AP_Filesystem_Mission::open(const char *fname, int flags)
+{
+    enum MAV_MISSION_TYPE mtype;
+
+    if (!check_file_name(fname, mtype)) {
+        errno = ENOENT;
+        return -1;
+    }
+    if ((flags & O_ACCMODE) != O_RDONLY) {
+        return -1;
+    }
+    uint8_t idx;
+    for (idx=0; idx<max_open_file; idx++) {
+        if (!file[idx].open) {
+            break;
+        }
+    }
+    if (idx == max_open_file) {
+        errno = ENFILE;
+        return -1;
+    }
+    struct rfile &r = file[idx];
+    r.file_ofs = 0;
+    r.open = true;
+    r.mtype = mtype;
+    r.num_items = get_num_items(r.mtype);
+
+    return idx;
+}
+
+int AP_Filesystem_Mission::close(int fd)
+{
+    if (fd < 0 || fd >= max_open_file || !file[fd].open) {
+        errno = EBADF;
+        return -1;
+    }
+    struct rfile &r = file[fd];
+    r.open = false;
+    return 0;
+}
+
+/*
+  packed format:
+    file header:
+      uint16_t magic = 0x671b
+      uint16_t data_type MAV_MISSION_TYPE_*
+      uint32_t total_items
+
+    per-entry is mavlink packed item
+ */
+
+/*
+  read from file handle
+ */
+int32_t AP_Filesystem_Mission::read(int fd, void *buf, uint32_t count)
+{
+    if (fd < 0 || fd >= max_open_file || !file[fd].open) {
+        errno = EBADF;
+        return -1;
+    }
+
+    struct rfile &r = file[fd];
+    size_t header_total = 0;
+    uint8_t *ubuf = (uint8_t *)buf;
+
+    if (r.file_ofs < sizeof(struct header)) {
+        struct header hdr;
+        hdr.data_type = uint16_t(r.mtype);
+        hdr.num_items = r.num_items;
+        uint8_t n = MIN(sizeof(hdr) - r.file_ofs, count);
+        const uint8_t *b = (const uint8_t *)&hdr;
+        memcpy(ubuf, &b[r.file_ofs], n);
+        count -= n;
+        header_total += n;
+        r.file_ofs += n;
+        ubuf += n;
+        if (count == 0) {
+            return header_total;
+        }
+    }
+
+    uint32_t data_ofs = r.file_ofs - sizeof(struct header);
+    mavlink_mission_item_int_t item;
+    const uint8_t item_size = MAVLINK_MSG_ID_MISSION_ITEM_INT_LEN;
+    uint32_t item_ofs = data_ofs % item_size;
+    uint32_t total = 0;
+
+    while (count > 0) {
+        uint32_t item_idx = data_ofs / item_size;
+
+        const uint8_t *ibuf = (const uint8_t *)&item;
+        if (!get_item(item_idx, r.mtype, item)) {
+            break;
+        }
+        const uint8_t n = MIN(item_size - item_ofs, count);
+        memcpy(ubuf, &ibuf[item_ofs], n);
+        ubuf += n;
+        count -= n;
+        total += n;
+        item_ofs = 0;
+        data_ofs += n;
+    }
+
+    r.file_ofs += total;
+    return total + header_total;
+}
+
+int32_t AP_Filesystem_Mission::lseek(int fd, int32_t offset, int seek_from)
+{
+    if (fd < 0 || fd >= max_open_file || !file[fd].open) {
+        errno = EBADF;
+        return -1;
+    }
+    struct rfile &r = file[fd];
+    switch (seek_from) {
+    case SEEK_SET:
+        r.file_ofs = offset;
+        break;
+    case SEEK_CUR:
+        r.file_ofs += offset;
+        break;
+    case SEEK_END:
+        errno = EINVAL;
+        return -1;
+    }
+    return r.file_ofs;
+}
+
+int AP_Filesystem_Mission::stat(const char *name, struct stat *stbuf)
+{
+    enum MAV_MISSION_TYPE mtype;
+    if (!check_file_name(name, mtype)) {
+        errno = ENOENT;
+        return -1;
+    }
+    memset(stbuf, 0, sizeof(*stbuf));
+    // give fixed size to avoid needing to scan entire file
+    stbuf->st_size = 1024*1024;
+    return 0;
+}
+
+/*
+  check for the right file name
+ */
+bool AP_Filesystem_Mission::check_file_name(const char *name, enum MAV_MISSION_TYPE &mtype)
+{
+    if (strcmp(name, "mission.dat") == 0) {
+        mtype = MAV_MISSION_TYPE_MISSION;
+        return true;
+    }
+    if (strcmp(name, "fence.dat") == 0) {
+        mtype = MAV_MISSION_TYPE_FENCE;
+        return true;
+    }
+    if (strcmp(name, "rally.dat") == 0) {
+        mtype = MAV_MISSION_TYPE_RALLY;
+        return true;
+    }
+    return false;
+}
+
+/*
+  get one item
+ */
+bool AP_Filesystem_Mission::get_item(uint32_t idx, enum MAV_MISSION_TYPE mtype, mavlink_mission_item_int_t &item)
+{
+    switch (mtype) {
+    case MAV_MISSION_TYPE_MISSION: {
+        auto *mission = AP::mission();
+        if (!mission) {
+            return false;
+        }
+        return mission->get_item(idx, item);
+    }
+    case MAV_MISSION_TYPE_FENCE:
+        return MissionItemProtocol_Fence::get_item_as_mission_item(idx, item);
+
+    case MAV_MISSION_TYPE_RALLY:
+        return MissionItemProtocol_Rally::get_item_as_mission_item(idx, item);
+
+    default:
+        break;
+    }
+    return false;
+}
+
+// get number of items
+uint32_t AP_Filesystem_Mission::get_num_items(enum MAV_MISSION_TYPE mtype) const
+{
+    switch (mtype) {
+    case MAV_MISSION_TYPE_MISSION: {
+        auto *mission = AP::mission();
+        if (!mission) {
+            return 0;
+        }
+        return mission->num_commands();
+    }
+        
+    case MAV_MISSION_TYPE_FENCE: {
+        auto *fence = AP::fence();
+        if (fence == nullptr) {
+            return 0;
+        }
+        return fence->polyfence().num_stored_items();
+    }
+
+    case MAV_MISSION_TYPE_RALLY: {
+        auto *rally = AP::rally();
+        if (rally == nullptr) {
+            return 0;
+        }
+        return rally->get_rally_total();
+    }
+        
+    default:
+        break;
+    }
+    return 0;
+}

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -61,7 +61,7 @@ private:
     bool check_file_name(const char *fname, enum MAV_MISSION_TYPE &mtype);
 
     // get one item
-    bool get_item(uint32_t idx, enum MAV_MISSION_TYPE mtype, mavlink_mission_item_int_t &item);
+    bool get_item(uint32_t idx, enum MAV_MISSION_TYPE mtype, mavlink_mission_item_int_t &item) const;
 
     // get number of items
     uint32_t get_num_items(enum MAV_MISSION_TYPE mtype) const;

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -36,11 +36,17 @@ private:
 
     static constexpr uint16_t mission_magic = 0x763d;
 
+    enum class Options {
+        NO_CLEAR = (1U<<0), // don't clear the old mission
+    };
+
     // header at front of the file
     struct header {
         uint16_t magic = mission_magic;
         uint16_t data_type; // MAV_MISSION_TYPE_*
-        uint32_t num_items;
+        uint16_t options; // optional features
+        uint16_t start; // first WP num, 0 for full upload
+        uint16_t num_items;
     };
 
     struct rfile {

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -1,0 +1,56 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "AP_Filesystem_backend.h"
+#include <GCS_MAVLink/GCS_MAVLink.h>
+
+class AP_Filesystem_Mission : public AP_Filesystem_Backend
+{
+public:
+    // functions that closely match the equivalent posix calls
+    int open(const char *fname, int flags) override;
+    int close(int fd) override;
+    int32_t read(int fd, void *buf, uint32_t count) override;
+    int32_t lseek(int fd, int32_t offset, int whence) override;
+    int stat(const char *pathname, struct stat *stbuf) override;
+
+private:
+    // only allow up to 4 files at a time
+    static constexpr uint8_t max_open_file = 4;
+
+    // header at front of the file
+    struct header {
+        uint16_t magic = 0x763d;
+        uint16_t data_type; // MAV_MISSION_TYPE_*
+        uint32_t num_items;
+    };
+
+    struct rfile {
+        bool open;
+        uint32_t file_ofs;
+        uint32_t num_items;
+        enum MAV_MISSION_TYPE mtype;
+    } file[max_open_file];
+
+    bool check_file_name(const char *fname, enum MAV_MISSION_TYPE &mtype);
+
+    // get one item
+    bool get_item(uint32_t idx, enum MAV_MISSION_TYPE mtype, mavlink_mission_item_int_t &item);
+
+    // get number of items
+    uint32_t get_num_items(enum MAV_MISSION_TYPE mtype) const;
+};

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -62,4 +62,7 @@ private:
 
     // finish loading items
     bool finish_upload(const rfile &r);
+
+    // see if a block of memory is all zero
+    bool all_zero(const uint8_t *b, uint8_t size) const;
 };

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -17,6 +17,7 @@
 
 #include "AP_Filesystem_backend.h"
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Common/ExpandingString.h>
 
 class AP_Filesystem_Mission : public AP_Filesystem_Backend
 {
@@ -26,24 +27,29 @@ public:
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;
+    int32_t write(int fd, const void *buf, uint32_t count) override;
     int stat(const char *pathname, struct stat *stbuf) override;
 
 private:
     // only allow up to 4 files at a time
     static constexpr uint8_t max_open_file = 4;
 
+    static constexpr uint16_t mission_magic = 0x763d;
+
     // header at front of the file
     struct header {
-        uint16_t magic = 0x763d;
+        uint16_t magic = mission_magic;
         uint16_t data_type; // MAV_MISSION_TYPE_*
         uint32_t num_items;
     };
 
     struct rfile {
         bool open;
+        ExpandingString *writebuf;
         uint32_t file_ofs;
         uint32_t num_items;
         enum MAV_MISSION_TYPE mtype;
+        uint32_t last_op_ms;
     } file[max_open_file];
 
     bool check_file_name(const char *fname, enum MAV_MISSION_TYPE &mtype);
@@ -53,4 +59,7 @@ private:
 
     // get number of items
     uint32_t get_num_items(enum MAV_MISSION_TYPE mtype) const;
+
+    // finish loading items
+    bool finish_upload(const rfile &r);
 };

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -19,6 +19,7 @@
 #include "AP_Filesystem_Param.h"
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
+#include <ctype.h>
 
 #define PACKED_NAME "param.pck"
 
@@ -31,9 +32,7 @@ int AP_Filesystem_Param::open(const char *fname, int flags)
         errno = ENOENT;
         return -1;
     }
-    if ((flags & O_ACCMODE) != O_RDONLY) {
-        return -1;
-    }
+    bool read_only = ((flags & O_ACCMODE) == O_RDONLY);
     uint8_t idx;
     for (idx=0; idx<max_open_file; idx++) {
         if (!file[idx].open) {
@@ -45,15 +44,27 @@ int AP_Filesystem_Param::open(const char *fname, int flags)
         return -1;
     }
     struct rfile &r = file[idx];
-    r.cursors = new cursor[num_cursors];
-    if (r.cursors == nullptr) {
-        errno = ENOMEM;
-        return -1;
+    if (read_only) {
+        r.cursors = new cursor[num_cursors];
+        if (r.cursors == nullptr) {
+            errno = ENOMEM;
+            return -1;
+        }
     }
     r.file_ofs = 0;
     r.open = true;
     r.start = 0;
     r.count = 0;
+    r.writebuf = nullptr;
+    if (!read_only) {
+        // setup for upload
+        r.writebuf = new ExpandingString();
+        if (r.writebuf == nullptr) {
+            close(idx);
+            errno = ENOMEM;
+            return -1;
+        }
+    }
 
     /*
       allow for URI style arguments param.pck?start=N&count=C
@@ -99,9 +110,17 @@ int AP_Filesystem_Param::close(int fd)
         return -1;
     }
     struct rfile &r = file[fd];
+    int ret = 0;
+    if (r.writebuf != nullptr && !finish_upload(r)) {
+        errno = EINVAL;
+        ret = -1;
+    }
     r.open = false;
     delete [] r.cursors;
-    return 0;
+    r.cursors = nullptr;
+    delete r.writebuf;
+    r.writebuf = nullptr;
+    return ret;
 }
 
 /*
@@ -239,6 +258,11 @@ int32_t AP_Filesystem_Param::read(int fd, void *buf, uint32_t count)
     }
 
     struct rfile &r = file[fd];
+    if (r.writebuf != nullptr) {
+        // no read on upload
+        errno = EINVAL;
+        return -1;
+    }
     size_t header_total = 0;
 
     /*
@@ -397,4 +421,169 @@ bool AP_Filesystem_Param::check_file_name(const char *name)
         return true;
     }
     return false;
+}
+
+/*
+  support param upload
+ */
+int32_t AP_Filesystem_Param::write(int fd, const void *buf, uint32_t count)
+{
+    if (fd < 0 || fd >= max_open_file || !file[fd].open) {
+        errno = EBADF;
+        return -1;
+    }
+    struct rfile &r = file[fd];
+    if (r.writebuf == nullptr) {
+        errno = EBADF;
+        return -1;
+    }
+    struct header hdr;
+    if (r.file_ofs == 0 && count >= sizeof(hdr)) {
+        // pre-expand the buffer to the full size when we get the header
+        memcpy(&hdr, buf, sizeof(hdr));
+        if (hdr.magic == pmagic) {
+            const uint32_t flen = hdr.total_params;
+            if (flen > r.writebuf->get_length()) {
+                if (!r.writebuf->append(nullptr, flen - r.writebuf->get_length())) {
+                    // not enough memory
+                    return -1;
+                }
+            }
+        }
+    }
+    if (r.file_ofs + count > r.writebuf->get_length()) {
+        if (!r.writebuf->append(nullptr, r.file_ofs + count - r.writebuf->get_length())) {
+            return -1;
+        }
+    }
+    uint8_t *b = (uint8_t *)r.writebuf->get_writeable_string();
+    memcpy(&b[r.file_ofs], buf, count);
+    r.file_ofs += count;
+    return count;
+}
+
+/*
+  parse incoming parameters
+ */
+bool AP_Filesystem_Param::param_upload_parse(const rfile &r, bool &need_retry)
+{
+    need_retry = false;
+
+    const uint8_t *b = (const uint8_t *)r.writebuf->get_string();
+    uint32_t length = r.writebuf->get_length();
+    struct header hdr;
+    if (length < sizeof(hdr)) {
+        return false;
+    }
+    memcpy(&hdr, b, sizeof(hdr));
+    if (hdr.magic != pmagic) {
+        return false;
+    }
+    if (length != hdr.total_params) {
+        return false;
+    }
+    b += sizeof(hdr);
+
+    char last_name[17] {};
+
+    for (uint16_t i=0; i<hdr.num_params; i++) {
+        enum ap_var_type ptype = (enum ap_var_type)(b[0]&0x0F);
+        uint8_t flags = (enum ap_var_type)(b[0]>>4);
+        if (flags != 0) {
+            return false;
+        }
+        uint8_t common_len = b[1]&0xF;
+        uint8_t name_len = (b[1]>>4)+1;
+        if (common_len + name_len > 16) {
+            return false;
+        }
+        char name[17];
+        memcpy(name, last_name, common_len);
+        memcpy(&name[common_len], &b[2], name_len);
+        name[common_len+name_len] = 0;
+
+        memcpy(last_name, name, sizeof(name));
+        enum ap_var_type ptype2 = AP_PARAM_NONE;
+        uint16_t flags2;
+
+        b += 2 + name_len;
+
+        AP_Param *p = AP_Param::find(name, &ptype2, &flags2);
+        if (p == nullptr) {
+            if (ptype == AP_PARAM_INT8) {
+                b++;
+            } else if (ptype == AP_PARAM_INT16) {
+                b += 2;
+            } else {
+                b += 4;
+            }
+            continue;
+        }
+
+        /*
+          if we are enabling a subsystem we need a small delay between
+          parameters to allow main thread to perform any allocation of
+          backends
+        */
+        bool need_delay = ((flags2 & AP_PARAM_FLAG_ENABLE) != 0 &&
+                           ptype2 == AP_PARAM_INT8 &&
+                           ((AP_Int8 *)p)->get() == 0);
+
+        if (ptype == ptype2 && ptype == AP_PARAM_INT32) {
+            // special handling of int32_t to preserve all bits
+            int32_t v;
+            memcpy(&v, b, sizeof(v));
+            ((AP_Int32 *)p)->set(v);
+            b += 4;
+        } else if (ptype == AP_PARAM_INT8) {
+            if (need_delay && b[0] == 0) {
+                need_delay = false;
+            }
+            p->set_float((int8_t)b[0], ptype2);
+            b += 1;
+        } else if (ptype == AP_PARAM_INT16) {
+            int16_t v;
+            memcpy(&v, b, sizeof(v));
+            p->set_float(float(v), ptype2);
+            b += 2;
+        } else if (ptype == AP_PARAM_INT32) {
+            int32_t v;
+            memcpy(&v, b, sizeof(v));
+            p->set_float(float(v), ptype2);
+            b += 4;
+        } else if (ptype == AP_PARAM_FLOAT) {
+            float v;
+            memcpy(&v, b, sizeof(v));
+            p->set_float(v, ptype2);
+            b += 4;
+        }
+
+        p->save_sync(false, false);
+
+        if (need_delay) {
+            // let main thread have some time to init backends
+            need_retry = true;
+            hal.scheduler->delay(100);
+        }
+    }
+    return true;
+}
+
+
+/*
+  parse incoming parameters
+ */
+bool AP_Filesystem_Param::finish_upload(const rfile &r)
+{
+    uint8_t loops = 0;
+    while (loops++ < 4) {
+        bool need_retry;
+        if (!param_upload_parse(r, need_retry)) {
+            return false;
+        }
+        if (!need_retry) {
+            break;
+        }
+    }
+    return true;
 }

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "AP_Filesystem_backend.h"
+#include <AP_Common/ExpandingString.h>
 
 #include <AP_Param/AP_Param.h>
 
@@ -28,6 +29,7 @@ public:
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;
     int stat(const char *pathname, struct stat *stbuf) override;
+    int32_t write(int fd, const void *buf, uint32_t count) override;
 
 private:
     // we maintain two cursors per open file to minimise seeking
@@ -40,11 +42,13 @@ private:
     // maximum size of one packed parameter
     static constexpr uint8_t max_pack_len = AP_MAX_NAME_SIZE + 2 + 4 + 3;
 
+    static constexpr uint16_t pmagic = 0x671b;
+
     // header at front of the file
     struct header {
-        uint16_t magic = 0x671b;
+        uint16_t magic = pmagic;
         uint16_t num_params;
-        uint16_t total_params;
+        uint16_t total_params; // for upload this is total file length
     };
 
     struct cursor {
@@ -64,9 +68,14 @@ private:
         uint32_t file_ofs;
         uint32_t file_size;
         struct cursor *cursors;
+        ExpandingString *writebuf; // for upload
     } file[max_open_file];
 
     bool token_seek(const struct rfile &r, const uint32_t data_ofs, struct cursor &c);
     uint8_t pack_param(const struct rfile &r, struct cursor &c, uint8_t *buf);
     bool check_file_name(const char *fname);
+
+    // finish uploading parameters
+    bool finish_upload(const rfile &r);
+    bool param_upload_parse(const rfile &r, bool &need_retry);
 };

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
@@ -159,7 +159,7 @@ define BOARD_PWM_COUNT_DEFAULT 8
 # setup for OSD
 define OSD_ENABLED 1
 define HAL_OSD_TYPE_DEFAULT 1
-ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
+ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin
 
 # disable SMBUS and fuel battery monitors to save flash
 define HAL_BATTMON_SMBUS_ENABLE 0
@@ -171,3 +171,8 @@ define HAL_SPRAYER_ENABLED 0
 
 # reduce max size of embedded params for apj_tool.py
 define AP_PARAM_MAX_EMBEDDED_PARAM 1024
+
+# save some flash
+define GENERATOR_ENABLED 0
+define AC_OAPATHPLANNER_ENABLED 0
+define PRECISION_LANDING 0

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1097,7 +1097,7 @@ void AP_Param::notify() const {
 /*
   Save the variable to HAL storage, synchronous version
 */
-void AP_Param::save_sync(bool force_save)
+void AP_Param::save_sync(bool force_save, bool send_to_gcs)
 {
     uint32_t group_element = 0;
     const struct GroupInfo *ginfo;
@@ -1144,7 +1144,9 @@ void AP_Param::save_sync(bool force_save)
     if (scan(&phdr, &ofs)) {
         // found an existing copy of the variable
         eeprom_write_check(ap, ofs+sizeof(phdr), type_size((enum ap_var_type)phdr.type));
-        send_parameter(name, (enum ap_var_type)phdr.type, idx);
+        if (send_to_gcs) {
+            send_parameter(name, (enum ap_var_type)phdr.type, idx);
+        }
         return;
     }
     if (ofs == (uint16_t) ~0) {
@@ -1161,7 +1163,9 @@ void AP_Param::save_sync(bool force_save)
             v2 = get_default_value(this, &info->def_value);
         }
         if (is_equal(v1,v2) && !force_save) {
-            GCS_SEND_PARAM(name, (enum ap_var_type)info->type, v2);
+            if (send_to_gcs) {
+                GCS_SEND_PARAM(name, (enum ap_var_type)info->type, v2);
+            }
             return;
         }
         if (!force_save &&
@@ -1169,7 +1173,9 @@ void AP_Param::save_sync(bool force_save)
              (fabsf(v1-v2) < 0.0001f*fabsf(v1)))) {
             // for other than 32 bit integers, we accept values within
             // 0.01 percent of the current value as being the same
-            GCS_SEND_PARAM(name, (enum ap_var_type)info->type, v2);
+            if (send_to_gcs) {
+                GCS_SEND_PARAM(name, (enum ap_var_type)info->type, v2);
+            }
             return;
         }
     }
@@ -1185,7 +1191,9 @@ void AP_Param::save_sync(bool force_save)
     eeprom_write_check(ap, ofs+sizeof(phdr), type_size((enum ap_var_type)phdr.type));
     eeprom_write_check(&phdr, ofs, sizeof(phdr));
 
-    send_parameter(name, (enum ap_var_type)phdr.type, idx);
+    if (send_to_gcs) {
+        send_parameter(name, (enum ap_var_type)phdr.type, idx);
+    }
 }
 
 /*
@@ -1228,7 +1236,7 @@ void AP_Param::save_io_handler(void)
 {
     struct param_save p;
     while (save_queue.pop(p)) {
-        p.param->save_sync(p.force_save);
+        p.param->save_sync(p.force_save, true);
     }
     if (hal.scheduler->is_system_initialized()) {
         // pay the cost of parameter counting in the IO thread

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1207,8 +1207,8 @@ void AP_Param::save(bool force_save)
     }
     while (!save_queue.push(p)) {
         // if we can't save to the queue
-        if (hal.util->get_soft_armed() || !hal.scheduler->in_main_thread()) {
-            // if we are armed then don't sleep, instead we lose the
+        if (hal.util->get_soft_armed() && hal.scheduler->in_main_thread()) {
+            // if we are armed in main thread then don't sleep, instead we lose the
             // parameter save
             return;
         }
@@ -2559,6 +2559,36 @@ bool AP_Param::set_and_save_by_name(const char *name, float value)
         return true;
     case AP_PARAM_FLOAT:
         ((AP_Float *)vp)->set_and_save(value);
+        return true;
+    default:
+        break;
+    }
+    // not a supported type
+    return false;
+}
+
+/*
+  set and save a value by name
+ */
+bool AP_Param::set_and_save_by_name_ifchanged(const char *name, float value)
+{
+    enum ap_var_type vtype;
+    AP_Param *vp = find(name, &vtype);
+    if (vp == nullptr) {
+        return false;
+    }
+    switch (vtype) {
+    case AP_PARAM_INT8:
+        ((AP_Int8 *)vp)->set_and_save_ifchanged(value);
+        return true;
+    case AP_PARAM_INT16:
+        ((AP_Int16 *)vp)->set_and_save_ifchanged(value);
+        return true;
+    case AP_PARAM_INT32:
+        ((AP_Int32 *)vp)->set_and_save_ifchanged(value);
+        return true;
+    case AP_PARAM_FLOAT:
+        ((AP_Float *)vp)->set_and_save_ifchanged(value);
         return true;
     default:
         break;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -355,7 +355,7 @@ public:
     ///
     /// @return                True if the variable was saved successfully.
     ///
-    void save_sync(bool force_save=false);
+    void save_sync(bool force_save, bool send_to_gcs);
 
     /// flush all pending parameter saves
     /// used on reboot

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -304,6 +304,7 @@ public:
     /// @param  value           The new value
     /// @return                 true if the variable is found
     static bool set_and_save_by_name(const char *name, float value);
+    static bool set_and_save_by_name_ifchanged(const char *name, float value);
     // name helper for scripting
     static bool set_and_save(const char *name, float value) { return set_and_save_by_name(name, value); };
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -2,20 +2,25 @@
 
 #include <AC_Fence/AC_Fence.h>
 
-MAV_MISSION_RESULT MissionItemProtocol_Fence::get_item(const GCS_MAVLINK &_link,
-                                                       const mavlink_message_t &msg,
-                                                       const mavlink_mission_request_int_t &packet,
-                                                       mavlink_mission_item_int_t &ret_packet)
+/*
+  public function to format mission item as mavlink_mission_item_int_t
+ */
+bool MissionItemProtocol_Fence::get_item_as_mission_item(uint16_t seq,
+                                                         mavlink_mission_item_int_t &ret_packet)
 {
-    const uint8_t num_stored_items = _fence.polyfence().num_stored_items();
-    if (packet.seq > num_stored_items) {
-        return MAV_MISSION_INVALID_SEQUENCE;
+    AC_Fence *fence = AP::fence();
+    if (fence == nullptr) {
+        return false;
+    }
+    const uint8_t num_stored_items = fence->polyfence().num_stored_items();
+    if (seq > num_stored_items) {
+        return false;
     }
 
     AC_PolyFenceItem fenceitem;
 
-    if (!_fence.polyfence().get_item(packet.seq, fenceitem)) {
-        return MAV_MISSION_ERROR;
+    if (!fence->polyfence().get_item(seq, fenceitem)) {
+        return false;
     }
 
     MAV_CMD ret_cmd = MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION; // initialised to avoid compiler warning
@@ -41,7 +46,7 @@ MAV_MISSION_RESULT MissionItemProtocol_Fence::get_item(const GCS_MAVLINK &_link,
         p1 = fenceitem.radius;
         break;
     case AC_PolyFenceType::END_OF_STORAGE:
-        return MAV_MISSION_ERROR;
+        return false;
     }
 
     ret_packet.command = ret_cmd;
@@ -49,6 +54,23 @@ MAV_MISSION_RESULT MissionItemProtocol_Fence::get_item(const GCS_MAVLINK &_link,
     ret_packet.x = fenceitem.loc.x;
     ret_packet.y = fenceitem.loc.y;
     ret_packet.z = 0;
+
+    return true;
+}
+
+MAV_MISSION_RESULT MissionItemProtocol_Fence::get_item(const GCS_MAVLINK &_link,
+                                                       const mavlink_message_t &msg,
+                                                       const mavlink_mission_request_int_t &packet,
+                                                       mavlink_mission_item_int_t &ret_packet)
+{
+    const uint8_t num_stored_items = _fence.polyfence().num_stored_items();
+    if (packet.seq > num_stored_items) {
+        return MAV_MISSION_INVALID_SEQUENCE;
+    }
+
+    if (!get_item_as_mission_item(packet.seq, ret_packet)) {
+        return MAV_MISSION_ERROR;
+    }
 
     return MAV_MISSION_ACCEPTED;
 }

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.h
@@ -17,6 +17,11 @@ public:
     MAV_MISSION_RESULT complete(const GCS_MAVLINK &_link) override;
     void timeout() override;
 
+    /*
+      static function to format mission item as mavlink_mission_item_int_t
+    */
+    static bool get_item_as_mission_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet);
+    
 protected:
 
     ap_message next_item_ap_message_id() const override {

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
@@ -73,15 +73,18 @@ MAV_MISSION_RESULT MissionItemProtocol_Rally::convert_MISSION_ITEM_INT_to_RallyL
     return MAV_MISSION_ACCEPTED;
 }
 
-MAV_MISSION_RESULT MissionItemProtocol_Rally::get_item(const GCS_MAVLINK &_link,
-                                                       const mavlink_message_t &msg,
-                                                       const mavlink_mission_request_int_t &packet,
-                                                       mavlink_mission_item_int_t &ret_packet)
+/*
+  static function to get rally item as mavlink_mission_item_int_t
+ */
+bool MissionItemProtocol_Rally::get_item_as_mission_item(uint16_t seq,
+                                                         mavlink_mission_item_int_t &ret_packet)
 {
+    auto *rallyp = AP::rally();
+
     RallyLocation rallypoint;
 
-    if (!rally.get_rally_point_with_index(packet.seq, rallypoint)) {
-        return MAV_MISSION_INVALID_SEQUENCE;
+    if (rallyp == nullptr || !rallyp->get_rally_point_with_index(seq, rallypoint)) {
+        return false;
     }
 
     ret_packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
@@ -90,6 +93,17 @@ MAV_MISSION_RESULT MissionItemProtocol_Rally::get_item(const GCS_MAVLINK &_link,
     ret_packet.y = rallypoint.lng;
     ret_packet.z = rallypoint.alt;
 
+    return true;
+}
+
+MAV_MISSION_RESULT MissionItemProtocol_Rally::get_item(const GCS_MAVLINK &_link,
+                                                       const mavlink_message_t &msg,
+                                                       const mavlink_mission_request_int_t &packet,
+                                                       mavlink_mission_item_int_t &ret_packet)
+{
+    if (!get_item_as_mission_item(packet.seq, ret_packet)) {
+        return MAV_MISSION_INVALID_SEQUENCE;
+    }
     return MAV_MISSION_ACCEPTED;
 }
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Rally.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Rally.h
@@ -12,6 +12,11 @@ public:
     MAV_MISSION_RESULT complete(const GCS_MAVLINK &_link) override;
     void timeout() override;
 
+    /*
+      static function to get rally item as mavlink_mission_item_int_t
+    */
+    static bool get_item_as_mission_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet);
+    
 protected:
 
     ap_message next_item_ap_message_id() const override {


### PR DESCRIPTION
This exposes a @MISSION filesystem for upload and download of mission/fence/rally and extends @PARAM filesystem for parameter upload with ftp

mavproxy implementation: https://github.com/ArduPilot/MAVProxy/pull/880

working:
 - [x] mission download
 - [x] mission upload
 - [x] rally download
 - [x] fence download
 - [x] param upload