### PR TITLE
Fixed printf formatting errors

### DIFF
--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -46,7 +46,7 @@ void led_toggle(unsigned led);
 
 // printf to debug uart (or USB)
 extern "C" {
-void uprintf(const char *fmt, ...);
+void uprintf(const char *fmt, ...) FMT_PRINTF(1,2);
 }
 
 // generate a LED sequence forever

--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -291,7 +291,7 @@ void AP_Periph_FW::update_rainbow()
 void AP_Periph_FW::show_stack_free()
 {
     const uint32_t isr_stack_size = uint32_t((const uint8_t *)&__main_stack_end__ - (const uint8_t *)&__main_stack_base__);
-    can_printf("ISR %u/%u", stack_free(&__main_stack_base__), isr_stack_size);
+    can_printf("ISR %u/%u", unsigned(stack_free(&__main_stack_base__)), unsigned(isr_stack_size));
 
     for (thread_t *tp = chRegFirstThread(); tp; tp = chRegNextThread(tp)) {
         uint32_t total_stack;
@@ -303,7 +303,7 @@ void AP_Periph_FW::show_stack_free()
             // above the stack top
             total_stack = uint32_t(tp) - uint32_t(tp->wabase);
         }
-        can_printf("%s STACK=%u/%u\n", tp->name, stack_free(tp->wabase), total_stack);
+        can_printf("%s STACK=%u/%u\n", tp->name, unsigned(stack_free(tp->wabase)), unsigned(total_stack));
     }
 }
 #endif
@@ -360,7 +360,7 @@ void AP_Periph_FW::update()
     if (now - last_error_ms > 5000 && ierr.errors()) {
         // display internal errors as DEBUG every 5s
         last_error_ms = now;
-        can_printf("IERR 0x%x %u", ierr.errors(), ierr.last_error_line());
+        can_printf("IERR 0x%x %u", unsigned(ierr.errors()), unsigned(ierr.last_error_line()));
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS && CH_DBG_ENABLE_STACK_CHECK == TRUE

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -243,6 +243,6 @@ namespace AP
 extern AP_Periph_FW periph;
 
 extern "C" {
-void can_printf(const char *fmt, ...);
+void can_printf(const char *fmt, ...) FMT_PRINTF(1,2);
 }
 

--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -376,7 +376,7 @@ bool AP_Button::arming_checks(size_t buflen, char *buffer) const
     }
     for (uint8_t i=0; i<AP_BUTTON_NUM_PINS; i++) {
         if (pin[i] != -1 && !hal.gpio->valid_pin(pin[i])) {
-            hal.util->snprintf(buffer, buflen, "BTN_PIN%u invalid", i + 1, pin[i]);
+            hal.util->snprintf(buffer, buflen, "BTN_PIN%u %d invalid", unsigned(i + 1), int(pin[i].get()));
             return false;
         }
     }

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -91,7 +91,7 @@ public:
     }
     
     // Method to log status and debug information for review while debugging
-    void log_text(AP_CANManager::LogLevel loglevel, const char *tag, const char *fmt, ...);
+    void log_text(AP_CANManager::LogLevel loglevel, const char *tag, const char *fmt, ...) FMT_PRINTF(4,5);
 
     void log_retrieve(ExpandingString &str) const;
 

--- a/libraries/AP_CANManager/AP_CANTester.cpp
+++ b/libraries/AP_CANManager/AP_CANTester.cpp
@@ -53,7 +53,7 @@ const AP_Param::GroupInfo CANTester::var_info[] = {
 
 };
 
