### PR TITLE
AP_LeakDetector: enable for Pixhawk4

### DIFF
--- a/libraries/AP_LeakDetector/AP_LeakDetector.cpp
+++ b/libraries/AP_LeakDetector/AP_LeakDetector.cpp
@@ -70,7 +70,8 @@ void AP_LeakDetector::init()
 {
     for (int i = 0; i < LEAKDETECTOR_MAX_INSTANCES; i++) {
         switch (_pin[i]) {
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_FMUV3
+#if (CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_FMUV3 || \
+     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_FMUV5)
         case 50 ... 55:
             _state[i].instance = i;
             _drivers[i] = new AP_LeakDetector_Digital(*this, _state[i]);


### PR DESCRIPTION
Leak detector is currently only enabled for Pixhawk1 (ChibiOS FMUV3) and Navigator, using preprocessing directives.

This PR adds Pixhawk4 (ChibiOS FMUV5) to the existing Pixhawk1 directive case, as per [this forum post](https://discuss.bluerobotics.com/t/leak-detector-bar30-firmware-pixhawk4/10143/6).