### PR TITLE
AC_AttitudeControl: attitude controller quaternion fix

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -608,7 +608,7 @@ void AC_AttitudeControl::attitude_controller_run_quat()
 
     // Compute attitude error
     Vector3f attitude_error_vector;
-    thrust_heading_rotation_angles(_attitude_target_quat, attitude_vehicle_quat, attitude_error_vector, _thrust_error_angle);
+    thrust_heading_rotation_angles(_attitude_target_quat, attitude_vehicle_quat, attitude_error_vector, _thrust_angle, _thrust_error_angle);
 
     // Compute the angular velocity target from the attitude error
     _rate_target_ang_vel = update_ang_vel_target_from_att_error(attitude_error_vector);
@@ -618,7 +618,11 @@ void AC_AttitudeControl::attitude_controller_run_quat()
 
     // Add the angular velocity feedforward, rotated into vehicle frame
     Quaternion attitude_target_ang_vel_quat = Quaternion(0.0f, _attitude_target_ang_vel.x, _attitude_target_ang_vel.y, _attitude_target_ang_vel.z);
+
+    // rotation from the target frame to the vehicle frame
     Quaternion to_to_from_quat = attitude_vehicle_quat.inverse() * _attitude_target_quat;
+
+    // target angle velocity vector in the vehicle frame
     Quaternion desired_ang_vel_quat = to_to_from_quat * attitude_target_ang_vel_quat * to_to_from_quat.inverse();
 
     // Correct the thrust vector and smoothly add feedforward and yaw input
@@ -645,50 +649,65 @@ void AC_AttitudeControl::attitude_controller_run_quat()
         _attitude_target_quat.normalize();
     }
 
-    // ensure Quaternions stay normalized
+    // ensure Quaternion stay normalised
     _attitude_target_quat.normalize();
 
     // Record error to handle EKF resets
     _attitude_ang_error = attitude_vehicle_quat.inverse() * _attitude_target_quat;
 }
 