-#define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "CANTester",  fmt, #args); } while (0)
+#define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "CANTester",  fmt, ##args); } while (0)
 
 bool CANTester::add_interface(AP_HAL::CANIface* can_iface)
 {

--- a/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
+++ b/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
@@ -26,7 +26,7 @@
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
-#define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "TestKDECAN",  fmt, #args); } while (0)
+#define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "TestKDECAN",  fmt, ##args); } while (0)
 extern const AP_HAL::HAL& hal;
 
 void AP_CANTester_KDECAN::count_msg(uint32_t frame_id)

--- a/libraries/AP_Common/NMEA.h
+++ b/libraries/AP_Common/NMEA.h
@@ -24,4 +24,4 @@ char *nmea_vaprintf(const char *fmt, va_list ap);
 /*
   formatted print of NMEA message to a uart, with checksum appended
  */
-bool nmea_printf(AP_HAL::UARTDriver *uart, const char *fmt, ...);
+bool nmea_printf(AP_HAL::UARTDriver *uart, const char *fmt, ...) FMT_PRINTF(2,3);

--- a/libraries/AP_Common/tests/test_nmea_print.cpp
+++ b/libraries/AP_Common/tests/test_nmea_print.cpp
@@ -31,15 +31,12 @@ static DummyUart test_uart;
 
 TEST(NMEA, Printf)
 {
-    EXPECT_FALSE(nmea_printf(&test_uart, ""));
-    char test_string[] = "test\n";  // blabla not an NMEA string but whatever
-    const size_t len = strlen(test_string);
     // test not enought space
-    test_uart.set_txspace(len-2);
-    EXPECT_FALSE(nmea_printf(&test_uart, test_string));
+    test_uart.set_txspace(2);
+    EXPECT_FALSE(nmea_printf(&test_uart, "TEST"));
     // normal test
-    test_uart.set_txspace(42);
-    EXPECT_TRUE(nmea_printf(&test_uart, test_string));
+    test_uart.set_txspace(9);
+    EXPECT_TRUE(nmea_printf(&test_uart, "TEST"));
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -246,8 +246,8 @@ bool AP_GPS_NMEA::_have_new_message()
     if (labs(dt_ms - gps._rate_ms[state.instance]) > 50 &&
         get_type() == AP_GPS::GPS_TYPE_ALLYSTAR) {
         nmea_printf(port, "$PHD,06,42,UUUUTTTT,BB,0,%u,55,0,%u,0,0,0",
-                    1000U/gps._rate_ms[state.instance],
-                    gps._rate_ms[state.instance]);
+                    unsigned(1000U/gps._rate_ms[state.instance]),
+                    unsigned(gps._rate_ms[state.instance]));
     }
 
     _last_fix_ms = now;

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -141,7 +141,7 @@ void AP_GPS_Backend::_detection_message(char *buffer, const uint8_t buflen) cons
                  "GPS %d: detected as %s at %d baud",
                  instance + 1,
                  name(),
-                 gps._baudrates[dstate.current_baud]);
+                 int(gps._baudrates[dstate.current_baud]));
     } else {
         hal.util->snprintf(buffer, buflen,
                  "GPS %d: specified as %s",

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -8,7 +8,7 @@ class ExpandingString;
 class AP_HAL::Util {
 public:
     int snprintf(char* str, size_t size,
-                 const char *format, ...);
+                 const char *format, ...) FMT_PRINTF(4, 5);
 
     int vsnprintf(char* str, size_t size,
                   const char *format, va_list ap);

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -206,7 +206,7 @@ bool AP_Parachute::arming_checks(size_t buflen, char *buffer) const
                 return false;
             }
         } else if (!_relay.enabled(_release_type)) {
-            hal.util->snprintf(buffer, buflen, "Chute invalid relay %d", _release_type);
+            hal.util->snprintf(buffer, buflen, "Chute invalid relay %d", int(_release_type));
             return false;
         }
     }

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -235,7 +235,7 @@ bool AP_RPM::arming_checks(size_t buflen, char *buffer) const
                 return false;
             }
             if (!hal.gpio->valid_pin(_pin[i])) {
-                hal.util->snprintf(buffer, buflen, "RPM[%u] pin %d invalid", i + 1, _pin[i]);
+                hal.util->snprintf(buffer, buflen, "RPM[%u] pin %d invalid", unsigned(i + 1), int(_pin[i].get()));
                 return false;
             }
             break;

