### PR TITLE
AP_Scripting: add jitter correction bindings and example

### DIFF
--- a/libraries/AP_RTC/JitterCorrection.h
+++ b/libraries/AP_RTC/JitterCorrection.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 class JitterCorrection {
 public:
     // constructor

--- a/libraries/AP_Scripting/examples/jitter_correction.lua
+++ b/libraries/AP_Scripting/examples/jitter_correction.lua
@@ -1,0 +1,52 @@
+-- This script is an example jitter correction
+
+-- load jitter correction function, 5 seconds max lag
+local jitter_correction = JitterCorrection(5000)
+
+local lag = 2500
+local jitter_variance = 50
+local loop_time = 100
+
+local last_time_stamp = 0
+local last_corrected = 0
+local last_now = 0
+
+-- https://rosettacode.org/wiki/Statistics/Normal_distribution#Lua
+-- random normal distribution
+function gaussian (variance)
+    return  math.sqrt(-2 * variance * math.log(math.random())) *
+            math.cos(2 * math.pi * math.random())
+end
+
+function update()
+
+  local now = millis()
+
+  -- Offboard timestamp is jitter free (except the jitter due to scripting callback time), but is lagged
+  local offboard_time_stamp = now - lag
+
+  -- onboard time depends on how long the offboard time to too arive this is the jitter
+  local onboard_time_stamp = now:tofloat() + math.max(math.floor(gaussian(jitter_variance) + 0.5), -loop_time + 10)
+
+  -- apply jitter correction to the onbard timestamp
+  local corrected = jitter_correction:correct_offboard_timestamp_msec(offboard_time_stamp, onboard_time_stamp)
+
+  -- corrected DT should be close the to true
+  local corrected_dt = corrected - last_corrected
+  last_corrected = corrected
+  gcs:send_named_float("COR_DT",corrected_dt:tofloat())
+
+  -- the uncorrected DT
+  local raw_dt = onboard_time_stamp - last_time_stamp
+  last_time_stamp =  onboard_time_stamp
+  gcs:send_named_float("RAW_DT",raw_dt)
+
+  -- true DT due to scripting callback jitter
+  local true_dt = now - last_now
+  last_now =  now
+  gcs:send_named_float("TRUE_DT",true_dt:tofloat())
+
+  return update, loop_time
+end
+
+return update, lag * 2

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -372,3 +372,7 @@ singleton hal.gpio method pinMode void uint8_t 0 UINT8_MAX uint8_t 0 1
 singleton hal.analogin alias analog
 singleton hal.analogin literal
 singleton hal.analogin method channel AP_HAL::AnalogSource ANALOG_INPUT_NONE'literal
+
+include AP_RTC/JitterCorrection.h
+userdata JitterCorrection new uint16_t 0 UINT16_MAX
+userdata JitterCorrection method correct_offboard_timestamp_msec uint32_t uint32_t 0U UINT32_MAX uint32_t 0U UINT32_MAX


### PR DESCRIPTION
This adds bindings and a example for jitter correction, the example seems to work as expected although I'm not 100% sure I have faked up jitter correctly. We cant to a perfect job due to the scripting callback time resulting in jitter in our 'perfect' offboard timestamp.

This used named value floats to show how its doing. The `TRUE_DT` is the script callback time, `RAW_DT` is the callback time with fake jitter, `COR_DT` is the raw time with the jitter corrected. If the jitter correction was perfect `COR_DT` would be the same as `TRUE_DT` it nearly is, but not all time time, as I say, I think due to the scripting callback jitter.

![image](https://user-images.githubusercontent.com/33176108/120893558-cbbc7e80-c60b-11eb-8974-aa7c976e74e7.png)
