### PR TITLE
AP_BattMonitor: Add Param for I2C_address, Move Analog & I2C Params to VarPtr Groups 

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -614,10 +614,17 @@ class AutoTestPlane(AutoTest):
 
     def SmartBattery(self):
         self.set_parameters({
-            "BATT_MONITOR": 16,
-            "BATT_BUS": 2,  # specified in SIM_I2C.cpp
+            "BATT_MONITOR": 16, # Maxell battery monitor
+        })
+
+        # Must reboot sitl after setting montior type for SMBus parameters to be set due to dynamic group
+        self.reboot_sitl()
+        self.set_parameters({
+            "BATT_I2C_BUS": 2,      # specified in SIM_I2C.cpp
+            "BATT_I2C_ADDR": 11,    # specified in SIM_I2C.cpp
         })
         self.reboot_sitl()
+
         self.wait_ready_to_arm()
         m = self.mav.recv_match(type='BATTERY_STATUS', blocking=True, timeout=10)
         if m is None:

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -69,8 +69,50 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Params.cpp
     AP_SUBGROUPINFO(_params[8], "9_", 31, AP_BattMonitor, AP_BattMonitor_Params),
 
+    #if HAL_BATTMON_SMBUS_ENABLE
+    // @Group: _
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[0], "_", 32, AP_BattMonitor, backend_smbus_var_info[0]),
+
+    // @Group: 2_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[1], "2_", 33, AP_BattMonitor, backend_smbus_var_info[1]),
+
+    // @Group: 3_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[2], "3_", 34, AP_BattMonitor, backend_smbus_var_info[2]),
+
+    // @Group: 4_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[3], "4_", 35, AP_BattMonitor, backend_smbus_var_info[3]),
+
+    // @Group: 5_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[4], "5_", 36, AP_BattMonitor, backend_smbus_var_info[4]),
+
+    // @Group: 6_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[5], "6_", 37, AP_BattMonitor, backend_smbus_var_info[5]),
+
+    // @Group: 7_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[6], "7_", 38, AP_BattMonitor, backend_smbus_var_info[6]),
+
+    // @Group: 8_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[7], "8_", 39, AP_BattMonitor, backend_smbus_var_info[7]),
+
+    // @Group: 9_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    AP_SUBGROUPVARPTR(drivers[8], "9_", 40, AP_BattMonitor, backend_smbus_var_info[8]),
+#endif // HAL_BATTMON_SMBUS_ENABLE
+
     AP_GROUPEND
 };
+
+#if HAL_BATTMON_SMBUS_ENABLE
+const AP_Param::GroupInfo *AP_BattMonitor::backend_smbus_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
+#endif
 
 // Default constructor.
 // Note that the Vector/Matrix constructors already implicitly zero
@@ -121,45 +163,25 @@ AP_BattMonitor::init()
                 break;
 #if HAL_BATTMON_SMBUS_ENABLE
             case Type::SOLO:
-                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_INTERNAL);
-                drivers[instance] = new AP_BattMonitor_SMBus_Solo(*this, state[instance], _params[instance],
-                                                                  hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                          100000, true, 20));
+                drivers[instance] = new AP_BattMonitor_SMBus_Solo(*this, state[instance], _params[instance]);
                 break;
             case Type::SMBus_Generic:
-                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL);
-                drivers[instance] = new AP_BattMonitor_SMBus_Generic(*this, state[instance], _params[instance],
-                                                                     hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                             100000, true, 20));
+                drivers[instance] = new AP_BattMonitor_SMBus_Generic(*this, state[instance], _params[instance]);
                 break;
             case Type::SUI3:
-                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_INTERNAL),
-                drivers[instance] = new AP_BattMonitor_SMBus_SUI(*this, state[instance], _params[instance],
-                                                                 hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                          100000, true, 20), 3);
+                drivers[instance] = new AP_BattMonitor_SMBus_SUI(*this, state[instance], _params[instance], 3);
                 break;
             case Type::SUI6:
