### PR TITLE
Support BLHeli overrides correctly

### DIFF
--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -122,7 +122,6 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
     EXPECT_DELAY_MS(5000);
 
     // enable motors and pass through throttle
-    init_rc_out();
     enable_motor_output();
     motors->armed(true);
     hal.util->set_soft_armed(true);

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -150,7 +150,6 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
             EXPECT_DELAY_MS(3000);
             // enable and arm motors
             if (!motors->armed()) {
-                init_rc_out();
                 enable_motor_output();
                 motors->armed(true);
                 hal.util->set_soft_armed(true);

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -46,6 +46,7 @@ public:
     AP_BLHeli();
     
     void update(void);
+    void init(void);
     void update_telemetry(void);
     bool process_input(uint8_t b);
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -512,10 +512,10 @@ void AP_MotorsMulticopter::set_throttle_range(int16_t radio_min, int16_t radio_m
     _throttle_radio_min = radio_min;
     _throttle_radio_max = radio_max;
 
-    if (_pwm_type >= PWM_TYPE_DSHOT150 && _pwm_type <= PWM_TYPE_DSHOT1200) {
-        // force PWM range for DShot ESCs
-        _pwm_min.set(1000);
-        _pwm_max.set(2000);
+    // if all outputs are digital adjust the range
+    if (SRV_Channels::have_digital_outputs(get_motor_mask())) {
+        _pwm_min = 1000;
+        _pwm_max = 2000;
     }
 
     hal.rcout->set_esc_scaling(get_pwm_output_min(), get_pwm_output_max());

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -505,14 +505,13 @@ public:
     static void set_disabled_channel_mask(uint16_t mask) { disabled_mask = mask; }
 
     // add to mask of outputs which can do reverse thrust using digital controls
-    static void set_reversible_mask(uint16_t mask) {
-        reversible_mask |= mask;
-    }
+    static void set_reversible_mask(uint16_t mask);
 
     // add to mask of outputs which use digital (non-PWM) output, such as DShot
-    static void set_digital_mask(uint16_t mask) {
-        digital_mask |= mask;
-    }
+    static void set_digital_mask(uint16_t mask);
+
+    // return true if all of the outputs in mask are digital
+    static bool have_digital_outputs(uint16_t mask) { return mask != 0 && (mask & digital_mask) == mask; }
 
     // Set E - stop
     static void set_emergency_stop(bool state) {

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -504,11 +504,8 @@ public:
     // disable output to a set of channels given by a mask. This is used by the AP_BLHeli code
     static void set_disabled_channel_mask(uint16_t mask) { disabled_mask = mask; }
 
-    // add to mask of outputs which can do reverse thrust using digital controls
-    static void set_reversible_mask(uint16_t mask);
-
-    // add to mask of outputs which use digital (non-PWM) output, such as DShot
-    static void set_digital_mask(uint16_t mask);
+    // add to mask of outputs which use digital (non-PWM) output and optionally can reverse thrust, such as DShot
+    static void set_digital_outputs(uint16_t dig_mask, uint16_t rev_mask);
 
     // return true if all of the outputs in mask are digital
     static bool have_digital_outputs(uint16_t mask) { return mask != 0 && (mask & digital_mask) == mask; }

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -226,18 +226,6 @@ void SRV_Channels::enable_aux_servos()
 #endif
 }
 
-// add to mask of outputs which can do reverse thrust using digital controls
-// digital mask must have been set first
-void SRV_Channels::set_reversible_mask(uint16_t mask) {
-    reversible_mask |= mask;
-    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        SRV_Channel &c = channels[i];
-        if ((digital_mask & (1U<<i)) && (reversible_mask & (1U<<i))) {
-            c.servo_trim.set(1500);
-        }
-    }
-}
-
 /*
     for channels which have been marked as digital output then the
     MIN/MAX/TRIM values have no meaning for controlling output, as
@@ -248,8 +236,10 @@ void SRV_Channels::set_reversible_mask(uint16_t mask) {
     set TRIM to either 1000 or 1500 depending on whether the channel
     is reversible
 */
-void SRV_Channels::set_digital_mask(uint16_t mask) {
-    digital_mask |= mask;
+void SRV_Channels::set_digital_outputs(uint16_t dig_mask, uint16_t rev_mask) {
+    digital_mask |= dig_mask;
+    reversible_mask |= rev_mask;
+
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         SRV_Channel &c = channels[i];
         if (digital_mask & (1U<<i)) {

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -219,17 +219,39 @@ void SRV_Channels::enable_aux_servos()
             c.set_output_pwm(c.servo_max);
             c.output_ch();
         }
+    }
 
-        /*
-          for channels which have been marked as digital output then the
-          MIN/MAX/TRIM values have no meaning for controlling output, as
-          the HAL handles the scaling. We still need to cope with places
-          in the code that may try to set a PWM value however, so to
-          ensure consistency we force the MIN/MAX/TRIM to be consistent
-          across all digital channels. We use a MIN/MAX of 1000/2000, and
-          set TRIM to either 1000 or 1500 depending on whether the channel
-          is reversible
-        */
+#if HAL_SUPPORT_RCOUT_SERIAL
+    blheli_ptr->update();
+#endif
+}
+
+// add to mask of outputs which can do reverse thrust using digital controls
+// digital mask must have been set first
+void SRV_Channels::set_reversible_mask(uint16_t mask) {
+    reversible_mask |= mask;
+    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
+        SRV_Channel &c = channels[i];
+        if ((digital_mask & (1U<<i)) && (reversible_mask & (1U<<i))) {
+            c.servo_trim.set(1500);
+        }
+    }
+}
+
+/*
+    for channels which have been marked as digital output then the
+    MIN/MAX/TRIM values have no meaning for controlling output, as
+    the HAL handles the scaling. We still need to cope with places
+    in the code that may try to set a PWM value however, so to
+    ensure consistency we force the MIN/MAX/TRIM to be consistent
+    across all digital channels. We use a MIN/MAX of 1000/2000, and
+    set TRIM to either 1000 or 1500 depending on whether the channel
+    is reversible
+*/
+void SRV_Channels::set_digital_mask(uint16_t mask) {
+    digital_mask |= mask;
+    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
+        SRV_Channel &c = channels[i];
         if (digital_mask & (1U<<i)) {
             c.servo_min.set(1000);
             c.servo_max.set(2000);
@@ -240,10 +262,6 @@ void SRV_Channels::enable_aux_servos()
             }
         }
     }
-
-#if HAL_SUPPORT_RCOUT_SERIAL
-    blheli_ptr->update();
-#endif
 }
 
 /// enable output channels using a channel mask

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -245,6 +245,10 @@ SRV_Channels::SRV_Channels(void)
 // SRV_Channels initialization
 void SRV_Channels::init(void)
 {
+    // initialize BLHeli late so that all of the masks it might setup don't get trodden on by motor initialization
+#if HAL_SUPPORT_RCOUT_SERIAL
+    blheli_ptr->init();
+#endif
     hal.rcout->set_dshot_rate(_singleton->dshot_rate, AP::scheduler().get_loop_rate_hz());
 }
 


### PR DESCRIPTION
BLHeli digital overrides did not work if MOT_PWM_TYPE was not a digital protocol

This seems like a fairly important fix - I can see how the old behaviour would end up marking non-digital outputs as digital if configured wrongly which Would Be Bad