### PR TITLE
AP_Scripting: add ability to load scripts as librarys

### DIFF
--- a/libraries/AP_Scripting/examples/simple_libary.lual
+++ b/libraries/AP_Scripting/examples/simple_libary.lual
@@ -1,0 +1,16 @@
+-- this ia a example library
+
+-- all variables and function must be stored in a table, this table is then returned when the library is setup
+lib = {}
+
+lib.number = math.random()
+
+function lib.update()
+  gcs:send_text(0, "hello, world")
+
+  gcs:send_named_float('Lua Float',lib.number)
+  lib.number = lib.number + math.random()
+
+end
+
+return lib

--- a/libraries/AP_Scripting/examples/simple_library.lua
+++ b/libraries/AP_Scripting/examples/simple_library.lua
@@ -1,0 +1,16 @@
+-- this script is a example of loading a 'libary' sub - script
+
+local lib = load_script("./scripts/simple_libary.lual")
+
+function update() -- this is the loop which periodically runs
+
+  -- print the number stored in the lib
+  gcs:send_text(0, "lib ".. tostring(lib.number)) 
+
+  -- run a function in the lib
+  lib.update()
+
+  return update, 1000 -- reschedules the loop
+end
+
+return update() -- run immediately before starting to reschedule


### PR DESCRIPTION
This sort of gets us `requires` support. We can load a script that returns a table of the functions and variables it has, we can then call the functions and scripts from the 'master' script.

Having to put all the stuff you need inside the lib in a table it abit annoying, not sure how to do it better tho.