### PR TITLE
SITL: allow for street addresses and city names with -L option

### DIFF
--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -9,8 +9,8 @@ BASE_PKGS="base-devel ccache git gsfonts tk wget"
 SITL_PKGS="python2-pip python-pip wxpython opencv python2-numpy python2-scipy"
 PX4_PKGS="lib32-glibc zip zlib ncurses"
 
-PYTHON2_PKGS="future lxml pymavlink MAVProxy argparse matplotlib pyparsing"
-PYTHON3_PKGS="pyserial empy"
+PYTHON2_PKGS="future lxml pymavlink MAVProxy argparse matplotlib pyparsing geocoder"
+PYTHON3_PKGS="pyserial empy geocoder"
 
 # GNU Tools for ARM Embedded Processors
 # (see https://launchpad.net/gcc-arm-embedded/)

--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -25,7 +25,7 @@ else
     echo "pip installed"
 fi
 
-pip2 install --user pyserial future empy mavproxy pexpect
+pip2 install --user pyserial future empy mavproxy pexpect geocoder
 
 SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
 ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -121,7 +121,7 @@ fi
 
 # Lists of packages to install
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
-PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8"
+PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8 geocoder"
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:
 if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then
   PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"


### PR DESCRIPTION
This uses geocoder osm API to lookup lat/lon given an address. So you can do:

      sim_vehicle.py -L '26 Carstensz St Griffith' --console --map

and get my house

It also works for cities, for example -L London or -L Montreal
