### PR TITLE
20210709 pr heli yaw check fix

### DIFF
--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -27,7 +27,7 @@ void ModeAcro::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->reset_target_and_rate();
+        attitude_control->reset_target_and_rate(true);
         attitude_control->reset_rate_controller_I_terms();
         break;
 

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -45,14 +45,14 @@ void ModeAcro_Heli::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->reset_target_and_rate();
+        attitude_control->reset_target_and_rate(false);
         attitude_control->reset_rate_controller_I_terms();
         break;
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
         if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
-            attitude_control->reset_target_and_rate();
+            attitude_control->reset_target_and_rate(false);
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -50,7 +50,7 @@ void ModeAltHold::run()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->reset_yaw_target_and_rate();
+        attitude_control->reset_yaw_target_and_rate(false);
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -91,7 +91,7 @@ void ModeDrift::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->reset_yaw_target_and_rate();
+        attitude_control->reset_yaw_target_and_rate(false);
         attitude_control->reset_rate_controller_I_terms();
         break;
 

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -102,7 +102,7 @@ void ModePosHold::run()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->reset_yaw_target_and_rate();
+        attitude_control->reset_yaw_target_and_rate(false);
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -76,7 +76,7 @@ void ModeSport::run()
 
     case AltHold_MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->reset_yaw_target_and_rate();
+        attitude_control->reset_yaw_target_and_rate(false);
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -50,14 +50,14 @@ void ModeStabilize_Heli::run()
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
-        attitude_control->reset_yaw_target_and_rate();
+        attitude_control->reset_yaw_target_and_rate(false);
         attitude_control->reset_rate_controller_I_terms();
         break;
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
         if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
-            attitude_control->reset_yaw_target_and_rate();
+            attitude_control->reset_yaw_target_and_rate(false);
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -876,18 +876,22 @@ Vector3f AC_AttitudeControl::euler_accel_limit(const Vector3f &euler_rad, const 
 }
 
 // Sets attitude target to vehicle attitude and sets all rates to zero
-void AC_AttitudeControl::reset_target_and_rate()
+// If reset_rate is false rates are not reset to allow the rate controllers to run
+void AC_AttitudeControl::reset_target_and_rate(bool reset_rate)
 {
     // move attitude target to current attitude
     _ahrs.get_quat_body_to_ned(_attitude_target);
 
-    // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
-    _ang_vel_target.zero();
-    _euler_angle_target.zero();
+    if (reset_rate) {
+        // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
+        _ang_vel_target.zero();
+        _euler_angle_target.zero();
+    }
 }
 
 // Sets yaw target to vehicle heading and sets yaw rate to zero
-void AC_AttitudeControl::reset_yaw_target_and_rate()
+// If reset_rate is false rates are not reset to allow the rate controllers to run
+void AC_AttitudeControl::reset_yaw_target_and_rate(bool reset_rate)
 {
     // move attitude target to current heading
     float yaw_shift = _ahrs.yaw - _euler_angle_target.z;
@@ -895,11 +899,13 @@ void AC_AttitudeControl::reset_yaw_target_and_rate()
     _attitude_target_update.from_axis_angle(Vector3f{0.0f, 0.0f, yaw_shift});
     _attitude_target = _attitude_target_update * _attitude_target;
 
-    // set yaw rate to zero
-    _euler_rate_target.z = 0.0f;
+    if (reset_rate) {
+        // set yaw rate to zero
+        _euler_rate_target.z = 0.0f;
 
-    // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
-    euler_rate_to_ang_vel(_euler_angle_target, _euler_rate_target, _ang_vel_target);
+        // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
+        euler_rate_to_ang_vel(_euler_angle_target, _euler_rate_target, _ang_vel_target);
+    }
 }
 
 // Shifts the target attitude to maintain the current error in the event of an EKF reset

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -133,10 +133,12 @@ public:
     void reset_rate_controller_I_terms_smoothly();
 
     // Sets attitude target to vehicle attitude and sets all rates to zero
-    void reset_target_and_rate();
+    // If reset_rate is false rates are not reset to allow the rate controllers to run
+    void reset_target_and_rate(bool reset_rate = true);
 
     // Sets yaw target to vehicle heading and sets yaw rate to zero
-    void reset_yaw_target_and_rate();
+    // If reset_rate is false rates are not reset to allow the rate controllers to run
+    void reset_yaw_target_and_rate(bool reset_rate = true);
 
     // handle reset of attitude from EKF since the last iteration
     void inertial_frame_reset();


### PR DESCRIPTION
This removes the reset of yaw rate when disarmed to let heli users check yaw control on the ground before flight.
Ironically Heli doesn't do this in their own dedicated acro mode. This makes me wonder why we are compromising more semi autonomous modes when heli didn't think it was important enough in the most manual input mode....

I have removed the reset of yaw rate during all phases of Stabilize_Heli.

I have not removed it in any aspect of Loiter as you can't check roll and pitch in this mode either.

My personal opinion is that any checks should be done in Stabilize_Heli where you can check roll, pitch, yaw and collective (or acro if they allowed it).

To summarize the behaviour:
Heli Control checks (via the rate controllers) can be run on all four axis in Acro and Stab when in Motor_Stopped and Landed_Ground_Idle .
Heli Control checks (via the rate controllers) can be run on the roll, pitch and yaw axis in non-GPS, altitude hold based modes when in Motor_Stopped.
Other actuator frame types provide direct actuator output when disarmed in all modes OR control checks (via the rate controllers) when in Motor_Stopped in non-GPS modes.