### PR TITLE
autotest: disable quadplane ConfigErrorLoop test

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -595,6 +595,7 @@ class AutoTestQuadPlane(AutoTest):
             "FRSkyPassThrough": "Currently failing",
             "CPUFailsafe": "servo channel values not scaled like ArduPlane",
             "GyroFFT": "flapping test",
+            "ConfigErrorLoop": "failing because RC values not settable",
         }
 
     def test_pilot_yaw(self):


### PR DESCRIPTION
failing on the autotest server (and locally).

```
AT-1474.6: RC values bad: (ch=1 want=1500 got=0)
AT-1474.6: AP: Config error: Baro: unable to initialise driver
AT-1474.6: AP: Config Error: fix problem then reboot
AT-1474.6: RC values bad: (ch=1 want=1500 got=0)
AT-1474.6: RC values bad: (ch=1 want=1500 got=0)
AT-1474.6: RC values bad: (ch=1 want=1500 got=0)
```
