### PR TITLE
Copter: If negative, set to default value

### DIFF
--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -15,11 +15,11 @@ void Copter::init_rangefinder(void)
 #if RANGEFINDER_ENABLED == ENABLED
    rangefinder.set_log_rfnd_bit(MASK_LOG_CTUN);
    rangefinder.init(ROTATION_PITCH_270);
-   rangefinder_state.alt_cm_filt.set_cutoff_frequency(g2.rangefinder_filt);
+   rangefinder_state.alt_cm_filt.set_cutoff_frequency(is_negative(g2.rangefinder_filt)?RANGEFINDER_FILT_DEFAULT:g2.rangefinder_filt);
    rangefinder_state.enabled = rangefinder.has_orientation(ROTATION_PITCH_270);
 
    // upward facing range finder
-   rangefinder_up_state.alt_cm_filt.set_cutoff_frequency(g2.rangefinder_filt);
+   rangefinder_up_state.alt_cm_filt.set_cutoff_frequency(is_negative(g2.rangefinder_filt)?RANGEFINDER_FILT_DEFAULT:g2.rangefinder_filt);
    rangefinder_up_state.enabled = rangefinder.has_orientation(ROTATION_PITCH_90);
 #endif
 }


### PR DESCRIPTION
No action to be taken when a negative value is set.
No guarantee that GCS will check parameter ranges.
I think it is better to implement it with the awareness that it is not guaranteed.