### PR TITLE
AC_PrecLand: Minor bug fixes and changes

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -405,17 +405,10 @@ bool AC_PrecLand::retrieve_los_meas(Vector3f& target_vec_unit_body)
     if (_backend->have_los_meas() && _backend->los_meas_time_ms() != _last_backend_los_meas_ms) {
         _last_backend_los_meas_ms = _backend->los_meas_time_ms();
         _backend->get_los_body(target_vec_unit_body);
-
-        // Apply sensor yaw alignment rotation
-        float sin_yaw_align = sinf(radians(_yaw_align*0.01f));
-        float cos_yaw_align = cosf(radians(_yaw_align*0.01f));
-        Matrix3f Rz = Matrix3f(
-            cos_yaw_align, -sin_yaw_align, 0,
-            sin_yaw_align, cos_yaw_align, 0,
-            0, 0, 1
-        );
-
-        target_vec_unit_body = Rz*target_vec_unit_body;
+        if (!is_zero(_yaw_align)) {
+            // Apply sensor yaw alignment rotation
+            target_vec_unit_body.rotate_xy(radians(_yaw_align*0.01f));
+        }
         return true;
     } else {
         return false;

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -87,6 +87,11 @@ private:
         SITL = 4,
     };
 
+    // check if EKF got the time to initialize when the landing target was first detected
+    // Expects sensor to update within EKF_INIT_SENSOR_MIN_UPDATE_MS milliseconds till EKF_INIT_TIME_MS milliseconds have passed
+    // after this period landing target estimates can be used by vehicle
+    void check_ekf_init_timeout();
+
     // run target position estimator
     void run_estimator(float rangefinder_alt_m, bool rangefinder_alt_valid);
 
@@ -113,7 +118,9 @@ private:
     AP_Vector3f                 _cam_offset;        // Position of the camera relative to the CG
 
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
-    bool                        _target_acquired;   // true if target has been seen recently
+    bool                        _target_acquired;   // true if target has been seen recently after estimator is initialized
+    bool                        _estimator_initialized; // true if estimator has been initialized after few seconds of the target being detected by sensor
+    uint32_t                    _estimator_init_ms; // system time in millisecond when EKF was init
     uint32_t                    _last_backend_los_meas_ms;  // system time target was last seen
 
     PosVelEKF                   _ekf_x, _ekf_y;     // Kalman Filter for x and y axis


### PR DESCRIPTION
Most of these are minor bug fixes or slight optimizations.

1. This provides a fixed time period (2 secs for now) after the camera first detects the landing target, and we start using it (in EKF mode). This would allow the EKF to settle down its predictions. We can perhaps extend this to raw mode but I don't see anything good coming out of that.
2. Minor optimization with using rotate_xy instead of a full-blown matrix multiplication without checking for 0 rotation.
3. Include cam z offset while calculating height from rangefinders 