--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -157,7 +157,7 @@ bool AP_Relay::arming_checks(size_t buflen, char *buffer) const
 {
     for (uint8_t i=0; i<AP_RELAY_NUM_RELAYS; i++) {
         if (_pin[i] != -1 && !hal.gpio->valid_pin(_pin[i])) {
-            hal.util->snprintf(buffer, buflen, "Relay[%u] pin %d invalid", unsigned(i + 1), int(_pin[i].get()));
+            hal.util->snprintf(buffer, buflen, "Relay[%u] pin %d invalid", i + 1, int(_pin[i].get()));
             return false;
         }
     }

--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -157,7 +157,7 @@ bool AP_Relay::arming_checks(size_t buflen, char *buffer) const
 {
     for (uint8_t i=0; i<AP_RELAY_NUM_RELAYS; i++) {
         if (_pin[i] != -1 && !hal.gpio->valid_pin(_pin[i])) {
-            hal.util->snprintf(buffer, buflen, "Relay[%u] pin %d invalid", i + 1, _pin[i]);
+            hal.util->snprintf(buffer, buflen, "Relay[%u] pin %d invalid", unsigned(i + 1), int(_pin[i].get()));
             return false;
         }
     }

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -32,7 +32,7 @@
 extern const AP_HAL::HAL& hal;
 
 #if HAL_CANMANAGER_ENABLED
-#define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "ToshibaCAN",  fmt, #args); } while (0)
+#define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "ToshibaCAN",  fmt, ##args); } while (0)
 #else
 #define debug_can(level_debug, fmt, args...)
 #endif

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
@@ -633,9 +633,13 @@ void AP_UAVCAN_DNA_Server::handleAllocation(uint8_t driver_index, uint8_t node_i
     }
 
     if (rcvd_unique_id_offset) {
-        debug_uavcan(AP_CANManager::LOG_DEBUG, "TIME: %ld  -- Accepting Followup part! %u\n", uavcan::SystemClock::instance().getMonotonic().toUSec()/1000, (now - last_alloc_msg_ms));
+        debug_uavcan(AP_CANManager::LOG_DEBUG, "TIME: %ld  -- Accepting Followup part! %u\n",
+                     long(uavcan::SystemClock::instance().getMonotonic().toUSec()/1000),
+                     unsigned((now - last_alloc_msg_ms)));
     } else {
-        debug_uavcan(AP_CANManager::LOG_DEBUG, "TIME: %ld  -- Accepting First part! %u\n", uavcan::SystemClock::instance().getMonotonic().toUSec()/1000, (now - last_alloc_msg_ms));
+        debug_uavcan(AP_CANManager::LOG_DEBUG, "TIME: %ld  -- Accepting First part! %u\n",
+                     long(uavcan::SystemClock::instance().getMonotonic().toUSec()/1000),
+                     unsigned((now - last_alloc_msg_ms)));
     }
 
     last_alloc_msg_ms = now;

--- a/libraries/AP_UAVCAN/AP_UAVCAN_IfaceMgr.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_IfaceMgr.cpp
@@ -166,7 +166,7 @@ bool CanIfaceMgr::add_interface(AP_HAL::CANIface *can_iface)
         AP::can().log_text(AP_CANManager::LOG_ERROR, LOG_TAG, "UAVCANIfaceMgr: Setting event handle failed\n");
         return false;
     }
-    AP::can().log_text(AP_CANManager::LOG_INFO, LOG_TAG, "UAVCANIfaceMgr: Successfully added interface %d\n");
+    AP::can().log_text(AP_CANManager::LOG_INFO, LOG_TAG, "UAVCANIfaceMgr: Successfully added interface %d\n", int(num_ifaces));
     num_ifaces++;
     return true;
 }

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -585,9 +585,9 @@ int GCS_MAVLINK::gen_dir_entry(char *dest, size_t space, const char *path, const
         if (AP::FS().stat(full_path, &st)) {
             return -1;
         }
-        return hal.util->snprintf(dest, space, "F%s\t%u\0", entry->d_name, (unsigned)st.st_size);
+        return hal.util->snprintf(dest, space, "F%s\t%u%c", entry->d_name, (unsigned)st.st_size, (char)0);
     } else {
-        return hal.util->snprintf(dest, space, "D%s\0", entry->d_name);
+        return hal.util->snprintf(dest, space, "D%s%c", entry->d_name, (char)0);
     }
 }
 


### PR DESCRIPTION
This adds format checking to
 - hal.util->snprintf()
 - can_printf()
 - log_text in CANManager
 - nmea_printf
and fixes the resulting format warnings

This was inspired by a bug in the new relay pin warnings that would print an error like this:
```
AP: PreArm: Relay[1] pin 134351159 invalid
```
due to the cast of an AP_Int8 onto the stack
