### PR TITLE
Copter: remove unused AP_IRLock include

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -113,7 +113,6 @@
 #endif
 #if PRECISION_LANDING == ENABLED
  # include <AC_PrecLand/AC_PrecLand.h>
- # include <AP_IRLock/AP_IRLock.h>
 #endif
 #if MODE_FOLLOW_ENABLED == ENABLED
  # include <AP_Follow/AP_Follow.h>


### PR DESCRIPTION
This header is included as required by the AC_PrecLand library - it is
now responsible for actually instantiating the AP_IRLock instance if
required, so Copter doesn't need to know anything about AP_IRLock.