### PR TITLE
Warn user about CRSF on non-DMA channel

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -119,4 +119,9 @@ public:
     virtual uint32_t bw_in_kilobytes_per_second() const {
         return 57;
     }
+
+    /*
+      return true if this UART has DMA enabled on both RX and TX
+     */
+    virtual bool is_dma_enabled() const { return false; }
 };

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -131,6 +131,11 @@ public:
     // request information on uart I/O
     static void uart_info(ExpandingString &str);
 
+    /*
+      return true if this UART has DMA enabled on both RX and TX
+     */
+    bool is_dma_enabled() const override { return rx_dma_enabled && tx_dma_enabled; }
+
 private:
     const SerialDef &sdef;
     bool rx_dma_enabled;

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -148,8 +148,19 @@ void AP_CRSF_Telem::process_rf_mode_changes()
 {
     const AP_RCProtocol_CRSF::RFMode current_rf_mode = get_rf_mode();
     uint32_t now = AP_HAL::millis();
+
+    // the presence of a uart indicates that we are using CRSF for RC control
+    AP_RCProtocol_CRSF* crsf = AP::crsf();
+    AP_HAL::UARTDriver* uart = nullptr;
+    if (crsf != nullptr) {
+        uart = crsf->get_UART();
+    }
+    // warn the user if their setup is sub-optimal
+    if (_telem_last_report_ms == 0 && uart != nullptr && !uart->is_dma_enabled()) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "CRSF: running on non-DMA serial port");
+    }
     // report a change in RF mode or a chnage of more than 10Hz if we haven't done so in the last 5s
-    if ((now - _telem_last_report_ms > 5000) &&
+    if ((now - _telem_last_report_ms > 5000) && uart != nullptr &&
         (_telem_rf_mode != current_rf_mode || abs(int16_t(_telem_last_avg_rate) - int16_t(_scheduler.avg_packet_rate)) > 25)) {
         gcs().send_text(MAV_SEVERITY_INFO, "CRSF: RF mode %d, rate is %dHz", (uint8_t)current_rf_mode, _scheduler.avg_packet_rate);
         update_custom_telemetry_rates(current_rf_mode);


### PR DESCRIPTION
If the user is running CRSF on a non-DMA channel this will spit out a warning