### PR TITLE
RC_Channel: refactor EKF_POS_SOURCE (NFC)

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2980,10 +2980,10 @@ void AP_AHRS::request_yaw_reset(void)
 }
 
 // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
-void AP_AHRS::set_posvelyaw_source_set(uint8_t source_set_idx)
+void AP_AHRS::set_posvelyaw_source_set(AP_NavEKF_Source::SourceSetSelection source_set_idx)
 {
 #if HAL_NAVEKF3_AVAILABLE
-    EKF3.setPosVelYawSourceSet(source_set_idx);
+    EKF3.setPosVelYawSourceSet((uint8_t)source_set_idx);
 #endif
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -356,7 +356,7 @@ public:
     void request_yaw_reset(void);
 
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
-    void set_posvelyaw_source_set(uint8_t source_set_idx);
+    void set_posvelyaw_source_set(AP_NavEKF_Source::SourceSetSelection source_set_idx);
 
     //returns index of active source set used, 0=primary, 1=secondary, 2=tertiary
     uint8_t get_posvelyaw_source_set() const;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -24,6 +24,7 @@
 #include <inttypes.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
+#include <AP_NavEKF/AP_NavEKF_Source.h>
 
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
 #define AP_AHRS_RP_P_MIN   0.05f        // minimum value for AHRS_RP_P parameter
@@ -100,7 +101,7 @@ public:
     virtual void request_yaw_reset(void) {}
 
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
-    virtual void set_posvelyaw_source_set(uint8_t source_set_idx) {}
+    virtual void set_posvelyaw_source_set(AP_NavEKF_Source::SourceSetSelection source_set_idx) {}
 
     // reset the current gyro drift estimate
     //  should be called if gyro offsets are recalculated

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -147,11 +147,11 @@ AP_NavEKF_Source::AP_NavEKF_Source()
 }
 
 // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
-void AP_NavEKF_Source::setPosVelYawSourceSet(uint8_t source_set_idx)
+void AP_NavEKF_Source::setPosVelYawSourceSet(AP_NavEKF_Source::SourceSetSelection source_set_idx)
 {
     // sanity check source idx
-    if (source_set_idx < AP_NAKEKF_SOURCE_SET_MAX) {
-        active_source_set = source_set_idx;
+    if ((uint8_t)source_set_idx < AP_NAKEKF_SOURCE_SET_MAX) {
+        active_source_set = (uint8_t)source_set_idx;
         static const LogEvent evt[AP_NAKEKF_SOURCE_SET_MAX] {
             LogEvent::EK3_SOURCES_SET_TO_PRIMARY,
             LogEvent::EK3_SOURCES_SET_TO_SECONDARY,

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -50,6 +50,12 @@ public:
         FUSE_ALL_VELOCITIES = (1 << 0)  // fuse all velocities configured in source sets
     };
 
+    enum class SourceSetSelection : uint8_t {
+        PRIMARY = 0,
+        SECONDARY = 1,
+        TERTIARY = 2,
+    };
+
     // initialisation
     void init();
 
@@ -58,7 +64,7 @@ public:
     SourceZ getPosZSource() const { return _source_set[active_source_set].posz; }
 
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
-    void setPosVelYawSourceSet(uint8_t source_set_idx);
+    void setPosVelYawSourceSet(SourceSetSelection source_set_idx);
     uint8_t getPosVelYawSourceSet() const { return active_source_set; }
 
     // get/set velocity source

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1102,7 +1102,7 @@ void NavEKF3::setPosVelYawSourceSet(uint8_t source_set_idx)
     if (source_set_idx < AP_NAKEKF_SOURCE_SET_MAX) {
         AP::dal().log_event3(AP_DAL::Event(uint8_t(AP_DAL::Event::setSourceSet0)+source_set_idx));
     }
-    sources.setPosVelYawSourceSet(source_set_idx);
+    sources.setPosVelYawSourceSet((AP_NavEKF_Source::SourceSetSelection)source_set_idx);
 }
 
 // Check basic filter health metrics and return a consolidated health status

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2717,6 +2717,9 @@ function ahrs:get_vel_innovations_and_variances_for_source(source) end
 
 -- desc
 ---@param source_set_idx integer
+---| '0' # PRIMARY
+---| '1' # SECONDARY
+---| '2' # TERTIARY
 function ahrs:set_posvelyaw_source_set(source_set_idx) end
 
 -- desc

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -49,7 +49,7 @@ singleton AP_AHRS method earth_to_body Vector3f Vector3f
 singleton AP_AHRS method body_to_earth Vector3f Vector3f
 singleton AP_AHRS method get_EAS2TAS float
 singleton AP_AHRS method get_variances boolean float'Null float'Null float'Null Vector3f'Null float'Null
-singleton AP_AHRS method set_posvelyaw_source_set void uint8_t 0 2
+singleton AP_AHRS method set_posvelyaw_source_set void AP_NavEKF_Source::SourceSetSelection'enum AP_NavEKF_Source::SourceSetSelection::PRIMARY AP_NavEKF_Source::SourceSetSelection::TERTIARY
 singleton AP_AHRS method get_vel_innovations_and_variances_for_source boolean uint8_t 3 6 Vector3f'Null Vector3f'Null
 singleton AP_AHRS method set_home boolean Location
 singleton AP_AHRS method get_origin boolean Location'Null

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4484,7 +4484,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_set_ekf_source_set(const mavlink_command_
     uint32_t source_set = uint32_t(packet.param1);
     if ((source_set >= 1) && (source_set <= 3)) {
         // mavlink command uses range 1 to 3 while ahrs interface accepts 0 to 2
-        AP::ahrs().set_posvelyaw_source_set(source_set-1);
+        AP::ahrs().set_posvelyaw_source_set((AP_NavEKF_Source::SourceSetSelection)(source_set-1));
         return MAV_RESULT_ACCEPTED;
     }
     return MAV_RESULT_DENIED;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1413,15 +1413,15 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
         switch (ch_flag) {
         case AuxSwitchPos::LOW:
             // low switches to primary source
-            AP::ahrs().set_posvelyaw_source_set(0);
+            AP::ahrs().set_posvelyaw_source_set(AP_NavEKF_Source::SourceSetSelection::PRIMARY);
             break;
         case AuxSwitchPos::MIDDLE:
             // middle switches to secondary source
-            AP::ahrs().set_posvelyaw_source_set(1);
+            AP::ahrs().set_posvelyaw_source_set(AP_NavEKF_Source::SourceSetSelection::SECONDARY);
             break;
         case AuxSwitchPos::HIGH:
             // high switches to tertiary source
-            AP::ahrs().set_posvelyaw_source_set(2);
+            AP::ahrs().set_posvelyaw_source_set(AP_NavEKF_Source::SourceSetSelection::TERTIARY);
             break;
         }
         break;


### PR DESCRIPTION
I refactored the following Aux switch.
- AUX_FUNC::EKF_POS_SOURCE
 defined enum in AP_NavEKF_Source.h and used it instead of number

I have confirmed that the function is called with the intended value when switching the position in SITL.