### PR TITLE
AP_RangeFinder: Ensure that the maximum distance matches the device performance

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -775,7 +775,7 @@ void AP_RangeFinder_VL53L0X::update(void)
 void AP_RangeFinder_VL53L0X::timer(void)
 {
     uint16_t range_mm;
-    if (get_reading(range_mm) && range_mm < 8000) {
+    if (get_reading(range_mm) && range_mm <= 2000) {
         sum_mm += range_mm;
         counter++;
     }


### PR DESCRIPTION
i Re-Open #11230

I know from the datasheet that the maximum distance for this device is 2 meters.
However, this code determines it at 8 meters.
This code is wrong.
I know that the existing drivers will be diverted to the new device's drivers.
I think any engineer would recognize this mistake.
I think it is better to fix it.
