### PR TITLE
Copter: Append the flight mode number to the message

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -198,8 +198,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
     }
 
     Mode *new_flightmode = mode_from_mode_num((Mode::Number)mode);
-    if (new_flightmode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode %d", uint8_t(mode));
+    if (is_no_such_mode((void*)new_flightmode, uint8_t(mode))) {
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -199,7 +199,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 
     Mode *new_flightmode = mode_from_mode_num((Mode::Number)mode);
     if (new_flightmode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode");
+        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode %d", uint8_t(mode));
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -279,8 +279,7 @@ bool Plane::set_mode(const uint8_t new_mode, const ModeReason reason)
 {
     static_assert(sizeof(Mode::Number) == sizeof(new_mode), "The new mode can't be mapped to the vehicles mode number");
     Mode *mode = plane.mode_from_mode_num(static_cast<Mode::Number>(new_mode));
-    if (mode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Error: invalid mode number: %u", (unsigned)new_mode);
+    if (is_no_such_mode((void*)mode, new_mode)) {
         return false;
     }
     return set_mode(*mode, reason);
@@ -289,8 +288,7 @@ bool Plane::set_mode(const uint8_t new_mode, const ModeReason reason)
 bool Plane::set_mode_by_number(const Mode::Number new_mode_number, const ModeReason reason)
 {
     Mode *new_mode = plane.mode_from_mode_num(new_mode_number);
-    if (new_mode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Error: invalid mode number: %d", new_mode_number);
+    if (is_no_such_mode((void*)new_mode, new_mode_number)) {
         return false;
     }
     return set_mode(*new_mode, reason);

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -56,7 +56,7 @@ bool Blimp::set_mode(Mode::Number mode, ModeReason reason)
 
     Mode *new_flightmode = mode_from_mode_num((Mode::Number)mode);
     if (new_flightmode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode");
+        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode %u", uint8_t(mode));
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -55,8 +55,7 @@ bool Blimp::set_mode(Mode::Number mode, ModeReason reason)
     }
 
     Mode *new_flightmode = mode_from_mode_num((Mode::Number)mode);
-    if (new_flightmode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode %u", uint8_t(mode));
+    if (is_no_such_mode((void*)new_flightmode, uint8_t(mode))) {
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -405,6 +405,23 @@ void AP_Vehicle::publish_osd_info()
 }
 #endif
 
+/**
+ * Determine if flight mode is invalid
+ *
+ * @param [in] mode Flight Mode Pointer
+ * @param [in] mode_num Flight mode number
+ * @retval true Flight mode for flight number is invalid
+ * @retval false Flight mode for flight number is valid
+ */
+bool AP_Vehicle::is_no_such_mode(void* mode, uint8_t mode_num)
+{
+    if (mode == nullptr) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "invalid mode number: %d", mode_num);
+        return true;
+    }
+    return false;
+}
+
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;
 
 AP_Vehicle *AP_Vehicle::get_singleton()

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -336,6 +336,8 @@ protected:
 
     ModeReason control_mode_reason = ModeReason::UNKNOWN;
 
+    bool is_no_such_mode(void* mode, uint8_t mode_num);
+
 private:
 
     // delay() callback that processing MAVLink packets


### PR DESCRIPTION
There is a time lag between the response to the MAVLINK message and the GCS message.
I can convert the GCS message to a flight name if there is a flight mode number in the message.

![Screenshot from 2021-06-13 01-11-43](https://user-images.githubusercontent.com/646194/121782632-81c43180-cbe5-11eb-96c4-ba70f48aaaf1.png)
