### PR TITLE
Blimp: Remove comment out

### DIFF
--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -29,26 +29,6 @@ MAV_MODE GCS_MAVLINK_Blimp::base_mode() const
     // the APM flight mode and has a well defined meaning in the
     // ArduPlane documentation
 
-    // switch (blimp.control_mode) {
-    // case Mode::Number::AUTO:
-    // case Mode::Number::RTL:
-    // case Mode::Number::LOITER:
-    // case Mode::Number::AVOID_ADSB:
-    // case Mode::Number::FOLLOW:
-    // case Mode::Number::GUIDED:
-    // case Mode::Number::CIRCLE:
-    // case Mode::Number::POSHOLD:
-    // case Mode::Number::BRAKE:
-    // case Mode::Number::SMART_RTL:
-    //     _base_mode |= MAV_MODE_FLAG_GUIDED_ENABLED;
-    //     // note that MAV_MODE_FLAG_AUTO_ENABLED does not match what
-    //     // APM does in any mode, as that is defined as "system finds its own goal
-    //     // positions", which APM does not currently do
-    //     break;
-    // default:
-    //     break;
-    // }
-
     // all modes except INITIALISING have some form of manual
     // override if stick mixing is enabled
     _base_mode |= MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
@@ -117,49 +97,6 @@ void GCS_MAVLINK_Blimp::send_position_target_global_int()
         0.0f); // yaw_rate
 }
 
-// void GCS_MAVLINK_Blimp::send_position_target_local_ned()
-// {
-// #if MODE_GUIDED_ENABLED == ENABLED
-//     if (!blimp.flightmode->in_guided_mode()) {
-//         return;
-//     }
-
-//     const GuidedMode guided_mode = blimp.mode_guided.mode();
-//     Vector3f target_pos;
-//     Vector3f target_vel;
-//     uint16_t type_mask;
-
-//     if (guided_mode == Guided_WP) {
-//         type_mask = 0x0FF8; // ignore everything except position
-//         target_pos = blimp.wp_nav->get_wp_destination() * 0.01f; // convert to metres
-//     } else if (guided_mode == Guided_Velocity) {
-//         type_mask = 0x0FC7; // ignore everything except velocity
-//         target_vel = blimp.flightmode->get_desired_velocity() * 0.01f; // convert to m/s
-//     } else {
-//         type_mask = 0x0FC0; // ignore everything except position & velocity
-//         target_pos = blimp.wp_nav->get_wp_destination() * 0.01f;
-//         target_vel = blimp.flightmode->get_desired_velocity() * 0.01f;
-//     }
-
-//     mavlink_msg_position_target_local_ned_send(
-//         chan,
-//         AP_HAL::millis(), // time boot ms
-//         MAV_FRAME_LOCAL_NED,
-//         type_mask,
-//         target_pos.x, // x in metres
-//         target_pos.y, // y in metres
-//         -target_pos.z, // z in metres NED frame
-//         target_vel.x, // vx in m/s
-//         target_vel.y, // vy in m/s
-//         -target_vel.z, // vz in m/s NED frame
-//         0.0f, // afx
-//         0.0f, // afy
-//         0.0f, // afz
-//         0.0f, // yaw
-//         0.0f); // yaw_rate
-// #endif
-// }
-
 void GCS_MAVLINK_Blimp::send_nav_controller_output() const
 {
 
@@ -204,18 +141,6 @@ void GCS_MAVLINK_Blimp::send_pid_tuning()
         }
         const AP_Logger::PID_Info *pid_info = nullptr;
         switch (axes[i]) { //TODO This should probably become an acceleration controller?
-        // case PID_TUNING_ROLL:
-        //     pid_info = &blimp.attitude_control->get_rate_roll_pid().get_pid_info();
-        //     break;
-        // case PID_TUNING_PITCH:
-        //     pid_info = &blimp.attitude_control->get_rate_pitch_pid().get_pid_info();
-        //     break;
-        // case PID_TUNING_YAW:
-        //     pid_info = &blimp.attitude_control->get_rate_yaw_pid().get_pid_info();
-        //     break;
-        // case PID_TUNING_ACCZ:
-        //     pid_info = &blimp.pos_control->get_accel_z_pid().get_pid_info();
-        //     break;
         default:
             continue;
         }
