### PR TITLE
GCS_MAVLink: set message intervals from config files

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -246,6 +246,23 @@ FileData *AP_Filesystem::load_file(const char *filename)
     return backend.fs.load_file(filename);
 }
 
+// returns null-terminated string; cr or lf terminates line
+bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
+{
+    const Backend &backend = backend_by_fd(fd);
+
+    uint8_t i = 0;
+    for (; i<buflen-1; i++) {
+        if (backend.fs.read(fd, &buf[i], 1) != 1) {
+            break;
+        }
+        if (buf[i] == '\r' || buf[i] == '\n') {
+            break;
+        }
+    }
+    buf[i] = '\0';
+    return i != 0;
+}
 
 namespace AP
 {

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -89,6 +89,9 @@ public:
     // unmount filesystem for reboot
     void unmount(void);
 
+    // returns null-terminated string; cr or lf terminates line
+    bool fgets(char *buf, uint8_t buflen, int fd);
+
     /*
       load a full file. Use delete to free the data
      */

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -39,6 +39,10 @@
 #define HAL_HIGH_LATENCY2_ENABLED !HAL_MINIMIZE_FEATURES
 #endif
 
+#ifndef HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED
+#define HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED (HAVE_FILESYSTEM_SUPPORT && BOARD_FLASH_SIZE > 1024)
+#endif
+
 // macros used to determine if a message will fit in the space available.
 
 void gcs_out_of_space_to_send_count(mavlink_channel_t chan);
@@ -95,6 +99,37 @@ public:
     // saveable rate of each stream
     AP_Int16        streamRates[GCS_MAVLINK_NUM_STREAM_RATES];
 };
+
+#if HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED
+class DefaultIntervalsFromFiles
+{
+
+public:
+
+    DefaultIntervalsFromFiles(uint16_t max_num);
+    ~DefaultIntervalsFromFiles();
+
+    void set(ap_message id, uint16_t interval);
+    uint16_t num_intervals() const {
+        return _num_intervals;
+    }
+    bool get_interval_for_ap_message_id(ap_message id, uint16_t &interval) const;
+    ap_message id_at(uint8_t ofs) const;
+    uint16_t interval_at(uint8_t ofs) const;
+
+private:
+
+    struct from_file_default_interval {
+        ap_message id;
+        uint16_t interval;
+    };
+
+    from_file_default_interval *_intervals;
+
+    uint16_t _num_intervals;
+    uint16_t _max_intervals;
+};
+#endif
 
 ///
 /// @class	GCS_MAVLINK
@@ -682,6 +717,13 @@ private:
     // boolean that indicated that message intervals have been set
     // from streamrates:
     bool deferred_messages_initialised;
+#if HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED
+    // read configuration files from (e.g.) SD and ROMFS, set
+    // intervals from same
+    void initialise_message_intervals_from_config_files();
+    // read file, set message intervals from it:
+    void get_intervals_from_filepath(const char *path, DefaultIntervalsFromFiles &);
+#endif
     // return interval deferred message bucket should be sent after.
     // When sending parameters and waypoints this may be longer than
     // the interval specified in "deferred"
@@ -843,6 +885,12 @@ private:
     void load_signing_key(void);
     bool signing_enabled(void) const;
     static void save_signing_timestamp(bool force_save_now);
+
+#if HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED
+    // structure containing default intervals read from files for this
+    // link:
+    DefaultIntervalsFromFiles *default_intervals_from_files;
+#endif
 
     // alternative protocol handler support
     struct {


### PR DESCRIPTION
At startup, each GCS_MAVLink object will look for files corresponding to its channel number.  For example, channel 0 will look for `@ROMFS/message-intervals-chan0.txt` and `message-intervals-chan0.txt`.

The numbers become channel defaults - which is to say if you set the message interval via mavlink and then say "reset to default" using mavlink it will take the value taken from these files by preference (then from the stored stream rates).

This is an alternative to writing a script to accomplish the same thing.  It has the advantage that no messages will be sent until this has been read, which could be important for some links.

File format is simply `mavlink-message-id interval`:

```
pbarker@bluebottle:~/rc/ardupilot(pr/stream-intervals-from-filepath)$ cat message-intervals-chan0.txt 
30 50
29 200
pbarker@bluebottle:~/rc/ardupilot(pr/stream-intervals-from-filepath)$ 
```

```
STABILIZE> messagerate status
STABILIZE> ATTITUDE: 20.2/s
HEARTBEAT: 1.0/s
SCALED_PRESSURE: 5.0/s
TIMESYNC: 0.2/s
```

I considered Hz instead.  I really did.
