### PR TITLE
AC_PrecLand/Copter: PrecLand state machine

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -113,6 +113,7 @@
 #endif
 #if PRECISION_LANDING == ENABLED
  # include <AC_PrecLand/AC_PrecLand.h>
+ # include <AC_PrecLand/AC_PrecLand_StateMachine.h>
 #endif
 #if MODE_FOLLOW_ENABLED == ENABLED
  # include <AP_Follow/AP_Follow.h>
@@ -523,6 +524,7 @@ private:
     // Precision Landing
 #if PRECISION_LANDING == ENABLED
     AC_PrecLand precland;
+    AC_PrecLand_StateMachine precland_statemachine;
 #endif
 
     // Pilot Input Management Library

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -686,6 +686,100 @@ void Mode::land_run_horizontal_control()
     }
 }
 
+#if PRECISION_LANDING == ENABLED
+// Go towards a position commanded by prec land state machine in order to retry landing
+// The passed in location is expected to be NED and in m
+void Mode::land_retry_position(const Vector3f &retry_loc)
+{
+    if (!copter.failsafe.radio) {
+        if ((g.throttle_behavior & THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND) != 0 && copter.rc_throttle_control_in_filter.get() > LAND_CANCEL_TRIGGER_THR){
+            AP::logger().Write_Event(LogEvent::LAND_CANCELLED_BY_PILOT);
+            // exit land if throttle is high
+            if (!set_mode(Mode::Number::LOITER, ModeReason::THROTTLE_LAND_ESCAPE)) {
+                set_mode(Mode::Number::ALT_HOLD, ModeReason::THROTTLE_LAND_ESCAPE);
+            }
+        }
+
+        // allow user to take control during repositioning. Note: copied from land_run_horizontal_control()
+        // To-Do: this code exists at several different places in slightly diffrent forms and that should be fixed
+        if (g.land_repositioning) {
+            float target_roll = 0.0f;
+            float target_pitch = 0.0f;
+            // convert pilot input to lean angles
+            get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
+
+            // record if pilot has overridden roll or pitch
+            if (!is_zero(target_roll) || !is_zero(target_pitch)) {
+                if (!copter.ap.land_repo_active) {
+                    AP::logger().Write_Event(LogEvent::LAND_REPO_ACTIVE);
+                }
+                // this flag will be checked by prec land state machine later and any further landing retires will be cancelled
+                copter.ap.land_repo_active = true;
+            }
+        }
+    }
+
+    Vector3p retry_loc_NEU{retry_loc.x, retry_loc.y, retry_loc.z * -1.0f};
+    //pos contoller expects input in NEU cm's
+    retry_loc_NEU = retry_loc_NEU * 100.0f;
+    pos_control->input_pos_xyz(retry_loc_NEU, 0.0f, 1000.0f);
+
+    // run position controllers
+    pos_control->update_xy_controller();
+    pos_control->update_z_controller();
+
+    const Vector3f thrust_vector{pos_control->get_thrust_vector()};
+
+    // roll, pitch from position controller, yaw heading from auto_heading()
+    attitude_control->input_thrust_vector_heading(thrust_vector, auto_yaw.yaw());
+}
+
+// Run precland statemachine. This function should be called from any mode that wants to do precision landing.
+// This handles everything from prec landing, to prec landing failures, to retries and failsafe measures
+void Mode::run_precland()
+{
+    // if user is taking control, we will not run the statemachine, and simply land (may or may not be on target)
+    if (!copter.ap.land_repo_active) {
+        // This will get updated later to a retry pos if needed
+        Vector3f retry_pos;
+
+        switch (copter.precland_statemachine.update(retry_pos)) {
+        case AC_PrecLand_StateMachine::Status::RETRYING:
+            // we want to retry landing by going to another position
+            land_retry_position(retry_pos);
+            break;
+
+        case AC_PrecLand_StateMachine::Status::FAILSAFE: {
+            // we have hit a failsafe. Failsafe can only mean two things, we either want to stop permanently till user takes over or land
+            switch (copter.precland_statemachine.get_failsafe_actions()) {
+            case AC_PrecLand_StateMachine::FailSafeAction::DESCEND:
+                // descend normally, prec land target is definitely not in sight
+                run_land_controllers();
+                break;
+            case AC_PrecLand_StateMachine::FailSafeAction::HOLD_POS:
+                // sending "true" in this argument will stop the descend
+                run_land_controllers(true);
+                break;
+            }
+            break;
+        }
+        case AC_PrecLand_StateMachine::Status::ERROR:
+            // should never happen, is certainly a bug. Report then descend
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            FALLTHROUGH;
+        case AC_PrecLand_StateMachine::Status::DESCEND:
+            // run land controller. This will descend towards the target if prec land target is in sight
+            // else it will just descend vertically
+            run_land_controllers();
+            break;
+        }
+    } else {
+        // just land, since user has taken over controls, it does not make sense to run any retries or failsafe measures
+        run_land_controllers();
+    }
+}
+#endif
+
 float Mode::throttle_hover() const
 {
     return motors->get_throttle_hover();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -115,6 +115,10 @@ protected:
     // in modes that support landing
     void land_run_horizontal_control();
     void land_run_vertical_control(bool pause_descent = false);
+    void run_land_controllers(bool pause_descent = false) {
+        land_run_horizontal_control();
+        land_run_vertical_control(pause_descent);
+    }
 
     // return expected input throttle setting to hover:
     virtual float throttle_hover() const;
@@ -240,6 +244,17 @@ public:
     };
     static AutoYaw auto_yaw;
 
