### PR TITLE
AP_Proximity: fix proximity status for upward facing rangefinder

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -75,7 +75,8 @@ void AP_Proximity_RangeFinder::update(void)
     }
 
     // check for timeout and set health status
-    if ((_last_update_ms == 0) || (now - _last_update_ms > PROXIMITY_RANGEFIDER_TIMEOUT_MS)) {
+    if ((_last_update_ms == 0 || (now - _last_update_ms > PROXIMITY_RANGEFIDER_TIMEOUT_MS)) &&
+        (_last_upward_update_ms == 0 || (now - _last_upward_update_ms > PROXIMITY_RANGEFIDER_TIMEOUT_MS))) {
         set_status(AP_Proximity::Status::NoData);
     } else {
         set_status(AP_Proximity::Status::Good);


### PR DESCRIPTION
This PR fixes the problem of not being able to arm when using Proximity with upward facing rangefinder.

The cause was that the condition of upward lidar was missing when updating the status.
Therefore, the following error is displayed when arming.

PreArm: check proximity sensor