### PR TITLE
AP_Motors: Add interpolated matrix backend

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -869,7 +869,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad, 14:Deca, 15:Scripting Matrix, 16:6DoF Scripting
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad, 14:Deca, 15:Scripting Matrix, 16:6DoF Scripting, 17:Dynamic Scripting Matrix
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, DEFAULT_FRAME_CLASS),

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -469,6 +469,12 @@ void Copter::allocate_motors(void)
             motors_var_info = AP_MotorsMatrix_6DoF_Scripting::var_info;
 #endif // ENABLE_SCRIPTING
             break;
+case AP_Motors::MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX:
+#ifdef ENABLE_SCRIPTING
+            motors = new AP_MotorsMatrix_Scripting_Dynamic(copter.scheduler.get_loop_rate_hz());
+            motors_var_info = AP_MotorsMatrix_Scripting_Dynamic::var_info;
+#endif // ENABLE_SCRIPTING
+            break;
 #else // FRAME_CONFIG == HELI_FRAME
         case AP_Motors::MOTOR_FRAME_HELI_DUAL:
             motors = new AP_MotorsHeli_Dual(copter.scheduler.get_loop_rate_hz());

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -149,7 +149,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 7:Tri, 10: TailSitter, 12:DodecaHexa, 14:Deca, 15:Scripting Matrix
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 7:Tri, 10: TailSitter, 12:DodecaHexa, 14:Deca, 15:Scripting Matrix, 17:Dynamic Scripting Matrix
     // @User: Standard
     AP_GROUPINFO("FRAME_CLASS", 46, QuadPlane, frame_class, 1),
 
@@ -726,6 +726,8 @@ bool QuadPlane::setup(void)
         AP_Param::set_frame_type_flags(AP_PARAM_FRAME_TRICOPTER);
         break;
     case AP_Motors::MOTOR_FRAME_TAILSITTER:
+    case AP_Motors::MOTOR_FRAME_SCRIPTING_MATRIX:
+    case AP_Motors::MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX:
         break;
     default:
         AP_BoardConfig::config_error("Unsupported Q_FRAME_CLASS %u", frame_class);
@@ -745,6 +747,12 @@ bool QuadPlane::setup(void)
             if (tilt.tilt_type != TILT_TYPE_BICOPTER) {
                 rotation = ROTATION_PITCH_90;
             }
+            break;
+        case AP_Motors::MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX:
+#ifdef ENABLE_SCRIPTING
+            motors = new AP_MotorsMatrix_Scripting_Dynamic(plane.scheduler.get_loop_rate_hz());
+            motors_var_info = AP_MotorsMatrix_Scripting_Dynamic::var_info;
+#endif // ENABLE_SCRIPTING
             break;
         default:
             motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -12,3 +12,4 @@
 #include "AP_MotorsTailsitter.h"
 #include "AP_Motors6DOF.h"
 #include "AP_MotorsMatrix_6DoF_Scripting.h"
+#include "AP_MotorsMatrix_Scripting_Dynamic.h"

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -30,7 +30,7 @@ public:
     }
 
     // init
-    void                init(motor_frame_class frame_class, motor_frame_type frame_type) override;
+    virtual void        init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
 #ifdef ENABLE_SCRIPTING
     // Init to be called from scripting
@@ -61,7 +61,7 @@ public:
     bool                output_test_num(uint8_t motor, int16_t pwm);
 
     // output_to_motors - sends minimum values out to the motors
-    void                output_to_motors() override;
+    virtual void        output_to_motors() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict

