### PR TITLE
Fix ground effect compensation

### DIFF
--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -6,8 +6,8 @@ void Copter::update_ground_effect_detector(void)
         // disarmed - disable ground effect and return
         gndeffect_state.takeoff_expected = false;
         gndeffect_state.touchdown_expected = false;
-        ahrs.setTakeoffExpected(gndeffect_state.takeoff_expected);
-        ahrs.setTouchdownExpected(gndeffect_state.touchdown_expected);
+        ahrs.set_takeoff_expected(gndeffect_state.takeoff_expected);
+        ahrs.set_touchdown_expected(gndeffect_state.touchdown_expected);
         return;
     }
 
@@ -64,8 +64,8 @@ void Copter::update_ground_effect_detector(void)
     gndeffect_state.touchdown_expected = slow_horizontal && slow_descent;
 
     // Prepare the EKF for ground effect if either takeoff or touchdown is expected.
-    ahrs.setTakeoffExpected(gndeffect_state.takeoff_expected);
-    ahrs.setTouchdownExpected(gndeffect_state.touchdown_expected);
+    ahrs.set_takeoff_expected(gndeffect_state.takeoff_expected);
+    ahrs.set_touchdown_expected(gndeffect_state.touchdown_expected);
 }
 
 // update ekf terrain height stable setting

--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -31,8 +31,11 @@ void Copter::update_ground_effect_detector(void)
 
     // takeoff logic
 
-    // if we are armed and haven't yet taken off
-    if (motors->armed() && ap.land_complete && !gndeffect_state.takeoff_expected) {
+    if (flightmode->mode_number() == Mode::Number::THROW) {
+        // throw mode never wants the takeoff expected EKF code
+        gndeffect_state.takeoff_expected = false;
+    } else if (motors->armed() && ap.land_complete) {
+        // if we are armed and haven't yet taken off then we expect an imminent takeoff
         gndeffect_state.takeoff_expected = true;
     }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1536,7 +1536,7 @@ void QuadPlane::control_loiter()
         float descent_rate_cms = landing_descent_rate_cms(height_above_ground);
 
         if (poscontrol.state == QPOS_LAND_FINAL && (options & OPTION_DISABLE_GROUND_EFFECT_COMP) == 0) {
-            ahrs.setTouchdownExpected(true);
+            ahrs.set_touchdown_expected(true);
         }
 
         set_climb_rate_cms(-descent_rate_cms, descent_rate_cms>0);
@@ -2774,7 +2774,7 @@ void QuadPlane::vtol_position_controller(void)
         float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
         if (poscontrol.state == QPOS_LAND_FINAL) {
             if ((options & OPTION_DISABLE_GROUND_EFFECT_COMP) == 0) {
-                ahrs.setTouchdownExpected(true);
+                ahrs.set_touchdown_expected(true);
             }
         }
         const float descent_rate_cms = landing_descent_rate_cms(height_above_ground);
@@ -3066,7 +3066,7 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
 
     if (now - takeoff_start_time_ms < 3000 &&
         (options & OPTION_DISABLE_GROUND_EFFECT_COMP) == 0) {
-        ahrs.setTakeoffExpected(true);
+        ahrs.set_takeoff_expected(true);
     }
     
     // check for failure conditions
@@ -3536,7 +3536,7 @@ bool QuadPlane::do_user_takeoff(float takeoff_altitude)
     guided_start();
     guided_takeoff = true;
     if ((options & OPTION_DISABLE_GROUND_EFFECT_COMP) == 0) {
-        ahrs.setTakeoffExpected(true);
+        ahrs.set_takeoff_expected(true);
     }
     return true;
 }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -561,7 +561,7 @@ void Plane::set_servos_controlled(void)
 
     // let EKF know to start GSF yaw estimator before takeoff movement starts so that yaw angle is better estimated
     const float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
-    if (arming.is_armed()) {
+    if (!is_flying() && arming.is_armed()) {
         // Check if rate of change of velocity along X axis exceeds 1-g which normally indicates a throw.
         // Tests with hand carriage of micro UAS indicates that a 1-g threshold does not false trigger prior
         // to the throw, but there is margin to increase this threshold if false triggering becomes problematic.

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -570,7 +570,7 @@ void Plane::set_servos_controlled(void)
         bool throw_detected = accel_x_due_to_throw > GRAVITY_MSS;
         bool throttle_up_detected = throttle > aparm.throttle_cruise;
         if (throw_detected || throttle_up_detected) {
-            plane.ahrs.setTakeoffExpected(true);
+            plane.ahrs.set_takeoff_expected(true);
         }
     }
 }

--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -59,18 +59,6 @@ void LR_MsgHandler_REV2::process_message(uint8_t *msgbytes)
     case AP_DAL::Event::resetHeightDatum:
         ekf2.resetHeightDatum();
         break;
-    case AP_DAL::Event::setTakeoffExpected:
-        ekf2.setTakeoffExpected(true);
-        break;
-    case AP_DAL::Event::unsetTakeoffExpected:
-        ekf2.setTakeoffExpected(false);
-        break;
-    case AP_DAL::Event::setTouchdownExpected:
-        ekf2.setTouchdownExpected(true);
-        break;
-    case AP_DAL::Event::unsetTouchdownExpected:
-        ekf2.setTouchdownExpected(false);
-        break;
     case AP_DAL::Event::setTerrainHgtStable:
         ekf2.setTerrainHgtStable(true);
         break;
@@ -127,18 +115,6 @@ void LR_MsgHandler_REV3::process_message(uint8_t *msgbytes)
         break;
     case AP_DAL::Event::resetHeightDatum:
         ekf3.resetHeightDatum();
