### PR TITLE
AC_Avoidance: handle upward proximity enable and disable

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -390,7 +390,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
     // get distance from proximity sensor
     float proximity_alt_diff;
     AP_Proximity *proximity = AP::proximity();
-    if (proximity && proximity->get_upward_distance(proximity_alt_diff)) {
+    if (proximity && _proximity_enabled && proximity->get_upward_distance(proximity_alt_diff)) {
         proximity_alt_diff -= _margin;
         if (!limit_alt || proximity_alt_diff < alt_diff) {
             alt_diff = proximity_alt_diff;


### PR DESCRIPTION
This PR allows RCx_OPTION=40 (Proximity Avoidance) to control on / off of the upward proximity function.

I tested this in SITL.
![image](https://user-images.githubusercontent.com/16643069/127582284-9fb19b99-4a34-4452-a962-1bff8f354080.png)