### PR TITLE
GCS_MAVLink: add support for MAV_CMD_RUN_PREARM_CHECKS

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -463,6 +463,7 @@ protected:
     bool telemetry_delayed() const;
     virtual uint32_t telem_delay() const = 0;
 
+    MAV_RESULT handle_command_run_prearm_checks(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_preflight_set_sensor_offsets(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_flash_bootloader(const mavlink_command_long_t &packet);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3802,6 +3802,15 @@ MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_comma
     return _handle_command_preflight_calibration(packet);
 }
 
+MAV_RESULT GCS_MAVLINK::handle_command_run_prearm_checks(const mavlink_command_long_t &packet)
+{
+    if (hal.util->get_soft_armed()) {
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    }
+    (void)AP::arming().pre_arm_checks(true);
+    return MAV_RESULT_ACCEPTED;
+}
+
 MAV_RESULT GCS_MAVLINK::handle_command_preflight_can(const mavlink_command_long_t &packet)
 {
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
@@ -4171,6 +4180,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
         
     case MAV_CMD_PREFLIGHT_UAVCAN:
         result = handle_command_preflight_can(packet);
+        break;
+
+    case MAV_CMD_RUN_PREARM_CHECKS:
+        result = handle_command_run_prearm_checks(packet);
         break;
 
     case MAV_CMD_FLASH_BOOTLOADER:


### PR DESCRIPTION
Tested in MAVProxy using both `long` and a new `arm prearms` argument:

```
MANUAL> long RUN_PREARM_CHECKS
MANUAL> Got COMMAND_ACK: RUN_PREARM_CHECKS: ACCEPTED
AP: PreArm: Bad GPS Position
AP: AHRS: DCM active

MANUAL> 
MANUAL> AP: EKF3 IMU0 stopped aiding
AP: EKF3 IMU1 stopped aiding
MANUAL> arm prearms
MANUAL> Got COMMAND_ACK: RUN_PREARM_CHECKS: ACCEPTED
AP: PreArm: AHRS: Not healthy
AP: PreArm: Bad GPS Position
Flight battery 100 percent
```

PR against mavlink here: https://github.com/ArduPilot/mavlink/pull/208 (and yes, upstream needs to be done!)
