### PR TITLE
AP_Torqeedo: add support for directly connecting to motor

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -86,7 +86,7 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
     }
 
     return (AP_Arming::pre_arm_checks(report)
-            & rover.g2.motors.pre_arm_check(report)
+            & motor_checks(report)
             & oa_check(report)
             & parameter_checks(report)
             & mode_checks(report));
@@ -197,4 +197,23 @@ bool AP_Arming_Rover::mode_checks(bool report)
         return false;
     }
     return true;
+}
+
+// check motors are ready
+bool AP_Arming_Rover::motor_checks(bool report)
+{
+    bool ret = rover.g2.motors.pre_arm_check(report);
+
+#if HAL_TORQEEDO_ENABLED
+    char failure_msg[50];
+    AP_Torqeedo *torqeedo = AP_Torqeedo::get_singleton();
+    if (torqeedo != nullptr) {
+        if (!torqeedo->pre_arm_checks(failure_msg, ARRAY_SIZE(failure_msg))) {
+            check_failed(report, "Torqeedo: %s", failure_msg);
+            ret = false;
+        }
+    }
+#endif
+
+    return ret;
 }

--- a/Rover/AP_Arming.h
+++ b/Rover/AP_Arming.h
@@ -31,5 +31,6 @@ protected:
     bool oa_check(bool report);
     bool parameter_checks(bool report);
     bool mode_checks(bool report);
+    bool motor_checks(bool report);
 
 };

--- a/libraries/AP_Torqeedo/AP_Torqeedo.cpp
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.cpp
@@ -136,9 +136,14 @@ bool AP_Torqeedo::init_internals()
 // returns true if the driver is enabled
 bool AP_Torqeedo::enabled() const
 {
-    if (_type == ConnectionType::TYPE_TILLER || _type == ConnectionType::TYPE_MOTOR) {
+    switch ((ConnectionType)_type) {
+    case ConnectionType::TYPE_DISABLED:
+        return false;
+    case ConnectionType::TYPE_TILLER:
+    case ConnectionType::TYPE_MOTOR:
         return true;
     }
+
     return false;
 }
 
@@ -177,7 +182,7 @@ void AP_Torqeedo::thread_main()
         if (safe_to_send()) {
             // if connected to motor send motor speed every 0.5sec
             if (_type == ConnectionType::TYPE_MOTOR &&
-                (AP_HAL::micros() - _last_send_motor_us > TORQEEDO_SEND_MOTOR_SPEED_INTERVAL_US)) {\
+                (AP_HAL::micros() - _last_send_motor_us > TORQEEDO_SEND_MOTOR_SPEED_INTERVAL_US)) {
                 _send_motor_speed = true;
             }
 
@@ -202,7 +207,7 @@ bool AP_Torqeedo::healthy()
     {
         // healthy if both receive and send have occurred in the last 3 seconds
         WITH_SEMAPHORE(_last_healthy_sem);
-        uint32_t now_ms = AP_HAL::millis();
+        const uint32_t now_ms = AP_HAL::millis();
         return ((now_ms - _last_received_ms < 3000) && (now_ms - _last_send_motor_ms < 3000));
     }
 }

--- a/libraries/AP_Torqeedo/AP_Torqeedo.cpp
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.cpp
@@ -208,6 +208,7 @@ bool AP_Torqeedo::healthy()
 }
 
 // run pre-arm check.  returns false on failure and fills in failure_msg
+// any failure_msg returned will not include a prefix
 bool AP_Torqeedo::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)
 {
     // exit immediately if not enabled
@@ -215,13 +216,12 @@ bool AP_Torqeedo::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)
         return true;
     }
 
-    const char *failure_prefix = "Torqeedo:";
     if (!_initialised) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "%s not initialised", failure_prefix);
+        strncpy(failure_msg, "not initialised", failure_msg_len);
         return false;
     }
     if (!healthy()) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "%s not healthy", failure_prefix);
+        strncpy(failure_msg, "not healthy", failure_msg_len);
         return false;
     }
     return true;

--- a/libraries/AP_Torqeedo/AP_Torqeedo.h
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.h
@@ -67,6 +67,12 @@ private:
         WAITING_FOR_FOOTER,
     };
 
+    enum class DebugLevel {
+        NONE = 0,
+        LOGGING_ONLY = 1,
+        LOGGING_AND_GCS = 2
+    };
+
     // initialise serial port and gpio pins (run from background thread)
     // returns true on success
     bool init_internals();
