### PR TITLE
AC_Precland: remove unnecessary abstraction on getter

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.cpp
@@ -1,0 +1,10 @@
+#include "AC_PrecLand_Backend.h"
+
+bool AC_PrecLand_Backend::get_los_body(Vector3f& dir_body) const
+{
+    if (_have_los_meas) {
+        dir_body = _los_meas_body;
+        return true;
+    }
+    return false;
+}

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -23,16 +23,16 @@ public:
 
     // provides a unit vector towards the target in body frame
     //  returns same as have_los_meas()
-    virtual bool get_los_body(Vector3f& dir_body) = 0;
+    bool get_los_body(Vector3f& dir_body) const;
 
     // returns system time in milliseconds of last los measurement
-    virtual uint32_t los_meas_time_ms() = 0;
+    uint32_t los_meas_time_ms() const { return _los_meas_time_ms; };
 
     // return true if there is a valid los measurement available
-    virtual bool have_los_meas() = 0;
+    bool have_los_meas() const { return _have_los_meas; };
 
     // returns distance to target in meters (0 means distance is not known)
-    virtual float distance_to_target() { return 0.0f; };
+    virtual float distance_to_target() const { return 0.0f; };
 
     // parses a mavlink message from the companion computer
     virtual void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) {};
@@ -43,4 +43,7 @@ public:
 protected:
     const AC_PrecLand&  _frontend;          // reference to precision landing front end
     AC_PrecLand::precland_state &_state;    // reference to this instances state
+    Vector3f _los_meas_body;                // unit vector in body frame pointing towards target
+    uint32_t _los_meas_time_ms;             // system time in milliseconds when los was measured
+    bool _have_los_meas;                    // true if there is a valid measurement from the camera
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -15,29 +15,8 @@ void AC_PrecLand_Companion::update()
     _have_los_meas = _have_los_meas && AP_HAL::millis()-_los_meas_time_ms <= 1000;
 }
 
-// provides a unit vector towards the target in body frame
-//  returns same as have_los_meas()
-bool AC_PrecLand_Companion::get_los_body(Vector3f& ret) {
-    if (have_los_meas()) {
-        ret = _los_meas_body;
-        return true;
-    }
-    return false;
-}
-
-// returns system time in milliseconds of last los measurement
-uint32_t AC_PrecLand_Companion::los_meas_time_ms() {
-    return _los_meas_time_ms;
-}
-
-// return true if there is a valid los measurement available
-bool AC_PrecLand_Companion::have_los_meas()
-{
-    return _have_los_meas;
-}
-
 // return distance to target
-float AC_PrecLand_Companion::distance_to_target()
+float AC_PrecLand_Companion::distance_to_target() const
 {
     return _distance_to_target;
 }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -22,18 +22,8 @@ public:
     // retrieve updates from sensor
     void update() override;
 
-    // provides a unit vector towards the target in body frame
-    //  returns same as have_los_meas()
-    bool get_los_body(Vector3f& ret) override;
-
-    // returns system time in milliseconds of last los measurement
-    uint32_t los_meas_time_ms() override;
-
-    // return true if there is a valid los measurement available
-    bool have_los_meas() override;
-
     // returns distance to target in meters (0 means distance is not known)
-    float distance_to_target() override;
+    float distance_to_target() const override;
 
     // parses a mavlink message from the companion computer
     void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) override;
@@ -41,7 +31,4 @@ public:
 private:
     float               _distance_to_target;    // distance from the camera to target in meters
 
-    Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
-    bool                _have_los_meas;         // true if there is a valid measurement from the camera
-    uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
@@ -30,23 +30,3 @@ void AC_PrecLand_IRLock::update()
     }
     _have_los_meas = _have_los_meas && AP_HAL::millis()-_los_meas_time_ms <= 1000;
 }
-
-// provides a unit vector towards the target in body frame
-//  returns same as have_los_meas()
-bool AC_PrecLand_IRLock::get_los_body(Vector3f& ret) {
-    if (have_los_meas()) {
-        ret = _los_meas_body;
-        return true;
-    }
-    return false;
-}
-
-// returns system time in milliseconds of last los measurement
-uint32_t AC_PrecLand_IRLock::los_meas_time_ms() {
-    return _los_meas_time_ms;
-}
-
-// return true if there is a valid los measurement available
-bool AC_PrecLand_IRLock::have_los_meas() {
-    return _have_los_meas;
-}

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
@@ -26,23 +26,10 @@ public:
     // retrieve updates from sensor
     void update() override;
 
