### PR TITLE
Clean param_parse.py up a little

### DIFF
--- a/Tools/autotest/param_metadata/htmlemit.py
+++ b/Tools/autotest/param_metadata/htmlemit.py
@@ -51,7 +51,7 @@ DO NOT EDIT
         pass
 
     def emit(self, g):
-        tag = '%s Parameters' % g.name
+        tag = '%s Parameters' % g.reference
         t = '\n\n<h1>%s</h1>\n' % tag
 
         for param in g.params:

--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -33,10 +33,7 @@ class JSONEmit(Emit):
         # Copy content to avoid any modification
         g = copy.deepcopy(g)
 
-        # Get vehicle name
-        if 'truename' in g.__dict__:
-            self.name = g.__dict__['truename']
-            self.content[self.name] = {}
+        self.content[self.name] = {}
 
         # Check all params available
         for param in g.params:

--- a/Tools/autotest/param_metadata/mdemit.py
+++ b/Tools/autotest/param_metadata/mdemit.py
@@ -48,16 +48,16 @@ class MDEmit(Emit):
     def emit(self, g):
         nparam = False # Flag indicating this is a parameter group with redundant information (ie RCn_, SERVOn_)
         
-        if g.name == 'ArduSub':
+        if g.reference == 'ArduSub':
             self.blacklist = sub_blacklist
         
-        if self.blacklist is not None and g.name in self.blacklist:
+        if self.blacklist is not None and g.reference in self.blacklist:
             return
         
-        pname = g.name
+        pname = g.reference
         
         # Check to see this is a parameter group with redundant information
-        rename = re.sub('\d+', 'n', g.name)
+        rename = re.sub('\d+', 'n', g.reference)
         if rename in nparams:
             if rename in self.nparams:
                 return

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -6,18 +6,23 @@ class Parameter(object):
 
 
 class Vehicle(object):
-    def __init__(self, name, path, truename=None):
-        if truename is not None:
-            self.truename = truename
+    def __init__(self, name, path, reference=None):
         self.name = name
         self.path = path
+        self.reference = reference
+        if reference is None:
+            self.reference = self.truename
         self.params = []
 
 
 class Library(object):
     def __init__(self, name):
-        self.name = name
+        self.set_name(name)
         self.params = []
