### PR TITLE
autotest: retry SITL connect many times while running under GDB

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5648,9 +5648,12 @@ Also, ignores heartbeats not from our target system'''
     def get_mavlink_connection_going(self):
         # get a mavlink connection going
         try:
+            retries = 20
+            if self.gdb:
+                retries = 20000
             self.mav = mavutil.mavlink_connection(
                 self.autotest_connection_string_to_ardupilot(),
-                retries=20,
+                retries=retries,
                 robust_parsing=True,
                 source_system=250,
                 source_component=250,


### PR DESCRIPTION
Allows for easier debugging under gdb when checking startup code