### PR TITLE
Logging: prevent attempts to open logs in main thread while armed

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -285,6 +285,7 @@ int AP_Filesystem_FATFS::open(const char *pathname, int flags)
     FIL *fh;
     int res;
 
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     CHECK_REMOUNT();
@@ -359,6 +360,7 @@ int AP_Filesystem_FATFS::close(int fileno)
     FIL *fh;
     int res;
 
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     errno = 0;
@@ -389,6 +391,7 @@ int32_t AP_Filesystem_FATFS::read(int fd, void *buf, uint32_t count)
     int res;
     FIL *fh;
 
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     CHECK_REMOUNT();
@@ -439,6 +442,7 @@ int32_t AP_Filesystem_FATFS::write(int fd, const void *buf, uint32_t count)
     FIL *fh;
     errno = 0;
 
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     CHECK_REMOUNT();
@@ -486,6 +490,7 @@ int AP_Filesystem_FATFS::fsync(int fileno)
     FIL *fh;
     int res;
 
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     errno = 0;
@@ -515,6 +520,7 @@ off_t AP_Filesystem_FATFS::lseek(int fileno, off_t position, int whence)
     FIL *fh;
     errno = 0;
 
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     // fileno_to_fatfs checks for fd out of bounds
@@ -565,6 +571,7 @@ int AP_Filesystem_FATFS::stat(const char *name, struct stat *buf)
     time_t epoch;
     uint16_t mode;
 
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     CHECK_REMOUNT();
@@ -628,6 +635,7 @@ int AP_Filesystem_FATFS::stat(const char *name, struct stat *buf)
 
 int AP_Filesystem_FATFS::unlink(const char *pathname)
 {
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     errno = 0;
@@ -641,6 +649,7 @@ int AP_Filesystem_FATFS::unlink(const char *pathname)
 
 int AP_Filesystem_FATFS::mkdir(const char *pathname)
 {
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     errno = 0;
@@ -664,6 +673,7 @@ struct DIR_Wrapper {
 
 void *AP_Filesystem_FATFS::opendir(const char *pathdir)
 {
+    FS_CHECK_ALLOWED(nullptr);
     WITH_SEMAPHORE(sem);
 
     CHECK_REMOUNT_NULL();
@@ -691,6 +701,7 @@ void *AP_Filesystem_FATFS::opendir(const char *pathdir)
 
 struct dirent *AP_Filesystem_FATFS::readdir(void *dirp_void)
 {
+    FS_CHECK_ALLOWED(nullptr);
     WITH_SEMAPHORE(sem);
     DIR *dirp = (DIR *)dirp_void;
 
@@ -723,6 +734,7 @@ struct dirent *AP_Filesystem_FATFS::readdir(void *dirp_void)
 int AP_Filesystem_FATFS::closedir(void *dirp_void)
 {
     DIR *dirp = (DIR *)dirp_void;
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     struct DIR_Wrapper *d = (struct DIR_Wrapper *)dirp;
@@ -743,6 +755,7 @@ int AP_Filesystem_FATFS::closedir(void *dirp_void)
 // return free disk space in bytes
 int64_t AP_Filesystem_FATFS::disk_free(const char *path)
 {
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     FATFS *fs;
@@ -764,6 +777,7 @@ int64_t AP_Filesystem_FATFS::disk_free(const char *path)
 // return total disk space in bytes
 int64_t AP_Filesystem_FATFS::disk_space(const char *path)
 {
+    FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
     CHECK_REMOUNT();
@@ -812,6 +826,7 @@ bool AP_Filesystem_FATFS::set_mtime(const char *filename, const uint32_t mtime_s
     fno.fdate = fdate;
     fno.ftime = ftime;
 
+    FS_CHECK_ALLOWED(false);
     WITH_SEMAPHORE(sem);
 
     return f_utime(filename, (FILINFO *)&fno) == FR_OK;
@@ -822,6 +837,7 @@ bool AP_Filesystem_FATFS::set_mtime(const char *filename, const uint32_t mtime_s
 */
 bool AP_Filesystem_FATFS::retry_mount(void)
 {
+    FS_CHECK_ALLOWED(false);
     WITH_SEMAPHORE(sem);
     return sdcard_retry();
 }

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -78,4 +78,10 @@ public:
 
     // unload data from load_file()
     virtual void unload_file(FileData *fd);
+
+protected:
+    // return true if file operations are allowed
+    bool file_op_allowed(void) const;
 };
+
+#define FS_CHECK_ALLOWED(retfail) do { if (!file_op_allowed()) { return retfail; } } while(0)

--- a/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
@@ -51,6 +51,7 @@ static const char *map_filename(const char *fname)
 
 int AP_Filesystem_Posix::open(const char *fname, int flags)
 {
+    FS_CHECK_ALLOWED(-1);
     fname = map_filename(fname);
     // we automatically add O_CLOEXEC as we always want it for ArduPilot FS usage
     return ::open(fname, flags | O_CLOEXEC, 0644);
@@ -58,37 +59,44 @@ int AP_Filesystem_Posix::open(const char *fname, int flags)
 
 int AP_Filesystem_Posix::close(int fd)
 {
+    FS_CHECK_ALLOWED(-1);
     return ::close(fd);
 }
 
 int32_t AP_Filesystem_Posix::read(int fd, void *buf, uint32_t count)
 {
+    FS_CHECK_ALLOWED(-1);
     return ::read(fd, buf, count);
 }
 
 int32_t AP_Filesystem_Posix::write(int fd, const void *buf, uint32_t count)
 {
+    FS_CHECK_ALLOWED(-1);
     return ::write(fd, buf, count);
 }
 
 int AP_Filesystem_Posix::fsync(int fd)
 {
+    FS_CHECK_ALLOWED(-1);
     return ::fsync(fd);
 }
 
 int32_t AP_Filesystem_Posix::lseek(int fd, int32_t offset, int seek_from)
 {
+    FS_CHECK_ALLOWED(-1);
     return ::lseek(fd, offset, seek_from);
 }
 
 int AP_Filesystem_Posix::stat(const char *pathname, struct stat *stbuf)
 {
+    FS_CHECK_ALLOWED(-1);
     pathname = map_filename(pathname);
     return ::stat(pathname, stbuf);
 }
 
 int AP_Filesystem_Posix::unlink(const char *pathname)
 {
+    FS_CHECK_ALLOWED(-1);
     pathname = map_filename(pathname);
     // we match the FATFS interface and use unlink
     // for both files and directories
@@ -101,29 +109,34 @@ int AP_Filesystem_Posix::unlink(const char *pathname)
 
 int AP_Filesystem_Posix::mkdir(const char *pathname)
 {
+    FS_CHECK_ALLOWED(-1);
     pathname = map_filename(pathname);
     return ::mkdir(pathname, 0775);
 }
 
 void *AP_Filesystem_Posix::opendir(const char *pathname)
 {
+    FS_CHECK_ALLOWED(nullptr);
     pathname = map_filename(pathname);
     return (void*)::opendir(pathname);
 }
 
 struct dirent *AP_Filesystem_Posix::readdir(void *dirp)
 {
+    FS_CHECK_ALLOWED(nullptr);
     return ::readdir((DIR *)dirp);
 }
 
 int AP_Filesystem_Posix::closedir(void *dirp)
 {
+    FS_CHECK_ALLOWED(-1);
     return ::closedir((DIR *)dirp);
 }
 
 // return free disk space in bytes
 int64_t AP_Filesystem_Posix::disk_free(const char *path)
 {
+    FS_CHECK_ALLOWED(-1);
     path = map_filename(path);
     struct statfs stats;
     if (::statfs(path, &stats) < 0) {
@@ -135,6 +148,7 @@ int64_t AP_Filesystem_Posix::disk_free(const char *path)
 // return total disk space in bytes
 int64_t AP_Filesystem_Posix::disk_space(const char *path)
 {
+    FS_CHECK_ALLOWED(-1);
     path = map_filename(path);
     struct statfs stats;
     if (::statfs(path, &stats) < 0) {
@@ -149,6 +163,7 @@ int64_t AP_Filesystem_Posix::disk_space(const char *path)
  */
 bool AP_Filesystem_Posix::set_mtime(const char *filename, const uint32_t mtime_sec)
 {
+    FS_CHECK_ALLOWED(false);
     filename = map_filename(filename);
     struct utimbuf times {};
     times.actime = mtime_sec;

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -435,6 +435,17 @@ bool AP_Logger_File::StartNewLogOK() const
     if (recent_open_error()) {
         return false;
     }
+    if (hal.scheduler->in_main_thread() &&
+        hal.util->get_soft_armed() &&
+        AP_HAL::millis() - hal.util->get_last_armed_change() > 3000) {
+        // when we create the log while arming we are armed and the
+        // creation is in the main loop. We generally don't want to
+        // allow logs to start in main thread while armed, but we
+        // have an exception for the first 3s after arming to allow
+        // for the normal arming process to work. This can be removed
+        // when we move log creation to the logging thread
+        return false;
+    }
     return AP_Logger_Backend::StartNewLogOK();
 }
 


### PR DESCRIPTION
This fixes an issue where a bad sdcard can cause a remount of the filesystem while armed, which can result in the logging system creating a new log file. That causes file operations while armed from the main thread which can cause long delays in the main thread.
Because the initial creation of the log file when arming does happen in the main thread with the current code, this adds a 3 second grace period to allow file operations within 3s of arming. We can remove that once we've fixed logging to do the file creation in the logging thread.
thanks to @giacomo892 for noticing this issue on his flying wing
