### PR TITLE
Copter: Move "land_run_horizontal_control()" to use position controller only

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -876,14 +876,13 @@ void ModeAuto::land_run()
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_spool_down();
-        loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
+        pos_control->init_xy_controller();
         return;
     }
 
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-    
+
     land_run_horizontal_control();
     land_run_vertical_control();
 }
@@ -1039,8 +1038,7 @@ void ModeAuto::payload_place_run()
     if (!payload_place_run_should_run()) {
         zero_throttle_and_relax_ac();
         // set target to current position
-        loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
+        pos_control->init_xy_controller();
         return;
     }
 

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -7,9 +7,7 @@ bool ModeLand::init(bool ignore_checks)
     control_position = copter.position_ok();
     if (control_position) {
         // set target to stopping point
-        Vector2f stopping_point;
-        loiter_nav->get_stopping_point_xy(stopping_point);
-        loiter_nav->init_target(stopping_point);
+        pos_control->init_xy_controller_stopping_point();
     }
 
     // set vertical speed and acceleration limits

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -59,17 +59,16 @@ bool ModeLoiter::do_precision_loiter()
 void ModeLoiter::precision_loiter_xy()
 {
     loiter_nav->clear_pilot_desired_acceleration();
-    Vector2f target_pos, target_vel_rel;
+    Vector2f target_pos, target_vel;
     if (!copter.precland.get_target_position_cm(target_pos)) {
         target_pos.x = inertial_nav.get_position().x;
         target_pos.y = inertial_nav.get_position().y;
     }
-    if (!copter.precland.get_target_velocity_relative_cms(target_vel_rel)) {
-        target_vel_rel.x = -inertial_nav.get_velocity().x;
-        target_vel_rel.y = -inertial_nav.get_velocity().y;
-    }
+    // get the velocity of the target
+    copter.precland.get_target_velocity_cms(inertial_nav.get_velocity().xy(), target_vel);
+
     pos_control->set_pos_target_xy_cm(target_pos.x, target_pos.y);
-    pos_control->override_vehicle_velocity_xy(-target_vel_rel);
+    pos_control->set_vel_desired_xy_cms(target_vel);
 }
 #endif
 

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -399,8 +399,7 @@ void ModeRTL::land_run(bool disarm_on_land)
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_spool_down();
-        loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
+        pos_control->init_xy_controller();
         return;
     }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -641,16 +641,7 @@ void AC_PosControl::update_xy_controller()
     _vel_target.y += _vel_desired.y;
 
     // Velocity Controller
-
-    // check if vehicle velocity is being overridden
-    // todo: remove this and use input shaping
-    if (_flags.vehicle_horiz_vel_override) {
-        _flags.vehicle_horiz_vel_override = false;
-    } else {
-        _vehicle_horiz_vel.x = _inav.get_velocity().x;
-        _vehicle_horiz_vel.y = _inav.get_velocity().y;
-    }
-    Vector2f accel_target = _pid_vel_xy.update_all(Vector2f{_vel_target.x, _vel_target.y}, _vehicle_horiz_vel, Vector2f(_limit_vector.x, _limit_vector.y));
+    Vector2f accel_target = _pid_vel_xy.update_all(_vel_target.xy(), _inav.get_velocity().xy(), _limit_vector.xy());
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
     accel_target *= ekfNavVelGainScaler;
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -344,9 +344,6 @@ public:
     ///     this prevents integrator buildup
     void set_externally_limited_xy() { _limit_vector.x = _accel_target.x; _limit_vector.y = _accel_target.y; }
 
-    // overrides the velocity process variable for one timestep
-    void override_vehicle_velocity_xy(const Vector2f& vel_xy) { _vehicle_horiz_vel = vel_xy; _flags.vehicle_horiz_vel_override = true; }
-
     // lean_angles_to_accel - convert roll, pitch lean angles to lat/lon frame accelerations in cm/s/s
     Vector3f lean_angles_to_accel(const Vector3f& att_target_euler) const;
 
