### PR TITLE
Copter: timestamp-correct landing target data before passing into AC_PrecLand

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -568,6 +568,16 @@ void GCS_MAVLINK_Copter::handle_command_ack(const mavlink_message_t &msg)
     GCS_MAVLINK::handle_command_ack(msg);
 }
 
+/*
+  handle a LANDING_TARGET command. The timestamp has been jitter corrected
+*/
+void GCS_MAVLINK_Copter::handle_landing_target(const mavlink_landing_target_t &packet, uint32_t timestamp_ms)
+{
+#if PRECISION_LANDING == ENABLED
+    copter.precland.handle_msg(packet, timestamp_ms);
+#endif
+}
+
 MAV_RESULT GCS_MAVLINK_Copter::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
 {
     if (is_equal(packet.param6,1.0f)) {
@@ -1280,12 +1290,6 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         handle_radio_status(msg, copter.should_log(MASK_LOG_PM));
         break;
     }
-
-#if PRECISION_LANDING == ENABLED
-    case MAVLINK_MSG_ID_LANDING_TARGET:
-        copter.precland.handle_msg(msg);
-        break;
-#endif
 
     case MAVLINK_MSG_ID_TERRAIN_DATA:
     case MAVLINK_MSG_ID_TERRAIN_CHECK:

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -35,6 +35,8 @@ protected:
 
     void handle_mount_message(const mavlink_message_t &msg) override;
 
+    void handle_landing_target(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) override;
+
     bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
     bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     void send_nav_controller_output() const override;

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -263,11 +263,11 @@ bool AC_PrecLand::get_target_velocity_relative_cms(Vector2f& ret)
 }
 
 // handle_msg - Process a LANDING_TARGET mavlink message
-void AC_PrecLand::handle_msg(const mavlink_message_t &msg)
+void AC_PrecLand::handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms)
 {
     // run backend update
     if (_backend != nullptr) {
-        _backend->handle_msg(msg);
+        _backend->handle_msg(packet, timestamp_ms);
     }
 }
 

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -86,7 +86,7 @@ public:
     bool target_acquired();
 
     // process a LANDING_TARGET mavlink message
-    void handle_msg(const mavlink_message_t &msg);
+    void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms);
 
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -35,7 +35,7 @@ public:
     virtual float distance_to_target() { return 0.0f; };
 
     // parses a mavlink message from the companion computer
-    virtual void handle_msg(const mavlink_message_t &msg) {};
+    virtual void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) {};
 
     // get bus parameter
     int8_t get_bus(void) const { return _frontend._bus.get(); }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -42,18 +42,14 @@ float AC_PrecLand_Companion::distance_to_target()
     return _distance_to_target;
 }
 
-void AC_PrecLand_Companion::handle_msg(const mavlink_message_t &msg)
+void AC_PrecLand_Companion::handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms)
 {
-    // parse mavlink message
-    __mavlink_landing_target_t packet;
-    mavlink_msg_landing_target_decode(&msg, &packet);
-
     _distance_to_target = packet.distance;
 
     // compute unit vector towards target
     _los_meas_body = Vector3f(-tanf(packet.angle_y), tanf(packet.angle_x), 1.0f);
     _los_meas_body /= _los_meas_body.length();
 
-    _los_meas_time_ms = AP_HAL::millis();
+    _los_meas_time_ms = timestamp_ms;
     _have_los_meas = true;
 }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -36,7 +36,7 @@ public:
     float distance_to_target() override;
 
     // parses a mavlink message from the companion computer
-    void handle_msg(const mavlink_message_t &msg) override;
+    void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) override;
 
 private:
     float               _distance_to_target;    // distance from the camera to target in meters

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -504,6 +504,8 @@ protected:
 
     MAV_RESULT handle_fixed_mag_cal_yaw(const mavlink_command_long_t &packet);
 
+    // default empty handling of LANDING_TARGET
+    virtual void handle_landing_target(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) { }
     // vehicle-overridable message send function
     virtual bool try_send_message(enum ap_message id);
     virtual void send_global_position_int();
@@ -802,6 +804,7 @@ private:
                                                      const uint8_t reset_counter,
                                                      const uint16_t payload_size);
     void handle_vision_speed_estimate(const mavlink_message_t &msg);
+    void handle_landing_target(const mavlink_message_t &msg);
 
     void lock_channel(const mavlink_channel_t chan, bool lock);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3561,6 +3561,10 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_OSD_PARAM_SHOW_CONFIG:
         handle_osd_param_config(msg);
         break;
+
+    case MAVLINK_MSG_ID_LANDING_TARGET:
+        handle_landing_target(msg);
+        break;
     }
 
 }
@@ -4349,6 +4353,17 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const Location &roi_loc)
     return MAV_RESULT_UNSUPPORTED;
 #endif
 }
+
+
+void GCS_MAVLINK::handle_landing_target(const mavlink_message_t &msg)
+{
+    mavlink_landing_target_t m;
+    mavlink_msg_landing_target_decode(&msg, &m);
+    // correct offboard timestamp
+    const uint32_t corrected_ms = correct_offboard_timestamp_usec_to_ms(m.time_usec, PAYLOAD_SIZE(chan, LANDING_TARGET));
+    handle_landing_target(m, corrected_ms);
+}
+
 
 MAV_RESULT GCS_MAVLINK::handle_command_int_do_set_home(const mavlink_command_int_t &packet)
 {


### PR DESCRIPTION
This has been extracted from https://github.com/ArduPilot/ardupilot/pull/11339 as being a stand-alone change - and only affects Copter in master.

This has been adjusted from that original PR in method-naming and return-codes; `LANDING_TARGET` is not a command (just a message) and shouldn't look like one in our code.

Primarily this PR moves the decode of the message up into GCS_MAVLink so the timestamp can be adjusted (we need to have the uart do that), and the call path into AC_PrecLand gets an additional "true timestamp" parameter.  We use that corrected timestamp within AC_PrecLand in place of the value directly from the packet.

This code is tested in autotest via `test.Copter.PrecisionLoiterCompanion` .  I verified we cross these codepaths using GDB, and verified that the flight paths are the same before/after this patch set.