@@ -441,11 +366,7 @@ const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] = {
 
 bool GCS_MAVLINK_Blimp::handle_guided_request(AP_Mission::Mission_Command &cmd)
 {
-    // #if MODE_AUTO_ENABLED == ENABLED
-    //     // return blimp.mode_auto.do_guided(cmd);
-    // #else
     return false;
-    // #endif
 }
 
 void GCS_MAVLINK_Blimp::handle_change_alt_request(AP_Mission::Mission_Command &cmd)
@@ -574,41 +495,8 @@ MAV_RESULT GCS_MAVLINK_Blimp::handle_command_long_packet(const mavlink_command_l
     switch (packet.command) {
 
     case MAV_CMD_NAV_TAKEOFF: {
-        // param3 : horizontal navigation by pilot acceptable
-        // param4 : yaw angle   (not supported)
-        // param5 : latitude    (not supported)
-        // param6 : longitude   (not supported)
-        // param7 : altitude [metres]
-
-        // float takeoff_alt = packet.param7 * 100;      // Convert m to cm
-
-        // if (!blimp.flightmode->do_user_takeoff(takeoff_alt, is_zero(packet.param3))) {
-        //     return MAV_RESULT_FAILED;
-        //MIR Do I need this?
-        // }
         return MAV_RESULT_ACCEPTED;
     }
-
-    // #if MODE_AUTO_ENABLED == ENABLED
-    //     case MAV_CMD_DO_LAND_START:
-    //         if (blimp.mode_auto.mission.jump_to_landing_sequence() && blimp.set_mode(Mode::Number::AUTO, ModeReason::GCS_COMMAND)) {
-    //             return MAV_RESULT_ACCEPTED;
-    //         }
-    //         return MAV_RESULT_FAILED;
-    // #endif
-
-    // case MAV_CMD_NAV_LOITER_UNLIM:
-    //     if (!blimp.set_mode(Mode::Number::LOITER, ModeReason::GCS_COMMAND)) {
-    //         return MAV_RESULT_FAILED;
-    //     }
-    //     return MAV_RESULT_ACCEPTED;
-
-    // case MAV_CMD_NAV_RETURN_TO_LAUNCH:
-    //     if (!blimp.set_mode(Mode::Number::RTL, ModeReason::GCS_COMMAND)) {
-    //         return MAV_RESULT_FAILED;
-    //     }
-    //     return MAV_RESULT_ACCEPTED;
-
 
     case MAV_CMD_CONDITION_YAW:
         // param1 : target angle [0-360]
@@ -635,211 +523,6 @@ MAV_RESULT GCS_MAVLINK_Blimp::handle_command_long_packet(const mavlink_command_l
 void GCS_MAVLINK_Blimp::handleMessage(const mavlink_message_t &msg)
 {
     switch (msg.msgid) {
-
-    // #if MODE_GUIDED_ENABLED == ENABLED
-    //     case MAVLINK_MSG_ID_SET_ATTITUDE_TARGET:   // MAV ID: 82
-    //     {
-    //         // decode packet
-    //         mavlink_set_attitude_target_t packet;
-    //         mavlink_msg_set_attitude_target_decode(&msg, &packet);
-
-    //         // exit if vehicle is not in Guided mode or Auto-Guided mode
-    //         if (!blimp.flightmode->in_guided_mode()) {
-    //             break;
-    //         }
-
-    //         // ensure type_mask specifies to use attitude and thrust
-    //         if ((packet.type_mask & ((1<<7)|(1<<6))) != 0) {
-    //             break;
-    //         }
-
-    //         // check if the message's thrust field should be interpreted as a climb rate or as thrust
-    //         const bool use_thrust = blimp.g2.dev_options.get() & DevOptionSetAttitudeTarget_ThrustAsThrust;
-
-    //         float climb_rate_or_thrust;
-    //         if (use_thrust) {
-    //             // interpret thrust as thrust
-    //             climb_rate_or_thrust = constrain_float(packet.thrust, -1.0f, 1.0f);
-    //         } else {
-    //             // convert thrust to climb rate
-    //             packet.thrust = constrain_float(packet.thrust, 0.0f, 1.0f);
-    //             if (is_equal(packet.thrust, 0.5f)) {
-    //                 climb_rate_or_thrust = 0.0f;
-    //             } else if (packet.thrust > 0.5f) {
-    //                 // climb at up to WPNAV_SPEED_UP
-    //                 climb_rate_or_thrust = (packet.thrust - 0.5f) * 2.0f * blimp.wp_nav->get_default_speed_up();
-    //             } else {
-    //                 // descend at up to WPNAV_SPEED_DN
-    //                 climb_rate_or_thrust = (0.5f - packet.thrust) * 2.0f * -fabsf(blimp.wp_nav->get_default_speed_down());
-    //             }
-    //         }
-
-    //         // if the body_yaw_rate field is ignored, use the commanded yaw position
-    //         // otherwise use the commanded yaw rate
-    //         bool use_yaw_rate = false;
-    //         if ((packet.type_mask & (1<<2)) == 0) {
-    //             use_yaw_rate = true;
-    //         }
-
-    //         blimp.mode_guided.set_angle(Quaternion(packet.q[0],packet.q[1],packet.q[2],packet.q[3]),
-    //                 climb_rate_or_thrust, use_yaw_rate, packet.body_yaw_rate, use_thrust);
-
-    //         break;
-    //     }
-
-    //     case MAVLINK_MSG_ID_SET_POSITION_TARGET_LOCAL_NED:     // MAV ID: 84
-    //     {
-    //         // decode packet
-    //         mavlink_set_position_target_local_ned_t packet;
-    //         mavlink_msg_set_position_target_local_ned_decode(&msg, &packet);
-
-    //         // exit if vehicle is not in Guided mode or Auto-Guided mode
-    //         if (!blimp.flightmode->in_guided_mode()) {
-    //             break;
-    //         }
-
-    //         // check for supported coordinate frames
-    //         if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED &&
-    //             packet.coordinate_frame != MAV_FRAME_LOCAL_OFFSET_NED &&
-    //             packet.coordinate_frame != MAV_FRAME_BODY_NED &&
-    //             packet.coordinate_frame != MAV_FRAME_BODY_OFFSET_NED) {
-    //             break;
-    //         }
-
-    //         bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
-    //         bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
-    //         bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
-    //         bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
-    //         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
-
-    //         // exit immediately if acceleration provided
-    //         if (!acc_ignore) {
-    //             break;
-    //         }
-
-    //         // prepare position
-    //         Vector3f pos_vector;
-    //         if (!pos_ignore) {
-    //             // convert to cm
-    //             pos_vector = Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f);
-    //             // rotate to body-frame if necessary
-    //             if (packet.coordinate_frame == MAV_FRAME_BODY_NED ||
-    //                 packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-    //                 blimp.rotate_body_frame_to_NE(pos_vector.x, pos_vector.y);
-    //             }
-    //             // add body offset if necessary
-    //             if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED ||
-    //                 packet.coordinate_frame == MAV_FRAME_BODY_NED ||
-    //                 packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-    //                 pos_vector += blimp.inertial_nav.get_position();
-    //             }
-    //         }
-
-    //         // prepare velocity
-    //         Vector3f vel_vector;
-    //         if (!vel_ignore) {
-    //             // convert to cm
-    //             vel_vector = Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f);
-    //             // rotate to body-frame if necessary
-    //             if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-    //                 blimp.rotate_body_frame_to_NE(vel_vector.x, vel_vector.y);
-    //             }
-    //         }
-
-    //         // prepare yaw
-    //         float yaw_cd = 0.0f;
-    //         bool yaw_relative = false;
-    //         float yaw_rate_cds = 0.0f;
-    //         if (!yaw_ignore) {
-    //             yaw_cd = ToDeg(packet.yaw) * 100.0f;
-    //             yaw_relative = packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED;
-    //         }
-    //         if (!yaw_rate_ignore) {
-    //             yaw_rate_cds = ToDeg(packet.yaw_rate) * 100.0f;
-    //         }
-
-    //         // send request
-    //         if (!pos_ignore && !vel_ignore) {
-    //             blimp.mode_guided.set_destination_posvel(pos_vector, vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-    //         } else if (pos_ignore && !vel_ignore) {
-    //             blimp.mode_guided.set_velocity(vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-    //         } else if (!pos_ignore && vel_ignore) {
-    //             blimp.mode_guided.set_destination(pos_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-    //         }
-
-    //         break;
-    //     }
-
-    //     case MAVLINK_MSG_ID_SET_POSITION_TARGET_GLOBAL_INT:    // MAV ID: 86
-    //     {
-    //         // decode packet
-    //         mavlink_set_position_target_global_int_t packet;
-    //         mavlink_msg_set_position_target_global_int_decode(&msg, &packet);
-
-    //         // exit if vehicle is not in Guided mode or Auto-Guided mode
-    //         if (!blimp.flightmode->in_guided_mode()) {
-    //             break;
-    //         }
-
-    //         bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
-    //         bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
-    //         bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
-    //         bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
-    //         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
-
-    //         // exit immediately if acceleration provided
-    //         if (!acc_ignore) {
-    //             break;
-    //         }
-
-    //         // extract location from message
-    //         Location loc;
-    //         if (!pos_ignore) {
-    //             // sanity check location
-    //             if (!check_latlng(packet.lat_int, packet.lon_int)) {
-    //                 break;
-    //             }
-    //             Location::AltFrame frame;
-    //             if (!mavlink_coordinate_frame_to_location_alt_frame((MAV_FRAME)packet.coordinate_frame, frame)) {
-    //                 // unknown coordinate frame
-    //                 break;
-    //             }
-    //             loc = {packet.lat_int, packet.lon_int, int32_t(packet.alt*100), frame};
-    //         }
-
-    //         // prepare yaw
-    //         float yaw_cd = 0.0f;
-    //         bool yaw_relative = false;
-    //         float yaw_rate_cds = 0.0f;
-    //         if (!yaw_ignore) {
-    //             yaw_cd = ToDeg(packet.yaw) * 100.0f;
-    //             yaw_relative = packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED;
-    //         }
-    //         if (!yaw_rate_ignore) {
-    //             yaw_rate_cds = ToDeg(packet.yaw_rate) * 100.0f;
-    //         }
-
-    //         // send targets to the appropriate guided mode controller
-    //         if (!pos_ignore && !vel_ignore) {
-    //             // convert Location to vector from ekf origin for posvel controller
-    //             if (loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN) {
-    //                 // posvel controller does not support alt-above-terrain
-    //                 break;
-    //             }
-    //             Vector3f pos_neu_cm;
-    //             if (!loc.get_vector_from_origin_NEU(pos_neu_cm)) {
-    //                 break;
-    //             }
-    //             blimp.mode_guided.set_destination_posvel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f), !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-    //         } else if (pos_ignore && !vel_ignore) {
-    //             blimp.mode_guided.set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f), !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-    //         } else if (!pos_ignore && vel_ignore) {
-    //             blimp.mode_guided.set_destination(loc, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-    //         }
-
-    //         break;
-    //     }
-    // #endif
 
     case MAVLINK_MSG_ID_RADIO:
     case MAVLINK_MSG_ID_RADIO_STATUS: {     // MAV ID: 109
@@ -923,9 +606,6 @@ MAV_LANDED_STATE GCS_MAVLINK_Blimp::landed_state() const
     if (blimp.flightmode->is_landing()) {
         return MAV_LANDED_STATE_LANDING;
     }
-    // if (blimp.flightmode->is_taking_off()) {
-    //     return MAV_LANDED_STATE_TAKEOFF;
-    // }
     return MAV_LANDED_STATE_IN_AIR;
 }
 


### PR DESCRIPTION
I am unclear about the valid process by commenting out the process.
For example, I could not find #17412.
I will remove the processing comment-out.