### PR TITLE
tools: install_prereqs-mac: Update script to use correct gcc version

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -13,7 +13,7 @@ xcode-select --install
 
 brew tap ardupilot/homebrew-px4
 brew update
-brew install gcc-arm-none-eabi
+brew install ardupilot/px4/gcc-arm-none-eabi-63
 brew install gawk
 
 echo "Checking pip..."


### PR DESCRIPTION
master branch uses gcc 6 and not gcc 4

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>