### PR TITLE
ChibiOS: fixed the clock selection on H7 SDMMC

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -546,3 +546,10 @@
 
 // limit ISR count per byte
 #define STM32_I2C_ISR_LIMIT                 6
+
+// limit SDMMC clock to 12.5MHz by default. This increases
+// reliability
+#ifndef STM32_SDC_MAX_CLOCK
+#define STM32_SDC_MAX_CLOCK                 12500000
+#endif
+


### PR DESCRIPTION
cap clock at 12.5MHz

this also gets rid of the annoying warning when building on H7

requires https://github.com/ArduPilot/ChibiOS/pull/27
