### PR TITLE
AP_Scripting: add binding and example for set_origin()

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -972,6 +972,7 @@ Vector2f AP_AHRS_NavEKF::groundspeed_vector(void)
 // from which to decide the origin on its own
 bool AP_AHRS_NavEKF::set_origin(const Location &loc)
 {
+    WITH_SEMAPHORE(_rsem);
 #if HAL_NAVEKF2_AVAILABLE
     const bool ret2 = EKF2.setOriginLLH(loc);
 #endif

--- a/libraries/AP_Scripting/examples/ahrs-set-origin.lua
+++ b/libraries/AP_Scripting/examples/ahrs-set-origin.lua
@@ -1,0 +1,23 @@
+-- example script for using "set_origin()"" and "initialised()"
+-- sets the ekf origin if not already set
+
+
+function update ()
+
+    if not ahrs:initialised() then
+        return update, 5000
+    end
+    
+    origin = assert(not ahrs:get_origin(),"Refused to set EKF origin - already set")
+    location = Location() location:lat(-353632640) location:lng(1491652352) location:alt(58409)
+    
+    if ahrs:set_origin(location) then
+        gcs:send_text(0, string.format("Origin Set - Lat:%.7f Long:%.7f Alt:%.1f", location:lat()/10000000, location:lng()/10000000, location:alt()/100))
+    else
+        gcs:send_text(0, "Refused to set EKF origin")
+    end
+
+    return
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -46,6 +46,8 @@ singleton AP_AHRS method set_posvelyaw_source_set void uint8_t 0 2
 singleton AP_AHRS method get_vel_innovations_and_variances_for_source boolean uint8_t 3 6 Vector3f'Null Vector3f'Null
 singleton AP_AHRS method set_home boolean Location
 singleton AP_AHRS method get_origin boolean Location'Null
+singleton AP_AHRS method set_origin boolean Location
+singleton AP_AHRS method initialised boolean
 
 include AP_Arming/AP_Arming.h
 


### PR DESCRIPTION
Added binding for setting EKF origin, now that this fix is in [https://github.com/ArduPilot/ardupilot/pull/17786](https://github.com/ArduPilot/ardupilot/pull/17786)

Tested in SITL with simulated vicon:
![set_origin console](https://user-images.githubusercontent.com/43185766/123977062-f86f7600-d9be-11eb-831a-169d14092357.JPG)
