### PR TITLE
GCS_MAVLINK: mag health reported in SYS_STATUS should not depend on A…

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -150,7 +150,7 @@ void GCS::update_sensor_status_flags()
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
-    if (compass.enabled() && compass.healthy() && ahrs.use_compass()) {
+    if (compass.enabled() && compass.healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
 


### PR DESCRIPTION
…HRS use

When using external yaw, EKF3 always reports use_compass as false,
which causes the GCS to get a bad compass health message.

thanks to Argosdyne for reporting