### PR TITLE
AC_AutoTune:  Disable variables that are overwritten

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -157,8 +157,6 @@ bool AC_AutoTune::init_internals(bool _use_poshold,
 
     switch (mode) {
     case FAILED:
-        // autotune has been run but failed so reset state to uninitialized
-        mode = UNINITIALISED;
         // fall through to restart the tuning
         FALLTHROUGH;
 


### PR DESCRIPTION
FALLTHROUGH implements the following CASE process.
Therefore, the setting of the MODE variable will be overwritten.
Therefore, I commented it out.