### PR TITLE
AP_VisualOdom: use get_yaw instead of to_axis_angle

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -129,12 +129,6 @@ void AP_VisualOdom_IntelT265::rotate_attitude(Quaternion &attitude) const
 // use sensor provided attitude to calculate rotation to align sensor with AHRS/EKF attitude
 bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, const Quaternion &attitude)
 {
-    // fail immediately if ahrs cannot provide attitude
-    Quaternion ahrs_quat;
-    if (!AP::ahrs().get_quaternion(ahrs_quat)) {
-        return false;
-    }
-
     // do not align to ahrs if it is using us as its yaw source
     if (AP::ahrs().is_ext_nav_used_for_yaw()) {
         return false;
@@ -165,10 +159,8 @@ bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, 
     const float sens_yaw = att_corrected.get_euler_yaw();
 
     // trim yaw by difference between ahrs and sensor yaw
-    Vector3f angle_diff;
-    ahrs_quat.angular_difference(att_corrected).to_axis_angle(angle_diff);
     const float yaw_trim_orig = _yaw_trim;
-    _yaw_trim = angle_diff.z;
+    _yaw_trim = wrap_2PI(AP::ahrs().get_yaw() - sens_yaw);
     gcs().send_text(MAV_SEVERITY_CRITICAL, "VisOdom: yaw shifted %d to %d deg",
                     (int)degrees(_yaw_trim - yaw_trim_orig),
                     (int)wrap_360(degrees(sens_yaw + _yaw_trim)));


### PR DESCRIPTION
Visual Odometry "Calibration" (aka yaw alignment) via aux switch seems to have an issue which means that after the aux switch is moved, VISP.Yaw does not equal ATT.Yaw.
I fixed the issue to use get_yaw instead of to axis_angle function.

Before
![image](https://user-images.githubusercontent.com/16643069/119455599-b70ef980-bd74-11eb-9ce9-dacbc7269a2a.png)

After
![image](https://user-images.githubusercontent.com/16643069/119455712-d4dc5e80-bd74-11eb-8852-342bd4e1b29a.png)

I tested this with CubeBlack and CubeOrange.