### PR TITLE
Rplidar s1 support with optimized read()

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -25,6 +25,7 @@
 #include "AP_Proximity_LightWareSF40C.h"
 #include "AP_Proximity_LightWareSF45B.h"
 #include "AP_Proximity_SITL.h"
+#include "AP_Proximity_MorseSITL.h"
 #include "AP_Proximity_AirSimSITL.h"
 
 extern const AP_HAL::HAL &hal;
@@ -36,7 +37,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Proximity type
     // @Description: What type of proximity sensor is connected
-    // @Values: 0:None,7:LightwareSF40c,1:LightWareSF40C-legacy,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2,6:TeraRangerTowerEvo,8:LightwareSF45B,10:SITL,12:AirSimSITL
+    // @Values: 0:None,7:LightwareSF40c,1:LightWareSF40C-legacy,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2,6:TeraRangerTowerEvo,8:LightwareSF45B,9:RPLidarS1,10:SITL,12:AirSimSITL
     // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO("_TYPE",   1, AP_Proximity, _type[0], 0),
@@ -287,7 +288,9 @@ void AP_Proximity::detect_instance(uint8_t instance)
             return;
         }
         break;
+    //A2 and S1 uses the same protocol, only differ in reset
     case Type::RPLidarA2:
+    case Type::RPLidarS1:
         if (AP_Proximity_RPLidarA2::detect()) {
             state[instance].instance = instance;
             drivers[instance] = new AP_Proximity_RPLidarA2(*this, state[instance]);
@@ -339,6 +342,11 @@ void AP_Proximity::detect_instance(uint8_t instance)
     case Type::SITL:
         state[instance].instance = instance;
         drivers[instance] = new AP_Proximity_SITL(*this, state[instance]);
+        return;
+
+    case Type::MorseSITL:
+        state[instance].instance = instance;
+        drivers[instance] = new AP_Proximity_MorseSITL(*this, state[instance]);
         return;
 
     case Type::AirSimSITL:

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -25,7 +25,6 @@
 #include "AP_Proximity_LightWareSF40C.h"
 #include "AP_Proximity_LightWareSF45B.h"
 #include "AP_Proximity_SITL.h"
-#include "AP_Proximity_MorseSITL.h"
 #include "AP_Proximity_AirSimSITL.h"
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -343,11 +343,6 @@ void AP_Proximity::detect_instance(uint8_t instance)
         drivers[instance] = new AP_Proximity_SITL(*this, state[instance]);
         return;
 
-    case Type::MorseSITL:
-        state[instance].instance = instance;
-        drivers[instance] = new AP_Proximity_MorseSITL(*this, state[instance]);
-        return;
-
     case Type::AirSimSITL:
         state[instance].instance = instance;
         drivers[instance] = new AP_Proximity_AirSimSITL(*this, state[instance]);

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -56,6 +56,7 @@ public:
         TRTOWEREVO = 6,
         SF40C = 7,
         SF45B = 8,
+        RPLidarS1 = 9,
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         SITL    = 10,
         AirSimSITL = 12,

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -104,15 +104,6 @@ void AP_Proximity_RPLidarA2::update(void)
     }
 }
 
-// get maximum distance (in meters) of sensor
-float AP_Proximity_RPLidarA2::distance_max() const
-{
-    if (frontend.get_type(state.instance) == AP_Proximity::Type::RPLidarS1)
-        return 40.0f;  //This is the max range of S1, but it's usually overstated 
-    else
-        return 16.0f;  //16m max range RPLIDAR2, if you want to support the 8m version this is the only line to change
-}
-
 void AP_Proximity_RPLidarA2::send_command(const uint8_t command)
 {
     const uint8_t tx_buffer[2] {RPLIDAR_PREAMBLE, command};

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -198,14 +198,20 @@ void AP_Proximity_RPLidarA2::get_readings()
                 //Any input in resetted state come from scan before reset, must discard
                     _uart->discard_input();
                if ((AP_HAL::millis() - _last_reset_ms) > RESET_S1_WAIT_MS ) { 
-                         set_scan_mode();
+                         if (!make_first_byte_in_payload('R')) { // that's 'R' as in RPiLidar
+                              return;
+                         }
+                         if (_byte_count < 63) {
+                              return;
+                         }
                }
-            }
-            if (!make_first_byte_in_payload('R')) { // that's 'R' as in RPiLidar
-                return;
-            }
-            if (_byte_count < 63) {
-                return;
+            } else {
+                if (!make_first_byte_in_payload('R')) { // that's 'R' as in RPiLidar
+                    return;
+                }
+                if (_byte_count < 63) {
+                    return;
+                }
             }
 #if RP_DEBUG_LEVEL
             // optionally spit out via mavlink the 63-bytes of cruft

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -185,7 +185,7 @@ void AP_Proximity_RPLidarA2::get_readings()
             // looking for 0x52 at start of buffer; the 62 following
             // bytes are "information"
             //All you have to do is to wait 2.1s after reset and you can start scan mode with S1, 2ms is wrong in documentation
