### PR TITLE
AP_InertialSensor: enforce valid INS_GYR_CAL values

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -845,9 +845,15 @@ AP_InertialSensor::init(uint16_t loop_rate)
     }
 
     // calibrate gyros unless gyro calibration has been disabled
-    if (gyro_calibration_timing() != GYRO_CAL_NEVER) {
+    switch (gyro_calibration_timing()) {
+    case GYRO_CAL_NEVER:
+        break;
+    case GYRO_CAL_STARTUP_ONLY:
         init_gyro();
-    }
+        break;
+    default:
+        AP_BoardConfig::config_error("Invalid INS_GYR_CAL value");
+    };
 
     _sample_period_usec = 1000*1000UL / _loop_rate;
 


### PR DESCRIPTION
This will allow us to have other valid values into the future.

For example, value 103 might mean "calibrate once IMUs are at
temperature"

We could also have value 104 meaning, "any time you can actually manage to get consistent results from the IMU".  Currently if the gyros fail to cal at boot you have to either reboot and try again or issue a mavlink command to calibrate the gyros - when all you really should need to do is hold the machine still!

These new options are probably a 4.2 thing.  But if we can get this sanity check in place it will allow users who have a value other than 0 or 1 to correct that to a valid value (valid being defined as "in our enumeration").
