### PR TITLE
Tools: Add tmux support to run_in_terminal_window.sh

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -28,6 +28,8 @@ if [ -n "$SITL_RITW_TERMINAL" ]; then
   printf "%q " "$@" >>"$FILEPATH"
   chmod +x "$FILEPATH"
   $SITL_RITW_TERMINAL "$FILEPATH" &
+elif [ "$TERM" = "screen" ] && [ -n "$TMUX" ]; then
+  tmux new-window -dn "$name" "$*"
 elif [ -n "$DISPLAY" -a -n "$(which osascript)" ]; then
   osascript -e 'tell application "Terminal" to do script "'"$* "'"'
 elif [ -n "$DISPLAY" -a -n "$(which xterm)" ]; then


### PR DESCRIPTION
I added in an option so that if running SITL in a tmux session it will open a new window in the current tmux session.
Tmux is more or less an alternate option to screen and is slightly nicer to use in my opinion.
The option will detect if its running in a tmux session by checking the $TMUX and $TERM env variables.

I put it before other options because when I am running a tmux session even in a GUI environment I would prefer a new Tmux window compared to a new terminal.

This will only run if youre already in a tmux session it will not launch a new session.
 
The -d option means that the user wont automatically switch to the window that is launch which made sense to me since I rarely go to that window compared to the mavproxy window.