### PR TITLE
AP_Logger: fix memory leak when finding last log

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -503,6 +503,7 @@ uint16_t AP_Logger_File::find_last_log()
     }
     EXPECT_DELAY_MS(3000);
     FileData *fd = AP::FS().load_file(fname);
+    free(fname);
     if (fd != nullptr) {
         ret = strtol((const char *)fd->data, NULL, 10);
         delete fd;


### PR DESCRIPTION
Thanks to @giacomo892 for finding and narrowing this one down
