### PR TITLE
Add support for HIGH_LATENCY2 MAVLink message

### DIFF
--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -68,4 +68,13 @@ private:
     void send_winch_status() const override;
 
     void send_wind() const;
+
+#if HAL_HIGH_LATENCY2_ENABLED
+    int16_t high_latency_target_altitude() const override;
+    uint8_t high_latency_tgt_heading() const override;
+    uint16_t high_latency_tgt_dist() const override;
+    uint8_t high_latency_tgt_airspeed() const override;
+    uint8_t high_latency_wind_speed() const override;
+    uint8_t high_latency_wind_direction() const override;
+#endif // HAL_HIGH_LATENCY2_ENABLED
 };

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1331,3 +1331,82 @@ uint64_t GCS_MAVLINK_Plane::capabilities() const
 #endif
             GCS_MAVLINK::capabilities());
 }
+
+#if HAL_HIGH_LATENCY2_ENABLED
+int16_t GCS_MAVLINK_Plane::high_latency_target_altitude() const
+{
+    AP_AHRS &ahrs = AP::ahrs();
+    struct Location global_position_current;
+    UNUSED_RESULT(ahrs.get_position(global_position_current));
+
+    const QuadPlane &quadplane = plane.quadplane;
+    //return units are m
+    if (quadplane.show_vtol_view()) {
+        return (plane.control_mode != &plane.mode_qstabilize) ? 0.01 * (global_position_current.alt + quadplane.pos_control->get_pos_error_z_cm()) : 0;
+    } else {
+        return 0.01 * (global_position_current.alt + plane.altitude_error_cm);
+    }
+}
+
+uint8_t GCS_MAVLINK_Plane::high_latency_tgt_heading() const
+{
+    // return units are deg/2
+    const QuadPlane &quadplane = plane.quadplane;
+    if (quadplane.show_vtol_view()) {
+        const Vector3f &targets = quadplane.attitude_control->get_att_target_euler_cd();
+        return ((uint16_t)(targets.z * 0.01)) / 2;
+    } else {
+        const AP_Navigation *nav_controller = plane.nav_controller;
+        // need to convert -18000->18000 to 0->360/2
+        return wrap_360_cd(nav_controller->target_bearing_cd() ) / 200;
+    }   
+}
+    
+uint16_t GCS_MAVLINK_Plane::high_latency_tgt_dist() const
+{
+    // return units are dm
+    const QuadPlane &quadplane = plane.quadplane;
+    if (quadplane.show_vtol_view()) {
+        bool wp_nav_valid = quadplane.using_wp_nav();
+        return (wp_nav_valid ? MIN(quadplane.wp_nav->get_wp_distance_to_destination(), UINT16_MAX) : 0) / 10;
+    } else {
+        return MIN(plane.auto_state.wp_distance, UINT16_MAX) / 10;
+    }
+}
+
+uint8_t GCS_MAVLINK_Plane::high_latency_tgt_airspeed() const
+{
+    // return units are m/s*5
+    return plane.target_airspeed_cm * 0.05;
+}
+
+uint8_t GCS_MAVLINK_Plane::high_latency_wind_speed() const
+{
+    Vector3f wind;
+    wind = AP::ahrs().wind_estimate();
+
+    // return units are m/s*5
+    return MIN(wind.length() * 5, UINT8_MAX);
+}
+
+uint8_t GCS_MAVLINK_Plane::high_latency_wind_direction() const
+{
+    const Vector3f wind = AP::ahrs().wind_estimate();
+
+    // return units are deg/2
+    // need to convert -180->180 to 0->360/2
+    return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
+}
+
+int8_t GCS_MAVLINK_Plane::high_latency_air_temperature() const
+{
+    // return units are degC
+    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+    float air_temperature = 0;
+    if (airspeed != nullptr &&
+        airspeed->enabled()) {
+            airspeed->get_temperature(air_temperature);
+    }
+    return air_temperature;
+}
+#endif // HAL_HIGH_LATENCY2_ENABLED

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -63,5 +63,14 @@ private:
     float vfr_hud_airspeed() const override;
     int16_t vfr_hud_throttle() const override;
     float vfr_hud_climbrate() const override;
