### PR TITLE
Copter: Add an element of NAV_CONTROLLER_OUTPUT to ZIGZAG mode

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1570,6 +1570,9 @@ protected:
 
     const char *name() const override { return "ZIGZAG"; }
     const char *name4() const override { return "ZIGZ"; }
+    uint32_t wp_distance() const override { return wp_nav->get_wp_distance_to_destination(); }
+    int32_t wp_bearing() const override { return wp_nav->get_wp_bearing_to_destination(); }
+    float crosstrack_error() const override { return wp_nav->crosstrack_error(); }
 
 private:
 


### PR DESCRIPTION
The distance from point A to point B in ZIGZAG mode will be several tens of meters to several hundred meters.
In this case, the operator will not know until the WP is reached.
In Japan, the assistant will notify the distance between the WP and the vehicle by transceiver.
The auxiliary notifies 10 meters, 5 meters, and 0 meters before the WP.
I would like to add this notification to ZIGZAG.

AFTER:
![Screenshot from 2021-05-16 14-19-13](https://user-images.githubusercontent.com/646194/118386585-723be200-b653-11eb-8d89-6c0b977b0a0a.png)
