### PR TITLE
add support for mavlink events interface

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -490,6 +490,21 @@ private:
         BLOCK      = (1<<2),
     };
 
+    struct MAVLinkEventInterfaceQueue {
+        uint32_t mavlink_event_id;
+        uint32_t time_boot_ms;
+        uint16_t seqno;
+        uint8_t log_level;
+        uint8_t args[1];  // uint8_t[40] in the mavlink message
+    } mavlink_event_interface_queue[5];
+    uint8_t next_mavlink_event_interface_queue_entry;
+    bool queue_full;
+    uint16_t mavlink_event_interface_seq;
+    void queue_entry_to_event_message(mavlink_event_t &packet, const MAVLinkEventInterfaceQueue &entry);
+    void send_mavlink_event_interface_queue_entry(const MAVLinkEventInterfaceQueue &entry);
+    void send_mavlink_event_interface_queue_entry(const MAVLinkEventInterfaceQueue &entry, const GCS_MAVLINK &link);
+    void handle_message_request_event(GCS_MAVLINK &link, const mavlink_message_t &msg);
+
     /*
      * support for dynamic Write; user-supplies name, format,
      * labels and values in a single function call.

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3406,6 +3406,7 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_LOG_ERASE:
     case MAVLINK_MSG_ID_LOG_REQUEST_END:
     case MAVLINK_MSG_ID_REMOTE_LOG_BLOCK_STATUS:
+    case MAVLINK_MSG_ID_REQUEST_EVENT:
         AP::logger().handle_mavlink_msg(*this, msg);
         break;
 


### PR DESCRIPTION
- [ ] Move event interface to either be an `AP_Event` thing or `AP::vehicle().event(...)`/`AP::vehicle().error(...)`; it both logs and handles the mavlink queueing side of things rather than stuffing everything into AP_Logger
- [ ] provide the metadata to allow mapping back from the ID and provided arguments to an error string the GCS can present
- [ ] chase packet weirdnesses tracked in upstream PR (https://github.com/mavlink/mavlink/pull/1531/files)
- [ ] periodic broadcast of `CURRENT_EVENT_SEQUENCE` (1Hz?)
- [ ] determine if this really can help us remove vast swathes of text strings from our codebase
- [ ] work out what to do with `compid_this_mav`
