### PR TITLE
revo-mini variant with external I2C and respective bdshot 

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c-bdshot/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c-bdshot/hwdef-bl.dat
@@ -1,0 +1,1 @@
+include ../revo-mini-i2c/hwdef-bl.dat

--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c-bdshot/hwdef.dat
@@ -1,0 +1,13 @@
+# Bi-directional dshot version of revo-mini-i2c
+
+include ../revo-mini-i2c/hwdef.dat
+
+undef PB0 PB1 PA3 PA2 PA1 PA0
+
+PB0 TIM3_CH3  TIM3 PWM(1) GPIO(50)
+PB1 TIM3_CH4  TIM3 PWM(2) GPIO(51) BIDIR
+PA3 TIM2_CH4  TIM2 PWM(3) GPIO(52) BIDIR
+PA2 TIM2_CH3  TIM2 PWM(4) GPIO(53)
+
+undef BOARD_PWM_COUNT_DEFAULT
+define BOARD_PWM_COUNT_DEFAULT 4

--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c/hwdef-bl.dat
@@ -1,0 +1,42 @@
+# hw definition file for processing by chibios_pins.py
+# for minimal F405 bootloader
+
+# MCU class and specific type
+MCU STM32F4xx STM32F405xx
+
+# board ID for firmware load
+APJ_BOARD_ID 124
+
+# crystal frequency
+OSCILLATOR_HZ 8000000
+
+FLASH_SIZE_KB 1024
+
+# don't allow bootloader to use more than 16k
+FLASH_USE_MAX_KB 16
+
+# bootloader is installed at zero offset
+FLASH_RESERVE_START_KB 0
+
+# LEDs
+PB5 LED_BOOTLOADER OUTPUT LOW
+PB4 LED_ACTIVITY  OUTPUT LOW
+define HAL_LED_ON 0
+
+# the location where the bootloader will put the firmware
+FLASH_BOOTLOADER_LOAD_KB 64
+
+
+# order of UARTs
+SERIAL_ORDER OTG1
+
+PA11 OTG_FS_DM OTG1
+PA12 OTG_FS_DP OTG1
+
+define HAL_USE_EMPTY_STORAGE 1
+define HAL_STORAGE_SIZE 15360
+
+
+# Add CS pins to ensure they are high in bootloader
+PA4 MPU_CS CS
+PB3 FLASH_CS CS

