### PR TITLE
Up&Above Gimbal and external equipment for whole gimbal retract

### DIFF
--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -47,6 +47,7 @@ class AP_Mount_SoloGimbal;
 class AP_Mount_Alexmos;
 class AP_Mount_SToRM32;
 class AP_Mount_SToRM32_serial;
+class AP_Mount_Gimbal_uavcan;   //Add Up&Above Gimbal class
 
 /*
   This is a workaround to allow the MAVLink backend access to the
@@ -62,6 +63,7 @@ class AP_Mount
     friend class AP_Mount_Alexmos;
     friend class AP_Mount_SToRM32;
     friend class AP_Mount_SToRM32_serial;
+    friend class AP_Mount_Gimbal_uavcan;   //Added Up&Above 
 
 public:
     AP_Mount();
@@ -82,7 +84,16 @@ public:
         Mount_Type_SoloGimbal = 2,      /// Solo's gimbal
         Mount_Type_Alexmos = 3,         /// Alexmos mount
         Mount_Type_SToRM32 = 4,         /// SToRM32 mount using MAVLink protocol
-        Mount_Type_SToRM32_serial = 5   /// SToRM32 mount using custom serial protocol
+        Mount_Type_SToRM32_serial = 5,   /// SToRM32 mount using custom serial protocol
+        Mount_Type_Gimbal_uavcan = 6,   /// Added Up&Above Gimbal using UAVCAN
+    };
+    
+    // Added Up&Above Gimbal 
+    // UAVCAN Control mode
+    enum ControlMode {
+        Control_Angle_Body_Frame = 0,
+        Control_Angular_Rate = 1,
+        Control_Angle_Absolute_Frame = 2
     };
 
     // init - detect and initialise all mounts

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -217,4 +217,11 @@ bool AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vec
     return true;
 }
 
+// Added Up&Above Gimbal
+void AP_Mount_Backend::configure(enum MAV_MOUNT_MODE mount_mode, uint8_t stab_roll, uint8_t stab_pitch, uint8_t stab_yaw, enum AP_Mount::ControlMode roll_mode, enum AP_Mount::ControlMode pitch_mode, enum AP_Mount::ControlMode yaw_mode) {
+
+ _frontend.set_mode(_instance, mount_mode);
+}
+
+
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -33,6 +33,11 @@ public:
         _state(state),
         _instance(instance)
     {}
+    
+       
+    // Added Up&Above gimbal    
+    // control - control the mount
+    virtual void configure(enum MAV_MOUNT_MODE mount_mode, uint8_t stab_roll, uint8_t stab_pitch, uint8_t stab_yaw, enum AP_Mount::ControlMode roll_mode, enum AP_Mount::ControlMode pitch_mode, enum AP_Mount::ControlMode yaw_mode);
 
     // Virtual destructor
     virtual ~AP_Mount_Backend(void) {}

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -31,6 +31,8 @@
 
 #include <uavcan/helpers/heap_based_pool_allocator.hpp>
 
+// Added Up&Above Gimbal
+#include <AP_Mount/AP_Mount.h>
 
 #ifndef UAVCAN_NODE_POOL_SIZE
 #define UAVCAN_NODE_POOL_SIZE 8192
@@ -113,6 +115,15 @@ public:
 
     // send RTCMStream packets
     void send_RTCMStream(const uint8_t *data, uint32_t len);
+    
+     /**
+     * Added Up&Above equipment retract function
+     * Static function gives problems - Needs to be changet to non static, 
+     * but don't knew how to do it without errors
+     **/
+    static void do_gimbal_retract(bool retract);
+    // Added Up&Adbove Gimbal
+    void mount_write(bool geo_poi_mode, Vector3f angles, Location poi, enum AP_Mount::ControlMode mode);
 
     template <typename DataType_>
     class RegistryBinder {
@@ -162,6 +173,9 @@ private:
 
     // send GNSS injection
     void rtcm_stream_send();
+    
+    //Added Up&Above gimbal
+    void mount_out_send();
 
     uavcan::PoolAllocator<UAVCAN_NODE_POOL_SIZE, UAVCAN_NODE_POOL_BLOCK_SIZE, AP_UAVCAN::RaiiSynchronizer> _node_allocator;
 
@@ -204,6 +218,18 @@ private:
     } _led_conf;
 
     HAL_Semaphore _led_out_sem;
+    
+    // Added Up&Above gimbal
+    struct {
+        Location poi;
+        Vector3f target_angles;
+        bool geo_poi_mode;
+        bool broadcast_enabled;
+        bool new_data;
+        enum AP_Mount::ControlMode control_mode;
+    } _mount_conf;
+
+    HAL_Semaphore _mount_out_sem;
 
     // buzzer
     struct {


### PR DESCRIPTION
Gimbal control using UAVCAN protocol implementation. Also additional retract functionality if gimbal needed to hide in inside of the UAV.

Everything works and gimbals are in use by Lithuanian police and military. Additional video materials could be added by request.
Controller are based on EVGCC Plus custom version, also as Motor Modules.

Materials for gimbal PCB, firmware and Mission Planner plugins for control using joystic or RC could be found at: 
1. https://github.com/ZvelkAuksciau (Up&Above) - older versions of some software
2. https://github.com/raimapo - newer versions
3. https://github.com/MRazgunas - very old versions