### PR TITLE
Copter: loiter-turns fix

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1185,7 +1185,6 @@ bool ModeAuto::set_next_wp(const AP_Mission::Mission_Command& current_cmd, const
     switch (next_cmd.id) {
     case MAV_CMD_NAV_WAYPOINT:
     case MAV_CMD_NAV_LOITER_UNLIM:
-    case MAV_CMD_NAV_LOITER_TURNS:
     case MAV_CMD_NAV_LOITER_TIME: {
         const Location dest_loc = loc_from_cmd(current_cmd, default_loc);
         const Location next_dest_loc = loc_from_cmd(next_cmd, dest_loc);
@@ -1200,6 +1199,7 @@ bool ModeAuto::set_next_wp(const AP_Mission::Mission_Command& current_cmd, const
     }
     case MAV_CMD_NAV_LAND:
         // stop because we may change between rel,abs and terrain alt types
+    case MAV_CMD_NAV_LOITER_TURNS:
     case MAV_CMD_NAV_RETURN_TO_LAUNCH:
     case MAV_CMD_NAV_TAKEOFF:
         // always stop for RTL and takeoff commands


### PR DESCRIPTION
This fixes Auto flying LOITER_TURNS mission command with a lat,lon,alt specified and resolves issue: https://github.com/ArduPilot/ardupilot/issues/17126

The problem was that we were passing the loiter-turns lat,lon,alt to SCurves as the "next" destination.  This is incorrect because the vehicle will never actually travel to the lat,lon,alt within the loiter-turns command.  Instead it will fly to that location + circle radius.

The easy solution is just to *not* pass the loiter-turns command location to SCurves which is what this PR does.  A future enhancement would be to actually calculate where the edge of the circle will be and pass that into SCurves.  This would avoid a stop at the waypoint before the loiter-turns command.

This has been tested in SITL and below is a picture of a Copter flying a circle.  Previously it would get stuck after having flown to the center of the circle.
![image](https://user-images.githubusercontent.com/1498098/114297918-7f166480-9aee-11eb-9ccd-833e78bd0510.png)


