### PR TITLE
BLHeli: use AP_Motors::is_dshot() to check output type

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1351,7 +1351,7 @@ void AP_BLHeli::init(void)
     // setting the digital mask changes the min/max PWM values
     // it's important that this is NOT done for non-digital channels as otherwise
     // PWM min can result in motors turning. set for individual overrides first
-    if (mask && otype >= AP_Motors::PWM_TYPE_DSHOT150) {
+    if (mask && AP_Motors::is_dshot(otype)) {
         digital_mask = mask;
     }
 
@@ -1367,7 +1367,7 @@ void AP_BLHeli::init(void)
     if (motors) {
         uint16_t motormask = motors->get_motor_mask();
         // set the rest of the digital channels
-        if (motors->get_pwm_type() >= AP_Motors::PWM_TYPE_DSHOT150) {
+        if (AP_Motors::is_dshot(motors->get_pwm_type())) {
             digital_mask |= motormask;
         }
         mask |= motormask;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -224,6 +224,9 @@ public:
                     PWM_TYPE_PWM_RANGE  = 8 };
     pwm_type            get_pwm_type(void) const { return (pwm_type)_pwm_type.get(); }
 
+    // return true if a PWM type is a DShot varient
+    static bool is_dshot(enum pwm_type ptype) { return ptype >= PWM_TYPE_DSHOT150 && ptype <= PWM_TYPE_DSHOT1200; }
+
     MAV_TYPE get_frame_mav_type() const { return _mav_type; }
 
 protected:


### PR DESCRIPTION
This fixes an issue cause by #12540 
