### PR TITLE
Copter, Plane, Sub, AC_PosControl: formatting fixes

### DIFF
--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -75,7 +75,7 @@ void ModeLand::gps_run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // pause before beginning land descent
-        if(land_pause && millis()-land_start_time >= LAND_WITH_DELAY_MS) {
+        if (land_pause && millis()-land_start_time >= LAND_WITH_DELAY_MS) {
             land_pause = false;
         }
 
@@ -128,7 +128,7 @@ void ModeLand::nogps_run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // pause before beginning land descent
-        if(land_pause && millis()-land_start_time >= LAND_WITH_DELAY_MS) {
+        if (land_pause && millis()-land_start_time >= LAND_WITH_DELAY_MS) {
             land_pause = false;
         }
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -82,8 +82,7 @@ void Mode::_TakeOff::stop()
 //  pilot_climb_rate is both an input and an output
 //  takeoff_climb_rate is only an output
 //  has side-effect of turning takeoff off when timeout as expired
-void Mode::_TakeOff::get_climb_rates(float& pilot_climb_rate,
-                                                  float& takeoff_climb_rate)
+void Mode::_TakeOff::get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate)
 {
     // return pilot_climb_rate if take-off inactive
     if (!_running) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2530,8 +2530,8 @@ void QuadPlane::vtol_position_controller(void)
         pos_control->update_xy_controller();
 
         // nav roll and pitch are controller by position controller
-        plane.nav_roll_cd = pos_control->get_roll();
-        plane.nav_pitch_cd = pos_control->get_pitch();
+        plane.nav_roll_cd = pos_control->get_roll_cd();
+        plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
         /*
           limit the pitch down with an expanding envelope. This
@@ -2597,8 +2597,8 @@ void QuadPlane::vtol_position_controller(void)
         pos_control->update_xy_controller();
 
         // nav roll and pitch are controller by position controller
-        plane.nav_roll_cd = pos_control->get_roll();
-        plane.nav_pitch_cd = pos_control->get_pitch();
+        plane.nav_roll_cd = pos_control->get_roll_cd();
+        plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
         // call attitude controller
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
@@ -2735,8 +2735,8 @@ void QuadPlane::takeoff_controller(void)
     pos_control->update_xy_controller();
 
     // nav roll and pitch are controller by position controller
-    plane.nav_roll_cd = pos_control->get_roll();
-    plane.nav_pitch_cd = pos_control->get_pitch();
+    plane.nav_roll_cd = pos_control->get_roll_cd();
+    plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                   plane.nav_pitch_cd,

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1075,7 +1075,6 @@ void QuadPlane::control_stabilize(void)
     // normal QSTABILIZE mode
     float pilot_throttle_scaled = get_pilot_throttle();
     hold_stabilize(pilot_throttle_scaled);
-
 }
 
 // run the multicopter Z controller
@@ -1789,7 +1788,7 @@ void QuadPlane::update_transition(void)
         // the quad should provide some assistance to the plane
         assisted_flight = true;
         if (!is_tailsitter()) {
-            // update tansition state for vehicles using airspeed wait
+            // update transition state for vehicles using airspeed wait
             if (transition_state != TRANSITION_AIRSPEED_WAIT) {
                 gcs().send_text(MAV_SEVERITY_INFO, "Transition started airspeed %.1f", (double)aspeed);
             }
@@ -1950,7 +1949,7 @@ void QuadPlane::update_transition(void)
     }
 
     case TRANSITION_ANGLE_WAIT_VTOL:
-        // nothing to do, this is handled in the fw attitude controller
+        // nothing to do, this is handled in the fixed wing attitude controller
         return;
 
     case TRANSITION_DONE:

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -167,8 +167,8 @@ void Sub::translate_circle_nav_rp(float &lateral_out, float &forward_out)
 void Sub::translate_pos_control_rp(float &lateral_out, float &forward_out)
 {
     // get roll and pitch targets in centidegrees
-    int32_t lateral = pos_control.get_roll();
-    int32_t forward = -pos_control.get_pitch(); // output is reversed
+    int32_t lateral = pos_control.get_roll_cd();
+    int32_t forward = -pos_control.get_pitch_cd(); // output is reversed
 
     // constrain target forward/lateral values
     lateral = constrain_int16(lateral, -aparm.angle_max, aparm.angle_max);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -792,7 +792,7 @@ float AC_AttitudeControl::input_shaping_angle(float error_angle, float input_tc,
 {
     // Calculate the velocity as error approaches zero with acceleration limited by accel_max_radss
     desired_ang_vel += sqrt_controller(error_angle, 1.0f / MAX(input_tc, 0.01f), accel_max, dt);
-    if(is_positive(max_ang_vel)) {
+    if (is_positive(max_ang_vel)) {
         desired_ang_vel = constrain_float(desired_ang_vel, -max_ang_vel, max_ang_vel);
     }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -3,17 +3,17 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AC_PID/AC_P.h>               // P library
-#include <AC_PID/AC_PID.h>             // PID library
-#include <AC_PID/AC_P_1D.h>            // P library (1-axis)
-#include <AC_PID/AC_P_2D.h>            // P library (2-axis)
-#include <AC_PID/AC_PI_2D.h>           // PI library (2-axis)
-#include <AC_PID/AC_PID_Basic.h>          // PID library (1-axis)
-#include <AC_PID/AC_PID_2D.h>          // PID library (2-axis)
-#include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
-#include "AC_AttitudeControl.h" // Attitude control library
-#include <AP_Motors/AP_Motors.h>          // motors library
-#include <AP_Vehicle/AP_Vehicle.h>         // common vehicle parameters
+#include <AC_PID/AC_P.h>            // P library
+#include <AC_PID/AC_PID.h>          // PID library
+#include <AC_PID/AC_P_1D.h>         // P library (1-axis)
+#include <AC_PID/AC_P_2D.h>         // P library (2-axis)
+#include <AC_PID/AC_PI_2D.h>        // PI library (2-axis)
+#include <AC_PID/AC_PID_Basic.h>    // PID library (1-axis)
+#include <AC_PID/AC_PID_2D.h>       // PID library (2-axis)
+#include <AP_InertialNav/AP_InertialNav.h>  // Inertial Navigation library
+#include "AC_AttitudeControl.h"     // Attitude control library
+#include <AP_Motors/AP_Motors.h>    // motors library
+#include <AP_Vehicle/AP_Vehicle.h>  // common vehicle parameters
 
 
 // position controller default definitions
@@ -386,10 +386,10 @@ protected:
     void check_for_ekf_z_reset();
 
     // references to inertial nav and ahrs libraries
-    AP_AHRS_View &        _ahrs;
-    const AP_InertialNav&       _inav;
-    const AP_Motors&            _motors;
-    AC_AttitudeControl&         _attitude_control;
+    AP_AHRS_View&           _ahrs;
+    const AP_InertialNav&   _inav;
+    const AP_Motors&        _motors;
+    AC_AttitudeControl&     _attitude_control;
 
     // parameters
     AP_Float    _accel_xy_filt_hz;      // XY acceleration filter cutoff frequency
@@ -418,17 +418,17 @@ protected:
     // output from controller
     float       _roll_target;           // desired roll angle in centi-degrees calculated by position controller
     float       _pitch_target;          // desired roll pitch in centi-degrees calculated by position controller
-    float       _yaw_target;               // desired yaw in centi-degrees calculated by position controller
-    float       _yaw_rate_target;          // desired yaw rate in centi-degrees per second calculated by position controller
+    float       _yaw_target;            // desired yaw in centi-degrees calculated by position controller
+    float       _yaw_rate_target;       // desired yaw rate in centi-degrees per second calculated by position controller
 
     // position controller internal variables
-    Vector3f    _pos_target;            // target location in cm from home
-    Vector3f    _vel_desired;           // desired velocity in cm/s
-    Vector3f    _vel_target;            // velocity target in cm/s calculated by pos_to_rate step
+    Vector3f    _pos_target;            // target location in NEU cm from home
+    Vector3f    _vel_desired;           // desired velocity in NEU cm/s
+    Vector3f    _vel_target;            // velocity target in NEU cm/s calculated by pos_to_rate step
     Vector3f    _vel_error;             // error between desired and actual acceleration in cm/s
-    Vector3f    _accel_desired;         // desired acceleration in cm/s/s (feed forward)
-    Vector3f    _accel_target;          // acceleration target in cm/s/s
-    Vector3f    _accel_error;           // acceleration error in cm/s/s
+    Vector3f    _accel_desired;         // desired acceleration in NEU cm/s/s (feed forward)
+    Vector3f    _accel_target;          // acceleration target in NEU cm/s/s
+    Vector3f    _accel_error;           // acceleration error in NEU cm/s/s
     Vector2f    _vehicle_horiz_vel;     // velocity to use if _flags.vehicle_horiz_vel_override is set
     LowPassFilterFloat _vel_error_filter;   // low-pass-filter on z-axis velocity error
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -270,8 +270,8 @@ public:
     void update_vel_controller_xyz();
 
     /// get desired roll and pitch to be passed to the attitude controller
-    float get_roll() const { return _roll_target; }
-    float get_pitch() const { return _pitch_target; }
+    float get_roll_cd() const { return _roll_target; }
+    float get_pitch_cd() const { return _pitch_target; }
 
     /// get desired yaw to be passed to the attitude controller
     float get_yaw_cd() const { return _yaw_target; }

--- a/libraries/AC_PID/AC_HELI_PID.cpp
+++ b/libraries/AC_PID/AC_HELI_PID.cpp
@@ -84,7 +84,7 @@ AC_HELI_PID::AC_HELI_PID(float initial_p, float initial_i, float initial_d, floa
 
 void AC_HELI_PID::update_leaky_i(float leak_rate)
 {
-    if(!is_zero(_ki) && !is_zero(_dt)){
+    if (!is_zero(_ki) && !is_zero(_dt)){
 
         // integrator does not leak down below Leak Min
         if (_integrator > _leak_min){

--- a/libraries/AC_PID/AC_PID_2D.h
+++ b/libraries/AC_PID/AC_PID_2D.h
@@ -69,7 +69,7 @@ public:
     // integrator setting functions
     void set_integrator(const Vector2f& target, const Vector2f& measurement, const Vector2f& i);
     void set_integrator(const Vector2f& error, const Vector2f& i);
-    void set_integrator(const Vector3f& i) { set_integrator(Vector2f(i.x, i.y)); }
+    void set_integrator(const Vector3f& i) { set_integrator(Vector2f{i.x, i.y}); }
     void set_integrator(const Vector2f& i);
 
     const AP_Logger::PID_Info& get_pid_info_x(void) const { return _pid_info_x; }

--- a/libraries/AC_PID/AC_PI_2D.h
+++ b/libraries/AC_PID/AC_PI_2D.h
@@ -26,7 +26,7 @@ public:
     //  input is filtered before the PI controllers are run
     //  this should be called before any other calls to get_p, get_i or get_d
     void set_input(const Vector2f &input);
-    void set_input(const Vector3f &input) { set_input(Vector2f(input.x, input.y)); }
+    void set_input(const Vector3f &input) { set_input(Vector2f{input.x, input.y}); }
 
     // get_pi - get results from pid controller
     Vector2f get_pi();

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -64,8 +64,8 @@ public:
     bool update() WARN_IF_UNUSED;
 
     /// get desired roll, pitch which should be fed into stabilize controllers
-    float get_roll() const { return _pos_control.get_roll(); }
-    float get_pitch() const { return _pos_control.get_pitch(); }
+    float get_roll() const { return _pos_control.get_roll_cd(); }
+    float get_pitch() const { return _pos_control.get_pitch_cd(); }
     Vector3f get_thrust_vector() const { return _pos_control.get_thrust_vector(); }
     float get_yaw() const { return _yaw; }
 

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -51,8 +51,8 @@ public:
     void update(bool avoidance_on = true);
 
     /// get desired roll, pitch which should be fed into stabilize controllers
-    float get_roll() const { return _pos_control.get_roll(); }
-    float get_pitch() const { return _pos_control.get_pitch(); }
+    float get_roll() const { return _pos_control.get_roll_cd(); }
+    float get_pitch() const { return _pos_control.get_pitch_cd(); }
     Vector3f get_thrust_vector() const { return _pos_control.get_thrust_vector(); }
 
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -30,7 +30,7 @@ public:
     void set_pilot_desired_acceleration(float euler_roll_angle_cd, float euler_pitch_angle_cd, float dt);
 
     /// gets pilot desired acceleration, body frame, [forward,right]
-    Vector2f get_pilot_desired_acceleration() const { return Vector2f(_desired_accel.x, _desired_accel.y); }
+    Vector2f get_pilot_desired_acceleration() const { return Vector2f{_desired_accel.x, _desired_accel.y}; }
 
     /// clear pilot desired acceleration
     void clear_pilot_desired_acceleration() { _desired_accel.zero(); }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -192,8 +192,8 @@ public:
     ///
 
     /// get desired roll, pitch which should be fed into stabilize controllers
-    float get_roll() const { return _pos_control.get_roll(); }
-    float get_pitch() const { return _pos_control.get_pitch(); }
+    float get_roll() const { return _pos_control.get_roll_cd(); }
+    float get_pitch() const { return _pos_control.get_pitch_cd(); }
     Vector3f get_thrust_vector() const { return _pos_control.get_thrust_vector(); }
 
     /// advance_wp_target_along_track - move target location along track from origin to destination


### PR DESCRIPTION
This is a small step to try and reduce the complexity of @lthall's Position Controller Update PR https://github.com/ArduPilot/ardupilot/pull/17345 by extracting the most obvious formatting changes and a single (of many) renames in the AC_PosControl class.

This has only been lightly tested (a compilation test of Copter, Rover, Sub, TradHeli, Plane and the regular autotests) but hopefully through inspection we can see quickly that the changes are OK