### PR TITLE
Scripting: support CAN read and write

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -963,6 +963,7 @@ bool AP_Arming::can_checks(bool report)
                 case AP_CANManager::Driver_Type_USD1:
                 case AP_CANManager::Driver_Type_MPPT_PacketDigital:
                 case AP_CANManager::Driver_Type_None:
+                case AP_CANManager::Driver_Type_Scripting:
                     break;
             }
         }

--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
     // @Values{Copter,Plane,Sub,Rover}: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,8:KDECAN,9:PacketDigitalCAN
-    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN,9:PacketDigital
+    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN,9:PacketDigital,10:Scripting
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, AP_CANManager::Driver_Type_UAVCAN),

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -61,6 +61,7 @@ public:
         Driver_Type_USD1 = 7,
         Driver_Type_KDECAN = 8,
         Driver_Type_MPPT_PacketDigital = 9,
+        Driver_Type_Scripting = 10,
     };
 
     void init(void);

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -21,6 +21,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_HAL/I2CDevice.h>
+#include "AP_Scripting_CANSensor.h"
 
 #ifndef SCRIPTING_MAX_NUM_I2C_DEVICE
   #define SCRIPTING_MAX_NUM_I2C_DEVICE 4
@@ -66,6 +67,11 @@ public:
     // the number of and storage for i2c devices
     uint8_t num_i2c_devices;
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> *_i2c_dev[SCRIPTING_MAX_NUM_I2C_DEVICE];
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+    // Scripting CAN sensor
+    ScriptingCANSensor *_CAN_dev;
+#endif
 
     // mission item buffer
     static const int mission_cmd_queue_size = 5;

--- a/libraries/AP_Scripting/AP_Scripting_CANSensor.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_CANSensor.cpp
@@ -1,0 +1,82 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Scripting CANSensor class, for easy scripting CAN support
+ */
+#include "AP_Scripting_CANSensor.h"
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+
+// handler for outgoing frames, using uint32
+bool ScriptingCANSensor::write_frame(AP_HAL::CANFrame &out_frame, const uint32_t timeout_us)
+{
+    return CANSensor::write_frame(out_frame, timeout_us);
+};
+
+// handler for incoming frames, add to buffers
+void ScriptingCANSensor::handle_frame(AP_HAL::CANFrame &frame)
+{
+    WITH_SEMAPHORE(sem);
+    if (buffer_list != nullptr) {
+        buffer_list->handle_frame(frame);
+    }
+}
+
+// add a new buffer to this sensor
+ScriptingCANBuffer* ScriptingCANSensor::add_buffer(uint32_t buffer_len)
+{
+    WITH_SEMAPHORE(sem);
+    ScriptingCANBuffer *new_buff = new ScriptingCANBuffer(*this, buffer_len);
+    if (buffer_list == nullptr) {
+        buffer_list = new_buff;
+    } else {
+        buffer_list->add_buffer(new_buff);
+    }
+    return new_buff;
+}
+
+// Call main sensor write method
+bool ScriptingCANBuffer::write_frame(AP_HAL::CANFrame &out_frame, const uint32_t timeout_us)
+{
+    return sensor.write_frame(out_frame, timeout_us);
+};
+
+// read a frame from the buffer
+bool ScriptingCANBuffer::read_frame(AP_HAL::CANFrame &frame)
+{
+    return buffer.pop(frame);
+}
+
+// recursively add frame to buffer
+void ScriptingCANBuffer::handle_frame(AP_HAL::CANFrame &frame)
+{
+    WITH_SEMAPHORE(sem);
+    buffer.push(frame);
+    if (next != nullptr) {
+        next->handle_frame(frame);
+    }
+}
+
+// recursively add new buffer
+void ScriptingCANBuffer::add_buffer(ScriptingCANBuffer* new_buff) {
+    WITH_SEMAPHORE(sem);
+    if (next == nullptr) {
+        next = new_buff;
+        return;
+    }
+    next->add_buffer(new_buff);
+}
+
+#endif // HAL_MAX_CAN_PROTOCOL_DRIVERS

--- a/libraries/AP_Scripting/AP_Scripting_CANSensor.h
+++ b/libraries/AP_Scripting/AP_Scripting_CANSensor.h
@@ -1,0 +1,78 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Scripting CANSensor class, for easy scripting CAN support
+ */
+ 
+#pragma once
+
+#include <AP_CANManager/AP_CANSensor.h>
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+class ScriptingCANBuffer;
+class ScriptingCANSensor : public CANSensor {
+public:
+
+    ScriptingCANSensor():CANSensor("Script") {
+        register_driver(AP_CANManager::Driver_Type::Driver_Type_Scripting);
+    }
+
+    // handler for outgoing frames, using uint32
+    bool write_frame(AP_HAL::CANFrame &out_frame, const uint32_t timeout_us);
+
+    // handler for incoming frames, add to buffers
+    void handle_frame(AP_HAL::CANFrame &frame) override;
+
+    // add a new buffer to this sensor
+    ScriptingCANBuffer* add_buffer(uint32_t buffer_len);
+
+private:
+
+    HAL_Semaphore sem;
+
+    ScriptingCANBuffer *buffer_list;
+
+};
+
+class ScriptingCANBuffer {
+public:
+
+    ScriptingCANBuffer(ScriptingCANSensor &_sensor, uint32_t buffer_size):sensor(_sensor), buffer(buffer_size) {};
+
+    // Call main sensor write method
+    bool write_frame(AP_HAL::CANFrame &out_frame, const uint32_t timeout_us);
+
+    // read a frame from the buffer
+    bool read_frame(AP_HAL::CANFrame &frame);
+
+    // recursively add frame to buffer
+    void handle_frame(AP_HAL::CANFrame &frame);
+
+    // recursively add new buffer
+    void add_buffer(ScriptingCANBuffer* new_buff);
+
+private:
+
+    ObjectBuffer<AP_HAL::CANFrame> buffer;
+
+    ScriptingCANSensor &sensor;
+
+    ScriptingCANBuffer *next;
+
+    HAL_Semaphore sem;
+
+};
+
+#endif // HAL_MAX_CAN_PROTOCOL_DRIVERS

