### PR TITLE
Move set_blocking_writes method up to AP_HAL::UARTDriver

### DIFF
--- a/libraries/AP_Common/tests/test_nmea_print.cpp
+++ b/libraries/AP_Common/tests/test_nmea_print.cpp
@@ -11,7 +11,6 @@ public:
     void end() override {  };
     void flush() override {  };
     bool is_initialized() override { return true; };
-    void set_blocking_writes(bool blocking) override {  };
     bool tx_pending() override { return false; };
     uint32_t available() override { return 1; };
     uint32_t txspace() override { return _txspace; };

--- a/libraries/AP_Common/tests/test_nmea_vaprint.cpp
+++ b/libraries/AP_Common/tests/test_nmea_vaprint.cpp
@@ -49,7 +49,6 @@ public:
     void end() override {  };
     void flush() override {  };
     bool is_initialized() override { return true; };
-    void set_blocking_writes(bool blocking) override {  };
     bool tx_pending() override { return false; };
     uint32_t available() override { return 1; };
     uint32_t txspace() override { return _txspace; };

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -41,7 +41,9 @@ public:
     virtual void end() = 0;
     virtual void flush() = 0;
     virtual bool is_initialized() = 0;
-    virtual void set_blocking_writes(bool blocking) = 0;
+    void set_blocking_writes(bool blocking) {
+        _blocking_writes = blocking;
+    };
     virtual bool tx_pending() = 0;
 
     // lock a port for exclusive use. Use a key of 0 to unlock
@@ -136,4 +138,7 @@ public:
      */
     virtual bool set_RTS_pin(bool high) { return false; };
     virtual bool set_CTS_pin(bool high) { return false; };
+
+protected:
+    bool _blocking_writes;
 };

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -601,11 +601,6 @@ bool UARTDriver::is_initialized()
     return _tx_initialised && _rx_initialised;
 }
 
-void UARTDriver::set_blocking_writes(bool blocking)
-{
-    _blocking_writes = blocking;
-}
-
 bool UARTDriver::tx_pending() { return false; }
 
 /* Empty implementations of Stream virtual methods */

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -41,7 +41,6 @@ public:
     void end() override;
     void flush() override;
     bool is_initialized() override;
-    void set_blocking_writes(bool blocking) override;
     bool tx_pending() override;
 
 
@@ -202,7 +201,6 @@ private:
 #endif
     volatile bool _in_rx_timer;
     volatile bool _in_tx_timer;
-    bool _blocking_writes;
     volatile bool _rx_initialised;
     volatile bool _tx_initialised;
     volatile bool _device_initialised;

--- a/libraries/AP_HAL_Empty/UARTDriver.cpp
+++ b/libraries/AP_HAL_Empty/UARTDriver.cpp
@@ -9,7 +9,6 @@ void Empty::UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS) {}
 void Empty::UARTDriver::end() {}
 void Empty::UARTDriver::flush() {}
 bool Empty::UARTDriver::is_initialized() { return false; }
-void Empty::UARTDriver::set_blocking_writes(bool blocking) {}
 bool Empty::UARTDriver::tx_pending() { return false; }
 
 /* Empty implementations of Stream virtual methods */

--- a/libraries/AP_HAL_Empty/UARTDriver.h
+++ b/libraries/AP_HAL_Empty/UARTDriver.h
@@ -11,7 +11,6 @@ public:
     void end() override;
     void flush() override;
     bool is_initialized() override;
-    void set_blocking_writes(bool blocking) override;
     bool tx_pending() override;
 
     /* Empty implementations of Stream virtual methods */

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -241,15 +241,6 @@ bool UARTDriver::is_initialized()
 
 
 /*
-  enable or disable blocking writes
- */
-void UARTDriver::set_blocking_writes(bool blocking)
-{
-    _nonblocking_writes = !blocking;
-}
-
-
-/*
   do we have any bytes pending transmission?
  */
 bool UARTDriver::tx_pending()
@@ -313,7 +304,7 @@ size_t UARTDriver::write(uint8_t c)
     }
 
     while (_writebuf.space() == 0) {
-        if (_nonblocking_writes) {
+        if (!_blocking_writes) {
             _write_mutex.give();
             return 0;
         }
@@ -335,7 +326,7 @@ size_t UARTDriver::write(const uint8_t *buffer, size_t size)
     if (!_write_mutex.take_nonblocking()) {
         return 0;
     }
-    if (!_nonblocking_writes) {
+    if (_blocking_writes) {
         /*
           use the per-byte delay loop in write() above for blocking writes
          */

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -23,7 +23,6 @@ public:
     void end() override;
     void flush() override;
     bool is_initialized() override;
-    void set_blocking_writes(bool blocking) override;
     bool tx_pending() override;
 
     /* Linux implementations of Stream virtual methods */
@@ -71,7 +70,6 @@ public:
 
 private:
     AP_HAL::OwnPtr<SerialDevice> _device;
-    bool _nonblocking_writes;
     bool _console;
     volatile bool _in_timer;
     uint16_t _base_port;

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -35,11 +35,6 @@ public:
 
     ssize_t get_system_outqueue_length() const;
 
-    void set_blocking_writes(bool blocking) override
-    {
-        _nonblocking_writes = !blocking;
-    }
-
     bool tx_pending() override {
         return false;
     }
@@ -94,7 +89,6 @@ private:
     struct sockaddr_in _listen_sockaddr;
     int _serial_port;
     static bool _console;
-    bool _nonblocking_writes;
     ByteBuffer _readbuffer{16384};
     ByteBuffer _writebuffer{16384};
 


### PR DESCRIPTION
Makes this simple boolean state part of the base class.

Inverts the boolean on HAL_Linux and HAL_SITL to match HAL_ChibiOS
