### PR TITLE
SITL: fix memory over-read detected by Valgrind

### DIFF
--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -333,6 +333,9 @@ void Frame::load_frame_params(const char *model_json)
         fname = strdup(model_json);
     } else {
         IGNORE_RETURN(asprintf(&fname, "@ROMFS/models/%s", model_json));
+        if (AP::FS().stat(model_json, &st) != 0) {
+            AP_HAL::panic("%s failed to load\n", model_json);
+        }
     }
     if (fname == nullptr) {
         AP_HAL::panic("%s failed to load\n", model_json);

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -345,7 +345,8 @@ void Frame::load_frame_params(const char *model_json)
     if (fd == -1) {
         AP_HAL::panic("%s failed to load\n", model_json);
     }
-    char buf[st.st_size];
+    char buf[st.st_size+1];
+    memset(buf, '\0', sizeof(buf));
     if (AP::FS().read(fd, buf, st.st_size) != st.st_size) {
         AP_HAL::panic("%s failed to load\n", model_json);
     }


### PR DESCRIPTION
==15803== Conditional jump or move depends on uninitialised value(s)
==15803==    at 0x4C34975: index (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==15803==    by 0x444D8D: SITL::Frame::load_frame_params(char const*) (SIM_Frame.cpp:363)
==15803==    by 0x445415: SITL::Frame::init(char const*, SITL::Battery*) (SIM_Frame.cpp:432)
==15803==    by 0x3696ED: SITL::MultiCopter::MultiCopter(char const*) (SIM_Multicopter.cpp:35)
==15803==    by 0x34B49C: SITL::MultiCopter::create(char const*) (SIM_Multicopter.h:44)
==15803==    by 0x34C58E: HALSITL::SITL_State::_parse_command_line(int, char* const*) (SITL_cmdline.cpp:480)
==15803==    by 0x344005: HALSITL::SITL_State::init(int, char* const*) (SITL_State.cpp:923)
==15803==    by 0x33D854: HAL_SITL::run(int, char* const*, AP_HAL::HAL::Callbacks*) const (HAL_SITL_Class.cpp:182)
==15803==    by 0x15ACDD: main (Copter.cpp:678)
==15803==

Scanning for `{` in an unterminated buffer.
