### PR TITLE
AP_KDECAN: map channel to motors directly (attempt 2)

### DIFF
--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @Param: PROTOCOL
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
-    // @Values{Copter,Plane,Sub}: 0:Disabled,1:UAVCAN,2:KDECAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester
+    // @Values{Copter,Plane,Sub,Rover}: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,8:KDECAN
     // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1
     // @User: Advanced
     // @RebootRequired: True

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -53,12 +53,13 @@ public:
     enum Driver_Type : uint8_t {
         Driver_Type_None = 0,
         Driver_Type_UAVCAN = 1,
-        Driver_Type_KDECAN = 2,
+        // 2 was KDECAN -- do not re-use
         Driver_Type_ToshibaCAN = 3,
         Driver_Type_PiccoloCAN = 4,
         Driver_Type_CANTester = 5,
         Driver_Type_EFI_NWPMU = 6,
         Driver_Type_USD1 = 7,
+        Driver_Type_KDECAN = 8,
     };
 
     void init(void);

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -628,13 +628,12 @@ void AP_KDECAN::update()
 bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
 {
     if (!_enum_sem.take(1)) {
-        debug_can(AP_CANManager::LOG_DEBUG, "failed to get enumeration semaphore on read");
-        snprintf(reason, reason_len ,"Enumeration state unknown");
+        snprintf(reason, reason_len ,"enumeration state unknown");
         return false;
     }
 
     if (_enumeration_state != ENUMERATION_STOPPED) {
-        snprintf(reason, reason_len ,"Enumeration running");
+        snprintf(reason, reason_len, "enumeration running");
         _enum_sem.give();
         return false;
     }
@@ -652,17 +651,17 @@ bool AP_KDECAN::pre_arm_check(char* reason, uint8_t reason_len)
     uint8_t num_present_escs = __builtin_popcount(_esc_present_bitmask);
 
     if (num_present_escs < num_expected_motors) {
-        snprintf(reason, reason_len, "Too few ESCs detected");
+        snprintf(reason, reason_len, "too few ESCs detected (%u of %u)", (int)num_present_escs, (int)num_expected_motors);
         return false;
     }
 
     if (num_present_escs > num_expected_motors) {
-        snprintf(reason, reason_len, "Too many ESCs detected");
+        snprintf(reason, reason_len, "too many ESCs detected (%u > %u)", (int)num_present_escs, (int)num_expected_motors);
         return false;
     }
 
     if (_esc_max_node_id != num_expected_motors) {
-        snprintf(reason, reason_len, "Wrong node IDs, run enumeration");
+        snprintf(reason, reason_len, "wrong node IDs (%u!=%u), run enumeration", (int)_esc_max_node_id, (int)num_expected_motors);
         return false;
     }
 

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -570,17 +570,10 @@ void AP_KDECAN::update()
     if (_rc_out_sem.take(1)) {
         for (uint8_t i = 0; i < KDECAN_MAX_NUM_ESCS; i++) {
             if ((_esc_present_bitmask & (1 << i)) == 0) {
+                _scaled_output[i] = 0;
                 continue;
             }
-
-            SRV_Channel::Aux_servo_function_t motor_function = SRV_Channels::get_motor_function(i);
-
-            if (SRV_Channels::function_assigned(motor_function)) {
-                float norm_output = SRV_Channels::get_output_norm(motor_function);
-                _scaled_output[i] = uint16_t((norm_output + 1.0f) / 2.0f * 2000.0f);
-            } else {
-                _scaled_output[i] = 0;
-            }
+            _scaled_output[i] = SRV_Channels::srv_channel(i)->get_output_pwm();
         }
 
         _rc_out_sem.give();

--- a/libraries/AP_KDECAN/AP_KDECAN.h
+++ b/libraries/AP_KDECAN/AP_KDECAN.h
@@ -104,7 +104,7 @@ private:
 
 
     union frame_id_t {
-        struct {
+        struct PACKED {
             uint8_t object_address;
             uint8_t destination_id;
             uint8_t source_id;


### PR DESCRIPTION
This PR makes four small but perhaps important changes to the KDECAN driver:

- ESC id is mapped to the servo output channel rather than the SERVOx_FUNCTION::motor1 ~ motor12.  This makes KDECAN ESCs consistent with other ESC (UAVCAN, ToshibaCAN) and means that they can be used for vehicles besides Copter.
- The servo output channel's PWM is sent directly to the ESC without any scaling.  This resolves issue https://github.com/ArduPilot/ardupilot/issues/16905 in which the ESCs were not spinning until the throttle was raised to 50%.  From experimenting with the ESCs it seems that they treat the 0~2000 value sent over CAN just like a PWM value.  For example, the ESCs will even try to dynamically learn the range of the incoming value just like they would for a PWM.
- Pre-arm check messages are slightly improved to tell the user how many ESCs are found/missing, etc.
- KDE's enum in CAN_Dx_PROTOCOL is changed from "2" to "8" meaning old configurations of KDECAN will require at least some user intervention to start working again in the hopes the users will check the wiki or release notes and adjust the wiring and/or parameters to get KDECAN working again safely.

This replaces PR https://github.com/ArduPilot/ardupilot/pull/16752 and resolves issue https://github.com/ArduPilot/ardupilot/issues/16905

This has been tested on real hardware.

The wiki will need updating to fix:

- Instructions on wiring (the pins are completely reversed from the standard CAN cables)
- CAN_Dx_PROTOCOL setting to "8"
- KDE Direct Device Manager application settings:
  - KDECAN CONTROL: CAN BUS
  - THROTTLE CALIBRATION RANGE: 1000 2000
  - KDECAN ESC ID: Fixed 02, 03, 04, etc

By the way, I found two other issues with the driver:

- The ESCs must be powered before or at the same time as the autopilot or the driver won't find the ESCs
- If the ESCs are present at startup but are disconnected later (before takeoff) the pre-arm checks won't notice and stop arming

Thanks very much to @bugobliterator for his assistance with these changes and to Argodyne for providing the hardware.