### PR TITLE
AP_HAL_ChibiOS: fix invalid use of FDCAN2_IT0_IRQn enum for ifdef

### DIFF
--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -574,13 +574,13 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
             nvicEnableVector(FDCAN1_IT0_IRQn, CORTEX_MAX_KERNEL_PRIORITY);
             nvicEnableVector(FDCAN1_IT1_IRQn, CORTEX_MAX_KERNEL_PRIORITY);
             break;
-#ifdef FDCAN2_IT0_IRQn
+#ifdef FDCAN2
         case 1:
             nvicEnableVector(FDCAN2_IT0_IRQn, CORTEX_MAX_KERNEL_PRIORITY);
             nvicEnableVector(FDCAN2_IT1_IRQn, CORTEX_MAX_KERNEL_PRIORITY);
             break;
 #endif
-#ifdef FDCAN3_IT0_IRQn
+#ifdef FDCAN3
         case 2:
             nvicEnableVector(FDCAN3_IT0_IRQn, CORTEX_MAX_KERNEL_PRIORITY);
             nvicEnableVector(FDCAN3_IT1_IRQn, CORTEX_MAX_KERNEL_PRIORITY);


### PR DESCRIPTION
This had broken 2nd FDCAN on many devices and probably 3rd FDCAN hasn't been working as well. The bug was introduced here: https://github.com/ArduPilot/ardupilot/commit/bab0c1dfc7a6377a48cb7dc9b43932708f8d2426 