### PR TITLE
Make sure all MatekF405 bi-dir outputs get a DMA channel

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-bdshot/hwdef.dat
@@ -2,6 +2,12 @@
 
 include ../MatekF405/hwdef.dat
 
-undef PC6
+undef PC6 PC9 PA15 PA8
 
 PC6  TIM8_CH1 TIM8 PWM(1) GPIO(50) BIDIR
+PC9  TIM8_CH4 TIM8 PWM(4) GPIO(53) BIDIR
+# Can only do bdshot on M1-4, so give up DMA channels on M5/M6 to get full DMA on USART3 and UART4
+PA15 TIM2_CH1 TIM2 PWM(5) GPIO(54) NODMA
+PA8  TIM1_CH1 TIM1 PWM(6) GPIO(55) NODMA
+
+DMA_NOSHARE TIM8*


### PR DESCRIPTION
Enables bi-dir on MatekF405.

This also loses full DMA on USART1 so I've also removed the DMA on PWM5/PWM6 on the basis that if you want bi-directional dshot you are only using 4 motors and giving up DMA on these channels means that USART3 and UART4 are full DMA. If you want dshot on all channels you can use the regular config.