### PR TITLE
Move AOA and SSA state to be private in frontend

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -331,9 +331,6 @@ public:
     // write AOA and SSA information to dataflash logs:
     void Write_AOA_SSA(void) const;
 
-    // update AOA and SSA values
-    virtual void update_AOA_SSA(void);
-
     // return AOA
     float getAOA(void) const { return _AOA; }
 
@@ -407,6 +404,13 @@ private:
     };
 
     TriState terrainHgtStableState = TriState::UNKNOWN;
+
+    /*
+     * private AOA and SSA-related state and methods
+     */
+    float _AOA, _SSA;
+    uint32_t _last_AOA_update_ms;
+    void update_AOA_SSA(void);
 
     EKFType last_active_ekf_type;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -645,10 +645,6 @@ protected:
     // which accelerometer instance is active
     uint8_t _active_accel_instance;
 
-    // AOA and SSA
-    float _AOA, _SSA;
-    uint32_t _last_AOA_update_ms;
-
 private:
 
     uint32_t takeoff_expected_start_ms;


### PR DESCRIPTION
Simple tidy-up; the update function is only called in AHRS, and the state variables now belong in the frontend, not way down in the backend.

Also make the update method non-virtual.
