### PR TITLE
Copter: arming fails if set home fails unexpectedly

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -821,6 +821,7 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
     // Remember Orientation
     // --------------------
     copter.init_simple_bearing();
+    copter.update_super_simple_bearing(false);
 
     copter.initial_armed_bearing = ahrs.yaw_sensor;
 
@@ -835,7 +836,6 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
         // remember the height when we armed
         copter.arming_altitude_m = copter.inertial_nav.get_altitude() * 0.01;
     }
-    copter.update_super_simple_bearing(false);
 
     // Reset SmartRTL return location. If activated, SmartRTL will ultimately try to land at this point
 #if MODE_SMARTRTL_ENABLED == ENABLED


### PR DESCRIPTION
DO NOT MERGE

This is a follow up to PR https://github.com/ArduPilot/ardupilot/pull/17875 and PR https://github.com/ArduPilot/ardupilot/pull/17889 and resolves issue https://github.com/ArduPilot/ardupilot/issues/17888

During arming Copter attempts to move home to the vehicle's current location if home has already been set and it hasn't been locked (note: home becomes locked if the user manually sets the home location through the GCS).  This should never fail but if it does for some unknown reason then we fail to arm.

There is also a "drive-by" fix to initialising of the "arming_altitude_m" variable (only used by Toy mode) which could be left unset if the user had moved the home location.

One questionable thing is that we only fail to arm if "do_arming_checks" is true.  This could be false if the user forces the arm (I think).

Below is a before-vs-after screen shot from SITL showing how the procedure outlined in PR is now handled.  E.g. GPS Glitch is invoked during startup but cleared before takeoff resulting in a "flyaway" to a far away home.
![set-home-fail-prearm](https://user-images.githubusercontent.com/1498098/123744870-6007c180-d8ea-11eb-89f9-96913c2f503e.png)