### PR TITLE
AP_Torqeedo: send motor speed cmd at 50hz

### DIFF
--- a/libraries/AP_Torqeedo/AP_Torqeedo.cpp
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.cpp
@@ -27,7 +27,7 @@
 #define TORQEEDO_PACKET_HEADER      0xAC    // communication packet header
 #define TORQEEDO_PACKET_FOOTER      0xAD    // communication packer footer
 #define TORQEEDO_LOG_INTERVAL_MS    5000    // log debug info at this interval in milliseconds
-#define TORQEEDO_SEND_MOTOR_SPEED_INTERVAL_US   300000  // motor speed sent every 0.3sec if connected to motor
+#define TORQEEDO_SEND_MOTOR_SPEED_INTERVAL_US   20000   // motor speed sent at 50hz if connected to motor
 
 extern const AP_HAL::HAL& hal;
 


### PR DESCRIPTION
This small change improves the Torqeedo motor response by sending it the desired speed command at 50hz instead of 3hz.  This has been tested on real hardware.

In case it matters, the previous rate was base on the "smart" tiller's rate which is perhaps sufficient when a relatively slow human is in control but for an automated speed controller a faster rate should work better.

The theoretical maximum speed is just under 100hz based on the baud rate and how quickly the motor "ACKs".