### PR TITLE
Disable auto trim on UAVCAN channels

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -102,6 +102,8 @@ public:
     uint8_t get_driver_index() const { return _driver_index; }
 
 
+    uint32_t get_servo_output_bitmask () const { return (uint32_t)_servo_bm; }
+
     ///// SRV output /////
     void SRV_push_servos(void);
 


### PR DESCRIPTION
Auto trim of servos on plane doesn't work for a UAVCAN output. We send a normalized command value out over CAN [-1.0f, 1.0f]. Adjusting the trim parameter has no effect because we use a normalized output [-4500, 4500] to set the target PWM, then normalize that PWM value back to the CAN range. The only effect this actually has on a CAN servo is it reduces resolution one direction as it lowers the number of representable PWM values on the one side.

This takes the simple step of not trimming out the UAVCAN channels. I'm not wholly convinced this is the proper solution, because if you have a mixture of UAVCAN and non UAVCAN actuators on the same function (let's say aileron), then one would be trimmed down to oppose the error in the other one. That may be best, but it will probably lead towards just being an airbrake, while the log shows that it is in trim. But that's a small enough situation (and should be somewhat observable on the airframe) that maybe this is fine?

I don't currently have access to a setup that lets me validate this, so the whole PR is untested past that it compiles.