### PR TITLE
AC_AttitudeControl: Support thrust to weight of 10:1

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -295,8 +295,9 @@ float AC_AttitudeControl_Multi::get_throttle_boosted(float throttle_in)
     // inverted_factor reduces from 1 to 0 for tilt angles between 60 and 90 degrees
 
     float cos_tilt = _ahrs.cos_pitch() * _ahrs.cos_roll();
-    float inverted_factor = constrain_float(2.0f * cos_tilt, 0.0f, 1.0f);
-    float boost_factor = 1.0f / constrain_float(cos_tilt, 0.5f, 1.0f);
+    float inverted_factor = constrain_float(10.0f * cos_tilt, 0.0f, 1.0f);
+    float cos_tilt_target = cosf(_thrust_angle);
+    float boost_factor = 1.0f / constrain_float(cos_tilt_target, 0.1f, 1.0f);
 
     float throttle_out = throttle_in * inverted_factor * boost_factor;
     _angle_boost = constrain_float(throttle_out - throttle_in, -1.0f, 1.0f);


### PR DESCRIPTION
This PR makes two fundamental changes:
- It calculates the angle boost to be based on the target lean angle. This reduces oscillation due to poor attitude control (bad tunes).
- It delays the reduction of throttle to 84 degrees providing support for aircraft capable of thrust to weight ratios of 10:1.

This has been requested numerous times but the latest is here:
https://discuss.ardupilot.org/t/high-speed-auto-mission/74217/10

I have tested this on multirotor aircraft conducting auto and guided missions up to 55 m/s.

I think this should be included in 4.1