### PR TITLE
Ensure mandatory arming checks always occur

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -757,7 +757,7 @@ bool AP_Arming_Copter::mandatory_checks(bool display_failure)
         result = false;
     }
 
-    return result;
+    return AP_Arming::mandatory_checks(display_failure) && result;
 }
 
 void AP_Arming_Copter::set_pre_arm_check(bool b)

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -189,7 +189,7 @@ protected:
     bool disarm_switch_checks(bool report) const;
 
     // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced
-    virtual bool mandatory_checks(bool report) { return true; }
+    virtual bool mandatory_checks(bool report);
 
     // returns true if a particular check is enabled
     bool check_enabled(const enum AP_Arming::ArmingChecks check) const;


### PR DESCRIPTION
This ensures that dshot commands are sent before arming even if all arming checks are disabled. It also does this for arming side effects of FFT, Fence and Logging which are clearly not supposed to be optional.