### PR TITLE
AP_AHRS: move fly_forward flag to front end

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1750,7 +1750,7 @@ AP_AHRS::EKFType AP_AHRS::active_EKF_type(void) const
     if (ret != EKFType::NONE &&
         (_vehicle_class == AHRS_VEHICLE_FIXED_WING ||
          _vehicle_class == AHRS_VEHICLE_GROUND) &&
-        (_flags.fly_forward || !hal.util->get_soft_armed())) {
+        (fly_forward || !hal.util->get_soft_armed())) {
         bool should_use_gps = true;
         nav_filter_status filt_state;
 #if HAL_NAVEKF2_AVAILABLE

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -401,6 +401,19 @@ public:
         return touchdown_expected;
     }
 
+    /*
+     * fly_forward is set by the vehicles to indicate the vehicle
+     * should generally be moving in the direction of its heading.
+     * It is an additional piece of information that the backends can
+     * use to provide additional and/or improved estimates.
+     */
+    void set_fly_forward(bool b) {
+        fly_forward = b;
+    }
+    bool get_fly_forward(void) const {
+        return fly_forward;
+    }
+
 protected:
     // optional view class
     AP_AHRS_View *_view;
@@ -524,6 +537,14 @@ private:
     uint32_t takeoff_expected_start_ms;
     bool touchdown_expected;    // true if the vehicle is in a state that touchdown might be expected.  Ground effect may be in play.
     uint32_t touchdown_expected_start_ms;
+
+    /*
+     * fly_forward is set by the vehicles to indicate the vehicle
+     * should generally be moving in the direction of its heading.
+     * It is an additional piece of information that the backends can
+     * use to provide additional and/or improved estimates.
+     */
+    bool fly_forward; // true if we can assume the vehicle will be flying forward on its X axis
 
 #if HAL_NMEA_OUTPUT_ENABLED
     class AP_NMEA_Output* _nmea_out;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -58,15 +58,6 @@ public:
     // init sets up INS board orientation
     virtual void init();
 
-    // Accessors
-    void set_fly_forward(bool b) {
-        _flags.fly_forward = b;
-    }
-
-    bool get_fly_forward(void) const {
-        return _flags.fly_forward;
-    }
-
     AHRS_VehicleClass get_vehicle_class(void) const {
         return _vehicle_class;
     }
@@ -522,7 +513,6 @@ protected:
     // flags structure
     struct ahrs_flags {
         uint8_t have_initial_yaw        : 1;    // whether the yaw value has been intialised with a reference
-        uint8_t fly_forward             : 1;    // 1 if we can assume the aircraft will be flying forward on its X axis
         uint8_t correct_centrifugal     : 1;    // 1 if we should correct for centrifugal forces (allows arducopter to turn this off when motors are disarmed)
         uint8_t wind_estimation         : 1;    // 1 if we should do wind estimation
     } _flags;


### PR DESCRIPTION
This same flag is requested by the DAL so AN_NavEKF2 and AP_NavEKF3 can
use it in their estimates - so AP_AHRS_DCM accessing it via the same
mechanism is not out-of-shape
