### PR TITLE
AP_Mission: Set the WAYPOINT hold time setting to 0 or more(Fix #17488)

### DIFF
--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -560,8 +560,8 @@ bool ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd, bool always_sto
     // this will be used to remember the time in millis after we reach or pass the WP.
     loiter_start_time = 0;
 
-    // this is the delay, stored in seconds, checked such that commanded delays < 0 delay 0 seconds
-    loiter_duration = ((int16_t) cmd.p1 < 0) ? 0 : cmd.p1;
+    // this is the delay, stored in seconds
+    loiter_duration = cmd.p1;
 
     return true;
 }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -885,6 +885,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.p1 = (passby << 8) | (acp & 0x00FF);
 #else
         // delay at waypoint in seconds (this is for copters???)
+        if (is_negative(packet.param1) || (packet.param1 > UINT16_MAX)) {
+            return MAV_MISSION_INVALID_PARAM1;
+        }
         cmd.p1 = packet.param1;
 #endif
     }
@@ -938,6 +941,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_NAV_SPLINE_WAYPOINT:                   // MAV ID: 82
+        if (is_negative(packet.param1) || (packet.param1 > UINT16_MAX)) {
+            return MAV_MISSION_INVALID_PARAM1;
+        }
         cmd.p1 = packet.param1;                         // delay at waypoint in seconds
         break;
 


### PR DESCRIPTION
Fix #17488

I determine if the message is a floating value and negative because it is a floating value.
I would prefer not to implement it differently from the MAVLINK specification.

AFTER:
![Screenshot from 2021-06-08 23-56-47](https://user-images.githubusercontent.com/646194/121211458-74423b00-c8b7-11eb-807f-4c4389b7eb44.png)
