### PR TITLE
AC_WPNav: fix takeoff drift if vehicle is not in origin

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -371,15 +371,14 @@ bool AC_WPNav::set_wp_destination_next_NED(const Vector3f& destination_NED)
 ///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
 void AC_WPNav::shift_wp_origin_to_current_pos()
 {
-    // get current and target locations
+    // get current locations
     const Vector3f &curr_pos = _inav.get_position();
-    const Vector3f pos_target = _pos_control.get_pos_target();
 
-    // calculate difference between current position and target
-    Vector3f pos_diff = curr_pos - pos_target;
+    // calculate difference between current position and origin
+    Vector3f pos_diff = curr_pos - _origin;
 
     // shift origin and destination
-    _origin += pos_diff;
+    _origin = curr_pos;
     _destination += pos_diff;
 
     // move pos controller target and disable feed forward


### PR DESCRIPTION
Both dbe1c5566680248ec2e7855166ed823c4966c55e and comments in `shift_wp_origin_to_current_pos()` states this function  shifts the origin and destination so the **origin starts at the current position**. But its implementation seems incorrect. Everything was fine before, because it returns early if vehicle is not in origin https://github.com/ArduPilot/ardupilot/blob/d66101d22f70a3096369825c2d80ab3fce457314/libraries/AC_WPNav/AC_WPNav.cpp#L282-L285

But `_track_desired` assignment is removed when #15896 merged, it will always be zero and it never return early. This may cause a horizontal drift when vehicle takeoff.
[20 2021-4-8 am 09-41-18.zip](https://github.com/ArduPilot/ardupilot/files/6284392/20.2021-4-8.am.09-41-18.zip)
![Log Browser - 20 2021-4-8 上午 09-41-18 bin 2021_4_9 上午 11_22_14](https://user-images.githubusercontent.com/19793511/114154947-86553b00-9953-11eb-9897-60010102012b.png)

This PR fix this problem by implementing this function as its comments state. Test flights using motion capture system and ext nav.
[25 2021-4-9 PM 03-43-38.zip](https://github.com/ArduPilot/ardupilot/files/6284407/25.2021-4-9.PM.03-43-38.zip)
[26 2021-4-9 PM 03-45-20.zip](https://github.com/ArduPilot/ardupilot/files/6284408/26.2021-4-9.PM.03-45-20.zip)

related to #16478)
