### PR TITLE
Correct OSD horizon for VTOL modes and TRIM_PITCH_CD in Fixed Wing

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -691,4 +691,19 @@ bool Plane::get_target_location(Location& target_loc)
 }
 #endif // ENABLE_SCRIPTING
 
+#if OSD_ENABLED
+// correct AHRS pitch for TRIM_PITCH_CD in non-VTOL modes, and return VTOL view in VTOL
+void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const
+{
+   pitch = ahrs.pitch;
+   roll = ahrs.roll;
+   if (!quadplane.show_vtol_view()) {  // correct for TRIM_PITCH_CD
+      pitch -= g.pitch_trim_cd * 0.01 * DEG_TO_RAD;
+   } else {
+      pitch = quadplane.ahrs_view->pitch;
+      roll = quadplane.ahrs_view->roll;
+   }
+}
+#endif
+
 AP_HAL_MAIN_CALLBACKS(&plane);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -951,6 +951,9 @@ private:
 
     // ArduPlane.cpp
     void disarm_if_autoland_complete();
+# if OSD_ENABLED
+    void get_osd_roll_pitch_rad(float &roll, float &pitch) const override;
+#endif
     float tecs_hgt_afe(void);
     void efi_update(void);
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -40,6 +40,7 @@
 #include <AP_VideoTX/AP_VideoTX.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_Vehicle/AP_Vehicle.h>
 #if APM_BUILD_TYPE(APM_BUILD_Rover)
 #include <AP_WindVane/AP_WindVane.h>
 #endif
@@ -1455,8 +1456,10 @@ void AP_OSD_Screen::draw_horizon(uint8_t x, uint8_t y)
 {
     AP_AHRS &ahrs = AP::ahrs();
     WITH_SEMAPHORE(ahrs.get_semaphore());
-    float roll = ahrs.roll;
-    float pitch = -ahrs.pitch;
+    float roll;
+    float pitch;
+    AP::vehicle()->get_osd_roll_pitch_rad(roll,pitch);
+    pitch *= -1;
 
     //inverted roll AH
     if (check_option(AP_OSD::OPTION_INVERTED_AH_ROLL)) {

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -403,6 +403,13 @@ void AP_Vehicle::publish_osd_info()
     nav_info.wp_number = mission->get_current_nav_index();
     osd->set_nav_info(nav_info);
 }
+
+void AP_Vehicle::get_osd_roll_pitch_rad(float &roll, float &pitch) const
+{
+    roll = ahrs.roll;
+    pitch = ahrs.pitch;
+}
+
 #endif
 
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -252,6 +252,11 @@ public:
      */
     virtual bool get_pan_tilt_norm(float &pan_norm, float &tilt_norm) const { return false; }
 
+#if OSD_ENABLED
+   // Returns roll and  pitch for OSD Horizon, Plane overrides to correct for VTOL view and fixed wing TRIM_PITCH_CD
+    virtual void get_osd_roll_pitch_rad(float &roll, float &pitch) const;
+#endif
+
 protected:
 
     virtual void init_ardupilot() = 0;


### PR DESCRIPTION
Need help on making the override work...this compiles without complaint, but does not override the AP_Vehicle virtual method...

had a sign wrong...working fine now...thanks Josh~