### PR TITLE
Copter/QuadPlane: set yaw rate to zero during arming

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -458,7 +458,7 @@ void Mode::make_safe_spool_down()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // relax controllers during idle states
         attitude_control->reset_rate_controller_I_terms_smoothly();
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         break;
 
     case AP_Motors::SpoolState::SPOOLING_UP:

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -27,13 +27,13 @@ void ModeAcro::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->set_attitude_target_to_current_attitude();
+        attitude_control->reset_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         break;
 
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
-        attitude_control->set_attitude_target_to_current_attitude();
+        attitude_control->reset_target_and_rate();
         attitude_control->reset_rate_controller_I_terms_smoothly();
         break;
 

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -45,14 +45,14 @@ void ModeAcro_Heli::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->set_attitude_target_to_current_attitude();
+        attitude_control->reset_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         break;
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
         if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
-            attitude_control->set_attitude_target_to_current_attitude();
+            attitude_control->reset_target_and_rate();
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -45,12 +45,12 @@ void ModeAltHold::run()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHold_Landed_Ground_Idle:
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -50,7 +50,7 @@ void AutoTune::run()
             copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
         }
         copter.attitude_control->reset_rate_controller_I_terms_smoothly();
-        copter.attitude_control->set_yaw_target_to_current_heading();
+        copter.attitude_control->reset_yaw_target_and_rate();
 
         float target_roll, target_pitch, target_yaw_rate;
         get_pilot_desired_rp_yrate_cd(target_roll, target_pitch, target_yaw_rate);

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -91,13 +91,13 @@ void ModeDrift::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         break;
 
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms_smoothly();
         break;
 

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -263,7 +263,7 @@ void ModeFlowHold::run()
     case AltHold_MotorStopped:
         copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
         copter.attitude_control->reset_rate_controller_I_terms();
-        copter.attitude_control->set_yaw_target_to_current_heading();
+        copter.attitude_control->reset_yaw_target_and_rate();
         copter.pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         flow_pi_xy.reset_I();
         break;
@@ -285,7 +285,7 @@ void ModeFlowHold::run()
         break;
 
     case AltHold_Landed_Ground_Idle:
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -147,7 +147,7 @@ void ModeLoiter::run()
     case AltHold_Landed_Pre_Takeoff:
         attitude_control->reset_rate_controller_I_terms_smoothly();
         loiter_nav->init_target();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
+        attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate);
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -115,7 +115,7 @@ void ModeLoiter::run()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->init_target();
         attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate);
@@ -141,7 +141,7 @@ void ModeLoiter::run()
         break;
 
     case AltHold_Landed_Ground_Idle:
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -101,7 +101,7 @@ void ModePosHold::run()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
@@ -141,7 +141,7 @@ void ModePosHold::run()
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
         loiter_nav->update(false);
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         init_wind_comp_estimate();
         FALLTHROUGH;
 

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -75,7 +75,7 @@ void ModeSport::run()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
@@ -93,7 +93,7 @@ void ModeSport::run()
         break;
 
     case AltHold_Landed_Ground_Idle:
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -31,13 +31,13 @@ void ModeStabilize::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         break;
 
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms_smoothly();
         break;
 

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -50,14 +50,14 @@ void ModeStabilize_Heli::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         break;
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
         if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
-            attitude_control->set_yaw_target_to_current_heading();
+            attitude_control->reset_yaw_target_and_rate();
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -131,7 +131,7 @@ void ModeSystemId::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         break;
 
@@ -140,7 +140,7 @@ void ModeSystemId::run()
         // Tradheli initializes targets when going from disarmed to armed state. 
         // init_targets_on_arming is always set true for multicopter.
         if (motors->init_targets_on_arming()) {
-            attitude_control->set_yaw_target_to_current_heading();
+            attitude_control->reset_yaw_target_and_rate();
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -114,7 +114,7 @@ void ModeThrow::run()
         }
 
         // demand zero throttle (motors will be stopped anyway) and continually reset the attitude controller
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_throttle_out(0,true,g.throttle_filt);
         break;
