### PR TITLE
always writing log header after boot

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -668,7 +668,9 @@ void AP_Logger::set_vehicle_armed(const bool armed_state)
     }
     _armed = armed_state;
 
-    if (!_armed) {
+    if (_armed) {
+        FOR_EACH_BACKEND(vehicle_armed());
+    } else {
         // went from armed to disarmed
         FOR_EACH_BACKEND(vehicle_was_disarmed());
     }
@@ -1358,6 +1360,10 @@ bool AP_Logger::log_while_disarmed(void) const
         return true;
     }
     if (_params.log_disarmed != 0) {
+        return true;
+    }
+
+    if (!backends[0]->allow_start_ekf()) {
         return true;
     }
 

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -125,6 +125,7 @@ public:
     bool allow_start_ekf() const;
 
     virtual void vehicle_was_disarmed();
+    virtual void vehicle_armed() {}
 
     bool Write_Unit(const struct UnitStructure *s);
     bool Write_Multiplier(const struct MultiplierStructure *s);

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -684,6 +684,9 @@ uint16_t AP_Logger_File::get_num_logs()
             ret++;
         }
     }
+    if (file_exists("APM/LOGS/CACHE.TXT")) {
+        ret--;
+    }
     return ret;
 }
 
@@ -747,6 +750,12 @@ void AP_Logger_File::start_new_log(void)
     }
 
     uint16_t log_num = find_last_log();
+    if (file_exists("APM/LOGS/CACHE.TXT")) {
+        log_num--;
+    } else {
+        int fd = AP::FS().open("APM/LOGS/CACHE.TXT", O_WRONLY|O_CREAT);
+        AP::FS().close(fd);
+    }
     // re-use empty logs if possible
     if (_get_log_size(log_num) > 0 || log_num == 0) {
         log_num++;
@@ -1032,6 +1041,11 @@ void AP_Logger_File::erase_next(void)
     _cached_oldest_log = 0;
 
     erase.log_num = 0;
+}
+
+void AP_Logger_File::vehicle_armed() {
+    EXPECT_DELAY_MS(2000);
+    AP::FS().unlink("APM/LOGS/CACHE.TXT");
 }
 
 #endif // HAL_LOGGING_FILESYSTEM_ENABLED

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -57,6 +57,8 @@ public:
     bool logging_started(void) const override { return _write_fd != -1; }
     void io_timer(void) override;
 
+    void vehicle_armed() override;
+
 protected:
 
     bool WritesOK() const override;


### PR DESCRIPTION
fix #11304 and #13882

There is lots of data (format, params) needed to be written when vehicle arming. It cause EKF altitude incorrectly climbing for a few seconds. This PR fix this problem by writing log headers after boot. 
1. after boot, it create a new log file, write headers only. if CACHE.TXT is existed, it will reuse the log number found in LASTLOG.TXT. if CACHE.TXT not existed it will create an empty file named CACHE.TXT to indicate last log file is a cache.
2. when vehicle armed, it remove CACHE.TXT 
3. when download logs, it will report log num minus 1 if CACHE.TXT existed

before this PR
![Log Browser - 43 2021-5-7 下午 02-18-32 bin 2021_5_7 下午 02_39_35](https://user-images.githubusercontent.com/19793511/117408235-38c3f200-af42-11eb-8241-d6aa496f69aa.png)
after this PR
![Log Browser - 41 2021-5-7 下午 02-11-16 bin 2021_5_7 下午 02_40_32](https://user-images.githubusercontent.com/19793511/117408289-4aa59500-af42-11eb-8cdf-434ec695f9f8.png)
[pr_fix_log.zip](https://github.com/ArduPilot/ardupilot/files/6439539/pr_fix_log.zip)

It is not a completed PR. I just want to propose a fix.