### PR TITLE
HAL_ChibiOS: add MatekF405-STD S7 PWM output

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-STD/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-STD/hwdef.dat
@@ -5,3 +5,13 @@ include ../MatekF405/hwdef.dat
 # different IMU orientation
 undef IMU
 IMU Invensense SPI:mpu6000 ROTATION_YAW_90
+
+# Use TIM5 for ST clock
+undef STM32_ST_USE_TIMER
+undef CH_CFG_ST_RESOLUTION
+define STM32_ST_USE_TIMER 5
+define CH_CFG_ST_RESOLUTION 32
+
+# Add S7 Pad for MatekF405 STD
+PB8  TIM4_CH3 TIM4 PWM(7) GPIO(56) NODMA
+


### PR DESCRIPTION
MatekF405-STD board has a pad for S7 PWM output not defined in the hwdef.
Defines a new PWM output on pin PB8, using TIM4 with no DMA.
Moves ST timer to TIM5, 32 bit.
Discontinued variants of this board: -OSD, -AIO, do not have the S7 pad the PB8 pin is not used.
Flight tested on a MatekF405-STD board.