### PR TITLE
waf: removed debug code

### DIFF
--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -143,7 +143,7 @@ def configure(cfg):
         return
 
     _set_pkgconfig_crosscompilation_wrapper(cfg)
-    if sys.platform.startswith("cygwin") or True:
+    if sys.platform.startswith("cygwin"):
         # on cygwin arm-none-eabi-ar doesn't support the @FILE syntax for splitting long lines
         cfg.find_program('ar', var='AR', quiet=True)
     else:


### PR DESCRIPTION
this was in to test cygwin ar behaviour on linux. It should not have
been committed.

Thanks to Andy for letting me know it broke MacOS