### PR TITLE
Copter: Change to a message method intended for gcs notification

### DIFF
--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -201,10 +201,10 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
                     spray(true);
                     reach_wp_time_ms = 0;
                     if (is_auto == false || line_num == ZIGZAG_LINE_INFINITY) {
-                        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", (ab_dest == Destination::A) ? "A" : "B");
+                        gcs().send_text_gcsonly(MAV_SEVERITY_INFO, "ZigZag: moving to %s", (ab_dest == Destination::A) ? "A" : "B");
                     } else {
                         line_count++;
-                        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s (line %d/%d)", (ab_dest == Destination::A) ? "A" : "B", line_count, line_num);
+                        gcs().send_text_gcsonly(MAV_SEVERITY_INFO, "ZigZag: moving to %s (line %d/%d)", (ab_dest == Destination::A) ? "A" : "B", line_count, line_num);
                     }
                 }
             }
@@ -226,7 +226,7 @@ void ModeZigZag::move_to_side()
                 current_terr_alt = terr_alt;
                 reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
+                gcs().send_text_gcsonly(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
             }
         }
     }
@@ -541,7 +541,7 @@ void ModeZigZag::run_auto()
                 stage = AUTO;
                 reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
+                gcs().send_text_gcsonly(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
             }
         }
     } else {

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -79,6 +79,32 @@ void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)
     va_end(arg_list);
 }
 
+/*
+  send a text message to all GCS only
+ */
+void GCS::send_textv_gcsonly(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
+{
+    uint8_t mask = statustext_send_channel_mask();
+    if (!update_send_has_been_called) {
+        // we have not yet initialised the streaming-channel-mask,
+        // which is done as part of the update() call.  So just send
+        // it to all channels:
+        mask = (1<<_num_gcs)-1;
+    }
+    send_textv_gcsonly(severity, fmt, arg_list, mask);
+}
+
+/*
+  send a text message to all GCS only
+ */
+void GCS::send_text_gcsonly(MAV_SEVERITY severity, const char *fmt, ...)
+{
+    va_list arg_list;
+    va_start(arg_list, fmt);
+    send_textv_gcsonly(severity, fmt, arg_list);
+    va_end(arg_list);
+}
+
 void GCS::send_to_active_channels(uint32_t msgid, const char *pkt)
 {
     const mavlink_msg_entry_t *entry = mavlink_get_msg_entry(msgid);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -931,6 +931,9 @@ public:
     void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
     virtual void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t mask);
     uint8_t statustext_send_channel_mask() const;
+    void send_text_gcsonly(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(3, 4);
+    void send_textv_gcsonly(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
+    virtual void send_textv_gcsonly(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t dest_bitmask);
 
     virtual GCS_MAVLINK *chan(const uint8_t ofs) = 0;
     virtual const GCS_MAVLINK *chan(const uint8_t ofs) const = 0;


### PR DESCRIPTION
A message intended to notify the GCS is logged in the flight log.
There is no SEND_TEXT method that is not logged in the flight log.
I will add a SEND_TEXT method that does not log to the flight log.
I applied this method to ZIGZAG's repeating notification messages.

AFTER
![Screenshot from 2021-05-29 22-49-47](https://user-images.githubusercontent.com/646194/120073593-f2425d00-c0d3-11eb-9cc6-038650fb02ec.png)

BBEFORE
![Screenshot from 2021-05-29 22-34-00](https://user-images.githubusercontent.com/646194/120073599-01c1a600-c0d4-11eb-98fb-f04a7a629f18.png)

GCS MESSAGE: After change and before change are the same
![Screenshot from 2021-05-29 22-47-37](https://user-images.githubusercontent.com/646194/120073647-39305280-c0d4-11eb-8edb-b3d66cf4333d.png)