### PR TITLE
EKF: implement a moving origin

### DIFF
--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -108,9 +108,6 @@ bool Copter::far_from_EKF_origin(const Location& loc)
     // check distance to EKF origin
     Location ekf_origin;
     if (ahrs.get_origin(ekf_origin)) {
-        if ((ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_KM*1000.0)) {
-            return true;
-        }
         if (labs(ekf_origin.alt - loc.alt)*0.01 > EKF_ORIGIN_MAX_ALT_KM*1000.0) {
             return true;
         }

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -168,9 +168,6 @@
  # define FS_EKF_THRESHOLD_DEFAULT      0.8f    // EKF failsafe's default compass and velocity variance threshold above which the EKF failsafe will be triggered
 #endif
 
-#ifndef EKF_ORIGIN_MAX_DIST_KM
- # define EKF_ORIGIN_MAX_DIST_KM        250   // EKF origin and home must be within 250km horizontally
-#endif
 #ifndef EKF_ORIGIN_MAX_ALT_KM
  # define EKF_ORIGIN_MAX_ALT_KM         50   // EKF origin and home must be within 50km vertically
 #endif

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -61,7 +61,7 @@ Location::Location(const Vector3d &ekf_offset_neu, AltFrame frame)
     if (AP::ahrs().get_origin(ekf_origin)) {
         lat = ekf_origin.lat;
         lng = ekf_origin.lng;
-        offset_double(ekf_offset_neu.x * 0.01, ekf_offset_neu.y * 0.01);
+        offset(ekf_offset_neu.x * 0.01, ekf_offset_neu.y * 0.01);
     }
 }
 
@@ -284,7 +284,7 @@ Vector2F Location::get_distance_NE_ftype(const Location &loc2) const
 }
 
 // extrapolate latitude/longitude given distances (in meters) north and east
-void Location::offset(float ofs_north, float ofs_east)
+void Location::offset_latlng(int32_t &lat, int32_t &lng, ftype ofs_north, ftype ofs_east)
 {
     const int32_t dlat = ofs_north * LOCATION_SCALING_FACTOR_INV;
     const int64_t dlng = (ofs_east * LOCATION_SCALING_FACTOR_INV) / longitude_scale(lat+dlat/2);
@@ -293,12 +293,10 @@ void Location::offset(float ofs_north, float ofs_east)
     lng = wrap_longitude(dlng+lng);
 }
 
-void Location::offset_double(double ofs_north, double ofs_east)
+// extrapolate latitude/longitude given distances (in meters) north and east
+void Location::offset(ftype ofs_north, ftype ofs_east)
 {
-    const int64_t dlat = ofs_north * double(LOCATION_SCALING_FACTOR_INV);
-    const int64_t dlng = (ofs_east * double(LOCATION_SCALING_FACTOR_INV)) / longitude_scale(lat+dlat/2);
-    lat = limit_lattitude(int64_t(lat)+dlat);
-    lng = wrap_longitude(int64_t(lng)+dlng);
+    offset_latlng(lat, lng, ofs_north, ofs_east);
 }
 
 /*
@@ -326,10 +324,10 @@ void Location::offset_bearing_and_pitch(float bearing_deg, float pitch_deg, floa
 }
 
 
-float Location::longitude_scale(int32_t lat)
+ftype Location::longitude_scale(int32_t lat)
 {
-    float scale = cosf(lat * (1.0e-7f * DEG_TO_RAD));
-    return MAX(scale, 0.01f);
+    ftype scale = cosF(lat * (1.0e-7 * DEG_TO_RAD));
+    return MAX(scale, 0.01);
 }
 
 /*

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -237,10 +237,10 @@ bool Location::get_vector_from_origin_NEU(Vector3f &vec_neu) const
 }
 
 // return distance in meters between two locations
-float Location::get_distance(const struct Location &loc2) const
+ftype Location::get_distance(const struct Location &loc2) const
 {
-    float dlat = (float)(loc2.lat - lat);
-    float dlng = ((float)diff_longitude(loc2.lng,lng)) * longitude_scale((lat+loc2.lat)/2);
+    ftype dlat = (ftype)(loc2.lat - lat);
+    ftype dlng = ((ftype)diff_longitude(loc2.lng,lng)) * longitude_scale((lat+loc2.lat)/2);
     return norm(dlat, dlng) * LOCATION_SCALING_FACTOR;
 }
 
@@ -306,20 +306,20 @@ void Location::offset(ftype ofs_north, ftype ofs_east)
  * positions, so it keeps the accuracy even when dealing with small
  * distances and floating point numbers
  */
