### PR TITLE
AP_Scripting: add ability to load bindings at run time

### DIFF
--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -75,11 +75,21 @@ static int lua_mission_receive(lua_State *L) {
     return 5;
 }
 
+static int lua_load_singleton(lua_State *L) {
+    check_arguments(L, 1, "load_singleton");
+    const char * name = luaL_checkstring(L, 1);
+    if (!load_singleton_fun(L,name)) {
+        return luaL_error(L, "failed to load singleton: %s",name);
+    }
+    return 1;
+}
+
 static const luaL_Reg global_functions[] =
 {
     {"millis", lua_millis},
     {"micros", lua_micros},
     {"mission_receive", lua_mission_receive},
+    {"load_singleton", lua_load_singleton},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
We are using increasingly more memory in scripting.

This adds the ability to mark singletons to not be loaded by default in the description for example: 

`singleton AP_MotorsMatrix_6DoF_Scripting dont_load`

Then to get the functionality you would:

`Motors_6DoF = load_singleton("Motors_6DoF")`

Then you can use the singletons as normal. *except the enums

I tend to think that we have already got all the core bindings we need, so all future singletons should not be loaded by default. We should possibly also mark some of the existing ones too, at the expense of breaking some peoples scripts. It would be quite easy to support both in a script.

```
if not Motors_6DoF then
  Motors_6DoF = load_singleton("Motors_6DoF")
end
```

We could also have `SCR_ENABLE` = 2 meaning don't load any singletons. Each script would then maunaly load the ones it needs, this would result in a significant reduction in memory usage. 

We might want to also implement this for userdata and ap_object but there are far fewer of those.
