### PR TITLE
AP_AHRS: remove unused active_accel_instance

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -471,11 +471,6 @@ public:
         return false;
     }
 
-    // return the active accelerometer instance
-    uint8_t get_active_accel_instance(void) const {
-        return _active_accel_instance;
-    }
-
     // is the AHRS subsystem healthy?
     virtual bool healthy(void) const = 0;
 


### PR DESCRIPTION
Not a great member function as only DCM updates this