### PR TITLE
SITL: Add C++ library for JSON interface

### DIFF
--- a/libraries/SITL/examples/JSON/C++/SocketExample.cpp
+++ b/libraries/SITL/examples/JSON/C++/SocketExample.cpp
@@ -1,0 +1,228 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "SocketExample.h"
+
+/*
+  constructor
+ */
+SocketExample::SocketExample(bool _datagram) : 
+    SocketExample(_datagram, socket(AF_INET, _datagram?SOCK_DGRAM:SOCK_STREAM, 0)) 
+{}
+
+SocketExample::SocketExample(bool _datagram, int _fd) :
+    datagram(_datagram),
+    fd(_fd)
+{
+    fcntl(fd, F_SETFD, FD_CLOEXEC);
+    if (!datagram) {
+        int one = 1;
+        setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+    }
+}
+
+SocketExample::~SocketExample()
+{
+    if (fd != -1) {
+        ::close(fd);
+        fd = -1;
+    }
+}
+
+void SocketExample::make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr)
+{
+    memset(&sockaddr, 0, sizeof(sockaddr));
+
+#ifdef HAVE_SOCK_SIN_LEN
+    sockaddr.sin_len = sizeof(sockaddr);
+#endif
+    sockaddr.sin_port = htons(port);
+    sockaddr.sin_family = AF_INET;
+    sockaddr.sin_addr.s_addr = inet_addr(address);
+}
+
+/*
+  connect the socket
+ */
+bool SocketExample::connect(const char *address, uint16_t port)
+{
+    struct sockaddr_in sockaddr;
+    make_sockaddr(address, port, sockaddr);
+
+    if (::connect(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
+        return false;
+    }
+    return true;
+}
+
+/*
+  bind the socket
+ */
+bool SocketExample::bind(const char *address, uint16_t port)
+{
+    struct sockaddr_in sockaddr;
+    make_sockaddr(address, port, sockaddr);
+
+    if (::bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
+        return false;
+    }
+    return true;
+}
+
+
+/*
+  set SO_REUSEADDR
+ */
+bool SocketExample::reuseaddress(void) const
+{
+    int one = 1;
+    return (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != -1);
+}
+
+/*
+  set blocking state
+ */
+bool SocketExample::set_blocking(bool blocking) const
+{
+    int fcntl_ret;
+    if (blocking) {
+        fcntl_ret = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~O_NONBLOCK);
+    } else {
+        fcntl_ret = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
+    }
+    return fcntl_ret != -1;
+}
+
+/*
+  set cloexec state
+ */
+bool SocketExample::set_cloexec() const
+{
+    return (fcntl(fd, F_SETFD, FD_CLOEXEC) != -1);
+}
+
+/*
+  send some data
+ */
+ssize_t SocketExample::send(const void *buf, size_t size) const
+{
+    return ::send(fd, buf, size, 0);
+}
+
+/*
+  send some data
+ */
+ssize_t SocketExample::sendto(const void *buf, size_t size, const char *address, uint16_t port)
+{
+    struct sockaddr_in sockaddr;
+    make_sockaddr(address, port, sockaddr);
+    return ::sendto(fd, buf, size, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+}
+
+/*
+  receive some data
+ */
+ssize_t SocketExample::recv(void *buf, size_t size, uint32_t timeout_ms)
+{
+    if (!pollin(timeout_ms)) {
+        return -1;
+    }
+    socklen_t len = sizeof(in_addr);
+    return ::recvfrom(fd, buf, size, MSG_DONTWAIT, (sockaddr *)&in_addr, &len);
+}
+
+/*
+  return the IP address and port of the last received packet
+ */
+void SocketExample::last_recv_address(const char *&ip_addr, uint16_t &port) const
+{
+    ip_addr = inet_ntoa(in_addr.sin_addr);
+    port = ntohs(in_addr.sin_port);
+}
+
+void SocketExample::set_broadcast(void) const
+{
+    int one = 1;
+    setsockopt(fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
+}
+
+/*
+  return true if there is pending data for input
+ */
+bool SocketExample::pollin(uint32_t timeout_ms)
+{
+    fd_set fds;
+    struct timeval tv;
+
+    FD_ZERO(&fds);
+    FD_SET(fd, &fds);
+
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000UL;
+
+    if (select(fd+1, &fds, nullptr, nullptr, &tv) != 1) {
+        return false;
+    }
+    return true;
+}
+
+
+/*
+  return true if there is room for output data
+ */
+bool SocketExample::pollout(uint32_t timeout_ms)
+{
+    fd_set fds;
+    struct timeval tv;
+
+    FD_ZERO(&fds);
+    FD_SET(fd, &fds);
+
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000UL;
+
+    if (select(fd+1, nullptr, &fds, nullptr, &tv) != 1) {
+        return false;
+    }
+    return true;
+}
+
+/* 
+   start listening for new tcp connections
+ */
+bool SocketExample::listen(uint16_t backlog) const
+{
+    return ::listen(fd, (int)backlog) == 0;
+}
+
+/*
+  accept a new connection. Only valid for TCP connections after
+  listen has been used. A new socket is returned
+*/
+SocketExample *SocketExample::accept(uint32_t timeout_ms)
+{
+    if (!pollin(timeout_ms)) {
+        return nullptr;
+    }
+
+    int newfd = ::accept(fd, nullptr, nullptr);
+    if (newfd == -1) {
+        return nullptr;
+    }
+    // turn off nagle for lower latency
+    int one = 1;
+    setsockopt(newfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+    return new SocketExample(false, newfd);
+}

--- a/libraries/SITL/examples/JSON/C++/SocketExample.h
+++ b/libraries/SITL/examples/JSON/C++/SocketExample.h
@@ -1,0 +1,71 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple socket handling class for systems with BSD socket API
+ */
+#pragma once
+
+#include <cstring>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <sys/select.h>
+
+class SocketExample {
+public:
+    SocketExample(bool _datagram);
+    SocketExample(bool _datagram, int _fd);
+    ~SocketExample();
+
+    bool connect(const char *address, uint16_t port);
+    bool bind(const char *address, uint16_t port);
+    bool reuseaddress() const;
+    bool set_blocking(bool blocking) const;
+    bool set_cloexec() const;
+    void set_broadcast(void) const;
+
+    ssize_t send(const void *pkt, size_t size) const;
+    ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
+    ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
+
+    // return the IP address and port of the last received packet
+    void last_recv_address(const char *&ip_addr, uint16_t &port) const;
+
+    // return true if there is pending data for input
+    bool pollin(uint32_t timeout_ms);
+
+    // return true if there is room for output data
+    bool pollout(uint32_t timeout_ms);
+
+    // start listening for new tcp connections
+    bool listen(uint16_t backlog) const;
+
+    // accept a new connection. Only valid for TCP connections after
+    // listen has been used. A new socket is returned
+    SocketExample *accept(uint32_t timeout_ms);
+
+private:
+    bool datagram;
+    struct sockaddr_in in_addr {};
+
+    int fd = -1;
+
+    void make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr);
+};

--- a/libraries/SITL/examples/JSON/C++/libAP_JSON.cpp
+++ b/libraries/SITL/examples/JSON/C++/libAP_JSON.cpp
@@ -1,0 +1,241 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * Adapted from Pierre Kancir's ArduPilot plugin for Gazebo
+ */
+
+#include "libAP_JSON.h"
+
+#define DEBUG_ENABLED 0
+
+// SITL JSON interface supplies 16 servo channels
+#define MAX_SERVO_CHANNELS 16
+
+// The servo packet received from ArduPilot SITL. Defined in SIM_JSON.h.
+struct servo_packet {
+    uint16_t magic; // 18458 expected magic value
+    uint16_t frame_rate;
+    uint32_t frame_count;
+    uint16_t pwm[16];
+};
+
+bool libAP_JSON::InitSockets(const char *fdm_address, const uint16_t fdm_port_in) {
+    // configure port
+    sock.set_blocking(false);
+    sock.reuseaddress();
+
+    // bind the socket
+    if (!sock.bind(fdm_address, fdm_port_in))
+    {
+        std::cout << "[libAP_JSON] " << "failed to bind with "
+                  << fdm_address << ":" << fdm_port_in << std::endl;
+        return false;
+    }
+    std::cout << "[libAP_JSON] " << "flight dynamics model at "
+              << fdm_address << ":" << fdm_port_in << std::endl;
+    return true;
+}
+
+bool libAP_JSON::ReceiveServoPacket(uint16_t servo_out[]) {
+    // Added detection for whether ArduPilot is online or not.
+    // If ArduPilot is detected (receive of fdm packet from someone),
+    // then socket receive wait time is increased from 1ms to 1 sec
+    // to accommodate network jitter.
+    // If ArduPilot is not detected, receive call blocks for 1ms
+    // on each call.
+    // Once ArduPilot presence is detected, it takes this many
+    // missed receives before declaring the FCS offline.
+
+    uint32_t waitMs;
+    if (ap_online) {
+        // Increase timeout for recv once we detect a packet from ArduPilot FCS.
+        // If this value is too high then it will block the main Gazebo update loop
+        // and adversely affect the RTF.
+        waitMs = 10;
+    } else {
+        // Otherwise skip quickly and do not set control force.
+        waitMs = 1;
+    }
+
+    servo_packet pkt;
+    auto recvSize = sock.recv(&pkt, sizeof(servo_packet), waitMs);
+    // libAP_JSON::fcu_address = fcu_address;
+    // libAP_JSON::fcu_port_out = fcu_port_out;
+
+    sock.last_recv_address(fcu_address, fcu_port_out);
+
+    // drain the socket in the case we're backed up
+    int counter = 0;
+    while (true) {
+        servo_packet last_pkt;
+        auto recvSize_last = sock.recv(&last_pkt, sizeof(servo_packet), 0ul);
+        if (recvSize_last == -1) {
+            break;
+        }
+        counter++;
+        pkt = last_pkt;
+        recvSize = recvSize_last;
+    }
+    if (counter > 0) {
+        std::cout << "[libAP_JSON] " << "Drained n packets: " << counter << std::endl;
+    }
+
+    // didn't receive a packet, increment timeout count if online, then return
+    if (recvSize == -1) {
+        if (ap_online) {
+            if (++connectionTimeoutCount > connectionTimeoutMaxCount) {
+                connectionTimeoutCount = 0;
+                ap_online = false;
+                std::cout << "[libAP_JSON] " << "Broken ArduPilot connection (no packets received)" << std::endl;
+            }
+        }
+        return false;
+    }
+
+#if DEBUG_ENABLED
+    // debug: inspect SITL packet
+    std::cout << "recv " << recvSize << " bytes from " << fcu_address << ":" << fcu_port_out << "\n";
+    std::cout << "magic: " << pkt.magic << "\n";
+    std::cout << "frame_rate: " << pkt.frame_rate << "\n";
+    std::cout << "frame_count: " << pkt.frame_count << "\n";
+    std::cout << "pwm: [";
+    for (auto i = 0; i < MAX_SERVO_CHANNELS - 1; ++i) {
+        std::cout << pkt.pwm[i] << ", ";
+    }
+    std::cout << pkt.pwm[MAX_SERVO_CHANNELS - 1] << "]\n";
+    std::cout << "\n";
+#endif
+
+    // check magic, return if invalid
+    const uint16_t magic = 18458;
+    if (magic != pkt.magic) {
+        std::cout << "[libAP_JSON] Incorrect protocol magic " << pkt.magic << " should be " << magic << "\n";
+        return false;
+    }
+
+    // check frame rate and frame order
+    fcu_frame_rate = pkt.frame_rate;
+    if (pkt.frame_count < fcu_frame_count) {
+        // @TODO - implement re-initialisation
+        std::cout << "[libAP_JSON] ArduPilot controller has reset\n";
+    }
+    else if (pkt.frame_count == fcu_frame_count) {
+        // received duplicate frame, skip
+        std::cout << "[libAP_JSON] Duplicate input frame count" << fcu_frame_count << "\n";
+        return false;
+    }
+    else if (pkt.frame_count != fcu_frame_count + 1 && ap_online) {
+        // missed frames, warn only
+        std::cout << "[libAP_JSON] Missed " << fcu_frame_count - pkt.frame_count << " input frames\n";
+    }
+    fcu_frame_count = pkt.frame_count;
+
+    // always reset the connection timeout so we don't accumulate
+    connectionTimeoutCount = 0;
+    if (!ap_online) {
+        ap_online = true;
+
+        std::cout << "[libAP_JSON] " << "Connected to ArduPilot controller @ "
+                  << fcu_address << ":" << fcu_port_out << "\n";
+    }
+
+    for (int i = 0; i < MAX_SERVO_CHANNELS - 1; i++) {
+        servo_out[i] = pkt.pwm[i];
+    }
+
+    return true;
+}
+
+void libAP_JSON::SendState(double timestamp, // seconds
+                           double gyro_x, double gyro_y, double gyro_z, // rad/sec
+                           double accel_x, double accel_y, double accel_z, // m/s^2
+                           double pos_x, double pos_y, double pos_z, // m in inertial frame
+                           double phi, double theta, double psi, // attitude radians
+                           double V_x, double V_y, double V_z) // m/s (standard fixed wing frame is negative)
+{
+    // it is assumed that the imu orientation is NED, i.e.:
+    //   x forward
+    //   y right
+    //   z down
+
+    // Example ArduPilot JSON interface messages. Preceed and terminate with \n
+    // {"timestamp":2500,"imu":{"gyro":[0,0,0],"accel_body":[0,0,0]},"position":[0,0,0],"attitude":[0,0,0],"velocity":[0,0,0]}
+
+    // using namespace rapidjson;
+
+    // build JSON string
+    // all the required pieces first
+    std::string s =  "\n{\"timestamp\":" + std::to_string(timestamp)
+                    + ",\"imu\":{"
+                        + "\"gyro\":[" + std::to_string(gyro_x) + "," + std::to_string(gyro_y) + "," + std::to_string(gyro_z) + "]"
+                        + ",\"accel_body\":[" + std::to_string(accel_x) + "," + std::to_string(accel_y) + "," + std::to_string(accel_z) + "]"
+                        + "}"
+                    + ",\"position\":[" + std::to_string(pos_x) + "," + std::to_string(pos_y) + "," + std::to_string(pos_z) + "]"
+                    + ",\"attitude\":[" + std::to_string(phi) + "," + std::to_string(theta) + "," + std::to_string(psi) + "]"
+                    + ",\"velocity\":[" + std::to_string(V_x) + "," + std::to_string(V_y) + "," + std::to_string(V_z) + "]";
+    
+    // handle the optional JSON data
+    if (set_airspeed_flag) {
+        s = s + ",\"airspeed\":" + std::to_string(airspeed);
+    }
+    if (set_windvane_flag) {
+        s = s + ",\"windvane\":{\"direction\":" + std::to_string(windvane_direction) + ",\"speed\":" + std::to_string(windvane_speed) + "}";
+    }
+    if (rangefinder_count > 0) {
+        for (int i = 0; i < rangefinder_count; i++) {
+            // rangefinder data is 1 indexed
+            s = s + ",\"rng_" + std::to_string(i + 1) + "\":" + std::to_string(rangefinder[i]);
+        }
+    }
+
+    s = s + "}\n"; // close the JSON
+    
+    // send JSON string to ArduPilot
+    auto bytes_sent = sock.sendto(
+        s.c_str(), s.size(),
+        fcu_address,
+        fcu_port_out);
+
+#if DEBUG_ENABLED
+    std::cout << s << std::endl;
+#endif
+}
+
+void libAP_JSON::setAirspeed(double airspeed_in)
+{
+    airspeed = airspeed_in;
+    set_airspeed_flag = true;
+}
+
+void libAP_JSON::setWindvane(double direction, double speed)
+{
+    windvane_direction = direction;
+    windvane_speed = speed;
+    set_windvane_flag = true;
+}
+
+void libAP_JSON::setRangefinder(double *rangefinder_in, uint8_t n)
+{
+    if (n <= 6) {
+        rangefinder_count = n;
+        for (int i = 0; i < n; i++) {
+            rangefinder[i] = rangefinder_in[i];
+        }
+    } else {
+        std::cout << "[libAP_JSON] Too many rangerfinder values!" << std::endl;
+    }
+}

--- a/libraries/SITL/examples/JSON/C++/libAP_JSON.h
+++ b/libraries/SITL/examples/JSON/C++/libAP_JSON.h
@@ -1,0 +1,73 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <iostream>
+#include <string>
+
+#include "SocketExample.cpp"
+
+class libAP_JSON {
+public:
+    bool InitSockets(const char *fdm_address, const uint16_t fdm_port_in);
+    bool ReceiveServoPacket(uint16_t servo_out[]);
+    void SendState(double timestamp,
+                   double gyro_x, double gyro_y, double gyro_z, // rad/sec
+                   double accel_x, double accel_y, double accel_z, // m/s^2
+                   double pos_x, double pos_y, double pos_z, // m in inertial frame
+                   double phi, double theta, double psi, // attitude radians
+                   double V_x, double V_y, double V_z); // m/s in inertial frame
+    void setAirspeed(double airspeed_in); // m/s
+    void setWindvane(double direction, // radians clockwise to the front (0 is head to wind)
+                     double speed); // m/s
+    void setRangefinder(double *rangefinder_in, uint8_t n);
+    bool ap_online;
+private:
+    // Socket manager
+    SocketExample sock = SocketExample(true);
+
+    // The address for the flight dynamics model
+    // const char *libAP_JSON::fdm_address;
+
+    // The address for the SITL flight controller - auto detected
+    const char *fcu_address;
+
+    // The port for the flight dynamics model
+    // uint16_t libAP_JSON::fdm_port_in;
+
+    // The port for the SITL flight controller - auto detected
+    uint16_t fcu_port_out;
+
+    // Number of consecutive missed ArduPilot controller messages
+    int connectionTimeoutCount;
+
+    // Max number of consecutive missed ArduPilot controller messages before timeout
+    int connectionTimeoutMaxCount = 10;
+
+    // Last received frame rate from the ArduPilot controller
+    uint16_t fcu_frame_rate;
+
+    // Last received frame count from the ArduPilot controller
+    uint32_t fcu_frame_count = -1;
+
+    // optional JSON data
+    double airspeed;
+    bool set_airspeed_flag = false;
+    double windvane_direction;
+    double windvane_speed;
+    bool set_windvane_flag = false;
+    double rangefinder[6];
+    uint8_t rangefinder_count = 0;
+};

--- a/libraries/SITL/examples/JSON/C++/minimal.cpp
+++ b/libraries/SITL/examples/JSON/C++/minimal.cpp
@@ -1,0 +1,81 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// This is very minimal example of using libAP_JSON to send simulator data to ArduPilot SITL
+
+#include <time.h>
+#include <chrono>
+#include <stdlib.h>
+
+#include "libAP_JSON.cpp"
+
+uint16_t servo_out[16];
+
+uint64_t micros() {
+    uint64_t us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::
+                  now().time_since_epoch()).count();
+    return us; 
+}
+
+int main() {
+    // init the ArduPilot connection
+    libAP_JSON ap;
+    if (ap.InitSockets("127.0.0.1", 9002))
+    {
+        std::cout << "started socket" << std::endl;
+    }
+
+    // send and receive data from AP
+    while (true)
+    {
+        double timestamp = (double) micros() / 1000000.0;
+
+        if (ap.ReceiveServoPacket(servo_out))
+        {
+#if DEBUG_ENABLED
+            std::cout << "servo_out PWM: [";
+            for (int i = 0; i < MAX_SERVO_CHANNELS - 1; ++i)
+            {
+                std::cout << servo_out[i] << ", ";
+            }
+            std::cout << servo_out[MAX_SERVO_CHANNELS - 1] << "]" << std::endl;
+#endif
+        }
+
+        if (!ap.ap_online) {
+            continue;
+        }
+
+        // example rangefinder data
+        double rangefinder_example[] = {1, 2, 3, 4, 5, 6};
+
+        // set the optionals
+        ap.setAirspeed(1);
+        ap.setWindvane(1 , 1);
+        ap.setRangefinder(rangefinder_example, 6);
+
+        // send with the required
+        ap.SendState(timestamp,
+                     0, 0, 0,    // gyro
+                     0, 0, -9.81, // accel
+                     0, 0, 0,    // position
+                     0, 0, 0,    // attitude
+                     0, 0, 0);    // velocity
+
+        usleep(1000); // run this example at about 1000 Hz. Realistically it is about 800 Hz.
+    }
+    return 0;
+}

--- a/libraries/SITL/examples/JSON/C++/readme.md
+++ b/libraries/SITL/examples/JSON/C++/readme.md
@@ -1,0 +1,7 @@
+# C++
+
+This library links a simulator written in C++ with ArduPilot through a UDP JSON interface. This simplifies adding support for ArduPilot to a simulator. A minimal example is included in `minimal.cpp`. This can be built-in Linux with the command `g++ minimal.cpp -o minimal.o`. The minimal example shows how each method in the library is used and can be used to test the library as well. The `simpleRover.cpp` example is a 1-D model of a rover that shows how a physics model can be integrated with this library.
+
+Connection to SITL is made via a UDP link. The physics backend should listen for incoming messages on port 9002. The sim should then reply to the IP and port the messages were received from. This is handled by libAP_JSON. This removes the need to configure the target IP and port for SITL in the physics backend. ArduPilot SITL will send an output message every 10 seconds allowing the physics backend to auto-detect.
+
+After a connection has been made, the optional values should be set. Then the vehicle state can be sent with `SendState`. This call includes all of the required values. The `servo_out` array supports 16 servo outputs from ArduPilot.

--- a/libraries/SITL/examples/JSON/C++/simpleRover.cpp
+++ b/libraries/SITL/examples/JSON/C++/simpleRover.cpp
@@ -1,0 +1,135 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// This is a very simple 1-D rover model using libAP_JSON for C++
+
+#include <math.h>
+#include <time.h>
+#include <chrono>
+#include <stdlib.h>
+
+#include "libAP_JSON.cpp"
+#include "simpleRover.h"
+
+uint16_t servo_out[16];
+
+uint64_t micros() {
+    uint64_t us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::
+                  now().time_since_epoch()).count();
+    return us; 
+}
+
+bool simpleRover::update(simpleRover &rover, uint16_t servo_out[]) {
+    // returns true is the update went well. false means something went wrong and the physics model should exit
+    // this is main portion of the physics
+
+    // ideal vehicle model
+    /* servos are defined as
+        1. throttle (really just velocity control)
+        2. steering (really just turn rate omega)
+     */
+
+    double timestep = rover.state.timestamp - rover.old_state.timestamp;
+    if (timestep < 0) {
+        // the sim is trying to go backwards in time
+        std::cout << "[simpleRover] Error: Time went backwards" << std::endl;
+        return false;
+    } else if (timestep == 0) {
+        // time did not advance. no physics step
+        std::cout << "[simpleRover] Warning: Time did not step forward" << std::endl;
+        return true;
+    } else if (timestep > 60) {
+        // limiting timestep to less than 1 minute
+        std::cout << "[simpleRover] Warning: Time step was very large" << std::endl;
+        return true;
+    }
+
+    // how fast is the rover moving
+    double max_velocity = 1; // m/s
+    double body_v = _interp1D(servo_out[0], 1100, 1900, 0, max_velocity);
+
+    // how fast is the rover turning
+    // Just doing 1-D right now. This Needs a bit of system dynamics math and geometry to get to 2-D.
+    // double max_turn_rate = 5 * M_PI / 180;
+    // double body_omega_z = _interp1D(servo_out[1], 1100, 1900, -max_turn_rate, max_turn_rate);
+
+    // update the state
+    rover.state.V_x = body_v;
+    rover.state.accel_x = (rover.state.V_x - rover.old_state.V_x) / timestep; // derivative for accel
+    double delta_pos_x = (rover.state.V_x) * timestep; // integrate for position change
+    rover.state.pos_x = delta_pos_x + rover.old_state.pos_x; // plus c
+
+    // update successful
+    return true;
+}
+
+int main() {
+    // init the ArduPilot connection
+    libAP_JSON ap;
+    if (ap.InitSockets("127.0.0.1", 9002))
+    {
+        std::cout << "started socket" << std::endl;
+    }
+
+    // init a simpleRover
+    simpleRover rover;
+
+    // send and receive data from AP
+    while (true)
+    {
+        rover.state.timestamp = (double) micros() / 1000000.0;
+
+        if (ap.ReceiveServoPacket(servo_out))
+        {
+#if DEBUG_ENABLED
+            std::cout << "servo_out PWM: [";
+            for (int i = 0; i < MAX_SERVO_CHANNELS - 1; ++i)
+            {
+                std::cout << servo_out[i] << ", ";
+            }
+            std::cout << servo_out[MAX_SERVO_CHANNELS - 1] << "]" << std::endl;
+#endif
+        }
+
+        if (!ap.ap_online) {
+            continue;
+        }
+
+        // calc rover physics
+        if (!rover.update(rover, servo_out)) {
+            // something went wrong with the physics
+            std::cout << "[simpleRover] Error: Physics update has caused an exit" << std::endl;
+            return 1;
+        };
+
+        // step the sim forward
+        rover.old_state = rover.state;
+
+        // send with the required state
+        ap.SendState(rover.state.timestamp,
+                     0, 0, 0,    // gyro
+                     rover.state.accel_x, 0, -9.81, // accel
+                     rover.state.pos_x, 0, 0,    // position
+                     0, 0, 0,    // attitude
+                     rover.state.V_x, 0, 0);    // velocity
+    }
+    return 0;
+}
+
+double simpleRover::_interp1D(const double &x, const double &x0, const double &x1, const double &y0, const double &y1)
+{
+    return ((y0 * (x1 - x)) + (y1 * (x - x0))) / (x1 - x0);
+}

