### PR TITLE
Copter: Change the message level depending on whether GNSS is used or not

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -285,12 +285,13 @@ void Copter::gpsglitch_check()
     // log start or stop of gps glitch.  AP_Notify update is handled from within AP_AHRS
     if (ap.gps_glitching != gps_glitching) {
         ap.gps_glitching = gps_glitching;
+        MAV_SEVERITY level = flightmode->requires_GPS() ? MAV_SEVERITY_CRITICAL : MAV_SEVERITY_INFO;
         if (gps_glitching) {
             AP::logger().Write_Error(LogErrorSubsystem::GPS, LogErrorCode::GPS_GLITCH);
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"GPS Glitch");
+            gcs().send_text(level,"GPS Glitch");
         } else {
             AP::logger().Write_Error(LogErrorSubsystem::GPS, LogErrorCode::ERROR_RESOLVED);
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"GPS Glitch cleared");
+            gcs().send_text(level,"GPS Glitch cleared");
         }
     }
 }


### PR DESCRIPTION
QGC shows and hides voice notifications and pop-up messages on the screen at the message level.
I saw the GPS glitch message in the Mission Planner HUD while arming in stabilize mode.
I know that stabilize mode does not use GNSS.
I know that Stabilize mode does not use GNSS, so GPS glitching is not a critical error for flight modes that do not use GNSS.
I change the level of the message depending on whether GNSS is used or not.

AFTER:
![Screenshot from 2021-06-05 09-23-50](https://user-images.githubusercontent.com/646194/120874400-70759680-c5e1-11eb-9b13-152a1fcc7a53.png)
