### PR TITLE
ROVER: allow backup fast by user

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -288,7 +288,6 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
 {
     // get acceleration limited target speed
     target_speed = attitude_control.get_desired_speed_accel_limited(target_speed, rover.G_Dt);
-    float target_speed_org = target_speed;
     // apply object avoidance to desired speed using half vehicle's maximum deceleration
     if (avoidance_enabled) {
         g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_decel_max(), ahrs.yaw, target_speed, rover.G_Dt);
@@ -296,22 +295,6 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
             // we are a sailboat trying to avoid fence, try a tack
             if (rover.control_mode != &rover.mode_acro) {
                 rover.control_mode->handle_tack_request();
-            }
-        }
-
-        // give user control in the backup direction if user wants fast response.
-        const Vector3f obstacle_inaction = g2.avoid.get_vector_to_obstacle_inaction();
-        if (!obstacle_inaction.is_zero())
-        {
-            if ((obstacle_inaction.x>0.0f) && (target_speed_org<0) && (target_speed_org < target_speed))
-            { // allow going backward faster than desired speed 
-                printf("backward faster %f, %f\r\n",target_speed, target_speed_org);     
-                target_speed = target_speed_org;
-            }else
-            if ((obstacle_inaction.x<0.0f) && (target_speed_org>0) && (target_speed_org > target_speed))
-            { // allow going forward faster than desired speed 
-                printf("forward faster %f, %f\r\n",target_speed, target_speed_org);
-                target_speed = target_speed_org;
             }
         }
     }

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -299,10 +299,20 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
             }
         }
 
-        // allow going backward fast than desired speed if user wants so.
-        if ((target_speed_org<0) && (target_speed_org < target_speed))
+        // give user control in the backup direction if user wants fast response.
+        const Vector3f obstacle_inaction = g2.avoid.get_vector_to_obstacle_inaction();
+        if (!obstacle_inaction.is_zero())
         {
-            target_speed = target_speed_org;
+            if ((obstacle_inaction.x>0.0f) && (target_speed_org<0) && (target_speed_org < target_speed))
+            { // allow going backward faster than desired speed 
+                printf("backward faster %f, %f\r\n",target_speed, target_speed_org);     
+                target_speed = target_speed_org;
+            }else
+            if ((obstacle_inaction.x<0.0f) && (target_speed_org>0) && (target_speed_org > target_speed))
+            { // allow going forward faster than desired speed 
+                printf("forward faster %f, %f\r\n",target_speed, target_speed_org);
+                target_speed = target_speed_org;
+            }
         }
     }
 

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -288,7 +288,7 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
 {
     // get acceleration limited target speed
     target_speed = attitude_control.get_desired_speed_accel_limited(target_speed, rover.G_Dt);
-
+    float target_speed_org = target_speed;
     // apply object avoidance to desired speed using half vehicle's maximum deceleration
     if (avoidance_enabled) {
         g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_decel_max(), ahrs.yaw, target_speed, rover.G_Dt);
@@ -297,6 +297,12 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
             if (rover.control_mode != &rover.mode_acro) {
                 rover.control_mode->handle_tack_request();
             }
+        }
+
+        // allow going backward fast than desired speed if user wants so.
+        if ((target_speed_org<0) && (target_speed_org < target_speed))
+        {
+            target_speed = target_speed_org;
         }
     }
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -1127,6 +1127,7 @@ void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector3f &d
     const uint8_t obstacle_num = _proximity.get_obstacle_count();
     if (obstacle_num == 0) {
         // no obstacles
+        _vector_to_obstacle_inaction.zero();
         return;
     }
  
@@ -1178,11 +1179,13 @@ void AC_Avoid::adjust_velocity_proximity(float kP, float accel_cmss, Vector3f &d
                 const float z_back_dist = margin_vector.z;
                 calc_backup_velocity_3D(kP, accel_cmss, quad_1_back_vel, quad_2_back_vel, quad_3_back_vel, quad_4_back_vel, xy_back_dist, vector_to_obstacle, kP_z, accel_cmss_z, z_back_dist, min_back_vel_z, max_back_vel_z, dt);
             }
