### PR TITLE
AP_AHRS: Remove unused methods

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1780,11 +1780,6 @@ bool AP_AHRS_NavEKF::pre_arm_check(bool requires_position, char *failure_msg, ui
     return false;
 }
 
-void AP_AHRS_NavEKF::set_ekf_use(bool setting)
-{
-    _ekf_type.set(setting?1:0);
-}
-
 // true if the AHRS has completed initialisation
 bool AP_AHRS_NavEKF::initialised(void) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -197,8 +197,6 @@ public:
     // get speed limit
     void getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const;
 
-    void set_ekf_use(bool setting);
-
     // is the AHRS subsystem healthy?
     bool healthy() const override;
 


### PR DESCRIPTION
I learned that this method is not accessed from anywhere else.
I will remove the unnecessary method.