### PR TITLE
AP_NavEKF3: skip GSF reset count check if source actively changed

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -757,7 +757,7 @@ void NavEKF3_core::runYawEstimatorCorrection()
 
         // action an external reset request
         if (EKFGSF_yaw_reset_request_ms > 0 && imuSampleTime_ms - EKFGSF_yaw_reset_request_ms < YAW_RESET_TO_GSF_TIMEOUT_MS) {
-            EKFGSF_resetMainFilterYaw();
+            EKFGSF_resetMainFilterYaw(true);
         }
     } else {
         EKFGSF_yaw_valid_count = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -951,8 +951,9 @@ private:
     void resetQuatStateYawOnly(ftype yaw, ftype yawVariance, rotationOrder order);
 
     // attempt to reset the yaw to the EKF-GSF value
+    // emergency_reset should be true if this reset is triggered by the loss of the yaw estimate
     // returns false if unsuccessful
-    bool EKFGSF_resetMainFilterYaw();
+    bool EKFGSF_resetMainFilterYaw(bool emergency_reset);
 
     // returns true on success and populates yaw (in radians) and yawVariance (rad^2)
     bool EKFGSF_getYaw(ftype &yaw, ftype &yawVariance) const;


### PR DESCRIPTION
This PR resolves an [issue reported in this 4.1.0-beta discussion](https://discuss.ardupilot.org/t/loss-of-correction-after-switching-couple-times-between-yaw-compass-source-and-gsf-source/72687/18) in which the EKF's yaw source could only be actively switched between compass and GSF a few times because of the limit controlled by the EK3_GSF_RST_MAX parameter.

The proposed solution is to separate "active" switching to GSF vs "emergency" switching and only apply the GSF_RST_MAX param on emergency resets.

This issue can be recreated in SITL by doing the following:

- param set EK3_SRC2_POSXY 3  (GPS)
- param set EK3_SRC2_VELXY 3  (GPS)
- param set EK3_SRC2_VELZ 3  (GPS)
- param set EK3_SRC2_YAW 8  (**GSF**)
- param set RC9_OPTION 90  (EKF pos source)
- Loiter
- arm throttle
- rc 3 2000 (climb to 10m)
- rc 3 1500
- rc 2 1000 (fly forward)
- rc 2 1500 (stop, this allows GSF to get a good yaw estimate)
- rc 2 1200 (fly forward)
- rc 9 1500 (to switch to EK3_SRC2_xx sources)
- rc 9 1000 (to switch back to EK3_SRC1_xx sources)

If the last two steps were repeated a couple of times the vehicle will fail to reset to the GSF yaw.

Below are before and after screen shots along with some annotations.
![before](https://user-images.githubusercontent.com/1498098/128341674-f69590fc-b9bf-470d-b19a-1d67a3fc125f.png)
![after](https://user-images.githubusercontent.com/1498098/128341681-736c90fb-c647-47ea-b869-dc151f440730.png)

I've also tested that the GSF reset logic still works by purposely setting COMPASS_ORIENT = 4 and taking off in Loiter mode and the heading was corrected soon after the pilot commanded a forward pitch.

Note: maybe we should also consider removing the EK3_GSF_RST_MAX parameter?