### PR TITLE
INS: Allow for accelcal for tailsitters when nose up

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -52,7 +52,6 @@ const AP_Scheduler::Task Tracker::scheduler_tasks[] = {
     SCHED_TASK(one_second_loop,         1,   3900),
     SCHED_TASK_CLASS(Compass,          &tracker.compass,              cal_update, 50, 100),
     SCHED_TASK(stats_update,            1,    200),
-    SCHED_TASK(accel_cal_update,       10,    100)
 };
 
 void Tracker::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -194,7 +194,6 @@ private:
     void update_ahrs();
     void compass_save();
     void update_compass(void);
-    void accel_cal_update(void);
     void update_GPS(void);
     void handle_battery_failsafe(const char* type_str, const int8_t action);
 

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -26,20 +26,6 @@ void Tracker::compass_save() {
 }
 
 /*
-    Accel calibration
-*/
-void Tracker::accel_cal_update() {
-    if (hal.util->get_soft_armed()) {
-        return;
-    }
-    ins.acal_update();
-    float trim_roll, trim_pitch;
-    if (ins.get_new_trim(trim_roll, trim_pitch)) {
-        ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
-    }
-}
-
-/*
   read the GPS
  */
 void Tracker::update_GPS(void)

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -167,7 +167,6 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(rpm_update,            40,    200),
 #endif
     SCHED_TASK_CLASS(Compass, &copter.compass, cal_update, 100, 100),
-    SCHED_TASK(accel_cal_update,      10,    100),
     SCHED_TASK_CLASS(AP_TempCalibration,   &copter.g2.temp_calibration, update,          10, 100),
 #if HAL_ADSB_ENABLED
     SCHED_TASK(avoidance_adsb_update, 10,    100),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -869,7 +869,7 @@ private:
     bool rangefinder_up_ok() const;
     void rpm_update();
     void update_optical_flow(void);
-    void accel_cal_update(void);
+    void compass_cal_update(void);
     void init_proximity();
     void update_proximity();
 

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -163,26 +163,6 @@ void Copter::rpm_update(void)
 }
 
 
-void Copter::accel_cal_update()
-{
-    if (hal.util->get_soft_armed()) {
-        return;
-    }
-    ins.acal_update();
-    // check if new trim values, and set them
-    float trim_roll, trim_pitch;
-    if(ins.get_new_trim(trim_roll, trim_pitch)) {
-        ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
-    }
-
-#ifdef CAL_ALWAYS_REBOOT
-    if (ins.accel_cal_requires_reboot()) {
-        hal.scheduler->delay(1000);
-        hal.scheduler->reboot(false);
-    }
-#endif
-}
-
 // initialise proximity sensor
 void Copter::init_proximity(void)
 {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -64,7 +64,6 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(read_rangefinder,       50,    100),
     SCHED_TASK_CLASS(AP_ICEngine, &plane.g2.ice_control, update, 10, 100),
     SCHED_TASK_CLASS(Compass,          &plane.compass,              cal_update, 50, 50),
-    SCHED_TASK(accel_cal_update,       10,    50),
 #if OPTFLOW == ENABLED
     SCHED_TASK_CLASS(OpticalFlow, &plane.optflow, update,    50,    50),
 #endif

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1032,7 +1032,6 @@ private:
     void read_rangefinder(void);
     void read_airspeed(void);
     void rpm_update(void);
-    void accel_cal_update(void);
 
     // system.cpp
     void init_ardupilot() override;

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -35,20 +35,6 @@ void Plane::read_rangefinder(void)
 }
 
 /*
-    Accel calibration
-*/
-void Plane::accel_cal_update() {
-    if (hal.util->get_soft_armed()) {
-        return;
-    }
-    ins.acal_update();
-    float trim_roll, trim_pitch;
-    if(ins.get_new_trim(trim_roll, trim_pitch)) {
-        ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
-    }
-}
-
-/*
   ask airspeed sensor for a new value
  */
 void Plane::read_airspeed(void)

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -58,7 +58,6 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK(rpm_update,            10,    200),
 #endif
     SCHED_TASK_CLASS(Compass,          &sub.compass,              cal_update, 100, 100),
