### PR TITLE
Copter: add change altitude with MP in loiter mode

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -442,6 +442,10 @@ private:
     AP_OSD osd;
 #endif
 
+    // Modify altitude by GCS 
+    bool is_change_alt = false; 
+    float gcs_target_alt = 0.0; // gcs target alt in cm
+
     // Altitude
     int32_t baro_alt;            // barometer altitude in cm above home
     LowPassFilterVector3f land_accel_ef_filter; // accelerations for land and crash detector tests

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -527,12 +527,20 @@ bool GCS_MAVLINK_Copter::handle_guided_request(AP_Mission::Mission_Command &cmd)
 
 void GCS_MAVLINK_Copter::handle_change_alt_request(AP_Mission::Mission_Command &cmd)
 {
+#if 0
     // add home alt if needed
     if (cmd.content.location.relative_alt) {
         cmd.content.location.alt += copter.ahrs.get_home().alt;
     }
+#endif
 
     // To-Do: update target altitude for loiter or waypoint controller depending upon nav mode
+    if(copter.flightmode->mode_number() == Mode::Number::LOITER) {
+        copter.gcs_target_alt = cmd.content.location.alt;
+        copter.is_change_alt = true;
+    } else {
+        return;
+    }
 }
 
 void GCS_MAVLINK_Copter::packetReceived(const mavlink_status_t &status,

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -152,6 +152,14 @@ void ModeLoiter::run()
         break;
 
     case AltHold_Flying:
+        if(copter.is_change_alt) {
+            float curr_alt = pos_control->get_pos_target_z_cm();
+            float target_alt = copter.gcs_target_alt;
+            pos_control->set_alt_target_with_slew(target_alt);
+            if(is_zero(floorf(fabs(curr_alt - target_alt)))) {
+                copter.is_change_alt = false;
+            }
+        }
         // set motors to full range
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 


### PR DESCRIPTION
This feature for Copter, can change altitude in loiter mode using Mission Planner -> Actions -> Change Alt
Copter must in loiter mode.
Mission Planner 1.3.74