### PR TITLE
AP_Filesystem: fixed a read past EOF bug in @PARAM

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Param.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.h
@@ -62,6 +62,7 @@ private:
         uint16_t start;
         uint16_t count;
         uint32_t file_ofs;
+        uint32_t file_size;
         struct cursor *cursors;
     } file[max_open_file];
 


### PR DESCRIPTION
this could cause mavproxy FTP param download to fail