### PR TITLE
AC_PrecLand: Add low pass filter to PrecLand output

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -111,6 +111,7 @@ private:
     AP_Float                    _land_ofs_cm_y;     // Desired landing position of the camera right of the target in vehicle body frame
     AP_Float                    _accel_noise;       // accelerometer process noise
     AP_Vector3f                 _cam_offset;        // Position of the camera relative to the CG
+    AP_Float                    _cutoff_filt;
 
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently
@@ -126,6 +127,9 @@ private:
 
     Vector2f                    _target_pos_rel_out_NE; // target's position relative to the camera, fed into position controller
     Vector2f                    _target_vel_rel_out_NE; // target's velocity relative to the CG, fed into position controller
+
+    LowPassFilterVector2f       *_filter_output_pos;
+    LowPassFilterVector2f       *_filter_output_vel;
 
     // structure and buffer to hold a history of vehicle velocity
     struct inertial_data_frame_s {


### PR DESCRIPTION
This is a small improvement that adds a low pass filter to smoothen the output (both position and velocity) of the PrecLand lib.

In the graph below you can see on the left a raw output of the position.x, and on the right, a low-pass filtered version. This comes from a simulated noisy landing target stream:
![image](https://user-images.githubusercontent.com/36970042/120935310-bdf81d80-c71f-11eb-9ea2-1febb6e257a9.png)
