### PR TITLE
AP_RangeFinder: add get_temp() and implement for NMEA driver

### DIFF
--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -46,9 +46,7 @@ void Rover::Log_Write_Depth()
 
     // get position
     Location loc;
-    if (!ahrs.get_position(loc)) {
-        return;
-    }
+    IGNORE_RETURN(ahrs.get_position(loc));
 
     // check if new sensor reading has arrived
     uint32_t reading_ms = rangefinder.last_reading_ms(ROTATION_PITCH_270);

--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -57,19 +57,27 @@ void Rover::Log_Write_Depth()
     }
     rangefinder_last_reading_ms = reading_ms;
 
+    // get temperature
+    float temp_C;
+    if (!rangefinder.get_temp(ROTATION_PITCH_270, temp_C)) {
+        temp_C = 0.0f;
+    }
+
 // @LoggerMessage: DPTH
 // @Description: Depth messages on boats with downwards facing range finder
 // @Field: TimeUS: Time since system startup
 // @Field: Lat: Latitude 
 // @Field: Lng: Longitude   
 // @Field: Depth: Depth as detected by the sensor
+// @Field: Temp: Temperature
 
-    logger.Write("DPTH", "TimeUS,Lat,Lng,Depth",
-                        "sDUm", "FGG0", "QLLf",
+    logger.Write("DPTH", "TimeUS,Lat,Lng,Depth,Temp",
+                        "sDUmO", "FGG00", "QLLff",
                         AP_HAL::micros64(),
                         loc.lat,
                         loc.lng,
-                        (double)(rangefinder.distance_cm_orient(ROTATION_PITCH_270) * 0.01f));
+                        (double)(rangefinder.distance_cm_orient(ROTATION_PITCH_270) * 0.01f),
+                        temp_C);
 }
 
 // guided mode logging

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -744,6 +744,16 @@ MAV_DISTANCE_SENSOR RangeFinder::get_mav_distance_sensor_type_orient(enum Rotati
     return backend->get_mav_distance_sensor_type();
 }
 
+// get temperature reading in C.  returns true on success and populates temp argument
+bool RangeFinder::get_temp(enum Rotation orientation, float &temp)
+{
+    AP_RangeFinder_Backend *backend = find_instance(orientation);
+    if (backend == nullptr) {
+        return false;
+    }
+    return backend->get_temp(temp);
+}
+
 // Write an RFND (rangefinder) packet
 void RangeFinder::Log_RFND() const
 {

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -181,6 +181,9 @@ public:
     const Vector3f &get_pos_offset_orient(enum Rotation orientation) const;
     uint32_t last_reading_ms(enum Rotation orientation) const;
 
+    // get temperature reading in C.  returns true on success and populates temp argument
+    bool get_temp(enum Rotation orientation, float &temp);
+
     /*
       set an externally estimated terrain height. Used to enable power
       saving (where available) at high altitudes.

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -59,6 +59,9 @@ public:
     // return system time of last successful read from the sensor
     uint32_t last_reading_ms() const { return state.last_reading_ms; }
 
+    // get temperature reading in C.  returns true on success and populates temp argument
+    virtual bool get_temp(float &temp) { return false; }
+
 protected:
 
     // update status based on distance measurement

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
@@ -37,16 +37,20 @@ private:
     enum sentence_types : uint8_t {
         SONAR_UNKNOWN = 0,
         SONAR_DBT,
-        SONAR_DPT
+        SONAR_DPT,
+        SONAR_MTW   // mean water temperature
     };
 
-    // get a reading
+    // get a distance reading
     bool get_reading(uint16_t &reading_cm) override;
+
+    // get temperature reading in C.  returns true on success and populates temp argument
+    bool get_temp(float &temp) override;
 
     uint16_t read_timeout_ms() const override { return 3000; }
 
     // add a single character to the buffer and attempt to decode
-    // returns true if a complete sentence was successfully decoded
+    // returns true if a distance was successfully decoded
     // distance should be pulled directly from _distance_m member
     bool decode(char c);
 
@@ -59,6 +63,9 @@ private:
     uint8_t _term_offset;                   // offset within the _term buffer where the next character should be placed
     uint8_t _term_number;                   // term index within the current sentence
     float _distance_m = -1.0f;              // distance in meters parsed from a term, -1 if no distance
+    float _temp_unvalidated;                // unvalidated temperature in C (may have failed checksum)
+    float _temp;                            // temperature in C (validated)
+    uint32_t _temp_readtime_ms;             // system time we last read a validated temperature, 0 if never read
     uint8_t _checksum;                      // checksum accumulator
     bool _term_is_checksum;                 // current term is the checksum
     sentence_types _sentence_type;          // the sentence type currently being processed


### PR DESCRIPTION
This PR makes two changes:

- adds support for reading the MWT (Mean Water Temperature) NMEA message from NMEA rangefinders.  The Rover/Boat firmware then logs this in the DPTH message.
- logs the DPTH message even if the vehicle does not have a position estimate (lat,lon are logged as zero). Resolves issue  https://github.com/ArduPilot/ardupilot/issues/17190

Th water temperature has been requested by at least two users although it is not in the issues list (it probably should be).

The MTW message format can be found here: https://gpsd.gitlab.io/gpsd/NMEA.html#_mtw_mean_temperature_of_water

This has been tested on real hardware and the results are below:
![image](https://user-images.githubusercontent.com/1498098/114820824-94df9e80-9dfa-11eb-96dc-ba46017c62a0.png)

Below is a test of what happens when the GPS_TYPE is set to 0 to disable the position estimate and we see the message keeps logging with the last known lat,lon.  If the vehicle has never had a good position estimate the lat,lon fields are zero.
![image](https://user-images.githubusercontent.com/1498098/115098445-23732d80-9f6b-11eb-85dc-48a5b6d59f78.png)

