### PR TITLE
Log EKF3 source selection into XKFS

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -60,6 +60,7 @@ public:
 
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
     void setPosVelYawSourceSet(uint8_t source_set_idx);
+    uint8_t getPosVelYawSourceSet() const { return active_source_set; }
 
     // get/set velocity source
     SourceXY getVelXYSource() const { return _source_set[active_source_set].velxy; }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -95,7 +95,8 @@ void NavEKF3_core::Log_Write_XKFS(uint64_t time_us) const
         mag_index      : magSelectIndex,
         baro_index     : selected_baro,
         gps_index      : selected_gps,
-        airspeed_index : getActiveAirspeed()
+        airspeed_index : getActiveAirspeed(),
+        source_set     : frontend->sources.getPosVelYawSourceSet()
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -343,6 +343,7 @@ struct PACKED log_XKQ {
 // @Field: BI: barometer selection index
 // @Field: GI: GPS selection index
 // @Field: AI: airspeed selection index
+// @Field: SS: Source Set (primary=0/secondary=1/tertiary=2)
 struct PACKED log_XKFS {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -351,6 +352,7 @@ struct PACKED log_XKFS {
     uint8_t baro_index;
     uint8_t gps_index;
     uint8_t airspeed_index;
+    uint8_t source_set;
 };
 
 // @LoggerMessage: XKTV
@@ -436,7 +438,7 @@ struct PACKED log_XKV {
     { LOG_XKFM_MSG, sizeof(log_XKFM),   \
       "XKFM", "QBBffff", "TimeUS,C,OGNM,GLR,ALR,GDR,ADR", "s#-----", "F------"}, \
     { LOG_XKFS_MSG, sizeof(log_XKFS), \
-      "XKFS","QBBBBB","TimeUS,C,MI,BI,GI,AI", "s#----", "F-----" }, \
+      "XKFS","QBBBBBB","TimeUS,C,MI,BI,GI,AI,SS", "s#-----", "F------" }, \
     { LOG_XKQ_MSG, sizeof(log_XKQ), "XKQ", "QBffff", "TimeUS,C,Q1,Q2,Q3,Q4", "s#????", "F-????" }, \
     { LOG_XKT_MSG, sizeof(log_XKT),   \
       "XKT", "QBIffffffff", "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax", "s#sssssssss", "F-000000000"}, \


### PR DESCRIPTION
Except from `test.Copter.GPSViconSwitching` log:

```
2021-07-16 14:24:31.54: XKFS {TimeUS : 84571991, C : 1, MI : 0, BI : 0, GI : 0, AI : 0, SS : 0}
2021-07-16 14:24:31.64: XKFS {TimeUS : 84671951, C : 0, MI : 0, BI : 0, GI : 0, AI : 0, SS : 0}
2021-07-16 14:24:31.64: XKFS {TimeUS : 84671951, C : 1, MI : 0, BI : 0, GI : 0, AI : 0, SS : 0}
2021-07-16 14:24:31.74: XKFS {TimeUS : 84771911, C : 0, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
2021-07-16 14:24:31.74: XKFS {TimeUS : 84771911, C : 1, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
2021-07-16 14:24:31.84: XKFS {TimeUS : 84871871, C : 0, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
2021-07-16 14:24:31.84: XKFS {TimeUS : 84871871, C : 1, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
2021-07-16 14:24:31.94: XKFS {TimeUS : 84971831, C : 0, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
2021-07-16 14:24:31.94: XKFS {TimeUS : 84971831, C : 1, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
2021-07-16 14:24:32.04: XKFS {TimeUS : 85071791, C : 0, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
2021-07-16 14:24:32.04: XKFS {TimeUS : 85071791, C : 1, MI : 0, BI : 0, GI : 0, AI : 0, SS : 1}
```

Alternative to https://github.com/ArduPilot/ardupilot/pull/18033