-            if ( (frontend.get_type(state.instance) == AP_Proximity::Type::RPLidarS1) {
+            if (frontend.get_type(state.instance) == AP_Proximity::Type::RPLidarS1) {
                 //Any input in resetted state come from scan before reset, must discard
                     _uart->discard_input();
                if ((AP_HAL::millis() - _last_reset_ms) > RESET_S1_WAIT_MS ) { 

--- a/libraries/SITL/SIM_PS_RPLidarA2.cpp
+++ b/libraries/SITL/SIM_PS_RPLidarA2.cpp
@@ -103,6 +103,30 @@ void PS_RPLidarA2::update_input()
             set_inputstate(InputState::WAITING_FOR_PREAMBLE);
             return;
         }
+        case Command::GET_DEVICE_INFO: {
+            // consume the command:
+            memmove(_buffer, &_buffer[1], _buflen-1);
+            _buflen--;
+            send_response_descriptor(0x14, SendMode::SRSR, DataType::Unknown04);
+            // now send the device info:
+            struct PACKED _device_info {
+                uint8_t model;
+                uint8_t firmware_minor;
+                uint8_t firmware_major;
+                uint8_t hardware;
+                uint8_t serial[16];
+            } device_info;
+            device_info.model = device_info_model();
+            device_info.firmware_minor = 17;
+            device_info.firmware_major = 42;
+            device_info.hardware = 6;
+            const ssize_t ret = write_to_autopilot((const char*)&device_info, sizeof(device_info));
+            if (ret != sizeof(device_info)) {
+                abort();
+            }
+            set_inputstate(InputState::WAITING_FOR_PREAMBLE);
+            return;
+        }
         case Command::FORCE_SCAN:
             abort();
         case Command::RESET:

--- a/libraries/SITL/SIM_PS_RPLidarA2.h
+++ b/libraries/SITL/SIM_PS_RPLidarA2.h
@@ -101,12 +101,14 @@ private:
         SCAN = 0x20,
         FORCE_SCAN = 0x21,
         RESET = 0x40,
+        GET_DEVICE_INFO = 0x50,
         GET_HEALTH = 0x52,
     };
 
     void move_preamble_in_buffer();
 
     enum class DataType {
+        Unknown04 = 0x04, // uint8_t ?!
         Unknown06 = 0x06, // uint8_t ?!
         Unknown81 = 0x81, // uint8_t ?!
     };
@@ -124,6 +126,9 @@ private:
     // the driver expects to see an "R" followed by 62 bytes more crap.
     static const constexpr char *FIRMWARE_INFO = "R12345678901234567890123456789012345678901234567890123456789012";
     uint8_t _firmware_info_offset;
+
+    // this will be pure-virtual in a notional RPLidar base class:
+    uint8_t device_info_model() const { return 0x28; }
 };
 
 };


### PR DESCRIPTION
Attempt at merging PR #16505 and PR #14527 to master. 

The purpose of this is to add support for the RPlidar S1 which is lighter, more durable than the A series, and can work outdoors in full sun. 
A new PRX_TYPE = “9” is added for the Rplidar S1. 
The S1 will run in compatibility mode at a lower refresh rate using the same driver for the A2. The difference being that the lidar must be communicated with at 256k baud, and a delay of 2100ms must be implemented upon reset or startup. 

Currently untested, building and deploying now. Will update with results.