### PR TITLE
Copter: reset land_repo_active flag in RTL mode

### DIFF
--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -22,6 +22,8 @@ bool ModeRTL::init(bool ignore_checks)
     _state = SubMode::STARTING;
     _state_complete = true; // see run() method below
     terrain_following_allowed = !copter.failsafe.terrain;
+    // reset flag indicating if pilot has applied roll or pitch inputs during landing
+    copter.ap.land_repo_active = false;
     return true;
 }
 


### PR DESCRIPTION
Fix to issue #17970 

The flag indicating if the pilot has applied roll or pitch inputs during landing now gets reset when switching into RTL mode.