+#if PRECISION_LANDING == ENABLED
+    // Go towards a position commanded by prec land state machine in order to retry landing
+    // The passed in location is expected to be NED and in meters
+    void land_retry_position(const Vector3f &retry_loc);
+
+    // Run precland statemachine. This function should be called from any mode that wants to do precision landing.
+    // This handles everything from prec landing, to prec landing failures, to retries and failsafe measures
+    void run_precland();
+
+#endif
+
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base
     // class.
@@ -251,7 +266,6 @@ public:
     GCS_Copter &gcs();
     void set_throttle_takeoff(void);
     uint16_t get_pilot_speed_dn(void);
-
     // end pass-through functions
 };
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -50,6 +50,11 @@ bool ModeAuto::init(bool ignore_checks)
         // clear guided limits
         copter.mode_guided.limit_clear();
 
+#if PRECISION_LANDING == ENABLED
+        // initialise precland state machine
+        copter.precland_statemachine.init();
+#endif
+
         return true;
     } else {
         return false;
@@ -883,9 +888,13 @@ void ModeAuto::land_run()
 
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-    
-    land_run_horizontal_control();
-    land_run_vertical_control();
+
+#if PRECISION_LANDING == ENABLED
+        // the state machine takes care of the entire landing procedure
+        run_precland();
+#else
+        run_land_controllers();
+#endif
 }
 
 // auto_rtl_run - rtl in AUTO flight mode

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -24,6 +24,12 @@ bool ModeRTL::init(bool ignore_checks)
     terrain_following_allowed = !copter.failsafe.terrain;
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     copter.ap.land_repo_active = false;
+
+#if PRECISION_LANDING == ENABLED
+    // initialise precland state machine
+    copter.precland_statemachine.init();
+#endif
+
     return true;
 }
 
@@ -407,8 +413,12 @@ void ModeRTL::land_run(bool disarm_on_land)
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
-    land_run_horizontal_control();
-    land_run_vertical_control();
+#if PRECISION_LANDING == ENABLED
+        // the state machine takes care of the entire landing procedure
+        run_precland();
+#else
+        run_land_controllers();
+#endif
 }
 
 void ModeRTL::build_path()

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -7,6 +7,7 @@
 #include "AC_PrecLand_IRLock.h"
 #include "AC_PrecLand_SITL_Gazebo.h"
 #include "AC_PrecLand_SITL.h"
+#include <GCS_MAVLink/GCS.h>
 
 #include <AP_AHRS/AP_AHRS.h>
 
@@ -15,6 +16,8 @@ extern const AP_HAL::HAL& hal;
 static const uint32_t EKF_INIT_TIME_MS = 2000; // EKF initialisation requires this many milliseconds of good sensor data
 static const uint32_t EKF_INIT_SENSOR_MIN_UPDATE_MS = 500; // Sensor must update within this many ms during EKF init, else init will fail
 static const uint32_t LANDING_TARGET_TIMEOUT_MS = 2000; // Sensor must update within this many ms, else prec landing will be switched off
+static const uint32_t LANDING_TARGET_LOST_TIMEOUT_MS = 180000; // Target will be considered as "lost" if the last known location of the target is more than this many ms ago
+static const float    LANDING_TARGET_LOST_DIST_THRESH_M  = 30; // If the last known location of the landing target is beyond this many meters, then we will consider it lost
 
 const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Param: ENABLED
@@ -121,16 +124,57 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("XY_DIST_MAX", 10, AC_PrecLand, _xy_max_dist_desc, 2.5f),
+    // @Param: STRICT
+    // @DisplayName: PrecLand strictness
+    // @Description: How strictly should the vehicle land on the target if target is lost
+    // @Values: 0: Land Vertically (Not strict), 1: Retry Landing(Normal Strictness), 2: Do not land (just Hover) (Very Strict)
+    AP_GROUPINFO("STRICT", 11, AC_PrecLand, _strict, 1),
+
+    // @Param: RET_MAX
+    // @DisplayName: PrecLand Maximum number of retires for a failed landing
+    // @Description: PrecLand Maximum number of retires for a failed landing. Set to zero to disable landing retry.
+    // @Range: 0 10
+    // @Increment: 1
+    AP_GROUPINFO("RET_MAX", 12, AC_PrecLand, _retry_max, 4),
+
+    // @Param: TIMEOUT
+    // @DisplayName: PrecLand retry timeout
+    // @Description: Time for which vehicle continues descend even if target is lost. After this time period, vehicle will attemp a landing retry depending on PLND_STRICT parameter.
+    // @Range: 0 20
+    // @Units: s
+    AP_GROUPINFO("TIMEOUT", 13, AC_PrecLand, _retry_timeout_sec, 4),
+
+    // @Param: RET_BEHAVE
+    // @DisplayName: PrecLand retry behaviour
+    // @Description: Prec Land will do the action selected by this parameter if a retry to a landing is needed
+    // @Values: 0: Go to the last location where landing target was detected, 1: Go towards the approximate location of the detected landing target
+    AP_GROUPINFO("RET_BEHAVE", 14, AC_PrecLand, _retry_behave, 0),
+
+    // @Param: ALT_MIN
+    // @DisplayName: PrecLand minimum alt for retry
+    // @Description: Vehicle will continue landing vertically even if target is lost below this height. This needs a rangefinder to work. Set to zero to disable this.
+    // @Range: 0 5
+    // @Units: m
+    AP_GROUPINFO("ALT_MIN", 15, AC_PrecLand, _sensor_min_alt, 0.75),
+
+    // @Param: ALT_MAX
+    // @DisplayName: PrecLand maximum alt for retry
+    // @Description: Vehicle will continue landing vertically until this height if target is not found. Below this height if landing target is not found, landing retry/failsafe might be attempted. This needs a rangefinder to work. Set to zero to disable this.
+    // @Range: 0 50
+    // @Units: m
+    AP_GROUPINFO("ALT_MAX", 16, AC_PrecLand, _sensor_max_alt, 8),
 
     AP_GROUPEND
 };
 
 // Default constructor.
