### PR TITLE
Create separate parameter metadata files for Helicopter

### DIFF
--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -27,6 +27,9 @@ class AutoTestHelicopter(AutoTestCopter):
     def log_name(self):
         return "HeliCopter"
 
+    def param_metadata_vehicle_name(self):
+        return "Heli"
+
     def default_frame(self):
         return "heli"
 

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -80,6 +80,7 @@ def find_vehicle_parameter_filepath(vehicle_name):
         "Plane": "ArduPlane",
         "Tracker": "AntennaTracker",
         "Sub": "ArduSub",
+        "Heli": "ArduCopter",
     }
 
     # first try ArduCopter/Parameters.cpp
@@ -158,6 +159,7 @@ truename_map = {
     "AntennaTracker": "Tracker",
     "AP_Periph": "AP_Periph",
     "Blimp": "Blimp",
+    "Helicopter": "Heli",
 }
 valid_truenames = frozenset(truename_map.values())
 truename = truename_map.get(args.vehicle, args.vehicle)
@@ -172,6 +174,8 @@ vehicle_path = find_vehicle_parameter_filepath(args.vehicle)
 basename = os.path.basename(os.path.dirname(vehicle_path))
 path = os.path.normpath(os.path.dirname(vehicle_path))
 reference = basename  # so links don't break we use ArduCopter
+if truename == "Heli":
+    reference = "Helicopter"
 vehicle = Vehicle(truename, path, reference=reference)
 debug('Found vehicle type %s' % vehicle.name)
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2539,6 +2539,9 @@ class TestSuite(abc.ABC):
             "CC_TYPE": 2,         # AC_CustomControl: PID backend (ArduCopter)
         }
 
+    def param_metadata_vehicle_name(self):
+        return self.log_name()
+
     def test_parameter_documentation_get_all_parameters(self):
 
         xml_filepath = os.path.join(self.buildlogs_dirpath(), "apm.pdef.xml")
@@ -2547,9 +2550,7 @@ class TestSuite(abc.ABC):
             os.unlink(xml_filepath)
         except OSError:
             pass
-        vehicle = self.log_name()
-        if vehicle == "HeliCopter":
-            vehicle = "ArduCopter"
+        vehicle = self.param_metadata_vehicle_name()
         if vehicle == "QuadPlane":
             vehicle = "ArduPlane"
         cmd = [param_parse_filepath, '--vehicle', vehicle]

--- a/Tools/scripts/build_parameters.sh
+++ b/Tools/scripts/build_parameters.sh
@@ -53,3 +53,5 @@ generate_parameters AntennaTracker
 generate_parameters AP_Periph
 
 generate_parameters Blimp
