### PR TITLE
AP_Logger: fix MAVLink logger random failure on SITL

### DIFF
--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -560,7 +560,7 @@ bool AP_Logger_MAVLink::send_log_block(struct dm_block &block)
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     // deliberately fail 10% of the time in SITL:
-    if (rand() < 0.1) {
+    if ((rand() % 100 + 1) < 10) {
         return false;
     }
 #endif


### PR DESCRIPTION
rand() return an int