### PR TITLE
AP_BattMonitor: Record and report UAVCAN Battery Info temperature correctly

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1480,7 +1480,9 @@ void AP_Periph_FW::can_battery_update(void)
         }
         float temperature;
         if (battery.lib.get_temperature(temperature, i)) {
-            pkt.temperature = temperature;
+            // Battery lib reports temperature in Celsius.
+            // Convert Celsius to Kelvin for tranmission on CAN.
+            pkt.temperature = temperature + C_TO_KELVIN;
         }
 
         fix_float16(pkt.voltage);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
@@ -27,6 +27,8 @@ public:
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     uint8_t capacity_remaining_pct() const override;
 
+    bool has_temperature() const override { return _has_temperature; }
+
     bool has_current() const override {
         return true;
     }
@@ -51,4 +53,5 @@ private:
     AP_UAVCAN* _ap_uavcan;
     uint8_t _node_id;
     uint8_t _soc;
+    bool _has_temperature;
 };


### PR DESCRIPTION
This addresses two issues with UAVCAN Battery Info reporting:
* Battery temperature reported over UAVCAN is not reported in neither `BATTERY_STATUS` nor Logging messages `BAT` or `BAT[x]`. This is because the `has_temperature()` function is reporting no temperature present for smart battery.
* There currently exists no conversion for what the battery transmits (kelvin) to what the battery monitor stores internally (Celsius). Battery temperature is transmitted over UAVCAN in Kelvin, stored in Celsius and reported in `cdegC`.

Before and after the change set:

![image](https://user-images.githubusercontent.com/12959316/119440661-174b6e80-bd68-11eb-8c7a-ed93ff700644.png)



