### PR TITLE
AP_Scripting: receive command long and int

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -234,6 +234,26 @@ void AP_Scripting::handle_mission_command(const AP_Mission::Mission_Command& cmd
     mission_data->push(cmd);
 }
 
+bool AP_Scripting::handle_command_long(const mavlink_command_long_t& cmd, const mavlink_channel_t chan)
+{
+    if (!_enable || mavlink_data.cmd_buffer == nullptr) {
+        // not enabled or buffer not created
+        return false;
+    }
+    WITH_SEMAPHORE(mavlink_data.sem);
+    return mavlink_data.cmd_buffer->write(cmd, AP_HAL::millis(), chan);
+}
+
+bool AP_Scripting::handle_command_int(const mavlink_command_int_t& cmd, const mavlink_channel_t chan)
+{
+    if (!_enable || mavlink_data.cmd_buffer == nullptr) {
+        // not enabled or buffer not created
+        return false;
+    }
+    WITH_SEMAPHORE(mavlink_data.sem);
+    return mavlink_data.cmd_buffer->write(cmd, AP_HAL::millis(), chan);
+}
+
 AP_Scripting *AP_Scripting::_singleton = nullptr;
 
 namespace AP {

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -22,6 +22,7 @@
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_HAL/I2CDevice.h>
 #include "AP_Scripting_CANSensor.h"
+#include "AP_Scripting_MAVLink_buffer.h"
 
 #ifndef SCRIPTING_MAX_NUM_I2C_DEVICE
   #define SCRIPTING_MAX_NUM_I2C_DEVICE 4
@@ -48,6 +49,9 @@ public:
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
 
     void handle_mission_command(const AP_Mission::Mission_Command& cmd);
+
+    bool handle_command_long(const mavlink_command_long_t& cmd, const mavlink_channel_t chan);
+    bool handle_command_int(const mavlink_command_int_t& cmd, const mavlink_channel_t chan);
 
    // User parameters for inputs into scripts 
    AP_Float _user[4]; 
@@ -83,6 +87,11 @@ public:
         uint32_t time_ms;
     };
     ObjectBuffer<struct scripting_mission_cmd> * mission_data;