-// Note that the Vector/Matrix constructors already implicitly zero
-// their values.
-//
 AC_PrecLand::AC_PrecLand()
 {
+    if (_singleton != nullptr) {
+        AP_HAL::panic("AC_PrecLand must be singleton");
+    }
+    _singleton = this;
+
     // set parameters to defaults
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -143,6 +187,9 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
     if (_backend != nullptr) {
         return;
     }
+
+    // init as target TARGET_NEVER_SEEN, we will update this later
+    _current_target_state = TargetState::TARGET_NEVER_SEEN;
 
     // default health to false
     _backend = nullptr;
@@ -217,11 +264,16 @@ void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
     inertial_data_newest.time_usec = AP_HAL::micros64();
     _inertial_history->push_force(inertial_data_newest);
 
+    const float rangefinder_alt_m = rangefinder_alt_cm*0.01f;  //cm to meter
+
     // update estimator of target position
     if (_backend != nullptr && _enabled) {
         _backend->update();
-        run_estimator(rangefinder_alt_cm*0.01f, rangefinder_alt_valid);
+        run_estimator(rangefinder_alt_m, rangefinder_alt_valid);
     }
+
+    // check the status of the landing target location
+    check_target_status(rangefinder_alt_m, rangefinder_alt_valid);
 
     const uint32_t now = AP_HAL::millis();
     if (now - last_log_ms > 40) {  // 25Hz
@@ -230,9 +282,92 @@ void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
     }
 }
 
