### PR TITLE
AP_Rangefinder: little fixes

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -745,7 +745,7 @@ MAV_DISTANCE_SENSOR RangeFinder::get_mav_distance_sensor_type_orient(enum Rotati
 }
 
 // get temperature reading in C.  returns true on success and populates temp argument
-bool RangeFinder::get_temp(enum Rotation orientation, float &temp)
+bool RangeFinder::get_temp(enum Rotation orientation, float &temp) const
 {
     AP_RangeFinder_Backend *backend = find_instance(orientation);
     if (backend == nullptr) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -182,7 +182,7 @@ public:
     uint32_t last_reading_ms(enum Rotation orientation) const;
 
     // get temperature reading in C.  returns true on success and populates temp argument
-    bool get_temp(enum Rotation orientation, float &temp);
+    bool get_temp(enum Rotation orientation, float &temp) const;
 
     /*
       set an externally estimated terrain height. Used to enable power

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
@@ -29,7 +29,7 @@ protected:
 
     // it is essential that anyone relying on the base-class update to
     // implement this:
-    virtual bool get_reading(uint16_t &reading_cm) { return false; }
+    virtual bool get_reading(uint16_t &reading_cm) = 0;
 
     // maximum time between readings before we change state to NoData:
     virtual uint16_t read_timeout_ms() const { return 200; }


### PR DESCRIPTION
Those were catch by coverage.
It makes save a little of flash
The change in Lightwareserial is a simplification : high_byte, c is char but the return of read() and we already checked that something is available to read, so it could not be negative. Moreover -1 & 0x7f = 127 so we cannot have negative value there.