### PR TITLE
Plane: Add TRIM_PITCH_CD FLIGHT_OPTIONS bits for GCS and OSD

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -695,9 +695,9 @@ void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const
 {
    pitch = ahrs.pitch;
    roll = ahrs.roll;
-   if (!quadplane.show_vtol_view()) {  // correct for TRIM_PITCH_CD
+   if (!quadplane.show_vtol_view() && !(g2.flight_options & FlightOptions::OSD_REMOVE_TRIM_PITCH_CD)) {  // correct for TRIM_PITCH_CD
       pitch -= g.pitch_trim_cd * 0.01 * DEG_TO_RAD;
-   } else {
+   } else if (!quadplane.show_vtol_view()) {
       pitch = quadplane.ahrs_view->pitch;
       roll = quadplane.ahrs_view->roll;
    }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -114,8 +114,12 @@ void GCS_MAVLINK_Plane::send_attitude() const
     const AP_AHRS &ahrs = AP::ahrs();
 
     float r = ahrs.roll;
-    float p = ahrs.pitch - radians(plane.g.pitch_trim_cd*0.01f);
+    float p = ahrs.pitch;
     float y = ahrs.yaw;
+
+    if (!(plane.g2.flight_options & FlightOptions::GCS_REMOVE_TRIM_PITCH_CD)) {
+        p -= radians(plane.g.pitch_trim_cd * 0.01f);
+    }
     
     if (plane.quadplane.show_vtol_view()) {
         r = plane.quadplane.ahrs_view->roll;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1103,7 +1103,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5: Enable yaw damper in acro mode, 6: Surpress speed scaling during auto takeoffs to be 1 or less to prevent oscillations without airpseed sensor, 7:EnableDefaultAirspeed for takeoff
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5: Enable yaw damper in acro mode, 6: Surpress speed scaling during auto takeoffs to be 1 or less to prevent oscillations without airpseed sensor., 7:EnableDefaultAirspeed for takeoff, 8: Remove the TRIM_PITCH_CD on the GCS horizon, 9: Remove the TRIM_PITCH_CD on the OSD horizon
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -160,6 +160,8 @@ enum FlightOptions {
     ACRO_YAW_DAMPER = (1 << 5),
     SURPRESS_TKOFF_SCALING = (1<<6),
     ENABLE_DEFAULT_AIRSPEED = (1<<7),
+    GCS_REMOVE_TRIM_PITCH_CD = (1 << 8),
+    OSD_REMOVE_TRIM_PITCH_CD = (1 << 9),
 };
 
 enum CrowFlapOptions {


### PR DESCRIPTION
To me TRIM_PITCH_CD should not offset the displayed theta angle shown on a GCS. What a data display shows should be similar to a manned aircraft which is body frame. Not changing the display target to zero. This has caught many users I work with off guard when doing pre flight checks when it appears as though the aircraft is no longer level. As an engineer, I want to see how well my aircraft has reached the target pitch attitude and what that measurement is. I don't want to have to dig through parameters to determine that the pitch in a tlog is not the same as the body frame.

For display purposes this can be an option, but that should be a separate parameter and not tied to the same parameter as the target pitch.

This ones goes back to a PDE file change. It's also come up a few times since then in discussions.