### PR TITLE
autotest: make vib failsafe test more realistic

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1051,19 +1051,26 @@ class AutoTestCopter(AutoTest):
         # takeoff in Loiter to 20m
         self.takeoff(20, mode="LOITER")
 
-        # simulate accel bias caused by high vibration
+        # simulate clipping on accelerometers by changing dynamic range to
+        # 4g and adding some motor frequency vibration
         self.set_parameters({
-            'SIM_ACC1_BIAS_Z': 2,
-            'SIM_ACC2_BIAS_Z': 2,
-            'SIM_ACC3_BIAS_Z': 2,
+            'SIM_ACC1_RND': 2,
+            'SIM_ACC2_RND': 2,
+            'SIM_ACC3_RND': 2,
+            'SIM_ACCEL1_CLIP': 5,
+            'SIM_ACCEL2_CLIP': 5,
+            'SIM_ACCEL3_CLIP': 5,
+            'SIM_VIB_MOT_MAX' : 10,
+            'SIM_VIB_MOT_MULT' : 5,
         })
 
         # wait for Vibration compensation warning and change to LAND mode
         self.wait_statustext("Vibration compensation ON", timeout=30)
         self.wait_mode("LAND")
 
-        # check vehicle descends to 2m or less within 30 seconds
-        self.wait_altitude(-5, 2, timeout=30, relative=True)
+        # check vehicle descends to 2m or less within 40 seconds
+        # use GPS altitude as EKF altitude will be unreliable
+        self.wait_altitude(-5, 2, timeout=40, relative=True, use_GPS=True)
 
         # force disarm of vehicle (it will likely not automatically disarm)
         self.disarm_vehicle(force=True)

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4744,8 +4744,26 @@ class AutoTest(ABC):
         while tstart + seconds_to_wait > tnow:
             tnow = self.get_sim_time()
 
-    def get_altitude(self, relative=False, timeout=30):
+    def get_altitude(self, relative=False, use_GPS=False, timeout=30):
         '''returns vehicles altitude in metres, possibly relative-to-home'''
+        if use_GPS:
+            # use GPS altitude
+            if relative:
+                # use GPS altitude above home
+                home = self.mav.messages.get("HOME_POSITION", None)
+                if home is None:
+                    home = self.poll_home_position(quiet=True)
+                base_alt = home.altitude*0.001
+            else:
+                base_alt = 0.0
+            msg = self.mav.recv_match(type='GPS_RAW_INT',
+                                      blocking=True,
+                                      timeout=timeout)
+            if msg is None:
+                raise MsgRcvTimeoutException("Failed to get GPS_RAW_INT")
+            return msg.alt*0.001 - base_alt
+
+        # use GLOBAL_POSITION_INT
         msg = self.mav.recv_match(type='GLOBAL_POSITION_INT',
                                   blocking=True,
                                   timeout=timeout)
@@ -4755,7 +4773,7 @@ class AutoTest(ABC):
             return msg.relative_alt / 1000.0  # mm -> m
         return msg.alt / 1000.0  # mm -> m
 
-    def wait_altitude(self, altitude_min, altitude_max, relative=False, timeout=30, **kwargs):
+    def wait_altitude(self, altitude_min, altitude_max, relative=False, use_GPS=False, timeout=30, **kwargs):
         """Wait for a given altitude range."""
         assert altitude_min <= altitude_max, "Minimum altitude should be less than maximum altitude."
 
@@ -4770,6 +4788,7 @@ class AutoTest(ABC):
             target=altitude_min,
             current_value_getter=lambda: self.get_altitude(
                 relative=relative,
+                use_GPS=use_GPS,
                 timeout=timeout,
             ),
             accuracy=(altitude_max - altitude_min),

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -173,6 +173,16 @@ void AP_InertialSensor_SITL::generate_accel()
             accel.x = accel.y = accel.z = sitl->accel_fail[accel_instance];
         }
 
+        if (sitl->accel_clip[accel_instance] > 0) {
+            const float limit = sitl->accel_clip[accel_instance]*GRAVITY_MSS;
+            _clip_limit = 0.95*limit;
+            accel.x = constrain_float(accel.x, -limit, limit);
+            accel.y = constrain_float(accel.y, -limit, limit);
+            accel.z = constrain_float(accel.z, -limit, limit);
+        } else {
+            _clip_limit = 0.95*16*GRAVITY_MSS;
+        }
+        
         sitl->imu_tcal[gyro_instance].sitl_apply_accel(T, accel);
 
         _notify_new_accel_sensor_rate_sample(accel_instance, accel);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -267,6 +267,11 @@ const AP_Param::GroupInfo SITL::var_info3[] = {
 
     AP_GROUPINFO("ESC_TELEM", 40, SITL, esc_telem, 1),
 
+    // @Param: SAIL_TYPE
+    // @DisplayName: Sailboat simulation sail type
+    // @Description: 0: mainsail with sheet, 1: directly actuated wing
+    AP_GROUPINFO("SAIL_TYPE",     41, SITL, sail_type, 0),
+
     // user settable parameters for the 1st airspeed sensor
     AP_GROUPINFO("ARSPD_RND",     50, SITL,  arspd_noise[0], 2.0),
     AP_GROUPINFO("ARSPD_OFS",     51, SITL,  arspd_offset[0], 2013),
@@ -432,11 +437,9 @@ const AP_Param::GroupInfo SITL::var_ins[] = {
     AP_GROUPINFO("ACC3_SCAL",    24, SITL, accel_scale[2], 0),
     AP_GROUPINFO("ACC_TRIM",     25, SITL, accel_trim, 0),
 
-    // @Param: SAIL_TYPE
-    // @DisplayName: Sailboat simulation sail type
-    // @Description: 0: mainsail with sheet, 1: directly actuated wing
-    AP_GROUPINFO("SAIL_TYPE",     26, SITL, sail_type, 0),
-
+    AP_GROUPINFO("ACCEL1_CLIP",  26, SITL, accel_clip[0],  0),
+    AP_GROUPINFO("ACCEL2_CLIP",  27, SITL, accel_clip[1],  0),
+    AP_GROUPINFO("ACCEL3_CLIP",  28, SITL, accel_clip[2],  0),
 
     // the IMUT parameters must be last due to the enable parameters
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SITL, AP_InertialSensor::TCal),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -468,6 +468,7 @@ public:
     AP_Vector3f accel_scale[INS_MAX_INSTANCES]; // in m/s/s
     AP_Vector3f accel_trim;
     AP_Float accel_fail[INS_MAX_INSTANCES];  // accelerometer failure value
+    AP_Float accel_clip[INS_MAX_INSTANCES];  // accelerometer clip limit
     // gyro and accel fail masks
     AP_Int8 gyro_fail_mask;
     AP_Int8 accel_fail_mask;


### PR DESCRIPTION
Use motor vibration and clip limits, not accel offsets. This will allow @priseborough to better handle clipping in the EKF

Note that this does not model aliasing. The parameters in the test are quite critical. Small changes make the test fail and the vibration failsafe handling in copter is quite fragile.
