### PR TITLE
RC_Channel: Add a check for allocation to RC1~4

### DIFF
--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -225,7 +225,8 @@ bool RC_Channels::flight_mode_channel_conflicts_with_rc_option() const
     if (chan == nullptr) {
         return false;
     }
-    return (RC_Channel::aux_func_t)chan->option.get() != RC_Channel::AUX_FUNC::DO_NOTHING;
+    
+    return (flight_mode_channel_number() < 5) || (RC_Channel::aux_func_t)chan->option.get() != RC_Channel::AUX_FUNC::DO_NOTHING;
 }
 
 /*


### PR DESCRIPTION
Knowing that RC1 to RC4 of the radio is assigned to the stick is limited.
The app developer only knows the allocation of specific RCs.
If the GCS developer doesn't know, he will set the wrong value to the config parameter.
I think it is better to include RC1~4 in the check.

AFTER
![Screenshot from 2021-06-24 08-01-01](https://user-images.githubusercontent.com/646194/123179348-28e97880-d4c4-11eb-949b-e587cdbc09e4.png)

RC1-4_OPTION VALUE IS 0
![Screenshot from 2021-06-24 08-17-17](https://user-images.githubusercontent.com/646194/123179598-b88f2700-d4c4-11eb-9764-4a9570c4a1d2.png)