### PR TITLE
AP_OSD: fixes bug introduced by #16477

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -433,8 +433,11 @@ void AP_OSD::update_current_screen()
     case PWM_RANGE:
         for (int i=0; i<AP_OSD_NUM_SCREENS; i++) {
             if (get_screen(i).enabled && get_screen(i).channel_min <= channel_value && get_screen(i).channel_max > channel_value) {
+                if (previous_pwm_screen == i) {
+                    break;
+                } else {
                 current_screen = previous_pwm_screen = i;
-                break;
+                }
             }
         }
         break;


### PR DESCRIPTION
previous fix was to help idiot proof OSD config that had same PWM ranges....but it allowed the search and screen change to happen every update, overwriting screens that had been set by ARM/DISARM or FS....this fix accomplishes the same thing but breaks out without updating the screen if the PWM value matches current PWM screen selection even if not the current screen, allowing those previously set to remain until their condition changes or the channel PWM changes to a new PWM screen selection....tested on QioTekZealot