### PR TITLE
Run autotest in its own directory and use links to update website

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -76,7 +76,8 @@ def get_default_params(atype, binary):
                            speedup=10,
                            unhide_parameters=True)
     mavproxy = util.start_MAVProxy_SITL(atype,
-                                        master=mavproxy_master)
+                                        master=mavproxy_master,
+                                        state_basedir=buildlogs_dirpath())
     print("Dumping defaults")
     idx = mavproxy.expect([r'Saved [0-9]+ parameters to (\S+)'])
     if idx == 0:
@@ -85,7 +86,8 @@ def get_default_params(atype, binary):
         util.pexpect_close(sitl)
         sitl = util.start_SITL(binary, model=frame, home=home, speedup=10)
         mavproxy = util.start_MAVProxy_SITL(atype,
-                                            master=mavproxy_master)
+                                            master=mavproxy_master,
+                                            state_basedir=buildlogs_dirpath())
         mavproxy.expect(r'Saved [0-9]+ parameters to (\S+)')
     parmfile = mavproxy.match.group(1)
     dest = buildlogs_path('%s-defaults.parm' % atype)
@@ -1085,6 +1087,11 @@ if __name__ == "__main__":
             new_skipsteps.append(skipstep)
     skipsteps = new_skipsteps
 
+    # create our own process group as the alarm handler kills
+    # everything in it.  If we don't do this then we end up killing
+    # build_autotest.sh, our calling process on the test server
+    os.setsid()
+
     # ensure we catch timeouts
     signal.signal(signal.SIGALRM, alarm_handler)
     if opts.timeout is not None:
@@ -1113,11 +1120,12 @@ if __name__ == "__main__":
 
     util.mkdir_p(buildlogs_dirpath())
 
-    lckfile = buildlogs_path('autotest.lck')
+    lckfile = os.getenv("AUTOTEST_LOCKFILE", buildlogs_path('autotest.lck'))
     print("lckfile=%s" % repr(lckfile))
     lck = util.lock_file(lckfile)
 
     if lck is None:
+        # we shouldn't get here as build_all.sh should have it locked out
         print("autotest is locked - exiting.  lckfile=(%s)" % (lckfile,))
         sys.exit(0)
 

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -39,6 +39,7 @@ from common import Test
 
 tester = None
 
+# version 3
 
 def buildlogs_dirpath():
     """Return BUILDLOGS directory path."""

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -1126,7 +1126,7 @@ if __name__ == "__main__":
     lck = util.lock_file(lckfile)
 
     if lck is None:
