### PR TITLE
AP_HAL_SITL: correct compilation for mission pread/pwrite ret check

### DIFF
--- a/libraries/AP_HAL_SITL/Storage.cpp
+++ b/libraries/AP_HAL_SITL/Storage.cpp
@@ -232,7 +232,9 @@ static void sitl_flash_open(void)
             }
             uint8_t fill[HAL_FLASH_SECTOR_SIZE*2];
             memset(fill, 0xff, sizeof(fill));
-            pwrite(flash_fd, fill, sizeof(fill), 0);
+            if (pwrite(flash_fd, fill, sizeof(fill), 0) != (ssize_t)sizeof(fill)) {
+                AP_HAL::panic("Failed to fill flash.dat");
+            }
         }
     }
 }
@@ -241,7 +243,7 @@ static bool sitl_flash_write(uint32_t addr, const uint8_t *data, uint32_t length
 {
     sitl_flash_open();
     uint8_t old[length];
-    if (pread(flash_fd, old, length, addr) != length) {
+    if (pread(flash_fd, old, length, addr) != (ssize_t)length) {
         AP_HAL::panic("Failed to read flash.dat at %u len=%u", unsigned(addr), unsigned(length));
     }
 #if defined(HAL_FLASH_MIN_WRITE_SIZE) && HAL_FLASH_MIN_WRITE_SIZE == 32
@@ -275,13 +277,13 @@ static bool sitl_flash_write(uint32_t addr, const uint8_t *data, uint32_t length
         }
 #endif
     }
-    return pwrite(flash_fd, data, length, addr) == length;
+    return pwrite(flash_fd, data, length, addr) == (ssize_t)length;
 }
 
 static bool sitl_flash_read(uint32_t addr, uint8_t *data, uint32_t length)
 {
     sitl_flash_open();
-    return pread(flash_fd, data, length, addr) == length;
+    return pread(flash_fd, data, length, addr) == (ssize_t)length;
 }
 
 static bool sitl_flash_erasepage(uint32_t page)


### PR DESCRIPTION
pwrite is marked as must-check-return-result on some compilers

We were comparing signed result and unsigned length, so cast length of them.