--- a/libraries/AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.cpp
@@ -1,0 +1,128 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifdef ENABLE_SCRIPTING
+
+// This allows motor roll, pitch, yaw and throttle factors to be changed in flight, allowing vehicle geometry to be changed
+
+#include "AP_MotorsMatrix_Scripting_Dynamic.h"
+#include <GCS_MAVLink/GCS.h>
+#include <AP_HAL/AP_HAL.h>
+
+extern const AP_HAL::HAL& hal;
+
+#define debug_print 0
+
+// add a motor and give its testing order
+bool AP_MotorsMatrix_Scripting_Dynamic::add_motor(uint8_t motor_num, uint8_t testing_order)
+{
+    if (initialised_ok()) {
+        // no adding motors after init
+        return false;
+    }
+    if (motor_num < AP_MOTORS_MAX_NUM_MOTORS) {
+        _test_order[motor_num] = testing_order;
+        motor_enabled[motor_num] = true;
+        return true;
+    }
+    return false;
+}
+
+void AP_MotorsMatrix_Scripting_Dynamic::load_factors(const factor_table &new_table)
+{
+    WITH_SEMAPHORE(_sem);
+    had_table = true;
+
+    memcpy(_roll_factor,new_table.roll,sizeof(_roll_factor));
+    memcpy(_pitch_factor,new_table.pitch,sizeof(_pitch_factor));
+    memcpy(_yaw_factor,new_table.yaw,sizeof(_yaw_factor));
+    memcpy(_throttle_factor,new_table.throttle,sizeof(_throttle_factor));
+
+#if debug_print
+    hal.console->printf("Got new factors:\n");
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            hal.console->printf("%i - Roll: %0.2f, Pitch %0.2f, Yaw: %0.2f, throttle %0.2f\n",i,_roll_factor[i],_pitch_factor[i],_yaw_factor[i],_throttle_factor[i]);
+        }
+    }
+#endif
+
+}
+
+bool AP_MotorsMatrix_Scripting_Dynamic::init(uint8_t expected_num_motors)
+{
+    WITH_SEMAPHORE(_sem);
+
+    // Check factors have been set
+    if (!had_table) {
+        return false;
+    }
+
+    // Make sure the correct number of motors have been added
+    uint8_t num_motors = 0;
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            num_motors++;
+        }
+    }
+
+    set_initialised_ok(expected_num_motors == num_motors);
+
+    if (!initialised_ok()) {
+        _mav_type = MAV_TYPE_GENERIC;
+        return false;
+    }
+
+    switch (num_motors) {
+        case 3:
+            _mav_type = MAV_TYPE_TRICOPTER;
+            break;
+        case 4:
+            _mav_type = MAV_TYPE_QUADROTOR;
+            break;
+        case 6:
+            _mav_type = MAV_TYPE_HEXAROTOR;
+            break;
+        case 8:
+            _mav_type = MAV_TYPE_OCTOROTOR;
+            break;
+        case 10:
+            _mav_type = MAV_TYPE_DECAROTOR;
+            break;
+        case 12:
+            _mav_type = MAV_TYPE_DODECAROTOR;
+            break;
+        default:
+            _mav_type = MAV_TYPE_GENERIC;
+    }
+
+    set_update_rate(_speed_hz);
+
+    return true;
+}
+
+// output - sends commands to the motors, 
+// Need to take the semaphore to enasure the motor factors are not changed during the mixer calculation
+void AP_MotorsMatrix_Scripting_Dynamic::output_to_motors()
+{
+    WITH_SEMAPHORE(_sem);
+
+    // call the base class ouput function
+    AP_MotorsMatrix::output_to_motors();
+}
+
+// singleton instance
+AP_MotorsMatrix_Scripting_Dynamic *AP_MotorsMatrix_Scripting_Dynamic::_singleton;
+
+#endif // ENABLE_SCRIPTING

