### PR TITLE
Emit event when EKF data source changed from primary/secondary/tertiary

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -153,6 +153,12 @@ enum class LogEvent : uint8_t {
     FENCE_FLOOR_ENABLE = 80,
     FENCE_FLOOR_DISABLE = 81,
 
+    // if the EKF's source input set is changed (e.g. via a switch or
+    // a script), we log an event:
+    EK3_SOURCES_SET_TO_PRIMARY = 85,
+    EK3_SOURCES_SET_TO_SECONDARY = 86,
+    EK3_SOURCES_SET_TO_TERTIARY = 87,
+
     SURFACED = 163,
     NOT_SURFACED = 164,
     BOTTOMED = 165,

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -16,6 +16,7 @@
 #include "AP_NavEKF_Source.h"
 #include <AP_Math/AP_Math.h>
 #include <AP_DAL/AP_DAL.h>
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -151,6 +152,12 @@ void AP_NavEKF_Source::setPosVelYawSourceSet(uint8_t source_set_idx)
     // sanity check source idx
     if (source_set_idx < AP_NAKEKF_SOURCE_SET_MAX) {
         active_source_set = source_set_idx;
+        static const LogEvent evt[AP_NAKEKF_SOURCE_SET_MAX] {
+            LogEvent::EK3_SOURCES_SET_TO_PRIMARY,
+            LogEvent::EK3_SOURCES_SET_TO_SECONDARY,
+            LogEvent::EK3_SOURCES_SET_TO_TERTIARY,
+        };
+        AP::logger().Write_Event(evt[active_source_set]);
     }
 }
 


### PR DESCRIPTION
This is an excerpt from a `test.Copter.GPSViconSwitching` log:

```
2021-07-16 12:24:46.640 SRC=250/250:AT-0021.5: SIM_VICON_FAIL is now 0.000000
2021-07-16 12:24:46.940 EKFPosSource MIDDLE
2021-07-16 12:24:46.940 Event: 86
2021-07-16 12:24:46.942 EKF3 IMU1 yaw aligned
```

The source was changed using a switch (the "MIDDLE" line), and the event indicating is then emitted.  

MAVProxy has a static map from number to description which will need updating.
