### PR TITLE
GPS: fixed angular rate impact on moving baseline Z test

### DIFF
--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -358,7 +358,12 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(const float reported_heading_deg,
             get_lag(lag);
 
             // get vehicle rotation, projected back in time using the gyro
-            auto &ahrs = AP::ahrs();
+            // this is not 100% accurate, but it is good enough for
+            // this test. To do it completely accurately we'd need an
+            // interface into DCM, EKF2 and EKF3 to ask for a
+            // historical attitude. That is far too complex to justify
+            // for this use case
+            const auto &ahrs = AP::ahrs();
             const Vector3f &gyro = ahrs.get_gyro();
             Matrix3f rot_body_to_ned = ahrs.get_rotation_body_to_ned();
             rot_body_to_ned.rotate(gyro * (-lag));

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -353,8 +353,20 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(const float reported_heading_deg,
 
 #ifndef HAL_BUILD_AP_PERIPH
         {
-            const Vector3f antenna_tilt = AP::ahrs().get_rotation_body_to_ned() * offset;
+            // get lag
+            float lag = 0.1;
+            get_lag(lag);
+
+            // get vehicle rotation, projected back in time using the gyro
+            auto &ahrs = AP::ahrs();
+            const Vector3f &gyro = ahrs.get_gyro();
+            Matrix3f rot_body_to_ned = ahrs.get_rotation_body_to_ned();
+            rot_body_to_ned.rotate(gyro * (-lag));
+
+            // apply rotation to the offset to get the Z offset in NED
+            const Vector3f antenna_tilt = rot_body_to_ned * offset;
             const float alt_error = reported_D + antenna_tilt.z;
+
             if (fabsf(alt_error) > permitted_error_length_pct * min_dist) {
                 // the vertical component is out of range, reject it
                 goto bad_yaw;

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -426,7 +426,13 @@ void SITL_State::_update_gps_ubx(const struct gps_data *d, uint8_t instance)
         const Vector3f ant2_pos = _sitl->gps_pos_offset[instance].get();
         Vector3f rel_antenna_pos = ant2_pos - ant1_pos;
         Matrix3f rot;
+        // project attitude back using gyros to get antenna orientation at time of GPS sample
+        Vector3f gyro(radians(_sitl->state.rollRate),
+                      radians(_sitl->state.pitchRate),
+                      radians(_sitl->state.yawRate));
         rot.from_euler(radians(_sitl->state.rollDeg), radians(_sitl->state.pitchDeg), radians(d->yaw));
+        const float lag = (1.0/_sitl->gps_hertz[instance]) * gps_state[instance].delay;
+        rot.rotate(gyro * (-lag));
         rel_antenna_pos = rot * rel_antenna_pos;
         relposned.version = 1;
         relposned.iTOW = time_week_ms;


### PR DESCRIPTION
Rapid roll/pitch caused GPS switching due to lag