-    // provides a unit vector towards the target in body frame
-    //  returns same as have_los_meas()
-    bool get_los_body(Vector3f& ret) override;
-
-    // returns system time in milliseconds of last los measurement
-    uint32_t los_meas_time_ms() override;
-
-    // return true if there is a valid los measurement available
-    bool have_los_meas() override;
-
 private:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     AP_IRLock_SITL irlock;
 #else
     AP_IRLock_I2C irlock;
 #endif
-    Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
-    bool                _have_los_meas;         // true if there is a valid measurement from the camera
-    uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
@@ -29,20 +29,4 @@ void AC_PrecLand_SITL::update()
     _have_los_meas = _have_los_meas && AP_HAL::millis() - _los_meas_time_ms <= 1000;
 }
 
-bool AC_PrecLand_SITL::have_los_meas() {
-    return AP_HAL::millis() - _los_meas_time_ms < 1000;
-}
-
-
-// provides a unit vector towards the target in body frame
-//  returns same as have_los_meas()
-bool AC_PrecLand_SITL::get_los_body(Vector3f& ret) {
-    if (AP_HAL::millis() - _los_meas_time_ms > 1000) {
-        // no measurement for a full second; no vector available
-        return false;
-    }
-    ret = _los_meas_body;
-    return true;
-}
-
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.h
@@ -22,21 +22,9 @@ public:
     // retrieve updates from sensor
     void update() override;
 
-    // provides a unit vector towards the target in body frame
-    //  returns same as have_los_meas()
-    bool get_los_body(Vector3f& ret) override;
-
-    // returns system time in milliseconds of last los measurement
-    uint32_t los_meas_time_ms() override { return _los_meas_time_ms; }
-
-    // return true if there is a valid los measurement available
-    bool have_los_meas() override;
-
 private:
     SITL::SITL          *_sitl;                 // sitl instance pointer
-    Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
-    uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
-    bool                _have_los_meas;         // true if there is a valid measurement from the camera
+
 };
 
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
@@ -35,24 +35,4 @@ void AC_PrecLand_SITL_Gazebo::update()
     _have_los_meas = _have_los_meas && AP_HAL::millis()-_los_meas_time_ms <= 1000;
 }
 
-// provides a unit vector towards the target in body frame
-//  returns same as have_los_meas()
-bool AC_PrecLand_SITL_Gazebo::get_los_body(Vector3f& ret) {
-    if (have_los_meas()) {
-        ret = _los_meas_body;
-        return true;
-    }
-    return false;
-}
-
-// returns system time in milliseconds of last los measurement
-uint32_t AC_PrecLand_SITL_Gazebo::los_meas_time_ms() {
-    return _los_meas_time_ms;
-}
-
-// return true if there is a valid los measurement available
-bool AC_PrecLand_SITL_Gazebo::have_los_meas() {
-    return _have_los_meas;
-}
-
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
@@ -23,22 +23,9 @@ public:
     // retrieve updates from sensor
     void update() override;
 
-    // provides a unit vector towards the target in body frame
-    //  returns same as have_los_meas()
-    bool get_los_body(Vector3f& ret) override;
-
-    // returns system time in milliseconds of last los measurement
-    uint32_t los_meas_time_ms() override;
-
-    // return true if there is a valid los measurement available
-    bool have_los_meas() override;
-
 private:
     AP_IRLock_SITL_Gazebo irlock;
 
-    Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
-    bool                _have_los_meas;         // true if there is a valid measurement from the camera
-    uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
 };
 
 #endif


### PR DESCRIPTION
the getter are made const and moved to the base class as they are always the same.
get_los_body() function was unified accross the backend and the unless have_los_meas() call removed in favor of the using the variable directly

for SITL backend, get_los_body() was corrected to be able to use the SIM_PLD_RATE correctly. In master, it was impossible to get get_los_body() to return false.

This was test in SITL and is coverred by autotest even IRLock backend