-    SCHED_TASK(accel_cal_update,      10,    100),
     SCHED_TASK(terrain_update,        10,    100),
 #if GRIPPER_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Gripper,          &sub.g2.gripper,       update,              10,  75),

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -591,7 +591,6 @@ private:
     bool verify_nav_delay(const AP_Mission::Mission_Command& cmd);
 
     void log_init(void);
-    void accel_cal_update(void);
     void read_airspeed();
 
     void failsafe_leak_check();

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -86,19 +86,6 @@ void Sub::rpm_update(void)
 }
 #endif
 
-void Sub::accel_cal_update()
-{
-    if (hal.util->get_soft_armed()) {
-        return;
-    }
-    ins.acal_update();
-    // check if new trim values, and set them
-    float trim_roll, trim_pitch;
-    if (ins.get_new_trim(trim_roll, trim_pitch)) {
-        ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
-    }
-}
-
 /*
   ask airspeed sensor for a new value, duplicated from plane
  */

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -57,7 +57,6 @@ const AP_Scheduler::Task Blimp::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_InertialSensor,    &blimp.ins,                 periodic,       400,  50),
     SCHED_TASK_CLASS(AP_Scheduler,         &blimp.scheduler,           update_logging, 0.1,  75),
     SCHED_TASK_CLASS(Compass,              &blimp.compass,             cal_update,     100, 100),
-    SCHED_TASK(accel_cal_update,      10,    100),
 #if STATS_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Stats,             &blimp.g2.stats,            update,           1, 100),
 #endif

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -427,7 +427,6 @@ private:
     bool rangefinder_up_ok();
     void rpm_update();
     void update_optical_flow(void);
-    void accel_cal_update(void);
     void init_proximity();
     void update_proximity();
 

--- a/Blimp/sensors.cpp
+++ b/Blimp/sensors.cpp
@@ -7,23 +7,3 @@ void Blimp::read_barometer(void)
 
     baro_alt = barometer.get_altitude() * 100.0f;
 }
-
-void Blimp::accel_cal_update()
-{
-    if (hal.util->get_soft_armed()) {
-        return;
-    }
-    ins.acal_update();
-    // check if new trim values, and set them
-    float trim_roll, trim_pitch;
-    if (ins.get_new_trim(trim_roll, trim_pitch)) {
-        ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
-    }
-
-#ifdef CAL_ALWAYS_REBOOT
-    if (ins.accel_cal_requires_reboot()) {
-        hal.scheduler->delay(1000);
-        hal.scheduler->reboot(false);
-    }
-#endif
-}

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -93,7 +93,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #endif
     SCHED_TASK_CLASS(Compass,          &rover.compass,              cal_update, 50, 200),
     SCHED_TASK(compass_save,           0.1,   200),
-    SCHED_TASK(accel_cal_update,       10,    200),
 #if LOGGING_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Logger,     &rover.logger,        periodic_tasks, 50,  300),
 #endif

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -359,7 +359,6 @@ private:
     void update_compass(void);
     void compass_save(void);
     void update_wheel_encoder();
-    void accel_cal_update(void);
     void read_rangefinders(void);
     void read_airspeed();
     void rpm_update(void);

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -87,20 +87,6 @@ void Rover::update_wheel_encoder()
 #endif
 }
 
-// Accel calibration
-
-void Rover::accel_cal_update() {
-    if (hal.util->get_soft_armed()) {
-        return;
-    }
-    ins.acal_update();
-    // check if new trim values, and set them    float trim_roll, trim_pitch;
-    float trim_roll, trim_pitch;
-    if (ins.get_new_trim(trim_roll, trim_pitch)) {
-        ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
-    }
-}
-
 // read the rangefinders
 void Rover::read_rangefinders(void)
 {

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -195,7 +195,7 @@ AP_AHRS::AP_AHRS(uint8_t flags) :
 
     // initialise the controller-to-autopilot-body trim state:
     _last_trim = _trim.get();
-    _rotation_autopilot_body_to_vehicle_body.from_euler(_last_trim.x, _last_trim.y, 0.0f);
+    _rotation_autopilot_body_to_vehicle_body.from_euler(_last_trim.x, _last_trim.y, _last_trim.z);
     _rotation_vehicle_body_to_autopilot_body = _rotation_autopilot_body_to_vehicle_body.transposed();
 }
 
