### PR TITLE
AP_Rangefinder: fix override

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -326,7 +326,7 @@ bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend, uint8_t instance
         // we've allocated the same instance twice
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     }
-
+    backend->init_serial();
     drivers[instance] = backend;
     num_instances = MAX(num_instances, instance+1);
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -30,6 +30,7 @@ public:
 
     // update the state structure
     virtual void update() = 0;
+    virtual void init_serial() {};
 
     virtual void handle_msg(const mavlink_message_t &msg) { return; }
 #if HAL_MSP_RANGEFINDER_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
@@ -30,17 +30,23 @@ AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial(
     RangeFinder::RangeFinder_State &_state,
     AP_RangeFinder_Params &_params,
     uint8_t serial_instance) :
+    _serial_instance(serial_instance),
     AP_RangeFinder_Backend(_state, _params)
 {
-    uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
+
+}
+
+void AP_RangeFinder_Backend_Serial::init_serial()
+{
+    uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, _serial_instance);
     if (uart != nullptr) {
-        uart->begin(initial_baudrate(serial_instance), rx_bufsize(), tx_bufsize());
+        uart->begin(initial_baudrate(), rx_bufsize(), tx_bufsize());
     }
 }
 
-uint32_t AP_RangeFinder_Backend_Serial::initial_baudrate(const uint8_t serial_instance) const
+uint32_t AP_RangeFinder_Backend_Serial::initial_baudrate() const
 {
-    return AP::serialmanager().find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
+    return AP::serialmanager().find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, _serial_instance);
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
@@ -10,19 +10,21 @@ public:
                                   AP_RangeFinder_Params &_params,
                                   uint8_t serial_instance);
 
+    void init_serial() override;
     // static detection function
     static bool detect(uint8_t serial_instance);
 
 protected:
 
     // baudrate used during object construction:
-    virtual uint32_t initial_baudrate(uint8_t serial_instance) const;
+    virtual uint32_t initial_baudrate() const;
 
     // the value 0 is special to the UARTDriver - it's "use default"
     virtual uint16_t rx_bufsize() const { return 0; }
     virtual uint16_t tx_bufsize() const { return 0; }
 
     AP_HAL::UARTDriver *uart = nullptr;
+    uint8_t _serial_instance;
 
     // update state; not all backends call this!
     virtual void update(void) override;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_GYUS42v2.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_GYUS42v2.h
@@ -16,7 +16,7 @@ protected:
         return MAV_DISTANCE_SENSOR_ULTRASOUND;
     }
 
-    uint32_t initial_baudrate(uint8_t serial_instance) const override {
+    uint32_t initial_baudrate() const override {
         return 9600;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Lanbao.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Lanbao.h
@@ -11,7 +11,7 @@ public:
     using AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial;
 
     // Lanbao is always 115200:
-    uint32_t initial_baudrate(uint8_t serial_instance) const override {
+    uint32_t initial_baudrate() const override {
         return 115200;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarVu8.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarVu8.h
@@ -15,7 +15,7 @@ public:
 protected:
 
     // baudrate used during object construction:
-    uint32_t initial_baudrate(uint8_t serial_instance) const override {
+    uint32_t initial_baudrate() const override {
         return 115200;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Wasp.h
@@ -20,7 +20,7 @@ public:
 protected:
 
     // Wasp is always 115200
-    uint32_t initial_baudrate(uint8_t serial_instance) const override {
+    uint32_t initial_baudrate() const override {
         return 115200;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
@@ -17,7 +17,7 @@ protected:
     }
 
     // baudrate used during object construction:
-    uint32_t initial_baudrate(uint8_t serial_instance) const override {
+    uint32_t initial_baudrate() const override {
         return 115200;
     }
 


### PR DESCRIPTION
Alternative to https://github.com/ArduPilot/ardupilot/pull/17660.
It consumes a little more space as setting serial instance as parameter will be allocating it into each serial rangefinder driver.