### PR TITLE
AP_Math: Update implementation of Quaternion::from_axis_angle() and to_axis_angle()

### DIFF
--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -490,12 +490,13 @@ void Quaternion::to_axis_angle(Vector3f &v) const
     const float sin_half_theta_sq = sq(q2, q3, q4);
     const float &cos_half_theta = q1;
 
-    float vec_coeff;
+    float vec_coeff = 0.0f;
     // Each use of APPROXIMATION_TOL is multiplied by 0.5 since trig values are being compared
     // and sin(x/2) ~= x/2 and cos((pi - x)/2) ~= x/2 for small x
     if (sin_half_theta_sq < 0.25f * APPROXIMATION_TOL * APPROXIMATION_TOL) {
         if (is_zero(cos_half_theta)) {
-            vec_coeff = 0.0f; // The code goes here if the quaternion is [0,0,0,0]. Really shouldn't happen.
+            // The code goes here if the quaternion is [0,0,0,0]. This shouldn't happen.
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         } else {
             const float cos_half_theta_sq = sq(cos_half_theta);
             vec_coeff = (2.0f - 2.0f / 3.0f * sin_half_theta_sq / cos_half_theta_sq) / cos_half_theta;

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -482,74 +482,38 @@ void Quaternion::rotate(const Vector3f &v)
 
 // convert this quaternion to a rotation vector where the direction of the vector represents
 // the axis of rotation and the length of the vector represents the angle of rotation
+// Algorithm source:
+// Christoph Hertzberg, Rene Wagner, Udo Frese, et al. Integrating Generic Sensor Fusion Algorithms with Sound State
+// Representations through Encapsulation of Manifolds. 2011. arXiv:1107.1119 [cs.RO].1
 void Quaternion::to_axis_angle(Vector3f &v) const
 {
-    const float l = sqrtf(sq(q2)+sq(q3)+sq(q4));
-    v = Vector3f(q2,q3,q4);
-    if (!is_zero(l)) {
-        v /= l;
-        v *= wrap_PI(2.0f * atan2f(l,q1));
+    const float sin_half_theta_sq = sq(q2, q3, q4);
+    const float &cos_half_theta = q1;
+
+    float vec_coeff;
+    // Each use of APPROXIMATION_TOL is multiplied by 0.5 since trig values are being compared
+    // and sin(x/2) ~= x/2 and cos((pi - x)/2) ~= x/2 for small x
+    if (sin_half_theta_sq < 0.25f * APPROXIMATION_TOL * APPROXIMATION_TOL) {
+        if (is_zero(cos_half_theta)) {
+            vec_coeff = 0.0f; // The code goes here if the quaternion is [0,0,0,0]. Really shouldn't happen.
+        } else {
+            const float cos_half_theta_sq = sq(cos_half_theta);
+            vec_coeff = (2.0f - 2.0f / 3.0f * sin_half_theta_sq / cos_half_theta_sq) / cos_half_theta;
+        }
+    } else {
+        float sin_half_theta = sqrtf(sin_half_theta_sq);
+
+        // Check the sign of cos(theta/2) and flip signs of the operands to atan2 as appropriate
+        // This folds wrap_PI() inside evaluation of atan2()
+        // atan2() also elegantly handles the case of cos_half_theta ~= 0
+        const float half_theta = is_negative(cos_half_theta) ? atan2f(-sin_half_theta, -cos_half_theta)
+                                                                : atan2f(sin_half_theta, cos_half_theta);
+        vec_coeff = 2.0f * half_theta / sin_half_theta;
+        
     }
-}
-
-// create a quaternion from its axis-angle representation
-// only use with small angles.  I.e. length of v should less than 0.17 radians (i.e. 10 degrees)
-void Quaternion::from_axis_angle_fast(Vector3f v)
-{
-    const float theta = v.length();
-    if (is_zero(theta)) {
-        q1 = 1.0f;
-        q2=q3=q4=0.0f;
-        return;
-    }
-    v /= theta;
-    from_axis_angle_fast(v,theta);
-}
-
-// create a quaternion from its axis-angle representation
-// theta should less than 0.17 radians (i.e. 10 degrees)
-void Quaternion::from_axis_angle_fast(const Vector3f &axis, float theta)
-{
-    const float t2 = theta/2.0f;
-    const float sqt2 = sq(t2);
-    const float st2 = t2-sqt2*t2/6.0f;
-
-    q1 = 1.0f-(sqt2/2.0f)+sq(sqt2)/24.0f;
-    q2 = axis.x * st2;
-    q3 = axis.y * st2;
-    q4 = axis.z * st2;
-}
-
-// rotate by the provided axis angle
-// only use with small angles.  I.e. length of v should less than 0.17 radians (i.e. 10 degrees)
-void Quaternion::rotate_fast(const Vector3f &v)
-{
-    const float theta = v.length();
-    if (is_zero(theta)) {
-        return;
-    }
-    const float t2 = theta/2.0f;
-    const float sqt2 = sq(t2);
-    float st2 = t2-sqt2*t2/6.0f;
-    st2 /= theta;
-
-    //"rotation quaternion"
-    const float w2 = 1.0f-(sqt2/2.0f)+sq(sqt2)/24.0f;
-    const float x2 = v.x * st2;
-    const float y2 = v.y * st2;
-    const float z2 = v.z * st2;
-
-    //copy our quaternion
-    const float w1 = q1;
-    const float x1 = q2;
-    const float y1 = q3;
-    const float z1 = q4;
-
-    //do the multiply into our quaternion
-    q1 = w1*w2 - x1*x2 - y1*y2 - z1*z2;
-    q2 = w1*x2 + x1*w2 + y1*z2 - z1*y2;
-    q3 = w1*y2 - x1*z2 + y1*w2 + z1*x2;
-    q4 = w1*z2 + x1*y2 - y1*x2 + z1*w2;
+    v.x = vec_coeff * q2;
+    v.y = vec_coeff * q3;
+    v.z = vec_coeff * q4;
 }
 
 // get euler roll angle

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -102,17 +102,6 @@ public:
     // rotate by the provided rotation vector
     void        rotate(const Vector3f &v);
 
-    // create a quaternion from a rotation vector
-    // only use with small angles.  I.e. length of v should less than 0.17 radians (i.e. 10 degrees)
-    void        from_axis_angle_fast(Vector3f v);
-
-    // create a quaternion from its axis-angle representation
-    // the axis vector must be length 1, theta should less than 0.17 radians (i.e. 10 degrees)
-    void        from_axis_angle_fast(const Vector3f &axis, float theta);
-
-    // rotate by the provided rotation vector
-    // only use with small angles.  I.e. length of v should less than 0.17 radians (i.e. 10 degrees)
-    void        rotate_fast(const Vector3f &v);
 
     // get euler roll angle
     float       get_euler_roll() const;

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -93,7 +93,7 @@ public:
 
     // create a quaternion from a rotation vector where the direction of the vector represents
     // the axis of rotation and the length of the vector represents the angle of rotation
-    void        from_axis_angle(Vector3f v);
+    void        from_axis_angle(const Vector3f &v);
 
     // create a quaternion from its axis-angle representation
     // the axis vector must be length 1. the rotation angle theta is in radians

--- a/libraries/AP_Math/tests/test_quaternion.cpp
+++ b/libraries/AP_Math/tests/test_quaternion.cpp
@@ -69,9 +69,27 @@ TEST(QuaternionConversionTest, GeneralQuaternionToRotationVector) {
     EXPECT_NEAR(res.z, -1.4125197f, 1e-6f);
 }
 
+// Tests that the quaternion to rotation matrix conversion formula is correctly derived from the Hamilton's quaternion
+// multiplication convention. This specific example is taken from "Why and How to Avoid the Flipped Quaternion
+// Multiplication" (https://arxiv.org/pdf/1801.07478.pdf)
+TEST(QuaternionConversionTest, QuaternionToRotationMatrix) {
+    Matrix3f res;
+    Quaternion(0.5f * sqrtf(2.0f), 0.0f, 0.0f, 0.5f * sqrtf(2.0f)).rotation_matrix(res);
+
+    EXPECT_NEAR(res.a.x, 0.0f, 1e-6f);
+    EXPECT_NEAR(res.a.y, -1.0f, 1e-6f);
+    EXPECT_NEAR(res.a.z, 0.0f, 1e-6f);
+    EXPECT_NEAR(res.b.x, 1.0f, 1e-6f);
+    EXPECT_NEAR(res.b.y, 0.0f, 1e-6f);
+    EXPECT_NEAR(res.b.z, 0.0f, 1e-6f);
+    EXPECT_NEAR(res.c.x, 0.0f, 1e-6f);
+    EXPECT_NEAR(res.c.y, 0.0f, 1e-6f);
+    EXPECT_NEAR(res.c.z, 1.0f, 1e-6f);
+}
+
 // Tests that quaternion multiplication obeys Hamilton's quaternion multiplication convention
 // i*i == j*j == k*k == i*j*k == -1
-TEST(QuaternionTest, QuaternionMultiplicationOfBases) {
+TEST(QuaternionAlgebraTest, QuaternionMultiplicationOfBases) {
     const Quaternion unit(1.0f, 0.0f, 0.0f, 0.0f);
     const Quaternion i(0.0f, 1.0f, 0.0f, 0.0f);
     const Quaternion j(0.0f, 0.0f, 1.0f, 0.0f);
@@ -107,27 +125,9 @@ TEST(QuaternionTest, QuaternionMultiplicationOfBases) {
     }
 }
 
-// Tests that the quaternion to rotation matrix conversion formula is correctly derived from the Hamilton's quaternion
-// multiplication convention. This specific example is taken from "Why and How to Avoid the Flipped Quaternion
-// Multiplication" (https://arxiv.org/pdf/1801.07478.pdf)
-TEST(QuaternionTest, QuaternionToRotationMatrix) {
-    Matrix3f res;
-    Quaternion(0.5f * sqrtf(2.0f), 0.0f, 0.0f, 0.5f * sqrtf(2.0f)).rotation_matrix(res);
-
-    EXPECT_NEAR(res.a.x, 0.0f, 1e-6f);
-    EXPECT_NEAR(res.a.y, -1.0f, 1e-6f);
-    EXPECT_NEAR(res.a.z, 0.0f, 1e-6f);
-    EXPECT_NEAR(res.b.x, 1.0f, 1e-6f);
-    EXPECT_NEAR(res.b.y, 0.0f, 1e-6f);
-    EXPECT_NEAR(res.b.z, 0.0f, 1e-6f);
-    EXPECT_NEAR(res.c.x, 0.0f, 1e-6f);
-    EXPECT_NEAR(res.c.y, 0.0f, 1e-6f);
-    EXPECT_NEAR(res.c.z, 1.0f, 1e-6f);
-}
-
 // Tests that quaternion multiplication is homomorphic with rotation matrix
 // multiplication, or C(q0 * q1) = C(q0) * C(q1)
-TEST(QuaternionTest, QuaternionMultiplicationIsHomomorphism) {
+TEST(QuaternionAlgebraTest, QuaternionMultiplicationIsHomomorphism) {
     Quaternion l_quat(0.8365163f, 0.48296291f, 0.22414387f, -0.12940952f);
     Quaternion r_quat(0.9576622f, 0.03378266f, 0.12607862f, 0.25660481f);
 
@@ -151,7 +151,7 @@ TEST(QuaternionTest, QuaternionMultiplicationIsHomomorphism) {
 }
 
 // Tests that applying a rotation by a unit quaternion does nothing
-TEST(QuaternionTest, QuatenionRotationByUnitQuaternion) {
+TEST(QuaternionAlgebraTest, QuatenionRotationByUnitQuaternion) {
     Vector3f v(1.0f, 2.0f, 3.0f);
     Quaternion q(1.0f, 0.0f, 0.0f, 0.0f);
 
@@ -163,9 +163,9 @@ TEST(QuaternionTest, QuatenionRotationByUnitQuaternion) {
 }
 
 // Tests that applying a rotation by a quaternion whose axis is parallel to the vector does nothing
-TEST(QuaternionTest, QuatenionRotationByParallelQuaternion) {
+TEST(QuaternionAlgebraTest, QuatenionRotationByParallelQuaternion) {
     Vector3f v(1.0f, 2.0f, 3.0f);
-    Quaternion q(0.730296743340221, 0.182574185835055, 0.365148371670111, 0.547722557505166f);
+    Quaternion q(0.7302967f, 0.1825742f, 0.3651484f, 0.5477226f);
 
     Vector3f res = q * v;
 
@@ -174,8 +174,8 @@ TEST(QuaternionTest, QuatenionRotationByParallelQuaternion) {
     }
 }
 
-// Tests that applying a rotation by a unit quaternion does not change the vector's length
-TEST(QuaternionTest, QuatenionRotationLengthPreserving) {
+// Tests that applying a rotation by any quaternion does not change the vector's length
+TEST(QuaternionAlgebraTest, QuatenionRotationLengthPreserving) {
     Vector3f v(1.0f, 2.0f, 3.0f);
     Quaternion q(0.8365163f, 0.48296291f, 0.22414387f, -0.12940952f);
 
@@ -186,7 +186,7 @@ TEST(QuaternionTest, QuatenionRotationLengthPreserving) {
 
 // Tests that calling the quaternion rotation operator is equivalent to the formula q * v * q.inverse(), and to
 // converting to rotation matrix followed by matrix multiplication
-TEST(QuaternionTest, QuatenionRotationFormulaEquivalence) {
+TEST(QuaternionAlgebraTest, QuatenionRotationFormulaEquivalence) {
     Vector3f res_1, res_0, res_2;
     Vector3f v(1.0f, 2.0f, 3.0f);
     Quaternion q(0.8365163f, 0.48296291f, 0.22414387f, -0.12940952f);
@@ -209,7 +209,7 @@ TEST(QuaternionTest, QuatenionRotationFormulaEquivalence) {
 
 // Tests that the calling the rotation operator on a inverted quaternion is equivalent to q.inverse() * v * q, and to
 // converting to rotation matrix, taking transpose, followed by matrix multiplication
-TEST(QuaternionTest, QuatenionInverseRotationFormulaEquivalence) {
+TEST(QuaternionAlgebraTest, QuatenionInverseRotationFormulaEquivalence) {
     Vector3f res_0, res_1, res_2;
     Vector3f v(1.0f, 2.0f, 3.0f);
     Quaternion q(0.8365163f, 0.48296291f, 0.22414387f, -0.12940952f);

--- a/libraries/AP_Math/tests/test_quaternion.cpp
+++ b/libraries/AP_Math/tests/test_quaternion.cpp
@@ -2,6 +2,73 @@
 
 #include <AP_Math/AP_Math.h>
 
+TEST(QuaternionConversionTest, SpecialRotationVectorToQuaternion) {
+    const Vector3f small_vec(1e-4f, -2e-4f, 3e-4f);
+
+    Quaternion res;
+    res.from_axis_angle(small_vec);
+
+    // Check if the Taylor series approximations of quaternion coefficients violate the unit-length constraint
+    EXPECT_FLOAT_EQ(res.length(), 1.0f);
+    EXPECT_NEAR(res.q1, 1.0f, 1e-6f);
+    EXPECT_NEAR(res.q2, 5e-5f, 1e-6f);
+    EXPECT_NEAR(res.q3, -1e-4, 1e-6f);
+    EXPECT_NEAR(res.q4, 1.5e-4f, 1e-6f);
+}
+
+TEST(QuaternionConversionTest, GeneralRotationVectorToQuaternion) {
+    const Vector3f vec(-0.43192759f, -0.21596379f, 0.43192759f);
+
+    Quaternion res;
+    res.from_axis_angle(vec);
+    const float half_theta = 0.323945691482636f;
+    const float re_coeff = cosf(half_theta);
+    const float im_coeff = sinf(half_theta);
+
+    EXPECT_NEAR(res.q1, re_coeff, 1e-6f);
+    EXPECT_NEAR(res.q2, -2.0f / 3.0f * im_coeff, 1e-6f);
+    EXPECT_NEAR(res.q3, -1.0f / 3.0f * im_coeff, 1e-6f);
+    EXPECT_NEAR(res.q4, 2.0f / 3.0f * im_coeff, 1e-6f);
+}
+
+TEST(QuaternionConversionTest, SpecialQuaternionToRotationVector) {
+    Vector3f res;
+
+    Quaternion small_quat(1.0f, 1.15e-3f, 2.5e-4f, -7.5e-5f);
+    small_quat.to_axis_angle(res);
+    EXPECT_NEAR(res.x, 0.0023f, 1e-6f);
+    EXPECT_NEAR(res.y, 5e-4f, 1e-6f);
+    EXPECT_NEAR(res.z, -1.5e-4f, 1e-6f);
+
+    Quaternion approx_gt_pi_quat(-0.0042036f, 0.6329564f, 0.1941979f, 0.7494236f);
+    approx_gt_pi_quat.to_axis_angle(res);
+    EXPECT_NEAR(res.x, -1.9831872f, 1e-6f);
+    EXPECT_NEAR(res.y, -0.6084635f, 1e-6f);
+    EXPECT_NEAR(res.z, -2.3481037f, 1e-6f);
+
+    Quaternion approx_lt_pi_quat(0.0057963f, 0.7191047f, 0.3164257f, 0.6186515f);
+    approx_lt_pi_quat.to_axis_angle(res);
+    EXPECT_NEAR(res.x, 2.2508355f, 1e-6f);
+    EXPECT_NEAR(res.y, 0.990429f, 1e-6f);
+    EXPECT_NEAR(res.z, 1.9364116f, 1e-6f);
+}
+
+TEST(QuaternionConversionTest, GeneralQuaternionToRotationVector) {
+    Vector3f res;
+
+    Quaternion lt_pi_quat(0.3623578f, 0.6702449f, 0.2949261f, 0.576617f);
+    lt_pi_quat.to_axis_angle(res);
+    EXPECT_NEAR(res.x, 1.7258802f, 1e-6f);
+    EXPECT_NEAR(res.y, 0.7594344f, 1e-6f);
+    EXPECT_NEAR(res.z, 1.4847885f, 1e-6f);
+
+    Quaternion gt_pi_quat(-0.4161468f, 0.653891f, 0.2877299f, 0.5625476f);
+    gt_pi_quat.to_axis_angle(res);
+    EXPECT_NEAR(res.x, -1.6418768f, 1e-6f);
+    EXPECT_NEAR(res.y, -0.7224706f, 1e-6f);
+    EXPECT_NEAR(res.z, -1.4125197f, 1e-6f);
+}
+
 // Tests that quaternion multiplication obeys Hamilton's quaternion multiplication convention
 // i*i == j*j == k*k == i*j*k == -1
 TEST(QuaternionTest, QuaternionMultiplicationOfBases) {
@@ -164,3 +231,4 @@ TEST(QuaternionTest, QuatenionInverseRotationFormulaEquivalence) {
 }
 
 AP_GTEST_MAIN()
+int hal = 0; // Needed to ensure test builds, see last line of test_3d_lines.cpp


### PR DESCRIPTION
New algorithm for `Quaternion::from_axis_angle()` and `to_axis_angle()` checks if the input represents a small rotation and switches to fast, trig-free, Taylor-series approximation of the output. The new algorithm also subsumes the purpose of `from_axis_angle_fast()`, which are unused throughout the codebase and deleted. 

Implementations are jointly inspired by [Ceres's](https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/rotation.h) `ceres::QuaternionToAngleAxis()`/`ceres::AngleAxisToQuaternion()` and [Sophus's](https://github.com/strasdat/Sophus/blob/master/sophus/so3.hpp)`Sophus::SO3::exp()`/`Sophus::SO3::log()`


