### PR TITLE
librarys: add enable flags

### DIFF
--- a/libraries/AP_Beacon/AP_Beacon.cpp
+++ b/libraries/AP_Beacon/AP_Beacon.cpp
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo AP_Beacon::var_info[] = {
     // @Description: What type of beacon based position estimation device is connected
     // @Values: 0:None,1:Pozyx,2:Marvelmind,3:Nooploop,10:SITL
     // @User: Advanced
-    AP_GROUPINFO("_TYPE",    0, AP_Beacon, _type, 0),
+    AP_GROUPINFO_FLAGS("_TYPE",    0, AP_Beacon, _type, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: _LATITUDE
     // @DisplayName: Beacon origin's latitude

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -138,12 +138,19 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FLAP_PERCNT", 13, AP_Landing, flap_percent, 0),
 
+    // @Param: OPTIONS
+    // @DisplayName: Landing options bitmask
+    // @Description: Bitmask of options to use with landing.
+    // @Bitmask: 0: honor min throttle during landing flare
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 16, AP_Landing, _options, 0),
+
     // @Param: TYPE
     // @DisplayName: Auto-landing type
     // @Description: Specifies the auto-landing type to use
     // @Values: 0:Standard Glide Slope, 1:Deepstall
     // @User: Standard
-    AP_GROUPINFO("TYPE",    14, AP_Landing, type, TYPE_STANDARD_GLIDE_SLOPE),
+    AP_GROUPINFO_FLAGS("TYPE",    14, AP_Landing, type, TYPE_STANDARD_GLIDE_SLOPE, AP_PARAM_FLAG_ENABLE),
 
 #if HAL_LANDING_DEEPSTALL_ENABLED
     // @Group: DS_
@@ -151,12 +158,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     AP_SUBGROUPINFO(deepstall, "DS_", 15, AP_Landing, AP_Landing_Deepstall),
 #endif
 
-    // @Param: OPTIONS
-    // @DisplayName: Landing options bitmask
-    // @Description: Bitmask of options to use with landing.
-    // @Bitmask: 0: honor min throttle during landing flare
-    // @User: Advanced
-    AP_GROUPINFO("OPTIONS", 16, AP_Landing, _options, 0),
+    // additional global params should be placed in the list above TYPE to avoid the enable flag hiding the deepstall params
 
     AP_GROUPEND
 };

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -39,7 +39,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Values: 0:None,7:LightwareSF40c,1:LightWareSF40C-legacy,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2,6:TeraRangerTowerEvo,8:LightwareSF45B,10:SITL,12:AirSimSITL
     // @RebootRequired: True
     // @User: Standard
-    AP_GROUPINFO("_TYPE",   1, AP_Proximity, _type[0], 0),
+    AP_GROUPINFO_FLAGS("_TYPE",   1, AP_Proximity, _type[0], 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: _ORIENT
     // @DisplayName: Proximity sensor orientation

--- a/libraries/AP_Radio/AP_Radio.cpp
+++ b/libraries/AP_Radio/AP_Radio.cpp
@@ -19,7 +19,7 @@ const AP_Param::GroupInfo AP_Radio::var_info[] = {
     // @Values: 0:None,1:CYRF6936,2:CC2500,3:BK2425
 
     // @User: Advanced
-    AP_GROUPINFO("_TYPE",  1, AP_Radio, radio_type, 0),
+    AP_GROUPINFO_FLAGS("_TYPE",  1, AP_Radio, radio_type, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: _PROT
     // @DisplayName: protocol


### PR DESCRIPTION
This adds enable flags to 6 library's. With SITL defaults this results in hiding 29 prams for plane and 31 for copter.

It would be a big win if we could hide the second set of GPS params behind GPS_TPYE2, its just a matter of the list order, but that would be quite a big rearrangement so I have not done it in this PR. That would save another 18 params for the majority of people.

With this PR (and SITL defualts) plane has 1350 visible params and copter 1273. 

IMHO the more params we can hide the better, its less confusing for users and makes it harder to set something wrong by mistake. 

With this we have done all of the easy ones, there maybe more we can have two enables in. 

There are a few that don't have param with a convenient 0 value to flag as enable, `AP_Camera` for example, in those cases we have to add a param and work out a way to set it based on the users current config. Or possibly a new param flag where -1 is the disable value. 