### PR TITLE
Link quality

### DIFF
--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -34,7 +34,7 @@ public:
 
     /* get receiver based RSSI if available. -1 for unknown, 0 for no link, 255 for maximum link */
     virtual int16_t get_rssi(void) { return -1; }
-
+    virtual int16_t get_rx_link_quality(void) { return -1; }
     /* Return string describing method RC input protocol */
     virtual const char *protocol() const = 0;
 

--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -180,6 +180,7 @@ void RCInput::_timer_tick(void)
         _num_channels = MIN(_num_channels, RC_INPUT_MAX_CHANNELS);
         rcprot.read(_rc_values, _num_channels);
         _rssi = rcprot.get_RSSI();
+        _rx_link_quality = rcprot.get_rx_link_quality();
 #ifndef HAL_NO_UARTDRIVER
         rc_protocol = rcprot.protocol_name();
 #endif

--- a/libraries/AP_HAL_ChibiOS/RCInput.h
+++ b/libraries/AP_HAL_ChibiOS/RCInput.h
@@ -52,7 +52,9 @@ public:
     int16_t get_rssi(void) override {
         return _rssi;
     }
-
+    int16_t get_rx_link_quality(void) override {
+        return _rx_link_quality;
+    }
     const char *protocol() const override { return last_protocol; }
 
     void _timer_tick(void);
@@ -65,6 +67,7 @@ private:
     uint8_t _num_channels;
     Semaphore rcin_mutex;
     int16_t _rssi = -1;
