### PR TITLE
GCS_MAVLink: increase statustext queue size to 7 on low-mem boards

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -12,6 +12,12 @@
 
 extern const AP_HAL::HAL& hal;
 
+// if this assert fails then fix it and the comment in GCS.h where
+// _statustext_queue is declared
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+assert_storage_size<GCS::statustext_t, 58> _assert_statustext_t_size;
+#endif
+
 void GCS::get_sensor_status_flags(uint32_t &present,
                                   uint32_t &enabled,
                                   uint32_t &health)

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1035,12 +1035,13 @@ private:
 
     void service_statustext(void);
 #if HAL_MEM_CLASS <= HAL_MEM_CLASS_192 || CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    static const uint8_t _status_capacity = 5;
+    static const uint8_t _status_capacity = 7;
 #else
     static const uint8_t _status_capacity = 30;
 #endif
 
-    // queue of outgoing statustext messages
+    // queue of outgoing statustext messages.  Each entry consumes 58
+    // bytes of RAM on stm32
     StatusTextQueue _statustext_queue{_status_capacity};
 
     // true if we have already allocated protocol objects:


### PR DESCRIPTION
... and SITL....

Copter currently spits out so many messages on a banner-send (e.g what
we do when parameters are fetched) that it puses the first sent message
straight out of the queue before it gets a chance to be sent from the
queue.

Each entry is currently 40 bytes long on stm32, so this costs us 80 bytes of RAM on every board.

Closes https://github.com/ArduPilot/ardupilot/issues/17515


Note that a more elaborate fix here would be to run some sort of state machine which is reset any time we'd currently send all of these banner messages out.  It would then issue the statustexts only when the queue was empty or not full (or something).  That would likely cost us several hundred bytes of flash.
