### PR TITLE
AP_Soaring: Remove redundant ALERT messages

### DIFF
--- a/ArduPlane/mode_thermal.cpp
+++ b/ArduPlane/mode_thermal.cpp
@@ -94,17 +94,17 @@ void ModeThermal::update_soaring()
     // Heading lined up and loiter status not good to continue. Need to restore previous mode.
     switch (loiterStatus) {
     case SoaringController::LoiterStatus::ALT_TOO_HIGH:
-        restore_mode("Too high", ModeReason::SOARING_ALT_TOO_HIGH);
+        restore_mode("Reached SOAR_ALT_MAX", ModeReason::SOARING_ALT_TOO_HIGH);
         break;
     case SoaringController::LoiterStatus::ALT_TOO_LOW:
-        restore_mode("Too low", ModeReason::SOARING_ALT_TOO_LOW);
+        restore_mode("Reached SOAR_ALT_MIN", ModeReason::SOARING_ALT_TOO_LOW);
         break;
     default:
     case SoaringController::LoiterStatus::THERMAL_WEAK:
-        restore_mode("Thermal ended", ModeReason::SOARING_THERMAL_ESTIMATE_DETERIORATED);
+        restore_mode("Climb below SOAR_VSPEED", ModeReason::SOARING_THERMAL_ESTIMATE_DETERIORATED);
         break;
     case SoaringController::LoiterStatus::DRIFT_EXCEEDED:
-        restore_mode("Drifted too far", ModeReason::SOARING_DRIFT_EXCEEDED);
+        restore_mode("Reached SOAR_MAX_DRIFT", ModeReason::SOARING_DRIFT_EXCEEDED);
         break;
     case SoaringController::LoiterStatus::EXIT_COMMANDED:
         restore_mode("Exit via RC switch", ModeReason::RC_COMMAND);

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -197,10 +197,13 @@ bool SoaringController::check_thermal_criteria()
 
 SoaringController::LoiterStatus SoaringController::check_cruise_criteria(Vector2f prev_wp, Vector2f next_wp)
 {
+    // Check conditions for re-entering cruise. Note that the aircraft needs to also be aligned with the appropriate
+    // heading before some of these conditions will actually trigger.
+    // The GCS messages are emitted in mode_thermal.cpp. Update these if the logic here is changed.
+
     ActiveStatus status = active_state();
 
     if (status == ActiveStatus::SOARING_DISABLED) {
-        _cruise_criteria_msg_last = LoiterStatus::DISABLED;
         return LoiterStatus::DISABLED;
     }
 
@@ -211,35 +214,19 @@ SoaringController::LoiterStatus SoaringController::check_cruise_criteria(Vector2
         result = LoiterStatus::EXIT_COMMANDED;
     } else if (alt > alt_max) {
         result = LoiterStatus::ALT_TOO_HIGH;
-        if (result != _cruise_criteria_msg_last) {
-            gcs().send_text(MAV_SEVERITY_ALERT, "Reached upper alt = %dm", (int16_t)alt);
-        }
     } else if (alt < alt_min) {
         result = LoiterStatus::ALT_TOO_LOW;
-        if (result != _cruise_criteria_msg_last) {
-            gcs().send_text(MAV_SEVERITY_ALERT, "Reached lower alt = %dm", (int16_t)alt);
-        }
     } else if ((AP_HAL::micros64() - _thermal_start_time_us) > ((unsigned)min_thermal_s * 1e6)) {
         const float mcCreadyAlt = McCready(alt);
         if (_thermalability < mcCreadyAlt) {
             result = LoiterStatus::THERMAL_WEAK;
-            if (result != _cruise_criteria_msg_last) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Thermal weak: th %3.1fm/s alt %3.1fm Mc %3.1fm/s", (double)_thermalability, (double)alt, (double)mcCreadyAlt);
-            }
         } else if (alt < (-_thermal_start_pos.z) || _vario.smoothed_climb_rate < 0.0) {
             result = LoiterStatus::ALT_LOST;
-            if (result != _cruise_criteria_msg_last) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Not climbing");
-            }
         } else if (check_drift(prev_wp, next_wp)) {
             result = LoiterStatus::DRIFT_EXCEEDED;
-            if (result != _cruise_criteria_msg_last) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Drifted too far");
-            }
         }
     }
 
-    _cruise_criteria_msg_last = result;
     return result;
 }
 

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -138,8 +138,6 @@ public:
     float get_thermalling_radius() const;
 
 private:
-    // slow down messages if they are the same. During loiter we could smap the same message. Only show new messages during loiters
-    LoiterStatus _cruise_criteria_msg_last;
 
     ActiveStatus _last_update_status;
 


### PR DESCRIPTION
- Remove debug messages encountered in normal operation that don't result in an action, previously sent at ALERT priority.
- Update remaining messages to reference the relevant parameter names.