### PR TITLE
AP_RangeFinder: add support for TOF10120 rangefinder

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -48,6 +48,7 @@
 #include "AP_RangeFinder_SITL.h"
 #include "AP_RangeFinder_MSP.h"
 #include "AP_RangeFinder_USD1_CAN.h"
+#include "AP_RangeFinder_TOF10120_I2C.h"
 
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
@@ -357,6 +358,20 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         }
         FOREACH_I2C(i) {
             if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
+                                                                  hal.i2c_mgr->get_device(i, addr)),
+                             instance)) {
+                break;
+            }
+        }
+        break;
+    }
+    case Type::TOF10120_I2C: {
+        uint8_t addr = AP_RANGE_FINDER_TOF10120_I2C_DEFAULT_ADDR;
+        if (params[instance].address != 0) {
+            addr = params[instance].address;
+        }
+        FOREACH_I2C(i) {
+            if (_add_backend(AP_RangeFinder_TOF10120_I2C::detect(state[instance], params[instance],
                                                                   hal.i2c_mgr->get_device(i, addr)),
                              instance)) {
                 break;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -89,6 +89,7 @@ public:
         MSP = 32,
         USD1_CAN = 33,
         SITL = 100,
+        TOF10120_I2C = 120,
     };
 
     enum class Function {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TOF10120_I2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TOF10120_I2C.cpp
@@ -1,0 +1,155 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *   AP_RangeFinder_TOF10120_I2C.cpp - rangefinder for Taidacent TOF10120 Time of Flight Sensor
+ *
+ *   TOF10120 - a low cost and lightweight laser distance sensor with I2C & UART interfaces.
+ *
+ *   Datasheet: https://github.com/simpleiot/reference/blob/master/sensors/TOF10120.pdf
+ *   Datasheet (EN): https://github.com/simpleiot/reference/blob/master/sensors/TOF10120_english.pdf
+ */
+
+#include "AP_RangeFinder_TOF10120_I2C.h"
+
+#include <utility>
+#include <math.h>
+
+#include <AP_HAL/AP_HAL.h>
+
+extern const AP_HAL::HAL& hal;
+
+AP_RangeFinder_TOF10120_I2C::AP_RangeFinder_TOF10120_I2C(RangeFinder::RangeFinder_State &_state,
+                                                           AP_RangeFinder_Params &_params,
+                                                           AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+    : AP_RangeFinder_Backend(_state, _params)
+    , _dev(std::move(dev))
+{
+}
+
+/*
+   detect if a TOF10120 rangefinder is connected.
+*/
+AP_RangeFinder_Backend *AP_RangeFinder_TOF10120_I2C::detect(RangeFinder::RangeFinder_State &_state,
+																AP_RangeFinder_Params &_params,
+                                                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+{
+    if (!dev) {
+        return nullptr;
+    }
+
+    AP_RangeFinder_TOF10120_I2C *sensor
+        = new AP_RangeFinder_TOF10120_I2C(_state, _params, std::move(dev));
+    if (!sensor) {
+        return nullptr;
+    }
+
+    if (!sensor->init()) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
+}
+
+/*
+  initialise sensor
+ */
+bool AP_RangeFinder_TOF10120_I2C::init(void)
+{
+    _dev->get_semaphore()->take_blocking();
+
+    if (!start_reading()) {
+        _dev->get_semaphore()->give();
+        return false;
+    }
+
+    // give time for the sensor to process the request
+    hal.scheduler->delay(100);
+
+    uint16_t reading_cm;
+    if (!get_reading(reading_cm)) {
+        _dev->get_semaphore()->give();
+        return false;
+    }
+
+    _dev->get_semaphore()->give();
+
+    _dev->register_periodic_callback(100000,
+                                     FUNCTOR_BIND_MEMBER(&AP_RangeFinder_TOF10120_I2C::timer, void));
+
+    return true;
+}
+
+// ask sensor to make a range reading
+bool AP_RangeFinder_TOF10120_I2C::start_reading()
+{
+    uint8_t cmd = AP_RANGE_FINDER_TOF10120_I2C_RANGE_READING_CMD;
+
+    // send command to take reading
+    return _dev->transfer(&cmd, sizeof(cmd), nullptr, 0);
+}
+
+// read - return last value measured by sensor
+bool AP_RangeFinder_TOF10120_I2C::get_reading(uint16_t &reading_cm)
+{
+    uint16_t distance_mm = 0;
+    uint8_t buffer[2];
+
+    // take range reading
+    bool ret = _dev->transfer(nullptr, 0, (uint8_t *) &buffer, sizeof(buffer));
+
+    if (ret) {
+        distance_mm = (buffer[0] << 8) | buffer[1];
+
+        reading_cm = (int)roundf(distance_mm / 10);
+
+        // trigger a new reading
+        start_reading();
+    }
+
+    return ret;
+}
+
+/*
+  timer called at 10Hz
+*/
+void AP_RangeFinder_TOF10120_I2C::timer(void)
+{
+    uint16_t d;
+    if (get_reading(d)) {
+        WITH_SEMAPHORE(_sem);
+        distance = d;
+        new_distance = true;
+        state.last_reading_ms = AP_HAL::millis();
+    }
+}
+
+/*
+   update the state of the sensor
+*/
+void AP_RangeFinder_TOF10120_I2C::update(void)
+{
+    WITH_SEMAPHORE(_sem);
+    if (new_distance) {
+        state.distance_cm = distance;
+        new_distance = false;
+        update_status();
+    } else if (AP_HAL::millis() - state.last_reading_ms > 300) {
+        // if no updates for 0.3 seconds set no-data
+        set_status(RangeFinder::Status::NoData);
+    }
+}
+

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TOF10120_I2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TOF10120_I2C.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "AP_RangeFinder.h"
+#include "AP_RangeFinder_Backend.h"
+#include <AP_HAL/I2CDevice.h>
+
+#define AP_RANGE_FINDER_TOF10120_I2C_DEFAULT_ADDR 0x52
+#define AP_RANGE_FINDER_TOF10120_I2C_RANGE_READING_CMD 0x00
+
+class AP_RangeFinder_TOF10120_I2C : public AP_RangeFinder_Backend
+{
+
+public:
+
+    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state,
+                                          AP_RangeFinder_Params &_params,
+                                          AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+
+    void update(void) override;
+
+protected:
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_LASER;
+    }
+
+private:
+
+    // constructor
+    AP_RangeFinder_TOF10120_I2C(RangeFinder::RangeFinder_State &_state,
+    								AP_RangeFinder_Params &_params,
+                                 AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+
+    bool init(void);
+    void timer(void);
+
+    bool start_reading(void);
+    bool get_reading(uint16_t &reading_cm);
+
+    uint16_t distance;
+    bool new_distance;
+
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+};


### PR DESCRIPTION
Compact & lightweight sensor, useful for auto landing on small drones. Max distance: 2m. Min distance by datasheet: 10cm, min distance by real tests: ~1cm.