### PR TITLE
AP_Frsky_Telem: added an airspeed OPTIONS flag to frame 0x5005

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
@@ -139,6 +139,10 @@ protected:
     static const uint8_t SENSOR_ID_RPM             = 0xE4; // Sensor ID  4
     static const uint8_t SENSOR_ID_SP2UR           = 0xC6; // Sensor ID  6
 
+    enum frsky_options_e : uint8_t {
+        OPTION_AIRSPEED_AND_GROUNDSPEED = 1U<<0,
+    };
+
 private:
 
     void loop(void);

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.cpp
@@ -44,6 +44,13 @@ const AP_Param::GroupInfo AP_Frsky_Parameters::var_info[] = {
     // @Values: -1:Disable,7:7,8:8,9:9,10:10,11:11,12:12,13:13,14:14,15:15,16:16,17:17,18:18,19:19,20:20,21:21,22:22,23:23,24:24,25:25,26:26,27:27
     // @User: Advanced
     AP_GROUPINFO("DNLINK_ID",  4, AP_Frsky_Parameters, _dnlink_id, 27),
+
+    // @Param: OPTIONS
+    // @DisplayName: FRSky Telemetry Options
+    // @Description: A bitmask to set some FRSky Telemetry specific options
+    // @Bitmask: 0:EnableAirspeedAndGroundspeed
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 5, AP_Frsky_Parameters, _options, 0),
     AP_GROUPEND
 };
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.h
@@ -37,6 +37,7 @@ private:
     AP_Int8 _dnlink_id;
     AP_Int8 _dnlink1_id;
     AP_Int8 _dnlink2_id;
+    AP_Int8 _options;
 };
 
 #endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
@@ -20,7 +20,7 @@ public:
     bool sport_telemetry_push(const uint8_t sensor, const uint8_t frame, const uint16_t appid, const int32_t data);
     // utility method to pack numbers in a compact size
     uint16_t prep_number(int32_t const number, const uint8_t digits, const uint8_t power);
-    
+
     static AP_Frsky_SPort *get_singleton(void) {
         return singleton;
     }
@@ -31,6 +31,7 @@ protected:
 
     struct PACKED {
         bool send_latitude; // sizeof(bool) = 4 ?
+        bool send_airspeed; // toggles 0x5005 between airspeed and groundspeed
         uint32_t gps_lng_sample;
         uint8_t new_byte;
     } _passthrough;


### PR DESCRIPTION
added a new parameter FRSKY_OPTIONS to enable sending airspeed and groundspeed on the same frame 0x5005

![image](https://user-images.githubusercontent.com/30294218/123923653-7ca70680-d989-11eb-8860-8c81ec4e078c.png)