-        break;
-    case AP_DAL::Event::setTakeoffExpected:
-        ekf3.setTakeoffExpected(true);
-        break;
-    case AP_DAL::Event::unsetTakeoffExpected:
-        ekf3.setTakeoffExpected(false);
-        break;
-    case AP_DAL::Event::setTouchdownExpected:
-        ekf3.setTouchdownExpected(true);
-        break;
-    case AP_DAL::Event::unsetTouchdownExpected:
-        ekf3.setTouchdownExpected(false);
         break;
     case AP_DAL::Event::setTerrainHgtStable:
         ekf3.setTerrainHgtStable(true);

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6662,6 +6662,101 @@ class AutoTestCopter(AutoTest):
         if ex is not None:
             raise ex
 
+    def get_ground_effect_duration_from_current_onboard_log(self, bit, ignore_multi=False):
+        '''returns a duration in seconds we were expecting to interact with
+        the ground.  Will die if there's more than one such block of
+        time and ignore_multi is not set (will return first duration
+        otherwise)
+        '''
+        ret = []
+        dfreader = self.dfreader_for_current_onboard_log()
+        seen_expected_start_TimeUS = None
+        first = None
+        last = None
+        while True:
+            m = dfreader.recv_match(type="XKF4")
+            if m is None:
+                break
+            last = m
+            if first is None:
+                first = m
+            # self.progress("%s" % str(m))
+            expected = m.SS & (1 << bit)
+            if expected:
+                if seen_expected_start_TimeUS is None:
+                    seen_expected_start_TimeUS = m.TimeUS
+                    continue
+            else:
+                if seen_expected_start_TimeUS is not None:
+                    duration = (m.TimeUS - seen_expected_start_TimeUS)/1000000.0
+                    ret.append(duration)
+                    seen_expected_start_TimeUS = None
+        if seen_expected_start_TimeUS is not None:
+            duration = (last.TimeUS - seen_expected_start_TimeUS)/1000000.0
+            ret.append(duration)
+        return ret
+
+    def get_takeoffexpected_durations_from_current_onboard_log(self, ignore_multi=False):
+        return self.get_ground_effect_duration_from_current_onboard_log(11, ignore_multi=ignore_multi)
+
+    def get_touchdownexpected_durations_from_current_onboard_log(self, ignore_multi=False):
+        return self.get_ground_effect_duration_from_current_onboard_log(12, ignore_multi=ignore_multi)
+
+    def GroundEffectCompensation_takeOffExpected(self):
+        self.change_mode('ALT_HOLD')
+        self.set_parameter("LOG_FILE_DSRMROT", 1)
+        self.progress("Making sure we'll have a short log to look at")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.disarm_vehicle()
+
+        # arm the vehicle and let it disarm normally.  This should
+        # yield a log where the EKF considers a takeoff imminent until
+        # disarm
+        self.start_subtest("Check ground effect compensation remains set in EKF while we're at idle on the ground")
+        self.arm_vehicle()
+        self.wait_disarmed()
+
+        durations = self.get_takeoffexpected_durations_from_current_onboard_log()
+        duration = durations[0]
+        want = 9
+        self.progress("takeoff-expected duration: %fs" % (duration,))
+        if duration < want:  # assumes default 10-second DISARM_DELAY
+            raise NotAchievedException("Should have been expecting takeoff for longer than %fs (want>%f)" %
+                                       (duration, want))
+
+        self.start_subtest("takeoffExpected should be false very soon after we launch into the air")
+        self.takeoff(mode='ALT_HOLD', alt_min=5)
+        self.change_mode('LAND')
+        self.wait_disarmed()
+        durations = self.get_takeoffexpected_durations_from_current_onboard_log(ignore_multi=True)
+        duration = durations[0]
+        self.progress("takeoff-expected-duration %f" % (duration,))
+        want_lt = 5
+        if duration >= want_lt:
+            raise NotAchievedException("Was expecting takeoff for longer than expected; got=%f want<=%f" %
+                                       (duration, want_lt))
+
+    def GroundEffectCompensation_touchDownExpected(self):
+        self.zero_throttle()
+        self.change_mode('ALT_HOLD')
+        self.set_parameter("LOG_FILE_DSRMROT", 1)
+        self.progress("Making sure we'll have a short log to look at")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.disarm_vehicle()
+
+        self.start_subtest("Make sure touchdown-expected duration is about right")
+        self.takeoff(20, mode='ALT_HOLD')
+        self.change_mode('LAND')
+        self.wait_disarmed()
+
+        gots = self.get_touchdownexpected_durations_from_current_onboard_log(ignore_multi=True)
+        got = gots[2]
+        expected = 23  # this is the time in the final descent phase of LAND
+        if abs(got - expected) > 5:
+            raise NotAchievedException("Was expecting roughly %fs of touchdown expected, got %f" % (expected, got))
+
     # a wrapper around all the 1A,1B,1C..etc tests for travis
     def tests1(self):
         ret = ([])
@@ -7098,6 +7193,14 @@ class AutoTestCopter(AutoTest):
             Test("Replay",
                  "Test Replay",
                  self.test_replay),
+
+            Test("GroundEffectCompensation_touchDownExpected",
+                 "Test EKF's handling of touchdown-expected",
+                 self.GroundEffectCompensation_touchDownExpected),
+
+            Test("GroundEffectCompensation_takeOffExpected",
+                 "Test EKF's handling of takeoff-expected",
+                 self.GroundEffectCompensation_takeOffExpected),
 
             Test("LogUpload",
                  "Log upload",

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -508,6 +508,32 @@ Vector3f AP_AHRS::get_vibration(void) const
     return AP::ins().get_vibration_levels();
 }
 
