### PR TITLE
AP_Arming: Add parameter to send pre-arm failure messages

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -19,6 +19,21 @@ const AP_Param::GroupInfo AP_Arming_Plane::var_info[] = {
   additional arming checks for plane
 
  */
+void AP_Arming_Plane::update(void)
+{
+    static uint8_t pre_arm_display_counter = PREARM_DISPLAY_PERIOD/2;
+    pre_arm_display_counter++;
+    bool display_fail = false;
+    if (pre_arm_display_counter >= PREARM_DISPLAY_PERIOD) {
+        display_fail = true;
+        pre_arm_display_counter = 0;
+    }
+
+    AP_Notify::flags.pre_arm_check = pre_arm_checks(get_display_failed_checks() || display_fail);
+    AP_Notify::flags.pre_arm_gps_check = true;
+    AP_Notify::flags.armed = is_armed() || arming_required() == AP_Arming::Required::NO;
+}
+
 bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
 {
     //are arming checks disabled?

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -18,6 +18,7 @@ public:
     AP_Arming_Plane(const AP_Arming_Plane &other) = delete;
     AP_Arming_Plane &operator=(const AP_Arming_Plane&) = delete;
 
+    void update(void);
     bool pre_arm_checks(bool report) override;
     bool arm_checks(AP_Arming::Method method) override;
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -278,7 +278,7 @@ void Plane::one_second_loop()
     SRV_Channels::enable_aux_servos();
 
     // update notify flags
-    AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);
+    AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(arming.get_display_failed_checks());
     AP_Notify::flags.pre_arm_gps_check = true;
     AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::Required::NO;
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -278,9 +278,7 @@ void Plane::one_second_loop()
     SRV_Channels::enable_aux_servos();
 
     // update notify flags
-    AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(arming.get_display_failed_checks());
-    AP_Notify::flags.pre_arm_gps_check = true;
-    AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::Required::NO;
+    arming.update();
 
 #if AP_TERRAIN_AVAILABLE
     if (should_log(MASK_LOG_GPS)) {

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -290,3 +290,7 @@
 #ifndef FS_EKF_THRESHOLD_DEFAULT
  # define FS_EKF_THRESHOLD_DEFAULT      0.8f    // EKF failsafe's default compass and velocity variance threshold above which the EKF failsafe will be triggered
 #endif
+
+#ifndef PREARM_DISPLAY_PERIOD
+# define PREARM_DISPLAY_PERIOD 30
+#endif

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -122,6 +122,8 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
+    AP_GROUPINFO("DISPLAY",      9,     AP_Arming,  display_failed_checks,   false),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -124,6 +124,9 @@ public:
     // vehicle has been disarmed at least once.
     Method last_disarm_method() const { return _last_disarm_method; } 
 
+    // TODO: something useful here
+    bool get_display_failed_checks() { return display_failed_checks; }
+
 protected:
 
     // Parameters
@@ -131,7 +134,8 @@ protected:
     AP_Int32                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
-    AP_Int32                 _required_mission_items;
+    AP_Int32                _required_mission_items;
+    AP_Int8                 display_failed_checks;
 
     // internal members
     bool                    armed;


### PR DESCRIPTION
This came up after a long session of working out why the sad tones (P_NOTIFY_TONE_QUIET_NOT_READY_OR_NOT_FINISHED) were playing on a vehicle. Turned out to be a I2C issue, but getting there took time. This parameter allows for knowing why the sad tones are playing and keeping everyone, including the vehicle, happier.

Now the way I have done this might not be great. Copter already has a nice arming update method with a counter to display these messages every 30 seconds. Plane just has `false`. The issue comes when there is a really quick sad tones happy tones coming from the buzzer that I don't think would be captured by the Copter implementation. On the trouble vehicle the sequence of tones was too quick for an arming command to be sent and have the pre-arm checks listed the normal way.

Currently failing CI vehicle tests because of a parameter xml check. Not exactly sure which xml I need to update.

Tested on CubeBlack with "faulty" airspeed check.