### PR TITLE
Copter: add configurable rangefinder filter and restore default to 0.25

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1058,6 +1058,18 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 44, ParametersG2, flight_options, 0),
 
+#if RANGEFINDER_ENABLED == ENABLED
+    // @Param: RNGFND_FILT
+    // @DisplayName: Rangefinder filter
+    // @Description: Rangefinder filter to smooth distance.  Set to zero to disable filtering
+    // @Units: Hz
+    // @Range: 0 50
+    // @Increment: 0.05
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("RNGFND_FILT", 45, ParametersG2, rangefinder_filt, RANGEFINDER_FILT_DEFAULT),
+#endif
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -645,6 +645,10 @@ public:
 
     AP_Int32 flight_options;
 
+#if RANGEFINDER_ENABLED == ENABLED
+    AP_Float rangefinder_filt;
+#endif
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -92,16 +92,16 @@
  # define RANGEFINDER_GAIN_DEFAULT 0.8f     // gain for controlling how quickly rangefinder range adjusts target altitude (lower means slower reaction)
 #endif
 
+#ifndef RANGEFINDER_FILT_DEFAULT
+ # define RANGEFINDER_FILT_DEFAULT 0.25f    // filter for rangefinder distance
+#endif
+
 #ifndef SURFACE_TRACKING_VELZ_MAX
  # define SURFACE_TRACKING_VELZ_MAX 150     // max vertical speed change while surface tracking with rangefinder
 #endif
 
 #ifndef SURFACE_TRACKING_TIMEOUT_MS
  # define SURFACE_TRACKING_TIMEOUT_MS  1000 // surface tracking target alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
-#endif
-
-#ifndef RANGEFINDER_WPNAV_FILT_HZ
- # define RANGEFINDER_WPNAV_FILT_HZ   0.5f // filter frequency for rangefinder altitude provided to waypoint navigation class
 #endif
 
 #ifndef RANGEFINDER_TILT_CORRECTION         // by disable tilt correction for use of range finder data by EKF

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -15,11 +15,11 @@ void Copter::init_rangefinder(void)
 #if RANGEFINDER_ENABLED == ENABLED
    rangefinder.set_log_rfnd_bit(MASK_LOG_CTUN);
    rangefinder.init(ROTATION_PITCH_270);
-   rangefinder_state.alt_cm_filt.set_cutoff_frequency(RANGEFINDER_WPNAV_FILT_HZ);
+   rangefinder_state.alt_cm_filt.set_cutoff_frequency(g2.rangefinder_filt);
    rangefinder_state.enabled = rangefinder.has_orientation(ROTATION_PITCH_270);
 
    // upward facing range finder
-   rangefinder_up_state.alt_cm_filt.set_cutoff_frequency(RANGEFINDER_WPNAV_FILT_HZ);
+   rangefinder_up_state.alt_cm_filt.set_cutoff_frequency(g2.rangefinder_filt);
    rangefinder_up_state.enabled = rangefinder.has_orientation(ROTATION_PITCH_90);
 #endif
 }


### PR DESCRIPTION
This PR adds a RNGFND_FILT parameter to allow the user to configure the filtering used for surface tracking and terrain following.  The default filter value is set to 0.25 which was the default for 4.0 (lower than default of 0.5 which is currently in master)

This parameter appears to be necessary because PR https://github.com/ArduPilot/ardupilot/pull/16135 increased the filter value from 0.25 to 0.5 to reduce overshoot during takeoffs but during 4.1 beta testing we have a user complaining of "Dolphin" terrain following ([discussion is here](https://discuss.ardupilot.org/t/dolphin-fly-big-altitude-oscillation-in-rangefinder-based-auto-mission/72008)).

This has been lightly tested in SITL and below is a screenshot of the vehicles desired and actual climb rate when filters were set to 0.5 and 10 respectively.

![sitl-testing](https://user-images.githubusercontent.com/1498098/121837719-4aeb3a00-cd11-11eb-923a-72e336c3bbef.png)