@@ -129,7 +129,7 @@ void ModeThrow::run()
         }
 
         // Hold throttle at zero during the throw and continually reset the attitude controller
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_throttle_out(0,true,g.throttle_filt);
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -326,7 +326,7 @@ void ModeZigZag::manual_control()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->init_target();
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
@@ -352,7 +352,7 @@ void ModeZigZag::manual_control()
         break;
 
     case AltHold_Landed_Ground_Idle:
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         FALLTHROUGH;
 
     case AltHold_Landed_Pre_Takeoff:

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -358,7 +358,7 @@ void ModeZigZag::manual_control()
     case AltHold_Landed_Pre_Takeoff:
         attitude_control->reset_rate_controller_I_terms_smoothly();
         loiter_nav->init_target();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
+        attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate);
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 

--- a/ArduCopter/standby.cpp
+++ b/ArduCopter/standby.cpp
@@ -18,6 +18,6 @@ void Copter::standby_update()
     }
 
     attitude_control->reset_rate_controller_I_terms();
-    attitude_control->set_yaw_target_to_current_heading();
+    attitude_control->reset_yaw_target_and_rate();
     pos_control->standby_xyz_reset();
 }

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -123,7 +123,7 @@ void Mode::auto_takeoff_run()
         wp_nav->shift_wp_origin_and_destination_to_current_pos_xy();
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         pos_control->update_z_controller();
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
         return;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1913,7 +1913,7 @@ void QuadPlane::update_transition(void)
             // using vectored yaw for tilt-rotors as the yaw control
             // is needed to maintain good control in forward
             // transitions
-            attitude_control->set_yaw_target_to_current_heading();
+            attitude_control->reset_yaw_target_and_rate();
             attitude_control->rate_bf_yaw_target(ahrs.get_gyro().z);
         }
 
@@ -1965,7 +1965,7 @@ void QuadPlane::update_transition(void)
         // We disable this for vectored yaw tilt rotors as they do need active
         // yaw control throughout the transition
         if (!tilt.is_vectored) {
-            attitude_control->set_yaw_target_to_current_heading();
+            attitude_control->reset_yaw_target_and_rate();
             attitude_control->rate_bf_yaw_target(ahrs.get_gyro().z);
         }
         break;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -875,13 +875,20 @@ Vector3f AC_AttitudeControl::euler_accel_limit(const Vector3f &euler_rad, const 
     return rot_accel;
 }
 
-// Shifts earth frame yaw target by yaw_shift_cd. yaw_shift_cd should be in centidegrees and is added to the current target heading
-void AC_AttitudeControl::shift_ef_yaw_target(float yaw_shift_cd)
+// Sets yaw target to vehicle heading and sets yaw rate to zero
+void AC_AttitudeControl::set_yaw_target_to_current_heading()
 {
-    float yaw_shift = radians(yaw_shift_cd * 0.01f);
+    // move attitude target to current heading
+    float yaw_shift = _ahrs.yaw - _euler_angle_target.z;
     Quaternion _attitude_target_update;
     _attitude_target_update.from_axis_angle(Vector3f{0.0f, 0.0f, yaw_shift});
     _attitude_target = _attitude_target_update * _attitude_target;
+
+    // set yaw rate to zero
+    _euler_rate_target.z = 0.0f;
+
+    // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
+    euler_rate_to_ang_vel(_euler_angle_target, _euler_rate_target, _ang_vel_target);
 }
 
 // Shifts the target attitude to maintain the current error in the event of an EKF reset

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -876,7 +876,7 @@ Vector3f AC_AttitudeControl::euler_accel_limit(const Vector3f &euler_rad, const 
 }
 
 // Sets attitude target to vehicle attitude and sets all rates to zero
