### PR TITLE
EKF: Split GPS yaw into a separate measurement step from GPS posvel

### DIFF
--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -57,7 +57,7 @@ void AP_DAL_GPS::start_frame()
 
         RGPJ.velocity = gps.velocity(i);
         RGPI.speed_accuracy_returncode = gps.speed_accuracy(i, RGPJ.sacc);
-        RGPI.gps_yaw_deg_returncode = gps.gps_yaw_deg(i, RGPJ.yaw_deg, RGPJ.yaw_accuracy_deg);
+        RGPI.gps_yaw_deg_returncode = gps.gps_yaw_deg(i, RGPJ.yaw_deg, RGPJ.yaw_accuracy_deg, RGPJ.yaw_deg_time_ms);
 
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPI, RGPI, old_RGPI);
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPJ, RGPJ, old_RGPJ);

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -92,13 +92,10 @@ public:
         return speed_accuracy(primary_sensor(), sacc);
     }
 
-    bool gps_yaw_deg(float &yaw_deg, float &accuracy_deg) const {
-        return gps_yaw_deg(_RGPH.primary_sensor, yaw_deg, accuracy_deg);
-    }
-
-    bool gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg) const {
+    bool gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, uint32_t &time_ms) const {
         yaw_deg = _RGPJ[instance].yaw_deg;
         accuracy_deg = _RGPJ[instance].yaw_accuracy_deg;
+        time_ms = _RGPJ[instance].yaw_deg_time_ms;
         return _RGPI[instance].gps_yaw_deg_returncode;
     }
 

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -208,6 +208,7 @@ struct log_RGPJ {
     float sacc;
     float yaw_deg;
     float yaw_accuracy_deg;
+    uint32_t yaw_deg_time_ms;
     int32_t lat;
     int32_t lng;
     int32_t alt;
@@ -399,7 +400,7 @@ struct log_RBOH {
     { LOG_RGPI_MSG, RLOG_SIZE(RGPI),                                   \
       "RGPI", "ffffBBBB", "OX,OY,OZ,Lg,Flags,Stat,NSats,I", "-------#", "--------" }, \
     { LOG_RGPJ_MSG, RLOG_SIZE(RGPJ),                                   \
-      "RGPJ", "IffffffiiiffHB", "TS,VX,VY,VZ,SA,Y,YA,Lat,Lon,Alt,HA,VA,HD,I", "-------------#", "--------------" }, \
+      "RGPJ", "IffffffIiiiffHB", "TS,VX,VY,VZ,SA,Y,YA,YT,Lat,Lon,Alt,HA,VA,HD,I", "--------------#", "---------------" }, \
     { LOG_RMGH_MSG, RLOG_SIZE(RMGH),                                   \
       "RMGH", "BBfBBBB", "Dec,NumInst,AutoDec,NumEna,LOE,C,FUsable", "-------", "-------" },  \
     { LOG_RMGI_MSG, RLOG_SIZE(RMGI),                                   \

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -168,6 +168,7 @@ public:
         float ground_speed;                 ///< ground speed in m/sec
         float ground_course;                ///< ground course in degrees
         float gps_yaw;                      ///< GPS derived yaw information, if available (degrees)
+        uint32_t gps_yaw_time_ms;           ///< timestamp of last GPS yaw reading
         bool  gps_yaw_configured;           ///< GPS is configured to provide yaw
         uint16_t hdop;                      ///< horizontal dilution of precision in cm
         uint16_t vdop;                      ///< vertical dilution of precision in cm
@@ -328,21 +329,9 @@ public:
     }
 
     // yaw in degrees if available
-    bool gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg) const {
-        if (!have_gps_yaw(instance)) {
-            return false;
-        }
-        yaw_deg = state[instance].gps_yaw;
-        if (state[instance].have_gps_yaw_accuracy) {
-            accuracy_deg = state[instance].gps_yaw_accuracy;
-        } else {
-            // fall back to 10 degrees as a generic default
-            accuracy_deg = 10;
-        }
-        return true;
-    }
-    bool gps_yaw_deg(float &yaw_deg, float &accuracy_deg) const {
-        return gps_yaw_deg(primary_instance, yaw_deg, accuracy_deg);
+    bool gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, uint32_t &time_ms) const;
+    bool gps_yaw_deg(float &yaw_deg, float &accuracy_deg, uint32_t &time_ms) const {
+        return gps_yaw_deg(primary_instance, yaw_deg, accuracy_deg, time_ms);
     }
 
     // number of locked satellites

--- a/libraries/AP_GPS/AP_GPS_MSP.cpp
+++ b/libraries/AP_GPS/AP_GPS_MSP.cpp
@@ -77,12 +77,13 @@ void AP_GPS_MSP::handle_msp(const MSP::msp_gps_data_message_t &pkt)
     state.vertical_accuracy = pkt.vertical_pos_accuracy * 0.01;
     state.speed_accuracy = pkt.horizontal_vel_accuracy * 0.01;
 