-// thrust_heading_rotation_angles - calculates two ordered rotations to move the att_from_quat quaternion to the att_to_quat quaternion.
-// The first rotation corrects the thrust vector and the second rotation corrects the heading vector.
-void AC_AttitudeControl::thrust_heading_rotation_angles(Quaternion& attitude_target_quat, const Quaternion& attitude_vehicle_quat, Vector3f& attitude_error_vector, float& thrust_error_angle)
+// thrust_heading_rotation_angles - calculates two ordered rotations to move the attitude_vehicle_quat quaternion to the attitude_target_quat quaternion.
+// The maximum error in the yaw axis is limited based on the angle yaw P value and acceleration.
+void AC_AttitudeControl::thrust_heading_rotation_angles(Quaternion& attitude_target_quat, const Quaternion& attitude_vehicle_quat, Vector3f& attitude_error_vector, float& thrust_angle, float& thrust_error_angle)
 {
-    Matrix3f att_to_rot_matrix; // rotation from the target body frame to the inertial frame.
-    attitude_target_quat.rotation_matrix(att_to_rot_matrix);
-    Vector3f att_to_thrust_vec = att_to_rot_matrix * Vector3f(0.0f, 0.0f, 1.0f);
+    Quaternion thrust_vec_correction_quat;
+    thrust_vector_rotation_angles(attitude_target_quat, attitude_vehicle_quat, thrust_vec_correction_quat, attitude_error_vector, thrust_angle, thrust_error_angle);
 
-    Matrix3f att_from_rot_matrix; // rotation from the current body frame to the inertial frame.
-    attitude_vehicle_quat.rotation_matrix(att_from_rot_matrix);
-    Vector3f att_from_thrust_vec = att_from_rot_matrix * Vector3f(0.0f, 0.0f, 1.0f);
+    // Todo: Limit roll an pitch error based on output saturation and maximum error.
+
+    // Limit Yaw Error based on maximum acceleration - Update to include output saturation and maximum error.
+    // Currently the limit is based on the maximum acceleration using the linear part of the SQRT controller.
+    // This should be updated to be based on an angle limit, saturation, or unlimited based on user defined parameters.
+    Quaternion yaw_vec_correction_quat;
+    if (!is_zero(_p_angle_yaw.kP()) && fabsf(attitude_error_vector.z) > AC_ATTITUDE_ACCEL_Y_CONTROLLER_MAX_RADSS / _p_angle_yaw.kP()) {
+        attitude_error_vector.z = constrain_float(wrap_PI(attitude_error_vector.z), -AC_ATTITUDE_ACCEL_Y_CONTROLLER_MAX_RADSS / _p_angle_yaw.kP(), AC_ATTITUDE_ACCEL_Y_CONTROLLER_MAX_RADSS / _p_angle_yaw.kP());
+        yaw_vec_correction_quat.from_axis_angle(Vector3f(0.0f, 0.0f, attitude_error_vector.z));
+        attitude_target_quat = attitude_vehicle_quat * thrust_vec_correction_quat * yaw_vec_correction_quat;
+    }
+}
+
+// thrust_vector_rotation_angles - calculates two ordered rotations to move the attitude_vehicle_quat quaternion to the attitude_target_quat quaternion.
+// The first rotation corrects the thrust vector and the second rotation corrects the heading vector.
+void AC_AttitudeControl::thrust_vector_rotation_angles(const Quaternion& attitude_target_quat, const Quaternion& attitude_vehicle_quat, Quaternion& thrust_vec_correction_quat, Vector3f& attitude_error_vector, float& thrust_angle, float& thrust_error_angle)
+{
+    Matrix3f att_target_rot_matrix; // rotation from the inertial frame to the target body frame.
+    attitude_target_quat.rotation_matrix(att_target_rot_matrix);
+    Vector3f att_target_thrust_vec = att_target_rot_matrix * Vector3f(0.0f, 0.0f, -1.0f); // target thrust vector
+
+    Matrix3f att_vehicle_rot_matrix; // rotation from the inertial frame to the vehicle body frame.
+    attitude_vehicle_quat.rotation_matrix(att_vehicle_rot_matrix);
+    Vector3f att_vehicle_thrust_vec = att_vehicle_rot_matrix * Vector3f(0.0f, 0.0f, -1.0f); // current thrust vector
 
     // the dot product is used to calculate the current lean angle for use of external functions
-    _thrust_angle = acosf(constrain_float(Vector3f(0.0f,0.0f,1.0f) * att_from_thrust_vec,-1.0f,1.0f));
+    thrust_angle = acosf(constrain_float(Vector3f(0.0f,0.0f,1.0f) * att_vehicle_thrust_vec,-1.0f,1.0f));
 
     // the cross product of the desired and target thrust vector defines the rotation vector
-    Vector3f thrust_vec_cross = att_from_thrust_vec % att_to_thrust_vec;
+    Vector3f thrust_vec_cross = att_vehicle_thrust_vec % att_target_thrust_vec;
 
     // the dot product is used to calculate the angle between the target and desired thrust vectors
-    thrust_error_angle = acosf(constrain_float(att_from_thrust_vec * att_to_thrust_vec, -1.0f, 1.0f));
+    thrust_error_angle = acosf(constrain_float(att_vehicle_thrust_vec * att_target_thrust_vec, -1.0f, 1.0f));
 
     // Normalize the thrust rotation vector
     float thrust_vector_length = thrust_vec_cross.length();
     if (is_zero(thrust_vector_length) || is_zero(thrust_error_angle)) {
         thrust_vec_cross = Vector3f(0, 0, 1);
-        thrust_error_angle = 0.0f;
     } else {
         thrust_vec_cross /= thrust_vector_length;
     }
-    Quaternion thrust_vec_correction_quat;
     thrust_vec_correction_quat.from_axis_angle(thrust_vec_cross, thrust_error_angle);
 
-    // Rotate thrust_vec_correction_quat to the att_from frame
+    // Rotate thrust_vec_correction_quat to the att_vehicle frame
     thrust_vec_correction_quat = attitude_vehicle_quat.inverse() * thrust_vec_correction_quat * attitude_vehicle_quat;
-
-    // calculate the remaining rotation required after thrust vector is rotated transformed to the att_from frame
-    Quaternion yaw_vec_correction_quat = thrust_vec_correction_quat.inverse() * attitude_vehicle_quat.inverse() * attitude_target_quat;
 
     // calculate the angle error in x and y.
     Vector3f rotation;
@@ -696,20 +715,12 @@ void AC_AttitudeControl::thrust_heading_rotation_angles(Quaternion& attitude_tar
     attitude_error_vector.x = rotation.x;
     attitude_error_vector.y = rotation.y;
 
+    // calculate the remaining rotation required after thrust vector is rotated transformed to the att_vehicle frame
+    Quaternion heading_vec_correction_quat = thrust_vec_correction_quat.inverse() * attitude_vehicle_quat.inverse() * attitude_target_quat;
+
     // calculate the angle error in z (x and y should be zero here).
-    yaw_vec_correction_quat.to_axis_angle(rotation);
+    heading_vec_correction_quat.to_axis_angle(rotation);
     attitude_error_vector.z = rotation.z;
-
-    // Todo: Limit roll an pitch error based on output saturation and maximum error.
-
-    // Limit Yaw Error based on maximum acceleration - Update to include output saturation and maximum error.
-    // Currently the limit is based on the maximum acceleration using the linear part of the SQRT controller.
-    // This should be updated to be based on an angle limit, saturation, or unlimited based on user defined parameters.
-    if (!is_zero(_p_angle_yaw.kP()) && fabsf(attitude_error_vector.z) > AC_ATTITUDE_ACCEL_Y_CONTROLLER_MAX_RADSS / _p_angle_yaw.kP()) {
-        attitude_error_vector.z = constrain_float(wrap_PI(attitude_error_vector.z), -AC_ATTITUDE_ACCEL_Y_CONTROLLER_MAX_RADSS / _p_angle_yaw.kP(), AC_ATTITUDE_ACCEL_Y_CONTROLLER_MAX_RADSS / _p_angle_yaw.kP());
-        yaw_vec_correction_quat.from_axis_angle(Vector3f(0.0f, 0.0f, attitude_error_vector.z));
-        attitude_target_quat = attitude_vehicle_quat * thrust_vec_correction_quat * yaw_vec_correction_quat;
-    }
 }
 
 // calculates the velocity correction from an angle error. The angular velocity has acceleration and

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -298,12 +298,16 @@ public:
     // translates body frame acceleration limits to the euler axis
     Vector3f euler_accel_limit(const Vector3f &euler_rad, const Vector3f &euler_accel);
 
-    // thrust_heading_rotation_angles - calculates two ordered rotations to move the att_from_quat quaternion to the att_to_quat quaternion.
-    // The first rotation corrects the thrust vector and the second rotation corrects the heading vector.
-    void thrust_heading_rotation_angles(Quaternion& attitude_target_quat, const Quaternion& attitude_vehicle_quat, Vector3f& attitude_error_vector, float& thrust_error_angle);
-
     // Calculates the body frame angular velocities to follow the target attitude
     void attitude_controller_run_quat();
+
+    // thrust_heading_rotation_angles - calculates two ordered rotations to move the attitude_vehicle_quat quaternion to the attitude_target_quat quaternion.
+    // The maximum error in the yaw axis is limited based on the angle yaw P value and acceleration.
+    void thrust_heading_rotation_angles(Quaternion& attitude_target_quat, const Quaternion& attitude_vehicle_quat, Vector3f& attitude_error_vector, float& thrust_angle, float& thrust_error_angle);
+
+    // thrust_vector_rotation_angles - calculates two ordered rotations to move the attitude_vehicle_quat quaternion to the attitude_target_quat quaternion.
+    // The first rotation corrects the thrust vector and the second rotation corrects the heading vector.
+    void thrust_vector_rotation_angles(const Quaternion& attitude_target_quat, const Quaternion& attitude_vehicle_quat, Quaternion& thrust_vec_correction_quat, Vector3f& rotation, float& thrust_angle, float& thrust_error_angle);
 
     // sanity check parameters.  should be called once before take-off
     virtual void parameter_sanity_check() {}

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -400,7 +400,7 @@ protected:
 
     // This represents a 321-intrinsic rotation in NED frame to the target (setpoint)
     // attitude used in the attitude controller, in radians.
-    Vector3f            _euler_angle_target; // _euler_angle_target
+    Vector3f            _euler_angle_target;
 
     // This represents the angular velocity of the target (setpoint) attitude used in
     // the attitude controller as 321-intrinsic euler angle derivatives, in radians per

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -333,20 +333,20 @@ void AC_AttitudeControl_Multi::rate_controller_run()
     // move throttle vs attitude mixing towards desired (called from here because this is conveniently called on every iteration)
     update_throttle_rpy_mix();
 
-    _rate_target_ang_vel += _rate_sysid_ang_vel;
+    _ang_vel_body += _sysid_ang_vel_body;
 
     Vector3f gyro_latest = _ahrs.get_gyro_latest();
 
-    _motors.set_roll(get_rate_roll_pid().update_all(_rate_target_ang_vel.x, gyro_latest.x, _motors.limit.roll) + _actuator_sysid.x);
+    _motors.set_roll(get_rate_roll_pid().update_all(_ang_vel_body.x, gyro_latest.x, _motors.limit.roll) + _actuator_sysid.x);
     _motors.set_roll_ff(get_rate_roll_pid().get_ff());
 
-    _motors.set_pitch(get_rate_pitch_pid().update_all(_rate_target_ang_vel.y, gyro_latest.y, _motors.limit.pitch) + _actuator_sysid.y);
+    _motors.set_pitch(get_rate_pitch_pid().update_all(_ang_vel_body.y, gyro_latest.y, _motors.limit.pitch) + _actuator_sysid.y);
     _motors.set_pitch_ff(get_rate_pitch_pid().get_ff());
 
-    _motors.set_yaw(get_rate_yaw_pid().update_all(_rate_target_ang_vel.z, gyro_latest.z, _motors.limit.yaw) + _actuator_sysid.z);
+    _motors.set_yaw(get_rate_yaw_pid().update_all(_ang_vel_body.z, gyro_latest.z, _motors.limit.yaw) + _actuator_sysid.z);
     _motors.set_yaw_ff(get_rate_yaw_pid().get_ff()*_feedforward_scalar);
 
-    _rate_sysid_ang_vel.zero();
+    _sysid_ang_vel_body.zero();
     _actuator_sysid.zero();
 
     control_monitor_update();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -359,9 +359,9 @@ void AC_AttitudeControl_Sub::rate_controller_run()
     update_throttle_rpy_mix();
 
     Vector3f gyro_latest = _ahrs.get_gyro_latest();
-    _motors.set_roll(get_rate_roll_pid().update_all(_rate_target_ang_vel.x, gyro_latest.x, _motors.limit.roll));
-    _motors.set_pitch(get_rate_pitch_pid().update_all(_rate_target_ang_vel.y, gyro_latest.y, _motors.limit.pitch));
-    _motors.set_yaw(get_rate_yaw_pid().update_all(_rate_target_ang_vel.z, gyro_latest.z, _motors.limit.yaw));
+    _motors.set_roll(get_rate_roll_pid().update_all(_ang_vel_body.x, gyro_latest.x, _motors.limit.roll));
+    _motors.set_pitch(get_rate_pitch_pid().update_all(_ang_vel_body.y, gyro_latest.y, _motors.limit.pitch));
+    _motors.set_yaw(get_rate_yaw_pid().update_all(_ang_vel_body.z, gyro_latest.z, _motors.limit.yaw));
 
     control_monitor_update();
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
@@ -41,16 +41,16 @@ void AC_AttitudeControl_TS::relax_attitude_controllers(bool exclude_pitch)
         // by rotating the current_attitude quaternion by the error in desired pitch
         Quaternion pitch_rotation;
         pitch_rotation.from_axis_angle(Vector3f(0, -1, 0), current_eulers.y);
-        _attitude_target_quat = current_attitude * pitch_rotation;
-        _attitude_target_quat.normalize();
-        _attitude_target_quat.to_euler(_attitude_target_euler_angle.x, _attitude_target_euler_angle.y, _attitude_target_euler_angle.z);
-        _attitude_ang_error = current_attitude.inverse() * _attitude_target_quat;
+        _attitude_target = current_attitude * pitch_rotation;
+        _attitude_target.normalize();
+        _attitude_target.to_euler(_euler_angle_target.x, _euler_angle_target.y, _euler_angle_target.z);
+        _attitude_ang_error = current_attitude.inverse() * _attitude_target;
 
         // Initialize the roll and yaw angular rate variables to the current rate
-        _attitude_target_ang_vel = _ahrs.get_gyro();
-        ang_vel_to_euler_rate(_attitude_target_euler_angle, _attitude_target_ang_vel, _attitude_target_euler_rate);
-        _rate_target_ang_vel.x = _ahrs.get_gyro().x;
-        _rate_target_ang_vel.z = _ahrs.get_gyro().z;
+        _ang_vel_target = _ahrs.get_gyro();
+        ang_vel_to_euler_rate(_euler_angle_target, _ang_vel_target, _euler_rate_target);
+        _ang_vel_body.x = _ahrs.get_gyro().x;
+        _ang_vel_body.z = _ahrs.get_gyro().z;
 
         // Reset the roll and yaw I terms
         get_rate_roll_pid().reset_I();
@@ -78,7 +78,7 @@ void AC_AttitudeControl_TS::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool 
     Quaternion attitude_vehicle_quat;
     Quaternion error_quat;
     _ahrs.get_quat_body_to_ned(attitude_vehicle_quat);
-    error_quat = attitude_vehicle_quat.inverse() * _attitude_target_quat;
+    error_quat = attitude_vehicle_quat.inverse() * _attitude_target;
     Vector3f att_error;
     error_quat.to_axis_angle(att_error);
 
@@ -93,10 +93,10 @@ void AC_AttitudeControl_TS::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool 
     if (error_ratio > 1) {
         yaw_rate /= (error_ratio * error_ratio);
     }
-    _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + yaw_rate * _dt);
+    _euler_angle_target.z = wrap_PI(_euler_angle_target.z + yaw_rate * _dt);
 
     // init attitude target to desired euler yaw and pitch with zero roll
