### PR TITLE
AP_NavEKF3: make time-horizon OF data a local variable

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -795,10 +795,10 @@ private:
     void SelectBodyOdomFusion();
 
     // Estimate terrain offset using a single state EKF
-    void EstimateTerrainOffset();
+    void EstimateTerrainOffset(const of_elements &ofDataDelayed);
 
     // fuse optical flow measurements into the main filter
-    void FuseOptFlow();
+    void FuseOptFlow(const of_elements &ofDataDelayed);
 
     // Control filter mode changes
     void controlFilterModes();
@@ -1145,7 +1145,6 @@ private:
     // variables added for optical flow fusion
     EKF_obs_buffer_t<of_elements> storedOF;    // OF data buffer
     of_elements ofDataNew;          // OF data at the current time horizon
-    of_elements ofDataDelayed;      // OF data at the fusion time horizon
     bool flowDataValid;             // true while optical flow data is still fresh
     Vector2f auxFlowObsInnov;       // optical flow rate innovation from 1-state terrain offset estimator
     uint32_t flowValidMeaTime_ms;   // time stamp from latest valid flow measurement (msec)


### PR DESCRIPTION
Saves 40 bytes of RAM per core on stm32

Flow-on effect from 

```
commit c4b7a1c41a1b9f501277abaa36346acd988ea9b1
Author: Randy Mackay <rmackay9@yahoo.com>
Date:   Tue Aug 18 11:46:57 2020 +0900

    AP_NavEKF3: flowDataToFuse moved to local variable
```
