### PR TITLE
AP_HAL_SITL: implement read(buf, length)

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -180,12 +180,16 @@ uint32_t UARTDriver::txspace(void)
 
 int16_t UARTDriver::read(void)
 {
-    if (available() <= 0) {
+    uint8_t c;
+    if (read(&c, 1) == 0) {
         return -1;
     }
-    uint8_t c;
-    _readbuffer.read(&c, 1);
     return c;
+}
+
+ssize_t UARTDriver::read(uint8_t *buffer, uint16_t count)
+{
+    return _readbuffer.read(buffer, count);
 }
 
 bool UARTDriver::discard_input(void)

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -48,6 +48,7 @@ public:
     uint32_t available() override;
     uint32_t txspace() override;
     int16_t read() override;
+    ssize_t read(uint8_t *buffer, uint16_t count) override;
 
     bool discard_input() override;
 


### PR DESCRIPTION
This replaces the base-class implementation which just loops using `read()`
