### PR TITLE
Remove AP::ahrs().get_vibration()

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -319,12 +319,6 @@ float AP_AHRS_Backend::get_EAS2TAS(void) const {
     return AP::baro().get_EAS2TAS();
 }
 
-// return current vibration vector for primary IMU
-Vector3f AP_AHRS_Backend::get_vibration(void) const
-{
-    return AP::ins().get_vibration_levels();
-}
-
 void AP_AHRS_Backend::set_takeoff_expected(bool b)
 {
     _flags.takeoff_expected = b;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -479,9 +479,6 @@ public:
     // Write velocity data from an external navigation system
     virtual void writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms) { }
 
-    // return current vibration vector for primary IMU
-    Vector3f get_vibration(void) const;
-
     // set and save the alt noise parameter value
     virtual void set_alt_measurement_noise(float noise) {};
 

--- a/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
+++ b/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
@@ -45,7 +45,7 @@ function check_engine()
   end
 
   local rpm = RPM:get_rpm(0)
-  local vibe = ahrs:get_vibration():length()
+  local vibe = ins:get_vibration_levels():length()
 
   -- if either RPM is high or vibe is high then assume engine is running
   if (rpm and (rpm > RPM_LOW_THRESH)) or (vibe > VIBE_LOW_THRESH) then

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -38,7 +38,6 @@ singleton AP_AHRS method get_relative_position_NED_home boolean Vector3f'Null
 singleton AP_AHRS method home_is_set boolean
 singleton AP_AHRS method healthy boolean
 singleton AP_AHRS method airspeed_estimate boolean float'Null
-singleton AP_AHRS method get_vibration Vector3f
 singleton AP_AHRS method earth_to_body Vector3f Vector3f
 singleton AP_AHRS method body_to_earth Vector3f Vector3f
 singleton AP_AHRS method get_EAS2TAS float
@@ -405,6 +404,7 @@ userdata AP_MotorsMatrix_Scripting_Dynamic::factor_table field throttle'array AP
 include AP_InertialSensor/AP_InertialSensor.h
 singleton AP_InertialSensor alias ins
 singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES
+singleton AP_InertialSensor method get_vibration_levels Vector3f
 
 
 include AP_Scripting/AP_Scripting_CANSensor.h depends HAL_MAX_CAN_PROTOCOL_DRIVERS


### PR DESCRIPTION
This is a breaking change for existing scripts

This was made to avoid making the INS singleton.  Well, we have one of those now.
