### PR TITLE
CI: enable cygwin build in github actions

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -1,0 +1,31 @@
+name: Cygwin Build
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: 'windows-latest'
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Install cygwin
+        env:
+          HOME: ${{ runner.workspace }}/ardupilot
+        run: |
+          choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
+          choco install cygwin32-gcc-g++ python36 python36-future python36-lxml python36-pip python36-setuptools python36-wheel git libexpat procps gettext --source cygwin
+          C:\Cygwin\bin\bash --login -c "ln -sf /usr/bin/python3.6 /usr/bin/python && ln -sf /usr/bin/pip3.6 /usr/bin/pip"
+      - name: Build SITL
+        env:
+          HOME: ${{ runner.workspace }}/ardupilot
+        run: |
+          C:\Cygwin\bin\bash --login -c "Tools/scripts/cygwin_build.sh"
+
+      - name: Archive build
+        uses: actions/upload-artifact@v2
+        with:
+           name: binaries
+           path: artifacts
+           retention-days: 7

--- a/Tools/scripts/cygwin_build.sh
+++ b/Tools/scripts/cygwin_build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# script to build cygwin binaries for using in MissionPlanner
+# the contents of artifacts directory is uploaded to:
+# https://firmware.ardupilot.org/Tools/MissionPlanner/sitl/
+
+# the script assumes you start in the root of the ardupilot git tree
+
+set -x
+
+rm -rf artifacts
+mkdir artifacts
+
+(
+    python ./waf --color yes --toolchain i686-pc-cygwin --board sitl configure 2>&1
+    python ./waf plane rover copter sub heli 2>&1
+) | tee artifacts/build.txt
+
+i686-pc-cygwin-g++ -print-sysroot
+
+cp -v build/sitl/bin/arduplane artifacts/ArduPlane.elf
+cp -v build/sitl/bin/arducopter artifacts/ArduCopter.elf
+cp -v build/sitl/bin/arducopter-heli artifacts/ArduHeli.elf
+cp -v build/sitl/bin/ardurover artifacts/ArduRover.elf
+cp -v build/sitl/bin/ardusub artifacts/ArduSub.elf
+
+cp -v /usr/i686-pc-cygwin/sys-root/usr/bin/*.dll artifacts/
+
+git log -1 > artifacts/git.txt


### PR DESCRIPTION
this will allow us to drop azure builds once this is confirmed working