@@ -238,7 +238,7 @@ void AP_AHRS::update_trim_rotation_matrices()
     }
 
     _last_trim = _trim.get();
-    _rotation_autopilot_body_to_vehicle_body.from_euler(_last_trim.x, _last_trim.y, 0.0f);
+    _rotation_autopilot_body_to_vehicle_body.from_euler(_last_trim.x, _last_trim.y, _last_trim.z);
     _rotation_vehicle_body_to_autopilot_body = _rotation_autopilot_body_to_vehicle_body.transposed();
 }
 
@@ -3059,7 +3059,7 @@ void AP_AHRS::set_alt_measurement_noise(float noise)
 }
 
 /*
-  get the current views rotation, or ROTATION_NONE
+  get the current view's rotation, or ROTATION_NONE
  */
 enum Rotation AP_AHRS::get_view_rotation(void) const
 {

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3058,6 +3058,13 @@ void AP_AHRS::set_alt_measurement_noise(float noise)
 #endif
 }
 
+/*
+  get the current views rotation, or ROTATION_NONE
+ */
+enum Rotation AP_AHRS::get_view_rotation(void) const
+{
+    return _view?_view->get_rotation():ROTATION_NONE;
+}
 
 // singleton instance
 AP_AHRS *AP_AHRS::_singleton;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -457,6 +457,9 @@ public:
         _vehicle_class = vclass;
     }
 
+    // get the views rotation, or ROTATION_NONE
+    enum Rotation get_view_rotation(void) const;
+
 protected:
     // optional view class
     AP_AHRS_View *_view;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -457,7 +457,7 @@ public:
         _vehicle_class = vclass;
     }
 
-    // get the views rotation, or ROTATION_NONE
+    // get the view's rotation, or ROTATION_NONE
     enum Rotation get_view_rotation(void) const;
 
 protected:

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -38,9 +38,11 @@ Vector3f AP_AHRS_Backend::get_gyro_latest(void) const
 // set_trim
 void AP_AHRS::set_trim(const Vector3f &new_trim)
 {
-    Vector3f trim;
-    trim.x = constrain_float(new_trim.x, ToRad(-AP_AHRS_TRIM_LIMIT), ToRad(AP_AHRS_TRIM_LIMIT));
-    trim.y = constrain_float(new_trim.y, ToRad(-AP_AHRS_TRIM_LIMIT), ToRad(AP_AHRS_TRIM_LIMIT));
+    const Vector3f trim {
+        constrain_float(new_trim.x, ToRad(-AP_AHRS_TRIM_LIMIT), ToRad(AP_AHRS_TRIM_LIMIT)),
+        constrain_float(new_trim.y, ToRad(-AP_AHRS_TRIM_LIMIT), ToRad(AP_AHRS_TRIM_LIMIT)),
+        constrain_float(new_trim.z, ToRad(-AP_AHRS_TRIM_LIMIT), ToRad(AP_AHRS_TRIM_LIMIT))
+    };
     _trim.set_and_save(trim);
 }
 

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -185,6 +185,12 @@ public:
     int32_t pitch_sensor;
     int32_t yaw_sensor;
 
+
+    // get current rotation
+    enum Rotation get_rotation(void) const {
+        return rotation;
+    }
+
 private:
     const enum Rotation rotation;
     AP_AHRS &ahrs;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -67,6 +67,10 @@ extern const AP_HAL::HAL& hal;
 
 #define GYRO_INIT_MAX_DIFF_DPS 0.1f
 
