### PR TITLE
AC_Fence: remove alt from TYPE param desc for Rover

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -25,9 +25,9 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Fence Type
     // @Description: Enabled fence types held as bitmask
-    // @Values{Rover}: 0:None,1:Altitude,2:Circle,3:Altitude and Circle,4:Polygon,5:Altitude and Polygon,6:Circle and Polygon,7:All
+    // @Values{Rover}: 0:None,2:Circle,4:Polygon,6:All
     // @Values{Copter, Plane, Sub}: 0:None,1:Max altitude,2:Circle,3:Max altitude and Circle,4:Polygon,5:Max altitude and Polygon,6:Circle and Polygon,7:Max altitude circle and Polygon,8:Min altitude
-    // @Bitmask{Rover}: 0:Altitude,1:Circle,2:Polygon
+    // @Bitmask{Rover}: 1:Circle,2:Polygon
     // @Bitmask{Copter, Plane, Sub}: 0:Max altitude,1:Circle,2:Polygon,3:Min altitude
     // @User: Standard
     AP_GROUPINFO("TYPE",        1,  AC_Fence,   _enabled_fences,  AC_FENCE_TYPE_DEFAULT),


### PR DESCRIPTION
This removes the unused "altitude" options from the FENCE_TYPE param descriptions for Rover.

The only slight question is whether "6" should be "Circle and Polygon" or "All" but I've gone with "All".  This is the default for the parameter on Rover.

Thanks to @Hwurzburg for noticing this.

This resolves issue https://github.com/ArduPilot/ardupilot/issues/17207

I'm not exactly sure how to test this without merging it.  Anyway, the change is not dangerous so perhaps review by inspection is enough.