### PR TITLE
AP_InertialSensor: AP_Gyro_initialization_message_and_gyro_abnormal_value_notification_to_GCS2

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1333,7 +1333,7 @@ AP_InertialSensor::_init_gyro()
     AP_Notify::flags.initialising = true;
 
     // cold start
-    hal.console->printf("Init Gyro");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Init Gyro");
 
     /*
       we do the gyro calibration with no board rotation. This avoids
@@ -1437,10 +1437,9 @@ AP_InertialSensor::_init_gyro()
 
     // we've kept the user waiting long enough - use the best pair we
     // found so far
-    hal.console->printf("\n");
     for (uint8_t k=0; k<num_gyros; k++) {
         if (!converged[k]) {
-            hal.console->printf("gyro[%u] did not converge: diff=%f dps (expected < %f)\n",
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "gyro%u not conv: diff=%f dps (expected<%f)",
                                 (unsigned)k,
                                 (double)ToDeg(best_diff[k]),
                                 (double)GYRO_INIT_MAX_DIFF_DPS);


### PR DESCRIPTION
I am maintaining a business vehicle.
I want to know what anomalies the GCS detects when the vehicle starts up.
My vehicle does not have an easy USB connection.
By setting the console output to GCS notification, I can use GCS to know when to initialize the gyro and when the gyro fails to initialize.