+    int16_t _rx_link_quality = -1;
     uint32_t _rcin_timestamp_last_signal;
     bool _init;
     const char *last_protocol;

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -210,7 +210,8 @@ void AP_Logger::Write_RSSI()
     const struct log_RSSI pkt{
         LOG_PACKET_HEADER_INIT(LOG_RSSI_MSG),
         time_us       : AP_HAL::micros64(),
-        RXRSSI        : rssi->read_receiver_rssi()
+        RXRSSI        : rssi->read_receiver_rssi(),
+        RXLQ          : rssi->read_receiver_link_quality()
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -286,6 +286,7 @@ struct PACKED log_RSSI {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     float RXRSSI;
+    float RXLQ;
 };
 
 struct PACKED log_Optflow {
@@ -1105,6 +1106,7 @@ struct PACKED log_PSCZ {
 // @Description: Received Signal Strength Indicator for RC receiver
 // @Field: TimeUS: Time since system startup
 // @Field: RXRSSI: RSSI
+// @Field: RXLQ: RX Link Quality
 
 // @LoggerMessage: SIM
 // @Description: SITL simulator state
@@ -1229,7 +1231,7 @@ LOG_STRUCTURE_FROM_GPS \
     { LOG_RCOUT_MSG, sizeof(log_RCOUT), \
       "RCOU",  "QHHHHHHHHHHHHHH",     "TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14", "sYYYYYYYYYYYYYY", "F--------------"  }, \
     { LOG_RSSI_MSG, sizeof(log_RSSI), \
-      "RSSI",  "Qf",     "TimeUS,RXRSSI", "s-", "F-"  }, \
+      "RSSI",  "Qff",     "TimeUS,RXRSSI,RXLQ", "s--", "F--"  }, \
 LOG_STRUCTURE_FROM_BARO \
 LOG_STRUCTURE_FROM_PRECLAND \
     { LOG_POWR_MSG, sizeof(log_POWR), \

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -35,6 +35,9 @@
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Terrain/AP_Terrain.h>
 
+// macro for easy use of var_info2
+#define AP_SUBGROUPINFO2(element, name, idx, thisclazz, elclazz) { AP_PARAM_GROUP, idx, name, AP_VAROFFSET(thisclazz, element), { group_info : elclazz::var_info2 }, AP_PARAM_FLAG_NESTED_OFFSET }
+
 const AP_Param::GroupInfo AP_OSD::var_info[] = {
 
     // @Param: _TYPE
@@ -211,6 +214,13 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Path: AP_OSD_ParamScreen.cpp
     AP_SUBGROUPINFO(param_screen[1], "6_", 22, AP_OSD, AP_OSD_ParamScreen),
 #endif
+
+    // additional tables to go beyond 63 limit
+    AP_SUBGROUPINFO2(screen[0], "1_", 27, AP_OSD, AP_OSD_Screen),
+    AP_SUBGROUPINFO2(screen[1], "2_", 28, AP_OSD, AP_OSD_Screen),
+    AP_SUBGROUPINFO2(screen[2], "3_", 29, AP_OSD, AP_OSD_Screen),
+    AP_SUBGROUPINFO2(screen[3], "4_", 30, AP_OSD, AP_OSD_Screen),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -137,6 +137,7 @@ private:
     AP_OSD_Setting altitude{true, 23, 8};
     AP_OSD_Setting bat_volt{true, 24, 1};
     AP_OSD_Setting rssi{true, 1, 1};
+    AP_OSD_Setting link_quality{false,1,1};
     AP_OSD_Setting restvolt{false, 24, 2};
     AP_OSD_Setting avgcellvolt{false, 24, 3};
     AP_OSD_Setting current{true, 25, 2};
@@ -203,6 +204,7 @@ private:
     void draw_avgcellvolt(uint8_t x, uint8_t y);
     void draw_restvolt(uint8_t x, uint8_t y);
     void draw_rssi(uint8_t x, uint8_t y);
+    void draw_link_quality(uint8_t x, uint8_t y);
     void draw_current(uint8_t x, uint8_t y);
     void draw_current(uint8_t instance, uint8_t x, uint8_t y);
     void draw_batused(uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -121,6 +121,7 @@ public:
 
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
+    static const struct AP_Param::GroupInfo var_info2[];
 
 private:
     friend class AP_MSP;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -995,6 +995,10 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(rngf, "RNGF", 60, AP_OSD_Screen, AP_OSD_Setting),
 
+    AP_GROUPEND
+};
+
+const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Param: LINK_Q_EN
     // @DisplayName: LINK_Q_EN
     // @Description: Displays Receiver link quality
@@ -1009,7 +1013,8 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @DisplayName: LINK_Q_Y
     // @Description: Vertical position on screen
     // @Range: 0 15
-    AP_SUBGROUPINFO(link_quality, "LINK_Q", 61, AP_OSD_Screen, AP_OSD_Setting),
+    AP_SUBGROUPINFO(link_quality, "LINK_Q", 1, AP_OSD_Screen, AP_OSD_Setting),
+
     AP_GROUPEND
 };
 
@@ -1017,6 +1022,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 AP_OSD_Screen::AP_OSD_Screen()
 {
     AP_Param::setup_object_defaults(this, var_info);
+    AP_Param::setup_object_defaults(this, var_info2);
 }
 
 //Symbols

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -994,6 +994,22 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     AP_SUBGROUPINFO(rngf, "RNGF", 60, AP_OSD_Screen, AP_OSD_Setting),
+
+    // @Param: LINK_Q_EN
+    // @DisplayName: LINK_Q_EN
+    // @Description: Displays Receiver link quality
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: LINK_Q_X
+    // @DisplayName: LINK_Q_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: LINK_Q_Y
+    // @DisplayName: LINK_Q_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(link_quality, "LINK_Q", 61, AP_OSD_Screen, AP_OSD_Setting),
     AP_GROUPEND
 };
 
@@ -1268,6 +1284,19 @@ void AP_OSD_Screen::draw_rssi(uint8_t x, uint8_t y)
     if (ap_rssi) {
         const uint8_t rssiv = ap_rssi->read_receiver_rssi() * 99;
         backend->write(x, y, rssiv < osd->warn_rssi, "%c%2d", SYM_RSSI, rssiv);
+    }
+}
+
+void AP_OSD_Screen::draw_link_quality(uint8_t x, uint8_t y)
+{
+    AP_RSSI *ap_rssi = AP_RSSI::get_singleton();
+    if (ap_rssi) {
+        const int16_t lqv = ap_rssi->read_receiver_link_quality();
+        if (lqv < 0){
+            backend->write(x, y, false, "%c--", SYM_RSSI);
+        } else {
+            backend->write(x, y, false, "%c%2d", SYM_RSSI, lqv);
+        }
     }
 }
 
@@ -2029,6 +2058,7 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(avgcellvolt);
     DRAW_SETTING(restvolt);
     DRAW_SETTING(rssi);
+    DRAW_SETTING(link_quality);
     DRAW_SETTING(current);
     DRAW_SETTING(batused);
     DRAW_SETTING(bat2used);

--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -351,7 +351,13 @@ int16_t AP_RCProtocol::get_RSSI(void) const
     }
     return -1;
 }
-
+int16_t AP_RCProtocol::get_rx_link_quality(void) const
+{
+    if (_detected_protocol != AP_RCProtocol::NONE) {
+        return backend[_detected_protocol]->get_rx_link_quality();
+    }
+    return -1;
+}
 /*
   ask for bind start on supported receivers (eg spektrum satellite)
  */

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -70,6 +70,7 @@ public:
     bool new_input();
     void start_bind(void);
     int16_t get_RSSI(void) const;
+    int16_t get_rx_link_quality(void) const;
 
     // return protocol name as a string
     static const char *protocol_name_from_protocol(rcprotocol_t protocol);

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
@@ -58,7 +58,7 @@ void AP_RCProtocol_Backend::read(uint16_t *pwm, uint8_t n)
 /*
   provide input from a backend
  */
-void AP_RCProtocol_Backend::add_input(uint8_t num_values, uint16_t *values, bool in_failsafe, int16_t _rssi)
+void AP_RCProtocol_Backend::add_input(uint8_t num_values, uint16_t *values, bool in_failsafe, int16_t _rssi, int16_t _rx_link_quality)
 {
     num_values = MIN(num_values, MAX_RCIN_CHANNELS);
     memcpy(_pwm_values, values, num_values*sizeof(uint16_t));
@@ -73,6 +73,7 @@ void AP_RCProtocol_Backend::add_input(uint8_t num_values, uint16_t *values, bool
         rc_input_count++;
     }
     rssi = _rssi;
+    rx_link_quality = _rx_link_quality;
 }
 
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -67,7 +67,9 @@ public:
     int16_t get_RSSI(void) const {
         return rssi;
     }
