### PR TITLE
Have AdvancedFailsafe use mission singleton

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1094,7 +1094,7 @@ ParametersG2::ParametersG2(void)
     , proximity()
 #endif
 #if ADVANCED_FAILSAFE == ENABLED
-    ,afs(copter.mode_auto.mission)
+    ,afs()
 #endif
 #if MODE_SMARTRTL_ENABLED == ENABLED
     ,smart_rtl()

--- a/ArduCopter/afs_copter.cpp
+++ b/ArduCopter/afs_copter.cpp
@@ -6,12 +6,6 @@
 
 #if ADVANCED_FAILSAFE == ENABLED
 
-// Constructor
-AP_AdvancedFailsafe_Copter::AP_AdvancedFailsafe_Copter(AP_Mission &_mission) :
-    AP_AdvancedFailsafe(_mission)
-{}
-
-
 /*
   setup radio_out values for all channels to termination values
  */

--- a/ArduCopter/afs_copter.h
+++ b/ArduCopter/afs_copter.h
@@ -27,7 +27,8 @@
 class AP_AdvancedFailsafe_Copter : public AP_AdvancedFailsafe
 {
 public:
-    AP_AdvancedFailsafe_Copter(AP_Mission &_mission);
+
+    using AP_AdvancedFailsafe::AP_AdvancedFailsafe;
 
     // called to set all outputs to termination state
     void terminate_vehicle(void) override;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -644,7 +644,7 @@ private:
 
     // Outback Challenge Failsafe Support
 #if ADVANCED_FAILSAFE == ENABLED
-    AP_AdvancedFailsafe_Plane afs {mission};
+    AP_AdvancedFailsafe_Plane afs;
 #endif
 
     /*

--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -5,11 +5,6 @@
 #include "Plane.h"
 
 #if ADVANCED_FAILSAFE == ENABLED
-// Constructor
-AP_AdvancedFailsafe_Plane::AP_AdvancedFailsafe_Plane(AP_Mission &_mission) :
-    AP_AdvancedFailsafe(_mission)
-{}
-
 
 /*
   setup radio_out values for all channels to termination values

--- a/ArduPlane/afs_plane.h
+++ b/ArduPlane/afs_plane.h
@@ -27,7 +27,8 @@
 class AP_AdvancedFailsafe_Plane : public AP_AdvancedFailsafe
 {
 public:
-    AP_AdvancedFailsafe_Plane(AP_Mission &_mission);
+
+    using AP_AdvancedFailsafe::AP_AdvancedFailsafe;
 
     // called to set all outputs to termination state
     void terminate_vehicle(void) override;

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -690,7 +690,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 ParametersG2::ParametersG2(void)
     :
 #if ADVANCED_FAILSAFE == ENABLED
-    afs(rover.mode_auto.mission),
+    afs(),
 #endif
     beacon(rover.serial_manager),
     motors(rover.ServoRelayEvents, wheel_rate_control),

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -26,6 +26,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_Mission/AP_Mission.h>
 
 AP_AdvancedFailsafe *AP_AdvancedFailsafe::_singleton;
 
@@ -207,6 +208,12 @@ AP_AdvancedFailsafe::check(bool geofence_breached, uint32_t last_valid_rc_ms)
     uint32_t now = AP_HAL::millis();
     bool gcs_link_ok = ((now - last_heartbeat_ms) < 10000);
     bool gps_lock_ok = ((now - AP::gps().last_fix_time_ms()) < 3000);
+
+    AP_Mission *_mission = AP::mission();
+    if (_mission == nullptr) {
+        return;
+    }
+    AP_Mission &mission = *_mission;
 
     switch (_state) {
     case STATE_PREFLIGHT:

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -22,9 +22,8 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_Mission/AP_Mission.h>
 #include <inttypes.h>
-
+#include <AP_Common/Location.h>
 
 class AP_AdvancedFailsafe
 {
@@ -52,8 +51,7 @@ public:
     AP_AdvancedFailsafe &operator=(const AP_AdvancedFailsafe&) = delete;
 
     // Constructor
-    AP_AdvancedFailsafe(AP_Mission &_mission) :
-        mission(_mission)
+    AP_AdvancedFailsafe()
         {
             AP_Param::setup_object_defaults(this, var_info);
             if (_singleton != nullptr) {
@@ -105,8 +103,6 @@ protected:
     virtual enum control_mode afs_mode(void) = 0;
 
     enum state _state;
-
-    AP_Mission &mission;
 
     AP_Int8 _enable;
     // digital output pins for communicating with the failsafe board


### PR DESCRIPTION
Stop passing mission into the constructor, grab it from the singleton instead.

Tested in SITL (enabled and disabled on Copter/Rover)
