### PR TITLE
Copter: flowhold: use correct angle max

### DIFF
--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -313,7 +313,7 @@ void ModeFlowHold::run()
     // calculate alt-hold angles
     int16_t roll_in = copter.channel_roll->get_control_in();
     int16_t pitch_in = copter.channel_pitch->get_control_in();
-    float angle_max = copter.attitude_control->get_althold_lean_angle_max();
+    float angle_max = copter.aparm.angle_max;
     get_pilot_desired_lean_angles(bf_angles.x, bf_angles.y, angle_max, attitude_control->get_althold_lean_angle_max());
 
     if (quality_filtered >= flow_min_quality &&


### PR DESCRIPTION
Fixes #10524

Flow hold was always using lean angle max, that is none configurable and can be very high if a copter has a low hover throttle.