### PR TITLE
Tidy filling in of sensor status flags

### DIFF
--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -8,27 +8,28 @@ uint8_t GCS_Plane::sysid_this_mav() const
 
 void GCS_Plane::update_vehicle_sensor_status_flags(void)
 {
-    // first what sensors/controllers we have
+    // airspeed
     const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed && airspeed->enabled()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
     }
-#if OPTFLOW == ENABLED
-    const OpticalFlow *optflow = AP::opticalflow();
-    if (optflow && optflow->enabled()) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
-    }
-#endif
-
-    if (plane.have_reverse_thrust()) {
-        control_sensors_present |= MAV_SYS_STATUS_REVERSE_MOTOR;
-    }
-
     if (airspeed && airspeed->enabled() && airspeed->use()) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
     }
+    if (airspeed && airspeed->all_healthy()) {
+        control_sensors_health |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
+    }
 
+    // reverse thrust
+    if (plane.have_reverse_thrust()) {
+        control_sensors_present |= MAV_SYS_STATUS_REVERSE_MOTOR;
+    }
+    if (plane.have_reverse_thrust() && SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) < 0) {
+        control_sensors_enabled |= MAV_SYS_STATUS_REVERSE_MOTOR;
+        control_sensors_health |= MAV_SYS_STATUS_REVERSE_MOTOR;
+    }
+
+    // flightmode-specific
     control_sensors_present |=
         MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL |
         MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION |
@@ -101,13 +102,15 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
     }
 
 #if OPTFLOW == ENABLED
+    const OpticalFlow *optflow = AP::opticalflow();
+    if (optflow && optflow->enabled()) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
+    }
     if (optflow && optflow->healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
     }
 #endif
-    if (airspeed && airspeed->all_healthy()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
-    }
 
     control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
     control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
@@ -140,10 +143,5 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
         if (rangefinder->has_data_orient(ROTATION_PITCH_270)) {
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;            
         }
-    }
-
-    if (plane.have_reverse_thrust() && SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) < 0) {
-        control_sensors_enabled |= MAV_SYS_STATUS_REVERSE_MOTOR;
-        control_sensors_health |= MAV_SYS_STATUS_REVERSE_MOTOR;
     }
 }

--- a/Blimp/GCS_Blimp.cpp
+++ b/Blimp/GCS_Blimp.cpp
@@ -14,6 +14,7 @@ const char* GCS_Blimp::frame_string() const
 
 void GCS_Blimp::update_vehicle_sensor_status_flags(void)
 {
+    // mode-specific flags:
     control_sensors_present |=
         MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL |
         MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION |
@@ -29,18 +30,16 @@ void GCS_Blimp::update_vehicle_sensor_status_flags(void)
         MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION |
         MAV_SYS_STATUS_SENSOR_YAW_POSITION;
 
+    control_sensors_present |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
+    control_sensors_present |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
+
     const Blimp::ap_t &ap = blimp.ap;
 
     if (ap.rc_receiver_present) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
     }
-
-    control_sensors_present |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
-    control_sensors_present |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
-
     if (ap.rc_receiver_present && !blimp.failsafe.radio) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
     }
-
 }

--- a/Rover/GCS_Rover.cpp
+++ b/Rover/GCS_Rover.cpp
@@ -27,15 +27,7 @@ bool GCS_Rover::supersimple_input_active() const
 
 void GCS_Rover::update_vehicle_sensor_status_flags(void)
 {
-    // first what sensors/controllers we have
-#if HAL_PROXIMITY_ENABLED
-    const AP_Proximity *proximity = AP_Proximity::get_singleton();
-    if (proximity && proximity->get_status() > AP_Proximity::Status::NotConnected) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-    }
-#endif
-
+    // mode-specific:
     control_sensors_present |=
         MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL |
         MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION |
@@ -55,6 +47,17 @@ void GCS_Rover::update_vehicle_sensor_status_flags(void)
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL; // X/Y position control
     }
 
+#if HAL_PROXIMITY_ENABLED
+    const AP_Proximity *proximity = AP_Proximity::get_singleton();
+    if (proximity && proximity->get_status() > AP_Proximity::Status::NotConnected) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
+    }
+    if (proximity && proximity->get_status() != AP_Proximity::Status::NoData) {
+        control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
+    }
+#endif
+
     const RangeFinder *rangefinder = RangeFinder::get_singleton();
     if (rangefinder && rangefinder->num_sensors() > 0) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
@@ -64,10 +67,4 @@ void GCS_Rover::update_vehicle_sensor_status_flags(void)
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
     }
-
-#if HAL_PROXIMITY_ENABLED
-    if (proximity && proximity->get_status() != AP_Proximity::Status::NoData) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-    }
-#endif
 }


### PR DESCRIPTION
This completes a transformation started quite some time ago, where we fill in all of present, enabled and healthy in the one place in these functions, rather than scattering them throughout.

I've tried very hard to make this a simple rearrangement, not optimising the code.

Doing this will allow future enhancements like lifting the code for OpticalFlow up into GCS_MAVLink/GCS.cpp as it is common between three vehicles (we would need to move to `HAL_OPTICALFLOW_ENABLED` for that).

This should make handling these less error-prone in the meantime, too.  This PR was motivated by a bug in a PR where flags were not being filled in appropriately (incomplete copy/paste).
