### PR TITLE
Copter: fix AHRS and VisualOdom pre-arm attitude consistency checks

### DIFF
--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -692,3 +692,22 @@ Quaternion Quaternion::angular_difference(const Quaternion &v) const
 {
     return v.inverse() * *this;
 }
+
+// absolute (e.g. always positive) earth-frame roll-pitch difference (in radians) between this Quaternion and another
+float Quaternion::roll_pitch_difference(const Quaternion &v) const
+{
+    // convert Quaternions to rotation matrices
+    Matrix3f m, vm;
+    rotation_matrix(m);
+    v.rotation_matrix(vm);
+
+    // rotate earth frame vertical vector by each rotation matrix
+    const Vector3f z_unit_vec{0,0,1};
+    const Vector3f z_unit_m = m.mul_transpose(z_unit_vec);
+    const Vector3f z_unit_vm = vm.mul_transpose(z_unit_vec);
+    const Vector3f vec_diff = z_unit_vm - z_unit_m;
+    const float vec_len_div2 = constrain_float(vec_diff.length() * 0.5f, 0.0f, 1.0f);
+
+    // calculate and return angular difference
+    return (2.0f * asinf(vec_len_div2));
+}

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -171,4 +171,7 @@ public:
 
     // angular difference between quaternions
     Quaternion angular_difference(const Quaternion &v) const;
+
+    // absolute (e.g. always positive) earth-frame roll-pitch difference (in radians) between this Quaternion and another
+    float roll_pitch_difference(const Quaternion &v) const;
 };

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -237,18 +237,16 @@ bool AP_VisualOdom_IntelT265::pre_arm_check(char *failure_msg, uint8_t failure_m
         return false;
     }
 
-    // get angular difference between AHRS and camera attitude
-    Vector3f angle_diff;
-    _attitude_last.angular_difference(ahrs_quat).to_axis_angle(angle_diff);
-
     // check if roll and pitch is different by > 10deg (using NED so cannot determine whether roll or pitch specifically)
-    const float rp_diff_deg = degrees(safe_sqrt(sq(angle_diff.x)+sq(angle_diff.y)));
+    const float rp_diff_deg = degrees(ahrs_quat.roll_pitch_difference(_attitude_last));
     if (rp_diff_deg > 10.0f) {
         hal.util->snprintf(failure_msg, failure_msg_len, "roll/pitch diff %4.1f deg (>10)",(double)rp_diff_deg);
         return false;
     }
 
     // check if yaw is different by > 10deg
+    Vector3f angle_diff;
+    ahrs_quat.angular_difference(_attitude_last).to_axis_angle(angle_diff);
     const float yaw_diff_deg = degrees(fabsf(angle_diff.z));
     if (yaw_diff_deg > 10.0f) {
         hal.util->snprintf(failure_msg, failure_msg_len, "yaw diff %4.1f deg (>10)",(double)yaw_diff_deg);


### PR DESCRIPTION
This PR fixes two similar pre-arm attitude consistency checks, one in AP_AHRS and another in AP_VisualOdom.

The issue was that the roll, pitch angle comparison was failing and alerting the user when in fact, it was the yaw that was different. This was especially troublesome in cases where we only want to compare roll and pitch (and not yaw) for example when using external nav for yaw across DCM and EKF3.

This has been tested in SITL and on a real board.

Resolves issue https://github.com/ArduPilot/ardupilot/issues/17442