-
+    
+#if HAL_HIGH_LATENCY2_ENABLED
+    int16_t high_latency_target_altitude() const override;
+    uint8_t high_latency_tgt_heading() const override;
+    uint16_t high_latency_tgt_dist() const override;
+    uint8_t high_latency_tgt_airspeed() const override;
+    uint8_t high_latency_wind_speed() const override;
+    uint8_t high_latency_wind_direction() const override;
+    int8_t high_latency_air_temperature() const override;
+#endif // HAL_HIGH_LATENCY2_ENABLED
 };

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -799,3 +799,47 @@ int32_t GCS_MAVLINK_Sub::global_position_int_relative_alt() const {
     }
     return GCS_MAVLINK::global_position_int_relative_alt();
 }
+
+#if HAL_HIGH_LATENCY2_ENABLED
+int16_t GCS_MAVLINK_Sub::high_latency_target_altitude() const
+{
+    AP_AHRS &ahrs = AP::ahrs();
+    struct Location global_position_current;
+    UNUSED_RESULT(ahrs.get_position(global_position_current));
+
+    //return units are m
+    if (sub.control_mode == AUTO || sub.control_mode == GUIDED) {
+        return 0.01 * (global_position_current.alt + sub.pos_control.get_pos_error_z_cm());
+    }
+    return 0;
+    
+}
+
+uint8_t GCS_MAVLINK_Sub::high_latency_tgt_heading() const
+{
+    // return units are deg/2
+    if (sub.control_mode == AUTO || sub.control_mode == GUIDED) {
+        // need to convert -18000->18000 to 0->360/2
+        return wrap_360_cd(sub.wp_nav.get_wp_bearing_to_destination()) / 200;
+    }
+    return 0;      
+}
+    
+uint16_t GCS_MAVLINK_Sub::high_latency_tgt_dist() const
+{
+    // return units are dm
+    if (sub.control_mode == AUTO || sub.control_mode == GUIDED) {
+        return MIN(sub.wp_nav.get_wp_distance_to_destination() * 0.001, UINT16_MAX);
+    }
+    return 0;
+}
+
+uint8_t GCS_MAVLINK_Sub::high_latency_tgt_airspeed() const
+{
+    // return units are m/s*5
+    if (sub.control_mode == AUTO || sub.control_mode == GUIDED) {
+        return MIN((sub.pos_control.get_vel_desired_cms().length()/100) * 5, UINT8_MAX);
+    }
+    return 0;
+}
+#endif // HAL_HIGH_LATENCY2_ENABLED

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -53,4 +53,10 @@ private:
 
     int16_t vfr_hud_throttle() const override;
 
+#if HAL_HIGH_LATENCY2_ENABLED
+    int16_t high_latency_target_altitude() const override;
+    uint8_t high_latency_tgt_heading() const override;
+    uint16_t high_latency_tgt_dist() const override;
+    uint8_t high_latency_tgt_airspeed() const override;
+#endif // HAL_HIGH_LATENCY2_ENABLED
 };

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -647,3 +647,31 @@ void GCS_MAVLINK_Blimp::send_wind() const
         wind.length(),
         wind.z);
 }
+
+#if HAL_HIGH_LATENCY2_ENABLED
+uint8_t GCS_MAVLINK_Blimp::high_latency_wind_speed() const
+{
+    Vector3f airspeed_vec_bf;
+    if (!AP::ahrs().airspeed_vector_true(airspeed_vec_bf)) {
+        // if we don't have an airspeed estimate then we don't have a
+        // valid wind estimate on blimps
+        return 0;
+    }
+    // return units are m/s*5
+    const Vector3f wind = AP::ahrs().wind_estimate();
+    return wind.length() * 5;
+}
+
+uint8_t GCS_MAVLINK_Blimp::high_latency_wind_direction() const
+{
+    Vector3f airspeed_vec_bf;
+    if (!AP::ahrs().airspeed_vector_true(airspeed_vec_bf)) {
+        // if we don't have an airspeed estimate then we don't have a
+        // valid wind estimate on blimps
+        return 0;
+    }
+    const Vector3f wind = AP::ahrs().wind_estimate();
+    // need to convert -180->180 to 0->360/2
+    return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
+}
+#endif // HAL_HIGH_LATENCY2_ENABLED

