### PR TITLE
Make BLHeli Passthru more reliable

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -362,7 +362,10 @@ void AP_BLHeli::msp_process_command(void)
     }
 
     case MSP_REBOOT:
-        debug("MSP: ignoring reboot command");
+        debug("MSP: ignoring reboot command, end serial comms");
+        hal.rcout->serial_end();
+        blheli.connected[blheli.chan] = false;
+        serial_start_ms = 0;
         break;
 
     case MSP_UID:
@@ -590,6 +593,9 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
+    // 19200 baud is 52us per bit - wait for half a bit between sending and receiving to avoid reading
+    // the end of the last sent bit by accident
+    hal.scheduler->delay_microseconds(26);
     return true;
 }
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1819,8 +1819,10 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
     }
     pwm_group &group = *serial_group;
     const ioline_t line = group.pal_lines[group.serial.chan];
-    uint32_t gpio_mode = PAL_MODE_INPUT_PULLUP;
-    uint32_t restore_mode = PAL_MODE_ALTERNATE(group.alt_functions[group.serial.chan]) | PAL_STM32_OSPEED_MID2 | PAL_STM32_OTYPE_PUSHPULL;
+    // keep speed low to avoid noise when switching between input and output
+    uint32_t gpio_mode = PAL_STM32_MODE_INPUT | PAL_STM32_OTYPE_PUSHPULL | PAL_STM32_PUPDR_PULLUP | PAL_STM32_OSPEED_LOWEST;
+    // restore the line to what it was before
+    iomode_t restore_mode = palReadLineMode(line);
     uint16_t i = 0;
 
 #if RCOU_SERIAL_TIMING_DEBUG


### PR DESCRIPTION
BLHeli passthru is a half-duplex protocol. The current implementation on H7's could end up reading the data being sent when switching between send and receive. This PR introduces a small delay between send and receive that prevents this and also slightly adjusts the GPIO settings to be less noisy.