### PR TITLE
Plane: tailsitter: increase severity level of failed transisisons

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -248,11 +248,11 @@ bool QuadPlane::tailsitter_transition_fw_complete(void)
         return true;
     }
     if (labs(ahrs_view->roll_sensor) > MAX(4500, plane.roll_limit_cd + 500)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Transition FW done, roll error");
+        gcs().send_text(MAV_SEVERITY_WARNING, "Transition FW done, roll error");
         return true;
     }
     if (AP_HAL::millis() - transition_start_ms > ((tailsitter.transition_angle_fw+(transition_initial_pitch*0.01f))/tailsitter.transition_rate_fw)*1500) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Transition FW done, timeout");
+        gcs().send_text(MAV_SEVERITY_WARNING, "Transition FW done, timeout");
         return true;
     }
     // still waiting
@@ -291,11 +291,11 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
         roll_cd = 18000 - roll_cd;
     }
     if (roll_cd > MAX(4500, plane.roll_limit_cd + 500)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done, roll error");
+        gcs().send_text(MAV_SEVERITY_WARNING, "Transition VTOL done, roll error");
         return true;
     }
     if (AP_HAL::millis() - transition_start_ms >  ((trans_angle-(transition_initial_pitch*0.01f))/tailsitter.transition_rate_vtol)*1500) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done, timeout");
+        gcs().send_text(MAV_SEVERITY_WARNING, "Transition VTOL done, timeout");
         return true;
     }
     // still waiting


### PR DESCRIPTION
This bumps the severity level of timed out and roll error transmissions, hopefully this till make them easier to spot for those not used to looking at the messages.