### PR TITLE
Log which RC channels are being overridden

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -488,7 +488,7 @@ private:
     bool _armed;
 
     // state to help us not log unneccesary RCIN values:
-    bool seen_nonzero_rcin15_or_rcin16;
+    bool should_log_rcin2;
 
     void Write_Compass_instance(uint64_t time_us, uint8_t mag_instance);
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -149,20 +149,28 @@ void AP_Logger::Write_RCIN(void)
     };
     WriteBlock(&pkt, sizeof(pkt));
 
+    const uint16_t override_mask = rc().get_override_mask();
+
     // don't waste logging bandwidth if we haven't seen non-zero
     // channels 15/16:
-    if (!seen_nonzero_rcin15_or_rcin16) {
-        if (!values[14] && !values[15]) {
-            return;
+    if (!should_log_rcin2) {
+        if (values[14] || values[15]) {
+            should_log_rcin2 = true;
+        } else if (override_mask != 0) {
+            should_log_rcin2 = true;
         }
-        seen_nonzero_rcin15_or_rcin16 = true;
+    }
+
+    if (!should_log_rcin2) {
+        return;
     }
 
     const struct log_RCIN2 pkt2{
         LOG_PACKET_HEADER_INIT(LOG_RCIN2_MSG),
         time_us       : AP_HAL::micros64(),
         chan15         : values[14],
-        chan16         : values[15]
+        chan16         : values[15],
+        override_mask  : override_mask,
     };
     WriteBlock(&pkt2, sizeof(pkt2));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -247,6 +247,7 @@ struct PACKED log_RCIN2 {
     uint64_t time_us;
     uint16_t chan15;
     uint16_t chan16;
+    uint16_t override_mask;
 };
 
 struct PACKED log_RCOUT {
@@ -1223,7 +1224,7 @@ LOG_STRUCTURE_FROM_GPS \
     { LOG_RCIN_MSG, sizeof(log_RCIN), \
       "RCIN",  "QHHHHHHHHHHHHHH",     "TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14", "sYYYYYYYYYYYYYY", "F--------------" }, \
     { LOG_RCIN2_MSG, sizeof(log_RCIN2), \
-      "RCI2",  "QHH",     "TimeUS,C15,C16", "sYY", "F--" }, \
+      "RCI2",  "QHHH",     "TimeUS,C15,C16,OMask", "sYY-", "F---" }, \
     { LOG_RCOUT_MSG, sizeof(log_RCOUT), \
       "RCOU",  "QHHHHHHHHHHHHHH",     "TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14", "sYYYYYYYYYYYYYY", "F--------------"  }, \
     { LOG_RSSI_MSG, sizeof(log_RSSI), \

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -399,6 +399,10 @@ public:
     static void set_override(const uint8_t chan, const int16_t value, const uint32_t timestamp_ms = 0); // set a channels override value
     static bool has_active_overrides(void);                            // returns true if there are overrides applied that are valid
 
+    // returns a mask indicating which channels have overrides.  Bit 0
+    // is RC channel 1.  Beware this is not a cheap call.
+    static uint16_t get_override_mask();
+
     class RC_Channel *find_channel_for_option(const RC_Channel::aux_func_t option);
     bool duplicate_options_exist();
     RC_Channel::AuxSwitchPos get_channel_pos(const uint8_t rcmapchan) const;

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -107,6 +107,18 @@ void RC_Channels::clear_overrides(void)
     // copter and plane, RC_Channels needs to control failsafes to resolve this
 }
 
+uint16_t RC_Channels::get_override_mask(void)
+{
+    uint16_t ret = 0;
+    RC_Channels &_rc = rc();
+    for (uint8_t i = 0; i < NUM_RC_CHANNELS; i++) {
+        if (_rc.channel(i)->has_override()) {
+            ret |= (1U << i);
+        }
+    }
+    return ret;
+}
+
 void RC_Channels::set_override(const uint8_t chan, const int16_t value, const uint32_t timestamp_ms)
 {
     RC_Channels &_rc = rc();


### PR DESCRIPTION
Tested in SITL by connecting a second MAVProxy on port :14550, changing SYSID_MYGCS to correspond to its system-id and then issuing `rc 6 1700`.
