### PR TITLE
AC_Fence: Set the notification level to Information

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -749,7 +749,7 @@ bool AC_PolyFence_loader::load_from_eeprom()
             boundary.points_lla = next_storage_point_lla;
             boundary.count = index.count;
             if (index.count < 3) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: invalid polygon vertex count");
+                gcs().send_text(MAV_SEVERITY_INFO, "AC_Fence: invalid polygon vertex count");
                 storage_valid = false;
                 break;
             }


### PR DESCRIPTION
I uploaded a normal polygon fence.
FC notifies "AC_Fence: invalid polygon vertex count" at warning level.
I found out that this message was being output during the process.
I think this message is informational level.

![Screenshot from 2021-07-03 17-45-25](https://user-images.githubusercontent.com/646194/124349961-ba778980-dc2c-11eb-8440-30e17cc043c5.png)

AFTER:
![Screenshot from 2021-07-03 18-23-50](https://user-images.githubusercontent.com/646194/124350032-2eb22d00-dc2d-11eb-9d8d-0a7df7c8d247.png)

BEFORE
![Screenshot from 2021-07-03 17-45-16](https://user-images.githubusercontent.com/646194/124349927-a0d64200-dc2c-11eb-97e3-b4bcd3f94e4b.png)
