### PR TITLE
AP_BattMonitor: Fix the comment of BATTx_OPTIONS

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -172,7 +172,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Battery monitor options
     // @Description: This sets options to change the behaviour of the battery monitor
-    // @Bitmask: 1:IgnoreUAVCAN SoC
+    // @Bitmask: 0:Ignore UAVCAN SoC
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
 


### PR DESCRIPTION
Correction BATTx_OPTIONS comments, you need to make changes in https://autotest.ardupilot.org/Parameters/SITL/apm.pdef.xml.gz in.
