### PR TITLE
Fix PR #17569 and analog OSD ESC telemetry

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -112,6 +112,7 @@ known_units = {
              'gravities': 'standard acceleration due to gravity' , # g_n would be a more correct unit, but IMHO no one understands what g_n means
              'octal'   : 'octal'                 ,
              'RPM'     : 'Revolutions Per Minute',
+             'kRPM'    : 'Thousands of Revolutions Per Minute',
              'kg/m/m'  : 'kilograms per square meter', # metre is the SI unit name, meter is the american spelling of it
              }
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -121,6 +121,28 @@ bool AP_ESC_Telem::get_rpm(uint8_t esc_index, float& rpm) const
     return false;
 }
 
+// get the highest ESC RPM if available, returns true if there is valid data for at least one ESC
+bool AP_ESC_Telem::get_highest_motor_rpm(float& rpm) const
+{
+    uint8_t valid_escs = 0;
+    float lh_rpm = -std::numeric_limits<float>::max();
+
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        float temp_rpm;
+        if (get_rpm(i, temp_rpm)) {
+            lh_rpm = MAX(lh_rpm, temp_rpm);
+            valid_escs++;
+        }
+    }
+
+    if (valid_escs > 0) {
+        rpm = lh_rpm;
+        return true;
+    }
+
+    return false;
+}
+
 // get an individual ESC's raw rpm if available, returns true on success
 bool AP_ESC_Telem::get_raw_rpm(uint8_t esc_index, float& rpm) const
 {

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -214,6 +214,65 @@ bool AP_ESC_Telem::get_current(uint8_t esc_index, float& amps) const
     return true;
 }
 
+// get the highest ESC current if available, returns true if there is valid data for at least one ESC
+bool AP_ESC_Telem::get_highest_current(float& amps) const
+{
+    uint8_t valid_escs = 0;
+
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        float temp_amps;
+        if (get_current(i, temp_amps)) {
+            amps = MAX(amps, temp_amps);
+            valid_escs++;
+        }
+    }
+
+    return valid_escs > 0;
+}
+
+// get the average ESC current between all ESCs if available, returns true if there is valid data for at least one ESC
+bool AP_ESC_Telem::get_average_current(float& amps_avg) const
+{
+    float amps_acc = 0.0f;
+    uint8_t valid_escs = 0;
+
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        float esc_amps;
+        if (get_current(i, esc_amps)) {
+            amps_acc += esc_amps;
+            valid_escs++;
+        }
+    }
+
+    if (valid_escs > 0) {
+        amps_avg = amps_acc / valid_escs;
+        return true;
+    }
+
+    return false;
+}
+
+// get the sum of the ESCs measured current if available, returns true if there is valid data for at least one ESC
+bool AP_ESC_Telem::get_total_current(float& amps) const
+{
+    float amps_acc = 0.0f;
+    uint8_t valid_escs = 0;
+
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        float esc_amps;
+        if (get_current(i, esc_amps)) {
+            amps_acc += esc_amps;
+        }
+    }
+
+    if (valid_escs > 0) {
+        amps = amps_acc;
+        return true;
+    }
+
+    return false;
+}
+
 // get an individual ESC's voltage in Volt if available, returns true on success
 bool AP_ESC_Telem::get_voltage(uint8_t esc_index, float& volts) const
 {

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -190,16 +190,22 @@ bool AP_ESC_Telem::get_motor_temperature(uint8_t esc_index, int16_t& temp) const
 bool AP_ESC_Telem::get_highest_temperature(int16_t& temp) const
 {
     uint8_t valid_escs = 0;
+    int16_t lh_temp = INT16_MIN;
 
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
         int16_t temp_temp;
         if (get_temperature(i, temp_temp)) {
-            temp = MAX(temp, temp_temp);
+            lh_temp = MAX(lh_temp, temp_temp);
             valid_escs++;
         }
     }
 
-    return valid_escs > 0;
+    if (valid_escs > 0) {
+        temp = lh_temp;
+        return true;
+    }
+
+    return false;
 }
 
 // get an individual ESC's current in Ampere if available, returns true on success
@@ -218,16 +224,22 @@ bool AP_ESC_Telem::get_current(uint8_t esc_index, float& amps) const
 bool AP_ESC_Telem::get_highest_current(float& amps) const
 {
     uint8_t valid_escs = 0;
+    float lh_amps = -std::numeric_limits<float>::max();
 
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
         float temp_amps;
         if (get_current(i, temp_amps)) {
-            amps = MAX(amps, temp_amps);
+            lh_amps = MAX(lh_amps, temp_amps);
             valid_escs++;
         }
     }
 
