### PR TITLE
AP_AHRS: move AP_NMEA_Output to AHRS frontend

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -216,6 +216,10 @@ void AP_AHRS::init()
 
     // init parent class
     AP_AHRS_DCM::init();
+
+#if HAL_NMEA_OUTPUT_ENABLED
+    _nmea_out = AP_NMEA_Output::probe();
+#endif
 }
 
 // return the smoothed gyro vector corrected for drift
@@ -316,9 +320,11 @@ void AP_AHRS::update(bool skip_ins_update)
         _view->update(skip_ins_update);
     }
 
-#if !HAL_MINIMIZE_FEATURES
+#if HAL_NMEA_OUTPUT_ENABLED
     // update NMEA output
-    update_nmea_out();
+    if (_nmea_out != nullptr) {
+        _nmea_out->update();
+    }
 #endif
 
     EKFType active = active_EKF_type();

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -51,6 +51,8 @@ class AP_AHRS_View;
 
 #define AP_AHRS_NAVEKF_SETTLE_TIME_MS 20000     // time in milliseconds the ekf needs to settle after being started
 
+#include <AP_NMEA_Output/AP_NMEA_Output.h>
+
 class AP_AHRS : public AP_AHRS_DCM {
     friend class AP_AHRS_View;
 public:
@@ -401,6 +403,10 @@ private:
 #if HAL_EXTERNAL_AHRS_ENABLED
     void update_external(void);
 #endif    
+
+#if HAL_NMEA_OUTPUT_ENABLED
+    class AP_NMEA_Output* _nmea_out;
+#endif
 };
 
 namespace AP {

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -20,7 +20,6 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
-#include <AP_NMEA_Output/AP_NMEA_Output.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -28,10 +27,6 @@ extern const AP_HAL::HAL& hal;
 void AP_AHRS_Backend::init()
 {
     update_orientation();
-
-#if !HAL_MINIMIZE_FEATURES
-    _nmea_out = AP_NMEA_Output::probe();
-#endif
 }
 
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
@@ -347,15 +342,6 @@ void AP_AHRS_Backend::Log_Write_Home_And_Origin()
 // get apparent to true airspeed ratio
 float AP_AHRS_Backend::get_EAS2TAS(void) const {
     return AP::baro().get_EAS2TAS();
-}
-
-void AP_AHRS_Backend::update_nmea_out()
-{
-#if !HAL_MINIMIZE_FEATURES
-    if (_nmea_out != nullptr) {
-        _nmea_out->update();
-    }
-#endif
 }
 
 // return current vibration vector for primary IMU

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -28,7 +28,6 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/Location.h>
 
-class AP_NMEA_Output;
 class OpticalFlow;
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
 #define AP_AHRS_RP_P_MIN   0.05f        // minimum value for AHRS_RP_P parameter
@@ -578,7 +577,6 @@ public:
     void Write_POS(void) const;
 
 protected:
-    void update_nmea_out();
 
     // multi-thread access support
     HAL_Semaphore _rsem;
@@ -682,8 +680,6 @@ protected:
     uint32_t _last_AOA_update_ms;
 
 private:
-
-    AP_NMEA_Output* _nmea_out;
 
     uint32_t takeoff_expected_start_ms;
     uint32_t touchdown_expected_start_ms;

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -19,16 +19,15 @@
 
 #include "AP_NMEA_Output.h"
 
-#if !HAL_MINIMIZE_FEATURES
+#if HAL_NMEA_OUTPUT_ENABLED
 
 #include <AP_Math/definitions.h>
 #include <AP_RTC/AP_RTC.h>
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
 #include <stdio.h>
 #include <time.h>
-
-AP_NMEA_Output* AP_NMEA_Output::_singleton;
 
 AP_NMEA_Output::AP_NMEA_Output()
 {
@@ -46,11 +45,12 @@ AP_NMEA_Output::AP_NMEA_Output()
 
 AP_NMEA_Output* AP_NMEA_Output::probe()
 {
-    if (!_singleton && AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_NMEAOutput, 0) != nullptr) {
-       _singleton = new AP_NMEA_Output();
+    AP_NMEA_Output *ret = new AP_NMEA_Output();
+    if (ret == nullptr || ret->_num_outputs == 0) {
+        delete ret;
+        return nullptr;
     }
-
-    return _singleton;
+    return ret;
 }
 
 uint8_t AP_NMEA_Output::_nmea_checksum(const char *str)
@@ -187,4 +187,4 @@ void AP_NMEA_Output::update()
     }
 }
 
-#endif  // !HAL_MINIMIZE_FEATURES
+#endif  // HAL_NMEA_OUTPUT_ENABLED

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.h
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.h
@@ -20,9 +20,12 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
 
-#if !HAL_MINIMIZE_FEATURES
+#ifndef HAL_NMEA_OUTPUT_ENABLED
+#define HAL_NMEA_OUTPUT_ENABLED !HAL_MINIMIZE_FEATURES
+#endif
+
+#if HAL_NMEA_OUTPUT_ENABLED
 
 #include <AP_SerialManager/AP_SerialManager.h>
 
@@ -32,8 +35,7 @@ public:
     static AP_NMEA_Output* probe();
 
     /* Do not allow copies */
-    AP_NMEA_Output(const AP_NMEA_Output &other) = delete;
-    AP_NMEA_Output &operator=(const AP_NMEA_Output&) = delete;
+    CLASS_NO_COPY(AP_NMEA_Output);
 
     void update();
 
@@ -41,8 +43,6 @@ private:
     AP_NMEA_Output();
 
     uint8_t _nmea_checksum(const char *str);
-
-    static AP_NMEA_Output* _singleton;
 
     uint8_t _num_outputs;
     AP_HAL::UARTDriver* _uart[SERIALMANAGER_NUM_PORTS];


### PR DESCRIPTION
Also make it optionally-built, saving 1kB if it is removed with `HAL_NMEA_OUTPUT_ENABLED`
