### PR TITLE
AC_WPNav: fix spline initialisation of terrain offset

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -687,14 +687,16 @@ bool AC_WPNav::set_spline_destination(const Vector3f& destination, bool terrain_
 
     // calculate origin and origin velocity vector
     Vector3f origin_vector;
-    if (terrain_alt == _terrain_alt && _flags.fast_waypoint) {
-        // calculate origin vector
-        if (_this_leg_is_spline) {
-            // if previous leg was a spline we can use destination velocity vector for origin velocity vector
-            origin_vector = _spline_this_leg.get_destination_vel();
-        } else {
-            // use direction of the previous straight line segment
-            origin_vector = _destination - _origin;
+    if (terrain_alt == _terrain_alt) {
+        if (_flags.fast_waypoint) {
+            // calculate origin vector
+            if (_this_leg_is_spline) {
+                // if previous leg was a spline we can use destination velocity vector for origin velocity vector
+                origin_vector = _spline_this_leg.get_destination_vel();
+            } else {
+                // use direction of the previous straight line segment
+                origin_vector = _destination - _origin;
+            }
         }
 
         // use previous destination as origin


### PR DESCRIPTION
This fixes a bug in AC_WPNav's spline initialisation which can cause it to fly at the wrong altitude if the vehicle has come to a stop before starting the spline (aka not a "fast waypoint").

The bug can be recreated in SITL using a mission like shown below flying in an environment with significant terrain changes.  The trouble occurs on command 3 when it incorrectly applies a terrain offset to the spline's origin and destination
![before](https://user-images.githubusercontent.com/1498098/116237865-b0a05880-a79b-11eb-9984-e9f800f0fb28.png)

Below is a screenshot of the same test with this PR's fix applied and we can see there is no strange climb above 10m (relative).
![image](https://user-images.githubusercontent.com/1498098/116238195-0aa11e00-a79c-11eb-93b4-ef4a3718e3eb.png)

This also resolves issue https://github.com/ArduPilot/ardupilot/issues/17250 found by PeterB.  Thanks!