+void AP_AHRS::set_takeoff_expected(bool b)
+{
+    _flags.takeoff_expected = b;
+    takeoff_expected_start_ms = AP_HAL::millis();
+}
+
+void AP_AHRS::set_touchdown_expected(bool b)
+{
+    _flags.touchdown_expected = b;
+    touchdown_expected_start_ms = AP_HAL::millis();
+}
+
+/*
+  update takeoff/touchdown flags
+ */
+void AP_AHRS::update_flags(void)
+{
+    const uint32_t timeout_ms = 1000;
+    if (_flags.takeoff_expected && AP_HAL::millis() - takeoff_expected_start_ms > timeout_ms) {
+        _flags.takeoff_expected = false;
+    }
+    if (_flags.touchdown_expected && AP_HAL::millis() - touchdown_expected_start_ms > timeout_ms) {
+        _flags.touchdown_expected = false;
+    }
+}
+
 // singleton instance
 AP_AHRS *AP_AHRS::_singleton;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -95,6 +95,18 @@ public:
         return _flags.fly_forward;
     }
 
+    void set_takeoff_expected(bool b);
+
+    bool get_takeoff_expected(void) const {
+        return _flags.takeoff_expected;
+    }
+
+    void set_touchdown_expected(bool b);
+
+    bool get_touchdown_expected(void) const {
+        return _flags.touchdown_expected;
+    }
+
     AHRS_VehicleClass get_vehicle_class(void) const {
         return _vehicle_class;
     }
@@ -640,6 +652,8 @@ protected:
         uint8_t fly_forward             : 1;    // 1 if we can assume the aircraft will be flying forward on its X axis
         uint8_t correct_centrifugal     : 1;    // 1 if we should correct for centrifugal forces (allows arducopter to turn this off when motors are disarmed)
         uint8_t wind_estimation         : 1;    // 1 if we should do wind estimation
+        uint8_t takeoff_expected        : 1;    // 1 if the vehicle is in a state that takeoff might be expected.  Ground effect may be in play.
+        uint8_t touchdown_expected      : 1;    // 1 if the vehicle is in a state that touchdown might be expected.  Ground effect may be in play.
     } _flags;
 
     // calculate sin/cos of roll/pitch/yaw from rotation
@@ -653,6 +667,9 @@ protected:
 
     // update roll_sensor, pitch_sensor and yaw_sensor
     void update_cd_values(void);
+
+    // update takeoff/touchdown flags
+    void update_flags();
 
     // pointer to compass object, if available
     Compass         * _compass;
@@ -707,6 +724,9 @@ private:
     static AP_AHRS *_singleton;
 
     AP_NMEA_Output* _nmea_out;
+
+    uint32_t takeoff_expected_start_ms;
+    uint32_t touchdown_expected_start_ms;
 };
 
 #include "AP_AHRS_DCM.h"

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -116,6 +116,9 @@ AP_AHRS_DCM::update(bool skip_ins_update)
     update_AOA_SSA();
 
     backup_attitude();
+
+    // update takeoff/touchdown flags
+    update_flags();
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -2581,58 +2581,6 @@ bool AP_AHRS_NavEKF::get_vel_innovations_and_variances_for_source(uint8_t source
     return false;
 }
 
-void AP_AHRS_NavEKF::setTakeoffExpected(bool val)
-{
-    switch (takeoffExpectedState) {
-    case TriState::UNKNOWN:
-        break;
-    case TriState::True:
-        if (val) {
-            return;
-        }
-        break;
-    case TriState::False:
-        if (!val) {
-            return;
-        }
-        break;
-    }
-    takeoffExpectedState = (TriState)val;
-
-#if HAL_NAVEKF2_AVAILABLE
-    EKF2.setTakeoffExpected(val);
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    EKF3.setTakeoffExpected(val);
-#endif
-}
-
-void AP_AHRS_NavEKF::setTouchdownExpected(bool val)
-{
-    switch (touchdownExpectedState) {
-    case TriState::UNKNOWN:
-        break;
-    case TriState::True:
-        if (val) {
-            return;
-        }
-        break;
-    case TriState::False:
-        if (!val) {
-            return;
-        }
-        break;
-    }
-    touchdownExpectedState = (TriState)val;
-
-#if HAL_NAVEKF2_AVAILABLE
-    EKF2.setTouchdownExpected(val);
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    EKF3.setTouchdownExpected(val);
-#endif
-}
-
 bool AP_AHRS_NavEKF::getGpsGlitchStatus() const
 {
     nav_filter_status ekf_status {};

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -278,9 +278,6 @@ public:
     // returns the estimated magnetic field offsets in body frame
     bool get_mag_field_correction(Vector3f &ret) const override;
 
-    void setTakeoffExpected(bool val);
-    void setTouchdownExpected(bool val);
-
     bool getGpsGlitchStatus() const;
 
     // return the index of the airspeed we should use for airspeed measurements
@@ -388,8 +385,7 @@ private:
         True = 1,
         UNKNOWN = 3,
     };
-    TriState touchdownExpectedState = TriState::UNKNOWN;
-    TriState takeoffExpectedState = TriState::UNKNOWN;
+
     TriState terrainHgtStableState = TriState::UNKNOWN;
 
     EKFType last_active_ekf_type;

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -62,6 +62,8 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.EAS2TAS = AP::baro().get_EAS2TAS();
     _RFRN.vehicle_class = ahrs.get_vehicle_class();
     _RFRN.fly_forward = ahrs.get_fly_forward();
+    _RFRN.takeoff_expected = ahrs.get_takeoff_expected();
+    _RFRN.touchdown_expected = ahrs.get_touchdown_expected();
     _RFRN.ahrs_airspeed_sensor_enabled = AP::ahrs().airspeed_sensor_enabled();
     _RFRN.available_memory = hal.util->available_memory();
     _RFRN.ahrs_trim = ahrs.get_trim();
@@ -96,6 +98,15 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _millis = _RFRH.time_us / 1000UL;
 
     force_write = false;
