### PR TITLE
EKF: Initialize stateStruct.quat to unit length

### DIFF
--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -626,6 +626,9 @@ void QuaternionT<T>::normalize(void)
         q2 *= quatMagInv;
         q3 *= quatMagInv;
         q4 *= quatMagInv;
+    } else {
+        // The code goes here if the quaternion is [0,0,0,0]. This shouldn't happen.
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     }
 }
 
@@ -708,6 +711,12 @@ QuaternionT<T> QuaternionT<T>::operator/(const QuaternionT<T> &v) const
     const T &quat1 = q2;
     const T &quat2 = q3;
     const T &quat3 = q4;
+
+    const T quatMag = length();
+    if (is_zero(quatMag)) {
+        // The code goes here if the quaternion is [0,0,0,0]. This shouldn't happen.
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+    }
 
     const T rquat0 = v.q1;
     const T rquat1 = v.q2;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -237,6 +237,7 @@ void NavEKF2_core::InitialiseVariables()
     runUpdates = false;
     framesSincePredict = 0;
     gpsYawResetRequest = false;
+    stateStruct.quat.initialise();
     quatAtLastMagReset = stateStruct.quat;
     delAngBiasLearned = false;
     memset(&filterStatus, 0, sizeof(filterStatus));

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -461,6 +461,7 @@ void NavEKF3_core::InitialiseVariablesMag()
     magYawResetRequest = false;
     posDownAtLastMagReset = stateStruct.position.z;
     yawInnovAtLastMagReset = 0.0f;
+    stateStruct.quat.initialise();
     quatAtLastMagReset = stateStruct.quat;
     magFieldLearned = false;
     storedMag.reset();


### PR DESCRIPTION
A bug was found in this PR https://github.com/ArduPilot/ardupilot/pull/17935 that 0 length quaternions were being caught. 

It appears that `stateStruct.quat` is being initialized to [0,0,0,0] instead of [1,0,0,0]

To reproduce in master add the Internal_Error code in this PR for `Quaternion::operator/(const Quaternion &v) const`
`./Tools/autotest/sim_vehicle.py -v AntennaTracker -D --map --console --speedup 1`  
It also appears in `test.copter.motortest` but  I couldn't get it to fail locally. But it does fail on the autotest server if you look at the logs of the above PR.

I'm not sure if keeping the internal errors for vehicle code makes sense? But probably it should be kept for SITL builds?

Debug output showing stateStruct.quat in master is [0,0,0,0]:
![image](https://user-images.githubusercontent.com/69225461/125022452-bdb6af00-e04a-11eb-85cc-43dd5a979634.png)
