### PR TITLE
Rover: Specify the process

### DIFF
--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -78,5 +78,6 @@ void Rover::update_home()
 
     if (!ahrs.set_home(loc)) {
         // silently ignored...
+        return;
     }
 }


### PR DESCRIPTION
I indicate that it is clearly RETURN, from empty processing.