### PR TITLE
Update 2D PID filter param names

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1244,7 +1244,7 @@ void Copter::convert_pid_parameters(void)
         { Parameters::k_param_pi_vel_xy, 0, AP_PARAM_FLOAT, "PSC_VELXY_P" },
         { Parameters::k_param_pi_vel_xy, 1, AP_PARAM_FLOAT, "PSC_VELXY_I" },
         { Parameters::k_param_pi_vel_xy, 2, AP_PARAM_FLOAT, "PSC_VELXY_IMAX" },
-        { Parameters::k_param_pi_vel_xy, 3, AP_PARAM_FLOAT, "PSC_VELXY_FILT" },
+        { Parameters::k_param_pi_vel_xy, 3, AP_PARAM_FLOAT, "PSC_VELXY_FLTE" },
         { Parameters::k_param_p_vel_z, 0, AP_PARAM_FLOAT, "PSC_VELZ_P" },
         { Parameters::k_param_pid_accel_z, 0, AP_PARAM_FLOAT, "PSC_ACCZ_P" },
         { Parameters::k_param_pid_accel_z, 1, AP_PARAM_FLOAT, "PSC_ACCZ_I" },

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -529,7 +529,7 @@ const AP_Param::ConversionInfo q_conversion_table[] = {
     { Parameters::k_param_quadplane, 4046, AP_PARAM_FLOAT, "Q_P_VELXY_P"},     //  Q_VXY_P
     { Parameters::k_param_quadplane, 78,   AP_PARAM_FLOAT, "Q_P_VELXY_I"},     //  Q_VXY_I
     { Parameters::k_param_quadplane, 142,  AP_PARAM_FLOAT, "Q_P_VELXY_IMAX"},  //  Q_VXY_IMAX
-    { Parameters::k_param_quadplane, 206,  AP_PARAM_FLOAT, "Q_P_VELXY_FILT"},  //  Q_VXY_FILT_HZ
+    { Parameters::k_param_quadplane, 206,  AP_PARAM_FLOAT, "Q_P_VELXY_FLTE"},  //  Q_VXY_FILT_HZ
     { Parameters::k_param_quadplane, 4047, AP_PARAM_FLOAT, "Q_P_VELZ_P"},      //  Q_VZ_P
     { Parameters::k_param_quadplane, 4048, AP_PARAM_FLOAT, "Q_P_ACCZ_P"},      //  Q_AZ_P
     { Parameters::k_param_quadplane, 80,   AP_PARAM_FLOAT, "Q_P_ACCZ_I"},      //  Q_AZ_I

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -465,14 +465,14 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Units: cm/s/s
     // @User: Advanced
 
-    // @Param: VELXY_FILT
+    // @Param: VELXY_FLTE
     // @DisplayName: Velocity (horizontal) input filter
     // @Description: Velocity (horizontal) input filter.  This filter (in Hz) is applied to the input for P and I terms
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
 
-    // @Param: VELXY_D_FILT
+    // @Param: VELXY_FLTD
     // @DisplayName: Velocity (horizontal) input filter
     // @Description: Velocity (horizontal) input filter.  This filter (in Hz) is applied to the input for D term
     // @Range: 0 100
@@ -516,14 +516,14 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Units: cm/s/s
     // @User: Advanced
 
-    // @Param: VELZ_FILT
+    // @Param: VELZ_FLTE
     // @DisplayName: Velocity (vertical) input filter
     // @Description: Velocity (vertical) input filter.  This filter (in Hz) is applied to the input for P and I terms
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
 
-    // @Param: VELZ_D_FILT
+    // @Param: VELZ_FLTD
     // @DisplayName: Velocity (vertical) input filter
     // @Description: Velocity (vertical) input filter.  This filter (in Hz) is applied to the input for D term
     // @Range: 0 100
@@ -567,14 +567,14 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Units: cm/s/s
     // @User: Advanced
 
-    // @Param: VELYAW_FILT
+    // @Param: VELYAW_FLTE
     // @DisplayName: Velocity (yaw) input filter
     // @Description: Velocity (yaw) input filter.  This filter (in Hz) is applied to the input for P and I terms
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
 
-    // @Param: VELYAW_D_FILT
+    // @Param: VELYAW_FLTE
     // @DisplayName: Velocity (yaw) input filter
     // @Description: Velocity (yaw) input filter.  This filter (in Hz) is applied to the input for D term
     // @Range: 0 100
@@ -618,14 +618,14 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Units: cm/s/s
     // @User: Advanced
 
-    // @Param: POSXY_FILT
+    // @Param: POSXY_FLTE
     // @DisplayName: Position (horizontal) input filter
     // @Description: Position (horizontal) input filter.  This filter (in Hz) is applied to the input for P and I terms
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
 
-    // @Param: POSXY_D_FILT
+    // @Param: POSXY_FLTD
     // @DisplayName: Position (horizontal) input filter
     // @Description: Position (horizontal) input filter.  This filter (in Hz) is applied to the input for D term
     // @Range: 0 100
@@ -669,14 +669,14 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Units: cm/s/s
     // @User: Advanced
 
-    // @Param: POSZ_FILT
+    // @Param: POSZ_FLTE
     // @DisplayName: Position (vertical) input filter
     // @Description: Position (vertical) input filter.  This filter (in Hz) is applied to the input for P and I terms
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
 
-    // @Param: POSZ_D_FILT
+    // @Param: POSZ_FLTD
     // @DisplayName: Position (vertical) input filter
     // @Description: Position (vertical) input filter.  This filter (in Hz) is applied to the input for D term
     // @Range: 0 100

--- a/Tools/Frame_params/SkyViper-2450GPS/defaults.parm
+++ b/Tools/Frame_params/SkyViper-2450GPS/defaults.parm
@@ -221,7 +221,7 @@ RC4_DZ              15
 PSC_POSXY_P           0.7
 PSC_VELXY_I           0.3
 PSC_VELXY_P           0.6
-PSC_VELXY_FILT        1.0
+PSC_VELXY_FLTE        1.0
 WPNAV_LOIT_JERK     4000
 WPNAV_LOIT_MAXA      800
 WPNAV_LOIT_MINA      250

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -239,14 +239,14 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Units: cm/s/s
     // @User: Advanced
 
-    // @Param: _VELXY_FILT
+    // @Param: _VELXY_FLTE
     // @DisplayName: Velocity (horizontal) input filter
     // @Description: Velocity (horizontal) input filter.  This filter (in Hz) is applied to the input for P and I terms
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
 
-    // @Param: _VELXY_D_FILT
+    // @Param: _VELXY_FLTD
     // @DisplayName: Velocity (horizontal) input filter
     // @Description: Velocity (horizontal) input filter.  This filter (in Hz) is applied to the input for D term
     // @Range: 0 100

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -4,8 +4,7 @@
 #include <AP_Math/AP_Math.h>
 #include "AC_PID_2D.h"
 
-#define AC_PID_2D_FILT_HZ_DEFAULT  20.0f   // default input filter frequency
-#define AC_PID_2D_FILT_HZ_MIN      0.01f   // minimum input filter frequency
+#define AC_PID_2D_FILT_E_HZ_DEFAULT  20.0f   // default input filter frequency
 #define AC_PID_2D_FILT_D_HZ_DEFAULT  10.0f   // default input filter frequency
 #define AC_PID_2D_FILT_D_HZ_MIN      0.005f   // minimum input filter frequency
 
@@ -25,22 +24,22 @@ const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
     // @Description: The maximum/minimum value that the I term can output
     AP_GROUPINFO("IMAX", 2, AC_PID_2D, _kimax, 0),
 
-    // @Param: FILT
+    // @Param: FLTE
     // @DisplayName: PID Input filter frequency in Hz
     // @Description: Input filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FILT", 3, AC_PID_2D, _filt_E_hz, AC_PID_2D_FILT_HZ_DEFAULT),
+    AP_GROUPINFO("FLTE", 3, AC_PID_2D, _filt_E_hz, AC_PID_2D_FILT_E_HZ_DEFAULT),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
     AP_GROUPINFO("D",    4, AC_PID_2D, _kd, 0),
 
-    // @Param: D_FILT
+    // @Param: FLTD
     // @DisplayName: D term filter frequency in Hz
     // @Description: D term filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("D_FILT", 5, AC_PID_2D, _filt_D_hz, AC_PID_2D_FILT_D_HZ_DEFAULT),
+    AP_GROUPINFO("FLTD", 5, AC_PID_2D, _filt_D_hz, AC_PID_2D_FILT_D_HZ_DEFAULT),
 
     // @Param: FF
     // @DisplayName: PID Feed Forward Gain

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/defaults.parm
@@ -348,7 +348,7 @@ RC4_DZ              15
 PSC_POSXY_P           0.7
 PSC_VELXY_I           0.3
 PSC_VELXY_P           0.6
-PSC_VELXY_FILT        1.0
+PSC_VELXY_FLTE        1.0
 WPNAV_LOIT_JERK     4000
 WPNAV_LOIT_MAXA      800
 WPNAV_LOIT_MINA      250


### PR DESCRIPTION
This change makes these filter parameter names consistent with our other controller naming conventions.