### PR TITLE
Tools: Add reStructuredText emitter for sphinx latexpdf builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /Tools/autotest/ch7_mission.txt
 /Tools/autotest/param_metadata/Parameters.html
 /Tools/autotest/param_metadata/Parameters.rst
+/Tools/autotest/param_metadata/ParametersLatex.rst
 /Tools/autotest/param_metadata/Parameters.wiki
 /Tools/autotest/param_metadata/Parameters.md
 /Tools/autotest/param_metadata/apm.pdef.xml

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -17,6 +17,7 @@ from param import (Library, Parameter, Vehicle, known_group_fields,
                    known_param_fields, required_param_fields, known_units)
 from htmlemit import HtmlEmit
 from rstemit import RSTEmit
+from rstlatexpdfemit import RSTLATEXPDFEmit
 from xmlemit import XmlEmit
 from mdemit import MDEmit
 from jsonemit import JSONEmit
@@ -34,7 +35,7 @@ parser.add_argument("--format",
                     dest='output_format',
                     action='store',
                     default='all',
-                    choices=['all', 'html', 'rst', 'wiki', 'xml', 'json', 'edn', 'md', 'xml_mp'],
+                    choices=['all', 'html', 'rst', 'rstlatexpdf', 'wiki', 'xml', 'json', 'edn', 'md', 'xml_mp'],
                     help="what output format to use")
 parser.add_argument("--sitl",
                     dest='emit_sitl',
@@ -455,6 +456,7 @@ all_emitters = {
     'xml': XmlEmit,
     'html': HtmlEmit,
     'rst': RSTEmit,
+    'rstlatexpdf': RSTLATEXPDFEmit,
     'md': MDEmit,
     'xml_mp': XmlEmitMP,
 }

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -22,16 +22,18 @@ This list is automatically generated from the latest ardupilot source code, and 
     def toolname(self):
         return "Tools/autotest/param_metadata/param_parse.py"
 
+    def output_fname(self):
+        return 'Parameters.rst'
+
     def __init__(self, *args, **kwargs):
         Emit.__init__(self, *args, **kwargs)
-        output_fname = 'Parameters.rst'
-        self.f = open(output_fname, mode='w')
+        self.f = open(self.output_fname(), mode='w')
         self.spacer = re.compile("^", re.MULTILINE)
         self.rstescape = re.compile("([^a-zA-Z0-9\n 	])")
         if self.sitl:
             parameterlisttype = "SITL Parameter List"
         else:
-             parameterlisttype = "Complete Parameter List"
+            parameterlisttype = "Complete Parameter List"
         parameterlisttype += "\n" + "=" * len(parameterlisttype)
         self.preamble = """.. Dynamically generated list of documented parameters
 .. This page was generated using {toolname}
@@ -51,7 +53,7 @@ This list is automatically generated from the latest ardupilot source code, and 
         self.t = ''
 
     def escape(self, s):
-        ret = re.sub(self.rstescape, "\\\\\g<1>", s)
+        ret = re.sub(self.rstescape, r"\\\g<1>", s)
         return ret
 
     def close(self):
@@ -189,6 +191,10 @@ This list is automatically generated from the latest ardupilot source code, and 
             rows.append(v)
         return self.tablify(rows, headings=render_info["headings"])
 
+    def render_table_headings(self, ret, row, headings, field_table_info, field, param):
+        row.append(self.render_prog_values_field(field_table_info[field], param, field))
+        return ''
+
     def emit(self, g):
         tag = '%s Parameters' % self.escape(g.reference)
         reference = "parameters_" + g.reference
@@ -250,10 +256,11 @@ This list is automatically generated from the latest ardupilot source code, and 
             headings = []
             row = []
             for field in sorted(param.__dict__.keys()):
-                if field not in ['name', 'DisplayName', 'Description', 'User', 'RebootRequired'] and field in known_param_fields:
+                if (field not in ['name', 'DisplayName', 'Description', 'User', 'RebootRequired'] and
+                        field in known_param_fields):
                     headings.append(field)
                     if field in field_table_info and Emit.prog_values_field.match(param.__dict__[field]):
-                        row.append(self.render_prog_values_field(field_table_info[field], param, field))
+                        ret += self.render_table_headings(ret, row, headings, field_table_info, field, param)
                     elif field == "Range":
                         (param_min, param_max) = (param.__dict__[field]).split(' ')
                         row.append("%s - %s" % (param_min, param_max,))

--- a/Tools/autotest/param_metadata/rstlatexpdfemit.py
+++ b/Tools/autotest/param_metadata/rstlatexpdfemit.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from rstemit import RSTEmit
+
+
+class RSTLATEXPDFEmit(RSTEmit):
+    def __init__(self, *args, **kwargs):
+        RSTEmit.__init__(self, *args, **kwargs)
+
+    def output_fname(self):
+        return 'ParametersLatex.rst'
+
+    def render_table_headings(self, ret, row, headings, field_table_info, field, param):
+        # add to ret rather than append rows
+        ret = ''
+        if field in ['Values', 'Bitmask']:
+            ret = "\n\n" + self.render_prog_values_field(field_table_info[field], param, field) + "\n\n"
+        else:
+            row.append(self.render_prog_values_field(field_table_info[field], param, field))
+
+        # remove Values and Bitmask items from headings list
+        while any(x in headings for x in ['Values', 'Bitmask']):
+            try:
+                headings.remove('Bitmask')
+            except ValueError:
+                pass
+            try:
+                headings.remove('Values')
+            except ValueError:
+                pass
+        return ret

--- a/Tools/scripts/build_parameters.sh
+++ b/Tools/scripts/build_parameters.sh
@@ -25,6 +25,9 @@ generate_parameters() {
     if [ -e "Parameters.rst" ]; then
 	/bin/cp Parameters.rst "$VEHICLE_PARAMS_DIR/"
     fi
+    if [ -e "ParametersLatex.rst" ]; then
+    /bin/cp ParametersLatex.rst "$VEHICLE_PARAMS_DIR/"
+    fi
 }
 
 generate_sitl_parameters() {
@@ -41,6 +44,9 @@ generate_sitl_parameters() {
     xz -e <"$VEHICLE_PARAMS_DIR"/apm.pdef.xml >"$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz.new && mv "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz.new "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz
     if [ -e "Parameters.rst" ]; then
 	/bin/cp Parameters.rst "$VEHICLE_PARAMS_DIR/"
+    fi
+    if [ -e "ParametersLatex.rst" ]; then
+    /bin/cp ParametersLatex.rst "$VEHICLE_PARAMS_DIR/"
     fi
 }
 


### PR DESCRIPTION
This solves some issues found while working on ArduPilot/ardupilot_wiki#3650.

Tables built this way are functional in the sphinx latexpdf builder. They don't look perfect though.

![image](https://user-images.githubusercontent.com/5710309/127542160-1c3f1459-10f9-4f91-8f23-72d1da905ccd.png)

They look great using the sphinx html builder!

Moved the RebootRequired label to a note rather than a column in a table. Fixed Flake8 errors. I think the way I wrote that if statement is PEP8. I don't usually hit the line length limit there.