### PR TITLE
waf: list boards 1/line in case of board-not-found error

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -404,7 +404,11 @@ Please use a replacement build as follows:
 
         boards = _board_classes.keys()
         if not ctx.env.BOARD in boards:
-            ctx.fatal("Invalid board '%s': choices are %s" % (ctx.env.BOARD, ', '.join(sorted(boards, key=str.lower))))
+            ctx.fatal(
+                "Invalid board '%s': choices are\n%sInvalid board '%s'.  Options shown above this line." %
+                (ctx.env.BOARD,
+                 ''.join(["  %s\n" % x for x in sorted(boards, key=str.lower)]),
+                 ctx.env.BOARD))
         _board = _board_classes[ctx.env.BOARD]()
     return _board
 


### PR DESCRIPTION
This line is now way too long, and splitting it this way will allow the
output to be grepped for likely-looking board names.