### PR TITLE
Ensure Rover arming worked before contining motor test

### DIFF
--- a/Rover/motor_test.cpp
+++ b/Rover/motor_test.cpp
@@ -124,7 +124,9 @@ MAV_RESULT Rover::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, AP_Motor
 
             // arm motors
             if (!arming.is_armed()) {
-                arming.arm(AP_Arming::Method::MOTORTEST);
+                if (!arming.arm(AP_Arming::Method::MOTORTEST)) {
+                    return MAV_RESULT_FAILED;
+                }
             }
 
             // disable failsafes

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -4552,6 +4552,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def test_motor_test(self):
         '''AKA run-rover-run'''
         magic_throttle_value = 1812
+        self.wait_ready_to_arm()
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST,
             1, # p1 - motor instance


### PR DESCRIPTION
We didn't react to the vehicle failing to arm and would continue with the testing procedure rather than return an error message to the user.

If your arming checks were failing for whatever reason you'd not be able to do a test.... so e.g. position-required might cause it to fail.

Also a fix for a test which, when run alone, would fail due to this.
