### PR TITLE
.github: change to using pull_request_target

### DIFF
--- a/.github/workflows/issue_notifier.yml
+++ b/.github/workflows/issue_notifier.yml
@@ -3,7 +3,7 @@ name: Notify users based on issue labels
 on:
   issues:
       types: [labeled]
-  pull_request:
+  pull_request_target:
       types: [labeled]
 
 jobs:


### PR DESCRIPTION
This ensures that correct credentials are passed down to allow comments on the PRs. 
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target