-                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_INTERNAL),
-                drivers[instance] = new AP_BattMonitor_SMBus_SUI(*this, state[instance], _params[instance],
-                                                                 hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                         100000, true, 20), 6);
+                drivers[instance] = new AP_BattMonitor_SMBus_SUI(*this, state[instance], _params[instance], 6);
                 break;
             case Type::MAXELL:
-                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL);
-                drivers[instance] = new AP_BattMonitor_SMBus_Maxell(*this, state[instance], _params[instance],
-                                                                    hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                            100000, true, 20));
+                drivers[instance] = new AP_BattMonitor_SMBus_Maxell(*this, state[instance], _params[instance]);
                 break;
             case Type::Rotoye:
-                drivers[instance] = new AP_BattMonitor_SMBus_Rotoye(*this, state[instance], _params[instance],
-                                                                    hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                            100000, true, 20));
+                drivers[instance] = new AP_BattMonitor_SMBus_Rotoye(*this, state[instance], _params[instance]);
                 break;
             case Type::NeoDesign:
-                _params[instance]._i2c_bus.set_default(AP_BATTMONITOR_SMBUS_BUS_INTERNAL),
-                drivers[instance] = new AP_BattMonitor_SMBus_NeoDesign(*this, state[instance], _params[instance],
-                                                                 hal.i2c_mgr->get_device(_params[instance]._i2c_bus, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                         100000, true, 20));
+                drivers[instance] = new AP_BattMonitor_SMBus_NeoDesign(*this, state[instance], _params[instance]);
                 break;
 #endif // HAL_BATTMON_SMBUS_ENABLE
             case Type::BEBOP:
@@ -188,7 +210,6 @@ AP_BattMonitor::init()
                 drivers[instance] = new AP_BattMonitor_FuelLevel_PWM(*this, state[instance], _params[instance]);
                 break;
 #endif // HAL_BATTMON_FUEL_ENABLE
-
 #if GENERATOR_ENABLED
             case Type::GENERATOR_ELEC:
                 drivers[instance] = new AP_BattMonitor_Generator_Elec(*this, state[instance], _params[instance]);
@@ -207,6 +228,20 @@ AP_BattMonitor::init()
                 break;
         }
 
+#if HAL_BATTMON_SMBUS_ENABLE
+    // if the backend has some local parameters then make those available in the tree
+    if (drivers[instance] && state[instance].var_info) {
+        Type type = get_type(instance);
+        if ((type == Type::MAXELL) || (type == Type::NeoDesign) || (type == Type::Rotoye) || (type == Type::SMBus_Generic) ||
+            (type == Type::SOLO)   || (type == Type::SUI3)      || (type == Type::SUI6)) {
+            backend_smbus_var_info[instance] = state[instance].var_info;
+            AP_Param::load_object_from_eeprom(drivers[instance], backend_smbus_var_info[instance]);
+        }
+        // param count could have changed
+        AP_Param::invalidate_count();
+    }
+#endif
+
         // call init function for each backend
         if (drivers[instance] != nullptr) {
             drivers[instance]->init();
@@ -215,7 +250,60 @@ AP_BattMonitor::init()
             // there will be a gap, but as we always check for drivers[instances] being nullptr
             // this is safe
             _num_instances = instance + 1;
+
+            // Convert the old analog & Bus parameters to the new dynamic parameter groups
+            convert_dynamic_param_groups(instance);
         }
