### PR TITLE
Logging: Move log file open to backend thread

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
@@ -71,11 +71,6 @@ bool AP_Filesystem_Backend::file_op_allowed(void) const
     if (!hal.util->get_soft_armed() || !hal.scheduler->in_main_thread()) {
         return true;
     }
-    if (AP_HAL::millis() - hal.util->get_last_armed_change() < 3000) {
-        // allow file operations from main thread in first 3s after
-        // arming to allow for log file creation
-        return true;
-    }
     return false;
 }
 

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -459,16 +459,25 @@ bool AP_Logger_Backend::ShouldLog(bool is_critical)
     return true;
 }
 
-void AP_Logger_Backend::PrepForArming()
+// check if we should rotate when arming
+void AP_Logger_Backend::arming_rotate_check(void)
 {
     if (_rotate_pending) {
         _rotate_pending = false;
         stop_logging();
     }
-    if (logging_started()) {
-        return;
+}
+
+/*
+  setup for armed state, starting logging
+  This function is replaced in the File backend
+ */
+void AP_Logger_Backend::PrepForArming()
+{
+    arming_rotate_check();
+    if (!logging_started()) {
+        start_new_log();
     }
-    start_new_log();
 }
 
 bool AP_Logger_Backend::Write_MessageF(const char *fmt, ...)

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -459,25 +459,16 @@ bool AP_Logger_Backend::ShouldLog(bool is_critical)
     return true;
 }
 
-// check if we should rotate when arming
-void AP_Logger_Backend::arming_rotate_check(void)
+void AP_Logger_Backend::PrepForArming()
 {
     if (_rotate_pending) {
         _rotate_pending = false;
         stop_logging();
     }
-}
-
-/*
-  setup for armed state, starting logging
-  This function is replaced in the File backend
- */
-void AP_Logger_Backend::PrepForArming()
-{
-    arming_rotate_check();
-    if (!logging_started()) {
-        start_new_log();
+    if (logging_started()) {
+        return;
     }
+    PrepForArming_start_logging();
 }
 
 bool AP_Logger_Backend::Write_MessageF(const char *fmt, ...)

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -144,8 +144,10 @@ protected:
     virtual bool WritesOK() const = 0;
     virtual bool StartNewLogOK() const;
 
-    // check if we should rotate when arming
-    void arming_rotate_check(void);
+    // called by PrepForArming to actually start logging
+    virtual void PrepForArming_start_logging(void) {
+        start_new_log();
+    }
 
     /*
       read a block

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -144,6 +144,9 @@ protected:
     virtual bool WritesOK() const = 0;
     virtual bool StartNewLogOK() const;
 
+    // check if we should rotate when arming
+    void arming_rotate_check(void);
+
     /*
       read a block
     */

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -710,17 +710,14 @@ void AP_Logger_File::stop_logging(void)
 }
 
 /*
-  wrapper for PrepForArming to move start_new_log to the logger thread
+  does start_new_log in the logger thread
  */
-void AP_Logger_File::PrepForArming()
+void AP_Logger_File::PrepForArming_start_logging()
 {
-#if APM_BUILD_TYPE(APM_BUILD_Replay)
-    AP_Logger_Backend::PrepForArming();
-#else
-    arming_rotate_check();
     if (logging_started()) {
         return;
     }
+
     uint32_t start_ms = AP_HAL::millis();
     const uint32_t open_limit_ms = 250;
 
@@ -736,7 +733,6 @@ void AP_Logger_File::PrepForArming()
         }
         hal.scheduler->delay(1);
     }
-#endif
 }
 
 /*

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -61,6 +61,7 @@ protected:
 
     bool WritesOK() const override;
     bool StartNewLogOK() const override;
+    void PrepForArming() override;
 
 private:
     int _write_fd = -1;
@@ -134,6 +135,8 @@ private:
     void erase_next(void);
 
     const char *last_io_operation = "";
+
+    bool start_new_log_pending;
 };
 
 #endif // HAL_LOGGING_FILESYSTEM_ENABLED

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -61,7 +61,7 @@ protected:
 
     bool WritesOK() const override;
     bool StartNewLogOK() const override;
-    void PrepForArming() override;
+    void PrepForArming_start_logging() override;
 
 private:
     int _write_fd = -1;


### PR DESCRIPTION
This is to prevent watchdogs when the filesystem is corrupt and a file open for logging may block for more than the watchdog timeout.
@peterbarker has a more comprehensive PR here: https://github.com/ArduPilot/ardupilot/pull/17267
that PR is much more complex however. This PR is extremely simple, making it more suitable for consideration for 4.1.0

tested in SITL and on MatekF405-Wing
