### PR TITLE
AP_Mount: Initialize backends after all mounts were added

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -479,7 +479,9 @@ void AP_Mount::init()
 
     // init each instance, do it after all instances were created, so that they all know things
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
-        if (_backends[instance] != nullptr) _backends[instance]->init();
+        if (_backends[instance] != nullptr) {
+            _backends[instance]->init();
+        }
     }
 }
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -470,12 +470,16 @@ void AP_Mount::init()
 
         // init new instance
         if (_backends[instance] != nullptr) {
-            _backends[instance]->init();
             if (!primary_set) {
                 _primary = instance;
                 primary_set = true;
             }
         }
+    }
+
+    // init each instance, do it after all instances were created, so that they all know things
+    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != nullptr) _backends[instance]->init();
     }
 }
 


### PR DESCRIPTION
setups with two mounts are not in the limelight, but ArduPilot supports that.

This change initializes the mounts only after they all were created, which is needed so they realize what the state of affairs is.