### PR TITLE
Add a "wait for throttle unlimited" stage to mode throw

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1465,9 +1465,9 @@ protected:
 private:
 
     bool throw_detected();
-    bool throw_position_good();
-    bool throw_height_good();
-    bool throw_attitude_good();
+    bool throw_position_good() const;
+    bool throw_height_good() const;
+    bool throw_attitude_good() const;
 
     // Throw stages
     enum ThrowModeStage {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1468,7 +1468,6 @@ private:
     bool throw_position_good() const;
     bool throw_height_good() const;
     bool throw_attitude_good() const;
-    bool throttle_is_unlimited() const;
 
     // Throw stages
     enum ThrowModeStage {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1468,11 +1468,13 @@ private:
     bool throw_position_good() const;
     bool throw_height_good() const;
     bool throw_attitude_good() const;
+    bool throttle_is_unlimited() const;
 
     // Throw stages
     enum ThrowModeStage {
         Throw_Disarmed,
         Throw_Detecting,
+        Throw_Wait_Throttle_Unlimited,
         Throw_Uprighting,
         Throw_HgtStabilise,
         Throw_PosHold

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -276,20 +276,20 @@ bool ModeThrow::throw_detected()
     return throw_condition_confirmed;
 }
 
-bool ModeThrow::throw_attitude_good()
+bool ModeThrow::throw_attitude_good() const
 {
     // Check that we have uprighted the copter
     const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
     return (rotMat.c.z > 0.866f); // is_upright
 }
 
-bool ModeThrow::throw_height_good()
+bool ModeThrow::throw_height_good() const
 {
     // Check that we are within 0.5m of the demanded height
     return (pos_control->get_pos_error_z_cm() < 50.0f);
 }
 
-bool ModeThrow::throw_position_good()
+bool ModeThrow::throw_position_good() const
 {
     // check that our horizontal position error is within 50cm
     return (pos_control->get_pos_error_xy_cm() < 50.0f);

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -57,7 +57,8 @@ void ModeThrow::run()
         // Cancel the waiting for throw tone sequence
         AP_Notify::flags.waiting_for_throw = false;
 
-    } else if (stage == Throw_Wait_Throttle_Unlimited && throttle_is_unlimited()) {
+    } else if (stage == Throw_Wait_Throttle_Unlimited &&
+               motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
         gcs().send_text(MAV_SEVERITY_INFO,"throttle is unlimited - uprighting");
         stage = Throw_Uprighting;
     } else if (stage == Throw_Uprighting && throw_attitude_good()) {
@@ -305,19 +306,4 @@ bool ModeThrow::throw_position_good() const
     return (pos_control->get_pos_error_xy_cm() < 50.0f);
 }
 
-bool ModeThrow::throttle_is_unlimited() const
-{
-    switch (motors->get_spool_state()) {
-    case AP_Motors::SpoolState::SHUT_DOWN:
-    case AP_Motors::SpoolState::GROUND_IDLE:
-    case AP_Motors::SpoolState::SPOOLING_UP:
-        return false;
-    case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
-        return true;
-    case AP_Motors::SpoolState::SPOOLING_DOWN:
-        return false;
-    }
-    // compiler ensures we never get here
-    return true;
-}
 #endif

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6939,7 +6939,8 @@ class AutoTestCopter(AutoTest):
 
         self.wait_altitude(100, 1000, timeout=100, relative=True)
         self.context_collect('STATUSTEXT')
-        self.wait_statustext("throw detected - uprighting", check_context=True, timeout=10)
+        self.wait_statustext("throw detected - spooling motors", check_context=True, timeout=10)
+        self.wait_statustext("throttle is unlimited - uprighting", check_context=True)
         self.wait_statustext("uprighted - controlling height", check_context=True)
         self.wait_statustext("height achieved - controlling position", check_context=True)
         self.progress("Waiting for still")
@@ -6966,8 +6967,8 @@ class AutoTestCopter(AutoTest):
             pass
 
         self.wait_altitude(100, 1000, timeout=100, relative=True)
-        self.context_collect('STATUSTEXT')
-        self.wait_statustext("throw detected - uprighting", check_context=True, timeout=10)
+        self.wait_statustext("throw detected - spooling motors", check_context=True, timeout=10)
+        self.wait_statustext("throttle is unlimited - uprighting", check_context=True)
         self.wait_statustext("uprighted - controlling height", check_context=True)
         self.wait_statustext("height achieved - controlling position", check_context=True)
         self.wait_mode('AUTO')


### PR DESCRIPTION
This PR incorporates another which adds a test for "drop mode".

It adds a stage to stop the vehicle from moving through the Throw state machine as soon as it is dropped - we've seen instances where the vehicle was tumbling in "nextmode" and it was up to that mode to right the vehicle.

Before:
![image](https://user-images.githubusercontent.com/7077857/124236666-06a5c980-db5a-11eb-9118-f625d45b7406.png)

You can see that we're in AUTO mode and the motors are still ramping up - we don't have attitude control at that point, and we won't get the benefits of throw-mode's playing around with settings to upright fast.

After, ThrowMode stays in stage 2, "wait for throttle unlimited" while the motors ramp:
![image](https://user-images.githubusercontent.com/7077857/124235765-01944a80-db59-11eb-808b-c043a2680457.png)
