### PR TITLE
ArduPlane: correct Mission Reset  behaviour in Plane

### DIFF
--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -135,11 +135,6 @@ void RC_Channel_Plane::do_aux_function_flare(AuxSwitchPos ch_flag)
         }    
 }
 
-void RC_Channel_Plane::do_aux_function_mission_reset(const AuxSwitchPos ch_flag)
-{
-    plane.mission.start();
-    plane.prev_WP_loc = plane.current_loc;
-}
 
 void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
                                          const RC_Channel::AuxSwitchPos ch_flag)

--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -26,8 +26,6 @@ private:
 
     void do_aux_function_flare(AuxSwitchPos ch_flag);
 
-    void do_aux_function_mission_reset(const AuxSwitchPos ch_flag) override;
-
 };
 
 class RC_Channels_Plane : public RC_Channels

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -276,7 +276,7 @@ protected:
     void do_aux_function_clear_wp(const AuxSwitchPos ch_flag);
     void do_aux_function_gripper(const AuxSwitchPos ch_flag);
     void do_aux_function_lost_vehicle_sound(const AuxSwitchPos ch_flag);
-    virtual void do_aux_function_mission_reset(const AuxSwitchPos ch_flag);
+    void do_aux_function_mission_reset(const AuxSwitchPos ch_flag);
     void do_aux_function_rc_override_enable(const AuxSwitchPos ch_flag);
     void do_aux_function_relay(uint8_t relay, bool val);
     void do_aux_function_sprayer(const AuxSwitchPos ch_flag);


### PR DESCRIPTION
fixes a few issues with current override (thanks to @tridge for helping find this):
1. any switch position change triggers it, instead of >1800us
2. it always sets MISSION_RUNNING since it uses mission->start() instead of reset() which prevents a mission->clear() from occurring in any mode until the mission is completed. Should be able to clear a mission in any not AUTO mode.

new(actually old) behavior:
will reset the mission pointer to the first WP any time aux switch  transitions to high, either while armed in any non-auto mode or while armed in auto, causing the mission to restart at its beginning....disarming resets the mission also

SITL tested