### PR TITLE
Sitl:  serial rangefinder health

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6126,6 +6126,21 @@ class AutoTestCopter(AutoTest):
                 raise NotAchievedException("Did not get %s" % want)
             still_want.remove(m.get_type())
 
+    def fly_rangefinder_sitl(self):
+        """This test need an access to JSON backend that implement the SITL RF.
+        It currently does nothing else that checking return is -1."""
+        self.set_parameter("RNGFND1_TYPE", 100)
+        self.reboot_sitl()
+        self.change_mode('GUIDED')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        expected_alt = 5
+        self.user_takeoff(alt_min=expected_alt)
+        self.land_and_disarm()
+        self.progress("Ensure RFND messages in log")
+        if not self.current_onboard_log_contains_message("RFND"):
+            raise NotAchievedException("No RFND messages in log")
+
     def fly_rangefinder_mavlink(self):
         self.fly_rangefinder_mavlink_distance_sensor()
 
@@ -6282,6 +6297,7 @@ class AutoTestCopter(AutoTest):
             self.fly_rangefinder_drivers_fly([x[0] for x in do_drivers])
 
         self.fly_rangefinder_mavlink()
+        self.fly_rangefinder_sitl()
 
         i2c_drivers = [
             ("maxbotixi2cxl", 2),

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -299,7 +299,7 @@ class AutoTestCopter(AutoTest):
                                              origin.longitude,
                                              final_alt)
 
-    def change_alt(self, alt_min, climb_throttle=1920, descend_throttle=1080):
+    def change_alt(self, alt_min, climb_throttle=1920, descend_throttle=1080, timeout=30):
         """Change altitude."""
         def adjust_altitude(current_alt, target_alt, accuracy):
             if math.fabs(current_alt - target_alt) <= accuracy:
@@ -312,6 +312,7 @@ class AutoTestCopter(AutoTest):
             (alt_min - 5),
             alt_min,
             relative=True,
+            timeout=timeout,
             called_function=lambda current_alt, target_alt: adjust_altitude(current_alt, target_alt, 1)
         )
         self.hover()

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -227,7 +227,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
 }
 
 #define streq(a, b) (!strcmp(a, b))
