### PR TITLE
Tracker: log PIDs

### DIFF
--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -17,6 +17,9 @@ void Tracker::Log_Write_Attitude()
     sitl.Log_Write_SIMSTATE();
 #endif
     ahrs.Write_POS();
+
+    logger.Write_PID(LOG_PIDY_MSG, g.pidYaw2Srv.get_pid_info());
+    logger.Write_PID(LOG_PIDP_MSG, g.pidPitch2Srv.get_pid_info());
 }
 
 struct PACKED log_Vehicle_Baro {

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -154,6 +154,13 @@ private:
         bool need_altitude_calibration  : 1;// true if tracker altitude has not been determined (true after startup)
         bool scan_reverse_pitch         : 1;// controls direction of pitch movement in SCAN mode
         bool scan_reverse_yaw           : 1;// controls direction of yaw movement in SCAN mode
+
+        // stashed values for logging purposes
+        float pidP_target;
+        float pidP_actual;
+        float pidY_target;
+        float pidY_actual;
+
     } nav_status;
 
     // setup the var_info table

--- a/AntennaTracker/mode.cpp
+++ b/AntennaTracker/mode.cpp
@@ -93,12 +93,11 @@ void Mode::calc_angle_error(float pitch, float yaw, bool direction_reversed)
     nav_status.angle_error_pitch = bf_pitch_err;
     nav_status.angle_error_yaw = bf_yaw_err;
 
-    // set actual and desired for logging, note we are using angles not rates
-    Parameters &g = tracker.g;
-    g.pidPitch2Srv.set_target_rate(pitch * 0.01);
-    g.pidPitch2Srv.set_actual_rate(ahrs_pitch * 0.01);
-    g.pidYaw2Srv.set_target_rate(yaw * 0.01);
-    g.pidYaw2Srv.set_actual_rate(ahrs_yaw_cd * 0.01);
+    // stash target and achieved PID values for logging purposes
+    nav_status.pidP_target = pitch;
+    nav_status.pidP_actual = ahrs_pitch;
+    nav_status.pidY_target = yaw;
+    nav_status.pidY_actual = ahrs_yaw_cd;
 }
 
 void Mode::convert_ef_to_bf(float pitch, float yaw, float& bf_pitch, float& bf_yaw)

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -75,6 +75,9 @@ void Tracker::update_pitch_position_servo()
 
     // calculate new servo position
     int32_t new_servo_out = SRV_Channels::get_output_scaled(SRV_Channel::k_tracker_pitch) + g.pidPitch2Srv.update_error(nav_status.angle_error_pitch);
+    // set actual and desired for logging, note we are using angles not rates
+    g.pidPitch2Srv.set_target_rate(nav_status.pidP_target);
+    g.pidPitch2Srv.set_actual_rate(nav_status.pidP_actual);
 
     // position limit pitch servo
     if (new_servo_out <= pitch_min_cd) {
@@ -126,6 +129,11 @@ void Tracker::update_pitch_onoff_servo(float pitch) const
 void Tracker::update_pitch_cr_servo(float pitch)
 {
     const float pitch_out = constrain_float(g.pidPitch2Srv.update_error(nav_status.angle_error_pitch), -(-g.pitch_min+g.pitch_max) * 100/2, (-g.pitch_min+g.pitch_max) * 100/2);
+
+    // set actual and desired for logging, note we are using angles not rates
+    g.pidPitch2Srv.set_target_rate(nav_status.pidP_target);
+    g.pidPitch2Srv.set_actual_rate(nav_status.pidP_actual);
+
     SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_pitch, pitch_out);
 }
 
@@ -188,6 +196,9 @@ void Tracker::update_yaw_position_servo()
      */
 
     float servo_change = g.pidYaw2Srv.update_error(nav_status.angle_error_yaw);
+    // set actual and desired for logging, note we are using angles not rates
+    g.pidYaw2Srv.set_target_rate(nav_status.pidY_target);
+    g.pidYaw2Srv.set_actual_rate(nav_status.pidY_actual);
     servo_change = constrain_float(servo_change, -18000, 18000);
     float new_servo_out = constrain_float(SRV_Channels::get_output_scaled(SRV_Channel::k_tracker_yaw) + servo_change, -18000, 18000);
 
@@ -239,5 +250,8 @@ void Tracker::update_yaw_onoff_servo(float yaw) const
 void Tracker::update_yaw_cr_servo(float yaw)
 {
     const float yaw_out = constrain_float(-g.pidYaw2Srv.update_error(nav_status.angle_error_yaw), -g.yaw_range * 100/2, g.yaw_range * 100/2);
+    // set actual and desired for logging, note we are using angles not rates
+    g.pidYaw2Srv.set_target_rate(nav_status.pidY_target);
+    g.pidYaw2Srv.set_actual_rate(nav_status.pidY_actual);
     SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_yaw, yaw_out);
 }


### PR DESCRIPTION
Tracker: correct logging of pidP and pidY

Calling update_error zeroes the target/actual