### PR TITLE
Copter: fix takeoff drift if vehicle is not in origin

### DIFF
--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -146,7 +146,7 @@ void Mode::auto_takeoff_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !copter.ap.auto_armed) {
         make_safe_spool_down();
-        wp_nav->shift_wp_origin_to_current_pos();
+        wp_nav->shift_wp_origin_and_destination_to_current_pos_xy();
         return;
     }
 
@@ -165,7 +165,7 @@ void Mode::auto_takeoff_run()
         set_land_complete(false);
     } else {
         // motors have not completed spool up yet so relax navigation and position controllers
-        wp_nav->shift_wp_origin_to_current_pos();
+        wp_nav->shift_wp_origin_and_destination_to_current_pos_xy();
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         pos_control->update_z_controller();
         attitude_control->set_yaw_target_to_current_heading();

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -365,26 +365,6 @@ bool AC_WPNav::set_wp_destination_next_NED(const Vector3f& destination_NED)
     return set_wp_destination_next(Vector3f(destination_NED.x * 100.0f, destination_NED.y * 100.0f, -destination_NED.z * 100.0f), false);
 }
 
-/// shift_wp_origin_to_current_pos - shifts the origin and destination so the origin starts at the current position
-///     used to reset the position just before takeoff
-///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
-void AC_WPNav::shift_wp_origin_to_current_pos()
-{
-    // get current and target locations
-    const Vector3f &curr_pos = _inav.get_position();
-    const Vector3f pos_target = _pos_control.get_pos_target();
-
-    // calculate difference between current position and target
-    Vector3f pos_diff = curr_pos - pos_target;
-
-    // shift origin and destination
-    _origin += pos_diff;
-    _destination += pos_diff;
-
-    // move pos controller target and disable feed forward
-    _pos_control.set_pos_target(curr_pos);
-}
-
 /// shifts the origin and destination horizontally to the current position
 ///     used to reset the track when taking off without horizontal position control
 ///     relies on set_wp_destination or set_wp_origin_and_destination having been called first

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -116,11 +116,6 @@ public:
     bool set_wp_destination_NED(const Vector3f& destination_NED);
     bool set_wp_destination_next_NED(const Vector3f& destination_NED);
 
-    /// shift_wp_origin_to_current_pos - shifts the origin and destination so the origin starts at the current position
-    ///     used to reset the position just before takeoff
-    ///     relies on set_wp_destination or set_wp_origin_and_destination having been called first
-    void shift_wp_origin_to_current_pos();
-
     /// shifts the origin and destination horizontally to the current position
     ///     used to reset the track when taking off without horizontal position control
     ///     relies on set_wp_destination or set_wp_origin_and_destination having been called first


### PR DESCRIPTION
replace #17132

@lthall [suggest](https://github.com/ArduPilot/ardupilot/pull/17132#issuecomment-826488543) change the implementation of ```shift_wp_origin_to_current_pos()``` to

``` 
// get current and target locations
const Vector3f& curr_pos = _inav.get_position();

// shift origin and destination horizontally
_origin.x = curr_pos.x;
_origin.y = curr_pos.y;
_destination.x = curr_pos.x;
_destination.y = curr_pos.y;

// move pos controller to the current position
_pos_control.set_pos_target(curr_pos); 
``` 
It makes it just the same as ```shift_wp_origin_and_destination_to_current_pos_xy()```. Maybe we should just use it
flight test log using ext nav
[5 2021-4-29 AM 10-12-26.zip](https://github.com/ArduPilot/ardupilot/files/6395979/5.2021-4-29.AM.10-12-26.zip)
[4 2021-4-29 AM 10-10-10.zip](https://github.com/ArduPilot/ardupilot/files/6395980/4.2021-4-29.AM.10-10-10.zip)

