### PR TITLE
AC_PosControl: remove pos control accel correction limit

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -64,8 +64,7 @@ public:
     ///
 
     /// set_max_speed_accel_xy - set the maximum horizontal speed in cm/s and acceleration in cm/s/s
-    /// If set accel_limit_cmss limits the maximum correction from the position controller to be less than the maximum lean angle
-    void set_max_speed_accel_xy(float speed_cms, float accel_cmss, float accel_limit_cmss = 0.0f);
+    void set_max_speed_accel_xy(float speed_cms, float accel_cmss);
 
     /// get_max_speed_xy_cms - get the maximum horizontal speed in cm/s
     float get_max_speed_xy_cms() const { return _vel_max_xy_cms; }
@@ -401,7 +400,6 @@ protected:
     float       _vel_max_up_cms;        // max climb rate in cm/s
     float       _vel_max_down_cms;      // max descent rate in cm/s
     float       _accel_max_xy_cmss;     // max horizontal acceleration in cm/s/s
-    float       _accel_limit_xy_cmss;   // max horizontal acceleration in cm/s/s
     float       _accel_max_z_cmss;      // max vertical acceleration in cm/s/s
     float       _vel_z_control_ratio = 2.0f;    // confidence that we have control in the vertical axis
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -91,7 +91,7 @@ void AC_Loiter::init_target(const Vector3f& position)
     sanity_check_params();
 
     // initialise pos controller speed, acceleration
-    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss, _accel_cmss);
+    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss);
     // initialise position controller
     _pos_control.init_xy_controller_stopping_point();
 
@@ -111,7 +111,7 @@ void AC_Loiter::init_target()
     sanity_check_params();
 
     // initialise position controller speed and acceleration
-    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss, _accel_cmss);
+    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss);
 
     // initialise position controller
     _pos_control.init_xy_controller();
@@ -190,7 +190,7 @@ float AC_Loiter::get_angle_max_cd() const
 void AC_Loiter::update(bool avoidance_on)
 {
     // initialise pos controller speed and acceleration
-    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss, _accel_cmss);
+    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss);
 
     calc_desired_velocity(_pos_control.get_dt(), avoidance_on);
     _pos_control.update_xy_controller();
@@ -223,7 +223,7 @@ void AC_Loiter::calc_desired_velocity(float nav_dt, bool avoidance_on)
     }
 
     // initialise pos controller speed, acceleration
-    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss, _accel_cmss);
+    _pos_control.set_max_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss);
 
     // get loiters desired velocity from the position controller where it is being stored.
     const Vector3f &desired_vel_3d = _pos_control.get_vel_desired_cms();


### PR DESCRIPTION
This PR fixes #17747

This is a minor change that only affects loiter. This change restores the previous behaviour of Loiter and removes the unnecessary additional variable.