### PR TITLE
Plane: don't output throttle in when safe

### DIFF
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -47,10 +47,6 @@ void Plane::set_control_channels(void)
     // update manual forward throttle channel assignment
     quadplane.rc_fwd_thr_ch = rc().find_channel_for_option(RC_Channel::AUX_FUNC::FWD_THR);
 
-    if (!arming.is_armed() && arming.arming_required() == AP_Arming::Required::YES_MIN_PWM) {
-        SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, have_reverse_thrust()?SRV_Channel::Limit::TRIM:SRV_Channel::Limit::MIN);
-    }
-
     if (!quadplane.enable) {
         // setup correct scaling for ESCs like the UAVCAN ESCs which
         // take a proportion of speed. For quadplanes we use AP_Motors
@@ -90,12 +86,7 @@ void Plane::init_rc_out_main()
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_elevator, SRV_Channel::Limit::TRIM);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttle, SRV_Channel::Limit::TRIM);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_rudder, SRV_Channel::Limit::TRIM);
-    
-    // setup flight controller to output the min throttle when safety off if arming
-    // is setup for min on disarm
-    if (arming.arming_required() == AP_Arming::Required::YES_MIN_PWM) {
-        SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, have_reverse_thrust()?SRV_Channel::Limit::TRIM:SRV_Channel::Limit::MIN);
-    }
+
 }
 
 /*


### PR DESCRIPTION
Fixes #16629 and probably also Fixes #16630

We were setting the output for safe to be the same as disarmed rather than honoring the expected safety mask and outputting no PWM. This means if you go messing with the SERVO trims you can cause the motors to spin despite being 'safe'. 

@rmackay9 The same bug actually also exists in rover, https://github.com/ArduPilot/ardupilot/blob/d47a032a09a22a04592e85b0954947936acbc300/libraries/AP_Motors/AP_MotorsUGV.cpp#L153

I would quite like to delete the `set_safety_limit` method all together. It should always be no PWM, other wise you might as well let it through the safety mask, where by we use `ARMING_REQUIRE` on plane and `MOT_SAFE_DISARM` on rover to decide zero or min/trim PWM.