### PR TITLE
Rover: avoid shaking when simple avoidance has stopped vehicle

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -433,8 +433,16 @@ void Mode::navigate_to_waypoint()
         const float turn_rate = g2.sailboat.tacking() ? g2.wp_nav.get_pivot_rate() : 0.0f;
         calc_steering_to_heading(desired_heading_cd, turn_rate);
     } else {
+        // retrieve turn rate from waypoint controller
+        float desired_turn_rate_rads = g2.wp_nav.get_turn_rate_rads();
+
+        // if simple avoidance is active at very low speed do not attempt to turn
+        if (g2.avoid.limits_active() && (fabsf(attitude_control.get_desired_speed()) <= attitude_control.get_stop_speed())) {
+            desired_turn_rate_rads = 0.0f;
+        }
+
         // call turn rate steering controller
-        calc_steering_from_turn_rate(g2.wp_nav.get_turn_rate_rads());
+        calc_steering_from_turn_rate(desired_turn_rate_rads);
     }
 }
 

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -146,6 +146,9 @@ public:
     // get minimum stopping distance (in meters) given a speed (in m/s)
     float get_stopping_distance(float speed) const;
 
+    // get speed below which vehicle is considered stopped (in m/s)
+    float get_stop_speed() const { return MAX(_stop_speed, 0.0f); }
+
     // relax I terms of throttle and steering controllers
     void relax_I();
 


### PR DESCRIPTION
This attempts to resolve issue https://github.com/ArduPilot/ardupilot/issues/17338 by reducing the desired turn rate to zero if simple avoidance has stopped the vehicle in Auto, Guided, RTL and SmartRTL modes.

The vehicle is considered to have stopped when its desired speed has dropped below the ATC_STOP_SPEED parameter value which defaults to 0.1m/s.

@jmachuca77 could you re-test this with the change to use the parameter value instead of the hard-coded 0.2m/s value you tests a day or two ago?