### PR TITLE
Copter: RNGFND_FILT param default increased from 0.25 to 0.5

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1063,7 +1063,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @DisplayName: Rangefinder filter
     // @Description: Rangefinder filter to smooth distance.  Set to zero to disable filtering
     // @Units: Hz
-    // @Range: 0 50
+    // @Range: 0 5
     // @Increment: 0.05
     // @User: Standard
     // @RebootRequired: True

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -86,7 +86,7 @@
 #endif
 
 #ifndef RANGEFINDER_FILT_DEFAULT
- # define RANGEFINDER_FILT_DEFAULT 0.25f    // filter for rangefinder distance
+ # define RANGEFINDER_FILT_DEFAULT 0.5f     // filter for rangefinder distance
 #endif
 
 #ifndef SURFACE_TRACKING_VELZ_MAX


### PR DESCRIPTION
This restores the rangefinder default filter to 0.5hz reverting part of PR https://github.com/ArduPilot/ardupilot/pull/17765

Here is some background about how we got here:

1. Copter-4.0 had the filter hard-coded to 0.25hz
2. Copter-4.1 had the filter increased to 0.5hz (PR https://github.com/ArduPilot/ardupilot/pull/16135) to reduce overshoot during takeoffs when using a rangefinder
3. [Copter-4.1 beta testing revealed bouncy terrain following in auto](https://discuss.ardupilot.org/t/dolphin-fly-big-altitude-oscillation-in-rangefinder-based-auto-mission/72008/17) (aka "Dolphin") and I thought reverting the above change would fix the problem
4. Further testing with the user revealed the above did not fix the problem and Leonard has a new fix with PR https://github.com/ArduPilot/ardupilot/pull/17852

So we don't need change 3 but we might as well leave the configurable filter in place but revert its default value to what we had in step2

The RNGFND_FILT parameter's upper range is reduced from 50hz to 5hz after a discussion with Leonard.