### PR TITLE
Plane: add compassmot functionality to Plane

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -613,6 +613,11 @@ void GCS_MAVLINK_Plane::handle_change_alt_request(AP_Mission::Mission_Command &c
     plane.reset_offset_altitude();
 }
 
+void GCS_MAVLINK_Plane::handle_command_ack(const mavlink_message_t &msg)
+{
+    plane.command_ack_counter++;
+    GCS_MAVLINK::handle_command_ack(msg);
+}
 
 MAV_RESULT GCS_MAVLINK_Plane::handle_command_preflight_calibration(const mavlink_command_long_t &packet)
 {
@@ -631,6 +636,12 @@ MAV_RESULT GCS_MAVLINK_Plane::_handle_command_preflight_calibration(const mavlin
         } else {
             return MAV_RESULT_FAILED;
         }
+    }
+
+    if (is_equal(packet.param6,1.0f)) {
+        // compassmot calibration
+        return plane.mavlink_compassmot(*this);
+        // return MAV_RESULT_ACCEPTED;
     }
 
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet);

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -46,6 +46,7 @@ private:
     void send_pid_info(const AP_Logger::PID_Info *pid_info, const uint8_t axis, const float achieved);
 
     void handleMessage(const mavlink_message_t &msg) override;
+    void handle_command_ack(const mavlink_message_t &msg) override;
     bool handle_guided_request(AP_Mission::Mission_Command &cmd) override;
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -176,6 +176,12 @@ private:
     Parameters g;
     ParametersG2 g2;
 
+    // main loop scheduler
+    AP_Scheduler scheduler;
+
+    // used to detect MAVLink acks from GCS to stop compassmot
+    uint8_t command_ack_counter;
+
     // mapping between input channels
     RCMapper rcmap;
 
@@ -234,6 +240,10 @@ private:
     // external failsafe boards during baro and airspeed calibration
     bool in_calibration;
 
+    // is compass_mot running? This is used to prevent multiple instances
+    // of compass_mot calibration from running
+    bool compass_mot;
+    
     // GCS selection
     GCS_Plane _gcs; // avoid using this; use gcs()
     GCS_Plane &gcs() { return _gcs; }
@@ -1065,6 +1075,10 @@ private:
 
     // parachute.cpp
     void parachute_check();
+
+    // compassmot.cpp
+    MAV_RESULT mavlink_compassmot(const GCS_MAVLINK &gcs_chan);
+
 #if PARACHUTE == ENABLED
     void do_parachute(const AP_Mission::Mission_Command& cmd);
     void parachute_release();

