### PR TITLE
SITL: update param doc syntax

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -251,7 +251,6 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     // @Units: m
     // @User: Advanced
     
-    // user settable parameters for the 1st barometer
     // @Param: BAR3_RND
     // @DisplayName: Baro Noise
     // @Description: amount of (evenly-distributed) noise injected into the 3rd baro

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -239,29 +239,28 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     // @Units: m
     // @User: Advanced
     
-    // user settable parameters for the 1st barometer
     // @Param: BAR2_RND
     // @DisplayName: Baro Noise
-    // @Description: amount of (evenly-distributed) noise injected into the 1st baro
+    // @Description: amount of (evenly-distributed) noise injected into the 2nd baro
     // @Units: m
     // @User: Advanced
 
     // @Param: BAR2_GLITCH
     // @DisplayName: Baro Glitch
-    // @Description: user-settable 1st-barometer glitch
+    // @Description: user-settable 2st-barometer glitch
     // @Units: m
     // @User: Advanced
     
     // user settable parameters for the 1st barometer
     // @Param: BAR3_RND
     // @DisplayName: Baro Noise
-    // @Description: amount of (evenly-distributed) noise injected into the 1st baro
+    // @Description: amount of (evenly-distributed) noise injected into the 3rd baro
     // @Units: m
     // @User: Advanced
 
     // @Param: BAR3_GLITCH
     // @DisplayName: Baro Glitch
-    // @Description: user-settable 1st-barometer glitch
+    // @Description: user-settable 3st-barometer glitch
     // @Units: m
     // @User: Advanced
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -227,13 +227,39 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
     AP_SUBGROUPINFO(baro[2], "BAR3_", 36, SITL, SITL::BaroParm),
 
     // user settable parameters for the 1st barometer
-    // @Param: BARO_RND, BAR2_RND, BAR3_RND
+    // @Param: BARO_RND
     // @DisplayName: Baro Noise
     // @Description: amount of (evenly-distributed) noise injected into the 1st baro
     // @Units: m
     // @User: Advanced
 
-    // @Param: BARO_GLITCH,BAR2_GLITCH, BAR3_GLITCH
+    // @Param: BARO_GLITCH
+    // @DisplayName: Baro Glitch
+    // @Description: user-settable 1st-barometer glitch
+    // @Units: m
+    // @User: Advanced
+    
+    // user settable parameters for the 1st barometer
+    // @Param: BAR2_RND
+    // @DisplayName: Baro Noise
+    // @Description: amount of (evenly-distributed) noise injected into the 1st baro
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: BAR2_GLITCH
+    // @DisplayName: Baro Glitch
+    // @Description: user-settable 1st-barometer glitch
+    // @Units: m
+    // @User: Advanced
+    
+    // user settable parameters for the 1st barometer
+    // @Param: BAR3_RND
+    // @DisplayName: Baro Noise
+    // @Description: amount of (evenly-distributed) noise injected into the 1st baro
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: BAR3_GLITCH
     // @DisplayName: Baro Glitch
     // @Description: user-settable 1st-barometer glitch
     // @Units: m


### PR DESCRIPTION
this fixs a issue with MP param doc parser caused by a syntax change