--- a/libraries/AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.h
@@ -1,0 +1,65 @@
+#pragma once
+#ifdef ENABLE_SCRIPTING
+
+#include "AP_MotorsMatrix.h"
+
+class AP_MotorsMatrix_Scripting_Dynamic : public AP_MotorsMatrix {
+public:
+
+    // Constructor
+    AP_MotorsMatrix_Scripting_Dynamic(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_MotorsMatrix(loop_rate, speed_hz)
+    {
+        if (_singleton != nullptr) {
+            AP_HAL::panic("AP_MotorsMatrix_Scripting_Dynamic must be singleton");
+        }
+        _singleton = this;
+    };
+
+    // get singleton instance
+    static AP_MotorsMatrix_Scripting_Dynamic *get_singleton() {
+        return _singleton;
+    }
+
+    struct factor_table {
+        float roll[AP_MOTORS_MAX_NUM_MOTORS];
+        float pitch[AP_MOTORS_MAX_NUM_MOTORS];
+        float yaw[AP_MOTORS_MAX_NUM_MOTORS];
+        float throttle[AP_MOTORS_MAX_NUM_MOTORS];
+    };
+
+    // base class method must not be used
+    void init(motor_frame_class frame_class, motor_frame_type frame_type) override {};
+
+    // Init to be called from scripting
+    bool init(uint8_t expected_num_motors) override;
+
+    // add a motor and give its testing order
+    bool add_motor(uint8_t motor_num, uint8_t testing_order);
+
+    // add a interpolation point table
+    void load_factors(const factor_table &table);
+
+    // output - sends commands to the motors
+    void output_to_motors() override;
+
+    const char* get_frame_string() const override { return "Dynamic Matrix"; }
+
+protected:
+
+    // Do not apply thrust compensation, this is used by Quadplane tiltrotors
+    // assume the compensation is done in the mixer and should not be done by quadplane
+    void thrust_compensation(void) override {};
+
+private:
+
+    // True when received a factors table, will only init having received a table
+    bool had_table;
+
+    // For loading of new factors, cannot load while in use
+    HAL_Semaphore _sem;
+
+    static AP_MotorsMatrix_Scripting_Dynamic *_singleton;
+};
+
+#endif // ENABLE_SCRIPTING

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -47,6 +47,7 @@ public:
         MOTOR_FRAME_DECA = 14,
         MOTOR_FRAME_SCRIPTING_MATRIX = 15,
         MOTOR_FRAME_6DOF_SCRIPTING = 16,
+        MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX = 17,
     };
 
     // return string corresponding to frame_class

--- a/libraries/AP_Scripting/examples/Motor_mixer_dynamic_setup.lua
+++ b/libraries/AP_Scripting/examples/Motor_mixer_dynamic_setup.lua
@@ -1,0 +1,47 @@
+-- This script is an example setting up a custom dynamic motor matrix
+-- allowing a vehicle to change geometry in flight
+
+-- this mixer is for a plus quad copter, the default SITL vehicle.
+-- Setup motor number (zero indexed) and testing order (1 indexed)
+Motors_dynamic:add_motor(0, 2)
+Motors_dynamic:add_motor(1, 4)
+Motors_dynamic:add_motor(2, 1)
+Motors_dynamic:add_motor(3, 3)
+
+factors = motor_factor_table()
+
+-- Roll for motors 1 - 4
+factors:roll(0, -0.5)
+factors:roll(1,  0.5)
+factors:roll(2,  0)
+factors:roll(3,  0)
+
+-- pitch for motors 1 -4
+factors:pitch(0,  0)
+factors:pitch(1,  0)
+factors:pitch(2,  0.5)
+factors:pitch(3, -0.5)
+
+-- yaw for motors 1 -4
+factors:yaw(0,  0.5)
+factors:yaw(1,  0.5)
+factors:yaw(2, -0.5)
+factors:yaw(3, -0.5)
+
+-- throttle for motors 1 -4
+factors:throttle(0,  1)
+factors:throttle(1,  1)
+factors:throttle(2,  1)
+factors:throttle(3,  1)
+
+-- must load factors before init
+Motors_dynamic:load_factors(factors)
+
+-- were expecting 4 motors
+assert(Motors_dynamic:init(4), "Failed to init Motors_dynamic")
+
+-- at any time we can then re-load new factors
+Motors_dynamic:load_factors(factors)
+
+-- if doing changes in flight it is a good idea to us pcall to protect the script from crashing
+-- see 'protected_call.lua' example

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -334,8 +334,8 @@ singleton QuadPlane method in_vtol_mode boolean
 include AP_Motors/AP_MotorsMatrix.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 singleton AP_MotorsMatrix depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 singleton AP_MotorsMatrix alias MotorsMatrix