+    }
+}
+
+void AP_BattMonitor::convert_dynamic_param_groups(uint8_t instance)
+{
+    AP_Param::ConversionInfo info;
+    if (!AP_Param::find_top_level_key_by_pointer(this, info.old_key)) {
+        return;
+    }
+
+    char param_prefix[6] {};
+    char param_name[17] {};
+    info.new_name = param_name;
+
+    const uint8_t param_instance = instance + 1;
+    // first battmonitor does not have '1' in the param name
+    if(param_instance == 1) {
+        hal.util->snprintf(param_prefix, sizeof(param_prefix), "BATT");
+    } else {
+        hal.util->snprintf(param_prefix, sizeof(param_prefix), "BATT%X", param_instance);
+    }
+    param_prefix[sizeof(param_prefix)-1] = '\0';
+
+    hal.util->snprintf(param_name, sizeof(param_name), "%s_%s", param_prefix, "MONITOR");
+    param_name[sizeof(param_name)-1] = '\0';
+
+    // Find the index of the BATTn_MONITOR which is not moving to index the moving parameters off from
+    AP_Param::ParamToken token = AP_Param::ParamToken {};
+    ap_var_type type;
+    AP_Param* param = AP_Param::find_by_name(param_name, &type, &token);
+    const uint8_t battmonitor_index = 1;
+    if( param == nullptr) {
+        // BATTn_MONITOR not found
+        return;
+    }
+
+    const struct convert_table {
+        uint32_t old_group_element;
+        ap_var_type type;
+        const char* new_name;
+    }  conversion_table[] = {
+            { 20, AP_PARAM_INT8,  "I2C_BUS"   },
+        };
+
+    for (const auto & elem : conversion_table) {
+        info.old_group_element = token.group_element + ((elem.old_group_element - battmonitor_index) * 64);;
+        info.type = elem.type;
+
+        hal.util->snprintf(param_name, sizeof(param_name), "%s_%s", param_prefix, elem.new_name);
+        AP_Param::convert_old_parameter(&info, 1.0f, 0);
     }
 }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -131,6 +131,7 @@ public:
         const struct AP_Param::GroupInfo *var_info;
     };
 
+    static const struct AP_Param::GroupInfo *backend_analog_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
     static const struct AP_Param::GroupInfo *backend_smbus_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
 
     // Return the number of battery monitor instances

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -128,7 +128,10 @@ public:
         bool        healthy;                   // battery monitor is communicating correctly
         bool        is_powering_off;           // true when power button commands power off
         bool        powerOffNotified;          // only send powering off notification once
+        const struct AP_Param::GroupInfo *var_info;
     };
+
+    static const struct AP_Param::GroupInfo *backend_smbus_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
 
     // Return the number of battery monitor instances
     uint8_t num_instances(void) const { return _num_instances; }
@@ -237,6 +240,7 @@ private:
     uint8_t     _num_instances;                                     /// number of monitors
 
     void convert_params(void);
+    void convert_dynamic_param_groups(uint8_t instance);
 
     /// returns the failsafe state of the battery
     Failsafe check_failsafe(const uint8_t instance);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -1,10 +1,50 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
