### PR TITLE
APM_Control: lower the tuning trigger threshold

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -10494,6 +10494,7 @@ switch value'''
         if delta_y_g + 1 > 0.1:
             raise NotAchievedException("Magic AHRS_ORIENTATION update did not work (delta_y_g=%f)" % (delta_y_g,))
         self.context_pop()
+        self.reboot_sitl()
         self.delay_sim_time(2)  # we update orientation on a timer
 
     def tests(self):

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -220,7 +220,7 @@ void AP_AutoTune::update(AP_Logger::PID_Info &pinfo, float scaler, float angle_e
     }
 
     // thresholds for when we consider an event to start and end
-    const float rate_threshold1 = 0.6 * MIN(att_limit_deg / current.tau.get(), current.rmax_pos);
+    const float rate_threshold1 = 0.4 * MIN(att_limit_deg / current.tau.get(), current.rmax_pos);
     const float rate_threshold2 = 0.25 * rate_threshold1;
     bool in_att_demand = fabsf(angle_err_deg) >= 0.3 * att_limit_deg;
 


### PR DESCRIPTION
this allows for slower stick movements during tuning

This is based on analysing the log from kir850 on rcgroups

this also adds a reboot in the AHRS_ORIENTATION test so we don't get a flapping test due to the EKF being unhappy after an orientation change