+
+    struct mavlink {
+        command_buffer * cmd_buffer;
+        HAL_Semaphore sem;
+    } mavlink_data;
 
 private:
 

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink_buffer.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink_buffer.cpp
@@ -1,0 +1,85 @@
+
+#include "AP_Scripting_MAVLink_buffer.h"
+
+command_buffer::command_buffer(uint8_t buffer_size, int16_t _watch_CMD, uint32_t _watch_msgid) :
+    buffer(buffer_size),
+    watch_CMD(_watch_CMD),
+    watch_msgid(_watch_msgid) {}
+
+// Add a new buffer to the linked list
+void command_buffer::add_buffer(command_buffer * _new) {
+    WITH_SEMAPHORE(sem);
+    if (next == nullptr) {
+        next =_new;
+        return;
+    }
+    next->add_buffer(_new);
+}
+
+// write command long to buffer if it is the watched command and ID
+bool command_buffer::write(const mavlink_command_long_t &cmd, const uint32_t time_ms, const mavlink_channel_t chan) {
+    WITH_SEMAPHORE(sem);
+    bool ret = false;
+    if ((watch_msgid == MAVLINK_MSG_ID_COMMAND_LONG) && (cmd.command == watch_CMD)) {
+        struct scripting_cmd data {{.LONG = cmd}, time_ms, chan};
+        buffer.push(data);
+        ret = true;
+    }
+    if (next != nullptr) {
+        ret |= next->write(cmd, time_ms, chan);
+    }
+    return ret;
+}
+
+// write command int to buffer if it is the watched command and ID
+bool command_buffer::write(const mavlink_command_int_t& cmd, const uint32_t time_ms, const mavlink_channel_t chan) {
+    WITH_SEMAPHORE(sem);
+    bool ret = false;
+    if ((watch_msgid == MAVLINK_MSG_ID_COMMAND_INT) && (cmd.command == watch_CMD)) {
+        struct scripting_cmd data {{.INT = cmd}, time_ms, chan};
+        buffer.push(data);
+        ret = true;
+    }
+    if (next != nullptr) {
+        ret |= next->write(cmd, time_ms, chan);
+    }
+    return ret;
+}
+
+// pop command from buffer, save last channel for ack
+uint8_t command_buffer::receive(mavlink_command_long_t &LONG, mavlink_command_int_t &INT, uint32_t &time_ms, uint8_t &chan) {
+    WITH_SEMAPHORE(sem);
+    scripting_cmd command;
+    if (buffer.pop(command)) {
+        uint8_t ret;
+        if (watch_msgid == MAVLINK_MSG_ID_COMMAND_LONG) {
+            LONG = command.cmd.LONG;
+            // tell scripting the first, third and fourth returns are valid
+            ret = 0b1101;
+
+        } else if (watch_msgid == MAVLINK_MSG_ID_COMMAND_INT) {
+            INT = command.cmd.INT;
+            ret = 0b1110;
+
+        } else {
+            return 0;
+        }
+        time_ms = command.time_ms;
+        chan = command.chan;
+        _last_chan = chan;
+        return ret;
+    }
+    return 0;
+}
+
+// send ack back to the last channel
+void command_buffer::send_ack(MAV_RESULT result) {
+    if (_last_chan >= mavlink_channel_t::MAVLINK_COMM_0  && _last_chan <= mavlink_channel_t::MAVLINK_COMM_3) {
+        send_chan_ack(result, (mavlink_channel_t)_last_chan);
+    }
+}
+
+// send ack to a given channel
+void command_buffer::send_chan_ack(MAV_RESULT result, mavlink_channel_t chan) {
+    mavlink_msg_command_ack_send(chan, watch_CMD, result);
+}

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink_buffer.h
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink_buffer.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <GCS_MAVLink/GCS.h>
+
+class command_buffer {
+public:
+    // constructor
+    command_buffer(uint8_t buffer_size, int16_t _watch_CMD, uint32_t _watch_msgid);
+
+    // Add a new buffer to the linked list
+    void add_buffer(command_buffer * _new);
+
+    // write item to buffer if it is the watched command ID and type
+    bool write(const mavlink_command_long_t &cmd, const uint32_t time_ms, const mavlink_channel_t chan);
+    bool write(const mavlink_command_int_t &cmd, const uint32_t time_ms, const mavlink_channel_t chan);
+
+    // pop command from buffer, save last channel for ack
+    uint8_t receive(mavlink_command_long_t &LONG, mavlink_command_int_t &INT, uint32_t &time_ms, uint8_t &chan);
+
+    // send ack back to the last channel
+    void send_ack(MAV_RESULT result);
+
+    // send ack to a given channel
+    void send_chan_ack(MAV_RESULT result, mavlink_channel_t chan);
+
+private:
+
+    // struct for object buffer
+    struct scripting_cmd {
+        union cmd_union {
+            mavlink_command_long_t LONG;
+            mavlink_command_int_t INT;
+        } cmd;
+        uint32_t time_ms;
+        mavlink_channel_t chan;
+    };
+
+    // the message and command IDs to watch
+    const int16_t watch_CMD;
+    const uint32_t watch_msgid;
+
+    // last channel popped
+    int8_t _last_chan = -1;
+
+    ObjectBuffer<scripting_cmd> buffer;
+
+    command_buffer * next;
+
+    HAL_Semaphore sem;
+
+};

--- a/libraries/AP_Scripting/examples/command_long_int.lua
+++ b/libraries/AP_Scripting/examples/command_long_int.lua
@@ -1,0 +1,36 @@
+
+
+-- register for command long user 1 (31010) with buffer size of 5
+local CMD_USER_1 = mavlink.register_command_long(31010, 5)
+
+-- register for command int waypoint user 1 (31010) with buffer size of 5
+local CMD_WAYPOINT_USER_1  = mavlink.register_command_int(31000, 5)
+
+-- mav result enum to send back for ack
+local MAV_RESULT_ACCEPTED = 0
+local MAV_RESULT_TEMPORARILY_REJECTED = 1
+local MAV_RESULT_DENIED = 2
+local MAV_RESULT_UNSUPPORTED = 3
+local MAV_RESULT_FAILED = 4
+local MAV_RESULT_IN_PROGRESS = 5
+
+function update()
+
+    local cmd, time_ms, chan = CMD_USER_1:receive()
+    if cmd and chan then
+        gcs:send_text(6,string.format("Got long %i on chan %i : %f, %f, %f, %f, %f, %f, %f",cmd:command(),chan, cmd:param1(), cmd:param2(), cmd:param3(), cmd:param4(), cmd:param5(), cmd:param6(), cmd:param7() ))
+        gcs:send_text(6,tostring(millis() - time_ms) .. " ms ago")
+        CMD_USER_1:send_ack(MAV_RESULT_ACCEPTED)
+    end
+
+    cmd, time_ms, chan = CMD_WAYPOINT_USER_1:receive()
+    if cmd and chan then
+        gcs:send_text(6,string.format("Got int %i on chan %i : %f, %f, %f, %f, %i, %i, %f",cmd:command(),chan, cmd:param1(), cmd:param2(), cmd:param3(), cmd:param4(), cmd:x(), cmd:y(), cmd:z() ))
+        gcs:send_text(6,tostring(millis() - time_ms) .. " ms ago")
+        CMD_WAYPOINT_USER_1:send_ack(MAV_RESULT_TEMPORARILY_REJECTED)
+    end
+
+    return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -314,6 +314,35 @@ userdata mavlink_mission_item_int_t field frame uint8_t read write  0 UINT8_MAX
 userdata mavlink_mission_item_int_t field current uint8_t read write  0 UINT8_MAX
 -- userdata mavlink_mission_item_int_t field autocontinue uint8_t read write  0 UINT8_MAX
 