-        # we shouldn't get here as build_all.sh should have it locked out
+        # we shouldn't get here as autotest should be run once in a directory...
         print("autotest is locked - exiting.  lckfile=(%s)" % (lckfile,))
         sys.exit(0)
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5934,7 +5934,8 @@ Also, ignores heartbeats not from our target system'''
             self.vehicleinfo_key(),
             logfile=self.mavproxy_logfile,
             options=self.mavproxy_options(),
-            pexpect_timeout=pexpect_timeout)
+            pexpect_timeout=pexpect_timeout,
+            state_basedir=self.buildlogs_dirpath())
         mavproxy.expect(r'Telemetry log: (\S+)\r\n')
         self.logfile = mavproxy.match.group(1)
         self.progress("LOGFILE %s" % self.logfile)

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -470,7 +470,8 @@ def start_MAVProxy_SITL(atype,
                         master='tcp:127.0.0.1:5762',
                         options=[],
                         pexpect_timeout=60,
-                        logfile=sys.stdout):
+                        logfile=sys.stdout,
+                        state_basedir=None):
     """Launch mavproxy connected to a SITL instance."""
     local_mp_modules_dir = os.path.abspath(
         os.path.join(__file__, '..', '..', '..', 'mavproxy_modules'))
@@ -492,6 +493,8 @@ def start_MAVProxy_SITL(atype,
     cmd.extend(['--aircraft', aircraft])
     cmd.extend(options)
     cmd.extend(['--default-modules', 'misc,terrain,wp,rally,fence,param,arm,mode,rc,cmdlong,output'])
+    if state_basedir is not None:
+        cmd.extend(['--state-basedir', state_basedir])
 
     print("PYTHONPATH: %s" % str(env['PYTHONPATH']))
     print("Running: %s" % cmd_as_shell(cmd))

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -155,14 +155,15 @@ pushd $BUILDLOGS
   # autotest is done, so update the link to the most-recent build
   ln -sfn "$HISTORY_DIR" latest
 
-  # if Parameters is a link, update the link.  If it is a directory
-  # then copy the contents down:
+  # copy Parameters and LogMessages from top-level dir down into HISTORY
   for dir in "Parameters" "LogMessages"; do
-      if [ ! -a "$dir" -o -d "$dir" ]; then
-          rsync -aP "$dir/" "$HISTORY_DIR"/"$dir"
-      else
-          echo "What manner of evil is ($dir)?"
+      SOURCE="$BUILD_BINARIES_BUILDLOGS_DIR/$dir"
+      if test -l "$SOURCE"; then
+          # source directory is a link, presumably to "latest"
+          continue
       fi
+      OUT="$HISTORY_DIR/$dir"
+      rsync -aP "$SOURCE/" "$OUT"
   done
 
   # remove the "currently-building" link as we're not currently building

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -91,6 +91,8 @@ popd
 githash=$(cd APM && git rev-parse HEAD)
 hdate=$(date +"%Y-%m-%d-%H:%m")
 
+WEB_BOILTERPLATE="$PWD/APM/Tools/autotest/web-firmware"
+
 killall -9 JSBSim || /bin/true
 
 # raise core limit
@@ -132,7 +134,7 @@ pushd $BUILDLOGS
   mkdir -p "$HISTORY_DIR"
 
   # populate index.html etc from the repository:
-  rsync -a APM/Tools/autotest/web-firmware/ "$HISTORY_DIR"
+  rsync -aPH "$WEB_BOILTERPLATE/" "$HISTORY_DIR"
 
   # create a link so people can see what we're currently doing:
   ln -sfn "$HISTORY_DIR" currently-building

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -71,7 +71,7 @@ git reset --hard origin/master
 git pull
 git clean -f -f -x -d -d
 git tag autotest-$(date '+%Y-%m-%d-%H%M%S') -m "test tag `date`"
-cp ../config.mk .
+-e ../config.mk && cp ../config.mk .
 popd
 
 echo "Updating MAVProxy"

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 set -x
 
 export PATH=$HOME/.local/bin:/usr/local/bin:$HOME/prefix/bin:$HOME/gcc/active/bin:$PATH
@@ -123,7 +124,7 @@ fi
 mkdir -p $BUILDLOGS
 
 # update index.html from the repository:
-rsync -a APM/Tools/autotest/web-firmware/ buildlogs/binaries/
+rsync -a APM/Tools/autotest/web-firmware/ "$BUILDLOGS/binaries/"
 
 pushd $BUILDLOGS
 
@@ -146,7 +147,7 @@ pushd $BUILDLOGS
     if [ -n "$(which timelimit)" ]; then
         TIMELIMIT="timelimit $TIMELIMIT_TIME_LIMIT"
     fi
-    $TIMELIMIT "$AUTOTEST" --timeout=300000 > "autotest-output.txt" 2>&1
+    $TIMELIMIT "$AUTOTEST" --autotest-server --timeout=300000 > "autotest-output.txt" 2>&1
   popd
 
   # autotest is done, so update the link to the most-recent build

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -147,7 +147,7 @@ pushd $BUILDLOGS
     if [ -n "$(which timelimit)" ]; then
         TIMELIMIT="timelimit $TIMELIMIT_TIME_LIMIT"
     fi
-    $TIMELIMIT "$AUTOTEST" --autotest-server --timeout=300000 > "autotest-output.txt" 2>&1
+    $TIMELIMIT "$AUTOTEST" --autotest-server --timeout=300000 > "$PWD/autotest-output.txt" 2>&1
   popd
 
   # autotest is done, so update the link to the most-recent build

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -71,7 +71,7 @@ git reset --hard origin/master
 git pull
 git clean -f -f -x -d -d
 git tag autotest-$(date '+%Y-%m-%d-%H%M%S') -m "test tag `date`"
--e ../config.mk && cp ../config.mk .
+test -f ../config.mk && cp ../config.mk .
 popd
 
 echo "Updating MAVProxy"

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -146,7 +146,7 @@ pushd $BUILDLOGS
     if [ -n "$(which timelimit)" ]; then
         TIMELIMIT="timelimit $TIMELIMIT_TIME_LIMIT"
     fi
-    $TIMELIMIT "$AUTOTEST" --timeout=30000 > "autotest-output.txt" 2>&1
+    $TIMELIMIT "$AUTOTEST" --timeout=300000 > "autotest-output.txt" 2>&1
   popd
 
   # autotest is done, so update the link to the most-recent build

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -149,7 +149,7 @@ pushd $BUILDLOGS
     if [ -n "$(which timelimit)" ]; then
         TIMELIMIT="timelimit $TIMELIMIT_TIME_LIMIT"
     fi
-    $TIMELIMIT "$AUTOTEST" --autotest-server --timeout=300000 > "$PWD/autotest-output.txt" 2>&1
+    $TIMELIMIT "$AUTOTEST" --autotest-server --timeout=300000 > "$PWD/autotest-output.txt" 2>&1 || true  # ignore test failure
   popd
 
   # autotest is done, so update the link to the most-recent build

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -123,9 +123,6 @@ fi
 
 mkdir -p $BUILDLOGS
 
-# update index.html from the repository:
-rsync -a APM/Tools/autotest/web-firmware/ "$BUILDLOGS/binaries/"
-
 pushd $BUILDLOGS
 
   export BUILD_BINARIES_BUILDLOGS_DIR="$PWD"
@@ -133,6 +130,9 @@ pushd $BUILDLOGS
 
   HISTORY_DIR="history/$hdate"
   mkdir -p "$HISTORY_DIR"
+
+  # populate index.html etc from the repository:
+  rsync -a APM/Tools/autotest/web-firmware/ "$HISTORY_DIR"
 
   # create a link so people can see what we're currently doing:
   ln -sfn "$HISTORY_DIR" currently-building

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -1,23 +1,11 @@
 #!/bin/bash
 
+set -x
+
 export PATH=$HOME/.local/bin:/usr/local/bin:$HOME/prefix/bin:$HOME/gcc/active/bin:$PATH
 export PYTHONUNBUFFERED=1
 
 cd $HOME/APM || exit 1
-
-test -n "$FORCEBUILD" || {
-(cd APM && git fetch > /dev/null 2>&1)
-
-newtags=$(cd APM && git fetch --tags | wc -l)
-oldhash=$(cd APM && git rev-parse origin/master)
-newhash=$(cd APM && git rev-parse HEAD)
-
-if [ "$oldhash" = "$newhash" -a "$newtags" = "0" ]; then
-    echo "$(date) no change $oldhash $newhash" >> build.log
-    exit 0
-fi
-echo "$(date) Build triggered $oldhash $newhash $newtags" >> build.log
-}
 
 ############################
 # grab a lock file. Not atomic, but close :)
@@ -40,9 +28,28 @@ lock_file() {
 
 
 lock_file build.lck || {
+    echo "$(date) Build locked" >> build.log
     exit 1
 }
 
+if [ -e "$HOME/APM/FORCEBUILD" ]; then
+   unlink "$HOME/APM/FORCEBUILD"
+   FORCEBUILD=1
+fi
+
+test -n "$FORCEBUILD" || {
+(cd APM && git fetch > /dev/null 2>&1)
+
+newtags=$(cd APM && git fetch --tags | wc -l)
+oldhash=$(cd APM && git rev-parse origin/master)
+newhash=$(cd APM && git rev-parse HEAD)
+
+if [ "$oldhash" = "$newhash" -a "$newtags" = "0" ]; then
+    echo "$(date) no change $oldhash $newhash" >> build.log
+    exit 0
+fi
+echo "$(date) Build triggered $oldhash $newhash $newtags" >> build.log
+}
 
 #ulimit -m 500000
 #ulimit -s 500000
@@ -52,27 +59,6 @@ lock_file build.lck || {
 (
 date
 
-report() {
-    d="$1"
-    old="$2"
-    new="$3"
-    cat <<EOF | mail -s 'build failed' ardupilot.devel@google.com
-A build of $d failed at `date`
-
-You can view the build logs at https://autotest.ardupilot.org/
-
-A log of the commits since the last attempted build is below
-
-`git log $old $new`
-EOF
-}
-
-report_pull_failure() {
-    d="$1"
-    git show origin/master | mail -s 'APM pull failed' ardupilot.devel@google.com
-    exit 1
-}
-
 oldhash=$(cd APM && git rev-parse HEAD)
 
 echo "Updating APM"
@@ -81,13 +67,11 @@ git checkout -f master
 git fetch origin
 git submodule update --recursive --force
 git reset --hard origin/master
-git pull || report_pull_failure
+git pull
 git clean -f -f -x -d -d
 git tag autotest-$(date '+%Y-%m-%d-%H%M%S') -m "test tag `date`"
 cp ../config.mk .
 popd
-
-rsync -a APM/Tools/autotest/web-firmware/ buildlogs/binaries/
 
 echo "Updating MAVProxy"
 pushd MAVProxy
@@ -106,12 +90,6 @@ popd
 githash=$(cd APM && git rev-parse HEAD)
 hdate=$(date +"%Y-%m-%d-%H:%m")
 
-(cd APM && Tools/scripts/build_parameters.sh)
-
-(cd APM && Tools/scripts/build_log_message_documentation.sh)
-
-(cd APM && Tools/scripts/build_docs.sh)
-
 killall -9 JSBSim || /bin/true
 
 # raise core limit
@@ -123,12 +101,70 @@ export BUILD_BINARIES_PATH=$HOME/build/tmp
 # exit on panic so we don't waste time waiting around
 export SITL_PANIC_EXIT=1
 
-timelimit 32000 APM/Tools/autotest/autotest.py --autotest-server --timeout=30000 > buildlogs/autotest-output.txt 2>&1
+ARDUPILOT_ROOT="$PWD/APM"
+AUTOTEST="$ARDUPILOT_ROOT/Tools/autotest/autotest.py"
+AUTOTEST_LOCKFILE="$PWD/autotest.lck"
 
-mkdir -p "buildlogs/history/$hdate"
+# we run the timelimit shell command to kill autotest if it behaves badly:
+TIMELIMIT_TIME_LIMIT=32000
+# we pass this into autotest.py to get it to time limit itself
+AUTOTEST_TIME_LIMIT=30000
 
-(cd buildlogs && cp -f *.txt *.flashlog *.tlog *.km[lz] *.gpx *.html *.png *.bin *.BIN *.elf "history/$hdate/")
-echo $githash > "buildlogs/history/$hdate/githash.txt"
+pushd APM
+  ./Tools/scripts/build_parameters.sh
+  ./Tools/scripts/build_log_message_documentation.sh
+  ./Tools/scripts/build_docs.sh
+popd
+
+if [ "x$BUILDLOGS" = "x" ]; then
+    BUILDLOGS="buildlogs"
+fi
+
+mkdir -p $BUILDLOGS
+
+# update index.html from the repository:
+rsync -a APM/Tools/autotest/web-firmware/ buildlogs/binaries/
+
+pushd $BUILDLOGS
+
+  export BUILD_BINARIES_BUILDLOGS_DIR="$PWD"
+  export BUILD_BINARIES_HISTORY="$PWD/build_binaries_history.sqlite"
+
+  HISTORY_DIR="history/$hdate"
+  mkdir -p "$HISTORY_DIR"
+
+  # create a link so people can see what we're currently doing:
+  ln -sfn "$HISTORY_DIR" currently-building
+
+  pushd "$HISTORY_DIR"
+
+    echo $githash > "githash.txt"
+
+    # autotest.py honours BUILDLOGS
+    export BUILDLOGS="$PWD"
+    TIMELIMIT=""
+    if [ -n "$(which timelimit)" ]; then
+        TIMELIMIT="timelimit $TIMELIMIT_TIME_LIMIT"
+    fi
+    $TIMELIMIT "$AUTOTEST" --timeout=30000 > "autotest-output.txt" 2>&1
+  popd
+
+  # autotest is done, so update the link to the most-recent build
+  ln -sfn "$HISTORY_DIR" latest
+
+  # if Parameters is a link, update the link.  If it is a directory
+  # then copy the contents down:
+  for dir in "Parameters" "LogMessages"; do
+      if [ ! -a "$dir" -o -d "$dir" ]; then
+          rsync -aP "$dir/" "$HISTORY_DIR"/"$dir"
+      else
+          echo "What manner of evil is ($dir)?"
+      fi
+  done
+
+  # remove the "currently-building" link as we're not currently building
+  rm -f currently-building
+popd
 
 ) >> build.log 2>&1
 

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -794,6 +794,7 @@ is bob we will attempt to checkout bob-AVR'''
         out = os.getenv("BUILD_BINARIES_BUILDLOGS_DIR", None)
         if out is not None:
             return out
