### PR TITLE
AC_PosControl: Added a max leash length parameter (PSC_MAX_LEASH)

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -961,7 +961,7 @@ void AC_PosControl::update_vel_controller_xyz()
 void AC_PosControl::calc_leash_length_xy()
 {
     // Check if PSC_MAX_LEASH (_max_leash_length) agrees with _current_max_leash_length
-    if (std::abs(_current_max_leash_length - _max_leash_length) > 0){
+    if (!is_equal(_current_max_leash_length, _max_leash_length)) {
         // If _max_leash_length == 0 (or less) perform the calculation to automatically set the 
         //     _leash variable
         if (_max_leash_length <= 0.0f){

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -965,7 +965,7 @@ void AC_PosControl::calc_leash_length_xy()
         // If _max_leash_length == 0 (or less) perform the calculation to automatically set the 
         //     _leash variable
         _current_max_leash_length = _max_leash_length;
-        if (_max_leash_length <= 0.0f){
+        if (!is_positive(_max_leash_length)) {
             _flags.recalc_leash_xy = true;
         // else set _leash equal to _max_leash_length
         } else {

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -273,7 +273,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
 
     // @Param: _MAX_LEASH
     // @DisplayName: Position Control Leash Length Max
-    // @Description: Maximum position correction for velocity command.  Set to zero to use default calculate _leash value
+    // @Description: Maximum position correction for velocity command.  Set to zero to use default calculated leash value
     // @Units: cm
     // @Range: 0 1000
     // @Increment: 1

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -969,7 +969,6 @@ void AC_PosControl::calc_leash_length_xy()
         // else set _leash equal to _max_leash_length
         } else {
             set_leash_length_xy(_max_leash_length);
-            _current_max_leash_length = _max_leash_length;
         }
     }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -961,7 +961,7 @@ void AC_PosControl::update_vel_controller_xyz()
 void AC_PosControl::calc_leash_length_xy()
 {
     // Check if PSC_MAX_LEASH (_max_leash_length) agrees with _current_max_leash_length
-    if (!is_equal(_current_max_leash_length, _max_leash_length)) {
+    if (!is_equal(_current_max_leash_length, static_cast<float>(_max_leash_length))) {
         // If _max_leash_length == 0 (or less) perform the calculation to automatically set the 
         //     _leash variable
         _current_max_leash_length = _max_leash_length;

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -964,6 +964,7 @@ void AC_PosControl::calc_leash_length_xy()
     if (!is_equal(_current_max_leash_length, _max_leash_length)) {
         // If _max_leash_length == 0 (or less) perform the calculation to automatically set the 
         //     _leash variable
+        _current_max_leash_length = _max_leash_length;
         if (_max_leash_length <= 0.0f){
             _flags.recalc_leash_xy = true;
         // else set _leash equal to _max_leash_length

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -961,7 +961,7 @@ void AC_PosControl::update_vel_controller_xyz()
 void AC_PosControl::calc_leash_length_xy()
 {
     // Check if PSC_MAX_LEASH (_max_leash_length) agrees with _current_max_leash_length
-    if (!is_equal(_current_max_leash_length, static_cast<float>(_max_leash_length))) {
+    if (!is_equal(_current_max_leash_length, _max_leash_length.get())) {
         // If _max_leash_length == 0 (or less) perform the calculation to automatically set the 
         //     _leash variable
         _current_max_leash_length = _max_leash_length;

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -273,7 +273,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
 
     // @Param: _MAX_LEASH
     // @DisplayName: Position Control Leash Length Max
-    // @Description: Maximum position correction for velocity command.  Set to zero to use default calculated leash value
+    // @Description: Maximum position deviation for velocity command.  Set to zero to use default calculated leash value
     // @Units: cm
     // @Range: 0 1000
     // @Increment: 1

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -966,7 +966,6 @@ void AC_PosControl::calc_leash_length_xy()
         //     _leash variable
         if (_max_leash_length <= 0.0f){
             _flags.recalc_leash_xy = true;
-            _current_max_leash_length = _max_leash_length;
         // else set _leash equal to _max_leash_length
         } else {
             set_leash_length_xy(_max_leash_length);

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -42,6 +42,7 @@
 #define POSCONTROL_JERK_RATIO                   1.0f    // Defines the time it takes to reach the requested acceleration
 
 #define POSCONTROL_OVERSPEED_GAIN_Z             2.0f    // gain controlling rate at which z-axis speed is brought back within SPEED_UP and SPEED_DOWN range
+#define POSCONTROL_MAX_LEASH                    0.0f    // default max leash length (value of 0 keeps the calculated _leash value)
 
 class AC_PosControl
 {
@@ -381,6 +382,7 @@ protected:
     // parameters
     AP_Float    _accel_xy_filt_hz;      // XY acceleration filter cutoff frequency
     AP_Float    _lean_angle_max;        // Maximum autopilot commanded angle (in degrees). Set to zero for Angle Max
+    AP_Float    _max_leash_length;      // Max leash length for position control
     AC_P_2D     _p_pos_xy;              // XY axis position controller to convert distance error to desired velocity
     AC_P_1D     _p_pos_z;               // Z axis position controller to convert altitude error to desired climb rate
     AC_PID_2D   _pid_vel_xy;            // XY axis velocity controller to convert velocity error to desired acceleration
@@ -401,6 +403,7 @@ protected:
     float       _leash_down_z;          // vertical leash down in cm.  target will never be further than this distance below the vehicle
     float       _leash_up_z;            // vertical leash up in cm.  target will never be further than this distance above the vehicle
     float       _vel_z_control_ratio = 2.0f;   // confidence that we have control in the vertical axis
+    float       _current_max_leash_length; // current maximum leash length. This is used to keep track of parameter changes
 
     // output from controller
     float       _roll_target;           // desired roll angle in centi-degrees calculated by position controller


### PR DESCRIPTION
Added a parameter that allows the user to set the maximum controllable position error in lateral control. 
Optional parameter called PSC_MAX_LEASH. If set to non-zero value, The maximum position error will be equal to PSC_MAX_LEASH rather than the default calculated value