+userdata mavlink_command_long_t field param1 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_long_t field param2 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_long_t field param3 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_long_t field param4 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_long_t field param5 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_long_t field param6 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_long_t field param7 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_long_t field command uint16_t read write 0 UINT16_MAX
+userdata mavlink_command_long_t field target_system uint8_t read write 0 UINT8_MAX
+userdata mavlink_command_long_t field target_component uint8_t read write 0 UINT8_MAX
+userdata mavlink_command_long_t alias command_long
+
+userdata mavlink_command_int_t field param1 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_int_t field param2 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_int_t field param3 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_int_t field param4 float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_int_t field x int32_t read write -INT32_MAX INT32_MAX
+userdata mavlink_command_int_t field y int32_t read write -INT32_MAX INT32_MAX
+userdata mavlink_command_int_t field z float read write -FLT_MAX FLT_MAX
+userdata mavlink_command_int_t field command uint16_t read write 0 UINT16_MAX
+userdata mavlink_command_int_t field target_system uint8_t read write 0 UINT8_MAX
+userdata mavlink_command_int_t field target_component uint8_t read write 0 UINT8_MAX
+userdata mavlink_command_int_t field frame uint8_t read write  0 UINT8_MAX
+userdata mavlink_command_int_t alias command_int
+
+include AP_Scripting/AP_Scripting_MAVLink_buffer.h
+ap_object command_buffer method receive uint8_t mavlink_command_long_t'Null mavlink_command_int_t'Null uint32_t'Null uint8_t'Null
+ap_object command_buffer method send_ack void MAV_RESULT'enum 0 MAV_RESULT_ENUM_END-1
+ap_object command_buffer method send_chan_ack void MAV_RESULT'enum 0 MAV_RESULT_ENUM_END-1 mavlink_channel_t'enum 0  mavlink_channel_t::MAVLINK_COMM_3
 
 include AP_RPM/AP_RPM.h
 singleton AP_RPM alias RPM

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -723,8 +723,8 @@ void handle_method(char *parent_name, struct method **methods) {
     if (arg_type.type == TYPE_NONE) {
       error(ERROR_USERDATA, "Can't pass an empty argument to a method");
     }
-    if ((method->return_type.type != TYPE_BOOLEAN) && (arg_type.flags & TYPE_FLAGS_NULLABLE)) {
-      error(ERROR_USERDATA, "Nullable arguments are only available on a boolean method");
+    if (((method->return_type.type != TYPE_BOOLEAN) && (method->return_type.type != TYPE_UINT8_T)) && (arg_type.flags & TYPE_FLAGS_NULLABLE)) {
+      error(ERROR_USERDATA, "Nullable arguments are only available on a boolean or uint8_t method");
     }
     if ((method->return_type.type == TYPE_BOOLEAN) && (arg_type.flags & TYPE_FLAGS_REFERNCE)) {
       error(ERROR_USERDATA, "Use Nullable arguments on a boolean method, not 'Ref");
@@ -1437,13 +1437,7 @@ void emit_userdata_fields() {
   }
 }
 
-// emit refences functions for a call, return the number of arduments added
-int emit_references(const struct argument *arg, const char * tab) {
-  int arg_index = NULLABLE_ARG_COUNT_BASE + 2;
-  int return_count = 0;
-  while (arg != NULL) {
-    if (arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) {
-      return_count++;
+void emit_refence_type(const struct argument *arg, const char * tab, int arg_index) {
       switch (arg->type.type) {
         case TYPE_BOOLEAN:
           fprintf(source, "%slua_pushboolean(L, data_%d);\n", tab, arg_index);
@@ -1481,11 +1475,39 @@ int emit_references(const struct argument *arg, const char * tab) {
           error(ERROR_INTERNAL, "Attempted to make a nullable or reference ap_object");
           break;
       }
+}
+
+// emit refences functions for a call, return the number of arduments added
+int emit_references(const struct argument *arg, const char * tab) {
+  int arg_index = NULLABLE_ARG_COUNT_BASE + 2;
+  int return_count = 0;
+  while (arg != NULL) {
+    if (arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) {
+      return_count++;
+      emit_refence_type(arg, tab, arg_index);
     }
     arg_index++;
     arg = arg->next;
   }
   return return_count;
+}
+
+// emit refences functions for a call, return the number of arduments added, apply return mask
+void emit_references_mask(const struct argument *arg, const char * tab) {
+  int arg_index = NULLABLE_ARG_COUNT_BASE + 2;
+  int count = 0;
+  char *tabtab = (char *)allocate(strlen(tab) + 4);
+  sprintf(tabtab, "%s    ", tab);
+  while (arg != NULL) {
+    if (arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) {
+      fprintf(source, "%sif (data & (1U << %i)) {\n", tab, count);
+      emit_refence_type(arg, tabtab, arg_index);
+      fprintf(source, "%s}\n", tab);
+      count++;
+    }
+    arg_index++;
+    arg = arg->next;
+  }
 }
 
 void emit_userdata_method(const struct userdata *data, const struct method *method) {
@@ -1696,6 +1718,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
     return_count += emit_references(arg,"    ");
   }
 
+  int add_return = TRUE;
   switch (method->return_type.type) {
     case TYPE_BOOLEAN:
       if (method->flags & TYPE_FLAGS_NULLABLE) {
@@ -1707,8 +1730,19 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
         fprintf(source, "    } else {\n");
         fprintf(source, "        return 0;\n");
         fprintf(source, "    }\n");
+        add_return = FALSE;
       } else {
         fprintf(source, "    lua_pushboolean(L, data);\n");
+      }
+      break;
+    case TYPE_UINT8_T:
+      if (method->flags & TYPE_FLAGS_NULLABLE) {
+        arg = method->arguments;
+        emit_references_mask(arg,"    ");
+        fprintf(source, "    return __builtin_popcountll(data);\n");
+        add_return = FALSE;
+      } else {
+        fprintf(source, "    lua_pushinteger(L, data);\n");
       }
       break;
     case TYPE_FLOAT:
@@ -1717,7 +1751,6 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
     case TYPE_INT8_T:
     case TYPE_INT16_T:
     case TYPE_INT32_T:
-    case TYPE_UINT8_T:
     case TYPE_UINT16_T:
     case TYPE_ENUM:
       fprintf(source, "    lua_pushinteger(L, data);\n");
@@ -1748,7 +1781,7 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       break;
   }
 
-  if ((method->return_type.type != TYPE_BOOLEAN) || ((method->flags & TYPE_FLAGS_NULLABLE) == 0)) {
+  if (add_return) {
       fprintf(source, "    return %d;\n", return_count);
   }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4298,6 +4298,14 @@ void GCS_MAVLINK::handle_command_long(const mavlink_message_t &msg)
     mavlink_command_long_t packet;
     mavlink_msg_command_long_decode(&msg, &packet);
 
+#ifdef ENABLE_SCRIPTING
+    AP_Scripting *scripting = AP_Scripting::get_singleton();
+    if (scripting != nullptr && scripting->handle_command_long(packet, chan)) {
+        // Scripting is listening for this command don't process
+        return;
+    }
+#endif
+
     hal.util->persistent_data.last_mavlink_cmd = packet.command;
 
     const MAV_RESULT result = handle_command_long_packet(packet);
@@ -4484,6 +4492,14 @@ void GCS_MAVLINK::handle_command_int(const mavlink_message_t &msg)
     // decode packet
     mavlink_command_int_t packet;
     mavlink_msg_command_int_decode(&msg, &packet);
+
+#ifdef ENABLE_SCRIPTING
+    AP_Scripting *scripting = AP_Scripting::get_singleton();
+    if (scripting != nullptr && scripting->handle_command_int(packet, chan)) {
+        // Scripting is listening command don't process
+        return;
+    }
+#endif
 
     hal.util->persistent_data.last_mavlink_cmd = packet.command;
 


### PR DESCRIPTION
This is a companion to https://github.com/ArduPilot/ardupilot/pull/13660, in that case we cant selectively listen to a particular command long/int message. This means that AP will go ahead and do what ever and send a ACK. In the case of the user command it will report as unsupported. 

To fix that we have to take the messages and not let AP see them. Obviously it would be bad to just do that for all command longs, so we need to have a special case per command ID, this is that.

I got a little carried away with the buffering, unlike https://github.com/ArduPilot/ardupilot/pull/13660 this can listen to as many commands as it likes from lots of different scripts. 

~~I have also added the ability to send command long and ints to AP from scripting, this is logged as channel -1 (I had to sacrifice the `current` field to get all the log fields to fit, but the spec says its not used)~~

~~As a drive by I have added `#ifdef`  to all the vehicle function only used by scripting, this saves about 500 bytes.~~

~~The only remaining thing is to add the ability to send back ACK's from scripting.~~

Can now send ACKs

 
 