-#include "AP_BattMonitor.h"
 #include "AP_BattMonitor_Analog.h"
 
 extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_BattMonitor_Analog::var_info[] = {
+
+    // @Param: VOLT_PIN
+    // @DisplayName: Battery Voltage sensing pin
+    // @Description: Sets the analog input pin that should be used for voltage monitoring.
+    // @Values: -1:Disabled, 2:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 5:Navigator, 13:Pixhawk2_PM2/CubeOrange_PM2, 14:CubeOrange, 16:Durandal, 100:PX4-v1
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("VOLT_PIN", 1, AP_BattMonitor_Analog, _volt_pin, AP_BATT_VOLT_PIN),
+
+    // @Param: CURR_PIN
+    // @DisplayName: Battery Current sensing pin
+    // @Description: Sets the analog input pin that should be used for current monitoring.
+    // @Values: -1:Disabled, 3:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 4:CubeOrange_PM2/Navigator, 14:Pixhawk2_PM2, 15:CubeOrange, 17:Durandal, 101:PX4-v1
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("CURR_PIN", 2, AP_BattMonitor_Analog, _curr_pin, AP_BATT_CURR_PIN),
+
+    // @Param: VOLT_MULT
+    // @DisplayName: Voltage Multiplier
+    // @Description: Used to convert the voltage of the voltage sensing pin (@PREFIX@VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick with a Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX using the PX4IO power supply this should be set to 1.
+    // @User: Advanced
+    AP_GROUPINFO("VOLT_MULT", 3, AP_BattMonitor_Analog, _volt_multiplier, AP_BATT_VOLTDIVIDER_DEFAULT),
+
+    // @Param: AMP_PERVLT
+    // @DisplayName: Amps per volt
+    // @Description: Number of amps that a 1V reading on the current sensor corresponds to. With a Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17.
+    // @Units: A/V
+    // @User: Standard
+    AP_GROUPINFO("AMP_PERVLT", 4, AP_BattMonitor_Analog, _curr_amp_per_volt, AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
+
+    // @Param: AMP_OFFSET
+    // @DisplayName: AMP offset
+    // @Description: Voltage offset at zero current on current sensor
+    // @Units: V
+    // @User: Standard
+    AP_GROUPINFO("AMP_OFFSET", 5, AP_BattMonitor_Analog, _curr_amp_offset, 0),
+
+    AP_GROUPEND
+};
 
 /// Constructor
 AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
@@ -12,8 +52,11 @@ AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
                                              AP_BattMonitor_Params &params) :
     AP_BattMonitor_Backend(mon, mon_state, params)
 {
-    _volt_pin_analog_source = hal.analogin->channel(_params._volt_pin);
-    _curr_pin_analog_source = hal.analogin->channel(_params._curr_pin);
+    AP_Param::setup_object_defaults(this, var_info);
+    _state.var_info = var_info;
+    
+    _volt_pin_analog_source = hal.analogin->channel(_volt_pin);
+    _curr_pin_analog_source = hal.analogin->channel(_curr_pin);
 
     // always healthy
     _state.healthy = true;
@@ -24,10 +67,10 @@ void
 AP_BattMonitor_Analog::read()
 {
     // this copes with changing the pin at runtime
-    _volt_pin_analog_source->set_pin(_params._volt_pin);
+    _volt_pin_analog_source->set_pin(_volt_pin);
 
     // get voltage
-    _state.voltage = _volt_pin_analog_source->voltage_average() * _params._volt_multiplier;
+    _state.voltage = _volt_pin_analog_source->voltage_average() * _volt_multiplier;
 
     // read current
     if (has_current()) {
@@ -36,10 +79,10 @@ AP_BattMonitor_Analog::read()
         float dt = tnow - _state.last_time_micros;
 
         // this copes with changing the pin at runtime
-        _curr_pin_analog_source->set_pin(_params._curr_pin);
+        _curr_pin_analog_source->set_pin(_curr_pin);
 
         // read current
-        _state.current_amps = (_curr_pin_analog_source->voltage_average()-_params._curr_amp_offset)*_params._curr_amp_per_volt;
+        _state.current_amps = (_curr_pin_analog_source->voltage_average() - _curr_amp_offset) * _curr_amp_per_volt;
 
         // update total current drawn since startup
         if (_state.last_time_micros != 0 && dt < 2000000.0f) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
@@ -83,18 +83,27 @@ public:
     AP_BattMonitor_Analog(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params);
 
     /// Read the battery voltage and current.  Should be called at 10hz
-    void read() override;
+    virtual void read() override;
 
     /// returns true if battery monitor provides consumed energy info
-    bool has_consumed_energy() const override { return has_current(); }
+    virtual bool has_consumed_energy() const override { return has_current(); }
 
     /// returns true if battery monitor provides current info
-    bool has_current() const override;
+    virtual bool has_current() const override;
 
-    void init(void) override {}
+    virtual void init(void) override {}
+
+    static const struct AP_Param::GroupInfo var_info[];
 
 protected:
 
     AP_HAL::AnalogSource *_volt_pin_analog_source;
     AP_HAL::AnalogSource *_curr_pin_analog_source;
+
+    // Parameters
+    AP_Float _volt_multiplier;          /// voltage on volt pin multiplied by this to calculate battery voltage
+    AP_Float _curr_amp_per_volt;        /// voltage on current pin multiplied by this to calculate current in amps
+    AP_Float _curr_amp_offset;          /// offset voltage that is subtracted from current pin before conversion to amps
+    AP_Int8  _volt_pin;                 /// board pin used to measure battery voltage
+    AP_Int8  _curr_pin;                 /// board pin used to measure battery current
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.cpp
@@ -23,7 +23,7 @@ extern const AP_HAL::HAL& hal;
 AP_BattMonitor_FuelFlow::AP_BattMonitor_FuelFlow(AP_BattMonitor &mon,
                                                  AP_BattMonitor::BattMonitor_State &mon_state,
                                                  AP_BattMonitor_Params &params) :
-    AP_BattMonitor_Backend(mon, mon_state, params)
+    AP_BattMonitor_Analog(mon, mon_state, params)
 {
     _state.voltage = 1.0; // show a fixed voltage of 1v
 
@@ -56,7 +56,7 @@ void AP_BattMonitor_FuelFlow::irq_handler(uint8_t pin, bool pin_state, uint32_t 
 */
 void AP_BattMonitor_FuelFlow::read()
 {
-    int8_t pin = _params._curr_pin;
+    int8_t pin = _curr_pin;
     if (last_pin != pin) {
         // detach from last pin
         if (last_pin != -1) {
@@ -107,7 +107,7 @@ void AP_BattMonitor_FuelFlow::read()
         litres = 0;
         litres_pec_sec = 0;
     } else {
-        litres = state.pulse_count * _params._curr_amp_per_volt * 0.001f;
+        litres = state.pulse_count * _curr_amp_per_volt * 0.001f;
         litres_pec_sec = litres / irq_dt;
     }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "AP_BattMonitor.h"
-#include "AP_BattMonitor_Backend.h"
+#include "AP_BattMonitor_Analog.h"
 
-class AP_BattMonitor_FuelFlow : public AP_BattMonitor_Backend
+class AP_BattMonitor_FuelFlow : public AP_BattMonitor_Analog
 {
 public:
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.cpp
@@ -15,7 +15,7 @@ extern const AP_HAL::HAL& hal;
 
 /// Constructor
 AP_BattMonitor_FuelLevel_PWM::AP_BattMonitor_FuelLevel_PWM(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params) :
-    AP_BattMonitor_Backend(mon, mon_state, params)
+    AP_BattMonitor_Analog(mon, mon_state, params)
 {
     _state.voltage = 1.0; // show a fixed voltage of 1v
 
@@ -28,7 +28,7 @@ AP_BattMonitor_FuelLevel_PWM::AP_BattMonitor_FuelLevel_PWM(AP_BattMonitor &mon, 
 */
 void AP_BattMonitor_FuelLevel_PWM::read()
 {
-    if (!pwm_source.set_pin(_params._curr_pin, "FuelLevelPWM")) {
+    if (!pwm_source.set_pin(_curr_pin, "FuelLevelPWM")) {
         _state.healthy = false;
         return;
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "AP_BattMonitor.h"
-#include "AP_BattMonitor_Backend.h"
+#include "AP_BattMonitor_Analog.h"
 
-class AP_BattMonitor_FuelLevel_PWM : public AP_BattMonitor_Backend
+class AP_BattMonitor_FuelLevel_PWM : public AP_BattMonitor_Analog
 {
 public:
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -164,12 +164,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ARM_MAH", 19, AP_BattMonitor_Params, _arming_minimum_capacity, 0),
 
-    // @Param: BUS
-    // @DisplayName: Battery monitor I2C bus number
-    // @Description: Battery monitor I2C bus number
-    // @Range: 0 3
-    // @User: Standard
-    AP_GROUPINFO("BUS", 20, AP_BattMonitor_Params, _i2c_bus, 0),
+    // 20 was BUS
 
     // @Param: OPTIONS
     // @DisplayName: Battery monitor options

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -1,7 +1,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include "AP_BattMonitor_Params.h"
-#include "AP_BattMonitor_Analog.h"
+#include "AP_BattMonitor.h"
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
   #define DEFAULT_LOW_BATTERY_VOLTAGE 10.5f
@@ -17,42 +17,16 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("MONITOR", 1, AP_BattMonitor_Params, _type, int8_t(AP_BattMonitor::Type::NONE), AP_PARAM_FLAG_ENABLE),
+    
+    // 2 was VOLT_PIN
 
-    // @Param: VOLT_PIN
-    // @DisplayName: Battery Voltage sensing pin
-    // @Description: Sets the analog input pin that should be used for voltage monitoring.
-    // @Values: -1:Disabled, 2:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 5:Navigator, 13:Pixhawk2_PM2/CubeOrange_PM2, 14:CubeOrange, 16:Durandal, 100:PX4-v1
-    // @User: Standard
-    // @RebootRequired: True
-    AP_GROUPINFO("VOLT_PIN", 2, AP_BattMonitor_Params, _volt_pin, AP_BATT_VOLT_PIN),
+    // 3 was CURR_PIN
 
-    // @Param: CURR_PIN
-    // @DisplayName: Battery Current sensing pin
-    // @Description: Sets the analog input pin that should be used for current monitoring.
-    // @Values: -1:Disabled, 3:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 4:CubeOrange_PM2/Navigator, 14:Pixhawk2_PM2, 15:CubeOrange, 17:Durandal, 101:PX4-v1
-    // @User: Standard
-    // @RebootRequired: True
-    AP_GROUPINFO("CURR_PIN", 3, AP_BattMonitor_Params, _curr_pin, AP_BATT_CURR_PIN),
+    // 4 was VOLT_MULT
 
-    // @Param: VOLT_MULT
-    // @DisplayName: Voltage Multiplier
-    // @Description: Used to convert the voltage of the voltage sensing pin (@PREFIX@VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick with a Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX using the PX4IO power supply this should be set to 1.
-    // @User: Advanced
-    AP_GROUPINFO("VOLT_MULT", 4, AP_BattMonitor_Params, _volt_multiplier, AP_BATT_VOLTDIVIDER_DEFAULT),
+    // 5 was AMP_PERVLT
 
-    // @Param: AMP_PERVLT
-    // @DisplayName: Amps per volt
-    // @Description: Number of amps that a 1V reading on the current sensor corresponds to. With a Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17.
-    // @Units: A/V
-    // @User: Standard
-    AP_GROUPINFO("AMP_PERVLT", 5, AP_BattMonitor_Params, _curr_amp_per_volt, AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
-
-    // @Param: AMP_OFFSET
-    // @DisplayName: AMP offset
-    // @Description: Voltage offset at zero current on current sensor
-    // @Units: V
-    // @User: Standard
-    AP_GROUPINFO("AMP_OFFSET", 6, AP_BattMonitor_Params, _curr_amp_offset, 0),
+    // 6 was AMP_OFFSET
 
     // @Param: CAPACITY
     // @DisplayName: Battery capacity

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -40,7 +40,6 @@ public:
     AP_Int8  _volt_pin;                 /// board pin used to measure battery voltage
     AP_Int8  _curr_pin;                 /// board pin used to measure battery current
     AP_Int8  _low_voltage_timeout;      /// timeout in seconds before a low voltage event will be triggered
-    AP_Int8  _i2c_bus;                  /// I2C bus number
     AP_Int8  _failsafe_voltage_source;  /// voltage type used for detection of low voltage event
     AP_Int8  _failsafe_low_action;      /// action to preform on a low battery failsafe
     AP_Int8  _failsafe_critical_action; /// action to preform on a critical battery failsafe

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -23,9 +23,6 @@ public:
 
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }
 
-    AP_Float _volt_multiplier;          /// voltage on volt pin multiplied by this to calculate battery voltage
-    AP_Float _curr_amp_per_volt;        /// voltage on current pin multiplied by this to calculate current in amps
-    AP_Float _curr_amp_offset;          /// offset voltage that is subtracted from current pin before conversion to amps
     AP_Int32 _pack_capacity;            /// battery pack capacity less reserve in mAh
     AP_Int32 _serial_number;            /// battery serial number, automatically filled in on SMBus batteries
     AP_Float _low_voltage;              /// voltage level used to trigger a low battery failsafe
@@ -37,8 +34,6 @@ public:
     AP_Int32 _options;                  /// Options
     AP_Int16 _watt_max;                 /// max battery power allowed. Reduce max throttle to reduce current to satisfy t    his limit
     AP_Int8  _type;                     /// 0=disabled, 3=voltage only, 4=voltage and current
-    AP_Int8  _volt_pin;                 /// board pin used to measure battery voltage
-    AP_Int8  _curr_pin;                 /// board pin used to measure battery current
     AP_Int8  _low_voltage_timeout;      /// timeout in seconds before a low voltage event will be triggered
     AP_Int8  _failsafe_voltage_source;  /// voltage type used for detection of low voltage event
     AP_Int8  _failsafe_low_action;      /// action to preform on a low battery failsafe

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -34,7 +34,7 @@ public:
     AP_BattMonitor_SMBus(AP_BattMonitor &mon,
                     AP_BattMonitor::BattMonitor_State &mon_state,
                     AP_BattMonitor_Params &params,
-                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+                    uint8_t i2c_bus);
 
     // virtual destructor to reduce compiler warnings
     virtual ~AP_BattMonitor_SMBus() {}
@@ -53,6 +53,8 @@ public:
     bool get_cycle_count(uint16_t &cycles) const override;
 
     virtual void init(void) override;
+
+    static const struct AP_Param::GroupInfo var_info[];
 
 protected:
 
@@ -99,4 +101,9 @@ protected:
     virtual void timer(void) = 0;   // timer function to read from the battery
 
     AP_HAL::Device::PeriodicHandle timer_handle;
+
+    // Parameters
+    AP_Int8  _bus;          // I2C bus number
+    AP_Int8  _address;      // I2C address
+
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
@@ -44,9 +44,8 @@ uint8_t smbus_cell_ids[] = { 0x3f,  // cell 1
 // Constructor
 AP_BattMonitor_SMBus_Generic::AP_BattMonitor_SMBus_Generic(AP_BattMonitor &mon,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
-                                                   AP_BattMonitor_Params &params,
-                                                   AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-    : AP_BattMonitor_SMBus(mon, mon_state, params, std::move(dev))
+                                                   AP_BattMonitor_Params &params)
+    : AP_BattMonitor_SMBus(mon, mon_state, params, AP_BATTMONITOR_SMBUS_BUS_EXTERNAL)
 {}
 
 void AP_BattMonitor_SMBus_Generic::timer()

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.h
@@ -15,8 +15,7 @@ public:
     // Constructor
     AP_BattMonitor_SMBus_Generic(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
-                             AP_BattMonitor_Params &params,
-                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+                             AP_BattMonitor_Params &params);
 
 private:
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.cpp
@@ -9,9 +9,8 @@
 // Constructor
 AP_BattMonitor_SMBus_NeoDesign::AP_BattMonitor_SMBus_NeoDesign(AP_BattMonitor &mon,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
-                                                   AP_BattMonitor_Params &params,
-                                                   AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-    : AP_BattMonitor_SMBus(mon, mon_state, params, std::move(dev))
+                                                   AP_BattMonitor_Params &params)
+    : AP_BattMonitor_SMBus(mon, mon_state, params, AP_BATTMONITOR_SMBUS_BUS_INTERNAL)
 {
     _pec_supported = true;
 }
@@ -76,4 +75,3 @@ void AP_BattMonitor_SMBus_NeoDesign::timer()
     read_remaining_capacity();
     read_temp();
 }
-

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_NeoDesign.h
@@ -7,8 +7,7 @@ class AP_BattMonitor_SMBus_NeoDesign : public AP_BattMonitor_SMBus
 public:
     AP_BattMonitor_SMBus_NeoDesign(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
-                             AP_BattMonitor_Params &params,
-                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+                             AP_BattMonitor_Params &params);
 
 private:
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.cpp
@@ -17,9 +17,8 @@ extern const AP_HAL::HAL& hal;
 AP_BattMonitor_SMBus_SUI::AP_BattMonitor_SMBus_SUI(AP_BattMonitor &mon,
         AP_BattMonitor::BattMonitor_State &mon_state,
         AP_BattMonitor_Params &params,
-        AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
         uint8_t _cell_count)
-    : AP_BattMonitor_SMBus(mon, mon_state, params, std::move(dev)),
+    : AP_BattMonitor_SMBus(mon, mon_state, params, AP_BATTMONITOR_SMBUS_BUS_INTERNAL),
       cell_count(_cell_count)
 {
     _pec_supported = false;
@@ -84,7 +83,7 @@ bool AP_BattMonitor_SMBus_SUI::read_block(uint8_t reg, uint8_t* data, uint8_t le
     }
 
     // check PEC
-    uint8_t pec = get_PEC(AP_BATTMONITOR_SMBUS_I2C_ADDR, reg, true, buff, bufflen+1);
+    uint8_t pec = get_PEC(_address, reg, true, buff, bufflen+1);
     if (pec != buff[bufflen+1]) {
         return false;
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.h
@@ -11,7 +11,6 @@ public:
     AP_BattMonitor_SMBus_SUI(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_BattMonitor_Params &params,
-                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
                              uint8_t cell_count
                             );
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -26,9 +26,8 @@
 // Constructor
 AP_BattMonitor_SMBus_Solo::AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
-                                                   AP_BattMonitor_Params &params,
-                                                   AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-    : AP_BattMonitor_SMBus(mon, mon_state, params, std::move(dev))
+                                                   AP_BattMonitor_Params &params)
+    : AP_BattMonitor_SMBus(mon, mon_state, params, AP_BATTMONITOR_SMBUS_BUS_INTERNAL)
 {
     _pec_supported = true;
 }
@@ -116,7 +115,7 @@ uint8_t AP_BattMonitor_SMBus_Solo::read_block(uint8_t reg, uint8_t* data, uint8_
     }
 
     // check PEC
-    uint8_t pec = get_PEC(AP_BATTMONITOR_SMBUS_I2C_ADDR, reg, true, buff, bufflen+1);
+    uint8_t pec = get_PEC(_address, reg, true, buff, bufflen+1);
     if (pec != buff[bufflen+1]) {
         return 0;
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
@@ -9,8 +9,7 @@ public:
     // Constructor
     AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
-                             AP_BattMonitor_Params &params,
-                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+                             AP_BattMonitor_Params &params);
 
 private:
 


### PR DESCRIPTION
This adds a parameter for the I2C_address for smbus batteries. It also moves it and the I2C_bus into a param subgroup. The subgroup part was suggested by @WickedShell

~~I'm marking this draft to get feedback on how to do the parameter conversion to keep the old behavior (if deemed necessary)?~~

It was tested with my smartbatt PR in sitl. And included testing parameter conversion. 

New
- Adds a parameter for the I2C_address for smbus batteries
- Moves the analog specific params to a VarPtr subgroup to hide the params from other backend types
- Moves the smbus I2C params to a varptr subgroup