--- a/libraries/AP_Scripting/examples/CAN_read.lua
+++ b/libraries/AP_Scripting/examples/CAN_read.lua
@@ -1,0 +1,20 @@
+-- This script is an example of reading from the CAN bus
+
+-- Load CAN driver, using the scripting protocol and with a buffer size of 5
+local driver = CAN.get_device(5)
+
+function update()
+
+  -- Read a message from the buffer
+  frame = driver:read_frame()
+
+  if frame then
+    -- note that we have to be careful to keep the ID as a uint32_t userdata to retain precision
+    gcs:send_text(0,string.format("CAN msg from " .. tostring(frame:id()) .. ": %i, %i, %i, %i, %i, %i, %i, %i", frame:data(0), frame:data(1), frame:data(2), frame:data(3), frame:data(4), frame:data(5), frame:data(6), frame:data(7)))
+  end
+
+  return update, 100
+
+end
+
+return update()

--- a/libraries/AP_Scripting/examples/CAN_write.lua
+++ b/libraries/AP_Scripting/examples/CAN_write.lua
@@ -1,0 +1,74 @@
+-- This script is an example of writing to CAN bus
+
+-- Load CAN driver, using the scripting protocol and with a buffer size of 5
+local driver = CAN.get_device(5)
+
+-- transfer ID of the message were sending
+local Transfer_ID = 0
+
+-- RGB colours in 0 - 255 range, and RGB fade speed
+local red = 255
+local green = 0
+local blue  = 0
+local fade_speed = 5
+
+
+function update()
+
+  -- send UAVCAN Light command
+  -- uavcan.equipment.indication.LightsCommand
+  -- note that as we don't do dynamic node allocation, the target light device must have a static node ID
+
+  msg = CANFrame()
+
+  -- extended frame, priority 30, message ID 1081 and node ID 11
+  -- lua cannot handle numbers so large, so we have to use uint32_t userdata
+  msg:id( (uint32_t(1) << 31) | (uint32_t(30) << 24) | (uint32_t(1081) << 8) | uint32_t(11) )
+
+  msg:data(0,0) -- set light_id = 0
+
+  -- convert colors to 565 rgb
+  local red_5bit   = red >> 3
+  local green_6bit = green >> 2
+  local blue_5bit  = blue >> 3
+
+  -- first is made up of 5 bits red and 3 bits of green
+  msg:data(1, (red_5bit << 3) | (green_6bit >> 3))
+
+  -- remaining 3 bits of green and 5 of blue
+  msg:data(2, ((green_6bit << 5) | blue_5bit) & 0xFF)
+
+  -- Tail includes, start of transfer, end of transfer, toggle and transfer ID bits.
+  msg:data(3, (1 << 7) | (1 << 6) | Transfer_ID)
+
+  Transfer_ID = Transfer_ID + 1
+  -- transfer ID is 5 bits
+  if Transfer_ID > 31 then
+    Transfer_ID = 0
+  end
+
+  -- sending 4 bytes of data
+  msg:dlc(4)
+
+  -- write the frame with a 10000us timeout
+  driver:write_frame(msg, 10000)
+
+  -- basic RGB fade
+  if red > 0 and blue == 0 then
+    red = red - fade_speed
+    green = green + fade_speed
+  end
+  if green > 0 and red == 0 then
+    green = green - fade_speed
+    blue = blue + fade_speed
+  end
+  if blue > 0 and green == 0 then
+    red = red + fade_speed
+    blue = blue - fade_speed
+  end
+
+  return update, 100
+
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -403,3 +403,20 @@ userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field throttle'array AP
 include AP_InertialSensor/AP_InertialSensor.h
 singleton AP_InertialSensor alias ins
 singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES
+
+
+include AP_Scripting/AP_Scripting_CANSensor.h depends HAL_MAX_CAN_PROTOCOL_DRIVERS
+include AP_HAL/AP_HAL.h
+
+userdata AP_HAL::CANFrame depends HAL_MAX_CAN_PROTOCOL_DRIVERS
+userdata AP_HAL::CANFrame alias CANFrame
+userdata AP_HAL::CANFrame field id uint32_t read write 0U UINT32_MAX
+userdata AP_HAL::CANFrame field data'array int(ARRAY_SIZE(ud->data)) uint8_t read write 0 UINT8_MAX
+userdata AP_HAL::CANFrame field dlc uint8_t read write 0 int(ARRAY_SIZE(ud->data))
+userdata AP_HAL::CANFrame method isExtended boolean
+userdata AP_HAL::CANFrame method isRemoteTransmissionRequest boolean
+userdata AP_HAL::CANFrame method isErrorFrame boolean
+
+ap_object ScriptingCANBuffer depends HAL_MAX_CAN_PROTOCOL_DRIVERS
+ap_object ScriptingCANBuffer method write_frame boolean AP_HAL::CANFrame uint32_t 0U UINT32_MAX
+ap_object ScriptingCANBuffer method read_frame boolean AP_HAL::CANFrame'Null


### PR DESCRIPTION
Lots of nice generator improvements. All seems to work so long as there are no CAN messages before the driver is init, messages before the script comes up will result in a hard lockup. 

I suspect something to do with threading, not sure what yet.....