### PR TITLE
Rover (sailboat), true wind if no windspeed sensor, bug fixed

### DIFF
--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -298,7 +298,7 @@ void AP_WindVane::update()
     } else {
         // only have direction, can't do true wind calcs, set true direction to apparent + heading
         _direction_true_raw = wrap_PI(_direction_apparent_raw + AP::ahrs().yaw);
-        _speed_true = 0.0f;
+        _speed_true_raw = 0.0f;
     }
 
     /*

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -296,8 +296,8 @@ void AP_WindVane::update()
             update_apparent_wind_dir_from_true();
         }
     } else {
-        // only have direction, cant to true wind calcs, set true direction to apparent
-        _direction_true = _direction_apparent_raw + AP::ahrs().yaw;
+        // only have direction, can't do true wind calcs, set true direction to apparent + heading
+        _direction_true_raw = wrap_PI(_direction_apparent_raw + AP::ahrs().yaw);
         _speed_true = 0.0f;
     }
 


### PR DESCRIPTION
The calculation for true wind direction in the case where the boat does not have a wind speed sensor had a bug.  It used the wrong variable (filtered not raw) and did not wrap the angle calculation.  Because the raw direction was not calculated, the filter later in the code calculates 0 for true wind.  I tested both the original and fixed versions on my boat with an analog wind vane and it works for me.