### PR TITLE
AP_Scripting: avoid a error in lua with gcc 10.2 on STM32 with -Werror

### DIFF
--- a/libraries/AP_Scripting/lua/src/lstring.c
+++ b/libraries/AP_Scripting/lua/src/lstring.c
@@ -139,7 +139,12 @@ static TString *createstrobj (lua_State *L, size_t l, int tag, unsigned int h) {
   ts = gco2ts(o);
   ts->hash = h;
   ts->extra = 0;
+#pragma GCC diagnostic push
+#if defined(__GNUC__) &&  __GNUC__ >= 10
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
   getstr(ts)[l] = '\0';  /* ending 0 */
+#pragma GCC diagnostic pop
   return ts;
 }
 


### PR DESCRIPTION
g++ 10.2.1 for STM32 gives this:
![image](https://user-images.githubusercontent.com/831867/127244840-4e710674-4eca-489b-aacb-48d737dee857.png)
it seems to be a false positive