### PR TITLE
Copter: cope with flying a long distance from the origin

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -324,7 +324,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
         }
 
         // if we are outside the circle, point at the edge, otherwise hold yaw
-        const Vector3f &circle_center_neu = copter.circle_nav->get_center();
+        const Vector3p &circle_center_neu = copter.circle_nav->get_center();
         const Vector3f &curr_pos = inertial_nav.get_position();
         float dist_to_center = norm(circle_center_neu.x - curr_pos.x, circle_center_neu.y - curr_pos.y);
         // initialise yaw

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -412,10 +412,10 @@ void ModeRTL::land_run(bool disarm_on_land)
 void ModeRTL::build_path()
 {
     // origin point is our stopping point
-    Vector3f stopping_point;
+    Vector3p stopping_point;
     pos_control->get_stopping_point_xy_cm(stopping_point.xy());
     pos_control->get_stopping_point_z_cm(stopping_point.z);
-    rtl_path.origin_point = Location(stopping_point, Location::AltFrame::ABOVE_ORIGIN);
+    rtl_path.origin_point = Location(stopping_point.tofloat(), Location::AltFrame::ABOVE_ORIGIN);
     rtl_path.origin_point.change_alt_frame(Location::AltFrame::ABOVE_HOME);
 
     // compute return target

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -16,10 +16,10 @@ bool ModeSmartRTL::init(bool ignore_checks)
         wp_nav->wp_and_spline_init();
 
         // set current target to a reasonable stopping point
-        Vector3f stopping_point;
+        Vector3p stopping_point;
         pos_control->get_stopping_point_xy_cm(stopping_point.xy());
         pos_control->get_stopping_point_z_cm(stopping_point.z);
-        wp_nav->set_wp_destination(stopping_point);
+        wp_nav->set_wp_destination(stopping_point.tofloat());
 
         // initialise yaw to obey user parameter
         auto_yaw.set_mode_to_default(true);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2547,7 +2547,7 @@ void QuadPlane::update_land_positioning(void)
     poscontrol.target_vel_cms = Vector3f(-pitch_in, roll_in, 0) * speed_max_cms;
     poscontrol.target_vel_cms.rotate_xy(ahrs_view->yaw);
 
-    poscontrol.target_cm += poscontrol.target_vel_cms * dt;
+    poscontrol.target_cm += (poscontrol.target_vel_cms * dt).topostype();
 
     poscontrol.pilot_correction_active = (!is_zero(roll_in) || !is_zero(pitch_in));
     if (poscontrol.pilot_correction_active) {
@@ -3091,7 +3091,7 @@ void QuadPlane::setup_target_position(void)
     if (!loc.same_latlon_as(last_auto_target) ||
         plane.next_WP_loc.alt != last_auto_target.alt ||
         now - last_loiter_ms > 500) {
-        wp_nav->set_wp_destination(poscontrol.target_cm);
+        wp_nav->set_wp_destination(poscontrol.target_cm.tofloat());
         last_auto_target = loc;
     }
     last_loiter_ms = now;
@@ -3500,7 +3500,7 @@ bool QuadPlane::verify_vtol_land(void)
         if (poscontrol.pilot_correction_done) {
             reached_position = !poscontrol.pilot_correction_active;
         } else {
-            const float dist = (inertial_nav.get_position() - poscontrol.target_cm).xy().length() * 0.01;
+            const float dist = (inertial_nav.get_position().topostype() - poscontrol.target_cm).xy().length() * 0.01;
             reached_position = dist < descend_dist_threshold;
         }
         if (reached_position &&

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -478,7 +478,7 @@ private:
         uint32_t time_since_state_start_ms() const {
             return AP_HAL::millis() - last_state_change_ms;
         }
-        Vector3f target_cm;
+        Vector3p target_cm;
         Vector3f target_vel_cms;
         bool slow_descent:1;
         bool pilot_correction_active;

--- a/ArduSub/control_auto.cpp
+++ b/ArduSub/control_auto.cpp
@@ -205,7 +205,7 @@ void Sub::auto_circle_movetoedge_start(const Location &circle_center, float radi
         }
 
         // if we are outside the circle, point at the edge, otherwise hold yaw
-        const Vector3f &circle_center_neu = circle_nav.get_center();
+        const Vector3p &circle_center_neu = circle_nav.get_center();
         const Vector3f &curr_pos = inertial_nav.get_position();
         float dist_to_center = norm(circle_center_neu.x - curr_pos.x, circle_center_neu.y - curr_pos.y);
         if (dist_to_center > circle_nav.get_radius() && dist_to_center > 500) {

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -330,6 +330,9 @@ class Board:
         if cfg.options.disable_ekf3:
             env.CXXFLAGS += ['-DHAL_NAVEKF3_AVAILABLE=0']
 
+        if cfg.options.postype_single:
+            env.CXXFLAGS += ['-DHAL_WITH_POSTYPE_DOUBLE=0']
+            
         if cfg.options.osd or cfg.options.osd_fonts:
             env.CXXFLAGS += ['-DOSD_ENABLED=1', '-DHAL_MSP_ENABLED=1']
 

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -323,6 +323,9 @@ def do_build(opts, frame_options):
     if opts.disable_ekf3:
         cmd_configure.append("--disable-ekf3")
 
+    if opts.postype_single:
+        cmd_configure.append("--postype-single")
+
     pieces = [shlex.split(x) for x in opts.waf_configure_args]
     for piece in pieces:
         cmd_configure.extend(piece)
@@ -1049,6 +1052,9 @@ group_sim.add_option("", "--sysid",
                      type='int',
                      default=None,
                      help="Set SYSID_THISMAV")
+group_sim.add_option("--postype-single",
+                     action='store_true',
+                     help="force single precision postype_t")
 parser.add_option_group(group_sim)
 
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -54,7 +54,7 @@ public:
     /// input_pos_vel_accel_xyz - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
-    void input_pos_vel_accel_xyz(const Vector3f& pos);
+    void input_pos_vel_accel_xyz(const Vector3p& pos);
 
     ///
     /// Lateral position controller
@@ -96,7 +96,7 @@ public:
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
     ///     The function alters the pos and vel to be the kinematic path based on accel
-    void input_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel);
+    void input_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel);
 
     // is_active_xy - returns true if the xy position controller has been run in the previous 5 loop times
     bool is_active_xy() const;
@@ -190,8 +190,8 @@ public:
     ///
 
     /// set commanded position (cm), velocity (cm/s) and acceleration (cm/s/s) inputs when the path is created externally.
-    void set_pos_vel_accel(const Vector3f& pos, const Vector3f& vel, const Vector3f& accel);
-    void set_pos_vel_accel_xy(const Vector2f& pos, const Vector2f& vel, const Vector2f& accel);
+    void set_pos_vel_accel(const Vector3p& pos, const Vector3f& vel, const Vector3f& accel);
+    void set_pos_vel_accel_xy(const Vector2p& pos, const Vector2f& vel, const Vector2f& accel);
 
 
     /// Position
@@ -200,7 +200,7 @@ public:
     void set_pos_target_xy_cm(float pos_x, float pos_y) { _pos_target.x = pos_x; _pos_target.y = pos_y; }
 
     /// get_pos_target_cm - returns the position target in NEU cm from home
-    const Vector3f& get_pos_target_cm() const { return _pos_target; }
+    const Vector3p& get_pos_target_cm() const { return _pos_target; }
 
     /// set_pos_target_z_cm - set altitude target in cm above home
     void set_pos_target_z_cm(float pos_target) { _pos_target.z = pos_target; }
@@ -209,13 +209,13 @@ public:
     float get_pos_target_z_cm() const { return _pos_target.z; }
 
     /// get_stopping_point_xy_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-    void get_stopping_point_xy_cm(Vector2f &stopping_point) const;
+    void get_stopping_point_xy_cm(Vector2p &stopping_point) const;
 
     /// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-    void get_stopping_point_z_cm(float &stopping_point) const;
+    void get_stopping_point_z_cm(postype_t &stopping_point) const;
 
     /// get_pos_error_cm - get position error vector between the current and target position
-    const Vector3f get_pos_error_cm() const { return _pos_target - _inav.get_position(); }
+    const Vector3f get_pos_error_cm() const { return (_pos_target - _inav.get_position().topostype()).tofloat(); }
 
     /// get_pos_error_xy_cm - get the length of the position error vector in the xy plane
     float get_pos_error_xy_cm() const { return norm(_pos_target.x - _inav.get_position().x, _pos_target.y - _inav.get_position().y); }
@@ -396,7 +396,7 @@ protected:
     float       _yaw_rate_target;       // desired yaw rate in centi-degrees per second calculated by position controller
 
     // position controller internal variables
-    Vector3f    _pos_target;            // target location in NEU cm from home
+    Vector3p    _pos_target;            // target location in NEU cm from home
     Vector3f    _vel_desired;           // desired velocity in NEU cm/s
     Vector3f    _vel_target;            // velocity target in NEU cm/s calculated by pos_to_rate step
     Vector3f    _accel_desired;         // desired acceleration in NEU cm/s/s (feed forward)

--- a/libraries/AC_PID/AC_P_2D.cpp
+++ b/libraries/AC_PID/AC_P_2D.cpp
@@ -24,12 +24,12 @@ AC_P_2D::AC_P_2D(float initial_p, float dt) :
 
 // update_all - set target and measured inputs to P controller and calculate outputs
 // limit is set true if the target has been moved to limit the maximum position error
-Vector2f AC_P_2D::update_all(float &target_x, float &target_y, const Vector2f &measurement, bool &limit)
+Vector2f AC_P_2D::update_all(postype_t &target_x, postype_t &target_y, const Vector2f &measurement, bool &limit)
 {
     limit = false;
 
     // calculate distance _error
-    _error = Vector2f{target_x, target_y} - measurement;
+    _error = (Vector2p{target_x, target_y} - measurement.topostype()).tofloat();
 
     // Constrain _error and target position
     // Constrain the maximum length of _vel_target to the maximum position correction velocity

--- a/libraries/AC_PID/AC_P_2D.h
+++ b/libraries/AC_PID/AC_P_2D.h
@@ -20,11 +20,11 @@ public:
     void set_dt(float dt) { _dt = dt; }
 
     // set target and measured inputs to P controller and calculate outputs
-    Vector2f update_all(float &target_x, float &target_y, const Vector2f &measurement, bool &limit) WARN_IF_UNUSED;
+    Vector2f update_all(postype_t &target_x, postype_t &target_y, const Vector2f &measurement, bool &limit) WARN_IF_UNUSED;
 
     // set target and measured inputs to P controller and calculate outputs
     // measurement is provided as 3-axis vector but only x and y are used
-    Vector2f update_all(float &target_x, float &target_y, const Vector3f &measurement, bool &limit) WARN_IF_UNUSED {
+    Vector2f update_all(postype_t &target_x, postype_t &target_y, const Vector3f &measurement, bool &limit) WARN_IF_UNUSED {
         return update_all(target_x, target_y, Vector2f{measurement.x, measurement.y}, limit);
     }
 

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
@@ -16,9 +16,9 @@ void AC_PrecLand_SITL::update()
     _state.healthy = _sitl->precland_sim.healthy();
 
     if (_state.healthy && _sitl->precland_sim.last_update_ms() != _los_meas_time_ms) {
-        const Vector3f position = _sitl->precland_sim.get_target_position();
-        const Matrix3f &body_to_ned = AP::ahrs().get_rotation_body_to_ned();
-        _los_meas_body =  body_to_ned.mul_transpose(-position);
+        const Vector3d position = _sitl->precland_sim.get_target_position();
+        const Matrix3d body_to_ned = AP::ahrs().get_rotation_body_to_ned().todouble();
+        _los_meas_body =  body_to_ned.mul_transpose(-position).tofloat();
         _los_meas_body /= _los_meas_body.length();
         _have_los_meas = true;
         _los_meas_time_ms = _sitl->precland_sim.last_update_ms();

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -58,7 +58,7 @@ AC_Circle::AC_Circle(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_Po
 /// init - initialise circle controller setting center specifically
 ///     set terrain_alt to true if center.z should be interpreted as an alt-above-terrain
 ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
-void AC_Circle::init(const Vector3f& center, bool terrain_alt)
+void AC_Circle::init(const Vector3p& center, bool terrain_alt)
 {
     _center = center;
     _terrain_alt = terrain_alt;
@@ -86,7 +86,7 @@ void AC_Circle::init()
     _pos_control.init_z_controller_stopping_point();
 
     // get stopping point
-    const Vector3f& stopping_point = _pos_control.get_pos_target_cm();
+    const Vector3p& stopping_point = _pos_control.get_pos_target_cm();
 
     // set circle center to circle_radius ahead of stopping point
     _center = stopping_point;
@@ -189,7 +189,7 @@ bool AC_Circle::update(float climb_rate_cms)
     }
 
     // if the circle_radius is zero we are doing panorama so no need to update loiter target
-    Vector3f target {
+    Vector3p target {
         _center.x,
         _center.y,
         target_z_cm
@@ -200,7 +200,7 @@ bool AC_Circle::update(float climb_rate_cms)
         target.y += - _radius * sinf(-_angle);
 
         // heading is from vehicle to center of circle
-        _yaw = get_bearing_cd(_inav.get_position(), _center);
+        _yaw = get_bearing_cd(_inav.get_position(), _center.tofloat());
 
         if ((_options.get() & CircleOptions::FACE_DIRECTION_OF_TRAVEL) != 0) {
             _yaw += is_positive(_rate)?-9000.0f:9000.0f;
@@ -217,7 +217,8 @@ bool AC_Circle::update(float climb_rate_cms)
     _pos_control.input_pos_vel_accel_xy(target.xy(), zero, zero);
     if (_terrain_alt) {
         float zero2 = 0;
-        _pos_control.input_pos_vel_accel_z(target.z, zero2, 0);
+        float target_zf = target.z;
+        _pos_control.input_pos_vel_accel_z(target_zf, zero2, 0);
     } else {
         _pos_control.set_pos_target_z_from_climb_rate_cm(climb_rate_cms,  false);
     }
@@ -240,16 +241,16 @@ void AC_Circle::get_closest_point_on_circle(Vector3f &result) const
 {
     // return center if radius is zero
     if (_radius <= 0) {
-        result = _center;
+        result = _center.tofloat();
         return;
     }
 
     // get current position
-    Vector2f stopping_point;
+    Vector2p stopping_point;
     _pos_control.get_stopping_point_xy_cm(stopping_point);
 
     // calc vector from stopping point to circle center
-    Vector2f vec = stopping_point - _center.xy();
+    Vector2f vec = (stopping_point - _center.xy()).tofloat();
     float dist = vec.length();
 
     // if current location is exactly at the center of the circle return edge directly behind vehicle
@@ -313,7 +314,7 @@ void AC_Circle::init_start_angle(bool use_heading)
     } else {
         // if we are exactly at the center of the circle, init angle to directly behind vehicle (so vehicle will backup but not change heading)
         const Vector3f &curr_pos = _inav.get_position();
-        if (is_equal(curr_pos.x,_center.x) && is_equal(curr_pos.y,_center.y)) {
+        if (is_equal(curr_pos.x,float(_center.x)) && is_equal(curr_pos.y,float(_center.y))) {
             _angle = wrap_PI(_ahrs.yaw-M_PI);
         } else {
             // get bearing from circle center to vehicle in radians

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -22,7 +22,7 @@ public:
     /// init - initialise circle controller setting center specifically
     ///     set terrain_alt to true if center.z should be interpreted as an alt-above-terrain
     ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
-    void init(const Vector3f& center, bool terrain_alt);
+    void init(const Vector3p& center, bool terrain_alt);
 
     /// init - initialise circle controller setting center using stopping point and projecting out based on the copter's heading
     ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
@@ -33,10 +33,10 @@ public:
 
     /// set_circle_center as a vector from ekf origin
     ///     terrain_alt should be true if center.z is alt is above terrain
-    void set_center(const Vector3f& center, bool terrain_alt) { _center = center; _terrain_alt = terrain_alt; }
+    void set_center(const Vector3f& center, bool terrain_alt) { _center = center.topostype(); _terrain_alt = terrain_alt; }
 
     /// get_circle_center in cm from home
-    const Vector3f& get_center() const { return _center; }
+    const Vector3p& get_center() const { return _center; }
 
     /// returns true if using terrain altitudes
     bool center_is_terrain_alt() const { return _terrain_alt; }
@@ -143,7 +143,7 @@ private:
     AP_Int16    _options;       // stick control enable/disable
 
     // internal variables
-    Vector3f    _center;        // center of circle in cm from home
+    Vector3p    _center;        // center of circle in cm from home
     float       _radius;        // radius of circle in cm
     float       _yaw;           // yaw heading (normally towards circle center)
     float       _angle;         // current angular position around circle in radians (0=directly north of the center of the circle)

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -174,7 +174,9 @@ void AC_Loiter::set_pilot_desired_acceleration(float euler_roll_angle_cd, float 
 /// get vector to stopping point based on a horizontal position and velocity
 void AC_Loiter::get_stopping_point_xy(Vector2f& stopping_point) const
 {
-    _pos_control.get_stopping_point_xy_cm(stopping_point);
+    Vector2p stop;
+    _pos_control.get_stopping_point_xy_cm(stop);
+    stopping_point = stop.tofloat();
 }
 
 /// get maximum lean angle when using loiter
@@ -287,11 +289,10 @@ void AC_Loiter::calc_desired_velocity(float nav_dt, bool avoidance_on)
     }
 
     // get loiters desired velocity from the position controller where it is being stored.
-    const Vector3f &target_pos_3d = _pos_control.get_pos_target_cm();
-    Vector2f target_pos{target_pos_3d.x, target_pos_3d.y};
+    Vector2p target_pos = _pos_control.get_pos_target_cm().xy();
 
     // update the target position using our predicted velocity
-    target_pos += desired_vel * nav_dt;
+    target_pos += (desired_vel * nav_dt).topostype();
 
     // send adjusted feed forward acceleration and velocity back to the Position Controller
     _pos_control.set_pos_vel_accel_xy(target_pos, desired_vel, _desired_accel);

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -398,14 +398,18 @@ void AC_WPNav::shift_wp_origin_and_destination_to_stopping_point_xy()
 /// get_wp_stopping_point_xy - returns vector to stopping point based on a horizontal position and velocity
 void AC_WPNav::get_wp_stopping_point_xy(Vector2f& stopping_point) const
 {
-	_pos_control.get_stopping_point_xy_cm(stopping_point);
+    Vector2p stop;
+    _pos_control.get_stopping_point_xy_cm(stop);
+    stopping_point = stop.tofloat();
 }
 
 /// get_wp_stopping_point - returns vector to stopping point based on 3D position and velocity
 void AC_WPNav::get_wp_stopping_point(Vector3f& stopping_point) const
 {
-    _pos_control.get_stopping_point_xy_cm(stopping_point.xy());
-    _pos_control.get_stopping_point_z_cm(stopping_point.z);
+    Vector3p stop;
+    _pos_control.get_stopping_point_xy_cm(stop.xy());
+    _pos_control.get_stopping_point_z_cm(stop.z);
+    stopping_point = stop.tofloat();
 }
 
 /// advance_wp_target_along_track - move target location along track from origin to destination
@@ -463,9 +467,9 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
 
     // input shape the terrain offset
     shape_pos_vel_accel(terr_offset, 0.0f, 0.0f,
-        _pos_terrain_offset, _vel_terrain_offset, _accel_terrain_offset,
-        0.0f, _pos_control.get_max_speed_down_cms(), _pos_control.get_max_speed_up_cms(),
-        -_pos_control.get_max_accel_z_cmss(), _pos_control.get_max_accel_z_cmss(), 0.05f, dt);
+                        _pos_terrain_offset, _vel_terrain_offset, _accel_terrain_offset,
+                        0.0f, _pos_control.get_max_speed_down_cms(), _pos_control.get_max_speed_up_cms(),
+                        -_pos_control.get_max_accel_z_cmss(), _pos_control.get_max_accel_z_cmss(), 0.05f, dt);
 
     update_pos_vel_accel(_pos_terrain_offset, _vel_terrain_offset, _accel_terrain_offset, dt, 0.0f);
 
@@ -475,7 +479,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     target_accel.z += _accel_terrain_offset;
 
     // pass new target to the position controller
-    _pos_control.set_pos_vel_accel(target_pos, target_vel, target_accel);
+    _pos_control.set_pos_vel_accel(target_pos.topostype(), target_vel, target_accel);
 
     // check if we've reached the waypoint
     if (!_flags.reached_destination) {

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -274,7 +274,7 @@ protected:
     float       _rangefinder_alt_cm;    // latest distance from the rangefinder
 
     // position, velocity and acceleration targets passed to position controller
-    float       _pos_terrain_offset;
+    postype_t   _pos_terrain_offset;
     float       _vel_terrain_offset;
     float       _accel_terrain_offset;
 

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -242,7 +242,15 @@ Vector3f Location::get_distance_NED(const Location &loc2) const
 {
     return Vector3f((loc2.lat - lat) * LOCATION_SCALING_FACTOR,
                     (loc2.lng - lng) * LOCATION_SCALING_FACTOR * longitude_scale(),
-                    (alt - loc2.alt) * 0.01f);
+                    (alt - loc2.alt) * 0.01);
+}
+
+// return the distance in meters in North/East/Down plane as a N/E/D vector to loc2
+Vector3d Location::get_distance_NED_double(const Location &loc2) const
+{
+    return Vector3d((loc2.lat - lat) * double(LOCATION_SCALING_FACTOR),
+                    (loc2.lng - lng) * double(LOCATION_SCALING_FACTOR) * longitude_scale(),
+                    (alt - loc2.alt) * 0.01);
 }
 
 // extrapolate latitude/longitude given distances (in meters) north and east
@@ -250,6 +258,14 @@ void Location::offset(float ofs_north, float ofs_east)
 {
     const int32_t dlat = ofs_north * LOCATION_SCALING_FACTOR_INV;
     const int32_t dlng = (ofs_east * LOCATION_SCALING_FACTOR_INV) / longitude_scale();
+    lat += dlat;
+    lng += dlng;
+}
+
+void Location::offset_double(double ofs_north, double ofs_east)
+{
+    const int32_t dlat = ofs_north * double(LOCATION_SCALING_FACTOR_INV);
+    const int32_t dlng = (ofs_east * double(LOCATION_SCALING_FACTOR_INV)) / longitude_scale();
     lat += dlat;
     lng += dlng;
 }

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -64,12 +64,14 @@ public:
 
     // return the distance in meters in North/East/Down plane as a N/E/D vector to loc2
     Vector3f get_distance_NED(const Location &loc2) const;
+    Vector3d get_distance_NED_double(const Location &loc2) const;
 
     // return the distance in meters in North/East plane as a N/E vector to loc2
     Vector2f get_distance_NE(const Location &loc2) const;
 
     // extrapolate latitude/longitude given distances (in meters) north and east
     void offset(float ofs_north, float ofs_east);
+    void offset_double(double ofs_north, double ofs_east);
 
     // extrapolate latitude/longitude given bearing and distance
     void offset_bearing(float bearing_deg, float distance);

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -1219,6 +1219,15 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
 {
     char c;
 
+    if (AP_HAL::millis() < 20000) {
+        // apply the init offsets for the first 20s. This allows for
+        // having the origin a long way from the takeoff location,
+        // which makes testing long flights easier
+        latitude += _sitl->gps_init_lat_ofs;
+        longitude += _sitl->gps_init_lon_ofs;
+        altitude += _sitl->gps_init_alt_ofs;
+    }
+
     //Capture current position as basestation location for
     if (!_gps_has_basestation_position &&
         _have_lock &&

--- a/libraries/AP_IRLock/AP_IRLock_SITL.cpp
+++ b/libraries/AP_IRLock/AP_IRLock_SITL.cpp
@@ -41,9 +41,9 @@ bool AP_IRLock_SITL::update()
     }
 
     if (_sitl->precland_sim.last_update_ms() != _last_timestamp) {
-        const Vector3f position = _sitl->precland_sim.get_target_position();
-        const Matrix3f &body_to_ned = AP::ahrs().get_rotation_body_to_ned();
-        const Vector3f real_position =  body_to_ned.mul_transpose(-position);
+        const Vector3d position = _sitl->precland_sim.get_target_position();
+        const Matrix3d body_to_ned = AP::ahrs().get_rotation_body_to_ned().todouble();
+        const Vector3d real_position =  body_to_ned.mul_transpose(-position);
         _last_timestamp = _sitl->precland_sim.last_update_ms();
         _last_update_ms = _last_timestamp;
         _target_info.timestamp = _last_timestamp;

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -39,7 +39,7 @@ void update_vel_accel(float& vel, float accel, float dt, float limit)
 
 // update_pos_vel_accel - single axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
-void update_pos_vel_accel(float& pos, float& vel, float accel, float dt, float limit)
+void update_pos_vel_accel(postype_t& pos, float& vel, float accel, float dt, float limit)
 {
     // move position and velocity forward by dt if it does not increase error when limited.
     float delta_pos = vel * dt + accel * 0.5f * sq(dt);
@@ -68,7 +68,7 @@ void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, Vector2
 
 // update_pos_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
-void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
+void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
 {
     // move position and velocity forward by dt.
     Vector2f delta_pos = vel * dt + accel * 0.5f * sq(dt);
@@ -81,7 +81,7 @@ void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel
         }
     }
 
-    pos += delta_pos;
+    pos += delta_pos.topostype();
 
     update_vel_accel_xy(vel, accel, dt, limit);
 }
@@ -245,8 +245,8 @@ void shape_vel_accel_xy(const Vector2f &vel_input1, const Vector2f& accel_input,
  The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input
  The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
-void shape_pos_vel_accel(const float pos_input, const float vel_input, const float accel_input,
-                         const float pos, const float vel, float& accel,
+void shape_pos_vel_accel(const postype_t pos_input, const float vel_input, const float accel_input,
+                         const postype_t pos, const float vel, float& accel,
                          const float vel_correction_max, const float vel_min, const float vel_max,
                          const float accel_min, const float accel_max, const float tc, const float dt)
 {
@@ -277,8 +277,8 @@ void shape_pos_vel_accel(const float pos_input, const float vel_input, const flo
 }
 
 // 2D version
-void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
-                            const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
+void shape_pos_vel_accel_xy(const Vector2p& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
+                            const Vector2p& pos, const Vector2f& vel, Vector2f& accel,
                             const float vel_correction_max, const float vel_max, const float accel_max, const float tc, const float dt)
 {
     if (!is_positive(tc)) {
@@ -290,7 +290,7 @@ void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input
     const float accel_tc_max = accel_max*(1.0f - 1.0f/CONTROL_TIME_CONSTANT_RATIO);
 
     // position error to be corrected
-    Vector2f pos_error = pos_input - pos;
+    Vector2f pos_error = (pos_input - pos).tofloat();
 
     // velocity to correct position
     Vector2f vel_target = sqrt_controller(pos_error, KPv, accel_tc_max, dt);

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -29,13 +29,13 @@ void update_vel_accel(float& vel, float accel, float dt, float limit);
 
 // update_vel_accel projects the velocity, vel, forward in time based on a time step of dt and acceleration of accel.
 // update_vel_accel - single axis projection.
-void update_pos_vel_accel(float& pos, float& vel, float accel, float dt, float limit);
+void update_pos_vel_accel(postype_t & pos, float& vel, float accel, float dt, float limit);
 
 // update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
 void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
 
 // update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
+void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
 
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
  The function takes the current acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -84,12 +84,12 @@ void shape_vel_accel_xy(const Vector2f &vel_input, const Vector2f& accel_input,
  The time constant must be positive.
  The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input
 */
-void shape_pos_vel_accel(const float pos_input, const float vel_input, const float accel_input,
-                         const float pos, const float vel, float& accel,
+void shape_pos_vel_accel(const postype_t pos_input, const float vel_input, const float accel_input,
+                         const postype_t pos, const float vel, float& accel,
                          const float vel_correction_max, const float vel_min, const float vel_max,
                          const float accel_min, const float accel_max, const float tc, const float dt);
-void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
-                            const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
+void shape_pos_vel_accel_xy(const Vector2p& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
+                            const Vector2p& pos, const Vector2f& vel, Vector2f& accel,
                             const float vel_correction_max, const float vel_max, const float accel_max, const float tc, const float dt);
 
 // proportional controller with piecewise sqrt sections to constrain second derivative

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -1,5 +1,24 @@
 #pragma once
 
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef HAL_WITH_POSTYPE_DOUBLE
+#define HAL_WITH_POSTYPE_DOUBLE BOARD_FLASH_SIZE > 1024
+#endif
+
+#if HAL_WITH_POSTYPE_DOUBLE
+typedef double postype_t;
+typedef Vector2d Vector2p;
+typedef Vector3d Vector3p;
+#define topostype todouble
+#else
+typedef float postype_t;
+typedef Vector2f Vector2p;
+typedef Vector3f Vector3p;
+#define topostype tofloat
+#endif
+
 /*
   common controller helper functions
  */

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -265,6 +265,13 @@ public:
     
     // normalize a rotation matrix
     void        normalize(void);
+
+    Matrix3<double> todouble(void) const {
+        return Matrix3<double>(a.todouble(), b.todouble(), c.todouble());
+    }
+    Matrix3<float> tofloat(void) const {
+        return Matrix3<float>(a.tofloat(), b.tofloat(), c.tofloat());
+    }
 };
 
 typedef Matrix3<int16_t>                Matrix3i;

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -204,10 +204,10 @@ template <typename T>
 bool Vector2<T>::circle_segment_intersection(const Vector2<T>& seg_start, const Vector2<T>& seg_end, const Vector2<T>& circle_center, float radius, Vector2<T>& intersection)
 {
     // calculate segment start and end as offsets from circle's center
-    const Vector2f seg_start_local = seg_start - circle_center;
+    const Vector2<T> seg_start_local = seg_start - circle_center;
 
     // calculate vector from start to end
-    const Vector2f seg_end_minus_start = seg_end - seg_start;
+    const Vector2<T> seg_end_minus_start = seg_end - seg_start;
 
     const float a = sq(seg_end_minus_start.x) + sq(seg_end_minus_start.y);
     const float b = 2 * ((seg_end_minus_start.x * seg_start_local.x) + (seg_end_minus_start.y * seg_start_local.y));
@@ -448,8 +448,21 @@ void Vector2<T>::rotate(float angle_rad)
     y = ry;
 }
 
-// only define for float
+template <typename T>
+Vector2<double> Vector2<T>::todouble(void) const
+{
+    return Vector2d{x,y};
+}
+
+template <typename T>
+Vector2<float> Vector2<T>::tofloat(void) const
+{
+    return Vector2f{float(x),float(y)};
+}
+
+// define for float and double
 template class Vector2<float>;
+template class Vector2<double>;
 
 // define some ops for int and long
 template bool Vector2<long>::operator ==(const Vector2<long> &v) const;

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -448,18 +448,6 @@ void Vector2<T>::rotate(float angle_rad)
     y = ry;
 }
 
-template <typename T>
-Vector2<double> Vector2<T>::todouble(void) const
-{
-    return Vector2d{x,y};
-}
-
-template <typename T>
-Vector2<float> Vector2<T>::tofloat(void) const
-{
-    return Vector2f{float(x),float(y)};
-}
-
 // define for float and double
 template class Vector2<float>;
 template class Vector2<double>;

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -162,6 +162,12 @@ struct Vector2
     // rotate vector by angle in radians
     void rotate(float angle_rad);
 
+    /*
+      conversion to/from double
+     */
+    Vector2<float> tofloat() const;
+    Vector2<double> todouble() const;
+    
     // given a position p1 and a velocity v1 produce a vector
     // perpendicular to v1 maximising distance from p1
     static Vector2<T> perpendicular(const Vector2<T> &pos_delta, const Vector2<T> &v1);
@@ -269,3 +275,4 @@ typedef Vector2<uint16_t>       Vector2ui;
 typedef Vector2<int32_t>        Vector2l;
 typedef Vector2<uint32_t>       Vector2ul;
 typedef Vector2<float>          Vector2f;
+typedef Vector2<double>          Vector2d;

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -165,8 +165,12 @@ struct Vector2
     /*
       conversion to/from double
      */
-    Vector2<float> tofloat() const;
-    Vector2<double> todouble() const;
+    Vector2<float> tofloat() const {
+        return Vector2<float>{float(x),float(y)};
+    }
+    Vector2<double> todouble() const {
+        return Vector2<double>{x,y};
+    }
     
     // given a position p1 and a velocity v1 produce a vector
     // perpendicular to v1 maximising distance from p1

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -264,7 +264,13 @@ public:
 
     // extrapolate position given bearing and pitch (in degrees) and distance
     void offset_bearing(float bearing, float pitch, float distance);
-    
+
+    /*
+      conversion to/from double
+     */
+    Vector3<float> tofloat() const;
+    Vector3<double> todouble() const;
+
     // given a position p1 and a velocity v1 produce a vector
     // perpendicular to v1 maximising distance from p1.  If p1 is the
     // zero vector the return from the function will always be the

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -268,8 +268,12 @@ public:
     /*
       conversion to/from double
      */
-    Vector3<float> tofloat() const;
-    Vector3<double> todouble() const;
+    Vector3<float> tofloat() const {
+        return Vector3<float>{float(x),float(y),float(z)};
+    }
+    Vector3<double> todouble() const {
+        return Vector3<double>{x,y,z};
+    }
 
     // given a position p1 and a velocity v1 produce a vector
     // perpendicular to v1 maximising distance from p1.  If p1 is the

--- a/libraries/SITL/SIM_AirSim.cpp
+++ b/libraries/SITL/SIM_AirSim.cpp
@@ -307,7 +307,7 @@ void AirSim::recv_fdm(const sitl_input& input)
     location.lng = state.gps.lon * 1.0e7;
     location.alt = state.gps.alt * 100.0f;
 
-    position = home.get_distance_NED(location);
+    position = home.get_distance_NED_double(location);
 
     dcm.from_euler(state.pose.roll, state.pose.pitch, state.pose.yaw);
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -127,7 +127,7 @@ public:
 
     const Location &get_location() const { return location; }
 
-    const Vector3f &get_position() const { return position; }
+    const Vector3d &get_position() const { return position; }
 
     // distance the rangefinder is perceiving
     float rangefinder_range() const;
@@ -166,7 +166,7 @@ protected:
     Vector3f wind_ef;                    // m/s, earth frame
     Vector3f velocity_air_ef;            // velocity relative to airmass, earth frame
     Vector3f velocity_air_bf;            // velocity relative to airmass, body frame
-    Vector3f position;                   // meters, NED from origin
+    Vector3d position;                   // meters, NED from origin
     float mass;                          // kg
     float external_payload_mass;         // kg
     Vector3f accel_body{0.0f, 0.0f, -GRAVITY_MSS}; // m/s/s NED, body frame
@@ -297,7 +297,7 @@ protected:
     void add_twist_forces(Vector3f &rot_accel);
 
     // get local thermal updraft
-    float get_local_updraft(Vector3f currentPos);
+    float get_local_updraft(const Vector3d &currentPos);
 
 private:
     uint64_t last_time_us;
@@ -313,7 +313,7 @@ private:
         Vector3f accel_body;
         Vector3f gyro;
         Matrix3f rotation_b2e;
-        Vector3f position;
+        Vector3d position;
         Vector3f velocity_ef;
         uint64_t last_update_us;
         Location location;

--- a/libraries/SITL/SIM_BalanceBot.cpp
+++ b/libraries/SITL/SIM_BalanceBot.cpp
@@ -149,7 +149,7 @@ void BalanceBot::update(const struct sitl_input &input)
     velocity_ef += accel_earth * delta_time;
 
     // new position vector
-    position += (velocity_ef * delta_time);
+    position += (velocity_ef * delta_time).todouble();
 
     // neglect roll
     dcm.to_euler(&r, &p, &y);

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -412,7 +412,7 @@ void FlightAxis::update(const struct sitl_input &input)
     velocity_ef = Vector3f(state.m_velocityWorldU_MPS,
                              state.m_velocityWorldV_MPS,
                              state.m_velocityWorldW_MPS);
-    position = Vector3f(state.m_aircraftPositionY_MTR,
+    position = Vector3d(state.m_aircraftPositionY_MTR,
                         state.m_aircraftPositionX_MTR,
                         -state.m_altitudeASL_MTR - home.alt*0.01);
 

--- a/libraries/SITL/SIM_FlightAxis.h
+++ b/libraries/SITL/SIM_FlightAxis.h
@@ -178,7 +178,7 @@ private:
     uint64_t socket_frame_counter;
     uint64_t last_socket_frame_counter;
     double last_frame_count_s;
-    Vector3f position_offset;
+    Vector3d position_offset;
     Vector3f last_velocity_ef;
 
     const char *controller_ip = "127.0.0.1";

--- a/libraries/SITL/SIM_Gazebo.cpp
+++ b/libraries/SITL/SIM_Gazebo.cpp
@@ -117,9 +117,9 @@ void Gazebo::recv_fdm(const struct sitl_input &input)
                            static_cast<float>(pkt.velocity_xyz[1]),
                            static_cast<float>(pkt.velocity_xyz[2]));
 
-    position = Vector3f(static_cast<float>(pkt.position_xyz[0]),
-                        static_cast<float>(pkt.position_xyz[1]),
-                        static_cast<float>(pkt.position_xyz[2]));
+    position = Vector3d(pkt.position_xyz[0],
+                        pkt.position_xyz[1],
+                        pkt.position_xyz[2]);
 
 
     // auto-adjust to simulation frame rate

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -184,6 +184,16 @@ uint16_t JSON::parse_sensors(const char *json)
                 break;
             }
 
+            case DATA_VECTOR3D: {
+                Vector3d *v = (Vector3d *)key.ptr;
+                if (sscanf(p, "[%lf, %lf, %lf]", &v->x, &v->y, &v->z) != 3) {
+                    printf("Failed to parse Vector3f for %s/%s\n", key.section, key.key);
+                    return received_bitmask;
+                }
+                //printf("%s/%s = %f, %f, %f\n", key.section, key.key, v->x, v->y, v->z);
+                break;
+            }
+
             case QUATERNION: {
                 Quaternion *v = static_cast<Quaternion*>(key.ptr);
                 if (sscanf(p, "[%f, %f, %f, %f]", &(v->q1), &(v->q2), &(v->q3), &(v->q4)) != 4) {

--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -68,6 +68,7 @@ private:
         DATA_FLOAT,
         DATA_DOUBLE,
         DATA_VECTOR3F,
+        DATA_VECTOR3D,
         QUATERNION,
     };
 
@@ -77,7 +78,7 @@ private:
             Vector3f gyro;
             Vector3f accel_body;
         } imu;
-        Vector3f position;
+        Vector3d position;
         Vector3f attitude;
         Quaternion quaternion;
         Vector3f velocity;
@@ -100,7 +101,7 @@ private:
         { "", "timestamp", &state.timestamp_s, DATA_DOUBLE, true },
         { "imu", "gyro",    &state.imu.gyro, DATA_VECTOR3F, true },
         { "imu", "accel_body", &state.imu.accel_body, DATA_VECTOR3F, true },
-        { "", "position", &state.position, DATA_VECTOR3F, true },
+        { "", "position", &state.position, DATA_VECTOR3D, true },
         { "", "attitude", &state.attitude, DATA_VECTOR3F, false },
         { "", "quaternion", &state.quaternion, QUATERNION, false },
         { "", "velocity", &state.velocity, DATA_VECTOR3F, true },

--- a/libraries/SITL/SIM_Morse.cpp
+++ b/libraries/SITL/SIM_Morse.cpp
@@ -512,7 +512,7 @@ void Morse::update(const struct sitl_input &input)
                            -state.velocity.world_linear_velocity[1],
                            -state.velocity.world_linear_velocity[2]);
 
-    position = Vector3f(state.gps.x, -state.gps.y, -state.gps.z);
+    position = Vector3d(state.gps.x, -state.gps.y, -state.gps.z);
 
     // Morse IMU accel is NEU, convert to NED
     accel_body = Vector3f(state.imu.linear_acceleration[0],

--- a/libraries/SITL/SIM_Precland.cpp
+++ b/libraries/SITL/SIM_Precland.cpp
@@ -101,7 +101,7 @@ const AP_Param::GroupInfo SIM_Precland::var_info[] = {
     AP_GROUPEND
 };
 
-void SIM_Precland::update(const Location &loc, const Vector3f &position)
+void SIM_Precland::update(const Location &loc, const Vector3d &position)
 {
     if (!_enable) {
         _healthy = false;
@@ -162,7 +162,7 @@ void SIM_Precland::update(const Location &loc, const Vector3f &position)
             break;
         }
     }
-    _target_pos = position - Vector3f(center.x, center.y, origin_height_m);
+    _target_pos = position - Vector3d(center.x, center.y, origin_height_m);
     _healthy = true;
 }
 

--- a/libraries/SITL/SIM_Precland.h
+++ b/libraries/SITL/SIM_Precland.h
@@ -28,7 +28,7 @@ public:
     };
 
     // update precland state
-    void update(const Location &loc, const Vector3f &position);
+    void update(const Location &loc, const Vector3d &position);
 
     // true if precland sensor is online and healthy
     bool healthy() const { return _healthy; }
@@ -36,7 +36,7 @@ public:
     // timestamp of most recent data read from the sensor
     uint32_t last_update_ms() const { return _last_update_ms; }
 
-    const Vector3f &get_target_position() const { return _target_pos; }
+    const Vector3d &get_target_position() const { return _target_pos; }
     bool is_enabled() const {return static_cast<bool>(_enable);}
     void set_default_location(float lat, float lon, int16_t yaw);
     static const struct AP_Param::GroupInfo var_info[];
@@ -60,7 +60,7 @@ public:
 private:
     uint32_t _last_update_ms;
     bool _healthy;
-    Vector3f _target_pos;
+    Vector3d _target_pos;
 };
 
 }

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -158,7 +158,7 @@ void SimRover::update(const struct sitl_input &input)
     velocity_ef += accel_earth * delta_time;
 
     // new position vector
-    position += velocity_ef * delta_time;
+    position += (velocity_ef * delta_time).todouble();
 
     update_external_payload(input);
 

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -294,7 +294,7 @@ void Sailboat::update(const struct sitl_input &input)
     velocity_ef = velocity_ef_water + tide_velocity_ef;
 
     // new position vector
-    position += velocity_ef * delta_time;
+    position += (velocity_ef * delta_time).todouble();
 
     // update lat/lon/altitude
     update_position();

--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -138,7 +138,7 @@ void Submarine::calculate_buoyancy_torque(Vector3f &torque)
  * @param position
  * @return float
  */
-float Submarine::calculate_sea_floor_depth(const Vector3f &/*position*/)
+float Submarine::calculate_sea_floor_depth(const Vector3d &/*position*/)
 {
     return 50;
 }

--- a/libraries/SITL/SIM_Submarine.h
+++ b/libraries/SITL/SIM_Submarine.h
@@ -90,7 +90,7 @@ protected:
     bool on_ground() const override;
 
     // calculate sea floor depth based for terrain follow
-    float calculate_sea_floor_depth(const Vector3f &/*position*/);
+    float calculate_sea_floor_depth(const Vector3d &/*position*/);
     // calculate rotational and linear accelerations
     void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
     // calculate buoyancy

--- a/libraries/SITL/SIM_Vicon.h
+++ b/libraries/SITL/SIM_Vicon.h
@@ -34,7 +34,7 @@ public:
     Vicon();
 
     // update state
-    void update(const Location &loc, const Vector3f &position, const Vector3f &velocity, const Quaternion &attitude);
+    void update(const Location &loc, const Vector3d &position, const Vector3f &velocity, const Quaternion &attitude);
 
 private:
 
@@ -70,7 +70,7 @@ private:
     bool get_free_msg_buf_index(uint8_t &index);
 
     void update_vicon_position_estimate(const Location &loc,
-                                        const Vector3f &position,
+                                        const Vector3d &position,
                                         const Vector3f &velocity,
                                         const Quaternion &attitude);
 
@@ -79,7 +79,7 @@ private:
 
     // position delta message 
     Quaternion _attitude_prev; // Rotation to previous MAV_FRAME_BODY_FRD from MAV_FRAME_LOCAL_NED
-    Vector3f _position_prev;  // previous position from origin (m) MAV_FRAME_LOCAL_NED
+    Vector3d _position_prev;  // previous position from origin (m) MAV_FRAME_LOCAL_NED
 };
 
 }

--- a/libraries/SITL/SIM_Webots.cpp
+++ b/libraries/SITL/SIM_Webots.cpp
@@ -515,7 +515,7 @@ void Webots::update(const struct sitl_input &input)
                             +state.velocity.world_linear_velocity[1],
                             -state.velocity.world_linear_velocity[2]);
         
-        position = Vector3f(state.gps.x, state.gps.y, -state.gps.z);
+        position = Vector3d(state.gps.x, state.gps.y, -state.gps.z);
         
 
         // limit to 16G to match pixhawk1

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -115,7 +115,7 @@ bool XPlane::receive_data(void)
                                     one << PropPitch | one << EngineRPM | one << PropRPM | one << Generator |
                                     one << Mixture);
     Location loc {};
-    Vector3f pos;
+    Vector3d pos;
     uint32_t wait_time_ms = 1;
     uint32_t now = AP_HAL::millis();
 

--- a/libraries/SITL/SIM_XPlane.h
+++ b/libraries/SITL/SIM_XPlane.h
@@ -54,7 +54,7 @@ private:
 
     uint64_t time_base_us;
     uint32_t last_data_time_ms;
-    Vector3f position_zero;
+    Vector3d position_zero;
     Vector3f accel_earth;
     float throttle_sent = -1;
     bool connected = false;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -342,6 +342,10 @@ const AP_Param::GroupInfo SITL::var_gps[] = {
     AP_GROUPINFO("GPS2_ACC",      43, SITL,  gps_accuracy[1], 0.3),
     AP_GROUPINFO("GPS2_VERR",     44, SITL,  gps_vel_err[1], 0),
 
+    AP_GROUPINFO("INIT_LAT_OFS",  45, SITL,  gps_init_lat_ofs, 0),
+    AP_GROUPINFO("INIT_LON_OFS",  46, SITL,  gps_init_lon_ofs, 0),
+    AP_GROUPINFO("INIT_ALT_OFS",  47, SITL,  gps_init_alt_ofs, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -211,6 +211,11 @@ public:
     AP_Float gps_accuracy[2];
     AP_Vector3f gps_vel_err[2]; // Velocity error offsets in NED (x = N, y = E, z = D)
 
+    // initial offset on GPS lat/lon, used to shift origin
+    AP_Float gps_init_lat_ofs;
+    AP_Float gps_init_lon_ofs;
+    AP_Float gps_init_alt_ofs;
+
     AP_Float batt_voltage; // battery voltage base
     AP_Float batt_capacity_ah; // battery capacity in Ah
     AP_Int8  rc_fail;     // fail RC input

--- a/wscript
+++ b/wscript
@@ -257,6 +257,11 @@ configuration in order to save typing.
         default=False,
         help='Force a static build')
 
+    g.add_option('--postype-single',
+        action='store_true',
+        default=False,
+        help='force single precision postype_t')
+    
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():
         paths = []


### PR DESCRIPTION
The copter position controller often does calculations like this:

  position += velocity * dt;

when this is run at the loop rate then the delta to the position is small enough relative to the position that it becomes zero when we are at a long distance from the origin. At a speed of 1.5m/s the delta becomes zero at around 100km from the origin. This means that flying more 100km from the origin leads to navigation failures.
This PR converts the position portion of the copter position controller to double precision. This allows for flying at up to around 800km from the origin. To go beyond that we need to convert the EKF to double precision, see PR #17356 

To aid in testing the PR also adds SIM_INIT_LAT_OFS, SIM_INIT_LON_OFS and SIM_INIT_ALT_OFS. These offset the initial GPS position (for first 20s after startup), which moves the origin. The issues with flying at a long distance from the origin then become very apparent.
A simple test is to fly in LOITER with RC4 at 1400, this demanding a small forward speed. Without this PR the copter does not move forward. With this PR it does.
Even with this PR there is a small amplitude oscillation in velocity at 112km (lat offset of 1). I don't yet know what causes that

Note: We need to look at the CPU cost of this on F405 boards. If unacceptable it would be possible to make this compile time by using a Vector2p and Vector3p type, which would be Vector2f or Vector2d based on a build option, the 'p' standing for position.
