### PR TITLE
Tools/ardupilotwaf: make skipped summary warning red

### DIFF
--- a/Tools/ardupilotwaf/build_summary.py
+++ b/Tools/ardupilotwaf/build_summary.py
@@ -154,7 +154,7 @@ def _build_summary(bld):
             Logs.info('')
             Logs.pprint(
                 'NORMAL',
-                'Note: Some targets were suppressed. Use --summary-all if you want information of all targets.',
+                '\033[0;31;1mNote: Some targets were suppressed. Use --summary-all if you want information of all targets.',
             )
 
     if hasattr(bld, 'extra_build_summary'):


### PR DESCRIPTION
Just makes the warning more clear, I thought we were missing some builds until I spotted this.

Before:
![image](https://user-images.githubusercontent.com/33176108/126813688-4467f991-ddbf-4126-81e4-469ac335dcdc.png)

After:
![image](https://user-images.githubusercontent.com/33176108/126813626-76909b9b-46eb-4c4f-a5b5-66774565b87e.png)

