### PR TITLE
AP_CANManager: Hexa character is converted to binary by arithmetic operation

### DIFF
--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -81,23 +81,14 @@ static uint8_t nibble2hex(uint8_t x)
 
 static uint8_t hex2nibble(char c)
 {
-    // Must go into RAM, not flash, because flash is slow
-    static uint8_t NumConversionTable[] = {
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9
-    };
-
-    static uint8_t AlphaConversionTable[] = {
-        10, 11, 12, 13, 14, 15
-    };
-
     uint8_t out = 255;
 
     if (c >= '0' && c <= '9') {
-        out = NumConversionTable[int(c) - int('0')];
+        out = c - '0';
     } else if (c >= 'a' && c <= 'f') {
-        out = AlphaConversionTable[int(c) - int('a')];
+        out = c - 'a' + 10;
     } else if (c >= 'A' && c <= 'F') {
-        out = AlphaConversionTable[int(c) - int('A')];
+        out = c - 'A' + 10;
     }
 
     if (out == 255) {


### PR DESCRIPTION
The process of converting hexa character to binary is done by AP_WindVane_NMEA::char_to_hex method.
I divert this process so that no table is needed.
When calculating the index of the table, it is already converted to a number.
I think you can see that by using this value, the table is no longer needed.
Hexa character is converted to binary by arithmetic operation
