### PR TITLE
Guided: Add terrain following initialization.

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -153,6 +153,9 @@ void ModeGuided::pva_control_start()
 
     // initialise yaw
     auto_yaw.set_mode_to_default(false);
+
+    // initialise terain alt
+    guided_pos_terrain_alt = false;
 }
 
 // initialise guided mode's position controller


### PR DESCRIPTION
This address the bug highlighted here:
https://discuss.ardupilot.org/t/terrain-following-in-auto-may-hit-terrain/74365