### PR TITLE
AP_BattMonitor: Add emergency voltage and emergency capacity

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -422,6 +422,10 @@ void AP_BattMonitor::check_failsafes(void)
                     action = _params[i]._failsafe_critical_action;
                     type_str = "critical";
                     break;
+                case Failsafe::Emergency:
+                    action = _params[i]._failsafe_emergency_action;
+                    type_str = "emergency";
+                    break;
             }
 
             GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Battery %d is %s %.2fV used %.0f mAh", i + 1, type_str,
@@ -607,6 +611,9 @@ MAV_BATTERY_CHARGE_STATE AP_BattMonitor::get_mavlink_charge_state(const uint8_t 
 
     case Failsafe::Critical:
         return MAV_BATTERY_CHARGE_STATE_CRITICAL;
+
+    case Failsafe::Emergency:
+        return MAV_BATTERY_CHARGE_STATE_EMERGENCY;
     }
 
     // Should not reach this

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -67,7 +67,8 @@ public:
     enum class Failsafe : uint8_t {
         None = 0,
         Low,
-        Critical
+        Critical,
+        Emergency,
     };
 
     // Battery monitor driver types
@@ -120,6 +121,7 @@ public:
         uint32_t    last_time_micros;          // time when voltage and current was last read in microseconds
         uint32_t    low_voltage_start_ms;      // time when voltage dropped below the minimum in milliseconds
         uint32_t    critical_voltage_start_ms; // critical voltage failsafe start timer in milliseconds
+        uint32_t    emergency_voltage_start_ms; // emergency voltage failsafe start timer in milliseconds
         float       temperature;               // battery temperature in degrees Celsius
         uint32_t    temperature_time;          // timestamp of the last received temperature message
         float       voltage_resting_estimate;  // voltage with sag removed based on current and resistance estimate in Volt

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -78,7 +78,7 @@ protected:
     AP_BattMonitor_Params               &_params;   // reference to this instances parameters (held in the front-end)
 
     // checks what failsafes could be triggered
-    void check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity) const;
+    void check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity, bool &emergency_voltage, bool &emergency_capacity) const;
 
 private:
     // resistance estimate

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -176,6 +176,33 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
 
+    // @Param: EMG_VOLT
+    // @DisplayName: Emergency battery voltage
+    // @Description: Battery voltage that triggers a emergency battery failsafe. Set to 0 to disable. If the battery voltage drops below this voltage continuously for more then the period specified by the @PREFIX@LOW_TIMER parameter then the vehicle will perform the failsafe specified by the @PREFIX@FS_EMG_ACT parameter.
+    // @Units: V
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("EMG_VOLT", 22, AP_BattMonitor_Params, _emergency_voltage, 0),
+
+    // @Param: EMG_MAH
+    // @DisplayName: Battery emergency capacity
+    // @Description: Battery capacity at which the emergency battery failsafe is triggered. Set to 0 to disable battery remaining failsafe. If the battery capacity drops below this level the vehicle will perform the failsafe specified by the @PREFIX@_FS_EMG_ACT parameter.
+    // @Units: mAh
+    // @Increment: 50
+    // @User: Standard
+    AP_GROUPINFO("EMG_MAH", 23, AP_BattMonitor_Params, _emergency_capacity, 0),
+
+    // @Param: FS_EMG_ACT
+    // @DisplayName: Emergency battery failsafe action
+    // @Description: What action the vehicle should perform if it hits a emergency battery failsafe
+    // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate,4:QLand,5:Parachute
+    // @Values{Copter}: 0:None,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate
+    // @Values{Sub}: 0:None,2:Disarm,3:Enter surface mode
+    // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate
+    // @Values{Tracker}: 0:None
+    // @User: Standard
+    AP_GROUPINFO("FS_EMG_ACT", 24, AP_BattMonitor_Params, _failsafe_emergency_action, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -32,6 +32,8 @@ public:
     AP_Float _low_capacity;             /// capacity level used to trigger a low battery failsafe
     AP_Float _critical_voltage;         /// voltage level used to trigger a critical battery failsafe
     AP_Float _critical_capacity;        /// capacity level used to trigger a critical battery failsafe
+    AP_Float _emergency_voltage;        /// voltage level used to trigger a emergency battery failsafe
+    AP_Float _emergency_capacity;       /// capacity level used to trigger a emergency battery failsafe
     AP_Int32 _arming_minimum_capacity;  /// capacity level required to arm
     AP_Float _arming_minimum_voltage;   /// voltage level required to arm
     AP_Int32 _options;                  /// Options
@@ -44,4 +46,5 @@ public:
     AP_Int8  _failsafe_voltage_source;  /// voltage type used for detection of low voltage event
     AP_Int8  _failsafe_low_action;      /// action to preform on a low battery failsafe
     AP_Int8  _failsafe_critical_action; /// action to preform on a critical battery failsafe
+    AP_Int8  _failsafe_emergency_action; /// action to preform on a emergency battery failsafe
 };


### PR DESCRIPTION
MAVLINK has an emergency status defined.
I know that some change gently and some change abruptly, depending on the type of battery.
I know that there are operators who want to fly until the very last minute.
I think it would be good if we could define critical as RTL and urgent as LAND.

I would suggest that while returning in RTL, if the voltage drops to a level where it can be landed, switch to LAND mode.
This emergency designation makes it possible to switch from RTL to LAND, which cannot be handled by criticality.

MAVLINK specifications:
https://mavlink.io/en/messages/common.html#MAV_BATTERY_CHARGE_STATE

after:
![Screenshot from 2021-06-27 11-28-04](https://user-images.githubusercontent.com/646194/123531116-ca7aff00-d73c-11eb-8a8b-476626151f6b.png)