### PR TITLE
AC_WPNav: fix xtrack reporting

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -227,6 +227,9 @@ protected:
     // updates _scurve_jerk and _scurve_jerk_time
     void calc_scurve_jerk_and_jerk_time();
 
+    // compute and set the horizontal error
+    void compute_track_xy_error(const Vector3f &curr_pos);
+
     // references and pointers to external libraries
     const AP_InertialNav&   _inav;
     const AP_AHRS_View&     _ahrs;


### PR DESCRIPTION
This is my attempt to fix the crosstrack error reporting that got started over on https://github.com/ArduPilot/ardupilot/pull/17631.

Tested in SITL on copter starting with SIM_WIND_SPD 30 and then halfway through set  SIM_WIND_SPD 40 to where the copter can no longer cope.

**Before scurves:** at https://github.com/ArduPilot/ardupilot/commit/fb789a07ce90e875aca0c16f92c14864bdbfab8e : In this image I end up with cross_track_error of say 600m
![image](https://user-images.githubusercontent.com/69225461/121478746-5815cb00-c997-11eb-8144-2780b29bb3af.png)

**Master** Note: xtrack_error = 0, but we are 242m from the WP
![image](https://user-images.githubusercontent.com/69225461/121612889-58f73d00-ca29-11eb-822e-78865c98317b.png)

**This PR** xtrack_error = 252.7m and we are 252m from WP
![image](https://user-images.githubusercontent.com/69225461/121612947-7cba8300-ca29-11eb-9b71-29e006eae205.png)