### PR TITLE
Copter: add TKOFF_SPEED to support takeoff speed being different from WPNAV_SPEED_UP

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1079,6 +1079,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_GROUPINFO("GUID_TIMEOUT", 46, ParametersG2, guided_timeout, 3.0),
 #endif
 
+    // @Param: TKOFF_SPEED
+    // @DisplayName: Takeoff speed
+    // @Description: Vertical speed (in cm/s) when taking off in Auto or Guided.  Leave as zero to use WPNAV_SPEED_UP.
+    // @Units: cm/s
+    // @Range: 0 1000
+    // @Increment: 10
+    // @User: Standard
+    AP_GROUPINFO("TKOFF_SPEED", 47, ParametersG2, takeoff_speed_cms, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -652,6 +652,8 @@ public:
 #if MODE_GUIDED_ENABLED == ENABLED
     AP_Float guided_timeout;
 #endif
+
+    AP_Int16 takeoff_speed_cms;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -379,12 +379,14 @@ public:
         NAV_PAYLOAD_PLACE,
     };
 
-    // Auto
+    // submode
     SubMode mode() const { return _mode; }
+    void set_submode(SubMode submode);
 
     bool loiter_start();
     void rtl_start();
     void takeoff_start(const Location& dest_loc);
+    void takeoff_end();
     void wp_start(const Location& dest_loc);
     void land_start();
     void land_start(const Vector2f& destination);
@@ -562,6 +564,9 @@ private:
 
     // True if we have entered AUTO to perform a DO_LAND_START landing sequence and we should report as AUTO RTL mode
     bool auto_RTL;
+
+    // takeoff speed used (0 if not used)
+    float takeoff_speed_used_cms = 0;
 };
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -124,6 +124,11 @@ bool ModeGuided::do_user_takeoff_start(float takeoff_alt_cm)
         return false;
     }
 
+    // set wp_nav's speed up if necessary
+    if (copter.g2.takeoff_speed_cms > 0) {
+        wp_nav->set_speed_up(copter.g2.takeoff_speed_cms);
+    }
+
     // initialise yaw
     auto_yaw.set_mode(AUTO_YAW_HOLD);
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -132,12 +132,11 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
 void AC_WPNav::wp_and_spline_init(float speed_cms)
 {
-    
     // sanity check parameters
     // check _wp_accel_cmss is reasonable
     const float wp_accel_cmss = MIN(_wp_accel_cmss, GRAVITY_MSS * 100.0f * tanf(ToRad(_attitude_control.lean_angle_max() * 0.01f)));
     _wp_accel_cmss.set_and_save_ifchanged((_wp_accel_cmss <= 0) ? WPNAV_ACCELERATION : wp_accel_cmss);
-    
+
     // check _wp_radius_cm is reasonable
     _wp_radius_cm.set_and_save_ifchanged(MAX(_wp_radius_cm, WPNAV_WP_RADIUS_MIN));
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -200,6 +200,12 @@ void AC_WPNav::set_speed_xy(float speed_cms)
     }
 }
 
+/// get current target climb rate in cm/s
+float AC_WPNav::get_speed_up() const
+{
+    return _pos_control.get_max_speed_up_cms();
+}
+
 /// set current target climb rate during wp navigation
 void AC_WPNav::set_speed_up(float speed_up_cms)
 {

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -69,6 +69,9 @@ public:
     /// set current target horizontal speed during wp navigation
     void set_speed_xy(float speed_cms);
 
+    /// get current target climb rate in cm/s
+    float get_speed_up() const;
+
     /// set current target climb or descent rate during wp navigation
     void set_speed_up(float speed_up_cms);
     void set_speed_down(float speed_down_cms);


### PR DESCRIPTION
This PR adds a new parameter TKOFF_SPEED that allows users to specify the climb rate used during takeoff in Auto or Guided mode that is separate from WPNAV_SPEED_UP.  If this new param is left at zero (the default), WPNAV_SPEED_UP is used during takeoff meaning no change in behaviour.

This requirement stems from [this user request from Copter-4.1.0 beta testing](https://discuss.ardupilot.org/t/set-position-target-global-int-velocity-bound-by-wpnav-speed/73988) in which the user has trouble with a change in behaviour in Copter-4.1 (vs 4.0).  The change is that in 4.1 the WPNAV_SPEED_UP/DN are used to limit the maximum speed up or down in Guided mode when the vehicle is controlled using velocity and/or acceleration targets (previously the vehicle would attempt to reach whatever speed the user requested).  This means that to attain high climb or descent rates the user must specify large WPNAV_SPEED_UP/DN values but this leads to overly aggressive takeoffs and descents.

This has been tested in SITL and some screenshots are shown below

In Auto we created a short mission consisting of a takeoff to 50m followed by a waypoint at 100m.
![sitl-image](https://user-images.githubusercontent.com/1498098/127956294-b6076ba1-1e99-4b57-bdc2-b5a6d408449b.png)

.. and we see the vehicle is obeying the TKOFF_SPEED parameter in two back-to-back tests.
![tkoff-speed-auto-test](https://user-images.githubusercontent.com/1498098/127956310-43593ff4-7a20-4b3b-b808-7f2b4ff6af21.png)

In Guided we basically repeated the same test as in auto above but using Fly-to-here commands from the GCS
![tkoff-speed-guided-test](https://user-images.githubusercontent.com/1498098/127956563-a87dabbc-1169-42d6-858b-1e9f36491c0b.png)

