### PR TITLE
AC_Avoid: Fix simple avoidance stopping mode bug

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -81,13 +81,13 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("BACKUP_SPD", 6, AC_Avoid, _backup_speed_max, 0.75f),
 
-    // @Param: ALT_MIN
+    // @Param{Copter}: ALT_MIN
     // @DisplayName: Avoidance minimum altitude
     // @Description: Minimum altitude above which proximity based avoidance will start working. This requires a valid downward facing rangefinder reading to work. Set zero to disable
     // @Units: m
     // @Range: 0 6
     // @User: Standard
-    AP_GROUPINFO("ALT_MIN", 7, AC_Avoid, _alt_min, 0.0f),
+    AP_GROUPINFO_FRAME("ALT_MIN", 7, AC_Avoid, _alt_min, 0.0f, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_TRICOPTER),
 
     // @Param: ACCEL_MAX
     // @DisplayName: Avoidance maximum acceleration

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -19,7 +19,6 @@
 #define AC_AVOID_ANGLE_MAX_PERCENT          0.75f   // object avoidance max lean angle as a percentage (expressed in 0 ~ 1 range) of total vehicle max lean angle
 
 #define AC_AVOID_ACTIVE_LIMIT_TIMEOUT_MS    500     // if limiting is active if last limit is happend in the last x ms
