### PR TITLE
ACC & GYR move log structs to AP_InertialSensor

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -306,17 +306,7 @@ void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sa
         return;
     }
     if (should_log_imu_raw()) {
-        uint64_t now = AP_HAL::micros64();
-        const struct log_GYR pkt{
-            LOG_PACKET_HEADER_INIT(LOG_GYR_MSG),
-            time_us   : now,
-            instance  : instance,
-            sample_us : sample_us?sample_us:now,
-            GyrX      : gyro.x,
-            GyrY      : gyro.y,
-            GyrZ      : gyro.z
-        };
-        logger->WriteBlock(&pkt, sizeof(pkt));
+        Write_GYR(instance, sample_us, gyro);
     } else {
         if (!_imu.batchsampler.doing_sensor_rate_logging()) {
             _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, sample_us, gyro);
@@ -454,17 +444,7 @@ void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t s
         return;
     }
     if (should_log_imu_raw()) {
-        uint64_t now = AP_HAL::micros64();
-        const struct log_ACC pkt {
-            LOG_PACKET_HEADER_INIT(LOG_ACC_MSG),
-            time_us   : now,
-            instance  : instance,
-            sample_us : sample_us?sample_us:now,
-            AccX      : accel.x,
-            AccY      : accel.y,
-            AccZ      : accel.z
-        };
-        logger->WriteBlock(&pkt, sizeof(pkt));
+        Write_ACC(instance, sample_us, accel);
     } else {
         if (!_imu.batchsampler.doing_sensor_rate_logging()) {
             _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, sample_us, accel);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -342,4 +342,8 @@ private:
     void log_accel_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &accel);
     void log_gyro_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &gryo);
 
+    // logging
+    void Write_ACC(const uint8_t instance, const uint64_t sample_us, const Vector3f &accel) const; // Write ACC data packet: raw accel data
+    void Write_GYR(const uint8_t instance, const uint64_t sample_us, const Vector3f &gyro) const;  // Write GYR data packet: raw gyro data
+
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -3,6 +3,38 @@
 
 #include <AP_Logger/AP_Logger.h>
 
