### PR TITLE
Plane: GCS_Plane.cpp Fix of inappropriate critical warning CRT:NoRCReceiver

### DIFF
--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -114,7 +114,8 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
 
     control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
     control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    if (millis() - plane.failsafe.last_valid_rc_ms < 200) {
+    uint32_t last_valid = plane.failsafe.last_valid_rc_ms;
+    if (millis() - last_valid < 200) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
     }
 


### PR DESCRIPTION
Fix chronological sequence to avoid inappropriate critical warning CRT:NoRCReceiver 
by ensuring the call of plane.failsafe.last_valid_rc_ms before calling millis()

Tested in real flight -> no inappropriate warning
Tested in range mode -> correct warning

Further explanations and pictures:
https://discuss.ardupilot.org/t/message-no-rc-receiver/71324/27
