### PR TITLE
Copter: standby: set land complete flag and re-init current flightmode

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -775,6 +775,8 @@ private:
 
     // standby.cpp
     void standby_update();
+    void enter_standby();
+    void exit_standby();
 
     // Log.cpp
     void Log_Write_Control_Tuning();

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -529,14 +529,10 @@ bool RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const AuxSwi
         case AUX_FUNC::STANDBY: {
             switch (ch_flag) {
                 case AuxSwitchPos::HIGH:
-                    copter.standby_active = true;
-                    AP::logger().Write_Event(LogEvent::STANDBY_ENABLE);
-                    gcs().send_text(MAV_SEVERITY_INFO, "Stand By Enabled");
+                    copter.enter_standby();
                     break;
                 default:
-                    copter.standby_active = false;
-                    AP::logger().Write_Event(LogEvent::STANDBY_DISABLE);
-                    gcs().send_text(MAV_SEVERITY_INFO, "Stand By Disabled");
+                    copter.exit_standby();
                     break;
                 }
             break;

--- a/ArduCopter/standby.cpp
+++ b/ArduCopter/standby.cpp
@@ -21,3 +21,25 @@ void Copter::standby_update()
     attitude_control->set_yaw_target_to_current_heading();
     pos_control->standby_xyz_reset();
 }
+
+// enter standby mode, flight controller is no longer flying the vehicle
+void Copter::enter_standby()
+{
+    standby_active = true;
+    AP::logger().Write_Event(LogEvent::STANDBY_ENABLE);
+    gcs().send_text(MAV_SEVERITY_INFO, "StandBy Enabled");
+}
+
+// Exit standby mode, takeover flying of the vehicle
+void Copter::exit_standby()
+{
+    standby_active = false;
+    AP::logger().Write_Event(LogEvent::STANDBY_DISABLE);
+    gcs().send_text(MAV_SEVERITY_INFO, "StandBy Disabled");
+
+    // if motors are armed make sure the vehicle does not think its on the ground
+    set_land_complete(!motors->armed());
+
+    // re init the current mode ignoring checks, should make the switch more seamless
+    flightmode->init(true);
+}


### PR DESCRIPTION
This adds enter and exit functions for standby. There are two additions that are called when standby is exited. 

Firstly the land_complete flag is set to false if the motors are armed. Currently it is possible to exit standby with AP still thinking its on the ground, in this case it will soon be proved correct as it will not try and fly. 

Secondly the init function for the current flight mode is re-called. This should make for a more seamless switch.