### PR TITLE
AP_BatteryMoniter: fix mah to wh conversion, log in units people understand and log percentage

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -232,13 +232,13 @@ void AP_BattMonitor_Backend::check_failsafe_types(bool &low_voltage, bool &low_c
 bool AP_BattMonitor_Backend::reset_remaining(float percentage)
 {
     percentage = constrain_float(percentage, 0, 100);
-    const float used_proportion = (100 - percentage) * 0.01;
+    const float used_proportion = (100.0f - percentage) * 0.01f;
     _state.consumed_mah = used_proportion * _params._pack_capacity;
     // without knowing the history we can't do consumed_wh
     // accurately. Best estimate is based on current voltage. This
     // will be good when resetting the battery to a value close to
     // full charge
-    _state.consumed_wh = _state.consumed_mah * 1000 * _state.voltage;
+    _state.consumed_wh = _state.consumed_mah * 0.001f * _state.voltage;
 
     // reset failsafe state for this backend
     _state.failsafe = update_failsafes();

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Logging.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Logging.cpp
@@ -18,7 +18,8 @@ void AP_BattMonitor_Backend::Log_Write_BAT(const uint8_t instance, const uint64_
         current_total       : has_curr ? _state.consumed_mah : AP::logger().quiet_nanf(),
         consumed_wh         : has_curr ? _state.consumed_wh : AP::logger().quiet_nanf(),
         temperature         : (int16_t) ( has_temperature() ? _state.temperature * 100 : 0),
-        resistance          : _state.resistance
+        resistance          : _state.resistance,
+        rem_percent         : capacity_remaining_pct(),
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_BattMonitor/LogStructure.h
+++ b/libraries/AP_BattMonitor/LogStructure.h
@@ -13,10 +13,11 @@
 // @Field: Volt: measured voltage
 // @Field: VoltR: estimated resting voltage
 // @Field: Curr: measured current
-// @Field: CurrTot: current * time
-// @Field: EnrgTot: energy this battery has produced
+// @Field: CurrTot: consumed Ah, current * time
+// @Field: EnrgTot: consumed Wh, energy this battery has expended
 // @Field: Temp: measured temperature
 // @Field: Res: estimated battery resistance
+// @Field: RemPct: remaining percentage
 struct PACKED log_BAT {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -28,6 +29,7 @@ struct PACKED log_BAT {
     float    consumed_wh;
     int16_t  temperature; // degrees C * 100
     float    resistance;
+    uint8_t  rem_percent;
 };
 
 // @LoggerMessage: BCL
@@ -57,6 +59,6 @@ struct PACKED log_BCL {
 
 #define LOG_STRUCTURE_FROM_BATTMONITOR        \
     { LOG_BAT_MSG, sizeof(log_BAT), \
-        "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "s#vvAiJOw", "F-000!/?0" },  \
+        "BAT", "QBfffffcfB", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res,RemPct", "s#vvAaXOw%", "F-000C0?00" },  \
     { LOG_BCL_MSG, sizeof(log_BCL), \
         "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" },

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -73,7 +73,8 @@ const struct UnitStructure log_Units[] = {
     { 'v', "V" },             // Volt
     { 'P', "Pa" },            // Pascal
     { 'w', "Ohm" },           // Ohm
-    { 'W', "Watt" },        // Watt
+    { 'W', "Watt" },          // Watt
+    { 'X', "W.h" },           // Watt hour
     { 'Y', "us" },            // pulse width modulation in microseconds
     { 'z', "Hz" },            // Hertz
     { '#', "instance" }       // (e.g.)Sensor instance number

--- a/libraries/AP_Logger/README.md
+++ b/libraries/AP_Logger/README.md
@@ -71,6 +71,8 @@ Please keep the names consistent with Tools/autotest/param_metadata/param.py:33
 | 'v' | "V" | Volt|
 | 'P' | "Pa" | Pascal|
 | 'w' | "Ohm" | Ohm|
+| 'W' | "W" | watt |
+| 'X' | "W.h" | watt hour |
 | 'Y' | "us" | pulse width modulation in microseconds|
 | 'z' | "Hz" | Hertz|
 | '#' | "instance" | (e.g.)Sensor instance number|


### PR DESCRIPTION
Firstly this fixes the mah to wh conversion in the percentage reset code, currently it is 1,000,000 times out.

Secondly this converts the logging from `Ampere second` and `Joule` to `milliamp hour` and `watt hour`. I realize there not SI units, but:

1. People understand them
2. The params are in those units
3. The code is in those units

Finally this adds logging of the battery percentage. 
