### PR TITLE
libraries: unify the pi values

### DIFF
--- a/libraries/AP_GyroFFT/CMSIS_5/include/arm_math.h
+++ b/libraries/AP_GyroFFT/CMSIS_5/include/arm_math.h
@@ -346,7 +346,7 @@ extern "C"
 #define DELTA_Q15          0x5
 #define INDEX_MASK         0x0000003F
 #ifndef PI
-  #define PI               3.14159265358979f
+  #define PI               (M_PI)
 #endif
 
   /**

--- a/libraries/AP_HAL_SITL/Synth.hpp
+++ b/libraries/AP_HAL_SITL/Synth.hpp
@@ -33,7 +33,7 @@ struct sTone
 ////////////////////////////////////////////////////////////
 // Converts frequency (Hz) to angular velocity
 ////////////////////////////////////////////////////////////
-const double PI = 3.14159265359;
+const double PI = M_PI;
 double w(const double dHertz)
 {
     return dHertz * 2.0 * PI;


### PR DESCRIPTION
I learned that there are multiple definitions of pi.
I learned that there are different values of pi.
I unify them into M_PI so that the arithmetic values are the same.
The value of M_PI is more accurate than other values of pi.
I know that the STM32F cannot handle double precision values.
I got a comment a long time ago that even if a CPU can't handle double precision, there is no need to intentionally reduce the precision of floating values.