### PR TITLE
AC_PID: add initial I param and reset to it.

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -386,6 +386,11 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: PITCH2SRV_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     GGROUP(pidPitch2Srv,       "PITCH2SRV_", AC_PID),
 
     // @Param: YAW2SRV_P
@@ -453,6 +458,11 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: YAW2SRV_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
     // @User: Advanced
 
     GGROUP(pidYaw2Srv,         "YAW2SRV_", AC_PID),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -86,6 +86,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_YAW_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 2, AC_AttitudeControl_Heli, AC_HELI_PID),
 
     // @Param: RAT_PIT_P
@@ -160,6 +165,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_YAW_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 3, AC_AttitudeControl_Heli, AC_HELI_PID),
 
     // @Param: RAT_YAW_P
@@ -232,6 +242,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: RAT_YAW_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 4, AC_AttitudeControl_Heli, AC_HELI_PID),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -74,6 +74,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_RLL_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Multi, AC_PID),
 
     // @Param: RAT_PIT_P
@@ -143,6 +148,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_PIT_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Multi, AC_PID),
 
     // @Param: RAT_YAW_P
@@ -210,6 +220,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: RAT_YAW_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Multi, AC_PID),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -74,6 +74,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_RLL_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Sub, AC_PID),
 
     // @Param: RAT_PIT_P
@@ -143,6 +148,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_PIT_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Sub, AC_PID),
 
     // @Param: RAT_YAW_P
@@ -210,6 +220,11 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: RAT_YAW_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Sub, AC_PID),

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -202,6 +202,11 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: _ACCZ_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_accel_z, "_ACCZ_", 4, AC_PosControl, AC_PID),
 
     // @Param: _POSXY_P

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -138,6 +138,7 @@ protected:
     AP_Float _filt_E_hz;         // PID error filter frequency in Hz
     AP_Float _filt_D_hz;         // PID derivative filter frequency in Hz
     AP_Float _slew_rate_max;
+    AP_Float _ki_zero;
 
     SlewLimiter _slew_limiter{_slew_rate_max, _slew_rate_tau};
 

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -128,6 +128,11 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: _RATE_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 11, AP_PitchController, AC_PID),
     
     AP_GROUPEND

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -111,6 +111,11 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: _RATE_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 9, AP_RollController, AC_PID),
     
     AP_GROUPEND

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -96,6 +96,11 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: _STR_RAT_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_steer_rate_pid, "_STR_RAT_", 1, AR_AttitudeControl, AC_PID),
 
     // @Param: _SPEED_P
@@ -170,6 +175,11 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: _SPEED_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
     // @User: Advanced
 
     AP_SUBGROUPINFO(_throttle_speed_pid, "_SPEED_", 2, AR_AttitudeControl, AC_PID),
@@ -308,6 +318,11 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: _BAL_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pitch_to_throttle_pid, "_BAL_", 10, AR_AttitudeControl, AC_PID),
 
     // @Param: _BAL_SPD_FF
@@ -390,6 +405,11 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: _SAIL_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
     // @User: Advanced
 
     AP_SUBGROUPINFO(_sailboat_heel_pid, "_SAIL_", 12, AR_AttitudeControl, AC_PID),

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
@@ -86,6 +86,11 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: _RATE_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_rate_pid0, "_RATE_", 3, AP_WheelRateControl, AC_PID),
 
     // @Param: 2_RATE_FF
@@ -154,6 +159,11 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: 2_RATE_I0
+    // @DisplayName: Initial I value
+    // @Description: Initial I value, this can be used to account for CG offsets by reducing the time taken to reach a steady state value, must be less than +-IMAX
     // @User: Advanced
 
     AP_SUBGROUPINFO(_rate_pid1, "2_RATE_", 4, AP_WheelRateControl, AC_PID),


### PR DESCRIPTION
This adds `I0` param to AC_PID, this value is reset to when `reset_I` or `reset_I_smoothly` is called. The param can be used to account for a steady I value offset due to center of gravity. Starting from 0 it takes a little time for the I to reach the steady state value resulting in exciting takeoffs, this parram allows to start from the correct point.

Perform a hover test and set the param to the steady state I value from log.

Open to better names than `I0` but we only have 4 characters...