+            _vector_to_obstacle_inaction =   vector_to_obstacle;      
         }
 
         if (desired_vel_cms.is_zero()) {
             // cannot limit velocity if there is nothing to limit
             // backing up (if needed) has already been done
+            _vector_to_obstacle_inaction =   vector_to_obstacle;
             continue;
         }
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -223,24 +223,50 @@ void AC_Avoid::adjust_velocity(Vector3f &desired_vel_cms, bool &backing_up, floa
         // this has to be done for x,y,z seperately. For eg, user is doing fine in "x" direction but might need backing up in "y".
         if (!is_zero(desired_backup_vel.x)) {
             if (is_positive(desired_backup_vel.x)) {
-                desired_vel_cms.x = MAX(desired_vel_cms.x, desired_backup_vel.x);
+                desired_vel_cms.x = MAX(desired_vel_cms_original.x, desired_backup_vel.x);
             } else {
-                desired_vel_cms.x = MIN(desired_vel_cms.x, desired_backup_vel.x);
+                desired_vel_cms.x = MIN(desired_vel_cms_original.x, desired_backup_vel.x);
             }
         }
         if (!is_zero(desired_backup_vel.y)) {
             if (is_positive(desired_backup_vel.y)) {
-                desired_vel_cms.y = MAX(desired_vel_cms.y, desired_backup_vel.y);
+                desired_vel_cms.y = MAX(desired_vel_cms_original.y, desired_backup_vel.y);
             } else {
-                desired_vel_cms.y = MIN(desired_vel_cms.y, desired_backup_vel.y);
+                desired_vel_cms.y = MIN(desired_vel_cms_original.y, desired_backup_vel.y);
             }
         }
         if (!is_zero(desired_backup_vel.z)) {
-            if (is_positive(desired_backup_vel.z)) {
-                desired_vel_cms.z = MAX(desired_vel_cms.z, desired_backup_vel.z);
+            if (is_positive(desired_vel_cms_original.z)) {
+                desired_vel_cms.z = MAX(desired_vel_cms_original.z, desired_backup_vel.z);
             } else {
-                desired_vel_cms.z = MIN(desired_vel_cms.z, desired_backup_vel.z);
+                desired_vel_cms.z = MIN(desired_vel_cms_original.z, desired_backup_vel.z);
             }
+        }
+    }else
+    if (!_vector_to_obstacle_inaction.is_zero() && desired_backup_vel.is_zero())
+    {
+        bool sign_desired_vel_cms_original_x = desired_vel_cms_original.x>=0.0f;
+        bool sign__vector_to_obstacle_inaction_x = _vector_to_obstacle_inaction.x >=0.0f;
+        
+        bool sign_desired_vel_cms_original_y = desired_vel_cms_original.y>=0.0f;
+        bool sign__vector_to_obstacle_inaction_y = _vector_to_obstacle_inaction.y >=0.0f;
+        
+        bool sign_desired_vel_cms_original_z = desired_vel_cms_original.z>=0.0f;
+        bool sign__vector_to_obstacle_inaction_z = _vector_to_obstacle_inaction.z >=0.0f;
+        
+        if (sign_desired_vel_cms_original_x != sign__vector_to_obstacle_inaction_x)
+        {
+            desired_vel_cms.x = desired_vel_cms_original.x;   
+        }
+
+        if (sign_desired_vel_cms_original_y != sign__vector_to_obstacle_inaction_y)
+        {
+            desired_vel_cms.x = desired_vel_cms_original.x;   
+        }
+
+        if (sign_desired_vel_cms_original_z != sign__vector_to_obstacle_inaction_z)
+        {
+            desired_vel_cms.x = desired_vel_cms_original.x;   
         }
     }
     // limit acceleration

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -84,6 +84,8 @@ public:
     bool proximity_avoidance_enabled() const { return _proximity_enabled; }
     void proximity_alt_avoidance_enable(bool on_off) { _proximity_alt_enabled = on_off; }
 
+    Vector3f get_vector_to_obstacle_inaction () { return _vector_to_obstacle_inaction; }
+
     // helper functions
 
     // Limits the component of desired_vel_cms in the direction of the unit vector
@@ -222,7 +224,7 @@ private:
     uint32_t _last_limit_time;      // the last time a limit was active
     uint32_t _last_log_ms;          // the last time simple avoidance was logged
     Vector3f _prev_avoid_vel;       // copy of avoidance adjusted velocity
-
+    Vector3f _vector_to_obstacle_inaction; //current obstacle we try to avoid.
     static AC_Avoid *_singleton;
 };
 


### PR DESCRIPTION
I used VL53L1X_RangeLaserLidar for rover to test obstacle avoidance in steering mode.
when obstacle is found I found two behaviors:
    1- backup away from the object. but slowly. ch3-output decrease value slowly. and I want the user to be able to press backward and get control as long as it is moving away from the obstacle.
    2- rover stops and you can no longer move it as the desired speed is calculated zero.

The modification allows the user to press backward and move away from object.


