### PR TITLE
Update Scripting/applets/SmartAudio.lua

### DIFF
--- a/libraries/AP_Scripting/applets/SmartAudio.lua
+++ b/libraries/AP_Scripting/applets/SmartAudio.lua
@@ -37,8 +37,8 @@ power_commands[5] = { {0x00,0x00,0xAA,0x55,0x05,0x01,0x03,0xC1,0x00}, "VTX PWR M
 
 -- return a power level from 1 to 5 as set with a switch
 function get_power()
-  input = scripting_rc:norm_input() -- - 1 to 1
-  input = (input + 1) * 2 -- 0 to 4
+  input = scripting_rc:norm_input() -- 0 to 1
+  input = (input * 4) -- 0 to 4
   return math.floor(input+0.5) + 1 -- integer 1 to 5
 end
 


### PR DESCRIPTION
scripting_rc:norm_input does not return -1 - 1 but now returns 0 -1. Have updated the multiplier to get value 0-4