### PR TITLE
Copter: AutoTune entry simplification and always init position controller

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -550,7 +550,6 @@ public:
     void run() override;
 
 protected:
-    bool start(void) override;
     bool position_ok() override;
     float get_pilot_desired_climb_rate_cms(void) const override;
     void get_pilot_desired_rp_yrate_cd(float &roll_cd, float &pitch_cd, float &yaw_rate_cds) override;

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -8,21 +8,6 @@
 
 bool AutoTune::init()
 {
-    // use position hold while tuning if we were in QLOITER
-    bool position_hold = (copter.flightmode->mode_number() == Mode::Number::LOITER || copter.flightmode->mode_number() == Mode::Number::POSHOLD);
-
-    return init_internals(position_hold,
-                          copter.attitude_control,
-                          copter.pos_control,
-                          copter.ahrs_view,
-                          &copter.inertial_nav);
-}
-
-/*
-  start autotune mode
- */
-bool AutoTune::start()
-{
     // only allow AutoTune from some flight modes, for example Stabilize, AltHold,  PosHold or Loiter modes
     if (!copter.flightmode->allows_autotune()) {
         return false;
@@ -38,7 +23,14 @@ bool AutoTune::start()
         return false;
     }
 
-    return AC_AutoTune::start();
+    // use position hold while tuning if we were in QLOITER
+    bool position_hold = (copter.flightmode->mode_number() == Mode::Number::LOITER || copter.flightmode->mode_number() == Mode::Number::POSHOLD);
+
+    return init_internals(position_hold,
+                          copter.attitude_control,
+                          copter.pos_control,
+                          copter.ahrs_view,
+                          &copter.inertial_nav);
 }
 
 void AutoTune::run()
@@ -127,7 +119,6 @@ bool ModeAutoTune::init(bool ignore_checks)
 {
     return autotune.init();
 }
-
 
 void ModeAutoTune::run()
 {

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -61,9 +61,6 @@ protected:
 
     // log PIDs at full rate for during twitch
     virtual void log_pids() = 0;
-    
-    // start tune - virtual so that vehicle code can add additional pre-conditions
-    virtual bool start(void);
 
     // return true if we have a good position estimate
     virtual bool position_ok();
@@ -74,6 +71,9 @@ protected:
                         AC_PosControl *pos_control,
                         AP_AHRS_View *ahrs_view,
                         AP_InertialNav *inertial_nav);
+
+    // initialise position controller
+    bool init_position_controller();
 
 private:
     void control_attitude();


### PR DESCRIPTION
This PR does three things related to AutoTune's initialisation:

1. Simplifies the entry checks to AutoTune mode by moving the Copter specific checks into the AutoTune::init() method.  This is a slightly simpler flow of control vs master which is Copter::AutoTune::init() -> AC_AutoTune::init_internals -> Copter::AutoTune::start().  This removes the need for start() to be virtual.
2. The motors->armed() check is also moved out of AC_AutoTune::start() to the top of AC_AutoTune::init_internals() and "start" is renamed to "init_position_controller" because it's purpose has been reduced.  I think this name is more specific and less confusing that "start" which implied that the method was responsible for somehow setting state variables related to the tune.
3. The position controller is always initialised.  Previously it was not being initialised if the mode == SUCCESS.  the issue was that init_internals was not calling "start()" if mode == SUCCESS

This requires some more testing at least in SITL.
The missing position controller initialisation was uncovered as part of @lthall's upcoming position controller changes.

I've tested Copter AutoTune and it produces very similar results as before



Copter  | old | new | difference
-- | -- | -- | --
ATC_ACCEL_P_MAX | 378049.1 | 380000.3 | 0.52%
ATC_ACCEL_R_MAX | 376223.6 | 372854.8 | -0.90%
ATC_ACCEL_Y_MAX | 52867.1 | 53567.6 | 1.32%
ATC_ANG_PIT_P | 18.0 | 18.0 | 0.00%
ATC_ANG_RLL_P | 18.0 | 18.0 | 0.00%
ATC_ANG_YAW_P | 18.0 | 18.0 | 0.00%
ATC_RAT_PIT_D | 0.0 | 0.0 | 5.24%
ATC_RAT_PIT_I | 0.2 | 0.2 | 0.25%
ATC_RAT_PIT_P | 0.2 | 0.2 | 0.25%
ATC_RAT_RLL_D | 0.0 | 0.0 | 5.24%
ATC_RAT_RLL_I | 0.2 | 0.2 | 0.25%
ATC_RAT_RLL_IMAX | 0.5 | 0.5 | 0.00%
ATC_RAT_RLL_P | 0.2 | 0.2 | 0.25%
ATC_RAT_YAW_D | 0 | 0 | 0.00%
ATC_RAT_YAW_FF | 0 | 0 | 0.00%
ATC_RAT_YAW_FLTD | 0 | 0 | 0.00%
ATC_RAT_YAW_FLTE | 5 | 5 | 0.00%
ATC_RAT_YAW_FLTT | 20 | 20 | 0.00%
ATC_RAT_YAW_I | 0.004243 | 0.004243 | 0.00%
ATC_RAT_YAW_P | 0.042435 | 0.042435 | 0.00%