@@ -88,10 +94,14 @@ private:
     // value is taken directly from SRV_Channel
     void send_motor_speed_cmd();
 
+    // output logging and debug messages (if required)
+    void log_and_debug();
+
     // parameters
     AP_Int8 _enable;        // 1 if torqeedo feature is enabled
     AP_Int8 _pin_onoff;     // Pin number connected to Torqeedo's on/off pin. -1 to disable turning motor on/off from autopilot
     AP_Int8 _pin_de;        // Pin number connected to RS485 to Serial converter's DE pin. -1 to disable sending commands to motor
+    AP_Enum<DebugLevel> _debug_level;  // debug level
 
     // members
     AP_HAL::UARTDriver *_uart;      // serial port to communicate with motor
@@ -103,6 +113,7 @@ private:
     // health reporting
     uint32_t _last_healthy_ms;      // system time (in millis) that driver was last considered healthy
     HAL_Semaphore _last_healthy_sem;// semaphore protecting reading and updating of _last_healthy_ms
+    uint32_t _last_debug_ms;        // system time (in millis) that debug was last output
 
     // message parsing members
     ParseState _parse_state;        // current state of parsing

--- a/libraries/AP_Torqeedo/AP_Torqeedo.h
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.h
@@ -24,6 +24,7 @@
 #if HAL_TORQEEDO_ENABLED
 
 #include <AP_Param/AP_Param.h>
+#include <AP_HAL/Semaphores.h>
 
 #define TORQEEDO_MESSAGE_LEN_MAX    30  // messages are no more than 30 bytes
 
@@ -41,6 +42,12 @@ public:
     // consume incoming messages from motor, reply with latest motor speed
     // runs in background thread
     void thread_main();
+
+    // returns true if communicating with the motor
+    bool healthy();
+
+    // run pre-arm check.  returns false on failure and fills in failure_msg
+    bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -92,6 +99,10 @@ private:
     int16_t _motor_speed;           // desired motor speed (set from within update method)
     uint32_t _last_send_motor_us;   // system time (in micros) last motor speed command was sent
     uint32_t _send_delay_us;        // delay (in micros) to allow bytes to be sent after which pin can be unset.  0 if not delaying
+
+    // health reporting
+    uint32_t _last_healthy_ms;      // system time (in millis) that driver was last considered healthy
+    HAL_Semaphore _last_healthy_sem;// semaphore protecting reading and updating of _last_healthy_ms
 
     // message parsing members
     ParseState _parse_state;        // current state of parsing

--- a/libraries/AP_Torqeedo/AP_Torqeedo.h
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.h
@@ -74,10 +74,10 @@ private:
         TYPE_MOTOR = 2
     };
 
-    enum class DebugLevel {
-        NONE = 0,
-        LOGGING_ONLY = 1,
-        LOGGING_AND_GCS = 2
+    // OPTIONS parameter values
+    enum options {
+        LOG             = 1<<0,
+        DEBUG_TO_GCS    = 1<<1,
     };
 
     // initialise serial port and gpio pins (run from background thread)
@@ -114,7 +114,7 @@ private:
     AP_Enum<ConnectionType> _type;      // connector type used (0:disabled, 1:tiller connector, 2: motor connector)
     AP_Int8 _pin_onoff;     // Pin number connected to Torqeedo's on/off pin. -1 to disable turning motor on/off from autopilot
     AP_Int8 _pin_de;        // Pin number connected to RS485 to Serial converter's DE pin. -1 to disable sending commands to motor
-    AP_Enum<DebugLevel> _debug_level;  // debug level
+    AP_Int16 _options;      // options bitmask
 
     // members
     AP_HAL::UARTDriver *_uart;      // serial port to communicate with motor

--- a/libraries/AP_Torqeedo/AP_Torqeedo.h
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.h
@@ -67,6 +67,13 @@ private:
         WAITING_FOR_FOOTER,
     };
 
