### PR TITLE
AP_RCTelemetry: warn if Passthru miss-configured

### DIFF
--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -94,6 +94,14 @@ void AP_CRSF_Telem::setup_custom_telemetry()
         return;
     }
 
+    // check if passthru already assigned
+    const int8_t frsky_port = AP::serialmanager().find_portnum(AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough,0); 
+    if (frsky_port != -1) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "CRSF: passthrough telemetry conflict on SERIAL%d",frsky_port);
+       _custom_telem.init_done = true;
+       return;
+    }
+
     // we need crossfire firmware version
     if (_crsf_version.pending) {
         return;


### PR DESCRIPTION
prevent custom telem init and warns if Passthru assigned to another serial port
this tries to prevent double configuration of Passthru telem which ultimately creates a silent failure for CRSF Passthru

tested on F765-Wing