### PR TITLE
BLHeli boot fix

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1492,6 +1492,10 @@ void AP_BLHeli::log_bidir_telemetry(void)
         }
     }
 
+    if (!SRV_Channels::have_digital_outputs()) {
+        return;
+    }
+
     // ask the next ESC for telemetry
     uint8_t idx_pos = last_telem_esc;
     for (uint8_t idx = (idx_pos + 1) % num_motors;
@@ -1517,7 +1521,7 @@ void AP_BLHeli::update_telemetry(void)
         log_bidir_telemetry();
     }
 #endif
-    if (!telem_uart) {
+    if (!telem_uart || !SRV_Channels::have_digital_outputs()) {
         return;
     }
     uint32_t now = AP_HAL::micros();

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -510,6 +510,9 @@ public:
     // return true if all of the outputs in mask are digital
     static bool have_digital_outputs(uint16_t mask) { return mask != 0 && (mask & digital_mask) == mask; }
 
+    // return true if any of the outputs are digital
+    static bool have_digital_outputs() { return digital_mask != 0; }
+
     // Set E - stop
     static void set_emergency_stop(bool state) {
         emergency_stop = state;


### PR DESCRIPTION
If you configure BLHeli only for passthrough without any use of dshot then the flight controller gets stuck at boot