### PR TITLE
Fix compass not detected error with single compass and add single compass board to build_ci

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -19,9 +19,9 @@ export CHIBIOS_GIT_VERSION="ci_test"
 export CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime"
 autotest_args=""
 
-# If CI_BUILD_TARGET is not set, build 3 different ones
+# If CI_BUILD_TARGET is not set, build 4 different ones
 if [ -z "$CI_BUILD_TARGET" ]; then
-    CI_BUILD_TARGET="sitl linux fmuv3"
+    CI_BUILD_TARGET="sitl linux fmuv3 omnibusf4pro-one"
 fi
 
 waf=modules/waf/waf-light

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -879,6 +879,7 @@ bool Compass::register_compass(int32_t dev_id, uint8_t& instance)
     _state[i].registered = true;
     _state[i].priority = priority;
     instance = uint8_t(i);
+    _compass_count = 1;
     return true;
 #else
     Priority priority;


### PR DESCRIPTION
apparently `compass_count_=0` was allowing one to arm as EKF doesn't look into the value unless its time to switch. Even the configuration was passing  as well so no prearm checks were trigerred as well.
MAVLink stream and Compass Mot Cal uses this value though and were affected by this bug.