### PR TITLE
autotest: wait for a few seconds for arm-failure messages to appear

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5398,6 +5398,8 @@ class AutoTest(ABC):
             if t2 - tstart > timeout:
                 self.progress("Prearm bit never went true.  Attempting arm to elicit reason from autopilot")
                 self.arm_vehicle()
+                # statustexts are queued; give it a second to arrive:
+                self.delay_sim_time(5)
                 raise AutoTestTimeoutException("Prearm bit never went true")
             if self.sensor_has_state(mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK, True, True, True):
                 break


### PR DESCRIPTION
If prearms never come true then we try to arm the vehicle so it tells us
what is wrong.  Since we no longer push statustexts hard, we have to
wait for the reasons to come out at normal clocked rates.