-int SITL_State::sim_fd(const char *name, const char *arg)
+int SITL_State::sim_fd(const char *name, const char *arg, int8_t port_num)
 {
     if (streq(name, "vicon")) {
         if (vicon != nullptr) {
@@ -239,86 +239,86 @@ int SITL_State::sim_fd(const char *name, const char *arg)
         if (benewake_tf02 != nullptr) {
             AP_HAL::panic("Only one benewake_tf02 at a time");
         }
-        benewake_tf02 = new SITL::RF_Benewake_TF02();
+        benewake_tf02 = new SITL::RF_Benewake_TF02(port_num);
         return benewake_tf02->fd();
     } else if (streq(name, "benewake_tf03")) {
         if (benewake_tf03 != nullptr) {
             AP_HAL::panic("Only one benewake_tf03 at a time");
         }
-        benewake_tf03 = new SITL::RF_Benewake_TF03();
+        benewake_tf03 = new SITL::RF_Benewake_TF03(port_num);
         return benewake_tf03->fd();
     } else if (streq(name, "benewake_tfmini")) {
         if (benewake_tfmini != nullptr) {
             AP_HAL::panic("Only one benewake_tfmini at a time");
         }
-        benewake_tfmini = new SITL::RF_Benewake_TFmini();
+        benewake_tfmini = new SITL::RF_Benewake_TFmini(port_num);
         return benewake_tfmini->fd();
     } else if (streq(name, "lightwareserial")) {
         if (lightwareserial != nullptr) {
             AP_HAL::panic("Only one lightwareserial at a time");
         }
-        lightwareserial = new SITL::RF_LightWareSerial();
+        lightwareserial = new SITL::RF_LightWareSerial(port_num);
         return lightwareserial->fd();
     } else if (streq(name, "lightwareserial-binary")) {
         if (lightwareserial_binary != nullptr) {
             AP_HAL::panic("Only one lightwareserial-binary at a time");
         }
-        lightwareserial_binary = new SITL::RF_LightWareSerialBinary();
+        lightwareserial_binary = new SITL::RF_LightWareSerialBinary(port_num);
         return lightwareserial_binary->fd();
     } else if (streq(name, "lanbao")) {
         if (lanbao != nullptr) {
             AP_HAL::panic("Only one lanbao at a time");
         }
-        lanbao = new SITL::RF_Lanbao();
+        lanbao = new SITL::RF_Lanbao(port_num);
         return lanbao->fd();
     } else if (streq(name, "blping")) {
         if (blping != nullptr) {
             AP_HAL::panic("Only one blping at a time");
         }
-        blping = new SITL::RF_BLping();
+        blping = new SITL::RF_BLping(port_num);
         return blping->fd();
     } else if (streq(name, "leddarone")) {
         if (leddarone != nullptr) {
             AP_HAL::panic("Only one leddarone at a time");
         }
-        leddarone = new SITL::RF_LeddarOne();
+        leddarone = new SITL::RF_LeddarOne(port_num);
         return leddarone->fd();
     } else if (streq(name, "ulanding_v0")) {
         if (ulanding_v0 != nullptr) {
             AP_HAL::panic("Only one ulanding_v0 at a time");
         }
-        ulanding_v0 = new SITL::RF_uLanding_v0();
+        ulanding_v0 = new SITL::RF_uLanding_v0(port_num);
         return ulanding_v0->fd();
     } else if (streq(name, "ulanding_v1")) {
         if (ulanding_v1 != nullptr) {
             AP_HAL::panic("Only one ulanding_v1 at a time");
         }
-        ulanding_v1 = new SITL::RF_uLanding_v1();
+        ulanding_v1 = new SITL::RF_uLanding_v1(port_num);
         return ulanding_v1->fd();
     } else if (streq(name, "maxsonarseriallv")) {
         if (maxsonarseriallv != nullptr) {
             AP_HAL::panic("Only one maxsonarseriallv at a time");
         }
-        maxsonarseriallv = new SITL::RF_MaxsonarSerialLV();
+        maxsonarseriallv = new SITL::RF_MaxsonarSerialLV(port_num);
         return maxsonarseriallv->fd();
     } else if (streq(name, "wasp")) {
         if (wasp != nullptr) {
             AP_HAL::panic("Only one wasp at a time");
         }
-        wasp = new SITL::RF_Wasp();
+        wasp = new SITL::RF_Wasp(port_num);
         return wasp->fd();
     } else if (streq(name, "nmea")) {
         if (nmea != nullptr) {
             AP_HAL::panic("Only one nmea at a time");
         }
-        nmea = new SITL::RF_NMEA();
+        nmea = new SITL::RF_NMEA(port_num);
         return nmea->fd();
 
     } else if (streq(name, "rf_mavlink")) {
         if (wasp != nullptr) {
             AP_HAL::panic("Only one rf_mavlink at a time");
         }
-        rf_mavlink = new SITL::RF_MAVLink();
+        rf_mavlink = new SITL::RF_MAVLink(port_num);
         return rf_mavlink->fd();
 
     } else if (streq(name, "frsky-d")) {
@@ -374,7 +374,7 @@ int SITL_State::sim_fd(const char *name, const char *arg)
         if (gyus42v2 != nullptr) {
             AP_HAL::panic("Only one gyus42v2 at a time");
         }
-        gyus42v2 = new SITL::RF_GYUS42v2();
+        gyus42v2 = new SITL::RF_GYUS42v2(port_num);
         return gyus42v2->fd();
     } else if (streq(name, "VectorNav")) {
         if (vectornav != nullptr) {

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -643,49 +643,49 @@ void SITL_State::_fdm_input_local(void)
                       attitude);
     }
     if (benewake_tf02 != nullptr) {
-        benewake_tf02->update(sitl_model->rangefinder_range());
+        benewake_tf02->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[benewake_tf02->get_port()]);
     }
     if (benewake_tf03 != nullptr) {
-        benewake_tf03->update(sitl_model->rangefinder_range());
+        benewake_tf03->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[benewake_tf03->get_port()]);
     }
     if (benewake_tfmini != nullptr) {
-        benewake_tfmini->update(sitl_model->rangefinder_range());
+        benewake_tfmini->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[benewake_tfmini->get_port()]);
     }
     if (lightwareserial != nullptr) {
-        lightwareserial->update(sitl_model->rangefinder_range());
+        lightwareserial->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[lightwareserial->get_port()]);
     }
     if (lightwareserial_binary != nullptr) {
-        lightwareserial_binary->update(sitl_model->rangefinder_range());
+        lightwareserial_binary->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[lightwareserial_binary->get_port()]);
     }
     if (lanbao != nullptr) {
-        lanbao->update(sitl_model->rangefinder_range());
+        lanbao->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[lanbao->get_port()]);
     }
     if (blping != nullptr) {
-        blping->update(sitl_model->rangefinder_range());
+        blping->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[blping->get_port()]);
     }
     if (leddarone != nullptr) {
-        leddarone->update(sitl_model->rangefinder_range());
+        leddarone->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[leddarone->get_port()]);
     }
     if (ulanding_v0 != nullptr) {
-        ulanding_v0->update(sitl_model->rangefinder_range());
+        ulanding_v0->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[ulanding_v0->get_port()]);
     }
     if (ulanding_v1 != nullptr) {
-        ulanding_v1->update(sitl_model->rangefinder_range());
+        ulanding_v1->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[ulanding_v1->get_port()]);
     }
     if (maxsonarseriallv != nullptr) {
-        maxsonarseriallv->update(sitl_model->rangefinder_range());
+        maxsonarseriallv->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[maxsonarseriallv->get_port()]);
     }
     if (wasp != nullptr) {
-        wasp->update(sitl_model->rangefinder_range());
+        wasp->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[wasp->get_port()]);
     }
     if (nmea != nullptr) {
-        nmea->update(sitl_model->rangefinder_range());
+        nmea->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[nmea->get_port()]);
     }
     if (rf_mavlink != nullptr) {
-        rf_mavlink->update(sitl_model->rangefinder_range());
+        rf_mavlink->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[rf_mavlink->get_port()]);
     }
     if (gyus42v2 != nullptr) {
-        gyus42v2->update(sitl_model->rangefinder_range());
+        gyus42v2->update(sitl_model->rangefinder_range(), _sitl->rangefinder_serial_health[gyus42v2->get_port()]);
     }
 
     if (frsky_d != nullptr) {

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -86,7 +86,7 @@ public:
 
     // create a file descriptor attached to a virtual device; type of
     // device is given by name parameter
-    int sim_fd(const char *name, const char *arg);
+    int sim_fd(const char *name, const char *arg, int8_t port_num);
     // returns a write file descriptor for a created virtual device
     int sim_fd_write(const char *name);
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -118,7 +118,7 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
             if (!_connected) {
                 ::printf("SIM connection %s:%s on port %u\n", args1, args2, _portNumber);
                 _connected = true;
-                _fd = _sitlState->sim_fd(args1, args2);
+                _fd = _sitlState->sim_fd(args1, args2, _portNumber);
                 _fd_write = _sitlState->sim_fd_write(args1);
             }
         } else if (strcmp(devtype, "udpclient") == 0) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -745,7 +745,7 @@ MAV_DISTANCE_SENSOR RangeFinder::get_mav_distance_sensor_type_orient(enum Rotati
 }
 
 // get temperature reading in C.  returns true on success and populates temp argument
