### PR TITLE
Copter: make terrain-height-stable-when-no-position value stick

### DIFF
--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -76,6 +76,7 @@ void Copter::update_ekf_terrain_height_stable()
     // set to false if no position estimate
     if (!position_ok() && !ekf_has_relative_position()) {
         ahrs.set_terrain_hgt_stable(false);
+        return;
     }
 
     // consider terrain height stable if vehicle is taking off or landing


### PR DESCRIPTION
The set immediately above this return is completely ineffective without
a return statement.

Completely untested (except I did eyeball it for spelling mistakes).

The use of `ekf_has_relative_position` is also dubious (here and in other places) as it ignores the value of `failsafe.ekf` 
