### PR TITLE
Convert servo indexing to FMU indexing for ESC telemetry

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1505,14 +1505,14 @@ void AP_BLHeli::log_bidir_telemetry(void)
 
     // ask the next ESC for telemetry
     uint8_t idx_pos = last_telem_esc;
-    for (uint8_t idx = (idx_pos + 1) % num_motors;
-        idx != idx_pos;
-        idx = (idx_pos + 1) % num_motors) {
-        uint16_t mask = 1U << motor_map[idx];
-        if (SRV_Channels::have_digital_outputs(mask)) {
-            last_telem_esc = idx;
+    uint8_t idx = (idx_pos + 1) % num_motors;
+    for (; idx != idx_pos; idx = (idx_pos + 1) % num_motors) {
+        if (SRV_Channels::have_digital_outputs(1U << motor_map[idx])) {
             break;
         }
+    }
+    if (SRV_Channels::have_digital_outputs(1U << motor_map[idx])) {
+        last_telem_esc = idx;
     }
 }
 
@@ -1574,16 +1574,17 @@ void AP_BLHeli::update_telemetry(void)
     if (now - last_telem_request_us >= telem_rate_us) {
         // ask the next ESC for telemetry
         uint8_t idx_pos = last_telem_esc;
-        for (uint8_t idx = (idx_pos + 1) % num_motors;
-            idx != idx_pos;
-            idx = (idx_pos + 1) % num_motors) {
-            uint16_t mask = 1U << motor_map[idx];
-            if (SRV_Channels::have_digital_outputs(mask)) {
-                hal.rcout->set_telem_request_mask(mask);
-                last_telem_esc = idx;
-                last_telem_request_us = now;
+        uint8_t idx = (idx_pos + 1) % num_motors;
+        for (; idx != idx_pos; idx = (idx_pos + 1) % num_motors) {
+            if (SRV_Channels::have_digital_outputs(1U << motor_map[idx])) {
                 break;
             }
+        }
+        uint16_t mask = 1U << motor_map[idx];
+        if (SRV_Channels::have_digital_outputs(mask)) {
+            hal.rcout->set_telem_request_mask(mask);
+            last_telem_esc = idx;
+            last_telem_request_us = now;
         }
     }
 }

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -245,6 +245,9 @@ private:
     uint8_t motor_map[max_motors];
     uint16_t motor_mask;
 
+    // convert between servo number and FMU channel number for ESC telemetry
+    uint8_t chan_offset;
+
     // when did we last request telemetry?
     uint32_t last_telem_request_us;
     uint8_t last_telem_esc;


### PR DESCRIPTION
ESCs are always indexed from 0 for telemetry. Make sure this happens on IOMCU boards.

This also fixes ESC telemetry when there is only one motor