### PR TITLE
Copter: limit maximum target distance with upward proximity

### DIFF
--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -29,7 +29,7 @@ float Copter::SurfaceTracking::adjust_climb_rate(float target_rate)
         (last_glitch_cleared_ms != rf_state.glitch_cleared_ms)) {
         target_dist_cm = rf_state.alt_cm + (dir * current_alt_error);
         reset_target = false;
-        last_glitch_cleared_ms = rf_state.glitch_cleared_ms;\
+        last_glitch_cleared_ms = rf_state.glitch_cleared_ms;
     }
     last_update_ms = now;
 

--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -42,7 +42,7 @@ float Copter::SurfaceTracking::adjust_climb_rate(float target_rate)
 #if AC_AVOID_ENABLED == ENABLED
     // upward facing terrain following never gets closer than avoidance margin
     if (surface == Surface::CEILING) {
-        const float margin_cm = copter.avoid.enabled() ? copter.avoid.get_margin() * 100.0f : 0.0f;
+        const float margin_cm = copter.avoid.proximity_avoidance_enabled() ? copter.avoid.get_margin() * 100.0f : 0.0f;
         target_dist_cm = MAX(target_dist_cm, margin_cm);
     }
     // limit maximum target distance when attaching downward lidar for terrain following and upward lidar for proximity avoidance

--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -45,6 +45,11 @@ float Copter::SurfaceTracking::adjust_climb_rate(float target_rate)
         const float margin_cm = copter.avoid.enabled() ? copter.avoid.get_margin() * 100.0f : 0.0f;
         target_dist_cm = MAX(target_dist_cm, margin_cm);
     }
+    // limit maximum target distance when attaching downward lidar for terrain following and upward lidar for proximity avoidance
+    if (surface == Surface::GROUND && copter.avoid.proximity_avoidance_enabled() && copter.rangefinder_up_ok()) {
+        const float limit_target_dist_cm = rf_state.alt_cm + current_alt_error + copter.rangefinder_up_state.alt_cm - copter.avoid.get_margin() * 100.0f;
+        target_dist_cm = MIN(target_dist_cm, limit_target_dist_cm);
+    }
 #endif
 
     // calc desired velocity correction from target rangefinder alt vs actual rangefinder alt (remove the error already passed to Altitude controller to avoid oscillations)


### PR DESCRIPTION
In case of using upward rangefinder as proximity, there is a issue that target alt is increased even if reaching the margin distance.
The issue occurs when the following conditions are met.
 1. attach downward and upward facing lidars
 2. using terrain following with downward lidar
 3. using proximity with upward lidar

I tested this in SITL.
Before
![image](https://user-images.githubusercontent.com/16643069/128990772-41e966ee-be34-45fb-bfee-7e7211feb24b.png)
SAlt (Green) stopped when reaching the distance margin, but DSAlt (Red) increased continuously. 
This makes the copter rise when  the obstacle in the upward direction disappeared.

After
![image](https://user-images.githubusercontent.com/16643069/128990791-5b06dce8-2061-4907-b8d0-bdde0ad077dc.png)

I also replaced avoid.enabled to avoid.proximity_avoidance_enabled for upward facing terrain following and proximity.
This change make proximity avoidance follow UseProximitySensor bit.