### PR TITLE
AP_Scripting: add OSD bindings

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -542,6 +542,20 @@ public:
     void enable() {
         _disable = false;
     }
+#if defined(ENABLE_SCRIPTING) && ENABLE_SCRIPTING
+    AP_OSD_Backend *scripting_get_backend() {
+        scripting_override = true;
+        override_count = 0;
+        return backend;
+    }
+    void draw_screen() {
+        if (scripting_override) {
+            update_osd();
+        }
+    }
+    bool display_disabled() const { return _disable; }
+    uint8_t get_screen() const { return current_screen; }
+#endif // ENABLE_SCRIPTING
 
     AP_OSD_AbstractScreen& get_screen(uint8_t idx) {
 #if OSD_PARAM_ENABLED
@@ -601,7 +615,11 @@ private:
     StatsInfo _stats;
 #endif
     AP_OSD_Backend *backend;
-
+#if defined(ENABLE_SCRIPTING) && ENABLE_SCRIPTING
+    // bool for scripting override and counter to timeout override
+    bool scripting_override;
+    uint8_t override_count;
+#endif // ENABLE_SCRIPTING
     static AP_OSD *_singleton;
     // multi-thread access support
     HAL_Semaphore _sem;

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -56,6 +56,13 @@ public:
     // copy the backend specific symbol set to the OSD lookup table
     virtual void init_symbol_set(uint8_t *symbols, const uint8_t size);
 
+#if OSD_ENABLED && defined(ENABLE_SCRIPTING) && ENABLE_SCRIPTING
+    // passthrough OSD functions for use by scripting
+    bool display_disabled() const { return _osd.display_disabled(); }
+    uint8_t get_screen() const { return _osd.get_screen(); }
+    void draw_screen() { _osd.draw_screen(); }
+#endif
+
     AP_OSD * get_osd()
     {
         return &_osd;

--- a/libraries/AP_Scripting/examples/OSD.lua
+++ b/libraries/AP_Scripting/examples/OSD.lua
@@ -1,0 +1,56 @@
+local x = 0
+local y = 0
+local x_inc = 0.1
+local y_inc = 0.2
+
+local x_max = 28
+local y_max = 15
+
+local screen_tick = 0
+local display_screen = true
+
+function update()
+
+  OSD:clear()
+
+  -- this displays the standard AP screens
+  if display_screen then
+    OSD:draw_screen()
+  end
+  -- toggle the standard screen
+  screen_tick = screen_tick + 1
+  if screen_tick > 100 then
+    screen_tick = 0
+    display_screen = not display_screen
+  end
+
+  -- we can also add our own stuff
+  OSD:write(math.floor(x+0.5),math.floor(y+0.5),"ARDUPILOT")
+
+  OSD:flush()
+
+  -- bounce the custom text about
+  x = x + x_inc
+  if x >= x_max then
+    x = x_max
+    x_inc = -math.abs(x_inc)
+  end
+  if x < 0 then
+    x = 0
+    x_inc = math.abs(x_inc)
+  end
+
+  y = y + y_inc
+  if y >= y_max then
+    y = y_max
+    y_inc = -math.abs(y_inc)
+  end
+  if y < 0 then
+    y = 0
+    y_inc = math.abs(y_inc)
+  end
+
+  return update, 100
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -446,3 +446,16 @@ singleton AP_Periph_FW depends defined(HAL_BUILD_AP_PERIPH)
 singleton AP_Periph_FW alias periph
 singleton AP_Periph_FW method get_yaw_earth float
 singleton AP_Periph_FW method get_vehicle_state uint32_t
+
+
+include AP_OSD/AP_OSD_Backend.h depends defined(OSD_ENABLED) && OSD_ENABLED
+singleton AP_OSD_Backend depends defined(OSD_ENABLED) && OSD_ENABLED
+singleton AP_OSD_Backend alias OSD
+singleton AP_OSD_Backend get AP_OSD::get_singleton()->scripting_get_backend()
+singleton AP_OSD_Backend method write void uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX string
+singleton AP_OSD_Backend method flush void
+singleton AP_OSD_Backend method clear void
+singleton AP_OSD_Backend method draw_screen void
+singleton AP_OSD_Backend method get_aspect_ratio_correction float
+singleton AP_OSD_Backend method get_screen uint8_t
+singleton AP_OSD_Backend method display_disabled boolean

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -24,6 +24,8 @@ char keyword_singleton[]           = "singleton";
 char keyword_userdata[]            = "userdata";
 char keyword_write[]               = "write";
 char keyword_literal[]             = "literal";
+char keyword_get[]                 = "get";
+
 
 // attributes (should include the leading ' )
 char keyword_attr_enum[]    = "'enum";
@@ -372,6 +374,7 @@ struct userdata {
   uint32_t operations; // bitset of enum operation_types
   int flags; // flags from the userdata_flags enum
   char *dependency;
+  char *get_string; // custom string to get object pointer
 };
 
 static struct userdata *parsed_userdata;
@@ -918,6 +921,15 @@ void handle_singleton(void) {
       error(ERROR_DEPENDS, "Expected a depends string for %s",node->name);
     }
     string_copy(&(node->dependency), depends);
+  } else if (strcmp(type, keyword_get) == 0) {
+    if (node->get_string != NULL) {
+      error(ERROR_SINGLETON, "Singletons only support a single get");
+    }
+    char *get = strtok(NULL, "");
+    if (get == NULL) {
+      error(ERROR_DEPENDS, "Expected a get string for %s",node->name);
+    }
+    string_copy(&(node->get_string), get);
   } else if (strcmp(type, keyword_literal) == 0) {
     node->flags |= UD_FLAG_LITERAL;
   } else {
@@ -1501,7 +1513,11 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
 
   if ((data->ud_type == UD_SINGLETON) && !(data->flags & UD_FLAG_LITERAL)) {
       // fetch and check the singleton pointer
-      fprintf(source, "    %s * ud = %s::get_singleton();\n", data->name, data->name);
+      if (data->get_string == NULL) {
+        fprintf(source, "    %s * ud = %s::get_singleton();\n", data->name, data->name);
+      } else {
+        fprintf(source, "    %s * ud = %s;\n", data->name, data->get_string);
+      }
       fprintf(source, "    if (ud == nullptr) {\n");
       fprintf(source, "        return not_supported_error(L, %d, \"%s\");\n", arg_count, access_name);
       fprintf(source, "    }\n\n");


### PR DESCRIPTION
This adds bindings allowing custom text on the OSD from scripting.

There is no semaphore between the OSD thread updating the stats and scripting drawing screens that might use those stats. So there is a race there, but its only OSD stats....  There is also a race if you try and do OSD stuff from two scripts at once, so don't do that...?

~~We could add some `ENABLE_SCRIPTING` ifdefs to OSD and save some flash on builds with OSD but not scripting, probably not much tho, CI should tell us....~~

There is a example script, we retain the ability to draw the user normal setup screens, so it is easy to add stuff to those, we can also get the current screen number to do clever options there, and we can get the disabled flag so we can stop displaying when asked to (if the script honors the flag), for example when doing the runcam stuff.

If scripting stops using the OSD it will timeout back to normal AP stuff after 2 seconds

I have added the ability to give a custom string to get the pointer for scripting, this lets us do:
```    AP_OSD_Backend * ud = AP_OSD::get_singleton()->scripting_get_backend();``` 
instead of
```    AP_OSD_Backend * ud = AP_OSD_Backend::get_singleton();```
Thus avoiding having to add a singleton for AP_OSD_Backend
