### PR TITLE
AC_PrecLand: Add LANDING_TARGET_TYPE and LANDING_TARGET.type support

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -490,7 +490,8 @@ void AC_PrecLand::Write_Precland()
         meas_z          : target_pos_meas.z,
         last_meas       : last_backend_los_meas_ms(),
         ekf_outcount    : ekf_outlier_count(),
-        estimator       : (uint8_t)_estimator_type
+        estimator       : (uint8_t)_estimator_type,
+        target_type     : (uint8_t)_backend->target_type()
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -34,6 +34,9 @@ public:
     // returns distance to target in meters (0 means distance is not known)
     virtual float distance_to_target() { return 0.0f; };
 
+    // returns target type
+    virtual LANDING_TARGET_TYPE target_type() const = 0;
+
     // parses a mavlink message from the companion computer
     virtual void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) {};
 

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -52,4 +52,12 @@ void AC_PrecLand_Companion::handle_msg(const mavlink_landing_target_t &packet, u
 
     _los_meas_time_ms = timestamp_ms;
     _have_los_meas = true;
+    
+    _target_type = (LANDING_TARGET_TYPE)packet.type;
+}
+
+// return target type
+LANDING_TARGET_TYPE AC_PrecLand_Companion::target_type() const
+{
+    return _target_type;
 }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -35,6 +35,9 @@ public:
     // returns distance to target in meters (0 means distance is not known)
     float distance_to_target() override;
 
+    // returns target type
+    LANDING_TARGET_TYPE target_type() const override;
+
     // parses a mavlink message from the companion computer
     void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) override;
 
@@ -44,4 +47,6 @@ private:
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
+    
+    LANDING_TARGET_TYPE _target_type;           // LANDING_TARGET_TYPE enum
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
@@ -50,3 +50,9 @@ uint32_t AC_PrecLand_IRLock::los_meas_time_ms() {
 bool AC_PrecLand_IRLock::have_los_meas() {
     return _have_los_meas;
 }
+
+// return target type
+LANDING_TARGET_TYPE AC_PrecLand_IRLock::target_type() const
+{
+    return LANDING_TARGET_TYPE_LIGHT_BEACON;
+}

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
@@ -35,6 +35,9 @@ public:
 
     // return true if there is a valid los measurement available
     bool have_los_meas() override;
+    
+    // return target type
+    LANDING_TARGET_TYPE target_type() const override;
 
 private:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
@@ -45,4 +45,10 @@ bool AC_PrecLand_SITL::get_los_body(Vector3f& ret) {
     return true;
 }
 
+// return target type
+LANDING_TARGET_TYPE AC_PrecLand_SITL::target_type() const
+{
+    return LANDING_TARGET_TYPE_VISION_OTHER;
+}
+
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.h
@@ -32,6 +32,9 @@ public:
     // return true if there is a valid los measurement available
     bool have_los_meas() override;
 
+    // return target type
+    LANDING_TARGET_TYPE target_type() const override;
+
 private:
     SITL::SITL          *_sitl;                 // sitl instance pointer
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
@@ -55,4 +55,10 @@ bool AC_PrecLand_SITL_Gazebo::have_los_meas() {
     return _have_los_meas;
 }
 
+// return target type
+LANDING_TARGET_TYPE AC_PrecLand_SITL_Gazebo::target_type() const
+{
+    return LANDING_TARGET_TYPE_VISION_FIDUCIAL;
+}
+
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
@@ -33,6 +33,9 @@ public:
     // return true if there is a valid los measurement available
     bool have_los_meas() override;
 
+    // return target type
+    LANDING_TARGET_TYPE target_type() const override;
+
 private:
     AP_IRLock_SITL_Gazebo irlock;
 

--- a/libraries/AC_PrecLand/LogStructure.h
+++ b/libraries/AC_PrecLand/LogStructure.h
@@ -20,6 +20,7 @@
 // @Field: LastMeasMS: Time when target was last detected
 // @Field: EKFOutl: EKF's outlier count
 // @Field: Est: Type of estimator used
+// @Field: TTy: Landing Target Signaling type according to LANDING_TARGET_TYPE
 
 // precision landing logging
 struct PACKED log_Precland {
@@ -37,8 +38,9 @@ struct PACKED log_Precland {
     uint32_t last_meas;
     uint32_t ekf_outcount;
     uint8_t estimator;
+    uint8_t target_type;
 };
 
 #define LOG_STRUCTURE_FROM_PRECLAND                                     \
     { LOG_PRECLAND_MSG, sizeof(log_Precland),                           \
-      "PL",    "QBBfffffffIIB",    "TimeUS,Heal,TAcq,pX,pY,vX,vY,mX,mY,mZ,LastMeasMS,EKFOutl,Est", "s--mmnnmmms--","F--BBBBBBBC--" },
+      "PL",    "QBBfffffffIIBB",    "TimeUS,Heal,TAcq,pX,pY,vX,vY,mX,mY,mZ,LastMeasMS,EKFOutl,Est,TTy", "s--mmnnmmms---","F--BBBBBBBC---" },


### PR DESCRIPTION
Rework from https://github.com/ArduPilot/ardupilot/pull/9132

add target type to the precland backend. Used only for logging for now. It will be use with https://github.com/ArduPilot/ardupilot/pull/17557 after it is merged