-singleton AP_MotorsMatrix method init boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
-singleton AP_MotorsMatrix method add_motor_raw void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
+singleton AP_MotorsMatrix method init boolean uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
+singleton AP_MotorsMatrix method add_motor_raw void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
 singleton AP_MotorsMatrix method set_throttle_factor boolean int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float 0 FLT_MAX
 
 include AP_Frsky_Telem/AP_Frsky_SPort.h
@@ -354,8 +354,8 @@ singleton AC_AttitudeControl_Multi_6DoF method set_offset_roll_pitch void float 
 include AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h  depends APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 singleton AP_MotorsMatrix_6DoF_Scripting depends APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 singleton AP_MotorsMatrix_6DoF_Scripting alias Motors_6DoF
-singleton AP_MotorsMatrix_6DoF_Scripting method init boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
-singleton AP_MotorsMatrix_6DoF_Scripting method add_motor void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX boolean uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1)
+singleton AP_MotorsMatrix_6DoF_Scripting method init boolean uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
+singleton AP_MotorsMatrix_6DoF_Scripting method add_motor void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX boolean uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
 
 include AP_HAL/I2CDevice.h
 ap_object AP_HAL::I2CDevice semaphore-pointer
@@ -385,3 +385,17 @@ singleton hal.gpio method pinMode void uint8_t 0 UINT8_MAX uint8_t 0 1
 singleton hal.analogin alias analog
 singleton hal.analogin literal
 singleton hal.analogin method channel AP_HAL::AnalogSource ANALOG_INPUT_NONE'literal
+
+include AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+singleton AP_MotorsMatrix_Scripting_Dynamic depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+singleton AP_MotorsMatrix_Scripting_Dynamic alias Motors_dynamic
+singleton AP_MotorsMatrix_Scripting_Dynamic method init boolean uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
+singleton AP_MotorsMatrix_Scripting_Dynamic method add_motor void uint8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
+singleton AP_MotorsMatrix_Scripting_Dynamic method load_factors void AP_MotorsMatrix_Scripting_Dynamic::factor_table
+
+userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table alias motor_factor_table
+userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field roll'array AP_MOTORS_MAX_NUM_MOTORS float read write -FLT_MAX FLT_MAX
+userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field pitch'array AP_MOTORS_MAX_NUM_MOTORS float read write -FLT_MAX FLT_MAX
+userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field yaw'array AP_MOTORS_MAX_NUM_MOTORS float read write -FLT_MAX FLT_MAX
+userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field throttle'array AP_MOTORS_MAX_NUM_MOTORS float read write -FLT_MAX FLT_MAX

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -30,6 +30,7 @@ char keyword_attr_enum[]    = "'enum";
 char keyword_attr_literal[] = "'literal";
 char keyword_attr_null[]    = "'Null";
 char keyword_attr_reference[]  = "'Ref";
+char keyword_attr_array[]      = "'array";
 
 // type keywords
 char keyword_boolean[]  = "boolean";
