### PR TITLE
define out scripting specific vehicle functions when no scripting. 

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -270,6 +270,7 @@ void Copter::fast_loop()
     AP_Vehicle::fast_loop();
 }
 
+#ifdef ENABLE_SCRIPTING
 // start takeoff to given altitude (for use by scripting)
 bool Copter::start_takeoff(float alt)
 {
@@ -336,6 +337,7 @@ bool Copter::set_target_angle_and_climbrate(float roll_deg, float pitch_deg, flo
     mode_guided.set_angle(q, climb_rate_ms*100, use_yaw_rate, radians(yaw_rate_degs), false);
     return true;
 }
+#endif // ENABLE_SCRIPTING
 
 
 // rc_loops - reads user input from transmitter/receiver

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -642,11 +642,13 @@ private:
                              uint8_t &task_count,
                              uint32_t &log_bit) override;
     void fast_loop() override;
+#ifdef ENABLE_SCRIPTING
     bool start_takeoff(float alt) override;
     bool set_target_location(const Location& target_loc) override;
     bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) override;
+#endif // ENABLE_SCRIPTING
     void rc_loop();
     void throttle_loop();
     void update_batt_compass(void);

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -647,7 +647,7 @@ bool Plane::get_wp_crosstrack_error_m(float &xtrack_error) const
     return true;
 }
 
-
+#ifdef ENABLE_SCRIPTING
 // set target location (for use by scripting)
 bool Plane::set_target_location(const Location& target_loc)
 {
@@ -685,5 +685,6 @@ bool Plane::get_target_location(Location& target_loc)
     }
     return false;
 }
+#endif // ENABLE_SCRIPTING
 
 AP_HAL_MAIN_CALLBACKS(&plane);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1141,8 +1141,11 @@ private:
 
 public:
     void failsafe_check(void);
+#ifdef ENABLE_SCRIPTING
     bool set_target_location(const Location& target_loc) override;
     bool get_target_location(Location& target_loc) override;
+#endif // ENABLE_SCRIPTING
+
 };
 
 extern Plane plane;

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -135,6 +135,7 @@ Rover::Rover(void) :
 {
 }
 
+#ifdef ENABLE_SCRIPTING
 // set target location (for use by scripting)
 bool Rover::set_target_location(const Location& target_loc)
 {
@@ -213,6 +214,7 @@ bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &
     }
     return false;
 }
+#endif // ENABLE_SCRIPTING
 
 #if STATS_ENABLED == ENABLED
 /*

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -273,10 +273,12 @@ private:
 private:
 
     // Rover.cpp
+#ifdef ENABLE_SCRIPTING
     bool set_target_location(const Location& target_loc) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_steering_and_throttle(float steering, float throttle) override;
     bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) override;
+#endif // ENABLE_SCRIPTING
     void stats_update();
     void ahrs_update();
     void gcs_failsafe_check(void);

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -178,6 +178,7 @@ public:
     // returns true if the vehicle has crashed
     virtual bool is_crashed() const;
 
+#ifdef ENABLE_SCRIPTING
     /*
       methods to control vehicle for use by scripting
     */
@@ -192,6 +193,8 @@ public:
 
     // set steering and throttle (-1 to +1) (for use by scripting with Rover)
     virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
+#endif // ENABLE_SCRIPTING
+
 
     // control outputs enumeration
     enum class ControlOutput {


### PR DESCRIPTION
Easy win, saving 600 bytes on copter F405 Wing

```
Binary           text             data         bss            total
---------------  ---------------  -----------  -------------  ---------------
antennatracker   -84 (-0.0127%)   0 (0.0000%)  4 (+0.0031%)   -80 (-0.0101%)
arducopter       -600 (-0.0643%)  0 (0.0000%)  0 (0.0000%)    -600 (-0.0564%)
arducopter-heli  -600 (-0.0654%)  0 (0.0000%)  0 (0.0000%)    -600 (-0.0572%)
ardurover        -576 (-0.0694%)  0 (0.0000%)  0 (0.0000%)    -576 (-0.0599%)
arduplane        -228 (-0.0235%)  0 (0.0000%)  -4 (-0.0031%)  -232 (-0.0211%)
blimp            -84 (-0.0124%)   0 (0.0000%)  4 (+0.0031%)   -80 (-0.0099%)
ardusub          -84 (-0.0104%)   0 (0.0000%)  4 (+0.0031%)   -80 (-0.0085%)

```