### PR TITLE
Add atleast one build with debug flag

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -23,7 +23,8 @@ jobs:
             periph-build,
             iofirmware,
             CubeOrange-bootloader,
-            revo-bootloader
+            revo-bootloader,
+            stm32h7-debug
         ]
         toolchain: [
             chibios,  # GCC-6

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -247,6 +247,14 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "stm32h7-debug" ]; then
+        echo "Building Durandal"
+        $waf configure --board Durandal --debug
+        $waf clean
+        $waf copter
+        continue
+    fi
+
     if [ "$t" == "fmuv2-plane" ]; then
         echo "Building fmuv2 plane"
         $waf configure --board fmuv2

--- a/libraries/AP_NavEKF/AP_NavEKF_core_common.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core_common.h
@@ -61,7 +61,7 @@ protected:
 #if MATH_CHECK_INDEXES
 #pragma GCC diagnostic error "-Wframe-larger-than=4000"
 #else
-#pragma GCC diagnostic error "-Wframe-larger-than=2100"
+#pragma GCC diagnostic error "-Wframe-larger-than=2500"
 #endif
 #endif
 


### PR DESCRIPTION
This PR adds stm32h7-debug build to ensure we are not overflowing things with debug flags.
It turned out that we were running out of max allowed stack frame size in NavEKF when debug flag was added to configure.