### PR TITLE
autotest: wipe SITL state after temperature cal test

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2406,6 +2406,11 @@ class AutoTestPlane(AutoTest):
         if not bad_value:
             raise NotAchievedException("uncompensated IMUs did not vary enough")
 
+        # the above tests change the internal persistent state of the
+        # vehicle in ways that autotest doesn't track (magically set
+        # parameters).  So wipe the vehicle's eeprom:
+        self.reset_SITL_commandline()
+
     def ekf_lane_switch(self):
 
         self.context_push()


### PR DESCRIPTION
ArduPilot internals are fiddling state that the autotest suite is
unaware of, so wipe the eeprom after the test