### PR TITLE
Copter: cleanup position control APIs

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -380,7 +380,7 @@ public:
     void takeoff_start(const Location& dest_loc);
     void wp_start(const Location& dest_loc);
     void land_start();
-    void land_start(const Vector3f& destination);
+    void land_start(const Vector2f& destination);
     void circle_movetoedge_start(const Location &circle_center, float radius_m);
     void circle_start();
     void nav_guided_start();
@@ -442,7 +442,7 @@ private:
 
     Location loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc) const;
 
-    void payload_place_start(const Vector3f& destination);
+    void payload_place_start(const Vector2f& destination);
     void payload_place_run();
     bool payload_place_run_should_run();
     void payload_place_run_loiter();

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -255,7 +255,7 @@ void ModeAuto::wp_start(const Location& dest_loc)
 void ModeAuto::land_start()
 {
     // set target to stopping point
-    Vector3f stopping_point;
+    Vector2f stopping_point;
     loiter_nav->get_stopping_point_xy(stopping_point);
 
     // call location specific land start function
@@ -263,7 +263,7 @@ void ModeAuto::land_start()
 }
 
 // auto_land_start - initialises controller to implement a landing
-void ModeAuto::land_start(const Vector3f& destination)
+void ModeAuto::land_start(const Vector2f& destination)
 {
     _mode = SubMode::LAND;
 
@@ -392,7 +392,7 @@ bool ModeAuto::is_taking_off() const
 void ModeAuto::payload_place_start()
 {
     // set target to stopping point
-    Vector3f stopping_point;
+    Vector2f stopping_point;
     loiter_nav->get_stopping_point_xy(stopping_point);
 
     // call location specific place start function
@@ -988,7 +988,7 @@ void ModeAuto::loiter_to_alt_run()
 }
 
 // auto_payload_place_start - initialises controller to implement placement of a load
-void ModeAuto::payload_place_start(const Vector3f& destination)
+void ModeAuto::payload_place_start(const Vector2f& destination)
 {
     _mode = SubMode::NAV_PAYLOAD_PLACE;
     nav_payload_place.state = PayloadPlaceStateType_Calibrating_Hover_Start;
@@ -1253,7 +1253,7 @@ void ModeAuto::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
     if (target_loc.lat == 0 && target_loc.lng == 0) {
         // To-Do: make this simpler
         Vector3f temp_pos;
-        copter.wp_nav->get_wp_stopping_point_xy(temp_pos);
+        copter.wp_nav->get_wp_stopping_point_xy(temp_pos.xy());
         const Location temp_loc(temp_pos, Location::AltFrame::ABOVE_ORIGIN);
         target_loc.lat = temp_loc.lat;
         target_loc.lng = temp_loc.lng;
@@ -1588,7 +1588,7 @@ bool ModeAuto::verify_land()
             // check if we've reached the location
             if (copter.wp_nav->reached_wp_destination()) {
                 // get destination so we can use it for loiter target
-                const Vector3f& dest = copter.wp_nav->get_wp_destination();
+                const Vector2f& dest = copter.wp_nav->get_wp_destination().xy();
 
                 // initialise landing controller
                 land_start(dest);

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -49,8 +49,8 @@ void ModeBrake::run()
     }
 
     // use position controller to stop
-    Vector3f vel;
-    Vector3f accel;
+    Vector2f vel;
+    Vector2f accel;
     pos_control->input_vel_accel_xy(vel, accel);
     pos_control->update_xy_controller();
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -557,8 +557,8 @@ void ModeGuided::posvel_control_run()
     guided_pos_target_cm += guided_vel_target_cms * pos_control->get_dt();
 
     // send position and velocity targets to position controller
-    pos_control->input_pos_vel_accel_xy(guided_pos_target_cm, guided_vel_target_cms, Vector3f());
-    pos_control->input_pos_vel_accel_z(guided_pos_target_cm, guided_vel_target_cms, Vector3f());
+    pos_control->input_pos_vel_accel_xy(guided_pos_target_cm.xy(), guided_vel_target_cms.xy(), Vector2f());
+    pos_control->input_pos_vel_accel_z(guided_pos_target_cm.z, guided_vel_target_cms.z, 0);
 
     // run position controllers
     pos_control->update_xy_controller();
@@ -670,8 +670,8 @@ void ModeGuided::set_desired_velocity_with_accel_and_fence_limits(const Vector3f
 #endif
 
     // update position controller with new target
-    pos_control->input_vel_accel_xy(curr_vel_des, Vector3f());
-    pos_control->input_vel_accel_z(curr_vel_des, Vector3f(), false);
+    pos_control->input_vel_accel_xy(curr_vel_des.xy(), Vector2f());
+    pos_control->input_vel_accel_z(curr_vel_des.z, 0, false);
 }
 
 // helper function to set yaw state and targets

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -7,7 +7,7 @@ bool ModeLand::init(bool ignore_checks)
     control_position = copter.position_ok();
     if (control_position) {
         // set target to stopping point
-        Vector3f stopping_point;
+        Vector2f stopping_point;
         loiter_nav->get_stopping_point_xy(stopping_point);
         loiter_nav->init_target(stopping_point);
     }

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -379,7 +379,7 @@ void ModePosHold::run()
         pitch_mode = RPMode::BRAKE_TO_LOITER;
         brake.to_loiter_timer = POSHOLD_BRAKE_TO_LOITER_TIMER;
         // init loiter controller
-        loiter_nav->init_target(inertial_nav.get_position());
+        loiter_nav->init_target(inertial_nav.get_position().xy());
         // set delay to start of wind compensation estimate updates
         wind_comp_start_timer = POSHOLD_WIND_COMP_START_TIMER;
     }

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -263,7 +263,7 @@ void ModeRTL::descent_start()
     _state_complete = false;
 
     // Set wp navigation target to above home
-    loiter_nav->init_target(wp_nav->get_wp_destination());
+    loiter_nav->init_target(wp_nav->get_wp_destination().xy());
 
     // initialise altitude target to stopping point
     pos_control->init_z_controller_stopping_point();
@@ -356,7 +356,7 @@ void ModeRTL::land_start()
     _state_complete = false;
 
     // Set wp navigation target to above home
-    loiter_nav->init_target(wp_nav->get_wp_destination());
+    loiter_nav->init_target(wp_nav->get_wp_destination().xy());
 
     // initialise the vertical position controller
     if (!pos_control->is_active_z()) {
@@ -413,8 +413,8 @@ void ModeRTL::build_path()
 {
     // origin point is our stopping point
     Vector3f stopping_point;
-    pos_control->get_stopping_point_xy_cm(stopping_point);
-    pos_control->get_stopping_point_z_cm(stopping_point);
+    pos_control->get_stopping_point_xy_cm(stopping_point.xy());
+    pos_control->get_stopping_point_z_cm(stopping_point.z);
     rtl_path.origin_point = Location(stopping_point, Location::AltFrame::ABOVE_ORIGIN);
     rtl_path.origin_point.change_alt_frame(Location::AltFrame::ABOVE_HOME);
 

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -17,8 +17,8 @@ bool ModeSmartRTL::init(bool ignore_checks)
 
         // set current target to a reasonable stopping point
         Vector3f stopping_point;
-        pos_control->get_stopping_point_xy_cm(stopping_point);
-        pos_control->get_stopping_point_z_cm(stopping_point);
+        pos_control->get_stopping_point_xy_cm(stopping_point.xy());
+        pos_control->get_stopping_point_z_cm(stopping_point.z);
         wp_nav->set_wp_destination(stopping_point);
 
         // initialise yaw to obey user parameter

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -171,8 +171,8 @@ void ModeThrow::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // use position controller to stop
-        Vector3f vel;
-        Vector3f accel;
+        Vector2f vel;
+        Vector2f accel;
         pos_control->input_vel_accel_xy(vel, accel);
         pos_control->update_xy_controller();
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -241,7 +241,7 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
         loiter_nav->clear_pilot_desired_acceleration();
         if (maintain_target) {
             const Vector3f& wp_dest = wp_nav->get_wp_destination();
-            loiter_nav->init_target(wp_dest);
+            loiter_nav->init_target(wp_dest.xy());
             if (wp_nav->origin_and_destination_are_terrain_alt()) {
                 copter.surface_tracking.set_target_alt_cm(wp_dest.z);
             }

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -79,15 +79,11 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
         return;
     }
 
-    Vector3f pos;
-    Vector3f vel;
-    Vector3f accel;
-
-    pos.z = take_off_complete_alt ;
-    vel.z = pilot_climb_rate_cm;
+    float pos_z = take_off_complete_alt;
+    float vel_z = pilot_climb_rate_cm;
 
     // command the aircraft to the take off altitude and current pilot climb rate
-    copter.pos_control->input_pos_vel_accel_z(pos, vel, accel);
+    copter.pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
 
     // stop take off early and return if negative climb rate is commanded or we are within 0.1% of our take off altitude
     if (is_negative(pilot_climb_rate_cm) ||

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1158,8 +1158,7 @@ void QuadPlane::check_yaw_reset(void)
 
 void QuadPlane::set_climb_rate_cms(float target_climb_rate_cms, bool force_descend)
 {
-    Vector3f vel{0,0,target_climb_rate_cms};
-    pos_control->input_vel_accel_z(vel, Vector3f(), force_descend);
+    pos_control->input_vel_accel_z(target_climb_rate_cms, 0, force_descend);
 }
 
 /*
@@ -2887,11 +2886,11 @@ void QuadPlane::vtol_position_controller(void)
         if (poscontrol.pilot_correction_done) {
             // if the pilot has repositioned the vehicle then we switch to velocity control.  This prevents the vehicle
             // shifting position in the event of GPS glitches.
-            Vector3f zero;
-            pos_control->input_vel_accel_xy(poscontrol.target_vel_cms, zero);
+            Vector2f zero;
+            pos_control->input_vel_accel_xy(poscontrol.target_vel_cms.xy(), zero);
         } else {
-            Vector3f zero;
-            pos_control->input_pos_vel_accel_xy(poscontrol.target_cm, zero, zero);
+            Vector2f zero;
+            pos_control->input_pos_vel_accel_xy(poscontrol.target_cm.xy(), zero, zero);
         }
 
         // also run fixed wing navigation
@@ -2930,8 +2929,8 @@ void QuadPlane::vtol_position_controller(void)
             pos_control->relax_velocity_controller_xy();
         } else {
             // we use velocity control in QPOS_LAND_FINAL to allow for GPS glitch handling
-            Vector3f zero;
-            pos_control->input_vel_accel_xy(poscontrol.target_vel_cms, zero);
+            Vector2f zero;
+            pos_control->input_vel_accel_xy(poscontrol.target_vel_cms.xy(), zero);
         }
 
         run_xy_controller();
@@ -3010,9 +3009,9 @@ void QuadPlane::vtol_position_controller(void)
                 target_altitude_cm += MAX(terrain_altitude_offset_cm*100,0);
             }
 #endif
-            Vector3f pos{0,0,float(target_altitude_cm)};
-            Vector3f zero;
-            pos_control->input_pos_vel_accel_z(pos, zero, zero);
+            float zero = 0;
+            float target_z = target_altitude_cm;
+            pos_control->input_pos_vel_accel_z(target_z, zero, 0);
         } else {
             set_climb_rate_cms(0, false);
         }
@@ -3118,7 +3117,7 @@ void QuadPlane::takeoff_controller(void)
     pos_control->set_accel_desired_xy_cmss(Vector2f());
 
     // set position control target and update
-    Vector3f zero;
+    Vector2f zero;
     pos_control->input_vel_accel_xy(zero, zero);
 
     run_xy_controller();

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -299,7 +299,7 @@ void Sub::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
     if (target_loc.lat == 0 && target_loc.lng == 0) {
         // To-Do: make this simpler
         Vector3f temp_pos;
-        wp_nav.get_wp_stopping_point_xy(temp_pos);
+        wp_nav.get_wp_stopping_point_xy(temp_pos.xy());
         const Location temp_loc(temp_pos, Location::AltFrame::ABOVE_ORIGIN);
         target_loc.lat = temp_loc.lat;
         target_loc.lng = temp_loc.lng;

--- a/ArduSub/control_guided.cpp
+++ b/ArduSub/control_guided.cpp
@@ -217,8 +217,8 @@ bool Sub::guided_set_destination_posvel(const Vector3f& destination, const Vecto
     posvel_pos_target_cm = destination;
     posvel_vel_target_cms = velocity;
 
-    pos_control.input_pos_vel_accel_xy(posvel_pos_target_cm, posvel_vel_target_cms, Vector3f());
-    pos_control.input_pos_vel_accel_z(posvel_pos_target_cm, posvel_vel_target_cms, Vector3f());
+    pos_control.input_pos_vel_accel_xy(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
+    pos_control.input_pos_vel_accel_z(posvel_pos_target_cm.z, posvel_vel_target_cms.z, 0);
 
     // log target
     Log_Write_GuidedTarget(guided_mode, destination, velocity);
@@ -421,8 +421,8 @@ void Sub::guided_posvel_control_run()
     posvel_pos_target_cm += posvel_vel_target_cms * pos_control.get_dt();
 
     // send position and velocity targets to position controller
-    pos_control.input_pos_vel_accel_xy(posvel_pos_target_cm, posvel_vel_target_cms, Vector3f());
-    pos_control.input_pos_vel_accel_z(posvel_pos_target_cm, posvel_vel_target_cms, Vector3f());
+    pos_control.input_pos_vel_accel_xy(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
+    pos_control.input_pos_vel_accel_z(posvel_pos_target_cm.z, posvel_vel_target_cms.z, 0);
 
     // run position controller
     pos_control.update_xy_controller();

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -489,8 +489,6 @@ void AC_PosControl::init_xy()
 ///     The vel is projected forwards in time based on a time step of dt and acceleration accel.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
 ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
-///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-///     The time constant also defines the time taken to achieve the maximum acceleration.
 void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel)
 {
     // check for ekf xy position reset
@@ -507,9 +505,7 @@ void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel)
 /// input_pos_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
 ///     The pos and vel are projected forwards in time based on a time step of dt and acceleration accel.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
-///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-///     The time constant also defines the time taken to achieve the maximum acceleration.
+///     The function alters the pos and vel to be the kinematic path based on accel
 void AC_PosControl::input_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel)
 {
     // check for ekf xy position reset
@@ -750,10 +746,7 @@ void AC_PosControl::init_z()
 /// input_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
 ///     The vel is projected forwards in time based on a time step of dt and acceleration accel.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_z and time constant.
-///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-///     The time constant also defines the time taken to achieve the maximum acceleration.
-///     ignore_descent_limit turns off output saturation handling to aid in landing detection. ignore_descent_limit should be true unless landing.
+///     The function alters the vel to be the kinematic path based on accel
 void AC_PosControl::input_vel_accel_z(float &vel, const float accel, bool ignore_descent_limit)
 {
     // check for ekf z position reset
@@ -797,9 +790,7 @@ void AC_PosControl::set_pos_target_z_from_climb_rate_cm(const float vel, bool ig
 /// input_pos_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
 ///     The pos and vel are projected forwards in time based on a time step of dt and acceleration accel.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_z and time constant.
-///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-///     The time constant also defines the time taken to achieve the maximum acceleration.
+///     The function alters the pos and vel to be the kinematic path based on accel
 void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, const float accel)
 {
     // check for ekf z position reset

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -54,8 +54,6 @@ public:
     /// input_pos_vel_accel_xyz - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
-    ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-    ///     The time constant also defines the time taken to achieve the maximum acceleration.
     void input_pos_vel_accel_xyz(const Vector3f& pos);
 
     ///
@@ -91,17 +89,13 @@ public:
     /// input_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
-    ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-    ///     The time constant also defines the time taken to achieve the maximum acceleration.
-    ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+    ///     The function alters the vel to be the kinematic path based on accel
     void input_vel_accel_xy(Vector2f& vel, const Vector2f& accel);
 
     /// input_pos_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
-    ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-    ///     The time constant also defines the time taken to achieve the maximum acceleration.
-    ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+    ///     The function alters the pos and vel to be the kinematic path based on accel
     void input_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel);
 
     // is_active_xy - returns true if the xy position controller has been run in the previous 5 loop times
@@ -163,10 +157,7 @@ public:
     /// input_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_z and time constant.
-    ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-    ///     The time constant also defines the time taken to achieve the maximum acceleration.
-    ///     The function alters the input velocitiy to be the velocity that the system could reach zero acceleration in the minimum time.
-    ///     ignore_descent_limit turns off output saturation handling to aid in landing detection. ignore_descent_limit should be true unless landing.
+    ///     The function alters the vel to be the kinematic path based on accel
     virtual void input_vel_accel_z(float &vel, const float accel, bool ignore_descent_limit);
 
     /// set_pos_target_z_from_climb_rate_cm - adjusts target up or down using a climb rate in cm/s
@@ -176,10 +167,7 @@ public:
 
     /// input_pos_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-    ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_z and time constant.
-    ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
-    ///     The time constant also defines the time taken to achieve the maximum acceleration.
-    ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+    ///     The function alters the pos and vel to be the kinematic path based on accel
     void input_pos_vel_accel_z(float &pos, float &vel, float accel);
 
     /// set_alt_target_with_slew - adjusts target up or down using a commanded altitude in cm

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -56,7 +56,6 @@ public:
     ///     The kinematic path is constrained by the maximum acceleration and time constant set using the function set_max_speed_accel_xy and time constant.
     ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
     ///     The time constant also defines the time taken to achieve the maximum acceleration.
-    ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
     void input_pos_vel_accel_xyz(const Vector3f& pos);
 
     ///

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -95,7 +95,7 @@ public:
     ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
     ///     The time constant also defines the time taken to achieve the maximum acceleration.
     ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
-    void input_vel_accel_xy(Vector3f& vel, const Vector3f& accel);
+    void input_vel_accel_xy(Vector2f& vel, const Vector2f& accel);
 
     /// input_pos_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -103,7 +103,7 @@ public:
     ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
     ///     The time constant also defines the time taken to achieve the maximum acceleration.
     ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
-    void input_pos_vel_accel_xy(Vector3f& pos, Vector3f& vel, const Vector3f& accel);
+    void input_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel);
 
     // is_active_xy - returns true if the xy position controller has been run in the previous 5 loop times
     bool is_active_xy() const;
@@ -168,12 +168,12 @@ public:
     ///     The time constant also defines the time taken to achieve the maximum acceleration.
     ///     The function alters the input velocitiy to be the velocity that the system could reach zero acceleration in the minimum time.
     ///     ignore_descent_limit turns off output saturation handling to aid in landing detection. ignore_descent_limit should be true unless landing.
-    virtual void input_vel_accel_z(Vector3f& vel, const Vector3f& accel, bool force_descend);
+    virtual void input_vel_accel_z(float &vel, const float accel, bool ignore_descent_limit);
 
     /// set_pos_target_z_from_climb_rate_cm - adjusts target up or down using a climb rate in cm/s
     ///     using the default position control kinimatic path.
     ///     ignore_descent_limit turns off output saturation handling to aid in landing detection. ignore_descent_limit should be true unless landing.
-    void set_pos_target_z_from_climb_rate_cm(const float vel, bool force_descend);
+    void set_pos_target_z_from_climb_rate_cm(const float vel, bool ignore_descent_limit);
 
     /// input_pos_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -181,7 +181,7 @@ public:
     ///     The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
     ///     The time constant also defines the time taken to achieve the maximum acceleration.
     ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
-    void input_pos_vel_accel_z(Vector3f& pos, Vector3f& vel, const Vector3f& accel);
+    void input_pos_vel_accel_z(float &pos, float &vel, float accel);
 
     /// set_alt_target_with_slew - adjusts target up or down using a commanded altitude in cm
     ///     using the default position control kinimatic path.
@@ -222,10 +222,10 @@ public:
     float get_pos_target_z_cm() const { return _pos_target.z; }
 
     /// get_stopping_point_xy_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-    void get_stopping_point_xy_cm(Vector3f &stopping_point) const;
+    void get_stopping_point_xy_cm(Vector2f &stopping_point) const;
 
     /// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-    void get_stopping_point_z_cm(Vector3f& stopping_point) const;
+    void get_stopping_point_z_cm(float &stopping_point) const;
 
     /// get_pos_error_cm - get position error vector between the current and target position
     const Vector3f get_pos_error_cm() const { return _pos_target - _inav.get_position(); }
@@ -243,7 +243,7 @@ public:
     void set_vel_desired_cms(const Vector3f &des_vel) { _vel_desired = des_vel; }
 
     /// set_vel_desired_xy_cms - sets horizontal desired velocity in NEU cm/s
-    void set_vel_desired_xy_cms(const Vector2f &vel) {_vel_desired.x = vel.x; _vel_desired.y = vel.y; }
+    void set_vel_desired_xy_cms(const Vector2f &vel) {_vel_desired.xy() = vel; }
 
     /// get_vel_desired_cms - returns desired velocity (i.e. feed forward) in cm/s in NEU
     const Vector3f& get_vel_desired_cms() { return _vel_desired; }
@@ -261,7 +261,7 @@ public:
     /// Acceleration
 
     // set_accel_desired_xy_cmss set desired acceleration in cm/s in xy axis
-    void set_accel_desired_xy_cmss(const Vector2f &accel_cms) { _accel_desired.x = accel_cms.x; _accel_desired.y = accel_cms.y; }
+    void set_accel_desired_xy_cmss(const Vector2f &accel_cms) { _accel_desired.xy() = accel_cms; }
 
     // get_accel_target_cmss - returns the target acceleration in NEU cm/s/s
     const Vector3f& get_accel_target_cmss() const { return _accel_target; }

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -17,14 +17,14 @@ AC_PosControl_Sub::AC_PosControl_Sub(AP_AHRS_View& ahrs, const AP_InertialNav& i
 ///     The time constant also defines the time taken to achieve the maximum acceleration.
 ///     The time constant must be positive.
 ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
-void AC_PosControl_Sub::input_vel_accel_z(Vector3f& vel, const Vector3f& accel, bool force_descend)
+void AC_PosControl_Sub::input_vel_accel_z(float &vel, const float accel, bool force_descend)
 {
     // check for ekf z position reset
     handle_ekf_z_reset();
 
     // limit desired velocity to prevent breeching altitude limits
     if (_alt_min < 0 && _alt_min < _alt_max && _alt_max < 100 && _pos_target.z < _alt_min) {
-        vel.z = constrain_float(vel.z,
+        vel = constrain_float(vel,
             sqrt_controller(_alt_min-_pos_target.z, 0.0f, _accel_max_z_cmss, 0.0f),
             sqrt_controller(_alt_max-_pos_target.z, 0.0f, _accel_max_z_cmss, 0.0f));
     }
@@ -39,18 +39,18 @@ void AC_PosControl_Sub::input_vel_accel_z(Vector3f& vel, const Vector3f& accel, 
     }
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel_z(_pos_target, _vel_desired, _accel_desired, _dt, _limit_vector);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
 
     // prevent altitude target from breeching altitude limits
     if (is_negative(_alt_min) && _alt_min < _alt_max && _alt_max < 100 && _pos_target.z < _alt_min) {
         _pos_target.z = constrain_float(_pos_target.z, _alt_min, _alt_max);
     }
 
-    shape_vel_accel(vel.z, accel.z,
+    shape_vel_accel(vel, accel,
         _vel_desired.z, _accel_desired.z,
         _vel_max_down_cms, _vel_max_up_cms,
         -accel_z_cms, accel_z_cms,
         _tc_z_s, _dt);
 
-    update_vel_accel_z(vel, accel, _dt, _limit_vector);
+    update_vel_accel(vel, accel, _dt, _limit_vector.z);
 }

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.h
@@ -29,7 +29,7 @@ public:
     ///     The time constant also defines the time taken to achieve the maximum acceleration.
     ///     The time constant must be positive.
     ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
-    void input_vel_accel_z(Vector3f& vel, const Vector3f& accel, bool force_descend) override;
+    void input_vel_accel_z(float &vel, float accel, bool force_descend) override;
 
 private:
     float       _alt_max; // max altitude - should be updated from the main code with altitude limit from fence

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -213,10 +213,11 @@ bool AC_Circle::update(float climb_rate_cms)
     }
 
     // update position controller target
-    Vector3f zero;
-    _pos_control.input_pos_vel_accel_xy(target, zero, zero);
-    if(_terrain_alt) {
-        _pos_control.input_pos_vel_accel_z(target, zero, zero);
+    Vector2f zero;
+    _pos_control.input_pos_vel_accel_xy(target.xy(), zero, zero);
+    if (_terrain_alt) {
+        float zero2 = 0;
+        _pos_control.input_pos_vel_accel_z(target.z, zero2, 0);
     } else {
         _pos_control.set_pos_target_z_from_climb_rate_cm(climb_rate_cms,  false);
     }
@@ -244,14 +245,12 @@ void AC_Circle::get_closest_point_on_circle(Vector3f &result) const
     }
 
     // get current position
-    Vector3f stopping_point;
+    Vector2f stopping_point;
     _pos_control.get_stopping_point_xy_cm(stopping_point);
 
     // calc vector from stopping point to circle center
-    Vector2f vec;   // vector from circle center to current location
-    vec.x = (stopping_point.x - _center.x);
-    vec.y = (stopping_point.y - _center.y);
-    float dist = norm(vec.x, vec.y);
+    Vector2f vec = stopping_point - _center.xy();
+    float dist = vec.length();
 
     // if current location is exactly at the center of the circle return edge directly behind vehicle
     if (is_zero(dist)) {

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -86,7 +86,7 @@ AC_Loiter::AC_Loiter(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_Po
 }
 
 /// init_target to a position in cm from ekf origin
-void AC_Loiter::init_target(const Vector3f& position)
+void AC_Loiter::init_target(const Vector2f& position)
 {
     sanity_check_params();
 
@@ -172,7 +172,7 @@ void AC_Loiter::set_pilot_desired_acceleration(float euler_roll_angle_cd, float 
 }
 
 /// get vector to stopping point based on a horizontal position and velocity
-void AC_Loiter::get_stopping_point_xy(Vector3f& stopping_point) const
+void AC_Loiter::get_stopping_point_xy(Vector2f& stopping_point) const
 {
     _pos_control.get_stopping_point_xy_cm(stopping_point);
 }

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -17,7 +17,7 @@ public:
     AC_Loiter(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
 
     /// init_target to a position in cm from ekf origin
-    void init_target(const Vector3f& position);
+    void init_target(const Vector2f& position);
 
     /// initialize's position and feed-forward velocity from current pos and velocity
     void init_target();
@@ -36,7 +36,7 @@ public:
     void clear_pilot_desired_acceleration() { _desired_accel.zero(); }
 
     /// get vector to stopping point based on a horizontal position and velocity
-    void get_stopping_point_xy(Vector3f& stopping_point) const;
+    void get_stopping_point_xy(Vector2f& stopping_point) const;
 
     /// get horizontal distance to loiter target in cm
     float get_distance_to_target() const { return _pos_control.get_pos_error_xy_cm(); }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -384,21 +384,19 @@ void AC_WPNav::shift_wp_origin_and_destination_to_stopping_point_xy()
     _pos_control.relax_velocity_controller_xy();
 
     // get current and target locations
-    Vector3f stopping_point;
+    Vector2f stopping_point;
     get_wp_stopping_point_xy(stopping_point);
 
     // shift origin and destination horizontally
-    _origin.x = stopping_point.x;
-    _origin.y = stopping_point.y;
-    _destination.x = stopping_point.x;
-    _destination.y = stopping_point.y;
+    _origin.xy() = stopping_point;
+    _destination.xy() = stopping_point;
 
     // move pos controller target horizontally
     _pos_control.set_pos_target_xy_cm(stopping_point.x, stopping_point.y);
 }
 
 /// get_wp_stopping_point_xy - returns vector to stopping point based on a horizontal position and velocity
-void AC_WPNav::get_wp_stopping_point_xy(Vector3f& stopping_point) const
+void AC_WPNav::get_wp_stopping_point_xy(Vector2f& stopping_point) const
 {
 	_pos_control.get_stopping_point_xy_cm(stopping_point);
 }
@@ -406,8 +404,8 @@ void AC_WPNav::get_wp_stopping_point_xy(Vector3f& stopping_point) const
 /// get_wp_stopping_point - returns vector to stopping point based on 3D position and velocity
 void AC_WPNav::get_wp_stopping_point(Vector3f& stopping_point) const
 {
-    _pos_control.get_stopping_point_xy_cm(stopping_point);
-    _pos_control.get_stopping_point_z_cm(stopping_point);
+    _pos_control.get_stopping_point_xy_cm(stopping_point.xy());
+    _pos_control.get_stopping_point_z_cm(stopping_point.z);
 }
 
 /// advance_wp_target_along_track - move target location along track from origin to destination

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -128,7 +128,7 @@ public:
 
     /// get_wp_stopping_point_xy - calculates stopping point based on current position, velocity, waypoint acceleration
     ///		results placed in stopping_position vector
-    void get_wp_stopping_point_xy(Vector3f& stopping_point) const;
+    void get_wp_stopping_point_xy(Vector2f& stopping_point) const;
     void get_wp_stopping_point(Vector3f& stopping_point) const;
 
     /// get_wp_distance_to_destination - get horizontal distance to destination in cm

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -94,11 +94,11 @@ void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+ The function alters the input accel to be jerk limited
 */
-void shape_accel(float accel_input, float& accel,
-    float accel_min, float accel_max,
-    float tc, float dt)
+void shape_accel(const float accel_input, float& accel,
+                 const float accel_min, const float accel_max,
+                 const float tc, const float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -177,14 +177,15 @@ void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+ The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel
+ to be jerk limited
  The accel_max limit can be removed by setting it to zero.
 */
-void shape_vel_accel(float &vel_input, float accel_input,
-                     float vel, float& accel,
-                     float vel_min, float vel_max,
-                     float accel_min, float accel_max,
-                     float tc, float dt)
+void shape_vel_accel(float &vel_input, const float accel_input,
+                     const float vel, float& accel,
+                     const float vel_min, const float vel_max,
+                     const float accel_min, const float accel_max,
+                     const float tc, const float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -220,12 +221,13 @@ void shape_vel_accel(float &vel_input, float accel_input,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+ The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
  This function operates on the x and y axis of both Vector2f or Vector3f inputs.
  The accel_max limit can be removed by setting it to zero.
 */
 void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
-                        const Vector2f& vel, Vector2f& accel, float vel_max, float accel_max, float tc, float dt)
+                        const Vector2f& vel, Vector2f& accel,
+                        const float vel_max, const float accel_max, const float tc, const float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -261,13 +263,13 @@ void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
+ The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
  The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
-void shape_pos_vel_accel(float &pos_input, float vel_input, float accel_input,
-                         float pos, float vel, float& accel,
-                         float vel_correction_max, float vel_min, float vel_max,
-                         float accel_min, float accel_max, float tc, float dt)
+void shape_pos_vel_accel(float &pos_input, const float vel_input, const float accel_input,
+                         const float pos, const float vel, float& accel,
+                         const float vel_correction_max, const float vel_min, const float vel_max,
+                         const float accel_min, const float accel_max, const float tc, const float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -304,13 +306,12 @@ void shape_pos_vel_accel(float &pos_input, float vel_input, float accel_input,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
- This function operates on the x and y axis of both Vector2f or Vector3f inputs.
+ The function alters the accel to be jerk limited
  The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
 void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
-    const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
-    float vel_correction_max, float vel_max, float accel_max, float tc, float dt)
+                            const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
+                            const float vel_correction_max, const float vel_max, const float accel_max, const float tc, const float dt)
 {
     if (!is_positive(tc)) {
         return;

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -94,7 +94,7 @@ void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input accel to be jerk limited
+ The function alters the variable accel to follow a jerk limited kinematic path to accel_input
 */
 void shape_accel(const float accel_input, float& accel,
                  const float accel_min, const float accel_max,
@@ -126,21 +126,9 @@ void shape_accel(const float accel_input, float& accel,
     }
 }
 
-/* shape_accel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
- The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
- The kinematic path is constrained by:
-     vel_max : maximum velocity
-     accel_max : maximum acceleration
-     tc : time constant
- The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
- The time constant also defines the time taken to achieve the maximum acceleration.
- The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
- This function operates on the x and y axis of both Vector2f or Vector3f inputs.
- The accel_max limit can be removed by setting it to zero.
-*/
+// 2D version
 void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
-    float accel_max, float tc, float dt)
+                    float accel_max, float tc, float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -177,11 +165,10 @@ void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel
- to be jerk limited
+ The function alters the variable accel to follow a jerk limited kinematic path to vel_input and accel_input
  The accel_max limit can be removed by setting it to zero.
 */
-void shape_vel_accel(float &vel_input, const float accel_input,
+void shape_vel_accel(const float vel_input1, const float accel_input,
                      const float vel, float& accel,
                      const float vel_min, const float vel_max,
                      const float accel_min, const float accel_max,
@@ -194,6 +181,9 @@ void shape_vel_accel(float &vel_input, const float accel_input,
 
     // Calculate time constants and limits to ensure stable operation
     const float KPa = 1.0 / tc;
+
+    // we are changing vel_input, but don't want the change in the caller
+    float vel_input = vel_input1;
 
     // limit velocity to vel_max
     if (is_negative(vel_min) && is_positive(vel_max)){
@@ -212,20 +202,8 @@ void shape_vel_accel(float &vel_input, const float accel_input,
     shape_accel(accel_target, accel, accel_min, accel_max, tc, dt);
 }
 
-/* shape_vel_accel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
- The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
- The kinematic path is constrained by:
-     vel_max : maximum velocity
-     accel_max : maximum acceleration
-     tc : time constant
- The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
- The time constant also defines the time taken to achieve the maximum acceleration.
- The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
- This function operates on the x and y axis of both Vector2f or Vector3f inputs.
- The accel_max limit can be removed by setting it to zero.
-*/
-void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
+// 2D version
+void shape_vel_accel_xy(const Vector2f &vel_input1, const Vector2f& accel_input,
                         const Vector2f& vel, Vector2f& accel,
                         const float vel_max, const float accel_max, const float tc, const float dt)
 {
@@ -233,6 +211,7 @@ void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
     if (!is_positive(tc)) {
         return;
     }
+    Vector2f vel_input = vel_input1;
 
     // limit velocity to vel_max
     if (is_negative(vel_max)) {
@@ -263,10 +242,10 @@ void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
+ The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input
  The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
-void shape_pos_vel_accel(float &pos_input, const float vel_input, const float accel_input,
+void shape_pos_vel_accel(const float pos_input, const float vel_input, const float accel_input,
                          const float pos, const float vel, float& accel,
                          const float vel_correction_max, const float vel_min, const float vel_max,
                          const float accel_min, const float accel_max, const float tc, const float dt)
@@ -297,18 +276,7 @@ void shape_pos_vel_accel(float &pos_input, const float vel_input, const float ac
     shape_vel_accel(vel_target, accel_input, vel, accel, vel_min, vel_max, accel_min, accel_max, tc, dt);
 }
 
-/* shape_pos_vel_accel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
- The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
- The kinematic path is constrained by:
-     vel_max : maximum velocity
-     accel_max : maximum acceleration
-     tc : time constant
- The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
- The time constant also defines the time taken to achieve the maximum acceleration.
- The time constant must be positive.
- The function alters the accel to be jerk limited
- The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
-*/
+// 2D version
 void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
                             const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
                             const float vel_correction_max, const float vel_max, const float accel_max, const float tc, const float dt)

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -37,13 +37,6 @@ void update_vel_accel(float& vel, float accel, float dt, float limit)
     }
 }
 
-// update_vel_accel_z - single axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the velocity is not moved in the direction of limit if limit is not set to zero
-void update_vel_accel_z(Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit)
-{
-    update_vel_accel(vel.z, accel.z, dt, limit.z);
-}
-
 // update_pos_vel_accel - single axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
 void update_pos_vel_accel(float& pos, float& vel, float accel, float dt, float limit)
@@ -57,16 +50,9 @@ void update_pos_vel_accel(float& pos, float& vel, float accel, float dt, float l
     update_vel_accel(vel, accel, dt, limit);
 }
 
-// update_pos_vel_accel_z - single axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the position and velocity is not moved in the direction of limit if limit is not set to zero
-void update_pos_vel_accel_z(Vector3f& pos, Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit)
-{
-    update_pos_vel_accel(pos.z, vel.z, accel.z, dt, limit.z);
-}
-
 // update_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
 // the velocity is not moved in the direction of limit if limit is not set to zero
-void update_vel_accel(Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
+void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
 {
     // increase velocity by acceleration * dt if it does not increase error when limited.
     Vector2f delta_vel = accel * dt;
@@ -80,22 +66,9 @@ void update_vel_accel(Vector2f& vel, const Vector2f& accel, float dt, Vector2f l
     vel += delta_vel;
 }
 
-// update_vel_accel_xy - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the velocity is not moved in the direction of limit if limit is not set to zero
-// This function only updates the x and y axis leaving the z axis unchanged.
-void update_vel_accel_xy(Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit)
-{
-    Vector2f vel_2f {vel.x, vel.y};
-    const Vector2f accel_2f {accel.x, accel.y};
-    const Vector2f limit_2f {limit.x, limit.y};
-    update_vel_accel(vel_2f, accel_2f, dt, limit_2f);
-    vel.x = vel_2f.x;
-    vel.y = vel_2f.y;
-}
-
 // update_pos_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
-void update_pos_vel_accel(Vector2f& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
+void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
 {
     // move position and velocity forward by dt.
     Vector2f delta_pos = vel * dt + accel * 0.5f * sq(dt);
@@ -110,23 +83,7 @@ void update_pos_vel_accel(Vector2f& pos, Vector2f& vel, const Vector2f& accel, f
 
     pos += delta_pos;
 
-    update_vel_accel(vel, accel, dt, limit);
-}
-
-// update_pos_vel_accel_xy - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the position and velocity is not moved in the direction of limit if limit is not set to zero
-// This function only updates the x and y axis leaving the z axis unchanged.
-void update_pos_vel_accel_xy(Vector3f& pos, Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit)
-{
-    Vector2f pos_2f {pos.x, pos.y};
-    Vector2f vel_2f {vel.x, vel.y};
-    const Vector2f accel_2f {accel.x, accel.y};
-    const Vector2f limit_2f {limit.x, limit.y};
-    update_pos_vel_accel(pos_2f, vel_2f, accel_2f, dt, limit_2f);
-    pos.x = pos_2f.x;
-    pos.y = pos_2f.y;
-    vel.x = vel_2f.x;
-    vel.y = vel_2f.y;
+    update_vel_accel_xy(vel, accel, dt, limit);
 }
 
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
@@ -223,11 +180,11 @@ void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
  The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
  The accel_max limit can be removed by setting it to zero.
 */
-void shape_vel_accel(float vel_input, float accel_input,
-    float vel, float& accel,
-    float vel_min, float vel_max,
-    float accel_min, float accel_max,
-    float tc, float dt)
+void shape_vel_accel(float &vel_input, float accel_input,
+                     float vel, float& accel,
+                     float vel_min, float vel_max,
+                     float accel_min, float accel_max,
+                     float tc, float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -254,19 +211,6 @@ void shape_vel_accel(float vel_input, float accel_input,
     shape_accel(accel_target, accel, accel_min, accel_max, tc, dt);
 }
 
-void shape_vel_accel_z(const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& vel, Vector3f& accel,
-    float vel_min, float vel_max,
-    float accel_min, float accel_max,
-    float tc, float dt)
-{
-    shape_vel_accel(vel_input.z, accel_input.z,
-        vel.z, accel.z,
-        vel_min, vel_max,
-        accel_min, accel_max,
-        tc, dt);
-}
-
 /* shape_vel_accel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by:
@@ -280,8 +224,8 @@ void shape_vel_accel_z(const Vector3f& vel_input, const Vector3f& accel_input,
  This function operates on the x and y axis of both Vector2f or Vector3f inputs.
  The accel_max limit can be removed by setting it to zero.
 */
-void shape_vel_accel_xy(Vector2f vel_input, const Vector2f& accel_input,
-    const Vector2f& vel, Vector2f& accel, float vel_max, float accel_max, float tc, float dt)
+void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
+                        const Vector2f& vel, Vector2f& accel, float vel_max, float accel_max, float tc, float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -308,19 +252,6 @@ void shape_vel_accel_xy(Vector2f vel_input, const Vector2f& accel_input,
     shape_accel_xy(accel_target, accel, accel_max, tc, dt);
 }
 
-void shape_vel_accel_xy(const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& vel, Vector3f& accel, float vel_max, float accel_max, float tc, float dt)
-{
-    Vector2f vel_input_2f {vel_input.x, vel_input.y};
-    const Vector2f accel_input_2f {accel_input.x, accel_input.y};
-    const Vector2f vel_2f {vel.x, vel.y};
-    Vector2f accel_2f {accel.x, accel.y};
-
-    shape_vel_accel_xy(vel_input_2f, accel_input_2f, vel_2f, accel_2f, vel_max, accel_max, tc, dt);
-    accel.x = accel_2f.x;
-    accel.y = accel_2f.y;
-}
-
 /* shape_pos_vel_accel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by :
@@ -333,10 +264,10 @@ void shape_vel_accel_xy(const Vector3f& vel_input, const Vector3f& accel_input,
  The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
  The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
-void shape_pos_vel_accel(float pos_input, float vel_input, float accel_input,
-    float pos, float vel, float& accel,
-    float vel_correction_max, float vel_min, float vel_max,
-    float accel_min, float accel_max, float tc, float dt)
+void shape_pos_vel_accel(float &pos_input, float vel_input, float accel_input,
+                         float pos, float vel, float& accel,
+                         float vel_correction_max, float vel_min, float vel_max,
+                         float accel_min, float accel_max, float tc, float dt)
 {
     // sanity check tc
     if (!is_positive(tc)) {
@@ -362,18 +293,6 @@ void shape_pos_vel_accel(float pos_input, float vel_input, float accel_input,
     vel_target += vel_input;
 
     shape_vel_accel(vel_target, accel_input, vel, accel, vel_min, vel_max, accel_min, accel_max, tc, dt);
-}
-
-void shape_pos_vel_accel_z(const Vector3f& pos_input, const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& pos, const Vector3f& vel, Vector3f& accel,
-    float vel_correction_max, float vel_min, float vel_max,
-    float accel_min, float accel_max, float tc, float dt)
-{
-    shape_pos_vel_accel(pos_input.z, vel_input.z, accel_input.z,
-        pos.z, vel.z, accel.z,
-        vel_correction_max, vel_min, vel_max,
-        accel_min, accel_max,
-        tc, dt);
 }
 
 /* shape_pos_vel_accel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
@@ -416,36 +335,6 @@ void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input
     vel_target = vel_target + vel_input;
 
     shape_vel_accel_xy(vel_target, accel_input, vel, accel, vel_max, accel_max, tc, dt);
-}
-
-/* shape_pos_vel_accel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
- The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
- The kinematic path is constrained by:
-     vel_max : maximum velocity
-     accel_max : maximum acceleration
-     tc : time constant
- The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
- The time constant also defines the time taken to achieve the maximum acceleration.
- The time constant must be positive.
- The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
- This function operates only on the x and y axis of the Vector2f or Vector3f inputs.
- The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
-*/
-void shape_pos_vel_accel_xy(const Vector3f& pos_input, const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& pos, const Vector3f& vel, Vector3f& accel,
-    float vel_max, float vel_correction_max, float accel_max, float tc, float dt)
-{
-    const Vector2f pos_input_2f {pos_input.x, pos_input.y};
-    const Vector2f vel_input_2f {vel_input.x, vel_input.y};
-    const Vector2f accel_input_2f {accel_input.x, accel_input.y};
-    const Vector2f pos_2f {pos.x, pos.y};
-    const Vector2f vel_2f {vel.x, vel.y};
-    Vector2f accel_2f {accel.x, accel.y};
-
-    shape_pos_vel_accel_xy(pos_input_2f, vel_input_2f, accel_input_2f,
-        pos_2f, vel_2f, accel_2f, vel_max, vel_correction_max, accel_max, tc, dt);
-    accel.x = accel_2f.x;
-    accel.y = accel_2f.y;
 }
 
 // proportional controller with piecewise sqrt sections to constrain second derivative

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -26,14 +26,14 @@ void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+ The function alters the input accel to be jerk limited
 */
-void shape_accel(float accel_input, float& accel,
-                 float accel_min, float accel_max,
-                 float tc, float dt);
+void shape_accel(const float accel_input, float& accel,
+                 const float accel_min, const float accel_max,
+                 const float tc, const float dt);
 
 void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
-                    float accel_max, float tc, float dt);
+                    const float accel_max, const float tc, const float dt);
 
 /* shape_vel calculates a jerk limited path from the current velocity and acceleration to an input velocity.
  The function takes the current velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -44,13 +44,14 @@ void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+ The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel
+ to be jerk limited
 */
 void shape_vel_accel(float &vel_input, const float accel_input,
-                     float vel, float& accel,
-                     float vel_min, float vel_max,
-                     float accel_min, float accel_max,
-                     float tc, float dt);
+                     const float vel, float& accel,
+                     const float vel_min, const float vel_max,
+                     const float accel_min, const float accel_max,
+                     const float tc, const float dt);
 
 /* shape_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -61,12 +62,13 @@ void shape_vel_accel(float &vel_input, const float accel_input,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
+ The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
  This function operates on the x and y axis of both Vector2f or Vector3f inputs.
  The accel_max limit can be removed by setting it to zero.
 */
 void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
-                        const Vector2f& vel, Vector2f& accel, float vel_max, float accel_max, float tc, float dt);
+                        const Vector2f& vel, Vector2f& accel,
+                        const float vel_max, const float accel_max, const float tc, const float dt);
 
 /* shape_pos_vel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -77,12 +79,12 @@ void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
+ The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
 */
 void shape_pos_vel_accel(float &pos_input, const float vel_input, const float accel_input,
-                         float pos, float vel, float& accel,
-                         float vel_correction_max, float vel_min, float vel_max,
-                         float accel_min, float accel_max, float tc, float dt);
+                         const float pos, const float vel, float& accel,
+                         const float vel_correction_max, const float vel_min, const float vel_max,
+                         const float accel_min, const float accel_max, const float tc, const float dt);
 
 /* shape_pos_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -93,13 +95,12 @@ void shape_pos_vel_accel(float &pos_input, const float vel_input, const float ac
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
- This function operates only on the x and y axis of the Vector2f or Vector3f inputs.
+ The function alters the accel to be jerk limited
  The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
 void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
-    const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
-    float vel_correction_max, float vel_max, float accel_max, float tc, float dt);
+                            const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
+                            const float vel_correction_max, const float vel_max, const float accel_max, const float tc, const float dt);
 
 // proportional controller with piecewise sqrt sections to constrain second derivative
 float sqrt_controller(float error, float p, float second_ord_lim, float dt);

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -7,20 +7,16 @@
 // update_vel_accel projects the velocity, vel, forward in time based on a time step of dt and acceleration of accel.
 // update_vel_accel - single axis projection.
 void update_vel_accel(float& vel, float accel, float dt, float limit);
-void update_vel_accel_z(Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit);
 
 // update_vel_accel projects the velocity, vel, forward in time based on a time step of dt and acceleration of accel.
 // update_vel_accel - single axis projection.
 void update_pos_vel_accel(float& pos, float& vel, float accel, float dt, float limit);
-void update_pos_vel_accel_z(Vector3f& pos, Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit);
 
 // update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_vel_accel(Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
-void update_vel_accel_xy(Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit);
+void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
 
 // update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_pos_vel_accel(Vector2f& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
-void update_pos_vel_accel_xy(Vector3f& pos, Vector3f& vel, const Vector3f& accel, float dt, Vector3f limit);
+void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
 
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
  The function takes the current acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -33,11 +29,11 @@ void update_pos_vel_accel_xy(Vector3f& pos, Vector3f& vel, const Vector3f& accel
  The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
 */
 void shape_accel(float accel_input, float& accel,
-    float accel_min, float accel_max,
-    float tc, float dt);
+                 float accel_min, float accel_max,
+                 float tc, float dt);
 
 void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
-    float accel_max, float tc, float dt);
+                    float accel_max, float tc, float dt);
 
 /* shape_vel calculates a jerk limited path from the current velocity and acceleration to an input velocity.
  The function takes the current velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -50,17 +46,11 @@ void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
  The time constant must be positive.
  The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
 */
-void shape_vel_accel(float vel_input, float accel_input,
-    float vel, float& accel,
-    float vel_min, float vel_max,
-    float accel_min, float accel_max,
-    float tc, float dt);
-
-void shape_vel_accel_z(const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& vel, Vector3f& accel,
-    float vel_min, float vel_max,
-    float accel_min, float accel_max,
-    float tc, float dt);
+void shape_vel_accel(float &vel_input, const float accel_input,
+                     float vel, float& accel,
+                     float vel_min, float vel_max,
+                     float accel_min, float accel_max,
+                     float tc, float dt);
 
 /* shape_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -75,11 +65,8 @@ void shape_vel_accel_z(const Vector3f& vel_input, const Vector3f& accel_input,
  This function operates on the x and y axis of both Vector2f or Vector3f inputs.
  The accel_max limit can be removed by setting it to zero.
 */
-void shape_vel_accel_xy(Vector2f vel_input, const Vector2f& accel_input,
-    const Vector2f& vel, Vector2f& accel, float vel_max, float accel_max, float tc, float dt);
-
-void shape_vel_accel_xy(const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& vel, Vector3f& accel, float vel_max, float accel_max, float tc, float dt);
+void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
+                        const Vector2f& vel, Vector2f& accel, float vel_max, float accel_max, float tc, float dt);
 
 /* shape_pos_vel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -92,15 +79,10 @@ void shape_vel_accel_xy(const Vector3f& vel_input, const Vector3f& accel_input,
  The time constant must be positive.
  The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time.
 */
-void shape_pos_vel_accel(float pos_input, float vel_input, float accel_input,
-    float pos, float vel, float& accel,
-    float vel_correction_max, float vel_min, float vel_max,
-    float accel_min, float accel_max, float tc, float dt);
-
-void shape_pos_vel_accel_z(const Vector3f& pos_input, const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& pos, const Vector3f& vel, Vector3f& accel,
-    float vel_correction_max, float vel_min, float vel_max,
-    float accel_min, float accel_max, float tc, float dt);
+void shape_pos_vel_accel(float &pos_input, const float vel_input, const float accel_input,
+                         float pos, float vel, float& accel,
+                         float vel_correction_max, float vel_min, float vel_max,
+                         float accel_min, float accel_max, float tc, float dt);
 
 /* shape_pos_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
@@ -118,10 +100,6 @@ void shape_pos_vel_accel_z(const Vector3f& pos_input, const Vector3f& vel_input,
 void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
     const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
     float vel_correction_max, float vel_max, float accel_max, float tc, float dt);
-
-void shape_pos_vel_accel_xy(const Vector3f& pos_input, const Vector3f& vel_input, const Vector3f& accel_input,
-    const Vector3f& pos, const Vector3f& vel, Vector3f& accel,
-    float vel_max, float vel_correction_max, float accel_max, float tc, float dt);
 
 // proportional controller with piecewise sqrt sections to constrain second derivative
 float sqrt_controller(float error, float p, float second_ord_lim, float dt);

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -26,12 +26,11 @@ void update_pos_vel_accel_xy(Vector2f& pos, Vector2f& vel, const Vector2f& accel
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input accel to be jerk limited
+ The function alters the variable accel to follow a jerk limited kinematic path to accel_input
 */
 void shape_accel(const float accel_input, float& accel,
                  const float accel_min, const float accel_max,
                  const float tc, const float dt);
-
 void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
                     const float accel_max, const float tc, const float dt);
 
@@ -44,29 +43,14 @@ void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel
- to be jerk limited
+ The function alters the variable accel to follow a jerk limited kinematic path to vel_input and accel_input
 */
-void shape_vel_accel(float &vel_input, const float accel_input,
+void shape_vel_accel(const float vel_input, const float accel_input,
                      const float vel, float& accel,
                      const float vel_min, const float vel_max,
                      const float accel_min, const float accel_max,
                      const float tc, const float dt);
-
-/* shape_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
- The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
- The kinematic path is constrained by:
-     vel_max : maximum velocity
-     accel_max : maximum acceleration
-     tc : time constant
- The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
- The time constant also defines the time taken to achieve the maximum acceleration.
- The time constant must be positive.
- The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
- This function operates on the x and y axis of both Vector2f or Vector3f inputs.
- The accel_max limit can be removed by setting it to zero.
-*/
-void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
+void shape_vel_accel_xy(const Vector2f &vel_input, const Vector2f& accel_input,
                         const Vector2f& vel, Vector2f& accel,
                         const float vel_max, const float accel_max, const float tc, const float dt);
 
@@ -79,25 +63,12 @@ void shape_vel_accel_xy(Vector2f &vel_input, const Vector2f& accel_input,
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the input position to be the closest position that the system could reach zero acceleration in the minimum time and alters the accel to be jerk limited
+ The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input
 */
-void shape_pos_vel_accel(float &pos_input, const float vel_input, const float accel_input,
+void shape_pos_vel_accel(const float pos_input, const float vel_input, const float accel_input,
                          const float pos, const float vel, float& accel,
                          const float vel_correction_max, const float vel_min, const float vel_max,
                          const float accel_min, const float accel_max, const float tc, const float dt);
-
-/* shape_pos_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
- The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
- The kinematic path is constrained by:
-     vel_max : maximum velocity
-     accel_max : maximum acceleration
-     tc : time constant
- The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
- The time constant also defines the time taken to achieve the maximum acceleration.
- The time constant must be positive.
- The function alters the accel to be jerk limited
- The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
-*/
 void shape_pos_vel_accel_xy(const Vector2f& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
                             const Vector2f& pos, const Vector2f& vel, Vector2f& accel,
                             const float vel_correction_max, const float vel_max, const float accel_max, const float tc, const float dt);

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -617,13 +617,6 @@ bool Vector3<T>::segment_plane_intersect(const Vector3<T>& seg_start, const Vect
     return true;
 }
 
-// return xy components of a vector3
-template <typename T>
-Vector2<T> Vector3<T>::xy()
-{
-    return Vector2<T>{x,y};
-}
-
 // define for float and double
 template class Vector3<float>;
 template class Vector3<double>;

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -192,9 +192,15 @@ public:
     // rotate vector by angle in radians in xy plane leaving z untouched
     void rotate_xy(float rotation_rad);
 
-    // return xy components of a vector3
-    Vector2<T> xy();
-    
+    // return xy components of a vector3 as a vector2.
+    // this returns a reference to the original vector3 xy data
+    const Vector2<T> &xy() const {
+        return *(const Vector2<T> *)this;
+    }
+    Vector2<T> &xy() {
+        return *(Vector2<T> *)this;
+    }
+
     // gets the length of this vector squared
     T  length_squared() const
     {


### PR DESCRIPTION
@peterbarker suggested that before #17803 we should cleanup the APIs to correctly use Vector2 for xy operations and float for z. This PR achieves that by making the xy() method on Vector3 produce a reference to a Vector2, which allows for efficient use of Vector2 APIs without a copy
