### PR TITLE
GCS_MAVLink: cope with MAV_CMD_ACCELCAL_VEHICLE_POS outside accelcal

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4021,7 +4021,8 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_sprayer(const mavlink_command_long_t &
 
 MAV_RESULT GCS_MAVLINK::handle_command_accelcal_vehicle_pos(const mavlink_command_long_t &packet)
 {
-    if (!AP::ins().get_acal()->gcs_vehicle_position(packet.param1)) {
+    if (AP::ins().get_acal() == nullptr ||
+        !AP::ins().get_acal()->gcs_vehicle_position(packet.param1)) {
         return MAV_RESULT_FAILED;
     }
     return MAV_RESULT_ACCEPTED;


### PR DESCRIPTION
Closes issue raised by @KimHyungSub  here: https://discuss.ardupilot.org/t/mavlink-commands-causing-memory-access-violation-and-integer-overflow/74260