+#endif
+}
+
+// for EKF usage to enable takeoff expected to true
+void AP_DAL::set_takeoff_expected()
+{
+#if !APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone) && !APM_BUILD_TYPE(APM_BUILD_Replay)
+    AP_AHRS &ahrs = AP::ahrs();
+    ahrs.set_takeoff_expected(true);
 #endif
 }
 

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -37,10 +37,10 @@ public:
         resetGyroBias             =  0,
         resetHeightDatum          =  1,
         //setInhibitGPS           =  2, // removed
-        setTakeoffExpected        =  3,
-        unsetTakeoffExpected      =  4,
-        setTouchdownExpected      =  5,
-        unsetTouchdownExpected    =  6,
+        //setTakeoffExpected        =  3, // removed
+        //unsetTakeoffExpected      =  4, // removed
+        //setTouchdownExpected      =  5, // removed
+        //unsetTouchdownExpected    =  6, // removed
         //setInhibitGpsVertVelUse   =  7, // removed
         //unsetInhibitGpsVertVelUse =  8, // removed
         setTerrainHgtStable       =  9,
@@ -172,6 +172,17 @@ public:
     bool get_fly_forward(void) const {
         return _RFRN.fly_forward;
     }
+
+    bool get_takeoff_expected(void) const {
+        return _RFRN.takeoff_expected;
+    }
+
+    bool get_touchdown_expected(void) const {
+        return _RFRN.touchdown_expected;
+    }
+
+    // for EKF usage to enable takeoff expected to true
+    void set_takeoff_expected();
 
     // get ahrs trim
     const Vector3f &get_trim() const {

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -67,6 +67,8 @@ struct log_RFRN {
     uint8_t ahrs_airspeed_sensor_enabled:1;
     uint8_t opticalflow_enabled:1;
     uint8_t wheelencoder_enabled:1;
+    uint8_t takeoff_expected:1;
+    uint8_t touchdown_expected:1;
     uint8_t _end;
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1233,40 +1233,6 @@ void NavEKF2::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &raw
     }
 }
 
-// called by vehicle code to specify that a takeoff is happening
-// causes the EKF to compensate for expected barometer errors due to ground effect
-void NavEKF2::setTakeoffExpected(bool val)
-{
-    if (val) {
-        AP::dal().log_event2(AP_DAL::Event::setTakeoffExpected);
-    } else {
-        AP::dal().log_event2(AP_DAL::Event::unsetTakeoffExpected);
-    }
-
-    if (core) {
-        for (uint8_t i=0; i<num_cores; i++) {
-            core[i].setTakeoffExpected(val);
-        }
-    }
-}
-
-// called by vehicle code to specify that a touchdown is expected to happen
-// causes the EKF to compensate for expected barometer errors due to ground effect
-void NavEKF2::setTouchdownExpected(bool val)
-{
-    if (val) {
-        AP::dal().log_event2(AP_DAL::Event::setTouchdownExpected);
-    } else {
-        AP::dal().log_event2(AP_DAL::Event::unsetTouchdownExpected);
-    }
-
-    if (core) {
-        for (uint8_t i=0; i<num_cores; i++) {
-            core[i].setTouchdownExpected(val);
-        }
-    }
-}
-
 // Set to true if the terrain underneath is stable enough to be used as a height reference
 // in combination with a range finder. Set to false if the terrain underneath the vehicle
 // cannot be used as a height reference. Use to prevent range finder operation otherwise

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -192,14 +192,6 @@ public:
     // posOffset is the XYZ flow sensor position in the body frame in m
     void  writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
 
-    // called by vehicle code to specify that a takeoff is happening
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTakeoffExpected(bool val);
-
-    // called by vehicle code to specify that a touchdown is expected to happen
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTouchdownExpected(bool val);
-
     // Set to true if the terrain underneath is stable enough to be used as a height reference
     // in combination with a range finder. Set to false if the terrain underneath the vehicle
     // cannot be used as a height reference. Use to prevent range finder operation otherwise
@@ -407,7 +399,6 @@ private:
     const float fScaleFactorPnoise = 1e-10f;       // Process noise added to focal length scale factor state variance at each time step
     const uint8_t flowTimeDeltaAvg_ms = 100;       // average interval between optical flow measurements (msec)
     const uint8_t flowIntervalMax_ms = 100;       // maximum allowable time between flow fusion events
-    const uint16_t gndEffectTimeout_ms = 1000;     // time in msec that ground effect mode is active after being activated
     const float gndEffectBaroScaler = 4.0f;        // scaler applied to the barometer observation variance when ground effect mode is active
     const uint8_t fusionTimeStep_ms = 10;          // The minimum time interval between covariance predictions and measurement fusions in msec
     const float maxYawEstVelInnov = 2.0f;          // Maximum acceptable length of the velocity innovation returned by the EKF-GSF yaw estimator (m/s)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -512,8 +512,8 @@ void  NavEKF2_core::updateFilterStatus(void)
     filterStatus.flags.pred_horiz_pos_rel = ((optFlowNavPossible || gpsNavPossible) && filterHealthy) || filterStatus.flags.horiz_pos_rel; // we should be able to estimate a relative position when we enter flight mode
     filterStatus.flags.pred_horiz_pos_abs = (gpsNavPossible && filterHealthy) || filterStatus.flags.horiz_pos_abs; // we should be able to estimate an absolute position when we enter flight mode
     filterStatus.flags.takeoff_detected = takeOffDetected; // takeoff for optical flow navigation has been detected
