### PR TITLE
AP_VisualOdom: Change the GCS message level to INFO

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -161,7 +161,7 @@ bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, 
     // trim yaw by difference between ahrs and sensor yaw
     const float yaw_trim_orig = _yaw_trim;
     _yaw_trim = wrap_2PI(AP::ahrs().get_yaw() - sens_yaw);
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "VisOdom: yaw shifted %d to %d deg",
+    gcs().send_text(MAV_SEVERITY_INFO, "VisOdom: yaw shifted %d to %d deg",
                     (int)degrees(_yaw_trim - yaw_trim_orig),
                     (int)wrap_360(degrees(sens_yaw + _yaw_trim)));
 


### PR DESCRIPTION
I change this GCS message level from Critical to Informational.
I do my normal processing after this GCS message.
The critical level is "Action must be taken immediately. Indicates failure in a primary system".
I don't think this GCS message meets this intent.