### PR TITLE
autotest: add test which flies each frame we can

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6494,7 +6494,6 @@ class AutoTestCopter(AutoTest):
             'hexa-cwx': "does not take off",
             'hexa-dji': "does not take off",
             'octa-cwx': "does not take off",
-            'octa-dji': "does not take off",
             'octa-quad-cwx': "does not take off",
             'tri': "does not take off",
         }

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6486,7 +6486,13 @@ class AutoTestCopter(AutoTest):
         copter_vinfo_options = vinfo.options[self.vehicleinfo_key()]
         known_broken_frames = {
             'cwx': "missing defaults file",
-            'deca-cwx': "doesn't take off",
+            # the following can be removed once
+            # https://github.com/ArduPilot/mavlink/pull/205 and and
+            # associated PR against ardupilot for the mavlink
+            # submodule have been merged:
+            'deca': "pymavlink reference out-of-date in ArduPilot's mavlink",
+            'deca-cwx': "pymavlink reference out-of-date in ArduPilot's mavlink",
+            'dodeca-hexa': "pymavlink reference out-of-date in ArduPilot's mavlink",
             'djix': "missing defaults file",
             'heli-compound': "wrong binary, different takeoff regime",
             'heli-dual': "wrong binary, different takeoff regime",

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6493,7 +6493,6 @@ class AutoTestCopter(AutoTest):
             'heli': "wrong binary, different takeoff regime",
             'hexa-cwx': "does not take off",
             'hexa-dji': "does not take off",
-            'octa-cwx': "does not take off",
             'octa-quad-cwx': "does not take off",
             'tri': "does not take off",
         }

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4525,7 +4525,7 @@ class AutoTest(ABC):
                 return mode_map.get(mode)
         if mode in mode_map.values():
             return mode
-        self.progress("Available modes '%s'" % mode_map)
+        self.progress("No mode (%s); available modes '%s'" % (mode, mode_map))
         raise ErrorException("Unknown mode '%s'" % mode)
 
     def run_cmd_do_set_mode(self,

--- a/Tools/autotest/default_params/copter-octa-cwx.parm
+++ b/Tools/autotest/default_params/copter-octa-cwx.parm
@@ -1,0 +1,1 @@
+FRAME_TYPE     14

--- a/Tools/autotest/default_params/copter-octa-dji.parm
+++ b/Tools/autotest/default_params/copter-octa-dji.parm
@@ -1,0 +1,1 @@
+FRAME_TYPE     13

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -58,7 +58,11 @@ class VehicleInfo(object):
             },
              "octa-cwx": {
                 "waf_target": "bin/arducopter",
-                "default_params_filename": "default_params/copter.parm",
+                "default_params_filename": [
+                    "default_params/copter.parm",
+                    "default_params/copter-octa.parm",
+                    "default_params/copter-octa-cwx.parm"
+                ],
             },
             "octa-quad-cwx": {
                 "waf_target": "bin/arducopter",

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -106,16 +106,19 @@ class VehicleInfo(object):
             "IrisRos": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": "default_params/copter.parm",
+                "external": True,
             },
             "gazebo-iris": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": ["default_params/copter.parm",
                                             "default_params/gazebo-iris.parm"],
+                "external": True,
             },
             "airsim-copter": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": ["default_params/copter.parm",
                                             "default_params/airsim-quadX.parm"],
+                "external": True,
             },
             # HELICOPTER
             "heli": {
@@ -142,9 +145,11 @@ class VehicleInfo(object):
             "scrimmage-copter" : {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": "default_params/copter.parm",
+                "external": True,
             },
             "calibration": {
                 "extra_mavlink_cmds": "module load sitl_calibration;",
+                "external": True,  # lies!  OTOH, hard to take off with this
             },
             "Callisto": {
                 "model": "octa-quad:@ROMFS/models/Callisto.json",

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -76,7 +76,11 @@ class VehicleInfo(object):
             },
             "octa-dji": {
                 "waf_target": "bin/arducopter",
-                "default_params_filename": "default_params/copter.parm",
+                "default_params_filename": [
+                    "default_params/copter.parm",
+                    "default_params/copter-octa.parm",
+                    "default_params/copter-octa-dji.parm"
+                ],
             },
             "deca": {
                 "waf_target": "bin/arducopter",


### PR DESCRIPTION
Can't fly a large number of frames in the autotest suite ATM - at least not trivially:

```
            'cwx': "missing defaults file",
            'deca-cwx': "doesn't take off",
            'djix': "missing defaults file",
            'heli-compound': "wrong binary, different takeoff regime",
            'heli-dual': "wrong binary, different takeoff regime",
            'heli': "wrong binary, different takeoff regime",
            'hexa-cwx': "does not take off",
            'hexa-dji': "does not take off",
            'octa-cwx': "does not take off",
            'octa-dji': "does not take off",
            'octa-quad-cwx': "does not take off",
            'tri': "does not take off",
```

... but once they're fixed and removed from that list they'll at least be able to take off in SITL...
