### PR TITLE
Copter: fix terrain following in Auto

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -46,6 +46,9 @@ public:
     /// get_dt - gets time delta in seconds for all position controllers
     float get_dt() const { return _dt; }
 
+    /// get_shaping_tc_z_s - gets the time constant of the z kinimatic path generation in seconds
+    float get_shaping_tc_z_s() const { return _shaping_tc_z_s; }
+
 
     ///
     /// 3D position shaper

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -469,7 +469,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     shape_pos_vel_accel(terr_offset, 0.0f, 0.0f,
                         _pos_terrain_offset, _vel_terrain_offset, _accel_terrain_offset,
                         0.0f, _pos_control.get_max_speed_down_cms(), _pos_control.get_max_speed_up_cms(),
-                        -_pos_control.get_max_accel_z_cmss(), _pos_control.get_max_accel_z_cmss(), 0.05f, dt);
+                        -_pos_control.get_max_accel_z_cmss(), _pos_control.get_max_accel_z_cmss(), _pos_control.get_shaping_tc_z_s(), dt);
 
     update_pos_vel_accel(_pos_terrain_offset, _vel_terrain_offset, _accel_terrain_offset, dt, 0.0f);
 


### PR DESCRIPTION
This PR fixes the "dolphin" issue discussed here:
https://discuss.ardupilot.org/t/dolphin-fly-big-altitude-oscillation-in-rangefinder-based-auto-mission/72008/17

The behaviour is now as expected:
![image](https://user-images.githubusercontent.com/100896/123189575-38c18680-d4dd-11eb-9496-9e231d0d7fc0.png)
![image](https://user-images.githubusercontent.com/100896/123189587-3eb76780-d4dd-11eb-9fce-5f5fd2dfcc33.png)
