### PR TITLE
RC_Channel/AP_Arming: add flight mode conflict check

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -578,6 +578,10 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
         check_failed(ARMING_CHECK_PARAMETERS, true, "Duplicate Aux Switch Options");
         check_passed = false;
     }
+    if (rc().flight_mode_channel_conflicts_with_rc_option()) {
+        check_failed(ARMING_CHECK_PARAMETERS, true, "Mode channel and RC%d_OPTION conflict", rc().flight_mode_channel_number());
+        check_passed = false;
+    }
     const RCMapper * rcmap = AP::rcmap();
     if (rcmap != nullptr) {
         if (!rc().arming_skip_checks_rpy()) {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -511,6 +511,13 @@ public:
         return rc_channel(0)->run_aux_function(ch_option, pos, source);
     }
 
+    // check if flight mode channel is assigned RC option
+    // return true if assigned
+    bool flight_mode_channel_conflicts_with_rc_option();
+
+    // flight_mode_channel_number must be overridden in vehicle specific code
+    virtual int8_t flight_mode_channel_number() const = 0;
+
 protected:
 
     enum class Option {
@@ -542,8 +549,6 @@ private:
     AP_Int32  _options;
     AP_Int32  _protocols;
 
-    // flight_mode_channel_number must be overridden in vehicle specific code
-    virtual int8_t flight_mode_channel_number() const = 0;
     RC_Channel *flight_mode_channel();
 
     // Allow override by default at start

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -513,7 +513,7 @@ public:
 
     // check if flight mode channel is assigned RC option
     // return true if assigned
-    bool flight_mode_channel_conflicts_with_rc_option();
+    bool flight_mode_channel_conflicts_with_rc_option() const;
 
     // flight_mode_channel_number must be overridden in vehicle specific code
     virtual int8_t flight_mode_channel_number() const = 0;
@@ -549,7 +549,7 @@ private:
     AP_Int32  _options;
     AP_Int32  _protocols;
 
-    RC_Channel *flight_mode_channel();
+    RC_Channel *flight_mode_channel() const;
 
     // Allow override by default at start
     bool _gcs_overrides_enabled = true;

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -183,7 +183,7 @@ void RC_Channels::init_aux_all()
 //
 // Support for mode switches
 //
-RC_Channel *RC_Channels::flight_mode_channel()
+RC_Channel *RC_Channels::flight_mode_channel() const
 {
     const int8_t num = flight_mode_channel_number();
     if (num <= 0) {
@@ -192,7 +192,7 @@ RC_Channel *RC_Channels::flight_mode_channel()
     if (num >= NUM_RC_CHANNELS) {
         return nullptr;
     }
-    return channel(num-1);
+    return rc_channel(num-1);
 }
 
 void RC_Channels::reset_mode_switch()
@@ -219,7 +219,7 @@ void RC_Channels::read_mode_switch()
 
 // check if flight mode channel is assigned RC option
 // return true if assigned
-bool RC_Channels::flight_mode_channel_conflicts_with_rc_option()
+bool RC_Channels::flight_mode_channel_conflicts_with_rc_option() const
 {
     RC_Channel *chan = flight_mode_channel();
     if (chan == nullptr) {

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -217,6 +217,17 @@ void RC_Channels::read_mode_switch()
     c->read_mode_switch();
 }
 
+// check if flight mode channel is assigned RC option
+// return true if assigned
+bool RC_Channels::flight_mode_channel_conflicts_with_rc_option()
+{
+    RC_Channel *chan = flight_mode_channel();
+    if (chan == nullptr) {
+        return false;
+    }
+    return (RC_Channel::aux_func_t)chan->option.get() != RC_Channel::AUX_FUNC::DO_NOTHING;
+}
+
 /*
   get the RC input PWM value given a channel number.  Note that
   channel numbers start at 1, as this API is designed for use in


### PR DESCRIPTION
If the user set the following incorrect settings, he/she cannot change the flight mode from the transmitter.

 FLTMODE_CH 5
 RC5_OPTION 4

I added arming check and error message because assigning any option to the flight mode channel causes unexpected behavior.
I received reports of this issue from two users.

This is the test result in SITL.

```
STABILIZE> param set RC5_OPTION 41
STABILIZE> arm throttle
STABILIZE> Got COMMAND_ACK: COMPONENT_ARM_DISARM: FAILED
APM: PreArm: FLTMODE_CH and RC5_OPTION are in conflict

STABILIZE> param set RC5_OPTION 0
STABILIZE> arm throttle
STABILIZE> Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
APM: Arming motors
ARMED
STABILIZE> APM: Disarming motors
DISARMED

STABILIZE> param set FLTMODE_CH 7
STABILIZE> param show RC7_OPTION
STABILIZE> RC7_OPTION       7.000000

STABILIZE> arm throttle
STABILIZE> Got COMMAND_ACK: COMPONENT_ARM_DISARM: FAILED
APM: PreArm: FLTMODE_CH and RC7_OPTION are in conflict
```