### PR TITLE
WPNav: scurve direction length check and simplifications

### DIFF
--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -61,8 +61,9 @@ void SCurve::calculate_track(const Vector3f &origin, const Vector3f &destination
 {
     init();
 
-    // leave track as zero length if origin and destination are the same
-    if (origin == destination) {
+    // leave track as zero length if origin and destination are equal or if the new track length squared is zero
+    const Vector3f track_temp = destination - origin;
+    if (track_temp.is_zero() || is_zero(track_temp.length_squared())) {
         return;
     }
 
@@ -84,7 +85,7 @@ void SCurve::calculate_track(const Vector3f &origin, const Vector3f &destination
         return;
     }
 
-    track = destination - origin;
+    track = track_temp;
     const float track_length = track.length();
     if (is_zero(track_length)) {
         // avoid possible divide by zero


### PR DESCRIPTION
I've come across what I think is a bug in how `calculate_track` checks before continuing if the origin and destination are the same. It ends up hitting the zero path length check and Internal_Error

When debugging the origin and destination were far enough apart to pass the current check. However, the check in control.cpp `kinematic_limit`  is hit because the difference squared is <0. 

The stack trace in sitl is the following screen it is difficult to reproduce on master, but usually occurs right on takeoff.
![image](https://user-images.githubusercontent.com/69225461/120911517-14008e80-c656-11eb-8bef-4bdae2eb08f6.png)

I also simplified a bit in calculate_track  and spline_curve to save a few bytes. 
