### PR TITLE
Re-enable LEDs on MatekF405-bdshot

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-bdshot/hwdef.dat
@@ -2,12 +2,11 @@
 
 include ../MatekF405/hwdef.dat
 
-undef PC6 PC9 PA15 PA8
+undef PC6 PC9 PA8
 
 PC6  TIM8_CH1 TIM8 PWM(1) GPIO(50) BIDIR
 PC9  TIM8_CH4 TIM8 PWM(4) GPIO(53) BIDIR
-# Can only do bdshot on M1-4, so give up DMA channels on M5/M6 to get full DMA on USART3 and UART4
-PA15 TIM2_CH1 TIM2 PWM(5) GPIO(54) NODMA
+# Can only do bdshot on M1-4, so give up DMA channel on M6 to get full DMA on USART3
 PA8  TIM1_CH1 TIM1 PWM(6) GPIO(55) NODMA
 
 DMA_NOSHARE TIM8*


### PR DESCRIPTION
This allows PWM5 to be used with NeoPixel et al LEDs on the bdshot configuration. It means that only USART3 has full DMA on this configuration. PWM5 is the Matek recommendation for LED support. 

Discussion https://discuss.ardupilot.org/t/bi-directional-dshot-support/70210/73