### PR TITLE
build: switch to gcc 10.2.1 for master builds

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -769,6 +769,7 @@ class chibios(Board):
             ('6','3','1'),
             ('9','2','1'),
             ('9','3','1'),
+            ('10','2','1'),
         ]
 
         if cfg.options.Werror or cfg.env.CC_VERSION in gcc_whitelist:

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -156,6 +156,13 @@ class Board:
 
         cfg.msg("CXX Compiler", "%s %s"  % (cfg.env.COMPILER_CXX, ".".join(cfg.env.CC_VERSION)))
 
+        if cfg.options.assert_cc_version:
+            cfg.msg("Checking compiler", "%s %s"  % (cfg.options.assert_cc_version, ".".join(cfg.env.CC_VERSION)))
+            have_version = cfg.env.COMPILER_CXX+"-"+'.'.join(list(cfg.env.CC_VERSION))
+            want_version = cfg.options.assert_cc_version
+            if have_version != want_version:
+                cfg.fatal("cc version mismatch: %s should be %s" % (have_version, want_version))
+        
         if 'clang' in cfg.env.COMPILER_CC:
             env.CFLAGS += [
                 '-fcolor-diagnostics',

--- a/Tools/debug/README.md
+++ b/Tools/debug/README.md
@@ -22,7 +22,7 @@ your black magic probe, or install the provided udev rules file so
 that the probe will be loaded as /dev/ttyBmpGdb
 
 Now make sure you have the right version of arm-none-eabi-gdb
-installed. We recommend version 6-2017-q2-update, which is available
+installed. We recommend version 10-2020-q4-major, which is available
 here: https://firmware.ardupilot.org/Tools/STM32-tools/
 
 Now build ArduPilot with the --debug configure option. You may also

--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -14,8 +14,8 @@ PYTHON3_PKGS="pyserial empy geocoder"
 
 # GNU Tools for ARM Embedded Processors
 # (see https://launchpad.net/gcc-arm-embedded/)
-ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
-ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
+ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
+ARM_TARBALL="$ARM_ROOT-x86_64-linux.tar.bz2"
 ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
 
 # Ardupilot Tools

--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -62,7 +62,7 @@ fi
 function install_arm_none_eabi_toolchain() {
     # GNU Tools for ARM Embedded Processors
     # (see https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
-    ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
+    ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
     ARM_TARBALL="$ARM_ROOT-mac.tar.bz2"
     ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
     if [ ! -d $OPT/$ARM_ROOT ]; then

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -142,8 +142,8 @@ fi
 function install_arm_none_eabi_toolchain() {
   # GNU Tools for ARM Embedded Processors
   # (see https://launchpad.net/gcc-arm-embedded/)
-  ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
-  ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
+  ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
+  ARM_TARBALL="$ARM_ROOT-x86_64-linux.tar.bz2"
   ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
   if [ ! -d $OPT/$ARM_ROOT ]; then
     (

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -6,8 +6,8 @@ set -ex
 # Disable ccache for the configure phase, it's not worth it
 export CCACHE_DISABLE="true"
 
-ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
-ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
+ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
+ARM_TARBALL="$ARM_ROOT-x86_64-linux.tar.bz2"
 
 RPI_ROOT="master"
 RPI_TARBALL="$RPI_ROOT.tar.gz"
@@ -83,7 +83,7 @@ ln -s ~/opt/$CCACHE_ROOT/ccache ~/ccache/clang
 exportline="export PATH=$HOME/ccache"
 exportline="${exportline}:$HOME/bin"
 exportline="${exportline}:$HOME/.local/bin"
-exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-6-2017-q2-update/bin"
+exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-10-2020-q4-major/bin"
 exportline="${exportline}:$HOME/opt/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin"
 exportline="${exportline}:$HOME/opt/arm-linux-musleabihf-cross/bin"
 exportline="${exportline}:$HOME/opt/$CCACHE_ROOT"

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -164,7 +164,9 @@ void CompassLearn::update(void)
             sample_available = false;
             num_samples = 0;
             have_earth_field = false;
-            memset(predicted_offsets, 0, sizeof(predicted_offsets));
+            for (auto &v : predicted_offsets) {
+                v.zero();
+            }
             worst_error = 0;
             best_error = 0;
             best_yaw_deg = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
@@ -376,7 +376,7 @@ void AP_InertialSensor::TCal::update_gyro_learning(const Vector3f &gyro, float t
  */
 void AP_InertialSensor::TCal::Learn::reset(float temperature)
 {
-    memset(state, 0, sizeof(state));
+    memset((void*)&state[0], 0, sizeof(state));
     start_tmax = tcal.temp_max;
     accel_start.zero();
     for (uint8_t i=0; i<ARRAY_SIZE(state); i++) {

--- a/wscript
+++ b/wscript
@@ -286,6 +286,10 @@ configuration in order to save typing.
 	    default=None,
 	    help='Extra hwdef.dat file for custom build.')
 
+    g.add_option('--assert-cc-version',
+                 default=None,
+                 help='fail configure if not using the specified gcc version')
+    
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():
         paths = []


### PR DESCRIPTION
This adds support for having a different compiler for different build tags. It switches the build of 'latest' on the build server to the 10.2.1 compiler while leaving beta and stable releases as our current 6.3.1 compiler.
The 10.2.1 compiler has several advantages:
 - saves about 10k of flash on F4 boards
 - slightly faster code (lower sched misses on CubeBlack)
 - better warnings (already found one real bug see #18106 )
 - support for newer C++ features

I flew 10.2.1 on a plane yesterday, and @MichelleRos flew it on a copter

To use the new compiler with build_binaries.py you need to setup a $HOME/arm-gcc directory on the system with a link to the compiler with link name "g++-10.2.1"
for example:
  g++-10.2.1 -> gcc-arm-none-eabi-10-2020-q4-major

The new compilers are here:
https://firmware.ardupilot.org/Tools/STM32-tools/

we should also think about -ffast-math, which would save us another 10k of flash on F4

@khancyr we are going to need new VMs for 10.2 compiler I think. Ideally it would have both 6.3.1 and 10.2.1 in $HOME/arm-gcc, with links like this:
![image](https://user-images.githubusercontent.com/831867/126917918-32a7c3aa-577f-428b-b037-ee8b71a838dd.png)

This PR builds on:
https://github.com/ArduPilot/ardupilot/pull/18122
https://github.com/ArduPilot/ChibiOS/pull/31