### PR TITLE
waf: allow overriding uploader script with custom uploader script

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -56,7 +56,11 @@ class upload_fw(Task.Task):
         upload_tools = self.env.get_flat('UPLOAD_TOOLS')
         upload_port = self.generator.bld.options.upload_port
         src = self.inputs[0]
-        cmd = "{} '{}/uploader.py' '{}'".format(self.env.get_flat('PYTHON'), upload_tools, src)
+        # Refer Tools/scripts/macos_remote_upload.sh for details
+        if 'AP_OVERRIDE_UPLOAD_CMD' in os.environ:
+            cmd = "{} '{}'".format(os.environ['AP_OVERRIDE_UPLOAD_CMD'], src.abspath())
+        else:
+            cmd = "{} '{}/uploader.py' '{}'".format(self.env.get_flat('PYTHON'), upload_tools, src)
         if upload_port is not None:
             cmd += " '--port' '%s'" % upload_port
         return self.exec_command(cmd)

--- a/Tools/scripts/macos_remote_upload.sh
+++ b/Tools/scripts/macos_remote_upload.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# allows uploading firmware via ssh from remote computer to 
+# device connected to macos system
+# place export AP_OVERRIDE_UPLOAD_CMD=". /path/to/macos_remote_upload.sh" to bashrc
+# to use this
+USER_HOST=user@hostname # please edit this with macos ssh 
+tmpdir=$(ssh $USER_HOST mktemp -d)
+filename=$(basename $@)
+uploader=$(realpath $(dirname $@))/../../../Tools/scripts/uploader.py
+scp $@ $USER_HOST:$tmpdir/
+scp $uploader $USER_HOST:$tmpdir/
+#  source "\$HOME/.bash_profile" && $tmpdir/uploader.py $tmpdir/$filename
+ssh $USER_HOST /bin/bash << ENDSSH
+source ~/.bash_profile
+$tmpdir/uploader.py $tmpdir/$filename
+rm -r $tmpdir
+ENDSSH


### PR DESCRIPTION
This allows for writing an alternate uploader script. 
My particular use case is to do development and builds on a high performance remote machine over SSH on my notebook. And still be able to upload firmware using --upload command with hardware connected to my notebook. So I use a custom script for the same.