### PR TITLE
AP_Periph: fixed DShot in AP_Periph

### DIFF
--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -57,6 +57,9 @@ void AP_Periph_FW::rcout_init()
 
     // run this once and at 1Hz to configure aux and esc ranges
     rcout_init_1Hz();
+
+    // run DShot at 1kHz
+    hal.rcout->set_dshot_rate(0, 400);
 }
 
 void AP_Periph_FW::rcout_init_1Hz()


### PR DESCRIPTION
if this isn't called then DShot doesn't work. 400Hz is arbitrary