-
+    int16_t get_rx_link_quality(void) const {
+        return rx_link_quality;
+    }
     // get UART for RCIN, if available. This will return false if we
     // aren't getting the active RC input protocol via the uart
     AP_HAL::UARTDriver *get_UART(void) const {
@@ -99,7 +101,7 @@ protected:
         uint32_t ch7 : 11;
     } PACKED;
 
-    void add_input(uint8_t num_channels, uint16_t *values, bool in_failsafe, int16_t rssi=-1);
+    void add_input(uint8_t num_channels, uint16_t *values, bool in_failsafe, int16_t rssi=-1, int16_t rx_link_quality=-1);
     AP_RCProtocol &frontend;
 
     void log_data(AP_RCProtocol::rcprotocol_t prot, uint32_t timestamp, const uint8_t *data, uint8_t len) const;
@@ -115,4 +117,5 @@ private:
     uint16_t _pwm_values[MAX_RCIN_CHANNELS];
     uint8_t  _num_channels;
     int16_t rssi = -1;
+    int16_t rx_link_quality = -1;
 };

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -204,7 +204,7 @@ void AP_RCProtocol_CRSF::_process_byte(uint32_t timestamp_us, uint8_t byte)
         _last_frame_time_us = timestamp_us;
         // decode here
         if (decode_csrf_packet()) {
-            add_input(MAX_CHANNELS, _channels, false, _link_status.rssi);
+            add_input(MAX_CHANNELS, _channels, false, _link_status.rssi, _link_status.link_quality);
         }
     }
 }
@@ -341,6 +341,7 @@ void AP_RCProtocol_CRSF::process_link_stats_frame(const void* data)
     } else {
         rssi_dbm = link->uplink_rssi_ant2;
     }
+    _link_status.link_quality = link->uplink_status;
      // AP rssi: -1 for unknown, 0 for no link, 255 for maximum link
     if (rssi_dbm < 50) {
         _link_status.rssi = 255;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -181,6 +181,7 @@ public:
 
     struct LinkStatus {
         int16_t rssi = -1;
+        int16_t link_quality = -1;
         RFMode rf_mode;
     };
 

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -154,6 +154,15 @@ float AP_RSSI::read_receiver_rssi()
     return 0.0f;
 }
 
+// Only valid for RECEIVER type RSSI selections. Returns -1 if protocol does not provide link quality report.
+float AP_RSSI::read_receiver_link_quality()
+{
+    if (RssiType(rssi_type.get()) == RssiType::RECEIVER) {
+        return RC_Channels::get_receiver_link_quality();
+    }
+    return -1;
+}
+
 // Read the receiver RSSI value as an 8-bit integer
 // 0 represents weakest signal, 255 represents maximum signal.
 uint8_t AP_RSSI::read_receiver_rssi_uint8()

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -50,7 +50,7 @@ public:
     // Read the receiver RSSI value as a float 0.0f - 1.0f.
     // 0.0 represents weakest signal, 1.0 represents maximum signal.
     float read_receiver_rssi();
-
+    float read_receiver_link_quality();
     // Read the receiver RSSI value as an 8-bit integer
     // 0 represents weakest signal, 255 represents maximum signal.
     uint8_t read_receiver_rssi_uint8();   

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -399,6 +399,7 @@ public:
 
     static uint8_t get_valid_channel_count(void);                      // returns the number of valid channels in the last read
     static int16_t get_receiver_rssi(void);                            // returns [0, 255] for receiver RSSI (0 is no link) if present, otherwise -1
+    static int16_t get_receiver_link_quality(void);                         // returns 0-100 % of last 100 packets received at receiver are valid
     bool read_input(void);                                             // returns true if new input has been read in
     static void clear_overrides(void);                                 // clears any active overrides
     static bool receiver_bind(const int dsmMode);                      // puts the receiver in bind mode if present, returns true if success

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -95,7 +95,10 @@ int16_t RC_Channels::get_receiver_rssi(void)
 {
     return hal.rcin->get_rssi();
 }
-
+int16_t RC_Channels::get_receiver_link_quality(void)
+{
+    return hal.rcin->get_rx_link_quality();
+}
 void RC_Channels::clear_overrides(void)
 {
     RC_Channels &_rc = rc();


### PR DESCRIPTION
adds getters for rx link quality....CRSF, ELRS, and now FRSKY report packet loss rates at RX....next step is to add OSD panel, and then FRSKY decodes
@andyp1per can you test this? I do not have a CRSF system up yet (still in box)

note: StonedDawg, an ELRS contributor, wrote most of this and its been flight tested in ArduPilot (although not 100% exactly this code) with ELRS sucessfully