### PR TITLE
CI: WIP test for archiving failure logs

### DIFF
--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -113,7 +113,9 @@ jobs:
         if: failure()
         with:
            name: fail-${{matrix.config}}
-           path: /tmp/buildlogs
+           path: |
+             /tmp/buildlogs
+             /__w/ardupilot/ardupilot/logs
            retention-days: 14
 
       - name: Archive .bin artifacts
@@ -214,7 +216,9 @@ jobs:
         if: failure()
         with:
            name: fail-${{matrix.config}}
-           path: /tmp/buildlogs
+           path: |
+             /tmp/buildlogs
+             /__w/ardupilot/ardupilot/logs
            retention-days: 14
 
       - name: Archive .bin artifacts

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -108,7 +108,9 @@ jobs:
         if: failure()
         with:
            name: fail-${{matrix.config}}
-           path: /tmp/buildlogs
+           path: |
+             /tmp/buildlogs
+             /__w/ardupilot/ardupilot/logs
            retention-days: 14
 
       - name: Archive .bin artifacts

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -108,7 +108,9 @@ jobs:
         if: failure()
         with:
            name: fail-${{matrix.config}}
-           path: /tmp/buildlogs
+           path: |
+             /tmp/buildlogs
+             /__w/ardupilot/ardupilot/logs
            retention-days: 14
 
       - name: Archive .bin artifacts

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -107,7 +107,9 @@ jobs:
         if: failure()
         with:
            name: fail-${{matrix.config}}
-           path: /tmp/buildlogs
+           path: |
+             /tmp/buildlogs
+             /__w/ardupilot/ardupilot/logs
            retention-days: 14
 
       - name: Archive .bin artifacts

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -107,7 +107,9 @@ jobs:
         if: failure()
         with:
            name: fail-${{matrix.config}}
-           path: /tmp/buildlogs
+           path: |
+             /tmp/buildlogs
+             /__w/ardupilot/ardupilot/logs
            retention-days: 14
 
       - name: Archive .bin artifacts


### PR DESCRIPTION
this logs both directories on failure, ensuring we get the logs we need.
Example: https://pipelines.actions.githubusercontent.com/4bSYDuWgW7QWp7XoLwrDsGYdL1OYQSygZbXR4yNYg2nuNM1iaD/_apis/pipelines/1/runs/63271/signedartifactscontent?artifactName=fail-sitltest-copter-tests1b&urlExpires=2021-05-07T09%3A55%3A11.2519481Z&urlSigningMethod=HMACV1&urlSignature=tkg%2F179oRaYtyK%2Bwpk1JKZQm3X3Yo4tuLGfVVI9SWos%3D
```
tridge@blu4:~/transfer$ unzip -t fail-sitltest-copter-tests1b\(1\).zip 
Archive:  fail-sitltest-copter-tests1b(1).zip
    testing: __w/                     OK
    testing: tmp/                     OK
    testing: __w/ardupilot/           OK
    testing: __w/ardupilot/ardupilot/   OK
    testing: __w/ardupilot/ardupilot/logs/   OK
    testing: __w/ardupilot/ardupilot/logs/00000004.BIN   OK
    testing: __w/ardupilot/ardupilot/logs/00000005.BIN   OK
    testing: __w/ardupilot/ardupilot/logs/LASTLOG.TXT   OK
    testing: tmp/buildlogs/           OK
    testing: tmp/buildlogs/ArduCopter-BrakeMode.txt   OK
    testing: tmp/buildlogs/ArduCopter-GCSFailsafe-00000003.BIN   OK
    testing: tmp/buildlogs/ArduCopter-GCSFailsafe-00000004.BIN   OK
    testing: tmp/buildlogs/ArduCopter-GCSFailsafe.txt   OK
    testing: tmp/buildlogs/ArduCopter-RecordThenPlayMission-00000001.BIN   OK
    testing: tmp/buildlogs/ArduCopter-RecordThenPlayMission-00000002.BIN   OK
    testing: tmp/buildlogs/ArduCopter-RecordThenPlayMission.txt   OK
    testing: tmp/buildlogs/ArduCopter-ThrottleFailsafe-00000002.BIN   OK
    testing: tmp/buildlogs/ArduCopter-ThrottleFailsafe-00000003.BIN   OK
    testing: tmp/buildlogs/ArduCopter-ThrottleFailsafe.txt   OK
    testing: tmp/buildlogs/ArduCopter-ThrowMode.txt   OK
    testing: tmp/buildlogs/autotest-badge.svg   OK
    testing: tmp/buildlogs/autotest.lck   OK
    testing: tmp/buildlogs/css/       OK
    testing: tmp/buildlogs/index.html   OK
    testing: tmp/buildlogs/css/main.css   OK
```
