### PR TITLE
autotest: add test for Sub entering circle twice

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -367,6 +367,14 @@ class AutoTestSub(AutoTest):
                 break
         self.initialise_after_reboot_sitl()
 
+    def DoubleCircle(self):
+        self.change_mode('CIRCLE')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('STABILIZE')
+        self.change_mode('CIRCLE')
+        self.disarm_vehicle()
+
     def default_parameter_list(self):
         ret = super(AutoTestSub, self).default_parameter_list()
         ret["FS_GCS_ENABLE"] = 0  # FIXME
@@ -396,6 +404,10 @@ class AutoTestSub(AutoTest):
             ("GripperMission",
              "Test gripper mission items",
              self.test_gripper_mission),
+
+            ("DoubleCircle",
+             "Test entering circle twice",
+             self.DoubleCircle),
 
             ("MotorThrustHoverParameterIgnore", "Test if we are ignoring MOT_THST_HOVER", self.test_mot_thst_hover_ignore),
 


### PR DESCRIPTION
This adds an autotest which reproduces an internal error.

`./Tools/autotest/autotest.py --gdb --debug build.Sub test.Sub.DoubleCircle`

This probably comes down to Sub not poking the position controller while the vehicle is not armed.  Or failing to init it once the vehicle is armed.

@lthall @rmackay9 @jaxxzer 