### PR TITLE
Copter/Sub/QuadPlane: PSCZ logged in AltHold and other modes with only vertical control

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -419,7 +419,7 @@ void Copter::ten_hz_logging_loop()
     if (should_log(MASK_LOG_RCOUT)) {
         logger.Write_RCOUT();
     }
-    if (should_log(MASK_LOG_NTUN) && (flightmode->requires_GPS() || landing_with_GPS())) {
+    if (should_log(MASK_LOG_NTUN) && (flightmode->requires_GPS() || landing_with_GPS() || !flightmode->has_manual_throttle())) {
         pos_control->write_log();
     }
     if (should_log(MASK_LOG_IMU) || should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -195,7 +195,7 @@ void Sub::ten_hz_logging_loop()
     if (should_log(MASK_LOG_RCOUT)) {
         logger.Write_RCOUT();
     }
-    if (should_log(MASK_LOG_NTUN) && mode_requires_GPS(control_mode)) {
+    if (should_log(MASK_LOG_NTUN) && (mode_requires_GPS(control_mode) || !mode_has_manual_throttle(control_mode))) {
         pos_control.write_log();
     }
     if (should_log(MASK_LOG_IMU) || should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1081,18 +1081,21 @@ void AC_PosControl::standby_xyz_reset()
     init_ekf_xy_reset();
 }
 
-// write log to dataflash
+// write PSC and/or PSCZ logs
 void AC_PosControl::write_log()
 {
-    float accel_x, accel_y;
-    lean_angles_to_accel_xy(accel_x, accel_y);
+    if (is_active_xy()) {
+        float accel_x, accel_y;
+        lean_angles_to_accel_xy(accel_x, accel_y);
+        AP::logger().Write_PSC(get_pos_target_cm(), _inav.get_position(), get_vel_target_cms(), _inav.get_velocity(), get_accel_target_cmss(), accel_x, accel_y);
+    }
 
-    AP::logger().Write_PSC(get_pos_target_cm(), _inav.get_position(), get_vel_target_cms(), _inav.get_velocity(), get_accel_target_cmss(), accel_x, accel_y);
-    AP::logger().Write_PSCZ(get_pos_target_cm().z, _inav.get_position().z,
-        get_vel_desired_cms().z, get_vel_target_cms().z, _inav.get_velocity().z,
-                            _accel_desired.z, get_accel_target_cmss().z, get_z_accel_cmss(), _attitude_control.get_throttle_in());
+    if (is_active_z()) {
+        AP::logger().Write_PSCZ(get_pos_target_cm().z, _inav.get_position().z,
+                                get_vel_desired_cms().z, get_vel_target_cms().z, _inav.get_velocity().z,
+                                _accel_desired.z, get_accel_target_cmss().z, get_z_accel_cmss(), _attitude_control.get_throttle_in());
+    }
 }
-
 
 ///
 /// private methods

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -310,6 +310,7 @@ public:
     // lean_angles_to_accel - convert roll, pitch lean angles to lat/lon frame accelerations in cm/s/s
     Vector3f lean_angles_to_accel(const Vector3f& att_target_euler) const;
 
+    // write PSC and/or PSCZ logs
     void write_log();
 
     // provide feedback on whether arming would be a good idea right now:


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/17441 by logging the PSCZ messages in modes that only have vertical control like AltHold.

This has been tested in SITL for Copter, Sub and QuadPlane to confirm that messages PSCZ message now appear when the vehicle is in AltHold mode or QHover.  Below shows a screen shot of the Copter log extracted into a spreadsheet and we see PSCZ messages appear in AltHold and PSC and PSCZ still appear in Loiter. 
![image](https://user-images.githubusercontent.com/1498098/119441661-76f24b80-bd61-11eb-8c83-7a91a7d72e00.png)

The only downside to this change is that we can get one extra PSC message when entering AltHold mode because the is_active_xy() might still return true because it uses a timeout.  This is shown below when Sub changes from Guided to AltHold and we see one extra PSC message.
![image](https://user-images.githubusercontent.com/1498098/119442749-5925e600-bd63-11eb-84fc-55404043b404.png)

