### PR TITLE
autotest: retry dynamic notches 8 times before failing

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7035,7 +7035,7 @@ class AutoTestCopter(AutoTest):
             Test("DynamicRpmNotches",
                  "Fly Dynamic Notches driven by ESC Telemetry",
                  self.fly_esc_telemetry_notches,
-                 attempts=1),
+                 attempts=8),
 
             Test("GyroFFT",
                  "Fly Gyro FFT",


### PR DESCRIPTION
This test is flapping.

This is a poor - but serviceable - workaround.