### PR TITLE
NavEKFx: Change the direct value to an ekf type definition

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -331,22 +331,16 @@ public:
     NavEKF3 EKF3;
 #endif
 
-private:
     enum class EKFType {
-        NONE = 0
-#if HAL_NAVEKF3_AVAILABLE
-        ,THREE = 3
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-        ,TWO = 2
-#endif
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        ,SITL = 10
-#endif
-#if HAL_EXTERNAL_AHRS_ENABLED
-        ,EXTERNAL = 11
-#endif
+        NONE     = 0,
+        TWO      = 2,
+        THREE    = 3,
+        SITL     = 10,
+        EXTERNAL = 11,
     };
+
+private:
+
     EKFType active_EKF_type(void) const;
 
     // if successful returns true and sets secondary_ekf_type to None (for DCM), EKF3 or EKF3

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -624,7 +624,7 @@ bool NavEKF2::InitialiseFilter(void)
 
     initFailure = InitFailures::UNKNOWN;
     if (_enable == 0) {
-        if (AP::dal().get_ekf_type() == 2) {
+        if (AP::dal().get_ekf_type() == (int8_t)AP_AHRS_NavEKF::EKFType::TWO) {
             initFailure = InitFailures::NO_ENABLE;
         }
         return false;

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -211,7 +211,7 @@ void GCS::update_sensor_status_flags()
     control_sensors_health |= MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    if (ahrs.get_ekf_type() == 10) {
+    if (ahrs.get_ekf_type() == (int8_t)AP_AHRS_NavEKF::EKFType::SITL) {
         // always show EKF type 10 as healthy. This prevents spurious error
         // messages in xplane and other simulators that use EKF type 10
         control_sensors_health |= MAV_SYS_STATUS_AHRS | MAV_SYS_STATUS_SENSOR_GPS | MAV_SYS_STATUS_SENSOR_3D_ACCEL | MAV_SYS_STATUS_SENSOR_3D_GYRO;


### PR DESCRIPTION
I am comparing the EKF_TYPE decision with the direct value.
However, EKF_TYPE is defined.
I think it is better to use the definition.
Also, if you disable the inclusion of EKF2 and EKF3, you will get an error in the SWITCH statement, so add a DEFAULT statement.