--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-i2c/hwdef.dat
@@ -1,0 +1,137 @@
+# hw definition file for processing by chibios_pins.py
+# for Revo-Mini hardware
+
+# MCU class and specific type
+MCU STM32F4xx STM32F405xx
+
+# board ID for firmware load
+APJ_BOARD_ID 124
+
+# crystal frequency
+OSCILLATOR_HZ 8000000
+
+define STM32_ST_USE_TIMER 5
+
+FLASH_SIZE_KB 1024
+
+
+# use USB for stdout, so no STDOUT_SERIAL
+# STDOUT_SERIAL SD3
+# STDOUT_BAUDRATE 57600
+
+# two I2C bus: I2C1 internal, I2C2 external
+I2C_ORDER I2C1 I2C2
+
+# order of UARTs (and USB)
+SERIAL_ORDER OTG1 USART1 EMPTY USART6
+
+# rcinput is PB14, which is the 1st "PWM IN" pin (the white wire on a
+# revolution board)
+PB14 TIM12_CH1 TIM12 RCININT PULLDOWN LOW
+
+# analog pins
+PC3 VDD_5V_SENS ADC1
+PC2 BATT_VOLTAGE_SENS ADC1 SCALE(1)
+PC1 BATT_CURRENT_SENS ADC1 SCALE(1)
+PC5 USB_SENSE ADC1
+
+# define default battery setup
+define HAL_BATT_VOLT_PIN 12
+define HAL_BATT_CURR_PIN 11
+define HAL_BATT_VOLT_SCALE 10.1
+define HAL_BATT_CURR_SCALE 17.0
+
+
+PC0 SBUS_INVERT OUTPUT LOW
+
+# LEDs
+PB5 LED_BLUE OUTPUT LOW GPIO(0)
+PB6 LED_YELLOW OUTPUT LOW GPIO(1) # optional
+PB4 LED_RED OUTPUT LOW GPIO(2)
+
+# GPS port
+PC6 USART6_TX USART6
+PC7 USART6_RX USART6
+
+# flexi port for USART3, alternative config
+#PB10 USART3_TX USART3
+#PB11 USART3_RX USART3
+
+# main port, for telem1
+PA9 USART1_TX USART1
+PA10 USART1_RX USART1
+
+# flexi port, for external I2C
+PB10 I2C2_SCL I2C2
+PB11 I2C2_SDA I2C2
+
+# spi bus for IMU
+PA5 SPI1_SCK SPI1
+PA6 SPI1_MISO SPI1
+PA7 SPI1_MOSI SPI1
+
+# spi bus for dataflash
+PC10 SPI3_SCK SPI3
+PC11 SPI3_MISO SPI3
+PC12 SPI3_MOSI SPI3
+
+# IRQ for MPU6000
+PC4 EXTI_MPU6000 INPUT
+
+# PA10 IO-debug-console
+PA11 OTG_FS_DM OTG1
+PA12 OTG_FS_DP OTG1
+
+PA13 JTMS-SWDIO SWD
+PA14 JTCK-SWCLK SWD
+
+# only one I2C bus in normal config
+PB8 I2C1_SCL I2C1
+PB9 I2C1_SDA I2C1
+
+# SPI chip selects
+PA4 MPU_CS CS
+PB3 FLASH_CS CS
+
+# PWM out pins
+PB0 TIM3_CH3 TIM3 PWM(1) GPIO(50)
+PB1 TIM3_CH4 TIM3 PWM(2) GPIO(51)
+PA3 TIM2_CH4 TIM2 PWM(3) GPIO(52)
+PA2 TIM2_CH3 TIM2 PWM(4) GPIO(53)
+PA1 TIM2_CH2 TIM2 PWM(5) GPIO(54)
+PA0 TIM2_CH1 TIM2 PWM(6) GPIO(55)
+# disable last two channels as conflicts with TIM8 for RCIN
+#PC8 TIM8_CH3 TIM8 PWM(7) GPIO(56)
+#PC9 TIM8_CH4 TIM8 PWM(8) GPIO(57)
+
+PB7 DRDY_HMC5883 INPUT PULLUP
+
+define HAL_STORAGE_SIZE 15360
+define STORAGE_FLASH_PAGE 2
+
+# reserve 32k for bootloader and 32k for flash storage
+FLASH_RESERVE_START_KB 64
+
+# one IMU
+IMU Invensense SPI:mpu6000 ROTATION_YAW_180
+
+# one baro
+BARO MS56XX I2C:0:0x77
+
+# also allow for probing of external barometers
+define HAL_PROBE_EXTERNAL_I2C_BAROS
+
+# look for internal I2C compass
+COMPASS HMC5843 I2C:0:0x1E false ROTATION_YAW_270
+
+# SPI devices
+SPIDEV mpu6000   SPI1 DEVID1 MPU_CS   MODE3 1*MHZ 8*MHZ 
+SPIDEV dataflash SPI3 DEVID1 FLASH_CS MODE3 32*MHZ 32*MHZ
+
+# enable logging to dataflash
+define HAL_LOGGING_DATAFLASH
+
+# 6 PWM available by default
+define BOARD_PWM_COUNT_DEFAULT 6
+define HAL_WITH_DSP FALSE
+


### PR DESCRIPTION
A new hardware config for revo-mini with name revo-mini-i2c + bdshot version (revo-mini-i2c-bdshot) with the purpose of use external I2C.

Some difference in the signal port assignment:

revo-mini (actual on master)
-------------------------------------

Main Port (Serial1)
1   GND
2   VCC
3   USART1 TX (**PA9**)
4   USART1 RX (**PA10**)

Flexi Port (Serial3)
1   GND
2   VCC
3   USART3 TX (**PB10**)
4   USART3 RX (**PB11**)

RC Input (Flexi-IO) on **Revolution**
1    GND
2    VCC
3    NN
4    NN
5    NN
6    NN
7    RC in (**PC6**)
8    NN
9    PWM7 (on wiki but on hwdef.dat commented out for conflicts)
10   PWM8 (on wiki but on hwdef.dat commented out for conflicts)

RC Input on **RevoMini**
1    GND
2    VCC
3    NN
4    NN
5    RC in (**PC6**)
6    NN
7    PWM7 (on wiki but on hwdef.dat commented out for conflicts)
8    PWM8 (on wiki but on hwdef.dat commented out for conflicts)

revo-mini-i2c (from this PR)
------------------------------------

Main Port (Serial1)
1   GND
2   VCC
3   USART1 TX (**PA9**)
4   USART1 RX (**PA10**)

Flexi Port (Ext I2C)
1   GND
2   VCC
3   I2C2 SCL (**PB10**)
4   I2C2 SDA (**PB11**)

RC Input (Flexi-IO) on **Revolution**
1    GND
2    VCC
3    NN
4    NN
5    RC in (**PB14**)
6    NN
7    UART6 TX (**PC6**) (Serial3)
8    UART6 RX (**PC7**)
9    NN
10   NN

RC Input on **RevoMini**
1    GND
2    VCC
3    RC in (**PB14**)
4    NN
5    UART6 TX (**PC6**) (Serial3)
6    UART6 RX (**PC7**)
7    NN
8    NN