-#define AC_AVOID_MIN_BACKUP_BREACH_DIST     10.0f   // vehicle will backaway if breach is greater than this distance in cm
 #define AC_AVOID_ACCEL_TIMEOUT_MS           200     // stored velocity used to calculate acceleration will be reset if avoidance is active after this many ms
 
 /*
@@ -216,6 +215,7 @@ private:
     AP_Float _backup_speed_max; // Maximum speed that will be used to back away (in m/s)
     AP_Float _alt_min;          // alt below which Proximity based avoidance is turned off
     AP_Float _accel_max;        // maximum accelration while simple avoidance is active
+    AP_Float _backup_deadzone;  // distance beyond AVOID_MARGIN parameter, after which vehicle will backaway from obstacles
 
     bool _proximity_enabled = true; // true if proximity sensor based avoidance is enabled (used to allow pilot to enable/disable)
     bool _proximity_alt_enabled = true; // true if proximity sensor based avoidance is enabled based on altitude

--- a/libraries/AP_Math/tests/test_3d_lines.cpp
+++ b/libraries/AP_Math/tests/test_3d_lines.cpp
@@ -14,7 +14,7 @@
 
 
 TEST(Lines3dTests, ClosestDistBetweenLinePoint)
-{   
+{
     // check if the 2-d and 3-d variant of this method is same if the third-dimension is zero
     float dist_3d = Vector3f::closest_distance_between_line_and_point(Vector3f{0.0f, 1.0f, 0.0f}, Vector3f{0.0f, 10.0f, 0.0f}, Vector3f{6.0f, 5.0f, 0.0f});
     float dist_2d = Vector2f::closest_distance_between_line_and_point(Vector2f{0.0f, 1.0f}, Vector2f{0.0f, 10.0f}, Vector2f{6.0f, 5.0f});
@@ -25,20 +25,18 @@ TEST(Lines3dTests, ClosestDistBetweenLinePoint)
     EXPECT_VECTOR3F_EQ((Vector3f{0.0f, 5.0f, 5.0f}), intersection);
 }
 
-TEST(Lines3dTests, SegmentToSegmentDistance)
-{   
+TEST(Lines3dTests, SegmentToSegmentCloestPoint)
+{
     // random segments test
     Vector3f intersection;
-    float dist = Vector3f::segment_to_segment_dist(Vector3f{-10.0f,0.0f,0.0f}, Vector3f{10.0f,0.0f,0.0f}, Vector3f{0.0f, -5.0f, 1.0}, Vector3f{0.0f, 5.0f, 1.0f}, intersection);
-    EXPECT_FLOAT_EQ(dist, 1.0f);
+    Vector3f::segment_to_segment_closest_point(Vector3f{-10.0f,0.0f,0.0f}, Vector3f{10.0f,0.0f,0.0f}, Vector3f{0.0f, -5.0f, 1.0}, Vector3f{0.0f, 5.0f, 1.0f}, intersection);
     EXPECT_VECTOR3F_EQ(intersection, (Vector3f{0.0f, 0.0f, 1.0f}));
 
     // check for intersecting segments. Verify with the 2-d variant
-    dist = Vector3f::segment_to_segment_dist(Vector3f{}, Vector3f{10.0f,10.0f,0.0f}, Vector3f{2.0f, -10.0f, 0.0}, Vector3f{3.0f, 10.0f, 0.0f}, intersection);
+    Vector3f::segment_to_segment_closest_point(Vector3f{}, Vector3f{10.0f,10.0f,0.0f}, Vector3f{2.0f, -10.0f, 0.0}, Vector3f{3.0f, 10.0f, 0.0f}, intersection);
     Vector2f intersection_2d;
     const bool result = Vector2f::segment_intersection(Vector2f{}, Vector2f{10.0f,10.0}, Vector2f{2.0f, -10.0f}, Vector2f{3.0f, 10.0f}, intersection_2d);
-    EXPECT_EQ(true, result); 
-    EXPECT_FLOAT_EQ(dist, 0.0f);
+    EXPECT_EQ(true, result);
     EXPECT_VECTOR3F_EQ(intersection, (Vector3f(intersection_2d.x, intersection_2d.y, 0.0f)));
 }
 

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -512,12 +512,12 @@ Vector3<T> Vector3<T>::point_on_line_closest_to_other_point(const Vector3<T> &w1
     return (closest_point + w1);
 }
 
-// Shortest distance between two line segments
+// Closest point between two line segments
 // This implementation is borrowed from: http://geomalgorithms.com/a07-_distance.html
 // INPUT: 4 points corresponding to start and end of two line segments
-// OUTPUT: shortest distance, and closest point on segment 2, from segment 1, gets passed on reference as "intersection" 
+// OUTPUT: closest point on segment 2, from segment 1, gets passed on reference as "closest_point"
 template <typename T>
-float Vector3<T>::segment_to_segment_dist(const Vector3<T>& seg1_start, const Vector3<T>& seg1_end, const Vector3<T>& seg2_start, const Vector3<T>& seg2_end, Vector3<T>& intersection)
+void Vector3<T>::segment_to_segment_closest_point(const Vector3<T>& seg1_start, const Vector3<T>& seg1_end, const Vector3<T>& seg2_start, const Vector3<T>& seg2_end, Vector3<T>& closest_point)
 {
     // direction vectors
     const Vector3<T> line1 = seg1_end - seg1_start;
@@ -532,24 +532,24 @@ float Vector3<T>::segment_to_segment_dist(const Vector3<T>& seg1_start, const Ve
     const float e = line2*diff;
 
     const float discriminant = (a*c) - (b*b);
-    float sc, sN, sD = discriminant;       // sc = sN / sD, default sD = D >= 0
+    float sN, sD = discriminant;           // default sD = D >= 0
     float tc, tN, tD = discriminant;       // tc = tN / tD, default tD = D >= 0 
-    
+
     if (discriminant < FLT_EPSILON) {
         sN = 0.0;         // force using point seg1_start on line 1
         sD = 1.0;         // to prevent possible division by 0.0 later
         tN = e;
         tD = c;
-    } else {                 
+    } else {
         // get the closest points on the infinite lines
         sN = (b*e - c*d);
         tN = (a*e - b*d);
-        if (sN < 0.0) {        
+        if (sN < 0.0) {
             // sc < 0 => the s=0 edge is visible
             sN = 0.0;
             tN = e;
             tD = c;
-        } else if (sN > sD) {  
+        } else if (sN > sD) {
             // sc > 1  => the s=1 edge is visible
             sN = sD;
             tN = e + b;
@@ -557,7 +557,7 @@ float Vector3<T>::segment_to_segment_dist(const Vector3<T>& seg1_start, const Ve
         }
     }
 
-    if (tN < 0.0) {            
+    if (tN < 0.0) {
         // tc < 0 => the t=0 edge is visible
         tN = 0.0;
         // recompute sc for this edge
@@ -569,7 +569,7 @@ float Vector3<T>::segment_to_segment_dist(const Vector3<T>& seg1_start, const Ve
             sN = -d;
             sD = a;
         }
-    } else if (tN > tD) {      
+    } else if (tN > tD) {
         // tc > 1  => the t=1 edge is visible
         tN = tD;
         // recompute sc for this edge
@@ -582,14 +582,39 @@ float Vector3<T>::segment_to_segment_dist(const Vector3<T>& seg1_start, const Ve
             sD = a;
         }
     }
-    // finally do the division to get sc and tc
-    sc = (fabsf(sN) < FLT_EPSILON ? 0.0 : sN / sD);
+    // finally do the division to get tc
     tc = (fabsf(tN) < FLT_EPSILON ? 0.0 : tN / tD);
 
-    const Vector3<T> closest_line_segment = diff + (line1*sc) - (line2*tc);
-    const float len = closest_line_segment.length();
-    intersection = seg2_start + line2*tc;
-    return len;
+    // closest point on seg2
+    closest_point = seg2_start + line2*tc;
+}
+
+// Returns true if the passed 3D segment passes through a plane defined by plane normal, and a point on the plane
+template <typename T>
+bool Vector3<T>::segment_plane_intersect(const Vector3<T>& seg_start, const Vector3<T>& seg_end, const Vector3<T>& plane_normal, const Vector3<T>& plane_point)
+{
+    Vector3<T> u = seg_end - seg_start;
+    Vector3<T> w = seg_start - plane_point;
+
+    float D = plane_normal * u;
+    float N = -(plane_normal * w);
+
+    if (fabsf(D) < FLT_EPSILON) {
+        if (::is_zero(N)) {
+            // segment lies in this plane
+            return true;
+        } else {
+            // does not intersect
+            return false;
+        }
+    }
+    const float sI = N / D;
+    if (sI < 0 || sI > 1) {
+        // does not intersect
+        return false;
+    }
+    // intersects at unique point
+    return true;
 }
 
 // define for float and double

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -277,8 +277,11 @@ public:
 
     // This implementation is borrowed from: http://geomalgorithms.com/a07-_distance.html
     // INPUT: 4 points corresponding to start and end of two line segments
-    // OUTPUT: shortest distance between segments, and closest point on segment 2, from segment 1, gets passed on reference as "intersection" 
-    static float segment_to_segment_dist(const Vector3<T>& seg1_start, const Vector3<T>& seg1_end, const Vector3<T>& seg2_start, const Vector3<T>& seg2_end, Vector3<T>& intersection) WARN_IF_UNUSED;
+    // OUTPUT: closest point on segment 2, from segment 1, gets passed on reference as "closest_point"
+    static void segment_to_segment_closest_point(const Vector3<T>& seg1_start, const Vector3<T>& seg1_end, const Vector3<T>& seg2_start, const Vector3<T>& seg2_end, Vector3<T>& closest_point);
+
+    // Returns true if the passed 3D segment passes through a plane defined by plane normal, and a point on the plane
+    static bool segment_plane_intersect(const Vector3<T>& seg_start, const Vector3<T>& seg_end, const Vector3<T>& plane_normal, const Vector3<T>& plane_point);
 };
 
 typedef Vector3<int16_t>                Vector3i;

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -398,12 +398,12 @@ bool AP_Proximity::get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle)
 
 // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
 // used in GPS based Simple Avoidance
-float AP_Proximity::distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const
+bool AP_Proximity::closest_point_from_segment_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const
 {
     if (!valid_instance(primary_instance)) {
-        return FLT_MAX;
+        return false;
     }
-    return drivers[primary_instance]->distance_to_obstacle(obstacle_num, seg_start, seg_end, closest_point);
+    return drivers[primary_instance]->closest_point_from_segment_to_obstacle(obstacle_num, seg_start, seg_end, closest_point);
 }
 
 // get distance and angle to closest object (used for pre-arm check)

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -114,7 +114,7 @@ public:
     
     // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
     // returns FLT_MAX if it's an invalid instance.
-    float distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;
+    bool closest_point_from_segment_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;
 
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -60,7 +60,7 @@ public:
     
     // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
     // used in GPS based Simple Avoidance
-    float distance_to_obstacle(const uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const { return boundary.distance_to_obstacle(obstacle_num , seg_start, seg_end, closest_point); } 
+    bool closest_point_from_segment_to_obstacle(const uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const { return boundary.closest_point_from_segment_to_obstacle(obstacle_num , seg_start, seg_end, closest_point); }
 
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings

--- a/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
+++ b/libraries/AP_Proximity/AP_Proximity_Boundary_3D.h
@@ -97,8 +97,8 @@ public:
     bool get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_boundary) const;
 
     // Returns a body frame vector (in cm) nearest to obstacle, in betwen seg_start and seg_end
-    // FLT_MAX is returned if the obstacle_num provided does not produce a valid obstacle
-    float distance_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;
+    // True is returned if the segment intersects a plane formed by considering the "closest point" as normal vector to the plane.
+    bool closest_point_from_segment_to_obstacle(uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const;
 
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings


### PR DESCRIPTION
This fixes a bug I introduced with the 3D conversion of Simple Avoidance. We need to check if the stopping point intersects the boundary before "stopping" the vehicle. Currently, in master it just stops the vehicle if it is anywhere near the boundary margin, which would mean even if the person is backing away manually from an obstacle, it won't let you do that and keep "stopping",