### PR TITLE
waf: add files from ROMFS_custom to ROMFS

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -369,6 +369,17 @@ class Board:
         if cfg.options.ekf_single:
             env.CXXFLAGS += ['-DHAL_WITH_EKF_DOUBLE=0']
 
+        # add files from ROMFS_custom
+        custom_dir = 'ROMFS_custom'
+        if os.path.exists(custom_dir):
+            for root, subdirs, files in os.walk(custom_dir):
+                for f in files:
+                    if fnmatch.fnmatch(f,"*~"):
+                        # exclude emacs tmp files
+                        continue
+                    fname = root[len(custom_dir)+1:]+"/"+f
+                    env.ROMFS_FILES += [(fname,root+"/"+f)]
+
     def pre_build(self, bld):
         '''pre-build hook that gets called before dynamic sources'''
         if bld.env.ROMFS_FILES:


### PR DESCRIPTION
this allows for lua scripts in the root of the source tree as ROMFS_custom/scripts/*.lua

it also allows for any other custom data files that may be
needed. This is cleaner for custom scripts than having the files in
AP_HAL_ChibiOS/hwdef/BOARD/scripts, and allows for the same scripts
working in SITL, Linux and ChibiOS