### PR TITLE
AP_NMEA_Output: fix baud rate

### DIFF
--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -40,6 +40,7 @@ AP_NMEA_Output::AP_NMEA_Output()
         if (_uart[i] == nullptr) {
             break;
         }
+        _uart[i]->begin(sm.find_baudrate(AP_SerialManager::SerialProtocol_NMEAOutput, i));
         _num_outputs++;
     }
 }


### PR DESCRIPTION
This ensure that the NMEA Output feature uses the SERIALx_BAUD rate parameter.

There is one report that this feature is always using 57600 so this attempts to resolve this.

We should wait to complete testing before this is merged.