### PR TITLE
AP_Logger: minimal fix for allowing log listing while logging

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -620,6 +620,19 @@ bool AP_Logger::should_log(const uint32_t mask) const
     return true;
 }
 
+/*
+  return true if in log download which should prevent logging
+ */
+bool AP_Logger::in_log_download() const
+{
+    if (uint8_t(_params.backend_types) & uint8_t(Backend_Type::BLOCK)) {
+        // when we have a BLOCK backend then listing completely prevents logging
+        return transfer_activity != TransferActivity::IDLE;
+    }
+    // for other backends listing does not interfere with logging
+    return transfer_activity == TransferActivity::SENDING;
+}
+
 const struct UnitStructure *AP_Logger::unit(uint16_t num) const
 {
     return &_units[num];

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -407,9 +407,7 @@ public:
     bool vehicle_is_armed() const { return _armed; }
 
     void handle_log_send();
-    bool in_log_download() const {
-        return transfer_activity != TransferActivity::IDLE;
-    }
+    bool in_log_download() const;
 
     float quiet_nanf() const { return nanf("0x4152"); } // "AR"
     double quiet_nan() const { return nan("0x4152445550490a"); } // "ARDUPI"

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -429,7 +429,8 @@ bool AP_Logger_Backend::ShouldLog(bool is_critical)
         return false;
     }
 
-    if (_front._last_mavlink_log_transfer_message_handled_ms != 0) {
+    if (_front.in_log_download() &&
+        _front._last_mavlink_log_transfer_message_handled_ms != 0) {
         if (AP_HAL::millis() - _front._last_mavlink_log_transfer_message_handled_ms < 10000) {
             if (!_front.vehicle_is_armed()) {
                 // user is transfering files via mavlink


### PR DESCRIPTION
this prevents loss of log data when listing logs on file backend
This is a minimal fix for 4.1 to make replay logging reliable