+    state.last_gps_time_ms = AP_HAL::millis();
+
     if (pkt.true_yaw != 65535) {
         state.gps_yaw = wrap_360(pkt.true_yaw*0.01);
         state.have_gps_yaw = true;
+        state.gps_yaw_time_ms = state.last_gps_time_ms;
     }
-
-    state.last_gps_time_ms = AP_HAL::millis();
 
     new_data = pkt.fix_type>0;
 }

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -339,6 +339,7 @@ bool AP_GPS_NMEA::_term_complete()
                     _last_HDT_THS_ms = now;
                     state.gps_yaw = wrap_360(_new_gps_yaw*0.01f);
                     state.have_gps_yaw = true;
+                    state.gps_yaw_time_ms = AP_HAL::millis();
                     // remember that we are setup to provide yaw. With
                     // a NMEA GPS we can only tell if the GPS is
                     // configured to provide yaw when it first sends a

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -525,6 +525,9 @@ void AP_GPS_UAVCAN::handle_heading_msg(const HeadingCb &cb)
 
     interim_state.have_gps_yaw = cb.msg->heading_valid;
     interim_state.gps_yaw = degrees(cb.msg->heading_rad);
+    if (interim_state.have_gps_yaw) {
+        interim_state.gps_yaw_time_ms = AP_HAL::millis();
+    }
 
     interim_state.have_gps_yaw_accuracy = cb.msg->heading_accuracy_valid;
     interim_state.gps_yaw_accuracy = degrees(cb.msg->heading_accuracy_rad);

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -384,6 +384,7 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(const float reported_heading_deg,
             const float rotation_offset_rad = Vector2f(-offset.x, -offset.y).angle();
             state.gps_yaw = wrap_360(reported_heading_deg - degrees(rotation_offset_rad));
             state.have_gps_yaw = true;
+            state.gps_yaw_time_ms = AP_HAL::millis();
         }
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -701,17 +701,26 @@ void NavEKF3_core::readGpsData()
         // declare GPS available for use
         gpsNotAvailable = false;
     }
+}
 
-    // if the GPS has yaw data then input that as well
+// check for new valid GPS yaw data
+void NavEKF3_core::readGpsYawData()
+{
+    const auto &gps = dal.gps();
+
+    // if the GPS has yaw data then fuse it as an Euler yaw angle
     float yaw_deg, yaw_accuracy_deg;
-    if (dal.gps().gps_yaw_deg(selected_gps, yaw_deg, yaw_accuracy_deg)) {
+    uint32_t yaw_time_ms;
+    if (gps.status(selected_gps) >= AP_DAL_GPS::GPS_OK_FIX_3D &&
+        dal.gps().gps_yaw_deg(selected_gps, yaw_deg, yaw_accuracy_deg, yaw_time_ms) &&
+        yaw_time_ms != yawMeasTime_ms) {
         // GPS modules are rather too optimistic about their
         // accuracy. Set to min of 5 degrees here to prevent
         // the user constantly receiving warnings about high
         // normalised yaw innovations
         const ftype min_yaw_accuracy_deg = 5.0f;
         yaw_accuracy_deg = MAX(yaw_accuracy_deg, min_yaw_accuracy_deg);
-        writeEulerYawAngle(radians(yaw_deg), radians(yaw_accuracy_deg), gpsDataNew.time_ms, 2);
+        writeEulerYawAngle(radians(yaw_deg), radians(yaw_accuracy_deg), yaw_time_ms, 2);
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -445,6 +445,7 @@ void NavEKF3_core::SelectVelPosFusion()
 
     // Read GPS data from the sensor
     readGpsData();
+    readGpsYawData();
 
     // get data that has now fallen behind the fusion time horizon
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -499,6 +499,7 @@ bool NavEKF3_core::InitialiseFilterBootstrap(void)
     readIMUData();
     readMagData();
     readGpsData();
+    readGpsYawData();
     readBaroData();
 
     if (statesInitialised) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -696,6 +696,9 @@ private:
     // check for new valid GPS data and update stored measurement if available
     void readGpsData();
 
+    // check for new valid GPS yaw data
+    void readGpsYawData();
+
     // check for new altitude measurement data and update stored measurement if available
     void readBaroData();
 


### PR DESCRIPTION
This separates out the timestamp for GPS yaw from the main GPS position/velocity timestamp, allowing the EKF to process the measurements on separate time horizon. 
It also fixes the nasty hack where we switched GPS primary when a moving baseline rover gained/lost yaw. Instead we use the moving base whenever it has 3D lock, which means we get the more accurate position and velocity data (the base position and velocity is always more accurate and less lagged than the rover data, as the rover data is derived from the base)
It also fixes the timestamp we use for GPS yaw. The writeEulerYawAngle() function wasn't taking account of the GPS lag, which means it was using the wrong timestamp.
Tested on a CubeOrange with two F9P modules, in bench setup