### PR TITLE
.github: swith to GCC10 for chibios build

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -30,9 +30,9 @@ jobs:
             chibios,  # GCC-6
             chibios-clang,
         ]
-        gcc: [6, 9]
+        gcc: [6, 10]
         exclude:
-          - gcc: 9
+          - gcc: 10
             toolchain: chibios-clang
 
     steps:


### PR DESCRIPTION
This use the new docker containers that got gcc10 for Chibios build.