### PR TITLE
AP_ServoRelayEvents: Change the message

### DIFF
--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -42,7 +42,7 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
     case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
         break;
     default:
-        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
+        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Cannot be set to Channel %d", _channel);
         return false;
     }
     if (type == EVENT_TYPE_SERVO && 
@@ -97,7 +97,7 @@ bool AP_ServoRelayEvents::do_repeat_servo(uint8_t _channel, uint16_t _servo_valu
     case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
         break;
     default:
-        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
+        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Cannot be set to Channel %d", _channel);
         return false;
     }
     channel = _channel;


### PR DESCRIPTION
This method sets the specified servo if it can be set.
If the servo is not set, a message is sent.
Therefore, the message will be "could not be set".