### PR TITLE
AP_TECS: Fix glide without airspeed.

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -770,6 +770,7 @@ void AP_TECS::_update_throttle_without_airspeed(int16_t throttle_nudge)
     if (_flags.is_gliding)
     {
         _throttle_dem = 0.0f;
+        return;
     }
 
     // Calculate additional throttle for turn drag compensation including throttle nudging


### PR DESCRIPTION
Ensure zero throttle output if is_gliding flag is true when flying without airspeed. This makes sure there is zero throttle output in THERMAL mode. Previously the roll compensation was added after output was zero'd, making output non-zero.