### PR TITLE
AP_Rangefinder: Lightwareserial: remove useless negative test

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -75,15 +75,11 @@ bool AP_RangeFinder_LightWareSerial::get_reading(uint16_t &reading_cm)
                 // received the low byte which should be second
                 if (high_byte_received) {
                     const float dist = (high_byte & 0x7f) << 7 | (c & 0x7f);
-                    if (!is_negative(dist)) {
-                        sum += dist * 0.01f;
-                        valid_count++;
-                        // if still determining protocol update binary valid count
-                        if (protocol_state == ProtocolState::UNKNOWN) {
-                            binary_valid_count++;
-                        }
-                    } else {
-                        invalid_count++;
+                    sum += dist * 0.01f;
+                    valid_count++;
+                    // if still determining protocol update binary valid count
+                    if (protocol_state == ProtocolState::UNKNOWN) {
+                        binary_valid_count++;
                     }
                 }
                 high_byte_received = false;


### PR DESCRIPTION
extracted from https://github.com/ArduPilot/ardupilot/pull/17677

The change in Lightwareserial is a simplification : high_byte, c is char but the return of read() and we already checked that something is available to read, so it could not be negative. Moreover -1 & 0x7f = 127 so we cannot have negative value there.

Need a real testing even if tested in the test suite