### PR TITLE
AP_Scripting: add AP_InertialSensor binding

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -399,3 +399,7 @@ userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field roll'array AP_MOT
 userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field pitch'array AP_MOTORS_MAX_NUM_MOTORS float read write -FLT_MAX FLT_MAX
 userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field yaw'array AP_MOTORS_MAX_NUM_MOTORS float read write -FLT_MAX FLT_MAX
 userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field throttle'array AP_MOTORS_MAX_NUM_MOTORS float read write -FLT_MAX FLT_MAX
+
+include AP_InertialSensor/AP_InertialSensor.h
+singleton AP_InertialSensor alias ins
+singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES


### PR DESCRIPTION
I added this to monitor if the IMU is at the applicable temperature.

I tested this in SITL.

```
gcs:send_text(6, string.format("ins temp0 %f", ins:get_temperature(0)))
gcs:send_text(6, string.format("ins temp1 %f", ins:get_temperature(1)))
```

```
AP: ins temp0 25.945900
AP: ins temp1 25.945900
AP: ins temp0 26.135618
AP: ins temp1 26.135681
AP: ins temp0 26.323446
AP: ins temp1 26.323446
AP: ins temp0 26.509527
AP: ins temp1 26.509588
AP: ins temp0 26.693693
AP: ins temp1 26.693754
```