### PR TITLE
AP_L1_Control: correct zeroing of cross-track integrator

### DIFF
--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -205,9 +205,13 @@ void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct
 
     uint32_t now = AP_HAL::micros();
     float dt = (now - _last_update_waypoint_us) * 1.0e-6f;
+    if (dt > 1) {
+        // controller hasn't been called for an extended period of
+        // time.  Reinitialise it.
+        _L1_xtrack_i = 0.0f;
+    }
     if (dt > 0.1) {
         dt = 0.1;
-        _L1_xtrack_i = 0.0f;
     }
     _last_update_waypoint_us = now;
 


### PR DESCRIPTION
backporting Plane/Rover's L1 xtrack error bug to Plane 4.0 branch

This routine is generally only called at 10Hz, so the integrator was
regularly reset.

(cherry picked from commit fd9068de8a2759766ca3319cfef12ca58a4a3147)

closes https://github.com/ArduPilot/ardupilot/issues/2650