-    return valid_escs > 0;
+    if (valid_escs > 0) {
+        amps = lh_amps;
+        return true;
+    }
+
+    return false;
 }
 
 // get the average ESC current between all ESCs if available, returns true if there is valid data for at least one ESC

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -165,13 +165,13 @@ bool AP_ESC_Telem::get_motor_temperature(uint8_t esc_index, int16_t& temp) const
 }
 
 // get the highest ESC temperature in centi-degrees if available, returns true if there is valid data for at least one ESC
-bool AP_ESC_Telem::get_highest_motor_temperature(int16_t& temp) const
+bool AP_ESC_Telem::get_highest_temperature(int16_t& temp) const
 {
     uint8_t valid_escs = 0;
 
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
         int16_t temp_temp;
-        if (get_motor_temperature(i, temp_temp)) {
+        if (get_temperature(i, temp_temp)) {
             temp = MAX(temp, temp_temp);
             valid_escs++;
         }

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -48,6 +48,15 @@ public:
     // get an individual ESC's current in Ampere if available, returns true on success
     bool get_current(uint8_t esc_index, float& amps) const;
 
+    // get the highest ESC current if available, returns true if there is valid data for at least one ESC
+    bool get_highest_current(float& amps) const;
+
+    // get the average ESC current between all ESCs if available, returns true if there is valid data for at least one ESC
+    bool get_average_current(float& amps_avg) const;
+
+    // get the sum of the ESCs measured current if available, returns true if there is valid data for at least one ESC
+    bool get_total_current(float& amps) const;
+
     // get an individual ESC's usage time in seconds if available, returns true on success
     bool get_usage_seconds(uint8_t esc_index, uint32_t& usage_sec) const;
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -33,6 +33,9 @@ public:
     // return the average motor RPM
     float get_average_motor_rpm() const { return get_average_motor_rpm(0xFFFFFFFF); }
 
+    // get the highest ESC RPM if available, returns true if there is valid data for at least one ESC
+    bool get_highest_motor_rpm(float& rpm) const;
+
     // get an individual ESC's temperature in centi-degrees if available, returns true on success
     bool get_temperature(uint8_t esc_index, int16_t& temp) const;
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -36,11 +36,11 @@ public:
     // get an individual ESC's temperature in centi-degrees if available, returns true on success
     bool get_temperature(uint8_t esc_index, int16_t& temp) const;
 
+    // get the highest ESC temperature in centi-degrees if available, returns true if there is valid data for at least one ESC
+    bool get_highest_temperature(int16_t& temp) const;
+
     // get an individual motor's temperature in centi-degrees if available, returns true on success
     bool get_motor_temperature(uint8_t esc_index, int16_t& temp) const;
-
-    // get the highest ESC temperature in centi-degrees if available, returns true if there is valid data for at least one ESC
-    bool get_highest_motor_temperature(int16_t& temp) const;
 
     // get an individual ESC's current in Ampere if available, returns true on success
     bool get_current(uint8_t esc_index, float& amps) const;

--- a/libraries/AP_MSP/AP_MSP.cpp
+++ b/libraries/AP_MSP/AP_MSP.cpp
@@ -170,7 +170,7 @@ void AP_MSP::update_osd_item_settings()
     _osd_item_settings[OSD_NUMERICAL_HEADING] = &osd->screen[_msp_status.current_screen].heading;   // OSDn_HEADING
     _osd_item_settings[OSD_NUMERICAL_VARIO] = &osd->screen[_msp_status.current_screen].vspeed;      // OSDn_VSPEED
 #if HAL_WITH_ESC_TELEM
-    _osd_item_settings[OSD_ESC_TMP] = &osd->screen[_msp_status.current_screen].esc_temp;            // OSDn_ESCTEMP
+    _osd_item_settings[OSD_ESC_TMP] = &osd->screen[_msp_status.current_screen].highest_esc_temp;    // OSDn_ESCTEMP
 #endif
     _osd_item_settings[OSD_RTC_DATETIME] = &osd->screen[_msp_status.current_screen].clk;            // OSDn_CLK
 #endif  // OSD_ENABLED

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -95,7 +95,7 @@ MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_esc_sensor_data(sbuf_t *dst)
     int16_t highest_temperature = 0;
     AP_ESC_Telem& telem = AP::esc_telem();
     if (!displaying_stats_screen()) {
-        telem.get_highest_motor_temperature(highest_temperature);
+        telem.get_highest_temperature(highest_temperature);
     } else {
         AP_OSD *osd = AP::osd();
         if (osd == nullptr) {

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -206,6 +206,40 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_W_RESTVOLT", 26, AP_OSD, warn_restvolt, 10.0f),
 
+#if HAL_WITH_ESC_TELEM
+    // @Param: _W_ESCRPM
+    // @DisplayName: ESCRPM warn level
+    // @Description: Set level above which ESCRPM item will flash
+    // @Range: 0 500
+    // @Units: kRPM
+    // @User: Standard
+    AP_GROUPINFO("_W_ESCRPM", 31, AP_OSD, warn_esc_high_rpm, 0.0f),
+
+    // @Param: _W_ESCLRPM
+    // @DisplayName: ESCRPM warn level
+    // @Description: Set level under which ESCRPM item will flash with throttle > 5% and armed
+    // @Range: 0 10000
+    // @Units: RPM
+    // @User: Standard
+    AP_GROUPINFO("_W_ESCLRPM", 32, AP_OSD, warn_esc_low_rpm, 0.1f),
+
+    // @Param: _W_ESCTEMP
+    // @DisplayName: ESCTEMP warn level
+    // @Description: Set level at which ESCTEMP item will flash
+    // @Range: 0 200
+    // @Units: degC
+    // @User: Standard
+    AP_GROUPINFO("_W_ESCTEMP", 33, AP_OSD, warn_esc_temp, 80.0f),
+
+    // @Param: _W_ESCAMPS
+    // @DisplayName: ESCAMPS warn level
+    // @Description: Set level at which ESCAMPS item will flash
+    // @Range: 0 200
+    // @Units: A
+    // @User: Standard
+    AP_GROUPINFO("_W_ESCAMPS", 34, AP_OSD, warn_esc_amps, 80.0f),
+#endif
+
 #endif //osd enabled
 #if OSD_PARAM_ENABLED
     // @Group: 5_

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -419,7 +419,7 @@ void AP_OSD::update_stats()
     // max esc temp
     AP_ESC_Telem& telem = AP::esc_telem();
     int16_t highest_temperature = 0;
-    telem.get_highest_motor_temperature(highest_temperature);
+    telem.get_highest_temperature(highest_temperature);
     _stats.max_esc_temp = MAX(_stats.max_esc_temp, highest_temperature);
 #endif
 }

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -484,6 +484,13 @@ public:
     AP_Int8 failsafe_scr;
     AP_Int32 button_delay_ms;
 
+#if HAL_WITH_ESC_TELEM
+    AP_Float warn_esc_high_rpm;
+    AP_Float warn_esc_low_rpm;
+    AP_Float warn_esc_temp;
+    AP_Float warn_esc_amps;
+#endif
+
     enum {
         OPTION_DECIMAL_PACK = 1U<<0,
         OPTION_INVERTED_WIND = 1U<<1,

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -163,9 +163,12 @@ private:
     AP_OSD_Setting aspd2{false, 0, 0};
     AP_OSD_Setting vspeed{true, 24, 9};
 #if HAL_WITH_ESC_TELEM
-    AP_OSD_Setting esc_temp {false, 24, 13};
-    AP_OSD_Setting esc_rpm{false, 22, 12};
-    AP_OSD_Setting esc_amps{false, 24, 14};
+    AP_OSD_Setting highest_esc_temp {false, 24, 13};
+    AP_OSD_Setting avg_esc_rpm{false, 22, 12};
+    AP_OSD_Setting highest_esc_rpm{false, 22, 12};
+    AP_OSD_Setting avg_esc_amps{false, 24, 14};
+    AP_OSD_Setting highest_esc_amps{false, 24, 14};
+    AP_OSD_Setting total_esc_amps{false, 24, 14};
 #endif
     AP_OSD_Setting gps_latitude{true, 9, 13};
     AP_OSD_Setting gps_longitude{true, 9, 14};
@@ -236,9 +239,13 @@ private:
     void draw_speed(uint8_t x, uint8_t y, float angle_rad, float magnitude);
     void draw_distance(uint8_t x, uint8_t y, float distance);
 #if HAL_WITH_ESC_TELEM
-    void draw_esc_temp(uint8_t x, uint8_t y);
-    void draw_esc_rpm(uint8_t x, uint8_t y);
-    void draw_esc_amps(uint8_t x, uint8_t y);
+    void draw_highest_esc_temp(uint8_t x, uint8_t y);
+    void draw_rpm(uint8_t x, uint8_t y, float rpm); // helper
+    void draw_avg_esc_rpm(uint8_t x, uint8_t y);
+    void draw_highest_esc_rpm(uint8_t x, uint8_t y);
+    void draw_avg_esc_amps(uint8_t x, uint8_t y);
+    void draw_highest_esc_amps(uint8_t x, uint8_t y);
+    void draw_total_esc_amps(uint8_t x, uint8_t y);
 #endif
     void draw_gps_latitude(uint8_t x, uint8_t y);
     void draw_gps_longitude(uint8_t x, uint8_t y);


### PR DESCRIPTION
* Fix mistake in #17569 due to last minute rebase showing motor temperarure instead of ESC temperature
* Show highest ESC temperature instead of showing the temperature of the hypothetical ESC on the first output
* Possibility to show total, average and highest ESC RPM and current

Closes #17641 