### PR TITLE
AP_ExternalAHRS: remove message when EAHRS_TYPE is None

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -72,6 +72,9 @@ void AP_ExternalAHRS::init(void)
     }
 
     switch (DevType(devtype)) {
+    case DevType::None:
+        // nothing to do
+        break;
     case DevType::VecNav:
         backend = new AP_ExternalAHRS_VectorNav(this, state);
         break;


### PR DESCRIPTION
I changed to not show the message if it is not set.
![image](https://user-images.githubusercontent.com/16643069/114645899-3e4c6480-9d15-11eb-9c50-ff04574a4aba.png)
