### PR TITLE
AP_BattMonitor: Add Temperature Arming and Failsafe Checks 

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -511,6 +511,10 @@ void AP_BattMonitor::check_failsafes(void)
                     action = _params[i]._failsafe_critical_action;
                     type_str = "critical";
                     break;
+                case Failsafe::Unhealthy:
+                    action = _params[i]._failsafe_unhealthy_action;
+                    type_str = "unhealthy";
+                    break;
             }
 
             GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Battery %d is %s %.2fV used %.0f mAh", i + 1, type_str,
@@ -679,7 +683,7 @@ bool AP_BattMonitor::reset_remaining_mask(uint16_t battery_mask, float percentag
 
 // Returns the mavlink charge state. The following mavlink charge states are not used
 // MAV_BATTERY_CHARGE_STATE_EMERGENCY , MAV_BATTERY_CHARGE_STATE_FAILED
-// MAV_BATTERY_CHARGE_STATE_UNHEALTHY, MAV_BATTERY_CHARGE_STATE_CHARGING
+// MAV_BATTERY_CHARGE_STATE_CHARGING
 MAV_BATTERY_CHARGE_STATE AP_BattMonitor::get_mavlink_charge_state(const uint8_t instance) const 
 {
     if (instance >= _num_instances) {
@@ -699,6 +703,9 @@ MAV_BATTERY_CHARGE_STATE AP_BattMonitor::get_mavlink_charge_state(const uint8_t 
 
     case Failsafe::Critical:
         return MAV_BATTERY_CHARGE_STATE_CRITICAL;
+
+    case Failsafe::Unhealthy:
+        return MAV_BATTERY_CHARGE_STATE_UNHEALTHY;
     }
 
     // Should not reach this

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -75,8 +75,9 @@ public:
     // battery failsafes must be defined in levels of severity so that vehicles wont fall backwards
     enum class Failsafe : uint8_t {
         None = 0,
+        Unhealthy,
         Low,
-        Critical
+        Critical,
     };
 
     // Battery monitor driver types

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -84,8 +84,17 @@ protected:
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)
     AP_BattMonitor_Params               &_params;   // reference to this instances parameters (held in the front-end)
 
+    struct Failsafes{
+        bool low_voltage;
+        bool low_capacity;
+        bool critical_voltage;
+        bool critical_capacity;
+        bool below_temperature;
+        bool above_temperature;
+    };
+
     // checks what failsafes could be triggered
-    void check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity) const;
+    void check_failsafe_types(Failsafes& failsafes) const;
 
 private:
     // resistance estimate

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -147,6 +147,34 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
 
+    // @Param: TEMP_MIN
+    // @DisplayName: Minimum temperature
+    // @Description: The temperature which the battery must be above to not trigger a failsafe, -200 disables the check
+    // @Units: degC
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("TEMP_MIN", 22, AP_BattMonitor_Params, _minimum_temperature, DEFAULT_FAILSAFE_TEMPERATURE),
+
+    // @Param: TEMP_MAX
+    // @DisplayName: Maximum temperature
+    // @Description: The temperature which the battery must be below to not trigger a failsafe, -200 disables the check
+    // @Units: degC
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("TEMP_MAX", 23, AP_BattMonitor_Params, _maximum_temperature, DEFAULT_FAILSAFE_TEMPERATURE),
+
+    // @Param: FS_UNH_ACT
+    // @DisplayName: Unhealthy battery failsafe action
+    // @Description: What action the vehicle should perform if it hits an unhealthy failsafe
+    // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate,4:QLand
+    // @Values{Copter}: 0:None,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate
+    // @Values{Sub}: 0:None,2:Disarm,3:Enter surface mode
+    // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate
+    // @Values{Tracker}: 0:None
+    // @Values{Blimp}: 0:None,1:Land
+    // @User: Advanced
+    AP_GROUPINFO("FS_UNH_ACT", 24, AP_BattMonitor_Params, _failsafe_unhealthy_action, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -149,7 +149,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
 
     // @Param: TEMP_MIN
     // @DisplayName: Minimum temperature
-    // @Description: The temperature which the battery must be above to not trigger a failsafe, -200 disables the check
+    // @Description: Trigger a failsafe if the battery temperature is below this threshold, -200 disables the check
     // @Units: degC
     // @Increment: 0.1
     // @User: Advanced
@@ -157,7 +157,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
 
     // @Param: TEMP_MAX
     // @DisplayName: Maximum temperature
-    // @Description: The temperature which the battery must be below to not trigger a failsafe, -200 disables the check
+    // @Description: Trigger a failsafe if the battery temperature is above this threshold, -200 disables the check
     // @Units: degC
     // @Increment: 0.1
     // @User: Advanced

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -2,6 +2,8 @@
 
 #include <AP_Param/AP_Param.h>
 
+#define DEFAULT_FAILSAFE_TEMPERATURE -200.0f // Default arming temperature in Celsius
+
 class AP_BattMonitor_Params {
 public:
     static const struct AP_Param::GroupInfo var_info[];
@@ -43,4 +45,8 @@ public:
     AP_Int8  _failsafe_voltage_source;  /// voltage type used for detection of low voltage event
     AP_Int8  _failsafe_low_action;      /// action to preform on a low battery failsafe
     AP_Int8  _failsafe_critical_action; /// action to preform on a critical battery failsafe
+    AP_Int8  _failsafe_unhealthy_action; /// action to perform on an unhealthy failsafe
+
+    AP_Float _minimum_temperature;      /// [degC] minimum temperature
+    AP_Float _maximum_temperature;      /// [degC] maximum temperature
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -52,6 +52,15 @@ void AP_BattMonitor_SMBus::init(void)
     }
 }
 
+// Reset frontend failsafes to present backend state
+// don't allow reset of remaining capacity for SMBus
+bool AP_BattMonitor_SMBus::reset_remaining(float percentage)
+{
+    // reset failsafe state for this backend
+    _state.failsafe = update_failsafes();
+    return true;
+}
+
 // return true if cycle count can be provided and fills in cycles argument
 bool AP_BattMonitor_SMBus::get_cycle_count(uint16_t &cycles) const
 {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -46,8 +46,9 @@ public:
     // all smart batteries are expected to provide current
     bool has_current() const override { return true; }
 
+    // Reset frontend failsafes to present backend state
     // don't allow reset of remaining capacity for SMBus
-    bool reset_remaining(float percentage) override { return false; }
+    bool reset_remaining(float percentage) override;
 
     // return true if cycle count can be provided and fills in cycles argument
     bool get_cycle_count(uint16_t &cycles) const override;

--- a/libraries/SITL/SIM_BattMonitor_SMBus.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus.cpp
@@ -17,7 +17,6 @@ SITL::SIM_BattMonitor_SMBus::SIM_BattMonitor_SMBus() :
     add_block("Device Name", SMBusBattDevReg::DEVICE_NAME, SITL::I2CRegisters::RegMode::RDONLY);
     add_register("Manufacture Data", SMBusBattDevReg::MANUFACTURE_DATA, SITL::I2CRegisters::RegMode::RDONLY);
 
-    set_register(SMBusBattDevReg::TEMP, (int16_t)((15 + C_TO_KELVIN)*10));
      // see update for voltage
      // see update for current
      // TODO: remaining capacity
@@ -62,6 +61,12 @@ void SITL::SIM_BattMonitor_SMBus::update(const class Aircraft &aircraft)
         // FIXME: is this REALLY what the hardware will do?
         const int16_t current = constrain_int32(AP::sitl()->state.battery_current*-1000, -32768, 32767);
         set_register(SMBusBattDevReg::CURRENT, current);
+
+        // Update internal battery temperature measurement stored in centi-degC
+        const float sim_temperature = (AP::sitl()->batt_temperature + C_TO_KELVIN) * 10;
+        set_register(SMBusBattDevReg::TEMP, int16_t(sim_temperature));
+
+
         last_update_ms = now;
     }
 }

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -44,7 +44,7 @@ SIM *SIM::_singleton = nullptr;
 
 // table of user settable parameters
 const AP_Param::GroupInfo SIM::var_info[] = {
-    
+    AP_SUBGROUPEXTENSION("",       1, SIM,  var_info4),
     AP_GROUPINFO("DRIFT_SPEED",    5, SIM,  drift_speed, 0.05f),
     AP_GROUPINFO("DRIFT_TIME",     6, SIM,  drift_time,  5),
     AP_GROUPINFO("ENGINE_MUL",     8, SIM,  engine_mul,  1),
@@ -297,6 +297,13 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
 #ifdef SFML_JOYSTICK
     AP_SUBGROUPEXTENSION("",      63, SIM,  var_sfml_joystick),
 #endif // SFML_JOYSTICK
+
+    AP_GROUPEND
+};
+
+// fourth table of user settable parameters for SITL.
+const AP_Param::GroupInfo SIM::var_info4[] = {
+    AP_GROUPINFO("BATT_TEMP",      1, SIM, batt_temperature, 20.0),
 
     AP_GROUPEND
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -102,6 +102,7 @@ public:
         AP_Param::setup_object_defaults(this, var_info);
         AP_Param::setup_object_defaults(this, var_info2);
         AP_Param::setup_object_defaults(this, var_info3);
+        AP_Param::setup_object_defaults(this, var_info4);
         AP_Param::setup_object_defaults(this, var_gps);
         AP_Param::setup_object_defaults(this, var_mag);
         AP_Param::setup_object_defaults(this, var_ins);
@@ -147,6 +148,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
     static const struct AP_Param::GroupInfo var_info2[];
     static const struct AP_Param::GroupInfo var_info3[];
+    static const struct AP_Param::GroupInfo var_info4[];
     static const struct AP_Param::GroupInfo var_gps[];
     static const struct AP_Param::GroupInfo var_mag[];
     static const struct AP_Param::GroupInfo var_ins[];
@@ -205,6 +207,7 @@ public:
 
     AP_Float batt_voltage; // battery voltage base
     AP_Float batt_capacity_ah; // battery capacity in Ah
+    AP_Float batt_temperature; // battery temperature in deg C
     AP_Int8  rc_fail;     // fail RC input
     AP_Int8  rc_chancount; // channel count
     AP_Int8  float_exception; // enable floating point exception checks


### PR DESCRIPTION
This PR adds failsafe and arming checks for minimum and maximum temperatures. It replaces this PR https://github.com/ArduPilot/ardupilot/pull/7451 

It should be useful for those operating in cold environments or wanting to detect battery pack anomalies.

**Additions**
- Uses `MAV_BATTERY_CHARGE_STATE_UNHEALTHY` when a temperature failsafe occurs
- SITL  `sim_batt_temp` state param in order to test the failsafes via autotests. 
- Autotests to test no failsafe action occurs when the temperature failsafes are hit but no action is defined for `Unhealthy`
- Autotest to ensure that priority of `Critical` over `Unhealthy` is tested and obeys `Critical's` set actions
- Controversial item?: method to reset smbus fail safes to the most recent status as I think this could be useful...for resetting intermittent failsafes from mission planner. Truly `reset_remaining()` should be renamed as its base implementation does more than reset the remaining capacity.

**Points of discussion:**

- What should happen when these checks fail in terms of a failsafe?
  - Here I set `MAV_BATTERY_CHARGE_STATE_UNHEALTHY` as that seemed the most logical and added an action param for `Failsafe::Unhealthy`
- What should the order of  `Failsafe::Unhealthy` be with respect to `Failsafe::Low` &  `Failsafe::Critical`?
  - I've put it with a lower priority than `Low`, but I think a case could be made for higher than `Low`. IE if you batteries are burning hot land Now
- Should the user be notified during flight more specifically that the temperature is unhealthy?
   - On arming the notification is specific to temperature.

**Below shows Pre-Arm Failsafes**
![image](https://user-images.githubusercontent.com/69225461/126133193-86c988c5-0cbe-43a3-814b-c196ad6c3c9f.png)

**Below shows in-flight failsafe performa Smart RTL action**
![image](https://user-images.githubusercontent.com/69225461/126133007-ec2c6160-0464-4b1c-aff5-0425d7741a5d.png)
