### PR TITLE
autotest: drain pexpects in set_parameters loop

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4032,6 +4032,7 @@ class AutoTest(ABC):
         autopilot_values = {}
         for i in range(attempts):
             self.drain_mav(quiet=True)
+            self.drain_all_pexpects()
             received = set()
             for (name, value) in want.items():
                 if verbose:


### PR DESCRIPTION
This loop doesn't self.mav.recv(), so the idle loop isn't called, so the
pexpects aren't drained.  That can cause ArduPilot to block on stderr if
it is trying to print a stacktrace, for example