### PR TITLE
Copter: these two errors are too common to be called "emergency"

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -14,7 +14,6 @@
 
 // Yaw imbalance check
 #define YAW_IMBALANCE_IMAX_THRESHOLD 0.75f
-#define YAW_IMBALANCE_I_THERSHOLD 0.1f
 #define YAW_IMBALANCE_WARN_MS 10000
 
 // crash_check - disarms motors if a crash has been detected
@@ -209,8 +208,7 @@ void Copter::yaw_imbalance_check()
     }
 
     const float I_max = attitude_control->get_rate_yaw_pid().imax();
-    if ((is_positive(I_max) && ((I > YAW_IMBALANCE_IMAX_THRESHOLD * I_max) || (is_equal(I_term,I_max)))) ||
-        (I >YAW_IMBALANCE_I_THERSHOLD)) {
+    if ((is_positive(I_max) && ((I > YAW_IMBALANCE_IMAX_THRESHOLD * I_max) || (is_equal(I_term,I_max))))) {
         // filtered using over precentage of I max or unfiltered = I max
         // I makes up more than precentage of total available control power
         const uint32_t now = millis();


### PR DESCRIPTION
using emergency leads to panic messages in the GCS
![image](https://user-images.githubusercontent.com/831867/119735899-58ef2d00-bec0-11eb-86e5-bbc4093eaec8.png)
