### PR TITLE
Copter: Changing preprocessor conditions

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -41,7 +41,7 @@ void Copter::crash_check()
         return;
     }
 
-#if MODE_AUTOROTATE_ENABLED == ENABLED
+#if FRAME_CONFIG == HELI_FRAME
     //return immediately if in autorotation mode
     if (flightmode->mode_number() == Mode::Number::AUTOROTATE) {
         crash_counter = 0;


### PR DESCRIPTION
#17732 reviewed.
I stopped determining whether autorotate is disabled.
I found it easier to understand by disabling the process for all but helicopters.