### PR TITLE
AP_Baro: KellerLD pressure offset fix

### DIFF
--- a/libraries/AP_Baro/AP_Baro_KellerLD.cpp
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.cpp
@@ -30,6 +30,8 @@
 
 extern const AP_HAL::HAL &hal;
 
+// sensor metadata register
+static const uint8_t CMD_METADATA_PMODE = 0x12;
 // Measurement range registers
 static const uint8_t CMD_PRANGE_MIN_MSB = 0x13;
 static const uint8_t CMD_PRANGE_MIN_LSB = 0x14;
@@ -81,6 +83,26 @@ bool AP_Baro_KellerLD::_init()
     // measurement range, but for some reason this isn't an issue when requesting measurements.
     // This is why we need to split the transfers with delays like this.
     // (Using AP_HAL::I2CDevice::set_split_transfers will not work with these sensors)
+    
+    // Read out sensor P-mode and select relevant pressure offset
+    cal_read_ok &= _dev->transfer(&CMD_METADATA_PMODE, 1, nullptr, 0);
+    hal.scheduler->delay(1);
+    cal_read_ok &= _dev->transfer(nullptr, 0, &data[0], 3);
+    hal.scheduler->delay(1);
+    
+    switch (data[2] & 0b11) {
+        case 0:
+            // PR-mode Vented Gauge sensor (zero at 1 atm)
+            _p_mode_offset = 1.01325;
+            break;
+        case 1:
+            // PA-mode Sealed Gauge sensor (zero at 1 bar)
+            _p_mode_offset = 1.0;
+            break;
+        default:
+            // PAA-mode Absolute sensor (zero at vacuum), or undefined mode
+            _p_mode_offset = 0.0;
+    }
 
     // Read out pressure measurement range
     cal_read_ok &= _dev->transfer(&CMD_PRANGE_MIN_MSB, 1, nullptr, 0);
@@ -248,9 +270,8 @@ void AP_Baro_KellerLD::update()
     uint16_t raw_temperature_avg = sum_temperature / num_samples;
 
     // per datasheet
-    float pressure = (raw_pressure_avg - 16384) * (_p_max - _p_min) / 32768 + _p_min;
+    float pressure = (raw_pressure_avg - 16384) * (_p_max - _p_min) / 32768 + _p_min + _p_mode_offset;
     pressure *= 100000; // bar -> Pascal
-    pressure += 101300; // MSL pressure offset
     float temperature = ((raw_temperature_avg >> 4) - 24) * 0.05f - 50;
 
     _copy_to_frontend(_instance, pressure, temperature);

--- a/libraries/AP_Baro/AP_Baro_KellerLD.h
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.h
@@ -64,9 +64,11 @@ private:
     } _accum;
 
     uint8_t _instance;
-
-    // measurement range parameters used in pressure calculation
-    // varies based on model, stored in ROM on device
+    
+    // Model-specific offset/calibration values stored in device ROM
+    //  pressure offset used in pressure calculation
+    float _p_mode_offset;
+    //  measurement range parameters used in pressure calculation
     float _p_min;
     float _p_max;
 };


### PR DESCRIPTION
Fix #17944

Add P-mode pressure offset handling for PR, PA and PAA type sensors, auto-determined based on sensor mode (stored in device ROM).