### PR TITLE
HAL_ChibiOS: fixed order and labelling of @SYS/uarts.txt

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -5,6 +5,8 @@
 #include "AP_HAL_Namespace.h"
 #include "utility/BetterStream.h"
 
+class ExpandingString;
+
 /* Pure virtual UARTDriver class */
 class AP_HAL::UARTDriver : public AP_HAL::BetterStream {
 public:
@@ -124,4 +126,7 @@ public:
       return true if this UART has DMA enabled on both RX and TX
      */
     virtual bool is_dma_enabled() const { return false; }
+
+    // request information on uart I/O for this uart, for @SYS/uarts.txt
+    virtual void uart_info(ExpandingString &str) {}
 };

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1678,15 +1678,15 @@ void UARTDriver::uart_info(ExpandingString &str)
     str.printf("UARTV1\n");
 
     uint32_t now_ms = AP_HAL::millis();
-    for (uint8_t i = 0; i < UART_MAX_DRIVERS; i++) {
-        UARTDriver* uart = uart_drivers[i];
+    for (uint8_t i = 0; i < HAL_UART_NUM_SERIAL_PORTS; i++) {
+        UARTDriver* uart = (UARTDriver *)hal.serial(i);
 
         if (uart == nullptr || uart->uart_thread_ctx == nullptr) {
             continue;
         }
 
-        const char* fmt = "%-8s TX%c=%8u RX%c=%8u TXBD=%6u RXBD=%6u\n";
-        str.printf(fmt, uart->uart_thread_name, uart->tx_dma_enabled ? '*' : ' ', uart->_tx_stats_bytes,
+        const char* fmt = "SERIAL%u %-5s TX%c=%8u RX%c=%8u TXBD=%6u RXBD=%6u\n";
+        str.printf(fmt, i, uart->uart_thread_name, uart->tx_dma_enabled ? '*' : ' ', uart->_tx_stats_bytes,
             uart->rx_dma_enabled ? '*' : ' ', uart->_rx_stats_bytes,
             uart->_tx_stats_bytes * 10000 / (now_ms - _last_stats_ms), uart->_rx_stats_bytes * 10000 / (now_ms - _last_stats_ms));
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1673,8 +1673,12 @@ uint8_t UARTDriver::get_options(void) const
 void UARTDriver::uart_info(ExpandingString &str)
 {
     uint32_t now_ms = AP_HAL::millis();
-    str.printf("%-5s TX%c=%8u RX%c=%8u TXBD=%6u RXBD=%6u\n",
-               uart_thread_name,
+    if (sdef.is_usb) {
+        str.printf("OTG%u  ", unsigned(sdef.instance));
+    } else {
+        str.printf("UART%u ", unsigned(sdef.instance));
+    }
+    str.printf("TX%c=%8u RX%c=%8u TXBD=%6u RXBD=%6u\n",
                tx_dma_enabled ? '*' : ' ',
                unsigned(_tx_stats_bytes),
                rx_dma_enabled ? '*' : ' ',

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -128,8 +128,9 @@ public:
         }
         return _baudrate/(9*1024);
     }
-    // request information on uart I/O
-    static void uart_info(ExpandingString &str);
+
+    // request information on uart I/O for one uart
+    void uart_info(ExpandingString &str) override;
 
     /*
       return true if this UART has DMA enabled on both RX and TX
@@ -217,7 +218,7 @@ private:
     // statistics
     uint32_t _tx_stats_bytes;
     uint32_t _rx_stats_bytes;
-    static uint32_t _last_stats_ms;
+    uint32_t _last_stats_ms;
 
     // we remember config options from set_options to apply on sdStart()
     uint32_t _cr1_options;

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -576,10 +576,26 @@ void Util::apply_persistent_params(void) const
 }
 #endif // HAL_ENABLE_SAVE_PERSISTENT_PARAMS
 
+#if HAL_WITH_IO_MCU
+extern ChibiOS::UARTDriver uart_io;
+#endif
+
 // request information on uart I/O
 void Util::uart_info(ExpandingString &str)
 {
 #if !defined(HAL_NO_UARTDRIVER)    
-    ChibiOS::UARTDriver::uart_info(str);
+    // a header to allow for machine parsers to determine format
+    str.printf("UARTV1\n");
+    for (uint8_t i = 0; i < HAL_UART_NUM_SERIAL_PORTS; i++) {
+        auto *uart = hal.serial(i);
+        if (uart) {
+            str.printf("SERIAL%u ", i);
+            uart->uart_info(str);
+        }
+    }
+#if HAL_WITH_IO_MCU
+    str.printf("IOMCU   ");
+    uart_io.uart_info(str);
 #endif
+#endif // HAL_NO_UARTDRIVER
 }

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1199,12 +1199,11 @@ def write_UART_config(f):
     devnames = "ABCDEFGHI"
     sdev = 0
     idx = 0
-    num_empty_uarts = 0
     for dev in uart_list:
         if dev == 'EMPTY':
             f.write('#define HAL_UART%s_DRIVER Empty::UARTDriver uart%sDriver\n' %
                     (devnames[idx], devnames[idx]))
-            num_empty_uarts += 1
+            sdev += 1
         else:
             f.write(
                 '#define HAL_UART%s_DRIVER ChibiOS::UARTDriver uart%sDriver(%u)\n'
@@ -1242,6 +1241,7 @@ def write_UART_config(f):
         elif dev.startswith('OTG'):
             n = int(dev[3:])
         elif dev.startswith('EMPTY'):
+            devlist.append('{}')
             continue
         else:
             error("Invalid element %s in UART_ORDER" % dev)
@@ -1307,7 +1307,7 @@ def write_UART_config(f):
         num_uarts -= 1
     if num_uarts > 9:
         error("Exceeded max num UARTs of 9 (%u)" % num_uarts)
-    f.write('#define HAL_UART_NUM_SERIAL_PORTS %u\n' % (num_uarts+num_empty_uarts))
+    f.write('#define HAL_UART_NUM_SERIAL_PORTS %u\n' % num_uarts)
 
 
 def write_UART_config_bootloader(f):

--- a/libraries/AP_HAL_Empty/UARTDriver.cpp
+++ b/libraries/AP_HAL_Empty/UARTDriver.cpp
@@ -1,5 +1,6 @@
 
 #include "UARTDriver.h"
+#include <AP_Common/ExpandingString.h>
 
 Empty::UARTDriver::UARTDriver() {}
 
@@ -27,4 +28,9 @@ size_t Empty::UARTDriver::write(const uint8_t *buffer, size_t size)
         n += write(*buffer++);
     }
     return n;
+}
+
+void Empty::UARTDriver::uart_info(ExpandingString &str)
+{
+    str.printf("EMPTY\n");
 }

--- a/libraries/AP_HAL_Empty/UARTDriver.h
+++ b/libraries/AP_HAL_Empty/UARTDriver.h
@@ -23,4 +23,7 @@ public:
     /* Empty implementations of Print virtual methods */
     size_t write(uint8_t c) override;
     size_t write(const uint8_t *buffer, size_t size) override;
+
+    // request information on uart I/O for one uart
+    void uart_info(ExpandingString &str) override;
 };


### PR DESCRIPTION
this makes the uarts.txt display saner, for example on CubeOrange:

```
UARTV1
SERIAL0 OTG1  TX =   58797 RX =     826 TXBD= 20567 RXBD=   288
SERIAL1 UART2 TX*=     581 RX*=       0 TXBD=   203 RXBD=     0
SERIAL2 UART3 TX*=     581 RX*=       0 TXBD=   203 RXBD=     0
SERIAL3 UART4 TX*=    1843 RX =       0 TXBD=   644 RXBD=     0
SERIAL4 UART8 TX =       0 RX*=       0 TXBD=     0 RXBD=     0
SERIAL5 UART7 TX*=       0 RX*=       0 TXBD=     0 RXBD=     0
SERIAL6 OTG2  TX =       0 RX =       0 TXBD=     0 RXBD=     0
```

order is now correct, and SERIALn labelled.

this is WIP as I found an issue with boards that set one of the SERIAL_ORDER uarts to EMPTY. In that case we dereference the wrong class.