-void AC_AttitudeControl::set_attitude_target_to_current_attitude()
+void AC_AttitudeControl::reset_target_and_rate()
 {
     // move attitude target to current attitude
     _ahrs.get_quat_body_to_ned(_attitude_target);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -875,6 +875,17 @@ Vector3f AC_AttitudeControl::euler_accel_limit(const Vector3f &euler_rad, const 
     return rot_accel;
 }
 
+// Sets attitude target to vehicle attitude and sets all rates to zero
+void AC_AttitudeControl::set_attitude_target_to_current_attitude()
+{
+    // move attitude target to current attitude
+    _ahrs.get_quat_body_to_ned(_attitude_target);
+
+    // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
+    _ang_vel_target.zero();
+    _euler_angle_target.zero();
+}
+
 // Sets yaw target to vehicle heading and sets yaw rate to zero
 void AC_AttitudeControl::reset_yaw_target_and_rate()
 {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -876,7 +876,7 @@ Vector3f AC_AttitudeControl::euler_accel_limit(const Vector3f &euler_rad, const 
 }
 
 // Sets yaw target to vehicle heading and sets yaw rate to zero
-void AC_AttitudeControl::set_yaw_target_to_current_heading()
+void AC_AttitudeControl::reset_yaw_target_and_rate()
 {
     // move attitude target to current heading
     float yaw_shift = _ahrs.yaw - _euler_angle_target.z;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -130,7 +130,7 @@ public:
     void reset_rate_controller_I_terms_smoothly();
 
     // Sets attitude target to vehicle attitude and sets all rates to zero
-    void set_attitude_target_to_current_attitude();
+    void reset_target_and_rate();
 
     // Sets yaw target to vehicle heading and sets yaw rate to zero
     void reset_yaw_target_and_rate();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -133,7 +133,7 @@ public:
     void set_attitude_target_to_current_attitude() { _ahrs.get_quat_body_to_ned(_attitude_target); }
 
     // Sets yaw target to vehicle heading and sets yaw rate to zero
-    void set_yaw_target_to_current_heading();
+    void reset_yaw_target_and_rate();
 
     // handle reset of attitude from EKF since the last iteration
     void inertial_frame_reset();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -132,11 +132,8 @@ public:
     // Sets attitude target to vehicle attitude
     void set_attitude_target_to_current_attitude() { _ahrs.get_quat_body_to_ned(_attitude_target); }
 
-    // Sets yaw target to vehicle heading
-    void set_yaw_target_to_current_heading() { shift_ef_yaw_target(degrees(_ahrs.yaw - _euler_angle_target.z) * 100.0f); }
-
-    // Shifts earth frame yaw target by yaw_shift_cd. yaw_shift_cd should be in centidegrees and is added to the current target heading
-    void shift_ef_yaw_target(float yaw_shift_cd);
+    // Sets yaw target to vehicle heading and sets yaw rate to zero
+    void set_yaw_target_to_current_heading();
 
     // handle reset of attitude from EKF since the last iteration
     void inertial_frame_reset();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -129,8 +129,8 @@ public:
     // reset rate controller I terms smoothly to zero in 0.5 seconds
     void reset_rate_controller_I_terms_smoothly();
 
-    // Sets attitude target to vehicle attitude
-    void set_attitude_target_to_current_attitude() { _ahrs.get_quat_body_to_ned(_attitude_target); }
+    // Sets attitude target to vehicle attitude and sets all rates to zero
+    void set_attitude_target_to_current_attitude();
 
     // Sets yaw target to vehicle heading and sets yaw rate to zero
     void reset_yaw_target_and_rate();


### PR DESCRIPTION
This PR fixes a bug where the act of arming the aircraft commands a yaw rate request that is not zeroed. This means that the aircraft develops a yaw offset immediately after arming.

This also fixes a similar issue with Loiter where the attitude is commanded level rather than the current attitude causing motors to run up unnecessarily.