-void Location::offset_bearing(float bearing_deg, float distance)
+void Location::offset_bearing(ftype bearing_deg, ftype distance)
 {
-    const float ofs_north = cosf(radians(bearing_deg)) * distance;
-    const float ofs_east  = sinf(radians(bearing_deg)) * distance;
+    const ftype ofs_north = cosF(radians(bearing_deg)) * distance;
+    const ftype ofs_east  = sinF(radians(bearing_deg)) * distance;
     offset(ofs_north, ofs_east);
 }
 
 // extrapolate latitude/longitude given bearing, pitch and distance
-void Location::offset_bearing_and_pitch(float bearing_deg, float pitch_deg, float distance)
+void Location::offset_bearing_and_pitch(ftype bearing_deg, ftype pitch_deg, ftype distance)
 {
-    const float ofs_north =  cosf(radians(pitch_deg)) * cosf(radians(bearing_deg)) * distance;
-    const float ofs_east  =  cosf(radians(pitch_deg)) * sinf(radians(bearing_deg)) * distance;
+    const ftype ofs_north =  cosF(radians(pitch_deg)) * cosF(radians(bearing_deg)) * distance;
+    const ftype ofs_east  =  cosF(radians(pitch_deg)) * sinF(radians(bearing_deg)) * distance;
     offset(ofs_north, ofs_east);
-    const int32_t dalt =  sinf(radians(pitch_deg)) * distance *100.0f;
+    const int32_t dalt =  sinF(radians(pitch_deg)) * distance *100.0f;
     alt += dalt; 
 }
 
