### PR TITLE
Correct watchdog wp/home restoration under Plane

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -391,7 +391,7 @@ void Plane::update_GPS_10Hz(void)
             if (current_loc.lat == 0 && current_loc.lng == 0) {
                 ground_start_count = 5;
 
-            } else {
+            } else if (!hal.util->was_watchdog_reset()) {
                 if (!set_home_persistently(gps.location())) {
                     // silently ignore failure...
                 }

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9,6 +9,7 @@ AP_FLAKE8_CLEAN
 from __future__ import print_function
 import math
 import os
+import signal
 import time
 
 from pymavlink import quaternion
@@ -2985,6 +2986,59 @@ class AutoTestPlane(AutoTest):
             True,
             True)
 
+    def WatchdogHome(self):
+        if self.gdb:
+            # we end up signalling the wrong process.  I think.
+            # Probably need to have a "sitl_pid()" method to get the
+            # ardupilot process's PID.
+            self.progress("######## Skipping WatchdogHome test under GDB")
+            return
+
+        ex = None
+        try:
+            self.progress("Enabling watchdog")
+            self.set_parameter("BRD_OPTIONS", 1 << 0)
+            self.reboot_sitl()
+            self.wait_ready_to_arm()
+            self.progress("Explicitly setting home to a known location")
+            orig_home = self.poll_home_position()
+            new_home = orig_home
+            new_home.latitude = new_home.latitude + 1000
+            new_home.longitude = new_home.longitude + 2000
+            new_home.altitude = new_home.altitude + 300000 # 300 metres
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_DO_SET_HOME,
+                0, # p1,
+                0, # p2,
+                0, # p3,
+                0, # p4,
+                new_home.latitude,
+                new_home.longitude,
+                new_home.altitude/1000.0, # mm => m
+            )
+            old_bootcount = self.get_parameter('STAT_BOOTCNT')
+            self.progress("Forcing watchdog reset")
+            os.kill(self.sitl.pid, signal.SIGALRM)
+            self.detect_and_handle_reboot(old_bootcount)
+            self.wait_statustext("WDG:")
+            self.wait_statustext("IMU1 is using GPS")  # won't be come armable
+            self.progress("Verifying home position")
+            post_reboot_home = self.poll_home_position()
+            delta = self.get_distance_int(new_home, post_reboot_home)
+            max_delta = 1
+            if delta > max_delta:
+                raise NotAchievedException(
+                    "New home not where it should be (dist=%f) (want=%s) (got=%s)" %
+                    (delta, str(new_home), str(post_reboot_home)))
+        except Exception as e:
+            self.print_exception_caught(e)
+            ex = e
+
+        self.reboot_sitl()
+
+        if ex is not None:
+            raise ex
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestPlane, self).tests()
@@ -3117,6 +3171,10 @@ class AutoTestPlane(AutoTest):
             ("DeepStall",
              "Test DeepStall Landing",
              self.fly_deepstall),
+
+            ("WatchdogHome",
+             "Ensure home is restored after watchdog reset",
+             self.WatchdogHome),
 
             ("LargeMissions",
              "Test Manipulation of Large missions",


### PR DESCRIPTION
.... and add test for same.

Plane overwrites home on restore in its "start" routines.

This is bad as we'll fly to the current location rather than home.

This is easy to reproduce in SITL:
 - enable watchdog and reboot
 - set home using right-mouse-button menu on map
 - `killall -ALRM arduplane`
 - watch what happens to home when the thing recovers.
