### PR TITLE
Fix bad calls from thread by CANSensor child classes

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_MPPT_PacketDigital.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_MPPT_PacketDigital.h
@@ -20,8 +20,10 @@ public:
     // construct the CAN Sensor
     AP_BattMonitor_MPPT_PacketDigital(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params):
         AP_BattMonitor_Backend(mon, mon_state, params),
-        CANSensor("MPPT", AP_CANManager::Driver_Type_MPPT_PacketDigital)
-    { };
+        CANSensor("MPPT")
+    {
+        register_driver(AP_CANManager::Driver_Type_MPPT_PacketDigital);
+    }
 
     /// Read the battery voltage and current.  Should be called at 10hz
     void read() override;

--- a/libraries/AP_CANManager/AP_CANSensor.cpp
+++ b/libraries/AP_CANManager/AP_CANSensor.cpp
@@ -30,20 +30,26 @@ extern const AP_HAL::HAL& hal;
 #define debug_can(level_debug, fmt, args...)
 #endif
 
-CANSensor::CANSensor(const char *driver_name, AP_CANManager::Driver_Type dtype, uint16_t stack_size) :
+CANSensor::CANSensor(const char *driver_name, uint16_t stack_size) :
     _driver_name(driver_name),
     _stack_size(stack_size)
+{}
+
+
+void CANSensor::register_driver(AP_CANManager::Driver_Type dtype)
 {
 #if HAL_CANMANAGER_ENABLED
     if (!AP::can().register_driver(dtype, this)) {
-        debug_can(AP_CANManager::LOG_ERROR, "Failed to register CANSensor %s", driver_name);
+        debug_can(AP_CANManager::LOG_ERROR, "Failed to register CANSensor %s", _driver_name);
     } else {
-        debug_can(AP_CANManager::LOG_INFO, "%s: constructed", driver_name);
+        debug_can(AP_CANManager::LOG_INFO, "%s: constructed", _driver_name);
     }
 #elif defined(HAL_BUILD_AP_PERIPH)
     register_driver_periph(dtype);
 #endif
 }
+
+
 #ifdef HAL_BUILD_AP_PERIPH
 CANSensor::CANSensor_Periph CANSensor::_periph[HAL_NUM_CAN_IFACES];
 

--- a/libraries/AP_CANManager/AP_CANSensor.h
+++ b/libraries/AP_CANManager/AP_CANSensor.h
@@ -24,8 +24,8 @@
 
 class CANSensor : public AP_CANDriver {
 public:
-    CANSensor(const char *driver_name, AP_CANManager::Driver_Type dtype, uint16_t stack_size=2048);
-    
+    CANSensor(const char *driver_name, uint16_t stack_size=2048);
+
     /* Do not allow copies */
     CANSensor(const CANSensor &other) = delete;
     CANSensor &operator=(const CANSensor&) = delete;
@@ -47,6 +47,9 @@ public:
         }
     }
 #endif
+
+protected:
+    void register_driver(AP_CANManager::Driver_Type dtype);
 
 private:
     void loop();

--- a/libraries/AP_EFI/AP_EFI_NWPMU.cpp
+++ b/libraries/AP_EFI/AP_EFI_NWPMU.cpp
@@ -26,9 +26,10 @@
 extern const AP_HAL::HAL& hal;
 
 AP_EFI_NWPMU::AP_EFI_NWPMU(AP_EFI &_frontend) :
-    CANSensor("NWPMU", AP_CANManager::Driver_Type_EFI_NWPMU),
+    CANSensor("NWPMU"),
     AP_EFI_Backend(_frontend)
 {
+    register_driver(AP_CANManager::Driver_Type_EFI_NWPMU);
 }
 
 void AP_EFI_NWPMU::handle_frame(AP_HAL::CANFrame &frame)

--- a/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.cpp
@@ -7,9 +7,10 @@
   constructor
  */
 AP_RangeFinder_USD1_CAN::AP_RangeFinder_USD1_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
-    CANSensor("USD1", AP_CANManager::Driver_Type_USD1),
+    CANSensor("USD1"),
     AP_RangeFinder_Backend(_state, _params)
 {
+    register_driver(AP_CANManager::Driver_Type_USD1);
 }
 
 // update state


### PR DESCRIPTION
This PR resolves the issue where we were starting threads under CANSensor constructor. These threads in turn call virtual methods overriden in Child class, this ends up raising fault and permanent lock up as observed in this PR https://github.com/ArduPilot/ardupilot/pull/17681 .