### PR TITLE
Copter: improve check of far_from_EKF_origin

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -573,9 +573,15 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
         }
     }
 
-    // check home and EKF origin are not too far
+    // check if home is too far from EKF origin
     if (copter.far_from_EKF_origin(ahrs.get_home())) {
-        check_failed(display_failure, "EKF-home variance");
+        check_failed(display_failure, "Home too far from EKF origin");
+        return false;
+    }
+
+    // check if vehicle is too far from EKF origin
+    if (copter.far_from_EKF_origin(copter.current_loc)) {
+        check_failed(display_failure, "Vehicle too far from EKF origin");
         return false;
     }
 

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -107,8 +107,13 @@ bool Copter::far_from_EKF_origin(const Location& loc)
 {
     // check distance to EKF origin
     Location ekf_origin;
-    if (ahrs.get_origin(ekf_origin) && ((ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_M) || (labs(ekf_origin.alt - loc.alt) > EKF_ORIGIN_MAX_DIST_M))) {
-        return true;
+    if (ahrs.get_origin(ekf_origin)) {
+        if ((ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_KM*1000.0)) {
+            return true;
+        }
+        if (labs(ekf_origin.alt - loc.alt)*0.01 > EKF_ORIGIN_MAX_ALT_KM*1000.0) {
+            return true;
+        }
     }
 
     // close enough to origin

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -168,8 +168,11 @@
  # define FS_EKF_THRESHOLD_DEFAULT      0.8f    // EKF failsafe's default compass and velocity variance threshold above which the EKF failsafe will be triggered
 #endif
 
-#ifndef EKF_ORIGIN_MAX_DIST_M
- # define EKF_ORIGIN_MAX_DIST_M         50000   // EKF origin and waypoints (including home) must be within 50km
+#ifndef EKF_ORIGIN_MAX_DIST_KM
+ # define EKF_ORIGIN_MAX_DIST_KM        250   // EKF origin and home must be within 250km horizontally
+#endif
+#ifndef EKF_ORIGIN_MAX_ALT_KM
+ # define EKF_ORIGIN_MAX_ALT_KM         50   // EKF origin and home must be within 50km vertically
 #endif
 
 #ifndef COMPASS_CAL_STICK_GESTURE_TIME


### PR DESCRIPTION
This is a cut-down and slightly modified version of PR https://github.com/ArduPilot/ardupilot/pull/17875

Changes in this PR are:

1. home's max allowable distance from EKF origin is increased from 50km to 250km horizontally
2. fixes a bug in the far-from-EKF-origin related to height (was 500m, now 50km)
3. adds arming check that the vehicle is also within 250km of the EKF origin horizontally and 50km vertically

Below is screenshot showing that the altitude bug (see 2 above) is fixed (home can now be set >500m from the ekf origin)
![before-vs-after](https://user-images.githubusercontent.com/1498098/123737348-c9350800-d8dd-11eb-8160-3130b4b80049.png)

Below is a screenshot of a test in which a large GPS glitch caused the EKF origin and home to be a long way from the vehicle (test as described in the original PR https://github.com/ArduPilot/ardupilot/pull/17875).  The new pre-arm check triggers because the vehicle is very far from the EKF origin.
![pre-armcheck](https://user-images.githubusercontent.com/1498098/123737450-ec5fb780-d8dd-11eb-9a40-de7fa13768e9.png)

I've also created issue https://github.com/ArduPilot/ardupilot/issues/17888 so that we don't forget to fix the bug involving not resetting the home position to the vehicle's current location during arming
