### PR TITLE
Bi-directional dshot for revo-mini

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-bdshot/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-bdshot/hwdef-bl.dat
@@ -1,0 +1,1 @@
+include ../revo-mini/hwdef-bl.dat

--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-bdshot/hwdef.dat
@@ -1,0 +1,13 @@
+# Bi-directional dshot version of revo-mini
+
+include ../revo-mini/hwdef.dat
+
+undef PB0 PB1 PA3 PA2 PA1 PA0
+
+PB0 TIM3_CH3  TIM3 PWM(1) GPIO(50)
+PB1 TIM3_CH4  TIM3 PWM(2) GPIO(51) BIDIR
+PA3 TIM2_CH4  TIM2 PWM(3) GPIO(52) BIDIR
+PA2 TIM2_CH3  TIM2 PWM(4) GPIO(53)
+
+undef BOARD_PWM_COUNT_DEFAULT
+define BOARD_PWM_COUNT_DEFAULT 4


### PR DESCRIPTION
Tested on Copter with BLHeli_S ESC with JazzMaverick FW 16.73.
DShot300 and DShot600 works good with ESC telemetry used for harmonic notch.
Thanks to @andyp1per 