### PR TITLE
EKF3 Fix vulnerability to vertical velocity variance collapse

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -328,14 +328,12 @@ void NavEKF3_core::setAidingMode()
                 PV_AidingMode = AID_NONE;
                 posTimeout = true;
                 velTimeout = true;
-                rngBcnTimeout = true;
                 tasTimeout = true;
                 gpsNotAvailable = true;
              } else if (posAidLossCritical) {
                 // if the loss of position is critical, declare all sources of position aiding as being timed out
                 posTimeout = true;
                 velTimeout = !optFlowUsed && !gpsVelUsed && !bodyOdmUsed;
-                rngBcnTimeout = true;
                 gpsNotAvailable = true;
 
             }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -274,6 +274,7 @@ void NavEKF3_core::ResetHeight(void)
     {
         P[6][6] = sq(frontend->_gpsVertVelNoise);
     }
+    vertVelVarClipCount = 0;
 }
 
 // Zero the EKF height datum

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -595,7 +595,7 @@ void NavEKF3_core::FuseVelPosNED()
     bool hgtCheckPassed = false; // boolean true if height measurements have passed innovation consistency check
 
     // declare variables used to control access to arrays
-    bool fuseData[6] = {false,false,false,false,false,false};
+    bool fuseData[6] {};
     uint8_t stateIndex;
     uint8_t obsIndex;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -711,7 +711,6 @@ void NavEKF3_core::FuseVelPosNED()
             // Always fuse data if bad IMU to prevent aliasing and clipping pulling the state estimate away
             // from the measurement un-opposed if test threshold is exceeded.
             if (posCheckPassed || posTimeout || badIMUdata) {
-                posCheckPassed = true;
                 lastPosPassTime_ms = imuSampleTime_ms;
                 // if timed out or outside the specified uncertainty radius, reset to the external sensor
                 if (posTimeout || ((P[8][8] + P[7][7]) > sq(float(frontend->_gpsGlitchRadiusMax)))) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -274,7 +274,7 @@ void NavEKF3_core::ResetHeight(void)
     {
         P[6][6] = sq(frontend->_gpsVertVelNoise);
     }
-    vertVelVarClipCount = 0;
+    vertVelVarClipCounter = 0;
 }
 
 // Zero the EKF height datum

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -342,7 +342,6 @@ void NavEKF3_core::InitialiseVariables()
     lastRngBcnPassTime_ms = 0;
     rngBcnTestRatio = 0.0f;
     rngBcnHealth = false;
-    rngBcnTimeout = true;
     varInnovRngBcn = 0.0f;
     innovRngBcn = 0.0f;
     memset(&lastTimeRngBcn_ms, 0, sizeof(lastTimeRngBcn_ms));

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -86,7 +86,8 @@
 
 // maximum number of times the vertical velocity variance can hit the lower limit before the
 // associated states, variances and covariances are reset
-#define VERT_VEL_VAR_CLIP_COUNT_LIM 5
+#define EKF_TARGET_RATE_HZ uint32_t(1.0f / EKF_TARGET_DT)
+#define VERT_VEL_VAR_CLIP_COUNT_LIM (5 * EKF_TARGET_RATE_HZ)
 
 class NavEKF3_core : public NavEKF_core_common
 {
@@ -944,7 +945,7 @@ private:
     bool magTimeout;                // boolean true if magnetometer measurements have failed for too long and have timed out
     bool tasTimeout;                // boolean true if true airspeed measurements have failed for too long and have timed out
     bool badIMUdata;                // boolean true if the bad IMU data is detected
-    uint8_t vertVelVarClipCount;    // number of times the vertical velocity variance has exveeded the lower limit and been clipped since the last reset
+    uint32_t vertVelVarClipCounter; // counter used to control reset of vertical velocity variance following collapse against the lower limit
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
     Matrix24 P;                     // covariance matrix

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -80,6 +80,14 @@
 // number of continuous valid GSF yaw estimates required to confirm valid hostory
 #define GSF_YAW_VALID_HISTORY_THRESHOLD 5
 
+// minimum variances allowed for velocity and position states
+#define VEL_STATE_MIN_VARIANCE 1E-4f
+#define POS_STATE_MIN_VARIANCE 1E-4f
+
+// maximum number of times the vertical velocity variance can hit the lower limit before the
+// associated states, variances and covariances are reset
+#define VERT_VEL_VAR_CLIP_COUNT_LIM 5
+
 class NavEKF3_core : public NavEKF_core_common
 {
 public:
@@ -936,6 +944,7 @@ private:
     bool magTimeout;                // boolean true if magnetometer measurements have failed for too long and have timed out
     bool tasTimeout;                // boolean true if true airspeed measurements have failed for too long and have timed out
     bool badIMUdata;                // boolean true if the bad IMU data is detected
+    uint8_t vertVelVarClipCount;    // number of times the vertical velocity variance has exveeded the lower limit and been clipped since the last reset
 
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
     Matrix24 P;                     // covariance matrix

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1215,7 +1215,6 @@ private:
     uint32_t lastRngBcnPassTime_ms;     // time stamp when the range beacon measurement last passed innovation consistency checks (msec)
     float rngBcnTestRatio;              // Innovation test ratio for range beacon measurements
     bool rngBcnHealth;                  // boolean true if range beacon measurements have passed innovation consistency check
-    bool rngBcnTimeout;                 // boolean true if range beacon measurements have failed innovation consistency checks for too long
     float varInnovRngBcn;               // range beacon observation innovation variance (m^2)
     float innovRngBcn;                  // range beacon observation innovation (m)
     uint32_t lastTimeRngBcn_ms[4];      // last time we received a range beacon measurement (msec)


### PR DESCRIPTION
These changes close a vulnerability to collapse of the vertical velocity variance as experienced here: https://discuss.ardupilot.org/t/ekf3-position-going-mad-bug-in-4-1-0-beta3-or-defective-cube-orange/72369/4 but do not fix the root cause of the collapse of the vertical velocity variance which is still unconfirmed.

The behaviour reported arose from the a sequence of events:

1) Collapse of the vertical velocity variance to zero (cause of collapse unknown, but appears to be linked to the use of GPS for yaw)
2) When the vertical velocity variance goes to zero, this results in the vertical position state variance also collapsing and divergence of the vertical position and velocity states.
3) The state divergence looks the same as a bad inertial nav solution caused by clipping or aliasing which results in badIMUdata being set tot true.
4) When badIMUdata is set to true it prevents the  failure of the vertical position and velocity innovation consistency checks being recorded. This prevents the timeout reset of the vertical position and velocity states to the sensor which would also have reset the variances and covariances.

These fixes:

Apply a minimum value of 1E-4 to the velocity and position variances
Reset the vertical velocity variance and covariances if the variance collapses against the lower limit 5 times since the last reset.
Generate a innovation check timeout regardless of the badIMUdata status for all position and velocity fusion operations.