### PR TITLE
APM_Control: use FF to increase but not reduce tau in autotune

### DIFF
--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -528,7 +528,7 @@ void AP_AutoTune::update_rmax(void)
     if (level > 0 && is_positive(current.FF)) {
         const float invtau = ((1.0f / target_tau) + (current.I / current.FF));
         if (is_positive(invtau)) {
-            target_tau = 1.0f / invtau;
+            target_tau = MAX(target_tau,1.0f / invtau);
         }
     }
 


### PR DESCRIPTION
if user wants a slow time constant we should not override
@priseborough this look ok to you?