+#ifndef HAL_INS_TRIM_LIMIT_DEG
+#define HAL_INS_TRIM_LIMIT_DEG 10
+#endif
+
 // Class level parameters
 const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // 0 was PRODUCT_ID
@@ -1099,19 +1103,59 @@ void AP_InertialSensor::periodic()
   _calculate_trim - calculates the x and y trim angles. The
   accel_sample must be correctly scaled, offset and oriented for the
   board
+
+  Note that this only changes 2 axes of the trim vector. When in
+  ROTATION_NONE view we can calculate the x and y trim. When in
+  ROTATION_PITCH_90 for tailsitters we can calculate y and z. This
+  allows users to trim for both flight orientations by doing two trim
+  operations, one at each orientation
+
+  When doing a full accel cal we pass in a trim vector that has been
+  zeroed so the 3rd non-observable axis is reset
 */
-bool AP_InertialSensor::_calculate_trim(const Vector3f &accel_sample, float& trim_roll, float& trim_pitch)
+bool AP_InertialSensor::_calculate_trim(const Vector3f &accel_sample, Vector3f &trim)
 {
-    trim_pitch = atan2f(accel_sample.x, norm(accel_sample.y, accel_sample.z));
-    trim_roll = atan2f(-accel_sample.y, -accel_sample.z);
-    if (fabsf(trim_roll) > radians(10) ||
-        fabsf(trim_pitch) > radians(10)) {
+    // allow multiple rotations, this allows us to cope with tailsitters
+    const enum Rotation rotations[] = {ROTATION_NONE,
+#ifndef HAL_BUILD_AP_PERIPH
+                                       AP::ahrs().get_view_rotation()
+#endif
+    };
+    bool good_trim = false;
+    Vector3f newtrim;
+    for (const auto r : rotations) {
+        newtrim = trim;
+        switch (r) {
+        case ROTATION_NONE:
+            newtrim.y = atan2f(accel_sample.x, norm(accel_sample.y, accel_sample.z));
+            newtrim.x = atan2f(-accel_sample.y, -accel_sample.z);
+            break;
+
+        case ROTATION_PITCH_90: {
+            newtrim.y = atan2f(accel_sample.z, norm(accel_sample.y, -accel_sample.x));
+            newtrim.z = atan2f(-accel_sample.y, accel_sample.x);
+            break;
+        }
+        default:
+            // unsupported
+            continue;
+        }
+        if (fabsf(newtrim.x) <= radians(HAL_INS_TRIM_LIMIT_DEG) &&
+            fabsf(newtrim.y) <= radians(HAL_INS_TRIM_LIMIT_DEG) &&
+            fabsf(newtrim.z) <= radians(HAL_INS_TRIM_LIMIT_DEG)) {
+            good_trim = true;
+            break;
+        }
+    }
+    if (!good_trim) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "trim over maximum of 10 degrees");
         return false;
     }
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Trim OK: roll=%.2f pitch=%.2f",
-                  (double)degrees(trim_roll),
-                  (double)degrees(trim_pitch));
+    trim = newtrim;
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Trim OK: roll=%.2f pitch=%.2f yaw=%.2f",
+                  (double)degrees(trim.x),
+                  (double)degrees(trim.y),
+                  (double)degrees(trim.z));
     return true;
 }
 
@@ -1199,7 +1243,7 @@ bool AP_InertialSensor::get_accel_health_all(void) const
   calculate the trim_roll and trim_pitch. This is used for redoing the
   trim without needing a full accel cal
  */
-bool AP_InertialSensor::calibrate_trim(float &trim_roll, float &trim_pitch)
+bool AP_InertialSensor::calibrate_trim(Vector3f &trim_rad)
 {
     Vector3f level_sample;
 
@@ -1227,21 +1271,18 @@ bool AP_InertialSensor::calibrate_trim(float &trim_roll, float &trim_pitch)
         samp = get_accel(0);
         level_sample += samp;
         if (!get_accel_health(0)) {
-            goto failed;
+            return false;
         }
         hal.scheduler->delay(update_dt_milliseconds);
         num_samples++;
     }
     level_sample /= num_samples;
 