+        raise ValueError("Expected BUILD_BINARIES_BUILDLOGS_DIR")
         return os.getenv("BUILDLOGS",
                          os.path.join(os.getcwd(), "..", "buildlogs"))
 

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -36,8 +36,11 @@ class build_binaries(object):
     def __init__(self, tags):
         self.tags = tags
         self.dirty = False
-        binaries_history_filepath = os.path.join(self.buildlogs_dirpath(),
-                                                 "build_binaries_history.sqlite")
+        default_binaries_history_filepath = os.path.join(
+            self.buildlogs_dirpath(),
+            "build_binaries_history.sqlite")
+        binaries_history_filepath = os.getenv("BUILD_BINARIES_HISTORY",
+                                              default_binaries_history_filepath)
         self.history = build_binaries_history.BuildBinariesHistory(binaries_history_filepath)
 
     def progress(self, string):
@@ -788,6 +791,9 @@ is bob we will attempt to checkout bob-AVR'''
             shutil.rmtree(self.tmpdir)
 
     def buildlogs_dirpath(self):
+        out = os.getenv("BUILD_BINARIES_BUILDLOGS_DIR", None)
+        if out is not None:
+            return out
         return os.getenv("BUILDLOGS",
                          os.path.join(os.getcwd(), "..", "buildlogs"))
 


### PR DESCRIPTION
This runs autotest in the history directory, rather than running in the buildlogs directory and creating the history directy as an after-thought.

Once the run is complete, symlinks are used to update a "current" link to point to the newly completed run.  A symlink is also used to point to the run currently in progress.

This will have several advantages
 - user will always be shown the last complete run, rather than a mixture of last and current run
 - log files will not be left lying around in the buildlogs directory to be shown on every subsequent run (relevant/updated or not)
 - all history will be preserved, rather than just the file we remember to copy
