### PR TITLE
RC_Channel: Set the minimum PWM to 800 (1500 - 700)

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -259,7 +259,7 @@ public:
     const char *string_for_aux_function(AUX_FUNC function) const;
 #endif
     // pwm value under which we consider that Radio value is invalid
-    static const uint16_t RC_MIN_LIMIT_PWM = 900;
+    static const uint16_t RC_MIN_LIMIT_PWM = 800;
     // pwm value above which we consider that Radio value is invalid
     static const uint16_t RC_MAX_LIMIT_PWM = 2200;
 


### PR DESCRIPTION
I believe that the maximum and minimum PWM values for the channel are 1500 ± 700.
The config parameter has a range value of 800 to 2200.
I want the config value and the decision value to be the same.

If I don't need them to be the same, I want to describe why in the source.
I want to know the reason.