### PR TITLE
AP_Stats:  Notify GCS of the current flight time

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -2,6 +2,7 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_RTC/AP_RTC.h>
+#include <GCS_MAVLink/GCS.h>
 
 const extern AP_HAL::HAL& hal;
 
@@ -123,13 +124,16 @@ void AP_Stats::update()
 
 void AP_Stats::set_flying(const bool is_flying)
 {
+    static uint32_t oneFlightTime = 0;
     if (is_flying) {
         if (!_flying_ms) {
             _flying_ms = AP_HAL::millis();
+            oneFlightTime = _flying_ms;
         }
     } else {
         update_flighttime();
         _flying_ms = 0;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "current flight time is %.1f sec", (AP_HAL::millis() - oneFlightTime)*0.001f);
     }
 }
 


### PR DESCRIPTION
The flight time obtained by STAT is cumulative.
Cumulative time is good for maintenance of the aircraft.
The flight record of a Japanese vehicle describes the place of flight and the flight time.
I will have it logged in the flight log for this record.
I will also notify the operator of the current flight time.

![Screenshot from 2021-05-30 01-37-36](https://user-images.githubusercontent.com/646194/120077911-c4671380-c0e7-11eb-8641-ee77876fe1cd.png)
