### PR TITLE
Tidy Copter frame/type string output

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -570,8 +570,9 @@ void GCS_MAVLINK_Copter::send_banner()
         send_text(MAV_SEVERITY_INFO, "motors not allocated");
         return;
     }
-    send_text(MAV_SEVERITY_INFO, "Frame: %s/%s", copter.motors->get_frame_string(),
-                                                 copter.motors->get_type_string());
+    char frame_and_type_string[30];
+    copter.motors->get_frame_and_type_string(frame_and_type_string, ARRAY_SIZE(frame_and_type_string));
+    send_text(MAV_SEVERITY_INFO, "%s", frame_and_type_string);
 }
 
 void GCS_MAVLINK_Copter::handle_command_ack(const mavlink_message_t &msg)

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -547,7 +547,9 @@ const struct LogStructure Copter::log_structure[] = {
 void Copter::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by AP_Logger
-    logger.Write_MessageF("Frame: %s/%s", motors->get_frame_string(), motors->get_type_string());
+    char frame_and_type_string[30];
+    copter.motors->get_frame_and_type_string(frame_and_type_string, ARRAY_SIZE(frame_and_type_string));
+    logger.Write_MessageF("%s", frame_and_type_string);
     logger.Write_Mode((uint8_t)flightmode->mode_number(), control_mode_reason);
     ahrs.Log_Write_Home_And_Origin();
     gps.Write_AP_Logger_Log_Startup_messages();

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -48,6 +48,17 @@ AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
     _thrust_balanced = true;
 };
 
+void AP_Motors::get_frame_and_type_string(char *buffer, uint8_t buflen) const
+{
+    const char *frame_str = get_frame_string();
+    const char *type_str = get_type_string();
+    if (type_str != nullptr && strlen(type_str)) {
+        hal.util->snprintf(buffer, buflen, "Frame: %s/%s", frame_str, type_str);
+    } else {
+        hal.util->snprintf(buffer, buflen, "Frame: %s", frame_str);
+    }
+}
+
 void AP_Motors::armed(bool arm)
 {
     if (_armed != arm) {

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -74,6 +74,9 @@ public:
     // return string corresponding to frame_type
     virtual const char* get_type_string() const { return ""; }
 
+    // returns a formatted string into buffer, e.g. "QUAD/X"
+    void get_frame_and_type_string(char *buffer, uint8_t buflen) const;
+
     // Constructor
     AP_Motors(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
 


### PR DESCRIPTION
Before: `AP: Frame: TRI/`
After: `AP: Frame: TRI`
