### PR TITLE
Tools: param_parse: fix vehicle specific parameter with multiple fields

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -242,7 +242,7 @@ def process_library(vehicle, library, pathprefix=None):
                 debug("field[0]=%s vehicle=%s truename=%s field[1]=%s only_for_vehicles=%s\n" %
                       (field[0], vehicle.name, vehicle.truename, field[1], str(only_for_vehicles)))
                 value = re.sub('@PREFIX@', library.name, field[2])
-                if field[0] == "Values":
+                if field[0] in ['Values', 'Bitmask']:
                     if vehicle.truename in only_for_vehicles:
                         this_vehicle_values_seen = True
                         this_vehicle_value = value
@@ -254,12 +254,12 @@ def process_library(vehicle, library, pathprefix=None):
                     setattr(p, field[0], value)
                 else:
                     error("tagged param<: unknown parameter metadata field '%s'" % field[0])
-            if ((non_vehicle_specific_values_seen or not other_vehicle_values_seen) or this_vehicle_values_seen):
-                if this_vehicle_values_seen and field[0] == 'Values':
-                    setattr(p, field[0], this_vehicle_value)
-#                debug("Appending (non_vehicle_specific_values_seen=%u "
-#                      "other_vehicle_values_seen=%u this_vehicle_values_seen=%u)" %
-#                      (non_vehicle_specific_values_seen, other_vehicle_values_seen, this_vehicle_values_seen))
+                if ((non_vehicle_specific_values_seen or not other_vehicle_values_seen) or this_vehicle_values_seen):
+                    if this_vehicle_values_seen and field[0] in ['Values', 'Bitmask']:
+                        setattr(p, field[0], this_vehicle_value)
+    #                debug("Appending (non_vehicle_specific_values_seen=%u "
+    #                      "other_vehicle_values_seen=%u this_vehicle_values_seen=%u)" %
+    #                      (non_vehicle_specific_values_seen, other_vehicle_values_seen, this_vehicle_values_seen))
             p.path = path # Add path. Later deleted - only used for duplicates
             library.params.append(p)
 


### PR DESCRIPTION
fix vehicle specific parameter with multiple fields.
For example in AC_Fence, Rover got resttrictions on Values an Bitmask : see https://github.com/ArduPilot/ardupilot/pull/17208

Without the fix, we got : 
```
<param humanName="Fence Type" name="FENCE_TYPE" documentation="Enabled fence types held as bitmask" user="Standard">
        <values>
          <value code="0">None</value>
          <value code="1">Max altitude</value>
          <value code="2">Circle</value>
          <value code="3">Max altitude and Circle</value>
          <value code="4">Polygon</value>
          <value code="5">Max altitude and Polygon</value>
          <value code="6">Circle and Polygon</value>
          <value code="7">Max altitude circle and Polygon</value>
          <value code="8">Min altitude</value>
        </values>
        <field name="Bitmask">0:Max altitude,1:Circle,2:Polygon,3:Min altitude</field>
      </param>
```

With the fix : 
```
      <param humanName="Fence Type" name="FENCE_TYPE" documentation="Enabled fence types held as bitmask" user="Standard">
        <values>
          <value code="0">None</value>
          <value code="2">Circle</value>
          <value code="4">Polygon</value>
          <value code="6">All</value>
        </values>
        <field name="Bitmask">1:Circle,2:Polygon</field>
      </param>
```

I have check on the xml version and that is on the only change.