### PR TITLE
Correct rotation of Quaternions returned from AP_AHRS

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1860,25 +1860,6 @@ class AutoTestCopter(AutoTest):
 
         self.do_RTL()
 
-    def wait_attitude(self, desroll=None, despitch=None, timeout=2, tolerance=10):
-        '''wait for an attitude (degrees)'''
-        if desroll is None and despitch is None:
-            raise ValueError("despitch or desroll must be supplied")
-        tstart = self.get_sim_time()
-        while True:
-            if self.get_sim_time_cached() - tstart > 2:
-                raise AutoTestTimeoutException("Failed to achieve attitude")
-            m = self.mav.recv_match(type='ATTITUDE', blocking=True)
-            roll_deg = math.degrees(m.roll)
-            pitch_deg = math.degrees(m.pitch)
-            self.progress("wait_att: roll=%f desroll=%s pitch=%f despitch=%s" %
-                          (roll_deg, desroll, pitch_deg, despitch))
-            if desroll is not None and abs(roll_deg - desroll) > tolerance:
-                continue
-            if despitch is not None and abs(pitch_deg - despitch) > tolerance:
-                continue
-            return
-
     def fly_flip(self):
         ex = None
         try:

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3186,6 +3186,10 @@ class AutoTestPlane(AutoTest):
              "Test AHRS_ORIENTATION parameter",
              self.AHRS_ORIENTATION),
 
+            ("AHRSTrim",
+             "AHRS trim testing",
+             self.ahrstrim),
+
             ("LogUpload",
              "Log upload",
              self.log_upload),

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3783,6 +3783,25 @@ class AutoTest(ABC):
                               (delta, timeout))
                 return True
 
+    def wait_attitude(self, desroll=None, despitch=None, timeout=2, tolerance=10):
+        '''wait for an attitude (degrees)'''
+        if desroll is None and despitch is None:
+            raise ValueError("despitch or desroll must be supplied")
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 2:
+                raise AutoTestTimeoutException("Failed to achieve attitude")
+            m = self.mav.recv_match(type='ATTITUDE', blocking=True)
+            roll_deg = math.degrees(m.roll)
+            pitch_deg = math.degrees(m.pitch)
+            self.progress("wait_att: roll=%f desroll=%s pitch=%f despitch=%s" %
+                          (roll_deg, desroll, pitch_deg, despitch))
+            if desroll is not None and abs(roll_deg - desroll) > tolerance:
+                continue
+            if despitch is not None and abs(pitch_deg - despitch) > tolerance:
+                continue
+            return
+
     def CPUFailsafe(self):
         '''Most vehicles just disarm on failsafe'''
         # customising the SITL commandline ensures the process will

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5879,10 +5879,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
              "Accelerometer Calibration testing",
              self.accelcal),
 
-            ("AHRSTrim",
-             "Accelerometer trim testing",
-             self.ahrstrim),
-
             ("AP_Proximity_MAV",
              "Test MAV proximity backend",
              self.ap_proximity_mav),

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -417,6 +417,11 @@ void QuaternionT<T>::from_euler(T roll, T pitch, T yaw)
     q3 = cr2*sp2*cy2 + sr2*cp2*sy2;
     q4 = cr2*cp2*sy2 - sr2*sp2*cy2;
 }
+template <typename T>
+void QuaternionT<T>::from_euler(const Vector3<T> &v)
+{
+    from_euler(v[0], v[1], v[2]);
+}
 
 // create a quaternion from Euler angles applied in yaw, roll, pitch order
 // instead of the normal yaw, pitch, roll order

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -81,6 +81,7 @@ public:
 
     // create a quaternion from Euler angles
     void        from_euler(T roll, T pitch, T yaw);
+    void        from_euler(const Vector3<T> &v);
 
     // create a quaternion from Euler angles applied in yaw, roll, pitch order
     // instead of the normal yaw, pitch, roll order

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4648,7 +4648,7 @@ void GCS_MAVLINK::send_attitude_quaternion() const
 {
     const AP_AHRS &ahrs = AP::ahrs();
     Quaternion quat;
-    if (!ahrs.get_secondary_quaternion(quat)) {
+    if (!ahrs.get_quaternion(quat)) {
         return;
     }
     const Vector3f omega = ahrs.get_gyro();


### PR DESCRIPTION
These were not being rotated according to `AHRS_TRIM`.

This is mostly a reporting thing (e.g. `ATTITUDE_QUATERNION` should match `ATTITUDE`!), but also affects the T265 visual odometry support.

I think the confusion comes about here because the EKFs *do* rotate the Eulers according to trim before returning them.  We should probably stop EKFs doing that, and rotate them in the AHRS (and in the EKF logging)

Would also be nice if we could eliminate these trims entirely, making people use custom rotations if required (performance concerns yada yada yada)


.... we were also getting the secondary quaternion when reporting via `ATTITUDE_QUATERNION`, which was kind of wrong.