+
+generate_parameters Heli

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -70,49 +70,49 @@
 
 const AP_Param::GroupInfo AC_AutoTune_Heli::var_info[] = {
 
-    // @Param: AXES
+    // @Param{Heli}: AXES
     // @DisplayName: Autotune axis bitmask
     // @Description: 1-byte bitmap of axes to autotune
     // @Bitmask: 0:Roll,1:Pitch,2:Yaw
     // @User: Standard
     AP_GROUPINFO("AXES", 1, AC_AutoTune_Heli, axis_bitmask,  1),
 
-    // @Param: SEQ
+    // @Param{Heli}: SEQ
     // @DisplayName: AutoTune Sequence Bitmask
     // @Description: 2-byte bitmask to select what tuning should be performed.  Max gain automatically performed if Rate D is selected. Values: 7:All,1:VFF Only,2:Rate D/Rate P Only(incl max gain),4:Angle P Only,8:Max Gain Only,16:Tune Check,3:VFF and Rate D/Rate P(incl max gain),5:VFF and Angle P,6:Rate D/Rate P(incl max gain) and angle P
     // @Bitmask: 0:VFF,1:Rate D/Rate P(incl max gain),2:Angle P,3:Max Gain Only,4:Tune Check
     // @User: Standard
     AP_GROUPINFO("SEQ", 2, AC_AutoTune_Heli, seq_bitmask,  3),
 
-    // @Param: FRQ_MIN
+    // @Param{Heli}: FRQ_MIN
     // @DisplayName: AutoTune minimum sweep frequency
     // @Description: Defines the start frequency for sweeps and dwells
     // @Range: 10 30
     // @User: Standard
     AP_GROUPINFO("FRQ_MIN", 3, AC_AutoTune_Heli, min_sweep_freq,  10.0f),
 
-    // @Param: FRQ_MAX
+    // @Param{Heli}: FRQ_MAX
     // @DisplayName: AutoTune maximum sweep frequency
     // @Description: Defines the end frequency for sweeps and dwells
     // @Range: 50 120
     // @User: Standard
     AP_GROUPINFO("FRQ_MAX", 4, AC_AutoTune_Heli, max_sweep_freq,  70.0f),
 
-    // @Param: GN_MAX
+    // @Param{Heli}: GN_MAX
     // @DisplayName: AutoTune maximum response gain
     // @Description: Defines the response gain (output/input) to tune
     // @Range: 1 2.5
     // @User: Standard
     AP_GROUPINFO("GN_MAX", 5, AC_AutoTune_Heli, max_resp_gain,  1.0f),
 
-    // @Param: VELXY_P
+    // @Param{Heli}: VELXY_P
     // @DisplayName: AutoTune velocity xy P gain
     // @Description: Velocity xy P gain used to hold position during Max Gain, Rate P, and Rate D frequency sweeps
     // @Range: 0 1
     // @User: Standard
     AP_GROUPINFO("VELXY_P", 6, AC_AutoTune_Heli, vel_hold_gain,  0.1f),
 
-    // @Param: ACC_MAX
+    // @Param{Heli}: ACC_MAX
     // @DisplayName: AutoTune maximum allowable angular acceleration
     // @Description: maximum angular acceleration in deg/s/s allowed during autotune maneuvers
     // @Range: 1 4000
@@ -120,7 +120,7 @@ const AP_Param::GroupInfo AC_AutoTune_Heli::var_info[] = {
     // @Units: deg/s/s
     AP_GROUPINFO("ACC_MAX", 7, AC_AutoTune_Heli, accel_max_degss, 0.0f),
 
-    // @Param: RAT_MAX
+    // @Param{Heli}: RAT_MAX
     // @DisplayName: Autotune maximum allowable angular rate
     // @Description: maximum angular rate in deg/s allowed during autotune maneuvers
     // @Range: 0 500

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -94,21 +94,21 @@
 // allows us to go beyond the 64 parameter limit
 const AP_Param::GroupInfo AC_AutoTune_Multi::var_info[] = {
 
-    // @Param: AXES
+    // @Param{Copter,Plane}: AXES
     // @DisplayName: Autotune axis bitmask
     // @Description: 1-byte bitmap of axes to autotune
     // @Bitmask: 0:Roll,1:Pitch,2:Yaw,3:YawD
     // @User: Standard
     AP_GROUPINFO("AXES", 1, AC_AutoTune_Multi, axis_bitmask,  7),  // AUTOTUNE_AXIS_BITMASK_DEFAULT
 
-    // @Param: AGGR
+    // @Param{Copter,Plane}: AGGR
     // @DisplayName: Autotune aggressiveness
     // @Description: Autotune aggressiveness. Defines the bounce back used to detect size of the D term.
     // @Range: 0.05 0.10
     // @User: Standard
     AP_GROUPINFO("AGGR", 2, AC_AutoTune_Multi, aggressiveness, 0.075f),
 
-    // @Param: MIN_D
+    // @Param{Copter,Plane}: MIN_D
     // @DisplayName: AutoTune minimum D
     // @Description: Defines the minimum D gain
     // @Range: 0.0001 0.005

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
 
     // 2 was ANGLE_MAX (in centi-degrees)
 
-    // @Param{Copter}: DIST_MAX
+    // @Param{Copter,Heli}: DIST_MAX
     // @DisplayName: Avoidance distance maximum in non-GPS flight modes
     // @Description: Distance from object at which obstacle avoidance will begin in non-GPS modes
     // @Units: m
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("MARGIN", 4, AC_Avoid, _margin_m, 2.0f),
 
-    // @Param{Copter, Rover}: BEHAVE
+    // @Param{Copter, Rover, Heli}: BEHAVE
     // @DisplayName: Avoidance behaviour
     // @Description: Avoidance behaviour (slide or stop)
     // @Values: 0:Slide,1:Stop
@@ -80,7 +80,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("BACKUP_SPD", 6, AC_Avoid, _backup_speed_max_ne_ms, 0.75f),
 
-    // @Param{Copter}: ALT_MIN
+    // @Param{Copter,Heli}: ALT_MIN
     // @DisplayName: Avoidance minimum altitude
     // @Description: Minimum altitude above which proximity based avoidance will start working. This requires a valid downward facing rangefinder reading to work. Set zero to disable
     // @Units: m
@@ -113,7 +113,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     AP_GROUPINFO("BACKZ_SPD", 10, AC_Avoid, _backup_speed_max_u_ms, 0.75),
 
 #if AP_AVOIDANCE_ALTHOLD_ENABLED
-    // @Param{Copter}: ANG_MAX
+    // @Param{Copter,Heli}: ANG_MAX
     // @DisplayName: Avoidance max lean angle in non-GPS flight modes
     // @Description: Max lean angle used to avoid obstacles while in non-GPS modes.  Set to zero to disable lean-based avoidance
     // @Units: deg

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_OABendyRuler::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("CONT_ANGLE", 3, AP_OABendyRuler, _bendy_angle, OA_BENDYRULER_ANGLE_DEFAULT),
 
-    // @Param{Copter}: TYPE
+    // @Param{Copter,Heli}: TYPE
     // @DisplayName: Type of BendyRuler
     // @Description: BendyRuler will search for clear path along the direction defined by this parameter
     // @Values: 1:Horizontal search, 2:Vertical search

--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -99,7 +99,7 @@ const AP_Param::GroupInfo AP_OADatabase::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DIST_MAX", 7, AP_OADatabase, _dist_max, 0.0f),
 
-    // @Param{Copter}: ALT_MIN
+    // @Param{Copter,Heli}: ALT_MIN
     // @DisplayName: OADatabase minimum altitude above home before storing obstacles
     // @Description: OADatabase will reject obstacles if vehicle's altitude above home is below this parameter, in a 3 meter radius around home. Set 0 to disable this feature.
     // @Units: m

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -63,7 +63,7 @@ const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
     // @DisplayName: Options while recovering from Object Avoidance
     // @Description: Bitmask which will govern vehicles behaviour while recovering from Obstacle Avoidance (i.e Avoidance is turned off after the path ahead is clear).   
     // @Bitmask{Rover}: 0: Reset the origin of the waypoint to the present location, 1: log Dijkstra points
-    // @Bitmask{Copter}: 1:log Dijkstra points, 2:Allow fast waypoints (Dijkastras only)
+    // @Bitmask{Copter,Heli}: 1:log Dijkstra points, 2:Allow fast waypoints (Dijkastras only)
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 5, AP_OAPathPlanner, _options, OA_OPTIONS_DEFAULT),
 

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -60,21 +60,21 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @DisplayName: Fence Type
     // @Description: Configured fence types held as bitmask. Max altitide, Circle and Polygon fences will be immediately enabled if configured. Min altitude fence will only be enabled once the minimum altitude is reached.
     // @Bitmask{Rover}: 1:Circle Centered on Home,2:Inclusion/Exclusion Circles+Polygons
-    // @Bitmask{Copter, Plane, Sub}: 0:Max altitude,1:Circle Centered on Home,2:Inclusion/Exclusion Circles+Polygons,3:Min altitude
+    // @Bitmask{Copter, Heli, Plane, Sub}: 0:Max altitude,1:Circle Centered on Home,2:Inclusion/Exclusion Circles+Polygons,3:Min altitude
     // @User: Standard
     AP_GROUPINFO("TYPE", 1, AC_Fence, _configured_fences, AC_FENCE_TYPE_DEFAULT),
 
     // @Param: ACTION
     // @DisplayName: Fence Action
     // @Description: What action should be taken when fence is breached
-    // @Values{Copter}: 0:Report Only,1:RTL or Land,2:Always Land,3:SmartRTL or RTL or Land,4:Brake or Land,5:SmartRTL or Land
+    // @Values{Copter,Heli}: 0:Report Only,1:RTL or Land,2:Always Land,3:SmartRTL or RTL or Land,4:Brake or Land,5:SmartRTL or Land
     // @Values{Rover}: 0:Report Only,1:RTL or Hold,2:Hold,3:SmartRTL or RTL or Hold,4:SmartRTL or Hold,5:Terminate,6:Loiter or Hold
     // @Values{Plane}: 0:Report Only,1:RTL,6:Guided,7:GuidedThrottlePass,8:AUTOLAND if possible else RTL
     // @Values: 0:Report Only,1:RTL or Land
     // @User: Standard
     AP_GROUPINFO("ACTION", 2,  AC_Fence, _action, float(Action::RTL_AND_LAND)),
 
-    // @Param{Copter, Plane, Sub}: ALT_MAX
+    // @Param{Copter, Heli, Plane, Sub}: ALT_MAX
     // @DisplayName: Fence Maximum Altitude
     // @Description: Maximum altitude allowed before geofence triggers. See FENCE_ALT_MAX_TP for reference frame.
     // @Units: m
@@ -106,7 +106,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("TOTAL", 6, AC_Fence, _total, 0),
 
-    // @Param{Copter, Plane, Sub}: ALT_MIN
+    // @Param{Copter, Heli, Plane, Sub}: ALT_MIN
     // @DisplayName: Fence Minimum Altitude
     // @Description: Minimum altitude allowed before geofence triggers. See FENCE_ALT_MIN_TP for reference frame.
     // @Units: m
@@ -133,10 +133,10 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @User: Standard
     AP_GROUPINFO_FRAME("RET_ALT", 9,  AC_Fence, _ret_altitude, 0.0f, AP_PARAM_FRAME_PLANE),
 
-    // @Param{Plane, Copter}: AUTOENABLE
+    // @Param{Plane, Copter, Heli}: AUTOENABLE
     // @DisplayName: Fence Auto-Enable
     // @Description: Auto-enable of fences. AutoEnableOnTakeoff enables all configured fences, except the minimum altitude fence (which is enabled when the minimum altitude is reached), after autotakeoffs reach altitude. During autolandings the fences will be disabled.  AutoEnableDisableFloorOnLanding enables all configured fences, except the minimum altitude fence (which is enabled when the minimum altitude is reached), after autotakeoffs reach altitude. During autolandings only the Minimum Altitude fence will be disabled. AutoEnableOnlyWhenArmed enables all configured fences on arming, except the minimum altitude fence (which is enabled when the minimum altitude is reached), but no fences are disabled during autolandings. However, fence breaches are ignored while executing prior breach recovery actions which may include autolandings.
-    // @Values{Plane, Copter}: 0:AutoEnableOff,1:AutoEnableOnTakeoff,2:AutoEnableDisableFloorOnLanding,3:AutoEnableOnlyWhenArmed
+    // @Values{Plane, Copter, Heli}: 0:AutoEnableOff,1:AutoEnableOnTakeoff,2:AutoEnableDisableFloorOnLanding,3:AutoEnableOnlyWhenArmed
     // @Range: 0 3
     // @Increment: 1
     // @User: Standard

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
 
     // @Param: ANG_MAX
     // @DisplayName: Loiter pilot angle max
-    // @Description{Copter, Sub}: Loiter maximum pilot requested lean angle. Set to zero for 2/3 of PSC_ANGLE_MAX/ATC_ANGLE_MAX. The maximum vehicle lean angle is still limited by PSC_ANGLE_MAX/ATC_ANGLE_MAX
+    // @Description{Copter, Heli, Sub}: Loiter maximum pilot requested lean angle. Set to zero for 2/3 of PSC_ANGLE_MAX/ATC_ANGLE_MAX. The maximum vehicle lean angle is still limited by PSC_ANGLE_MAX/ATC_ANGLE_MAX
     // @Description: Loiter maximum pilot requested lean angle. Set to zero for 2/3 of Q_P_ANGLE_MAX/Q_A_ANGLE_MAX. The maximum vehicle lean angle is still limited by Q_P_ANGLE_MAX/Q_A_ANGLE_MAX
     // @Units: deg
     // @Range: 0 45

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -138,7 +138,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // index 4 was VOLT_MIN, moved to AP_BattMonitor
     // index 5 was VOLT2_MIN, moved to AP_BattMonitor
 
-    // @Param{Plane,Rover,Copter,Blimp}: RUDDER
+    // @Param{Plane,Rover,Copter,Heli,Blimp}: RUDDER
     // @DisplayName: Arming with Rudder enable/disable
     // @Description: Allow arm/disarm by rudder input. When enabled arming can be done with right rudder, disarming with left rudder. Rudder arming only works with throttle at zero +- deadzone (RCx_DZ). Depending on vehicle type, arming in certain modes is prevented. See the wiki for each vehicle. Caution is recommended when arming if it is allowed in an auto-throttle mode!
     // @Values: 0:Disabled,1:ArmingOnly,2:ArmOrDisarm
@@ -188,7 +188,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @DisplayName: Require vehicle location
     // @Description: Require that the vehicle have an absolute position before it arms.  This can help ensure that the vehicle can Return To Launch.
     // @User: Advanced
-    // @Values{Copter,Rover}: 0:Do not require location,1:Require Location
+    // @Values{Copter,Heli,Rover}: 0:Do not require location,1:Require Location
     AP_GROUPINFO("NEED_LOC", 12, AP_Arming, require_location, float(AP_ARMING_NEED_LOC_DEFAULT)),
 #endif  // AP_ARMING_NEED_LOC_PARAMETER_ENABLED
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: FS_LOW_ACT
     // @DisplayName: Low battery failsafe action
     // @Description: What action the vehicle should perform if it hits a low battery failsafe
-    // @Values{Copter}: 0:Warn only,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate,6:Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Brake or Land
+    // @Values{Copter,Heli}: 0:Warn only,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate,6:Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Brake or Land
     // @Values{Plane}: 0:Warn only,1:RTL,2:Land,3:Terminate,4:QLand,5:Parachute release,6:Loiter to QLand,7:AUTOLAND or RTL
     // @Values{Sub}: 0:Warn only,2:Disarm,3:Enter surface mode
     // @Values{Rover}: 0:Warn only,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate,6:Loiter or Hold
@@ -155,7 +155,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: FS_CRT_ACT
     // @DisplayName: Critical battery failsafe action
     // @Description: What action the vehicle should perform if it hits a critical battery failsafe
-    // @Values{Copter}: 0:Warn only,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate,6:Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Brake or Land
+    // @Values{Copter,Heli}: 0:Warn only,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate,6:Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Brake or Land
     // @Values{Plane}: 0:Warn only,1:RTL,2:Land,3:Terminate,4:QLand,5:Parachute,6:Loiter to QLand,7:AUTOLAND or RTL
     // @Values{Sub}: 0:Warn only,2:Disarm,3:Enter surface mode
     // @Values{Rover}: 0:Warn only,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate,6:Loiter or Hold

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
 
     // @Param: OPTIONS
     // @DisplayName: Landing gear auto retract/deploy options
-    // @Description{Copter}: Options to retract or deploy landing gear in Auto or Guided mode
+    // @Description{Copter,Heli}: Options to retract or deploy landing gear in Auto or Guided mode
     // @Description{Plane}: Options to retract or deploy landing gear in Auto, Takeoff and Autoland modes
     // @Bitmask: 0:Retract after Takeoff,1:Deploy during Land
     // @User: Standard

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -41,7 +41,7 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @DisplayName: Mission options bitmask
     // @Description: Bitmask of what options to use in missions. If the DontZeroCounter counter option is set than on completion of a jump loop the counter is left at zero, so the jump will not happen again if the loop is re-entered.
     // @Bitmask: 0:Clear Mission on reboot, 1:Use distance to land calc on battery failsafe,2:ContinueAfterLand, 3:DontZeroCounter
-    // @Bitmask{Copter}: 0:Clear Mission on reboot, 2:ContinueAfterLand
+    // @Bitmask{Copter,Heli}: 0:Clear Mission on reboot, 2:ContinueAfterLand
     // @Bitmask{Rover, Sub}: 0:Clear Mission on reboot
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -46,7 +46,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // 3 was _YAW_CORR
     // 4 to 15 was _IGN_ANG1 to _IGN_WID6
 
-    // @Param{Copter}: _IGN_GND
+    // @Param{Copter,Heli}: _IGN_GND
     // @DisplayName: Proximity sensor land detection
     // @Description: Ignore proximity data that is within 1 meter of the ground below the vehicle. This requires a downward facing rangefinder
     // @Values: 0:Disabled, 1:Enabled
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // 19 was _MIN
     // 20 was _MAX
 
-    // @Param{Copter}: _ALT_MIN
+    // @Param{Copter,Heli}: _ALT_MIN
     // @DisplayName: Proximity lowest altitude.
     // @Description: Minimum altitude below which proximity should not work.
     // @Units: m

--- a/libraries/AP_Relay/AP_Relay_Params.cpp
+++ b/libraries/AP_Relay/AP_Relay_Params.cpp
@@ -5,11 +5,11 @@ const AP_Param::GroupInfo AP_Relay_Params::var_info[] = {
     // @Param: FUNCTION
     // @DisplayName: Relay function
     // @Description: The function the relay channel is mapped to.
-    // @Values{Copter, Rover, Plane, Blimp,Sub}: 0:None
-    // @Values{Copter, Rover, Plane, Blimp,Sub}: 1:Relay
+    // @Values{Copter, Heli, Rover, Plane, Blimp,Sub}: 0:None
+    // @Values{Copter, Heli, Rover, Plane, Blimp,Sub}: 1:Relay
     // @Values{Plane}: 2:Ignition
-    // @Values{Plane, Copter}: 3:Parachute
-    // @Values{Copter, Rover, Plane, Blimp,Sub}: 4:Camera
+    // @Values{Plane, Copter, Heli}: 3:Parachute
+    // @Values{Copter, Heli, Rover, Plane, Blimp,Sub}: 4:Camera
     // @Values{Rover}: 5:Bushed motor reverse 1 throttle or throttle-left or omni motor 1
     // @Values{Rover}: 6:Bushed motor reverse 2 throttle-right or omni motor 2
     // @Values{Rover}: 7:Bushed motor reverse 3 omni motor 3

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -150,30 +150,30 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     // @Param: FLTMODE_GCSBLOCK
     // @DisplayName: Flight mode block from GCS
     // @Description: Bitmask of flight modes to disable for GCS selection. Mode can still be accessed via RC or failsafe.
-    // @Bitmask{Copter}: 0:Stabilize
-    // @Bitmask{Copter}: 1:Acro
-    // @Bitmask{Copter}: 2:AltHold
-    // @Bitmask{Copter}: 3:Auto
-    // @Bitmask{Copter}: 4:Guided
-    // @Bitmask{Copter}: 5:Loiter
-    // @Bitmask{Copter}: 6:Circle
-    // @Bitmask{Copter}: 7:Drift
-    // @Bitmask{Copter}: 8:Sport
-    // @Bitmask{Copter}: 9:Flip
-    // @Bitmask{Copter}: 10:AutoTune
-    // @Bitmask{Copter}: 11:PosHold
-    // @Bitmask{Copter}: 12:Brake
-    // @Bitmask{Copter}: 13:Throw
-    // @Bitmask{Copter}: 14:Avoid_ADSB
-    // @Bitmask{Copter}: 15:Guided_NoGPS
-    // @Bitmask{Copter}: 16:Smart_RTL
-    // @Bitmask{Copter}: 17:FlowHold
-    // @Bitmask{Copter}: 18:Follow
-    // @Bitmask{Copter}: 19:ZigZag
-    // @Bitmask{Copter}: 20:SystemID
-    // @Bitmask{Copter}: 21:Heli_Autorotate
-    // @Bitmask{Copter}: 22:Auto RTL
-    // @Bitmask{Copter}: 23:Turtle
+    // @Bitmask{Copter,Heli}: 0:Stabilize
+    // @Bitmask{Copter,Heli}: 1:Acro
+    // @Bitmask{Copter,Heli}: 2:AltHold
+    // @Bitmask{Copter,Heli}: 3:Auto
+    // @Bitmask{Copter,Heli}: 4:Guided
+    // @Bitmask{Copter,Heli}: 5:Loiter
+    // @Bitmask{Copter,Heli}: 6:Circle
+    // @Bitmask{Copter,Heli}: 7:Drift
+    // @Bitmask{Copter,Heli}: 8:Sport
+    // @Bitmask{Copter,Heli}: 9:Flip
+    // @Bitmask{Copter,Heli}: 10:AutoTune
+    // @Bitmask{Copter,Heli}: 11:PosHold
+    // @Bitmask{Copter,Heli}: 12:Brake
+    // @Bitmask{Copter,Heli}: 13:Throw
+    // @Bitmask{Copter,Heli}: 14:Avoid_ADSB
+    // @Bitmask{Copter,Heli}: 15:Guided_NoGPS
+    // @Bitmask{Copter,Heli}: 16:Smart_RTL
+    // @Bitmask{Copter,Heli}: 17:FlowHold
+    // @Bitmask{Copter,Heli}: 18:Follow
+    // @Bitmask{Copter,Heli}: 19:ZigZag
+    // @Bitmask{Copter,Heli}: 20:SystemID
+    // @Bitmask{Copter,Heli}: 21:Heli_Autorotate
+    // @Bitmask{Copter,Heli}: 22:Auto RTL
+    // @Bitmask{Copter,Heli}: 23:Turtle
     // @Bitmask{Plane}: 0:Manual
     // @Bitmask{Plane}: 1:Circle
     // @Bitmask{Plane}: 2:Stabilize


### PR DESCRIPTION
If we don't have `Values{Heli}` then we use `Values{Copter}` if it exists, else we use just `Values:`

~~This is based on top of some cleanup PRs - only the last two patches add are not part of other PRs.~~
