### PR TITLE
Copter: Detect illegal values of system id

### DIFF
--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -20,6 +20,11 @@ bool ModeFollow::init(const bool ignore_checks)
         gcs().send_text(MAV_SEVERITY_WARNING, "Set FOLL_ENABLE = 1");
         return false;
     }
+    if (g2.follow.get_sysid() < 0 || g2.follow.get_sysid() > 255) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Check FOLL_SYSID %d (0-255)", g2.follow.get_sysid());
+        return false;
+    }
+
     // re-use guided mode
     return ModeGuided::init(ignore_checks);
 }

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -86,6 +86,9 @@ public:
     // get bearing to target (including offset) in degrees (for reporting purposes)
     float get_bearing_to_target() const { return _bearing_to_target; }
 
+    // get system id
+    int16_t get_sysid() const { return _sysid; }
+
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
I'm REOPENED #17389 

I confirmed this with APM PLANNER2.
APM PLANNER2 does not display any warning.
I think the perception that all GCSs issue warnings is not.
I am unclear how many GCS check the input and show warning.

I saw that TAJISOFT, who teaches at the Drone Engineer Training School in Japan, has developed a browser GCS.
I think it's up to the GCS developers to decide if all GCSs check for config parameters that have a range.
Therefore, I think we need to defend ourselves from the point of view that FC is not checked.

I found that the FC did not do all the input value checks, which caused the FC to use abnormal values as normal values, making the aircraft externally inoperable.

APM PLANNER２
![Screenshot from 2021-05-13 07-08-01](https://user-images.githubusercontent.com/646194/118051593-3b986a00-b3bc-11eb-96e0-3a9385ade2ac.png)

SITL:
![Screenshot from 2021-05-13 07-08-11](https://user-images.githubusercontent.com/646194/118051608-4226e180-b3bc-11eb-8de9-a42f4e1758fa.png)
