### PR TITLE
Blimp: remove armed_with_switch state

### DIFF
--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -421,9 +421,6 @@ bool AP_Arming_Blimp::arm(const AP_Arming::Method method, const bool do_arming_c
     // Start the arming delay
     blimp.ap.in_arming_delay = true;
 
-    // assumed armed without a arming, switch. Overridden in switches.cpp
-    blimp.ap.armed_with_switch = false;
-
     // return success
     return true;
 }

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -190,7 +190,7 @@ private:
             uint8_t initialised_params      : 1; // 24      // true when the all parameters have been initialised. we cannot send parameters to the GCS until this is done
             uint8_t unused3                 : 1; // 25      // was compass_init_location; true when the compass's initial location has been set
             uint8_t unused2                 : 1; // 26      // aux switch rc_override is allowed
-            uint8_t armed_with_switch       : 1; // 27      // we armed using a arming switch
+            uint8_t unused4                 : 1; // 27      // was "we armed using a arming switch"
         };
         uint32_t value;
     } ap_t;

--- a/Blimp/RC_Channel.cpp
+++ b/Blimp/RC_Channel.cpp
@@ -93,16 +93,6 @@ void RC_Channel_Blimp::do_aux_function_change_mode(const Mode::Number mode,
     }
 }
 
-void RC_Channel_Blimp::do_aux_function_armdisarm(const AuxSwitchPos ch_flag)
-{
-    RC_Channel::do_aux_function_armdisarm(ch_flag);
-    if (blimp.arming.is_armed()) {
-        // remember that we are using an arming switch, for use by
-        // set_throttle_zero_flag
-        blimp.ap.armed_with_switch = true;
-    }
-}
-
 // do_aux_function - implement the function invoked by auxiliary switches
 bool RC_Channel_Blimp::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos ch_flag)
 {

--- a/Blimp/RC_Channel.h
+++ b/Blimp/RC_Channel.h
@@ -16,7 +16,6 @@ protected:
 
 private:
 
-    void do_aux_function_armdisarm(const AuxSwitchPos ch_flag) override;
     void do_aux_function_change_mode(const Mode::Number mode,
                                      const AuxSwitchPos ch_flag);
     void do_aux_function_change_air_mode(const AuxSwitchPos ch_flag);


### PR DESCRIPTION
Unused state

Used in Copter to enable airmode, not relevant for a blimp

