### PR TITLE
Stop using AHRS as conduit for Compass pointer

### DIFF
--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -18,7 +18,7 @@ void Tracker::update_compass(void)
 
 // Save compass offsets
 void Tracker::compass_save() {
-    if (AP::compass().enabled() &&
+    if (AP::compass().available() &&
         compass.get_learn_type() >= Compass::LEARN_INTERNAL &&
         !hal.util->get_soft_armed()) {
         compass.save_offsets();

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -13,9 +13,7 @@ void Tracker::update_ahrs()
  */
 void Tracker::update_compass(void)
 {
-    if (AP::compass().enabled() && compass.read()) {
-        ahrs.set_compass(&compass);
-    }
+    compass.read();
 }
 
 // Save compass offsets

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -380,7 +380,7 @@ void Copter::update_batt_compass(void)
     // read battery before compass because it may be used for motor interference compensation
     battery.read();
 
-    if(AP::compass().enabled()) {
+    if(AP::compass().available()) {
         // update compass with throttle value - used for compassmot
         compass.set_throttle(motors->get_throttle());
         compass.set_voltage(battery.voltage());

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -34,7 +34,7 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
     }
 
     // check compass is enabled
-    if (!AP::compass().enabled()) {
+    if (!AP::compass().available()) {
         gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Compass disabled");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -312,7 +312,7 @@ void Plane::three_hz_loop()
 
 void Plane::compass_save()
 {
-    if (AP::compass().enabled() &&
+    if (AP::compass().available() &&
         compass.get_learn_type() >= Compass::LEARN_INTERNAL &&
         !hal.util->get_soft_armed()) {
         /*

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -185,9 +185,7 @@ void Plane::update_speed_height(void)
  */
 void Plane::update_compass(void)
 {
-    if (AP::compass().enabled() && compass.read()) {
-        ahrs.set_compass(&compass);
-    }
+    compass.read();
 }
 
 /*

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -164,7 +164,7 @@ void Sub::update_batt_compass()
     // read battery before compass because it may be used for motor interference compensation
     battery.read();
 
-    if (AP::compass().enabled()) {
+    if (AP::compass().available()) {
         // update compass with throttle value - used for compassmot
         compass.set_throttle(motors.get_throttle());
         compass.read();

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -133,7 +133,7 @@ void Blimp::update_batt_compass(void)
     // read battery before compass because it may be used for motor interference compensation
     battery.read();
 
-    if (AP::compass().enabled()) {
+    if (AP::compass().available()) {
         // update compass with throttle value - used for compassmot
         compass.set_voltage(battery.voltage());
         compass.read();

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -10,7 +10,7 @@ void Rover::update_compass(void)
 
 // Save compass offsets
 void Rover::compass_save() {
-    if (AP::compass().enabled() &&
+    if (AP::compass().available() &&
         compass.get_learn_type() >= Compass::LEARN_INTERNAL &&
         !arming.is_armed()) {
         compass.save_offsets();

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -5,9 +5,7 @@
 // check for new compass data - 10Hz
 void Rover::update_compass(void)
 {
-    if (AP::compass().enabled() && compass.read()) {
-        ahrs.set_compass(&compass);
-    }
+    compass.read();
 }
 
 // Save compass offsets

--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -151,7 +151,7 @@ void AP_Periph_FW::init()
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_MAG
-    if (compass.enabled()) {
+    if (compass.available()) {
         compass.init();
     }
 #endif

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1480,7 +1480,7 @@ void AP_Periph_FW::can_update()
 void AP_Periph_FW::can_mag_update(void)
 {
 #ifdef HAL_PERIPH_ENABLE_MAG
-    if (!compass.enabled()) {
+    if (!compass.available()) {
         return;
     }
     compass.read();

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1759,7 +1759,7 @@ AP_AHRS::EKFType AP_AHRS::active_EKF_type(void) const
         }
         if (!filt_state.flags.horiz_vel ||
             (!filt_state.flags.horiz_pos_abs && !filt_state.flags.horiz_pos_rel)) {
-            if ((!_compass || !_compass->use_for_yaw()) &&
+            if ((!AP::compass().use_for_yaw()) &&
                 AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D &&
                 AP::gps().ground_speed() < 2) {
                 /*
@@ -2172,7 +2172,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
     Quaternion primary_quat;
     get_quat_body_to_ned(primary_quat);
     // only check yaw if compasses are being used
-    bool check_yaw = _compass && _compass->use_for_yaw();
+    const bool check_yaw = AP::compass().use_for_yaw();
     uint8_t total_ekf_cores = 0;
 
 #if HAL_NAVEKF2_AVAILABLE

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -75,6 +75,10 @@ public:
         return _singleton;
     }
 
+    // allow for runtime change of orientation
+    // this makes initial config easier
+    void update_orientation();
+
     // return the smoothed gyro vector corrected for drift
     const Vector3f &get_gyro(void) const override;
     const Matrix3f &get_rotation_body_to_ned(void) const override;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -26,7 +26,6 @@ extern const AP_HAL::HAL& hal;
 // init sets up INS board orientation
 void AP_AHRS_Backend::init()
 {
-    update_orientation();
 }
 
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
@@ -64,20 +63,16 @@ void AP_AHRS_Backend::add_trim(float roll_in_radians, float pitch_in_radians, bo
 }
 
 // Set the board mounting orientation, may be called while disarmed
-void AP_AHRS_Backend::update_orientation()
+void AP_AHRS::update_orientation()
 {
     const enum Rotation orientation = (enum Rotation)_board_orientation.get();
     if (orientation != ROTATION_CUSTOM) {
         AP::ins().set_board_orientation(orientation);
-        if (_compass != nullptr) {
-            _compass->set_board_orientation(orientation);
-        }
+        AP::compass().set_board_orientation(orientation);
     } else {
         _custom_rotation.from_euler(radians(_custom_roll), radians(_custom_pitch), radians(_custom_yaw));
         AP::ins().set_board_orientation(orientation, &_custom_rotation);
-        if (_compass != nullptr) {
-            _compass->set_board_orientation(orientation, &_custom_rotation);
-        }
+        AP::compass().set_board_orientation(orientation, &_custom_rotation);
     }
 }
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -95,19 +95,6 @@ public:
         _flags.wind_estimation = b;
     }
 
-    void set_compass(Compass *compass) {
-        _compass = compass;
-        update_orientation();
-    }
-
-    const Compass* get_compass() const {
-        return _compass;
-    }
-
-    // allow for runtime change of orientation
-    // this makes initial config easier
-    void update_orientation();
-
     // return the index of the primary core or -1 if no primary core selected
     virtual int8_t get_primary_core_index() const { return -1; }
 
@@ -332,9 +319,7 @@ public:
     }
 
     // return true if we will use compass for yaw
-    virtual bool use_compass(void) {
-        return _compass && _compass->use_for_yaw();
-    }
+    virtual bool use_compass(void) = 0;
 
     // return true if yaw has been initialised
     bool yaw_initialised(void) const {
@@ -633,13 +618,7 @@ protected:
     // update takeoff/touchdown flags
     void update_flags();
 
-    // pointer to compass object, if available
-    Compass         * _compass;
-
     // pointer to airspeed object, if available
-
-    // time in microseconds of last compass update
-    uint32_t _compass_last_update;
 
     // a vector to capture the difference between the controller and body frames
     AP_Vector3f         _trim;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -349,7 +349,7 @@ AP_AHRS_DCM::normalize(void)
 // produce a yaw error value. The returned value is proportional
 // to sin() of the current heading error in earth frame
 float
-AP_AHRS_DCM::yaw_error_compass(void)
+AP_AHRS_DCM::yaw_error_compass(Compass *_compass)
 {
     const Vector3f &mag = _compass->get_field();
     // get the mag vector in the earth frame
@@ -437,6 +437,9 @@ bool AP_AHRS_DCM::use_fast_gains(void) const
 // return true if we should use the compass for yaw correction
 bool AP_AHRS_DCM::use_compass(void)
 {
+    Compass &compass = AP::compass();
+    Compass *_compass = &compass;
+
     if (!_compass || !_compass->use_for_yaw()) {
         // no compass available
         return false;
@@ -488,6 +491,9 @@ AP_AHRS_DCM::drift_correction_yaw(void)
 
     const AP_GPS &_gps = AP::gps();
 
+    Compass &compass = AP::compass();
+    Compass *_compass = &compass;
+
     if (_compass && _compass->is_calibrating()) {
         // don't do any yaw correction while calibrating
         return;
@@ -510,7 +516,7 @@ AP_AHRS_DCM::drift_correction_yaw(void)
                 _flags.have_initial_yaw = true;
             }
             new_value = true;
-            yaw_error = yaw_error_compass();
+            yaw_error = yaw_error_compass(_compass);
 
             // also update the _gps_last_update, so if we later
             // disable the compass due to significant yaw error we

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -128,7 +128,7 @@ private:
     bool            renorm(Vector3f const &a, Vector3f &result);
     void            drift_correction(float deltat);
     void            drift_correction_yaw(void);
-    float           yaw_error_compass();
+    float           yaw_error_compass(Compass *_compass);
     void            euler_angles(void);
     bool            have_gps(void) const;
     bool            use_fast_gains(void) const;
@@ -163,6 +163,9 @@ private:
     uint16_t _renorm_val_count;
     float _error_rp{1.0f};
     float _error_yaw{1.0f};
+
+    // time in microseconds of last compass update
+    uint32_t _compass_last_update;
 
     // time in millis when we last got a GPS heading
     uint32_t _gps_last_update;

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -50,10 +50,7 @@ void setup(void)
     vehicle.init();
     serial_manager.init();
     AP::compass().init();
-    if(AP::compass().read()) {
-        hal.console->printf("Enabling compass\n");
-        ahrs.set_compass(&AP::compass());
-    } else {
+    if (!AP::compass().read()) {
         hal.console->printf("No compass detected\n");
     }
     AP::gps().init(serial_manager);

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -785,7 +785,8 @@ void Compass::init()
     }
 
 #ifndef HAL_BUILD_AP_PERIPH
-    AP::ahrs().set_compass(this);
+    // updating the AHRS orientation updates our own orientation:
+    AP::ahrs().update_orientation();
 #endif
 
     init_done = true;

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -681,7 +681,7 @@ Compass::Compass(void)
 //
 void Compass::init()
 {
-    if (!AP::compass().enabled()) {
+    if (!_enabled) {
         return;
     }
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -545,6 +545,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Enable Compass
     // @Description: Setting this to Enabled(1) will enable the compass. Setting this to Disabled(0) will disable the compass. Note that this is separate from COMPASS_USE. This will enable the low level senor, and will enable logging of magnetometer data. To use the compass for navigation you must also set COMPASS_USE to 1.
     // @User: Standard
+    // @RebootRequired: True
     // @Values: 0:Disabled,1:Enabled
     AP_GROUPINFO("ENABLE", 39, Compass, _enabled, 1),
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1512,6 +1512,10 @@ void
 Compass::_detect_runtime(void)
 {
 #if HAL_ENABLE_LIBUAVCAN_DRIVERS
+    if (!available()) {
+        return;
+    }
+
     //Don't try to add device while armed
     if (hal.util->get_soft_armed()) {
         return;
@@ -1537,6 +1541,10 @@ Compass::_detect_runtime(void)
 bool
 Compass::read(void)
 {
+    if (!available()) {
+        return false;
+    }
+
 #ifndef HAL_BUILD_AP_PERIPH
     if (!_initial_location_set) {
         try_set_initial_location();
@@ -1726,6 +1734,9 @@ Compass::use_for_yaw(void) const
 bool
 Compass::use_for_yaw(uint8_t i) const
 {
+    if (!available()) {
+        return false;
+    }
     // when we are doing in-flight compass learning the state
     // estimator must not use the compass. The learning code turns off
     // inflight learning when it has converged
@@ -1938,6 +1949,9 @@ bool Compass::consistent() const
  */
 bool Compass::have_scale_factor(uint8_t i) const
 {
+    if (!available()) {
+        return false;
+    }
     StateIndex id = _get_state_id(Priority(i));
     if (id >= COMPASS_MAX_INSTANCES ||
         _state[id].scale_factor < COMPASS_MIN_SCALE_FACTOR ||

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -104,6 +104,10 @@ public:
 
     bool enabled() const { return _enabled; }
 
+    // available returns true if the compass is both enabled and has
+    // been initialised
+    bool available() const { return _enabled && init_done; }
+
     /// Calculate the tilt-compensated heading_ variables.
     ///
     /// @param dcm_matrix			The current orientation rotation matrix

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -459,9 +459,6 @@ private:
     // enable automatic declination code
     AP_Int8     _auto_declination;
 
-    // first-time-around flag used by offset nulling
-    bool        _null_init_done;
-
     // stores which bit is used to indicate we should log compass readings
     uint32_t _log_bit = -1;
 

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -102,8 +102,6 @@ public:
     ///
     bool read();
 
-    bool enabled() const { return _enabled; }
-
     // available returns true if the compass is both enabled and has
     // been initialised
     bool available() const { return _enabled && init_done; }

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -58,7 +58,6 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.lat = _home.lat;
     _RFRN.lng = _home.lng;
     _RFRN.alt = _home.alt;
-    _RFRN.get_compass_is_null = AP::ahrs().get_compass() == nullptr;
     _RFRN.EAS2TAS = AP::baro().get_EAS2TAS();
     _RFRN.vehicle_class = ahrs.get_vehicle_class();
     _RFRN.fly_forward = ahrs.get_fly_forward();
@@ -255,15 +254,6 @@ int AP_DAL::snprintf(char* str, size_t size, const char *format, ...) const
 void *AP_DAL::malloc_type(size_t size, Memory_Type mem_type) const
 {
     return hal.util->malloc_type(size, AP_HAL::Util::Memory_Type(mem_type));
-}
-
-
-const AP_DAL_Compass *AP_DAL::get_compass() const
-{
-    if (_RFRN.get_compass_is_null) {
-        return nullptr;
-    }
-    return &_compass;
 }
 
 // map core number for replay

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -141,17 +141,7 @@ public:
     }
 #endif
 
-    // this method *always* returns you the compass.  This is in
-    // constrast to get_compass, which only returns the compass once
-    // the vehicle deigns to permit its use by the EKF.
     AP_DAL_Compass &compass() { return _compass; }
-
-    // this call replaces AP::ahrs()->get_compass(), whose return
-    // result can be varied by the vehicle (typically by setting when
-    // first reading is received).  This is explicitly not
-    // "AP_DAL_Compass &compass() { return _compass; } - but it should
-    // change to be that.
-    const AP_DAL_Compass *get_compass() const;
 
     // random methods that AP_NavEKF3 wants to call on AHRS:
     bool airspeed_sensor_enabled(void) const {

--- a/libraries/AP_DAL/AP_DAL_Compass.cpp
+++ b/libraries/AP_DAL/AP_DAL_Compass.cpp
@@ -17,6 +17,7 @@ void AP_DAL_Compass::start_frame()
     const auto &compass = AP::compass();
 
     const log_RMGH old = _RMGH;
+    _RMGH.available = compass.available();
     _RMGH.count = compass.get_count();
     _RMGH.auto_declination_enabled = compass.auto_declination_enabled();
     _RMGH.declination = compass.get_declination();

--- a/libraries/AP_DAL/AP_DAL_Compass.h
+++ b/libraries/AP_DAL/AP_DAL_Compass.h
@@ -38,6 +38,10 @@ public:
         return _RMGH.declination;
     }
 
+    bool available() const {
+        return _RMGH.available;
+    }
+
     // return the number of enabled sensors
     uint8_t get_num_enabled(void) const { return _RMGH.num_enabled; }
 

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -240,6 +240,7 @@ struct log_RASI {
 // @Description: Replay Data Magnetometer Header
 struct log_RMGH {
     float declination;
+    bool available;
     uint8_t count;
     bool auto_declination_enabled;
     uint8_t num_enabled;
@@ -402,7 +403,7 @@ struct log_RBOH {
     { LOG_RGPJ_MSG, RLOG_SIZE(RGPJ),                                   \
       "RGPJ", "IffffffIiiiffHB", "TS,VX,VY,VZ,SA,Y,YA,YT,Lat,Lon,Alt,HA,VA,HD,I", "--------------#", "---------------" }, \
     { LOG_RMGH_MSG, RLOG_SIZE(RMGH),                                   \
-      "RMGH", "BBfBBBB", "Dec,NumInst,AutoDec,NumEna,LOE,C,FUsable", "-------", "-------" },  \
+      "RMGH", "BBBfBBBB", "Dec,Avail,NumInst,AutoDec,NumEna,LOE,C,FUsable", "--------", "--------" },  \
     { LOG_RMGI_MSG, RLOG_SIZE(RMGI),                                   \
       "RMGI", "IffffffBBBB", "LU,OX,OY,OZ,FX,FY,FZ,UFY,H,HSF,I", "----------#", "-----------" },                                        \
     { LOG_RBCH_MSG, RLOG_SIZE(RBCH),                                   \

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -62,7 +62,7 @@ struct log_RFRN {
     uint8_t vehicle_class;
     uint8_t ekf_type;
     uint8_t armed:1;
-    uint8_t get_compass_is_null:1;
+    uint8_t unused:1;  // was get_compass_is_null
     uint8_t fly_forward:1;
     uint8_t ahrs_airspeed_sensor_enabled:1;
     uint8_t opticalflow_enabled:1;

--- a/libraries/AP_Mount/SoloGimbalEKF.cpp
+++ b/libraries/AP_Mount/SoloGimbalEKF.cpp
@@ -668,16 +668,15 @@ void SoloGimbalEKF::fuseVelocity()
 // check for new magnetometer data and update store measurements if available
 void SoloGimbalEKF::readMagData()
 {
-    const auto &_ahrs = AP::ahrs();
+    Compass &compass = AP::compass();
 
-    if (_ahrs.get_compass() &&
-        _ahrs.get_compass()->use_for_yaw() &&
-        _ahrs.get_compass()->last_update_usec() != lastMagUpdate) {
+    if (compass.use_for_yaw() &&
+        compass.last_update_usec() != lastMagUpdate) {
         // store time of last measurement update
-        lastMagUpdate = _ahrs.get_compass()->last_update_usec();
+        lastMagUpdate = compass.last_update_usec();
 
         // read compass data and scale to improve numerical conditioning
-        magData = _ahrs.get_compass()->get_field();
+        magData = compass.get_field();
 
         // let other processes know that new compass data has arrived
         newDataMag = true;
@@ -877,7 +876,7 @@ float SoloGimbalEKF::calcMagHeadingInnov()
     if (!earth_magfield.is_zero()) {
         declination = atan2f(earth_magfield.y,earth_magfield.x);
     } else {
-        declination = _ahrs.get_compass()->get_declination();
+        declination = AP::compass().get_declination();
     }
 
     Vector3f body_magfield = Vector3f(0,0,0);

--- a/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
+++ b/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
@@ -78,10 +78,7 @@ void setup(void)
     vehicle.ahrs.init();
 
     AP::compass().init();
-    if(AP::compass().read()) {
-        hal.console->printf("Enabling compass\n");
-        vehicle.ahrs.set_compass(&AP::compass());
-    } else {
+    if(!AP::compass().read()) {
         hal.console->printf("No compass detected\n");
     }
     AP::gps().init(serial_manager);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -408,7 +408,7 @@ bool NavEKF2_core::readyToUseExtNav(void) const
 // return true if we should use the compass
 bool NavEKF2_core::use_compass(void) const
 {
-    return dal.get_compass() && dal.get_compass()->use_for_yaw(magSelectIndex) && !allMagSensorsFailed;
+    return dal.compass().use_for_yaw(magSelectIndex) && !allMagSensorsFailed;
 }
 
 /*

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -228,12 +228,12 @@ void NavEKF2_core::tryChangeCompass(void)
 // check for new magnetometer data and update store measurements if available
 void NavEKF2_core::readMagData()
 {
-    if (!dal.get_compass()) {
+    const auto &compass = dal.compass();
+
+    if (!compass.available()) {
         allMagSensorsFailed = true;
         return;        
     }
-
-    const auto &compass = dal.compass();
 
     // If we are a vehicle with a sideslip constraint to aid yaw estimation and we have timed out on our last avialable
     // magnetometer, then declare the magnetometers as failed for this flight
@@ -627,8 +627,9 @@ void NavEKF2_core::readGpsData()
             }
 
             if (gpsGoodToAlign && !have_table_earth_field) {
-                const auto *compass = dal.get_compass();
-                if (compass && compass->have_scale_factor(magSelectIndex) && compass->auto_declination_enabled()) {
+                const auto &compass = dal.compass();
+                if (compass.have_scale_factor(magSelectIndex) &&
+                    compass.auto_declination_enabled()) {
                     table_earth_field_ga = AP_Declination::get_earth_field_ga(gpsloc).toftype();
                     table_declination = radians(AP_Declination::get_declination(gpsloc.lat*1.0e-7,
                                                                                 gpsloc.lng*1.0e-7));
@@ -984,7 +985,7 @@ ftype NavEKF2_core::MagDeclination(void) const
     if (!use_compass()) {
         return 0;
     }
-    return dal.get_compass()->get_declination();
+    return dal.compass().get_declination();
 }
 
 /*

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -377,7 +377,8 @@ void NavEKF2_core::getMagXYZ(Vector3f &magXYZ) const
 // return true if offsets are valid
 bool NavEKF2_core::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 {
-    if (!dal.get_compass()) {
+    const auto &compass = dal.compass();
+    if (!compass.available()) {
         return false;
     }
 
@@ -388,12 +389,12 @@ bool NavEKF2_core::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
     if ((mag_idx == magSelectIndex) &&
             finalInflightMagInit &&
             !inhibitMagStates &&
-            dal.get_compass()->healthy(magSelectIndex) &&
+            compass.healthy(magSelectIndex) &&
             variancesConverged) {
-        magOffsets = dal.get_compass()->get_offsets(magSelectIndex) - (stateStruct.body_magfield*1000.0).tofloat();
+        magOffsets = compass.get_offsets(magSelectIndex) - (stateStruct.body_magfield*1000.0).tofloat();
         return true;
     } else {
-        magOffsets = dal.get_compass()->get_offsets(magSelectIndex);
+        magOffsets = compass.get_offsets(magSelectIndex);
         return false;
     }
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -567,9 +567,8 @@ bool NavEKF3_core::use_compass(void) const
         return false;
     }
 
-    const auto *compass = dal.get_compass();
-    return compass &&
-           compass->use_for_yaw(magSelectIndex) &&
+    const auto &compass = dal.compass();
+    return compass.use_for_yaw(magSelectIndex) &&
            !allMagSensorsFailed;
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -377,9 +377,11 @@ void NavEKF3_core::getMagXYZ(Vector3f &magXYZ) const
 // return true if offsets are valid
 bool NavEKF3_core::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 {
-    if (!dal.get_compass()) {
+    const auto &compass = dal.compass();
+    if (!compass.available()) {
         return false;
     }
+
     // compass offsets are valid if we have finalised magnetic field initialisation, magnetic field learning is not prohibited,
     // primary compass is valid and state variances have converged
     const float maxMagVar = 5E-6f;
@@ -387,12 +389,12 @@ bool NavEKF3_core::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
     if ((mag_idx == magSelectIndex) &&
             finalInflightMagInit &&
             !inhibitMagStates &&
-            dal.get_compass()->healthy(magSelectIndex) &&
+            compass.healthy(magSelectIndex) &&
             variancesConverged) {
-        magOffsets = dal.get_compass()->get_offsets(magSelectIndex) - stateStruct.body_magfield.tofloat()*1000.0;
+        magOffsets = compass.get_offsets(magSelectIndex) - stateStruct.body_magfield.tofloat()*1000.0;
         return true;
     } else {
-        magOffsets = dal.get_compass()->get_offsets(magSelectIndex);
+        magOffsets = compass.get_offsets(magSelectIndex);
         return false;
     }
 }

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -155,11 +155,11 @@ void GCS::update_sensor_status_flags()
 
 #if !defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_MAG)
     const Compass &compass = AP::compass();
-    if (AP::compass().enabled()) {
+    if (AP::compass().available()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
-    if (compass.enabled() && compass.healthy()) {
+    if (compass.available() && compass.healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
 #endif


### PR DESCRIPTION
This stops the AHRS acting as a conduit for a pointer to the compass.

This pointer was set if the compass was enabled at boot-time.

It appears that enabling the compass at runtime may do bad things if you are using UAVCAN compasses, as we won't have ever run init, and the runtime detection is poking around in structures initialised in init().  That is a pre-existing issue, and this PR can only help when resolving that one.

I've test-flown this on a SkyViper.