-    if (!_calculate_trim(level_sample, trim_roll, trim_pitch)) {
-        goto failed;
+    if (!_calculate_trim(level_sample, trim_rad)) {
+        return false;
     }
 
     return true;
-
-failed:
-    return false;
 }
 
 /*
@@ -1956,8 +1997,8 @@ void AP_InertialSensor::_acal_save_calibrations()
             // The first level step of accel cal will be taken as gnd truth,
             // i.e. trim will be set as per the output of primary accel from the level step
             get_primary_accel_cal_sample_avg(0,aligned_sample);
-            _trim_pitch = atan2f(aligned_sample.x, norm(aligned_sample.y, aligned_sample.z));
-            _trim_roll = atan2f(-aligned_sample.y, -aligned_sample.z);
+            _trim_rad.zero();
+            _calculate_trim(aligned_sample, _trim_rad);
             _new_trim = true;
             break;
         case 2:
@@ -1969,8 +2010,9 @@ void AP_InertialSensor::_acal_save_calibrations()
                 float dot = (misaligned_sample*aligned_sample);
                 Quaternion q(safe_sqrt(sq(misaligned_sample.length())*sq(aligned_sample.length()))+dot, cross.x, cross.y, cross.z);
                 q.normalize();
-                _trim_roll = q.get_euler_roll();
-                _trim_pitch = q.get_euler_pitch();
+                _trim_rad.x = q.get_euler_roll();
+                _trim_rad.y = q.get_euler_pitch();
+                _trim_rad.z = 0;
                 _new_trim = true;
             }
             break;
@@ -1979,9 +2021,10 @@ void AP_InertialSensor::_acal_save_calibrations()
             /* no break */
     }
 
