### PR TITLE
Fix memset warning on GCC 10

### DIFF
--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -164,7 +164,11 @@ void CompassLearn::update(void)
             sample_available = false;
             num_samples = 0;
             have_earth_field = false;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+            // this is use on vector3f, therefore the memset is the fastest option
             memset(predicted_offsets, 0, sizeof(predicted_offsets));
+#pragma pop
             worst_error = 0;
             best_error = 0;
             best_yaw_deg = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
@@ -376,7 +376,11 @@ void AP_InertialSensor::TCal::update_gyro_learning(const Vector3f &gyro, float t
  */
 void AP_InertialSensor::TCal::Learn::reset(float temperature)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+    // this is use on vector3f, therefore the memset is the fastest option
     memset(state, 0, sizeof(state));
+#pragma GCC diagnostic pop
     start_tmax = tcal.temp_max;
     accel_start.zero();
     for (uint8_t i=0; i<ARRAY_SIZE(state); i++) {

--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -36,7 +36,11 @@ class VectorN
 public:
     // trivial ctor
     inline VectorN<T,N>() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+        // this is use on vector or complex class, therefore the memset is the fastest option
         memset(_v, 0, sizeof(T)*N);
+#pragma pop
     }
 
     // vector ctor


### PR DESCRIPTION
We got some warning on gcc10 : 
```

In file included from ../../libraries/AP_AccelCal/AccelCalibrator.h:16,
                 from ../../libraries/AP_AccelCal/AP_AccelCal.h:4,
                 from ../../libraries/AP_InertialSensor/AP_InertialSensor.h:41,
                 from ../../libraries/AP_HAL_SITL/SITL_State.h:23,
                 from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.h:9,
                 from ../../libraries/AP_HAL_SITL/AP_HAL_SITL.h:7,
                 from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:10:
../../libraries/AP_Math/vectorN.h: In instantiation of ‘VectorN<T, N>::VectorN() [with T = HALSITL::SITL_State::readings_mag; unsigned char N = 250]’:
../../libraries/AP_HAL_SITL/SITL_State.h:61:16:   required from here
../../libraries/AP_Math/vectorN.h:39:15: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct HALSITL::SITL_State::readings_mag’; use assignment or value-initialization instead [-Wclass-memaccess]
   39 |         memset(_v, 0, sizeof(T)*N);
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~
In file included from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.h:9,
                 from ../../libraries/AP_HAL_SITL/AP_HAL_SITL.h:7,
                 from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:10:
../../libraries/AP_HAL_SITL/SITL_State.h:225:12: note: ‘struct HALSITL::SITL_State::readings_mag’ declared here
  225 |     struct readings_mag {
      |     
```


On compass, we could use a loop to zero() the vectors but that is longer than the memset.
On other place, I don't think there is easy way to fix this so I discard the warning on those.