@@ -376,11 +373,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:
-
-    // general purpose flags
-    struct poscontrol_flags {
-            uint16_t vehicle_horiz_vel_override : 1; // 1 if we should use _vehicle_horiz_vel as our velocity process variable for one timestep
-    } _flags;
 
     // limit flags structure
     struct poscontrol_limit_flags {
@@ -460,7 +452,6 @@ protected:
     Vector3f    _accel_desired;         // desired acceleration in NEU cm/s/s (feed forward)
     Vector3f    _accel_target;          // acceleration target in NEU cm/s/s
     Vector3f    _limit_vector;          // the direction that the position controller is limited, zero when not limited
-    Vector2f    _vehicle_horiz_vel;     // velocity to use if _flags.vehicle_horiz_vel_override is set
     float       _pos_offset_z;          // vertical position offset in NEU cm from home
     float       _vel_offset_z;          // vertical velocity offset in NEU cm/s calculated by pos_to_rate step
     float       _accel_offset_z;        // vertical acceleration offset in NEU cm/s/s

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -114,6 +114,13 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("LAG", 9, AC_PrecLand, _lag, 0.02f), // 20ms is the old default buffer size (8 frames @ 400hz/2.5ms)
 
+    // @Param: MOVING
+    // @DisplayName: Precision Landing Target stationary/moving
+    // @Description: Precision Landing Target stationary/moving
+    // @Values: 0:Stationary, 1:Moving
+    // @User: Advanced
+    AP_GROUPINFO("MOVING", 10, AC_PrecLand, _moving, 0),
+
     AP_GROUPEND
 };
 
@@ -269,6 +276,31 @@ bool AC_PrecLand::get_target_velocity_relative_cms(Vector2f& ret)
     }
     ret = _target_vel_rel_out_NE*100.0f;
     return true;
+}
+
+// get the absolute velocity of the vehicle
+void AC_PrecLand::get_target_velocity_cms(const Vector2f& vehicle_velocity_cms, Vector2f& target_vel_cms)
+{
+    if (!_moving) {
+        // the target should not be moving
+        target_vel_cms.zero();
+        return;
+    }
+    if ((EstimatorType)_estimator_type.get() == EstimatorType::RAW_SENSOR) {
+        // We do not predict the velocity of the target in this case
+        // assume velocity to be zero
+        target_vel_cms.zero();
+        return;
+    }
+    Vector2f target_vel_rel_cms;
+    if (!get_target_velocity_relative_cms(target_vel_rel_cms)) {
+        // Don't know where the target is
+        // assume velocity to be zero
+        target_vel_cms.zero();
+        return;
+    }
+    // return the absolute velocity
+    target_vel_cms  = target_vel_rel_cms + vehicle_velocity_cms;
 }
 
 // handle_msg - Process a LANDING_TARGET mavlink message

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -63,6 +63,9 @@ public:
     // returns target velocity relative to vehicle
     bool get_target_velocity_relative_cms(Vector2f& ret);
 
+    // get the absolute velocity of the vehicle
+    void get_target_velocity_cms(const Vector2f& vehicle_velocity_cms, Vector2f& target_vel_cms);
+
     // returns true when the landing target has been detected
     bool target_acquired();
 
@@ -116,6 +119,7 @@ private:
     AP_Float                    _land_ofs_cm_y;     // Desired landing position of the camera right of the target in vehicle body frame
     AP_Float                    _accel_noise;       // accelerometer process noise
     AP_Vector3f                 _cam_offset;        // Position of the camera relative to the CG
+    AP_Int8                     _moving;            // True if the landing target is moving (non-stationary)
 
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently after estimator is initialized


### PR DESCRIPTION
This uses the new Position Controller methods for landing instead of relying on loiter
Also removed direct injection of velocity into position controller 