@@ -369,7 +369,7 @@ int32_t Location::get_bearing_to(const struct Location &loc2) const
 {
     const int32_t off_x = diff_longitude(loc2.lng,lng);
     const int32_t off_y = (loc2.lat - lat) / loc2.longitude_scale((lat+loc2.lat)/2);
-    int32_t bearing = 9000 + atan2f(-off_y, off_x) * DEGX100;
+    int32_t bearing = 9000 + atan2F(-off_y, off_x) * DEGX100;
     if (bearing < 0) {
         bearing += 36000;
     }
@@ -410,7 +410,7 @@ float Location::line_path_proportion(const Location &point1, const Location &poi
 {
     const Vector2f vec1 = point1.get_distance_NE(point2);
     const Vector2f vec2 = point1.get_distance_NE(*this);
-    const float dsquared = sq(vec1.x) + sq(vec1.y);
+    const ftype dsquared = sq(vec1.x) + sq(vec1.y);
     if (dsquared < 0.001f) {
         // the two points are very close together
         return 1.0f;

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -69,8 +69,8 @@ public:
     Vector2F get_distance_NE_ftype(const Location &loc2) const;
 
     // extrapolate latitude/longitude given distances (in meters) north and east
-    void offset(float ofs_north, float ofs_east);
-    void offset_double(double ofs_north, double ofs_east);
+    static void offset_latlng(int32_t &lat, int32_t &lng, ftype ofs_north, ftype ofs_east);
+    void offset(ftype ofs_north, ftype ofs_east);
 
     // extrapolate latitude/longitude given bearing and distance
     void offset_bearing(float bearing_deg, float distance);
@@ -82,7 +82,7 @@ public:
     // shrinking longitude as you move north or south from the equator
     // Note: this does not include the scaling to convert
     // longitude/latitude points to meters or centimeters
-    static float longitude_scale(int32_t lat);
+    static ftype longitude_scale(int32_t lat);
 
     bool is_zero(void) const WARN_IF_UNUSED;
 
@@ -128,7 +128,7 @@ public:
     
     // get lon1-lon2, wrapping at -180e7 to 180e7
     static int32_t diff_longitude(int32_t lon1, int32_t lon2);
-    
+
 private:
 
     // scaling factor from 1e-7 degrees to meters at equator

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -57,7 +57,7 @@ public:
     bool get_vector_from_origin_NEU(Vector3f &vec_neu) const WARN_IF_UNUSED;
 
     // return distance in meters between two locations
-    float get_distance(const struct Location &loc2) const;
+    ftype get_distance(const struct Location &loc2) const;
 
     // return the distance in meters in North/East/Down plane as a N/E/D vector to loc2
     Vector3f get_distance_NED(const Location &loc2) const;
@@ -73,10 +73,10 @@ public:
     void offset(ftype ofs_north, ftype ofs_east);
 
     // extrapolate latitude/longitude given bearing and distance
-    void offset_bearing(float bearing_deg, float distance);
+    void offset_bearing(ftype bearing_deg, ftype distance);
     
     // extrapolate latitude/longitude given bearing, pitch and distance
-    void offset_bearing_and_pitch(float bearing_deg, float pitch_deg, float distance);
+    void offset_bearing_and_pitch(ftype bearing_deg, ftype pitch_deg, ftype distance);
 
     // longitude_scale - returns the scaler to compensate for
     // shrinking longitude as you move north or south from the equator
@@ -91,7 +91,7 @@ public:
     // return bearing in centi-degrees from location to loc2
     int32_t get_bearing_to(const struct Location &loc2) const;
     // return the bearing in radians
-    float get_bearing(const struct Location &loc2) const { return radians(get_bearing_to(loc2) * 0.01f); } ;
+    ftype get_bearing(const struct Location &loc2) const { return radians(get_bearing_to(loc2) * 0.01); } ;
 
     // check if lat and lng match. Ignore altitude and options
     bool same_latlon_as(const Location &loc2) const;

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -104,7 +104,7 @@ TEST(Location, LatLngWrapping)
         int32_t expected_lat;
         int32_t expected_lng;
     } tests[] {
-        {519634000, 1797560000, Vector2f{0, 100000}, 519634000, -1787860774}
+        {519634000, 1797560000, Vector2f{0, 100000}, 519634000, -1787860775}
     };
 
     for (auto &test : tests) {
@@ -139,7 +139,7 @@ TEST(Location, LocOffsetDouble)
                -353632620, 1491652373,
                Vector2d{4682795.4576701336, 5953662.7673837934},
                Vector2d{4682797.1904749088, 5953664.1586009059},
-               Vector2d{1.7365739867091179,1.4261966},
+               Vector2d{1.7365739867091179,1.2050807},
     };
 
     for (auto &test : tests) {

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -146,8 +146,8 @@ TEST(Location, LocOffsetDouble)
         Location home{test.home_lat, test.home_lng, 0, Location::AltFrame::ABOVE_HOME};
         Location loc1 = home;
         Location loc2 = home;
-        loc1.offset_double(test.delta_metres_ne1.x, test.delta_metres_ne1.y);
-        loc2.offset_double(test.delta_metres_ne2.x, test.delta_metres_ne2.y);
+        loc1.offset(test.delta_metres_ne1.x, test.delta_metres_ne1.y);
+        loc2.offset(test.delta_metres_ne2.x, test.delta_metres_ne2.y);
         Vector2d diff = loc1.get_distance_NE_double(loc2);
         EXPECT_FLOAT_EQ(diff.x, test.expected_pos_change.x);
         EXPECT_FLOAT_EQ(diff.y, test.expected_pos_change.y);

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -638,7 +638,7 @@ void SITL_State::_fdm_input_local(void)
         Quaternion attitude;
         sitl_model->get_attitude(attitude);
         vicon->update(sitl_model->get_location(),
-                      sitl_model->get_position(),
+                      sitl_model->get_position_relhome(),
                       sitl_model->get_velocity_ef(),
                       attitude);
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -611,9 +611,12 @@ bool NavEKF3_core::setOrigin(const Location &loc)
     validOrigin = true;
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u origin set",(unsigned)imu_index);
 
-    // put origin in frontend as well to ensure it stays in sync between lanes
-    frontend->common_EKF_origin = EKF_origin;
-    frontend->common_origin_valid = true;
+    if (!frontend->common_origin_valid) {
+        frontend->common_origin_valid = true;
+        // put origin in frontend as well to ensure it stays in sync between lanes
+        public_origin = EKF_origin;
+    }
+
 
     return true;
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -499,7 +499,7 @@ private:
     };
 
     struct gps_elements : EKF_obs_element_t {
-        Vector2F    pos;            // horizontal North East position of the GPS antenna in local NED earth frame (m)
+        int32_t     lat, lng;       // latitude and longitude in 1e7 degrees
         ftype       hgt;            // height of the GPS antenna in local NED earth frame (m)
         Vector3F    vel;            // velocity of the GPS antenna in local NED earth frame (m/sec)
         uint8_t     sensor_idx;     // unique integer identifying the GPS sensor
@@ -1025,7 +1025,8 @@ private:
     bool needEarthBodyVarReset;     // we need to reset mag earth variances at next CovariancePrediction
     bool inhibitDelAngBiasStates;   // true when IMU delta angle bias states are inactive
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
-    struct Location EKF_origin;     // LLH origin of the NED axis system
+    struct Location EKF_origin;     // LLH origin of the NED axis system, internal only
+    struct Location &public_origin; // LLH origin of the NED axis system, public functions
     bool validOrigin;               // true when the EKF origin is valid
     ftype gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver
     ftype gpsPosAccuracy;           // estimated position accuracy in m returned by the GPS receiver
@@ -1403,7 +1404,13 @@ private:
     bool have_table_earth_field;   // true when we have initialised table_earth_field_ga
     Vector3F table_earth_field_ga; // earth field from WMM tables
     ftype table_declination;       // declination in radians from the tables
-    uint32_t last_field_update_ms;
+
+    // 1Hz update
+    uint32_t last_oneHz_ms;
+    void oneHzUpdate(void);
+
+    // move EKF origin at 1Hz
+    void moveEKFOrigin(void);
 
     // handle earth field updates
     void getEarthFieldTable(const Location &loc);

--- a/libraries/SITL/SIM_ADSB.cpp
+++ b/libraries/SITL/SIM_ADSB.cpp
@@ -192,7 +192,7 @@ void ADSB::send_report(void)
             ADSB_Vehicle &vehicle = vehicles[i];
             Location loc = home;
 
-            loc.offset_double(vehicle.position.x, vehicle.position.y);
+            loc.offset(vehicle.position.x, vehicle.position.y);
 
             // re-init when exceeding radius range
             if (home.get_distance(loc) > _sitl->adsb_radius_m) {

--- a/libraries/SITL/SIM_AirSim.cpp
+++ b/libraries/SITL/SIM_AirSim.cpp
@@ -307,7 +307,7 @@ void AirSim::recv_fdm(const sitl_input& input)
     location.lng = state.gps.lon * 1.0e7;
     location.alt = state.gps.alt * 100.0f;
 
-    position = home.get_distance_NED_double(location);
+    position = origin.get_distance_NED_double(location);
 
     dcm.from_euler(state.pose.roll, state.pose.pitch, state.pose.yaw);
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -126,7 +126,8 @@ public:
 
     const Location &get_location() const { return location; }
 
-    const Vector3d &get_position() const { return position; }
+    // get position relative to home
+    Vector3d get_position_relhome() const;
 
     // distance the rangefinder is perceiving
     float rangefinder_range() const;
@@ -152,6 +153,9 @@ public:
 
 protected:
     SITL *sitl;
+    // origin of position vector
+    Location origin;
+    // home location
     Location home;
     bool home_is_set;
     Location location;
@@ -175,6 +179,7 @@ protected:
     float battery_current;
     float local_ground_level;            // ground level at local position
     bool lock_step_scheduled;
+    uint32_t last_one_hz_ms;
 
     // battery model
     Battery battery;

--- a/libraries/SITL/SIM_CRRCSim.cpp
+++ b/libraries/SITL/SIM_CRRCSim.cpp
@@ -119,12 +119,9 @@ void CRRCSim::recv_fdm(const struct sitl_input &input)
     gyro = Vector3f(pkt.rollRate, pkt.pitchRate, pkt.yawRate);
     velocity_ef = Vector3f(pkt.speedN, pkt.speedE, pkt.speedD);
 
-    Location loc1, loc2;
-    loc2.lat = pkt.latitude * 1.0e7;
-    loc2.lng = pkt.longitude * 1.0e7;
-    const Vector2f posdelta = loc1.get_distance_NE(loc2);
-    position.x = posdelta.x;
-    position.y = posdelta.y;
+    origin.lat = pkt.latitude * 1.0e7;
+    origin.lng = pkt.longitude * 1.0e7;
+    position.xy().zero();
     position.z = -pkt.altitude;
 
     airspeed = pkt.airspeed;

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -415,6 +415,7 @@ void FlightAxis::update(const struct sitl_input &input)
     position = Vector3d(state.m_aircraftPositionY_MTR,
                         state.m_aircraftPositionX_MTR,
                         -state.m_altitudeASL_MTR - home.alt*0.01);
+    position.xy() += origin.get_distance_NE_double(home);
 
     accel_body = {
         float(state.m_accelerationBodyAX_MPS2),

--- a/libraries/SITL/SIM_Gazebo.cpp
+++ b/libraries/SITL/SIM_Gazebo.cpp
@@ -120,7 +120,7 @@ void Gazebo::recv_fdm(const struct sitl_input &input)
     position = Vector3d(pkt.position_xyz[0],
                         pkt.position_xyz[1],
                         pkt.position_xyz[2]);
-
+    position.xy() += origin.get_distance_NE_double(home);
 
     // auto-adjust to simulation frame rate
     time_now_us += static_cast<uint64_t>(deltat * 1.0e6);

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -284,6 +284,7 @@ void JSON::recv_fdm(const struct sitl_input &input)
     gyro = state.imu.gyro;
     velocity_ef = state.velocity;
     position = state.position;
+    position.xy() += origin.get_distance_NE_double(home);
 
     // deal with euler or quaternion attitude
     if ((received_bitmask & QUAT_ATT) != 0) {

--- a/libraries/SITL/SIM_Morse.cpp
+++ b/libraries/SITL/SIM_Morse.cpp
@@ -513,6 +513,7 @@ void Morse::update(const struct sitl_input &input)
                            -state.velocity.world_linear_velocity[2]);
 
     position = Vector3d(state.gps.x, -state.gps.y, -state.gps.z);
+    position.xy() += origin.get_distance_NE_double(home);
 
     // Morse IMU accel is NEU, convert to NED
     accel_body = Vector3f(state.imu.linear_acceleration[0],

--- a/libraries/SITL/SIM_SerialProximitySensor.cpp
+++ b/libraries/SITL/SIM_SerialProximitySensor.cpp
@@ -97,7 +97,7 @@ float SerialProximitySensor::measure_distance_at_angle_bf(const Location &locati
     for (int8_t x=-num_post_offset; x<num_post_offset; x++) {
         for (int8_t y=-num_post_offset; y<num_post_offset; y++) {
             Location post_location = post_origin;
-            post_location.offset_double(x*10+3, y*10+2);
+            post_location.offset(x*10+3, y*10+2);
             if (postfile != nullptr) {
                 ::fprintf(postfile, "map circle %f %f %f blue\n", post_location.lat*1e-7, post_location.lng*1e-7, radius_cm/100.0);
             }
@@ -111,8 +111,8 @@ float SerialProximitySensor::measure_distance_at_angle_bf(const Location &locati
                 float dist_cm = (intersection_point_cm-vehicle_pos_cm).length();
                 if (intersectionsfile != nullptr) {
                     Location intersection_point = location;
-                    intersection_point.offset_double(intersection_point_cm.x/100.0,
-                                                     intersection_point_cm.y/100.0);
+                    intersection_point.offset(intersection_point_cm.x/100.0,
+                                              intersection_point_cm.y/100.0);
                     ::fprintf(intersectionsfile,
                               "map icon %f %f barrell\n",
                               intersection_point.lat*1e-7,

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -85,7 +85,7 @@ Vector2f ShipSim::get_ground_speed_adjustment(const Location &loc, float &yaw_ra
         return Vector2f(0,0);
     }
     Location shiploc = home;
-    shiploc.offset_double(ship.position.x, ship.position.y);
+    shiploc.offset(ship.position.x, ship.position.y);
     if (loc.get_distance(shiploc) > deck_size) {
         yaw_rate = 0;
         return Vector2f(0,0);
@@ -172,7 +172,7 @@ void ShipSim::send_report(void)
       send a GLOBAL_POSITION_INT messages
      */
     Location loc = home;
-    loc.offset_double(ship.position.x, ship.position.y);
+    loc.offset(ship.position.x, ship.position.y);
 
     int32_t alt_mm = home.alt * 10;  // assume home altitude
 

--- a/libraries/SITL/SIM_SilentWings.cpp
+++ b/libraries/SITL/SIM_SilentWings.cpp
@@ -195,7 +195,7 @@ void SilentWings::process_packet()
     curr_location.lng = pkt.position_longitude * 1.0e7;
     curr_location.alt = pkt.altitude_msl * 100.0f;
     ground_level = curr_location.alt * 0.01f - pkt.altitude_ground;
-    Vector3f posdelta = home.get_distance_NED(curr_location);
+    Vector3f posdelta = origin.get_distance_NED(curr_location);
     position.x = posdelta.x;
     position.y = posdelta.y;
     position.z = posdelta.z;
@@ -209,6 +209,8 @@ void SilentWings::process_packet()
         // reset home location
         home.lat = curr_location.lat;
         home.lng = curr_location.lng;
+        origin.lat = home.lat;
+        origin.lng = home.lng;
         // Resetting altitude reference point in flight can throw off a bunch
         // of important calculations, so let the home altitude always be 0m MSL
         home.alt = 0;

--- a/libraries/SITL/SIM_Webots.cpp
+++ b/libraries/SITL/SIM_Webots.cpp
@@ -516,7 +516,7 @@ void Webots::update(const struct sitl_input &input)
                             -state.velocity.world_linear_velocity[2]);
         
         position = Vector3d(state.gps.x, state.gps.y, -state.gps.z);
-        
+        position.xy() += origin.get_distance_NE_double(home);
 
         // limit to 16G to match pixhawk1
         float a_limit = GRAVITY_MSS*16;

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -303,6 +303,7 @@ bool XPlane::receive_data(void)
         }
     }
     position = pos + position_zero;
+    position.xy() += origin.get_distance_NE_double(home);
     update_position();
     time_advance();
 
@@ -318,6 +319,7 @@ bool XPlane::receive_data(void)
         home.lat = loc.lat;
         home.lng = loc.lng;
         home.alt = loc.alt;
+        origin = home;
         position.x = 0;
         position.y = 0;
         position.z = 0;


### PR DESCRIPTION
This separates out the public origin in the EKF from the internal origin of the position state. The public origin is used for all exposed output data, the internal original only for the position state.
This solves a problem of the EKF becoming badly unstable at distances or more than 2000 km, where the curvature of the earth makes the flat earth model of the EKF untenable.
The internal origin is updated at 1Hz to the current position, which means the "locally flat" assumption is good
