### PR TITLE
Revert "waf: list boards 1/line in case of board-not-found error"

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -404,11 +404,7 @@ Please use a replacement build as follows:
 
         boards = _board_classes.keys()
         if not ctx.env.BOARD in boards:
-            ctx.fatal(
-                "Invalid board '%s': choices are\n%sInvalid board '%s'.  Options shown above this line." %
-                (ctx.env.BOARD,
-                 ''.join(["  %s\n" % x for x in sorted(boards, key=str.lower)]),
-                 ctx.env.BOARD))
+            ctx.fatal("Invalid board '%s': choices are %s" % (ctx.env.BOARD, ', '.join(sorted(boards, key=str.lower))))
         _board = _board_classes[ctx.env.BOARD]()
     return _board
 


### PR DESCRIPTION
This reverts commit 8ab74d9462e1063ac6908e8f70e86cf23c1d03d7.

This broke the build server which parses the output of this