### PR TITLE
Rename AHRS yaw_initialised access method to dcm_yaw_initialised 

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -496,7 +496,7 @@ void Plane::do_loiter_to_alt(const AP_Mission::Mission_Command& cmd)
 /********************************************************************************/
 bool Plane::verify_takeoff()
 {
-    if (ahrs.yaw_initialised() && steer_state.hold_course_cd == -1) {
+    if (ahrs.dcm_yaw_initialised() && steer_state.hold_course_cd == -1) {
         const float min_gps_speed = 5;
         if (auto_state.takeoff_speed_time_ms == 0 && 
             gps.status() >= AP_GPS::GPS_OK_FIX_3D && 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -200,6 +200,11 @@ public:
     // true if the AHRS has completed initialisation
     bool initialised() const override;
 
+    // return true if *DCM* yaw has been initialised
+    bool dcm_yaw_initialised(void) const {
+        return AP_AHRS_DCM::yaw_initialised();
+    }
+
     // get_filter_status - returns filter status as a series of flags
     bool get_filter_status(nav_filter_status &status) const;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -273,11 +273,6 @@ public:
     // return true if we will use compass for yaw
     virtual bool use_compass(void) = 0;
 
-    // return true if yaw has been initialised
-    bool yaw_initialised(void) const {
-        return _flags.have_initial_yaw;
-    }
-
     // helper trig value accessors
     float cos_roll() const  {
         return _cos_roll;
@@ -479,7 +474,6 @@ protected:
 
     // flags structure
     struct ahrs_flags {
-        uint8_t have_initial_yaw        : 1;    // whether the yaw value has been intialised with a reference
         uint8_t wind_estimation         : 1;    // 1 if we should do wind estimation
     } _flags;
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -493,11 +493,11 @@ AP_AHRS_DCM::drift_correction_yaw(void)
             // we force an additional compass read()
             // here. This has the effect of throwing away
             // the first compass value, which can be bad
-            if (!_flags.have_initial_yaw && compass.read()) {
+            if (!have_initial_yaw && compass.read()) {
                 const float heading = compass.calculate_heading(_dcm_matrix);
                 _dcm_matrix.from_euler(roll, pitch, heading);
                 _omega_yaw_P.zero();
-                _flags.have_initial_yaw = true;
+                have_initial_yaw = true;
             }
             new_value = true;
             yaw_error = yaw_error_compass(compass);
@@ -536,13 +536,13 @@ AP_AHRS_DCM::drift_correction_yaw(void)
                operator pulls back the plane rapidly enough then on
                release the GPS heading changes very rapidly
             */
-            if (!_flags.have_initial_yaw ||
+            if (!have_initial_yaw ||
                     yaw_deltat > 20 ||
                     (_gps.ground_speed() >= 3*GPS_SPEED_MIN && fabsf(yaw_error_rad) >= 1.047f)) {
                 // reset DCM matrix based on current yaw
                 _dcm_matrix.from_euler(roll, pitch, gps_course_rad);
                 _omega_yaw_P.zero();
-                _flags.have_initial_yaw = true;
+                have_initial_yaw = true;
                 yaw_error = 0;
             }
         }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -62,6 +62,11 @@ public:
     void            update(bool skip_ins_update=false) override;
     void            reset(bool recover_eulers = false) override;
 
+    // return true if yaw has been initialised
+    bool yaw_initialised(void) const {
+        return have_initial_yaw;
+    }
+
     // dead-reckoning support
     virtual bool get_position(struct Location &loc) const override;
 
@@ -145,6 +150,8 @@ private:
     Vector3f _omega_I_sum;
     float _omega_I_sum_time;
     Vector3f _omega;                            // Corrected Gyro_Vector data
+
+    bool have_initial_yaw; // true if the yaw value has been initialised with a reference
 
     // variables to cope with delaying the GA sum to match GPS lag
     Vector3f ra_delayed(uint8_t instance, const Vector3f &ra);

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -135,7 +135,7 @@ bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, 
     }
 
     // do not align until ahrs yaw initialised
-    if (!AP::ahrs().initialised() || !AP::ahrs().yaw_initialised()) {
+    if (!AP::ahrs().initialised() || !AP::ahrs().dcm_yaw_initialised()) {
         return false;
     }
 


### PR DESCRIPTION
.... and move its state into DCM.

@rmackay9 was a touch surprised to learn this accessor only related to DCM's state, not whichever estimator we're actually using.

This should probably go away at some stage, with the two users doing something else:
 - VisualOdom probably wants to know about whether the AHRS can produce a valid yaw estimate - we could perhaps make `yaw_initialised()` pure-virtual on the backend class once we have a proper frontend/backend split in place.
 - Plane probably just wants to know whether the GPS is consistently giving us data rather than whether DCM is actually happy with its yaw estimate.  It could potentially keep track of that itself.
 - 