### PR TITLE
AP_OSD: do not show hgt_abvterr and fence elements by default

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -181,8 +181,8 @@ private:
     AP_OSD_Setting clk{false, 0, 0};
     AP_OSD_Setting callsign{false, 0, 0};
     AP_OSD_Setting vtx_power{false, 0, 0};
-    AP_OSD_Setting hgt_abvterr{true, 23, 7};
-    AP_OSD_Setting fence{true, 14, 9};
+    AP_OSD_Setting hgt_abvterr{false, 23, 7};
+    AP_OSD_Setting fence{false, 14, 9};
 #if HAL_PLUSCODE_ENABLE
     AP_OSD_Setting pluscode{false, 0, 0};
 #endif


### PR DESCRIPTION
I don't think the hgt_abvterr and fence OSD elements should be enabled by default. In fact all the new elements should probably be disabled by default so that they don't just appear after a firmware update.