### PR TITLE
AP_Logger: remove un-needed forward declarations

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -236,10 +236,6 @@ enum class LogErrorCode : uint8_t {
     GPS_GLITCH = 2,
 };
 
-// fwd declarations to avoid include errors
-class AC_AttitudeControl;
-class AC_PosControl;
-
 class AP_Logger
 {
     friend class AP_Logger_Backend; // for _num_types


### PR DESCRIPTION
We moved the logging into the relevant library.  Yay!