--- a/libraries/SITL/examples/JSON/C++/simpleRover.h
+++ b/libraries/SITL/examples/JSON/C++/simpleRover.h
@@ -1,0 +1,31 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class simpleRover {
+public:
+    struct simpleRoverState {
+        double timestamp = 0;
+        double gyro_x, gyro_y, gyro_z = 0; // rad/sec
+        double accel_x, accel_y, accel_z = 0; // m/s^2
+        double pos_x, pos_y, pos_z = 0; // m in inertial frame
+        double phi, theta, psi = 0; // attitude radians
+        double V_x, V_y, V_z = 0; // m/s in inertial frame
+    } state, old_state;
+
+    bool update(simpleRover &rover, uint16_t servo_out[]);
+private:
+    double _interp1D(const double &x, const double &x0, const double &x1, const double &y0, const double &y1);
+};


### PR DESCRIPTION
We were working on creating a simulator from scratch to meet some specific needs and I realized there wasn't a plug-and-play way to add support for ArduPilot to a new sim. This is probably trivial for most, but I found this to be very useful for my work.

Right now this code is not the best and naming is open for suggestions. Ideally, there would be a proper way to change what pieces of JSON data to send to ArduPilot, but I am not sure if that should be done with API methods with default value NULL values and several statements similar to `if airseed is not None`. I know in Python I would use optional arguments, but I'm not sure what something similar would look like here.