--- a/Blimp/GCS_Mavlink.h
+++ b/Blimp/GCS_Mavlink.h
@@ -76,4 +76,9 @@ private:
         POSZ =        7,
         POSYAW =      8,
     };
+    
+#if HAL_HIGH_LATENCY2_ENABLED
+    uint8_t high_latency_wind_speed() const override;
+    uint8_t high_latency_wind_direction() const override;
+#endif // HAL_HIGH_LATENCY2_ENABLED
 };

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -1054,3 +1054,53 @@ uint64_t GCS_MAVLINK_Rover::capabilities() const
             MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET |
             GCS_MAVLINK::capabilities());
 }
+
+#if HAL_HIGH_LATENCY2_ENABLED
+uint8_t GCS_MAVLINK_Rover::high_latency_tgt_heading() const
+{
+    const Mode *control_mode = rover.control_mode;
+    if (rover.control_mode->is_autopilot_mode()) {
+        // need to convert -180->180 to 0->360/2
+        return wrap_360(control_mode->wp_bearing()) / 2;
+    }
+    return 0;      
+}
+    
+uint16_t GCS_MAVLINK_Rover::high_latency_tgt_dist() const
+{
+    const Mode *control_mode = rover.control_mode;
+    if (rover.control_mode->is_autopilot_mode()) {
+        // return units are dm
+        return MIN((control_mode->get_distance_to_destination()) / 10, UINT16_MAX);
+    }
+    return 0;  
+}
+
+uint8_t GCS_MAVLINK_Rover::high_latency_tgt_airspeed() const
+{
+    const Mode *control_mode = rover.control_mode;
+    if (rover.control_mode->is_autopilot_mode()) {
+        // return units are m/s*5
+        return MIN((vfr_hud_airspeed() - control_mode->speed_error()) * 5, UINT8_MAX);
+    }
+    return 0;
+}
+
+uint8_t GCS_MAVLINK_Rover::high_latency_wind_speed() const
+{
+    if (rover.g2.windvane.enabled()) {
+        // return units are m/s*5
+        return MIN(rover.g2.windvane.get_true_wind_speed() * 5, UINT8_MAX);
+    }
+    return 0; 
+}
+
+uint8_t GCS_MAVLINK_Rover::high_latency_wind_direction() const
+{
+    if (rover.g2.windvane.enabled()) {
+        // return units are deg/2
+        return wrap_360(degrees(rover.g2.windvane.get_true_wind_direction_rad())) / 2;
+    }
+    return 0; 
+}
+#endif // HAL_HIGH_LATENCY2_ENABLED

--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -53,4 +53,11 @@ private:
 
     void send_rangefinder() const override;
 
+#if HAL_HIGH_LATENCY2_ENABLED
+    uint8_t high_latency_tgt_heading() const override;
+    uint16_t high_latency_tgt_dist() const override;
+    uint8_t high_latency_tgt_airspeed() const override;
+    uint8_t high_latency_wind_speed() const override;
+    uint8_t high_latency_wind_direction() const override;
+#endif // HAL_HIGH_LATENCY2_ENABLED
 };

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -27,6 +27,10 @@
 
 #define GCS_DEBUG_SEND_MESSAGE_TIMINGS 0
 
+#ifndef HAL_HIGH_LATENCY2_ENABLED
+#define HAL_HIGH_LATENCY2_ENABLED !HAL_MINIMIZE_FEATURES
+#endif
+
 #ifndef HAL_NO_GCS
 
 // macros used to determine if a message will fit in the space available.
@@ -269,6 +273,9 @@ public:
     void send_generator_status() const;
     virtual void send_winch_status() const {};
     void send_water_depth() const;
