### PR TITLE
AP_OSD: add option for imperial miles to be shown at 5280ft vs 10000ft

### DIFF
--- a/libraries/AP_Scripting/lua/src/lstring.c
+++ b/libraries/AP_Scripting/lua/src/lstring.c
@@ -22,7 +22,7 @@
 #include "lstring.h"
 
 
-#define MEMERRMSG       "not enough memory"
+#define MEMERRMSG       "not enough mem,increase scr_heap_size"
 
 
 /*


### PR DESCRIPTION
make LUA memory panic message helpful