### PR TITLE
Improve Plane's support for EXTENDED_SYS_STATE

### DIFF
--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -73,4 +73,8 @@ private:
     uint8_t high_latency_wind_direction() const override;
     int8_t high_latency_air_temperature() const override;
 #endif // HAL_HIGH_LATENCY2_ENABLED
+
+    MAV_VTOL_STATE vtol_state() const override;
+    MAV_LANDED_STATE landed_state() const override;
+
 };

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1360,7 +1360,8 @@ bool QuadPlane::is_flying(void)
     if (plane.control_mode == &plane.mode_guided && guided_takeoff) {
         return true;
     }
-    if (motors->get_throttle() > 0.01f && !motors->limit.throttle_lower) {
+    if (motors->get_spool_state() != AP_Motors::SpoolState::SHUT_DOWN &&
+        motors->get_throttle() > 0.01f && !motors->limit.throttle_lower) {
         return true;
     }
     if (in_tailsitter_vtol_transition()) {

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -84,6 +84,14 @@ public:
       return true if we are in a transition to fwd flight from hover
     */
     bool in_transition(void) const;
+    enum transition_state_t {
+        TRANSITION_AIRSPEED_WAIT,
+        TRANSITION_TIMER,
+        TRANSITION_ANGLE_WAIT_FW,
+        TRANSITION_ANGLE_WAIT_VTOL,
+        TRANSITION_DONE
+    };
+    transition_state_t get_transition_state() const { return transition_state; }
 
     /*
       return true if we are a tailsitter transitioning to VTOL flight
@@ -425,14 +433,7 @@ private:
     // when did we last run the attitude controller?
     uint32_t last_att_control_ms;
 
-    // true if we have reached the airspeed threshold for transition
-    enum {
-        TRANSITION_AIRSPEED_WAIT,
-        TRANSITION_TIMER,
-        TRANSITION_ANGLE_WAIT_FW,
-        TRANSITION_ANGLE_WAIT_VTOL,
-        TRANSITION_DONE
-    } transition_state;
+    transition_state_t transition_state;
 
     // true when waiting for pilot throttle
     bool throttle_wait:1;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -433,7 +433,7 @@ private:
     // when did we last run the attitude controller?
     uint32_t last_att_control_ms;
 
-    transition_state_t transition_state;
+    transition_state_t transition_state = QuadPlane::TRANSITION_DONE;
 
     // true when waiting for pilot throttle
     bool throttle_wait:1;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -92,6 +92,7 @@ public:
         TRANSITION_DONE
     };
     transition_state_t get_transition_state() const { return transition_state; }
+    bool to_fw_transition_initialised;
 
     /*
       return true if we are a tailsitter transitioning to VTOL flight

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -361,7 +361,7 @@ class AutoTestQuadPlane(AutoTest):
         # should not change just because we arm:
         # note that Q-modes always consider themselves as flying when armed,
         # thus the IN_AIR just here.
-#FIXME: removed because state isn't well-reflected; fixed in future PR
+# FIXME: removed because state isn't well-reflected; fixed in future PR
 #        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
 #                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
         self.change_mode("MANUAL")

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -361,9 +361,8 @@ class AutoTestQuadPlane(AutoTest):
         # should not change just because we arm:
         # note that Q-modes always consider themselves as flying when armed,
         # thus the IN_AIR just here.
-# FIXME: removed because state isn't well-reflected; fixed in future PR
-#        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-#                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
+        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
         self.change_mode("MANUAL")
         self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_FW,
                                        mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND)
@@ -372,9 +371,8 @@ class AutoTestQuadPlane(AutoTest):
         self.progress("Taking off")
         self.set_rc(3, 1750)
         self.wait_altitude(1, 5, relative=True)
-# FIXME: removed because state isn't well-reflected; fixed in future PR
-#        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-#                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
+        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
         self.wait_altitude(10, 15, relative=True)
 
         self.progress("Transitioning to fixed wing")
@@ -390,14 +388,12 @@ class AutoTestQuadPlane(AutoTest):
         self.change_mode("QHOVER")
         # for a standard quadplane there is no transition-to-mc stage.
         # tailsitters do have such a state.
-# FIXME: removed because state isn't well-reflected; fixed in future PR
-#        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-#                                     mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
+        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+                                     mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
         self.change_mode("QLAND")
         self.wait_altitude(0, 2, relative=True, timeout=60)
-# FIXME: removed because state isn't well-reflected; fixed in future PR
-#        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-#                                     mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND)
+        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+                                     mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND)
         self.mav.motors_disarmed_wait()
 
     def fly_qautotune(self):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -361,8 +361,9 @@ class AutoTestQuadPlane(AutoTest):
         # should not change just because we arm:
         # note that Q-modes always consider themselves as flying when armed,
         # thus the IN_AIR just here.
-        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
+#FIXME: removed because state isn't well-reflected; fixed in future PR
+#        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+#                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
         self.change_mode("MANUAL")
         self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_FW,
                                        mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND)
@@ -371,8 +372,9 @@ class AutoTestQuadPlane(AutoTest):
         self.progress("Taking off")
         self.set_rc(3, 1750)
         self.wait_altitude(1, 5, relative=True)
-        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
+# FIXME: removed because state isn't well-reflected; fixed in future PR
+#        self.assert_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+#                                       mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
         self.wait_altitude(10, 15, relative=True)
 
         self.progress("Transitioning to fixed wing")
@@ -388,12 +390,14 @@ class AutoTestQuadPlane(AutoTest):
         self.change_mode("QHOVER")
         # for a standard quadplane there is no transition-to-mc stage.
         # tailsitters do have such a state.
-        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-                                     mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
+# FIXME: removed because state isn't well-reflected; fixed in future PR
+#        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+#                                     mavutil.mavlink.MAV_LANDED_STATE_IN_AIR)
         self.change_mode("QLAND")
         self.wait_altitude(0, 2, relative=True, timeout=60)
-        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
-                                     mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND)
+# FIXME: removed because state isn't well-reflected; fixed in future PR
+#        self.wait_extended_sys_state(mavutil.mavlink.MAV_VTOL_STATE_MC,
+#                                     mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND)
         self.mav.motors_disarmed_wait()
 
     def fly_qautotune(self):


### PR DESCRIPTION
This builds (and is based on top of) https://github.com/ArduPilot/ardupilot/pull/10698

It changes some of the logic in QuadPlane to better reflect the vehicle's state.

I've been rebasing this for years - the chances are good that it has bitrotted and all of the logic needs checking again.
