### PR TITLE
Coveralls3: add CAN code coverage

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ardupilot/ardupilot-dev-coverage:latest
-      options: --user 1001
+      options: --privileged
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -22,6 +22,7 @@ jobs:
         ]
         config: [
             coverage,
+            sitltest-can,
         ]
     steps:
       # git checkout the PR
@@ -49,6 +50,16 @@ jobs:
           echo "max_size = 400M" >> ~/.ccache/ccache.conf
           ccache -s
           ccache -z
+      - name: Configure CAN
+        if: ${{ matrix.config == 'sitltest-can'}}
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt update
+          sudo apt install -y gcc-multilib g++-multilib
+          sudo apt -y install can-utils iproute2 linux-modules-extra-$(uname -r)
+          sudo modprobe vcan
+          sudo ip link add dev vcan0 type vcan
+          sudo ip link set up vcan0
       - name: test ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -59,10 +70,33 @@ jobs:
           python -m pip uninstall -y pymavlink
           git submodule update --init --recursive
           (cd modules/mavlink/pymavlink && DISABLE_MAVNATIVE=True MDEF="$PWD/../message_definitions" python -m pip install --user .)
-          Tools/scripts/run_coverage.py -f
+          if [[ ${{ matrix.config }} = "coverage" ]]; then
+            Tools/scripts/run_coverage.py -f
+          else
+            Tools/scripts/run_coverage.py -i
+            ./waf configure --board sitl_periph_gps --debug --coverage
+            ./waf build --target bin/AP_Periph
+            Tools/scripts/run_coverage.py -i
+            Tools/autotest/autotest.py test.CAN --debug --coverage
+            Tools/scripts/run_coverage.py -u
+          fi
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./reports/lcov-report/lcov.info
+          flag-name: run-${{matrix.config}}
+          parallel: true
+
+
+  finish:
+    if: always()
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/Tools/scripts/run_coverage.py
+++ b/Tools/scripts/run_coverage.py
@@ -230,9 +230,12 @@ class CoverageRunner(object):
                                     ".waf*",
                                     root_dir + "/modules/gtest/*",
                                     root_dir + "/modules/uavcan/*",
+                                    root_dir + "/modules/libcanard/*",
                                     root_dir + "/build/linux/libraries/*",
                                     root_dir + "/build/sitl/libraries/*",
                                     root_dir + "/build/sitl/modules/*",
+                                    root_dir + "/build/sitl_periph_gps/libraries/*",
+                                    root_dir + "/build/sitl_periph_gps/modules/*",
                                     root_dir + "/libraries/*/examples/*",
                                     "-o", self.INFO_FILE
                                     ], stdout=tmp_file, stderr=subprocess.STDOUT, text=True, check=True)


### PR DESCRIPTION
Add sitl_periph_gps test to code coverage. 
This initialize the coverage support for AP_Periph and fill some data into the CAN testing !