### PR TITLE
AP_BattMonitor: set Rotoye I2C bus param to external bus

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -151,6 +151,7 @@ AP_BattMonitor::init()
                                                                                             100000, true, 20));
                 break;
             case Type::Rotoye:
+                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL);
                 drivers[instance] = new AP_BattMonitor_SMBus_Rotoye(*this, state[instance], _params[instance],
                                                                     hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
                                                                                             100000, true, 20));


### PR DESCRIPTION
Found while testing my smartbatt PR we weren't setting the default bus for Rotoye that is set for all other external smbus monitors.

Not sure the usefulness though of the defaults besides from user experience, though?