### PR TITLE
Add macro for page count, and rows per page calculation

### DIFF
--- a/libraries/AP_Notify/Display_SH1106_I2C.cpp
+++ b/libraries/AP_Notify/Display_SH1106_I2C.cpp
@@ -65,7 +65,7 @@ bool Display_SH1106_I2C::hw_init()
             0x02, 0x10    // Column Address
     } };
 
-    memset(_displaybuffer, 0, SH1106_COLUMNS * SH1106_ROWS_PER_PAGE);
+    memset(_displaybuffer, 0, SH1106_COLUMNS * SH1106_PAGES);
 
     // take i2c bus semaphore
     if (!_dev) {
@@ -112,7 +112,7 @@ void Display_SH1106_I2C::_timer()
     } display_buffer = { 0x40, {} };
 
     // write buffer to display
-    for (uint8_t i = 0; i < (SH1106_ROWS / SH1106_ROWS_PER_PAGE); i++) {
+    for (uint8_t i = 0; i < (SH1106_ROWS / SH1106_PAGES); i++) {
         command.page = 0xB0 | (i & 0x0F);
         _dev->transfer((uint8_t *)&command, sizeof(command), nullptr, 0);
 
@@ -145,5 +145,5 @@ void Display_SH1106_I2C::clear_pixel(uint16_t x, uint16_t y)
 
 void Display_SH1106_I2C::clear_screen()
 {
-    memset(_displaybuffer, 0, SH1106_COLUMNS * SH1106_ROWS_PER_PAGE);
+    memset(_displaybuffer, 0, SH1106_COLUMNS * SH1106_PAGES);
 }

--- a/libraries/AP_Notify/Display_SH1106_I2C.h
+++ b/libraries/AP_Notify/Display_SH1106_I2C.h
@@ -6,7 +6,8 @@
 
 #define SH1106_COLUMNS 132		// display columns
 #define SH1106_ROWS 64		    // display rows
-#define SH1106_ROWS_PER_PAGE 8
+#define SH1106_PAGES 8
+#define SH1106_ROWS_PER_PAGE (SH1106_ROWS/SH1106_PAGES)
 
 class Display_SH1106_I2C: public Display_Backend {
 
@@ -31,7 +32,7 @@ private:
     void _timer();
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
-    uint8_t _displaybuffer[SH1106_COLUMNS * SH1106_ROWS_PER_PAGE];
+    uint8_t _displaybuffer[SH1106_COLUMNS * SH1106_PAGES];
     bool _need_hw_update;
 
 };

--- a/libraries/AP_Notify/Display_SSD1306_I2C.cpp
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.cpp
@@ -73,7 +73,7 @@ bool Display_SSD1306_I2C::hw_init()
             0x22, 0, 7    // +++ Page Address: (== start:0, end:7)
     } };
 
-    memset(_displaybuffer, 0, SSD1306_COLUMNS * SSD1306_ROWS_PER_PAGE);
+    memset(_displaybuffer, 0, SSD1306_COLUMNS * SSD1306_PAGES);
 
     // take i2c bus semaphore
     if (!_dev) {
@@ -118,7 +118,7 @@ void Display_SSD1306_I2C::_timer()
     } display_buffer = { 0x40, {} };
 
     // write buffer to display
-    for (uint8_t i = 0; i < (SSD1306_ROWS / SSD1306_ROWS_PER_PAGE); i++) {
+    for (uint8_t i = 0; i < (SSD1306_ROWS / SSD1306_PAGES); i++) {
         command.cmd[4] = i;
         _dev->transfer((uint8_t *)&command, sizeof(command), nullptr, 0);
 
@@ -152,5 +152,5 @@ void Display_SSD1306_I2C::clear_pixel(uint16_t x, uint16_t y)
 
 void Display_SSD1306_I2C::clear_screen()
 {
-     memset(_displaybuffer, 0, SSD1306_COLUMNS * SSD1306_ROWS_PER_PAGE);
+     memset(_displaybuffer, 0, SSD1306_COLUMNS * SSD1306_PAGES);
 }

--- a/libraries/AP_Notify/Display_SSD1306_I2C.h
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.h
@@ -6,7 +6,8 @@
 
 #define SSD1306_COLUMNS 128		// display columns
 #define SSD1306_ROWS 64		    // display rows
-#define SSD1306_ROWS_PER_PAGE 8
+#define SSD1306_PAGES 8
+#define SSD1306_ROWS_PER_PAGE (SSD1306_ROWS/SSD1306_PAGES)
 
 class Display_SSD1306_I2C: public Display_Backend {
 
@@ -31,6 +32,6 @@ private:
     void _timer();
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
-    uint8_t _displaybuffer[SSD1306_COLUMNS * SSD1306_ROWS_PER_PAGE];
+    uint8_t _displaybuffer[SSD1306_COLUMNS * SSD1306_PAGES];
     bool _need_hw_update;
 };


### PR DESCRIPTION
PAGES 8
ROWS_PER_PAGE (SSD1306_ROWS / SSD1306_PAGES)
Added for both SSD1306 and SH1106

SSD1306_ROWS_PER_PAGE is defined, and the name implies it should be the number of rows per page, and not the number of pages, but it is actually used for both numbers. Coincidentally, for the the specific 128x64 display, the number of pages and the number of rows per page are identical (equal to 8), but that's not neccessarily so for other display formats. This mixup could thus lead to potential memory issues, if in later stages other displays are added.