### PR TITLE
Rover: Change BEACON to optional

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -422,9 +422,11 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(afs, "AFS_", 5, ParametersG2, AP_AdvancedFailsafe),
 #endif
 
+#if BEACON_ENABLED == ENABLED
     // @Group: BCN
     // @Path: ../libraries/AP_Beacon/AP_Beacon.cpp
     AP_SUBGROUPINFO(beacon, "BCN", 6, ParametersG2, AP_Beacon),
+#endif
 
     // 7 was used by AP_VisualOdometry
 
@@ -692,7 +694,9 @@ ParametersG2::ParametersG2(void)
 #if ADVANCED_FAILSAFE == ENABLED
     afs(),
 #endif
+#if BEACON_ENABLED == ENABLED 
     beacon(rover.serial_manager),
+#endif
     motors(rover.ServoRelayEvents, wheel_rate_control),
     wheel_rate_control(wheel_encoder),
     attitude_control(),

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -299,7 +299,9 @@ public:
     AP_AdvancedFailsafe_Rover afs;
 #endif
 
+#if BEACON_ENABLED == ENABLED
     AP_Beacon beacon;
+#endif
 
     // Motor library
     AP_MotorsUGV motors;

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -55,7 +55,9 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(set_servos,            400,    200),
     SCHED_TASK_CLASS(AP_GPS,              &rover.gps,              update,         50,  300),
     SCHED_TASK_CLASS(AP_Baro,             &rover.barometer,        update,         10,  200),
+#if BEACON_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Beacon,           &rover.g2.beacon,        update,         50,  200),
+#endif
 #if HAL_PROXIMITY_ENABLED
     SCHED_TASK_CLASS(AP_Proximity,        &rover.g2.proximity,     update,         50,  200),
 #endif
@@ -300,10 +302,12 @@ void Rover::update_logging1(void)
         Log_Write_Sail();
     }
 
+#if BEACON_ENABLED == ENABLED 
     if (should_log(MASK_LOG_THR)) {
         Log_Write_Throttle();
         logger.Write_Beacon(g2.beacon);
     }
+#endif
 
     if (should_log(MASK_LOG_NTUN)) {
         Log_Write_Nav_Tuning();

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -30,7 +30,6 @@
 #include <AP_Airspeed/AP_Airspeed.h>                // needed for AHRS build
 #include <AP_Baro/AP_Baro.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>          // Battery monitor library
-#include <AP_Beacon/AP_Beacon.h>
 #include <AP_Camera/AP_Camera.h>                    // Camera triggering
 #include <AP_Compass/AP_Compass.h>                  // ArduPilot Mega Magnetometer Library
 #include <AP_Declination/AP_Declination.h>          // Compass declination library
@@ -94,6 +93,10 @@
 #include "GCS_Rover.h"
 #include "AP_Rally.h"
 #include "RC_Channel.h"                  // RC Channel Library
+
+#if BEACON_ENABLED == ENABLED
+#include <AP_Beacon/AP_Beacon.h>
+#endif
 
 class Rover : public AP_Vehicle {
 public:

--- a/Rover/config.h
+++ b/Rover/config.h
@@ -118,3 +118,6 @@
  #define OSD_ENABLED DISABLED
 #endif
 
+#ifndef BEACON_ENABLED
+ # define BEACON_ENABLED DISABLED
+#endif

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -73,8 +73,10 @@ void Rover::init_ardupilot()
     g2.proximity.init();
 #endif
 
+#if BEACON_ENABLED == ENABLED 
     // init beacons used for non-gps position estimation
     g2.beacon.init();
+#endif
 
     // and baro for EKF
     barometer.set_log_baro_bit(MASK_LOG_IMU);


### PR DESCRIPTION
I don't see any videos of rovers running or boats navigating with beacons.
I don't think beacons are an essential feature in rovers or boats.
I would make the beacon optional.