### PR TITLE
Added DEVID to airspeed drivers, and improved MS4525 I2C probing

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -20,6 +20,7 @@ parser = optparse.OptionParser("decode_devid.py")
 parser.add_option("-C", "--compass", action='store_true', help='decode compass IDs')
 parser.add_option("-I", "--imu", action='store_true', help='decode IMU IDs')
 parser.add_option("-B", "--baro", action='store_true', help='decode barometer IDs')
+parser.add_option("-A", "--airspeed", action='store_true', help='decode airspeed IDs')
 
 opts, args = parser.parse_args()
 
@@ -108,6 +109,19 @@ baro_types = {
     0x0C : "DEVTYPE_BARO_SPL06",
     0x0D : "DEVTYPE_BARO_UAVCAN",
 }
+
+airspeed_types = {
+    0x01 : "DEVTYPE_AIRSPEED_SITL",
+    0x02 : "DEVTYPE_AIRSPEED_MS4525",
+    0x03 : "DEVTYPE_AIRSPEED_MS5525",
+    0x04 : "DEVTYPE_AIRSPEED_DLVR",
+    0x05 : "DEVTYPE_AIRSPEED_MSP",
+    0x06 : "DEVTYPE_AIRSPEED_SDP3X",
+    0x07 : "DEVTYPE_AIRSPEED_UAVCAN",
+    0x08 : "DEVTYPE_AIRSPEED_ANALOG",
+    0x09 : "DEVTYPE_AIRSPEED_NMEA",
+    0x0A : "DEVTYPE_AIRSPEED_ASP5033",
+}
     
 decoded_devname = ""
 
@@ -120,6 +134,9 @@ if opts.imu:
 if opts.baro:
     decoded_devname = baro_types.get(devtype, "UNKNOWN")
 
+if opts.airspeed:
+    decoded_devname = airspeed_types.get(devtype, "UNKNOWN")
+    
 if bus_type == 3:
     #uavcan devtype represents sensor_id
     print("bus_type:%s(%u)  bus:%u address:%u(0x%x) sensor_id:%u(0x%x) %s" % (

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -167,8 +167,8 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 #ifndef HAL_BUILD_AP_PERIPH
     // @Param: _OPTIONS
     // @DisplayName: Airspeed options bitmask
-    // @Description: Bitmask of options to use with airspeed. Disable and/or re-enable sensor based on the difference between airspeed and ground speed based on ARSPD_WIND_MAX threshold, if set
-    // @Bitmask: 0:Disable sensor, 1:Re-enable sensor, 2:DisableVoltageCorrection
+    // @Description: Bitmask of options to use with airspeed. 0:Disable use based on airspeed/groundspeed mismatch (see ARSPD_WIND_MAX), 1:Automatically reenable use based on airspeed/groundspeed mismatch recovery (see ARSPD_WIND_MAX) 2:Disable voltage correction
+    // @Bitmask: 0:SpeedMismatchDisable, 1:AllowSpeedMismatchRecovery, 2:DisableVoltageCorrection
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS", 21, AP_Airspeed, _options, OPTIONS_DEFAULT),
 

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -257,6 +257,23 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
     // Note that 21, 22 and 23 are used above by the _OPTIONS, _WIND_MAX and _WIND_WARN parameters.  Do not use them!!
 
+    // @Param: _DEVID
+    // @DisplayName: Airspeed ID
+    // @Description: Airspeed sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("_DEVID", 24, AP_Airspeed, param[0].bus_id, 0, AP_PARAM_FLAG_INTERNAL_USE_ONLY),
+
+#if AIRSPEED_MAX_SENSORS > 1
+    // @Param: 2_DEVID
+    // @DisplayName: Airspeed2 ID
+    // @Description: Airspeed2 sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("2_DEVID", 25, AP_Airspeed, param[1].bus_id, 0, AP_PARAM_FLAG_INTERNAL_USE_ONLY),
+#endif
+    
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -168,7 +168,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: Airspeed options bitmask
     // @Description: Bitmask of options to use with airspeed. Disable and/or re-enable sensor based on the difference between airspeed and ground speed based on ARSPD_WIND_MAX threshold, if set
-    // @Bitmask: 0:Disable sensor, 1:Re-enable sensor
+    // @Bitmask: 0:Disable sensor, 1:Re-enable sensor, 2:DisableVoltageCorrection
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS", 21, AP_Airspeed, _options, OPTIONS_DEFAULT),
 

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -145,6 +145,7 @@ public:
     enum OptionsMask {
         ON_FAILURE_AHRS_WIND_MAX_DO_DISABLE                   = (1<<0),   // If set then use airspeed failure check
         ON_FAILURE_AHRS_WIND_MAX_RECOVERY_DO_REENABLE         = (1<<1),   // If set then automatically enable the airspeed sensor use when healthy again.
+        DISABLE_VOLTAGE_CORRECTION                            = (1<<2),
     };
 
     enum airspeed_type {

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -205,6 +205,7 @@ private:
         AP_Int8  autocal;
         AP_Int8  tube_order;
         AP_Int8  skip_cal;
+        AP_Int32 bus_id;
     } param[AIRSPEED_MAX_SENSORS];
 
     struct airspeed_state {

--- a/libraries/AP_Airspeed/AP_Airspeed_ASP5033.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_ASP5033.cpp
@@ -54,6 +54,9 @@ bool AP_Airspeed_ASP5033::init()
             continue;
         }
 
+        dev->set_device_type(uint8_t(DevType::ASP5033));
+        set_bus_id(dev->get_bus_id());
+
         dev->register_periodic_callback(1000000UL/80U,
                                         FUNCTOR_BIND_MEMBER(&AP_Airspeed_ASP5033::timer, void));
         return true;

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
@@ -49,3 +49,8 @@ uint8_t AP_Airspeed_Backend::get_bus(void) const
 {
     return frontend.param[instance].bus;
 }
+
+bool AP_Airspeed_Backend::bus_is_confgured(void) const
+{
+    return frontend.param[instance].bus.configured();
+}

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -86,6 +86,24 @@ protected:
         frontend.param[instance].use.set(use);
     }
 
+    // set bus ID of this instance, for ARSPD_DEVID parameters
+    void set_bus_id(uint32_t id) {
+        frontend.param[instance].bus_id.set(int32_t(id));
+    }
+
+    enum class DevType {
+        SITL     = 0x01,
+        MS4525   = 0x02,
+        MS5525   = 0x03,
+        DLVR     = 0x04,
+        MSP      = 0x05,
+        SDP3X    = 0x06,
+        UAVCAN   = 0x07,
+        ANALOG   = 0x08,
+        NMEA     = 0x09,
+        ASP5033  = 0x0A,
+    };
+    
 private:
     AP_Airspeed &frontend;
     uint8_t instance;

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -55,6 +55,11 @@ protected:
         return instance;
     }
 