--- a/ArduPlane/compassmot.cpp
+++ b/ArduPlane/compassmot.cpp
@@ -1,0 +1,248 @@
+#include "Plane.h"
+
+/*
+  compass/motor interference calibration
+ */
+
+// setup_compassmot - sets compass's motor interference parameters
+MAV_RESULT Plane::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
+{
+    int8_t   comp_type;                 // throttle or current based compensation
+    Vector3f compass_base[COMPASS_MAX_INSTANCES];           // compass vector when throttle is zero
+    Vector3f motor_impact[COMPASS_MAX_INSTANCES];           // impact of motors on compass vector
+    Vector3f motor_impact_scaled[COMPASS_MAX_INSTANCES];    // impact of motors on compass vector scaled with throttle
+    Vector3f motor_compensation[COMPASS_MAX_INSTANCES];     // final compensation to be stored to eeprom
+    float    throttle_pct;              // throttle as a percentage 0.0 ~ 1.0
+    float    throttle_pct_max = 0.0f;   // maximum throttle reached (as a percentage 0~1.0)
+    float    current_amps_max = 0.0f;   // maximum current reached
+    float    interference_pct[COMPASS_MAX_INSTANCES]{};       // interference as a percentage of total mag field (for reporting purposes only)
+    uint32_t last_run_time;
+    uint32_t last_send_time;
+    bool     updated = false;           // have we updated the compensation vector at least once
+    uint8_t  command_ack_start = command_ack_counter;
+
+    // exit immediately if we are already in compassmot
+    if (compass_mot) {
+        // ignore restart messages
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    } else {
+        compass_mot = true;
+    }
+
+    // check compass is enabled
+    if (!AP::compass().enabled()) {
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Compass disabled");
+        compass_mot = false;
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    }
+
+    // check compass health
+    compass.read();
+    for (uint8_t i=0; i<compass.get_count(); i++) {
+        if (!compass.healthy(i)) {
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Check compass");
+        compass_mot = false;
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+        }
+    }
+
+    // check throttle is at zero
+    read_radio();
+    if (channel_throttle->get_control_in() != 0) {
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Throttle not zero");
+        compass_mot = false;
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    }
+
+    // check we are landed
+    if (is_flying()) {
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Is flying");
+        compass_mot = false;
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    }
+
+    // prevent failsafe from triggering due to long delay in main loop
+    // may need to add failsafe_disable() similar to copter
+    in_calibration = true;
+
+    float current;
+
+    // default compensation type to use current if possible
+    if (battery.current_amps(current)) {
+        comp_type = AP_COMPASS_MOT_COMP_CURRENT;
+    } else {
+        comp_type = AP_COMPASS_MOT_COMP_THROTTLE;
+    }
+
+    // send back initial ACK
+    mavlink_msg_command_ack_send(gcs_chan.get_chan(), MAV_CMD_PREFLIGHT_CALIBRATION,0);
+
+    // flash leds
+    AP_Notify::flags.esc_calibration = true;
+
+    // warn user we are starting calibration
+    gcs_chan.send_text(MAV_SEVERITY_INFO, "Starting Calibration");
+
+    // inform what type of compensation we are attempting
+    if (comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
+        gcs_chan.send_text(MAV_SEVERITY_INFO, "Current");
+    } else {
+        gcs_chan.send_text(MAV_SEVERITY_INFO, "Throttle");
+    }
+
+    // disable throttle failsafe
+    g.throttle_fs_enabled = 0;
+  
+    // disable motor compensation
+    compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);
+    for (uint8_t i=0; i<compass.get_count(); i++) {
+        compass.set_motor_compensation(i, Vector3f(0,0,0));
+    }
+
+    // get initial compass readings
+    compass.read();
+
+    // store initial x,y,z compass values
+    // initialise interference percentage
+    for (uint8_t i=0; i<compass.get_count(); i++) {
+        compass_base[i] = compass.get_field(i);
+        interference_pct[i] = 0.0f;
+    }
+
+    EXPECT_DELAY_MS(5000);
+
+    // enable motors and pass through throttle
+    init_rc_out_main();
+    hal.util->set_soft_armed(true);
+
+    // initialise run time
+    last_run_time = millis();
+    last_send_time = millis();
+
+    // main run while there is no user input and the compass is healthy
+    while (command_ack_start == command_ack_counter && compass.healthy()) {
+        EXPECT_DELAY_MS(5000);
+
+        // 50hz loop
+        if (millis() - last_run_time < 20) {
+            hal.scheduler->delay(5);
+            continue;
+        }
+        last_run_time = millis();
+
+        // read the radio input
+        read_radio();
+
+        // pass through throttle to motors
+        SRV_Channels::cork();
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_throttle_input(true));
+        SRV_Channels::push();
+
+        // read some compass values
+        compass.read();
+
+        // read current
+        battery.read();
+
+        // calculate scaling for throttle
+        throttle_pct = (float)channel_throttle->get_control_in() / 1000.0f;
+        throttle_pct = constrain_float(throttle_pct,0.0f,1.0f);
+
+        if (!battery.current_amps(current)) {
+        current = 0;
+        }
+        current_amps_max = MAX(current_amps_max, current);
+
+        // if throttle is near zero, update base x,y,z values
+        if (throttle_pct <= 0.0f) {
+            for (uint8_t i=0; i<compass.get_count(); i++) {
+            compass_base[i] = compass_base[i] * 0.99f + compass.get_field(i) * 0.01f;
+        }
+        } else {
+
+            // calculate diff from compass base and scale with throttle
+            for (uint8_t i=0; i<compass.get_count(); i++) {
+                motor_impact[i] = compass.get_field(i) - compass_base[i];
+            }
+
+            // throttle based compensation
+            if (comp_type == AP_COMPASS_MOT_COMP_THROTTLE) {
+                // for each compass
+                for (uint8_t i=0; i<compass.get_count(); i++) {
+                    // scale by throttle
+                    motor_impact_scaled[i] = motor_impact[i] / throttle_pct;
+                    // adjust the motor compensation to negate the impact
+                    motor_compensation[i] = motor_compensation[i] * 0.99f - motor_impact_scaled[i] * 0.01f;
+                }
+                updated = true;
+            } else {
+                // for each compass
+                for (uint8_t i=0; i<compass.get_count(); i++) {
+                    // adjust the motor compensation to negate the impact if drawing over 3amps
+                    if (current >= 3.0f) {
+                        motor_impact_scaled[i] = motor_impact[i] / current;
+                        motor_compensation[i] = motor_compensation[i] * 0.99f - motor_impact_scaled[i] * 0.01f;
+                        updated = true;
+                    }
+                }
+            }
+
+            // calculate interference percentage at full throttle as a % of total mag field
+            if (comp_type == AP_COMPASS_MOT_COMP_THROTTLE) {
+                for (uint8_t i=0; i<compass.get_count(); i++) {
+                    // interference is impact@fullthrottle / mag field * 100
+                    interference_pct[i] = motor_compensation[i].length() / (float)arming.compass_magfield_expected() * 100.0f;
+                }
+            } else {
+                for (uint8_t i=0; i<compass.get_count(); i++) {
+                    // interference is impact/amp * (max current seen / max throttle seen) / mag field * 100
+                    interference_pct[i] = motor_compensation[i].length() * (current_amps_max/throttle_pct_max) / (float)arming.compass_magfield_expected() * 100.0f;
+                }
+            }
+
+            // record maximum throttle
+            throttle_pct_max = MAX(throttle_pct_max, throttle_pct);
+        }
+        if (AP_HAL::millis() - last_send_time > 500) {
+            last_send_time = AP_HAL::millis();
+            mavlink_msg_compassmot_status_send(gcs_chan.get_chan(),
+                                                channel_throttle->get_control_in(),
+                                                current,
+                                                interference_pct[0],
+                                                motor_compensation[0].x,
+                                                motor_compensation[0].y,
+                                                motor_compensation[0].z);
+        }
+    }
+    // stop motors
+    hal.util->set_soft_armed(false);
+
+    // set and save motor compensation
+    if (updated) {
+        compass.motor_compensation_type(comp_type);
+        for (uint8_t i=0; i<compass.get_count(); i++) {
+        compass.set_motor_compensation(i, motor_compensation[i]);
+        }
+        compass.save_motor_compensation();
+        //display success message
+        gcs_chan.send_text(MAV_SEVERITY_INFO, "Calibration successful");
+    } else {
+        // compensation vector never updated, report failure
+        gcs_chan.send_text(MAV_SEVERITY_NOTICE, "Failed");
+        compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);
+    }
+    
+    // turn off notify leds
+    AP_Notify::flags.esc_calibration = true;
+
+    // stop heartbeat / re-enable failsafes
+    in_calibration = false;
+
+    // re-enable throttle failsafes
+    g.throttle_fs_enabled.load();
+
+    // flag we have completed
+    compass_mot = false;
+    
+    return MAV_RESULT_ACCEPTED;
+}


### PR DESCRIPTION
Procedure emulating how ArduCopter does compassmot ported over to Plane. Small changes had to be made between the copter version and plane to allow rc input for throttle to be passed through during calibration.

Process was verified on hardware, confirming the fail-safe procedures work as intended.