### PR TITLE
HAL_ChibiOS: empty dma.txt on first fetch

### DIFF
--- a/libraries/AP_HAL_ChibiOS/shared_dma.cpp
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.cpp
@@ -235,7 +235,7 @@ void Shared_DMA::dma_info(ExpandingString &str)
     // no buffer allocated, start counting
     if (_contention_stats == nullptr) {
         _contention_stats = new dma_stats[SHARED_DMA_MAX_STREAM_ID+1];
-        return;
+        // return zeros on first fetch
     }
 
     // a header to allow for machine parsers to determine format


### PR DESCRIPTION
this gives an empty DMA file, which means no error on GCS for first fetch
tested on CubeOrange