-bool RangeFinder::get_temp(enum Rotation orientation, float &temp)
+bool RangeFinder::get_temp(enum Rotation orientation, float &temp) const
 {
     AP_RangeFinder_Backend *backend = find_instance(orientation);
     if (backend == nullptr) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -314,7 +314,7 @@ void RangeFinder::update(void)
 #endif
 }
 
-bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend, uint8_t instance)
+bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend, uint8_t instance, uint8_t serial_instance)
 {
     if (!backend) {
         return false;
@@ -326,7 +326,7 @@ bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend, uint8_t instance
         // we've allocated the same instance twice
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     }
-
+    backend->init(serial_instance);
     drivers[instance] = backend;
     num_instances = MAX(num_instances, instance+1);
 
@@ -442,17 +442,17 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         break;
     case Type::LWSER:
         if (AP_RangeFinder_LightWareSerial::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_LightWareSerial(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_LightWareSerial(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::LEDDARONE:
         if (AP_RangeFinder_LeddarOne::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_LeddarOne(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_LeddarOne(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::ULANDING:
         if (AP_RangeFinder_uLanding::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_uLanding(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_uLanding(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::BEBOP:
@@ -472,7 +472,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         break;
     case Type::MBSER:
         if (AP_RangeFinder_MaxsonarSerialLV::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_MaxsonarSerialLV(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_MaxsonarSerialLV(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::ANALOG:
@@ -493,27 +493,27 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         break;
     case Type::NMEA:
         if (AP_RangeFinder_NMEA::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_NMEA(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_NMEA(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::WASP:
         if (AP_RangeFinder_Wasp::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_Wasp(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_Wasp(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::BenewakeTF02:
         if (AP_RangeFinder_Benewake_TF02::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_Benewake_TF02(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_Benewake_TF02(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::BenewakeTFmini:
         if (AP_RangeFinder_Benewake_TFMini::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_Benewake_TFMini(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_Benewake_TFMini(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::BenewakeTF03:
         if (AP_RangeFinder_Benewake_TF03::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_Benewake_TF03(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_Benewake_TF03(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::PWM:
@@ -525,17 +525,17 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         break;
     case Type::BLPing:
         if (AP_RangeFinder_BLPing::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_BLPing(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_BLPing(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::Lanbao:
         if (AP_RangeFinder_Lanbao::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_Lanbao(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_Lanbao(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
     case Type::LeddarVu8_Serial:
         if (AP_RangeFinder_LeddarVu8::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_LeddarVu8(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_LeddarVu8(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
 
@@ -552,7 +552,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 
     case Type::GYUS42v2:
         if (AP_RangeFinder_GYUS42v2::detect(serial_instance)) {
-            _add_backend(new AP_RangeFinder_GYUS42v2(state[instance], params[instance], serial_instance++), instance);
+            _add_backend(new AP_RangeFinder_GYUS42v2(state[instance], params[instance]), instance, serial_instance++);
         }
         break;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -212,7 +212,7 @@ private:
 
     void detect_instance(uint8_t instance, uint8_t& serial_instance);
 
-    bool _add_backend(AP_RangeFinder_Backend *driver, uint8_t instance);
+    bool _add_backend(AP_RangeFinder_Backend *driver, uint8_t instance, uint8_t serial_instance=0);
 
     uint32_t _log_rfnd_bit = -1;
     void Log_RFND() const;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -182,7 +182,7 @@ public:
     uint32_t last_reading_ms(enum Rotation orientation) const;
 
     // get temperature reading in C.  returns true on success and populates temp argument
-    bool get_temp(enum Rotation orientation, float &temp);
+    bool get_temp(enum Rotation orientation, float &temp) const;
 
     /*
       set an externally estimated terrain height. Used to enable power

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -30,6 +30,7 @@ public:
 
     // update the state structure
     virtual void update() = 0;
+    virtual void init(uint8_t serial_instance) {};
 
     virtual void handle_msg(const mavlink_message_t &msg) { return; }
 #if HAL_MSP_RANGEFINDER_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
@@ -28,9 +28,13 @@ extern const AP_HAL::HAL& hal;
 */
 AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial(
     RangeFinder::RangeFinder_State &_state,
-    AP_RangeFinder_Params &_params,
-    uint8_t serial_instance) :
+    AP_RangeFinder_Params &_params) :
     AP_RangeFinder_Backend(_state, _params)
+{
+
+}
+
+void AP_RangeFinder_Backend_Serial::init(uint8_t serial_instance)
 {
     uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
     if (uart != nullptr) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
@@ -29,7 +29,7 @@ protected:
 
     // it is essential that anyone relying on the base-class update to
     // implement this:
-    virtual bool get_reading(uint16_t &reading_cm) { return false; }
+    virtual bool get_reading(uint16_t &reading_cm) = 0;
 
     // maximum time between readings before we change state to NoData:
     virtual uint16_t read_timeout_ms() const { return 200; }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
@@ -7,9 +7,9 @@ class AP_RangeFinder_Backend_Serial : public AP_RangeFinder_Backend
 public:
     // constructor
     AP_RangeFinder_Backend_Serial(RangeFinder::RangeFinder_State &_state,
-                                  AP_RangeFinder_Params &_params,
-                                  uint8_t serial_instance);
+                                  AP_RangeFinder_Params &_params);
 
+    void init(uint8_t serial_instance) override;
     // static detection function
     static bool detect(uint8_t serial_instance);
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -75,15 +75,11 @@ bool AP_RangeFinder_LightWareSerial::get_reading(uint16_t &reading_cm)
                 // received the low byte which should be second
                 if (high_byte_received) {
                     const float dist = (high_byte & 0x7f) << 7 | (c & 0x7f);
-                    if (!is_negative(dist)) {
-                        sum += dist * 0.01f;
-                        valid_count++;
-                        // if still determining protocol update binary valid count
-                        if (protocol_state == ProtocolState::UNKNOWN) {
-                            binary_valid_count++;
-                        }
-                    } else {
-                        invalid_count++;
+                    sum += dist * 0.01f;
+                    valid_count++;
+                    // if still determining protocol update binary valid count
+                    if (protocol_state == ProtocolState::UNKNOWN) {
+                        binary_valid_count++;
                     }
                 }
                 high_byte_received = false;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.cpp
@@ -67,9 +67,8 @@ const AP_Param::GroupInfo AP_RangeFinder_Wasp::var_info[] = {
 };
 
 AP_RangeFinder_Wasp::AP_RangeFinder_Wasp(RangeFinder::RangeFinder_State &_state,
-                                         AP_RangeFinder_Params &_params,
-                                         uint8_t serial_instance) :
-    AP_RangeFinder_Backend_Serial(_state, _params, serial_instance)
+                                         AP_RangeFinder_Params &_params) :
+    AP_RangeFinder_Backend_Serial(_state, _params)
 {
     AP_Param::setup_object_defaults(this, var_info);
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.h
@@ -10,8 +10,7 @@ class AP_RangeFinder_Wasp : public AP_RangeFinder_Backend_Serial {
 
 public:
     AP_RangeFinder_Wasp(RangeFinder::RangeFinder_State &_state,
-                        AP_RangeFinder_Params &_params,
-                        uint8_t serial_instance);
+                        AP_RangeFinder_Params &_params);
 
     void update(void) override;
 

--- a/libraries/SITL/SIM_RF_BLping.h
+++ b/libraries/SITL/SIM_RF_BLping.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_BLping : public SerialRangeFinder {
 public:
-
+    RF_BLping(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 };

--- a/libraries/SITL/SIM_RF_Benewake.cpp
+++ b/libraries/SITL/SIM_RF_Benewake.cpp
@@ -24,7 +24,7 @@ uint32_t RF_Benewake::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t b
 {
     buffer[0] = 0x59;
     buffer[1] = 0x59;
-    buffer[3] = alt_cm >> 8;
+    buffer[3] = (out_of_range + alt_cm) >> 8;
     buffer[2] = alt_cm & 0xff;
     buffer[4] = byte4();
     buffer[5] = byte5();

--- a/libraries/SITL/SIM_RF_Benewake.h
+++ b/libraries/SITL/SIM_RF_Benewake.h
@@ -27,7 +27,26 @@ public:
     RF_Benewake(uint8_t port_num): SerialRangeFinder(port_num) {};
 
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint16_t out_of_range;
 
+    void set_health(RangeFinder::Status health) override
+    {
+        out_of_range = 0;
+        switch (health) {
+        case RangeFinder::Status::NotConnected :
+            break;
+
+        case RangeFinder::Status::OutOfRangeLow :
+            break;
+        case RangeFinder::Status::NoData :
+        case RangeFinder::Status::OutOfRangeHigh :
+            out_of_range = 32768;
+            break;
+
+        case RangeFinder::Status::Good :
+            break;
+        }
+    };
 private:
 
     virtual uint8_t byte4() const = 0;

--- a/libraries/SITL/SIM_RF_Benewake.h
+++ b/libraries/SITL/SIM_RF_Benewake.h
@@ -24,6 +24,7 @@ namespace SITL {
 
 class RF_Benewake : public SerialRangeFinder {
 public:
+    RF_Benewake(uint8_t port_num): SerialRangeFinder(port_num) {};
 
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 

--- a/libraries/SITL/SIM_RF_Benewake_TF02.h
+++ b/libraries/SITL/SIM_RF_Benewake_TF02.h
@@ -36,12 +36,37 @@ namespace SITL {
 
 class RF_Benewake_TF02 : public RF_Benewake {
 public:
+    RF_Benewake_TF02(uint8_t port_num): RF_Benewake(port_num) {};
 
+    void set_health(RangeFinder::Status health) override
+    {
+        out_of_range = 0;
+        switch (health) {
+        case RangeFinder::Status::NotConnected :
+        case RangeFinder::Status::NoData :
+            reliability = 0;
+            break;
+
+        case RangeFinder::Status::OutOfRangeLow :
+            break;
+
+        case RangeFinder::Status::OutOfRangeHigh :
+            out_of_range = 32768;
+            break;
+
+        case RangeFinder::Status::Good :
+            reliability = 7;
+            break;
+        }
+    };
+    uint8_t reliability = 7;
     // see AP_RangeFinder_Benewake.cpp for definitions
     uint8_t byte4() const override { return 1; } // strength low-bits
     uint8_t byte5() const override { return 1; } // strength high-bits
-    uint8_t byte6() const override { return 7; } // reliability
+    uint8_t byte6() const override { return reliability; } // reliability
     uint8_t byte7() const override { return 0x06; } // exposure time
+
+private:
 
 };
 

--- a/libraries/SITL/SIM_RF_Benewake_TF03.h
+++ b/libraries/SITL/SIM_RF_Benewake_TF03.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_Benewake_TF03 : public RF_Benewake {
 public:
-
+    RF_Benewake_TF03(uint8_t port_num): RF_Benewake(port_num) {};
     // see AP_RangeFinder_Benewake.cpp for definitions
     uint8_t byte4() const override { return 0; } // reserved
     uint8_t byte5() const override { return 0; } // reserved

--- a/libraries/SITL/SIM_RF_Benewake_TFmini.h
+++ b/libraries/SITL/SIM_RF_Benewake_TFmini.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_Benewake_TFmini : public RF_Benewake {
 public:
-
+    RF_Benewake_TFmini(uint8_t port_num): RF_Benewake(port_num) {};
     // see AP_RangeFinder_Benewake.cpp for definitions
     uint8_t byte4() const override { return 1; } // strength L
     uint8_t byte5() const override { return 1; } // strength H

--- a/libraries/SITL/SIM_RF_GYUS42v2.h
+++ b/libraries/SITL/SIM_RF_GYUS42v2.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_GYUS42v2 : public SerialRangeFinder {
 public:
-
+    RF_GYUS42v2(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
     // TODO: work this out

--- a/libraries/SITL/SIM_RF_Lanbao.h
+++ b/libraries/SITL/SIM_RF_Lanbao.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_Lanbao : public SerialRangeFinder {
 public:
-
+    RF_Lanbao(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 };

--- a/libraries/SITL/SIM_RF_LeddarOne.h
+++ b/libraries/SITL/SIM_RF_LeddarOne.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_LeddarOne : public SerialRangeFinder {
 public:
-
+    RF_LeddarOne(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 };

--- a/libraries/SITL/SIM_RF_LightWareSerial.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerial.cpp
@@ -40,15 +40,15 @@ bool RF_LightWareSerial::check_synced()
     return synced;
 }
 
-void RF_LightWareSerial::update(float range)
+void RF_LightWareSerial::update(float range, uint8_t health)
 {
     if (!check_synced()) {
         return;
     }
-    return SerialRangeFinder::update(range);
+    return SerialRangeFinder::update(range, health);
 }
 
 uint32_t RF_LightWareSerial::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
-    return snprintf((char*)buffer, buflen, "%f\r", alt_cm / 100.0f); // note tragic lack of snprintf return checking
+    return snprintf((char*)buffer, buflen, "%f\r", (alt_cm * out_of_range) / 100.0f); // note tragic lack of snprintf return checking
 }

--- a/libraries/SITL/SIM_RF_LightWareSerial.h
+++ b/libraries/SITL/SIM_RF_LightWareSerial.h
@@ -36,11 +36,30 @@ namespace SITL {
 class RF_LightWareSerial : public SerialRangeFinder {
 public:
     RF_LightWareSerial(uint8_t port_num): SerialRangeFinder(port_num) {};
-
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
-    void update(float range) override;
+    void update(float range, uint8_t health) override;
 
+    float out_of_range;
+    void set_health(RangeFinder::Status health) override
+    {
+        out_of_range = 1.0f;
+        switch (health) {
+        case RangeFinder::Status::NotConnected :
+            break;
+
+        case RangeFinder::Status::OutOfRangeLow :
+            break;
+
+        case RangeFinder::Status::NoData :
+        case RangeFinder::Status::OutOfRangeHigh :
+            out_of_range = -1.0f;
+            break;
+
+        case RangeFinder::Status::Good :
+            break;
+        }
+    };
 private:
 
     bool check_synced();

--- a/libraries/SITL/SIM_RF_LightWareSerial.h
+++ b/libraries/SITL/SIM_RF_LightWareSerial.h
@@ -35,6 +35,7 @@ namespace SITL {
 
 class RF_LightWareSerial : public SerialRangeFinder {
 public:
+    RF_LightWareSerial(uint8_t port_num): SerialRangeFinder(port_num) {};
 
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 

--- a/libraries/SITL/SIM_RF_LightWareSerialBinary.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerialBinary.cpp
@@ -27,7 +27,7 @@ using namespace SITL;
 uint32_t RF_LightWareSerialBinary::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
     // high byte is second 7 bits but high bit set
-    buffer[0] = ((alt_cm >> 7) & 0x7f) | (1<<7);
+    buffer[0] = ((alt_cm>> 7) & 0x7f) | (1<<7);
     // low byte is just first 7 bits
     buffer[1] = alt_cm & 0x7f;
     return 2;

--- a/libraries/SITL/SIM_RF_LightWareSerialBinary.h
+++ b/libraries/SITL/SIM_RF_LightWareSerialBinary.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_LightWareSerialBinary : public SerialRangeFinder {
 public:
-
+    RF_LightWareSerialBinary(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 };

--- a/libraries/SITL/SIM_RF_MAVLink.h
+++ b/libraries/SITL/SIM_RF_MAVLink.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_MAVLink : public SerialRangeFinder {
 public:
-
+    RF_MAVLink(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 private:

--- a/libraries/SITL/SIM_RF_MaxsonarSerialLV.h
+++ b/libraries/SITL/SIM_RF_MaxsonarSerialLV.h
@@ -35,7 +35,7 @@ namespace SITL {
 
 class RF_MaxsonarSerialLV : public SerialRangeFinder {
 public:
-
+    RF_MaxsonarSerialLV(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 };

--- a/libraries/SITL/SIM_RF_NMEA.h
+++ b/libraries/SITL/SIM_RF_NMEA.h
@@ -35,11 +35,10 @@ namespace SITL {
 
 class RF_NMEA : public SerialRangeFinder {
 public:
-
+    RF_NMEA(uint8_t port_num): SerialRangeFinder(port_num) {};
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 private:
-
 };
 
 }

--- a/libraries/SITL/SIM_RF_Wasp.cpp
+++ b/libraries/SITL/SIM_RF_Wasp.cpp
@@ -104,10 +104,10 @@ void RF_Wasp::check_configuration()
     _buflen = 0;
 }
 
-void RF_Wasp::update(float range)
+void RF_Wasp::update(float range, uint8_t health)
 {
     check_configuration();
-    return SerialRangeFinder::update(range);
+    return SerialRangeFinder::update(range, health);
 }
 
 

--- a/libraries/SITL/SIM_RF_Wasp.h
+++ b/libraries/SITL/SIM_RF_Wasp.h
@@ -36,8 +36,7 @@ namespace SITL {
 class RF_Wasp : public SerialRangeFinder {
 public:
     RF_Wasp(uint8_t port_num): SerialRangeFinder(port_num) {};
-
-    void update(float range) override;
+    void update(float range, uint8_t health) override;
 
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 

--- a/libraries/SITL/SIM_RF_Wasp.h
+++ b/libraries/SITL/SIM_RF_Wasp.h
@@ -35,6 +35,7 @@ namespace SITL {
 
 class RF_Wasp : public SerialRangeFinder {
 public:
+    RF_Wasp(uint8_t port_num): SerialRangeFinder(port_num) {};
 
     void update(float range) override;
 

--- a/libraries/SITL/SIM_RF_uLanding.h
+++ b/libraries/SITL/SIM_RF_uLanding.h
@@ -24,6 +24,8 @@ namespace SITL {
 
 class RF_uLanding : public SerialRangeFinder {
 public:
+    RF_uLanding(uint8_t port_num): SerialRangeFinder(port_num) {};
+
 };
 
 }

--- a/libraries/SITL/SIM_RF_uLanding_v0.h
+++ b/libraries/SITL/SIM_RF_uLanding_v0.h
@@ -35,6 +35,7 @@ namespace SITL {
 
 class RF_uLanding_v0 : public RF_uLanding {
 public:
+    RF_uLanding_v0(uint8_t port_num): RF_uLanding(port_num) {};
 
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 

--- a/libraries/SITL/SIM_RF_uLanding_v1.h
+++ b/libraries/SITL/SIM_RF_uLanding_v1.h
@@ -35,6 +35,7 @@ namespace SITL {
 
 class RF_uLanding_v1 : public RF_uLanding {
 public:
+    RF_uLanding_v1(uint8_t port_num): RF_uLanding(port_num) {};
 
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 

--- a/libraries/SITL/SIM_SerialRangeFinder.cpp
+++ b/libraries/SITL/SIM_SerialRangeFinder.cpp
@@ -20,7 +20,7 @@
 
 using namespace SITL;
 
-void SerialRangeFinder::update(float range)
+void SerialRangeFinder::update(float range, uint8_t health)
 {
     // just send a chunk of data at 5Hz:
     const uint32_t now = AP_HAL::millis();
@@ -28,7 +28,7 @@ void SerialRangeFinder::update(float range)
         return;
     }
     last_sent_ms = now;
-
+    set_health(static_cast<RangeFinder::Status>(health));
     const uint16_t range_cm = uint16_t(range*100);
     uint8_t data[255];
     const uint32_t packetlen = packet_for_alt(range_cm,

--- a/libraries/SITL/SIM_SerialRangeFinder.h
+++ b/libraries/SITL/SIM_SerialRangeFinder.h
@@ -23,6 +23,7 @@
 #include <SITL/SITL.h>
 
 #include "SIM_SerialDevice.h"
+#include <AP_RangeFinder/AP_RangeFinder.h>
 
 namespace SITL {
 
@@ -32,13 +33,15 @@ public:
     SerialRangeFinder(uint8_t port_num): _port_num(port_num) {};
 
     // update state
-    virtual void update(float range);
+    virtual void update(float range, uint8_t health);
 
     virtual uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) = 0;
 
     virtual uint16_t reading_interval_ms() const { return 200; } // 5Hz default
 
     uint8_t get_port() const { return _port_num; }
+
+    virtual void set_health(RangeFinder::Status health) {};
 
 private:
 

--- a/libraries/SITL/SIM_SerialRangeFinder.h
+++ b/libraries/SITL/SIM_SerialRangeFinder.h
@@ -29,7 +29,7 @@ namespace SITL {
 class SerialRangeFinder : public SerialDevice {
 public:
 
-    SerialRangeFinder() {};
+    SerialRangeFinder(uint8_t port_num): _port_num(port_num) {};
 
     // update state
     virtual void update(float range);
@@ -38,9 +38,12 @@ public:
 
     virtual uint16_t reading_interval_ms() const { return 200; } // 5Hz default
 
+    uint8_t get_port() const { return _port_num; }
+
 private:
 
     uint32_t last_sent_ms;
+    uint8_t _port_num;
 };
 
 }

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -443,6 +443,15 @@ const AP_Param::GroupInfo SITL::var_rng[] = {
     AP_GROUPINFO("SONAR_RND",     2, SITL,  sonar_noise, 0),
     AP_GROUPINFO("SONAR_SCALE",   3, SITL,  sonar_scale, 12.1212f),
     AP_GROUPINFO("RGFD_POS",     4, SITL,  rngfnd_pos_offset, 0),
+    AP_GROUPINFO("RF_0_HEALTH",     5, SITL,  rangefinder_serial_health[0], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_1_HEALTH",     6, SITL,  rangefinder_serial_health[1], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_2_HEALTH",     7, SITL,  rangefinder_serial_health[2], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_3_HEALTH",     8, SITL,  rangefinder_serial_health[3], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_4_HEALTH",     9, SITL,  rangefinder_serial_health[4], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_5_HEALTH",     10, SITL,  rangefinder_serial_health[5], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_6_HEALTH",     11, SITL,  rangefinder_serial_health[6], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_7_HEALTH",     12, SITL,  rangefinder_serial_health[7], (int8_t)RangeFinder::Status::Good),
+    AP_GROUPINFO("RF_8_HEALTH",     13, SITL,  rangefinder_serial_health[8], (int8_t)RangeFinder::Status::Good),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -53,11 +53,9 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("SERVO_SPEED",   16, SITL,  servo_speed,  0.14),
     AP_GROUPINFO("BATT_VOLTAGE",  19, SITL,  batt_voltage,  12.6f),
     AP_GROUPINFO("BATT_CAP_AH",   20, SITL,  batt_capacity_ah,  0),
-    AP_GROUPINFO("SONAR_GLITCH",  23, SITL,  sonar_glitch, 0),
-    AP_GROUPINFO("SONAR_RND",     24, SITL,  sonar_noise, 0),
+    AP_SUBGROUPEXTENSION("",      23, SITL,  var_rng),
     AP_GROUPINFO("RC_FAIL",       25, SITL,  rc_fail, 0),
     AP_GROUPINFO("FLOAT_EXCEPT",  28, SITL,  float_exception, 1),
-    AP_GROUPINFO("SONAR_SCALE",   32, SITL,  sonar_scale, 12.1212f),
     AP_GROUPINFO("FLOW_ENABLE",   33, SITL,  flow_enable, 0),
     AP_GROUPINFO("TERRAIN",       34, SITL,  terrain_enable, 1),
     AP_GROUPINFO("FLOW_RATE",     35, SITL,  flow_rate, 10),
@@ -71,7 +69,6 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("SPEEDUP",       52, SITL,  speedup, -1),
     AP_GROUPINFO("IMU_POS",       53, SITL,  imu_pos_offset, 0),
     AP_SUBGROUPEXTENSION("",      54, SITL,  var_ins),
-    AP_GROUPINFO("SONAR_POS",     55, SITL,  rngfnd_pos_offset, 0),
     AP_GROUPINFO("FLOW_POS",      56, SITL,  optflow_pos_offset, 0),
     AP_GROUPINFO("ENGINE_FAIL",   58, SITL,  engine_fail,  0),
     AP_SUBGROUPINFO(shipsim, "SHIP_", 59, SITL, ShipSim),
@@ -438,6 +435,14 @@ const AP_Param::GroupInfo SITL::var_ins[] = {
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SITL, AP_InertialSensor::TCal),
     AP_SUBGROUPINFO(imu_tcal[1], "IMUT2_", 62, SITL, AP_InertialSensor::TCal),
     AP_SUBGROUPINFO(imu_tcal[2], "IMUT3_", 63, SITL, AP_InertialSensor::TCal),
+    AP_GROUPEND
+};
+
+const AP_Param::GroupInfo SITL::var_rng[] = {
+    AP_GROUPINFO("SONAR_GLITCH",  1, SITL,  sonar_glitch, 0),
+    AP_GROUPINFO("SONAR_RND",     2, SITL,  sonar_noise, 0),
+    AP_GROUPINFO("SONAR_SCALE",   3, SITL,  sonar_scale, 12.1212f),
+    AP_GROUPINFO("RGFD_POS",     4, SITL,  rngfnd_pos_offset, 0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -472,6 +472,7 @@ public:
     // Sailboat sim only
     AP_Int8 sail_type;
 
+    AP_Int8 rangefinder_serial_health[9];
 };
 
 } // namespace SITL

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -102,6 +102,7 @@ public:
         AP_Param::setup_object_defaults(this, var_gps);
         AP_Param::setup_object_defaults(this, var_mag);
         AP_Param::setup_object_defaults(this, var_ins);
+        AP_Param::setup_object_defaults(this, var_rng);
 #ifdef SFML_JOYSTICK
         AP_Param::setup_object_defaults(this, var_sfml_joystick);
 #endif // SFML_JOYSTICK
@@ -163,6 +164,7 @@ public:
     static const struct AP_Param::GroupInfo var_gps[];
     static const struct AP_Param::GroupInfo var_mag[];
     static const struct AP_Param::GroupInfo var_ins[];
+    static const struct AP_Param::GroupInfo var_rng[];
 #ifdef SFML_JOYSTICK
     static const struct AP_Param::GroupInfo var_sfml_joystick[];
 #endif //SFML_JOYSTICK


### PR DESCRIPTION
Implement support for serial rangefinder health setting.
This improve the the coverage a bit
This save some bytes and find some issue on AP_Rangefinder

Old coverage
![lcov_rangefinder_old](https://user-images.githubusercontent.com/705341/120929044-b026a600-c6e7-11eb-93cd-f1d07f46b7a7.png)

New coverage
![lcov_rangefinder_new](https://user-images.githubusercontent.com/705341/120929055-be74c200-c6e7-11eb-9f87-6b639586f0c7.png)

