### PR TITLE
AP_Navigation: make crosstrack_error_integrator pure virtual as nobod…

### DIFF
--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -44,7 +44,7 @@ public:
     // return the crosstrack error in meters. This is the distance in
     // the X-Y plane that we are off the desired track
     virtual float crosstrack_error(void) const = 0;
-    virtual float crosstrack_error_integrator(void) const { return 0; }
+    virtual float crosstrack_error_integrator(void) const = 0;
 
     // return the distance in meters at which a turn should commence
     // to allow the vehicle to neatly move to the next track in the


### PR DESCRIPTION
…y use the base class

AP_Navigation is only use by L1_controler that implement the crosstrack_error_integrator() so the base implementation is useless for now. 

Weirdly, this don't save any flash on F4 build but use 16bytes more on Durandal ...