### PR TITLE
AC_WPNav: remove unused enum and unnecessary assignment

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -93,7 +93,6 @@ AC_WPNav::AC_WPNav(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosC
     // init flags
     _flags.reached_destination = false;
     _flags.fast_waypoint = false;
-    _flags.segment_type = SEGMENT_STRAIGHT;
 
     // sanity check some parameters
     _wp_accel_cmss = MIN(_wp_accel_cmss, GRAVITY_MSS * 100.0f * tanf(ToRad(_attitude_control.lean_angle_max() * 0.01f)));

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -455,14 +455,12 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     Vector3f curr_target_vel = _pos_control.get_desired_velocity();
     curr_target_vel.z -= _vel_terrain_offset;
 
-    float track_error = 0.0f;
-    float track_velocity = 0.0f;
     float track_scaler_dt = 1.0f;
     // check target velocity is non-zero
     if (is_positive(curr_target_vel.length())) {
         Vector3f track_direction = curr_target_vel.normalized();
-        track_error = _pos_control.get_pos_error().dot(track_direction);
-        track_velocity = _inav.get_velocity().dot(track_direction);
+        const float track_error = _pos_control.get_pos_error().dot(track_direction);
+        const float track_velocity = _inav.get_velocity().dot(track_direction);
         // set time scaler to be consistent with the achievable aircraft speed with a 5% buffer for short term variation.
         track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_xy_p().kP() * track_error) / curr_target_vel.length(), 0.1f, 1.0f);
         // set time scaler to not exceed the maximum vertical velocity during terrain following.
@@ -471,8 +469,6 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         } else if (is_negative(curr_target_vel.z)) {
             track_scaler_dt = MIN(track_scaler_dt, fabsf(_wp_speed_down_cms / curr_target_vel.z));
         }
-    } else {
-        track_scaler_dt = 1.0f;
     }
     // change s-curve time speed with a time constant of maximum acceleration / maximum jerk
     float track_scaler_tc = 1.0f;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -29,13 +29,6 @@ class AC_WPNav
 {
 public:
 
-    // spline segment end types enum
-    enum spline_segment_end_type {
-        SEGMENT_END_STOP = 0,
-        SEGMENT_END_STRAIGHT,
-        SEGMENT_END_SPLINE
-    };
-
     /// Constructor
     AC_WPNav(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
 
@@ -221,17 +214,10 @@ public:
 
 protected:
 
-    // segment types, either straight or spine
-    enum SegmentType {
-        SEGMENT_STRAIGHT = 0,
-        SEGMENT_SPLINE = 1
-    };
-
     // flags structure
     struct wpnav_flags {
         uint8_t reached_destination     : 1;    // true if we have reached the destination
         uint8_t fast_waypoint           : 1;    // true if we should ignore the waypoint radius and consider the waypoint complete once the intermediate target has reached the waypoint
-        SegmentType segment_type        : 1;    // active segment is either straight or spline
         uint8_t wp_yaw_set              : 1;    // true if yaw target has been set
     } _flags;
 


### PR DESCRIPTION
This non-functional change removes a couple of unused enums made obsolete by the SCurves PR.

It also removes an duplicate assignment of a local variable called track_scaler_dt to -1.0f.  It is already set to this value a few lines higher when it is first declared.  In the same area the scope of a couple of local variables are reduced and they are made const.

This has not been tested beyond a compilation test but this should be enough and the autotest will give it a more thorough test.