### PR TITLE
AP_HAL_SITL: Return zero when using the help command

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -457,6 +457,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             printf("Setting SYSID_THISMAV=%d\n", sysid);
             break;
         }
+        case 'h':
+            _usage();
+            exit(0);
         default:
             _usage();
             exit(1);


### PR DESCRIPTION
Returning an error code while running the help command is not a good practice. 