### PR TITLE
AP_HAL_ChibiOS: Pixhawk4 blue and red LEDs swapped

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk4/hwdef.dat
@@ -3,6 +3,14 @@
 
 include ../fmuv5/hwdef.dat
 
+# red and blue LEDs swapped vs fmuv5
+# red LED marked as B/E
+undef PB1
+PB1 LED_RED OUTPUT OPENDRAIN GPIO(92)
+# blue LED marked as ACT
+undef PC7
+PC7 LED_BLUE OUTPUT GPIO(90) HIGH
+
 # setup for supplied power brick
 undef HAL_BATT_VOLT_SCALE
 define HAL_BATT_VOLT_SCALE 18.182


### PR DESCRIPTION
This is a relatively simple fix to swap the red and blue LEDs on the Pixhawk4 and resolve issue https://github.com/ArduPilot/ardupilot/issues/15739.

This was also brought during [Copter-4.1.0 beta testing discussions here](https://discuss.ardupilot.org/t/copter-4-1-0-beta6-released-for-beta-testing/74139/14).

Fixes #15739