### PR TITLE
Plane: actually fail to enter mode, don't just put the mode back and return true

### DIFF
--- a/ArduPlane/mode_qacro.cpp
+++ b/ArduPlane/mode_qacro.cpp
@@ -3,13 +3,7 @@
 
 bool ModeQAcro::_enter()
 {
-    if (!plane.quadplane.init_mode() && plane.previous_mode != nullptr) {
-        plane.control_mode = plane.previous_mode;
-    } else {
-        plane.auto_state.vtol_mode = true;
-    }
-
-    return true;
+    return plane.mode_qstabilize._enter();
 }
 
 void ModeQAcro::update()

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -3,12 +3,10 @@
 
 bool ModeQStabilize::_enter()
 {
-    if (!plane.quadplane.init_mode() && plane.previous_mode != nullptr) {
-        plane.control_mode = plane.previous_mode;
-    } else {
-        plane.auto_state.vtol_mode = true;
+    if (!plane.quadplane.init_mode()) {
+        return false;
     }
-
+    plane.auto_state.vtol_mode = true;
     return true;
 }
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -246,15 +246,8 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
         // we failed entering new mode, roll back to old
         previous_mode = &old_previous_mode;
         control_mode = &old_mode;
-
         control_mode_reason = previous_mode_reason;
 
-        // currently, only Q modes can fail enter(). This will likely change in the future and all modes
-        // should be changed to check dependencies and fail early before depending on changes in Mode::set_mode()
-        if (control_mode->is_vtol_mode()) {
-            // ignore result because if we fail we risk looping at the qautotune check above
-            control_mode->enter();
-        }
         // make sad noise
         if (reason != ModeReason::INITIALISED) {
             AP_Notify::events.user_mode_change_failed = 1;


### PR DESCRIPTION
Found while testing https://github.com/ArduPilot/ardupilot/pull/18227 We never return false, so never get the sad noise.

Currently this mode failed code is not used: 
https://github.com/ArduPilot/ardupilot/blob/44d5885d99851a0a772972ba7bb83568d4c03df5/ArduPlane/system.cpp#L230

Looks like this issue is left over from the plane onion, so the mode fail code that we now hit has never been tested......

Fixes https://github.com/ArduPilot/ardupilot/issues/16120