### PR TITLE
ArduCopter: guided auto_yaw_angle_rate timeout

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -602,7 +602,7 @@ void ModeGuided::accel_control_run()
     if (tnow - update_time_ms > get_timeout_ms()) {
         guided_vel_target_cms.zero();
         guided_accel_target_cmss.zero();
-        if (auto_yaw.mode() == AUTO_YAW_RATE) {
+        if ((auto_yaw.mode() == AUTO_YAW_RATE) || (auto_yaw.mode() == AUTO_YAW_ANGLE_RATE)) {
             auto_yaw.set_rate(0.0f);
         }
         pos_control->input_vel_accel_xy(guided_vel_target_cms.xy(), guided_accel_target_cmss.xy());
@@ -665,7 +665,7 @@ void ModeGuided::velaccel_control_run()
     if (tnow - update_time_ms > get_timeout_ms()) {
         guided_vel_target_cms.zero();
         guided_accel_target_cmss.zero();
-        if (auto_yaw.mode() == AUTO_YAW_RATE) {
+        if ((auto_yaw.mode() == AUTO_YAW_RATE) || (auto_yaw.mode() == AUTO_YAW_ANGLE_RATE)) {
             auto_yaw.set_rate(0.0f);
         }
     }
@@ -740,7 +740,7 @@ void ModeGuided::posvelaccel_control_run()
     if (tnow - update_time_ms > get_timeout_ms()) {
         guided_vel_target_cms.zero();
         guided_accel_target_cmss.zero();
-        if (auto_yaw.mode() == AUTO_YAW_RATE) {
+        if ((auto_yaw.mode() == AUTO_YAW_RATE) || (auto_yaw.mode() == AUTO_YAW_ANGLE_RATE)) {
             auto_yaw.set_rate(0.0f);
         }
     }


### PR DESCRIPTION
In guided mode if you set a target with neither yaw or yaw rate ignored and then set a yaw rate you will spin forever. This occurs even if no commands are sent past the timeout. This is because if both are able to be set you are in 
 `auto_yaw_angle_rate` mode.

To reproduce using mavproxy in sitl:
`mode guided`
`arm throttle`
`takeoff 10`
`module load message`
`message SET_POSITION_TARGET_LOCAL_NED 0 1 0 1 7 0 0 0 0 0 0 0 0 0 0 1.57` 

