### PR TITLE
Copter: Detect illegal values of system ID

### DIFF
--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -20,6 +20,11 @@ bool ModeFollow::init(const bool ignore_checks)
         gcs().send_text(MAV_SEVERITY_WARNING, "Set FOLL_ENABLE = 1");
         return false;
     }
+    if (g2.follow.get_sysid() < 0 || g2.follow.get_sysid() > 255) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Check FOLL_SYSID %d (0-255)", g2.follow.get_sysid());
+        return false;
+    }
+
     // re-use guided mode
     return ModeGuided::init(ignore_checks);
 }

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -86,6 +86,9 @@ public:
     // get bearing to target (including offset) in degrees (for reporting purposes)
     float get_bearing_to_target() const { return _bearing_to_target; }
 
+    // get system id
+    int16_t get_sysid() const { return _sysid; }
+
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
The AP_Follow class does not detect illegal values of system ID.
If the system ID is set to an invalid value, all the values will be mismatched.
I have made it so that in case of an invalid value, a message is notified and the mode is not switched.

![Screenshot from 2021-05-09 10-59-35](https://user-images.githubusercontent.com/646194/117558444-86fb0180-b0b8-11eb-98bd-2780a39bcdf0.png)