### PR TITLE
HAL_ChibiOS: use DNA for node allocation on Matek GPS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/f303-MatekGPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f303-MatekGPS/hwdef.dat
@@ -128,8 +128,8 @@ PA3 USART2_RX USART2 SPEED_HIGH NODMA
 PB10  USART3_TX USART3 SPEED_HIGH
 PB11  USART3_RX USART3 SPEED_HIGH
 
-# use a default node ID so this works with MSP only
-define HAL_CAN_DEFAULT_NODE_ID 112
+# use DNA for node allocation
+define HAL_CAN_DEFAULT_NODE_ID 0
 
 define CAN_APP_NODE_NAME "org.ardupilot.f303_MatekGPS"
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/f405-MatekGPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f405-MatekGPS/hwdef.dat
@@ -109,8 +109,8 @@ PB8 CAN1_RX CAN1
 PB9 CAN1_TX CAN1
 PC13 GPIO_CAN1_SILENT OUTPUT PUSHPULL SPEED_LOW LOW
 
-# use a default node ID so this works with MSP only
-define HAL_CAN_DEFAULT_NODE_ID 113
+# use DNA for node allocation
+define HAL_CAN_DEFAULT_NODE_ID 0
 
 define CAN_APP_NODE_NAME "org.ardupilot.f405_MatekGPS"
 


### PR DESCRIPTION
this works as MSP is now active when a DNA server is not found
ping @MATEKSYS 