### PR TITLE
Libraries: removed dead code from RC_Channel

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -176,10 +176,6 @@ int16_t RC_Channel::get_control_mid() const
     if (type_in == RC_CHANNEL_TYPE_RANGE) {
         int16_t r_in = (radio_min.get() + radio_max.get())/2;
 
-        if (reversed) {
-            r_in = radio_max.get() - (r_in - radio_min.get());
-        }
-
         int16_t radio_trim_low  = radio_min + dead_zone;
 
         return (((int32_t)(high_in) * (int32_t)(r_in - radio_trim_low)) / (int32_t)(radio_max - radio_trim_low));


### PR DESCRIPTION
There seems to be dead code on libraries/RC_Channel/RC_Channel.cpp, namely in function get_control_mid().

If my math doesn't fail, the calculation made in if(reversed){} maintains the same value calculated previously:

r_in = 0.5min + 0.5max

r_in = max - (r_in - min) = max - (0.5min + 0.5max - min) = max - (0.5max - 0.5min) = 0.5max + 0.5min = Previously calculated value

Is there any reason for this to be, still, on the code?
Also, is there any reason for sometimes the parameters using .get() and others don't? For example:
```
 int16_t r_in = (radio_min.get() + radio_max.get())/2;
```
vs 
```
int16_t radio_trim_low  = radio_min + dead_zone; 
```
(both in same function)
