### PR TITLE
AC_PosControl: PSC_ACCZ_P param range min reduced to 0.2

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -141,7 +141,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _ACCZ_P
     // @DisplayName: Acceleration (vertical) controller P gain
     // @Description: Acceleration (vertical) controller P gain.  Converts the difference between desired vertical acceleration and actual acceleration into a motor output
-    // @Range: 0.500 1.500
+    // @Range: 0.200 1.500
     // @Increment: 0.05
     // @User: Standard
 


### PR DESCRIPTION
This reduces the [PSC_ACCZ_P parameter](https://ardupilot.org/copter/docs/parameters.html#psc-accz-p-acceleration-vertical-controller-p-gain) descriptions minimum value from 0.5 to 0.2 so that it can be set according to the [Tuning Process Guide's](https://ardupilot.org/copter/docs/tuning-process-instructions.html#test-althold) which recommends it should be set to the MOT_THST_HOVER value which is very often below 0.5.

This is in response to a user who found Mission Planner was complaining that the value he attempted to set was out-of-range even though it was what the tuning process guide recommended.