### PR TITLE
Rover: Enable RFND logging

### DIFF
--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -65,6 +65,7 @@ void Rover::init_ardupilot()
     AP::compass().init();
 
     // initialise rangefinder
+    rangefinder.set_log_rfnd_bit(MASK_LOG_RANGEFINDER);
     rangefinder.init(ROTATION_NONE);
 
 #if HAL_PROXIMITY_ENABLED


### PR DESCRIPTION
This solves #17334
Earlier we could get away with just logging PRX messages, but now that PRX library has gotten complicated and has the ability to filter, reject distances it's good to have a raw range finder log here for debugging. 

We don't have a good front-facing rangefinder simulation.. so I just used the bottom facing one we use in-plane and copter SITL. Although I didn't get any non-zero readings, but the messages were logged. Additionally, I have checked with GDB if all the necessary functions are being now called.  

![image](https://user-images.githubusercontent.com/36970042/117048647-d8119b00-ad30-11eb-8867-f72e6f89dabb.png)
