### PR TITLE
Rover: fix loiter_delay, cmd <0 sets a delay of 0 seconds

### DIFF
--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -560,8 +560,8 @@ bool ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd, bool always_sto
     // this will be used to remember the time in millis after we reach or pass the WP.
     loiter_start_time = 0;
 
-    // this is the delay, stored in seconds
-    loiter_duration = cmd.p1;
+    // this is the delay, stored in seconds, checked such that commanded delays < 0 delay 0 seconds
+    loiter_duration = ((int16_t) cmd.p1 < 0) ? 0 : cmd.p1;
 
     return true;
 }


### PR DESCRIPTION
Fixes #17488

I'm not sure if this user input case with `delay < 0` is better handled by the GCSs instead? 
This treats any negative input as 0 delay as I doubt a user wants a delay 9-18 hours long....

Tested with SITL using MAVProxy, Mission Planner, & QGC

![image](https://user-images.githubusercontent.com/69225461/119031612-43867a00-b979-11eb-81e2-0c27b0247baa.png)

![image](https://user-images.githubusercontent.com/69225461/119032065-c3acdf80-b979-11eb-9a96-9de8b37a78ff.png)
