### PR TITLE
Correct metadata that has BOTH range and value entries

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -477,8 +477,7 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Param: ACRO_RP_EXPO
     // @DisplayName: Acro Roll/Pitch Expo
-    // @Description: Acro roll/pitch Expo to allow faster rotation when stick at edges
-    // @Values: 0:Disabled,0.1:Very Low,0.2:Low,0.3:Medium,0.4:High,0.5:Very High
+    // @Description: Acro roll/pitch Expo to allow faster rotation when stick at edges. 0: disables, 0.1: Very Low, 1.0: Maximum positive, -0.5: Maximum negative
     // @Range: -0.5 1.0
     // @User: Advanced
     GSCALAR(acro_rp_expo,  "ACRO_RP_EXPO",    ACRO_RP_EXPO_DEFAULT),
@@ -833,8 +832,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: ACRO_Y_EXPO
     // @DisplayName: Acro Yaw Expo
-    // @Description: Acro yaw expo to allow faster rotation when stick at edges
-    // @Values: 0:Disabled,0.1:Very Low,0.2:Low,0.3:Medium,0.4:High,0.5:Very High
+    // @Description: Acro yaw expo to allow faster rotation when stick at edges.0: disables, 0.1: Very Low, 1.0: Maximum positive, -0.5: Maximum negative
     // @Range: -0.5 1.0
     // @User: Advanced
     AP_GROUPINFO("ACRO_Y_EXPO", 9, ParametersG2, acro_y_expo, ACRO_Y_EXPO_DEFAULT),

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -72,7 +72,6 @@ const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
     // @Param: MODE
     // @DisplayName: Harmonic Notch Filter dynamic frequency tracking mode
     // @Description: Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor, ESC telemetry or dynamic FFT based. Throttle-based updates should only be used with multicopters.
-    // @Range: 0 4
     // @Values: 0:Disabled,1:Throttle,2:RPM Sensor,3:ESC Telemetry,4:Dynamic FFT
     // @User: Advanced
     AP_GROUPINFO("MODE", 7, HarmonicNotchFilterParams, _tracking_mode, 1),


### PR DESCRIPTION
having both screws up the GSC displays since it only expects one or the other to display....otherwise it concatenates both....have only checked Copter/Heli....will check other vehicles when time permits...