### PR TITLE
AP_BoardConfig: Enable to specify the upper board voltage

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -792,8 +792,9 @@ bool AP_Arming::board_voltage_checks(bool report)
 #if HAL_HAVE_BOARD_VOLTAGE
         const float bus_voltage =  hal.analogin->board_voltage();
         const float vbus_min = AP_BoardConfig::get_minimum_board_voltage();
-        if(((bus_voltage < vbus_min) || (bus_voltage > AP_ARMING_BOARD_VOLTAGE_MAX))) {
-            check_failed(ARMING_CHECK_VOLTAGE, report, "Board (%1.1fv) out of range %1.1f-%1.1fv", (double)bus_voltage, (double)vbus_min, (double)AP_ARMING_BOARD_VOLTAGE_MAX);
+        const float vbus_max = AP_BoardConfig::get_maximum_board_voltage();
+        if(((bus_voltage < vbus_min) || (bus_voltage > vbus_max))) {
+            check_failed(ARMING_CHECK_VOLTAGE, report, "Board (%1.1fv) out of range %1.1f-%1.1fv", (double)bus_voltage, (double)vbus_min, (double)vbus_max);
             return false;
         }
 #endif // HAL_HAVE_BOARD_VOLTAGE

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -62,6 +62,9 @@
 #ifndef BOARD_CONFIG_BOARD_VOLTAGE_MIN
 #define BOARD_CONFIG_BOARD_VOLTAGE_MIN 4.3f
 #endif
+#ifndef BOARD_CONFIG_BOARD_VOLTAGE_MAX
+#define BOARD_CONFIG_BOARD_VOLTAGE_MAX 5.8f
+#endif
 
 #ifndef HAL_BRD_OPTIONS_DEFAULT
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS && !APM_BUILD_TYPE(APM_BUILD_UNKNOWN) && !APM_BUILD_TYPE(APM_BUILD_Replay)
@@ -233,6 +236,15 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("VBUS_MIN",    15,     AP_BoardConfig,  _vbus_min,  BOARD_CONFIG_BOARD_VOLTAGE_MIN),
+
+    // @Param: VBUS_MAX
+    // @DisplayName: Autopilot board voltage requirement
+    // @Description: Maximum voltage on the autopilot power rail to allow the aircraft to arm. 0 to disable the check.
+    // @Units: V
+    // @Range: 4.0 5.8
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("VBUS_MAX",    26,     AP_BoardConfig,  _vbus_max,  BOARD_CONFIG_BOARD_VOLTAGE_MAX),
 
 #endif
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -157,6 +157,10 @@ public:
     static float get_minimum_board_voltage(void) {
         return _singleton?_singleton->_vbus_min.get():0;
     }
+    // get maximum board voltage
+    static float get_maximum_board_voltage(void) {
+        return _singleton?_singleton->_vbus_max.get():0;
+    }
 #endif
 
 #if HAL_HAVE_SERVO_VOLTAGE
@@ -266,6 +270,7 @@ private:
 
 #if HAL_HAVE_BOARD_VOLTAGE
     AP_Float _vbus_min;
+    AP_Float _vbus_max;
 #endif
 
 #if HAL_HAVE_SERVO_VOLTAGE


### PR DESCRIPTION
Depending on the FC, there is also an upper limit to the guaranteed operating voltage.
The ArduPilot is fixed at 5.8V.
I would like to set the upper limit depending on the FC.
For example, CUAV V5+ is 5.4V.

https://ardupilot.org/copter/docs/common-cuav-v5plus-overview.html

AFTER:
![Screenshot from 2021-07-21 13-34-43](https://user-images.githubusercontent.com/646194/126432935-f4a4a527-f701-4493-92e7-139c981c55d8.png)
