### PR TITLE
AP_GPS: Nova: Remove unneeded injection override

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -290,17 +290,6 @@ AP_GPS_NOVA::process_message(void)
     return false;
 }
 
-void
-AP_GPS_NOVA::inject_data(const uint8_t *data, uint16_t len)
-{
-    if (port->txspace() > len) {
-        last_injected_data_ms = AP_HAL::millis();
-        port->write(data, len);
-    } else {
-        Debug("NOVA: Not enough TXSPACE");
-    }
-}
-
 #define CRC32_POLYNOMIAL 0xEDB88320L
 uint32_t AP_GPS_NOVA::CRC32Value(uint32_t icrc)
 {

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -32,8 +32,6 @@ public:
     // Methods
     bool read() override;
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-
     const char *name() const override { return "NOVA"; }
 
 private:
@@ -59,7 +57,6 @@ private:
     static const char* const _initialisation_blob[6];
    
     uint32_t crc_error_counter = 0;
-    uint32_t last_injected_data_ms = 0;
 
     struct PACKED nova_header
     {


### PR DESCRIPTION
The only reason to override this is for the inject data timestamping, which is an SBP driver logging feature, and not something any of the other drivers do.

We potentially should just do this at the top level for all drivers, it's a somewhat useful metric to have when debugging RTK, but first I was just removing it where it's just adding to the build size.