### PR TITLE
AC_Loiter: init brake_accel and fix brake timer type

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -99,6 +99,7 @@ void AC_Loiter::init_target(const Vector3f& position)
     _predicted_accel.zero();
     _desired_accel.zero();
     _predicted_euler_angle.zero();
+    _brake_accel = 0.0f;
 
     // set target position
     _pos_control.set_pos_target_xy_cm(position.x, position.y);
@@ -121,6 +122,7 @@ void AC_Loiter::init_target()
     _predicted_accel.y = _pos_control.get_accel_target_cmss().y;
     _predicted_euler_angle.x = radians(_pos_control.get_roll_cd()*0.01f);
     _predicted_euler_angle.y = radians(_pos_control.get_pitch_cd()*0.01f);
+    _brake_accel = 0.0f;
 }
 
 /// reduce response for landing

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -85,6 +85,6 @@ protected:
     Vector2f    _predicted_accel;
     Vector2f    _predicted_euler_angle;
     Vector2f    _predicted_euler_rate;
-    float       _brake_timer;
-    float       _brake_accel;
+    uint32_t    _brake_timer;           // system time that brake was initiated
+    float       _brake_accel;           // acceleration due to braking from previous iteration (used for jerk limiting)
 };


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/17709 which could lead to the vehicle decelerating too quickly if Loiter was interrupted (e.g. vehicle was switched out of Loiter) during the braking phase.  The issue was that the _brace_accel variables was not being initialised to zero which meant the jerk limiting was not working properly.

This PR also modifies the type of the _brake_timer member but this makes no function difference as far as I can tell.

Before are before and after tests showing the difference.
![target-zccel-before](https://user-images.githubusercontent.com/1498098/121294809-f6b71300-c928-11eb-804a-292052d0ff6b.png)
![target-zccel-after](https://user-images.githubusercontent.com/1498098/121294812-f880d680-c928-11eb-8783-e53faba63fb0.png)
