### PR TITLE
AP_RSSI & GCS_Mavlink: Make rssi adhere to MAVLink standard

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -139,7 +139,7 @@ void Rover::send_servo_out(mavlink_channel_t chan)
         0,
         0,
         0,
-        rssi.read_receiver_rssi_uint8());
+        rssi.read_receiver_rssi_mavlink());
 }
 
 int16_t GCS_MAVLINK_Rover::vfr_hud_throttle() const

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -170,6 +170,18 @@ uint8_t AP_RSSI::read_receiver_rssi_uint8()
     return read_receiver_rssi() * 255; 
 }
 
+// Read the receiver RSSI value as an 8-bit integer with adhering to MAVLink standard
+// 0 represents weakest signal, 254 represents maximum signal, 255 represents invalid/unknown signal
+// we could rescale to range [0..254], but rather simply avoid 255, as this makes number consistent across telemetries
+uint8_t AP_RSSI::read_receiver_rssi_mavlink()
+{
+    if (!enabled()) {
+        return 255;
+    }
+    uint8_t rssi = read_receiver_rssi() * 255;
+    return (rssi < 255) ? rssi : 254;
+}
+
 // Private
 // -------
 

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -53,7 +53,10 @@ public:
     float read_receiver_link_quality();
     // Read the receiver RSSI value as an 8-bit integer
     // 0 represents weakest signal, 255 represents maximum signal.
-    uint8_t read_receiver_rssi_uint8();   
+    uint8_t read_receiver_rssi_uint8();
+    // Read the receiver RSSI value as an 8-bit integer with adhering to MAVLink standard
+    // 0 represents weakest signal, 254 represents maximum signal, 255 represents invalid/unknown signal
+    uint8_t read_receiver_rssi_mavlink();
 
     // parameter block
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1615,9 +1615,9 @@ void GCS_MAVLINK::send_system_time()
 void GCS_MAVLINK::send_rc_channels() const
 {
     AP_RSSI *rssi = AP::rssi();
-    uint8_t receiver_rssi = 0;
+    uint8_t receiver_rssi = UINT8_MAX;
     if (rssi != nullptr) {
-        receiver_rssi = rssi->read_receiver_rssi_uint8();
+        receiver_rssi = rssi->read_receiver_rssi_mavlink();
     }
 
     uint16_t values[18] = {};
@@ -1666,9 +1666,9 @@ void GCS_MAVLINK::send_rc_channels_raw() const
         return;
     }
     AP_RSSI *rssi = AP::rssi();
-    uint8_t receiver_rssi = 0;
+    uint8_t receiver_rssi = UINT8_MAX;
     if (rssi != nullptr) {
-        receiver_rssi = rssi->read_receiver_rssi_uint8();
+        receiver_rssi = rssi->read_receiver_rssi_mavlink();
     }
     uint16_t values[8] = {};
     rc().get_radio_in(values, ARRAY_SIZE(values));


### PR DESCRIPTION
this is "somewhat" annoying, so why not correcting it

As regards rssi in the respective messages the MAVLink standard as well as ArduPilot-MAVlink says 

"Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown."

System which follow MAVLink principles can struggle here, so, correction.