### PR TITLE
AP_Scheduler: Change the Task Performance Notification Level to information

### DIFF
--- a/libraries/AP_Scheduler/PerfInfo.cpp
+++ b/libraries/AP_Scheduler/PerfInfo.cpp
@@ -162,7 +162,7 @@ float AP::PerfInfo::get_filtered_time() const
 
 void AP::PerfInfo::update_logging() const
 {
-    gcs().send_text(MAV_SEVERITY_WARNING,
+    gcs().send_text(MAV_SEVERITY_INFO,
                     "PERF: %u/%u [%lu:%lu] F=%uHz sd=%lu Ex=%lu",
                     (unsigned)get_num_long_running(),
                     (unsigned)get_num_loops(),


### PR DESCRIPTION
This GCS message informs you of the performance information.
The level of the GCS message is warning.
Since this message is not a warning, change the level to information.