-    _attitude_target_quat.from_euler(0, euler_pitch, _attitude_target_euler_angle.z);
+    _attitude_target.from_euler(0, euler_pitch, _euler_angle_target.z);
 
     // apply body-frame yaw/roll (this is roll/yaw for a tailsitter in forward flight)
     // rotate body_roll axis by |sin(pitch angle)|
@@ -110,23 +110,23 @@ void AC_AttitudeControl_TS::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool 
     } else {
         bf_yaw_Q.from_axis_angle(Vector3f(-cpitch * body_roll, 0, 0));
     }
-    _attitude_target_quat = _attitude_target_quat * bf_roll_Q * bf_yaw_Q;
+    _attitude_target = _attitude_target * bf_roll_Q * bf_yaw_Q;
 
-    // _attitude_target_euler_angle roll and pitch: Note: roll/yaw will be indeterminate when pitch is near +/-90
+    // _euler_angle_target roll and pitch: Note: roll/yaw will be indeterminate when pitch is near +/-90
     // These should be used only for logging target eulers, with the caveat noted above.
-    // Also note that _attitude_target_quat.from_euler() should only be used in special circumstances
+    // Also note that _attitude_target.from_euler() should only be used in special circumstances
     // such as when attitude is specified directly in terms of Euler angles.
