### PR TITLE
AP_Scripting: add binding for RC_Channel by number.

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -243,6 +243,8 @@ singleton RC_Channels method get_pwm boolean uint8_t 1 NUM_RC_CHANNELS uint16_t'
 singleton RC_Channels method find_channel_for_option RC_Channel RC_Channel::AUX_FUNC'enum 0 UINT16_MAX
 singleton RC_Channels method run_aux_function boolean RC_Channel::AUX_FUNC'enum 0 UINT16_MAX RC_Channel::AuxSwitchPos'enum RC_Channel::AuxSwitchPos::LOW RC_Channel::AuxSwitchPos::HIGH RC_Channel::AuxFuncTriggerSource::SCRIPTING'literal
 singleton RC_Channels method has_valid_input boolean
+singleton RC_Channels method lua_rc_channel RC_Channel uint8_t 1 NUM_RC_CHANNELS
+singleton RC_Channels method lua_rc_channel alias get_channel
 
 include AP_SerialManager/AP_SerialManager.h
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -399,6 +399,11 @@ public:
     // this function is implemented in the child class in the vehicle
     // code
     virtual RC_Channel *channel(uint8_t chan) = 0;
+    // helper used by scripting to convert the above function from 0 to 1 indexeing
+    // range is checked correctly by the underlying channel function
+    RC_Channel *lua_rc_channel(const uint8_t chan) {
+        return channel(chan -1);
+    }
 
     uint8_t get_radio_in(uint16_t *chans, const uint8_t num_channels); // reads a block of chanel radio_in values starting from channel 0
                                                                        // returns the number of valid channels


### PR DESCRIPTION
Currently we can only get RC_Channel object by option, this adds a binding for by number. To match the existing `get_pwm` binding we have a helper to convert from 1 index to 0 indexed. 

You might want to do this for example:

`local roll_in = assert(rc:get_channel(param:get('RCMAP_ROLL')),'get roll RC in failed')`

Then you can use the get norm in method:

`roll_in:norm_input()`