### PR TITLE
Sub: use BARO instead of GND prefix to set default baro parameters

### DIFF
--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -40,17 +40,17 @@ void Sub::init_ardupilot()
     // Detection won't work until after BoardConfig.init()
     switch (AP_BoardConfig::get_board_type()) {
     case AP_BoardConfig::PX4_BOARD_PIXHAWK2:
-        AP_Param::set_default_by_name("GND_EXT_BUS", 0);
+        AP_Param::set_default_by_name("BARO_EXT_BUS", 0);
         break;
     case AP_BoardConfig::PX4_BOARD_PIXHAWK:
-        AP_Param::set_by_name("GND_EXT_BUS", 1);
+        AP_Param::set_by_name("BARO_EXT_BUS", 1);
         break;
     default:
-        AP_Param::set_default_by_name("GND_EXT_BUS", 1);
+        AP_Param::set_default_by_name("BARO_EXT_BUS", 1);
         break;
     }
 #else
-    AP_Param::set_default_by_name("GND_EXT_BUS", 1);
+    AP_Param::set_default_by_name("BARO_EXT_BUS", 1);
 #endif
     celsius.init(barometer.external_bus());
 


### PR DESCRIPTION
This updates the code to deal with the changes from 3f6fd49507f286ad8f6ccc9e29b110d5e9fc9207