-    //    _attitude_target_euler_angle.x = _attitude_target_quat.get_euler_roll();
-    //    _attitude_target_euler_angle.y = euler_pitch;
+    //    _euler_angle_target.x = _attitude_target.get_euler_roll();
+    //    _euler_angle_target.y = euler_pitch;
 
     // Set rate feedforward requests to zero
-    _attitude_target_euler_rate.zero();
-    _attitude_target_ang_vel.zero();
+    _euler_rate_target.zero();
+    _ang_vel_target.zero();
 
     // Compute attitude error
-    error_quat = attitude_vehicle_quat.inverse() * _attitude_target_quat;
+    error_quat = attitude_vehicle_quat.inverse() * _attitude_target;
     error_quat.to_axis_angle(att_error);
 
     // Compute the angular velocity target from the attitude error
-    _rate_target_ang_vel = update_ang_vel_target_from_att_error(att_error);
+    _ang_vel_body = update_ang_vel_target_from_att_error(att_error);
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
@@ -75,10 +75,10 @@ void AC_AttitudeControl_TS::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool 
     const float spitch = fabsf(sinf(euler_pitch));
 
     // Compute attitude error
-    Quaternion attitude_vehicle_quat;
+    Quaternion attitude_body;
     Quaternion error_quat;
-    _ahrs.get_quat_body_to_ned(attitude_vehicle_quat);
-    error_quat = attitude_vehicle_quat.inverse() * _attitude_target;
+    _ahrs.get_quat_body_to_ned(attitude_body);
+    error_quat = attitude_body.inverse() * _attitude_target;
     Vector3f att_error;
     error_quat.to_axis_angle(att_error);
 
@@ -124,7 +124,7 @@ void AC_AttitudeControl_TS::input_euler_rate_yaw_euler_angle_pitch_bf_roll(bool 
     _ang_vel_target.zero();
 
     // Compute attitude error
-    error_quat = attitude_vehicle_quat.inverse() * _attitude_target;
+    error_quat = attitude_body.inverse() * _attitude_target;
     error_quat.to_axis_angle(att_error);
 
     // Compute the angular velocity target from the attitude error


### PR DESCRIPTION
This PR fixes a problem with the feed forward angular velocity calculation highlighted in issue ArduPilot#17059.

We have also taken this opportunity to redefine the parameter names to make these algorithms easier to read and review.

The last three commits are the first from Hs293Go. These commits focus on replacing the vector rotation to again improve readability and reduce operations.

This PR also sets up the calculations in preparation for thrust vector attitude PR to follow.