@@ -344,6 +345,7 @@ struct userdata_field {
   struct type type; // field type, points to a string
   int line; // line declared on
   unsigned int access_flags;
+  char * array_len; // literal array length
 };
 
 enum userdata_flags {
@@ -639,17 +641,26 @@ void handle_userdata_field(struct userdata *data) {
   trace(TRACE_USERDATA, "Adding a userdata field");
 
   // find the field name
-  char * field_name = next_token();
-  if (field_name == NULL) {
+  char * token = next_token();
+  if (token == NULL) {
     error(ERROR_USERDATA, "Missing a field name for userdata %s", data->name);
   }
-  
+
+  size_t split = strcspn(token, "\'");
+  char * field_name;
+  if (split == strlen(token)) {
+    string_copy(&field_name, token);
+  } else {
+    field_name = (char *)allocate(split+1);
+    memcpy(field_name, token, split);
+  }
+
   struct userdata_field * field = data->fields;
   while (field != NULL && strcmp(field->name, field_name)) {
     field = field-> next;
   }
   if (field != NULL) {
-    error(ERROR_USERDATA, "Field %s already exsists in userdata %s (declared on %d)", field_name, data->name, field->line);
+    error(ERROR_USERDATA, "Field %s already exists in userdata %s (declared on %d)", field_name, data->name, field->line);
   }
 
   trace(TRACE_USERDATA, "Adding field %s", field_name);
@@ -658,6 +669,16 @@ void handle_userdata_field(struct userdata *data) {
   data->fields = field;
   field->line = state.line_num;
   string_copy(&(field->name), field_name);
+
+  char *attribute = strchr(token, '\'');
+  if (attribute != NULL) {
+    if (strcmp(attribute, keyword_attr_array) != 0) {
+      error(ERROR_USERDATA, "Unknown feild attribute %s for userdata %s feild %s", attribute, data->name, field_name);
+    }
+    char * token = next_token();
+    string_copy(&(field->array_len), token);
+    trace(TRACE_USERDATA, "userdata %s feild %s array length %s", data->name, field->name, field->array_len);
+  }
 
   parse_type(&(field->type), TYPE_RESTRICTION_NOT_NULLABLE, RANGE_CHECK_NONE);
   field->access_flags = parse_access_flags(&(field->type));
@@ -1309,16 +1330,31 @@ void emit_checker(const struct type t, int arg_number, int skipped, const char *
 void emit_userdata_field(const struct userdata *data, const struct userdata_field *field) {
   fprintf(source, "static int %s_%s(lua_State *L) {\n", data->sanatized_name, field->name);
   fprintf(source, "    %s *ud = check_%s(L, 1);\n", data->name, data->sanatized_name);
-  fprintf(source, "    switch(lua_gettop(L)) {\n");
+
+  char *index_string = "";
+  int write_arg_number = 2;
+  if (field->array_len != NULL) {
+    index_string = "[index]";
+    write_arg_number = 3;
+
+    fprintf(source, "\n    const lua_Integer raw_index = luaL_checkinteger(L, 2);\n");
+    fprintf(source, "    luaL_argcheck(L, ((raw_index >= 0) && (raw_index < MIN(%s, UINT8_MAX))), 2, \"index out of range\");\n",field->array_len);
+    fprintf(source, "    const uint8_t index = static_cast<uint8_t>(raw_index);\n\n");
+
+    fprintf(source, "    switch(lua_gettop(L)-1) {\n");
+
+  } else {
+    fprintf(source, "    switch(lua_gettop(L)) {\n");
+  }
 
   if (field->access_flags & ACCESS_FLAG_READ) {
     fprintf(source, "        case 1:\n");
     switch (field->type.type) {
       case TYPE_BOOLEAN:
-        fprintf(source, "            lua_pushinteger(L, ud->%s);\n", field->name);
+        fprintf(source, "            lua_pushinteger(L, ud->%s%s);\n", field->name, index_string);
         break;
       case TYPE_FLOAT:
-        fprintf(source, "            lua_pushnumber(L, ud->%s);\n", field->name);
+        fprintf(source, "            lua_pushnumber(L, ud->%s%s);\n", field->name, index_string);
         break;
       case TYPE_INT8_T:
       case TYPE_INT16_T:
@@ -1326,11 +1362,11 @@ void emit_userdata_field(const struct userdata *data, const struct userdata_fiel
       case TYPE_UINT8_T:
       case TYPE_UINT16_T:
       case TYPE_ENUM:
-        fprintf(source, "            lua_pushinteger(L, ud->%s);\n", field->name);
+        fprintf(source, "            lua_pushinteger(L, ud->%s%s);\n", field->name, index_string);
         break;
       case TYPE_UINT32_T:
         fprintf(source, "            new_uint32_t(L);\n");
-        fprintf(source, "            *static_cast<uint32_t *>(luaL_checkudata(L, -1, \"uint32_t\")) = ud->%s;\n", field->name);
+        fprintf(source, "            *static_cast<uint32_t *>(luaL_checkudata(L, -1, \"uint32_t\")) = ud->%s%s;\n", field->name, index_string);
         break;
       case TYPE_NONE:
         error(ERROR_INTERNAL, "Can't access a NONE field");
@@ -1339,13 +1375,13 @@ void emit_userdata_field(const struct userdata *data, const struct userdata_fiel
         error(ERROR_INTERNAL, "Can't access a literal field");
         break;
       case TYPE_STRING:
-        fprintf(source, "            lua_pushstring(L, ud->%s);\n", field->name);
+        fprintf(source, "            lua_pushstring(L, ud->%s%s);\n", field->name, index_string);
         break;
       case TYPE_USERDATA:
-        error(ERROR_USERDATA, "Userdata does not currently support accss to userdata field's");
+        error(ERROR_USERDATA, "Userdata does not currently support access to userdata field's");
         break;
       case TYPE_AP_OBJECT: // FIXME: collapse the identical cases here, and use the type string function
-        error(ERROR_USERDATA, "AP_Object does not currently support accss to userdata field's");
+        error(ERROR_USERDATA, "AP_Object does not currently support access to userdata field's");
         break;
     }
     fprintf(source, "            return 1;\n");
@@ -1353,8 +1389,8 @@ void emit_userdata_field(const struct userdata *data, const struct userdata_fiel
 
   if (field->access_flags & ACCESS_FLAG_WRITE) {
     fprintf(source, "        case 2: {\n");
-    emit_checker(field->type, 2, 0, "            ", field->name);
-    fprintf(source, "            ud->%s = data_2;\n", field->name);
+    emit_checker(field->type, write_arg_number, 0, "            ", field->name);
+    fprintf(source, "            ud->%s%s = data_%i;\n", field->name, index_string, write_arg_number);
     fprintf(source, "            return 0;\n");
     fprintf(source, "         }\n");
   }

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -839,7 +839,17 @@ void handle_userdata(void) {
     }
     node->alias = (char *)allocate(strlen(alias) + 1);
     strcpy(node->alias, alias);
-  
+
+  } else if (strcmp(type, keyword_depends) == 0) {
+      if (node->dependency != NULL) {
+        error(ERROR_SINGLETON, "Userdata only support a single depends");
+      }
+      char *depends = strtok(NULL, "");
+      if (depends == NULL) {
+        error(ERROR_DEPENDS, "Expected a depends string for %s",node->name);
+      }
+      string_copy(&(node->dependency), depends);
+
   } else {
     error(ERROR_USERDATA, "Unknown or unsupported type for userdata: %s", type);
   }


### PR DESCRIPTION
This adds a motors back-end that allows dynamically changing the per-motor roll, pitch, yaw and throttle factors. This enables vehicles that change geometry. This was originally added for the transwing tilt-rotor aircraft. https://youtu.be/-QAy2u33BEc

This is only a 1D interpolation so can only cope with changing geometry with 1 DoF.

This currently loads everything from scripting, the interpolation is then done completely in C++ so scripting cannot go away and leave motors hanging. However we do still rely on scripting to update the interpolation point, so scripting going away could be bad still. 

If we were to directly load the factors in flight from scripting, it would be a very minimal C++ change and would allow as many degrees of freedom needed. However the script crashing would probably result in the vehicle crashing. 

I'm not really sure which is best, basically it boils down to how much we trust scripting. 

