### PR TITLE
Quadplane: move mode functions to mode classes in-place

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -1,6 +1,11 @@
 #include "Plane.h"
 
-Mode::Mode()
+Mode::Mode() :
+    quadplane(plane.quadplane),
+    pos_control(plane.quadplane.pos_control),
+    attitude_control(plane.quadplane.attitude_control),
+    loiter_nav(plane.quadplane.loiter_nav),
+    poscontrol(plane.quadplane.poscontrol)
 {
 }
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -7,7 +7,11 @@
 #include <AP_Soaring/AP_Soaring.h>
 #include <AP_ADSB/AP_ADSB.h>
 #include <AP_Vehicle/ModeReason.h>
+#include "quadplane.h"
 
+class AC_PosControl;
+class AC_AttitudeControl_Multi;
+class AC_Loiter;
 class Mode
 {
 public:
@@ -117,6 +121,14 @@ protected:
 
     // subclasses override this to perform any required cleanup when exiting the mode
     virtual void _exit() { return; }
+
+    // References for convenience, used by QModes
+    QuadPlane& quadplane;
+    AC_PosControl*& pos_control;
+    AC_AttitudeControl_Multi*& attitude_control;
+    AC_Loiter*& loiter_nav;
+    QuadPlane::PosControlState &poscontrol;
+
 };
 
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -54,6 +54,12 @@ public:
     // perform any cleanups required:
     void exit();
 
+    // run controllers specific to this mode
+    virtual void run() {};
+
+    // init function, used only be quadplane modes, to be factored in to _enter() in the future
+    virtual void init() {};
+
     // returns a unique number specific to this mode
     virtual Number mode_number() const = 0;
 
@@ -446,6 +452,10 @@ public:
     // used as a base class for all Q modes
     bool _enter() override;
 
+    void run() override;
+
+    void init() override;
+
 protected:
 private:
 
@@ -468,6 +478,10 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
+    void run() override;
+
+    void init() override;
+
 protected:
 
     bool _enter() override;
@@ -475,6 +489,8 @@ protected:
 
 class ModeQLoiter : public Mode
 {
+friend class QuadPlane;
+friend class ModeQLand;
 public:
 
     Number mode_number() const override { return Number::QLOITER; }
@@ -486,6 +502,10 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    void run() override;
+
+    void init() override;
 
 protected:
 
@@ -504,6 +524,10 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    void run() override;
+
+    void init() override;
 
     bool allows_arming() const override { return false; }
 
@@ -524,6 +548,10 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    void run() override;
+
+    void init() override;
 
     bool allows_arming() const override { return false; }
 
@@ -551,6 +579,10 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
+    void run() override;
+
+    void init() override;
+
 protected:
 
     bool _enter() override;
@@ -566,6 +598,8 @@ public:
 
     bool is_vtol_mode() const override { return true; }
     virtual bool is_vtol_man_mode() const override { return true; }
+
+    void run() override;
 
     // methods that affect movement of the vehicle in this mode
     void update() override;

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -44,7 +44,8 @@ const AP_Param::GroupInfo ModeTakeoff::var_info[] = {
     AP_GROUPEND
 };
 
-ModeTakeoff::ModeTakeoff()
+ModeTakeoff::ModeTakeoff() :
+    Mode()
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -224,30 +224,16 @@ private:
 
     // update yaw target for tiltrotor transition
     void update_yaw_target();
-    
-    // main entry points for VTOL flight modes
-    void init_stabilize(void);
-    void control_stabilize(void);
 
     void check_attitude_relax(void);
-    void init_qacro(void);
     float get_pilot_throttle(void);
-    void control_qacro(void);
-    void init_hover(void);
     void control_hover(void);
     void relax_attitude_control();
 
-
-    void init_loiter(void);
-    void init_qland(void);
-    void control_loiter(void);
     bool check_land_complete(void);
     bool land_detector(uint32_t timeout_ms);
     bool check_land_final(void);
 
-    void init_qrtl(void);
-    void control_qrtl(void);
-    
     float assist_climb_rate_cms(void) const;
 
     // calculate desired yaw rate for assistance


### PR DESCRIPTION
This is a in-place change of mode `run()` and `init()` functions to mode classes. 

Future PR:
 - move to the correct files. 
 - factor out the new `init()` function and move it to the existing mode `_enter()`.
 - remove Quadaplane `control_run` and `init_mode` switch case statements