### PR TITLE
AP_NavEKF3: add 'vertical position' to pre_arm_check description

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -299,7 +299,7 @@ void AP_NavEKF_Source::mark_configured_in_storage()
 }
 
 // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-// requires_position should be true if horizontal position configuration should be checked
+// requires_position should be true if vertical or horizontal position configuration should be checked
 bool AP_NavEKF_Source::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
 {
     auto &dal = AP::dal();


### PR DESCRIPTION
~This just takes these checks out of the `if (position_required)`~

~This way, the INS pre-arm check complains  when I try to use EK3_SRC1_VELZ = 1 (BARO) in sub, as expected.~

~The comment on top of `AP_NavEKF_Source::pre_arm_check` also implies that this (position_required affecting horizontal positioning only) is the expected behavior:~
```
// returns false if we fail arming checks, in which case the buffer will be populated with a failure message
// requires_position should be true if horizontal position configuration should be checked
```

Update: now this just fixes the docstring. I'll handle checking if the EKF has a good vertical position estimate in sub mode changes in another pr.