### PR TITLE
Copter: Notify a message if the wp radius exceeds the zigzag wp radius

### DIFF
--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -97,6 +97,10 @@ bool ModeZigZag::init(bool ignore_checks)
     // initialize zigzag auto
     init_auto();
 
+    if (wp_nav->get_wp_radius() > ZIGZAG_WP_RADIUS_CM) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "ZIGZAG: Check WP Radius %.0f>%d", wp_nav->get_wp_radius(), ZIGZAG_WP_RADIUS_CM);
+    }
+
     return true;
 }
 

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -92,6 +92,9 @@ public:
     /// true if origin.z and destination.z are alt-above-terrain, false if alt-above-ekf-origin
     bool origin_and_destination_are_terrain_alt() const { return _terrain_alt; }
 
+    /// get_wp_radius - return way point radius in cm during missions.
+    float get_wp_radius() const { return _wp_radius_cm; }
+
     /// set_wp_destination waypoint using location class
     ///     provide the next_destination if known
     ///     returns false if conversion from location to vector from ekf origin cannot be calculated


### PR DESCRIPTION
The WP radius is 3D and the ZIGZAG WP radius is 2D.
In the case of ZIGZAG, if the horizontal radius is satisfied, it is considered an achievement.
If the WP radius exceeds the WP radius of ZIGZAG, notify GCS to review the setting.
I want this notification to make them set the value below the WP radius of ZIGZAG.
Notify a message if the WP radius exceeds the ZIGZAG WP radius

![Screenshot from 2021-05-04 16-33-06](https://user-images.githubusercontent.com/646194/116975928-6408d000-acfb-11eb-978b-a35757a86bed.png)
