### PR TITLE
Ensure UAVCAN BeepCommands are not disabled when ALARM pin is undefined

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -477,7 +477,7 @@ static void handle_beep_command(CanardInstance* ins, CanardRxTransfer* transfer)
     if (!initialised) {
         initialised = true;
         hal.rcout->init();
-        hal.util->toneAlarm_init(AP_HAL::Util::ALARM_BUZZER);
+        hal.util->toneAlarm_init(AP_Notify::Notify_Buzz_Builtin);
     }
     fix_float16(req.frequency);
     fix_float16(req.duration);

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -125,15 +125,6 @@ public:
      */
     virtual void commandline_arguments(uint8_t &argc, char * const *&argv) { argc = 0; }
 
-    /*
-        ToneAlarm Driver
-    */
-    enum ToneAlarmType {
-        ALARM_NONE=0,
-        ALARM_BUZZER=1<<0,
-        ALARM_DSHOT=1<<1
-    };
-
     virtual bool toneAlarm_init(uint8_t types) { return false;}
     virtual void toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms) {}
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -29,7 +29,9 @@
 #include "sdcard.h"
 #include "shared_dma.h"
 #include <AP_Common/ExpandingString.h>
-
+#if defined(HAL_PWM_ALARM) || HAL_DSHOT_ALARM || HAL_ENABLE_LIBUAVCAN_DRIVERS
+#include <AP_Notify/AP_Notify.h>
+#endif
 #if HAL_ENABLE_SAVE_PERSISTENT_PARAMS
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #endif
@@ -155,7 +157,6 @@ Util::safety_state Util::safety_switch_state(void)
 struct Util::ToneAlarmPwmGroup Util::_toneAlarm_pwm_group = HAL_PWM_ALARM;
 #endif
 
-#if defined(HAL_PWM_ALARM) || HAL_DSHOT_ALARM
 uint8_t  Util::_toneAlarm_types = 0;
 
 bool Util::toneAlarm_init(uint8_t types)
@@ -165,7 +166,13 @@ bool Util::toneAlarm_init(uint8_t types)
     pwmStart(_toneAlarm_pwm_group.pwm_drv, &_toneAlarm_pwm_group.pwm_cfg);
 #endif
     _toneAlarm_types = types;
+
+#if !defined(HAL_PWM_ALARM) && !HAL_DSHOT_ALARM && !HAL_ENABLE_LIBUAVCAN_DRIVERS
+    // Nothing to do
+    return false;
+#else
     return true;
+#endif
 }
 
 void Util::toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms)
@@ -182,7 +189,7 @@ void Util::toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t dur
 #endif // HAL_PWM_ALARM
 #if HAL_DSHOT_ALARM
     // don't play the motors while flying
-    if (!(_toneAlarm_types & ALARM_DSHOT) || get_soft_armed() || hal.rcout->get_dshot_esc_type() != RCOutput::DSHOT_ESC_BLHELI) {
+    if (!(_toneAlarm_types & AP_Notify::Notify_Buzz_DShot) || get_soft_armed() || hal.rcout->get_dshot_esc_type() != RCOutput::DSHOT_ESC_BLHELI) {
         return;
     }
 
@@ -201,7 +208,6 @@ void Util::toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t dur
     }
 #endif // HAL_DSHOT_ALARM
 }
-#endif
 
 /*
   set HW RTC in UTC microseconds

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -59,11 +59,9 @@ public:
     bool get_system_id(char buf[40]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
 
-#if defined(HAL_PWM_ALARM) || HAL_DSHOT_ALARM
     bool toneAlarm_init(uint8_t types) override;
     void toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms) override;
     static uint8_t _toneAlarm_types;
-#endif
 
     // return true if the reason for the reboot was a watchdog reset
     bool was_watchdog_reset() const override;

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -94,12 +94,17 @@ AP_Notify *AP_Notify::_singleton;
 #endif // BUILD_DEFAULT_LED_TYPE
 
 #ifndef BUZZER_ENABLE_DEFAULT
-#define BUZZER_ENABLE_DEFAULT 1
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+// Enable Buzzer messages over UAVCAN
+#define BUZZER_ENABLE_DEFAULT (Notify_Buzz_Builtin | Notify_Buzz_UAVCAN)
+#else
+#define BUZZER_ENABLE_DEFAULT Notify_Buzz_Builtin
+#endif
 #endif
 
 #ifndef BUILD_DEFAULT_BUZZER_TYPE
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS && HAL_DSHOT_ALARM
-  #define BUILD_DEFAULT_BUZZER_TYPE (BUZZER_ENABLE_DEFAULT | (HAL_DSHOT_ALARM << 1))
+  #define BUILD_DEFAULT_BUZZER_TYPE (BUZZER_ENABLE_DEFAULT | Notify_Buzz_DShot)
 #else
   #define BUILD_DEFAULT_BUZZER_TYPE BUZZER_ENABLE_DEFAULT
 #endif
@@ -134,7 +139,7 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Param: BUZZ_TYPES
     // @DisplayName: Buzzer Driver Types
     // @Description: Controls what types of Buzzer will be enabled
-    // @Bitmask: 0:Built-in buzzer, 1:DShot
+    // @Bitmask: 0:Built-in buzzer, 1:DShot, 2:UAVCAN
     // @User: Advanced
     AP_GROUPINFO("BUZZ_TYPES", 1, AP_Notify, _buzzer_type, BUILD_DEFAULT_BUZZER_TYPE),
 

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -76,6 +76,13 @@ public:
         Notify_LED_MAX
     };
 
+    enum Notify_Buzz_Type {
+        Notify_Buzz_None                    = 0,
+        Notify_Buzz_Builtin                 = (1 << 0), // Built in default Alarm Out
+        Notify_Buzz_DShot                   = (1 << 1), // DShot Alarm
+        Notify_Buzz_UAVCAN                  = (1 << 2), // UAVCAN Alarm
+    };
+
     /// notify_flags_type - bitmask of notification flags
     struct notify_flags_and_values_type {
         bool initialising;        // true if initialising and the vehicle should not be moved

--- a/libraries/AP_Notify/MMLPlayer.cpp
+++ b/libraries/AP_Notify/MMLPlayer.cpp
@@ -70,7 +70,8 @@ void MMLPlayer::start_note(float duration, float frequency, float volume)
 
     for (uint8_t i = 0; i < can_num_drivers; i++) {
         AP_UAVCAN *uavcan = AP_UAVCAN::get_uavcan(i);
-        if (uavcan != nullptr) {
+        if (uavcan != nullptr &&
+            (AP::notify().get_buzzer_types() & AP_Notify::Notify_Buzz_UAVCAN)) {
             uavcan->set_buzzer_tone(frequency, _note_duration_us*1.0e-6);
         }
     }

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -105,9 +105,14 @@ bool AP_ToneAlarm::init()
     if (pNotify->buzzer_enabled() == false) {
         return false;
     }
+#if ((defined(HAL_PWM_ALARM) || HAL_DSHOT_ALARM) && CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS) || \
+    CONFIG_HAL_BOARD == HAL_BOARD_LINUX || \
+    CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (!hal.util->toneAlarm_init(pNotify->get_buzzer_types())) {
         return false;
     }
+#endif
+
 
     // set initial boot states. This prevents us issuing a arming
     // warning in plane and rover on every boot


### PR DESCRIPTION
Tested on CubeOrange with ALARM pin disabled. Also checked normal operation functional. Fixes issue https://github.com/ArduPilot/ardupilot/issues/17296