### PR TITLE
AP_NavEKF3: init rngOnGnd to 5cm to avoid div-by-zero

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -277,6 +277,7 @@ void NavEKF3_core::InitialiseVariables()
     gpsPosAccuracy = 0.0f;
     gpsHgtAccuracy = 0.0f;
     baroHgtOffset = 0.0f;
+    rngOnGnd = 0.05f;
     yawResetAngle = 0.0f;
     lastYawReset_ms = 0;
     tiltErrorVariance = sq(M_2PI);


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/17565 by ensuring that rngOnGnd is never zero and thus avoids a divide-by-zero when fusing optical flow measurements.

Testing has been only in SITL but I have checked before and after that this resolves the divide-by-zero.  I think from inspection it is also clear that this is a safe change.

@priseborough may have other ideas on the fix though.