+    // see if voltage correction should be disabled
+    bool disable_voltage_correction(void) const {
+        return (frontend._options.get() & AP_Airspeed::OptionsMask::DISABLE_VOLTAGE_CORRECTION) != 0;
+    }
+
     AP_Airspeed::pitot_tube_order get_tube_order(void) const {
         return AP_Airspeed::pitot_tube_order(frontend.param[instance].tube_order.get());
     }

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -50,6 +50,10 @@ protected:
     int8_t get_pin(void) const;
     float get_psi_range(void) const;
     uint8_t get_bus(void) const;
+    bool bus_is_confgured(void) const;
+    uint8_t get_instance(void) const {
+        return instance;
+    }
 
     AP_Airspeed::pitot_tube_order get_tube_order(void) const {
         return AP_Airspeed::pitot_tube_order(frontend.param[instance].tube_order.get());

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
@@ -43,10 +43,12 @@ bool AP_Airspeed_DLVR::init()
     if (!dev) {
         return false;
     }
-    dev->get_semaphore()->take_blocking();
+    WITH_SEMAPHORE(dev->get_semaphore());
     dev->set_speed(AP_HAL::Device::SPEED_LOW);
     dev->set_retries(2);
-    dev->get_semaphore()->give();
+    dev->set_device_type(uint8_t(DevType::DLVR));
+    set_bus_id(dev->get_bus_id());
+
     dev->register_periodic_callback(1000000UL/50U,
                                     FUNCTOR_BIND_MEMBER(&AP_Airspeed_DLVR::timer, void));
     return true;

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -59,7 +59,7 @@ bool AP_Airspeed_MS4525::probe(uint8_t bus, uint8_t address)
 // probe and initialise the sensor
 bool AP_Airspeed_MS4525::init()
 {
-    const uint8_t addresses[] = { MS4525D0_I2C_ADDR1, MS4525D0_I2C_ADDR2, MS4525D0_I2C_ADDR3 };
+    static const uint8_t addresses[] = { MS4525D0_I2C_ADDR1, MS4525D0_I2C_ADDR2, MS4525D0_I2C_ADDR3 };
     if (bus_is_confgured()) {
         // the user has configured a specific bus
         for (uint8_t addr : addresses) {

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -90,6 +90,9 @@ bool AP_Airspeed_MS4525::init()
     return false;
 
 found_sensor:
+    _dev->set_device_type(uint8_t(DevType::MS4525));
+    set_bus_id(_dev->get_bus_id());
+
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "MS4525[%u]: Found bus %u addr 0x%02x", get_instance(), _dev->bus_num(), _dev->get_bus_address());
 
     // drop to 2 retries for runtime

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -22,55 +22,75 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/I2CDevice.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
 #include <stdio.h>
 #include <utility>
 
 extern const AP_HAL::HAL &hal;
 
-#define MS4525D0_I2C_ADDR 0x28
+#define MS4525D0_I2C_ADDR1 0x28
+#define MS4525D0_I2C_ADDR2 0x36
+#define MS4525D0_I2C_ADDR3 0x46
 
 AP_Airspeed_MS4525::AP_Airspeed_MS4525(AP_Airspeed &_frontend, uint8_t _instance) :
     AP_Airspeed_Backend(_frontend, _instance)
 {
 }
 
+// probe for a sensor
+bool AP_Airspeed_MS4525::probe(uint8_t bus, uint8_t address)
+{
+    _dev = hal.i2c_mgr->get_device(bus, address);
+    if (!_dev) {
+        return false;
+    }
+    WITH_SEMAPHORE(_dev->get_semaphore());
+
+    // lots of retries during probe
+    _dev->set_retries(10);
+    
+    _measure();
+    hal.scheduler->delay(10);
+    _collect();
+
+    return _last_sample_time_ms != 0;
+}
+
 // probe and initialise the sensor
 bool AP_Airspeed_MS4525::init()
 {
-    const struct {
-        uint8_t bus;
-        uint8_t addr;
-    } addresses[] = {
-        { 1, MS4525D0_I2C_ADDR },
-        { 0, MS4525D0_I2C_ADDR },
-        { 2, MS4525D0_I2C_ADDR },
-        { 3, MS4525D0_I2C_ADDR },
-    };
-    bool found = false;
-    for (uint8_t i=0; i<ARRAY_SIZE(addresses); i++) {
-        _dev = hal.i2c_mgr->get_device(addresses[i].bus, addresses[i].addr);
-        if (!_dev) {
-            continue;
+    const uint8_t addresses[] = { MS4525D0_I2C_ADDR1, MS4525D0_I2C_ADDR2, MS4525D0_I2C_ADDR3 };
+    if (bus_is_confgured()) {
+        // the user has configured a specific bus
+        for (uint8_t addr : addresses) {
+            if (probe(get_bus(), addr)) {
+                goto found_sensor;
+            }
         }
-        WITH_SEMAPHORE(_dev->get_semaphore());
-
-        // lots of retries during probe
-        _dev->set_retries(10);
-    
-        _measure();
-        hal.scheduler->delay(10);
-        _collect();
-
-        found = (_last_sample_time_ms != 0);
-        if (found) {
-            printf("MS4525: Found sensor on bus %u address 0x%02x\n", addresses[i].bus, addresses[i].addr);
-            break;
+    } else {
+        // if bus is not configured then fall back to the old
+        // behaviour of probing all buses, external first
+        FOREACH_I2C_EXTERNAL(bus) {
+            for (uint8_t addr : addresses) {
+                if (probe(bus, addr)) {
+                    goto found_sensor;
+                }
+            }
+        }
+        FOREACH_I2C_INTERNAL(bus) {
+            for (uint8_t addr : addresses) {
+                if (probe(bus, addr)) {
+                    goto found_sensor;
+                }
+            }
         }
     }
-    if (!found) {
-        printf("MS4525: no sensor found\n");
-        return false;
-    }
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "MS4525[%u]: no sensor found", get_instance());
+    return false;
+
+found_sensor:
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "MS4525[%u]: Found bus %u addr 0x%02x", get_instance(), _dev->bus_num(), _dev->get_bus_address());
 
     // drop to 2 retries for runtime
     _dev->set_retries(2);

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -193,8 +193,10 @@ void AP_Airspeed_MS4525::_collect()
     float temp  = _get_temperature(dT_raw);
     float temp2 = _get_temperature(dT_raw2);
     
-    _voltage_correction(press, temp);
-    _voltage_correction(press2, temp2);
+    if (!disable_voltage_correction()) {
+        _voltage_correction(press, temp);
+        _voltage_correction(press2, temp2);
+    }
 
     WITH_SEMAPHORE(sem);
 

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
@@ -58,4 +58,6 @@ private:
     uint32_t _last_sample_time_ms;
     uint32_t _measurement_started_ms;
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+
+    bool probe(uint8_t bus, uint8_t address);
 };

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
@@ -27,6 +27,7 @@
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Math/crc.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -79,13 +80,13 @@ bool AP_Airspeed_MS5525::init()
         found = read_prom();
         
         if (found) {
-            printf("MS5525: Found sensor on bus %u address 0x%02x\n", get_bus(), addresses[i]);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "MS5525[%u]: Found on bus %u addr 0x%02x", get_instance(), get_bus(), addresses[i]);
             break;
         }
         dev->get_semaphore()->give();
     }
     if (!found) {
-        printf("MS5525: no sensor found\n");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "MS5525[%u]: no sensor found", get_instance());
         return false;
     }
 

--- a/libraries/AP_Airspeed/AP_Airspeed_MSP.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MSP.cpp
@@ -6,6 +6,7 @@ AP_Airspeed_MSP::AP_Airspeed_MSP(AP_Airspeed &_frontend, uint8_t _instance, uint
     AP_Airspeed_Backend(_frontend, _instance),
     msp_instance(_msp_instance)
 {
+    set_bus_id(AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_MSP,0,msp_instance,0));
 }
 
 // return the current differential_pressure in Pascal

--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
@@ -42,6 +42,8 @@ bool AP_Airspeed_NMEA::init()
         return false;
     }
 
