### PR TITLE
AP_AHRS: correct compilation under SITL with no EKF3

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -792,11 +792,15 @@ bool AP_AHRS::airspeed_estimate(float &airspeed_ret) const
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SITL:
+#if HAL_NAVEKF3_AVAILABLE
         if (EKF3.getWind(-1,wind_vel)) {
              ret = true;
         } else {
             ret = false;
         }
+#else
+        ret = false;
+#endif
         break;
 #endif
 


### PR DESCRIPTION
Closes https://github.com/ArduPilot/ardupilot/issues/18198

Just need to work around a bad dependency between using the SITL backend and grabbing wind from EKF3.

Hack around it using preprocessor - but it would probably be better ot not use the EKF3 wind like this when using the SITL backend - we should really be returning the perfect wind estimate instead!
