### PR TITLE
.github: add issue label notifier

### DIFF
--- a/.github/workflows/issue_notifier.yml
+++ b/.github/workflows/issue_notifier.yml
@@ -1,0 +1,20 @@
+name: Notify users based on issue labels
+
+on:
+  issues:
+      types: [labeled]
+  pull_request:
+      types: [labeled]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: bugobliterator/issue-label-notification-action@master
+          with:
+             recipients: |
+                  CAN=@bugobliterator
+                  AP_Periph=@bugobliterator
+                  ChibiOS=@bugobliterator
+                  Compass=@bugobliterator
+                  bootloader=@bugobliterator


### PR DESCRIPTION
Allows for developers to be notified for specific labels on Issues and Pull Requests. I believe it can be really handy to keep Notification clutter low and allow for better management for reviewers.

![image](https://user-images.githubusercontent.com/5697288/119144752-97bb5800-ba66-11eb-8779-2c3e327ef7b6.png)

In addition to this I believe we can also add things like auto assign etc. based on label. Maybe MergeOnCIPass happens automatically! Current repo for the action is here, https://github.com/bugobliterator/issue-label-notification-action