### PR TITLE
AP_Scripting - add bindings for set_home() and get_origin()

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1089,6 +1089,7 @@ bool AP_AHRS_DCM::airspeed_estimate(uint8_t airspeed_index, float &airspeed_ret)
 
 bool AP_AHRS_DCM::set_home(const Location &loc)
 {
+    WITH_SEMAPHORE(_rsem);
     // check location is valid
     if (loc.lat == 0 && loc.lng == 0 && loc.alt == 0) {
         return false;

--- a/libraries/AP_Scripting/examples/ahrs-print-home-and-origin.lua
+++ b/libraries/AP_Scripting/examples/ahrs-print-home-and-origin.lua
@@ -1,0 +1,21 @@
+-- example script for using "get_origin()"
+-- prints the home and ekf origin lat long and altitude to the console every 5 seconds
+
+function update ()
+
+    home = ahrs:get_home()
+    origin = ahrs:get_origin()
+
+    if home then
+        gcs:send_text(0, string.format("Home - Lat:%.1f Long:%.1f Alt:%.1f", home:lat(), home:lng(), home:alt()))
+    end
+
+    if origin then
+        gcs:send_text(0, string.format("Origin - Lat:%.1f Long:%.1f Alt:%.1f", origin:lat(), origin:lng(), origin:alt()))
+    end
+
+    return update, 5000
+
+end
+
+return update()

--- a/libraries/AP_Scripting/examples/ahrs-set-home-to-vehicle-location.lua
+++ b/libraries/AP_Scripting/examples/ahrs-set-home-to-vehicle-location.lua
@@ -1,0 +1,15 @@
+-- example script for using "set_home()"
+-- sets the home location to the current vehicle location every 5 seconds
+
+function update ()
+
+    if ahrs:home_is_set() then
+        ahrs:set_home(ahrs:get_position())
+        gcs:send_text(0, "Home position reset")
+    end
+
+    return update, 5000
+
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -44,6 +44,8 @@ singleton AP_AHRS method get_EAS2TAS float
 singleton AP_AHRS method get_variances boolean float'Null float'Null float'Null Vector3f'Null float'Null
 singleton AP_AHRS method set_posvelyaw_source_set void uint8_t 0 2
 singleton AP_AHRS method get_vel_innovations_and_variances_for_source boolean uint8_t 3 6 Vector3f'Null Vector3f'Null
+singleton AP_AHRS method set_home boolean Location
+singleton AP_AHRS method get_origin boolean Location'Null
 
 include AP_Arming/AP_Arming.h
 


### PR DESCRIPTION
Add Lua bindings for AHRS methods set_home() and get_origin() as well as example scripts for each. 

I've also added a semaphore around the set_home() function in the AHRS code, as requested by @WickedShell - this may require further discussion. 