+#if HAL_HIGH_LATENCY2_ENABLED
+    void send_high_latency() const;
+#endif // HAL_HIGH_LATENCY2_ENABLED
 
     // lock a channel, preventing use by MAVLink
     void lock(bool _lock) {
@@ -523,6 +530,16 @@ protected:
     virtual float vfr_hud_airspeed() const;
     virtual int16_t vfr_hud_throttle() const { return 0; }
     virtual float vfr_hud_alt() const;
+
+#if HAL_HIGH_LATENCY2_ENABLED
+    virtual int16_t high_latency_target_altitude() const { return 0; }
+    virtual uint8_t high_latency_tgt_heading() const { return 0; }
+    virtual uint16_t high_latency_tgt_dist() const { return 0; }
+    virtual uint8_t high_latency_tgt_airspeed() const { return 0; }
+    virtual uint8_t high_latency_wind_speed() const { return 0; }
+    virtual uint8_t high_latency_wind_direction() const { return 0; }
+    virtual int8_t high_latency_air_temperature() const { return 0; }
+#endif // HAL_HIGH_LATENCY2_ENABLED
 
     static constexpr const float magic_force_arm_value = 2989.0f;
     static constexpr const float magic_force_disarm_value = 21196.0f;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -852,6 +852,7 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_GENERATOR_STATUS,      MSG_GENERATOR_STATUS},
         { MAVLINK_MSG_ID_WINCH_STATUS,          MSG_WINCH_STATUS},
         { MAVLINK_MSG_ID_WATER_DEPTH,           MSG_WATER_DEPTH},
