### PR TITLE
Reset SITL commandline on context pop

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -671,6 +671,12 @@ def run_tests(steps):
     """Run a list of steps."""
     global results
 
+    corefiles = glob.glob("core*")
+    if corefiles:
+        print('Removing corefiles: %s' % str(corefiles))
+        for f in corefiles:
+            os.unlink(f)
+
     passed = True
     failed = []
     failed_testinstances = dict()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4155,6 +4155,9 @@ class AutoTest(ABC):
     def context_pop(self):
         """Set parameters to origin values in reverse order."""
         dead = self.contexts.pop()
+        if dead.sitl_commandline_customised and len(self.contexts):
+            self.contexts[-1].sitl_commandline_customised = True
+
         dead_parameters_dict = {}
         for p in dead.parameters:
             dead_parameters_dict[p[0]] = p[1]


### PR DESCRIPTION
This PR resolves an issue in autotest where we would run the Callisto frame for tests after the baro-wind-compensation test as the "sitl commandline was customised" flag was not passed up to the enclosing context.

This changes us to reset the SITL commandline on any context pop - the customisation is part of the context now.

Tested... in autotest...

Also snuck a patch in here to delete corefiles.  Because they caused false failures.  And vexed me.
