### PR TITLE
Update and fix Cygwin environment

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -15,8 +15,8 @@ jobs:
           HOME: ${{ runner.workspace }}/ardupilot
         run: |
           choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
-          choco install cygwin32-gcc-g++ python36 python36-future python36-lxml python36-pip python36-setuptools python36-wheel git libexpat procps gettext --source cygwin
-          C:\Cygwin\bin\bash --login -c "ln -sf /usr/bin/python3.6 /usr/bin/python && ln -sf /usr/bin/pip3.6 /usr/bin/pip"
+          choco install cygwin32-gcc-g++ python37 python37-future python37-lxml python37-pip python37-setuptools python37-wheel git libexpat procps gettext --source cygwin
+          C:\Cygwin\bin\bash --login -c "ln -sf /usr/bin/python3.7 /usr/bin/python && ln -sf /usr/bin/pip3.7 /usr/bin/pip"
       - name: Build SITL
         env:
           HOME: ${{ runner.workspace }}/ardupilot

--- a/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
+++ b/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
@@ -11,9 +11,9 @@ Write-Output "Downloading Cygwin x64 (2/6)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"
 
 Write-Output "Installing Cygwin x64 (3/6)"
-Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python36,python36-future,python36-lxml,python36-pip,libxslt-devel,python36-devel,procps-ng,zip,gdb,ddd --quiet-mode"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -s /usr/bin/python3.6 /usr/bin/python'"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -s /usr/bin/pip3.6 /usr/bin/pip'"
+Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd --quiet-mode"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/python3.7 /usr/bin/python'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
 Write-Output "Downloading extra Python packages (4/6)"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink'"

--- a/Tools/environment_install/install-prereqs-windows.ps1
+++ b/Tools/environment_install/install-prereqs-windows.ps1
@@ -11,9 +11,9 @@ Write-Output "Downloading Cygwin x64 (2/5)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"
 
 Write-Output "Installing Cygwin x64 (3/5)"
-Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python36,python36-future,python36-lxml,python36-pip,libxslt-devel,python36-devel,procps-ng,zip,gdb,ddd,xterm --quiet-mode"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -s /usr/bin/python3.6 /usr/bin/python'"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -s /usr/bin/pip3.6 /usr/bin/pip'"
+Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd,xterm --quiet-mode"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/python3.7 /usr/bin/python'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
 Write-Output "Downloading extra Python packages (4/5)"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink'"


### PR DESCRIPTION
Two parts to this PR:
- Update the Cygwin environment to Python 3.7 (now the default on Cygwin)
- Fix a bug in the environment install (add a "-f" to the ``ln`` command) to force overwrite the default python to the "correct" python. This command was previously failing, leading to some Python packages being installed in Python3.6 and others to Python 3.7. Overall caused all sorts of missing library issues for Cygwin users.