### PR TITLE
Get the last time when the tx write buffer got emptied

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -151,6 +151,8 @@ public:
      */
     virtual bool is_dma_enabled() const { return false; }
 
+    virtual uint32_t get_last_tx_empty_us() const { return 0; }
+
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O for this uart, for @SYS/uarts.txt
     virtual void uart_info(ExpandingString &str) {}

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -146,6 +146,11 @@ void UARTDriver::uart_thread()
         if (_tx_initialised && ((mask & EVT_TRANSMIT_DATA_READY) || need_tick || (hd_tx_active && (mask & EVT_TRANSMIT_END)))) {
             _tx_timer_tick();
         }
+
+        // record the time when a half-duplex TX buffer got emptied
+        if (_tx_initialised && hd_tx_active && (mask & EVT_TRANSMIT_END) && _writebuf.is_empty()) {
+            _last_write_completed_us = now;
+        }
     }
 }
 #pragma GCC diagnostic pop

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -131,6 +131,13 @@ public:
      */
     bool is_dma_enabled() const override { return rx_dma_enabled && tx_dma_enabled; }
 
+    // get the last time when the tx write buffer got emptied
+#if CH_CFG_USE_EVENTS == TRUE
+    uint32_t get_last_tx_empty_us() const override { return ((tx_dma_enabled || half_duplex) && _writebuf.is_empty()) ? _last_write_completed_us : 0; }
+#else
+    uint32_t get_last_tx_empty_us() const override { return (tx_dma_enabled && _writebuf.is_empty()) ? _last_write_completed_us : 0; }
+#endif
+
 private:
     const SerialDef &sdef;
     bool rx_dma_enabled;


### PR DESCRIPTION
```
Binary Name      Text [B]        Data [B]     BSS (B)        Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  --------------  -----------  -------------  ----------------------------  -------------------------
ardurover        108 (+0.0066%)  0 (0.0000%)  -4 (-0.0015%)  108 (+0.0066%)                                   337492
blimp            108 (+0.0081%)  0 (0.0000%)  4 (+0.0015%)   108 (+0.0080%)                                   623048
arducopter       108 (+0.0061%)  0 (0.0000%)  -4 (-0.0015%)  108 (+0.0061%)                                   193140
arduplane        108 (+0.0061%)  0 (0.0000%)  -4 (-0.0015%)  108 (+0.0061%)                                   201456
ardusub          108 (+0.0069%)  0 (0.0000%)  4 (+0.0015%)   108 (+0.0069%)                                   400760
antennatracker   108 (+0.0082%)  0 (0.0000%)  -4 (-0.0015%)  108 (+0.0082%)                                   645924
arducopter-heli  108 (+0.0061%)  0 (0.0000%)  -4 (-0.0015%)  108 (+0.0061%)                                   186972
```