### PR TITLE
GCS_MAVLink: Strictly check extensions.

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -296,7 +296,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                         put_le32_ptr(reply.data, (uint32_t)file_size);
 
                         // provide compatibility with old protocol banner download
-                        if (strncmp((const char *)request.data, "@PARAM/param.pck", 16) == 0) {
+                        if (strnlen((const char *)request.data, ARRAY_SIZE(request.data)) == 16 && (strncmp((const char *)request.data, "@PARAM/param.pck", 16) == 0)) {
                             ftp.need_banner_send_mask |= 1U<<reply.chan;
                         }
                         break;


### PR DESCRIPTION
rework from https://github.com/ArduPilot/ardupilot/pull/16155

The change is fine but I am not sure that is worth it. We don't have another filepath looking like this one and trying to get a non existing file will trigger error before reaching this. So, IMHO that is just correct dead code.