+        { MAVLINK_MSG_ID_HIGH_LATENCY2,         MSG_HIGH_LATENCY2},
             };
 
     for (uint8_t i=0; i<ARRAY_SIZE(map); i++) {
@@ -5113,6 +5114,13 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         CHECK_PAYLOAD_SIZE(WATER_DEPTH);
         send_water_depth();
         break;
+    case MSG_HIGH_LATENCY2:
+#if HAL_HIGH_LATENCY2_ENABLED
+        CHECK_PAYLOAD_SIZE(HIGH_LATENCY2);
+        send_high_latency();
+#endif // HAL_HIGH_LATENCY2_ENABLED
+        break;
+
 
     default:
         // try_send_message must always at some stage return true for
@@ -5416,3 +5424,117 @@ GCS &gcs()
 {
     return *GCS::get_singleton();
 }
+
+/*
+  send HIGH_LATENCY2 message
+ */
+#if HAL_HIGH_LATENCY2_ENABLED
+void GCS_MAVLINK::send_high_latency() const
+{
+    AP_AHRS &ahrs = AP::ahrs();
+    struct Location global_position_current;
+    UNUSED_RESULT(ahrs.get_position(global_position_current));
+
+    Location cur = AP::gps().location();
+
+    const AP_BattMonitor &battery = AP::battery();
+    float battery_current;
+    int8_t battery_remaining;
+
+    if (battery.healthy() && battery.current_amps(battery_current)) {
+        battery_remaining = battery.capacity_remaining_pct();
+        battery_current = constrain_float(battery_current * 100,-INT16_MAX,INT16_MAX);
+    } else {
+        battery_current = -1;
+        battery_remaining = -1;
+    }
+
+    AP_Mission *mission = AP::mission();
+    uint16_t current_waypoint = 0;
+    if (mission != nullptr) {
+        current_waypoint = mission->get_current_nav_index();
+    }
+
+    uint32_t present;
+    uint32_t enabled;
+    uint32_t health;
+    uint16_t failure_flags = 0;
+    gcs().get_sensor_status_flags(present, enabled, health);
+    // Remap HL_FAILURE_FLAG from system status flags
+    if (!(health & MAV_SYS_STATUS_SENSOR_GPS))
+    {
+        failure_flags |= HL_FAILURE_FLAG_GPS;
+    }
+    if (!(health & MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE))
+    {
+        failure_flags |= HL_FAILURE_FLAG_DIFFERENTIAL_PRESSURE;
+    }    
+    if (!(health & MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE))
+    {
+        failure_flags |= HL_FAILURE_FLAG_ABSOLUTE_PRESSURE;
+    }    
+    if (!(health & MAV_SYS_STATUS_SENSOR_3D_ACCEL))
+    {
+        failure_flags |= HL_FAILURE_FLAG_3D_ACCEL;
+    }  
+    if (!(health & MAV_SYS_STATUS_SENSOR_3D_GYRO))
+    {
+        failure_flags |= HL_FAILURE_FLAG_3D_GYRO;
+    }  
+    if (!(health & MAV_SYS_STATUS_SENSOR_3D_MAG))
+    {
+        failure_flags |= HL_FAILURE_FLAG_3D_MAG;
+    }  
+    if (!(health & MAV_SYS_STATUS_TERRAIN))
+    {
+        failure_flags |= HL_FAILURE_FLAG_TERRAIN;
+    }  
+    if (!(health & MAV_SYS_STATUS_SENSOR_BATTERY))
+    {
+        failure_flags |= HL_FAILURE_FLAG_BATTERY;
+    }  
+    if (!(health & MAV_SYS_STATUS_SENSOR_RC_RECEIVER))
+    {
+        failure_flags |= HL_FAILURE_FLAG_RC_RECEIVER;
+    }  
+    if (!(health & MAV_SYS_STATUS_GEOFENCE))
+    {
+        failure_flags |= HL_FAILURE_FLAG_GEOFENCE;
+    } 
+    if (!(health & MAV_SYS_STATUS_AHRS))
+    {
+        failure_flags |= HL_FAILURE_FLAG_ESTIMATOR;
+    }
+
+    //send_text(MAV_SEVERITY_INFO, "Yaw: %u", (((uint16_t)ahrs.yaw_sensor / 100) % 360));
+
+    mavlink_msg_high_latency2_send(chan, 
+        AP_HAL::millis(), //[ms] Timestamp (milliseconds since boot or Unix epoch)
+        gcs().frame_type(), // Type of the MAV (quadrotor, helicopter, etc.)
+        MAV_AUTOPILOT_ARDUPILOTMEGA, // Autopilot type / class. Use MAV_AUTOPILOT_INVALID for components that are not flight controllers.
+        gcs().custom_mode(), // A bitfield for use for autopilot-specific flags (2 byte version).
+        cur.lat, // [degE7] Latitude
+        cur.lng, // [degE7] Longitude
+        global_position_current.alt * 0.01f, // [m] Altitude above mean sea level
+        high_latency_target_altitude(), // [m] Altitude setpoint
+        (((uint16_t)ahrs.yaw_sensor / 100) % 360) / 2, // [deg/2] Heading
+        high_latency_tgt_heading(), // [deg/2] Heading setpoint
+        high_latency_tgt_dist(), // [dam] Distance to target waypoint or position
+        abs(vfr_hud_throttle()), // [%] Throttle
+        MIN(vfr_hud_airspeed() * 5, UINT8_MAX), // [m/s*5] Airspeed
+        high_latency_tgt_airspeed(), // [m/s*5] Airspeed setpoint
+        MIN(ahrs.groundspeed() * 5, UINT8_MAX), // [m/s*5] Groundspeed
+        high_latency_wind_speed(), // [m/s*5] Windspeed
+        high_latency_wind_direction(), // [deg/2] Wind heading
+        0, // [dm] Maximum error horizontal position since last message
+        0, // [dm] Maximum error vertical position since last message
+        high_latency_air_temperature(), // [degC] Air temperature from airspeed sensor
+        0, // [dm/s] Maximum climb rate magnitude since last message
+        battery_remaining, // [%] Battery level (-1 if field not provided).
+        current_waypoint, // Current waypoint number
+        failure_flags, // Bitmap of failure flags.
+        base_mode(), // Field for custom payload. base mode (arming status) in ArduPilot's case
+        0, // Field for custom payload.
+        0); // Field for custom payload.
+}
+#endif // HAL_HIGH_LATENCY2_ENABLED

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -78,5 +78,6 @@ enum ap_message : uint8_t {
     MSG_GENERATOR_STATUS,
     MSG_WINCH_STATUS,
     MSG_WATER_DEPTH,
+    MSG_HIGH_LATENCY2,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
This patch adds the HIGH_LATENCY2 message to all vehicles (minus Antenna Tracker). This message is useful for vehicles operating over very low bandwidth and high latency links, such as a satellite link.

It also includes support for the MAV_CMD_CONTROL_HIGH_LATENCY message, as it is used to turn the HIGH_LATENCY2 messages on and off (see https://mavlink.io/en/services/high_latency.html). Due to this, I've separated out the HIGH_LATENCY2 message into it's own stream parameter.

Tested in SITL using QGC (as it's the only GCS that currently supports HIGH_LATENCY2 message).