### PR TITLE
autotest: add option to hard-reset after every test

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -513,6 +513,7 @@ def run_step(step):
         "replay": opts.replay,
         "logs_dir": buildlogs_dirpath(),
         "sup_binaries": supplementary_binaries,
+        "reset_after_every_test": opts.reset_after_every_test,
     }
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup
@@ -994,6 +995,10 @@ if __name__ == "__main__":
                                 type='string',
                                 default="",
                                 help='list available subtests for a vehicle e.g Copter')
+    group_completion.add_option("--reset-after-every-test",
+                                action='store_true',
+                                default=False,
+                                help='reset everything after every test run')
     parser.add_option_group(group_completion)
 
     opts, args = parser.parse_args()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1218,7 +1218,8 @@ class AutoTest(ABC):
                  logs_dir=None,
                  force_ahrs_type=None,
                  replay=False,
-                 sup_binaries=[]):
+                 sup_binaries=[],
+                 reset_after_every_test=False):
 
         self.start_time = time.time()
         global __autotest__ # FIXME; make progress a non-staticmethod
@@ -1241,6 +1242,7 @@ class AutoTest(ABC):
         if self.speedup is None:
             self.speedup = self.default_speedup()
         self.sup_binaries = sup_binaries
+        self.reset_after_every_test = reset_after_every_test
 
         self.mavproxy = None
         self._mavproxy = None  # for auto-cleanup on failed tests
@@ -6040,6 +6042,9 @@ Also, ignores heartbeats not from our target system'''
             if interact:
                 self.progress("Starting MAVProxy interaction as directed")
                 self.mavproxy.interact()
+
+        if self.reset_after_every_test:
+            reset_needed = True
 
         if reset_needed:
             self.reset_SITL_commandline()


### PR DESCRIPTION
Using the option imposed a ~30% performance penalty in rough testing done here.