+    set_bus_id(AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SERIAL,0,0,0));
+
     _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_AirSpeed, 0));
 
     // make sure this sensor cannot be used in the EKF

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -127,8 +127,9 @@ bool AP_Airspeed_SDP3X::init()
             c = '3';
             break;
         }
-        hal.console->printf("SDP3%c: Found on bus %u address 0x%02x scale=%u\n",
-                            c, get_bus(), addresses[i], _scale);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SDP3%c[%u]: Found bus %u addr 0x%02x scale=%u",
+                      get_instance(),
+                      c, get_bus(), addresses[i], _scale);
     }
 
     if (!found) {

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -143,6 +143,9 @@ bool AP_Airspeed_SDP3X::init()
     set_skip_cal();
     set_offset(0);
     
+    _dev->set_device_type(uint8_t(DevType::SDP3X));
+    set_bus_id(_dev->get_bus_id());
+
     // drop to 2 retries for runtime
     _dev->set_retries(2);
 

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -115,6 +115,7 @@ bool AP_Airspeed_SDP3X::init()
 
         found = true;
 
+#ifndef HAL_NO_GCS
         char c = 'X';
         switch (_scale) {
         case SDP3X_SCALE_PRESSURE_SDP31:
@@ -130,6 +131,7 @@ bool AP_Airspeed_SDP3X::init()
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SDP3%c[%u]: Found bus %u addr 0x%02x scale=%u",
                       get_instance(),
                       c, get_bus(), addresses[i], _scale);
+#endif
     }
 
     if (!found) {

--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
@@ -63,6 +63,9 @@ AP_Airspeed_Backend* AP_Airspeed_UAVCAN::probe(AP_Airspeed &_frontend, uint8_t _
                                       "Registered UAVCAN Airspeed Node %d on Bus %d\n",
                                       _detected_modules[i].node_id,
                                       _detected_modules[i].ap_uavcan->get_driver_index());
+                backend->set_bus_id(AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_UAVCAN,
+                                                                _detected_modules[i].ap_uavcan->get_driver_index(),
+                                                                _detected_modules[i].node_id, 0));
             }
             break;
         }


### PR DESCRIPTION
This fixes several things in airspeed:
 - adds probing for all 3 possible MS4525 I2C addresses
 - obeys ARSPD_BUS on MS4525 if it has been configured, otherwise probes all for backwards compatibility
 - adds DEVID params for logging of sensor types and bus address
 - adds ARSPD_OPTIONS bit for disabling MS4525 voltage scaling
 - cleans up printf calls for sensor probing
