### PR TITLE
AC_Avoid: limit accel till a few seconds after avoidance is turned off

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -249,14 +249,21 @@ void AC_Avoid::adjust_velocity(Vector3f &desired_vel_cms, bool &backing_up, floa
 */
 void AC_Avoid::limit_accel(const Vector3f &original_vel, Vector3f &modified_vel, float dt)
 {
-    if (original_vel == modified_vel || is_zero(_accel_max) || !is_positive(dt)) {
+    if (is_zero(_accel_max) || !is_positive(dt)) {
         // we can't limit accel if any of these conditions are true
         return;
     }
 
-    if (AP_HAL::millis() - _last_limit_time > AC_AVOID_ACCEL_TIMEOUT_MS) {
-        // reset this velocity because its been a long time since avoidance was active
-        _prev_avoid_vel = original_vel;
+    // ms since avoidance was last active last avoidance active
+    const uint32_t last_avoidance_active =  AP_HAL::millis() - _last_limit_time;
+
+    if (original_vel == modified_vel) {
+        // limit accel if avoidance has been just turned off
+        if (last_avoidance_active > AC_AVOID_ACCEL_LIMIT_TIME) {
+            // don't limit acceleration now because long time has passed since avoidance was active
+            _prev_avoid_vel = original_vel;
+            return;
+        }
     }
 
     // acceleration demanded by avoidance

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -20,7 +20,7 @@
 
 #define AC_AVOID_ACTIVE_LIMIT_TIMEOUT_MS    500     // if limiting is active if last limit is happend in the last x ms
 #define AC_AVOID_MIN_BACKUP_BREACH_DIST     10.0f   // vehicle will backaway if breach is greater than this distance in cm
-#define AC_AVOID_ACCEL_TIMEOUT_MS           200     // stored velocity used to calculate acceleration will be reset if avoidance is active after this many ms
+#define AC_AVOID_ACCEL_LIMIT_TIME           2500    // ms after avoidance is turned off till acceleration is limited
 
 /*
  * This class prevents the vehicle from leaving a polygon fence or hitting proximity-based obstacles


### PR DESCRIPTION
We recently started limiting the rate of change of output velocity (or acceleration) by Simple Avoidance. This has made the avoidance experience much much smoother. However, as soon as avoidance is turned off, the acceleration limits also stop. Meaning, if a person is pushing against the obstacle, and suddenly the obstacle goes away, avoidance is turned off, and the vehicle springs forward. 

Therefore, this PR limits the acceleration to an additional 2.5 secs for a better experience.