### PR TITLE
AP_Scheduler: corrected tick counter overflow handling, fixes #17642

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -160,7 +160,7 @@ void AP_Scheduler::run(uint32_t time_available)
     for (uint8_t i=0; i<_num_tasks; i++) {
         const AP_Scheduler::Task& task = (i < _num_unshared_tasks) ? _tasks[i] : _common_tasks[i - _num_unshared_tasks];
 
-        uint32_t dt = _tick_counter - _last_run[i];
+        const uint16_t dt = _tick_counter - _last_run[i];
         // we allow 0 to mean loop rate
         uint32_t interval_ticks = (is_zero(task.rate_hz) ? 1 : _loop_rate_hz / task.rate_hz);
         if (interval_ticks < 1) {


### PR DESCRIPTION
This PR fixes the issue outlined with the task scheduler in #17642.

Right now the scheduler will prematurely schedule all tasks at the same time every 65536 ticks (~163 seconds on a 400 Hz loop). The PR fixes the problem by reverting the type of the tick count difference variables to `uint16_t` from `uint32_t`.

A more detailed description of the problem (along with symptoms) is in #17642.