+
+    def set_name(self, name):
+        self.name = name
+        self.reference = name
 
 known_param_fields = [
              'Description',

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
+
+'''Generates parameter metadata files suitable for consumption by
+  ground control stations and various web services
+
+  AP_FLAKE8_CLEAN
+
+'''
+
 from __future__ import print_function
-import glob
 import os
 import re
 import sys
@@ -40,7 +47,7 @@ args = parser.parse_args()
 
 # Regular expressions for parsing the parameter metadata
 
-prog_param = re.compile(r"@Param(?:{([^}]+)})?: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: ?(.*))+)(?:\n[ \t\r]*\n|\n[ \t]+[A-Z])", re.MULTILINE)
+prog_param = re.compile(r"@Param(?:{([^}]+)})?: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: ?(.*))+)(?:\n[ \t\r]*\n|\n[ \t]+[A-Z])", re.MULTILINE)  # noqa
 
 # match e.g @Value: 0=Unity, 1=Koala, 17=Liability
 prog_param_fields = re.compile(r"[ \t]*// @(\w+): ?([^\r\n]*)")
@@ -50,6 +57,7 @@ prog_param_tagged_fields = re.compile(r"[ \t]*// @(\w+){([^}]+)}: ([^\r\n]*)")
 prog_groups = re.compile(r"@Group: *(\w+).*((?:\n[ \t]*// @(Path): (\S+))+)", re.MULTILINE)
 
 apm_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../')
+
 
 def find_vehicle_parameter_filepath(vehicle_name):
     apm_tools_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../Tools/')
@@ -74,6 +82,7 @@ def find_vehicle_parameter_filepath(vehicle_name):
                 return path
 
     raise ValueError("Unable to find parameters file for (%s)" % vehicle_name)
+
 
 libraries = []
 
@@ -122,6 +131,7 @@ path = os.path.normpath(os.path.dirname(vehicle_path))
 vehicle = Vehicle(name, path, truename_map[name])
 debug('Found vehicle type %s' % vehicle.name)
 
+
 def process_vehicle(vehicle):
     debug("===\n\n\nProcessing %s" % vehicle.name)
     current_file = vehicle.path+'/Parameters.cpp'
@@ -147,7 +157,6 @@ def process_vehicle(vehicle):
     if not args.emit_sitl:
         param_matches = prog_param.findall(p_text)
 
-
     for param_match in param_matches:
         (only_vehicles, param_name, field_text) = (param_match[0],
                                                    param_match[1],
@@ -161,6 +170,7 @@ def process_vehicle(vehicle):
                 continue
         p = Parameter(vehicle.name+":"+param_name, current_file)
         debug(p.name + ' ')
+        global current_param
         current_param = p.name
         fields = prog_param_fields.findall(field_text)
         field_list = []
@@ -179,6 +189,7 @@ def process_vehicle(vehicle):
     current_file = None
     debug("Processed %u params" % len(vehicle.params))
 
+
 process_vehicle(vehicle)
 
 debug("Found %u documented libraries" % len(libraries))
@@ -191,6 +202,7 @@ else:
 libraries = list(libraries)
 
 alllibs = libraries[:]
+
 
 def process_library(vehicle, library, pathprefix=None):
     '''process one library'''
@@ -310,6 +322,7 @@ def process_library(vehicle, library, pathprefix=None):
 
     current_file = None
 
+
 for library in libraries:
     debug("===\n\n\nProcessing library %s" % library.name)
 
@@ -349,6 +362,7 @@ def clean_param(param):
             new_valueList.append(":".join([start, end]))
         param.Values = ",".join(new_valueList)
 
+
 def validate(param):
     """
     Validates the parameter meta data.
@@ -372,12 +386,12 @@ def validate(param):
         if not is_number(max_value):
             error("Max value not number: %s %s" % (param.name, max_value))
             return
-    # Check for duplicate in @value field 
+    # Check for duplicate in @value field
     if (hasattr(param, "Values")):
         valueList = param.__dict__["Values"].split(",")
         values = []
         for i in valueList:
-            i = i.replace(" ","")
+            i = i.replace(" ", "")
             values.append(i.partition(":")[0])
         if (len(values) != len(set(values))):
             error("Duplicate values found")
@@ -393,6 +407,7 @@ def validate(param):
     if (hasattr(param, "Description")):
         if not param.Description or not param.Description.strip():
             error("Empty Description (%s)" % param)
+
 
 for param in vehicle.params:
     clean_param(param)

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -190,8 +190,8 @@ This list is automatically generated from the latest ardupilot source code, and 
         return self.tablify(rows, headings=render_info["headings"])
 
     def emit(self, g):
-        tag = '%s Parameters' % self.escape(g.name)
-        reference = "parameters_" + g.name
+        tag = '%s Parameters' % self.escape(g.reference)
+        reference = "parameters_" + g.reference
 
         field_table_info = {
             "Values": {

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -33,7 +33,7 @@ class XmlEmit(Emit):
         self.current_element = self.libraries
 
     def emit(self, g):
-        xml_parameters = etree.SubElement(self.current_element, 'parameters', name=g.name)  # i.e. ArduPlane
+        xml_parameters = etree.SubElement(self.current_element, 'parameters', name=g.reference)  # i.e. ArduPlane
 
         for param in g.params:
             # Begin our parameter node

--- a/Tools/autotest/param_metadata/xmlemit_mp.py
+++ b/Tools/autotest/param_metadata/xmlemit_mp.py
@@ -43,7 +43,7 @@ class XmlEmitMP(Emit):
     def emit(self, g):
         t = ""
         if not self.skip_name:
-            self.gname = g.name
+            self.gname = g.reference
             if self.gname == "ArduCopter":
                 self.gname = "ArduCopter2"
             if self.gname == "APMrover2" or self.gname == "Rover":


### PR DESCRIPTION
In preparation for supporting `Values{Heli}`, some cleanups seemed like a good idea.

This was tested by running `build_parameters.sh` on master and then on this, and doing a `diff -ur` on the resulting directories (and some `zcmp`s to ensure some compressed files were identical.
