### PR TITLE
Copter: fixed check for EKF origin location

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -574,7 +574,8 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     }
 
     // check home and EKF origin are not too far
-    if (copter.far_from_EKF_origin(ahrs.get_home())) {
+    if (copter.far_from_EKF_origin(ahrs.get_home()) ||
+        copter.far_from_EKF_origin(copter.current_loc)) {
         check_failed(display_failure, "EKF-home variance");
         return false;
     }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -685,6 +685,7 @@ private:
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
     bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
+    bool set_home_no_distance_check(const Location& loc, bool lock) WARN_IF_UNUSED;
     bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
     bool far_from_EKF_origin(const Location& loc);
 

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -168,8 +168,11 @@
  # define FS_EKF_THRESHOLD_DEFAULT      0.8f    // EKF failsafe's default compass and velocity variance threshold above which the EKF failsafe will be triggered
 #endif
 
-#ifndef EKF_ORIGIN_MAX_DIST_M
- # define EKF_ORIGIN_MAX_DIST_M         50000   // EKF origin and waypoints (including home) must be within 50km
+#ifndef EKF_ORIGIN_MAX_DIST_KM
+ # define EKF_ORIGIN_MAX_DIST_KM        250   // EKF origin and home must be within 250km
+#endif
+#ifndef EKF_ORIGIN_MAX_ALT_KM
+ # define EKF_ORIGIN_MAX_ALT_KM         10   // EKF origin and home must be within 10km vertically
 #endif
 
 #ifndef COMPASS_CAL_STICK_GESTURE_TIME


### PR DESCRIPTION
this fixes a bug where the following happens:

 - GPS glitch on startup at over 50km from true location
 - EKF origin and home get set to glitch pos
 - GPS comes good to true location
 - pilot arms and takes off, then enters RTL
 - copter flies to the GPS glitch position

the basic problem is that setting home on arming silently fails, leaving home set to the glitch location. Pilot also cannot fix home
via mavlink.
This also fixes a bug in the alt checking for EKF origin, which had a meters vs cm mixup, leaving the limit as 500m
It also changes the max dist from origin to 250km, which is a reasonable limit until we change to double precision EKF, at which point we can make this larger