### PR TITLE
Ekf3: sensors provide body offset

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -311,7 +311,7 @@ void NavEKF3_core::FuseOptFlow(const of_elements &ofDataDelayed)
         // correct range for flow sensor offset body frame position offset
         // the corrected value is the predicted range from the sensor focal point to the
         // centre of the image on the ground assuming flat terrain
-        Vector3F posOffsetBody = ofDataDelayed.body_offset - accelPosOffset;
+        Vector3F posOffsetBody = ofDataDelayed.body_offset;
         if (!posOffsetBody.is_zero()) {
             Vector3F posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
             range -= posOffsetEarth.z / prevTnb.c.z;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -360,7 +360,7 @@ void NavEKF3_core::CorrectExtNavForSensorOffset(ext_nav_elements &ext_nav_data)
     if (visual_odom == nullptr) {
         return;
     }
-    const Vector3F posOffsetBody = visual_odom->get_pos_offset().toftype() - accelPosOffset;
+    const Vector3F posOffsetBody = visual_odom->get_pos_offset().toftype();
     if (posOffsetBody.is_zero()) {
         return;
     }
@@ -385,7 +385,7 @@ void NavEKF3_core::CorrectExtNavVelForSensorOffset(ext_nav_vel_elements &ext_nav
     if (visual_odom == nullptr) {
         return;
     }
-    const Vector3F posOffsetBody = visual_odom->get_pos_offset().toftype() - accelPosOffset;
+    const Vector3F posOffsetBody = visual_odom->get_pos_offset().toftype();
     if (posOffsetBody.is_zero()) {
         return;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1258,7 +1258,7 @@ void NavEKF3_core::FuseBodyVel()
         bodyVelPred = (prevTnb * stateStruct.velocity);
 
         // correct sensor offset body frame position offset relative to IMU
-        Vector3F posOffsetBody = bodyOdmDataDelayed.body_offset - accelPosOffset;
+        Vector3F posOffsetBody = bodyOdmDataDelayed.body_offset;
 
         // correct prediction for relative motion due to rotation
         // note - % operator overloaded for cross product

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -327,7 +327,7 @@ void NavEKF3_core::CorrectGPSForAntennaOffset(gps_elements &gps_data) const
     }
     gps_data.corrected = true;
 
-    const Vector3F posOffsetBody = dal.gps().get_antenna_offset(gps_data.sensor_idx).toftype() - accelPosOffset;
+    const Vector3F posOffsetBody = dal.gps().get_antenna_offset(gps_data.sensor_idx).toftype();
     if (posOffsetBody.is_zero()) {
         return;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1049,7 +1049,7 @@ void NavEKF3_core::selectHeightForFusion()
     if (_rng && rangeDataToFuse) {
         auto *sensor = _rng->get_backend(rangeDataDelayed.sensor_idx);
         if (sensor != nullptr) {
-            Vector3F posOffsetBody = sensor->get_pos_offset().toftype() - accelPosOffset;
+            Vector3F posOffsetBody = sensor->get_pos_offset().toftype();
             if (!posOffsetBody.is_zero()) {
                 Vector3F posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
                 rangeDataDelayed.rng += posOffsetEarth.z / prevTnb.c.z;


### PR DESCRIPTION
This PR is a result of [this 4.1.0-beta discussion with Yuri_Rage](https://discuss.ardupilot.org/t/rover-4-1-0-beta6-released-for-beta-testing/74013/25).

We seem to have a discrepancy between our [sensor position offset wiki](https://ardupilot.org/copter/docs/common-sensor-offset-compensation.html) and the EKF3 (and EKF2) implementation.

The relevant part of the wiki description is here

`In practice the distance to the sensor can be measured from the center of the autopilot unless the autopilot itself is placed a significant distance from the vehicle’s center of gravity in which case the IMU position offsets can be specified and then the other sensor’s position offsets can be specified from the vehicle’s center of gravity.`

..but the "bodyPosOffset" calculations for the various sensors always also include the IMU offsets which, according to the description above, they should not.  If we move the IMU on the vehicle we shouldn't then also have to update every sensor's position as well should we?

I suspect either way works but either the docs or the code should probably be fixed.