### PR TITLE
AP_Scripting: correct rotations in fault tolerant hex example

### DIFF
--- a/libraries/AP_Scripting/examples/MotorMatrix_fault_tolerant_hex.lua
+++ b/libraries/AP_Scripting/examples/MotorMatrix_fault_tolerant_hex.lua
@@ -14,7 +14,7 @@ local AP_MOTORS_MOT_4 = 3
 local AP_MOTORS_MOT_5 = 4
 local AP_MOTORS_MOT_6 = 5
 
--- helper function duplication the one found in AP_MotorsMatrix
+-- helper function duplication of the one found in AP_MotorsMatrix
 local function add_motor(motor_num, angle_degrees, yaw_factor, testing_order)
 
     MotorsMatrix:add_motor_raw(motor_num,math.cos(math.rad(angle_degrees + 90)),
@@ -27,9 +27,9 @@ end
 -- this duplicates the add motor format used in AP_Motors for ease of modification of existing mixes
 add_motor(AP_MOTORS_MOT_1,  90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2)
 add_motor(AP_MOTORS_MOT_2, -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5)
-add_motor(AP_MOTORS_MOT_3, -30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6)
+add_motor(AP_MOTORS_MOT_3, -30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 6)
 add_motor(AP_MOTORS_MOT_4, 150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3)
-add_motor(AP_MOTORS_MOT_5,  30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1)
+add_motor(AP_MOTORS_MOT_5,  30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1)
 add_motor(AP_MOTORS_MOT_6,-150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  4)
 
 assert(MotorsMatrix:init(6), "Failed to init MotorsMatrix")


### PR DESCRIPTION
My fault tollerant hex example is just a normal hex mixer, I guess I was testing it in realflight and never put it back, ooops.

Thanks to @tkhamvilai for spotting my mistake. https://github.com/ArduPilot/ardupilot/pull/16563#issuecomment-814343333