### PR TITLE
Simplify get_wp_destination_loc()

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -247,19 +247,15 @@ bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
     return set_wp_destination_next(dest_neu, terr_alt);
 }
 
-// get destination as a location.  Altitude frame will be absolute (AMSL) or above terrain
+// get destination as a location. Altitude frame will be above origin or above terrain
 // returns false if unable to return a destination (for example if origin has not yet been set)
 bool AC_WPNav::get_wp_destination_loc(Location& destination) const
 {
     if (!AP::ahrs().get_origin(destination)) {
         return false;
     }
-    destination.offset(_destination.x*0.01f, _destination.y*0.01f);
-    if (_terrain_alt) {
-        destination.set_alt_cm(_destination.z, Location::AltFrame::ABOVE_TERRAIN);
-    } else {
-        destination.alt += _destination.z;
-    }
+
+    destination = Location{get_wp_destination(), _terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN};
     return true;
 }
 


### PR DESCRIPTION
This simplifies get_wp_destination_loc() to leave changing of the altitude frame to the caller.  It saves around 64 bytes for copter.

~Initially, there was an issue with one auto test fly_rangefinder_drivers() failing. This is why the `AP::ahrs().healthy()` was added to `send_position_target_global_int()`. I think this is because this message gets sent via `STREAM_EXTENDED_STATUS_msgs` before the EKF origin is set. And thus this is currently being caught many function calls deep in `get_wp_destination_loc()`.~



