### PR TITLE
Precland target

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -277,6 +277,17 @@ void GCS_MAVLINK_Copter::send_winch_status() const
 #endif
 }
 
+void GCS_MAVLINK_Copter::send_landing_target() const
+{
+#if PRECISION_LANDING == ENABLED
+    AC_PrecLand *precland = AP::precland();
+    if (precland == nullptr) {
+        return;
+    }
+    precland->send_landing_target(chan);
+#endif
+}
+
 uint8_t GCS_MAVLINK_Copter::sysid_my_gcs() const
 {
     return copter.g.sysid_my_gcs;

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -66,6 +66,7 @@ private:
     void send_pid_tuning() override;
 
     void send_winch_status() const override;
+    void send_landing_target() const override;
 
     void send_wind() const;
 };

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -407,13 +407,13 @@ bool AC_PrecLand::construct_pos_meas_using_rangefinder(float rangefinder_alt_m, 
         bool target_vec_valid = target_vec_unit_ned.z > 0.0f;
         bool alt_valid = (rangefinder_alt_valid && rangefinder_alt_m > 0.0f) || (_backend->distance_to_target() > 0.0f);
         if (target_vec_valid && alt_valid) {
-            float dist, alt;
+            float alt;
             if (_backend->distance_to_target() > 0.0f) {
-                dist = _backend->distance_to_target();
-                alt = dist * target_vec_unit_ned.z;
+                _dist = _backend->distance_to_target();
+                alt = _dist * target_vec_unit_ned.z;
             } else {
                 alt = MAX(rangefinder_alt_m, 0.0f);
-                dist = alt / target_vec_unit_ned.z;
+                _dist = alt / target_vec_unit_ned.z;
             }
 
             // Compute camera position relative to IMU
@@ -421,7 +421,7 @@ bool AC_PrecLand::construct_pos_meas_using_rangefinder(float rangefinder_alt_m, 
             Vector3f cam_pos_ned = inertial_data_delayed->Tbn * (_cam_offset.get() - accel_body_offset);
 
             // Compute target position relative to IMU
-            _target_pos_rel_meas_NED = Vector3f(target_vec_unit_ned.x*dist, target_vec_unit_ned.y*dist, alt) + cam_pos_ned;
+            _target_pos_rel_meas_NED = Vector3f(target_vec_unit_ned.x * _dist, target_vec_unit_ned.y * _dist, alt) + cam_pos_ned;
             return true;
         }
     }

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -468,6 +468,28 @@ void AC_PrecLand::run_output_prediction()
     _target_pos_rel_out_NE.y += land_ofs_ned_m.y;
 }
 
+// Send LANDING_TARGET mavlink message
+void AC_PrecLand::send_landing_target(mavlink_channel_t chan)
+{
+    mavlink_msg_landing_target_send(
+            chan,
+            _last_backend_los_meas_ms * 1000, // sensor/measurement timestamp in microseconds, either from epoch or since boot
+            0,
+            MAV_FRAME_LOCAL_NED, // frame
+            0,
+            0,
+            _dist, // distance to target, measured from rangefinder or sensor message
+            0,
+            0,
+            _target_pos_rel_out_NE.x, // x,
+            _target_pos_rel_out_NE.y, // y,
+            0,
+            0,
+            LANDING_TARGET_TYPE_LIGHT_BEACON, // TODO: use type from backend default to IRLOCK type,
+            target_acquired()  // use acquire as validator as that is use in the code for now
+    );
+}
+
 // Write a precision landing entry
 void AC_PrecLand::Write_Precland()
 {

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -119,6 +119,13 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
 //
 AC_PrecLand::AC_PrecLand()
 {
+    if (_singleton) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        AP_HAL::panic("Too many precland");
+#endif
+        return;
+    }
+    _singleton = this;
     // set parameters to defaults
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -494,4 +501,19 @@ void AC_PrecLand::Write_Precland()
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
+
+// Get the AP_Generator singleton
+AC_PrecLand *AC_PrecLand::get_singleton()
+{
+    return _singleton;
+}
+
+AC_PrecLand *AC_PrecLand::_singleton;
+
+namespace AP {
+AC_PrecLand *precland()
+{
+    return AC_PrecLand::get_singleton();
+}
+};
 

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -29,6 +29,9 @@ public:
     AC_PrecLand(const AC_PrecLand &other) = delete;
     AC_PrecLand &operator=(const AC_PrecLand&) = delete;
 
+    static AC_PrecLand *get_singleton();
+    static AC_PrecLand *_singleton;
+
     // perform any required initialisation of landing controllers
     // update_rate_hz should be the rate at which the update method will be called in hz
     void init(uint16_t update_rate_hz);
@@ -147,4 +150,8 @@ private:
     // write out PREC message to log:
     void Write_Precland();
     uint32_t last_log_ms;  // last time we logged
+};
+
+namespace AP {
+AC_PrecLand *precland();
 };

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -72,6 +72,8 @@ public:
     // process a LANDING_TARGET mavlink message
     void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms);
 
+    void send_landing_target(mavlink_channel_t chan);
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -129,6 +129,7 @@ private:
 
     Vector2f                    _target_pos_rel_out_NE; // target's position relative to the camera, fed into position controller
     Vector2f                    _target_vel_rel_out_NE; // target's velocity relative to the CG, fed into position controller
+    float                       _dist;                  // Distance to target measured from rangefinder or sensor
 
     // structure and buffer to hold a history of vehicle velocity
     struct inertial_data_frame_s {

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -268,6 +268,7 @@ public:
     void send_rpm() const;
     void send_generator_status() const;
     virtual void send_winch_status() const {};
+    virtual void send_landing_target() const {};
 
     // lock a channel, preventing use by MAVLink
     void lock(bool _lock) {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -858,6 +858,7 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_EFI_STATUS,            MSG_EFI_STATUS},
         { MAVLINK_MSG_ID_GENERATOR_STATUS,      MSG_GENERATOR_STATUS},
         { MAVLINK_MSG_ID_WINCH_STATUS,          MSG_WINCH_STATUS},
+        { MAVLINK_MSG_ID_LANDING_TARGET,        MSG_LANDING_TARGET},
             };
 
     for (uint8_t i=0; i<ARRAY_SIZE(map); i++) {
@@ -4774,6 +4775,7 @@ void GCS_MAVLINK::send_generator_status() const
 #endif
 }
 
+
 bool GCS_MAVLINK::try_send_message(const enum ap_message id)
 {
     bool ret = true;
@@ -5080,6 +5082,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
     case MSG_WINCH_STATUS:
         CHECK_PAYLOAD_SIZE(WINCH_STATUS);
         send_winch_status();
+        break;
+
+    case MSG_LANDING_TARGET:
+        CHECK_PAYLOAD_SIZE(LANDING_TARGET);
+        send_landing_target();
         break;
 
     default:

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -77,5 +77,6 @@ enum ap_message : uint8_t {
     MSG_EFI_STATUS,
     MSG_GENERATOR_STATUS,
     MSG_WINCH_STATUS,
+    MSG_LANDING_TARGET,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
Rework from https://github.com/ArduPilot/ardupilot/pull/9125

This implement support for the drone to send the LANDING_TARGET back. This is available only with MESSAGE_INTERVAL and not part of any stream by default.

It was tested in SITL.

 close https://github.com/ArduPilot/ardupilot/pull/9125
close https://github.com/ArduPilot/ardupilot/pull/9092