### PR TITLE
Quadplane: tailsitter: always allow assist at min throttle

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1636,10 +1636,11 @@ bool QuadPlane::should_assist(float aspeed, bool have_airspeed)
         return false;
     }
 
-    if (!( (plane.control_mode->does_auto_throttle() && !plane.throttle_suppressed)
+    if (!tailsitter.enabled() && !( (plane.control_mode->does_auto_throttle() && !plane.throttle_suppressed)
                                                                       || plane.get_throttle_input()>0 
                                                                       || plane.is_flying() ) ) {
         // not in a flight mode and condition where it would be safe to turn on vertial lift motors
+        // skip this check for tailsitters because the forward and vertial motors are the same and are controled directly by throttle imput unlike other quadplanes
         in_angle_assist = false;
         angle_error_start_ms = 0;
         return false;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -181,10 +181,7 @@ private:
     AirMode air_mode;
 
     // check for quadplane assistance needed
-    bool assistance_needed(float aspeed, bool have_airspeed);
-
-    // check if it is safe to provide assistance
-    bool assistance_safe();
+    bool should_assist(float aspeed, bool have_airspeed);
 
     // update transition handling
     void update_transition(void);


### PR DESCRIPTION
This is a change to allays allow assistance at min throttle for tailsitters, should be no change for other vehicles. 

Tailsitters are a special case where the 'copter' motors are directly slaved to the forward flight throttle, unlike normal quadplanes where the two throttles are independent. This change means that we keep under copter control and abide by spin armed/min giving a clear visual clue that assistance is active. Currently tailsitter motors at zero throttle default back to outputs as set by `Q_TAILSIT_MOTMX` and `RUDD_DT_GAIN`. 

This change also means that https://github.com/ArduPilot/ardupilot/pull/18170 behaves the same in all forward flight modes, previously it would only work in auto throttle modes as assist would stop in manual throttle modes. That does also mean that you can end up with stabilization when you may not want it, such as on the ground sitting as a tailsitter in a forward flight mode, in this case you have a 90deg pitch error, so it will try quite hard to get level. 

