### PR TITLE
AP_InertialSensor: Make bmi160 generically available

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -18,8 +18,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_HAL_Linux/GPIO.h>
 #include <AP_Math/AP_Math.h>
@@ -494,5 +492,3 @@ bool AP_InertialSensor_BMI160::_init()
 
     return ret;
 }
-
-#endif

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -146,6 +146,27 @@ AP_InertialSensor_BMI160::probe(AP_InertialSensor &imu,
     return sensor;
 }
 
+AP_InertialSensor_Backend *
+AP_InertialSensor_BMI160::probe(AP_InertialSensor &imu,
+                                AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+{
+    if (!dev) {
+        return nullptr;
+    }
+    auto sensor = new AP_InertialSensor_BMI160(imu, std::move(dev));
+
+    if (!sensor) {
+        return nullptr;
+    }
+
+    if (!sensor->_init()) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
+}
+
 void AP_InertialSensor_BMI160::start()
 {
     bool r;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -119,20 +119,23 @@ struct PACKED RawData {
 };
 
 AP_InertialSensor_BMI160::AP_InertialSensor_BMI160(AP_InertialSensor &imu,
-                                                   AP_HAL::OwnPtr<AP_HAL::Device> dev)
+                                                   AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                                   enum Rotation rotation)
     : AP_InertialSensor_Backend(imu)
     , _dev(std::move(dev))
+    , _rotation(rotation)
 {
 }
 
 AP_InertialSensor_Backend *
 AP_InertialSensor_BMI160::probe(AP_InertialSensor &imu,
-                                AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev)
+                                AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev,
+                                enum Rotation rotation)
 {
     if (!dev) {
         return nullptr;
     }
-    auto sensor = new AP_InertialSensor_BMI160(imu, std::move(dev));
+    auto sensor = new AP_InertialSensor_BMI160(imu, std::move(dev), rotation);
 
     if (!sensor) {
         return nullptr;
@@ -148,12 +151,13 @@ AP_InertialSensor_BMI160::probe(AP_InertialSensor &imu,
 
 AP_InertialSensor_Backend *
 AP_InertialSensor_BMI160::probe(AP_InertialSensor &imu,
-                                AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+                                AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+                                enum Rotation rotation)
 {
     if (!dev) {
         return nullptr;
     }
-    auto sensor = new AP_InertialSensor_BMI160(imu, std::move(dev));
+    auto sensor = new AP_InertialSensor_BMI160(imu, std::move(dev), rotation);
 
     if (!sensor) {
         return nullptr;
@@ -410,10 +414,8 @@ read_fifo_read_data:
                       (float)(int16_t)le16toh(raw_data[i].gyro.y),
                       (float)(int16_t)le16toh(raw_data[i].gyro.z)};
 
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
-        accel.rotate(ROTATION_ROLL_180);
-        gyro.rotate(ROTATION_ROLL_180);
-#endif
+        accel.rotate(_rotation);
+        gyro.rotate(_rotation);
 
         accel *= _accel_scale;
         gyro *= _gyro_scale;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.h
@@ -23,13 +23,21 @@
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_Backend.h"
 
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
+#define BMI160_DEFAULT_ROTATION ROTATION_ROLL_180
+#else
+#define BMI160_DEFAULT_ROTATION ROTATION_NONE
+#endif
+
 class AP_InertialSensor_BMI160 : public AP_InertialSensor_Backend {
 public:
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
-                                            AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev);
+                                            AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev,
+                                            enum Rotation rotation=BMI160_DEFAULT_ROTATION);
 
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
-                                            AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+                                            AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+                                            enum Rotation rotation=BMI160_DEFAULT_ROTATION);
 
     /**
      * Configure the sensors and start reading routine.
@@ -40,7 +48,8 @@ public:
 
 private:
     AP_InertialSensor_BMI160(AP_InertialSensor &imu,
-                             AP_HAL::OwnPtr<AP_HAL::Device> dev);
+                             AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                             enum Rotation rotation);
 
     /**
      * If the macro BMI160_DEBUG is defined, check if there are errors reported
@@ -109,6 +118,7 @@ private:
     void _read_fifo();
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    enum Rotation _rotation;
 
     uint8_t _accel_instance;
     float _accel_scale;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/SPIDevice.h>
+#include <AP_HAL/I2CDevice.h>
 
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_Backend.h"
@@ -25,6 +27,9 @@ class AP_InertialSensor_BMI160 : public AP_InertialSensor_Backend {
 public:
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
                                             AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev);
+
+    static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
+                                            AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     /**
      * Configure the sensors and start reading routine.

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.h
@@ -18,8 +18,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_Backend.h"
 
@@ -115,5 +113,3 @@ private:
 
     AP_HAL::DigitalSource *_int1_pin;
 };
-
-#endif


### PR DESCRIPTION
This makes it possible to use BMI160 in I2C mode in a definition in hwdef

i.e.
IMU BMI160 I2C:0:0x69 ROTATION_PITCH_180

Bench tested with a DFRobot BMI160 board attached to a Nucleo-F746ZG dev board.
-https://www.dfrobot.com/product-1716.html 
- https://os.mbed.com/platforms/ST-Nucleo-F746ZG/

Possible future work:
- Making the interrupt pin(s) configurable.