### PR TITLE
HAL_SITL: fixed constructor ordering bug in AP_ESC_Telem

### DIFF
--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -85,7 +85,12 @@ void RCOutput::push(void)
         memcpy(_sitlState->pwm_output, _pending, SITL_NUM_CHANNELS * sizeof(uint16_t));
         _corked = false;
     }
-    esc_telem.update();
+    if (esc_telem == nullptr) {
+        esc_telem = new AP_ESC_Telem_SITL;
+    }
+    if (esc_telem != nullptr) {
+        esc_telem->update();
+    }
 }
 
 /*

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -37,7 +37,7 @@ public:
     
 private:
     SITL_State *_sitlState;
-    AP_ESC_Telem_SITL esc_telem;
+    AP_ESC_Telem_SITL *esc_telem;
 
     uint16_t _freq_hz;
     uint16_t _enable_mask;


### PR DESCRIPTION
on cygwin RCOutput was being constructed before AP_ESC_Telem, leading
to a panic