-    if (fabsf(_trim_roll) > radians(10) ||
-        fabsf(_trim_pitch) > radians(10)) {
-        hal.console->printf("ERR: Trim over maximum of 10 degrees!!");
+    if (fabsf(_trim_rad.x) > radians(HAL_INS_TRIM_LIMIT_DEG) ||
+        fabsf(_trim_rad.y) > radians(HAL_INS_TRIM_LIMIT_DEG) ||
+        fabsf(_trim_rad.z) > radians(HAL_INS_TRIM_LIMIT_DEG)) {
+        hal.console->printf("ERR: Trim over maximum of %.1f degrees!!", float(HAL_INS_TRIM_LIMIT_DEG));
         _new_trim = false;  //we have either got faulty level during acal or highly misaligned accelerometers
     }
 
@@ -1999,11 +2042,10 @@ void AP_InertialSensor::_acal_event_failure()
 /*
     Returns true if new valid trim values are available and passes them to reference vars
 */
-bool AP_InertialSensor::get_new_trim(float& trim_roll, float &trim_pitch)
+bool AP_InertialSensor::get_new_trim(Vector3f &trim_rad)
 {
     if (_new_trim) {
-        trim_roll = _trim_roll;
-        trim_pitch = _trim_pitch;
+        trim_rad = _trim_rad;
         _new_trim = false;
         return true;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -102,7 +102,7 @@ public:
     // a function called by the main thread at the main loop rate:
     void periodic();
 
-    bool calibrate_trim(float &trim_roll, float &trim_pitch);
+    bool calibrate_trim(Vector3f &trim_rad);
 
     /// calibrating - returns true if the gyros or accels are currently being calibrated
     bool calibrating() const;
@@ -317,7 +317,7 @@ public:
     bool get_primary_accel_cal_sample_avg(uint8_t sample_num, Vector3f& ret) const;
 
     // Returns newly calculated trim values if calculated
-    bool get_new_trim(float& trim_roll, float &trim_pitch);
+    bool get_new_trim(Vector3f &trim_rad);
 
     // initialise and register accel calibrator
     // called during the startup of accel cal
@@ -449,7 +449,7 @@ private:
     // blog post describing the method: http://chionophilous.wordpress.com/2011/10/24/accelerometer-calibration-iv-1-implementing-gauss-newton-on-an-atmega/
     // original sketch available at http://rolfeschmidt.com/mathtools/skimetrics/adxl_gn_calibration.pde
 
-    bool _calculate_trim(const Vector3f &accel_sample, float& trim_roll, float& trim_pitch);
+    bool _calculate_trim(const Vector3f &accel_sample, Vector3f &trim_rad);
 
     // save gyro calibration values to eeprom
     void _save_gyro_calibration();
@@ -666,8 +666,7 @@ private:
     // Returns AccelCalibrator objects pointer for specified acceleromter
     AccelCalibrator* _acal_get_calibrator(uint8_t i) override { return i<get_accel_count()?&(_accel_calibrator[i]):nullptr; }
 
-    float _trim_pitch;
-    float _trim_roll;
+    Vector3f _trim_rad;
     bool _new_trim;
 
     bool _accel_cal_requires_reboot;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -242,6 +242,7 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #if OSD_ENABLED
     SCHED_TASK(publish_osd_info, 1, 10),
 #endif
+    SCHED_TASK(accel_cal_update,      10,    100),
 };
 
 void AP_Vehicle::get_common_scheduler_tasks(const AP_Scheduler::Task*& tasks, uint8_t& num_tasks)
@@ -428,6 +429,36 @@ void AP_Vehicle::get_osd_roll_pitch_rad(float &roll, float &pitch) const
 }
 
 #endif
+
+#ifndef HAL_CAL_ALWAYS_REBOOT
+// allow for forced reboot after accelcal
+#define HAL_CAL_ALWAYS_REBOOT 0
+#endif
+
+/*
+  update accel cal
+ */
+void AP_Vehicle::accel_cal_update()
+{
+    if (hal.util->get_soft_armed()) {
+        return;
+    }
+    ins.acal_update();
+    // check if new trim values, and set them
+    Vector3f trim_rad;
+    if (ins.get_new_trim(trim_rad)) {
+        ahrs.set_trim(trim_rad);
+    }
+
+#if HAL_CAL_ALWAYS_REBOOT
+    if (ins.accel_cal_requires_reboot() &&
+        !hal.util->get_soft_armed()) {
+        hal.scheduler->delay(1000);
+        hal.scheduler->reboot(false);
+    }
+#endif
+}
+
 
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -358,6 +358,9 @@ protected:
     void publish_osd_info();
 #endif
 
+    // update accel calibration
+    void accel_cal_update();
+
     ModeReason control_mode_reason = ModeReason::UNKNOWN;
 
 private:

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3776,12 +3776,12 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_comm
         if (!calibrate_gyros()) {
             return MAV_RESULT_FAILED;
         }
-        float trim_roll, trim_pitch;
-        if (!AP::ins().calibrate_trim(trim_roll, trim_pitch)) {
+        Vector3f trim_rad = AP::ahrs().get_trim();
+        if (!AP::ins().calibrate_trim(trim_rad)) {
             return MAV_RESULT_FAILED;
         }
         // reset ahrs's trim to suggested values from calibration routine
-        AP::ahrs().set_trim(Vector3f(trim_roll, trim_pitch, 0));
+        AP::ahrs().set_trim(trim_rad);
         return MAV_RESULT_ACCEPTED;
     }
 


### PR DESCRIPTION
For vehicles that are in a different AHRS view allow the ahrs trim to be calculated from the rotated frame.
This means for quadplane tailsitters the user can calibrate either in fixed wing flight rotation or in nose up rotation. To calibrate in nose up rotation you need to be in a Q mode (eg. QHOVER).
Note that only AHRS_TRIM_X and AHRS_TRIM_Y are observable when in normal orientation, and AHRS_TRIM_Y and AHRS_TRIM_Z are observable when nose up (tailsitter). 
To do a full trim on a tailsitter you have to first do an AHRS trim while in fixed wing orientation then again when in hover orientation. The code has been changed to preserve the non-observable axis when doing a trim, and zero the non-observable axis when doing a full 6-axis cal.