### PR TITLE
Rover/GCS: send water depth and temperature

### DIFF
--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -76,6 +76,9 @@ void Rover::Log_Write_Depth()
                         loc.lng,
                         (double)(rangefinder.distance_cm_orient(ROTATION_PITCH_270) * 0.01f),
                         temp_C);
+
+    // send water depth and temp to ground station
+    gcs().send_message(MSG_WATER_DEPTH);
 }
 
 // guided mode logging

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -268,6 +268,7 @@ public:
     void send_rpm() const;
     void send_generator_status() const;
     virtual void send_winch_status() const {};
+    void send_water_depth() const;
 
     // lock a channel, preventing use by MAVLink
     void lock(bool _lock) {

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -77,5 +77,6 @@ enum ap_message : uint8_t {
     MSG_EFI_STATUS,
     MSG_GENERATOR_STATUS,
     MSG_WINCH_STATUS,
+    MSG_WATER_DEPTH,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
This PR adds support for bots with downward facing rangefinders (assumed to be underwater sonar) to send the WATER_DEPTH message each time a new reading is received.  This message contains the depth, water temperature, location and attitude of the vehicle.  This is conceptually similar to camera feedback messages which are sent to the GCS each time a picture is taken

This has been lightly tested in SITL to ensure the message is only sent for Rovers with downward facing rangefinders.


