### PR TITLE
Prioritize pitmode over power

### DIFF
--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -201,7 +201,14 @@ void AP_SmartAudio::update_vtx_params()
             }
         }
 
-        if (_vtx_freq_change_pending) {
+        if (pitMode) {// prevent power changes in pitmode as this takes the VTX out of pitmode
+            _vtx_power_change_pending = false;
+        }
+
+        // prioritize pitmode changes
+        if (_vtx_options_change_pending) {
+            set_operation_mode(mode);
+        } else if (_vtx_freq_change_pending) {
             if (_vtx_use_set_freq) {
                 set_frequency(vtx.get_configured_frequency_mhz(), false);
             } else {
@@ -224,8 +231,6 @@ void AP_SmartAudio::update_vtx_params()
                 }
                 break;
             }
-        } else if (_vtx_options_change_pending) {
-            set_operation_mode(mode);
         }
     }
 }

--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -183,8 +183,9 @@ void AP_SmartAudio::update_vtx_params()
         uint8_t pitModeRunning = (vtx.get_options() & uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE));
         uint8_t pitMode = opts & uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE);
         uint8_t mode;
-        // check if we are turning pitmode on or off
-        if (pitMode != pitModeRunning) {
+        // check if we are turning pitmode on or off, but only on SA 2.1 as older versions
+        // appear not to work properly
+        if (pitMode != pitModeRunning && _protocol_version >= SMARTAUDIO_SPEC_PROTOCOL_v21) {
             if (pitModeRunning) {
                 debug("Turning OFF pitmode");
                 // turn it off


### PR DESCRIPTION
Pending VTX power changes that cannot be actioned (e.g. because the VTX is not unlocked) will prevent the device going into pitmode.
VTX power changes when in pitmode will take the device out of pitmode.
This change makes sure pitmode gets precedence over power.