### PR TITLE
Fixed Scurve panic in CI

### DIFF
--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -738,7 +738,7 @@ void SCurve::add_segments(float L)
 // Vm - maximum constant velocity
 // L - Length of the path
 // t2_out, t4_out, t6_out are the segment durations needed to achieve the kinimatic path specified by the input variables
-void SCurve::calculate_path(float tj, float Jm, float V0, float Am, float Vm, float L, float &Jm_out, float &t2_out, float &t4_out, float &t6_out) const
+void SCurve::calculate_path(float tj, float Jm, float V0, float Am, float Vm, float L, float &Jm_out, float &t2_out, float &t4_out, float &t6_out)
 {
     // init outputs
     Jm_out = 0.0f;
@@ -772,6 +772,7 @@ void SCurve::calculate_path(float tj, float Jm, float V0, float Am, float Vm, fl
             // solution = 2 - t6 t4 t2 = 0 1 0
             t2_out = 0.0f;
             t4_out = MIN(-(V0 - Vm + Am * tj + (Am * Am) / Jm) / Am, MAX(((Am * Am) * (-3.0f / 2.0f) + safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm), ((Am * Am) * (-3.0f / 2.0f) - safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm)));
+            t4_out = MAX(t4_out, 0.0);
             t6_out = 0.0f;
         }
     } else {
@@ -785,6 +786,7 @@ void SCurve::calculate_path(float tj, float Jm, float V0, float Am, float Vm, fl
             // solution = 7 - t6 t4 t2 = 1 1 1
             t2_out = Am / Jm - tj;
             t4_out = MIN(-(V0 - Vm + Am * tj + (Am * Am) / Jm) / Am, MAX(((Am * Am) * (-3.0f / 2.0f) + safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm), ((Am * Am) * (-3.0f / 2.0f) - safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm)));
+            t4_out = MAX(t4_out, 0.0);
             t6_out = t2_out;
         }
     }

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -52,6 +52,16 @@ public:
     // initialise and clear the path
     void init();
 
+    // calculate the segment times for the trigonometric S-Curve path defined by:
+    // tj - duration of the raised cosine jerk profile (aka jerk time)
+    // Jm - maximum value of the raised cosine jerk profile (aka jerk max)
+    // V0 - initial velocity magnitude
+    // Am - maximum constant acceleration
+    // Vm - maximum constant velocity
+    // L - Length of the path
+    // this is an internal function, static for test suite
+    static void calculate_path(float tj, float Jm, float V0, float Am, float Vm, float L, float &Jm_out, float &t2_out, float &t4_out, float &t6_out);
+
     // generate a trigonometric track in 3D space that moves over a straight line
     // between two points defined by the origin and destination
     void calculate_track(const Vector3f &origin, const Vector3f &destination,
@@ -134,15 +144,6 @@ private:
 
     // generate time segments for straight segment
     void add_segments(float L);
-
-    // calculate the segment times for the trigonometric S-Curve path defined by:
-    // tj - duration of the raised cosine jerk profile (aka jerk time)
-    // Jm - maximum value of the raised cosine jerk profile (aka jerk max)
-    // V0 - initial velocity magnitude
-    // Am - maximum constant acceleration
-    // Vm - maximum constant velocity
-    // L - Length of the path
-    void calculate_path(float tj, float Jm, float V0, float Am, float Vm, float L, float &Jm_out, float &t2_out, float &t4_out, float &t6_out) const;
 
     // generate three time segments forming the jerk profile
     void add_segments_jerk(uint8_t &seg_pnt, float tj, float Jm, float Tcj);

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -1,0 +1,21 @@
+#include <AP_gtest.h>
+
+#include <AP_Math/AP_Math.h>
+#include <AP_Math/vector2.h>
+#include <AP_Math/vector3.h>
+#include <AP_Math/SCurve.h>
+
+TEST(LinesScurve, test_calculate_path)
+{
+    float Jm_out, t2_out, t4_out, t6_out;
+    SCurve::calculate_path(0.300000012, 19.4233513, 0, 5.82700586, 188.354691, 2.09772229,
+                           Jm_out, t2_out, t4_out, t6_out);
+    EXPECT_FLOAT_EQ(Jm_out, 19.423351);
+    EXPECT_FLOAT_EQ(t2_out, 0.0);
+    EXPECT_FLOAT_EQ(t4_out, 0.0);
+    EXPECT_FLOAT_EQ(t6_out, 0.0);
+}
+
+
+AP_GTEST_MAIN()
+int hal = 0; //weirdly the build will fail without this


### PR DESCRIPTION
This fixes a case where numerical precision can lead to t4_out being negative. Added as a test suite 
