### PR TITLE
Copter: circle mode: allow updating radius from param

### DIFF
--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -40,6 +40,9 @@ void ModeCircle::run()
         pilot_yaw_override = true;
     }
 
+    // Check for any change in params and update in real time
+    copter.circle_nav->check_param_change();
+
     // pilot changes to circle rate and radius
     // skip if in radio failsafe
     if (!copter.failsafe.radio && copter.circle_nav->pilot_control_enabled()) {

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -81,9 +81,11 @@ void AC_Circle::init(const Vector3f& center, bool terrain_alt)
 /// init - initialise circle controller setting center using stopping point and projecting out based on the copter's heading
 ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
 void AC_Circle::init()
-{   
-    //initialize radius from params
-    _radius =_radius_parm;
+{
+    // initialize radius from params
+    _radius = _radius_parm;
+    _last_radius_param = _radius_parm;
+
     // initialise position controller (sets target roll angle, pitch angle and I terms based on vehicle current lean angles)
     _pos_control.set_desired_accel_xy(0.0f,0.0f);
     _pos_control.set_desired_velocity_xy(0.0f,0.0f);
@@ -381,4 +383,12 @@ bool AC_Circle::get_terrain_offset(float& offset_cm)
 
     // we should never get here but just in case
     return false;
+}
+
+void AC_Circle::check_param_change()
+{
+    if (!is_equal(_last_radius_param,_radius_parm.get())) {
+        _radius = _radius_parm;
+        _last_radius_param = _radius_parm;
+    }
 }

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -92,6 +92,9 @@ public:
     /// provide rangefinder altitude
     void set_rangefinder_alt(bool use, bool healthy, float alt_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_alt_cm = alt_cm; }
 
+    /// check for a change in the radius params
+    void check_param_change();
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -149,6 +152,7 @@ private:
     float       _angular_vel_max;   // maximum velocity in radians/sec
     float       _angular_accel; // angular acceleration in radians/sec/sec
     uint32_t    _last_update_ms;    // system time of last update
+    float       _last_radius_param; // last value of radius param, used to update radius on param change
 
     // terrain following variables
     bool        _terrain_alt;           // true if _center.z is alt-above-terrain, false if alt-above-ekf-origin


### PR DESCRIPTION
This is a follow up to https://github.com/ArduPilot/ardupilot/pull/16757 from @giacomo892. This allows one to change the radius param and have the radius update in real time. This was the behavior prior to https://github.com/ArduPilot/ardupilot/pull/16757, current master requires to switch out of circle and back to re-check the param value. 

This is implemented via a new `check_param_change` function to ensure it is only active in circle mode and not loiter turns in auto.