### PR TITLE
Make DCM's application of centrifigual correction an internal decision

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -842,8 +842,6 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
     copter.g2.smart_rtl.set_home(copter.position_ok());
 #endif
 
-    // enable gps velocity based centrefugal force compensation
-    ahrs.set_correct_centrifugal(true);
     hal.util->set_soft_armed(true);
 
 #if SPRAYER_ENABLED == ENABLED
@@ -941,8 +939,6 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
 
     AP::logger().set_vehicle_armed(false);
 
-    // disable gps velocity based centrefugal force compensation
-    ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
     copter.ap.in_arming_delay = false;

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1166,8 +1166,6 @@ void Copter::load_parameters(void)
         AP_HAL::panic("Bad var table");
     }
 
-    // disable centrifugal force correction, it will be enabled as part of the arming process
-    ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
     if (!g.format_version.load() ||

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -126,8 +126,6 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
         }
     }
 
-    // enable gps velocity based centrefugal force compensation
-    ahrs.set_correct_centrifugal(true);
     hal.util->set_soft_armed(true);
 
     // enable output to motors
@@ -187,8 +185,6 @@ bool AP_Arming_Sub::disarm(const AP_Arming::Method method, bool do_disarm_checks
 
     AP::logger().set_vehicle_armed(false);
 
-    // disable gps velocity based centrefugal force compensation
-    ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
     // clear input holds

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -688,8 +688,6 @@ void Sub::load_parameters()
         AP_HAL::panic("Bad var table");
     }
 
-    // disable centrifugal force correction, it will be enabled as part of the arming process
-    ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
     if (!g.format_version.load() ||

--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -384,8 +384,6 @@ bool AP_Arming_Blimp::arm(const AP_Arming::Method method, const bool do_arming_c
         blimp.arming_altitude_m = blimp.inertial_nav.get_altitude() * 0.01;
     }
 
-    // enable gps velocity based centrifugal force compensation
-    ahrs.set_correct_centrifugal(true);
     hal.util->set_soft_armed(true);
 
     // finally actually arm the motors
@@ -443,8 +441,6 @@ bool AP_Arming_Blimp::disarm(const AP_Arming::Method method, bool do_disarm_chec
 
     AP::logger().set_vehicle_armed(false);
 
-    // disable gps velocity based centrefugal force compensation
-    ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
     blimp.ap.in_arming_delay = false;

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -876,8 +876,6 @@ void Blimp::load_parameters(void)
         AP_HAL::panic("Bad var table");
     }
 
-    // disable centrifugal force correction, it will be enabled as part of the arming process
-    ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);
 
     if (!g.format_version.load() ||

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -47,10 +47,7 @@ class AP_AHRS_Backend
 public:
 
     // Constructor
-    AP_AHRS_Backend() {
-        // enable centrifugal correction by default
-        _flags.correct_centrifugal = true;
-    }
+    AP_AHRS_Backend() {}
 
     // empty virtual destructor
     virtual ~AP_AHRS_Backend() {}
@@ -298,17 +295,6 @@ public:
         return _flags.have_initial_yaw;
     }
 
-    // set the correct centrifugal flag
-    // allows arducopter to disable corrections when disarmed
-    void set_correct_centrifugal(bool setting) {
-        _flags.correct_centrifugal = setting;
-    }
-
-    // get the correct centrifugal flag
-    bool get_correct_centrifugal(void) const {
-        return _flags.correct_centrifugal;
-    }
-
     // helper trig value accessors
     float cos_roll() const  {
         return _cos_roll;
@@ -513,7 +499,6 @@ protected:
     // flags structure
     struct ahrs_flags {
         uint8_t have_initial_yaw        : 1;    // whether the yaw value has been intialised with a reference
-        uint8_t correct_centrifugal     : 1;    // 1 if we should correct for centrifugal forces (allows arducopter to turn this off when motors are disarmed)
         uint8_t wind_estimation         : 1;    // 1 if we should do wind estimation
     } _flags;
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -156,6 +156,13 @@ private:
     // P term yaw gain based on rate of change of horiz velocity
     float           _yaw_gain(void) const;
 
+    /* returns true if attitude should be corrected from GPS-derived
+     * velocity-deltas.  We turn this off for Copter and other similar
+     * vehicles while the vehicle is disarmed to avoid the HUD bobbing
+     * around while the vehicle is disarmed.
+     */
+    bool should_correct_centrifugal() const;
+
     // state to support status reporting
     float _renorm_val_sum;
     uint16_t _renorm_val_count;


### PR DESCRIPTION
The external call used by Sub, Copter and Blimp didn't make it clear this only applied to the DCM backend.

Given this has been tightly tied to the arming state for so long, and that the arming state is now available from the HAL, make DCM do it internally and remove the external calls.

I've tested this by inserting `gcs().send_text` statements into the correction block in the DCM file and making sure we get there in the same way on both Copter and Plane.

My understanding is that this is all for cosmetics only.
