### PR TITLE
Copter: Delete a break that will not be executed

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -793,10 +793,8 @@ uint32_t ModeGuided::wp_distance() const
     switch(guided_mode) {
     case SubMode::WP:
         return wp_nav->get_wp_distance_to_destination();
-        break;
     case SubMode::PosVel:
         return pos_control->get_pos_error_xy();
-        break;
     default:
         return 0;
     }
@@ -807,10 +805,8 @@ int32_t ModeGuided::wp_bearing() const
     switch(guided_mode) {
     case SubMode::WP:
         return wp_nav->get_wp_bearing_to_destination();
-        break;
     case SubMode::PosVel:
         return pos_control->get_bearing_to_target();
-        break;
     case SubMode::TakeOff:
     case SubMode::Velocity:
     case SubMode::Angle:


### PR DESCRIPTION
I delete BREAKs that are not executed.
I find the meaningless code unnecessary.
I've never seen a programming book that describes BREAK after RETURN.
I don't see the point of writing code that will not be executed.