### PR TITLE
AP_GPS: get ellipsoid height from ublox GPS and UAVCAN GPS

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1538,7 +1538,7 @@ void AP_Periph_FW::can_gps_update(void)
         }
         pkt.longitude_deg_1e8 = uint64_t(loc.lng) * 10ULL;
         pkt.latitude_deg_1e8 = uint64_t(loc.lat) * 10ULL;
-        pkt.height_ellipsoid_mm = loc.alt * 10;
+        pkt.height_ellipsoid_mm = loc.alt_ellipsoid * 10;
         pkt.height_msl_mm = loc.alt * 10;
         for (uint8_t i=0; i<3; i++) {
             // the canard dsdl compiler doesn't understand float16
@@ -1621,7 +1621,7 @@ void AP_Periph_FW::can_gps_update(void)
         }
         pkt.longitude_deg_1e8 = uint64_t(loc.lng) * 10ULL;
         pkt.latitude_deg_1e8 = uint64_t(loc.lat) * 10ULL;
-        pkt.height_ellipsoid_mm = loc.alt * 10;
+        pkt.height_ellipsoid_mm = loc.alt_ellipsoid * 10;
         pkt.height_msl_mm = loc.alt * 10;
         for (uint8_t i=0; i<3; i++) {
             pkt.ned_velocity[i] = vel[i];

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -314,7 +314,7 @@ bool Location::sanitize(const Location &defaultLoc)
 }
 
 // make sure we know what size the Location object is:
-assert_storage_size<Location, 16> _assert_storage_size_Location;
+assert_storage_size<Location, 20> _assert_storage_size_Location;
 
 
 // return bearing in centi-degrees from location to loc2

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -20,7 +20,7 @@ public:
     int32_t alt;
     int32_t lat;
     int32_t lng;
-
+    int32_t alt_ellipsoid;
     /// enumeration of possible altitude types
     enum class AltFrame {
         ABSOLUTE = 0,

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1268,7 +1268,7 @@ void AP_GPS::send_mavlink_gps_raw(mavlink_channel_t chan)
         ground_speed(0)*100,  // cm/s
         ground_course(0)*100, // 1/100 degrees,
         num_sats(0),
-        0,                    // TODO: Elipsoid height in mm
+        loc.alt_ellipsoid * 10UL,    // Elipsoid height in mm
         hacc * 1000,          // one-sigma standard deviation in mm
         vacc * 1000,          // one-sigma standard deviation in mm
         sacc * 1000,          // one-sigma standard deviation in mm/s

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1226,6 +1226,7 @@ AP_GPS_UBLOX::_parse_gps(void)
         state.location.lng    = _buffer.posllh.longitude;
         state.location.lat    = _buffer.posllh.latitude;
         state.location.alt    = _buffer.posllh.altitude_msl / 10;
+        state.location.alt_ellipsoid = _buffer.posllh.altitude_ellipsoid / 10;
         state.status          = next_fix;
         _new_position = true;
         state.horizontal_accuracy = _buffer.posllh.horizontal_accuracy*1.0e-3f;
@@ -1373,6 +1374,7 @@ AP_GPS_UBLOX::_parse_gps(void)
         state.location.lng    = _buffer.pvt.lon;
         state.location.lat    = _buffer.pvt.lat;
         state.location.alt    = _buffer.pvt.h_msl / 10;
+        state.location.alt_ellipsoid = _buffer.pvt.height / 10;
         switch (_buffer.pvt.fix_type) 
         {
             case 0:


### PR DESCRIPTION
This PR is get the right ellipsoid height from GPS(ublox and UAVCAN GPS only for now), It's tested on CUAV X7 and CUAV CAN GPS and F9P.