### PR TITLE
AP_Periph: fix checking compass available before init

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -151,9 +151,7 @@ void AP_Periph_FW::init()
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_MAG
-    if (compass.available()) {
-        compass.init();
-    }
+    compass.init();
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_BARO


### PR DESCRIPTION
Fixes bug introduced here https://github.com/ArduPilot/ardupilot/commit/d40587062edc35161d730eba29e76a4cb2260dcf# . We were basically checking for init_done before init was actually done.