+// check the status of the target
+void AC_PrecLand::check_target_status(float rangefinder_alt_m, bool rangefinder_alt_valid)
+{
+    if (target_acquired()) {
+        // target in sight
+        _current_target_state = TargetState::TARGET_FOUND;
+        // early return because we already know the status
+        return;
+    }
+
+    // target not in sight
+    if (_current_target_state == TargetState::TARGET_FOUND ||
+               _current_target_state == TargetState::TARGET_RECENTLY_LOST) {
+        // we had target in sight, but not any more, i.e we have lost the target
+        _current_target_state = TargetState::TARGET_RECENTLY_LOST;
+    } else {
+        // we never had the target in sight
+        _current_target_state = TargetState::TARGET_NEVER_SEEN;
+    }
+
+    // We definitely do not have the target in sight
+    // check if the precision landing sensor is supposed to be in range
+    // this needs a valid rangefinder to work
+    if (!check_if_sensor_in_range(rangefinder_alt_m, rangefinder_alt_valid)) {
+        // Target is not in range (vehicle is either too high or too low). Vehicle will not be attempting any sort of landing retries during this period
+        _current_target_state = TargetState::TARGET_OUT_OF_RANGE;
+        return;
+    }
+
+    if (_current_target_state == TargetState::TARGET_RECENTLY_LOST) {
+        // check if it's nearby/found recently, else the status will be demoted to "TARGET_LOST"
+        Vector2f curr_pos;
+        if (AP::ahrs().get_relative_position_NE_origin(curr_pos)) {
+            const float dist_to_last_target_loc_xy = (curr_pos - Vector2f{_last_target_pos_rel_origin_NED.x, _last_target_pos_rel_origin_NED.y}).length();
+            const float dist_to_last_loc_xy = (curr_pos - Vector2f{_last_vehicle_pos_NED.x, _last_vehicle_pos_NED.y}).length();
+            if ((AP_HAL::millis() - _last_valid_target_ms) > LANDING_TARGET_LOST_TIMEOUT_MS) {
+                // the target has not been seen for a long time
+                // might as well consider it as "never seen"
+                _current_target_state = TargetState::TARGET_NEVER_SEEN;
+                return;
+            }
+
+            if ((dist_to_last_target_loc_xy > LANDING_TARGET_LOST_DIST_THRESH_M) || (dist_to_last_loc_xy > LANDING_TARGET_LOST_DIST_THRESH_M)) {
+                // the last known location of target is too far away
+                _current_target_state = TargetState::TARGET_NEVER_SEEN;
+                return;
+            }
+        }
+    }
+}
+
+// Check if the landing target is supposed to be in sight based on the height of the vehicle from the ground
+// This needs a valid rangefinder to work, if the min/max parameters are non zero
+bool AC_PrecLand::check_if_sensor_in_range(float rangefinder_alt_m, bool rangefinder_alt_valid) const
+{
+    if (is_zero(_sensor_max_alt) && is_zero(_sensor_min_alt)) {
+        // no sensor limits have been specified, assume sensor is always in range
+        return true;
+    }
+
+    if (!rangefinder_alt_valid) {
+        // rangefinder isn't healthy. We might be at a very high altitude
+        return false;
+    }
+
+    if (rangefinder_alt_m > _sensor_max_alt && !is_zero(_sensor_max_alt)) {
+        // this prevents triggering a retry when we are too far away from the target
+        return false;
+    }
+
+    if (rangefinder_alt_m < _sensor_min_alt && !is_zero(_sensor_min_alt)) {
+        // this prevents triggering a retry when we are very close to the target
+        return false;
+    }
+
+    // target should be in range
+    return true;
+}
+
 bool AC_PrecLand::target_acquired()
 {
     if ((AP_HAL::millis()-_last_update_ms) > LANDING_TARGET_TIMEOUT_MS) {
+        if (_target_acquired) {
+            // just lost the landing target, inform the user. This message will only be sent once everytime target is lost
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PrecLand: Target Lost");
+        }
         // not had a sensor update since a long time
         // probably lost the target
         _estimator_initialized = false;
@@ -317,6 +452,10 @@ void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_va
 
             // Update if a new Line-Of-Sight measurement is available
             if (construct_pos_meas_using_rangefinder(rangefinder_alt_m, rangefinder_alt_valid)) {
+                if (!_estimator_initialized) {
+                    gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Target Found");
+                    _estimator_initialized = true;
+                }
                 _target_pos_rel_est_NE.x = _target_pos_rel_meas_NED.x;
                 _target_pos_rel_est_NE.y = _target_pos_rel_meas_NED.y;
                 _target_vel_rel_est_NE.x = -inertial_data_delayed->inertialNavVelocity.x;
@@ -334,7 +473,7 @@ void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_va
         }
         case EstimatorType::KALMAN_FILTER: {
             // Predict
-            if (target_acquired()) {
+            if (target_acquired() || _estimator_initialized) {
                 const float& dt = inertial_data_delayed->dt;
                 const Vector3f& vehicleDelVel = inertial_data_delayed->correctedVehicleDeltaVelocityNED;
 
@@ -346,6 +485,8 @@ void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_va
             if (construct_pos_meas_using_rangefinder(rangefinder_alt_m, rangefinder_alt_valid)) {
                 float xy_pos_var = sq(_target_pos_rel_meas_NED.z*(0.01f + 0.01f*AP::ahrs().get_gyro().length()) + 0.02f);
                 if (!_estimator_initialized) {
+                    // Inform the user landing target has been found
+                    gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Target Found");
                     // start init of EKF. We will let the filter consume the data for a while before it available for consumption
                     // reset filter state
                     if (inertial_data_delayed->inertialNavVelocityValid) {
@@ -401,9 +542,11 @@ void AC_PrecLand::check_ekf_init_timeout()
         if (AP_HAL::millis()-_last_update_ms > EKF_INIT_SENSOR_MIN_UPDATE_MS) {
             // we have lost the target, not enough readings to initialize the EKF
             _estimator_initialized = false;
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PrecLand: Init Failed");
         } else if (AP_HAL::millis()-_estimator_init_ms > EKF_INIT_TIME_MS) {
             // the target has been visible for a while, EKF should now have initialized to a good value
             _target_acquired = true;
+            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Init Complete");
         }
     }
 }
@@ -458,6 +601,14 @@ bool AC_PrecLand::construct_pos_meas_using_rangefinder(float rangefinder_alt_m, 
 
             // Compute target position relative to IMU
             _target_pos_rel_meas_NED = Vector3f{target_vec_unit_ned.x*dist, target_vec_unit_ned.y*dist, alt} + cam_pos_ned_rel_imu;
+
+            // store the current relative down position so that if we need to retry landing, we know at this height landing target can be found
+            const AP_AHRS &_ahrs = AP::ahrs();
+            Vector3f pos_NED;
+            if (_ahrs.get_relative_position_NED_origin(pos_NED)) {
+                _last_target_pos_rel_origin_NED.z = pos_NED.z;
+                _last_vehicle_pos_NED = pos_NED;
+            }
             return true;
         }
     }
@@ -502,6 +653,15 @@ void AC_PrecLand::run_output_prediction()
     Vector3f land_ofs_ned_m = _ahrs.get_rotation_body_to_ned() * Vector3f(_land_ofs_cm_x,_land_ofs_cm_y,0) * 0.01f;
     _target_pos_rel_out_NE.x += land_ofs_ned_m.x;
     _target_pos_rel_out_NE.y += land_ofs_ned_m.y;
+
+    // store the landing target as a offset from current position. This is used in landing retry
+    Vector2f last_target_loc_rel_origin_2d;
+    get_target_position_cm(last_target_loc_rel_origin_2d);
+    _last_target_pos_rel_origin_NED.x = last_target_loc_rel_origin_2d.x * 0.01f;
+    _last_target_pos_rel_origin_NED.y = last_target_loc_rel_origin_2d.y * 0.01f;
+
+    // record the last time there was a target output
+    _last_valid_target_ms = AP_HAL::millis();
 }
 
 // Write a precision landing entry
@@ -538,3 +698,14 @@ void AC_PrecLand::Write_Precland()
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
 
+// singleton instance
+AC_PrecLand *AC_PrecLand::_singleton;
+
+namespace AP {
+
+AC_PrecLand *ac_precland()
+{
+    return AC_PrecLand::get_singleton();
+}
+
+}

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "PosVelEKF.h"
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AC_PrecLand/AC_PrecLand_StateMachine.h>
 
 // declare backend classes
 class AC_PrecLand_Backend;
@@ -28,6 +29,11 @@ public:
     /* Do not allow copies */
     AC_PrecLand(const AC_PrecLand &other) = delete;
     AC_PrecLand &operator=(const AC_PrecLand&) = delete;
+
+    // return singleton
+    static AC_PrecLand *get_singleton() {
+        return _singleton;
+    }
 
     // perform any required initialisation of landing controllers
     // update_rate_hz should be the rate at which the update method will be called in hz
@@ -72,6 +78,32 @@ public:
     // process a LANDING_TARGET mavlink message
     void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms);
 
+    // State of the Landing Target Location
+    enum class TargetState: uint8_t {
+        TARGET_NEVER_SEEN = 0,
+        TARGET_OUT_OF_RANGE,
+        TARGET_RECENTLY_LOST,
+        TARGET_FOUND
+    };
+
+    // return the last time PrecLand library had a output of the landing target position
+    uint32_t get_last_valid_target_ms() const { return _last_valid_target_ms; }
+
+    // return the current state of the location of the target
+    TargetState get_target_state() const { return _current_target_state; }
+
+    // return the last known landing position in Earth Frame NED meters.
+    void get_last_detected_landing_pos(Vector3f &pos) const { pos = _last_target_pos_rel_origin_NED; }
+
+    // return the last known postion of the vehicle when the target was detected in Earth Frame NED meters.
+    void get_last_vehicle_pos_when_target_detected(Vector3f &pos) const { pos = _last_vehicle_pos_NED; }
+
+    // Parameter getters
+    AC_PrecLand_StateMachine::RetryStrictness get_retry_strictness() const { return static_cast<AC_PrecLand_StateMachine::RetryStrictness>(_strict.get()); }
+    uint8_t get_max_retry_allowed() const { return _retry_max; }
+    float get_min_retry_time_sec() const { return _retry_timeout_sec; }
+    AC_PrecLand_StateMachine::RetryAction get_retry_behaviour() const { return static_cast<AC_PrecLand_StateMachine::RetryAction>(_retry_behave.get()); }
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -89,6 +121,13 @@ private:
         SITL_GAZEBO = 3,
         SITL = 4,
     };
+
+    // check the status of the target
+    void check_target_status(float rangefinder_alt_m, bool rangefinder_alt_valid);
+
+    // Check if the landing target is supposed to be in sight based on the height of the vehicle from the ground
+    // This needs a valid rangefinder to work, if the min/max parameters are non zero
+    bool check_if_sensor_in_range(float rangefinder_alt_m, bool rangefinder_alt_valid) const;
 
     // check if EKF got the time to initialize when the landing target was first detected
     // Expects sensor to update within EKF_INIT_SENSOR_MIN_UPDATE_MS milliseconds till EKF_INIT_TIME_MS milliseconds have passed
@@ -120,22 +159,34 @@ private:
     AP_Float                    _accel_noise;       // accelerometer process noise
     AP_Vector3f                 _cam_offset;        // Position of the camera relative to the CG
     AP_Float                    _xy_max_dist_desc;  // Vehicle doing prec land will only descent vertically when horizontal error (in m) is below this limit
+    AP_Int8                     _strict;            // PrecLand strictness
+    AP_Int8                     _retry_max;         // PrecLand Maximum number of retires to a failed landing
+    AP_Float                    _retry_timeout_sec; // Time for which vehicle continues descend even if target is lost. After this time period, vehicle will attemp a landing retry depending on PLND_STRICT param.
+    AP_Int8                     _retry_behave;      // Action to do when trying a landing retry
+    AP_Float                    _sensor_min_alt;     // PrecLand minimum height required for detecting target
+    AP_Float                    _sensor_max_alt;     // PrecLand maximum height the sensor can detect target
+
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently after estimator is initialized
     bool                        _estimator_initialized; // true if estimator has been initialized after few seconds of the target being detected by sensor
     uint32_t                    _estimator_init_ms; // system time in millisecond when EKF was init
     uint32_t                    _last_backend_los_meas_ms;  // system time target was last seen
+    uint32_t                    _last_valid_target_ms;       // last time PrecLand library had a output of the landing target position
 
     PosVelEKF                   _ekf_x, _ekf_y;     // Kalman Filter for x and y axis
     uint32_t                    _outlier_reject_count;  // mini-EKF's outlier counter (3 consecutive outliers lead to EKF accepting updates)
-    
+
     Vector3f                    _target_pos_rel_meas_NED; // target's relative position as 3D vector
 
+    Vector3f                    _last_target_pos_rel_origin_NED;  // stores the last known location of the target horizontally, and the height of the vehicle where it detected this target in meters NED
+    Vector3f                    _last_vehicle_pos_NED;            // stores the position of the vehicle when landing target was last detected in m and NED
     Vector2f                    _target_pos_rel_est_NE; // target's position relative to the IMU, not compensated for lag
     Vector2f                    _target_vel_rel_est_NE; // target's velocity relative to the IMU, not compensated for lag
 
     Vector2f                    _target_pos_rel_out_NE; // target's position relative to the camera, fed into position controller
     Vector2f                    _target_vel_rel_out_NE; // target's velocity relative to the CG, fed into position controller
+
+    TargetState                 _current_target_state;  // Current status of the landing target
 
     // structure and buffer to hold a history of vehicle velocity
     struct inertial_data_frame_s {
@@ -157,4 +208,10 @@ private:
     // write out PREC message to log:
     void Write_Precland();
     uint32_t last_log_ms;  // last time we logged
+
+    static AC_PrecLand *_singleton; //singleton
+};
+
+namespace AP {
+    AC_PrecLand *ac_precland();
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
@@ -1,0 +1,259 @@
+#include "AC_PrecLand_StateMachine.h"
+#include <AC_PrecLand/AC_PrecLand.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+static const float MAX_POS_ERROR_M = 0.75f;  // Maximum possition error for retry locations
+static const uint32_t FAILSAFE_INIT_TIMEOUT_MS = 7000;   // Timeout in ms before failsafe measures are started. During this period vehicle is completely stopped to give user the time to take over
+static const float RETRY_OFFSET_ALT_M = 1.5f;  // This gets added to the altitude of the retry location
+
+// Initialize the state machine. This is called everytime vehicle switches mode
+void AC_PrecLand_StateMachine::init()
+{
+    // init is only called ONCE per mode change. So in a particuar mode we can retry only a finite times.
+    // The counter will be reset if the statemachine is called from a different mode
+    _retry_count = 0;
+    // reset every other statemachine
+    reset_failed_landing_statemachine();
+}
+
+// Reset the landing statemachines. This needs to be called everytime the landing target is back in sight.
+// So that if the landing target goes out of sight again, we can start the failed landing procedure back from the beginning stage
+void AC_PrecLand_StateMachine::reset_failed_landing_statemachine()
+{
+    landing_target_lost_action = TargetLostAction::INIT;
+    _retry_state = RetryLanding::INIT;
+    failsafe_initialized = false;
+}
+
+// Run Prec Land State Machine. During Prec Landing, we might encounter four scenarios:
+// 1. We had the target in sight, but have lost it now. 2. We never had the target in sight and user wants to land.
+// 3. We have the target in sight and can continue landing. 4. The sensor is out of range
+// This method deals with all of these scenarios
+// Returns the action needed to be done by the vehicle.
+// Parameters: Vector3f "retry_pos_m" is filled with the required location if we need to retry landing.
+AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::update(Vector3f &retry_pos_m)
+{
+
+    // grab the current status of Landing Target
+    AC_PrecLand *_precland = AP::ac_precland();
+    if (_precland == nullptr) {
+        // should never happen
+        return Status::ERROR;
+    }
+    AC_PrecLand::TargetState precland_target_state =  _precland->get_target_state();
+
+    switch (precland_target_state) {
+    case AC_PrecLand::TargetState::TARGET_RECENTLY_LOST:
+        // we have lost the target but had it in sight at least once recently
+        // action will depend on what user wants
+        return get_target_lost_actions(retry_pos_m);
+
+    case AC_PrecLand::TargetState::TARGET_NEVER_SEEN:
+        // we have no clue where we are supposed to be landing
+        // let user decide how strict our failsafe actions need to be
+        return Status::FAILSAFE;
+
+    case AC_PrecLand::TargetState::TARGET_OUT_OF_RANGE:
+        // The target isn't in sight, but we can't run any fail safe measures or do landing retry
+        // Therefore just descend for now, and check again later if retry is allowed
+    case AC_PrecLand::TargetState::TARGET_FOUND:
+        // no action required, target is in sight
+        reset_failed_landing_statemachine();
+        return Status::DESCEND;
+    }
+
+    // should never reach here, all values are handled above
+    return Status::ERROR;
+}
+
+
+// Target is lost (i.e we had it in sight some time back), this method helps decide on what needs to be done next
+// The chosen action depends on user set landing strictness and will be returned by this function
+// Parameters: Vector3f "retry_pos_m" is filled with the required location if we need to retry landing.
+AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::get_target_lost_actions(Vector3f &retry_pos_m)
+{
+    AC_PrecLand *_precland = AP::ac_precland();
+    if (_precland == nullptr) {
+        // should never happen
+        return Status::ERROR;
+    }
+
+    switch (landing_target_lost_action) {
+    case TargetLostAction::INIT: {
+        // figure out how strict the user is with the landing
+        const RetryStrictness strictness =_precland->get_retry_strictness();
+        switch (strictness) {
+            case RetryStrictness::NORMAL:
+            case RetryStrictness::VERY_STRICT:
+                // We eventually want to retry landing, but lets descend for some time and hope the target gets in sight
+                // If not, we will retry landing
+                landing_target_lost_action = TargetLostAction::DESCEND;
+                break;
+            case RetryStrictness::NOT_STRICT:
+                // User just wants to land, prec land isn't a priority
+                landing_target_lost_action = TargetLostAction::LAND_VERTICALLY;
+                break;
+        }
+        // at this stage we will be descending no matter what
+        // so no special action required
+        return Status::DESCEND;
+    }
+
+    case TargetLostAction::DESCEND:
+        if (AP_HAL::millis() - _precland->get_last_valid_target_ms() >=_precland->get_min_retry_time_sec() * 1000) {
+            // we have descended for some time and the target still isn't in sight
+            // lets retry
+            landing_target_lost_action = TargetLostAction::RETRY_LANDING;
+            _retry_state = RetryLanding::INIT;
+        }
+        // still descending, no other action
+        return Status::DESCEND;
+
+    case TargetLostAction::RETRY_LANDING:
+        // retry the landing by going to another position
+        return retry_landing(retry_pos_m);
+
+    case TargetLostAction::LAND_VERTICALLY:
+        // Just land vertically
+        // we will not be retrying to any location here on, so return false
+        return Status::DESCEND;
+    }
+
+    // should never reach here, all cases are handled above
+    return Status::ERROR;
+}
+
+// Retry landing based on a previously known location of the landing target
+// Returns the action that should be taken by the vehicle
+// Vector3f "retry_pos_m" is filled with the required location.
+AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3f &retry_pos_m)
+{
+    AC_PrecLand *_precland = AP::ac_precland();
+    if (_precland == nullptr) {
+        // should never happen
+        return Status::ERROR;
+    }
+
+    if (_precland->get_max_retry_allowed() == 0) {
+        // user does not want retry
+        return Status::FAILSAFE;
+    }
+
+    if (_retry_count > _precland->get_max_retry_allowed()) {
+        // we have exhausted the amount of times vehicle was allowed to retry landing
+        // do failsafe measure so the vehicle isn't stuck in a constant loop
+        return Status::FAILSAFE;
+    }
+
+    // get the retry position. This depends on what retry behavior has been set by user
+    Vector3f go_to_pos;
+    const RetryAction retry_action = _precland->get_retry_behaviour();
+    if (retry_action == RetryAction::GO_TO_TARGET_LOC) {
+        _precland->get_last_detected_landing_pos(go_to_pos);
+    } else if (retry_action == RetryAction::GO_TO_LAST_LOC) {
+        _precland->get_last_vehicle_pos_when_target_detected(go_to_pos);
+    }
+
+    // add a little bit offset so the vehicle climbs slightly higher than where it was
+    // remember this is "D" frame and in meters's
+    go_to_pos.z -= RETRY_OFFSET_ALT_M;
+
+    switch (_retry_state) {
+    case RetryLanding::INIT:
+        // Init the Retry
+        _retry_count ++;
+        _retry_state = RetryLanding::IN_PROGRESS;
+        // inform the user what we are doing
+        if (_retry_count <= _precland->get_max_retry_allowed()) {
+            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Retrying");
+        }
+        retry_pos_m = go_to_pos;
+        return Status::RETRYING;
+
+    case RetryLanding::IN_PROGRESS: {
+        // continue converging towards the target till we are close by
+        retry_pos_m = go_to_pos;
+        Vector3f pos;
+        if (!AP::ahrs().get_relative_position_NED_origin(pos)) {
+            return Status::ERROR;
+        }
+        const float dist_to_target = (go_to_pos-pos).length();
+        if ((dist_to_target < MAX_POS_ERROR_M)) {
+            // we have approx reached landing location previously detected
+            _retry_state = RetryLanding::DESCEND;
+        }
+        return Status::RETRYING;
+    }
+
+    case RetryLanding::DESCEND: {
+        // descend a little bit before completing the retry
+        // This will descend to the original height of where landing target was first detected
+        Vector3f pos;
+        if (!AP::ahrs().get_relative_position_NED_origin(pos)) {
+            return Status::ERROR;
+        }
+        // z_target is in "D" frame
+        const float z_target = go_to_pos.z + RETRY_OFFSET_ALT_M;
+        retry_pos_m = Vector3f{pos.x, pos.y, z_target};
+        if (fabsf(pos.z - retry_pos_m.z) < MAX_POS_ERROR_M) {
+            // we have descended to the original height where we started the climb from
+            _retry_state = RetryLanding::COMPLETE;
+            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Retry Completed");
+        }
+        return Status::RETRYING;
+    }
+
+    case RetryLanding::COMPLETE:
+        // Vehicle has completed a retry, and most likely the landing location still isn't sight
+        // we have no choice but to force a failsafe action
+        return Status::FAILSAFE;
+    }
+
+    // should never reach here
+    return Status::ERROR;
+}
+
+// This is only called when the current status of the state machine returns "failsafe" and will return the action that the vehicle should do
+// At the moment this method only allows you to stop in air permanently, or land vertically
+// Failsafe will only trigger as a last resort
+AC_PrecLand_StateMachine::FailSafeAction AC_PrecLand_StateMachine::get_failsafe_actions()
+{
+    AC_PrecLand *_precland = AP::ac_precland();
+    if (_precland == nullptr) {
+        // should never happen, just descend
+        return FailSafeAction::DESCEND;
+    }
+
+    if (!failsafe_initialized) {
+        // start the timer
+        failsafe_start_ms = AP_HAL::millis();
+        failsafe_initialized = true;
+        gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Failsafe Measures");
+    }
+
+    // Depending on the strictness we will either land vertically, wait for some time and then land vertically, not land at all
+    const RetryStrictness strictness= _precland->get_retry_strictness();
+    switch (strictness) {
+    case RetryStrictness::VERY_STRICT:
+        // user does not want to land on anything but the target
+        // stop landing (hover)
+        return FailSafeAction::HOLD_POS;
+
+    case RetryStrictness::NORMAL:
+        if (AP_HAL::millis() - failsafe_start_ms < FAILSAFE_INIT_TIMEOUT_MS) {
+            // stop the vehicle for at least a few seconds before descending
+            // this might give user the chance to take over
+            // we do not want to be too linent in landing vertically because of the strictness set by the user
+            return FailSafeAction::HOLD_POS;
+        }
+        // land the vehicle vertically
+        return FailSafeAction::DESCEND;
+
+    case RetryStrictness::NOT_STRICT:
+        // User wants to prioritize landing over staying in the air
+        return FailSafeAction::DESCEND;
+    }
+
+    // should never reach here
+    return FailSafeAction::DESCEND;
+}

--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
+
+// This class constantly monitors what the status of the landing target is
+// If it is not in sight, depending on user parameters, it decides what measures can be taken to bring the target back in sight
+// If the target has been lost recently, the vehicle might try to retry the landing by going to the last known location of the target/going to the location where the target was last detected
+// If we have no clue where the target might be, then failsafe measures are activated
+// Failsafe measures can include stopping completely (hover), or landing vertically
+class AC_PrecLand_StateMachine {
+public:
+
+    // Constructor
+    AC_PrecLand_StateMachine() {
+        init();
+    };
+
+    // Do not allow copies
+    AC_PrecLand_StateMachine(const AC_PrecLand_StateMachine &other) = delete;
+    AC_PrecLand_StateMachine &operator=(const AC_PrecLand_StateMachine&) = delete;
+
+    // Initialize the state machine. This is called everytime vehicle switches mode
+    void init();
+
+    // Current status of the precland state machine
+    enum class Status: uint8_t {
+        ERROR = 0,               // Unknown error
+        DESCEND,                 // No action is required, just descend vertically
+        RETRYING,                // Vehicle is attempting to retry landing
+        FAILSAFE                 // Switch to prec landing failsafe
+    };
+
+    // FailSafe action needed
+    enum class FailSafeAction: uint8_t {
+        HOLD_POS = 0,            // Hold the current position of the vehicle
+        DESCEND                  // Descend vertically
+    };
+
+    // Run Prec Land State Machine. During Prec Landing, we might encounter four scenarios:
+    // 1. We had the target in sight, but have lost it now. 2. We never had the target in sight and user wants to land.
+    // 3. We have the target in sight and can continue landing. 4. The sensor is out of range
+    // This method deals with all of these scenarios
+    // Returns the action needed to be done by the vehicle.
+    // Parameters: Vector3f "retry_pos_m" is filled with the required location if we need to retry landing.
+    Status update(Vector3f &retry_pos_m);
+
+    // This is only called when the current status of the state machine returns "failsafe" and will return the action that the vehicle should do
+    // At the moment this method only allows you to stop in air permanently, or land vertically
+    // Failsafe will only trigger as a last resort
+    FailSafeAction get_failsafe_actions();
+
+    // Strictness that the user wants for Prec Landing
+    enum class RetryStrictness: uint8_t {
+        NOT_STRICT = 0,         // This is the behaviour on Copter 4.1 and below. The vehicle will land ASAP irrespective of target in sight or not
+        NORMAL,                 // Vehicle will retry a failed prec landing; if the target isn't found, it will land vertically
+        VERY_STRICT             // Same as above, except vehicle will never land if the target isn't found
+    };
+
+    // which retry action should be done
+    enum class RetryAction: uint8_t {
+        GO_TO_LAST_LOC = 0,     // Go to the last location where landing target was detected
+        GO_TO_TARGET_LOC        // Go towards the location of the detected landing target
+    };
+
+private:
+
+    // Target is lost (i.e we had it in sight some time back), this method helps decide on what needs to be done next
+    // The chosen action depends on user set landing strictness and will be returned by this function
+    // Parameters: Vector3f "retry_pos_m" is filled with the required location if we need to retry landing.
+    Status get_target_lost_actions(Vector3f &retry_pos_m);
+
+    // Retry landing based on a previously known location of the landing target
+    // Returns the action that should be taken by the vehicle
+    // Vector3f "retry_pos_m" is filled with the required location.
+    Status retry_landing(Vector3f &retry_pos_m);
+
+    // Reset the landing statemachine. This needs to be called everytime the landing target is back in sight.
+    // So that if the landing target goes out of sight again, we can start the failed landing procedure back from the beginning stage
+    void reset_failed_landing_statemachine();
+
+    // State machine for action to do when Landing target is lost (after it was in sight a while back)
+    enum class TargetLostAction: uint8_t {
+        INIT = 0,               // Decide on what action needs to be taken
+        DESCEND,                // Descend for sometime (happens if we have just lost the target)
+        LAND_VERTICALLY,        // Land vertically
+        RETRY_LANDING,          // Retry landing (only possible if we had the landing target in sight sometime during the flight)
+    };
+
+    TargetLostAction landing_target_lost_action;  // Current action being done in the Lost Landing target state machine
+
+    // State Machine for landing retry
+    enum class RetryLanding : uint8_t {
+        INIT = 0,               // Init the retry statemachine. This would involve increasing the retry counter (so we how many times we have already retried)
+        IN_PROGRESS,            // Retry in progress, we wait for the vehicle to get close to the target location
+        DESCEND,                // Descend to the original height from where we had started the retry
+        COMPLETE                // Retry completed. We try failsafe measures after this
+    };
+    RetryLanding _retry_state;   // Current action being done in the Landing retry state machine
+    uint8_t _retry_count;       // Total number of retires done in this mode
+
+    bool failsafe_initialized;  // True if failsafe has been initalized
+    uint32_t failsafe_start_ms; // timestamp of when failsafe was triggered
+
+};


### PR DESCRIPTION
This is an early draft of a state machine that allows us to retry prec landing, as well as initiate, fail-safe measures in case we can't land on target.

This is another implementation of: https://github.com/ArduPilot/ardupilot/pull/17480 . A lot of the ideas were picked from that PR.
The major difference in this PR is that it entirely uses Position Controller only, and does not rely on WP controller. 

The basic workflow of the PR is:
1. Status of the Landing target is grabbed from AC_PrecLand (is it visible/lost/recently lost/out of range)
2. Depending on the strictness the user wants (set by PLND_STRICT), we decide if we want to retry landing or do a failsafe measure
3. If we have had a landing target sighting nearby before the target was lost, we will go towards the landing target at a height it was detected at. This is called a "landing retry" and can only be done a finite number of times (as set by the user).
4. If we have no idea where the landing target might be, failsafe measures are triggered.
5. Failsafe again depends on what the strictness of the landing is. If very strict, the copter will hover there till the user takes over. If it isn't strict, then it's just going to land vertically.