### PR TITLE
AP_Common: Location Vector3f constructor zero out fields

### DIFF
--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -37,6 +37,8 @@ Location::Location(int32_t latitude, int32_t longitude, int32_t alt_in_cm, AltFr
 
 Location::Location(const Vector3f &ekf_offset_neu, AltFrame frame)
 {
+    zero();
+
     // store alt and alt frame
     set_alt_cm(ekf_offset_neu.z, frame);
 


### PR DESCRIPTION
The `loiter_xtrack` and `loiter_ccw` fields were not being zeroed out on construction. Thus they could be randomly set true.

Example before PR,

![image](https://user-images.githubusercontent.com/69225461/121324334-a024e700-c8de-11eb-88da-5abf9aea1967.png)

After PR,

![image](https://user-images.githubusercontent.com/69225461/121324617-e37f5580-c8de-11eb-92b4-cc2f0657e0e5.png)
