### PR TITLE
Copter: Adjust MAV_CMD_DO_CHANGE_SPEED to the MAVLINK specification

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -809,9 +809,8 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             } else {
                 copter.wp_nav->set_speed_xy(packet.param2 * 100.0f);
             }
-            return MAV_RESULT_ACCEPTED;
         }
-        return MAV_RESULT_FAILED;
+        return MAV_RESULT_ACCEPTED;
 
 #if MODE_AUTO_ENABLED == ENABLED
     case MAV_CMD_MISSION_START:


### PR DESCRIPTION
I ran the command MAV_CMD_DO_CHANGE_SPEED.
I set parameter 2 to -1.0.
I got FAILED back in the processing result.
The flight plan executed the process successfully.
I changed the processing of the command because it did not meet the MAVLINK specification.

AUTO CLASS：
https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_auto.cpp#L1465