### PR TITLE
Copter: Change the direct value to the definition name

### DIFF
--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -117,7 +117,7 @@ void ModeZigZag::run()
 
     // set the direction and the total number of lines
     zigzag_direction = (Direction)constrain_int16(_direction, 0, 3);
-    line_num = constrain_int16(_line_num, -1, 32767);
+    line_num = constrain_int16(_line_num, ZIGZAG_LINE_INFINITY, 32767);
 
     // auto control
     if (stage == AUTO) {


### PR DESCRIPTION
I would change the direct value to the definition name.
I prefer to use the definition name, if available.