+// Write ACC data packet: raw accel data
+void AP_InertialSensor_Backend::Write_ACC(const uint8_t instance, const uint64_t sample_us, const Vector3f &accel) const
+{
+        const uint64_t now = AP_HAL::micros64();
+        const struct log_ACC pkt {
+            LOG_PACKET_HEADER_INIT(LOG_ACC_MSG),
+            time_us   : now,
+            instance  : instance,
+            sample_us : sample_us?sample_us:now,
+            AccX      : accel.x,
+            AccY      : accel.y,
+            AccZ      : accel.z
+        };
+        AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write GYR data packet: raw gyro data
+void AP_InertialSensor_Backend::Write_GYR(const uint8_t instance, const uint64_t sample_us, const Vector3f &gyro) const
+{
+        const uint64_t now = AP_HAL::micros64();
+        const struct log_GYR pkt{
+            LOG_PACKET_HEADER_INIT(LOG_GYR_MSG),
+            time_us   : now,
+            instance  : instance,
+            sample_us : sample_us?sample_us:now,
+            GyrX      : gyro.x,
+            GyrY      : gyro.y,
+            GyrZ      : gyro.z
+        };
+        AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
 // Write IMU data packet: raw accel/gyro data
 void AP_InertialSensor::Write_IMU_instance(const uint64_t time_us, const uint8_t imu_instance) const
 {

--- a/libraries/AP_InertialSensor/LogStructure.h
+++ b/libraries/AP_InertialSensor/LogStructure.h
@@ -3,10 +3,44 @@
 #include <AP_Logger/LogStructure.h>
 
 #define LOG_IDS_FROM_INERTIALSENSOR \
+    LOG_ACC_MSG, \
+    LOG_GYR_MSG, \
     LOG_IMU_MSG, \
     LOG_ISBH_MSG, \
     LOG_ISBD_MSG, \
     LOG_VIBE_MSG
+
+// @LoggerMessage: ACC
+// @Description: IMU accelerometer data
+// @Field: TimeUS: Time since system startup
+// @Field: I: accelerometer sensor instance number
+// @Field: SampleUS: time since system startup this sample was taken
+// @Field: AccX: acceleration along X axis
+// @Field: AccY: acceleration along Y axis
+// @Field: AccZ: acceleration along Z axis
+struct PACKED log_ACC {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    uint64_t sample_us;
+    float AccX, AccY, AccZ;
+};
+
+// @LoggerMessage: GYR
+// @Description: IMU gyroscope data
+// @Field: TimeUS: Time since system startup
+// @Field: I: gyroscope sensor instance number
+// @Field: SampleUS: time since system startup this sample was taken
+// @Field: GyrX: measured rotation rate about X axis
+// @Field: GyrY: measured rotation rate about Y axis
+// @Field: GyrZ: measured rotation rate about Z axis
+struct PACKED log_GYR {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    uint64_t sample_us;
+    float GyrX, GyrY, GyrZ;
+};
 
 // @LoggerMessage: IMU
 // @Description: Inertial Measurement Unit data
@@ -78,6 +112,10 @@ struct PACKED log_Vibe {
 };
 
 #define LOG_STRUCTURE_FROM_INERTIALSENSOR        \
+    { LOG_ACC_MSG, sizeof(log_ACC), \
+      "ACC", "QBQfff",        "TimeUS,I,SampleUS,AccX,AccY,AccZ", "s#sooo", "F-F000" }, \
+    { LOG_GYR_MSG, sizeof(log_GYR), \
+      "GYR", "QBQfff",        "TimeUS,I,SampleUS,GyrX,GyrY,GyrZ", "s#sEEE", "F-F000" }, \
     { LOG_IMU_MSG, sizeof(log_IMU), \
       "IMU",  "QBffffffIIfBBHH", "TimeUS,I,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,EG,EA,T,GH,AH,GHz,AHz", "s#EEEooo--O--zz", "F-000000-----00" }, \
     { LOG_VIBE_MSG, sizeof(log_Vibe), \

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -491,22 +491,6 @@ struct PACKED log_ARSP {
     uint8_t primary;
 };
 
-struct PACKED log_ACC {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t instance;
-    uint64_t sample_us;
-    float AccX, AccY, AccZ;
-};
-
-struct PACKED log_GYR {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t instance;
-    uint64_t sample_us;
-    float GyrX, GyrY, GyrZ;
-};
-
 struct PACKED log_MAV_Stats {
     LOG_PACKET_HEADER;
     uint64_t timestamp;
@@ -799,15 +783,6 @@ struct PACKED log_PSCZ {
 #define PID_UNITS  "s----------"
 #define PID_MULTS  "F----------"
 
-// @LoggerMessage: ACC
-// @Description: IMU accelerometer data
-// @Field: TimeUS: Time since system startup
-// @Field: I: accelerometer sensor instance number
-// @Field: SampleUS: time since system startup this sample was taken
-// @Field: AccX: acceleration along X axis
-// @Field: AccY: acceleration along Y axis
-// @Field: AccZ: acceleration along Z axis
-
 // @LoggerMessage: ADSB
 // @Description: Automatic Dependant Serveillance - Broadcast detected vehicle information
 // @Field: TimeUS: Time since system startup
@@ -972,16 +947,6 @@ struct PACKED log_PSCZ {
 // @Field: FmtType: numeric reference to associated FMT message
 // @Field: UnitIds: each character refers to a UNIT message.  The unit at an offset corresponds to the field at the same offset in FMT.Format
 // @Field: MultIds: each character refers to a MULT message.  The multiplier at an offset corresponds to the field at the same offset in FMT.Format
-
-
-// @LoggerMessage: GYR
-// @Description: IMU gyroscope data
-// @Field: TimeUS: Time since system startup
-// @Field: I: gyroscope sensor instance number
-// @Field: SampleUS: time since system startup this sample was taken
-// @Field: GyrX: measured rotation rate about X axis
-// @Field: GyrY: measured rotation rate about Y axis
-// @Field: GyrZ: measured rotation rate about Z axis
 
 // @LoggerMessage: LGR
 // @Description: Landing gear information
@@ -1436,10 +1401,6 @@ LOG_STRUCTURE_FROM_CAMERA \
       "CSRV","QBfffB","TimeUS,Id,Pos,Force,Speed,Pow", "s#---%", "F-0000" }, \
     { LOG_CESC_MSG, sizeof(log_CESC), \
       "CESC","QBIfffiB","TimeUS,Id,ECnt,Voltage,Curr,Temp,RPM,Pow", "s#-vAOq%", "F-000000" }, \
-    { LOG_ACC_MSG, sizeof(log_ACC), \
-      "ACC", "QBQfff",        "TimeUS,I,SampleUS,AccX,AccY,AccZ", "s#sooo", "F-F000" }, \
-    { LOG_GYR_MSG, sizeof(log_GYR), \
-      "GYR", "QBQfff",        "TimeUS,I,SampleUS,GyrX,GyrY,GyrZ", "s#sEEE", "F-F000" }, \
     { LOG_PIDR_MSG, sizeof(log_PID), \
       "PIDR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS }, \
     { LOG_PIDP_MSG, sizeof(log_PID), \
@@ -1559,8 +1520,6 @@ enum LogMessages : uint8_t {
     LOG_IDS_FROM_DAL,
     LOG_IDS_FROM_INERTIALSENSOR,
 
-    LOG_ACC_MSG,
-    LOG_GYR_MSG,
     LOG_PIDR_MSG,
     LOG_PIDP_MSG,
     LOG_PIDY_MSG,


### PR DESCRIPTION
This moves the `GYR` & `ACC` log structs from `AP_Logger` to `AP_IntertialSensor`. And places the logging to `AP_IntertialSensor_Logging.cpp`

Edit: see review below
~~Removes a redundant logger nullptr check that is already covered in `should_log_imu_raw()`.~~

**Before PR**
![before_pr_x_z](https://user-images.githubusercontent.com/69225461/116668014-e0518b00-a96a-11eb-8e0b-07d1cfcbd99e.png)

**After PR**
![after_pr_x_z](https://user-images.githubusercontent.com/69225461/116668051-eba4b680-a96a-11eb-8782-7193fd2dbc33.png)
