### PR TITLE
AP_IOMCU: fixed a safety reset case for IOMCU reset

### DIFF
--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -154,6 +154,9 @@ private:
     // have we forced the safety off?
     bool safety_forced_off;
 
+    // was safety off on last status?
+    bool last_safety_off;
+
     void send_servo_out(void);
     void read_rc_input(void);
     void read_servo(void);


### PR DESCRIPTION
if IOMCU resets in flight when user had disabled the safety switch
using the button then the IOCMU force safety code was not called

Tested on CubeOrange:
 - tested without this patch, armed IOMCU watchdog left safety on if safety was disabled using safety button
 - tested with this patch. armed IOMCU watchdog left safety off