-    filterStatus.flags.takeoff = expectGndEffectTakeoff; // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
-    filterStatus.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
+    filterStatus.flags.takeoff = dal.get_takeoff_expected(); // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
+    filterStatus.flags.touchdown = dal.get_touchdown_expected(); // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     filterStatus.flags.using_gps = ((imuSampleTime_ms - lastPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);
     filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE) && !extNavUsedForPos; // GPS glitching is affecting navigation accuracy
     filterStatus.flags.gps_quality_good = gpsGoodToAlign;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -672,7 +672,7 @@ void NavEKF2_core::readBaroData()
 
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
-        if (getTakeoffExpected()) {
+        if (dal.get_takeoff_expected()) {
             baroDataNew.hgt = MAX(baroDataNew.hgt, meaHgtAtTakeOff);
         }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -672,7 +672,7 @@ void NavEKF2_core::readBaroData()
 
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
-        if (dal.get_takeoff_expected()) {
+        if (dal.get_takeoff_expected() && !assume_zero_sideslip()) {
             baroDataNew.hgt = MAX(baroDataNew.hgt, meaHgtAtTakeOff);
         }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -815,7 +815,7 @@ void NavEKF2_core::FuseVelPosNED()
                     const float gndMaxBaroErr = 4.0f;
                     const float gndBaroInnovFloor = -0.5f;
 
-                    if(getTouchdownExpected() && activeHgtSource == HGT_SOURCE_BARO) {
+                    if(dal.get_touchdown_expected() && activeHgtSource == HGT_SOURCE_BARO) {
                         // when a touchdown is expected, floor the barometer innovation at gndBaroInnovFloor
                         // constrain the correction between 0 and gndBaroInnovFloor+gndMaxBaroErr
                         // this function looks like this:
@@ -1029,7 +1029,7 @@ void NavEKF2_core::selectHeightForFusion()
         }
         // filtered baro data used to provide a reference for takeoff
         // it is is reset to last height measurement on disarming in performArmingChecks()
-        if (!getTakeoffExpected()) {
+        if (!dal.get_takeoff_expected()) {
             const float gndHgtFiltTC = 0.5f;
             const float dtBaro = frontend->hgtAvg_ms*1.0e-3f;
             float alpha = constrain_float(dtBaro / (dtBaro+gndHgtFiltTC),0.0f,1.0f);
@@ -1091,12 +1091,12 @@ void NavEKF2_core::selectHeightForFusion()
         // set the observation noise
         posDownObsNoise = sq(constrain_float(frontend->_baroAltNoise, 0.1f, 10.0f));
         // reduce weighting (increase observation noise) on baro if we are likely to be in ground effect
-        if (getTakeoffExpected() || getTouchdownExpected()) {
+        if (dal.get_takeoff_expected() || dal.get_touchdown_expected()) {
             posDownObsNoise *= frontend->gndEffectBaroScaler;
         }
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
-        if (motorsArmed && getTakeoffExpected()) {
+        if (motorsArmed && dal.get_takeoff_expected()) {
             hgtMea = MAX(hgtMea, meaHgtAtTakeOff);
         }
     } else {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -1096,7 +1096,7 @@ void NavEKF2_core::selectHeightForFusion()
         }
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
-        if (motorsArmed && dal.get_takeoff_expected()) {
+        if (motorsArmed && dal.get_takeoff_expected() && !assume_zero_sideslip()) {
             hgtMea = MAX(hgtMea, meaHgtAtTakeOff);
         }
     } else {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -417,43 +417,6 @@ void NavEKF2_core::detectFlight()
 }
 
 
-// determine if a takeoff is expected so that we can compensate for expected barometer errors due to ground effect
-bool NavEKF2_core::getTakeoffExpected()
-{
-    if (expectGndEffectTakeoff && imuSampleTime_ms - takeoffExpectedSet_ms > frontend->gndEffectTimeout_ms) {
-        expectGndEffectTakeoff = false;
-    }
-
-    return expectGndEffectTakeoff;
-}
-
-// called by vehicle code to specify that a takeoff is happening
-// causes the EKF to compensate for expected barometer errors due to ground effect
-void NavEKF2_core::setTakeoffExpected(bool val)
-{
-    takeoffExpectedSet_ms = imuSampleTime_ms;
-    expectGndEffectTakeoff = val;
-}
-
-
-// determine if a touchdown is expected so that we can compensate for expected barometer errors due to ground effect
-bool NavEKF2_core::getTouchdownExpected()
-{
-    if (expectGndEffectTouchdown && imuSampleTime_ms - touchdownExpectedSet_ms > frontend->gndEffectTimeout_ms) {
-        expectGndEffectTouchdown = false;
-    }
-
-    return expectGndEffectTouchdown;
-}
-
-// called by vehicle code to specify that a touchdown is expected to happen
-// causes the EKF to compensate for expected barometer errors due to ground effect
-void NavEKF2_core::setTouchdownExpected(bool val)
-{
-    touchdownExpectedSet_ms = imuSampleTime_ms;
-    expectGndEffectTouchdown = val;
-}
-
 // Set to true if the terrain underneath is stable enough to be used as a height reference
 // in combination with a range finder. Set to false if the terrain underneath the vehicle
 // cannot be used as a height reference. Use to prevent range finder operation otherwise

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -190,10 +190,6 @@ void NavEKF2_core::InitialiseVariables()
     inhibitWindStates = true;
     gndOffsetValid =  false;
     validOrigin = false;
-    takeoffExpectedSet_ms = 0;
-    expectGndEffectTakeoff = false;
-    touchdownExpectedSet_ms = 0;
-    expectGndEffectTouchdown = false;
     gpsSpdAccuracy = 0.0f;
     gpsPosAccuracy = 0.0f;
     gpsHgtAccuracy = 0.0f;
@@ -935,7 +931,7 @@ void NavEKF2_core::CovariancePrediction()
     for (uint8_t i= 0; i<=8;  i++) processNoise[i] = 0.0f;
     for (uint8_t i=9; i<=11; i++) processNoise[i] = dAngBiasSigma;
     for (uint8_t i=12; i<=14; i++) processNoise[i] = dAngScaleSigma;
-    if (expectGndEffectTakeoff) {
+    if (dal.get_takeoff_expected()) {
         processNoise[15] = 0.0f;
     } else {
         processNoise[15] = dVelBiasSigma;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -207,14 +207,6 @@ public:
     */
     bool getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED, float &offsetHigh, float &offsetLow);
 
-    // called by vehicle code to specify that a takeoff is happening
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTakeoffExpected(bool val);
-
-    // called by vehicle code to specify that a touchdown is expected to happen
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTouchdownExpected(bool val);
-
     // Set to true if the terrain underneath is stable enough to be used as a height reference
     // in combination with a range finder. Set to false if the terrain underneath the vehicle
     // cannot be used as a height reference. Use to prevent range finder operation otherwise
@@ -680,12 +672,6 @@ private:
     // Set the NED origin to be used until the next filter reset
     void setOrigin(const Location &loc);
 
-    // determine if a takeoff is expected so that we can compensate for expected barometer errors due to ground effect
-    bool getTakeoffExpected();
-
-    // determine if a touchdown is expected so that we can compensate for expected barometer errors due to ground effect
-    bool getTouchdownExpected();
-
     // Assess GPS data quality and set gpsGoodToAlign if good enough to align the EKF
     void calcGpsGoodToAlign(void);
 
@@ -1068,10 +1054,6 @@ private:
     uint32_t timeAtArming_ms;       // time in msec that the vehicle armed
 
     // baro ground effect
-    bool expectGndEffectTakeoff;      // external state from ArduCopter - takeoff expected
-    uint32_t takeoffExpectedSet_ms;   // system time at which expectGndEffectTakeoff was set
-    bool expectGndEffectTouchdown;    // external state from ArduCopter - touchdown expected
-    uint32_t touchdownExpectedSet_ms; // system time at which expectGndEffectTouchdown was set
     float meaHgtAtTakeOff;            // height measured at commencement of takeoff
 
     // control of post takeoff magnetic field and heading resets

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -704,6 +704,14 @@ const AP_Param::GroupInfo NavEKF3::var_info2[] = {
     // @User: Advanced
     AP_GROUPINFO("OGNM_TEST_SF", 6, NavEKF3, _ognmTestScaleFactor, 2.0f),
 
+    // @Param: GND_EFF_DZ
+    // @DisplayName: Baro height ground effect dead zone
+    // @Description: This parameter sets the size of the dead zone that is applied to negative baro height spikes that can occur when takeing off or landing when a vehicle with lift rotors is operating in ground effect ground effect. Set to about 0.5m less than the amount of negative offset in baro height that occurs just prior to takeoff when lift motors are spooling up. Set to 0 if no ground effect is present. 
+    // @Range: 0.0 10.0
+    // @Increment: 0.5
+    // @User: Advanced
+    AP_GROUPINFO("GND_EFF_DZ", 7, NavEKF3, _baroGndEffectDeadZone, 4.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1696,41 +1696,6 @@ void NavEKF3::convert_parameters()
     }
 }
 
-// called by vehicle code to specify that a takeoff is happening
-// causes the EKF to compensate for expected barometer errors due to rotor wash ground interaction
-// causes the EKF to start the EKF-GSF yaw estimator
-void NavEKF3::setTakeoffExpected(bool val)
-{
-    if (val) {
-        AP::dal().log_event3(AP_DAL::Event::setTakeoffExpected);
-    } else {
-        AP::dal().log_event3(AP_DAL::Event::unsetTakeoffExpected);
-    }
-
-    if (core) {
-        for (uint8_t i=0; i<num_cores; i++) {
-            core[i].setTakeoffExpected(val);
-        }
-    }
-}
-
-// called by vehicle code to specify that a touchdown is expected to happen
-// causes the EKF to compensate for expected barometer errors due to ground effect
-void NavEKF3::setTouchdownExpected(bool val)
-{
-    if (val) {
-        AP::dal().log_event3(AP_DAL::Event::setTouchdownExpected);
-    } else {
-        AP::dal().log_event3(AP_DAL::Event::unsetTouchdownExpected);
-    }
-
-    if (core) {
-        for (uint8_t i=0; i<num_cores; i++) {
-            core[i].setTouchdownExpected(val);
-        }
-    }
-}
-
 // Set to true if the terrain underneath is stable enough to be used as a height reference
 // in combination with a range finder. Set to false if the terrain underneath the vehicle
 // cannot be used as a height reference. Use to prevent range finder operation otherwise

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -439,6 +439,7 @@ private:
     AP_Float _momentumDragCoef;     // lift rotor momentum drag coefficient
     AP_Int8 _betaMask;              // Bitmask controlling when sideslip angle fusion is used to estimate non wind states
     AP_Float _ognmTestScaleFactor;  // Scale factor applied to the thresholds used by the on ground not moving test
+    AP_Float _baroGndEffectDeadZone;// Dead zone applied to positive baro height innovations when in ground effect (m)
 
 // Possible values for _flowUse
 #define FLOW_USE_NONE    0

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -270,15 +270,6 @@ public:
     */
     void writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms);
 
-    // called by vehicle code to specify that a takeoff is happening
-    // causes the EKF to compensate for expected barometer errors due to rotor wash ground interaction
-    // causes the EKF to start the EKF-GSF yaw estimator
-    void setTakeoffExpected(bool val);
-
-    // called by vehicle code to specify that a touchdown is expected to happen
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTouchdownExpected(bool val);
-
     // Set to true if the terrain underneath is stable enough to be used as a height reference
     // in combination with a range finder. Set to false if the terrain underneath the vehicle
     // cannot be used as a height reference. Use to prevent range finder operation otherwise
@@ -478,7 +469,6 @@ private:
     const float fScaleFactorPnoise = 1e-10f;       // Process noise added to focal length scale factor state variance at each time step
     const uint8_t flowTimeDeltaAvg_ms = 100;       // average interval between optical flow measurements (msec)
     const uint32_t flowIntervalMax_ms = 100;       // maximum allowable time between flow fusion events
-    const uint16_t gndEffectTimeout_ms = 1000;     // time in msec that ground effect mode is active after being activated
     const float gndEffectBaroScaler = 4.0f;        // scaler applied to the barometer observation variance when ground effect mode is active
     const uint8_t gndGradientSigma = 50;           // RMS terrain gradient percentage assumed by the terrain height estimation
     const uint16_t fusionTimeStep_ms = 10;         // The minimum time interval between covariance predictions and measurement fusions in msec

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -678,8 +678,8 @@ void  NavEKF3_core::updateFilterStatus(void)
     filterStatus.flags.pred_horiz_pos_rel = filterStatus.flags.horiz_pos_rel; // EKF3 enters the required mode before flight
     filterStatus.flags.pred_horiz_pos_abs = filterStatus.flags.horiz_pos_abs; // EKF3 enters the required mode before flight
     filterStatus.flags.takeoff_detected = takeOffDetected; // takeoff for optical flow navigation has been detected
-    filterStatus.flags.takeoff = expectTakeoff; // The EKF has been told to expect takeoff is in a ground effect mitigation mode and has started the EKF-GSF yaw estimator
-    filterStatus.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
+    filterStatus.flags.takeoff = dal.get_takeoff_expected(); // The EKF has been told to expect takeoff is in a ground effect mitigation mode and has started the EKF-GSF yaw estimator
+    filterStatus.flags.touchdown = dal.get_touchdown_expected(); // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     filterStatus.flags.using_gps = ((imuSampleTime_ms - lastPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);
     filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE) && (frontend->sources.getPosXYSource() == AP_NavEKF_Source::SourceXY::GPS); // GPS glitching is affecting navigation accuracy
     filterStatus.flags.gps_quality_good = gpsGoodToAlign;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -735,12 +735,6 @@ void NavEKF3_core::readBaroData()
 
         baroDataNew.hgt = baro.get_altitude(selected_baro);
 
-        // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
-        // This prevents negative baro disturbances due to rotor wash ground interaction corrupting the EKF altitude during initial ascent
-        if (dal.get_takeoff_expected() && !assume_zero_sideslip()) {
-            baroDataNew.hgt = MAX(baroDataNew.hgt, meaHgtAtTakeOff);
-        }
-
         // time stamp used to check for new measurement
         lastBaroReceived_ms = baro.get_last_update(selected_baro);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -737,7 +737,7 @@ void NavEKF3_core::readBaroData()
 
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to rotor wash ground interaction corrupting the EKF altitude during initial ascent
-        if (expectGndEffectTakeoff) {
+        if (dal.get_takeoff_expected()) {
             baroDataNew.hgt = MAX(baroDataNew.hgt, meaHgtAtTakeOff);
         }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -737,7 +737,7 @@ void NavEKF3_core::readBaroData()
 
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to rotor wash ground interaction corrupting the EKF altitude during initial ascent
-        if (dal.get_takeoff_expected()) {
+        if (dal.get_takeoff_expected() && !assume_zero_sideslip()) {
             baroDataNew.hgt = MAX(baroDataNew.hgt, meaHgtAtTakeOff);
         }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -851,7 +851,7 @@ void NavEKF3_core::FuseVelPosNED()
                     const float gndMaxBaroErr = 4.0f;
                     const float gndBaroInnovFloor = -0.5f;
 
-                    if (expectGndEffectTouchdown && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {
+                    if (dal.get_touchdown_expected() && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {
                         // when a touchdown is expected, floor the barometer innovation at gndBaroInnovFloor
                         // constrain the correction between 0 and gndBaroInnovFloor+gndMaxBaroErr
                         // this function looks like this:
@@ -1111,7 +1111,7 @@ void NavEKF3_core::selectHeightForFusion()
         }
         // filtered baro data used to provide a reference for takeoff
         // it is is reset to last height measurement on disarming in performArmingChecks()
-        if (!expectGndEffectTakeoff) {
+        if (!dal.get_takeoff_expected()) {
             const float gndHgtFiltTC = 0.5f;
             const float dtBaro = frontend->hgtAvg_ms*1.0e-3f;
             float alpha = constrain_float(dtBaro / (dtBaro+gndHgtFiltTC),0.0f,1.0f);
@@ -1177,12 +1177,12 @@ void NavEKF3_core::selectHeightForFusion()
         // set the observation noise
         posDownObsNoise = sq(constrain_float(frontend->_baroAltNoise, 0.1f, 10.0f));
         // reduce weighting (increase observation noise) on baro if we are likely to be experiencing rotor wash ground interaction
-        if (expectGndEffectTakeoff || expectGndEffectTouchdown) {
+        if (dal.get_takeoff_expected() || dal.get_touchdown_expected()) {
             posDownObsNoise *= frontend->gndEffectBaroScaler;
         }
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to rotor wash ground interaction corrupting the EKF altitude during initial ascent
-        if (motorsArmed && expectGndEffectTakeoff) {
+        if (motorsArmed && dal.get_takeoff_expected()) {
             hgtMea = MAX(hgtMea, meaHgtAtTakeOff);
         }
         velPosObs[5] = -hgtMea;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1181,11 +1181,6 @@ void NavEKF3_core::selectHeightForFusion()
         if (dal.get_takeoff_expected() || dal.get_touchdown_expected()) {
             posDownObsNoise *= frontend->gndEffectBaroScaler;
         }
-        // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
-        // This prevents negative baro disturbances due to rotor wash ground interaction corrupting the EKF altitude during initial ascent
-        if (motorsArmed && dal.get_takeoff_expected() && !assume_zero_sideslip()) {
-            hgtMea = MAX(hgtMea, meaHgtAtTakeOff);
-        }
         velPosObs[5] = -hgtMea;
     } else {
         fuseHgtData = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -848,7 +848,7 @@ void NavEKF3_core::FuseVelPosNED()
                     R_OBS[obsIndex] *= sq(gpsNoiseScaler);
                 } else if (obsIndex == 5) {
                     innovVelPos[obsIndex] = stateStruct.position[obsIndex-3] - velPosObs[obsIndex];
-                    const float gndMaxBaroErr = 4.0f;
+                    const float gndMaxBaroErr = MAX(frontend->_baroGndEffectDeadZone, 0.0f);
                     const float gndBaroInnovFloor = -0.5f;
 
                     if ((dal.get_touchdown_expected() || dal.get_takeoff_expected()) && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1182,7 +1182,7 @@ void NavEKF3_core::selectHeightForFusion()
         }
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to rotor wash ground interaction corrupting the EKF altitude during initial ascent
-        if (motorsArmed && dal.get_takeoff_expected()) {
+        if (motorsArmed && dal.get_takeoff_expected() && !assume_zero_sideslip()) {
             hgtMea = MAX(hgtMea, meaHgtAtTakeOff);
         }
         velPosObs[5] = -hgtMea;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -851,8 +851,9 @@ void NavEKF3_core::FuseVelPosNED()
                     const float gndMaxBaroErr = 4.0f;
                     const float gndBaroInnovFloor = -0.5f;
 
-                    if (dal.get_touchdown_expected() && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {
-                        // when a touchdown is expected, floor the barometer innovation at gndBaroInnovFloor
+                    if ((dal.get_touchdown_expected() || dal.get_takeoff_expected()) && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {
+                        // when baro positive pressure error due to ground effect is expected,
+                        // floor the barometer innovation at gndBaroInnovFloor
                         // constrain the correction between 0 and gndBaroInnovFloor+gndMaxBaroErr
                         // this function looks like this:
                         //         |/

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -268,11 +268,6 @@ void NavEKF3_core::InitialiseVariables()
     inhibitDelAngBiasStates = true;
     gndOffsetValid =  false;
     validOrigin = false;
-    takeoffExpectedSet_ms = 0;
-    expectTakeoff = false;
-    touchdownExpectedSet_ms = 0;
-    expectGndEffectTakeoff = false;
-    expectGndEffectTouchdown = false;
     gpsSpdAccuracy = 0.0f;
     gpsPosAccuracy = 0.0f;
     gpsHgtAccuracy = 0.0f;
@@ -901,10 +896,10 @@ void NavEKF3_core::calcOutputStates()
 
     // Detect fixed wing launch acceleration using latest data from IMU to enable early startup of filter functions
     // that use launch acceleration to detect start of flight
-    if (!inFlight && !expectTakeoff && assume_zero_sideslip()) {
+    if (!inFlight && !dal.get_takeoff_expected() && assume_zero_sideslip()) {
         const float launchDelVel = imuDataNew.delVel.x + GRAVITY_MSS * imuDataNew.delVelDT * Tbn_temp.c.x;
         if (launchDelVel > GRAVITY_MSS * imuDataNew.delVelDT) {
-            setTakeoffExpected(true);
+            dal.set_takeoff_expected();
         }
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -291,15 +291,6 @@ public:
     */
     void writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms);
 
-    // called by vehicle code to specify that a takeoff is happening
-    // causes the EKF to compensate for expected barometer errors due to rotor wash ground interaction
-    // causes the EKF to start the EKF-GSF yaw estimator
-    void setTakeoffExpected(bool val);
-
-    // called by vehicle code to specify that a touchdown is expected to happen
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTouchdownExpected(bool val);
-
     // Set to true if the terrain underneath is stable enough to be used as a height reference
     // in combination with a range finder. Set to false if the terrain underneath the vehicle
     // cannot be used as a height reference. Use to prevent range finder operation otherwise
@@ -823,15 +814,6 @@ private:
     // Set the NED origin to be used until the next filter reset
     void setOrigin(const Location &loc);
 
-    // update and return the status that indicates takeoff is expected so that we can compensate for expected
-    // barometer errors due to rotor-wash ground interaction and start the EKF-GSF yaw estimator prior to
-    // takeoff movement
-    bool updateTakeoffExpected();
-
-    // update and return the status that indicates touchdown is expected so that we can compensate for expected
-    // barometer errors due to rotor-wash ground interaction
-    bool updateTouchdownExpected();
-
     // Assess GPS data quality and set gpsGoodToAlign
     void calcGpsGoodToAlign(void);
 
@@ -1296,14 +1278,7 @@ private:
     uint32_t timeAtArming_ms;       // time in msec that the vehicle armed
 
     // baro ground effect
-    bool expectGndEffectTakeoff;      // external state - takeoff expected in VTOL flight
-    bool expectGndEffectTouchdown;    // external state - touchdown expected in VTOL flight
-    uint32_t touchdownExpectedSet_ms; // system time at which expectGndEffectTouchdown was set
     float meaHgtAtTakeOff;            // height measured at commencement of takeoff
-
-    // takeoff preparation used to start EKF-GSF yaw estimator and mitigate rotor-wash ground interaction Baro errors
-    uint32_t takeoffExpectedSet_ms;   // system time at which expectTakeoff was set
-    bool expectTakeoff;               // external state from vehicle conrol code - takeoff expected
 
     // control of post takeoff magnetic field and heading resets
     bool finalInflightYawInit;      // true when the final post takeoff initialisation of yaw angle has been performed


### PR DESCRIPTION
Closes #17552 

Apart from the autotest I've added here, I've manually reviewed the logs produced by the autotest to ensure the flag continues to be set as appropriate.

I've also tested quadplane before/after this patch.  Before the patch the ground effect compensation was only turned on for a second (the predicted broken behaviour), after the fix it remained on for ~20 seconds while the vehicle was `QLAND`ing.

The solution here effectively decimates the messages we pass down to the EKFs.  I would have actually preferred to eliminate the timeout of the state down in the EKF, but quadplane's structure means this would be rather involved.