+    // TYPE parameter values
+    enum class ConnectionType {
+        TYPE_DISABLED = 0,
+        TYPE_TILLER = 1,
+        TYPE_MOTOR = 2
+    };
+
     enum class DebugLevel {
         NONE = 0,
         LOGGING_ONLY = 1,
@@ -77,9 +84,15 @@ private:
     // returns true on success
     bool init_internals();
 
+    // returns true if the driver is enabled
+    bool enabled() const;
+
     // process a single byte received on serial port
     // return true if a this driver should send a set-motor-speed message
     bool parse_byte(uint8_t b);
+
+    // returns true if it is safe to send a message
+    bool safe_to_send() const { return (_send_delay_us == 0); }
 
     // set pin to enable sending commands to motor
     void send_start();
@@ -98,7 +111,7 @@ private:
     void log_and_debug();
 
     // parameters
-    AP_Int8 _enable;        // 1 if torqeedo feature is enabled
+    AP_Enum<ConnectionType> _type;      // connector type used (0:disabled, 1:tiller connector, 2: motor connector)
     AP_Int8 _pin_onoff;     // Pin number connected to Torqeedo's on/off pin. -1 to disable turning motor on/off from autopilot
     AP_Int8 _pin_de;        // Pin number connected to RS485 to Serial converter's DE pin. -1 to disable sending commands to motor
     AP_Enum<DebugLevel> _debug_level;  // debug level
@@ -106,6 +119,7 @@ private:
     // members
     AP_HAL::UARTDriver *_uart;      // serial port to communicate with motor
     bool _initialised;              // true once driver has been initialised
+    bool _send_motor_speed;         // true if motor speed should be sent at next opportunity
     int16_t _motor_speed;           // desired motor speed (set from within update method)
     uint32_t _last_send_motor_us;   // system time (in micros) last motor speed command was sent
     uint32_t _send_delay_us;        // delay (in micros) to allow bytes to be sent after which pin can be unset.  0 if not delaying

--- a/libraries/AP_Torqeedo/AP_Torqeedo.h
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.h
@@ -121,12 +121,12 @@ private:
     bool _initialised;              // true once driver has been initialised
     bool _send_motor_speed;         // true if motor speed should be sent at next opportunity
     int16_t _motor_speed;           // desired motor speed (set from within update method)
-    uint32_t _last_send_motor_us;   // system time (in micros) last motor speed command was sent
+    uint32_t _last_send_motor_ms;   // system time (in millis) last motor speed command was sent (used for health reporting)
+    uint32_t _last_send_motor_us;   // system time (in micros) last motor speed command was sent (used for timing to unset DE pin)
     uint32_t _send_delay_us;        // delay (in micros) to allow bytes to be sent after which pin can be unset.  0 if not delaying
 
     // health reporting
-    uint32_t _last_healthy_ms;      // system time (in millis) that driver was last considered healthy
-    HAL_Semaphore _last_healthy_sem;// semaphore protecting reading and updating of _last_healthy_ms
+    HAL_Semaphore _last_healthy_sem;// semaphore protecting reading and updating of _last_send_motor_ms and _last_received_ms
     uint32_t _last_debug_ms;        // system time (in millis) that debug was last output
 
     // message parsing members
@@ -135,6 +135,7 @@ private:
     uint32_t _parse_success_count;  // number of messages successfully parsed (for reporting)
     uint8_t _received_buff[TORQEEDO_MESSAGE_LEN_MAX];   // characters received
     uint8_t _received_buff_len;     // number of characters received
+    uint32_t _last_received_ms;     // system time (in millis) that a message was successfully parsed (for health reporting)
 
     static AP_Torqeedo *_singleton;
 };

--- a/libraries/AP_Torqeedo/AP_Torqeedo.h
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.h
@@ -69,7 +69,7 @@ private:
     };
 
     // TYPE parameter values
-    enum class ConnectionType {
+    enum class ConnectionType : uint8_t {
         TYPE_DISABLED = 0,
         TYPE_TILLER = 1,
         TYPE_MOTOR = 2

--- a/libraries/AP_Torqeedo/AP_Torqeedo.h
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.h
@@ -47,6 +47,7 @@ public:
     bool healthy();
 
     // run pre-arm check.  returns false on failure and fills in failure_msg
+    // any failure_msg returned will not include a prefix
     bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);
 
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
The Torqeedo 1003 has two external available connectors.  One that connects the tiller to the battery.  The other connects the battery to the motor.

This PR adds support for directly connecting the autopilot to the motor connector.  The advantage of this is that we bypass the smart battery which simplifies communication and allows using a different (perhaps larger) battery.

![image](https://user-images.githubusercontent.com/1498098/128126650-aa9b2ffe-3292-44bf-b3d9-f432ff904729.png)

This PR also adds these smaller features:

- simple logging of health, paring success and error counts and currently throttle level being sent to the motor
- debug output to the GCS (same contents as the above logging)
- health reporting and pre-arm checks

This has been tested on real hardware.

A new [wiki page for the Torqeedo is here](https://ardupilot.org/rover/docs/common-torqeedo.html).