### PR TITLE
Plane: Target airspeed handling fixes

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -238,8 +238,7 @@ void Plane::calc_airspeed_errors()
     }
 
     // Apply airspeed limit
-    if (target_airspeed_cm > (aparm.airspeed_max * 100))
-        target_airspeed_cm = (aparm.airspeed_max * 100);
+    target_airspeed_cm = constrain_int32(target_airspeed_cm, aparm.airspeed_min*100, aparm.airspeed_max*100);
 
     // use the TECS view of the target airspeed for reporting, to take
     // account of the landing speed

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -203,7 +203,10 @@ void Plane::calc_airspeed_errors()
             // normal AUTO mode and new_airspeed variable was set by DO_CHANGE_SPEED command while in AUTO mode
             if (new_airspeed_cm > 0) {
                 target_airspeed_cm = new_airspeed_cm;
-           }
+            } else {
+                // fallover to normal airspeed
+                target_airspeed_cm = aparm.airspeed_cruise_cm;
+            }
         }
     } else {
         // Normal airspeed target for all other cases


### PR DESCRIPTION
This fixes two problems with airspeed handling in master.

1) In auto mode the target airspeed is not updated unless a DO_CHANGE_SPEED command has been received,. The target remains at whatever it was when entering the mode. Changes to TRIM_ARSPD_CM are not respected.

2) Target airspeed is constrained by ARSPD_FBW_MAX but not ARSPD_FBW_MIN. If TRIM_ARSPD_CM is set too low - or perhaps an issue in another part of the logic - the plane will stall.


