### PR TITLE
Copter and Plane: Allow alt-frames to be set

### DIFF
--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -8,6 +8,10 @@
 // called at 1hz
 void Copter::fence_check()
 {
+    if (fence.conv_alt_frame()) {
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Alt frame change successful");
+    }
+    
     const uint8_t orig_breaches = fence.get_breaches();
 
     // check for new breaches; new_breaches is bitmask of fence types breached

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -7,6 +7,10 @@
 // fence_check - ask fence library to check for breaches and initiate the response
 void Plane::fence_check()
 {
+    if (fence.conv_alt_frame()) {
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Alt frame change successful");
+    }
+    
     const uint8_t orig_breaches = fence.get_breaches();
 
     // check for new breaches; new_breaches is bitmask of fence types breached

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -3,6 +3,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Param/AP_Param.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -108,6 +109,13 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @User: Standard
     AP_GROUPINFO_FRAME("AUTOENABLE", 10, AC_Fence, _auto_enabled, static_cast<uint8_t>(AutoEnable::ALWAYS_DISABLED), AP_PARAM_FRAME_PLANE),
 
+    // @Param: ALT_FRAME
+    // @DisplayName: Fence Altitude Frame
+    // @Description: Frame for min and max altitude, default is 1
+    // @Values: 0:MSL,1:REL/HOME
+    // @User: Standard
+    AP_GROUPINFO_FRAME("ALT_FRAME", 11, AC_Fence, _alt_frame_ext, AC_FENCE_ALT_FRAME_DEFAULT, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_SUB | AP_PARAM_FRAME_TRICOPTER | AP_PARAM_FRAME_HELI | AP_PARAM_FRAME_PLANE),
+
     AP_GROUPEND
 };
 
@@ -121,6 +129,8 @@ AC_Fence::AC_Fence()
 #endif
     _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
+
+    _alt_frame = _alt_frame_ext;
 }
 
 /// enable the Fence code generally; a master switch for all fences
@@ -433,6 +443,32 @@ bool AC_Fence::check_fence_alt_min()
         _alt_min_breach_distance = 0.0f;
     }
 
+    return false;
+}
+
+// returns true if alt-frame is converted successfully
+bool AC_Fence::conv_alt_frame()
+{
+    if (_alt_frame != _alt_frame_ext) {
+        int32_t _new_max_alt_cm, _new_min_alt_cm;
+        if (fenceloc.get_spec_alt_cm(static_cast<Location::AltFrame>(int(_alt_frame)), Location::AltFrame((int)_alt_frame_ext), _alt_max * 100.0f, _new_max_alt_cm)) {
+            _alt_max = (int) _new_max_alt_cm / 100.0f;
+            AP_Param::set_and_save_by_name("FENCE_ALT_MAX", _alt_max);
+        } else {
+            gcs().send_text(MAV_SEVERITY_NOTICE, "Max alt frame change not accepted, current frame is..."); // Finish, return false
+            return false;
+        }
+    
+        if (fenceloc.get_spec_alt_cm(static_cast<Location::AltFrame>(int(_alt_frame)), Location::AltFrame((int)_alt_frame_ext), _alt_min * 100.0f, _new_min_alt_cm)) {
+            _alt_min = (int) _new_min_alt_cm / 100.0f;
+            AP_Param::set_and_save_by_name("FENCE_ALT_MIN", _alt_min);
+        } else {
+            gcs().send_text(MAV_SEVERITY_NOTICE, "Min alt frame change not accepted, current frame is..."); // Finish, return false
+            return false;
+        }
+        _alt_frame = _alt_frame_ext;
+        return true;
+    }
     return false;
 }
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -32,6 +32,7 @@
 #define AC_FENCE_ALT_MIN_BACKUP_DISTANCE            20.0f   // after fence is broken we recreate the fence 20m further down
 #define AC_FENCE_CIRCLE_RADIUS_BACKUP_DISTANCE      20.0f   // after fence is broken we recreate the fence 20m further out
 #define AC_FENCE_MARGIN_DEFAULT                     2.0f    // default distance in meters that autopilot's should maintain from the fence to avoid a breach
+#define AC_FENCE_ALT_FRAME_DEFAULT                  1       // default altitude frame is rel; MSL = 0, REL/HOME = 1, ORIGIN = 2, TERRAIN = 3
 
 // give up distance
 #define AC_FENCE_GIVE_UP_DISTANCE                   100.0f  // distance outside the fence at which we should give up and just land.  Note: this is not used by library directly but is intended to be used by the main code
@@ -57,6 +58,9 @@ public:
 
     void init() {
         _poly_loader.init();
+        AP_Param::set_and_save_by_name("FENCE_ALT_MAX", AC_FENCE_ALT_MAX_DEFAULT);
+        AP_Param::set_and_save_by_name("FENCE_ALT_FRAME", AC_FENCE_ALT_FRAME_DEFAULT);
+        AP_Param::set_and_save_by_name("FENCE_ALT_MIN", AC_FENCE_ALT_MIN_DEFAULT);
     }
 
     // get singleton instance
@@ -146,6 +150,9 @@ public:
     ///     has no effect if no breaches have occurred
     void manual_recovery_start();
 
+    // method for setting alt frames
+    bool conv_alt_frame();
+
     // methods for mavlink SYS_STATUS message (send_sys_status)
     bool sys_status_present() const;
     bool sys_status_enabled() const;
@@ -194,6 +201,8 @@ private:
     AP_Int8         _total;                 // number of polygon points saved in eeprom
     AP_Int8         _ret_rally;             // return to fence return point or rally point/home
     AP_Int16        _ret_altitude;          // return to this altitude
+    AP_Int8         _alt_frame;             // frame that alt_max and alt_min are currently in
+    AP_Int8         _alt_frame_ext;         // front facing alt frame
 
     // backup fences
     float           _alt_max_backup;        // backup altitude upper limit in meters used to refire the breach if the vehicle continues to move further away
@@ -221,6 +230,7 @@ private:
 
 
     AC_PolyFence_loader _poly_loader{_total}; // polygon fence
+    Location        fenceloc;
 };
 
 namespace AP {

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -44,6 +44,8 @@ public:
     // can only happen if the original frame or desired frame is above-terrain
     bool get_alt_cm(AltFrame desired_frame, int32_t &ret_alt_cm) const WARN_IF_UNUSED;
 
+    bool get_spec_alt_cm(AltFrame current_frame, AltFrame desired_frame, int32_t _alt_conv, int32_t &ret_alt_cm) const;
+
     // get altitude frame
     AltFrame get_alt_frame() const;
 


### PR DESCRIPTION
Applies to fence max altitude frame and min altitude frame.

References this PR: https://github.com/ArduPilot/ardupilot/pull/16452 