### PR TITLE
Copter: stop sending POSITION_TARGET_LOCAL_NED in guided-angle mode 

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -792,7 +792,7 @@ private:
 #if FRAME_CONFIG == HELI_FRAME
     void Log_Write_Heli(void);
 #endif
-    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
+    void Log_Write_GuidedTarget(ModeGuided::SubMode submode, const Vector3f& pos_target, const Vector3f& vel_target);
     void Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out);
     void Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq, float angle_x, float angle_y, float angle_z, float accel_x, float accel_y, float accel_z);
     void Log_Write_Vehicle_Startup_Messages();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -126,16 +126,16 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     if (!copter.flightmode->in_guided_mode()) {
         return;
     }
-    
-    const GuidedMode guided_mode = copter.mode_guided.mode();
+
+    const ModeGuided::SubMode guided_mode = copter.mode_guided.submode();
     Vector3f target_pos;
     Vector3f target_vel;
     uint16_t type_mask;
 
-    if (guided_mode == Guided_WP) {
+    if (guided_mode == ModeGuided::SubMode::WP) {
         type_mask = 0x0FF8; // ignore everything except position
         target_pos = copter.wp_nav->get_wp_destination() * 0.01f; // convert to metres
-    } else if (guided_mode == Guided_Velocity) {
+    } else if (guided_mode == ModeGuided::SubMode::Velocity) {
         type_mask = 0x0FC7; // ignore everything except velocity
         target_vel = copter.flightmode->get_desired_velocity() * 0.01f; // convert to m/s
     } else {

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -130,18 +130,26 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     const ModeGuided::SubMode guided_mode = copter.mode_guided.submode();
     Vector3f target_pos;
     Vector3f target_vel;
-    uint16_t type_mask;
+    uint16_t type_mask = 0;
 
-    if (guided_mode == ModeGuided::SubMode::WP) {
+    switch (guided_mode) {
+    case ModeGuided::SubMode::Angle:
+        // we don't have a local target when in angle mode
+        return;
+    case ModeGuided::SubMode::WP:
         type_mask = 0x0FF8; // ignore everything except position
         target_pos = copter.wp_nav->get_wp_destination() * 0.01f; // convert to metres
-    } else if (guided_mode == ModeGuided::SubMode::Velocity) {
+        break;
+    case ModeGuided::SubMode::Velocity:
         type_mask = 0x0FC7; // ignore everything except velocity
         target_vel = copter.flightmode->get_desired_velocity() * 0.01f; // convert to m/s
-    } else {
+        break;
+    case ModeGuided::SubMode::TakeOff:
+    case ModeGuided::SubMode::PosVel:
         type_mask = 0x0FC0; // ignore everything except position & velocity
         target_pos = copter.wp_nav->get_wp_destination() * 0.01f;
         target_vel = copter.flightmode->get_desired_velocity() * 0.01f;
+        break;
     }
 
     mavlink_msg_position_target_local_ned_send(

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -382,12 +382,12 @@ struct PACKED log_GuidedTarget {
 // Write a Guided mode target
 // pos_target is lat, lon, alt OR offset from ekf origin in cm OR roll, pitch, yaw target in centi-degrees
 // vel_target is cm/s
-void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target)
+void Copter::Log_Write_GuidedTarget(ModeGuided::SubMode target_type, const Vector3f& pos_target, const Vector3f& vel_target)
 {
     struct log_GuidedTarget pkt = {
         LOG_PACKET_HEADER_INIT(LOG_GUIDEDTARGET_MSG),
         time_us         : AP_HAL::micros64(),
-        type            : target_type,
+        type            : (uint8_t)target_type,
         pos_target_x    : pos_target.x,
         pos_target_y    : pos_target.y,
         pos_target_z    : pos_target.z,
@@ -571,7 +571,7 @@ void Copter::Log_Write_Data(LogDataID id, uint16_t value) {}
 void Copter::Log_Write_Data(LogDataID id, float value) {}
 void Copter::Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, float tune_min, float tune_max) {}
 void Copter::Log_Sensor_Health() {}
-void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}
+void Copter::Log_Write_GuidedTarget(ModeGuided::SubMode&, const Vector3f& pos_target, const Vector3f& vel_target) {}
 void Copter::Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out) {}
 void Copter::Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq, float angle_x, float angle_y, float angle_z, float accel_x, float accel_y, float accel_z) {}
 void Copter::Log_Write_Vehicle_Startup_Messages() {}

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -97,15 +97,6 @@ enum AutoMode {
     Auto_NavPayloadPlace,
 };
 
-// Guided modes
-enum GuidedMode {
-    Guided_TakeOff,
-    Guided_WP,
-    Guided_Velocity,
-    Guided_PosVel,
-    Guided_Angle,
-};
-
 // Airmode
 enum class AirMode {
     AIRMODE_NONE,

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -846,7 +846,15 @@ public:
 
     bool do_user_takeoff_start(float takeoff_alt_cm) override;
 
-    GuidedMode mode() const { return guided_mode; }
+    enum class SubMode {
+        TakeOff,
+        WP,
+        Velocity,
+        PosVel,
+        Angle,
+    };
+
+    SubMode submode() const { return guided_mode; }
 
     void angle_control_start();
     void angle_control_run();
@@ -881,7 +889,7 @@ private:
     bool use_pilot_yaw(void) const;
 
     // controls which controller is run (pos or vel):
-    GuidedMode guided_mode = Guided_TakeOff;
+    SubMode guided_mode = SubMode::TakeOff;
     bool send_notification;     // used to send one time notification to ground station
 
 };


### PR DESCRIPTION
The message is not relevant when doing angle-control.

This issue became apparent when moving Guided_Mode to be an enum-class on mode-guided, something I wanted to do as part of having a "landing" submode in guided (rather than it currently just switching to mode-land.  In any case, using `case` statements means people need to think about things when adding a new submode.
