### PR TITLE
AP_scripting: stop and restart all scripts over mavlink

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -40,6 +40,7 @@ public:
     bool init_failed(void) const { return _init_failed; }
 
     bool enabled(void) const { return _enable != 0; };
+    bool should_run(void) const { return enabled() && !_stop; }
 
     static AP_Scripting * get_singleton(void) { return _singleton; }
 
@@ -100,6 +101,8 @@ private:
     AP_Int16 _dir_disable;
 
     bool _init_failed;  // true if memory allocation failed
+    bool _restart; // true if scripts should be restarted
+    bool _stop; // true if scripts should be stopped
 
     static AP_Scripting *_singleton;
 

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -429,7 +429,7 @@ void lua_scripts::run(void) {
     succeeded_initial_load = true;
 #endif // __clang_analyzer__
 
-    while (AP_Scripting::get_singleton()->enabled()) {
+    while (AP_Scripting::get_singleton()->should_run()) {
         // handle terminal data if we have any
         if (terminal.session) {
             doREPL(L);


### PR DESCRIPTION
https://github.com/ArduPilot/mavlink/pull/217

Unlike some of my past attempts this is all scripts. You can stop all and restart all over MAVLink, ~you can also mark all to be restarted from a script, obviously that only really works well when you have a single script running~.  You can also restart by setting `SCR_ENABLE` to 0 and back to 1. This only works if scripting was enabled at boot.