### PR TITLE
AP_Logger: fixed log creation on forced arm

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -134,14 +134,19 @@ void AP_Logger_File::periodic_1Hz()
     }
     
     if (_initialised &&
+        !start_new_log_pending &&
         _write_fd == -1 && _read_fd == -1 &&
         logging_enabled() &&
-        !recent_open_error() &&
-        !hal.util->get_soft_armed()) {
+        !recent_open_error()) {
         // retry logging open. This allows for booting with
         // LOG_DISARMED=1 with a bad microSD or no microSD. Once a
         // card is inserted then logging starts
-        start_new_log();
+        // this also allows for logging to start after forced arming
+        if (!hal.util->get_soft_armed()) {
+            start_new_log();
+        } else {
+            start_new_log_pending = true;
+        }
     }
 
     if (!io_thread_alive()) {


### PR DESCRIPTION
when we force arm we need to ask the IO thread to create the log, not
create it ourselves
Otherwise a forced arm does not start logging. You do get a short log after you disarm, but you miss all the data from the flight