### PR TITLE
move to using tool instead of tools program group

### DIFF
--- a/Tools/CPUInfo/Makefile
+++ b/Tools/CPUInfo/Makefile
@@ -3,7 +3,7 @@
 all:
 	@cd ../../ && modules/waf/waf-light configure --board linux --debug
 	@cd ../../ && modules/waf/waf-light tools
-	@cp ../../build/linux/tools/CPUInfo CPUInfo.elf
+	@cp ../../build/linux/tool/CPUInfo CPUInfo.elf
 	@echo Built CPUInfo.elf
 
 clean:

--- a/Tools/CPUInfo/wscript
+++ b/Tools/CPUInfo/wscript
@@ -4,5 +4,5 @@
 def build(bld):
     bld.ap_program(
         use='ap',
-        program_groups='tools',
+        program_groups=['tool'],
     )

--- a/Tools/Replay/Makefile
+++ b/Tools/Replay/Makefile
@@ -2,8 +2,8 @@
 
 all:
 	@cd ../../ && modules/waf/waf-light configure --board sitl --debug --disable-scripting
-	@cd ../../ && modules/waf/waf-light --target tools/Replay
-	@cp ../../build/sitl/tools/Replay Replay.elf
+	@cd ../../ && modules/waf/waf-light --target tool/Replay
+	@cp ../../build/sitl/tool/Replay Replay.elf
 	@echo Built Replay.elf
 
 clean:

--- a/Tools/Replay/check_replay_branch.py
+++ b/Tools/Replay/check_replay_branch.py
@@ -95,7 +95,7 @@ class CheckReplayBranch(object):
         subprocess.check_call(["./waf", "replay"])
 
     def run_replay_on_log(self, logfile_path):
-        subprocess.check_call(["./build/sitl/tools/Replay", logfile_path])
+        subprocess.check_call(["./build/sitl/tool/Replay", logfile_path])
 
     def get_logs(self):
         return sorted(glob.glob("logs/*.BIN"))

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -23,6 +23,6 @@ def build(bld):
     )
 
     bld.ap_program(
-        program_groups=['tools','replay'],
+        program_groups=['tool','replay'],
         use=vehicle + '_libs',
     )

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -129,6 +129,8 @@ def ap_autoconfigure(execute_method):
         """
         Wraps :py:func:`waflib.Context.Context.execute` on the context class
         """
+        if 'tools/' in self.targets:
+            raise Errors.WafError('\"tools\" name has been replaced with \"tool\" for build please use that!')
         if not Configure.autoconfig:
             return execute_method(self)
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6777,7 +6777,7 @@ class AutoTestCopter(AutoTest):
     def test_replay(self):
         '''test replay correctness'''
         self.progress("Building Replay")
-        util.build_SITL('tools/Replay', clean=False, configure=False)
+        util.build_SITL('tool/Replay', clean=False, configure=False)
 
         self.test_replay_bit(self.test_replay_gps_bit)
         self.test_replay_bit(self.test_replay_beacon_bit)
@@ -6790,7 +6790,7 @@ class AutoTestCopter(AutoTest):
 
         self.progress("Running replay on (%s)" % current_log_filepath)
 
-        util.run_cmd(['build/sitl/tools/Replay', current_log_filepath],
+        util.run_cmd(['build/sitl/tool/Replay', current_log_filepath],
                      directory=util.topdir(), checkfail=True, show=True)
 
         self.context_pop()

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -272,7 +272,7 @@ for t in $CI_BUILD_TARGET; do
         $waf replay
         echo "Building AP_DAL standalone test"
         $waf configure --board sitl --debug --disable-scripting --no-gcs
-        $waf --target tools/AP_DAL_Standalone
+        $waf --target tool/AP_DAL_Standalone
         $waf clean
         continue
     fi

--- a/libraries/AP_DAL/examples/AP_DAL_Standalone/wscript
+++ b/libraries/AP_DAL/examples/AP_DAL_Standalone/wscript
@@ -21,6 +21,6 @@ def build(bld):
     # only valid to build with no GCS and no scripting
     if '-DHAL_NO_GCS=1' in bld.env.CXXFLAGS and 'ENABLE_SCRIPTING=1' not in bld.env.DEFINES:
         bld.ap_program(
-            program_groups=['tools'],
+            program_groups=['tool'],
             use='AP_DAL_libs',
         )

--- a/wscript
+++ b/wscript
@@ -681,7 +681,7 @@ for name in ('antennatracker', 'copter', 'heli', 'plane', 'rover', 'sub', 'blimp
         doc='builds %s programs' % name,
     )
 
-for program_group in ('all', 'bin', 'tools', 'examples', 'tests', 'benchmarks'):
+for program_group in ('all', 'bin', 'tool', 'examples', 'tests', 'benchmarks'):
     ardupilotwaf.build_command(program_group,
         program_group_list=program_group,
         doc='builds all programs of %s group' % program_group,


### PR DESCRIPTION
Some file system formats are case insensitive, like macOS where the system is case aware but case insensitive. This creates an issue when building tools, as we have a directory where the Tools objects are placed under `Tools/CPUInfo` directory and when time comes to generate binary `tools\CPUInfo` things don't go well as the binary name conflicts with directory name.